### PR TITLE
Use PrependToMapping method to replace Window MapTitle method

### DIFF
--- a/eng/pipelines/common/device-tests-steps.yml
+++ b/eng/pipelines/common/device-tests-steps.yml
@@ -62,13 +62,13 @@ steps:
     inputs:
       testResultsFormat: xUnit
       testResultsFiles: '$(TestResultsDirectory)/**/TestResults.xml'
-      testRunTitle: '$(System.PhaseName)'
+      testRunTitle: '$(System.PhaseName) (attempt: $(System.JobAttempt))'
 
   - task: PublishBuildArtifacts@1
     displayName: Publish Artifacts
     condition: always()
     inputs:
-      artifactName: $(System.PhaseName)
+      artifactName: $(System.PhaseName)_attempt_$(System.JobAttempt)
 
   # This must always be placed as the last step in the job
   - template: agent-rebooter/mac.v1.yml@yaml-templates

--- a/src/Controls/src/Core/HandlerImpl/Window/Window.Android.cs
+++ b/src/Controls/src/Core/HandlerImpl/Window/Window.Android.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Maui.Controls
 		{
 		}
 
+		[Obsolete]
 		public static void MapContent(IWindowHandler handler, IWindow view)
 		{
 		}

--- a/src/Controls/src/Core/HandlerImpl/Window/Window.Windows.cs
+++ b/src/Controls/src/Core/HandlerImpl/Window/Window.Windows.cs
@@ -17,16 +17,11 @@ namespace Microsoft.Maui.Controls
 			Handler?.UpdateValue(nameof(IWindow.TitleBarDragRectangles));
 		}
 
-		static void MapWindowTitle(IWindowHandler handler, IWindow window)
+		static void MapTitle(IWindowHandler handler, Window window)
 		{
-			if (window is Window controlsWindow)
-			{
-				handler
-					.PlatformView
-					.UpdateTitle(window, controlsWindow.GetCurrentlyPresentedMauiContext());
-			}
-
-			WindowHandler.MapTitle(handler, window);
+			handler
+				.PlatformView
+				.UpdateTitle(window, window.GetCurrentlyPresentedMauiContext());
 		}
 
 		Rect[] IWindow.TitleBarDragRectangles

--- a/src/Controls/src/Core/HandlerImpl/Window/Window.cs
+++ b/src/Controls/src/Core/HandlerImpl/Window/Window.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Maui.Controls
 #endif
 
 #if WINDOWS
-			WindowHandler.Mapper.ReplaceMapping<Window, IWindowHandler>(nameof(ITitledElement.Title), MapTitle);
+			WindowHandler.Mapper.PrependToMapping<Window, IWindowHandler>(nameof(ITitledElement.Title), MapTitle);
 #endif
 		}
 	}

--- a/src/Controls/src/Core/HandlerImpl/Window/Window.cs
+++ b/src/Controls/src/Core/HandlerImpl/Window/Window.cs
@@ -6,26 +6,20 @@ namespace Microsoft.Maui.Controls
 {
 	public partial class Window
 	{
+		[Obsolete("Use WindowHandler.Mapper instead.")]
 		public static IPropertyMapper<IWindow, WindowHandler> ControlsWindowMapper =
-			new PropertyMapper<IWindow, WindowHandler>(WindowHandler.Mapper);
+			new PropertyMapper<Window, WindowHandler>(WindowHandler.Mapper);
 
-		// ControlsWindowMapper incorrectly typed to WindowHandler
-		static IPropertyMapper<IWindow, IWindowHandler> Mapper =
-			new PropertyMapper<IWindow, IWindowHandler>(ControlsWindowMapper)
-			{
+		internal static new void RemapForControls()
+		{
 #if ANDROID
-				// This property is also on the Application Mapper since that's where the attached property exists				
-				[PlatformConfiguration.AndroidSpecific.Application.WindowSoftInputModeAdjustProperty.PropertyName] = MapWindowSoftInputModeAdjust,
+			// This property is also on the Application Mapper since that's where the attached property exists
+			WindowHandler.Mapper.ReplaceMapping<IWindow, IWindowHandler>(PlatformConfiguration.AndroidSpecific.Application.WindowSoftInputModeAdjustProperty.PropertyName, MapWindowSoftInputModeAdjust);
 #endif
 
 #if WINDOWS
-				[nameof(ITitledElement.Title)] = MapWindowTitle
+			WindowHandler.Mapper.PrependToMapping<Window, IWindowHandler>(nameof(ITitledElement.Title), MapTitle);
 #endif
-			};
-
-		internal static void RemapForControls()
-		{
-			WindowHandler.Mapper = Mapper;
 		}
 	}
 }

--- a/src/Controls/src/Core/HandlerImpl/Window/Window.cs
+++ b/src/Controls/src/Core/HandlerImpl/Window/Window.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Maui.Controls
 #endif
 
 #if WINDOWS
-			WindowHandler.Mapper.PrependToMapping<Window, IWindowHandler>(nameof(ITitledElement.Title), MapTitle);
+			WindowHandler.Mapper.ReplaceMapping<Window, IWindowHandler>(nameof(ITitledElement.Title), MapTitle);
 #endif
 		}
 	}

