### PR TITLE
[net7.0] Microsoft.Windows.SDK.BuildTools can be transitive

### DIFF
--- a/eng/Microsoft.Extensions.targets
+++ b/eng/Microsoft.Extensions.targets
@@ -70,6 +70,10 @@
         NoWarn="NU1605"
     />
     <PackageReference
+        Update="Microsoft.Windows.SDK.BuildTools"
+        Version="$(MicrosoftWindowsSDKBuildToolsPackageVersion)"
+    />
+    <PackageReference
         Update="Microsoft.Graphics.Win2D"
         Version="$(MicrosoftGraphicsWin2DPackageVersion)"
     />

--- a/src/Core/src/Core.csproj
+++ b/src/Core/src/Core.csproj
@@ -20,6 +20,7 @@
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.Contains('-windows'))">
     <PackageReference Include="Microsoft.WindowsAppSDK" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" />
     <PackageReference Include="Microsoft.Graphics.Win2D" />
     <ProjectReference Include="..\..\Graphics\src\Graphics.Win2D\Graphics.Win2D.csproj" />
   </ItemGroup>

--- a/src/Essentials/src/Essentials.csproj
+++ b/src/Essentials/src/Essentials.csproj
@@ -33,6 +33,7 @@
     <Compile Include="**\*.uwp.cs" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
     <Compile Include="**\*.uwp.*.cs" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
     <PackageReference Include="Microsoft.WindowsAppSDK" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetPlatformIdentifier)' == 'android' ">
     <Compile Include="**\*.android.cs" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />

--- a/src/Graphics/samples/GraphicsTester.WinUI.Desktop/GraphicsTester.WinUI.Desktop.csproj
+++ b/src/Graphics/samples/GraphicsTester.WinUI.Desktop/GraphicsTester.WinUI.Desktop.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.WindowsAppSdk" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" />
     <PackageReference Include="Microsoft.Graphics.Win2D" />
     <Manifest Include="$(ApplicationManifest)" />
   </ItemGroup>

--- a/src/Graphics/src/Graphics.Win2D/Graphics.Win2D.csproj
+++ b/src/Graphics/src/Graphics.Win2D/Graphics.Win2D.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.WindowsAppSDK" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" />
     <PackageReference Include="Microsoft.Graphics.Win2D" />
   </ItemGroup>
 

--- a/src/Workload/Microsoft.Maui.Sdk/Sdk/BundledVersions.in.targets
+++ b/src/Workload/Microsoft.Maui.Sdk/Sdk/BundledVersions.in.targets
@@ -134,7 +134,6 @@
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="@MicrosoftWindowsAppSDKPackageVersion@" IsImplicitlyDefined="true">
       <PrivateAssets Condition=" '$(OutputType)' == 'Library' ">all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="@MicrosoftWindowsSDKBuildToolsPackageVersion@" IsImplicitlyDefined="true" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
### Description of Change
The version of Microsoft.Windows.SDK.BuildTools updated in https://github.com/dotnet/maui/pull/14150 allows us to no longer have to directly import this package into all apps.

This will potentially make things even easier to - like https://github.com/dotnet/maui/pull/14331