### PR TITLE
Make Windows FrameRenderer border measure area on resize

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Windows/FrameRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Windows/FrameRenderer.cs
@@ -105,6 +105,8 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		protected override global::Windows.Foundation.Size MeasureOverride(global::Windows.Foundation.Size availableSize)
 		{
+			Control?.Measure(availableSize);
+
 			if (Element is IContentView cv)
 			{
 				// If there's a border specified, include the thickness in our measurements


### PR DESCRIPTION
The WBorder that is used in the windows Frame control did not measure the area it had available when resizing, so text would not wrap and the border wouldn't resize properly


### Description of Change

Added a call to `Control?.Measure(availableSize)` so the contents of the control are resized appropriately. This mimics the behavior done in `ArrangeOverride` : 

https://github.com/dotnet/maui/blob/main/src/Controls/src/Core/Compatibility/Handlers/Windows/FrameRenderer.cs#L95-L96

**NOTE:** This solution is not perfect; if you look at the gif below, you'll notice that word wrapping is not perfect when the window is extremely slim. It also seems that some words are covered by the margin before they wrap. I noticed that this is all dependent on the `Control.Measure(...)` call, but was unable to pinpoint why this was caused. Any help would be appreciated! 

![Demo](https://user-images.githubusercontent.com/32918747/227372386-a5c34139-6b94-4e11-9780-374bc941d4d6.gif)

### Issues Fixed

Fixes: https://github.com/dotnet/maui/issues/13552

