### PR TITLE
[iOS] Change the impl of the event handler to use a notification center to avoid circular refs.

### DIFF
--- a/src/Core/src/Handlers/Editor/EditorHandler.iOS.cs
+++ b/src/Core/src/Handlers/Editor/EditorHandler.iOS.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Maui.Handlers
 			}
 		}
 #endif
-		
+
 		public override void SetVirtualView(IView view)
 		{
 			base.SetVirtualView(view);
@@ -67,10 +67,11 @@ namespace Microsoft.Maui.Handlers
 
 		protected override void OnNativeViewChanged(NSNotification notification)
 		{
-			switch(notification.Name) {
-			case MauiTextView.TextSetOrChangedNotification:
-				OnTextPropertySet(notification.Object, EventArgs.Empty);
-				break;
+			switch (notification.Name)
+			{
+				case MauiTextView.TextSetOrChangedNotification:
+					OnTextPropertySet(notification.Object, EventArgs.Empty);
+					break;
 			}
 		}
 

--- a/src/Core/src/Handlers/Editor/EditorHandler.iOS.cs
+++ b/src/Core/src/Handlers/Editor/EditorHandler.iOS.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using CoreGraphics;
 using Foundation;
-using Microsoft.Maui.Devices;
 using Microsoft.Maui.Graphics;
 using UIKit;
 
@@ -35,7 +33,7 @@ namespace Microsoft.Maui.Handlers
 			}
 		}
 #endif
-
+		
 		public override void SetVirtualView(IView view)
 		{
 			base.SetVirtualView(view);
@@ -51,7 +49,8 @@ namespace Microsoft.Maui.Handlers
 			platformView.ShouldChangeText += OnShouldChangeText;
 			platformView.Started += OnStarted;
 			platformView.Ended += OnEnded;
-			platformView.TextSetOrChanged += OnTextPropertySet;
+			// register to native notitications
+			base.RegisterToNotifications(platformView);
 		}
 
 		protected override void DisconnectHandler(MauiTextView platformView)
@@ -59,12 +58,20 @@ namespace Microsoft.Maui.Handlers
 			platformView.ShouldChangeText -= OnShouldChangeText;
 			platformView.Started -= OnStarted;
 			platformView.Ended -= OnEnded;
-			platformView.TextSetOrChanged -= OnTextPropertySet;
 
 			if (_set)
 				platformView.SelectionChanged -= OnSelectionChanged;
 
 			_set = false;
+		}
+
+		protected override void OnNativeViewChanged(NSNotification notification)
+		{
+			switch(notification.Name) {
+			case MauiTextView.TextSetOrChangedNotification:
+				OnTextPropertySet(notification.Object, EventArgs.Empty);
+				break;
+			}
 		}
 
 		public override Size GetDesiredSize(double widthConstraint, double heightConstraint)

--- a/src/Core/src/Handlers/Element/ElementHandler.iOS.cs
+++ b/src/Core/src/Handlers/Element/ElementHandler.iOS.cs
@@ -1,0 +1,53 @@
+using Foundation;
+
+#nullable enable
+namespace Microsoft.Maui.Handlers
+{
+
+	public abstract partial class ElementHandler : NSObject
+	{
+		protected void RegisterToNotifications(NSObject view, string? notificationName = null)
+		{
+			NSNotificationCenter.DefaultCenter.AddObserver(this, new ObjCRuntime.Selector("onNativeNotification:"), (NSString?)notificationName, view);
+		}
+
+		// methods that will allow to receive nsnotifications from views, this way
+		// we do not need to have a event handler from the view directly.
+		// The main idea between this solution is to remove the need to have an event handler
+		// in the view that will have a reference to the handler and therefore create a circular ref
+		[Export("onNativeNotification:")]
+		private void InternalOnNativeNotification(NSNotification notification)
+		{
+			// there are two types of notifications we are interested:
+			//
+			//  1. When the native object is disposed (should be implemented by the inherting maui types)
+			//  2. All other notifications.
+			//
+			// 1. is very important, we want to remove ourselfs from the NSNotification center, 2 we fwd to the virtual method  
+			if (notification.Name == "Disposing")
+			{
+				NSNotificationCenter.DefaultCenter.RemoveObserver(this);
+				OnNativeViewDisposed();
+			}
+			else
+			{
+				OnNativeViewChanged(notification);
+			}
+		}
+
+		protected virtual void OnNativeViewDisposed()
+		{
+		}
+
+		protected virtual void OnNativeViewChanged(NSNotification notification)
+		{
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			// we need to remove ourselfs from the NSNotification center
+			NSNotificationCenter.DefaultCenter.RemoveObserver(this);
+			base.Dispose(disposing);
+		}
+	}
+}

