### PR TITLE
Ensure that Grid is treating star rows/columns as Auto when unconstrained

### DIFF
--- a/src/Core/src/Layouts/GridLayoutManager.cs
+++ b/src/Core/src/Layouts/GridLayoutManager.cs
@@ -373,6 +373,9 @@ namespace Microsoft.Maui.Layouts
 				{
 					var cell = _cells[n];
 
+					bool treatCellHeightAsAuto = TreatCellHeightAsAuto(cell);
+					bool treatCellWidthAsAuto = TreatCellWidthAsAuto(cell);
+
 					if (double.IsNaN(cell.MeasureHeight) || double.IsNaN(cell.MeasureWidth))
 					{
 						// We still have some unknown measure constraints (* rows/columns that need to have
@@ -380,7 +383,7 @@ namespace Microsoft.Maui.Layouts
 						// second pass, once we know the constraints.
 						cell.NeedsSecondPass = true;
 
-						if (!cell.IsColumnSpanAuto && !cell.IsRowSpanAuto)
+						if (!(treatCellHeightAsAuto || treatCellWidthAsAuto))
 						{
 							// If neither span of this cell includes _any_ Auto values, then there's no reason
 							// to measure it at all during this pass; we can skip it for now
@@ -393,7 +396,7 @@ namespace Microsoft.Maui.Layouts
 
 					var measure = MeasureCell(cell, measureWidth, measureHeight);
 
-					if (cell.IsColumnSpanAuto)
+					if (treatCellWidthAsAuto)
 					{
 						if (cell.ColumnSpan == 1)
 						{
@@ -405,7 +408,7 @@ namespace Microsoft.Maui.Layouts
 						}
 					}
 
-					if (cell.IsRowSpanAuto)
+					if (treatCellHeightAsAuto)
 					{
 						if (cell.RowSpan == 1)
 						{
@@ -951,7 +954,7 @@ namespace Microsoft.Maui.Layouts
 					measureWidth += _columns[column].Size;
 				}
 
-				cell.MeasureWidth = measureWidth;
+				cell.MeasureWidth = measureWidth; 
 			}
 
 			void UpdateKnownMeasureHeight(Cell cell)
@@ -971,13 +974,8 @@ namespace Microsoft.Maui.Layouts
 				{
 					UpdateKnownMeasureWidth(cell);
 				}
-				else if (cell.IsColumnSpanAuto)
+				else if (TreatCellWidthAsAuto(cell))
 				{
-					cell.MeasureWidth = double.PositiveInfinity;
-				}
-				else if (cell.IsColumnSpanStar && double.IsInfinity(_gridWidthConstraint))
-				{
-					// Because the Grid isn't horizontally constrained, we treat * columns as Auto 
 					cell.MeasureWidth = double.PositiveInfinity;
 				}
 
@@ -990,17 +988,44 @@ namespace Microsoft.Maui.Layouts
 				{
 					UpdateKnownMeasureHeight(cell);
 				}
-				else if (cell.IsRowSpanAuto)
+				else if (TreatCellHeightAsAuto(cell))
 				{
-					cell.MeasureHeight = double.PositiveInfinity;
-				}
-				else if (cell.IsRowSpanStar && double.IsInfinity(_gridHeightConstraint))
-				{
-					// Because the Grid isn't vertically constrained, we treat * rows as Auto 
 					cell.MeasureHeight = double.PositiveInfinity;
 				}
 
 				// For all other situations, we'll have to wait until we've measured the Auto rows
+			}
+
+			bool TreatCellWidthAsAuto(Cell cell) 
+			{
+				if (cell.IsColumnSpanAuto)
+				{
+					return true;
+				}
+
+				if (double.IsInfinity(_gridWidthConstraint) && cell.IsColumnSpanStar)
+				{
+					// Because the Grid isn't horizontally constrained, we treat * columns as Auto 
+					return true;
+				}
+
+				return false;
+			}
+
+			bool TreatCellHeightAsAuto(Cell cell) 
+			{
+				if (cell.IsRowSpanAuto)
+				{ 
+					return true;
+				}
+
+				if (double.IsInfinity(_gridHeightConstraint) && cell.IsRowSpanStar)
+				{
+					// Because the Grid isn't vertically constrained, we treat * rows  as Auto 
+					return true;
+				}
+
+				return false;
 			}
 		}
 

--- a/src/Core/src/Layouts/GridLayoutManager.cs
+++ b/src/Core/src/Layouts/GridLayoutManager.cs
@@ -954,7 +954,7 @@ namespace Microsoft.Maui.Layouts
 					measureWidth += _columns[column].Size;
 				}
 
-				cell.MeasureWidth = measureWidth; 
+				cell.MeasureWidth = measureWidth;
 			}
 
 			void UpdateKnownMeasureHeight(Cell cell)
