### PR TITLE
Treat */Auto spans as resolvable finite measures rather than infinite 

### DIFF
--- a/src/Core/src/Layouts/GridLayoutManager.cs
+++ b/src/Core/src/Layouts/GridLayoutManager.cs
@@ -388,10 +388,7 @@ namespace Microsoft.Maui.Layouts
 						continue;
 					}
 
-					var measureWidth = cell.MeasureWidth;
-					var measureHeight = cell.MeasureHeight;
-
-					var measure = MeasureCell(cell, measureWidth, measureHeight);
+					var measure = MeasureCell(cell, cell.MeasureWidth, cell.MeasureHeight);
 
 					if (treatCellWidthAsAuto)
 					{

--- a/src/Core/src/Layouts/GridLayoutManager.cs
+++ b/src/Core/src/Layouts/GridLayoutManager.cs
@@ -47,6 +47,8 @@ namespace Microsoft.Maui.Layouts
 
 			var actual = new Size(_gridStructure.MeasuredGridWidth(), _gridStructure.MeasuredGridHeight());
 
+			_gridStructure = null;
+
 			return actual.AdjustForFill(bounds, Grid);
 		}
 
@@ -336,7 +338,7 @@ namespace Microsoft.Maui.Layouts
 
 			void MeasureCells()
 			{
-				KnownMeasurePass();
+				FirstMeasurePass();
 
 				if (!_isStarWidthPrecomputable)
 				{
@@ -367,7 +369,7 @@ namespace Microsoft.Maui.Layouts
 				return result;
 			}
 
-			void KnownMeasurePass()
+			void FirstMeasurePass()
 			{
 				for (int n = 0; n < _cells.Length; n++)
 				{
@@ -380,19 +382,14 @@ namespace Microsoft.Maui.Layouts
 					{
 						// We still have some unknown measure constraints (* rows/columns that need to have
 						// the Auto measurements settled before we can measure them). So mark this cell for the 
-						// second pass, once we know the constraints.
+						// second pass, to be done once we know the constraints.
 						cell.NeedsSecondPass = true;
 
-						if (!(treatCellHeightAsAuto || treatCellWidthAsAuto))
-						{
-							// If neither span of this cell includes _any_ Auto values, then there's no reason
-							// to measure it at all during this pass; we can skip it for now
-							continue;
-						}
+						continue;
 					}
 
-					var measureWidth = double.IsNaN(cell.MeasureWidth) ? double.PositiveInfinity : cell.MeasureWidth;
-					var measureHeight = double.IsNaN(cell.MeasureHeight) ? double.PositiveInfinity : cell.MeasureHeight;
+					var measureWidth = cell.MeasureWidth;
+					var measureHeight = cell.MeasureHeight;
 
 					var measure = MeasureCell(cell, measureWidth, measureHeight);
 
@@ -400,10 +397,7 @@ namespace Microsoft.Maui.Layouts
 					{
 						if (cell.ColumnSpan == 1)
 						{
-							if (!cell.NeedsSecondPass)
-							{
-								_columns[cell.Column].Update(measure.Width);
-							}
+							_columns[cell.Column].Update(measure.Width);
 						}
 						else
 						{
@@ -415,10 +409,7 @@ namespace Microsoft.Maui.Layouts
 					{
 						if (cell.RowSpan == 1)
 						{
-							if (!cell.NeedsSecondPass)
-							{
-								_rows[cell.Row].Update(measure.Height);
-							}
+							_rows[cell.Row].Update(measure.Height);
 						}
 						else
 						{
@@ -440,7 +431,7 @@ namespace Microsoft.Maui.Layouts
 					double width = 0;
 					double height = 0;
 
-					if (cell.IsRowSpanAuto)
+					if (double.IsInfinity(cell.MeasureHeight))
 					{
 						height = double.PositiveInfinity;
 					}
@@ -452,7 +443,7 @@ namespace Microsoft.Maui.Layouts
 						}
 					}
 
-					if (cell.IsColumnSpanAuto)
+					if (double.IsInfinity(cell.MeasureWidth))
 					{
 						width = double.PositiveInfinity;
 					}
@@ -603,6 +594,14 @@ namespace Microsoft.Maui.Layouts
 
 			void ResolveStars(Definition[] defs, double availableSpace, Func<Cell, bool> cellCheck, Func<Size, double> dimension)
 			{
+				if (availableSpace < 0)
+				{
+					// This can happen if an Auto-measured part of a span is larger than the Grid's constraint;
+					// There's a negative amount of space left for the Star values. Just bail, the
+					// Star values are already zero and they can't get any smaller.
+					return;
+				}
+
 				// Count up the total weight of star columns (e.g., "*, 3*, *" == 5)
 
 				var starCount = 0.0;
@@ -1032,34 +1031,24 @@ namespace Microsoft.Maui.Layouts
 
 			bool TreatCellWidthAsAuto(Cell cell)
 			{
-				if (cell.IsColumnSpanAuto)
-				{
-					return true;
-				}
-
-				if (double.IsInfinity(_gridWidthConstraint) && cell.IsColumnSpanStar)
+				if (cell.IsColumnSpanStar)
 				{
 					// Because the Grid isn't horizontally constrained, we treat * columns as Auto 
-					return true;
+					return double.IsInfinity(_gridWidthConstraint);
 				}
 
-				return false;
+				return cell.IsColumnSpanAuto;
 			}
 
 			bool TreatCellHeightAsAuto(Cell cell)
 			{
-				if (cell.IsRowSpanAuto)
-				{
-					return true;
-				}
-
-				if (double.IsInfinity(_gridHeightConstraint) && cell.IsRowSpanStar)
+				if (cell.IsRowSpanStar)
 				{
 					// Because the Grid isn't vertically constrained, we treat * rows  as Auto 
-					return true;
+					return double.IsInfinity(_gridHeightConstraint);
 				}
 
-				return false;
+				return cell.IsRowSpanAuto;
 			}
 		}
 

--- a/src/Core/tests/UnitTests/Layouts/GridLayoutManagerTests.cs
+++ b/src/Core/tests/UnitTests/Layouts/GridLayoutManagerTests.cs
@@ -2547,5 +2547,49 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			// We expect the Grid to group to accommodate the full width of view1 at this height
 			Assert.Equal(constrainedWidth, measure.Width);
 		}
+
+		[Theory]
+		[InlineData(20, 100)]
+		[InlineData(200, 100)]
+		public void AutoStarColumnSpanMeasureIsSumOfAutoAndStar(double determinantViewWidth, double widthConstraint) 
+		{
+			var grid = CreateGridLayout(columns: "Auto, *", rows: "Auto, Auto");
+			var view0 = CreateTestView(new Size(20, 20));
+			var view1 = CreateTestView(new Size(determinantViewWidth, 20));
+			SubstituteChildren(grid, view0, view1);
+			SetLocation(grid, view0, row: 0, col: 0, colSpan: 2);
+			SetLocation(grid, view1, row: 1, col: 0, colSpan: 1);
+
+			var measure = MeasureAndArrange(grid, widthConstraint: widthConstraint, heightConstraint: 100);
+
+			// view1 should make column 0 at least `determinantViewWidth` units wide
+			// So view0 should be getting measured at _at least_ that value; if the widthConstraint is larger
+			// than that, the * should bump the measure value up to match the widthConstraint
+			var expectedMeasureWidth = Math.Max(determinantViewWidth, widthConstraint);
+
+			view0.Received().Measure(Arg.Is<double>(expectedMeasureWidth), Arg.Any<double>());
+		}
+
+		[Theory]
+		[InlineData(20, 100)]
+		[InlineData(200, 100)]
+		public void AutoStarRowSpanMeasureIsSumOfAutoAndStar(double determinantViewHeight, double heightConstraint)
+		{
+			var grid = CreateGridLayout(columns: "Auto, Auto", rows: "Auto, *");
+			var view0 = CreateTestView(new Size(20, 20));
+			var view1 = CreateTestView(new Size(20, determinantViewHeight));
+			SubstituteChildren(grid, view0, view1);
+			SetLocation(grid, view0, row: 0, col: 0, rowSpan: 2);
+			SetLocation(grid, view1, row: 0, col: 1, rowSpan: 1);
+
+			var measure = MeasureAndArrange(grid, widthConstraint: 100, heightConstraint: heightConstraint);
+
+			// view1 should make row 0 at least `determinantViewHeight` units tall
+			// So view0 should be getting measured at _at least_ that value; if the heightConstraint is larger
+			// than that, the * should bump the measure value up to match the heightConstraint
+			var expectedMeasureHeight = Math.Max(determinantViewHeight, heightConstraint);
+
+			view0.Received().Measure(Arg.Any<double>(), Arg.Is<double>(expectedMeasureHeight));
+		}
 	}
 }

--- a/src/Core/tests/UnitTests/Layouts/GridLayoutManagerTests.cs
+++ b/src/Core/tests/UnitTests/Layouts/GridLayoutManagerTests.cs
@@ -2551,7 +2551,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 		[Theory]
 		[InlineData(20, 100)]
 		[InlineData(200, 100)]
-		public void AutoStarColumnSpanMeasureIsSumOfAutoAndStar(double determinantViewWidth, double widthConstraint) 
+		public void AutoStarColumnSpanMeasureIsSumOfAutoAndStar(double determinantViewWidth, double widthConstraint)
 		{
 			var grid = CreateGridLayout(columns: "Auto, *", rows: "Auto, Auto");
 			var view0 = CreateTestView(new Size(20, 20));


### PR DESCRIPTION
### Description of Change

When revising the Grid to handle more `*` column/row cases as resolvable from the outset (rather than having to measure them multiple times), combination values of `Auto`/`*` were treated as requiring unconstrained measures (because of the `Auto` component). This causes a couple of problems - for one, it means that Labels spanning `Auto`/`*` column combinations are always measured as if they will be allowed infinite width; this means they will never wrap. For another, we see problems like #14537 where the native Windows layout system only sees unconstrained width measures and assumes that the native control's DesiredSize is correct even when the container's width expands. This results in a situation where expanding the container does not expand the content, even though we request that it lay out at a larger width.

These changes make the cross-platform Grid treat constrained `Auto`/`*` combinations as resolvable (the size the `Auto` value + the size of the `*` value, if any) to a finite size and measure accordingly, rather then treating those values as unconstrained. With tests to that effect.

### Issues Fixed

Fixes #14537