--- a/src/Controls/src/Core/HandlerImpl/Window/Window.cs
+++ b/src/Controls/src/Core/HandlerImpl/Window/Window.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Maui.Controls
 		public static IPropertyMapper<IWindow, WindowHandler> ControlsWindowMapper =
 			new PropertyMapper<Window, WindowHandler>(WindowHandler.Mapper);
 
-		internal static new void RemapForControls()
+		internal static void RemapForControls()
 		{
 #if ANDROID
 			// This property is also on the Application Mapper since that's where the attached property exists

--- a/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.Windows.cs
@@ -85,5 +85,52 @@ namespace Microsoft.Maui.DeviceTests
 					Assert.Equal(modalNavigationRootManager.WindowTitle, mauiWindow.Title);
 				});
 		}
+
+		[Fact]
+		public async Task WindowTitleIsCorrectAfterPushAndPop()
+		{
+			const string OriginalTitle = "Original Title";
+			const string UpdatedTitle = "Updated Title";
+
+			SetupBuilder();
+
+			var navPage = new NavigationPage(new ContentPage());
+			var window = new Window(navPage) { Title = OriginalTitle };
+
+			await CreateHandlerAndAddToWindow(window,
+				(Func<IWindowHandler, Task>)(async (handler) =>
+				{
+					var mauiWindow = handler.PlatformView;
+					var currentPage = navPage.CurrentPage;
+					var modalPage = new ContentPage();
+
+					await currentPage.Navigation.PushModalAsync(modalPage);
+					await OnLoadedAsync(modalPage);
+
+					var currentNavigationRootManager = currentPage
+						.FindMauiContext()
+						.GetNavigationRootManager();
+					var modalNavigationRootManager = modalPage
+						.FindMauiContext()
+						.GetNavigationRootManager();
+
+					Assert.Equal(OriginalTitle, mauiWindow.Title);
+					Assert.Equal(OriginalTitle, currentNavigationRootManager.WindowTitle);
+					Assert.Equal(OriginalTitle, modalNavigationRootManager.WindowTitle);
+					
+					window.Title = UpdatedTitle;
+
+					Assert.Equal(UpdatedTitle, mauiWindow.Title);
+					Assert.Equal(UpdatedTitle, currentNavigationRootManager.WindowTitle);
+					Assert.Equal(UpdatedTitle, modalNavigationRootManager.WindowTitle);
+
+					await currentPage.Navigation.PopModalAsync();
+					await OnUnloadedAsync(modalPage);
+
+					Assert.Equal(UpdatedTitle, mauiWindow.Title);
+					Assert.Equal(UpdatedTitle, currentNavigationRootManager.WindowTitle);
+					Assert.Equal(UpdatedTitle, modalNavigationRootManager.WindowTitle);
+				}));
+		}
 	}
 }


### PR DESCRIPTION
### Description of Change

This PR makes the Window Title mapper use new methods instead of calling "base" mappers.

Part of the fix for #11662 and part of PR #13836