### PR TITLE
[controls] fix cases a GC causes events to not fire

### DIFF
--- a/src/Controls/src/Core/BindableLayout.cs
+++ b/src/Controls/src/Core/BindableLayout.cs
@@ -202,6 +202,7 @@ namespace Microsoft.Maui.Controls
 	{
 		readonly WeakReference<IBindableLayout> _layoutWeakReference;
 		readonly WeakNotifyCollectionChangedProxy _collectionChangedProxy = new();
+		readonly NotifyCollectionChangedEventHandler _collectionChangedEventHandler;
 		IEnumerable _itemsSource;
 		DataTemplate _itemTemplate;
 		DataTemplateSelector _itemTemplateSelector;
@@ -220,6 +221,7 @@ namespace Microsoft.Maui.Controls
 		public BindableLayoutController(IBindableLayout layout)
 		{
 			_layoutWeakReference = new WeakReference<IBindableLayout>(layout);
+			_collectionChangedEventHandler = ItemsSourceCollectionChanged;
 		}
 
 		~BindableLayoutController() => _collectionChangedProxy.Unsubscribe();
@@ -246,7 +248,7 @@ namespace Microsoft.Maui.Controls
 
 			if (_itemsSource is INotifyCollectionChanged c)
 			{
-				_collectionChangedProxy.Subscribe(c, ItemsSourceCollectionChanged);
+				_collectionChangedProxy.Subscribe(c, _collectionChangedEventHandler);
 			}
 
 			if (!_isBatchUpdate)

--- a/src/Controls/src/Core/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement.cs
@@ -103,8 +103,9 @@ namespace Microsoft.Maui.Controls
 			var clip = Clip;
 			if (clip != null)
 			{
-				var proxy = _clipProxy ??= new();
-				proxy.Subscribe(clip, (sender, e) => OnPropertyChanged(nameof(Clip)));
+				_clipChanged ??= (sender, e) => OnPropertyChanged(nameof(Clip));
+				_clipProxy ??= new();
+				_clipProxy.Subscribe(clip, _clipChanged);
 			}
 		}
 
@@ -276,8 +277,9 @@ namespace Microsoft.Maui.Controls
 					(bindable as VisualElement)?.NotifyBackgroundChanges();
 			});
 
-		WeakBackgroundChangedProxy _backgroundProxy = null;
-		WeakClipChangedProxy _clipProxy = null;
+		WeakBackgroundChangedProxy _backgroundProxy;
+		WeakClipChangedProxy _clipProxy;
+		EventHandler _backgroundChanged, _clipChanged;
 
 		~VisualElement()
 		{
@@ -294,8 +296,9 @@ namespace Microsoft.Maui.Controls
 			if (background != null)
 			{
 				SetInheritedBindingContext(background, BindingContext);
-				var proxy = _backgroundProxy ??= new();
-				proxy.Subscribe(background, (sender, e) => OnPropertyChanged(nameof(Background)));
+				_backgroundChanged ??= (sender, e) => OnPropertyChanged(nameof(Background));
+				_backgroundProxy ??= new();
+				_backgroundProxy.Subscribe(background, _backgroundChanged);
 			}
 		}
 

--- a/src/Controls/tests/Core.UnitTests/BindingUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/BindingUnitTests.cs
@@ -2045,32 +2045,21 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact]
-		public void BindingUnsubscribesForDeadTarget()
+		public async Task BindingUnsubscribesForDeadTarget()
 		{
-			TestViewModel viewmodel = new TestViewModel();
+			var viewmodel = new TestViewModel();
 
-			int i = 0;
-			Action create = null;
-			create = () =>
 			{
-				if (i++ < 1024)
-				{
-					create();
-					return;
-				}
-
 				var button = new Button();
 				button.SetBinding(Button.TextProperty, "Foo");
 				button.BindingContext = viewmodel;
-			};
-
-			create();
+			}
 
 			Assert.Equal(1, viewmodel.InvocationListSize());
 
+			await Task.Yield();
 			GC.Collect();
 			GC.WaitForPendingFinalizers();
-			GC.Collect();
 
 			viewmodel.OnPropertyChanged("Foo");
 
