### PR TITLE
[vs-workload] Remove @(MultiTargetPackNames)

### DIFF
--- a/eng/automation/vs-workload.template.props
+++ b/eng/automation/vs-workload.template.props
@@ -28,6 +28,5 @@
     <ComponentResources Include="maui-ios"          Version="@VS_COMPONENT_VERSION@" Category=".NET" Title=".NET MAUI SDK for iOS" Description=".NET SDK Workload for building MAUI applications that target iOS." />
     <ComponentResources Include="maui-windows"      Version="@VS_COMPONENT_VERSION@" Category=".NET" Title=".NET MAUI SDK for Windows" Description=".NET SDK Workload for building MAUI applications that target Windows." />
     <WorkloadPackages Include="$(NuGetPackagePath)\Microsoft.NET.Sdk.Maui.Manifest*.nupkg" Version="@VS_COMPONENT_VERSION@" SupportsMachineArch="true" />
-    <MultiTargetPackNames Include="Maui.Sdk;Maui.Templates" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Context: https://github.com/xamarin/yaml-templates/pull/251

The VS manifest files generated during MSI conversion will now be split up using the workload pack type rather than a substring match.