### PR TITLE
[controls] fix memory leak in `CollectionView`

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/Android/MauiRecyclerView.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/MauiRecyclerView.cs
@@ -42,6 +42,10 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		ItemTouchHelper _itemTouchHelper;
 		SimpleItemTouchHelperCallback _itemTouchHelperCallback;
+		WeakNotifyPropertyChangedProxy _layoutPropertyChangedProxy;
+		PropertyChangedEventHandler _layoutPropertyChanged;
+
+		~MauiRecyclerView() => _layoutPropertyChangedProxy?.Unsubscribe();
 
 		public MauiRecyclerView(Context context, Func<IItemsLayout> getItemsLayout, Func<TAdapter> getAdapter) : base(context)
 		{
@@ -58,9 +62,10 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		public virtual void TearDownOldElement(TItemsView oldElement)
 		{
 			// Stop listening for layout property changes
-			if (ItemsLayout != null)
+			if (_layoutPropertyChangedProxy is not null)
 			{
-				ItemsLayout.PropertyChanged -= LayoutPropertyChanged;
+				_layoutPropertyChangedProxy.Unsubscribe();
+				_layoutPropertyChanged = null;
 			}
 
 			// Stop listening for ScrollTo requests
@@ -283,14 +288,16 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		public virtual void UpdateLayoutManager()
 		{
-			if (ItemsLayout != null)
-				ItemsLayout.PropertyChanged -= LayoutPropertyChanged;
+			_layoutPropertyChangedProxy?.Unsubscribe();
 
 			ItemsLayout = _getItemsLayout();
 
 			// Keep track of the ItemsLayout's property changes
 			if (ItemsLayout != null)
-				ItemsLayout.PropertyChanged += LayoutPropertyChanged;
+			{
+				_layoutPropertyChanged ??= LayoutPropertyChanged;
+				_layoutPropertyChangedProxy = new WeakNotifyPropertyChangedProxy(ItemsLayout, _layoutPropertyChanged);
+			}
 
 			SetLayoutManager(SelectLayoutManager(ItemsLayout));
 

--- a/src/Controls/src/Core/Handlers/Items/iOS/CarouselViewDelegator.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/CarouselViewDelegator.cs
@@ -49,11 +49,11 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		{
 			var (VisibleItems, First, Center, Last) = GetVisibleItemsIndexPath();
 			int firstVisibleItemIndex = -1, centerItemIndex = -1, lastVisibleItemIndex = -1;
-			if (VisibleItems)
+			if (VisibleItems && ViewController is CarouselViewController vc)
 			{
-				firstVisibleItemIndex = ViewController.GetIndexFromIndexPath(First);
-				centerItemIndex = ViewController.GetIndexFromIndexPath(Center);
-				lastVisibleItemIndex = ViewController.GetIndexFromIndexPath(Last);
+				firstVisibleItemIndex = vc.GetIndexFromIndexPath(First);
+				centerItemIndex = vc.GetIndexFromIndexPath(Center);
+				lastVisibleItemIndex = vc.GetIndexFromIndexPath(Last);
 			}
 			return (VisibleItems, firstVisibleItemIndex, centerItemIndex, lastVisibleItemIndex);
 		}

--- a/src/Controls/src/Core/Handlers/Items/iOS/GroupableItemsViewDelegator.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/GroupableItemsViewDelegator.cs
@@ -17,12 +17,12 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		public override CGSize GetReferenceSizeForHeader(UICollectionView collectionView, UICollectionViewLayout layout, nint section)
 		{
-			return ViewController.GetReferenceSizeForHeader(collectionView, layout, section);
+			return ViewController?.GetReferenceSizeForHeader(collectionView, layout, section) ?? CGSize.Empty;
 		}
 
 		public override CGSize GetReferenceSizeForFooter(UICollectionView collectionView, UICollectionViewLayout layout, nint section)
 		{
-			return ViewController.GetReferenceSizeForFooter(collectionView, layout, section);
+			return ViewController?.GetReferenceSizeForFooter(collectionView, layout, section) ?? CGSize.Empty;
 		}
 
 		public override void ScrollAnimationEnded(UIScrollView scrollView)
@@ -37,7 +37,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				return default;
 			}
 
-			return ViewController.GetInsetForSection(ItemsViewLayout, collectionView, section);
+			return ViewController?.GetInsetForSection(ItemsViewLayout, collectionView, section) ?? UIEdgeInsets.Zero;
 		}
 	}
 }

