### PR TITLE
Fix menu item command binding (#13848)

### DIFF
--- a/src/Controls/src/Core/MenuBar.cs
+++ b/src/Controls/src/Core/MenuBar.cs
@@ -96,9 +96,6 @@ namespace Microsoft.Maui.Controls
 			var result = _menus.Remove(item);
 			NotifyHandler(nameof(IMenuBarHandler.Remove), index, item);
 
-			if (item is Element e)
-				e.Parent = null;
-
 			return result;
 		}
 
@@ -111,9 +108,6 @@ namespace Microsoft.Maui.Controls
 
 			_menus.RemoveAt(index);
 			NotifyHandler(nameof(IMenuBarHandler.Remove), index, item);
-
-			if (item is Element e)
-				e.Parent = null;
 		}
 
 		IEnumerator IEnumerable.GetEnumerator()

--- a/src/Controls/tests/Core.UnitTests/Menu/MenuTestBase.cs
+++ b/src/Controls/tests/Core.UnitTests/Menu/MenuTestBase.cs
@@ -101,11 +101,13 @@ namespace Microsoft.Maui.Controls.Core.UnitTests.Menu
 
 			if (typeof(TChildType) == typeof(MenuBarItem))
 			{
-				(child0.Parent as ContentPage)!.MenuBarItems.Clear();
+				(child0.Parent as ContentPage)!.MenuBarItems.Remove(child0 as MenuBarItem);
+				(child1.Parent as ContentPage)!.MenuBarItems.Remove(child1 as MenuBarItem);
 			}
 			else
 			{
-				menuBar.Clear();
+				menuBar.Remove(child0);
+				menuBar.Remove(child1);
 			}
 
 			Assert.Null(child0.Parent);


### PR DESCRIPTION



### Description of Change

Fix menu item command binding is removed after navigation. The reference to parent should not be remove when navigating between pages. Page level already handle removal of parent on menu item if the menu item is removed / no longer needed.

### Issues Fixed

Fixes #13848

