### PR TITLE
Make Benchmarks.Droid runnable as APK for perf testing

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -19,6 +19,7 @@
     <add key="dotnet7" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json" />
     <add key="skiasharp" value="https://pkgs.dev.azure.com/xamarin/public/_packaging/SkiaSharp/nuget/v3/index.json" />
     <add key="wasdk-internal" value="https://pkgs.dev.azure.com/microsoft/ProjectReunion/_packaging/Project.Reunion.nuget.internal/nuget/v3/index.json" />
+    <add key="benchmark-dotnet-prerelease" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/benchmark-dotnet-prerelease/nuget/v3/index.json" />
     <!-- Added manually for dotnet/runtime 6.0.11 -->
     <add key="darc-pub-dotnet-emsdk-c3fc739" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-emsdk-c3fc739c/nuget/v3/index.json" />
     <add key="darc-pub-dotnet-runtime-1e1f688" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-1e1f688d/nuget/v3/index.json" />

--- a/src/Core/tests/Benchmarks.Droid/Benchmarks.Droid.csproj
+++ b/src/Core/tests/Benchmarks.Droid/Benchmarks.Droid.csproj
@@ -13,8 +13,7 @@
     <RunAOTCompilation>false</RunAOTCompilation>
     <!-- Physical device is recommended -->
     <RuntimeIdentifier>android-arm64</RuntimeIdentifier>
-    <!-- HACK: to workaround System.IO.FileNotFoundException: /System.Private.CoreLib.dll -->
-    <EmbedAssembliesIntoApk>false</EmbedAssembliesIntoApk>
+    <DisableTransitiveFrameworkReferenceDownloads>False</DisableTransitiveFrameworkReferenceDownloads>
     <AndroidPackageFormat>apk</AndroidPackageFormat>
   </PropertyGroup>
   <ItemGroup>
@@ -28,7 +27,7 @@
     <Using Include="BenchmarkDotNet.Loggers" />
     <Using Include="BenchmarkDotNet.Order" />
     <Using Include="BenchmarkDotNet.Running" />
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.3" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.5" />
     <PackageReference Include="Xamarin.Android.Glide" Version="4.14.2.1" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Core/tests/Benchmarks.Droid/Benchmarks.Droid.csproj
+++ b/src/Core/tests/Benchmarks.Droid/Benchmarks.Droid.csproj
@@ -27,7 +27,7 @@
     <Using Include="BenchmarkDotNet.Loggers" />
     <Using Include="BenchmarkDotNet.Order" />
     <Using Include="BenchmarkDotNet.Running" />
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.5" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.5.2136" />
     <PackageReference Include="Xamarin.Android.Glide" Version="4.14.2.1" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Core/tests/Benchmarks.Droid/MainInstrumentation.cs
+++ b/src/Core/tests/Benchmarks.Droid/MainInstrumentation.cs
@@ -10,6 +10,8 @@ public class MainInstrumentation : Instrumentation
 
 	public static MainInstrumentation? Instance { get; private set; }
 
+	static string outputPath = "/storage/emulated/0/Android/data/com.microsoft.maui.benchmarks/files";
+
 	protected MainInstrumentation(IntPtr handle, JniHandleOwnership transfer)
 		: base(handle, transfer) { }
 
