### PR TITLE
[core] use ToUpperInvariant() / ToLowerInvariant()

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -27,6 +27,7 @@ dotnet_diagnostic.IL2050.severity = none
 # Code analyzers
 dotnet_diagnostic.CA1307.severity = error
 dotnet_diagnostic.CA1309.severity = error
+dotnet_diagnostic.CA1311.severity = error
 dotnet_diagnostic.CA1815.severity = error
 
 # nullability checks

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla32148.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla32148.cs
@@ -163,7 +163,7 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.Issues
 						return "?";
 					}
 
-					return FirstName[0].ToString().ToUpper();
+					return FirstName[0].ToString().ToUpperInvariant();
 				}
 			}
 		}

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue8833.xaml.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue8833.xaml.cs
@@ -223,7 +223,7 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.Issues
 
 		void FilterItems(string filter)
 		{
-			var filteredItems = _source.Where(monkey => monkey.Name.ToLower().Contains(filter.ToLower())).ToList();
+			var filteredItems = _source.Where(monkey => monkey.Name.ToLowerInvariant().Contains(filter.ToLowerInvariant())).ToList();
 			foreach (var monkey in _source)
 			{
 				if (!filteredItems.Contains(monkey))

--- a/src/Compatibility/ControlGallery/src/iOS/AppDelegate.cs
+++ b/src/Compatibility/ControlGallery/src/iOS/AppDelegate.cs
@@ -435,9 +435,9 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.iOS
 			set
 			{
 
-				WillChangeValue(nameof(KVOValue).ToLower());
+				WillChangeValue(nameof(KVOValue).ToLowerInvariant());
 				_kVOValue = Value = value;
-				DidChangeValue(nameof(KVOValue).ToLower());
+				DidChangeValue(nameof(KVOValue).ToLowerInvariant());
 			}
 		}
 	}

--- a/src/Compatibility/ControlGallery/src/iOS/BrokenNativeControl.cs
+++ b/src/Compatibility/ControlGallery/src/iOS/BrokenNativeControl.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.iOS
 		public override string Text
 		{
 			get { return base.Text; }
-			set { base.Text = value.ToUpper(); }
+			set { base.Text = value.ToUpperInvariant(); }
 		}
 
 		public override CGSize SizeThatFits(CGSize size)

--- a/src/Compatibility/Core/src/Android/ResourceManager.cs
+++ b/src/Compatibility/Core/src/Android/ResourceManager.cs
@@ -402,7 +402,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 			if (defType == "style" || (resourceType != null && resourceType == StyleClass))
 				name = title;
 			else
-				name = title.ToLower();
+				name = title.ToLowerInvariant();
 
 			if (defType == _drawableDefType || (resourceType != null && resourceType == DrawableClass))
 				name = IOPath.GetFileNameWithoutExtension(name);

--- a/src/Controls/samples/Controls.Sample/Pages/AppShell.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/AppShell.xaml.cs
@@ -52,7 +52,7 @@ namespace Maui.Controls.Sample.Pages
 			else
 			{
 				ItemsSource = Pages
-					.Where(page => page.Name.ToLower().Contains(newValue.ToLower(), StringComparison.OrdinalIgnoreCase))
+					.Where(page => page.Name.ToLowerInvariant().Contains(newValue.ToLowerInvariant(), StringComparison.OrdinalIgnoreCase))
 					.ToList();
 			}
 		}

