### PR TITLE
Allow SearchBar to take full width on Android

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/SearchBar/SearchBarTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/SearchBar/SearchBarTests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
-using Microsoft.Maui.DeviceTests.Stubs;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Platform;
 using Xunit;

--- a/src/Controls/tests/DeviceTests/Elements/SearchBar/SearchBarTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/SearchBar/SearchBarTests.cs
@@ -71,32 +71,5 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 #endif
-
-#if ANDROID
-		[Fact]
-		public async Task SearchBarTakesFullWidth()
-		{
-			SetupBuilder();
-
-			SearchBar searchBar = new();
-
-			ContentPage page = new()
-			{
-				Content = searchBar
-			};
-
-			NavigationPage navPage = new(new ContentPage());
-
-			await CreateHandlerAndAddToWindow<IWindowHandler>(navPage,
-				async (_) =>
-				{
-					await navPage.CurrentPage.Navigation.PushAsync(page);
-				});
-
-			Assert.NotEqual(-1, page.Width);
-			Assert.NotEqual(-1, searchBar.Width);
-			Assert.Equal(page.Width, searchBar.Width);
-		}
-#endif
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/SearchBar/SearchBarTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/SearchBar/SearchBarTests.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.DeviceTests.Stubs;
 using Microsoft.Maui.Handlers;
-using Microsoft.Maui.Hosting;
 using Microsoft.Maui.Platform;
 using Xunit;
 
@@ -12,21 +11,6 @@ namespace Microsoft.Maui.DeviceTests
 	[Category(TestCategory.SearchBar)]
 	public partial class SearchBarTests : ControlsHandlerTestBase
 	{
-		void SetupBuilder()
-		{
-			EnsureHandlerCreated(builder =>
-			{
-				builder.ConfigureMauiHandlers(handlers =>
-				{
-					handlers.AddHandler(typeof(Toolbar), typeof(ToolbarHandler));
-					handlers.AddHandler(typeof(SearchBar), typeof(SearchBarHandler));
-					handlers.AddHandler(typeof(NavigationPage), typeof(NavigationViewHandler));
-					handlers.AddHandler<Page, PageHandler>();
-					handlers.AddHandler<Window, WindowHandlerStub>();
-				});
-			});
-		}
-
 		[Theory]
 		[ClassData(typeof(TextTransformCases))]
 		public async Task InitialTextTransformApplied(string text, TextTransform transform, string expected)

--- a/src/Core/src/Platform/Android/MauiSearchView.cs
+++ b/src/Core/src/Platform/Android/MauiSearchView.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Maui.Platform
 		void Initialize()
 		{
 			SetIconifiedByDefault(false);
+			MaxWidth = int.MaxValue;
 
 			_queryEditor = this.GetFirstChildOfType<EditText>();
 

--- a/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.Android.cs
@@ -119,24 +119,28 @@ namespace Microsoft.Maui.DeviceTests
 		[Fact]
 		public async Task SearchBarTakesFullWidthByDefault()
 		{
-			var layout = new LayoutStub()
-			{
-				Width = 500
-			};
-
-			var searchbar = new SearchBarStub
-			{
-				Text = "My Search Term",
-			};
-
-			layout.Add(searchbar);
-
 			await InvokeOnMainThreadAsync(async () =>
 			{
+				var layout = new LayoutStub()
+				{
+					Width = 500
+				};
+
+				var searchbar = new SearchBarStub
+				{
+					Text = "My Search Term",
+				};
+
+				layout.Add(searchbar);
+
 				var layoutHandler = CreateHandler(layout);
 				await layoutHandler.PlatformView.AttachAndRun(() =>
 				{
-					Assert.Equal(layout.Width, searchbar.Width);
+					var layoutSize = layout.Measure(double.PositiveInfinity, double.PositiveInfinity);
+					var rect = new Rect(0, 0, layoutSize.Width, layoutSize.Height);
+					var searchbarSize = searchbar.Measure(rect.Width, rect.Height);
+				
+					Assert.Equal(layoutSize.Width, searchbarSize.Width);
 				});
 			});
 		}

--- a/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.Android.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Android.Text;
 using Android.Text.Method;
@@ -112,6 +113,31 @@ namespace Microsoft.Maui.DeviceTests
 				var editText = view.GetFirstChildOfType<EditText>();
 
 				Assert.NotNull(editText);
+			});
+		}
+
+		[Fact]
+		public async Task SearchBarTakesFullWidthByDefault()
+		{
+			var layout = new LayoutStub()
+			{
+				Width = 500
+			};
+
+			var searchbar = new SearchBarStub
+			{
+				Text = "My Search Term",
+			};
+
+			layout.Add(searchbar);
+
+			await InvokeOnMainThreadAsync(async () =>
+			{
+				var layoutHandler = CreateHandler(layout);
+				await layoutHandler.PlatformView.AttachAndRun(() =>
+				{
+					Assert.Equal(layout.Width, searchbar.Width);
+				});
 			});
 		}
 

--- a/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.Android.cs
@@ -139,7 +139,7 @@ namespace Microsoft.Maui.DeviceTests
 					var layoutSize = layout.Measure(double.PositiveInfinity, double.PositiveInfinity);
 					var rect = new Rect(0, 0, layoutSize.Width, layoutSize.Height);
 					var searchbarSize = searchbar.Measure(rect.Width, rect.Height);
-				
+
 					Assert.Equal(layoutSize.Width, searchbarSize.Width);
 				});
 			});


### PR DESCRIPTION
### Description of Change

By setting the `MaxWidth` to something big the `SearchView` can take full width. This is what I found being recommended in this case for Android. Don't necessarily like it, but other ways didn't seem to work. This makes the width consistent with how it was on Xamarin.Forms.

As a workaround you should be able to use this today: 

```csharp
#if ANDROID
Microsoft.Maui.Handlers.SearchBarHandler.Mapper.AppendToMapping("FullWidth", (handler, control) =>
{
	handler.PlatformView.MaxWidth = int.MaxValue;
});
#endif
```

You can put this code somewhere in the startup path of your app, doesn't really matter where.

### Issues Fixed

Fixes #7137