@@ -2080,7 +2069,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		[Fact]
 		public async Task BindingDoesNotStayAliveForDeadTarget()
 		{
-			TestViewModel viewModel = new TestViewModel();
+			var viewModel = new TestViewModel();
 			WeakReference bindingRef;
 
 			{
@@ -2095,10 +2084,9 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			Assert.Equal(1, viewModel.InvocationListSize());
 
-			//NOTE: this was the only way I could "for sure" get the binding to get GC'd
+			await Task.Yield();
 			GC.Collect();
-			await Task.Delay(10);
-			GC.Collect();
+			GC.WaitForPendingFinalizers();
 
 			Assert.False(bindingRef.IsAlive, "Binding should not be alive!");
 		}

--- a/src/Controls/tests/Core.UnitTests/MapTests.cs
+++ b/src/Controls/tests/Core.UnitTests/MapTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.Maui.Controls.Maps;
 using Microsoft.Maui.Devices.Sensors;
 using Microsoft.Maui.Maps;
@@ -325,8 +326,8 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.True(IsMapWithItemsSource(itemsSource, map));
 		}
 
-		[Fact(Skip = "https://github.com/dotnet/maui/issues/1524")]
-		public void ElementIsGarbageCollectedAfterItsRemoved()
+		[Fact]
+		public async Task ElementIsGarbageCollectedAfterItsRemoved()
 		{
 			var map = new Map()
 			{
@@ -351,6 +352,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			pageRoot.Children.Remove(map);
 			map = null;
 
+			await Task.Yield();
 			GC.Collect();
 			GC.WaitForPendingFinalizers();
 

--- a/src/Controls/tests/Core.UnitTests/MessagingCenterTests.cs
+++ b/src/Controls/tests/Core.UnitTests/MessagingCenterTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using Xunit;
 using Xunit.Sdk;
 
@@ -261,8 +262,8 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.True(((TestSubcriber)wr.Target).Successful);  // Since it's still alive, the subscriber should still have received the message and updated the property
 		}
 
-		[Fact(Skip = "https://github.com/dotnet/maui/issues/1524")]
-		public void SubscriberCollectableAfterUnsubscribeEvenIfHeldByClosure()
+		[Fact]
+		public async Task SubscriberCollectableAfterUnsubscribeEvenIfHeldByClosure()
 		{
 			WeakReference wr = null;
 
@@ -279,6 +280,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			MessagingCenter.Unsubscribe<TestPublisher>(wr.Target, "test");
 
+			await Task.Yield();
 			GC.Collect();
 			GC.WaitForPendingFinalizers();
 

--- a/src/Controls/tests/Core.UnitTests/VisualElementTests.cs
+++ b/src/Controls/tests/Core.UnitTests/VisualElementTests.cs
@@ -143,6 +143,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			await Task.Yield();
 			GC.Collect();
 			GC.WaitForPendingFinalizers();
+			GC.KeepAlive(visual);
 
 			gradient.GradientStops.Add(new GradientStop(Colors.CornflowerBlue, 1));
 			Assert.True(fired, "PropertyChanged did not fire!");
@@ -179,6 +180,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			await Task.Yield();
 			GC.Collect();
 			GC.WaitForPendingFinalizers();
+			GC.KeepAlive(visual);
 
 			geometry.Rect = new Rect(1, 2, 3, 4);
 			Assert.True(fired, "PropertyChanged did not fire!");

--- a/src/Controls/tests/Core.UnitTests/VisualElementTests.cs
+++ b/src/Controls/tests/Core.UnitTests/VisualElementTests.cs
@@ -121,7 +121,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact]
-		public void GradientBrushSubscribed()
+		public async Task GradientBrushSubscribed()
 		{
 			var gradient = new LinearGradientBrush
 			{
@@ -139,6 +139,10 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 				if (e.PropertyName == nameof(VisualElement.Background))
 					fired = true;
 			};
+
+			await Task.Yield();
+			GC.Collect();
+			GC.WaitForPendingFinalizers();
 
 			gradient.GradientStops.Add(new GradientStop(Colors.CornflowerBlue, 1));
 			Assert.True(fired, "PropertyChanged did not fire!");
@@ -160,7 +164,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact]
-		public void RectangleGeometrySubscribed()
+		public async Task RectangleGeometrySubscribed()
 		{
 			var geometry = new RectangleGeometry();
 			var visual = new VisualElement { Clip = geometry };
@@ -171,6 +175,10 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 				if (e.PropertyName == nameof(VisualElement.Clip))
 					fired = true;
 			};
+
+			await Task.Yield();
+			GC.Collect();
+			GC.WaitForPendingFinalizers();
 
 			geometry.Rect = new Rect(1, 2, 3, 4);
 			Assert.True(fired, "PropertyChanged did not fire!");

--- a/src/Controls/tests/Core.UnitTests/WeakEventProxyTests.cs
+++ b/src/Controls/tests/Core.UnitTests/WeakEventProxyTests.cs
@@ -36,13 +36,14 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			var proxy = new WeakNotifyCollectionChangedProxy();
 
 			bool fired = false;
-			// NOTE: this test wouldn't pass if we didn't save this in a variable
+			// NOTE: this test wouldn't pass if we didn't save this and GC.KeepAlive() it
 			NotifyCollectionChangedEventHandler handler = (s, e) => fired = true;
 			proxy.Subscribe(list, handler);
 
 			await Task.Yield();
 			GC.Collect();
 			GC.WaitForPendingFinalizers();
+			GC.KeepAlive(handler);
 
 			list.Add("a");
 

--- a/src/Controls/tests/Core.UnitTests/WeakEventProxyTests.cs
+++ b/src/Controls/tests/Core.UnitTests/WeakEventProxyTests.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			GC.WaitForPendingFinalizers();
 
 			list.Add("a");
-			
+
 			Assert.True(fired);
 		}
 

