### PR TITLE
Document ContainsKey behavior

### DIFF
--- a/src/Controls/docs/Microsoft.Maui.Controls/ResourceDictionary.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/ResourceDictionary.xml
@@ -238,7 +238,7 @@
         <param name="key">The identifier being searched for.</param>
         <summary>Whether the <see cref="T:Microsoft.Maui.Controls.ResourceDictionary" /> contains a key-value pair identified by <paramref name="key" />.</summary>
         <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <remarks>This method will only return true if the key is in the immediate ResourceDictionary; it will not search any merged dictionaries.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Count">

--- a/src/Controls/src/Core/ResourceDictionary.cs
+++ b/src/Controls/src/Core/ResourceDictionary.cs
@@ -179,6 +179,9 @@ namespace Microsoft.Maui.Controls
 		/// <include file="../../docs/Microsoft.Maui.Controls/ResourceDictionary.xml" path="//Member[@MemberName='ContainsKey']/Docs/*" />
 		public bool ContainsKey(string key)
 		{
+			// Note that this only checks the inner dictionary and ignores the merged dictionaries. This is apparently an intended 
+			// behavior to support Hot Reload. 
+
 			return _innerDictionary.ContainsKey(key);
 		}
 


### PR DESCRIPTION
### Description of Change

Update the documentation for ResourceDictionary with info on the unexpected behavior of `ContainsKey`.

### Issues Fixed

None, just reducing the confusion documented in #13268.
