### PR TITLE
Correctly re-apply font formatting to HTML text

### DIFF
--- a/src/Controls/src/Core/HandlerImpl/Label/Label.Android.cs
+++ b/src/Controls/src/Core/HandlerImpl/Label/Label.Android.cs
@@ -33,29 +33,18 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		public static void MapTextType(LabelHandler handler, Label label) => MapText((ILabelHandler)handler, label);
+		public static void MapTextType(LabelHandler handler, Label label) => MapTextType((ILabelHandler)handler, label);
 		public static void MapText(LabelHandler handler, Label label) => MapText((ILabelHandler)handler, label);
 		public static void MapLineBreakMode(LabelHandler handler, Label label) => MapLineBreakMode((ILabelHandler)handler, label);
 
 
 		public static void MapTextType(ILabelHandler handler, Label label)
 		{
-			Platform.TextViewExtensions.UpdateText(handler.PlatformView, label);
+			handler.UpdateValue(nameof(ILabel.Text));
 		}
 
 		public static void MapText(ILabelHandler handler, Label label)
 		{
-			Platform.TextViewExtensions.UpdateText(handler.PlatformView, label);
-		}
-
-		// TODO: NET8 make this public
-		internal static void MapTextColor(ILabelHandler handler, Label label)
-		{
-			handler.PlatformView?.UpdateTextColor(label);
-
-			if (label?.HasFormattedTextSpans ?? false)
-				return;
-
 			Platform.TextViewExtensions.UpdateText(handler.PlatformView, label);
 		}
 

