### PR TITLE
[ios] fix memory leak in Image

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Image/ImageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Image/ImageTests.cs
@@ -47,5 +47,45 @@ namespace Microsoft.Maui.DeviceTests
 				await handler.ToPlatform().AssertContainsColor(Colors.Red, MauiContext);
 			});
 		}
+
+		[Fact("Image Does Not Leak")]
+		public async Task DoesNotLeak()
+		{
+			SetupBuilder();
+			WeakReference platformViewReference = null;
+			WeakReference handlerReference = null;
+
+			await InvokeOnMainThreadAsync(async () =>
+			{
+				var layout = new VerticalStackLayout();
+				var image = new Image
+				{
+					Background = Colors.Black,
+					Source = "red.png",
+				};
+				layout.Add(image);
+
+				var handler = CreateHandler<LayoutHandler>(layout);
+				handlerReference = new WeakReference(image.Handler);
+				platformViewReference = new WeakReference(image.Handler.PlatformView);
+				await image.Wait();
+			});
+
+			Assert.NotNull(handlerReference);
+			Assert.NotNull(platformViewReference);
+
+			// Several GCs required on iOS
+			for (int i = 0; i < 5; i++)
+			{
+				if (!handlerReference.IsAlive && !platformViewReference.IsAlive)
+					break;
+				await Task.Yield();
+				GC.Collect();
+				GC.WaitForPendingFinalizers();
+			}
+
+			Assert.False(handlerReference.IsAlive, "Handler should not be alive!");
+			Assert.False(platformViewReference.IsAlive, "PlatformView should not be alive!");
+		}
 	}
 }

--- a/src/Core/src/Handlers/Button/ButtonHandler.Android.cs
+++ b/src/Core/src/Handlers/Button/ButtonHandler.Android.cs
@@ -121,7 +121,7 @@ namespace Microsoft.Maui.Handlers
 			return handler.ImageSourceLoader.UpdateImageSourceAsync();
 		}
 
-		void ISetImageHandler.SetImageSource(Drawable? obj)
+		void IImageSourcePartSetter.SetImageSource(Drawable? obj)
 		{
 			PlatformView.Icon = obj;
 		}

--- a/src/Core/src/Handlers/Button/ButtonHandler.Android.cs
+++ b/src/Core/src/Handlers/Button/ButtonHandler.Android.cs
@@ -121,7 +121,7 @@ namespace Microsoft.Maui.Handlers
 			return handler.ImageSourceLoader.UpdateImageSourceAsync();
 		}
 
-		void OnSetImageSource(Drawable? obj)
+		void ISetImageHandler.SetImageSource(Drawable? obj)
 		{
 			PlatformView.Icon = obj;
 		}

--- a/src/Core/src/Handlers/Button/ButtonHandler.Standard.cs
+++ b/src/Core/src/Handlers/Button/ButtonHandler.Standard.cs
@@ -16,6 +16,6 @@ namespace Microsoft.Maui.Handlers
 		public static void MapPadding(IButtonHandler handler, IButton button) { }
 		public static void MapImageSource(IButtonHandler handler, IImage image) { }
 
-		void ISetImageHandler.SetImageSource(object? obj) { }
+		void IImageSourcePartSetter.SetImageSource(object? obj) { }
 	}
 }

--- a/src/Core/src/Handlers/Button/ButtonHandler.Standard.cs
+++ b/src/Core/src/Handlers/Button/ButtonHandler.Standard.cs
@@ -16,6 +16,6 @@ namespace Microsoft.Maui.Handlers
 		public static void MapPadding(IButtonHandler handler, IButton button) { }
 		public static void MapImageSource(IButtonHandler handler, IImage image) { }
 
-		void OnSetImageSource(object? obj) { }
+		void ISetImageHandler.SetImageSource(object? obj) { }
 	}
 }

--- a/src/Core/src/Handlers/Button/ButtonHandler.Tizen.cs
+++ b/src/Core/src/Handlers/Button/ButtonHandler.Tizen.cs
@@ -110,7 +110,7 @@ namespace Microsoft.Maui.Handlers
 			VirtualView?.Pressed();
 		}
 
-		void ISetImageHandler.SetImageSource(MauiImageSource? image)
+		void IImageSourcePartSetter.SetImageSource(MauiImageSource? image)
 		{
 			if (image == null)
 				return;

--- a/src/Core/src/Handlers/Button/ButtonHandler.Tizen.cs
+++ b/src/Core/src/Handlers/Button/ButtonHandler.Tizen.cs
@@ -110,7 +110,7 @@ namespace Microsoft.Maui.Handlers
 			VirtualView?.Pressed();
 		}
 
