### PR TITLE
[tests] Update timeout for iOS template runs

### DIFF
--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/AppleTemplateTests.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/AppleTemplateTests.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Maui.IntegrationTests
 
 			var appFile = Path.Combine(projectDir, "bin", config, $"{framework}-ios", "iossimulator-x64", $"{Path.GetFileName(projectDir)}.app");
 
-			Assert.IsTrue(XHarness.RunAppleForTimeout(appFile, Path.Combine(projectDir, "xh-results"), TestSimulator.XHarnessID, 25),
+			Assert.IsTrue(XHarness.RunAppleForTimeout(appFile, Path.Combine(projectDir, "xh-results"), TestSimulator.XHarnessID),
 				$"Project {Path.GetFileName(projectFile)} failed to run. Check test output/attachments for errors.");
 		}
 

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/XHarness.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/XHarness.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Maui.IntegrationTests
 		/// <param name="targetDevice"></param>
 		/// <param name="launchTimeoutSeconds"></param>
 		/// <returns>True if the app launch command timed out, false if it exits early.</returns>
-		public static bool RunAppleForTimeout(string appPath, string resultDir, string targetDevice, int launchTimeoutSeconds = 120)
+		public static bool RunAppleForTimeout(string appPath, string resultDir, string targetDevice, int launchTimeoutSeconds = 75)
 		{
 			var timeoutString = TimeSpan.FromSeconds(launchTimeoutSeconds).ToString();
 			var args = $"apple run --app=\"{appPath}\" --output-directory=\"{resultDir}\" --target={targetDevice} --timeout=\"{timeoutString}\" --verbosity=Debug";


### PR DESCRIPTION
Bumps the timeout for running iOS templates on simulator from 25 to 75
seconds.  We've been seeing intermittent failures in this test which are
likely caused by differences in simulator launch/startup times across
different test machines.