### PR TITLE
[Android] Changes updating ImageButton Padding to avoid size issues

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Controls/ImageButtonPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/ImageButtonPage.xaml
@@ -124,6 +124,32 @@
                         </VisualStateGroup>
                     </VisualStateManager.VisualStateGroups>
                 </ImageButton>
+                <Label       
+                    Text="Padding"
+                    Style="{StaticResource Headline}"/>
+                <ImageButton 
+                    HorizontalOptions="Center" 
+                    Clicked="OnImageButtonClicked"
+                    Aspect="AspectFit" 
+                    Background="Green"
+                    BorderColor="Red"
+                    BorderWidth="10"
+                    Source="cog.png"
+                    Padding="0" />
+                <ImageButton 
+                    HorizontalOptions="Center" 
+                    Clicked="OnImageButtonClicked"
+                    Aspect="AspectFit" 
+                    Background="Green"
+                    BorderColor="Red"
+                    BorderWidth="10"
+                    Source="cog.png"
+                    Padding="{Binding Source={x:Reference PaddingSlider}, Path=Value}" />
+                <Slider 
+                    x:Name="PaddingSlider"
+                    Minimum="0"
+                    Maximum="60"
+                    Value =" 10"/>
             </VerticalStackLayout>
         </ScrollView>
     </views:BasePage.Content>

--- a/src/Core/src/Platform/Android/ImageButtonExtensions.cs
+++ b/src/Core/src/Platform/Android/ImageButtonExtensions.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Maui.Platform
 		{
 			var imageView = platformButton as ImageView;
 
-			if(imageView is not null)
+			if (imageView is not null)
 			{
 				var bitmapDrawable = imageView.Drawable as BitmapDrawable;
 

--- a/src/Core/src/Platform/Android/ImageButtonExtensions.cs
+++ b/src/Core/src/Platform/Android/ImageButtonExtensions.cs
@@ -1,4 +1,6 @@
-﻿using Google.Android.Material.ImageView;
+﻿using Android.Graphics.Drawables;
+using Android.Widget;
+using Google.Android.Material.ImageView;
 using Google.Android.Material.Shape;
 using Microsoft.Maui.Graphics;
 
@@ -42,25 +44,34 @@ namespace Microsoft.Maui.Platform
 		public static void UpdatePadding(this ShapeableImageView platformButton, IImageButton imageButton)
 		{
 			platformButton.SetContentPadding(imageButton);
-
-			// NOTE(jpr): post on handler to get around an Android Framework bug.
-			// see: https://github.com/material-components/material-components-android/issues/2063
 			platformButton.Post(() =>
 			{
 				platformButton.SetContentPadding(imageButton);
 			});
+			platformButton.SetContentPadding(imageButton);
 		}
 
 		internal static void SetContentPadding(this ShapeableImageView platformButton, IImageButton imageButton)
 		{
-			var padding = imageButton.Padding;
+			var imageView = platformButton as ImageView;
 
-			platformButton.SetContentPadding(
-				(int)platformButton.Context.ToPixels(padding.Left),
-				(int)platformButton.Context.ToPixels(padding.Top),
-				(int)platformButton.Context.ToPixels(padding.Right),
-				(int)platformButton.Context.ToPixels(padding.Bottom)
-			);
+			if(imageView is not null)
+			{
+				var bitmapDrawable = imageView.Drawable as BitmapDrawable;
+
+				if (bitmapDrawable is null)
+					return;
+
+				var backgroundBounds = bitmapDrawable.Bounds;
+
+				var padding = imageButton.Padding;
+
+				bitmapDrawable.SetBounds(
+					backgroundBounds.Left + (int)platformButton.Context.ToPixels(padding.Left),
+					backgroundBounds.Top + (int)platformButton.Context.ToPixels(padding.Top),
+					backgroundBounds.Right - (int)platformButton.Context.ToPixels(padding.Right),
+					backgroundBounds.Bottom - (int)platformButton.Context.ToPixels(padding.Bottom));
+			}
 		}
 	}
 }

--- a/src/Core/src/Platform/Android/ImageButtonExtensions.cs
+++ b/src/Core/src/Platform/Android/ImageButtonExtensions.cs
@@ -59,6 +59,8 @@ namespace Microsoft.Maui.Platform
 			{
 				var bitmapDrawable = imageView.Drawable as BitmapDrawable;
 
+				// Without ImageSource we do not apply Padding, although since there is no content
+				// there are no differences.
 				if (bitmapDrawable is null)
 					return;
 

--- a/src/Core/tests/DeviceTests/Handlers/ImageButton/ImageButtonHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/ImageButton/ImageButtonHandlerTests.Android.cs
@@ -33,17 +33,6 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
-		Thickness GetNativePadding(ImageButtonHandler imageButtonHandler)
-		{
-			var shapeableImageView = GetPlatformImageButton(imageButtonHandler);
-
-			return new Thickness(
-				shapeableImageView.ContentPaddingLeft,
-				shapeableImageView.ContentPaddingTop,
-				shapeableImageView.ContentPaddingRight,
-				shapeableImageView.ContentPaddingBottom);
-		}
-
 		bool ImageSourceLoaded(ImageButtonHandler imageButtonHandler) =>
 			imageButtonHandler.PlatformView.Drawable != null;
 	}

--- a/src/Core/tests/DeviceTests/Handlers/ImageButton/ImageButtonHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/ImageButton/ImageButtonHandlerTests.cs
@@ -95,6 +95,7 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.True(loadingCompleted);
 		}
 
+#if IOS || MACCATALYST
 		[Theory(DisplayName = "Padding Initializes Correctly")]
 		[InlineData(0, 0, 0, 0)]
 		[InlineData(1, 1, 1, 1)]
@@ -114,10 +115,6 @@ namespace Microsoft.Maui.DeviceTests
 				var native = GetNativePadding(handler);
 				var scaled = user;
 
-#if __ANDROID__
-				scaled = handler.PlatformView.Context!.ToPixels(scaled);
-#endif
-
 				return (scaled, native);
 			});
 
@@ -126,6 +123,7 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.Equal(expected.Right, native.Right, Precision);
 			Assert.Equal(expected.Bottom, native.Bottom, Precision);
 		}
+#endif
 
 		[Category(TestCategory.ImageButton)]
 		public partial class ImageButtonImageHandlerTests : ImageHandlerTests<ImageButtonHandler, ImageButtonStub>


### PR DESCRIPTION
### Description of Change

Changes updating Android ImageButton Padding to avoid sizing issues.

Before
![ib-padding-before](https://user-images.githubusercontent.com/6755973/235904606-9fe32017-1bb0-42de-b1dc-952190ecb321.gif)
Notice the external padding/border issue in addition to the sizing problems.

After
![ib-padding-after](https://user-images.githubusercontent.com/6755973/235904602-88292319-a01e-46ad-b657-812ea82d7d4f.gif)

To validate the changes use the new sample added to the ImageButton page in the .NET MAUI Gallery.

### Issues Fixed

Fixes #7927 
Fixes #13101
