### PR TITLE
[net7.0] Update dependencies from xamarin/xamarin-macios to Xcode 14.3

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,7 +15,7 @@
       ]
     },
     "microsoft.dotnet.xharness.cli": {
-      "version": "1.0.0-prerelease.23173.1",
+      "version": "1.0.0-prerelease.23212.1",
       "commands": [
         "xharness"
       ]

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,7 +15,7 @@
       ]
     },
     "microsoft.dotnet.xharness.cli": {
-      "version": "1.0.0-prerelease.22524.1",
+      "version": "1.0.0-prerelease.23173.1",
       "commands": [
         "xharness"
       ]

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -87,15 +87,15 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>3f4da9ced34942d83054e647f3b1d9d7dde281e8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XHarness.TestRunners.Common" Version="1.0.0-prerelease.22524.1">
+    <Dependency Name="Microsoft.DotNet.XHarness.TestRunners.Common" Version="1.0.0-prerelease.23212.1">
       <Uri>https://github.com/dotnet/xharness</Uri>
       <Sha>49b581c1ac56352864cb692d3c523b3fc27eddf7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="1.0.0-prerelease.22524.1">
+    <Dependency Name="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="1.0.0-prerelease.23212.1">
       <Uri>https://github.com/dotnet/xharness</Uri>
       <Sha>49b581c1ac56352864cb692d3c523b3fc27eddf7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XHarness.CLI" Version="1.0.0-prerelease.22524.1">
+    <Dependency Name="Microsoft.DotNet.XHarness.CLI" Version="1.0.0-prerelease.23212.1">
       <Uri>https://github.com/dotnet/xharness</Uri>
       <Sha>49b581c1ac56352864cb692d3c523b3fc27eddf7</Sha>
     </Dependency>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -12,21 +12,21 @@
       <Uri>https://github.com/xamarin/xamarin-android</Uri>
       <Sha>dc07f98a55b1597c834bf7b5ebd6b10223244583</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.MacCatalyst.Sdk" Version="16.4.7044">
+    <Dependency Name="Microsoft.MacCatalyst.Sdk" Version="16.4.7045">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>d657df2c33254f1470ddcc6d37e73bf51d22709c</Sha>
+      <Sha>86ef29d43cbc82594457c73813515c96c4e637ac</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.macOS.Sdk" Version="13.3.7044">
+    <Dependency Name="Microsoft.macOS.Sdk" Version="13.3.7045">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>d657df2c33254f1470ddcc6d37e73bf51d22709c</Sha>
+      <Sha>86ef29d43cbc82594457c73813515c96c4e637ac</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.iOS.Sdk" Version="16.4.7044">
+    <Dependency Name="Microsoft.iOS.Sdk" Version="16.4.7045">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>d657df2c33254f1470ddcc6d37e73bf51d22709c</Sha>
+      <Sha>86ef29d43cbc82594457c73813515c96c4e637ac</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.tvOS.Sdk" Version="16.4.7044">
+    <Dependency Name="Microsoft.tvOS.Sdk" Version="16.4.7045">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>d657df2c33254f1470ddcc6d37e73bf51d22709c</Sha>
+      <Sha>86ef29d43cbc82594457c73813515c96c4e637ac</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.Workload.Emscripten.net6.Manifest-7.0.100" Version="7.0.4" CoherentParentDependency="Microsoft.NETCore.App.Ref">
       <Uri>https://github.com/dotnet/emsdk</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -12,21 +12,21 @@
       <Uri>https://github.com/xamarin/xamarin-android</Uri>
       <Sha>dc07f98a55b1597c834bf7b5ebd6b10223244583</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.MacCatalyst.Sdk" Version="16.2.2052">
+    <Dependency Name="Microsoft.MacCatalyst.Sdk" Version="16.4.7042">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>38fa7f7899ce4cee61b13c620196dd38065b9194</Sha>
+      <Sha>07b6b0219b27c98eacc757b470ff6ee6dc5e5996</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.macOS.Sdk" Version="13.1.2052">
+    <Dependency Name="Microsoft.macOS.Sdk" Version="13.3.7042">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>38fa7f7899ce4cee61b13c620196dd38065b9194</Sha>
+      <Sha>07b6b0219b27c98eacc757b470ff6ee6dc5e5996</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.iOS.Sdk" Version="16.2.2052">
+    <Dependency Name="Microsoft.iOS.Sdk" Version="16.4.7042">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>38fa7f7899ce4cee61b13c620196dd38065b9194</Sha>
+      <Sha>07b6b0219b27c98eacc757b470ff6ee6dc5e5996</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.tvOS.Sdk" Version="16.1.2549">
+    <Dependency Name="Microsoft.tvOS.Sdk" Version="16.4.7042">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>38fa7f7899ce4cee61b13c620196dd38065b9194</Sha>
+      <Sha>07b6b0219b27c98eacc757b470ff6ee6dc5e5996</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.Workload.Emscripten.net6.Manifest-7.0.100" Version="7.0.4" CoherentParentDependency="Microsoft.NETCore.App.Ref">
       <Uri>https://github.com/dotnet/emsdk</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -12,21 +12,21 @@
       <Uri>https://github.com/xamarin/xamarin-android</Uri>
       <Sha>dc07f98a55b1597c834bf7b5ebd6b10223244583</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.MacCatalyst.Sdk" Version="16.4.7042">
+    <Dependency Name="Microsoft.MacCatalyst.Sdk" Version="16.4.7044">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>07b6b0219b27c98eacc757b470ff6ee6dc5e5996</Sha>
+      <Sha>d657df2c33254f1470ddcc6d37e73bf51d22709c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.macOS.Sdk" Version="13.3.7042">
+    <Dependency Name="Microsoft.macOS.Sdk" Version="13.3.7044">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>07b6b0219b27c98eacc757b470ff6ee6dc5e5996</Sha>
+      <Sha>d657df2c33254f1470ddcc6d37e73bf51d22709c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.iOS.Sdk" Version="16.4.7042">
+    <Dependency Name="Microsoft.iOS.Sdk" Version="16.4.7044">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>07b6b0219b27c98eacc757b470ff6ee6dc5e5996</Sha>
+      <Sha>d657df2c33254f1470ddcc6d37e73bf51d22709c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.tvOS.Sdk" Version="16.4.7042">
+    <Dependency Name="Microsoft.tvOS.Sdk" Version="16.4.7044">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>07b6b0219b27c98eacc757b470ff6ee6dc5e5996</Sha>
+      <Sha>d657df2c33254f1470ddcc6d37e73bf51d22709c</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.Workload.Emscripten.net6.Manifest-7.0.100" Version="7.0.4" CoherentParentDependency="Microsoft.NETCore.App.Ref">
       <Uri>https://github.com/dotnet/emsdk</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -28,11 +28,11 @@
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
       <Sha>86ef29d43cbc82594457c73813515c96c4e637ac</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Workload.Emscripten.net6.Manifest-7.0.100" Version="7.0.4" CoherentParentDependency="Microsoft.NETCore.App.Ref">
+    <Dependency Name="Microsoft.NET.Workload.Emscripten.net6.Manifest-7.0.100" Version="7.0.5" CoherentParentDependency="Microsoft.NETCore.App.Ref">
       <Uri>https://github.com/dotnet/emsdk</Uri>
       <Sha>3d7178d836ea32bb7bb51d8d1c714d52fe641ffa</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Workload.Emscripten.net7.Manifest-7.0.100" Version="7.0.4" CoherentParentDependency="Microsoft.NETCore.App.Ref">
+    <Dependency Name="Microsoft.NET.Workload.Emscripten.net7.Manifest-7.0.100" Version="7.0.5" CoherentParentDependency="Microsoft.NETCore.App.Ref">
       <Uri>https://github.com/dotnet/emsdk</Uri>
       <Sha>3d7178d836ea32bb7bb51d8d1c714d52fe641ffa</Sha>
     </Dependency>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -20,7 +20,7 @@
     <!-- Samsung/Tizen.NET -->
     <SamsungTizenSdkPackageVersion>7.0.105</SamsungTizenSdkPackageVersion>
     <!-- emsdk -->
-    <MicrosoftNETWorkloadEmscriptennet7Manifest70100PackageVersion>7.0.4</MicrosoftNETWorkloadEmscriptennet7Manifest70100PackageVersion>
+    <MicrosoftNETWorkloadEmscriptennet7Manifest70100PackageVersion>7.0.5</MicrosoftNETWorkloadEmscriptennet7Manifest70100PackageVersion>
     <MicrosoftNETWorkloadEmscriptenPackageVersion>$(MicrosoftNETWorkloadEmscriptennet7Manifest70100PackageVersion)</MicrosoftNETWorkloadEmscriptenPackageVersion>
     <!-- wasdk -->
     <MicrosoftWindowsAppSDKPackageVersion>1.2.221209.1</MicrosoftWindowsAppSDKPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -13,10 +13,10 @@
     <!-- xamarin/xamarin-android -->
     <MicrosoftAndroidSdkWindowsPackageVersion>33.0.52</MicrosoftAndroidSdkWindowsPackageVersion>
     <!-- xamarin/xamarin-macios -->
-    <MicrosoftMacCatalystSdkPackageVersion>16.4.7044</MicrosoftMacCatalystSdkPackageVersion>
-    <MicrosoftmacOSSdkPackageVersion>13.3.7044</MicrosoftmacOSSdkPackageVersion>
-    <MicrosoftiOSSdkPackageVersion>16.4.7044</MicrosoftiOSSdkPackageVersion>
-    <MicrosofttvOSSdkPackageVersion>16.4.7044</MicrosofttvOSSdkPackageVersion>
+    <MicrosoftMacCatalystSdkPackageVersion>16.4.7045</MicrosoftMacCatalystSdkPackageVersion>
+    <MicrosoftmacOSSdkPackageVersion>13.3.7045</MicrosoftmacOSSdkPackageVersion>
+    <MicrosoftiOSSdkPackageVersion>16.4.7045</MicrosoftiOSSdkPackageVersion>
+    <MicrosofttvOSSdkPackageVersion>16.4.7045</MicrosofttvOSSdkPackageVersion>
     <!-- Samsung/Tizen.NET -->
     <SamsungTizenSdkPackageVersion>7.0.105</SamsungTizenSdkPackageVersion>
     <!-- emsdk -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -13,10 +13,10 @@
     <!-- xamarin/xamarin-android -->
     <MicrosoftAndroidSdkWindowsPackageVersion>33.0.52</MicrosoftAndroidSdkWindowsPackageVersion>
     <!-- xamarin/xamarin-macios -->
-    <MicrosoftMacCatalystSdkPackageVersion>16.2.2052</MicrosoftMacCatalystSdkPackageVersion>
-    <MicrosoftmacOSSdkPackageVersion>13.1.2052</MicrosoftmacOSSdkPackageVersion>
-    <MicrosoftiOSSdkPackageVersion>16.2.2052</MicrosoftiOSSdkPackageVersion>
-    <MicrosofttvOSSdkPackageVersion>16.1.2549</MicrosofttvOSSdkPackageVersion>
+    <MicrosoftMacCatalystSdkPackageVersion>16.4.7042</MicrosoftMacCatalystSdkPackageVersion>
+    <MicrosoftmacOSSdkPackageVersion>13.3.7042</MicrosoftmacOSSdkPackageVersion>
+    <MicrosoftiOSSdkPackageVersion>16.4.7042</MicrosoftiOSSdkPackageVersion>
+    <MicrosofttvOSSdkPackageVersion>16.4.7042</MicrosofttvOSSdkPackageVersion>
     <!-- Samsung/Tizen.NET -->
     <SamsungTizenSdkPackageVersion>7.0.105</SamsungTizenSdkPackageVersion>
     <!-- emsdk -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -61,9 +61,9 @@
     <_HarfBuzzSharpVersion>2.8.2.2</_HarfBuzzSharpVersion>
     <_SkiaSharpNativeAssetsVersion>0.0.0-commit.193b587552cb0ed39372a049d7e6c692db98c267.483</_SkiaSharpNativeAssetsVersion>
     <MicrosoftTemplateEngineTasksVersion>7.0.100-preview.5.22226.1</MicrosoftTemplateEngineTasksVersion>
-    <MicrosoftDotNetXHarnessTestRunnersCommonVersion>1.0.0-prerelease.23173.1</MicrosoftDotNetXHarnessTestRunnersCommonVersion>
-    <MicrosoftDotNetXHarnessTestRunnersXunitVersion>1.0.0-prerelease.23173.1</MicrosoftDotNetXHarnessTestRunnersXunitVersion>
-    <MicrosoftDotNetXHarnessCLIVersion>1.0.0-prerelease.23173.1</MicrosoftDotNetXHarnessCLIVersion>
+    <MicrosoftDotNetXHarnessTestRunnersCommonVersion>1.0.0-prerelease.23212.1</MicrosoftDotNetXHarnessTestRunnersCommonVersion>
+    <MicrosoftDotNetXHarnessTestRunnersXunitVersion>1.0.0-prerelease.23212.1</MicrosoftDotNetXHarnessTestRunnersXunitVersion>
+    <MicrosoftDotNetXHarnessCLIVersion>1.0.0-prerelease.23212.1</MicrosoftDotNetXHarnessCLIVersion>
     <TizenUIExtensionsVersion>0.9.0</TizenUIExtensionsVersion>
     <SvgSkiaPackageVersion>0.5.13</SvgSkiaPackageVersion>
     <FizzlerPackageVersion>1.2.0</FizzlerPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -61,9 +61,9 @@
     <_HarfBuzzSharpVersion>2.8.2.2</_HarfBuzzSharpVersion>
     <_SkiaSharpNativeAssetsVersion>0.0.0-commit.193b587552cb0ed39372a049d7e6c692db98c267.483</_SkiaSharpNativeAssetsVersion>
     <MicrosoftTemplateEngineTasksVersion>7.0.100-preview.5.22226.1</MicrosoftTemplateEngineTasksVersion>
-    <MicrosoftDotNetXHarnessTestRunnersCommonVersion>1.0.0-prerelease.22524.1</MicrosoftDotNetXHarnessTestRunnersCommonVersion>
-    <MicrosoftDotNetXHarnessTestRunnersXunitVersion>1.0.0-prerelease.22524.1</MicrosoftDotNetXHarnessTestRunnersXunitVersion>
-    <MicrosoftDotNetXHarnessCLIVersion>1.0.0-prerelease.22524.1</MicrosoftDotNetXHarnessCLIVersion>
+    <MicrosoftDotNetXHarnessTestRunnersCommonVersion>1.0.0-prerelease.23173.1</MicrosoftDotNetXHarnessTestRunnersCommonVersion>
+    <MicrosoftDotNetXHarnessTestRunnersXunitVersion>1.0.0-prerelease.23173.1</MicrosoftDotNetXHarnessTestRunnersXunitVersion>
+    <MicrosoftDotNetXHarnessCLIVersion>1.0.0-prerelease.23173.1</MicrosoftDotNetXHarnessCLIVersion>
     <TizenUIExtensionsVersion>0.9.0</TizenUIExtensionsVersion>
     <SvgSkiaPackageVersion>0.5.13</SvgSkiaPackageVersion>
     <FizzlerPackageVersion>1.2.0</FizzlerPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -13,10 +13,10 @@
     <!-- xamarin/xamarin-android -->
     <MicrosoftAndroidSdkWindowsPackageVersion>33.0.52</MicrosoftAndroidSdkWindowsPackageVersion>
     <!-- xamarin/xamarin-macios -->
-    <MicrosoftMacCatalystSdkPackageVersion>16.4.7042</MicrosoftMacCatalystSdkPackageVersion>
-    <MicrosoftmacOSSdkPackageVersion>13.3.7042</MicrosoftmacOSSdkPackageVersion>
-    <MicrosoftiOSSdkPackageVersion>16.4.7042</MicrosoftiOSSdkPackageVersion>
-    <MicrosofttvOSSdkPackageVersion>16.4.7042</MicrosofttvOSSdkPackageVersion>
+    <MicrosoftMacCatalystSdkPackageVersion>16.4.7044</MicrosoftMacCatalystSdkPackageVersion>
+    <MicrosoftmacOSSdkPackageVersion>13.3.7044</MicrosoftmacOSSdkPackageVersion>
+    <MicrosoftiOSSdkPackageVersion>16.4.7044</MicrosoftiOSSdkPackageVersion>
+    <MicrosofttvOSSdkPackageVersion>16.4.7044</MicrosofttvOSSdkPackageVersion>
     <!-- Samsung/Tizen.NET -->
     <SamsungTizenSdkPackageVersion>7.0.105</SamsungTizenSdkPackageVersion>
     <!-- emsdk -->

--- a/eng/devices/ios.cake
+++ b/eng/devices/ios.cake
@@ -5,7 +5,7 @@ string TARGET = Argument("target", "Test");
 
 // required
 FilePath PROJECT = Argument("project", EnvironmentVariable("IOS_TEST_PROJECT") ?? "");
-string TEST_DEVICE = Argument("device", EnvironmentVariable("IOS_TEST_DEVICE") ?? "ios-simulator-64_14.4"); // comma separated in the form <platform>-<device|simulator>[-<32|64>][_<version>] (eg: ios-simulator-64_13.4,[...])
+string TEST_DEVICE = Argument("device", EnvironmentVariable("IOS_TEST_DEVICE") ?? "ios-simulator-64_16.4"); // comma separated in the form <platform>-<device|simulator>[-<32|64>][_<version>] (eg: ios-simulator-64_13.4,[...])
 
 // optional
 var USE_DOTNET = Argument("dotnet", true);

--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -8,9 +8,9 @@ variables:
 - name: DOTNET_VERSION
   value: 7.0.100
 - name: REQUIRED_XCODE
-  value: 14.2.0
+  value: 14.3.0
 - name: DEVICETESTS_REQUIRED_XCODE
-  value: 14.2.0
+  value: 14.3.0
 - name: LocBranchPrefix
   value: 'loc-hb'
 - name: isMainBranch

--- a/eng/pipelines/device-tests.yml
+++ b/eng/pipelines/device-tests.yml
@@ -71,6 +71,7 @@ parameters:
       vmImage: $(androidTestsVmImage)
       demands:
         - macOS.Name -equals Ventura
+        - macOS.Architecture -equals x64
 
 resources:
   repositories:

--- a/eng/pipelines/device-tests.yml
+++ b/eng/pipelines/device-tests.yml
@@ -90,7 +90,7 @@ stages:
       ${{ if or(parameters.BuildEverything, and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'devdiv'))) }}:
         androidApiLevels: [ 30, 29, 28, 27, 26, 25, 24, 23 ]
         # androidApiLevels: [ 30, 29, 28, 27, 26, 25, 24, 23, 22, 21 ] # fix the issue of getting the test results off
