### PR TITLE
Update All (most) BindableProperty XML docs

### DIFF
--- a/src/Controls/Foldable/src/SpanModeStateTrigger.cs
+++ b/src/Controls/Foldable/src/SpanModeStateTrigger.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Maui.Controls.Foldable
 			set => SetValue(SpanModeProperty, value);
 		}
 
+		/// <summary>Bindable property for <see cref="SpanMode"/>.</summary>
 		public static readonly BindableProperty SpanModeProperty =
 			BindableProperty.Create(nameof(SpanMode), typeof(TwoPaneViewMode), typeof(SpanModeStateTrigger), default(TwoPaneViewMode),
 				propertyChanged: OnSpanModeChanged);

--- a/src/Controls/Foldable/src/TwoPaneView.cs
+++ b/src/Controls/Foldable/src/TwoPaneView.cs
@@ -47,35 +47,45 @@ namespace Microsoft.Maui.Controls.Foldable
 		double _previousWidth = -1;
 		double _previousHeight = -1;
 
+		/// <summary>Bindable property for <see cref="TallModeConfiguration"/>.</summary>
 		public static readonly BindableProperty TallModeConfigurationProperty
 			= BindableProperty.Create("TallModeConfiguration", typeof(TwoPaneViewTallModeConfiguration), typeof(TwoPaneView), defaultValue: TwoPaneViewTallModeConfiguration.TopBottom, propertyChanged: TwoPaneViewLayoutPropertyChanged);
 
+		/// <summary>Bindable property for <see cref="WideModeConfiguration"/>.</summary>
 		public static readonly BindableProperty WideModeConfigurationProperty
 			= BindableProperty.Create("WideModeConfiguration", typeof(TwoPaneViewWideModeConfiguration), typeof(TwoPaneView), defaultValue: TwoPaneViewWideModeConfiguration.LeftRight, propertyChanged: TwoPaneViewLayoutPropertyChanged);
 
+		/// <summary>Bindable property for <see cref="Pane1"/>.</summary>
 		public static readonly BindableProperty Pane1Property
 			= BindableProperty.Create("Pane1", typeof(View), typeof(TwoPaneView), propertyChanged: (b, o, n) => OnPanePropertyChanged(b, o, n, 0));
 
+		/// <summary>Bindable property for <see cref="Pane2"/>.</summary>
 		public static readonly BindableProperty Pane2Property
 			= BindableProperty.Create("Pane2", typeof(View), typeof(TwoPaneView), propertyChanged: (b, o, n) => OnPanePropertyChanged(b, o, n, 1));
 
 		static readonly BindablePropertyKey ModePropertyKey
 			= BindableProperty.CreateReadOnly("Mode", typeof(TwoPaneViewMode), typeof(TwoPaneView), defaultValue: TwoPaneViewMode.SinglePane, propertyChanged: OnModePropertyChanged);
 
+		/// <summary>Bindable property for <see cref="Mode"/>.</summary>
 		public static readonly BindableProperty ModeProperty = ModePropertyKey.BindableProperty;
 
+		/// <summary>Bindable property for <see cref="PanePriority"/>.</summary>
 		public static readonly BindableProperty PanePriorityProperty
 			= BindableProperty.Create("PanePriority", typeof(TwoPaneViewPriority), typeof(TwoPaneView), defaultValue: TwoPaneViewPriority.Pane1, propertyChanged: TwoPaneViewLayoutPropertyChanged);
 
+		/// <summary>Bindable property for <see cref="MinTallModeHeight"/>.</summary>
 		public static readonly BindableProperty MinTallModeHeightProperty
 			= BindableProperty.Create("MinTallModeHeight", typeof(double), typeof(TwoPaneView), defaultValueCreator: OnMinModePropertyCreate, propertyChanged: TwoPaneViewLayoutPropertyChanged);
 
+		/// <summary>Bindable property for <see cref="MinWideModeWidth"/>.</summary>
 		public static readonly BindableProperty MinWideModeWidthProperty
 			= BindableProperty.Create("MinWideModeWidth", typeof(double), typeof(TwoPaneView), defaultValueCreator: OnMinModePropertyCreate, propertyChanged: TwoPaneViewLayoutPropertyChanged);
 
+		/// <summary>Bindable property for <see cref="Pane1Length"/>.</summary>
 		public static readonly BindableProperty Pane1LengthProperty
 			= BindableProperty.Create("Pane1Length", typeof(GridLength), typeof(TwoPaneView), defaultValue: GridLength.Star, propertyChanged: TwoPaneViewLayoutPropertyChanged);
 
+		/// <summary>Bindable property for <see cref="Pane2Length"/>.</summary>
 		public static readonly BindableProperty Pane2LengthProperty
 			= BindableProperty.Create("Pane2Length", typeof(GridLength), typeof(TwoPaneView), defaultValue: GridLength.Star, propertyChanged: TwoPaneViewLayoutPropertyChanged);
 

--- a/src/Controls/Foldable/src/WindowSpanModeStateTrigger.cs
+++ b/src/Controls/Foldable/src/WindowSpanModeStateTrigger.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Maui.Controls.Foldable
 			set => SetValue(SpanModeProperty, value);
 		}
 
+		/// <summary>Bindable property for <see cref="SpanMode"/>.</summary>
 		public static readonly BindableProperty SpanModeProperty =
 			BindableProperty.Create(nameof(SpanMode), typeof(TwoPaneViewMode), typeof(WindowSpanModeStateTrigger), default(TwoPaneViewMode),
 				propertyChanged: OnSpanModeChanged);

--- a/src/Controls/Maps/src/Circle.cs
+++ b/src/Controls/Maps/src/Circle.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Maui.Devices.Sensors;
+using Microsoft.Maui.Devices.Sensors;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Maps;
 
@@ -6,18 +6,21 @@ namespace Microsoft.Maui.Controls.Maps
 {
 	public partial class Circle : MapElement
 	{
+		/// <summary>Bindable property for <see cref="Center"/>.</summary>
 		public static readonly BindableProperty CenterProperty = BindableProperty.Create(
 			nameof(Center),
 			typeof(Location),
 			typeof(Circle),
 			default(Location));
 
+		/// <summary>Bindable property for <see cref="Radius"/>.</summary>
 		public static readonly BindableProperty RadiusProperty = BindableProperty.Create(
 			nameof(Radius),
 			typeof(Distance),
 			typeof(Circle),
 			default(Distance));
 
+		/// <summary>Bindable property for <see cref="FillColor"/>.</summary>
 		public static readonly BindableProperty FillColorProperty = BindableProperty.Create(
 			nameof(FillColor),
 			typeof(Color),

--- a/src/Controls/Maps/src/Map.cs
+++ b/src/Controls/Maps/src/Map.cs
@@ -12,22 +12,30 @@ namespace Microsoft.Maui.Controls.Maps
 {
 	public partial class Map : View
 	{
+		/// <summary>Bindable property for <see cref="MapType"/>.</summary>
 		public static readonly BindableProperty MapTypeProperty = BindableProperty.Create(nameof(MapType), typeof(MapType), typeof(Map), default(MapType));
 
+		/// <summary>Bindable property for <see cref="IsShowingUser"/>.</summary>
 		public static readonly BindableProperty IsShowingUserProperty = BindableProperty.Create(nameof(IsShowingUser), typeof(bool), typeof(Map), default(bool));
 
+		/// <summary>Bindable property for <see cref="IsTrafficEnabled"/>.</summary>
 		public static readonly BindableProperty IsTrafficEnabledProperty = BindableProperty.Create(nameof(IsTrafficEnabled), typeof(bool), typeof(Map), default(bool));
 
+		/// <summary>Bindable property for <see cref="IsScrollEnabled"/>.</summary>
 		public static readonly BindableProperty IsScrollEnabledProperty = BindableProperty.Create(nameof(IsScrollEnabled), typeof(bool), typeof(Map), true);
 
+		/// <summary>Bindable property for <see cref="IsZoomEnabled"/>.</summary>
 		public static readonly BindableProperty IsZoomEnabledProperty = BindableProperty.Create(nameof(IsZoomEnabled), typeof(bool), typeof(Map), true);
 
+		/// <summary>Bindable property for <see cref="ItemsSource"/>.</summary>
 		public static readonly BindableProperty ItemsSourceProperty = BindableProperty.Create(nameof(ItemsSource), typeof(IEnumerable), typeof(Map), default(IEnumerable),
 			propertyChanged: (b, o, n) => ((Map)b).OnItemsSourcePropertyChanged((IEnumerable)o, (IEnumerable)n));
 
+		/// <summary>Bindable property for <see cref="ItemTemplate"/>.</summary>
 		public static readonly BindableProperty ItemTemplateProperty = BindableProperty.Create(nameof(ItemTemplate), typeof(DataTemplate), typeof(Map), default(DataTemplate),
 			propertyChanged: (b, o, n) => ((Map)b).OnItemTemplatePropertyChanged((DataTemplate)o, (DataTemplate)n));
 
+		/// <summary>Bindable property for <see cref="ItemTemplateSelector"/>.</summary>
 		public static readonly BindableProperty ItemTemplateSelectorProperty = BindableProperty.Create(nameof(ItemTemplateSelector), typeof(DataTemplateSelector), typeof(Map), default(DataTemplateSelector),
 			propertyChanged: (b, o, n) => ((Map)b).OnItemTemplateSelectorPropertyChanged());
 

--- a/src/Controls/Maps/src/MapElement.cs
+++ b/src/Controls/Maps/src/MapElement.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Text;
@@ -9,12 +9,14 @@ namespace Microsoft.Maui.Controls.Maps
 {
 	public partial class MapElement : Element
 	{
+		/// <summary>Bindable property for <see cref="StrokeColor"/>.</summary>
 		public static readonly BindableProperty StrokeColorProperty = BindableProperty.Create(
 			nameof(StrokeColor),
 			typeof(Color),
 			typeof(MapElement),
 			null);
 
+		/// <summary>Bindable property for <see cref="StrokeWidth"/>.</summary>
 		public static readonly BindableProperty StrokeWidthProperty = BindableProperty.Create(
 			nameof(StrokeWidth),
 			typeof(float),

--- a/src/Controls/Maps/src/Pin.cs
+++ b/src/Controls/Maps/src/Pin.cs
@@ -7,12 +7,16 @@ namespace Microsoft.Maui.Controls.Maps
 {
 	public partial class Pin : Element
 	{
+		/// <summary>Bindable property for <see cref="Type"/>.</summary>
 		public static readonly BindableProperty TypeProperty = BindableProperty.Create(nameof(Type), typeof(PinType), typeof(Pin), default(PinType));
 
+		/// <summary>Bindable property for <see cref="Location"/>.</summary>
 		public static readonly BindableProperty LocationProperty = BindableProperty.Create(nameof(Location), typeof(Location), typeof(Pin), default(Location));
 
+		/// <summary>Bindable property for <see cref="Address"/>.</summary>
 		public static readonly BindableProperty AddressProperty = BindableProperty.Create(nameof(Address), typeof(string), typeof(Pin), default(string));
 
+		/// <summary>Bindable property for <see cref="Label"/>.</summary>
 		public static readonly BindableProperty LabelProperty = BindableProperty.Create(nameof(Label), typeof(string), typeof(Pin), default(string));
 		private object? _markerId;
 

--- a/src/Controls/Maps/src/Polygon.cs
+++ b/src/Controls/Maps/src/Polygon.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Maui.Controls.Maps
 {
 	public partial class Polygon : MapElement
 	{
+		/// <summary>Bindable property for <see cref="FillColor"/>.</summary>
 		public static readonly BindableProperty FillColorProperty = BindableProperty.Create(
 			nameof(FillColor),
 			typeof(Color),

--- a/src/Controls/src/Core/ActivityIndicator.cs
+++ b/src/Controls/src/Core/ActivityIndicator.cs
@@ -7,10 +7,10 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../docs/Microsoft.Maui.Controls/ActivityIndicator.xml" path="Type[@FullName='Microsoft.Maui.Controls.ActivityIndicator']/Docs/*" />
 	public partial class ActivityIndicator : View, IColorElement, IElementConfiguration<ActivityIndicator>
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/ActivityIndicator.xml" path="//Member[@MemberName='IsRunningProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="IsRunning"/>.</summary>
 		public static readonly BindableProperty IsRunningProperty = BindableProperty.Create("IsRunning", typeof(bool), typeof(ActivityIndicator), default(bool));
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ActivityIndicator.xml" path="//Member[@MemberName='ColorProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Color"/>.</summary>
 		public static readonly BindableProperty ColorProperty = ColorElement.ColorProperty;
 
 		readonly Lazy<PlatformConfigurationRegistry<ActivityIndicator>> _platformConfigurationRegistry;

--- a/src/Controls/src/Core/AdaptiveTrigger.cs
+++ b/src/Controls/src/Core/AdaptiveTrigger.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Maui.Controls
 			set => SetValue(MinWindowHeightProperty, value);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/AdaptiveTrigger.xml" path="//Member[@MemberName='MinWindowHeightProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="MinWindowHeight"/>.</summary>
 		public static readonly BindableProperty MinWindowHeightProperty =
 			BindableProperty.Create(nameof(MinWindowHeight), typeof(double), typeof(AdaptiveTrigger), -1d,
 				propertyChanged: OnMinWindowDimensionChanged);
@@ -33,7 +33,7 @@ namespace Microsoft.Maui.Controls
 			set => SetValue(MinWindowWidthProperty, value);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/AdaptiveTrigger.xml" path="//Member[@MemberName='MinWindowWidthProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="MinWindowWidth"/>.</summary>
 		public static readonly BindableProperty MinWindowWidthProperty =
 			BindableProperty.Create(nameof(MinWindowWidth), typeof(double), typeof(AdaptiveTrigger), -1d,
 				propertyChanged: OnMinWindowDimensionChanged);

--- a/src/Controls/src/Core/AppLinkEntry.cs
+++ b/src/Controls/src/Core/AppLinkEntry.cs
@@ -15,19 +15,19 @@ namespace Microsoft.Maui.Controls
 			keyValues = new Dictionary<string, string>();
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/AppLinkEntry.xml" path="//Member[@MemberName='TitleProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Title"/>.</summary>
 		public static readonly BindableProperty TitleProperty = BindableProperty.Create(nameof(Title), typeof(string), typeof(AppLinkEntry), default(string));
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/AppLinkEntry.xml" path="//Member[@MemberName='DescriptionProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Description"/>.</summary>
 		public static readonly BindableProperty DescriptionProperty = BindableProperty.Create(nameof(Description), typeof(string), typeof(AppLinkEntry), default(string));
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/AppLinkEntry.xml" path="//Member[@MemberName='ThumbnailProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Thumbnail"/>.</summary>
 		public static readonly BindableProperty ThumbnailProperty = BindableProperty.Create(nameof(Thumbnail), typeof(ImageSource), typeof(AppLinkEntry), default(ImageSource));
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/AppLinkEntry.xml" path="//Member[@MemberName='AppLinkUriProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="AppLinkUri"/>.</summary>
 		public static readonly BindableProperty AppLinkUriProperty = BindableProperty.Create(nameof(AppLinkUri), typeof(Uri), typeof(AppLinkEntry), null);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/AppLinkEntry.xml" path="//Member[@MemberName='IsLinkActiveProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="IsLinkActive"/>.</summary>
 		public static readonly BindableProperty IsLinkActiveProperty = BindableProperty.Create(nameof(IsLinkActive), typeof(bool), typeof(AppLinkEntry), false);
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/AppLinkEntry.xml" path="//Member[@MemberName='AppLinkUri']/Docs/*" />

--- a/src/Controls/src/Core/AutomationProperties.cs
+++ b/src/Controls/src/Core/AutomationProperties.cs
@@ -6,20 +6,21 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../docs/Microsoft.Maui.Controls/AutomationProperties.xml" path="Type[@FullName='Microsoft.Maui.Controls.AutomationProperties']/Docs/*" />
 	public class AutomationProperties
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/AutomationProperties.xml" path="//Member[@MemberName='HelpTextProperty']/Docs/*" />
+		/// <summary>Bindable property for <c>HelpText</c>.</summary>
 		[Obsolete("Use SemanticProperties.Hint instead. See the conceptual docs about accessibility for more information.")]
 		public static readonly BindableProperty HelpTextProperty = BindableProperty.Create("HelpText", typeof(string), typeof(AutomationProperties), default(string));
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/AutomationProperties.xml" path="//Member[@MemberName='IsInAccessibleTreeProperty']/Docs/*" />
+		/// <summary>Bindable property for <c>IsInAccessibleTree</c>.</summary>
 		public static readonly BindableProperty IsInAccessibleTreeProperty = BindableProperty.Create("IsInAccessibleTree", typeof(bool?), typeof(AutomationProperties), null);
 
+		/// <summary>Bindable property for <c>ExcludedWithChildren</c>.</summary>
 		public static readonly BindableProperty ExcludedWithChildrenProperty = BindableProperty.Create("ExcludedWithChildren", typeof(bool?), typeof(AutomationProperties), null);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/AutomationProperties.xml" path="//Member[@MemberName='LabeledByProperty']/Docs/*" />
+		/// <summary>Bindable property for <c>LabeledBy</c>.</summary>
 		[Obsolete("Use a SemanticProperties.Description binding instead. See the conceptual docs about accessibility for more information.")]
 		public static readonly BindableProperty LabeledByProperty = BindableProperty.Create("LabeledBy", typeof(VisualElement), typeof(AutomationProperties), default(VisualElement));
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/AutomationProperties.xml" path="//Member[@MemberName='NameProperty']/Docs/*" />
+		/// <summary>Bindable property for <c>Name</c>.</summary>
 		[Obsolete("Use SemanticProperties.Description instead. See the conceptual docs about accessibility for more information.")]
 		public static readonly BindableProperty NameProperty = BindableProperty.Create("Name", typeof(string), typeof(AutomationProperties), default(string));
 

--- a/src/Controls/src/Core/BarElement.cs
+++ b/src/Controls/src/Core/BarElement.cs
@@ -5,12 +5,15 @@ namespace Microsoft.Maui.Controls
 {
 	static class BarElement
 	{
+		/// <summary>Bindable property for <see cref="BarBackgroundColor"/>.</summary>
 		public static readonly BindableProperty BarBackgroundColorProperty =
 			BindableProperty.Create(nameof(IBarElement.BarBackgroundColor), typeof(Color), typeof(IBarElement), default(Color));
 
+		/// <summary>Bindable property for <see cref="BarBackground"/>.</summary>
 		public static readonly BindableProperty BarBackgroundProperty =
 			BindableProperty.Create(nameof(IBarElement.BarBackground), typeof(Brush), typeof(IBarElement), default(Brush));
 
+		/// <summary>Bindable property for <see cref="BarTextColor"/>.</summary>
 		public static readonly BindableProperty BarTextColorProperty =
 			BindableProperty.Create(nameof(IBarElement.BarTextColor), typeof(Color), typeof(IBarElement), default(Color));
 	}

--- a/src/Controls/src/Core/BarElement.cs
+++ b/src/Controls/src/Core/BarElement.cs
@@ -5,15 +5,15 @@ namespace Microsoft.Maui.Controls
 {
 	static class BarElement
 	{
-		/// <summary>Bindable property for <see cref="BarBackgroundColor"/>.</summary>
+		/// <summary>Bindable property for <see cref="IBarElement.BarBackgroundColor"/>.</summary>
 		public static readonly BindableProperty BarBackgroundColorProperty =
 			BindableProperty.Create(nameof(IBarElement.BarBackgroundColor), typeof(Color), typeof(IBarElement), default(Color));
 
-		/// <summary>Bindable property for <see cref="BarBackground"/>.</summary>
+		/// <summary>Bindable property for <see cref="IBarElement.BarBackground"/>.</summary>
 		public static readonly BindableProperty BarBackgroundProperty =
 			BindableProperty.Create(nameof(IBarElement.BarBackground), typeof(Brush), typeof(IBarElement), default(Brush));
 
-		/// <summary>Bindable property for <see cref="BarTextColor"/>.</summary>
+		/// <summary>Bindable property for <see cref="IBarElement.BarTextColor"/>.</summary>
 		public static readonly BindableProperty BarTextColorProperty =
 			BindableProperty.Create(nameof(IBarElement.BarTextColor), typeof(Color), typeof(IBarElement), default(Color));
 	}

--- a/src/Controls/src/Core/BindableLayout.cs
+++ b/src/Controls/src/Core/BindableLayout.cs
@@ -18,17 +18,17 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../docs/Microsoft.Maui.Controls/BindableLayout.xml" path="Type[@FullName='Microsoft.Maui.Controls.BindableLayout']/Docs/*" />
 	public static class BindableLayout
 	{
-		/// <summary>Bindable property for <see cref="ItemsSource"/>.</summary>
+		/// <summary>Bindable property for attached property <c>ItemsSource</c>.</summary>
 		public static readonly BindableProperty ItemsSourceProperty =
 			BindableProperty.CreateAttached("ItemsSource", typeof(IEnumerable), typeof(IBindableLayout), default(IEnumerable),
 				propertyChanged: (b, o, n) => { GetBindableLayoutController(b).ItemsSource = (IEnumerable)n; });
 
-		/// <summary>Bindable property for <see cref="ItemTemplate"/>.</summary>
+		/// <summary>Bindable property for attached property <c>ItemTemplate</c>.</summary>
 		public static readonly BindableProperty ItemTemplateProperty =
 			BindableProperty.CreateAttached("ItemTemplate", typeof(DataTemplate), typeof(IBindableLayout), default(DataTemplate),
 				propertyChanged: (b, o, n) => { GetBindableLayoutController(b).ItemTemplate = (DataTemplate)n; });
 
-		/// <summary>Bindable property for <see cref="ItemTemplateSelector"/>.</summary>
+		/// <summary>Bindable property for attached property <c>ItemTemplateSelector</c>.</summary>
 		public static readonly BindableProperty ItemTemplateSelectorProperty =
 			BindableProperty.CreateAttached("ItemTemplateSelector", typeof(DataTemplateSelector), typeof(IBindableLayout), default(DataTemplateSelector),
 				propertyChanged: (b, o, n) => { GetBindableLayoutController(b).ItemTemplateSelector = (DataTemplateSelector)n; });
@@ -38,11 +38,11 @@ namespace Microsoft.Maui.Controls
 				 defaultValueCreator: (b) => new BindableLayoutController((IBindableLayout)b),
 				 propertyChanged: (b, o, n) => OnControllerChanged(b, (BindableLayoutController)o, (BindableLayoutController)n));
 
-		/// <summary>Bindable property for <see cref="EmptyView"/>.</summary>
+		/// <summary>Bindable property for attached property <c>EmptyView</c>.</summary>
 		public static readonly BindableProperty EmptyViewProperty =
 			BindableProperty.Create("EmptyView", typeof(object), typeof(IBindableLayout), null, propertyChanged: (b, o, n) => { GetBindableLayoutController(b).EmptyView = n; });
 
-		/// <summary>Bindable property for <see cref="EmptyViewTemplate"/>.</summary>
+		/// <summary>Bindable property for attached property <c>EmptyViewTemplate</c>.</summary>
 		public static readonly BindableProperty EmptyViewTemplateProperty =
 			BindableProperty.Create("EmptyViewTemplate", typeof(DataTemplate), typeof(IBindableLayout), null, propertyChanged: (b, o, n) => { GetBindableLayoutController(b).EmptyViewTemplate = (DataTemplate)n; });
 

--- a/src/Controls/src/Core/BindableLayout.cs
+++ b/src/Controls/src/Core/BindableLayout.cs
@@ -18,17 +18,17 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../docs/Microsoft.Maui.Controls/BindableLayout.xml" path="Type[@FullName='Microsoft.Maui.Controls.BindableLayout']/Docs/*" />
 	public static class BindableLayout
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/BindableLayout.xml" path="//Member[@MemberName='ItemsSourceProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="ItemsSource"/>.</summary>
 		public static readonly BindableProperty ItemsSourceProperty =
 			BindableProperty.CreateAttached("ItemsSource", typeof(IEnumerable), typeof(IBindableLayout), default(IEnumerable),
 				propertyChanged: (b, o, n) => { GetBindableLayoutController(b).ItemsSource = (IEnumerable)n; });
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/BindableLayout.xml" path="//Member[@MemberName='ItemTemplateProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="ItemTemplate"/>.</summary>
 		public static readonly BindableProperty ItemTemplateProperty =
 			BindableProperty.CreateAttached("ItemTemplate", typeof(DataTemplate), typeof(IBindableLayout), default(DataTemplate),
 				propertyChanged: (b, o, n) => { GetBindableLayoutController(b).ItemTemplate = (DataTemplate)n; });
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/BindableLayout.xml" path="//Member[@MemberName='ItemTemplateSelectorProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="ItemTemplateSelector"/>.</summary>
 		public static readonly BindableProperty ItemTemplateSelectorProperty =
 			BindableProperty.CreateAttached("ItemTemplateSelector", typeof(DataTemplateSelector), typeof(IBindableLayout), default(DataTemplateSelector),
 				propertyChanged: (b, o, n) => { GetBindableLayoutController(b).ItemTemplateSelector = (DataTemplateSelector)n; });
@@ -38,11 +38,11 @@ namespace Microsoft.Maui.Controls
 				 defaultValueCreator: (b) => new BindableLayoutController((IBindableLayout)b),
 				 propertyChanged: (b, o, n) => OnControllerChanged(b, (BindableLayoutController)o, (BindableLayoutController)n));
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/BindableLayout.xml" path="//Member[@MemberName='EmptyViewProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="EmptyView"/>.</summary>
 		public static readonly BindableProperty EmptyViewProperty =
 			BindableProperty.Create("EmptyView", typeof(object), typeof(IBindableLayout), null, propertyChanged: (b, o, n) => { GetBindableLayoutController(b).EmptyView = n; });
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/BindableLayout.xml" path="//Member[@MemberName='EmptyViewTemplateProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="EmptyViewTemplate"/>.</summary>
 		public static readonly BindableProperty EmptyViewTemplateProperty =
 			BindableProperty.Create("EmptyViewTemplate", typeof(DataTemplate), typeof(IBindableLayout), null, propertyChanged: (b, o, n) => { GetBindableLayoutController(b).EmptyViewTemplate = (DataTemplate)n; });
 

--- a/src/Controls/src/Core/BindableObject.cs
+++ b/src/Controls/src/Core/BindableObject.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Maui.Controls
 		bool _applying;
 		WeakReference _inheritedContext;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/BindableObject.xml" path="//Member[@MemberName='BindingContextProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="BindingContext"/>.</summary>
 		public static readonly BindableProperty BindingContextProperty =
 			BindableProperty.Create(nameof(BindingContext), typeof(object), typeof(BindableObject), default(object),
 									BindingMode.OneWay, null, BindingContextPropertyChanged, null, null, BindingContextPropertyBindingChanging);

--- a/src/Controls/src/Core/Border.cs
+++ b/src/Controls/src/Core/Border.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
@@ -31,9 +31,11 @@ namespace Microsoft.Maui.Controls
 		internal override IReadOnlyList<Element> LogicalChildrenInternal =>
 			_logicalChildren ??= new ReadOnlyCollection<Element>(InternalChildren);
 
+		/// <summary>Bindable property for <see cref="Content"/>.</summary>
 		public static readonly BindableProperty ContentProperty = BindableProperty.Create(nameof(Content), typeof(View),
 			typeof(Border), null, propertyChanged: ContentChanged);
 
+		/// <summary>Bindable property for <see cref="Padding"/>.</summary>
 		public static readonly BindableProperty PaddingProperty = PaddingElement.PaddingProperty;
 
 		public View? Content
@@ -48,6 +50,7 @@ namespace Microsoft.Maui.Controls
 			set => SetValue(PaddingElement.PaddingProperty, value);
 		}
 
+		/// <summary>Bindable property for <see cref="StrokeShape"/>.</summary>
 		public static readonly BindableProperty StrokeShapeProperty =
 			BindableProperty.Create(nameof(StrokeShape), typeof(IShape), typeof(Border), new Rectangle(),
 				propertyChanging: (bindable, oldvalue, newvalue) =>
@@ -87,6 +90,7 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
+		/// <summary>Bindable property for <see cref="Stroke"/>.</summary>
 		public static readonly BindableProperty StrokeProperty =
 			BindableProperty.Create(nameof(Stroke), typeof(Brush), typeof(Border), null,
 				propertyChanging: (bindable, oldvalue, newvalue) =>
@@ -130,22 +134,28 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
+		/// <summary>Bindable property for <see cref="StrokeThickness"/>.</summary>
 		public static readonly BindableProperty StrokeThicknessProperty =
 			BindableProperty.Create(nameof(StrokeThickness), typeof(double), typeof(Border), 1.0, propertyChanged: StrokeThicknessChanged);
 
+		/// <summary>Bindable property for <see cref="StrokeDashArray"/>.</summary>
 		public static readonly BindableProperty StrokeDashArrayProperty =
 			BindableProperty.Create(nameof(StrokeDashArray), typeof(DoubleCollection), typeof(Border), null,
 				defaultValueCreator: bindable => new DoubleCollection());
 
+		/// <summary>Bindable property for <see cref="StrokeDashOffset"/>.</summary>
 		public static readonly BindableProperty StrokeDashOffsetProperty =
 			BindableProperty.Create(nameof(StrokeDashOffset), typeof(double), typeof(Border), 0.0);
 
+		/// <summary>Bindable property for <see cref="StrokeLineCap"/>.</summary>
 		public static readonly BindableProperty StrokeLineCapProperty =
 			BindableProperty.Create(nameof(StrokeLineCap), typeof(PenLineCap), typeof(Border), PenLineCap.Flat);
 
+		/// <summary>Bindable property for <see cref="StrokeLineJoin"/>.</summary>
 		public static readonly BindableProperty StrokeLineJoinProperty =
 			BindableProperty.Create(nameof(StrokeLineJoin), typeof(PenLineJoin), typeof(Border), PenLineJoin.Miter);
 
+		/// <summary>Bindable property for <see cref="StrokeMiterLimit"/>.</summary>
 		public static readonly BindableProperty StrokeMiterLimitProperty =
 			BindableProperty.Create(nameof(StrokeMiterLimit), typeof(double), typeof(Border), 10.0);
 

--- a/src/Controls/src/Core/BorderElement.cs
+++ b/src/Controls/src/Core/BorderElement.cs
@@ -1,4 +1,4 @@
-﻿#nullable disable
+#nullable disable
 using System;
 using Microsoft.Maui.Graphics;
 
@@ -8,12 +8,15 @@ namespace Microsoft.Maui.Controls
 	{
 		public const int DefaultCornerRadius = -1;
 
+		/// <summary>Bindable property for <see cref="BorderColor"/>.</summary>
 		public static readonly BindableProperty BorderColorProperty =
 			BindableProperty.Create(nameof(IBorderElement.BorderColor), typeof(Color), typeof(IBorderElement), null,
 									propertyChanged: OnBorderColorPropertyChanged);
 
+		/// <summary>Bindable property for <see cref="BorderWidth"/>.</summary>
 		public static readonly BindableProperty BorderWidthProperty = BindableProperty.Create(nameof(IBorderElement.BorderWidth), typeof(double), typeof(IBorderElement), -1d);
 
+		/// <summary>Bindable property for <see cref="CornerRadius"/>.</summary>
 		public static readonly BindableProperty CornerRadiusProperty = BindableProperty.Create(nameof(IBorderElement.CornerRadius), typeof(int), typeof(IBorderElement), defaultValue: DefaultCornerRadius);
 
 		static void OnBorderColorPropertyChanged(BindableObject bindable, object oldValue, object newValue)

--- a/src/Controls/src/Core/BorderElement.cs
+++ b/src/Controls/src/Core/BorderElement.cs
@@ -8,15 +8,15 @@ namespace Microsoft.Maui.Controls
 	{
 		public const int DefaultCornerRadius = -1;
 
-		/// <summary>Bindable property for <see cref="BorderColor"/>.</summary>
+		/// <summary>Bindable property for <see cref="IBorderElement.BorderColor"/>.</summary>
 		public static readonly BindableProperty BorderColorProperty =
 			BindableProperty.Create(nameof(IBorderElement.BorderColor), typeof(Color), typeof(IBorderElement), null,
 									propertyChanged: OnBorderColorPropertyChanged);
 
-		/// <summary>Bindable property for <see cref="BorderWidth"/>.</summary>
+		/// <summary>Bindable property for <see cref="IBorderElement.BorderWidth"/>.</summary>
 		public static readonly BindableProperty BorderWidthProperty = BindableProperty.Create(nameof(IBorderElement.BorderWidth), typeof(double), typeof(IBorderElement), -1d);
 
-		/// <summary>Bindable property for <see cref="CornerRadius"/>.</summary>
+		/// <summary>Bindable property for <see cref="IBorderElement.CornerRadius"/>.</summary>
 		public static readonly BindableProperty CornerRadiusProperty = BindableProperty.Create(nameof(IBorderElement.CornerRadius), typeof(int), typeof(IBorderElement), defaultValue: DefaultCornerRadius);
 
 		static void OnBorderColorPropertyChanged(BindableObject bindable, object oldValue, object newValue)

--- a/src/Controls/src/Core/BoxView.cs
+++ b/src/Controls/src/Core/BoxView.cs
@@ -8,10 +8,10 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../docs/Microsoft.Maui.Controls/BoxView.xml" path="Type[@FullName='Microsoft.Maui.Controls.BoxView']/Docs/*" />
 	public partial class BoxView : View, IColorElement, ICornerElement, IElementConfiguration<BoxView>
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/BoxView.xml" path="//Member[@MemberName='ColorProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Color"/>.</summary>
 		public static readonly BindableProperty ColorProperty = ColorElement.ColorProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/BoxView.xml" path="//Member[@MemberName='CornerRadiusProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="CornerRadius"/>.</summary>
 		public static readonly BindableProperty CornerRadiusProperty = CornerElement.CornerRadiusProperty;
 
 		readonly Lazy<PlatformConfigurationRegistry<BoxView>> _platformConfigurationRegistry;

--- a/src/Controls/src/Core/Cells/Cell.cs
+++ b/src/Controls/src/Core/Cells/Cell.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Maui.Controls
 	{
 		/// <include file="../../../docs/Microsoft.Maui.Controls/Cell.xml" path="//Member[@MemberName='DefaultCellHeight']/Docs/*" />
 		public const int DefaultCellHeight = 40;
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Cell.xml" path="//Member[@MemberName='IsEnabledProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="IsEnabled"/>.</summary>
 		public static readonly BindableProperty IsEnabledProperty = BindableProperty.Create("IsEnabled", typeof(bool), typeof(Cell), true, propertyChanged: OnIsEnabledPropertyChanged);
 
 		ObservableCollection<MenuItem> _contextActions;

--- a/src/Controls/src/Core/Cells/EntryCell.cs
+++ b/src/Controls/src/Core/Cells/EntryCell.cs
@@ -1,4 +1,4 @@
-﻿#nullable disable
+#nullable disable
 using System;
 using System.ComponentModel;
 using Microsoft.Maui.Graphics;
@@ -8,25 +8,25 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../../docs/Microsoft.Maui.Controls/EntryCell.xml" path="Type[@FullName='Microsoft.Maui.Controls.EntryCell']/Docs/*" />
 	public class EntryCell : Cell, ITextAlignmentElement, IEntryCellController, ITextAlignment
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Controls/EntryCell.xml" path="//Member[@MemberName='TextProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Text"/>.</summary>
 		public static readonly BindableProperty TextProperty = BindableProperty.Create("Text", typeof(string), typeof(EntryCell), null, BindingMode.TwoWay);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/EntryCell.xml" path="//Member[@MemberName='LabelProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Label"/>.</summary>
 		public static readonly BindableProperty LabelProperty = BindableProperty.Create("Label", typeof(string), typeof(EntryCell), null);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/EntryCell.xml" path="//Member[@MemberName='PlaceholderProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Placeholder"/>.</summary>
 		public static readonly BindableProperty PlaceholderProperty = BindableProperty.Create("Placeholder", typeof(string), typeof(EntryCell), null);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/EntryCell.xml" path="//Member[@MemberName='LabelColorProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="LabelColor"/>.</summary>
 		public static readonly BindableProperty LabelColorProperty = BindableProperty.Create("LabelColor", typeof(Color), typeof(EntryCell), null);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/EntryCell.xml" path="//Member[@MemberName='KeyboardProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Keyboard"/>.</summary>
 		public static readonly BindableProperty KeyboardProperty = BindableProperty.Create("Keyboard", typeof(Keyboard), typeof(EntryCell), Keyboard.Default);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/EntryCell.xml" path="//Member[@MemberName='HorizontalTextAlignmentProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="HorizontalTextAlignment"/>.</summary>
 		public static readonly BindableProperty HorizontalTextAlignmentProperty = TextAlignmentElement.HorizontalTextAlignmentProperty;
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/EntryCell.xml" path="//Member[@MemberName='VerticalTextAlignmentProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="VerticalTextAlignment"/>.</summary>
 		public static readonly BindableProperty VerticalTextAlignmentProperty = TextAlignmentElement.VerticalTextAlignmentProperty;
 
 		/// <include file="../../../docs/Microsoft.Maui.Controls/EntryCell.xml" path="//Member[@MemberName='HorizontalTextAlignment']/Docs/*" />

--- a/src/Controls/src/Core/Cells/ImageCell.cs
+++ b/src/Controls/src/Core/Cells/ImageCell.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../../docs/Microsoft.Maui.Controls/ImageCell.xml" path="Type[@FullName='Microsoft.Maui.Controls.ImageCell']/Docs/*" />
 	public class ImageCell : TextCell
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Controls/ImageCell.xml" path="//Member[@MemberName='ImageSourceProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="ImageSource"/>.</summary>
 		public static readonly BindableProperty ImageSourceProperty = BindableProperty.Create("ImageSource", typeof(ImageSource), typeof(ImageCell), null,
 			propertyChanging: (bindable, oldvalue, newvalue) => ((ImageCell)bindable).OnSourcePropertyChanging((ImageSource)oldvalue, (ImageSource)newvalue),
 			propertyChanged: (bindable, oldvalue, newvalue) => ((ImageCell)bindable).OnSourcePropertyChanged((ImageSource)oldvalue, (ImageSource)newvalue));

--- a/src/Controls/src/Core/Cells/SwitchCell.cs
+++ b/src/Controls/src/Core/Cells/SwitchCell.cs
@@ -1,4 +1,4 @@
-﻿#nullable disable
+#nullable disable
 using System;
 using Microsoft.Maui.Graphics;
 
@@ -7,17 +7,17 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../../docs/Microsoft.Maui.Controls/SwitchCell.xml" path="Type[@FullName='Microsoft.Maui.Controls.SwitchCell']/Docs/*" />
 	public class SwitchCell : Cell
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Controls/SwitchCell.xml" path="//Member[@MemberName='OnProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="On"/>.</summary>
 		public static readonly BindableProperty OnProperty = BindableProperty.Create("On", typeof(bool), typeof(SwitchCell), false, propertyChanged: (obj, oldValue, newValue) =>
 		{
 			var switchCell = (SwitchCell)obj;
 			switchCell.OnChanged?.Invoke(obj, new ToggledEventArgs((bool)newValue));
 		}, defaultBindingMode: BindingMode.TwoWay);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/SwitchCell.xml" path="//Member[@MemberName='TextProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Text"/>.</summary>
 		public static readonly BindableProperty TextProperty = BindableProperty.Create("Text", typeof(string), typeof(SwitchCell), default(string));
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/SwitchCell.xml" path="//Member[@MemberName='OnColorProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="OnColor"/>.</summary>
 		public static readonly BindableProperty OnColorProperty = BindableProperty.Create(nameof(OnColor), typeof(Color), typeof(SwitchCell), null);
 
 		/// <include file="../../../docs/Microsoft.Maui.Controls/SwitchCell.xml" path="//Member[@MemberName='OnColor']/Docs/*" />

--- a/src/Controls/src/Core/Cells/TextCell.cs
+++ b/src/Controls/src/Core/Cells/TextCell.cs
@@ -1,4 +1,4 @@
-﻿#nullable disable
+#nullable disable
 using System;
 using System.Windows.Input;
 using Microsoft.Maui.Graphics;
@@ -8,7 +8,7 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../../docs/Microsoft.Maui.Controls/TextCell.xml" path="Type[@FullName='Microsoft.Maui.Controls.TextCell']/Docs/*" />
 	public class TextCell : Cell
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Controls/TextCell.xml" path="//Member[@MemberName='CommandProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Command"/>.</summary>
 		public static readonly BindableProperty CommandProperty = BindableProperty.Create("Command", typeof(ICommand), typeof(TextCell), default(ICommand),
 			propertyChanging: (bindable, oldvalue, newvalue) =>
 			{
@@ -27,7 +27,7 @@ namespace Microsoft.Maui.Controls
 				}
 			});
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/TextCell.xml" path="//Member[@MemberName='CommandParameterProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="CommandParameter"/>.</summary>
 		public static readonly BindableProperty CommandParameterProperty = BindableProperty.Create("CommandParameter", typeof(object), typeof(TextCell), default(object),
 			propertyChanged: (bindable, oldvalue, newvalue) =>
 			{
@@ -38,16 +38,16 @@ namespace Microsoft.Maui.Controls
 				}
 			});
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/TextCell.xml" path="//Member[@MemberName='TextProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Text"/>.</summary>
 		public static readonly BindableProperty TextProperty = BindableProperty.Create("Text", typeof(string), typeof(TextCell), default(string));
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/TextCell.xml" path="//Member[@MemberName='DetailProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Detail"/>.</summary>
 		public static readonly BindableProperty DetailProperty = BindableProperty.Create("Detail", typeof(string), typeof(TextCell), default(string));
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/TextCell.xml" path="//Member[@MemberName='TextColorProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="TextColor"/>.</summary>
 		public static readonly BindableProperty TextColorProperty = BindableProperty.Create("TextColor", typeof(Color), typeof(TextCell), null);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/TextCell.xml" path="//Member[@MemberName='DetailColorProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="DetailColor"/>.</summary>
 		public static readonly BindableProperty DetailColorProperty = BindableProperty.Create("DetailColor", typeof(Color), typeof(TextCell), null);
 
 		/// <include file="../../../docs/Microsoft.Maui.Controls/TextCell.xml" path="//Member[@MemberName='Command']/Docs/*" />

--- a/src/Controls/src/Core/CheckBox.cs
+++ b/src/Controls/src/Core/CheckBox.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Maui.Controls
 		/// <include file="../../docs/Microsoft.Maui.Controls/CheckBox.xml" path="//Member[@MemberName='IsCheckedVisualState']/Docs/*" />
 		public const string IsCheckedVisualState = "IsChecked";
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/CheckBox.xml" path="//Member[@MemberName='IsCheckedProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="IsChecked"/>.</summary>
 		public static readonly BindableProperty IsCheckedProperty =
 			BindableProperty.Create(nameof(IsChecked), typeof(bool), typeof(CheckBox), false,
 				propertyChanged: (bindable, oldValue, newValue) =>
@@ -21,7 +21,7 @@ namespace Microsoft.Maui.Controls
 					((CheckBox)bindable).ChangeVisualState();
 				}, defaultBindingMode: BindingMode.TwoWay);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/CheckBox.xml" path="//Member[@MemberName='ColorProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Color"/>.</summary>
 		public static readonly BindableProperty ColorProperty = ColorElement.ColorProperty;
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/CheckBox.xml" path="//Member[@MemberName='Color']/Docs/*" />

--- a/src/Controls/src/Core/ClickGestureRecognizer.cs
+++ b/src/Controls/src/Core/ClickGestureRecognizer.cs
@@ -8,16 +8,16 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../docs/Microsoft.Maui.Controls/ClickGestureRecognizer.xml" path="Type[@FullName='Microsoft.Maui.Controls.ClickGestureRecognizer']/Docs/*" />
 	public sealed class ClickGestureRecognizer : GestureRecognizer
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/ClickGestureRecognizer.xml" path="//Member[@MemberName='CommandProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Command"/>.</summary>
 		public static readonly BindableProperty CommandProperty = BindableProperty.Create(nameof(Command), typeof(ICommand), typeof(ClickGestureRecognizer), null);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ClickGestureRecognizer.xml" path="//Member[@MemberName='CommandParameterProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="CommandParameter"/>.</summary>
 		public static readonly BindableProperty CommandParameterProperty = BindableProperty.Create(nameof(CommandParameter), typeof(object), typeof(ClickGestureRecognizer), null);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ClickGestureRecognizer.xml" path="//Member[@MemberName='NumberOfClicksRequiredProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="NumberOfClicksRequired"/>.</summary>
 		public static readonly BindableProperty NumberOfClicksRequiredProperty = BindableProperty.Create(nameof(NumberOfClicksRequired), typeof(int), typeof(ClickGestureRecognizer), 1);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ClickGestureRecognizer.xml" path="//Member[@MemberName='ButtonsProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Buttons"/>.</summary>
 		public static readonly BindableProperty ButtonsProperty = BindableProperty.Create(nameof(Buttons), typeof(ButtonsMask), typeof(ClickGestureRecognizer), ButtonsMask.Primary);
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/ClickGestureRecognizer.xml" path="//Member[@MemberName='.ctor']/Docs/*" />

--- a/src/Controls/src/Core/ColorElement.cs
+++ b/src/Controls/src/Core/ColorElement.cs
@@ -1,10 +1,11 @@
-﻿#nullable disable
+#nullable disable
 using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Controls
 {
 	static class ColorElement
 	{
+		/// <summary>Bindable property for <see cref="Color"/>.</summary>
 		public static readonly BindableProperty ColorProperty =
 			BindableProperty.Create(nameof(IColorElement.Color), typeof(Color), typeof(IColorElement), null);
 	}

--- a/src/Controls/src/Core/ColumnDefinition.cs
+++ b/src/Controls/src/Core/ColumnDefinition.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../docs/Microsoft.Maui.Controls/ColumnDefinition.xml" path="Type[@FullName='Microsoft.Maui.Controls.ColumnDefinition']/Docs/*" />
 	public sealed class ColumnDefinition : BindableObject, IDefinition, IGridColumnDefinition
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/ColumnDefinition.xml" path="//Member[@MemberName='WidthProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Width"/>.</summary>
 		public static readonly BindableProperty WidthProperty = BindableProperty.Create(nameof(Width), typeof(GridLength), typeof(ColumnDefinition), GridLength.Star,
 			propertyChanged: (bindable, oldValue, newValue) => ((ColumnDefinition)bindable).OnSizeChanged());
 

--- a/src/Controls/src/Core/CompareStateTrigger.cs
+++ b/src/Controls/src/Core/CompareStateTrigger.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Maui.Controls
 			set => SetValue(PropertyProperty, value);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/CompareStateTrigger.xml" path="//Member[@MemberName='PropertyProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Property"/>.</summary>
 		public static readonly BindableProperty PropertyProperty =
 		BindableProperty.Create(nameof(Property), typeof(object), typeof(CompareStateTrigger), null,
 			propertyChanged: OnPropertyChanged);
@@ -37,7 +37,7 @@ namespace Microsoft.Maui.Controls
 			set => SetValue(ValueProperty, value);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/CompareStateTrigger.xml" path="//Member[@MemberName='ValueProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Value"/>.</summary>
 		public static readonly BindableProperty ValueProperty =
 		BindableProperty.Create(nameof(Value), typeof(object), typeof(CompareStateTrigger), null,
 			propertyChanged: OnValueChanged);

--- a/src/Controls/src/Core/CompressedLayout.cs
+++ b/src/Controls/src/Core/CompressedLayout.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../docs/Microsoft.Maui.Controls/CompressedLayout.xml" path="Type[@FullName='Microsoft.Maui.Controls.CompressedLayout']/Docs/*" />
 	public static class CompressedLayout
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/CompressedLayout.xml" path="//Member[@MemberName='IsHeadlessProperty']/Docs/*" />
+		/// <summary>Bindable property for <c>IsHeadless</c>.</summary>
 		public static readonly BindableProperty IsHeadlessProperty =
 			BindableProperty.Create("IsHeadless", typeof(bool), typeof(CompressedLayout), default(bool),
 				propertyChanged: OnIsHeadlessPropertyChanged);
@@ -33,7 +33,7 @@ namespace Microsoft.Maui.Controls
 		static readonly BindablePropertyKey HeadlessOffsetPropertyKey =
 			BindableProperty.CreateReadOnly("HeadlessOffset", typeof(Point), typeof(CompressedLayout), default(Point));
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/CompressedLayout.xml" path="//Member[@MemberName='HeadlessOffsetProperty']/Docs/*" />
+		/// <summary>Bindable property for <c>HeadlessOffset</c>.</summary>
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static readonly BindableProperty HeadlessOffsetProperty = HeadlessOffsetPropertyKey.BindableProperty;
 

--- a/src/Controls/src/Core/ContentPage.cs
+++ b/src/Controls/src/Core/ContentPage.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Maui.Controls
 	[ContentProperty("Content")]
 	public partial class ContentPage : TemplatedPage
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/ContentPage.xml" path="//Member[@MemberName='ContentProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Content"/>.</summary>
 		public static readonly BindableProperty ContentProperty = BindableProperty.Create(nameof(Content), typeof(View), typeof(ContentPage), null, propertyChanged: TemplateUtilities.OnContentChanged);
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/ContentPage.xml" path="//Member[@MemberName='Content']/Docs/*" />

--- a/src/Controls/src/Core/ContentView.cs
+++ b/src/Controls/src/Core/ContentView.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Maui.Controls
 	[ContentProperty("Content")]
 	public partial class ContentView : TemplatedView
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/ContentView.xml" path="//Member[@MemberName='ContentProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Content"/>.</summary>
 		public static readonly BindableProperty ContentProperty = BindableProperty.Create(nameof(Content), typeof(View), typeof(ContentView), null, propertyChanged: TemplateUtilities.OnContentChanged);
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/ContentView.xml" path="//Member[@MemberName='Content']/Docs/*" />

--- a/src/Controls/src/Core/CornerElement.cs
+++ b/src/Controls/src/Core/CornerElement.cs
@@ -3,6 +3,7 @@ namespace Microsoft.Maui.Controls
 {
 	static class CornerElement
 	{
+		/// <summary>Bindable property for <see cref="CornerRadius"/>.</summary>
 		public static readonly BindableProperty CornerRadiusProperty =
 			BindableProperty.Create(nameof(CornerRadius), typeof(CornerRadius), typeof(ICornerElement), default(CornerRadius));
 	}

--- a/src/Controls/src/Core/DatePicker.cs
+++ b/src/Controls/src/Core/DatePicker.cs
@@ -8,38 +8,39 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../docs/Microsoft.Maui.Controls/DatePicker.xml" path="Type[@FullName='Microsoft.Maui.Controls.DatePicker']/Docs/*" />
 	public partial class DatePicker : View, IFontElement, ITextElement, IElementConfiguration<DatePicker>
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/DatePicker.xml" path="//Member[@MemberName='FormatProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Format"/>.</summary>
 		public static readonly BindableProperty FormatProperty = BindableProperty.Create(nameof(Format), typeof(string), typeof(DatePicker), "d");
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/DatePicker.xml" path="//Member[@MemberName='DateProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Date"/>.</summary>
 		public static readonly BindableProperty DateProperty = BindableProperty.Create(nameof(Date), typeof(DateTime), typeof(DatePicker), default(DateTime), BindingMode.TwoWay,
 			coerceValue: CoerceDate,
 			propertyChanged: DatePropertyChanged,
 			defaultValueCreator: (bindable) => DateTime.Today);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/DatePicker.xml" path="//Member[@MemberName='MinimumDateProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="MinimumDate"/>.</summary>
 		public static readonly BindableProperty MinimumDateProperty = BindableProperty.Create(nameof(MinimumDate), typeof(DateTime), typeof(DatePicker), new DateTime(1900, 1, 1),
 			validateValue: ValidateMinimumDate, coerceValue: CoerceMinimumDate);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/DatePicker.xml" path="//Member[@MemberName='MaximumDateProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="MaximumDate"/>.</summary>
 		public static readonly BindableProperty MaximumDateProperty = BindableProperty.Create(nameof(MaximumDate), typeof(DateTime), typeof(DatePicker), new DateTime(2100, 12, 31),
 			validateValue: ValidateMaximumDate, coerceValue: CoerceMaximumDate);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/DatePicker.xml" path="//Member[@MemberName='TextColorProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="TextColor"/>.</summary>
 		public static readonly BindableProperty TextColorProperty = TextElement.TextColorProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/DatePicker.xml" path="//Member[@MemberName='CharacterSpacingProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="CharacterSpacing"/>.</summary>
 		public static readonly BindableProperty CharacterSpacingProperty = TextElement.CharacterSpacingProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/DatePicker.xml" path="//Member[@MemberName='FontFamilyProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="FontFamily"/>.</summary>
 		public static readonly BindableProperty FontFamilyProperty = FontElement.FontFamilyProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/DatePicker.xml" path="//Member[@MemberName='FontSizeProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="FontSize"/>.</summary>
 		public static readonly BindableProperty FontSizeProperty = FontElement.FontSizeProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/DatePicker.xml" path="//Member[@MemberName='FontAttributesProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="FontAttributes"/>.</summary>
 		public static readonly BindableProperty FontAttributesProperty = FontElement.FontAttributesProperty;
 
+		/// <summary>Bindable property for <see cref="FontAutoScalingEnabled"/>.</summary>
 		public static readonly BindableProperty FontAutoScalingEnabledProperty = FontElement.FontAutoScalingEnabledProperty;
 
 		readonly Lazy<PlatformConfigurationRegistry<DatePicker>> _platformConfigurationRegistry;

--- a/src/Controls/src/Core/DecorableTextElement.cs
+++ b/src/Controls/src/Core/DecorableTextElement.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Maui.Controls
 {
 	static class DecorableTextElement
 	{
+		/// <summary>Bindable property for <see cref="TextDecorations"/>.</summary>
 		public static readonly BindableProperty TextDecorationsProperty = BindableProperty.Create(nameof(IDecorableTextElement.TextDecorations), typeof(TextDecorations), typeof(IDecorableTextElement), TextDecorations.None);
 	}
 

--- a/src/Controls/src/Core/DeviceStateTrigger.cs
+++ b/src/Controls/src/Core/DeviceStateTrigger.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Maui.Controls
 			set => SetValue(DeviceProperty, value);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/DeviceStateTrigger.xml" path="//Member[@MemberName='DeviceProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Device"/>.</summary>
 		public static readonly BindableProperty DeviceProperty =
 			BindableProperty.Create(nameof(Device), typeof(string), typeof(DeviceStateTrigger), string.Empty,
 				propertyChanged: OnDeviceChanged);

--- a/src/Controls/src/Core/DragAndDrop/DragGestureRecognizer.cs
+++ b/src/Controls/src/Core/DragAndDrop/DragGestureRecognizer.cs
@@ -13,19 +13,19 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../../docs/Microsoft.Maui.Controls/DragGestureRecognizer.xml" path="Type[@FullName='Microsoft.Maui.Controls.DragGestureRecognizer']/Docs/*" />
 	public class DragGestureRecognizer : GestureRecognizer
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Controls/DragGestureRecognizer.xml" path="//Member[@MemberName='CanDragProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="CanDrag"/>.</summary>
 		public static readonly BindableProperty CanDragProperty = BindableProperty.Create(nameof(CanDrag), typeof(bool), typeof(DragGestureRecognizer), true);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/DragGestureRecognizer.xml" path="//Member[@MemberName='DropCompletedCommandProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="DropCompletedCommand"/>.</summary>
 		public static readonly BindableProperty DropCompletedCommandProperty = BindableProperty.Create(nameof(DropCompletedCommand), typeof(ICommand), typeof(DragGestureRecognizer), null);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/DragGestureRecognizer.xml" path="//Member[@MemberName='DropCompletedCommandParameterProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="DropCompletedCommandParameter"/>.</summary>
 		public static readonly BindableProperty DropCompletedCommandParameterProperty = BindableProperty.Create(nameof(DropCompletedCommandParameter), typeof(object), typeof(DragGestureRecognizer), null);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/DragGestureRecognizer.xml" path="//Member[@MemberName='DragStartingCommandProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="DragStartingCommand"/>.</summary>
 		public static readonly BindableProperty DragStartingCommandProperty = BindableProperty.Create(nameof(DragStartingCommand), typeof(ICommand), typeof(DragGestureRecognizer), null);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/DragGestureRecognizer.xml" path="//Member[@MemberName='DragStartingCommandParameterProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="DragStartingCommandParameter"/>.</summary>
 		public static readonly BindableProperty DragStartingCommandParameterProperty = BindableProperty.Create(nameof(DragStartingCommandParameter), typeof(object), typeof(DragGestureRecognizer), null);
 
 		bool _isDragActive;

--- a/src/Controls/src/Core/DragAndDrop/DropGestureRecognizer.cs
+++ b/src/Controls/src/Core/DragAndDrop/DropGestureRecognizer.cs
@@ -11,25 +11,25 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../../docs/Microsoft.Maui.Controls/DropGestureRecognizer.xml" path="Type[@FullName='Microsoft.Maui.Controls.DropGestureRecognizer']/Docs/*" />
 	public class DropGestureRecognizer : GestureRecognizer
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Controls/DropGestureRecognizer.xml" path="//Member[@MemberName='AllowDropProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="AllowDrop"/>.</summary>
 		public static readonly BindableProperty AllowDropProperty = BindableProperty.Create(nameof(AllowDrop), typeof(bool), typeof(DropGestureRecognizer), true);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/DropGestureRecognizer.xml" path="//Member[@MemberName='DragOverCommandProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="DragOverCommand"/>.</summary>
 		public static readonly BindableProperty DragOverCommandProperty = BindableProperty.Create(nameof(DragOverCommand), typeof(ICommand), typeof(DropGestureRecognizer), null);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/DropGestureRecognizer.xml" path="//Member[@MemberName='DragOverCommandParameterProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="DragOverCommandParameter"/>.</summary>
 		public static readonly BindableProperty DragOverCommandParameterProperty = BindableProperty.Create(nameof(DragOverCommandParameter), typeof(object), typeof(DropGestureRecognizer), null);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/DropGestureRecognizer.xml" path="//Member[@MemberName='DragLeaveCommandProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="DragLeaveCommand"/>.</summary>
 		public static readonly BindableProperty DragLeaveCommandProperty = BindableProperty.Create(nameof(DragLeaveCommand), typeof(ICommand), typeof(DropGestureRecognizer), null);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/DropGestureRecognizer.xml" path="//Member[@MemberName='DragLeaveCommandParameterProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="DragLeaveCommandParameter"/>.</summary>
 		public static readonly BindableProperty DragLeaveCommandParameterProperty = BindableProperty.Create(nameof(DragLeaveCommandParameter), typeof(object), typeof(DropGestureRecognizer), null);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/DropGestureRecognizer.xml" path="//Member[@MemberName='DropCommandProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="DropCommand"/>.</summary>
 		public static readonly BindableProperty DropCommandProperty = BindableProperty.Create(nameof(DropCommand), typeof(ICommand), typeof(DragGestureRecognizer), null);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/DropGestureRecognizer.xml" path="//Member[@MemberName='DropCommandParameterProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="DropCommandParameter"/>.</summary>
 		public static readonly BindableProperty DropCommandParameterProperty = BindableProperty.Create(nameof(DropCommandParameter), typeof(object), typeof(DropGestureRecognizer), null);
 
 		/// <include file="../../../docs/Microsoft.Maui.Controls/DropGestureRecognizer.xml" path="//Member[@MemberName='.ctor']/Docs/*" />

--- a/src/Controls/src/Core/Editor.cs
+++ b/src/Controls/src/Core/Editor.cs
@@ -11,15 +11,16 @@ namespace Microsoft.Maui.Controls
 		/// <include file="../../docs/Microsoft.Maui.Controls/Editor.xml" path="//Member[@MemberName='TextProperty']/Docs/*" />
 		public new static readonly BindableProperty TextProperty = InputView.TextProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Editor.xml" path="//Member[@MemberName='FontFamilyProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="FontFamily"/>.</summary>
 		public static readonly BindableProperty FontFamilyProperty = FontElement.FontFamilyProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Editor.xml" path="//Member[@MemberName='FontSizeProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="FontSize"/>.</summary>
 		public static readonly BindableProperty FontSizeProperty = FontElement.FontSizeProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Editor.xml" path="//Member[@MemberName='FontAttributesProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="FontAttributes"/>.</summary>
 		public static readonly BindableProperty FontAttributesProperty = FontElement.FontAttributesProperty;
 
+		/// <summary>Bindable property for <see cref="FontAutoScalingEnabled"/>.</summary>
 		public static readonly BindableProperty FontAutoScalingEnabledProperty = FontElement.FontAutoScalingEnabledProperty;
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/Editor.xml" path="//Member[@MemberName='TextColorProperty']/Docs/*" />
@@ -34,19 +35,23 @@ namespace Microsoft.Maui.Controls
 		/// <include file="../../docs/Microsoft.Maui.Controls/Editor.xml" path="//Member[@MemberName='PlaceholderColorProperty']/Docs/*" />
 		public new static readonly BindableProperty PlaceholderColorProperty = InputView.PlaceholderColorProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Editor.xml" path="//Member[@MemberName='IsTextPredictionEnabledProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="IsTextPredictionEnabled"/>.</summary>
 		public static readonly BindableProperty IsTextPredictionEnabledProperty = BindableProperty.Create(nameof(IsTextPredictionEnabled), typeof(bool), typeof(Editor), true, BindingMode.Default);
 
+		/// <summary>Bindable property for <see cref="CursorPosition"/>.</summary>
 		public static readonly BindableProperty CursorPositionProperty = BindableProperty.Create(nameof(CursorPosition), typeof(int), typeof(Editor), 0, validateValue: (b, v) => (int)v >= 0);
 
+		/// <summary>Bindable property for <see cref="SelectionLength"/>.</summary>
 		public static readonly BindableProperty SelectionLengthProperty = BindableProperty.Create(nameof(SelectionLength), typeof(int), typeof(Editor), 0, validateValue: (b, v) => (int)v >= 0);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Editor.xml" path="//Member[@MemberName='AutoSizeProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="AutoSize"/>.</summary>
 		public static readonly BindableProperty AutoSizeProperty = BindableProperty.Create(nameof(AutoSize), typeof(EditorAutoSizeOption), typeof(Editor), defaultValue: EditorAutoSizeOption.Disabled, propertyChanged: (bindable, oldValue, newValue)
 			=> ((Editor)bindable)?.UpdateAutoSizeOption());
 
+		/// <summary>Bindable property for <see cref="HorizontalTextAlignment"/>.</summary>
 		public static readonly BindableProperty HorizontalTextAlignmentProperty = TextAlignmentElement.HorizontalTextAlignmentProperty;
 
+		/// <summary>Bindable property for <see cref="VerticalTextAlignment"/>.</summary>
 		public static readonly BindableProperty VerticalTextAlignmentProperty = BindableProperty.Create(nameof(VerticalTextAlignment), typeof(TextAlignment), typeof(Editor), TextAlignment.Start);
 
 		readonly Lazy<PlatformConfigurationRegistry<Editor>> _platformConfigurationRegistry;

--- a/src/Controls/src/Core/Element.cs
+++ b/src/Controls/src/Core/Element.cs
@@ -15,10 +15,10 @@ namespace Microsoft.Maui.Controls
 	{
 		internal static readonly ReadOnlyCollection<Element> EmptyChildren = new ReadOnlyCollection<Element>(Array.Empty<Element>());
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Element.xml" path="//Member[@MemberName='AutomationIdProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="AutomationId"/>.</summary>
 		public static readonly BindableProperty AutomationIdProperty = BindableProperty.Create(nameof(AutomationId), typeof(string), typeof(Element), null);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Element.xml" path="//Member[@MemberName='ClassIdProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="ClassId"/>.</summary>
 		public static readonly BindableProperty ClassIdProperty = BindableProperty.Create(nameof(ClassId), typeof(string), typeof(Element), null);
 
 		IList<BindableObject> _bindableResources;

--- a/src/Controls/src/Core/FileImageSource.cs
+++ b/src/Controls/src/Core/FileImageSource.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Maui.Controls
 	[System.ComponentModel.TypeConverter(typeof(FileImageSourceConverter))]
 	public sealed partial class FileImageSource : ImageSource
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/FileImageSource.xml" path="//Member[@MemberName='FileProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="File"/>.</summary>
 		public static readonly BindableProperty FileProperty = BindableProperty.Create("File", typeof(string), typeof(FileImageSource), default(string));
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/FileImageSource.xml" path="//Member[@MemberName='IsEmpty']/Docs/*" />

--- a/src/Controls/src/Core/FlyoutBase.cs
+++ b/src/Controls/src/Core/FlyoutBase.cs
@@ -3,7 +3,7 @@ namespace Microsoft.Maui.Controls
 {
 	public abstract class FlyoutBase : Element, IFlyout
 	{
-		/// <summary>Bindable property for <see cref="ContextFlyout"/>.</summary>
+		/// <summary>Bindable property for attached property <c>ContextFlyout</c>.</summary>
 		public static readonly BindableProperty ContextFlyoutProperty = BindableProperty.CreateAttached("ContextFlyout", typeof(FlyoutBase), typeof(FlyoutBase), null,
 			propertyChanged: (bo, oldV, newV) =>
 			{

--- a/src/Controls/src/Core/FlyoutBase.cs
+++ b/src/Controls/src/Core/FlyoutBase.cs
@@ -1,8 +1,9 @@
-﻿#nullable disable
+#nullable disable
 namespace Microsoft.Maui.Controls
 {
 	public abstract class FlyoutBase : Element, IFlyout
 	{
+		/// <summary>Bindable property for <see cref="ContextFlyout"/>.</summary>
 		public static readonly BindableProperty ContextFlyoutProperty = BindableProperty.CreateAttached("ContextFlyout", typeof(FlyoutBase), typeof(FlyoutBase), null,
 			propertyChanged: (bo, oldV, newV) =>
 			{

--- a/src/Controls/src/Core/FlyoutPage.cs
+++ b/src/Controls/src/Core/FlyoutPage.cs
@@ -13,14 +13,14 @@ namespace Microsoft.Maui.Controls
 	[ContentProperty(nameof(Detail))]
 	public partial class FlyoutPage : Page, IFlyoutPageController, IElementConfiguration<FlyoutPage>
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/FlyoutPage.xml" path="//Member[@MemberName='IsGestureEnabledProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="IsGestureEnabled"/>.</summary>
 		public static readonly BindableProperty IsGestureEnabledProperty = BindableProperty.Create(nameof(IsGestureEnabled), typeof(bool), typeof(FlyoutPage), true);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/FlyoutPage.xml" path="//Member[@MemberName='IsPresentedProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="IsPresented"/>.</summary>
 		public static readonly BindableProperty IsPresentedProperty = BindableProperty.Create(nameof(IsPresented), typeof(bool), typeof(FlyoutPage), default(bool),
 			propertyChanged: OnIsPresentedPropertyChanged, propertyChanging: OnIsPresentedPropertyChanging, defaultValueCreator: GetDefaultValue);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/FlyoutPage.xml" path="//Member[@MemberName='FlyoutLayoutBehaviorProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="FlyoutLayoutBehavior"/>.</summary>
 		public static readonly BindableProperty FlyoutLayoutBehaviorProperty = BindableProperty.Create(nameof(FlyoutLayoutBehavior), typeof(FlyoutLayoutBehavior), typeof(FlyoutPage), default(FlyoutLayoutBehavior),
 			propertyChanged: OnFlyoutLayoutBehaviorPropertyChanged);
 

--- a/src/Controls/src/Core/FontImageSource.cs
+++ b/src/Controls/src/Core/FontImageSource.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Maui.Controls
 		/// <include file="../../docs/Microsoft.Maui.Controls/FontImageSource.xml" path="//Member[@MemberName='IsEmpty']/Docs/*" />
 		public override bool IsEmpty => string.IsNullOrEmpty(Glyph);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/FontImageSource.xml" path="//Member[@MemberName='ColorProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Color"/>.</summary>
 		public static readonly BindableProperty ColorProperty = BindableProperty.Create(nameof(Color), typeof(Color), typeof(FontImageSource), default(Color),
 			propertyChanged: (b, o, n) => ((FontImageSource)b).OnSourceChanged());
 
@@ -20,7 +20,7 @@ namespace Microsoft.Maui.Controls
 			set => SetValue(ColorProperty, value);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/FontImageSource.xml" path="//Member[@MemberName='FontFamilyProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="FontFamily"/>.</summary>
 		public static readonly BindableProperty FontFamilyProperty = BindableProperty.Create(nameof(FontFamily), typeof(string), typeof(FontImageSource), default(string),
 			propertyChanged: (b, o, n) => ((FontImageSource)b).OnSourceChanged());
 
@@ -31,7 +31,7 @@ namespace Microsoft.Maui.Controls
 			set => SetValue(FontFamilyProperty, value);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/FontImageSource.xml" path="//Member[@MemberName='GlyphProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Glyph"/>.</summary>
 		public static readonly BindableProperty GlyphProperty = BindableProperty.Create(nameof(Glyph), typeof(string), typeof(FontImageSource), default(string),
 			propertyChanged: (b, o, n) => ((FontImageSource)b).OnSourceChanged());
 
@@ -42,7 +42,7 @@ namespace Microsoft.Maui.Controls
 			set => SetValue(GlyphProperty, value);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/FontImageSource.xml" path="//Member[@MemberName='SizeProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Size"/>.</summary>
 		public static readonly BindableProperty SizeProperty = BindableProperty.Create(nameof(Size), typeof(double), typeof(FontImageSource), 30d,
 			propertyChanged: (b, o, n) => ((FontImageSource)b).OnSourceChanged());
 
@@ -54,6 +54,7 @@ namespace Microsoft.Maui.Controls
 			set => SetValue(SizeProperty, value);
 		}
 
+		/// <summary>Bindable property for <see cref="FontAutoScalingEnabled"/>.</summary>
 		public static readonly BindableProperty FontAutoScalingEnabledProperty =
 			BindableProperty.Create("FontAutoScalingEnabled", typeof(bool), typeof(FontImageSource), false,
 				propertyChanged: (b, o, n) => ((FontImageSource)b).OnSourceChanged());

--- a/src/Controls/src/Core/Frame.cs
+++ b/src/Controls/src/Core/Frame.cs
@@ -9,13 +9,13 @@ namespace Microsoft.Maui.Controls
 	[ContentProperty(nameof(Content))]
 	public partial class Frame : ContentView, IElementConfiguration<Frame>, IPaddingElement, IBorderElement, IContentView
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/Frame.xml" path="//Member[@MemberName='BorderColorProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="BorderColor"/>.</summary>
 		public static readonly BindableProperty BorderColorProperty = BorderElement.BorderColorProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Frame.xml" path="//Member[@MemberName='HasShadowProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="HasShadow"/>.</summary>
 		public static readonly BindableProperty HasShadowProperty = BindableProperty.Create("HasShadow", typeof(bool), typeof(Frame), true);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Frame.xml" path="//Member[@MemberName='CornerRadiusProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="CornerRadius"/>.</summary>
 		public static readonly BindableProperty CornerRadiusProperty = BindableProperty.Create(nameof(CornerRadius), typeof(float), typeof(Frame), -1.0f,
 									validateValue: (bindable, value) => ((float)value) == -1.0f || ((float)value) >= 0f);
 

--- a/src/Controls/src/Core/GradientBrush.cs
+++ b/src/Controls/src/Core/GradientBrush.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Maui.Controls
 
 		public event EventHandler InvalidateGradientBrushRequested;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/GradientBrush.xml" path="//Member[@MemberName='GradientStopsProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="GradientStops"/>.</summary>
 		public static readonly BindableProperty GradientStopsProperty =
 			BindableProperty.Create(nameof(GradientStops), typeof(GradientStopCollection), typeof(GradientBrush), null,
 				propertyChanged: OnGradientStopsChanged);

--- a/src/Controls/src/Core/GradientStop.cs
+++ b/src/Controls/src/Core/GradientStop.cs
@@ -1,4 +1,4 @@
-﻿#nullable disable
+#nullable disable
 using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Controls
@@ -6,7 +6,7 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../docs/Microsoft.Maui.Controls/GradientStop.xml" path="Type[@FullName='Microsoft.Maui.Controls.GradientStop']/Docs/*" />
 	public class GradientStop : Element
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/GradientStop.xml" path="//Member[@MemberName='ColorProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Color"/>.</summary>
 		public static readonly BindableProperty ColorProperty = BindableProperty.Create(
 			nameof(Color), typeof(Color), typeof(GradientStop), null);
 
@@ -17,7 +17,7 @@ namespace Microsoft.Maui.Controls
 			set => SetValue(ColorProperty, value);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/GradientStop.xml" path="//Member[@MemberName='OffsetProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Offset"/>.</summary>
 		public static readonly BindableProperty OffsetProperty = BindableProperty.Create(
 			nameof(Offset), typeof(float), typeof(GradientStop), 0f);
 

--- a/src/Controls/src/Core/HandlerImpl/GraphicsView.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/GraphicsView.Impl.cs
@@ -1,4 +1,4 @@
-﻿#nullable disable
+#nullable disable
 using System;
 using Microsoft.Maui.Graphics;
 
@@ -14,6 +14,7 @@ namespace Microsoft.Maui.Controls
 		public event EventHandler<TouchEventArgs> EndInteraction;
 		public event EventHandler CancelInteraction;
 
+		/// <summary>Bindable property for <see cref="Drawable"/>.</summary>
 		public static readonly BindableProperty DrawableProperty =
 			BindableProperty.Create(nameof(Drawable), typeof(IDrawable), typeof(GraphicsView), null);
 

--- a/src/Controls/src/Core/HandlerImpl/VisualElement/VisualElement.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/VisualElement/VisualElement.Impl.cs
@@ -60,6 +60,7 @@ namespace Microsoft.Maui.Controls
 
 		IShadow IView.Shadow => Shadow;
 
+		/// <summary>Bindable property for <see cref="Shadow"/>.</summary>
 		public static readonly BindableProperty ShadowProperty =
  			BindableProperty.Create(nameof(Shadow), typeof(Shadow), typeof(VisualElement), defaultValue: null,
 				propertyChanging: (bindable, oldvalue, newvalue) =>
@@ -79,6 +80,7 @@ namespace Microsoft.Maui.Controls
 			set { SetValue(ShadowProperty, value); }
 		}
 
+		/// <summary>Bindable property for <see cref="ZIndex"/>.</summary>
 		public static readonly BindableProperty ZIndexProperty =
 			BindableProperty.Create(nameof(ZIndex), typeof(int), typeof(VisualElement), default(int),
 				propertyChanged: ZIndexPropertyChanged);

--- a/src/Controls/src/Core/HandlerImpl/Window/Window.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Window/Window.Impl.cs
@@ -15,38 +15,49 @@ namespace Microsoft.Maui.Controls
 	[ContentProperty(nameof(Page))]
 	public partial class Window : NavigableElement, IWindow, IVisualTreeElement, IToolbarElement, IMenuBarElement, IFlowDirectionController, IWindowController
 	{
+		/// <summary>Bindable property for <see cref="Title"/>.</summary>
 		public static readonly BindableProperty TitleProperty = BindableProperty.Create(
 			nameof(Title), typeof(string), typeof(Window), default(string?));
 
+		/// <summary>Bindable property for <see cref="Page"/>.</summary>
 		public static readonly BindableProperty PageProperty = BindableProperty.Create(
 			nameof(Page), typeof(Page), typeof(Window), default(Page?),
 			propertyChanging: OnPageChanging,
 			propertyChanged: (b, o, n) => ((Window)b).OnPageChanged(o as Page, n as Page));
 
+		/// <summary>Bindable property for <see cref="FlowDirection"/>.</summary>
 		public static readonly BindableProperty FlowDirectionProperty =
 			BindableProperty.Create(nameof(FlowDirection), typeof(FlowDirection), typeof(Window), FlowDirection.MatchParent, propertyChanging: FlowDirectionChanging, propertyChanged: FlowDirectionChanged);
 
+		/// <summary>Bindable property for <see cref="X"/>.</summary>
 		public static readonly BindableProperty XProperty = BindableProperty.Create(
 			nameof(X), typeof(double), typeof(Window), Primitives.Dimension.Unset);
 
+		/// <summary>Bindable property for <see cref="Y"/>.</summary>
 		public static readonly BindableProperty YProperty = BindableProperty.Create(
 			nameof(Y), typeof(double), typeof(Window), Primitives.Dimension.Unset);
 
+		/// <summary>Bindable property for <see cref="Width"/>.</summary>
 		public static readonly BindableProperty WidthProperty = BindableProperty.Create(
 			nameof(Width), typeof(double), typeof(Window), Primitives.Dimension.Unset);
 
+		/// <summary>Bindable property for <see cref="Height"/>.</summary>
 		public static readonly BindableProperty HeightProperty = BindableProperty.Create(
 			nameof(Height), typeof(double), typeof(Window), Primitives.Dimension.Unset);
 
+		/// <summary>Bindable property for <see cref="MaximumWidth"/>.</summary>
 		public static readonly BindableProperty MaximumWidthProperty = BindableProperty.Create(
 			nameof(MaximumWidth), typeof(double), typeof(Window), Primitives.Dimension.Maximum);
 
+		/// <summary>Bindable property for <see cref="MaximumHeight"/>.</summary>
 		public static readonly BindableProperty MaximumHeightProperty = BindableProperty.Create(
 			nameof(MaximumHeight), typeof(double), typeof(Window), Primitives.Dimension.Maximum);
 
+		/// <summary>Bindable property for <see cref="MinimumWidth"/>.</summary>
 		public static readonly BindableProperty MinimumWidthProperty = BindableProperty.Create(
 			nameof(MinimumWidth), typeof(double), typeof(Window), Primitives.Dimension.Minimum);
 
+		/// <summary>Bindable property for <see cref="MinimumHeight"/>.</summary>
 		public static readonly BindableProperty MinimumHeightProperty = BindableProperty.Create(
 			nameof(MinimumHeight), typeof(double), typeof(Window), Primitives.Dimension.Minimum);
 

--- a/src/Controls/src/Core/HtmlWebViewSource.cs
+++ b/src/Controls/src/Core/HtmlWebViewSource.cs
@@ -6,11 +6,11 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../docs/Microsoft.Maui.Controls/HtmlWebViewSource.xml" path="Type[@FullName='Microsoft.Maui.Controls.HtmlWebViewSource']/Docs/*" />
 	public class HtmlWebViewSource : WebViewSource
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/HtmlWebViewSource.xml" path="//Member[@MemberName='HtmlProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Html"/>.</summary>
 		public static readonly BindableProperty HtmlProperty = BindableProperty.Create("Html", typeof(string), typeof(HtmlWebViewSource), default(string),
 			propertyChanged: (bindable, oldvalue, newvalue) => ((HtmlWebViewSource)bindable).OnSourceChanged());
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/HtmlWebViewSource.xml" path="//Member[@MemberName='BaseUrlProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="BaseUrl"/>.</summary>
 		public static readonly BindableProperty BaseUrlProperty = BindableProperty.Create("BaseUrl", typeof(string), typeof(HtmlWebViewSource), default(string),
 			propertyChanged: (bindable, oldvalue, newvalue) => ((HtmlWebViewSource)bindable).OnSourceChanged());
 

--- a/src/Controls/src/Core/Image.cs
+++ b/src/Controls/src/Core/Image.cs
@@ -7,21 +7,21 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../docs/Microsoft.Maui.Controls/Image.xml" path="Type[@FullName='Microsoft.Maui.Controls.Image']/Docs/*" />
 	public partial class Image : View, IImageController, IElementConfiguration<Image>, IViewController, IImageElement
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/Image.xml" path="//Member[@MemberName='SourceProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Source"/>.</summary>
 		public static readonly BindableProperty SourceProperty = ImageElement.SourceProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Image.xml" path="//Member[@MemberName='AspectProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Aspect"/>.</summary>
 		public static readonly BindableProperty AspectProperty = ImageElement.AspectProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Image.xml" path="//Member[@MemberName='IsOpaqueProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="IsOpaque"/>.</summary>
 		public static readonly BindableProperty IsOpaqueProperty = ImageElement.IsOpaqueProperty;
 
 		internal static readonly BindablePropertyKey IsLoadingPropertyKey = BindableProperty.CreateReadOnly(nameof(IsLoading), typeof(bool), typeof(Image), default(bool));
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Image.xml" path="//Member[@MemberName='IsLoadingProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="IsLoading"/>.</summary>
 		public static readonly BindableProperty IsLoadingProperty = IsLoadingPropertyKey.BindableProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Image.xml" path="//Member[@MemberName='IsAnimationPlayingProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="IsAnimationPlaying"/>.</summary>
 		public static readonly BindableProperty IsAnimationPlayingProperty = ImageElement.IsAnimationPlayingProperty;
 
 		readonly Lazy<PlatformConfigurationRegistry<Image>> _platformConfigurationRegistry;

--- a/src/Controls/src/Core/ImageBrush.cs
+++ b/src/Controls/src/Core/ImageBrush.cs
@@ -1,4 +1,4 @@
-﻿namespace Microsoft.Maui.Controls
+namespace Microsoft.Maui.Controls
 {
 	[ContentProperty(nameof(ImageSource))]
 	class ImageBrush : Brush
@@ -15,6 +15,7 @@
 		public override bool IsEmpty =>
 			ImageSource?.IsEmpty ?? true;
 
+		/// <summary>Bindable property for <see cref="ImageSource"/>.</summary>
 		public static readonly BindableProperty ImageSourceProperty = BindableProperty.Create(
 			nameof(ImageSource), typeof(ImageSource), typeof(ImageBrush), default(ImageSource));
 

--- a/src/Controls/src/Core/ImageButton.cs
+++ b/src/Controls/src/Core/ImageButton.cs
@@ -14,41 +14,41 @@ namespace Microsoft.Maui.Controls
 	{
 		const int DefaultCornerRadius = -1;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ImageButton.xml" path="//Member[@MemberName='CommandProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Command"/>.</summary>
 		public static readonly BindableProperty CommandProperty = ButtonElement.CommandProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ImageButton.xml" path="//Member[@MemberName='CommandParameterProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="CommandParameter"/>.</summary>
 		public static readonly BindableProperty CommandParameterProperty = ButtonElement.CommandParameterProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ImageButton.xml" path="//Member[@MemberName='CornerRadiusProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="CornerRadius"/>.</summary>
 		public static readonly BindableProperty CornerRadiusProperty = BorderElement.CornerRadiusProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ImageButton.xml" path="//Member[@MemberName='BorderWidthProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="BorderWidth"/>.</summary>
 		public static readonly BindableProperty BorderWidthProperty = BorderElement.BorderWidthProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ImageButton.xml" path="//Member[@MemberName='BorderColorProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="BorderColor"/>.</summary>
 		public static readonly BindableProperty BorderColorProperty = BorderElement.BorderColorProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ImageButton.xml" path="//Member[@MemberName='SourceProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Source"/>.</summary>
 		public static readonly BindableProperty SourceProperty = ImageElement.SourceProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ImageButton.xml" path="//Member[@MemberName='AspectProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Aspect"/>.</summary>
 		public static readonly BindableProperty AspectProperty = ImageElement.AspectProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ImageButton.xml" path="//Member[@MemberName='IsOpaqueProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="IsOpaque"/>.</summary>
 		public static readonly BindableProperty IsOpaqueProperty = ImageElement.IsOpaqueProperty;
 
 		internal static readonly BindablePropertyKey IsLoadingPropertyKey = BindableProperty.CreateReadOnly(nameof(IsLoading), typeof(bool), typeof(ImageButton), default(bool));
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ImageButton.xml" path="//Member[@MemberName='IsLoadingProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="IsLoading"/>.</summary>
 		public static readonly BindableProperty IsLoadingProperty = IsLoadingPropertyKey.BindableProperty;
 
 		internal static readonly BindablePropertyKey IsPressedPropertyKey = BindableProperty.CreateReadOnly(nameof(IsPressed), typeof(bool), typeof(ImageButton), default(bool));
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ImageButton.xml" path="//Member[@MemberName='IsPressedProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="IsPressed"/>.</summary>
 		public static readonly BindableProperty IsPressedProperty = IsPressedPropertyKey.BindableProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ImageButton.xml" path="//Member[@MemberName='PaddingProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Padding"/>.</summary>
 		public static readonly BindableProperty PaddingProperty = PaddingElement.PaddingProperty;
 
 		public event EventHandler Clicked;

--- a/src/Controls/src/Core/ImageElement.cs
+++ b/src/Controls/src/Core/ImageElement.cs
@@ -7,18 +7,18 @@ namespace Microsoft.Maui.Controls
 {
 	static class ImageElement
 	{
-		/// <summary>Bindable property for <see cref="ImageSource"/>.</summary>
+		/// <summary>Bindable property for <c>ImageSource</c>.</summary>
 		public static readonly BindableProperty ImageSourceProperty = BindableProperty.Create("ImageSource", typeof(ImageSource), typeof(IImageElement), default(ImageSource),
 			propertyChanging: OnImageSourceChanging, propertyChanged: OnImageSourceChanged);
 
-		/// <summary>Bindable property for <see cref="Source"/>.</summary>
+		/// <summary>Bindable property for <see cref="IImageElement.Source"/>.</summary>
 		public static readonly BindableProperty SourceProperty = BindableProperty.Create(nameof(IImageElement.Source), typeof(ImageSource), typeof(IImageElement), default(ImageSource),
 			propertyChanging: OnImageSourceChanging, propertyChanged: OnImageSourceChanged);
 
-		/// <summary>Bindable property for <see cref="Aspect"/>.</summary>
+		/// <summary>Bindable property for <see cref="IImageElement.Aspect"/>.</summary>
 		public static readonly BindableProperty AspectProperty = BindableProperty.Create(nameof(IImageElement.Aspect), typeof(Aspect), typeof(IImageElement), Aspect.AspectFit);
 
-		/// <summary>Bindable property for <see cref="IsOpaque"/>.</summary>
+		/// <summary>Bindable property for <see cref="IImageElement.IsOpaque"/>.</summary>
 		public static readonly BindableProperty IsOpaqueProperty = BindableProperty.Create(nameof(IImageElement.IsOpaque), typeof(bool), typeof(IImageElement), false);
 
 		internal static readonly BindableProperty IsAnimationPlayingProperty = BindableProperty.Create(nameof(IImageElement.IsAnimationPlaying), typeof(bool), typeof(IImageElement), false);

--- a/src/Controls/src/Core/ImageElement.cs
+++ b/src/Controls/src/Core/ImageElement.cs
@@ -7,14 +7,18 @@ namespace Microsoft.Maui.Controls
 {
 	static class ImageElement
 	{
+		/// <summary>Bindable property for <see cref="ImageSource"/>.</summary>
 		public static readonly BindableProperty ImageSourceProperty = BindableProperty.Create("ImageSource", typeof(ImageSource), typeof(IImageElement), default(ImageSource),
 			propertyChanging: OnImageSourceChanging, propertyChanged: OnImageSourceChanged);
 
+		/// <summary>Bindable property for <see cref="Source"/>.</summary>
 		public static readonly BindableProperty SourceProperty = BindableProperty.Create(nameof(IImageElement.Source), typeof(ImageSource), typeof(IImageElement), default(ImageSource),
 			propertyChanging: OnImageSourceChanging, propertyChanged: OnImageSourceChanged);
 
+		/// <summary>Bindable property for <see cref="Aspect"/>.</summary>
 		public static readonly BindableProperty AspectProperty = BindableProperty.Create(nameof(IImageElement.Aspect), typeof(Aspect), typeof(IImageElement), Aspect.AspectFit);
 
+		/// <summary>Bindable property for <see cref="IsOpaque"/>.</summary>
 		public static readonly BindableProperty IsOpaqueProperty = BindableProperty.Create(nameof(IImageElement.IsOpaque), typeof(bool), typeof(IImageElement), false);
 
 		internal static readonly BindableProperty IsAnimationPlayingProperty = BindableProperty.Create(nameof(IImageElement.IsAnimationPlaying), typeof(bool), typeof(IImageElement), false);

--- a/src/Controls/src/Core/IndicatorView.cs
+++ b/src/Controls/src/Core/IndicatorView.cs
@@ -1,4 +1,4 @@
-﻿#nullable disable
+#nullable disable
 using System;
 using System.Collections;
 using System.Collections.Specialized;
@@ -14,37 +14,37 @@ namespace Microsoft.Maui.Controls
 	{
 		const int DefaultPadding = 4;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/IndicatorView.xml" path="//Member[@MemberName='IndicatorsShapeProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="IndicatorsShape"/>.</summary>
 		public static readonly BindableProperty IndicatorsShapeProperty = BindableProperty.Create(nameof(IndicatorsShape), typeof(IndicatorShape), typeof(IndicatorView), Controls.IndicatorShape.Circle);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/IndicatorView.xml" path="//Member[@MemberName='PositionProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Position"/>.</summary>
 		public static readonly BindableProperty PositionProperty = BindableProperty.Create(nameof(Position), typeof(int), typeof(IndicatorView), default(int), BindingMode.TwoWay);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/IndicatorView.xml" path="//Member[@MemberName='CountProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Count"/>.</summary>
 		public static readonly BindableProperty CountProperty = BindableProperty.Create(nameof(Count), typeof(int), typeof(IndicatorView), default(int), propertyChanged: (bindable, oldValue, newValue)
 			=> (((IndicatorView)bindable).IndicatorLayout as IndicatorStackLayout)?.ResetIndicatorCount((int)oldValue));
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/IndicatorView.xml" path="//Member[@MemberName='MaximumVisibleProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="MaximumVisible"/>.</summary>
 		public static readonly BindableProperty MaximumVisibleProperty = BindableProperty.Create(nameof(MaximumVisible), typeof(int), typeof(IndicatorView), int.MaxValue, propertyChanged: (bindable, oldValue, newValue)
 		=> (((IndicatorView)bindable).IndicatorLayout as IndicatorStackLayout)?.ResetIndicators());
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/IndicatorView.xml" path="//Member[@MemberName='IndicatorTemplateProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="IndicatorTemplate"/>.</summary>
 		public static readonly BindableProperty IndicatorTemplateProperty = BindableProperty.Create(nameof(IndicatorTemplate), typeof(DataTemplate), typeof(IndicatorView), default(DataTemplate), propertyChanging: (bindable, oldValue, newValue)
 			=> UpdateIndicatorLayout((IndicatorView)bindable, newValue));
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/IndicatorView.xml" path="//Member[@MemberName='HideSingleProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="HideSingle"/>.</summary>
 		public static readonly BindableProperty HideSingleProperty = BindableProperty.Create(nameof(HideSingle), typeof(bool), typeof(IndicatorView), true);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/IndicatorView.xml" path="//Member[@MemberName='IndicatorColorProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="IndicatorColor"/>.</summary>
 		public static readonly BindableProperty IndicatorColorProperty = BindableProperty.Create(nameof(IndicatorColor), typeof(Color), typeof(IndicatorView), Colors.LightGrey);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/IndicatorView.xml" path="//Member[@MemberName='SelectedIndicatorColorProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="SelectedIndicatorColor"/>.</summary>
 		public static readonly BindableProperty SelectedIndicatorColorProperty = BindableProperty.Create(nameof(SelectedIndicatorColor), typeof(Color), typeof(IndicatorView), Colors.Black);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/IndicatorView.xml" path="//Member[@MemberName='IndicatorSizeProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="IndicatorSize"/>.</summary>
 		public static readonly BindableProperty IndicatorSizeProperty = BindableProperty.Create(nameof(IndicatorSize), typeof(double), typeof(IndicatorView), 6.0);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/IndicatorView.xml" path="//Member[@MemberName='ItemsSourceProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="ItemsSource"/>.</summary>
 		public static readonly BindableProperty ItemsSourceProperty = BindableProperty.Create(nameof(ItemsSource), typeof(IEnumerable), typeof(IndicatorView), null, propertyChanged: (bindable, oldValue, newValue)
 			=> ((IndicatorView)bindable).ResetItemsSource((IEnumerable)oldValue));
 

--- a/src/Controls/src/Core/InputView.cs
+++ b/src/Controls/src/Core/InputView.cs
@@ -8,36 +8,36 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../docs/Microsoft.Maui.Controls/InputView.xml" path="Type[@FullName='Microsoft.Maui.Controls.InputView']/Docs/*" />
 	public class InputView : View, IPlaceholderElement, ITextElement
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/InputView.xml" path="//Member[@MemberName='TextProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Text"/>.</summary>
 		public static readonly BindableProperty TextProperty = BindableProperty.Create(nameof(Text), typeof(string), typeof(InputView), defaultBindingMode: BindingMode.TwoWay,
 			propertyChanged: (bindable, oldValue, newValue) => ((InputView)bindable).OnTextChanged((string)oldValue, (string)newValue));
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/InputView.xml" path="//Member[@MemberName='KeyboardProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Keyboard"/>.</summary>
 		public static readonly BindableProperty KeyboardProperty = BindableProperty.Create(nameof(Keyboard), typeof(Keyboard), typeof(InputView), Keyboard.Default,
 			coerceValue: (o, v) => (Keyboard)v ?? Keyboard.Default);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/InputView.xml" path="//Member[@MemberName='IsSpellCheckEnabledProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="IsSpellCheckEnabled"/>.</summary>
 		public static readonly BindableProperty IsSpellCheckEnabledProperty = BindableProperty.Create(nameof(IsSpellCheckEnabled), typeof(bool), typeof(InputView), true);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/InputView.xml" path="//Member[@MemberName='MaxLengthProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="MaxLength"/>.</summary>
 		public static readonly BindableProperty MaxLengthProperty = BindableProperty.Create(nameof(MaxLength), typeof(int), typeof(int), int.MaxValue);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/InputView.xml" path="//Member[@MemberName='IsReadOnlyProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="IsReadOnly"/>.</summary>
 		public static readonly BindableProperty IsReadOnlyProperty = BindableProperty.Create(nameof(IsReadOnly), typeof(bool), typeof(InputView), false);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/InputView.xml" path="//Member[@MemberName='PlaceholderProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Placeholder"/>.</summary>
 		public static readonly BindableProperty PlaceholderProperty = PlaceholderElement.PlaceholderProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/InputView.xml" path="//Member[@MemberName='PlaceholderColorProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="PlaceholderColor"/>.</summary>
 		public static readonly BindableProperty PlaceholderColorProperty = PlaceholderElement.PlaceholderColorProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/InputView.xml" path="//Member[@MemberName='TextColorProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="TextColor"/>.</summary>
 		public static readonly BindableProperty TextColorProperty = TextElement.TextColorProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/InputView.xml" path="//Member[@MemberName='CharacterSpacingProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="CharacterSpacing"/>.</summary>
 		public static readonly BindableProperty CharacterSpacingProperty = TextElement.CharacterSpacingProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/InputView.xml" path="//Member[@MemberName='TextTransformProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="TextTransform"/>.</summary>
 		public static readonly BindableProperty TextTransformProperty = TextElement.TextTransformProperty;
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/InputView.xml" path="//Member[@MemberName='MaxLength']/Docs/*" />

--- a/src/Controls/src/Core/Internals/NameScope.cs
+++ b/src/Controls/src/Core/Internals/NameScope.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Maui.Controls.Internals
 	[EditorBrowsable(EditorBrowsableState.Never)]
 	public class NameScope : INameScope
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/NameScope.xml" path="//Member[@MemberName='NameScopeProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="NameScope"/>.</summary>
 		public static readonly BindableProperty NameScopeProperty =
 			BindableProperty.CreateAttached("NameScope", typeof(INameScope), typeof(NameScope), default(INameScope));
 

--- a/src/Controls/src/Core/Items/CarouselView.cs
+++ b/src/Controls/src/Core/Items/CarouselView.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Maui.Controls
 		/// <include file="../../../docs/Microsoft.Maui.Controls/CarouselView.xml" path="//Member[@MemberName='DefaultItemVisualState']/Docs/*" />
 		public const string DefaultItemVisualState = "DefaultItem";
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/CarouselView.xml" path="//Member[@MemberName='LoopProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Loop"/>.</summary>
 		public static readonly BindableProperty LoopProperty = BindableProperty.Create(nameof(Loop), typeof(bool), typeof(CarouselView), true, BindingMode.OneTime);
 
 		/// <include file="../../../docs/Microsoft.Maui.Controls/CarouselView.xml" path="//Member[@MemberName='Loop']/Docs/*" />
@@ -32,7 +32,7 @@ namespace Microsoft.Maui.Controls
 			set { SetValue(LoopProperty, value); }
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/CarouselView.xml" path="//Member[@MemberName='PeekAreaInsetsProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="PeekAreaInsets"/>.</summary>
 		public static readonly BindableProperty PeekAreaInsetsProperty = BindableProperty.Create(nameof(PeekAreaInsets), typeof(Thickness), typeof(CarouselView), default(Thickness));
 
 		/// <include file="../../../docs/Microsoft.Maui.Controls/CarouselView.xml" path="//Member[@MemberName='PeekAreaInsets']/Docs/*" />
@@ -44,7 +44,7 @@ namespace Microsoft.Maui.Controls
 
 		static readonly BindablePropertyKey VisibleViewsPropertyKey = BindableProperty.CreateReadOnly(nameof(VisibleViews), typeof(ObservableCollection<View>), typeof(CarouselView), null, defaultValueCreator: (b) => new ObservableCollection<View>());
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/CarouselView.xml" path="//Member[@MemberName='VisibleViewsProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="VisibleViews"/>.</summary>
 		public static readonly BindableProperty VisibleViewsProperty = VisibleViewsPropertyKey.BindableProperty;
 
 		/// <include file="../../../docs/Microsoft.Maui.Controls/CarouselView.xml" path="//Member[@MemberName='VisibleViews']/Docs/*" />
@@ -52,13 +52,13 @@ namespace Microsoft.Maui.Controls
 
 		static readonly BindablePropertyKey IsDraggingPropertyKey = BindableProperty.CreateReadOnly(nameof(IsDragging), typeof(bool), typeof(CarouselView), false);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/CarouselView.xml" path="//Member[@MemberName='IsDraggingProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="IsDragging"/>.</summary>
 		public static readonly BindableProperty IsDraggingProperty = IsDraggingPropertyKey.BindableProperty;
 
 		/// <include file="../../../docs/Microsoft.Maui.Controls/CarouselView.xml" path="//Member[@MemberName='IsDragging']/Docs/*" />
 		public bool IsDragging => (bool)GetValue(IsDraggingProperty);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/CarouselView.xml" path="//Member[@MemberName='IsBounceEnabledProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="IsBounceEnabled"/>.</summary>
 		public static readonly BindableProperty IsBounceEnabledProperty =
 			BindableProperty.Create(nameof(IsBounceEnabled), typeof(bool), typeof(CarouselView), true);
 
@@ -69,7 +69,7 @@ namespace Microsoft.Maui.Controls
 			set { SetValue(IsBounceEnabledProperty, value); }
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/CarouselView.xml" path="//Member[@MemberName='IsSwipeEnabledProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="IsSwipeEnabled"/>.</summary>
 		public static readonly BindableProperty IsSwipeEnabledProperty =
 			BindableProperty.Create(nameof(IsSwipeEnabled), typeof(bool), typeof(CarouselView), true);
 
@@ -80,7 +80,7 @@ namespace Microsoft.Maui.Controls
 			set { SetValue(IsSwipeEnabledProperty, value); }
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/CarouselView.xml" path="//Member[@MemberName='IsScrollAnimatedProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="IsScrollAnimated"/>.</summary>
 		public static readonly BindableProperty IsScrollAnimatedProperty =
 		BindableProperty.Create(nameof(IsScrollAnimated), typeof(bool), typeof(CarouselView), true);
 
@@ -91,16 +91,16 @@ namespace Microsoft.Maui.Controls
 			set { SetValue(IsScrollAnimatedProperty, value); }
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/CarouselView.xml" path="//Member[@MemberName='CurrentItemProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="CurrentItem"/>.</summary>
 		public static readonly BindableProperty CurrentItemProperty =
 		BindableProperty.Create(nameof(CurrentItem), typeof(object), typeof(CarouselView), default, BindingMode.TwoWay,
 			propertyChanged: CurrentItemPropertyChanged);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/CarouselView.xml" path="//Member[@MemberName='CurrentItemChangedCommandProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="CurrentItemChangedCommand"/>.</summary>
 		public static readonly BindableProperty CurrentItemChangedCommandProperty =
 			BindableProperty.Create(nameof(CurrentItemChangedCommand), typeof(ICommand), typeof(CarouselView));
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/CarouselView.xml" path="//Member[@MemberName='CurrentItemChangedCommandParameterProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="CurrentItemChangedCommandParameter"/>.</summary>
 		public static readonly BindableProperty CurrentItemChangedCommandParameterProperty =
 			BindableProperty.Create(nameof(CurrentItemChangedCommandParameter), typeof(object), typeof(CarouselView));
 
@@ -148,16 +148,16 @@ namespace Microsoft.Maui.Controls
 			carouselView.OnCurrentItemChanged(args);
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/CarouselView.xml" path="//Member[@MemberName='PositionProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Position"/>.</summary>
 		public static readonly BindableProperty PositionProperty =
 		BindableProperty.Create(nameof(Position), typeof(int), typeof(CarouselView), default(int), BindingMode.TwoWay,
 			propertyChanged: PositionPropertyChanged);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/CarouselView.xml" path="//Member[@MemberName='PositionChangedCommandProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="PositionChangedCommand"/>.</summary>
 		public static readonly BindableProperty PositionChangedCommandProperty =
 			BindableProperty.Create(nameof(PositionChangedCommand), typeof(ICommand), typeof(CarouselView));
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/CarouselView.xml" path="//Member[@MemberName='PositionChangedCommandParameterProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="PositionChangedCommandParameter"/>.</summary>
 		public static readonly BindableProperty PositionChangedCommandParameterProperty =
 			BindableProperty.Create(nameof(PositionChangedCommandParameter), typeof(object),
 				typeof(CarouselView));
@@ -183,7 +183,7 @@ namespace Microsoft.Maui.Controls
 			set => SetValue(PositionChangedCommandParameterProperty, value);
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/CarouselView.xml" path="//Member[@MemberName='ItemsLayoutProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="ItemsLayout"/>.</summary>
 		public static readonly BindableProperty ItemsLayoutProperty =
 			BindableProperty.Create(nameof(ItemsLayout), typeof(LinearItemsLayout), typeof(ItemsView),
 				LinearItemsLayout.CarouselDefault);

--- a/src/Controls/src/Core/Items/GridItemsLayout.cs
+++ b/src/Controls/src/Core/Items/GridItemsLayout.cs
@@ -4,7 +4,7 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../../docs/Microsoft.Maui.Controls/GridItemsLayout.xml" path="Type[@FullName='Microsoft.Maui.Controls.GridItemsLayout']/Docs/*" />
 	public class GridItemsLayout : ItemsLayout
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Controls/GridItemsLayout.xml" path="//Member[@MemberName='SpanProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Span"/>.</summary>
 		public static readonly BindableProperty SpanProperty =
 			BindableProperty.Create(nameof(Span), typeof(int), typeof(GridItemsLayout), 1,
 				validateValue: (bindable, value) => (int)value >= 1);
@@ -28,7 +28,7 @@ namespace Microsoft.Maui.Controls
 			Span = span;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/GridItemsLayout.xml" path="//Member[@MemberName='VerticalItemSpacingProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="VerticalItemSpacing"/>.</summary>
 		public static readonly BindableProperty VerticalItemSpacingProperty =
 			BindableProperty.Create(nameof(VerticalItemSpacing), typeof(double), typeof(GridItemsLayout), default(double),
 				validateValue: (bindable, value) => (double)value >= 0);
@@ -40,7 +40,7 @@ namespace Microsoft.Maui.Controls
 			set => SetValue(VerticalItemSpacingProperty, value);
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/GridItemsLayout.xml" path="//Member[@MemberName='HorizontalItemSpacingProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="HorizontalItemSpacing"/>.</summary>
 		public static readonly BindableProperty HorizontalItemSpacingProperty =
 			BindableProperty.Create(nameof(HorizontalItemSpacing), typeof(double), typeof(GridItemsLayout), default(double),
 				validateValue: (bindable, value) => (double)value >= 0);

--- a/src/Controls/src/Core/Items/GroupableItemsView.cs
+++ b/src/Controls/src/Core/Items/GroupableItemsView.cs
@@ -4,7 +4,7 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../../docs/Microsoft.Maui.Controls/GroupableItemsView.xml" path="Type[@FullName='Microsoft.Maui.Controls.GroupableItemsView']/Docs/*" />
 	public class GroupableItemsView : SelectableItemsView
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Controls/GroupableItemsView.xml" path="//Member[@MemberName='IsGroupedProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="IsGrouped"/>.</summary>
 		public static readonly BindableProperty IsGroupedProperty =
 			BindableProperty.Create(nameof(IsGrouped), typeof(bool), typeof(GroupableItemsView), false);
 
@@ -15,7 +15,7 @@ namespace Microsoft.Maui.Controls
 			set => SetValue(IsGroupedProperty, value);
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/GroupableItemsView.xml" path="//Member[@MemberName='GroupHeaderTemplateProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="GroupHeaderTemplate"/>.</summary>
 		public static readonly BindableProperty GroupHeaderTemplateProperty =
 			BindableProperty.Create(nameof(GroupHeaderTemplate), typeof(DataTemplate), typeof(GroupableItemsView), default(DataTemplate));
 
@@ -26,7 +26,7 @@ namespace Microsoft.Maui.Controls
 			set => SetValue(GroupHeaderTemplateProperty, value);
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/GroupableItemsView.xml" path="//Member[@MemberName='GroupFooterTemplateProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="GroupFooterTemplate"/>.</summary>
 		public static readonly BindableProperty GroupFooterTemplateProperty =
 			BindableProperty.Create(nameof(GroupFooterTemplate), typeof(DataTemplate), typeof(GroupableItemsView), default(DataTemplate));
 

--- a/src/Controls/src/Core/Items/ItemsLayout.cs
+++ b/src/Controls/src/Core/Items/ItemsLayout.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Maui.Controls
 			Orientation = orientation;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/ItemsLayout.xml" path="//Member[@MemberName='SnapPointsAlignmentProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="SnapPointsAlignment"/>.</summary>
 		public static readonly BindableProperty SnapPointsAlignmentProperty =
 			BindableProperty.Create(nameof(SnapPointsAlignment), typeof(SnapPointsAlignment), typeof(ItemsLayout),
 				SnapPointsAlignment.Start);
@@ -24,7 +24,7 @@ namespace Microsoft.Maui.Controls
 			set => SetValue(SnapPointsAlignmentProperty, value);
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/ItemsLayout.xml" path="//Member[@MemberName='SnapPointsTypeProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="SnapPointsType"/>.</summary>
 		public static readonly BindableProperty SnapPointsTypeProperty =
 			BindableProperty.Create(nameof(SnapPointsType), typeof(SnapPointsType), typeof(ItemsLayout),
 				SnapPointsType.None);

--- a/src/Controls/src/Core/Items/ItemsView.cs
+++ b/src/Controls/src/Core/Items/ItemsView.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Maui.Controls
 	{
 		List<Element> _logicalChildren = new List<Element>();
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/ItemsView.xml" path="//Member[@MemberName='EmptyViewProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="EmptyView"/>.</summary>
 		public static readonly BindableProperty EmptyViewProperty =
 			BindableProperty.Create(nameof(EmptyView), typeof(object), typeof(ItemsView), null);
 
@@ -27,7 +27,7 @@ namespace Microsoft.Maui.Controls
 			set => SetValue(EmptyViewProperty, value);
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/ItemsView.xml" path="//Member[@MemberName='EmptyViewTemplateProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="EmptyViewTemplate"/>.</summary>
 		public static readonly BindableProperty EmptyViewTemplateProperty =
 			BindableProperty.Create(nameof(EmptyViewTemplate), typeof(DataTemplate), typeof(ItemsView), null);
 
@@ -38,7 +38,7 @@ namespace Microsoft.Maui.Controls
 			set => SetValue(EmptyViewTemplateProperty, value);
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/ItemsView.xml" path="//Member[@MemberName='ItemsSourceProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="ItemsSource"/>.</summary>
 		public static readonly BindableProperty ItemsSourceProperty =
 			BindableProperty.Create(nameof(ItemsSource), typeof(IEnumerable), typeof(ItemsView), null);
 
@@ -49,7 +49,7 @@ namespace Microsoft.Maui.Controls
 			set => SetValue(ItemsSourceProperty, value);
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/ItemsView.xml" path="//Member[@MemberName='RemainingItemsThresholdReachedCommandProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="RemainingItemsThresholdReachedCommand"/>.</summary>
 		public static readonly BindableProperty RemainingItemsThresholdReachedCommandProperty =
 			BindableProperty.Create(nameof(RemainingItemsThresholdReachedCommand), typeof(ICommand), typeof(ItemsView), null);
 
@@ -60,7 +60,7 @@ namespace Microsoft.Maui.Controls
 			set => SetValue(RemainingItemsThresholdReachedCommandProperty, value);
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/ItemsView.xml" path="//Member[@MemberName='RemainingItemsThresholdReachedCommandParameterProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="RemainingItemsThresholdReachedCommandParameter"/>.</summary>
 		public static readonly BindableProperty RemainingItemsThresholdReachedCommandParameterProperty = BindableProperty.Create(nameof(RemainingItemsThresholdReachedCommandParameter), typeof(object), typeof(ItemsView), default(object));
 
 		/// <include file="../../../docs/Microsoft.Maui.Controls/ItemsView.xml" path="//Member[@MemberName='RemainingItemsThresholdReachedCommandParameter']/Docs/*" />
@@ -70,7 +70,7 @@ namespace Microsoft.Maui.Controls
 			set => SetValue(RemainingItemsThresholdReachedCommandParameterProperty, value);
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/ItemsView.xml" path="//Member[@MemberName='HorizontalScrollBarVisibilityProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="HorizontalScrollBarVisibility"/>.</summary>
 		public static readonly BindableProperty HorizontalScrollBarVisibilityProperty = BindableProperty.Create(
 			nameof(HorizontalScrollBarVisibility),
 			typeof(ScrollBarVisibility),
@@ -84,7 +84,7 @@ namespace Microsoft.Maui.Controls
 			set => SetValue(HorizontalScrollBarVisibilityProperty, value);
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/ItemsView.xml" path="//Member[@MemberName='VerticalScrollBarVisibilityProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="VerticalScrollBarVisibility"/>.</summary>
 		public static readonly BindableProperty VerticalScrollBarVisibilityProperty = BindableProperty.Create(
 			nameof(VerticalScrollBarVisibility),
 			typeof(ScrollBarVisibility),
@@ -98,7 +98,7 @@ namespace Microsoft.Maui.Controls
 			set => SetValue(VerticalScrollBarVisibilityProperty, value);
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/ItemsView.xml" path="//Member[@MemberName='RemainingItemsThresholdProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="RemainingItemsThreshold"/>.</summary>
 		public static readonly BindableProperty RemainingItemsThresholdProperty =
 			BindableProperty.Create(nameof(RemainingItemsThreshold), typeof(int), typeof(ItemsView), -1, validateValue: (bindable, value) => (int)value >= -1);
 
@@ -172,7 +172,7 @@ namespace Microsoft.Maui.Controls
 			set => SetValue(InternalItemsLayoutProperty, value);
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/ItemsView.xml" path="//Member[@MemberName='ItemTemplateProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="ItemTemplate"/>.</summary>
 		public static readonly BindableProperty ItemTemplateProperty =
 			BindableProperty.Create(nameof(ItemTemplate), typeof(DataTemplate), typeof(ItemsView));
 
@@ -183,7 +183,7 @@ namespace Microsoft.Maui.Controls
 			set => SetValue(ItemTemplateProperty, value);
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/ItemsView.xml" path="//Member[@MemberName='ItemsUpdatingScrollModeProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="ItemsUpdatingScrollMode"/>.</summary>
 		public static readonly BindableProperty ItemsUpdatingScrollModeProperty =
 			BindableProperty.Create(nameof(ItemsUpdatingScrollMode), typeof(ItemsUpdatingScrollMode), typeof(ItemsView),
 				default(ItemsUpdatingScrollMode));

--- a/src/Controls/src/Core/Items/LinearItemsLayout.cs
+++ b/src/Controls/src/Core/Items/LinearItemsLayout.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Maui.Controls
 			SnapPointsAlignment = SnapPointsAlignment.Center
 		};
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/LinearItemsLayout.xml" path="//Member[@MemberName='ItemSpacingProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="ItemSpacing"/>.</summary>
 		public static readonly BindableProperty ItemSpacingProperty =
 			BindableProperty.Create(nameof(ItemSpacing), typeof(double), typeof(LinearItemsLayout), default(double),
 				validateValue: (bindable, value) => (double)value >= 0);

--- a/src/Controls/src/Core/Items/ReorderableItemsView.cs
+++ b/src/Controls/src/Core/Items/ReorderableItemsView.cs
@@ -1,4 +1,4 @@
-﻿#nullable disable
+#nullable disable
 using System;
 using System.ComponentModel;
 
@@ -8,6 +8,7 @@ namespace Microsoft.Maui.Controls
 	{
 		public event EventHandler ReorderCompleted;
 
+		/// <summary>Bindable property for <see cref="CanMixGroups"/>.</summary>
 		public static readonly BindableProperty CanMixGroupsProperty = BindableProperty.Create("CanMixGroups", typeof(bool), typeof(ReorderableItemsView), false);
 		public bool CanMixGroups
 		{
@@ -15,6 +16,7 @@ namespace Microsoft.Maui.Controls
 			set { SetValue(CanMixGroupsProperty, value); }
 		}
 
+		/// <summary>Bindable property for <see cref="CanReorderItems"/>.</summary>
 		public static readonly BindableProperty CanReorderItemsProperty = BindableProperty.Create("CanReorderItems", typeof(bool), typeof(ReorderableItemsView), false);
 		public bool CanReorderItems
 		{

--- a/src/Controls/src/Core/Items/SelectableItemsView.cs
+++ b/src/Controls/src/Core/Items/SelectableItemsView.cs
@@ -8,18 +8,18 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../../docs/Microsoft.Maui.Controls/SelectableItemsView.xml" path="Type[@FullName='Microsoft.Maui.Controls.SelectableItemsView']/Docs/*" />
 	public class SelectableItemsView : StructuredItemsView
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Controls/SelectableItemsView.xml" path="//Member[@MemberName='SelectionModeProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="SelectionMode"/>.</summary>
 		public static readonly BindableProperty SelectionModeProperty =
 			BindableProperty.Create(nameof(SelectionMode), typeof(SelectionMode), typeof(SelectableItemsView),
 				SelectionMode.None, propertyChanged: SelectionModePropertyChanged);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/SelectableItemsView.xml" path="//Member[@MemberName='SelectedItemProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="SelectedItem"/>.</summary>
 		public static readonly BindableProperty SelectedItemProperty =
 			BindableProperty.Create(nameof(SelectedItem), typeof(object), typeof(SelectableItemsView), default(object),
 				defaultBindingMode: BindingMode.TwoWay,
 				propertyChanged: SelectedItemPropertyChanged);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/SelectableItemsView.xml" path="//Member[@MemberName='SelectedItemsProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="SelectedItems"/>.</summary>
 		public static readonly BindableProperty SelectedItemsProperty =
 			BindableProperty.Create(nameof(SelectedItems), typeof(IList<object>), typeof(SelectableItemsView), null,
 				defaultBindingMode: BindingMode.OneWay,
@@ -27,11 +27,11 @@ namespace Microsoft.Maui.Controls
 				coerceValue: CoerceSelectedItems,
 				defaultValueCreator: DefaultValueCreator);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/SelectableItemsView.xml" path="//Member[@MemberName='SelectionChangedCommandProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="SelectionChangedCommand"/>.</summary>
 		public static readonly BindableProperty SelectionChangedCommandProperty =
 			BindableProperty.Create(nameof(SelectionChangedCommand), typeof(ICommand), typeof(SelectableItemsView));
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/SelectableItemsView.xml" path="//Member[@MemberName='SelectionChangedCommandParameterProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="SelectionChangedCommandParameter"/>.</summary>
 		public static readonly BindableProperty SelectionChangedCommandParameterProperty =
 			BindableProperty.Create(nameof(SelectionChangedCommandParameter), typeof(object),
 				typeof(SelectableItemsView));

--- a/src/Controls/src/Core/Items/StructuredItemsView.cs
+++ b/src/Controls/src/Core/Items/StructuredItemsView.cs
@@ -4,7 +4,7 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../../docs/Microsoft.Maui.Controls/StructuredItemsView.xml" path="Type[@FullName='Microsoft.Maui.Controls.StructuredItemsView']/Docs/*" />
 	public class StructuredItemsView : ItemsView
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Controls/StructuredItemsView.xml" path="//Member[@MemberName='HeaderProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Header"/>.</summary>
 		public static readonly BindableProperty HeaderProperty =
 			BindableProperty.Create(nameof(Header), typeof(object), typeof(ItemsView), null);
 
@@ -15,7 +15,7 @@ namespace Microsoft.Maui.Controls
 			set => SetValue(HeaderProperty, value);
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/StructuredItemsView.xml" path="//Member[@MemberName='HeaderTemplateProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="HeaderTemplate"/>.</summary>
 		public static readonly BindableProperty HeaderTemplateProperty =
 			BindableProperty.Create(nameof(HeaderTemplate), typeof(DataTemplate), typeof(ItemsView), null);
 
@@ -26,7 +26,7 @@ namespace Microsoft.Maui.Controls
 			set => SetValue(HeaderTemplateProperty, value);
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/StructuredItemsView.xml" path="//Member[@MemberName='FooterProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Footer"/>.</summary>
 		public static readonly BindableProperty FooterProperty =
 			BindableProperty.Create(nameof(Footer), typeof(object), typeof(ItemsView), null);
 
@@ -37,7 +37,7 @@ namespace Microsoft.Maui.Controls
 			set => SetValue(FooterProperty, value);
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/StructuredItemsView.xml" path="//Member[@MemberName='FooterTemplateProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="FooterTemplate"/>.</summary>
 		public static readonly BindableProperty FooterTemplateProperty =
 			BindableProperty.Create(nameof(FooterTemplate), typeof(DataTemplate), typeof(ItemsView), null);
 
@@ -48,7 +48,7 @@ namespace Microsoft.Maui.Controls
 			set => SetValue(FooterTemplateProperty, value);
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/StructuredItemsView.xml" path="//Member[@MemberName='ItemsLayoutProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="ItemsLayout"/>.</summary>
 		public static readonly BindableProperty ItemsLayoutProperty = InternalItemsLayoutProperty;
 
 		/// <include file="../../../docs/Microsoft.Maui.Controls/StructuredItemsView.xml" path="//Member[@MemberName='ItemsLayout']/Docs/*" />
@@ -58,7 +58,7 @@ namespace Microsoft.Maui.Controls
 			set => InternalItemsLayout = value;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/StructuredItemsView.xml" path="//Member[@MemberName='ItemSizingStrategyProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="ItemSizingStrategy"/>.</summary>
 		public static readonly BindableProperty ItemSizingStrategyProperty =
 			BindableProperty.Create(nameof(ItemSizingStrategy), typeof(ItemSizingStrategy), typeof(ItemsView));
 

--- a/src/Controls/src/Core/ItemsView.cs
+++ b/src/Controls/src/Core/ItemsView.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Maui.Controls
 	public abstract class ItemsView<[DynamicallyAccessedMembers(BindableProperty.DeclaringTypeMembers)] TVisual> : View, ITemplatedItemsView<TVisual> where TVisual : BindableObject
 	{
 		/*
+		/// <summary>Bindable property for <see cref="InfiniteScrolling"/>.</summary>
 		public static readonly BindableProperty InfiniteScrollingProperty =
 			BindableProperty.Create<ItemsView, bool> (lv => lv.InfiniteScrolling, false);
 
@@ -20,12 +21,12 @@ namespace Microsoft.Maui.Controls
 			set { SetValue (InfiniteScrollingProperty, value); }
 		}*/
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ItemsView.xml" path="//Member[@MemberName='ItemsSourceProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="ItemsSource"/>.</summary>
 		public static readonly BindableProperty ItemsSourceProperty =
 			BindableProperty.Create(nameof(ItemsSource), typeof(IEnumerable), typeof(ItemsView<TVisual>), null,
 									propertyChanged: OnItemsSourceChanged);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ItemsView.xml" path="//Member[@MemberName='ItemTemplateProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="ItemTemplate"/>.</summary>
 		public static readonly BindableProperty ItemTemplateProperty =
 			BindableProperty.Create(nameof(ItemTemplate), typeof(DataTemplate), typeof(ItemsView<TVisual>), null,
 									validateValue: (b, v) => ((ItemsView<TVisual>)b).ValidateItemTemplate((DataTemplate)v));

--- a/src/Controls/src/Core/Label.cs
+++ b/src/Controls/src/Core/Label.cs
@@ -14,39 +14,40 @@ namespace Microsoft.Maui.Controls
 	[ContentProperty(nameof(Text))]
 	public partial class Label : View, IFontElement, ITextElement, ITextAlignmentElement, ILineHeightElement, IElementConfiguration<Label>, IDecorableTextElement, IPaddingElement
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/Label.xml" path="//Member[@MemberName='HorizontalTextAlignmentProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="HorizontalTextAlignment"/>.</summary>
 		public static readonly BindableProperty HorizontalTextAlignmentProperty = TextAlignmentElement.HorizontalTextAlignmentProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Label.xml" path="//Member[@MemberName='VerticalTextAlignmentProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="VerticalTextAlignment"/>.</summary>
 		public static readonly BindableProperty VerticalTextAlignmentProperty = BindableProperty.Create("VerticalTextAlignment", typeof(TextAlignment), typeof(Label), TextAlignment.Start);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Label.xml" path="//Member[@MemberName='TextColorProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="TextColor"/>.</summary>
 		public static readonly BindableProperty TextColorProperty = TextElement.TextColorProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Label.xml" path="//Member[@MemberName='CharacterSpacingProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="CharacterSpacing"/>.</summary>
 		public static readonly BindableProperty CharacterSpacingProperty = TextElement.CharacterSpacingProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Label.xml" path="//Member[@MemberName='TextProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Text"/>.</summary>
 		public static readonly BindableProperty TextProperty = BindableProperty.Create(nameof(Text), typeof(string), typeof(Label), default(string), propertyChanged: OnTextPropertyChanged);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Label.xml" path="//Member[@MemberName='FontFamilyProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="FontFamily"/>.</summary>
 		public static readonly BindableProperty FontFamilyProperty = FontElement.FontFamilyProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Label.xml" path="//Member[@MemberName='FontSizeProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="FontSize"/>.</summary>
 		public static readonly BindableProperty FontSizeProperty = FontElement.FontSizeProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Label.xml" path="//Member[@MemberName='FontAttributesProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="FontAttributes"/>.</summary>
 		public static readonly BindableProperty FontAttributesProperty = FontElement.FontAttributesProperty;
 
+		/// <summary>Bindable property for <see cref="FontAutoScalingEnabled"/>.</summary>
 		public static readonly BindableProperty FontAutoScalingEnabledProperty = FontElement.FontAutoScalingEnabledProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Label.xml" path="//Member[@MemberName='TextTransformProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="TextTransform"/>.</summary>
 		public static readonly BindableProperty TextTransformProperty = TextElement.TextTransformProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Label.xml" path="//Member[@MemberName='TextDecorationsProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="TextDecorations"/>.</summary>
 		public static readonly BindableProperty TextDecorationsProperty = DecorableTextElement.TextDecorationsProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Label.xml" path="//Member[@MemberName='FormattedTextProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="FormattedText"/>.</summary>
 		public static readonly BindableProperty FormattedTextProperty = BindableProperty.Create(nameof(FormattedText), typeof(FormattedString), typeof(Label), default(FormattedString),
 			propertyChanging: (bindable, oldvalue, newvalue) =>
 			{
@@ -91,14 +92,14 @@ namespace Microsoft.Maui.Controls
 		public virtual string UpdateFormsText(string source, TextTransform textTransform)
 			=> TextTransformUtilites.GetTransformedText(source, textTransform);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Label.xml" path="//Member[@MemberName='LineBreakModeProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="LineBreakMode"/>.</summary>
 		public static readonly BindableProperty LineBreakModeProperty = BindableProperty.Create(nameof(LineBreakMode), typeof(LineBreakMode), typeof(Label), LineBreakMode.WordWrap,
 			propertyChanged: (bindable, oldvalue, newvalue) => ((Label)bindable).InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged));
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Label.xml" path="//Member[@MemberName='LineHeightProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="LineHeight"/>.</summary>
 		public static readonly BindableProperty LineHeightProperty = LineHeightElement.LineHeightProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Label.xml" path="//Member[@MemberName='MaxLinesProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="MaxLines"/>.</summary>
 		public static readonly BindableProperty MaxLinesProperty = BindableProperty.Create(nameof(MaxLines), typeof(int), typeof(Label), -1, propertyChanged: (bindable, oldvalue, newvalue) =>
 			{
 				if (bindable != null)
@@ -107,10 +108,10 @@ namespace Microsoft.Maui.Controls
 				}
 			});
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Label.xml" path="//Member[@MemberName='PaddingProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Padding"/>.</summary>
 		public static readonly BindableProperty PaddingProperty = PaddingElement.PaddingProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Label.xml" path="//Member[@MemberName='TextTypeProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="TextType"/>.</summary>
 		public static readonly BindableProperty TextTypeProperty = BindableProperty.Create(nameof(TextType), typeof(TextType), typeof(Label), TextType.Text,
 			propertyChanged: (bindable, oldvalue, newvalue) => ((Label)bindable).InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged));
 

--- a/src/Controls/src/Core/Layout.cs
+++ b/src/Controls/src/Core/Layout.cs
@@ -65,13 +65,16 @@ namespace Microsoft.Maui.Controls.Compatibility
 
 	public abstract class Layout : View, ILayout, ILayoutController, IPaddingElement, IView, IVisualTreeElement
 	{
+		/// <summary>Bindable property for <see cref="IsClippedToBounds"/>.</summary>
 		public static readonly BindableProperty IsClippedToBoundsProperty =
 			BindableProperty.Create(nameof(IsClippedToBounds), typeof(bool), typeof(Layout), false,
 				propertyChanged: IsClippedToBoundsPropertyChanged);
 
+		/// <summary>Bindable property for <see cref="CascadeInputTransparent"/>.</summary>
 		public static readonly BindableProperty CascadeInputTransparentProperty =
 			BindableProperty.Create(nameof(CascadeInputTransparent), typeof(bool), typeof(Layout), true);
 
+		/// <summary>Bindable property for <see cref="Padding"/>.</summary>
 		public static readonly BindableProperty PaddingProperty = PaddingElement.PaddingProperty;
 
 		bool _hasDoneLayout;

--- a/src/Controls/src/Core/Layout/AbsoluteLayout.cs
+++ b/src/Controls/src/Core/Layout/AbsoluteLayout.cs
@@ -21,11 +21,11 @@ namespace Microsoft.Maui.Controls
 
 		#region Attached Properties
 
-		/// <summary>Bindable property for <see cref="LayoutFlags"/>.</summary>
+		/// <summary>Bindable property for attached property <c>LayoutFlags</c>.</summary>
 		public static readonly BindableProperty LayoutFlagsProperty = BindableProperty.CreateAttached("LayoutFlags",
 			typeof(AbsoluteLayoutFlags), typeof(AbsoluteLayout), AbsoluteLayoutFlags.None);
 
-		/// <summary>Bindable property for <see cref="LayoutBounds"/>.</summary>
+		/// <summary>Bindable property for attached property <c>LayoutBounds</c>.</summary>
 		public static readonly BindableProperty LayoutBoundsProperty = BindableProperty.CreateAttached("LayoutBounds",
 			typeof(Rect), typeof(AbsoluteLayout), new Rect(0, 0, AutoSize, AutoSize), propertyChanged: LayoutBoundsPropertyChanged);
 

--- a/src/Controls/src/Core/Layout/AbsoluteLayout.cs
+++ b/src/Controls/src/Core/Layout/AbsoluteLayout.cs
@@ -21,11 +21,11 @@ namespace Microsoft.Maui.Controls
 
 		#region Attached Properties
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/AbsoluteLayout.xml" path="//Member[@MemberName='LayoutFlagsProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="LayoutFlags"/>.</summary>
 		public static readonly BindableProperty LayoutFlagsProperty = BindableProperty.CreateAttached("LayoutFlags",
 			typeof(AbsoluteLayoutFlags), typeof(AbsoluteLayout), AbsoluteLayoutFlags.None);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/AbsoluteLayout.xml" path="//Member[@MemberName='LayoutBoundsProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="LayoutBounds"/>.</summary>
 		public static readonly BindableProperty LayoutBoundsProperty = BindableProperty.CreateAttached("LayoutBounds",
 			typeof(Rect), typeof(AbsoluteLayout), new Rect(0, 0, AutoSize, AutoSize), propertyChanged: LayoutBoundsPropertyChanged);
 

--- a/src/Controls/src/Core/Layout/FlexLayout.cs
+++ b/src/Controls/src/Core/Layout/FlexLayout.cs
@@ -15,57 +15,57 @@ namespace Microsoft.Maui.Controls
 	{
 		Flex.Item _root;
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='DirectionProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Direction"/>.</summary>
 		public static readonly BindableProperty DirectionProperty =
 			BindableProperty.Create(nameof(Direction), typeof(FlexDirection), typeof(FlexLayout), FlexDirection.Row,
 									propertyChanged: OnDirectionPropertyChanged);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='JustifyContentProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="JustifyContent"/>.</summary>
 		public static readonly BindableProperty JustifyContentProperty =
 			BindableProperty.Create(nameof(JustifyContent), typeof(FlexJustify), typeof(FlexLayout), FlexJustify.Start,
 									propertyChanged: OnJustifyContentPropertyChanged);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='AlignContentProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="AlignContent"/>.</summary>
 		public static readonly BindableProperty AlignContentProperty =
 			BindableProperty.Create(nameof(AlignContent), typeof(FlexAlignContent), typeof(FlexLayout), FlexAlignContent.Stretch,
 									propertyChanged: OnAlignContentPropertyChanged);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='AlignItemsProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="AlignItems"/>.</summary>
 		public static readonly BindableProperty AlignItemsProperty =
 			BindableProperty.Create(nameof(AlignItems), typeof(FlexAlignItems), typeof(FlexLayout), FlexAlignItems.Stretch,
 									propertyChanged: OnAlignItemsPropertyChanged);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='PositionProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Position"/>.</summary>
 		public static readonly BindableProperty PositionProperty =
 			BindableProperty.Create(nameof(Position), typeof(FlexPosition), typeof(FlexLayout), FlexPosition.Relative,
 									propertyChanged: OnPositionPropertyChanged);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='WrapProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Wrap"/>.</summary>
 		public static readonly BindableProperty WrapProperty =
 			BindableProperty.Create(nameof(Wrap), typeof(FlexWrap), typeof(FlexLayout), FlexWrap.NoWrap,
 									propertyChanged: OnWrapPropertyChanged);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='OrderProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Order"/>.</summary>
 		public static readonly BindableProperty OrderProperty =
 			BindableProperty.CreateAttached("Order", typeof(int), typeof(FlexLayout), default(int),
 											propertyChanged: OnOrderPropertyChanged);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='GrowProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Grow"/>.</summary>
 		public static readonly BindableProperty GrowProperty =
 			BindableProperty.CreateAttached("Grow", typeof(float), typeof(FlexLayout), default(float),
 											propertyChanged: OnGrowPropertyChanged, validateValue: (bindable, value) => (float)value >= 0);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='ShrinkProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Shrink"/>.</summary>
 		public static readonly BindableProperty ShrinkProperty =
 			BindableProperty.CreateAttached("Shrink", typeof(float), typeof(FlexLayout), 1f,
 											propertyChanged: OnShrinkPropertyChanged, validateValue: (bindable, value) => (float)value >= 0);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='AlignSelfProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="AlignSelf"/>.</summary>
 		public static readonly BindableProperty AlignSelfProperty =
 			BindableProperty.CreateAttached("AlignSelf", typeof(FlexAlignSelf), typeof(FlexLayout), FlexAlignSelf.Auto,
 											propertyChanged: OnAlignSelfPropertyChanged);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='BasisProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Basis"/>.</summary>
 		public static readonly BindableProperty BasisProperty =
 			BindableProperty.CreateAttached("Basis", typeof(FlexBasis), typeof(FlexLayout), FlexBasis.Auto,
 											propertyChanged: OnBasisPropertyChanged);

--- a/src/Controls/src/Core/Layout/FlexLayout.cs
+++ b/src/Controls/src/Core/Layout/FlexLayout.cs
@@ -15,57 +15,57 @@ namespace Microsoft.Maui.Controls
 	{
 		Flex.Item _root;
 
-		/// <summary>Bindable property for <see cref="Direction"/>.</summary>
+		/// <summary>Bindable property for attached property <see cref="Direction"/>.</summary>
 		public static readonly BindableProperty DirectionProperty =
 			BindableProperty.Create(nameof(Direction), typeof(FlexDirection), typeof(FlexLayout), FlexDirection.Row,
 									propertyChanged: OnDirectionPropertyChanged);
 
-		/// <summary>Bindable property for <see cref="JustifyContent"/>.</summary>
+		/// <summary>Bindable property for attached property <see cref="JustifyContent"/>.</summary>
 		public static readonly BindableProperty JustifyContentProperty =
 			BindableProperty.Create(nameof(JustifyContent), typeof(FlexJustify), typeof(FlexLayout), FlexJustify.Start,
 									propertyChanged: OnJustifyContentPropertyChanged);
 
-		/// <summary>Bindable property for <see cref="AlignContent"/>.</summary>
+		/// <summary>Bindable property for attached property <see cref="AlignContent"/>.</summary>
 		public static readonly BindableProperty AlignContentProperty =
 			BindableProperty.Create(nameof(AlignContent), typeof(FlexAlignContent), typeof(FlexLayout), FlexAlignContent.Stretch,
 									propertyChanged: OnAlignContentPropertyChanged);
 
-		/// <summary>Bindable property for <see cref="AlignItems"/>.</summary>
+		/// <summary>Bindable property for attached property <see cref="AlignItems"/>.</summary>
 		public static readonly BindableProperty AlignItemsProperty =
 			BindableProperty.Create(nameof(AlignItems), typeof(FlexAlignItems), typeof(FlexLayout), FlexAlignItems.Stretch,
 									propertyChanged: OnAlignItemsPropertyChanged);
 
-		/// <summary>Bindable property for <see cref="Position"/>.</summary>
+		/// <summary>Bindable property for attached property <see cref="Position"/>.</summary>
 		public static readonly BindableProperty PositionProperty =
 			BindableProperty.Create(nameof(Position), typeof(FlexPosition), typeof(FlexLayout), FlexPosition.Relative,
 									propertyChanged: OnPositionPropertyChanged);
 
-		/// <summary>Bindable property for <see cref="Wrap"/>.</summary>
+		/// <summary>Bindable property for attached property <see cref="Wrap"/>.</summary>
 		public static readonly BindableProperty WrapProperty =
 			BindableProperty.Create(nameof(Wrap), typeof(FlexWrap), typeof(FlexLayout), FlexWrap.NoWrap,
 									propertyChanged: OnWrapPropertyChanged);
 
-		/// <summary>Bindable property for <see cref="Order"/>.</summary>
+		/// <summary>Bindable property for attached property <c>Order</c>.</summary>
 		public static readonly BindableProperty OrderProperty =
 			BindableProperty.CreateAttached("Order", typeof(int), typeof(FlexLayout), default(int),
 											propertyChanged: OnOrderPropertyChanged);
 
-		/// <summary>Bindable property for <see cref="Grow"/>.</summary>
+		/// <summary>Bindable property for attached property <c>Grow</c>.</summary>
 		public static readonly BindableProperty GrowProperty =
 			BindableProperty.CreateAttached("Grow", typeof(float), typeof(FlexLayout), default(float),
 											propertyChanged: OnGrowPropertyChanged, validateValue: (bindable, value) => (float)value >= 0);
 
-		/// <summary>Bindable property for <see cref="Shrink"/>.</summary>
+		/// <summary>Bindable property for attached property <c>Shrink</c>.</summary>
 		public static readonly BindableProperty ShrinkProperty =
 			BindableProperty.CreateAttached("Shrink", typeof(float), typeof(FlexLayout), 1f,
 											propertyChanged: OnShrinkPropertyChanged, validateValue: (bindable, value) => (float)value >= 0);
 
-		/// <summary>Bindable property for <see cref="AlignSelf"/>.</summary>
+		/// <summary>Bindable property for attached property <c>AlignSelf</c>.</summary>
 		public static readonly BindableProperty AlignSelfProperty =
 			BindableProperty.CreateAttached("AlignSelf", typeof(FlexAlignSelf), typeof(FlexLayout), FlexAlignSelf.Auto,
 											propertyChanged: OnAlignSelfPropertyChanged);
 
-		/// <summary>Bindable property for <see cref="Basis"/>.</summary>
+		/// <summary>Bindable property for attached property <c>Basis</c>.</summary>
 		public static readonly BindableProperty BasisProperty =
 			BindableProperty.CreateAttached("Basis", typeof(FlexBasis), typeof(FlexLayout), FlexBasis.Auto,
 											propertyChanged: OnBasisPropertyChanged);

--- a/src/Controls/src/Core/Layout/Grid.cs
+++ b/src/Controls/src/Core/Layout/Grid.cs
@@ -41,22 +41,22 @@ namespace Microsoft.Maui.Controls
 
 		#region Row/Column/Span Attached Properties
 
-		/// <summary>Bindable property for <see cref="Row"/>.</summary>
+		/// <summary>Bindable property for attached property <c>Row</c>.</summary>
 		public static readonly BindableProperty RowProperty = BindableProperty.CreateAttached("Row",
 			typeof(int), typeof(Grid), default(int), validateValue: (bindable, value) => (int)value >= 0,
 			propertyChanged: Invalidate);
 
-		/// <summary>Bindable property for <see cref="RowSpan"/>.</summary>
+		/// <summary>Bindable property for attached property <c>RowSpan</c>.</summary>
 		public static readonly BindableProperty RowSpanProperty = BindableProperty.CreateAttached("RowSpan",
 			typeof(int), typeof(Grid), 1, validateValue: (bindable, value) => (int)value >= 1,
 			propertyChanged: Invalidate);
 
-		/// <summary>Bindable property for <see cref="Column"/>.</summary>
+		/// <summary>Bindable property for attached property <c>Column</c>.</summary>
 		public static readonly BindableProperty ColumnProperty = BindableProperty.CreateAttached("Column",
 			typeof(int), typeof(Grid), default(int), validateValue: (bindable, value) => (int)value >= 0,
 			propertyChanged: Invalidate);
 
-		/// <summary>Bindable property for <see cref="ColumnSpan"/>.</summary>
+		/// <summary>Bindable property for attached property <c>ColumnSpan</c>.</summary>
 		public static readonly BindableProperty ColumnSpanProperty = BindableProperty.CreateAttached("ColumnSpan",
 			typeof(int), typeof(Grid), 1, validateValue: (bindable, value) => (int)value >= 1,
 			propertyChanged: Invalidate);

--- a/src/Controls/src/Core/Layout/Grid.cs
+++ b/src/Controls/src/Core/Layout/Grid.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Maui.Controls
 	{
 		readonly Dictionary<IView, GridInfo> _viewInfo = new();
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='ColumnDefinitionsProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="ColumnDefinitions"/>.</summary>
 		public static readonly BindableProperty ColumnDefinitionsProperty = BindableProperty.Create("ColumnDefinitions",
 			typeof(ColumnDefinitionCollection), typeof(Grid), null, validateValue: (bindable, value) => value != null,
 			propertyChanged: UpdateSizeChangedHandlers, defaultValueCreator: bindable =>
@@ -21,7 +21,7 @@ namespace Microsoft.Maui.Controls
 				return colDef;
 			});
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='RowDefinitionsProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="RowDefinitions"/>.</summary>
 		public static readonly BindableProperty RowDefinitionsProperty = BindableProperty.Create("RowDefinitions",
 			typeof(RowDefinitionCollection), typeof(Grid), null, validateValue: (bindable, value) => value != null,
 			propertyChanged: UpdateSizeChangedHandlers, defaultValueCreator: bindable =>
@@ -31,32 +31,32 @@ namespace Microsoft.Maui.Controls
 				return rowDef;
 			});
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='RowSpacingProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="RowSpacing"/>.</summary>
 		public static readonly BindableProperty RowSpacingProperty = BindableProperty.Create("RowSpacing", typeof(double),
 			typeof(Grid), 0d, propertyChanged: Invalidate);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='ColumnSpacingProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="ColumnSpacing"/>.</summary>
 		public static readonly BindableProperty ColumnSpacingProperty = BindableProperty.Create("ColumnSpacing", typeof(double),
 			typeof(Grid), 0d, propertyChanged: Invalidate);
 
 		#region Row/Column/Span Attached Properties
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='RowProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Row"/>.</summary>
 		public static readonly BindableProperty RowProperty = BindableProperty.CreateAttached("Row",
 			typeof(int), typeof(Grid), default(int), validateValue: (bindable, value) => (int)value >= 0,
 			propertyChanged: Invalidate);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='RowSpanProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="RowSpan"/>.</summary>
 		public static readonly BindableProperty RowSpanProperty = BindableProperty.CreateAttached("RowSpan",
 			typeof(int), typeof(Grid), 1, validateValue: (bindable, value) => (int)value >= 1,
 			propertyChanged: Invalidate);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='ColumnProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Column"/>.</summary>
 		public static readonly BindableProperty ColumnProperty = BindableProperty.CreateAttached("Column",
 			typeof(int), typeof(Grid), default(int), validateValue: (bindable, value) => (int)value >= 0,
 			propertyChanged: Invalidate);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='ColumnSpanProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="ColumnSpan"/>.</summary>
 		public static readonly BindableProperty ColumnSpanProperty = BindableProperty.CreateAttached("ColumnSpan",
 			typeof(int), typeof(Grid), 1, validateValue: (bindable, value) => (int)value >= 1,
 			propertyChanged: Invalidate);

--- a/src/Controls/src/Core/Layout/Layout.cs
+++ b/src/Controls/src/Core/Layout/Layout.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Layout.xml" path="//Member[@MemberName='IsClippedToBoundsProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="IsClippedToBounds"/>.</summary>
 		public static readonly BindableProperty IsClippedToBoundsProperty =
 			BindableProperty.Create(nameof(IsClippedToBounds), typeof(bool), typeof(Layout), false,
 				propertyChanged: IsClippedToBoundsPropertyChanged);
@@ -99,7 +99,7 @@ namespace Microsoft.Maui.Controls
 
 		bool Maui.ILayout.ClipsToBounds => IsClippedToBounds;
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Layout.xml" path="//Member[@MemberName='PaddingProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Padding"/>.</summary>
 		public static readonly BindableProperty PaddingProperty = PaddingElement.PaddingProperty;
 
 		/// <include file="../../../docs/Microsoft.Maui.Controls/Layout.xml" path="//Member[@MemberName='Padding']/Docs/*" />
@@ -293,6 +293,7 @@ namespace Microsoft.Maui.Controls
 			ViewHandler.ViewMapper = ControlsLayoutMapper;
 		}
 
+		/// <summary>Bindable property for <see cref="CascadeInputTransparent"/>.</summary>
 		public static readonly BindableProperty CascadeInputTransparentProperty =
 			BindableProperty.Create(nameof(CascadeInputTransparent), typeof(bool), typeof(Layout), true);
 

--- a/src/Controls/src/Core/Layout/StackBase.cs
+++ b/src/Controls/src/Core/Layout/StackBase.cs
@@ -1,8 +1,9 @@
-﻿#nullable disable
+#nullable disable
 namespace Microsoft.Maui.Controls
 {
 	public abstract class StackBase : Layout, IStackLayout
 	{
+		/// <summary>Bindable property for <see cref="Spacing"/>.</summary>
 		public static readonly BindableProperty SpacingProperty = BindableProperty.Create(nameof(Spacing), typeof(double), typeof(StackBase), 0d,
 				propertyChanged: (bindable, oldvalue, newvalue) => ((IView)bindable).InvalidateMeasure());
 

--- a/src/Controls/src/Core/Layout/StackLayout.cs
+++ b/src/Controls/src/Core/Layout/StackLayout.cs
@@ -1,4 +1,4 @@
-﻿#nullable disable
+#nullable disable
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Layouts;
 
@@ -7,7 +7,7 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../../docs/Microsoft.Maui.Controls/StackLayout.xml" path="Type[@FullName='Microsoft.Maui.Controls.StackLayout']/Docs/*" />
 	public class StackLayout : StackBase, IStackLayout
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Controls/StackLayout.xml" path="//Member[@MemberName='OrientationProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Orientation"/>.</summary>
 		public static readonly BindableProperty OrientationProperty = BindableProperty.Create(nameof(Orientation), typeof(StackOrientation), typeof(StackLayout), StackOrientation.Vertical,
 			propertyChanged: OrientationChanged);
 

--- a/src/Controls/src/Core/LegacyLayouts/AbsoluteLayout.cs
+++ b/src/Controls/src/Core/LegacyLayouts/AbsoluteLayout.cs
@@ -13,10 +13,10 @@ namespace Microsoft.Maui.Controls.Compatibility
 	[ContentProperty(nameof(Children))]
 	public class AbsoluteLayout : Layout<View>, IElementConfiguration<AbsoluteLayout>
 	{
-		/// <summary>Bindable property for <see cref="LayoutFlags"/>.</summary>
+		/// <summary>Bindable property for attached property <c>LayoutFlags</c>.</summary>
 		public static readonly BindableProperty LayoutFlagsProperty = BindableProperty.CreateAttached("LayoutFlags", typeof(AbsoluteLayoutFlags), typeof(AbsoluteLayout), AbsoluteLayoutFlags.None);
 
-		/// <summary>Bindable property for <see cref="LayoutBounds"/>.</summary>
+		/// <summary>Bindable property for attached property <c>LayoutBounds</c>.</summary>
 		public static readonly BindableProperty LayoutBoundsProperty = BindableProperty.CreateAttached("LayoutBounds", typeof(Rect), typeof(AbsoluteLayout), new Rect(0, 0, AutoSize, AutoSize));
 
 		readonly AbsoluteElementCollection _children;

--- a/src/Controls/src/Core/LegacyLayouts/AbsoluteLayout.cs
+++ b/src/Controls/src/Core/LegacyLayouts/AbsoluteLayout.cs
@@ -13,8 +13,10 @@ namespace Microsoft.Maui.Controls.Compatibility
 	[ContentProperty(nameof(Children))]
 	public class AbsoluteLayout : Layout<View>, IElementConfiguration<AbsoluteLayout>
 	{
+		/// <summary>Bindable property for <see cref="LayoutFlags"/>.</summary>
 		public static readonly BindableProperty LayoutFlagsProperty = BindableProperty.CreateAttached("LayoutFlags", typeof(AbsoluteLayoutFlags), typeof(AbsoluteLayout), AbsoluteLayoutFlags.None);
 
+		/// <summary>Bindable property for <see cref="LayoutBounds"/>.</summary>
 		public static readonly BindableProperty LayoutBoundsProperty = BindableProperty.CreateAttached("LayoutBounds", typeof(Rect), typeof(AbsoluteLayout), new Rect(0, 0, AutoSize, AutoSize));
 
 		readonly AbsoluteElementCollection _children;

--- a/src/Controls/src/Core/LegacyLayouts/FlexLayout.cs
+++ b/src/Controls/src/Core/LegacyLayouts/FlexLayout.cs
@@ -45,27 +45,27 @@ namespace Microsoft.Maui.Controls.Compatibility
 		static readonly BindableProperty FlexItemProperty =
 			BindableProperty.CreateAttached("FlexItem", typeof(Flex.Item), typeof(FlexLayout), null);
 
-		/// <summary>Bindable property for <see cref="Order"/>.</summary>
+		/// <summary>Bindable property for attached property <c>Order</c>.</summary>
 		public static readonly BindableProperty OrderProperty =
 			BindableProperty.CreateAttached("Order", typeof(int), typeof(FlexLayout), default(int),
 											propertyChanged: OnOrderPropertyChanged);
 
-		/// <summary>Bindable property for <see cref="Grow"/>.</summary>
+		/// <summary>Bindable property for attached property <c>Grow</c>.</summary>
 		public static readonly BindableProperty GrowProperty =
 			BindableProperty.CreateAttached("Grow", typeof(float), typeof(FlexLayout), default(float),
 											propertyChanged: OnGrowPropertyChanged, validateValue: (bindable, value) => (float)value >= 0);
 
-		/// <summary>Bindable property for <see cref="Shrink"/>.</summary>
+		/// <summary>Bindable property for attached property <c>Shrink</c>.</summary>
 		public static readonly BindableProperty ShrinkProperty =
 			BindableProperty.CreateAttached("Shrink", typeof(float), typeof(FlexLayout), 1f,
 											propertyChanged: OnShrinkPropertyChanged, validateValue: (bindable, value) => (float)value >= 0);
 
-		/// <summary>Bindable property for <see cref="AlignSelf"/>.</summary>
+		/// <summary>Bindable property for attached property <c>AlignSelf</c>.</summary>
 		public static readonly BindableProperty AlignSelfProperty =
 			BindableProperty.CreateAttached("AlignSelf", typeof(FlexAlignSelf), typeof(FlexLayout), FlexAlignSelf.Auto,
 											propertyChanged: OnAlignSelfPropertyChanged);
 
-		/// <summary>Bindable property for <see cref="Basis"/>.</summary>
+		/// <summary>Bindable property for attached property <c>Basis</c>.</summary>
 		public static readonly BindableProperty BasisProperty =
 			BindableProperty.CreateAttached("Basis", typeof(FlexBasis), typeof(FlexLayout), FlexBasis.Auto,
 											propertyChanged: OnBasisPropertyChanged);

--- a/src/Controls/src/Core/LegacyLayouts/FlexLayout.cs
+++ b/src/Controls/src/Core/LegacyLayouts/FlexLayout.cs
@@ -12,26 +12,32 @@ namespace Microsoft.Maui.Controls.Compatibility
 	[ContentProperty(nameof(Children))]
 	public class FlexLayout : Layout<View>
 	{
+		/// <summary>Bindable property for <see cref="Direction"/>.</summary>
 		public static readonly BindableProperty DirectionProperty =
 			BindableProperty.Create(nameof(Direction), typeof(FlexDirection), typeof(FlexLayout), FlexDirection.Row,
 									propertyChanged: OnDirectionPropertyChanged);
 
+		/// <summary>Bindable property for <see cref="JustifyContent"/>.</summary>
 		public static readonly BindableProperty JustifyContentProperty =
 			BindableProperty.Create(nameof(JustifyContent), typeof(FlexJustify), typeof(FlexLayout), FlexJustify.Start,
 									propertyChanged: OnJustifyContentPropertyChanged);
 
+		/// <summary>Bindable property for <see cref="AlignContent"/>.</summary>
 		public static readonly BindableProperty AlignContentProperty =
 			BindableProperty.Create(nameof(AlignContent), typeof(FlexAlignContent), typeof(FlexLayout), FlexAlignContent.Stretch,
 									propertyChanged: OnAlignContentPropertyChanged);
 
+		/// <summary>Bindable property for <see cref="AlignItems"/>.</summary>
 		public static readonly BindableProperty AlignItemsProperty =
 			BindableProperty.Create(nameof(AlignItems), typeof(FlexAlignItems), typeof(FlexLayout), FlexAlignItems.Stretch,
 									propertyChanged: OnAlignItemsPropertyChanged);
 
+		/// <summary>Bindable property for <see cref="Position"/>.</summary>
 		public static readonly BindableProperty PositionProperty =
 			BindableProperty.Create(nameof(Position), typeof(FlexPosition), typeof(FlexLayout), FlexPosition.Relative,
 									propertyChanged: OnPositionPropertyChanged);
 
+		/// <summary>Bindable property for <see cref="Wrap"/>.</summary>
 		public static readonly BindableProperty WrapProperty =
 			BindableProperty.Create(nameof(Wrap), typeof(FlexWrap), typeof(FlexLayout), FlexWrap.NoWrap,
 									propertyChanged: OnWrapPropertyChanged);
@@ -39,22 +45,27 @@ namespace Microsoft.Maui.Controls.Compatibility
 		static readonly BindableProperty FlexItemProperty =
 			BindableProperty.CreateAttached("FlexItem", typeof(Flex.Item), typeof(FlexLayout), null);
 
+		/// <summary>Bindable property for <see cref="Order"/>.</summary>
 		public static readonly BindableProperty OrderProperty =
 			BindableProperty.CreateAttached("Order", typeof(int), typeof(FlexLayout), default(int),
 											propertyChanged: OnOrderPropertyChanged);
 
+		/// <summary>Bindable property for <see cref="Grow"/>.</summary>
 		public static readonly BindableProperty GrowProperty =
 			BindableProperty.CreateAttached("Grow", typeof(float), typeof(FlexLayout), default(float),
 											propertyChanged: OnGrowPropertyChanged, validateValue: (bindable, value) => (float)value >= 0);
 
+		/// <summary>Bindable property for <see cref="Shrink"/>.</summary>
 		public static readonly BindableProperty ShrinkProperty =
 			BindableProperty.CreateAttached("Shrink", typeof(float), typeof(FlexLayout), 1f,
 											propertyChanged: OnShrinkPropertyChanged, validateValue: (bindable, value) => (float)value >= 0);
 
+		/// <summary>Bindable property for <see cref="AlignSelf"/>.</summary>
 		public static readonly BindableProperty AlignSelfProperty =
 			BindableProperty.CreateAttached("AlignSelf", typeof(FlexAlignSelf), typeof(FlexLayout), FlexAlignSelf.Auto,
 											propertyChanged: OnAlignSelfPropertyChanged);
 
+		/// <summary>Bindable property for <see cref="Basis"/>.</summary>
 		public static readonly BindableProperty BasisProperty =
 			BindableProperty.CreateAttached("Basis", typeof(FlexBasis), typeof(FlexLayout), FlexBasis.Auto,
 											propertyChanged: OnBasisPropertyChanged);

--- a/src/Controls/src/Core/LegacyLayouts/Grid.cs
+++ b/src/Controls/src/Core/LegacyLayouts/Grid.cs
@@ -12,20 +12,27 @@ namespace Microsoft.Maui.Controls.Compatibility
 	[ContentProperty(nameof(Children))]
 	public partial class Grid : Layout<View>, IGridController, IElementConfiguration<Grid>, IGridLayout
 	{
+		/// <summary>Bindable property for <see cref="Row"/>.</summary>
 		public static readonly BindableProperty RowProperty = BindableProperty.CreateAttached("Row", typeof(int), typeof(Grid), default(int), validateValue: (bindable, value) => (int)value >= 0);
 
+		/// <summary>Bindable property for <see cref="RowSpan"/>.</summary>
 		public static readonly BindableProperty RowSpanProperty = BindableProperty.CreateAttached("RowSpan", typeof(int), typeof(Grid), 1, validateValue: (bindable, value) => (int)value >= 1);
 
+		/// <summary>Bindable property for <see cref="Column"/>.</summary>
 		public static readonly BindableProperty ColumnProperty = BindableProperty.CreateAttached("Column", typeof(int), typeof(Grid), default(int), validateValue: (bindable, value) => (int)value >= 0);
 
+		/// <summary>Bindable property for <see cref="ColumnSpan"/>.</summary>
 		public static readonly BindableProperty ColumnSpanProperty = BindableProperty.CreateAttached("ColumnSpan", typeof(int), typeof(Grid), 1, validateValue: (bindable, value) => (int)value >= 1);
 
+		/// <summary>Bindable property for <see cref="RowSpacing"/>.</summary>
 		public static readonly BindableProperty RowSpacingProperty = BindableProperty.Create("RowSpacing", typeof(double), typeof(Grid), 6d,
 			propertyChanged: (bindable, oldValue, newValue) => ((Grid)bindable).InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged));
 
+		/// <summary>Bindable property for <see cref="ColumnSpacing"/>.</summary>
 		public static readonly BindableProperty ColumnSpacingProperty = BindableProperty.Create("ColumnSpacing", typeof(double), typeof(Grid), 6d,
 			propertyChanged: (bindable, oldValue, newValue) => ((Grid)bindable).InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged));
 
+		/// <summary>Bindable property for <see cref="ColumnDefinitions"/>.</summary>
 		public static readonly BindableProperty ColumnDefinitionsProperty = BindableProperty.Create("ColumnDefinitions", typeof(ColumnDefinitionCollection), typeof(Grid), null,
 			validateValue: (bindable, value) => value != null, propertyChanged: (bindable, oldvalue, newvalue) =>
 			{
@@ -41,6 +48,7 @@ namespace Microsoft.Maui.Controls.Compatibility
 				return colDef;
 			});
 
+		/// <summary>Bindable property for <see cref="RowDefinitions"/>.</summary>
 		public static readonly BindableProperty RowDefinitionsProperty = BindableProperty.Create("RowDefinitions", typeof(RowDefinitionCollection), typeof(Grid), null,
 			validateValue: (bindable, value) => value != null, propertyChanged: (bindable, oldvalue, newvalue) =>
 			{

--- a/src/Controls/src/Core/LegacyLayouts/Grid.cs
+++ b/src/Controls/src/Core/LegacyLayouts/Grid.cs
@@ -12,16 +12,16 @@ namespace Microsoft.Maui.Controls.Compatibility
 	[ContentProperty(nameof(Children))]
 	public partial class Grid : Layout<View>, IGridController, IElementConfiguration<Grid>, IGridLayout
 	{
-		/// <summary>Bindable property for <see cref="Row"/>.</summary>
+		/// <summary>Bindable property for attached property <c>Row</c>.</summary>
 		public static readonly BindableProperty RowProperty = BindableProperty.CreateAttached("Row", typeof(int), typeof(Grid), default(int), validateValue: (bindable, value) => (int)value >= 0);
 
-		/// <summary>Bindable property for <see cref="RowSpan"/>.</summary>
+		/// <summary>Bindable property for attached property <c>RowSpan</c>.</summary>
 		public static readonly BindableProperty RowSpanProperty = BindableProperty.CreateAttached("RowSpan", typeof(int), typeof(Grid), 1, validateValue: (bindable, value) => (int)value >= 1);
 
-		/// <summary>Bindable property for <see cref="Column"/>.</summary>
+		/// <summary>Bindable property for attached property <c>Column</c>.</summary>
 		public static readonly BindableProperty ColumnProperty = BindableProperty.CreateAttached("Column", typeof(int), typeof(Grid), default(int), validateValue: (bindable, value) => (int)value >= 0);
 
-		/// <summary>Bindable property for <see cref="ColumnSpan"/>.</summary>
+		/// <summary>Bindable property for attached property <c>ColumnSpan</c>.</summary>
 		public static readonly BindableProperty ColumnSpanProperty = BindableProperty.CreateAttached("ColumnSpan", typeof(int), typeof(Grid), 1, validateValue: (bindable, value) => (int)value >= 1);
 
 		/// <summary>Bindable property for <see cref="RowSpacing"/>.</summary>

--- a/src/Controls/src/Core/LegacyLayouts/RelativeLayout.cs
+++ b/src/Controls/src/Core/LegacyLayouts/RelativeLayout.cs
@@ -13,14 +13,19 @@ namespace Microsoft.Maui.Controls.Compatibility
 	[ContentProperty(nameof(Children))]
 	public class RelativeLayout : Layout<View>, IElementConfiguration<RelativeLayout>
 	{
+		/// <summary>Bindable property for <see cref="XConstraint"/>.</summary>
 		public static readonly BindableProperty XConstraintProperty = BindableProperty.CreateAttached("XConstraint", typeof(Constraint), typeof(RelativeLayout), null, propertyChanged: ConstraintChanged);
 
+		/// <summary>Bindable property for <see cref="YConstraint"/>.</summary>
 		public static readonly BindableProperty YConstraintProperty = BindableProperty.CreateAttached("YConstraint", typeof(Constraint), typeof(RelativeLayout), null, propertyChanged: ConstraintChanged);
 
+		/// <summary>Bindable property for <see cref="WidthConstraint"/>.</summary>
 		public static readonly BindableProperty WidthConstraintProperty = BindableProperty.CreateAttached("WidthConstraint", typeof(Constraint), typeof(RelativeLayout), null, propertyChanged: ConstraintChanged);
 
+		/// <summary>Bindable property for <see cref="HeightConstraint"/>.</summary>
 		public static readonly BindableProperty HeightConstraintProperty = BindableProperty.CreateAttached("HeightConstraint", typeof(Constraint), typeof(RelativeLayout), null, propertyChanged: ConstraintChanged);
 
+		/// <summary>Bindable property for <see cref="BoundsConstraint"/>.</summary>
 		public static readonly BindableProperty BoundsConstraintProperty = BindableProperty.CreateAttached("BoundsConstraint", typeof(BoundsConstraint), typeof(RelativeLayout), null);
 
 		readonly RelativeElementCollection _children;

--- a/src/Controls/src/Core/LegacyLayouts/RelativeLayout.cs
+++ b/src/Controls/src/Core/LegacyLayouts/RelativeLayout.cs
@@ -13,19 +13,19 @@ namespace Microsoft.Maui.Controls.Compatibility
 	[ContentProperty(nameof(Children))]
 	public class RelativeLayout : Layout<View>, IElementConfiguration<RelativeLayout>
 	{
-		/// <summary>Bindable property for <see cref="XConstraint"/>.</summary>
+		/// <summary>Bindable property for attached property <c>XConstraint</c>.</summary>
 		public static readonly BindableProperty XConstraintProperty = BindableProperty.CreateAttached("XConstraint", typeof(Constraint), typeof(RelativeLayout), null, propertyChanged: ConstraintChanged);
 
-		/// <summary>Bindable property for <see cref="YConstraint"/>.</summary>
+		/// <summary>Bindable property for attached property <c>YConstraint</c>.</summary>
 		public static readonly BindableProperty YConstraintProperty = BindableProperty.CreateAttached("YConstraint", typeof(Constraint), typeof(RelativeLayout), null, propertyChanged: ConstraintChanged);
 
-		/// <summary>Bindable property for <see cref="WidthConstraint"/>.</summary>
+		/// <summary>Bindable property for attached property <c>WidthConstraint</c>.</summary>
 		public static readonly BindableProperty WidthConstraintProperty = BindableProperty.CreateAttached("WidthConstraint", typeof(Constraint), typeof(RelativeLayout), null, propertyChanged: ConstraintChanged);
 
-		/// <summary>Bindable property for <see cref="HeightConstraint"/>.</summary>
+		/// <summary>Bindable property for attached property <c>HeightConstraint</c>.</summary>
 		public static readonly BindableProperty HeightConstraintProperty = BindableProperty.CreateAttached("HeightConstraint", typeof(Constraint), typeof(RelativeLayout), null, propertyChanged: ConstraintChanged);
 
-		/// <summary>Bindable property for <see cref="BoundsConstraint"/>.</summary>
+		/// <summary>Bindable property for attached property <c>BoundsConstraint</c>.</summary>
 		public static readonly BindableProperty BoundsConstraintProperty = BindableProperty.CreateAttached("BoundsConstraint", typeof(BoundsConstraint), typeof(RelativeLayout), null);
 
 		readonly RelativeElementCollection _children;

--- a/src/Controls/src/Core/LegacyLayouts/StackLayout.cs
+++ b/src/Controls/src/Core/LegacyLayouts/StackLayout.cs
@@ -9,9 +9,11 @@ namespace Microsoft.Maui.Controls.Compatibility
 	[ContentProperty(nameof(Children))]
 	public class StackLayout : Layout<View>, IElementConfiguration<StackLayout>, IView
 	{
+		/// <summary>Bindable property for <see cref="Orientation"/>.</summary>
 		public static readonly BindableProperty OrientationProperty = BindableProperty.Create(nameof(Orientation), typeof(StackOrientation), typeof(StackLayout), StackOrientation.Vertical,
 			propertyChanged: (bindable, oldvalue, newvalue) => ((StackLayout)bindable).InvalidateLayout());
 
+		/// <summary>Bindable property for <see cref="Spacing"/>.</summary>
 		public static readonly BindableProperty SpacingProperty = BindableProperty.Create(nameof(Spacing), typeof(double), typeof(StackLayout), 6d,
 			propertyChanged: (bindable, oldvalue, newvalue) => ((StackLayout)bindable).InvalidateLayout());
 

--- a/src/Controls/src/Core/LineHeightElement.cs
+++ b/src/Controls/src/Core/LineHeightElement.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Maui.Controls
 {
 	static class LineHeightElement
 	{
-		/// <summary>Bindable property for <see cref="LineHeight"/>.</summary>
+		/// <summary>Bindable property for <see cref="ILineHeightElement.LineHeight"/>.</summary>
 		public static readonly BindableProperty LineHeightProperty =
 			BindableProperty.Create(nameof(ILineHeightElement.LineHeight), typeof(double), typeof(ILineHeightElement), -1.0d,
 									propertyChanged: OnLineHeightChanged);

--- a/src/Controls/src/Core/LineHeightElement.cs
+++ b/src/Controls/src/Core/LineHeightElement.cs
@@ -5,6 +5,7 @@ namespace Microsoft.Maui.Controls
 {
 	static class LineHeightElement
 	{
+		/// <summary>Bindable property for <see cref="LineHeight"/>.</summary>
 		public static readonly BindableProperty LineHeightProperty =
 			BindableProperty.Create(nameof(ILineHeightElement.LineHeight), typeof(double), typeof(ILineHeightElement), -1.0d,
 									propertyChanged: OnLineHeightChanged);

--- a/src/Controls/src/Core/LinearGradientBrush.cs
+++ b/src/Controls/src/Core/LinearGradientBrush.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/LinearGradientBrush.xml" path="//Member[@MemberName='StartPointProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="StartPoint"/>.</summary>
 		public static readonly BindableProperty StartPointProperty = BindableProperty.Create(
 			nameof(StartPoint), typeof(Point), typeof(LinearGradientBrush), new Point(0, 0));
 
@@ -47,7 +47,7 @@ namespace Microsoft.Maui.Controls
 			set => SetValue(StartPointProperty, value);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/LinearGradientBrush.xml" path="//Member[@MemberName='EndPointProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="EndPoint"/>.</summary>
 		public static readonly BindableProperty EndPointProperty = BindableProperty.Create(
 			nameof(EndPoint), typeof(Point), typeof(LinearGradientBrush), new Point(1, 1));
 

--- a/src/Controls/src/Core/ListView.cs
+++ b/src/Controls/src/Core/ListView.cs
@@ -22,62 +22,62 @@ namespace Microsoft.Maui.Controls
 
 		internal override IEnumerable<Element> ChildrenNotDrawnByThisElement => _logicalChildren;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ListView.xml" path="//Member[@MemberName='IsPullToRefreshEnabledProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="IsPullToRefreshEnabled"/>.</summary>
 		public static readonly BindableProperty IsPullToRefreshEnabledProperty = BindableProperty.Create("IsPullToRefreshEnabled", typeof(bool), typeof(ListView), false);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ListView.xml" path="//Member[@MemberName='IsRefreshingProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="IsRefreshing"/>.</summary>
 		public static readonly BindableProperty IsRefreshingProperty = BindableProperty.Create("IsRefreshing", typeof(bool), typeof(ListView), false, BindingMode.TwoWay);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ListView.xml" path="//Member[@MemberName='RefreshCommandProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="RefreshCommand"/>.</summary>
 		public static readonly BindableProperty RefreshCommandProperty = BindableProperty.Create("RefreshCommand", typeof(ICommand), typeof(ListView), null, propertyChanged: OnRefreshCommandChanged);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ListView.xml" path="//Member[@MemberName='HeaderProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Header"/>.</summary>
 		public static readonly BindableProperty HeaderProperty = BindableProperty.Create("Header", typeof(object), typeof(ListView), null, propertyChanged: OnHeaderChanged);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ListView.xml" path="//Member[@MemberName='HeaderTemplateProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="HeaderTemplate"/>.</summary>
 		public static readonly BindableProperty HeaderTemplateProperty = BindableProperty.Create("HeaderTemplate", typeof(DataTemplate), typeof(ListView), null, propertyChanged: OnHeaderTemplateChanged,
 			validateValue: ValidateHeaderFooterTemplate);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ListView.xml" path="//Member[@MemberName='FooterProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Footer"/>.</summary>
 		public static readonly BindableProperty FooterProperty = BindableProperty.Create("Footer", typeof(object), typeof(ListView), null, propertyChanged: OnFooterChanged);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ListView.xml" path="//Member[@MemberName='FooterTemplateProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="FooterTemplate"/>.</summary>
 		public static readonly BindableProperty FooterTemplateProperty = BindableProperty.Create("FooterTemplate", typeof(DataTemplate), typeof(ListView), null, propertyChanged: OnFooterTemplateChanged,
 			validateValue: ValidateHeaderFooterTemplate);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ListView.xml" path="//Member[@MemberName='SelectedItemProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="SelectedItem"/>.</summary>
 		public static readonly BindableProperty SelectedItemProperty = BindableProperty.Create("SelectedItem", typeof(object), typeof(ListView), null, BindingMode.OneWayToSource,
 			propertyChanged: OnSelectedItemChanged);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ListView.xml" path="//Member[@MemberName='SelectionModeProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="SelectionMode"/>.</summary>
 		public static readonly BindableProperty SelectionModeProperty = BindableProperty.Create(nameof(SelectionMode), typeof(ListViewSelectionMode), typeof(ListView), ListViewSelectionMode.Single);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ListView.xml" path="//Member[@MemberName='HasUnevenRowsProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="HasUnevenRows"/>.</summary>
 		public static readonly BindableProperty HasUnevenRowsProperty = BindableProperty.Create("HasUnevenRows", typeof(bool), typeof(ListView), false);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ListView.xml" path="//Member[@MemberName='RowHeightProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="RowHeight"/>.</summary>
 		public static readonly BindableProperty RowHeightProperty = BindableProperty.Create("RowHeight", typeof(int), typeof(ListView), -1);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ListView.xml" path="//Member[@MemberName='GroupHeaderTemplateProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="GroupHeaderTemplate"/>.</summary>
 		public static readonly BindableProperty GroupHeaderTemplateProperty = BindableProperty.Create("GroupHeaderTemplate", typeof(DataTemplate), typeof(ListView), null,
 			propertyChanged: OnGroupHeaderTemplateChanged);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ListView.xml" path="//Member[@MemberName='IsGroupingEnabledProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="IsGroupingEnabled"/>.</summary>
 		public static readonly BindableProperty IsGroupingEnabledProperty = BindableProperty.Create("IsGroupingEnabled", typeof(bool), typeof(ListView), false);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ListView.xml" path="//Member[@MemberName='SeparatorVisibilityProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="SeparatorVisibility"/>.</summary>
 		public static readonly BindableProperty SeparatorVisibilityProperty = BindableProperty.Create("SeparatorVisibility", typeof(SeparatorVisibility), typeof(ListView), SeparatorVisibility.Default);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ListView.xml" path="//Member[@MemberName='SeparatorColorProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="SeparatorColor"/>.</summary>
 		public static readonly BindableProperty SeparatorColorProperty = BindableProperty.Create("SeparatorColor", typeof(Color), typeof(ListView), null);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ListView.xml" path="//Member[@MemberName='RefreshControlColorProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="RefreshControlColor"/>.</summary>
 		public static readonly BindableProperty RefreshControlColorProperty = BindableProperty.Create(nameof(RefreshControlColor), typeof(Color), typeof(ListView), null);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ListView.xml" path="//Member[@MemberName='HorizontalScrollBarVisibilityProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="HorizontalScrollBarVisibility"/>.</summary>
 		public static readonly BindableProperty HorizontalScrollBarVisibilityProperty = BindableProperty.Create(nameof(HorizontalScrollBarVisibility), typeof(ScrollBarVisibility), typeof(ListView), ScrollBarVisibility.Default);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ListView.xml" path="//Member[@MemberName='VerticalScrollBarVisibilityProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="VerticalScrollBarVisibility"/>.</summary>
 		public static readonly BindableProperty VerticalScrollBarVisibilityProperty = BindableProperty.Create(nameof(VerticalScrollBarVisibility), typeof(ScrollBarVisibility), typeof(ListView), ScrollBarVisibility.Default);
 
 		static readonly ToStringValueConverter _toStringValueConverter = new ToStringValueConverter();

--- a/src/Controls/src/Core/MenuBar.cs
+++ b/src/Controls/src/Core/MenuBar.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Maui.Controls
 {
 	public partial class MenuBar : Element, IMenuBar
 	{
+		/// <summary>Bindable property for <see cref="IsEnabled"/>.</summary>
 		public static readonly BindableProperty IsEnabledProperty = BindableProperty.Create(nameof(IsEnabled), typeof(bool),
 			typeof(MenuBar), true);
 

--- a/src/Controls/src/Core/MenuBarItem.cs
+++ b/src/Controls/src/Core/MenuBarItem.cs
@@ -8,9 +8,11 @@ namespace Microsoft.Maui.Controls
 {
 	public partial class MenuBarItem : BaseMenuItem, IMenuBarItem
 	{
+		/// <summary>Bindable property for <see cref="Text"/>.</summary>
 		public static readonly BindableProperty TextProperty =
 			BindableProperty.Create(nameof(Text), typeof(string), typeof(MenuBarItem), null);
 
+		/// <summary>Bindable property for <see cref="IsEnabled"/>.</summary>
 		public static readonly BindableProperty IsEnabledProperty = BindableProperty.Create(nameof(IsEnabled), typeof(bool),
 			typeof(MenuBarItem), true);
 

--- a/src/Controls/src/Core/MenuItem.cs
+++ b/src/Controls/src/Core/MenuItem.cs
@@ -11,32 +11,32 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../docs/Microsoft.Maui.Controls/MenuItem.xml" path="Type[@FullName='Microsoft.Maui.Controls.MenuItem']/Docs/*" />
 	public partial class MenuItem : BaseMenuItem, IMenuItemController, IStyleSelectable, ICommandElement
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/MenuItem.xml" path="//Member[@MemberName='AcceleratorProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Accelerator"/>.</summary>
 		public static readonly BindableProperty AcceleratorProperty = BindableProperty.CreateAttached(nameof(Accelerator), typeof(Accelerator), typeof(MenuItem), null);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/MenuItem.xml" path="//Member[@MemberName='CommandProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Command"/>.</summary>
 		public static readonly BindableProperty CommandProperty = BindableProperty.Create(
 			nameof(Command), typeof(ICommand), typeof(MenuItem), null,
 			propertyChanging: CommandElement.OnCommandChanging,
 			propertyChanged: CommandElement.OnCommandChanged);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/MenuItem.xml" path="//Member[@MemberName='CommandParameterProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="CommandParameter"/>.</summary>
 		public static readonly BindableProperty CommandParameterProperty = BindableProperty.Create(
 			nameof(CommandParameter), typeof(object), typeof(MenuItem), null,
 			propertyChanged: CommandElement.OnCommandParameterChanged);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/MenuItem.xml" path="//Member[@MemberName='IsDestructiveProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="IsDestructive"/>.</summary>
 		public static readonly BindableProperty IsDestructiveProperty = BindableProperty.Create(nameof(IsDestructive), typeof(bool), typeof(MenuItem), false);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/MenuItem.xml" path="//Member[@MemberName='IconImageSourceProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="IconImageSource"/>.</summary>
 		public static readonly BindableProperty IconImageSourceProperty = BindableProperty.Create(nameof(IconImageSource), typeof(ImageSource), typeof(MenuItem), default(ImageSource));
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/MenuItem.xml" path="//Member[@MemberName='IsEnabledProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="IsEnabled"/>.</summary>
 		public static readonly BindableProperty IsEnabledProperty = BindableProperty.Create(
 			nameof(IsEnabled), typeof(bool), typeof(MenuItem), true,
 			coerceValue: CoerceIsEnabledProperty);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/MenuItem.xml" path="//Member[@MemberName='TextProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Text"/>.</summary>
 		public static readonly BindableProperty TextProperty = BindableProperty.Create(nameof(Text), typeof(string), typeof(MenuItem), null);
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/MenuItem.xml" path="//Member[@MemberName='GetAccelerator']/Docs/*" />

--- a/src/Controls/src/Core/MultiPage.cs
+++ b/src/Controls/src/Core/MultiPage.cs
@@ -15,10 +15,13 @@ namespace Microsoft.Maui.Controls
 	[ContentProperty("Children")]
 	public abstract class MultiPage<[DynamicallyAccessedMembers(BindableProperty.DeclaringTypeMembers)] T> : Page, IViewContainer<T>, IPageContainer<T>, IItemsView<T>, IMultiPageController<T> where T : Page
 	{
+		/// <summary>Bindable property for <see cref="ItemsSource"/>.</summary>
 		public static readonly BindableProperty ItemsSourceProperty = BindableProperty.Create("ItemsSource", typeof(IEnumerable), typeof(MultiPage<>), null);
 
+		/// <summary>Bindable property for <see cref="ItemTemplate"/>.</summary>
 		public static readonly BindableProperty ItemTemplateProperty = BindableProperty.Create("ItemTemplate", typeof(DataTemplate), typeof(MultiPage<>), null);
 
+		/// <summary>Bindable property for <see cref="SelectedItem"/>.</summary>
 		public static readonly BindableProperty SelectedItemProperty = BindableProperty.Create("SelectedItem", typeof(object), typeof(MultiPage<>), null, BindingMode.TwoWay);
 
 		internal static readonly BindableProperty IndexProperty = BindableProperty.Create("Index", typeof(int), typeof(Page), -1);

--- a/src/Controls/src/Core/NavigationPage.cs
+++ b/src/Controls/src/Core/NavigationPage.cs
@@ -1,4 +1,4 @@
-﻿#nullable disable
+#nullable disable
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -13,41 +13,41 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../docs/Microsoft.Maui.Controls/NavigationPage.xml" path="Type[@FullName='Microsoft.Maui.Controls.NavigationPage']/Docs/*" />
 	public partial class NavigationPage : Page, IPageContainer<Page>, IBarElement, IElementConfiguration<NavigationPage>
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/NavigationPage.xml" path="//Member[@MemberName='BackButtonTitleProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="BackButtonTitle"/>.</summary>
 		public static readonly BindableProperty BackButtonTitleProperty = BindableProperty.CreateAttached("BackButtonTitle", typeof(string), typeof(Page), null);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/NavigationPage.xml" path="//Member[@MemberName='HasNavigationBarProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="HasNavigationBar"/>.</summary>
 		public static readonly BindableProperty HasNavigationBarProperty =
 			BindableProperty.CreateAttached("HasNavigationBar", typeof(bool), typeof(Page), true);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/NavigationPage.xml" path="//Member[@MemberName='HasBackButtonProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="HasBackButton"/>.</summary>
 		public static readonly BindableProperty HasBackButtonProperty = BindableProperty.CreateAttached("HasBackButton", typeof(bool), typeof(NavigationPage), true);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/NavigationPage.xml" path="//Member[@MemberName='BarBackgroundColorProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="BarBackgroundColor"/>.</summary>
 		public static readonly BindableProperty BarBackgroundColorProperty = BarElement.BarBackgroundColorProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/NavigationPage.xml" path="//Member[@MemberName='BarBackgroundProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="BarBackground"/>.</summary>
 		public static readonly BindableProperty BarBackgroundProperty = BarElement.BarBackgroundProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/NavigationPage.xml" path="//Member[@MemberName='BarTextColorProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="BarTextColor"/>.</summary>
 		public static readonly BindableProperty BarTextColorProperty = BarElement.BarTextColorProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/NavigationPage.xml" path="//Member[@MemberName='TitleIconImageSourceProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="TitleIconImageSource"/>.</summary>
 		public static readonly BindableProperty TitleIconImageSourceProperty = BindableProperty.CreateAttached("TitleIconImageSource", typeof(ImageSource), typeof(NavigationPage), default(ImageSource));
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/NavigationPage.xml" path="//Member[@MemberName='IconColorProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="IconColor"/>.</summary>
 		public static readonly BindableProperty IconColorProperty = BindableProperty.CreateAttached("IconColor", typeof(Color), typeof(NavigationPage), null);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/NavigationPage.xml" path="//Member[@MemberName='TitleViewProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="TitleView"/>.</summary>
 		public static readonly BindableProperty TitleViewProperty = BindableProperty.CreateAttached("TitleView", typeof(View), typeof(NavigationPage), null, propertyChanging: TitleViewPropertyChanging);
 
 		static readonly BindablePropertyKey CurrentPagePropertyKey = BindableProperty.CreateReadOnly("CurrentPage", typeof(Page), typeof(NavigationPage), null, propertyChanged: OnCurrentPageChanged);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/NavigationPage.xml" path="//Member[@MemberName='CurrentPageProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="CurrentPage"/>.</summary>
 		public static readonly BindableProperty CurrentPageProperty = CurrentPagePropertyKey.BindableProperty;
 
 		static readonly BindablePropertyKey RootPagePropertyKey = BindableProperty.CreateReadOnly(nameof(RootPage), typeof(Page), typeof(NavigationPage), null);
-		/// <include file="../../docs/Microsoft.Maui.Controls/NavigationPage.xml" path="//Member[@MemberName='RootPageProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="RootPage"/>.</summary>
 		public static readonly BindableProperty RootPageProperty = RootPagePropertyKey.BindableProperty;
 
 		INavigationPageController NavigationPageController => this;

--- a/src/Controls/src/Core/NavigationPage.cs
+++ b/src/Controls/src/Core/NavigationPage.cs
@@ -13,14 +13,14 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../docs/Microsoft.Maui.Controls/NavigationPage.xml" path="Type[@FullName='Microsoft.Maui.Controls.NavigationPage']/Docs/*" />
 	public partial class NavigationPage : Page, IPageContainer<Page>, IBarElement, IElementConfiguration<NavigationPage>
 	{
-		/// <summary>Bindable property for <see cref="BackButtonTitle"/>.</summary>
+		/// <summary>Bindable property for attached property <c>BackButtonTitle</c>.</summary>
 		public static readonly BindableProperty BackButtonTitleProperty = BindableProperty.CreateAttached("BackButtonTitle", typeof(string), typeof(Page), null);
 
-		/// <summary>Bindable property for <see cref="HasNavigationBar"/>.</summary>
+		/// <summary>Bindable property for attached property <c>HasNavigationBar</c>.</summary>
 		public static readonly BindableProperty HasNavigationBarProperty =
 			BindableProperty.CreateAttached("HasNavigationBar", typeof(bool), typeof(Page), true);
 
-		/// <summary>Bindable property for <see cref="HasBackButton"/>.</summary>
+		/// <summary>Bindable property for attached property <c>HasBackButton</c>.</summary>
 		public static readonly BindableProperty HasBackButtonProperty = BindableProperty.CreateAttached("HasBackButton", typeof(bool), typeof(NavigationPage), true);
 
 		/// <summary>Bindable property for <see cref="BarBackgroundColor"/>.</summary>
@@ -32,13 +32,13 @@ namespace Microsoft.Maui.Controls
 		/// <summary>Bindable property for <see cref="BarTextColor"/>.</summary>
 		public static readonly BindableProperty BarTextColorProperty = BarElement.BarTextColorProperty;
 
-		/// <summary>Bindable property for <see cref="TitleIconImageSource"/>.</summary>
+		/// <summary>Bindable property for attached property <c>TitleIconImageSource</c>.</summary>
 		public static readonly BindableProperty TitleIconImageSourceProperty = BindableProperty.CreateAttached("TitleIconImageSource", typeof(ImageSource), typeof(NavigationPage), default(ImageSource));
 
-		/// <summary>Bindable property for <see cref="IconColor"/>.</summary>
+		/// <summary>Bindable property for attached property <c>IconColor</c>.</summary>
 		public static readonly BindableProperty IconColorProperty = BindableProperty.CreateAttached("IconColor", typeof(Color), typeof(NavigationPage), null);
 
-		/// <summary>Bindable property for <see cref="TitleView"/>.</summary>
+		/// <summary>Bindable property for attached property <c>TitleView</c>.</summary>
 		public static readonly BindableProperty TitleViewProperty = BindableProperty.CreateAttached("TitleView", typeof(View), typeof(NavigationPage), null, propertyChanging: TitleViewPropertyChanging);
 
 		static readonly BindablePropertyKey CurrentPagePropertyKey = BindableProperty.CreateReadOnly("CurrentPage", typeof(Page), typeof(NavigationPage), null, propertyChanged: OnCurrentPageChanged);

--- a/src/Controls/src/Core/OrientationStateTrigger.cs
+++ b/src/Controls/src/Core/OrientationStateTrigger.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Maui.Controls
 			set => SetValue(OrientationProperty, value);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/OrientationStateTrigger.xml" path="//Member[@MemberName='OrientationProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Orientation"/>.</summary>
 		public static readonly BindableProperty OrientationProperty =
 			BindableProperty.Create(nameof(Orientation), typeof(DisplayOrientation), typeof(OrientationStateTrigger), null,
 				propertyChanged: OnOrientationChanged);

--- a/src/Controls/src/Core/PaddingElement.cs
+++ b/src/Controls/src/Core/PaddingElement.cs
@@ -3,7 +3,7 @@ namespace Microsoft.Maui.Controls
 {
 	static class PaddingElement
 	{
-		/// <summary>Bindable property for <see cref="Padding"/>.</summary>
+		/// <summary>Bindable property for <see cref="IPaddingElement.Padding"/>.</summary>
 		public static readonly BindableProperty PaddingProperty =
 			BindableProperty.Create(nameof(IPaddingElement.Padding), typeof(Thickness), typeof(IPaddingElement), default(Thickness),
 									propertyChanged: OnPaddingPropertyChanged,
@@ -19,7 +19,7 @@ namespace Microsoft.Maui.Controls
 			return ((IPaddingElement)bindable).PaddingDefaultValueCreator();
 		}
 
-		/// <summary>Bindable property for <see cref="PaddingLeft"/>.</summary>
+		/// <summary>Bindable property for attached property <c>PaddingLeft</c>.</summary>
 		public static readonly BindableProperty PaddingLeftProperty =
 			BindableProperty.Create("PaddingLeft", typeof(double), typeof(IPaddingElement), default(double),
 									propertyChanged: OnPaddingLeftChanged);
@@ -31,7 +31,7 @@ namespace Microsoft.Maui.Controls
 			bindable.SetValue(PaddingProperty, padding);
 		}
 
-		/// <summary>Bindable property for <see cref="PaddingTop"/>.</summary>
+		/// <summary>Bindable property for attached property <c>PaddingTop</c>.</summary>
 		public static readonly BindableProperty PaddingTopProperty =
 			BindableProperty.Create("PaddingTop", typeof(double), typeof(IPaddingElement), default(double),
 									propertyChanged: OnPaddingTopChanged);
@@ -43,7 +43,7 @@ namespace Microsoft.Maui.Controls
 			bindable.SetValue(PaddingProperty, padding);
 		}
 
-		/// <summary>Bindable property for <see cref="PaddingRight"/>.</summary>
+		/// <summary>Bindable property for attached property <c>PaddingRight</c>.</summary>
 		public static readonly BindableProperty PaddingRightProperty =
 			BindableProperty.Create("PaddingRight", typeof(double), typeof(IPaddingElement), default(double),
 									propertyChanged: OnPaddingRightChanged);
@@ -55,7 +55,7 @@ namespace Microsoft.Maui.Controls
 			bindable.SetValue(PaddingProperty, padding);
 		}
 
-		/// <summary>Bindable property for <see cref="PaddingBottom"/>.</summary>
+		/// <summary>Bindable property for attached property <c>PaddingBottom</c>.</summary>
 		public static readonly BindableProperty PaddingBottomProperty =
 			BindableProperty.Create("PaddingBottom", typeof(double), typeof(IPaddingElement), default(double),
 									propertyChanged: OnPaddingBottomChanged);

--- a/src/Controls/src/Core/PaddingElement.cs
+++ b/src/Controls/src/Core/PaddingElement.cs
@@ -3,6 +3,7 @@ namespace Microsoft.Maui.Controls
 {
 	static class PaddingElement
 	{
+		/// <summary>Bindable property for <see cref="Padding"/>.</summary>
 		public static readonly BindableProperty PaddingProperty =
 			BindableProperty.Create(nameof(IPaddingElement.Padding), typeof(Thickness), typeof(IPaddingElement), default(Thickness),
 									propertyChanged: OnPaddingPropertyChanged,
@@ -18,6 +19,7 @@ namespace Microsoft.Maui.Controls
 			return ((IPaddingElement)bindable).PaddingDefaultValueCreator();
 		}
 
+		/// <summary>Bindable property for <see cref="PaddingLeft"/>.</summary>
 		public static readonly BindableProperty PaddingLeftProperty =
 			BindableProperty.Create("PaddingLeft", typeof(double), typeof(IPaddingElement), default(double),
 									propertyChanged: OnPaddingLeftChanged);
@@ -29,6 +31,7 @@ namespace Microsoft.Maui.Controls
 			bindable.SetValue(PaddingProperty, padding);
 		}
 
+		/// <summary>Bindable property for <see cref="PaddingTop"/>.</summary>
 		public static readonly BindableProperty PaddingTopProperty =
 			BindableProperty.Create("PaddingTop", typeof(double), typeof(IPaddingElement), default(double),
 									propertyChanged: OnPaddingTopChanged);
@@ -40,6 +43,7 @@ namespace Microsoft.Maui.Controls
 			bindable.SetValue(PaddingProperty, padding);
 		}
 
+		/// <summary>Bindable property for <see cref="PaddingRight"/>.</summary>
 		public static readonly BindableProperty PaddingRightProperty =
 			BindableProperty.Create("PaddingRight", typeof(double), typeof(IPaddingElement), default(double),
 									propertyChanged: OnPaddingRightChanged);
@@ -51,6 +55,7 @@ namespace Microsoft.Maui.Controls
 			bindable.SetValue(PaddingProperty, padding);
 		}
 
+		/// <summary>Bindable property for <see cref="PaddingBottom"/>.</summary>
 		public static readonly BindableProperty PaddingBottomProperty =
 			BindableProperty.Create("PaddingBottom", typeof(double), typeof(IPaddingElement), default(double),
 									propertyChanged: OnPaddingBottomChanged);

--- a/src/Controls/src/Core/Page.cs
+++ b/src/Controls/src/Core/Page.cs
@@ -30,19 +30,19 @@ namespace Microsoft.Maui.Controls
 
 		internal static readonly BindableProperty IgnoresContainerAreaProperty = BindableProperty.Create("IgnoresContainerArea", typeof(bool), typeof(Page), false);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Page.xml" path="//Member[@MemberName='BackgroundImageSourceProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="BackgroundImageSource"/>.</summary>
 		public static readonly BindableProperty BackgroundImageSourceProperty = BindableProperty.Create(nameof(BackgroundImageSource), typeof(ImageSource), typeof(Page), default(ImageSource));
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Page.xml" path="//Member[@MemberName='IsBusyProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="IsBusy"/>.</summary>
 		public static readonly BindableProperty IsBusyProperty = BindableProperty.Create("IsBusy", typeof(bool), typeof(Page), false, propertyChanged: (bo, o, n) => ((Page)bo).OnPageBusyChanged());
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Page.xml" path="//Member[@MemberName='PaddingProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Padding"/>.</summary>
 		public static readonly BindableProperty PaddingProperty = PaddingElement.PaddingProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Page.xml" path="//Member[@MemberName='TitleProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Title"/>.</summary>
 		public static readonly BindableProperty TitleProperty = BindableProperty.Create("Title", typeof(string), typeof(Page), null);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Page.xml" path="//Member[@MemberName='IconImageSourceProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="IconImageSource"/>.</summary>
 		public static readonly BindableProperty IconImageSourceProperty = BindableProperty.Create(nameof(IconImageSource), typeof(ImageSource), typeof(Page), default(ImageSource));
 
 		readonly Lazy<PlatformConfigurationRegistry<Page>> _platformConfigurationRegistry;

--- a/src/Controls/src/Core/PanGestureRecognizer.cs
+++ b/src/Controls/src/Core/PanGestureRecognizer.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Maui.Controls
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static AutoId CurrentId { get; } = new();
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/PanGestureRecognizer.xml" path="//Member[@MemberName='TouchPointsProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="TouchPoints"/>.</summary>
 		public static readonly BindableProperty TouchPointsProperty = BindableProperty.Create("TouchPoints", typeof(int), typeof(PanGestureRecognizer), 1);
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/PanGestureRecognizer.xml" path="//Member[@MemberName='TouchPoints']/Docs/*" />

--- a/src/Controls/src/Core/Picker.cs
+++ b/src/Controls/src/Core/Picker.cs
@@ -14,50 +14,51 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../docs/Microsoft.Maui.Controls/Picker.xml" path="Type[@FullName='Microsoft.Maui.Controls.Picker']/Docs/*" />
 	public partial class Picker : View, IFontElement, ITextElement, ITextAlignmentElement, IElementConfiguration<Picker>
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/Picker.xml" path="//Member[@MemberName='TextColorProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="TextColor"/>.</summary>
 		public static readonly BindableProperty TextColorProperty = TextElement.TextColorProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Picker.xml" path="//Member[@MemberName='CharacterSpacingProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="CharacterSpacing"/>.</summary>
 		public static readonly BindableProperty CharacterSpacingProperty = TextElement.CharacterSpacingProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Picker.xml" path="//Member[@MemberName='TitleProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Title"/>.</summary>
 		public static readonly BindableProperty TitleProperty =
 			BindableProperty.Create(nameof(Title), typeof(string), typeof(Picker), default(string));
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Picker.xml" path="//Member[@MemberName='TitleColorProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="TitleColor"/>.</summary>
 		public static readonly BindableProperty TitleColorProperty =
 			BindableProperty.Create(nameof(TitleColor), typeof(Color), typeof(Picker), default(Color));
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Picker.xml" path="//Member[@MemberName='SelectedIndexProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="SelectedIndex"/>.</summary>
 		public static readonly BindableProperty SelectedIndexProperty =
 			BindableProperty.Create(nameof(SelectedIndex), typeof(int), typeof(Picker), -1, BindingMode.TwoWay,
 									propertyChanged: OnSelectedIndexChanged, coerceValue: CoerceSelectedIndex);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Picker.xml" path="//Member[@MemberName='ItemsSourceProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="ItemsSource"/>.</summary>
 		public static readonly BindableProperty ItemsSourceProperty =
 			BindableProperty.Create(nameof(ItemsSource), typeof(IList), typeof(Picker), default(IList),
 									propertyChanged: OnItemsSourceChanged);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Picker.xml" path="//Member[@MemberName='SelectedItemProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="SelectedItem"/>.</summary>
 		public static readonly BindableProperty SelectedItemProperty =
 			BindableProperty.Create(nameof(SelectedItem), typeof(object), typeof(Picker), null, BindingMode.TwoWay,
 									propertyChanged: OnSelectedItemChanged);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Picker.xml" path="//Member[@MemberName='FontFamilyProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="FontFamily"/>.</summary>
 		public static readonly BindableProperty FontFamilyProperty = FontElement.FontFamilyProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Picker.xml" path="//Member[@MemberName='FontSizeProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="FontSize"/>.</summary>
 		public static readonly BindableProperty FontSizeProperty = FontElement.FontSizeProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Picker.xml" path="//Member[@MemberName='FontAttributesProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="FontAttributes"/>.</summary>
 		public static readonly BindableProperty FontAttributesProperty = FontElement.FontAttributesProperty;
 
+		/// <summary>Bindable property for <see cref="FontAutoScalingEnabled"/>.</summary>
 		public static readonly BindableProperty FontAutoScalingEnabledProperty = FontElement.FontAutoScalingEnabledProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Picker.xml" path="//Member[@MemberName='HorizontalTextAlignmentProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="HorizontalTextAlignment"/>.</summary>
 		public static readonly BindableProperty HorizontalTextAlignmentProperty = TextAlignmentElement.HorizontalTextAlignmentProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Picker.xml" path="//Member[@MemberName='VerticalTextAlignmentProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="VerticalTextAlignment"/>.</summary>
 		public static readonly BindableProperty VerticalTextAlignmentProperty = TextAlignmentElement.VerticalTextAlignmentProperty;
 
 		readonly Lazy<PlatformConfigurationRegistry<Picker>> _platformConfigurationRegistry;

--- a/src/Controls/src/Core/PlaceholderElement.cs
+++ b/src/Controls/src/Core/PlaceholderElement.cs
@@ -5,9 +5,11 @@ namespace Microsoft.Maui.Controls
 {
 	static class PlaceholderElement
 	{
+		/// <summary>Bindable property for <see cref="Placeholder"/>.</summary>
 		public static readonly BindableProperty PlaceholderProperty =
 			BindableProperty.Create(nameof(IPlaceholderElement.Placeholder), typeof(string), typeof(IPlaceholderElement), default(string));
 
+		/// <summary>Bindable property for <see cref="PlaceholderColor"/>.</summary>
 		public static readonly BindableProperty PlaceholderColorProperty =
 			BindableProperty.Create(nameof(IPlaceholderElement.PlaceholderColor), typeof(Color), typeof(IPlaceholderElement), default(Color));
 	}

--- a/src/Controls/src/Core/PlaceholderElement.cs
+++ b/src/Controls/src/Core/PlaceholderElement.cs
@@ -5,11 +5,11 @@ namespace Microsoft.Maui.Controls
 {
 	static class PlaceholderElement
 	{
-		/// <summary>Bindable property for <see cref="Placeholder"/>.</summary>
+		/// <summary>Bindable property for <see cref="IPlaceholderElement.Placeholder"/>.</summary>
 		public static readonly BindableProperty PlaceholderProperty =
 			BindableProperty.Create(nameof(IPlaceholderElement.Placeholder), typeof(string), typeof(IPlaceholderElement), default(string));
 
-		/// <summary>Bindable property for <see cref="PlaceholderColor"/>.</summary>
+		/// <summary>Bindable property for <see cref="IPlaceholderElement.PlaceholderColor"/>.</summary>
 		public static readonly BindableProperty PlaceholderColorProperty =
 			BindableProperty.Create(nameof(IPlaceholderElement.PlaceholderColor), typeof(Color), typeof(IPlaceholderElement), default(Color));
 	}

--- a/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/AppCompat/Application.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/AppCompat/Application.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompa
 	/// <include file="../../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompat/Application.xml" path="Type[@FullName='Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompat.Application']/Docs/*" />
 	public static class Application
 	{
-		/// <include file="../../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompat/Application.xml" path="//Member[@MemberName='SendDisappearingEventOnPauseProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="SendDisappearingEventOnPause"/>.</summary>
 		public static readonly BindableProperty SendDisappearingEventOnPauseProperty = BindableProperty.Create(nameof(SendDisappearingEventOnPause), typeof(bool), typeof(Application), true);
 
 		/// <include file="../../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompat/Application.xml" path="//Member[@MemberName='GetSendDisappearingEventOnPause'][1]/Docs/*" />
@@ -34,7 +34,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompa
 			return config;
 		}
 
-		/// <include file="../../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompat/Application.xml" path="//Member[@MemberName='SendAppearingEventOnResumeProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="SendAppearingEventOnResume"/>.</summary>
 		public static readonly BindableProperty SendAppearingEventOnResumeProperty = BindableProperty.Create(nameof(SendAppearingEventOnResume), typeof(bool), typeof(Application), true);
 
 		/// <include file="../../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompat/Application.xml" path="//Member[@MemberName='GetSendAppearingEventOnResume'][1]/Docs/*" />
@@ -62,7 +62,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompa
 			return config;
 		}
 
-		/// <include file="../../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompat/Application.xml" path="//Member[@MemberName='ShouldPreserveKeyboardOnResumeProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="ShouldPreserveKeyboardOnResume"/>.</summary>
 		public static readonly BindableProperty ShouldPreserveKeyboardOnResumeProperty = BindableProperty.Create(nameof(ShouldPreserveKeyboardOnResume), typeof(bool), typeof(Application), false);
 
 		/// <include file="../../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompat/Application.xml" path="//Member[@MemberName='GetShouldPreserveKeyboardOnResume'][1]/Docs/*" />

--- a/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/AppCompat/NavigationPage.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/AppCompat/NavigationPage.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompa
 	/// <include file="../../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompat/NavigationPage.xml" path="Type[@FullName='Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompat.NavigationPage']/Docs/*" />
 	public static class NavigationPage
 	{
-		/// <include file="../../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompat/NavigationPage.xml" path="//Member[@MemberName='BarHeightProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="BarHeight"/>.</summary>
 		public static readonly BindableProperty BarHeightProperty = BindableProperty.Create("BarHeight", typeof(int), typeof(NavigationPage), default(int));
 
 		/// <include file="../../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompat/NavigationPage.xml" path="//Member[@MemberName='GetBarHeight'][1]/Docs/*" />

--- a/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/AppCompat/NavigationPage.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/AppCompat/NavigationPage.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompa
 	/// <include file="../../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompat/NavigationPage.xml" path="Type[@FullName='Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompat.NavigationPage']/Docs/*" />
 	public static class NavigationPage
 	{
-		/// <summary>Bindable property for <see cref="BarHeight"/>.</summary>
+		/// <summary>Bindable property for attached property <c>BarHeight</c>.</summary>
 		public static readonly BindableProperty BarHeightProperty = BindableProperty.Create("BarHeight", typeof(int), typeof(NavigationPage), default(int));
 
 		/// <include file="../../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompat/NavigationPage.xml" path="//Member[@MemberName='GetBarHeight'][1]/Docs/*" />

--- a/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/Application.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/Application.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 	/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/Application.xml" path="Type[@FullName='Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.Application']/Docs/*" />
 	public static class Application
 	{
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/Application.xml" path="//Member[@MemberName='WindowSoftInputModeAdjustProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="WindowSoftInputModeAdjust"/>.</summary>
 		public static readonly BindableProperty WindowSoftInputModeAdjustProperty =
 			BindableProperty.Create("WindowSoftInputModeAdjust", typeof(WindowSoftInputModeAdjust),
 			typeof(Application), WindowSoftInputModeAdjust.Pan);

--- a/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/Button.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/Button.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 	public static class Button
 	{
 		#region UseDefaultPadding
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/Button.xml" path="//Member[@MemberName='UseDefaultPaddingProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="UseDefaultPadding"/>.</summary>
 		public static readonly BindableProperty UseDefaultPaddingProperty = BindableProperty.Create("UseDefaultPadding", typeof(bool), typeof(Button), false);
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/Button.xml" path="//Member[@MemberName='GetUseDefaultPadding']/Docs/*" />
@@ -37,7 +37,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 		#endregion
 
 		#region UseDefaultShadow
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/Button.xml" path="//Member[@MemberName='UseDefaultShadowProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="UseDefaultShadow"/>.</summary>
 		public static readonly BindableProperty UseDefaultShadowProperty = BindableProperty.Create("UseDefaultShadow", typeof(bool), typeof(Button), false);
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/Button.xml" path="//Member[@MemberName='GetUseDefaultShadow']/Docs/*" />

--- a/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/Entry.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/Entry.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 	/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/Entry.xml" path="Type[@FullName='Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.Entry']/Docs/*" />
 	public static class Entry
 	{
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/Entry.xml" path="//Member[@MemberName='ImeOptionsProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="ImeOptions"/>.</summary>
 		public static readonly BindableProperty ImeOptionsProperty = BindableProperty.Create(nameof(ImeOptions), typeof(ImeFlags), typeof(Entry), ImeFlags.Default);
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/Entry.xml" path="//Member[@MemberName='GetImeOptions']/Docs/*" />

--- a/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/ImageButton.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/ImageButton.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 	public static class ImageButton
 	{
 		#region Shadow
-		/// <summary>Bindable property for <see cref="IsShadowEnabled"/>.</summary>
+		/// <summary>Bindable property for attached property <c>IsShadowEnabled</c>.</summary>
 		public static readonly BindableProperty IsShadowEnabledProperty = BindableProperty.Create("IsShadowEnabled", typeof(bool), typeof(Maui.Controls.ImageButton), false);
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='GetIsShadowEnabled'][1]/Docs/*" />
@@ -36,7 +36,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			return config;
 		}
 
-		/// <summary>Bindable property for <see cref="ShadowColor"/>.</summary>
+		/// <summary>Bindable property for attached property <c>ShadowColor</c>.</summary>
 		public static readonly BindableProperty ShadowColorProperty = BindableProperty.Create("ShadowColor", typeof(Color), typeof(ImageButton), null);
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='GetShadowColor'][1]/Docs/*" />
@@ -64,7 +64,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			return config;
 		}
 
-		/// <summary>Bindable property for <see cref="ShadowRadius"/>.</summary>
+		/// <summary>Bindable property for attached property <c>ShadowRadius</c>.</summary>
 		public static readonly BindableProperty ShadowRadiusProperty = BindableProperty.Create("ShadowRadius", typeof(double), typeof(ImageButton), 10.0);
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='GetShadowRadius'][1]/Docs/*" />
@@ -92,7 +92,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			return config;
 		}
 
-		/// <summary>Bindable property for <see cref="ShadowOffset"/>.</summary>
+		/// <summary>Bindable property for attached property <c>ShadowOffset</c>.</summary>
 		public static readonly BindableProperty ShadowOffsetProperty = BindableProperty.Create("ShadowOffset", typeof(Size), typeof(VisualElement), Size.Zero);
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='GetShadowOffset'][1]/Docs/*" />

--- a/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/ImageButton.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/ImageButton.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 	public static class ImageButton
 	{
 		#region Shadow
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='IsShadowEnabledProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="IsShadowEnabled"/>.</summary>
 		public static readonly BindableProperty IsShadowEnabledProperty = BindableProperty.Create("IsShadowEnabled", typeof(bool), typeof(Maui.Controls.ImageButton), false);
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='GetIsShadowEnabled'][1]/Docs/*" />
@@ -36,7 +36,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			return config;
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='ShadowColorProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="ShadowColor"/>.</summary>
 		public static readonly BindableProperty ShadowColorProperty = BindableProperty.Create("ShadowColor", typeof(Color), typeof(ImageButton), null);
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='GetShadowColor'][1]/Docs/*" />
@@ -64,7 +64,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			return config;
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='ShadowRadiusProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="ShadowRadius"/>.</summary>
 		public static readonly BindableProperty ShadowRadiusProperty = BindableProperty.Create("ShadowRadius", typeof(double), typeof(ImageButton), 10.0);
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='GetShadowRadius'][1]/Docs/*" />
@@ -92,7 +92,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			return config;
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='ShadowOffsetProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="ShadowOffset"/>.</summary>
 		public static readonly BindableProperty ShadowOffsetProperty = BindableProperty.Create("ShadowOffset", typeof(Size), typeof(VisualElement), Size.Zero);
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='GetShadowOffset'][1]/Docs/*" />

--- a/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/ListView.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/ListView.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 	/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ListView.xml" path="Type[@FullName='Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.ListView']/Docs/*" />
 	public static class ListView
 	{
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ListView.xml" path="//Member[@MemberName='IsFastScrollEnabledProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="IsFastScrollEnabled"/>.</summary>
 		public static readonly BindableProperty IsFastScrollEnabledProperty = BindableProperty.Create("IsFastScrollEnabled", typeof(bool), typeof(ListView), false);
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ListView.xml" path="//Member[@MemberName='GetIsFastScrollEnabled']/Docs/*" />

--- a/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/SwipeView.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/SwipeView.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 	/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/SwipeView.xml" path="Type[@FullName='Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.SwipeView']/Docs/*" />
 	public static class SwipeView
 	{
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/SwipeView.xml" path="//Member[@MemberName='SwipeTransitionModeProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="SwipeTransitionMode"/>.</summary>
 		public static readonly BindableProperty SwipeTransitionModeProperty = BindableProperty.Create("SwipeTransitionMode", typeof(SwipeTransitionMode), typeof(SwipeView), SwipeTransitionMode.Reveal);
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/SwipeView.xml" path="//Member[@MemberName='GetSwipeTransitionMode'][1]/Docs/*" />

--- a/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/TabbedPage.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/TabbedPage.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 	/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/TabbedPage.xml" path="Type[@FullName='Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.TabbedPage']/Docs/*" />
 	public static class TabbedPage
 	{
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/TabbedPage.xml" path="//Member[@MemberName='IsSwipePagingEnabledProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="IsSwipePagingEnabled"/>.</summary>
 		public static readonly BindableProperty IsSwipePagingEnabledProperty =
 			BindableProperty.Create("IsSwipePagingEnabled", typeof(bool),
 			typeof(TabbedPage), true);
@@ -51,7 +51,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			return config;
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/TabbedPage.xml" path="//Member[@MemberName='IsSmoothScrollEnabledProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="IsSmoothScrollEnabled"/>.</summary>
 		public static readonly BindableProperty IsSmoothScrollEnabledProperty =
 			BindableProperty.Create("IsSmoothScrollEnabled", typeof(bool),
 			typeof(TabbedPage), true);
@@ -95,7 +95,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			return config;
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/TabbedPage.xml" path="//Member[@MemberName='OffscreenPageLimitProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="OffscreenPageLimit"/>.</summary>
 		public static readonly BindableProperty OffscreenPageLimitProperty =
 			BindableProperty.Create("OffscreenPageLimit", typeof(int),
 			typeof(TabbedPage), 3, validateValue: (binding, value) => (int)value >= 0);
@@ -125,7 +125,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			return config;
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/TabbedPage.xml" path="//Member[@MemberName='ToolbarPlacementProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="ToolbarPlacement"/>.</summary>
 		public static readonly BindableProperty ToolbarPlacementProperty =
 			BindableProperty.Create("ToolbarPlacement", typeof(ToolbarPlacement),
 			typeof(TabbedPage), ToolbarPlacement.Top);

--- a/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/ViewCell.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/ViewCell.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 	/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ViewCell.xml" path="Type[@FullName='Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.ViewCell']/Docs/*" />
 	public static class ViewCell
 	{
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ViewCell.xml" path="//Member[@MemberName='IsContextActionsLegacyModeEnabledProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="IsContextActionsLegacyModeEnabled"/>.</summary>
 		public static readonly BindableProperty IsContextActionsLegacyModeEnabledProperty = BindableProperty.Create("IsContextActionsLegacyModeEnabled", typeof(bool), typeof(Maui.Controls.ViewCell), false, propertyChanged: OnIsContextActionsLegacyModeEnabledPropertyChanged);
 
 		private static void OnIsContextActionsLegacyModeEnabledPropertyChanged(BindableObject element, object oldValue, object newValue)

--- a/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/ViewCell.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/ViewCell.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 	/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ViewCell.xml" path="Type[@FullName='Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.ViewCell']/Docs/*" />
 	public static class ViewCell
 	{
-		/// <summary>Bindable property for <see cref="IsContextActionsLegacyModeEnabled"/>.</summary>
+		/// <summary>Bindable property for attached property <c>IsContextActionsLegacyModeEnabled</c>.</summary>
 		public static readonly BindableProperty IsContextActionsLegacyModeEnabledProperty = BindableProperty.Create("IsContextActionsLegacyModeEnabled", typeof(bool), typeof(Maui.Controls.ViewCell), false, propertyChanged: OnIsContextActionsLegacyModeEnabledPropertyChanged);
 
 		private static void OnIsContextActionsLegacyModeEnabledPropertyChanged(BindableObject element, object oldValue, object newValue)

--- a/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/VisualElement.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/VisualElement.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 	{
 		#region Elevation
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/VisualElement.xml" path="//Member[@MemberName='ElevationProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Elevation"/>.</summary>
 		public static readonly BindableProperty ElevationProperty =
 			BindableProperty.Create("Elevation", typeof(float?),
 				typeof(FormsElement));
@@ -42,7 +42,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 
 		#region IsLegacyColorModeEnabled
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/VisualElement.xml" path="//Member[@MemberName='IsLegacyColorModeEnabledProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="IsLegacyColorModeEnabled"/>.</summary>
 		public static readonly BindableProperty IsLegacyColorModeEnabledProperty =
 			BindableProperty.CreateAttached("IsLegacyColorModeEnabled", typeof(bool),
 				typeof(FormsElement), true);

--- a/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/VisualElement.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/VisualElement.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 	{
 		#region Elevation
 
-		/// <summary>Bindable property for <see cref="Elevation"/>.</summary>
+		/// <summary>Bindable property for attached property <c>Elevation</c>.</summary>
 		public static readonly BindableProperty ElevationProperty =
 			BindableProperty.Create("Elevation", typeof(float?),
 				typeof(FormsElement));
@@ -42,7 +42,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 
 		#region IsLegacyColorModeEnabled
 
-		/// <summary>Bindable property for <see cref="IsLegacyColorModeEnabled"/>.</summary>
+		/// <summary>Bindable property for attached property <c>IsLegacyColorModeEnabled</c>.</summary>
 		public static readonly BindableProperty IsLegacyColorModeEnabledProperty =
 			BindableProperty.CreateAttached("IsLegacyColorModeEnabled", typeof(bool),
 				typeof(FormsElement), true);

--- a/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/WebView.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/WebView.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 	/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/WebView.xml" path="Type[@FullName='Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.WebView']/Docs/*" />
 	public static class WebView
 	{
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/WebView.xml" path="//Member[@MemberName='MixedContentModeProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="MixedContentMode"/>.</summary>
 		public static readonly BindableProperty MixedContentModeProperty = BindableProperty.Create("MixedContentMode", typeof(MixedContentHandling), typeof(WebView), MixedContentHandling.NeverAllow);
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/WebView.xml" path="//Member[@MemberName='GetMixedContentMode']/Docs/*" />
@@ -46,7 +46,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			return config;
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/WebView.xml" path="//Member[@MemberName='EnableZoomControlsProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="EnableZoomControls"/>.</summary>
 		public static readonly BindableProperty EnableZoomControlsProperty = BindableProperty.Create("EnableZoomControls", typeof(bool), typeof(FormsElement), false);
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/WebView.xml" path="//Member[@MemberName='GetEnableZoomControls']/Docs/*" />
@@ -79,7 +79,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			return config;
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/WebView.xml" path="//Member[@MemberName='DisplayZoomControlsProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="DisplayZoomControls"/>.</summary>
 		public static readonly BindableProperty DisplayZoomControlsProperty = BindableProperty.Create("DisplayZoomControls", typeof(bool), typeof(FormsElement), true);
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/WebView.xml" path="//Member[@MemberName='GetDisplayZoomControls']/Docs/*" />

--- a/src/Controls/src/Core/PlatformConfiguration/GTKSpecific/BoxView.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/GTKSpecific/BoxView.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific
 	/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific/BoxView.xml" path="Type[@FullName='Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific.BoxView']/Docs/*" />
 	public static class BoxView
 	{
-		/// <summary>Bindable property for <see cref="HasCornerRadius"/>.</summary>
+		/// <summary>Bindable property for attached property <c>HasCornerRadius</c>.</summary>
 		public static readonly BindableProperty HasCornerRadiusProperty =
 			BindableProperty.Create("HasCornerRadius", typeof(bool),
 				typeof(BoxView), default(bool));

--- a/src/Controls/src/Core/PlatformConfiguration/GTKSpecific/BoxView.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/GTKSpecific/BoxView.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific
 	/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific/BoxView.xml" path="Type[@FullName='Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific.BoxView']/Docs/*" />
 	public static class BoxView
 	{
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific/BoxView.xml" path="//Member[@MemberName='HasCornerRadiusProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="HasCornerRadius"/>.</summary>
 		public static readonly BindableProperty HasCornerRadiusProperty =
 			BindableProperty.Create("HasCornerRadius", typeof(bool),
 				typeof(BoxView), default(bool));

--- a/src/Controls/src/Core/PlatformConfiguration/GTKSpecific/NavigationPage.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/GTKSpecific/NavigationPage.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific
 	/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific/NavigationPage.xml" path="Type[@FullName='Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific.NavigationPage']/Docs/*" />
 	public static class NavigationPage
 	{
-		/// <summary>Bindable property for <see cref="BackButtonIcon"/>.</summary>
+		/// <summary>Bindable property for attached property <c>BackButtonIcon</c>.</summary>
 		public static readonly BindableProperty BackButtonIconProperty =
 			BindableProperty.Create("BackButtonIcon", typeof(string),
 				typeof(NavigationPage), default(string));

--- a/src/Controls/src/Core/PlatformConfiguration/GTKSpecific/NavigationPage.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/GTKSpecific/NavigationPage.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific
 	/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific/NavigationPage.xml" path="Type[@FullName='Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific.NavigationPage']/Docs/*" />
 	public static class NavigationPage
 	{
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific/NavigationPage.xml" path="//Member[@MemberName='BackButtonIconProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="BackButtonIcon"/>.</summary>
 		public static readonly BindableProperty BackButtonIconProperty =
 			BindableProperty.Create("BackButtonIcon", typeof(string),
 				typeof(NavigationPage), default(string));

--- a/src/Controls/src/Core/PlatformConfiguration/GTKSpecific/TabbedPage.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/GTKSpecific/TabbedPage.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific
 	/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific/TabbedPage.xml" path="Type[@FullName='Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific.TabbedPage']/Docs/*" />
 	public static class TabbedPage
 	{
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific/TabbedPage.xml" path="//Member[@MemberName='TabPositionProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="TabPosition"/>.</summary>
 		public static readonly BindableProperty TabPositionProperty =
 			BindableProperty.Create("TabPosition", typeof(TabPosition),
 				typeof(TabbedPage), TabPosition.Default);

--- a/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/Application.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/Application.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 	/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Application.xml" path="Type[@FullName='Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific.Application']/Docs/*" />
 	public static class Application
 	{
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Application.xml" path="//Member[@MemberName='UseBezelInteractionProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="UseBezelInteraction"/>.</summary>
 		public static readonly BindableProperty UseBezelInteractionProperty = BindableProperty.Create("UseBezelInteraction", typeof(bool), typeof(FormsElement), true);
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Application.xml" path="//Member[@MemberName='GetUseBezelInteraction'][1]/Docs/*" />
@@ -36,7 +36,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 			return config;
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Application.xml" path="//Member[@MemberName='OverlayContentProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="OverlayContent"/>.</summary>
 		public static readonly BindableProperty OverlayContentProperty = BindableProperty.CreateAttached("OverlayContent", typeof(View), typeof(FormsElement), default(View));
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Application.xml" path="//Member[@MemberName='GetOverlayContent'][1]/Docs/*" />

--- a/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/Application.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/Application.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 	/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Application.xml" path="Type[@FullName='Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific.Application']/Docs/*" />
 	public static class Application
 	{
-		/// <summary>Bindable property for <see cref="UseBezelInteraction"/>.</summary>
+		/// <summary>Bindable property for attached property <c>UseBezelInteraction</c>.</summary>
 		public static readonly BindableProperty UseBezelInteractionProperty = BindableProperty.Create("UseBezelInteraction", typeof(bool), typeof(FormsElement), true);
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Application.xml" path="//Member[@MemberName='GetUseBezelInteraction'][1]/Docs/*" />
@@ -36,7 +36,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 			return config;
 		}
 
-		/// <summary>Bindable property for <see cref="OverlayContent"/>.</summary>
+		/// <summary>Bindable property for attached property <c>OverlayContent</c>.</summary>
 		public static readonly BindableProperty OverlayContentProperty = BindableProperty.CreateAttached("OverlayContent", typeof(View), typeof(FormsElement), default(View));
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Application.xml" path="//Member[@MemberName='GetOverlayContent'][1]/Docs/*" />

--- a/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/Entry.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/Entry.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 	/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Entry.xml" path="Type[@FullName='Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific.Entry']/Docs/*" />
 	public static class Entry
 	{
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Entry.xml" path="//Member[@MemberName='FontWeightProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="FontWeight"/>.</summary>
 		public static readonly BindableProperty FontWeightProperty = BindableProperty.Create("FontWeight", typeof(string), typeof(FormsElement), FontWeight.None);
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Entry.xml" path="//Member[@MemberName='GetFontWeight'][1]/Docs/*" />

--- a/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/Image.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/Image.cs
@@ -7,10 +7,10 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 	/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Image.xml" path="Type[@FullName='Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific.Image']/Docs/*" />
 	public static class Image
 	{
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Image.xml" path="//Member[@MemberName='BlendColorProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="BlendColor"/>.</summary>
 		public static readonly BindableProperty BlendColorProperty = BindableProperty.Create("BlendColor", typeof(Color), typeof(FormsElement), null);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Image.xml" path="//Member[@MemberName='FileProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="File"/>.</summary>
 		public static readonly BindableProperty FileProperty = BindableProperty.Create("File", typeof(string), typeof(FormsElement), default(string));
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Image.xml" path="//Member[@MemberName='GetBlendColor'][1]/Docs/*" />

--- a/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/Image.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/Image.cs
@@ -7,10 +7,10 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 	/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Image.xml" path="Type[@FullName='Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific.Image']/Docs/*" />
 	public static class Image
 	{
-		/// <summary>Bindable property for <see cref="BlendColor"/>.</summary>
+		/// <summary>Bindable property for attached property <c>BlendColor</c>.</summary>
 		public static readonly BindableProperty BlendColorProperty = BindableProperty.Create("BlendColor", typeof(Color), typeof(FormsElement), null);
 
-		/// <summary>Bindable property for <see cref="File"/>.</summary>
+		/// <summary>Bindable property for attached property <c>File</c>.</summary>
 		public static readonly BindableProperty FileProperty = BindableProperty.Create("File", typeof(string), typeof(FormsElement), default(string));
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Image.xml" path="//Member[@MemberName='GetBlendColor'][1]/Docs/*" />

--- a/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/ItemsView.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/ItemsView.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 
 	public static class ItemsView
 	{
-		/// <summary>Bindable property for <see cref="FocusedItemScrollPosition"/>.</summary>
+		/// <summary>Bindable property for attached property <c>FocusedItemScrollPosition</c>.</summary>
 		public static readonly BindableProperty FocusedItemScrollPositionProperty = BindableProperty.Create("FocusedItemScrollPosition", typeof(ScrollToPosition), typeof(FormsElement), ScrollToPosition.MakeVisible);
 
 

--- a/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/ItemsView.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/ItemsView.cs
@@ -5,6 +5,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 
 	public static class ItemsView
 	{
+		/// <summary>Bindable property for <see cref="FocusedItemScrollPosition"/>.</summary>
 		public static readonly BindableProperty FocusedItemScrollPositionProperty = BindableProperty.Create("FocusedItemScrollPosition", typeof(ScrollToPosition), typeof(FormsElement), ScrollToPosition.MakeVisible);
 
 

--- a/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/Label.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/Label.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 	/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Label.xml" path="Type[@FullName='Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific.Label']/Docs/*" />
 	public static class Label
 	{
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Label.xml" path="//Member[@MemberName='FontWeightProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="FontWeight"/>.</summary>
 		public static readonly BindableProperty FontWeightProperty = BindableProperty.Create("FontWeight", typeof(string), typeof(FormsElement), FontWeight.None);
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Label.xml" path="//Member[@MemberName='GetFontWeight'][1]/Docs/*" />

--- a/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/NavigationPage.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/NavigationPage.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 	public static class NavigationPage
 	{
 		#region HasBreadCrumbsBar
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/NavigationPage.xml" path="//Member[@MemberName='HasBreadCrumbsBarProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="HasBreadCrumbsBar"/>.</summary>
 		public static readonly BindableProperty HasBreadCrumbsBarProperty
 			= BindableProperty.CreateAttached("HasBreadCrumbsBar", typeof(bool), typeof(FormsElement), false);
 

--- a/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/NavigationPage.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/NavigationPage.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 	public static class NavigationPage
 	{
 		#region HasBreadCrumbsBar
-		/// <summary>Bindable property for <see cref="HasBreadCrumbsBar"/>.</summary>
+		/// <summary>Bindable property for attached property <c>HasBreadCrumbsBar</c>.</summary>
 		public static readonly BindableProperty HasBreadCrumbsBarProperty
 			= BindableProperty.CreateAttached("HasBreadCrumbsBar", typeof(bool), typeof(FormsElement), false);
 

--- a/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/Page.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/Page.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 	public static class Page
 	{
 		#region BreadCrumbName
-		/// <summary>Bindable property for <see cref="BreadCrumb"/>.</summary>
+		/// <summary>Bindable property for attached property <c>BreadCrumb</c>.</summary>
 		public static readonly BindableProperty BreadCrumbProperty
 			= BindableProperty.CreateAttached("BreadCrumb", typeof(string), typeof(FormsElement), default(string));
 

--- a/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/Page.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/Page.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 	public static class Page
 	{
 		#region BreadCrumbName
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Page.xml" path="//Member[@MemberName='BreadCrumbProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="BreadCrumb"/>.</summary>
 		public static readonly BindableProperty BreadCrumbProperty
 			= BindableProperty.CreateAttached("BreadCrumb", typeof(string), typeof(FormsElement), default(string));
 

--- a/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/ProgressBar.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/ProgressBar.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 	/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/ProgressBar.xml" path="Type[@FullName='Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific.ProgressBar']/Docs/*" />
 	public static class ProgressBar
 	{
-		/// <summary>Bindable property for <see cref="ProgressBarPulsingStatus"/>.</summary>
+		/// <summary>Bindable property for attached property <c>ProgressBarPulsingStatus</c>.</summary>
 		public static readonly BindableProperty ProgressBarPulsingStatusProperty =
 			BindableProperty.Create("ProgressBarPulsingStatus", typeof(bool),
 			typeof(FormsElement), false);

--- a/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/ProgressBar.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/ProgressBar.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 	/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/ProgressBar.xml" path="Type[@FullName='Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific.ProgressBar']/Docs/*" />
 	public static class ProgressBar
 	{
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/ProgressBar.xml" path="//Member[@MemberName='ProgressBarPulsingStatusProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="ProgressBarPulsingStatus"/>.</summary>
 		public static readonly BindableProperty ProgressBarPulsingStatusProperty =
 			BindableProperty.Create("ProgressBarPulsingStatus", typeof(bool),
 			typeof(FormsElement), false);

--- a/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/ScrollView.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/ScrollView.cs
@@ -5,14 +5,14 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 
 	public static class ScrollView
 	{
-		/// <summary>Bindable property for <see cref="VerticalScrollStep"/>.</summary>
+		/// <summary>Bindable property for attached property <c>VerticalScrollStep</c>.</summary>
 		public static readonly BindableProperty VerticalScrollStepProperty = BindableProperty.Create("VerticalScrollStep", typeof(int), typeof(FormsElement), -1,
 			coerceValue: (bindable, value) =>
 			{
 				return ((int)value < 0) ? -1 : value;
 			});
 
-		/// <summary>Bindable property for <see cref="HorizontalScrollStep"/>.</summary>
+		/// <summary>Bindable property for attached property <c>HorizontalScrollStep</c>.</summary>
 		public static readonly BindableProperty HorizontalScrollStepProperty = BindableProperty.Create("HorizontalScrollStep", typeof(int), typeof(FormsElement), -1,
 			coerceValue: (bindable, value) =>
 			{

--- a/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/ScrollView.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/ScrollView.cs
@@ -5,12 +5,14 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 
 	public static class ScrollView
 	{
+		/// <summary>Bindable property for <see cref="VerticalScrollStep"/>.</summary>
 		public static readonly BindableProperty VerticalScrollStepProperty = BindableProperty.Create("VerticalScrollStep", typeof(int), typeof(FormsElement), -1,
 			coerceValue: (bindable, value) =>
 			{
 				return ((int)value < 0) ? -1 : value;
 			});
 
+		/// <summary>Bindable property for <see cref="HorizontalScrollStep"/>.</summary>
 		public static readonly BindableProperty HorizontalScrollStepProperty = BindableProperty.Create("HorizontalScrollStep", typeof(int), typeof(FormsElement), -1,
 			coerceValue: (bindable, value) =>
 			{

--- a/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/Switch.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/Switch.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 	/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Switch.xml" path="Type[@FullName='Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific.Switch']/Docs/*" />
 	public static class Switch
 	{
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Switch.xml" path="//Member[@MemberName='ColorProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Color"/>.</summary>
 		public static readonly BindableProperty ColorProperty = BindableProperty.Create(nameof(Color), typeof(Color), typeof(FormsElement), null);
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Switch.xml" path="//Member[@MemberName='GetColor'][1]/Docs/*" />

--- a/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/VisualElement.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/VisualElement.cs
@@ -13,9 +13,8 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 		/// <summary>Bindable property for attached property <c>IsFocusAllowed</c>.</summary>
 		public static readonly BindableProperty IsFocusAllowedProperty = BindableProperty.Create("IsFocusAllowed", typeof(bool?), typeof(VisualElement), null);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='NextFocusDirectionProperty']/Docs/*" />
+		/// <summary>Bindable property for attached property <c>NextFocusDirection</c>.</summary>
 		[EditorBrowsable(EditorBrowsableState.Never)]
-		/// <summary>Bindable property for <see cref="NextFocusDirection"/>.</summary>
 		public static readonly BindableProperty NextFocusDirectionProperty = BindableProperty.Create("NextFocusDirection", typeof(string), typeof(VisualElement), FocusDirection.None, propertyChanged: OnNextFocusDirectionPropertyChanged);
 
 		/// <summary>Bindable property for attached property <c>NextFocusUpView</c>.</summary>

--- a/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/VisualElement.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/VisualElement.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 		/// <summary>Bindable property for <see cref="Style"/>.</summary>
 		public static readonly BindableProperty StyleProperty = BindableProperty.Create("ThemeStyle", typeof(string), typeof(VisualElement), default(string));
 
-		/// <summary>Bindable property for <see cref="IsFocusAllowed"/>.</summary>
+		/// <summary>Bindable property for attached property <c>IsFocusAllowed</c>.</summary>
 		public static readonly BindableProperty IsFocusAllowedProperty = BindableProperty.Create("IsFocusAllowed", typeof(bool?), typeof(VisualElement), null);
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='NextFocusDirectionProperty']/Docs/*" />
@@ -18,22 +18,22 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 		/// <summary>Bindable property for <see cref="NextFocusDirection"/>.</summary>
 		public static readonly BindableProperty NextFocusDirectionProperty = BindableProperty.Create("NextFocusDirection", typeof(string), typeof(VisualElement), FocusDirection.None, propertyChanged: OnNextFocusDirectionPropertyChanged);
 
-		/// <summary>Bindable property for <see cref="NextFocusUpView"/>.</summary>
+		/// <summary>Bindable property for attached property <c>NextFocusUpView</c>.</summary>
 		public static readonly BindableProperty NextFocusUpViewProperty = BindableProperty.Create("NextFocusUpView", typeof(View), typeof(VisualElement), default(View));
 
-		/// <summary>Bindable property for <see cref="NextFocusDownView"/>.</summary>
+		/// <summary>Bindable property for attached property <c>NextFocusDownView</c>.</summary>
 		public static readonly BindableProperty NextFocusDownViewProperty = BindableProperty.Create("NextFocusDownView", typeof(View), typeof(VisualElement), default(View));
 
-		/// <summary>Bindable property for <see cref="NextFocusLeftView"/>.</summary>
+		/// <summary>Bindable property for attached property <c>NextFocusLeftView</c>.</summary>
 		public static readonly BindableProperty NextFocusLeftViewProperty = BindableProperty.Create("NextFocusLeftView", typeof(View), typeof(VisualElement), default(View));
 
-		/// <summary>Bindable property for <see cref="NextFocusRightView"/>.</summary>
+		/// <summary>Bindable property for attached property <c>NextFocusRightView</c>.</summary>
 		public static readonly BindableProperty NextFocusRightViewProperty = BindableProperty.Create("NextFocusRightView", typeof(View), typeof(VisualElement), default(View));
 
-		/// <summary>Bindable property for <see cref="NextFocusBackView"/>.</summary>
+		/// <summary>Bindable property for attached property <c>NextFocusBackView</c>.</summary>
 		public static readonly BindableProperty NextFocusBackViewProperty = BindableProperty.Create("NextFocusBackView", typeof(View), typeof(VisualElement), default(View));
 
-		/// <summary>Bindable property for <see cref="NextFocusForwardView"/>.</summary>
+		/// <summary>Bindable property for attached property <c>NextFocusForwardView</c>.</summary>
 		public static readonly BindableProperty NextFocusForwardViewProperty = BindableProperty.Create("NextFocusForwardView", typeof(View), typeof(VisualElement), default(View));
 
 		/// <summary>Bindable property for <see cref="ToolTip"/>.</summary>

--- a/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/VisualElement.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/VisualElement.cs
@@ -7,35 +7,36 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 	/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="Type[@FullName='Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific.VisualElement']/Docs/*" />
 	public static class VisualElement
 	{
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='StyleProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Style"/>.</summary>
 		public static readonly BindableProperty StyleProperty = BindableProperty.Create("ThemeStyle", typeof(string), typeof(VisualElement), default(string));
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='IsFocusAllowedProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="IsFocusAllowed"/>.</summary>
 		public static readonly BindableProperty IsFocusAllowedProperty = BindableProperty.Create("IsFocusAllowed", typeof(bool?), typeof(VisualElement), null);
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='NextFocusDirectionProperty']/Docs/*" />
 		[EditorBrowsable(EditorBrowsableState.Never)]
+		/// <summary>Bindable property for <see cref="NextFocusDirection"/>.</summary>
 		public static readonly BindableProperty NextFocusDirectionProperty = BindableProperty.Create("NextFocusDirection", typeof(string), typeof(VisualElement), FocusDirection.None, propertyChanged: OnNextFocusDirectionPropertyChanged);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='NextFocusUpViewProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="NextFocusUpView"/>.</summary>
 		public static readonly BindableProperty NextFocusUpViewProperty = BindableProperty.Create("NextFocusUpView", typeof(View), typeof(VisualElement), default(View));
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='NextFocusDownViewProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="NextFocusDownView"/>.</summary>
 		public static readonly BindableProperty NextFocusDownViewProperty = BindableProperty.Create("NextFocusDownView", typeof(View), typeof(VisualElement), default(View));
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='NextFocusLeftViewProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="NextFocusLeftView"/>.</summary>
 		public static readonly BindableProperty NextFocusLeftViewProperty = BindableProperty.Create("NextFocusLeftView", typeof(View), typeof(VisualElement), default(View));
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='NextFocusRightViewProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="NextFocusRightView"/>.</summary>
 		public static readonly BindableProperty NextFocusRightViewProperty = BindableProperty.Create("NextFocusRightView", typeof(View), typeof(VisualElement), default(View));
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='NextFocusBackViewProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="NextFocusBackView"/>.</summary>
 		public static readonly BindableProperty NextFocusBackViewProperty = BindableProperty.Create("NextFocusBackView", typeof(View), typeof(VisualElement), default(View));
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='NextFocusForwardViewProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="NextFocusForwardView"/>.</summary>
 		public static readonly BindableProperty NextFocusForwardViewProperty = BindableProperty.Create("NextFocusForwardView", typeof(View), typeof(VisualElement), default(View));
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='ToolTipProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="ToolTip"/>.</summary>
 		public static readonly BindableProperty ToolTipProperty = BindableProperty.Create("ToolTip", typeof(string), typeof(VisualElement), default(string));
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetStyle'][1]/Docs/*" />

--- a/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/Application.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/Application.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 	/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Application.xml" path="Type[@FullName='Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific.Application']/Docs/*" />
 	public static class Application
 	{
-		/// <summary>Bindable property for <see cref="ImageDirectory"/>.</summary>
+		/// <summary>Bindable property for attached property <c>ImageDirectory</c>.</summary>
 		public static readonly BindableProperty ImageDirectoryProperty =
 			BindableProperty.Create("ImageDirectory", typeof(string), typeof(FormsElement), string.Empty,
 				propertyChanged: OnImageDirectoryChanged);

--- a/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/Application.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/Application.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 	/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Application.xml" path="Type[@FullName='Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific.Application']/Docs/*" />
 	public static class Application
 	{
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Application.xml" path="//Member[@MemberName='ImageDirectoryProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="ImageDirectory"/>.</summary>
 		public static readonly BindableProperty ImageDirectoryProperty =
 			BindableProperty.Create("ImageDirectory", typeof(string), typeof(FormsElement), string.Empty,
 				propertyChanged: OnImageDirectoryChanged);

--- a/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/FlyoutPage.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/FlyoutPage.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 
 		#region CollapsedPaneWidth
 
-		/// <summary>Bindable property for <see cref="CollapsedPaneWidth"/>.</summary>
+		/// <summary>Bindable property for attached property <c>CollapsedPaneWidth</c>.</summary>
 		public static readonly BindableProperty CollapsedPaneWidthProperty =
 			BindableProperty.CreateAttached("CollapsedPaneWidth", typeof(double),
 				typeof(FlyoutPage), 48d, validateValue: (bindable, value) => (double)value >= 0);

--- a/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/FlyoutPage.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/FlyoutPage.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 	{
 		#region CollapsedStyle
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/FlyoutPage.xml" path="//Member[@MemberName='CollapseStyleProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="CollapseStyle"/>.</summary>
 		public static readonly BindableProperty CollapseStyleProperty =
 			BindableProperty.CreateAttached("CollapseStyle", typeof(CollapseStyle),
 				typeof(FlyoutPage), CollapseStyle.Full);
@@ -53,7 +53,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 
 		#region CollapsedPaneWidth
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/FlyoutPage.xml" path="//Member[@MemberName='CollapsedPaneWidthProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="CollapsedPaneWidth"/>.</summary>
 		public static readonly BindableProperty CollapsedPaneWidthProperty =
 			BindableProperty.CreateAttached("CollapsedPaneWidth", typeof(double),
 				typeof(FlyoutPage), 48d, validateValue: (bindable, value) => (double)value >= 0);

--- a/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/InputView.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/InputView.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 	/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/InputView.xml" path="Type[@FullName='Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific.InputView']/Docs/*" />
 	public static class InputView
 	{
-		/// <summary>Bindable property for <see cref="DetectReadingOrderFromContent"/>.</summary>
+		/// <summary>Bindable property for attached property <c>DetectReadingOrderFromContent</c>.</summary>
 		public static readonly BindableProperty DetectReadingOrderFromContentProperty = BindableProperty.Create("DetectReadingOrderFromContent", typeof(bool), typeof(FormsElement), false);
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/InputView.xml" path="//Member[@MemberName='SetDetectReadingOrderFromContent'][1]/Docs/*" />

--- a/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/InputView.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/InputView.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 	/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/InputView.xml" path="Type[@FullName='Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific.InputView']/Docs/*" />
 	public static class InputView
 	{
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/InputView.xml" path="//Member[@MemberName='DetectReadingOrderFromContentProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="DetectReadingOrderFromContent"/>.</summary>
 		public static readonly BindableProperty DetectReadingOrderFromContentProperty = BindableProperty.Create("DetectReadingOrderFromContent", typeof(bool), typeof(FormsElement), false);
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/InputView.xml" path="//Member[@MemberName='SetDetectReadingOrderFromContent'][1]/Docs/*" />

--- a/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/Label.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/Label.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 	/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Label.xml" path="Type[@FullName='Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific.Label']/Docs/*" />
 	public static class Label
 	{
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Label.xml" path="//Member[@MemberName='DetectReadingOrderFromContentProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="DetectReadingOrderFromContent"/>.</summary>
 		public static readonly BindableProperty DetectReadingOrderFromContentProperty = BindableProperty.Create("DetectReadingOrderFromContent", typeof(bool), typeof(FormsElement), false);
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Label.xml" path="//Member[@MemberName='SetDetectReadingOrderFromContent'][1]/Docs/*" />

--- a/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/Label.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/Label.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 	/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Label.xml" path="Type[@FullName='Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific.Label']/Docs/*" />
 	public static class Label
 	{
-		/// <summary>Bindable property for <see cref="DetectReadingOrderFromContent"/>.</summary>
+		/// <summary>Bindable property for attached property <c>DetectReadingOrderFromContent</c>.</summary>
 		public static readonly BindableProperty DetectReadingOrderFromContentProperty = BindableProperty.Create("DetectReadingOrderFromContent", typeof(bool), typeof(FormsElement), false);
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Label.xml" path="//Member[@MemberName='SetDetectReadingOrderFromContent'][1]/Docs/*" />

--- a/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/ListView.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/ListView.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 	{
 		#region SelectionMode
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/ListView.xml" path="//Member[@MemberName='SelectionModeProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="SelectionMode"/>.</summary>
 		public static readonly BindableProperty SelectionModeProperty =
 			BindableProperty.CreateAttached("WindowsSelectionMode", typeof(ListViewSelectionMode),
 				typeof(ListView), ListViewSelectionMode.Accessible);

--- a/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/Page.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/Page.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 	{
 		#region ToolbarPlacement
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Page.xml" path="//Member[@MemberName='ToolbarPlacementProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="ToolbarPlacement"/>.</summary>
 		public static readonly BindableProperty ToolbarPlacementProperty =
 			BindableProperty.CreateAttached("ToolbarPlacement", typeof(ToolbarPlacement),
 				typeof(FormsElement), ToolbarPlacement.Default);
@@ -49,7 +49,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 
 		#region ToolbarDynamicOverflowEnabled
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Page.xml" path="//Member[@MemberName='ToolbarDynamicOverflowEnabledProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="ToolbarDynamicOverflowEnabled"/>.</summary>
 		public static readonly BindableProperty ToolbarDynamicOverflowEnabledProperty =
 			BindableProperty.CreateAttached("ToolbarDynamicOverflowEnabled", typeof(bool),
 				typeof(FormsElement), true);

--- a/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/Page.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/Page.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 
 		#region ToolbarDynamicOverflowEnabled
 
-		/// <summary>Bindable property for <see cref="ToolbarDynamicOverflowEnabled"/>.</summary>
+		/// <summary>Bindable property for attached property <c>ToolbarDynamicOverflowEnabled</c>.</summary>
 		public static readonly BindableProperty ToolbarDynamicOverflowEnabledProperty =
 			BindableProperty.CreateAttached("ToolbarDynamicOverflowEnabled", typeof(bool),
 				typeof(FormsElement), true);

--- a/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/RefreshView.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/RefreshView.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 			BottomToTop
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/RefreshView.xml" path="//Member[@MemberName='RefreshPullDirectionProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="RefreshPullDirection"/>.</summary>
 		public static readonly BindableProperty RefreshPullDirectionProperty = BindableProperty.Create("RefreshPullDirection", typeof(RefreshPullDirection), typeof(FormsElement), RefreshPullDirection.TopToBottom);
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/RefreshView.xml" path="//Member[@MemberName='SetRefreshPullDirection'][1]/Docs/*" />

--- a/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/SearchBar.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/SearchBar.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 	/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/SearchBar.xml" path="Type[@FullName='Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific.SearchBar']/Docs/*" />
 	public static class SearchBar
 	{
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/SearchBar.xml" path="//Member[@MemberName='IsSpellCheckEnabledProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="IsSpellCheckEnabled"/>.</summary>
 		public static readonly BindableProperty IsSpellCheckEnabledProperty =
 			BindableProperty.Create("IsSpellCheckEnabled ", typeof(bool), typeof(SearchBar), false);
 

--- a/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/TabbedPage.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/TabbedPage.cs
@@ -11,11 +11,11 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 	/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/TabbedPage.xml" path="Type[@FullName='Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific.TabbedPage']/Docs/*" />
 	public static class TabbedPage
 	{
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/TabbedPage.xml" path="//Member[@MemberName='HeaderIconsEnabledProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="HeaderIconsEnabled"/>.</summary>
 		public static readonly BindableProperty HeaderIconsEnabledProperty =
 			BindableProperty.Create(nameof(HeaderIconsEnabledProperty), typeof(bool), typeof(TabbedPage), true);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/TabbedPage.xml" path="//Member[@MemberName='HeaderIconsSizeProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="HeaderIconsSize"/>.</summary>
 		public static readonly BindableProperty HeaderIconsSizeProperty =
 			BindableProperty.Create(nameof(HeaderIconsSizeProperty), typeof(Size), typeof(TabbedPage), new Size(16, 16));
 

--- a/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/TabbedPage.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/TabbedPage.cs
@@ -11,11 +11,11 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 	/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/TabbedPage.xml" path="Type[@FullName='Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific.TabbedPage']/Docs/*" />
 	public static class TabbedPage
 	{
-		/// <summary>Bindable property for <see cref="HeaderIconsEnabled"/>.</summary>
+		/// <summary>Bindable property for attached property <c>HeaderIconsEnabled</c>.</summary>
 		public static readonly BindableProperty HeaderIconsEnabledProperty =
 			BindableProperty.Create(nameof(HeaderIconsEnabledProperty), typeof(bool), typeof(TabbedPage), true);
 
-		/// <summary>Bindable property for <see cref="HeaderIconsSize"/>.</summary>
+		/// <summary>Bindable property for attached property <c>HeaderIconsSize</c>.</summary>
 		public static readonly BindableProperty HeaderIconsSizeProperty =
 			BindableProperty.Create(nameof(HeaderIconsSizeProperty), typeof(Size), typeof(TabbedPage), new Size(16, 16));
 

--- a/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/VisualElement.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/VisualElement.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 	/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="Type[@FullName='Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific.VisualElement']/Docs/*" />
 	public static class VisualElement
 	{
-		/// <summary>Bindable property for <see cref="AccessKey"/>.</summary>
+		/// <summary>Bindable property for attached property <c>AccessKey</c>.</summary>
 		public static readonly BindableProperty AccessKeyProperty =
 			BindableProperty.Create("AccessKey", typeof(string), typeof(VisualElement));
 
@@ -14,11 +14,11 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 		public static readonly BindableProperty AccessKeyPlacementProperty =
 					BindableProperty.Create(nameof(AccessKeyPlacement), typeof(AccessKeyPlacement), typeof(VisualElement), AccessKeyPlacement.Auto);
 
-		/// <summary>Bindable property for <see cref="AccessKeyHorizontalOffset"/>.</summary>
+		/// <summary>Bindable property for attached property <c>AccessKeyHorizontalOffset</c>.</summary>
 		public static readonly BindableProperty AccessKeyHorizontalOffsetProperty =
 					BindableProperty.Create("AccessKeyHorizontalOffset", typeof(double), typeof(FormsElement), 0.0);
 
-		/// <summary>Bindable property for <see cref="AccessKeyVerticalOffset"/>.</summary>
+		/// <summary>Bindable property for attached property <c>AccessKeyVerticalOffset</c>.</summary>
 		public static readonly BindableProperty AccessKeyVerticalOffsetProperty =
 					BindableProperty.Create("AccessKeyVerticalOffset", typeof(double), typeof(FormsElement), 0.0);
 
@@ -117,7 +117,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 		}
 		#region IsLegacyColorModeEnabled
 
-		/// <summary>Bindable property for <see cref="IsLegacyColorModeEnabled"/>.</summary>
+		/// <summary>Bindable property for attached property <c>IsLegacyColorModeEnabled</c>.</summary>
 		public static readonly BindableProperty IsLegacyColorModeEnabledProperty =
 			BindableProperty.CreateAttached("IsLegacyColorModeEnabled", typeof(bool),
 				typeof(FormsElement), true);

--- a/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/VisualElement.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/VisualElement.cs
@@ -6,19 +6,19 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 	/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="Type[@FullName='Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific.VisualElement']/Docs/*" />
 	public static class VisualElement
 	{
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='AccessKeyProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="AccessKey"/>.</summary>
 		public static readonly BindableProperty AccessKeyProperty =
 			BindableProperty.Create("AccessKey", typeof(string), typeof(VisualElement));
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='AccessKeyPlacementProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="AccessKeyPlacement"/>.</summary>
 		public static readonly BindableProperty AccessKeyPlacementProperty =
 					BindableProperty.Create(nameof(AccessKeyPlacement), typeof(AccessKeyPlacement), typeof(VisualElement), AccessKeyPlacement.Auto);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='AccessKeyHorizontalOffsetProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="AccessKeyHorizontalOffset"/>.</summary>
 		public static readonly BindableProperty AccessKeyHorizontalOffsetProperty =
 					BindableProperty.Create("AccessKeyHorizontalOffset", typeof(double), typeof(FormsElement), 0.0);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='AccessKeyVerticalOffsetProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="AccessKeyVerticalOffset"/>.</summary>
 		public static readonly BindableProperty AccessKeyVerticalOffsetProperty =
 					BindableProperty.Create("AccessKeyVerticalOffset", typeof(double), typeof(FormsElement), 0.0);
 
@@ -117,7 +117,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 		}
 		#region IsLegacyColorModeEnabled
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='IsLegacyColorModeEnabledProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="IsLegacyColorModeEnabled"/>.</summary>
 		public static readonly BindableProperty IsLegacyColorModeEnabledProperty =
 			BindableProperty.CreateAttached("IsLegacyColorModeEnabled", typeof(bool),
 				typeof(FormsElement), true);

--- a/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/WebView.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/WebView.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 	/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/WebView.xml" path="Type[@FullName='Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific.WebView']/Docs/*" />
 	public static class WebView
 	{
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/WebView.xml" path="//Member[@MemberName='IsJavaScriptAlertEnabledProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="IsJavaScriptAlertEnabled"/>.</summary>
 		public static readonly BindableProperty IsJavaScriptAlertEnabledProperty = BindableProperty.Create("IsJavaScriptAlertEnabled", typeof(bool), typeof(WebView), false);
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/WebView.xml" path="//Member[@MemberName='GetIsJavaScriptAlertEnabled']/Docs/*" />
@@ -35,6 +35,9 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 			return config;
 		}
 
+
+
+		/// <summary>Bindable property for <see cref="ExecutionMode"/>.</summary>
 
 
 		public static readonly BindableProperty ExecutionModeProperty = BindableProperty.Create("ExecutionMode", typeof(WebViewExecutionMode), typeof(WebView), WebViewExecutionMode.SameThread);

--- a/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/WebView.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/WebView.cs
@@ -35,11 +35,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 			return config;
 		}
 
-
-
-		/// <summary>Bindable property for <see cref="ExecutionMode"/>.</summary>
-
-
+		/// <summary>Bindable property for attached property <c>ExecutionMode</c>.</summary>
 		public static readonly BindableProperty ExecutionModeProperty = BindableProperty.Create("ExecutionMode", typeof(WebViewExecutionMode), typeof(WebView), WebViewExecutionMode.SameThread);
 
 		public static WebViewExecutionMode GetExecutionMode(BindableObject element)

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/Application.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/Application.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 	public static class Application
 	{
 		#region PanGestureRecognizerShouldRecognizeSimultaneously
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Application.xml" path="//Member[@MemberName='PanGestureRecognizerShouldRecognizeSimultaneouslyProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="PanGestureRecognizerShouldRecognizeSimultaneously"/>.</summary>
 		public static readonly BindableProperty PanGestureRecognizerShouldRecognizeSimultaneouslyProperty = BindableProperty.Create("PanGestureRecognizerShouldRecognizeSimultaneously", typeof(bool), typeof(Application), false);
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Application.xml" path="//Member[@MemberName='GetPanGestureRecognizerShouldRecognizeSimultaneously'][1]/Docs/*" />
@@ -37,7 +37,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 		#endregion
 
 		#region HandleControlUpdatesOnMainThread
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Application.xml" path="//Member[@MemberName='HandleControlUpdatesOnMainThreadProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="HandleControlUpdatesOnMainThread"/>.</summary>
 		public static readonly BindableProperty HandleControlUpdatesOnMainThreadProperty = BindableProperty.Create("HandleControlUpdatesOnMainThread", typeof(bool), typeof(Application), false);
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Application.xml" path="//Member[@MemberName='GetHandleControlUpdatesOnMainThread'][1]/Docs/*" />
@@ -67,7 +67,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 		#endregion
 
 		#region EnableAccessibilityScalingForNamedFontSizes
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Application.xml" path="//Member[@MemberName='EnableAccessibilityScalingForNamedFontSizesProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="EnableAccessibilityScalingForNamedFontSizes"/>.</summary>
 		public static readonly BindableProperty EnableAccessibilityScalingForNamedFontSizesProperty = BindableProperty.Create("EnableAccessibilityScalingForNamedFontSizes", typeof(bool), typeof(Application), true);
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Application.xml" path="//Member[@MemberName='GetEnableAccessibilityScalingForNamedFontSizes'][1]/Docs/*" />

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/Application.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/Application.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 	public static class Application
 	{
 		#region PanGestureRecognizerShouldRecognizeSimultaneously
-		/// <summary>Bindable property for <see cref="PanGestureRecognizerShouldRecognizeSimultaneously"/>.</summary>
+		/// <summary>Bindable property for attached property <c>PanGestureRecognizerShouldRecognizeSimultaneously</c>.</summary>
 		public static readonly BindableProperty PanGestureRecognizerShouldRecognizeSimultaneouslyProperty = BindableProperty.Create("PanGestureRecognizerShouldRecognizeSimultaneously", typeof(bool), typeof(Application), false);
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Application.xml" path="//Member[@MemberName='GetPanGestureRecognizerShouldRecognizeSimultaneously'][1]/Docs/*" />
@@ -37,7 +37,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 		#endregion
 
 		#region HandleControlUpdatesOnMainThread
-		/// <summary>Bindable property for <see cref="HandleControlUpdatesOnMainThread"/>.</summary>
+		/// <summary>Bindable property for attached property <c>HandleControlUpdatesOnMainThread</c>.</summary>
 		public static readonly BindableProperty HandleControlUpdatesOnMainThreadProperty = BindableProperty.Create("HandleControlUpdatesOnMainThread", typeof(bool), typeof(Application), false);
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Application.xml" path="//Member[@MemberName='GetHandleControlUpdatesOnMainThread'][1]/Docs/*" />
@@ -67,7 +67,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 		#endregion
 
 		#region EnableAccessibilityScalingForNamedFontSizes
-		/// <summary>Bindable property for <see cref="EnableAccessibilityScalingForNamedFontSizes"/>.</summary>
+		/// <summary>Bindable property for attached property <c>EnableAccessibilityScalingForNamedFontSize</c>.</summary>
 		public static readonly BindableProperty EnableAccessibilityScalingForNamedFontSizesProperty = BindableProperty.Create("EnableAccessibilityScalingForNamedFontSizes", typeof(bool), typeof(Application), true);
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Application.xml" path="//Member[@MemberName='GetEnableAccessibilityScalingForNamedFontSizes'][1]/Docs/*" />

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/Cell.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/Cell.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 	/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Cell.xml" path="Type[@FullName='Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific.Cell']/Docs/*" />
 	public static class Cell
 	{
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Cell.xml" path="//Member[@MemberName='DefaultBackgroundColorProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="DefaultBackgroundColor"/>.</summary>
 		public static readonly BindableProperty DefaultBackgroundColorProperty = BindableProperty.Create(nameof(DefaultBackgroundColor), typeof(Color), typeof(Cell), null);
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Cell.xml" path="//Member[@MemberName='GetDefaultBackgroundColor']/Docs/*" />

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/DatePicker.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/DatePicker.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 	/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/DatePicker.xml" path="Type[@FullName='Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific.DatePicker']/Docs/*" />
 	public static class DatePicker
 	{
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/DatePicker.xml" path="//Member[@MemberName='UpdateModeProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="UpdateMode"/>.</summary>
 		public static readonly BindableProperty UpdateModeProperty = BindableProperty.Create(
 			nameof(UpdateMode),
 			typeof(UpdateMode),

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/Entry.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/Entry.cs
@@ -13,7 +13,8 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 		public static readonly BindableProperty AdjustsFontSizeToFitWidthProperty =
 			BindableProperty.Create("AdjustsFontSizeToFitWidth", typeof(bool),
 				typeof(Entry), false);
-		/// <summary>Bindable property for <see cref="CursorColor"/>.</summary>
+
+		/// <summary>Bindable property for attached property <c>CursorColor</c>.</summary>
 		public static readonly BindableProperty CursorColorProperty = BindableProperty.Create("CursorColor", typeof(Color), typeof(Entry), null);
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Entry.xml" path="//Member[@MemberName='GetAdjustsFontSizeToFitWidth']/Docs/*" />

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/Entry.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/Entry.cs
@@ -9,11 +9,11 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 	/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Entry.xml" path="Type[@FullName='Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific.Entry']/Docs/*" />
 	public static class Entry
 	{
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Entry.xml" path="//Member[@MemberName='AdjustsFontSizeToFitWidthProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="AdjustsFontSizeToFitWidth"/>.</summary>
 		public static readonly BindableProperty AdjustsFontSizeToFitWidthProperty =
 			BindableProperty.Create("AdjustsFontSizeToFitWidth", typeof(bool),
 				typeof(Entry), false);
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Entry.xml" path="//Member[@MemberName='CursorColorProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="CursorColor"/>.</summary>
 		public static readonly BindableProperty CursorColorProperty = BindableProperty.Create("CursorColor", typeof(Color), typeof(Entry), null);
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Entry.xml" path="//Member[@MemberName='GetAdjustsFontSizeToFitWidth']/Docs/*" />

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/FlyoutPage.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/FlyoutPage.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 	public static class FlyoutPage
 	{
 		#region ApplyShadow
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/FlyoutPage.xml" path="//Member[@MemberName='ApplyShadowProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="ApplyShadow"/>.</summary>
 		public static readonly BindableProperty ApplyShadowProperty = BindableProperty.Create("ApplyShadow", typeof(bool), typeof(FlyoutPage), false);
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/FlyoutPage.xml" path="//Member[@MemberName='GetApplyShadow'][1]/Docs/*" />

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/FlyoutPage.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/FlyoutPage.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 	public static class FlyoutPage
 	{
 		#region ApplyShadow
-		/// <summary>Bindable property for <see cref="ApplyShadow"/>.</summary>
+		/// <summary>Bindable property for attached property <c>ApplyShadow</c>.</summary>
 		public static readonly BindableProperty ApplyShadowProperty = BindableProperty.Create("ApplyShadow", typeof(bool), typeof(FlyoutPage), false);
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/FlyoutPage.xml" path="//Member[@MemberName='GetApplyShadow'][1]/Docs/*" />

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/ListView.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/ListView.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 	/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ListView.xml" path="Type[@FullName='Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific.ListView']/Docs/*" />
 	public static class ListView
 	{
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ListView.xml" path="//Member[@MemberName='SeparatorStyleProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="SeparatorStyle"/>.</summary>
 		public static readonly BindableProperty SeparatorStyleProperty = BindableProperty.Create(nameof(SeparatorStyle), typeof(SeparatorStyle), typeof(FormsElement), SeparatorStyle.Default);
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ListView.xml" path="//Member[@MemberName='GetSeparatorStyle'][1]/Docs/*" />
@@ -34,7 +34,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			return config;
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ListView.xml" path="//Member[@MemberName='GroupHeaderStyleProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="GroupHeaderStyle"/>.</summary>
 		public static readonly BindableProperty GroupHeaderStyleProperty = BindableProperty.Create(nameof(GroupHeaderStyle), typeof(GroupHeaderStyle), typeof(FormsElement), GroupHeaderStyle.Plain);
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ListView.xml" path="//Member[@MemberName='GetGroupHeaderStyle'][1]/Docs/*" />
@@ -62,7 +62,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			return config;
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ListView.xml" path="//Member[@MemberName='RowAnimationsEnabledProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="RowAnimationsEnabled"/>.</summary>
 		public static readonly BindableProperty RowAnimationsEnabledProperty = BindableProperty.Create(nameof(RowAnimationsEnabled), typeof(bool), typeof(ListView), true);
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ListView.xml" path="//Member[@MemberName='GetRowAnimationsEnabled']/Docs/*" />

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/NavigationPage.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/NavigationPage.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 	public static class NavigationPage
 	{
 		#region Translucent
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/NavigationPage.xml" path="//Member[@MemberName='IsNavigationBarTranslucentProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="IsNavigationBarTranslucent"/>.</summary>
 		public static readonly BindableProperty IsNavigationBarTranslucentProperty =
 			BindableProperty.Create("IsNavigationBarTranslucent", typeof(bool),
 			typeof(NavigationPage), false);
@@ -55,7 +55,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 
 
 		#region StatusBarTextColorMode
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/NavigationPage.xml" path="//Member[@MemberName='StatusBarTextColorModeProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="StatusBarTextColorMode"/>.</summary>
 		public static readonly BindableProperty StatusBarTextColorModeProperty =
 			BindableProperty.Create("StatusBarColorTextMode", typeof(StatusBarTextColorMode),
 			typeof(NavigationPage), StatusBarTextColorMode.MatchNavigationBarTextLuminosity);
@@ -87,7 +87,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 		#endregion
 
 		#region PrefersLargeTitles
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/NavigationPage.xml" path="//Member[@MemberName='PrefersLargeTitlesProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="PrefersLargeTitles"/>.</summary>
 		public static readonly BindableProperty PrefersLargeTitlesProperty = BindableProperty.Create(nameof(PrefersLargeTitles), typeof(bool), typeof(Page), false);
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/NavigationPage.xml" path="//Member[@MemberName='GetPrefersLargeTitles']/Docs/*" />
@@ -117,7 +117,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 		#endregion
 
 		#region HideNavigationBarSeparator
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/NavigationPage.xml" path="//Member[@MemberName='HideNavigationBarSeparatorProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="HideNavigationBarSeparator"/>.</summary>
 		public static readonly BindableProperty HideNavigationBarSeparatorProperty = BindableProperty.Create(nameof(HideNavigationBarSeparator), typeof(bool), typeof(Page), false);
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/NavigationPage.xml" path="//Member[@MemberName='GetHideNavigationBarSeparator']/Docs/*" />

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/Page.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/Page.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 	/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Page.xml" path="Type[@FullName='Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific.Page']/Docs/*" />
 	public static class Page
 	{
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Page.xml" path="//Member[@MemberName='PrefersStatusBarHiddenProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="PrefersStatusBarHidden"/>.</summary>
 		public static readonly BindableProperty PrefersStatusBarHiddenProperty =
 			BindableProperty.Create("PrefersStatusBarHidden", typeof(StatusBarHiddenMode), typeof(Page), StatusBarHiddenMode.Default);
 
@@ -37,7 +37,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			return config;
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Page.xml" path="//Member[@MemberName='PreferredStatusBarUpdateAnimationProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="PreferredStatusBarUpdateAnimation"/>.</summary>
 		public static readonly BindableProperty PreferredStatusBarUpdateAnimationProperty =
 			BindableProperty.Create("PreferredStatusBarUpdateAnimation", typeof(UIStatusBarAnimation), typeof(Page), UIStatusBarAnimation.None);
 
@@ -71,7 +71,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			return config;
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Page.xml" path="//Member[@MemberName='UseSafeAreaProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="UseSafeArea"/>.</summary>
 		public static readonly BindableProperty UseSafeAreaProperty = BindableProperty.Create("UseSafeArea", typeof(bool), typeof(Page), true);
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Page.xml" path="//Member[@MemberName='GetUseSafeArea']/Docs/*" />
@@ -99,7 +99,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			return GetUseSafeArea(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Page.xml" path="//Member[@MemberName='LargeTitleDisplayProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="LargeTitleDisplay"/>.</summary>
 		public static readonly BindableProperty LargeTitleDisplayProperty = BindableProperty.Create(nameof(LargeTitleDisplay), typeof(LargeTitleDisplayMode), typeof(Page), LargeTitleDisplayMode.Automatic);
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Page.xml" path="//Member[@MemberName='GetLargeTitleDisplay']/Docs/*" />
@@ -129,7 +129,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 
 		static readonly BindablePropertyKey SafeAreaInsetsPropertyKey = BindableProperty.CreateReadOnly(nameof(SafeAreaInsets), typeof(Thickness), typeof(Page), default(Thickness));
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Page.xml" path="//Member[@MemberName='SafeAreaInsetsProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="SafeAreaInsets"/>.</summary>
 		public static readonly BindableProperty SafeAreaInsetsProperty = SafeAreaInsetsPropertyKey.BindableProperty;
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Page.xml" path="//Member[@MemberName='GetSafeAreaInsets']/Docs/*" />
@@ -157,7 +157,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			return config;
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Page.xml" path="//Member[@MemberName='ModalPresentationStyleProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="ModalPresentationStyle"/>.</summary>
 		public static readonly BindableProperty ModalPresentationStyleProperty =
 			BindableProperty.Create(nameof(ModalPresentationStyle), typeof(UIModalPresentationStyle), typeof(Page), UIModalPresentationStyle.FullScreen);
 
@@ -185,7 +185,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			element.SetValue(ModalPresentationStyleProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Page.xml" path="//Member[@MemberName='PrefersHomeIndicatorAutoHiddenProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="PrefersHomeIndicatorAutoHidden"/>.</summary>
 		public static readonly BindableProperty PrefersHomeIndicatorAutoHiddenProperty =
 			BindableProperty.Create(nameof(PrefersHomeIndicatorAutoHidden), typeof(bool), typeof(Page), false);
 

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/Page.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/Page.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			return config;
 		}
 
-		/// <summary>Bindable property for <see cref="UseSafeArea"/>.</summary>
+		/// <summary>Bindable property for attached property <c>UseSafeArea</c>.</summary>
 		public static readonly BindableProperty UseSafeAreaProperty = BindableProperty.Create("UseSafeArea", typeof(bool), typeof(Page), true);
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Page.xml" path="//Member[@MemberName='GetUseSafeArea']/Docs/*" />

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/Picker.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/Picker.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 	/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Picker.xml" path="Type[@FullName='Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific.Picker']/Docs/*" />
 	public static class Picker
 	{
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Picker.xml" path="//Member[@MemberName='UpdateModeProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="UpdateMode"/>.</summary>
 		public static readonly BindableProperty UpdateModeProperty = BindableProperty.Create(nameof(UpdateMode), typeof(UpdateMode), typeof(Picker), default(UpdateMode));
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Picker.xml" path="//Member[@MemberName='GetUpdateMode']/Docs/*" />

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/ScrollView.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/ScrollView.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 	/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ScrollView.xml" path="Type[@FullName='Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific.ScrollView']/Docs/*" />
 	public static class ScrollView
 	{
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ScrollView.xml" path="//Member[@MemberName='ShouldDelayContentTouchesProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="ShouldDelayContentTouches"/>.</summary>
 		public static readonly BindableProperty ShouldDelayContentTouchesProperty = BindableProperty.Create(nameof(ShouldDelayContentTouches), typeof(bool), typeof(ScrollView), true);
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ScrollView.xml" path="//Member[@MemberName='GetShouldDelayContentTouches']/Docs/*" />

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/SearchBar.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/SearchBar.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 	/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/SearchBar.xml" path="Type[@FullName='Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific.SearchBar']/Docs/*" />
 	public static class SearchBar
 	{
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/SearchBar.xml" path="//Member[@MemberName='SearchBarStyleProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="SearchBarStyle"/>.</summary>
 		public static readonly BindableProperty SearchBarStyleProperty = BindableProperty.Create("SearchBarStyle", typeof(UISearchBarStyle), typeof(SearchBar), UISearchBarStyle.Default);
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/SearchBar.xml" path="//Member[@MemberName='GetSearchBarStyle'][1]/Docs/*" />

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/SearchBar.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/SearchBar.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 	/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/SearchBar.xml" path="Type[@FullName='Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific.SearchBar']/Docs/*" />
 	public static class SearchBar
 	{
-		/// <summary>Bindable property for <see cref="SearchBarStyle"/>.</summary>
+		/// <summary>Bindable property for attached property <c>SearchBarStyle</c>.</summary>
 		public static readonly BindableProperty SearchBarStyleProperty = BindableProperty.Create("SearchBarStyle", typeof(UISearchBarStyle), typeof(SearchBar), UISearchBarStyle.Default);
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/SearchBar.xml" path="//Member[@MemberName='GetSearchBarStyle'][1]/Docs/*" />

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/Slider.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/Slider.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 	/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Slider.xml" path="Type[@FullName='Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific.Slider']/Docs/*" />
 	public static class Slider
 	{
-		/// <summary>Bindable property for <see cref="UpdateOnTap"/>.</summary>
+		/// <summary>Bindable property for attached property <c>UpdateOnTap</c>.</summary>
 		public static readonly BindableProperty UpdateOnTapProperty = BindableProperty.Create("UpdateOnTap", typeof(bool), typeof(Slider), false);
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Slider.xml" path="//Member[@MemberName='GetUpdateOnTap'][1]/Docs/*" />

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/Slider.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/Slider.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 	/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Slider.xml" path="Type[@FullName='Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific.Slider']/Docs/*" />
 	public static class Slider
 	{
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Slider.xml" path="//Member[@MemberName='UpdateOnTapProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="UpdateOnTap"/>.</summary>
 		public static readonly BindableProperty UpdateOnTapProperty = BindableProperty.Create("UpdateOnTap", typeof(bool), typeof(Slider), false);
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Slider.xml" path="//Member[@MemberName='GetUpdateOnTap'][1]/Docs/*" />

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/SwipeView.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/SwipeView.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 	/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/SwipeView.xml" path="Type[@FullName='Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific.SwipeView']/Docs/*" />
 	public static class SwipeView
 	{
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/SwipeView.xml" path="//Member[@MemberName='SwipeTransitionModeProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="SwipeTransitionMode"/>.</summary>
 		public static readonly BindableProperty SwipeTransitionModeProperty = BindableProperty.Create("SwipeTransitionMode", typeof(SwipeTransitionMode), typeof(SwipeView), SwipeTransitionMode.Reveal);
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/SwipeView.xml" path="//Member[@MemberName='GetSwipeTransitionMode'][1]/Docs/*" />

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/TabbedPage.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/TabbedPage.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 	/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/TabbedPage.xml" path="Type[@FullName='Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific.TabbedPage']/Docs/*" />
 	public static class TabbedPage
 	{
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/TabbedPage.xml" path="//Member[@MemberName='TranslucencyModeProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="TranslucencyMode"/>.</summary>
 		public static readonly BindableProperty TranslucencyModeProperty =
 			BindableProperty.Create("TranslucencyMode",
 				typeof(TranslucencyMode), typeof(TabbedPage), TranslucencyMode.Default);

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/TimePicker.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/TimePicker.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 	/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/TimePicker.xml" path="Type[@FullName='Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific.TimePicker']/Docs/*" />
 	public static class TimePicker
 	{
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/TimePicker.xml" path="//Member[@MemberName='UpdateModeProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="UpdateMode"/>.</summary>
 		public static readonly BindableProperty UpdateModeProperty = BindableProperty.Create(
 			nameof(UpdateMode),
 			typeof(UpdateMode),

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/VisualElement.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/VisualElement.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 	/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="Type[@FullName='Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific.VisualElement']/Docs/*" />
 	public static class VisualElement
 	{
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='BlurEffectProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="BlurEffect"/>.</summary>
 		public static readonly BindableProperty BlurEffectProperty = BindableProperty.Create("BlurEffect", typeof(BlurEffectStyle), typeof(VisualElement), BlurEffectStyle.None);
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='GetBlurEffect'][1]/Docs/*" />
@@ -44,7 +44,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			public ShadowEffect() : base("Microsoft.Maui.Controls.ShadowEffect") { }
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='IsShadowEnabledProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="IsShadowEnabled"/>.</summary>
 		public static readonly BindableProperty IsShadowEnabledProperty =
 			BindableProperty.Create("IsShadowEnabled", typeof(bool),
 			typeof(VisualElement), false, propertyChanged: OnIsShadowEnabledChanged);
@@ -95,7 +95,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			return config;
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='ShadowColorProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="ShadowColor"/>.</summary>
 		public static readonly BindableProperty ShadowColorProperty =
 			BindableProperty.Create("ShadowColor", typeof(Color),
 			typeof(VisualElement), null);
@@ -125,7 +125,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			return config;
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='ShadowRadiusProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="ShadowRadius"/>.</summary>
 		public static readonly BindableProperty ShadowRadiusProperty =
 			BindableProperty.Create("ShadowRadius", typeof(double),
 			typeof(VisualElement), 10.0);
@@ -155,7 +155,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			return config;
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='ShadowOffsetProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="ShadowOffset"/>.</summary>
 		public static readonly BindableProperty ShadowOffsetProperty =
 		BindableProperty.Create("ShadowOffset", typeof(Size),
 		typeof(VisualElement), Size.Zero);
@@ -185,7 +185,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			return config;
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='ShadowOpacityProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="ShadowOpacity"/>.</summary>
 		public static readonly BindableProperty ShadowOpacityProperty =
 		BindableProperty.Create("ShadowOpacity", typeof(double),
 		typeof(VisualElement), 0.5);
@@ -219,7 +219,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 
 		#region IsLegacyColorModeEnabled
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='IsLegacyColorModeEnabledProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="IsLegacyColorModeEnabled"/>.</summary>
 		public static readonly BindableProperty IsLegacyColorModeEnabledProperty =
 			BindableProperty.CreateAttached("IsLegacyColorModeEnabled", typeof(bool),
 				typeof(FormsElement), true);
@@ -252,7 +252,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 
 		#endregion
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='CanBecomeFirstResponderProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="CanBecomeFirstResponder"/>.</summary>
 		public static readonly BindableProperty CanBecomeFirstResponderProperty = BindableProperty.Create(nameof(CanBecomeFirstResponder), typeof(bool), typeof(VisualElement), false);
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='GetCanBecomeFirstResponder']/Docs/*" />

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/VisualElement.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/VisualElement.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 	/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="Type[@FullName='Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific.VisualElement']/Docs/*" />
 	public static class VisualElement
 	{
-		/// <summary>Bindable property for <see cref="BlurEffect"/>.</summary>
+		/// <summary>Bindable property for attached property <c>BlurEffect</c>.</summary>
 		public static readonly BindableProperty BlurEffectProperty = BindableProperty.Create("BlurEffect", typeof(BlurEffectStyle), typeof(VisualElement), BlurEffectStyle.None);
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='GetBlurEffect'][1]/Docs/*" />
@@ -44,7 +44,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			public ShadowEffect() : base("Microsoft.Maui.Controls.ShadowEffect") { }
 		}
 
-		/// <summary>Bindable property for <see cref="IsShadowEnabled"/>.</summary>
+		/// <summary>Bindable property for attached property <c>IsShadowEnabled</c>.</summary>
 		public static readonly BindableProperty IsShadowEnabledProperty =
 			BindableProperty.Create("IsShadowEnabled", typeof(bool),
 			typeof(VisualElement), false, propertyChanged: OnIsShadowEnabledChanged);
@@ -95,7 +95,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			return config;
 		}
 
-		/// <summary>Bindable property for <see cref="ShadowColor"/>.</summary>
+		/// <summary>Bindable property for attached property <c>ShadowColor</c>.</summary>
 		public static readonly BindableProperty ShadowColorProperty =
 			BindableProperty.Create("ShadowColor", typeof(Color),
 			typeof(VisualElement), null);
@@ -125,7 +125,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			return config;
 		}
 
-		/// <summary>Bindable property for <see cref="ShadowRadius"/>.</summary>
+		/// <summary>Bindable property for attached property <c>ShadowRadius</c>.</summary>
 		public static readonly BindableProperty ShadowRadiusProperty =
 			BindableProperty.Create("ShadowRadius", typeof(double),
 			typeof(VisualElement), 10.0);
@@ -155,7 +155,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			return config;
 		}
 
-		/// <summary>Bindable property for <see cref="ShadowOffset"/>.</summary>
+		/// <summary>Bindable property for attached property <c>ShadowOffset</c>.</summary>
 		public static readonly BindableProperty ShadowOffsetProperty =
 		BindableProperty.Create("ShadowOffset", typeof(Size),
 		typeof(VisualElement), Size.Zero);
@@ -185,7 +185,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			return config;
 		}
 
-		/// <summary>Bindable property for <see cref="ShadowOpacity"/>.</summary>
+		/// <summary>Bindable property for attached property <c>ShadowOpacity</c>.</summary>
 		public static readonly BindableProperty ShadowOpacityProperty =
 		BindableProperty.Create("ShadowOpacity", typeof(double),
 		typeof(VisualElement), 0.5);
@@ -219,7 +219,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 
 		#region IsLegacyColorModeEnabled
 
-		/// <summary>Bindable property for <see cref="IsLegacyColorModeEnabled"/>.</summary>
+		/// <summary>Bindable property for attached property <c>IsLegacyColorModeEnabled</c>.</summary>
 		public static readonly BindableProperty IsLegacyColorModeEnabledProperty =
 			BindableProperty.CreateAttached("IsLegacyColorModeEnabled", typeof(bool),
 				typeof(FormsElement), true);

--- a/src/Controls/src/Core/PlatformConfiguration/macOSSpecific/NavigationPage.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/macOSSpecific/NavigationPage.cs
@@ -6,9 +6,9 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific
 	/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific/NavigationPage.xml" path="Type[@FullName='Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific.NavigationPage']/Docs/*" />
 	public static class NavigationPage
 	{
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific/NavigationPage.xml" path="//Member[@MemberName='NavigationTransitionPushStyleProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="NavigationTransitionPushStyle"/>.</summary>
 		public static readonly BindableProperty NavigationTransitionPushStyleProperty = BindableProperty.Create("NavigationTransitionPushStyle", typeof(NavigationTransitionStyle), typeof(NavigationPage), NavigationTransitionStyle.SlideForward);
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific/NavigationPage.xml" path="//Member[@MemberName='NavigationTransitionPopStyleProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="NavigationTransitionPopStyle"/>.</summary>
 		public static readonly BindableProperty NavigationTransitionPopStyleProperty = BindableProperty.Create("NavigationTransitionPopStyle", typeof(NavigationTransitionStyle), typeof(NavigationPage), NavigationTransitionStyle.SlideBackward);
 
 		#region PushStyle

--- a/src/Controls/src/Core/PlatformConfiguration/macOSSpecific/NavigationPage.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/macOSSpecific/NavigationPage.cs
@@ -6,9 +6,9 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific
 	/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific/NavigationPage.xml" path="Type[@FullName='Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific.NavigationPage']/Docs/*" />
 	public static class NavigationPage
 	{
-		/// <summary>Bindable property for <see cref="NavigationTransitionPushStyle"/>.</summary>
+		/// <summary>Bindable property for attached property <c>NavigationTransitionPushStyle</c>.</summary>
 		public static readonly BindableProperty NavigationTransitionPushStyleProperty = BindableProperty.Create("NavigationTransitionPushStyle", typeof(NavigationTransitionStyle), typeof(NavigationPage), NavigationTransitionStyle.SlideForward);
-		/// <summary>Bindable property for <see cref="NavigationTransitionPopStyle"/>.</summary>
+		/// <summary>Bindable property for attached property <c>NavigationTransitionPopStyle</c>.</summary>
 		public static readonly BindableProperty NavigationTransitionPopStyleProperty = BindableProperty.Create("NavigationTransitionPopStyle", typeof(NavigationTransitionStyle), typeof(NavigationPage), NavigationTransitionStyle.SlideBackward);
 
 		#region PushStyle

--- a/src/Controls/src/Core/PlatformConfiguration/macOSSpecific/Page.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/macOSSpecific/Page.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific
 	public static class Page
 	{
 		#region TabsStyle
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific/Page.xml" path="//Member[@MemberName='TabOrderProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="TabOrder"/>.</summary>
 		public static readonly BindableProperty TabOrderProperty = BindableProperty.Create("TabOrder", typeof(VisualElement[]), typeof(Page), null);
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific/Page.xml" path="//Member[@MemberName='GetTabOrder'][1]/Docs/*" />

--- a/src/Controls/src/Core/PlatformConfiguration/macOSSpecific/Page.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/macOSSpecific/Page.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific
 	public static class Page
 	{
 		#region TabsStyle
-		/// <summary>Bindable property for <see cref="TabOrder"/>.</summary>
+		/// <summary>Bindable property for attached property <c>TabOrder</c>.</summary>
 		public static readonly BindableProperty TabOrderProperty = BindableProperty.Create("TabOrder", typeof(VisualElement[]), typeof(Page), null);
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific/Page.xml" path="//Member[@MemberName='GetTabOrder'][1]/Docs/*" />

--- a/src/Controls/src/Core/PlatformConfiguration/macOSSpecific/TabbedPage.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/macOSSpecific/TabbedPage.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific
 	public static class TabbedPage
 	{
 		#region TabsStyle
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific/TabbedPage.xml" path="//Member[@MemberName='TabsStyleProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="TabsStyle"/>.</summary>
 		public static readonly BindableProperty TabsStyleProperty = BindableProperty.Create("TabsStyle", typeof(TabsStyle), typeof(TabbedPage), TabsStyle.Default);
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific/TabbedPage.xml" path="//Member[@MemberName='GetTabsStyle'][1]/Docs/*" />

--- a/src/Controls/src/Core/ProgressBar.cs
+++ b/src/Controls/src/Core/ProgressBar.cs
@@ -1,4 +1,4 @@
-﻿#nullable disable
+#nullable disable
 using System;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
@@ -10,10 +10,10 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../docs/Microsoft.Maui.Controls/ProgressBar.xml" path="Type[@FullName='Microsoft.Maui.Controls.ProgressBar']/Docs/*" />
 	public partial class ProgressBar : View, IElementConfiguration<ProgressBar>
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/ProgressBar.xml" path="//Member[@MemberName='ProgressColorProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="ProgressColor"/>.</summary>
 		public static readonly BindableProperty ProgressColorProperty = BindableProperty.Create(nameof(ProgressColor), typeof(Color), typeof(ProgressBar), null);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ProgressBar.xml" path="//Member[@MemberName='ProgressProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Progress"/>.</summary>
 		public static readonly BindableProperty ProgressProperty = BindableProperty.Create(nameof(Progress), typeof(double), typeof(ProgressBar), 0d, coerceValue: (bo, v) => ((double)v).Clamp(0, 1));
 
 		readonly Lazy<PlatformConfigurationRegistry<ProgressBar>> _platformConfigurationRegistry;

--- a/src/Controls/src/Core/RadialGradientBrush.cs
+++ b/src/Controls/src/Core/RadialGradientBrush.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/RadialGradientBrush.xml" path="//Member[@MemberName='CenterProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Center"/>.</summary>
 		public static readonly BindableProperty CenterProperty = BindableProperty.Create(
 			nameof(Center), typeof(Point), typeof(RadialGradientBrush), new Point(0.5, 0.5));
 
@@ -54,7 +54,7 @@ namespace Microsoft.Maui.Controls
 			set => SetValue(CenterProperty, value);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/RadialGradientBrush.xml" path="//Member[@MemberName='RadiusProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Radius"/>.</summary>
 		public static readonly BindableProperty RadiusProperty = BindableProperty.Create(
 			nameof(Radius), typeof(double), typeof(RadialGradientBrush), 0.5d);
 

--- a/src/Controls/src/Core/RadioButton.cs
+++ b/src/Controls/src/Core/RadioButton.cs
@@ -50,53 +50,54 @@ namespace Microsoft.Maui.Controls
 
 		public event EventHandler<CheckedChangedEventArgs> CheckedChanged;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/RadioButton.xml" path="//Member[@MemberName='ContentProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Content"/>.</summary>
 		public static readonly BindableProperty ContentProperty =
 			BindableProperty.Create(nameof(Content), typeof(object), typeof(RadioButton), null);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/RadioButton.xml" path="//Member[@MemberName='ValueProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Value"/>.</summary>
 		public static readonly BindableProperty ValueProperty =
 			BindableProperty.Create(nameof(Value), typeof(object), typeof(RadioButton), null,
 			propertyChanged: (b, o, n) => ((RadioButton)b).OnValuePropertyChanged());
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/RadioButton.xml" path="//Member[@MemberName='IsCheckedProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="IsChecked"/>.</summary>
 		public static readonly BindableProperty IsCheckedProperty = BindableProperty.Create(
 			nameof(IsChecked), typeof(bool), typeof(RadioButton), false,
 			propertyChanged: (b, o, n) => ((RadioButton)b).OnIsCheckedPropertyChanged((bool)n),
 			defaultBindingMode: BindingMode.TwoWay);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/RadioButton.xml" path="//Member[@MemberName='GroupNameProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="GroupName"/>.</summary>
 		public static readonly BindableProperty GroupNameProperty = BindableProperty.Create(
 			nameof(GroupName), typeof(string), typeof(RadioButton), null,
 			propertyChanged: (b, o, n) => ((RadioButton)b).OnGroupNamePropertyChanged((string)o, (string)n));
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/RadioButton.xml" path="//Member[@MemberName='TextColorProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="TextColor"/>.</summary>
 		public static readonly BindableProperty TextColorProperty = TextElement.TextColorProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/RadioButton.xml" path="//Member[@MemberName='CharacterSpacingProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="CharacterSpacing"/>.</summary>
 		public static readonly BindableProperty CharacterSpacingProperty = TextElement.CharacterSpacingProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/RadioButton.xml" path="//Member[@MemberName='TextTransformProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="TextTransform"/>.</summary>
 		public static readonly BindableProperty TextTransformProperty = TextElement.TextTransformProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/RadioButton.xml" path="//Member[@MemberName='FontAttributesProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="FontAttributes"/>.</summary>
 		public static readonly BindableProperty FontAttributesProperty = FontElement.FontAttributesProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/RadioButton.xml" path="//Member[@MemberName='FontFamilyProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="FontFamily"/>.</summary>
 		public static readonly BindableProperty FontFamilyProperty = FontElement.FontFamilyProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/RadioButton.xml" path="//Member[@MemberName='FontSizeProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="FontSize"/>.</summary>
 		public static readonly BindableProperty FontSizeProperty = FontElement.FontSizeProperty;
 
+		/// <summary>Bindable property for <see cref="FontAutoScalingEnabled"/>.</summary>
 		public static readonly BindableProperty FontAutoScalingEnabledProperty = FontElement.FontAutoScalingEnabledProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/RadioButton.xml" path="//Member[@MemberName='BorderColorProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="BorderColor"/>.</summary>
 		public static readonly BindableProperty BorderColorProperty = BorderElement.BorderColorProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/RadioButton.xml" path="//Member[@MemberName='CornerRadiusProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="CornerRadius"/>.</summary>
 		public static readonly BindableProperty CornerRadiusProperty = BorderElement.CornerRadiusProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/RadioButton.xml" path="//Member[@MemberName='BorderWidthProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="BorderWidth"/>.</summary>
 		public static readonly BindableProperty BorderWidthProperty = BorderElement.BorderWidthProperty;
 
 		// If Content is set to a string, the string will be displayed using the native Text property

--- a/src/Controls/src/Core/RadioButtonGroup.cs
+++ b/src/Controls/src/Core/RadioButtonGroup.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Maui.Controls
 			return (RadioButtonGroupController)b.GetValue(RadioButtonGroupControllerProperty);
 		}
 
-		/// <summary>Bindable property for <see cref="GroupName"/>.</summary>
+		/// <summary>Bindable property for attached property <c>GroupName</c>.</summary>
 		public static readonly BindableProperty GroupNameProperty =
 			BindableProperty.Create("GroupName", typeof(string), typeof(Maui.ILayout), null,
 			propertyChanged: (b, o, n) => { GetRadioButtonGroupController(b).GroupName = (string)n; });
@@ -35,7 +35,7 @@ namespace Microsoft.Maui.Controls
 			bindable.SetValue(GroupNameProperty, groupName);
 		}
 
-		/// <summary>Bindable property for <see cref="SelectedValue"/>.</summary>
+		/// <summary>Bindable property for attached property <c>SelectedValue</c>.</summary>
 		public static readonly BindableProperty SelectedValueProperty =
 			BindableProperty.Create("SelectedValue", typeof(object), typeof(Maui.ILayout), null,
 			defaultBindingMode: BindingMode.TwoWay,

--- a/src/Controls/src/Core/RadioButtonGroup.cs
+++ b/src/Controls/src/Core/RadioButtonGroup.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Maui.Controls
 			return (RadioButtonGroupController)b.GetValue(RadioButtonGroupControllerProperty);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/RadioButtonGroup.xml" path="//Member[@MemberName='GroupNameProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="GroupName"/>.</summary>
 		public static readonly BindableProperty GroupNameProperty =
 			BindableProperty.Create("GroupName", typeof(string), typeof(Maui.ILayout), null,
 			propertyChanged: (b, o, n) => { GetRadioButtonGroupController(b).GroupName = (string)n; });
@@ -35,7 +35,7 @@ namespace Microsoft.Maui.Controls
 			bindable.SetValue(GroupNameProperty, groupName);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/RadioButtonGroup.xml" path="//Member[@MemberName='SelectedValueProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="SelectedValue"/>.</summary>
 		public static readonly BindableProperty SelectedValueProperty =
 			BindableProperty.Create("SelectedValue", typeof(object), typeof(Maui.ILayout), null,
 			defaultBindingMode: BindingMode.TwoWay,

--- a/src/Controls/src/Core/RefreshView.cs
+++ b/src/Controls/src/Core/RefreshView.cs
@@ -1,4 +1,4 @@
-﻿#nullable disable
+#nullable disable
 using System;
 using System.Runtime.CompilerServices;
 using System.Windows.Input;
@@ -24,7 +24,7 @@ namespace Microsoft.Maui.Controls
 			_platformConfigurationRegistry = new Lazy<PlatformConfigurationRegistry<RefreshView>>(() => new PlatformConfigurationRegistry<RefreshView>(this));
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/RefreshView.xml" path="//Member[@MemberName='IsRefreshingProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="IsRefreshing"/>.</summary>
 		public static readonly BindableProperty IsRefreshingProperty =
 			BindableProperty.Create(nameof(IsRefreshing), typeof(bool), typeof(RefreshView), false, BindingMode.TwoWay, coerceValue: OnIsRefreshingPropertyCoerced, propertyChanged: OnIsRefreshingPropertyChanged);
 
@@ -66,7 +66,7 @@ namespace Microsoft.Maui.Controls
 			set { SetValue(IsRefreshingProperty, value); }
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/RefreshView.xml" path="//Member[@MemberName='CommandProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Command"/>.</summary>
 		public static readonly BindableProperty CommandProperty =
 			BindableProperty.Create(nameof(Command), typeof(ICommand), typeof(RefreshView), propertyChanged: OnCommandChanged);
 
@@ -89,7 +89,7 @@ namespace Microsoft.Maui.Controls
 			set { SetValue(CommandProperty, value); }
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/RefreshView.xml" path="//Member[@MemberName='CommandParameterProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="CommandParameter"/>.</summary>
 		public static readonly BindableProperty CommandParameterProperty =
 			BindableProperty.Create(nameof(CommandParameter),
 				typeof(object),
@@ -119,7 +119,7 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/RefreshView.xml" path="//Member[@MemberName='RefreshColorProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="RefreshColor"/>.</summary>
 		public static readonly BindableProperty RefreshColorProperty =
 			BindableProperty.Create(nameof(RefreshColor), typeof(Color), typeof(RefreshView), null);
 

--- a/src/Controls/src/Core/Routing.cs
+++ b/src/Controls/src/Core/Routing.cs
@@ -118,7 +118,7 @@ namespace Microsoft.Maui.Controls
 			s_routeKeys = null;
 		}
 
-		/// <summary>Bindable property for <see cref="Route"/>.</summary>
+		/// <summary>Bindable property for attached property <c>Route</c>.</summary>
 		public static readonly BindableProperty RouteProperty =
 			BindableProperty.CreateAttached("Route", typeof(string), typeof(Routing), null,
 				defaultValueCreator: CreateDefaultRoute);

--- a/src/Controls/src/Core/Routing.cs
+++ b/src/Controls/src/Core/Routing.cs
@@ -118,7 +118,7 @@ namespace Microsoft.Maui.Controls
 			s_routeKeys = null;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Routing.xml" path="//Member[@MemberName='RouteProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Route"/>.</summary>
 		public static readonly BindableProperty RouteProperty =
 			BindableProperty.CreateAttached("Route", typeof(string), typeof(Routing), null,
 				defaultValueCreator: CreateDefaultRoute);

--- a/src/Controls/src/Core/RowDefinition.cs
+++ b/src/Controls/src/Core/RowDefinition.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../docs/Microsoft.Maui.Controls/RowDefinition.xml" path="Type[@FullName='Microsoft.Maui.Controls.RowDefinition']/Docs/*" />
 	public sealed class RowDefinition : BindableObject, IDefinition, IGridRowDefinition
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/RowDefinition.xml" path="//Member[@MemberName='HeightProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Height"/>.</summary>
 		public static readonly BindableProperty HeightProperty = BindableProperty.Create(nameof(Height), typeof(GridLength), typeof(RowDefinition), GridLength.Star,
 			propertyChanged: (bindable, oldValue, newValue) => ((RowDefinition)bindable).OnSizeChanged());
 

--- a/src/Controls/src/Core/ScrollView.cs
+++ b/src/Controls/src/Core/ScrollView.cs
@@ -96,30 +96,30 @@ namespace Microsoft.Maui.Controls
 
 		#endregion IScrollViewController
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ScrollView.xml" path="//Member[@MemberName='OrientationProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Orientation"/>.</summary>
 		public static readonly BindableProperty OrientationProperty = BindableProperty.Create("Orientation", typeof(ScrollOrientation), typeof(ScrollView), ScrollOrientation.Vertical);
 
 		static readonly BindablePropertyKey ScrollXPropertyKey = BindableProperty.CreateReadOnly("ScrollX", typeof(double), typeof(ScrollView), 0d);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ScrollView.xml" path="//Member[@MemberName='ScrollXProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="ScrollX"/>.</summary>
 		public static readonly BindableProperty ScrollXProperty = ScrollXPropertyKey.BindableProperty;
 
 		static readonly BindablePropertyKey ScrollYPropertyKey = BindableProperty.CreateReadOnly("ScrollY", typeof(double), typeof(ScrollView), 0d);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ScrollView.xml" path="//Member[@MemberName='ScrollYProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="ScrollY"/>.</summary>
 		public static readonly BindableProperty ScrollYProperty = ScrollYPropertyKey.BindableProperty;
 
 		static readonly BindablePropertyKey ContentSizePropertyKey = BindableProperty.CreateReadOnly("ContentSize", typeof(Size), typeof(ScrollView), default(Size));
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ScrollView.xml" path="//Member[@MemberName='ContentSizeProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="ContentSize"/>.</summary>
 		public static readonly BindableProperty ContentSizeProperty = ContentSizePropertyKey.BindableProperty;
 
 		readonly Lazy<PlatformConfigurationRegistry<ScrollView>> _platformConfigurationRegistry;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ScrollView.xml" path="//Member[@MemberName='HorizontalScrollBarVisibilityProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="HorizontalScrollBarVisibility"/>.</summary>
 		public static readonly BindableProperty HorizontalScrollBarVisibilityProperty = BindableProperty.Create(nameof(HorizontalScrollBarVisibility), typeof(ScrollBarVisibility), typeof(ScrollView), ScrollBarVisibility.Default);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ScrollView.xml" path="//Member[@MemberName='VerticalScrollBarVisibilityProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="VerticalScrollBarVisibility"/>.</summary>
 		public static readonly BindableProperty VerticalScrollBarVisibilityProperty = BindableProperty.Create(nameof(VerticalScrollBarVisibility), typeof(ScrollBarVisibility), typeof(ScrollView), ScrollBarVisibility.Default);
 
 		View _content;

--- a/src/Controls/src/Core/SearchBar.cs
+++ b/src/Controls/src/Core/SearchBar.cs
@@ -10,12 +10,12 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../docs/Microsoft.Maui.Controls/SearchBar.xml" path="Type[@FullName='Microsoft.Maui.Controls.SearchBar']/Docs/*" />
 	public partial class SearchBar : InputView, IFontElement, ITextAlignmentElement, ISearchBarController, IElementConfiguration<SearchBar>, ICommandElement
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/SearchBar.xml" path="//Member[@MemberName='SearchCommandProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="SearchCommand"/>.</summary>
 		public static readonly BindableProperty SearchCommandProperty = BindableProperty.Create(
 			"SearchCommand", typeof(ICommand), typeof(SearchBar), null,
 			propertyChanging: CommandElement.OnCommandChanging, propertyChanged: CommandElement.OnCommandChanged);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/SearchBar.xml" path="//Member[@MemberName='SearchCommandParameterProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="SearchCommandParameter"/>.</summary>
 		public static readonly BindableProperty SearchCommandParameterProperty = BindableProperty.Create(
 			"SearchCommandParameter", typeof(object), typeof(SearchBar), null,
 			propertyChanged: CommandElement.OnCommandParameterChanged);
@@ -23,7 +23,7 @@ namespace Microsoft.Maui.Controls
 		/// <include file="../../docs/Microsoft.Maui.Controls/SearchBar.xml" path="//Member[@MemberName='TextProperty']/Docs/*" />
 		public new static readonly BindableProperty TextProperty = InputView.TextProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/SearchBar.xml" path="//Member[@MemberName='CancelButtonColorProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="CancelButtonColor"/>.</summary>
 		public static readonly BindableProperty CancelButtonColorProperty = BindableProperty.Create("CancelButtonColor", typeof(Color), typeof(SearchBar), default(Color));
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/SearchBar.xml" path="//Member[@MemberName='PlaceholderProperty']/Docs/*" />
@@ -32,27 +32,31 @@ namespace Microsoft.Maui.Controls
 		/// <include file="../../docs/Microsoft.Maui.Controls/SearchBar.xml" path="//Member[@MemberName='PlaceholderColorProperty']/Docs/*" />
 		public new static readonly BindableProperty PlaceholderColorProperty = InputView.PlaceholderColorProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/SearchBar.xml" path="//Member[@MemberName='FontFamilyProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="FontFamily"/>.</summary>
 		public static readonly BindableProperty FontFamilyProperty = FontElement.FontFamilyProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/SearchBar.xml" path="//Member[@MemberName='FontSizeProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="FontSize"/>.</summary>
 		public static readonly BindableProperty FontSizeProperty = FontElement.FontSizeProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/SearchBar.xml" path="//Member[@MemberName='FontAttributesProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="FontAttributes"/>.</summary>
 		public static readonly BindableProperty FontAttributesProperty = FontElement.FontAttributesProperty;
 
+		/// <summary>Bindable property for <see cref="IsTextPredictionEnabled"/>.</summary>
 		public static readonly BindableProperty IsTextPredictionEnabledProperty = BindableProperty.Create(nameof(IsTextPredictionEnabled), typeof(bool), typeof(SearchBar), true, BindingMode.Default);
 
+		/// <summary>Bindable property for <see cref="CursorPosition"/>.</summary>
 		public static readonly BindableProperty CursorPositionProperty = BindableProperty.Create(nameof(CursorPosition), typeof(int), typeof(SearchBar), 0, validateValue: (b, v) => (int)v >= 0);
 
+		/// <summary>Bindable property for <see cref="SelectionLength"/>.</summary>
 		public static readonly BindableProperty SelectionLengthProperty = BindableProperty.Create(nameof(SelectionLength), typeof(int), typeof(SearchBar), 0, validateValue: (b, v) => (int)v >= 0);
 
+		/// <summary>Bindable property for <see cref="FontAutoScalingEnabled"/>.</summary>
 		public static readonly BindableProperty FontAutoScalingEnabledProperty = FontElement.FontAutoScalingEnabledProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/SearchBar.xml" path="//Member[@MemberName='HorizontalTextAlignmentProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="HorizontalTextAlignment"/>.</summary>
 		public static readonly BindableProperty HorizontalTextAlignmentProperty = TextAlignmentElement.HorizontalTextAlignmentProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/SearchBar.xml" path="//Member[@MemberName='VerticalTextAlignmentProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="VerticalTextAlignment"/>.</summary>
 		public static readonly BindableProperty VerticalTextAlignmentProperty = TextAlignmentElement.VerticalTextAlignmentProperty;
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/SearchBar.xml" path="//Member[@MemberName='TextColorProperty']/Docs/*" />

--- a/src/Controls/src/Core/SemanticProperties.cs
+++ b/src/Controls/src/Core/SemanticProperties.cs
@@ -6,13 +6,13 @@ namespace Microsoft.Maui.Controls
 {
 	public class SemanticProperties
 	{
-		/// <summary>Bindable property for <see cref="Description"/>.</summary>
+		/// <summary>Bindable property for attached property <c>Description</c>.</summary>
 		public static readonly BindableProperty DescriptionProperty = BindableProperty.CreateAttached("Description", typeof(string), typeof(SemanticProperties), default(string));
 
-		/// <summary>Bindable property for <see cref="Hint"/>.</summary>
+		/// <summary>Bindable property for attached property <c>Hint</c>.</summary>
 		public static readonly BindableProperty HintProperty = BindableProperty.CreateAttached("Hint", typeof(string), typeof(SemanticProperties), default(string));
 
-		/// <summary>Bindable property for <see cref="HeadingLevel"/>.</summary>
+		/// <summary>Bindable property for attached property <c>HeadingLevel</c>.</summary>
 		public static readonly BindableProperty HeadingLevelProperty = BindableProperty.CreateAttached("HeadingLevel", typeof(SemanticHeadingLevel), typeof(SemanticProperties), SemanticHeadingLevel.None);
 
 		public static string GetDescription(BindableObject bindable)

--- a/src/Controls/src/Core/SemanticProperties.cs
+++ b/src/Controls/src/Core/SemanticProperties.cs
@@ -6,10 +6,13 @@ namespace Microsoft.Maui.Controls
 {
 	public class SemanticProperties
 	{
+		/// <summary>Bindable property for <see cref="Description"/>.</summary>
 		public static readonly BindableProperty DescriptionProperty = BindableProperty.CreateAttached("Description", typeof(string), typeof(SemanticProperties), default(string));
 
+		/// <summary>Bindable property for <see cref="Hint"/>.</summary>
 		public static readonly BindableProperty HintProperty = BindableProperty.CreateAttached("Hint", typeof(string), typeof(SemanticProperties), default(string));
 
+		/// <summary>Bindable property for <see cref="HeadingLevel"/>.</summary>
 		public static readonly BindableProperty HeadingLevelProperty = BindableProperty.CreateAttached("HeadingLevel", typeof(SemanticHeadingLevel), typeof(SemanticProperties), SemanticHeadingLevel.None);
 
 		public static string GetDescription(BindableObject bindable)

--- a/src/Controls/src/Core/Shadow.cs
+++ b/src/Controls/src/Core/Shadow.cs
@@ -1,16 +1,20 @@
-﻿#nullable disable
+#nullable disable
 using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Controls
 {
 	public class Shadow : Element, IShadow
 	{
+		/// <summary>Bindable property for <see cref="Radius"/>.</summary>
 		public static readonly BindableProperty RadiusProperty = BindableProperty.Create(nameof(Radius), typeof(float), typeof(Shadow), 10f);
 
+		/// <summary>Bindable property for <see cref="Opacity"/>.</summary>
 		public static readonly BindableProperty OpacityProperty = BindableProperty.Create(nameof(Opacity), typeof(float), typeof(Shadow), 1f);
 
+		/// <summary>Bindable property for <see cref="Brush"/>.</summary>
 		public static readonly BindableProperty BrushProperty = BindableProperty.Create(nameof(Brush), typeof(Brush), typeof(Shadow), Brush.Black);
 
+		/// <summary>Bindable property for <see cref="Offset"/>.</summary>
 		public static readonly BindableProperty OffsetProperty = BindableProperty.Create(nameof(Offset), typeof(Point), typeof(Shadow), null);
 
 		Paint IShadow.Paint => Brush;

--- a/src/Controls/src/Core/Shapes/ArcSegment.cs
+++ b/src/Controls/src/Core/Shapes/ArcSegment.cs
@@ -23,23 +23,23 @@ namespace Microsoft.Maui.Controls.Shapes
 			IsLargeArc = isLargeArc;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/ArcSegment.xml" path="//Member[@MemberName='PointProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Point"/>.</summary>
 		public static readonly BindableProperty PointProperty =
 			BindableProperty.Create(nameof(Point), typeof(Point), typeof(ArcSegment), new Point(0, 0));
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/ArcSegment.xml" path="//Member[@MemberName='SizeProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Size"/>.</summary>
 		public static readonly BindableProperty SizeProperty =
 			BindableProperty.Create(nameof(Size), typeof(Size), typeof(ArcSegment), new Size(0, 0));
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/ArcSegment.xml" path="//Member[@MemberName='RotationAngleProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="RotationAngle"/>.</summary>
 		public static readonly BindableProperty RotationAngleProperty =
 			BindableProperty.Create(nameof(RotationAngle), typeof(double), typeof(ArcSegment), 0.0);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/ArcSegment.xml" path="//Member[@MemberName='SweepDirectionProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="SweepDirection"/>.</summary>
 		public static readonly BindableProperty SweepDirectionProperty =
 			BindableProperty.Create(nameof(SweepDirection), typeof(SweepDirection), typeof(ArcSegment), SweepDirection.CounterClockwise);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/ArcSegment.xml" path="//Member[@MemberName='IsLargeArcProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="IsLargeArc"/>.</summary>
 		public static readonly BindableProperty IsLargeArcProperty =
 			BindableProperty.Create(nameof(IsLargeArc), typeof(bool), typeof(ArcSegment), false);
 

--- a/src/Controls/src/Core/Shapes/BezierSegment.cs
+++ b/src/Controls/src/Core/Shapes/BezierSegment.cs
@@ -20,15 +20,15 @@ namespace Microsoft.Maui.Controls.Shapes
 			Point3 = point3;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/BezierSegment.xml" path="//Member[@MemberName='Point1Property']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Point1"/>.</summary>
 		public static readonly BindableProperty Point1Property =
 			BindableProperty.Create(nameof(Point1), typeof(Point), typeof(BezierSegment), new Point(0, 0));
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/BezierSegment.xml" path="//Member[@MemberName='Point2Property']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Point2"/>.</summary>
 		public static readonly BindableProperty Point2Property =
 			BindableProperty.Create(nameof(Point2), typeof(Point), typeof(BezierSegment), new Point(0, 0));
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/BezierSegment.xml" path="//Member[@MemberName='Point3Property']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Point3"/>.</summary>
 		public static readonly BindableProperty Point3Property =
 			BindableProperty.Create(nameof(Point3), typeof(Point), typeof(BezierSegment), new Point(0, 0));
 

--- a/src/Controls/src/Core/Shapes/CompositeTransform.cs
+++ b/src/Controls/src/Core/Shapes/CompositeTransform.cs
@@ -4,46 +4,46 @@ namespace Microsoft.Maui.Controls.Shapes
 	/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/CompositeTransform.xml" path="Type[@FullName='Microsoft.Maui.Controls.Shapes.CompositeTransform']/Docs/*" />
 	public sealed class CompositeTransform : Transform
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/CompositeTransform.xml" path="//Member[@MemberName='CenterXProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="CenterX"/>.</summary>
 		public static readonly BindableProperty CenterXProperty =
 			BindableProperty.Create(nameof(CenterX), typeof(double), typeof(CompositeTransform), 0.0,
 				propertyChanged: OnTransformPropertyChanged);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/CompositeTransform.xml" path="//Member[@MemberName='CenterYProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="CenterY"/>.</summary>
 		public static readonly BindableProperty CenterYProperty =
 			BindableProperty.Create(nameof(CenterY), typeof(double), typeof(CompositeTransform), 0.0,
 				propertyChanged: OnTransformPropertyChanged);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/CompositeTransform.xml" path="//Member[@MemberName='ScaleXProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="ScaleX"/>.</summary>
 		public static readonly BindableProperty ScaleXProperty =
 			BindableProperty.Create(nameof(ScaleX), typeof(double), typeof(CompositeTransform), 1.0, propertyChanged: OnTransformPropertyChanged);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/CompositeTransform.xml" path="//Member[@MemberName='ScaleYProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="ScaleY"/>.</summary>
 		public static readonly BindableProperty ScaleYProperty =
 			BindableProperty.Create(nameof(ScaleY), typeof(double), typeof(CompositeTransform), 1.0,
 				propertyChanged: OnTransformPropertyChanged);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/CompositeTransform.xml" path="//Member[@MemberName='SkewXProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="SkewX"/>.</summary>
 		public static readonly BindableProperty SkewXProperty =
 			BindableProperty.Create(nameof(SkewX), typeof(double), typeof(CompositeTransform), 0.0,
 				propertyChanged: OnTransformPropertyChanged);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/CompositeTransform.xml" path="//Member[@MemberName='SkewYProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="SkewY"/>.</summary>
 		public static readonly BindableProperty SkewYProperty =
 			BindableProperty.Create(nameof(SkewY), typeof(double), typeof(CompositeTransform), 0.0,
 				propertyChanged: OnTransformPropertyChanged);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/CompositeTransform.xml" path="//Member[@MemberName='RotationProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Rotation"/>.</summary>
 		public static readonly BindableProperty RotationProperty =
 			BindableProperty.Create(nameof(Rotation), typeof(double), typeof(CompositeTransform), 0.0,
 				propertyChanged: OnTransformPropertyChanged);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/CompositeTransform.xml" path="//Member[@MemberName='TranslateXProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="TranslateX"/>.</summary>
 		public static readonly BindableProperty TranslateXProperty =
 			BindableProperty.Create(nameof(TranslateX), typeof(double), typeof(CompositeTransform), 0.0,
 				propertyChanged: OnTransformPropertyChanged);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/CompositeTransform.xml" path="//Member[@MemberName='TranslateYProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="TranslateY"/>.</summary>
 		public static readonly BindableProperty TranslateYProperty =
 			BindableProperty.Create(nameof(TranslateY), typeof(double), typeof(CompositeTransform), 0.0,
 				propertyChanged: OnTransformPropertyChanged);

--- a/src/Controls/src/Core/Shapes/EllipseGeometry.cs
+++ b/src/Controls/src/Core/Shapes/EllipseGeometry.cs
@@ -21,15 +21,15 @@ namespace Microsoft.Maui.Controls.Shapes
 			RadiusY = radiusY;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/EllipseGeometry.xml" path="//Member[@MemberName='CenterProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Center"/>.</summary>
 		public static readonly BindableProperty CenterProperty =
 			BindableProperty.Create(nameof(Center), typeof(Point), typeof(EllipseGeometry), new Point());
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/EllipseGeometry.xml" path="//Member[@MemberName='RadiusXProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="RadiusX"/>.</summary>
 		public static readonly BindableProperty RadiusXProperty =
 			BindableProperty.Create(nameof(RadiusX), typeof(double), typeof(EllipseGeometry), 0.0);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/EllipseGeometry.xml" path="//Member[@MemberName='RadiusYProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="RadiusY"/>.</summary>
 		public static readonly BindableProperty RadiusYProperty =
 			BindableProperty.Create(nameof(RadiusY), typeof(double), typeof(EllipseGeometry), 0.0);
 

--- a/src/Controls/src/Core/Shapes/GeometryGroup.cs
+++ b/src/Controls/src/Core/Shapes/GeometryGroup.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Maui.Controls.Shapes
 	[ContentProperty("Children")]
 	public class GeometryGroup : Geometry
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/GeometryGroup.xml" path="//Member[@MemberName='ChildrenProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Children"/>.</summary>
 		public static readonly BindableProperty ChildrenProperty =
 			BindableProperty.Create(nameof(Children), typeof(GeometryCollection), typeof(GeometryGroup), null,
 				propertyChanged: OnChildrenChanged);
@@ -19,7 +19,7 @@ namespace Microsoft.Maui.Controls.Shapes
 			(bindable as GeometryGroup)?.UpdateChildren(oldValue as GeometryCollection, newValue as GeometryCollection);
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/GeometryGroup.xml" path="//Member[@MemberName='FillRuleProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="FillRule"/>.</summary>
 		public static readonly BindableProperty FillRuleProperty =
 			BindableProperty.Create(nameof(FillRule), typeof(FillRule), typeof(GeometryGroup), FillRule.EvenOdd);
 

--- a/src/Controls/src/Core/Shapes/Line.cs
+++ b/src/Controls/src/Core/Shapes/Line.cs
@@ -17,19 +17,19 @@ namespace Microsoft.Maui.Controls.Shapes
 			Y2 = y2;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Line.xml" path="//Member[@MemberName='X1Property']/Docs/*" />
+		/// <summary>Bindable property for <see cref="X1"/>.</summary>
 		public static readonly BindableProperty X1Property =
 			BindableProperty.Create(nameof(X1), typeof(double), typeof(Line), 0.0d);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Line.xml" path="//Member[@MemberName='Y1Property']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Y1"/>.</summary>
 		public static readonly BindableProperty Y1Property =
 			BindableProperty.Create(nameof(Y1), typeof(double), typeof(Line), 0.0d);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Line.xml" path="//Member[@MemberName='X2Property']/Docs/*" />
+		/// <summary>Bindable property for <see cref="X2"/>.</summary>
 		public static readonly BindableProperty X2Property =
 			BindableProperty.Create(nameof(X2), typeof(double), typeof(Line), 0.0d);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Line.xml" path="//Member[@MemberName='Y2Property']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Y2"/>.</summary>
 		public static readonly BindableProperty Y2Property =
 			BindableProperty.Create(nameof(Y2), typeof(double), typeof(Line), 0.0d);
 

--- a/src/Controls/src/Core/Shapes/LineGeometry.cs
+++ b/src/Controls/src/Core/Shapes/LineGeometry.cs
@@ -20,11 +20,11 @@ namespace Microsoft.Maui.Controls.Shapes
 			EndPoint = endPoint;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/LineGeometry.xml" path="//Member[@MemberName='StartPointProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="StartPoint"/>.</summary>
 		public static readonly BindableProperty StartPointProperty =
 			BindableProperty.Create(nameof(StartPoint), typeof(Point), typeof(LineGeometry), new Point());
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/LineGeometry.xml" path="//Member[@MemberName='EndPointProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="EndPoint"/>.</summary>
 		public static readonly BindableProperty EndPointProperty =
 			BindableProperty.Create(nameof(EndPoint), typeof(Point), typeof(LineGeometry), new Point());
 

--- a/src/Controls/src/Core/Shapes/LineSegment.cs
+++ b/src/Controls/src/Core/Shapes/LineSegment.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Maui.Controls.Shapes
 			Point = point;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/LineSegment.xml" path="//Member[@MemberName='PointProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Point"/>.</summary>
 		public static readonly BindableProperty PointProperty =
 			BindableProperty.Create(nameof(Point), typeof(Point), typeof(LineSegment), new Point(0, 0));
 

--- a/src/Controls/src/Core/Shapes/MatrixTransform.cs
+++ b/src/Controls/src/Core/Shapes/MatrixTransform.cs
@@ -4,7 +4,7 @@ namespace Microsoft.Maui.Controls.Shapes
 	/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/MatrixTransform.xml" path="Type[@FullName='Microsoft.Maui.Controls.Shapes.MatrixTransform']/Docs/*" />
 	public class MatrixTransform : Transform
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/MatrixTransform.xml" path="//Member[@MemberName='MatrixProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Matrix"/>.</summary>
 		public static readonly BindableProperty MatrixProperty =
 			BindableProperty.Create(nameof(Matrix), typeof(Matrix), typeof(MatrixTransform), new Matrix(),
 				propertyChanged: OnTransformPropertyChanged);

--- a/src/Controls/src/Core/Shapes/Path.cs
+++ b/src/Controls/src/Core/Shapes/Path.cs
@@ -17,12 +17,12 @@ namespace Microsoft.Maui.Controls.Shapes
 			Data = data;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Path.xml" path="//Member[@MemberName='DataProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Data"/>.</summary>
 		public static readonly BindableProperty DataProperty =
 			 BindableProperty.Create(nameof(Data), typeof(Geometry), typeof(Path), null,
 				 propertyChanged: OnGeometryPropertyChanged);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Path.xml" path="//Member[@MemberName='RenderTransformProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="RenderTransform"/>.</summary>
 		public static readonly BindableProperty RenderTransformProperty =
 			BindableProperty.Create(nameof(RenderTransform), typeof(Transform), typeof(Path), null,
 				propertyChanged: OnTransformPropertyChanged);

--- a/src/Controls/src/Core/Shapes/PathFigure.cs
+++ b/src/Controls/src/Core/Shapes/PathFigure.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Maui.Controls.Shapes
 			Segments = new PathSegmentCollection();
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/PathFigure.xml" path="//Member[@MemberName='SegmentsProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Segments"/>.</summary>
 		public static readonly BindableProperty SegmentsProperty =
 			BindableProperty.Create(nameof(Segments), typeof(PathSegmentCollection), typeof(PathFigure), null,
 				propertyChanged: OnPathSegmentCollectionChanged);
@@ -26,15 +26,15 @@ namespace Microsoft.Maui.Controls.Shapes
 			(bindable as PathFigure)?.UpdatePathSegmentCollection(oldValue as PathSegmentCollection, newValue as PathSegmentCollection);
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/PathFigure.xml" path="//Member[@MemberName='StartPointProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="StartPoint"/>.</summary>
 		public static readonly BindableProperty StartPointProperty =
 			BindableProperty.Create(nameof(StartPoint), typeof(Point), typeof(PathFigure), new Point(0, 0));
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/PathFigure.xml" path="//Member[@MemberName='IsClosedProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="IsClosed"/>.</summary>
 		public static readonly BindableProperty IsClosedProperty =
 			BindableProperty.Create(nameof(IsClosed), typeof(bool), typeof(PathFigure), false);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/PathFigure.xml" path="//Member[@MemberName='IsFilledProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="IsFilled"/>.</summary>
 		public static readonly BindableProperty IsFilledProperty =
 			BindableProperty.Create(nameof(IsFilled), typeof(bool), typeof(PathFigure), true);
 

--- a/src/Controls/src/Core/Shapes/PathGeometry.cs
+++ b/src/Controls/src/Core/Shapes/PathGeometry.cs
@@ -31,12 +31,12 @@ namespace Microsoft.Maui.Controls.Shapes
 			FillRule = fillRule;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/PathGeometry.xml" path="//Member[@MemberName='FiguresProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Figures"/>.</summary>
 		public static readonly BindableProperty FiguresProperty =
 			BindableProperty.Create(nameof(Figures), typeof(PathFigureCollection), typeof(PathGeometry), null,
 				propertyChanged: OnPathFigureCollectionChanged);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/PathGeometry.xml" path="//Member[@MemberName='FillRuleProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="FillRule"/>.</summary>
 		public static readonly BindableProperty FillRuleProperty =
 			BindableProperty.Create(nameof(FillRule), typeof(FillRule), typeof(PathGeometry), FillRule.EvenOdd);
 

--- a/src/Controls/src/Core/Shapes/PolyBezierSegment.cs
+++ b/src/Controls/src/Core/Shapes/PolyBezierSegment.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Maui.Controls.Shapes
 			Points = points;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/PolyBezierSegment.xml" path="//Member[@MemberName='PointsProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Points"/>.</summary>
 		public static readonly BindableProperty PointsProperty =
 			BindableProperty.Create(nameof(Points), typeof(PointCollection), typeof(PolyBezierSegment), null);
 

--- a/src/Controls/src/Core/Shapes/PolyLineSegment.cs
+++ b/src/Controls/src/Core/Shapes/PolyLineSegment.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Maui.Controls.Shapes
 			Points = points;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/PolyLineSegment.xml" path="//Member[@MemberName='PointsProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Points"/>.</summary>
 		public static readonly BindableProperty PointsProperty =
 			BindableProperty.Create(nameof(Points), typeof(PointCollection), typeof(PolyLineSegment), null);
 

--- a/src/Controls/src/Core/Shapes/PolyQuadraticBezierSegment.cs
+++ b/src/Controls/src/Core/Shapes/PolyQuadraticBezierSegment.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Maui.Controls.Shapes
 			Points = points;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/PolyQuadraticBezierSegment.xml" path="//Member[@MemberName='PointsProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Points"/>.</summary>
 		public static readonly BindableProperty PointsProperty =
 			BindableProperty.Create(nameof(Points), typeof(PointCollection), typeof(PolyQuadraticBezierSegment), null);
 

--- a/src/Controls/src/Core/Shapes/Polygon.cs
+++ b/src/Controls/src/Core/Shapes/Polygon.cs
@@ -14,11 +14,11 @@ namespace Microsoft.Maui.Controls.Shapes
 			Points = points;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Polygon.xml" path="//Member[@MemberName='PointsProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Points"/>.</summary>
 		public static readonly BindableProperty PointsProperty =
 			BindableProperty.Create(nameof(Points), typeof(PointCollection), typeof(Polygon), null, defaultValueCreator: bindable => new PointCollection());
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Polygon.xml" path="//Member[@MemberName='FillRuleProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="FillRule"/>.</summary>
 		public static readonly BindableProperty FillRuleProperty =
 			BindableProperty.Create(nameof(FillRule), typeof(FillRule), typeof(Polygon), FillRule.EvenOdd);
 

--- a/src/Controls/src/Core/Shapes/Polyline.cs
+++ b/src/Controls/src/Core/Shapes/Polyline.cs
@@ -14,11 +14,11 @@ namespace Microsoft.Maui.Controls.Shapes
 			Points = points;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Polyline.xml" path="//Member[@MemberName='PointsProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Points"/>.</summary>
 		public static readonly BindableProperty PointsProperty =
 			BindableProperty.Create(nameof(Points), typeof(PointCollection), typeof(Polyline), null, defaultValueCreator: bindable => new PointCollection());
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Polyline.xml" path="//Member[@MemberName='FillRuleProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="FillRule"/>.</summary>
 		public static readonly BindableProperty FillRuleProperty =
 			BindableProperty.Create(nameof(FillRule), typeof(FillRule), typeof(Polyline), FillRule.EvenOdd);
 

--- a/src/Controls/src/Core/Shapes/QuadraticBezierSegment.cs
+++ b/src/Controls/src/Core/Shapes/QuadraticBezierSegment.cs
@@ -19,11 +19,11 @@ namespace Microsoft.Maui.Controls.Shapes
 			Point2 = point2;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/QuadraticBezierSegment.xml" path="//Member[@MemberName='Point1Property']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Point1"/>.</summary>
 		public static readonly BindableProperty Point1Property =
 			BindableProperty.Create(nameof(Point1), typeof(Point), typeof(QuadraticBezierSegment), new Point(0, 0));
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/QuadraticBezierSegment.xml" path="//Member[@MemberName='Point2Property']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Point2"/>.</summary>
 		public static readonly BindableProperty Point2Property =
 			BindableProperty.Create(nameof(Point2), typeof(Point), typeof(QuadraticBezierSegment), new Point(0, 0));
 

--- a/src/Controls/src/Core/Shapes/Rectangle.cs
+++ b/src/Controls/src/Core/Shapes/Rectangle.cs
@@ -12,11 +12,11 @@ namespace Microsoft.Maui.Controls.Shapes
 			Aspect = Stretch.Fill;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Rectangle.xml" path="//Member[@MemberName='RadiusXProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="RadiusX"/>.</summary>
 		public static readonly BindableProperty RadiusXProperty =
 			BindableProperty.Create(nameof(RadiusX), typeof(double), typeof(Rectangle), 0.0d);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Rectangle.xml" path="//Member[@MemberName='RadiusYProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="RadiusY"/>.</summary>
 		public static readonly BindableProperty RadiusYProperty =
 			BindableProperty.Create(nameof(RadiusY), typeof(double), typeof(Rectangle), 0.0d);
 

--- a/src/Controls/src/Core/Shapes/RectangleGeometry.cs
+++ b/src/Controls/src/Core/Shapes/RectangleGeometry.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Maui.Controls.Shapes
 			Rect = rect;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/RectangleGeometry.xml" path="//Member[@MemberName='RectProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Rect"/>.</summary>
 		public static readonly BindableProperty RectProperty =
 			BindableProperty.Create(nameof(Rect), typeof(Rect), typeof(RectangleGeometry), new Rect());
 

--- a/src/Controls/src/Core/Shapes/RotateTransform.cs
+++ b/src/Controls/src/Core/Shapes/RotateTransform.cs
@@ -26,17 +26,17 @@ namespace Microsoft.Maui.Controls.Shapes
 			CenterY = centerY;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/RotateTransform.xml" path="//Member[@MemberName='AngleProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Angle"/>.</summary>
 		public static readonly BindableProperty AngleProperty =
 			BindableProperty.Create(nameof(Angle), typeof(double), typeof(RotateTransform), 0.0,
 				propertyChanged: OnTransformPropertyChanged);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/RotateTransform.xml" path="//Member[@MemberName='CenterXProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="CenterX"/>.</summary>
 		public static readonly BindableProperty CenterXProperty =
 			BindableProperty.Create(nameof(CenterX), typeof(double), typeof(RotateTransform), 0.0,
 				propertyChanged: OnTransformPropertyChanged);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/RotateTransform.xml" path="//Member[@MemberName='CenterYProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="CenterY"/>.</summary>
 		public static readonly BindableProperty CenterYProperty =
 			BindableProperty.Create(nameof(CenterY), typeof(double), typeof(RotateTransform), 0.0,
 				propertyChanged: OnTransformPropertyChanged);

--- a/src/Controls/src/Core/Shapes/RoundRectangle.cs
+++ b/src/Controls/src/Core/Shapes/RoundRectangle.cs
@@ -1,4 +1,4 @@
-﻿#nullable disable
+#nullable disable
 namespace Microsoft.Maui.Controls.Shapes
 {
 	public sealed partial class RoundRectangle : Shape
@@ -8,6 +8,7 @@ namespace Microsoft.Maui.Controls.Shapes
 			Aspect = Stretch.Fill;
 		}
 
+		/// <summary>Bindable property for <see cref="CornerRadius"/>.</summary>
 		public static readonly BindableProperty CornerRadiusProperty =
 			BindableProperty.Create(nameof(CornerRadius), typeof(CornerRadius), typeof(RoundRectangle), new CornerRadius());
 

--- a/src/Controls/src/Core/Shapes/RoundRectangleGeometry.cs
+++ b/src/Controls/src/Core/Shapes/RoundRectangleGeometry.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Maui.Controls.Shapes
 			Rect = rect;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/RoundRectangleGeometry.xml" path="//Member[@MemberName='RectProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Rect"/>.</summary>
 		public static readonly BindableProperty RectProperty =
 		   BindableProperty.Create(nameof(Rect), typeof(Rect), typeof(RoundRectangleGeometry), new Rect(),
 			   propertyChanged: OnRectChanged);
@@ -38,7 +38,7 @@ namespace Microsoft.Maui.Controls.Shapes
 			get { return (Rect)GetValue(RectProperty); }
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/RoundRectangleGeometry.xml" path="//Member[@MemberName='CornerRadiusProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="CornerRadius"/>.</summary>
 		public static readonly BindableProperty CornerRadiusProperty =
 			BindableProperty.Create(nameof(CornerRadius), typeof(CornerRadius), typeof(RoundRectangleGeometry), new CornerRadius(),
 				propertyChanged: OnCornerRadiusChanged);

--- a/src/Controls/src/Core/Shapes/ScaleTransform.cs
+++ b/src/Controls/src/Core/Shapes/ScaleTransform.cs
@@ -26,22 +26,22 @@ namespace Microsoft.Maui.Controls.Shapes
 			CenterY = centerY;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/ScaleTransform.xml" path="//Member[@MemberName='ScaleXProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="ScaleX"/>.</summary>
 		public static readonly BindableProperty ScaleXProperty =
 			BindableProperty.Create(nameof(ScaleX), typeof(double), typeof(ScaleTransform), 1.0,
 				propertyChanged: OnTransformPropertyChanged);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/ScaleTransform.xml" path="//Member[@MemberName='ScaleYProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="ScaleY"/>.</summary>
 		public static readonly BindableProperty ScaleYProperty =
 			BindableProperty.Create(nameof(ScaleY), typeof(double), typeof(ScaleTransform), 1.0,
 				propertyChanged: OnTransformPropertyChanged);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/ScaleTransform.xml" path="//Member[@MemberName='CenterXProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="CenterX"/>.</summary>
 		public static readonly BindableProperty CenterXProperty =
 			BindableProperty.Create(nameof(CenterX), typeof(double), typeof(ScaleTransform), 0.0,
 				propertyChanged: OnTransformPropertyChanged);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/ScaleTransform.xml" path="//Member[@MemberName='CenterYProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="CenterY"/>.</summary>
 		public static readonly BindableProperty CenterYProperty =
 			BindableProperty.Create(nameof(CenterY), typeof(double), typeof(ScaleTransform), 0.0,
 				propertyChanged: OnTransformPropertyChanged);

--- a/src/Controls/src/Core/Shapes/Shape.cs
+++ b/src/Controls/src/Core/Shapes/Shape.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Linq;
 using System.Numerics;
@@ -29,7 +29,7 @@ namespace Microsoft.Maui.Controls.Shapes
 		double _fallbackWidth;
 		double _fallbackHeight;
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Shape.xml" path="//Member[@MemberName='FillProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Fill"/>.</summary>
 		public static readonly BindableProperty FillProperty =
 			BindableProperty.Create(nameof(Fill), typeof(Brush), typeof(Shape), null,
 				propertyChanging: (bindable, oldvalue, newvalue) =>
@@ -43,7 +43,7 @@ namespace Microsoft.Maui.Controls.Shapes
 						(bindable as Shape)?.NotifyFillChanges();
 				});
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Shape.xml" path="//Member[@MemberName='StrokeProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Stroke"/>.</summary>
 		public static readonly BindableProperty StrokeProperty =
 			BindableProperty.Create(nameof(Stroke), typeof(Brush), typeof(Shape), null,
 				propertyChanging: (bindable, oldvalue, newvalue) =>
@@ -57,32 +57,32 @@ namespace Microsoft.Maui.Controls.Shapes
 						(bindable as Shape)?.NotifyStrokeChanges();
 				});
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Shape.xml" path="//Member[@MemberName='StrokeThicknessProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="StrokeThickness"/>.</summary>
 		public static readonly BindableProperty StrokeThicknessProperty =
 			BindableProperty.Create(nameof(StrokeThickness), typeof(double), typeof(Shape), 1.0);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Shape.xml" path="//Member[@MemberName='StrokeDashArrayProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="StrokeDashArray"/>.</summary>
 		public static readonly BindableProperty StrokeDashArrayProperty =
 			BindableProperty.Create(nameof(StrokeDashArray), typeof(DoubleCollection), typeof(Shape), null,
 				defaultValueCreator: bindable => new DoubleCollection());
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Shape.xml" path="//Member[@MemberName='StrokeDashOffsetProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="StrokeDashOffset"/>.</summary>
 		public static readonly BindableProperty StrokeDashOffsetProperty =
 			BindableProperty.Create(nameof(StrokeDashOffset), typeof(double), typeof(Shape), 0.0);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Shape.xml" path="//Member[@MemberName='StrokeLineCapProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="StrokeLineCap"/>.</summary>
 		public static readonly BindableProperty StrokeLineCapProperty =
 			BindableProperty.Create(nameof(StrokeLineCap), typeof(PenLineCap), typeof(Shape), PenLineCap.Flat);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Shape.xml" path="//Member[@MemberName='StrokeLineJoinProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="StrokeLineJoin"/>.</summary>
 		public static readonly BindableProperty StrokeLineJoinProperty =
 			BindableProperty.Create(nameof(StrokeLineJoin), typeof(PenLineJoin), typeof(Shape), PenLineJoin.Miter);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Shape.xml" path="//Member[@MemberName='StrokeMiterLimitProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="StrokeMiterLimit"/>.</summary>
 		public static readonly BindableProperty StrokeMiterLimitProperty =
 			BindableProperty.Create(nameof(StrokeMiterLimit), typeof(double), typeof(Shape), 10.0);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Shape.xml" path="//Member[@MemberName='AspectProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Aspect"/>.</summary>
 		public static readonly BindableProperty AspectProperty =
 			BindableProperty.Create(nameof(Aspect), typeof(Stretch), typeof(Shape), Stretch.None);
 

--- a/src/Controls/src/Core/Shapes/SkewTransform.cs
+++ b/src/Controls/src/Core/Shapes/SkewTransform.cs
@@ -28,22 +28,22 @@ namespace Microsoft.Maui.Controls.Shapes
 			CenterY = centerY;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/SkewTransform.xml" path="//Member[@MemberName='AngleXProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="AngleX"/>.</summary>
 		public static readonly BindableProperty AngleXProperty =
 			BindableProperty.Create(nameof(AngleX), typeof(double), typeof(SkewTransform), 0.0,
 				propertyChanged: OnTransformPropertyChanged);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/SkewTransform.xml" path="//Member[@MemberName='AngleYProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="AngleY"/>.</summary>
 		public static readonly BindableProperty AngleYProperty =
 			BindableProperty.Create(nameof(AngleY), typeof(double), typeof(SkewTransform), 0.0,
 				propertyChanged: OnTransformPropertyChanged);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/SkewTransform.xml" path="//Member[@MemberName='CenterXProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="CenterX"/>.</summary>
 		public static readonly BindableProperty CenterXProperty =
 			BindableProperty.Create(nameof(CenterX), typeof(double), typeof(SkewTransform), 0.0,
 				propertyChanged: OnTransformPropertyChanged);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/SkewTransform.xml" path="//Member[@MemberName='CenterYProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="CenterY"/>.</summary>
 		public static readonly BindableProperty CenterYProperty =
 			BindableProperty.Create(nameof(CenterY), typeof(double), typeof(SkewTransform), 0.0,
 				propertyChanged: OnTransformPropertyChanged);

--- a/src/Controls/src/Core/Shapes/Transform.cs
+++ b/src/Controls/src/Core/Shapes/Transform.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Maui.Controls.Shapes
 	[System.ComponentModel.TypeConverter(typeof(TransformTypeConverter))]
 	public class Transform : BindableObject
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Transform.xml" path="//Member[@MemberName='ValueProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Value"/>.</summary>
 		public static readonly BindableProperty ValueProperty =
 		   BindableProperty.Create(nameof(Value), typeof(Matrix), typeof(Transform), new Matrix());
 

--- a/src/Controls/src/Core/Shapes/TransformGroup.cs
+++ b/src/Controls/src/Core/Shapes/TransformGroup.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Maui.Controls.Shapes
 	[ContentProperty("Children")]
 	public sealed class TransformGroup : Transform
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/TransformGroup.xml" path="//Member[@MemberName='ChildrenProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Children"/>.</summary>
 		public static readonly BindableProperty ChildrenProperty =
 			BindableProperty.Create(nameof(Children), typeof(TransformCollection), typeof(TransformGroup), null,
 				propertyChanged: OnTransformGroupChanged);

--- a/src/Controls/src/Core/Shapes/TranslateTransform.cs
+++ b/src/Controls/src/Core/Shapes/TranslateTransform.cs
@@ -17,12 +17,12 @@ namespace Microsoft.Maui.Controls.Shapes
 			Y = y;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/TranslateTransform.xml" path="//Member[@MemberName='XProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="X"/>.</summary>
 		public static readonly BindableProperty XProperty =
 			BindableProperty.Create(nameof(X), typeof(double), typeof(TranslateTransform), 0.0,
 				propertyChanged: OnTransformPropertyChanged);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/TranslateTransform.xml" path="//Member[@MemberName='YProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Y"/>.</summary>
 		public static readonly BindableProperty YProperty =
 			BindableProperty.Create(nameof(Y), typeof(double), typeof(TranslateTransform), 0.0,
 				propertyChanged: OnTransformPropertyChanged);

--- a/src/Controls/src/Core/Shell/BackButtonBehavior.cs
+++ b/src/Controls/src/Core/Shell/BackButtonBehavior.cs
@@ -7,28 +7,29 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../../docs/Microsoft.Maui.Controls/BackButtonBehavior.xml" path="Type[@FullName='Microsoft.Maui.Controls.BackButtonBehavior']/Docs/*" />
 	public class BackButtonBehavior : BindableObject
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Controls/BackButtonBehavior.xml" path="//Member[@MemberName='CommandParameterProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="CommandParameter"/>.</summary>
 		public static readonly BindableProperty CommandParameterProperty =
 			BindableProperty.Create(nameof(CommandParameter), typeof(object), typeof(BackButtonBehavior), null, BindingMode.OneTime,
 				propertyChanged: OnCommandParameterChanged);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/BackButtonBehavior.xml" path="//Member[@MemberName='CommandProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Command"/>.</summary>
 		public static readonly BindableProperty CommandProperty =
 			BindableProperty.Create(nameof(Command), typeof(ICommand), typeof(BackButtonBehavior), null, BindingMode.OneTime,
 				propertyChanged: OnCommandChanged);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/BackButtonBehavior.xml" path="//Member[@MemberName='IconOverrideProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="IconOverride"/>.</summary>
 		public static readonly BindableProperty IconOverrideProperty =
 			BindableProperty.Create(nameof(IconOverride), typeof(ImageSource), typeof(BackButtonBehavior), null, BindingMode.OneTime);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/BackButtonBehavior.xml" path="//Member[@MemberName='IsEnabledProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="IsEnabled"/>.</summary>
 		public static readonly BindableProperty IsEnabledProperty =
 			BindableProperty.Create(nameof(IsEnabled), typeof(bool), typeof(BackButtonBehavior), true, BindingMode.OneTime);
 
+		/// <summary>Bindable property for <see cref="IsVisible"/>.</summary>
 		public static readonly BindableProperty IsVisibleProperty =
 			BindableProperty.Create(nameof(IsVisible), typeof(bool), typeof(BackButtonBehavior), true, BindingMode.OneTime);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/BackButtonBehavior.xml" path="//Member[@MemberName='TextOverrideProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="TextOverride"/>.</summary>
 		public static readonly BindableProperty TextOverrideProperty =
 			BindableProperty.Create(nameof(TextOverride), typeof(string), typeof(BackButtonBehavior), null, BindingMode.OneTime);
 

--- a/src/Controls/src/Core/Shell/BaseShellItem.cs
+++ b/src/Controls/src/Core/Shell/BaseShellItem.cs
@@ -35,27 +35,27 @@ namespace Microsoft.Maui.Controls
 
 		#endregion PropertyKeys
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/BaseShellItem.xml" path="//Member[@MemberName='FlyoutIconProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="FlyoutIcon"/>.</summary>
 		public static readonly BindableProperty FlyoutIconProperty =
 			BindableProperty.Create(nameof(FlyoutIcon), typeof(ImageSource), typeof(BaseShellItem), null, BindingMode.OneTime);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/BaseShellItem.xml" path="//Member[@MemberName='IconProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Icon"/>.</summary>
 		public static readonly BindableProperty IconProperty =
 			BindableProperty.Create(nameof(Icon), typeof(ImageSource), typeof(BaseShellItem), null, BindingMode.OneWay,
 				propertyChanged: OnIconChanged);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/BaseShellItem.xml" path="//Member[@MemberName='IsCheckedProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="IsChecked"/>.</summary>
 		public static readonly BindableProperty IsCheckedProperty = IsCheckedPropertyKey.BindableProperty;
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/BaseShellItem.xml" path="//Member[@MemberName='IsEnabledProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="IsEnabled"/>.</summary>
 		public static readonly BindableProperty IsEnabledProperty =
 			BindableProperty.Create(nameof(IsEnabled), typeof(bool), typeof(BaseShellItem), true, BindingMode.OneWay);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/BaseShellItem.xml" path="//Member[@MemberName='TitleProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Title"/>.</summary>
 		public static readonly BindableProperty TitleProperty =
 			BindableProperty.Create(nameof(Title), typeof(string), typeof(BaseShellItem), null, BindingMode.OneTime, propertyChanged: OnTitlePropertyChanged);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/BaseShellItem.xml" path="//Member[@MemberName='IsVisibleProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="IsVisible"/>.</summary>
 		public static readonly BindableProperty IsVisibleProperty =
 			BindableProperty.Create(nameof(IsVisible), typeof(bool), typeof(BaseShellItem), true);
 
@@ -322,6 +322,7 @@ namespace Microsoft.Maui.Controls
 		static readonly BindablePropertyKey WindowPropertyKey = BindableProperty.CreateReadOnly(
 			nameof(Window), typeof(Window), typeof(BaseShellItem), null);
 
+		/// <summary>Bindable property for <see cref="Window"/>.</summary>
 		public static readonly BindableProperty WindowProperty = WindowPropertyKey.BindableProperty;
 
 		public Window Window => (Window)GetValue(WindowProperty);

--- a/src/Controls/src/Core/Shell/NavigableElement.cs
+++ b/src/Controls/src/Core/Shell/NavigableElement.cs
@@ -12,10 +12,10 @@ namespace Microsoft.Maui.Controls
 		static readonly BindablePropertyKey NavigationPropertyKey =
 			BindableProperty.CreateReadOnly("Navigation", typeof(INavigation), typeof(VisualElement), default(INavigation));
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/NavigableElement.xml" path="//Member[@MemberName='NavigationProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Navigation"/>.</summary>
 		public static readonly BindableProperty NavigationProperty = NavigationPropertyKey.BindableProperty;
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/NavigableElement.xml" path="//Member[@MemberName='StyleProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Style"/>.</summary>
 		public static readonly BindableProperty StyleProperty =
 			BindableProperty.Create("Style", typeof(Style), typeof(VisualElement), default(Style),
 				propertyChanged: (bindable, oldvalue, newvalue) => ((NavigableElement)bindable)._mergedStyle.Style = (Style)newvalue);

--- a/src/Controls/src/Core/Shell/SearchHandler.cs
+++ b/src/Controls/src/Core/Shell/SearchHandler.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Maui.Controls
 		public event EventHandler<EventArgs> Focused;
 		public event EventHandler<EventArgs> Unfocused;
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/SearchHandler.xml" path="//Member[@MemberName='IsFocusedProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="IsFocused"/>.</summary>
 		public static readonly BindableProperty IsFocusedProperty = IsFocusedPropertyKey.BindableProperty;
 
 		/// <include file="../../../docs/Microsoft.Maui.Controls/SearchHandler.xml" path="//Member[@MemberName='IsFocused']/Docs/*" />
@@ -94,7 +94,7 @@ namespace Microsoft.Maui.Controls
 
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/SearchHandler.xml" path="//Member[@MemberName='KeyboardProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Keyboard"/>.</summary>
 		public static readonly BindableProperty KeyboardProperty = BindableProperty.Create(nameof(Keyboard), typeof(Keyboard), typeof(SearchHandler), Keyboard.Default, coerceValue: (o, v) => (Keyboard)v ?? Keyboard.Default);
 
 		/// <include file="../../../docs/Microsoft.Maui.Controls/SearchHandler.xml" path="//Member[@MemberName='Keyboard']/Docs/*" />
@@ -104,10 +104,10 @@ namespace Microsoft.Maui.Controls
 			set { SetValue(KeyboardProperty, value); }
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/SearchHandler.xml" path="//Member[@MemberName='HorizontalTextAlignmentProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="HorizontalTextAlignment"/>.</summary>
 		public static readonly BindableProperty HorizontalTextAlignmentProperty = TextAlignmentElement.HorizontalTextAlignmentProperty;
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/SearchHandler.xml" path="//Member[@MemberName='VerticalTextAlignmentProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="VerticalTextAlignment"/>.</summary>
 		public static readonly BindableProperty VerticalTextAlignmentProperty = TextAlignmentElement.VerticalTextAlignmentProperty;
 
 		void ITextAlignmentElement.OnHorizontalTextAlignmentPropertyChanged(TextAlignment oldValue, TextAlignment newValue)
@@ -128,10 +128,10 @@ namespace Microsoft.Maui.Controls
 			set { SetValue(TextAlignmentElement.VerticalTextAlignmentProperty, value); }
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/SearchHandler.xml" path="//Member[@MemberName='TextColorProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="TextColor"/>.</summary>
 		public static readonly BindableProperty TextColorProperty = TextElement.TextColorProperty;
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/SearchHandler.xml" path="//Member[@MemberName='CharacterSpacingProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="CharacterSpacing"/>.</summary>
 		public static readonly BindableProperty CharacterSpacingProperty = TextElement.CharacterSpacingProperty;
 
 		/// <include file="../../../docs/Microsoft.Maui.Controls/SearchHandler.xml" path="//Member[@MemberName='TextColor']/Docs/*" />
@@ -141,27 +141,28 @@ namespace Microsoft.Maui.Controls
 			set { SetValue(TextElement.TextColorProperty, value); }
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/SearchHandler.xml" path="//Member[@MemberName='CancelButtonColorProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="CancelButtonColor"/>.</summary>
 		public static readonly BindableProperty CancelButtonColorProperty = BindableProperty.Create(nameof(CancelButtonColor), typeof(Color), typeof(SearchHandler), default(Color));
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/SearchHandler.xml" path="//Member[@MemberName='FontFamilyProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="FontFamily"/>.</summary>
 		public static readonly BindableProperty FontFamilyProperty = FontElement.FontFamilyProperty;
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/SearchHandler.xml" path="//Member[@MemberName='FontSizeProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="FontSize"/>.</summary>
 		public static readonly BindableProperty FontSizeProperty = FontElement.FontSizeProperty;
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/SearchHandler.xml" path="//Member[@MemberName='FontAttributesProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="FontAttributes"/>.</summary>
 		public static readonly BindableProperty FontAttributesProperty = FontElement.FontAttributesProperty;
 
+		/// <summary>Bindable property for <see cref="FontAutoScalingEnabled"/>.</summary>
 		public static readonly BindableProperty FontAutoScalingEnabledProperty = FontElement.FontAutoScalingEnabledProperty;
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/SearchHandler.xml" path="//Member[@MemberName='PlaceholderProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Placeholder"/>.</summary>
 		public static readonly BindableProperty PlaceholderProperty = PlaceholderElement.PlaceholderProperty;
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/SearchHandler.xml" path="//Member[@MemberName='PlaceholderColorProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="PlaceholderColor"/>.</summary>
 		public static readonly BindableProperty PlaceholderColorProperty = PlaceholderElement.PlaceholderColorProperty;
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/SearchHandler.xml" path="//Member[@MemberName='TextTransformProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="TextTransform"/>.</summary>
 		public static readonly BindableProperty TextTransformProperty = TextElement.TextTransformProperty;
 
 		/// <include file="../../../docs/Microsoft.Maui.Controls/SearchHandler.xml" path="//Member[@MemberName='TextTransform']/Docs/*" />
@@ -255,7 +256,7 @@ namespace Microsoft.Maui.Controls
 			set => SetValue(PlaceholderElement.PlaceholderProperty, value);
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/SearchHandler.xml" path="//Member[@MemberName='BackgroundColorProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="BackgroundColor"/>.</summary>
 		public static readonly BindableProperty BackgroundColorProperty = BindableProperty.Create(nameof(BackgroundColor), typeof(Color), typeof(SearchHandler), null);
 
 		/// <include file="../../../docs/Microsoft.Maui.Controls/SearchHandler.xml" path="//Member[@MemberName='BackgroundColor']/Docs/*" />
@@ -304,99 +305,100 @@ namespace Microsoft.Maui.Controls
 			OnQueryConfirmed();
 		}
 
+		/// <summary>Bindable property for <see cref="AutomationId"/>.</summary>
 		public static readonly BindableProperty AutomationIdProperty = BindableProperty.Create(nameof(AutomationId), typeof(string), typeof(SearchHandler), null);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/SearchHandler.xml" path="//Member[@MemberName='ClearIconHelpTextProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="ClearIconHelpText"/>.</summary>
 		public static readonly BindableProperty ClearIconHelpTextProperty =
 			BindableProperty.Create(nameof(ClearIconHelpText), typeof(string), typeof(SearchHandler), null, BindingMode.OneTime,
 				propertyChanged: (b, o, n) => ((SearchHandler)b).UpdateAutomationProperties());
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/SearchHandler.xml" path="//Member[@MemberName='ClearIconNameProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="ClearIconName"/>.</summary>
 		public static readonly BindableProperty ClearIconNameProperty =
 			BindableProperty.Create(nameof(ClearIconName), typeof(string), typeof(SearchHandler), null, BindingMode.OneTime,
 				propertyChanged: (b, o, n) => ((SearchHandler)b).UpdateAutomationProperties());
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/SearchHandler.xml" path="//Member[@MemberName='ClearIconProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="ClearIcon"/>.</summary>
 		public static readonly BindableProperty ClearIconProperty =
 			BindableProperty.Create(nameof(ClearIcon), typeof(ImageSource), typeof(SearchHandler), null, BindingMode.OneTime);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/SearchHandler.xml" path="//Member[@MemberName='ClearPlaceholderCommandParameterProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="ClearPlaceholderCommandParameter"/>.</summary>
 		public static readonly BindableProperty ClearPlaceholderCommandParameterProperty =
 			BindableProperty.Create(nameof(ClearPlaceholderCommandParameter), typeof(object), typeof(SearchHandler), null,
 				propertyChanged: OnClearPlaceholderCommandParameterChanged);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/SearchHandler.xml" path="//Member[@MemberName='ClearPlaceholderCommandProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="ClearPlaceholderCommand"/>.</summary>
 		public static readonly BindableProperty ClearPlaceholderCommandProperty =
 			BindableProperty.Create(nameof(ClearPlaceholderCommand), typeof(ICommand), typeof(SearchHandler), null, BindingMode.OneTime,
 				propertyChanged: OnClearPlaceholderCommandChanged);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/SearchHandler.xml" path="//Member[@MemberName='ClearPlaceholderEnabledProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="ClearPlaceholderEnabled"/>.</summary>
 		public static readonly BindableProperty ClearPlaceholderEnabledProperty =
 			BindableProperty.Create(nameof(ClearPlaceholderEnabled), typeof(bool), typeof(SearchHandler), false);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/SearchHandler.xml" path="//Member[@MemberName='ClearPlaceholderHelpTextProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="ClearPlaceholderHelpText"/>.</summary>
 		public static readonly BindableProperty ClearPlaceholderHelpTextProperty =
 			BindableProperty.Create(nameof(ClearPlaceholderHelpText), typeof(string), typeof(SearchHandler), null, BindingMode.OneTime,
 				propertyChanged: (b, o, n) => ((SearchHandler)b).UpdateAutomationProperties());
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/SearchHandler.xml" path="//Member[@MemberName='ClearPlaceholderIconProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="ClearPlaceholderIcon"/>.</summary>
 		public static readonly BindableProperty ClearPlaceholderIconProperty =
 			BindableProperty.Create(nameof(ClearPlaceholderIcon), typeof(ImageSource), typeof(SearchHandler), null, BindingMode.OneTime,
 				propertyChanged: (b, o, n) => ((SearchHandler)b).UpdateAutomationProperties());
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/SearchHandler.xml" path="//Member[@MemberName='ClearPlaceholderNameProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="ClearPlaceholderName"/>.</summary>
 		public static readonly BindableProperty ClearPlaceholderNameProperty =
 			BindableProperty.Create(nameof(ClearPlaceholderName), typeof(string), typeof(SearchHandler), null, BindingMode.OneTime,
 				propertyChanged: (b, o, n) => ((SearchHandler)b).UpdateAutomationProperties());
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/SearchHandler.xml" path="//Member[@MemberName='CommandParameterProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="CommandParameter"/>.</summary>
 		public static readonly BindableProperty CommandParameterProperty =
 			BindableProperty.Create(nameof(CommandParameter), typeof(object), typeof(SearchHandler), null,
 				propertyChanged: OnCommandParameterChanged);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/SearchHandler.xml" path="//Member[@MemberName='CommandProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Command"/>.</summary>
 		public static readonly BindableProperty CommandProperty =
 			BindableProperty.Create(nameof(Command), typeof(ICommand), typeof(SearchHandler), null, BindingMode.OneTime,
 				propertyChanged: OnCommandChanged);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/SearchHandler.xml" path="//Member[@MemberName='DisplayMemberNameProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="DisplayMemberName"/>.</summary>
 		public static readonly BindableProperty DisplayMemberNameProperty =
 			BindableProperty.Create(nameof(DisplayMemberName), typeof(string), typeof(SearchHandler), null, BindingMode.OneTime);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/SearchHandler.xml" path="//Member[@MemberName='IsSearchEnabledProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="IsSearchEnabled"/>.</summary>
 		public static readonly BindableProperty IsSearchEnabledProperty =
 			BindableProperty.Create(nameof(IsSearchEnabled), typeof(bool), typeof(SearchHandler), true, BindingMode.OneWay);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/SearchHandler.xml" path="//Member[@MemberName='ItemsSourceProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="ItemsSource"/>.</summary>
 		public static readonly BindableProperty ItemsSourceProperty =
 			BindableProperty.Create(nameof(ItemsSource), typeof(IEnumerable), typeof(SearchHandler), null, BindingMode.OneTime,
 				propertyChanged: OnItemsSourceChanged);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/SearchHandler.xml" path="//Member[@MemberName='ItemTemplateProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="ItemTemplate"/>.</summary>
 		public static readonly BindableProperty ItemTemplateProperty =
 			BindableProperty.Create(nameof(ItemTemplate), typeof(DataTemplate), typeof(SearchHandler), null, BindingMode.OneTime);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/SearchHandler.xml" path="//Member[@MemberName='QueryIconHelpTextProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="QueryIconHelpText"/>.</summary>
 		public static readonly BindableProperty QueryIconHelpTextProperty =
 			BindableProperty.Create(nameof(QueryIconHelpText), typeof(string), typeof(SearchHandler), null, BindingMode.OneTime,
 				propertyChanged: (b, o, n) => ((SearchHandler)b).UpdateAutomationProperties());
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/SearchHandler.xml" path="//Member[@MemberName='QueryIconNameProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="QueryIconName"/>.</summary>
 		public static readonly BindableProperty QueryIconNameProperty =
 			BindableProperty.Create(nameof(QueryIconName), typeof(string), typeof(SearchHandler), null, BindingMode.OneTime,
 				propertyChanged: (b, o, n) => ((SearchHandler)b).UpdateAutomationProperties());
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/SearchHandler.xml" path="//Member[@MemberName='QueryIconProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="QueryIcon"/>.</summary>
 		public static readonly BindableProperty QueryIconProperty =
 			BindableProperty.Create(nameof(QueryIcon), typeof(ImageSource), typeof(SearchHandler), null, BindingMode.OneTime,
 				propertyChanged: (b, o, n) => ((SearchHandler)b).UpdateAutomationProperties());
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/SearchHandler.xml" path="//Member[@MemberName='QueryProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Query"/>.</summary>
 		public static readonly BindableProperty QueryProperty =
 			BindableProperty.Create(nameof(Query), typeof(string), typeof(SearchHandler), null, BindingMode.TwoWay,
 				propertyChanged: OnQueryChanged);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/SearchHandler.xml" path="//Member[@MemberName='SearchBoxVisibilityProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="SearchBoxVisibility"/>.</summary>
 		public static readonly BindableProperty SearchBoxVisibilityProperty =
 			BindableProperty.Create(nameof(SearchBoxVisibility), typeof(SearchBoxVisibility), typeof(SearchHandler), SearchBoxVisibility.Expanded, BindingMode.OneWay);
 
@@ -406,7 +408,7 @@ namespace Microsoft.Maui.Controls
 		/// <include file="../../../docs/Microsoft.Maui.Controls/SearchHandler.xml" path="//Member[@MemberName='SelectedItemProperty']/Docs/*" />
 		public static BindableProperty SelectedItemProperty = SelectedItemPropertyKey.BindableProperty;
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/SearchHandler.xml" path="//Member[@MemberName='ShowsResultsProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="ShowsResults"/>.</summary>
 		public static readonly BindableProperty ShowsResultsProperty =
 			BindableProperty.Create(nameof(ShowsResults), typeof(bool), typeof(SearchHandler), false, BindingMode.OneTime);
 

--- a/src/Controls/src/Core/Shell/Shell.cs
+++ b/src/Controls/src/Core/Shell/Shell.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Maui.Controls
 		/// <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='CurrentPage']/Docs/*" />
 		public Page CurrentPage => GetVisiblePage() as Page;
 
-		/// <summary>Bindable property for <see cref="BackButtonBehavior"/>.</summary>
+		/// <summary>Bindable property for attached property <c>BackButtonBehavior</c>.</summary>
 		public static readonly BindableProperty BackButtonBehaviorProperty =
 			BindableProperty.CreateAttached("BackButtonBehavior", typeof(BackButtonBehavior), typeof(Shell), null, BindingMode.OneTime,
 				propertyChanged: OnBackButonBehaviorPropertyChanged);
@@ -39,24 +39,24 @@ namespace Microsoft.Maui.Controls
 				SetInheritedBindingContext(newHandlerBehavior, bindable.BindingContext);
 		}
 
-		/// <summary>Bindable property for <see cref="PresentationMode"/>.</summary>
+		/// <summary>Bindable property for attached property <c>PresentationMode</c>.</summary>
 		public static readonly BindableProperty PresentationModeProperty = BindableProperty.CreateAttached("PresentationMode", typeof(PresentationMode), typeof(Shell), PresentationMode.Animated);
 
-		/// <summary>Bindable property for <see cref="FlyoutBehavior"/>.</summary>
+		/// <summary>Bindable property for attached property <c>FlyoutBehavior</c>.</summary>
 		public static readonly BindableProperty FlyoutBehaviorProperty =
 			BindableProperty.CreateAttached("FlyoutBehavior", typeof(FlyoutBehavior), typeof(Shell), FlyoutBehavior.Flyout,
 				propertyChanged: OnFlyoutBehaviorChanged);
 
-		/// <summary>Bindable property for <see cref="NavBarIsVisible"/>.</summary>
+		/// <summary>Bindable property for attached property <c>NavBarIsVisible</c>.</summary>
 		public static readonly BindableProperty NavBarIsVisibleProperty =
 			BindableProperty.CreateAttached("NavBarIsVisible", typeof(bool), typeof(Shell), true);
 
-		/// <summary>Bindable property for <see cref="NavBarHasShadow"/>.</summary>
+		/// <summary>Bindable property for attached property <c>NavBarHasShadow</c>.</summary>
 		public static readonly BindableProperty NavBarHasShadowProperty =
 			BindableProperty.CreateAttached("NavBarHasShadow", typeof(bool), typeof(Shell), default(bool),
 				defaultValueCreator: (b) => DeviceInfo.Platform == DevicePlatform.Android);
 
-		/// <summary>Bindable property for <see cref="SearchHandler"/>.</summary>
+		/// <summary>Bindable property for attached property <c>SearchHandler</c>.</summary>
 		public static readonly BindableProperty SearchHandlerProperty =
 			BindableProperty.CreateAttached("SearchHandler", typeof(SearchHandler), typeof(Shell), null, BindingMode.OneTime,
 				propertyChanged: OnSearchHandlerPropertyChanged);
@@ -69,7 +69,7 @@ namespace Microsoft.Maui.Controls
 				SetInheritedBindingContext(newHandler, bindable.BindingContext);
 		}
 
-		/// <summary>Bindable property for <see cref="FlyoutItemIsVisible"/>.</summary>
+		/// <summary>Bindable property for attached property <c>FlyoutItemIsVisible</c>.</summary>
 		public static readonly BindableProperty FlyoutItemIsVisibleProperty =
 			BindableProperty.CreateAttached("FlyoutItemIsVisible", typeof(bool), typeof(Shell), true, propertyChanged: OnFlyoutItemIsVisibleChanged);
 		public static bool GetFlyoutItemIsVisible(BindableObject obj) => (bool)obj.GetValue(FlyoutItemIsVisibleProperty);
@@ -83,15 +83,15 @@ namespace Microsoft.Maui.Controls
 					?.SendFlyoutItemsChanged();
 		}
 
-		/// <summary>Bindable property for <see cref="TabBarIsVisible"/>.</summary>
+		/// <summary>Bindable property for attached property <c>TabBarIsVisible</c>.</summary>
 		public static readonly BindableProperty TabBarIsVisibleProperty =
 			BindableProperty.CreateAttached("TabBarIsVisible", typeof(bool), typeof(Shell), true);
 
-		/// <summary>Bindable property for <see cref="TitleView"/>.</summary>
+		/// <summary>Bindable property for attached property <c>TitleView</c>.</summary>
 		public static readonly BindableProperty TitleViewProperty =
 			BindableProperty.CreateAttached("TitleView", typeof(View), typeof(Shell), null, propertyChanged: OnTitleViewChanged);
 
-		/// <summary>Bindable property for <see cref="MenuItemTemplate"/>.</summary>
+		/// <summary>Bindable property for attached property <c>MenuItemTemplate</c>.</summary>
 		public static readonly BindableProperty MenuItemTemplateProperty =
 			BindableProperty.CreateAttached(nameof(MenuItemTemplate), typeof(DataTemplate), typeof(Shell), null, BindingMode.OneTime);
 
@@ -100,7 +100,7 @@ namespace Microsoft.Maui.Controls
 		/// <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='SetMenuItemTemplate']/Docs/*" />
 		public static void SetMenuItemTemplate(BindableObject obj, DataTemplate menuItemTemplate) => obj.SetValue(MenuItemTemplateProperty, menuItemTemplate);
 
-		/// <summary>Bindable property for <see cref="ItemTemplate"/>.</summary>
+		/// <summary>Bindable property for attached property <c>ItemTemplate</c>.</summary>
 		public static readonly BindableProperty ItemTemplateProperty =
 			BindableProperty.CreateAttached(nameof(ItemTemplate), typeof(DataTemplate), typeof(Shell), null, BindingMode.OneTime);
 
@@ -173,62 +173,62 @@ namespace Microsoft.Maui.Controls
 			BindableProperty.CreateAttached("BackgroundColor", typeof(Color), typeof(Shell), null,
 				propertyChanged: OnShellAppearanceValueChanged);
 
-		/// <summary>Bindable property for <see cref="DisabledColor"/>.</summary>
+		/// <summary>Bindable property for attached property <c>DisabledColor</c>.</summary>
 		public static readonly BindableProperty DisabledColorProperty =
 			BindableProperty.CreateAttached("DisabledColor", typeof(Color), typeof(Shell), null,
 				propertyChanged: OnShellAppearanceValueChanged);
 
-		/// <summary>Bindable property for <see cref="ForegroundColor"/>.</summary>
+		/// <summary>Bindable property for attached property <c>ForegroundColor</c>.</summary>
 		public static readonly BindableProperty ForegroundColorProperty =
 			BindableProperty.CreateAttached("ForegroundColor", typeof(Color), typeof(Shell), null,
 				propertyChanged: OnShellAppearanceValueChanged);
 
-		/// <summary>Bindable property for <see cref="TabBarBackgroundColor"/>.</summary>
+		/// <summary>Bindable property for attached property <c>TabBarBackgroundColor</c>.</summary>
 		public static readonly BindableProperty TabBarBackgroundColorProperty =
 			BindableProperty.CreateAttached("TabBarBackgroundColor", typeof(Color), typeof(Shell), null,
 				propertyChanged: OnShellAppearanceValueChanged);
 
-		/// <summary>Bindable property for <see cref="TabBarDisabledColor"/>.</summary>
+		/// <summary>Bindable property for attached property <c>TabBarDisabledColor</c>.</summary>
 		public static readonly BindableProperty TabBarDisabledColorProperty =
 			BindableProperty.CreateAttached("TabBarDisabledColor", typeof(Color), typeof(Shell), null,
 				propertyChanged: OnShellAppearanceValueChanged);
 
-		/// <summary>Bindable property for <see cref="TabBarForegroundColor"/>.</summary>
+		/// <summary>Bindable property for attached property <c>TabBarForegroundColor</c>.</summary>
 		public static readonly BindableProperty TabBarForegroundColorProperty =
 			BindableProperty.CreateAttached("TabBarForegroundColor", typeof(Color), typeof(Shell), null,
 				propertyChanged: OnShellAppearanceValueChanged);
 
-		/// <summary>Bindable property for <see cref="TabBarTitleColor"/>.</summary>
+		/// <summary>Bindable property for attached property <c>TabBarTitleColor</c>.</summary>
 		public static readonly BindableProperty TabBarTitleColorProperty =
 			BindableProperty.CreateAttached("TabBarTitleColor", typeof(Color), typeof(Shell), null,
 				propertyChanged: OnShellAppearanceValueChanged);
 
-		/// <summary>Bindable property for <see cref="TabBarUnselectedColor"/>.</summary>
+		/// <summary>Bindable property for attached property <c>TabBarUnselectedColor</c>.</summary>
 		public static readonly BindableProperty TabBarUnselectedColorProperty =
 			BindableProperty.CreateAttached("TabBarUnselectedColor", typeof(Color), typeof(Shell), null,
 				propertyChanged: OnShellAppearanceValueChanged);
 
-		/// <summary>Bindable property for <see cref="TitleColor"/>.</summary>
+		/// <summary>Bindable property for attached property <c>TitleColor</c>.</summary>
 		public static readonly BindableProperty TitleColorProperty =
 			BindableProperty.CreateAttached("TitleColor", typeof(Color), typeof(Shell), null,
 				propertyChanged: OnShellAppearanceValueChanged);
 
-		/// <summary>Bindable property for <see cref="UnselectedColor"/>.</summary>
+		/// <summary>Bindable property for attached property <c>UnselectedColor</c>.</summary>
 		public static readonly BindableProperty UnselectedColorProperty =
 			BindableProperty.CreateAttached("UnselectedColor", typeof(Color), typeof(Shell), null,
 				propertyChanged: OnShellAppearanceValueChanged);
 
-		/// <summary>Bindable property for <see cref="FlyoutBackdrop"/>.</summary>
+		/// <summary>Bindable property for attached property <c>FlyoutBackdrop</c>.</summary>
 		public static readonly BindableProperty FlyoutBackdropProperty =
 			BindableProperty.CreateAttached("FlyoutBackdrop", typeof(Brush), typeof(Shell), Brush.Default,
 				propertyChanged: OnShellAppearanceValueChanged);
 
-		/// <summary>Bindable property for <see cref="FlyoutWidth"/>.</summary>
+		/// <summary>Bindable property for attached property <c>FlyoutWidth</c>.</summary>
 		public static readonly BindableProperty FlyoutWidthProperty =
 			BindableProperty.CreateAttached("FlyoutWidth", typeof(double), typeof(Shell), -1d,
 				propertyChanged: OnShellAppearanceValueChanged);
 
-		/// <summary>Bindable property for <see cref="FlyoutHeight"/>.</summary>
+		/// <summary>Bindable property for attached property <c>FlyoutHeight</c>.</summary>
 		public static readonly BindableProperty FlyoutHeightProperty =
 			BindableProperty.CreateAttached("FlyoutHeight", typeof(double), typeof(Shell), -1d,
 				propertyChanged: OnShellAppearanceValueChanged);

--- a/src/Controls/src/Core/Shell/Shell.cs
+++ b/src/Controls/src/Core/Shell/Shell.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Maui.Controls
 		/// <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='CurrentPage']/Docs/*" />
 		public Page CurrentPage => GetVisiblePage() as Page;
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='BackButtonBehaviorProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="BackButtonBehavior"/>.</summary>
 		public static readonly BindableProperty BackButtonBehaviorProperty =
 			BindableProperty.CreateAttached("BackButtonBehavior", typeof(BackButtonBehavior), typeof(Shell), null, BindingMode.OneTime,
 				propertyChanged: OnBackButonBehaviorPropertyChanged);
@@ -39,24 +39,24 @@ namespace Microsoft.Maui.Controls
 				SetInheritedBindingContext(newHandlerBehavior, bindable.BindingContext);
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='PresentationModeProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="PresentationMode"/>.</summary>
 		public static readonly BindableProperty PresentationModeProperty = BindableProperty.CreateAttached("PresentationMode", typeof(PresentationMode), typeof(Shell), PresentationMode.Animated);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='FlyoutBehaviorProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="FlyoutBehavior"/>.</summary>
 		public static readonly BindableProperty FlyoutBehaviorProperty =
 			BindableProperty.CreateAttached("FlyoutBehavior", typeof(FlyoutBehavior), typeof(Shell), FlyoutBehavior.Flyout,
 				propertyChanged: OnFlyoutBehaviorChanged);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='NavBarIsVisibleProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="NavBarIsVisible"/>.</summary>
 		public static readonly BindableProperty NavBarIsVisibleProperty =
 			BindableProperty.CreateAttached("NavBarIsVisible", typeof(bool), typeof(Shell), true);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='NavBarHasShadowProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="NavBarHasShadow"/>.</summary>
 		public static readonly BindableProperty NavBarHasShadowProperty =
 			BindableProperty.CreateAttached("NavBarHasShadow", typeof(bool), typeof(Shell), default(bool),
 				defaultValueCreator: (b) => DeviceInfo.Platform == DevicePlatform.Android);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='SearchHandlerProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="SearchHandler"/>.</summary>
 		public static readonly BindableProperty SearchHandlerProperty =
 			BindableProperty.CreateAttached("SearchHandler", typeof(SearchHandler), typeof(Shell), null, BindingMode.OneTime,
 				propertyChanged: OnSearchHandlerPropertyChanged);
@@ -69,6 +69,7 @@ namespace Microsoft.Maui.Controls
 				SetInheritedBindingContext(newHandler, bindable.BindingContext);
 		}
 
+		/// <summary>Bindable property for <see cref="FlyoutItemIsVisible"/>.</summary>
 		public static readonly BindableProperty FlyoutItemIsVisibleProperty =
 			BindableProperty.CreateAttached("FlyoutItemIsVisible", typeof(bool), typeof(Shell), true, propertyChanged: OnFlyoutItemIsVisibleChanged);
 		public static bool GetFlyoutItemIsVisible(BindableObject obj) => (bool)obj.GetValue(FlyoutItemIsVisibleProperty);
@@ -82,15 +83,15 @@ namespace Microsoft.Maui.Controls
 					?.SendFlyoutItemsChanged();
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='TabBarIsVisibleProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="TabBarIsVisible"/>.</summary>
 		public static readonly BindableProperty TabBarIsVisibleProperty =
 			BindableProperty.CreateAttached("TabBarIsVisible", typeof(bool), typeof(Shell), true);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='TitleViewProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="TitleView"/>.</summary>
 		public static readonly BindableProperty TitleViewProperty =
 			BindableProperty.CreateAttached("TitleView", typeof(View), typeof(Shell), null, propertyChanged: OnTitleViewChanged);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='MenuItemTemplateProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="MenuItemTemplate"/>.</summary>
 		public static readonly BindableProperty MenuItemTemplateProperty =
 			BindableProperty.CreateAttached(nameof(MenuItemTemplate), typeof(DataTemplate), typeof(Shell), null, BindingMode.OneTime);
 
@@ -99,7 +100,7 @@ namespace Microsoft.Maui.Controls
 		/// <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='SetMenuItemTemplate']/Docs/*" />
 		public static void SetMenuItemTemplate(BindableObject obj, DataTemplate menuItemTemplate) => obj.SetValue(MenuItemTemplateProperty, menuItemTemplate);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='ItemTemplateProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="ItemTemplate"/>.</summary>
 		public static readonly BindableProperty ItemTemplateProperty =
 			BindableProperty.CreateAttached(nameof(ItemTemplate), typeof(DataTemplate), typeof(Shell), null, BindingMode.OneTime);
 
@@ -172,60 +173,62 @@ namespace Microsoft.Maui.Controls
 			BindableProperty.CreateAttached("BackgroundColor", typeof(Color), typeof(Shell), null,
 				propertyChanged: OnShellAppearanceValueChanged);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='DisabledColorProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="DisabledColor"/>.</summary>
 		public static readonly BindableProperty DisabledColorProperty =
 			BindableProperty.CreateAttached("DisabledColor", typeof(Color), typeof(Shell), null,
 				propertyChanged: OnShellAppearanceValueChanged);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='ForegroundColorProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="ForegroundColor"/>.</summary>
 		public static readonly BindableProperty ForegroundColorProperty =
 			BindableProperty.CreateAttached("ForegroundColor", typeof(Color), typeof(Shell), null,
 				propertyChanged: OnShellAppearanceValueChanged);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='TabBarBackgroundColorProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="TabBarBackgroundColor"/>.</summary>
 		public static readonly BindableProperty TabBarBackgroundColorProperty =
 			BindableProperty.CreateAttached("TabBarBackgroundColor", typeof(Color), typeof(Shell), null,
 				propertyChanged: OnShellAppearanceValueChanged);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='TabBarDisabledColorProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="TabBarDisabledColor"/>.</summary>
 		public static readonly BindableProperty TabBarDisabledColorProperty =
 			BindableProperty.CreateAttached("TabBarDisabledColor", typeof(Color), typeof(Shell), null,
 				propertyChanged: OnShellAppearanceValueChanged);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='TabBarForegroundColorProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="TabBarForegroundColor"/>.</summary>
 		public static readonly BindableProperty TabBarForegroundColorProperty =
 			BindableProperty.CreateAttached("TabBarForegroundColor", typeof(Color), typeof(Shell), null,
 				propertyChanged: OnShellAppearanceValueChanged);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='TabBarTitleColorProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="TabBarTitleColor"/>.</summary>
 		public static readonly BindableProperty TabBarTitleColorProperty =
 			BindableProperty.CreateAttached("TabBarTitleColor", typeof(Color), typeof(Shell), null,
 				propertyChanged: OnShellAppearanceValueChanged);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='TabBarUnselectedColorProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="TabBarUnselectedColor"/>.</summary>
 		public static readonly BindableProperty TabBarUnselectedColorProperty =
 			BindableProperty.CreateAttached("TabBarUnselectedColor", typeof(Color), typeof(Shell), null,
 				propertyChanged: OnShellAppearanceValueChanged);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='TitleColorProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="TitleColor"/>.</summary>
 		public static readonly BindableProperty TitleColorProperty =
 			BindableProperty.CreateAttached("TitleColor", typeof(Color), typeof(Shell), null,
 				propertyChanged: OnShellAppearanceValueChanged);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='UnselectedColorProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="UnselectedColor"/>.</summary>
 		public static readonly BindableProperty UnselectedColorProperty =
 			BindableProperty.CreateAttached("UnselectedColor", typeof(Color), typeof(Shell), null,
 				propertyChanged: OnShellAppearanceValueChanged);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='FlyoutBackdropProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="FlyoutBackdrop"/>.</summary>
 		public static readonly BindableProperty FlyoutBackdropProperty =
 			BindableProperty.CreateAttached("FlyoutBackdrop", typeof(Brush), typeof(Shell), Brush.Default,
 				propertyChanged: OnShellAppearanceValueChanged);
 
+		/// <summary>Bindable property for <see cref="FlyoutWidth"/>.</summary>
 		public static readonly BindableProperty FlyoutWidthProperty =
 			BindableProperty.CreateAttached("FlyoutWidth", typeof(double), typeof(Shell), -1d,
 				propertyChanged: OnShellAppearanceValueChanged);
 
+		/// <summary>Bindable property for <see cref="FlyoutHeight"/>.</summary>
 		public static readonly BindableProperty FlyoutHeightProperty =
 			BindableProperty.CreateAttached("FlyoutHeight", typeof(double), typeof(Shell), -1d,
 				propertyChanged: OnShellAppearanceValueChanged);
@@ -722,65 +725,67 @@ namespace Microsoft.Maui.Controls
 			VisualDiagnostics.OnChildRemoved(this, element, oldLogicalIndex);
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='CurrentItemProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="CurrentItem"/>.</summary>
 		public static readonly BindableProperty CurrentItemProperty =
 			BindableProperty.Create(nameof(CurrentItem), typeof(ShellItem), typeof(Shell), null, BindingMode.TwoWay,
 				propertyChanging: OnCurrentItemChanging,
 				propertyChanged: OnCurrentItemChanged);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='CurrentStateProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="CurrentState"/>.</summary>
 		public static readonly BindableProperty CurrentStateProperty = CurrentStatePropertyKey.BindableProperty;
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='FlyoutBackgroundImageProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="FlyoutBackgroundImage"/>.</summary>
 		public static readonly BindableProperty FlyoutBackgroundImageProperty =
 			BindableProperty.Create(nameof(FlyoutBackgroundImage), typeof(ImageSource), typeof(Shell), default(ImageSource), BindingMode.OneTime);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='FlyoutBackgroundImageAspectProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="FlyoutBackgroundImageAspect"/>.</summary>
 		public static readonly BindableProperty FlyoutBackgroundImageAspectProperty =
 			BindableProperty.Create(nameof(FlyoutBackgroundImageAspect), typeof(Aspect), typeof(Shell), default(Aspect), BindingMode.OneTime);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='FlyoutBackgroundColorProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="FlyoutBackgroundColor"/>.</summary>
 		public static readonly BindableProperty FlyoutBackgroundColorProperty =
 			BindableProperty.Create(nameof(FlyoutBackgroundColor), typeof(Color), typeof(Shell), null, BindingMode.OneTime);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='FlyoutBackgroundProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="FlyoutBackground"/>.</summary>
 		public static readonly BindableProperty FlyoutBackgroundProperty =
 			BindableProperty.Create(nameof(FlyoutBackground), typeof(Brush), typeof(Shell), SolidColorBrush.Default, BindingMode.OneTime);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='FlyoutHeaderBehaviorProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="FlyoutHeaderBehavior"/>.</summary>
 		public static readonly BindableProperty FlyoutHeaderBehaviorProperty =
 			BindableProperty.Create(nameof(FlyoutHeaderBehavior), typeof(FlyoutHeaderBehavior), typeof(Shell), FlyoutHeaderBehavior.Default, BindingMode.OneTime);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='FlyoutHeaderProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="FlyoutHeader"/>.</summary>
 		public static readonly BindableProperty FlyoutHeaderProperty =
 			BindableProperty.Create(nameof(FlyoutHeader), typeof(object), typeof(Shell), null, BindingMode.OneTime,
 				propertyChanging: OnFlyoutHeaderChanging);
 
+		/// <summary>Bindable property for <see cref="FlyoutFooter"/>.</summary>
 		public static readonly BindableProperty FlyoutFooterProperty =
 			BindableProperty.Create(nameof(FlyoutFooter), typeof(object), typeof(Shell), null, BindingMode.OneTime,
 				propertyChanging: OnFlyoutFooterChanging);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='FlyoutHeaderTemplateProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="FlyoutHeaderTemplate"/>.</summary>
 		public static readonly BindableProperty FlyoutHeaderTemplateProperty =
 			BindableProperty.Create(nameof(FlyoutHeaderTemplate), typeof(DataTemplate), typeof(Shell), null, BindingMode.OneTime,
 				propertyChanging: OnFlyoutHeaderTemplateChanging);
 
+		/// <summary>Bindable property for <see cref="FlyoutFooterTemplate"/>.</summary>
 		public static readonly BindableProperty FlyoutFooterTemplateProperty =
 			BindableProperty.Create(nameof(FlyoutFooterTemplate), typeof(DataTemplate), typeof(Shell), null, BindingMode.OneTime,
 				propertyChanging: OnFlyoutFooterTemplateChanging);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='FlyoutIsPresentedProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="FlyoutIsPresented"/>.</summary>
 		public static readonly BindableProperty FlyoutIsPresentedProperty =
 			BindableProperty.Create(nameof(FlyoutIsPresented), typeof(bool), typeof(Shell), false, BindingMode.TwoWay);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='ItemsProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Items"/>.</summary>
 		public static readonly BindableProperty ItemsProperty = ItemsPropertyKey.BindableProperty;
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='FlyoutIconProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="FlyoutIcon"/>.</summary>
 		public static readonly BindableProperty FlyoutIconProperty =
 			BindableProperty.Create(nameof(FlyoutIcon), typeof(ImageSource), typeof(Shell), null);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='FlyoutVerticalScrollModeProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="FlyoutVerticalScrollMode"/>.</summary>
 		public static readonly BindableProperty FlyoutVerticalScrollModeProperty =
 			BindableProperty.Create(nameof(FlyoutVerticalScrollMode), typeof(ScrollMode), typeof(Shell), ScrollMode.Auto);
 
@@ -1578,9 +1583,12 @@ namespace Microsoft.Maui.Controls
 		#region Shell Flyout Content
 
 
+		/// <summary>Bindable property for <see cref="FlyoutContent"/>.</summary>
+
 		public static readonly BindableProperty FlyoutContentProperty =
 			BindableProperty.Create(nameof(FlyoutContent), typeof(object), typeof(Shell), null, BindingMode.OneTime, propertyChanging: OnFlyoutContentChanging);
 
+		/// <summary>Bindable property for <see cref="FlyoutContentTemplate"/>.</summary>
 		public static readonly BindableProperty FlyoutContentTemplateProperty =
 			BindableProperty.Create(nameof(FlyoutContentTemplate), typeof(DataTemplate), typeof(Shell), null, BindingMode.OneTime, propertyChanging: OnFlyoutContentTemplateChanging);
 

--- a/src/Controls/src/Core/Shell/ShellContent.cs
+++ b/src/Controls/src/Core/Shell/ShellContent.cs
@@ -17,14 +17,14 @@ namespace Microsoft.Maui.Controls
 			BindableProperty.CreateReadOnly(nameof(MenuItems), typeof(MenuItemCollection), typeof(ShellContent), null,
 				defaultValueCreator: bo => new MenuItemCollection());
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/ShellContent.xml" path="//Member[@MemberName='MenuItemsProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="MenuItems"/>.</summary>
 		public static readonly BindableProperty MenuItemsProperty = MenuItemsPropertyKey.BindableProperty;
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/ShellContent.xml" path="//Member[@MemberName='ContentProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Content"/>.</summary>
 		public static readonly BindableProperty ContentProperty =
 			BindableProperty.Create(nameof(Content), typeof(object), typeof(ShellContent), null, BindingMode.OneTime, propertyChanged: OnContentChanged);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/ShellContent.xml" path="//Member[@MemberName='ContentTemplateProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="ContentTemplate"/>.</summary>
 		public static readonly BindableProperty ContentTemplateProperty =
 			BindableProperty.Create(nameof(ContentTemplate), typeof(DataTemplate), typeof(ShellContent), null, BindingMode.OneTime);
 

--- a/src/Controls/src/Core/Shell/ShellGroupItem.cs
+++ b/src/Controls/src/Core/Shell/ShellGroupItem.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../../docs/Microsoft.Maui.Controls/ShellGroupItem.xml" path="Type[@FullName='Microsoft.Maui.Controls.ShellGroupItem']/Docs/*" />
 	public class ShellGroupItem : BaseShellItem
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Controls/ShellGroupItem.xml" path="//Member[@MemberName='FlyoutDisplayOptionsProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="FlyoutDisplayOptions"/>.</summary>
 		public static readonly BindableProperty FlyoutDisplayOptionsProperty =
 			BindableProperty.Create(nameof(FlyoutDisplayOptions), typeof(FlyoutDisplayOptions), typeof(ShellGroupItem), FlyoutDisplayOptions.AsSingleItem, BindingMode.OneTime, propertyChanged: OnFlyoutDisplayOptionsPropertyChanged);
 

--- a/src/Controls/src/Core/Shell/ShellItem.cs
+++ b/src/Controls/src/Core/Shell/ShellItem.cs
@@ -132,13 +132,14 @@ namespace Microsoft.Maui.Controls
 		}
 		#endregion
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/ShellItem.xml" path="//Member[@MemberName='CurrentItemProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="CurrentItem"/>.</summary>
 		public static readonly BindableProperty CurrentItemProperty =
 			BindableProperty.Create(nameof(CurrentItem), typeof(ShellSection), typeof(ShellItem), null, BindingMode.TwoWay,
 				propertyChanged: OnCurrentItemChanged);
 
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/ShellItem.xml" path="//Member[@MemberName='ItemsProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Items"/>.</summary>
+
 		public static readonly BindableProperty ItemsProperty = ItemsPropertyKey.BindableProperty;
 		Lazy<PlatformConfigurationRegistry<ShellItem>> _platformConfigurationRegistry;
 

--- a/src/Controls/src/Core/Shell/ShellSection.cs
+++ b/src/Controls/src/Core/Shell/ShellSection.cs
@@ -198,12 +198,12 @@ namespace Microsoft.Maui.Controls
 		}
 		#endregion
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/ShellSection.xml" path="//Member[@MemberName='CurrentItemProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="CurrentItem"/>.</summary>
 		public static readonly BindableProperty CurrentItemProperty =
 			BindableProperty.Create(nameof(CurrentItem), typeof(ShellContent), typeof(ShellSection), null, BindingMode.TwoWay,
 				propertyChanged: OnCurrentItemChanged);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/ShellSection.xml" path="//Member[@MemberName='ItemsProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Items"/>.</summary>
 		public static readonly BindableProperty ItemsProperty = ItemsPropertyKey.BindableProperty;
 
 		Page _displayedPage;

--- a/src/Controls/src/Core/Slider.cs
+++ b/src/Controls/src/Core/Slider.cs
@@ -1,4 +1,4 @@
-﻿#nullable disable
+#nullable disable
 using System;
 using System.Windows.Input;
 using Microsoft.Maui.Graphics;
@@ -8,7 +8,7 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../docs/Microsoft.Maui.Controls/Slider.xml" path="Type[@FullName='Microsoft.Maui.Controls.Slider']/Docs/*" />
 	public partial class Slider : View, ISliderController, IElementConfiguration<Slider>
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/Slider.xml" path="//Member[@MemberName='MinimumProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Minimum"/>.</summary>
 		public static readonly BindableProperty MinimumProperty = BindableProperty.Create(nameof(Minimum), typeof(double), typeof(Slider), 0d, coerceValue: (bindable, value) =>
 		{
 			var slider = (Slider)bindable;
@@ -16,7 +16,7 @@ namespace Microsoft.Maui.Controls
 			return value;
 		});
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Slider.xml" path="//Member[@MemberName='MaximumProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Maximum"/>.</summary>
 		public static readonly BindableProperty MaximumProperty = BindableProperty.Create(nameof(Maximum), typeof(double), typeof(Slider), 1d, coerceValue: (bindable, value) =>
 		{
 			var slider = (Slider)bindable;
@@ -24,7 +24,7 @@ namespace Microsoft.Maui.Controls
 			return value;
 		});
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Slider.xml" path="//Member[@MemberName='ValueProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Value"/>.</summary>
 		public static readonly BindableProperty ValueProperty = BindableProperty.Create(nameof(Value), typeof(double), typeof(Slider), 0d, BindingMode.TwoWay, coerceValue: (bindable, value) =>
 		{
 			var slider = (Slider)bindable;
@@ -35,22 +35,22 @@ namespace Microsoft.Maui.Controls
 			slider.ValueChanged?.Invoke(slider, new ValueChangedEventArgs((double)oldValue, (double)newValue));
 		});
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Slider.xml" path="//Member[@MemberName='MinimumTrackColorProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="MinimumTrackColor"/>.</summary>
 		public static readonly BindableProperty MinimumTrackColorProperty = BindableProperty.Create(nameof(MinimumTrackColor), typeof(Color), typeof(Slider), null);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Slider.xml" path="//Member[@MemberName='MaximumTrackColorProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="MaximumTrackColor"/>.</summary>
 		public static readonly BindableProperty MaximumTrackColorProperty = BindableProperty.Create(nameof(MaximumTrackColor), typeof(Color), typeof(Slider), null);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Slider.xml" path="//Member[@MemberName='ThumbColorProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="ThumbColor"/>.</summary>
 		public static readonly BindableProperty ThumbColorProperty = BindableProperty.Create(nameof(ThumbColor), typeof(Color), typeof(Slider), null);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Slider.xml" path="//Member[@MemberName='ThumbImageSourceProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="ThumbImageSource"/>.</summary>
 		public static readonly BindableProperty ThumbImageSourceProperty = BindableProperty.Create(nameof(ThumbImageSource), typeof(ImageSource), typeof(Slider), default(ImageSource));
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Slider.xml" path="//Member[@MemberName='DragStartedCommandProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="DragStartedCommand"/>.</summary>
 		public static readonly BindableProperty DragStartedCommandProperty = BindableProperty.Create(nameof(DragStartedCommand), typeof(ICommand), typeof(Slider), default(ICommand));
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Slider.xml" path="//Member[@MemberName='DragCompletedCommandProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="DragCompletedCommand"/>.</summary>
 		public static readonly BindableProperty DragCompletedCommandProperty = BindableProperty.Create(nameof(DragCompletedCommand), typeof(ICommand), typeof(Slider), default(ICommand));
 
 		readonly Lazy<PlatformConfigurationRegistry<Slider>> _platformConfigurationRegistry;

--- a/src/Controls/src/Core/SolidColorBrush.cs
+++ b/src/Controls/src/Core/SolidColorBrush.cs
@@ -1,4 +1,4 @@
-﻿#nullable disable
+#nullable disable
 using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Controls
@@ -29,7 +29,7 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/SolidColorBrush.xml" path="//Member[@MemberName='ColorProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Color"/>.</summary>
 		public static readonly BindableProperty ColorProperty = BindableProperty.Create(
 			nameof(Color), typeof(Color), typeof(SolidColorBrush), null);
 

--- a/src/Controls/src/Core/Span.cs
+++ b/src/Controls/src/Core/Span.cs
@@ -17,14 +17,14 @@ namespace Microsoft.Maui.Controls
 			_mergedStyle = new MergedStyle(GetType(), this);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Span.xml" path="//Member[@MemberName='StyleProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Style"/>.</summary>
 		public static readonly BindableProperty StyleProperty = BindableProperty.Create(nameof(Style), typeof(Style), typeof(Span), default(Style),
 			propertyChanged: (bindable, oldvalue, newvalue) => ((Span)bindable)._mergedStyle.Style = (Style)newvalue, defaultBindingMode: BindingMode.OneWay);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Span.xml" path="//Member[@MemberName='TextDecorationsProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="TextDecorations"/>.</summary>
 		public static readonly BindableProperty TextDecorationsProperty = DecorableTextElement.TextDecorationsProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Span.xml" path="//Member[@MemberName='TextTransformProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="TextTransform"/>.</summary>
 		public static readonly BindableProperty TextTransformProperty = TextElement.TextTransformProperty;
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/Span.xml" path="//Member[@MemberName='Style']/Docs/*" />
@@ -34,7 +34,7 @@ namespace Microsoft.Maui.Controls
 			set { SetValue(StyleProperty, value); }
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Span.xml" path="//Member[@MemberName='BackgroundColorProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="BackgroundColor"/>.</summary>
 		public static readonly BindableProperty BackgroundColorProperty
 			= BindableProperty.Create(nameof(BackgroundColor), typeof(Color), typeof(Span), default(Color), defaultBindingMode: BindingMode.OneWay);
 
@@ -45,7 +45,7 @@ namespace Microsoft.Maui.Controls
 			set { SetValue(BackgroundColorProperty, value); }
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Span.xml" path="//Member[@MemberName='TextColorProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="TextColor"/>.</summary>
 		public static readonly BindableProperty TextColorProperty = TextElement.TextColorProperty;
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/Span.xml" path="//Member[@MemberName='TextColor']/Docs/*" />
@@ -55,7 +55,7 @@ namespace Microsoft.Maui.Controls
 			set { SetValue(TextElement.TextColorProperty, value); }
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Span.xml" path="//Member[@MemberName='CharacterSpacingProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="CharacterSpacing"/>.</summary>
 		public static readonly BindableProperty CharacterSpacingProperty = TextElement.CharacterSpacingProperty;
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/Span.xml" path="//Member[@MemberName='CharacterSpacing']/Docs/*" />
@@ -76,7 +76,7 @@ namespace Microsoft.Maui.Controls
 		public virtual string UpdateFormsText(string source, TextTransform textTransform)
 			=> TextTransformUtilites.GetTransformedText(source, textTransform);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Span.xml" path="//Member[@MemberName='TextProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Text"/>.</summary>
 		public static readonly BindableProperty TextProperty
 			= BindableProperty.Create(nameof(Text), typeof(string), typeof(Span), "", defaultBindingMode: BindingMode.OneWay);
 
@@ -87,18 +87,19 @@ namespace Microsoft.Maui.Controls
 			set { SetValue(TextProperty, value); }
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Span.xml" path="//Member[@MemberName='FontFamilyProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="FontFamily"/>.</summary>
 		public static readonly BindableProperty FontFamilyProperty = FontElement.FontFamilyProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Span.xml" path="//Member[@MemberName='FontSizeProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="FontSize"/>.</summary>
 		public static readonly BindableProperty FontSizeProperty = FontElement.FontSizeProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Span.xml" path="//Member[@MemberName='FontAttributesProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="FontAttributes"/>.</summary>
 		public static readonly BindableProperty FontAttributesProperty = FontElement.FontAttributesProperty;
 
+		/// <summary>Bindable property for <see cref="FontAutoScalingEnabled"/>.</summary>
 		public static readonly BindableProperty FontAutoScalingEnabledProperty = FontElement.FontAutoScalingEnabledProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Span.xml" path="//Member[@MemberName='LineHeightProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="LineHeight"/>.</summary>
 		public static readonly BindableProperty LineHeightProperty = LineHeightElement.LineHeightProperty;
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/Span.xml" path="//Member[@MemberName='FontAttributes']/Docs/*" />

--- a/src/Controls/src/Core/StateTrigger.cs
+++ b/src/Controls/src/Core/StateTrigger.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Maui.Controls
 			set => SetValue(IsActiveProperty, value);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/StateTrigger.xml" path="//Member[@MemberName='IsActiveProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="IsActive"/>.</summary>
 		public static readonly BindableProperty IsActiveProperty =
 			BindableProperty.Create(nameof(IsActive), typeof(bool), typeof(StateTrigger), default(bool),
 				propertyChanged: OnIsActiveChanged);

--- a/src/Controls/src/Core/Stepper.cs
+++ b/src/Controls/src/Core/Stepper.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../docs/Microsoft.Maui.Controls/Stepper.xml" path="Type[@FullName='Microsoft.Maui.Controls.Stepper']/Docs/*" />
 	public partial class Stepper : View, IElementConfiguration<Stepper>, IStepper
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/Stepper.xml" path="//Member[@MemberName='MaximumProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Maximum"/>.</summary>
 		public static readonly BindableProperty MaximumProperty = BindableProperty.Create(nameof(Maximum), typeof(double), typeof(Stepper), 100.0,
 			validateValue: (bindable, value) => (double)value > ((Stepper)bindable).Minimum,
 			coerceValue: (bindable, value) =>
@@ -18,7 +18,7 @@ namespace Microsoft.Maui.Controls
 				return value;
 			});
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Stepper.xml" path="//Member[@MemberName='MinimumProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Minimum"/>.</summary>
 		public static readonly BindableProperty MinimumProperty = BindableProperty.Create(nameof(Minimum), typeof(double), typeof(Stepper), 0.0,
 			validateValue: (bindable, value) => (double)value < ((Stepper)bindable).Maximum,
 			coerceValue: (bindable, value) =>
@@ -28,7 +28,7 @@ namespace Microsoft.Maui.Controls
 				return value;
 			});
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Stepper.xml" path="//Member[@MemberName='ValueProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Value"/>.</summary>
 		public static readonly BindableProperty ValueProperty = BindableProperty.Create(nameof(Value), typeof(double), typeof(Stepper), 0.0, BindingMode.TwoWay,
 			coerceValue: (bindable, value) =>
 			{
@@ -44,7 +44,7 @@ namespace Microsoft.Maui.Controls
 		int digits = 4;
 		//'-log10(increment) + 4' as rounding digits gives us 4 significant decimal digits after the most significant one.
 		//If your increment uses more than 4 significant digits, you're holding it wrong.
-		/// <include file="../../docs/Microsoft.Maui.Controls/Stepper.xml" path="//Member[@MemberName='IncrementProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Increment"/>.</summary>
 		public static readonly BindableProperty IncrementProperty = BindableProperty.Create(nameof(Increment), typeof(double), typeof(Stepper), 1.0,
 			propertyChanged: (b, o, n) => { ((Stepper)b).digits = (int)(-Math.Log10((double)n) + 4).Clamp(1, 15); });
 

--- a/src/Controls/src/Core/StreamImageSource.cs
+++ b/src/Controls/src/Core/StreamImageSource.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../docs/Microsoft.Maui.Controls/StreamImageSource.xml" path="Type[@FullName='Microsoft.Maui.Controls.StreamImageSource']/Docs/*" />
 	public partial class StreamImageSource : ImageSource, IStreamImageSource
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/StreamImageSource.xml" path="//Member[@MemberName='StreamProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Stream"/>.</summary>
 		public static readonly BindableProperty StreamProperty = BindableProperty.Create("Stream", typeof(Func<CancellationToken, Task<Stream>>), typeof(StreamImageSource),
 			default(Func<CancellationToken, Task<Stream>>));
 

--- a/src/Controls/src/Core/SwipeGestureRecognizer.cs
+++ b/src/Controls/src/Core/SwipeGestureRecognizer.cs
@@ -12,16 +12,16 @@ namespace Microsoft.Maui.Controls
 
 		double _totalX, _totalY;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/SwipeGestureRecognizer.xml" path="//Member[@MemberName='CommandProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Command"/>.</summary>
 		public static readonly BindableProperty CommandProperty = BindableProperty.Create(nameof(Command), typeof(ICommand), typeof(SwipeGestureRecognizer), null);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/SwipeGestureRecognizer.xml" path="//Member[@MemberName='CommandParameterProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="CommandParameter"/>.</summary>
 		public static readonly BindableProperty CommandParameterProperty = BindableProperty.Create("CommandParameter", typeof(object), typeof(SwipeGestureRecognizer), null);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/SwipeGestureRecognizer.xml" path="//Member[@MemberName='DirectionProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Direction"/>.</summary>
 		public static readonly BindableProperty DirectionProperty = BindableProperty.Create("Direction", typeof(SwipeDirection), typeof(SwipeGestureRecognizer), default(SwipeDirection));
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/SwipeGestureRecognizer.xml" path="//Member[@MemberName='ThresholdProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Threshold"/>.</summary>
 		public static readonly BindableProperty ThresholdProperty = BindableProperty.Create("Threshold", typeof(uint), typeof(SwipeGestureRecognizer), DefaultSwipeThreshold);
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/SwipeGestureRecognizer.xml" path="//Member[@MemberName='Command']/Docs/*" />

--- a/src/Controls/src/Core/SwipeItem.cs
+++ b/src/Controls/src/Core/SwipeItem.cs
@@ -1,4 +1,4 @@
-﻿#nullable disable
+#nullable disable
 using System;
 using System.ComponentModel;
 using Microsoft.Maui.Graphics;
@@ -8,10 +8,10 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../docs/Microsoft.Maui.Controls/SwipeItem.xml" path="Type[@FullName='Microsoft.Maui.Controls.SwipeItem']/Docs/*" />
 	public partial class SwipeItem : MenuItem, Controls.ISwipeItem
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/SwipeItem.xml" path="//Member[@MemberName='BackgroundColorProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="BackgroundColor"/>.</summary>
 		public static readonly BindableProperty BackgroundColorProperty = BindableProperty.Create(nameof(BackgroundColor), typeof(Color), typeof(SwipeItem), null);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/SwipeItem.xml" path="//Member[@MemberName='IsVisibleProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="IsVisible"/>.</summary>
 		public static readonly BindableProperty IsVisibleProperty = BindableProperty.Create(nameof(IsVisible), typeof(bool), typeof(SwipeItem), true);
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/SwipeItem.xml" path="//Member[@MemberName='BackgroundColor']/Docs/*" />

--- a/src/Controls/src/Core/SwipeItemView.cs
+++ b/src/Controls/src/Core/SwipeItemView.cs
@@ -9,12 +9,12 @@ namespace Microsoft.Maui.Controls
 	[ContentProperty(nameof(Content))]
 	public partial class SwipeItemView : ContentView, Controls.ISwipeItem, Maui.ISwipeItemView
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/SwipeItemView.xml" path="//Member[@MemberName='CommandProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Command"/>.</summary>
 		public static readonly BindableProperty CommandProperty = BindableProperty.Create(nameof(Command), typeof(ICommand), typeof(SwipeItemView), null,
 			propertyChanging: (bo, o, n) => ((SwipeItemView)bo).OnCommandChanging(),
 			propertyChanged: (bo, o, n) => ((SwipeItemView)bo).OnCommandChanged());
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/SwipeItemView.xml" path="//Member[@MemberName='CommandParameterProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="CommandParameter"/>.</summary>
 		public static readonly BindableProperty CommandParameterProperty = BindableProperty.Create(nameof(CommandParameter), typeof(object), typeof(SwipeItemView), null,
 			propertyChanged: (bo, o, n) => ((SwipeItemView)bo).OnCommandParameterChanged());
 

--- a/src/Controls/src/Core/SwipeItems.cs
+++ b/src/Controls/src/Core/SwipeItems.cs
@@ -26,9 +26,9 @@ namespace Microsoft.Maui.Controls
 
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/SwipeItems.xml" path="//Member[@MemberName='ModeProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Mode"/>.</summary>
 		public static readonly BindableProperty ModeProperty = BindableProperty.Create(nameof(Mode), typeof(SwipeMode), typeof(SwipeItems), SwipeMode.Reveal);
-		/// <include file="../../docs/Microsoft.Maui.Controls/SwipeItems.xml" path="//Member[@MemberName='SwipeBehaviorOnInvokedProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="SwipeBehaviorOnInvoked"/>.</summary>
 		public static readonly BindableProperty SwipeBehaviorOnInvokedProperty = BindableProperty.Create(nameof(SwipeBehaviorOnInvoked), typeof(SwipeBehaviorOnInvoked), typeof(SwipeItems), SwipeBehaviorOnInvoked.Auto);
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/SwipeItems.xml" path="//Member[@MemberName='Mode']/Docs/*" />

--- a/src/Controls/src/Core/SwipeView.cs
+++ b/src/Controls/src/Core/SwipeView.cs
@@ -17,26 +17,26 @@ namespace Microsoft.Maui.Controls
 			_platformConfigurationRegistry = new Lazy<PlatformConfigurationRegistry<SwipeView>>(() => new PlatformConfigurationRegistry<SwipeView>(this));
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/SwipeView.xml" path="//Member[@MemberName='ThresholdProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Threshold"/>.</summary>
 		public static readonly BindableProperty ThresholdProperty =
 			BindableProperty.Create(nameof(Threshold), typeof(double), typeof(SwipeView), default(double));
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/SwipeView.xml" path="//Member[@MemberName='LeftItemsProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="LeftItems"/>.</summary>
 		public static readonly BindableProperty LeftItemsProperty =
 			BindableProperty.Create(nameof(LeftItems), typeof(SwipeItems), typeof(SwipeView), null, BindingMode.OneWay, null, defaultValueCreator: SwipeItemsDefaultValueCreator,
 				propertyChanged: OnSwipeItemsChanged);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/SwipeView.xml" path="//Member[@MemberName='RightItemsProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="RightItems"/>.</summary>
 		public static readonly BindableProperty RightItemsProperty =
 			BindableProperty.Create(nameof(RightItems), typeof(SwipeItems), typeof(SwipeView), null, BindingMode.OneWay, null, defaultValueCreator: SwipeItemsDefaultValueCreator,
 				propertyChanged: OnSwipeItemsChanged);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/SwipeView.xml" path="//Member[@MemberName='TopItemsProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="TopItems"/>.</summary>
 		public static readonly BindableProperty TopItemsProperty =
 			BindableProperty.Create(nameof(TopItems), typeof(SwipeItems), typeof(SwipeView), null, BindingMode.OneWay, null, defaultValueCreator: SwipeItemsDefaultValueCreator,
 				propertyChanged: OnSwipeItemsChanged);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/SwipeView.xml" path="//Member[@MemberName='BottomItemsProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="BottomItems"/>.</summary>
 		public static readonly BindableProperty BottomItemsProperty =
 			BindableProperty.Create(nameof(BottomItems), typeof(SwipeItems), typeof(SwipeView), null, BindingMode.OneWay, null, defaultValueCreator: SwipeItemsDefaultValueCreator,
 				propertyChanged: OnSwipeItemsChanged);

--- a/src/Controls/src/Core/Switch.cs
+++ b/src/Controls/src/Core/Switch.cs
@@ -1,4 +1,4 @@
-﻿#nullable disable
+#nullable disable
 using System;
 using Microsoft.Maui.Graphics;
 
@@ -12,7 +12,7 @@ namespace Microsoft.Maui.Controls
 		/// <include file="../../docs/Microsoft.Maui.Controls/Switch.xml" path="//Member[@MemberName='SwitchOffVisualState']/Docs/*" />
 		public const string SwitchOffVisualState = "Off";
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Switch.xml" path="//Member[@MemberName='IsToggledProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="IsToggled"/>.</summary>
 		public static readonly BindableProperty IsToggledProperty = BindableProperty.Create(nameof(IsToggled), typeof(bool), typeof(Switch), false, propertyChanged: (bindable, oldValue, newValue) =>
 		{
 			((Switch)bindable).Toggled?.Invoke(bindable, new ToggledEventArgs((bool)newValue));
@@ -21,14 +21,14 @@ namespace Microsoft.Maui.Controls
 
 		}, defaultBindingMode: BindingMode.TwoWay);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Switch.xml" path="//Member[@MemberName='OnColorProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="OnColor"/>.</summary>
 		public static readonly BindableProperty OnColorProperty = BindableProperty.Create(nameof(OnColor), typeof(Color), typeof(Switch), null,
 			propertyChanged: (bindable, oldValue, newValue) =>
 			{
 				((IView)bindable)?.Handler?.UpdateValue(nameof(ISwitch.TrackColor));
 			});
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Switch.xml" path="//Member[@MemberName='ThumbColorProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="ThumbColor"/>.</summary>
 		public static readonly BindableProperty ThumbColorProperty = BindableProperty.Create(nameof(ThumbColor), typeof(Color), typeof(Switch), null);
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/Switch.xml" path="//Member[@MemberName='OnColor']/Docs/*" />

--- a/src/Controls/src/Core/TabbedPage.cs
+++ b/src/Controls/src/Core/TabbedPage.cs
@@ -8,19 +8,19 @@ namespace Microsoft.Maui.Controls
 	[ContentProperty(nameof(Children))]
 	public partial class TabbedPage : MultiPage<Page>, IBarElement, IElementConfiguration<TabbedPage>
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/TabbedPage.xml" path="//Member[@MemberName='BarBackgroundColorProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="BarBackgroundColor"/>.</summary>
 		public static readonly BindableProperty BarBackgroundColorProperty = BarElement.BarBackgroundColorProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/TabbedPage.xml" path="//Member[@MemberName='BarBackgroundProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="BarBackground"/>.</summary>
 		public static readonly BindableProperty BarBackgroundProperty = BarElement.BarBackgroundProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/TabbedPage.xml" path="//Member[@MemberName='BarTextColorProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="BarTextColor"/>.</summary>
 		public static readonly BindableProperty BarTextColorProperty = BarElement.BarTextColorProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/TabbedPage.xml" path="//Member[@MemberName='UnselectedTabColorProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="UnselectedTabColor"/>.</summary>
 		public static readonly BindableProperty UnselectedTabColorProperty = BindableProperty.Create(nameof(UnselectedTabColor), typeof(Color), typeof(TabbedPage), default(Color));
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/TabbedPage.xml" path="//Member[@MemberName='SelectedTabColorProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="SelectedTabColor"/>.</summary>
 		public static readonly BindableProperty SelectedTabColorProperty = BindableProperty.Create(nameof(SelectedTabColor), typeof(Color), typeof(TabbedPage), default(Color));
 
 		readonly Lazy<PlatformConfigurationRegistry<TabbedPage>> _platformConfigurationRegistry;

--- a/src/Controls/src/Core/TableSectionBase.cs
+++ b/src/Controls/src/Core/TableSectionBase.cs
@@ -1,4 +1,4 @@
-﻿#nullable disable
+#nullable disable
 using System;
 using Microsoft.Maui.Graphics;
 
@@ -7,9 +7,9 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../docs/Microsoft.Maui.Controls/TableSectionBase.xml" path="Type[@FullName='Microsoft.Maui.Controls.TableSectionBase']/Docs/*" />
 	public abstract class TableSectionBase : BindableObject
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/TableSectionBase.xml" path="//Member[@MemberName='TitleProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Title"/>.</summary>
 		public static readonly BindableProperty TitleProperty = BindableProperty.Create("Title", typeof(string), typeof(TableSectionBase), null);
-		/// <include file="../../docs/Microsoft.Maui.Controls/TableSectionBase.xml" path="//Member[@MemberName='TextColorProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="TextColor"/>.</summary>
 		public static readonly BindableProperty TextColorProperty = BindableProperty.Create(nameof(TextColor), typeof(Color), typeof(TableSectionBase), null);
 
 		/// <summary>

--- a/src/Controls/src/Core/TableView.cs
+++ b/src/Controls/src/Core/TableView.cs
@@ -15,10 +15,10 @@ namespace Microsoft.Maui.Controls
 	[ContentProperty(nameof(Root))]
 	public class TableView : View, ITableViewController, IElementConfiguration<TableView>, IVisualTreeElement
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/TableView.xml" path="//Member[@MemberName='RowHeightProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="RowHeight"/>.</summary>
 		public static readonly BindableProperty RowHeightProperty = BindableProperty.Create("RowHeight", typeof(int), typeof(TableView), -1);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/TableView.xml" path="//Member[@MemberName='HasUnevenRowsProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="HasUnevenRows"/>.</summary>
 		public static readonly BindableProperty HasUnevenRowsProperty = BindableProperty.Create("HasUnevenRows", typeof(bool), typeof(TableView), false);
 
 		readonly Lazy<PlatformConfigurationRegistry<TableView>> _platformConfigurationRegistry;

--- a/src/Controls/src/Core/TapGestureRecognizer.cs
+++ b/src/Controls/src/Core/TapGestureRecognizer.cs
@@ -7,15 +7,16 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../docs/Microsoft.Maui.Controls/TapGestureRecognizer.xml" path="Type[@FullName='Microsoft.Maui.Controls.TapGestureRecognizer']/Docs/*" />
 	public sealed class TapGestureRecognizer : GestureRecognizer
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/TapGestureRecognizer.xml" path="//Member[@MemberName='CommandProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Command"/>.</summary>
 		public static readonly BindableProperty CommandProperty = BindableProperty.Create("Command", typeof(ICommand), typeof(TapGestureRecognizer), null);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/TapGestureRecognizer.xml" path="//Member[@MemberName='CommandParameterProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="CommandParameter"/>.</summary>
 		public static readonly BindableProperty CommandParameterProperty = BindableProperty.Create(nameof(CommandParameter), typeof(object), typeof(TapGestureRecognizer), null);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/TapGestureRecognizer.xml" path="//Member[@MemberName='NumberOfTapsRequiredProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="NumberOfTapsRequired"/>.</summary>
 		public static readonly BindableProperty NumberOfTapsRequiredProperty = BindableProperty.Create("NumberOfTapsRequired", typeof(int), typeof(TapGestureRecognizer), 1);
 
+		/// <summary>Bindable property for <see cref="Buttons"/>.</summary>
 		public static readonly BindableProperty ButtonsProperty = BindableProperty.Create(nameof(Buttons), typeof(ButtonsMask), typeof(TapGestureRecognizer), ButtonsMask.Primary);
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/TapGestureRecognizer.xml" path="//Member[@MemberName='.ctor'][1]/Docs/*" />

--- a/src/Controls/src/Core/TemplatedItemsList.cs
+++ b/src/Controls/src/Core/TemplatedItemsList.cs
@@ -19,8 +19,10 @@ namespace Microsoft.Maui.Controls.Internals
 												where TView : BindableObject, IItemsView<TItem>
 												where TItem : BindableObject
 	{
+		/// <summary>Bindable property for <see cref="Name"/>.</summary>
 		public static readonly BindableProperty NameProperty = BindableProperty.Create("Name", typeof(string), typeof(TemplatedItemsList<TView, TItem>), null);
 
+		/// <summary>Bindable property for <see cref="ShortName"/>.</summary>
 		public static readonly BindableProperty ShortNameProperty = BindableProperty.Create("ShortName", typeof(string), typeof(TemplatedItemsList<TView, TItem>), null);
 
 		static readonly BindablePropertyKey HeaderContentPropertyKey = BindableProperty.CreateReadOnly("HeaderContent", typeof(TItem), typeof(TemplatedItemsList<TView, TItem>), null);

--- a/src/Controls/src/Core/TemplatedPage.cs
+++ b/src/Controls/src/Core/TemplatedPage.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../docs/Microsoft.Maui.Controls/TemplatedPage.xml" path="Type[@FullName='Microsoft.Maui.Controls.TemplatedPage']/Docs/*" />
 	public class TemplatedPage : Page, IControlTemplated
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/TemplatedPage.xml" path="//Member[@MemberName='ControlTemplateProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="ControlTemplate"/>.</summary>
 		public static readonly BindableProperty ControlTemplateProperty = BindableProperty.Create(nameof(ControlTemplate), typeof(ControlTemplate), typeof(TemplatedPage), null,
 			propertyChanged: TemplateUtilities.OnControlTemplateChanged);
 

--- a/src/Controls/src/Core/TemplatedView.cs
+++ b/src/Controls/src/Core/TemplatedView.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../docs/Microsoft.Maui.Controls/TemplatedView.xml" path="Type[@FullName='Microsoft.Maui.Controls.TemplatedView']/Docs/*" />
 	public partial class TemplatedView : Compatibility.Layout, IControlTemplated
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/TemplatedView.xml" path="//Member[@MemberName='ControlTemplateProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="ControlTemplate"/>.</summary>
 		public static readonly BindableProperty ControlTemplateProperty = BindableProperty.Create(nameof(ControlTemplate), typeof(ControlTemplate), typeof(TemplatedView), null,
 			propertyChanged: TemplateUtilities.OnControlTemplateChanged);
 

--- a/src/Controls/src/Core/TextAlignmentElement.cs
+++ b/src/Controls/src/Core/TextAlignmentElement.cs
@@ -3,10 +3,12 @@ namespace Microsoft.Maui.Controls
 {
 	static class TextAlignmentElement
 	{
+		/// <summary>Bindable property for <see cref="HorizontalTextAlignment"/>.</summary>
 		public static readonly BindableProperty HorizontalTextAlignmentProperty =
 			BindableProperty.Create(nameof(ITextAlignmentElement.HorizontalTextAlignment), typeof(TextAlignment), typeof(ITextAlignmentElement), TextAlignment.Start,
 									propertyChanged: OnHorizontalTextAlignmentPropertyChanged);
 
+		/// <summary>Bindable property for <see cref="VerticalTextAlignment"/>.</summary>
 		public static readonly BindableProperty VerticalTextAlignmentProperty =
 			BindableProperty.Create(nameof(ITextAlignmentElement.VerticalTextAlignment), typeof(TextAlignment), typeof(ITextAlignmentElement), TextAlignment.Center);
 

--- a/src/Controls/src/Core/TextAlignmentElement.cs
+++ b/src/Controls/src/Core/TextAlignmentElement.cs
@@ -3,12 +3,12 @@ namespace Microsoft.Maui.Controls
 {
 	static class TextAlignmentElement
 	{
-		/// <summary>Bindable property for <see cref="HorizontalTextAlignment"/>.</summary>
+		/// <summary>Bindable property for <see cref="ITextAlignmentElement.HorizontalTextAlignment"/>.</summary>
 		public static readonly BindableProperty HorizontalTextAlignmentProperty =
 			BindableProperty.Create(nameof(ITextAlignmentElement.HorizontalTextAlignment), typeof(TextAlignment), typeof(ITextAlignmentElement), TextAlignment.Start,
 									propertyChanged: OnHorizontalTextAlignmentPropertyChanged);
 
-		/// <summary>Bindable property for <see cref="VerticalTextAlignment"/>.</summary>
+		/// <summary>Bindable property for <see cref="ITextAlignmentElement.VerticalTextAlignment"/>.</summary>
 		public static readonly BindableProperty VerticalTextAlignmentProperty =
 			BindableProperty.Create(nameof(ITextAlignmentElement.VerticalTextAlignment), typeof(TextAlignment), typeof(ITextAlignmentElement), TextAlignment.Center);
 

--- a/src/Controls/src/Core/TimePicker.cs
+++ b/src/Controls/src/Core/TimePicker.cs
@@ -8,16 +8,16 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../docs/Microsoft.Maui.Controls/TimePicker.xml" path="Type[@FullName='Microsoft.Maui.Controls.TimePicker']/Docs/*" />
 	public partial class TimePicker : View, IFontElement, ITextElement, IElementConfiguration<TimePicker>
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/TimePicker.xml" path="//Member[@MemberName='FormatProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Format"/>.</summary>
 		public static readonly BindableProperty FormatProperty = BindableProperty.Create(nameof(Format), typeof(string), typeof(TimePicker), "t");
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/TimePicker.xml" path="//Member[@MemberName='TextColorProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="TextColor"/>.</summary>
 		public static readonly BindableProperty TextColorProperty = TextElement.TextColorProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/TimePicker.xml" path="//Member[@MemberName='CharacterSpacingProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="CharacterSpacing"/>.</summary>
 		public static readonly BindableProperty CharacterSpacingProperty = TextElement.CharacterSpacingProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/TimePicker.xml" path="//Member[@MemberName='TimeProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Time"/>.</summary>
 		public static readonly BindableProperty TimeProperty = BindableProperty.Create(nameof(Time), typeof(TimeSpan), typeof(TimePicker), new TimeSpan(0), BindingMode.TwoWay,
 			validateValue: (bindable, value) =>
 		{
@@ -25,15 +25,16 @@ namespace Microsoft.Maui.Controls
 			return time.TotalHours < 24 && time.TotalMilliseconds >= 0;
 		});
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/TimePicker.xml" path="//Member[@MemberName='FontFamilyProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="FontFamily"/>.</summary>
 		public static readonly BindableProperty FontFamilyProperty = FontElement.FontFamilyProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/TimePicker.xml" path="//Member[@MemberName='FontSizeProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="FontSize"/>.</summary>
 		public static readonly BindableProperty FontSizeProperty = FontElement.FontSizeProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/TimePicker.xml" path="//Member[@MemberName='FontAttributesProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="FontAttributes"/>.</summary>
 		public static readonly BindableProperty FontAttributesProperty = FontElement.FontAttributesProperty;
 
+		/// <summary>Bindable property for <see cref="FontAutoScalingEnabled"/>.</summary>
 		public static readonly BindableProperty FontAutoScalingEnabledProperty = FontElement.FontAutoScalingEnabledProperty;
 
 		readonly Lazy<PlatformConfigurationRegistry<TimePicker>> _platformConfigurationRegistry;

--- a/src/Controls/src/Core/ToolTipProperties.cs
+++ b/src/Controls/src/Core/ToolTipProperties.cs
@@ -4,6 +4,7 @@ namespace Microsoft.Maui.Controls
 {
 	public class ToolTipProperties
 	{
+		/// <summary>Bindable property for <see cref="Text"/>.</summary>
 		public static readonly BindableProperty TextProperty =
  			BindableProperty.CreateAttached("Text", typeof(string), typeof(ToolTipProperties), defaultValue: null, propertyChanged: OnToolTipPropertyChanged);
 

--- a/src/Controls/src/Core/ToolTipProperties.cs
+++ b/src/Controls/src/Core/ToolTipProperties.cs
@@ -4,7 +4,7 @@ namespace Microsoft.Maui.Controls
 {
 	public class ToolTipProperties
 	{
-		/// <summary>Bindable property for <see cref="Text"/>.</summary>
+		/// <summary>Bindable property for attached property <c>Text</c>.</summary>
 		public static readonly BindableProperty TextProperty =
  			BindableProperty.CreateAttached("Text", typeof(string), typeof(ToolTipProperties), defaultValue: null, propertyChanged: OnToolTipPropertyChanged);
 

--- a/src/Controls/src/Core/UriImageSource.cs
+++ b/src/Controls/src/Core/UriImageSource.cs
@@ -12,15 +12,17 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../docs/Microsoft.Maui.Controls/UriImageSource.xml" path="Type[@FullName='Microsoft.Maui.Controls.UriImageSource']/Docs/*" />
 	public sealed partial class UriImageSource : ImageSource, IStreamImageSource
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/UriImageSource.xml" path="//Member[@MemberName='UriProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Uri"/>.</summary>
 		public static readonly BindableProperty UriProperty = BindableProperty.Create(
 			nameof(Uri), typeof(Uri), typeof(UriImageSource), default(Uri),
 			propertyChanged: (bindable, oldvalue, newvalue) => ((UriImageSource)bindable).OnUriChanged(),
 			validateValue: (bindable, value) => value == null || ((Uri)value).IsAbsoluteUri);
 
+		/// <summary>Bindable property for <see cref="CacheValidity"/>.</summary>
 		public static readonly BindableProperty CacheValidityProperty = BindableProperty.Create(
 			nameof(CacheValidity), typeof(TimeSpan), typeof(UriImageSource), TimeSpan.FromDays(1));
 
+		/// <summary>Bindable property for <see cref="CachingEnabled"/>.</summary>
 		public static readonly BindableProperty CachingEnabledProperty = BindableProperty.Create(
 			nameof(CachingEnabled), typeof(bool), typeof(UriImageSource), true);
 

--- a/src/Controls/src/Core/UrlWebViewSource.cs
+++ b/src/Controls/src/Core/UrlWebViewSource.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../docs/Microsoft.Maui.Controls/UrlWebViewSource.xml" path="Type[@FullName='Microsoft.Maui.Controls.UrlWebViewSource']/Docs/*" />
 	public class UrlWebViewSource : WebViewSource
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/UrlWebViewSource.xml" path="//Member[@MemberName='UrlProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Url"/>.</summary>
 		public static readonly BindableProperty UrlProperty = BindableProperty.Create("Url", typeof(string), typeof(UrlWebViewSource), default(string),
 			propertyChanged: (bindable, oldvalue, newvalue) => ((UrlWebViewSource)bindable).OnSourceChanged());
 

--- a/src/Controls/src/Core/View.cs
+++ b/src/Controls/src/Core/View.cs
@@ -16,19 +16,19 @@ namespace Microsoft.Maui.Controls
 	{
 		protected internal IGestureController GestureController => this;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/View.xml" path="//Member[@MemberName='VerticalOptionsProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="VerticalOptions"/>.</summary>
 		public static readonly BindableProperty VerticalOptionsProperty =
 			BindableProperty.Create(nameof(VerticalOptions), typeof(LayoutOptions), typeof(View), LayoutOptions.Fill,
 									propertyChanged: (bindable, oldvalue, newvalue) =>
 									((View)bindable).InvalidateMeasureInternal(InvalidationTrigger.VerticalOptionsChanged));
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/View.xml" path="//Member[@MemberName='HorizontalOptionsProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="HorizontalOptions"/>.</summary>
 		public static readonly BindableProperty HorizontalOptionsProperty =
 			BindableProperty.Create(nameof(HorizontalOptions), typeof(LayoutOptions), typeof(View), LayoutOptions.Fill,
 									propertyChanged: (bindable, oldvalue, newvalue) =>
 									((View)bindable).InvalidateMeasureInternal(InvalidationTrigger.HorizontalOptionsChanged));
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/View.xml" path="//Member[@MemberName='MarginProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Margin"/>.</summary>
 		public static readonly BindableProperty MarginProperty =
 			BindableProperty.Create(nameof(Margin), typeof(Thickness), typeof(View), default(Thickness),
 									propertyChanged: MarginPropertyChanged);

--- a/src/Controls/src/Core/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement.cs
@@ -20,70 +20,70 @@ namespace Microsoft.Maui.Controls
 		/// <include file="../../docs/Microsoft.Maui.Controls/VisualElement.xml" path="//Member[@MemberName='StyleProperty']/Docs/*" />
 		public new static readonly BindableProperty StyleProperty = NavigableElement.StyleProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/VisualElement.xml" path="//Member[@MemberName='InputTransparentProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="InputTransparent"/>.</summary>
 		public static readonly BindableProperty InputTransparentProperty = BindableProperty.Create("InputTransparent", typeof(bool), typeof(VisualElement), default(bool));
 
 		bool _isEnabledExplicit = (bool)IsEnabledProperty.DefaultValue;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/VisualElement.xml" path="//Member[@MemberName='IsEnabledProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="IsEnabled"/>.</summary>
 		public static readonly BindableProperty IsEnabledProperty = BindableProperty.Create("IsEnabled", typeof(bool),
 			typeof(VisualElement), true, propertyChanged: OnIsEnabledPropertyChanged, coerceValue: CoerceIsEnabledProperty);
 
 		static readonly BindablePropertyKey XPropertyKey = BindableProperty.CreateReadOnly("X", typeof(double), typeof(VisualElement), default(double));
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/VisualElement.xml" path="//Member[@MemberName='XProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="X"/>.</summary>
 		public static readonly BindableProperty XProperty = XPropertyKey.BindableProperty;
 
 		static readonly BindablePropertyKey YPropertyKey = BindableProperty.CreateReadOnly("Y", typeof(double), typeof(VisualElement), default(double));
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/VisualElement.xml" path="//Member[@MemberName='YProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Y"/>.</summary>
 		public static readonly BindableProperty YProperty = YPropertyKey.BindableProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/VisualElement.xml" path="//Member[@MemberName='AnchorXProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="AnchorX"/>.</summary>
 		public static readonly BindableProperty AnchorXProperty = BindableProperty.Create("AnchorX", typeof(double), typeof(VisualElement), .5d);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/VisualElement.xml" path="//Member[@MemberName='AnchorYProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="AnchorY"/>.</summary>
 		public static readonly BindableProperty AnchorYProperty = BindableProperty.Create("AnchorY", typeof(double), typeof(VisualElement), .5d);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/VisualElement.xml" path="//Member[@MemberName='TranslationXProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="TranslationX"/>.</summary>
 		public static readonly BindableProperty TranslationXProperty = BindableProperty.Create("TranslationX", typeof(double), typeof(VisualElement), 0d);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/VisualElement.xml" path="//Member[@MemberName='TranslationYProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="TranslationY"/>.</summary>
 		public static readonly BindableProperty TranslationYProperty = BindableProperty.Create("TranslationY", typeof(double), typeof(VisualElement), 0d);
 
 		static readonly BindablePropertyKey WidthPropertyKey = BindableProperty.CreateReadOnly("Width", typeof(double), typeof(VisualElement), -1d,
 			coerceValue: (bindable, value) => double.IsNaN((double)value) ? 0d : value);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/VisualElement.xml" path="//Member[@MemberName='WidthProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Width"/>.</summary>
 		public static readonly BindableProperty WidthProperty = WidthPropertyKey.BindableProperty;
 
 		static readonly BindablePropertyKey HeightPropertyKey = BindableProperty.CreateReadOnly("Height", typeof(double), typeof(VisualElement), -1d,
 			coerceValue: (bindable, value) => double.IsNaN((double)value) ? 0d : value);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/VisualElement.xml" path="//Member[@MemberName='HeightProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Height"/>.</summary>
 		public static readonly BindableProperty HeightProperty = HeightPropertyKey.BindableProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/VisualElement.xml" path="//Member[@MemberName='RotationProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Rotation"/>.</summary>
 		public static readonly BindableProperty RotationProperty = BindableProperty.Create("Rotation", typeof(double), typeof(VisualElement), default(double));
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/VisualElement.xml" path="//Member[@MemberName='RotationXProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="RotationX"/>.</summary>
 		public static readonly BindableProperty RotationXProperty = BindableProperty.Create("RotationX", typeof(double), typeof(VisualElement), default(double));
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/VisualElement.xml" path="//Member[@MemberName='RotationYProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="RotationY"/>.</summary>
 		public static readonly BindableProperty RotationYProperty = BindableProperty.Create("RotationY", typeof(double), typeof(VisualElement), default(double));
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/VisualElement.xml" path="//Member[@MemberName='ScaleProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Scale"/>.</summary>
 		public static readonly BindableProperty ScaleProperty = BindableProperty.Create(nameof(Scale), typeof(double), typeof(VisualElement), 1d);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/VisualElement.xml" path="//Member[@MemberName='ScaleXProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="ScaleX"/>.</summary>
 		public static readonly BindableProperty ScaleXProperty = BindableProperty.Create(nameof(ScaleX), typeof(double), typeof(VisualElement), 1d);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/VisualElement.xml" path="//Member[@MemberName='ScaleYProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="ScaleY"/>.</summary>
 		public static readonly BindableProperty ScaleYProperty = BindableProperty.Create(nameof(ScaleY), typeof(double), typeof(VisualElement), 1d);
 
 		internal static readonly BindableProperty TransformProperty = BindableProperty.Create("Transform", typeof(string), typeof(VisualElement), null, propertyChanged: OnTransformChanged);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/VisualElement.xml" path="//Member[@MemberName='ClipProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Clip"/>.</summary>
 		public static readonly BindableProperty ClipProperty = BindableProperty.Create(nameof(Clip), typeof(Geometry), typeof(VisualElement), null,
 			propertyChanging: (bindable, oldvalue, newvalue) =>
 			{
@@ -156,7 +156,7 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/VisualElement.xml" path="//Member[@MemberName='VisualProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Visual"/>.</summary>
 		public static readonly BindableProperty VisualProperty =
 			BindableProperty.Create(nameof(Visual), typeof(IVisual), typeof(VisualElement), Maui.Controls.VisualMarker.MatchParent,
 									validateValue: (b, v) => v != null, propertyChanged: OnVisualChanged);
@@ -252,17 +252,17 @@ namespace Microsoft.Maui.Controls
 			BindableProperty.Create("TransformOrigin", typeof(Point), typeof(VisualElement), new Point(.5d, .5d),
 									propertyChanged: (b, o, n) => { (((VisualElement)b).AnchorX, ((VisualElement)b).AnchorY) = (Point)n; });
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/VisualElement.xml" path="//Member[@MemberName='IsVisibleProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="IsVisible"/>.</summary>
 		public static readonly BindableProperty IsVisibleProperty = BindableProperty.Create("IsVisible", typeof(bool), typeof(VisualElement), true,
 			propertyChanged: (bindable, oldvalue, newvalue) => ((VisualElement)bindable).OnIsVisibleChanged((bool)oldvalue, (bool)newvalue));
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/VisualElement.xml" path="//Member[@MemberName='OpacityProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Opacity"/>.</summary>
 		public static readonly BindableProperty OpacityProperty = BindableProperty.Create("Opacity", typeof(double), typeof(VisualElement), 1d, coerceValue: (bindable, value) => ((double)value).Clamp(0, 1));
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/VisualElement.xml" path="//Member[@MemberName='BackgroundColorProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="BackgroundColor"/>.</summary>
 		public static readonly BindableProperty BackgroundColorProperty = BindableProperty.Create(nameof(BackgroundColor), typeof(Color), typeof(VisualElement), null);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/VisualElement.xml" path="//Member[@MemberName='BackgroundProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Background"/>.</summary>
 		public static readonly BindableProperty BackgroundProperty = BindableProperty.Create(nameof(Background), typeof(Brush), typeof(VisualElement), Brush.Default,
 			propertyChanging: (bindable, oldvalue, newvalue) =>
 			{
@@ -368,7 +368,7 @@ namespace Microsoft.Maui.Controls
 				return collection;
 			});
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/VisualElement.xml" path="//Member[@MemberName='BehaviorsProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Behaviors"/>.</summary>
 		public static readonly BindableProperty BehaviorsProperty = BehaviorsPropertyKey.BindableProperty;
 
 		internal static readonly BindablePropertyKey TriggersPropertyKey = BindableProperty.CreateReadOnly("Triggers", typeof(IList<TriggerBase>), typeof(VisualElement), default(IList<TriggerBase>),
@@ -379,24 +379,27 @@ namespace Microsoft.Maui.Controls
 				return collection;
 			});
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/VisualElement.xml" path="//Member[@MemberName='TriggersProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Triggers"/>.</summary>
 		public static readonly BindableProperty TriggersProperty = TriggersPropertyKey.BindableProperty;
 
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/VisualElement.xml" path="//Member[@MemberName='WidthRequestProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="WidthRequest"/>.</summary>
+
 		public static readonly BindableProperty WidthRequestProperty = BindableProperty.Create(nameof(WidthRequest), typeof(double), typeof(VisualElement), -1d, propertyChanged: OnRequestChanged);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/VisualElement.xml" path="//Member[@MemberName='HeightRequestProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="HeightRequest"/>.</summary>
 		public static readonly BindableProperty HeightRequestProperty = BindableProperty.Create(nameof(HeightRequest), typeof(double), typeof(VisualElement), -1d, propertyChanged: OnRequestChanged);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/VisualElement.xml" path="//Member[@MemberName='MinimumWidthRequestProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="MinimumWidthRequest"/>.</summary>
 		public static readonly BindableProperty MinimumWidthRequestProperty = BindableProperty.Create(nameof(MinimumWidthRequest), typeof(double), typeof(VisualElement), -1d, propertyChanged: OnRequestChanged);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/VisualElement.xml" path="//Member[@MemberName='MinimumHeightRequestProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="MinimumHeightRequest"/>.</summary>
 		public static readonly BindableProperty MinimumHeightRequestProperty = BindableProperty.Create(nameof(MinimumHeightRequest), typeof(double), typeof(VisualElement), -1d, propertyChanged: OnRequestChanged);
 
+		/// <summary>Bindable property for <see cref="MaximumWidthRequest"/>.</summary>
 		public static readonly BindableProperty MaximumWidthRequestProperty = BindableProperty.Create(nameof(MaximumWidthRequest), typeof(double), typeof(VisualElement), double.PositiveInfinity, propertyChanged: OnRequestChanged);
 
+		/// <summary>Bindable property for <see cref="MaximumHeightRequest"/>.</summary>
 		public static readonly BindableProperty MaximumHeightRequestProperty = BindableProperty.Create(nameof(MaximumHeightRequest), typeof(double), typeof(VisualElement), double.PositiveInfinity, propertyChanged: OnRequestChanged);
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/VisualElement.xml" path="//Member[@MemberName='IsFocusedPropertyKey']/Docs/*" />
@@ -404,10 +407,10 @@ namespace Microsoft.Maui.Controls
 		public static readonly BindablePropertyKey IsFocusedPropertyKey = BindableProperty.CreateReadOnly("IsFocused",
 			typeof(bool), typeof(VisualElement), default(bool), propertyChanged: OnIsFocusedPropertyChanged);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/VisualElement.xml" path="//Member[@MemberName='IsFocusedProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="IsFocused"/>.</summary>
 		public static readonly BindableProperty IsFocusedProperty = IsFocusedPropertyKey.BindableProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/VisualElement.xml" path="//Member[@MemberName='FlowDirectionProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="FlowDirection"/>.</summary>
 		public static readonly BindableProperty FlowDirectionProperty = BindableProperty.Create(nameof(FlowDirection), typeof(FlowDirection), typeof(VisualElement), FlowDirection.MatchParent, propertyChanging: FlowDirectionChanging, propertyChanged: FlowDirectionChanged);
 
 		IFlowDirectionController FlowController => this;
@@ -446,6 +449,7 @@ namespace Microsoft.Maui.Controls
 		static readonly BindablePropertyKey WindowPropertyKey = BindableProperty.CreateReadOnly(
 			nameof(Window), typeof(Window), typeof(VisualElement), null, propertyChanged: OnWindowChanged);
 
+		/// <summary>Bindable property for <see cref="Window"/>.</summary>
 		public static readonly BindableProperty WindowProperty = WindowPropertyKey.BindableProperty;
 
 		public Window Window => (Window)GetValue(WindowProperty);

--- a/src/Controls/src/Core/VisualStateManager.cs
+++ b/src/Controls/src/Core/VisualStateManager.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Maui.Controls
 			internal const string Unfocused = "Unfocused";
 		}
 
-		/// <summary>Bindable property for <see cref="VisualStateGroups"/>.</summary>
+		/// <summary>Bindable property for attached property <c>VisualStateGroups</c>.</summary>
 		public static readonly BindableProperty VisualStateGroupsProperty =
 			BindableProperty.CreateAttached("VisualStateGroups", typeof(VisualStateGroupList), typeof(VisualElement),
 				defaultValue: null, propertyChanged: VisualStateGroupsPropertyChanged, propertyChanging: VisualStateGroupsPropertyChanging,

--- a/src/Controls/src/Core/VisualStateManager.cs
+++ b/src/Controls/src/Core/VisualStateManager.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Maui.Controls
 			internal const string Unfocused = "Unfocused";
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/VisualStateManager.xml" path="//Member[@MemberName='VisualStateGroupsProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="VisualStateGroups"/>.</summary>
 		public static readonly BindableProperty VisualStateGroupsProperty =
 			BindableProperty.CreateAttached("VisualStateGroups", typeof(VisualStateGroupList), typeof(VisualElement),
 				defaultValue: null, propertyChanged: VisualStateGroupsPropertyChanged, propertyChanging: VisualStateGroupsPropertyChanging,

--- a/src/Controls/src/Core/WebView.cs
+++ b/src/Controls/src/Core/WebView.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../docs/Microsoft.Maui.Controls/WebView.xml" path="Type[@FullName='Microsoft.Maui.Controls.WebView']/Docs/*" />
 	public partial class WebView : View, IWebViewController, IElementConfiguration<WebView>
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/WebView.xml" path="//Member[@MemberName='SourceProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Source"/>.</summary>
 		public static readonly BindableProperty SourceProperty = BindableProperty.Create("Source", typeof(WebViewSource), typeof(WebView), default(WebViewSource),
 			propertyChanging: (bindable, oldvalue, newvalue) =>
 			{
@@ -33,18 +33,18 @@ namespace Microsoft.Maui.Controls
 
 		static readonly BindablePropertyKey CanGoBackPropertyKey = BindableProperty.CreateReadOnly("CanGoBack", typeof(bool), typeof(WebView), false);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/WebView.xml" path="//Member[@MemberName='CanGoBackProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="CanGoBack"/>.</summary>
 		public static readonly BindableProperty CanGoBackProperty = CanGoBackPropertyKey.BindableProperty;
 
 		static readonly BindablePropertyKey CanGoForwardPropertyKey = BindableProperty.CreateReadOnly("CanGoForward", typeof(bool), typeof(WebView), false);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/WebView.xml" path="//Member[@MemberName='CanGoForwardProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="CanGoForward"/>.</summary>
 		public static readonly BindableProperty CanGoForwardProperty = CanGoForwardPropertyKey.BindableProperty;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/WebView.xml" path="//Member[@MemberName='UserAgentProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="UserAgent"/>.</summary>
 		public static readonly BindableProperty UserAgentProperty = BindableProperty.Create(nameof(UserAgent), typeof(string), typeof(WebView), null);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/WebView.xml" path="//Member[@MemberName='CookiesProperty']/Docs/*" />
+		/// <summary>Bindable property for <see cref="Cookies"/>.</summary>
 		public static readonly BindableProperty CookiesProperty = BindableProperty.Create(nameof(Cookies), typeof(CookieContainer), typeof(WebView), null);
 
 		readonly Lazy<PlatformConfigurationRegistry<WebView>> _platformConfigurationRegistry;


### PR DESCRIPTION
### Description of Change

Thought as a quick win I could write a little script that updates/adds all public XML docs for `BindableProperty`s there might still be some missing, but I think this should cover most and should convert the `<include/>` tags to an actual comment and add the XML comment where they are missing.

### Issues Fixed

Related to #3960