### PR TITLE
Add HostIdentifier for mauilib template to prevent warning during creation

### DIFF
--- a/src/Templates/src/templates/maui-lib/.template.config/template.json
+++ b/src/Templates/src/templates/maui-lib/.template.config/template.json
@@ -47,6 +47,10 @@
         ],
         "replaces": "DOTNET_TFM",
         "defaultValue": "DOTNET_TFM_VALUE"
+      },
+      "HostIdentifier": {
+          "type": "bind",
+          "binding": "HostIdentifier"
       }
     },
     "defaultName": "MauiLib1"


### PR DESCRIPTION
### Description of Change

This adds a binding to the `HostIdentifier` variable in the template so that it identifies the creating application correctly and therefore does not try to execute the opening of a cs file while creating the template from the command-line which will then in turn trigger a warning.

### Issues Fixed

Fixes #4994