### PR TITLE
[Tests] Move sample build test to IntegrationTests

### DIFF
--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -150,6 +150,23 @@ Task("dotnet-samples")
         }, binlogPrefix: "sample-");
     });
 
+Task("dotnet-samples-test")
+    .Does(() =>
+    {
+        var buildSettings = new DotNetCoreBuildSettings
+        {
+            MSBuildSettings = new DotNetCoreMSBuildSettings()
+                .SetConfiguration(configuration)
+        };
+        DotNetCoreBuild("./src/TestUtils/src/Microsoft.Maui.IntegrationTests/Microsoft.Maui.IntegrationTests.csproj", buildSettings);
+
+        var testSettings = new DotNetCoreTestSettings
+        {
+            Filter = "FullyQualifiedName=Microsoft.Maui.IntegrationTests.SampleTests"
+        };
+        DotNetCoreTest($"./src/TestUtils/src/Microsoft.Maui.IntegrationTests/bin/{configuration}/net7.0/Microsoft.Maui.IntegrationTests.dll", testSettings);
+    });
+
 Task("dotnet-test")
     .IsDependentOn("dotnet")
     .Description("Build the solutions")

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -204,55 +204,55 @@ stages:
                 gitHubToken: $(github--pat--vs-mobiletools-engineering-service2)
 
   - stage: samples_net
-    displayName: Build .NET MAUI Samples
+    displayName: Test .NET MAUI Samples
     dependsOn: pack_net
     jobs:
       - ${{ each BuildPlatform in parameters.BuildPlatforms }}:
-        - ${{ each BuildConfiguration in parameters.BuildConfigurations }}:
-          - job: build_net_${{ BuildPlatform.name }}_${{ BuildConfiguration }}
-            workspace:
-              clean: all
-            displayName: ${{ BuildPlatform.name }} (${{ BuildConfiguration }})
-            timeoutInMinutes: 240
-            condition: or(
-              ${{ parameters.BuildEverything }},
-              ne(variables['Build.Reason'], 'PullRequest'),
-              eq('${{ BuildConfiguration }}', 'Release'))
-            pool:
-              name: ${{ BuildPlatform.poolName }}
-              vmImage: ${{ BuildPlatform.vmImage }}
-              demands:
-                - macOS.Name -equals Monterey
-                - macOS.Architecture -equals x64
-                - Agent.HasDevices -equals False
-                - Agent.IsPaired -equals False
-            steps:
-              - template: common/provision.yml
-                parameters:
-                  platform: ${{ BuildPlatform.name }}
-                  poolName: ${{ BuildPlatform.poolName }}
-                  
-              - task: DownloadBuildArtifacts@0
-                displayName: 'Download Packages'
-                inputs:
-                  artifactName: nuget
-                  itemPattern: '**/*.nupkg'
-                  downloadPath: $(System.DefaultWorkingDirectory)/artifacts
-              - pwsh: Move-Item -Path artifacts\nuget\*.nupkg -Destination artifacts -Force
-                displayName: Move the downloaded artifacts
-              - pwsh: ./build.ps1 --target=dotnet-local-workloads --configuration="${{ BuildConfiguration }}" --verbosity=diagnostic
-                displayName: 'Install .NET (Local Workloads)'
-                retryCountOnTaskFailure: 3
-                env:
-                  DOTNET_TOKEN: $(dotnetbuilds-internal-container-read-token)
-                  PRIVATE_BUILD: $(PrivateBuild)
-              - pwsh: ./build.ps1 --target=dotnet-samples --configuration="${{ BuildConfiguration }}" --verbosity=diagnostic
-                displayName: 'Build .NET MAUI Samples'
-              - task: PublishBuildArtifacts@1
-                condition: always()
-                displayName: publish artifacts
-                inputs:
-                  ArtifactName: ${{ BuildPlatform.artifact }}
+        - job: build_net_${{ BuildPlatform.name }}_samples
+          workspace:
+            clean: all
+          displayName: ${{ BuildPlatform.name }}
+          timeoutInMinutes: 120
+          pool:
+            name: ${{ BuildPlatform.poolName }}
+            vmImage: ${{ BuildPlatform.vmImage }}
+            demands:
+              - macOS.Name -equals Monterey
+              - macOS.Architecture -equals x64
+              - Agent.HasDevices -equals False
+              - Agent.IsPaired -equals False
+          steps:
+            - template: common/provision.yml
+              parameters:
+                platform: ${{ BuildPlatform.name }}
+                poolName: ${{ BuildPlatform.poolName }}
+
+            - task: DownloadBuildArtifacts@0
+              displayName: 'Download Packages'
+              inputs:
+                artifactName: nuget
+                itemPattern: '**/*.nupkg'
+                downloadPath: $(System.DefaultWorkingDirectory)/artifacts
+            - pwsh: Move-Item -Path artifacts\nuget\*.nupkg -Destination artifacts -Force
+              displayName: Move the downloaded artifacts
+            - pwsh: ./build.ps1 --target=dotnet-local-workloads --verbosity=diagnostic
+              displayName: 'Install .NET (Local Workloads)'
+              retryCountOnTaskFailure: 3
+              env:
+                DOTNET_TOKEN: $(dotnetbuilds-internal-container-read-token)
+                PRIVATE_BUILD: $(PrivateBuild)
+            - task: DotNetCoreCLI@2
+              inputs:
+                projects: $(Build.SourcesDirectory)/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Microsoft.Maui.IntegrationTests.csproj
+              displayName: Build Microsoft.Maui.IntegrationTests
+            - task: DotNetCoreCLI@2
+              inputs:
+                command: test
+                projects: $(Build.SourcesDirectory)/src/TestUtils/src/Microsoft.Maui.IntegrationTests/bin/Debug/net7.0/Microsoft.Maui.IntegrationTests.dll
+                arguments: --logger "console;verbosity=normal" --filter "FullyQualifiedName=Microsoft.Maui.IntegrationTests.SampleTests"
+                publishTestResults: true
+                testRunTitle: ${{ BuildPlatform.name }} sample build tests
+              displayName: ${{ BuildPlatform.name }} sample build tests
 
   - stage: templates_net
     displayName: Test Templates

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/BaseBuildTest.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/BaseBuildTest.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Maui.IntegrationTests
 			$"RestorePackagesPath={Path.Combine(TestEnvironment.GetTestDirectoryRoot(), "packages")}",
 			$"RestoreConfigFile={TestNuGetConfig}",
 			// Avoid iOS build warning as error on Windows: There is no available connection to the Mac. Task 'VerifyXcodeVersion' will not be executed
