### PR TITLE
Use Frame command to recalc span bounds

### DIFF
--- a/src/Controls/src/Core/Label/Label.Android.cs
+++ b/src/Controls/src/Core/Label/Label.Android.cs
@@ -1,6 +1,8 @@
 #nullable disable
 using System;
 using Android.Text;
+using Android.Widget;
+using AndroidX.AppCompat.Widget;
 using Microsoft.Maui.Controls.Platform;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
@@ -9,30 +11,6 @@ namespace Microsoft.Maui.Controls
 {
 	public partial class Label
 	{
-		MauiTextView _mauiTextView;
-
-		private protected override void OnHandlerChangedCore()
-		{
-			base.OnHandlerChangedCore();
-
-			if (Handler != null)
-			{
-				if (Handler is LabelHandler labelHandler && labelHandler.PlatformView is MauiTextView mauiTextView)
-				{
-					_mauiTextView = mauiTextView;
-					_mauiTextView.LayoutChanged += OnLayoutChanged;
-				}
-			}
-			else
-			{
-				if (_mauiTextView != null)
-				{
-					_mauiTextView.LayoutChanged -= OnLayoutChanged;
-					_mauiTextView = null;
-				}
-			}
-		}
-
 		public static void MapTextType(LabelHandler handler, Label label) => MapTextType((ILabelHandler)handler, label);
 		public static void MapText(LabelHandler handler, Label label) => MapText((ILabelHandler)handler, label);
 		public static void MapLineBreakMode(LabelHandler handler, Label label) => MapLineBreakMode((ILabelHandler)handler, label);
@@ -58,26 +36,13 @@ namespace Microsoft.Maui.Controls
 			handler.PlatformView?.UpdateMaxLines(label);
 		}
 
-		void OnLayoutChanged(object sender, LayoutChangedEventArgs args)
+		internal static void MapFrame(ILabelHandler handler, Label label, object args)
 		{
-			if (Handler is not ILabelHandler labelHandler)
-				return;
-
-			var platformView = labelHandler.PlatformView;
-			var virtualView = labelHandler.VirtualView as Label;
-
-			if (platformView == null || virtualView == null)
-				return;
-
-			var text = virtualView.FormattedText;
-
 			// don't attempt to layout if this is not a formatted text WITH some text
-			if (virtualView.TextType != TextType.Text || text?.Spans == null || text.Spans.Count == 0)
+			if (label.TextType != TextType.Text || label.FormattedText is not FormattedString text || text?.Spans == null || text.Spans.Count == 0)
 				return;
 
-			var spannableString = virtualView.ToSpannableString();
-
-			platformView.RecalculateSpanPositions(virtualView, spannableString, new SizeRequest(new Size(args.Right - args.Left, args.Bottom - args.Top)));
+			handler.PlatformView?.RecalculateSpanPositions(label.Padding, text);
 		}
 	}
 }

--- a/src/Controls/src/Core/Label/Label.Mapper.cs
+++ b/src/Controls/src/Core/Label/Label.Mapper.cs
@@ -32,6 +32,10 @@ namespace Microsoft.Maui.Controls
 #endif
 			LabelHandler.Mapper.ReplaceMapping<Label, ILabelHandler>(nameof(Label.LineBreakMode), MapLineBreakMode);
 			LabelHandler.Mapper.ReplaceMapping<Label, ILabelHandler>(nameof(Label.MaxLines), MapMaxLines);
+
+#if ANDROID
+			LabelHandler.CommandMapper.AppendToMapping<Label, ILabelHandler>(nameof(Frame), MapFrame);
+#endif
 		}
 	}
 }

--- a/src/Core/src/Handlers/Label/LabelHandler.Android.cs
+++ b/src/Core/src/Handlers/Label/LabelHandler.Android.cs
@@ -15,54 +15,54 @@ namespace Microsoft.Maui.Handlers
 			base.PlatformArrange(frame);
 		}
 
-		internal static void MapBackground(ILabelHandler handler, ILabel label)
+		public static partial void MapBackground(ILabelHandler handler, ILabel label)
 		{
 			handler.PlatformView?.UpdateBackground(label);
 		}
 
-		public static void MapText(ILabelHandler handler, ILabel label)
+		public static partial void MapText(ILabelHandler handler, ILabel label)
 		{
 			handler.PlatformView?.UpdateTextPlainText(label);
 		}
 
-		public static void MapTextColor(ILabelHandler handler, ILabel label)
+		public static partial void MapTextColor(ILabelHandler handler, ILabel label)
 		{
 			handler.PlatformView?.UpdateTextColor(label);
 		}
 
-		public static void MapCharacterSpacing(ILabelHandler handler, ILabel label)
+		public static partial void MapCharacterSpacing(ILabelHandler handler, ILabel label)
 		{
 			handler.PlatformView?.UpdateCharacterSpacing(label);
 		}
 
