### PR TITLE
Obsolete Dictionary and shift to single state object

### DIFF
--- a/src/Controls/src/Core/Shell/Shell.cs
+++ b/src/Controls/src/Core/Shell/Shell.cs
@@ -677,6 +677,7 @@ namespace Microsoft.Maui.Controls
 
 		/// <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='GoToAsync'][1]/Docs/*" />
 #pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+		[Obsolete]
 		public Task GoToAsync(ShellNavigationState state, IDictionary<string, object> parameters)
 #pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
 		{
@@ -685,11 +686,34 @@ namespace Microsoft.Maui.Controls
 
 		/// <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='GoToAsync'][2]/Docs/*" />
 #pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+		[Obsolete]
 		public Task GoToAsync(ShellNavigationState state, bool animate, IDictionary<string, object> parameters)
 #pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
 		{
 			return _navigationManager.GoToAsync(state, animate, false, parameters: new ShellRouteParameters(parameters));
 		}
+
+		/// <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='GoToAsync'][2]/Docs/*" />
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+#pragma warning disable RS0016 // Add public types and members to the declared API
+		// This will propagate your navigationState to a key/property with the name "navigationState"
+		// NavigationState isn't maintained between navigations and will only propagate to your page during initial navigation
+		public Task GoToAsync(ShellNavigationState state, object navigationState)
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+		{
+			return GoToAsync(state, new KeyValuePair<string, object>("NavigationState", navigationState));
+		}
+
+#pragma warning disable RS0016 // Add public types and members to the declared API
+		// This can be used to propagate your navigationState to a specific key of your choosing.
+		// NavigationState isn't maintained between navigations and will only propagate to your page during initial navigation
+		public Task GoToAsync(ShellNavigationState state, KeyValuePair<string, object> navigationState)
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
+		{
+			throw new NotImplementedException();
+		}
+
+#pragma warning restore RS0016 // Add public types and members to the declared API
 
 		public void AddLogicalChild(Element element)
 		{


### PR DESCRIPTION
### Description of Change

- Obsolete the shell.gotoasync API that takes `Dictionary<string, object>`
- Add a new overload that's specific to just passing `navigationState`. This structure matches WPF a bit with how the `NavigationService` works
- No breaking changes
- Splits out the concept of "queryParameters" vs "navigationState" a bit more explicitly. 

### Justification

Alternate PR Idea for: https://github.com/dotnet/maui/pull/14965

Currently when you pass extra parameters to shell via the parameters dictionary those are retained forever and reapplied with each navigation. The workarounds to remove those parameters is fairly cumbersome. Through discussions with users, it's become apparent that we need a mechanism to have parameters that only get applied during the initial navigation request. This PR clears any parameters that aren't part of the QueryString.

It's particularly problematic to retain those parameters because if the user passes a complex object that object is retained in memory forever unknown to the user.

### Thoughts
- It is a little odd to apply the navigationState through the existing `IQueryAttributable` but the idea would be to eventually promote this to `NavigatingEventArgs` like `UWP/WPF` has and you can grab it from the `ExtraData`. Then we can eventually elevate that to work with `NavigationPage` as well
- We could add an interface with this PR `IReceivesNavigationState` that you could mark on your classes and then that's where it'd pass the `navigationState` to

### FAQ
- Why is the Query Property an internal BP?
  - This was done for Hot Reload purposes. In theory there would be scenarios where hot reload could trigger a page to be recreated and thus all BP's would need to get copied from one Page to another. 
-  What about a perfect solution? 
  - Ideally we restructure shell when there's more time to flesh out more interfaces/apis for parameters passing. For now, we need a way for users to opt out of parameters being reapplied 
- What changed between MAUI and XF?
  - The only thing that changed was the addition of the dictionary overload on GotoAsync. Parameters have always reapplied. So, for users coming from XF there is no change in behavior. This would mainly be a change for users that started using the new API.
- What if users are using the setting of the parameter for `OnAppearing`? 
   - IApplyQueryAttributes will still get called so users can use that interface.

### Examples for the docs to improve clarity
We should enhance the navigation part of the `Shell` docs to include various example permutations of how parameters are handled.

#### Still works the same 

```C#
await GotoAsync("firstPage?param=1");
await GotoAsync("nextPage");
await GotoAsync(".."); // param = 1 will get applied to `firstPage`
```

#### New

```C#
ComplexObject obj;
await GotoAsync("firstPage?param=1", obj);
await GotoAsync("nextPage");
await GotoAsync(".."); // param = 1 will get applied to `firstPage` but `ComplexObject` won't
```

```C#
ComplexObject obj;
await GotoAsync("firstPage?param=1", new KeyValuePair<string, object>("MyParameter", obj));
await GotoAsync("nextPage");
await GotoAsync(".."); // param = 1 will get applied to `firstPage` but `ComplexObject` won't
```


### Issues Fixed


Fixes #10294


