### PR TITLE
[C] Properly set SelectedItem and Index

### DIFF
--- a/src/Controls/src/Core/Picker.cs
+++ b/src/Controls/src/Core/Picker.cs
@@ -340,27 +340,27 @@ namespace Microsoft.Maui.Controls
 		{
 			if (ItemsSource != null)
 			{
-				SelectedIndex = ItemsSource.IndexOf(selectedItem);
+				SetValueCore(SelectedIndexProperty, ItemsSource.IndexOf(selectedItem));
 				return;
 			}
-			SelectedIndex = Items.IndexOf(selectedItem);
+			SetValueCore(SelectedIndexProperty, Items.IndexOf(selectedItem));
 		}
 
 		void UpdateSelectedItem(int index)
 		{
 			if (index == -1)
 			{
-				SelectedItem = null;
+				SetValueCore(SelectedItemProperty, null);
 				return;
 			}
 
 			if (ItemsSource != null)
 			{
-				SelectedItem = ItemsSource[index];
+				SetValueCore(SelectedItemProperty, ItemsSource[index]);
 				return;
 			}
 
-			SelectedItem = Items[index];
+			SetValueCore(SelectedItemProperty, Items[index]);
 		}
 
 		/// <inheritdoc/>


### PR DESCRIPTION
### Description of Change

Avoid clearing bindings, by setting the BP instead of the property

### Issues Fixed

fixes #6571