-		public static void MapHorizontalTextAlignment(ILabelHandler handler, ILabel label)
+		public static partial void MapHorizontalTextAlignment(ILabelHandler handler, ILabel label)
 		{
 			handler.PlatformView?.UpdateHorizontalTextAlignment(label);
 		}
 
-		public static void MapVerticalTextAlignment(ILabelHandler handler, ILabel label)
+		public static partial void MapVerticalTextAlignment(ILabelHandler handler, ILabel label)
 		{
 			handler.PlatformView?.UpdateVerticalTextAlignment(label);
 		}
 
-		public static void MapPadding(ILabelHandler handler, ILabel label)
+		public static partial void MapPadding(ILabelHandler handler, ILabel label)
 		{
 			handler.PlatformView?.UpdatePadding(label);
 		}
 
-		public static void MapTextDecorations(ILabelHandler handler, ILabel label)
+		public static partial void MapTextDecorations(ILabelHandler handler, ILabel label)
 		{
 			handler.PlatformView?.UpdateTextDecorations(label);
 		}
 
-		public static void MapFont(ILabelHandler handler, ILabel label)
+		public static partial void MapFont(ILabelHandler handler, ILabel label)
 		{
 			var fontManager = handler.GetRequiredService<IFontManager>();
 
 			handler.PlatformView?.UpdateFont(label, fontManager);
 		}
 
-		public static void MapLineHeight(ILabelHandler handler, ILabel label)
+		public static partial void MapLineHeight(ILabelHandler handler, ILabel label)
 		{
 			handler.PlatformView?.UpdateLineHeight(label);
 		}

--- a/src/Core/src/Handlers/Label/LabelHandler.Standard.cs
+++ b/src/Core/src/Handlers/Label/LabelHandler.Standard.cs
@@ -6,15 +6,15 @@ namespace Microsoft.Maui.Handlers
 	{
 		protected override object CreatePlatformView() => throw new NotImplementedException();
 
-		public static void MapText(ILabelHandler handler, ILabel label) { }
-		public static void MapTextColor(ILabelHandler handler, ILabel label) { }
-		public static void MapCharacterSpacing(ILabelHandler handler, ILabel label) { }
-		public static void MapFont(ILabelHandler handler, ILabel label) { }
-		public static void MapHorizontalTextAlignment(ILabelHandler handler, ILabel label) { }
-		public static void MapVerticalTextAlignment(ILabelHandler handler, ILabel label) { }
-		public static void MapTextDecorations(ILabelHandler handler, ILabel label) { }
-		public static void MapMaxLines(ILabelHandler handler, ILabel label) { }
-		public static void MapPadding(ILabelHandler handler, ILabel label) { }
-		public static void MapLineHeight(ILabelHandler handler, ILabel label) { }
+		public static partial void MapBackground(ILabelHandler handler, ILabel label) { }
+		public static partial void MapText(ILabelHandler handler, ILabel label) { }
+		public static partial void MapTextColor(ILabelHandler handler, ILabel label) { }
+		public static partial void MapCharacterSpacing(ILabelHandler handler, ILabel label) { }
+		public static partial void MapFont(ILabelHandler handler, ILabel label) { }
+		public static partial void MapHorizontalTextAlignment(ILabelHandler handler, ILabel label) { }
+		public static partial void MapVerticalTextAlignment(ILabelHandler handler, ILabel label) { }
+		public static partial void MapTextDecorations(ILabelHandler handler, ILabel label) { }
+		public static partial void MapPadding(ILabelHandler handler, ILabel label) { }
+		public static partial void MapLineHeight(ILabelHandler handler, ILabel label) { }
 	}
 }

