### PR TITLE
Reinstate WebView cookie functionality for Android & iOS

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Controls/WebViewPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/WebViewPage.xaml
@@ -135,9 +135,15 @@
                     <Label
                         Text="Platform Specifics"
                         Style="{StaticResource Headline}"/>
+                    <Label
+                        Text="Mixed Content Mode"
+                        Style="{StaticResource Headline}"/>
                     <Button
                         Text="Allow MixedContentMode"
                         Clicked="OnAllowMixedContentClicked"/>
+                    <Label
+                        Text="Zoom Controls"
+                        Style="{StaticResource Headline}"/>
                     <Button
                         Text="Enable Zoom Controls"
                         Clicked="OnEnableZoomControlsClicked"/>

--- a/src/Core/src/Handlers/WebView/WebViewHandler.Android.cs
+++ b/src/Core/src/Handlers/WebView/WebViewHandler.Android.cs
@@ -149,7 +149,7 @@ namespace Microsoft.Maui.Handlers
 			if (url == AssetBaseUrl)
 				return false;
 
-			// TODO: Sync Cookies
+			SyncPlatformCookies(url);
 			bool cancel = VirtualView.Navigating(CurrentNavigationEvent, url);
 
 			// if the user disconnects from the handler we want to exit

--- a/src/Core/src/Handlers/WebView/WebViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/WebView/WebViewHandler.iOS.cs
@@ -174,7 +174,7 @@ namespace Microsoft.Maui.Handlers
 			}
 		}
 
-		bool HasCookiesToLoad(string url)
+		internal bool HasCookiesToLoad(string url)
 		{
 			var uri = CreateUriForCookies(url);
 
@@ -244,7 +244,7 @@ namespace Microsoft.Maui.Handlers
 			await SyncPlatformCookiesAsync(url);
 		}
 
-		async Task SyncPlatformCookiesAsync(string url)
+		internal async Task SyncPlatformCookiesAsync(string url)
 		{
 			var uri = CreateUriForCookies(url);
 

--- a/src/Core/src/Platform/Android/MauiWebViewClient.cs
+++ b/src/Core/src/Platform/Android/MauiWebViewClient.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Maui.Platform
 
 		public MauiWebViewClient(WebViewHandler handler)
 		{
-			_handler = handler ?? throw new ArgumentNullException("handler");
+			_handler = handler ?? throw new ArgumentNullException(nameof(handler));
 
 			_navigationResult = WebNavigationResult.Success;
 		}
@@ -24,7 +24,10 @@ namespace Microsoft.Maui.Platform
 			if (_handler?.VirtualView == null || url == WebViewHandler.AssetBaseUrl)
 				return;
 
-			// TODO: Sync Cookies
+			if (!string.IsNullOrWhiteSpace(url))
+			{
+				_handler.SyncPlatformCookiesToVirtualView(url);
+			}
 
 			var cancel = false;
 

--- a/src/Core/src/Platform/iOS/MauiWKWebView.cs
+++ b/src/Core/src/Platform/iOS/MauiWKWebView.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Maui.Platform
 				LoadHtmlString(html, baseUrl == null ? new NSUrl(NSBundle.MainBundle.BundlePath, true) : new NSUrl(baseUrl, true));
 		}
 
