### PR TITLE
[Android] Properly remove the Frame's border thickness

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Android/FrameRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Android/FrameRenderer.cs
@@ -155,10 +155,10 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			}
 		}
 
-		static int RemoveBorderFromMeasureSpec(int measureSpec, int borderThickness) 
+		static int RemoveBorderFromMeasureSpec(int measureSpec, int borderThickness)
 		{
 			var mode = MeasureSpec.GetMode(measureSpec);
-			
+
 			if (mode == MeasureSpecMode.Unspecified)
 			{
 				// Since it's unspecified, the border won't make any difference

--- a/src/Controls/src/Core/Compatibility/Handlers/Android/FrameRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Android/FrameRenderer.cs
@@ -179,13 +179,12 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				Element is IContentView cv)
 			{
 				var deviceIndependentBorderThickness = (Element.BorderColor.IsNotDefault() ? FrameBorderThickness : 0) * 2;
+				var platformBorderThickness = (int)Context.ToPixels(deviceIndependentBorderThickness);
 
-				if (deviceIndependentBorderThickness > 0)
+				if (platformBorderThickness > 0)
 				{
-					var platformBorderThickness = Context.ToPixels(deviceIndependentBorderThickness);
-
-					widthMeasureSpec = RemoveBorderFromMeasureSpec(widthMeasureSpec, (int)platformBorderThickness);
-					heightMeasureSpec = RemoveBorderFromMeasureSpec(heightMeasureSpec, (int)platformBorderThickness);
+					widthMeasureSpec = RemoveBorderFromMeasureSpec(widthMeasureSpec, platformBorderThickness);
+					heightMeasureSpec = RemoveBorderFromMeasureSpec(heightMeasureSpec, platformBorderThickness);
 				}
 
 				var size = pvh.MeasureVirtualView(
@@ -193,7 +192,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 					heightMeasureSpec,
 					cv.CrossPlatformMeasure);
 
-				SetMeasuredDimension((int)size.Width + deviceIndependentBorderThickness, (int)size.Height + deviceIndependentBorderThickness);
+				SetMeasuredDimension((int)size.Width + platformBorderThickness, (int)size.Height + platformBorderThickness);
 			}
 			else
 				base.OnMeasure(widthMeasureSpec, heightMeasureSpec);

--- a/src/Controls/src/Core/Frame.cs
+++ b/src/Controls/src/Core/Frame.cs
@@ -55,11 +55,12 @@ namespace Microsoft.Maui.Controls
 
 		int IBorderElement.CornerRadius => (int)CornerRadius;
 
-		// not currently used by frame
+		// TODO fix iOS/WinUI to work the same as Android
 #if ANDROID
 		double IBorderElement.BorderWidth => 3;
 #else
-		double IBorderElement.BorderWidth => 1;
+		// not currently used by frame
+		double IBorderElement.BorderWidth => -1d;
 #endif
 
 		int IBorderElement.CornerRadiusDefaultValue => (int)CornerRadiusProperty.DefaultValue;
@@ -88,7 +89,12 @@ namespace Microsoft.Maui.Controls
 
 		bool IBorderElement.IsBorderWidthSet() => false;
 
-		// Copied this from Border
+		// TODO fix iOS/WinUI to work the same as Android
+		// once this has been fixed on iOS/WinUI we should centralize 
+		// this code and Border into LayoutExtensions
+		// WinUI being fixed as part of
+		// https://github.com/dotnet/maui/issues/13552
+#if ANDROID
 		Size IContentView.CrossPlatformArrange(Graphics.Rect bounds)
 		{
 			bounds = bounds.Inset((this as IBorderElement).BorderWidth);
@@ -96,12 +102,13 @@ namespace Microsoft.Maui.Controls
 			return bounds.Size;
 		}
 
-		// Copied this from Border
 		Size IContentView.CrossPlatformMeasure(double widthConstraint, double heightConstraint)
 		{
 			var inset = Padding + (this as IBorderElement).BorderWidth;
 			return this.MeasureContent(inset, widthConstraint, heightConstraint);
 		}
+#endif
+
 	}
 
 	internal static class FrameExtensions

