### PR TITLE
Deprecate via Handler2

### DIFF
--- a/src/Controls/samples/Controls.Sample.Sandbox/MainPage.xaml
+++ b/src/Controls/samples/Controls.Sample.Sandbox/MainPage.xaml
@@ -4,4 +4,7 @@
     x:Class="Maui.Controls.Sample.MainPage"
     xmlns:local="clr-namespace:Maui.Controls.Sample">
 
+    <VerticalStackLayout>
+        <Button Text="I am a button"></Button>
+    </VerticalStackLayout>
 </ContentPage>

--- a/src/Controls/src/Xaml/Controls.Xaml.csproj
+++ b/src/Controls/src/Xaml/Controls.Xaml.csproj
@@ -7,7 +7,7 @@
 		<IsPackable>true</IsPackable>
 		<IsTrimmable>false</IsTrimmable>
 		<_MauiDesignDllBuild Condition=" '$(OS)' != 'Unix' ">True</_MauiDesignDllBuild>
-		<NoWarn>$(NoWarn);CA2200;CS1591;RS0041</NoWarn>
+		<NoWarn>$(NoWarn);CA2200;CS1591;RS0041;RS0016</NoWarn>
 		<PackageId>Microsoft.Maui.Controls.Xaml</PackageId>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 	</PropertyGroup>

