### PR TITLE
Add an error if Xamarin.Forms was found

### DIFF
--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
@@ -53,6 +53,16 @@
 			Text="Microsoft.Maui requires .NETFramework >= v4.6.1. You have '$(TargetFrameworkVersion)'" />
 	</Target>
 
+	<Target
+		Name="_ValidateMauiDoesNotHaveXamarinForms"
+		BeforeTargets="_CheckForInvalidConfigurationAndPlatform"
+		Condition="'$(MauiDisableXamarinFormsValidation)' != 'True'">
+		<Error
+			Code="MA001"
+			Text="This project or a dependency has imported the Xamarin.Forms packages. .NET MAUI is not compatible with Xamarin.Forms and is unable to build. Please remove Xamarin.Forms or the project/package dependency that is using Xamarin.Forms."
+			Condition="'$(_XFTargetsImported)' == 'true'"/>
+	</Target>
+
 
   <!-- Inject MauiXaml and MauiCss as AdditionalFiles for partial type generation-->
   <Target Name="_MauiInjectXamlCssAdditionalFiles"


### PR DESCRIPTION
### Description of Change

Adding a target to verify that no Xamarin.Forms is included in the project as it imports targets that directly conflict with .NET MAUI.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #13666

> Technically it does not fix #13666 as the issue is Xamarin.Forms is included, but this error will bring it out.