### PR TITLE
[net7.0] Reinstate WebView Cookies functionality net7

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Controls/WebViewPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/WebViewPage.xaml
@@ -109,6 +109,12 @@
 					x:Name="EvalResultLabel"
                     Text="..."
                     Style="{StaticResource Headline}"/>
+                <Label
+                    Text="Cookies"
+                    Style="{StaticResource Headline}"/>
+                <Button
+                    Text="Load httpbin.org with Cookies"
+                    Clicked="OnLoadHttpBinClicked" />
                 <StackLayout
                     IsVisible="{OnPlatform Android=True, Default=False}">
                     <Label

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/WebViewPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/WebViewPage.xaml.cs
@@ -101,5 +101,15 @@ namespace Maui.Controls.Sample.Pages
 		{
 			MauiWebView.On<Microsoft.Maui.Controls.PlatformConfiguration.Android>().EnableZoomControls(true);
 		}
+
+		void OnLoadHttpBinClicked(object sender, EventArgs e)
+		{
+			// on httpbin.org find the section where you can load the cookies for the website.
+			// The cookie that is set below should show up for this to succeed.
+			MauiWebView.Cookies = new System.Net.CookieContainer();
+			MauiWebView.Cookies.Add(new System.Net.Cookie("MauiCookie", "Hmmm Cookies!", "/", "httpbin.org"));
+
+			MauiWebView.Source = new UrlWebViewSource { Url = "https://httpbin.org/#/Cookies/get_cookies" };
+		}
 	}
 }

--- a/src/Core/src/Handlers/WebView/WebViewHandler.Android.cs
+++ b/src/Core/src/Handlers/WebView/WebViewHandler.Android.cs
@@ -144,7 +144,7 @@ namespace Microsoft.Maui.Handlers
 			if (url == AssetBaseUrl)
 				return false;
 
-			// TODO: Sync Cookies
+			SyncPlatformCookies(url);
 			bool cancel = VirtualView.Navigating(CurrentNavigationEvent, url);
 
 			// if the user disconnects from the handler we want to exit

--- a/src/Core/src/Handlers/WebView/WebViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/WebView/WebViewHandler.Windows.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Threading.Tasks;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.Web.WebView2.Core;
@@ -15,7 +16,7 @@ namespace Microsoft.Maui.Handlers
 		readonly HashSet<string> _loadedCookies = new HashSet<string>();
 		Window? _window;
 
-		protected override WebView2 CreatePlatformView() => new MauiWebView();
+		protected override WebView2 CreatePlatformView() => new MauiWebView(this);
 
 		internal WebNavigationEvent CurrentNavigationEvent
 		{
@@ -171,11 +172,11 @@ namespace Microsoft.Maui.Handlers
 				SendNavigated(uri, CurrentNavigationEvent, WebNavigationResult.Failure);
 		}
 