-        iosVersions: [ 'latest', '15.5', '14.5', '13.7', '12.4' ]
+        iosVersions: [ 'latest', '15.5', '14.5', '13.7']
         provisionatorChannel: ${{ parameters.provisionatorChannel }}
       ${{ if not(or(parameters.BuildEverything, and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'devdiv')))) }}:
         androidApiLevels: [ 30, 23 ]
@@ -112,18 +112,15 @@ stages:
           desc: Core
           androidApiLevelsExclude: [25] # Ignore for now API25 since the runs's are not stable
           android: $(System.DefaultWorkingDirectory)/src/Core/tests/DeviceTests/Core.DeviceTests.csproj
-          iosVersionsExclude: [ '12.4'] # Ignore iOS 12.4 while we can't make it work on CI
           ios: $(System.DefaultWorkingDirectory)/src/Core/tests/DeviceTests/Core.DeviceTests.csproj
         - name: controls
           desc: Controls
           androidApiLevelsExclude: [25] # Ignore for now API25 since the runs's are not stable
           android: $(System.DefaultWorkingDirectory)/src/Controls/tests/DeviceTests/Controls.DeviceTests.csproj
-          iosVersionsExclude: [ '12.4'] # Ignore iOS 12.4 while we can't make it work on CI
           ios: $(System.DefaultWorkingDirectory)/src/Controls/tests/DeviceTests/Controls.DeviceTests.csproj
         - name: blazorwebview
           desc: BlazorWebView
           androidApiLevelsExclude: [ 27, 26, 25, 24, 23, 22, 21 ] # BlazorWebView requires a recent version of Chrome
           android: $(System.DefaultWorkingDirectory)/src/BlazorWebView/tests/MauiDeviceTests/MauiBlazorWebView.DeviceTests.csproj
