### PR TITLE
Update Win2D

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -24,7 +24,7 @@
     <!-- wasdk -->
     <MicrosoftWindowsAppSDKPackageVersion>1.3.230502000</MicrosoftWindowsAppSDKPackageVersion>
     <MicrosoftWindowsSDKBuildToolsPackageVersion>10.0.22621.756</MicrosoftWindowsSDKBuildToolsPackageVersion>
-    <MicrosoftGraphicsWin2DPackageVersion>1.0.4</MicrosoftGraphicsWin2DPackageVersion>
+    <MicrosoftGraphicsWin2DPackageVersion>1.0.5.1</MicrosoftGraphicsWin2DPackageVersion>
     <!-- Everything else -->
     <MicrosoftAspNetCoreAuthorizationPackageVersion>7.0.5</MicrosoftAspNetCoreAuthorizationPackageVersion>
     <MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>7.0.5</MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>


### PR DESCRIPTION
### Description of Change

Bump Win2D to the latest patch which includes a fix for loading fonts via file:// -based URI which allows for unpackaged apps to use it.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #9104

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