--- a/src/Core/src/Handlers/Label/LabelHandler.Tizen.cs
+++ b/src/Core/src/Handlers/Label/LabelHandler.Tizen.cs
@@ -6,59 +6,59 @@ namespace Microsoft.Maui.Handlers
 	{
 		protected override Label CreatePlatformView() => new();
 
-		public static void MapBackground(ILabelHandler handler, ILabel label)
+		public static partial void MapBackground(ILabelHandler handler, ILabel label)
 		{
 			handler.UpdateValue(nameof(handler.ContainerView));
 			handler.ToPlatform()?.UpdateBackground(label);
 		}
 
-		public static void MapText(ILabelHandler handler, ILabel label)
+		public static partial void MapText(ILabelHandler handler, ILabel label)
 		{
 			handler.PlatformView?.UpdateText(label);
 		}
 
-		public static void MapTextColor(ILabelHandler handler, ILabel label)
+		public static partial void MapTextColor(ILabelHandler handler, ILabel label)
 		{
 			handler.PlatformView?.UpdateTextColor(label);
 		}
 
-		public static void MapHorizontalTextAlignment(ILabelHandler handler, ILabel label)
+		public static partial void MapHorizontalTextAlignment(ILabelHandler handler, ILabel label)
 		{
 			handler.PlatformView?.UpdateHorizontalTextAlignment(label);
 		}
 
-		public static void MapVerticalTextAlignment(ILabelHandler handler, ILabel label)
+		public static partial void MapVerticalTextAlignment(ILabelHandler handler, ILabel label)
 		{
 			handler.PlatformView?.UpdateVerticalTextAlignment(label);
 		}
 
-		public static void MapTextDecorations(ILabelHandler handler, ILabel label)
+		public static partial void MapTextDecorations(ILabelHandler handler, ILabel label)
 		{
 			handler.PlatformView?.UpdateTextDecorations(label);
 		}
 
-		public static void MapFont(ILabelHandler handler, ILabel label)
+		public static partial void MapFont(ILabelHandler handler, ILabel label)
 		{
 			var fontManager = handler.GetRequiredService<IFontManager>();
 			handler.PlatformView?.UpdateFont(label, fontManager);
 		}
 
-		public static void MapShadow(ILabelHandler handler, ILabel label)
+		public static partial void MapShadow(ILabelHandler handler, ILabel label)
 		{
 			handler.PlatformView?.UpdateShadow(label);
 		}
 
-		public static void MapCharacterSpacing(ILabelHandler handler, ILabel label)
+		public static partial void MapCharacterSpacing(ILabelHandler handler, ILabel label)
 		{
 			handler.PlatformView.UpdateCharacterSpacing(label);
 		}
 
-		public static void MapLineHeight(ILabelHandler handler, ILabel label)
+		public static partial void MapLineHeight(ILabelHandler handler, ILabel label)
 		{
 			handler.PlatformView.UpdateLineHeight(label);
 		}
 
 		[MissingMapper]
-		public static void MapPadding(ILabelHandler handler, ILabel label) { }
+		public static partial void MapPadding(ILabelHandler handler, ILabel label) { }
 	}
 }

--- a/src/Core/src/Handlers/Label/LabelHandler.Windows.cs
+++ b/src/Core/src/Handlers/Label/LabelHandler.Windows.cs
@@ -29,58 +29,54 @@ namespace Microsoft.Maui.Handlers
 			MapHeight(this, VirtualView);
 		}
 
-		public static void MapHeight(ILabelHandler handler, ILabel view) =>
+		public static partial void MapHeight(ILabelHandler handler, ILabel view) =>
 			// VerticalAlignment only works when the container's Height is set and the child's Height is Auto. The child's Height
 			// is set to Auto when the container is introduced
 			handler.ToPlatform().UpdateHeight(view);
 
-		public static void MapBackground(ILabelHandler handler, ILabel label)
+		public static partial void MapBackground(ILabelHandler handler, ILabel label)
 		{
 			handler.UpdateValue(nameof(IViewHandler.ContainerView));
 
 			handler.ToPlatform().UpdateBackground(label);
 		}
 
-		public static void MapOpacity(ILabelHandler handler, ILabel label)
-		{
-			handler.UpdateValue(nameof(IViewHandler.ContainerView));
-			handler.PlatformView.UpdateOpacity(label);
-			handler.ToPlatform().UpdateOpacity(label);
-		}
+		public static void MapOpacity(ILabelHandler handler, ILabel label) =>
+			ViewHandler.MapOpacity(handler, label);
 
-		public static void MapText(ILabelHandler handler, ILabel label) =>
+		public static partial void MapText(ILabelHandler handler, ILabel label) =>
 			handler.PlatformView?.UpdateText(label);
 
-		public static void MapTextColor(ILabelHandler handler, ILabel label) =>
+		public static partial void MapTextColor(ILabelHandler handler, ILabel label) =>
 			handler.PlatformView?.UpdateTextColor(label);
 
-		public static void MapCharacterSpacing(ILabelHandler handler, ILabel label) =>
+		public static partial void MapCharacterSpacing(ILabelHandler handler, ILabel label) =>
 			handler.PlatformView?.UpdateCharacterSpacing(label);
 
-		public static void MapFont(ILabelHandler handler, ILabel label)
+		public static partial void MapFont(ILabelHandler handler, ILabel label)
 		{
 			var fontManager = handler.GetRequiredService<IFontManager>();
 
 			handler.PlatformView?.UpdateFont(label, fontManager);
 		}
 
-		public static void MapHorizontalTextAlignment(ILabelHandler handler, ILabel label) =>
+		public static partial void MapHorizontalTextAlignment(ILabelHandler handler, ILabel label) =>
 			handler.PlatformView?.UpdateHorizontalTextAlignment(label);
 
-		public static void MapVerticalTextAlignment(ILabelHandler handler, ILabel label)
+		public static partial void MapVerticalTextAlignment(ILabelHandler handler, ILabel label)
 		{
 			handler.UpdateValue(nameof(IViewHandler.ContainerView));
 
 			handler.PlatformView?.UpdateVerticalTextAlignment(label);
 		}
 
-		public static void MapTextDecorations(ILabelHandler handler, ILabel label) =>
+		public static partial void MapTextDecorations(ILabelHandler handler, ILabel label) =>
 			handler.PlatformView?.UpdateTextDecorations(label);
 
