### PR TITLE
Set Version for Windows

### DIFF
--- a/src/Core/src/nuget/buildTransitive/WinUI.targets
+++ b/src/Core/src/nuget/buildTransitive/WinUI.targets
@@ -1,14 +1,6 @@
 <!-- Workarounds for WinUI -->
 <Project>
 
-  <!--
-    NOTE: workaround https://github.com/NuGet/Home/issues/6461
-    We should also follow Android, iOS, etc. workloads.
-  -->
-  <PropertyGroup>
-    <Version Condition=" '$(ApplicationDisplayVersion)' != '' ">$(ApplicationDisplayVersion)</Version>
-  </PropertyGroup>
-
   <Target Name="_AddMauiPriFiles" AfterTargets="ResolveAssemblyReferences">
     <ItemGroup>
       <_ReferenceRelatedPaths

--- a/src/Workload/Microsoft.Maui.Sdk/Sdk/Microsoft.Maui.Sdk.Before.targets
+++ b/src/Workload/Microsoft.Maui.Sdk/Sdk/Microsoft.Maui.Sdk.Before.targets
@@ -19,4 +19,13 @@
     <_MauiUsingDefaultRuntimeIdentifier>true</_MauiUsingDefaultRuntimeIdentifier>
   </PropertyGroup>
 
+  <!--
+    Workaround for https://github.com/NuGet/Home/issues/6461
+    By default, Android and iOS set the Version property, so we need to do the same for Windows.
+    This also has to be done outside of the NuGets as this affects the NuGet restore.
+  -->
+  <PropertyGroup Condition=" '$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'windows' and '$(OutputType)' == 'WinExe' ">
+    <Version Condition=" $([System.Version]::TryParse ('$(ApplicationDisplayVersion)', $([System.Version]::Parse('1.0')))) ">$(ApplicationDisplayVersion)</Version>
+  </PropertyGroup>
+
 </Project>


### PR DESCRIPTION
### Description of Change

This PR fixes an issue where setting `<ApplicationDisplayVersion>` to anything other than `1.0` caused the IDE to fail to restore NuGets. There was a fix before https://github.com/dotnet/maui/pull/6628 however, it appears this was before another fix landed which effectively disabled the change until after the NuGet restore completed: https://github.com/dotnet/maui/pull/6767

As a result, the fix was "lost". This PR moves the fix out of the NuGet (where it is too late) and directly into the workload.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

- Fixes #12859
- Fixes #10579
- Related https://github.com/dotnet/maui/issues/6626

### Workaround

For now the easiest workaround is to add `<Version>$(ApplicationVersion)</Version>` in your project directly after your `<ApplicationVersion>1.0</ApplicationVersion>` property.