### PR TITLE
Make layout honor MaxWidth and MaxHeight requests

### DIFF
--- a/src/Core/src/Layouts/LayoutExtensions.cs
+++ b/src/Core/src/Layouts/LayoutExtensions.cs
@@ -72,15 +72,17 @@ namespace Microsoft.Maui.Layouts
 		static double AlignHorizontal(IView view, Rect bounds, Thickness margin)
 		{
 			var alignment = view.HorizontalLayoutAlignment;
+			var desiredWidth = view.DesiredSize.Width;
 
 			if (alignment == LayoutAlignment.Fill && (IsExplicitSet(view.Width) || !double.IsInfinity(view.MaximumWidth)))
 			{
 				// If the view has an explicit width (or non-infinite MaxWidth) set and the layout alignment is Fill,
 				// we just treat the view as centered within the space it "fills"
 				alignment = LayoutAlignment.Center;
-			}
 
-			var desiredWidth = view.DesiredSize.Width;
+				// If the width is not set, we use the minimum between the MaxWidth or the bound's width
+				desiredWidth = IsExplicitSet(view.Width) ? desiredWidth : Math.Min(bounds.Width, view.MaximumWidth);
+			}
 
 			return AlignHorizontal(bounds.X, margin.Left, margin.Right, bounds.Width, desiredWidth, alignment);
 		}
