### PR TITLE
Change Windows WebView Cookies to CoreWebView2

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Controls/WebViewPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/WebViewPage.xaml
@@ -57,8 +57,7 @@
                         </HtmlWebViewSource>
                     </WebView.Source>
                 </WebView>
-                <StackLayout
-                    Orientation="Horizontal">
+                <HorizontalStackLayout>
                     <Entry 
                         x:Name="input"
                         WidthRequest="150" 
@@ -70,9 +69,8 @@
                         Clicked="OnLoadHtmlFileClicked" 
                         HeightRequest="48" 
                         WidthRequest="150" />
-                </StackLayout>
-                <StackLayout
-                    Orientation="Horizontal">
+                </HorizontalStackLayout>
+                <HorizontalStackLayout>
                     <Entry 
                         x:Name="userAgent"
                         Text="{Binding UserAgent, Source={x:Reference FileWebView}}"
@@ -84,7 +82,7 @@
                         Clicked="OnSetUserAgentClicked"
                         HeightRequest="48" 
                         WidthRequest="150" />
-                </StackLayout>
+                </HorizontalStackLayout>
                 <Label
                     Text="UrlWebViewSource"
                     Style="{StaticResource Headline}"/>
@@ -127,10 +125,19 @@
 					x:Name="EvalResultLabel"
                     Text="..."
                     Style="{StaticResource Headline}"/>
+                <Label
+                    Text="HTML5 Video"
+                    Style="{StaticResource Headline}"/>
                 <Button
                     Text="Load HTML5 Video"
                     Clicked="OnLoadHtml5VideoClicked" />
-                <StackLayout
+                <Label
+                    Text="Cookies"
+                    Style="{StaticResource Headline}"/>
+                <Button
+                    Text="Load httpbin.org with Cookies"
+                    Clicked="OnLoadHttpBinClicked" />
+                <VerticalStackLayout
                     IsVisible="{OnPlatform Android=True, Default=False}">
                     <Label
                         Text="Platform Specifics"
@@ -141,7 +148,7 @@
                     <Button
                         Text="Enable Zoom Controls"
                         Clicked="OnEnableZoomControlsClicked"/>
-                </StackLayout>
+                </VerticalStackLayout>
             </VerticalStackLayout>
         </ScrollView>
     </views:BasePage.Content>

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/WebViewPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/WebViewPage.xaml.cs
@@ -126,7 +126,7 @@ namespace Maui.Controls.Sample.Pages
 			// on httpbin.org find the section where you can load the cookies for the website.
 			// The cookie that is set below should show up for this to succeed.
 			MauiWebView.Cookies = new System.Net.CookieContainer();
-			MauiWebView.Cookies.Add(new System.Net.Cookie("MauiCookie", "Hmmm Cookies! If you see this cookie in the http bin output, test passed!", "/", "httpbin.org"));
+			MauiWebView.Cookies.Add(new System.Net.Cookie("MauiCookie", "Hmmm Cookies!", "/", "httpbin.org"));
 
 			MauiWebView.Source = new UrlWebViewSource { Url = "https://httpbin.org/#/Cookies/get_cookies" };
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/WebViewPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/WebViewPage.xaml.cs
@@ -120,5 +120,15 @@ namespace Maui.Controls.Sample.Pages
 		{
 			MauiWebView.Source = new UrlWebViewSource { Url = "video.html" };
 		}
+
+		void OnLoadHttpBinClicked(object sender, EventArgs e)
+		{
+			// on httpbin.org find the section where you can load the cookies for the website.
+			// The cookie that is set below should show up for this to succeed.
+			MauiWebView.Cookies = new System.Net.CookieContainer();
+			MauiWebView.Cookies.Add(new System.Net.Cookie("MauiCookie", "Hmmm Cookies! If you see this cookie in the http bin output, test passed!", "/", "httpbin.org"));
+
+			MauiWebView.Source = new UrlWebViewSource { Url = "https://httpbin.org/#/Cookies/get_cookies" };
+		}
 	}
 }

