### PR TITLE
[CI] Remove template explosion on the maui templates build tests.

### DIFF
--- a/eng/pipelines/common/maui-templates.yml
+++ b/eng/pipelines/common/maui-templates.yml
@@ -55,68 +55,75 @@ parameters:
     default: []
 
 jobs:
-- ${{ each BuildPlatform in parameters.BuildPlatforms }}:
-  - job: build_${{ BuildPlatform.name }}
-    workspace:
-      clean: all
-    displayName: ${{ BuildPlatform.name }}
-    timeoutInMinutes: 240
-    condition: ${{ parameters.condition}}
-    pool:
-      name: ${{ BuildPlatform.poolName }}
-      vmImage: ${{ BuildPlatform.vmImage }}
-      demands:
-        - macOS.Name -equals Ventura
-        - macOS.Architecture -equals x64
-    steps:
+- job: build_maui_templates
+  workspace:
+    clean: all
+  displayName: 'Build platform:'
+  timeoutInMinutes: 240
+  condition: ${{ parameters.condition}}
+  strategy:
+    matrix:
+      ${{ each BuildPlatform in parameters.BuildPlatforms }}:
+        ${{ BuildPlatform.name }}:
+          POOL_NAME: ${{ BuildPlatform.poolName }}
+          POOL_VIMAGE: ${{ BuildPlatform.vmImage }}
+          PLATFORM_NAME: ${{ BuildPlatform.name }}
 
-    - ${{ each step in parameters.prepareSteps }}:
-      - ${{ each pair in step }}:
-          ${{ pair.key }}: ${{ pair.value }}
+  pool:
+    name: $(POOL_NAME)
+    vmImage: $(POOL_VIMAGE)
+    demands:
+      - macOS.Name -equals Ventura
+      - macOS.Architecture -equals x64
+  steps:
 
-    - template: provision.yml
-      parameters:
-        checkoutDirectory: ${{ parameters.checkoutDirectory }}
+  - ${{ each step in parameters.prepareSteps }}:
+    - ${{ each pair in step }}:
+        ${{ pair.key }}: ${{ pair.value }}
 
-    - task: DownloadBuildArtifacts@0
-      displayName: 'Download Packages'
-      inputs:
-        artifactName: ${{ parameters.artifactName }}
-        itemPattern: ${{ parameters.artifactItemPattern }}
-        downloadPath: $(System.DefaultWorkingDirectory)/artifacts
+  - template: provision.yml
+    parameters:
+      checkoutDirectory: ${{ parameters.checkoutDirectory }}
 
-    - pwsh: Move-Item -Path artifacts\${{ parameters.artifactName }}\*.nupkg -Destination artifacts -Force
-      displayName: Move the downloaded artifacts
+  - task: DownloadBuildArtifacts@0
+    displayName: 'Download Packages'
+    inputs:
+      artifactName: ${{ parameters.artifactName }}
+      itemPattern: ${{ parameters.artifactItemPattern }}
+      downloadPath: $(System.DefaultWorkingDirectory)/artifacts
 
-    - pwsh: ./build.ps1 --target=dotnet-local-workloads --verbosity=diagnostic
-      displayName: 'Install .NET (Local Workloads)'
-      retryCountOnTaskFailure: 3
-      workingDirectory: ${{ parameters.checkoutDirectory }}
-      env:
-        DOTNET_TOKEN: $(dotnetbuilds-internal-container-read-token)
-        PRIVATE_BUILD: $(PrivateBuild)
+  - pwsh: Move-Item -Path artifacts\${{ parameters.artifactName }}\*.nupkg -Destination artifacts -Force
+    displayName: Move the downloaded artifacts
 
-    - task: DotNetCoreCLI@2
-      inputs:
-        projects: ${{ parameters.checkoutDirectory }}/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Microsoft.Maui.IntegrationTests.csproj
-      displayName: Build Microsoft.Maui.IntegrationTests
+  - pwsh: ./build.ps1 --target=dotnet-local-workloads --verbosity=diagnostic
+    displayName: 'Install .NET (Local Workloads)'
+    retryCountOnTaskFailure: 3
+    workingDirectory: ${{ parameters.checkoutDirectory }}
+    env:
+      DOTNET_TOKEN: $(dotnetbuilds-internal-container-read-token)
+      PRIVATE_BUILD: $(PrivateBuild)
 
-    - task: DotNetCoreCLI@2
-      inputs:
-        command: test
-        projects: ${{ parameters.checkoutDirectory }}/src/TestUtils/src/Microsoft.Maui.IntegrationTests/bin/Debug/net7.0/Microsoft.Maui.IntegrationTests.dll
-        arguments: --logger "console;verbosity=normal" --filter "FullyQualifiedName=Microsoft.Maui.IntegrationTests.TemplateTests"
-        publishTestResults: true
-        testRunTitle: ${{ BuildPlatform.name }} template build tests
-      displayName: ${{ BuildPlatform.name }} template build tests
-      continueOnError: true
+  - task: DotNetCoreCLI@2
+    inputs:
+      projects: ${{ parameters.checkoutDirectory }}/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Microsoft.Maui.IntegrationTests.csproj
+    displayName: Build Microsoft.Maui.IntegrationTests
 
-    - pwsh: |
-        Write-Host "Current job status is: $env:AGENT_JOBSTATUS"
-        if ($env:AGENT_JOBSTATUS -eq "SucceededWithIssues") {
-            Write-Host "##vso[task.complete result=Failed;]DONE"
-        }
-      displayName: Fail if any issues occurred
+  - task: DotNetCoreCLI@2
+    inputs:
+      command: test
+      projects: ${{ parameters.checkoutDirectory }}/src/TestUtils/src/Microsoft.Maui.IntegrationTests/bin/Debug/net7.0/Microsoft.Maui.IntegrationTests.dll
+      arguments: --logger "console;verbosity=normal" --filter "FullyQualifiedName=Microsoft.Maui.IntegrationTests.TemplateTests"
+      publishTestResults: true
+      testRunTitle: $(PLATFORM_NAME) template build tests
+    displayName: $(PLATFORM_NAME) template build tests
+    continueOnError: true
+
+  - pwsh: |
+      Write-Host "Current job status is: $env:AGENT_JOBSTATUS"
+      if ($env:AGENT_JOBSTATUS -eq "SucceededWithIssues") {
+          Write-Host "##vso[task.complete result=Failed;]DONE"
+      }
+    displayName: Fail if any issues occurred
 
 - ${{ each RunPlatform in parameters.RunPlatforms }}:
   - job: run_${{ RunPlatform.testName }}

--- a/eng/pipelines/common/maui-templates.yml
+++ b/eng/pipelines/common/maui-templates.yml
@@ -67,7 +67,7 @@ jobs:
         ${{ BuildPlatform.name }}:
           POOL_NAME: ${{ BuildPlatform.poolName }}
           POOL_VIMAGE: ${{ BuildPlatform.vmImage }}
-          PLATFORM_NAME: ${{ BuildPlatform.name }}
+          PLATFORM_NAME: ${{ lower(BuildPlatform.name) }}
 
   pool:
     name: $(POOL_NAME)


### PR DESCRIPTION
Move to minimize the size of the yaml by using a matrix over expanding the same templates twice. This will reduce the final size of the yaml of the pipeline.


