### PR TITLE
[CI] Remove the template explosion in the CI via a matrix

### DIFF
--- a/eng/pipelines/common/device-tests.yml
+++ b/eng/pipelines/common/device-tests.yml
@@ -69,7 +69,7 @@ stages:
             ${{ if ne(project.ios, '') }}:
               ${{ each version in parameters.iosVersions }}:
                 ${{ if not(containsValue(project.iosVersionsExclude, version)) }}:
-                  ${{ replace(coalesce(project.desc, project.name), ' ', '_') }}_V${{ version }}:
+                  ${{ replace(coalesce(project.desc, project.name), ' ', '_') }}_V_${{ version }}:
                     REQUIRED_XCODE: $(DEVICETESTS_REQUIRED_XCODE)
                     PROJECT_PATH: ${{ project.ios }}
                     ${{ if eq(version, 'latest') }}:

--- a/eng/pipelines/common/device-tests.yml
+++ b/eng/pipelines/common/device-tests.yml
@@ -35,7 +35,7 @@ stages:
                   ${{ replace(coalesce(project.desc, project.name), ' ', '_') }}_API_${{ api }}:
                     ${{ if ge(api, 24) }}:
                       ANDROID_EMULATORS: "system-images;android-${{ api }};google_apis_playstore;x86"
-                    ${{ if lt(api, 24) }}:
+                    ${{ else }}:
                       ANDROID_EMULATORS: "system-images;android-${{ api }};google_apis;x86"
                     REQUIRED_XCODE: $(DEVICETESTS_REQUIRED_XCODE)
                     PROJECT_PATH: ${{ project.android }}
@@ -57,29 +57,34 @@ stages:
     displayName: iOS Device Tests
     dependsOn: []
     jobs:
-      - ${{ each project in parameters.projects }}:
-        - ${{ if ne(project.ios, '') }}:
-          - ${{ each version in parameters.iosVersions }}:
-            - ${{ if not(containsValue(project.iosVersionsExclude, version)) }}:
-              - job: ios_device_tests_${{ project.name }}_${{ replace(version, '.', '_') }}
-                workspace:
-                  clean: all
-                displayName: ${{ coalesce(project.desc, project.name) }} (v${{ version }})
-                pool: ${{ parameters.iosPool }}
-                variables:
-                  REQUIRED_XCODE: $(DEVICETESTS_REQUIRED_XCODE)
-                steps:
-                  - template: device-tests-steps.yml
-                    parameters:
-                      platform: ios
-                      path: ${{ project.ios }}
-                      ${{ if eq(version, 'latest') }}:
-                        device: ios-simulator-64
-                      ${{ if ne(version, 'latest') }}:
-                        device: ios-simulator-64_${{ version }}
-                      provisionatorChannel: ${{ parameters.provisionatorChannel }}
-                      agentPoolAccessToken: ${{ parameters.agentPoolAccessToken }}
-                      artifactName: ${{ parameters.artifactName }}
-                      artifactItemPattern: ${{ parameters.artifactItemPattern }}
-                      checkoutDirectory: ${{ parameters.checkoutDirectory }}
-                      useArtifacts: ${{ parameters.useArtifacts }}
+    - job: ios_device_tests
+      workspace:
+        clean: all
+      displayName: "iOS simulator tests"
+      pool: ${{ parameters.iosPool }}
+      strategy:
+        matrix:
+          # create all the variables used for the matrix
+          ${{ each project in parameters.projects }}:
+            ${{ if ne(project.ios, '') }}:
+              ${{ each version in parameters.iosVersions }}:
+                ${{ if not(containsValue(project.iosVersionsExclude, version)) }}:
+                  ${{ replace(coalesce(project.desc, project.name), ' ', '_') }}_V${{ version }}:
+                    REQUIRED_XCODE: $(DEVICETESTS_REQUIRED_XCODE)
+                    PROJECT_PATH: ${{ project.ios }}
+                    ${{ if eq(version, 'latest') }}:
+                      DEVICE: ios-simulator-64
+                    ${{ else }}:
+                      DEVICE: ios-simulator-64_${{ version }}
+      steps:
+        - template: device-tests-steps.yml
+          parameters:
+            platform: ios
+            path: $(PROJECT_PATH)
+            device: $(DEVICE)
+            provisionatorChannel: ${{ parameters.provisionatorChannel }}
+            agentPoolAccessToken: ${{ parameters.agentPoolAccessToken }}
+            artifactName: ${{ parameters.artifactName }}
+            artifactItemPattern: ${{ parameters.artifactItemPattern }}
+            checkoutDirectory: ${{ parameters.checkoutDirectory }}
+            useArtifacts: ${{ parameters.useArtifacts }}


### PR DESCRIPTION
This PR is a continuation of https://github.com/dotnet/maui/pull/15334 the removes the exact same problem but with the iOS device tests rather than with the android tests.

Uses the exact same approach, moves from using a template explosion to a matrix with the diff combinations.

Previous version with the android only using a matrix:  https://gist.github.com/mandel-macaque/ddbd66bbfb09531e866ee5b9354b8604  - 8210 lines

New version with both using a matrix: https://gist.github.com/mandel-macaque/32f4f6f2c286d800944822437313bcf6 - 2874 lines.

With this PR + the previous one we have gone from 18850 lines of expanded yaml to 2874 lines. The rest of the improvements have to go to the yaml templates repository (already in the works).



