### PR TITLE
Add Shell.Title to default template

### DIFF
--- a/src/Templates/README.md
+++ b/src/Templates/README.md
@@ -15,5 +15,5 @@ dotnet new -i artifacts\Microsoft.Maui.Templates.*.nupkg
 # then just in the maui folder, so you get a NuGet.config
 mkdir foo
 cd foo
-dotnet new maui-mobile
+dotnet new maui
 ```

--- a/src/Templates/src/templates/maui-mobile/AppShell.xaml
+++ b/src/Templates/src/templates/maui-mobile/AppShell.xaml
@@ -4,7 +4,8 @@
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:local="clr-namespace:MauiApp._1"
-    Shell.FlyoutBehavior="Disabled">
+    Shell.FlyoutBehavior="Disabled"
+    Title="MauiApp._1">
 
     <ShellContent
         Title="Home"


### PR DESCRIPTION
### Description of Change

Adds a `Title` to the default `AppShell.xaml` file so that the template is more accessibility proof out of the box!

The title is the name of the project as specified in Visual Studio or the CLI, same as the one used in the namespaces and other metadata.

### Issues Fixed

Fixes #12973