--- a/src/Core/src/Handlers/View/ViewHandlerOfT.iOS.cs
+++ b/src/Core/src/Handlers/View/ViewHandlerOfT.iOS.cs
@@ -1,4 +1,5 @@
 using Microsoft.Maui.Graphics;
+using Foundation;
 using UIKit;
 
 namespace Microsoft.Maui.Handlers
@@ -67,5 +68,7 @@ namespace Microsoft.Maui.Handlers
 				}
 			}
 		}
+
+
 	}
 }

--- a/src/Core/src/Handlers/View/ViewHandlerOfT.iOS.cs
+++ b/src/Core/src/Handlers/View/ViewHandlerOfT.iOS.cs
@@ -1,5 +1,5 @@
-using Microsoft.Maui.Graphics;
 using Foundation;
+using Microsoft.Maui.Graphics;
 using UIKit;
 
 namespace Microsoft.Maui.Handlers

--- a/src/Core/src/Platform/iOS/MauiTextView.cs
+++ b/src/Core/src/Platform/iOS/MauiTextView.cs
@@ -35,9 +35,10 @@ namespace Microsoft.Maui.Platform
 		// Native Changed doesn't fire when the Text Property is set in code
 		// We use this event as a way to fire changes whenever the Text changes
 		// via code or user interaction.
-		private void TextSetOrChanged() {
-				var notification = NSNotification.FromName(TextSetOrChangedNotification, this);
-				NSNotificationCenter.DefaultCenter.PostNotification(notification);
+		private void TextSetOrChanged()
+		{
+			var notification = NSNotification.FromName(TextSetOrChangedNotification, this);
+			NSNotificationCenter.DefaultCenter.PostNotification(notification);
 		}
 
 		public string? PlaceholderText

--- a/src/Core/src/Platform/iOS/MauiTextView.cs
+++ b/src/Core/src/Platform/iOS/MauiTextView.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Maui.Platform
 {
 	public class MauiTextView : UITextView
 	{
+		internal const string TextSetOrChangedNotification = "TextSetOrChanged";
 		readonly UILabel _placeholderLabel;
 		nfloat? _defaultPlaceholderSize;
 
@@ -34,7 +35,10 @@ namespace Microsoft.Maui.Platform
 		// Native Changed doesn't fire when the Text Property is set in code
 		// We use this event as a way to fire changes whenever the Text changes
 		// via code or user interaction.
-		public event EventHandler? TextSetOrChanged;
+		private void TextSetOrChanged() {
+				var notification = NSNotification.FromName(TextSetOrChangedNotification, this);
+				NSNotificationCenter.DefaultCenter.PostNotification(notification);
+		}
 
 		public string? PlaceholderText
 		{
@@ -76,7 +80,7 @@ namespace Microsoft.Maui.Platform
 				if (old != value)
 				{
 					HidePlaceholderIfTextIsPresent(value);
-					TextSetOrChanged?.Invoke(this, EventArgs.Empty);
+					TextSetOrChanged();
 				}
 			}
 		}
@@ -104,7 +108,7 @@ namespace Microsoft.Maui.Platform
 				if (old?.Value != value?.Value)
 				{
 					HidePlaceholderIfTextIsPresent(value?.Value);
-					TextSetOrChanged?.Invoke(this, EventArgs.Empty);
+					TextSetOrChanged();
 				}
 			}
 		}
@@ -143,7 +147,7 @@ namespace Microsoft.Maui.Platform
 		void OnChanged(object? sender, EventArgs e)
 		{
 			HidePlaceholderIfTextIsPresent(Text);
-			TextSetOrChanged?.Invoke(this, EventArgs.Empty);
+			TextSetOrChanged();
 		}
 
 		void ShouldCenterVertically()

