### PR TITLE
Don't retain parameters not passed as query string parameters

### DIFF
--- a/src/Controls/src/Core/Shell/ShellContent.cs
+++ b/src/Controls/src/Core/Shell/ShellContent.cs
@@ -295,7 +295,10 @@ namespace Microsoft.Maui.Controls
 			var type = content.GetType();
 			var queryPropertyAttributes = type.GetCustomAttributes(typeof(QueryPropertyAttribute), true);
 			if (queryPropertyAttributes.Length == 0)
+			{
+				ClearQueryIfAppliedToPage(query, content);
 				return;
+			}
 
 			foreach (QueryPropertyAttribute attrib in queryPropertyAttributes)
 			{
@@ -326,6 +329,16 @@ namespace Microsoft.Maui.Controls
 					if (prop != null && prop.CanWrite && prop.SetMethod.IsPublic)
 						prop.SetValue(content, null);
 				}
+			}
+
+			ClearQueryIfAppliedToPage(query, content);
+
+			static void ClearQueryIfAppliedToPage(ShellRouteParameters query, object content)
+			{
+				// Once we've applied the attributes to ContentPage lets remove the 
+				// parameters used during navigation
+				if (content is ContentPage)
+					query.ResetToQueryParameters();
 			}
 		}
 	}

--- a/src/Controls/src/Core/Shell/ShellNavigationManager.cs
+++ b/src/Controls/src/Core/Shell/ShellNavigationManager.cs
@@ -92,8 +92,7 @@ namespace Microsoft.Maui.Controls
 
 			var uri = navigationRequest.Request.FullUri;
 			var queryString = navigationRequest.Query;
-			var queryData = ParseQueryString(queryString);
-			parameters.Merge(queryData);
+			parameters.SetQueryStringParameters(queryString);
 			ApplyQueryAttributes(_shell, parameters, false, false);
 
 			var shellItem = navigationRequest.Request.Item;
@@ -306,17 +305,7 @@ namespace Microsoft.Maui.Controls
 				baseShellItem = element?.Parent as BaseShellItem;
 
 			//filter the query to only apply the keys with matching prefix
-			var filteredQuery = new ShellRouteParameters(query.Count);
-
-			foreach (var q in query)
-			{
-				if (!q.Key.StartsWith(prefix, StringComparison.Ordinal))
-					continue;
-				var key = q.Key.Substring(prefix.Length);
-				if (key.IndexOf(".", StringComparison.Ordinal) != -1)
-					continue;
-				filteredQuery.Add(key, q.Value);
-			}
+			var filteredQuery = new ShellRouteParameters(query, prefix);
 
 
 			if (baseShellItem is ShellContent)
@@ -486,24 +475,6 @@ namespace Microsoft.Maui.Controls
 				return ShellNavigationSource.Insert;
 
 			return ShellNavigationSource.Push;
