### PR TITLE
[xamlc] fix build error for System.Private.CoreLib

### DIFF
--- a/src/Controls/src/Build.Tasks/XamlCAssemblyResolver.cs
+++ b/src/Controls/src/Build.Tasks/XamlCAssemblyResolver.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 				return assembly;
 			if (IsMscorlib(name)
 				&& (TryResolve(AssemblyNameReference.Parse("mscorlib"), out assembly)
+				   || TryResolve(AssemblyNameReference.Parse("System.Private.CoreLib"), out assembly)
 				   || TryResolve(AssemblyNameReference.Parse("netstandard"), out assembly)
 				   || TryResolve(AssemblyNameReference.Parse("System.Runtime"), out assembly)))
 				return assembly;
@@ -42,6 +43,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 		static bool IsMscorlib(AssemblyNameReference name)
 		{
 			return name.Name == "mscorlib"
+				   || name.Name == "System.Private.CoreLib"
 				   || name.Name == "System.Runtime"
 				   || name.Name == "netstandard";
 		}


### PR DESCRIPTION
In 880ce096, I made XamlC try `System.Private.CoreLib` for XAML like:

    xmlns:sys="clr-namespace:System;assembly=mscorlib"

This fixed cases where `mscorlib.dll` is trimmed away in `Release` mode.

However, building the device tests this morning in `Release` mode I got the error:

    Elements\RadioButton\RadioButtonUsing.xaml Failed to resolve assembly: 'System.Private.CoreLib, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'
    at Microsoft.Maui.Controls.Build.Tasks.XamlCAssemblyResolver.Resolve(AssemblyNameReference name) in C:\src\maui\src\Controls\src\Build.Tasks\XamlCAssemblyResolver.cs:line 25
    at Microsoft.Maui.Controls.Build.Tasks.ModuleDefinitionExtensions.<>c__DisplayClass21_0.<GetTypeDefinition>b__0(ValueTuple`2 x) in C:\src\maui\src\Controls\src\Build.Tasks\ModuleDefinitionExtensions.cs:line 257
    at Microsoft.Maui.Controls.Build.Tasks.XamlCache.GetOrAdd[TKey,TValue](Dictionary`2 dictionary, TKey key, Func`2 valueFactory) in C:\src\maui\src\Controls\src\Build.Tasks\XamlCache.cs:line 27
    at Microsoft.Maui.Controls.Build.Tasks.ModuleDefinitionExtensions.GetTypeDefinition(ModuleDefinition module, XamlCache cache, ValueTuple`3 type) in C:\src\maui\src\Controls\src\Build.Tasks\ModuleDefinitionExtensions.cs:line 255
    at Microsoft.Maui.Controls.Build.Tasks.XmlTypeExtensions.<>c__DisplayClass3_0.<TryGetTypeReference>b__0(ValueTuple`3 typeInfo) in C:\src\maui\src\Controls\src\Build.Tasks\XmlTypeExtensions.cs:line 88
    at Microsoft.Maui.Controls.Xaml.XmlTypeXamlExtensions.GetTypeReference[T](XmlType xmlType, IEnumerable`1 xmlnsDefinitions, String defaultAssemblyName, Func`2 refFromTypeInfo) in C:\src\maui\src\Controls\src\Xaml\XmlTypeXamlExtensions.cs:line 96
    at Microsoft.Maui.Controls.Build.Tasks.XmlTypeExtensions.TryGetTypeReference(XmlType xmlType, XamlCache cache, ModuleDefinition module, IXmlLineInfo xmlInfo, TypeReference& typeReference) in C:\src\maui\src\Controls\src\Build.Tasks\XmlTypeExtensions.cs:line 85
    at Microsoft.Maui.Controls.Build.Tasks.XmlTypeExtensions.GetTypeReference(XmlType xmlType, XamlCache cache, ModuleDefinition module, IXmlLineInfo xmlInfo) in C:\src\maui\src\Controls\src\Build.Tasks\XmlTypeExtensions.cs:line 99
    at Microsoft.Maui.Controls.Build.Tasks.CreateObjectVisitor.Visit(ElementNode node, INode parentNode)
    at Microsoft.Maui.Controls.Xaml.ElementNode.Accept(IXamlNodeVisitor visitor, INode parentNode) in C:\src\maui\src\Controls\src\Xaml\XamlNode.cs:line 161
    at Microsoft.Maui.Controls.Xaml.ElementNode.Accept(IXamlNodeVisitor visitor, INode parentNode) in C:\src\maui\src\Controls\src\Xaml\XamlNode.cs:line 152
    at Microsoft.Maui.Controls.Xaml.RootNode.Accept(IXamlNodeVisitor visitor, INode parentNode) in C:\src\maui\src\Controls\src\Xaml\XamlNode.cs:line 209
    at Microsoft.Maui.Controls.Build.Tasks.XamlCTask.TryCoreCompile(MethodDefinition initComp, ILRootNode rootnode, String xamlFilePath, TaskLoggingHelper loggingHelper, Exception& exception) in C:\src\maui\src\Controls\src\Build.Tasks\XamlCTask.cs:line 280

`XamlCAssemblyResolver` needed to add a case for `System.Private.CoreLib`.

I'm not sure why I didn't hit this earlier, but we should hopefully catch this on CI next time when this one lands:

https://github.com/dotnet/maui/pull/14392