-		public static void MapPadding(ILabelHandler handler, ILabel label) =>
+		public static partial void MapPadding(ILabelHandler handler, ILabel label) =>
 			handler.PlatformView?.UpdatePadding(label);
 
-		public static void MapLineHeight(ILabelHandler handler, ILabel label) =>
+		public static partial void MapLineHeight(ILabelHandler handler, ILabel label) =>
 			handler.PlatformView?.UpdateLineHeight(label);
 	}
 }

--- a/src/Core/src/Handlers/Label/LabelHandler.cs
+++ b/src/Core/src/Handlers/Label/LabelHandler.cs
@@ -13,21 +13,21 @@ using PlatformView = System.Object;
 
 namespace Microsoft.Maui.Handlers
 {
+	/// <summary>
+	/// Represents the view handler for the abstract <see cref="ILabel"/> view and its platform-specific implementation.
+	/// </summary>
+	/// <seealso href="https://learn.microsoft.com/dotnet/maui/user-interface/handlers/">Conceptual documentation on handlers</seealso>
 	public partial class LabelHandler : ILabelHandler
 	{
 		public static IPropertyMapper<ILabel, ILabelHandler> Mapper = new PropertyMapper<ILabel, ILabelHandler>(ViewHandler.ViewMapper)
 		{
-#if IOS || TIZEN
-			[nameof(ILabel.Background)] = MapBackground,
-			[nameof(ILabel.Opacity)] = MapOpacity,
-#elif WINDOWS
-			[nameof(ILabel.Background)] = MapBackground,
+#if WINDOWS
 			[nameof(ILabel.Height)] = MapHeight,
-			[nameof(ILabel.Opacity)] = MapOpacity,
 #endif
 #if TIZEN
 			[nameof(ILabel.Shadow)] = MapShadow,
 #endif
+			[nameof(ILabel.Background)] = MapBackground,
 			[nameof(ITextStyle.CharacterSpacing)] = MapCharacterSpacing,
 			[nameof(ITextStyle.Font)] = MapFont,
 			[nameof(ITextAlignment.HorizontalTextAlignment)] = MapHorizontalTextAlignment,
@@ -37,9 +37,6 @@ namespace Microsoft.Maui.Handlers
 			[nameof(ILabel.Text)] = MapText,
 			[nameof(ITextStyle.TextColor)] = MapTextColor,
 			[nameof(ILabel.TextDecorations)] = MapTextDecorations,
-#if ANDROID
-			[nameof(ILabel.Background)] = MapBackground,
-#endif
 		};
 
 		public static CommandMapper<ILabel, ILabelHandler> CommandMapper = new(ViewCommandMapper)
@@ -63,5 +60,93 @@ namespace Microsoft.Maui.Handlers
 		ILabel ILabelHandler.VirtualView => VirtualView;
 
 		PlatformView ILabelHandler.PlatformView => PlatformView;
+
+#if WINDOWS
+		/// <summary>
+		/// Maps the abstract <see cref="IView.Height"/> property to the platform-specific implementations.
+		/// </summary>
+		/// <param name="handler">The associated handler.</param>
+		/// <param name="view">The associated <see cref="ILabel"/> instance.</param>
+		public static partial void MapHeight(ILabelHandler handler, ILabel view);
+#endif
+
+#if TIZEN
+		/// <summary>
+		/// Maps the abstract <see cref="IView.Shadow"/> property to the platform-specific implementations.
+		/// </summary>
+		/// <param name="handler">The associated handler.</param>
+		/// <param name="label">The associated <see cref="ILabel"/> instance.</param>
+		public static partial void MapShadow(ILabelHandler handler, ILabel label);
+#endif
+
+		/// <summary>
+		/// Maps the abstract <see cref="IView.Background"/> property to the platform-specific implementations.
+		/// </summary>
+		/// <param name="handler">The associated handler.</param>
+		/// <param name="label">The associated <see cref="ILabel"/> instance.</param>
+		public static partial void MapBackground(ILabelHandler handler, ILabel label);
+
+		/// <summary>
+		/// Maps the abstract <see cref="IText.Text"/> property to the platform-specific implementations.
+		/// </summary>
+		/// <param name="handler">The associated handler.</param>
+		/// <param name="label">The associated <see cref="ILabel"/> instance.</param>
+		public static partial void MapText(ILabelHandler handler, ILabel label);
+
+		/// <summary>
+		/// Maps the abstract <see cref="ITextStyle.TextColor"/> property to the platform-specific implementations.
+		/// </summary>
+		/// <param name="handler">The associated handler.</param>
+		/// <param name="label">The associated <see cref="ILabel"/> instance.</param>
+		public static partial void MapTextColor(ILabelHandler handler, ILabel label);
+
+		/// <summary>
+		/// Maps the abstract <see cref="ITextStyle.CharacterSpacing"/> property to the platform-specific implementations.
+		/// </summary>
+		/// <param name="handler">The associated handler.</param>
+		/// <param name="label">The associated <see cref="ILabel"/> instance.</param>
+		public static partial void MapCharacterSpacing(ILabelHandler handler, ILabel label);
+
+		/// <summary>
+		/// Maps the abstract <see cref="ITextStyle.Font"/> property to the platform-specific implementations.
+		/// </summary>
+		/// <param name="handler">The associated handler.</param>
+		/// <param name="label">The associated <see cref="ILabel"/> instance.</param>
+		public static partial void MapFont(ILabelHandler handler, ILabel label);
+
+		/// <summary>
+		/// Maps the abstract <see cref="ITextAlignment.HorizontalTextAlignment"/> property to the platform-specific implementations.
+		/// </summary>
+		/// <param name="handler">The associated handler.</param>
+		/// <param name="label">The associated <see cref="ILabel"/> instance.</param>
+		public static partial void MapHorizontalTextAlignment(ILabelHandler handler, ILabel label);
+
+		/// <summary>
+		/// Maps the abstract <see cref="ITextAlignment.VerticalTextAlignment"/> property to the platform-specific implementations.
+		/// </summary>
+		/// <param name="handler">The associated handler.</param>
+		/// <param name="label">The associated <see cref="ILabel"/> instance.</param>
+		public static partial void MapVerticalTextAlignment(ILabelHandler handler, ILabel label);
+
+		/// <summary>
+		/// Maps the abstract <see cref="ILabel.TextDecorations"/> property to the platform-specific implementations.
+		/// </summary>
+		/// <param name="handler">The associated handler.</param>
+		/// <param name="label">The associated <see cref="ILabel"/> instance.</param>
+		public static partial void MapTextDecorations(ILabelHandler handler, ILabel label);
+
+		/// <summary>
+		/// Maps the abstract <see cref="IPadding.Padding"/> property to the platform-specific implementations.
+		/// </summary>
+		/// <param name="handler">The associated handler.</param>
+		/// <param name="label">The associated <see cref="ILabel"/> instance.</param>
+		public static partial void MapPadding(ILabelHandler handler, ILabel label);
+
+		/// <summary>
+		/// Maps the abstract <see cref="ILabel.LineHeight"/> property to the platform-specific implementations.
+		/// </summary>
+		/// <param name="handler">The associated handler.</param>
+		/// <param name="label">The associated <see cref="ILabel"/> instance.</param>
+		public static partial void MapLineHeight(ILabelHandler handler, ILabel label);
 	}
 }

