### PR TITLE
Account for padding when expanding * rows/columns to new sizes

### DIFF
--- a/src/Core/src/Layouts/GridLayoutManager.cs
+++ b/src/Core/src/Layouts/GridLayoutManager.cs
@@ -813,12 +813,12 @@ namespace Microsoft.Maui.Layouts
 
 				if (expandStarRows)
 				{
-					ExpandStarDefinitions(_rows, targetSize.Height, GridMinimumHeight(), _rowSpacing, _rowStarCount);
+					ExpandStarDefinitions(_rows, targetSize.Height - _padding.VerticalThickness, GridMinimumHeight(), _rowSpacing, _rowStarCount);
 				}
 
 				if (expandStarColumns)
 				{
-					ExpandStarDefinitions(_columns, targetSize.Width, GridMinimumWidth(), _columnSpacing, _columnStarCount);
+					ExpandStarDefinitions(_columns, targetSize.Width - _padding.HorizontalThickness, GridMinimumWidth(), _columnSpacing, _columnStarCount);
 				}
 			}
 

--- a/src/Core/tests/UnitTests/Layouts/GridLayoutManagerTests.cs
+++ b/src/Core/tests/UnitTests/Layouts/GridLayoutManagerTests.cs
@@ -2858,5 +2858,55 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			// So view1 should be arranged at an X value of 100 + 300 = 400 
 			AssertArranged(view1, new Rect(400, 0, 100, 100));
 		}
+
+		[Theory, Category(GridStarSizing)]
+		[InlineData(0, 0)]
+		[InlineData(16, 0)]
+		[InlineData(0, 16)]
+		[InlineData(16, 16)]
+		[InlineData(-16, 16)]
+		[InlineData(-16, -16)]
+		[InlineData(16, -16)]
+		public void StarColumnsAccountForPadding(double left, double right)
+		{
+			var grid = CreateGridLayout(columns: "*,48", rows: "200");
+			grid.Width.Returns(200);
+			grid.Padding.Returns(new Thickness(left, 0, right, 0));
+
+			var view0 = CreateTestView(new Size(20, 20));
+			SubstituteChildren(grid, view0);
+			SetLocation(grid, view0, col: 0, row: 0, colSpan: 2);
+
+			MeasureAndArrange(grid, 900, 900);
+
+			// We expect the left edge of the view to be inset by the left padding,
+			// and the width of the view to be the width of the Grid minus all padding
+			AssertArranged(view0, new Rect(left, 0, 200 - left - right, 200));
+		}
+
+		[Theory, Category(GridStarSizing)]
+		[InlineData(0, 0)]
+		[InlineData(16, 0)]
+		[InlineData(0, 16)]
+		[InlineData(16, 16)]
+		[InlineData(-16, 16)]
+		[InlineData(-16, -16)]
+		[InlineData(16, -16)]
+		public void StarRowsAccountForPadding(double top, double bottom)
+		{
+			var grid = CreateGridLayout(rows: "*,48", columns: "200");
+			grid.Height.Returns(200);
+			grid.Padding.Returns(new Thickness(0, top, 0, bottom));
+
+			var view0 = CreateTestView(new Size(20, 20));
+			SubstituteChildren(grid, view0);
+			SetLocation(grid, view0, col: 0, row: 0, rowSpan: 2);
+
+			MeasureAndArrange(grid, 900, 900);
+
+			// We expect the top edge of the view to be inset by the top padding,
+			// and the height of the view to be the height of the Grid minus all padding
+			AssertArranged(view0, new Rect(0, top, 200, 200 - top - bottom));
+		}
 	}
 }


### PR DESCRIPTION
### Description of Change

The Grid is accounting for padding when handling the initial measure, but was not accounting for it when expanding * rows/columns to the target size on Arrange. This causes some items to expand to a larger size than they should, and the expansion can ripple to incorrectly offset items in other rows/columns.

These changes account for the padding, and add tests to prevent this issue in the future. 

### Issues Fixed

Fixes #15018