--- a/src/Controls/src/Xaml/Hosting/AppHostBuilderExtensions.cs
+++ b/src/Controls/src/Xaml/Hosting/AppHostBuilderExtensions.cs
@@ -219,7 +219,7 @@ namespace Microsoft.Maui.Controls.Hosting
 		{
 			builder.ConfigureMauiHandlers(handlers =>
 			{
-				handlers.AddHandler(typeof(Button), typeof(ButtonHandler2));
+				handlers.AddHandler(typeof(Button), typeof(ButtonHandler));
 			});
 
 			return builder;

--- a/src/Controls/src/Xaml/Hosting/AppHostBuilderExtensions.cs
+++ b/src/Controls/src/Xaml/Hosting/AppHostBuilderExtensions.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Maui.Controls.Hosting
 			handlersCollection.AddHandler<Application, ApplicationHandler>();
 			handlersCollection.AddHandler<ActivityIndicator, ActivityIndicatorHandler>();
 			handlersCollection.AddHandler<BoxView, ShapeViewHandler>();
-			handlersCollection.AddHandler<Button, ButtonHandler>();
+			handlersCollection.AddHandler<Button, ButtonHandler2>();
 			handlersCollection.AddHandler<CheckBox, CheckBoxHandler>();
 			handlersCollection.AddHandler<DatePicker, DatePickerHandler>();
 			handlersCollection.AddHandler<Editor, EditorHandler>();
@@ -210,6 +210,16 @@ namespace Microsoft.Maui.Controls.Hosting
 				services.AddService<FontImageSource>(svcs => new FontImageSourceService(svcs.GetRequiredService<IFontManager>(), svcs.CreateLogger<FontImageSourceService>()));
 				services.AddService<StreamImageSource>(svcs => new StreamImageSourceService(svcs.CreateLogger<StreamImageSourceService>()));
 				services.AddService<UriImageSource>(svcs => new UriImageSourceService(svcs.CreateLogger<UriImageSourceService>()));
+			});
+
+			return builder;
+		}
+
+		public static MauiAppBuilder UseNet7Handlers(this MauiAppBuilder builder)
+		{
+			builder.ConfigureMauiHandlers(handlers =>
+			{
+				handlers.AddHandler(typeof(Button), typeof(ButtonHandler2));
 			});
 
 			return builder;

--- a/src/Core/src/Core.csproj
+++ b/src/Core/src/Core.csproj
@@ -9,7 +9,7 @@
     <IsPackable>true</IsPackable>
     <IsTrimmable>false</IsTrimmable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <NoWarn>$(NoWarn);CS1591;RS0041;RS0026;RS0027</NoWarn>
+    <NoWarn>$(NoWarn);CS1591;RS0041;RS0026;RS0027;RS0016</NoWarn>
   </PropertyGroup>
 
   <Import Project="$(MauiSrcDirectory)MultiTargeting.targets" />

--- a/src/Core/src/Handlers/Button/NET8/ButtonHandler2.Android.cs
+++ b/src/Core/src/Handlers/Button/NET8/ButtonHandler2.Android.cs
@@ -1,0 +1,14 @@
+using System.Threading.Tasks;
+using Android.Content.Res;
+using Android.Graphics.Drawables;
+using Android.Views;
+using Google.Android.Material.Button;
+using Microsoft.Maui.Graphics;
+using AView = Android.Views.View;
+
+namespace Microsoft.Maui.Handlers
+{
+	public partial class ButtonHandler2 : ButtonHandler
+	{
+	}
+}

--- a/src/Core/src/Handlers/Button/NET8/ButtonHandler2.Standard.cs
+++ b/src/Core/src/Handlers/Button/NET8/ButtonHandler2.Standard.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace Microsoft.Maui.Handlers
+{
+	public partial class ButtonHandler2 : ButtonHandler
+	{
+	}
+}

--- a/src/Core/src/Handlers/Button/NET8/ButtonHandler2.Tizen.cs
+++ b/src/Core/src/Handlers/Button/NET8/ButtonHandler2.Tizen.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Threading.Tasks;
+using Tizen.NUI.BaseComponents;
+using Tizen.UIExtensions.NUI;
+
+namespace Microsoft.Maui.Handlers
+{
+	public partial class ButtonHandler2 : ButtonHandler
+	{
+	}
+}

--- a/src/Core/src/Handlers/Button/NET8/ButtonHandler2.Windows.cs
+++ b/src/Core/src/Handlers/Button/NET8/ButtonHandler2.Windows.cs
@@ -1,0 +1,90 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+
+namespace Microsoft.Maui.Handlers
+{
+	public partial class ButtonHandler2 : ViewHandler<IButton, FrameworkElement>
+	{
+		protected override FrameworkElement CreatePlatformView() => new StackPanel()
+		{
+			Children =
+			{
+				new Microsoft.UI.Xaml.Controls.TextBlock()
+			}
+		};
+
+		protected override void ConnectHandler(FrameworkElement platformView)
+		{
+			base.ConnectHandler(platformView);
+		}
+
+		protected override void DisconnectHandler(FrameworkElement platformView)
+		{
+			base.DisconnectHandler(platformView);
+		}
+
+		// This is a Windows-specific mapping
+		public static void MapBackground(IButtonHandler2 handler, IButton button)
+		{
+		}
+
+		public static void MapStrokeColor(IButtonHandler2 handler, IButtonStroke buttonStroke)
+		{
+		}
+
+		public static void MapStrokeThickness(IButtonHandler2 handler, IButtonStroke buttonStroke)
+		{
+		}
+
+		public static void MapCornerRadius(IButtonHandler2 handler, IButtonStroke buttonStroke)
+		{
+		}
+
+		public static void MapText(IButtonHandler2 handler, IText button)
+		{
+			((handler.PlatformView as StackPanel)!.Children[0] as TextBlock)!.Text = button.Text;
+		}
+
+		public static void MapTextColor(IButtonHandler2 handler, ITextStyle button)
+		{
+		}
+
+		public static void MapCharacterSpacing(IButtonHandler2 handler, ITextStyle button)
+		{
+		}
+
+		public static void MapFont(IButtonHandler2 handler, ITextStyle button)
+		{
+		}
+
+		public static void MapPadding(IButtonHandler2 handler, IButton button)
+		{
+		}
+
+		public static void MapImageSource(IButtonHandler2 handler, IImage image)
+		{
+
+		}
+
+		void OnSetImageSource(ImageSource? platformImageSource)
+		{
+		}
+
+		void OnClick(object sender, RoutedEventArgs e)
+		{
+			VirtualView?.Clicked();
+		}
+
+		void OnPointerPressed(object sender, PointerRoutedEventArgs e)
+		{
+			VirtualView?.Pressed();
+		}
+
+		void OnPointerReleased(object sender, PointerRoutedEventArgs e)
+		{
+			VirtualView?.Released();
+		}
+	}
+}

--- a/src/Core/src/Handlers/Button/NET8/ButtonHandler2.cs
+++ b/src/Core/src/Handlers/Button/NET8/ButtonHandler2.cs
@@ -1,0 +1,74 @@
+#if __IOS__ || MACCATALYST
+using PlatformView = UIKit.UIButton;
+#elif MONOANDROID
+using PlatformView = Google.Android.Material.Button.MaterialButton;
+#elif WINDOWS
+using PlatformView = Microsoft.UI.Xaml.FrameworkElement;
+#elif TIZEN
+using PlatformView = Tizen.UIExtensions.NUI.Button;
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0_OR_GREATER && !IOS && !ANDROID && !TIZEN)
+using PlatformView = System.Object;
+#endif
+
+using System;
+
+namespace Microsoft.Maui.Handlers
+{
+	public partial class ButtonHandler2 : IButtonHandler2
+	{
+#if WINDOWS
+		ImageSourcePartLoader? _imageSourcePartLoader;
+		public ImageSourcePartLoader ImageSourceLoader =>
+			_imageSourcePartLoader ??= new ImageSourcePartLoader(this, () => (VirtualView as IImageButton), OnSetImageSource);
+
+		public static IPropertyMapper<IImage, IButtonHandler2> ImageButtonMapper = new PropertyMapper<IImage, IButtonHandler2>()
+		{
+			[nameof(IImage.Source)] = MapImageSource
+		};
+
+		public static IPropertyMapper<ITextButton, IButtonHandler2> TextButtonMapper = new PropertyMapper<ITextButton, IButtonHandler2>()
+		{
+			[nameof(ITextStyle.CharacterSpacing)] = MapCharacterSpacing,
+			[nameof(ITextStyle.Font)] = MapFont,
+			[nameof(ITextStyle.TextColor)] = MapTextColor,
+			[nameof(IText.Text)] = MapText
+		};
+
+		public static IPropertyMapper<IButton, IButtonHandler2> Mapper = new PropertyMapper<IButton, IButtonHandler2>(TextButtonMapper, ImageButtonMapper, ViewHandler.ViewMapper)
+		{
+			[nameof(IButton.Background)] = MapBackground,
+			[nameof(IButton.Padding)] = MapPadding,
+			[nameof(IButtonStroke.StrokeThickness)] = MapStrokeThickness,
+			[nameof(IButtonStroke.StrokeColor)] = MapStrokeColor,
+			[nameof(IButtonStroke.CornerRadius)] = MapCornerRadius
+		};
+
+		public static CommandMapper<IButton, IButtonHandler2> CommandMapper = new(ViewCommandMapper);
+#endif
+
+		public ButtonHandler2() : base(Mapper, CommandMapper)
+		{
+
+		}
+
+		public ButtonHandler2(IPropertyMapper? mapper)
+			: base(mapper ?? Mapper, CommandMapper)
+		{
+		}
+
+		public ButtonHandler2(IPropertyMapper? mapper, CommandMapper? commandMapper)
+			: base(mapper ?? Mapper, commandMapper ?? CommandMapper)
+		{
+		}
+
+#if WINDOWS
+		IButton IButtonHandler2.VirtualView => VirtualView;
+
+		PlatformView IButtonHandler2.PlatformView => PlatformView;
+#else
+		IButton IButtonHandler.VirtualView => VirtualView;
+
+		PlatformView IButtonHandler.PlatformView => PlatformView;
+#endif
+	}
+}

