### PR TITLE
Hook up CarouselView Scrolled event on Windows

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/CarouselViewHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Items/CarouselViewHandler.Windows.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		protected override void ConnectHandler(ListViewBase platformView)
 		{
-			ItemsView.Scrolled -= CarouselScrolled;
+			ItemsView.Scrolled += CarouselScrolled;
 			ListViewBase.SizeChanged += InitialSetup;
 
 			UpdateScrollBarVisibilityForLoop();


### PR DESCRIPTION
### Description of Change

The event was unhooked instead of hooked while initializing

### Issues Fixed

Fixes #12725
