### PR TITLE
Handle Grid * expansion when size is larger than minimum, but less than sufficient to display full size

### DIFF
--- a/src/Core/src/Layouts/GridLayoutManager.cs
+++ b/src/Core/src/Layouts/GridLayoutManager.cs
@@ -286,12 +286,12 @@ namespace Microsoft.Maui.Layouts
 				return new Rect(left + xOffset, top + yOffset, width, height);
 			}
 
-			public double GridHeight()
+			double GridHeight()
 			{
 				return SumDefinitions(_rows, _rowSpacing) + _padding.VerticalThickness;
 			}
 
-			public double GridWidth()
+			double GridWidth()
 			{
 				return SumDefinitions(_columns, _columnSpacing) + _padding.HorizontalThickness;
 			}
@@ -699,82 +699,6 @@ namespace Microsoft.Maui.Layouts
 						UpdateKnownMeasureHeight(cell);
 					}
 				}
-			}
-
-			double AvailableWidth(Cell cell)
-			{
-				// Because our cell may overlap columns that are already measured (and counted in GridWidth()),
-				// we'll need to add the size of those columns back into our available space
-				double cellColumnsWidth = 0;
-
-				// So we'll have to tally up the known widths of those rows. While we do that, we'll
-				// keep track of whether all the columns spanned by this cell are absolute widths
-				bool absolute = true;
-
-				for (int c = cell.Column; c < cell.Column + cell.ColumnSpan; c++)
-				{
-					cellColumnsWidth += _columns[c].Size;
-
-					if (!_columns[c].IsAbsolute)
-					{
-						absolute = false;
-					}
-				}
-
-				cellColumnsWidth += (cell.ColumnSpan - 1) * _columnSpacing;
-
-				if (absolute)
-				{
-					// If all the spanned columns were absolute, then we know the exact available width for 
-					// the view that's in this cell
-					return cellColumnsWidth;
-				}
-
-				// Since some of the columns weren't already specified, we'll need to work out what's left
-				// of the Grid's width for this cell
-
-				var alreadyUsed = GridWidth();
-				var available = _gridWidthConstraint - alreadyUsed;
-
-				return available + cellColumnsWidth;
-			}
-
-			double AvailableHeight(Cell cell)
-			{
-				// Because our cell may overlap rows that are already measured (and counted in GridHeight()),
-				// we'll need to add the size of those rows back into our available space
-				double cellRowsHeight = 0;
-
-				// So we'll have to tally up the known heights of those rows. While we do that, we'll
-				// keep track of whether all the rows spanned by this cell are absolute heights
-				bool absolute = true;
-
-				for (int c = cell.Row; c < cell.Row + cell.RowSpan; c++)
-				{
-					cellRowsHeight += _rows[c].Size;
-
-					if (!_rows[c].IsAbsolute)
-					{
-						absolute = false;
-					}
-				}
-
-				cellRowsHeight += (cell.RowSpan - 1) * _rowSpacing;
-
-				if (absolute)
-				{
-					// If all the spanned rows were absolute, then we know the exact available height for 
-					// the view that's in this cell
-					return cellRowsHeight;
-				}
-
-				// Since some of the rows weren't already specified, we'll need to work out what's left
-				// of the Grid's height for this cell
-
-				var alreadyUsed = GridHeight();
-				var available = _gridHeightConstraint - alreadyUsed;
-
-				return available + cellRowsHeight;
 			}
 
 			static void UseCompressedSize(Definition[] defs)

--- a/src/Core/src/Layouts/GridLayoutManager.cs
+++ b/src/Core/src/Layouts/GridLayoutManager.cs
@@ -291,12 +291,12 @@ namespace Microsoft.Maui.Layouts
 				return SumDefinitions(_columns, _columnSpacing) + _padding.HorizontalThickness;
 			}
 
-			double GridMinimumHeight() 
+			double GridMinimumHeight()
 			{
 				return SumDefinitions(_rows, _rowSpacing, minimize: true) + _padding.VerticalThickness;
 			}
 
-			double GridMinimumWidth() 
+			double GridMinimumWidth()
 			{
 				return SumDefinitions(_columns, _columnSpacing, minimize: true) + _padding.HorizontalThickness;
 			}
@@ -824,7 +824,7 @@ namespace Microsoft.Maui.Layouts
 				}
 			}
 
