### PR TITLE
[controls] fix memory leak in `VisualElement.Background`

### DIFF
--- a/src/Controls/src/Core/BindableLayout.cs
+++ b/src/Controls/src/Core/BindableLayout.cs
@@ -201,7 +201,7 @@ namespace Microsoft.Maui.Controls
 	class BindableLayoutController
 	{
 		readonly WeakReference<IBindableLayout> _layoutWeakReference;
-		readonly WeakCollectionChangedProxy _collectionChangedProxy = new();
+		readonly WeakNotifyCollectionChangedProxy _collectionChangedProxy = new();
 		IEnumerable _itemsSource;
 		DataTemplate _itemTemplate;
 		DataTemplateSelector _itemTemplateSelector;
@@ -394,46 +394,6 @@ namespace Microsoft.Maui.Controls
 			// UpdateEmptyView is called from within CreateChildren, therefor skip it for Reset
 			if (e.Action != NotifyCollectionChangedAction.Reset)
 				UpdateEmptyView(layout);
-		}
-
-		class WeakCollectionChangedProxy
-		{
-			WeakReference<NotifyCollectionChangedEventHandler> _handler;
-			WeakReference<INotifyCollectionChanged> _source;
-
-			void OnCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
-			{
-				if (_handler.TryGetTarget(out var handler))
-				{
-					handler(sender, e);
-				}
-				else
-				{
-					Unsubscribe();
-				}
-			}
-
-			public void Subscribe(INotifyCollectionChanged source, NotifyCollectionChangedEventHandler handler)
-			{
-				if (_source is not null && _source.TryGetTarget(out var s))
-				{
-					s.CollectionChanged -= OnCollectionChanged;
-				}
-
-				_source = new WeakReference<INotifyCollectionChanged>(source);
-				_handler = new WeakReference<NotifyCollectionChangedEventHandler>(handler);
-				source.CollectionChanged += OnCollectionChanged;
-			}
-
-			public void Unsubscribe()
-			{
-				if (_source is not null && _source.TryGetTarget(out var s))
-				{
-					s.CollectionChanged -= OnCollectionChanged;
-				}
-				_source = null;
-				_handler = null;
-			}
 		}
 	}
 }

--- a/src/Controls/src/Core/BindingExpression.cs
+++ b/src/Controls/src/Core/BindingExpression.cs
@@ -606,55 +606,39 @@ namespace Microsoft.Maui.Controls
 			public object Source { get; private set; }
 		}
 
