### PR TITLE
[android] improve layout performance of Label

### DIFF
--- a/src/Core/src/Handlers/ViewHandlerExtensions.Android.cs
+++ b/src/Core/src/Handlers/ViewHandlerExtensions.Android.cs
@@ -143,9 +143,7 @@ namespace Microsoft.Maui
 			}
 
 			var platformView = handler.ToPlatform();
-			var context = platformView?.Context;
-
-			if (platformView == null || context == null)
+			if (platformView == null)
 			{
 				return;
 			}
@@ -160,7 +158,7 @@ namespace Microsoft.Maui
 			// in order to properly handle any TextAlignment properties and some internal bookkeeping
 			if (virtualView.NeedsExactMeasure())
 			{
-				platformView.Measure(context.MakeMeasureSpecExact(frame.Width), context.MakeMeasureSpecExact(frame.Height));
+				platformView.Measure(platformView.MakeMeasureSpecExact(frame.Width), platformView.MakeMeasureSpecExact(frame.Height));
 			}
 		}
 
@@ -185,10 +183,10 @@ namespace Microsoft.Maui
 			return true;
 		}
 
-		internal static int MakeMeasureSpecExact(this Context context, double size)
+		internal static int MakeMeasureSpecExact(this PlatformView view, double size)
 		{
 			// Convert to a native size to create the spec for measuring
-			var deviceSize = (int)context!.ToPixels(size);
+			var deviceSize = (int)view.ToPixels(size);
 			return MeasureSpecMode.Exactly.MakeMeasureSpec(deviceSize);
 		}
 	}


### PR DESCRIPTION
Context: https://github.com/dotnet/maui/issues/12130
Context: https://github.com/angelru/CvSlowJittering
Context: https://github.com/jonathanpeppers/lols

Testing a customer sample and my LOLs per second sample, I could see a lot of time (5.1%) spent in `PrepareForTextViewArrange()`:

    1.01s (5.1%) microsoft.maui!Microsoft.Maui.ViewHandlerExtensions.PrepareForTextViewArrange(Microsoft.Maui.IViewHandler,Microsoft.Maui
    635.99ms (3.2%) mono.android!Android.Views.View.get_Context()

Most of the time is spent just calling `View.Context` to be able to do:

    internal static int MakeMeasureSpecExact(this Context context, double size)
    {
        // Convert to a native size to create the spec for measuring
        var deviceSize = (int)context!.ToPixels(size);
        return MeasureSpecMode.Exactly.MakeMeasureSpec(deviceSize);
    }

In eea91d30, I added an overload for `ToPixels()` that allows you to get the same value with an `Android.Views.View` -- avoiding the need to call `View.Context`.

So we can instead do:

    internal static int MakeMeasureSpecExact(this PlatformView view, double size)
    {
        // Convert to a native size to create the spec for measuring
        var deviceSize = (int)view.ToPixels(size);
        return MeasureSpecMode.Exactly.MakeMeasureSpec(deviceSize);
    }

After these changes, it seems to be ~2.7% better:

    420.68ms (2.4%) microsoft.maui!Microsoft.Maui.ViewHandlerExtensions.PrepareForTextViewArrange(Microsoft.Maui.IViewHandler,Microsoft.Maui

The `View.Context` call is now completely gone.

It appears to show a good result in the LOLs/second sample as well:

![image](https://user-images.githubusercontent.com/840039/236891928-8eeb3fe7-a3c4-4026-b948-e35c08c91361.png)
