### PR TITLE
[CI] Remove the template explosion in the CI via a matrix

### DIFF
--- a/eng/pipelines/common/device-tests.yml
+++ b/eng/pipelines/common/device-tests.yml
@@ -32,7 +32,7 @@ stages:
             ${{ if ne(project.android, '') }}:
               ${{ each api in parameters.androidApiLevels }}:
                 ${{ if not(containsValue(project.androidApiLevelsExclude, api)) }}:
-                  ${{ replace(coalesce(project.desc, project.name) }}_API_${{ api }}, ' ', '_') }}:
+                  ${{ join('_', [replace(coalesce(project.desc, project.name) }}, ' ', '_'), 'API',  api]) }}:
                     ${{ if ge(api, 24) }}:
                       ANDROID_EMULATORS: "system-images;android-${{ api }};google_apis_playstore;x86"
                     ${{ if lt(api, 24) }}:

--- a/eng/pipelines/common/device-tests.yml
+++ b/eng/pipelines/common/device-tests.yml
@@ -20,7 +20,7 @@ stages:
     displayName: Android Device Tests
     dependsOn: []
     jobs:
-    - job: android_device_tests_${{ project.name }}_${{ api }}
+    - job: android_device_tests
       workspace:
         clean: all
       displayName: ${{ coalesce(project.desc, project.name) }} (API ${{ api }})

--- a/eng/pipelines/common/device-tests.yml
+++ b/eng/pipelines/common/device-tests.yml
@@ -32,7 +32,7 @@ stages:
             ${{ if ne(project.android, '') }}:
               ${{ each api in parameters.androidApiLevels }}:
                 ${{ if not(containsValue(project.androidApiLevelsExclude, api)) }}:
-                  ${{ join('_', [replace(coalesce(project.desc, project.name) }}, ' ', '_'), 'API',  api]) }}:
+                  ${{ replace(coalesce(project.desc, project.name), ' ', '_') }}_API_${{ api }}:
                     ${{ if ge(api, 24) }}:
                       ANDROID_EMULATORS: "system-images;android-${{ api }};google_apis_playstore;x86"
                     ${{ if lt(api, 24) }}:

--- a/eng/pipelines/common/device-tests.yml
+++ b/eng/pipelines/common/device-tests.yml
@@ -16,38 +16,41 @@ parameters:
       ios: /optional/path/to/ios.csproj
 
 stages:
-
   - stage: android_device_tests
     displayName: Android Device Tests
     dependsOn: []
     jobs:
-      - ${{ each project in parameters.projects }}:
-        - ${{ if ne(project.android, '') }}:
-          - ${{ each api in parameters.androidApiLevels }}:
-            - ${{ if not(containsValue(project.androidApiLevelsExclude, api)) }}:
-              - job: android_device_tests_${{ project.name }}_${{ api }}
-                workspace:
-                  clean: all
-                displayName: ${{ coalesce(project.desc, project.name) }} (API ${{ api }})
-                pool: ${{ parameters.androidPool }}
-                variables:
+    - job: android_device_tests_${{ project.name }}_${{ api }}
+      workspace:
+        clean: all
+      displayName: ${{ coalesce(project.desc, project.name) }} (API ${{ api }})
+      pool: ${{ parameters.androidPool }}
+      strategy: matrix
+      # create all the variables used for the matrix
+        ${{ each project in parameters.projects }}:
+          ${{ if ne(project.android, '') }}:
+            ${{ each api in parameters.androidApiLevels }}:
+              ${{ if not(containsValue(project.androidApiLevelsExclude, api)) }}:
+                ${{ replace(coalesce(project.desc, project.name) }}_API_${{ api }}, ' ', '_') }}:
                   ${{ if ge(api, 24) }}:
                     ANDROID_EMULATORS: "system-images;android-${{ api }};google_apis_playstore;x86"
                   ${{ if lt(api, 24) }}:
                     ANDROID_EMULATORS: "system-images;android-${{ api }};google_apis;x86"
                   REQUIRED_XCODE: $(DEVICETESTS_REQUIRED_XCODE)