-          iosVersionsExclude: [ '12.4'] # Ignore iOS 12.4 while we can't make it work on CI
           ios: $(System.DefaultWorkingDirectory)/src/BlazorWebView/tests/MauiDeviceTests/MauiBlazorWebView.DeviceTests.csproj
 

--- a/eng/pipelines/device-tests.yml
+++ b/eng/pipelines/device-tests.yml
@@ -71,7 +71,6 @@ parameters:
       vmImage: $(androidTestsVmImage)
       demands:
         - macOS.Name -equals Ventura
-        - macOS.Architecture -equals x64
 
 resources:
   repositories:

--- a/eng/pipelines/device-tests.yml
+++ b/eng/pipelines/device-tests.yml
@@ -62,7 +62,7 @@ parameters:
       name: $(androidTestsVmPool)
       vmImage: $(androidTestsVmImage)
       demands:
-        - macOS.Name -equals Monterey
+        - macOS.Name -equals Ventura
         - macOS.Architecture -equals x64
   - name: iosPool
     type: object

--- a/eng/pipelines/device-tests.yml
+++ b/eng/pipelines/device-tests.yml
@@ -67,8 +67,11 @@ parameters:
   - name: iosPool
     type: object
     default:
-      name: $(iosTestsVmPool)
-      vmImage: $(iosTestsVmImage)
+      name: $(androidTestsVmPool)
+      vmImage: $(androidTestsVmImage)
+      demands:
+        - macOS.Name -equals Ventura
+        - macOS.Architecture -equals x64
 
 resources:
   repositories:

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -145,10 +145,8 @@ stages:
               name: ${{ BuildPlatform.poolName }}
               vmImage: ${{ BuildPlatform.vmImage }}
               demands:
