### PR TITLE
[xamlc] fix `assembly=mscorlib` namespaces in `Release` mode

### DIFF
--- a/src/Controls/src/Xaml/XmlTypeXamlExtensions.cs
+++ b/src/Controls/src/Xaml/XmlTypeXamlExtensions.cs
@@ -78,8 +78,18 @@ namespace Microsoft.Maui.Controls.Xaml
 
 			var potentialTypes = new List<(string typeName, string clrNamespace, string assemblyName)>();
 			foreach (string typeName in lookupNames)
+			{
 				foreach (XmlnsDefinitionAttribute xmlnsDefinitionAttribute in lookupAssemblies)
+				{
 					potentialTypes.Add(new(typeName, xmlnsDefinitionAttribute.ClrNamespace, xmlnsDefinitionAttribute.AssemblyName));
+
+					// As a fallback, for assembly=mscorlib try assembly=System.Private.CoreLib
+					if (xmlnsDefinitionAttribute.AssemblyName == "mscorlib")
+					{
+						potentialTypes.Add(new(typeName, xmlnsDefinitionAttribute.ClrNamespace, "System.Private.CoreLib"));
+					}
+				}
+			}
 
 			T? type = null;
 			foreach (var typeInfo in potentialTypes)

--- a/src/Controls/tests/DeviceTests/Controls.DeviceTests.csproj
+++ b/src/Controls/tests/DeviceTests/Controls.DeviceTests.csproj
@@ -51,6 +51,11 @@
   <ItemGroup Condition="!$(TargetFramework.Contains('-windows'))">
     <Compile Remove="**\*.Windows.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <Compile Update="Elements\RadioButton\RadioButtonUsing.xaml.cs">
+      <DependentUpon>%(Filename)</DependentUpon>
+    </Compile>
+  </ItemGroup>
 
   <Import Project="$(MauiSrcDirectory)Maui.InTree.props" Condition=" '$(UseMaui)' != 'true' " />
 

--- a/src/Controls/tests/DeviceTests/Elements/RadioButton/RadioButtonTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/RadioButton/RadioButtonTests.cs
@@ -47,18 +47,18 @@ namespace Microsoft.Maui.DeviceTests
 		{
 			var page = new ContentPage();
 			page.LoadFromXaml(
-"""
-<?xml version="1.0" encoding="UTF-8"?>
-<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-	xmlns:sys="clr-namespace:System;assembly=mscorlib">
-	<RadioButton>
-		<RadioButton.Value>
-			<sys:Int32>1</sys:Int32>
-		</RadioButton.Value>
-	</RadioButton>
-</ContentPage>
-""");
+				"""
+				<?xml version="1.0" encoding="UTF-8"?>
+				<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+					xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+					xmlns:sys="clr-namespace:System;assembly=mscorlib">
+					<RadioButton>
+						<RadioButton.Value>
+							<sys:Int32>1</sys:Int32>
+						</RadioButton.Value>
+					</RadioButton>
+				</ContentPage>
+				""");
 			Assert.IsType<RadioButton>(page.Content);
 			Assert.Equal(1, ((RadioButton)page.Content).Value);
 		}

--- a/src/Controls/tests/DeviceTests/Elements/RadioButton/RadioButtonTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/RadioButton/RadioButtonTests.cs
@@ -1,6 +1,6 @@
-﻿#if WINDOWS
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
 using Microsoft.Maui.Handlers;
 using Xunit;
 
@@ -9,6 +9,7 @@ namespace Microsoft.Maui.DeviceTests
 	[Category(TestCategory.RadioButton)]
 	public partial class RadioButtonTests : ControlsHandlerTestBase
 	{
+#if WINDOWS
 		[Theory(DisplayName = "IsChecked Initializes Correctly")]
 		[InlineData(false)]
 		[InlineData(true)]
@@ -39,6 +40,35 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.Equal(xplatIsChecked, valuesSecond.ViewValue);
 			Assert.Equal(expectedValue, valuesSecond.PlatformViewValue);
 		}
+#endif
+
+		[Fact("Parsed XAML can use mscorlib")]
+		public void Namespace_mscorlib_Parsed()
+		{
+			var page = new ContentPage();
+			page.LoadFromXaml(
+"""
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+	xmlns:sys="clr-namespace:System;assembly=mscorlib">
+	<RadioButton>
+		<RadioButton.Value>
+			<sys:Int32>1</sys:Int32>
+		</RadioButton.Value>
+	</RadioButton>
+</ContentPage>
+""");
+			Assert.IsType<RadioButton>(page.Content);
+			Assert.Equal(1, ((RadioButton)page.Content).Value);
+		}
+
+		[Fact("Compiled XAML can use mscorlib")]
+		public void Namespace_mscorlib_Compiled()
+		{
+			var page = new RadioButtonUsing();
+			Assert.IsType<RadioButton>(page.Content);
+			Assert.Equal(1, ((RadioButton)page.Content).Value);
+		}
 	}
 }