--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		bool _emptyViewDisplayed;
 		bool _disposed;
 
+		Func<UICollectionViewCell> _getPrototype;
 		UIView _emptyUIView;
 		VisualElement _emptyViewFormsElement;
 		Dictionary<object, TemplatedCell> _measurementCells = new Dictionary<object, TemplatedCell>();
@@ -200,7 +201,8 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 			_initialized = true;
 
-			ItemsViewLayout.GetPrototype = GetPrototype;
+			_getPrototype ??= GetPrototype;
+			ItemsViewLayout.GetPrototype = _getPrototype;
 
 			Delegator = CreateDelegator();
 			CollectionView.Delegate = Delegator;

--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewDelegator.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewDelegator.cs
@@ -12,15 +12,17 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		where TItemsView : ItemsView
 		where TViewController : ItemsViewController<TItemsView>
 	{
+		readonly WeakReference<TViewController> _viewController;
+
 		public ItemsViewLayout ItemsViewLayout { get; }
-		public TViewController ViewController { get; }
+		public TViewController ViewController => _viewController.TryGetTarget(out var vc) ? vc : null;
 
 		protected float PreviousHorizontalOffset, PreviousVerticalOffset;
 
 		public ItemsViewDelegator(ItemsViewLayout itemsViewLayout, TViewController itemsViewController)
 		{
 			ItemsViewLayout = itemsViewLayout;
-			ViewController = itemsViewController;
+			_viewController = new(itemsViewController);
 		}
 
 		public override void Scrolled(UIScrollView scrollView)
@@ -45,8 +47,12 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				LastVisibleItemIndex = lastVisibleItemIndex
 			};
 
-			var itemsView = ViewController.ItemsView;
-			var source = ViewController.ItemsSource;
+			var viewController = ViewController;
+			if (viewController is null)
+				return;
+
+			var itemsView = viewController.ItemsView;
+			var source = viewController.ItemsSource;
 			itemsView.SendScrolled(itemsViewScrolledEventArgs);
 
 			PreviousHorizontalOffset = (float)contentOffsetX;
@@ -119,7 +125,11 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		protected virtual (bool VisibleItems, NSIndexPath First, NSIndexPath Center, NSIndexPath Last) GetVisibleItemsIndexPath()
 		{
-			var indexPathsForVisibleItems = ViewController.CollectionView.IndexPathsForVisibleItems.OrderBy(x => x.Row).ToList();
+			var collectionView = ViewController?.CollectionView;
+			if (collectionView is null)
+				return default;
+
+			var indexPathsForVisibleItems = collectionView.IndexPathsForVisibleItems.OrderBy(x => x.Row).ToList();
 
 			var visibleItems = indexPathsForVisibleItems.Count > 0;
 			NSIndexPath firstVisibleItemIndex = null, centerItemIndex = null, lastVisibleItemIndex = null;
@@ -127,7 +137,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			if (visibleItems)
 			{
 				firstVisibleItemIndex = indexPathsForVisibleItems.First();
-				centerItemIndex = GetCenteredIndexPath(ViewController.CollectionView);
+				centerItemIndex = GetCenteredIndexPath(collectionView);
 				lastVisibleItemIndex = indexPathsForVisibleItems.Last();
 			}
 
@@ -166,7 +176,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		public override CGSize GetSizeForItem(UICollectionView collectionView, UICollectionViewLayout layout, NSIndexPath indexPath)
 		{
-			return ViewController.GetSizeForItem(indexPath);
+			return ViewController?.GetSizeForItem(indexPath) ?? CGSize.Empty;
 		}
 	}
 }

--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewLayout.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewLayout.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		CGSize _adjustmentSize0;
 		CGSize _adjustmentSize1;
 		CGSize _currentSize;
+		WeakReference<Func<UICollectionViewCell>> _getPrototype;
 
 		const double ConstraintSizeTolerance = 0.00001;
 
@@ -28,7 +29,11 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		public nfloat ConstrainedDimension { get; set; }
 
