### PR TITLE
[net8] Bump to latest .NET 8 Preview 3 builds

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,16 +1,16 @@
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.Dotnet.Sdk.Internal" Version="8.0.100-preview.3.23163.4" CoherentParentDependency="Microsoft.Android.Sdk.Windows">
+    <Dependency Name="Microsoft.Dotnet.Sdk.Internal" Version="8.0.100-preview.3.23170.5" CoherentParentDependency="Microsoft.Android.Sdk.Windows">
       <Uri>https://github.com/dotnet/installer</Uri>
-      <Sha>cddf8e60e12dc484fd551d18e0c37bf1412e7ec2</Sha>
+      <Sha>c3730935bc3a06db5d51e8f3f36d88b8056a2cb5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="8.0.0-preview.3.23159.4" CoherentParentDependency="Microsoft.Android.Sdk.Windows">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="8.0.0-preview.3.23168.2" CoherentParentDependency="Microsoft.Android.Sdk.Windows">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>a92ed6e2ce778c8b18dfa66f8f75368eca901f99</Sha>
+      <Sha>2aec3816f9bbc0eda3261daa335a05ea0df31b9c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Android.Sdk.Windows" Version="34.0.0-preview.3.213">
+    <Dependency Name="Microsoft.Android.Sdk.Windows" Version="34.0.0-preview.3.217">
       <Uri>https://github.com/xamarin/xamarin-android</Uri>
-      <Sha>c31f6783a545133a5f06053c1ac280b654128927</Sha>
+      <Sha>7d97205889411746b829881c2e468e7cb2534a3a</Sha>
     </Dependency>
     <Dependency Name="Microsoft.MacCatalyst.Sdk" Version="16.2.443-net8-p3">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
@@ -28,9 +28,9 @@
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
       <Sha>fb95323a395c3ab2d43ec9db0556dbc9dbc54e6d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Workload.Emscripten.Current.Manifest-8.0.100-preview.3" Version="8.0.0-preview.3.23156.1" CoherentParentDependency="Microsoft.NETCore.App.Ref">
+    <Dependency Name="Microsoft.NET.Workload.Emscripten.Current.Manifest-8.0.100.Transport" Version="8.0.0-preview.3.23167.1" CoherentParentDependency="Microsoft.NETCore.App.Ref">
       <Uri>https://github.com/dotnet/emsdk</Uri>
-      <Sha>4c1f185a78249c6974c1f6c248dad189fe70497b</Sha>
+      <Sha>25d9f7a5e38a2d61b94ff341bc0d32135fcb15f9</Sha>
     </Dependency>
     <Dependency Name="Microsoft.WindowsAppSDK" Version="0.0.1">
       <Uri>https://dev.azure.com/microsoft/ProjectReunion/_git/ProjectReunionInternal</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -3,15 +3,15 @@
     <!-- Current previous .NET SDK major version's stable release of MAUI packages -->
     <MicrosoftMauiPreviousDotNetReleasedVersion>7.0.59</MicrosoftMauiPreviousDotNetReleasedVersion>
     <!-- dotnet/installer -->
-    <MicrosoftDotnetSdkInternalPackageVersion>8.0.100-preview.3.23163.4</MicrosoftDotnetSdkInternalPackageVersion>
+    <MicrosoftDotnetSdkInternalPackageVersion>8.0.100-preview.3.23170.5</MicrosoftDotnetSdkInternalPackageVersion>
     <!-- dotnet/runtime -->
-    <MicrosoftNETCoreAppRefPackageVersion>8.0.0-preview.3.23159.4</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>8.0.0-preview.3.23168.2</MicrosoftNETCoreAppRefPackageVersion>
     <!-- NOTE: should eventually revert back to $(MicrosoftNETCoreAppRefPackageVersion) in .NET 7 -->
     <MicrosoftExtensionsPackageVersion>8.0.0-preview.2.23128.3</MicrosoftExtensionsPackageVersion>
     <MicrosoftExtensionsServicingPackageVersion>8.0.0-preview.2.23128.3</MicrosoftExtensionsServicingPackageVersion>
     <SystemCodeDomPackageVersion>8.0.0-preview.2.23128.3</SystemCodeDomPackageVersion>
     <!-- xamarin/xamarin-android -->
