### PR TITLE
[vs-workload] Use variable to control VSMAN name

### DIFF
--- a/src/Workload/Microsoft.NET.Sdk.Maui/Microsoft.NET.Sdk.Maui.csproj
+++ b/src/Workload/Microsoft.NET.Sdk.Maui/Microsoft.NET.Sdk.Maui.csproj
@@ -88,7 +88,7 @@
     <ItemGroup>
       <_WorkloadPropsReplacements Include="@PACK_VERSION_LONG@"     NewValue="$(PackageReferenceVersion)" />
       <_WorkloadPropsReplacements Include="@VS_COMPONENT_VERSION@"  NewValue="$(VSComponentVersion)" />
-      <_WorkloadPropsReplacements Include="@VSMAN_VERSION@"         NewValue="net7.0" /> <!-- TODO: Replace with $(_MauiDotNetTfm) -->
+      <_WorkloadPropsReplacements Include="@VSMAN_VERSION@"         NewValue="$(_MauiDotNetTfm)" />
     </ItemGroup>
     <Copy
       SourceFiles="$(MauiRootDirectory)eng/automation/vs-workload.template.props"


### PR DESCRIPTION
In .NET 8 we will want our VSMAN files to be versioned with a `.net8.0` suffix.