--- a/src/Core/src/PublicAPI/net-ios/PublicAPI.Shipped.txt
+++ b/src/Core/src/PublicAPI/net-ios/PublicAPI.Shipped.txt
@@ -1657,7 +1657,6 @@ Microsoft.Maui.Platform.MauiTextView.PlaceholderText.get -> string?
 Microsoft.Maui.Platform.MauiTextView.PlaceholderText.set -> void
 Microsoft.Maui.Platform.MauiTextView.PlaceholderTextColor.get -> UIKit.UIColor?
 Microsoft.Maui.Platform.MauiTextView.PlaceholderTextColor.set -> void
-Microsoft.Maui.Platform.MauiTextView.TextSetOrChanged -> System.EventHandler?
 Microsoft.Maui.Platform.MauiTextView.VerticalTextAlignment.get -> Microsoft.Maui.TextAlignment
 Microsoft.Maui.Platform.MauiTextView.VerticalTextAlignment.set -> void
 Microsoft.Maui.Platform.MauiTimePicker

--- a/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -1,6 +1,7 @@
 #nullable enable
 Microsoft.Maui.CommandMapper.Invoke(Microsoft.Maui.IElementHandler! viewHandler, Microsoft.Maui.IElement? virtualView, string! property, object? args) -> void
 Microsoft.Maui.FocusRequest.FocusRequest() -> void
+Microsoft.Maui.Handlers.ElementHandler.RegisterToNotifications(Foundation.NSObject! view, string? notificationName = null) -> void
 Microsoft.Maui.Handlers.SwipeItemButton
 Microsoft.Maui.Handlers.SwipeItemButton.FrameChanged -> System.EventHandler?
 Microsoft.Maui.Handlers.SwipeItemButton.SwipeItemButton() -> void
@@ -19,6 +20,8 @@ Microsoft.Maui.SizeRequest.Equals(Microsoft.Maui.SizeRequest other) -> bool
 Microsoft.Maui.Platform.MauiScrollView
 Microsoft.Maui.Platform.MauiScrollView.MauiScrollView() -> void
 override Microsoft.Maui.Handlers.ContentViewHandler.DisconnectHandler(Microsoft.Maui.Platform.ContentView! platformView) -> void
+override Microsoft.Maui.Handlers.EditorHandler.OnNativeViewChanged(Foundation.NSNotification! notification) -> void
+override Microsoft.Maui.Handlers.ElementHandler.Dispose(bool disposing) -> void
 override Microsoft.Maui.Handlers.ScrollViewHandler.NeedsContainer.get -> bool
 override Microsoft.Maui.Handlers.SwipeItemButton.Frame.get -> CoreGraphics.CGRect
 override Microsoft.Maui.Handlers.SwipeItemButton.Frame.set -> void
@@ -68,6 +71,8 @@ static Microsoft.Maui.PropertyMapperExtensions.PrependToMapping<TVirtualView, TV
 static Microsoft.Maui.PropertyMapperExtensions.ReplaceMapping<TVirtualView, TViewHandler>(this Microsoft.Maui.IPropertyMapper<Microsoft.Maui.IElement!, Microsoft.Maui.IElementHandler!>! propertyMapper, string! key, System.Action<TViewHandler, TVirtualView>! method) -> void
 static Microsoft.Maui.SizeRequest.operator !=(Microsoft.Maui.SizeRequest left, Microsoft.Maui.SizeRequest right) -> bool
 static Microsoft.Maui.SizeRequest.operator ==(Microsoft.Maui.SizeRequest left, Microsoft.Maui.SizeRequest right) -> bool
+virtual Microsoft.Maui.Handlers.ElementHandler.OnNativeViewChanged(Foundation.NSNotification! notification) -> void
+virtual Microsoft.Maui.Handlers.ElementHandler.OnNativeViewDisposed() -> void
 virtual Microsoft.Maui.MauiUIApplicationDelegate.PerformFetch(UIKit.UIApplication! application, System.Action<UIKit.UIBackgroundFetchResult>! completionHandler) -> void
 Microsoft.Maui.Platform.MauiView.CacheMeasureConstraints(double widthConstraint, double heightConstraint) -> void
 Microsoft.Maui.Platform.MauiView.InvalidateConstraintsCache() -> void

