### PR TITLE
[controls] fix memory leak in `VisualElement.Clip`

### DIFF
--- a/src/Controls/src/Core/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement.cs
@@ -98,34 +98,61 @@ namespace Microsoft.Maui.Controls
 
 		void NotifyClipChanges()
 		{
-			if (Clip != null)
+			var clip = Clip;
+			if (clip != null)
 			{
-				Clip.PropertyChanged += OnClipChanged;
-
-				if (Clip is GeometryGroup geometryGroup)
-					geometryGroup.InvalidateGeometryRequested += InvalidateGeometryRequested;
+				var proxy = _clipProxy ??= new();
+				proxy.Subscribe(clip, (sender, e) => OnPropertyChanged(nameof(Clip)));
 			}
 		}
 
 		void StopNotifyingClipChanges()
 		{
-			if (Clip != null)
+			_clipProxy?.Unsubscribe();
+		}
+
+		class WeakClipChangedProxy : WeakEventProxy<Geometry, EventHandler>
+		{
+			void OnClipChanged(object sender, EventArgs e)
 			{
-				Clip.PropertyChanged -= OnClipChanged;
-
-				if (Clip is GeometryGroup geometryGroup)
-					geometryGroup.InvalidateGeometryRequested -= InvalidateGeometryRequested;
+				if (TryGetHandler(out var handler))
+				{
+					handler(sender, e);
+				}
+				else
+				{
+					Unsubscribe();
+				}
 			}
-		}
 
-		void OnClipChanged(object sender, PropertyChangedEventArgs e)
-		{
-			OnPropertyChanged(nameof(Clip));
-		}
+			public override void Subscribe(Geometry source, EventHandler handler)
+			{
+				if (TryGetSource(out var s))
+				{
+					s.PropertyChanged -= OnClipChanged;
 
-		void InvalidateGeometryRequested(object sender, EventArgs e)
-		{
-			OnPropertyChanged(nameof(Clip));
+					if (s is GeometryGroup g)
+						g.InvalidateGeometryRequested -= OnClipChanged;
+				}
+
+				source.PropertyChanged += OnClipChanged;
+				if (source is GeometryGroup geometryGroup)
+					geometryGroup.InvalidateGeometryRequested += OnClipChanged;
+
+				base.Subscribe(source, handler);
+			}
+
+			public override void Unsubscribe()
+			{
+				if (TryGetSource(out var s))
+				{
+					s.PropertyChanged -= OnClipChanged;
+
+					if (s is GeometryGroup g)
+						g.InvalidateGeometryRequested -= OnClipChanged;
+				}
+				base.Unsubscribe();
+			}
 		}
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/VisualElement.xml" path="//Member[@MemberName='VisualProperty']/Docs/*" />
@@ -247,9 +274,14 @@ namespace Microsoft.Maui.Controls
 					(bindable as VisualElement)?.NotifyBackgroundChanges();
 			});
 
-		readonly WeakBackgroundChangedProxy _backgroundProxy = new();
+		WeakBackgroundChangedProxy _backgroundProxy = null;
+		WeakClipChangedProxy _clipProxy = null;
 
-		~VisualElement() => _backgroundProxy.Unsubscribe();
+		~VisualElement()
+		{
+			_clipProxy?.Unsubscribe();
+			_backgroundProxy?.Unsubscribe();
+		}
 
 		void NotifyBackgroundChanges()
 		{
@@ -260,7 +292,8 @@ namespace Microsoft.Maui.Controls
 			if (background != null)
 			{
 				SetInheritedBindingContext(background, BindingContext);
-				_backgroundProxy.Subscribe(background, (sender, e) => OnPropertyChanged(nameof(Background)));
+				var proxy = _backgroundProxy ??= new();
+				proxy.Subscribe(background, (sender, e) => OnPropertyChanged(nameof(Background)));
 			}
 		}
 
@@ -273,7 +306,7 @@ namespace Microsoft.Maui.Controls
 			if (background != null)
 			{
 				SetInheritedBindingContext(background, null);
-				_backgroundProxy.Unsubscribe();
+				_backgroundProxy?.Unsubscribe();
 			}
 		}
 


### PR DESCRIPTION
This is very much related to 58a42e5. If you:

1. Define a `<RectangleGeometry />` as a `StaticResource` at the application-level.

2. Use the `StaticResource` on `VisualElement.Clip`.

3. The `VisualElement` will live forever.

I could reproduce this in a unit test.

I used the same technique in 58a42e5, except for one small change. The "proxy" member fields are now allowed to be `null`, so these small objects should only be created on-demand now. I added appropriate null checks for this as well.
