### PR TITLE
Use default SmallChange value for WinUI slider

### DIFF
--- a/src/Core/src/Platform/Windows/SliderExtensions.cs
+++ b/src/Core/src/Platform/Windows/SliderExtensions.cs
@@ -11,14 +11,29 @@ namespace Microsoft.Maui.Platform
 {
 	public static class SliderExtensions
 	{
+		static void UpdateIncrement(this Slider nativeSlider, ISlider slider)
+		{
+			var difference = slider.Maximum - slider.Minimum;
+
+			double stepping = 1;
+
+			// Setting the Slider SmallChange property to 0 would throw an System.ArgumentException.
+			if (difference != 0)
+				stepping = Math.Min((difference) / 1000, 1);
+
+			nativeSlider.StepFrequency = stepping;
+		}
+
 		public static void UpdateMinimum(this Slider nativeSlider, ISlider slider)
 		{
 			nativeSlider.Minimum = slider.Minimum;
+			nativeSlider.UpdateIncrement(slider);
 		}
 
 		public static void UpdateMaximum(this Slider nativeSlider, ISlider slider)
 		{
 			nativeSlider.Maximum = slider.Maximum;
+			nativeSlider.UpdateIncrement(slider);
 		}
 
 		public static void UpdateValue(this Slider nativeSlider, ISlider slider)

--- a/src/Core/src/Platform/Windows/SliderExtensions.cs
+++ b/src/Core/src/Platform/Windows/SliderExtensions.cs
@@ -11,30 +11,14 @@ namespace Microsoft.Maui.Platform
 {
 	public static class SliderExtensions
 	{
-		static void UpdateIncrement(this Slider nativeSlider, ISlider slider)
-		{
-			var difference = slider.Maximum - slider.Minimum;
-
-			double stepping = 1;
-
-			// Setting the Slider SmallChange property to 0 would throw an System.ArgumentException.
-			if (difference != 0)
-				stepping = Math.Min((difference) / 1000, 1);
-
-			nativeSlider.StepFrequency = stepping;
-			nativeSlider.SmallChange = stepping;
-		}
-
 		public static void UpdateMinimum(this Slider nativeSlider, ISlider slider)
 		{
 			nativeSlider.Minimum = slider.Minimum;
-			nativeSlider.UpdateIncrement(slider);
 		}
 
 		public static void UpdateMaximum(this Slider nativeSlider, ISlider slider)
 		{
 			nativeSlider.Maximum = slider.Maximum;
-			nativeSlider.UpdateIncrement(slider);
 		}
 
 		public static void UpdateValue(this Slider nativeSlider, ISlider slider)


### PR DESCRIPTION
### Description of Change

Use default SmallChange value for WinUI slider.

**Context:**

Currently, we are calculating a value for SmallChange to be 0.1% at all times. This makes the slider experience pretty inaccessible, via touch/tap (with Narrator, on touch devices, double tap increments and triple tap decrements) and keyboard (using left/right arrow keys, with or without Narrator). This is inaccessible because it requires 1000 strokes to move the thumb from one end of the slider to the other.

On WinUI, the default values make slider increment by just 1 value (which is a different % based on the min and max values; i.e. 100% for default slider 0 to 1; 10% for a slider with min 5 to max 15) via mouse, touch, and keyboard. As long as a StepFrequency or SmallChange is NOT set and/or are the same value, the increment is consistent via both mouse/touch and keyboard. While this would be an ideal condition to have, it will lead to either: (a) touch and keyboard navigation inaccessible, or (b) mouse dragging slider smoothly in-between values impossible (thumb will snap to increment values).

Since we don't currently have a Slider property in .NET MAUI for setting the increment, we need to ensure that the default increment that we offer is still sensible and accessible. In investigating the behavior on other platforms, I discovered that unlike on WinUI, the mouse drag behavior is actually NOT consistent with the touch and keyboard behaviors for slide ron any of the other platforms.

So, at least for now, it makes sense to stick to the default value for SmallChange. (We can keep the 0.001 increment for StepFrequency for now, as that is what allows for the smooth mouse click/drag sliding of the slider).

(no crashing here on the min=max=value edge case either, as that was happening due to the increment calculation previously being based on min and max values)

### Issues Fixed

Fixes #14748

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