@@ -107,12 +109,16 @@ namespace Microsoft.Maui.Layouts
 		static double AlignVertical(IView view, Rect bounds, Thickness margin)
 		{
 			var alignment = view.VerticalLayoutAlignment;
+			var desiredHeight = view.DesiredSize.Height;
 
 			if (alignment == LayoutAlignment.Fill && (IsExplicitSet(view.Height) || !double.IsInfinity(view.MaximumHeight)))
 			{
 				// If the view has an explicit height (or non-infinite MaxHeight) set and the layout alignment is Fill,
 				// we just treat the view as centered within the space it "fills"
 				alignment = LayoutAlignment.Center;
+
+				// If the height is not set, we use the minimum between the MaxHeight or the bound's height
+				desiredHeight = IsExplicitSet(view.Height) ? desiredHeight : Math.Min(bounds.Height, view.MaximumHeight);
 			}
 
 			double frameY = bounds.Y + margin.Top;
@@ -120,11 +126,11 @@ namespace Microsoft.Maui.Layouts
 			switch (alignment)
 			{
 				case LayoutAlignment.Center:
-					frameY += (bounds.Height - view.DesiredSize.Height) / 2;
+					frameY += (bounds.Height - desiredHeight) / 2;
 					break;
 
 				case LayoutAlignment.End:
-					frameY += bounds.Height - view.DesiredSize.Height;
+					frameY += bounds.Height - desiredHeight;
 					break;
 			}
 

--- a/src/Core/src/Layouts/LayoutExtensions.cs
+++ b/src/Core/src/Layouts/LayoutExtensions.cs
@@ -41,8 +41,8 @@ namespace Microsoft.Maui.Layouts
 			if (view.HorizontalLayoutAlignment == LayoutAlignment.Fill && !IsExplicitSet(view.Width))
 			{
 				// But if the element is set to fill horizontally and it doesn't have an explicitly set width,
-				// then we want the width of the entire bounds
-				consumedWidth = bounds.Width;
+				// then we want the minimum between its maximumWidth (if set) and the bounds' width
+				consumedWidth = IsExplicitSet(view.MaximumWidth) ? Math.Min(bounds.Width, view.MaximumWidth) : bounds.Width;
 			}
 
 			// And the actual frame width needs to subtract the margins
@@ -52,10 +52,10 @@ namespace Microsoft.Maui.Layouts
 			var consumedHeight = view.DesiredSize.Height;
 
 			// But, if the element is set to fill vertically and it doesn't have an explicitly set height,
-			// then we want the height of the entire bounds
+			// then we want the minimum between its maximumHeight (if set) and the bounds' height
 			if (view.VerticalLayoutAlignment == LayoutAlignment.Fill && !IsExplicitSet(view.Height))
 			{
-				consumedHeight = bounds.Height;
+				consumedHeight = IsExplicitSet(view.MaximumHeight) ? Math.Min(bounds.Height, view.MaximumHeight) : bounds.Height;
 			}
 
 			// And the actual frame height needs to subtract the margins

--- a/src/Core/src/Layouts/LayoutExtensions.cs
+++ b/src/Core/src/Layouts/LayoutExtensions.cs
@@ -38,11 +38,12 @@ namespace Microsoft.Maui.Layouts
 			// We need to determine the width the element wants to consume; normally that's the element's DesiredSize.Width
 			var consumedWidth = view.DesiredSize.Width;
 
+			// But if the element is set to fill horizontally and it doesn't have an explicitly set width,
+			// then we want the minimum between its MaximumWidth and the bounds' width
+			// MaximumWidth is always positive infinity if not defined by the user
 			if (view.HorizontalLayoutAlignment == LayoutAlignment.Fill && !IsExplicitSet(view.Width))
 			{
-				// But if the element is set to fill horizontally and it doesn't have an explicitly set width,
-				// then we want the minimum between its maximumWidth (if set) and the bounds' width
-				consumedWidth = IsExplicitSet(view.MaximumWidth) ? Math.Min(bounds.Width, view.MaximumWidth) : bounds.Width;
+				consumedWidth = Math.Min(bounds.Width, view.MaximumWidth);
 			}
 
 			// And the actual frame width needs to subtract the margins
@@ -52,10 +53,11 @@ namespace Microsoft.Maui.Layouts
 			var consumedHeight = view.DesiredSize.Height;
 
 			// But, if the element is set to fill vertically and it doesn't have an explicitly set height,
-			// then we want the minimum between its maximumHeight (if set) and the bounds' height
+			// then we want the minimum between its MaximumHeight  and the bounds' height
+			// MaximumHeight is always positive infinity if not defined by the user
 			if (view.VerticalLayoutAlignment == LayoutAlignment.Fill && !IsExplicitSet(view.Height))
 			{
-				consumedHeight = IsExplicitSet(view.MaximumHeight) ? Math.Min(bounds.Height, view.MaximumHeight) : bounds.Height;
+				consumedHeight = Math.Min(bounds.Height, view.MaximumHeight);
 			}
 
 			// And the actual frame height needs to subtract the margins
@@ -71,9 +73,9 @@ namespace Microsoft.Maui.Layouts
 		{
 			var alignment = view.HorizontalLayoutAlignment;
 
-			if (alignment == LayoutAlignment.Fill && IsExplicitSet(view.Width))
+			if (alignment == LayoutAlignment.Fill && (IsExplicitSet(view.Width) || !double.IsInfinity(view.MaximumWidth)))
 			{
-				// If the view has an explicit width set and the layout alignment is Fill,
+				// If the view has an explicit width (or non-infinite MaxWidth) set and the layout alignment is Fill,
 				// we just treat the view as centered within the space it "fills"
 				alignment = LayoutAlignment.Center;
 			}
@@ -106,9 +108,9 @@ namespace Microsoft.Maui.Layouts
 		{
 			var alignment = view.VerticalLayoutAlignment;
 
-			if (alignment == LayoutAlignment.Fill && IsExplicitSet(view.Height))
+			if (alignment == LayoutAlignment.Fill && (IsExplicitSet(view.Height) || !double.IsInfinity(view.MaximumHeight)))
 			{
-				// If the view has an explicit height set and the layout alignment is Fill,
+				// If the view has an explicit height (or non-infinite MaxHeight) set and the layout alignment is Fill,
 				// we just treat the view as centered within the space it "fills"
 				alignment = LayoutAlignment.Center;
 			}

--- a/src/Core/tests/UnitTests/Layouts/LayoutExtensionTests.cs
+++ b/src/Core/tests/UnitTests/Layouts/LayoutExtensionTests.cs
@@ -332,7 +332,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			var widthConstraint = 300;
 			var heightConstraint = 300;
 			var desiredSize = new Size(50, 50);
-			
+
 			var maxWidth = 100;
 
 			var element = Substitute.For<IView>();


### PR DESCRIPTION
### Description of Change

Layouts were not taking into account a view's MaxWidth/Height if the layout's alignment policy was set to `Fill`. This caused the frustrating behavior that you would specify an element's MaxWidth/Height but have these values completely ignored. 

The fix consists on making the `ComputeFrame` method and the `AlignHorizontal`/`AlignVertical` methods to take into account these properties. The changes can be summarized as follows:

If an element has an **unset** `WidthRequest` but **has** a `MaximumWidthRequest`, then its consumed width should be the minimum between the MaximumWidthRequest and the available space (i.e `bounds.Width`). This type of logic should also be used in the alignment calculations iff the `WidthRequest` is not set. 

Below are screenshots of the before and after of running this code on different platforms:
```xaml
    <StackLayout>
            <Button Text="Some random text that I've typed to occupy space"
                    BackgroundColor="AliceBlue"
                    TextColor="Black"
                    MaximumWidthRequest="100"
                    />
    </StackLayout>
```

| Before | After | 
| -- | -- |
| <img width="700" src="https://github.com/dotnet/maui/assets/32918747/1e0f4096-d0a6-4f4b-b6ec-d446782ead42"> | <img width="700" alt="image" src="https://github.com/dotnet/maui/assets/32918747/4d0da553-9527-48ee-83b9-8a9c71bc8faa"> |
| <img width="700" src="https://github.com/dotnet/maui/assets/32918747/508638aa-fdf2-477e-bc59-58b1b879c5c6"> |  <img width="700" alt="image" src="https://github.com/dotnet/maui/assets/32918747/d80581c5-c321-4d3a-a9d7-4005563436fa"> | 
| <img width="400" src="https://github.com/dotnet/maui/assets/32918747/bcfa0457-2ff7-40ff-9fad-3848da821c73"> |  <img width="414" alt="image" src="https://github.com/dotnet/maui/assets/32918747/2f452bb9-3acb-4da5-8b19-456a757baf80"> |

Notice how the buttons are now smaller and obey their MaximumWidthRequests.

<hr>

Las but not least, some of the existing unit tests were modified to take into account MaximumWidth/Height since the substitutes would return 0 for these values. I've also added tests to ensure that layouts behave as expected when the Width and Height are **not** set but their Maximum counterparts are. 

### Issues Fixed

Fixes #15002
