### PR TITLE
[iOS] Don't apply mask to UIScrollView so the content doesn't get masked out

### DIFF
--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.iOS.cs
@@ -16,6 +16,8 @@ namespace Microsoft.Maui.Handlers
 	{
 		const nint ContentPanelTag = 0x845fed;
 
+		public override bool NeedsContainer => true;
+
 		protected override UIScrollView CreatePlatformView()
 		{
 			return new MauiScrollView();

--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.iOS.cs
@@ -16,7 +16,19 @@ namespace Microsoft.Maui.Handlers
 	{
 		const nint ContentPanelTag = 0x845fed;
 
-		public override bool NeedsContainer => true;
+		public override bool NeedsContainer
+		{
+			get
+			{
+				//if we are being wrapped by a BorderView we need a container
+				//so we can handle masks and clip shapes
+				if (VirtualView.Parent is IBorderView)
+				{
+					return true;
+				}
+				return base.NeedsContainer;
+			}
+		}
 
 		protected override UIScrollView CreatePlatformView()
 		{

--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.iOS.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Maui.Handlers
 			{
 				//if we are being wrapped by a BorderView we need a container
 				//so we can handle masks and clip shapes
-				if (VirtualView.Parent is IBorderView)
+				if (VirtualView?.Parent is IBorderView)
 				{
 					return true;
 				}

--- a/src/Core/src/Platform/iOS/ContentView.cs
+++ b/src/Core/src/Platform/iOS/ContentView.cs
@@ -117,7 +117,7 @@ namespace Microsoft.Maui.Platform
 				return;
 
 			var child = Subviews[0];
-				
+
 			if (child is MauiScrollView mauiScrollView)
 			{
 				return;

--- a/src/Core/src/Platform/iOS/ContentView.cs
+++ b/src/Core/src/Platform/iOS/ContentView.cs
@@ -116,13 +116,6 @@ namespace Microsoft.Maui.Platform
 			if (Subviews.Length == 0)
 				return;
 
-			var child = Subviews[0];
-				
-			if (child is MauiScrollView mauiScrollView)
-			{
-				return;
-			}
-
 			var mask = ChildMaskLayer;
 
 			if (mask == null && Clip == null)

--- a/src/Core/src/Platform/iOS/ContentView.cs
+++ b/src/Core/src/Platform/iOS/ContentView.cs
@@ -116,6 +116,13 @@ namespace Microsoft.Maui.Platform
 			if (Subviews.Length == 0)
 				return;
 
+			var child = Subviews[0];
+				
+			if (child is MauiScrollView mauiScrollView)
+			{
+				return;
+			}
+
 			var mask = ChildMaskLayer;
 
 			if (mask == null && Clip == null)

--- a/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -10,6 +10,7 @@ Microsoft.Maui.SizeRequest.Equals(Microsoft.Maui.SizeRequest other) -> bool
 Microsoft.Maui.Platform.MauiScrollView
 Microsoft.Maui.Platform.MauiScrollView.MauiScrollView() -> void
 override Microsoft.Maui.Handlers.ContentViewHandler.DisconnectHandler(Microsoft.Maui.Platform.ContentView! platformView) -> void
+override Microsoft.Maui.Handlers.ScrollViewHandler.NeedsContainer.get -> bool
 override Microsoft.Maui.Handlers.SwipeItemButton.Frame.get -> CoreGraphics.CGRect
 override Microsoft.Maui.Handlers.SwipeItemButton.Frame.set -> void
 override Microsoft.Maui.Handlers.SwipeItemMenuItemHandler.ConnectHandler(UIKit.UIButton! platformView) -> void

--- a/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -9,6 +9,7 @@ Microsoft.Maui.SizeRequest.Equals(Microsoft.Maui.SizeRequest other) -> bool
 Microsoft.Maui.Platform.MauiScrollView
 Microsoft.Maui.Platform.MauiScrollView.MauiScrollView() -> void
 override Microsoft.Maui.Handlers.ContentViewHandler.DisconnectHandler(Microsoft.Maui.Platform.ContentView! platformView) -> void
+override Microsoft.Maui.Handlers.ScrollViewHandler.NeedsContainer.get -> bool
 override Microsoft.Maui.Handlers.SwipeItemButton.Frame.get -> CoreGraphics.CGRect
 override Microsoft.Maui.Handlers.SwipeItemButton.Frame.set -> void
 override Microsoft.Maui.Handlers.SwipeItemMenuItemHandler.ConnectHandler(UIKit.UIButton! platformView) -> void


### PR DESCRIPTION
### Description of Change

On iOS the border platform view `ContainerView` is always applying a Mask using its frame to the child content. This prevents the UIScrollView to proper render its own content because some of it gets masked out.
The fix for now is wrap the platform view `UIScrollView` on the handler in a container when it's inside a `Border`.

Here's some code to test the example:


```
<Border WidthRequest="200" HeightRequest="500" VerticalOptions="Center" HorizontalOptions="Center"
            Stroke="Blue"
            StrokeThickness="4"
            Padding="20"
            Background="LightGray">
        <Border.StrokeShape>
             <RoundRectangle CornerRadius="50,50,50,50" />
        </Border.StrokeShape>
        <ScrollView Padding="10" BackgroundColor="Yellow">
            <Label HeightRequest="1000" HorizontalOptions="Fill" Background="GreenYellow"/>
        </ScrollView>
</Border>
```
iPhone
![Simulator Screen Shot - iPhone 14 Pro Max - 2023-03-21 at 14 45 57](https://user-images.githubusercontent.com/1235097/226643213-d426a81a-a5f8-4494-b33f-6d3fd7d42688.png)

Android
<img width="536" alt="MicrosoftTeams-image" src="https://user-images.githubusercontent.com/1235097/226644449-731c77ee-e1d4-4ef2-9337-6ccadb1cfdaf.png">

### Issues Fixed

Fixes #8923
Fixes #14091
Fixes #7524
