### PR TITLE
Remove unsupported UIDeviceFamily for Mac Catalyst

### DIFF
--- a/src/Templates/src/templates/maui-blazor/Platforms/MacCatalyst/Info.plist
+++ b/src/Templates/src/templates/maui-blazor/Platforms/MacCatalyst/Info.plist
@@ -4,7 +4,6 @@
 <dict>
     <key>UIDeviceFamily</key>
     <array>
-        <integer>1</integer>
         <integer>2</integer>
     </array>
     <key>UIRequiredDeviceCapabilities</key>

--- a/src/Templates/src/templates/maui-mobile/Platforms/MacCatalyst/Info.plist
+++ b/src/Templates/src/templates/maui-mobile/Platforms/MacCatalyst/Info.plist
@@ -4,7 +4,6 @@
 <dict>
 	<key>UIDeviceFamily</key>
 	<array>
-		<integer>1</integer>
 		<integer>2</integer>
 	</array>
 	<key>UIRequiredDeviceCapabilities</key>


### PR DESCRIPTION
### Description of Change

This removes the unsupported `UIDeviceFamily` value `1` from the default templates for Mac Catalyst (.NET MAUI and Blazor Hybrid).
Not added `6` as a default, this should only be done in certain scenarios which @davidbritch will describe in the docs.

According to this link, this is also inline with the default Xcode behavior where they say option `2` is the starting point: https://developer.apple.com/documentation/uikit/mac_catalyst/choosing_a_user_interface_idiom_for_your_mac_app?language=objc

### Issues Fixed

Fixes #13910