### PR TITLE
[Windows] Display alerts by Window

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Core/MultiWindowPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/MultiWindowPage.xaml
@@ -28,7 +28,11 @@
             <Button
                 Clicked="OnCloseWindowClicked"
                 Text="Close this Window" />
-
+            <Label 
+                Text="Dialogs:" />
+            <Button
+                Clicked="OnOpenDialogClicked"
+                Text="Open Dialog" />
             <Label Text="Control Size:" />
             <Button
                 Clicked="OnSetMinSize"

--- a/src/Controls/samples/Controls.Sample/Pages/Core/MultiWindowPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/MultiWindowPage.xaml.cs
@@ -24,6 +24,11 @@ namespace Maui.Controls.Sample.Pages
 			Application.Current.CloseWindow(Window);
 		}
 
+		async void OnOpenDialogClicked(object sender, EventArgs e)
+		{
+			await DisplayAlert("Information", "The dialog should open by Window.", "Ok");
+		}
+
 		void OnSetMaxSize(object sender, EventArgs e)
 		{
 			Window.MaximumWidth = 800;

--- a/src/Controls/src/Core/Platform/AlertManager/AlertManager.Windows.cs
+++ b/src/Controls/src/Core/Platform/AlertManager/AlertManager.Windows.cs
@@ -73,6 +73,9 @@ namespace Microsoft.Maui.Controls.Platform
 
 			async void OnAlertRequested(Page sender, AlertArguments arguments)
 			{
+				if (!PageIsInThisWindow(sender))
+					return;
+
 				string content = arguments.Message ?? string.Empty;
 				string title = arguments.Title ?? string.Empty;
 
@@ -123,9 +126,12 @@ namespace Microsoft.Maui.Controls.Platform
 				arguments.SetResult(await CurrentAlert.ConfigureAwait(false));
 				CurrentAlert = null;
 			}
-
+			
 			async void OnPromptRequested(Page sender, PromptArguments arguments)
 			{
+				if (!PageIsInThisWindow(sender))
+					return;
+
 				var promptDialog = new PromptDialog
 				{
 					Title = arguments.Title ?? string.Empty,
@@ -160,6 +166,9 @@ namespace Microsoft.Maui.Controls.Platform
 
 			void OnActionSheetRequested(Page sender, ActionSheetArguments arguments)
 			{
+				if (!PageIsInThisWindow(sender))
+					return;
+
 				bool userDidSelect = false;
 
 				if (arguments.FlowDirection == FlowDirection.MatchParent)
@@ -233,6 +242,17 @@ namespace Microsoft.Maui.Controls.Platform
 					return prompt.Input;
 
 				return null;
+			}
+
+			bool PageIsInThisWindow(Page page)
+			{
+				var window = page?.Window;
+				var platformWindow = window?.MauiContext.GetPlatformWindow();
+
+				if (window is null || platformWindow is null)
+					return false;
+
+				return platformWindow == Window;
 			}
 		}
 	}


### PR DESCRIPTION
### Description of Change

Currently when displaying alerts are displayed in all the opened windows. This PR include changes to display the alert only in the current parent window.

![fix-10026-II](https://user-images.githubusercontent.com/6755973/228218134-30f4a7f0-c610-4fe0-8835-c4ece66a18d2.gif)

### Issues Fixed

Fixes #10026