### PR TITLE
Add top safe area when top tabs are present

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellSectionRootRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellSectionRootRenderer.cs
@@ -8,7 +8,6 @@ using CoreGraphics;
 using Foundation;
 using Microsoft.Extensions.DependencyInjection;
 using ObjCRuntime;
-using SpriteKit;
 using UIKit;
 
 namespace Microsoft.Maui.Controls.Platform.Compatibility

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellSectionRootRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellSectionRootRenderer.cs
@@ -221,7 +221,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 					var view = renderer.ViewController.View;
 					if (view != null)
 					{
-						view.Frame = new CGRect(0, 0, _containerArea.Frame.Width, _containerArea.Frame.Height);
+						view.Frame = new CGRect(0, 0, View.Bounds.Width, View.Bounds.Height);
 						UpdateAdditionalSafeAreaInsets(renderer);
 					}
 				}

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellSectionRootRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellSectionRootRenderer.cs
@@ -458,7 +458,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				{
 					_header = CreateShellSectionRootHeader(_shellContext);
 					_header.ShellSection = ShellSection;
-					
+
 					AddChildViewController(_header.ViewController);
 					View.AddSubview(_header.ViewController.View);
 				}

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.iOS.cs
@@ -24,6 +24,52 @@ namespace Microsoft.Maui.DeviceTests
 	[Category(TestCategory.Shell)]
 	public partial class ShellTests
 	{
+		[Fact(DisplayName = "Page Adjust When Top Tabs Are Present")]
+		public async Task PageAdjustsWhenTopTabsArePresent()
+		{
+			SetupBuilder();
+			var pageWithTopTabs = new ContentPage() { Content = new Label() { Text = "Page With Top Tabs" } };
+			var pageWithoutTopTabs = new ContentPage() { Content = new Label() { Text = "Page With Bottom Tabs" } };
+
+			var mainTab1 = new Tab()
+			{
+				Items =
+				{
+					new ShellContent() { Content = pageWithTopTabs, Title = "tab 1" },
+					new ShellContent() { Content = new ContentPage(), Title = "tab 2" }
+				}
+			};
+
+			var mainTab2 = new Tab()
+			{
+				Items =
+				{
+					new ShellContent() { Content = pageWithoutTopTabs, Title = "tab 3"  }
+				}
+			};
+
+			var shell = new Shell()
+			{
+				Items = { mainTab1, mainTab2 }
+			};
+
+			await CreateHandlerAndAddToWindow<ShellRenderer>(shell, async (handler) =>
+			{
+				await OnFrameSetToNotEmpty(pageWithTopTabs.Content);
+				var boundsWithTopTabs = pageWithTopTabs.Content.GetPlatformViewBounds();
+				shell.CurrentItem = mainTab2;
+				await OnFrameSetToNotEmpty(pageWithoutTopTabs.Content);
+				var boundsWithoutTopTabs = pageWithoutTopTabs.Content.GetPlatformViewBounds();
+				Assert.Equal(ShellSectionRootRenderer.HeaderHeight, (boundsWithTopTabs.Top - boundsWithoutTopTabs.Top), 1);
+
+				shell.CurrentItem = mainTab1;
+				await OnFrameSetToNotEmpty(pageWithTopTabs.Content);
+
+				var boundsWithTopTabsNavigatedBack = pageWithTopTabs.Content.GetPlatformViewBounds();
+				Assert.Equal(boundsWithTopTabsNavigatedBack, boundsWithTopTabs);
+			});
+		}
+
 		[Fact(DisplayName = "Swiping Away Modal Propagates to Shell")]
 		public async Task SwipingAwayModalPropagatesToShell()
 		{


### PR DESCRIPTION
### Description of Change

In XF offsetting the top tabs was handled by the PageRenderer. Inside the PageRenderer we would just add padding to the content. This code wasn't copied over to MAUI. 

iOS11 added this super helpful API `AdditionalSafeAreaInsets` so we don't have to fake safe areas anymore. 

### Issues Fixed

Fixes #12479

