### PR TITLE
[CI] Do not rebuild the ms tasks on device tests.

### DIFF
--- a/eng/pipelines/common/device-tests-steps.yml
+++ b/eng/pipelines/common/device-tests-steps.yml
@@ -8,6 +8,7 @@ parameters:
   artifactName: 'nuget'
   artifactItemPattern: '**/*.nupkg'
   checkoutDirectory: $(System.DefaultWorkingDirectory)
+  useArtifacts: false
 
 steps:
   - template: provision.yml
@@ -26,23 +27,29 @@ steps:
   - pwsh: echo "##vso[task.prependpath]$(DotNet.Dir)"
     displayName: 'Add .NET to PATH'
 
-  - task: DownloadBuildArtifacts@0
-    displayName: 'Download Packages'
-    inputs:
-      artifactName: ${{ parameters.artifactName }}
-      itemPattern: ${{ parameters.artifactItemPattern }}
-      downloadPath: $(System.DefaultWorkingDirectory)/artifacts
+  - if ${{ eq(parameters.useArtifacts, true) }}:
 
-  - pwsh: Move-Item -Path artifacts\${{ parameters.artifactName }}\*.nupkg -Destination artifacts -Force
-    displayName: Move the downloaded artifacts
+    - task: DownloadBuildArtifacts@0
+      displayName: 'Download Packages'
+      inputs:
+        artifactName: ${{ parameters.artifactName }}
+        itemPattern: ${{ parameters.artifactItemPattern }}
+        downloadPath: $(System.DefaultWorkingDirectory)/artifacts
 
-  - pwsh: ./build.ps1 --target=dotnet-local-workloads --verbosity=diagnostic
-    displayName: 'Install .NET (Local Workloads)'
-    retryCountOnTaskFailure: 3
-    workingDirectory: ${{ parameters.checkoutDirectory }}
-    env:
-      DOTNET_TOKEN: $(dotnetbuilds-internal-container-read-token)
-      PRIVATE_BUILD: $(PrivateBuild)
+    - pwsh: Move-Item -Path artifacts\${{ parameters.artifactName }}\*.nupkg -Destination artifacts -Force
+      displayName: Move the downloaded artifacts
+
+    - pwsh: ./build.ps1 --target=dotnet-local-workloads --verbosity=diagnostic
+      displayName: 'Install .NET (Local Workloads)'
+      retryCountOnTaskFailure: 3
+      workingDirectory: ${{ parameters.checkoutDirectory }}
+      env:
+        DOTNET_TOKEN: $(dotnetbuilds-internal-container-read-token)
+        PRIVATE_BUILD: $(PrivateBuild)
+
+  - ${{ else }}:
+    - pwsh: ./build.ps1 --target=dotnet-buildtasks --configuration="Release"
+      displayName: 'Build the MSBuild Tasks'
 
   - pwsh: ./build.ps1 -Script eng/devices/${{ parameters.platform }}.cake --project="${{ parameters.path }}" --device=${{ parameters.device }} --results="$(TestResultsDirectory)" --binlog="$(LogDirectory)" ${{ parameters.cakeArgs }}
     displayName: $(Agent.JobName)

--- a/eng/pipelines/common/device-tests-steps.yml
+++ b/eng/pipelines/common/device-tests-steps.yml
@@ -27,7 +27,7 @@ steps:
   - pwsh: echo "##vso[task.prependpath]$(DotNet.Dir)"
     displayName: 'Add .NET to PATH'
 
-  - if ${{ eq(parameters.useArtifacts, true) }}:
+  - ${{ if eq(parameters.useArtifacts, true) }}:
 
     - task: DownloadBuildArtifacts@0
       displayName: 'Download Packages'

--- a/eng/pipelines/common/device-tests-steps.yml
+++ b/eng/pipelines/common/device-tests-steps.yml
@@ -5,6 +5,9 @@ parameters:
   cakeArgs: '' # additional cake args
   provisionatorChannel: 'latest'
   agentPoolAccessToken: ''
+  artifactName: 'nuget'
+  artifactItemPattern: '**/*.nupkg'
+  checkoutDirectory: $(System.DefaultWorkingDirectory)
 
 steps:
   - template: provision.yml
@@ -23,11 +26,27 @@ steps:
   - pwsh: echo "##vso[task.prependpath]$(DotNet.Dir)"
     displayName: 'Add .NET to PATH'
 
