### PR TITLE
Android: fix dialog button colors in dark mode

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/AlertDialog/AlertDialogTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/AlertDialog/AlertDialogTests.Android.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Maui.DeviceTests.Stubs;
+using Microsoft.Maui.Platform;
+using Xunit;
+using AndroidX.AppCompat.App;
+using Android.Graphics;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	public partial class AlertDialogTests: ControlsHandlerTestBase
+	{
+
+		async Task<Color> GetDialogButtonTextColor(int nightMode)
+		{
+			var mauiContextStub1 = new ContextStub(ApplicationServices);
+			var activity = mauiContextStub1.GetActivity();
+			mauiContextStub1.Context = new Android.Views.ContextThemeWrapper(activity, Resource.Style.Maui_MainTheme_NoActionBar);
+			Color color = Color.Transparent;
+			await InvokeOnMainThreadAsync(() =>
+			{
+				var initialNightMode = activity.Delegate.LocalNightMode;
+				activity.Delegate.SetLocalNightMode(nightMode);
+				var builder = new AlertDialog.Builder(activity);
+				var alertDialog = builder.Create();
+				alertDialog.Show();
+				var button = alertDialog.GetButton((int)Android.Content.DialogButtonType.Negative);
+				var textColor = button.CurrentTextColor;
+				color = new Color(textColor);
+				activity.Delegate.SetLocalNightMode(initialNightMode);
+				alertDialog.Hide();
+			});
+
+			return color;
+		}
+
+		[Fact]
+		public void AlertDialogButtonColorLightTheme()
+		{
+			var textColor = GetDialogButtonTextColor(AppCompatDelegate.ModeNightNo).Result;
+			Assert.True(textColor.GetBrightness() < 0.5);
+		}
+
+		[Fact]
+		public void AlertDialogButtonColorDarkTheme()
+		{
+			var textColor = GetDialogButtonTextColor(AppCompatDelegate.ModeNightYes).Result;
+			Assert.True(textColor.GetBrightness() > 0.5);
+		}
+	}
+}

--- a/src/Core/src/Handlers/Picker/PickerHandler.Android.cs
+++ b/src/Core/src/Handlers/Picker/PickerHandler.Android.cs
@@ -6,12 +6,13 @@ using Android.Graphics.Drawables;
 using Android.Text;
 using Android.Text.Style;
 using AResource = Android.Resource;
+using AppCompatAlertDialog = AndroidX.AppCompat.App.AlertDialog;
 
 namespace Microsoft.Maui.Handlers
 {
 	public partial class PickerHandler : ViewHandler<IPicker, MauiPicker>
 	{
-		AlertDialog? _dialog;
+		AppCompatAlertDialog? _dialog;
 
 		protected override MauiPicker CreatePlatformView() =>
 			new MauiPicker(Context);
@@ -108,7 +109,7 @@ namespace Microsoft.Maui.Handlers
 		{
 			if (_dialog == null && VirtualView != null)
 			{
-				using (var builder = new AlertDialog.Builder(Context))
+				using (var builder = new AppCompatAlertDialog.Builder(Context))
 				{
 					if (VirtualView.TitleColor == null)
 					{

--- a/src/Core/src/Platform/Android/PickerExtensions.cs
+++ b/src/Core/src/Platform/Android/PickerExtensions.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Maui.Platform
 				platformPicker.Text = picker.GetItem(picker.SelectedIndex);
 		}
 
-		internal static void UpdateFlowDirection(this AlertDialog alertDialog, MauiPicker platformPicker)
+		internal static void UpdateFlowDirection(this AndroidX.AppCompat.App.AlertDialog alertDialog, MauiPicker platformPicker)
 		{
 			var platformLayoutDirection = platformPicker.LayoutDirection;
 

--- a/src/Core/src/Platform/Android/Resources/values/styles.xml
+++ b/src/Core/src/Platform/Android/Resources/values/styles.xml
@@ -11,6 +11,7 @@
         <item name="materialButtonStyle">@style/MauiMaterialButton</item>
         <item name="checkboxStyle">@style/MauiCheckBox</item>
         <item name="android:textAllCaps">false</item>
+        <item name="alertDialogTheme">@style/MauiAlertDialogTheme</item>
     </style>
     <style name="Maui.MainTheme.NoActionBar" parent="Maui.MainTheme">
         <item name="windowActionBar">false</item>
@@ -64,6 +65,10 @@
       <!-- remove all the min sizes as MAUI manages it -->
       <item name="android:minWidth">0dp</item>
       <item name="android:minHeight">0dp</item>
+    </style>
+
+    <style name="MauiAlertDialogTheme" parent="ThemeOverlay.MaterialComponents.MaterialAlertDialog">
+      <item name="colorPrimary">?attr/colorOnSurface</item>
     </style>
 
   <!-- 


### PR DESCRIPTION
### Description

Fix alert dialog button colors in dark mode.
Use ?attr/colorOnSurface for text color in dialogs.
This ensures contrasting color for both dark and light modes.

Use AppCompat version of AlertDialog in picker.
This ensures consistent styling between picker dialog and
alert dialog.

### Fixes

Fixes #15088

### Screenshots

Now dialogs with default Android theme look like this:
| Dark | Light |
| :-: | :-: |
| ![Capture-alertDialog-dark-1](https://github.com/dotnet/maui/assets/6537039/058fd591-107d-44f0-9fbe-803a99ddf602) | ![Capture-alertDialog-light-1](https://github.com/dotnet/maui/assets/6537039/0a2e9ffb-038b-4375-873e-102b63f587f7) |
| ![Capture-alertDialog-light-2](https://github.com/dotnet/maui/assets/6537039/f7af8a4c-c6f4-4f3c-814f-120c30562361)  |![Capture-alertDialog-dark-2](https://github.com/dotnet/maui/assets/6537039/1bffc793-853c-4034-b4e5-67cca4ca0917) |