### PR TITLE
[workload] add metadata about .NET 6 EOL

### DIFF
--- a/src/Workload/Microsoft.Maui.Sdk/Sdk/AutoImport.in.props
+++ b/src/Workload/Microsoft.Maui.Sdk/Sdk/AutoImport.in.props
@@ -2,6 +2,10 @@
 <!-- all <ItemGroup/>'s must include $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '@MAUI_DOTNET_VERSION@'))  -->
 <Project>
 
+  <ItemGroup Condition=" ('$(UseMaui)' == 'true' or '$(UseMauiAssets)' == 'true' or '$(UseMauiCore)' == 'true' or '$(UseMauiEssentials)' == 'true') and $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '@MAUI_DOTNET_VERSION@')) ">
+    <EolWorkload Include="maui" Url="https://aka.ms/maui-support-policy" />
+  </ItemGroup>
+
   <ItemDefinitionGroup>
     <MauiXaml>
       <SubType>Designer</SubType>

--- a/src/Workload/Microsoft.Maui.Sdk/Sdk/AutoImport.in.props
+++ b/src/Workload/Microsoft.Maui.Sdk/Sdk/AutoImport.in.props
@@ -2,7 +2,7 @@
 <!-- all <ItemGroup/>'s must include $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '@MAUI_DOTNET_VERSION@'))  -->
 <Project>
 
-  <ItemGroup Condition=" ('$(UseMaui)' == 'true' or '$(UseMauiAssets)' == 'true' or '$(UseMauiCore)' == 'true' or '$(UseMauiEssentials)' == 'true') and $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '@MAUI_DOTNET_VERSION@')) ">
+  <ItemGroup Condition=" ('$(UseMaui)' == 'true' or '$(UseMauiAssets)' == 'true' or '$(UseMauiCore)' == 'true' or '$(UseMauiEssentials)' == 'true') and '$(TargetFrameworkVersion)' != '' and $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '@MAUI_DOTNET_VERSION@')) ">
     <EolWorkload Include="maui" Url="https://aka.ms/maui-support-policy" />
   </ItemGroup>
 


### PR DESCRIPTION
Context: https://aka.ms/maui-support-policy
Context: https://github.com/xamarin/xamarin-android/commit/25cb50d78ac929b03d2ec6f1a4c0a7aeb9bcebc3
Context: https://github.com/dotnet/sdk/pull/32426

dotnet/sdk#32426 adds support for an optional workload to specify that it is no longer supported by adding an item to the `@(EolWorkload)` item group:

    <ItemGroup Condition=" '$(UseMaui)' == 'true' and $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '6.0')) ">
      <EolWorkload Include="maui" Url="https://aka.ms/maui-support-policy" />
    </ItemGroup>

This will cause `dotnet build` to issue a new NETSDK1202 build warning:

    dotnet\sdk\6.0.409\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.EolTargetFrameworks.targets(35,5):
    warning NETSDK1202: The workload 'maui' is out of support and will not receive security updates in the future. Please refer to https://aka.ms/maui-support-policy for more information about the support policy.

I also included the message for any one of `$(UseMaui)`, `$(UseMauiAssets)`, `$(UseMauiCore)`, or `$(UseMauiEssentials)`.