### PR TITLE
Fix ContentView RTL

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Layout/LayoutTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Layout/LayoutTests.iOS.cs
@@ -3,10 +3,14 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using CoreGraphics;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Hosting;
 using Microsoft.Maui.Platform;
+using Microsoft.VisualBasic;
+using UIKit;
 using Xunit;
 
 namespace Microsoft.Maui.DeviceTests
@@ -161,6 +165,64 @@ namespace Microsoft.Maui.DeviceTests
 
 			Assert.True(view.InputTransparent == !value,
 				$"InputTransparent: {view.InputTransparent}. UserInteractionEnabled: {platformView.UserInteractionEnabled}");
+		}
+
+		async Task WaitForLayout(UIView view, CGRect initialFrame, int timeout) 
+		{
+			int interval = 100;
+
+			while (timeout > 0)
+			{
+				if (view.Frame != initialFrame)
+				{
+					return;
+				}
+
+				await Task.Delay(interval);
+				timeout -= interval;
+			}
+		}
+
+		[Fact]
+		public async Task NestedLayoutsInRTLRemainOnScreen()
+		{
+			EnsureHandlerCreated((builder) =>
+			{
+				builder.ConfigureMauiHandlers(handler =>
+				{
+					handler.AddHandler(typeof(Button), typeof(ButtonHandler));
+					handler.AddHandler(typeof(Layout), typeof(LayoutHandler));
+					handler.AddHandler(typeof(Controls.ContentView), typeof(ContentViewHandler));
+				});
+			});
+
+			var level0 = new Controls.ContentView() { FlowDirection = FlowDirection.RightToLeft};
+			var level1 = new Grid() { HorizontalOptions = LayoutOptions.End, WidthRequest = 200 };
+			var level2 = new Grid() { HorizontalOptions = LayoutOptions.Start, WidthRequest = 200 };
+			var button = new Button() { Text = "Hello", HorizontalOptions = LayoutOptions.Start, WidthRequest = 100 };
+			
+			level0.Content = level1;
+			level1.Add(level2);
+			level2.Add(button);
+
+			await AttachAndRun(level0, async (handler) =>
+			{
+				var root = handler.ToPlatform();
+
+				await WaitForLayout(root, CGRect.Empty, 5000);
+
+				UIKit.UIView nativeView = button.Handler.PlatformView as UIKit.UIView;
+				Assert.NotNull(nativeView);
+
+				// Work our way up the tree and verify that no one
+				// has a negative X position (which would make the view not 
+				// show up on screen)
+				while (nativeView != null)
+				{
+					Assert.True(nativeView.Bounds.X >= 0);
+					nativeView = nativeView.Superview;
+				}
+			});
 		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Layout/LayoutTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Layout/LayoutTests.iOS.cs
@@ -167,7 +167,7 @@ namespace Microsoft.Maui.DeviceTests
 				$"InputTransparent: {view.InputTransparent}. UserInteractionEnabled: {platformView.UserInteractionEnabled}");
 		}
 
-		async Task WaitForLayout(UIView view, CGRect initialFrame, int timeout) 
+		async Task WaitForLayout(UIView view, CGRect initialFrame, int timeout)
 		{
 			int interval = 100;
 
@@ -196,11 +196,11 @@ namespace Microsoft.Maui.DeviceTests
 				});
 			});
 
-			var level0 = new Controls.ContentView() { FlowDirection = FlowDirection.RightToLeft};
+			var level0 = new Controls.ContentView() { FlowDirection = FlowDirection.RightToLeft };
 			var level1 = new Grid() { HorizontalOptions = LayoutOptions.End, WidthRequest = 200 };
 			var level2 = new Grid() { HorizontalOptions = LayoutOptions.Start, WidthRequest = 200 };
 			var button = new Button() { Text = "Hello", HorizontalOptions = LayoutOptions.Start, WidthRequest = 100 };
-			
+
 			level0.Content = level1;
 			level1.Add(level2);
 			level2.Add(button);


### PR DESCRIPTION
### Description of Change

The logic in the iOS platform arrangement handler has faulty logic which sometimes gives child views negative X positions within their parent views; this happens when the flow direction is set to RTL and it makes the child views disappear.

These changes fix the logic to avoid disappearing the views and adds an automated test to guard against this in the future.

### Issues Fixed

Fixes #15095 

