### PR TITLE
[Windows] Fix CollectionView.RemainingItemsThresholdReached

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/ItemsViewHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Items/ItemsViewHandler.Windows.cs
@@ -424,8 +424,9 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 			Element.SendScrolled(itemsViewScrolledEventArgs);
 
-			if (Element.RemainingItemsThreshold > -1 &&
-				ItemCount - 1 - itemsViewScrolledEventArgs.LastVisibleItemIndex <= Element.RemainingItemsThreshold)
+			var remainingItemsThreshold = Element.RemainingItemsThreshold;
+			if (remainingItemsThreshold > -1 &&
+				ItemCount - 1 - itemsViewScrolledEventArgs.LastVisibleItemIndex <= remainingItemsThreshold)
 			{
 				Element.SendRemainingItemsThresholdReached();
 			}

--- a/src/Controls/src/Core/Handlers/Items/ItemsViewHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Items/ItemsViewHandler.Windows.cs
@@ -423,6 +423,20 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			itemsViewScrolledEventArgs = ComputeVisibleIndexes(itemsViewScrolledEventArgs, layoutOrientaton, advancing);
 
 			Element.SendScrolled(itemsViewScrolledEventArgs);
+
+			switch (Element.RemainingItemsThreshold)
+			{
+				case -1:
+					return;
+				case 0:
+					if (itemsViewScrolledEventArgs.LastVisibleItemIndex == ItemCount - 1)
+						Element.SendRemainingItemsThresholdReached();
+					break;
+				default:
+					if (ItemCount - 1 - itemsViewScrolledEventArgs.LastVisibleItemIndex <= Element.RemainingItemsThreshold)
+						Element.SendRemainingItemsThresholdReached();
+					break;
+			}
 		}
 
 		protected virtual ItemsViewScrolledEventArgs ComputeVisibleIndexes(ItemsViewScrolledEventArgs args, ItemsLayoutOrientation orientation, bool advancing)

--- a/src/Controls/src/Core/Handlers/Items/ItemsViewHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Items/ItemsViewHandler.Windows.cs
@@ -424,18 +424,10 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 			Element.SendScrolled(itemsViewScrolledEventArgs);
 
-			switch (Element.RemainingItemsThreshold)
+			if (Element.RemainingItemsThreshold > -1 &&
+				ItemCount - 1 - itemsViewScrolledEventArgs.LastVisibleItemIndex <= Element.RemainingItemsThreshold)
 			{
-				case -1:
-					return;
-				case 0:
-					if (itemsViewScrolledEventArgs.LastVisibleItemIndex == ItemCount - 1)
-						Element.SendRemainingItemsThresholdReached();
-					break;
-				default:
-					if (ItemCount - 1 - itemsViewScrolledEventArgs.LastVisibleItemIndex <= Element.RemainingItemsThreshold)
-						Element.SendRemainingItemsThresholdReached();
-					break;
+				Element.SendRemainingItemsThresholdReached();
 			}
 		}
 

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.Windows.cs
@@ -100,5 +100,42 @@ namespace Microsoft.Maui.DeviceTests
 
 			Assert.Equal(0d, minHeight);
 		}
+
+		[Fact]
+		public async Task ValidateSendRemainingItemsThresholdReached()
+		{
+			SetupBuilder();
+			ObservableCollection<string> data = new();
+			for (int i = 0; i < 20; i++)
+			{
+				data.Add($"Item {i + 1}");
+			}
+
+			CollectionView collectionView = new();
+			collectionView.ItemsSource = data;
+			collectionView.HeightRequest = 200;
+
+			var layout = new VerticalStackLayout()
+			{
+				collectionView
+			};
+
+			collectionView.RemainingItemsThreshold = 1;
+			collectionView.RemainingItemsThresholdReached += (s, e) =>
+			{
+				for (int i = 20; i < 30; i++)
+				{
+					data.Add($"Item {i + 1}");
+				}
+			};
+
+			await CreateHandlerAndAddToWindow<LayoutHandler>(layout, async (handler) =>
+			{
+				await Task.Delay(200);
+				collectionView.ScrollTo(19, -1, position: ScrollToPosition.End, false);
+				await Task.Delay(200);
+				Assert.True(data.Count == 30);
+			});
+		}
 	}
 }


### PR DESCRIPTION
### Description of Change

* Fixed an issue where the `CollectionView.RemainingItemsThresholdReached` event wasn't firing on Windows. This issue was caused by missing code in `ItemsViewHandler.Windows` to fire the event.

### Issues Fixed

Fixes #8338
Fixes #9935 (dupe)
Fixes #12066 (dupe) 