### PR TITLE
Removing skip attribute from SearchBarHandlerTests.CancelButtonColorInitializeCorrectly on Windows

### DIFF
--- a/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.cs
@@ -120,11 +120,7 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.Equal(expectedText, platformText);
 		}
 
-		[Fact(DisplayName = "CancelButtonColor Initialize Correctly"
-#if WINDOWS
-			, Skip = "This test currently fails on Windows due to https://github.com/dotnet/maui/issues/13507"
-#endif
-			)]
+		[Fact(DisplayName = "CancelButtonColor Initialize Correctly")]
 		public async Task CancelButtonColorInitializeCorrectly()
 		{
 			var searchBar = new SearchBarStub()


### PR DESCRIPTION
### Description of Change

I previously disabled this test on Windows due to it failing, but with the fix for https://github.com/dotnet/maui/issues/13507 it can be reenabled.

### Issues Fixed

No issue, just adds back a test
