### PR TITLE
Update Fabricbot backlog messaging

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -1351,7 +1351,7 @@
           {
             "name": "addReply",
             "parameters": {
-              "comment": "We've moved this issue to the Backlog milestone. This means that it is not going to be worked on for the coming release. We will reassess the backlog following the current release and consider this item at that time. To learn more about our issue management process and to have better expectation regarding different types of issues you can read our [Triage Process](https://github.com/dotnet/maui/blob/main/docs/TriageProcess.md)."
+              "comment": "We've added this issue to our backlog, and we will work to address it as time and resources allow. If you have any additional information or questions about this issue, please leave a comment. For additional info about issue management, please read our [Triage Process] (https://github.com/dotnet/maui/blob/main/docs/TriageProcess.md)."
             }
           }
         ]


### PR DESCRIPTION
### Description of Change

The current messaging when putting an issue in the backlog wasn't correct. Putting an issue in the backlog does not necessarily mean that it won't be worked on soon. This removes some of that messaging to hopefully avoid any confusion and frustration.
