### PR TITLE
Add Pages VC View opposed to the handlers view

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellSectionRootRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellSectionRootRenderer.cs
@@ -218,7 +218,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				var shellContent = items[i];
 				if (_renderers.TryGetValue(shellContent, out var renderer))
 				{
-					var view = renderer.PlatformView;
+					var view = renderer.ViewController.View;
 					if (view != null)
 						view.Frame = new CGRect(0, 0, View.Bounds.Width, View.Bounds.Height);
 				}
@@ -262,7 +262,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 				if (item == currentItem)
 				{
-					_containerArea.AddSubview(renderer.PlatformView);
+					_containerArea.AddSubview(renderer.ViewController.View);
 					_currentContent = currentItem;
 					_currentIndex = i;
 				}

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellSectionRootRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellSectionRootRenderer.cs
@@ -181,11 +181,8 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				{
 					var oldRenderer = renderer.Value;
 
-					if (oldRenderer.PlatformView != null)
-						oldRenderer.PlatformView.RemoveFromSuperview();
-
-					if (oldRenderer.ViewController != null)
-						oldRenderer.ViewController.RemoveFromParentViewController();
+					oldRenderer.ViewController?.ViewIfLoaded?.RemoveFromSuperview();
+					oldRenderer.ViewController?.RemoveFromParentViewController();
 
 					var element = oldRenderer.VirtualView;
 					oldRenderer?.DisconnectHandler();
@@ -351,21 +348,21 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			int newIndex,
 			UIView containerView)
 		{
-			containerView.AddSubview(newRenderer.PlatformView);
+			containerView.AddSubview(newRenderer.ViewController.View);
 			// -1 == slide left, 1 ==  slide right
 			int motionDirection = newIndex > oldIndex ? -1 : 1;
 
-			newRenderer.PlatformView.Frame = new CGRect(-motionDirection * View.Bounds.Width, 0, View.Bounds.Width, View.Bounds.Height);
+			newRenderer.ViewController.View.Frame = new CGRect(-motionDirection * View.Bounds.Width, 0, View.Bounds.Width, View.Bounds.Height);
 
-			if (oldRenderer.PlatformView != null)
-				oldRenderer.PlatformView.Frame = containerView.Bounds;
+			if (oldRenderer.ViewController.View != null)
+				oldRenderer.ViewController.View.Frame = containerView.Bounds;
 
 			return new UIViewPropertyAnimator(0.25, UIViewAnimationCurve.EaseOut, () =>
 			{
-				newRenderer.PlatformView.Frame = containerView.Bounds;
+				newRenderer.ViewController.View.Frame = containerView.Bounds;
 
-				if (oldRenderer.PlatformView != null)
-					oldRenderer.PlatformView.Frame = new CGRect(motionDirection * View.Bounds.Width, 0, View.Bounds.Width, View.Bounds.Height);
+				if (oldRenderer.ViewController.View != null)
+					oldRenderer.ViewController.View.Frame = new CGRect(motionDirection * View.Bounds.Width, 0, View.Bounds.Width, View.Bounds.Height);
 
 			});
 		}
@@ -388,14 +385,14 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 					var oldContent = r.Key;
 					var oldRenderer = r.Value;
 
-					r.Value.PlatformView.RemoveFromSuperview();
+					r.Value.ViewController?.ViewIfLoaded?.RemoveFromSuperview();
 
 					if (!sectionItems.Contains(oldContent) && _renderers.ContainsKey(oldContent))
 					{
 						removeMe = removeMe ?? new List<ShellContent>();
 						removeMe.Add(oldContent);
 
-						if (oldRenderer.PlatformView != null)
+						if (oldRenderer.PlatformView is not null)
 						{
 							oldRenderer.ViewController.RemoveFromParentViewController();
 							oldRenderer.DisconnectHandler();
@@ -482,7 +479,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 						_currentIndex--;
 
 					_renderers.Remove(oldItem);
-					oldRenderer.PlatformView.RemoveFromSuperview();
+					oldRenderer.ViewController.ViewIfLoaded?.RemoveFromSuperview();
 					oldRenderer.ViewController.RemoveFromParentViewController();
 					oldRenderer.DisconnectHandler();
 				}

--- a/src/Controls/tests/DeviceTests/ControlsHandlerTestBase.cs
+++ b/src/Controls/tests/DeviceTests/ControlsHandlerTestBase.cs
@@ -147,7 +147,7 @@ namespace Microsoft.Maui.DeviceTests
 
 						if (content is FlyoutPage fp)
 							content = fp.Detail;
-							
+
 						if (window is Window w && w.Navigation.ModalStack.Count > 0)
 							content = w.Navigation.ModalStack.Last();
 

--- a/src/Controls/tests/DeviceTests/ControlsHandlerTestBase.cs
+++ b/src/Controls/tests/DeviceTests/ControlsHandlerTestBase.cs
@@ -32,26 +32,8 @@ namespace Microsoft.Maui.DeviceTests
 			return mauiAppBuilder.ConfigureTestBuilder();
 		}
 
