### PR TITLE
[ios] fix memory leak with `Page` + `Layout`

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.cs
@@ -298,15 +298,19 @@ namespace Microsoft.Maui.DeviceTests
 
 			await CreateHandlerAndAddToWindow<WindowHandlerStub>(new Window(navPage), async (handler) =>
 			{
-				var page = new ContentPage { Title = "Page 2" };
+				var page = new ContentPage { Title = "Page 2", Content = new VerticalStackLayout { new Label() } };
 				pageReference = new WeakReference(page);
 				await navPage.Navigation.PushAsync(page);
 				await navPage.Navigation.PopAsync();
 			});
 
-			await Task.Yield();
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+			// 3 GCs were required in Android API 23, 2 worked otherwise
+			for (int i = 0; i < 3; i++)
+			{
+				await Task.Yield();
+				GC.Collect();
+				GC.WaitForPendingFinalizers();
+			}
 
 			Assert.NotNull(pageReference);
 			Assert.False(pageReference.IsAlive, "Page should not be alive!");

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
@@ -932,7 +932,7 @@ namespace Microsoft.Maui.DeviceTests
 			{
 				await OnLoadedAsync(shell.CurrentPage);
 
-				var page = new ContentPage { Title = "Page 2" };
+				var page = new ContentPage { Title = "Page 2", Content = new VerticalStackLayout { new Label() } };
 				pageReference = new WeakReference(page);
 
 				await shell.Navigation.PushAsync(page);

--- a/src/Core/src/Handlers/Layout/LayoutHandler.iOS.cs
+++ b/src/Core/src/Handlers/Layout/LayoutHandler.iOS.cs
@@ -14,13 +14,7 @@ namespace Microsoft.Maui.Handlers
 				throw new InvalidOperationException($"{nameof(VirtualView)} must be set to create a LayoutViewGroup");
 			}
 
-			var view = new LayoutView
-			{
-				CrossPlatformMeasure = VirtualView.CrossPlatformMeasure,
-				CrossPlatformArrange = VirtualView.CrossPlatformArrange,
-			};
-
-			return view;
+			return new();
 		}
 
 		public override void SetVirtualView(IView view)
@@ -32,8 +26,6 @@ namespace Microsoft.Maui.Handlers
 			_ = MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
 
 			PlatformView.View = view;
-			PlatformView.CrossPlatformMeasure = VirtualView.CrossPlatformMeasure;
-			PlatformView.CrossPlatformArrange = VirtualView.CrossPlatformArrange;
 
 			// Remove any previous children 
 			PlatformView.ClearSubviews();

--- a/src/Core/src/Platform/iOS/MauiView.cs
+++ b/src/Core/src/Platform/iOS/MauiView.cs
@@ -1,4 +1,5 @@
-﻿using CoreGraphics;
+﻿using System;
+using CoreGraphics;
 using ObjCRuntime;
 using UIKit;
 
@@ -8,7 +9,13 @@ namespace Microsoft.Maui.Platform
 	{
 		static bool? _respondsToSafeArea;
 
-		public IView? View { get; set; }
+		WeakReference<IView>? _reference;
+
+		public IView? View
+		{
+			get => _reference != null && _reference.TryGetTarget(out var v) ? v : null;
+			set => _reference = value == null ? null : new(value);
+		}
 
 		bool RespondsToSafeArea()
 		{


### PR DESCRIPTION
Further fixes #13520

7d0af63c did not appear to be a complete fix for #13520, as when I retested the customer sample, I found I needed to remove a `VerticalStackLayout` for the problem to go away.

I could reproduce the issue in a test by doing:

    var page = new ContentPage { Title = "Page 2", Content = new VerticalStackLayout { new Label() } };

After lots of debugging, I found the underlying issue was that `MauiView` on iOS held a reference to the cross-platform `IView`.

After changing the backing field for this to be a `WeakReference<IView>` the above problem appears to be solved.

I also removed `LayoutView.CrossplatformArrange/Measure` as we can just use the `View` property directly instead.