### PR TITLE
Fix edge case with Grids, *s, and unconstrained layouts

### DIFF
--- a/src/Core/src/Layouts/GridLayoutManager.cs
+++ b/src/Core/src/Layouts/GridLayoutManager.cs
@@ -749,7 +749,13 @@ namespace Microsoft.Maui.Layouts
 
 			public void DecompressStars(Size targetSize)
 			{
-				if (_grid.VerticalLayoutAlignment == LayoutAlignment.Fill || Dimension.IsExplicitSet(_explicitGridHeight))
+				bool decompressVertical = Dimension.IsExplicitSet(_explicitGridHeight)
+					|| _grid.VerticalLayoutAlignment == LayoutAlignment.Fill && targetSize.Height > MeasuredGridHeight();
+
+				bool decompressHorizontal = Dimension.IsExplicitSet(_explicitGridWidth) 
+					|| _grid.HorizontalLayoutAlignment == LayoutAlignment.Fill && targetSize.Width > MeasuredGridWidth();
+
+				if (decompressVertical)
 				{
 					// Reset the size on all star rows
 					ZeroOutStarSizes(_rows);
@@ -758,7 +764,7 @@ namespace Microsoft.Maui.Layouts
 					ResolveStarRows(targetSize.Height, true);
 				}
 
-				if (_grid.HorizontalLayoutAlignment == LayoutAlignment.Fill || Dimension.IsExplicitSet(_explicitGridWidth))
+				if (decompressHorizontal)
 				{
 					// Reset the size on all star columns
 					ZeroOutStarSizes(_columns);

--- a/src/Core/src/Layouts/GridLayoutManager.cs
+++ b/src/Core/src/Layouts/GridLayoutManager.cs
@@ -752,7 +752,7 @@ namespace Microsoft.Maui.Layouts
 				bool decompressVertical = Dimension.IsExplicitSet(_explicitGridHeight)
 					|| _grid.VerticalLayoutAlignment == LayoutAlignment.Fill && targetSize.Height > MeasuredGridHeight();
 
-				bool decompressHorizontal = Dimension.IsExplicitSet(_explicitGridWidth) 
+				bool decompressHorizontal = Dimension.IsExplicitSet(_explicitGridWidth)
 					|| _grid.HorizontalLayoutAlignment == LayoutAlignment.Fill && targetSize.Width > MeasuredGridWidth();
 
 				if (decompressVertical)

--- a/src/Core/tests/UnitTests/Layouts/GridLayoutManagerTests.cs
+++ b/src/Core/tests/UnitTests/Layouts/GridLayoutManagerTests.cs
@@ -1936,7 +1936,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 
 		[Fact("ArrangeChildren should arranged within measured size")]
 		[Category(GridStarSizing)]
-		public void ArrangeChildrenShouldArrangedWithinMeasuredSize()
+		public void ArrangeChildrenShouldArrangeWithinMeasuredSize()
 		{
 			var grid = CreateGridLayout(rows: "*");
 			grid.Width.Returns(105);
@@ -1953,7 +1953,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			AssertArranged(view0, 0, 0, measuredSize.Width, measuredSize.Height);
 		}
 
-		[Theory]
+		[Theory, Category(GridStarSizing)]
 		[InlineData(LayoutAlignment.Center, true)]
 		[InlineData(LayoutAlignment.Center, false)]
 		[InlineData(LayoutAlignment.Start, true)]
@@ -1980,7 +1980,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			Assert.Equal(20, measuredSize.Width);
 		}
 
-		[Theory]
+		[Theory, Category(GridStarSizing)]
 		[InlineData(true, 100)]
 		[InlineData(false, 100)]
 		[InlineData(true, 15)]
@@ -2002,7 +2002,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			AssertArranged(view0, new Rect(0, 0, constraint, 100));
 		}
 
