### PR TITLE
Code generation now supports internal duplicate types

### DIFF
--- a/Microsoft.Maui-dev.sln
+++ b/Microsoft.Maui-dev.sln
@@ -201,6 +201,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Graphics.DeviceTests", "src
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Controls.Xaml.UnitTests.ExternalAssembly", "src\Controls\tests\Xaml.UnitTests.ExternalAssembly\Controls.Xaml.UnitTests.ExternalAssembly.csproj", "{B5F38A9E-1949-4779-8739-D682B09E0CB3}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Controls.Xaml.UnitTests.InternalsVisibleAssembly", "src\Controls\tests\Xaml.UnitTests.InternalsVisibleAssembly\Controls.Xaml.UnitTests.InternalsVisibleAssembly.csproj", "{B5F38A9E-1949-4779-6666-D682B09E0CB3}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Controls.Xaml.UnitTests.InternalsHiddenAssembly", "src\Controls\tests\Xaml.UnitTests.InternalsHiddenAssembly\Controls.Xaml.UnitTests.InternalsHiddenAssembly.csproj", "{FB39FACE-BAF2-4F97-A249-E45BA63D77FE}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -507,6 +511,14 @@ Global
 		{B5F38A9E-1949-4779-8739-D682B09E0CB3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B5F38A9E-1949-4779-8739-D682B09E0CB3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B5F38A9E-1949-4779-8739-D682B09E0CB3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B5F38A9E-1949-4779-6666-D682B09E0CB3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B5F38A9E-1949-4779-6666-D682B09E0CB3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B5F38A9E-1949-4779-6666-D682B09E0CB3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B5F38A9E-1949-4779-6666-D682B09E0CB3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FB39FACE-BAF2-4F97-A249-E45BA63D77FE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FB39FACE-BAF2-4F97-A249-E45BA63D77FE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FB39FACE-BAF2-4F97-A249-E45BA63D77FE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FB39FACE-BAF2-4F97-A249-E45BA63D77FE}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -599,6 +611,8 @@ Global
 		{66CC98E3-6A1A-4C44-A23C-B575E82106EC} = {C564DDD6-DE79-45CD-88EA-3F690481572A}
 		{34969E49-FA6E-41BB-9813-5689BB14021E} = {936C47A9-A7EA-4FBD-8733-CED1D4100E69}
 		{B5F38A9E-1949-4779-8739-D682B09E0CB3} = {25D0D27A-C5FE-443D-8B65-D6C987F4A80E}
+		{B5F38A9E-1949-4779-6666-D682B09E0CB3} = {25D0D27A-C5FE-443D-8B65-D6C987F4A80E}
+		{FB39FACE-BAF2-4F97-A249-E45BA63D77FE} = {25D0D27A-C5FE-443D-8B65-D6C987F4A80E}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {0B8ABEAD-D2B5-4370-A187-62B5ABE4EE50}

--- a/Microsoft.Maui-mac.slnf
+++ b/Microsoft.Maui-mac.slnf
@@ -22,6 +22,8 @@
       "src\\Controls\\tests\\CustomAttributes\\Controls.CustomAttributes.csproj",
       "src\\Controls\\tests\\DeviceTests\\Controls.DeviceTests.csproj",
       "src\\Controls\\tests\\Xaml.UnitTests.ExternalAssembly\\Controls.Xaml.UnitTests.ExternalAssembly.csproj",
+      "src\\Controls\\tests\\Xaml.UnitTests.InternalsVisibleAssembly\\Controls.Xaml.UnitTests.InternalsVisibleAssembly.csproj",
+      "src\\Controls\\tests\\Xaml.UnitTests.InternalsHiddenAssembly\\Controls.Xaml.UnitTests.InternalsHiddenAssembly.csproj",
       "src\\Controls\\tests\\Xaml.UnitTests\\Controls.Xaml.UnitTests.csproj",
       "src\\Core\\maps\\src\\Maps.csproj",
       "src\\Core\\src\\Core.csproj",

