### PR TITLE
Fix android border stroke to use dp vs px

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Android/FrameRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Android/FrameRenderer.cs
@@ -293,7 +293,13 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			if (borderColor == null)
 				_backgroundDrawable.SetStroke(0, AColor.Transparent);
 			else if (VirtualView is IBorderElement be)
-				_backgroundDrawable.SetStroke((int)be.BorderWidth, borderColor.ToPlatform());
+			{
+				var borderWidth = be.BorderWidth;
+				if (borderWidth < 0)
+					borderWidth = 1;
+
+				_backgroundDrawable.SetStroke((int)Context.ToPixels(borderWidth), borderColor.ToPlatform());
+			}
 		}
 
 		void UpdateShadow()

--- a/src/Controls/src/Core/Compatibility/Handlers/Android/FrameRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Android/FrameRenderer.cs
@@ -295,8 +295,8 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			else if (VirtualView is IBorderElement be)
 			{
 				var borderWidth = be.BorderWidth;
-				if (borderWidth < 0)
-					borderWidth = 1;
+				if (borderWidth < 0 || borderWidth == Primitives.Dimension.Unset)
+					borderWidth = 0;
 
 				_backgroundDrawable.SetStroke((int)Context.ToPixels(borderWidth), borderColor.ToPlatform());
 			}

--- a/src/Controls/src/Core/Frame.cs
+++ b/src/Controls/src/Core/Frame.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Maui.Controls
 
 		// TODO fix iOS/WinUI to work the same as Android
 #if ANDROID
-		double IBorderElement.BorderWidth => 3;
+		double IBorderElement.BorderWidth => 1;
 #else
 		// not currently used by frame
 		double IBorderElement.BorderWidth => -1d;

--- a/src/Controls/src/Core/Frame.cs
+++ b/src/Controls/src/Core/Frame.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Maui.Controls
 
 		Color IBorderElement.BorderColorDefaultValue => (Color)BorderColorProperty.DefaultValue;
 
-		double IBorderElement.BorderWidthDefaultValue => -1d;
+		double IBorderElement.BorderWidthDefaultValue => ((IBorderElement)this).BorderWidth;
 
 		/// <inheritdoc/>
 		public IPlatformElementConfiguration<T, Frame> On<T>() where T : IConfigPlatform
@@ -97,14 +97,14 @@ namespace Microsoft.Maui.Controls
 #if ANDROID
 		Size IContentView.CrossPlatformArrange(Graphics.Rect bounds)
 		{
-			bounds = bounds.Inset((this as IBorderElement).BorderWidth);
+			bounds = bounds.Inset(((IBorderElement)this).BorderWidth);
 			this.ArrangeContent(bounds);
 			return bounds.Size;
 		}
 
 		Size IContentView.CrossPlatformMeasure(double widthConstraint, double heightConstraint)
 		{
-			var inset = Padding + (this as IBorderElement).BorderWidth;
+			var inset = Padding + ((IBorderElement)this).BorderWidth;
 			return this.MeasureContent(inset, widthConstraint, heightConstraint);
 		}
 #endif

--- a/src/Controls/tests/DeviceTests/Elements/Frame/FrameTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Frame/FrameTests.Android.cs
@@ -67,6 +67,49 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.Null(frame.Content);
 		}
 
+		[Fact]
+		public async Task FrameContentAccountsForBorderThickness()
+		{
+			SetupBuilder();
+
+			double contentSize = 50;
+			var innerFrame = new Frame()
+			{
+				BorderColor = Colors.Black,
+				BackgroundColor = Colors.Blue,
+				CornerRadius = 0,
+				Padding = new Thickness(0),
+				Margin = new Thickness(0)
+			};
+
+			var outerFrame = new Frame()
+			{
+				Content = innerFrame,
+				BorderColor = Colors.Black,
+				CornerRadius = 0,
+				Padding = new Thickness(0),
+				Margin = new Thickness(0),
+				WidthRequest = contentSize,
+				HeightRequest = contentSize
+			};
+
+			var layout = new StackLayout()
+			{
+				Background = Colors.Purple,
+				Children =
+				{
+					outerFrame
+				}
+			};
+
+			// This tests that the border drawn fills the entire space it's expected to
+			// There shouldn't be any white between the two frames
+			await LayoutFrame(layout, outerFrame, 100, 100, () =>
+			{
+				return AssertionExtensions.AssertDoesNotContainColor(layout.ToPlatform(), Colors.White.ToPlatform());
+			});
+		}
+
 		Task PerformClick(IButton button)
 		{
 			return InvokeOnMainThreadAsync(() =>

--- a/src/TestUtils/src/DeviceTests/AssertionExtensions.Android.cs
+++ b/src/TestUtils/src/DeviceTests/AssertionExtensions.Android.cs
@@ -335,7 +335,17 @@ namespace Microsoft.Maui.DeviceTests
 				{
 					LayoutParameters = new FrameLayout.LayoutParams(ViewGroup.LayoutParams.MatchParent, ViewGroup.LayoutParams.MatchParent)
 				};
-				view.LayoutParameters = new FrameLayout.LayoutParams(view.Width, view.Height)
+
+				var width = view.Width;
+				var height = view.Height;
+
+				if (width <= 0)
+					width = FrameLayout.LayoutParams.WrapContent;
+
+				if (height <= 0)
+					height = FrameLayout.LayoutParams.WrapContent;
+
+				view.LayoutParameters = new FrameLayout.LayoutParams(width, height)
 				{
 					Gravity = GravityFlags.Center
 				};
@@ -377,14 +387,7 @@ namespace Microsoft.Maui.DeviceTests
 
 		public static Task<Bitmap> ToBitmap(this AView view)
 		{
-			if (view.Parent is not null)
-			{
-				return Task.FromResult(CreateBitmap(view));
-			}
-
-			return view.AttachAndRun(() => CreateBitmap(view));
-
-			Bitmap CreateBitmap(AView view)
+			return view.AttachAndRun(() =>
 			{
 				if (view.Parent is WrapperView wrapper)
 					view = wrapper;
@@ -395,7 +398,7 @@ namespace Microsoft.Maui.DeviceTests
 					view.Draw(canvas);
 				}
 				return bitmap;
-			}
+			});
 		}
 
 		public static Bitmap AssertColorAtPoint(this Bitmap bitmap, AColor expectedColor, int x, int y)

