### PR TITLE
Adjust index path for cell reuseid in carouselview

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/iOS/CarouselViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/CarouselViewController.cs
@@ -155,7 +155,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		override string DetermineCellReuseId(NSIndexPath indexPath)
 		{
 			var itemIndex = GetIndexFromIndexPath(indexPath);
-			base.DetermineCellReuseId(NSIndexPath.FromItemSection(itemIndex, 0));
+			return base.DetermineCellReuseId(NSIndexPath.FromItemSection(itemIndex, 0));
 		}
 
 		protected override void RegisterViewTypes()

--- a/src/Controls/src/Core/Handlers/Items/iOS/CarouselViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/CarouselViewController.cs
@@ -135,9 +135,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		protected override UICollectionViewDelegateFlowLayout CreateDelegator() => new CarouselViewDelegator(ItemsViewLayout, this);
 
-#if NET8_0_OR_GREATER
 		[Obsolete("Use DetermineCellReuseId(NSIndexPath indexPath) instead.")]
-#endif
 		protected override string DetermineCellReuseId()
 		{
 			if (Carousel.ItemTemplate != null)
@@ -146,13 +144,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			return base.DetermineCellReuseId();
 		}
 
-
-#if NET8_0_OR_GREATER
-		protected
-#else
-		internal
-#endif
-		override string DetermineCellReuseId(NSIndexPath indexPath)
+		protected override string DetermineCellReuseId(NSIndexPath indexPath)
 		{
 			var itemIndex = GetIndexFromIndexPath(indexPath);
 			return base.DetermineCellReuseId(NSIndexPath.FromItemSection(itemIndex, 0));

--- a/src/Controls/src/Core/Handlers/Items/iOS/CarouselViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/CarouselViewController.cs
@@ -146,6 +146,18 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			return base.DetermineCellReuseId();
 		}
 
+
+#if NET8_0_OR_GREATER
+		protected
+#else
+		internal
+#endif
+		override string DetermineCellReuseId(NSIndexPath indexPath)
+		{
+			var itemIndex = GetIndexFromIndexPath(indexPath);
+			base.DetermineCellReuseId(NSIndexPath.FromItemSection(itemIndex, 0));
+		}
+
 		protected override void RegisterViewTypes()
 		{
 			CollectionView.RegisterClassForCell(typeof(CarouselTemplatedCell), CarouselTemplatedCell.ReuseId);

--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
@@ -341,12 +341,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			}
 		}
 
-#if NET8_0_OR_GREATER
-		protected
-#else
-		internal
-#endif
-		virtual string DetermineCellReuseId(NSIndexPath indexPath)
+		protected virtual string DetermineCellReuseId(NSIndexPath indexPath)
 		{
 			if (ItemsView.ItemTemplate != null)
 			{
@@ -373,9 +368,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				: VerticalDefaultCell.ReuseId;
 		}
 
-#if NET8_0_OR_GREATER
 		[Obsolete("Use DetermineCellReuseId(NSIndexPath indexPath) instead.")]
-#endif
 		protected virtual string DetermineCellReuseId()
 		{
 			if (ItemsView.ItemTemplate != null)

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -30,6 +30,7 @@ static Microsoft.Maui.Controls.Shapes.Matrix.operator ==(Microsoft.Maui.Controls
 override Microsoft.Maui.Controls.View.ChangeVisualState() -> void
 Microsoft.Maui.Controls.Handlers.BoxViewHandler
 Microsoft.Maui.Controls.Handlers.BoxViewHandler.BoxViewHandler() -> void
+~override Microsoft.Maui.Controls.Handlers.Items.CarouselViewController.DetermineCellReuseId(Foundation.NSIndexPath indexPath) -> string
 ~override Microsoft.Maui.Controls.ImageButton.OnPropertyChanged(string propertyName = null) -> void
 ~override Microsoft.Maui.Controls.Handlers.Compatibility.PhoneFlyoutPageRenderer.ViewWillTransitionToSize(CoreGraphics.CGSize toSize, UIKit.IUIViewControllerTransitionCoordinator coordinator) -> void
 ~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRootRenderer.TraitCollectionDidChange(UIKit.UITraitCollection previousTraitCollection) -> void
@@ -91,3 +92,4 @@ Microsoft.Maui.Controls.IValueConverter.ConvertBack(object? value, System.Type! 
 ~static Microsoft.Maui.Controls.GridExtensions.Add(this Microsoft.Maui.Controls.Grid grid, Microsoft.Maui.IView view, int left, int right, int top, int bottom) -> void
 ~static Microsoft.Maui.Controls.GridExtensions.AddWithSpan(this Microsoft.Maui.Controls.Grid grid, Microsoft.Maui.IView view, int row = 0, int column = 0, int rowSpan = 1, int columnSpan = 1) -> void
 *REMOVED*override Microsoft.Maui.Controls.Handlers.Compatibility.PhoneFlyoutPageRenderer.WillRotate(UIKit.UIInterfaceOrientation toInterfaceOrientation, double duration) -> void
+~virtual Microsoft.Maui.Controls.Handlers.Items.ItemsViewController<TItemsView>.DetermineCellReuseId(Foundation.NSIndexPath indexPath) -> string

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -30,6 +30,7 @@ static Microsoft.Maui.Controls.Shapes.Matrix.operator ==(Microsoft.Maui.Controls
 override Microsoft.Maui.Controls.View.ChangeVisualState() -> void
 Microsoft.Maui.Controls.Handlers.BoxViewHandler
 Microsoft.Maui.Controls.Handlers.BoxViewHandler.BoxViewHandler() -> void
+~override Microsoft.Maui.Controls.Handlers.Items.CarouselViewController.DetermineCellReuseId(Foundation.NSIndexPath indexPath) -> string
 ~override Microsoft.Maui.Controls.ImageButton.OnPropertyChanged(string propertyName = null) -> void
 ~override Microsoft.Maui.Controls.Handlers.Compatibility.PhoneFlyoutPageRenderer.ViewWillTransitionToSize(CoreGraphics.CGSize toSize, UIKit.IUIViewControllerTransitionCoordinator coordinator) -> void
 ~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRootRenderer.TraitCollectionDidChange(UIKit.UITraitCollection previousTraitCollection) -> void
@@ -91,3 +92,4 @@ Microsoft.Maui.Controls.IValueConverter.ConvertBack(object? value, System.Type! 
 ~static Microsoft.Maui.Controls.GridExtensions.Add(this Microsoft.Maui.Controls.Grid grid, Microsoft.Maui.IView view, int left, int right, int top, int bottom) -> void
 ~static Microsoft.Maui.Controls.GridExtensions.AddWithSpan(this Microsoft.Maui.Controls.Grid grid, Microsoft.Maui.IView view, int row = 0, int column = 0, int rowSpan = 1, int columnSpan = 1) -> void
 *REMOVED*override Microsoft.Maui.Controls.Handlers.Compatibility.PhoneFlyoutPageRenderer.WillRotate(UIKit.UIInterfaceOrientation toInterfaceOrientation, double duration) -> void
+~virtual Microsoft.Maui.Controls.Handlers.Items.ItemsViewController<TItemsView>.DetermineCellReuseId(Foundation.NSIndexPath indexPath) -> string


### PR DESCRIPTION
Since CarouselView uses a fake number of items for looping effect like android does, we also need to correct the index used in the base items controller to be the actual item index, not the looped one.

This fixes the change missed in #12011 