### PR TITLE
Move Windows and iOS Frame measure and arrange to xplat layer

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Windows/FrameRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Windows/FrameRenderer.cs
@@ -57,7 +57,6 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				PackChild();
 				UpdateBorder();
 				UpdateCornerRadius();
-				UpdatePadding();
 			}
 		}
 
@@ -77,15 +76,6 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			{
 				UpdateCornerRadius();
 			}
-			else if (e.PropertyName == Frame.PaddingProperty.PropertyName)
-			{
-				UpdatePadding();
-			}
-		}
-
-		void UpdatePadding()
-		{
-			Control.Padding = Element.Padding.ToPlatform();
 		}
 
 		protected override global::Windows.Foundation.Size ArrangeOverride(global::Windows.Foundation.Size finalSize)

--- a/src/Controls/src/Core/Compatibility/Handlers/iOS/FrameRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/iOS/FrameRenderer.cs
@@ -9,8 +9,6 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 {
 	public class FrameRenderer : VisualElementRenderer<Frame>
 	{
-		const int FrameBorderThickness = 1;
-
 		public static IPropertyMapper<Frame, FrameRenderer> Mapper
 			= new PropertyMapper<Frame, FrameRenderer>(VisualElementRendererMapper);
 
@@ -126,8 +124,11 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			}
 			else
 			{
+				var borderWidth = (int)(Element is IBorderElement be ? be.BorderWidth : 1);
+				borderWidth = Math.Max(1, borderWidth);
+
 				_actualView.Layer.BorderColor = Element.BorderColor.ToCGColor();
-				_actualView.Layer.BorderWidth = FrameBorderThickness;
+				_actualView.Layer.BorderWidth = borderWidth;
 			}
 
 			Layer.RasterizationScale = UIScreen.MainScreen.Scale;
@@ -158,12 +159,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		public override CGSize SizeThatFits(CGSize size)
 		{
-			var borderThickness = (Element.BorderColor.IsNotDefault() ? FrameBorderThickness : 0) * 2;
-
-			var availableSize = new CGSize(size.Width - borderThickness, size.Height - borderThickness);
-			var result = _actualView.SizeThatFits(availableSize);
-
-			return new CGSize(result.Width + borderThickness, result.Height + borderThickness);
+			return _actualView.SizeThatFits(size);
 		}
 
 		public override void Draw(CGRect rect)

--- a/src/Controls/src/Core/Frame.cs
+++ b/src/Controls/src/Core/Frame.cs
@@ -55,13 +55,7 @@ namespace Microsoft.Maui.Controls
 
 		int IBorderElement.CornerRadius => (int)CornerRadius;
 
-		// TODO fix iOS/WinUI to work the same as Android
-#if ANDROID
 		double IBorderElement.BorderWidth => 1;
-#else
-		// not currently used by frame
-		double IBorderElement.BorderWidth => -1d;
-#endif
 
 		int IBorderElement.CornerRadiusDefaultValue => (int)CornerRadiusProperty.DefaultValue;
 
@@ -92,23 +86,23 @@ namespace Microsoft.Maui.Controls
 		// TODO fix iOS/WinUI to work the same as Android
 		// once this has been fixed on iOS/WinUI we should centralize 
 		// this code and Border into LayoutExtensions
-		// WinUI being fixed as part of
-		// https://github.com/dotnet/maui/issues/13552
-#if ANDROID
 		Size IContentView.CrossPlatformArrange(Graphics.Rect bounds)
 		{
-			bounds = bounds.Inset(((IBorderElement)this).BorderWidth);
+#if !WINDOWS
+			bounds = bounds.Inset(((IBorderElement)this).BorderWidth); // Windows' implementation would cause an incorrect double-counting of the inset
+#endif
 			this.ArrangeContent(bounds);
 			return bounds.Size;
 		}
 
 		Size IContentView.CrossPlatformMeasure(double widthConstraint, double heightConstraint)
 		{
-			var inset = Padding + ((IBorderElement)this).BorderWidth;
+			var inset = Padding;
+#if !WINDOWS
+			inset += ((IBorderElement)this).BorderWidth; // Windows' implementation would cause an incorrect double-counting of the inset
+#endif
 			return this.MeasureContent(inset, widthConstraint, heightConstraint);
 		}
-#endif
-
 	}
 
 	internal static class FrameExtensions

--- a/src/Controls/tests/DeviceTests/Elements/Frame/FrameTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Frame/FrameTests.cs
@@ -271,7 +271,7 @@ namespace Microsoft.Maui.DeviceTests
 			var originalLayoutDimensions = 300;
 			var shrunkWindowWidth = originalLayoutDimensions - 100;
 