--- a/src/Core/src/Handlers/Label/LabelHandler.iOS.cs
+++ b/src/Core/src/Handlers/Label/LabelHandler.iOS.cs
@@ -13,14 +13,14 @@ namespace Microsoft.Maui.Handlers
 			VirtualView?.Background != null ||
 			base.NeedsContainer;
 
-		public static void MapBackground(ILabelHandler handler, ILabel label)
+		public static partial void MapBackground(ILabelHandler handler, ILabel label)
 		{
 			handler.UpdateValue(nameof(IViewHandler.ContainerView));
 
 			handler.ToPlatform().UpdateBackground(label);
 		}
 
-		public static void MapText(ILabelHandler handler, ILabel label)
+		public static partial void MapText(ILabelHandler handler, ILabel label)
 		{
 			handler.PlatformView?.UpdateTextPlainText(label);
 
@@ -28,44 +28,44 @@ namespace Microsoft.Maui.Handlers
 			MapFormatting(handler, label);
 		}
 
-		public static void MapTextColor(ILabelHandler handler, ILabel label)
+		public static partial void MapTextColor(ILabelHandler handler, ILabel label)
 		{
 			handler.PlatformView?.UpdateTextColor(label);
 		}
 
-		public static void MapCharacterSpacing(ILabelHandler handler, ILabel label)
+		public static partial void MapCharacterSpacing(ILabelHandler handler, ILabel label)
 		{
 			handler.PlatformView?.UpdateCharacterSpacing(label);
 		}
 
-		public static void MapHorizontalTextAlignment(ILabelHandler handler, ILabel label)
+		public static partial void MapHorizontalTextAlignment(ILabelHandler handler, ILabel label)
 		{
 			handler.PlatformView?.UpdateHorizontalTextAlignment(label);
 		}
 
-		public static void MapVerticalTextAlignment(ILabelHandler handler, ILabel label)
+		public static partial void MapVerticalTextAlignment(ILabelHandler handler, ILabel label)
 		{
 			handler.PlatformView?.UpdateVerticalTextAlignment(label);
 		}
 
-		public static void MapPadding(ILabelHandler handler, ILabel label)
+		public static partial void MapPadding(ILabelHandler handler, ILabel label)
 		{
 			handler.PlatformView?.UpdatePadding(label);
 		}
 
-		public static void MapTextDecorations(ILabelHandler handler, ILabel label)
+		public static partial void MapTextDecorations(ILabelHandler handler, ILabel label)
 		{
 			handler.PlatformView?.UpdateTextDecorations(label);
 		}
 
