### PR TITLE
[Essentials] add WiFi permissions on Android 13+

### DIFF
--- a/src/Essentials/src/Permissions/Permissions.android.cs
+++ b/src/Essentials/src/Permissions/Permissions.android.cs
@@ -357,6 +357,32 @@ namespace Microsoft.Maui.ApplicationModel
 				new (string, bool)[] { (Manifest.Permission.RecordAudio, true) };
 		}
 
+		public partial class NearbyWifiDevices : BasePlatformPermission
+		{
+			public override (string androidPermission, bool isRuntime)[] RequiredPermissions
+			{
+				get
+				{
+					var permissions = new List<(string, bool)>();
+					// When targeting Android 12 or lower, AccessFineLocation is required for several WiFi APIs.
+					// For Android 13 and above, it is optional.
+					if (Application.Context.ApplicationInfo.TargetSdkVersion < BuildVersionCodes.Tiramisu || IsDeclaredInManifest(Manifest.Permission.AccessFineLocation))
+						permissions.Add((Manifest.Permission.AccessFineLocation, true));
+
+#if __ANDROID_33__
+					if (OperatingSystem.IsAndroidVersionAtLeast(33) && Application.Context.ApplicationInfo.TargetSdkVersion >= BuildVersionCodes.Tiramisu)
+					{
+						// new runtime permission on Android 13
+						if (IsDeclaredInManifest(Manifest.Permission.NearbyWifiDevices))
+							permissions.Add((Manifest.Permission.NearbyWifiDevices, true));
+					}
+#endif
+
+					return permissions.ToArray();
+				}
+			}
+		}
+
 		public partial class NetworkState : BasePlatformPermission
 		{
 			public override (string androidPermission, bool isRuntime)[] RequiredPermissions

--- a/src/Essentials/src/Permissions/Permissions.ios.tvos.watchos.cs
+++ b/src/Essentials/src/Permissions/Permissions.ios.tvos.watchos.cs
@@ -268,6 +268,10 @@ namespace Microsoft.Maui.ApplicationModel
 		{
 		}
 
+		public partial class NearbyWifiDevices : BasePlatformPermission
+		{
+		}
+
 		public partial class NetworkState : BasePlatformPermission
 		{
 		}

--- a/src/Essentials/src/Permissions/Permissions.macos.cs
+++ b/src/Essentials/src/Permissions/Permissions.macos.cs
@@ -187,6 +187,10 @@ namespace Microsoft.Maui.ApplicationModel
 		{
 		}
 
+		public partial class NearbyWifiDevices : BasePlatformPermission
+		{
+		}
+
 		public partial class NetworkState : BasePlatformPermission
 		{
 		}

--- a/src/Essentials/src/Permissions/Permissions.netstandard.cs
+++ b/src/Essentials/src/Permissions/Permissions.netstandard.cs
@@ -89,6 +89,10 @@ namespace Microsoft.Maui.ApplicationModel
 		{
 		}
 
+		public partial class NearbyWifiDevices : BasePlatformPermission
+		{
+		}
+
 		public partial class NetworkState : BasePlatformPermission
 		{
 		}

--- a/src/Essentials/src/Permissions/Permissions.shared.cs
+++ b/src/Essentials/src/Permissions/Permissions.shared.cs
@@ -218,6 +218,13 @@ namespace Microsoft.Maui.ApplicationModel
 		}
 
 		/// <summary>
+		/// Represents permission to access nearby WiFi devices.
+		/// </summary>
+		public partial class NearbyWifiDevices
+		{
+		}
+
+		/// <summary>
 		/// Represents permission to access the device network state information.
 		/// </summary>
 		public partial class NetworkState

--- a/src/Essentials/src/Permissions/Permissions.tizen.cs
+++ b/src/Essentials/src/Permissions/Permissions.tizen.cs
@@ -187,6 +187,10 @@ namespace Microsoft.Maui.ApplicationModel
 				new[] { ("http://tizen.org/privilege/recorder", false) };
 		}
 