-		internal class WeakPropertyChangedProxy
+		internal class WeakPropertyChangedProxy : WeakEventProxy<INotifyPropertyChanged, PropertyChangedEventHandler>
 		{
-			readonly WeakReference<INotifyPropertyChanged> _source = new WeakReference<INotifyPropertyChanged>(null);
-			readonly WeakReference<PropertyChangedEventHandler> _listener = new WeakReference<PropertyChangedEventHandler>(null);
-			readonly PropertyChangedEventHandler _handler;
-			readonly EventHandler _bchandler;
-			internal WeakReference<INotifyPropertyChanged> Source => _source;
+			public WeakPropertyChangedProxy() { }
 
-			public WeakPropertyChangedProxy()
+			public WeakPropertyChangedProxy(INotifyPropertyChanged source, PropertyChangedEventHandler listener)
 			{
-				_handler = new PropertyChangedEventHandler(OnPropertyChanged);
-				_bchandler = new EventHandler(OnBCChanged);
+				Subscribe(source, listener);
 			}
 
-			public WeakPropertyChangedProxy(INotifyPropertyChanged source, PropertyChangedEventHandler listener) : this()
+
+
+			public override void Subscribe(INotifyPropertyChanged source, PropertyChangedEventHandler listener)
 			{
-				SubscribeTo(source, listener);
+				source.PropertyChanged += OnPropertyChanged;
+				if (source is BindableObject bo)
+					bo.BindingContextChanged += OnBCChanged;
+
+				base.Subscribe(source, listener);
 			}
 
-			public void SubscribeTo(INotifyPropertyChanged source, PropertyChangedEventHandler listener)
+			public override void Unsubscribe()
 			{
-				source.PropertyChanged += _handler;
-				var bo = source as BindableObject;
-				if (bo != null)
-					bo.BindingContextChanged += _bchandler;
-				_source.SetTarget(source);
-				_listener.SetTarget(listener);
-			}
+				if (TryGetSource(out var source))
+					source.PropertyChanged -= OnPropertyChanged;
+				if (source is BindableObject bo)
+					bo.BindingContextChanged -= OnBCChanged;
 
-			public void Unsubscribe(bool finalizer = false)
-			{
-				INotifyPropertyChanged source;
-				if (_source.TryGetTarget(out source) && source != null)
-					source.PropertyChanged -= _handler;
-				var bo = source as BindableObject;
-				if (bo != null)
-					bo.BindingContextChanged -= _bchandler;
-
-				// If we are called from a finalizer, WeakReference<T>.SetTarget() can throw InvalidOperationException
-				if (finalizer)
-					return;
-
-				_source.SetTarget(null);
-				_listener.SetTarget(null);
+				base.Unsubscribe();
 			}
 
 			void OnPropertyChanged(object sender, PropertyChangedEventArgs e)
 			{
-				if (_listener.TryGetTarget(out var handler) && handler != null)
+				if (TryGetHandler(out var handler))
 					handler(sender, e);
 				else
 					Unsubscribe();
@@ -662,7 +646,7 @@ namespace Microsoft.Maui.Controls
 
 			void OnBCChanged(object sender, EventArgs e)
 			{
-				OnPropertyChanged(sender, new PropertyChangedEventArgs("BindingContext"));
+				OnPropertyChanged(sender, new PropertyChangedEventArgs(nameof(BindableObject.BindingContext)));
 			}
 		}
 
@@ -672,7 +656,7 @@ namespace Microsoft.Maui.Controls
 			readonly PropertyChangedEventHandler _changeHandler;
 			WeakPropertyChangedProxy _listener;
 
-			~BindingExpressionPart() => _listener?.Unsubscribe(finalizer: true);
+			~BindingExpressionPart() => _listener?.Unsubscribe();
 
 			public BindingExpressionPart(BindingExpression expression, string content, bool isIndexer = false)
 			{
@@ -687,7 +671,7 @@ namespace Microsoft.Maui.Controls
 			public void Subscribe(INotifyPropertyChanged handler)
 			{
 				INotifyPropertyChanged source;
-				if (_listener != null && _listener.Source.TryGetTarget(out source) && ReferenceEquals(handler, source))
+				if (_listener != null && _listener.TryGetSource(out source) && ReferenceEquals(handler, source))
 					// Already subscribed
 					return;
 

--- a/src/Controls/src/Core/Internals/MaybeNullWhenAttribute.cs
+++ b/src/Controls/src/Core/Internals/MaybeNullWhenAttribute.cs
@@ -9,144 +9,144 @@
 namespace System.Diagnostics.CodeAnalysis
 {
 #if !NETCOREAPP
- 
-    /// <summary>Specifies that null is allowed as an input even if the corresponding type disallows it.</summary>
-    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property, Inherited = false)]
-    internal sealed class AllowNullAttribute : Attribute { }
- 
-    /// <summary>Specifies that null is disallowed as an input even if the corresponding type allows it.</summary>
-    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property, Inherited = false)]
-    internal sealed class DisallowNullAttribute : Attribute { }
- 
-    /// <summary>Specifies that an output may be null even if the corresponding type disallows it.</summary>
-    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, Inherited = false)]
-    internal sealed class MaybeNullAttribute : Attribute { }
- 
-    /// <summary>Specifies that an output will not be null even if the corresponding type allows it.</summary>
-    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, Inherited = false)]
-    internal sealed class NotNullAttribute : Attribute { }
- 
-    /// <summary>Specifies that when a method returns <see cref="ReturnValue"/>, the parameter may be null even if the corresponding type disallows it.</summary>
-    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
-    internal sealed class MaybeNullWhenAttribute : Attribute
-    {
-        /// <summary>Initializes the attribute with the specified return value condition.</summary>
-        /// <param name="returnValue">
-        /// The return value condition. If the method returns this value, the associated parameter may be null.
-        /// </param>
-        public MaybeNullWhenAttribute(bool returnValue) => ReturnValue = returnValue;
- 
-        /// <summary>Gets the return value condition.</summary>
-        public bool ReturnValue { get; }
-    }
- 
-    /// <summary>Specifies that when a method returns <see cref="ReturnValue"/>, the parameter will not be null even if the corresponding type allows it.</summary>
-    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
-    internal sealed class NotNullWhenAttribute : Attribute
-    {
-        /// <summary>Initializes the attribute with the specified return value condition.</summary>
-        /// <param name="returnValue">
-        /// The return value condition. If the method returns this value, the associated parameter will not be null.
-        /// </param>
-        public NotNullWhenAttribute(bool returnValue) => ReturnValue = returnValue;
- 
-        /// <summary>Gets the return value condition.</summary>
-        public bool ReturnValue { get; }
-    }
- 
-    /// <summary>Specifies that the output will be non-null if the named parameter is non-null.</summary>
-    [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, AllowMultiple = true, Inherited = false)]
-    internal sealed class NotNullIfNotNullAttribute : Attribute
-    {
-        /// <summary>Initializes the attribute with the associated parameter name.</summary>
-        /// <param name="parameterName">
-        /// The associated parameter name.  The output will be non-null if the argument to the parameter specified is non-null.
-        /// </param>
-        public NotNullIfNotNullAttribute(string parameterName) => ParameterName = parameterName;
- 
-        /// <summary>Gets the associated parameter name.</summary>
-        public string ParameterName { get; }
-    }
- 
-    /// <summary>Applied to a method that will never return under any circumstance.</summary>
-    [AttributeUsage(AttributeTargets.Method, Inherited = false)]
-    internal sealed class DoesNotReturnAttribute : Attribute { }
- 
-    /// <summary>Specifies that the method will not return if the associated Boolean parameter is passed the specified value.</summary>
-    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
-    internal sealed class DoesNotReturnIfAttribute : Attribute
-    {
-        /// <summary>Initializes the attribute with the specified parameter value.</summary>
-        /// <param name="parameterValue">
-        /// The condition parameter value. Code after the method will be considered unreachable by diagnostics if the argument to
-        /// the associated parameter matches this value.
-        /// </param>
-        public DoesNotReturnIfAttribute(bool parameterValue) => ParameterValue = parameterValue;
- 
-        /// <summary>Gets the condition parameter value.</summary>
-        public bool ParameterValue { get; }
-    }
- 
+
+	/// <summary>Specifies that null is allowed as an input even if the corresponding type disallows it.</summary>
+	[AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property, Inherited = false)]
+	internal sealed class AllowNullAttribute : Attribute { }
+
+	/// <summary>Specifies that null is disallowed as an input even if the corresponding type allows it.</summary>
+	[AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property, Inherited = false)]
+	internal sealed class DisallowNullAttribute : Attribute { }
+
+	/// <summary>Specifies that an output may be null even if the corresponding type disallows it.</summary>
+	[AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, Inherited = false)]
+	internal sealed class MaybeNullAttribute : Attribute { }
+
+	/// <summary>Specifies that an output will not be null even if the corresponding type allows it.</summary>
+	[AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, Inherited = false)]
+	internal sealed class NotNullAttribute : Attribute { }
+
+	/// <summary>Specifies that when a method returns <see cref="ReturnValue"/>, the parameter may be null even if the corresponding type disallows it.</summary>
+	[AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+	internal sealed class MaybeNullWhenAttribute : Attribute
+	{
+		/// <summary>Initializes the attribute with the specified return value condition.</summary>
+		/// <param name="returnValue">
+		/// The return value condition. If the method returns this value, the associated parameter may be null.
+		/// </param>
+		public MaybeNullWhenAttribute(bool returnValue) => ReturnValue = returnValue;
+
+		/// <summary>Gets the return value condition.</summary>
+		public bool ReturnValue { get; }
+	}
+
+	/// <summary>Specifies that when a method returns <see cref="ReturnValue"/>, the parameter will not be null even if the corresponding type allows it.</summary>
+	[AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+	internal sealed class NotNullWhenAttribute : Attribute
+	{
+		/// <summary>Initializes the attribute with the specified return value condition.</summary>
+		/// <param name="returnValue">
+		/// The return value condition. If the method returns this value, the associated parameter will not be null.
+		/// </param>
+		public NotNullWhenAttribute(bool returnValue) => ReturnValue = returnValue;
+
+		/// <summary>Gets the return value condition.</summary>
+		public bool ReturnValue { get; }
+	}
+
+	/// <summary>Specifies that the output will be non-null if the named parameter is non-null.</summary>
+	[AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, AllowMultiple = true, Inherited = false)]
+	internal sealed class NotNullIfNotNullAttribute : Attribute
+	{
+		/// <summary>Initializes the attribute with the associated parameter name.</summary>
+		/// <param name="parameterName">
+		/// The associated parameter name.  The output will be non-null if the argument to the parameter specified is non-null.
+		/// </param>
+		public NotNullIfNotNullAttribute(string parameterName) => ParameterName = parameterName;
+
+		/// <summary>Gets the associated parameter name.</summary>
+		public string ParameterName { get; }
+	}
+
+	/// <summary>Applied to a method that will never return under any circumstance.</summary>
+	[AttributeUsage(AttributeTargets.Method, Inherited = false)]
+	internal sealed class DoesNotReturnAttribute : Attribute { }
+
+	/// <summary>Specifies that the method will not return if the associated Boolean parameter is passed the specified value.</summary>
+	[AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+	internal sealed class DoesNotReturnIfAttribute : Attribute
+	{
+		/// <summary>Initializes the attribute with the specified parameter value.</summary>
+		/// <param name="parameterValue">
+		/// The condition parameter value. Code after the method will be considered unreachable by diagnostics if the argument to
+		/// the associated parameter matches this value.
+		/// </param>
+		public DoesNotReturnIfAttribute(bool parameterValue) => ParameterValue = parameterValue;
+
+		/// <summary>Gets the condition parameter value.</summary>
+		public bool ParameterValue { get; }
+	}
+
 #endif
 
 #if !NETCOREAPP || NETCOREAPP3_1
- 
-    /// <summary>Specifies that the method or property will ensure that the listed field and property members have not-null values.</summary>
-    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = false, AllowMultiple = true)]
-    internal sealed class MemberNotNullAttribute : Attribute
-    {
-        /// <summary>Initializes the attribute with a field or property member.</summary>
-        /// <param name="member">
-        /// The field or property member that is promised to be not-null.
-        /// </param>
-        public MemberNotNullAttribute(string member) => Members = new[] { member };
- 
-        /// <summary>Initializes the attribute with the list of field and property members.</summary>
-        /// <param name="members">
-        /// The list of field and property members that are promised to be not-null.
-        /// </param>
-        public MemberNotNullAttribute(params string[] members) => Members = members;
- 
-        /// <summary>Gets field or property member names.</summary>
-        public string[] Members { get; }
-    }
- 
-    /// <summary>Specifies that the method or property will ensure that the listed field and property members have not-null values when returning with the specified return value condition.</summary>
-    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = false, AllowMultiple = true)]
-    internal sealed class MemberNotNullWhenAttribute : Attribute
-    {
-        /// <summary>Initializes the attribute with the specified return value condition and a field or property member.</summary>
-        /// <param name="returnValue">
-        /// The return value condition. If the method returns this value, the associated parameter will not be null.
-        /// </param>
-        /// <param name="member">
-        /// The field or property member that is promised to be not-null.
-        /// </param>
-        public MemberNotNullWhenAttribute(bool returnValue, string member)
-        {
-            ReturnValue = returnValue;
-            Members = new[] { member };
-        }
- 
-        /// <summary>Initializes the attribute with the specified return value condition and list of field and property members.</summary>
-        /// <param name="returnValue">
-        /// The return value condition. If the method returns this value, the associated parameter will not be null.
-        /// </param>
-        /// <param name="members">
-        /// The list of field and property members that are promised to be not-null.
-        /// </param>
-        public MemberNotNullWhenAttribute(bool returnValue, params string[] members)
-        {
-            ReturnValue = returnValue;
-            Members = members;
-        }
- 
-        /// <summary>Gets the return value condition.</summary>
-        public bool ReturnValue { get; }
- 
-        /// <summary>Gets field or property member names.</summary>
-        public string[] Members { get; }
-    }
- 
+
+	/// <summary>Specifies that the method or property will ensure that the listed field and property members have not-null values.</summary>
+	[AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = false, AllowMultiple = true)]
+	internal sealed class MemberNotNullAttribute : Attribute
+	{
+		/// <summary>Initializes the attribute with a field or property member.</summary>
+		/// <param name="member">
+		/// The field or property member that is promised to be not-null.
+		/// </param>
+		public MemberNotNullAttribute(string member) => Members = new[] { member };
+
+		/// <summary>Initializes the attribute with the list of field and property members.</summary>
+		/// <param name="members">
+		/// The list of field and property members that are promised to be not-null.
+		/// </param>
+		public MemberNotNullAttribute(params string[] members) => Members = members;
+
+		/// <summary>Gets field or property member names.</summary>
+		public string[] Members { get; }
+	}
+
+	/// <summary>Specifies that the method or property will ensure that the listed field and property members have not-null values when returning with the specified return value condition.</summary>
+	[AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = false, AllowMultiple = true)]
+	internal sealed class MemberNotNullWhenAttribute : Attribute
+	{
+		/// <summary>Initializes the attribute with the specified return value condition and a field or property member.</summary>
+		/// <param name="returnValue">
+		/// The return value condition. If the method returns this value, the associated parameter will not be null.
+		/// </param>
+		/// <param name="member">
+		/// The field or property member that is promised to be not-null.
+		/// </param>
+		public MemberNotNullWhenAttribute(bool returnValue, string member)
+		{
+			ReturnValue = returnValue;
+			Members = new[] { member };
+		}
+
+		/// <summary>Initializes the attribute with the specified return value condition and list of field and property members.</summary>
+		/// <param name="returnValue">
+		/// The return value condition. If the method returns this value, the associated parameter will not be null.
+		/// </param>
+		/// <param name="members">
+		/// The list of field and property members that are promised to be not-null.
+		/// </param>
+		public MemberNotNullWhenAttribute(bool returnValue, params string[] members)
+		{
+			ReturnValue = returnValue;
+			Members = members;
+		}
+
+		/// <summary>Gets the return value condition.</summary>
+		public bool ReturnValue { get; }
+
+		/// <summary>Gets field or property member names.</summary>
+		public string[] Members { get; }
+	}
+
 #endif
 }

