### PR TITLE
[CI] Fix the generated rollback files.

### DIFF
--- a/src/Workload/Microsoft.NET.Sdk.Maui/Rollback.in.json
+++ b/src/Workload/Microsoft.NET.Sdk.Maui/Rollback.in.json
@@ -5,8 +5,8 @@
   "microsoft.net.sdk.macos": "@MicrosoftmacOSSdkPackageVersion@/@DotNetMaciOSManifestVersionBand@",
   "microsoft.net.sdk.maui": "@VERSION@/@DotNetMauiManifestVersionBand@",
   "microsoft.net.sdk.tvos": "@MicrosofttvOSSdkPackageVersion@/@DotNetMaciOSManifestVersionBand@",
-  "microsoft.net.workload.mono.toolchain.net6": "@MicrosoftNETCoreAppRefPackageVersion@/@DotNetMonoManifestVersionBand@",
   "microsoft.net.workload.mono.toolchain.net7": "@MicrosoftNETCoreAppRefPackageVersion@/@DotNetMonoManifestVersionBand@",
+  "microsoft.net.workload.mono.toolchain.current": "@MicrosoftNETCoreAppRefPackageVersion@/@DotNetMonoManifestVersionBand@",
   "microsoft.net.workload.emscripten.net6": "@MicrosoftNETWorkloadEmscriptenPackageVersion@/@DotNetEmscriptenManifestVersionBand@",
   "microsoft.net.workload.emscripten.net7": "@MicrosoftNETWorkloadEmscriptenPackageVersion@/@DotNetEmscriptenManifestVersionBand@"
 }

--- a/src/Workload/Microsoft.NET.Sdk.Maui/Rollback.in.json
+++ b/src/Workload/Microsoft.NET.Sdk.Maui/Rollback.in.json
@@ -7,6 +7,6 @@
   "microsoft.net.sdk.tvos": "@MicrosofttvOSSdkPackageVersion@/@DotNetMaciOSManifestVersionBand@",
   "microsoft.net.workload.mono.toolchain.net7": "@MicrosoftNETCoreAppRefPackageVersion@/@DotNetMonoManifestVersionBand@",
   "microsoft.net.workload.mono.toolchain.current": "@MicrosoftNETCoreAppRefPackageVersion@/@DotNetMonoManifestVersionBand@",
-  "microsoft.net.workload.emscripten.net6": "@MicrosoftNETWorkloadEmscriptenPackageVersion@/@DotNetEmscriptenManifestVersionBand@",
-  "microsoft.net.workload.emscripten.net7": "@MicrosoftNETWorkloadEmscriptenPackageVersion@/@DotNetEmscriptenManifestVersionBand@"
+  "microsoft.net.workload.emscripten.net7": "@MicrosoftNETWorkloadEmscriptenPackageVersion@/@DotNetEmscriptenManifestVersionBand@",
+  "microsoft.net.workload.emscripten.current": "@MicrosoftNETWorkloadEmscriptenPackageVersion@/@DotNetEmscriptenManifestVersionBand@"
 }


### PR DESCRIPTION
As it is right now the generated rollback files look like the following
```json
{
"microsoft.net.sdk.android": "34.0.0-preview.2.187/8.0.100-preview.2",
"microsoft.net.sdk.ios": "16.2.379-net8-p2/8.0.100-preview.2",
"microsoft.net.sdk.maccatalyst": "16.2.379-net8-p2/8.0.100-preview.2",
"microsoft.net.sdk.macos": "13.1.379-net8-p2/8.0.100-preview.2",
"microsoft.net.sdk.maui": "8.0.0-preview.2.5602/8.0.100-preview.2",
"microsoft.net.sdk.tvos": "16.1.1167-net8-p2/8.0.100-preview.2",
"microsoft.net.workload.mono.toolchain.net6": "8.0.0-preview.2.23128.3/8.0.100-preview.2",
"microsoft.net.workload.mono.toolchain.net7": "8.0.0-preview.2.23128.3/8.0.100-preview.2",
"microsoft.net.workload.emscripten.net6": "8.0.0-preview.2.23127.1/8.0.100-preview.2",
"microsoft.net.workload.emscripten.net7": "8.0.0-preview.2.23127.1/8.0.100-preview.2"
}
```

While they should look like the following to be able to be used for dogfooding.
```json
{
  "microsoft.net.sdk.android": "34.0.0-preview.2.181/8.0.100-preview.2",
  "microsoft.net.sdk.ios": "16.2.367-net8-p2/8.0.100-preview.2",
  "microsoft.net.sdk.maccatalyst": "16.2.367-net8-p2/8.0.100-preview.2",
  "microsoft.net.sdk.macos": "13.1.367-net8-p2/8.0.100-preview.2",
  "microsoft.net.sdk.maui": "8.0.0-preview.2.7832/8.0.100-preview.2",
  "microsoft.net.sdk.tvos": "16.1.1155-net8-p2/8.0.100-preview.2",
  "microsoft.net.workload.mono.toolchain.net7": "8.0.0-preview.2.23127.2/8.0.100-preview.2",
  "microsoft.net.workload.mono.toolchain.current": "8.0.0-preview.2.23127.2/8.0.100-preview.2",
  "microsoft.net.workload.emscripten.net7": "8.0.0-preview.2.23127.1/8.0.100-preview.2",
  "microsoft.net.workload.emscripten.current": "8.0.0-preview.2.23127.1/8.0.100-preview.2"
}
```