-		}
-
-		static Dictionary<string, string> ParseQueryString(string query)
-		{
-			if (query.StartsWith("?", StringComparison.Ordinal))
-				query = query.Substring(1);
-			Dictionary<string, string> lookupDict = new(StringComparer.Ordinal);
-			if (query == null)
-				return lookupDict;
-			foreach (var part in query.Split('&'))
-			{
-				var p = part.Split('=');
-				if (p.Length != 2)
-					continue;
-				lookupDict[p[0]] = p[1];
-			}
-
-			return lookupDict;
 		}
 
 		public static ShellNavigationParameters GetNavigationParameters(

--- a/src/Controls/tests/Core.UnitTests/ShellParameterPassingTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellParameterPassingTests.cs
@@ -377,6 +377,103 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact]
+		public async Task ExtraParametersDontGetRetained()
+		{
+			var shell = new Shell();
+			var item = CreateShellItem(shellSectionRoute: "section2");
+			Routing.RegisterRoute("details", typeof(ShellTestPage));
+			shell.Items.Add(item);
+			var obj = new object();
+			var parameter = new ShellRouteParameters
+			{
+				{"DoubleQueryParameter", 2d },
+				{ "ComplexObject", obj}
+			};
+
+			await shell.GoToAsync(new ShellNavigationState($"details?{nameof(ShellTestPage.SomeQueryParameter)}=1234"), parameter);
+			var testPage = (shell.CurrentItem.CurrentItem as IShellSectionController).PresentedPage as ShellTestPage;
+
+			await shell.Navigation.PushAsync(new ContentPage());
+
+			testPage.SomeQueryParameter = String.Empty;
+			testPage.DoubleQueryParameter = -1d;
+			testPage.ComplexObject = null;
+
+			await shell.GoToAsync("..");
+
+			Assert.Equal("1234", testPage.SomeQueryParameter);
+			Assert.Equal(-1d, testPage.DoubleQueryParameter);
+			Assert.Null(testPage.ComplexObject);
+		}
+
+		[Fact]
+		public async Task ExtraParametersArentReAppliedWhenNavigatingBackToShellContent()
+		{
+			var shell = new Shell();
+			var item = CreateShellItem(shellContentRoute: "start");
+			var withParams = CreateShellItem(page: new ShellTestPage(), shellContentRoute: "withParams", templated: true);
+			shell.Items.Add(item);
+			shell.Items.Add(withParams);
+			var obj = new object();
+			var parameter = new ShellRouteParameters
+			{
+				{ "ComplexObject", obj},
+				{ nameof(ShellTestPage.SomeQueryParameter), "1234"}
+			};
+
+			await shell.GoToAsync(new ShellNavigationState($"//start"));
+			await shell.GoToAsync(new ShellNavigationState($"//withParams"), parameter);
+
+			var testPage = (shell.CurrentItem.CurrentItem.CurrentItem as IShellContentController).GetOrCreateContent() as ShellTestPage;
+
+			// Validate parameter was set during first navigation
+			Assert.Equal(obj, testPage.ComplexObject);
+
+			// Clear parameters
+			testPage.ComplexObject = null;
+			testPage.SomeQueryParameter = null;
+
+			// Navigate away and back to page with params
+			await shell.GoToAsync(new ShellNavigationState($"//start"));
+			shell.CurrentItem = withParams;
+			await Task.Yield();
+
+			var testPage2 = (shell.CurrentItem.CurrentItem as IShellSectionController).PresentedPage as ShellTestPage;
+			Assert.Null(testPage2.SomeQueryParameter);
+			Assert.Null(testPage2.ComplexObject);
+			Assert.Equal(testPage2, testPage);
+		}
+
+		[Fact]
+		public async Task ExtraParamsReplaceQueryStringParams()
+		{
+			var shell = new Shell();
+			var item = CreateShellItem(shellSectionRoute: "section2");
+			Routing.RegisterRoute("details", typeof(ShellTestPage));
+			shell.Items.Add(item);
+			var obj = new object();
+			var parameter = new ShellRouteParameters
+			{
+				{$"{nameof(ShellTestPage.SomeQueryParameter)}", "4321" },
+				{ "ComplexObject", obj}
+			};
+
+			await shell.GoToAsync(new ShellNavigationState($"details?{nameof(ShellTestPage.SomeQueryParameter)}=1234"), parameter);
+			var testPage = (shell.CurrentItem.CurrentItem as IShellSectionController).PresentedPage as ShellTestPage;
+
+			// Parameters passed in will win
+			Assert.Equal("4321", testPage.SomeQueryParameter);
+			await shell.Navigation.PushAsync(new ContentPage());
+			await shell.GoToAsync("..");
+
+			// Parameters will return to previous query parameter values
+			Assert.Equal("1234", testPage.SomeQueryParameter);
+
+			// Previous parameter set by extra passed parameters doesn't get set to null
+			Assert.Equal(obj, testPage.ComplexObject);
+		}
+
+		[Fact]
 		public async Task DotDotNavigationPassesShellParameters()
 		{
 			Routing.RegisterRoute(nameof(DotDotNavigationPassesParameters), typeof(ContentPage));

--- a/src/Controls/tests/Core.UnitTests/ShellParameterPassingTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellParameterPassingTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -404,6 +405,12 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.Equal("1234", testPage.SomeQueryParameter);
 			Assert.Equal(-1d, testPage.DoubleQueryParameter);
 			Assert.Null(testPage.ComplexObject);
+
+			// ensure that AppliedQueryAttributes is called with correct parameters each time
+			Assert.Equal(2, testPage.AppliedQueryAttributes.Count);
+			Assert.Equal(3, testPage.AppliedQueryAttributes[0].Count);
+			Assert.Equal(1, testPage.AppliedQueryAttributes[1].Count);
+			Assert.Equal($"{nameof(ShellTestPage.SomeQueryParameter)}", testPage.AppliedQueryAttributes[1].Keys.First());
 		}
 
 		[Fact]