--- a/src/Controls/src/Core/Internals/MaybeNullWhenAttribute.cs
+++ b/src/Controls/src/Core/Internals/MaybeNullWhenAttribute.cs
@@ -1,0 +1,152 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// This was copied from https://github.com/dotnet/runtime/blob/39b9607807f29e48cae4652cd74735182b31182e/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/NullableAttributes.cs
+// and updated to have the scope of the attributes be internal.
+
+#nullable disable
+
+namespace System.Diagnostics.CodeAnalysis
+{
+#if !NETCOREAPP
+ 
+    /// <summary>Specifies that null is allowed as an input even if the corresponding type disallows it.</summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property, Inherited = false)]
+    internal sealed class AllowNullAttribute : Attribute { }
+ 
+    /// <summary>Specifies that null is disallowed as an input even if the corresponding type allows it.</summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property, Inherited = false)]
+    internal sealed class DisallowNullAttribute : Attribute { }
+ 
+    /// <summary>Specifies that an output may be null even if the corresponding type disallows it.</summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, Inherited = false)]
+    internal sealed class MaybeNullAttribute : Attribute { }
+ 
+    /// <summary>Specifies that an output will not be null even if the corresponding type allows it.</summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, Inherited = false)]
+    internal sealed class NotNullAttribute : Attribute { }
+ 
+    /// <summary>Specifies that when a method returns <see cref="ReturnValue"/>, the parameter may be null even if the corresponding type disallows it.</summary>
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+    internal sealed class MaybeNullWhenAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the specified return value condition.</summary>
+        /// <param name="returnValue">
+        /// The return value condition. If the method returns this value, the associated parameter may be null.
+        /// </param>
+        public MaybeNullWhenAttribute(bool returnValue) => ReturnValue = returnValue;
+ 
+        /// <summary>Gets the return value condition.</summary>
+        public bool ReturnValue { get; }
+    }
+ 
+    /// <summary>Specifies that when a method returns <see cref="ReturnValue"/>, the parameter will not be null even if the corresponding type allows it.</summary>
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+    internal sealed class NotNullWhenAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the specified return value condition.</summary>
+        /// <param name="returnValue">
+        /// The return value condition. If the method returns this value, the associated parameter will not be null.
+        /// </param>
+        public NotNullWhenAttribute(bool returnValue) => ReturnValue = returnValue;
+ 
+        /// <summary>Gets the return value condition.</summary>
+        public bool ReturnValue { get; }
+    }
+ 
+    /// <summary>Specifies that the output will be non-null if the named parameter is non-null.</summary>
+    [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, AllowMultiple = true, Inherited = false)]
+    internal sealed class NotNullIfNotNullAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the associated parameter name.</summary>
+        /// <param name="parameterName">
+        /// The associated parameter name.  The output will be non-null if the argument to the parameter specified is non-null.
+        /// </param>
+        public NotNullIfNotNullAttribute(string parameterName) => ParameterName = parameterName;
+ 
+        /// <summary>Gets the associated parameter name.</summary>
+        public string ParameterName { get; }
+    }
+ 
+    /// <summary>Applied to a method that will never return under any circumstance.</summary>
+    [AttributeUsage(AttributeTargets.Method, Inherited = false)]
+    internal sealed class DoesNotReturnAttribute : Attribute { }
+ 
+    /// <summary>Specifies that the method will not return if the associated Boolean parameter is passed the specified value.</summary>
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+    internal sealed class DoesNotReturnIfAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the specified parameter value.</summary>
+        /// <param name="parameterValue">
+        /// The condition parameter value. Code after the method will be considered unreachable by diagnostics if the argument to
+        /// the associated parameter matches this value.
+        /// </param>
+        public DoesNotReturnIfAttribute(bool parameterValue) => ParameterValue = parameterValue;
+ 
+        /// <summary>Gets the condition parameter value.</summary>
+        public bool ParameterValue { get; }
+    }
+ 
+#endif
+
+#if !NETCOREAPP || NETCOREAPP3_1
+ 
+    /// <summary>Specifies that the method or property will ensure that the listed field and property members have not-null values.</summary>
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = false, AllowMultiple = true)]
+    internal sealed class MemberNotNullAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with a field or property member.</summary>
+        /// <param name="member">
+        /// The field or property member that is promised to be not-null.
+        /// </param>
+        public MemberNotNullAttribute(string member) => Members = new[] { member };
+ 
+        /// <summary>Initializes the attribute with the list of field and property members.</summary>
+        /// <param name="members">
+        /// The list of field and property members that are promised to be not-null.
+        /// </param>
+        public MemberNotNullAttribute(params string[] members) => Members = members;
+ 
+        /// <summary>Gets field or property member names.</summary>
+        public string[] Members { get; }
+    }
+ 
+    /// <summary>Specifies that the method or property will ensure that the listed field and property members have not-null values when returning with the specified return value condition.</summary>
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = false, AllowMultiple = true)]
+    internal sealed class MemberNotNullWhenAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the specified return value condition and a field or property member.</summary>
+        /// <param name="returnValue">
+        /// The return value condition. If the method returns this value, the associated parameter will not be null.
+        /// </param>
+        /// <param name="member">
+        /// The field or property member that is promised to be not-null.
+        /// </param>
+        public MemberNotNullWhenAttribute(bool returnValue, string member)
+        {
+            ReturnValue = returnValue;
+            Members = new[] { member };
+        }
+ 
+        /// <summary>Initializes the attribute with the specified return value condition and list of field and property members.</summary>
+        /// <param name="returnValue">
+        /// The return value condition. If the method returns this value, the associated parameter will not be null.
+        /// </param>
+        /// <param name="members">
+        /// The list of field and property members that are promised to be not-null.
+        /// </param>
+        public MemberNotNullWhenAttribute(bool returnValue, params string[] members)
+        {
+            ReturnValue = returnValue;
+            Members = members;
+        }
+ 
+        /// <summary>Gets the return value condition.</summary>
+        public bool ReturnValue { get; }
+ 
+        /// <summary>Gets field or property member names.</summary>
+        public string[] Members { get; }
+    }
+ 
+#endif
+}