--- a/src/Controls/src/Core/HandlerImpl/Label/Label.Tizen.cs
+++ b/src/Controls/src/Core/HandlerImpl/Label/Label.Tizen.cs
@@ -7,12 +7,12 @@ namespace Microsoft.Maui.Controls
 {
 	public partial class Label
 	{
-		public static void MapTextType(LabelHandler handler, Label label) => MapText((ILabelHandler)handler, label);
+		public static void MapTextType(LabelHandler handler, Label label) => MapTextType((ILabelHandler)handler, label);
 		public static void MapText(LabelHandler handler, Label label) => MapText((ILabelHandler)handler, label);
 
 		public static void MapTextType(ILabelHandler handler, Label label)
 		{
-			Platform.TextExtensions.UpdateText(handler.PlatformView, label);
+			handler.UpdateValue(nameof(ILabel.Text));
 		}
 
 		public static void MapText(ILabelHandler handler, Label label)

--- a/src/Controls/src/Core/HandlerImpl/Label/Label.Windows.cs
+++ b/src/Controls/src/Core/HandlerImpl/Label/Label.Windows.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Maui.Controls
 			Platform.TextBlockExtensions.UpdateDetectReadingOrderFromContent(handler.PlatformView, label);
 
 		public static void MapTextType(ILabelHandler handler, Label label) =>
-			Platform.TextBlockExtensions.UpdateText(handler.PlatformView, label);
+			handler.UpdateValue(nameof(ILabel.Text));
 
 		public static void MapText(ILabelHandler handler, Label label) =>
 			Platform.TextBlockExtensions.UpdateText(handler.PlatformView, label);

--- a/src/Controls/src/Core/HandlerImpl/Label/Label.cs
+++ b/src/Controls/src/Core/HandlerImpl/Label/Label.cs
@@ -15,9 +15,6 @@ namespace Microsoft.Maui.Controls
 #if WINDOWS
 			[PlatformConfiguration.WindowsSpecific.InputView.DetectReadingOrderFromContentProperty.PropertyName] = MapDetectReadingOrderFromContent,
 #endif
-#if ANDROID
-			[nameof(TextColor)] = MapTextColor,
-#endif
 #if IOS
 			[nameof(TextDecorations)] = MapTextDecorations,
 			[nameof(CharacterSpacing)] = MapCharacterSpacing,

--- a/src/Controls/src/Core/HandlerImpl/Label/Label.iOS.cs
+++ b/src/Controls/src/Core/HandlerImpl/Label/Label.iOS.cs
@@ -1,12 +1,12 @@
 ﻿#nullable disable
+using System;
 using Microsoft.Maui.Controls.Platform;
-using Microsoft.Maui.Handlers;
 
 namespace Microsoft.Maui.Controls
 {
 	public partial class Label
 	{
-		public static void MapTextType(LabelHandler handler, Label label) => MapText((ILabelHandler)handler, label);
+		public static void MapTextType(LabelHandler handler, Label label) => MapTextType((ILabelHandler)handler, label);
 		public static void MapText(LabelHandler handler, Label label) => MapText((ILabelHandler)handler, label);
 		public static void MapCharacterSpacing(LabelHandler handler, Label label) => MapCharacterSpacing((ILabelHandler)handler, label);
 		public static void MapTextDecorations(LabelHandler handler, Label label) => MapTextDecorations((ILabelHandler)handler, label);
@@ -17,61 +17,48 @@ namespace Microsoft.Maui.Controls
 
 		public static void MapTextType(ILabelHandler handler, Label label)
 		{
-			Platform.LabelExtensions.UpdateText(handler.PlatformView, label);
+			handler.UpdateValue(nameof(ILabel.Text));
 		}
 
 		public static void MapText(ILabelHandler handler, Label label)
 		{
 			Platform.LabelExtensions.UpdateText(handler.PlatformView, label);
+
+			MapFormatting(handler, label);
 		}
 
 		public static void MapTextDecorations(ILabelHandler handler, Label label)
 		{
-			if (label?.HasFormattedTextSpans ?? false)
+			if (!IsPlainText(label))
 				return;
-
-			if (label?.TextType == TextType.Html)
-			{
-				return;
-			}
 
 			LabelHandler.MapTextDecorations(handler, label);
 		}
 
 		public static void MapCharacterSpacing(ILabelHandler handler, Label label)
 		{
-			if (label?.HasFormattedTextSpans ?? false)
+			if (!IsPlainText(label))
 				return;
-
-			if (label?.TextType == TextType.Html)
-			{
-				return;
-			}
 
 			LabelHandler.MapCharacterSpacing(handler, label);
 		}
 
 		public static void MapLineHeight(ILabelHandler handler, Label label)
 		{
-			if (label?.HasFormattedTextSpans ?? false)
+			if (!IsPlainText(label))
 				return;
-
-			if (label?.TextType == TextType.Html)
-			{
-				return;
-			}
 
 			LabelHandler.MapLineHeight(handler, label);
 		}
 
 		public static void MapFont(ILabelHandler handler, Label label)
 		{
-			if (label?.HasFormattedTextSpans ?? false)
+			if (label.HasFormattedTextSpans)
 				return;
 
-			if (label?.TextType == TextType.Html && FontIsDefault(label))
+			if (label.TextType == TextType.Html && IsDefaultFont(label))
 			{
-				// If no explicit font has been specified and we're displaying HTML, 
+				// If no explicit font has been specified and we're displaying HTML,
 				// let the HTML determine the font
 				return;
 			}
@@ -81,12 +68,12 @@ namespace Microsoft.Maui.Controls
 
 		public static void MapTextColor(ILabelHandler handler, Label label)
 		{
-			if (label?.HasFormattedTextSpans ?? false)
+			if (label.HasFormattedTextSpans)
 				return;
 
-			if (label?.TextType == TextType.Html && label.GetValue(TextColorProperty) == null)
+			if (label.TextType == TextType.Html && label.TextColor.IsDefault())
 			{
-				// If no explicit text color has been specified and we're displaying HTML, 
+				// If no explicit text color has been specified and we're displaying HTML,
 				// let the HTML determine the colors
 				return;
 			}
@@ -104,22 +91,33 @@ namespace Microsoft.Maui.Controls
 			handler.PlatformView?.UpdateMaxLines(label);
 		}
 
-		static bool FontIsDefault(Label label)
+		static void MapFormatting(ILabelHandler handler, Label label)
+		{
+			handler.UpdateValue(nameof(ILabel.TextColor));
+			handler.UpdateValue(nameof(ILabel.Font));
+		}
+
+		static bool IsDefaultFont(Label label)
 		{
 			if (label.IsSet(Label.FontAttributesProperty))
-			{
 				return false;
-			}
 
 			if (label.IsSet(Label.FontFamilyProperty))
-			{
 				return false;
-			}
 
 			if (label.IsSet(Label.FontSizeProperty))
-			{
 				return false;
-			}
+
+			return true;
+		}
+
+		static bool IsPlainText(Label label)
+		{
+			if (label.HasFormattedTextSpans)
+				return false;
+
+			if (label.TextType != TextType.Text)
+				return false;
 
 			return true;
 		}

--- a/src/Controls/tests/DeviceTests/Controls.DeviceTests.csproj
+++ b/src/Controls/tests/DeviceTests/Controls.DeviceTests.csproj
@@ -27,6 +27,11 @@
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
   </PropertyGroup>
   
+  <PropertyGroup Condition="'$(TargetFramework)'=='net7.0-ios'">
+    <CodesignKey>Apple Development: Created via API (A97WW3QZ6T)</CodesignKey>
+    <CodesignProvision>VS: WildCard Development</CodesignProvision>
+  </PropertyGroup>
+  
   <ItemGroup>
     <ProjectReference Include="..\..\..\Core\tests\DeviceTests.Shared\Core.DeviceTests.Shared.csproj" />
     <ProjectReference Include="..\..\..\TestUtils\src\DeviceTests\TestUtils.DeviceTests.csproj" />

--- a/src/Controls/tests/DeviceTests/Controls.DeviceTests.csproj
+++ b/src/Controls/tests/DeviceTests/Controls.DeviceTests.csproj
@@ -27,11 +27,6 @@
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
   </PropertyGroup>
   
-  <PropertyGroup Condition="'$(TargetFramework)'=='net7.0-ios'">
-    <CodesignKey>Apple Development: Created via API (A97WW3QZ6T)</CodesignKey>
-    <CodesignProvision>VS: WildCard Development</CodesignProvision>
-  </PropertyGroup>
-  
   <ItemGroup>
     <ProjectReference Include="..\..\..\Core\tests\DeviceTests.Shared\Core.DeviceTests.Shared.csproj" />
     <ProjectReference Include="..\..\..\TestUtils\src\DeviceTests\TestUtils.DeviceTests.csproj" />

--- a/src/Controls/tests/DeviceTests/Elements/Label/LabelTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Label/LabelTests.cs
@@ -410,6 +410,50 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
+		[Fact]
+		public async Task TextTypeAfterFontStuffIsCorrect()
+		{
+			// Note: this is specifically a Controls-level rule that's inherited from Forms
+			// There's no reason other SDKs need to force font properties when dealing 
+			// with HTML text (since HTML can do that on its own)
+
+			var label = new Label
+			{
+				FontSize = 64,
+				FontFamily = "Baskerville",
+				Text = "<p>Test</p>"
+			};
+
+			await InvokeOnMainThreadAsync(() =>
+			{
+				var handler = CreateHandler<LabelHandler>(label);
+				label.TextType = TextType.Html;
+				AssertEquivalentFont(handler, label.ToFont());
+			});
+		}
+
+		[Fact]
+		public async Task FontStuffAfterTextTypeIsCorrect()
+		{
+			// Note: this is specifically a Controls-level rule that's inherited from Forms
+			// There's no reason other SDKs need to force font properties when dealing 
+			// with HTML text (since HTML can do that on its own)
+
+			var label = new Label
+			{
+				TextType = TextType.Html,
+				Text = "<p>Test</p>"
+			};
+
+			await InvokeOnMainThreadAsync(() =>
+			{
+				var handler = CreateHandler<LabelHandler>(label);
+				label.FontFamily = "Baskerville";
+				label.FontSize = 64;
+				AssertEquivalentFont(handler, label.ToFont());
+			});
+		}
+
 		Color TextColor(LabelHandler handler)
 		{
 #if __IOS__

--- a/src/Core/src/Handlers/Label/LabelHandler.iOS.cs
+++ b/src/Core/src/Handlers/Label/LabelHandler.iOS.cs
@@ -73,13 +73,13 @@ namespace Microsoft.Maui.Handlers
 		public static void MapFormatting(ILabelHandler handler, ILabel label)
 		{
 			// Update all of the attributed text formatting properties
-			handler.PlatformView?.UpdateLineHeight(label);
-			handler.PlatformView?.UpdateTextDecorations(label);
-			handler.PlatformView?.UpdateCharacterSpacing(label);
+			handler.UpdateValue(nameof(ILabel.LineHeight));
+			handler.UpdateValue(nameof(ILabel.TextDecorations));
+			handler.UpdateValue(nameof(ILabel.CharacterSpacing));
 
 			// Setting any of those may have removed text alignment settings,
 			// so we need to make sure those are applied, too
-			handler.PlatformView?.UpdateHorizontalTextAlignment(label);
+			handler.UpdateValue(nameof(ILabel.HorizontalTextAlignment));
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change

Setting the text on iOS resets all formatting, so we need to re-apply size, color and other properties.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #12230
Fixes #11817

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
