### PR TITLE
[core] use StringComparer for Dictionary/HashSet

### DIFF
--- a/src/BlazorWebView/src/Maui/Tizen/BlazorWebViewHandler.Tizen.cs
+++ b/src/BlazorWebView/src/Maui/Tizen/BlazorWebViewHandler.Tizen.cs
@@ -44,7 +44,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 			})();
 		";
 
-		static private Dictionary<string, WeakReference<BlazorWebViewHandler>> s_webviewHandlerTable = new Dictionary<string, WeakReference<BlazorWebViewHandler>>();
+		static private Dictionary<string, WeakReference<BlazorWebViewHandler>> s_webviewHandlerTable = new(StringComparer.Ordinal);
 
 		private TizenWebViewManager? _webviewManager;
 

--- a/src/BlazorWebView/src/Maui/Windows/StaticContentProvider.cs
+++ b/src/BlazorWebView/src/Maui/Windows/StaticContentProvider.cs
@@ -24,7 +24,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 			: "application/octet-stream";
 
 		internal static IDictionary<string, string> GetResponseHeaders(string contentType)
-			=> new Dictionary<string, string>()
+			=> new Dictionary<string, string>(StringComparer.Ordinal)
 			{
 				{ "Content-Type", contentType },
 				{ "Cache-Control", "no-cache, max-age=0, must-revalidate, no-store" },

--- a/src/Compatibility/Core/src/Android/Renderers/FormsVideoView.cs
+++ b/src/Compatibility/Core/src/Android/Renderers/FormsVideoView.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 
 		public override void SetVideoURI(global::Android.Net.Uri uri)
 		{
-			GetMetaData(uri, new Dictionary<string, string>());
+			GetMetaData(uri, new Dictionary<string, string>(StringComparer.Ordinal));
 			base.SetVideoURI(uri);
 		}
 

--- a/src/Compatibility/Core/src/Tizen/Renderers/VisualElementRenderer.cs
+++ b/src/Compatibility/Core/src/Tizen/Renderers/VisualElementRenderer.cs
@@ -25,9 +25,9 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Tizen
 	{
 		event EventHandler<VisualElementChangedEventArgs> _elementChanged;
 
-		readonly Dictionary<string, Action<bool>> _propertyHandlersWithInit = new Dictionary<string, Action<bool>>();
+		readonly Dictionary<string, Action<bool>> _propertyHandlersWithInit = new(StringComparer.Ordinal);
 
-		readonly Dictionary<string, Action> _propertyHandlers = new Dictionary<string, Action>();
+		readonly Dictionary<string, Action> _propertyHandlers = new(StringComparer.Ordinal);
 
 		readonly HashSet<string> _batchedProperties = new HashSet<string>();
 

--- a/src/Compatibility/Core/src/WPF/Extensions/FontExtensions.cs
+++ b/src/Compatibility/Core/src/WPF/Extensions/FontExtensions.cs
@@ -114,7 +114,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.WPF
 			return self.FontFamily == null && self.FontSize == Device.GetNamedSize(NamedSize.Default, typeof(Label), true) && self.FontAttributes == FontAttributes.None;
 		}
 
-		static Dictionary<string, FontFamily> FontFamilies = new Dictionary<string, FontFamily>();
+		static Dictionary<string, FontFamily> FontFamilies = new(StringComparer.Ordinal);
 
 
 		public static FontFamily ToFontFamily(this string fontFamily, string defaultFontResource = "FontFamilySemiBold")

--- a/src/Controls/src/Build.Tasks/PerformanceProvider.cs
+++ b/src/Controls/src/Build.Tasks/PerformanceProvider.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 			public bool IsDetail;
 		}
 
-		readonly Dictionary<string, Statistic> _Statistics = new Dictionary<string, Statistic>();
+		readonly Dictionary<string, Statistic> _Statistics = new(StringComparer.Ordinal);
 
 		public Dictionary<string, Statistic> Statistics
 		{

--- a/src/Controls/src/Core/AppLinkEntry.cs
+++ b/src/Controls/src/Core/AppLinkEntry.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Maui.Controls
 		/// <include file="../../docs/Microsoft.Maui.Controls/AppLinkEntry.xml" path="//Member[@MemberName='.ctor']/Docs/*" />
 		public AppLinkEntry()
 		{
-			keyValues = new Dictionary<string, string>();
+			keyValues = new(StringComparer.Ordinal);
 		}
 
 		/// <summary>Bindable property for <see cref="Title"/>.</summary>

--- a/src/Controls/src/Core/Application.cs
+++ b/src/Controls/src/Core/Application.cs
@@ -327,7 +327,7 @@ namespace Microsoft.Maui.Controls
 				return;
 			}
 
