### PR TITLE
[Windows] Allow early use of DeviceDisplay.Current.MainDisplayInfo

### DIFF
--- a/src/Core/src/Hosting/EssentialsMauiAppBuilderExtensions.cs
+++ b/src/Core/src/Hosting/EssentialsMauiAppBuilderExtensions.cs
@@ -69,6 +69,10 @@ namespace Microsoft.Maui.Hosting
 					.OnLaunched((application, args) =>
 					{
 						ApplicationModel.Platform.OnLaunched(args);
+					})
+					.OnPlatformWindowSubclassed((window, context) =>
+					{
+						ApplicationModel.Platform.OnPlatformWindowInitialized(window);
 					}));
 #elif TIZEN
 

--- a/src/Core/src/LifecycleEvents/Windows/WindowsLifecycleBuilderExtensions.cs
+++ b/src/Core/src/LifecycleEvents/Windows/WindowsLifecycleBuilderExtensions.cs
@@ -10,7 +10,7 @@
 		public static IWindowsLifecycleBuilder OnWindowCreated(this IWindowsLifecycleBuilder lifecycle, WindowsLifecycle.OnWindowCreated del) => lifecycle.OnEvent(del);
 		public static IWindowsLifecycleBuilder OnResumed(this IWindowsLifecycleBuilder lifecycle, WindowsLifecycle.OnResumed del) => lifecycle.OnEvent(del);
 		public static IWindowsLifecycleBuilder OnPlatformMessage(this IWindowsLifecycleBuilder lifecycle, WindowsLifecycle.OnPlatformMessage del) => lifecycle.OnEvent(del);
-		public static IWindowsLifecycleBuilder OnPlatformWindowSubclassed(this IWindowsLifecycleBuilder lifecycle, WindowsLifecycle.OnPlatformWindowSubclassed del) => lifecycle.OnPlatformWindowSubclassed(del);
+		public static IWindowsLifecycleBuilder OnPlatformWindowSubclassed(this IWindowsLifecycleBuilder lifecycle, WindowsLifecycle.OnPlatformWindowSubclassed del) => lifecycle.OnEvent(del);
 
 		internal static IWindowsLifecycleBuilder OnMauiContextCreated(this IWindowsLifecycleBuilder lifecycle, WindowsLifecycle.OnMauiContextCreated del) => lifecycle.OnEvent(del);
 	}

--- a/src/Essentials/src/Platform/Platform.shared.cs
+++ b/src/Essentials/src/Platform/Platform.shared.cs
@@ -141,6 +141,10 @@ namespace Microsoft.Maui.ApplicationModel
 		public static void OnLaunched(UI.Xaml.LaunchActivatedEventArgs e) =>
 			AppActions.Current.OnLaunched(e);
 
+		/// <inheritdoc cref="IWindowStateManager.OnPlatformWindowInitialized(UI.Xaml.Window)"/>
+		public static void OnPlatformWindowInitialized(UI.Xaml.Window window) =>
+			WindowStateManager.Default.OnPlatformWindowInitialized(window);
+
 		/// <inheritdoc cref="IWindowStateManager.OnActivated(UI.Xaml.Window, UI.Xaml.WindowActivatedEventArgs)"/>
 		public static void OnActivated(UI.Xaml.Window window, UI.Xaml.WindowActivatedEventArgs args) =>
 			WindowStateManager.Default.OnActivated(window, args);

--- a/src/Essentials/src/Platform/WindowStateManager.uwp.cs
+++ b/src/Essentials/src/Platform/WindowStateManager.uwp.cs
@@ -22,6 +22,12 @@ namespace Microsoft.Maui.ApplicationModel
 		Window? GetActiveWindow();
 
 		/// <summary>
+		/// Occurs when a new window is created, but not yet displayed
+		/// </summary>
+		/// <param name="window">The <see cref="Window"/> object</param>
+		void OnPlatformWindowInitialized(Window window);
+
+		/// <summary>
 		/// Sets the new active window that can be retrieved with <see cref="GetActiveWindow"/>.
 		/// </summary>
 		/// <param name="window">The <see cref="Window"/> object that is activated.</param>