@@ -25,6 +27,21 @@ public class MainInstrumentation : Instrumentation
 	public async override void OnStart()
 	{
 		base.OnStart();
+		System.Environment.SetEnvironmentVariable("PERFLAB_INLAB", "1");
+		System.Environment.SetEnvironmentVariable("PERFLAB_BUILDTIMESTAMP", "0001-01-01T00:00:00.0000000Z");
+		System.Environment.SetEnvironmentVariable("PERFLAB_BUILDNUM", "REPLACE_BUILDNUM");
+		System.Environment.SetEnvironmentVariable("DOTNET_VERSION", "REPLACE_DOTNET_VERSION");
+		System.Environment.SetEnvironmentVariable("PERFLAB_HASH", "REPLACE_HASH");
+		System.Environment.SetEnvironmentVariable("HELIX_CORRELATION_ID", "REPLACE_HELIX_CORRELATION_ID");
+		System.Environment.SetEnvironmentVariable("PERFLAB_PERFHASH", "REPLACE_PERFLAB_PERFHASH");
+		System.Environment.SetEnvironmentVariable("PERFLAB_RUNNAME", "REPLACE_PERFLAB_RUNNAME");
+		System.Environment.SetEnvironmentVariable("HELIX_WORKITEM_FRIENDLYNAME", "REPLACE_HELIX_WORKITEM_FRIENDLYNAME");
+		System.Environment.SetEnvironmentVariable("PERFLAB_REPO", "REPLACE_PERFLAB_REPO");
+		System.Environment.SetEnvironmentVariable("PERFLAB_BRANCH", "REPLACE_PERFLAB_BRANCH");
+		System.Environment.SetEnvironmentVariable("PERFLAB_QUEUE", "REPLACE_PERFLAB_QUEUE");
+		System.Environment.SetEnvironmentVariable("PERFLAB_BUILDARCH", "REPLACE_PERFLAB_BUILDARCH");
+		System.Environment.SetEnvironmentVariable("PERFLAB_LOCALE", "REPLACE_PERFLAB_LOCALE");
+		Directory.CreateDirectory(outputPath);
 
 		var success = await Task.Factory.StartNew(Run);
 		Log.Debug(Tag, $"Benchmark complete, success: {success}");

--- a/src/Core/tests/Benchmarks.Droid/MainInstrumentation.cs
+++ b/src/Core/tests/Benchmarks.Droid/MainInstrumentation.cs
@@ -27,21 +27,23 @@ public class MainInstrumentation : Instrumentation
 	public async override void OnStart()
 	{
 		base.OnStart();
-		System.Environment.SetEnvironmentVariable("PERFLAB_INLAB", "1");
-		System.Environment.SetEnvironmentVariable("PERFLAB_BUILDTIMESTAMP", "0001-01-01T00:00:00.0000000Z");
-		System.Environment.SetEnvironmentVariable("PERFLAB_BUILDNUM", "REPLACE_BUILDNUM");
-		System.Environment.SetEnvironmentVariable("DOTNET_VERSION", "REPLACE_DOTNET_VERSION");
-		System.Environment.SetEnvironmentVariable("PERFLAB_HASH", "REPLACE_HASH");
-		System.Environment.SetEnvironmentVariable("HELIX_CORRELATION_ID", "REPLACE_HELIX_CORRELATION_ID");
-		System.Environment.SetEnvironmentVariable("PERFLAB_PERFHASH", "REPLACE_PERFLAB_PERFHASH");
-		System.Environment.SetEnvironmentVariable("PERFLAB_RUNNAME", "REPLACE_PERFLAB_RUNNAME");
-		System.Environment.SetEnvironmentVariable("HELIX_WORKITEM_FRIENDLYNAME", "REPLACE_HELIX_WORKITEM_FRIENDLYNAME");
-		System.Environment.SetEnvironmentVariable("PERFLAB_REPO", "REPLACE_PERFLAB_REPO");
-		System.Environment.SetEnvironmentVariable("PERFLAB_BRANCH", "REPLACE_PERFLAB_BRANCH");
-		System.Environment.SetEnvironmentVariable("PERFLAB_QUEUE", "REPLACE_PERFLAB_QUEUE");
-		System.Environment.SetEnvironmentVariable("PERFLAB_BUILDARCH", "REPLACE_PERFLAB_BUILDARCH");
-		System.Environment.SetEnvironmentVariable("PERFLAB_LOCALE", "REPLACE_PERFLAB_LOCALE");
-		Directory.CreateDirectory(outputPath);
+		#if PERFLAB_INLAB
+			Environment.SetEnvironmentVariable("PERFLAB_INLAB", "1");
+			Environment.SetEnvironmentVariable("PERFLAB_BUILDTIMESTAMP", "0001-01-01T00:00:00.0000000Z");
+			Environment.SetEnvironmentVariable("PERFLAB_BUILDNUM", "REPLACE_BUILDNUM");
+			Environment.SetEnvironmentVariable("DOTNET_VERSION", "REPLACE_DOTNET_VERSION");
+			Environment.SetEnvironmentVariable("PERFLAB_HASH", "REPLACE_HASH");
+			Environment.SetEnvironmentVariable("HELIX_CORRELATION_ID", "REPLACE_HELIX_CORRELATION_ID");
+			Environment.SetEnvironmentVariable("PERFLAB_PERFHASH", "REPLACE_PERFLAB_PERFHASH");
+			Environment.SetEnvironmentVariable("PERFLAB_RUNNAME", "REPLACE_PERFLAB_RUNNAME");
+			Environment.SetEnvironmentVariable("HELIX_WORKITEM_FRIENDLYNAME", "REPLACE_HELIX_WORKITEM_FRIENDLYNAME");
+			Environment.SetEnvironmentVariable("PERFLAB_REPO", "REPLACE_PERFLAB_REPO");
+			Environment.SetEnvironmentVariable("PERFLAB_BRANCH", "REPLACE_PERFLAB_BRANCH");
+			Environment.SetEnvironmentVariable("PERFLAB_QUEUE", "REPLACE_PERFLAB_QUEUE");
+			Environment.SetEnvironmentVariable("PERFLAB_BUILDARCH", "REPLACE_PERFLAB_BUILDARCH");
+			Environment.SetEnvironmentVariable("PERFLAB_LOCALE", "REPLACE_PERFLAB_LOCALE");
+			Directory.CreateDirectory(outputPath);
+		#endif
 
 		var success = await Task.Factory.StartNew(Run);
 		Log.Debug(Tag, $"Benchmark complete, success: {success}");

--- a/src/Core/tests/Benchmarks.Droid/MainInstrumentation.cs
+++ b/src/Core/tests/Benchmarks.Droid/MainInstrumentation.cs
@@ -10,8 +10,6 @@ public class MainInstrumentation : Instrumentation
 
 	public static MainInstrumentation? Instance { get; private set; }
 
-	static string outputPath = "/storage/emulated/0/Android/data/com.microsoft.maui.benchmarks/files";
-
 	protected MainInstrumentation(IntPtr handle, JniHandleOwnership transfer)
 		: base(handle, transfer) { }
 
@@ -42,7 +40,7 @@ public class MainInstrumentation : Instrumentation
 		Environment.SetEnvironmentVariable("PERFLAB_QUEUE", "REPLACE_PERFLAB_QUEUE");
 		Environment.SetEnvironmentVariable("PERFLAB_BUILDARCH", "REPLACE_PERFLAB_BUILDARCH");
 		Environment.SetEnvironmentVariable("PERFLAB_LOCALE", "REPLACE_PERFLAB_LOCALE");
-		Directory.CreateDirectory(outputPath);
+		Directory.CreateDirectory("/storage/emulated/0/Android/data/com.microsoft.maui.benchmarks/files");
 #endif
 
 		var success = await Task.Factory.StartNew(Run);

--- a/src/Core/tests/Benchmarks.Droid/MainInstrumentation.cs
+++ b/src/Core/tests/Benchmarks.Droid/MainInstrumentation.cs
@@ -27,7 +27,7 @@ public class MainInstrumentation : Instrumentation
 	public async override void OnStart()
 	{
 		base.OnStart();
-		#if PERFLAB_INLAB
+#if PERFLAB_INLAB
 			Environment.SetEnvironmentVariable("PERFLAB_INLAB", "1");
 			Environment.SetEnvironmentVariable("PERFLAB_BUILDTIMESTAMP", "0001-01-01T00:00:00.0000000Z");
 			Environment.SetEnvironmentVariable("PERFLAB_BUILDNUM", "REPLACE_BUILDNUM");
@@ -43,7 +43,7 @@ public class MainInstrumentation : Instrumentation
 			Environment.SetEnvironmentVariable("PERFLAB_BUILDARCH", "REPLACE_PERFLAB_BUILDARCH");
 			Environment.SetEnvironmentVariable("PERFLAB_LOCALE", "REPLACE_PERFLAB_LOCALE");
 			Directory.CreateDirectory(outputPath);
-		#endif
+#endif
 
 		var success = await Task.Factory.StartNew(Run);
 		Log.Debug(Tag, $"Benchmark complete, success: {success}");

--- a/src/Core/tests/Benchmarks.Droid/MainInstrumentation.cs
+++ b/src/Core/tests/Benchmarks.Droid/MainInstrumentation.cs
@@ -28,21 +28,21 @@ public class MainInstrumentation : Instrumentation
 	{
 		base.OnStart();
 #if PERFLAB_INLAB
-			Environment.SetEnvironmentVariable("PERFLAB_INLAB", "1");
-			Environment.SetEnvironmentVariable("PERFLAB_BUILDTIMESTAMP", "0001-01-01T00:00:00.0000000Z");
-			Environment.SetEnvironmentVariable("PERFLAB_BUILDNUM", "REPLACE_BUILDNUM");
-			Environment.SetEnvironmentVariable("DOTNET_VERSION", "REPLACE_DOTNET_VERSION");
-			Environment.SetEnvironmentVariable("PERFLAB_HASH", "REPLACE_HASH");
-			Environment.SetEnvironmentVariable("HELIX_CORRELATION_ID", "REPLACE_HELIX_CORRELATION_ID");
-			Environment.SetEnvironmentVariable("PERFLAB_PERFHASH", "REPLACE_PERFLAB_PERFHASH");
-			Environment.SetEnvironmentVariable("PERFLAB_RUNNAME", "REPLACE_PERFLAB_RUNNAME");
-			Environment.SetEnvironmentVariable("HELIX_WORKITEM_FRIENDLYNAME", "REPLACE_HELIX_WORKITEM_FRIENDLYNAME");
-			Environment.SetEnvironmentVariable("PERFLAB_REPO", "REPLACE_PERFLAB_REPO");
-			Environment.SetEnvironmentVariable("PERFLAB_BRANCH", "REPLACE_PERFLAB_BRANCH");
-			Environment.SetEnvironmentVariable("PERFLAB_QUEUE", "REPLACE_PERFLAB_QUEUE");
-			Environment.SetEnvironmentVariable("PERFLAB_BUILDARCH", "REPLACE_PERFLAB_BUILDARCH");
-			Environment.SetEnvironmentVariable("PERFLAB_LOCALE", "REPLACE_PERFLAB_LOCALE");
-			Directory.CreateDirectory(outputPath);
+		Environment.SetEnvironmentVariable("PERFLAB_INLAB", "1");
+		Environment.SetEnvironmentVariable("PERFLAB_BUILDTIMESTAMP", "0001-01-01T00:00:00.0000000Z");
+		Environment.SetEnvironmentVariable("PERFLAB_BUILDNUM", "REPLACE_BUILDNUM");
+		Environment.SetEnvironmentVariable("DOTNET_VERSION", "REPLACE_DOTNET_VERSION");
+		Environment.SetEnvironmentVariable("PERFLAB_HASH", "REPLACE_HASH");
+		Environment.SetEnvironmentVariable("HELIX_CORRELATION_ID", "REPLACE_HELIX_CORRELATION_ID");
+		Environment.SetEnvironmentVariable("PERFLAB_PERFHASH", "REPLACE_PERFLAB_PERFHASH");
+		Environment.SetEnvironmentVariable("PERFLAB_RUNNAME", "REPLACE_PERFLAB_RUNNAME");
+		Environment.SetEnvironmentVariable("HELIX_WORKITEM_FRIENDLYNAME", "REPLACE_HELIX_WORKITEM_FRIENDLYNAME");
+		Environment.SetEnvironmentVariable("PERFLAB_REPO", "REPLACE_PERFLAB_REPO");
+		Environment.SetEnvironmentVariable("PERFLAB_BRANCH", "REPLACE_PERFLAB_BRANCH");
+		Environment.SetEnvironmentVariable("PERFLAB_QUEUE", "REPLACE_PERFLAB_QUEUE");
+		Environment.SetEnvironmentVariable("PERFLAB_BUILDARCH", "REPLACE_PERFLAB_BUILDARCH");
+		Environment.SetEnvironmentVariable("PERFLAB_LOCALE", "REPLACE_PERFLAB_LOCALE");
+		Directory.CreateDirectory(outputPath);
 #endif
 
 		var success = await Task.Factory.StartNew(Run);


### PR DESCRIPTION
### Description of Change

Sets up the Benchmarks.Droid test app for testing as an APK in the performance lab. This change is being done in conjunction with  work to get Android BenchmarkDotnet runs working: https://github.com/dotnet/performance/pull/2955/files