### PR TITLE
Blank image when Source set to null or on image loading error

### DIFF
--- a/src/Core/src/Platform/Android/ImageSourcePartExtensions.cs
+++ b/src/Core/src/Platform/Android/ImageSourcePartExtensions.cs
@@ -70,6 +70,11 @@ namespace Microsoft.Maui.Platform
 			}
 			catch (Exception ex)
 			{
+				if (setImage is not null)
+				{
+					setImage(null);
+				}
+
 				events?.LoadingFailed(ex);
 			}
 			finally

--- a/src/Core/src/Platform/Android/ImageSourcePartExtensions.cs
+++ b/src/Core/src/Platform/Android/ImageSourcePartExtensions.cs
@@ -70,11 +70,7 @@ namespace Microsoft.Maui.Platform
 			}
 			catch (Exception ex)
 			{
-				if (setImage is not null)
-				{
-					setImage(null);
-				}
-
+				setImage?.Invoke(null);
 				events?.LoadingFailed(ex);
 			}
 			finally

--- a/src/Core/src/Platform/ImageSourcePartLoader.cs
+++ b/src/Core/src/Platform/ImageSourcePartLoader.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Maui.Platform
 				await Task.CompletedTask;
 #endif
 			}
-			else 
+			else
 			{
 				SetImage?.Invoke(null);
 			}

--- a/src/Core/src/Platform/ImageSourcePartLoader.cs
+++ b/src/Core/src/Platform/ImageSourcePartLoader.cs
@@ -42,6 +42,7 @@ namespace Microsoft.Maui.Platform
 		{
 			Handler = handler;
 			_imageSourcePart = imageSourcePart;
+
 			SetImage = setImage;
 		}
 
@@ -52,27 +53,28 @@ namespace Microsoft.Maui.Platform
 
 		public async Task UpdateImageSourceAsync()
 		{
-			if (PlatformView != null)
+			if (PlatformView is null)
 			{
-				var token = this.SourceManager.BeginLoad();
-				var imageSource = _imageSourcePart();
+				return;
+			}
 
-				if (imageSource != null)
-				{
+			var token = this.SourceManager.BeginLoad();
+			var imageSource = _imageSourcePart();
+
+			if (imageSource is not null && imageSource.Source is not null)
+			{
 #if __IOS__ || __ANDROID__ || WINDOWS || TIZEN
-					var result = await imageSource.UpdateSourceAsync(PlatformView, ImageSourceServiceProvider, SetImage!, token)
-						.ConfigureAwait(false);
+				var result = await imageSource.UpdateSourceAsync(PlatformView, ImageSourceServiceProvider, SetImage!, token)
+					.ConfigureAwait(false);
 
-					SourceManager.CompleteLoad(result);
+				SourceManager.CompleteLoad(result);
 #else
-					await Task.CompletedTask;
+				await Task.CompletedTask;
 #endif
-				}
-				else
-				{
-					SetImage?.Invoke(null);
-					SourceManager.CompleteLoad(null);
-				}
+			}
+			else 
+			{
+				SetImage?.Invoke(null);
 			}
 		}
 	}

--- a/src/Core/src/Platform/ImageSourcePartLoader.cs
+++ b/src/Core/src/Platform/ImageSourcePartLoader.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Maui.Platform
 			var token = this.SourceManager.BeginLoad();
 			var imageSource = _imageSourcePart();
 
-			if (imageSource is not null && imageSource.Source is not null)
+			if (imageSource?.Source is not null)
 			{
 #if __IOS__ || __ANDROID__ || WINDOWS || TIZEN
 				var result = await imageSource.UpdateSourceAsync(PlatformView, ImageSourceServiceProvider, SetImage!, token)

--- a/src/Core/src/Platform/Windows/ImageSourcePartExtensions.cs
+++ b/src/Core/src/Platform/Windows/ImageSourcePartExtensions.cs
@@ -56,6 +56,11 @@ namespace Microsoft.Maui.Platform
 			}
 			catch (Exception ex)
 			{
+				if (setImage is not null)
+				{
+					setImage(null);
+				}
+
 				events?.LoadingFailed(ex);
 			}
 			finally

--- a/src/Core/src/Platform/Windows/ImageSourcePartExtensions.cs
+++ b/src/Core/src/Platform/Windows/ImageSourcePartExtensions.cs
@@ -56,11 +56,7 @@ namespace Microsoft.Maui.Platform
 			}
 			catch (Exception ex)
 			{
-				if (setImage is not null)
-				{
-					setImage(null);
-				}
-
+				setImage?.Invoke(null);
 				events?.LoadingFailed(ex);
 			}
 			finally

