### PR TITLE
Add implicit package reference for Compat

### DIFF
--- a/src/Workload/Microsoft.Maui.Sdk/Sdk/BundledVersions.in.targets
+++ b/src/Workload/Microsoft.Maui.Sdk/Sdk/BundledVersions.in.targets
@@ -4,6 +4,13 @@
     <MauiWorkloadVersion>@VERSION@</MauiWorkloadVersion>
     <MauiWorkloadTargetFramework>@TFM@</MauiWorkloadTargetFramework>
     <MauiVersion Condition=" '$(MauiVersion)' == '' ">$(MauiWorkloadVersion)</MauiVersion>
+
+    <!-- 
+      Indicates that the Microsoft.Maui.Controls.Compatibility package should be implicitly
+      referenced.  This will eventually switch to false by default and become opt, in,
+      however Visual Studio currently depends on this assembly being loaded for Live Visual Tree.
+    -->
+    <UseMauiCompat Condition=" '$(UseMauiCompat)' == '' and '$(UseMaui)' == 'true' ">true</UseMauiCompat>
   </PropertyGroup>
 
   <!--
@@ -33,6 +40,11 @@
   </ItemGroup>
   <ItemGroup Condition=" '$(UseMaui)' == 'true' ">
     <_MauiImplicitPackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)">
+      <PrivateAssets Condition=" '$(OutputType)' == 'Library' and '$(AndroidApplication)' != 'true' ">all</PrivateAssets>
+    </_MauiImplicitPackageReference>
+  </ItemGroup>
+  <ItemGroup Condition=" '$(UseMaui)' == 'true' and '$(UseMauiCompat)' == 'true' ">
+    <_MauiImplicitPackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)">
       <PrivateAssets Condition=" '$(OutputType)' == 'Library' and '$(AndroidApplication)' != 'true' ">all</PrivateAssets>
     </_MauiImplicitPackageReference>
   </ItemGroup>


### PR DESCRIPTION
Ultimately we want this to be an implicit reference which is not included by default and opt-in, however visual studio's Live Visual tree currently depends on the assembly existing and being loaded so we cannot yet remove it.

The default property assignment can be removed once VS is ready for this.

