### PR TITLE
[macOS] Display alert by Window

### DIFF
--- a/src/Controls/src/Core/Platform/AlertManager/AlertManager.Windows.cs
+++ b/src/Controls/src/Core/Platform/AlertManager/AlertManager.Windows.cs
@@ -16,17 +16,17 @@ namespace Microsoft.Maui.Controls.Platform
 		{
 			var platformWindow = window.MauiContext.GetPlatformWindow();
 
-			if (Subscriptions.Any(s => s.Window == platformWindow))
+			if (Subscriptions.Any(s => s.PlatformView == platformWindow))
 				return;
 
-			Subscriptions.Add(new AlertRequestHelper(platformWindow, window.MauiContext));
+			Subscriptions.Add(new AlertRequestHelper(window, platformWindow));
 		}
 
 		internal void Unsubscribe(Window window)
 		{
 			var platformWindow = window.MauiContext.GetPlatformWindow();
 
-			var toRemove = Subscriptions.Where(s => s.Window == platformWindow).ToList();
+			var toRemove = Subscriptions.Where(s => s.PlatformView == platformWindow).ToList();
 
 			foreach (AlertRequestHelper alertRequestHelper in toRemove)
 			{
@@ -40,29 +40,30 @@ namespace Microsoft.Maui.Controls.Platform
 			static Task<bool>? CurrentAlert;
 			static Task<string?>? CurrentPrompt;
 
-			internal AlertRequestHelper(UI.Xaml.Window window, IMauiContext mauiContext)
+			internal AlertRequestHelper(Window virtualView, UI.Xaml.Window platformView)
 			{
-				Window = window;
-				MauiContext = mauiContext;
+				VirtualView = virtualView;
+				PlatformView = platformView;
 
 #pragma warning disable CS0618 // TODO: Remove when we internalize/replace MessagingCenter
-				MessagingCenter.Subscribe<Page, bool>(Window, Page.BusySetSignalName, OnPageBusy);
-				MessagingCenter.Subscribe<Page, AlertArguments>(Window, Page.AlertSignalName, OnAlertRequested);
-				MessagingCenter.Subscribe<Page, PromptArguments>(Window, Page.PromptSignalName, OnPromptRequested);
-				MessagingCenter.Subscribe<Page, ActionSheetArguments>(Window, Page.ActionSheetSignalName, OnActionSheetRequested);
+				MessagingCenter.Subscribe<Page, bool>(PlatformView, Page.BusySetSignalName, OnPageBusy);
+				MessagingCenter.Subscribe<Page, AlertArguments>(PlatformView, Page.AlertSignalName, OnAlertRequested);
+				MessagingCenter.Subscribe<Page, PromptArguments>(PlatformView, Page.PromptSignalName, OnPromptRequested);
+				MessagingCenter.Subscribe<Page, ActionSheetArguments>(PlatformView, Page.ActionSheetSignalName, OnActionSheetRequested);
 #pragma warning restore CS0618 // Type or member is obsolete
 			}
 
-			public UI.Xaml.Window Window { get; }
-			public IMauiContext MauiContext { get; }
+			public Window VirtualView { get; }
+
+			public UI.Xaml.Window PlatformView { get; }
 
 			public void Dispose()
 			{
 #pragma warning disable CS0618 // TODO: Remove when we internalize/replace MessagingCenter
-				MessagingCenter.Unsubscribe<Page, bool>(Window, Page.BusySetSignalName);
-				MessagingCenter.Unsubscribe<Page, AlertArguments>(Window, Page.AlertSignalName);
-				MessagingCenter.Unsubscribe<Page, PromptArguments>(Window, Page.PromptSignalName);
-				MessagingCenter.Unsubscribe<Page, ActionSheetArguments>(Window, Page.ActionSheetSignalName);
+				MessagingCenter.Unsubscribe<Page, bool>(PlatformView, Page.BusySetSignalName);
+				MessagingCenter.Unsubscribe<Page, AlertArguments>(PlatformView, Page.AlertSignalName);
+				MessagingCenter.Unsubscribe<Page, PromptArguments>(PlatformView, Page.PromptSignalName);
+				MessagingCenter.Unsubscribe<Page, ActionSheetArguments>(PlatformView, Page.ActionSheetSignalName);
 #pragma warning restore CS0618 // Type or member is obsolete
 			}
 
@@ -112,7 +113,7 @@ namespace Microsoft.Maui.Controls.Platform
 					alertDialog.PrimaryButtonText = arguments.Accept;
 
 				// This is a temporary workaround
-				alertDialog.XamlRoot = Window.Content.XamlRoot;
+				alertDialog.XamlRoot = PlatformView.Content.XamlRoot;
 
 				var currentAlert = CurrentAlert;
 
@@ -157,7 +158,7 @@ namespace Microsoft.Maui.Controls.Platform
 				}
 
 				// This is a temporary workaround
-				promptDialog.XamlRoot = Window.Content.XamlRoot;
+				promptDialog.XamlRoot = PlatformView.Content.XamlRoot;
 
 				CurrentPrompt = ShowPrompt(promptDialog);
 				arguments.SetResult(await CurrentPrompt.ConfigureAwait(false));
@@ -205,7 +206,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 				try
 				{
-					var current = sender.ToPlatform(MauiContext);
+					var current = sender.ToPlatform(VirtualView.RequireMauiContext());
 					var pageParent = current?.Parent as FrameworkElement;
 
 					if (pageParent != null)
@@ -244,16 +245,8 @@ namespace Microsoft.Maui.Controls.Platform
 				return null;
 			}
 
-			bool PageIsInThisWindow(Page page)
-			{
-				var window = page?.Window;
-				var platformWindow = window?.MauiContext.GetPlatformWindow();
-
-				if (window is null || platformWindow is null)
-					return false;
-
-				return platformWindow == Window;
-			}
+			bool PageIsInThisWindow(Page page) =>
+				page?.Window == VirtualView;
 		}
 	}
 }