--- a/src/Controls/tests/Core.UnitTests/ShellTestBase.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellTestBase.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		[QueryProperty("SomeQueryParameter", "SomeQueryParameter")]
 		[QueryProperty("CancelNavigationOnBackButtonPressed", "CancelNavigationOnBackButtonPressed")]
 		[QueryProperty("ComplexObject", "ComplexObject")]
-		public class ShellTestPage : ContentPage
+		public class ShellTestPage : ContentPage, IQueryAttributable
 		{
 			public string CancelNavigationOnBackButtonPressed { get; set; }
 			public ShellTestPage()
@@ -127,6 +127,12 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 					return false;
 
 				return base.OnBackButtonPressed();
+			}
+
+			public List<IDictionary<string, object>> AppliedQueryAttributes = new List<IDictionary<string, object>>();
+			public void ApplyQueryAttributes(IDictionary<string, object> query)
+			{
+				AppliedQueryAttributes.Add(new Dictionary<string, object>(query));
 			}
 		}
 


### PR DESCRIPTION
### Description of Change

Currently when you pass extra parameters to shell via the parameters dictionary those are retained forever and reapplied with each navigation. The workarounds to remove those parameters is fairly cumbersome. Through discussions with users, it's become apparent that we need a mechanism to have parameters that only get applied during the initial navigation request. This PR clears any parameters that aren't part of the QueryString.

It's particularly problematic to retain those parameters because if the user passes a complex object that object is retained in memory forever unknown to the user.

### FAQ
- Why is the Query Property an internal BP?
  - This was done for Hot Reload purposes. In theory there would be scenarios where hot reload could trigger a page to be recreated and thus all BP's would need to get copied from one Page to another. 
-  What about a perfect solution? 
  - Ideally we restructure shell when there's more time to flesh out more interfaces/apis for parameters passing. For now, we need a way for users to opt out of parameters being reapplied 
- What changed between MAUI and XF?
  - The only thing that changed was the addition of the dictionary overload on GotoAsync. Parameters have always reapplied. So, for users coming from XF there is no change in behavior. This would mainly be a change for users that started using the new API.
- What if users are using the setting of the parameter for `OnAppearing`? 
   - IApplyQueryAttributes will still get called so users can use that interface.
  
### Breaking Change

- When renavigating to a page (clicking back or navigating tabs) `ApplyQueryAttributes` will only be called with the parameters that are part of the query string of that route.  This also means that properties defined in `QueryPropertyAttribute` will only be set if they are part of the query string.

### Examples for the docs to improve clarity
We should enhance the navigation part of the `Shell` docs to include various example permutations of how parameters are handled.

#### Still works the same 

```C#
await GotoAsync("firstPage?param=1");
await GotoAsync("nextPage");
await GotoAsync(".."); // param = 1 will get applied to `firstPage`
```

#### Breaking Change
```C#
var parameter = new ShellRouteParameters
{
     { "ComplexObject", obj}
};

await GotoAsync("firstPage?param=1", parameter);
await GotoAsync("nextPage");
await GotoAsync(".."); // param = 1 will get applied to `firstPage` but `ComplexObject` won't
```

```C#
var parameter = new ShellRouteParameters
{
     { "ComplexObject", obj}
};

await GotoAsync("firstPage", parameter);
await GotoAsync("nextPage");
await GotoAsync(".."); // IQueryAttributable.ApplyQueryAttributes will still get called but the dict will be empty
```

### Issues Fixed


Fixes #10294

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->


### Alternative Approaches
#### Add an enumeration to `Shell` so users can control the life cycle. 

```
public enum ParameterPassingBehavior
{
    OnlyPassOnFirstNavigation,
    PassEveryTime
}
```

##### Issues
- Complex objects are still retained inside the BP which might cause unknown memory leaks for users. 

#### Add a new overload for shell GotoAsync that differentiates navigation parameters vs query parameters.
```C#
GotoAsync("url", new NavigationArgs())

class NavigationArgs : IReadOnlyDictionary<string, object>
{
    // Additional properties we might use later on that help with other scenarios.
     public bool IsAnimated
     public bool PopToRoot
}

```

##### Issues
- Adding too much API that we might deprecate down the road