### PR TITLE
Modify ID Generator Starting Point of DataTemplate Class to Prevent ItemViewType Collision

### DIFF
--- a/src/Controls/src/Core/DataTemplate.cs
+++ b/src/Controls/src/Core/DataTemplate.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../docs/Microsoft.Maui.Controls/DataTemplate.xml" path="Type[@FullName='Microsoft.Maui.Controls.DataTemplate']/Docs/*" />
 	public class DataTemplate : ElementTemplate, IDataTemplateController
 	{
-		static int idCounter = 1;
+		static int idCounter = 100;
 
 		int _id;
 		string _idString;


### PR DESCRIPTION
Hi! There was a recent change to generate unique IDs for DataTemplate.Type to cache and reuse templates [here](https://github.com/dotnet/maui/pull/12011). Unfortunately, it causes an unwanted side effect as the ID of types in ItemViewType (e.g., TextItem, Header, GroupHeader, etc.) are defined within the ID range of 41-46. 

### Description of Change

I believe the simplest change would be to start ID generation of the DataTemplate class to a higher value, say 100. This prevents collisions with the predefined IDs in ItemViewType for Android, but also provides room for extension if additional types need to be added in the future. 

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #15437

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