-		public static void MapFont(ILabelHandler handler, ILabel label)
+		public static partial void MapFont(ILabelHandler handler, ILabel label)
 		{
 			var fontManager = handler.GetRequiredService<IFontManager>();
 
 			handler.PlatformView?.UpdateFont(label, fontManager);
 		}
 
-		public static void MapLineHeight(ILabelHandler handler, ILabel label)
+		public static partial void MapLineHeight(ILabelHandler handler, ILabel label)
 		{
 			handler.PlatformView?.UpdateLineHeight(label);
 		}

--- a/src/Core/src/Platform/Android/LayoutChangedEventArgs.cs
+++ b/src/Core/src/Platform/Android/LayoutChangedEventArgs.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.ComponentModel;
+
+namespace Microsoft.Maui.Platform
+{
+	/// <summary>
+	/// This type is for internal use only by the .NET MAUI framework.
+	/// </summary>
+	[EditorBrowsable(EditorBrowsableState.Never)]
+	public class LayoutChangedEventArgs : EventArgs
+	{
+		public LayoutChangedEventArgs()
+		{
+
+		}
+
+		public LayoutChangedEventArgs(int l, int t, int r, int b)
+		{
+			Left = l;
+			Top = t;
+			Right = r;
+			Bottom = b;
+		}
+
+		public int Left { get; set; }
+		public int Top { get; set; }
+		public int Right { get; set; }
+		public int Bottom { get; set; }
+	}
+}

--- a/src/Core/src/Platform/Android/MauiTextView.cs
+++ b/src/Core/src/Platform/Android/MauiTextView.cs
@@ -1,43 +1,17 @@
-﻿using System;
-using Android.Content;
+﻿using Android.Content;
 using AndroidX.AppCompat.Widget;
 
 namespace Microsoft.Maui.Platform
 {
+	/// <summary>
+	/// This type extends the features of the base AndroidX AppCompatTextView with
+	/// additional features requried by .NET MAUI.
+	/// </summary>
 	public class MauiTextView : AppCompatTextView
 	{
+		/// <inheritdoc/>
 		public MauiTextView(Context context) : base(context)
 		{
 		}
-
-		internal event EventHandler<LayoutChangedEventArgs>? LayoutChanged;
-
-		protected override void OnLayout(bool changed, int l, int t, int r, int b)
-		{
-			base.OnLayout(changed, l, t, r, b);
-
-			LayoutChanged?.Invoke(this, new LayoutChangedEventArgs(l, t, r, b));
-		}
-	}
-
-	public class LayoutChangedEventArgs : EventArgs
-	{
-		public LayoutChangedEventArgs()
-		{
-
-		}
-
-		public LayoutChangedEventArgs(int l, int t, int r, int b)
-		{
-			Left = l;
-			Top = t;
-			Right = r;
-			Bottom = b;
-		}
-
-		public int Left { get; set; }
-		public int Top { get; set; }
-		public int Right { get; set; }
-		public int Bottom { get; set; }
 	}
 }

