### PR TITLE
Remove view from previous containerview

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Core/ModalPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/ModalPage.xaml.cs
@@ -24,6 +24,9 @@ namespace Maui.Controls.Sample.Pages
 
 		protected override void OnNavigatedTo(NavigatedToEventArgs args)
 		{
+			if (this.Window is null)
+				return;
+
 			if (PopModal.IsVisible)
 			{
 				this.Window.Title = "Modal Gallery";

--- a/src/Controls/src/Core/HandlerImpl/NavigationPage/NavigationPage.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/NavigationPage/NavigationPage.Impl.cs
@@ -112,7 +112,10 @@ namespace Microsoft.Maui.Controls
 			if (this.Toolbar != null)
 				return Toolbar;
 
-			var rootPage = this.FindParentWith(x => (x is IWindow te || Navigation.ModalStack.Contains(x)), true);
+			if (this.Window is null)
+				return null;
+
+			var rootPage = this.FindParentWith(x => (x is IWindow te || Window.Navigation.ModalStack.Contains(x)), true);
 			if (this.FindParentWith(x => (x is IToolbarElement te && te.Toolbar != null), false) is IToolbarElement te)
 			{
 				// This means I'm inside a Modal Page so we shouldn't return the Toolbar from the window
@@ -129,16 +132,20 @@ namespace Microsoft.Maui.Controls
 		{
 			// If this NavigationPage is removed from the window
 			// Then we just invalidate the toolbar that this NavigationPage created
-			if (this.Window is null && _toolbar is not null)
+			if (this.Window is null)
 			{
-				if (_toolbar.Parent is Window w &&
-					w.Toolbar == _toolbar)
+				if (_toolbar is not null)
 				{
-					w.Toolbar = null;
+					if (_toolbar.Parent is Window w &&
+						w.Toolbar == _toolbar)
+					{
+						w.Toolbar = null;
+					}
+
+					_toolbar.Disconnect();
+					_toolbar = null;
 				}
 
-				_toolbar.Disconnect();
-				_toolbar = null;
 				return;
 			}
 
@@ -157,7 +164,7 @@ namespace Microsoft.Maui.Controls
 				else
 				{
 					// Is the root the window or is this part of a modal stack
-					var rootPage = this.FindParentWith(x => (x is IWindow te || Navigation.ModalStack.Contains(x)), true);
+					var rootPage = this.FindParentWith(x => (x is IWindow te || Window.Navigation.ModalStack.Contains(x)), true);
 
 					if (rootPage is Window w)
 					{

--- a/src/Controls/src/Core/HandlerImpl/Window/Window.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Window/Window.Impl.cs
@@ -577,22 +577,8 @@ namespace Microsoft.Maui.Controls
 
 		static void OnPageChanging(BindableObject bindable, object oldValue, object newValue)
 		{
-			if (bindable is not Window window)
-				return;
-
 			if (oldValue is Page oldPage)
 				oldPage.SendDisappearing();
-
-			if (newValue is IToolbarElement toolbarElement &&
-				toolbarElement.Toolbar is Toolbar tb &&
-				newValue is not Shell)
-			{
-				window.Toolbar = tb;
-			}
-			else
-			{
-				window.Toolbar = null;
-			}
 		}
 
 		void OnPageChanged(Page? oldPage, Page? newPage)

--- a/src/Controls/src/Core/NavigationPageToolbar.cs
+++ b/src/Controls/src/Core/NavigationPageToolbar.cs
@@ -16,7 +16,9 @@ namespace Microsoft.Maui.Controls
 		string _title;
 		VisualElement _titleView;
 		bool _drawerToggleVisible;
-		Page _rootPage;
+		bool _backButtonVisible;
+		bool _userChanged;
+		internal Page RootPage { get; private set; }
 		List<NavigationPage> _navigationPagesStack = new List<NavigationPage>();
 		internal NavigationPage CurrentNavigationPage => _currentNavigationPage;
 		internal ToolbarTracker ToolbarTracker => _toolbarTracker;
@@ -28,11 +30,16 @@ namespace Microsoft.Maui.Controls
 
 		public NavigationPageToolbar(Maui.IElement parent, Page rootPage) : base(parent)
 		{
-			_toolbarTracker.CollectionChanged += (_, __) => ToolbarItems = _toolbarTracker.ToolbarItems;
-			_rootPage = rootPage;
+			_toolbarTracker.CollectionChanged += OnToolbarItemsChanged;
+			RootPage = rootPage;
 			_toolbarTracker.PageAppearing += OnPageAppearing;
 			_toolbarTracker.PagePropertyChanged += OnPagePropertyChanged;
-			_toolbarTracker.Target = _rootPage;
+			_toolbarTracker.Target = RootPage;
+		}
+
+		void OnToolbarItemsChanged(object sender, EventArgs e)
+		{
+			ToolbarItems = _toolbarTracker.ToolbarItems;
 		}
 
 		void OnPagePropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
@@ -89,14 +96,14 @@ namespace Microsoft.Maui.Controls
 			_hasAppeared = true;
 
 			ApplyChanges(_currentNavigationPage);
+		}
 
-			// This is to catch scenarios where the user
-			// inserts or removes the root page.
-			// Which will cause the back button visibility to change.
-			void NavigationPageChildrenChanged(object s, ElementEventArgs a)
-			{
-				ApplyChanges(_currentNavigationPage);
-			}
+		// This is to catch scenarios where the user
+		// inserts or removes the root page.
+		// Which will cause the back button visibility to change.
+		void NavigationPageChildrenChanged(object s, ElementEventArgs a)
+		{
+			ApplyChanges(_currentNavigationPage);
 		}
 
 		bool GetBackButtonVisible()
@@ -106,9 +113,6 @@ namespace Microsoft.Maui.Controls
 
 			return NavigationPage.GetHasBackButton(_currentPage) && GetBackButtonVisibleCalculated(false).Value;
 		}
-
-		bool _backButtonVisible;
-		bool _userChanged;
 
 		public override bool BackButtonVisible
 		{
@@ -286,6 +290,26 @@ namespace Microsoft.Maui.Controls
 			}
 
 			return NavigationPage.GetTitleView(target);
+		}
+
+		internal void Disconnect()
+		{
+			if (_toolbarTracker is not null)
+			{
+				_toolbarTracker.PageAppearing -= OnPageAppearing;
+				_toolbarTracker.PagePropertyChanged -= OnPagePropertyChanged;
+				_toolbarTracker.CollectionChanged -= OnToolbarItemsChanged;
+				_toolbarTracker.Target = null;
+			}
+
+			if (_navigationPagesStack is not null)
+			{
+				foreach (var navPage in _navigationPagesStack)
+				{
+					navPage.ChildAdded -= NavigationPageChildrenChanged;
+					navPage.ChildRemoved -= NavigationPageChildrenChanged;
+				}
+			}
 		}
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/ToolbarTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ToolbarTests.cs
@@ -234,5 +234,26 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			await outerNavigationPage.PopAsync();
 			Assert.False(toolbar.BackButtonVisible);
 		}
+
+		[Fact]
+		public async Task ToolbarDoesntSetOnWindowWhenSwappingBackToSameFlyoutPage()
+		{
+			var window = new TestWindow();
+			var navPage = new NavigationPage(new ContentPage()) { Title = "Detail" };
+			var flyoutPage = new FlyoutPage()
+			{
+				Detail = navPage,
+				Flyout = new ContentPage() { Title = "Flyout" }
+			};
+
+			IToolbarElement windowToolbarElement = window;
+
+			window.Page = flyoutPage;
+			window.Page = new ContentPage();
+			window.Page = flyoutPage;
+
+			Assert.Null(windowToolbarElement.Toolbar);
+			Assert.NotNull((flyoutPage as IToolbarElement).Toolbar);
+		}
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/ToolbarTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ToolbarTests.cs
@@ -255,5 +255,29 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.Null(windowToolbarElement.Toolbar);
 			Assert.NotNull((flyoutPage as IToolbarElement).Toolbar);
 		}
+
+		[Fact]
+		public async Task ToolbarSetsToCorrectPageWithModal()
+		{
+			var window = new TestWindow();
+			IToolbarElement toolbarElement = window;
+			var startingPage = new TestNavigationPage(true, new ContentPage());
+			window.Page = startingPage;
+
+			await startingPage.NavigatingTask;
+
+			var rootPageToolbar = toolbarElement.Toolbar;
+
+			var modalPage = new TestNavigationPage(true, new ContentPage());
+			await startingPage.Navigation.PushModalAsync(modalPage);
+
+			Assert.Equal(rootPageToolbar, toolbarElement.Toolbar);
+
+			var modalPageToolBar = (modalPage as IToolbarElement).Toolbar;
+
+			Assert.NotNull(modalPageToolBar);
+			Assert.NotEqual(modalPageToolBar, rootPageToolbar);
+
+		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/ControlsHandlerTestBase.Android.cs
+++ b/src/Controls/tests/DeviceTests/ControlsHandlerTestBase.Android.cs
@@ -154,15 +154,30 @@ namespace Microsoft.Maui.DeviceTests
 		protected MaterialToolbar GetPlatformToolbar(IMauiContext mauiContext)
 		{
 			var navManager = mauiContext.GetNavigationRootManager();
+			if (navManager?.RootView is null)
+				return null;
+
 			var appbarLayout =
-				navManager?.RootView?.FindViewById<AViewGroup>(Resource.Id.navigationlayout_appbar);
+				navManager.RootView.FindViewById<AViewGroup>(Resource.Id.navigationlayout_appbar);
+
+			if (appbarLayout is null &&
+				navManager.RootView is ContainerView cv &&
+				cv.CurrentView is Shell shell)
+			{
+				if (shell.Handler is Controls.Platform.Compatibility.IShellContext sr)
+				{
+					var layout = sr.CurrentDrawerLayout;
+					var content = layout?.GetFirstChildOfType<Controls.Platform.Compatibility.CustomFrameLayout>();
+					appbarLayout = content?.GetFirstChildOfType<AppBarLayout>();
+				}
+			}
 
 			var toolBar = appbarLayout?.GetFirstChildOfType<MaterialToolbar>();
 
 			toolBar = toolBar ?? navManager.ToolbarElement?.Toolbar?.Handler?.PlatformView as
 				MaterialToolbar;
 
-			if (toolBar == null)
+			if (toolBar is null)
 			{
 				appbarLayout =
 					(navManager?.RootView as AViewGroup)?.GetFirstChildOfType<AppBarLayout>();

--- a/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.iOS.cs
@@ -225,7 +225,7 @@ namespace Microsoft.Maui.DeviceTests
 		{
 			[Theory]
 			[ClassData(typeof(ControlsPageTypesTestCases))]
-			public async Task NextMovesToNextEntry(string page)
+			public async Task NextMovesToNextEntry(ControlsPageTypesTestCase page)
 			{
 				bool isFocused = false;
 				EnsureHandlerCreated(builder =>

--- a/src/Controls/tests/DeviceTests/Elements/Toolbar/ToolbarTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Toolbar/ToolbarTests.cs
@@ -144,16 +144,17 @@ namespace Microsoft.Maui.DeviceTests
 					nextPage = GetPage(pageSet[i]);
 					window.Page = nextPage;
 
-					if (window.Page is IPageContainer<Page> pc)
-						await OnLoadedAsync(pc.CurrentPage);
-					else
-						await OnLoadedAsync(window.Page);
+					var currentPage = window.Page;
+
+					currentPage = Controls.Platform.PageExtensions.GetCurrentPage(currentPage);
+
+					await OnLoadedAsync(currentPage);
 
 					var shouldHaveToolbar =
 						pageSet[i].Contains("NavigationPage", StringComparison.OrdinalIgnoreCase) ||
 						pageSet[i].Contains("Shell", StringComparison.OrdinalIgnoreCase);
 
-					Assert.Equal(shouldHaveToolbar, IsNavigationBarVisible(nextPage.Handler));
+					Assert.Equal(shouldHaveToolbar, IsNavigationBarVisible(currentPage.Handler));
 				}
 			});
 

--- a/src/Controls/tests/DeviceTests/Elements/Toolbar/ToolbarTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Toolbar/ToolbarTests.cs
@@ -8,6 +8,7 @@ using Microsoft.Maui;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Handlers;
 using Microsoft.Maui.DeviceTests.Stubs;
+using Microsoft.Maui.DeviceTests.TestCases;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Hosting;
 using Microsoft.Maui.Platform;
@@ -116,18 +117,67 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
+		[Theory]
+		[InlineData($"{nameof(FlyoutPage)}WithNavigationPage, {nameof(ContentPage)}, {nameof(FlyoutPage)}WithNavigationPage")]
+		[InlineData($"{nameof(FlyoutPage)}WithNavigationPage, {nameof(FlyoutPage)}, {nameof(FlyoutPage)}WithNavigationPage")]
+		[InlineData($"{nameof(FlyoutPage)}WithNavigationPage, {nameof(NavigationPage)}, {nameof(FlyoutPage)}WithNavigationPage")]
+		[InlineData($"{nameof(Shell)}, {nameof(ContentPage)}, {nameof(Shell)}")]
+		[InlineData($"FlyoutPageWithNavigationPage, NavigationPageWithFlyoutPage, FlyoutPageWithNavigationPage")]
+		public async Task ToolbarUpdatesCorrectlyWhenSwappingMainPageWithAlreadyUsedPage(string pages)
+		{
+			string[] pageSet = pages.Split(',');
+
+			SetupBuilder();
+			Dictionary<ControlsPageTypesTestCase, Page> createdPages
+				= new Dictionary<ControlsPageTypesTestCase, Page>();
+
+			var window = new Window(GetPage(pageSet[0]));
+
+			await CreateHandlerAndAddToWindow<IWindowHandler>(window, async (handler) =>
+			{
+				await OnLoadedAsync(window.Page);
+
+				for (int i = 1; i < pageSet.Length; i++)
+				{
+					var nextPage = GetPage(pageSet[i]);
+
+					window.Page = GetPage(pageSet[i]);
+					if (window.Page is IPageContainer<Page> pc)
+						await OnLoadedAsync(pc.CurrentPage);
+					else
+						await OnLoadedAsync(window.Page);
+
+					bool shouldHaveToolbar =
+						pageSet[i].Contains("NavigationPage", StringComparison.OrdinalIgnoreCase) ||
+						pageSet[i].Contains("Shell", StringComparison.OrdinalIgnoreCase);
+
+					Assert.Equal(shouldHaveToolbar, IsNavigationBarVisible(nextPage.Handler));
+				}
+			}, timeOut: TimeSpan.FromMinutes(10));
+
+			Page GetPage(string name)
+			{
+				var result = (ControlsPageTypesTestCase)Enum.Parse(typeof(ControlsPageTypesTestCase), name);
+
+				if (!createdPages.ContainsKey(result))
+					createdPages[result] = ControlsPageTypesTestCases.CreatePageType(result);
+
+				return createdPages[result];
+			}
+		}
+
 #if !IOS && !MACCATALYST
 		[Theory(DisplayName = "Toolbar Recreates With New MauiContext")]
-		[InlineData(typeof(FlyoutPage))]
-		[InlineData(typeof(NavigationPage))]
-		[InlineData(typeof(TabbedPage))]
-		[InlineData(typeof(Shell))]
-		public async Task ToolbarRecreatesWithNewMauiContext(Type type)
+		[InlineData(nameof(FlyoutPage))]
+		[InlineData(nameof(NavigationPage))]
+		[InlineData(nameof(TabbedPage))]
+		[InlineData(nameof(Shell))]
+		public async Task ToolbarRecreatesWithNewMauiContext(string type)
 		{
 			SetupBuilder();
 			Page page = null;
 
-			if (type == typeof(FlyoutPage))
+			if (type == nameof(FlyoutPage))
 			{
 				page = new FlyoutPage()
 				{
@@ -135,11 +185,11 @@ namespace Microsoft.Maui.DeviceTests
 					Flyout = new ContentPage() { Title = "Flyout" }
 				};
 			}
-			else if (type == typeof(NavigationPage))
+			else if (type == nameof(NavigationPage))
 			{
 				page = new NavigationPage(new ContentPage() { Title = "Nav Page" });
 			}
-			else if (type == typeof(TabbedPage))
+			else if (type == nameof(TabbedPage))
 			{
 				page = new TabbedPage()
 				{
@@ -150,7 +200,7 @@ namespace Microsoft.Maui.DeviceTests
 					}
 				};
 			}
-			else if (type == typeof(Shell))
+			else if (type == nameof(Shell))
 			{
 				page = new Shell() { CurrentItem = new ContentPage() { Title = "Shell Page" } };
 			}

--- a/src/Controls/tests/DeviceTests/Elements/Toolbar/ToolbarTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Toolbar/ToolbarTests.cs
@@ -131,7 +131,9 @@ namespace Microsoft.Maui.DeviceTests
 			Dictionary<ControlsPageTypesTestCase, Page> createdPages
 				= new Dictionary<ControlsPageTypesTestCase, Page>();
 
-			var window = new Window(GetPage(pageSet[0]));
+			var nextPage = GetPage(pageSet[0]);
+			var window = new Window(nextPage);
+
 
 			await CreateHandlerAndAddToWindow<IWindowHandler>(window, async (handler) =>
 			{
@@ -139,28 +141,38 @@ namespace Microsoft.Maui.DeviceTests
 
 				for (int i = 1; i < pageSet.Length; i++)
 				{
-					var nextPage = GetPage(pageSet[i]);
+					nextPage = GetPage(pageSet[i]);
+					window.Page = nextPage;
 
-					window.Page = GetPage(pageSet[i]);
 					if (window.Page is IPageContainer<Page> pc)
 						await OnLoadedAsync(pc.CurrentPage);
 					else
 						await OnLoadedAsync(window.Page);
 
-					bool shouldHaveToolbar =
+					var shouldHaveToolbar =
 						pageSet[i].Contains("NavigationPage", StringComparison.OrdinalIgnoreCase) ||
 						pageSet[i].Contains("Shell", StringComparison.OrdinalIgnoreCase);
 
 					Assert.Equal(shouldHaveToolbar, IsNavigationBarVisible(nextPage.Handler));
 				}
-			}, timeOut: TimeSpan.FromMinutes(10));
+			});
 
 			Page GetPage(string name)
 			{
 				var result = (ControlsPageTypesTestCase)Enum.Parse(typeof(ControlsPageTypesTestCase), name);
 
 				if (!createdPages.ContainsKey(result))
-					createdPages[result] = ControlsPageTypesTestCases.CreatePageType(result);
+					createdPages[result] = ControlsPageTypesTestCases.CreatePageType(result, new ContentPage()
+					{
+						Title = "Page Title",
+						Content = new VerticalStackLayout()
+						{
+							new Label()
+							{
+								Text = "ToolbarUpdatesCorrectlyWhenSwappingMainPageWithAlreadyUsedPage"
+							}
+						}
+					});
 
 				return createdPages[result];
 			}

--- a/src/Controls/tests/DeviceTests/TestCases/ControlsPageTypesTestCases.cs
+++ b/src/Controls/tests/DeviceTests/TestCases/ControlsPageTypesTestCases.cs
@@ -17,15 +17,30 @@ using FlyoutViewHandler = Microsoft.Maui.Controls.Handlers.Compatibility.PhoneFl
 
 namespace Microsoft.Maui.DeviceTests.TestCases
 {
+	public enum ControlsPageTypesTestCase
+	{
+		ContentPage,
+		FlyoutPage,
+		TabbedPage,
+		Shell,
+		NavigationPage,
+		FlyoutPageWithNavigationPage,
+		TabbedPageWithNavigationPage,
+		NavigationPageWithFlyoutPage,
+		NavigationPageWithTabbedPage,
+		NavigationPageWithFlyoutPageWithNavigationPage,
+		NavigationPageWithTabbedPageWithNavigationPage
+	}
+
 	public class ControlsPageTypesTestCases : IEnumerable<object[]>
 	{
 		private readonly List<object[]> _data = new()
 		{
-			new object[] { nameof(FlyoutPage) },
-			new object[] { nameof(TabbedPage) },
-			new object[] { nameof(ContentPage) },
-			new object[] { nameof(Shell) },
-			new object[] { nameof(NavigationPage) },
+			new object[] { ControlsPageTypesTestCase.FlyoutPage },
+			new object[] { ControlsPageTypesTestCase.TabbedPage },
+			new object[] { ControlsPageTypesTestCase.ContentPage },
+			new object[] { ControlsPageTypesTestCase.Shell },
+			new object[] { ControlsPageTypesTestCase.NavigationPage },
 		};
 
 		public IEnumerator<object[]> GetEnumerator() => _data.GetEnumerator();
@@ -33,25 +48,43 @@ namespace Microsoft.Maui.DeviceTests.TestCases
 		IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
 
-		public static Page CreatePageType(string name, Page content)
+		public static Page CreatePageType(ControlsPageTypesTestCase name, Page content)
 		{
 			switch (name)
 			{
-				case nameof(FlyoutPage):
+				case ControlsPageTypesTestCase.FlyoutPage:
 					content.Title = content.Title ?? "Detail Title";
 					return new FlyoutPage() { Flyout = new ContentPage() { Title = "title" }, Detail = content };
-				case nameof(TabbedPage):
+				case ControlsPageTypesTestCase.TabbedPage:
 					return new TabbedPage() { Children = { content } };
-				case nameof(ContentPage):
+				case ControlsPageTypesTestCase.ContentPage:
 					return content;
-				case nameof(Shell):
+				case ControlsPageTypesTestCase.Shell:
 					return new Shell() { CurrentItem = (ContentPage)content };
-				case nameof(NavigationPage):
+				case ControlsPageTypesTestCase.NavigationPage:
 					return new NavigationPage(content);
+				case ControlsPageTypesTestCase.FlyoutPageWithNavigationPage:
+					return new FlyoutPage()
+					{
+						Flyout = new ContentPage() { Title = "title" },
+						Detail = new NavigationPage(content)
+					};
+				case ControlsPageTypesTestCase.TabbedPageWithNavigationPage:
+					return new TabbedPage() { Children = { new NavigationPage(content) } };
+				case ControlsPageTypesTestCase.NavigationPageWithFlyoutPage:
+					return new NavigationPage(new FlyoutPage()
+					{
+						Flyout = new ContentPage() { Title = "title" },
+						Detail = content
+					});
+				case ControlsPageTypesTestCase.NavigationPageWithTabbedPage:
+					return new NavigationPage(new TabbedPage() { Children = { content } });
 			}
 
 			throw new Exception($"{name} not found");
 		}
+
+		public static Page CreatePageType(ControlsPageTypesTestCase name) => CreatePageType(name, new ContentPage());
 
 		public static void Setup(MauiAppBuilder builder)
 		{

--- a/src/Core/src/Platform/Android/ContainerView.cs
+++ b/src/Core/src/Platform/Android/ContainerView.cs
@@ -39,6 +39,7 @@ namespace Microsoft.Maui.Platform
 
 				if (_mainView != null)
 				{
+					_mainView.RemoveFromParent();
 					_mainView.LayoutParameters = new ViewGroup.LayoutParams(LayoutParams.MatchParent, LayoutParams.MatchParent);
 					AddView(_mainView);
 				}

--- a/src/Core/src/Platform/Android/ContainerView.cs
+++ b/src/Core/src/Platform/Android/ContainerView.cs
@@ -39,6 +39,9 @@ namespace Microsoft.Maui.Platform
 
 				if (_mainView != null)
 				{
+					if (_mainView.Parent is ContainerView cv && cv != this)
+						cv.CurrentView = null;
+
 					_mainView.RemoveFromParent();
 					_mainView.LayoutParameters = new ViewGroup.LayoutParams(LayoutParams.MatchParent, LayoutParams.MatchParent);
 					AddView(_mainView);

--- a/src/Core/src/Platform/Android/Navigation/NavigationRootManager.cs
+++ b/src/Core/src/Platform/Android/Navigation/NavigationRootManager.cs
@@ -54,7 +54,6 @@ namespace Microsoft.Maui.Platform
 			if (view is IFlyoutView)
 			{
 				var containerView = view.ToContainerView(mauiContext);
-				navigationLayout = containerView.FindViewById<CoordinatorLayout>(Resource.Id.navigation_layout);
 
 				if (containerView is DrawerLayout dl)
 				{


### PR DESCRIPTION
### Description of Change

- Added code to `ContainerView` on `Android`, so that we remove the view from the previous `ContainerView`. This primarily happens if you reuse the same instance of a page for the `Window.Page`
- Fixed up the code that sets the `Toolbar` property on the correct MAUI xplat view. When this code was previously written we didn't have the `WindowChanged` event to work with so it made the timing tricky when to trigger `NavigationPage` to remove/add a toolbar. With this new code we are able to add/remove the toolbar in a more logical location. 

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #14866

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
