### PR TITLE
Fix iOS ListView cell gone hidden (#11287)

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/iOS/CellTableViewCell.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/iOS/CellTableViewCell.cs
@@ -72,6 +72,13 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			else
 				reusableCell = tableView.DequeueReusableCell(id);
 
+			if (reusableCell != null && reusableCell.Hidden)
+			{
+				// set hidden to false doesn't work
+				// force recreate of the whole cell instead
+				reusableCell = null;
+			}
+
 			cell.Handler?.DisconnectHandler();
 			cell.ReusableCell = reusableCell;
 			cell.TableView = tableView;

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/iOS/CellTableViewCell.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/iOS/CellTableViewCell.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			else
 				reusableCell = tableView.DequeueReusableCell(id);
 
-			if (reusableCell != null && reusableCell.Hidden)
+			if (reusableCell is not null && reusableCell.Hidden)
 			{
 				// set hidden to false doesn't work
 				// force recreate of the whole cell instead


### PR DESCRIPTION
### Description of Change
Workaround iOS / MacOS ListView cell disappear when user scroll back and DequeueReusableCell return a hidden cell.
Force any hidden cell return by DequeueReusableCell which are hidden to create a new cell instead (set hidden to false doesn't work).

### Issues Fixed
Fixes #11287