-		public Func<UICollectionViewCell> GetPrototype { get; set; }
+		public Func<UICollectionViewCell> GetPrototype
+		{
+			get => _getPrototype is not null && _getPrototype.TryGetTarget(out var func) ? func : null;
+			set => _getPrototype = new(value);
+		}
 
 		internal ItemSizingStrategy ItemSizingStrategy { get; private set; }
 

--- a/src/Controls/src/Core/Handlers/Items/iOS/LoopObservableItemsSource.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/LoopObservableItemsSource.cs
@@ -1,4 +1,5 @@
 #nullable disable
+using System;
 using System.Collections;
 using Foundation;
 using ObjCRuntime;
@@ -26,8 +27,12 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				return base.CreateIndexesFrom(startIndex, count);
 			}
 
+			var collectionView = CollectionView;
+			if (collectionView == null)
+				return Array.Empty<NSIndexPath>();
+
 			return IndexPathHelpers.GenerateLoopedIndexPathRange(Section,
-				(int)CollectionView.NumberOfItemsInSection(Section), LoopBy, startIndex, count);
+				(int)collectionView.NumberOfItemsInSection(Section), LoopBy, startIndex, count);
 		}
 	}
 }

--- a/src/Controls/src/Core/Handlers/Items/iOS/LoopObservableItemsSource.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/LoopObservableItemsSource.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			}
 
 			var collectionView = CollectionView;
-			if (collectionView == null)
+			if (collectionView is null)
 				return Array.Empty<NSIndexPath>();
 
 			return IndexPathHelpers.GenerateLoopedIndexPathRange(Section,

--- a/src/Controls/src/Core/Handlers/Items/iOS/ObservableItemsSource.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ObservableItemsSource.cs
@@ -10,8 +10,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 {
 	internal class ObservableItemsSource : IObservableItemsViewSource
 	{
-		readonly UICollectionViewController _collectionViewController;
-		protected readonly UICollectionView CollectionView;
+		readonly WeakReference<UICollectionViewController> _collectionViewController;
 		readonly bool _grouped;
 		readonly int _section;
 		readonly IEnumerable _itemsSource;
@@ -19,8 +18,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		public ObservableItemsSource(IEnumerable itemSource, UICollectionViewController collectionViewController, int group = -1)
 		{
-			_collectionViewController = collectionViewController;
-			CollectionView = _collectionViewController.CollectionView;
+			_collectionViewController = new(collectionViewController);
 
 			_section = group < 0 ? 0 : group;
 			_grouped = group >= 0;
@@ -34,6 +32,8 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		internal event NotifyCollectionChangedEventHandler CollectionViewUpdating;
 		internal event NotifyCollectionChangedEventHandler CollectionViewUpdated;
+
+		internal UICollectionView CollectionView => _collectionViewController.TryGetTarget(out var controller) ? controller.CollectionView : null;
 
 		public int Count { get; private set; }
 
@@ -125,9 +125,13 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		void CollectionChanged(NotifyCollectionChangedEventArgs args)
 		{
+			if (!_collectionViewController.TryGetTarget(out var controller))
+				return;
+
 			// Force UICollectionView to get the internal accounting straight
-			if (!CollectionView.Hidden)
-				CollectionView.NumberOfItemsInSection(_section);
+			var collectionView = controller.CollectionView;
+			if (!collectionView.Hidden)
+				collectionView.NumberOfItemsInSection(_section);
 
 			switch (args.Action)
 			{
@@ -153,14 +157,18 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		void Reload()
 		{
+			if (!_collectionViewController.TryGetTarget(out var controller))
+				return;
+
 			var args = new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset);
 
 			Count = ItemsCount();
 
 			OnCollectionViewUpdating(args);
 
-			CollectionView.ReloadData();
-			CollectionView.CollectionViewLayout.InvalidateLayout();
+			var collectionView = controller.CollectionView;
+			collectionView.ReloadData();
+			collectionView.CollectionViewLayout.InvalidateLayout();
 
 			OnCollectionViewUpdated(args);
 		}
@@ -177,7 +185,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			var startIndex = args.NewStartingIndex > -1 ? args.NewStartingIndex : IndexOf(args.NewItems[0]);
 
 			// Queue up the updates to the UICollectionView
-			Update(() => CollectionView.InsertItems(CreateIndexesFrom(startIndex, count)), args);
+			Update(c => c.InsertItems(CreateIndexesFrom(startIndex, count)), args);
 		}
 
 		void Remove(NotifyCollectionChangedEventArgs args)
@@ -196,7 +204,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			var count = args.OldItems.Count;
 			Count -= count;
 
-			Update(() => CollectionView.DeleteItems(CreateIndexesFrom(startIndex, count)), args);
+			Update(c => c.DeleteItems(CreateIndexesFrom(startIndex, count)), args);
 		}
 
 		void Replace(NotifyCollectionChangedEventArgs args)
@@ -209,7 +217,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 				// We are replacing one set of items with a set of equal size; we can do a simple item range update
 
-				Update(() => CollectionView.ReloadItems(CreateIndexesFrom(startIndex, newCount)), args);
+				Update(c => c.ReloadItems(CreateIndexesFrom(startIndex, newCount)), args);
 				return;
 			}
 
@@ -228,14 +236,14 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				var oldPath = NSIndexPath.Create(_section, args.OldStartingIndex);
 				var newPath = NSIndexPath.Create(_section, args.NewStartingIndex);
 
-				Update(() => CollectionView.MoveItem(oldPath, newPath), args);
+				Update(c => c.MoveItem(oldPath, newPath), args);
 				return;
 			}
 
 			var start = Math.Min(args.OldStartingIndex, args.NewStartingIndex);
 			var end = Math.Max(args.OldStartingIndex, args.NewStartingIndex) + count;
 
-			Update(() => CollectionView.ReloadItems(CreateIndexesFrom(start, end)), args);
+			Update(c => c.ReloadItems(CreateIndexesFrom(start, end)), args);
 		}
 
 		internal int ItemsCount()