@@ -996,7 +996,7 @@ namespace Microsoft.Maui.Layouts
 				// For all other situations, we'll have to wait until we've measured the Auto rows
 			}
 
-			bool TreatCellWidthAsAuto(Cell cell) 
+			bool TreatCellWidthAsAuto(Cell cell)
 			{
 				if (cell.IsColumnSpanAuto)
 				{
@@ -1012,10 +1012,10 @@ namespace Microsoft.Maui.Layouts
 				return false;
 			}
 
-			bool TreatCellHeightAsAuto(Cell cell) 
+			bool TreatCellHeightAsAuto(Cell cell)
 			{
 				if (cell.IsRowSpanAuto)
-				{ 
+				{
 					return true;
 				}
 

--- a/src/Core/tests/UnitTests/Layouts/GridLayoutManagerTests.cs
+++ b/src/Core/tests/UnitTests/Layouts/GridLayoutManagerTests.cs
@@ -2398,7 +2398,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			// and the single view does not have an explicit height, then there should have been at least
 			// one measurement with an unconstrained height
 			view0.Received().Measure(Arg.Any<double>(), double.PositiveInfinity);
-			
+
 			// The Auto column has no Views, so we expect it to have zero width; the single view should
 			// be arranged at the top left corner
 			AssertArranged(view0, new Rect(0, 0, 20, 20));

--- a/src/Core/tests/UnitTests/Layouts/GridLayoutManagerTests.cs
+++ b/src/Core/tests/UnitTests/Layouts/GridLayoutManagerTests.cs
@@ -7,6 +7,7 @@ using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Layouts;
 using Microsoft.Maui.Primitives;
 using NSubstitute;
+using NSubstitute.ReceivedExtensions;
 using Xunit;
 using static Microsoft.Maui.UnitTests.Layouts.LayoutTestHelpers;
 using LayoutAlignment = Microsoft.Maui.Primitives.LayoutAlignment;
@@ -2377,6 +2378,54 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			_ = MeasureAndArrange(grid);
 
 			AssertArranged(view0, new Rect(0, 0, 100, 120));
+		}
+
+		[Fact]
+		public void AutoStarColumnsRespectUnconstrainedHeight()
+		{
+			var grid = CreateGridLayout(columns: "Auto, *");
+
+			var view0 = CreateTestView(new Size(20, 20));
+			view0.HorizontalLayoutAlignment.Returns(LayoutAlignment.Start);
+			view0.VerticalLayoutAlignment.Returns(LayoutAlignment.Start);
+
+			SubstituteChildren(grid, view0);
+			SetLocation(grid, view0, col: 1);
+
+			_ = MeasureAndArrange(grid, widthConstraint: 200, heightConstraint: double.PositiveInfinity);
+
+			// The Grid only has one view; since we're measuring the Grid without height constraints,
+			// and the single view does not have an explicit height, then there should have been at least
+			// one measurement with an unconstrained height
+			view0.Received().Measure(Arg.Any<double>(), double.PositiveInfinity);
+			
+			// The Auto column has no Views, so we expect it to have zero width; the single view should
+			// be arranged at the top left corner
+			AssertArranged(view0, new Rect(0, 0, 20, 20));
+		}
+
+		[Fact]
+		public void AutoStarRowsRespectUnconstrainedWidth()
+		{
+			var grid = CreateGridLayout(rows: "Auto, *");
+
+			var view0 = CreateTestView(new Size(20, 20));
+			view0.HorizontalLayoutAlignment.Returns(LayoutAlignment.Start);
+			view0.VerticalLayoutAlignment.Returns(LayoutAlignment.Start);
+
+			SubstituteChildren(grid, view0);
+			SetLocation(grid, view0, row: 1);
+
+			_ = MeasureAndArrange(grid, widthConstraint: double.PositiveInfinity, heightConstraint: 200);
+
+			// The Grid only has one view; since we're measuring the Grid without width constraints,
+			// and the single view does not have an explicit width, then there should have been at least
+			// one measurement with an unconstrained width
+			view0.Received().Measure(double.PositiveInfinity, Arg.Any<double>());
+
+			// The Auto row has no Views, so we expect it to have zero height; the single view should
+			// be arranged at the top left corner
+			AssertArranged(view0, new Rect(0, 0, 20, 20));
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change

When a Grid dimension is unconstrained (e.g., if inside a StackLayout), `*` rows/columns along that dimension should be treated as if they were `Auto`. In cases where a `*` exists in the unconstrained dimension and an `Auto` row/column exist in the alternated dimension, the layout manager could get into a situation where it never measures the views which exist entirely within the intersection of `*` rows and columns.

These changes correct that issue and add tests to account for the situation.

### Issues Fixed

Fixes #13993