### PR TITLE
[windows] fix memory leak when `CollectionView.ItemsSource` changes

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/ItemsViewHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Items/ItemsViewHandler.Windows.cs
@@ -123,6 +123,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				CollectionViewSource.Source = null;
 				CollectionViewSource = null;
 			}
+			VirtualView?.ClearLogicalChildren();
 
 			if (VirtualView?.ItemsSource == null)
 			{

--- a/src/Controls/src/Core/Items/ItemsView.cs
+++ b/src/Controls/src/Core/Items/ItemsView.cs
@@ -142,6 +142,15 @@ namespace Microsoft.Maui.Controls
 			VisualDiagnostics.OnChildRemoved(this, element, oldLogicalIndex);
 		}
 
+		internal void ClearLogicalChildren()
+		{
+			// Reverse for-loop, so children can be removed while iterating
+			for (int i = _logicalChildren.Count - 1; i >= 0; i--)
+			{
+				RemoveLogicalChild(_logicalChildren[i]);
+			}
+		}
+
 		internal override IReadOnlyList<Element> LogicalChildrenInternal => _logicalChildren.AsReadOnly();
 
 		internal static readonly BindableProperty InternalItemsLayoutProperty =

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.NotNull(weakReference);
 			Assert.False(weakReference.IsAlive, "ObservableCollection should not be alive!");
 			Assert.NotNull(logicalChildren);
-			Assert.Equal(3, logicalChildren.Count);
+			Assert.True (logicalChildren.Count <= 3, "_logicalChildren should not grow in size!");
 		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.NotNull(weakReference);
 			Assert.False(weakReference.IsAlive, "ObservableCollection should not be alive!");
 			Assert.NotNull(logicalChildren);
-			Assert.True (logicalChildren.Count <= 3, "_logicalChildren should not grow in size!");
+			Assert.True(logicalChildren.Count <= 3, "_logicalChildren should not grow in size!");
 		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.cs
@@ -1,4 +1,9 @@
-﻿using Microsoft.Maui.Controls;
+﻿using System;
+using System.Collections;
+using System.Collections.ObjectModel;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Handlers.Items;
 using Microsoft.Maui.DeviceTests.Stubs;
 using Microsoft.Maui.Handlers;
@@ -27,6 +32,50 @@ namespace Microsoft.Maui.DeviceTests
 					handlers.AddHandler<Label, LabelHandler>();
 				});
 			});
+		}
+
+		[Fact]
+		public async Task ItemsSourceDoesNotLeak()
+		{
+			SetupBuilder();
+
+			IList logicalChildren = null;
+			WeakReference weakReference = null;
+			var collectionView = new CollectionView
+			{
+				ItemTemplate = new DataTemplate(() => new Label())
+			};
+
+			await CreateHandlerAndAddToWindow<CollectionViewHandler>(collectionView, async handler =>
+			{
+				var data = new ObservableCollection<string>()
+				{
+					"Item 1",
+					"Item 2",
+					"Item 3"
+				};
+				weakReference = new WeakReference(data);
+				collectionView.ItemsSource = data;
+				await Task.Delay(100);
+
+				// Get ItemsView._logicalChildren
+				var flags = BindingFlags.NonPublic | BindingFlags.Instance;
+				logicalChildren = typeof(ItemsView).GetField("_logicalChildren", flags).GetValue(collectionView) as IList;
+				Assert.NotNull(logicalChildren);
+
+				// Replace with cloned collection
+				collectionView.ItemsSource = new ObservableCollection<string>(data);
+				await Task.Delay(100);
+			});
+
+			await Task.Yield();
+			GC.Collect();
+			GC.WaitForPendingFinalizers();
+
+			Assert.NotNull(weakReference);
+			Assert.False(weakReference.IsAlive, "ObservableCollection should not be alive!");
+			Assert.NotNull(logicalChildren);
+			Assert.Equal(3, logicalChildren.Count);
 		}
 	}
 }


### PR DESCRIPTION
Fixes #13393
Context: https://github.com/ivan-todorov-progress/maui-collection-view-memory-leak-bug

Debugging the above sample, I found that `ItemsView._logicalChildren` grew indefinitely in size if you replace a  `CollectionView`'s `ItemsSource` over and over.

I could fix this by creating a new `internal` `ItemsView.ClearLogicalChildren()` method and call it from the Windows `ItemsViewHandler`.

I could reproduce this issue in a Device Test running on Windows.

It appears the problem does not occur on Android or iOS due to the recycling behavior of the underlying platforms.

For example, Android calls `OnViewRecycled()` which calls `RemoveLogicalChild(view)`:

https://github.com/dotnet/maui/blob/53f6e393750a3df05b12fcde442daf3616c216f8/src/Controls/src/Core/Handlers/Items/Android/Adapters/ItemsViewAdapter.cs#L52-L57
https://github.com/dotnet/maui/blob/53f6e393750a3df05b12fcde442daf3616c216f8/src/Controls/src/Core/Handlers/Items/Android/TemplatedItemViewHolder.cs#L37-L45

On Windows, we merely have a `ItemContentControl` and there is no callback for when things are recycled. We *do* get a callback for when the `FormsDataContext` value changes, so an option is to clear the list in this case.

After this change, my test passes -- but it was already passing on iOS and Android.