-			void ExpandStarDefinitions(Definition[] definitions, double targetSize, double currentSize, double spacing, double starCount) 
+			void ExpandStarDefinitions(Definition[] definitions, double targetSize, double currentSize, double spacing, double starCount)
 			{
 				// Figure out what the star value should be at this size
 				var starSize = ComputeStarSizeForTarget(targetSize, definitions, spacing, starCount);
@@ -835,7 +835,7 @@ namespace Microsoft.Maui.Layouts
 
 			double ComputeStarSizeForTarget(double targetSize, Definition[] defs, double spacing, double starCount)
 			{
-				var sum = SumDefinitions(defs, spacing,	true);
+				var sum = SumDefinitions(defs, spacing, true);
 
 				// Remove all the star defintions from the current size
 				foreach (var def in defs)
@@ -1138,7 +1138,7 @@ namespace Microsoft.Maui.Layouts
 			/// </summary>
 			public double Size
 			{
-				get => _size; 
+				get => _size;
 				set
 				{
 					_size = value;

--- a/src/Core/src/Layouts/GridLayoutManager.cs
+++ b/src/Core/src/Layouts/GridLayoutManager.cs
@@ -481,7 +481,10 @@ namespace Microsoft.Maui.Layouts
 					}
 					else if (cell.ColumnSpan == 1)
 					{
-						_columns[cell.Column].Update(measure.Width);
+						if (_columns[cell.Column].IsAuto)
+						{
+							_columns[cell.Column].Update(measure.Width);
+						}
 					}
 
 					if (cell.IsRowSpanStar && cell.RowSpan > 1)
@@ -490,7 +493,10 @@ namespace Microsoft.Maui.Layouts
 					}
 					else if (cell.RowSpan == 1)
 					{
-						_rows[cell.Row].Update(measure.Height);
+						if (_rows[cell.Row].IsAuto)
+						{
+							_rows[cell.Row].Update(measure.Height);
+						}
 					}
 				}
 			}
@@ -645,7 +651,7 @@ namespace Microsoft.Maui.Layouts
 					if (definition.IsStar)
 					{
 						// Give the star row/column the appropriate portion of the space based on its weight
-						definition.Size += starSize * definition.GridLength.Value;
+						definition.Size = starSize * definition.GridLength.Value;
 					}
 				}
 			}
@@ -783,6 +789,10 @@ namespace Microsoft.Maui.Layouts
 						if (definitions[n].IsStar)
 						{
 							definitions[n].MinimumSize += toAdd;
+							if (definitions[n].MinimumSize > definitions[n].Size)
+							{
+								definitions[n].MinimumSize = definitions[n].Size;
+							}
 						}
 					}
 				}

--- a/src/Core/src/Layouts/GridLayoutManager.cs
+++ b/src/Core/src/Layouts/GridLayoutManager.cs
@@ -3,7 +3,6 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
-using System.Security.Cryptography;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Primitives;
 

--- a/src/Core/src/Layouts/GridLayoutManager.cs
+++ b/src/Core/src/Layouts/GridLayoutManager.cs
@@ -296,6 +296,16 @@ namespace Microsoft.Maui.Layouts
 				return SumDefinitions(_columns, _columnSpacing) + _padding.HorizontalThickness;
 			}
 
+			double GridCompressedHeight() 
+			{
+				return SumDefinitions(_rows, _rowSpacing, true) + _padding.VerticalThickness;
+			}
+
+			double GridCompressedWidth() 
+			{
+				return SumDefinitions(_columns, _columnSpacing, true) + _padding.HorizontalThickness;
+			}
+
 			public double MeasuredGridHeight()
 			{
 				var height = Dimension.IsExplicitSet(_explicitGridHeight) ? _explicitGridHeight : GridHeight();
@@ -330,13 +340,13 @@ namespace Microsoft.Maui.Layouts
 				return width;
 			}
 
