### PR TITLE
Set menuItem show action back to Never

### DIFF
--- a/src/Controls/src/Core/Platform/Android/Extensions/ToolbarExtensions.cs
+++ b/src/Controls/src/Core/Platform/Android/Extensions/ToolbarExtensions.cs
@@ -321,6 +321,8 @@ namespace Microsoft.Maui.Controls.Platform
 
 			if (item.Order != ToolbarItemOrder.Secondary)
 				menuitem.SetShowAsAction(ShowAsAction.Always);
+			else
+				menuitem.SetShowAsAction(ShowAsAction.Never);
 
 			menuitem.SetOnMenuItemClickListener(new GenericMenuClickListener(((IMenuItemController)item).Activate));
 

--- a/src/Controls/tests/DeviceTests/ControlsHandlerTestBase.Android.cs
+++ b/src/Controls/tests/DeviceTests/ControlsHandlerTestBase.Android.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Maui.DeviceTests
 				ToolbarItem toolbarItem = toolbarItems[i];
 				var primaryCommand = menu.GetItem(i);
 				Assert.Equal(toolbarItem.Text, $"{primaryCommand.TitleFormatted}");
-								
+
 				if (primaryCommand is MenuItemImpl menuItemImpl)
 				{
 					if (toolbarItem.Order != ToolbarItemOrder.Secondary)

--- a/src/Controls/tests/DeviceTests/ControlsHandlerTestBase.Android.cs
+++ b/src/Controls/tests/DeviceTests/ControlsHandlerTestBase.Android.cs
@@ -5,6 +5,7 @@ using Android.Graphics.Drawables;
 using Android.OS;
 using AndroidX.AppCompat.App;
 using AndroidX.AppCompat.Graphics.Drawable;
+using AndroidX.AppCompat.View.Menu;
 using AndroidX.AppCompat.Widget;
 using AndroidX.CoordinatorLayout.Widget;
 using AndroidX.Fragment.App;
@@ -88,6 +89,22 @@ namespace Microsoft.Maui.DeviceTests
 				ToolbarItem toolbarItem = toolbarItems[i];
 				var primaryCommand = menu.GetItem(i);
 				Assert.Equal(toolbarItem.Text, $"{primaryCommand.TitleFormatted}");
+								
+				if (primaryCommand is MenuItemImpl menuItemImpl)
+				{
+					if (toolbarItem.Order != ToolbarItemOrder.Secondary)
+					{
+						Assert.True(menuItemImpl.RequiresActionButton(), "Secondary Menu Item `SetShowAsAction` not set correctly");
+					}
+					else
+					{
+						Assert.False(menuItemImpl.RequiresActionButton(), "Primary Menu Item `SetShowAsAction` not set correctly");
+					}
+				}
+				else
+				{
+					throw new Exception($"MenuItem type is not MenuItemImpl. Please rework test to work with {primaryCommand}");
+				}
 			}
 
 			return true;

--- a/src/Controls/tests/DeviceTests/ControlsHandlerTestBase.Windows.cs
+++ b/src/Controls/tests/DeviceTests/ControlsHandlerTestBase.Windows.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui;
@@ -10,6 +12,7 @@ using Microsoft.Maui.Platform;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Automation.Peers;
 using Microsoft.UI.Xaml.Controls;
+using Windows.Foundation.Collections;
 using Xunit;
 using NativeAutomationProperties = Microsoft.UI.Xaml.Automation.AutomationProperties;
 using WAppBarButton = Microsoft.UI.Xaml.Controls.AppBarButton;
