### PR TITLE
[iOS] Don't scroll more than the available scrollable space

### DIFF
--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.iOS.cs
@@ -85,7 +85,11 @@ namespace Microsoft.Maui.Handlers
 		{
 			if (args is ScrollToRequest request)
 			{
-				handler.PlatformView.SetContentOffset(new CoreGraphics.CGPoint(request.HorizontalOffset, request.VerticalOffset), !request.Instant);
+				var availableScrollHeight = handler.PlatformView.ContentSize.Height - handler.PlatformView.Frame.Height;
+				var availableScrollWidth = handler.PlatformView.ContentSize.Width - handler.PlatformView.Frame.Width;
+				var minScrollHorizontal = Math.Min(request.HorizontalOffset, availableScrollWidth);
+				var minScrollVertical = Math.Min(request.VerticalOffset, availableScrollHeight);
+				handler.PlatformView.SetContentOffset(new CoreGraphics.CGPoint(minScrollHorizontal, minScrollVertical), !request.Instant);
 
 				if (request.Instant)
 				{

--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.iOS.cs
@@ -85,11 +85,12 @@ namespace Microsoft.Maui.Handlers
 		{
 			if (args is ScrollToRequest request)
 			{
-				var availableScrollHeight = handler.PlatformView.ContentSize.Height - handler.PlatformView.Frame.Height;
-				var availableScrollWidth = handler.PlatformView.ContentSize.Width - handler.PlatformView.Frame.Width;
+				var uiScrollView = handler.PlatformView;
+				var availableScrollHeight = uiScrollView.ContentSize.Height - uiScrollView.Frame.Height;
+				var availableScrollWidth = uiScrollView.ContentSize.Width - uiScrollView.Frame.Width;
 				var minScrollHorizontal = Math.Min(request.HorizontalOffset, availableScrollWidth);
 				var minScrollVertical = Math.Min(request.VerticalOffset, availableScrollHeight);
-				handler.PlatformView.SetContentOffset(new CoreGraphics.CGPoint(minScrollHorizontal, minScrollVertical), !request.Instant);
+				uiScrollView.SetContentOffset(new CoreGraphics.CGPoint(minScrollHorizontal, minScrollVertical), !request.Instant);
 
 				if (request.Instant)
 				{


### PR DESCRIPTION
### Description of Change

On iOS if you were trying to scroll more than the available scroll space it would still put the ContentOffset of the UIScrollView to the requested value. That would cause the content to sometimes disappear, it also didn't show the same UI as for example on Android. 

With this change we clamp the value to the available scroll height/width.

Fixes #7373 