### PR TITLE
FilePicker on Mac Catalyst does not always return the file picked

### DIFF
--- a/src/Essentials/src/FilePicker/FilePicker.ios.cs
+++ b/src/Essentials/src/FilePicker/FilePicker.ios.cs
@@ -38,11 +38,13 @@ namespace Microsoft.Maui.Storage
 				PickHandler = urls => GetFileResults(urls, tcs)
 			};
 
+#if !MACCATALYST
 			if (documentPicker.PresentationController != null)
 			{
 				documentPicker.PresentationController.Delegate =
 					new UIPresentationControllerDelegate(() => GetFileResults(null, tcs));
 			}
+#endif
 
 			var parentController = WindowStateManager.Default.GetCurrentUIViewController(true);
 


### PR DESCRIPTION
### Description of Change

I'm creating this PR just to spark some discussion about the #11088 issue. The removed lines fixed the issue for me (on Mac Ventura 13.1 arm64). The reason why #11088 happens is because [the](https://github.com/dotnet/maui/blob/ae20455793142ae0034bcfdf8f810ca66aec782a/src/Essentials/src/FilePicker/FilePicker.ios.cs#L36-L39) [two](https://github.com/dotnet/maui/blob/ae20455793142ae0034bcfdf8f810ca66aec782a/src/Essentials/src/FilePicker/FilePicker.ios.cs#L41-L45) delegates compete with each other and if [this delegate](https://github.com/dotnet/maui/blob/ae20455793142ae0034bcfdf8f810ca66aec782a/src/Essentials/src/FilePicker/FilePicker.ios.cs#L41-L45) wins, then no file is picked.

I don't have deeper understanding of the code so that's as much as I know. Also I don't have an iOS device/environment at my disposal to really test it. I tested it only on Mac Ventura 13.1.

Anyway, my hope is that someone will know how to finish this PR.

### Issues Fixed

Fixes #11088
