### PR TITLE
[CI] Move the templates jobs to a yml template to be reusable.

### DIFF
--- a/eng/pipelines/common/maui-templates.yml
+++ b/eng/pipelines/common/maui-templates.yml
@@ -56,7 +56,10 @@ jobs:
             clean: all
           displayName: ${{ BuildPlatform.name }} ${{ TestTFM.tfm }} (${{ BuildConfiguration }})
           timeoutInMinutes: 240
-          condition: ${{ parameters.condition}}
+          condition: or(
+              ${{ parameters.condition}},
+              eq('${{ BuildConfiguration }}', 'Release')
+            )
           pool:
             name: ${{ BuildPlatform.poolName }}
             vmImage: ${{ BuildPlatform.vmImage }}

--- a/eng/pipelines/common/maui-templates.yml
+++ b/eng/pipelines/common/maui-templates.yml
@@ -1,0 +1,98 @@
+parameters:
+  - name: condition
+    default: true
+
+  - name: artifactName
+    type: string
+    default: nuget
+
+  - name: artefactItemPattern
+    type: string
+    default: '**/*.nupkg'
+
+  - name: uploadPrefix
+    type: string
+    default: ''
+
+  - name: BuildConfigurations
+    type: object
+    default:
+      - Debug
+      - Release
+
+  - name: BuildPlatforms
+    type: object
+    default:
+      - name: Windows
+        poolName: $(windowsNet6VmPool)
+        vmImage: $(windowsNet6VmImage)
+        bootsAndroid: $(Android.Msi)
+        bootsiOS: $(iOS.Msi)
+        artifact: build-windows
+      - name: macOS
+        poolName: $(macOSXNet6VmPool)
+        vmImage: $(macOSXNet6VmImage)
+        bootsAndroid: $(Android.Pkg)
+        bootsiOS: $(iOS.Pkg)
+        bootsMacCatalyst: $(MacCatalyst.Pkg)
+        artifact: build-macos
+
+  - name: TestTargetFrameworks
+    type: object
+    default:
+      - name: default
+        tfm: default
+      - name: net6
+        tfm: net6.0
+      - name: net7
+        tfm: net7.0
+
+jobs:
+  - ${{ each BuildPlatform in parameters.BuildPlatforms }}:
+    - ${{ each BuildConfiguration in parameters.BuildConfigurations }}:
+      - ${{ each TestTFM in parameters.TestTargetFrameworks }}:
+        - job: build_${{ TestTFM.name }}_${{ BuildPlatform.name }}_${{ BuildConfiguration }}
+          workspace:
+            clean: all
+          displayName: ${{ BuildPlatform.name }} ${{ TestTFM.tfm }} (${{ BuildConfiguration }})
+          timeoutInMinutes: 240
+          condition: ${{ parameters.condition}}
+          pool:
+            name: ${{ BuildPlatform.poolName }}
+            vmImage: ${{ BuildPlatform.vmImage }}
+            demands:
+              - macOS.Name -equals Monterey
+              - macOS.Architecture -equals x64
+              - Agent.HasDevices -equals False
+              - Agent.IsPaired -equals False
+          steps:
+            - template: provision.yml
+              parameters:
+                platform: ${{ BuildPlatform.name }}
+                poolName: ${{ BuildPlatform.poolName }}
+
+            - task: DownloadBuildArtifacts@0
+              displayName: 'Download Packages'
+              inputs:
+                artifactName: ${{ parameters.artifactName }}
+                itemPattern: ${{ parameters.artefactItemPattern }}
+                downloadPath: $(System.DefaultWorkingDirectory)/artifacts
+
+            - pwsh: Move-Item -Path artifacts\nuget\*.nupkg -Destination artifacts -Force
+              displayName: Move the downloaded artifacts
+
+            - pwsh: ./build.ps1 --target=dotnet-local-workloads --configuration="${{ BuildConfiguration }}" --verbosity=diagnostic
+              displayName: 'Install .NET (Local Workloads)'
+              retryCountOnTaskFailure: 3
+              env:
+                DOTNET_TOKEN: $(dotnetbuilds-internal-container-read-token)
+                PRIVATE_BUILD: $(PrivateBuild)
+
+            - pwsh: ./build.ps1 --target=dotnet-templates --configuration="${{ BuildConfiguration }}" --testtfm="${{ TestTFM.tfm }}" --verbosity=diagnostic
+              displayName: 'Build .NET MAUI Templates'
+
+            - task: PublishBuildArtifacts@1
+              condition: always()
+              displayName: publish artifacts
+              inputs:
+                ArtifactName: '${{ parameters.uploadPrefix }}${{ BuildPlatform.artifact }}'

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -265,8 +265,7 @@ stages:
           TestTargetFrameworks: ${{ parameters.TestTargetFrameworks }}
           condition: or(
             ${{ parameters.BuildEverything }},
-            ne(variables['Build.Reason'], 'PullRequest'),
-            eq('${{ BuildConfiguration }}', 'Release'))
+            ne(variables['Build.Reason'], 'PullRequest'))
 
   - template: common/security-compliance.yml
 

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -258,53 +258,15 @@ stages:
     displayName: Build .NET MAUI Templates
     dependsOn: pack_net
     jobs:
-      - ${{ each BuildPlatform in parameters.BuildPlatforms }}:
-        - ${{ each BuildConfiguration in parameters.BuildConfigurations }}:
-          - ${{ each TestTFM in parameters.TestTargetFrameworks }}:
-            - job: build_${{ TestTFM.name }}_${{ BuildPlatform.name }}_${{ BuildConfiguration }}
-              workspace:
-                clean: all
-              displayName: ${{ BuildPlatform.name }} ${{ TestTFM.tfm }} (${{ BuildConfiguration }})
-              timeoutInMinutes: 240
-              condition: or(
-                ${{ parameters.BuildEverything }},
-                ne(variables['Build.Reason'], 'PullRequest'),
-                eq('${{ BuildConfiguration }}', 'Release'))
-              pool:
-                name: ${{ BuildPlatform.poolName }}
-                vmImage: ${{ BuildPlatform.vmImage }}
-                demands:
-                  - macOS.Name -equals Monterey
-                  - macOS.Architecture -equals x64
-                  - Agent.HasDevices -equals False
-                  - Agent.IsPaired -equals False
-              steps:
-                - template: common/provision.yml
-                  parameters:
-                    platform: ${{ BuildPlatform.name }}
-                    poolName: ${{ BuildPlatform.poolName }}
-                    
-                - task: DownloadBuildArtifacts@0
-                  displayName: 'Download Packages'
-                  inputs:
-                    artifactName: nuget
-                    itemPattern: '**/*.nupkg'
-                    downloadPath: $(System.DefaultWorkingDirectory)/artifacts
-                - pwsh: Move-Item -Path artifacts\nuget\*.nupkg -Destination artifacts -Force
-                  displayName: Move the downloaded artifacts
-                - pwsh: ./build.ps1 --target=dotnet-local-workloads --configuration="${{ BuildConfiguration }}" --verbosity=diagnostic
-                  displayName: 'Install .NET (Local Workloads)'
-                  retryCountOnTaskFailure: 3
-                  env:
-                    DOTNET_TOKEN: $(dotnetbuilds-internal-container-read-token)
-                    PRIVATE_BUILD: $(PrivateBuild)
-                - pwsh: ./build.ps1 --target=dotnet-templates --configuration="${{ BuildConfiguration }}" --testtfm="${{ TestTFM.tfm }}" --verbosity=diagnostic
-                  displayName: 'Build .NET MAUI Templates'
-                - task: PublishBuildArtifacts@1
-                  condition: always()
-                  displayName: publish artifacts
-                  inputs:
-                    ArtifactName: ${{ BuildPlatform.artifact }}
+      - template: common/maui-templates.yml
+        parameters:
+          BuildConfigurations: ${{ parameters.BuildConfigurations }}
+          BuildPlatforms: ${{ parameters.BuildPlatforms }}
+          TestTargetFrameworks: ${{ parameters.TestTargetFrameworks }}
+          condition: or(
+            ${{ parameters.BuildEverything }},
+            ne(variables['Build.Reason'], 'PullRequest'),
+            eq('${{ BuildConfiguration }}', 'Release'))
 
   - template: common/security-compliance.yml
 


### PR DESCRIPTION
Move the jobs and the default values to a template, this will allow the megapipeline to reuse the template and be able to run the tests.

Some extra parameters have been added to allow the megapipeline to provide an upload prefix and the artefct names to download.