-		void OnSetImageSource(MauiImageSource? image)
+		void ISetImageHandler.SetImageSource(MauiImageSource? image)
 		{
 			if (image == null)
 				return;

--- a/src/Core/src/Handlers/Button/ButtonHandler.Windows.cs
+++ b/src/Core/src/Handlers/Button/ButtonHandler.Windows.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Maui.Handlers
 				.UpdateImageSourceAsync()
 				.FireAndForget(handler);
 
-		void OnSetImageSource(ImageSource? platformImageSource)
+		void ISetImageHandler.SetImageSource(ImageSource? platformImageSource)
 		{
 			PlatformView.UpdateImageSource(platformImageSource);
 		}

--- a/src/Core/src/Handlers/Button/ButtonHandler.Windows.cs
+++ b/src/Core/src/Handlers/Button/ButtonHandler.Windows.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Maui.Handlers
 				.UpdateImageSourceAsync()
 				.FireAndForget(handler);
 
-		void ISetImageHandler.SetImageSource(ImageSource? platformImageSource)
+		void IImageSourcePartSetter.SetImageSource(ImageSource? platformImageSource)
 		{
 			PlatformView.UpdateImageSource(platformImageSource);
 		}

--- a/src/Core/src/Handlers/Button/ButtonHandler.cs
+++ b/src/Core/src/Handlers/Button/ButtonHandler.cs
@@ -12,7 +12,7 @@ using PlatformView = System.Object;
 
 namespace Microsoft.Maui.Handlers
 {
-	public partial class ButtonHandler : IButtonHandler, ISetImageHandler
+	public partial class ButtonHandler : IButtonHandler, IImageSourcePartSetter
 	{
 		ImageSourcePartLoader? _imageSourcePartLoader;
 		public ImageSourcePartLoader ImageSourceLoader =>

--- a/src/Core/src/Handlers/Button/ButtonHandler.cs
+++ b/src/Core/src/Handlers/Button/ButtonHandler.cs
@@ -12,11 +12,11 @@ using PlatformView = System.Object;
 
 namespace Microsoft.Maui.Handlers
 {
-	public partial class ButtonHandler : IButtonHandler
+	public partial class ButtonHandler : IButtonHandler, ISetImageHandler
 	{
 		ImageSourcePartLoader? _imageSourcePartLoader;
 		public ImageSourcePartLoader ImageSourceLoader =>
-			_imageSourcePartLoader ??= new ImageSourcePartLoader(this, () => (VirtualView as IImageButton), OnSetImageSource);
+			_imageSourcePartLoader ??= new ImageSourcePartLoader(this);
 
 		public static IPropertyMapper<IImage, IButtonHandler> ImageButtonMapper = new PropertyMapper<IImage, IButtonHandler>()
 		{

--- a/src/Core/src/Handlers/Button/ButtonHandler.iOS.cs
+++ b/src/Core/src/Handlers/Button/ButtonHandler.iOS.cs
@@ -129,7 +129,7 @@ namespace Microsoft.Maui.Handlers
 			handler.PlatformView?.UpdateCharacterSpacing(button);
 		}
 
-		void OnSetImageSource(UIImage? image)
+		void ISetImageHandler.SetImageSource(UIImage? image)
 		{
 			if (image != null)
 			{

--- a/src/Core/src/Handlers/Button/ButtonHandler.iOS.cs
+++ b/src/Core/src/Handlers/Button/ButtonHandler.iOS.cs
@@ -129,7 +129,7 @@ namespace Microsoft.Maui.Handlers
 			handler.PlatformView?.UpdateCharacterSpacing(button);
 		}
 
-		void ISetImageHandler.SetImageSource(UIImage? image)
+		void IImageSourcePartSetter.SetImageSource(UIImage? image)
 		{
 			if (image != null)
 			{

--- a/src/Core/src/Handlers/Image/IImageHandler.cs
+++ b/src/Core/src/Handlers/Image/IImageHandler.cs
@@ -17,5 +17,9 @@ namespace Microsoft.Maui.Handlers
 		new IImage VirtualView { get; }
 		ImageSourcePartLoader SourceLoader { get; }
 		new PlatformView PlatformView { get; }
+
+#if IOS || MACCATALYST
+		void OnWindowChanged() { }
+#endif
 	}
 }

--- a/src/Core/src/Handlers/Image/IImageSourcePartSetter.cs
+++ b/src/Core/src/Handlers/Image/IImageSourcePartSetter.cs
@@ -10,7 +10,7 @@ using PlatformImage = Microsoft.Maui.Platform.MauiImageSource;
 using PlatformImage = System.Object;
 #endif
 
-namespace Microsoft.Maui
+namespace Microsoft.Maui.Handlers
 {
 	public interface IImageSourcePartSetter : IElementHandler
 	{

--- a/src/Core/src/Handlers/Image/IImageSourcePartSetter.cs
+++ b/src/Core/src/Handlers/Image/IImageSourcePartSetter.cs
@@ -12,7 +12,7 @@ using PlatformImage = System.Object;
 
 namespace Microsoft.Maui
 {
-	public interface ISetImageHandler : IElementHandler
+	public interface IImageSourcePartSetter : IElementHandler
 	{
 		void SetImageSource(PlatformImage? obj);
 	}

--- a/src/Core/src/Handlers/Image/ISetImageHandler.cs
+++ b/src/Core/src/Handlers/Image/ISetImageHandler.cs
@@ -1,0 +1,20 @@
+﻿#if __IOS__ || MACCATALYST
+using PlatformImage = UIKit.UIImage;
+#elif MONOANDROID
+using PlatformImage = Android.Graphics.Drawables.Drawable;
+#elif WINDOWS
+using PlatformImage = Microsoft.UI.Xaml.Media.ImageSource;
+#elif TIZEN
+using PlatformImage = Microsoft.Maui.Platform.MauiImageSource;
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0_OR_GREATER && !IOS && !ANDROID && !TIZEN)
+using PlatformImage = System.Object;
+#endif
+
+namespace Microsoft.Maui
+{
+	public interface ISetImageHandler : IElementHandler
+	{
+		void SetImageSource(PlatformImage? obj);
+	}
+}
+

--- a/src/Core/src/Handlers/Image/ImageHandler.Android.cs
+++ b/src/Core/src/Handlers/Image/ImageHandler.Android.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Maui.Handlers
 		public static Task MapSourceAsync(IImageHandler handler, IImage image) =>
 			handler.SourceLoader.UpdateImageSourceAsync();
 
-		void ISetImageHandler.SetImageSource(Drawable? obj) =>
+		void IImageSourcePartSetter.SetImageSource(Drawable? obj) =>
 			PlatformView.SetImageDrawable(obj);
 
 		public override void PlatformArrange(Graphics.Rect frame)

--- a/src/Core/src/Handlers/Image/ImageHandler.Android.cs
+++ b/src/Core/src/Handlers/Image/ImageHandler.Android.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Maui.Handlers
 		public static Task MapSourceAsync(IImageHandler handler, IImage image) =>
 			handler.SourceLoader.UpdateImageSourceAsync();
 
-		void OnSetImageSource(Drawable? obj) =>
+		void ISetImageHandler.SetImageSource(Drawable? obj) =>
 			PlatformView.SetImageDrawable(obj);
 
 		public override void PlatformArrange(Graphics.Rect frame)

--- a/src/Core/src/Handlers/Image/ImageHandler.Standard.cs
+++ b/src/Core/src/Handlers/Image/ImageHandler.Standard.cs
@@ -8,6 +8,6 @@ namespace Microsoft.Maui.Handlers
 		public static void MapAspect(IImageHandler handler, IImage image) { }
 		public static void MapIsAnimationPlaying(IImageHandler handler, IImage image) { }
 		public static void MapSource(IImageHandler handler, IImage image) { }
-		void ISetImageHandler.SetImageSource(object? obj) => throw new NotImplementedException();
+		void IImageSourcePartSetter.SetImageSource(object? obj) => throw new NotImplementedException();
 	}
 }

--- a/src/Core/src/Handlers/Image/ImageHandler.Standard.cs
+++ b/src/Core/src/Handlers/Image/ImageHandler.Standard.cs
@@ -8,6 +8,6 @@ namespace Microsoft.Maui.Handlers
 		public static void MapAspect(IImageHandler handler, IImage image) { }
 		public static void MapIsAnimationPlaying(IImageHandler handler, IImage image) { }
 		public static void MapSource(IImageHandler handler, IImage image) { }
-		void OnSetImageSource(object? obj) => throw new NotImplementedException();
+		void ISetImageHandler.SetImageSource(object? obj) => throw new NotImplementedException();
 	}
 }

--- a/src/Core/src/Handlers/Image/ImageHandler.Tizen.cs
+++ b/src/Core/src/Handlers/Image/ImageHandler.Tizen.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Maui.Handlers
 		public static Task MapSourceAsync(IImageHandler handler, IImage image) =>
 			handler.SourceLoader.UpdateImageSourceAsync();
 
-		void ISetImageHandler.SetImageSource(MauiImageSource? obj)
+		void IImageSourcePartSetter.SetImageSource(MauiImageSource? obj)
 		{
 			if (obj == null)
 				return;

--- a/src/Core/src/Handlers/Image/ImageHandler.Tizen.cs
+++ b/src/Core/src/Handlers/Image/ImageHandler.Tizen.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Maui.Handlers
 		public static Task MapSourceAsync(IImageHandler handler, IImage image) =>
 			handler.SourceLoader.UpdateImageSourceAsync();
 
-		void OnSetImageSource(MauiImageSource? obj)
+		void ISetImageHandler.SetImageSource(MauiImageSource? obj)
 		{
 			if (obj == null)
 				return;

--- a/src/Core/src/Handlers/Image/ImageHandler.Windows.cs
+++ b/src/Core/src/Handlers/Image/ImageHandler.Windows.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Maui.Handlers
 		public static Task MapSourceAsync(IImageHandler handler, IImage image) =>
 			handler.SourceLoader.UpdateImageSourceAsync();
 
-		void OnSetImageSource(ImageSource? obj) =>
+		void ISetImageHandler.SetImageSource(ImageSource? obj) =>
 			PlatformView.Source = obj;
 	}
 }

--- a/src/Core/src/Handlers/Image/ImageHandler.Windows.cs
+++ b/src/Core/src/Handlers/Image/ImageHandler.Windows.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Maui.Handlers
 		public static Task MapSourceAsync(IImageHandler handler, IImage image) =>
 			handler.SourceLoader.UpdateImageSourceAsync();
 
-		void ISetImageHandler.SetImageSource(ImageSource? obj) =>
+		void IImageSourcePartSetter.SetImageSource(ImageSource? obj) =>
 			PlatformView.Source = obj;
 	}
 }

--- a/src/Core/src/Handlers/Image/ImageHandler.cs
+++ b/src/Core/src/Handlers/Image/ImageHandler.cs
@@ -14,7 +14,7 @@ using PlatformView = System.Object;
 
 namespace Microsoft.Maui.Handlers
 {
-	public partial class ImageHandler : IImageHandler
+	public partial class ImageHandler : IImageHandler, ISetImageHandler
 	{
 		public static IPropertyMapper<IImage, IImageHandler> Mapper = new PropertyMapper<IImage, IImageHandler>(ViewHandler.ViewMapper)
 		{
@@ -32,7 +32,7 @@ namespace Microsoft.Maui.Handlers
 
 		ImageSourcePartLoader? _imageSourcePartLoader;
 		public ImageSourcePartLoader SourceLoader =>
-			_imageSourcePartLoader ??= new ImageSourcePartLoader(this, () => VirtualView, OnSetImageSource);
+			_imageSourcePartLoader ??= new ImageSourcePartLoader(this);
 
 		public ImageHandler() : base(Mapper)
 		{

--- a/src/Core/src/Handlers/Image/ImageHandler.cs
+++ b/src/Core/src/Handlers/Image/ImageHandler.cs
@@ -14,7 +14,7 @@ using PlatformView = System.Object;
 
 namespace Microsoft.Maui.Handlers
 {
-	public partial class ImageHandler : IImageHandler, ISetImageHandler
+	public partial class ImageHandler : IImageHandler, IImageSourcePartSetter
 	{
 		public static IPropertyMapper<IImage, IImageHandler> Mapper = new PropertyMapper<IImage, IImageHandler>(ViewHandler.ViewMapper)
 		{

--- a/src/Core/src/Handlers/Image/ImageHandler.iOS.cs
+++ b/src/Core/src/Handlers/Image/ImageHandler.iOS.cs
@@ -9,22 +9,11 @@ namespace Microsoft.Maui.Handlers
 {
 	public partial class ImageHandler : ViewHandler<IImage, UIImageView>
 	{
-		protected override UIImageView CreatePlatformView() => new MauiImageView();
-
-		protected override void ConnectHandler(UIImageView platformView)
-		{
-			base.ConnectHandler(platformView);
-
-			if (PlatformView is MauiImageView imageView)
-				imageView.WindowChanged += OnWindowChanged;
-		}
+		protected override UIImageView CreatePlatformView() => new MauiImageView(this);
 
 		protected override void DisconnectHandler(UIImageView platformView)
 		{
 			base.DisconnectHandler(platformView);
-
-			if (platformView is MauiImageView imageView)
-				imageView.WindowChanged -= OnWindowChanged;
 
 			SourceLoader.Reset();
 		}
@@ -52,10 +41,10 @@ namespace Microsoft.Maui.Handlers
 		public static Task MapSourceAsync(IImageHandler handler, IImage image) =>
 			handler.SourceLoader.UpdateImageSourceAsync();
 
-		void OnSetImageSource(UIImage? obj) =>
+		void ISetImageHandler.SetImageSource(UIImage? obj) =>
 			PlatformView.Image = obj;
 
-		void OnWindowChanged(object? sender, EventArgs e)
+		internal void NotifyWindowChanged()
 		{
 			if (SourceLoader.SourceManager.IsResolutionDependent)
 				UpdateValue(nameof(IImage.Source));

--- a/src/Core/src/Handlers/Image/ImageHandler.iOS.cs
+++ b/src/Core/src/Handlers/Image/ImageHandler.iOS.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Maui.Handlers
 		public static Task MapSourceAsync(IImageHandler handler, IImage image) =>
 			handler.SourceLoader.UpdateImageSourceAsync();
 
-		void ISetImageHandler.SetImageSource(UIImage? obj) =>
+		void IImageSourcePartSetter.SetImageSource(UIImage? obj) =>
 			PlatformView.Image = obj;
 
 		internal void NotifyWindowChanged()

--- a/src/Core/src/Handlers/Image/ImageHandler.iOS.cs
+++ b/src/Core/src/Handlers/Image/ImageHandler.iOS.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Maui.Handlers
 		void IImageSourcePartSetter.SetImageSource(UIImage? obj) =>
 			PlatformView.Image = obj;
 
-		internal void NotifyWindowChanged()
+		public void OnWindowChanged()
 		{
 			if (SourceLoader.SourceManager.IsResolutionDependent)
 				UpdateValue(nameof(IImage.Source));

--- a/src/Core/src/Handlers/ImageButton/ImageButtonHandler.Android.cs
+++ b/src/Core/src/Handlers/ImageButton/ImageButtonHandler.Android.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Maui.Handlers
 			return platformView;
 		}
 
-		void ISetImageHandler.SetImageSource(Drawable? obj)
+		void IImageSourcePartSetter.SetImageSource(Drawable? obj)
 		{
 			PlatformView.SetImageDrawable(obj);
 		}

--- a/src/Core/src/Handlers/ImageButton/ImageButtonHandler.Android.cs
+++ b/src/Core/src/Handlers/ImageButton/ImageButtonHandler.Android.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Maui.Handlers
 			return platformView;
 		}
 
-		void OnSetImageSource(Drawable? obj)
+		void ISetImageHandler.SetImageSource(Drawable? obj)
 		{
 			PlatformView.SetImageDrawable(obj);
 		}

--- a/src/Core/src/Handlers/ImageButton/ImageButtonHandler.Standard.cs
+++ b/src/Core/src/Handlers/ImageButton/ImageButtonHandler.Standard.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Maui.Handlers
 		public static void MapCornerRadius(IImageButtonHandler handler, IButtonStroke buttonStroke) { }
 		public static void MapPadding(IImageButtonHandler handler, IImageButton imageButton) { }
 
-		void ISetImageHandler.SetImageSource(object? obj)
+		void IImageSourcePartSetter.SetImageSource(object? obj)
 		{
 			throw new NotImplementedException();
 		}

--- a/src/Core/src/Handlers/ImageButton/ImageButtonHandler.Standard.cs
+++ b/src/Core/src/Handlers/ImageButton/ImageButtonHandler.Standard.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Maui.Handlers
 		public static void MapCornerRadius(IImageButtonHandler handler, IButtonStroke buttonStroke) { }
 		public static void MapPadding(IImageButtonHandler handler, IImageButton imageButton) { }
 
-		void OnSetImageSource(object? obj)
+		void ISetImageHandler.SetImageSource(object? obj)
 		{
 			throw new NotImplementedException();
 		}

--- a/src/Core/src/Handlers/ImageButton/ImageButtonHandler.Tizen.cs
+++ b/src/Core/src/Handlers/ImageButton/ImageButtonHandler.Tizen.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Maui.Handlers
 			VirtualView?.Clicked();
 		}
 
-		void OnSetImageSource(MauiImageSource? img)
+		void ISetImageHandler.SetImageSource(MauiImageSource? img)
 		{
 			if (img == null)
 				return;

--- a/src/Core/src/Handlers/ImageButton/ImageButtonHandler.Tizen.cs
+++ b/src/Core/src/Handlers/ImageButton/ImageButtonHandler.Tizen.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Maui.Handlers
 			VirtualView?.Clicked();
 		}
 
-		void ISetImageHandler.SetImageSource(MauiImageSource? img)
+		void IImageSourcePartSetter.SetImageSource(MauiImageSource? img)
 		{
 			if (img == null)
 				return;

--- a/src/Core/src/Handlers/ImageButton/ImageButtonHandler.Windows.cs
+++ b/src/Core/src/Handlers/ImageButton/ImageButtonHandler.Windows.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Maui.Handlers
 			(handler.PlatformView as Button)?.UpdatePadding(imageButton);
 		}
 
-		void ISetImageHandler.SetImageSource(ImageSource? nativeImageSource)
+		void IImageSourcePartSetter.SetImageSource(ImageSource? nativeImageSource)
 		{
 			PlatformView.UpdateImageSource(nativeImageSource);
 		}

--- a/src/Core/src/Handlers/ImageButton/ImageButtonHandler.Windows.cs
+++ b/src/Core/src/Handlers/ImageButton/ImageButtonHandler.Windows.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Maui.Handlers
 			(handler.PlatformView as Button)?.UpdatePadding(imageButton);
 		}
 
-		void OnSetImageSource(ImageSource? nativeImageSource)
+		void ISetImageHandler.SetImageSource(ImageSource? nativeImageSource)
 		{
 			PlatformView.UpdateImageSource(nativeImageSource);
 		}

--- a/src/Core/src/Handlers/ImageButton/ImageButtonHandler.cs
+++ b/src/Core/src/Handlers/ImageButton/ImageButtonHandler.cs
@@ -23,7 +23,7 @@ using PlatformView = System.Object;
 
 namespace Microsoft.Maui.Handlers
 {
-	public partial class ImageButtonHandler : IImageButtonHandler, ISetImageHandler
+	public partial class ImageButtonHandler : IImageButtonHandler, IImageSourcePartSetter
 	{
 		public static IPropertyMapper<IImage, IImageHandler> ImageMapper = new PropertyMapper<IImage, IImageHandler>(ImageHandler.Mapper);
 

--- a/src/Core/src/Handlers/ImageButton/ImageButtonHandler.cs
+++ b/src/Core/src/Handlers/ImageButton/ImageButtonHandler.cs
@@ -23,7 +23,7 @@ using PlatformView = System.Object;
 
 namespace Microsoft.Maui.Handlers
 {
-	public partial class ImageButtonHandler : IImageButtonHandler
+	public partial class ImageButtonHandler : IImageButtonHandler, ISetImageHandler
 	{
 		public static IPropertyMapper<IImage, IImageHandler> ImageMapper = new PropertyMapper<IImage, IImageHandler>(ImageHandler.Mapper);
 
@@ -44,7 +44,7 @@ namespace Microsoft.Maui.Handlers
 
 		ImageSourcePartLoader? _imageSourcePartLoader;
 		public ImageSourcePartLoader SourceLoader =>
-			_imageSourcePartLoader ??= new ImageSourcePartLoader(this, () => VirtualView, OnSetImageSource);
+			_imageSourcePartLoader ??= new ImageSourcePartLoader(this);
 
 		public ImageButtonHandler() : base(Mapper)
 		{

--- a/src/Core/src/Handlers/ImageButton/ImageButtonHandler.iOS.cs
+++ b/src/Core/src/Handlers/ImageButton/ImageButtonHandler.iOS.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Maui.Handlers
 			return platformView;
 		}
 
-		void OnSetImageSource(UIImage? obj)
+		void ISetImageHandler.SetImageSource(UIImage? obj)
 		{
 			PlatformView.SetImage(obj?.ImageWithRenderingMode(UIImageRenderingMode.AlwaysOriginal), UIControlState.Normal);
 			PlatformView.HorizontalAlignment = UIControlContentHorizontalAlignment.Fill;

--- a/src/Core/src/Handlers/ImageButton/ImageButtonHandler.iOS.cs
+++ b/src/Core/src/Handlers/ImageButton/ImageButtonHandler.iOS.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Maui.Handlers
 			return platformView;
 		}
 
-		void ISetImageHandler.SetImageSource(UIImage? obj)
+		void IImageSourcePartSetter.SetImageSource(UIImage? obj)
 		{
 			PlatformView.SetImage(obj?.ImageWithRenderingMode(UIImageRenderingMode.AlwaysOriginal), UIControlState.Normal);
 			PlatformView.HorizontalAlignment = UIControlContentHorizontalAlignment.Fill;

--- a/src/Core/src/Handlers/SwipeItemMenuItem/SwipeItemMenuItemHandler.Android.cs
+++ b/src/Core/src/Handlers/SwipeItemMenuItem/SwipeItemMenuItemHandler.Android.cs
@@ -133,7 +133,7 @@ namespace Microsoft.Maui.Handlers
 				var icons = textView.GetCompoundDrawables();
 				if (icons.Length > 1 && icons[1] != null)
 				{
-					((ISetImageHandler)this).SetImageSource(icons[1]);
+					((IImageSourcePartSetter)this).SetImageSource(icons[1]);
 				}
 			}
 
@@ -143,7 +143,7 @@ namespace Microsoft.Maui.Handlers
 			PlatformView.SetPadding(0, buttonPadding, 0, buttonPadding);
 		}
 
-		void ISetImageHandler.SetImageSource(Drawable? drawable)
+		void IImageSourcePartSetter.SetImageSource(Drawable? drawable)
 		{
 			if (drawable != null)
 			{

--- a/src/Core/src/Handlers/SwipeItemMenuItem/SwipeItemMenuItemHandler.Android.cs
+++ b/src/Core/src/Handlers/SwipeItemMenuItem/SwipeItemMenuItemHandler.Android.cs
@@ -133,7 +133,7 @@ namespace Microsoft.Maui.Handlers
 				var icons = textView.GetCompoundDrawables();
 				if (icons.Length > 1 && icons[1] != null)
 				{
-					OnSetImageSource(icons[1]);
+					((ISetImageHandler)this).SetImageSource(icons[1]);
 				}
 			}
 
@@ -143,7 +143,7 @@ namespace Microsoft.Maui.Handlers
 			PlatformView.SetPadding(0, buttonPadding, 0, buttonPadding);
 		}
 
-		void OnSetImageSource(Drawable? drawable)
+		void ISetImageHandler.SetImageSource(Drawable? drawable)
 		{
 			if (drawable != null)
 			{

--- a/src/Core/src/Handlers/SwipeItemMenuItem/SwipeItemMenuItemHandler.Standard.cs
+++ b/src/Core/src/Handlers/SwipeItemMenuItem/SwipeItemMenuItemHandler.Standard.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Maui.Handlers
 
 		public static void MapVisibility(ISwipeItemMenuItemHandler handler, ISwipeItemMenuItem view) { }
 
-		void OnSetImageSource(object? obj)
+		void ISetImageHandler.SetImageSource(object? obj)
 		{
 			throw new NotImplementedException();
 		}

--- a/src/Core/src/Handlers/SwipeItemMenuItem/SwipeItemMenuItemHandler.Standard.cs
+++ b/src/Core/src/Handlers/SwipeItemMenuItem/SwipeItemMenuItemHandler.Standard.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Maui.Handlers
 
 		public static void MapVisibility(ISwipeItemMenuItemHandler handler, ISwipeItemMenuItem view) { }
 
-		void ISetImageHandler.SetImageSource(object? obj)
+		void IImageSourcePartSetter.SetImageSource(object? obj)
 		{
 			throw new NotImplementedException();
 		}

--- a/src/Core/src/Handlers/SwipeItemMenuItem/SwipeItemMenuItemHandler.Tizen.cs
+++ b/src/Core/src/Handlers/SwipeItemMenuItem/SwipeItemMenuItemHandler.Tizen.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Maui.Handlers
 
 		}
 
-		void OnSetImageSource(MauiImageSource? obj)
+		void ISetImageHandler.SetImageSource(MauiImageSource? obj)
 		{
 			if (obj != null)
 				PlatformView.Icon.ResourceUrl = obj.ResourceUrl;

--- a/src/Core/src/Handlers/SwipeItemMenuItem/SwipeItemMenuItemHandler.Tizen.cs
+++ b/src/Core/src/Handlers/SwipeItemMenuItem/SwipeItemMenuItemHandler.Tizen.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Maui.Handlers
 
 		}
 
-		void ISetImageHandler.SetImageSource(MauiImageSource? obj)
+		void IImageSourcePartSetter.SetImageSource(MauiImageSource? obj)
 		{
 			if (obj != null)
 				PlatformView.Icon.ResourceUrl = obj.ResourceUrl;

--- a/src/Core/src/Handlers/SwipeItemMenuItem/SwipeItemMenuItemHandler.cs
+++ b/src/Core/src/Handlers/SwipeItemMenuItem/SwipeItemMenuItemHandler.cs
@@ -15,6 +15,9 @@ using System.Threading.Tasks;
 namespace Microsoft.Maui.Handlers
 {
 	public partial class SwipeItemMenuItemHandler : ISwipeItemMenuItemHandler
+#if !WINDOWS
+		, ISetImageHandler
+#endif
 	{
 		public static IPropertyMapper<ISwipeItemMenuItem, ISwipeItemMenuItemHandler> Mapper =
 			new PropertyMapper<ISwipeItemMenuItem, ISwipeItemMenuItemHandler>(ViewHandler.ElementMapper)
@@ -56,7 +59,7 @@ namespace Microsoft.Maui.Handlers
 #if !WINDOWS
 		ImageSourcePartLoader? _imageSourcePartLoader;
 		public ImageSourcePartLoader SourceLoader =>
-			_imageSourcePartLoader ??= new ImageSourcePartLoader(this, () => VirtualView, OnSetImageSource);
+			_imageSourcePartLoader ??= new ImageSourcePartLoader(this);
 
 
 		public static void MapSource(ISwipeItemMenuItemHandler handler, ISwipeItemMenuItem image) =>

--- a/src/Core/src/Handlers/SwipeItemMenuItem/SwipeItemMenuItemHandler.cs
+++ b/src/Core/src/Handlers/SwipeItemMenuItem/SwipeItemMenuItemHandler.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Maui.Handlers
 {
 	public partial class SwipeItemMenuItemHandler : ISwipeItemMenuItemHandler
 #if !WINDOWS
-		, ISetImageHandler
+		, IImageSourcePartSetter
 #endif
 	{
 		public static IPropertyMapper<ISwipeItemMenuItem, ISwipeItemMenuItemHandler> Mapper =

--- a/src/Core/src/Handlers/SwipeItemMenuItem/SwipeItemMenuItemHandler.iOS.cs
+++ b/src/Core/src/Handlers/SwipeItemMenuItem/SwipeItemMenuItemHandler.iOS.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Maui.Handlers
 				swipeItemMenuItemHandler.UpdateValue(nameof(ISwipeItemMenuItem.Source));
 		}
 
-		void OnSetImageSource(UIImage? image)
+		void ISetImageHandler.SetImageSource(UIImage? image)
 		{
 			if (PlatformView == null || PlatformView.Frame == CGRect.Empty)
 				return;

--- a/src/Core/src/Handlers/SwipeItemMenuItem/SwipeItemMenuItemHandler.iOS.cs
+++ b/src/Core/src/Handlers/SwipeItemMenuItem/SwipeItemMenuItemHandler.iOS.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Maui.Handlers
 				swipeItemMenuItemHandler.UpdateValue(nameof(ISwipeItemMenuItem.Source));
 		}
 
-		void ISetImageHandler.SetImageSource(UIImage? image)
+		void IImageSourcePartSetter.SetImageSource(UIImage? image)
 		{
 			if (PlatformView == null || PlatformView.Frame == CGRect.Empty)
 				return;

--- a/src/Core/src/Platform/ImageSourcePartLoader.cs
+++ b/src/Core/src/Platform/ImageSourcePartLoader.cs
@@ -27,17 +27,17 @@ namespace Microsoft.Maui.Platform
 		IImageSourceServiceProvider? _imageSourceServiceProvider;
 #endif
 
-		readonly WeakReference<ISetImageHandler> _handler;
+		readonly WeakReference<IImageSourcePartSetter> _handler;
 
 		internal ImageSourceServiceResultManager SourceManager { get; } = new ImageSourceServiceResultManager();
 
-		[Obsolete("Use ImageSourcePartLoader(ISetImageHandler handler) instead.")]
+		[Obsolete("Use ImageSourcePartLoader(IImageSourcePartSetter handler) instead.")]
 		public ImageSourcePartLoader(IElementHandler handler, Func<IImageSourcePart?> imageSourcePart, Action<PlatformImage?> setImage)
-			: this((ISetImageHandler)handler)
+			: this((IImageSourcePartSetter)handler)
 		{
 		}
 
-		public ImageSourcePartLoader(ISetImageHandler handler) => _handler = new(handler);
+		public ImageSourcePartLoader(IImageSourcePartSetter handler) => _handler = new(handler);
 
 		public void Reset()
 		{

--- a/src/Core/src/Platform/ImageSourcePartLoader.cs
+++ b/src/Core/src/Platform/ImageSourcePartLoader.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Maui.Platform
 
 		internal ImageSourceServiceResultManager SourceManager { get; } = new ImageSourceServiceResultManager();
 
-		[Obsolete("To be removed in a future release")]
+		[Obsolete("Use ImageSourcePartLoader(ISetImageHandler handler) instead.")]
 		public ImageSourcePartLoader(IElementHandler handler, Func<IImageSourcePart?> imageSourcePart, Action<PlatformImage?> setImage)
 			: this((ISetImageHandler)handler)
 		{

--- a/src/Core/src/Platform/iOS/MauiImageView.cs
+++ b/src/Core/src/Platform/iOS/MauiImageView.cs
@@ -7,18 +7,34 @@ namespace Microsoft.Maui.Platform
 {
 	public class MauiImageView : UIImageView
 	{
+		WeakReference<ImageHandler>? _handler;
+
+		public MauiImageView(ImageHandler handler) => _handler = new WeakReference<ImageHandler>(handler);
+
+		[Obsolete("To be removed in a future release")]
 		public MauiImageView()
 		{
 		}
 
+		[Obsolete("To be removed in a future release")]
 		public MauiImageView(CGRect frame)
 			: base(frame)
 		{
 		}
 
-		public override void MovedToWindow() =>
-			WindowChanged?.Invoke(this, EventArgs.Empty);
+		public override void MovedToWindow()
+		{
+			if (_handler is not null && _handler.TryGetTarget(out var handler))
+			{
+				handler.NotifyWindowChanged();
+			}
+		}
 
-		public event EventHandler? WindowChanged;
+		[Obsolete("To be removed in a future release")]
+		public event EventHandler? WindowChanged
+		{
+			add { }
+			remove { }
+		}
 	}
 }

--- a/src/Core/src/Platform/iOS/MauiImageView.cs
+++ b/src/Core/src/Platform/iOS/MauiImageView.cs
@@ -11,12 +11,12 @@ namespace Microsoft.Maui.Platform
 
 		public MauiImageView(ImageHandler handler) => _handler = new WeakReference<ImageHandler>(handler);
 
-		[Obsolete("To be removed in a future release")]
+		[Obsolete("Use MauiImageView(ImageHandler handler) instead.")]
 		public MauiImageView()
 		{
 		}
 
-		[Obsolete("To be removed in a future release")]
+		[Obsolete("Use MauiImageView(ImageHandler handler) instead.")]
 		public MauiImageView(CGRect frame)
 			: base(frame)
 		{

--- a/src/Core/src/Platform/iOS/MauiImageView.cs
+++ b/src/Core/src/Platform/iOS/MauiImageView.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Maui.Platform
 			}
 		}
 
-		[Obsolete("To be removed in a future release")]
+		[Obsolete("No longer fired on iOS, as it introduces a memory leak.")]
 		public event EventHandler? WindowChanged
 		{
 			add { }

--- a/src/Core/src/Platform/iOS/MauiImageView.cs
+++ b/src/Core/src/Platform/iOS/MauiImageView.cs
@@ -7,16 +7,16 @@ namespace Microsoft.Maui.Platform
 {
 	public class MauiImageView : UIImageView
 	{
-		WeakReference<ImageHandler>? _handler;
+		WeakReference<IImageHandler>? _handler;
 
-		public MauiImageView(ImageHandler handler) => _handler = new WeakReference<ImageHandler>(handler);
+		public MauiImageView(IImageHandler handler) => _handler = new(handler);
 
-		[Obsolete("Use MauiImageView(ImageHandler handler) instead.")]
+		[Obsolete("Use MauiImageView(IImageHandler handler) instead.")]
 		public MauiImageView()
 		{
 		}
 
-		[Obsolete("Use MauiImageView(ImageHandler handler) instead.")]
+		[Obsolete("Use MauiImageView(IImageHandler handler) instead.")]
 		public MauiImageView(CGRect frame)
 			: base(frame)
 		{
@@ -26,11 +26,11 @@ namespace Microsoft.Maui.Platform
 		{
 			if (_handler is not null && _handler.TryGetTarget(out var handler))
 			{
-				handler.NotifyWindowChanged();
+				handler.OnWindowChanged();
 			}
 		}
 
-		[Obsolete("No longer fired on iOS, as it introduces a memory leak.")]
+		[Obsolete("Use IImageHandler.OnWindowChanged() instead.")]
 		public event EventHandler? WindowChanged
 		{
 			add { }

--- a/src/Core/src/Platform/iOS/MauiImageView.cs
+++ b/src/Core/src/Platform/iOS/MauiImageView.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Maui.Platform
 {
 	public class MauiImageView : UIImageView
 	{
-		WeakReference<IImageHandler>? _handler;
+		readonly WeakReference<IImageHandler>? _handler;
 
 		public MauiImageView(IImageHandler handler) => _handler = new(handler);
 

--- a/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -12,10 +12,10 @@ Microsoft.Maui.ICommandMapper.Invoke(Microsoft.Maui.IElementHandler! viewHandler
 Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>
 Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>.Add(string! key, System.Action<TViewHandler, TVirtualView, object?>! action) -> void
 Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>.Add(string! key, System.Action<TViewHandler, TVirtualView>! action) -> void
-Microsoft.Maui.ISetImageHandler
-Microsoft.Maui.ISetImageHandler.SetImageSource(Android.Graphics.Drawables.Drawable? obj) -> void
+Microsoft.Maui.IImageSourcePartSetter
+Microsoft.Maui.IImageSourcePartSetter.SetImageSource(Android.Graphics.Drawables.Drawable? obj) -> void
 Microsoft.Maui.Layouts.FlexBasis.Equals(Microsoft.Maui.Layouts.FlexBasis other) -> bool
-Microsoft.Maui.Platform.ImageSourcePartLoader.ImageSourcePartLoader(Microsoft.Maui.ISetImageHandler! handler) -> void
+Microsoft.Maui.Platform.ImageSourcePartLoader.ImageSourcePartLoader(Microsoft.Maui.IImageSourcePartSetter! handler) -> void
 Microsoft.Maui.Platform.ShapeExtensions
 Microsoft.Maui.PlatformContentViewGroup
 Microsoft.Maui.PlatformContentViewGroup.PlatformContentViewGroup(Android.Content.Context? context) -> void

--- a/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -12,7 +12,10 @@ Microsoft.Maui.ICommandMapper.Invoke(Microsoft.Maui.IElementHandler! viewHandler
 Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>
 Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>.Add(string! key, System.Action<TViewHandler, TVirtualView, object?>! action) -> void
 Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>.Add(string! key, System.Action<TViewHandler, TVirtualView>! action) -> void
+Microsoft.Maui.ISetImageHandler
+Microsoft.Maui.ISetImageHandler.SetImageSource(Android.Graphics.Drawables.Drawable? obj) -> void
 Microsoft.Maui.Layouts.FlexBasis.Equals(Microsoft.Maui.Layouts.FlexBasis other) -> bool
+Microsoft.Maui.Platform.ImageSourcePartLoader.ImageSourcePartLoader(Microsoft.Maui.ISetImageHandler! handler) -> void
 Microsoft.Maui.Platform.ShapeExtensions
 Microsoft.Maui.PlatformContentViewGroup
 Microsoft.Maui.PlatformContentViewGroup.PlatformContentViewGroup(Android.Content.Context? context) -> void

--- a/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -12,10 +12,10 @@ Microsoft.Maui.ICommandMapper.Invoke(Microsoft.Maui.IElementHandler! viewHandler
 Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>
 Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>.Add(string! key, System.Action<TViewHandler, TVirtualView, object?>! action) -> void
 Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>.Add(string! key, System.Action<TViewHandler, TVirtualView>! action) -> void
-Microsoft.Maui.IImageSourcePartSetter
-Microsoft.Maui.IImageSourcePartSetter.SetImageSource(Android.Graphics.Drawables.Drawable? obj) -> void
+Microsoft.Maui.Handlers.IImageSourcePartSetter
+Microsoft.Maui.Handlers.IImageSourcePartSetter.SetImageSource(Android.Graphics.Drawables.Drawable? obj) -> void
 Microsoft.Maui.Layouts.FlexBasis.Equals(Microsoft.Maui.Layouts.FlexBasis other) -> bool
-Microsoft.Maui.Platform.ImageSourcePartLoader.ImageSourcePartLoader(Microsoft.Maui.IImageSourcePartSetter! handler) -> void
+Microsoft.Maui.Platform.ImageSourcePartLoader.ImageSourcePartLoader(Microsoft.Maui.Handlers.IImageSourcePartSetter! handler) -> void
 Microsoft.Maui.Platform.ShapeExtensions
 Microsoft.Maui.PlatformContentViewGroup
 Microsoft.Maui.PlatformContentViewGroup.PlatformContentViewGroup(Android.Content.Context? context) -> void

--- a/src/Core/src/PublicAPI/net-ios/PublicAPI.Shipped.txt
+++ b/src/Core/src/PublicAPI/net-ios/PublicAPI.Shipped.txt
@@ -2048,7 +2048,6 @@ override Microsoft.Maui.Handlers.GraphicsViewHandler.DisconnectHandler(Microsoft
 override Microsoft.Maui.Handlers.ImageButtonHandler.ConnectHandler(UIKit.UIButton! platformView) -> void
 override Microsoft.Maui.Handlers.ImageButtonHandler.CreatePlatformView() -> UIKit.UIButton!
 override Microsoft.Maui.Handlers.ImageButtonHandler.DisconnectHandler(UIKit.UIButton! platformView) -> void
-override Microsoft.Maui.Handlers.ImageHandler.ConnectHandler(UIKit.UIImageView! platformView) -> void
 override Microsoft.Maui.Handlers.ImageHandler.CreatePlatformView() -> UIKit.UIImageView!
 override Microsoft.Maui.Handlers.ImageHandler.DisconnectHandler(UIKit.UIImageView! platformView) -> void
 override Microsoft.Maui.Handlers.ImageHandler.NeedsContainer.get -> bool

--- a/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -12,11 +12,11 @@ Microsoft.Maui.ICommandMapper.Invoke(Microsoft.Maui.IElementHandler! viewHandler
 Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>
 Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>.Add(string! key, System.Action<TViewHandler, TVirtualView, object?>! action) -> void
 Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>.Add(string! key, System.Action<TViewHandler, TVirtualView>! action) -> void
-Microsoft.Maui.ISetImageHandler
-Microsoft.Maui.ISetImageHandler.SetImageSource(UIKit.UIImage? obj) -> void
+Microsoft.Maui.IImageSourcePartSetter
+Microsoft.Maui.IImageSourcePartSetter.SetImageSource(UIKit.UIImage? obj) -> void
 Microsoft.Maui.Layouts.FlexBasis.Equals(Microsoft.Maui.Layouts.FlexBasis other) -> bool
 Microsoft.Maui.LifecycleEvents.iOSLifecycle.PerformFetch
-Microsoft.Maui.Platform.ImageSourcePartLoader.ImageSourcePartLoader(Microsoft.Maui.ISetImageHandler! handler) -> void
+Microsoft.Maui.Platform.ImageSourcePartLoader.ImageSourcePartLoader(Microsoft.Maui.IImageSourcePartSetter! handler) -> void
 Microsoft.Maui.Platform.KeyboardAutoManagerScroll
 Microsoft.Maui.Platform.MauiImageView.MauiImageView(Microsoft.Maui.Handlers.ImageHandler! handler) -> void
 Microsoft.Maui.SizeRequest.Equals(Microsoft.Maui.SizeRequest other) -> bool

--- a/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -12,9 +12,13 @@ Microsoft.Maui.ICommandMapper.Invoke(Microsoft.Maui.IElementHandler! viewHandler
 Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>
 Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>.Add(string! key, System.Action<TViewHandler, TVirtualView, object?>! action) -> void
 Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>.Add(string! key, System.Action<TViewHandler, TVirtualView>! action) -> void
+Microsoft.Maui.ISetImageHandler
+Microsoft.Maui.ISetImageHandler.SetImageSource(UIKit.UIImage? obj) -> void
 Microsoft.Maui.Layouts.FlexBasis.Equals(Microsoft.Maui.Layouts.FlexBasis other) -> bool
 Microsoft.Maui.LifecycleEvents.iOSLifecycle.PerformFetch
+Microsoft.Maui.Platform.ImageSourcePartLoader.ImageSourcePartLoader(Microsoft.Maui.ISetImageHandler! handler) -> void
 Microsoft.Maui.Platform.KeyboardAutoManagerScroll
+Microsoft.Maui.Platform.MauiImageView.MauiImageView(Microsoft.Maui.Handlers.ImageHandler! handler) -> void
 Microsoft.Maui.SizeRequest.Equals(Microsoft.Maui.SizeRequest other) -> bool
 Microsoft.Maui.Platform.MauiScrollView
 Microsoft.Maui.Platform.MauiScrollView.MauiScrollView() -> void

--- a/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -1,6 +1,8 @@
 #nullable enable
 Microsoft.Maui.CommandMapper.Invoke(Microsoft.Maui.IElementHandler! viewHandler, Microsoft.Maui.IElement? virtualView, string! property, object? args) -> void
 Microsoft.Maui.FocusRequest.FocusRequest() -> void
+Microsoft.Maui.Handlers.IImageHandler.OnWindowChanged() -> void
+Microsoft.Maui.Handlers.ImageHandler.OnWindowChanged() -> void
 Microsoft.Maui.Handlers.SwipeItemButton
 Microsoft.Maui.Handlers.SwipeItemButton.FrameChanged -> System.EventHandler?
 Microsoft.Maui.Handlers.SwipeItemButton.SwipeItemButton() -> void
@@ -18,7 +20,7 @@ Microsoft.Maui.Layouts.FlexBasis.Equals(Microsoft.Maui.Layouts.FlexBasis other) 
 Microsoft.Maui.LifecycleEvents.iOSLifecycle.PerformFetch
 Microsoft.Maui.Platform.ImageSourcePartLoader.ImageSourcePartLoader(Microsoft.Maui.IImageSourcePartSetter! handler) -> void
 Microsoft.Maui.Platform.KeyboardAutoManagerScroll
-Microsoft.Maui.Platform.MauiImageView.MauiImageView(Microsoft.Maui.Handlers.ImageHandler! handler) -> void
+Microsoft.Maui.Platform.MauiImageView.MauiImageView(Microsoft.Maui.Handlers.IImageHandler! handler) -> void
 Microsoft.Maui.SizeRequest.Equals(Microsoft.Maui.SizeRequest other) -> bool
 Microsoft.Maui.Platform.MauiScrollView
 Microsoft.Maui.Platform.MauiScrollView.MauiScrollView() -> void

--- a/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -14,11 +14,11 @@ Microsoft.Maui.ICommandMapper.Invoke(Microsoft.Maui.IElementHandler! viewHandler
 Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>
 Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>.Add(string! key, System.Action<TViewHandler, TVirtualView, object?>! action) -> void
 Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>.Add(string! key, System.Action<TViewHandler, TVirtualView>! action) -> void
-Microsoft.Maui.IImageSourcePartSetter
-Microsoft.Maui.IImageSourcePartSetter.SetImageSource(UIKit.UIImage? obj) -> void
+Microsoft.Maui.Handlers.IImageSourcePartSetter
+Microsoft.Maui.Handlers.IImageSourcePartSetter.SetImageSource(UIKit.UIImage? obj) -> void
 Microsoft.Maui.Layouts.FlexBasis.Equals(Microsoft.Maui.Layouts.FlexBasis other) -> bool
 Microsoft.Maui.LifecycleEvents.iOSLifecycle.PerformFetch
-Microsoft.Maui.Platform.ImageSourcePartLoader.ImageSourcePartLoader(Microsoft.Maui.IImageSourcePartSetter! handler) -> void
+Microsoft.Maui.Platform.ImageSourcePartLoader.ImageSourcePartLoader(Microsoft.Maui.Handlers.IImageSourcePartSetter! handler) -> void
 Microsoft.Maui.Platform.KeyboardAutoManagerScroll
 Microsoft.Maui.Platform.MauiImageView.MauiImageView(Microsoft.Maui.Handlers.IImageHandler! handler) -> void
 Microsoft.Maui.SizeRequest.Equals(Microsoft.Maui.SizeRequest other) -> bool

--- a/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Shipped.txt
+++ b/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Shipped.txt
@@ -2047,7 +2047,6 @@ override Microsoft.Maui.Handlers.GraphicsViewHandler.DisconnectHandler(Microsoft
 override Microsoft.Maui.Handlers.ImageButtonHandler.ConnectHandler(UIKit.UIButton! platformView) -> void
 override Microsoft.Maui.Handlers.ImageButtonHandler.CreatePlatformView() -> UIKit.UIButton!
 override Microsoft.Maui.Handlers.ImageButtonHandler.DisconnectHandler(UIKit.UIButton! platformView) -> void
-override Microsoft.Maui.Handlers.ImageHandler.ConnectHandler(UIKit.UIImageView! platformView) -> void
 override Microsoft.Maui.Handlers.ImageHandler.CreatePlatformView() -> UIKit.UIImageView!
 override Microsoft.Maui.Handlers.ImageHandler.DisconnectHandler(UIKit.UIImageView! platformView) -> void
 override Microsoft.Maui.Handlers.ImageHandler.NeedsContainer.get -> bool

--- a/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,6 +1,8 @@
 #nullable enable
 Microsoft.Maui.CommandMapper.Invoke(Microsoft.Maui.IElementHandler! viewHandler, Microsoft.Maui.IElement? virtualView, string! property, object? args) -> void
 Microsoft.Maui.FocusRequest.FocusRequest() -> void
+Microsoft.Maui.Handlers.IImageHandler.OnWindowChanged() -> void
+Microsoft.Maui.Handlers.ImageHandler.OnWindowChanged() -> void
 Microsoft.Maui.Handlers.SwipeItemButton
 Microsoft.Maui.Handlers.SwipeItemButton.FrameChanged -> System.EventHandler?
 Microsoft.Maui.Handlers.SwipeItemButton.SwipeItemButton() -> void
@@ -16,7 +18,7 @@ Microsoft.Maui.IImageSourcePartSetter
 Microsoft.Maui.IImageSourcePartSetter.SetImageSource(UIKit.UIImage? obj) -> void
 Microsoft.Maui.Layouts.FlexBasis.Equals(Microsoft.Maui.Layouts.FlexBasis other) -> bool
 Microsoft.Maui.Platform.ImageSourcePartLoader.ImageSourcePartLoader(Microsoft.Maui.IImageSourcePartSetter! handler) -> void
-Microsoft.Maui.Platform.MauiImageView.MauiImageView(Microsoft.Maui.Handlers.ImageHandler! handler) -> void
+Microsoft.Maui.Platform.MauiImageView.MauiImageView(Microsoft.Maui.Handlers.IImageHandler! handler) -> void
 Microsoft.Maui.Platform.MauiView.CacheMeasureConstraints(double widthConstraint, double heightConstraint) -> void
 Microsoft.Maui.Platform.MauiView.InvalidateConstraintsCache() -> void
 Microsoft.Maui.Platform.MauiView.IsMeasureValid(double widthConstraint, double heightConstraint) -> bool

--- a/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -14,10 +14,10 @@ Microsoft.Maui.ICommandMapper.Invoke(Microsoft.Maui.IElementHandler! viewHandler
 Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>
 Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>.Add(string! key, System.Action<TViewHandler, TVirtualView, object?>! action) -> void
 Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>.Add(string! key, System.Action<TViewHandler, TVirtualView>! action) -> void
-Microsoft.Maui.IImageSourcePartSetter
-Microsoft.Maui.IImageSourcePartSetter.SetImageSource(UIKit.UIImage? obj) -> void
+Microsoft.Maui.Handlers.IImageSourcePartSetter
+Microsoft.Maui.Handlers.IImageSourcePartSetter.SetImageSource(UIKit.UIImage? obj) -> void
 Microsoft.Maui.Layouts.FlexBasis.Equals(Microsoft.Maui.Layouts.FlexBasis other) -> bool
-Microsoft.Maui.Platform.ImageSourcePartLoader.ImageSourcePartLoader(Microsoft.Maui.IImageSourcePartSetter! handler) -> void
+Microsoft.Maui.Platform.ImageSourcePartLoader.ImageSourcePartLoader(Microsoft.Maui.Handlers.IImageSourcePartSetter! handler) -> void
 Microsoft.Maui.Platform.MauiImageView.MauiImageView(Microsoft.Maui.Handlers.IImageHandler! handler) -> void
 Microsoft.Maui.Platform.MauiView.CacheMeasureConstraints(double widthConstraint, double heightConstraint) -> void
 Microsoft.Maui.Platform.MauiView.InvalidateConstraintsCache() -> void

--- a/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -12,10 +12,10 @@ Microsoft.Maui.ICommandMapper.Invoke(Microsoft.Maui.IElementHandler! viewHandler
 Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>
 Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>.Add(string! key, System.Action<TViewHandler, TVirtualView, object?>! action) -> void
 Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>.Add(string! key, System.Action<TViewHandler, TVirtualView>! action) -> void
-Microsoft.Maui.ISetImageHandler
-Microsoft.Maui.ISetImageHandler.SetImageSource(UIKit.UIImage? obj) -> void
+Microsoft.Maui.IImageSourcePartSetter
+Microsoft.Maui.IImageSourcePartSetter.SetImageSource(UIKit.UIImage? obj) -> void
 Microsoft.Maui.Layouts.FlexBasis.Equals(Microsoft.Maui.Layouts.FlexBasis other) -> bool
-Microsoft.Maui.Platform.ImageSourcePartLoader.ImageSourcePartLoader(Microsoft.Maui.ISetImageHandler! handler) -> void
+Microsoft.Maui.Platform.ImageSourcePartLoader.ImageSourcePartLoader(Microsoft.Maui.IImageSourcePartSetter! handler) -> void
 Microsoft.Maui.Platform.MauiImageView.MauiImageView(Microsoft.Maui.Handlers.ImageHandler! handler) -> void
 Microsoft.Maui.Platform.MauiView.CacheMeasureConstraints(double widthConstraint, double heightConstraint) -> void
 Microsoft.Maui.Platform.MauiView.InvalidateConstraintsCache() -> void

--- a/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -12,7 +12,11 @@ Microsoft.Maui.ICommandMapper.Invoke(Microsoft.Maui.IElementHandler! viewHandler
 Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>
 Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>.Add(string! key, System.Action<TViewHandler, TVirtualView, object?>! action) -> void
 Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>.Add(string! key, System.Action<TViewHandler, TVirtualView>! action) -> void
+Microsoft.Maui.ISetImageHandler
+Microsoft.Maui.ISetImageHandler.SetImageSource(UIKit.UIImage? obj) -> void
 Microsoft.Maui.Layouts.FlexBasis.Equals(Microsoft.Maui.Layouts.FlexBasis other) -> bool
+Microsoft.Maui.Platform.ImageSourcePartLoader.ImageSourcePartLoader(Microsoft.Maui.ISetImageHandler! handler) -> void
+Microsoft.Maui.Platform.MauiImageView.MauiImageView(Microsoft.Maui.Handlers.ImageHandler! handler) -> void
 Microsoft.Maui.Platform.MauiView.CacheMeasureConstraints(double widthConstraint, double heightConstraint) -> void
 Microsoft.Maui.Platform.MauiView.InvalidateConstraintsCache() -> void
 Microsoft.Maui.Platform.MauiView.IsMeasureValid(double widthConstraint, double heightConstraint) -> bool

--- a/src/Core/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -11,9 +11,9 @@ Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>.Add(string! key, Syste
 Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>.Add(string! key, System.Action<TViewHandler, TVirtualView>! action) -> void
 Microsoft.Maui.Layouts.FlexBasis.Equals(Microsoft.Maui.Layouts.FlexBasis other) -> bool
 Microsoft.Maui.SizeRequest.Equals(Microsoft.Maui.SizeRequest other) -> bool
-Microsoft.Maui.ISetImageHandler
-Microsoft.Maui.ISetImageHandler.SetImageSource(Microsoft.Maui.Platform.MauiImageSource? obj) -> void
-Microsoft.Maui.Platform.ImageSourcePartLoader.ImageSourcePartLoader(Microsoft.Maui.ISetImageHandler! handler) -> void
+Microsoft.Maui.IImageSourcePartSetter
+Microsoft.Maui.IImageSourcePartSetter.SetImageSource(Microsoft.Maui.Platform.MauiImageSource? obj) -> void
+Microsoft.Maui.Platform.ImageSourcePartLoader.ImageSourcePartLoader(Microsoft.Maui.IImageSourcePartSetter! handler) -> void
 override Microsoft.Maui.Layouts.FlexBasis.Equals(object? obj) -> bool
 override Microsoft.Maui.Layouts.FlexBasis.GetHashCode() -> int
 override Microsoft.Maui.SizeRequest.Equals(object? obj) -> bool

--- a/src/Core/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -11,9 +11,9 @@ Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>.Add(string! key, Syste
 Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>.Add(string! key, System.Action<TViewHandler, TVirtualView>! action) -> void
 Microsoft.Maui.Layouts.FlexBasis.Equals(Microsoft.Maui.Layouts.FlexBasis other) -> bool
 Microsoft.Maui.SizeRequest.Equals(Microsoft.Maui.SizeRequest other) -> bool
-Microsoft.Maui.IImageSourcePartSetter
-Microsoft.Maui.IImageSourcePartSetter.SetImageSource(Microsoft.Maui.Platform.MauiImageSource? obj) -> void
-Microsoft.Maui.Platform.ImageSourcePartLoader.ImageSourcePartLoader(Microsoft.Maui.IImageSourcePartSetter! handler) -> void
+Microsoft.Maui.Handlers.IImageSourcePartSetter
+Microsoft.Maui.Handlers.IImageSourcePartSetter.SetImageSource(Microsoft.Maui.Platform.MauiImageSource? obj) -> void
+Microsoft.Maui.Platform.ImageSourcePartLoader.ImageSourcePartLoader(Microsoft.Maui.Handlers.IImageSourcePartSetter! handler) -> void
 override Microsoft.Maui.Layouts.FlexBasis.Equals(object? obj) -> bool
 override Microsoft.Maui.Layouts.FlexBasis.GetHashCode() -> int
 override Microsoft.Maui.SizeRequest.Equals(object? obj) -> bool

--- a/src/Core/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -11,6 +11,9 @@ Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>.Add(string! key, Syste
 Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>.Add(string! key, System.Action<TViewHandler, TVirtualView>! action) -> void
 Microsoft.Maui.Layouts.FlexBasis.Equals(Microsoft.Maui.Layouts.FlexBasis other) -> bool
 Microsoft.Maui.SizeRequest.Equals(Microsoft.Maui.SizeRequest other) -> bool
+Microsoft.Maui.ISetImageHandler
+Microsoft.Maui.ISetImageHandler.SetImageSource(Microsoft.Maui.Platform.MauiImageSource? obj) -> void
+Microsoft.Maui.Platform.ImageSourcePartLoader.ImageSourcePartLoader(Microsoft.Maui.ISetImageHandler! handler) -> void
 override Microsoft.Maui.Layouts.FlexBasis.Equals(object? obj) -> bool
 override Microsoft.Maui.Layouts.FlexBasis.GetHashCode() -> int
 override Microsoft.Maui.SizeRequest.Equals(object? obj) -> bool

--- a/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -3,8 +3,8 @@ Microsoft.Maui.CommandMapper.Invoke(Microsoft.Maui.IElementHandler! viewHandler,
 Microsoft.Maui.FocusRequest.FocusRequest() -> void
 Microsoft.Maui.IApplication.UserAppTheme.get -> Microsoft.Maui.ApplicationModel.AppTheme
 Microsoft.Maui.Hosting.MauiApp.DisposeAsync() -> System.Threading.Tasks.ValueTask
-Microsoft.Maui.ISetImageHandler
-Microsoft.Maui.ISetImageHandler.SetImageSource(Microsoft.UI.Xaml.Media.ImageSource? obj) -> void
+Microsoft.Maui.IImageSourcePartSetter
+Microsoft.Maui.IImageSourcePartSetter.SetImageSource(Microsoft.UI.Xaml.Media.ImageSource? obj) -> void
 Microsoft.Maui.IWindow.TitleBarDragRectangles.get -> Microsoft.Maui.Graphics.Rect[]?
 Microsoft.Maui.ICommandMapper
 Microsoft.Maui.ICommandMapper.GetCommand(string! key) -> System.Action<Microsoft.Maui.IElementHandler!, Microsoft.Maui.IElement!, object?>?
@@ -13,7 +13,7 @@ Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>
 Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>.Add(string! key, System.Action<TViewHandler, TVirtualView, object?>! action) -> void
 Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>.Add(string! key, System.Action<TViewHandler, TVirtualView>! action) -> void
 Microsoft.Maui.Layouts.FlexBasis.Equals(Microsoft.Maui.Layouts.FlexBasis other) -> bool
-Microsoft.Maui.Platform.ImageSourcePartLoader.ImageSourcePartLoader(Microsoft.Maui.ISetImageHandler! handler) -> void
+Microsoft.Maui.Platform.ImageSourcePartLoader.ImageSourcePartLoader(Microsoft.Maui.IImageSourcePartSetter! handler) -> void
 Microsoft.Maui.Platform.MauiWebView.MauiWebView(Microsoft.Maui.Handlers.WebViewHandler! handler) -> void
 Microsoft.Maui.SizeRequest.Equals(Microsoft.Maui.SizeRequest other) -> bool
 override Microsoft.Maui.Handlers.ContentViewHandler.DisconnectHandler(Microsoft.Maui.Platform.ContentPanel! platformView) -> void

--- a/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -3,6 +3,8 @@ Microsoft.Maui.CommandMapper.Invoke(Microsoft.Maui.IElementHandler! viewHandler,
 Microsoft.Maui.FocusRequest.FocusRequest() -> void
 Microsoft.Maui.IApplication.UserAppTheme.get -> Microsoft.Maui.ApplicationModel.AppTheme
 Microsoft.Maui.Hosting.MauiApp.DisposeAsync() -> System.Threading.Tasks.ValueTask
+Microsoft.Maui.ISetImageHandler
+Microsoft.Maui.ISetImageHandler.SetImageSource(Microsoft.UI.Xaml.Media.ImageSource? obj) -> void
 Microsoft.Maui.IWindow.TitleBarDragRectangles.get -> Microsoft.Maui.Graphics.Rect[]?
 Microsoft.Maui.ICommandMapper
 Microsoft.Maui.ICommandMapper.GetCommand(string! key) -> System.Action<Microsoft.Maui.IElementHandler!, Microsoft.Maui.IElement!, object?>?
@@ -11,6 +13,7 @@ Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>
 Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>.Add(string! key, System.Action<TViewHandler, TVirtualView, object?>! action) -> void
 Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>.Add(string! key, System.Action<TViewHandler, TVirtualView>! action) -> void
 Microsoft.Maui.Layouts.FlexBasis.Equals(Microsoft.Maui.Layouts.FlexBasis other) -> bool
+Microsoft.Maui.Platform.ImageSourcePartLoader.ImageSourcePartLoader(Microsoft.Maui.ISetImageHandler! handler) -> void
 Microsoft.Maui.Platform.MauiWebView.MauiWebView(Microsoft.Maui.Handlers.WebViewHandler! handler) -> void
 Microsoft.Maui.SizeRequest.Equals(Microsoft.Maui.SizeRequest other) -> bool
 override Microsoft.Maui.Handlers.ContentViewHandler.DisconnectHandler(Microsoft.Maui.Platform.ContentPanel! platformView) -> void

--- a/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -3,8 +3,8 @@ Microsoft.Maui.CommandMapper.Invoke(Microsoft.Maui.IElementHandler! viewHandler,
 Microsoft.Maui.FocusRequest.FocusRequest() -> void
 Microsoft.Maui.IApplication.UserAppTheme.get -> Microsoft.Maui.ApplicationModel.AppTheme
 Microsoft.Maui.Hosting.MauiApp.DisposeAsync() -> System.Threading.Tasks.ValueTask
-Microsoft.Maui.IImageSourcePartSetter
-Microsoft.Maui.IImageSourcePartSetter.SetImageSource(Microsoft.UI.Xaml.Media.ImageSource? obj) -> void
+Microsoft.Maui.Handlers.IImageSourcePartSetter
+Microsoft.Maui.Handlers.IImageSourcePartSetter.SetImageSource(Microsoft.UI.Xaml.Media.ImageSource? obj) -> void
 Microsoft.Maui.IWindow.TitleBarDragRectangles.get -> Microsoft.Maui.Graphics.Rect[]?
 Microsoft.Maui.ICommandMapper
 Microsoft.Maui.ICommandMapper.GetCommand(string! key) -> System.Action<Microsoft.Maui.IElementHandler!, Microsoft.Maui.IElement!, object?>?
@@ -13,7 +13,7 @@ Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>
 Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>.Add(string! key, System.Action<TViewHandler, TVirtualView, object?>! action) -> void
 Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>.Add(string! key, System.Action<TViewHandler, TVirtualView>! action) -> void
 Microsoft.Maui.Layouts.FlexBasis.Equals(Microsoft.Maui.Layouts.FlexBasis other) -> bool
-Microsoft.Maui.Platform.ImageSourcePartLoader.ImageSourcePartLoader(Microsoft.Maui.IImageSourcePartSetter! handler) -> void
+Microsoft.Maui.Platform.ImageSourcePartLoader.ImageSourcePartLoader(Microsoft.Maui.Handlers.IImageSourcePartSetter! handler) -> void
 Microsoft.Maui.Platform.MauiWebView.MauiWebView(Microsoft.Maui.Handlers.WebViewHandler! handler) -> void
 Microsoft.Maui.SizeRequest.Equals(Microsoft.Maui.SizeRequest other) -> bool
 override Microsoft.Maui.Handlers.ContentViewHandler.DisconnectHandler(Microsoft.Maui.Platform.ContentPanel! platformView) -> void

--- a/src/Core/src/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -9,10 +9,10 @@ Microsoft.Maui.ICommandMapper.Invoke(Microsoft.Maui.IElementHandler! viewHandler
 Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>
 Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>.Add(string! key, System.Action<TViewHandler, TVirtualView, object?>! action) -> void
 Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>.Add(string! key, System.Action<TViewHandler, TVirtualView>! action) -> void
-Microsoft.Maui.ISetImageHandler
-Microsoft.Maui.ISetImageHandler.SetImageSource(object? obj) -> void
+Microsoft.Maui.IImageSourcePartSetter
+Microsoft.Maui.IImageSourcePartSetter.SetImageSource(object? obj) -> void
 Microsoft.Maui.Layouts.FlexBasis.Equals(Microsoft.Maui.Layouts.FlexBasis other) -> bool
-Microsoft.Maui.Platform.ImageSourcePartLoader.ImageSourcePartLoader(Microsoft.Maui.ISetImageHandler! handler) -> void
+Microsoft.Maui.Platform.ImageSourcePartLoader.ImageSourcePartLoader(Microsoft.Maui.IImageSourcePartSetter! handler) -> void
 Microsoft.Maui.SizeRequest.Equals(Microsoft.Maui.SizeRequest other) -> bool
 override Microsoft.Maui.Layouts.FlexBasis.Equals(object? obj) -> bool
 override Microsoft.Maui.Layouts.FlexBasis.GetHashCode() -> int

--- a/src/Core/src/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -9,10 +9,10 @@ Microsoft.Maui.ICommandMapper.Invoke(Microsoft.Maui.IElementHandler! viewHandler
 Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>
 Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>.Add(string! key, System.Action<TViewHandler, TVirtualView, object?>! action) -> void
 Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>.Add(string! key, System.Action<TViewHandler, TVirtualView>! action) -> void
-Microsoft.Maui.IImageSourcePartSetter
-Microsoft.Maui.IImageSourcePartSetter.SetImageSource(object? obj) -> void
+Microsoft.Maui.Handlers.IImageSourcePartSetter
+Microsoft.Maui.Handlers.IImageSourcePartSetter.SetImageSource(object? obj) -> void
 Microsoft.Maui.Layouts.FlexBasis.Equals(Microsoft.Maui.Layouts.FlexBasis other) -> bool
-Microsoft.Maui.Platform.ImageSourcePartLoader.ImageSourcePartLoader(Microsoft.Maui.IImageSourcePartSetter! handler) -> void
+Microsoft.Maui.Platform.ImageSourcePartLoader.ImageSourcePartLoader(Microsoft.Maui.Handlers.IImageSourcePartSetter! handler) -> void
 Microsoft.Maui.SizeRequest.Equals(Microsoft.Maui.SizeRequest other) -> bool
 override Microsoft.Maui.Layouts.FlexBasis.Equals(object? obj) -> bool
 override Microsoft.Maui.Layouts.FlexBasis.GetHashCode() -> int

--- a/src/Core/src/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -9,7 +9,10 @@ Microsoft.Maui.ICommandMapper.Invoke(Microsoft.Maui.IElementHandler! viewHandler
 Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>
 Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>.Add(string! key, System.Action<TViewHandler, TVirtualView, object?>! action) -> void
 Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>.Add(string! key, System.Action<TViewHandler, TVirtualView>! action) -> void
+Microsoft.Maui.ISetImageHandler
+Microsoft.Maui.ISetImageHandler.SetImageSource(object? obj) -> void
 Microsoft.Maui.Layouts.FlexBasis.Equals(Microsoft.Maui.Layouts.FlexBasis other) -> bool
+Microsoft.Maui.Platform.ImageSourcePartLoader.ImageSourcePartLoader(Microsoft.Maui.ISetImageHandler! handler) -> void
 Microsoft.Maui.SizeRequest.Equals(Microsoft.Maui.SizeRequest other) -> bool
 override Microsoft.Maui.Layouts.FlexBasis.Equals(object? obj) -> bool
 override Microsoft.Maui.Layouts.FlexBasis.GetHashCode() -> int

--- a/src/Core/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -9,10 +9,10 @@ Microsoft.Maui.ICommandMapper.Invoke(Microsoft.Maui.IElementHandler! viewHandler
 Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>
 Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>.Add(string! key, System.Action<TViewHandler, TVirtualView, object?>! action) -> void
 Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>.Add(string! key, System.Action<TViewHandler, TVirtualView>! action) -> void
-Microsoft.Maui.ISetImageHandler
-Microsoft.Maui.ISetImageHandler.SetImageSource(object? obj) -> void
+Microsoft.Maui.IImageSourcePartSetter
+Microsoft.Maui.IImageSourcePartSetter.SetImageSource(object? obj) -> void
 Microsoft.Maui.Layouts.FlexBasis.Equals(Microsoft.Maui.Layouts.FlexBasis other) -> bool
-Microsoft.Maui.Platform.ImageSourcePartLoader.ImageSourcePartLoader(Microsoft.Maui.ISetImageHandler! handler) -> void
+Microsoft.Maui.Platform.ImageSourcePartLoader.ImageSourcePartLoader(Microsoft.Maui.IImageSourcePartSetter! handler) -> void
 Microsoft.Maui.SizeRequest.Equals(Microsoft.Maui.SizeRequest other) -> bool
 override Microsoft.Maui.Layouts.FlexBasis.Equals(object? obj) -> bool
 override Microsoft.Maui.Layouts.FlexBasis.GetHashCode() -> int

--- a/src/Core/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -9,10 +9,10 @@ Microsoft.Maui.ICommandMapper.Invoke(Microsoft.Maui.IElementHandler! viewHandler
 Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>
 Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>.Add(string! key, System.Action<TViewHandler, TVirtualView, object?>! action) -> void
 Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>.Add(string! key, System.Action<TViewHandler, TVirtualView>! action) -> void
-Microsoft.Maui.IImageSourcePartSetter
-Microsoft.Maui.IImageSourcePartSetter.SetImageSource(object? obj) -> void
+Microsoft.Maui.Handlers.IImageSourcePartSetter
+Microsoft.Maui.Handlers.IImageSourcePartSetter.SetImageSource(object? obj) -> void
 Microsoft.Maui.Layouts.FlexBasis.Equals(Microsoft.Maui.Layouts.FlexBasis other) -> bool
-Microsoft.Maui.Platform.ImageSourcePartLoader.ImageSourcePartLoader(Microsoft.Maui.IImageSourcePartSetter! handler) -> void
+Microsoft.Maui.Platform.ImageSourcePartLoader.ImageSourcePartLoader(Microsoft.Maui.Handlers.IImageSourcePartSetter! handler) -> void
 Microsoft.Maui.SizeRequest.Equals(Microsoft.Maui.SizeRequest other) -> bool
 override Microsoft.Maui.Layouts.FlexBasis.Equals(object? obj) -> bool
 override Microsoft.Maui.Layouts.FlexBasis.GetHashCode() -> int

--- a/src/Core/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -9,7 +9,10 @@ Microsoft.Maui.ICommandMapper.Invoke(Microsoft.Maui.IElementHandler! viewHandler
 Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>
 Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>.Add(string! key, System.Action<TViewHandler, TVirtualView, object?>! action) -> void
 Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>.Add(string! key, System.Action<TViewHandler, TVirtualView>! action) -> void
+Microsoft.Maui.ISetImageHandler
+Microsoft.Maui.ISetImageHandler.SetImageSource(object? obj) -> void
 Microsoft.Maui.Layouts.FlexBasis.Equals(Microsoft.Maui.Layouts.FlexBasis other) -> bool
+Microsoft.Maui.Platform.ImageSourcePartLoader.ImageSourcePartLoader(Microsoft.Maui.ISetImageHandler! handler) -> void
 Microsoft.Maui.SizeRequest.Equals(Microsoft.Maui.SizeRequest other) -> bool
 override Microsoft.Maui.Layouts.FlexBasis.Equals(object? obj) -> bool
 override Microsoft.Maui.Layouts.FlexBasis.GetHashCode() -> int

--- a/src/Core/src/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -9,10 +9,10 @@ Microsoft.Maui.ICommandMapper.Invoke(Microsoft.Maui.IElementHandler! viewHandler
 Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>
 Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>.Add(string! key, System.Action<TViewHandler, TVirtualView, object?>! action) -> void
 Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>.Add(string! key, System.Action<TViewHandler, TVirtualView>! action) -> void
-Microsoft.Maui.ISetImageHandler
-Microsoft.Maui.ISetImageHandler.SetImageSource(object? obj) -> void
+Microsoft.Maui.IImageSourcePartSetter
+Microsoft.Maui.IImageSourcePartSetter.SetImageSource(object? obj) -> void
 Microsoft.Maui.Layouts.FlexBasis.Equals(Microsoft.Maui.Layouts.FlexBasis other) -> bool
-Microsoft.Maui.Platform.ImageSourcePartLoader.ImageSourcePartLoader(Microsoft.Maui.ISetImageHandler! handler) -> void
+Microsoft.Maui.Platform.ImageSourcePartLoader.ImageSourcePartLoader(Microsoft.Maui.IImageSourcePartSetter! handler) -> void
 Microsoft.Maui.SizeRequest.Equals(Microsoft.Maui.SizeRequest other) -> bool
 override Microsoft.Maui.Layouts.FlexBasis.Equals(object? obj) -> bool
 override Microsoft.Maui.Layouts.FlexBasis.GetHashCode() -> int

--- a/src/Core/src/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -9,10 +9,10 @@ Microsoft.Maui.ICommandMapper.Invoke(Microsoft.Maui.IElementHandler! viewHandler
 Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>
 Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>.Add(string! key, System.Action<TViewHandler, TVirtualView, object?>! action) -> void
 Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>.Add(string! key, System.Action<TViewHandler, TVirtualView>! action) -> void
-Microsoft.Maui.IImageSourcePartSetter
-Microsoft.Maui.IImageSourcePartSetter.SetImageSource(object? obj) -> void
+Microsoft.Maui.Handlers.IImageSourcePartSetter
+Microsoft.Maui.Handlers.IImageSourcePartSetter.SetImageSource(object? obj) -> void
 Microsoft.Maui.Layouts.FlexBasis.Equals(Microsoft.Maui.Layouts.FlexBasis other) -> bool
-Microsoft.Maui.Platform.ImageSourcePartLoader.ImageSourcePartLoader(Microsoft.Maui.IImageSourcePartSetter! handler) -> void
+Microsoft.Maui.Platform.ImageSourcePartLoader.ImageSourcePartLoader(Microsoft.Maui.Handlers.IImageSourcePartSetter! handler) -> void
 Microsoft.Maui.SizeRequest.Equals(Microsoft.Maui.SizeRequest other) -> bool
 override Microsoft.Maui.Layouts.FlexBasis.Equals(object? obj) -> bool
 override Microsoft.Maui.Layouts.FlexBasis.GetHashCode() -> int

--- a/src/Core/src/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -9,7 +9,10 @@ Microsoft.Maui.ICommandMapper.Invoke(Microsoft.Maui.IElementHandler! viewHandler
 Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>
 Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>.Add(string! key, System.Action<TViewHandler, TVirtualView, object?>! action) -> void
 Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>.Add(string! key, System.Action<TViewHandler, TVirtualView>! action) -> void
+Microsoft.Maui.ISetImageHandler
+Microsoft.Maui.ISetImageHandler.SetImageSource(object? obj) -> void
 Microsoft.Maui.Layouts.FlexBasis.Equals(Microsoft.Maui.Layouts.FlexBasis other) -> bool
+Microsoft.Maui.Platform.ImageSourcePartLoader.ImageSourcePartLoader(Microsoft.Maui.ISetImageHandler! handler) -> void
 Microsoft.Maui.SizeRequest.Equals(Microsoft.Maui.SizeRequest other) -> bool
 override Microsoft.Maui.Layouts.FlexBasis.Equals(object? obj) -> bool
 override Microsoft.Maui.Layouts.FlexBasis.GetHashCode() -> int


### PR DESCRIPTION
Context: https://github.com/dotnet/maui/issues/14664#issuecomment-1540510216

`Image` has two different "cycles" on iOS:

* `ImageHandler` -> `MauiImageView` -> `ImageHandler`

  * via the `WindowChanged` event

* `ImageHandler` -> `ImageSourcePartLoader` -> `ImageHandler`

    * via `Handler`, `Func<IImageSourcePart?>`, and `Action<PlatformImage?>`

This causes any `MauiImageView` to live forever.

To solve these issues:

* Get rid of the `MauiImageView.WindowChanged` event, and use a `WeakReference` to the handler instead.

* `ImageSourcePartLoader` now only has a `WeakReference` to the handler.

* This requires a new `ISetImageHandler` interface to be used by several handler types involving images.

Hopefully the changes here are using `[Obsolete]` correctly to make things backwards compatible & less breaking changes.

Unsure yet if this fully solves #14664, but at least one part of it.