--- a/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Shipped.txt
+++ b/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Shipped.txt
@@ -1657,7 +1657,6 @@ Microsoft.Maui.Platform.MauiTextView.PlaceholderText.get -> string?
 Microsoft.Maui.Platform.MauiTextView.PlaceholderText.set -> void
 Microsoft.Maui.Platform.MauiTextView.PlaceholderTextColor.get -> UIKit.UIColor?
 Microsoft.Maui.Platform.MauiTextView.PlaceholderTextColor.set -> void
-Microsoft.Maui.Platform.MauiTextView.TextSetOrChanged -> System.EventHandler?
 Microsoft.Maui.Platform.MauiTextView.VerticalTextAlignment.get -> Microsoft.Maui.TextAlignment
 Microsoft.Maui.Platform.MauiTextView.VerticalTextAlignment.set -> void
 Microsoft.Maui.Platform.MauiTimePicker

--- a/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,6 +1,7 @@
 #nullable enable
 Microsoft.Maui.CommandMapper.Invoke(Microsoft.Maui.IElementHandler! viewHandler, Microsoft.Maui.IElement? virtualView, string! property, object? args) -> void
 Microsoft.Maui.FocusRequest.FocusRequest() -> void
+Microsoft.Maui.Handlers.ElementHandler.RegisterToNotifications(Foundation.NSObject! view, string? notificationName = null) -> void
 Microsoft.Maui.Handlers.SwipeItemButton
 Microsoft.Maui.Handlers.SwipeItemButton.FrameChanged -> System.EventHandler?
 Microsoft.Maui.Handlers.SwipeItemButton.SwipeItemButton() -> void
@@ -13,14 +14,14 @@ Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>
 Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>.Add(string! key, System.Action<TViewHandler, TVirtualView, object?>! action) -> void
 Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>.Add(string! key, System.Action<TViewHandler, TVirtualView>! action) -> void
 Microsoft.Maui.Layouts.FlexBasis.Equals(Microsoft.Maui.Layouts.FlexBasis other) -> bool
-Microsoft.Maui.Platform.MauiView.CacheMeasureConstraints(double widthConstraint, double heightConstraint) -> void
-Microsoft.Maui.Platform.MauiView.InvalidateConstraintsCache() -> void
-Microsoft.Maui.Platform.MauiView.IsMeasureValid(double widthConstraint, double heightConstraint) -> bool
+Microsoft.Maui.LifecycleEvents.iOSLifecycle.PerformFetch
+Microsoft.Maui.Platform.KeyboardAutoManagerScroll
 Microsoft.Maui.SizeRequest.Equals(Microsoft.Maui.SizeRequest other) -> bool
 Microsoft.Maui.Platform.MauiScrollView
 Microsoft.Maui.Platform.MauiScrollView.MauiScrollView() -> void
-Microsoft.Maui.Platform.KeyboardAutoManagerScroll
 override Microsoft.Maui.Handlers.ContentViewHandler.DisconnectHandler(Microsoft.Maui.Platform.ContentView! platformView) -> void
+override Microsoft.Maui.Handlers.EditorHandler.OnNativeViewChanged(Foundation.NSNotification! notification) -> void
+override Microsoft.Maui.Handlers.ElementHandler.Dispose(bool disposing) -> void
 override Microsoft.Maui.Handlers.ScrollViewHandler.NeedsContainer.get -> bool
 override Microsoft.Maui.Handlers.SwipeItemButton.Frame.get -> CoreGraphics.CGRect
 override Microsoft.Maui.Handlers.SwipeItemButton.Frame.set -> void
