### PR TITLE
[iOS] Implement ScrollView Orientation

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Layouts/ScrollViewPages/ScrollViewOrientationPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Layouts/ScrollViewPages/ScrollViewOrientationPage.xaml
@@ -1,0 +1,33 @@
+﻿<views:BasePage
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="Maui.Controls.Sample.Pages.ScrollViewPages.ScrollViewOrientationPage"
+    xmlns:views="clr-namespace:Maui.Controls.Sample.Pages.Base"
+    Title="ScrollView">
+    <views:BasePage.Content>
+        <Grid Padding="12" ColumnSpacing="2">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition />
+            </Grid.RowDefinitions>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition/>
+            </Grid.ColumnDefinitions>
+            <Label Text="Change Orientation:"
+                   Style="{StaticResource Headline}" VerticalOptions="Center" />
+
+            <Picker x:Name="Orientation" Grid.Column="1" SelectedIndex="0" SelectedIndexChanged="OrientationSelectedIndexChanged" VerticalOptions="Start">
+                <Picker.Items>
+                    <x:String>Vertical</x:String>
+                    <x:String>Horizontal</x:String>
+                    <x:String>Both</x:String>
+                    <x:String>Neither</x:String>
+                </Picker.Items>
+            </Picker>
+            <ScrollView x:Name="ScrollViewer" Orientation="Horizontal" Grid.Row="1" Grid.ColumnSpan="2">
+                <Image Source="dotnet_bot.png" HeightRequest="1000" WidthRequest="1000" Aspect="AspectFit" />
+            </ScrollView>
+        </Grid>
+    </views:BasePage.Content>
+</views:BasePage>

--- a/src/Controls/samples/Controls.Sample/Pages/Layouts/ScrollViewPages/ScrollViewOrientationPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Layouts/ScrollViewPages/ScrollViewOrientationPage.xaml.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using Microsoft.Maui;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Graphics;
+
+namespace Maui.Controls.Sample.Pages.ScrollViewPages
+{
+	public partial class ScrollViewOrientationPage
+	{
+		public ScrollViewOrientationPage()
+		{
+			InitializeComponent();
+		}
+
+		public void OrientationSelectedIndexChanged(object sender, EventArgs args)
+		{
+			ScrollViewer.Orientation = (ScrollOrientation)Orientation.SelectedIndex;
+		}
+
+		protected override void OnAppearing()
+		{
+			Orientation.SelectedIndex = 0;
+			base.OnAppearing();
+		}
+	}
+}

--- a/src/Controls/samples/Controls.Sample/ViewModels/ScrollViewOptionsModel.cs
+++ b/src/Controls/samples/Controls.Sample/ViewModels/ScrollViewOptionsModel.cs
@@ -35,6 +35,10 @@ namespace Maui.Controls.Sample.ViewModels
 				new ScrollViewTemplatePageModel{ Spacing = 200, ScrollViewPadding = new Thickness(25),
 					ContentBackground = Colors.LightBlue, VerticalAlignment = LayoutOptions.Fill }),
 
+			new SectionModel(typeof(ScrollViewOrientationPage), "Orientation",
+				"Lock the orientation of your ScrollView",
+				new ScrollViewTemplatePageModel{ VerticalAlignment = LayoutOptions.Fill }),
+
 
 		};
 	}

--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.iOS.cs
@@ -175,7 +175,7 @@ namespace Microsoft.Maui.Handlers
 					container.Center = new CGPoint(container.Bounds.GetMidX(), container.Bounds.GetMidY());
 				}
 				var crossPlatformSize = internalArrange(rect);
-				var contentSize = crossPlatformSize.AccountForOrientation(scrollViewBounds.Width, scrollViewBounds.Height, scrollView);
+				var contentSize = AccountForOrientation(crossPlatformSize, scrollViewBounds.Width, scrollViewBounds.Height, scrollView.Orientation);
 				platformScrollView.ContentSize = contentSize;
 				return contentSize;
 			};
@@ -279,6 +279,21 @@ namespace Microsoft.Maui.Handlers
 		{
 			// Remove the padding from the constraint, but don't allow it to go negative
 			return Math.Max(0, constraint - padding);
+		}
+
+		internal static Size AccountForOrientation(Size size, double widthConstraint, double heightConstraint, ScrollOrientation orientation)
+		{
+			if (orientation is ScrollOrientation.Vertical or ScrollOrientation.Neither)
+			{
+				size.Width = widthConstraint;
+			}
+
+			if (orientation is ScrollOrientation.Horizontal or ScrollOrientation.Neither)
+			{
+				size.Height = heightConstraint;
+			}
+
+			return size;
 		}
 	}
 }

