### PR TITLE
Platfrom/Android: fix toolbar text color

### DIFF
--- a/src/Core/src/Platform/Android/Resources/values/styles.xml
+++ b/src/Core/src/Platform/Android/Resources/values/styles.xml
@@ -10,6 +10,7 @@
         <item name="bottomNavigationViewStyle">@style/Widget.Design.BottomNavigationView</item>
         <item name="materialButtonStyle">@style/MauiMaterialButton</item>
         <item name="checkboxStyle">@style/MauiCheckBox</item>
+        <item name="toolbarStyle">@style/MauiToolbarStyle</item>
         <item name="android:textAllCaps">false</item>
     </style>
     <style name="Maui.MainTheme.NoActionBar" parent="Maui.MainTheme">
@@ -44,6 +45,10 @@
     <style name="AppTheme" parent="Maui.MainTheme" />
     <style name="AppTheme.NoActionBar" parent="Maui.MainTheme.NoActionBar" />
 
+    <style name="MauiToolbarStyle" parent="@style/Widget.AppCompat.Toolbar">
+        <item name="titleTextColor">@android:color/white</item>
+    </style>
+    
     <style name="MauiMaterialButton" parent="Widget.MaterialComponents.Button.UnelevatedButton">
       <!-- remove all the min sizes as MAUI manages it -->
       <item name="android:minWidth">0dp</item>


### PR DESCRIPTION
Fix color of text in toolbar in default Android theme.
It was dark on dark background, now it's white on dark background. 

Fixes https://github.com/dotnet/maui/issues/14793