### PR TITLE
Wait for root page to load before processing modal

### DIFF
--- a/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.cs
+++ b/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.cs
@@ -324,7 +324,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 		// Windows and Android have basically the same requirement that
 		// we need to wait for the current page to finish loading before
-		// satsifying Modal requests.
+		// satisfying Modal requests.
 		// This will most likely change once we switch Android to using dialog fragments		
 #if WINDOWS || ANDROID
 		IDisposable? _platformPageWatchingForLoaded;
@@ -338,22 +338,33 @@ namespace Microsoft.Maui.Controls.Platform
 				await SyncPlatformModalStackAsync().ConfigureAwait(false);
 			}
 			else if (_window.IsActivated &&
-				_window?.Page?.Handler is not null)
+					_window?.Page?.Handler is not null)
 			{
 				if (CurrentPlatformPage.Handler is null)
 				{
 					CurrentPlatformPage.HandlerChanged += OnCurrentPlatformPageHandlerChanged;
-					;
+
 					_platformPageWatchingForLoaded = new ActionDisposable(() =>
 					{
 						CurrentPlatformPage.HandlerChanged -= OnCurrentPlatformPageHandlerChanged;
 					});
 				}
-				else if (!CurrentPlatformPage.IsLoadedOnPlatform() &&
-					CurrentPlatformPage.Handler is not null)
+				// This accounts for cases where we swap the root page out
+				// We want to wait for that to finish loading before processing any modal changes
+#if ANDROID
+				else if (!_window.Page.IsLoadedOnPlatform())
 				{
+					var windowPage = _window.Page;
 					_platformPageWatchingForLoaded =
-						CurrentPlatformPage.OnLoaded(() => OnCurrentPlatformPageLoaded(_platformPageWatchingForLoaded, EventArgs.Empty));
+						windowPage.OnLoaded(() => OnCurrentPlatformPageLoaded(windowPage, EventArgs.Empty));
+				}
+#endif
+				else if (!CurrentPlatformPage.IsLoadedOnPlatform() &&
+						  CurrentPlatformPage.Handler is not null)
+				{
+					var currentPlatformPage = CurrentPlatformPage;
+					_platformPageWatchingForLoaded =
+						currentPlatformPage.OnLoaded(() => OnCurrentPlatformPageLoaded(currentPlatformPage, EventArgs.Empty));
 				}
 			}
 		}
@@ -382,6 +393,7 @@ namespace Microsoft.Maui.Controls.Platform
 				bool result =
 					_window?.Page?.Handler is not null &&
 					_window.IsActivated
+					&& _window.Page.IsLoadedOnPlatform()
 					&& CurrentPlatformPage?.Handler is not null
 					&& CurrentPlatformPage.IsLoadedOnPlatform();
 

--- a/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.iOS.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Platform;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
 using UIKit;
@@ -23,7 +24,7 @@ namespace Microsoft.Maui.DeviceTests
 			await CreateHandlerAndAddToWindow<IWindowHandler>(rootPage,
 				async (handler) =>
 				{
-					var currentPage = (rootPage as IPageContainer<Page>).CurrentPage;
+					var currentPage = rootPage.GetCurrentPage();
 					await currentPage.Navigation.PushModalAsync(modalPage);
 					await OnLoadedAsync(modalPage);
 					Assert.Equal(1, currentPage.Navigation.ModalStack.Count);


### PR DESCRIPTION
### Description of Change

While testing https://github.com/dotnet/maui/pull/15020 I found a bug that's causing a crash when you try to swap out the root page when a modal page is currently open on android. 

With the old gallery a lot of the tests have to swap out the `mainpage` in order to run in an isolated context.

The code change in this PR fixes `android` so that it waits to process the modal pages until the root page has been loaded. There was a timing issue where the modal page was being removed before the root page was loaded in which would cause an NRE.