### PR TITLE
Propagate Title to android and ios window

### DIFF
--- a/src/Core/src/Handlers/Window/WindowHandler.Android.cs
+++ b/src/Core/src/Handlers/Window/WindowHandler.Android.cs
@@ -17,7 +17,8 @@ namespace Microsoft.Maui.Handlers
 			UpdateVirtualViewFrame(platformView);
 		}
 
-		public static void MapTitle(IWindowHandler handler, IWindow window) { }
+		public static void MapTitle(IWindowHandler handler, IWindow window) =>
+			handler.PlatformView.UpdateTitle(window);
 
 		public static void MapContent(IWindowHandler handler, IWindow window)
 		{

--- a/src/Core/src/Handlers/Window/WindowHandler.iOS.cs
+++ b/src/Core/src/Handlers/Window/WindowHandler.iOS.cs
@@ -12,14 +12,8 @@ namespace Microsoft.Maui.Handlers
 
 			UpdateVirtualViewFrame(platformView);
 		}
-
-		public static void MapTitle(IWindowHandler handler, IWindow window)
-		{
-#if MACCATALYST
-			if (handler.PlatformView.WindowScene is not null)
-				handler.PlatformView.WindowScene.Title = window.Title ?? String.Empty;
-#endif
-		}
+		public static void MapTitle(IWindowHandler handler, IWindow window) =>
+			handler.PlatformView.UpdateTitle(window);
 
 		public static void MapContent(IWindowHandler handler, IWindow window)
 		{

--- a/src/Core/src/Platform/Android/WindowExtensions.cs
+++ b/src/Core/src/Platform/Android/WindowExtensions.cs
@@ -9,6 +9,14 @@ namespace Microsoft.Maui
 {
 	public static partial class WindowExtensions
 	{
+		internal static void UpdateTitle(this Activity platformWindow, IWindow window)
+		{
+			if (string.IsNullOrEmpty(window.Title))
+				platformWindow.Title = ApplicationModel.AppInfo.Current.Name;
+			else
+				platformWindow.Title = window.Title;
+		}
+
 		internal static DisplayOrientation GetOrientation(this IWindow? window)
 		{
 			if (window == null)

--- a/src/Core/src/Platform/iOS/WindowExtensions.cs
+++ b/src/Core/src/Platform/iOS/WindowExtensions.cs
@@ -9,6 +9,15 @@ namespace Microsoft.Maui.Platform
 {
 	public static partial class WindowExtensions
 	{
+		internal static void UpdateTitle(this UIWindow platformWindow, IWindow window)
+		{
+			// If you set the title to null the app will crash
+			// If you set it to an empty string the title reverts back to the 
+			// default app title.
+			if (OperatingSystem.IsIOSVersionAtLeast(13) && platformWindow.WindowScene is not null)
+				platformWindow.WindowScene.Title = window.Title ?? String.Empty;
+		}
+
 		internal static void UpdateX(this UIWindow platformWindow, IWindow window) =>
 			platformWindow.UpdateUnsupportedCoordinate(window);
 

--- a/src/Core/tests/DeviceTests/Handlers/Window/WindowHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Window/WindowHandlerTests.Android.cs
@@ -1,0 +1,28 @@
+﻿using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Devices;
+using Microsoft.Maui.Graphics;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	public partial class WindowHandlerTests : CoreHandlerTestBase
+	{
+		[Fact]
+		public async Task TitleSetsOnWindow()
+		{
+			await InvokeOnMainThreadAsync(() =>
+			{
+				var activity = MauiContext.Context.GetActivity();
+				Assert.NotNull(activity);
+				var testWindow = activity.GetWindow() as Window;
+				Assert.NotNull(testWindow);
+
+				testWindow.Title = "Test Title";
+				Assert.Equal("Test Title", activity.Title);
+				testWindow.Title = null;
+				Assert.Equal(activity.Title, ApplicationModel.AppInfo.Current.Name);
+			});
+		}
+	}
+}

--- a/src/Core/tests/DeviceTests/Handlers/Window/WindowHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Window/WindowHandlerTests.Android.cs
@@ -3,6 +3,7 @@ using Microsoft.Maui.Controls;
 using Microsoft.Maui.Devices;
 using Microsoft.Maui.Graphics;
 using Xunit;
+using AActivity = Android.App.Activity;
 
 namespace Microsoft.Maui.DeviceTests
 {
@@ -13,10 +14,10 @@ namespace Microsoft.Maui.DeviceTests
 		{
 			await InvokeOnMainThreadAsync(() =>
 			{
-				var activity = MauiContext.Context.GetActivity();
-				Assert.NotNull(activity);
-				var testWindow = activity.GetWindow() as Window;
-				Assert.NotNull(testWindow);
+				var testWindow = Application.Current.Windows[0];
+				var activity = testWindow.Handler.PlatformView as AActivity;
+				Assert.True(activity is not null, "Activity is Null");
+				Assert.True(testWindow is not null, "Window is Null");
 
 				testWindow.Title = "Test Title";
 				Assert.Equal("Test Title", activity.Title);

--- a/src/Core/tests/DeviceTests/Handlers/Window/WindowHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Window/WindowHandlerTests.Android.cs
@@ -1,9 +1,7 @@
 ﻿using System.Threading.Tasks;
+using AndroidX.AppCompat.App;
 using Microsoft.Maui.Controls;
-using Microsoft.Maui.Devices;
-using Microsoft.Maui.Graphics;
 using Xunit;
-using AActivity = Android.App.Activity;
 
 namespace Microsoft.Maui.DeviceTests
 {
@@ -14,14 +12,18 @@ namespace Microsoft.Maui.DeviceTests
 		{
 			await InvokeOnMainThreadAsync(() =>
 			{
-				var testWindow = Application.Current.Windows[0];
-				var activity = testWindow.Handler.PlatformView as AActivity;
+				var activity = (AppCompatActivity)MauiProgramDefaults.DefaultContext;
+				var testWindow = new Window();
+
 				Assert.True(activity is not null, "Activity is Null");
-				Assert.True(testWindow is not null, "Window is Null");
 
 				testWindow.Title = "Test Title";
+				WindowExtensions.UpdateTitle(activity, testWindow);
+
 				Assert.Equal("Test Title", activity.Title);
 				testWindow.Title = null;
+
+				WindowExtensions.UpdateTitle(activity, testWindow);
 				Assert.Equal(activity.Title, ApplicationModel.AppInfo.Current.Name);
 			});
 		}


### PR DESCRIPTION
### Description of Change

Apply the window title to the Android Activity and iOS titles.

This is a continuation of https://github.com/dotnet/maui/pull/14399. 