-		[Theory]
+		[Theory, Category(GridStarSizing)]
 		[InlineData(LayoutAlignment.Center, true)]
 		[InlineData(LayoutAlignment.Center, false)]
 		[InlineData(LayoutAlignment.Start, true)]
@@ -2029,7 +2029,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			AssertArranged(view0, new Rect(0, 0, 20, 100));
 		}
 
-		[Theory]
+		[Theory, Category(GridStarSizing)]
 		[InlineData(LayoutAlignment.Center, true)]
 		[InlineData(LayoutAlignment.Center, false)]
 		[InlineData(LayoutAlignment.Start, true)]
@@ -2056,7 +2056,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			Assert.Equal(20, measuredSize.Height);
 		}
 
-		[Theory]
+		[Theory, Category(GridStarSizing)]
 		[InlineData(true, 100)]
 		[InlineData(false, 100)]
 		[InlineData(true, 15)]
@@ -2078,7 +2078,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			AssertArranged(view0, new Rect(0, 0, 100, constraint));
 		}
 
-		[Theory]
+		[Theory, Category(GridStarSizing)]
 		[InlineData(LayoutAlignment.Center, true)]
 		[InlineData(LayoutAlignment.Center, false)]
 		[InlineData(LayoutAlignment.Start, true)]
@@ -2104,7 +2104,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			AssertArranged(view0, new Rect(0, 0, 100, 20));
 		}
 
-		[Fact]
+		[Fact, Category(GridStarSizing)]
 		public void StarRowsResizeWhenGridExpandsToFill()
 		{
 			var grid = CreateGridLayout(rows: "*");
@@ -2130,7 +2130,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			AssertArranged(view0, new Rect(0, 0, 20, 100));
 		}
 
-		[Fact]
+		[Fact, Category(GridStarSizing)]
 		public void StarColumnsResizeWhenGridExpandsToFill()
 		{
 			var grid = CreateGridLayout(columns: "*");
@@ -2426,6 +2426,76 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			// The Auto row has no Views, so we expect it to have zero height; the single view should
 			// be arranged at the top left corner
 			AssertArranged(view0, new Rect(0, 0, 20, 20));
+		}
+
+		[Fact, Category(GridStarSizing)]
+		public void UnconstrainedStarRowsRetainTheirHeightsWhenArrangedAtMeasuredSize()
+		{
+			// This test accounts for the situation where a Grid has Rows marked as "*", is measured
+			// without height constraint, is vertically set to Fill, and is arranged at the measured height.
+			// Basically, a situation where the Grid is inside a vertically-oriented ScrollView or StackLayout, 
+			// and the concept of vertical "Fill" doesn't mean anything. In that situation, the rows should 
+			// retain their automatic sizing, rather than being evenly distributed as usual.
+
+			var grid = CreateGridLayout(rows: "*, *, *");
+			grid.VerticalLayoutAlignment.Returns(LayoutAlignment.Fill);
+
+			var view0 = CreateTestView(new Size(20, 20));
+			var view1 = CreateTestView(new Size(20, 40));
+			var view2 = CreateTestView(new Size(20, 60));
+
+			SubstituteChildren(grid, view0, view1, view2);
+			
+			SetLocation(grid, view0, row: 0);
+			SetLocation(grid, view1, row: 1);
+			SetLocation(grid, view2, row: 2);
+
+			// Measure the Grid with no height constraint, then arrange it using the resulting size
+			// Unconstrained, we expect the views to total 20 + 40 + 60 = 120 height
+			// Since we're arranging it at that same height, there's reason for it to expand the items
+			// so we expect them to be arranged at the same heights
+			var measure = MeasureAndArrange(grid, widthConstraint: 200, heightConstraint: double.PositiveInfinity);
+
+			Assert.Equal(120, measure.Height);
+
+			AssertArranged(view0, new Rect(0, 0, 20, 20));
+			AssertArranged(view1, new Rect(0, 20, 20, 40));
+			AssertArranged(view2, new Rect(0, 60, 20, 60));
+		}
+
+		[Fact, Category(GridStarSizing)]
+		public void UnconstrainedStarColumnsRetainTheirWidthsWhenArrangedAtMeasuredSize()
+		{
+			// This test accounts for the situation where a Grid has Columns marked as "*", is measured
+			// without width constraint, is horizontally set to Fill, and is arranged at the measured width.
+			// Basically, a situation where the Grid is inside a horizontally-oriented ScrollView or StackLayout, 
+			// and the concept of horizontal "Fill" doesn't mean anything. In that situation, the columns should 
+			// retain their automatic sizing, rather than being evenly distributed as usual.
+
+			var grid = CreateGridLayout(columns: "*, *, *");
+			grid.HorizontalLayoutAlignment.Returns(LayoutAlignment.Fill);
+
+			var view0 = CreateTestView(new Size(20, 20));
+			var view1 = CreateTestView(new Size(40, 20));
+			var view2 = CreateTestView(new Size(60, 20));
+
+			SubstituteChildren(grid, view0, view1, view2);
+
+			SetLocation(grid, view0, col: 0);
+			SetLocation(grid, view1, col: 1);
+			SetLocation(grid, view2, col: 2);
+
+			// Measure the Grid with no width constraint, then arrange it using the resulting size
+			// Unconstrained, we expect the views to total 20 + 40 + 60 = 120 width
+			// Since we're arranging it at that same width, there's reason for it to expand the items
+			// so we expect them to be arranged at the same widths
+			var measure = MeasureAndArrange(grid, widthConstraint: double.PositiveInfinity, heightConstraint: 200);
+			
+			Assert.Equal(120, measure.Width);
+
+			AssertArranged(view0, new Rect(0, 0, 20, 20));
+			AssertArranged(view1, new Rect(20, 00, 40, 20));
+			AssertArranged(view2, new Rect(60, 0, 60, 20));
 		}
 	}
 }

