### PR TITLE
Fix ListView not Truncating Labels iOS

### DIFF
--- a/src/Core/src/Layouts/HorizontalStackLayoutManager.cs
+++ b/src/Core/src/Layouts/HorizontalStackLayoutManager.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Maui.Layouts
 				}
 
 				spacingCount += 1;
-				var measure = child.Measure(double.PositiveInfinity, heightConstraint - padding.VerticalThickness);
+				var measure = child.Measure(widthConstraint, heightConstraint - padding.VerticalThickness);
 				measuredWidth += measure.Width;
 				measuredHeight = Math.Max(measuredHeight, measure.Height);
 			}

--- a/src/Core/src/Layouts/VerticalStackLayoutManager.cs
+++ b/src/Core/src/Layouts/VerticalStackLayoutManager.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Maui.Layouts
 				}
 
 				spacingCount += 1;
-				var measure = child.Measure(childWidthConstraint, double.PositiveInfinity);
+				var measure = child.Measure(childWidthConstraint, heightConstraint);
 				measuredHeight += measure.Height;
 				measuredWidth = Math.Max(measuredWidth, measure.Width);
 			}


### PR DESCRIPTION
### Description of Change

<!-- Enter description of the fix in this section -->

The following [issue](https://github.com/dotnet/maui/issues/11451) shows that in their example, the labels inside the HorizontalStackLayout inside the ListView are not truncating properly. 

<img width="300" alt="Screenshot 2023-05-08 at 2 34 48 PM" src="https://user-images.githubusercontent.com/50846373/236927074-3b28a6d9-cb27-4149-af68-ad6ad5a6f957.png">


I believe the problem lies in that for the children of HorizontalStackLayouts, the width they are given use is infinity. However, in cases where the width is decided on the parent, it seems to me that these should get passed to the child. 

After these changes, we can see that truncation is properly happening inside and outside the listview
<img width="300" alt="Screenshot 2023-05-08 at 1 14 21 PM" src="https://user-images.githubusercontent.com/50846373/236910363-b7dac703-04ab-4ae1-8624-1cc7eae08249.png">


**My biggest concern is that this may effect with something else that I am not aware of and would like input from those more experienced with the layouts!**

I will wait to add tests to this after confirming that this is a viable solution!

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #11451

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
