### PR TITLE
Ensure an exact measure for the nested horizontal scrollview

### DIFF
--- a/src/Core/src/Platform/Android/MauiScrollView.cs
+++ b/src/Core/src/Platform/Android/MauiScrollView.cs
@@ -310,6 +310,7 @@ namespace Microsoft.Maui.Platform
 		public MauiHorizontalScrollView(Context? context, MauiScrollView parentScrollView) : base(context)
 		{
 			_parentScrollView = parentScrollView;
+			Tag = "Microsoft.Maui.Android.HorizontalScrollView";
 		}
 
 		public MauiHorizontalScrollView(Context? context, IAttributeSet? attrs) : base(context, attrs)

--- a/src/Core/src/Platform/Android/MauiScrollView.cs
+++ b/src/Core/src/Platform/Android/MauiScrollView.cs
@@ -197,12 +197,12 @@ namespace Microsoft.Maui.Platform
 				//if we are scrolling both ways we need to lay out our MauiHorizontalScrollView with more than the available height
 				//so its parent the NestedScrollView can scroll vertically
 				hScrollViewHeight = _isBidirectional ? Math.Max(hScrollViewHeight, scrollViewContentHeight) : hScrollViewHeight;
-				
+
 				// Ensure that the horizontal scrollview has been measured at the actual target size
 				// so that it updates its internal bookkeeping to use the full size
-				_hScrollView.Measure(MeasureSpec.MakeMeasureSpec(right - left, MeasureSpecMode.Exactly), 
+				_hScrollView.Measure(MeasureSpec.MakeMeasureSpec(right - left, MeasureSpecMode.Exactly),
 					MeasureSpec.MakeMeasureSpec(hScrollViewHeight, MeasureSpecMode.Exactly));
-				
+
 				_hScrollView.Layout(0, 0, hScrollViewWidth, hScrollViewHeight);
 			}
 

--- a/src/Core/src/Platform/Android/MauiScrollView.cs
+++ b/src/Core/src/Platform/Android/MauiScrollView.cs
@@ -2,6 +2,7 @@
 using Android.Animation;
 using Android.Content;
 using Android.Graphics;
+using Android.Hardware.Lights;
 using Android.Runtime;
 using Android.Util;
 using Android.Views;
@@ -194,6 +195,7 @@ namespace Microsoft.Maui.Platform
 				//if we are scrolling both ways we need to lay out our MauiHorizontalScrollView with more than the available height
 				//so its parent the NestedScrollView can scroll vertically
 				var newBottom = _isBidirectional ? Math.Max(hScrollViewHeight, scrollViewContentHeight) : hScrollViewHeight;
+				_hScrollView.Measure(MeasureSpec.MakeMeasureSpec(right - left, MeasureSpecMode.Exactly), MeasureSpec.MakeMeasureSpec(newBottom, MeasureSpecMode.Exactly));
 				_hScrollView.Layout(0, 0, right - left, (int)newBottom);
 			}
 

--- a/src/Core/src/Platform/Android/MauiScrollView.cs
+++ b/src/Core/src/Platform/Android/MauiScrollView.cs
@@ -190,13 +190,20 @@ namespace Microsoft.Maui.Platform
 
 			if (_hScrollView?.Parent == this && _content is not null)
 			{
-				double scrollViewContentHeight = _content.Height;
+				var scrollViewContentHeight = (int)_content.Height;
 				var hScrollViewHeight = bottom - top;
+				var hScrollViewWidth = right - left;
+
 				//if we are scrolling both ways we need to lay out our MauiHorizontalScrollView with more than the available height
 				//so its parent the NestedScrollView can scroll vertically
-				var newBottom = _isBidirectional ? Math.Max(hScrollViewHeight, scrollViewContentHeight) : hScrollViewHeight;
-				_hScrollView.Measure(MeasureSpec.MakeMeasureSpec(right - left, MeasureSpecMode.Exactly), MeasureSpec.MakeMeasureSpec(newBottom, MeasureSpecMode.Exactly));
-				_hScrollView.Layout(0, 0, right - left, (int)newBottom);
+				hScrollViewHeight = _isBidirectional ? Math.Max(hScrollViewHeight, scrollViewContentHeight) : hScrollViewHeight;
+				
+				// Ensure that the horizontal scrollview has been measured at the actual target size
+				// so that it updates its internal bookkeeping to use the full size
+				_hScrollView.Measure(MeasureSpec.MakeMeasureSpec(right - left, MeasureSpecMode.Exactly), 
+					MeasureSpec.MakeMeasureSpec(hScrollViewHeight, MeasureSpecMode.Exactly));
+				
+				_hScrollView.Layout(0, 0, hScrollViewWidth, hScrollViewHeight);
 			}
 
 			if (CrossPlatformArrange == null)