--- a/Microsoft.Maui-windows.slnf
+++ b/Microsoft.Maui-windows.slnf
@@ -27,6 +27,8 @@
       "src\\Controls\\tests\\CustomAttributes\\Controls.CustomAttributes.csproj",
       "src\\Controls\\tests\\DeviceTests\\Controls.DeviceTests.csproj",
       "src\\Controls\\tests\\Xaml.UnitTests.ExternalAssembly\\Controls.Xaml.UnitTests.ExternalAssembly.csproj",
+      "src\\Controls\\tests\\Xaml.UnitTests.InternalsVisibleAssembly\\Controls.Xaml.UnitTests.InternalsVisibleAssembly.csproj",
+      "src\\Controls\\tests\\Xaml.UnitTests.InternalsHiddenAssembly\\Controls.Xaml.UnitTests.InternalsHiddenAssembly.csproj",
       "src\\Controls\\tests\\Xaml.UnitTests\\Controls.Xaml.UnitTests.csproj",
       "src\\Core\\maps\\src\\Maps.csproj",
       "src\\Core\\src\\Core.csproj",

--- a/Microsoft.Maui.BuildTasks.slnf
+++ b/Microsoft.Maui.BuildTasks.slnf
@@ -6,7 +6,7 @@
       "src\\Controls\\src\\Build.Tasks\\Controls.Build.Tasks.csproj",
       "src\\Controls\\src\\Core.Design\\Controls.Core.Design.csproj",
       "src\\Controls\\src\\Core\\Controls.Core.csproj",
-      "src\\Controls\\src\\NuGet\\Controls.NuGet.csproj",
+      "src\\Controls\\src\\SourceGen\\Controls.SourceGen.csproj",
       "src\\Controls\\src\\Xaml.Design\\Controls.Xaml.Design.csproj",
       "src\\Controls\\src\\Xaml\\Controls.Xaml.csproj",
       "src\\Core\\src\\Core.csproj",

