### PR TITLE
Adjust flex item position to account for reversal when laying out unconstrained

### DIFF
--- a/src/Controls/tests/Core.UnitTests/Layouts/FlexLayoutTests.cs
+++ b/src/Controls/tests/Core.UnitTests/Layouts/FlexLayoutTests.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.Maui.Graphics;
+﻿using System;
+using System.Transactions;
+using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Layouts;
 using NSubstitute;
 using Xunit;
@@ -91,10 +93,14 @@ namespace Microsoft.Maui.Controls.Core.UnitTests.Layouts
 		 * depending on the target platform.
 		 */
 
-		(IFlexLayout, IView) SetUpUnconstrainedTest()
+		(IFlexLayout, IView) SetUpUnconstrainedTest(Action<FlexLayout> configure = null)
 		{
 			var root = new Grid(); // FlexLayout requires a parent, at least for now
-			var flexLayout = new FlexLayout() as IFlexLayout;
+
+			var controlsFlexLayout = new FlexLayout();
+			configure?.Invoke(controlsFlexLayout);
+
+			var flexLayout = controlsFlexLayout as IFlexLayout;
 
 			var view = Substitute.For<IView>();
 			var size = new Size(100, 100);
@@ -128,6 +134,24 @@ namespace Microsoft.Maui.Controls.Core.UnitTests.Layouts
 			var flexFrame = flexLayout.GetFlexFrame(view);
 
 			Assert.Equal(100, flexFrame.Width);
+		}
+
+		[Theory]
+		[InlineData(double.PositiveInfinity, 400, FlexDirection.RowReverse)]
+		[InlineData(double.PositiveInfinity, 400, FlexDirection.Row)]
+		[InlineData(400, double.PositiveInfinity, FlexDirection.ColumnReverse)]
+		[InlineData(400, double.PositiveInfinity, FlexDirection.Column)]
+		public void UnconstrainedMeasureHonorsFlexDirection(double widthConstraint, double heightConstraint,
+			FlexDirection flexDirection)
+		{
+			(var flexLayout, var view) = SetUpUnconstrainedTest((fl)=> { fl.Direction = flexDirection; }) ;
+
+			_ = flexLayout.CrossPlatformMeasure(widthConstraint, heightConstraint);
+
+			var flexFrame = flexLayout.GetFlexFrame(view);
+
+			Assert.Equal(0, flexFrame.X);
+			Assert.Equal(0, flexFrame.Y);
 		}
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/Layouts/FlexLayoutTests.cs
+++ b/src/Controls/tests/Core.UnitTests/Layouts/FlexLayoutTests.cs
@@ -144,7 +144,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests.Layouts
 		public void UnconstrainedMeasureHonorsFlexDirection(double widthConstraint, double heightConstraint,
 			FlexDirection flexDirection)
 		{
-			(var flexLayout, var view) = SetUpUnconstrainedTest((fl)=> { fl.Direction = flexDirection; }) ;
+			(var flexLayout, var view) = SetUpUnconstrainedTest((fl) => { fl.Direction = flexDirection; });
 
 			_ = flexLayout.CrossPlatformMeasure(widthConstraint, heightConstraint);
 

--- a/src/Core/src/Layouts/Flex.cs
+++ b/src/Core/src/Layouts/Flex.cs
@@ -888,6 +888,28 @@ namespace Microsoft.Maui.Layouts.Flex
 
 				layout.lines_sizes += line.size;
 			}
+
+			if (layout.reverse && layout.size_dim == 0)
+			{
+				// Handle reversed layouts when there was no fixed size in the first place. All of the positions will be flipped
+				// across the axis. Luckily the pos variable is already tracking how far negative the values were in this situation,
+				// so we can just offset the distance by that amount and get the desired value
+
+				for (int i = child_begin; i < child_end; i++)
+				{
+					Item child = layout.child_at(item, i);
+					if (!child.IsVisible)
+						continue;
+
+					if (child.Position == Position.Absolute)
+					{
+						// Not helpful for this
+						continue;
+					}
+
+					child.Frame[layout.frame_pos_i] = child.Frame[layout.frame_pos_i] - pos;
+				}
+			}
 		}
 
 		static float absolute_size(float val, float pos1, float pos2, float dim) =>


### PR DESCRIPTION
### Description of Change

Like most of Flex, RowReverse/ColumnReverse don't make of a ton of sense when measuring/laying out in unconstrained directions. The implementation of reverse calls for starting at the far edge and laying out in reverse order; when the direction is unconstrained, "far edge" has no meaning. The current implementation treats the unconstrained "far edge" as zero; this means that the reversed items are starting at zero and laying out into negative X,Y positions.

The best option in the absence of a known constraint is to lay out in reverse order from the near edge; the width of the unconstrained container is just the width of the flex items within it. Since the implementation is already _almost_ doing this, we just do a final pass to adjust the positions of the items into positive X,Y positions. 

Draft for now; this needs unit tests.

### Issues Fixed

Fixes #7756