### PR TITLE
[controls] improve performance of {Binding}

### DIFF
--- a/src/Controls/src/Core/BindingExpression.cs
+++ b/src/Controls/src/Core/BindingExpression.cs
@@ -377,8 +377,7 @@ namespace Microsoft.Maui.Controls
 				if (property.CanWrite && property.SetMethod.IsPublic && !property.SetMethod.IsStatic)
 				{
 					part.LastSetter = property.SetMethod;
-					var lastSetterParameters = part.LastSetter.GetParameters();
-					part.SetterType = lastSetterParameters[lastSetterParameters.Length - 1].ParameterType;
+					part.SetterType = property.PropertyType;
 
 					if (Binding.AllowChaining)
 					{

--- a/src/Core/tests/Benchmarks/Benchmarks/BindingBenchmarker.cs
+++ b/src/Core/tests/Benchmarks/Benchmarks/BindingBenchmarker.cs
@@ -1,0 +1,72 @@
+﻿using System.Collections.Generic;
+using BenchmarkDotNet.Attributes;
+using Microsoft.Maui.Controls;
+
+namespace Microsoft.Maui.Benchmarks
+{
+	[MemoryDiagnoser]
+	public class BindingBenchmarker
+	{
+		// Avoids the warning:
+		// The minimum observed iteration time is 10.1000 us which is very small. It's recommended to increase it to at least 100.0000 ms using more operations.
+		const int Iterations = 10;
+
+		class MyObject : BindableObject
+		{
+			public static readonly BindableProperty NameProperty = BindableProperty.Create(nameof(Name), typeof(string), typeof(MyObject), default(string));
+
+			public string Name
+			{
+				get { return (string)GetValue(NameProperty); }
+				set { SetValue(NameProperty, value); }
+			}
+
+			public MyObject Child { get; set; }
+
+			public List<MyObject> Children { get; private set; } = new List<MyObject>();
+		}
+
+		readonly MyObject Source = new()
+		{
+			Name = "A",
+			Child = new() { Name = "A.Child" },
+			Children =
+			{
+				new() { Name = "A.Children[0]" },
+				new() { Name = "A.Children[1]" },
+			}
+		};
+		readonly MyObject Target = new() { Name = "B" };
+
+
+		[Benchmark]
+		public void BindName()
+		{
+			for (int i = 0; i < Iterations; i++)
+			{
+				var binding = new Binding("Name", source: Source);
+				Target.SetBinding(MyObject.NameProperty, binding);
+			}
+		}
+
+		[Benchmark]
+		public void BindChild()
+		{
+			for (int i = 0; i < Iterations; i++)
+			{
+				var binding = new Binding("Child.Name", source: Source);
+				Target.SetBinding(MyObject.NameProperty, binding);
+			}
+		}
+
+		[Benchmark]
+		public void BindChildIndexer()
+		{
+			for (int i = 0; i < Iterations; i++)
+			{
+				var binding = new Binding("Children[0].Name", source: Source);
+				Target.SetBinding(MyObject.NameProperty, binding);
+			}
+		}
+	}
+}


### PR DESCRIPTION
I wrote a benchmark for `Binding`, such as:

    [Benchmark]
    public void BindName()
    {
        var binding = new Binding("Name", source: Source);
        Target.SetBinding(MyObject.NameProperty, binding);
    }

Attaching `dotnet-trace`, I found ~53% of the time was spent in `MethodInfo.GetParameters()`:

    core.benchmarks!Microsoft.Maui.Benchmarks.BindingBenchmarker.BindName()
    ...
    microsoft.maui.controls!Microsoft.Maui.Controls.BindingExpression.SetupPart()
    System.Private.CoreLib.il!System.Reflection.RuntimeMethodInfo.GetParameters()

Reviewing the code, it was basically calling:

    System.Reflection.PropertyInfo.SetMethod.GetParameters()[0].ParameterType;

We can just call `PropertyInfo.PropertyType` instead, to avoid allocating a `ParameterInfo[]` and indexing into it.

The results of this change in my benchmarks:

|             Method |     Mean |    Error |   StdDev |   Gen0 |   Gen1 | Allocated |
|------------------- |---------:|---------:|---------:|-------:|-------:|----------:|
|         --BindName | 18.82 us | 0.336 us | 0.471 us | 1.2817 | 1.2512 |  10.55 KB |
|         ++BindName | 18.80 us | 0.371 us | 0.555 us | 1.2512 | 1.2207 |  10.23 KB |
|        --BindChild | 27.47 us | 0.542 us | 0.827 us | 2.0142 | 1.9836 |  16.56 KB |
|        ++BindChild | 26.71 us | 0.516 us | 0.652 us | 1.9226 | 1.8921 |  15.94 KB |
| --BindChildIndexer | 58.39 us | 1.113 us | 1.143 us | 3.1738 | 3.1128 |  26.17 KB |
| ++BindChildIndexer | 58.00 us | 1.055 us | 1.295 us | 3.1128 | 3.0518 |  25.47 KB |

-- Before
++ After

This should help scrolling performance such as in #12130, where bindings are updating while scrolling.