--- a/Microsoft.Maui.sln
+++ b/Microsoft.Maui.sln
@@ -249,7 +249,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Compatibility.Core.UnitTest
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Controls.Xaml.UnitTests.ExternalAssembly", "src\Controls\tests\Xaml.UnitTests.ExternalAssembly\Controls.Xaml.UnitTests.ExternalAssembly.csproj", "{F2ADA552-6328-4B2D-8D48-FCDD32C4AF60}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Controls.Xaml.UnitTests.InternalsVisibleAssembly", "src\Controls\tests\Xaml.UnitTests.InternalsVisibleAssembly\Controls.Xaml.UnitTests.InternalsVisibleAssembly.csproj", "{B5F38A9E-1949-4779-6666-D682B09E0CB3}"
+EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Maui.IntegrationTests", "src\TestUtils\src\Microsoft.Maui.IntegrationTests\Microsoft.Maui.IntegrationTests.csproj", "{1C899C94-8744-4E2A-8E23-1660393236FD}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Controls.Xaml.UnitTests.InternalsHiddenAssembly", "src\Controls\tests\Xaml.UnitTests.InternalsHiddenAssembly\Controls.Xaml.UnitTests.InternalsHiddenAssembly.csproj", "{FB39FACE-BAF2-4F97-A249-E45BA63D77FE}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -623,10 +627,18 @@ Global
 		{F2ADA552-6328-4B2D-8D48-FCDD32C4AF60}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F2ADA552-6328-4B2D-8D48-FCDD32C4AF60}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F2ADA552-6328-4B2D-8D48-FCDD32C4AF60}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B5F38A9E-1949-4779-6666-D682B09E0CB3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B5F38A9E-1949-4779-6666-D682B09E0CB3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B5F38A9E-1949-4779-6666-D682B09E0CB3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B5F38A9E-1949-4779-6666-D682B09E0CB3}.Release|Any CPU.Build.0 = Release|Any CPU
 		{1C899C94-8744-4E2A-8E23-1660393236FD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{1C899C94-8744-4E2A-8E23-1660393236FD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1C899C94-8744-4E2A-8E23-1660393236FD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1C899C94-8744-4E2A-8E23-1660393236FD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FB39FACE-BAF2-4F97-A249-E45BA63D77FE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FB39FACE-BAF2-4F97-A249-E45BA63D77FE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FB39FACE-BAF2-4F97-A249-E45BA63D77FE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FB39FACE-BAF2-4F97-A249-E45BA63D77FE}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -742,7 +754,9 @@ Global
 		{34969E49-FA6E-41BB-9813-5689BB14021E} = {936C47A9-A7EA-4FBD-8733-CED1D4100E69}
 		{13A1AFD2-78D3-4463-9977-C8B642BCE2E2} = {85EBD2BA-EA5A-4B1F-AF16-81FBD58579DF}
 		{F2ADA552-6328-4B2D-8D48-FCDD32C4AF60} = {25D0D27A-C5FE-443D-8B65-D6C987F4A80E}
+		{B5F38A9E-1949-4779-6666-D682B09E0CB3} = {25D0D27A-C5FE-443D-8B65-D6C987F4A80E}
 		{1C899C94-8744-4E2A-8E23-1660393236FD} = {7AC28763-9C68-4BF9-A1BA-25CBFFD2D15C}
+		{FB39FACE-BAF2-4F97-A249-E45BA63D77FE} = {25D0D27A-C5FE-443D-8B65-D6C987F4A80E}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {0B8ABEAD-D2B5-4370-A187-62B5ABE4EE50}

--- a/src/Controls/src/Build.Tasks/CompiledMarkupExtensions/StaticExtension.cs
+++ b/src/Controls/src/Build.Tasks/CompiledMarkupExtensions/StaticExtension.cs
@@ -100,10 +100,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 			{
 				if (fd.Module == module)
 					return true;
-				if (fd.Module.GetCustomAttributes().Any(ca => ca.AttributeType.FullName == "System.Runtime.CompilerServices.InternalsVisibleToAttribute"
-															&& ca.HasConstructorArguments
-															&& (ca.ConstructorArguments[0].Value as string) != null
-															&& (ca.ConstructorArguments[0].Value as string).StartsWith(module.Assembly.Name.Name, System.StringComparison.InvariantCulture)))
+				if (fd.Module.IsVisibleInternal(module))
 					return true;
 			}
 			return false;
@@ -125,10 +122,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 			{
 				if (md.Module == module)
 					return true;
-				if (md.Module.GetCustomAttributes().Any(ca => ca.AttributeType.FullName == "System.Runtime.CompilerServices.InternalsVisibleToAttribute"
-															&& ca.HasConstructorArguments
-															&& (ca.ConstructorArguments[0].Value as string) != null
-															&& (ca.ConstructorArguments[0].Value as string).StartsWith(module.Assembly.Name.Name, System.StringComparison.InvariantCulture)))
+				if (md.Module.IsVisibleInternal(module))
 					return true;
 			}
 			return false;

--- a/src/Controls/src/Build.Tasks/ModuleDefinitionExtensions.cs
+++ b/src/Controls/src/Build.Tasks/ModuleDefinitionExtensions.cs
@@ -294,5 +294,12 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 			var gitr = tr as GenericInstanceType;
 			return gitr == null ? serialized : $"{serialized}<{string.Join(",", gitr.GenericArguments.Select(SerializeTypeReference))}>";
 		}
+
+		public static bool IsVisibleInternal(this ModuleDefinition from, ModuleDefinition to) =>
+			from.GetCustomAttributes().Any(ca =>
+				ca.AttributeType.FullName == "System.Runtime.CompilerServices.InternalsVisibleToAttribute" &&
+				ca.HasConstructorArguments &&
+				ca.ConstructorArguments[0].Value is string visibleTo &&
+				visibleTo.StartsWith(to.Assembly.Name.Name, StringComparison.InvariantCulture));
 	}
 }

--- a/src/Controls/src/Build.Tasks/TypeDefinitionExtensions.cs
+++ b/src/Controls/src/Build.Tasks/TypeDefinitionExtensions.cs
@@ -57,5 +57,16 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 				self = self.BaseType?.ResolveCached(cache);
 			}
 		}
+
+		public static bool IsPublicOrVisibleInternal(this TypeDefinition self, ModuleDefinition module)
+		{
+			if (self.IsPublic)
+				return true;
+			if (self.Module == module)
+				return true;
+			if (self.Module.IsVisibleInternal(module))
+				return true;
+			return false;
+		}
 	}
 }

