### PR TITLE
[Android] Avoid to clip the SwipeView to the outline if the SwipeView or the Content has shadow

### DIFF
--- a/src/Core/src/Platform/Android/MauiSwipeView.cs
+++ b/src/Core/src/Platform/Android/MauiSwipeView.cs
@@ -51,7 +51,6 @@ namespace Microsoft.Maui.Platform
 
 			_swipeItems = new Dictionary<ISwipeItem, object>();
 
-			this.SetClipToOutline(Element?.Shadow is not null);
 			SetClipChildren(false);
 			SetClipToPadding(false);
 
@@ -64,6 +63,9 @@ namespace Microsoft.Maui.Platform
 		internal void SetElement(ISwipeView swipeView)
 		{
 			Element = swipeView;
+
+			bool clipToOutline = Element?.Shadow is null && (Element?.Content as IView)?.Shadow is null;
+			this.SetClipToOutline(clipToOutline);
 		}
 
 		protected override void OnAttachedToWindow()


### PR DESCRIPTION
### Description of Change

Avoid to clip the SwipeView to the outline if the SwipeView or the Content has shadow. Doing rebase and verifying an open PR related to SwipeView I have noticed an improvement when managing if the SwipeView is clipped or not to the outline.

With the changes of this PR:
- By default, clipping is done so that when you swipe the content is clipped.
- In case of having a Shadow in the SwipeView or in its content (we were not taking this into account before), clipping is avoided and not cut the shadow.

Content clipped to the outline
![image](https://user-images.githubusercontent.com/6755973/225977405-16730b1c-ab11-4340-8068-992be304db4f.png)

Shadow not clipped
![image](https://user-images.githubusercontent.com/6755973/225977455-e703976b-1c47-42be-9b8e-948f83b8a356.png)