--- a/src/TestUtils/src/DeviceTests/AssertionExtensions.Android.cs
+++ b/src/TestUtils/src/DeviceTests/AssertionExtensions.Android.cs
@@ -375,8 +375,16 @@ namespace Microsoft.Maui.DeviceTests
 			}
 		}
 
-		public static Task<Bitmap> ToBitmap(this AView view) =>
-			view.AttachAndRun(() =>
+		public static Task<Bitmap> ToBitmap(this AView view)
+		{
+			if (view.Parent is not null)
+			{
+				return Task.FromResult(CreateBitmap(view));
+			}
+
+			return view.AttachAndRun(() => CreateBitmap(view));
+
+			Bitmap CreateBitmap(AView view)
 			{
 				if (view.Parent is WrapperView wrapper)
 					view = wrapper;
@@ -387,7 +395,8 @@ namespace Microsoft.Maui.DeviceTests
 					view.Draw(canvas);
 				}
 				return bitmap;
-			});
+			}
+		}
 
 		public static Bitmap AssertColorAtPoint(this Bitmap bitmap, AColor expectedColor, int x, int y)
 		{
@@ -473,7 +482,7 @@ namespace Microsoft.Maui.DeviceTests
 				{
 					if (bitmap.ColorAtPoint(x, y, true).IsEquivalent(unexpectedColor))
 					{
-						throw new XunitException($"Color {unexpectedColor} was found at point {x}, {y}.");
+						throw new XunitException(CreateColorError(bitmap, $"Color {unexpectedColor} was found at point {x}, {y}."));
 					}
 				}
 			}


### PR DESCRIPTION
### Description of Change

I tested the backport pr [here](https://github.com/dotnet/maui/pull/14565) against the original issue and noticed a thin white line between the two frames.

I tracked this to the fact that we just pass in "3" to the `SetStroke` call for drawing the border inside the `FrameRenderer`, which we've done since Forms. This feels like an odd choice because it will always just draw it as "3 px" regardless of the DP of the device it's running on. The original choice for this seems arbitrary https://github.com/xamarin/Xamarin.Forms/pull/1385. 

Technically this is a slight breaking change, but just setting the border to always be 3px is very inconsistent for a lot of reasons. 

Given the following `XAML`

```XAML
    <Frame
               Margin="0"
               Padding="0"
               BorderColor="Black"
               CornerRadius="0"
                HeightRequest="50"
                WidthRequest="50"
               HasShadow="False">
            <Frame
                   Margin="0"
                   Padding="0"
                   BackgroundColor="Blue"
                   CornerRadius="0"
                   HasShadow="False">
                <Label Text="Frame"></Label>
            </Frame>
        </Frame>

        <Border
               Margin="0"
               Padding="0"
               Stroke="Black"
                StrokeThickness="1"
                HeightRequest="50"
                WidthRequest="50">
            <Border
                   Margin="0"
                   Padding="0"
                    StrokeThickness="1"
                   BackgroundColor="Blue">
                <Label Text="Border"></Label>
            </Border>
        </Border>
    </VerticalStackLayout>
```

#### Before

![image](https://user-images.githubusercontent.com/5375137/231875835-5b01e170-b817-41d0-80ea-5687b9206412.png)


#### After

![image](https://user-images.githubusercontent.com/5375137/231876160-154a9b12-212b-4668-8142-732e2def2555.png)
