### PR TITLE
Make CollectionView on iOS measure to content size

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/ItemsViewHandler.iOS.cs
+++ b/src/Controls/src/Core/Handlers/Items/ItemsViewHandler.iOS.cs
@@ -168,7 +168,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			// If contentSize does have a value, our target size is the smaller of it and the constraints
 
 			size.Width = contentSize.Width <= widthConstraint ? contentSize.Width : widthConstraint;
-			size.Height = contentSize.Height <= heightConstraint ? contentSize.Height: heightConstraint;
+			size.Height = contentSize.Height <= heightConstraint ? contentSize.Height : heightConstraint;
 
 			var virtualView = this.VirtualView as IView;
 

--- a/src/Controls/src/Core/Handlers/Items/ItemsViewHandler.iOS.cs
+++ b/src/Controls/src/Core/Handlers/Items/ItemsViewHandler.iOS.cs
@@ -154,7 +154,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			var potentialContentSize = Controller.GetSize();
 
 			// If contentSize comes back null, it means none of the content has been realized yet;
-			// we need to return the expansive size the the collection view wants by default to get
+			// we need to return the expansive size the collection view wants by default to get
 			// it to start measuring its content
 			if (potentialContentSize == null)
 			{

--- a/src/Controls/src/Core/Handlers/Items/ItemsViewHandler.iOS.cs
+++ b/src/Controls/src/Core/Handlers/Items/ItemsViewHandler.iOS.cs
@@ -31,9 +31,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		{
 			UpdateLayout();
 			Controller = CreateController(ItemsView, _layout);
-			var x = base.OnCreatePlatformView();
-
-			return x;
+			return base.OnCreatePlatformView();
 		}
 
 		protected TItemsView ItemsView => VirtualView;

--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
@@ -183,7 +183,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			LayoutEmptyView();
 		}
 