+		public partial class NearbyWifiDevices : BasePlatformPermission
+		{
+		}
+
 		public partial class NetworkState : BasePlatformPermission
 		{
 			/// <inheritdoc/>

--- a/src/Essentials/src/Permissions/Permissions.uwp.cs
+++ b/src/Essentials/src/Permissions/Permissions.uwp.cs
@@ -175,6 +175,10 @@ namespace Microsoft.Maui.ApplicationModel
 		{
 		}
 
+		public partial class NearbyWifiDevices : BasePlatformPermission
+		{
+		}
+
 		public partial class NetworkState : BasePlatformPermission
 		{
 		}

--- a/src/Essentials/src/PublicAPI/net-android/PublicAPI.Shipped.txt
+++ b/src/Essentials/src/PublicAPI/net-android/PublicAPI.Shipped.txt
@@ -90,6 +90,7 @@
 ~override Microsoft.Maui.ApplicationModel.Permissions.LocationWhenInUse.RequestAsync() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>
 ~override Microsoft.Maui.ApplicationModel.Permissions.LocationWhenInUse.RequiredPermissions.get -> (string androidPermission, bool isRuntime)[]
 ~override Microsoft.Maui.ApplicationModel.Permissions.Microphone.RequiredPermissions.get -> (string androidPermission, bool isRuntime)[]
+~override Microsoft.Maui.ApplicationModel.Permissions.NearbyWifiDevices.RequiredPermissions.get -> (string androidPermission, bool isRuntime)[]
 ~override Microsoft.Maui.ApplicationModel.Permissions.NetworkState.RequiredPermissions.get -> (string androidPermission, bool isRuntime)[]
 ~override Microsoft.Maui.ApplicationModel.Permissions.Phone.RequiredPermissions.get -> (string androidPermission, bool isRuntime)[]
 ~override Microsoft.Maui.ApplicationModel.Permissions.Sensors.RequiredPermissions.get -> (string androidPermission, bool isRuntime)[]
@@ -423,6 +424,8 @@ Microsoft.Maui.ApplicationModel.Permissions.Media
 Microsoft.Maui.ApplicationModel.Permissions.Media.Media() -> void
 Microsoft.Maui.ApplicationModel.Permissions.Microphone
 Microsoft.Maui.ApplicationModel.Permissions.Microphone.Microphone() -> void
+Microsoft.Maui.ApplicationModel.Permissions.NearbyWifiDevices
+Microsoft.Maui.ApplicationModel.Permissions.NearbyWifiDevices.NearbyWifiDevices() -> void
 Microsoft.Maui.ApplicationModel.Permissions.NetworkState
 Microsoft.Maui.ApplicationModel.Permissions.NetworkState.NetworkState() -> void
 Microsoft.Maui.ApplicationModel.Permissions.PermissionResult

--- a/src/Essentials/src/PublicAPI/net-ios/PublicAPI.Shipped.txt
+++ b/src/Essentials/src/PublicAPI/net-ios/PublicAPI.Shipped.txt
@@ -423,6 +423,8 @@ Microsoft.Maui.ApplicationModel.Permissions.Media
 Microsoft.Maui.ApplicationModel.Permissions.Media.Media() -> void
 Microsoft.Maui.ApplicationModel.Permissions.Microphone
 Microsoft.Maui.ApplicationModel.Permissions.Microphone.Microphone() -> void
+Microsoft.Maui.ApplicationModel.Permissions.NearbyWifiDevices
+Microsoft.Maui.ApplicationModel.Permissions.NearbyWifiDevices.NearbyWifiDevices() -> void
 Microsoft.Maui.ApplicationModel.Permissions.NetworkState
 Microsoft.Maui.ApplicationModel.Permissions.NetworkState.NetworkState() -> void
 Microsoft.Maui.ApplicationModel.Permissions.Phone

--- a/src/Essentials/src/PublicAPI/net-maccatalyst/PublicAPI.Shipped.txt
+++ b/src/Essentials/src/PublicAPI/net-maccatalyst/PublicAPI.Shipped.txt
@@ -423,6 +423,8 @@ Microsoft.Maui.ApplicationModel.Permissions.Media
 Microsoft.Maui.ApplicationModel.Permissions.Media.Media() -> void
 Microsoft.Maui.ApplicationModel.Permissions.Microphone
 Microsoft.Maui.ApplicationModel.Permissions.Microphone.Microphone() -> void
+Microsoft.Maui.ApplicationModel.Permissions.NearbyWifiDevices
+Microsoft.Maui.ApplicationModel.Permissions.NearbyWifiDevices.NearbyWifiDevices() -> void
 Microsoft.Maui.ApplicationModel.Permissions.NetworkState
 Microsoft.Maui.ApplicationModel.Permissions.NetworkState.NetworkState() -> void
 Microsoft.Maui.ApplicationModel.Permissions.Phone

--- a/src/Essentials/src/PublicAPI/net-tizen/PublicAPI.Shipped.txt
+++ b/src/Essentials/src/PublicAPI/net-tizen/PublicAPI.Shipped.txt
@@ -387,6 +387,8 @@ Microsoft.Maui.ApplicationModel.Permissions.Media
 Microsoft.Maui.ApplicationModel.Permissions.Media.Media() -> void
 Microsoft.Maui.ApplicationModel.Permissions.Microphone
 Microsoft.Maui.ApplicationModel.Permissions.Microphone.Microphone() -> void
+Microsoft.Maui.ApplicationModel.Permissions.NearbyWifiDevices
+Microsoft.Maui.ApplicationModel.Permissions.NearbyWifiDevices.NearbyWifiDevices() -> void
 Microsoft.Maui.ApplicationModel.Permissions.NetworkState
 Microsoft.Maui.ApplicationModel.Permissions.NetworkState.NetworkState() -> void
 Microsoft.Maui.ApplicationModel.Permissions.Phone

--- a/src/Essentials/src/PublicAPI/net-windows/PublicAPI.Shipped.txt
+++ b/src/Essentials/src/PublicAPI/net-windows/PublicAPI.Shipped.txt
@@ -384,6 +384,8 @@ Microsoft.Maui.ApplicationModel.Permissions.Media
 Microsoft.Maui.ApplicationModel.Permissions.Media.Media() -> void
 Microsoft.Maui.ApplicationModel.Permissions.Microphone
 Microsoft.Maui.ApplicationModel.Permissions.Microphone.Microphone() -> void
+Microsoft.Maui.ApplicationModel.Permissions.NearbyWifiDevices
+Microsoft.Maui.ApplicationModel.Permissions.NearbyWifiDevices.NearbyWifiDevices() -> void
 Microsoft.Maui.ApplicationModel.Permissions.NetworkState
 Microsoft.Maui.ApplicationModel.Permissions.NetworkState.NetworkState() -> void
 Microsoft.Maui.ApplicationModel.Permissions.Phone

--- a/src/Essentials/src/PublicAPI/net/PublicAPI.Shipped.txt
+++ b/src/Essentials/src/PublicAPI/net/PublicAPI.Shipped.txt
@@ -372,6 +372,8 @@ Microsoft.Maui.ApplicationModel.Permissions.Media
 Microsoft.Maui.ApplicationModel.Permissions.Media.Media() -> void
 Microsoft.Maui.ApplicationModel.Permissions.Microphone
 Microsoft.Maui.ApplicationModel.Permissions.Microphone.Microphone() -> void
+Microsoft.Maui.ApplicationModel.Permissions.NearbyWifiDevices
+Microsoft.Maui.ApplicationModel.Permissions.NearbyWifiDevices.NearbyWifiDevices() -> void
 Microsoft.Maui.ApplicationModel.Permissions.NetworkState
 Microsoft.Maui.ApplicationModel.Permissions.NetworkState.NetworkState() -> void
 Microsoft.Maui.ApplicationModel.Permissions.Phone

--- a/src/Essentials/src/PublicAPI/netstandard/PublicAPI.Shipped.txt
+++ b/src/Essentials/src/PublicAPI/netstandard/PublicAPI.Shipped.txt
@@ -372,6 +372,8 @@ Microsoft.Maui.ApplicationModel.Permissions.Media
 Microsoft.Maui.ApplicationModel.Permissions.Media.Media() -> void
 Microsoft.Maui.ApplicationModel.Permissions.Microphone
 Microsoft.Maui.ApplicationModel.Permissions.Microphone.Microphone() -> void
+Microsoft.Maui.ApplicationModel.Permissions.NearbyWifiDevices
+Microsoft.Maui.ApplicationModel.Permissions.NearbyWifiDevices.NearbyWifiDevices() -> void
 Microsoft.Maui.ApplicationModel.Permissions.NetworkState
 Microsoft.Maui.ApplicationModel.Permissions.NetworkState.NetworkState() -> void
 Microsoft.Maui.ApplicationModel.Permissions.Phone


### PR DESCRIPTION
### Description of Change

* Android 13 has a new (runtime) permission for accessing nearby WiFi devices

### Issues Fixed

Fixes #13721
