### PR TITLE
[templates] Add BorderWidth to button style

### DIFF
--- a/src/Templates/src/templates/maui-mobile/Resources/Styles/Styles.xaml
+++ b/src/Templates/src/templates/maui-mobile/Resources/Styles/Styles.xaml
@@ -28,6 +28,7 @@
         <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource White}}" />
         <Setter Property="FontFamily" Value="OpenSansRegular"/>
         <Setter Property="FontSize" Value="14"/>
+        <Setter Property="BorderWidth" Value="0"/>
         <Setter Property="CornerRadius" Value="8"/>
         <Setter Property="Padding" Value="14,10"/>
         <Setter Property="MinimumHeightRequest" Value="44"/>


### PR DESCRIPTION
Buttons that specified a border **color** but not a **width** would render the border in Windows but not in other platforms.

### Description of Change

As discussed with @PureWeen, the approach towards solving this issue was to set the `BorderWidth` of the button style equal to 0 in the project template. This ensures consistent behavior across platforms without modifying the native behavior in either. 

### Issues Fixed

Fixes #13612