@@ -281,15 +289,19 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			return -1;
 		}
 
-		void Update(Action update, NotifyCollectionChangedEventArgs args)
+		void Update(Action<UICollectionView> update, NotifyCollectionChangedEventArgs args)
 		{
-			if (CollectionView.Hidden)
+			if (!_collectionViewController.TryGetTarget(out var controller))
+				return;
+
+			var collectionView = controller.CollectionView;
+			if (collectionView.Hidden)
 			{
 				return;
 			}
 
 			OnCollectionViewUpdating(args);
-			update();
+			update(collectionView);
 			OnCollectionViewUpdated(args);
 		}
 

--- a/src/Controls/src/Core/Handlers/Items/iOS/ReorderableItemsViewDelegator.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ReorderableItemsViewDelegator.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		{
 			NSIndexPath targetIndexPath;
 
-			var itemsView = ViewController.ItemsView;
+			var itemsView = ViewController?.ItemsView;
 			if (itemsView?.IsGrouped == true)
 			{
 				if (originalIndexPath.Section == proposedIndexPath.Section || itemsView.CanMixGroups)

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -3,6 +3,7 @@
 Microsoft.Maui.Controls.Border.~Border() -> void
 Microsoft.Maui.Controls.Handlers.Compatibility.FrameRenderer.FrameRenderer(Android.Content.Context! context, Microsoft.Maui.IPropertyMapper! mapper) -> void
 Microsoft.Maui.Controls.Handlers.Compatibility.FrameRenderer.FrameRenderer(Android.Content.Context! context, Microsoft.Maui.IPropertyMapper! mapper, Microsoft.Maui.CommandMapper! commandMapper) -> void
+Microsoft.Maui.Controls.Handlers.Items.MauiRecyclerView<TItemsView, TAdapter, TItemsViewSource>.~MauiRecyclerView() -> void
 Microsoft.Maui.Controls.LayoutOptions.Equals(Microsoft.Maui.Controls.LayoutOptions other) -> bool
 Microsoft.Maui.Controls.Region.Equals(Microsoft.Maui.Controls.Region other) -> bool
 Microsoft.Maui.Controls.Shapes.Matrix.Equals(Microsoft.Maui.Controls.Shapes.Matrix other) -> bool

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -1,6 +1,7 @@
 #nullable enable
 *REMOVED*override Microsoft.Maui.Controls.RefreshView.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 Microsoft.Maui.Controls.Border.~Border() -> void
+Microsoft.Maui.Controls.Handlers.Items.StructuredItemsViewHandler<TItemsView>.~StructuredItemsViewHandler() -> void
 override Microsoft.Maui.Controls.Handlers.BoxViewHandler.NeedsContainer.get -> bool
 Microsoft.Maui.Controls.Handlers.BoxViewHandler
 Microsoft.Maui.Controls.Handlers.BoxViewHandler.BoxViewHandler() -> void

--- a/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Handlers.Compatibility;
+using Microsoft.Maui.Controls.Handlers.Items;
 using Microsoft.Maui.DeviceTests.Stubs;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Hosting;
@@ -35,6 +36,7 @@ namespace Microsoft.Maui.DeviceTests
 					handlers.AddHandler<Frame, FrameRenderer>();
 					handlers.AddHandler<Label, LabelHandler>();
 					handlers.AddHandler<Button, ButtonHandler>();
+					handlers.AddHandler<CollectionView, CollectionViewHandler>();
 				});
 			});
 		}
