### PR TITLE
[Android] Properly remove the Frame's border thickness from the measureSpec

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Android/FrameRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Android/FrameRenderer.cs
@@ -155,10 +155,10 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			}
 		}
 
-		static int RemoveBorderFromMeasureSpec(int measureSpec, int borderThickness) 
+		static int RemoveBorderFromMeasureSpec(int measureSpec, int borderThickness)
 		{
 			var mode = MeasureSpec.GetMode(measureSpec);
-			
+
 			if (mode == MeasureSpecMode.Unspecified)
 			{
 				// Since it's unspecified, the border won't make any difference

--- a/src/Controls/src/Core/Compatibility/Handlers/Android/FrameRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Android/FrameRenderer.cs
@@ -179,13 +179,12 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				Element is IContentView cv)
 			{
 				var deviceIndependentBorderThickness = (Element.BorderColor.IsNotDefault() ? FrameBorderThickness : 0) * 2;
+				var platformBorderThickness = (int)Context.ToPixels(deviceIndependentBorderThickness);
 
-				if (deviceIndependentBorderThickness > 0)
+				if (platformBorderThickness > 0)
 				{
-					var platformBorderThickness = Context.ToPixels(deviceIndependentBorderThickness);
-
-					widthMeasureSpec = RemoveBorderFromMeasureSpec(widthMeasureSpec, (int)platformBorderThickness);
-					heightMeasureSpec = RemoveBorderFromMeasureSpec(heightMeasureSpec, (int)platformBorderThickness);
+					widthMeasureSpec = RemoveBorderFromMeasureSpec(widthMeasureSpec, platformBorderThickness);
+					heightMeasureSpec = RemoveBorderFromMeasureSpec(heightMeasureSpec, platformBorderThickness);
 				}
 
 				var size = pvh.MeasureVirtualView(
@@ -193,7 +192,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 					heightMeasureSpec,
 					cv.CrossPlatformMeasure);
 
-				SetMeasuredDimension((int)size.Width + deviceIndependentBorderThickness, (int)size.Height + deviceIndependentBorderThickness);
+				SetMeasuredDimension((int)size.Width + platformBorderThickness, (int)size.Height + platformBorderThickness);
 			}
 			else
 				base.OnMeasure(widthMeasureSpec, heightMeasureSpec);

--- a/src/Controls/tests/DeviceTests/Elements/Frame/FrameTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Frame/FrameTests.cs
@@ -268,8 +268,8 @@ namespace Microsoft.Maui.DeviceTests
 
 			// We're checking the Frame size within a tolerance of 1; between screen density of test devices and rounding issues,
 			// it's not going to be exactly `expected`, but it should be close.
-			Assert.Equal(expected, layoutFrame.Width, 1);
-			Assert.Equal(expected, layoutFrame.Height, 1);
+			Assert.Equal(expected, layoutFrame.Width, 1.0d);
+			Assert.Equal(expected, layoutFrame.Height, 1.0d);
 		}
 
 		[Theory]

--- a/src/Controls/tests/DeviceTests/Elements/Frame/FrameTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Frame/FrameTests.cs
@@ -256,7 +256,7 @@ namespace Microsoft.Maui.DeviceTests
 			};
 
 			var layoutFrame = await LayoutFrame(layout, frame, 500, 500);
-			
+
 			// Because this Frame has a border color, we expect the border to show up. So we need to account for its size
 			var expected = contentSize + (FrameBorderThickness * 2);
 

--- a/src/Controls/tests/DeviceTests/Elements/Frame/FrameTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Frame/FrameTests.cs
@@ -266,8 +266,10 @@ namespace Microsoft.Maui.DeviceTests
 			// Because this Frame has a border color, we expect the border to show up. So we need to account for its size
 			var expected = contentSize + (FrameBorderThickness * 2);
 
-			Assert.Equal(expected, layoutFrame.Width);
-			Assert.Equal(expected, layoutFrame.Height);
+			// We're checking the Frame size within a tolerance of 1; between screen density of test devices and rounding issues,
+			// it's not going to be exactly `expected`, but it should be close.
+			Assert.Equal(expected, layoutFrame.Width, 1);
+			Assert.Equal(expected, layoutFrame.Height, 1);
 		}
 
 		[Theory]
@@ -330,6 +332,10 @@ namespace Microsoft.Maui.DeviceTests
 			// will have a border.
 			var minExpectedWidth = (2 * frameMargin) + (2 * middleFrameMarginWidth) + (2 * outerFrameMargin) + (2 * FrameBorderThickness);
 			var minExpectedHeight = (2 * frameMargin) + (2 * middleFrameMarginHeight) + (2 * outerFrameMargin) + (2 * FrameBorderThickness);
+
+			// This test is specifically to guard against Android measurement situations where the nested frames collapse,
+			// (see https://github.com/dotnet/maui/issues/14418)
+			// which is why we're ensuring that the Frame has at least the expected height/width
 
 			Assert.True(layoutFrame.Height > minExpectedHeight);
 			Assert.True(layoutFrame.Width > minExpectedWidth);

--- a/src/Controls/tests/DeviceTests/Elements/Frame/FrameTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Frame/FrameTests.cs
@@ -16,7 +16,13 @@ namespace Microsoft.Maui.DeviceTests
 	public partial class FrameTests : ControlsHandlerTestBase
 	{
 		// This a hard-coded legacy value
+#if ANDROID
+		// Android
 		const int FrameBorderThickness = 3;
+#else
+		// Windows and iOS
+		const int FrameBorderThickness = 1;
+#endif
 
 		void SetupBuilder()
 		{

--- a/src/Core/src/Handlers/ViewHandlerExtensions.Android.cs
+++ b/src/Core/src/Handlers/ViewHandlerExtensions.Android.cs
@@ -38,8 +38,8 @@ namespace Microsoft.Maui
 		// apply to LayoutViewGroup.OnMeasure
 		internal static Size MeasureVirtualView(
 			this IPlatformViewHandler viewHandler,
-			int platformWidthConstraint,
-			int platformHeightConstraint,
+			int widthMeasureSpec,
+			int heightMeasureSpec,
 			Func<double, double, Size>? measureFunc = null)
 		{
 			var context = viewHandler.MauiContext?.Context;
@@ -51,11 +51,11 @@ namespace Microsoft.Maui
 				return Size.Zero;
 			}
 
-			var deviceIndependentWidth = platformWidthConstraint.ToDouble(context);
-			var deviceIndependentHeight = platformHeightConstraint.ToDouble(context);
+			var deviceIndependentWidth = widthMeasureSpec.ToDouble(context);
+			var deviceIndependentHeight = heightMeasureSpec.ToDouble(context);
 
-			var widthMode = MeasureSpec.GetMode(platformWidthConstraint);
-			var heightMode = MeasureSpec.GetMode(platformHeightConstraint);
+			var widthMode = MeasureSpec.GetMode(widthMeasureSpec);
+			var heightMode = MeasureSpec.GetMode(heightMeasureSpec);
 
 			measureFunc ??= virtualView.Measure;
 			var measure = measureFunc(deviceIndependentWidth, deviceIndependentHeight);


### PR DESCRIPTION
### Description of Change

The FrameRenderer on Android is trying to subtract the Frame's border thickness from the Frame's measureSpecs before measuring the Frame's content. Unfortunately, it's subtracting the thickness from each packed measureSpec value, rather from the size of the measureSpec. 

These changes deconstruct each measureSpec and subtract the thickness from the Size portion of the measureSpec, then return a new measureSpec with the updated size. 

### Issues Fixed

Fixes #14418