### PR TITLE
Fix reliability of RemoveLastPage test

### DIFF
--- a/src/Controls/tests/Core.UnitTests/NavigationPageLifecycleTests.cs
+++ b/src/Controls/tests/Core.UnitTests/NavigationPageLifecycleTests.cs
@@ -91,30 +91,23 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		[InlineData(true)]
 		public async Task RemoveLastPage(bool useMaui)
 		{
-			ContentPage initialPage = new ContentPage();
-			ContentPage pushedPage = new ContentPage();
+			var initialPage = new PageLifeCycleTests.LCPage();
+			var pushedPage = new PageLifeCycleTests.LCPage();
 
-			ContentPage initialPageAppearing = null;
-			ContentPage pageDisappeared = null;
-
-			NavigationPage nav = new TestNavigationPage(useMaui, initialPage);
+			var nav = new TestNavigationPage(useMaui, initialPage);
 			_ = new TestWindow(nav);
-			nav.SendAppearing();
-
-			initialPage.Appearing += (sender, _)
-				=> initialPageAppearing = (ContentPage)sender;
-
-			pushedPage.Disappearing += (sender, _)
-				=> pageDisappeared = (ContentPage)sender;
 
 			await nav.PushAsync(pushedPage);
-			Assert.Null(initialPageAppearing);
-			Assert.Null(pageDisappeared);
+			Assert.Equal(1, initialPage.AppearingCount);
+			Assert.Equal(1, pushedPage.AppearingCount);
+			Assert.Equal(0, pushedPage.DisappearingCount);
 
 			nav.Navigation.RemovePage(pushedPage);
+			await nav.NavigatingTask;
 
-			Assert.Equal(initialPageAppearing, initialPage);
-			Assert.Equal(pageDisappeared, pushedPage);
+			Assert.Equal(2, initialPage.AppearingCount);
+			Assert.Equal(1, pushedPage.AppearingCount);
+			Assert.Equal(1, pushedPage.DisappearingCount);
 		}
 
 		[Theory]

--- a/src/Controls/tests/Core.UnitTests/PageLifeCycleTests.cs
+++ b/src/Controls/tests/Core.UnitTests/PageLifeCycleTests.cs
@@ -215,7 +215,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.Equal(1, firstModalPage.AppearingCount);
 		}
 
-		class LCPage : ContentPage
+		public class LCPage : ContentPage
 		{
 			public NavigatedFromEventArgs NavigatedFromArgs { get; private set; }
 			public NavigatingFromEventArgs NavigatingFromArgs { get; private set; }


### PR DESCRIPTION
### Description of Change

The `RemoveLastPage` test occasionally fails on CI. My guess is that the `Appearing` event is firing from a queue'd property changed. The way this test was checking lifecycle events was odd in general. These changes should make this test more deterministic. 