--- a/src/Core/src/Handlers/WebView/WebViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/WebView/WebViewHandler.Windows.cs
@@ -295,7 +295,7 @@ namespace Microsoft.Maui.Handlers
 
 		Task<IReadOnlyList<CoreWebView2Cookie>> GetCookiesFromPlatformStore(string url)
 		{
-			return PlatformView.CoreWebView2.CookieManager.GetCookiesAsync(url);
+			return PlatformView.CoreWebView2.CookieManager.GetCookiesAsync(url).AsTask();
 		}
 
 		Uri? CreateUriForCookies(string url)

--- a/src/Core/src/Handlers/WebView/WebViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/WebView/WebViewHandler.Windows.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Maui.Handlers
 		readonly HashSet<string> _loadedCookies = new();
 		Window? _window;
 
-		protected override WebView2 CreatePlatformView() => new MauiWebView();
+		protected override WebView2 CreatePlatformView() => new MauiWebView(this);
 
 		internal WebNavigationEvent CurrentNavigationEvent
 		{
@@ -99,7 +99,7 @@ namespace Microsoft.Maui.Handlers
 				NavigationFailed(sender, args);
 		}
 
-		async void OnNavigationStarting(CoreWebView2 sender, CoreWebView2NavigationStartingEventArgs args)
+		void OnNavigationStarting(CoreWebView2 sender, CoreWebView2NavigationStartingEventArgs args)
 		{
 			if (Uri.TryCreate(args.Uri, UriKind.Absolute, out Uri? uri) && uri is not null)
 			{
@@ -110,8 +110,6 @@ namespace Microsoft.Maui.Handlers
 				// Reset in this case because this is the last event we will get
 				if (cancel)
 					_eventState = WebNavigationEvent.NewPage;
-				else
-					await SyncPlatformCookies(uri.AbsoluteUri);
 			}
 		}
 
@@ -224,7 +222,7 @@ namespace Microsoft.Maui.Handlers
 			await SyncPlatformCookies(url);
 		}
 
-		async Task SyncPlatformCookies(string url)
+		internal async Task SyncPlatformCookies(string url)
 		{
 			var uri = CreateUriForCookies(url);
 

--- a/src/Core/src/Handlers/WebView/WebViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/WebView/WebViewHandler.Windows.cs
@@ -280,7 +280,7 @@ namespace Microsoft.Maui.Handlers
 
 				foreach (CoreWebView2Cookie cookie in existingCookies)
 				{
-					// TODO Ideally we use cookie.ToSystemNetCookie() here, but it's not available for some reason check bac later
+					// TODO Ideally we use cookie.ToSystemNetCookie() here, but it's not available for some reason check back later
 					if (cookies[cookie.Name] is null)
 						myCookieJar.SetCookies(uri,
 							new Cookie(cookie.Name, cookie.Value, cookie.Path, cookie.Domain)
@@ -293,11 +293,9 @@ namespace Microsoft.Maui.Handlers
 			}
 		}
 
-		async Task<IReadOnlyList<CoreWebView2Cookie>> GetCookiesFromPlatformStore(string url)
+		Task<IReadOnlyList<CoreWebView2Cookie>> GetCookiesFromPlatformStore(string url)
 		{
-			var platformCookies = await PlatformView.CoreWebView2.CookieManager.GetCookiesAsync(url);
-
-			return platformCookies;
+			return PlatformView.CoreWebView2.CookieManager.GetCookiesAsync(url);
 		}
 
 		Uri? CreateUriForCookies(string url)

--- a/src/Core/src/Handlers/WebView/WebViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/WebView/WebViewHandler.Windows.cs
@@ -280,9 +280,15 @@ namespace Microsoft.Maui.Handlers
 
 				foreach (CoreWebView2Cookie cookie in existingCookies)
 				{
+					// TODO Ideally we use cookie.ToSystemNetCookie() here, but it's not available for some reason check bac later
 					if (cookies[cookie.Name] is null)
 						myCookieJar.SetCookies(uri,
-							$"{cookie.Name}={cookie.Value}; domain={cookie.Domain}; path={cookie.Path}");
+							new Cookie(cookie.Name, cookie.Value, cookie.Path, cookie.Domain)
+							{
+								Expires = DateTimeOffset.FromUnixTimeMilliseconds((long)cookie.Expires).DateTime,
+								HttpOnly = cookie.IsHttpOnly,
+								Secure = cookie.IsSecure,
+							}.ToString());
 				}
 			}
 		}