-		protected void SetupShellHandlers(IMauiHandlersCollection handlers)
-		{
-			handlers.TryAddHandler(typeof(Controls.Shell), typeof(ShellHandler));
-			handlers.TryAddHandler<Layout, LayoutHandler>();
-			handlers.TryAddHandler<Image, ImageHandler>();
-			handlers.TryAddHandler<Label, LabelHandler>();
-			handlers.TryAddHandler<Page, PageHandler>();
-			handlers.TryAddHandler(typeof(Toolbar), typeof(ToolbarHandler));
-			handlers.TryAddHandler(typeof(MenuBar), typeof(MenuBarHandler));
-			handlers.TryAddHandler(typeof(MenuBarItem), typeof(MenuBarItemHandler));
-			handlers.TryAddHandler(typeof(MenuFlyoutItem), typeof(MenuFlyoutItemHandler));
-			handlers.TryAddHandler(typeof(MenuFlyoutSubItem), typeof(MenuFlyoutSubItemHandler));
-			handlers.TryAddHandler<ScrollView, ScrollViewHandler>();
-
-#if WINDOWS
-			handlers.TryAddHandler(typeof(ShellItem), typeof(ShellItemHandler));
-			handlers.TryAddHandler(typeof(ShellSection), typeof(ShellSectionHandler));
-			handlers.TryAddHandler(typeof(ShellContent), typeof(ShellContentHandler));
-#endif
-		}
+		protected void SetupShellHandlers(IMauiHandlersCollection handlers) =>
+			handlers.SetupShellHandlers();
 
 		protected THandler CreateHandler<THandler>(IElement view)
 			where THandler : IElementHandler, new()
@@ -100,6 +82,39 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
+		IWindow CreateWindowForContent(IElement view)
+		{
+			IWindow window;
+
+			if (view is IWindow w)
+				window = w;
+			else if (view is Page page)
+				window = new Controls.Window(page);
+			else
+				window = new Controls.Window(new ContentPage() { Content = (View)view });
+
+			return window;
+		}
+
+		protected Task CreateHandlerAndAddToWindow(IElement view, Action action)
+		{
+			return CreateHandlerAndAddToWindow<IWindowHandler>(CreateWindowForContent(view), handler =>
+			{
+				action();
+				return Task.CompletedTask;
+			});
+		}
+
+		protected Task CreateHandlerAndAddToWindow<THandler>(IElement view, Action<THandler> action)
+			where THandler : class, IElementHandler
+		{
+			return CreateHandlerAndAddToWindow<THandler>(view, handler =>
+			{
+				action(handler);
+				return Task.CompletedTask;
+			});
+		}
+
 		static SemaphoreSlim _takeOverMainContentSempahore = new SemaphoreSlim(1);
 		protected Task CreateHandlerAndAddToWindow<THandler>(IElement view, Func<THandler, Task> action, IMauiContext mauiContext = null, TimeSpan? timeOut = null)
 			where THandler : class, IElementHandler