@@ -126,6 +132,11 @@ namespace Microsoft.Maui.ApplicationModel
 			_activeWindow = window;
 
 			ActiveWindowChanged?.Invoke(window, EventArgs.Empty);
+		}
+
+		public void OnPlatformWindowInitialized(Window window)
+		{
+			SetActiveWindow(window);
 		}
 
 		public void OnActivated(Window window, WindowActivatedEventArgs args)

--- a/src/Essentials/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -1,9 +1,11 @@
 #nullable enable
+Microsoft.Maui.ApplicationModel.IWindowStateManager.OnPlatformWindowInitialized(Microsoft.UI.Xaml.Window! window) -> void
 Microsoft.Maui.Authentication.IWebAuthenticatorResponseDecoder
 Microsoft.Maui.Authentication.IWebAuthenticatorResponseDecoder.DecodeResponse(System.Uri! uri) -> System.Collections.Generic.IDictionary<string!, string!>?
 Microsoft.Maui.Authentication.WebAuthenticatorOptions.ResponseDecoder.get -> Microsoft.Maui.Authentication.IWebAuthenticatorResponseDecoder?
 Microsoft.Maui.Authentication.WebAuthenticatorOptions.ResponseDecoder.set -> void
 Microsoft.Maui.Devices.IFlashlight.IsSupportedAsync() -> System.Threading.Tasks.Task<bool>!
+static Microsoft.Maui.ApplicationModel.Platform.OnPlatformWindowInitialized(Microsoft.UI.Xaml.Window! window) -> void
 static Microsoft.Maui.Devices.Flashlight.IsSupportedAsync() -> System.Threading.Tasks.Task<bool>!
 ~Microsoft.Maui.Authentication.WebAuthenticatorResult.CallbackUri.get -> System.Uri
 ~Microsoft.Maui.Authentication.WebAuthenticatorResult.WebAuthenticatorResult(System.Uri uri, Microsoft.Maui.Authentication.IWebAuthenticatorResponseDecoder responseDecoder) -> void

--- a/src/Essentials/test/DeviceTests/Tests/Windows/ActiveWindowTracker_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/Windows/ActiveWindowTracker_Tests.cs
@@ -163,7 +163,7 @@ namespace Microsoft.Maui.Essentials.DeviceTests.Shared
 				SetActiveWindow(window);
 			}
 
-			private void SetActiveWindow(UI.Xaml.Window window)
+			void SetActiveWindow(UI.Xaml.Window window)
 			{
 				if (_window != window)
 				{

--- a/src/Essentials/test/DeviceTests/Tests/Windows/ActiveWindowTracker_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/Windows/ActiveWindowTracker_Tests.cs
@@ -155,8 +155,21 @@ namespace Microsoft.Maui.Essentials.DeviceTests.Shared
 
 			public void OnActivated(UI.Xaml.Window window, UI.Xaml.WindowActivatedEventArgs? args = null)
 			{
-				_window = window;
-				ActiveWindowChanged?.Invoke(window, EventArgs.Empty);
+				SetActiveWindow(window);
+			}
+
+			public void OnPlatformWindowInitialized(UI.Xaml.Window window)
+			{
+				SetActiveWindow(window);
+			}
+
+			private void SetActiveWindow(UI.Xaml.Window window)
+			{
+				if (_window != window)
+				{
+					_window = window;
+					ActiveWindowChanged?.Invoke(window, EventArgs.Empty);
+				}
 			}
 		}
 	}