@@ -135,16 +138,31 @@ namespace Microsoft.Maui.DeviceTests
 			IElementHandler handler,
 			params ToolbarItem[] toolbarItems)
 		{
+			var primaryToolbarItems = toolbarItems.Where(x => x.Order != ToolbarItemOrder.Secondary).ToArray();
+			var secondaryToolbarItems = toolbarItems.Where(x => x.Order == ToolbarItemOrder.Secondary).ToArray();
+
 			var navView = (RootNavigationView)GetMauiNavigationView(handler.MauiContext);
 			MauiToolbar windowHeader = (MauiToolbar)navView.Header;
-			Assert.NotNull(windowHeader?.CommandBar?.PrimaryCommands);
 
-			Assert.Equal(toolbarItems.Length, windowHeader.CommandBar.PrimaryCommands.Count);
-			for (var i = 0; i < toolbarItems.Length; i++)
+			ValidateCommandBarCommands(windowHeader?.CommandBar?.PrimaryCommands, primaryToolbarItems);
+			ValidateCommandBarCommands(windowHeader?.CommandBar?.SecondaryCommands, secondaryToolbarItems);
+
+			void ValidateCommandBarCommands(IObservableVector<ICommandBarElement> commands, ToolbarItem[] orderToolbarItems)
 			{
-				ToolbarItem toolbarItem = toolbarItems[i];
-				var primaryCommand = ((WAppBarButton)windowHeader.CommandBar.PrimaryCommands[i]);
-				Assert.Equal(toolbarItem, primaryCommand.DataContext);
+				if (orderToolbarItems.Length == 0)
+				{
+					Assert.True(commands is null || commands.Count == 0);
+					return;
+				}
+
+				Assert.NotNull(commands);
+				Assert.Equal(orderToolbarItems.Length, commands.Count);
+				for (var i = 0; i < toolbarItems.Length; i++)
+				{
+					ToolbarItem toolbarItem = orderToolbarItems[i];
+					var command = ((WAppBarButton)commands[i]);
+					Assert.Equal(toolbarItem, command.DataContext);
+				}
 			}
 
 			return true;

--- a/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.cs
@@ -157,45 +157,6 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
-#if !IOS && !MACCATALYST
-		[Fact(DisplayName = "Toolbar Items Map Correctly")]
-		public async Task ToolbarItemsMapCorrectly()
-		{
-			SetupBuilder();
-			var toolbarItem = new ToolbarItem() { Text = "Toolbar Item 1" };
-			var navPage = new NavigationPage(new ContentPage()
-			{
-				ToolbarItems =
-				{
-					toolbarItem
-				}
-			});
-
-			await CreateHandlerAndAddToWindow<WindowHandlerStub>(new Window(navPage), (handler) =>
-			{
-				ToolbarItemsMatch(handler, toolbarItem);
-				return Task.CompletedTask;
-			});
-		}
-#endif
-
-		[Fact(DisplayName = "Toolbar Title")]
-		public async Task ToolbarTitle()
-		{
-			SetupBuilder();
-			var navPage = new NavigationPage(new ContentPage()
-			{
-				Title = "Page Title"
-			});
-
-			await CreateHandlerAndAddToWindow<WindowHandlerStub>(new Window(navPage), (handler) =>
-			{
-				string title = GetToolbarTitle(handler);
-				Assert.Equal("Page Title", title);
-				return Task.CompletedTask;
-			});
-		}
-
 		[Fact(DisplayName = "Insert Page Before Root Page and then PopToRoot")]
 		public async Task InsertPageBeforeRootPageAndThenPopToRoot()
 		{

--- a/src/Controls/tests/DeviceTests/Elements/Toolbar/ToolbarTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Toolbar/ToolbarTests.cs
@@ -16,6 +16,7 @@ using Xunit.Sdk;
 
 #if IOS || MACCATALYST
 using FlyoutViewHandler = Microsoft.Maui.Controls.Handlers.Compatibility.PhoneFlyoutPageRenderer;
+using NavigationViewHandler = Microsoft.Maui.Controls.Handlers.Compatibility.NavigationRenderer;
 #endif
 
 namespace Microsoft.Maui.DeviceTests

--- a/src/Controls/tests/DeviceTests/Elements/Toolbar/ToolbarTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Toolbar/ToolbarTests.cs
@@ -42,6 +42,79 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
+
+#if !IOS && !MACCATALYST
+		[Fact(DisplayName = "Toolbar Items Map Correctly")]
+		public async Task ToolbarItemsMapCorrectly()
+		{
+			SetupBuilder();
+			var toolbarItem = new ToolbarItem() { Text = "Toolbar Item 1" };
+			var navPage = new NavigationPage(new ContentPage()
+			{
+				ToolbarItems =
+				{
+					toolbarItem
+				}
+			});
+
+			await CreateHandlerAndAddToWindow<WindowHandlerStub>(new Window(navPage), (handler) =>
+			{
+				ToolbarItemsMatch(handler, toolbarItem);
+				return Task.CompletedTask;
+			});
+		}
+
+		[Fact(DisplayName = "Toolbar Items Order Updates Correctly After Navigation")]
+		public async Task ToolbarItemsOrderUpdatesCorrectlyAfterNavigation()
+		{
+			SetupBuilder();
+			var toolbarItemFirstPage = new ToolbarItem() { Text = "Toolbar Item 1" };
+			var toolbarItemSecondPage = new ToolbarItem() { Text = "Toolbar Item Second Page", Order = ToolbarItemOrder.Secondary };
+
+			var navPage = new NavigationPage(new ContentPage()
+			{
+				ToolbarItems =
+				{
+					toolbarItemFirstPage
+				}
+			});
+
+			await CreateHandlerAndAddToWindow<WindowHandlerStub>(new Window(navPage), async (handler) =>
+			{
+				await navPage.PushAsync(new ContentPage()
+				{
+					ToolbarItems =
+					{
+						toolbarItemSecondPage
+					}
+				});
+
+				ToolbarItemsMatch(handler, GetExpectedToolbarItems(navPage));
+				ToolbarItemsMatch(handler, toolbarItemSecondPage);
+				await navPage.PopAsync();
+				ToolbarItemsMatch(handler, GetExpectedToolbarItems(navPage));
+				ToolbarItemsMatch(handler, toolbarItemFirstPage);
+			});
+		}
+#endif
+
+		[Fact(DisplayName = "Toolbar Title")]
+		public async Task ToolbarTitle()
+		{
+			SetupBuilder();
+			var navPage = new NavigationPage(new ContentPage()
+			{
+				Title = "Page Title"
+			});
+
+			await CreateHandlerAndAddToWindow<WindowHandlerStub>(new Window(navPage), (handler) =>
+			{
+				string title = GetToolbarTitle(handler);
+				Assert.Equal("Page Title", title);
+				return Task.CompletedTask;
+			});
+		}
+
 #if !IOS && !MACCATALYST
 		[Theory(DisplayName = "Toolbar Recreates With New MauiContext")]
 		[InlineData(typeof(FlyoutPage))]
@@ -104,5 +177,10 @@ namespace Microsoft.Maui.DeviceTests
 			}, context2);
 		}
 #endif
+
+		ToolbarItem[] GetExpectedToolbarItems(NavigationPage navPage)
+		{
+			return ((Toolbar)(navPage.Window as IToolbarElement).Toolbar).ToolbarItems.ToArray();
+		}
 	}
 }


### PR DESCRIPTION
### Description of Change

Prior to MAUI whenever the `ToolbarItems` changed we'd remove and readd all of them. This caused an awkward reshuffling effect with MAUI and the `MaterialToolbar`. So, we need to add code to switch `MenuItems` back to `Primary` when navigating. 

### Issues Fixed
Fixes #14617
