### PR TITLE
Try to make keyboard tests more reliable

### DIFF
--- a/src/TestUtils/src/DeviceTests/AssertionExtensions.Android.cs
+++ b/src/TestUtils/src/DeviceTests/AssertionExtensions.Android.cs
@@ -155,9 +155,7 @@ namespace Microsoft.Maui.DeviceTests
 			try
 			{
 				await view.FocusView(timeout);
-				if (!KeyboardManager.ShowKeyboard(view))
-					throw new Exception("ShowKeyboard operation failed");
-
+				KeyboardManager.ShowKeyboard(view);
 				await view.WaitForKeyboardToShow(timeout);
 			}
 			catch (Exception ex)
@@ -176,10 +174,20 @@ namespace Microsoft.Maui.DeviceTests
 
 			try
 			{
-				if (!KeyboardManager.HideKeyboard(view))
-					throw new Exception("HideKeyboard operation failed");
-
-				await view.WaitForKeyboardToHide(timeout);
+				int retry = 2;
+				for (int i = 0; i < retry; i++)
+				{
+					KeyboardManager.HideKeyboard(view);
+					try
+					{
+						await view.WaitForKeyboardToHide(timeout);
+					}
+					catch
+					{
+						if (i >= retry)
+							throw;
+					}
+				}
 			}
 			catch (Exception ex)
 			{
@@ -213,7 +221,7 @@ namespace Microsoft.Maui.DeviceTests
 		public static async Task WaitForKeyboardToHide(this AView view, int timeout = 1000)
 		{
 			var result = await Wait(() => !KeyboardManager.IsSoftKeyboardVisible(view), timeout);
-			Assert.True(result);
+			Assert.True(result, "Keyboard failed to hide");
 
 			// Even if the OS is reporting that the keyboard has closed it seems like the animation hasn't quite finished
 			// If you try to call hide too quickly after showing, sometimes it will just hide and then pop back up.

--- a/src/TestUtils/src/DeviceTests/AssertionExtensions.Windows.cs
+++ b/src/TestUtils/src/DeviceTests/AssertionExtensions.Windows.cs
@@ -279,7 +279,7 @@ namespace Microsoft.Maui.DeviceTests
 			=> bitmap.AssertColorAtPoint(expectedColor, bitmap.SizeInPixels.Width - 1, bitmap.SizeInPixels.Height - 1);
 
 		public static Task<CanvasBitmap> AssertContainsColor(this CanvasBitmap bitmap, Graphics.Color expectedColor, Func<Graphics.RectF, Graphics.RectF>? withinRectModifier = null)
-			=> bitmap.AssertContainsColor(expectedColor.ToWindowsColor());
+			=> bitmap.AssertContainsColor(expectedColor.ToWindowsColor(), withinRectModifier);
 
 		public static async Task<CanvasBitmap> AssertContainsColor(this CanvasBitmap bitmap, WColor expectedColor, Func<Graphics.RectF, Graphics.RectF>? withinRectModifier = null)
 		{


### PR DESCRIPTION
### Description of Change

- add a retry to hiding the keyboard
- don't throw an exception if the hide/show methods return "false" just move on and see if the keyboard has been hidden/shown.
- fix overload on AssertContainsColor that wasn't passing `withinRectModifier`
