### PR TITLE
[CI] Prepare the maui-template to work out of the repo pipeline.

### DIFF
--- a/eng/pipelines/common/maui-templates.yml
+++ b/eng/pipelines/common/maui-templates.yml
@@ -16,7 +16,7 @@ parameters:
 
   - name: checkoutDirectory
     type: string
-    value: $(System.DefaultWorkingDirectory)
+    default: $(System.DefaultWorkingDirectory)
 
   - name: BuildPlatforms
     type: object

--- a/eng/pipelines/common/maui-templates.yml
+++ b/eng/pipelines/common/maui-templates.yml
@@ -14,6 +14,10 @@ parameters:
     type: string
     default: ''
 
+  - name: checkoutDirectory
+    type: string
+    value: $(System.DefaultWorkingDirectory)
+
   - name: BuildPlatforms
     type: object
     default:
@@ -46,6 +50,10 @@ parameters:
       testName: RunOniOS
       artifact: templates-run-ios
 
+  - name: prepareSteps
+    type: stepList
+    default: []
+
 jobs:
 - ${{ each BuildPlatform in parameters.BuildPlatforms }}:
   - job: build_${{ BuildPlatform.name }}
@@ -63,9 +71,15 @@ jobs:
         - Agent.HasDevices -equals False
         - Agent.IsPaired -equals False
     steps:
+
+    - ${{ each step in parameters.prepareSteps }}:
+      - ${{ each pair in step }}:
+          ${{ pair.key }}: ${{ pair.value }}
+
     - template: provision.yml
       parameters:
         platform: ${{ BuildPlatform.name }}
+        checkoutDirectory: ${{ parameters.checkoutDirectory }}
 
     - task: DownloadBuildArtifacts@0
       displayName: 'Download Packages'
@@ -115,10 +129,16 @@ jobs:
     condition: ${{ parameters.condition}}
     pool: ${{ RunPlatform }}
     steps:
+
+    - ${{ each step in parameters.prepareSteps }}:
+      - ${{ each pair in step }}:
+          ${{ pair.key }}: ${{ pair.value }}
+
     - template: provision.yml
       parameters:
         platform: macos
         skipXcode: ${{ eq(RunPlatform.testName, 'RunOnAndroid') }}
+        checkoutDirectory: ${{ parameters.checkoutDirectory }}
 
     - task: DownloadBuildArtifacts@0
       displayName: 'Download Packages'


### PR DESCRIPTION
Few things that needed to be added to run the tests in the megapipeline:

1. Allow provisionator to use a diff checkout directory (the megapipeline has several checkout repos).
2. Allow to add extra prepare steps that will be used to do a all the prapre steps needed to get the agent ready with the latests build.
