### PR TITLE
Add updated WKWebView Inspectable flag

### DIFF
--- a/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
+++ b/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
@@ -86,10 +86,8 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 			config.UserContentController.AddUserScript(new WKUserScript(
 				new NSString(BlazorInitScript), WKUserScriptInjectionTime.AtDocumentEnd, true));
 
-#if MACCATALYST13_3_OR_GREATER || IOS16_1_OR_GREATER
 			// iOS WKWebView doesn't allow handling 'http'/'https' schemes, so we use the fake 'app' scheme
 			config.SetUrlSchemeHandler(new SchemeHandler(this), urlScheme: "app");
-#endif
 
 			var webview = new WKWebView(RectangleF.Empty, config)
 			{
@@ -97,9 +95,10 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 				AutosizesSubviews = true
 			};
 
+#if MACCATALYST13_3_OR_GREATER || IOS16_4_OR_GREATER
 			// Enable Developer Extras for Catalyst/iOS builds for 16.4+
 			webview.SetValueForKey(NSObject.FromObject(DeveloperTools.Enabled), new NSString("inspectable"));
-
+#endif
 			VirtualView.BlazorWebViewInitialized(new BlazorWebViewInitializedEventArgs
 			{
 				WebView = webview

--- a/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
+++ b/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
@@ -79,6 +79,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 				Configuration = config
 			});
 
+			// Legacy Developer Extras setting.
 			config.Preferences.SetValueForKey(NSObject.FromObject(DeveloperTools.Enabled), new NSString("developerExtrasEnabled"));
 
 			config.UserContentController.AddScriptMessageHandler(new WebViewScriptMessageHandler(MessageReceived), "webwindowinterop");
@@ -93,6 +94,9 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 				BackgroundColor = UIColor.Clear,
 				AutosizesSubviews = true
 			};
+
+			// Enable Developer Extras for Catalyst/iOS builds for 16.4+
+			webview.SetValueForKey(NSObject.FromObject(DeveloperTools.Enabled), new NSString("inspectable"));
 
 			VirtualView.BlazorWebViewInitialized(new BlazorWebViewInitializedEventArgs
 			{

--- a/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
+++ b/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
@@ -86,8 +86,10 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 			config.UserContentController.AddUserScript(new WKUserScript(
 				new NSString(BlazorInitScript), WKUserScriptInjectionTime.AtDocumentEnd, true));
 
+#if MACCATALYST13_3_OR_GREATER || IOS16_1_OR_GREATER
 			// iOS WKWebView doesn't allow handling 'http'/'https' schemes, so we use the fake 'app' scheme
 			config.SetUrlSchemeHandler(new SchemeHandler(this), urlScheme: "app");
+#endif
 
 			var webview = new WKWebView(RectangleF.Empty, config)
 			{


### PR DESCRIPTION
### Description of Change

Adds the "Inspectable" flag to the WKWebView implementation of BlazorWebView, this should allow the Safari Dev Tools to work again.

<img width="1185" alt="スクリーンショット 2023-04-17 18 29 44" src="https://user-images.githubusercontent.com/898335/232444265-6fcd5a65-e6e1-46cc-b424-56087327b06c.png">

<img width="805" alt="スクリーンショット 2023-04-17 18 30 19" src="https://user-images.githubusercontent.com/898335/232444403-f613928d-9751-4e22-a8e1-724f095b08b6.png">

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #14590
fixes #14835

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