--- a/src/Controls/src/Core/Internals/WeakEventProxy.cs
+++ b/src/Controls/src/Core/Internals/WeakEventProxy.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using System.Collections.Specialized;
+
+// NOTE: warning disabled for netstandard projects
+#pragma warning disable 0436
+using MaybeNullWhenAttribute = System.Diagnostics.CodeAnalysis.MaybeNullWhenAttribute;
+#pragma warning restore 0436
+
+namespace Microsoft.Maui.Controls
+{
+	/// <summary>
+	/// An abstract base class for subscribing to an event via WeakReference.
+	/// See WeakNotifyCollectionChangedProxy below for sublcass usage.
+	/// </summary>
+	/// <typeparam name="TSource">The object type that has the event</typeparam>
+	/// <typeparam name="TEventHandler">The event handler type of the event</typeparam>
+	abstract class WeakEventProxy<TSource, TEventHandler>
+		where TSource : class
+		where TEventHandler : Delegate
+	{
+		WeakReference<TSource>? _source;
+		WeakReference<TEventHandler>? _handler;
+
+		public bool TryGetSource([MaybeNullWhen(false)] out TSource source)
+		{
+			if (_source is not null && _source.TryGetTarget(out source))
+			{
+				return source is not null;
+			}
+
+			source = default;
+			return false;
+		}
+
+		public bool TryGetHandler([MaybeNullWhen(false)] out TEventHandler handler)
+		{
+			if (_handler is not null && _handler.TryGetTarget(out handler))
+			{
+				return handler is not null;
+			}
+
+			handler = default;
+			return false;
+		}
+
+		public virtual void Subscribe(TSource source, TEventHandler handler)
+		{
+			_source = new WeakReference<TSource>(source);
+			_handler = new WeakReference<TEventHandler>(handler);
+		}
+
+		public virtual void Unsubscribe()
+		{
+			_source = null;
+			_handler = null;
+		}
+	}
+
+	/// <summary>
+	/// A "proxy" class for subscribing INotifyCollectionChanged via WeakReference.
+	/// General usage is to store this in a member variable and call Subscribe()/Unsubscribe() appropriately.
+	/// Your class should have a finalizer that calls Unsubscribe() to prevent WeakNotifyCollectionChangedProxy objects from leaking.
+	/// </summary>
+	class WeakNotifyCollectionChangedProxy : WeakEventProxy<INotifyCollectionChanged, NotifyCollectionChangedEventHandler>
+	{
+		public WeakNotifyCollectionChangedProxy() { }
+
+		public WeakNotifyCollectionChangedProxy(INotifyCollectionChanged source, NotifyCollectionChangedEventHandler handler)
+		{
+			Subscribe(source, handler);
+		}
+
+		void OnCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+		{
+			if (TryGetHandler(out var handler))
+			{
+				handler(sender, e);
+			}
+			else
+			{
+				Unsubscribe();
+			}
+		}
+
+		public override void Subscribe(INotifyCollectionChanged source, NotifyCollectionChangedEventHandler handler)
+		{
+			if (TryGetSource(out var s))
+			{
+				s.CollectionChanged -= OnCollectionChanged;
+			}
+
+			source.CollectionChanged += OnCollectionChanged;
+			base.Subscribe(source, handler);
+		}
+
+		public override void Unsubscribe()
+		{
+			if (TryGetSource(out var s))
+			{
+				s.CollectionChanged -= OnCollectionChanged;
+			}
+			base.Unsubscribe();
+		}
+	}
+}