--- a/src/Core/src/Handlers/Button/NET8/ButtonHandler2.iOS.cs
+++ b/src/Core/src/Handlers/Button/NET8/ButtonHandler2.iOS.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.Maui.Graphics;
+using UIKit;
+
+namespace Microsoft.Maui.Handlers
+{
+	public partial class ButtonHandler2 : ButtonHandler
+	{
+
+	}
+}

--- a/src/Core/src/Handlers/Button/NET8/IButtonHandler2.cs
+++ b/src/Core/src/Handlers/Button/NET8/IButtonHandler2.cs
@@ -1,0 +1,28 @@
+﻿#if __IOS__ || MACCATALYST
+using PlatformView = UIKit.UIButton;
+#elif MONOANDROID
+using PlatformView = Google.Android.Material.Button.MaterialButton;
+#elif WINDOWS
+using PlatformView = Microsoft.UI.Xaml.FrameworkElement;
+#elif TIZEN
+using PlatformView = Tizen.UIExtensions.NUI.Button;
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0_OR_GREATER && !IOS && !ANDROID && !TIZEN)
+using PlatformView = System.Object;
+#endif
+
+namespace Microsoft.Maui.Handlers
+{
+#if WINDOWS
+	public partial interface IButtonHandler2 : IViewHandler
+#else
+	public partial interface IButtonHandler2 : IButtonHandler
+#endif
+	{
+
+#if WINDOWS
+		new PlatformView PlatformView { get; }
+		new IButton VirtualView { get; }
+		ImageSourcePartLoader ImageSourceLoader { get; }
+#endif
+	}
+}


### PR DESCRIPTION
### Description of Change

This PR is for discussion purposes only. 
This is a spike of what it would look like to deprecate a handler via `Handler<num>`

An alternative approach here would be to isolate the handler via namespace

`Microsoft.Maui.Platform.NET8`

- I've moved all handlers (even ones that didn't change ) to a ButtonHandler2. The main reason being symmetry of `Mapper` access so users don't have to if/def one for the other.
- Handlers that are the same inherit from the original handlers so they maintain the same behavior
  - I'm realizing as I type this thought that this probably makes deprecation impossible so we can't do that.