### PR TITLE
Centralize logic for handling logical children

### DIFF
--- a/src/Controls/src/Core/Application.cs
+++ b/src/Controls/src/Core/Application.cs
@@ -25,7 +25,6 @@ namespace Microsoft.Maui.Controls
 #pragma warning restore CS0612 // Type or member is obsolete
 
 		IAppIndexingProvider? _appIndexProvider;
-		ReadOnlyCollection<Element>? _logicalChildren;
 		bool _isStarted;
 
 		static readonly SemaphoreSlim SaveSemaphore = new SemaphoreSlim(1, 1);
@@ -111,16 +110,11 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		internal override IReadOnlyList<Element> LogicalChildrenInternal =>
-			_logicalChildren ??= new ReadOnlyCollection<Element>(InternalChildren);
-
 		/// <include file="../../docs/Microsoft.Maui.Controls/Application.xml" path="//Member[@MemberName='NavigationProxy']/Docs/*" />
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public NavigationProxy? NavigationProxy { get; private set; }
 
 		internal IResourceDictionary SystemResources => _systemResources.Value;
-
-		ObservableCollection<Element> InternalChildren { get; } = new ObservableCollection<Element>();
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/Application.xml" path="//Member[@MemberName='SetAppIndexingProvider']/Docs/*" />
 		[EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/Controls/src/Core/Border.cs
+++ b/src/Controls/src/Core/Border.cs
@@ -13,7 +13,6 @@ namespace Microsoft.Maui.Controls
 	public class Border : View, IContentView, IBorderView, IPaddingElement
 	{
 		float[]? _strokeDashPattern;
-		ReadOnlyCollection<Element>? _logicalChildren;
 
 		WeakNotifyPropertyChangedProxy? _strokeShapeProxy = null;
 		PropertyChangedEventHandler? _strokeShapeChanged;
@@ -25,11 +24,6 @@ namespace Microsoft.Maui.Controls
 			_strokeShapeProxy?.Unsubscribe();
 			_strokeProxy?.Unsubscribe();
 		}
-
-		internal ObservableCollection<Element> InternalChildren { get; } = new();
-
-		internal override IReadOnlyList<Element> LogicalChildrenInternal =>
-			_logicalChildren ??= new ReadOnlyCollection<Element>(InternalChildren);
 
 		/// <summary>Bindable property for <see cref="Content"/>.</summary>
 		public static readonly BindableProperty ContentProperty = BindableProperty.Create(nameof(Content), typeof(View),
@@ -274,17 +268,12 @@ namespace Microsoft.Maui.Controls
 			{
 				if (oldValue is Element oldElement)
 				{
-					int index = border.InternalChildren.IndexOf(oldElement);
-					if (border.InternalChildren.Remove(oldElement))
-					{
-						border.OnChildRemoved(oldElement, index);
-					}
+					border.RemoveLogicalChildInternal(oldElement);
 				}
 
 				if (newValue is Element newElement)
 				{
-					border.InternalChildren.Add(newElement);
-					border.OnChildAdded(newElement);
+					border.AddLogicalChildInternal(newElement);
 				}
 			}
 

--- a/src/Controls/src/Core/Cells/ViewCell.cs
+++ b/src/Controls/src/Core/Cells/ViewCell.cs
@@ -8,8 +8,6 @@ namespace Microsoft.Maui.Controls
 	[ContentProperty("View")]
 	public class ViewCell : Cell
 	{
-		ReadOnlyCollection<Element> _logicalChildren;
-
 		View _view;
 
 		/// <include file="../../../docs/Microsoft.Maui.Controls/ViewCell.xml" path="//Member[@MemberName='View']/Docs/*" />
@@ -25,7 +23,7 @@ namespace Microsoft.Maui.Controls
 
 				if (_view != null)
 				{
-					OnChildRemoved(_view, 0);
+					RemoveLogicalChildInternal(_view);
 					_view.ComputedConstraint = LayoutConstraint.None;
 				}
 
@@ -34,18 +32,12 @@ namespace Microsoft.Maui.Controls
 				if (_view != null)
 				{
 					_view.ComputedConstraint = LayoutConstraint.Fixed;
-					_logicalChildren = new ReadOnlyCollection<Element>(new List<Element>(new[] { View }));
-					OnChildAdded(_view);
+					AddLogicalChildInternal(_view);
 				}
-				else
-				{
-					_logicalChildren = null;
-				}
+
 				ForceUpdateSize();
 				OnPropertyChanged();
 			}
 		}
-
-		internal override IReadOnlyList<Element> LogicalChildrenInternal => _logicalChildren ?? base.LogicalChildrenInternal;
 	}
 }

