### PR TITLE
[ios] cleanup Loaded/Unloaded observers

### DIFF
--- a/src/Core/src/Platform/iOS/ContainerViewController.cs
+++ b/src/Core/src/Platform/iOS/ContainerViewController.cs
@@ -84,9 +84,9 @@ namespace Microsoft.Maui.Platform
 		public override void ViewDidLayoutSubviews()
 		{
 			base.ViewDidLayoutSubviews();
-			if (currentPlatformView == null)
+			if (currentPlatformView == null || !IsViewLoaded || View == null)
 				return;
-			currentPlatformView.Frame = View!.Bounds;
+			currentPlatformView.Frame = View.Bounds;
 		}
 
 		public void Reload() => SetView(CurrentView, true);

--- a/src/Core/src/Platform/iOS/ViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/ViewExtensions.cs
@@ -609,22 +609,22 @@ namespace Microsoft.Maui.Platform
 				return new ActionDisposable(() => { });
 			}
 
-			Dictionary<NSString, NSObject> observers = new Dictionary<NSString, NSObject>();
+			var observers = new List<IDisposable>(2);
 			ActionDisposable? disposable = null;
 			disposable = new ActionDisposable(() =>
 			{
 				disposable = null;
 				foreach (var observer in observers)
 				{
-					uiView.Layer.RemoveObserver(observer.Value, observer.Key);
-					observers.Remove(observer.Key);
+					observer.Dispose();
 				}
+				observers.Clear();
 			});
 
 			// Ideally we could wire into UIView.MovedToWindow but there's no way to do that without just inheriting from every single
 			// UIView. So we just make our best attempt by observering some properties that are going to fire once UIView is attached to a window.			
-			observers.Add(new NSString("bounds"), (NSObject)uiView.Layer.AddObserver("bounds", Foundation.NSKeyValueObservingOptions.OldNew, (oc) => OnLoadedCheck(oc)));
-			observers.Add(new NSString("frame"), (NSObject)uiView.Layer.AddObserver("frame", Foundation.NSKeyValueObservingOptions.OldNew, (oc) => OnLoadedCheck(oc)));
+			observers.Add(uiView.Layer.AddObserver("bounds", Foundation.NSKeyValueObservingOptions.OldNew, (oc) => OnLoadedCheck(oc)));
+			observers.Add(uiView.Layer.AddObserver("frame", Foundation.NSKeyValueObservingOptions.OldNew, (oc) => OnLoadedCheck(oc)));
 
 			// OnLoaded is called at the point in time where the xplat view knows it's going to be attached to the window.
 			// So this just serves as a way to queue a call on the UI Thread to see if that's enough time for the window
@@ -665,22 +665,22 @@ namespace Microsoft.Maui.Platform
 				return new ActionDisposable(() => { });
 			}
 
-			Dictionary<NSString, NSObject> observers = new Dictionary<NSString, NSObject>();
+			var observers = new List<IDisposable>(2);
 			ActionDisposable? disposable = null;
 			disposable = new ActionDisposable(() =>
 			{
 				disposable = null;
 				foreach (var observer in observers)
 				{
-					uiView.Layer.RemoveObserver(observer.Value, observer.Key);
-					observers.Remove(observer.Key);
+					observer.Dispose();
 				}
+				observers.Clear();
 			});
 
 			// Ideally we could wire into UIView.MovedToWindow but there's no way to do that without just inheriting from every single
 			// UIView. So we just make our best attempt by observering some properties that are going to fire once UIView is attached to a window.	
-			observers.Add(new NSString("bounds"), (NSObject)uiView.Layer.AddObserver("bounds", Foundation.NSKeyValueObservingOptions.OldNew, (_) => UnLoadedCheck()));
-			observers.Add(new NSString("frame"), (NSObject)uiView.Layer.AddObserver("frame", Foundation.NSKeyValueObservingOptions.OldNew, (_) => UnLoadedCheck()));
+			observers.Add(uiView.Layer.AddObserver("bounds", Foundation.NSKeyValueObservingOptions.OldNew, (_) => UnLoadedCheck()));
+			observers.Add(uiView.Layer.AddObserver("frame", Foundation.NSKeyValueObservingOptions.OldNew, (_) => UnLoadedCheck()));
 
 			// OnUnloaded is called at the point in time where the xplat view knows it's going to be detached from the window.
 			// So this just serves as a way to queue a call on the UI Thread to see if that's enough time for the window


### PR DESCRIPTION
Watching console output while navigating pages on iOS shows:

    2023-03-22 11:34:15.865716-0500 Warning: observer object was not disposed manually with Dispose()
    2023-03-22 11:34:15.866240-0500 Warning: observer object was not disposed manually with Dispose()

Reviewing the code:

    uiView.Layer.RemoveObserver(observer.Value, observer.Key);
    observers.Remove(observer.Key);

It actually does not call `observer.Value.Dispose()`, and we should be able to simply dispose instead of `RemoveObserver()`.

I think we can simplify this code in general:

* Store a `List<IDiposable>`, we don't need a dictionary.

* Call `Dispose()` instead of `RemoveObserver()`

* We know the capacity is 2, pass that in.

This does not solve any memory issues, but at least prevents the warning.

It may also improve performance a bit.