--- a/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -90,6 +90,7 @@ static Microsoft.Maui.GridLength.operator ==(Microsoft.Maui.GridLength left, Mic
 static Microsoft.Maui.Handlers.EditorHandler.MapIsSpellCheckEnabled(Microsoft.Maui.Handlers.IEditorHandler! handler, Microsoft.Maui.IEditor! editor) -> void
 static Microsoft.Maui.Handlers.EntryHandler.MapIsSpellCheckEnabled(Microsoft.Maui.Handlers.IEntryHandler! handler, Microsoft.Maui.IEntry! entry) -> void
 static Microsoft.Maui.Handlers.ImageButtonHandler.MapBackground(Microsoft.Maui.Handlers.IImageButtonHandler! handler, Microsoft.Maui.IImageButton! imageButton) -> void
+static Microsoft.Maui.Handlers.LabelHandler.MapBackground(Microsoft.Maui.Handlers.ILabelHandler! handler, Microsoft.Maui.ILabel! label) -> void
 static Microsoft.Maui.Handlers.SearchBarHandler.MapFocus(Microsoft.Maui.Handlers.ISearchBarHandler! handler, Microsoft.Maui.ISearchBar! searchBar, object? args) -> void
 static Microsoft.Maui.Handlers.SearchBarHandler.MapIsSpellCheckEnabled(Microsoft.Maui.Handlers.ISearchBarHandler! handler, Microsoft.Maui.ISearchBar! searchBar) -> void
 static Microsoft.Maui.Handlers.StepperHandler.MapIsEnabled(Microsoft.Maui.Handlers.IStepperHandler! handler, Microsoft.Maui.IStepper! stepper) -> void

--- a/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -26,6 +26,7 @@ Microsoft.Maui.KeyboardAcceleratorModifiers.None = 0 -> Microsoft.Maui.KeyboardA
 Microsoft.Maui.KeyboardAcceleratorModifiers.Shift = 1 -> Microsoft.Maui.KeyboardAcceleratorModifiers
 Microsoft.Maui.KeyboardAcceleratorModifiers.Windows = 16 -> Microsoft.Maui.KeyboardAcceleratorModifiers
 Microsoft.Maui.Layouts.FlexBasis.Equals(Microsoft.Maui.Layouts.FlexBasis other) -> bool
+*REMOVED*override Microsoft.Maui.Platform.MauiTextView.OnLayout(bool changed, int l, int t, int r, int b) -> void
 Microsoft.Maui.Platform.IImageSourcePartSetter
 Microsoft.Maui.Platform.IImageSourcePartSetter.Handler.get -> Microsoft.Maui.IElementHandler?
 Microsoft.Maui.Platform.IImageSourcePartSetter.ImageSourcePart.get -> Microsoft.Maui.IImageSourcePart?

--- a/src/Core/src/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -51,6 +51,7 @@ static Microsoft.Maui.GridLength.operator !=(Microsoft.Maui.GridLength left, Mic
 static Microsoft.Maui.GridLength.operator ==(Microsoft.Maui.GridLength left, Microsoft.Maui.GridLength right) -> bool
 static Microsoft.Maui.Handlers.EditorHandler.MapIsSpellCheckEnabled(Microsoft.Maui.Handlers.IEditorHandler! handler, Microsoft.Maui.IEditor! editor) -> void
 static Microsoft.Maui.Handlers.EntryHandler.MapIsSpellCheckEnabled(Microsoft.Maui.Handlers.IEntryHandler! handler, Microsoft.Maui.IEntry! entry) -> void
+static Microsoft.Maui.Handlers.LabelHandler.MapBackground(Microsoft.Maui.Handlers.ILabelHandler! handler, Microsoft.Maui.ILabel! label) -> void
 static Microsoft.Maui.Handlers.SearchBarHandler.MapIsSpellCheckEnabled(Microsoft.Maui.IViewHandler! handler, Microsoft.Maui.ISearchBar! searchBar) -> void
 static Microsoft.Maui.Hosting.MauiHandlersCollectionExtensions.AddHandler<TType>(this Microsoft.Maui.Hosting.IMauiHandlersCollection! handlersCollection, System.Func<System.IServiceProvider!, Microsoft.Maui.IElementHandler!>! handlerImplementationFactory) -> Microsoft.Maui.Hosting.IMauiHandlersCollection!
 static Microsoft.Maui.Hosting.MauiHandlersCollectionExtensions.TryAddHandler<TType>(this Microsoft.Maui.Hosting.IMauiHandlersCollection! handlersCollection, System.Func<System.IServiceProvider!, Microsoft.Maui.IElementHandler!>! handlerImplementationFactory) -> Microsoft.Maui.Hosting.IMauiHandlersCollection!
@@ -80,3 +81,4 @@ virtual Microsoft.Maui.Handlers.ButtonHandler.ImageSourceLoader.get -> Microsoft
 virtual Microsoft.Maui.Handlers.ImageButtonHandler.SourceLoader.get -> Microsoft.Maui.Platform.ImageSourcePartLoader!
 virtual Microsoft.Maui.Handlers.ImageHandler.SourceLoader.get -> Microsoft.Maui.Platform.ImageSourcePartLoader!
 virtual Microsoft.Maui.Handlers.SwipeItemMenuItemHandler.SourceLoader.get -> Microsoft.Maui.Platform.ImageSourcePartLoader!
+*REMOVED*static Microsoft.Maui.Handlers.LabelHandler.MapMaxLines(Microsoft.Maui.Handlers.ILabelHandler! handler, Microsoft.Maui.ILabel! label) -> void

--- a/src/Core/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -47,6 +47,7 @@ static Microsoft.Maui.GridLength.operator !=(Microsoft.Maui.GridLength left, Mic
 static Microsoft.Maui.GridLength.operator ==(Microsoft.Maui.GridLength left, Microsoft.Maui.GridLength right) -> bool
 static Microsoft.Maui.Handlers.EditorHandler.MapIsSpellCheckEnabled(Microsoft.Maui.Handlers.IEditorHandler! handler, Microsoft.Maui.IEditor! editor) -> void
 static Microsoft.Maui.Handlers.EntryHandler.MapIsSpellCheckEnabled(Microsoft.Maui.Handlers.IEntryHandler! handler, Microsoft.Maui.IEntry! entry) -> void
+static Microsoft.Maui.Handlers.LabelHandler.MapBackground(Microsoft.Maui.Handlers.ILabelHandler! handler, Microsoft.Maui.ILabel! label) -> void
 static Microsoft.Maui.Handlers.SearchBarHandler.MapIsSpellCheckEnabled(Microsoft.Maui.IViewHandler! handler, Microsoft.Maui.ISearchBar! searchBar) -> void
 static Microsoft.Maui.Hosting.MauiHandlersCollectionExtensions.AddHandler<TType>(this Microsoft.Maui.Hosting.IMauiHandlersCollection! handlersCollection, System.Func<System.IServiceProvider!, Microsoft.Maui.IElementHandler!>! handlerImplementationFactory) -> Microsoft.Maui.Hosting.IMauiHandlersCollection!
 static Microsoft.Maui.Hosting.MauiHandlersCollectionExtensions.TryAddHandler<TType>(this Microsoft.Maui.Hosting.IMauiHandlersCollection! handlersCollection, System.Func<System.IServiceProvider!, Microsoft.Maui.IElementHandler!>! handlerImplementationFactory) -> Microsoft.Maui.Hosting.IMauiHandlersCollection!
@@ -80,3 +81,4 @@ virtual Microsoft.Maui.Handlers.ImageButtonHandler.SourceLoader.get -> Microsoft
 virtual Microsoft.Maui.Handlers.ImageHandler.SourceLoader.get -> Microsoft.Maui.Platform.ImageSourcePartLoader!
 *REMOVED*Microsoft.Maui.Handlers.SwipeItemMenuItemHandler.SourceLoader.get -> Microsoft.Maui.Platform.ImageSourcePartLoader!
 virtual Microsoft.Maui.Handlers.SwipeItemMenuItemHandler.SourceLoader.get -> Microsoft.Maui.Platform.ImageSourcePartLoader!
+*REMOVED*static Microsoft.Maui.Handlers.LabelHandler.MapMaxLines(Microsoft.Maui.Handlers.ILabelHandler! handler, Microsoft.Maui.ILabel! label) -> void

--- a/src/Core/src/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -51,6 +51,7 @@ static Microsoft.Maui.GridLength.operator !=(Microsoft.Maui.GridLength left, Mic
 static Microsoft.Maui.GridLength.operator ==(Microsoft.Maui.GridLength left, Microsoft.Maui.GridLength right) -> bool
 static Microsoft.Maui.Handlers.EditorHandler.MapIsSpellCheckEnabled(Microsoft.Maui.Handlers.IEditorHandler! handler, Microsoft.Maui.IEditor! editor) -> void
 static Microsoft.Maui.Handlers.EntryHandler.MapIsSpellCheckEnabled(Microsoft.Maui.Handlers.IEntryHandler! handler, Microsoft.Maui.IEntry! entry) -> void
+static Microsoft.Maui.Handlers.LabelHandler.MapBackground(Microsoft.Maui.Handlers.ILabelHandler! handler, Microsoft.Maui.ILabel! label) -> void
 static Microsoft.Maui.Handlers.SearchBarHandler.MapIsSpellCheckEnabled(Microsoft.Maui.IViewHandler! handler, Microsoft.Maui.ISearchBar! searchBar) -> void
 static Microsoft.Maui.Hosting.MauiHandlersCollectionExtensions.AddHandler<TType>(this Microsoft.Maui.Hosting.IMauiHandlersCollection! handlersCollection, System.Func<System.IServiceProvider!, Microsoft.Maui.IElementHandler!>! handlerImplementationFactory) -> Microsoft.Maui.Hosting.IMauiHandlersCollection!
 static Microsoft.Maui.Hosting.MauiHandlersCollectionExtensions.TryAddHandler<TType>(this Microsoft.Maui.Hosting.IMauiHandlersCollection! handlersCollection, System.Func<System.IServiceProvider!, Microsoft.Maui.IElementHandler!>! handlerImplementationFactory) -> Microsoft.Maui.Hosting.IMauiHandlersCollection!
@@ -80,3 +81,4 @@ virtual Microsoft.Maui.Handlers.ImageButtonHandler.SourceLoader.get -> Microsoft
 virtual Microsoft.Maui.Handlers.ImageHandler.SourceLoader.get -> Microsoft.Maui.Platform.ImageSourcePartLoader!
 *REMOVED*Microsoft.Maui.Handlers.SwipeItemMenuItemHandler.SourceLoader.get -> Microsoft.Maui.Platform.ImageSourcePartLoader!
 virtual Microsoft.Maui.Handlers.SwipeItemMenuItemHandler.SourceLoader.get -> Microsoft.Maui.Platform.ImageSourcePartLoader!
+*REMOVED*static Microsoft.Maui.Handlers.LabelHandler.MapMaxLines(Microsoft.Maui.Handlers.ILabelHandler! handler, Microsoft.Maui.ILabel! label) -> void


### PR DESCRIPTION
### Description of Change

This PR attempts to simplify the span calculations by avoiding the custom events (and events in general) and instead using the Frame command that will fire when the layout changed.

I also tried to reduce the amount of work the layout does by skipping the recreation of the native `SpannableString` as this is not actually needed. The label control still has the instance in the `TextView.TextFormatted` property.

@ruiminhu this was inspired by your comment on https://github.com/dotnet/maui/pull/12027/files#r1119999281 and also in light of the recent iOS issues where local events keep things alive forever. @jsuarezruiz I think the labels page is working still, so not sure if there was other tests that you did or other pages to make sure that all is still well after this PR?