@@ -110,22 +125,9 @@ namespace Microsoft.Maui.DeviceTests
 
 			return InvokeOnMainThreadAsync(async () =>
 			{
-				IWindow window = null;
+				IWindow window = CreateWindowForContent(view);
 
 				var application = mauiContext.Services.GetService<IApplication>();
-
-				if (view is IWindow w)
-				{
-					window = w;
-				}
-				else if (view is Page page)
-				{
-					window = new Controls.Window(page);
-				}
-				else
-				{
-					window = new Controls.Window(new ContentPage() { Content = (View)view });
-				}
 
 				if (application is ApplicationStub appStub)
 				{
@@ -143,6 +145,9 @@ namespace Microsoft.Maui.DeviceTests
 					{
 						IView content = window.Content;
 
+						if (content is FlyoutPage fp)
+							content = fp.Detail;
+							
 						if (window is Window w && w.Navigation.ModalStack.Count > 0)
 							content = w.Navigation.ModalStack.Last();
 
@@ -191,6 +196,8 @@ namespace Microsoft.Maui.DeviceTests
 							handler = (THandler)window.Content.Handler;
 						else if (window.Content is ContentPage cp && typeof(THandler).IsAssignableFrom(cp.Content.Handler.GetType()))
 							handler = (THandler)cp.Content.Handler;
+						else if (typeof(THandler).IsAssignableFrom(typeof(WindowHandler)))
+							throw new Exception($"Use IWindowHandler instead of WindowHandler for CreateHandlerAndAddToWindow");
 						else
 							throw new Exception($"I can't work with {typeof(THandler)}");
 

--- a/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.iOS.cs
@@ -163,6 +163,7 @@ namespace Microsoft.Maui.DeviceTests
 			[ClassData(typeof(ControlsPageTypesTestCases))]
 			public async Task NextMovesToNextEntry(string page)
 			{
+				bool isFocused = false;
 				EnsureHandlerCreated(builder =>
 				{
 					ControlsPageTypesTestCases.Setup(builder);
@@ -194,15 +195,15 @@ namespace Microsoft.Maui.DeviceTests
 				};
 
 				Page rootPage = ControlsPageTypesTestCases.CreatePageType(page, contentPage);
-				Page hostPage = new ContentPage();
 
-				await CreateHandlerAndAddToWindow(hostPage, async () =>
+				await CreateHandlerAndAddToWindow(rootPage, async () =>
 				{
-					await hostPage.Navigation.PushModalAsync(rootPage);
 					KeyboardAutoManager.GoToNextResponderOrResign(entry1.ToPlatform());
 					await AssertionExtensions.Wait(() => entry2.IsFocused);
-					Assert.True(entry2.IsFocused);
+					isFocused = entry2.IsFocused;
 				});
+
+				Assert.True(isFocused, $"{page} failed to focus the second entry DANG");
 			}
 		}
 	}

--- a/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.iOS.cs
@@ -154,7 +154,7 @@ namespace Microsoft.Maui.DeviceTests
 				});
 			});
 		}
-		
+
 		[Category(TestCategory.Entry)]
 		[Collection(ControlsHandlerTestBase.RunInNewWindowCollection)]
 		public partial class EntryTestsWithWindow : ControlsHandlerTestBase

--- a/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.iOS.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Handlers.Compatibility;
+using Microsoft.Maui.DeviceTests.TestCases;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Hosting;
 using Microsoft.Maui.Platform;
@@ -152,6 +153,57 @@ namespace Microsoft.Maui.DeviceTests
 					Assert.True(field.Text == "EntryCell1");
 				});
 			});
+		}
+		
+		[Category(TestCategory.Entry)]
+		[Collection(ControlsHandlerTestBase.RunInNewWindowCollection)]
+		public partial class EntryTestsWithWindow : ControlsHandlerTestBase
+		{
+			[Theory]
+			[ClassData(typeof(ControlsPageTypesTestCases))]
+			public async Task NextMovesToNextEntry(string page)
+			{
+				EnsureHandlerCreated(builder =>
+				{
+					ControlsPageTypesTestCases.Setup(builder);
+					builder.ConfigureMauiHandlers(handlers =>
+					{
+						handlers.AddHandler(typeof(Entry), typeof(EntryHandler));
+					});
+				});
+
+				var entry1 = new Entry
+				{
+					Text = "Entry 1",
+					ReturnType = ReturnType.Next
+				};
+
+				var entry2 = new Entry
+				{
+					Text = "Entry 2",
+					ReturnType = ReturnType.Next
+				};
+
+				ContentPage contentPage = new ContentPage()
+				{
+					Content = new VerticalStackLayout()
+					{
+						entry1,
+						entry2
+					}
+				};
+
+				Page rootPage = ControlsPageTypesTestCases.CreatePageType(page, contentPage);
+				Page hostPage = new ContentPage();
+
+				await CreateHandlerAndAddToWindow(hostPage, async () =>
+				{
+					await hostPage.Navigation.PushModalAsync(rootPage);
+					KeyboardAutoManager.GoToNextResponderOrResign(entry1.ToPlatform());
+					await AssertionExtensions.Wait(() => entry2.IsFocused);
+					Assert.True(entry2.IsFocused);
+				});
+			}
 		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
@@ -977,7 +977,7 @@ namespace Microsoft.Maui.DeviceTests
 				Assert.Equal(pageBounds.Height, window.Height);
 			});
 		}
-		
+
 		[Fact(DisplayName = "Pages Do Not Leak")]
 		public async Task PagesDoNotLeak()
 		{

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
@@ -8,6 +8,7 @@ using Microsoft.Maui;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Handlers;
 using Microsoft.Maui.Controls.Handlers.Compatibility;
+using Microsoft.Maui.Devices;
 using Microsoft.Maui.DeviceTests.Stubs;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Hosting;
@@ -32,7 +33,42 @@ namespace Microsoft.Maui.DeviceTests
 				{
 					SetupShellHandlers(handlers);
 					handlers.AddHandler(typeof(NavigationPage), typeof(NavigationViewHandler));
+					handlers.AddHandler(typeof(Button), typeof(ButtonHandler));
 				});