--- a/src/Controls/src/Core/ListProxy.cs
+++ b/src/Controls/src/Core/ListProxy.cs
@@ -4,7 +4,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Dispatching;
 
@@ -12,11 +11,11 @@ namespace Microsoft.Maui.Controls
 {
 	internal sealed class ListProxy : IReadOnlyList<object>, IListProxy, INotifyCollectionChanged
 	{
-		IDispatcher _dispatcher;
+		readonly IDispatcher _dispatcher;
 		readonly ICollection _collection;
 		readonly IList _list;
 		readonly int _windowSize;
-		readonly ConditionalWeakTable<ListProxy, WeakNotifyProxy> _sourceToWeakHandlers;
+		readonly WeakNotifyCollectionChangedProxy _proxy;
 
 		IEnumerator _enumerator;
 		int _enumeratorIndex;
@@ -36,19 +35,19 @@ namespace Microsoft.Maui.Controls
 
 			ProxiedEnumerable = enumerable;
 			_collection = enumerable as ICollection;
-			_sourceToWeakHandlers = new ConditionalWeakTable<ListProxy, WeakNotifyProxy>();
 
-			if (_collection == null && enumerable is IReadOnlyCollection<object>)
-				_collection = new ReadOnlyListAdapter((IReadOnlyCollection<object>)enumerable);
+			if (_collection == null && enumerable is IReadOnlyCollection<object> coll)
+				_collection = new ReadOnlyListAdapter(coll);
 
 			_list = enumerable as IList;
 			if (_list == null && enumerable is IReadOnlyList<object>)
 				_list = new ReadOnlyListAdapter((IReadOnlyList<object>)enumerable);
 
-			var changed = enumerable as INotifyCollectionChanged;
-			if (changed != null)
-				_sourceToWeakHandlers.Add(this, new WeakNotifyProxy(this, changed));
+			if (enumerable is INotifyCollectionChanged changed)
+				_proxy = new WeakNotifyCollectionChangedProxy(changed, OnCollectionChanged);
 		}
+
+		~ListProxy() => _proxy?.Unsubscribe();
 
 		public IEnumerable ProxiedEnumerable { get; }
 
@@ -360,40 +359,6 @@ namespace Microsoft.Maui.Controls
 				OnCountChanged();
 
 			return _items.TryGetValue(index, out value);
-		}
-
-		class WeakNotifyProxy
-		{
-			readonly WeakReference<INotifyCollectionChanged> _weakCollection;
-			readonly WeakReference<ListProxy> _weakProxy;
-			readonly ConditionalWeakTable<ListProxy, NotifyCollectionChangedEventHandler> _sourceToWeakHandlers;
-
-			public WeakNotifyProxy(ListProxy proxy, INotifyCollectionChanged incc)
-			{
-				_sourceToWeakHandlers = new ConditionalWeakTable<ListProxy, NotifyCollectionChangedEventHandler>();
-				NotifyCollectionChangedEventHandler handler = new NotifyCollectionChangedEventHandler(OnCollectionChanged);
-
-				_sourceToWeakHandlers.Add(proxy, handler);
-				incc.CollectionChanged += handler;
-
-				_weakProxy = new WeakReference<ListProxy>(proxy);
-				_weakCollection = new WeakReference<INotifyCollectionChanged>(incc);
-			}
-
-			void OnCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
-			{
-				ListProxy proxy;
-				if (!_weakProxy.TryGetTarget(out proxy))
-				{
-					INotifyCollectionChanged collection;
-					if (_weakCollection.TryGetTarget(out collection))
-						collection.CollectionChanged -= OnCollectionChanged;
-
-					return;
-				}
-
-				proxy.OnCollectionChanged(sender, e);
-			}
 		}
 
 		class ProxyEnumerator : IEnumerator<object>

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -5,6 +5,7 @@ Microsoft.Maui.Controls.Handlers.Compatibility.FrameRenderer.FrameRenderer(Andro
 Microsoft.Maui.Controls.LayoutOptions.Equals(Microsoft.Maui.Controls.LayoutOptions other) -> bool
 Microsoft.Maui.Controls.Region.Equals(Microsoft.Maui.Controls.Region other) -> bool
 Microsoft.Maui.Controls.Shapes.Matrix.Equals(Microsoft.Maui.Controls.Shapes.Matrix other) -> bool
+Microsoft.Maui.Controls.VisualElement.~VisualElement() -> void
 override Microsoft.Maui.Controls.LayoutOptions.GetHashCode() -> int
 override Microsoft.Maui.Controls.Region.GetHashCode() -> int
 override Microsoft.Maui.Controls.Shapes.Matrix.GetHashCode() -> int

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -3,6 +3,7 @@
 Microsoft.Maui.Controls.LayoutOptions.Equals(Microsoft.Maui.Controls.LayoutOptions other) -> bool
 Microsoft.Maui.Controls.Region.Equals(Microsoft.Maui.Controls.Region other) -> bool
 Microsoft.Maui.Controls.Shapes.Matrix.Equals(Microsoft.Maui.Controls.Shapes.Matrix other) -> bool
+Microsoft.Maui.Controls.VisualElement.~VisualElement() -> void
 override Microsoft.Maui.Controls.LayoutOptions.GetHashCode() -> int
 override Microsoft.Maui.Controls.Platform.Compatibility.ShellPageRendererTracker.TitleViewContainer.LayoutSubviews() -> void
 override Microsoft.Maui.Controls.Region.GetHashCode() -> int

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -3,6 +3,7 @@
 Microsoft.Maui.Controls.LayoutOptions.Equals(Microsoft.Maui.Controls.LayoutOptions other) -> bool
 Microsoft.Maui.Controls.Region.Equals(Microsoft.Maui.Controls.Region other) -> bool
 Microsoft.Maui.Controls.Shapes.Matrix.Equals(Microsoft.Maui.Controls.Shapes.Matrix other) -> bool
+Microsoft.Maui.Controls.VisualElement.~VisualElement() -> void
 override Microsoft.Maui.Controls.LayoutOptions.GetHashCode() -> int
 override Microsoft.Maui.Controls.Platform.Compatibility.ShellPageRendererTracker.TitleViewContainer.LayoutSubviews() -> void
 override Microsoft.Maui.Controls.Region.GetHashCode() -> int

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -2,6 +2,7 @@
 Microsoft.Maui.Controls.LayoutOptions.Equals(Microsoft.Maui.Controls.LayoutOptions other) -> bool
 Microsoft.Maui.Controls.Region.Equals(Microsoft.Maui.Controls.Region other) -> bool
 Microsoft.Maui.Controls.Shapes.Matrix.Equals(Microsoft.Maui.Controls.Shapes.Matrix other) -> bool
+Microsoft.Maui.Controls.VisualElement.~VisualElement() -> void
 override Microsoft.Maui.Controls.LayoutOptions.GetHashCode() -> int
 override Microsoft.Maui.Controls.Region.GetHashCode() -> int
 override Microsoft.Maui.Controls.Shapes.Matrix.GetHashCode() -> int

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -3,6 +3,7 @@
 Microsoft.Maui.Controls.LayoutOptions.Equals(Microsoft.Maui.Controls.LayoutOptions other) -> bool
 Microsoft.Maui.Controls.Region.Equals(Microsoft.Maui.Controls.Region other) -> bool
 Microsoft.Maui.Controls.Shapes.Matrix.Equals(Microsoft.Maui.Controls.Shapes.Matrix other) -> bool
+Microsoft.Maui.Controls.VisualElement.~VisualElement() -> void
 override Microsoft.Maui.Controls.LayoutOptions.GetHashCode() -> int
 override Microsoft.Maui.Controls.Region.GetHashCode() -> int
 override Microsoft.Maui.Controls.Shapes.Matrix.GetHashCode() -> int

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -3,6 +3,7 @@
 Microsoft.Maui.Controls.LayoutOptions.Equals(Microsoft.Maui.Controls.LayoutOptions other) -> bool
 Microsoft.Maui.Controls.Region.Equals(Microsoft.Maui.Controls.Region other) -> bool
 Microsoft.Maui.Controls.Shapes.Matrix.Equals(Microsoft.Maui.Controls.Shapes.Matrix other) -> bool
+Microsoft.Maui.Controls.VisualElement.~VisualElement() -> void
 override Microsoft.Maui.Controls.LayoutOptions.GetHashCode() -> int
 override Microsoft.Maui.Controls.Region.GetHashCode() -> int
 override Microsoft.Maui.Controls.Shapes.Matrix.GetHashCode() -> int

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -3,6 +3,7 @@
 Microsoft.Maui.Controls.LayoutOptions.Equals(Microsoft.Maui.Controls.LayoutOptions other) -> bool
 Microsoft.Maui.Controls.Region.Equals(Microsoft.Maui.Controls.Region other) -> bool
 Microsoft.Maui.Controls.Shapes.Matrix.Equals(Microsoft.Maui.Controls.Shapes.Matrix other) -> bool
+Microsoft.Maui.Controls.VisualElement.~VisualElement() -> void
 override Microsoft.Maui.Controls.LayoutOptions.GetHashCode() -> int
 override Microsoft.Maui.Controls.Region.GetHashCode() -> int
 override Microsoft.Maui.Controls.Shapes.Matrix.GetHashCode() -> int

--- a/src/Controls/src/Core/TypedBinding.cs
+++ b/src/Controls/src/Core/TypedBinding.cs
@@ -252,13 +252,13 @@ namespace Microsoft.Maui.Controls.Internals
 			readonly BindingBase _binding;
 			PropertyChangedEventHandler handler;
 
-			~PropertyChangedProxy() => Listener?.Unsubscribe(finalizer: true);
+			~PropertyChangedProxy() => Listener?.Unsubscribe();
 
 			public INotifyPropertyChanged Part
 			{
 				get
 				{
-					if (Listener != null && Listener.Source.TryGetTarget(out var target))
+					if (Listener != null && Listener.TryGetSource(out var target))
 						return target;
 					return null;
 				}
@@ -267,12 +267,12 @@ namespace Microsoft.Maui.Controls.Internals
 					if (Listener != null)
 					{
 						//Already subscribed
-						if (Listener.Source.TryGetTarget(out var source) && ReferenceEquals(value, source))
+						if (Listener.TryGetSource(out var source) && ReferenceEquals(value, source))
 							return;
 
 						//clear out previous subscription
 						Listener.Unsubscribe();
-						Listener.SubscribeTo(value, handler);
+						Listener.Subscribe(value, handler);
 					}
 				}
 			}