@@ -306,6 +308,7 @@ namespace Microsoft.Maui.DeviceTests
 					{
 						new Label(),
 						new Button(),
+						new CollectionView(),
 					}
 				};
 				pageReference = new WeakReference(page);
@@ -313,9 +316,11 @@ namespace Microsoft.Maui.DeviceTests
 				await navPage.Navigation.PopAsync();
 			});
 
-			// 3 GCs were required in Android API 23, 2 worked otherwise
-			for (int i = 0; i < 3; i++)
+			// As we add more controls to this test, more GCs will be required
+			for (int i = 0; i < 16; i++)
 			{
+				if (!pageReference.IsAlive)
+					break;
 				await Task.Yield();
 				GC.Collect();
 				GC.WaitForPendingFinalizers();

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
@@ -8,6 +8,7 @@ using Microsoft.Maui;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Handlers;
 using Microsoft.Maui.Controls.Handlers.Compatibility;
+using Microsoft.Maui.Controls.Handlers.Items;
 using Microsoft.Maui.Devices;
 using Microsoft.Maui.DeviceTests.Stubs;
 using Microsoft.Maui.Handlers;
@@ -34,6 +35,7 @@ namespace Microsoft.Maui.DeviceTests
 					SetupShellHandlers(handlers);
 					handlers.AddHandler(typeof(NavigationPage), typeof(NavigationViewHandler));
 					handlers.AddHandler(typeof(Button), typeof(ButtonHandler));
+					handlers.AddHandler(typeof(CollectionView), typeof(CollectionViewHandler));
 				});
 			});
 		}
@@ -975,6 +977,7 @@ namespace Microsoft.Maui.DeviceTests
 					{
 						new Label(),
 						new Button(),
+						new CollectionView(),
 					}
 				};
 				pageReference = new WeakReference(page);
@@ -983,9 +986,11 @@ namespace Microsoft.Maui.DeviceTests
 				await shell.Navigation.PopAsync();
 			});
 
-			// 3 GCs were required in Android API 23, 2 worked otherwise
-			for (int i = 0; i < 3; i++)
+			// As we add more controls to this test, more GCs will be required
+			for (int i = 0; i < 16; i++)
 			{
+				if (!pageReference.IsAlive)
+					break;
 				await Task.Yield();
 				GC.Collect();
 				GC.WaitForPendingFinalizers();


### PR DESCRIPTION
Fixes #10578
Context: https://github.com/Vroomer/MAUI-navigation-memory-leak.git

After testing the above sample, I found that adding a `CollectionView` to a `Page`, makes it and the entire page live forever.

Android & Windows:

* `MauiRecyclerView` and `StructuredItemsViewHandler` respectively subscribed to `ItemsLayout.PropertyChanged`. This kept the `CollectionView` alive -> all the way up to the `Page`.

* Switched to using `WeakNotifyPropertyChangedProxy` solved the issue for these two platforms.

iOS:

* Generally had a small "nest" of circular references. Initially, I saw `CollectionView`, `UICollectionView`, and various helper classes that would live forever.

```
* ItemsViewController : UICollectionViewController -> 
  * ObservableItemsSource ->
    * UICollectionViewController and UICollectionView

* UICollectionView ->
  * ItemsViewLayout : UICollectionViewFlowLayout ->
    * Func<UICollectionViewCell> ->
      * ItemsViewController : UICollectionViewController ->
        * UICollectionView
```

I switched to using `WeakReference<T>` to break the circular references. This required several null checks, where `null` references were not possible before.

After these changes my tests pass, yay!