--- a/src/Controls/src/Core/Accelerator.cs
+++ b/src/Controls/src/Core/Accelerator.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Maui.Controls
 				for (int i = 0; i < acceleratorParts.Length; i++)
 				{
 					var modifierMask = acceleratorParts[i];
-					var modiferMaskLower = modifierMask.ToLower();
+					var modiferMaskLower = modifierMask.ToLowerInvariant();
 					switch (modiferMaskLower)
 					{
 						case "ctrl":

--- a/src/Controls/src/Core/Compatibility/Windows/CaseConverter.cs
+++ b/src/Controls/src/Core/Compatibility/Windows/CaseConverter.cs
@@ -1,5 +1,6 @@
 #nullable disable
 using System;
+using System.Globalization;
 
 namespace Microsoft.Maui.Controls.Platform.Compatibility
 {
@@ -13,7 +14,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				return null;
 
 			var v = (string)value;
-			return ConvertToUpper ? v.ToUpper() : v.ToLower();
+			return ConvertToUpper ? v.ToUpper(CultureInfo.CurrentCulture) : v.ToLower(CultureInfo.CurrentCulture);
 		}
 
 		public object ConvertBack(object value, Type targetType, object parameter, string language)

--- a/src/Controls/src/Core/Compatibility/iOS/Extensions/UIViewExtensions.cs
+++ b/src/Controls/src/Core/Compatibility/iOS/Extensions/UIViewExtensions.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.MacOS
 				{
 					//TODO: We need to figure a way to map the value back to the real objectiveC property.
 					//the X.IOS camelcase property name won't work
-					var key = new Foundation.NSString(propertyName.ToLower());
+					var key = new Foundation.NSString(propertyName.ToLowerInvariant());
 					var valueKey = view.ValueForKey(key);
 					if (valueKey != null)
 					{

--- a/src/Controls/tests/Core.UnitTests/BindableObjectUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/BindableObjectUnitTests.cs
@@ -519,12 +519,12 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		public void CoerceValue()
 		{
 			var property = BindableProperty.Create(nameof(MockBindable.Foo), typeof(string), typeof(MockBindable), null,
-				coerceValue: (bo, o) => ((string)o).ToUpper());
+				coerceValue: (bo, o) => ((string)o).ToUpperInvariant());
 
 			const string value = "value";
 			var mock = new MockBindable();
 			mock.SetValue(property, value);
-			Assert.Equal(value.ToUpper(), mock.GetValue(property));
+			Assert.Equal(value.ToUpperInvariant(), mock.GetValue(property));
 		}
 
 		[Fact]

--- a/src/Controls/tests/Core.UnitTests/MultiBindingTests.cs
+++ b/src/Controls/tests/Core.UnitTests/MultiBindingTests.cs
@@ -51,8 +51,8 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.Equal(oldName, label.Text);
 			Assert.Equal(oldName, group.Person1.FullName);
 
-			label.SetValueCore(Label.TextProperty, $"{oldFirstName.ToUpper()} {oldMiddleName} {oldLastName.ToUpper()}", Internals.SetValueFlags.None);
-			Assert.Equal($"{oldFirstName} {oldMiddleName} {oldLastName.ToUpper()}", group.Person1.FullName);
+			label.SetValueCore(Label.TextProperty, $"{oldFirstName.ToUpperInvariant()} {oldMiddleName} {oldLastName.ToUpperInvariant()}", Internals.SetValueFlags.None);
+			Assert.Equal($"{oldFirstName} {oldMiddleName} {oldLastName.ToUpperInvariant()}", group.Person1.FullName);
 		}
 
 		[Fact]
@@ -212,17 +212,17 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			var label2 = GenerateNameLabel(nameof(group.Person2), BindingMode.TwoWay);
 			stack.Children.Add(label2);
-			label2.SetValueCore(Label.TextProperty, $"DoNothing {oldMiddleName} {oldLastName.ToUpper()}", Internals.SetValueFlags.None);
-			Assert.Equal($"{oldFirstName} {oldMiddleName} {oldLastName.ToUpper()}", group.Person2.FullName);
-			Assert.Equal($"DoNothing {oldMiddleName} {oldLastName.ToUpper()}", label2.Text);
+			label2.SetValueCore(Label.TextProperty, $"DoNothing {oldMiddleName} {oldLastName.ToUpperInvariant()}", Internals.SetValueFlags.None);
+			Assert.Equal($"{oldFirstName} {oldMiddleName} {oldLastName.ToUpperInvariant()}", group.Person2.FullName);
+			Assert.Equal($"DoNothing {oldMiddleName} {oldLastName.ToUpperInvariant()}", label2.Text);
 
 			label2.Text = oldName;
 			Assert.Equal(oldName, group.Person2.FullName);
 			Assert.Equal(oldName, label2.Text);
 			// Any UnsetValue prevents any changes to source but target accepts value
-			label2.SetValueCore(Label.TextProperty, $"{oldFirstName.ToUpper()} UnsetValue {oldLastName}");
-			Assert.Equal($"{oldFirstName.ToUpper()} {oldMiddleName} {oldLastName}", group.Person2.FullName);
-			Assert.Equal($"{oldFirstName.ToUpper()} UnsetValue {oldLastName}", label2.Text);
+			label2.SetValueCore(Label.TextProperty, $"{oldFirstName.ToUpperInvariant()} UnsetValue {oldLastName}");
+			Assert.Equal($"{oldFirstName.ToUpperInvariant()} {oldMiddleName} {oldLastName}", group.Person2.FullName);
+			Assert.Equal($"{oldFirstName.ToUpperInvariant()} UnsetValue {oldLastName}", label2.Text);
 
 			label2.Text = oldName;
 			Assert.Equal(oldName, group.Person2.FullName);
@@ -285,7 +285,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		//	Assert.Equal(0, converter.ConvertBacks);
 
 		//	// Source change results in 1 additional Convert, no ConvertBack's
-		//	group.Person1.FirstName = group.Person1.FullName.ToUpper();
+		//	group.Person1.FirstName = group.Person1.FullName.ToUpperInvariant();
 		//	Assert.Equal(3, converter.Converts);
 		//	Assert.Equal(0, converter.ConvertBacks);
 
@@ -315,8 +315,8 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			var label2W = GenerateNameLabel(nameof(group.Person2), BindingMode.TwoWay);
 			stack.Children.Add(label2W);
 			Assert.Equal(group.Person2.FullName, label2W.Text);
-			label2W.Text = group.Person2.FullName.ToUpper();
-			Assert.Equal(group.Person2.FullName.ToUpper(), label2W.Text);
+			label2W.Text = group.Person2.FullName.ToUpperInvariant();
+			Assert.Equal(group.Person2.FullName.ToUpperInvariant(), label2W.Text);
 
 			oldName = group.Person3.FullName;
 			var label1WTS = GenerateNameLabel(nameof(group.Person3), BindingMode.OneWayToSource);

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Gh7837.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Gh7837.xaml.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 	public class Gh7837VM : Gh7837VMBase
 	{
 		public new string this[int index] => index == 42 ? "forty-two" : "dull number";
-		public new string this[string index] => index.ToUpper();
+		public new string this[string index] => index.ToUpperInvariant();
 	}
 
 	public partial class Gh7837 : ContentPage

--- a/src/Core/src/Platform/Android/BorderDrawable.cs
+++ b/src/Core/src/Platform/Android/BorderDrawable.cs
@@ -387,7 +387,7 @@ namespace Microsoft.Maui.Platform
 				if (_context.Theme.ResolveAttribute(global::Android.Resource.Attribute.WindowBackground, background, true))
 				{
 					var resource = _context.Resources.GetResourceTypeName(background.ResourceId);
-					var type = resource?.ToLower();
+					var type = resource?.ToLowerInvariant();
 
 					if (type == "color")
 					{

--- a/src/Core/src/Platform/Android/ViewExtensions.cs
+++ b/src/Core/src/Platform/Android/ViewExtensions.cs
@@ -145,7 +145,7 @@ namespace Microsoft.Maui.Platform
 			{
 				if (context.Theme.ResolveAttribute(global::Android.Resource.Attribute.WindowBackground, background, true))
 				{
-					string? type = context.Resources.GetResourceTypeName(background.ResourceId)?.ToLower();
+					string? type = context.Resources.GetResourceTypeName(background.ResourceId)?.ToLowerInvariant();
 
 					if (type != null)
 					{

--- a/src/Core/src/Platform/Windows/LabelHtmlHelper.cs
+++ b/src/Core/src/Platform/Windows/LabelHtmlHelper.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Maui.Platform
 				return;
 
 			var currentInlines = inlines;
-			var elementName = element.Name.ToString().ToUpper();
+			var elementName = element.Name.ToString().ToUpperInvariant();
 			switch (elementName)
 			{
 				case ElementB:

--- a/src/Core/tests/Benchmarks/Benchmarks/GridLayoutManagerBenchMarker.cs
+++ b/src/Core/tests/Benchmarks/Benchmarks/GridLayoutManagerBenchMarker.cs
@@ -177,7 +177,7 @@ namespace Microsoft.Maui.Handlers.Benchmarks
 				return new GridLength(double.Parse(gridLength), GridUnitType.Star);
 			}
 
-			if (gridLength.ToLower() == "auto")
+			if (gridLength.ToLowerInvariant() == "auto")
 			{
 				return GridLength.Auto;
 			}

--- a/src/Core/tests/UnitTests/Layouts/GridLayoutManagerTests.cs
+++ b/src/Core/tests/UnitTests/Layouts/GridLayoutManagerTests.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 				return new GridLength(double.Parse(gridLength), GridUnitType.Star);
 			}
 
-			if (gridLength.ToLower() == "auto")
+			if (gridLength.ToLowerInvariant() == "auto")
 			{
 				return GridLength.Auto;
 			}

--- a/src/Graphics/src/Graphics/Text/TextColors.cs
+++ b/src/Graphics/src/Graphics/Text/TextColors.cs
@@ -158,7 +158,7 @@ namespace Microsoft.Maui.Graphics.Text
 			//Remove # if present
 			if (!color.StartsWith("#", StringComparison.Ordinal))
 			{
-				if (!StandardColors.TryGetValue(color.ToUpper(), out color))
+				if (!StandardColors.TryGetValue(color.ToUpperInvariant(), out color))
 					return null;
 			}
 
@@ -201,7 +201,7 @@ namespace Microsoft.Maui.Graphics.Text
 			//Remove # if present
 			if (!color.StartsWith("#", StringComparison.Ordinal))
 			{
-				if (!StandardColors.TryGetValue(color.ToUpper(), out color))
+				if (!StandardColors.TryGetValue(color.ToUpperInvariant(), out color))
 					return null;
 			}
 

--- a/src/SingleProject/Resizetizer/src/TizenSplashUpdater.cs
+++ b/src/SingleProject/Resizetizer/src/TizenSplashUpdater.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Maui.Resizetizer
 
 				if (File.Exists(destination))
 				{
-					var resolution = dpi.Path.Split('-')[1].ToLower();
+					var resolution = dpi.Path.Split('-')[1].ToLowerInvariant();
 					foreach (var orientation in orientations)
 					{
 						var newImage = splashInfo.OutputName + "." + resolution + "." + orientation + ".png";

--- a/src/TestUtils/src/DeviceTests/AssertionExtensions.Android.cs
+++ b/src/TestUtils/src/DeviceTests/AssertionExtensions.Android.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Maui.DeviceTests
 
 			// I tried various permutations of KeyEventActions to set the keyboard in upper case
 			// But I wasn't successful
-			if (Enum.TryParse($"{value}".ToUpper(), out Keycode result))
+			if (Enum.TryParse($"{value}".ToUpperInvariant(), out Keycode result))
 			{
 				view.OnCreateInputConnection(new EditorInfo())?
 					.SendKeyEvent(new KeyEvent(10, 10, KeyEventActions.Down, result, 0));

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/AndroidTemplateTests.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/AndroidTemplateTests.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Maui.IntegrationTests
 			Assert.IsTrue(DotnetInternal.Build(projectFile, config, target: "Install", framework: $"{framework}-android", properties: BuildProps),
 				$"Project {Path.GetFileName(projectFile)} failed to install. Check test output/attachments for errors.");
 
-			testPackage = $"com.companyname.{Path.GetFileName(projectDir).ToLower()}";
+			testPackage = $"com.companyname.{Path.GetFileName(projectDir).ToLowerInvariant()}";
 			Assert.IsTrue(XHarness.RunAndroid(testPackage, Path.Combine(projectDir, "xh-results"), -1),
 				$"Project {Path.GetFileName(projectFile)} failed to run. Check test output/attachments for errors.");
 		}


### PR DESCRIPTION
Context: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1311
Context: https://learn.microsoft.com/previous-versions/dotnet/articles/ms994325(v=msdn.10)#the-turkish-example

In 8a58e01f, I found & fixed some performance issues around culture-aware strings. This takes this further by making `CA1311` a build error.

As mentioned in "the turkish example", doing something like:

    string text = something.ToUpper();
    switch (text) { ... }

Can actually cause unexpected behavior in Turkish locales, because in Turkish, the character I (Unicode 0049) is considered the upper case version of a different character ý (Unicode 0131), and i (Unicode 0069) is considered the lower case version of yet another character Ý (Unicode 0130).

`ToLowerInvariant()` and `ToUpperInvariant()` are also better for startup performance as it avoids loading the current culture.

I only found one place that actually *would* want to use the current culture, which is in `CaseConverter.cs`.