### PR TITLE
Remove incorrect call to `DisconnectHandler`

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/iOS/CellTableViewCell.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/iOS/CellTableViewCell.cs
@@ -72,7 +72,6 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			else
 				reusableCell = tableView.DequeueReusableCell(id);
 
-			cell.Handler?.DisconnectHandler();
 			cell.ReusableCell = reusableCell;
 			cell.TableView = tableView;
 			var handler = cell.ToHandler(cell.FindMauiContext());

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/iOS/ViewCellRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/iOS/ViewCellRenderer.cs
@@ -41,6 +41,20 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			return cell;
 		}
 
+
+
+
+#pragma warning disable RS0016 // Add public types and members to the declared API
+		protected override void DisconnectHandler(UITableViewCell platformView)
+#pragma warning restore RS0016 // Add public types and members to the declared API
+		{
+			if (platformView is ViewTableCell vtc)
+			{
+				vtc.ViewCell = null;
+			}
+		}
+
+
 		internal class ViewTableCell : UITableViewCell, INativeElementView
 		{
 			IMauiContext MauiContext => _viewCell.FindMauiContext();
@@ -170,7 +184,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 				var newRenderer = _viewCell.View.ToHandler(_viewCell.View.FindMauiContext());
 				_rendererRef = new WeakReference<IPlatformViewHandler>(newRenderer);
-				ContentView.AddSubview(newRenderer.PlatformView);
+				ContentView.AddSubview(newRenderer.VirtualView.ToPlatform());
 				return (IPlatformViewHandler)newRenderer;
 			}
 
@@ -187,6 +201,14 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				}
 
 				_viewCell = cell;
+
+				if (cell is null)
+				{
+					_rendererRef = null;
+					ContentView.ClearSubviews();
+					return;
+				}
+
 				_viewCell.PropertyChanged += ViewCellPropertyChanged;
 				BeginInvokeOnMainThread(_viewCell.SendAppearing);
 

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/iOS/ViewCellRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/iOS/ViewCellRenderer.cs
@@ -41,20 +41,6 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			return cell;
 		}
 
-
-
-
-#pragma warning disable RS0016 // Add public types and members to the declared API
-		protected override void DisconnectHandler(UITableViewCell platformView)
-#pragma warning restore RS0016 // Add public types and members to the declared API
-		{
-			if (platformView is ViewTableCell vtc)
-			{
-				vtc.ViewCell = null;
-			}
-		}
-
-
 		internal class ViewTableCell : UITableViewCell, INativeElementView
 		{
 			IMauiContext MauiContext => _viewCell.FindMauiContext();
@@ -184,6 +170,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 				var newRenderer = _viewCell.View.ToHandler(_viewCell.View.FindMauiContext());
 				_rendererRef = new WeakReference<IPlatformViewHandler>(newRenderer);
+				ContentView.ClearSubviews();
 				ContentView.AddSubview(newRenderer.VirtualView.ToPlatform());
 				return (IPlatformViewHandler)newRenderer;
 			}


### PR DESCRIPTION
### Description of Change

When I initially tried to fix an issue where the wrong virtual view was getting assigned to the wrong view cell, I did so by disconnecting the `ViewCell` at the wrong point in time. This PR moves the disconnect to the point in type when the ViewCell is being used for recycling.

### Issues Fixed
Fixes #11287
Fixes #11640

