### PR TITLE
Scrollview on Windows doesn't measure direct child on height changed

### DIFF
--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Windows.cs
@@ -73,6 +73,29 @@ namespace Microsoft.Maui.Handlers
 			}
 		}
 
+		public override Size GetDesiredSize(double widthConstraint, double heightConstraint)
+		{
+			var virtualView = VirtualView;
+			var platformView = PlatformView;
+
+			if (platformView == null || virtualView == null)
+			{
+				return base.GetDesiredSize(widthConstraint, heightConstraint);
+			}
+
+			var presentedContent = virtualView.PresentedContent;
+			if (presentedContent == null)
+			{
+				return base.GetDesiredSize(widthConstraint, heightConstraint);
+			}
+
+			// We need to make sure a call to Measure is invoked on our PresentedContent
+			// when we re-measure ourself
+			presentedContent.Measure(widthConstraint, heightConstraint);
+
+			return base.GetDesiredSize(widthConstraint, heightConstraint);
+		}
+
 		/*
 			Problem 1: Windows treats Padding differently than what we want for MAUI; Padding creates space
 			_around_ the scrollable area, rather than padding the content inside of it. 

--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Windows.cs
@@ -75,24 +75,12 @@ namespace Microsoft.Maui.Handlers
 
 		public override Size GetDesiredSize(double widthConstraint, double heightConstraint)
 		{
-			var virtualView = VirtualView;
-			var platformView = PlatformView;
-
-			if (platformView == null || virtualView == null)
+			if (VirtualView != null && VirtualView.PresentedContent != null)
 			{
-				return base.GetDesiredSize(widthConstraint, heightConstraint);
+				// We need to make sure a call to Measure is invoked on our PresentedContent
+				// when we re-measure ourself
+				VirtualView.PresentedContent.Measure(widthConstraint, heightConstraint);
 			}
-
-			var presentedContent = virtualView.PresentedContent;
-			if (presentedContent == null)
-			{
-				return base.GetDesiredSize(widthConstraint, heightConstraint);
-			}
-
-			// We need to make sure a call to Measure is invoked on our PresentedContent
-			// when we re-measure ourself
-			presentedContent.Measure(widthConstraint, heightConstraint);
-
 			return base.GetDesiredSize(widthConstraint, heightConstraint);
 		}
 

--- a/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -14,6 +14,7 @@ Microsoft.Maui.Layouts.FlexBasis.Equals(Microsoft.Maui.Layouts.FlexBasis other) 
 Microsoft.Maui.Platform.MauiWebView.MauiWebView(Microsoft.Maui.Handlers.WebViewHandler! handler) -> void
 Microsoft.Maui.SizeRequest.Equals(Microsoft.Maui.SizeRequest other) -> bool
 override Microsoft.Maui.Handlers.ContentViewHandler.DisconnectHandler(Microsoft.Maui.Platform.ContentPanel! platformView) -> void
+override Microsoft.Maui.Handlers.ScrollViewHandler.GetDesiredSize(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Layouts.FlexBasis.Equals(object? obj) -> bool
 override Microsoft.Maui.Layouts.FlexBasis.GetHashCode() -> int
 override Microsoft.Maui.SizeRequest.Equals(object? obj) -> bool


### PR DESCRIPTION
### Description of Change

Seeking input on this first if it's the right way to fix this, then will add a test if this is the right approach!


Fixed an issue where ScrollView on Windows wouldn't run a measure pass on it's child content when the ScrollView itself was measured. `GetDesiredSize` is invoked via the native platform method `MeasureOverride`.

This prevented children that expand vertically to the available size (horz stackpanel, grid without a set size, borders, etc) from resizing _unless_ the ScrollView width was modified. I'm still not 100% sure why resizing the width works, but the source for [WinUI ScrollPresenter](https://github.com/microsoft/microsoft-ui-xaml/blob/4cbade6959cda4fca42a299fb540adc2f99c1e8a/dev/ScrollPresenter/ScrollPresenter.cpp#L653) suggests that `MeasureOverride` should run a measure pass to the content (I'm also not sure if our use of `MeasureOverride` overrides this function or not).

Before:
https://github.com/dotnet/maui/assets/890772/ba4f678b-76f5-4a43-b8d1-0332effc8d82

After:
https://github.com/dotnet/maui/assets/890772/645f814b-6555-4064-9380-c2232bf056f8


### Issues Fixed

Fixes #14573