-		void InvalidateMeasureIfContentSizeChanged() 
+		void InvalidateMeasureIfContentSizeChanged()
 		{
 			var contentSize = CollectionView.CollectionViewLayout.CollectionViewContentSize;
 
@@ -207,7 +207,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				{
 					invalidate = true;
 				}
-				
+
 				if (contentSize.Height < screenHeight || contentSize.Height < screenHeight)
 				{
 					invalidate = true;
@@ -222,7 +222,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			_previousContentSize = contentSize;
 		}
 
-		internal Size? GetSize() 
+		internal Size? GetSize()
 		{
 			if (_emptyViewDisplayed)
 			{

--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
@@ -187,8 +187,10 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		{
 			var contentSize = CollectionView.CollectionViewLayout.CollectionViewContentSize;
 
-			if (_initialized && (_previousContentSize.Width != contentSize.Width
-				|| _previousContentSize.Height != contentSize.Height))
+			bool widthChanged = _previousContentSize.Width != contentSize.Width;
+			bool heightChanged = _previousContentSize.Height != contentSize.Height;
+
+			if (_initialized && (widthChanged || heightChanged))
 			{
 				var screenFrame = CollectionView.Window.Frame;
 				var screenWidth = screenFrame.Width;
@@ -203,12 +205,12 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				// If either size is smaller than that, we need to invalidate to ensure that the 
 				// CollectionView is re-measured and set to the correct size.
 
-				if (contentSize.Width < screenWidth || contentSize.Width < screenWidth)
+				if (widthChanged && (contentSize.Width < screenWidth || _previousContentSize.Width < screenWidth))
 				{
 					invalidate = true;
 				}
 
-				if (contentSize.Height < screenHeight || contentSize.Height < screenHeight)
+				if (heightChanged && (contentSize.Height < screenHeight || _previousContentSize.Height < screenHeight))
 				{
 					invalidate = true;
 				}

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -93,3 +93,4 @@ Microsoft.Maui.Controls.IValueConverter.ConvertBack(object? value, System.Type! 
 ~static Microsoft.Maui.Controls.GridExtensions.AddWithSpan(this Microsoft.Maui.Controls.Grid grid, Microsoft.Maui.IView view, int row = 0, int column = 0, int rowSpan = 1, int columnSpan = 1) -> void
 *REMOVED*override Microsoft.Maui.Controls.Handlers.Compatibility.PhoneFlyoutPageRenderer.WillRotate(UIKit.UIInterfaceOrientation toInterfaceOrientation, double duration) -> void
 ~virtual Microsoft.Maui.Controls.Handlers.Items.ItemsViewController<TItemsView>.DetermineCellReuseId(Foundation.NSIndexPath indexPath) -> string
+override Microsoft.Maui.Controls.Handlers.Items.ItemsViewHandler<TItemsView>.GetDesiredSize(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -93,3 +93,4 @@ Microsoft.Maui.Controls.IValueConverter.ConvertBack(object? value, System.Type! 
 ~static Microsoft.Maui.Controls.GridExtensions.AddWithSpan(this Microsoft.Maui.Controls.Grid grid, Microsoft.Maui.IView view, int row = 0, int column = 0, int rowSpan = 1, int columnSpan = 1) -> void
 *REMOVED*override Microsoft.Maui.Controls.Handlers.Compatibility.PhoneFlyoutPageRenderer.WillRotate(UIKit.UIInterfaceOrientation toInterfaceOrientation, double duration) -> void
 ~virtual Microsoft.Maui.Controls.Handlers.Items.ItemsViewController<TItemsView>.DetermineCellReuseId(Foundation.NSIndexPath indexPath) -> string
+override Microsoft.Maui.Controls.Handlers.Items.ItemsViewHandler<TItemsView>.GetDesiredSize(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewSizingTestCase.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewSizingTestCase.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using Microsoft.Maui.Controls;
+using System.Collections.Generic;
+using Xunit.Abstractions;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	public class CollectionViewSizingTestCase : IXunitSerializable
+	{
+		public LayoutOptions LayoutOptions { get; private set; }
+		public LinearItemsLayout ItemsLayout { get; private set; }
+
+		public CollectionViewSizingTestCase() { }
+
+		public CollectionViewSizingTestCase(LayoutOptions layoutOptions, LinearItemsLayout linearItemsLayout)
+		{
+			LayoutOptions = layoutOptions;
+			ItemsLayout = linearItemsLayout;
+		}
+
+		public void Deserialize(IXunitSerializationInfo info)
+		{
+			var orientationString = info.GetValue<string>(nameof(ItemsLayout));
+			var orientation = (ItemsLayoutOrientation)Enum.Parse(typeof(ItemsLayoutOrientation), orientationString);
+			ItemsLayout = new LinearItemsLayout(orientation);
+
+			var alignmentString = info.GetValue<string>(nameof(LayoutOptions));
+			var alignment = (LayoutAlignment)Enum.Parse(typeof(LayoutAlignment), alignmentString);
+			LayoutOptions = new LayoutOptions(alignment, false);
+		}
+
+		public void Serialize(IXunitSerializationInfo info)
+		{
+			info.AddValue(nameof(LayoutOptions), LayoutOptions.Alignment.ToString(), typeof(string));
+			info.AddValue(nameof(ItemsLayout), ItemsLayout.Orientation.ToString(), typeof(string));
+		}
+
+		public override string ToString()
+		{
+			var optionsString = LayoutOptions.Alignment.ToString();
+			return $"{ItemsLayout.Orientation}, {optionsString}";
+		}
+	}
+}

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewSizingTestCase.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewSizingTestCase.cs
@@ -1,6 +1,6 @@
 ﻿using System;
-using Microsoft.Maui.Controls;
 using System.Collections.Generic;
+using Microsoft.Maui.Controls;
 using Xunit.Abstractions;
 
 namespace Microsoft.Maui.DeviceTests

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.cs
@@ -9,6 +9,9 @@ using Microsoft.Maui.DeviceTests.Stubs;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Hosting;
 using Xunit;
+using System.Collections.Generic;
+using Microsoft.Maui.Graphics;
+using Xunit.Abstractions;
 
 namespace Microsoft.Maui.DeviceTests
 {
@@ -29,6 +32,7 @@ namespace Microsoft.Maui.DeviceTests
 
 					handlers.AddHandler<CollectionView, CollectionViewHandler>();
 					handlers.AddHandler<VerticalStackLayout, LayoutHandler>();
+					handlers.AddHandler<Grid, LayoutHandler>();
 					handlers.AddHandler<Label, LabelHandler>();
 				});
 			});
@@ -76,6 +80,122 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.False(weakReference.IsAlive, "ObservableCollection should not be alive!");
 			Assert.NotNull(logicalChildren);
 			Assert.True(logicalChildren.Count <= 3, "_logicalChildren should not grow in size!");
+		}
+
+		[Theory]
+		[MemberData(nameof(GenerateLayoutOptionsCombos))]
+		public async Task CollectionViewCanSizeToContent(CollectionViewSizingTestCase testCase)
+		{
+			// The goal of this test is to create a CollectionView inside a container with each combination of
+			// ItemsLayout (vertical or horizontal collection) and LayoutAlignment (Fill, Center, etc).
+			// And then layout that CollectionView using a fixed-size template and different sizes of collection
+
+			// At each collection size, we check the size of the CollectionView to verify that it's laying out
+			// at its content size, or at the size of the container (if the number of items is sufficiently large)
+
+			var itemsLayout = testCase.ItemsLayout;
+			var layoutOptions = testCase.LayoutOptions;
+
+			double templateHeight = 50;
+			double templateWidth = 50;
+
+			double containerHeight = 500;
+			double containerWidth = 500;
+
+			int[] itemCounts = new int[] { 1, 2, 12, 0 };
+
+			double tolerance = 1;
+
+			SetupBuilder();
+
+			var collectionView = new CollectionView
+			{
+				ItemsLayout = itemsLayout,
+				ItemTemplate = new DataTemplate(() => new Label() { HeightRequest = templateHeight, WidthRequest = templateWidth }),
+			};
+
+			if (itemsLayout.Orientation == ItemsLayoutOrientation.Horizontal)
+			{
+				collectionView.HorizontalOptions = layoutOptions;
+			}
+			else
+			{
+				collectionView.VerticalOptions = layoutOptions;
+			}
+
+			var layout = new Grid() { HeightRequest = containerHeight, WidthRequest = containerWidth };
+			layout.Add(collectionView);
+
+			ObservableCollection<string> data = new();
+
+			var frame = collectionView.Frame;
+
+			await CreateHandlerAndAddToWindow<LayoutHandler>(layout, async handler =>
+			{
+				for (int n = 0; n < itemCounts.Length; n++)
+				{
+					int itemsCount = itemCounts[n];
+					
+					GenerateItems(itemsCount, data);
+					collectionView.ItemsSource = data;
+
+					await WaitForUIUpdate(frame, collectionView);
+					frame = collectionView.Frame;
+
+					double expectedWidth = layoutOptions == LayoutOptions.Fill
+						? containerWidth
+						: Math.Min(itemsCount * templateWidth, containerWidth);
+
+					double expectedHeight = layoutOptions == LayoutOptions.Fill
+						? containerHeight
+						: Math.Min(itemsCount * templateHeight, containerHeight);
+					
+					if (itemsLayout.Orientation == ItemsLayoutOrientation.Horizontal)
+					{
+						Assert.Equal(expectedWidth, collectionView.Width, tolerance);
+					}
+					else
+					{
+						Assert.Equal(expectedHeight, collectionView.Height, tolerance);
+					}
+				}
+			});
+		}
+
+		public static IEnumerable<object[]> GenerateLayoutOptionsCombos()
+		{
+			var layoutOptions = new LayoutOptions[] { LayoutOptions.Center, LayoutOptions.Start, LayoutOptions.End, LayoutOptions.Fill };
+
+			foreach (var option in layoutOptions)
+			{
+				yield return new object[] { new CollectionViewSizingTestCase(option, new LinearItemsLayout(ItemsLayoutOrientation.Horizontal)) };
+				yield return new object[] { new CollectionViewSizingTestCase(option, new LinearItemsLayout(ItemsLayoutOrientation.Vertical)) };
+				yield return new object[] { new CollectionViewSizingTestCase(option, new LinearItemsLayout(ItemsLayoutOrientation.Horizontal)) };
+				yield return new object[] { new CollectionViewSizingTestCase(option, new LinearItemsLayout(ItemsLayoutOrientation.Vertical)) };
+			}
+		}
+
+		static void GenerateItems(int count, ObservableCollection<string> data)
+		{
+			if (data.Count > count)
+			{
+				data.Clear();
+			}
+
+			for (int n = data.Count; n < count; n++)
+			{
+				data.Add($"Item {n}");
+			}
+		}
+
+		static async Task WaitForUIUpdate(Rect frame, CollectionView collectionView, int timeout = 1000, int interval = 100)
+		{
+			// Wait for layout to happen
+			while (collectionView.Frame == frame && timeout >= 0)
+			{
+				await Task.Delay(interval);
+				timeout -= interval;
+			}
 		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.cs
@@ -1,16 +1,16 @@
 ﻿using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Handlers.Items;
 using Microsoft.Maui.DeviceTests.Stubs;
+using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Hosting;
 using Xunit;
-using System.Collections.Generic;
-using Microsoft.Maui.Graphics;
 using Xunit.Abstractions;
 
 namespace Microsoft.Maui.DeviceTests
@@ -135,7 +135,7 @@ namespace Microsoft.Maui.DeviceTests
 				for (int n = 0; n < itemCounts.Length; n++)
 				{
 					int itemsCount = itemCounts[n];
-					
+
 					GenerateItems(itemsCount, data);
 					collectionView.ItemsSource = data;
 
@@ -149,7 +149,7 @@ namespace Microsoft.Maui.DeviceTests
 					double expectedHeight = layoutOptions == LayoutOptions.Fill
 						? containerHeight
 						: Math.Min(itemsCount * templateHeight, containerHeight);
-					
+
 					if (itemsLayout.Orientation == ItemsLayoutOrientation.Horizontal)
 					{
 						Assert.Equal(expectedWidth, collectionView.Width, tolerance);

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.cs
@@ -123,7 +123,7 @@ namespace Microsoft.Maui.DeviceTests
 				collectionView.VerticalOptions = layoutOptions;
 			}
 
-			var layout = new Grid() { HeightRequest = containerHeight, WidthRequest = containerWidth };
+			var layout = new Grid() { IgnoreSafeArea = true, HeightRequest = containerHeight, WidthRequest = containerWidth };
 			layout.Add(collectionView);
 
 			ObservableCollection<string> data = new();


### PR DESCRIPTION
### Description of Change

Modifies the CollectionView on iOS to use its ContentSize as the value for GetDesiredSize; this forces the CollectionView to size to its content rather than attempting to fill the whole screen. 

### Issues Fixed

Fixes #9135
Fixes #14966
