### PR TITLE
Add windows build conditions

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -73,7 +73,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <DefineConstants Condition="'$(_MauiTargetPlatformIsWinAppSDK)' == 'True'">$(DefineConstants);WINDOWS</DefineConstants>
+    <DefineConstants Condition="'$(_MauiTargetPlatformIsWinAppSDK)' != 'false'">$(DefineConstants);WINDOWS</DefineConstants>
     <DefineConstants Condition="'$(IncludeCompatibilityProjects)' == 'True'">$(DefineConstants);COMPATIBILITY_ENABLED</DefineConstants>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <!-- <GenerateRuntimeConfigurationFiles>false</GenerateRuntimeConfigurationFiles> -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -26,9 +26,10 @@
     <_MauiTargetPlatformIsmacOS Condition="'$(_MauiTargetPlatformIdentifier)' == 'macos'">True</_MauiTargetPlatformIsmacOS>
     <_MauiTargetPlatformIstvOS>false</_MauiTargetPlatformIstvOS>
     <_MauiTargetPlatformIstvOS Condition="'$(_MauiTargetPlatformIdentifier)' == 'tvos'">True</_MauiTargetPlatformIstvOS>
-    <_MauiTargetPlatformIsWindows>false</_MauiTargetPlatformIsWindows>
-    <_MauiTargetPlatformIsWindows Condition="$(_MauiTargetPlatformIdentifier.Contains('windows')) == 'True'">True</_MauiTargetPlatformIsWindows>
     <_MauiTargetPlatformIsTizen>false</_MauiTargetPlatformIsTizen>
+    <_WindowsTargetIsWinAppSDK Condition="'$(UseWPF)' == 'true' OR '$(UseWindowsForms)' == 'true' " >false</_WindowsTargetIsWinAppSDK>
+    <_MauiTargetPlatformIsWinAppSDK>false</_MauiTargetPlatformIsWinAppSDK>
+    <_MauiTargetPlatformIsWinAppSDK Condition="'$(_WindowsTargetIsWinAppSDK)' == 'true' and $(_MauiTargetPlatformIdentifier.Contains('windows')) == 'True'">True</_MauiTargetPlatformIsWinAppSDK>
     <_MauiTargetPlatformIsTizen Condition="'$(_MauiTargetPlatformIdentifier)' == 'tizen'">True</_MauiTargetPlatformIsTizen>
   </PropertyGroup>
 
@@ -51,7 +52,7 @@
     <DotNetMacOSWorkloadIsInstalled Condition="Exists('$(DotNetWorkloadPacksInstallLocation)Microsoft.macOS.Sdk\$(DotNetMacOSWorkloadInstalledVersion)\Sdk\AutoImport.props')">true</DotNetMacOSWorkloadIsInstalled>
     <DotNetTizenWorkloadIsInstalled Condition="Exists('$(DotNetWorkloadPacksInstallLocation)Samsung.Tizen.Sdk\$(DotNetTizenWorkloadInstalledVersion)\Sdk\AutoImport.props')">true</DotNetTizenWorkloadIsInstalled>
 
-    <IncludeWindowsTargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) or '$(Packing)' == 'true'">true</IncludeWindowsTargetFrameworks>
+    <IncludeWindowsTargetFrameworks Condition="('$(_WindowsTargetIsWinAppSDK)' == 'true' and $([MSBuild]::IsOSPlatform('windows'))) or '$(Packing)' == 'true'">true</IncludeWindowsTargetFrameworks>
     <IncludeMacOSTargetFrameworks Condition="'$(DotNetMacOSWorkloadIsInstalled)' == 'true'">true</IncludeMacOSTargetFrameworks>
     <IncludeTizenTargetFrameworks Condition="'$(DotNetTizenWorkloadIsInstalled)' == 'true'">true</IncludeTizenTargetFrameworks>
     <IncludeAndroidTargetFrameworks>true</IncludeAndroidTargetFrameworks>
@@ -63,7 +64,7 @@
 
   <!-- this is CI, so everything should be there -->
   <PropertyGroup Condition="'$(CI)' == 'true' or '$(TF_BUILD)' == 'true'">
-    <IncludeWindowsTargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">true</IncludeWindowsTargetFrameworks>
+    <IncludeWindowsTargetFrameworks Condition="'$(_WindowsTargetIsWinAppSDK)' == 'true' AND $([MSBuild]::IsOSPlatform('windows'))">true</IncludeWindowsTargetFrameworks>
     <IncludeTizenTargetFrameworks>true</IncludeTizenTargetFrameworks>
     <IncludeMacOSTargetFrameworks>true</IncludeMacOSTargetFrameworks>
     <IncludeAndroidTargetFrameworks>true</IncludeAndroidTargetFrameworks>