--- a/src/Core/src/Platform/iOS/ImageSourcePartExtensions.cs
+++ b/src/Core/src/Platform/iOS/ImageSourcePartExtensions.cs
@@ -54,11 +54,7 @@ namespace Microsoft.Maui.Platform
 			}
 			catch (Exception ex)
 			{
-				if (setImage is not null)
-				{
-					setImage(null);
-				}
-
+				setImage?.Invoke(null);
 				events?.LoadingFailed(ex);
 			}
 			finally

--- a/src/Core/src/Platform/iOS/ImageSourcePartExtensions.cs
+++ b/src/Core/src/Platform/iOS/ImageSourcePartExtensions.cs
@@ -54,6 +54,11 @@ namespace Microsoft.Maui.Platform
 			}
 			catch (Exception ex)
 			{
+				if (setImage is not null)
+				{
+					setImage(null);
+				}
+
 				events?.LoadingFailed(ex);
 			}
 			finally

--- a/src/Core/tests/DeviceTests/Handlers/Image/ImageHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Image/ImageHandlerTests.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui.DeviceTests.Stubs;
 using Xunit;
+using System.ComponentModel;
 
 #if ANDROID
 using Android.Graphics.Drawables;
@@ -333,7 +334,10 @@ namespace Microsoft.Maui.DeviceTests
 
 				await image.Wait();
 
-				Assert.Empty(handler.ImageEvents);
+				// We expect that if the Image is created with no Source set, the platform image view
+				// will get a `null` image set
+				Assert.NotEmpty(handler.ImageEvents);
+				Assert.Null(handler.ImageEvents[0].Value);
 
 				await handler.PlatformView.AssertContainsColor(expectedColor);
 			});

--- a/src/TestUtils/src/DeviceTests/AssertionExtensions.Android.cs
+++ b/src/TestUtils/src/DeviceTests/AssertionExtensions.Android.cs
@@ -11,6 +11,7 @@ using Android.Widget;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Platform;
 using Xunit;
+using Xunit.Sdk;
 using AColor = Android.Graphics.Color;
 using AView = Android.Views.View;
 
@@ -324,6 +325,9 @@ namespace Microsoft.Maui.DeviceTests
 		public static Task<Bitmap> AssertContainsColor(this Bitmap bitmap, Graphics.Color expectedColor, Func<Maui.Graphics.RectF, Maui.Graphics.RectF>? withinRectModifier = null)
 			=> Task.FromResult(bitmap.AssertContainsColor(expectedColor.ToPlatform()));
 
+		public static Task<Bitmap> AssertDoesNotContainColor(this Bitmap bitmap, Graphics.Color unexpectedColor, Func<Maui.Graphics.RectF, Maui.Graphics.RectF>? withinRectModifier = null)
+			=> Task.FromResult(bitmap.AssertDoesNotContainColor(unexpectedColor.ToPlatform()));
+
 		public static Bitmap AssertContainsColor(this Bitmap bitmap, AColor expectedColor, Func<Maui.Graphics.RectF, Maui.Graphics.RectF>? withinRectModifier = null)
 		{
 			var imageRect = new Graphics.RectF(0, 0, bitmap.Width, bitmap.Height);
@@ -342,17 +346,46 @@ namespace Microsoft.Maui.DeviceTests
 				}
 			}
 
-			Assert.True(false, CreateColorError(bitmap, $"Color {expectedColor} not found."));
+			throw new XunitException($"Color {expectedColor} not found.");
+		}
+
+		public static Bitmap AssertDoesNotContainColor(this Bitmap bitmap, AColor unexpectedColor, Func<Maui.Graphics.RectF, Maui.Graphics.RectF>? withinRectModifier = null)
+		{
+			var imageRect = new Graphics.RectF(0, 0, bitmap.Width, bitmap.Height);
+
+			if (withinRectModifier is not null)
+				imageRect = withinRectModifier.Invoke(imageRect);
+
+			for (int x = (int)imageRect.X; x < (int)imageRect.Width; x++)
+			{
+				for (int y = (int)imageRect.Y; y < (int)imageRect.Height; y++)
+				{
+					if (bitmap.ColorAtPoint(x, y, true).IsEquivalent(unexpectedColor))
+					{
+						throw new XunitException($"Color {unexpectedColor} was found at point {x}, {y}.");
+					}
+				}
+			}
+
 			return bitmap;
 		}
 
 		public static Task<Bitmap> AssertContainsColor(this AView view, Graphics.Color expectedColor) =>
 			AssertContainsColor(view, expectedColor.ToPlatform());
 
