### PR TITLE
Catch InvalidProtocolBufferException creating EncryptedSharedPreferences

### DIFF
--- a/src/Essentials/src/SecureStorage/SecureStorage.android.cs
+++ b/src/Essentials/src/SecureStorage/SecureStorage.android.cs
@@ -2,13 +2,14 @@ using System.Threading.Tasks;
 using Android.App;
 using Android.Content;
 using AndroidX.Security.Crypto;
-using Javax.Crypto;
+using Java.Security;
+using Xamarin.Google.Crypto.Tink.Shaded.Protobuf;
 
 namespace Microsoft.Maui.Storage
 {
 	partial class SecureStorageImplementation : ISecureStorage
 	{
-		readonly object locker = new object();
+		readonly object locker = new();
 
 		Task<string> PlatformGetAsync(string key)
 		{
@@ -18,22 +19,28 @@ namespace Microsoft.Maui.Storage
 				{
 					lock (locker)
 					{
-						return GetEncryptedSharedPreferences().GetString(key, null);
+						ISharedPreferences sharedPreferences = GetEncryptedSharedPreferences();
+						if (sharedPreferences != null)
+							return sharedPreferences.GetString(key, null);
+
+						System.Diagnostics.Debug.WriteLine(
+							$"Unable to decrypt key, {key}, which is likely due to key corruption. Removing old key and returning null.");
+						return null;
 					}
 				}
-				catch (AEADBadTagException)
+				catch (GeneralSecurityException)
 				{
 					// TODO: Use Logger here?
-					System.Diagnostics.Debug.WriteLine($"Unable to decrypt key, {key}, which is likely due to an app uninstall. Removing old key and returning null.");
-					Remove(key);
+					System.Diagnostics.Debug.WriteLine(
+						$"Unable to decrypt key, {key}, which is likely due to an app uninstall. Removing old key and returning null.");
 
 					return null;
 				}
 				catch (Java.Lang.SecurityException)
 				{
 					// TODO: Use Logger here?
-					System.Diagnostics.Debug.WriteLine($"Unable to decrypt key, {key}, which is likely due to key corruption. Removing old key and returning null.");
-					Remove(key);
+					System.Diagnostics.Debug.WriteLine(
+						$"Unable to decrypt key, {key}, which is likely due to an app uninstall. Removing old key and returning null.");
 
 					return null;
 				}
@@ -46,14 +53,13 @@ namespace Microsoft.Maui.Storage
 			{
 				lock (locker)
 				{
-					using var editor = GetEncryptedSharedPreferences().Edit();
-
+					using ISharedPreferencesEditor editor = GetEncryptedSharedPreferences()?.Edit();
 					if (data == null)
-						editor.Remove(key);
+						editor?.Remove(key);
 					else
-						editor.PutString(key, data);
+						editor?.PutString(key, data);
 
-					editor.Apply();
+					editor?.Apply();
 				}
 			});
 		}
@@ -62,10 +68,8 @@ namespace Microsoft.Maui.Storage
 		{
 			lock (locker)
 			{
-				using (var editor = GetEncryptedSharedPreferences().Edit())
-				{
-					editor.Remove(key).Apply();
-				}
+				using ISharedPreferencesEditor editor = GetEncryptedSharedPreferences()?.Edit();
+				editor?.Remove(key)?.Apply();
 			}
 
 			return true;
@@ -76,26 +80,37 @@ namespace Microsoft.Maui.Storage
 			lock (locker)
 			{
 				using var editor = PreferencesImplementation.GetSharedPreferences(Alias).Edit();
-				editor.Clear().Apply();
+				editor?.Clear()?.Apply();
 			}
 		}
 
 		static ISharedPreferences GetEncryptedSharedPreferences()
 		{
-			var context = Application.Context;
+			try
+			{
+				var context = Application.Context;
 
-			MasterKey prefsMainKey = new MasterKey.Builder(context, Alias)
-				.SetKeyScheme(MasterKey.KeyScheme.Aes256Gcm)
-				.Build();
+				MasterKey prefsMainKey = new MasterKey.Builder(context, Alias)
+					.SetKeyScheme(MasterKey.KeyScheme.Aes256Gcm)
+					.Build();
 
-			var sharedPreferences = EncryptedSharedPreferences.Create(
-				context,
-				Alias,
-				prefsMainKey,
-				EncryptedSharedPreferences.PrefKeyEncryptionScheme.Aes256Siv,
-				EncryptedSharedPreferences.PrefValueEncryptionScheme.Aes256Gcm);
+				var sharedPreferences = EncryptedSharedPreferences.Create(
+					context,
+					Alias,
+					prefsMainKey,
+					EncryptedSharedPreferences.PrefKeyEncryptionScheme.Aes256Siv,
+					EncryptedSharedPreferences.PrefValueEncryptionScheme.Aes256Gcm);
 
-			return sharedPreferences;
+				return sharedPreferences;
+			}
+			catch (InvalidProtocolBufferException)
+			{
+				// TODO: Use Logger here?
+				System.Diagnostics.Debug.WriteLine(
+					"Unable get encrypted shared preferences, which is likely due to an app uninstall. Returning null.");
+
+				return null;
+			}
 		}
 	}
 }

--- a/src/Essentials/src/SecureStorage/SecureStorage.android.cs
+++ b/src/Essentials/src/SecureStorage/SecureStorage.android.cs
@@ -23,8 +23,10 @@ namespace Microsoft.Maui.Storage
 						if (sharedPreferences != null)
 							return sharedPreferences.GetString(key, null);
 
+						// TODO: Use Logger here?
 						System.Diagnostics.Debug.WriteLine(
 							$"Unable to decrypt key, {key}, which is likely due to key corruption. Removing old key and returning null.");
+						PlatformRemove(key);
 						return null;
 					}
 				}
@@ -33,7 +35,7 @@ namespace Microsoft.Maui.Storage
 					// TODO: Use Logger here?
 					System.Diagnostics.Debug.WriteLine(
 						$"Unable to decrypt key, {key}, which is likely due to an app uninstall. Removing old key and returning null.");
-
+					PlatformRemove(key);
 					return null;
 				}
 				catch (Java.Lang.SecurityException)
@@ -41,7 +43,7 @@ namespace Microsoft.Maui.Storage
 					// TODO: Use Logger here?
 					System.Diagnostics.Debug.WriteLine(
 						$"Unable to decrypt key, {key}, which is likely due to an app uninstall. Removing old key and returning null.");
-
+					PlatformRemove(key);
 					return null;
 				}
 			});
@@ -107,8 +109,8 @@ namespace Microsoft.Maui.Storage
 			{
 				// TODO: Use Logger here?
 				System.Diagnostics.Debug.WriteLine(
-					"Unable get encrypted shared preferences, which is likely due to an app uninstall. Returning null.");
-
+					"Unable get encrypted shared preferences, which is likely due to an app uninstall. Removing all keys and returning null.");
+				PlatformRemoveAll();
 				return null;
 			}
 		}

--- a/src/Essentials/src/SecureStorage/SecureStorage.android.cs
+++ b/src/Essentials/src/SecureStorage/SecureStorage.android.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Maui.Storage
 			}
 		}
 
-		static ISharedPreferences GetEncryptedSharedPreferences()
+		ISharedPreferences GetEncryptedSharedPreferences()
 		{
 			try
 			{


### PR DESCRIPTION
### Description of Change

<!-- Enter description of the fix in this section -->

Creating EncryptedSharedPreferences on some devices throw InvalidProtocolBufferException.

This PR catches this exception instead of throwing it to the consumer.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #13597

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
