### PR TITLE
[Android] Avoid OnDestroy lifecycle event firing twice

### DIFF
--- a/src/Core/src/Platform/Android/MauiAppCompatActivity.Lifecycle.cs
+++ b/src/Core/src/Platform/Android/MauiAppCompatActivity.Lifecycle.cs
@@ -89,12 +89,5 @@ namespace Microsoft.Maui
 
 			MauiApplication.Current?.Services?.InvokeLifecycleEvents<AndroidLifecycle.OnRestoreInstanceState>(del => del(this, savedInstanceState));
 		}
-
-		protected override void OnDestroy()
-		{
-			base.OnDestroy();
-
-			MauiApplication.Current?.Services?.InvokeLifecycleEvents<AndroidLifecycle.OnDestroy>(del => del(this));
-		}
 	}
 }

--- a/src/Core/src/PublicAPI/net-android/PublicAPI.Shipped.txt
+++ b/src/Core/src/PublicAPI/net-android/PublicAPI.Shipped.txt
@@ -2218,7 +2218,6 @@ override Microsoft.Maui.MauiAppCompatActivity.OnActivityResult(int requestCode, 
 override Microsoft.Maui.MauiAppCompatActivity.OnBackPressed() -> void
 override Microsoft.Maui.MauiAppCompatActivity.OnConfigurationChanged(Android.Content.Res.Configuration! newConfig) -> void
 override Microsoft.Maui.MauiAppCompatActivity.OnCreate(Android.OS.Bundle? savedInstanceState) -> void
-override Microsoft.Maui.MauiAppCompatActivity.OnDestroy() -> void
 override Microsoft.Maui.MauiAppCompatActivity.OnNewIntent(Android.Content.Intent? intent) -> void
 override Microsoft.Maui.MauiAppCompatActivity.OnPostCreate(Android.OS.Bundle? savedInstanceState) -> void
 override Microsoft.Maui.MauiAppCompatActivity.OnPostResume() -> void


### PR DESCRIPTION
### Description of Change

Avoid Android **OnDestroy** lifecycle event firing twice.

```
[0:] Lifecycle event: OnBackPressed
[0:] Lifecycle event: OnBackPressed (shortcut)
[0:] Lifecycle event: OnPause
[DOTNET] OnStopped
[0:] Lifecycle event: OnStop
[0:] Lifecycle event: OnSaveInstanceState
[0:] Lifecycle event: OnSaveInstanceState (shortcut)
[0:] OnDisappearing: Maui.Controls.Sample.Pages.MainPage
[DOTNET] OnDestroying
[0:] Lifecycle event: OnDestroy
```

### Issues Fixed

Fixes #8541
