### PR TITLE
Fix firing modal from appearing ios14

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
@@ -1028,6 +1028,8 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 						_finishedWithInitialNavigation = true;
 						np.SendNavigatedFromHandler(null);
 					}
+
+					r.CompletePendingNavigation(true);
 				}
 			}
 


### PR DESCRIPTION
### Description of Change

NavigationRenderer depends on `ViewDidAppear` getting called from `ParentingViewController`. If you push modals too early in the life cycle then `ViewDidAppear` is never called so the initial Navigation from loading the first page was never resolving. This wasn't an issue on shell because with shell all navigation passes through a single pipeline and that pipeline makes sure nav request don't overlap. 
