### PR TITLE
Set a GroupName when creating new WinUI RadioButtons

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/RadioButton/RadioButtonTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/RadioButton/RadioButtonTests.Windows.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.Maui.Handlers;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	public partial class RadioButtonTests
+	{
+		UI.Xaml.Controls.RadioButton GetNativeRadioButton(RadioButtonHandler radioButtonHandler) =>
+			radioButtonHandler.PlatformView;
+
+		bool GetNativeIsChecked(RadioButtonHandler radioButtonHandler) =>
+			GetNativeRadioButton(radioButtonHandler).IsChecked ?? false;
+	}
+}

--- a/src/Controls/tests/DeviceTests/Elements/RadioButton/RadioButtonTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/RadioButton/RadioButtonTests.cs
@@ -1,0 +1,44 @@
+﻿#if WINDOWS
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Handlers;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	[Category(TestCategory.RadioButton)]
+	public partial class RadioButtonTests : ControlsHandlerTestBase
+	{
+		[Theory(DisplayName = "IsChecked Initializes Correctly")]
+		[InlineData(false)]
+		[InlineData(true)]
+		public async Task IsCheckedInitializesCorrectly(bool isChecked)
+		{
+			bool xplatIsChecked = isChecked;
+			var radioButton = new RadioButton() { IsChecked = xplatIsChecked };
+			bool expectedValue = isChecked;
+			var layoutFirst = new VerticalStackLayout();
+			var rdFirst = new RadioButton { GroupName = "FirstGroup", IsChecked = xplatIsChecked };
+			layoutFirst.Add(rdFirst);
+			layoutFirst.Add(new RadioButton { GroupName = "FirstGroup" });
+			layoutFirst.Add(new RadioButton { GroupName = "FirstGroup" });
+			var layoutSecond = new VerticalStackLayout();
+			var rdSecond = new RadioButton { GroupName = "SecondGroup", IsChecked = xplatIsChecked };
+			layoutSecond.Add(rdSecond);
+			layoutSecond.Add(new RadioButton { GroupName = "SecondGroup" });
+			layoutSecond.Add(new RadioButton { GroupName = "SecondGroup" });
+			var layout = new VerticalStackLayout
+			{
+				layoutFirst,
+				layoutSecond
+			};
+			var valuesFirst = await GetValueAsync(rdFirst, (handler) => { return new { ViewValue = rdFirst.IsChecked, PlatformViewValue = GetNativeIsChecked(handler as RadioButtonHandler) }; });
+			var valuesSecond = await GetValueAsync(rdSecond, (handler) => { return new { ViewValue = rdSecond.IsChecked, PlatformViewValue = GetNativeIsChecked(handler as RadioButtonHandler) }; });
+			Assert.Equal(xplatIsChecked, valuesFirst.ViewValue);
+			Assert.Equal(expectedValue, valuesFirst.PlatformViewValue);
+			Assert.Equal(xplatIsChecked, valuesSecond.ViewValue);
+			Assert.Equal(expectedValue, valuesSecond.PlatformViewValue);
+		}
+	}
+}
+#endif

--- a/src/Controls/tests/DeviceTests/Elements/RadioButton/RadioButtonTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/RadioButton/RadioButtonTests.cs
@@ -23,9 +23,9 @@ namespace Microsoft.Maui.DeviceTests
 			layoutFirst.Add(new RadioButton { GroupName = "FirstGroup" });
 			layoutFirst.Add(new RadioButton { GroupName = "FirstGroup" });
 			var layoutSecond = new VerticalStackLayout();
+			layoutSecond.Add(new RadioButton { GroupName = "SecondGroup" });
 			var rdSecond = new RadioButton { GroupName = "SecondGroup", IsChecked = xplatIsChecked };
 			layoutSecond.Add(rdSecond);
-			layoutSecond.Add(new RadioButton { GroupName = "SecondGroup" });
 			layoutSecond.Add(new RadioButton { GroupName = "SecondGroup" });
 			var layout = new VerticalStackLayout
 			{

--- a/src/Controls/tests/DeviceTests/TestCategory.cs
+++ b/src/Controls/tests/DeviceTests/TestCategory.cs
@@ -30,6 +30,7 @@
 		public const string NavigationPage = "NavigationPage";
 		public const string Page = "Page";
 		public const string Picker = "Picker";
+		public const string RadioButton = "RadioButton";
 		public const string ScrollView = "ScrollView";
 		public const string SearchBar = "SearchBar";
 		public const string Shell = "Shell";

--- a/src/Core/src/Handlers/RadioButton/RadioButtonHandler.Windows.cs
+++ b/src/Core/src/Handlers/RadioButton/RadioButtonHandler.Windows.cs
@@ -1,11 +1,16 @@
-﻿using Microsoft.UI.Xaml;
+﻿using System;
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 
 namespace Microsoft.Maui.Handlers
 {
 	public partial class RadioButtonHandler : ViewHandler<IRadioButton, RadioButton>
 	{
-		protected override RadioButton CreatePlatformView() => new RadioButton();
+		protected override RadioButton CreatePlatformView()
+		{
+			// Note: We set a random GUID as the GroupName as part of the work-around in https://github.com/dotnet/maui/issues/11418
+			return new RadioButton() { GroupName = Guid.NewGuid().ToString() };
+		}
 
 		protected override void ConnectHandler(RadioButton platformView)
 		{


### PR DESCRIPTION
### Description of Change

This change sets a unique GroupName on every WinUI RadioButton created so that different groups of MAUI RadioButtons are not assumed by WinUI to share the same group and thus prevent IsChecked values from being set properly.

### Issues Fixed

Fixes #11418 
