### PR TITLE
Fixed RadioButtonGallery TemplateFromStyle page.

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Controls/RadioButtonGalleries/TemplateFromStyle.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/RadioButtonGalleries/TemplateFromStyle.xaml
@@ -7,7 +7,7 @@
     <ContentPage.Resources>
 
         <ControlTemplate x:Key="CalendarRadioTemplate">
-            <Frame BorderColor="#F3F2F1" BackgroundColor="#F3F2F1" HasShadow="False" 
+            <Border Stroke="#F3F2F1" BackgroundColor="#F3F2F1"
                    HeightRequest="100" WidthRequest="100" HorizontalOptions="Start" VerticalOptions="Start" Padding="0">
 
                 <VisualStateManager.VisualStateGroups>
@@ -16,7 +16,7 @@
 
                             <VisualState x:Name="Checked">
                                 <VisualState.Setters>
-                                    <Setter Property="BorderColor" Value="#FF3300"/>
+                                    <Setter Property="Stroke" Value="#FF3300"/>
                                     <Setter TargetName="Check" Property="Opacity" Value="1"/>
                                 </VisualState.Setters>
                             </VisualState>
@@ -24,7 +24,7 @@
                             <VisualState x:Name="Unchecked">
                                 <VisualState.Setters>
                                     <Setter Property="BackgroundColor" Value="#f3f2f1"/>
-                                    <Setter Property="BorderColor" Value="#f3f2f1"/>
+                                    <Setter Property="Stroke" Value="#f3f2f1"/>
                                     <Setter TargetName="Check" Property="Opacity" Value="0"/>
                                 </VisualState.Setters>
                             </VisualState>
@@ -33,14 +33,14 @@
                     </VisualStateGroupList>
                 </VisualStateManager.VisualStateGroups>
 
-                <Grid Margin="4" WidthRequest="100">
+                <Grid Margin="4" WidthRequest="100" Padding="2">
                     <Grid WidthRequest="18" HeightRequest="18" HorizontalOptions="End" VerticalOptions="Start">
                         <Ellipse Stroke="Blue" WidthRequest="16" HeightRequest="16" StrokeThickness="0.5" VerticalOptions="Center" HorizontalOptions="Center" Fill="White" />
                         <Ellipse x:Name="Check" WidthRequest="8" HeightRequest="8" Fill="Blue" VerticalOptions="Center" HorizontalOptions="Center" />
                     </Grid>
                     <ContentPresenter></ContentPresenter>
                 </Grid>
-            </Frame>
+            </Border>
         </ControlTemplate>
 
         <Style TargetType="RadioButton">


### PR DESCRIPTION
### Description of Change
Since we changed RadioButton's default control template to use Border instead of Frame, and the sample code has been changed in the official documentation, I changed it as well in our Controls.Sample app and updated the values accordingly.

### Issues Fixed
On Android, the "check mark" inner ellipse would not draw when you click anywhere within the frame, but were able to outside the frame. See #6938.

Demo:
[templateFromStyleFixVid.webm](https://user-images.githubusercontent.com/89540402/223614886-3353138c-b4b0-4be7-a775-f4b880a0baff.webm)

