### PR TITLE
Implements Color.Equal() correctly

### DIFF
--- a/src/Graphics/src/Graphics/Color.cs
+++ b/src/Graphics/src/Graphics/Color.cs
@@ -102,16 +102,10 @@ namespace Microsoft.Maui.Graphics
 		public override bool Equals(object obj)
 		{
 			if (obj is Color other)
-				return NearlyEqual(Red, other.Red)
-					&& NearlyEqual(Green, other.Green)
-					&& NearlyEqual(Blue, other.Blue)
-					&& NearlyEqual(Alpha, other.Alpha);
+				return ToInt() == other.ToInt();
 
 			return base.Equals(obj);
 		}
-
-		static bool NearlyEqual(float f1, float f2, float epsilon = 0.01f)
-			=> Math.Abs(f1 - f2) < epsilon;
 
 		[Obsolete("Use ToArgbHex instead.")]
 		public string ToHex(bool includeAlpha)

--- a/src/Graphics/tests/Graphics.Tests/ColorTypeConverterTests.cs
+++ b/src/Graphics/tests/Graphics.Tests/ColorTypeConverterTests.cs
@@ -46,8 +46,8 @@ namespace Microsoft.Maui.Graphics.Tests
 				new object[] { "hsva(0,0,0,1)", new Color() },
 				new object[] { "hsva(0,0,0,0)", Colors.Transparent },
 
-				new object[] { "hsl(253,66,50)", Color.FromArgb("#512BD4") },
-				new object[] { "hsv(253,80,83)", Color.FromArgb("#512BD4") },
+				new object[] { "hsl(253,66,50)", Color.FromArgb("#4F2BD3") },
+				new object[] { "hsv(253,80,83)", Color.FromArgb("#4F2AD3") },
 				new object[] { "rgb(81,43,212)", Color.FromArgb("#512BD4") },
 			};
 


### PR DESCRIPTION
### Description of Change

Fixes Color.Equal() to compare integer values instead of floating point values (with a large epsilon) for equality.

### Issues Fixed

Fixes issue #13968