-		void SendNavigated(string url, WebNavigationEvent evnt, WebNavigationResult result)
+		async void SendNavigated(string url, WebNavigationEvent evnt, WebNavigationResult result)
 		{
 			if (VirtualView is not null)
 			{
-				SyncPlatformCookiesToVirtualView(url);
+				await SyncPlatformCookiesToVirtualView(url);
 
 				VirtualView.Navigated(evnt, url, result);
 				PlatformView?.UpdateCanGoBackForward(VirtualView);
@@ -184,7 +185,7 @@ namespace Microsoft.Maui.Handlers
 			CurrentNavigationEvent = WebNavigationEvent.NewPage;
 		}
 
-		void SyncPlatformCookiesToVirtualView(string url)
+		async Task SyncPlatformCookiesToVirtualView(string url)
 		{
 			var myCookieJar = VirtualView.Cookies;
 
@@ -197,10 +198,9 @@ namespace Microsoft.Maui.Handlers
 				return;
 
 			var cookies = myCookieJar.GetCookies(uri);
-			var retrieveCurrentWebCookies = GetCookiesFromPlatformStore(url);
+			var retrieveCurrentWebCookies = await GetCookiesFromPlatformStore(url);
 
-			var filter = new global::Windows.Web.Http.Filters.HttpBaseProtocolFilter();
-			var platformCookies = filter.CookieManager.GetCookies(uri);
+			var platformCookies = await PlatformView.CoreWebView2.CookieManager.GetCookiesAsync(uri.AbsoluteUri);
 
 			foreach (Cookie cookie in cookies)
 			{
@@ -213,10 +213,10 @@ namespace Microsoft.Maui.Handlers
 					cookie.Value = httpCookie.Value;
 			}
 
-			SyncPlatformCookies(url);
+			await SyncPlatformCookies(url);
 		}
 
-		void SyncPlatformCookies(string url)
+		internal async Task SyncPlatformCookies(string url)
 		{
 			var uri = CreateUriForCookies(url);
 
@@ -228,35 +228,30 @@ namespace Microsoft.Maui.Handlers
 			if (myCookieJar is null)
 				return;
 
-			InitialCookiePreloadIfNecessary(url);
+			await InitialCookiePreloadIfNecessary(url);
 			var cookies = myCookieJar.GetCookies(uri);
 
 			if (cookies is null)
 				return;
 
-			var retrieveCurrentWebCookies = GetCookiesFromPlatformStore(url);
-
-			var filter = new global::Windows.Web.Http.Filters.HttpBaseProtocolFilter();
+			var retrieveCurrentWebCookies = await GetCookiesFromPlatformStore(url);
 
 			foreach (Cookie cookie in cookies)
 			{
-				HttpCookie httpCookie = new HttpCookie(cookie.Name, cookie.Domain, cookie.Path)
-				{
-					Value = cookie.Value
-				};
-				filter.CookieManager.SetCookie(httpCookie, false);
+				var createdCookie = PlatformView.CoreWebView2.CookieManager.CreateCookie(cookie.Name, cookie.Value, cookie.Domain, cookie.Path);
+				PlatformView.CoreWebView2.CookieManager.AddOrUpdateCookie(createdCookie);
 			}
 
-			foreach (HttpCookie cookie in retrieveCurrentWebCookies)
+			foreach (CoreWebView2Cookie cookie in retrieveCurrentWebCookies)
 			{
 				if (cookies[cookie.Name] is not null)
 					continue;
 
-				filter.CookieManager.DeleteCookie(cookie);
+				PlatformView.CoreWebView2.CookieManager.DeleteCookie(cookie);
 			}
 		}
 
-		void InitialCookiePreloadIfNecessary(string url)
+		async Task InitialCookiePreloadIfNecessary(string url)
 		{
 			var myCookieJar = VirtualView.Cookies;
 
@@ -272,22 +267,27 @@ namespace Microsoft.Maui.Handlers
 
 			if (cookies is not null)
 			{
-				var existingCookies = GetCookiesFromPlatformStore(url);
-				foreach (HttpCookie cookie in existingCookies)
+				var existingCookies = await GetCookiesFromPlatformStore(url);
+
+				if (existingCookies.Count == 0)
+					return;
+
+				foreach (CoreWebView2Cookie cookie in existingCookies)
 				{
-					if (cookies[cookie.Name] is null)
-						myCookieJar.SetCookies(uri, cookie.ToString());
+					myCookieJar.SetCookies(uri,
+							new Cookie(cookie.Name, cookie.Value, cookie.Path, cookie.Domain)
+							{
+								Expires = DateTimeOffset.FromUnixTimeMilliseconds((long)cookie.Expires).DateTime,
+								HttpOnly = cookie.IsHttpOnly,
+								Secure = cookie.IsSecure,
+							}.ToString());
 				}
 			}
 		}
 
-		HttpCookieCollection GetCookiesFromPlatformStore(string url)
+		Task<IReadOnlyList<CoreWebView2Cookie>> GetCookiesFromPlatformStore(string url)
 		{
-			var uri = CreateUriForCookies(url);
-			var filter = new global::Windows.Web.Http.Filters.HttpBaseProtocolFilter();
-			var platformCookies = filter.CookieManager.GetCookies(uri);
-
-			return platformCookies;
+			return PlatformView.CoreWebView2.CookieManager.GetCookiesAsync(url).AsTask();
 		}
 
 		Uri? CreateUriForCookies(string url)

--- a/src/Core/src/Handlers/WebView/WebViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/WebView/WebViewHandler.iOS.cs
@@ -169,7 +169,7 @@ namespace Microsoft.Maui.Handlers
 			}
 		}
 
-		bool HasCookiesToLoad(string url)
+		internal bool HasCookiesToLoad(string url)
 		{
 			var uri = CreateUriForCookies(url);
 
@@ -239,7 +239,7 @@ namespace Microsoft.Maui.Handlers
 			await SyncPlatformCookiesAsync(url);
 		}
 
-		async Task SyncPlatformCookiesAsync(string url)
+		internal async Task SyncPlatformCookiesAsync(string url)
 		{
 			var uri = CreateUriForCookies(url);
 

--- a/src/Core/src/Platform/Android/MauiWebViewClient.cs
+++ b/src/Core/src/Platform/Android/MauiWebViewClient.cs
@@ -24,7 +24,10 @@ namespace Microsoft.Maui.Platform
 			if (_handler?.VirtualView == null || url == WebViewHandler.AssetBaseUrl)
 				return;
 
-			// TODO: Sync Cookies
+			if (!string.IsNullOrWhiteSpace(url))
+			{
+				_handler.SyncPlatformCookiesToVirtualView(url);
+			}
 
 			var cancel = false;
 

--- a/src/Core/src/Platform/Windows/MauiWebView.cs
+++ b/src/Core/src/Platform/Windows/MauiWebView.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Reflection.Metadata;
 using System.Text.RegularExpressions;
 using Microsoft.Maui.ApplicationModel;
 using Microsoft.UI.Xaml.Controls;
@@ -9,6 +10,15 @@ namespace Microsoft.Maui.Platform
 {
 	public class MauiWebView : WebView2, IWebViewDelegate
 	{
+		readonly WeakReference<WebViewHandler>? _handler;
+
+		internal MauiWebView(WebViewHandler handler)
+			: this()
+		{
+			ArgumentNullException.ThrowIfNull(handler, nameof(handler));
+			_handler = new WeakReference<WebViewHandler>(handler);
+		}
+
 		public MauiWebView()
 		{
 			NavigationStarting += (sender, args) =>
@@ -122,7 +132,8 @@ namespace Microsoft.Maui.Platform
 				uri = new Uri(LocalScheme + url, UriKind.RelativeOrAbsolute);
 			}
 
-			// TODO: Sync Cookies
+			if (_handler?.TryGetTarget(out var handler) ?? false)
+				await handler.SyncPlatformCookies(uri.AbsoluteUri);
 
 			try
 			{


### PR DESCRIPTION
### Description of Change

Makes the cookie functionality work for `WebView` on iOS, Android and Windows. 
Backport or #13518 (but without the breaking changes) and #13736