-  - pwsh: ./build.ps1 --target=dotnet-buildtasks --configuration="Release"
-    displayName: 'Build the MSBuild Tasks'
+  - task: DownloadBuildArtifacts@0
+    displayName: 'Download Packages'
+    inputs:
+      artifactName: ${{ parameters.artifactName }}
+      itemPattern: ${{ parameters.artifactItemPattern }}
+      downloadPath: $(System.DefaultWorkingDirectory)/artifacts
+
+  - pwsh: Move-Item -Path artifacts\${{ parameters.artifactName }}\*.nupkg -Destination artifacts -Force
+    displayName: Move the downloaded artifacts
+
+  - pwsh: ./build.ps1 --target=dotnet-local-workloads --verbosity=diagnostic
+    displayName: 'Install .NET (Local Workloads)'
+    retryCountOnTaskFailure: 3
+    workingDirectory: ${{ parameters.checkoutDirectory }}
+    env:
+      DOTNET_TOKEN: $(dotnetbuilds-internal-container-read-token)
+      PRIVATE_BUILD: $(PrivateBuild)
 
   - pwsh: ./build.ps1 -Script eng/devices/${{ parameters.platform }}.cake --project="${{ parameters.path }}" --device=${{ parameters.device }} --results="$(TestResultsDirectory)" --binlog="$(LogDirectory)" ${{ parameters.cakeArgs }}
     displayName: $(Agent.JobName)
+    workingDirectory: ${{ parameters.checkoutDirectory }}
     retryCountOnTaskFailure: 2
 
   - task: PublishTestResults@2

--- a/eng/pipelines/common/device-tests.yml
+++ b/eng/pipelines/common/device-tests.yml
@@ -8,6 +8,7 @@ parameters:
   artifactName: 'nuget'
   artifactItemPattern: '**/*.nupkg'
   checkoutDirectory: $(System.DefaultWorkingDirectory)
+  useArtifacts: false
   projects:
     - name: name
       desc: Human Description
@@ -46,6 +47,7 @@ stages:
                       artifactName: ${{ parameters.artifactName }}
                       artifactItemPattern: ${{ parameters.artifactItemPattern }}
                       checkoutDirectory: ${{ parameters.checkoutDirectory }}
+                      useArtifacts: ${{ parameters.useArtifacts }}
 
   - stage: ios_device_tests
     displayName: iOS Device Tests
@@ -76,3 +78,4 @@ stages:
                       artifactName: ${{ parameters.artifactName }}
                       artifactItemPattern: ${{ parameters.artifactItemPattern }}
                       checkoutDirectory: ${{ parameters.checkoutDirectory }}
+                      useArtifacts: ${{ parameters.useArtifacts }}

--- a/eng/pipelines/common/device-tests.yml
+++ b/eng/pipelines/common/device-tests.yml
@@ -5,6 +5,9 @@ parameters:
   iosVersions: [ 'latest' ]
   provisionatorChannel: 'latest'
   agentPoolAccessToken: ''
+  artifactName: 'nuget'
+  artifactItemPattern: '**/*.nupkg'
+  checkoutDirectory: $(System.DefaultWorkingDirectory)
   projects:
     - name: name
       desc: Human Description
@@ -40,6 +43,9 @@ stages:
                       device: android-emulator-32_${{ api }}
                       provisionatorChannel: ${{ parameters.provisionatorChannel }}
                       agentPoolAccessToken: ${{ parameters.agentPoolAccessToken }}
+                      artifactName: ${{ parameters.artifactName }}
+                      artifactItemPattern: ${{ parameters.artifactItemPattern }}
+                      checkoutDirectory: ${{ parameters.checkoutDirectory }}
 
   - stage: ios_device_tests
     displayName: iOS Device Tests
@@ -67,3 +73,6 @@ stages:
                         device: ios-simulator-64_${{ version }}
                       provisionatorChannel: ${{ parameters.provisionatorChannel }}
                       agentPoolAccessToken: ${{ parameters.agentPoolAccessToken }}
+                      artifactName: ${{ parameters.artifactName }}
+                      artifactItemPattern: ${{ parameters.artifactItemPattern }}
+                      checkoutDirectory: ${{ parameters.checkoutDirectory }}


### PR DESCRIPTION
We do not want to rebuild the tasks but use the workloads to run the device tests. The reasons for this tests are:

1. We should be testing what we ship, not a diff build.
2. We cna emsure that the megapipeline will be testing with the bumped android and iOS sdks.