-			var innerKeys = new HashSet<string>();
+			var innerKeys = new HashSet<string>(StringComparer.Ordinal);
 			var changedResources = new List<KeyValuePair<string, object>>();
 			foreach (KeyValuePair<string, object> c in Resources)
 				innerKeys.Add(c.Key);

--- a/src/Controls/src/Core/DragAndDrop/DataPackagePropertySet.cs
+++ b/src/Controls/src/Core/DragAndDrop/DataPackagePropertySet.cs
@@ -1,4 +1,5 @@
 #nullable disable
+using System;
 using System.Collections;
 using System.Collections.Generic;
 
@@ -12,7 +13,7 @@ namespace Microsoft.Maui.Controls
 		/// <include file="../../../docs/Microsoft.Maui.Controls/DataPackagePropertySet.xml" path="//Member[@MemberName='.ctor']/Docs/*" />
 		public DataPackagePropertySet()
 		{
-			_propertyBag = new Dictionary<string, object>();
+			_propertyBag = new(StringComparer.Ordinal);
 		}
 
 		public object this[string key]

--- a/src/Controls/src/Core/HandlerImpl/Application/Application.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Application/Application.Impl.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Maui.Controls
 		internal const string MauiWindowIdKey = "__MAUI_WINDOW_ID__";
 
 		readonly List<Window> _windows = new();
-		readonly Dictionary<string, WeakReference<Window>> _requestedWindows = new();
+		readonly Dictionary<string, WeakReference<Window>> _requestedWindows = new(StringComparer.Ordinal);
 		ILogger<Application>? _logger;
 
 		ILogger<Application>? Logger =>

--- a/src/Controls/src/Core/Internals/NameScope.cs
+++ b/src/Controls/src/Core/Internals/NameScope.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Maui.Controls.Internals
 		public static readonly BindableProperty NameScopeProperty =
 			BindableProperty.CreateAttached("NameScope", typeof(INameScope), typeof(NameScope), default(INameScope));
 
-		readonly Dictionary<string, object> _names = new Dictionary<string, object>();
+		readonly Dictionary<string, object> _names = new(StringComparer.Ordinal);
 		readonly Dictionary<object, string> _values = new Dictionary<object, string>();
 
 		object INameScope.FindByName(string name)

--- a/src/Controls/src/Core/Registrar.cs
+++ b/src/Controls/src/Core/Registrar.cs
@@ -272,7 +272,7 @@ namespace Microsoft.Maui.Controls.Internals
 			Registered = new Registrar<IRegisterable>();
 		}
 
-		internal static Dictionary<string, Type> Effects { get; } = new Dictionary<string, Type>();
+		internal static Dictionary<string, Type> Effects { get; } = new(StringComparer.Ordinal);
 
 		internal static Dictionary<string, IList<StylePropertyAttribute>> StyleProperties => LazyStyleProperties.Value;
 
