### PR TITLE
Fix InputTransparent for layouts

### DIFF
--- a/src/Controls/src/Core/HandlerImpl/Layout/Layout.Android.cs
+++ b/src/Controls/src/Core/HandlerImpl/Layout/Layout.Android.cs
@@ -18,15 +18,19 @@ namespace Microsoft.Maui.Controls
 
 		static void UpdateInputTransparent(IViewHandler handler, IView layout)
 		{
-			if (handler.PlatformView is LayoutViewGroup layoutViewGroup)
+			if (handler is ILayoutHandler layoutHandler && layout is Layout controlsLayout)
 			{
-				// Handle input transparent for this view
-				layoutViewGroup.InputTransparent = layout.InputTransparent;
-			}
+				if (layoutHandler.PlatformView is LayoutViewGroup layoutViewGroup)
+				{
+					// Handle input transparent for this view
+					layoutViewGroup.InputTransparent = layout.InputTransparent;
+				}
 
-			if (layout is Layout l)
+				controlsLayout.UpdateDescendantInputTransparent();
+			}
+			else
 			{
-				l.UpdateDescendantInputTransparent();
+				ControlsVisualElementMapper.UpdateProperty(handler, layout, nameof(IView.InputTransparent));
 			}
 		}
 	}

--- a/src/Controls/src/Core/HandlerImpl/Layout/Layout.Windows.cs
+++ b/src/Controls/src/Core/HandlerImpl/Layout/Layout.Windows.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Maui.Controls
 		{
 			if (handler is ILayoutHandler layoutHandler && layout is Layout controlsLayout)
 			{
-				layoutHandler.PlatformView.UpdateInputTransparent(handler, controlsLayout);
+				layoutHandler.PlatformView.UpdateInputTransparent(layoutHandler, controlsLayout);
 				controlsLayout.UpdateDescendantInputTransparent();
 			}
 			else

--- a/src/Controls/src/Core/HandlerImpl/Layout/Layout.Windows.cs
+++ b/src/Controls/src/Core/HandlerImpl/Layout/Layout.Windows.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Maui.Controls
 		{
 			if (handler is ILayoutHandler layoutHandler && layout is Layout controlsLayout)
 			{
-				layoutHandler.PlatformView.UpdateInputTransparent(layoutHandler, controlsLayout);
+				layoutHandler.PlatformView?.UpdateInputTransparent(layoutHandler, controlsLayout);
 				controlsLayout.UpdateDescendantInputTransparent();
 			}
 			else

--- a/src/Controls/src/Core/HandlerImpl/Layout/Layout.Windows.cs
+++ b/src/Controls/src/Core/HandlerImpl/Layout/Layout.Windows.cs
@@ -16,12 +16,14 @@ namespace Microsoft.Maui.Controls
 
 		static void UpdateInputTransparent(IViewHandler handler, IView layout)
 		{
-			if (handler.PlatformView is LayoutPanel lp && handler is ILayoutHandler lh && layout is Maui.ILayout iLayout)
-				lp.UpdateInputTransparent(lh, iLayout);
-
-			if (layout is Layout l)
+			if (handler is ILayoutHandler layoutHandler && layout is Layout controlsLayout)
 			{
-				l.UpdateDescendantInputTransparent();
+				layoutHandler.PlatformView.UpdateInputTransparent(handler, controlsLayout);
+				controlsLayout.UpdateDescendantInputTransparent();
+			}
+			else
+			{
+				ControlsVisualElementMapper.UpdateProperty(handler, layout, nameof(IView.InputTransparent));
 			}
 		}
 	}

--- a/src/Controls/src/Core/HandlerImpl/Layout/Layout.Windows.cs
+++ b/src/Controls/src/Core/HandlerImpl/Layout/Layout.Windows.cs
@@ -16,8 +16,8 @@ namespace Microsoft.Maui.Controls
 
 		static void UpdateInputTransparent(IViewHandler handler, IView layout)
 		{
-			if (handler.PlatformView is FrameworkElement fe)
-				fe.UpdateInputTransparent(handler, layout);
+			if (handler.PlatformView is LayoutPanel lp && handler is ILayoutHandler lh && layout is Maui.ILayout iLayout)
+				lp.UpdateInputTransparent(lh, iLayout);
 
 			if (layout is Layout l)
 			{

--- a/src/Controls/src/Core/HandlerImpl/Layout/Layout.iOS.cs
+++ b/src/Controls/src/Core/HandlerImpl/Layout/Layout.iOS.cs
@@ -14,12 +14,14 @@ namespace Microsoft.Maui.Controls
 
 		static void UpdateInputTransparent(IViewHandler handler, IView layout)
 		{
-			if (handler.PlatformView is UIKit.UIView uiView)
-				uiView.UpdateInputTransparent(handler, layout);
-
-			if (layout is Layout l)
+			if (handler is ILayoutHandler layoutHandler && layout is Layout controlsLayout)
 			{
-				l.UpdateDescendantInputTransparent();
+				layoutHandler.PlatformView?.UpdateInputTransparent(layoutHandler, controlsLayout);
+				controlsLayout.UpdateDescendantInputTransparent();
+			}
+			else
+			{
+				ControlsVisualElementMapper.UpdateProperty(handler, layout, nameof(IView.InputTransparent));
 			}
 		}
 	}

--- a/src/Controls/tests/DeviceTests/Elements/Layout/LayoutTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Layout/LayoutTests.Android.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Platform;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	public partial class LayoutTests
+	{
+		void ValidateInputTransparentOnPlatformView(IView view)
+		{
+			if (view is ILayout)
+			{
+				Assert.True(view.ToPlatform(MauiContext) is not WrapperView wv || !wv.InputTransparent);
+				return;
+			}
+
+			if (view.InputTransparent)
+			{
+				Assert.True(view.ToPlatform(MauiContext) is WrapperView wv && wv.InputTransparent);
+			}
+			else
+			{
+				Assert.True(view.ToPlatform(MauiContext) is not WrapperView wv || !wv.InputTransparent);
+			}
+		}
+	}
+}

--- a/src/Controls/tests/DeviceTests/Elements/Layout/LayoutTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Layout/LayoutTests.Android.cs
@@ -15,9 +15,13 @@ namespace Microsoft.Maui.DeviceTests
 	{
 		void ValidateInputTransparentOnPlatformView(IView view)
 		{
-			if (view is ILayout)
+			var handler = view.ToHandler(MauiContext);
+			if (handler.PlatformView is LayoutViewGroup lvg)
 			{
-				Assert.True(view.ToPlatform(MauiContext) is not WrapperView wv || !wv.InputTransparent);
+				Assert.Equal(view.InputTransparent, lvg.InputTransparent);
+				if (handler.ContainerView is WrapperView wv)
+					Assert.False(wv.InputTransparent);
+
 				return;
 			}
 

--- a/src/Controls/tests/DeviceTests/Elements/Layout/LayoutTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Layout/LayoutTests.Windows.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Platform;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	public partial class LayoutTests
+	{
+		void ValidateInputTransparentOnPlatformView(IView view)
+		{
+			var handler = (IPlatformViewHandler)view.ToHandler(MauiContext);
+
+			if (handler.PlatformView is LayoutPanel lp)
+			{
+				Assert.True(lp.IsHitTestVisible);
+			}
+			else
+			{
+				Assert.Equal(!view.InputTransparent, !view.ToPlatform(MauiContext).IsHitTestVisible);
+			}
+		}
+	}
+}

--- a/src/Controls/tests/DeviceTests/Elements/Layout/LayoutTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Layout/LayoutTests.cs
@@ -3,8 +3,8 @@ using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
-using Microsoft.Maui.Platform;
 using Microsoft.Maui.Hosting;
+using Microsoft.Maui.Platform;
 using Xunit;
 using Xunit.Sdk;
 

--- a/src/Controls/tests/DeviceTests/Elements/Layout/LayoutTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Layout/LayoutTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Maui.Controls;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Platform;
+using Microsoft.Maui.Hosting;
 using Xunit;
 using Xunit.Sdk;
 
@@ -12,6 +13,55 @@ namespace Microsoft.Maui.DeviceTests
 	[Category(TestCategory.Layout)]
 	public partial class LayoutTests : ControlsHandlerTestBase
 	{
+		[Theory]
+		[InlineData(true)]
+		[InlineData(false)]
+		public async Task InputTransparentCorrectlyAppliedToPlatformView(bool inputTransparent)
+		{
+			EnsureHandlerCreated((builder) =>
+			{
+				builder.ConfigureMauiHandlers(handler =>
+				{
+					handler.AddHandler(typeof(Button), typeof(ButtonHandler));
+					handler.AddHandler(typeof(Layout), typeof(LayoutHandler));
+				});
+			});
+
+			var control = new Grid() { InputTransparent = inputTransparent, CascadeInputTransparent = false };
+			var child = new Button();
+			control.Add(child);
+
+			await InvokeOnMainThreadAsync(() =>
+			{
+				ValidateInputTransparentOnPlatformView(control);
+			});
+		}
+
+		[Theory]
+		[InlineData(true)]
+		[InlineData(false)]
+		public async Task InputTransparentUpdatesCorrectlyOnPlatformView(bool finalInputTransparent)
+		{
+			EnsureHandlerCreated((builder) =>
+			{
+				builder.ConfigureMauiHandlers(handler =>
+				{
+					handler.AddHandler(typeof(Button), typeof(ButtonHandler));
+					handler.AddHandler(typeof(Layout), typeof(LayoutHandler));
+				});
+			});
+
+			var control = new Grid() { InputTransparent = !finalInputTransparent, CascadeInputTransparent = false };
+			var child = new Button();
+			control.Add(child);
+
+			await InvokeOnMainThreadAsync(() =>
+			{
+				control.InputTransparent = finalInputTransparent;
+				ValidateInputTransparentOnPlatformView(control);
+			});
+		}
+
 		[Theory]
 		[InlineData(true, true, true)]
 		[InlineData(true, false, false)]

--- a/src/Controls/tests/DeviceTests/Elements/Layout/LayoutTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Layout/LayoutTests.iOS.cs
@@ -150,5 +150,10 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.Equal(100, updatedSize.Width);
 			Assert.Equal(300, updatedSize.Height);
 		}
+
+		void ValidateInputTransparentOnPlatformView(IView view)
+		{
+			Assert.Equal(view.InputTransparent, !view.ToPlatform(MauiContext).UserInteractionEnabled);
+		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Layout/LayoutTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Layout/LayoutTests.iOS.cs
@@ -153,7 +153,14 @@ namespace Microsoft.Maui.DeviceTests
 
 		void ValidateInputTransparentOnPlatformView(IView view)
 		{
-			Assert.Equal(view.InputTransparent, !view.ToPlatform(MauiContext).UserInteractionEnabled);
+			var platformView = view.ToPlatform(MauiContext);
+
+			bool value = platformView.UserInteractionEnabled;
+			if (platformView is LayoutView lv)
+				value = lv.UserInteractionEnabledOverride;
+
+			Assert.True(view.InputTransparent == !value,
+				$"InputTransparent: {view.InputTransparent}. UserInteractionEnabled: {platformView.UserInteractionEnabled}");
 		}
 	}
 }

--- a/src/Core/src/Handlers/View/ViewHandler.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.cs
@@ -277,16 +277,6 @@ namespace Microsoft.Maui.Handlers
 				handler.HasContainer = viewHandler.NeedsContainer;
 			else
 				handler.HasContainer = view.NeedsContainer();
-
-			UpdateInputTransparentOnContainerView(handler, view);
-		}
-
-		static void UpdateInputTransparentOnContainerView(IViewHandler handler, IView view)
-		{
-#if ANDROID
-			if (handler.ContainerView is WrapperView wrapper)
-				wrapper.InputTransparent = view.InputTransparent;
-#endif
 		}
 
 		public static void MapBorderView(IViewHandler handler, IView view)