--- a/src/Core/src/Platform/Android/MauiScrollView.cs
+++ b/src/Core/src/Platform/Android/MauiScrollView.cs
@@ -190,7 +190,7 @@ namespace Microsoft.Maui.Platform
 
 			if (_hScrollView?.Parent == this && _content is not null)
 			{
-				var scrollViewContentHeight = (int)_content.Height;
+				var scrollViewContentHeight = _content.Height;
 				var hScrollViewHeight = bottom - top;
 				var hScrollViewWidth = right - left;
 

--- a/src/Core/tests/DeviceTests/Handlers/ScrollView/ScrollViewHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/ScrollView/ScrollViewHandlerTests.Android.cs
@@ -1,12 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Android.Widget;
 using AndroidX.AppCompat.Widget;
 using AndroidX.Core.Widget;
 using Microsoft.Maui.DeviceTests.Stubs;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
 using Xunit;
+using static Android.Views.View;
 
 namespace Microsoft.Maui.DeviceTests
 {
@@ -98,6 +100,33 @@ namespace Microsoft.Maui.DeviceTests
 			});
 
 			Assert.Equal(expected, result);
+		}
+
+		[Fact]
+		public async Task MauiScrollViewGetsFullHeightInHorizontalOrientation()
+		{
+			await InvokeOnMainThreadAsync(() => {
+				var sv = new MauiScrollView(MauiContext.Context);
+				sv.SetOrientation(ScrollOrientation.Horizontal);
+				var content = new Button(MauiContext.Context);
+				sv.SetContent(content);
+
+				var hsv = sv.FindViewWithTag("Microsoft.Maui.Android.HorizontalScrollView") as MauiHorizontalScrollView;
+
+				Assert.NotNull(hsv);
+
+				sv.Measure(
+					MeasureSpec.MakeMeasureSpec(1000, Android.Views.MeasureSpecMode.Exactly),
+					MeasureSpec.MakeMeasureSpec(1000, Android.Views.MeasureSpecMode.Exactly));
+
+				sv.Layout(0, 0, 1000, 1000);
+
+				var measuredWidth = hsv.MeasuredWidth;
+				var measuredHeight = hsv.MeasuredHeight;
+
+				Assert.Equal(1000, measuredWidth);
+				Assert.Equal(1000, measuredHeight);
+			});
 		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/ScrollView/ScrollViewHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/ScrollView/ScrollViewHandlerTests.Android.cs
@@ -105,7 +105,8 @@ namespace Microsoft.Maui.DeviceTests
 		[Fact]
 		public async Task MauiScrollViewGetsFullHeightInHorizontalOrientation()
 		{
-			await InvokeOnMainThreadAsync(() => {
+			await InvokeOnMainThreadAsync(() =>
+			{
 				var sv = new MauiScrollView(MauiContext.Context);
 				sv.SetOrientation(ScrollOrientation.Horizontal);
 				var content = new Button(MauiContext.Context);


### PR DESCRIPTION
### Description of Change

The MauiScrollView knows what height the nested HorizontalScrollView _should_ be, but the default measurement system just sees it as vertical ScrollView content and measures it with MeasureSpecMode.Unspecified. Which means that it only gets a MeasuredHeight as tall as the content, despite the fact that it may be laid out at a greater height. 

We can fix this by adding a MeasureSpecMode.Exactly measure at the target height right before laying out the HorizontalScrollView. 

Marking this as a draft right now, it needs device tests. Plus, we could probably check the MeasuredHeight/Width of the HorizontalScrollView before doing the exact measure to determine if we really need the extra measure call (we don't need it unless the measured size is less than the target layout size).

### Issues Fixed

Fixes #13498
