### PR TITLE
Handled x:ClassModifier attribute to set the visibility of rootType

### DIFF
--- a/src/Controls/src/SourceGen/CodeBehindGenerator.cs
+++ b/src/Controls/src/SourceGen/CodeBehindGenerator.cs
@@ -123,7 +123,7 @@ namespace Microsoft.Maui.Controls.SourceGen
 				return;
 			var uid = Crc64.ComputeHashString($"{compilation.AssemblyName}.{itemName}");
 
-			if (!TryParseXaml(text, uid, compilation, xmlnsDefinitionCache, context.CancellationToken, out var rootType, out var rootClrNamespace, out var generateDefaultCtor, out var addXamlCompilationAttribute, out var hideFromIntellisense, out var XamlResourceIdOnly, out var baseType, out var namedFields, out var parseException))
+			if (!TryParseXaml(text, uid, compilation, xmlnsDefinitionCache, context.CancellationToken, out var accessModifier, out var rootType, out var rootClrNamespace, out var generateDefaultCtor, out var addXamlCompilationAttribute, out var hideFromIntellisense, out var XamlResourceIdOnly, out var baseType, out var namedFields, out var parseException))
 			{
 				if (parseException != null)
 					context.ReportDiagnostic(Diagnostic.Create(Descriptors.XamlParserError, null, parseException.Message));
@@ -154,7 +154,7 @@ namespace Microsoft.Maui.Controls.SourceGen
 			if (hideFromIntellisense)
 				sb.AppendLine($"\t[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]");
 
-			sb.AppendLine($"\tpublic partial class {rootType} : {baseType}");
+			sb.AppendLine($"\t{accessModifier} partial class {rootType} : {baseType}");
 			sb.AppendLine("\t{");
 
 			//optional default ctor
@@ -208,10 +208,11 @@ namespace Microsoft.Maui.Controls.SourceGen
 			context.AddSource(hintName, SourceText.From(sb.ToString(), Encoding.UTF8));
 		}
 
-		static bool TryParseXaml(SourceText text, string uid, Compilation compilation, IList<XmlnsDefinitionAttribute> xmlnsDefinitionCache, CancellationToken cancellationToken, out string? rootType, out string? rootClrNamespace, out bool generateDefaultCtor, out bool addXamlCompilationAttribute, out bool hideFromIntellisense, out bool xamlResourceIdOnly, out string? baseType, out IEnumerable<(string, string, string)>? namedFields, out Exception? exception)
+		static bool TryParseXaml(SourceText text, string uid, Compilation compilation, IList<XmlnsDefinitionAttribute> xmlnsDefinitionCache, CancellationToken cancellationToken, out string? accessModifier, out string? rootType, out string? rootClrNamespace, out bool generateDefaultCtor, out bool addXamlCompilationAttribute, out bool hideFromIntellisense, out bool xamlResourceIdOnly, out string? baseType, out IEnumerable<(string, string, string)>? namedFields, out Exception? exception)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
 
+			accessModifier = null;
 			rootType = null;
 			rootClrNamespace = null;
 			generateDefaultCtor = false;
@@ -282,6 +283,10 @@ namespace Microsoft.Maui.Controls.SourceGen
 			namedFields = GetNamedFields(root, nsmgr, compilation, xmlnsDefinitionCache, cancellationToken);
 			var typeArguments = GetAttributeValue(root, "TypeArguments", XamlParser.X2006Uri, XamlParser.X2009Uri);
 			baseType = GetTypeName(new XmlType(root.NamespaceURI, root.LocalName, typeArguments != null ? TypeArgumentsParser.ParseExpression(typeArguments, nsmgr, null) : null), compilation, xmlnsDefinitionCache);
+
+			// x:ClassModifier attribute
+			var classModifier = GetAttributeValue(root, "ClassModifier", XamlParser.X2006Uri, XamlParser.X2009Uri);
+			accessModifier = classModifier?.ToLowerInvariant().Replace("notpublic", "internal") ?? "public"; // notpublic is WPF for internal
 
 			return true;
 		}


### PR DESCRIPTION
### Description of Change

<!-- Enter the description of the fix in this section -->
As of now, while creating a type in XAML, the visibility is always set to `public`. But at times, there's a need to make the type hidden so that it's not accessible to the consumers in the scenario of library development. `x:ClassModifier` is the attribute that controls this behavior in XAML. This is to be defined at the root node.

[Web Ref.](https://learn.microsoft.com/en-us/dotnet/desktop/xaml-services/xclassmodifier-directive)

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #12322

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
