### PR TITLE
Fix incorrect caching of unconstrained measures

### DIFF
--- a/src/Core/src/Platform/iOS/ContentView.cs
+++ b/src/Core/src/Platform/iOS/ContentView.cs
@@ -11,8 +11,7 @@ namespace Microsoft.Maui.Platform
 		WeakReference<IBorderStroke>? _clip;
 		CAShapeLayer? _childMaskLayer;
 		internal event EventHandler? LayoutSubviewsChanged;
-		bool _measureValid;
-
+	
 		public ContentView()
 		{
 			Layer.CornerCurve = CACornerCurve.Continuous;
@@ -25,11 +24,12 @@ namespace Microsoft.Maui.Platform
 				return base.SizeThatFits(size);
 			}
 
-			var width = size.Width;
-			var height = size.Height;
+			var widthConstraint = size.Width;
+			var heightConstraint = size.Height;
 
-			var crossPlatformSize = CrossPlatformMeasure(width, height);
-			_measureValid = true;
+			var crossPlatformSize = CrossPlatformMeasure(widthConstraint, heightConstraint);
+
+			CacheMeasureConstraints(widthConstraint, heightConstraint);
 
 			return crossPlatformSize.ToCGSize();
 		}
@@ -39,11 +39,13 @@ namespace Microsoft.Maui.Platform
 			base.LayoutSubviews();
 
 			var bounds = AdjustForSafeArea(Bounds).ToRectangle();
+			var widthConstraint = bounds.Width;
+			var heightConstraint = bounds.Height;
 
-			if (!_measureValid)
+			if (!IsMeasureValid(widthConstraint, heightConstraint))
 			{
-				CrossPlatformMeasure?.Invoke(bounds.Width, bounds.Height);
-				_measureValid = true;
+				CrossPlatformMeasure?.Invoke(widthConstraint, heightConstraint);
+				CacheMeasureConstraints(widthConstraint, heightConstraint);
 			}
 
 			CrossPlatformArrange?.Invoke(bounds);
@@ -58,7 +60,7 @@ namespace Microsoft.Maui.Platform
 
 		public override void SetNeedsLayout()
 		{
-			_measureValid = false;
+			InvalidateConstraintsCache();
 			base.SetNeedsLayout();
 			Superview?.SetNeedsLayout();
 		}

--- a/src/Core/src/Platform/iOS/ContentView.cs
+++ b/src/Core/src/Platform/iOS/ContentView.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Maui.Platform
 		WeakReference<IBorderStroke>? _clip;
 		CAShapeLayer? _childMaskLayer;
 		internal event EventHandler? LayoutSubviewsChanged;
-	
+
 		public ContentView()
 		{
 			Layer.CornerCurve = CACornerCurve.Continuous;

--- a/src/Core/src/Platform/iOS/LayoutView.cs
+++ b/src/Core/src/Platform/iOS/LayoutView.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Maui.Platform
 	public class LayoutView : MauiView
 	{
 		bool _userInteractionEnabled;
-		
+
 
 		// TODO: Possibly reconcile this code with ViewHandlerExtensions.MeasureVirtualView
 		// If you make changes here please review if those changes should also
@@ -23,7 +23,7 @@ namespace Microsoft.Maui.Platform
 
 			var width = size.Width;
 			var height = size.Height;
-			
+
 			var crossPlatformSize = layout.CrossPlatformMeasure(width, height);
 
 			CacheMeasureConstraints(width, height);

--- a/src/Core/src/Platform/iOS/LayoutView.cs
+++ b/src/Core/src/Platform/iOS/LayoutView.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Maui.Platform
 	public class LayoutView : MauiView
 	{
 		bool _userInteractionEnabled;
-		bool _measureValid;
+		
 
 		// TODO: Possibly reconcile this code with ViewHandlerExtensions.MeasureVirtualView
 		// If you make changes here please review if those changes should also
@@ -23,9 +23,10 @@ namespace Microsoft.Maui.Platform
 
 			var width = size.Width;
 			var height = size.Height;
-
+			
 			var crossPlatformSize = layout.CrossPlatformMeasure(width, height);
-			_measureValid = true;
+
+			CacheMeasureConstraints(width, height);
 
 			return crossPlatformSize.ToCGSize();
 		}
@@ -44,10 +45,13 @@ namespace Microsoft.Maui.Platform
 
 			var bounds = AdjustForSafeArea(Bounds).ToRectangle();
 
-			if (!_measureValid)
+			var widthConstraint = bounds.Width;
+			var heightConstraint = bounds.Height;
+
+			if (!IsMeasureValid(widthConstraint, heightConstraint))
 			{
-				layout.CrossPlatformMeasure(bounds.Width, bounds.Height);
-				_measureValid = true;
+				layout.CrossPlatformMeasure(widthConstraint, heightConstraint);
+				CacheMeasureConstraints(widthConstraint, heightConstraint);
 			}
 
 			layout.CrossPlatformArrange(bounds);
@@ -55,21 +59,21 @@ namespace Microsoft.Maui.Platform
 
 		public override void SetNeedsLayout()
 		{
-			_measureValid = false;
+			InvalidateConstraintsCache();
 			base.SetNeedsLayout();
 			Superview?.SetNeedsLayout();
 		}
 
 		public override void SubviewAdded(UIView uiview)
 		{
-			_measureValid = false;
+			InvalidateConstraintsCache();
 			base.SubviewAdded(uiview);
 			Superview?.SetNeedsLayout();
 		}
 
 		public override void WillRemoveSubview(UIView uiview)
 		{
-			_measureValid = false;
+			InvalidateConstraintsCache();
 			base.WillRemoveSubview(uiview);
 			Superview?.SetNeedsLayout();
 		}

--- a/src/Core/src/Platform/iOS/MauiView.cs
+++ b/src/Core/src/Platform/iOS/MauiView.cs
@@ -9,6 +9,9 @@ namespace Microsoft.Maui.Platform
 	{
 		static bool? _respondsToSafeArea;
 
+		double _lastMeasureHeight = double.NaN;
+		double _lastMeasureWidth = double.NaN;
+
 		WeakReference<IView>? _reference;
 
 		public IView? View
@@ -34,6 +37,25 @@ namespace Microsoft.Maui.Platform
 #pragma warning disable CA1416 // TODO 'UIView.SafeAreaInsets' is only supported on: 'ios' 11.0 and later, 'maccatalyst' 11.0 and later, 'tvos' 11.0 and later.
 			return SafeAreaInsets.InsetRect(bounds);
 #pragma warning restore CA1416
+		}
+
+		protected bool IsMeasureValid(double widthConstraint, double heightConstraint)
+		{
+			// Check the last constraints this View was measured with; if they're the same,
+			// then the current measure info is already correct and we don't need to repeat it
+			return heightConstraint == _lastMeasureHeight && widthConstraint == _lastMeasureWidth;
+		}
+
+		protected void InvalidateConstraintsCache()
+		{
+			_lastMeasureWidth = double.NaN;
+			_lastMeasureHeight = double.NaN;
+		}
+
+		protected void CacheMeasureConstraints(double widthConstraint, double heightConstraint)
+		{
+			_lastMeasureWidth = widthConstraint;
+			_lastMeasureHeight = heightConstraint;
 		}
 	}
 }

