### PR TITLE
[ios] fix memory leak in `Button`

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Button/ButtonTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Button/ButtonTests.iOS.cs
@@ -1,7 +1,10 @@
 ﻿#nullable enable
+using System;
 using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
 using Microsoft.Maui.Handlers;
 using UIKit;
+using Xunit;
 
 namespace Microsoft.Maui.DeviceTests
 {
@@ -17,5 +20,21 @@ namespace Microsoft.Maui.DeviceTests
 
 		UILineBreakMode GetPlatformLineBreakMode(ButtonHandler buttonHandler) =>
 			GetPlatformButton(buttonHandler).TitleLabel.LineBreakMode;
+
+		[Fact("Clicked works after GC")]
+		public async Task ClickedWorksAfterGC()
+		{
+			bool fired = false;
+			var button = new Button();
+			button.Clicked += (sender, e) => fired = true;
+			var handler = await CreateHandlerAsync<ButtonHandler>(button);
+
+			await Task.Yield();
+			GC.Collect();
+			GC.WaitForPendingFinalizers();
+
+			await InvokeOnMainThreadAsync(() => handler.PlatformView.SendActionForControlEvents(UIControlEvent.TouchUpInside));
+			Assert.True(fired, "Button.Clicked did not fire!");
+		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.cs
@@ -34,6 +34,7 @@ namespace Microsoft.Maui.DeviceTests
 					handlers.AddHandler<Window, WindowHandlerStub>();
 					handlers.AddHandler<Frame, FrameRenderer>();
 					handlers.AddHandler<Label, LabelHandler>();
+					handlers.AddHandler<Button, ButtonHandler>();
 				});
 			});
 		}
@@ -298,7 +299,15 @@ namespace Microsoft.Maui.DeviceTests
 
 			await CreateHandlerAndAddToWindow<WindowHandlerStub>(new Window(navPage), async (handler) =>
 			{
-				var page = new ContentPage { Title = "Page 2", Content = new VerticalStackLayout { new Label() } };
+				var page = new ContentPage
+				{
+					Title = "Page 2",
+					Content = new VerticalStackLayout
+					{
+						new Label(),
+						new Button(),
+					}
+				};
 				pageReference = new WeakReference(page);
 				await navPage.Navigation.PushAsync(page);
 				await navPage.Navigation.PopAsync();

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
@@ -968,7 +968,15 @@ namespace Microsoft.Maui.DeviceTests
 			{
 				await OnLoadedAsync(shell.CurrentPage);
 
-				var page = new ContentPage { Title = "Page 2", Content = new VerticalStackLayout { new Label() } };
+				var page = new ContentPage
+				{
+					Title = "Page 2",
+					Content = new VerticalStackLayout
+					{
+						new Label(),
+						new Button(),
+					}
+				};
 				pageReference = new WeakReference(page);
 
 				await shell.Navigation.PushAsync(page);

--- a/src/Controls/tests/DeviceTests/Extensions.cs
+++ b/src/Controls/tests/DeviceTests/Extensions.cs
@@ -32,6 +32,7 @@ namespace Microsoft.Maui.DeviceTests
 			handlers.TryAddHandler<Layout, LayoutHandler>();
 			handlers.TryAddHandler<Image, ImageHandler>();
 			handlers.TryAddHandler<Label, LabelHandler>();
+			handlers.TryAddHandler<Button, ButtonHandler>();
 			handlers.TryAddHandler<Page, PageHandler>();
 			handlers.TryAddHandler(typeof(Toolbar), typeof(ToolbarHandler));
 			handlers.TryAddHandler(typeof(MenuBar), typeof(MenuBarHandler));


### PR DESCRIPTION
Fixes #12048
Context: https://github.com/jonathanpeppers/MemoryLeaksOniOS
Context: https://stackoverflow.com/a/13059140

Issue #12048 has four scenarios that are currently fixed in `main` for Android and Windows. Unfortunately, one of the four scenarios fails on iOS due to its usage of `Button`. I could reproduce the issue by simply adding a `Button` to existing memory leak tests.

`ButtonHandler.iOS.cs` has a "cycle":

* `ButtonHandler` subscribes to events like `UIButton.TouchUpInside` making `UIButton` hold a strong reference to `ButtonHandler`.

* `ButtonHandler` (like all handlers) has a strong reference to the `Microsoft.Maui.Button`.

* `ButtonHandler` has a strong reference to `UIButton`.

* `Microsoft.Maui.Button` has a strong reference to `ButtonHandler`.

To solve this issue, we can make a nested classed named `ButtonProxy`:

* Its purpose is subscribe to `UIButton.TouchUpInside` and invoke `Microsoft.Maui.Button.Clicked()`.

* `ButtonProxy` has a weak reference to the `Microsoft.Maui.Button`.

Now the `UIButton`, `ButtonProxy`, `ButtonHandler`, and `Microsoft.Maui.Button` can all be collected.