### PR TITLE
Remove typo in ResourceDictionary docs

### DIFF
--- a/src/Controls/docs/Microsoft.Maui.Controls/ResourceDictionary.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/ResourceDictionary.xml
@@ -141,7 +141,7 @@
       </Parameters>
       <Docs>
         <param name="styleSheet">The style sheet to add</param>
-        <summary>Adds <paramref name="styleSheet" /> tho <see langword="this" /> resource dictionary's list of style sheets.</summary>
+        <summary>Adds <paramref name="styleSheet" /> to <see langword="this" /> resource dictionary's list of style sheets.</summary>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>


### PR DESCRIPTION
### Description of Change

Fixed a typo (was tho instead of to) in ResourceDictionary's docs

### Issues Fixed

I didn't create an "official" issue for this typo