### PR TITLE
[iOS] Don't set constraints for orientation if they are 0

### DIFF
--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.iOS.cs
@@ -314,12 +314,12 @@ namespace Microsoft.Maui.Handlers
 
 		internal static Size AccountForOrientation(Size size, double widthConstraint, double heightConstraint, ScrollOrientation orientation)
 		{
-			if (orientation is ScrollOrientation.Vertical or ScrollOrientation.Neither)
+			if (orientation is ScrollOrientation.Vertical or ScrollOrientation.Neither && widthConstraint > 0)
 			{
 				size.Width = widthConstraint;
 			}
 
-			if (orientation is ScrollOrientation.Horizontal or ScrollOrientation.Neither)
+			if (orientation is ScrollOrientation.Horizontal or ScrollOrientation.Neither && heightConstraint > 0)
 			{
 				size.Height = heightConstraint;
 			}


### PR DESCRIPTION
### Description of Change

While investigating #9825  I found a issue where the bounds for the scrollview could be 0 (for example wrapping on a Grid with Auto columns), and we don't want to constrain the scrollview to 0.
