### PR TITLE
[Essentials] Remove lock from SecureStorage

### DIFF
--- a/src/Essentials/test/DeviceTests/Tests/SecureStorage_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/SecureStorage_Tests.cs
@@ -156,5 +156,21 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 				Assert.Equal(i.ToString(), v);
 			}
 		}
+
+		[Fact]
+		public async Task Set_Get_Remove_Async_MultipleTimes()
+		{
+			await Parallel.ForEachAsync(Enumerable.Range(0, 100), async (i, _) =>
+			{
+				var key = $"key{i}";
+				var value = $"value{i}";
+				await SecureStorage.SetAsync(key, value);
+				var fetched = await SecureStorage.GetAsync(key);
+				Assert.Equal(value, fetched);
+				SecureStorage.Remove(key);
+				fetched = await SecureStorage.GetAsync(key);
+				Assert.Null(fetched);
+			});
+		}
 	}
 }


### PR DESCRIPTION
Fixes #12341

Removes the lock from SecureStorage usage on Android, and marks GetAsync
and SetAsync as async methods.  This should reduce the likelyhood of
synchronization issues when using SecureStorage from other async code.

The [EncryptedSharedPreferences][0] class provides a thin implementation
of [SharedPreferences][1], which contains locking / data access
synchronization logic.

Rather than creating a `SharedPreferences` instance for every operation,
we will now reuse the first instance that is created.

[0]: https://developer.android.com/reference/androidx/security/crypto/EncryptedSharedPreferences
[1]: https://android.googlesource.com/platform/frameworks/base.git/+/master/core/java/android/app/SharedPreferencesImpl.java