--- a/src/Core/tests/UnitTests/Layouts/GridLayoutManagerTests.cs
+++ b/src/Core/tests/UnitTests/Layouts/GridLayoutManagerTests.cs
@@ -2445,7 +2445,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			var view2 = CreateTestView(new Size(20, 60));
 
 			SubstituteChildren(grid, view0, view1, view2);
-			
+
 			SetLocation(grid, view0, row: 0);
 			SetLocation(grid, view1, row: 1);
 			SetLocation(grid, view2, row: 2);
@@ -2490,7 +2490,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			// Since we're arranging it at that same width, there's reason for it to expand the items
 			// so we expect them to be arranged at the same widths
 			var measure = MeasureAndArrange(grid, widthConstraint: double.PositiveInfinity, heightConstraint: 200);
-			
+
 			Assert.Equal(120, measure.Width);
 
 			AssertArranged(view0, new Rect(0, 0, 20, 20));


### PR DESCRIPTION
### Description of Change

In a layout like this one:

```xaml
<VerticalStackLayout>
    <Grid RowDefinitions="*,*,*" VerticalOptions="Fill">
        <Border StrokeThickness="2" Stroke="LightBlue">
            <Label Text="Hello"></Label>
        </Border>
        <Border Grid.Row="1" Stroke="Orange" StrokeThickness="5">
            <Label Text="Hello" HeightRequest="25"></Label>
        </Border>
        <Border Grid.Row="2" Stroke="Red" StrokeThickness="10">
            <Label Text="Hello" HeightRequest="50"></Label>
        </Border>
    </Grid>
</VerticalStackLayout>
```

The Grid is taking the natural stacked size of the rows and trying to distribute the heights evenly (because of the * values), even though the `VerticalOptions="Fill"` shouldn't have any meaning in a vertically unconstrained layout. This ends up creating some weird layout results. The Grid _should_ be ignoring the "Fill" in this situation and just leaving the rows at their originally measured heights. (A similar issue is present for columns in horizontally unconstrained layouts.)

This PR fixes the issue so the Grid behaves. 