-                steps:
-                  - template: device-tests-steps.yml
-                    parameters:
-                      platform: android
-                      path: ${{ project.android }}
-                      device: android-emulator-32_${{ api }}
-                      provisionatorChannel: ${{ parameters.provisionatorChannel }}
-                      agentPoolAccessToken: ${{ parameters.agentPoolAccessToken }}
-                      artifactName: ${{ parameters.artifactName }}
-                      artifactItemPattern: ${{ parameters.artifactItemPattern }}
-                      checkoutDirectory: ${{ parameters.checkoutDirectory }}
-                      useArtifacts: ${{ parameters.useArtifacts }}
+                  PROJECT_PATH: ${{ project.android }}
+                  DEVICE: android-emulator-32_${{ api }}
+      steps:
+        - template: device-tests-steps.yml
+          parameters:
+            platform: android
+            path: $(PROJECT_PATH) 
+            device: $(DEVICE)
+            provisionatorChannel: ${{ parameters.provisionatorChannel }}
+            agentPoolAccessToken: ${{ parameters.agentPoolAccessToken }}
+            artifactName: ${{ parameters.artifactName }}
+            artifactItemPattern: ${{ parameters.artifactItemPattern }}
+            checkoutDirectory: ${{ parameters.checkoutDirectory }}
+            useArtifacts: ${{ parameters.useArtifacts }}
 
   - stage: ios_device_tests
     displayName: iOS Device Tests

--- a/eng/pipelines/common/device-tests.yml
+++ b/eng/pipelines/common/device-tests.yml
@@ -23,7 +23,7 @@ stages:
     - job: android_device_tests
       workspace:
         clean: all
-      displayName: ${{ coalesce(project.desc, project.name) }} (API ${{ api }})
+      displayName: "Android emulator tests"
       pool: ${{ parameters.androidPool }}
       strategy:
         matrix:

--- a/eng/pipelines/common/device-tests.yml
+++ b/eng/pipelines/common/device-tests.yml
@@ -25,20 +25,21 @@ stages:
         clean: all
       displayName: ${{ coalesce(project.desc, project.name) }} (API ${{ api }})
       pool: ${{ parameters.androidPool }}
-      strategy: matrix
-      # create all the variables used for the matrix
-        ${{ each project in parameters.projects }}:
-          ${{ if ne(project.android, '') }}:
-            ${{ each api in parameters.androidApiLevels }}:
-              ${{ if not(containsValue(project.androidApiLevelsExclude, api)) }}:
-                ${{ replace(coalesce(project.desc, project.name) }}_API_${{ api }}, ' ', '_') }}:
-                  ${{ if ge(api, 24) }}:
-                    ANDROID_EMULATORS: "system-images;android-${{ api }};google_apis_playstore;x86"
-                  ${{ if lt(api, 24) }}:
-                    ANDROID_EMULATORS: "system-images;android-${{ api }};google_apis;x86"
-                  REQUIRED_XCODE: $(DEVICETESTS_REQUIRED_XCODE)
-                  PROJECT_PATH: ${{ project.android }}
-                  DEVICE: android-emulator-32_${{ api }}
+      strategy:
+        matrix:
+          # create all the variables used for the matrix
+          ${{ each project in parameters.projects }}:
+            ${{ if ne(project.android, '') }}:
+              ${{ each api in parameters.androidApiLevels }}:
+                ${{ if not(containsValue(project.androidApiLevelsExclude, api)) }}:
+                  ${{ replace(coalesce(project.desc, project.name) }}_API_${{ api }}, ' ', '_') }}:
+                    ${{ if ge(api, 24) }}:
+                      ANDROID_EMULATORS: "system-images;android-${{ api }};google_apis_playstore;x86"
+                    ${{ if lt(api, 24) }}:
+                      ANDROID_EMULATORS: "system-images;android-${{ api }};google_apis;x86"
+                    REQUIRED_XCODE: $(DEVICETESTS_REQUIRED_XCODE)
+                    PROJECT_PATH: ${{ project.android }}
+                    DEVICE: android-emulator-32_${{ api }}
       steps:
         - template: device-tests-steps.yml
           parameters:


### PR DESCRIPTION
Templates are being abused and is resulting in a template explosion, this means that when the templates get expanded we have 100 thousans of lines generated. Azure devops has a limit in the size of the expanded template, and once that limit is reached, the pipeline wont be able to execute.

This changes makes the problem go away since a matrix is a native object for azure pipelines and does not get expanded.

This PR only takes care of the android emulator tests. A similar PR can be found in the xamarin-macios project:

https://github.com/xamarin/xamarin-macios/pull/18312

For a better idea of what we achieve, the following is the expanded template: https://gist.github.com/mandel-macaque/dda3cda899e975814e563d6e34b50192

The following is the matrix expanded version: https://gist.github.com/mandel-macaque/ddbd66bbfb09531e866ee5b9354b8604

As you can see we go from 18850 yaml lines to 8210, that is over 10000 lines less. This reduces the time it takes for the pipeline to start as well as the effort to debug it.





