### PR TITLE
Add Controls.Compatibility to local cache

### DIFF
--- a/src/Workload/Microsoft.NET.Sdk.Maui/WorkloadManifest.in.json
+++ b/src/Workload/Microsoft.NET.Sdk.Maui/WorkloadManifest.in.json
@@ -39,6 +39,7 @@
           "Microsoft.Maui.Controls.Build.Tasks",
           "Microsoft.Maui.Controls.Core",
           "Microsoft.Maui.Controls.Xaml",
+          "Microsoft.Maui.Controls.Compatibility",
           "Microsoft.Maui.Essentials"
       ]
     },
@@ -107,6 +108,10 @@
       "version": "@VERSION@"
     },
     "Microsoft.Maui.Controls.Xaml": {
+      "kind": "library",
+      "version": "@VERSION@"
+    },
+    "Microsoft.Maui.Controls.Compatibility": {
       "kind": "library",
       "version": "@VERSION@"
     },


### PR DESCRIPTION
### Description of Change

The Microsoft.Maui.Controls.Compatibility package was missing from the manifest and thus would not be installed with the workload nor will it get the msis generated.

I noticed this when doing an offline install.