### PR TITLE
[iOS] Clear BindingContext when cell is queued for reuse

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewDelegator.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewDelegator.cs
@@ -120,9 +120,9 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				// 	templatedCell.Unbind();
 
 				var itemsSource = ViewController?.ItemsSource;
-				if (itemsSource == null ||
+				if (itemsSource is null ||
 					!itemsSource.IsIndexPathValid(indexPath) ||
-					itemsSource[indexPath] != bindingContext)
+					itemsSource[indexPath] is not bindingContext)
 				{
 					templatedCell.Unbind();
 				}

--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewDelegator.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewDelegator.cs
@@ -122,7 +122,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				var itemsSource = ViewController?.ItemsSource;
 				if (itemsSource is null ||
 					!itemsSource.IsIndexPathValid(indexPath) ||
-					itemsSource[indexPath] is not bindingContext)
+					!Equals(itemsSource[indexPath], bindingContext))
 				{
 					templatedCell.Unbind();
 				}

--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewDelegator.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewDelegator.cs
@@ -114,10 +114,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				// We want to unbind a cell that is no longer present in the items source. Unfortunately
 				// it's too expensive to check directly, so let's check that the current binding context
 				// matches the item at a given position.
-				//
-				//var itemIndex = ViewController?.ItemsSource.GetIndexForItem(bindingContext);
-				//if (itemIndex.Item == -1)
-				// 	templatedCell.Unbind();
 
 				var itemsSource = ViewController?.ItemsSource;
 				if (itemsSource is null ||

--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewDelegator.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewDelegator.cs
@@ -108,6 +108,26 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		public override void CellDisplayingEnded(UICollectionView collectionView, UICollectionViewCell cell, NSIndexPath indexPath)
 		{
+			if (cell is TemplatedCell templatedCell &&
+				(templatedCell.PlatformHandler?.VirtualView as View)?.BindingContext is object bindingContext)
+			{
+				// We want to unbind a cell that is no longer present in the items source. Unfortunately
+				// it's too expensive to check directly, so let's check that the current binding context
+				// matches the item at a given position.
+				//
+				//var itemIndex = ViewController?.ItemsSource.GetIndexForItem(bindingContext);
+				//if (itemIndex.Item == -1)
+				// 	templatedCell.Unbind();
+
+				var itemsSource = ViewController?.ItemsSource;
+				if (itemsSource == null ||
+					!itemsSource.IsIndexPathValid(indexPath) ||
+					itemsSource[indexPath] != bindingContext)
+				{
+					templatedCell.Unbind();
+				}
+			}
+
 			if (ItemsViewLayout.ScrollDirection == UICollectionViewScrollDirection.Horizontal)
 			{
 				var actualWidth = collectionView.ContentSize.Width - collectionView.Bounds.Size.Width;

--- a/src/Controls/src/Core/Handlers/Items/iOS/TemplatedCell.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/TemplatedCell.cs
@@ -115,6 +115,15 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			PlatformHandler.VirtualView.Arrange(rectangle);
 			_size = rectangle.Size;
 		}
+		
+		public override void PrepareForReuse()
+		{
+			if (PlatformHandler?.VirtualView is View view)
+			{
+				view.BindingContext = null;
+			}
+			base.PrepareForReuse();
+		}
 
 		public void Bind(DataTemplate template, object bindingContext, ItemsView itemsView)
 		{

--- a/src/Controls/src/Core/Handlers/Items/iOS/TemplatedCell.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/TemplatedCell.cs
@@ -58,6 +58,15 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			ConstrainedDimension = default;
 		}
 
+		public void Unbind()
+		{
+			if (PlatformHandler?.VirtualView is View view)
+			{
+				view.MeasureInvalidated -= MeasureInvalidated;
+				view.BindingContext = null;
+			}
+		}
+
 		public override UICollectionViewLayoutAttributes PreferredLayoutAttributesFittingAttributes(
 			UICollectionViewLayoutAttributes layoutAttributes)
 		{
@@ -118,11 +127,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		public override void PrepareForReuse()
 		{
-			if (PlatformHandler?.VirtualView is View view)
-			{
-				view.MeasureInvalidated -= MeasureInvalidated;
-				view.BindingContext = null;
-			}
+			Unbind();
 			base.PrepareForReuse();
 		}
 

--- a/src/Controls/src/Core/Handlers/Items/iOS/TemplatedCell.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/TemplatedCell.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			PlatformHandler.VirtualView.Arrange(rectangle);
 			_size = rectangle.Size;
 		}
-		
+
 		public override void PrepareForReuse()
 		{
 			if (PlatformHandler?.VirtualView is View view)

--- a/src/Controls/src/Core/Handlers/Items/iOS/TemplatedCell.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/TemplatedCell.cs
@@ -120,6 +120,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		{
 			if (PlatformHandler?.VirtualView is View view)
 			{
+				view.MeasureInvalidated -= MeasureInvalidated;
 				view.BindingContext = null;
 			}
 			base.PrepareForReuse();
@@ -166,18 +167,10 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				// Same template
 				if (oldElement != null)
 				{
-					if (oldElement.BindingContext == null || !(oldElement.BindingContext.Equals(bindingContext)))
-					{
-						// If the data is different, update it
+					oldElement.BindingContext = bindingContext;
+					oldElement.MeasureInvalidated += MeasureInvalidated;
 
-						// Unhook the MeasureInvalidated handler, otherwise it'll fire for every invalidation during the 
-						// BindingContext change
-						oldElement.MeasureInvalidated -= MeasureInvalidated;
-						oldElement.BindingContext = bindingContext;
-						oldElement.MeasureInvalidated += MeasureInvalidated;
-
-						UpdateCellSize();
-					}
+					UpdateCellSize();
 				}
 			}
 

--- a/src/Controls/src/Core/Handlers/Items/iOS/TemplatedCell.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/TemplatedCell.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			ConstrainedDimension = default;
 		}
 
-		public void Unbind()
+		internal void Unbind()
 		{
 			if (PlatformHandler?.VirtualView is View view)
 			{

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -88,7 +88,6 @@ virtual Microsoft.Maui.Controls.DragStartingEventArgs.GetPosition(Microsoft.Maui
 virtual Microsoft.Maui.Controls.DropEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
 *REMOVED*override Microsoft.Maui.Controls.RefreshView.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 Microsoft.Maui.Controls.Border.~Border() -> void
-Microsoft.Maui.Controls.Handlers.Items.TemplatedCell.Unbind() -> void
 Microsoft.Maui.Controls.IWindowCreator
 Microsoft.Maui.Controls.IWindowCreator.CreateWindow(Microsoft.Maui.Controls.Application! app, Microsoft.Maui.IActivationState? activationState) -> Microsoft.Maui.Controls.Window!
 Microsoft.Maui.Controls.Handlers.Compatibility.PhoneFlyoutPageRenderer.FlyoutOverlapsDetailsInPopoverMode.get -> bool

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -88,6 +88,7 @@ virtual Microsoft.Maui.Controls.DragStartingEventArgs.GetPosition(Microsoft.Maui
 virtual Microsoft.Maui.Controls.DropEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
 *REMOVED*override Microsoft.Maui.Controls.RefreshView.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 Microsoft.Maui.Controls.Border.~Border() -> void
+Microsoft.Maui.Controls.Handlers.Items.TemplatedCell.Unbind() -> void
 Microsoft.Maui.Controls.IWindowCreator
 Microsoft.Maui.Controls.IWindowCreator.CreateWindow(Microsoft.Maui.Controls.Application! app, Microsoft.Maui.IActivationState? activationState) -> Microsoft.Maui.Controls.Window!
 Microsoft.Maui.Controls.Handlers.Compatibility.PhoneFlyoutPageRenderer.FlyoutOverlapsDetailsInPopoverMode.get -> bool

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -106,6 +106,7 @@ Microsoft.Maui.Controls.Region.Equals(Microsoft.Maui.Controls.Region other) -> b
 Microsoft.Maui.Controls.Shapes.Matrix.Equals(Microsoft.Maui.Controls.Shapes.Matrix other) -> bool
 Microsoft.Maui.Controls.Shapes.Shape.~Shape() -> void
 Microsoft.Maui.Controls.VisualElement.~VisualElement() -> void
+override Microsoft.Maui.Controls.Handlers.Items.TemplatedCell.PrepareForReuse() -> void
 override Microsoft.Maui.Controls.Handlers.Compatibility.PhoneFlyoutPageRenderer.ViewWillLayoutSubviews() -> void
 override Microsoft.Maui.Controls.LayoutOptions.GetHashCode() -> int
 override Microsoft.Maui.Controls.Platform.Compatibility.ShellPageRendererTracker.TitleViewContainer.LayoutSubviews() -> void

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -87,7 +87,6 @@ virtual Microsoft.Maui.Controls.DragStartingEventArgs.GetPosition(Microsoft.Maui
 virtual Microsoft.Maui.Controls.DropEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
 *REMOVED*override Microsoft.Maui.Controls.RefreshView.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 Microsoft.Maui.Controls.Border.~Border() -> void
-Microsoft.Maui.Controls.Handlers.Items.TemplatedCell.Unbind() -> void
 Microsoft.Maui.Controls.IWindowCreator
 Microsoft.Maui.Controls.IWindowCreator.CreateWindow(Microsoft.Maui.Controls.Application! app, Microsoft.Maui.IActivationState? activationState) -> Microsoft.Maui.Controls.Window!
 Microsoft.Maui.Controls.Handlers.Compatibility.PhoneFlyoutPageRenderer.FlyoutOverlapsDetailsInPopoverMode.get -> bool

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -105,6 +105,7 @@ Microsoft.Maui.Controls.Region.Equals(Microsoft.Maui.Controls.Region other) -> b
 Microsoft.Maui.Controls.Shapes.Matrix.Equals(Microsoft.Maui.Controls.Shapes.Matrix other) -> bool
 Microsoft.Maui.Controls.Shapes.Shape.~Shape() -> void
 Microsoft.Maui.Controls.VisualElement.~VisualElement() -> void
+override Microsoft.Maui.Controls.Handlers.Items.TemplatedCell.PrepareForReuse() -> void
 override Microsoft.Maui.Controls.Handlers.Compatibility.PhoneFlyoutPageRenderer.ViewWillLayoutSubviews() -> void
 override Microsoft.Maui.Controls.LayoutOptions.GetHashCode() -> int
 override Microsoft.Maui.Controls.Platform.Compatibility.ShellPageRendererTracker.TitleViewContainer.LayoutSubviews() -> void

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -87,6 +87,7 @@ virtual Microsoft.Maui.Controls.DragStartingEventArgs.GetPosition(Microsoft.Maui
 virtual Microsoft.Maui.Controls.DropEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
 *REMOVED*override Microsoft.Maui.Controls.RefreshView.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 Microsoft.Maui.Controls.Border.~Border() -> void
+Microsoft.Maui.Controls.Handlers.Items.TemplatedCell.Unbind() -> void
 Microsoft.Maui.Controls.IWindowCreator
 Microsoft.Maui.Controls.IWindowCreator.CreateWindow(Microsoft.Maui.Controls.Application! app, Microsoft.Maui.IActivationState? activationState) -> Microsoft.Maui.Controls.Window!
 Microsoft.Maui.Controls.Handlers.Compatibility.PhoneFlyoutPageRenderer.FlyoutOverlapsDetailsInPopoverMode.get -> bool

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.cs
@@ -430,6 +430,8 @@ namespace Microsoft.Maui.DeviceTests
 				var savedItems = data.ToArray();
 				data.Clear();
 
+				await Task.Delay(100);
+
 				// Check that all logical children have no binding context
 				foreach (var logicalChild in logicalChildren)
 				{
@@ -441,6 +443,8 @@ namespace Microsoft.Maui.DeviceTests
 				{
 					data.Add(savedItem);
 				}
+
+				await Task.Delay(100);
 
 				// Check that the right number of logical children have binding context again
 				int boundChildren = 0;

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.cs
@@ -406,7 +406,7 @@ namespace Microsoft.Maui.DeviceTests
 			IReadOnlyList<Element> logicalChildren = null;
 			var collectionView = new CollectionView
 			{
-				ItemTemplate = new DataTemplate(() => new Label() {  HeightRequest = 30, WidthRequest = 200 }),
+				ItemTemplate = new DataTemplate(() => new Label() { HeightRequest = 30, WidthRequest = 200 }),
 				WidthRequest = 200,
 				HeightRequest = 200,
 			};

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.cs
@@ -427,20 +427,32 @@ namespace Microsoft.Maui.DeviceTests
 				Assert.True(logicalChildren.Count == 3);
 
 				// Clear collection
+				var savedItems = data.ToArray();
 				data.Clear();
 
-				await Task.Delay(100);
+				// Check that all logical children have no binding context
+				foreach (var logicalChild in logicalChildren)
+				{
+					Assert.Null(logicalChild.BindingContext);
+				}
+
+				// Re-add the old children
+				foreach (var savedItem in savedItems)
+				{
+					data.Add(savedItem);
+				}
+
+				// Check that the right number of logical children have binding context again
+				int boundChildren = 0;
+				foreach (var logicalChild in logicalChildren)
+				{
+					if (logicalChild.BindingContext is not null)
+					{
+						boundChildren++;
+					}
+				}
+				Assert.Equal(3, boundChildren);
 			});
-
-			await Task.Yield();
-
-			Assert.NotNull(logicalChildren);
-			Assert.True(logicalChildren.Count <= 3, "LogicalChildren should not grow in size!");
-
-			foreach (var logicalChild in logicalChildren)
-			{
-				Assert.Null(logicalChild.BindingContext);
-			}
 		}
 
 		record MyRecord(string Name);


### PR DESCRIPTION
### Description of Change

This avoid holding references to objects that were already removed. Previously `UICollectionView` would cache the cells for reuse and hold the references to bound objects for undefined period of time.