### PR TITLE
Enable parallel builds back

### DIFF
--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -134,7 +134,7 @@ Task("dotnet-build")
         RunMSBuildWithDotNet("./Microsoft.Maui.BuildTasks.slnf");
         if (IsRunningOnWindows())
         {
-            RunMSBuildWithDotNet("./Microsoft.Maui.sln", maxCpuCount:1);
+            RunMSBuildWithDotNet("./Microsoft.Maui.sln");
         }
         else
         {


### PR DESCRIPTION
### Description of Change

We have disable building the .sln in parallel to try fix an issue, but it might not be related. 

This saves 40% of build time