### PR TITLE
[Android] Fix bidirectional scrolling on Android

### DIFF
--- a/src/Core/src/Platform/Android/MauiScrollView.cs
+++ b/src/Core/src/Platform/Android/MauiScrollView.cs
@@ -187,9 +187,14 @@ namespace Microsoft.Maui.Platform
 		{
 			base.OnLayout(changed, left, top, right, bottom);
 
-			if (_hScrollView != null && _hScrollView.Parent == this)
+			if (_hScrollView != null && _hScrollView.Parent == this && _content != null)
 			{
-				_hScrollView.Layout(0, 0, right - left, bottom - top);
+				double scrollViewContentHeight = _content.Height;
+				var hScrollViewHeight = bottom - top;
+				//if we are scrolling both ways we need to layout our MauiHorizontalScrollView with more than the available height
+				//so it's parent the NestedScrollView can scroll vertically
+				var newBottom = _isBidirectional ? Math.Max(hScrollViewHeight, scrollViewContentHeight) : hScrollViewHeight;
+				_hScrollView.Layout(0, 0, right - left, (int)newBottom);
 			}
 
 			if (CrossPlatformArrange == null)

--- a/src/Core/src/Platform/Android/MauiScrollView.cs
+++ b/src/Core/src/Platform/Android/MauiScrollView.cs
@@ -187,7 +187,7 @@ namespace Microsoft.Maui.Platform
 		{
 			base.OnLayout(changed, left, top, right, bottom);
 
-			if (_hScrollView != null && _hScrollView.Parent == this && _content != null)
+			if (_hScrollView?.Parent == this && _content is not null)
 			{
 				double scrollViewContentHeight = _content.Height;
 				var hScrollViewHeight = bottom - top;

--- a/src/Core/src/Platform/Android/MauiScrollView.cs
+++ b/src/Core/src/Platform/Android/MauiScrollView.cs
@@ -191,8 +191,8 @@ namespace Microsoft.Maui.Platform
 			{
 				double scrollViewContentHeight = _content.Height;
 				var hScrollViewHeight = bottom - top;
-				//if we are scrolling both ways we need to layout our MauiHorizontalScrollView with more than the available height
-				//so it's parent the NestedScrollView can scroll vertically
+				//if we are scrolling both ways we need to lay out our MauiHorizontalScrollView with more than the available height
+				//so its parent the NestedScrollView can scroll vertically
 				var newBottom = _isBidirectional ? Math.Max(hScrollViewHeight, scrollViewContentHeight) : hScrollViewHeight;
 				_hScrollView.Layout(0, 0, right - left, (int)newBottom);
 			}


### PR DESCRIPTION
### Description of Change

On android , we use 2 native scrollviews to handle bidirectional scrolling. The HorizontalScrollView was always laying on the available height, but we want the vertical scroll to work on it's parent we need to use the scrollview content height and not the default available height 

### Issues Fixed

Fixes #2768
Fixes #5759
Fixes #7811
Fixes #9000
Related to #7979 android part only
Related to #13187 android part only