@@ -323,7 +313,9 @@ namespace Microsoft.Maui.Handlers
 		{
 #if ANDROID
 			handler.UpdateValue(nameof(IViewHandler.ContainerView));
-			UpdateInputTransparentOnContainerView(handler, view);
+
+			if (handler.ContainerView is WrapperView wrapper)
+				wrapper.InputTransparent = view.InputTransparent;
 #else
 			((PlatformView?)handler.PlatformView)?.UpdateInputTransparent(handler, view);
 #endif

--- a/src/Core/src/Platform/iOS/LayoutView.cs
+++ b/src/Core/src/Platform/iOS/LayoutView.cs
@@ -94,6 +94,8 @@ namespace Microsoft.Maui.Platform
 			return result;
 		}
 
+		internal bool UserInteractionEnabledOverride => _userInteractionEnabled;
+
 		public override bool UserInteractionEnabled
 		{
 			get => base.UserInteractionEnabled;


### PR DESCRIPTION
### Description of Change

#### Windows

Fixing regressions caused by https://github.com/dotnet/maui/pull/12785

- Windows has two different overloads for `UpdateInputTransparent` and this wasn't taken into account on #12785. We needed to cast the mapper parameters to the previous layout types in order to call through to the correct overload. We should do another PR fixing this on main so that this logic is just inside `UpdateInputTransparent`. We do this inside the iOS `UpdateInputTransparent` so we should do the same on `Windows`

#### Android

https://github.com/dotnet/maui/pull/12799

- Before #12799 we would just call `UpdateContainerView` from all the mappers that needed the `ContainerView` recalculated. This wasn't allowing us to tap into `MapContainerView` ourselves and modifying the behavior inside `Controls`. The problem with #12799 is that it left a call to `UpdateInputTransparent` inside the `MapContainerView` which made it so the overrides in controls weren't being fully obeyed. The core code was still running even though `Controls` was replacing the behavior. 

fixes #14522