--- a/src/Core/src/Platform/Windows/MauiWebView.cs
+++ b/src/Core/src/Platform/Windows/MauiWebView.cs
@@ -9,8 +9,13 @@ namespace Microsoft.Maui.Platform
 {
 	public class MauiWebView : WebView2, IWebViewDelegate
 	{
-		public MauiWebView()
+		readonly WeakReference<WebViewHandler> _handler;
+
+		public MauiWebView(WebViewHandler handler)
 		{
+			ArgumentNullException.ThrowIfNull(handler, nameof(handler));
+			_handler = new WeakReference<WebViewHandler>(handler);
+
 			NavigationStarting += (sender, args) =>
 			{
 				// Auto map local virtual app dir host, e.g. if navigating back to local site from a link to an external site
@@ -127,7 +132,8 @@ namespace Microsoft.Maui.Platform
 				uri = new Uri(LocalScheme + url, UriKind.RelativeOrAbsolute);
 			}
 
-			// TODO: Sync Cookies
+			if (_handler.TryGetTarget(out var handler))
+				await handler.SyncPlatformCookies(uri.AbsoluteUri);
 
 			try
 			{

--- a/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -1,6 +1,7 @@
 #nullable enable
 Microsoft.Maui.Hosting.MauiApp.DisposeAsync() -> System.Threading.Tasks.ValueTask
 Microsoft.Maui.Layouts.FlexBasis.Equals(Microsoft.Maui.Layouts.FlexBasis other) -> bool
+Microsoft.Maui.Platform.MauiWebView.MauiWebView(Microsoft.Maui.Handlers.WebViewHandler! handler) -> void
 Microsoft.Maui.SizeRequest.Equals(Microsoft.Maui.SizeRequest other) -> bool
 override Microsoft.Maui.Layouts.FlexBasis.Equals(object? obj) -> bool
 override Microsoft.Maui.Layouts.FlexBasis.GetHashCode() -> int
@@ -19,3 +20,4 @@ static Microsoft.Maui.Platform.WebViewExtensions.UpdateUserAgent(this Microsoft.
 Microsoft.Maui.WeakEventManager.HandleEvent(object? sender, object? args, string! eventName) -> void
 static Microsoft.Maui.SizeRequest.operator !=(Microsoft.Maui.SizeRequest left, Microsoft.Maui.SizeRequest right) -> bool
 static Microsoft.Maui.SizeRequest.operator ==(Microsoft.Maui.SizeRequest left, Microsoft.Maui.SizeRequest right) -> bool
+*REMOVED*Microsoft.Maui.Platform.MauiWebView.MauiWebView() -> void


### PR DESCRIPTION
### Description of Change

The Windows implementation of how we handled cookies in `WebView` was outdated. Updated it to use the more modern API and make it work again.

I've added a button to the sample app which sets a cookie for httpbin.org, a site that allows you to read the cookies that are set back to you. Go to Controls > WebView and scroll down to the Load httpbin.org with Cookies button.

Click that and in the loaded website go to Cookies > Get /Cookies > Try it out > Execute and make sure the cookie that was set in code is shown.

![image](https://user-images.githubusercontent.com/939291/223126594-3196daaf-21be-44fe-abe2-9d8321cc2f7e.png)

### Issues Fixed

Fixes #3901