--- a/src/Controls/src/Core/Platform/AlertManager/AlertManager.Windows.cs
+++ b/src/Controls/src/Core/Platform/AlertManager/AlertManager.Windows.cs
@@ -37,8 +37,8 @@ namespace Microsoft.Maui.Controls.Platform
 
 		internal sealed class AlertRequestHelper : IDisposable
 		{
-			static Task<bool>? CurrentAlert;
-			static Task<string?>? CurrentPrompt;
+			Task<bool>? CurrentAlert;
+			Task<string?>? CurrentPrompt;
 
 			internal AlertRequestHelper(Window virtualView, UI.Xaml.Window platformView)
 			{

--- a/src/Controls/src/Core/Platform/AlertManager/AlertManager.iOS.cs
+++ b/src/Controls/src/Core/Platform/AlertManager/AlertManager.iOS.cs
@@ -82,16 +82,25 @@ namespace Microsoft.Maui.Controls.Platform
 
 			void OnAlertRequested(IView sender, AlertArguments arguments)
 			{
+				if (!PageIsInThisWindow(sender))
+					return;
+
 				PresentAlert(arguments);
 			}
 
 			void OnPromptRequested(IView sender, PromptArguments arguments)
 			{
+				if (!PageIsInThisWindow(sender))
+					return;
+
 				PresentPrompt(arguments);
 			}
 
 			void OnActionSheetRequested(IView sender, ActionSheetArguments arguments)
 			{
+				if (!PageIsInThisWindow(sender))
+					return;
+
 				PresentActionSheet(arguments);
 			}
 
@@ -205,6 +214,20 @@ namespace Microsoft.Maui.Controls.Platform
 				{
 					_ = platformView.RootViewController.PresentViewControllerAsync(alert, true);
 				});
+			}
+
+			bool PageIsInThisWindow(IView view)
+			{
+				if (view is not Page page)
+					return false;
+
+				var window = page.Window;
+				var platformWindow = window?.MauiContext.GetPlatformWindow();
+
+				if (window is null || platformWindow is null)
+					return false;
+
+				return platformWindow == PlatformView;
 			}
 		}
 	}

--- a/src/Controls/src/Core/Platform/AlertManager/AlertManager.iOS.cs
+++ b/src/Controls/src/Core/Platform/AlertManager/AlertManager.iOS.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Maui.Controls.Platform
 #pragma warning restore CS0618 // Type or member is obsolete
 			}
 
-			void OnPageBusy(IView sender, bool enabled)
+			void OnPageBusy(Page sender, bool enabled)
 			{
 				_busyCount = Math.Max(0, enabled ? _busyCount + 1 : _busyCount - 1);
 #pragma warning disable CA1416, CA1422 // TODO:  'UIApplication.NetworkActivityIndicatorVisible' is unsupported on: 'ios' 13.0 and later
@@ -80,7 +80,7 @@ namespace Microsoft.Maui.Controls.Platform
 #pragma warning restore CA1416, CA1422
 			}
 
-			void OnAlertRequested(IView sender, AlertArguments arguments)
+			void OnAlertRequested(Page sender, AlertArguments arguments)
 			{
 				if (!PageIsInThisWindow(sender))
 					return;
@@ -88,7 +88,7 @@ namespace Microsoft.Maui.Controls.Platform
 				PresentAlert(arguments);
 			}
 
-			void OnPromptRequested(IView sender, PromptArguments arguments)
+			void OnPromptRequested(Page sender, PromptArguments arguments)
 			{
 				if (!PageIsInThisWindow(sender))
 					return;
@@ -96,7 +96,7 @@ namespace Microsoft.Maui.Controls.Platform
 				PresentPrompt(arguments);
 			}
 
-			void OnActionSheetRequested(IView sender, ActionSheetArguments arguments)
+			void OnActionSheetRequested(Page sender, ActionSheetArguments arguments)
 			{
 				if (!PageIsInThisWindow(sender))
 					return;
@@ -198,7 +198,7 @@ namespace Microsoft.Maui.Controls.Platform
 				if (modalStack != null && modalStack.Count > 0)
 				{
 					var topPage = modalStack[modalStack.Count - 1];
-					var pageController = topPage.ToUIViewController(topPage.FindMauiContext());
+					var pageController = topPage.ToUIViewController(topPage.RequireMauiContext());
 
 					if (pageController != null)
 					{
@@ -216,19 +216,8 @@ namespace Microsoft.Maui.Controls.Platform
 				});
 			}
 
-			bool PageIsInThisWindow(IView view)
-			{
-				if (view is not Page page)
-					return false;
-
-				var window = page.Window;
-				var platformWindow = window?.MauiContext.GetPlatformWindow();
-
-				if (window is null || platformWindow is null)
-					return false;
-
-				return platformWindow == PlatformView;
-			}
+			bool PageIsInThisWindow(Page page) =>
+				page?.Window == VirtualView;
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change

Display alert by Window on macOS.

![fix-14343](https://user-images.githubusercontent.com/6755973/229489249-3b8de3ab-3b30-4f4d-8d67-823d2c6754f3.gif)

This fix is similar to https://github.com/dotnet/maui/pull/14229

To test the changes, launch the .NET MAUI Gallery and navigate to Core > MultiWindow. Open a secondary Window and then, tap the button to display an alert. The alert only must appear in the parent Window.

### Issues Fixed

Fixes #14343 
