### PR TITLE
Remove ReceiveSms added by default

### DIFF
--- a/src/Essentials/src/Permissions/Permissions.android.cs
+++ b/src/Essentials/src/Permissions/Permissions.android.cs
@@ -447,7 +447,6 @@ namespace Microsoft.Maui.ApplicationModel
 				{
 					var permissions = new List<(string, bool)>
 					{
-						(Manifest.Permission.ReceiveSms, true)
 					};
 
 					if (IsDeclaredInManifest(Manifest.Permission.SendSms))


### PR DESCRIPTION
### Description of Change

Removed ReceiveSms permission on Android which was added by default.

### Issues Fixed

Fixes #13446