-                - macOS.Name -equals Monterey
+                - macOS.Name -equals Ventura
                 - macOS.Architecture -equals x64
-                - Agent.HasDevices -equals False
-                - Agent.IsPaired -equals False
             steps:
               - template: common/provision.yml
                 parameters:
@@ -190,10 +188,8 @@ stages:
             name: ${{ PackPlatform.poolName }}
             vmImage: ${{ PackPlatform.vmImage }}
             demands:
-              - macOS.Name -equals Monterey
+              - macOS.Name -equals Ventura
               - macOS.Architecture -equals x64
-              - Agent.HasDevices -equals False
-              - Agent.IsPaired -equals False
           steps:
             - template: common/pack.yml
               parameters:
@@ -222,10 +218,8 @@ stages:
               name: ${{ BuildPlatform.poolName }}
               vmImage: ${{ BuildPlatform.vmImage }}
               demands:
-                - macOS.Name -equals Monterey
+                - macOS.Name -equals Ventura
                 - macOS.Architecture -equals x64
-                - Agent.HasDevices -equals False
-                - Agent.IsPaired -equals False
             steps:
               - template: common/provision.yml
                 parameters:
@@ -274,10 +268,8 @@ stages:
                 name: ${{ BuildPlatform.poolName }}
                 vmImage: ${{ BuildPlatform.vmImage }}
                 demands:
-                  - macOS.Name -equals Monterey
+                  - macOS.Name -equals Ventura
                   - macOS.Architecture -equals x64
-                  - Agent.HasDevices -equals False
-                  - Agent.IsPaired -equals False
               steps:
                 - template: common/provision.yml
                   parameters:

--- a/src/Core/src/ImageSources/iOS/ImageSourceExtensions.cs
+++ b/src/Core/src/ImageSources/iOS/ImageSourceExtensions.cs
@@ -18,18 +18,22 @@ namespace Microsoft.Maui
 			var glyph = (NSString)imageSource.Glyph;
 
 			var attString = new NSAttributedString(glyph, font, color);
-			var imagesize = glyph.GetSizeUsingAttributes(attString.GetUIKitAttributes(0, out _));
+			var attributes = attString.GetUIKitAttributes(0, out _);
+			if (attributes != null)
+			{
+				var imagesize = glyph.GetSizeUsingAttributes(attributes);
 
-			UIGraphics.BeginImageContextWithOptions(imagesize, false, scale);
-			var ctx = new NSStringDrawingContext();
+				UIGraphics.BeginImageContextWithOptions(imagesize, false, scale);
+				var ctx = new NSStringDrawingContext();
 
-			var boundingRect = attString.GetBoundingRect(imagesize, 0, ctx);
-			attString.DrawString(new CGRect(
-				imagesize.Width / 2 - boundingRect.Size.Width / 2,
-				imagesize.Height / 2 - boundingRect.Size.Height / 2,
-				imagesize.Width,
-				imagesize.Height));
-
+				var boundingRect = attString.GetBoundingRect(imagesize, 0, ctx);
+				attString.DrawString(new CGRect(
+					imagesize.Width / 2 - boundingRect.Size.Width / 2,
+					imagesize.Height / 2 - boundingRect.Size.Height / 2,
+					imagesize.Width,
+					imagesize.Height));
+				
+			}
 			var image = UIGraphics.GetImageFromCurrentImageContext();
 			UIGraphics.EndImageContext();
 