@@ -49,10 +50,10 @@ static Microsoft.Maui.Layouts.FlexBasis.operator !=(Microsoft.Maui.Layouts.FlexB
 static Microsoft.Maui.Layouts.FlexBasis.operator ==(Microsoft.Maui.Layouts.FlexBasis left, Microsoft.Maui.Layouts.FlexBasis right) -> bool
 static Microsoft.Maui.Layouts.LayoutExtensions.ArrangeContentUnbounded(this Microsoft.Maui.IContentView! contentView, Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
 static Microsoft.Maui.Handlers.SearchBarHandler.MapKeyboard(Microsoft.Maui.Handlers.ISearchBarHandler! handler, Microsoft.Maui.ISearchBar! searchBar) -> void
-static Microsoft.Maui.Platform.SearchBarExtensions.UpdateIsTextPredictionEnabled(this UIKit.UISearchBar! uiSearchBar, Microsoft.Maui.ISearchBar! searchBar, UIKit.UITextField? textField = null) -> void
-static Microsoft.Maui.Platform.SearchBarExtensions.UpdateKeyboard(this UIKit.UISearchBar! uiSearchBar, Microsoft.Maui.ISearchBar! searchBar) -> void
 static Microsoft.Maui.Platform.KeyboardAutoManagerScroll.Connect() -> void
 static Microsoft.Maui.Platform.KeyboardAutoManagerScroll.Disconnect() -> void
+static Microsoft.Maui.Platform.SearchBarExtensions.UpdateIsTextPredictionEnabled(this UIKit.UISearchBar! uiSearchBar, Microsoft.Maui.ISearchBar! searchBar, UIKit.UITextField? textField = null) -> void
+static Microsoft.Maui.Platform.SearchBarExtensions.UpdateKeyboard(this UIKit.UISearchBar! uiSearchBar, Microsoft.Maui.ISearchBar! searchBar) -> void
 override Microsoft.Maui.Platform.MauiTextField.WillMoveToWindow(UIKit.UIWindow? window) -> void
 override Microsoft.Maui.Platform.MauiTextView.WillMoveToWindow(UIKit.UIWindow? window) -> void
 *REMOVED*override Microsoft.Maui.Handlers.PageHandler.ConnectHandler(Microsoft.Maui.Platform.ContentView! nativeView) -> void
@@ -70,5 +71,9 @@ static Microsoft.Maui.PropertyMapperExtensions.PrependToMapping<TVirtualView, TV
 static Microsoft.Maui.PropertyMapperExtensions.ReplaceMapping<TVirtualView, TViewHandler>(this Microsoft.Maui.IPropertyMapper<Microsoft.Maui.IElement!, Microsoft.Maui.IElementHandler!>! propertyMapper, string! key, System.Action<TViewHandler, TVirtualView>! method) -> void
 static Microsoft.Maui.SizeRequest.operator !=(Microsoft.Maui.SizeRequest left, Microsoft.Maui.SizeRequest right) -> bool
 static Microsoft.Maui.SizeRequest.operator ==(Microsoft.Maui.SizeRequest left, Microsoft.Maui.SizeRequest right) -> bool
-Microsoft.Maui.LifecycleEvents.iOSLifecycle.PerformFetch
+virtual Microsoft.Maui.Handlers.ElementHandler.OnNativeViewChanged(Foundation.NSNotification! notification) -> void
+virtual Microsoft.Maui.Handlers.ElementHandler.OnNativeViewDisposed() -> void
 virtual Microsoft.Maui.MauiUIApplicationDelegate.PerformFetch(UIKit.UIApplication! application, System.Action<UIKit.UIBackgroundFetchResult>! completionHandler) -> void
+Microsoft.Maui.Platform.MauiView.CacheMeasureConstraints(double widthConstraint, double heightConstraint) -> void
+Microsoft.Maui.Platform.MauiView.InvalidateConstraintsCache() -> void
+Microsoft.Maui.Platform.MauiView.IsMeasureValid(double widthConstraint, double heightConstraint) -> bool


### PR DESCRIPTION
This is a draft, the  idea is to remove the use of delegates which will keep a strong ref to the handler, making ARC to not be able to celan the memory due to a circular reference. 

Notes: 

1. There is not direct link between the handler and the UI, we remove the circle.
2. All objects are in memory, and the xamarin iOS implementation of the notification center is the one that will keep them there: https://github.com/xamarin/xamarin-macios/blob/00de70eb8f69870825adef9157cc3522e730a294/src/Foundation/NSNotificationCenter.cs#L103