+			});
+		}
+
+		[Fact]
+		public async Task PageLayoutDoesNotExceedWindowBounds()
+		{
+			SetupBuilder();
+
+			var button = new Button()
+			{
+				Text = "Test me"
+			};
+
+			var contentPage = new ContentPage()
+			{
+				Content = button
+			};
+
+			var shell = new Shell()
+			{
+				CurrentItem = contentPage,
+				FlyoutBehavior = FlyoutBehavior.Disabled
+			};
+
+			await CreateHandlerAndAddToWindow<WindowHandlerStub>(shell, async (handler) =>
+			{
+				await OnFrameSetToNotEmpty(contentPage);
+				var pageBounds = contentPage.GetBoundingBox();
+				var window = contentPage.Window;
+
+				Assert.True(pageBounds.X >= 0);
+				Assert.True(pageBounds.Y >= 0);
+				Assert.True(pageBounds.Width <= window.Width);
+				Assert.True(pageBounds.Height <= window.Height);
 			});
 		}
 

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
@@ -917,6 +917,31 @@ namespace Microsoft.Maui.DeviceTests
 		}
 #endif
 
+		[Fact]
+		public async Task BasicContentPageMeasuresCorrectly()
+		{
+			SetupBuilder();
+			var page1 = new ContentPage()
+			{
+				Title = "Page 1"
+			};
+
+			var shell = new Shell()
+			{
+				CurrentItem = page1
+			};
+
+			var window = new Window(shell);
+			await CreateHandlerAndAddToWindow<IWindowHandler>(window, async (handler) =>
+			{
+				await Task.Delay(100);
+				var pageBounds = page1.GetBoundingBox();
+
+				Assert.Equal(pageBounds.Width, window.Width);
+				Assert.Equal(pageBounds.Height, window.Height);
+			});
+		}
+		
 		[Fact(DisplayName = "Pages Do Not Leak")]
 		public async Task PagesDoNotLeak()
 		{

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
@@ -953,31 +953,6 @@ namespace Microsoft.Maui.DeviceTests
 		}
 #endif
 