@@ -72,7 +73,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <DefineConstants Condition="'$(_MauiTargetPlatformIsWindows)' == 'True'">$(DefineConstants);WINDOWS</DefineConstants>
+    <DefineConstants Condition="'$(_MauiTargetPlatformIsWinAppSDK)' == 'True'">$(DefineConstants);WINDOWS</DefineConstants>
     <DefineConstants Condition="'$(IncludeCompatibilityProjects)' == 'True'">$(DefineConstants);COMPATIBILITY_ENABLED</DefineConstants>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <!-- <GenerateRuntimeConfigurationFiles>false</GenerateRuntimeConfigurationFiles> -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -29,7 +29,7 @@
     <_MauiTargetPlatformIsTizen>false</_MauiTargetPlatformIsTizen>
     <_WindowsTargetIsWinAppSDK Condition="'$(UseWPF)' == 'true' OR '$(UseWindowsForms)' == 'true' " >false</_WindowsTargetIsWinAppSDK>
     <_MauiTargetPlatformIsWinAppSDK>false</_MauiTargetPlatformIsWinAppSDK>
-    <_MauiTargetPlatformIsWinAppSDK Condition="'$(_WindowsTargetIsWinAppSDK)' == 'true' and $(_MauiTargetPlatformIdentifier.Contains('windows')) == 'True'">True</_MauiTargetPlatformIsWinAppSDK>
+    <_MauiTargetPlatformIsWinAppSDK Condition="'$(_WindowsTargetIsWinAppSDK)' != 'false' and $(_MauiTargetPlatformIdentifier.Contains('windows')) == 'True'">True</_MauiTargetPlatformIsWinAppSDK>
     <_MauiTargetPlatformIsTizen Condition="'$(_MauiTargetPlatformIdentifier)' == 'tizen'">True</_MauiTargetPlatformIsTizen>
   </PropertyGroup>
 
@@ -52,7 +52,7 @@
     <DotNetMacOSWorkloadIsInstalled Condition="Exists('$(DotNetWorkloadPacksInstallLocation)Microsoft.macOS.Sdk\$(DotNetMacOSWorkloadInstalledVersion)\Sdk\AutoImport.props')">true</DotNetMacOSWorkloadIsInstalled>
     <DotNetTizenWorkloadIsInstalled Condition="Exists('$(DotNetWorkloadPacksInstallLocation)Samsung.Tizen.Sdk\$(DotNetTizenWorkloadInstalledVersion)\Sdk\AutoImport.props')">true</DotNetTizenWorkloadIsInstalled>
 
-    <IncludeWindowsTargetFrameworks Condition="('$(_WindowsTargetIsWinAppSDK)' == 'true' and $([MSBuild]::IsOSPlatform('windows'))) or '$(Packing)' == 'true'">true</IncludeWindowsTargetFrameworks>
+    <IncludeWindowsTargetFrameworks Condition="('$(_WindowsTargetIsWinAppSDK)' != 'false' and $([MSBuild]::IsOSPlatform('windows'))) or '$(Packing)' == 'true'">true</IncludeWindowsTargetFrameworks>
     <IncludeMacOSTargetFrameworks Condition="'$(DotNetMacOSWorkloadIsInstalled)' == 'true'">true</IncludeMacOSTargetFrameworks>
     <IncludeTizenTargetFrameworks Condition="'$(DotNetTizenWorkloadIsInstalled)' == 'true'">true</IncludeTizenTargetFrameworks>
     <IncludeAndroidTargetFrameworks>true</IncludeAndroidTargetFrameworks>
@@ -64,7 +64,7 @@
 
   <!-- this is CI, so everything should be there -->
   <PropertyGroup Condition="'$(CI)' == 'true' or '$(TF_BUILD)' == 'true'">
-    <IncludeWindowsTargetFrameworks Condition="'$(_WindowsTargetIsWinAppSDK)' == 'true' AND $([MSBuild]::IsOSPlatform('windows'))">true</IncludeWindowsTargetFrameworks>
+    <IncludeWindowsTargetFrameworks Condition="'$(_WindowsTargetIsWinAppSDK)' != 'false' AND $([MSBuild]::IsOSPlatform('windows'))">true</IncludeWindowsTargetFrameworks>
     <IncludeTizenTargetFrameworks>true</IncludeTizenTargetFrameworks>
     <IncludeMacOSTargetFrameworks>true</IncludeMacOSTargetFrameworks>
     <IncludeAndroidTargetFrameworks>true</IncludeAndroidTargetFrameworks>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -10,6 +10,7 @@
   <PropertyGroup>
      <!-- Allows for MAUI Xaml Hot Reload Samples to run without checks  -->
     <IgnoreMauiXamlHotReloadCompatibilityCheck>True</IgnoreMauiXamlHotReloadCompatibilityCheck>
