### PR TITLE
[net6.0] Updating Microsoft.Windows.SDK.BuildTools to 10.0.22621.756

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -22,7 +22,7 @@
     <MicrosoftNETWorkloadEmscriptenPackageVersion>$(MicrosoftNETWorkloadEmscriptenManifest60300PackageVersion)</MicrosoftNETWorkloadEmscriptenPackageVersion>
     <!-- wasdk -->
     <MicrosoftWindowsAppSDKPackageVersion>1.1.5</MicrosoftWindowsAppSDKPackageVersion>
-    <MicrosoftWindowsSDKBuildToolsPackageVersion>10.0.22000.194</MicrosoftWindowsSDKBuildToolsPackageVersion>
+    <MicrosoftWindowsSDKBuildToolsPackageVersion>10.0.22621.756</MicrosoftWindowsSDKBuildToolsPackageVersion>
     <MicrosoftGraphicsWin2DPackageVersion>1.0.3.1</MicrosoftGraphicsWin2DPackageVersion>
     <!-- Everything else -->
     <MicrosoftAspNetCoreAuthorizationPackageVersion>6.0.8</MicrosoftAspNetCoreAuthorizationPackageVersion>


### PR DESCRIPTION
### Description of Change

Updating .NET 6.0 to use the 10.0.22621.756 version of Microsoft.Windows.SDK.BuildTools.  I'm going with the just released .756 version, even though the .755 version also has the arm64 fixes I'm looking for.

https://www.nuget.org/packages/Microsoft.Windows.SDK.BuildTools/

### Issues Fixed

This will allow MAUI apps that target .NET 6.0 to build on arm64 machines.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1767228
