### PR TITLE
Update DEVELOPMENT and README to make it clear that you need to run the build tasks.

### DIFF
--- a/.github/DEVELOPMENT.md
+++ b/.github/DEVELOPMENT.md
@@ -2,6 +2,10 @@
 
 This page contains steps to build and run the .NET MAUI repository from source. If you are looking to build apps with .NET MAUI please head over to the links in the [README](https://github.com/dotnet/maui/blob/main/README.md) to get started.
 
+## NOTE
+
+In order to open the MAUI solution files and build the product, you must run the MAUI Build Task scripts at least once. You can do this by following the "[Opening the Repository](#opening-the-repository)" directions below.
+
 ## Requirements
 
 ### Visual Studio

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 * [.NET MAUI Samples](https://github.com/dotnet/maui-samples)
 * [Development Guide](./.github/DEVELOPMENT.md)
 
-## Source Build TL;DR. ##
+## Source Build TL;DR
 
 Checkout the MAUI repository and run the following:
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,15 @@
 * [.NET MAUI Samples](https://github.com/dotnet/maui-samples)
 * [Development Guide](./.github/DEVELOPMENT.md)
 
+## Source Build TL;DR. ##
+
+Checkout the MAUI repository and run the following:
+
+```
+dotnet tool restore
+dotnet cake --target=dotnet-build --workloads=global
+```
+
 ## Overview
 
 .NET Multi-platform App UI (.NET MAUI) is the evolution of Xamarin.Forms that expands capabilities beyond mobile Android and iOS into desktop apps for Windows and macOS. With .NET MAUI, you can build apps that perform great for any device that runs Windows, macOS, Android, & iOS from a single codebase. Coupled with Visual Studio productivity tools and emulators, .NET and Visual Studio significantly speed up the development process for building apps that target the widest possible set of devices. Use a single development stack that supports the best of breed solutions for all modern workloads with a unified SDK, base class libraries, and toolchain. [Read More](https://docs.microsoft.com/dotnet/maui/what-is-maui)


### PR DESCRIPTION
### Description of Change

Added explicit references to README.md and DEVELOPMENT.md that you have to run the dotnet build tasks within the project folder before you're able to open the solution and build MAUI. This should hopefully start to make it clearer for those wanting to build MAUI locally to do so.

