### PR TITLE
Don't update the top tabs frame inside the safe area changed

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellSectionRootRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellSectionRootRenderer.cs
@@ -36,6 +36,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 		int _lastTabThickness = Int32.MinValue;
 		Thickness _lastInset;
 		bool _isDisposed;
+		bool _isRotating;
 		UIViewPropertyAnimator _pageAnimation;
 
 		ShellSection ShellSection
@@ -63,6 +64,13 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			LayoutRenderers();
 
 			LayoutHeader();
+			_isRotating = false;
+		}
+
+		public override void ViewWillTransitionToSize(CGSize toSize, IUIViewControllerTransitionCoordinator coordinator)
+		{
+			base.ViewWillTransitionToSize(toSize, coordinator);
+			_isRotating = true;
 		}
 
 		public override void ViewDidLoad()
@@ -128,7 +136,8 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 			base.ViewSafeAreaInsetsDidChange();
 
-			LayoutHeader();
+			if (_didLayoutSubviews && !_isRotating)
+				LayoutHeader();
 		}
 
 		public override void TraitCollectionDidChange(UITraitCollection previousTraitCollection)

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -27,6 +27,7 @@ Microsoft.Maui.Controls.Handlers.BoxViewHandler
 Microsoft.Maui.Controls.Handlers.BoxViewHandler.BoxViewHandler() -> void
 ~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRootRenderer.TraitCollectionDidChange(UIKit.UITraitCollection previousTraitCollection) -> void
 ~override Microsoft.Maui.Controls.LayoutOptions.Equals(object obj) -> bool
+~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRootRenderer.ViewWillTransitionToSize(CoreGraphics.CGSize toSize, UIKit.IUIViewControllerTransitionCoordinator coordinator) -> void
 ~override Microsoft.Maui.Controls.Platform.Compatibility.UIContainerView.AddSubview(UIKit.UIView view) -> void
 ~override Microsoft.Maui.Controls.Platform.Compatibility.UIContainerView.WillRemoveSubview(UIKit.UIView uiview) -> void
 *REMOVED*~Microsoft.Maui.Controls.IMessagingCenter.Send<TSender, TArgs>(TSender sender, string message, TArgs args) -> void

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -27,6 +27,7 @@ Microsoft.Maui.Controls.Handlers.BoxViewHandler
 Microsoft.Maui.Controls.Handlers.BoxViewHandler.BoxViewHandler() -> void
 ~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRootRenderer.TraitCollectionDidChange(UIKit.UITraitCollection previousTraitCollection) -> void
 ~override Microsoft.Maui.Controls.LayoutOptions.Equals(object obj) -> bool
+~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRootRenderer.ViewWillTransitionToSize(CoreGraphics.CGSize toSize, UIKit.IUIViewControllerTransitionCoordinator coordinator) -> void
 ~override Microsoft.Maui.Controls.Platform.Compatibility.UIContainerView.AddSubview(UIKit.UIView view) -> void
 ~override Microsoft.Maui.Controls.Platform.Compatibility.UIContainerView.WillRemoveSubview(UIKit.UIView uiview) -> void
 *REMOVED*~Microsoft.Maui.Controls.IMessagingCenter.Send<TSender, TArgs>(TSender sender, string message, TArgs args) -> void


### PR DESCRIPTION
### Description of Change

It looks like setting the top tabs frame too early in the rotation cycle causes the UICollectionView (used to render the top tabs) to not size correctly, so it only renderers the first cell. This change delays setting the frame during a rotation until the ViewDidLayoutSubviews fires. 

### Issues Fixed

Fixes #13621

### Testing

We can't rotate the device being tested on for device tests so there's not really a way for us to test this in our device tests. You can test this by telling the sample app to launch as shell and then navigating to:

Flyout => Tab 1

Now if you rotate the device you'll notice that the tabs don't disappear. 

You can also test the project attached to the original issue
