### PR TITLE
Fixed ResourceDictionary.ContainsKey method 

### DIFF
--- a/src/Controls/src/Core/ResourceDictionary.cs
+++ b/src/Controls/src/Core/ResourceDictionary.cs
@@ -179,7 +179,16 @@ namespace Microsoft.Maui.Controls
 		/// <include file="../../docs/Microsoft.Maui.Controls/ResourceDictionary.xml" path="//Member[@MemberName='ContainsKey']/Docs/*" />
 		public bool ContainsKey(string key)
 		{
-			return _innerDictionary.ContainsKey(key);
+			return _innerDictionary.ContainsKey(key) || (_mergedInstance?.ContainsKey(key) ?? false) || (_mergedDictionaries != null && MergedDictionaryContainsKey(key));
+		}
+
+		bool MergedDictionaryContainsKey(string key)
+		{
+			foreach (var dictionary in MergedDictionaries.Reverse())
+				if (dictionary.ContainsKey(key))
+					return true;
+
+			return false;
 		}
 
 		[IndexerName("Item")]

--- a/src/Controls/src/Core/ResourceDictionary.cs
+++ b/src/Controls/src/Core/ResourceDictionary.cs
@@ -170,7 +170,7 @@ namespace Microsoft.Maui.Controls
 		/// <include file="../../docs/Microsoft.Maui.Controls/ResourceDictionary.xml" path="//Member[@MemberName='Add'][4]/Docs/*" />
 		public void Add(string key, object value)
 		{
-			if (ContainsKey(key))
+			if (_innerDictionary.ContainsKey(key))
 				throw new ArgumentException($"A resource with the key '{key}' is already present in the ResourceDictionary.");
 			_innerDictionary.Add(key, value);
 			OnValueChanged(key, value);

--- a/src/Controls/tests/Core.UnitTests/ResourceDictionaryTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ResourceDictionaryTests.cs
@@ -470,7 +470,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			};
 			rd.MergedDictionaries.Add(
 				new ResourceDictionary() {
-					{ "foo", "bar" },
+					{ "foo", "Foo" },
 					{ "qux", "Qux" }
 				}
 			);

--- a/src/Controls/tests/Core.UnitTests/ResourceDictionaryTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ResourceDictionaryTests.cs
@@ -460,5 +460,25 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			rd0.Add("foo", "Foo");
 			Assert.Equal("Foo", label.Text);
 		}
+
+		[Fact]
+		public void ContainsKeySearchesForKeyInMergedRD()
+		{
+			var rd = new ResourceDictionary {
+				{"baz", "Baz"},
+				{"foo", "bar"},
+			};
+			rd.MergedDictionaries.Add(
+				new ResourceDictionary() { 
+					{ "foo", "bar" },
+					{ "qux", "Qux" }
+				}
+			);
+
+			Assert.True(rd.ContainsKey("foo"));
+			Assert.True(rd.ContainsKey("baz"));
+			Assert.True(rd.ContainsKey("qux"));
+			Assert.False(rd.ContainsKey("bar"));
+		}
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/ResourceDictionaryTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ResourceDictionaryTests.cs
@@ -469,7 +469,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 				{"foo", "bar"},
 			};
 			rd.MergedDictionaries.Add(
-				new ResourceDictionary() { 
+				new ResourceDictionary() {
 					{ "foo", "bar" },
 					{ "qux", "Qux" }
 				}


### PR DESCRIPTION
### Description of Change

<!-- Enter description of the fix in this section -->
This change fixes the resource dictionary `ContainsKey` method so that it also searches for key in merged dictionaries. Currently the `ContainsKey` method only looks at the inner dictionary of the primary resource dictionary and disregards merged dictionaries.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #13268

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
