### PR TITLE
Make sure to call `InitializeViewHandler` when creating a handler

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Label/LabelTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Label/LabelTests.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Maui.DeviceTests
 				builder.ConfigureMauiHandlers(handlers =>
 				{
 					handlers.AddHandler<Label, LabelHandler>();
+					handlers.AddHandler<Layout, LayoutHandler>();
 				});
 			});
 		}

--- a/src/Core/tests/DeviceTests.Shared/HandlerTests/HandlerTestBasement.cs
+++ b/src/Core/tests/DeviceTests.Shared/HandlerTests/HandlerTestBasement.cs
@@ -202,7 +202,11 @@ namespace Microsoft.Maui.DeviceTests
 				return action.Invoke((IPlatformViewHandler)handler);
 			}, MauiContext, (view) =>
 			{
+				if (view.Handler is IPlatformViewHandler platformViewHandler)
+					return Task.FromResult(platformViewHandler);
+
 				var handler = view.ToHandler(MauiContext);
+				InitializeViewHandler(view, handler, MauiContext);
 				return Task.FromResult(handler);
 			});
 		}

--- a/src/TestUtils/src/DeviceTests/AssertionExtensions.cs
+++ b/src/TestUtils/src/DeviceTests/AssertionExtensions.cs
@@ -92,41 +92,6 @@ namespace Microsoft.Maui.DeviceTests
 			}
 		}
 
-		public static Task AttachAndRun(this IView view, Action<IPlatformViewHandler> action, IMauiContext mauiContext) =>
-				view.AttachAndRun<bool>((handler) =>
-				{
-					action(handler);
-					return Task.FromResult(true);
-				}, mauiContext);
-
-		public static Task AttachAndRun(this IView view, Func<IPlatformViewHandler, Task> action, IMauiContext mauiContext)
-			 =>
-				view.AttachAndRun<bool>(async (handler) =>
-				{
-					await action(handler);
-					return true;
-				}, mauiContext);
-
-		public static Task<T> AttachAndRun<T>(this IView view, Func<IPlatformViewHandler, T> action, IMauiContext mauiContext)
-		{
-			Func<IPlatformViewHandler, Task<T>> taskAction = (handler) =>
-			{
-				return Task.FromResult(action.Invoke(handler));
-			};
-
-			return view.AttachAndRun<T>(taskAction, mauiContext);
-		}
-
-		public static Task<T> AttachAndRun<T>(this IView view, Func<IPlatformViewHandler, Task<T>> action, IMauiContext mauiContext) =>
-			view.AttachAndRun<T, IPlatformViewHandler>(action, mauiContext, (view) =>
-			{
-				var handler = view.ToHandler(mauiContext);
-				return Task.FromResult(handler);
-			});
-
-
-
-
 		public static Task AttachAndRun<THandler>(this IView view, Action<THandler> action, IMauiContext mauiContext, Func<IView, Task<THandler>> createHandler)
 		where THandler : IPlatformViewHandler =>
 			view.AttachAndRun<bool, THandler>((handler) =>


### PR DESCRIPTION
### Description of Change

When we create a handler via `AttachAndRun` we need to make sure to call `InitializeViewHandler` on the created handler