### PR TITLE
[Android] Fix NullReferenceException on WebAuthenticatorIntermediateActivity

### DIFF
--- a/src/Essentials/src/WebAuthenticator/WebAuthenticatorIntermediateActivity.android.cs
+++ b/src/Essentials/src/WebAuthenticator/WebAuthenticatorIntermediateActivity.android.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Maui.Authentication
 			if (!launched)
 			{
 				// if this is the first time, start the authentication flow
-				StartActivity(actualIntent);
+				StartActivity(actualIntent ?? Intent);
 
 				launched = true;
 			}


### PR DESCRIPTION
### Description of Change

<!-- Enter description of the fix in this section -->
This pull request fixes a NullReferenceException in WebAuthenticatorIntermediateActivity.
Complements this merged pull request #12347.
### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #13302, #13798, #12347

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->

### Browser tests
The following browsers have been configured as the default app in the Android operating system.
|Browser| CustomTab| Fallback| Login| Logout|Comment|Fix|
|:---|:---:|:---:|:---:|:---:|:---:|:---:|
|Chrome| true| false| ok| ok| -|   -|
|Samsung| true| true| ok| ok| -| -|
|Firefox| true| false| ok| ok| -| -|  
|Brave| true| false| ok| ok| -|   -|
|Edge| true| false| ok| ok| -|   -|
|Vivaldi| true| false| ok| ok| -|   -|
|Opera| false| true| ok| ok| -|   -|
|Tor| true| false| nok| nok| -|   -|
|Mi Browser| false| true| ok| ok| main activity remains hidden|LaunchMode.SingleTask|
|Duckduckgo| false| true| ok| ok| main activity remains hidden|LaunchMode.SingleTask|

For some browsers a correction of the user implementation is necessary. `LaunchMode = LaunchMode.SingleTask`.
https://github.com/dotnet/docs-maui/blob/main/docs/platform-integration/snippets/shared_1/Platforms/Android/WebAuthActivity.cs#L6
