### PR TITLE
Add references to Blazor Hybrid in .NET MAUI Templates

### DIFF
--- a/src/Templates/src/templates/maui-blazor/.template.config/template.json
+++ b/src/Templates/src/templates/maui-blazor/.template.config/template.json
@@ -1,12 +1,12 @@
 {
     "$schema": "http://json.schemastore.org/template",
     "author": "Microsoft",
-    "classifications": [ "MAUI", "Android", "iOS", "macOS", "Mac Catalyst", "Windows", "Tizen", "Blazor" ],
+    "classifications": [ "MAUI", "Android", "iOS", "macOS", "Mac Catalyst", "Windows", "Tizen", "Blazor", "Blazor Hybrid" ],
     "identity": "Microsoft.Maui.BlazorApp.CSharp.DOTNET_TFM_VERSION_VALUE",
     "groupIdentity": "Microsoft.Maui.BlazorApp",
     "precedence": "DOTNET_TFM_VERSION_MAJOR_VALUE",
-    "name": ".NET MAUI Blazor App",
-    "description": "A project for creating a .NET MAUI application for iOS, Android, Mac Catalyst, WinUI, and Tizen using Blazor",
+    "name": ".NET MAUI Blazor Hybrid App",
+    "description": "A project for creating a .NET MAUI application for iOS, Android, Mac Catalyst, WinUI, and Tizen using Blazor Hybrid",
     "shortName": "maui-blazor",
     "tags": {
       "language": "C#",


### PR DESCRIPTION
### Description of Change

Adds references to Blazor Hybrid to make the .NET MAUI Blazor templates more discoverable and connected to other public content.

### Issues Fixed

Fixes #13804