### PR TITLE
Fix OnBackButtonPressed on iOS (#8296)

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
@@ -1541,7 +1541,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 						{
 							backBarButtonItem.Title = NavigationPage.GetBackButtonTitle(currentPage);
 						}
-						
+
 						NavigationItem.SetLeftBarButtonItem(backBarButtonItem, true);
 					}
 					else

--- a/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
@@ -1508,8 +1508,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				var currentPage = Child;
 				var firstPage = n.NavPageController.Pages.FirstOrDefault();
 
-				if (firstPage != pageBeingRemoved && currentPage != firstPage && NavigationPage.GetHasBackButton(currentPage))
+				if (currentPage != firstPage && NavigationPage.GetHasBackButton(currentPage))
 				{
+					NavigationItem.LeftBarButtonItem = null;
 					if (OperatingSystem.IsIOSVersionAtLeast(16))
 					{
 						// it took them 16 version to add an override back action
@@ -1562,12 +1563,22 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 							NavigationItem.BackBarButtonItem = null;
 					}
 				}
-				else if (NavigationPage.GetHasBackButton(currentPage))
+				else if (n._parentFlyoutPage is not null)
 				{
-					if (n._parentFlyoutPage is not null)
+					SetFlyoutLeftBarButton(this, n._parentFlyoutPage);
+				}
+				else
+				{
+					NavigationItem.LeftBarButtonItem = null;
+					if (OperatingSystem.IsIOSVersionAtLeast(16))
 					{
-						// show hamburger menu button
-						SetFlyoutLeftBarButton(this, n._parentFlyoutPage);
+						// need to reset the back action in the event we no longer need the back button
+						// else the back button will still continue to show up
+						NavigationItem.BackAction = null;
+					}
+					else if (OperatingSystem.IsIOSVersionAtLeast(13))
+					{
+						NavigationItem.SetHidesBackButton(false, false);
 					}
 				}
 			}

--- a/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.iOS.cs
@@ -91,5 +91,55 @@ namespace Microsoft.Maui.DeviceTests
 				(handler as NavigationRenderer).Dispose();
 			});
 		}
+
+		[Fact(DisplayName = "Navigating Back Via Back Button Fires OnBackButtonPressed Event")]
+		public async Task NavigatingBackViaBackButtonFiresOnBackButtonPressedEvent()
+		{
+			SetupBuilder();
+			var firstPage = new ContentPage();
+			var navPage = new NavigationPage(firstPage) { Title = "App Page" };
+
+			var secondPage = new DoubleBackContentPage();
+			await navPage.PushAsync(secondPage);
+
+			await CreateHandlerAndAddToWindow<WindowHandlerStub>(new Window(navPage), async (handler) =>
+			{
+				await OnNavigatedToAsync(navPage.CurrentPage);
+				var navController = navPage.Handler as UINavigationController;
+
+				navController.NavigationBar.TapBackButton();
+
+				// race condition that if we can the is back button pressed, it will always return false.
+				// wait a little bit
+				await AssertionExtensions.Wait(() => navPage.CurrentPage == firstPage);
+
+				Assert.True(navPage.CurrentPage == secondPage);
+				Assert.True(secondPage.IsBackButtonPressed);
+
+				navController.NavigationBar.TapBackButton();
+
+				// wait a little bit
+				await AssertionExtensions.Wait(() => navPage.CurrentPage == firstPage);
+
+				Assert.True(navPage.CurrentPage == firstPage);
+				Assert.False(IsBackButtonVisible(navPage.Handler));
+			});
+		}
+
+		class DoubleBackContentPage : ContentPage
+		{
+			public bool IsBackButtonPressed { get; set; }
+
+			protected override bool OnBackButtonPressed()
+			{
+				if (!IsBackButtonPressed)
+				{
+					IsBackButtonPressed = true;
+					return true;
+				}
+
+				return base.OnBackButtonPressed();
+			}
+		}
 	}
 }


### PR DESCRIPTION
### Description of Change
Fix OnBackButtonPressed doesn't trigger on iOS. On iOS16+, iOS finally support back action. While for older version like iOS13+, create a left bar item to act as back button so that we can override the handler.

### Issues Fixed
Fixes #8296