-		private async Task LoadUrlAsync(string? url)
+		async Task LoadUrlAsync(string? url)
 		{
 			try
 			{

--- a/src/Core/src/Platform/iOS/MauiWKWebView.cs
+++ b/src/Core/src/Platform/iOS/MauiWKWebView.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Maui.Platform
 				LoadHtmlString(html, baseUrl == null ? new NSUrl(NSBundle.MainBundle.BundlePath, true) : new NSUrl(baseUrl, true));
 		}
 
-		public async void LoadUrl(string? url)
+		private async Task LoadUrlAsync(string? url)
 		{
 			try
 			{
@@ -100,11 +100,16 @@ namespace Microsoft.Maui.Platform
 				var safeFullUri = new Uri(safeHostUri, safeRelativeUri);
 				NSUrlRequest request = new NSUrlRequest(new NSUrl(safeFullUri.AbsoluteUri));
 
-				if (_handler.TryGetTarget(out var handler)) {
-				    if (handler.HasCookiesToLoad(safeFullUri.AbsoluteUri) && !(OperatingSystem.IsIOSVersionAtLeast(11) || OperatingSystem.IsTvOSVersionAtLeast(11))) 
-				        return;
-				    await handler.SyncPlatformCookiesAsync(safeFullUri.AbsoluteUri);
-				} 
+				if (_handler.TryGetTarget(out var handler))
+				{
+					if (handler.HasCookiesToLoad(safeFullUri.AbsoluteUri) &&
+						!(OperatingSystem.IsIOSVersionAtLeast(11) || OperatingSystem.IsTvOSVersionAtLeast(11)))
+					{
+						return;
+					}
+
+					await handler.SyncPlatformCookiesAsync(safeFullUri.AbsoluteUri);
+				}
 
 				LoadRequest(request);
 			}
@@ -128,6 +133,11 @@ namespace Microsoft.Maui.Platform
 				if (_handler.TryGetTarget(out var handler))
 					handler.MauiContext?.CreateLogger<MauiWKWebView>()?.LogWarning(nameof(MauiWKWebView), $"Unable to Load Url {url}: {exc}");
 			}
+		}
+
+		public void LoadUrl(string? url)
+		{
+			LoadUrlAsync(url).FireAndForget();
 		}
 
 		// https://developer.apple.com/forums/thread/99674

--- a/src/Core/src/Platform/iOS/MauiWKWebView.cs
+++ b/src/Core/src/Platform/iOS/MauiWKWebView.cs
@@ -100,13 +100,11 @@ namespace Microsoft.Maui.Platform
 				var safeFullUri = new Uri(safeHostUri, safeRelativeUri);
 				NSUrlRequest request = new NSUrlRequest(new NSUrl(safeFullUri.AbsoluteUri));
 
-				_ = _handler.TryGetTarget(out var handler);
-
-				if ((handler?.HasCookiesToLoad(safeFullUri.AbsoluteUri) ?? false) && !(OperatingSystem.IsIOSVersionAtLeast(11) || OperatingSystem.IsTvOSVersionAtLeast(11)))
-					return;
-
-				if (handler is not null)
-					await handler.SyncPlatformCookiesAsync(safeFullUri.AbsoluteUri);
+				if (_handler.TryGetTarget(out var handler)) {
+				    if (handler.HasCookiesToLoad(safeFullUri.AbsoluteUri) && !(OperatingSystem.IsIOSVersionAtLeast(11) || OperatingSystem.IsTvOSVersionAtLeast(11))) 
+				        return;
+				    await handler.SyncPlatformCookiesAsync(safeFullUri.AbsoluteUri);
+				} 
 
 				LoadRequest(request);
 			}

--- a/src/Core/src/Platform/iOS/MauiWKWebView.cs
+++ b/src/Core/src/Platform/iOS/MauiWKWebView.cs
@@ -100,11 +100,12 @@ namespace Microsoft.Maui.Platform
 				var safeFullUri = new Uri(safeHostUri, safeRelativeUri);
 				NSUrlRequest request = new NSUrlRequest(new NSUrl(safeFullUri.AbsoluteUri));
 
-				if (_handler.TryGetTarget(out var handler)) {
-				    if (handler.HasCookiesToLoad(safeFullUri.AbsoluteUri) && !(OperatingSystem.IsIOSVersionAtLeast(11) || OperatingSystem.IsTvOSVersionAtLeast(11))) 
-				        return;
-				    await handler.SyncPlatformCookiesAsync(safeFullUri.AbsoluteUri);
-				} 
+				if (_handler.TryGetTarget(out var handler))
+				{
+					if (handler.HasCookiesToLoad(safeFullUri.AbsoluteUri) && !(OperatingSystem.IsIOSVersionAtLeast(11) || OperatingSystem.IsTvOSVersionAtLeast(11)))
+						return;
+					await handler.SyncPlatformCookiesAsync(safeFullUri.AbsoluteUri);
+				}
 
 				LoadRequest(request);
 			}


### PR DESCRIPTION
### Description of Change

While working on #13518 I noticed that cookies weren't working for iOS and Android as well. Somehow there were still TODOs in the code for that. This PR reinstates the cookie functionality for iOS and Android.

When #13518 is merged, that adds a section to the WebView sample gallery that allows you to test this easier. 

### Issues Fixed

Fixes #12896