--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.iOS.cs
@@ -235,8 +235,7 @@ namespace Microsoft.Maui.Handlers
 			widthConstraint = AccountForPadding(widthConstraint, padding.HorizontalThickness);
 			heightConstraint = AccountForPadding(heightConstraint, padding.VerticalThickness);
 
-			var crossPlatformSize = virtualView.CrossPlatformMeasure(widthConstraint, heightConstraint);
-			var size = crossPlatformSize.AccountForOrientation(widthConstraint, heightConstraint, virtualView);
+			var size = virtualView.CrossPlatformMeasure(widthConstraint, heightConstraint);
 
 			// Add the padding back in for the final size
 			size.Width += padding.HorizontalThickness;

--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.iOS.cs
@@ -175,17 +175,17 @@ namespace Microsoft.Maui.Handlers
 					// cross-platform layout logic makes sense and the contents don't arrange outside the 
 					// container. (Everything will look correct if they do, but hit testing won't work properly.)
 
+					var scrollViewBounds = uiScrollView.Bounds;
 					var containerBounds = container.Bounds;
-					var scrollViewBounds = platformScrollView.Bounds;
 
 					container.Bounds = new CGRect(0, 0,
 						Math.Max(containerBounds.Width, scrollViewBounds.Width),
 						Math.Max(containerBounds.Height, scrollViewBounds.Height));
 					container.Center = new CGPoint(container.Bounds.GetMidX(), container.Bounds.GetMidY());
 				}
-				var crossPlatformSize = internalArrange(rect);
-				var contentSize = SetContentSizeForOrientation(platformScrollView, scrollView.Orientation, crossPlatformSize);
-				return contentSize;
+				var contentSize = internalArrange(rect);
+				var size = SetContentSizeForOrientation(platformScrollView, scrollView.Orientation, contentSize);
+				return size;
 			};
 		}
 

--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.iOS.cs
@@ -55,15 +55,9 @@ namespace Microsoft.Maui.Handlers
 			UpdateContentView(scrollView, handler);
 		}
 
-		// We don't actually have this mapped because we don't need it, but we can't remove it because it's public
-		public static void MapContentSize(IScrollViewHandler handler, IScrollView scrollView)
-		{
-			handler.PlatformView.UpdateContentSize(scrollView.ContentSize);
-		}
-
 		public static void MapIsEnabled(IScrollViewHandler handler, IScrollView scrollView)
 		{
-			handler.PlatformView.UpdateIsEnabled(scrollView);
+			handler.PlatformView?.UpdateIsEnabled(scrollView);
 		}
 
 		public static void MapHorizontalScrollBarVisibility(IScrollViewHandler handler, IScrollView scrollView)

--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.iOS.cs
@@ -55,6 +55,12 @@ namespace Microsoft.Maui.Handlers
 			UpdateContentView(scrollView, handler);
 		}
 
+		// We don't actually have this mapped because we don't need it, but we can't remove it because it's public
+		public static void MapContentSize(IScrollViewHandler handler, IScrollView scrollView)
+		{
+			handler.PlatformView?.UpdateContentSize(scrollView.ContentSize);
+		}
+
 		public static void MapIsEnabled(IScrollViewHandler handler, IScrollView scrollView)
 		{
 			handler.PlatformView?.UpdateIsEnabled(scrollView);

--- a/src/Core/src/Platform/iOS/ScrollViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/ScrollViewExtensions.cs
@@ -53,15 +53,5 @@ namespace Microsoft.Maui.Platform
 		{
 			nativeScrollView.ScrollEnabled = scrollView.IsEnabled;
 		}
-
-		internal static void UpdateOrientation(this UIScrollView platformScrollView, IScrollView scrollView)
-		{
-			var bounds = platformScrollView.GetPlatformViewBounds();
-			var widthConstraint = bounds.Width;
-			var heightConstraint = bounds.Height;
-			var result = scrollView.CrossPlatformMeasure(widthConstraint, heightConstraint);
-			var contentSize = ScrollViewHandler.AccountForOrientation(result, widthConstraint, heightConstraint, scrollView.Orientation);
-			platformScrollView.ContentSize = contentSize;
-		}
 	}
 }

--- a/src/Core/src/Platform/iOS/ScrollViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/ScrollViewExtensions.cs
@@ -44,5 +44,30 @@ namespace Microsoft.Maui.Platform
 		{
 			nativeScrollView.ScrollEnabled = scrollView.IsEnabled;
 		}