+    <NoWarn>$(NoWarn);RS0016</NoWarn>
   </PropertyGroup>
 
   <!-- platform version number information -->
@@ -49,7 +50,7 @@
     because we don't want to set these properties for WPF projects...
     There's probably a better way we should find to infer this
   -->
-  <PropertyGroup Condition="'$(_MauiTargetPlatformIsWindows)' == 'True' AND $(TargetFramework.Contains('-windows10'))">
+  <PropertyGroup Condition="'$(_MauiTargetPlatformIsWinAppSDK)' == 'True' AND $(TargetFramework.Contains('-windows10'))">
     <SupportedOSPlatformVersion>10.0.17763.0</SupportedOSPlatformVersion>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
   </PropertyGroup>
@@ -64,19 +65,19 @@
   </PropertyGroup>
 
   <!-- semi HACK: by default, WinUI includes all @(None) with .bmp/.png as @(Content) and adds that to the .pri -->
-  <ItemGroup Condition="'$(_MauiTargetPlatformIsWindows)' == 'True'">
+  <ItemGroup Condition="'$(_MauiTargetPlatformIsWinAppSDK)' == 'True'">
     <Content Remove="@(None->WithMetadataValue('Pack','true'))" />
   </ItemGroup>
 
   <!-- Until we get a new enough dotnet -->
-  <ItemGroup Condition="'$(_MauiTargetPlatformIsWindows)' == 'True'">
+  <ItemGroup Condition="'$(_MauiTargetPlatformIsWinAppSDK)' == 'True'">
     <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.19041.27" TargetingPackVersion="10.0.19041.27" />
   </ItemGroup>
 
   <!--
     Workaround for https://github.com/microsoft/WindowsAppSDK/issues/2684
   -->
-  <Import Project="src\Core\src\nuget\buildTransitive\WinUI.Unpackaged.targets" Condition=" '$(WindowsPackageType)' == 'None' and '$(_MauiTargetPlatformIsWindows)' == 'True' " />
+  <Import Project="src\Core\src\nuget\buildTransitive\WinUI.Unpackaged.targets" Condition=" '$(WindowsPackageType)' == 'None' and '$(_MauiTargetPlatformIsWinAppSDK)' == 'True' " />
 
     <!-- Packaging -->
   <ItemGroup Condition="'$(IsPackable)' == 'true'">

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -10,7 +10,6 @@
   <PropertyGroup>
      <!-- Allows for MAUI Xaml Hot Reload Samples to run without checks  -->
     <IgnoreMauiXamlHotReloadCompatibilityCheck>True</IgnoreMauiXamlHotReloadCompatibilityCheck>
-    <NoWarn>$(NoWarn);RS0016</NoWarn>
   </PropertyGroup>
 
   <!-- platform version number information -->

--- a/src/MultiTargeting.targets
+++ b/src/MultiTargeting.targets
@@ -39,7 +39,7 @@
     <Compile Remove="**\*.Platform.cs" />
     <None Include="**\*.Platform.cs" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(_MauiTargetPlatformIsWindows)' != 'True' ">
+  <ItemGroup Condition=" '$(_MauiTargetPlatformIsWinAppSDK)' != 'True' ">
     <Compile Remove="**\*.Windows.cs" />
     <None Include="**\*.Windows.cs" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
     <Compile Remove="**\Windows\**\*.cs" />
@@ -55,7 +55,7 @@
     <Compile Remove="**\Windows\**\*.xaml.cs" />
     <None Include="**\Windows\**\*.xaml.cs" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(_MauiTargetPlatformIsWindows)' != 'True' ">
+  <ItemGroup Condition=" '$(_MauiTargetPlatformIsWinAppSDK)' != 'True' ">
     <Compile Remove="**\*.uwp.cs" />
     <None Include="**\*.uwp.cs" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
   </ItemGroup>
@@ -107,7 +107,7 @@
   </PropertyGroup>
 
   <!-- Windows -->
-  <PropertyGroup Condition=" '$(_MauiTargetPlatformIsWindows)' == 'True' ">
+  <PropertyGroup Condition=" '$(_MauiTargetPlatformIsWinAppSDK)' == 'True' ">
     <DefineConstants>WINDOWS;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" $(TargetFramework.StartsWith('uap10.0')) ">


### PR DESCRIPTION
### Description of Change

If a project with `UseMaui` has `UseForms` or `UseWPF` specified, then don't include the WinAppSDK bits.

I tested this locally and for `WPF` you have to include these in your project so that we don't process the WPF `XAML`

```XAML
    <EnableDefaultXamlItems>false</EnableDefaultXamlItems>
    <EnableDefaultMauiItems>false</EnableDefaultMauiItems>
```

I feel like this is ok for now. I didn't want to add too much conditional behavior in our code. 

### Issues Fixed

Fixes #6450