--- a/src/Core/src/ImageSources/iOS/ImageSourceExtensions.cs
+++ b/src/Core/src/ImageSources/iOS/ImageSourceExtensions.cs
@@ -19,21 +19,19 @@ namespace Microsoft.Maui
 
 			var attString = new NSAttributedString(glyph, font, color);
 			var attributes = attString.GetUIKitAttributes(0, out _);
-			if (attributes != null)
-			{
-				var imagesize = glyph.GetSizeUsingAttributes(attributes);
 
-				UIGraphics.BeginImageContextWithOptions(imagesize, false, scale);
-				var ctx = new NSStringDrawingContext();
+			var imagesize = attributes == null ? attString.Size : glyph.GetSizeUsingAttributes(attributes);
 
-				var boundingRect = attString.GetBoundingRect(imagesize, 0, ctx);
-				attString.DrawString(new CGRect(
-					imagesize.Width / 2 - boundingRect.Size.Width / 2,
-					imagesize.Height / 2 - boundingRect.Size.Height / 2,
-					imagesize.Width,
-					imagesize.Height));
-				
-			}
+			UIGraphics.BeginImageContextWithOptions(imagesize, false, scale);
+			var ctx = new NSStringDrawingContext();
+
+			var boundingRect = attString.GetBoundingRect(imagesize, 0, ctx);
+			attString.DrawString(new CGRect(
+				imagesize.Width / 2 - boundingRect.Size.Width / 2,
+				imagesize.Height / 2 - boundingRect.Size.Height / 2,
+				imagesize.Width,
+				imagesize.Height));
+
 			var image = UIGraphics.GetImageFromCurrentImageContext();
 			UIGraphics.EndImageContext();
 

