### PR TITLE
[Windows] Allow to refresh the RefreshView using the mouse 

### DIFF
--- a/src/Core/src/Handlers/RefreshView/RefreshViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/RefreshView/RefreshViewHandler.Windows.cs
@@ -124,7 +124,7 @@ namespace Microsoft.Maui.Handlers
 			if (e.PointerDeviceType is UI.Input.PointerDeviceType.Touch)
 				return; // Already managed by the RefreshContainer control itself
 
-			const double minimumCumulativeY = 10;
+			const double minimumCumulativeY = 20;
 			double cumulativeY = e.Cumulative.Translation.Y;
 
 			if (cumulativeY > minimumCumulativeY && VirtualView is not null && !VirtualView.IsRefreshing)


### PR DESCRIPTION
### Description of Change

Allow to refresh the RefreshView using the mouse using the `ManipulationDelta `event.

![fix-refreshview](https://user-images.githubusercontent.com/6755973/228536432-ef073845-5acc-48e4-b88b-35ab762d0727.gif)

To validate the changes, launch the .NET MAUI Gallery and navigate to the RefreshView sample. Use the mouse pointer to refresh the collection.

### Issues Fixed

Fixes (but reverted) #6404 