+		public static Task<Bitmap> AssertDoesNotContainColor(this AView view, Graphics.Color unexpectedColor) =>
+			AssertDoesNotContainColor(view, unexpectedColor.ToPlatform());
+
 		public static async Task<Bitmap> AssertContainsColor(this AView view, AColor expectedColor)
 		{
 			var bitmap = await view.ToBitmap();
 			return AssertContainsColor(bitmap, expectedColor);
+		}
+
+		public static async Task<Bitmap> AssertDoesNotContainColor(this AView view, AColor unexpectedColor)
+		{
+			var bitmap = await view.ToBitmap();
+			return AssertDoesNotContainColor(bitmap, unexpectedColor);
 		}
 
 		public static async Task<Bitmap> AssertColorAtPointAsync(this AView view, AColor expectedColor, int x, int y)

--- a/src/TestUtils/src/DeviceTests/AssertionExtensions.iOS.cs
+++ b/src/TestUtils/src/DeviceTests/AssertionExtensions.iOS.cs
@@ -368,11 +368,11 @@ namespace Microsoft.Maui.DeviceTests
 				{
 					if (ColorComparison.ARGBEquivalent(bitmap.ColorAtPoint(x, y), unexpectedColor))
 					{
-						throw new XunitException($"Color {unexpectedColor} was found at point {x}, {y}.");						
+						throw new XunitException($"Color {unexpectedColor} was found at point {x}, {y}.");
 					}
 				}
 			}
-			
+
 			return bitmap;
 		}
 

--- a/src/TestUtils/src/DeviceTests/AssertionExtensions.iOS.cs
+++ b/src/TestUtils/src/DeviceTests/AssertionExtensions.iOS.cs
@@ -319,8 +319,17 @@ namespace Microsoft.Maui.DeviceTests
 			return bitmap.AssertContainsColor(expectedColor);
 		}
 
+		public static async Task<UIImage> AssertDoesNotContainColor(this UIView view, UIColor unexpectedColor)
+		{
+			var bitmap = await view.ToBitmap();
+			return bitmap.AssertDoesNotContainColor(unexpectedColor);
+		}
+
 		public static Task<UIImage> AssertContainsColor(this UIView view, Microsoft.Maui.Graphics.Color expectedColor) =>
 			AssertContainsColor(view, expectedColor.ToPlatform());
+
+		public static Task<UIImage> AssertDoesNotContainColor(this UIView view, Microsoft.Maui.Graphics.Color unexpectedColor) =>
+			AssertDoesNotContainColor(view, unexpectedColor.ToPlatform());
 
 		public static Task<UIImage> AssertContainsColor(this UIImage image, Graphics.Color expectedColor, Func<Graphics.RectF, Graphics.RectF>? withinRectModifier = null)
 			=> Task.FromResult(image.AssertContainsColor(expectedColor.ToPlatform(), withinRectModifier));
@@ -343,9 +352,30 @@ namespace Microsoft.Maui.DeviceTests
 				}
 			}
 
-			Assert.True(false, CreateColorError(bitmap, $"Color {expectedColor} not found."));
+			throw new XunitException($"Color {expectedColor} not found.");
+		}
+
+		public static UIImage AssertDoesNotContainColor(this UIImage bitmap, UIColor unexpectedColor, Func<Graphics.RectF, Graphics.RectF>? withinRectModifier = null)
+		{
+			var imageRect = new Graphics.RectF(0, 0, (float)bitmap.Size.Width.Value, (float)bitmap.Size.Height.Value);
+
+			if (withinRectModifier is not null)
+				imageRect = withinRectModifier.Invoke(imageRect);
+
+			for (int x = (int)imageRect.X; x < (int)imageRect.Width; x++)
+			{
+				for (int y = (int)imageRect.Y; y < (int)imageRect.Height; y++)
+				{
+					if (ColorComparison.ARGBEquivalent(bitmap.ColorAtPoint(x, y), unexpectedColor))
+					{
+						throw new XunitException($"Color {unexpectedColor} was found at point {x}, {y}.");						
+					}
+				}
+			}
+			
 			return bitmap;
 		}
+
 
 		public static Task AssertEqualAsync(this UIImage bitmap, UIImage other)
 		{


### PR DESCRIPTION
### Description of Change

Replace existing image with nothing when image source is set to `null`; replace existing image with nothing when new image results in a loading error.

### Issues Fixed

Fixes #8787