### PR TITLE
Skip GradientBackgroundInitializesCorrectly on iOS

### DIFF
--- a/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.iOS.cs
@@ -11,8 +11,11 @@ namespace Microsoft.Maui.DeviceTests
 {
 	public partial class SearchBarHandlerTests
 	{
-		[Theory(DisplayName = "Gradient Background Initializes Correctly")]
-
+		[Theory(DisplayName = "Gradient Background Initializes Correctly"
+#if IOS || MACCATALYST
+			, Skip = "This test is currently invalid https://github.com/dotnet/maui/issues/11948"
+#endif
+		)]
 		[InlineData(0xFFFF0000, 0xFFFE2500)]
 		[InlineData(0xFF00FF00, 0xFF04F800)]
 		[InlineData(0xFF0000FF, 0xFF0432FE)]


### PR DESCRIPTION
### Description of Change

https://github.com/dotnet/maui/pull/13266/files#diff-130f37295a7c9c6dc0456a3f97176b4db27d3467fdb9a355d2fb3a2fb1052a87R19 added this test back into the mix but it looks like it's currently failing on iOS14 which is breaking our builds.

This PR just re-skips this test for iOS until we can fix the test or code to work on iOS 14.