--- a/src/Controls/src/Core/Frame.cs
+++ b/src/Controls/src/Core/Frame.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/Frame.xml" path="Type[@FullName='Microsoft.Maui.Controls.Frame']/Docs/*" />
 	[ContentProperty(nameof(Content))]
-	public partial class Frame : ContentView, IElementConfiguration<Frame>, IPaddingElement, IBorderElement
+	public partial class Frame : ContentView, IElementConfiguration<Frame>, IPaddingElement, IBorderElement, IContentView
 	{
 		/// <include file="../../docs/Microsoft.Maui.Controls/Frame.xml" path="//Member[@MemberName='BorderColorProperty']/Docs/*" />
 		public static readonly BindableProperty BorderColorProperty = BorderElement.BorderColorProperty;
@@ -56,7 +56,11 @@ namespace Microsoft.Maui.Controls
 		int IBorderElement.CornerRadius => (int)CornerRadius;
 
 		// not currently used by frame
-		double IBorderElement.BorderWidth => -1d;
+#if ANDROID
+		double IBorderElement.BorderWidth => 3;
+#else
+		double IBorderElement.BorderWidth => 1;
+#endif
 
 		int IBorderElement.CornerRadiusDefaultValue => (int)CornerRadiusProperty.DefaultValue;
 
@@ -83,6 +87,21 @@ namespace Microsoft.Maui.Controls
 		bool IBorderElement.IsBorderColorSet() => IsSet(BorderColorProperty);
 
 		bool IBorderElement.IsBorderWidthSet() => false;
+
+		// Copied this from Border
+		Size IContentView.CrossPlatformArrange(Graphics.Rect bounds)
+		{
+			bounds = bounds.Inset((this as IBorderElement).BorderWidth);
+			this.ArrangeContent(bounds);
+			return bounds.Size;
+		}
+
+		// Copied this from Border
+		Size IContentView.CrossPlatformMeasure(double widthConstraint, double heightConstraint)
+		{
+			var inset = Padding + (this as IBorderElement).BorderWidth;
+			return this.MeasureContent(inset, widthConstraint, heightConstraint);
+		}
 	}
 
 	internal static class FrameExtensions

--- a/src/Controls/tests/DeviceTests/Elements/Frame/FrameTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Frame/FrameTests.cs
@@ -268,8 +268,8 @@ namespace Microsoft.Maui.DeviceTests
 
 			// We're checking the Frame size within a tolerance of 1; between screen density of test devices and rounding issues,
 			// it's not going to be exactly `expected`, but it should be close.
-			Assert.Equal(expected, layoutFrame.Width, 1);
-			Assert.Equal(expected, layoutFrame.Height, 1);
+			Assert.Equal(expected, layoutFrame.Width, 1.0d);
+			Assert.Equal(expected, layoutFrame.Height, 1.0d);
 		}
 
 		[Theory]

--- a/src/Controls/tests/DeviceTests/Elements/Frame/FrameTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Frame/FrameTests.cs
@@ -256,7 +256,7 @@ namespace Microsoft.Maui.DeviceTests
 			};
 
 			var layoutFrame = await LayoutFrame(layout, frame, 500, 500);
-			
+
 			// Because this Frame has a border color, we expect the border to show up. So we need to account for its size
 			var expected = contentSize + (FrameBorderThickness * 2);
 

--- a/src/Controls/tests/DeviceTests/Elements/Frame/FrameTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Frame/FrameTests.cs
@@ -266,8 +266,10 @@ namespace Microsoft.Maui.DeviceTests
 			// Because this Frame has a border color, we expect the border to show up. So we need to account for its size
 			var expected = contentSize + (FrameBorderThickness * 2);
 
-			Assert.Equal(expected, layoutFrame.Width);
-			Assert.Equal(expected, layoutFrame.Height);
+			// We're checking the Frame size within a tolerance of 1; between screen density of test devices and rounding issues,
+			// it's not going to be exactly `expected`, but it should be close.
+			Assert.Equal(expected, layoutFrame.Width, 1);
+			Assert.Equal(expected, layoutFrame.Height, 1);
 		}
 
 		[Theory]
@@ -330,6 +332,10 @@ namespace Microsoft.Maui.DeviceTests
 			// will have a border.
 			var minExpectedWidth = (2 * frameMargin) + (2 * middleFrameMarginWidth) + (2 * outerFrameMargin) + (2 * FrameBorderThickness);
 			var minExpectedHeight = (2 * frameMargin) + (2 * middleFrameMarginHeight) + (2 * outerFrameMargin) + (2 * FrameBorderThickness);
+
+			// This test is specifically to guard against Android measurement situations where the nested frames collapse,
+			// (see https://github.com/dotnet/maui/issues/14418)
+			// which is why we're ensuring that the Frame has at least the expected height/width
 
 			Assert.True(layoutFrame.Height > minExpectedHeight);
 			Assert.True(layoutFrame.Width > minExpectedWidth);

--- a/src/Controls/tests/DeviceTests/Elements/Frame/FrameTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Frame/FrameTests.cs
@@ -16,7 +16,13 @@ namespace Microsoft.Maui.DeviceTests
 	public partial class FrameTests : ControlsHandlerTestBase
 	{
 		// This a hard-coded legacy value
+#if ANDROID
+		// Android
 		const int FrameBorderThickness = 3;
+#else
+		// Windows and iOS
+		const int FrameBorderThickness = 1;
+#endif
 
 		void SetupBuilder()
 		{

--- a/src/Core/src/Handlers/ViewHandlerExtensions.Android.cs
+++ b/src/Core/src/Handlers/ViewHandlerExtensions.Android.cs
@@ -38,8 +38,8 @@ namespace Microsoft.Maui
 		// apply to LayoutViewGroup.OnMeasure
 		internal static Size MeasureVirtualView(
 			this IPlatformViewHandler viewHandler,
-			int platformWidthConstraint,
-			int platformHeightConstraint,
+			int widthMeasureSpec,
+			int heightMeasureSpec,
 			Func<double, double, Size>? measureFunc = null)
 		{
 			var context = viewHandler.MauiContext?.Context;
@@ -51,11 +51,11 @@ namespace Microsoft.Maui
 				return Size.Zero;
 			}
 
-			var deviceIndependentWidth = platformWidthConstraint.ToDouble(context);
-			var deviceIndependentHeight = platformHeightConstraint.ToDouble(context);
+			var deviceIndependentWidth = widthMeasureSpec.ToDouble(context);
+			var deviceIndependentHeight = heightMeasureSpec.ToDouble(context);
 
-			var widthMode = MeasureSpec.GetMode(platformWidthConstraint);
-			var heightMode = MeasureSpec.GetMode(platformHeightConstraint);
+			var widthMode = MeasureSpec.GetMode(widthMeasureSpec);
+			var heightMode = MeasureSpec.GetMode(heightMeasureSpec);
 
 			measureFunc ??= virtualView.Measure;
 			var measure = measureFunc(deviceIndependentWidth, deviceIndependentHeight);


### PR DESCRIPTION
### Description of Change

Move the code that takes into account Padding/BorderThickness up into the xplat layer. We moved this code down into the `FrameRenderer` which is causing us to just duplicate this behavior across all the platforms. 

We should just fix all the `FrameRenderer`'s to follow the same path as `Border` which will ensure that `Frame` is consistent across all platforms and fits into the current layout system better. 

### Issues Fixed

Fixes #14418