### PR TITLE
Optimize iOS selection synchronization

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/iOS/ListSource.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ListSource.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		{
 			for (int n = 0; n < _itemsSource.Count; n++)
 			{
-				if (_itemsSource[n] == item)
+				if (Equals(_itemsSource[n], item))
 				{
 					return NSIndexPath.Create(0, n);
 				}

--- a/src/Controls/src/Core/Handlers/Items/iOS/ObservableGroupedSource.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ObservableGroupedSource.cs
@@ -342,7 +342,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 					var index = 0;
 					while (enumerator.MoveNext())
 					{
-						if (enumerator.Current == item)
+						if (Equals(enumerator.Current, item))
 						{
 							return index;
 						}

--- a/src/Controls/src/Core/Handlers/Items/iOS/ObservableItemsSource.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ObservableItemsSource.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		{
 			for (int n = 0; n < Count; n++)
 			{
-				if (this[n] == item)
+				if (Equals(this[n], item))
 				{
 					return NSIndexPath.Create(_section, n);
 				}
@@ -281,7 +281,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			int count = 0;
 			foreach (var i in _itemsSource)
 			{
-				if (i == item)
+				if (Equals(i, item))
 					return count;
 				count++;
 			}

--- a/src/Controls/src/Core/Handlers/Items/iOS/SelectableItemsViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/SelectableItemsViewController.cs
@@ -1,6 +1,7 @@
 #nullable disable
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Foundation;
 using ObjCRuntime;
 using UIKit;
@@ -145,15 +146,19 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		void SynchronizePlatformSelectionWithSelectedItems()
 		{
-			var selectedItems = ItemsView.SelectedItems;
+			var selectedItems = ItemsView.SelectedItems.ToHashSet();
 			var selectedIndexPaths = CollectionView.GetIndexPathsForSelectedItems();
 
 			foreach (var path in selectedIndexPaths)
 			{
 				var itemAtPath = GetItemAtIndex(path);
-				if (ShouldNotBeSelected(itemAtPath, selectedItems))
+				if (!selectedItems.Contains(itemAtPath))
 				{
 					CollectionView.DeselectItem(path, true);
+				}
+				else
+				{
+					selectedItems.Remove(itemAtPath);
 				}
 			}
 
@@ -161,19 +166,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			{
 				SelectItem(item);
 			}
-		}
-
-		bool ShouldNotBeSelected(object item, IList<object> selectedItems)
-		{
-			for (int n = 0; n < selectedItems.Count; n++)
-			{
-				if (selectedItems[n] == item)
-				{
-					return false;
-				}
-			}
-
-			return true;
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change

Optimize iOS selection synchronization not to use O(n^2) algorithm and to respect GetHashCode/Equals overrides instead of relying on reference equality.

### Issues Fixed

Contributes to #14535
