### PR TITLE
Force menu rebuild when window is closed (#10702)

### DIFF
--- a/src/Core/src/Platform/iOS/MauiUIApplicationDelegate.Menu.cs
+++ b/src/Core/src/Platform/iOS/MauiUIApplicationDelegate.Menu.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.Versioning;
 using Foundation;
 using Microsoft.Extensions.DependencyInjection;
@@ -24,9 +26,43 @@ namespace Microsoft.Maui
 
 			MenuBuilder = builder;
 
-			var window = Window ?? this.GetWindow() ??
-				UIApplication.SharedApplication.GetWindow()?.Handler?.PlatformView as UIWindow;
+			UIWindow? window = null;
+			if (OperatingSystem.IsIOSVersionAtLeast(14))
+			{
+				// for iOS 14+ where active apperance is supported
+				var activeWindowScenes = new List<UIWindowScene>();
+				foreach (var scene in UIApplication.SharedApplication.ConnectedScenes)
+				{
+					if (scene is UIWindowScene windowScene &&
+						windowScene.TraitCollection.ActiveAppearance == UIUserInterfaceActiveAppearance.Active)
+					{
+						activeWindowScenes.Add(windowScene);
+					}
+				}
 
+				if (activeWindowScenes.Any())
+				{
+					// when a new window is created, some time more than 1 active window sence are returned
+					// we need to pick the newly created window in this case
+					// the order of window scene returned is not trustable, do not use last
+					// after some manual testing, windowing behaviour that is not ready yet is the newly created window
+					if (activeWindowScenes.Count > 1)
+					{
+						window = activeWindowScenes.FirstOrDefault(ws =>
+							ws.WindowingBehaviors is not null &&
+							!ws.WindowingBehaviors.Closable)
+								?.KeyWindow;
+					}
+					else
+						window = activeWindowScenes.First().KeyWindow;
+				}
+			}
+			else
+			{
+				// for iOS 13 where active apperance is not supported yet
+				window = Window ?? this.GetWindow() ??
+					UIApplication.SharedApplication.GetWindow()?.Handler?.PlatformView as UIWindow;
+			}
 			window?.GetWindow()?.Handler?.UpdateValue(nameof(IMenuBarElement.MenuBar));
 
 			MenuBuilder = null;

--- a/src/Core/src/Platform/iOS/MauiUIApplicationDelegate.Menu.cs
+++ b/src/Core/src/Platform/iOS/MauiUIApplicationDelegate.Menu.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.Versioning;
 using Foundation;
 using Microsoft.Extensions.DependencyInjection;
@@ -27,7 +26,7 @@ namespace Microsoft.Maui
 			MenuBuilder = builder;
 
 			UIWindow? window = null;
-			if (OperatingSystem.IsIOSVersionAtLeast(14))
+			if (OperatingSystem.IsMacCatalystVersionAtLeast(14))
 			{
 				// for iOS 14+ where active apperance is supported
 				var activeWindowScenes = new List<UIWindowScene>();
@@ -40,7 +39,7 @@ namespace Microsoft.Maui
 					}
 				}
 
-				if (activeWindowScenes.Any())
+				if (activeWindowScenes.Count > 0)
 				{
 					// when a new window is created, some time more than 1 active window sence are returned
 					// we need to pick the newly created window in this case
@@ -48,13 +47,17 @@ namespace Microsoft.Maui
 					// after some manual testing, windowing behaviour that is not ready yet is the newly created window
 					if (activeWindowScenes.Count > 1)
 					{
-						window = activeWindowScenes.FirstOrDefault(ws =>
-							ws.WindowingBehaviors is not null &&
-							!ws.WindowingBehaviors.Closable)
-								?.KeyWindow;
+						foreach (var ws in activeWindowScenes)
+						{
+							if (ws.WindowingBehaviors is not null && !ws.WindowingBehaviors.Closable)
+							{
+								window = ws.KeyWindow;
+								break;
+							}
+						}
 					}
 					else
-						window = activeWindowScenes.First().KeyWindow;
+						window = activeWindowScenes[0].KeyWindow;
 				}
 			}
 			else

