### PR TITLE
Reenable ViewTransform unit tests for iOS

### DIFF
--- a/src/Core/src/Platform/iOS/CoreAnimationExtensions.cs
+++ b/src/Core/src/Platform/iOS/CoreAnimationExtensions.cs
@@ -37,10 +37,6 @@ namespace Microsoft.Maui
 			if (layer == null)
 				return new Matrix4x4();
 
-			var superLayer = layer.SuperLayer;
-			if (layer.Transform.IsIdentity && superLayer == null)
-				return new Matrix4x4();
-
 			var superTransform = layer.SuperLayer?.GetChildTransform() ?? CATransform3D.Identity;
 
 			return layer.GetLocalTransform()

--- a/src/Core/tests/DeviceTests.Shared/HandlerTests/HandlerTestBaseOfT.Tests.cs
+++ b/src/Core/tests/DeviceTests.Shared/HandlerTests/HandlerTestBaseOfT.Tests.cs
@@ -314,11 +314,7 @@ namespace Microsoft.Maui.DeviceTests
 			AssertWithinTolerance(expected.Width, actual.Width, tolerance, "Width was not within tolerance.");
 		}
 
-		[Theory(DisplayName = "Native View Transforms are not empty"
-#if IOS
-					, Skip = "https://github.com/dotnet/maui/issues/3600"
-#endif
-			)]
+		[Theory(DisplayName = "PlatformView Transforms are not empty")]
 		[InlineData(1)]
 		[InlineData(100)]
 		[InlineData(1000)]


### PR DESCRIPTION
### Description of Change

Reenables the transform unit tests for iOS which were unable to run before because of #3600

### Issues Fixed

Fixes #13429