-		[Fact]
-		public async Task BasicContentPageMeasuresCorrectly()
-		{
-			SetupBuilder();
-			var page1 = new ContentPage()
-			{
-				Title = "Page 1"
-			};
-
-			var shell = new Shell()
-			{
-				CurrentItem = page1
-			};
-
-			var window = new Window(shell);
-			await CreateHandlerAndAddToWindow<IWindowHandler>(window, async (handler) =>
-			{
-				await Task.Delay(100);
-				var pageBounds = page1.GetBoundingBox();
-
-				Assert.Equal(pageBounds.Width, window.Width);
-				Assert.Equal(pageBounds.Height, window.Height);
-			});
-		}
-
 		[Fact(DisplayName = "Pages Do Not Leak")]
 		public async Task PagesDoNotLeak()
 		{

--- a/src/Controls/tests/DeviceTests/Extensions.cs
+++ b/src/Controls/tests/DeviceTests/Extensions.cs
@@ -1,6 +1,18 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Handlers;
+using Microsoft.Maui.Controls.Hosting;
+using Microsoft.Maui.Devices;
+using Microsoft.Maui.DeviceTests.Stubs;
+using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Hosting;
+using Microsoft.Maui.Platform;
+using Xunit;
+#if ANDROID || IOS || MACCATALYST
+using ShellHandler = Microsoft.Maui.Controls.Handlers.Compatibility.ShellRenderer;
+#endif
 
 namespace Microsoft.Maui.DeviceTests
 {
@@ -8,6 +20,32 @@ namespace Microsoft.Maui.DeviceTests
 	{
 		public static Task Wait(this Image image, int timeout = 1000) =>
 			AssertionExtensions.Wait(() => !image.IsLoading, timeout);
+
+		public static void SetupShellHandlers(this MauiAppBuilder builder)
+		{
+			builder.ConfigureMauiHandlers(SetupShellHandlers);
+		}
+
+		public static void SetupShellHandlers(this IMauiHandlersCollection handlers)
+		{
+			handlers.TryAddHandler(typeof(Controls.Shell), typeof(ShellHandler));
+			handlers.TryAddHandler<Layout, LayoutHandler>();
+			handlers.TryAddHandler<Image, ImageHandler>();
+			handlers.TryAddHandler<Label, LabelHandler>();
+			handlers.TryAddHandler<Page, PageHandler>();
+			handlers.TryAddHandler(typeof(Toolbar), typeof(ToolbarHandler));
+			handlers.TryAddHandler(typeof(MenuBar), typeof(MenuBarHandler));
+			handlers.TryAddHandler(typeof(MenuBarItem), typeof(MenuBarItemHandler));
+			handlers.TryAddHandler(typeof(MenuFlyoutItem), typeof(MenuFlyoutItemHandler));
+			handlers.TryAddHandler(typeof(MenuFlyoutSubItem), typeof(MenuFlyoutSubItemHandler));
+			handlers.TryAddHandler<ScrollView, ScrollViewHandler>();
+
+#if WINDOWS
+			handlers.TryAddHandler(typeof(ShellItem), typeof(ShellItemHandler));
+			handlers.TryAddHandler(typeof(ShellSection), typeof(ShellSectionHandler));
+			handlers.TryAddHandler(typeof(ShellContent), typeof(ShellContentHandler));
+#endif
+		}
 	}
 }
 

--- a/src/Controls/tests/DeviceTests/TestCases/ControlsPageTypesTestCases.cs
+++ b/src/Controls/tests/DeviceTests/TestCases/ControlsPageTypesTestCases.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Handlers.Compatibility;
+using Microsoft.Maui.DeviceTests.Stubs;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Hosting;
+
+#if IOS || MACCATALYST
+using FlyoutViewHandler = Microsoft.Maui.Controls.Handlers.Compatibility.PhoneFlyoutPageRenderer;
+#endif
+
+namespace Microsoft.Maui.DeviceTests.TestCases
+{
+	public class ControlsPageTypesTestCases : IEnumerable<object[]>
+	{
+		private readonly List<object[]> _data = new()
+		{
+			new object[] { nameof(FlyoutPage) },
+			new object[] { nameof(TabbedPage) },
+			new object[] { nameof(ContentPage) },
+			new object[] { nameof(Shell) },
+			new object[] { nameof(NavigationPage) },
+		};
+
+		public IEnumerator<object[]> GetEnumerator() => _data.GetEnumerator();
+
+		IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+
+		public static Page CreatePageType(string name, Page content)
+		{
+			switch (name)
+			{
+				case nameof(FlyoutPage):
+					content.Title = content.Title ?? "Detail Title";
+					return new FlyoutPage() { Flyout = new ContentPage() { Title = "title" }, Detail = content };
+				case nameof(TabbedPage):
+					return new TabbedPage() { Children = { content } };
+				case nameof(ContentPage):
+					return content;
+				case nameof(Shell):
+					return new Shell() { CurrentItem = (ContentPage)content };
+				case nameof(NavigationPage):
+					return new NavigationPage(content);
+			}
+
+			throw new Exception($"{name} not found");
+		}
+
+		public static void Setup(MauiAppBuilder builder)
+		{
+			builder.ConfigureMauiHandlers(handlers =>
+			{
+				handlers.SetupShellHandlers();
+
+				handlers.AddHandler(typeof(Controls.Label), typeof(LabelHandler));
+				handlers.AddHandler(typeof(Controls.Toolbar), typeof(ToolbarHandler));
+				handlers.AddHandler(typeof(FlyoutPage), typeof(FlyoutViewHandler));
+#if IOS || MACCATALYST
+				handlers.AddHandler(typeof(TabbedPage), typeof(TabbedRenderer));
+				handlers.AddHandler(typeof(NavigationPage), typeof(NavigationRenderer));
+#else
+				handlers.AddHandler(typeof(TabbedPage), typeof(TabbedViewHandler));
+				handlers.AddHandler(typeof(NavigationPage), typeof(NavigationViewHandler));
+#endif
+				handlers.AddHandler<Page, PageHandler>();
+				handlers.AddHandler<Controls.Window, WindowHandlerStub>();
+			});
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change

Go to next entry code wasn't working with shell because on iOS with shell we were never accessing ViewController.View on the PageViewController. This means that the View property on the PageViewController was never loading. We would just add the PageView.

This PR adds the View via the VC instead of the Handler so that the PageViewController can be setup as a NextResponder and thus be located by the FindNext code

The previous version of this PR didn't quite work. We also needed to change which view we are setting the `Frame` on inside `ShellSectionRootRenderer` . `ShellSectionRootRenderer` needs to set the `Frame` on the Page ViewControllers View instead of the PlatformView.

### Issues Fixed

Fixes #13332

