### PR TITLE
Workaround WinUI bug with adding/removing flyouts

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Core/ContextFlyoutPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/ContextFlyoutPage.xaml
@@ -30,9 +30,11 @@
                 <FlyoutBase.ContextFlyout>
                     <MenuFlyout>
                         <MenuFlyoutItem Text="Add top-level menu items" Clicked="OnAddMenuClicked"></MenuFlyoutItem>
-                        <MenuFlyoutSubItem Text="Sub menu items go in here">
+                        <MenuFlyoutSubItem Text="Sub menu items go in here" x:Name="subMenu">
                             <MenuFlyoutItem Text="Add sub menu items below here" Clicked="OnAddSubMenuClicked"></MenuFlyoutItem>
                             <MenuFlyoutSeparator />
+                            <MenuFlyoutSeparator />
+                            <MenuFlyoutItem Text="Remove sub menu item above here" Clicked="OnRemoveSubMenuClicked" x:Name="removeSubMenuItems" IsEnabled="False"></MenuFlyoutItem>
                         </MenuFlyoutSubItem>
                     </MenuFlyout>
                 </FlyoutBase.ContextFlyout>

--- a/src/Controls/samples/Controls.Sample/Pages/Core/ContextFlyoutPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/ContextFlyoutPage.xaml.cs
@@ -150,18 +150,48 @@ namespace Maui.Controls.Sample.Pages
 		void OnAddSubMenuClicked(object sender, EventArgs e)
 		{
 			var subMenu = (MenuFlyoutSubItem)((MenuFlyoutItem)sender).Parent;
-			AddNewMenu(subMenu, "sub-menu");
+			AddNewMenu(subMenu, "sub-menu", subMenu.Count - 2, subMenu.Count % 2 == 0);
+			CheckSubMenu();
+		}
+		void OnRemoveSubMenuClicked(object sender, EventArgs e)
+		{
+			var subMenu = (MenuFlyoutSubItem)((MenuFlyoutItem)sender).Parent;
+			subMenu.RemoveAt(subMenu.Count - 3);
+			CheckSubMenu();
 		}
 
-		private void AddNewMenu(IList<IMenuElement> parent, string newItemType)
+		void CheckSubMenu()
+		{
+			removeSubMenuItems.IsEnabled = subMenu.Count > 4;
+		}
+
+		private void AddNewMenu(IList<IMenuElement> parent, string newItemType, int index = -1, bool subMenuItem = false)
 		{
 			var newItemLocalValue = newMenuItemCount;
-			var newMenuItem = new MenuFlyoutItem() { Text = $"New {newItemType} menu item #{newItemLocalValue}" };
-			newMenuItem.Clicked += (s, e) => DisplayAlert(
+			IMenuElement newMenuItem;
+			MenuFlyoutItem mfi = new MenuFlyoutItem() { Text = $"New {newItemType} menu item #{newItemLocalValue}" };
+
+			mfi.Clicked += (s, e) => DisplayAlert(
 				title: "New Menu Item Click",
 				message: $"The new menu item {newItemLocalValue} was clicked",
 				cancel: "OK");
-			parent.Add(newMenuItem);
+
+			if (!subMenuItem)
+			{
+				newMenuItem = mfi;
+			}
+			else
+			{
+				var subItem = new MenuFlyoutSubItem() { Text = $"New {newItemType} menu item #{newItemLocalValue}" };
+				newMenuItem = subItem;
+				subItem.Add(mfi);
+			}
+
+			if (index == -1)
+				parent.Add(newMenuItem);
+			else
+				parent.Insert(index, newMenuItem);
+
 			newMenuItemCount++;
 		}
 	}

--- a/src/Core/src/Handlers/MenuFlyoutHandler/MenuFlyoutHandler.Windows.cs
+++ b/src/Core/src/Handlers/MenuFlyoutHandler/MenuFlyoutHandler.Windows.cs
@@ -9,6 +9,19 @@ namespace Microsoft.Maui.Handlers
 			return new MenuFlyout();
 		}
 
+		protected override void DisconnectHandler(MenuFlyout platformView)
+		{
+			if (VirtualView is not null)
+			{
+				foreach (var item in VirtualView)
+				{
+					item.Handler?.DisconnectHandler();
+				}
+			}
+
+			base.DisconnectHandler(platformView);
+		}
+
 		public override void SetVirtualView(IElement view)
 		{
 			base.SetVirtualView(view);

--- a/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -14,6 +14,7 @@ Microsoft.Maui.Layouts.FlexBasis.Equals(Microsoft.Maui.Layouts.FlexBasis other) 
 Microsoft.Maui.Platform.MauiWebView.MauiWebView(Microsoft.Maui.Handlers.WebViewHandler! handler) -> void
 Microsoft.Maui.SizeRequest.Equals(Microsoft.Maui.SizeRequest other) -> bool
 override Microsoft.Maui.Handlers.ContentViewHandler.DisconnectHandler(Microsoft.Maui.Platform.ContentPanel! platformView) -> void
+override Microsoft.Maui.Handlers.MenuFlyoutHandler.DisconnectHandler(Microsoft.UI.Xaml.Controls.MenuFlyout! platformView) -> void
 override Microsoft.Maui.Layouts.FlexBasis.Equals(object? obj) -> bool
 override Microsoft.Maui.Layouts.FlexBasis.GetHashCode() -> int
 override Microsoft.Maui.SizeRequest.Equals(object? obj) -> bool


### PR DESCRIPTION
### Description of Change

Workaround an [issue in `WinUI`](https://github.com/microsoft/microsoft-ui-xaml/issues/7797) where you can't add/remove flyout items to a submenu.

The fix was a bit more involved than I'd hoped it would be. You basically have to remove the SubMenuItem and recreate the entire thing in order to modify the menu. At least that's the only way I could get it to work. 

- If you just remove/add the item it doesn't work
- If you try to move any children menu from the old menu to the new menu it just crashes.

### Issues Fixed
Fixes #14984

### Testing

This is all visual so we can't really use our device tests for this