--- a/src/Controls/src/Core/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement.cs
@@ -1,7 +1,6 @@
 #nullable disable
 using System;
 using System.Collections.Generic;
-using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Globalization;
 using System.Runtime.InteropServices.ComTypes;
@@ -280,9 +279,9 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		class WeakBackgroundChangedProxy : WeakEventProxy<Brush, PropertyChangedEventHandler>
+		class WeakBackgroundChangedProxy : WeakEventProxy<Brush, EventHandler>
 		{
-			void OnBackgroundChanged(object sender, PropertyChangedEventArgs e)
+			void OnBackgroundChanged(object sender, EventArgs e)
 			{
 				if (TryGetHandler(out var handler))
 				{
@@ -294,19 +293,19 @@ namespace Microsoft.Maui.Controls
 				}
 			}
 
-			public override void Subscribe(Brush source, PropertyChangedEventHandler handler)
+			public override void Subscribe(Brush source, EventHandler handler)
 			{
 				if (TryGetSource(out var s))
 				{
 					s.PropertyChanged -= OnBackgroundChanged;
 
 					if (s is GradientBrush g)
-						g.PropertyChanged -= OnBackgroundChanged;
+						g.InvalidateGradientBrushRequested -= OnBackgroundChanged;
 				}
 
 				source.PropertyChanged += OnBackgroundChanged;
 				if (source is GradientBrush gradientBrush)
-					gradientBrush.PropertyChanged += OnBackgroundChanged;
+					gradientBrush.InvalidateGradientBrushRequested += OnBackgroundChanged;
 
 				base.Subscribe(source, handler);
 			}
@@ -318,7 +317,7 @@ namespace Microsoft.Maui.Controls
 					s.PropertyChanged -= OnBackgroundChanged;
 
 					if (s is GradientBrush g)
-						g.PropertyChanged -= OnBackgroundChanged;
+						g.InvalidateGradientBrushRequested -= OnBackgroundChanged;
 				}
 				base.Unsubscribe();
 			}

