### PR TITLE
[Windows] Fix ClearButtonVisibility and VerticalTextAlignment issues with invisible Entry

### DIFF
--- a/src/Core/src/Handlers/Entry/EntryHandler.Windows.cs
+++ b/src/Core/src/Handlers/Entry/EntryHandler.Windows.cs
@@ -34,12 +34,12 @@ namespace Microsoft.Maui.Handlers
 		{
 			platformView.KeyUp += OnPlatformKeyUp;
 			platformView.TextChanged += OnPlatformTextChanged;
-			platformView.Loaded += OnPlatformLoaded;
+			platformView.SizeChanged += OnPlatformViewSizeChanged;
 		}
 
 		protected override void DisconnectHandler(TextBox platformView)
 		{
-			platformView.Loaded -= OnPlatformLoaded;
+			platformView.SizeChanged -= OnPlatformViewSizeChanged;
 			platformView.KeyUp -= OnPlatformKeyUp;
 			platformView.TextChanged -= OnPlatformTextChanged;
 
@@ -139,8 +139,8 @@ namespace Microsoft.Maui.Handlers
 			if (VirtualView.SelectionLength != selectedTextLength)
 				VirtualView.SelectionLength = selectedTextLength;
 		}
-
-		void OnPlatformLoaded(object sender, RoutedEventArgs e) =>
+		
+		void OnPlatformViewSizeChanged(object sender, SizeChangedEventArgs e) =>
 			MauiTextBox.InvalidateAttachedProperties(PlatformView);
 	}
 }


### PR DESCRIPTION
### Description of Change

Fix `ClearButtonVisibility` and `VerticalTextAlignment` issues with invisible Entry on Windows.

ClearButtonVisibility
![fix-clearbutton-windows](https://user-images.githubusercontent.com/6755973/223773955-86460318-002e-4a4f-aee6-76e463e22c62.gif)

VerticalTextAlignment
![fix-verticaltext-windows](https://user-images.githubusercontent.com/6755973/223773780-2d17d714-3e7b-4dc4-8f29-9903d0cf9930.gif)

![image](https://user-images.githubusercontent.com/6755973/223772820-db7938d2-58ea-40d2-a4f6-ee4c24904b1d.png)

### Issues Fixed

Fixes #13714
Fixes #13743