### PR TITLE
Use the TextColor value to set the ClearButton color on the Entry

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Controls/EntryPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/EntryPage.xaml
@@ -27,6 +27,13 @@
                     Text="Text"
                     TextColor="Purple"/>
                 <Label
+                    Text="Using TextColor (for the text color and the clear button color)"
+                    Style="{StaticResource Headline}" />
+                <Entry 
+                    ClearButtonVisibility="WhileEditing"
+                    Text="Text"
+                    TextColor="Red"/>
+                <Label
                     Text="With Placeholder"
                     Style="{StaticResource Headline}" />
                 <Entry 

--- a/src/Core/src/Handlers/Entry/EntryHandler.Android.cs
+++ b/src/Core/src/Handlers/Entry/EntryHandler.Android.cs
@@ -199,14 +199,15 @@ namespace Microsoft.Maui.Handlers
 
 			var drawable = GetClearButtonDrawable();
 
-			if (PlatformView.LayoutDirection == LayoutDirection.Rtl)
-			{
-				PlatformView.SetCompoundDrawablesWithIntrinsicBounds(drawable, null, null, null);
-			}
+			if (VirtualView?.TextColor is not null)
+				drawable?.SetColorFilter(VirtualView.TextColor.ToPlatform(), FilterMode.SrcIn);
 			else
-			{
+				drawable?.ClearColorFilter();
+
+			if (PlatformView.LayoutDirection == LayoutDirection.Rtl)
+				PlatformView.SetCompoundDrawablesWithIntrinsicBounds(drawable, null, null, null);
+			else
 				PlatformView.SetCompoundDrawablesWithIntrinsicBounds(null, null, drawable, null);
-			}
 
 			_clearButtonVisible = true;
 		}

