### PR TITLE
[tests] Window now throws if on DEBUG and creating window second time

### DIFF
--- a/src/Controls/tests/Core.UnitTests/ApplicationTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ApplicationTests.cs
@@ -176,9 +176,12 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.Equal(0, app.OnStartCount);
 			(window as IWindow).Created();
 			Assert.Equal(1, app.OnStartCount);
+#if DEBUG
+			Assert.Throws<InvalidOperationException>(() => (window as IWindow).Created());
+#else
 			(window as IWindow).Created();
 			Assert.Equal(1, app.OnStartCount);
-
+#endif
 		}
 
 		class StubApp : Application


### PR DESCRIPTION
### Description of Change

Last changes to Window broke a unit test we had but only on "Debug" 

Tests were green on the pr because on PR's we just run them on release
