### PR TITLE
Propagate Navigation Events through PageContainer

### DIFF
--- a/src/Controls/src/Core/HandlerImpl/Page.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Page.Impl.cs
@@ -43,22 +43,34 @@ namespace Microsoft.Maui.Controls
 
 		internal void SendNavigatedTo(NavigatedToEventArgs args)
 		{
+			if (!HasAppeared)
+				return;
+
 			HasNavigatedTo = true;
 			NavigatedTo?.Invoke(this, args);
 			OnNavigatedTo(args);
+			(this as IPageContainer<Page>)?.CurrentPage?.SendNavigatedTo(args);
 		}
 
 		internal void SendNavigatingFrom(NavigatingFromEventArgs args)
 		{
+			if (!HasAppeared)
+				return;
+
 			NavigatingFrom?.Invoke(this, args);
 			OnNavigatingFrom(args);
+			(this as IPageContainer<Page>)?.CurrentPage?.SendNavigatingFrom(args);
 		}
 
 		internal void SendNavigatedFrom(NavigatedFromEventArgs args)
 		{
+			if (!HasAppeared)
+				return;
+
 			HasNavigatedTo = false;
 			NavigatedFrom?.Invoke(this, args);
 			OnNavigatedFrom(args);
+			(this as IPageContainer<Page>)?.CurrentPage?.SendNavigatedFrom(args);
 		}
 
 		public event EventHandler<NavigatedToEventArgs> NavigatedTo;