--- a/src/Core/src/Platform/iOS/TextFieldExtensions.cs
+++ b/src/Core/src/Platform/iOS/TextFieldExtensions.cs
@@ -190,8 +190,6 @@ namespace Microsoft.Maui.Platform
 		{
 			if (textField.ValueForKey(new NSString("clearButton")) is UIButton clearButton)
 			{
-				clearButton.TintColor = entry.TextColor.ToPlatform();
-
 				UIImage defaultClearImage = clearButton.ImageForState(UIControlState.Highlighted);
 
 				if (entry.TextColor is null)
@@ -201,8 +199,9 @@ namespace Microsoft.Maui.Platform
 				}
 				else
 				{
-					var tintedClearImage = GetClearButtonTintImage(defaultClearImage, entry.TextColor.ToPlatform());
+					clearButton.TintColor = entry.TextColor.ToPlatform();
 
+					var tintedClearImage = GetClearButtonTintImage(defaultClearImage, entry.TextColor.ToPlatform());
 					clearButton.SetImage(tintedClearImage, UIControlState.Normal);
 					clearButton.SetImage(tintedClearImage, UIControlState.Highlighted);
 				}

--- a/src/Core/src/Platform/iOS/TextFieldExtensions.cs
+++ b/src/Core/src/Platform/iOS/TextFieldExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using CoreGraphics;
 using Foundation;
 using Microsoft.Maui.Graphics;
 using ObjCRuntime;
@@ -176,7 +177,62 @@ namespace Microsoft.Maui.Platform
 
 		public static void UpdateClearButtonVisibility(this UITextField textField, IEntry entry)
 		{
-			textField.ClearButtonMode = entry.ClearButtonVisibility == ClearButtonVisibility.WhileEditing ? UITextFieldViewMode.WhileEditing : UITextFieldViewMode.Never;
+			if (entry.ClearButtonVisibility == ClearButtonVisibility.WhileEditing)
+			{
+				textField.ClearButtonMode = UITextFieldViewMode.WhileEditing;
+				textField.UpdateClearButtonColor(entry);
+			}
+			else
+				textField.ClearButtonMode = UITextFieldViewMode.Never;
+		}
+
+		internal static void UpdateClearButtonColor(this UITextField textField, IEntry entry)
+		{
+			if (textField.ValueForKey(new NSString("clearButton")) is UIButton clearButton)
+			{
+				clearButton.TintColor = entry.TextColor.ToPlatform();
+
+				UIImage defaultClearImage = clearButton.ImageForState(UIControlState.Highlighted);
+
+				if (entry.TextColor is null)
+				{
+					clearButton.SetImage(defaultClearImage, UIControlState.Normal);
+					clearButton.SetImage(defaultClearImage, UIControlState.Highlighted);
+				}
+				else
+				{
+					var tintedClearImage = GetClearButtonTintImage(defaultClearImage, entry.TextColor.ToPlatform());
+
+					clearButton.SetImage(tintedClearImage, UIControlState.Normal);
+					clearButton.SetImage(tintedClearImage, UIControlState.Highlighted);
+				}
+			}
+		}
+
+		internal static UIImage? GetClearButtonTintImage(UIImage image, UIColor color)
+		{
+			var size = image.Size;
+
+			UIGraphics.BeginImageContextWithOptions(size, false, UIScreen.MainScreen.Scale);
+
+			if (UIGraphics.GetCurrentContext() == null)
+				return null;
+
+			var context = UIGraphics.GetCurrentContext();
+
+			image.Draw(CGPoint.Empty, CGBlendMode.Normal, 1.0f);
+			context?.SetFillColor(color.CGColor);
+			context?.SetBlendMode(CGBlendMode.SourceIn);
+			context?.SetAlpha(1.0f);
+
+			var rect = new CGRect(CGPoint.Empty.X, CGPoint.Empty.Y, image.Size.Width, image.Size.Height);
+			context?.FillRect(rect);
+
+			var tintedImage = UIGraphics.GetImageFromCurrentImageContext();
+
+			UIGraphics.EndImageContext();
+
+			return tintedImage;
 		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.Android.cs
@@ -15,6 +15,25 @@ namespace Microsoft.Maui.DeviceTests
 {
 	public partial class EntryHandlerTests
 	{
+		[Theory(DisplayName = "ClearButton Color Initializes Correctly")]
+		[InlineData(0xFFFF0000)]
+		[InlineData(0xFF00FF00)]
+		[InlineData(0xFF0000FF)]
+		public async Task ClearButtonColorInitializesCorrectly(uint color)
+		{
+			var expected = Color.FromUint(color);
+
+			var entry = new EntryStub()
+			{
+				Text = "Test",
+				TextColor= expected,
+				ClearButtonVisibility = ClearButtonVisibility.WhileEditing
+			};
+
+			entry.Focus();
+
+			await ValidateHasColor(entry, expected);
+		}
 
 		[Fact(DisplayName = "Padding is the same after background changes")]
 		public async Task PaddingDoesntChangeAfterBackground()

--- a/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.Android.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Maui.DeviceTests
 			var entry = new EntryStub()
 			{
 				Text = "Test",
-				TextColor= expected,
+				TextColor = expected,
 				ClearButtonVisibility = ClearButtonVisibility.WhileEditing
 			};
 

--- a/src/Core/tests/DeviceTests/Stubs/StubBase.cs
+++ b/src/Core/tests/DeviceTests/Stubs/StubBase.cs
@@ -125,10 +125,16 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 		{
 		}
 
-		public bool Focus() => false;
+		public bool Focus()
+		{
+			IsFocused = true;
+
+			return true;
+		}
 
 		public void Unfocus()
 		{
+			IsFocused = false;
 		}
 
 		public Size Measure(double widthConstraint, double heightConstraint)


### PR DESCRIPTION
### Description of Change

Use the TextColor value to set the ClearButton color on the Entry. Reviewing issues I realized that 13432 was already fixed in Xamarin.Forms and we have not migrated the changes to .NET MAUI https://github.com/xamarin/Xamarin.Forms/pull/12391

To test the changes can use the added sample to the .NET MAUI Entry samples.

Android
![image](https://user-images.githubusercontent.com/6755973/220341910-ebcae27b-ef8b-4618-8994-c404dd570102.png)

iOS
<img width="375" alt="image" src="https://user-images.githubusercontent.com/6755973/220620782-7c7989df-05c7-4e9d-b2b0-e970616914fa.png">

![image](https://user-images.githubusercontent.com/6755973/220339830-56c9863b-5d7d-4f25-9b13-1e49720a33ac.png)

### Issues Fixed

Fixes #13432 