--- a/src/Core/src/Platform/iOS/MauiUISceneDelegate.cs
+++ b/src/Core/src/Platform/iOS/MauiUISceneDelegate.cs
@@ -33,13 +33,18 @@ namespace Microsoft.Maui
 		{
 			MauiUIApplicationDelegate.Current?.Services?.InvokeLifecycleEvents<iOSLifecycle.SceneDidDisconnect>(del => del(scene));
 
-			if (Window is not null && Window.IsKeyWindow)
+			// for iOS 13 only where active apperance is not supported yet
+			// for iOS 14+, see DidUpdateCoordinateSpace
+			if (OperatingSystem.IsIOSVersionAtLeast(13) && !OperatingSystem.IsIOSVersionAtLeast(14))
 			{
-				// manually resign the key window and rebuild the menu
-				Window.ResignKeyWindow();
-				UIMenuSystem
-					.MainSystem
-					.SetNeedsRebuild();
+				if (Window is not null && Window.IsKeyWindow)
+				{
+					// manually resign the key window and rebuild the menu
+					Window.ResignKeyWindow();
+					UIMenuSystem
+						.MainSystem
+						.SetNeedsRebuild();
+				}
 			}
 		}
 
@@ -129,7 +134,23 @@ namespace Microsoft.Maui
 		[System.Runtime.Versioning.SupportedOSPlatform("tvos13.0")]
 		[System.Runtime.Versioning.SupportedOSPlatform("maccatalyst13.0")]
 		[Export("windowScene:didUpdateCoordinateSpace:interfaceOrientation:traitCollection:")]
-		public virtual void DidUpdateCoordinateSpace(UIWindowScene windowScene, IUICoordinateSpace previousCoordinateSpace, UIInterfaceOrientation previousInterfaceOrientation, UITraitCollection previousTraitCollection) =>
+		public virtual void DidUpdateCoordinateSpace(UIWindowScene windowScene, IUICoordinateSpace previousCoordinateSpace, UIInterfaceOrientation previousInterfaceOrientation, UITraitCollection previousTraitCollection)
+		{
 			GetServiceProvider()?.InvokeLifecycleEvents<iOSLifecycle.WindowSceneDidUpdateCoordinateSpace>(del => del(windowScene, previousCoordinateSpace, previousInterfaceOrientation, previousTraitCollection));
+
+			if (OperatingSystem.IsIOSVersionAtLeast(14))
+			{
+				// for iOS 14+ where active apperance is supported
+				var newActiveAppearance = windowScene.TraitCollection.ActiveAppearance;
+				if (newActiveAppearance != previousTraitCollection.ActiveAppearance &&
+					newActiveAppearance == UIUserInterfaceActiveAppearance.Active)
+				{
+					// if window went from inactive to active (become focused), rebuild the menu
+					UIMenuSystem
+						.MainSystem
+						.SetNeedsRebuild();
+				}
+			}
+		}
 	}
 }

--- a/src/Core/src/Platform/iOS/MauiUISceneDelegate.cs
+++ b/src/Core/src/Platform/iOS/MauiUISceneDelegate.cs
@@ -32,6 +32,15 @@ namespace Microsoft.Maui
 		public virtual void DidDisconnect(UIScene scene)
 		{
 			MauiUIApplicationDelegate.Current?.Services?.InvokeLifecycleEvents<iOSLifecycle.SceneDidDisconnect>(del => del(scene));
+
+			if (Window is not null && Window.IsKeyWindow)
+			{
+				// manually resign the key window and rebuild the menu
+				Window.ResignKeyWindow();
+				UIMenuSystem
+					.MainSystem
+					.SetNeedsRebuild();
+			}
 		}
 
 		[Export("stateRestorationActivityForScene:")]

--- a/src/Core/src/Platform/iOS/MauiUISceneDelegate.cs
+++ b/src/Core/src/Platform/iOS/MauiUISceneDelegate.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Maui
 
 			// for iOS 13 only where active apperance is not supported yet
 			// for iOS 14+, see DidUpdateCoordinateSpace
-			if (OperatingSystem.IsIOSVersionAtLeast(13) && !OperatingSystem.IsIOSVersionAtLeast(14))
+			if (!OperatingSystem.IsMacCatalystVersionAtLeast(14))
 			{
 				if (Window is not null && Window.IsKeyWindow)
 				{


### PR DESCRIPTION

### Description of Change
Manually resign the key window and force the menu bar rebuild when key window is closed, so that the menu bar in MacOS is shown correctly (if the window is close in the correct order it is created). This changes still doesn't fix menu bar showing incorrectly if user switch window focus in MacOS manually or user close window different than the order it created.

### Issues Fixed
Fixes #10702