--- a/src/Controls/tests/Core.UnitTests/WeakEventProxyTests.cs
+++ b/src/Controls/tests/Core.UnitTests/WeakEventProxyTests.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Maui.Controls.Core.UnitTests
+{
+	public class WeakEventProxyTests
+	{
+		[Fact]
+		public async Task DoesNotLeak()
+		{
+			WeakReference reference;
+			var list = new ObservableCollection<string>();
+			var proxy = new WeakNotifyCollectionChangedProxy();
+
+			{
+				var subscriber = new Subscriber();
+				proxy.Subscribe(list, subscriber.OnCollectionChanged);
+				reference = new WeakReference(subscriber);
+			}
+
+			await Task.Yield();
+			GC.Collect();
+			GC.WaitForPendingFinalizers();
+
+			Assert.False(reference.IsAlive, "Subscriber should not be alive!");
+		}
+
+		[Fact]
+		public async Task EventFires()
+		{
+			var list = new ObservableCollection<string>();
+			var proxy = new WeakNotifyCollectionChangedProxy();
+
+			bool fired = false;
+			// NOTE: this test wouldn't pass if we didn't save this in a variable
+			NotifyCollectionChangedEventHandler handler = (s, e) => fired = true;
+			proxy.Subscribe(list, handler);
+
+			await Task.Yield();
+			GC.Collect();
+			GC.WaitForPendingFinalizers();
+
+			list.Add("a");
+			
+			Assert.True(fired);
+		}
+
+		class Subscriber
+		{
+			public void OnCollectionChanged(object sender, NotifyCollectionChangedEventArgs e) { }
+		}
+	}
+}


### PR DESCRIPTION
As seen in #13973, some of my recent changes had a flaw:

* https://github.com/dotnet/maui/pull/13550
* https://github.com/dotnet/maui/pull/13806
* https://github.com/dotnet/maui/pull/13656

Because nothing held onto the `EventHandler` in some of these cases, at some point a GC will prevent future events from firing.

So for example, my original attempt to test this behavior:

```csharp
[Fact]
public async Task RectangleGeometrySubscribed()
{
    var geometry = new RectangleGeometry();
    var visual = new VisualElement { Clip = geometry };

    bool fired = false;
    visual.PropertyChanged += (sender, e) =>
    {
        if (e.PropertyName == nameof(VisualElement.Clip))
            fired = true;
    };

    // Was missing these three lines!!!
    // await Task.Yield();
    // GC.Collect();
    // GC.WaitForPendingFinalizers();

    geometry.Rect = new Rect(1, 2, 3, 4);
    Assert.True(fired, "PropertyChanged did not fire!");
}
```

In each case, I added an additional test showing the problem.

I played around with some ideas, but the simplest solution is to save the `EventHandler` in a member field of the subscriber. Will keep thinking of smarter ways to handle this.

I also fixed several GC-related tests that were ignored, hoping they might help find issues in this area. My `await Task.Yield()` trick was enough to make them pass.