--- a/src/Core/src/Platform/iOS/LabelExtensions.cs
+++ b/src/Core/src/Platform/iOS/LabelExtensions.cs
@@ -83,9 +83,8 @@ namespace Microsoft.Maui.Platform
 				StringEncoding = NSStringEncoding.UTF8
 			};
 
-			NSError? nsError = null;
-
-			platformLabel.AttributedText = new NSAttributedString(text, attr, ref nsError);
+			NSError nSError = new NSError();
+			platformLabel.AttributedText = new NSAttributedString(text, attr,ref nSError);
 		}
 
 		internal static void UpdateTextPlainText(this UILabel platformLabel, IText label)

--- a/src/Core/src/Platform/iOS/LabelExtensions.cs
+++ b/src/Core/src/Platform/iOS/LabelExtensions.cs
@@ -84,7 +84,8 @@ namespace Microsoft.Maui.Platform
 			};
 
 			NSError nSError = new NSError();
-			platformLabel.AttributedText = new NSAttributedString(text, attr,ref nSError);
+
+			platformLabel.AttributedText = new NSAttributedString(text, attr, ref nSError);
 		}
 
 		internal static void UpdateTextPlainText(this UILabel platformLabel, IText label)

--- a/src/Core/src/Platform/iOS/MauiWebViewNavigationDelegate.cs
+++ b/src/Core/src/Platform/iOS/MauiWebViewNavigationDelegate.cs
@@ -93,8 +93,14 @@ namespace Microsoft.Maui.Platform
 		public void DecidePolicy(WKWebView webView, WKNavigationAction navigationAction, Action<WKNavigationActionPolicy> decisionHandler)
 		{
 			var handler = Handler;
-			if (handler == null)
+			if (handler == null || handler?.VirtualView == null)
+			{
+				//the only place we saw this happening is on device tests,
+				//But the decisionHandler should always be called, or else we will get an NSInternalInconsistencyException
+				decisionHandler(WKNavigationActionPolicy.Cancel);
 				return;
+			}
+				
 
 			var navEvent = WebNavigationEvent.NewPage;
 			var navigationType = navigationAction.NavigationType;
@@ -128,10 +134,7 @@ namespace Microsoft.Maui.Platform
 			_lastEvent = navEvent;
 
 			var virtualView = handler.VirtualView;
-
-			if (virtualView == null)
-				return;
-
+	
 			var request = navigationAction.Request;
 			var lastUrl = request.Url.ToString();
 


### PR DESCRIPTION
Updates macios version to the ones we plan to ship as Xcode 14.3 support.