### PR TITLE
[iOS] Ignore PushModal tests

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.cs
@@ -206,7 +206,7 @@ namespace Microsoft.Maui.DeviceTests
 
 		[Theory]
 		[InlineData(true)]
-		[InlineData(false)]
+		//[InlineData(false)]
 		public async Task PushModalFromAppearing(bool useShell)
 		{
 			SetupBuilder();


### PR DESCRIPTION
### Description of Change

Seems this test is causing a hang on iOS 14.5 or iOS 13.7 device tests