-			static double SumDefinitions(Definition[] definitions, double spacing)
+			static double SumDefinitions(Definition[] definitions, double spacing, bool compressed = false)
 			{
 				double sum = 0;
 
 				for (int n = 0; n < definitions.Length; n++)
 				{
-					sum += definitions[n].Size;
+					sum += compressed ? definitions[n].CompressedSize : definitions[n].Size;
 
 					if (n > 0)
 					{
@@ -767,7 +777,7 @@ namespace Microsoft.Maui.Layouts
 				return available + cellRowsHeight;
 			}
 
-			void UseCompressedSize(Definition[] defs)
+			static void UseCompressedSize(Definition[] defs)
 			{
 				foreach (var def in defs)
 				{
@@ -790,12 +800,12 @@ namespace Microsoft.Maui.Layouts
 
 				if (decompressVertical)
 				{
-					DecompressDefinitions(_rows, targetSize.Height, GridHeight(), _rowSpacing, _rowStarCount);
+					DecompressDefinitions(_rows, targetSize.Height, GridCompressedHeight(), _rowSpacing, _rowStarCount);
 				}
 
 				if (decompressHorizontal)
 				{
-					DecompressDefinitions(_columns, targetSize.Width, GridWidth(), _columnSpacing, _columnStarCount);
+					DecompressDefinitions(_columns, targetSize.Width, GridCompressedWidth(), _columnSpacing, _columnStarCount);
 				}
 			}
 
@@ -830,10 +840,7 @@ namespace Microsoft.Maui.Layouts
 
 			void DecompressStars(double targetSize, double currentSize, Definition[] defs, double starSize, double starCount)
 			{
-				if (starCount == 0)
-				{
-					return;
-				}
+				Debug.Assert(starCount > 0, "Assume that the caller has already checked for the existence of star rows/columns before using this.");
 
 				var availableSpace = targetSize - currentSize;
 
@@ -1088,7 +1095,7 @@ namespace Microsoft.Maui.Layouts
 				return cell.IsRowSpanAuto;
 			}
 
-			double CountStars(Definition[] definitions)
+			static double CountStars(Definition[] definitions)
 			{
 				// Count up the total weight of star values (e.g., "*, 3*, *" == 5)
 				var starCount = 0.0;

--- a/src/Core/src/Layouts/GridLayoutManager.cs
+++ b/src/Core/src/Layouts/GridLayoutManager.cs
@@ -735,10 +735,6 @@ namespace Microsoft.Maui.Layouts
 
 			void DecompressDefinitions(Definition[] definitions, double targetSize, double currentSize, double spacing, double starCount) 
 			{
-				// Reset the row definitions to the minimum sizes (in case Arrange has been called
-				// multiple times at different sizes without a new Measure call)
-				UseCompressedSize(definitions);
-
 				// Figure out what the star value should be at this size
 				var starSize = ComputeStarSizeForTarget(targetSize, definitions, spacing, starCount);
 
@@ -748,14 +744,14 @@ namespace Microsoft.Maui.Layouts
 
 			double ComputeStarSizeForTarget(double targetSize, Definition[] defs, double spacing, double starCount)
 			{
-				var sum = SumDefinitions(defs, spacing);
+				var sum = SumDefinitions(defs, spacing,	true);
 
 				// Remove all the star defintions from the current size
 				foreach (var def in defs)
 				{
 					if (def.IsStar)
 					{
-						sum -= def.Size;
+						sum -= def.CompressedSize;
 					}
 				}
 
@@ -779,7 +775,7 @@ namespace Microsoft.Maui.Layouts
 				{
 					if (definition.IsStar)
 					{
-						maxCurrentSize = Math.Max(maxCurrentSize, definition.Size);
+						maxCurrentSize = Math.Max(maxCurrentSize, definition.CompressedSize);
 					}
 				}
 
@@ -788,7 +784,7 @@ namespace Microsoft.Maui.Layouts
 				{
 					if (definition.IsStar)
 					{
-						totaldiff += maxCurrentSize - definition.Size;
+						totaldiff += maxCurrentSize - definition.CompressedSize;
 					}
 				}
 
@@ -798,13 +794,13 @@ namespace Microsoft.Maui.Layouts
 					{
 						if (maxCurrentSize >= (starSize * definition.GridLength.Value))
 						{
-							var diff = maxCurrentSize - definition.Size;
+							var diff = maxCurrentSize - definition.CompressedSize;
 
 							if (diff > 0)
 							{
-								var scale = ((maxCurrentSize - definition.Size) / totaldiff);
+								var scale = ((maxCurrentSize - definition.CompressedSize) / totaldiff);
 								var portion = scale * availableSpace;
-								definition.Size += portion;
+								definition.Size = definition.CompressedSize + portion;
 							}
 						}
 						else

--- a/src/Core/src/Layouts/GridLayoutManager.cs
+++ b/src/Core/src/Layouts/GridLayoutManager.cs
@@ -54,9 +54,6 @@ namespace Microsoft.Maui.Layouts
 
 		class GridStructure
 		{
-			public int _id;
-			static int _idSource;
-
 			readonly IGridLayout _grid;
 			readonly double _gridWidthConstraint;
 			readonly double _gridHeightConstraint;
@@ -88,8 +85,6 @@ namespace Microsoft.Maui.Layouts
 
 			public GridStructure(IGridLayout grid, double widthConstraint, double heightConstraint)
 			{
-				_id = _idSource++;
-
 				_grid = grid;
 
 				_explicitGridHeight = _grid.Height;
@@ -610,7 +605,7 @@ namespace Microsoft.Maui.Layouts
 				return top;
 			}
 
-			double ResolveStars(Definition[] defs, double availableSpace, Func<Cell, bool> cellCheck, Func<Size, double> dimension, double starCount)
+			void ResolveStars(Definition[] defs, double availableSpace, Func<Cell, bool> cellCheck, Func<Size, double> dimension, double starCount)
 			{
 				Debug.Assert(starCount > 0, "The caller of ResolveStars has already checked that there are star values to resolve.");
 
@@ -619,7 +614,7 @@ namespace Microsoft.Maui.Layouts
 					// This can happen if an Auto-measured part of a span is larger than the Grid's constraint;
 					// There's a negative amount of space left for the Star values. Just bail, the
 					// Star values are already zero and they can't get any smaller.
-					return starCount;
+					return;
 				}
 
 				double starSize = 0;
@@ -653,8 +648,6 @@ namespace Microsoft.Maui.Layouts
 						definition.Size += starSize * definition.GridLength.Value;
 					}
 				}
-
-				return starCount;
 			}
 
 			void ResolveStarColumns(double widthConstraint)

--- a/src/Core/src/Platform/iOS/ContentView.cs
+++ b/src/Core/src/Platform/iOS/ContentView.cs
@@ -42,7 +42,12 @@ namespace Microsoft.Maui.Platform
 			var widthConstraint = bounds.Width;
 			var heightConstraint = bounds.Height;
 
-			if (!IsMeasureValid(widthConstraint, heightConstraint))
+			// If the SuperView is a MauiView (backing a cross-platform ContentView or Layout), then measurement
+			// has already happened via SizeThatFits and doesn't need to be repeated in LayoutSubviews. But we
+			// _do_ need LayoutSubviews to make a measurement pass if the parent is something else (for example,
+			// the window); there's no guarantee that SizeThatFits has been called in that case.
+
+			if (!IsMeasureValid(widthConstraint, heightConstraint) && Superview is not MauiView)
 			{
 				CrossPlatformMeasure?.Invoke(widthConstraint, heightConstraint);
 				CacheMeasureConstraints(widthConstraint, heightConstraint);

--- a/src/Core/src/Platform/iOS/LayoutView.cs
+++ b/src/Core/src/Platform/iOS/LayoutView.cs
@@ -48,7 +48,12 @@ namespace Microsoft.Maui.Platform
 			var widthConstraint = bounds.Width;
 			var heightConstraint = bounds.Height;
 
-			if (!IsMeasureValid(widthConstraint, heightConstraint))
+			// If the SuperView is a MauiView (backing a cross-platform ContentView or Layout), then measurement
+			// has already happened via SizeThatFits and doesn't need to be repeated in LayoutSubviews. But we
+			// _do_ need LayoutSubviews to make a measurement pass if the parent is something else (for example,
+			// the window); there's no guarantee that SizeThatFits has been called in that case.
+
+			if (!IsMeasureValid(widthConstraint, heightConstraint) && Superview is not MauiView)
 			{
 				layout.CrossPlatformMeasure(widthConstraint, heightConstraint);
 				CacheMeasureConstraints(widthConstraint, heightConstraint);

--- a/src/Core/tests/UnitTests/Layouts/GridLayoutManagerTests.cs
+++ b/src/Core/tests/UnitTests/Layouts/GridLayoutManagerTests.cs
@@ -2851,7 +2851,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			// Measure the grid with a width constraint
 			var manager = new GridLayoutManager(grid);
 			var measure = manager.Measure(500, 100);
-			
+
 			manager.ArrangeChildren(new Rect(0, 0, 500, 100));
 
 			// At a width constraint of 500, we expect the star column to be 300 wide

--- a/src/Core/tests/UnitTests/Layouts/GridLayoutManagerTests.cs
+++ b/src/Core/tests/UnitTests/Layouts/GridLayoutManagerTests.cs
@@ -2465,8 +2465,10 @@ namespace Microsoft.Maui.UnitTests.Layouts
 
 		[Theory, Category(GridStarSizing)]
 		[InlineData(0.1)]
+		[InlineData(1)]
 		[InlineData(10)]
 		[InlineData(60)]
+		[InlineData(1000)]
 		[InlineData(-0.1)]
 		[InlineData(-10)]
 		[InlineData(-60)]
@@ -2522,6 +2524,12 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			Assert.False(view0Dest.IntersectsWith(view1Dest));
 			Assert.False(view1Dest.IntersectsWith(view2Dest));
 			Assert.False(view0Dest.IntersectsWith(view2Dest));
+
+			// And ensure that the destination rects are actually tall enough to fill up the arranged height.
+			// They might be taller (e.g., if a window is resized to be too small for the content), but they should
+			// _not_ be _less_ than the target arrangement height.
+			var destinationHeight = view0Dest.Height + view1Dest.Height + view2Dest.Height;
+			Assert.True(destinationHeight >= measure.Height + heightDelta);
 		}
 
 		[Theory, Category(GridStarSizing)]

--- a/src/Core/tests/UnitTests/Layouts/GridLayoutManagerTests.cs
+++ b/src/Core/tests/UnitTests/Layouts/GridLayoutManagerTests.cs
@@ -2724,9 +2724,17 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			view0.Received().Measure(Arg.Any<double>(), Arg.Is<double>(expectedMeasureHeight));
 		}
 
-		
-		[Fact]
-		public void MultipleArrangeCallsProduceConsistentResults()
+
+		[Theory, Category(GridStarSizing)]
+		[InlineData(0.1)]
+		[InlineData(1)]
+		[InlineData(10)]
+		[InlineData(60)]
+		[InlineData(1000)]
+		[InlineData(-0.1)]
+		[InlineData(-10)]
+		[InlineData(-60)]
+		public void MultipleArrangeCallsProduceConsistentResults(double delta)
 		{
 			var grid = CreateGridLayout(rows: "*, *, *", columns: "*, *, *");
 			grid.VerticalLayoutAlignment.Returns(LayoutAlignment.Fill);
@@ -2748,7 +2756,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			Assert.Equal(120, measure.Width);
 
 			// Now arrange it at a _different_ size
-			manager.ArrangeChildren(new Rect(0, 0, measure.Width + 100, measure.Height + 100));
+			manager.ArrangeChildren(new Rect(0, 0, measure.Width + delta, measure.Height + delta));
 
 			// Determine the destination Rect values that the manager passed in when calling Arrange() for each view
 			var v0ArrangeArgs1 = view0.ReceivedCalls().Single(c => c.GetMethodInfo().Name == nameof(IView.Arrange)).GetArguments();
@@ -2765,7 +2773,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			view2.ClearReceivedCalls();
 
 			// Now arrange it at the same size again
-			manager.ArrangeChildren(new Rect(0, 0, measure.Width + 100, measure.Height + 100));
+			manager.ArrangeChildren(new Rect(0, 0, measure.Width + delta, measure.Height + delta));
 
 			// Determine the destination Rect values that the manager passed in when calling Arrange() for each view
 			var v0ArrangeArgs2 = view0.ReceivedCalls().Single(c => c.GetMethodInfo().Name == nameof(IView.Arrange)).GetArguments();

--- a/src/Core/tests/UnitTests/Layouts/LayoutTestHelpers.cs
+++ b/src/Core/tests/UnitTests/Layouts/LayoutTestHelpers.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 		public static void SubstituteChildren(ILayout layout, IList<IView> children)
 		{
 			layout[Arg.Any<int>()].Returns(args => children[(int)args[0]]);
-			layout.GetEnumerator().Returns(children.GetEnumerator());
+			layout.GetEnumerator().Returns((ci) => children.GetEnumerator());
 			layout.Count.Returns(children.Count);
 		}
 


### PR DESCRIPTION
### Description of Change

(This is an expansion of the fix in #14114, which handled part of this problem on Windows, but didn't successfully fix it on Android and iOS. It also caused havoc in several other layout situations.)

When a Grid with * rows/columns is measured, the measurement should return the minimal values for those rows/columns to contain their content. When the Grid is arranged, those *s should (in some situations) be expanded to fill in the extra space if the arranged size is larger than the measured size. The size of those *s should be maxed out at what the Grid constraints allow for, and should not grow past that even if the contained controls return overly large sizes from measure (the situation described in #14818). 

However - that expansion _should not_ automatically be to the full potential size of the * rows/columns if the target size is not sufficient to contain it. Instead, the expansion should be distributed among the available space so that the smallest * rows/columns expand at the greatest rate until all rows/columns can be expanded to their full size. 

This PR handles that expansion properly, and also avoids the rounding errors described in #14694. This includes smoothly expanding as the window size is changed in environments (e.g., Desktop) where that's an issue. This also adds tests for the problem behavior in #14818, and does not allow controls to force the sizes of their * rows/columns beyond the confines of the Grid. 

In this PR:

- New tests to cover the various permutations of the situations described above
- Some cleanup and clarification of old tests
- Removal of vestigial methods in GridStructure
- A lot of method renaming in GridStructure to clarify what it's doing

### Issues Fixed

Fixes #14694
Fixes #14818


