### PR TITLE
Propagate title property to catalyst window

### DIFF
--- a/src/Core/src/Handlers/Window/WindowHandler.iOS.cs
+++ b/src/Core/src/Handlers/Window/WindowHandler.iOS.cs
@@ -13,7 +13,13 @@ namespace Microsoft.Maui.Handlers
 			UpdateVirtualViewFrame(platformView);
 		}
 
-		public static void MapTitle(IWindowHandler handler, IWindow window) { }
+		public static void MapTitle(IWindowHandler handler, IWindow window)
+		{
+#if MACCATALYST
+			if (handler.PlatformView.WindowScene is not null)
+				handler.PlatformView.WindowScene.Title = window.Title ?? String.Empty;
+#endif
+		}
 
 		public static void MapContent(IWindowHandler handler, IWindow window)
 		{

--- a/src/Core/tests/DeviceTests/Handlers/Window/WindowHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Window/WindowHandlerTests.iOS.cs
@@ -10,6 +10,28 @@ namespace Microsoft.Maui.DeviceTests
 	public partial class WindowHandlerTests : CoreHandlerTestBase
 	{
 #if MACCATALYST
+
+		[Fact]
+		public async Task TitleSetsOnWindow()
+		{
+			var window = new Window
+			{
+				Title = "Initial Title",
+				Page = new ContentPage
+				{
+					Content = new Label { Text = "Yay!" }
+				}
+			};
+
+			await RunWindowTest(window, handler =>
+			{
+				Assert.Equal("Initial Title", handler.PlatformView.WindowScene.Title);
+				window.Title = "Updated Title";
+				Assert.Equal("Updated Title", handler.PlatformView.WindowScene.Title);
+			});
+		}
+
+
 		[Fact]
 		public async Task ContentIsSetInitially()
 		{


### PR DESCRIPTION
### Description of Change

We never wired up the `Title` property on `Window` to the `Mapper` on `Catalyst`

### Issues Fixed

Fixes #11263
Fixes #12287
