### PR TITLE
RadioButton Default Template Fill Theme Fix and new Theme Colors for Samples app

### DIFF
--- a/src/Controls/samples/Controls.Sample/AppResources.xaml
+++ b/src/Controls/samples/Controls.Sample/AppResources.xaml
@@ -27,6 +27,18 @@
     <Color x:Key="DarkTextSecondaryColor">#f5f5f5</Color>
     <Color x:Key="DarkBorderColor">#fefefe</Color>
 
+    <!-- Older Dynamic Themes for RadioButtons -->
+    <!--<Color x:Key="RadioButtonThemeColor">#5639b0</Color>-->
+    <!--<Color x:Key="RadioButtonCheckMarkThemeColor">#7e2bea</Color>-->
+
+    <!--Individual Dark/Light Theme colors for RadioButton Components -->
+    <SolidColorBrush x:Key="RadioButtonOuterEllipseStrokeLight">#5639b0</SolidColorBrush>
+    <SolidColorBrush x:Key="RadioButtonOuterEllipseStrokeDark">#7e2bea</SolidColorBrush>
+    <SolidColorBrush x:Key="RadioButtonCheckGlyphStrokeLight">#5639b0</SolidColorBrush>
+    <SolidColorBrush x:Key="RadioButtonCheckGlyphStrokeDark">#7e2bea</SolidColorBrush>
+    <SolidColorBrush x:Key="RadioButtonCheckGlyphFillLight">#5639b0</SolidColorBrush>
+    <SolidColorBrush x:Key="RadioButtonCheckGlyphFillDark">#7e2bea</SolidColorBrush>
+
     <!-- STYLES -->
     <Style x:Key="SearchBorderStyle" TargetType="Frame">
         <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource LightBackgroundSecondaryColor}, Dark={StaticResource DarkBackgroundSecondaryColor}}" />

--- a/src/Controls/samples/Controls.Sample/AppResources.xaml
+++ b/src/Controls/samples/Controls.Sample/AppResources.xaml
@@ -27,10 +27,6 @@
     <Color x:Key="DarkTextSecondaryColor">#f5f5f5</Color>
     <Color x:Key="DarkBorderColor">#fefefe</Color>
 
-    <!-- Older Dynamic Themes for RadioButtons -->
-    <!--<Color x:Key="RadioButtonThemeColor">#5639b0</Color>-->
-    <!--<Color x:Key="RadioButtonCheckMarkThemeColor">#7e2bea</Color>-->
-
     <!--Individual Dark/Light Theme colors for RadioButton Components -->
     <SolidColorBrush x:Key="RadioButtonOuterEllipseStrokeLight">#5639b0</SolidColorBrush>
     <SolidColorBrush x:Key="RadioButtonOuterEllipseStrokeDark">#7e2bea</SolidColorBrush>

--- a/src/Controls/src/Core/RadioButton.cs
+++ b/src/Controls/src/Core/RadioButton.cs
@@ -526,6 +526,8 @@ namespace Microsoft.Maui.Controls
 			object outerEllipseVisualStateDark = null;
 			object checkMarkVisualStateLight = null;
 			object checkMarkVisualStateDark = null;
+			object checkMarkFillVisualStateLight = null;
+			object checkMarkFillVisualStateDark = null;
 
 			if (!normalEllipse.TrySetDynamicThemeColor(
 				RadioButtonThemeColor,
@@ -568,8 +570,8 @@ namespace Microsoft.Maui.Controls
 					Ellipse.FillProperty,
 					SolidColorBrush.White,
 					SolidColorBrush.Black,
-					out _,
-					out _);
+					out checkMarkFillVisualStateLight,
+					out checkMarkFillVisualStateDark);
 			}
 
 			contentPresenter.SetBinding(MarginProperty, new Binding("Padding", source: RelativeBindingSource.TemplatedParent));
@@ -620,7 +622,7 @@ namespace Microsoft.Maui.Controls
 				{
 					Property = Shape.FillProperty,
 					TargetName = CheckedIndicator,
-					Value = dynamicCheckMarkThemeColor is not null ? dynamicCheckMarkThemeColor : new AppThemeBinding() { Light = checkMarkVisualStateLight, Dark = checkMarkVisualStateDark }
+					Value = dynamicCheckMarkThemeColor is not null ? dynamicCheckMarkThemeColor : new AppThemeBinding() { Light = checkMarkFillVisualStateLight, Dark = checkMarkFillVisualStateDark }
 				});
 			checkedStates.States.Add(checkedVisualState);
 


### PR DESCRIPTION
### Description of Change
Fixed issue where fill property was not populating from ResourceDictionary. 
Added Light/Dark theme colors for RadioButton components to AppResources of sample app to visually demonstrate. (These were the default before, Black for Light and White for Dark modes.)

For the Samples app, I've chosen the previously chosen accent colors:
<img width="427" alt="image" src="https://user-images.githubusercontent.com/89540402/226802965-27e6ebb8-0c49-46e2-aae8-a252eeffff74.png">
<img width="420" alt="image" src="https://user-images.githubusercontent.com/89540402/226803038-895d930d-9ffc-4d6c-a8b2-0e7ac559dfd5.png">