-			$"CustomBeforeMicrosoftCSharpTargets={Path.Combine(TestEnvironment.GetMauiDirectory(),"src", "Templates", "TemplateTestExtraTargets.targets")}",
+			$"CustomBeforeMicrosoftCSharpTargets={Path.Combine(TestEnvironment.GetMauiDirectory(), "src", "Templates", "TemplateTestExtraTargets.targets")}",
 			//Try not restore dependencies of 6.0.10
 			$"DisableTransitiveFrameworkReferenceDownloads=true",
 		};

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/SampleTests.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/SampleTests.cs
@@ -1,0 +1,55 @@
+﻿
+using System.Collections;
+using Newtonsoft.Json;
+
+namespace Microsoft.Maui.IntegrationTests
+{
+	public class SampleTests : BaseBuildTest
+	{
+		public static IEnumerable SampleTestMatrix
+		{
+			get
+			{
+				// Parse individual project files from `Microsoft.Maui.Samples.slnf` to generate a set of test cases
+				var sampleSln = Path.Combine(TestEnvironment.GetMauiDirectory(), "Microsoft.Maui.Samples.slnf");
+				var slnFile = JsonConvert.DeserializeObject<SolutionFile>(File.ReadAllText(sampleSln));
+				foreach (var projectFile in slnFile?.solution.projects ?? new List<string> { sampleSln })
+				{
+					foreach (var config in new[] { "Debug", "Release" })
+					{
+						yield return new TestCaseData(projectFile, config);
+					}
+				}
+			}
+		}
+
+		[Test]
+		[TestCaseSource(nameof(SampleTestMatrix))]
+		public void Build(string relativeProj, string config)
+		{
+			var projectFile = Path.GetFullPath(Path.Combine(TestEnvironment.GetMauiDirectory(), relativeProj));
+			var binlog = Path.Combine(TestDirectory, Path.Combine("sample.binlog"));
+			var sampleProps = new[]
+			{
+				"UseWorkload=true",
+				$"RestoreConfigFile={TestNuGetConfig}",
+			};
+
+			Assert.IsTrue(DotnetInternal.Build(projectFile, config, properties: sampleProps, binlogPath: binlog),
+					$"Project {Path.GetFileName(projectFile)} failed to build. Check test output/attachments for errors.");
+		}
+
+	}
+
+
+	public class SolutionFile
+	{
+		public SolutionElement solution { get; set; } = new SolutionElement();
+	}
+
+	public class SolutionElement
+	{
+		public string path { get; set; } = "";
+		public List<string> projects { get; set; } = new List<string>();
+	}
+}

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/DotnetInternal.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/DotnetInternal.cs
@@ -5,9 +5,9 @@ namespace Microsoft.Maui.IntegrationTests
 	public static class DotnetInternal
 	{
 		static readonly string DotnetTool = Path.Combine(TestEnvironment.GetMauiDirectory(), "bin", "dotnet", "dotnet");
-		const int DEFAULT_TIMEOUT = 600;
+		const int DEFAULT_TIMEOUT = 900;
 
-		public static bool Build(string projectFile, string config, string target = "", string framework = "", IEnumerable<string>? properties = null)
+		public static bool Build(string projectFile, string config, string target = "", string framework = "", IEnumerable<string>? properties = null, string binlogPath = "")
 		{
 			var binlogName = $"build-{DateTime.UtcNow.ToFileTimeUtc()}.binlog";
 			var buildArgs = $"\"{projectFile}\" -c {config}";
@@ -29,7 +29,12 @@ namespace Microsoft.Maui.IntegrationTests
 				}
 			}
 
-			return Run("build", $"{buildArgs} -bl:\"{Path.Combine(Path.GetDirectoryName(projectFile) ?? "", binlogName)}\"");
+			if (string.IsNullOrEmpty(binlogPath))
+			{
+				binlogPath = Path.Combine(Path.GetDirectoryName(projectFile) ?? "", binlogName);
+			}
+
+			return Run("build", $"{buildArgs} -bl:\"{binlogPath}\"");
 		}
 
 		public static bool New(string shortName, string outputDirectory, string framework)


### PR DESCRIPTION
Moves the `Microsoft.Maui.Samples.slnf` build tests into the
IntegrationTests project.  This should improve test result visibility
and debugging efforts in Azure Pipelines.  The pipeline yaml has also
been simplified by replacing the project configuration parameter with a
test attribute.