+
+		internal static void UpdateOrientation(this UIScrollView platformScrollView, IScrollView scrollView)
+		{
+			var bounds = platformScrollView.GetPlatformViewBounds();
+			var widthConstraint = bounds.Width;
+			var heightConstraint = bounds.Height;
+			var result = scrollView.CrossPlatformMeasure(widthConstraint, heightConstraint);
+			var contentSize = result.AccountForOrientation(widthConstraint, heightConstraint, scrollView);
+			platformScrollView.ContentSize = contentSize;
+		}
+
+		internal static Size AccountForOrientation(this Size size, double widthConstraint, double heightConstraint, IScrollView view)
+		{
+			if (view.Orientation is ScrollOrientation.Vertical or ScrollOrientation.Neither)
+			{
+				size.Width = widthConstraint;
+			}
+
+			if (view.Orientation is ScrollOrientation.Horizontal or ScrollOrientation.Neither)
+			{
+				size.Height = heightConstraint;
+			}
+
+			return size;
+		}
 	}
 }

--- a/src/Core/src/Platform/iOS/ScrollViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/ScrollViewExtensions.cs
@@ -40,6 +40,15 @@ namespace Microsoft.Maui.Platform
 			}
 		}
 
+		public static void UpdateContentSize(this UIScrollView scrollView, Size contentSize)
+		{
+			var nativeContentSize = contentSize.ToCGSize();
+			if (nativeContentSize != scrollView.ContentSize)
+			{
+				scrollView.ContentSize = nativeContentSize;
+			}
+		}
+
 		public static void UpdateIsEnabled(this UIScrollView nativeScrollView, IScrollView scrollView)
 		{
 			nativeScrollView.ScrollEnabled = scrollView.IsEnabled;

--- a/src/Core/src/Platform/iOS/ScrollViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/ScrollViewExtensions.cs
@@ -40,16 +40,6 @@ namespace Microsoft.Maui.Platform
 			}
 		}
 
-		public static void UpdateContentSize(this UIScrollView scrollView, Size contentSize)
-		{
-			var nativeContentSize = contentSize.ToCGSize();
-
-			if (nativeContentSize != scrollView.ContentSize)
-			{
-				scrollView.ContentSize = nativeContentSize;
-			}
-		}
-
 		public static void UpdateIsEnabled(this UIScrollView nativeScrollView, IScrollView scrollView)
 		{
 			nativeScrollView.ScrollEnabled = scrollView.IsEnabled;

--- a/src/Core/src/Platform/iOS/ScrollViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/ScrollViewExtensions.cs
@@ -51,23 +51,8 @@ namespace Microsoft.Maui.Platform
 			var widthConstraint = bounds.Width;
 			var heightConstraint = bounds.Height;
 			var result = scrollView.CrossPlatformMeasure(widthConstraint, heightConstraint);
-			var contentSize = result.AccountForOrientation(widthConstraint, heightConstraint, scrollView);
+			var contentSize = ScrollViewHandler.AccountForOrientation(result, widthConstraint, heightConstraint, scrollView.Orientation);
 			platformScrollView.ContentSize = contentSize;
-		}
-
-		internal static Size AccountForOrientation(this Size size, double widthConstraint, double heightConstraint, IScrollView view)
-		{
-			if (view.Orientation is ScrollOrientation.Vertical or ScrollOrientation.Neither)
-			{
-				size.Width = widthConstraint;
-			}
-
-			if (view.Orientation is ScrollOrientation.Horizontal or ScrollOrientation.Neither)
-			{
-				size.Height = heightConstraint;
-			}
-
-			return size;
 		}
 	}
 }

