### PR TITLE
[Windows] Add helper method to get GetFirstChildOfType with null support.

### DIFF
--- a/src/Core/src/Platform/Android/ViewGroupExtensions.cs
+++ b/src/Core/src/Platform/Android/ViewGroupExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using AView = Android.Views.View;
 using AViewGroup = Android.Views.ViewGroup;
 
@@ -45,6 +46,12 @@ namespace Microsoft.Maui.Platform
 			}
 
 			return null;
+		}
+
+		public static bool TryGetFirstChildOfType<T>(this AViewGroup viewGroup, [NotNullWhen (true)] out T? result) where T : AView
+		{
+			result = viewGroup.GetFirstChildOfType<T> ();
+			return result is not null;
 		}
 	}
 }

--- a/src/Core/src/Platform/Android/ViewGroupExtensions.cs
+++ b/src/Core/src/Platform/Android/ViewGroupExtensions.cs
@@ -48,9 +48,9 @@ namespace Microsoft.Maui.Platform
 			return null;
 		}
 
-		public static bool TryGetFirstChildOfType<T>(this AViewGroup viewGroup, [NotNullWhen (true)] out T? result) where T : AView
+		public static bool TryGetFirstChildOfType<T>(this AViewGroup viewGroup, [NotNullWhen(true)] out T? result) where T : AView
 		{
-			result = viewGroup.GetFirstChildOfType<T> ();
+			result = viewGroup.GetFirstChildOfType<T>();
 			return result is not null;
 		}
 	}

--- a/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -20,6 +20,7 @@ static Microsoft.Maui.Layouts.LayoutExtensions.ArrangeContentUnbounded(this Micr
 Microsoft.Maui.IWebView.UserAgent.get -> string?
 Microsoft.Maui.IWebView.UserAgent.set -> void
 static Microsoft.Maui.Handlers.WebViewHandler.MapUserAgent(Microsoft.Maui.Handlers.IWebViewHandler! handler, Microsoft.Maui.IWebView! webView) -> void
+static Microsoft.Maui.Platform.ViewGroupExtensions.TryGetFirstChildOfType<T>(this Android.Views.ViewGroup! viewGroup, out T? result) -> bool
 static Microsoft.Maui.Platform.WebViewExtensions.UpdateUserAgent(this Android.Webkit.WebView! platformWebView, Microsoft.Maui.IWebView! webView) -> void
 *REMOVED*Microsoft.Maui.WeakEventManager.HandleEvent(object! sender, object! args, string! eventName) -> void
 Microsoft.Maui.WeakEventManager.HandleEvent(object? sender, object? args, string! eventName) -> void


### PR DESCRIPTION
Well make us move from code like this:

```csharp
if (searchView.GetFirstChildOfType<EditText>() is EditText foo)
    foo.SetInputType(searchBar);
```

```csharp
var foo = searchView.GetFirstChildOfType<EditText>();
if (foo is not null)
    foo.SetInputType(searchBar);
```
To a nicer:
```csharp
if (searchView.TryGetFirstChildOfType<EditText>(out var foo)
    foo.SetInputType(searchBar);
```