--- a/src/Controls/src/Core/HandlerImpl/Page.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Page.Impl.cs
@@ -43,9 +43,6 @@ namespace Microsoft.Maui.Controls
 
 		internal void SendNavigatedTo(NavigatedToEventArgs args)
 		{
-			if (!HasAppeared)
-				return;
-
 			HasNavigatedTo = true;
 			NavigatedTo?.Invoke(this, args);
 			OnNavigatedTo(args);
@@ -54,9 +51,6 @@ namespace Microsoft.Maui.Controls
 
 		internal void SendNavigatingFrom(NavigatingFromEventArgs args)
 		{
-			if (!HasAppeared)
-				return;
-
 			NavigatingFrom?.Invoke(this, args);
 			OnNavigatingFrom(args);
 			(this as IPageContainer<Page>)?.CurrentPage?.SendNavigatingFrom(args);
@@ -64,9 +58,6 @@ namespace Microsoft.Maui.Controls
 
 		internal void SendNavigatedFrom(NavigatedFromEventArgs args)
 		{
-			if (!HasAppeared)
-				return;
-
 			HasNavigatedTo = false;
 			NavigatedFrom?.Invoke(this, args);
 			OnNavigatedFrom(args);

--- a/src/Controls/tests/Core.UnitTests/PageLifeCycleTests.cs
+++ b/src/Controls/tests/Core.UnitTests/PageLifeCycleTests.cs
@@ -170,24 +170,6 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		[Theory]
 		[InlineData(false)]
 		[InlineData(true)]
-		public async Task WhileCoveredNavigationPageDoesntFireNavEvents(bool useMaui)
-		{
-			var lcPage = new ContentPage();
-			var targetPage = new LCPage();
-			var modalPage = new ContentPage();
-			var window = new TestWindow(new TestNavigationPage(useMaui, lcPage));
-
-			await window.Navigation.PushModalAsync(modalPage);
-			await window.Page.Navigation.PushAsync(targetPage);
-			Assert.Null(targetPage.NavigatedToArgs);
-			await window.Navigation.PopModalAsync();
-			Assert.NotNull(targetPage.NavigatedToArgs);
-			Assert.Equal(modalPage, targetPage.NavigatedToArgs.PreviousPage);
-		}
-
-		[Theory]
-		[InlineData(false)]
-		[InlineData(true)]
 		public async Task NavigationPagePropagatesEventsWhenCoveredByModal(bool useMaui)
 		{
 			var lcPage = new ContentPage();

--- a/src/Controls/tests/Core.UnitTests/PageLifeCycleTests.cs
+++ b/src/Controls/tests/Core.UnitTests/PageLifeCycleTests.cs
@@ -143,6 +143,47 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.Equal(1, lcPage.AppearingCount);
 		}
 
+		[Theory]
+		[InlineData(false)]
+		[InlineData(true)]
+		public async Task WhileCoveredNavigationPageDoesntFireNavEvents(bool useMaui)
+		{
+			var lcPage = new ContentPage();
+			var targetPage = new LCPage();
+			var modalPage = new ContentPage();
+			var window = new TestWindow(new TestNavigationPage(useMaui, lcPage));
+
+			await window.Navigation.PushModalAsync(modalPage);
+			await window.Page.Navigation.PushAsync(targetPage);
+			Assert.Null(targetPage.NavigatedToArgs);
+			await window.Navigation.PopModalAsync();
+			Assert.NotNull(targetPage.NavigatedToArgs);
+			Assert.Equal(modalPage, targetPage.NavigatedToArgs.PreviousPage);
+		}
+
+		[Theory]
+		[InlineData(false)]
+		[InlineData(true)]
+		public async Task NavigationPagePropagatesEventsWhenCoveredByModal(bool useMaui)
+		{
+			var lcPage = new ContentPage();
+			var targetPage = new LCPage();
+			var modalPage = new ContentPage();
+			var window = new TestWindow(new TestNavigationPage(useMaui, lcPage));
+
+			await window.Page.Navigation.PushAsync(targetPage);
+			targetPage.ClearNavigationArgs();
+			await window.Navigation.PushModalAsync(modalPage);
+
+			Assert.NotNull(targetPage.NavigatingFromArgs);
+			Assert.Null(targetPage.NavigatedToArgs);
+
+			await window.Navigation.PopModalAsync();
+			Assert.NotNull(targetPage.NavigatedToArgs);
+
+			Assert.Equal(modalPage, targetPage.NavigatedToArgs.PreviousPage);
+		}
+
 		[Fact]
 		public async Task PopModalPage()
 		{

--- a/src/Controls/tests/Core.UnitTests/PageLifeCycleTests.cs
+++ b/src/Controls/tests/Core.UnitTests/PageLifeCycleTests.cs
@@ -16,7 +16,9 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		public async Task NavigationPageInitialPage()
 		{
 			var lcPage = new LCPage();
-			var navigationPage = new TestNavigationPage(true, lcPage);
+			var navigationPage = new TestNavigationPage(true, lcPage)
+					.AddToTestWindow();
+
 			await navigationPage.NavigatingTask;
 			Assert.Null(lcPage.NavigatingFromArgs);
 			Assert.Null(lcPage.NavigatedFromArgs);
@@ -31,10 +33,15 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		{
 			var previousPage = new LCPage();
 			var lcPage = new LCPage();
-			NavigationPage navigationPage = new TestNavigationPage(useMaui, previousPage);
+			var navigationPage =
+				new TestNavigationPage(useMaui, previousPage)
+					.AddToTestWindow();
+
 			await navigationPage.PushAsync(lcPage);
 
 			Assert.NotNull(previousPage.NavigatingFromArgs);
+			Assert.NotNull(lcPage.NavigatedToArgs);
+			Assert.NotNull(previousPage.NavigatedFromArgs);
 			Assert.Equal(previousPage, lcPage.NavigatedToArgs.PreviousPage);
 			Assert.Equal(lcPage, previousPage.NavigatedFromArgs.DestinationPage);
 		}
@@ -47,7 +54,9 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			var firstPage = new LCPage();
 			var poppedPage = new LCPage();
 
-			NavigationPage navigationPage = new TestNavigationPage(useMaui, firstPage);
+			NavigationPage navigationPage = new TestNavigationPage(useMaui, firstPage)
+					.AddToTestWindow();
+
 			await navigationPage.PushAsync(poppedPage);
 			await navigationPage.PopAsync();
 
@@ -64,7 +73,9 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			var firstPage = new LCPage();
 			var poppedPage = new LCPage();
 
-			NavigationPage navigationPage = new TestNavigationPage(useMaui, firstPage);
+			NavigationPage navigationPage = new TestNavigationPage(useMaui, firstPage)
+					.AddToTestWindow();
+
 			await navigationPage.PushAsync(new ContentPage());
 			await navigationPage.PushAsync(new ContentPage());
 			await navigationPage.PushAsync(poppedPage);
@@ -80,7 +91,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		{
 			var firstPage = new LCPage() { Title = "First Page" };
 			var secondPage = new LCPage() { Title = "Second Page" };
-			var tabbedPage = new TabbedPage() { Children = { firstPage, secondPage } };
+			var tabbedPage = new TabbedPage() { Children = { firstPage, secondPage } }.AddToTestWindow();
 
 			tabbedPage.CurrentPage = secondPage;
 			Assert.NotNull(firstPage.NavigatingFromArgs);
@@ -93,7 +104,10 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		{
 			var firstPage = new LCPage() { Title = "First Page" };
 			var secondPage = new LCPage() { Title = "Second Page" };
-			var tabbedPage = new TabbedPage() { Children = { firstPage, secondPage } };
+			var tabbedPage = new TabbedPage().AddToTestWindow();
+
+			tabbedPage.Children.Add(firstPage);
+			tabbedPage.Children.Add(secondPage);
 			Assert.Null(firstPage.NavigatingFromArgs);
 			Assert.Null(firstPage.NavigatedFromArgs);
 			Assert.NotNull(firstPage.NavigatedToArgs);
@@ -105,7 +119,12 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		{
 			var firstPage = new LCPage() { Title = "First Page" };
 			var secondPage = new LCPage() { Title = "Second Page" };
-			var flyoutPage = new FlyoutPage() { Flyout = firstPage };
+			var flyoutPage = new FlyoutPage()
+			{
+				Detail = new ContentPage() { Title = "Detail" },
+				Flyout = firstPage
+			}.AddToTestWindow();
+
 			flyoutPage.Flyout = secondPage;
 
 			Assert.NotNull(firstPage.NavigatingFromArgs);
@@ -118,7 +137,12 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		{
 			var firstPage = new LCPage() { Title = "First Page" };
 			var secondPage = new LCPage() { Title = "Second Page" };
-			var flyoutPage = new FlyoutPage() { Detail = firstPage };
+			var flyoutPage = new FlyoutPage()
+			{
+				Detail = firstPage,
+				Flyout = new ContentPage() { Title = "Flyout" }
+			}.AddToTestWindow();
+
 			flyoutPage.Detail = secondPage;
 
 			Assert.NotNull(firstPage.NavigatingFromArgs);

--- a/src/Controls/tests/Core.UnitTests/TestClasses/TestWindow.cs
+++ b/src/Controls/tests/Core.UnitTests/TestClasses/TestWindow.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			}
 		}
 
-		
+
 	}
 
 	public static class TestWindowExtensions

--- a/src/Controls/tests/Core.UnitTests/TestClasses/TestWindow.cs
+++ b/src/Controls/tests/Core.UnitTests/TestClasses/TestWindow.cs
@@ -28,5 +28,16 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 				_ = (app as IApplication).CreateWindow(null);
 			}
 		}
+
+		
+	}
+
+	public static class TestWindowExtensions
+	{
+		public static T AddToTestWindow<T>(this T page)
+			where T : Page
+		{
+			return (T)new TestWindow(page).Page;
+		}
 	}
 }


### PR DESCRIPTION
### Description of Change

Navigation events aren't propagating through to child pages when covered by a Modal Page. When pushing a modal page the navigation events are fired on the covered page but those events aren't propagated through to the child pages.

This is related to https://github.com/dotnet/maui/pull/14517