### PR TITLE
[net7.0] Updating Microsoft.Windows.SDK.BuildTools to 10.0.22621.756

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -24,7 +24,7 @@
     <MicrosoftNETWorkloadEmscriptenPackageVersion>$(MicrosoftNETWorkloadEmscriptennet7Manifest70100PackageVersion)</MicrosoftNETWorkloadEmscriptenPackageVersion>
     <!-- wasdk -->
     <MicrosoftWindowsAppSDKPackageVersion>1.2.221209.1</MicrosoftWindowsAppSDKPackageVersion>
-    <MicrosoftWindowsSDKBuildToolsPackageVersion>10.0.22621.755</MicrosoftWindowsSDKBuildToolsPackageVersion>
+    <MicrosoftWindowsSDKBuildToolsPackageVersion>10.0.22621.756</MicrosoftWindowsSDKBuildToolsPackageVersion>
     <MicrosoftGraphicsWin2DPackageVersion>1.0.4</MicrosoftGraphicsWin2DPackageVersion>
     <!-- Everything else -->
     <MicrosoftAspNetCoreAuthorizationPackageVersion>7.0.0</MicrosoftAspNetCoreAuthorizationPackageVersion>


### PR DESCRIPTION
### Description of Change

Updating .NET 7.0 to use the 10.0.22621.756 version of Microsoft.Windows.SDK.BuildTools.

### Issues Fixed

No issue fixed here.  But this version is going to be used in net6.0 and 8.0, so I'm doing this for the sake of consistency.

.NET 6.0 PR: https://github.com/dotnet/maui/pull/14106