### PR TITLE
Fix broken button when adding PGR implicitly

### DIFF
--- a/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Android.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Android.cs
@@ -180,7 +180,34 @@ namespace Microsoft.Maui.Controls.Platform
 			if (platformView == null)
 				return;
 
-			if (View.GestureController.CompositeGestureRecognizers.Count == 0)
+			bool shouldAddTouchEvent = false;
+
+			// This change is probably not 100 percent correct.
+			// The main purpose right now is to maintain the behavior of this code
+			// prior to this change
+			// https://github.com/dotnet/maui/commit/2c301d7988a06c3b41c2992bbee557aca04c9388#diff-2d78f02242798d0f2863f679e4dfdee230944be37db5e1a1446bfa4c6c43a5c6R183
+			// If the only CompositeGestureRecognizers is a PointerGestureRecognizer
+			//
+			// Most likely we should just not subscribe to Touch at all if the only gesture is a PGR
+			// But that will be re-evaluated for preview6
+			if (View.GestureRecognizers.Count == 0)
+			{
+				var recognizers = View.GestureController.CompositeGestureRecognizers;
+				foreach (var recognizer in recognizers)
+				{
+					if (recognizer is not PointerGestureRecognizer)
+					{
+						shouldAddTouchEvent = true;
+						break;
+					}
+				}
+			}
+			else
+			{
+				shouldAddTouchEvent = true;
+			}
+
+			if (shouldAddTouchEvent)
 			{
 				platformView.Touch -= OnPlatformViewTouched;
 			}

--- a/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Android.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Android.cs
@@ -207,7 +207,7 @@ namespace Microsoft.Maui.Controls.Platform
 				shouldAddTouchEvent = true;
 			}
 
-			if (shouldAddTouchEvent)
+			if (!shouldAddTouchEvent)
 			{
 				platformView.Touch -= OnPlatformViewTouched;
 			}


### PR DESCRIPTION
### Description of Change

https://github.com/dotnet/maui/commit/2c301d7988a06c3b41c2992bbee557aca04c9388#diff-2d78f02242798d0f2863f679e4dfdee230944be37db5e1a1446bfa4c6c43a5c6R183

Caused a regression with `Button` when you have a `PointerOver` visual state added to a control. Whenever a control has a `PointerOver` VSM we add a PointerGestureRecognizer to handle that state change. Ideally, we could just add a PGR to everything so the behavior isn't so edge case but that causes accessibility on `Android` to break so we have to be much more targeted about when adding a PGR (https://github.com/dotnet/maui/issues/11742 and https://github.com/dotnet/maui/pull/11591 for background)




This change most likely isn't 100 percent correct but it should be small enough to return net8 back to working without introducing additional changes in behavior. I'm pretty sure we should be modifying OnTouchEvent to not consume the touch event if the only `GR` is a `PGR` or we should just not subscribe to OnTouched if the only `GR` is a `PGR`. 