-			var content = new Label 
+			var content = new Label
 			{
 				LineBreakMode = LineBreakMode.WordWrap,
 				Text = "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
@@ -285,7 +285,7 @@ namespace Microsoft.Maui.DeviceTests
 				Padding = new Thickness(0),
 				Margin = new Thickness(0),
 				VerticalOptions = LayoutOptions.Start,
-				HorizontalOptions = LayoutOptions.Start 
+				HorizontalOptions = LayoutOptions.Start
 			};
 
 			var layout = new StackLayout()
@@ -293,7 +293,7 @@ namespace Microsoft.Maui.DeviceTests
 				Children = { frame }
 			};
 
-			await CreateHandlerAndAddToWindow<IPlatformViewHandler>(layout,  async (handler)  =>
+			await CreateHandlerAndAddToWindow<IPlatformViewHandler>(layout, async (handler) =>
 					{
 						// Place the frame in a spacious container in a large window
 						var size = (layout as IView).Measure(originalLayoutDimensions, originalLayoutDimensions);

--- a/src/Controls/tests/DeviceTests/Elements/Frame/FrameTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Frame/FrameTests.cs
@@ -263,6 +263,45 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.Equal(expected, layoutFrame.Height, 1.0d);
 		}
 
+		[Fact]
+		public async Task FrameIncludesPadding()
+		{
+			SetupBuilder();
+
+			double contentSize = 50;
+			var content = new Label { Text = "Hey", WidthRequest = contentSize, HeightRequest = contentSize };
+			var padding = 10;
+
+			var frame = new Frame()
+			{
+				Content = content,
+				BorderColor = Colors.Black,
+				CornerRadius = 10,
+				Padding = new Thickness(padding),
+				Margin = new Thickness(0),
+				VerticalOptions = LayoutOptions.Start,
+				HorizontalOptions = LayoutOptions.Start
+			};
+
+			var layout = new StackLayout()
+			{
+				Children =
+				{
+					frame
+				}
+			};
+
+			var layoutFrame = await LayoutFrame(layout, frame, 500, 500);
+
+			// The expected content size should add padding to every direction
+			var expected = contentSize + (padding * 2) + (FrameBorderThickness * 2);
+
+			// We're checking the Frame size within a tolerance of 1; between screen density of test devices and rounding issues,
+			// it's not going to be exactly `expected`, but it should be close.
+			Assert.Equal(expected, layoutFrame.Width, 1.0d);
+			Assert.Equal(expected, layoutFrame.Height, 1.0d);
+		}
+
 #if !ANDROID
 		[Fact]
 		public async Task FrameResizesItsContents()

--- a/src/Controls/tests/DeviceTests/Elements/Frame/FrameTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Frame/FrameTests.cs
@@ -263,7 +263,7 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.Equal(expected, layoutFrame.Height, 1.0d);
 		}
 
-# if !ANDROID
+#if !ANDROID
 		[Fact]
 		public async Task FrameResizesItsContents()
 		{

--- a/src/Controls/tests/DeviceTests/Elements/Frame/FrameTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Frame/FrameTests.cs
@@ -263,6 +263,62 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.Equal(expected, layoutFrame.Height, 1.0d);
 		}
 
+		[Fact]
+		public async Task FrameResizesItsContents()
+		{
+			SetupBuilder();
+
+			var originalLayoutDimensions = 300;
+			var shrunkWindowWidth = originalLayoutDimensions - 100;
+
+			var content = new Label 
+			{
+				LineBreakMode = LineBreakMode.WordWrap,
+				Text = "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+			};
+
+			var frame = new Frame()
+			{
+				Content = content,
+				BorderColor = Colors.Black,
+				CornerRadius = 10,
+				Padding = new Thickness(0),
+				Margin = new Thickness(0),
+				VerticalOptions = LayoutOptions.Start,
+				HorizontalOptions = LayoutOptions.Start 
+			};
+
+			var layout = new StackLayout()
+			{
+				Children = { frame }
+			};
+
+			await CreateHandlerAndAddToWindow<IPlatformViewHandler>(layout,  async (handler)  =>
+					{
+						// Place the frame in a spacious container in a large window
+						var size = (layout as IView).Measure(originalLayoutDimensions, originalLayoutDimensions);
+						var rect = new Graphics.Rect(0, 0, size.Width, size.Height);
+						(layout as IView).Arrange(rect);
+						await OnFrameSetToNotEmpty(layout);
+						await OnFrameSetToNotEmpty(frame);
+
+						// Measure frame when it was first rendered in a spacious container
+						var frameControlSize = (frame.Handler as IPlatformViewHandler).PlatformView.GetBoundingBox();
+						var originalFrameHeight = frameControlSize.Height;
+						Assert.True(frameControlSize.Width > 0);
+						// Resize window to be smaller, forcing the frame to shrink (and wait for the changes to reflect)
+						layout.Window.Width = shrunkWindowWidth;
+						await Task.Delay(2000);
+
+						// Ensure frame is within the window dimensions
+						frameControlSize = (frame.Handler as IPlatformViewHandler).PlatformView.GetBoundingBox();
+						Assert.True((frameControlSize.Width > 0) && (frameControlSize.Width < shrunkWindowWidth));
+
+						// Ensure that inner text in the frame wrapped, thereby increasing its height
+						Assert.True(frameControlSize.Height > originalFrameHeight);
+					});
+		}
+
 		[Theory]
 		[InlineData(500, 500)]
 		[InlineData(500, double.PositiveInfinity)]

--- a/src/Controls/tests/DeviceTests/Elements/Frame/FrameTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Frame/FrameTests.cs
@@ -301,7 +301,7 @@ namespace Microsoft.Maui.DeviceTests
 						var rect = new Graphics.Rect(0, 0, size.Width, size.Height);
 						(layout as IView).Arrange(rect);
 						await OnFrameSetToNotEmpty(layout);
-						// await OnFrameSetToNotEmpty(frame);
+						await OnFrameSetToNotEmpty(frame);
 
 						// Measure frame when it was first rendered in a spacious container
 						var frameControlSize = (frame.Handler as IPlatformViewHandler).PlatformView.GetBoundingBox();

--- a/src/Controls/tests/DeviceTests/Elements/Frame/FrameTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Frame/FrameTests.cs
@@ -263,6 +263,7 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.Equal(expected, layoutFrame.Height, 1.0d);
 		}
 
+# if !ANDROID
 		[Fact]
 		public async Task FrameResizesItsContents()
 		{
@@ -300,7 +301,7 @@ namespace Microsoft.Maui.DeviceTests
 						var rect = new Graphics.Rect(0, 0, size.Width, size.Height);
 						(layout as IView).Arrange(rect);
 						await OnFrameSetToNotEmpty(layout);
-						await OnFrameSetToNotEmpty(frame);
+						// await OnFrameSetToNotEmpty(frame);
 
 						// Measure frame when it was first rendered in a spacious container
 						var frameControlSize = (frame.Handler as IPlatformViewHandler).PlatformView.GetBoundingBox();
@@ -314,10 +315,12 @@ namespace Microsoft.Maui.DeviceTests
 						frameControlSize = (frame.Handler as IPlatformViewHandler).PlatformView.GetBoundingBox();
 						Assert.True((frameControlSize.Width > 0) && (frameControlSize.Width < shrunkWindowWidth));
 
-						// Ensure that inner text in the frame wrapped, thereby increasing its height
-						Assert.True(frameControlSize.Height > originalFrameHeight);
+
+						// If the frame's height changed (it wrapped some text), ensure it hasn't shrunk
+						Assert.True(frameControlSize.Height >= originalFrameHeight);
 					});
 		}
+#endif
 
 		[Theory]
 		[InlineData(500, 500)]


### PR DESCRIPTION
### Description of Change
The Windows and iOS frame renderers were taking care of the measuring and arranging internally. These implementations differed from the standard Border implementation. In Windows, this caused a bug where frames would not resize if the Windows size changed. 

For Windows, the fix entails using a ContentPanel as a child within the frame element. Windows requires special treatment in the sense that we don't need to account for any inset calculations coming from the frame's border thickness - this is taken care of natively. Otherwise, we end up double-counting the frame's border when calculating size and fail the [FrameIncludesBorderThickness](https://github.com/dotnet/maui/blob/bd1c0138d4af38f96b8dab742c92c136f8e25d93/src/Controls/tests/DeviceTests/Elements/Frame/FrameTests.cs#L229) test. 

On iOS we use the xplat arrange and measure without extra changes. The native views are then able to handle the rest. 

<details>
<summary> Demo on windows using previously broken code</summary>

![Animation](https://user-images.githubusercontent.com/32918747/236956299-fcb34bb7-3a15-4121-92d0-8260b6ce2df1.gif)

</details>

### Issues Fixed

Fixes #13552