### PR TITLE
Fix iOS picker placeholder text overrided (#15139)

### DIFF
--- a/src/Core/src/Platform/iOS/PickerExtensions.cs
+++ b/src/Core/src/Platform/iOS/PickerExtensions.cs
@@ -32,16 +32,6 @@ namespace Microsoft.Maui.Platform
 		{
 			var selectedIndex = newSelectedIndex ?? picker.SelectedIndex;
 
-			if (selectedIndex != -1)
-			{
-				platformPicker.Text = picker.GetItem(selectedIndex);
-			}
-			else
-			{
-				platformPicker.Text = null;
-				platformPicker.UpdatePickerTitle(picker);
-			}
-
 			var pickerView = platformPicker.UIPickerView;
 			pickerView?.ReloadAllComponents();
 

--- a/src/Core/tests/DeviceTests/Handlers/Picker/PickerHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Picker/PickerHandlerTests.iOS.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.Maui.DeviceTests.Stubs;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
@@ -64,11 +65,43 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.Equal(expectedValue, values.PlatformViewValue);
 		}
 
+		[Fact(DisplayName = "Title Display Correctly")]
+		public async Task TitleDisplayCorrectly()
+		{
+			var title = "Select an Item";
+			var items = new List<string>()
+			{
+				"1",
+				"2",
+				"3"
+			};
+
+			var picker = new PickerStub
+			{
+				Title = title,
+				TitleColor = Colors.Red,
+				TextColor = Colors.Blue,
+				ItemsSource = items
+			};
+
+			var values = await GetValueAsync(picker, (handler) =>
+			{
+				return new
+				{
+					Text = GetNativeText(handler),
+					Title = GetNativeTitle(handler)
+				};
+			});
+
+			Assert.True(string.IsNullOrEmpty(values.Text));
+			Assert.Equal(title, values.Title);
+		}
+
 		MauiPicker GetNativePicker(PickerHandler pickerHandler) =>
 			pickerHandler.PlatformView;
 
 		string GetNativeTitle(PickerHandler pickerHandler) =>
-			GetNativePicker(pickerHandler).Text;
+			GetNativePicker(pickerHandler).Placeholder;
 
 		string GetNativeText(PickerHandler pickerHandler) =>
 			 GetNativePicker(pickerHandler).Text;


### PR DESCRIPTION
### Description of Change
Fix iOS picker update override the placeholder text with given text thus cause the text color to be shown instead of title color.

### Issues Fixed
Fixes #15139