### PR TITLE
Cleanup device tests

### DIFF
--- a/src/Controls/src/Core/HandlerImpl/Window/Window.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Window/Window.Impl.cs
@@ -468,10 +468,6 @@ namespace Microsoft.Maui.Controls
 
 		void IWindow.Created()
 		{
-#if DEBUG
-			if (IsCreated)
-				throw new InvalidOperationException("Window was already created");
-#endif
 			IsCreated = true;
 
 			Created?.Invoke(this, EventArgs.Empty);
@@ -502,10 +498,6 @@ namespace Microsoft.Maui.Controls
 
 		void IWindow.Destroying()
 		{
-#if DEBUG
-			if (IsDestroyed)
-				throw new InvalidOperationException("Window was already destroyed");
-#endif
 			IsDestroyed = true;
 			SendWindowDisppearing();
 			Destroying?.Invoke(this, EventArgs.Empty);

--- a/src/Controls/tests/DeviceTests/Stubs/WindowHandlerStub.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Stubs/WindowHandlerStub.iOS.cs
@@ -10,10 +10,11 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 {
 	public class WindowHandlerStub : ElementHandler<IWindow, UIWindow>, IWindowHandler
 	{
-		TaskCompletionSource<bool> _finishedDisconnecting = new TaskCompletionSource<bool>();
+		TaskCompletionSource _finishedDisconnecting = new TaskCompletionSource();
 		public Task FinishedDisconnecting => _finishedDisconnecting.Task;
 		IView _currentView;
-		bool disconnected;
+		public bool IsDisconnected { get; private set; }
+
 		public static IPropertyMapper<IWindow, WindowHandlerStub> WindowMapper = new PropertyMapper<IWindow, WindowHandlerStub>(WindowHandler.Mapper)
 		{
 			[nameof(IWindow.Content)] = MapContent
@@ -23,7 +24,7 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 		{
 			ReplaceCurrentView(_currentView, platformView, () =>
 			{
-				if (disconnected)
+				if (IsDisconnected)
 					return;
 
 				var virtualView = VirtualView;
@@ -156,9 +157,9 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 
 		protected override void DisconnectHandler(UIWindow platformView)
 		{
-			ReplaceCurrentView(VirtualView.Content, platformView, () => _finishedDisconnecting.SetResult(true), true);
+			ReplaceCurrentView(VirtualView.Content, platformView, () => _finishedDisconnecting.TrySetResult(), true);
 			base.DisconnectHandler(platformView);
-			disconnected = true;
+			IsDisconnected = true;
 		}
 
 		public WindowHandlerStub()


### PR DESCRIPTION
### Description of Change

Last changes to Window broke a unit test we had but only on "Debug" 

Tests were green on the pr because on PR's we just run them on release

This PR also fixes a few paths that were exposed [from](https://github.com/dotnet/maui/pull/13400). 