--- a/src/Controls/tests/Core.UnitTests/BrushUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/BrushUnitTests.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact]
-		public void TestBrushParent()
+		public void TestBrushBindingContext()
 		{
 			var context = new object();
 
@@ -84,7 +84,6 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			parent.Background = linearGradientBrush;
 
-			Assert.Same(parent, parent.Background.Parent);
 			Assert.Same(context, parent.Background.BindingContext);
 		}
 

--- a/src/Controls/tests/Core.UnitTests/VisualElementTests.cs
+++ b/src/Controls/tests/Core.UnitTests/VisualElementTests.cs
@@ -118,5 +118,29 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			Assert.False(reference.IsAlive, "VisualElement should not be alive!");
 		}
+
+		[Fact]
+		public void GradientBrushSubscribed()
+		{
+			var gradient = new LinearGradientBrush
+			{
+				GradientStops =
+				{
+					new GradientStop(Colors.White, 0),
+					new GradientStop(Colors.CornflowerBlue, 1),
+				}
+			};
+			var visual = new VisualElement { Background = gradient };
+
+			bool fired = false;
+			visual.PropertyChanged += (sender, e) =>
+			{
+				if (e.PropertyName == nameof(VisualElement.Background))
+					fired = true;
+			};
+
+			gradient.GradientStops.Add(new GradientStop(Colors.CornflowerBlue, 1));
+			Assert.True(fired, "PropertyChanged did not fire!");
+		}
 	}
 }


