### PR TITLE
[net7.0] Ensure that second-pass measures of Auto rows/columns are al…

### DIFF
--- a/src/Core/src/Layouts/GridLayoutManager.cs
+++ b/src/Core/src/Layouts/GridLayoutManager.cs
@@ -400,8 +400,11 @@ namespace Microsoft.Maui.Layouts
                     {
                         if (cell.ColumnSpan == 1)
                         {
+							if (!cell.NeedsSecondPass)
+							{
                             _columns[cell.Column].Update(measure.Width);
                         }
+						}
                         else
                         {
                             TrackSpan(new Span(cell.Column, cell.ColumnSpan, true, measure.Width));
@@ -412,8 +415,11 @@ namespace Microsoft.Maui.Layouts
                     {
                         if (cell.RowSpan == 1)
                         {
+							if (!cell.NeedsSecondPass)
+							{
                             _rows[cell.Row].Update(measure.Height);
                         }
+						}
                         else
                         {
                             TrackSpan(new Span(cell.Row, cell.RowSpan, false, measure.Height));
@@ -434,14 +440,28 @@ namespace Microsoft.Maui.Layouts
 					double width = 0;
 					double height = 0;
 
+					if (cell.IsRowSpanAuto)
+					{
+						height = double.PositiveInfinity;
+					}
+					else
+					{
 					for (int n = cell.Row; n < cell.Row + cell.RowSpan; n++)
 					{
 						height += _rows[n].Size;
 					}
+					}
 
+					if (cell.IsColumnSpanAuto)
+					{
+						width = double.PositiveInfinity;
+					}
+					else
+					{
 					for (int n = cell.Column; n < cell.Column + cell.ColumnSpan; n++)
 					{
 						width += _columns[n].Size;
+					}
 					}
 
 					if (width == 0 || height == 0)
@@ -455,10 +475,18 @@ namespace Microsoft.Maui.Layouts
 					{
 						TrackSpan(new Span(cell.Column, cell.ColumnSpan, true, measure.Width));
 					}
+					else if (cell.ColumnSpan == 1)
+					{
+						_columns[cell.Column].Update(measure.Width);
+					}
 
 					if (cell.IsRowSpanStar && cell.RowSpan > 1)
 					{
 						TrackSpan(new Span(cell.Row, cell.RowSpan, false, measure.Height));
+					}
+					else if (cell.RowSpan == 1)
+					{
+						_rows[cell.Row].Update(measure.Height);
 					}
 				}
 			}

--- a/src/Core/tests/UnitTests/Layouts/LayoutTestHelpers.cs
+++ b/src/Core/tests/UnitTests/Layouts/LayoutTestHelpers.cs
@@ -1,6 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Microsoft.Maui.Graphics;
 using NSubstitute;
+using NSubstitute.Core;
 
 namespace Microsoft.Maui.UnitTests.Layouts
 {
@@ -49,6 +51,84 @@ namespace Microsoft.Maui.UnitTests.Layouts
 		public static void AssertArranged(IView view, Rect expected)
 		{
 			view.Received().Arrange(Arg.Is(expected));
+		}
+
+		// Create a test view which works like a text block
+		// So the height is dependent on the width being measured
+		public static IView CreateWidthDominatedView(double unconstrainedWidth, double unconstrainedHeight,
+			params Tuple<double, double>[] sizes)
+		{
+			var view = CreateTestView();
+
+			Func<CallInfo, Size> fakeMeasure = (ci) =>
+			{
+				var widthConstraint = (double)ci.Args()[0];
+				var heightConstraint = (double)ci.Args()[1];
+
+				double width = 0;
+				double height = 0;
+
+				if (double.IsPositiveInfinity(widthConstraint))
+				{
+					width = unconstrainedWidth;
+					height = unconstrainedHeight;
+				}
+
+				for (int n = 0; n < sizes.Length; n++)
+				{
+					if (widthConstraint <= sizes[n].Item1)
+					{
+						width = widthConstraint;
+						height = sizes[n].Item2;
+						break;
+					}
+				}
+
+				return new Size(width, height);
+			};
+
+			view.Measure(Arg.Any<double>(), Arg.Any<double>()).Returns(fakeMeasure);
+
+			return view;
+		}
+
+		// Create a test view where the width is dependent on the height
+		// (e.g., like an image with a fixed aspect ratio)
+		public static IView CreateHeightDominatedView(double unconstrainedWidth, double unconstrainedHeight,
+			params Tuple<double, double>[] sizes)
+		{
+			var view = CreateTestView();
+
+			Func<CallInfo, Size> fakeMeasure = (ci) =>
+			{
+				var widthConstraint = (double)ci.Args()[0];
+				var heightConstraint = (double)ci.Args()[1];
+
+				double width = 0;
+				double height = 0;
+
+				if (double.IsPositiveInfinity(heightConstraint))
+				{
+					width = unconstrainedWidth;
+					height = unconstrainedHeight;
+				}
+
+				for (int n = 0; n < sizes.Length; n++)
+				{
+					if (heightConstraint <= sizes[n].Item2)
+					{
+						width = sizes[n].Item1;
+						height = heightConstraint;
+						break;
+					}
+				}
+
+				return new Size(width, height);
+			};
+
+			view.Measure(Arg.Any<double>(), Arg.Any<double>()).Returns(fakeMeasure);
+
+			return view;
 		}
 	}
 }


### PR DESCRIPTION
…lowed to expand (#14315)

Backport of #14315 to net7.0

/cc @mattleibow @hartez