@@ -319,7 +319,7 @@ namespace Microsoft.Maui.Controls.Internals
 
 		static Dictionary<string, IList<StylePropertyAttribute>> LoadStyleSheets()
 		{
-			var properties = new Dictionary<string, IList<StylePropertyAttribute>>();
+			var properties = new Dictionary<string, IList<StylePropertyAttribute>>(StringComparer.Ordinal);
 			if (DisableCSS)
 				return properties;
 			var assembly = typeof(StylePropertyAttribute).Assembly;

--- a/src/Controls/src/Core/ResourceDictionary.cs
+++ b/src/Controls/src/Core/ResourceDictionary.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Maui.Controls
 	{
 		const string GetResourcePathUriScheme = "maui://";
 		static ConditionalWeakTable<Type, ResourceDictionary> s_instances = new ConditionalWeakTable<Type, ResourceDictionary>();
-		readonly Dictionary<string, object> _innerDictionary = new Dictionary<string, object>();
+		readonly Dictionary<string, object> _innerDictionary = new(StringComparer.Ordinal);
 		ResourceDictionary _mergedInstance;
 		Uri _source;
 

--- a/src/Controls/src/Core/ResourcesExtensions.cs
+++ b/src/Controls/src/Core/ResourcesExtensions.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Maui.Controls
 				var ve = element as IResourcesProvider;
 				if (ve != null && ve.IsResourcesCreated)
 				{
-					resources = resources ?? new Dictionary<string, object>();
+					resources = resources ?? new(StringComparer.Ordinal);
 					foreach (KeyValuePair<string, object> res in ve.Resources.MergedResources)
 					{
 						// If a MergedDictionary value is overridden for a DynamicResource, 
@@ -33,7 +33,7 @@ namespace Microsoft.Maui.Controls
 				var app = element as Application;
 				if (app != null && app.SystemResources != null)
 				{
-					resources = resources ?? new Dictionary<string, object>(8);
+					resources = resources ?? new Dictionary<string, object>(8, StringComparer.Ordinal);
 					foreach (KeyValuePair<string, object> res in app.SystemResources)
 						if (!resources.ContainsKey(res.Key))
 							resources.Add(res.Key, res.Value);

--- a/src/Controls/src/Core/Routing.cs
+++ b/src/Controls/src/Core/Routing.cs
@@ -11,8 +11,8 @@ namespace Microsoft.Maui.Controls
 	public static class Routing
 	{
 		static int s_routeCount = 0;
-		static Dictionary<string, RouteFactory> s_routes = new Dictionary<string, RouteFactory>();
-		static Dictionary<string, Page> s_implicitPageRoutes = new Dictionary<string, Page>();
+		static Dictionary<string, RouteFactory> s_routes = new(StringComparer.Ordinal);
+		static Dictionary<string, Page> s_implicitPageRoutes = new(StringComparer.Ordinal);
 		static HashSet<string> s_routeKeys;
 
 		const string ImplicitPrefix = "IMPL_";

--- a/src/Controls/src/Core/Shell/ShellNavigationManager.cs
+++ b/src/Controls/src/Core/Shell/ShellNavigationManager.cs
@@ -492,7 +492,7 @@ namespace Microsoft.Maui.Controls
 		{
 			if (query.StartsWith("?", StringComparison.Ordinal))
 				query = query.Substring(1);
-			Dictionary<string, string> lookupDict = new Dictionary<string, string>();
+			Dictionary<string, string> lookupDict = new(StringComparer.Ordinal);
 			if (query == null)
 				return lookupDict;
 			foreach (var part in query.Split('&'))

--- a/src/Controls/src/Core/StyleSheets/Style.cs
+++ b/src/Controls/src/Core/StyleSheets/Style.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Maui.Controls.StyleSheets
 		{
 		}
 
-		public IDictionary<string, string> Declarations { get; set; } = new Dictionary<string, string>();
+		public IDictionary<string, string> Declarations { get; set; } = new Dictionary<string, string>(StringComparer.Ordinal);
 		Dictionary<KeyValuePair<string, string>, object> convertedValues = new Dictionary<KeyValuePair<string, string>, object>();
 
 		public static Style Parse(CssReader reader, char stopChar = '\0')

--- a/src/Controls/src/Core/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement.cs
@@ -1139,7 +1139,7 @@ namespace Microsoft.Maui.Controls
 				return;
 			}
 
-			var innerKeys = new HashSet<string>();
+			var innerKeys = new HashSet<string>(StringComparer.Ordinal);
 			var changedResources = new List<KeyValuePair<string, object>>();
 			foreach (KeyValuePair<string, object> c in Resources)
 				innerKeys.Add(c.Key);

--- a/src/Controls/src/Core/VisualStateManager.cs
+++ b/src/Controls/src/Core/VisualStateManager.cs
@@ -153,7 +153,7 @@ namespace Microsoft.Maui.Controls
 
 		// Used to check for duplicate names; we keep it around because it's cheaper to create it once and clear it
 		// than to create one every time we need to validate
-		readonly HashSet<string> _names = new HashSet<string>();
+		readonly HashSet<string> _names = new HashSet<string>(StringComparer.Ordinal);
 
 		void Validate(IList<VisualStateGroup> groups)
 		{

--- a/src/Controls/src/Xaml/XamlServiceProvider.cs
+++ b/src/Controls/src/Xaml/XamlServiceProvider.cs
@@ -271,7 +271,7 @@ namespace Microsoft.Maui.Controls.Xaml.Internals
 
 	public class XmlNamespaceResolver : IXmlNamespaceResolver
 	{
-		readonly Dictionary<string, string> namespaces = new Dictionary<string, string>();
+		readonly Dictionary<string, string> namespaces = new Dictionary<string, string>(StringComparer.Ordinal);
 
 		public IDictionary<string, string> GetNamespacesInScope(XmlNamespaceScope scope) => throw new NotImplementedException();
 

--- a/src/Core/src/CommandMapper.cs
+++ b/src/Core/src/CommandMapper.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Maui
 {
 	public abstract class CommandMapper : ICommandMapper
 	{
-		readonly Dictionary<string, Command> _mapper = new();
+		readonly Dictionary<string, Command> _mapper = new(StringComparer.Ordinal);
 
 		CommandMapper? _chained;
 

--- a/src/Core/src/Fonts/FontRegistrar.cs
+++ b/src/Core/src/Fonts/FontRegistrar.cs
@@ -10,9 +10,9 @@ namespace Microsoft.Maui
 	/// <inheritdoc cref="IFontRegistrar"/>
 	public partial class FontRegistrar : IFontRegistrar
 	{
-		readonly Dictionary<string, (string Filename, string? Alias, Assembly Assembly)> _embeddedFonts = new();
-		readonly Dictionary<string, (string Filename, string? Alias)> _nativeFonts = new();
-		readonly Dictionary<string, string?> _fontLookupCache = new();
+		readonly Dictionary<string, (string Filename, string? Alias, Assembly Assembly)> _embeddedFonts = new(StringComparer.Ordinal);
+		readonly Dictionary<string, (string Filename, string? Alias)> _nativeFonts = new(StringComparer.Ordinal);
+		readonly Dictionary<string, string?> _fontLookupCache = new(StringComparer.Ordinal);
 		readonly IServiceProvider? _serviceProvider;
 
 		IEmbeddedFontLoader _fontLoader;

--- a/src/Core/src/HotReload/HotReloadHelper.cs
+++ b/src/Core/src/HotReload/HotReloadHelper.cs
@@ -88,9 +88,9 @@ namespace Microsoft.Maui.HotReload
 		}
 
 		static internal readonly WeakList<IHotReloadableView> ActiveViews = new WeakList<IHotReloadableView>();
-		static Dictionary<string, Type> replacedViews = new Dictionary<string, Type>();
+		static Dictionary<string, Type> replacedViews = new(StringComparer.Ordinal);
 		static Dictionary<IHotReloadableView, object[]> currentViews = new Dictionary<IHotReloadableView, object[]>();
-		static Dictionary<string, List<KeyValuePair<Type, Type>>> replacedHandlers = new Dictionary<string, List<KeyValuePair<Type, Type>>>();
+		static Dictionary<string, List<KeyValuePair<Type, Type>>> replacedHandlers = new(StringComparer.Ordinal);
 		public static void RegisterReplacedView(string oldViewType, Type newViewType)
 		{
 			if (!IsEnabled)

--- a/src/Core/src/LifecycleEvents/LifecycleEventService.cs
+++ b/src/Core/src/LifecycleEvents/LifecycleEventService.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Maui.LifecycleEvents
 {
 	public class LifecycleEventService : ILifecycleEventService, ILifecycleBuilder
 	{
-		readonly Dictionary<string, List<Delegate>> _mapper = new Dictionary<string, List<Delegate>>();
+		readonly Dictionary<string, List<Delegate>> _mapper = new(StringComparer.Ordinal);
 
 		public LifecycleEventService(IEnumerable<LifecycleEventRegistration> registrations)
 		{

--- a/src/Core/src/PropertyMapper.cs
+++ b/src/Core/src/PropertyMapper.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Maui
 {
 	public abstract class PropertyMapper : IPropertyMapper
 	{
-		protected readonly Dictionary<string, Action<IElementHandler, IElement>> _mapper = new();
+		protected readonly Dictionary<string, Action<IElementHandler, IElement>> _mapper = new(StringComparer.Ordinal);
 
 		IPropertyMapper[]? _chained;
 

--- a/src/Core/src/WeakEventManager.cs
+++ b/src/Core/src/WeakEventManager.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Maui
 	/// <include file="../docs/Microsoft.Maui/WeakEventManager.xml" path="Type[@FullName='Microsoft.Maui.WeakEventManager']/Docs/*" />
 	public class WeakEventManager
 	{
-		readonly Dictionary<string, List<Subscription>> _eventHandlers = new Dictionary<string, List<Subscription>>();
+		readonly Dictionary<string, List<Subscription>> _eventHandlers = new(StringComparer.Ordinal);
 
 		/// <include file="../docs/Microsoft.Maui/WeakEventManager.xml" path="//Member[@MemberName='AddEventHandler'][1]/Docs/*" />
 		public void AddEventHandler<TEventArgs>(EventHandler<TEventArgs> handler, [CallerMemberName] string eventName = "")

--- a/src/Essentials/src/TextToSpeech/TextToSpeech.android.cs
+++ b/src/Essentials/src/TextToSpeech/TextToSpeech.android.cs
@@ -157,7 +157,7 @@ namespace Microsoft.Maui.Media
 			for (var i = 0; i < parts.Count && !cancelToken.IsCancellationRequested; i++)
 			{
 				// We require the utterance id to be set if we want the completed listener to fire
-				var map = new Dictionary<string, string>
+				var map = new Dictionary<string, string>(StringComparer.Ordinal)
 				{
 					{ AndroidTextToSpeech.Engine.KeyParamUtteranceId, $"{guid}.{i}" }
 				};

--- a/src/Essentials/src/Types/Shared/WebUtils.shared.cs
+++ b/src/Essentials/src/Types/Shared/WebUtils.shared.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Maui.ApplicationModel
 	{
 		internal static IDictionary<string, string> ParseQueryString(string url)
 		{
-			var d = new Dictionary<string, string>();
+			var d = new Dictionary<string, string>(StringComparer.Ordinal);
 
 			if (string.IsNullOrWhiteSpace(url) || (url.IndexOf("?", StringComparison.Ordinal) == -1 && url.IndexOf("#", StringComparison.Ordinal) == -1))
 				return d;

--- a/src/Essentials/src/VersionTracking/VersionTracking.shared.cs
+++ b/src/Essentials/src/VersionTracking/VersionTracking.shared.cs
@@ -238,7 +238,7 @@ namespace Microsoft.Maui.ApplicationModel
 			IsFirstLaunchEver = !preferences.ContainsKey(versionsKey, sharedName) || !preferences.ContainsKey(buildsKey, sharedName);
 			if (IsFirstLaunchEver)
 			{
-				versionTrail = new Dictionary<string, List<string>>
+				versionTrail = new(StringComparer.Ordinal)
 				{
 					{ versionsKey, new List<string>() },
 					{ buildsKey, new List<string>() }
@@ -246,7 +246,7 @@ namespace Microsoft.Maui.ApplicationModel
 			}
 			else
 			{
-				versionTrail = new Dictionary<string, List<string>>
+				versionTrail = new(StringComparer.Ordinal)
 				{
 					{ versionsKey, ReadHistory(versionsKey).ToList() },
 					{ buildsKey, ReadHistory(buildsKey).ToList() }

--- a/src/Essentials/src/WebAuthenticator/WebAuthenticatorResult.shared.cs
+++ b/src/Essentials/src/WebAuthenticator/WebAuthenticatorResult.shared.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Maui.Authentication
 		/// <summary>
 		/// The dictionary of key/value pairs parsed form the callback URI's query string.
 		/// </summary>
-		public Dictionary<string, string> Properties { get; set; } = new Dictionary<string, string>();
+		public Dictionary<string, string> Properties { get; set; } = new(StringComparer.Ordinal);
 
 		/// <summary>Puts a key/value pair into the dictionary.</summary>
 		public void Put(string key, string value)

--- a/src/Graphics/src/Graphics/Text/TextColors.cs
+++ b/src/Graphics/src/Graphics/Text/TextColors.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Maui.Graphics.Text
 {
 	public static class TextColors
 	{
-		public static Dictionary<string, string> StandardColors = new Dictionary<string, string>
+		public static Dictionary<string, string> StandardColors = new(StringComparer.OrdinalIgnoreCase)
 		{
 			{"BLACK", "#000000"},
 			{"NAVY", "#000080"},
@@ -158,7 +158,7 @@ namespace Microsoft.Maui.Graphics.Text
 			//Remove # if present
 			if (!color.StartsWith("#", StringComparison.Ordinal))
 			{
-				if (!StandardColors.TryGetValue(color.ToUpperInvariant(), out color))
+				if (!StandardColors.TryGetValue(color, out color))
 					return null;
 			}
 

--- a/src/Graphics/src/Text.Markdig/Renderer/SimpleCssParser.cs
+++ b/src/Graphics/src/Text.Markdig/Renderer/SimpleCssParser.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Maui.Graphics.Text.Renderer
 			if (string.IsNullOrEmpty(css))
 				return null;
 
-			var values = new Dictionary<string, string>();
+			var values = new Dictionary<string, string>(StringComparer.Ordinal);
 
 			var entries = css.Split(';');
 			foreach (var entry in entries)

--- a/src/SingleProject/Resizetizer/src/ResizetizeImages.cs
+++ b/src/SingleProject/Resizetizer/src/ResizetizeImages.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Maui.Resizetizer
 
 			foreach (var img in resizedImages)
 			{
-				var attr = new Dictionary<string, string>();
+				var attr = new Dictionary<string, string>(StringComparer.Ordinal);
 				string itemSpec = Path.GetFullPath(img.Filename);
 
 				// Fix the item spec to be relative for mac

--- a/src/SingleProject/Resizetizer/src/TizenResourceXmlGenerator.cs
+++ b/src/SingleProject/Resizetizer/src/TizenResourceXmlGenerator.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Xml;
 
@@ -6,7 +7,7 @@ namespace Microsoft.Maui.Resizetizer
 {
 	internal class TizenResourceXmlGenerator
 	{
-		static readonly IDictionary<string, string> resolutionMap = new Dictionary<string, string>
+		static readonly IDictionary<string, string> resolutionMap = new Dictionary<string, string>(StringComparer.Ordinal)
 		{
 			{ "LDPI", "from 0 to 240" },
 			{ "MDPI", "from 241 to 300" },


### PR DESCRIPTION
Context: https://github.com/dotnet/maui/issues/12130
Context: https://github.com/angelru/CvSlowJittering

When profiling the above customer app while scrolling, 4% of the time is spent doing dictionary lookups:

    (4.0%) System.Private.CoreLib!System.Collections.Generic.Dictionary<TKey_REF,TValue_REF>.FindValue(TKey_REF)

Observing the call stack, some of these are coming from culture-aware string lookups in MAUI:

* `microsoft.maui!Microsoft.Maui.PropertyMapper.GetProperty(string)`
* `microsoft.maui!Microsoft.Maui.WeakEventManager.AddEventHandler(System.EventHandler`1<TEventArgs_REF>,string)`
* `microsoft.maui!Microsoft.Maui.CommandMapper.GetCommand(string)`

Which show up as a mixture of `string` comparers:

    (0.98%) System.Private.CoreLib!System.Collections.Generic.NonRandomizedStringEqualityComparer.OrdinalComparer.GetHashCode(string)
    (0.71%) System.Private.CoreLib!System.String.GetNonRandomizedHashCode()
    (0.31%) System.Private.CoreLib!System.Collections.Generic.NonRandomizedStringEqualityComparer.OrdinalComparer.Equals(string,stri
    (0.01%) System.Private.CoreLib!System.Collections.Generic.NonRandomizedStringEqualityComparer.GetStringComparer(object)

In cases of `Dictionary<string, TValue>` or `HashSet<string>`, we can use `StringComparer.Ordinal` for faster dictionary lookups.

Unfortunately, there is no code analyzer for this:

https://github.com/dotnet/runtime/issues/52399

So, I manually went through the codebase and found all the places.

I now only see the *fast* string comparers in this sample:

    (1.3%) System.Private.CoreLib!System.Collections.Generic.NonRandomizedStringEqualityComparer.OrdinalComparer.GetHashCode(string)
    (0.35%) System.Private.CoreLib!System.Collections.Generic.NonRandomizedStringEqualityComparer.OrdinalComparer.Equals(string,stri

Which is about ~0.36% better than before.

This should slightly improve the performance of handlers & all controls on all platforms.

I also fixed `Microsoft.Maui.Graphics.Text.TextColors` to use `StringComparer.OrdinalIgnoreCase` -- and removed a `ToUpperInvariant()` call.