### PR TITLE
[shell] [windows] fix NRE when clearing shell items

### DIFF
--- a/src/Controls/src/Core/Handlers/Shell/ShellSectionHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellSectionHandler.Windows.cs
@@ -45,7 +45,9 @@ namespace Microsoft.Maui.Controls.Handlers
 			if (_shellSection != null)
 			{
 				((IShellSectionController)_shellSection).NavigationRequested -= OnNavigationRequested;
-				((IShellController)_shellSection.FindParentOfType<Shell>()!).RemoveAppearanceObserver(this);
+
+				var shell = _shellSection.FindParentOfType<Shell>() as IShellController;
+				shell?.RemoveAppearanceObserver(this);
 			}
 
 			// If we've already connected to the navigation manager
@@ -68,7 +70,9 @@ namespace Microsoft.Maui.Controls.Handlers
 			if (_shellSection != null)
 			{
 				((IShellSectionController)_shellSection).NavigationRequested += OnNavigationRequested;
-				((IShellController)_shellSection.FindParentOfType<Shell>()!).AddAppearanceObserver(this, _shellSection);
+
+				var shell = _shellSection.FindParentOfType<Shell>() as IShellController;
+				shell?.AddAppearanceObserver(this, _shellSection);
 			}
 		}
 

--- a/src/Controls/src/Core/Handlers/Shell/ShellSectionHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellSectionHandler.Windows.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Maui.Controls.Handlers
 				};
 
 		StackNavigationManager? _navigationManager;
+		WeakReference? _lastShell;
 
 		public ShellSectionHandler() : base(Mapper, CommandMapper)
 		{
@@ -46,8 +47,11 @@ namespace Microsoft.Maui.Controls.Handlers
 			{
 				((IShellSectionController)_shellSection).NavigationRequested -= OnNavigationRequested;
 
-				var shell = _shellSection.FindParentOfType<Shell>() as IShellController;
-				shell?.RemoveAppearanceObserver(this);
+				if (_lastShell?.Target is IShellController shell)
+				{
+					shell.RemoveAppearanceObserver(this);
+				}
+				_lastShell = null;
 			}
 
 			// If we've already connected to the navigation manager
@@ -72,7 +76,11 @@ namespace Microsoft.Maui.Controls.Handlers
 				((IShellSectionController)_shellSection).NavigationRequested += OnNavigationRequested;
 
 				var shell = _shellSection.FindParentOfType<Shell>() as IShellController;
-				shell?.AddAppearanceObserver(this, _shellSection);
+				if (shell != null)
+				{
+					_lastShell = new WeakReference(shell);
+					shell.AddAppearanceObserver(this, _shellSection);
+				}
 			}
 		}
 

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
@@ -1,7 +1,8 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
+using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui;
@@ -1035,10 +1036,18 @@ namespace Microsoft.Maui.DeviceTests
 			{
 				shell.CurrentItem = new ShellContent { Content = page };
 			});