-    <MicrosoftAndroidSdkWindowsPackageVersion>34.0.0-preview.3.213</MicrosoftAndroidSdkWindowsPackageVersion>
+    <MicrosoftAndroidSdkWindowsPackageVersion>34.0.0-preview.3.217</MicrosoftAndroidSdkWindowsPackageVersion>
     <!-- xamarin/xamarin-macios -->
     <MicrosoftMacCatalystSdkPackageVersion>16.2.443-net8-p3</MicrosoftMacCatalystSdkPackageVersion>
     <MicrosoftmacOSSdkPackageVersion>13.1.443-net8-p3</MicrosoftmacOSSdkPackageVersion>
@@ -20,8 +20,8 @@
     <!-- Samsung/Tizen.NET -->
     <SamsungTizenSdkPackageVersion>7.0.107</SamsungTizenSdkPackageVersion>
     <!-- emsdk -->
-    <MicrosoftNETWorkloadEmscriptenCurrentManifest80100preview3Version>8.0.0-preview.3.23156.1</MicrosoftNETWorkloadEmscriptenCurrentManifest80100preview3Version>
-    <MicrosoftNETWorkloadEmscriptenPackageVersion>$(MicrosoftNETWorkloadEmscriptenCurrentManifest80100preview3Version)</MicrosoftNETWorkloadEmscriptenPackageVersion>
+    <MicrosoftNETWorkloadEmscriptenCurrentManifest80100TransportVersion>8.0.0-preview.3.23167.1</MicrosoftNETWorkloadEmscriptenCurrentManifest80100TransportVersion>
+    <MicrosoftNETWorkloadEmscriptenPackageVersion>$(MicrosoftNETWorkloadEmscriptenCurrentManifest80100TransportVersion)</MicrosoftNETWorkloadEmscriptenPackageVersion>
     <!-- wasdk -->
     <MicrosoftWindowsAppSDKPackageVersion>1.2.230313.1</MicrosoftWindowsAppSDKPackageVersion>
     <MicrosoftWindowsSDKBuildToolsPackageVersion>10.0.22621.755</MicrosoftWindowsSDKBuildToolsPackageVersion>


### PR DESCRIPTION
Changes: https://github.com/xamarin/xamarin-android/compare/c31f678...7d97205

Manually fixed the dependency:

    Microsoft.NET.Workload.Emscripten.Current.Manifest-8.0.100-preview.3

Which is now:

    Microsoft.NET.Workload.Emscripten.Current.Manifest-8.0.100.Transport

And then I ran:

    > darc update-dependencies --id 171359
    Looking up build with BAR id 171359
    Updating 'Microsoft.Android.Sdk.Windows': '34.0.0-preview.3.213' => '34.0.0-preview.3.217' (from build 'main-7d97205889411746b829881c2e468e7cb2534a3a-1' of 'https://github.com/xamarin/xamarin-android')
    Checking for coherency updates...
    Using 'Strict' coherency mode. If this fails, a second attempt utilizing 'Legacy' Coherency mode will be made.
    Updating 'Microsoft.Dotnet.Sdk.Internal': '8.0.100-preview.3.23163.4' => '8.0.100-preview.3.23170.5' to ensure coherency with Microsoft.Android.Sdk.Windows@34.0.0-preview.3.217
    Updating 'Microsoft.NETCore.App.Ref': '8.0.0-preview.3.23159.4' => '8.0.0-preview.3.23168.2' to ensure coherency with Microsoft.Android.Sdk.Windows@34.0.0-preview.3.217
    Updating 'Microsoft.NET.Workload.Emscripten.Current.Manifest-8.0.100.Transport': '' => '8.0.0-preview.3.23167.1' to ensure coherency with Microsoft.NETCore.App.Ref@8.0.0-preview.3.23159.4
    Local dependencies updated based on build with BAR id 171359 (main-7d97205889411746b829881c2e468e7cb2534a3a-1 from https://github.com/xamarin/xamarin-android@main)