--- a/src/Controls/src/Core/ContextFlyout.cs
+++ b/src/Controls/src/Core/ContextFlyout.cs
@@ -9,11 +9,10 @@ namespace Microsoft.Maui.Controls
 
 	public partial class MenuFlyout : FlyoutBase, IMenuFlyout // Same pattern as MenuBarItem
 	{
-		ReadOnlyCastingList<Element, IMenuElement> _logicalChildren;
-		readonly ObservableCollection<IMenuElement> _menus = new ObservableCollection<IMenuElement>();
+		readonly List<IMenuElement> _menus = new List<IMenuElement>();
 
-		internal override IReadOnlyList<Element> LogicalChildrenInternal =>
-			_logicalChildren ??= new ReadOnlyCastingList<Element, IMenuElement>(_menus);
+		private protected override IList<Element> LogicalChildrenInternalBackingStore
+			=> new CastingList<Element, IMenuElement>(_menus);
 
 		public IMenuElement this[int index]
 		{
@@ -32,7 +31,7 @@ namespace Microsoft.Maui.Controls
 		public void Add(IMenuElement item)
 		{
 			var index = _menus.Count;
-			_menus.Add(item);
+			AddLogicalChildInternal((Element)item);
 			NotifyHandler(nameof(IMenuFlyoutHandler.Add), index, item);
 
 			// Take care of the Element internal bookkeeping
@@ -70,27 +69,15 @@ namespace Microsoft.Maui.Controls
 
 		public void Insert(int index, IMenuElement item)
 		{
-			_menus.Insert(index, item);
+			InsertLogicalChildInternal(index, (Element)item);
 			NotifyHandler(nameof(IMenuFlyoutHandler.Insert), index, item);
-
-			// Take care of the Element internal bookkeeping
-			if (item is Element element)
-			{
-				OnChildAdded(element);
-			}
 		}
 
 		public bool Remove(IMenuElement item)
 		{
 			var index = _menus.IndexOf(item);
-			var result = _menus.Remove(item);
+			var result = RemoveLogicalChildInternal((Element)item);
 			NotifyHandler(nameof(IMenuFlyoutHandler.Remove), index, item);
-
-			// Take care of the Element internal bookkeeping
-			if (item is Element element)
-			{
-				OnChildRemoved(element, index);
-			}
 
 			return result;
 		}
@@ -98,14 +85,7 @@ namespace Microsoft.Maui.Controls
 		public void RemoveAt(int index)
 		{
 			var item = _menus[index];
-			_menus.RemoveAt(index);
-			NotifyHandler(nameof(IMenuFlyoutHandler.Remove), index, item);
-
-			// Take care of the Element internal bookkeeping
-			if (item is Element element)
-			{
-				OnChildRemoved(element, index);
-			}
+			Remove(item);
 		}
 
 		IEnumerator IEnumerable.GetEnumerator()

--- a/src/Controls/src/Core/ContextFlyout.cs
+++ b/src/Controls/src/Core/ContextFlyout.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Maui.Controls
 		public bool Remove(IMenuElement item)
 		{
 			var index = _menus.IndexOf(item);
-			var result = RemoveLogicalChildInternal((Element)item);
+			var result = RemoveLogicalChildInternal((Element)item, index);
 			NotifyHandler(nameof(IMenuFlyoutHandler.Remove), index, item);
 
 			return result;
@@ -85,7 +85,8 @@ namespace Microsoft.Maui.Controls
 		public void RemoveAt(int index)
 		{
 			var item = _menus[index];
-			Remove(item);
+			RemoveLogicalChildInternal((Element)item, index);
+			NotifyHandler(nameof(IMenuFlyoutHandler.Remove), index, item);
 		}
 
 		IEnumerator IEnumerable.GetEnumerator()

--- a/src/Controls/src/Core/Element.cs
+++ b/src/Controls/src/Core/Element.cs
@@ -37,6 +37,10 @@ namespace Microsoft.Maui.Controls
 
 		string _styleId;
 
+		IReadOnlyList<Element> _logicalChildrenReadonly;
+
+		IList<Element> _internalChildren;
+
 		/// <include file="../../docs/Microsoft.Maui.Controls/Element.xml" path="//Member[@MemberName='AutomationId']/Docs/*" />
 		public string AutomationId
 		{
@@ -133,6 +137,8 @@ namespace Microsoft.Maui.Controls
 		public ReadOnlyCollection<Element> LogicalChildren =>
 			new ReadOnlyCollection<Element>(new TemporaryWrapper(LogicalChildrenInternal));
 
+		IReadOnlyList<Element> IElementController.LogicalChildren => LogicalChildrenInternal;
+
 		void SetupChildren()
 		{
 			_logicalChildrenReadonly ??= new ReadOnlyCollection<Element>(LogicalChildrenInternalBackingStore);
@@ -228,11 +234,6 @@ namespace Microsoft.Maui.Controls
 
 		// return null by default so we don't need to foreach over an empty collection in OnPropertyChanged
 		internal virtual IEnumerable<Element> ChildrenNotDrawnByThisElement => null;
-
-		IReadOnlyList<Element> _logicalChildrenReadonly;
-		IList<Element> _internalChildren;
-
-		IReadOnlyList<Element> IElementController.LogicalChildren => LogicalChildrenInternal;
 
 		internal bool Owned { get; set; }
 

--- a/src/Controls/src/Core/Element.cs
+++ b/src/Controls/src/Core/Element.cs
@@ -171,10 +171,13 @@ namespace Microsoft.Maui.Controls
 				return false;
 			}
 
-			if (LogicalChildrenInternalBackingStore is null || !LogicalChildrenInternalBackingStore.Contains(element))
+			if (LogicalChildrenInternalBackingStore is null)
 				return false;
 
 			var oldLogicalIndex = LogicalChildrenInternalBackingStore.IndexOf(element);
+			if (oldLogicalIndex < 0)
+				return false;
+
 			RemoveLogicalChildInternal(element, oldLogicalIndex);
 
 			return true;
@@ -195,7 +198,11 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		bool RemoveLogicalChildInternal(Element element, int oldLogicalIndex)
+		/// <summary>
+		/// This doesn't validate that the oldLogicalIndex is correct, so be sure you're passing in the
+		/// correct index
+		/// </summary>
+		internal bool RemoveLogicalChildInternal(Element element, int oldLogicalIndex)
 		{
 			LogicalChildrenInternalBackingStore.Remove(element);
 			OnChildRemoved(element, oldLogicalIndex);

--- a/src/Controls/src/Core/HandlerImpl/Application/Application.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Application/Application.Impl.cs
@@ -82,10 +82,7 @@ namespace Microsoft.Maui.Controls
 
 			if (window is Element windowElement)
 			{
-				var oldIndex = InternalChildren.IndexOf(windowElement);
-				InternalChildren.RemoveAt(oldIndex);
-				windowElement.Parent = null;
-				OnChildRemoved(windowElement, oldIndex);
+				RemoveLogicalChildInternal(windowElement);
 			}
 
 			_windows.Remove(window);
@@ -134,9 +131,7 @@ namespace Microsoft.Maui.Controls
 
 			if (window is Element windowElement)
 			{
-				windowElement.Parent = this;
-				InternalChildren.Add(windowElement);
-				OnChildAdded(windowElement);
+				AddLogicalChildInternal(windowElement);
 			}
 
 			if (window is NavigableElement ne)

--- a/src/Controls/src/Core/HandlerImpl/Window/Window.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Window/Window.Impl.cs
@@ -600,8 +600,8 @@ namespace Microsoft.Maui.Controls
 			if (oldPage != null)
 			{
 				_menuBarTracker.Target = null;
-				RemoveLogicalChildInternal(oldPage);
 				_visualChildren.Remove(oldPage);
+				RemoveLogicalChildInternal(oldPage);
 				oldPage.HandlerChanged -= OnPageHandlerChanged;
 				oldPage.HandlerChanging -= OnPageHandlerChanging;
 			}
@@ -611,8 +611,8 @@ namespace Microsoft.Maui.Controls
 
 			if (newPage != null)
 			{
-				AddLogicalChildInternal(newPage);
 				_visualChildren.Add(newPage);
+				AddLogicalChildInternal(newPage);
 				newPage.NavigationProxy.Inner = NavigationProxy;
 				_menuBarTracker.Target = newPage;
 

--- a/src/Controls/src/Core/Items/ItemsView.cs
+++ b/src/Controls/src/Core/Items/ItemsView.cs
@@ -14,8 +14,7 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../../docs/Microsoft.Maui.Controls/ItemsView.xml" path="Type[@FullName='Microsoft.Maui.Controls.ItemsView']/Docs/*" />
 	public abstract class ItemsView : View
 	{
-		List<Element> _logicalChildren = new List<Element>();
-
+	
 		/// <summary>Bindable property for <see cref="EmptyView"/>.</summary>
 		public static readonly BindableProperty EmptyViewProperty =
 			BindableProperty.Create(nameof(EmptyView), typeof(object), typeof(ItemsView), null);
@@ -110,48 +109,12 @@ namespace Microsoft.Maui.Controls
 		}
 
 		/// <include file="../../../docs/Microsoft.Maui.Controls/ItemsView.xml" path="//Member[@MemberName='AddLogicalChild']/Docs/*" />
-		public void AddLogicalChild(Element element)
-		{
-			if (element == null)
-			{
-				return;
-			}
-
-			_logicalChildren.Add(element);
-			element.Parent = this;
-			OnChildAdded(element);
-			VisualDiagnostics.OnChildAdded(this, element);
-		}
+		public void AddLogicalChild(Element element) =>
+			AddLogicalChildInternal(element);
 
 		/// <include file="../../../docs/Microsoft.Maui.Controls/ItemsView.xml" path="//Member[@MemberName='RemoveLogicalChild']/Docs/*" />
 		public void RemoveLogicalChild(Element element)
-		{
-			if (element == null)
-			{
-				return;
-			}
-
-			element.Parent = null;
-
-			if (!_logicalChildren.Contains(element))
-				return;
-
-			var oldLogicalIndex = _logicalChildren.IndexOf(element);
-			_logicalChildren.Remove(element);
-			OnChildRemoved(element, oldLogicalIndex);
-			VisualDiagnostics.OnChildRemoved(this, element, oldLogicalIndex);
-		}
-
-		internal void ClearLogicalChildren()
-		{
-			// Reverse for-loop, so children can be removed while iterating
-			for (int i = _logicalChildren.Count - 1; i >= 0; i--)
-			{
-				RemoveLogicalChild(_logicalChildren[i]);
-			}
-		}
-
-		internal override IReadOnlyList<Element> LogicalChildrenInternal => _logicalChildren.AsReadOnly();
+			=> RemoveLogicalChildInternal(element);
 
 		internal static readonly BindableProperty InternalItemsLayoutProperty =
 			BindableProperty.Create(nameof(ItemsLayout), typeof(IItemsLayout), typeof(ItemsView),

--- a/src/Controls/src/Core/Items/ItemsView.cs
+++ b/src/Controls/src/Core/Items/ItemsView.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../../docs/Microsoft.Maui.Controls/ItemsView.xml" path="Type[@FullName='Microsoft.Maui.Controls.ItemsView']/Docs/*" />
 	public abstract class ItemsView : View
 	{
-	
+
 		/// <summary>Bindable property for <see cref="EmptyView"/>.</summary>
 		public static readonly BindableProperty EmptyViewProperty =
 			BindableProperty.Create(nameof(EmptyView), typeof(object), typeof(ItemsView), null);

--- a/src/Controls/src/Core/Layout.cs
+++ b/src/Controls/src/Core/Layout.cs
@@ -80,8 +80,6 @@ namespace Microsoft.Maui.Controls.Compatibility
 		bool _hasDoneLayout;
 		Size _lastLayoutSize = new Size(-1, -1);
 
-		ReadOnlyCollection<Element> _logicalChildren;
-
 		protected Layout()
 		{
 			//if things were added in base ctor (through implicit styles), the items added aren't properly parented
@@ -121,9 +119,10 @@ namespace Microsoft.Maui.Controls.Compatibility
 			}
 		}
 
-		internal ObservableCollection<Element> InternalChildren { get; } = new ObservableCollection<Element>();
+		private protected override IList<Element> LogicalChildrenInternalBackingStore
+			=> InternalChildren;
 
-		internal override IReadOnlyList<Element> LogicalChildrenInternal => _logicalChildren ?? (_logicalChildren = new ReadOnlyCollection<Element>(InternalChildren));
+		internal ObservableCollection<Element> InternalChildren { get; } = new ObservableCollection<Element>();
 
 		public event EventHandler LayoutChanged;
 

--- a/src/Controls/src/Core/Layout/Layout.cs
+++ b/src/Controls/src/Core/Layout/Layout.cs
@@ -13,8 +13,6 @@ namespace Microsoft.Maui.Controls
 	[ContentProperty(nameof(Children))]
 	public abstract partial class Layout : View, Maui.ILayout, IList<IView>, IBindableLayout, IPaddingElement, IVisualTreeElement, ISafeAreaView
 	{
-		ReadOnlyCastingList<Element, IView> _logicalChildren;
-
 		protected ILayoutManager _layoutManager;
 
 		ILayoutManager LayoutManager
@@ -40,8 +38,8 @@ namespace Microsoft.Maui.Controls
 
 		IList IBindableLayout.Children => _children;
 
-		internal override IReadOnlyList<Element> LogicalChildrenInternal =>
-			_logicalChildren ??= new ReadOnlyCastingList<Element, IView>(_children);
+		private protected override IList<Element> LogicalChildrenInternalBackingStore
+			=> new CastingList<Element, IView>(_children);
 
 		public int Count => _children.Count;
 

--- a/src/Controls/src/Core/MenuBarItem.cs
+++ b/src/Controls/src/Core/MenuBarItem.cs
@@ -37,11 +37,10 @@ namespace Microsoft.Maui.Controls
 			set => SetValue(TextProperty, value);
 		}
 
-		ReadOnlyCastingList<Element, IMenuElement> _logicalChildren;
-		readonly ObservableCollection<IMenuElement> _menus = new ObservableCollection<IMenuElement>();
+		readonly List<IMenuElement> _menus = new List<IMenuElement>();
 
-		internal override IReadOnlyList<Element> LogicalChildrenInternal =>
-			_logicalChildren ??= new ReadOnlyCastingList<Element, IMenuElement>(_menus);
+		private protected override IList<Element> LogicalChildrenInternalBackingStore
+			=> new CastingList<Element, IMenuElement>(_menus);
 
 		public IMenuElement this[int index]
 		{
@@ -60,14 +59,8 @@ namespace Microsoft.Maui.Controls
 		public void Add(IMenuElement item)
 		{
 			var index = _menus.Count;
-			_menus.Add(item);
+			AddLogicalChildInternal((Element)item);
 			NotifyHandler(nameof(IMenuBarItemHandler.Add), index, item);
-
-			// Take care of the Element internal bookkeeping
-			if (item is Element element)
-			{
-				OnChildAdded(element);
-			}
 		}
 
 		public void Clear()
@@ -98,43 +91,21 @@ namespace Microsoft.Maui.Controls
 
 		public void Insert(int index, IMenuElement item)
 		{
-			_menus.Insert(index, item);
+			InsertLogicalChildInternal(index, (Element)item);
 			NotifyHandler(nameof(IMenuBarItemHandler.Insert), index, item);
-
-			// Take care of the Element internal bookkeeping
-			if (item is Element element)
-			{
-				OnChildAdded(element);
-			}
 		}
 
 		public bool Remove(IMenuElement item)
 		{
 			var index = _menus.IndexOf(item);
-			var result = _menus.Remove(item);
+			var result = RemoveLogicalChildInternal((Element)item);
 			NotifyHandler(nameof(IMenuBarItemHandler.Remove), index, item);
-
-			// Take care of the Element internal bookkeeping
-			if (item is Element element)
-			{
-				OnChildRemoved(element, index);
-			}
 
 			return result;
 		}
 
-		public void RemoveAt(int index)
-		{
-			var item = _menus[index];
-			_menus.RemoveAt(index);
-			NotifyHandler(nameof(IMenuBarItemHandler.Remove), index, item);
-
-			// Take care of the Element internal bookkeeping
-			if (item is Element element)
-			{
-				OnChildRemoved(element, index);
-			}
-		}
+		public void RemoveAt(int index) =>
+			Remove(_menus[index]);
 
 		IEnumerator IEnumerable.GetEnumerator()
 		{

--- a/src/Controls/src/Core/MenuBarItem.cs
+++ b/src/Controls/src/Core/MenuBarItem.cs
@@ -98,14 +98,18 @@ namespace Microsoft.Maui.Controls
 		public bool Remove(IMenuElement item)
 		{
 			var index = _menus.IndexOf(item);
-			var result = RemoveLogicalChildInternal((Element)item);
-			NotifyHandler(nameof(IMenuBarItemHandler.Remove), index, item);
+			var result = RemoveLogicalChildInternal((Element)item, index);
+			NotifyHandler(nameof(IMenuFlyoutHandler.Remove), index, item);
 
 			return result;
 		}
 
-		public void RemoveAt(int index) =>
-			Remove(_menus[index]);
+		public void RemoveAt(int index)
+		{
+			var item = _menus[index];
+			RemoveLogicalChildInternal((Element)item, index);
+			NotifyHandler(nameof(IMenuFlyoutHandler.Remove), index, item);
+		}
 
 		IEnumerator IEnumerable.GetEnumerator()
 		{

--- a/src/Controls/src/Core/MenuFlyoutSubItem.cs
+++ b/src/Controls/src/Core/MenuFlyoutSubItem.cs
@@ -12,11 +12,10 @@ namespace Microsoft.Maui.Controls
 {
 	public partial class MenuFlyoutSubItem : MenuFlyoutItem, IMenuFlyoutSubItem
 	{
-		ReadOnlyCastingList<Element, IMenuElement> _logicalChildren;
-		readonly ObservableCollection<IMenuElement> _menus = new ObservableCollection<IMenuElement>();
+		readonly List<IMenuElement> _menus = new List<IMenuElement>();
 
-		internal override IReadOnlyList<Element> LogicalChildrenInternal =>
-			_logicalChildren ??= new ReadOnlyCastingList<Element, IMenuElement>(_menus);
+		private protected override IList<Element> LogicalChildrenInternalBackingStore
+			=> new CastingList<Element, IMenuElement>(_menus);
 
 		public IMenuElement this[int index]
 		{
@@ -35,14 +34,8 @@ namespace Microsoft.Maui.Controls
 		public void Add(IMenuElement item)
 		{
 			var index = _menus.Count;
-			_menus.Add(item);
+			AddLogicalChildInternal((Element)item);
 			NotifyHandler(nameof(IMenuBarItemHandler.Add), index, item);
-
-			// Take care of the Element internal bookkeeping
-			if (item is Element element)
-			{
-				OnChildAdded(element);
-			}
 		}
 
 		public void Clear()
@@ -73,43 +66,21 @@ namespace Microsoft.Maui.Controls
 
 		public void Insert(int index, IMenuElement item)
 		{
-			_menus.Insert(index, item);
+			InsertLogicalChildInternal(index, (Element)item);
 			NotifyHandler(nameof(IMenuFlyoutSubItemHandler.Insert), index, item);
-
-			// Take care of the Element internal bookkeeping
-			if (item is Element element)
-			{
-				OnChildAdded(element);
-			}
 		}
 
 		public bool Remove(IMenuElement item)
 		{
 			var index = _menus.IndexOf(item);
-			var result = _menus.Remove(item);
+			var result = RemoveLogicalChildInternal((Element)item);
 			NotifyHandler(nameof(IMenuFlyoutSubItemHandler.Remove), index, item);
-
-			// Take care of the Element internal bookkeeping
-			if (item is Element element)
-			{
-				OnChildRemoved(element, index);
-			}
 
 			return result;
 		}
 
 		public void RemoveAt(int index)
-		{
-			var item = _menus[index];
-			_menus.RemoveAt(index);
-			NotifyHandler(nameof(IMenuFlyoutSubItemHandler.Remove), index, item);
-
-			// Take care of the Element internal bookkeeping
-			if (item is Element element)
-			{
-				OnChildRemoved(element, index);
-			}
-		}
+			=> Remove(_menus[index]);
 
 		IEnumerator IEnumerable.GetEnumerator()
 		{

--- a/src/Controls/src/Core/MenuFlyoutSubItem.cs
+++ b/src/Controls/src/Core/MenuFlyoutSubItem.cs
@@ -73,14 +73,18 @@ namespace Microsoft.Maui.Controls
 		public bool Remove(IMenuElement item)
 		{
 			var index = _menus.IndexOf(item);
-			var result = RemoveLogicalChildInternal((Element)item);
-			NotifyHandler(nameof(IMenuFlyoutSubItemHandler.Remove), index, item);
+			var result = RemoveLogicalChildInternal((Element)item, index);
+			NotifyHandler(nameof(IMenuFlyoutHandler.Remove), index, item);
 
 			return result;
 		}
 
 		public void RemoveAt(int index)
-			=> Remove(_menus[index]);
+		{
+			var item = _menus[index];
+			RemoveLogicalChildInternal((Element)item, index);
+			NotifyHandler(nameof(IMenuFlyoutHandler.Remove), index, item);
+		}
 
 		IEnumerator IEnumerable.GetEnumerator()
 		{

--- a/src/Controls/src/Core/Page.cs
+++ b/src/Controls/src/Core/Page.cs
@@ -55,8 +55,6 @@ namespace Microsoft.Maui.Controls
 		bool _hasAppeared;
 		private protected bool HasAppeared => _hasAppeared;
 
-		ReadOnlyCollection<Element> _logicalChildren;
-
 		View _titleView;
 
 		List<Action> _pendingActions = new List<Action>();
@@ -158,6 +156,11 @@ namespace Microsoft.Maui.Controls
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public ObservableCollection<Element> InternalChildren { get; } = new ObservableCollection<Element>();
 
+		// Todo rework Page to use AddLogical/RemoveLogical.
+		// Rework all the related parts of the code that interact with the `Page` InternalChildren
+		private protected override IList<Element> LogicalChildrenInternalBackingStore =>
+			InternalChildren;
+
 		internal override IEnumerable<Element> ChildrenNotDrawnByThisElement
 		{
 			get
@@ -172,9 +175,6 @@ namespace Microsoft.Maui.Controls
 					yield return titleViewPart2TheNavBar;
 			}
 		}
-
-		internal override IReadOnlyList<Element> LogicalChildrenInternal =>
-			_logicalChildren ?? (_logicalChildren = new ReadOnlyCollection<Element>(InternalChildren));
 
 		bool ISafeAreaView.IgnoreSafeArea => !On<PlatformConfiguration.iOS>().UsingSafeArea();
 

--- a/src/Controls/src/Core/ReadOnlyCastingList.cs
+++ b/src/Controls/src/Core/ReadOnlyCastingList.cs
@@ -1,6 +1,8 @@
 #nullable disable
+using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Microsoft.Maui.Controls
 {
@@ -31,6 +33,94 @@ namespace Microsoft.Maui.Controls
 		public T this[int index]
 		{
 			get { return _list[index] as T; }
+		}
+	}
+
+	internal class ReadOnlyCastingReadOnlyList<T, TFrom> : IReadOnlyList<T> where T : class where TFrom : class
+	{
+		readonly IReadOnlyList<TFrom> _readonlyList;
+
+		public ReadOnlyCastingReadOnlyList(IReadOnlyList<TFrom> list)
+		{
+			_readonlyList = list;
+		}
+
+		IEnumerator IEnumerable.GetEnumerator()
+		{
+			return ((IEnumerable)_readonlyList).GetEnumerator();
+		}
+
+		public IEnumerator<T> GetEnumerator()
+		{
+			return new CastingEnumerator<T, TFrom>(_readonlyList.GetEnumerator());
+		}
+
+		public int Count
+		{
+			get { return _readonlyList.Count; }
+		}
+
+		public T this[int index]
+		{
+			get { return _readonlyList[index] as T; }
+		}
+	}
+
+	class CastingList<T, TFrom> : IList<T>
+		where T : class
+		where TFrom : class
+	{
+		readonly IList<TFrom> _list;
+
+		public CastingList(IList<TFrom> list)
+		{
+			_list = list;
+		}
+
+		public T this[int index]
+		{
+			get => _list[index] as T;
+			set => _list[index] = value as TFrom;
+		}
+
+		public int Count => _list.Count;
+
+		public bool IsReadOnly => _list.IsReadOnly;
+
+		public void Add(T item) =>
+			_list.Add(item as TFrom);
+
+		public void Clear() => _list.Clear();
+
+		public bool Contains(T item)
+			=> _list.Contains(item as TFrom);
+
+		public void CopyTo(T[] array, int arrayIndex)
+		{
+			for (int i = arrayIndex; i < array.Length; i++)
+			{
+				array[i] = _list[i] as T;
+			}
+		}
+
+		public IEnumerator<T> GetEnumerator() =>
+			new CastingEnumerator<T, TFrom>(_list.GetEnumerator());
+
+		public int IndexOf(T item) =>
+			_list.IndexOf(item as TFrom);
+
+		public void Insert(int index, T item) =>
+			_list.Insert(index, item as TFrom);
+
+		public bool Remove(T item) =>
+			_list.Remove(item as TFrom);
+
+		public void RemoveAt(int index) =>
+			_list.RemoveAt(index);
+
+		IEnumerator IEnumerable.GetEnumerator()
+		{
+			return ((IEnumerable)_list).GetEnumerator();
 		}
 	}
 }

--- a/src/Controls/src/Core/Shell/BaseShellItem.cs
+++ b/src/Controls/src/Core/Shell/BaseShellItem.cs
@@ -27,7 +27,9 @@ namespace Microsoft.Maui.Controls
 
 		protected private ObservableCollection<Element> DeclaredChildren { get; } = new ObservableCollection<Element>();
 		readonly ObservableCollection<Element> _logicalChildren = new ObservableCollection<Element>();
-		internal override IReadOnlyList<Element> LogicalChildrenInternal => new ReadOnlyCollection<Element>(_logicalChildren);
+
+		private protected override IList<Element> LogicalChildrenInternalBackingStore
+			=> _logicalChildren;
 
 		#region PropertyKeys
 

--- a/src/Controls/src/Core/Shell/Shell.cs
+++ b/src/Controls/src/Core/Shell/Shell.cs
@@ -795,10 +795,11 @@ namespace Microsoft.Maui.Controls
 		ShellFlyoutItemsManager _flyoutManager;
 		Page _previousPage;
 
-		ObservableCollection<Element> _logicalChildren = new ObservableCollection<Element>();
+		ObservableCollection<Element> _logicalChildren
+			= new ObservableCollection<Element>();
 
-		internal override IReadOnlyList<Element> LogicalChildrenInternal =>
-			new ReadOnlyCollection<Element>(_logicalChildren);
+		private protected override IList<Element> LogicalChildrenInternalBackingStore
+			=> _logicalChildren;
 
 		/// <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='.ctor']/Docs/*" />
 		public Shell()

--- a/src/Controls/tests/Core.UnitTests/ElementTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ElementTests.cs
@@ -33,10 +33,8 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			get { return internalChildren; }
 		}
 
-		internal override IReadOnlyList<Element> LogicalChildrenInternal
-		{
-			get { return new ReadOnlyCollection<Element>(internalChildren); }
-		}
+		private protected override IList<Element> LogicalChildrenInternalBackingStore
+			=> internalChildren;
 
 		readonly ObservableCollection<Element> internalChildren = new ObservableCollection<Element>();
 	}

--- a/src/Controls/tests/Core.UnitTests/MultiBindingTests.cs
+++ b/src/Controls/tests/Core.UnitTests/MultiBindingTests.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 				IsEnabled = true,
 				IsExpanded = true
 			};
-			var cp = expander.Children[0].LogicalChildren[1] as ContentPresenter;
+			var cp = expander.Children[0].LogicalChildrenInternal[1] as ContentPresenter;
 			Assert.True(cp.IsVisible);
 			expander.IsEnabled = false;
 			Assert.False(cp.IsVisible);

--- a/src/Controls/tests/Core.UnitTests/ShellFlyoutItemTemplateTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellFlyoutItemTemplateTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			shell.Items.Add(shellItem);
 
 			var element = GetFlyoutItemDataTemplateElement<Element>(shell, shellItem);
-			var label = element.LogicalChildren.OfType<Label>().First();
+			var label = element.LogicalChildrenInternal.OfType<Label>().First();
 			Assert.Equal(TextAlignment.Center, label.VerticalTextAlignment);
 		}
 
@@ -43,7 +43,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			shell.Items.Add(shellItem);
 
 			var element = GetFlyoutItemDataTemplateElement<Element>(shell, shellItem);
-			var label = element.LogicalChildren.OfType<Label>().First();
+			var label = element.LogicalChildrenInternal.OfType<Label>().First();
 			Assert.Equal(TextAlignment.Start, label.VerticalTextAlignment);
 		}
 
@@ -160,7 +160,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			var shellItem = CreateShellItem();
 			shell.Items.Add(shellItem);
 			var grid = GetFlyoutItemDataTemplateElement<Grid>(shell, shellItem);
-			var label = grid.LogicalChildren.OfType<Label>().First();
+			var label = grid.LogicalChildrenInternal.OfType<Label>().First();
 
 			Assert.Equal(Colors.Red, label.BackgroundColor);
 			Assert.True(VisualStateManager.GoToState(grid, "Selected"));
@@ -269,7 +269,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			if (e == null)
 				return default(T);
 
-			return e.LogicalChildren.OfType<T>().First();
+			return e.LogicalChildrenInternal.OfType<T>().First();
 		}
 
 

--- a/src/Controls/tests/Core.UnitTests/ShellTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellTests.cs
@@ -759,12 +759,12 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Shell.SetTitleView(shell, layout);
 
 			// Should contain Layout in logical children of shell.
-			Assert.Contains(layout, shell.LogicalChildren);
+			Assert.Contains(layout, shell.LogicalChildrenInternal);
 
 			Shell.SetTitleView(shell, null);
 
 			// Should now be removed.
-			Assert.DoesNotContain(layout, shell.LogicalChildren);
+			Assert.DoesNotContain(layout, shell.LogicalChildrenInternal);
 		}
 
 		[Fact]
@@ -784,10 +784,10 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			shell.FlyoutHeader = null;
 			shell.FlyoutHeader = layout;
 
-			Assert.Contains(layout, shell.LogicalChildren);
+			Assert.Contains(layout, shell.LogicalChildrenInternal);
 			shell.FlyoutHeader = null;
 
-			Assert.DoesNotContain(layout, shell.LogicalChildren);
+			Assert.DoesNotContain(layout, shell.LogicalChildrenInternal);
 		}
 
 

--- a/src/Controls/tests/Core.UnitTests/VisualTreeHelperTests.cs
+++ b/src/Controls/tests/Core.UnitTests/VisualTreeHelperTests.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 		void OnVisualTreeChanged(object? sender, VisualTreeChangeEventArgs e)
 		{
+			Assert.True(e.ChildIndex >= 0, "Visual Tree inaccurate when OnVisualTreeChanged called");
 			_treeEvents.Add((sender as Element, e));
 			VisualTreeChanged?.Invoke(sender as Element, e);
 		}

--- a/src/Controls/tests/Core.UnitTests/WindowsTests.cs
+++ b/src/Controls/tests/Core.UnitTests/WindowsTests.cs
@@ -421,10 +421,10 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.Equal(app, window.Parent);
 			Assert.Equal(window, window.Page.Parent);
 			Assert.Equal(1, app.Windows.Count);
-			Assert.Equal(app.LogicalChildren[0], window);
-			Assert.Equal(window.LogicalChildren[0], page);
-			Assert.Single(app.LogicalChildren);
-			Assert.Single(window.LogicalChildren);
+			Assert.Equal(app.LogicalChildrenInternal[0], window);
+			Assert.Equal(window.LogicalChildrenInternal[0], page);
+			Assert.Single(app.LogicalChildrenInternal);
+			Assert.Single(window.LogicalChildrenInternal);
 			Assert.Equal(app.NavigationProxy, window.NavigationProxy.Inner);
 			Assert.Equal(window.NavigationProxy, page.NavigationProxy.Inner);
 		}

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Maui.DeviceTests
 
 				// Get ItemsView._logicalChildren
 				var flags = BindingFlags.NonPublic | BindingFlags.Instance;
-				logicalChildren = typeof(ItemsView).GetField("_logicalChildren", flags).GetValue(collectionView) as IList;
+				logicalChildren = typeof(Element).GetField("_internalChildren", flags).GetValue(collectionView) as IList;
 				Assert.NotNull(logicalChildren);
 
 				// Replace with cloned collection


### PR DESCRIPTION
### Description of Change

A lot of our logical children code was just being copy and pasted between different controls. This PR standardizes Adding/Removing logical children inside `Element`. This way, whenever we add/remove a logical control we always make sure the same set of operations occur and that the `VisualDiagnostics` code also gets triggered. 

This PR doesn't apply these changes to the `Page` elements yet because I felt like that would have stuffed too much logic into one PR.

Once/if this PR is merged then I will do a follow up PR against `Page` and all the derived page types.  This will help us to avoid scenarios where things aren't showing up in the VisualTree, plus, once we get `Page` straightened out, users will be able to add logical children to page, which has come up on the community toolkit https://github.com/CommunityToolkit/Maui/issues/620. 

The end goal will be to also remove the `ChildrenNotDrawnByThisElement` and `AllChildren` properties on `Element` as well. Which were only really hacks to workaround how `LogicalChildren` are handled inside `Page`

### Implementation
- The idea is that any subclasses should only call `AddLogicalChildren/RemoveLogicalChildren` to interact with their logical children. They shouldn't need to provide their own storage container for their own logical children.  That's just handled/managed by `Element` now
- I did add an override for `LogicalChildrenInternalBackingStore`, because there are a few cases (Page/Layout) where it's going to take a little more effort to make that code work by only calling `AddLogicalChildren/RemoveLogicalChildren`. `Page` also makes a lot of assumptions about its `LogicalChildren`, for example, it automatically calls `LayoutChildInBounds` on every single `LogicalChild`. 