-#endif

--- a/src/Controls/tests/DeviceTests/Elements/RadioButton/RadioButtonUsing.xaml
+++ b/src/Controls/tests/DeviceTests/Elements/RadioButton/RadioButtonUsing.xaml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+	xmlns:sys="clr-namespace:System;assembly=mscorlib"
+	x:Class="Microsoft.Maui.DeviceTests.RadioButtonUsing">
+	<ContentPage.Content>
+		<RadioButton>
+			<RadioButton.Value>
+				<sys:Int32>1</sys:Int32>
+			</RadioButton.Value>
+		</RadioButton>
+	</ContentPage.Content>
+</ContentPage>

--- a/src/Controls/tests/DeviceTests/Elements/RadioButton/RadioButtonUsing.xaml.cs
+++ b/src/Controls/tests/DeviceTests/Elements/RadioButton/RadioButtonUsing.xaml.cs
@@ -1,0 +1,14 @@
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	public partial class RadioButtonUsing : ContentPage
+	{
+		public RadioButtonUsing()
+		{
+			InitializeComponent();
+		}
+	}
+}

--- a/src/Controls/tests/Xaml.UnitTests/TestXmlnsUsing.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/TestXmlnsUsing.xaml
@@ -2,8 +2,21 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
 	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
 	xmlns:local="using:Microsoft.Maui.Controls.Xaml.UnitTests"
+	xmlns:sys="clr-namespace:System;assembly=mscorlib"
 	x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.TestXmlnsUsing">
 	<ContentPage.Content>
-		<local:CustomXamlView />
+		<VerticalStackLayout>
+			<local:CustomXamlView x:Name="CustomView" />
+			<RadioButton x:Name="Radio1">
+				<RadioButton.Value>
+					<sys:Int32>1</sys:Int32>
+				</RadioButton.Value>
+			</RadioButton>
+			<RadioButton x:Name="Radio2">
+				<RadioButton.Value>
+					<sys:Int32>2</sys:Int32>
+				</RadioButton.Value>
+			</RadioButton>
+		</VerticalStackLayout>
 	</ContentPage.Content>
 </ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/TestXmlnsUsing.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/TestXmlnsUsing.xaml.cs
@@ -33,7 +33,9 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 			{
 				var page = new TestXmlnsUsing(useCompiledXaml);
 				Assert.That(page.Content, Is.Not.Null);
-				Assert.That(page.Content, Is.TypeOf<CustomXamlView>());
+				Assert.That(page.CustomView, Is.TypeOf<CustomXamlView>());
+				Assert.That(page.Radio1.Value, Is.EqualTo(1));
+				Assert.That(page.Radio2.Value, Is.EqualTo(2));
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #9471
Context: https://learn.microsoft.com/dotnet/standard/assembly/type-forwarding

Using something like this fails in `Release` builds on some platforms:

    <ContentPage
        ...
        xmlns:sys="clr-namespace:System;assembly=mscorlib">
        <RadioButton>
            <RadioButton.Value>
                <sys:Int32>1</sys:Int32>
            </RadioButton.Value>
        </RadioButton>
    </ContentPage>

With the exception:

    System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
    ---> Microsoft.Maui.Controls.Xaml.XamlParseException: Position 11:22. Type sys:Int32 not found in xmlns clr-namespace:System;assembly=mscorlib
    at Microsoft.Maui.Controls.Xaml.CreateValuesVisitor.Visit(ElementNode node, INode parentNode)

What's going on here is that `mscorlib.dll` in .NET 5+ is an assembly that only contains type forwards. For example:

    [assembly: TypeForwardedTo(typeof(Int32))]

Where `System.Int32` is actually in `System.Private.CoreLib.dll`.

In builds that use `PublishTrimmed=true` it can get trimmed away and the type forwards disappear. Call sites will be updated with the "real" assembly. You'd see different behavior in `Debug` vs `Release` (iOS has to run the trimmer even in `Debug` mode, while Android & Windows do not).

I added a unit test for this scenario, which of course passes due to unit tests projects not using trimming. I had to add an on-device test, which only failed in `Release` mode where I tested it on Android.

To solve the issue, I added a fallback for `System.Private.CoreLib`:

    // As a fallback, for assembly=mscorlib try assembly=System.Private.CoreLib
    if (xmlnsDefinitionAttribute.AssemblyName == "mscorlib")
    {
        potentialTypes.Add(new(typeName, xmlnsDefinitionAttribute.ClrNamespace, "System.Private.CoreLib"));
    }

This seems like a safe fix, because it still attempts `mscorlib` first.

The XAML editor's Intellisense suggests `clr-namespace:System;assembly=mscorlib` quite easily. I think we have to support it.