### PR TITLE
[android] MauiTextView doesn't need ViewAttachedToWindow

### DIFF
--- a/src/Core/src/Platform/Android/MauiTextView.cs
+++ b/src/Core/src/Platform/Android/MauiTextView.cs
@@ -8,11 +8,6 @@ namespace Microsoft.Maui.Platform
 	{
 		public MauiTextView(Context context) : base(context)
 		{
-			this.ViewAttachedToWindow += MauiTextView_ViewAttachedToWindow;
-		}
-
-		private void MauiTextView_ViewAttachedToWindow(object? sender, ViewAttachedToWindowEventArgs e)
-		{
 		}
 
 		internal event EventHandler<LayoutChangedEventArgs>? LayoutChanged;


### PR DESCRIPTION
Context: https://github.com/dotnet/maui/issues/12130
Context: https://github.com/angelru/CvSlowJittering

Profiling a customer sample, I noticed that ~2.4% of of the time was spent subscribing to `ViewAttachedToWindow`:

    278.55ms (2.4%) mono.android!Android.Views.View.add_ViewAttachedToWindow(System.EventHandler`1<Android.Views.View/ViewAttachedToWindowEv

It appeared that for every `Label` on Android, we setup this event. Additionally, Java would have to call into C# when the event fires:

    30.55ms (0.26%) mono.android!Android.Views.View.IOnAttachStateChangeListenerInvoker.n_OnViewAttachedToWindow_Landroid_view_View__mm_wra

However, we don't actually *do* anything in the event (added in b6c3b533), so we should be able to just delete it?

    this.ViewAttachedToWindow += MauiTextView_ViewAttachedToWindow;
    //...
    private void MauiTextView_ViewAttachedToWindow(object? sender, ViewAttachedToWindowEventArgs e)
    {
    }

Doing this, dropped the call to ~0.02%:

    2.76ms (0.02%) mono.android!Android.Views.View.add_ViewAttachedToWindow(System.EventHandler`1<Android.Views.View/ViewAttachedToWindowEv

And the above `IOnAttachStateChangeListenerInvoker` call is gone completely.

This should improve the performance of every `Label` on Android.