--- a/src/Essentials/test/DeviceTests/Tests/Windows/DeviceDisplay_Windows_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/Windows/DeviceDisplay_Windows_Tests.cs
@@ -1,0 +1,74 @@
+﻿#nullable enable
+using System;
+using System.Threading.Tasks;
+using Microsoft.Maui.ApplicationModel;
+using Microsoft.Maui.Devices;
+using Microsoft.UI.Xaml;
+using Xunit;
+
+namespace Microsoft.Maui.Essentials.DeviceTests.Shared
+{
+	[Category("Windows DeviceDisplay")]
+	public class DeviceDisplay_Windows_Tests
+	{
+		[Fact]
+		public Task Screen_Metrics_Are_Valid_Before_Window_Activated()
+		{
+			return Utils.OnMainThread(() =>
+			{
+				var oldStateManager = WindowStateManager.Default;
+
+				TestWindowStateManagerImplementation testWindowStateManager = new();
+				WindowStateManager.SetDefault(testWindowStateManager);
+
+				// Create the window but don't activate it
+				var window = new MauiWinUIWindow();
+				var metrics = DeviceDisplay.MainDisplayInfo;
+
+				WindowStateManager.SetDefault(oldStateManager);
+
+				Assert.NotNull(testWindowStateManager.GetPlatformInitializedWindow());
+				Assert.NotNull(testWindowStateManager.GetActiveWindow());
+				Assert.True(metrics.Width > 0);
+				Assert.True(metrics.Height > 0);
+				Assert.True(metrics.Density > 0);
+			});
+		}
+
+		private class TestWindowStateManagerImplementation : IWindowStateManager
+		{
+			Window? _activeWindow;
+			Window? _activePlatformSetWindow;
+
+			public event EventHandler? ActiveWindowChanged;
+
+			public Window? GetActiveWindow() =>
+				_activeWindow;
+
+			public Window? GetPlatformInitializedWindow() =>
+				_activePlatformSetWindow;
+
+			void SetActiveWindow(Window window)
+			{
+				if (_activeWindow == window)
+					return;
+
+				_activeWindow = window;
+
+				ActiveWindowChanged?.Invoke(window, EventArgs.Empty);
+			}
+
+			public void OnPlatformWindowInitialized(Window window)
+			{
+				_activePlatformSetWindow = window;
+				SetActiveWindow(window);
+			}
+
+			public void OnActivated(Window window, WindowActivatedEventArgs args)
+			{
+				if (args.WindowActivationState != WindowActivationState.Deactivated)
+					SetActiveWindow(window);
+			}
+		}
+	}
+}

--- a/src/Essentials/test/DeviceTests/Tests/Windows/DeviceDisplay_Windows_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/Windows/DeviceDisplay_Windows_Tests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Maui.Essentials.DeviceTests.Shared
 			});
 		}
 
-		private class TestWindowStateManagerImplementation : IWindowStateManager
+		class TestWindowStateManagerImplementation : IWindowStateManager
 		{
 			Window? _activeWindow;
 			Window? _activePlatformSetWindow;


### PR DESCRIPTION
### Description of Change

Currently (on Windows), `DeviceDisplay.Current.MainDisplayInfo` doesn't get set until the first window is activated/shown on the screen since it uses the active window to gather this info.

This PR fixes that by setting the active window as soon as possible using the `OnPlatformWindowSubclassed` lifecycle event. This lifecycle event happens after we have a valid `HWND` but before the window is "technically" active. I don't think this will cause any issues (???).

As a result, Windows users can now do things like override `Application.CreateWindow` to set the initial window position and size before it's shown without needing to pinvoke:
```csharp
class App : Application
{
    protected override Window CreateWindow(IActivationState activationState)
    {
        Window window = new Window(new NavigationPage(new MainPage()));

        var disp = DeviceDisplay.Current.MainDisplayInfo;
        var newWidth = disp.Width / 2;
        var newHeight = disp.Height / 2;

        // center the window
        window.X = (disp.Width / disp.Density - newWidth) / 2;
        window.Y = (disp.Height / disp.Density - newHeight) / 2;

        return window;
    }
}
```

### Issues Fixed
Fixes #6976 