--- a/src/Controls/src/Build.Tasks/TypeReferenceExtensions.cs
+++ b/src/Controls/src/Build.Tasks/TypeReferenceExtensions.cs
@@ -278,6 +278,8 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 			Func<MethodDefinition, TypeReference, bool> predicate, ModuleDefinition module)
 		{
 			var typeDef = typeRef.ResolveCached(cache);
+			if (typeDef is null)
+				yield break;
 			foreach (var method in typeDef.Methods.Where(md => predicate(md, typeRef)))
 				yield return new Tuple<MethodDefinition, TypeReference>(method, typeRef);
 			if (typeDef.IsInterface)

--- a/src/Controls/src/Build.Tasks/XmlTypeExtensions.cs
+++ b/src/Controls/src/Build.Tasks/XmlTypeExtensions.cs
@@ -85,7 +85,10 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 			TypeReference type = xmlType.GetTypeReference(xmlnsDefinitions, module.Assembly.Name.Name, (typeInfo) =>
 			{
 				string typeName = typeInfo.typeName.Replace('+', '/'); //Nested types
-				return module.GetTypeDefinition(cache, (typeInfo.assemblyName, typeInfo.clrNamespace, typeName));
+				var type = module.GetTypeDefinition(cache, (typeInfo.assemblyName, typeInfo.clrNamespace, typeName));
+				if (type is not null && type.IsPublicOrVisibleInternal(module))
+					return type;
+				return null;
 			});
 
 			if (type != null && typeArguments != null && type.HasGenericParameters)

--- a/src/Controls/tests/Xaml.UnitTests.ExternalAssembly/Issues/Maui14158/Attributes.cs
+++ b/src/Controls/tests/Xaml.UnitTests.ExternalAssembly/Issues/Maui14158/Attributes.cs
@@ -1,0 +1,4 @@
+﻿using Microsoft.Maui.Controls;
+
+[assembly: XmlnsDefinition("http://schemas.microsoft.com/dotnet/2021/maui/xaml/tests", "Microsoft.Maui.Controls.Xaml.UnitTests.Issues.Maui14158")]
+[assembly: XmlnsDefinition("http://schemas.microsoft.com/dotnet/2021/maui/xaml/tests", "Microsoft.Maui.Controls.Xaml.UnitTests.Issues.Maui14158", AssemblyName = "Microsoft.Maui.Controls.Xaml.UnitTests.InternalsHiddenAssembly")]

--- a/src/Controls/tests/Xaml.UnitTests.ExternalAssembly/Issues/Maui14158/PublicTypes.cs
+++ b/src/Controls/tests/Xaml.UnitTests.ExternalAssembly/Issues/Maui14158/PublicTypes.cs
@@ -1,0 +1,13 @@
+﻿using System.ComponentModel;
+using Microsoft.Maui.Controls;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests.Issues.Maui14158;
+
+[Description("Microsoft.Maui.Controls.Xaml.UnitTests.ExternalAssembly")]
+public class PublicInExternal : Button { }
+
+[Description("Microsoft.Maui.Controls.Xaml.UnitTests.ExternalAssembly")]
+internal class PublicInHidden : Button { }
+
+[Description("Microsoft.Maui.Controls.Xaml.UnitTests.ExternalAssembly")]
+internal class PublicInVisible : Button { }

--- a/src/Controls/tests/Xaml.UnitTests.ExternalAssembly/Issues/Maui14158/WithSuffix.cs
+++ b/src/Controls/tests/Xaml.UnitTests.ExternalAssembly/Issues/Maui14158/WithSuffix.cs
@@ -1,0 +1,7 @@
+﻿using System.ComponentModel;
+using Microsoft.Maui.Controls;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests.Issues.Maui14158;
+
+[Description("Microsoft.Maui.Controls.Xaml.UnitTests.ExternalAssembly")]
+public class PublicWithSuffix : Button { }

--- a/src/Controls/tests/Xaml.UnitTests.InternalsHiddenAssembly/Controls.Xaml.UnitTests.InternalsHiddenAssembly.csproj
+++ b/src/Controls/tests/Xaml.UnitTests.InternalsHiddenAssembly/Controls.Xaml.UnitTests.InternalsHiddenAssembly.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(_MauiDotNetTfm)</TargetFramework>
+    <AssemblyName>Microsoft.Maui.Controls.Xaml.UnitTests.InternalsHiddenAssembly</AssemblyName>
+    <IsPackable>false</IsPackable>
+    <NoWarn>0114;0672;0108;0067;0168;0169;0219;0612;0618;1998;4014</NoWarn>
+    <RootNamespace>Microsoft.Maui.Controls.Xaml.UnitTests.InternalsHiddenAssembly</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Controls\Maps\src\Controls.Maps.csproj" />
+    <ProjectReference Include="..\..\..\Controls\src\Core\Controls.Core.csproj" />
+    <ProjectReference Include="..\..\..\Controls\src\Xaml\Controls.Xaml.csproj" />
+    <ProjectReference Include="..\..\..\Core\maps\src\Maps.csproj" />
+    <ProjectReference Include="..\..\..\Core\src\Core.csproj" />
+    <ProjectReference Include="..\..\..\Essentials\src\Essentials.csproj" />
+    <ProjectReference Include="..\..\..\TestUtils\src\TestUtils\TestUtils.csproj" />
+  </ItemGroup>
+
+  <Import Project="$(MauiSrcDirectory)Maui.InTree.props" Condition=" '$(UseMaui)' != 'true' " />
+
+</Project>

--- a/src/Controls/tests/Xaml.UnitTests.InternalsHiddenAssembly/Directory.Build.targets
+++ b/src/Controls/tests/Xaml.UnitTests.InternalsHiddenAssembly/Directory.Build.targets
@@ -1,0 +1,5 @@
+<Project>
+  <Import Project="$(MauiSrcDirectory)Maui.InTree.targets" Condition=" '$(UseMaui)' != 'true' " />
+  <Import Project="$(MauiSrcDirectory)Microsoft.Maui.Controls.Debug.targets" />
+  <Import Project="$(MauiRootDirectory)Directory.Build.targets" />
+</Project>

--- a/src/Controls/tests/Xaml.UnitTests.InternalsHiddenAssembly/Issues/Maui14158/PublicTypes.cs
+++ b/src/Controls/tests/Xaml.UnitTests.InternalsHiddenAssembly/Issues/Maui14158/PublicTypes.cs
@@ -1,0 +1,13 @@
+﻿using System.ComponentModel;
+using Microsoft.Maui.Controls;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests.Issues.Maui14158;
+
+[Description("Microsoft.Maui.Controls.Xaml.UnitTests.InternalsHiddenAssembly")]
+internal class PublicInExternal : Button { }
+
+[Description("Microsoft.Maui.Controls.Xaml.UnitTests.InternalsHiddenAssembly")]
+public class PublicInHidden : Button { }
+
+[Description("Microsoft.Maui.Controls.Xaml.UnitTests.InternalsHiddenAssembly")]
+internal class PublicInVisible : Button { }

--- a/src/Controls/tests/Xaml.UnitTests.InternalsHiddenAssembly/Issues/Maui14158/WithSuffix.cs
+++ b/src/Controls/tests/Xaml.UnitTests.InternalsHiddenAssembly/Issues/Maui14158/WithSuffix.cs
@@ -1,0 +1,10 @@
+﻿using System.ComponentModel;
+using Microsoft.Maui.Controls;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests.Issues.Maui14158;
+
+[Description("Microsoft.Maui.Controls.Xaml.UnitTests.InternalsHiddenAssembly")]
+internal class PublicWithSuffixExtension : Button { }
+
+[Description("Microsoft.Maui.Controls.Xaml.UnitTests.InternalsHiddenAssembly")]
+internal class InternalWithSuffixExtension : Button { }

--- a/src/Controls/tests/Xaml.UnitTests.InternalsHiddenAssembly/XmlnsDefinitionAttribute.cs
+++ b/src/Controls/tests/Xaml.UnitTests.InternalsHiddenAssembly/XmlnsDefinitionAttribute.cs
@@ -1,0 +1,11 @@
+// this file tests: https://github.com/dotnet/maui/issues/14158
+
+using System;
+
+namespace Microsoft.Maui.Controls;
+
+[AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+[Obsolete("This is not meant to be used by anything and is just for tests.", true)]
+internal sealed class XmlnsDefinitionAttribute : Attribute
+{
+}

--- a/src/Controls/tests/Xaml.UnitTests.InternalsVisibleAssembly/AssemblyInfo.cs
+++ b/src/Controls/tests/Xaml.UnitTests.InternalsVisibleAssembly/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Microsoft.Maui.Controls.Xaml.UnitTests")]

--- a/src/Controls/tests/Xaml.UnitTests.InternalsVisibleAssembly/Controls.Xaml.UnitTests.InternalsVisibleAssembly.csproj
+++ b/src/Controls/tests/Xaml.UnitTests.InternalsVisibleAssembly/Controls.Xaml.UnitTests.InternalsVisibleAssembly.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(_MauiDotNetTfm)</TargetFramework>
+    <AssemblyName>Microsoft.Maui.Controls.Xaml.UnitTests.InternalsVisibleAssembly</AssemblyName>
+    <IsPackable>false</IsPackable>
+    <NoWarn>0114;0672;0108;0067;0168;0169;0219;0612;0618;1998;4014</NoWarn>
+    <RootNamespace>Microsoft.Maui.Controls.Xaml.UnitTests.InternalsVisibleAssembly</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Controls\Maps\src\Controls.Maps.csproj" />
+    <ProjectReference Include="..\..\..\Controls\src\Core\Controls.Core.csproj" />
+    <ProjectReference Include="..\..\..\Controls\src\Xaml\Controls.Xaml.csproj" />
+    <ProjectReference Include="..\..\..\Core\maps\src\Maps.csproj" />
+    <ProjectReference Include="..\..\..\Core\src\Core.csproj" />
+    <ProjectReference Include="..\..\..\Essentials\src\Essentials.csproj" />
+    <ProjectReference Include="..\..\..\TestUtils\src\TestUtils\TestUtils.csproj" />
+  </ItemGroup>
+
+  <Import Project="$(MauiSrcDirectory)Maui.InTree.props" Condition=" '$(UseMaui)' != 'true' " />
+
+</Project>

--- a/src/Controls/tests/Xaml.UnitTests.InternalsVisibleAssembly/Directory.Build.targets
+++ b/src/Controls/tests/Xaml.UnitTests.InternalsVisibleAssembly/Directory.Build.targets
@@ -1,0 +1,5 @@
+<Project>
+  <Import Project="$(MauiSrcDirectory)Maui.InTree.targets" Condition=" '$(UseMaui)' != 'true' " />
+  <Import Project="$(MauiSrcDirectory)Microsoft.Maui.Controls.Debug.targets" />
+  <Import Project="$(MauiRootDirectory)Directory.Build.targets" />
+</Project>

--- a/src/Controls/tests/Xaml.UnitTests.InternalsVisibleAssembly/Issues/Maui14158/Attributes.cs
+++ b/src/Controls/tests/Xaml.UnitTests.InternalsVisibleAssembly/Issues/Maui14158/Attributes.cs
@@ -1,0 +1,3 @@
+﻿using Microsoft.Maui.Controls;
+
+[assembly: XmlnsDefinition("http://schemas.microsoft.com/dotnet/2021/maui/xaml/tests", "Microsoft.Maui.Controls.Xaml.UnitTests.Issues.Maui14158")]

--- a/src/Controls/tests/Xaml.UnitTests.InternalsVisibleAssembly/Issues/Maui14158/InternalVisibleTypes.cs
+++ b/src/Controls/tests/Xaml.UnitTests.InternalsVisibleAssembly/Issues/Maui14158/InternalVisibleTypes.cs
@@ -1,0 +1,7 @@
+﻿using System.ComponentModel;
+using Microsoft.Maui.Controls;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests.Issues.Maui14158;
+
+[Description("Microsoft.Maui.Controls.Xaml.UnitTests.InternalsVisibleAssembly")]
+internal class InternalButVisible : Label { }

--- a/src/Controls/tests/Xaml.UnitTests.InternalsVisibleAssembly/Issues/Maui14158/PublicTypes.cs
+++ b/src/Controls/tests/Xaml.UnitTests.InternalsVisibleAssembly/Issues/Maui14158/PublicTypes.cs
@@ -1,0 +1,7 @@
+﻿using System.ComponentModel;
+using Microsoft.Maui.Controls;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests.Issues.Maui14158;
+
+[Description("Microsoft.Maui.Controls.Xaml.UnitTests.InternalsVisibleAssembly")]
+public class PublicInVisible : Button { }

--- a/src/Controls/tests/Xaml.UnitTests.InternalsVisibleAssembly/Issues/Maui14158/WithSuffix.cs
+++ b/src/Controls/tests/Xaml.UnitTests.InternalsVisibleAssembly/Issues/Maui14158/WithSuffix.cs
@@ -1,0 +1,7 @@
+﻿using System.ComponentModel;
+using Microsoft.Maui.Controls;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests.Issues.Maui14158;
+
+[Description("Microsoft.Maui.Controls.Xaml.UnitTests.InternalsVisibleAssembly")]
+internal class InternalWithSuffix : Button { }

--- a/src/Controls/tests/Xaml.UnitTests/Controls.Xaml.UnitTests.csproj
+++ b/src/Controls/tests/Xaml.UnitTests/Controls.Xaml.UnitTests.csproj
@@ -38,6 +38,8 @@
     <ProjectReference Include="..\..\..\Core\src\Core.csproj" />
     <ProjectReference Include="..\..\..\Essentials\src\Essentials.csproj" />
     <ProjectReference Include="..\Xaml.UnitTests.ExternalAssembly\Controls.Xaml.UnitTests.ExternalAssembly.csproj" />
+    <ProjectReference Include="..\Xaml.UnitTests.InternalsHiddenAssembly\Controls.Xaml.UnitTests.InternalsHiddenAssembly.csproj" />
+    <ProjectReference Include="..\Xaml.UnitTests.InternalsVisibleAssembly\Controls.Xaml.UnitTests.InternalsVisibleAssembly.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui14158/InternalVisibleTypes.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui14158/InternalVisibleTypes.xaml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+			 xmlns:maui14158="http://schemas.microsoft.com/dotnet/2021/maui/xaml/tests"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+			 x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui14158.InternalVisibleTypes">
+	<StackLayout>
+
+		<maui14158:InternalButVisible x:Name="internalButVisible" />
+
+	</StackLayout>
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui14158/InternalVisibleTypes.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui14158/InternalVisibleTypes.xaml.cs
@@ -1,0 +1,33 @@
+using Microsoft.Maui.Controls.Xaml.UnitTests.Issues.Maui14158;
+using NUnit.Framework;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests.Maui14158;
+
+public partial class InternalVisibleTypes : ContentPage
+{
+	public InternalVisibleTypes()
+	{
+		InitializeComponent();
+	}
+
+	public InternalVisibleTypes(bool useCompiledXaml)
+	{
+		//this stub will be replaced at compile time
+	}
+
+	[TestFixture]
+	class Tests
+	{
+		[TestCase(true)]
+		[TestCase(false)]
+		public void VerifyCorrectTypesUsed(bool useCompiledXaml)
+		{
+			if (useCompiledXaml)
+				Assert.DoesNotThrow(() => MockCompiler.Compile(typeof(InternalVisibleTypes)));
+
+			var page = new InternalVisibleTypes(useCompiledXaml);
+
+			Assert.IsInstanceOf<InternalButVisible>(page.internalButVisible);
+		}
+	}
+}

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui14158/PublicTypes.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui14158/PublicTypes.xaml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+			 xmlns:maui14158="http://schemas.microsoft.com/dotnet/2021/maui/xaml/tests"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+			 x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui14158.PublicTypes">
+	<StackLayout>
+
+		<maui14158:PublicInExternal x:Name="publicInExternal" />
+
+		<maui14158:PublicInHidden x:Name="publicInHidden" /> 
+
+		<maui14158:PublicInVisible x:Name="publicInVisible" />
+
+	</StackLayout>
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui14158/PublicTypes.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui14158/PublicTypes.xaml.cs
@@ -1,0 +1,35 @@
+using Microsoft.Maui.Controls.Xaml.UnitTests.Issues.Maui14158;
+using NUnit.Framework;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests.Maui14158;
+
+public partial class PublicTypes : ContentPage
+{
+	public PublicTypes()
+	{
+		InitializeComponent();
+	}
+
+	public PublicTypes(bool useCompiledXaml)
+	{
+		//this stub will be replaced at compile time
+	}
+
+	[TestFixture]
+	class Tests
+	{
+		[TestCase(true)]
+		[TestCase(false)]
+		public void VerifyCorrectTypesUsed(bool useCompiledXaml)
+		{
+			if (useCompiledXaml)
+				Assert.DoesNotThrow(() => MockCompiler.Compile(typeof(PublicTypes)));
+
+			var page = new PublicTypes(useCompiledXaml);
+
+			Assert.IsInstanceOf<PublicInExternal>(page.publicInExternal);
+			Assert.IsInstanceOf<PublicInHidden>(page.publicInHidden);
+			Assert.IsInstanceOf<PublicInVisible>(page.publicInVisible);
+		}
+	}
+}

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui14158/WithSuffix.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui14158/WithSuffix.xaml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+			 xmlns:maui14158="http://schemas.microsoft.com/dotnet/2021/maui/xaml/tests"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+			 x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui14158.WithSuffix">
+	<StackLayout>
+
+		<maui14158:PublicWithSuffix x:Name="publicWithSuffix" />
+
+		<maui14158:InternalWithSuffix x:Name="internalWithSuffix" />
+
+	</StackLayout>
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui14158/WithSuffix.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui14158/WithSuffix.xaml.cs
@@ -1,0 +1,34 @@
+using Microsoft.Maui.Controls.Xaml.UnitTests.Issues.Maui14158;
+using NUnit.Framework;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests.Maui14158;
+
+public partial class WithSuffix : ContentPage
+{
+	public WithSuffix()
+	{
+		InitializeComponent();
+	}
+
+	public WithSuffix(bool useCompiledXaml)
+	{
+		//this stub will be replaced at compile time
+	}
+
+	[TestFixture]
+	class Tests
+	{
+		[TestCase(true)]
+		[TestCase(false)]
+		public void VerifyCorrectTypesUsed(bool useCompiledXaml)
+		{
+			if (useCompiledXaml)
+				Assert.DoesNotThrow(() => MockCompiler.Compile(typeof(WithSuffix)));
+
+			var page = new WithSuffix(useCompiledXaml);
+
+			Assert.IsInstanceOf<PublicWithSuffix>(page.publicWithSuffix);
+			Assert.IsInstanceOf<InternalWithSuffix>(page.internalWithSuffix);
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change

This PR fixes the case where duplicate types exist and then the source generator just stops. This issue actually also affects both the XAML parser and the IL generator. The parser throws a cast exception at runtime and the IL generator will result in a method access exception.

* In one case we may have duplicate `XmlnsDefinitionAttribute` declarations because we are going to IL merge all the dlls into the build tasks - and then use unit tests to reference this. As a result, we end up with an internal type in the build tasks and the public one in Controls.

* The other case is just duplicate types in different assemblies. This can easily be reproduced by creating an internal type in an external assembly - and not even externals as it can also happen if you declare it in the main assembly - and it happens to be the same of some other type in the maui dll.

Both issues are a case of `Compilation.GetTypeByMetadataName()` returning null if there are _any_ duplicate types. This even happens if the type is internal in both assemblies. Similarly, the XAML parser and IL generator also just get the type and never make sure it is a _visible_ type.

### Tests

This PR has some tests:

* Generator does not fail if there are duplicate `XmlnsDefinitionAttribute` attributes defined - one being internal and custom and the other being the maui one.
* Generator does not select internal types that it should not
* Generator can select types if the InternalsVisibleTo says it can


### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #14158

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
