### PR TITLE
Add legacy Grid method (and a better one)

### DIFF
--- a/src/Controls/docs/Microsoft.Maui.Controls/Grid.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/Grid.xml
@@ -61,32 +61,32 @@ namespace FormsGallery
                 }
             };
     
-            grid.Children.Add(new Label
+            grid.AddWithSpan(new Label
                 {
                     Text = "Grid",
                     FontSize = Device.GetNamedSize (NamedSize.Large, typeof(Label)),
                     HorizontalOptions = LayoutOptions.Center
                 }, 0, 3, 0, 1);
     
-            grid.Children.Add(new Label
+            grid.Add(new Label
                 {
                     Text = "Autosized cell",
                     TextColor = Color.White,
                     BackgroundColor = Color.Blue
                 }, 0, 1);
     
-            grid.Children.Add(new BoxView
+            grid.Add(new BoxView
                 {
                     Color = Color.Silver,
                     HeightRequest = 0
                 }, 1, 1);
     
-            grid.Children.Add(new BoxView
+            grid.Add(new BoxView
                 {
                     Color = Color.Teal
                 }, 0, 2);
     
-            grid.Children.Add(new Label
+            grid.Add(new Label
                 {
                     Text = "Leftover space",
                     TextColor = Color.Purple,
@@ -95,7 +95,7 @@ namespace FormsGallery
                     VerticalTextAlignment = TextAlignment.Center,
                 }, 1, 2);
     
-            grid.Children.Add(new Label
+            grid.AddWithSpan(new Label
                 {
                     Text = "Span two rows (or more if you want)",
                     TextColor = Color.Yellow,
@@ -104,7 +104,7 @@ namespace FormsGallery
                     VerticalTextAlignment = TextAlignment.Center
                 }, 2, 3, 1, 3);
     
-            grid.Children.Add(new Label
+            grid.AddWithSpan(new Label
                 {
                     Text = "Span 2 columns",
                     TextColor = Color.Blue,
@@ -113,7 +113,7 @@ namespace FormsGallery
                     VerticalTextAlignment = TextAlignment.Center
                 }, 0, 2, 3, 4);
     
-            grid.Children.Add(new Label
+            grid.Add(new Label
                 {
                     Text = "Fixed 100x100",
                     TextColor = Color.Aqua,

--- a/src/Controls/docs/Microsoft.Maui.Controls/SearchHandler.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/SearchHandler.xml
@@ -1004,8 +1004,8 @@
         Label nameLabel = new Label { FontAttributes = FontAttributes.Bold };
         nameLabel.SetBinding(Label.TextProperty, "Name");
         
-        grid.Children.Add(image);
-        grid.Children.Add(nameLabel, 1, 0);
+        grid.Add(image);
+        grid.Add(nameLabel, 1, 0);
         return grid;
     })
 });]]></code>

--- a/src/Controls/src/Core/Layout/Grid.cs
+++ b/src/Controls/src/Core/Layout/Grid.cs
@@ -248,29 +248,6 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		// These extra internal add methods are here to keep some other old stuff working until we re-add
-		// the Grid convenience methods
-		internal void Add(IView view, int left, int right, int top, int bottom)
-		{
-			if (view == null)
-				throw new ArgumentNullException(nameof(view));
-			if (left < 0)
-				throw new ArgumentOutOfRangeException(nameof(left));
-			if (top < 0)
-				throw new ArgumentOutOfRangeException(nameof(top));
-			if (left >= right)
-				throw new ArgumentOutOfRangeException(nameof(right));
-			if (top >= bottom)
-				throw new ArgumentOutOfRangeException(nameof(bottom));
-
-			SetRow(view, top);
-			SetRowSpan(view, bottom - top);
-			SetColumn(view, left);
-			SetColumnSpan(view, right - left);
-
-			Add(view);
-		}
-
 		protected override void OnAdd(int index, IView view)
 		{
 			if (view is not BindableObject)

--- a/src/Controls/src/Core/Layout/GridExtensions.cs
+++ b/src/Controls/src/Core/Layout/GridExtensions.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Maui.Controls
 		/// <exception cref="ArgumentOutOfRangeException">
 		/// Thrown when <paramref name="row"/> or <paramref name="column"/> are less than 0.
 		/// </exception>
+		/// <remarks>If the <see cref="Grid"/> does not have enough rows/columns to encompass the specified location, they will be added.</remarks>
 		public static void Add(this Grid grid, IView view, int column = 0, int row = 0)
 		{
 			grid.AddWithSpan(view, row, column, 1, 1);
@@ -35,6 +36,7 @@ namespace Microsoft.Maui.Controls
 		/// Thrown when <paramref name="left"/> or <paramref name="top"/> are less than 0, <paramref name="bottom"/> is less than or equal to <paramref name="top"/>,
 		/// or <paramref name="right"/> is less than or equal to <paramref name="left"/>.
 		/// </exception>
+		/// <remarks>If the <see cref="Grid"/> does not have enough rows/columns to encompass the specified spans, they will be added.</remarks>
 		public static void Add(this Grid grid, IView view, int left, int right, int top, int bottom)
 		{
 			grid.AddWithSpan(view, top, left, bottom - top, right - left);
@@ -53,6 +55,7 @@ namespace Microsoft.Maui.Controls
 		/// <exception cref="ArgumentOutOfRangeException">
 		/// Thrown when <paramref name="row"/> or <paramref name="column"/> are less than 0, or  <paramref name="rowSpan"/> or <paramref name="columnSpan"/> are less than 1.
 		/// </exception>
+		/// <remarks>If the <see cref="Grid"/> does not have enough rows/columns to encompass the specified spans, they will be added.</remarks>
 		public static void AddWithSpan(this Grid grid, IView view, int row = 0, int column = 0, int rowSpan = 1, int columnSpan = 1)
 		{
 			if (view is null)

--- a/src/Controls/src/Core/Layout/GridExtensions.cs
+++ b/src/Controls/src/Core/Layout/GridExtensions.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Maui.Controls
 			grid.SetColumnSpan(view, columnSpan);
 		}
 
-		static void EnsureRows(Grid grid, int rows) 
+		static void EnsureRows(Grid grid, int rows)
 		{
 			if (rows == 1)
 			{

--- a/src/Controls/src/Core/Layout/GridExtensions.cs
+++ b/src/Controls/src/Core/Layout/GridExtensions.cs
@@ -37,6 +37,7 @@ namespace Microsoft.Maui.Controls
 		/// or <paramref name="right"/> is less than or equal to <paramref name="left"/>.
 		/// </exception>
 		/// <remarks>If the <see cref="Grid"/> does not have enough rows/columns to encompass the specified spans, they will be added.</remarks>
+		[Obsolete("This method is obsolete. Please use AddWithSpan(this Grid, IView, int, int, int, int) instead.")]
 		public static void Add(this Grid grid, IView view, int left, int right, int top, int bottom)
 		{
 			grid.AddWithSpan(view, top, left, bottom - top, right - left);

--- a/src/Controls/src/Core/Layout/GridExtensions.cs
+++ b/src/Controls/src/Core/Layout/GridExtensions.cs
@@ -5,18 +5,106 @@ namespace Microsoft.Maui.Controls
 {
 	public static class GridExtensions
 	{
+		/// <summary>
+		/// Adds an <see cref="IView" /> to the <see cref="Grid"/> at the specified column and row with a row span of 1 and a column span of 1.
+		/// </summary>
+		/// <param name="grid">The <see cref="Grid"/> to which the <see cref="IView" /> will be added.</param>
+		/// <param name="view">The <see cref="IView" /> to add.</param>
+		/// <param name="column">The column in which to place the <see cref="IView" />.</param>
+		/// <param name="row">The row in which to place the <see cref="IView" />.</param>
+		/// <exception cref="ArgumentNullException">Thrown when <paramref name="view"/> is null.</exception>
+		/// <exception cref="ArgumentOutOfRangeException">
+		/// Thrown when <paramref name="row"/> or <paramref name="column"/> are less than 0.
+		/// </exception>
 		public static void Add(this Grid grid, IView view, int column = 0, int row = 0)
 		{
-			if (view == null)
+			grid.AddWithSpan(view, row, column, 1, 1);
+		}
+
+		/// <summary>
+		/// Adds an <see cref="IView" /> to the <see cref="Grid"/> at the specified row and column spans. 
+		/// </summary>
+		/// <param name="grid">The <see cref="Grid"/> to which the <see cref="IView" /> will be added.</param>
+		/// <param name="view">The <see cref="IView" /> to add.</param>
+		/// <param name="left">The left edge of the column span. Must be greater than or equal to 0.</param>
+		/// <param name="right">The right edge of the column span. Must be greater than left. The <see cref="IView" /> won't occupy this column, but will stop just before it.</param>
+		/// <param name="top">The top edge of the row span. Must be greater than or equal to 0.</param>
+		/// <param name="bottom">The bottom edge of the row span. Must be greater than top. The <see cref="IView" /> won't occupy this row, but will stop just before it.</param>
+		/// <exception cref="ArgumentNullException">Thrown when <paramref name="view"/> is null.</exception>
+		/// <exception cref="ArgumentOutOfRangeException">
+		/// Thrown when <paramref name="left"/> or <paramref name="top"/> are less than 0, <paramref name="bottom"/> is less than or equal to <paramref name="top"/>,
+		/// or <paramref name="right"/> is less than or equal to <paramref name="left"/>.
+		/// </exception>
+		public static void Add(this Grid grid, IView view, int left, int right, int top, int bottom)
+		{
+			grid.AddWithSpan(view, top, left, bottom - top, right - left);
+		}
+
+		/// <summary>
+		/// Adds an <see cref="IView" /> to the the <see cref="Grid"/> at the specified row and column with the specified row and column spans.
+		/// </summary>
+		/// <param name="grid">The <see cref="Grid"/> to which the <see cref="IView" /> will be added.</param>
+		/// <param name="view">The <see cref="IView" /> to add.</param>
+		/// <param name="row">The top row in which to place the <see cref="IView" />. Defaults to 0.</param>
+		/// <param name="column">The left column in which to place the <see cref="IView" />. Defaults to 0.</param>
+		/// <param name="rowSpan">The number of rows the <see cref="IView" /> should span. Defaults to 1.</param>
+		/// <param name="columnSpan">The number of columns the <see cref="IView" /> should span. Defaults to 1.</param>
+		/// <exception cref="ArgumentNullException">Thrown when <paramref name="view"/> is null.</exception>
+		/// <exception cref="ArgumentOutOfRangeException">
+		/// Thrown when <paramref name="row"/> or <paramref name="column"/> are less than 0, or  <paramref name="rowSpan"/> or <paramref name="columnSpan"/> are less than 1.
+		/// </exception>
+		public static void AddWithSpan(this Grid grid, IView view, int row = 0, int column = 0, int rowSpan = 1, int columnSpan = 1)
+		{
+			if (view is null)
 				throw new ArgumentNullException(nameof(view));
-			if (column < 0)
-				throw new ArgumentOutOfRangeException(nameof(column));
 			if (row < 0)
 				throw new ArgumentOutOfRangeException(nameof(row));
+			if (column < 0)
+				throw new ArgumentOutOfRangeException(nameof(column));
+			if (rowSpan < 1)
+				throw new ArgumentOutOfRangeException(nameof(rowSpan));
+			if (columnSpan < 1)
+				throw new ArgumentOutOfRangeException(nameof(columnSpan));
 
 			grid.Add(view);
-			grid.SetColumn(view, column);
+
+			EnsureRows(grid, row + rowSpan);
 			grid.SetRow(view, row);
+			grid.SetRowSpan(view, rowSpan);
+
+			EnsureColumns(grid, column + columnSpan);
+			grid.SetColumn(view, column);
+			grid.SetColumnSpan(view, columnSpan);
+		}
+
+		static void EnsureRows(Grid grid, int rows) 
+		{
+			if (rows == 1)
+			{
+				return;
+			}
+
+			var count = grid.RowDefinitions.Count;
+
+			for (int n = count; n < rows; n++)
+			{
+				grid.RowDefinitions.Add(new RowDefinition());
+			}
+		}
+
+		static void EnsureColumns(Grid grid, int columns)
+		{
+			if (columns == 1)
+			{
+				return;
+			}
+
+			var count = grid.ColumnDefinitions.Count;
+
+			for (int n = count; n < columns; n++)
+			{
+				grid.ColumnDefinitions.Add(new ColumnDefinition());
+			}
 		}
 	}
 }

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -74,3 +74,5 @@ override Microsoft.Maui.Controls.SearchBar.IsEnabledCore.get -> bool
 *REMOVED*Microsoft.Maui.Controls.Application.Properties.get -> System.Collections.Generic.IDictionary<string!, object!>!
 Microsoft.Maui.Controls.IValueConverter.Convert(object? value, System.Type! targetType, object? parameter, System.Globalization.CultureInfo! culture) -> object?
 Microsoft.Maui.Controls.IValueConverter.ConvertBack(object? value, System.Type! targetType, object? parameter, System.Globalization.CultureInfo! culture) -> object?
+~static Microsoft.Maui.Controls.GridExtensions.Add(this Microsoft.Maui.Controls.Grid grid, Microsoft.Maui.IView view, int left, int right, int top, int bottom) -> void
+~static Microsoft.Maui.Controls.GridExtensions.AddWithSpan(this Microsoft.Maui.Controls.Grid grid, Microsoft.Maui.IView view, int row = 0, int column = 0, int rowSpan = 1, int columnSpan = 1) -> void

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -69,3 +69,5 @@ override Microsoft.Maui.Controls.SearchBar.IsEnabledCore.get -> bool
 *REMOVED*Microsoft.Maui.Controls.Application.Properties.get -> System.Collections.Generic.IDictionary<string!, object!>!
 Microsoft.Maui.Controls.IValueConverter.Convert(object? value, System.Type! targetType, object? parameter, System.Globalization.CultureInfo! culture) -> object?
 Microsoft.Maui.Controls.IValueConverter.ConvertBack(object? value, System.Type! targetType, object? parameter, System.Globalization.CultureInfo! culture) -> object?
+~static Microsoft.Maui.Controls.GridExtensions.Add(this Microsoft.Maui.Controls.Grid grid, Microsoft.Maui.IView view, int left, int right, int top, int bottom) -> void
+~static Microsoft.Maui.Controls.GridExtensions.AddWithSpan(this Microsoft.Maui.Controls.Grid grid, Microsoft.Maui.IView view, int row = 0, int column = 0, int rowSpan = 1, int columnSpan = 1) -> void

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -69,3 +69,5 @@ override Microsoft.Maui.Controls.SearchBar.IsEnabledCore.get -> bool
 *REMOVED*Microsoft.Maui.Controls.Application.Properties.get -> System.Collections.Generic.IDictionary<string!, object!>!
 Microsoft.Maui.Controls.IValueConverter.Convert(object? value, System.Type! targetType, object? parameter, System.Globalization.CultureInfo! culture) -> object?
 Microsoft.Maui.Controls.IValueConverter.ConvertBack(object? value, System.Type! targetType, object? parameter, System.Globalization.CultureInfo! culture) -> object?
+~static Microsoft.Maui.Controls.GridExtensions.Add(this Microsoft.Maui.Controls.Grid grid, Microsoft.Maui.IView view, int left, int right, int top, int bottom) -> void
+~static Microsoft.Maui.Controls.GridExtensions.AddWithSpan(this Microsoft.Maui.Controls.Grid grid, Microsoft.Maui.IView view, int row = 0, int column = 0, int rowSpan = 1, int columnSpan = 1) -> void

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -67,3 +67,5 @@ override Microsoft.Maui.Controls.SearchBar.IsEnabledCore.get -> bool
 *REMOVED*Microsoft.Maui.Controls.Application.Properties.get -> System.Collections.Generic.IDictionary<string!, object!>!
 Microsoft.Maui.Controls.IValueConverter.Convert(object? value, System.Type! targetType, object? parameter, System.Globalization.CultureInfo! culture) -> object?
 Microsoft.Maui.Controls.IValueConverter.ConvertBack(object? value, System.Type! targetType, object? parameter, System.Globalization.CultureInfo! culture) -> object?
+~static Microsoft.Maui.Controls.GridExtensions.Add(this Microsoft.Maui.Controls.Grid grid, Microsoft.Maui.IView view, int left, int right, int top, int bottom) -> void
+~static Microsoft.Maui.Controls.GridExtensions.AddWithSpan(this Microsoft.Maui.Controls.Grid grid, Microsoft.Maui.IView view, int row = 0, int column = 0, int rowSpan = 1, int columnSpan = 1) -> void

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -66,3 +66,5 @@ override Microsoft.Maui.Controls.SearchBar.IsEnabledCore.get -> bool
 *REMOVED*Microsoft.Maui.Controls.Application.Properties.get -> System.Collections.Generic.IDictionary<string!, object!>!
 Microsoft.Maui.Controls.IValueConverter.Convert(object? value, System.Type! targetType, object? parameter, System.Globalization.CultureInfo! culture) -> object?
 Microsoft.Maui.Controls.IValueConverter.ConvertBack(object? value, System.Type! targetType, object? parameter, System.Globalization.CultureInfo! culture) -> object?
+~static Microsoft.Maui.Controls.GridExtensions.Add(this Microsoft.Maui.Controls.Grid grid, Microsoft.Maui.IView view, int left, int right, int top, int bottom) -> void
+~static Microsoft.Maui.Controls.GridExtensions.AddWithSpan(this Microsoft.Maui.Controls.Grid grid, Microsoft.Maui.IView view, int row = 0, int column = 0, int rowSpan = 1, int columnSpan = 1) -> void

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -70,3 +70,5 @@ override Microsoft.Maui.Controls.SearchBar.IsEnabledCore.get -> bool
 *REMOVED*Microsoft.Maui.Controls.Application.Properties.get -> System.Collections.Generic.IDictionary<string!, object!>!
 Microsoft.Maui.Controls.IValueConverter.Convert(object? value, System.Type! targetType, object? parameter, System.Globalization.CultureInfo! culture) -> object?
 Microsoft.Maui.Controls.IValueConverter.ConvertBack(object? value, System.Type! targetType, object? parameter, System.Globalization.CultureInfo! culture) -> object?
+~static Microsoft.Maui.Controls.GridExtensions.Add(this Microsoft.Maui.Controls.Grid grid, Microsoft.Maui.IView view, int left, int right, int top, int bottom) -> void
+~static Microsoft.Maui.Controls.GridExtensions.AddWithSpan(this Microsoft.Maui.Controls.Grid grid, Microsoft.Maui.IView view, int row = 0, int column = 0, int rowSpan = 1, int columnSpan = 1) -> void

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -64,3 +64,5 @@ override Microsoft.Maui.Controls.SearchBar.IsEnabledCore.get -> bool
 *REMOVED*Microsoft.Maui.Controls.Application.Properties.get -> System.Collections.Generic.IDictionary<string!, object!>!
 Microsoft.Maui.Controls.IValueConverter.Convert(object? value, System.Type! targetType, object? parameter, System.Globalization.CultureInfo! culture) -> object?
 Microsoft.Maui.Controls.IValueConverter.ConvertBack(object? value, System.Type! targetType, object? parameter, System.Globalization.CultureInfo! culture) -> object?
+~static Microsoft.Maui.Controls.GridExtensions.Add(this Microsoft.Maui.Controls.Grid grid, Microsoft.Maui.IView view, int left, int right, int top, int bottom) -> void
+~static Microsoft.Maui.Controls.GridExtensions.AddWithSpan(this Microsoft.Maui.Controls.Grid grid, Microsoft.Maui.IView view, int row = 0, int column = 0, int rowSpan = 1, int columnSpan = 1) -> void

--- a/src/Controls/tests/Core.UnitTests/Layouts/GridExtensionTests.cs
+++ b/src/Controls/tests/Core.UnitTests/Layouts/GridExtensionTests.cs
@@ -1,8 +1,9 @@
-﻿using Xunit;
+﻿using System;
+using Xunit;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests.Layouts
 {
-
+	[Category("Layout")]
 	public class GridExtensionTests
 	{
 		[Fact]
@@ -42,6 +43,80 @@ namespace Microsoft.Maui.Controls.Core.UnitTests.Layouts
 
 			Assert.Equal(0, grid.GetColumn(label));
 			Assert.Equal(3, grid.GetRow(label));
+		}
+
+		[Fact]
+		public void AddEnsuresRows() 
+		{
+			var grid = new Grid();
+			grid.Add(new Label(), 0, 4);
+
+			Assert.Equal(5, grid.RowDefinitions.Count);
+		}
+
+		[Fact]
+		public void AddEnsuresColumns()
+		{
+			var grid = new Grid();
+			grid.Add(new Label(), 4, 0);
+
+			Assert.Equal(5, grid.ColumnDefinitions.Count);
+		}
+
+		[Fact]
+		public void AddLRTBEnsuresRows()
+		{
+			var grid = new Grid();
+			grid.Add(new Label(), 0, 1, 0, 5);
+
+			Assert.Equal(5, grid.RowDefinitions.Count);
+		}
+
+		[Fact]
+		public void AddLRTBEnsuresColumns()
+		{
+			var grid = new Grid();
+			grid.Add(new Label(), 0, 5, 0, 1);
+
+			Assert.Equal(5, grid.ColumnDefinitions.Count);
+		}
+
+		[Fact]
+		public void WithSpanEnsuresRows()
+		{
+			var grid = new Grid();
+			grid.AddWithSpan(new Label(), rowSpan: 2);
+
+			Assert.Equal(2, grid.RowDefinitions.Count);
+		}
+
+		[Fact]
+		public void WithSpanEnsuresColumns()
+		{
+			var grid = new Grid();
+			grid.AddWithSpan(new Label(), columnSpan: 2);
+
+			Assert.Equal(2, grid.ColumnDefinitions.Count);
+		}
+
+		[Theory]
+		[InlineData(-1, 1, 0, 1)]
+		[InlineData(0, 1, -1, 1)]
+		public void ThrowsOnInvalidCells(int left, int right, int top, int bottom)
+		{
+			var grid = new Grid();
+			Assert.Throws<ArgumentOutOfRangeException>(() => grid.Add(new Label(), left, right, top, bottom));
+		}
+
+		[Theory]
+		[InlineData(0, 0, 0, 1)]
+		[InlineData(0, 1, 0, 0)]
+		[InlineData(1, 0, 0, 1)]
+		[InlineData(0, 1, 1, 0)]
+		public void ThrowsOnInvalidSpans(int left, int right, int top, int bottom) 
+		{
+			var grid = new Grid();
+			Assert.Throws<ArgumentOutOfRangeException>(() => grid.Add(new Label(), left, right, top, bottom));
 		}
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/Layouts/GridExtensionTests.cs
+++ b/src/Controls/tests/Core.UnitTests/Layouts/GridExtensionTests.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests.Layouts
 		}
 
 		[Fact]
-		public void AddEnsuresRows() 
+		public void AddEnsuresRows()
 		{
 			var grid = new Grid();
 			grid.Add(new Label(), 0, 4);
@@ -113,7 +113,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests.Layouts
 		[InlineData(0, 1, 0, 0)]
 		[InlineData(1, 0, 0, 1)]
 		[InlineData(0, 1, 1, 0)]
-		public void ThrowsOnInvalidSpans(int left, int right, int top, int bottom) 
+		public void ThrowsOnInvalidSpans(int left, int right, int top, int bottom)
 		{
 			var grid = new Grid();
 			Assert.Throws<ArgumentOutOfRangeException>(() => grid.Add(new Label(), left, right, top, bottom));


### PR DESCRIPTION
### Description of Change

Lots of folks are missing the 5-parameter overload of [Add from Xamarin.Forms](https://learn.microsoft.com/en-us/dotnet/api/xamarin.forms.grid.igridlist-1.add?view=xamarin-forms#xamarin-forms-grid-igridlist-1-add(xamarin-forms-view-system-int32-system-int32-system-int32-system-int32)) when migrating applications. While it's not possible to have the exact method signature (as the MAUI version of Grid does not use the IGridList interface or the internal GridElementCollection from Forms for performance reasons), we _can_ add a similar extension method with the same behavior for Grid.

So this pull request includes a 5-parameter overload of Add() with the same behavior as the Forms version. It's intended to aid migration; I would personally not recommend it for any other purpose because of its confusing behavior. 

Also included in this API is another method, AddWithSpan(), which does the exact same thing as Add() but has less confusing parameter names and more straightforward behavior. 

This PR also includes tests for both methods, plus documentation. 

I'm opening this PR so we have a stable point around which to discuss whether we simply keep the weird version of Add() or replace it with a more straightforward method, and how that impacts the migration tools. 

### Issues Fixed

Fixes #780
Closes #9891