### PR TITLE
[CI] Set the working directory for the build scripts.

### DIFF
--- a/eng/pipelines/common/maui-templates.yml
+++ b/eng/pipelines/common/maui-templates.yml
@@ -94,6 +94,7 @@ jobs:
     - pwsh: ./build.ps1 --target=dotnet-local-workloads --verbosity=diagnostic
       displayName: 'Install .NET (Local Workloads)'
       retryCountOnTaskFailure: 3
+      workingDirectory: ${{ parameters.checkoutDirectory }}
       env:
         DOTNET_TOKEN: $(dotnetbuilds-internal-container-read-token)
         PRIVATE_BUILD: $(PrivateBuild)
@@ -153,6 +154,7 @@ jobs:
     - pwsh: ./build.ps1 --target=dotnet-local-workloads --verbosity=diagnostic
       displayName: 'Install .NET (Local Workloads)'
       retryCountOnTaskFailure: 3
+      workingDirectory: ${{ parameters.checkoutDirectory }}
       env:
         DOTNET_TOKEN: $(dotnetbuilds-internal-container-read-token)
         PRIVATE_BUILD: $(PrivateBuild)


### PR DESCRIPTION
This allows to ensure that the script is found when the checkout is a diff directory from the template checkout.