--- a/src/Core/src/Platform/iOS/ScrollViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/ScrollViewExtensions.cs
@@ -43,6 +43,7 @@ namespace Microsoft.Maui.Platform
 		public static void UpdateContentSize(this UIScrollView scrollView, Size contentSize)
 		{
 			var nativeContentSize = contentSize.ToCGSize();
+
 			if (nativeContentSize != scrollView.ContentSize)
 			{
 				scrollView.ContentSize = nativeContentSize;

--- a/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -33,3 +33,5 @@ static Microsoft.Maui.Platform.WebViewExtensions.UpdateUserAgent(this WebKit.WKW
 Microsoft.Maui.WeakEventManager.HandleEvent(object? sender, object? args, string! eventName) -> void
 static Microsoft.Maui.SizeRequest.operator !=(Microsoft.Maui.SizeRequest left, Microsoft.Maui.SizeRequest right) -> bool
 static Microsoft.Maui.SizeRequest.operator ==(Microsoft.Maui.SizeRequest left, Microsoft.Maui.SizeRequest right) -> bool
+*REMOVED*static Microsoft.Maui.Handlers.ScrollViewHandler.MapContentSize(Microsoft.Maui.Handlers.IScrollViewHandler! handler, Microsoft.Maui.IScrollView! scrollView) -> void
+*REMOVED*static Microsoft.Maui.Platform.ScrollViewExtensions.UpdateContentSize(this UIKit.UIScrollView! scrollView, Microsoft.Maui.Graphics.Size contentSize) -> void

--- a/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -34,6 +34,4 @@ static Microsoft.Maui.Platform.WebViewExtensions.UpdateUserAgent(this WebKit.WKW
 Microsoft.Maui.WeakEventManager.HandleEvent(object? sender, object? args, string! eventName) -> void
 static Microsoft.Maui.SizeRequest.operator !=(Microsoft.Maui.SizeRequest left, Microsoft.Maui.SizeRequest right) -> bool
 static Microsoft.Maui.SizeRequest.operator ==(Microsoft.Maui.SizeRequest left, Microsoft.Maui.SizeRequest right) -> bool
-*REMOVED*static Microsoft.Maui.Handlers.ScrollViewHandler.MapContentSize(Microsoft.Maui.Handlers.IScrollViewHandler! handler, Microsoft.Maui.IScrollView! scrollView) -> void
-*REMOVED*static Microsoft.Maui.Platform.ScrollViewExtensions.UpdateContentSize(this UIKit.UIScrollView! scrollView, Microsoft.Maui.Graphics.Size contentSize) -> void
 virtual Microsoft.Maui.MauiUIApplicationDelegate.PerformFetch(UIKit.UIApplication! application, System.Action<UIKit.UIBackgroundFetchResult>! completionHandler) -> void

--- a/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -33,3 +33,5 @@ static Microsoft.Maui.Platform.WebViewExtensions.UpdateUserAgent(this WebKit.WKW
 Microsoft.Maui.WeakEventManager.HandleEvent(object? sender, object? args, string! eventName) -> void
 static Microsoft.Maui.SizeRequest.operator !=(Microsoft.Maui.SizeRequest left, Microsoft.Maui.SizeRequest right) -> bool
 static Microsoft.Maui.SizeRequest.operator ==(Microsoft.Maui.SizeRequest left, Microsoft.Maui.SizeRequest right) -> bool
+*REMOVED*static Microsoft.Maui.Handlers.ScrollViewHandler.MapContentSize(Microsoft.Maui.Handlers.IScrollViewHandler! handler, Microsoft.Maui.IScrollView! scrollView) -> void
+*REMOVED*static Microsoft.Maui.Platform.ScrollViewExtensions.UpdateContentSize(this UIKit.UIScrollView! scrollView, Microsoft.Maui.Graphics.Size contentSize) -> void

--- a/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -33,7 +33,5 @@ static Microsoft.Maui.Platform.WebViewExtensions.UpdateUserAgent(this WebKit.WKW
 Microsoft.Maui.WeakEventManager.HandleEvent(object? sender, object? args, string! eventName) -> void
 static Microsoft.Maui.SizeRequest.operator !=(Microsoft.Maui.SizeRequest left, Microsoft.Maui.SizeRequest right) -> bool
 static Microsoft.Maui.SizeRequest.operator ==(Microsoft.Maui.SizeRequest left, Microsoft.Maui.SizeRequest right) -> bool
-*REMOVED*static Microsoft.Maui.Handlers.ScrollViewHandler.MapContentSize(Microsoft.Maui.Handlers.IScrollViewHandler! handler, Microsoft.Maui.IScrollView! scrollView) -> void
-*REMOVED*static Microsoft.Maui.Platform.ScrollViewExtensions.UpdateContentSize(this UIKit.UIScrollView! scrollView, Microsoft.Maui.Graphics.Size contentSize) -> void
 Microsoft.Maui.LifecycleEvents.iOSLifecycle.PerformFetch
 virtual Microsoft.Maui.MauiUIApplicationDelegate.PerformFetch(UIKit.UIApplication! application, System.Action<UIKit.UIBackgroundFetchResult>! completionHandler) -> void


### PR DESCRIPTION
### Description of Change

Seems there was no specific implementation for ScrollViewOrientation on iOS. So it was always allowing to scroll in both directions, 13412 

The issue is the ContentSize of the UIScrollView is not set on the correct dimension by constraining the size of the scrollview depending on the orientation. 
The implementation of `IContentView.CrossPlatformMeasure` on ScrollView.Impl does try to constrain when measuring using the orientation but the final `DesiredSize` is always the expressed WidthRequested/HeightRequested.

So one way to fix is to take in account the orientation when setting the UIScrollView ContentSize.

### Issues Fixed

Fixes #13412
Fixes #13187
