### PR TITLE
Controls(Android): fix frame background color

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Android/FrameRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Android/FrameRenderer.cs
@@ -250,7 +250,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				return;
 
 			Color bgColor = Element.BackgroundColor;
-			_backgroundDrawable.SetColor(bgColor?.ToPlatform() ?? AColor.White);
+			_backgroundDrawable.SetColor(bgColor?.ToPlatform() ?? AColor.Transparent);
 		}
 
 		void UpdateBackground()

--- a/src/Controls/tests/DeviceTests/Elements/Frame/FrameTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Frame/FrameTests.cs
@@ -332,6 +332,41 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.True(layoutFrame.Width > minExpectedWidth);
 		}
 
+		[Fact]
+		public async Task FrameBackgroundColor()
+		{
+			SetupBuilder();
+			var expectedColor = Colors.Green;
+
+			var frame = new Frame()
+			{
+				HeightRequest = 300,
+				WidthRequest = 300,
+				Content = new Label()
+				{
+					VerticalOptions = LayoutOptions.Center,
+					HorizontalOptions = LayoutOptions.Center,
+					Text = "BackgroundColor"
+				}
+			};
+
+			var layout = new StackLayout()
+			{
+				BackgroundColor = expectedColor,
+				Children =
+				{
+					frame
+				}
+			};
+
+			await InvokeOnMainThreadAsync(() =>
+			{
+				var platformView = frame.ToPlatform(MauiContext);
+				platformView.AssertContainsColor(expectedColor, MauiContext);
+			});
+
+		}
+
 		async Task<Rect> LayoutFrame(Layout layout, Frame frame, double widthConstraint, double heightConstraint, Func<Task> additionalTests = null)
 		{
 			additionalTests ??= () => Task.CompletedTask;


### PR DESCRIPTION
Fix default frame background color on Android (when no background color is specified on Frame element).
Before it was white, which caused problems in dark mode. Now it is transparent.

Co-authored-by: Parham <parhaamsaremi@gmail.com>

Fixes https://github.com/dotnet/maui/issues/14916
