### PR TITLE
Call the correct Disconnect method from DisconnectHandler

### DIFF
--- a/src/Core/src/Handlers/WebView/WebViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/WebView/WebViewHandler.Windows.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Maui.Handlers
 
 		protected override void DisconnectHandler(WebView2 platformView)
 		{
-			DisconnectHandler(platformView);
+			Disconnect(platformView);
 			base.DisconnectHandler(platformView);
 		}
 


### PR DESCRIPTION
### Description of Change

DisconnectHandler is currently calling the wrong method. It needs to call `Disconnect` 

This PR doesn't have tests because the failure is caught by `DisconnectHandlerDoesntCrash`