### PR TITLE
Replace Shell sans-serif-medium magic string on Android

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellItemRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellItemRenderer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using Android.Content;
+using Android.Graphics;
 using Android.Graphics.Drawables;
 using Android.OS;
 using Android.Views;
@@ -244,9 +245,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 					using (var text = new TextView(Context))
 					{
-						text.Typeface = services.GetRequiredService<IFontManager>()
-							.GetTypeface(Font.OfSize("sans-serif-medium", 0.0));
-
+						text.SetTypeface(Typeface.SansSerif, TypefaceStyle.Normal);
 						text.SetTextColor(AColor.Black);
 						text.Text = shellContent.Title;
 						lp = new LinearLayout.LayoutParams(0, LP.WrapContent)

--- a/src/Controls/src/Core/Platform/Android/BottomNavigationViewUtils.cs
+++ b/src/Controls/src/Core/Platform/Android/BottomNavigationViewUtils.cs
@@ -215,7 +215,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 					using (var text = new TextView(context))
 					{
-						text.SetTypeface(Typeface.Create("sans-serif-medium", TypefaceStyle.Normal), TypefaceStyle.Normal);
+						text.SetTypeface(Typeface.SansSerif, TypefaceStyle.Normal);
 						text.SetTextColor(AColor.Black);
 						text.Text = shellContent.title;
 						lp = new LinearLayout.LayoutParams(0, LP.WrapContent)

--- a/src/Controls/src/Core/Shell/BaseShellItem.cs
+++ b/src/Controls/src/Core/Shell/BaseShellItem.cs
@@ -511,7 +511,6 @@ namespace Microsoft.Maui.Controls
 
 					defaultLabelClass.Setters.Add(new Setter { Property = Label.FontSizeProperty, Value = 14 });
 					defaultLabelClass.Setters.Add(new Setter { Property = Label.TextColorProperty, Value = textColor });
-					defaultLabelClass.Setters.Add(new Setter { Property = Label.FontFamilyProperty, Value = "sans-serif-medium" });
 					defaultLabelClass.Setters.Add(new Setter { Property = Label.MarginProperty, Value = new Thickness(20, 0, 0, 0) });
 				}
 				else if (DeviceInfo.Platform == DevicePlatform.iOS)


### PR DESCRIPTION
### Description of Change

In 3 places which had to do with Shell and/or TabbedPage we had a reference to `sans-serif-medium` as a string. This was causing exceptions, from what I can tell, on all Android devices and throwing underwater exceptions that the font could not be loaded.

I've changed these references to the `TypeFace.SansSerif` which is built-in and assume that it resolves to the same. From a visual test I don't see any differences. 

Thinking about it, there will probably be no differences, since the font couldn't be loaded earlier, it would not have shown as it was intended in the first place.

Unfortunately, I couldn't really find any definitive source on if this was removed on Android at some point or what the cause is that we are seeing this now.

Preferably I'd like @PureWeen to have a look being the one most likely to have implemented this

### Issues Fixed

Fixes #13239
