### PR TITLE
[templates] Fix applicationId template option

### DIFF
--- a/src/Templates/src/templates/maui-blazor/.template.config/template.json
+++ b/src/Templates/src/templates/maui-blazor/.template.config/template.json
@@ -55,8 +55,7 @@
       "applicationId": {
         "type": "parameter",
         "description": "Overrides the $(ApplicationId) in the project",
-        "datatype": "string",
-        "replaces": "com.companyname.mauiapp"
+        "datatype": "string"
       },
       "msExtensionsVersion": {
         "type": "parameter",
@@ -85,6 +84,39 @@
         "type": "generated",
         "generator": "guid",
         "replaces": "$guid9$"
+      },
+      "nameToLower":{
+        "type": "generated",
+        "generator": "casing",
+        "parameters": {
+          "source" : "name",
+          "toLower": true
+        }
+      },
+      "defaultAppId":{
+        "type": "generated",
+        "generator": "join",
+        "parameters": {
+          "symbols": [
+            {
+              "type": "const",
+              "value": "com.companyname."
+            },
+            {
+              "type": "ref",
+              "value": "nameToLower"
+            }
+          ]
+        }
+      },
+      "finalAppId":{
+        "type":"generated",
+        "generator": "coalesce",
+        "parameters": {
+          "sourceVariableName": "applicationId",
+          "fallbackVariableName": "defaultAppId"
+        },
+        "replaces": "com.companyname.mauiapp"
       }
     },
     "defaultName": "MauiApp1"

--- a/src/Templates/src/templates/maui-blazor/.template.config/template.json
+++ b/src/Templates/src/templates/maui-blazor/.template.config/template.json
@@ -56,7 +56,7 @@
         "type": "parameter",
         "description": "Overrides the $(ApplicationId) in the project",
         "datatype": "string",
-        "replaces": "com.companyname.MauiApp.1"
+        "replaces": "com.companyname.mauiapp"
       },
       "msExtensionsVersion": {
         "type": "parameter",

--- a/src/Templates/src/templates/maui-blazor/MauiApp.1.csproj
+++ b/src/Templates/src/templates/maui-blazor/MauiApp.1.csproj
@@ -16,7 +16,7 @@
         <ApplicationTitle>MauiApp.1</ApplicationTitle>
 
         <!-- App Identifier -->
-        <ApplicationId>com.companyname.mauiapp._1</ApplicationId>
+        <ApplicationId>com.companyname.mauiapp</ApplicationId>
 
         <!-- Versions -->
         <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>

--- a/src/Templates/src/templates/maui-mobile/.template.config/template.json
+++ b/src/Templates/src/templates/maui-mobile/.template.config/template.json
@@ -60,7 +60,7 @@
         "type": "parameter",
         "description": "Overrides the $(ApplicationId) in the project",
         "datatype": "string",
-        "replaces": "com.companyname.MauiApp.1"
+        "replaces": "com.companyname.mauiapp"
       },
       "msExtensionsVersion": {
         "type": "parameter",

--- a/src/Templates/src/templates/maui-mobile/.template.config/template.json
+++ b/src/Templates/src/templates/maui-mobile/.template.config/template.json
@@ -59,8 +59,7 @@
       "applicationId": {
         "type": "parameter",
         "description": "Overrides the $(ApplicationId) in the project",
-        "datatype": "string",
-        "replaces": "com.companyname.mauiapp"
+        "datatype": "string"
       },
       "msExtensionsVersion": {
         "type": "parameter",
@@ -89,6 +88,39 @@
         "type": "generated",
         "generator": "guid",
         "replaces": "$guid9$"
+      },
+      "nameToLower":{
+        "type": "generated",
+        "generator": "casing",
+        "parameters": {
+          "source" : "name",
+          "toLower": true
+        }
+      },
+      "defaultAppId":{
+        "type": "generated",
+        "generator": "join",
+        "parameters": {
+          "symbols": [
+            {
+              "type": "const",
+              "value": "com.companyname."
+            },
+            {
+              "type": "ref",
+              "value": "nameToLower"
+            }
+          ]
+        }
+      },
+      "finalAppId":{
+        "type":"generated",
+        "generator": "coalesce",
+        "parameters": {
+          "sourceVariableName": "applicationId",
+          "fallbackVariableName": "defaultAppId"
+        },
+        "replaces": "com.companyname.mauiapp"
       }
     },
     "defaultName": "MauiApp1"

--- a/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
+++ b/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
@@ -15,7 +15,7 @@
 		<ApplicationTitle>MauiApp.1</ApplicationTitle>
 
 		<!-- App Identifier -->
-		<ApplicationId>com.companyname.mauiapp._1</ApplicationId>
+		<ApplicationId>com.companyname.mauiapp</ApplicationId>
 
 		<!-- Versions -->
 		<ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>


### PR DESCRIPTION
### Description of Change

We prevent the templating engine from matching the AppID to the App's name (the sourceName). This allows the `applicationId` parameter to work as expected when doing `dotnet new -ap com.my.name`. I also make sure that if we're using the (lowercased) app name as an AppID in case no parameter is passed.

The changes required some tricks using the templating engine. Mainly:
- Creating a separate variable (symbol) for the lowercased app name
- Creating a new symbol `defaultAppId` that is the concatenation of "com.company." with the lowercased app name 
- Use the coalescing generator to evaluate the `finalAppID`. The result depends on whether the `applicationId` parameter was passed by the user. If the `applicationId` is null (i.e not given), we use the `defaultAppId`; otherwise we use whatever the user provided. 

### Issues Fixed
fixes #13297