### PR DESCRIPTION
Fixes #12344
Fixes #13557
Context: https://github.com/dotnet-presentations/dotnet-maui-workshop

While testing the `Monkey Finder` sample, I found the following scenario causes an issue:

1. Declare a `{StaticResource}` `Brush` at the `Application` level, with a lifetime of the entire application.

2. Set `Background` on an item in a `CollectionView`, `ListView`, etc.

3. Scroll a lot, navigate away, etc.

4. The `Brush` will hold onto any `View`'s indefinitely.

The core problem here being `VisualElement` does:

```cs
    void NotifyBackgroundChanges()
    {
        if (Background is ImmutableBrush)
            return;

        if (Background != null)
        {
            Background.Parent = this;
            Background.PropertyChanged += OnBackgroundChanged;

            if (Background is GradientBrush gradientBrush)
                gradientBrush.InvalidateGradientBrushRequested += InvalidateGradientBrushRequested;
        }
    }
```
If no user code sets `Background` to `null`, these events remain subscribed.

To fix this:

1. Create a `WeakNotifyCollectionChangedProxy` type for event subscription.

2. Don't set `Background.Parent = this`

## General Cleanup ##

Through doing other fixes related to memory leaks & C# events, we've started to gain a collection of `WeakEventProxy`-related types.

I created some core `internal` types to be reused:

* `abstract WeakEventProxy<TSource, TEventHandler>`
* `WeakNotifyCollectionChangedProxy`

The following classes now make use of these new shared types:

* `BindingExpression`
* `BindableLayout`
* `ListProxy`
* `VisualElement`

This should hopefully reduce mistakes and reuse code in this area.

## Concerns ##

Since, we are no longer doing:

    Background.Parent = this;

This is certainly a behavior change. It is now replaced with:

    SetInheritedBindingContext(Background, BindingContext);

I had to update one unit test that was asserting `Background.Parent`, which can assert `Background.BindingContext` instead.

As such, this change is definitely sketchy and I wouldn't backport to .NET 7 immediately. We might test it out in a .NET 8 preview first.