### PR TITLE
Allows support for other default browsers on Android to work with the Web Authenticator

### DIFF
--- a/src/Essentials/src/WebAuthenticator/WebAuthenticatorIntermediateActivity.android.cs
+++ b/src/Essentials/src/WebAuthenticator/WebAuthenticatorIntermediateActivity.android.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Maui.Authentication
 		{
 			base.OnResume();
 
-			if (!launched)
+			if (actualIntent != null && !launched)
 			{
 				// if this is the first time, start the authentication flow
 				StartActivity(actualIntent);


### PR DESCRIPTION
### Description of Change

When a browser different from Chrome is assigned as default in Android, the web authenticator throws an exception with **some** browsers only.
This change prevents NullReferenceException on WebAuthenticatorIntermediateActivity.android.cs and allows support for other default browsers on Android to work with the Web Authenticator, and continue the authentication flow.

**This change has been tested with the following browsers:**
- Firefox, 
- Microsoft Edge 
- Chrome
- DuckDuckGo
- Mi Browser
- Samsung Internet
- Opera
- Brave.

> **Important**: *Due to a browser limitation, some browsers do not support Android CustomTabs feature to get back to the app automatically, so, the user must manually hit the back button or open again the app (Opera and Mi Browser). This is something that cannot be managed in .NET MAUI.

### Issues Fixed

Fixes [#13798](https://github.com/dotnet/maui/issues/13798)
