### PR TITLE
[Housekeeping] Added Gallery sample to validate that colors changes from Converters

### DIFF
--- a/src/Controls/samples/Controls.Sample/Converters/BoolToCustomValueConverter.cs
+++ b/src/Controls/samples/Controls.Sample/Converters/BoolToCustomValueConverter.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Globalization;
+using Microsoft.Maui.Controls;
+
+namespace Controls.Sample.Converters
+{
+	public class BoolToCustomValueConverter : IValueConverter
+	{
+		public object ValueIfTrue { get; set; }
+		public object ValueIfFalse { get; set; }
+
+		public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+		{
+			if (value is bool boolValue)
+			{
+				return boolValue ? ValueIfTrue : ValueIfFalse;
+			}
+
+			return ValueIfFalse;
+		}
+
+		public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+		{
+			return null;
+		}
+	}
+}

--- a/src/Controls/samples/Controls.Sample/Converters/BoolToCustomValueConverter.cs
+++ b/src/Controls/samples/Controls.Sample/Converters/BoolToCustomValueConverter.cs
@@ -11,12 +11,7 @@ namespace Controls.Sample.Converters
 
 		public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
 		{
-			if (value is bool boolValue)
-			{
-				return boolValue ? ValueIfTrue : ValueIfFalse;
-			}
-
-			return ValueIfFalse;
+			return value is bool boolValue && boolValue ? ValueIfTrue : ValueIfFalse;
 		}
 
 		public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/ButtonPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/ButtonPage.xaml
@@ -2,9 +2,19 @@
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     x:Class="Maui.Controls.Sample.Pages.ButtonPage"
+    xmlns:converters="clr-namespace:Controls.Sample.Converters"
     xmlns:views="clr-namespace:Maui.Controls.Sample.Pages.Base"
     xmlns:local="clr-namespace:Maui.Controls.Sample"
     Title="Button">
+    <views:BasePage.Resources>
+        <ResourceDictionary>
+            <converters:BoolToCustomValueConverter 
+                x:Key="BoolToColorConverter"
+                ValueIfTrue="Green"
+                ValueIfFalse="Red"/>
+
+        </ResourceDictionary>
+    </views:BasePage.Resources>
     <views:BasePage.Content>
         <ScrollView>
             <VerticalStackLayout Margin="12" Spacing="6">
@@ -46,6 +56,14 @@
                  <Button 
                      Text="Button"
                      BackgroundColor="{Binding ButtonBackground}" />
+                <Label
+                    Text="Changing BackgroundColor from Converter"
+                    Style="{StaticResource Headline}"/>
+                <CheckBox 
+                    IsChecked="{Binding ChangeButtonColor, Mode=TwoWay}"/>
+                <Button 
+                    Text="Button"
+                    BackgroundColor="{Binding ChangeButtonColor, Converter={StaticResource BoolToColorConverter}}" />
                 <Label
                     Text="Background"
                     Style="{StaticResource Headline}" />

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/ButtonPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/ButtonPage.xaml.cs
@@ -84,7 +84,22 @@ namespace Maui.Controls.Sample.Pages
 
 	public class ButtonPageViewModel : BindableObject
 	{
+		bool _changeButtonColor;
+
 		public string ButtonBackground => "#fc87ad";
+
+		public bool ChangeButtonColor
+		{
+			get => _changeButtonColor;
+			set
+			{
+				if (_changeButtonColor != value)
+				{
+					_changeButtonColor = value;
+					OnPropertyChanged();
+				}
+			}
+		}
 
 		public ICommand ButtonCommand => new Command(OnExecuteImageButtonCommand);
 


### PR DESCRIPTION
### Description of Change

Added Gallery sample to validate that colors changes from Converters.

![fix-13865](https://user-images.githubusercontent.com/6755973/227219404-1f7659c2-7c5c-454e-89f2-2e92532dae90.gif)

The issue have been already fixed by https://github.com/dotnet/maui/pull/9814 This PR only includes a sample to validate this scenario using converters.

### Issues Fixed

Fixes #13865 