### PR TITLE
Fix Android WebAuth callback for system browser flows

### DIFF
--- a/src/Essentials/src/WebAuthenticator/WebAuthenticator.android.cs
+++ b/src/Essentials/src/WebAuthenticator/WebAuthenticator.android.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Maui.Authentication
 		Uri currentRedirectUri = null;
 		WebAuthenticatorOptions currentOptions = null;
 
+		internal bool AuthenticatingWithCustomTabs { get; private set; } = false;
+
 		public bool OnResumeCallback(Intent intent)
 		{
 			// If we aren't waiting on a task, don't handle the url
@@ -69,8 +71,12 @@ namespace Microsoft.Maui.Authentication
 
 			tcsResponse = new TaskCompletionSource<WebAuthenticatorResult>();
 			currentRedirectUri = callbackUrl;
+			
+			// Try to start with custom tabs if the system supports it and we resolve it
+			AuthenticatingWithCustomTabs = await StartCustomTabsActivity(url);
 
-			if (!(await StartCustomTabsActivity(url)))
+			// Fall back to using the system browser if necessary
+			if (!AuthenticatingWithCustomTabs)
 			{
 				// Fall back to opening the system-registered browser if necessary
 				var urlOriginalString = url.OriginalString;

--- a/src/Essentials/src/WebAuthenticator/WebAuthenticator.android.cs
+++ b/src/Essentials/src/WebAuthenticator/WebAuthenticator.android.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Maui.Authentication
 
 			tcsResponse = new TaskCompletionSource<WebAuthenticatorResult>();
 			currentRedirectUri = callbackUrl;
-			
+
 			// Try to start with custom tabs if the system supports it and we resolve it
 			AuthenticatingWithCustomTabs = await StartCustomTabsActivity(url);
 

--- a/src/Essentials/src/WebAuthenticator/WebAuthenticator.shared.cs
+++ b/src/Essentials/src/WebAuthenticator/WebAuthenticator.shared.cs
@@ -102,6 +102,11 @@ namespace Microsoft.Maui.Authentication
 			return platform;
 		}
 
+#if ANDROID
+		internal static bool IsAuthenticatingWithCustomTabs(this IWebAuthenticator webAuthenticator)
+			=> (webAuthenticator as WebAuthenticatorImplementation)?.AuthenticatingWithCustomTabs ?? false;
+#endif
+
 		/// <summary>
 		/// Begin an authentication flow by navigating to the specified url and waiting for a callback/redirect to the callbackUrl scheme.
 		/// </summary>

--- a/src/Essentials/src/WebAuthenticator/WebAuthenticatorCallbackActivity.android.cs
+++ b/src/Essentials/src/WebAuthenticator/WebAuthenticatorCallbackActivity.android.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Maui.Authentication
 				// No intermediate activity if we returned from a system browser
 				// intent since there's no custom tab instance to clean up
 				WebAuthenticator.Default.OnResume(Intent);
-			} 
+			}
 
 			// finish this activity
 			Finish();

--- a/src/Essentials/src/WebAuthenticator/WebAuthenticatorCallbackActivity.android.cs
+++ b/src/Essentials/src/WebAuthenticator/WebAuthenticatorCallbackActivity.android.cs
@@ -10,11 +10,21 @@ namespace Microsoft.Maui.Authentication
 		{
 			base.OnCreate(savedInstanceState);
 
-			// start the intermediate activity again with flags to close the custom tabs
-			var intent = new Intent(this, typeof(WebAuthenticatorIntermediateActivity));
-			intent.SetData(Intent.Data);
-			intent.AddFlags(ActivityFlags.ClearTop | ActivityFlags.SingleTop);
-			StartActivity(intent);
+			// Check how we launched the flow initially
+			if (WebAuthenticator.Default.IsAuthenticatingWithCustomTabs())
+			{
+				// start the intermediate activity again with flags to close the custom tabs
+				var intent = new Intent(this, typeof(WebAuthenticatorIntermediateActivity));
+				intent.SetData(Intent.Data);
+				intent.AddFlags(ActivityFlags.ClearTop | ActivityFlags.SingleTop);
+				StartActivity(intent);
+			}
+			else
+			{
+				// No intermediate activity if we returned from a system browser
+				// intent since there's no custom tab instance to clean up
+				WebAuthenticator.Default.OnResume(Intent);
+			} 
 
 			// finish this activity
 			Finish();


### PR DESCRIPTION
### Description of Change

This was actually found somewhat by accident.  On Android 11 (API30) and newer, you are required to declare in the manifest of your app intent queries if you want to be able to resolve intents from other packages than your own.  The [docs](https://learn.microsoft.com/en-us/dotnet/maui/platform-integration/communication/authentication?tabs=android) already describe this.

If you do not add the info to your manifest, the API will not resolve custom tabs and act as if your system does not support them.  In this case we defer to using the system default browser (we just use a generic Action.VIEW + URI).

When this happens, and eventually the flow calls back to your callback activity, we were assuming that custom tabs were used and so we would route the callback to the intermediate activity (which is needed for custom tabs to clean up the custom tab - that's another story), but that callback would fail because we were missing bundle extras that are set only for custom tabs flows.

This PR adds some tracking state to know which type of flow we launched from so that the callback knows the appropriate action to take to complete the flow.

### Issues Fixed

- Fixes #13302
- Fixes #13798