--- a/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -50,3 +50,6 @@ Microsoft.Maui.WeakEventManager.HandleEvent(object? sender, object? args, string
 static Microsoft.Maui.SizeRequest.operator !=(Microsoft.Maui.SizeRequest left, Microsoft.Maui.SizeRequest right) -> bool
 static Microsoft.Maui.SizeRequest.operator ==(Microsoft.Maui.SizeRequest left, Microsoft.Maui.SizeRequest right) -> bool
 virtual Microsoft.Maui.MauiUIApplicationDelegate.PerformFetch(UIKit.UIApplication! application, System.Action<UIKit.UIBackgroundFetchResult>! completionHandler) -> void
+Microsoft.Maui.Platform.MauiView.CacheMeasureConstraints(double widthConstraint, double heightConstraint) -> void
+Microsoft.Maui.Platform.MauiView.InvalidateConstraintsCache() -> void
+Microsoft.Maui.Platform.MauiView.IsMeasureValid(double widthConstraint, double heightConstraint) -> bool

--- a/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -5,6 +5,9 @@ Microsoft.Maui.Handlers.SwipeItemButton.SwipeItemButton() -> void
 Microsoft.Maui.IApplication.UserAppTheme.get -> Microsoft.Maui.ApplicationModel.AppTheme
 Microsoft.Maui.Hosting.MauiApp.DisposeAsync() -> System.Threading.Tasks.ValueTask
 Microsoft.Maui.Layouts.FlexBasis.Equals(Microsoft.Maui.Layouts.FlexBasis other) -> bool
+Microsoft.Maui.Platform.MauiView.CacheMeasureConstraints(double widthConstraint, double heightConstraint) -> void
+Microsoft.Maui.Platform.MauiView.InvalidateConstraintsCache() -> void
+Microsoft.Maui.Platform.MauiView.IsMeasureValid(double widthConstraint, double heightConstraint) -> bool
 Microsoft.Maui.SizeRequest.Equals(Microsoft.Maui.SizeRequest other) -> bool
 Microsoft.Maui.Platform.MauiScrollView
 Microsoft.Maui.Platform.MauiScrollView.MauiScrollView() -> void


### PR DESCRIPTION
### Description of Change

The code to avoid re-measurement in the Layout and ContentView backing controls on iOS was treating re-measures with unconstrained height/width as being duplicate measures and not bothering to re-measure them. However, this is incompatible with the way ScollViews on iOS treat their content. This caused some combinations of layouts (mostly ScrollView at the root, with a Grid as the Content, though there may be others) to behave weirdly during resize operations (mostly visible on macOS/Catalyst when resizing the window). 

This change treats re-measures at unconstrained height/width as being unequal to the previous measure, allowing the view to be measured again. It also consolidates the measure caching code from ContentView and LayoutView to reduce duplication.

This may technically re-introduce _some_ unconstrained measurement calls which were avoided by #12627; we'll need to investigate further to see if some of those can be avoided in the future without breaking resizing situations.

### Issues Fixed

Weird macOS resizing issues when hosting Grids inside of ScrollViews rooted at the Page level.
