### PR TITLE
[IntegrationTests] Bump template creation timeout

### DIFF
--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Microsoft.Maui.IntegrationTests.csproj
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Microsoft.Maui.IntegrationTests.csproj
@@ -5,6 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
+    <RollForward>Major</RollForward>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/DotnetInternal.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/DotnetInternal.cs
@@ -34,7 +34,9 @@ namespace Microsoft.Maui.IntegrationTests
 
 		public static bool New(string shortName, string outputDirectory, string framework)
 		{
-			return Run("new", $"{shortName} -o \"{outputDirectory}\" -f {framework}", timeoutinSeconds: 60);
+			var output = RunForOutput("new", $"{shortName} -o \"{outputDirectory}\" -f {framework}", out int exitCode, timeoutInSeconds: 300);
+			TestContext.WriteLine(output);
+			return exitCode == 0;
 		}
 
 		public static bool Run(string command, string args, int timeoutinSeconds = DEFAULT_TIMEOUT)


### PR DESCRIPTION
Bumps the process timeout for template creation to 5 minutes and adds
`<RollForward>Major</RollForward>` to the integration test project so it
can run on newer versions of .NET.