+
+			var appearanceObserversField = shell.GetType().GetField("_appearanceObservers", BindingFlags.Instance | BindingFlags.NonPublic);
+			Assert.NotNull(appearanceObserversField);
+			var appearanceObservers = appearanceObserversField.GetValue(shell) as IList;
+			Assert.NotNull(appearanceObservers);
+
 			await CreateHandlerAndAddToWindow<IWindowHandler>(shell, _ =>
 			{
+				int count = appearanceObservers.Count;
 				shell.Items.Clear();
 				shell.CurrentItem = new ShellContent { Content = page };
+				Assert.Equal(count, appearanceObservers.Count); // Count doesn't increase
 			});
 		}
 

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
@@ -1026,6 +1026,22 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
+		[Fact(DisplayName = "Can Clear ShellContent")]
+		public async Task CanClearShellContent()
+		{
+			SetupBuilder();
+			var page = new ContentPage();
+			var shell = await CreateShellAsync(shell =>
+			{
+				shell.CurrentItem = new ShellContent { Content = page };
+			});
+			await CreateHandlerAndAddToWindow<IWindowHandler>(shell, _ =>
+			{
+				shell.Items.Clear();
+				shell.CurrentItem = new ShellContent { Content = page };
+			});
+		}
+
 		protected Task<Shell> CreateShellAsync(Action<Shell> action) =>
 			InvokeOnMainThreadAsync(() =>
 			{


### PR DESCRIPTION
Fixes: https://github.com/dotnet/maui/issues/13775

You can cause MAUI to throw an NRE by doing:

1. Debug/run, have XAML hot reload enabled

2. Comment out the `ShellContent` in `AppShell.xaml`, hot reload

3. Uncomment the `ShellContent` in `AppShell.xaml`, hot reload

Crashes with:

    System.NullReferenceException: Object reference not set to an instance of an object.
    at Microsoft.Maui.Controls.Handlers.ShellSectionHandler.SetVirtualView(IElement view)
    at Microsoft.Maui.Controls.Handlers.ShellItemHandler.UpdateCurrentItem()
    at Microsoft.Maui.Controls.Handlers.ShellItemHandler.MapCurrentItem(ShellItemHandler handler, ShellItem item)
    at Microsoft.Maui.PropertyMapper`2.<>c__DisplayClass5_0.<Add>b__0(IElementHandler h, IElement v)
    at Microsoft.Maui.PropertyMapper.UpdatePropertyCore(String key, IElementHandler viewHandler, IElement virtualView)
    at Microsoft.Maui.PropertyMapper.UpdateProperties(IElementHandler viewHandler, IElement virtualView)
    at Microsoft.Maui.Handlers.ElementHandler.SetVirtualView(IElement view)
    at Microsoft.Maui.Controls.Handlers.ShellItemHandler.SetVirtualView(IElement view)
    at Microsoft.Maui.Controls.Platform.ShellView.CreateShellItemView()
    at Microsoft.Maui.Controls.Platform.ShellView.SwitchShellItem(ShellItem newItem, Boolean animate)
    at Microsoft.Maui.Controls.Handlers.ShellHandler.MapCurrentItem(ShellHandler handler, Shell view)
    at Microsoft.Maui.PropertyMapper`2.<>c__DisplayClass5_0.<Add>b__0(IElementHandler h, IElement v)
    at Microsoft.Maui.PropertyMapper.UpdatePropertyCore(String key, IElementHandler viewHandler, IElement virtualView)
    at Microsoft.Maui.PropertyMapper.UpdateProperty(IElementHandler viewHandler, IElement virtualView, String property)
    at Microsoft.Maui.Handlers.ElementHandler.UpdateValue(String property)
    at Microsoft.Maui.Controls.Element.OnPropertyChanged(String propertyName)
    at Microsoft.Maui.Controls.Shell.OnPropertyChanged(String propertyName)
    at Microsoft.Maui.Controls.BindableObject.SetValueActual(BindableProperty property, BindablePropertyContext context, Object value, Boolean currentlyApplying, SetValueFlags attributes, Boolean silent)
    at Microsoft.Maui.Controls.BindableObject.SetValueCore(BindableProperty property, Object value, SetValueFlags attributes, SetValuePrivateFlags privateAttributes)
    at Microsoft.Maui.Controls.BindableObject.SetValueCore(BindableProperty property, Object value, SetValueFlags attributes)
    at Microsoft.Maui.Controls.Element.SetValueFromRenderer(BindableProperty property, Object value)
    at Microsoft.Maui.Controls.ShellNavigationManager.GoToAsync(ShellNavigationParameters shellNavigationParameters, ShellNavigationRequest navigationRequest)
    at Microsoft.Maui.Controls.Shell.<Initialize>g__SetCurrentItem|172_1()
    at Microsoft.Maui.Controls.Shell.<Initialize>b__172_0(Object s, NotifyCollectionChangedEventArgs e)
    at System.Threading.Tasks.Task.<>c.<ThrowAsync>b__128_0(Object state)
    at Microsoft.UI.Dispatching.DispatcherQueueSynchronizationContext.<>c__DisplayClass2_0.<Post>b__0()

I could reproduce this in a test by simply doing:

    shell.CurrentItem = new ShellContent { Content = page };
    shell.Items.Clear();
    shell.CurrentItem = new ShellContent { Content = page };

I added appropriate null checking and the problem appears to be solved now.
