### PR TITLE
[xamlc] enable for $(Configuration) names like ReleaseProd

### DIFF
--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
@@ -148,7 +148,7 @@
 		Condition=" '$(DesignTimeBuild)' != 'True' AND '@(MauiXaml)' != ''">
 	    <PropertyGroup>
 		<_MauiXamlCValidateOnly>$(MauiXamlCValidateOnly)</_MauiXamlCValidateOnly>
-		<_MauiXamlCValidateOnly Condition="'$(Configuration)' != 'Release' AND '$(_MauiForceXamlCForDebug)' != 'True'">True</_MauiXamlCValidateOnly>
+		<_MauiXamlCValidateOnly Condition="'$(Configuration)' == 'Debug' AND '$(_MauiForceXamlCForDebug)' != 'True'">True</_MauiXamlCValidateOnly>
 		<_MauiXamlCValidateOnly Condition="'$(BuildingForLiveUnitTesting)' == 'True' ">True</_MauiXamlCValidateOnly>
 	    </PropertyGroup>
 		<XamlCTask


### PR DESCRIPTION
Context: https://github.com/dotnet/maui/issues/14591#issuecomment-1511380991

In testing a customer project, I found that using a non-standard `$(Configuration)` name like `ReleaseProd` disables XamlC.

In a30e2435, we added a check for `$(Configuration)` to be exactly `Release`. Let's invert this check to be `!= Debug`. I also added a test to verify this works.

This seems like a better default for customers, as it seems a lot worse for a `ReleaseProd` build to have XamlC off than a `DebugProd` build to accidentally have XamlC on.

Asking around, but the .NET SDK doesn't appear to do anything special for `$(Optimize)` and `$(DebugSymbols)` related to `$(Configuration)`:

https://github.com/dotnet/sdk/blob/7d23e9d3e4aad58a5b497d8d91a50ffdf148b238/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.props#L46-L54
