### PR TITLE
Fix issues setting Shell TabBar appearance 

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/AppShell.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/AppShell.xaml
@@ -6,6 +6,8 @@
     xmlns:pages="using:Maui.Controls.Sample.Pages"
     xmlns:shellPages="clr-namespace:Maui.Controls.Sample.Pages.ShellGalleries"
     FlyoutBackground="{AppThemeBinding Dark=Black, Light=White}"
+    TabBarForegroundColor="Red"
+    TabBarUnselectedColor="DarkBlue"
     Title="{Binding ShellTitle}">
     <Shell.TitleView>
         <Grid

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellBottomNavViewAppearanceTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellBottomNavViewAppearanceTracker.cs
@@ -54,8 +54,15 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			var unselectedColor = controller.EffectiveTabBarUnselectedColor;
 			var titleColor = controller.EffectiveTabBarTitleColor;
 
-			_itemTextColor = MakeColorStateList(titleColor, disabledColor, titleColor ?? unselectedColor);
-			_itemIconTint = MakeColorStateList(foregroundColor, disabledColor, unselectedColor);
+			_itemTextColor = MakeColorStateList(
+				titleColor ?? foregroundColor, 
+				disabledColor, 
+				titleColor ?? unselectedColor ?? foregroundColor);
+
+			_itemIconTint = MakeColorStateList(
+				foregroundColor ?? titleColor, 
+				disabledColor, 
+				unselectedColor ?? foregroundColor);
 
 			bottomView.ItemTextColor = _itemTextColor;
 			bottomView.ItemIconTintList = _itemIconTint;

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellBottomNavViewAppearanceTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellBottomNavViewAppearanceTracker.cs
@@ -24,7 +24,8 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 		static ColorStateList _defaultListDark;
 
 		bool _disposed;
-		ColorStateList _colorStateList;
+		ColorStateList _itemTextColor;
+		ColorStateList _itemIconTint;
 
 		public ShellBottomNavViewAppearanceTracker(IShellContext shellContext, ShellItem shellItem)
 		{
@@ -48,14 +49,16 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 		{
 			IShellAppearanceElement controller = appearance;
 			var backgroundColor = controller.EffectiveTabBarBackgroundColor;
-			var foregroundColor = controller.EffectiveTabBarForegroundColor; // currently unused
+			var foregroundColor = controller.EffectiveTabBarForegroundColor;
 			var disabledColor = controller.EffectiveTabBarDisabledColor;
 			var unselectedColor = controller.EffectiveTabBarUnselectedColor;
 			var titleColor = controller.EffectiveTabBarTitleColor;
 
-			_colorStateList = MakeColorStateList(titleColor, disabledColor, unselectedColor);
-			bottomView.ItemTextColor = _colorStateList;
-			bottomView.ItemIconTintList = _colorStateList;
+			_itemTextColor = MakeColorStateList(titleColor, disabledColor, titleColor ?? unselectedColor);
+			_itemIconTint = MakeColorStateList(foregroundColor, disabledColor, unselectedColor);
+
+			bottomView.ItemTextColor = _itemTextColor;
+			bottomView.ItemIconTintList = _itemIconTint;
 
 			SetBackgroundColor(bottomView, backgroundColor);
 		}
@@ -162,11 +165,13 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 			if (disposing)
 			{
-				_colorStateList?.Dispose();
+				_itemTextColor?.Dispose();
+				_itemIconTint?.Dispose();
 
+				_itemIconTint = null;
 				_shellItem = null;
 				_shellContext = null;
-				_colorStateList = null;
+				_itemTextColor = null;
 			}
 		}
 

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellBottomNavViewAppearanceTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellBottomNavViewAppearanceTracker.cs
@@ -57,12 +57,12 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			_itemTextColor = MakeColorStateList(
 				titleColor ?? foregroundColor, 
 				disabledColor, 
-				titleColor ?? unselectedColor ?? foregroundColor);
+				unselectedColor);
 
 			_itemIconTint = MakeColorStateList(
 				foregroundColor ?? titleColor, 
 				disabledColor, 
-				unselectedColor ?? foregroundColor);
+				unselectedColor);
 
 			bottomView.ItemTextColor = _itemTextColor;
 			bottomView.ItemIconTintList = _itemIconTint;

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/SafeShellTabBarAppearanceTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/SafeShellTabBarAppearanceTracker.cs
@@ -71,40 +71,47 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 		{
 			IShellAppearanceElement appearanceElement = appearance;
 
+			var backgroundColor = appearanceElement.EffectiveTabBarBackgroundColor;
+			var foregroundColor = appearanceElement.EffectiveTabBarForegroundColor;
+			var unselectedColor = appearanceElement.EffectiveTabBarUnselectedColor;
+			var titleColor = appearanceElement.EffectiveTabBarTitleColor;
+
 			controller.TabBar
 				.UpdateiOS15TabBarAppearance(
 					ref _tabBarAppearance,
 					null,
 					null,
-					appearanceElement.EffectiveTabBarForegroundColor,
-					appearanceElement.EffectiveTabBarUnselectedColor,
-					appearanceElement.EffectiveTabBarBackgroundColor,
-					appearanceElement.EffectiveTabBarTitleColor);
+					foregroundColor ?? titleColor,
+					unselectedColor,
+					backgroundColor,
+					titleColor ?? foregroundColor,
+					unselectedColor);
 		}
 
 		void UpdateTabBarAppearance(UITabBarController controller, ShellAppearance appearance)
 		{
 			IShellAppearanceElement appearanceElement = appearance;
 			var backgroundColor = appearanceElement.EffectiveTabBarBackgroundColor;
-			var unselectedColor = appearanceElement.EffectiveTabBarUnselectedColor;
 			var foregroundColor = appearanceElement.EffectiveTabBarForegroundColor;
-			var titleColor = appearanceElement.EffectiveTabBarTitleColor ?? foregroundColor;
+			var unselectedColor = appearanceElement.EffectiveTabBarUnselectedColor;
+			var titleColor = appearanceElement.EffectiveTabBarTitleColor;
 
 			var tabBar = controller.TabBar;
 
 			if (backgroundColor is not null && backgroundColor.IsNotDefault())
 				tabBar.BarTintColor = backgroundColor.ToPlatform();
 
-			if (foregroundColor.IsDefault != null && foregroundColor.IsNotDefault())
-				tabBar.TintColor = foregroundColor.ToPlatform();
-
 			if (unselectedColor.IsDefault != null && unselectedColor.IsNotDefault())
-				tabBar.UnselectedItemTintColor = unselectedColor.ToPlatform();
-
-			if (titleColor.IsDefault != null && titleColor.IsNotDefault())
 			{
-				UITabBarItem.Appearance.SetTitleTextAttributes(new UIStringAttributes { ForegroundColor = titleColor.ToPlatform() }, UIControlState.Normal);
-				UITabBarItem.Appearance.SetTitleTextAttributes(new UIStringAttributes { ForegroundColor = titleColor.ToPlatform() }, UIControlState.Selected);
+				tabBar.UnselectedItemTintColor = unselectedColor.ToPlatform();
+				UITabBarItem.Appearance.SetTitleTextAttributes(new UIStringAttributes { ForegroundColor = unselectedColor.ToPlatform() }, UIControlState.Normal);
+			}
+
+			if (titleColor.IsDefault != null && titleColor.IsNotDefault() ||
+				foregroundColor.IsDefault != null && foregroundColor.IsNotDefault())
+			{
+				tabBar.TintColor = (foregroundColor ?? titleColor).ToPlatform();
+				UITabBarItem.Appearance.SetTitleTextAttributes(new UIStringAttributes { ForegroundColor = (titleColor ?? foregroundColor).ToPlatform() }, UIControlState.Selected);
 			}
 		}
 	}

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/SafeShellTabBarAppearanceTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/SafeShellTabBarAppearanceTracker.cs
@@ -87,16 +87,25 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			IShellAppearanceElement appearanceElement = appearance;
 			var backgroundColor = appearanceElement.EffectiveTabBarBackgroundColor;
 			var unselectedColor = appearanceElement.EffectiveTabBarUnselectedColor;
-			var titleColor = appearanceElement.EffectiveTabBarTitleColor;
+			var foregroundColor = appearanceElement.EffectiveTabBarForegroundColor;
+			var titleColor = appearanceElement.EffectiveTabBarTitleColor ?? foregroundColor;
 
 			var tabBar = controller.TabBar;
 
-			if (backgroundColor != null)
+			if (backgroundColor is not null && backgroundColor.IsNotDefault())
 				tabBar.BarTintColor = backgroundColor.ToPlatform();
-			if (titleColor.IsDefault != null)
-				tabBar.TintColor = titleColor.ToPlatform();
-			if (unselectedColor.IsDefault != null)
+
+			if (foregroundColor.IsDefault != null && foregroundColor.IsNotDefault())
+				tabBar.TintColor = foregroundColor.ToPlatform();
+
+			if (unselectedColor.IsDefault != null && unselectedColor.IsNotDefault())
 				tabBar.UnselectedItemTintColor = unselectedColor.ToPlatform();
+
+			if (titleColor.IsDefault != null && titleColor.IsNotDefault())
+			{
+				UITabBarItem.Appearance.SetTitleTextAttributes(new UIStringAttributes { ForegroundColor = titleColor.ToPlatform() }, UIControlState.Normal);
+				UITabBarItem.Appearance.SetTitleTextAttributes(new UIStringAttributes { ForegroundColor = titleColor.ToPlatform() }, UIControlState.Selected);
+			}
 		}
 	}
 }

--- a/src/Controls/src/Core/Compatibility/Handlers/TabbedPage/iOS/TabbedRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/TabbedPage/iOS/TabbedRenderer.cs
@@ -507,6 +507,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				Tabbed.IsSet(TabbedPage.SelectedTabColorProperty) ? Tabbed.SelectedTabColor : null,
 				Tabbed.IsSet(TabbedPage.UnselectedTabColorProperty) ? Tabbed.UnselectedTabColor : null,
 				Tabbed.IsSet(TabbedPage.BarBackgroundColorProperty) ? Tabbed.BarBackgroundColor : null,
+				Tabbed.IsSet(TabbedPage.BarTextColorProperty) ? Tabbed.BarTextColor : null,
 				Tabbed.IsSet(TabbedPage.BarTextColorProperty) ? Tabbed.BarTextColor : null);
 		}
 

--- a/src/Controls/src/Core/Compatibility/Handlers/TabbedPage/iOS/TabbedRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/TabbedPage/iOS/TabbedRenderer.cs
@@ -376,23 +376,21 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			else
 				tabBarTextColor = barTextColor.ToPlatform();
 
-			var attributes = new UIStringAttributes();
-			attributes.ForegroundColor = tabBarTextColor;
-
 			foreach (UITabBarItem item in TabBar.Items)
 			{
-				item.SetTitleTextAttributes(attributes, UIControlState.Normal);
-				item.SetTitleTextAttributes(attributes, UIControlState.Selected);
+				item.SetTitleTextAttributes(new UIStringAttributes() { ForegroundColor = tabBarTextColor }, UIControlState.Normal);
+				item.SetTitleTextAttributes(new UIStringAttributes() { ForegroundColor = tabBarTextColor }, UIControlState.Selected);
+				item.SetTitleTextAttributes(new UIStringAttributes() { ForegroundColor = tabBarTextColor }, UIControlState.Disabled);
 			}
-
-			//UITabBarItem.Appearance.SetTitleTextAttributes(new UIStringAttributes { ForegroundColor = tabBarTextColor }, UIControlState.Selected);
 
 			// set TintColor for selected icon
 			// setting the unselected icon tint is not supported by iOS
 			if (OperatingSystem.IsIOSVersionAtLeast(15) || OperatingSystem.IsTvOSVersionAtLeast(15))
 				UpdateiOS15TabBarAppearance();
-			//else
-			//	TabBar.TintColor = isDefaultColor ? _defaultBarTextColor : barTextColor.ToPlatform();
+			else
+			{
+				TabBar.TintColor = isDefaultColor ? _defaultBarTextColor : barTextColor.ToPlatform();
+			}
 		}
 
 		void UpdateBarTranslucent()
@@ -433,11 +431,6 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			var count = Tabbed.InternalChildren.Count;
 			var index = (int)SelectedIndex;
 			((TabbedPage)Element).CurrentPage = index >= 0 && index < count ? Tabbed.GetPageByIndex(index) : null;
-			UpdateBarTextColor();
-			this.Invoke(() =>
-			{
-				UpdateBarTextColor();
-			}, 10);
 		}
 
 		async void SetTabBarItem(IPlatformViewHandler renderer)
@@ -479,8 +472,6 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				else
 					TabBar.UnselectedItemTintColor = UITabBar.Appearance.TintColor;
 			}
-
-			UpdateBarTextColor();
 		}
 
 		/// <summary>

--- a/src/Controls/src/Core/Compatibility/Handlers/TabbedPage/iOS/TabbedRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/TabbedPage/iOS/TabbedRenderer.cs
@@ -382,14 +382,17 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			foreach (UITabBarItem item in TabBar.Items)
 			{
 				item.SetTitleTextAttributes(attributes, UIControlState.Normal);
+				item.SetTitleTextAttributes(attributes, UIControlState.Selected);
 			}
+
+			//UITabBarItem.Appearance.SetTitleTextAttributes(new UIStringAttributes { ForegroundColor = tabBarTextColor }, UIControlState.Selected);
 
 			// set TintColor for selected icon
 			// setting the unselected icon tint is not supported by iOS
 			if (OperatingSystem.IsIOSVersionAtLeast(15) || OperatingSystem.IsTvOSVersionAtLeast(15))
 				UpdateiOS15TabBarAppearance();
-			else
-				TabBar.TintColor = isDefaultColor ? _defaultBarTextColor : barTextColor.ToPlatform();
+			//else
+			//	TabBar.TintColor = isDefaultColor ? _defaultBarTextColor : barTextColor.ToPlatform();
 		}
 
 		void UpdateBarTranslucent()
@@ -430,6 +433,11 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			var count = Tabbed.InternalChildren.Count;
 			var index = (int)SelectedIndex;
 			((TabbedPage)Element).CurrentPage = index >= 0 && index < count ? Tabbed.GetPageByIndex(index) : null;
+			UpdateBarTextColor();
+			this.Invoke(() =>
+			{
+				UpdateBarTextColor();
+			}, 10);
 		}
 
 		async void SetTabBarItem(IPlatformViewHandler renderer)
@@ -471,6 +479,8 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				else
 					TabBar.UnselectedItemTintColor = UITabBar.Appearance.TintColor;
 			}
+
+			UpdateBarTextColor();
 		}
 
 		/// <summary>
@@ -508,7 +518,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				Tabbed.IsSet(TabbedPage.UnselectedTabColorProperty) ? Tabbed.UnselectedTabColor : null,
 				Tabbed.IsSet(TabbedPage.BarBackgroundColorProperty) ? Tabbed.BarBackgroundColor : null,
 				Tabbed.IsSet(TabbedPage.BarTextColorProperty) ? Tabbed.BarTextColor : null,
-				Tabbed.IsSet(TabbedPage.BarTextColorProperty) ? Tabbed.BarTextColor : null);
+				null);
 		}
 
 		#region IPlatformViewHandler

--- a/src/Controls/src/Core/HandlerImpl/TabbedPage/TabbedPage.Windows.cs
+++ b/src/Controls/src/Core/HandlerImpl/TabbedPage/TabbedPage.Windows.cs
@@ -271,7 +271,7 @@ namespace Microsoft.Maui.Controls
 
 		internal static void MapBarBackground(ITabbedViewHandler handler, TabbedPage view)
 		{
-			view._navigationView?.UpdateTopNavAreaBackground(view.BarBackground ?? view.BarBackgroundColor?.AsPaint());
+			// view._navigationView?.UpdateTopNavAreaBackground(view.BarBackground ?? view.BarBackgroundColor?.AsPaint());
 		}
 
 		internal static void MapBarBackgroundColor(ITabbedViewHandler handler, TabbedPage view)
@@ -282,16 +282,17 @@ namespace Microsoft.Maui.Controls
 		internal static void MapBarTextColor(ITabbedViewHandler handler, TabbedPage view)
 		{
 			view._navigationView?.UpdateTopNavigationViewItemTextColor(view.BarTextColor?.AsPaint());
+			view._navigationView?.UpdateTopNavigationViewItemTextSelectedColor(view.BarTextColor?.AsPaint());
 		}
 
 		internal static void MapUnselectedTabColor(ITabbedViewHandler handler, TabbedPage view)
 		{
-			view._navigationView?.UpdateTopNavigationViewItemBackgroundUnselectedColor(view.UnselectedTabColor?.AsPaint());
+			view._navigationView?.UpdateTopNavigationViewItemUnselectedColor(view.UnselectedTabColor?.AsPaint());
 		}
 
 		internal static void MapSelectedTabColor(ITabbedViewHandler handler, TabbedPage view)
 		{
-			view._navigationView?.UpdateTopNavigationViewItemBackgroundSelectedColor(view.SelectedTabColor?.AsPaint());
+			view._navigationView?.UpdateTopNavigationViewItemSelectedColor(view.SelectedTabColor?.AsPaint());
 		}
 
 		internal static void MapItemsSource(ITabbedViewHandler handler, TabbedPage view)
@@ -316,10 +317,10 @@ namespace Microsoft.Maui.Controls
 						vm.Icon = page.IconImageSource?.ToIconSource(handler.MauiContext!)?.CreateIconElement();
 						vm.Content = page.Title;
 						vm.Data = page;
-						vm.SelectedForeground = view.BarTextColor?.AsPaint()?.ToPlatform();
-						vm.UnselectedForeground = view.BarTextColor?.AsPaint()?.ToPlatform();
-						vm.SelectedBackground = view.SelectedTabColor?.AsPaint()?.ToPlatform();
-						vm.UnselectedBackground = view.UnselectedTabColor?.AsPaint()?.ToPlatform();
+						vm.SelectedTitleColor = view.BarTextColor?.AsPaint()?.ToPlatform();
+						vm.UnselectedTitleColor = view.BarTextColor?.AsPaint()?.ToPlatform();
+						vm.SelectedForeground = view.SelectedTabColor?.AsPaint()?.ToPlatform();
+						vm.UnselectedForeground = view.UnselectedTabColor?.AsPaint()?.ToPlatform();
 					});
 
 				handler.UpdateValue(nameof(TabbedPage.CurrentPage));

--- a/src/Controls/src/Core/HandlerImpl/TabbedPage/TabbedPage.Windows.cs
+++ b/src/Controls/src/Core/HandlerImpl/TabbedPage/TabbedPage.Windows.cs
@@ -316,7 +316,8 @@ namespace Microsoft.Maui.Controls
 						vm.Icon = page.IconImageSource?.ToIconSource(handler.MauiContext!)?.CreateIconElement();
 						vm.Content = page.Title;
 						vm.Data = page;
-						vm.Foreground = view.BarTextColor?.AsPaint()?.ToPlatform();
+						vm.SelectedForeground = view.BarTextColor?.AsPaint()?.ToPlatform();
+						vm.UnselectedForeground = view.BarTextColor?.AsPaint()?.ToPlatform();
 						vm.SelectedBackground = view.SelectedTabColor?.AsPaint()?.ToPlatform();
 						vm.UnselectedBackground = view.UnselectedTabColor?.AsPaint()?.ToPlatform();
 					});

--- a/src/Controls/src/Core/Handlers/Shell/ShellItemHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellItemHandler.Windows.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Maui.Controls.Handlers
 		ShellItem? _shellItem;
 		SearchHandler? _currentSearchHandler;
 		MauiNavigationView? _mauiNavigationView;
+		IShellAppearanceElement? _shellAppearanceElement;
 		MauiNavigationView ShellItemNavigationView => _mauiNavigationView!;
 
 		public ShellItemHandler() : base(Mapper, CommandMapper)
@@ -442,29 +443,31 @@ namespace Microsoft.Maui.Controls.Handlers
 		{
 			if (appearance is IShellAppearanceElement a)
 			{
+				_shellAppearanceElement = a;
 				// This means the template hasn't been applied yet
-				if (ShellItemNavigationView.TopNavArea == null)
+				if (ShellItemNavigationView.TopNavArea is null)
 				{
 					ShellItemNavigationView.OnApplyTemplateFinished += OnApplyTemplateFinished;
-
-					void OnApplyTemplateFinished(object? sender, EventArgs e)
-					{
-						ShellItemNavigationView.OnApplyTemplateFinished -= OnApplyTemplateFinished;
-						ApplyAppearance();
-					}
-				}
-				else
-				{
-					ApplyAppearance();
 				}
 
-				void ApplyAppearance()
-				{
-					ShellItemNavigationView.UpdateTopNavAreaBackground(a.EffectiveTabBarBackgroundColor?.AsPaint());
-					ShellItemNavigationView.UpdateTopNavigationViewItemTextColor(a.EffectiveTabBarForegroundColor?.AsPaint());
-					ShellItemNavigationView.UpdateTopNavigationViewItemUnselectedColor(a.EffectiveTabBarUnselectedColor?.AsPaint());
-				}
+				ApplyAppearance();
 			}
+		}
+
+		void ApplyAppearance()
+		{
+			if (_shellAppearanceElement is null)
+				return;
+
+			ShellItemNavigationView.UpdateTopNavAreaBackground(_shellAppearanceElement.EffectiveTabBarBackgroundColor?.AsPaint());
+			ShellItemNavigationView.UpdateTopNavigationViewItemUnselectedColor(_shellAppearanceElement.EffectiveTabBarUnselectedColor?.AsPaint());
+			ShellItemNavigationView.UpdateTopNavigationViewItemTextColor(_shellAppearanceElement.EffectiveTabBarForegroundColor?.AsPaint());
+		}
+
+		void OnApplyTemplateFinished(object? sender, EventArgs e)
+		{
+			ShellItemNavigationView.OnApplyTemplateFinished -= OnApplyTemplateFinished;
+			ApplyAppearance();
 		}
 	}
 }

--- a/src/Controls/src/Core/Handlers/Shell/ShellItemHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellItemHandler.Windows.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using Microsoft.Maui.Controls.Platform;
+using Microsoft.Maui.Platform;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using WApp = Microsoft.UI.Xaml.Application;
@@ -461,7 +462,8 @@ namespace Microsoft.Maui.Controls.Handlers
 
 			ShellItemNavigationView.UpdateTopNavAreaBackground(_shellAppearanceElement.EffectiveTabBarBackgroundColor?.AsPaint());
 			ShellItemNavigationView.UpdateTopNavigationViewItemUnselectedColor(_shellAppearanceElement.EffectiveTabBarUnselectedColor?.AsPaint());
-			ShellItemNavigationView.UpdateTopNavigationViewItemTextColor(_shellAppearanceElement.EffectiveTabBarForegroundColor?.AsPaint());
+			ShellItemNavigationView.UpdateTopNavigationViewItemTextColor(_shellAppearanceElement.EffectiveTabBarTitleColor?.AsPaint());
+			ShellItemNavigationView.UpdateTopNavigationViewItemSelectedColor(_shellAppearanceElement.EffectiveTabBarForegroundColor?.AsPaint());
 		}
 
 		void OnApplyTemplateFinished(object? sender, EventArgs e)

--- a/src/Controls/src/Core/Handlers/Shell/ShellItemHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellItemHandler.Windows.cs
@@ -460,10 +460,16 @@ namespace Microsoft.Maui.Controls.Handlers
 			if (_shellAppearanceElement is null)
 				return;
 
-			ShellItemNavigationView.UpdateTopNavAreaBackground(_shellAppearanceElement.EffectiveTabBarBackgroundColor?.AsPaint());
-			ShellItemNavigationView.UpdateTopNavigationViewItemUnselectedColor(_shellAppearanceElement.EffectiveTabBarUnselectedColor?.AsPaint());
-			ShellItemNavigationView.UpdateTopNavigationViewItemTextColor(_shellAppearanceElement.EffectiveTabBarTitleColor?.AsPaint());
-			ShellItemNavigationView.UpdateTopNavigationViewItemSelectedColor(_shellAppearanceElement.EffectiveTabBarForegroundColor?.AsPaint());
+			var backgroundColor = _shellAppearanceElement.EffectiveTabBarBackgroundColor?.AsPaint();
+			var foregroundColor = _shellAppearanceElement.EffectiveTabBarForegroundColor?.AsPaint();
+			var unselectedColor = _shellAppearanceElement.EffectiveTabBarUnselectedColor?.AsPaint();
+			var titleColor = _shellAppearanceElement.EffectiveTabBarTitleColor?.AsPaint();
+
+			ShellItemNavigationView.UpdateTopNavAreaBackground(backgroundColor);
+			ShellItemNavigationView.UpdateTopNavigationViewItemUnselectedColor(unselectedColor ?? foregroundColor);
+			ShellItemNavigationView.UpdateTopNavigationViewItemTextSelectedColor(titleColor ?? foregroundColor);
+			ShellItemNavigationView.UpdateTopNavigationViewItemTextColor(titleColor ?? unselectedColor ?? foregroundColor);
+			ShellItemNavigationView.UpdateTopNavigationViewItemSelectedColor(foregroundColor ?? titleColor);
 		}
 
 		void OnApplyTemplateFinished(object? sender, EventArgs e)

--- a/src/Controls/src/Core/Handlers/Shell/ShellItemHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellItemHandler.Windows.cs
@@ -466,9 +466,9 @@ namespace Microsoft.Maui.Controls.Handlers
 			var titleColor = _shellAppearanceElement.EffectiveTabBarTitleColor?.AsPaint();
 
 			ShellItemNavigationView.UpdateTopNavAreaBackground(backgroundColor);
-			ShellItemNavigationView.UpdateTopNavigationViewItemUnselectedColor(unselectedColor ?? foregroundColor);
+			ShellItemNavigationView.UpdateTopNavigationViewItemUnselectedColor(unselectedColor);
 			ShellItemNavigationView.UpdateTopNavigationViewItemTextSelectedColor(titleColor ?? foregroundColor);
-			ShellItemNavigationView.UpdateTopNavigationViewItemTextColor(titleColor ?? unselectedColor ?? foregroundColor);
+			ShellItemNavigationView.UpdateTopNavigationViewItemTextColor(unselectedColor);
 			ShellItemNavigationView.UpdateTopNavigationViewItemSelectedColor(foregroundColor ?? titleColor);
 		}
 

--- a/src/Controls/src/Core/Handlers/Shell/ShellItemHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellItemHandler.Windows.cs
@@ -462,6 +462,7 @@ namespace Microsoft.Maui.Controls.Handlers
 				{
 					ShellItemNavigationView.UpdateTopNavAreaBackground(a.EffectiveTabBarBackgroundColor?.AsPaint());
 					ShellItemNavigationView.UpdateTopNavigationViewItemTextColor(a.EffectiveTabBarForegroundColor?.AsPaint());
+					ShellItemNavigationView.UpdateTopNavigationViewItemUnselectedColor(a.EffectiveTabBarUnselectedColor?.AsPaint());
 				}
 			}
 		}

--- a/src/Controls/src/Core/Platform/Windows/TabbedPage/TabbedPageStyle.xaml
+++ b/src/Controls/src/Core/Platform/Windows/TabbedPage/TabbedPageStyle.xaml
@@ -6,7 +6,7 @@
         <NavigationViewItem 
             x:Name="navViewItem"
             Content="{Binding Content}" 
-            Foreground="{Binding Foreground}" 
+            Foreground="{Binding TitleColor}" 
             Background="{Binding Background}" 
             IsSelected="{Binding IsSelected, Mode=TwoWay}"
             MenuItemsSource="{Binding MenuItemsSource}"

--- a/src/Controls/src/Core/Shell/ShellAppearance.cs
+++ b/src/Controls/src/Core/Shell/ShellAppearance.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Maui.Controls
 			TabBarForegroundColor ?? ForegroundColor;
 
 		Color IShellAppearanceElement.EffectiveTabBarTitleColor =>
-			TabBarTitleColor ?? TitleColor;
+			TabBarTitleColor ?? TitleColor ?? TabBarForegroundColor ?? ForegroundColor;
 
 		Color IShellAppearanceElement.EffectiveTabBarUnselectedColor =>
 			TabBarUnselectedColor ?? UnselectedColor;

--- a/src/Controls/src/Core/Shell/ShellAppearance.cs
+++ b/src/Controls/src/Core/Shell/ShellAppearance.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Maui.Controls
 			TabBarDisabledColor ?? DisabledColor;
 
 		Color IShellAppearanceElement.EffectiveTabBarForegroundColor =>
-			TabBarForegroundColor ?? ForegroundColor;
+			TabBarForegroundColor ?? ForegroundColor ?? TabBarTitleColor ?? TitleColor;
 
 		Color IShellAppearanceElement.EffectiveTabBarTitleColor =>
 			TabBarTitleColor ?? TitleColor ?? TabBarForegroundColor ?? ForegroundColor;

--- a/src/Controls/src/Core/Shell/ShellAppearance.cs
+++ b/src/Controls/src/Core/Shell/ShellAppearance.cs
@@ -81,10 +81,10 @@ namespace Microsoft.Maui.Controls
 			TabBarDisabledColor ?? DisabledColor;
 
 		Color IShellAppearanceElement.EffectiveTabBarForegroundColor =>
-			TabBarForegroundColor ?? ForegroundColor ?? TabBarTitleColor ?? TitleColor;
+			TabBarForegroundColor ?? ForegroundColor;
 
 		Color IShellAppearanceElement.EffectiveTabBarTitleColor =>
-			TabBarTitleColor ?? TitleColor ?? TabBarForegroundColor ?? ForegroundColor;
+			TabBarTitleColor ?? TitleColor;
 
 		Color IShellAppearanceElement.EffectiveTabBarUnselectedColor =>
 			TabBarUnselectedColor ?? UnselectedColor;

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.Windows.cs
@@ -72,6 +72,62 @@ namespace Microsoft.Maui.DeviceTests
 			await ValidateHasColor(shell, expectedColor, typeof(ShellHandler));
 		}
 
+		[Theory(DisplayName = "Shell TabBar Foreground Initializes Correctly")]
+		[InlineData("#FF0000")]
+		[InlineData("#0000FF")]
+		public async Task ShellTabBarForegroundInitializesCorrectly(string colorHex)
+		{
+			SetupBuilder();
+
+			var expectedColor = Color.FromArgb(colorHex);
+
+			var shell = await CreateShellAsync((shell) =>
+			{
+				shell.FlyoutBehavior = FlyoutBehavior.Disabled;
+				Shell.SetTabBarForegroundColor(shell, expectedColor);
+
+				shell.Items.Add(new TabBar()
+				{
+					Items =
+					{
+						new ShellContent()
+						{
+							Route = "Tab1",
+							Content = new ContentPage()
+						},
+						new ShellContent()
+						{
+							Route = "Tab2",
+							Content = new ContentPage()
+						},
+					}
+				});
+			});
+
+			await InvokeOnMainThreadAsync(async () =>
+			{
+				await CreateHandlerAndAddToWindow<ShellHandler>(shell, (handler) =>
+				{
+					var rootNavView = handler.PlatformView;
+					var shellItemView = shell.CurrentItem.Handler.PlatformView as MauiNavigationView;
+					var expectedRoot = UI.Xaml.Controls.NavigationViewPaneDisplayMode.LeftMinimal;
+				
+					Assert.Equal(expectedRoot, rootNavView.PaneDisplayMode);
+					Assert.NotNull(shellItemView);
+				
+					return Task.CompletedTask;
+				});
+
+				await AssertionExtensions.Wait(() =>
+				{
+					var platformView = shell.Handler.PlatformView as FrameworkElement;
+					return platformView is not null && (platformView.Height > 0 || platformView.Width > 0);
+				});
+			});
+
+			await ValidateHasColor(shell, expectedColor, typeof(ShellHandler));
+		}
+	
 		[Fact(DisplayName = "Back Button Enabled/Disabled")]
 		public async Task BackButtonEnabledAndDisabled()
 		{

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.Windows.cs
@@ -74,7 +74,8 @@ namespace Microsoft.Maui.DeviceTests
 
 		[Theory(DisplayName = "Shell TabBar Foreground Initializes Correctly")]
 		[InlineData("#FF0000")]
-		[InlineData("#0000FF")]
+		[InlineData("#00FF00")]
+
 		public async Task ShellTabBarForegroundInitializesCorrectly(string colorHex)
 		{
 			SetupBuilder();
@@ -93,11 +94,13 @@ namespace Microsoft.Maui.DeviceTests
 						new ShellContent()
 						{
 							Route = "Tab1",
+							Title= "Tab1",
 							Content = new ContentPage()
 						},
 						new ShellContent()
 						{
 							Route = "Tab2",
+							Title= "Tab2",
 							Content = new ContentPage()
 						},
 					}
@@ -111,10 +114,10 @@ namespace Microsoft.Maui.DeviceTests
 					var rootNavView = handler.PlatformView;
 					var shellItemView = shell.CurrentItem.Handler.PlatformView as MauiNavigationView;
 					var expectedRoot = UI.Xaml.Controls.NavigationViewPaneDisplayMode.LeftMinimal;
-				
+
 					Assert.Equal(expectedRoot, rootNavView.PaneDisplayMode);
 					Assert.NotNull(shellItemView);
-				
+
 					return Task.CompletedTask;
 				});
 
@@ -127,7 +130,66 @@ namespace Microsoft.Maui.DeviceTests
 
 			await ValidateHasColor(shell, expectedColor, typeof(ShellHandler));
 		}
-	
+
+		[Theory(DisplayName = "Shell TabBar UnselectedColor Initializes Correctly")]
+		[InlineData("#FF0000")]
+		[InlineData("#0000FF")]
+		public async Task ShellTabBarUnselectedColorInitializesCorrectly(string colorHex)
+		{
+			SetupBuilder();
+
+			var expectedColor = Color.FromArgb(colorHex);
+
+			var shell = await CreateShellAsync((shell) =>
+			{
+				shell.FlyoutBehavior = FlyoutBehavior.Disabled;
+				Shell.SetTabBarForegroundColor(shell, Colors.Black);
+				Shell.SetTabBarUnselectedColor(shell, expectedColor);
+
+				shell.Items.Add(new TabBar()
+				{
+					Items =
+					{
+						new ShellContent()
+						{
+							Route = "Tab1",
+							Title= "Tab1",
+							Content = new ContentPage()
+						},
+						new ShellContent()
+						{
+							Route = "Tab2",
+							Title= "Tab2",
+							Content = new ContentPage()
+						},
+					}
+				});
+			});
+
+			await InvokeOnMainThreadAsync(async () =>
+			{
+				await CreateHandlerAndAddToWindow<ShellHandler>(shell, (handler) =>
+				{
+					var rootNavView = handler.PlatformView;
+					var shellItemView = shell.CurrentItem.Handler.PlatformView as MauiNavigationView;
+					var expectedRoot = UI.Xaml.Controls.NavigationViewPaneDisplayMode.LeftMinimal;
+
+					Assert.Equal(expectedRoot, rootNavView.PaneDisplayMode);
+					Assert.NotNull(shellItemView);
+
+					return Task.CompletedTask;
+				});
+
+				await AssertionExtensions.Wait(() =>
+				{
+					var platformView = shell.Handler.PlatformView as FrameworkElement;
+					return platformView is not null && (platformView.Height > 0 || platformView.Width > 0);
+				});
+			});
+
+			await ValidateHasColor(shell, expectedColor, typeof(ShellHandler));
+		}
+
 		[Fact(DisplayName = "Back Button Enabled/Disabled")]
 		public async Task BackButtonEnabledAndDisabled()
 		{

--- a/src/Core/src/Platform/Windows/NavigationViewExtensions.cs
+++ b/src/Core/src/Platform/Windows/NavigationViewExtensions.cs
@@ -30,10 +30,6 @@ namespace Microsoft.Maui.Platform
 			{
 				if (brush is null)
 				{
-					navigationView.TopNavArea.Resources.Remove("TopNavigationViewItemForegroundSelected");
-					navigationView.TopNavArea.Resources.Remove("TopNavigationViewItemForegroundSelectedPointerOver");
-					navigationView.TopNavArea.Resources.Remove("TopNavigationViewItemForegroundSelectedPressed");
-					navigationView.TopNavArea.Resources.Remove("TopNavigationViewItemForegroundSelectedDisabled");
 					navigationView.TopNavArea.Resources.Remove("TopNavigationViewItemForeground");
 					navigationView.TopNavArea.Resources.Remove("TopNavigationViewItemForegroundPointerOver");
 					navigationView.TopNavArea.Resources.Remove("TopNavigationViewItemForegroundPressed");
@@ -41,22 +37,53 @@ namespace Microsoft.Maui.Platform
 				}
 				else
 				{
-					navigationView.TopNavArea.Resources["TopNavigationViewItemForegroundSelected"] = brush;
-					navigationView.TopNavArea.Resources["TopNavigationViewItemForegroundSelectedPointerOver"] = brush;
-					navigationView.TopNavArea.Resources["TopNavigationViewItemForegroundSelectedPressed"] = brush;
-					navigationView.TopNavArea.Resources["TopNavigationViewItemForegroundSelectedDisabled"] = brush;
 					navigationView.TopNavArea.Resources["TopNavigationViewItemForeground"] = brush;
 					navigationView.TopNavArea.Resources["TopNavigationViewItemForegroundPointerOver"] = brush;
 					navigationView.TopNavArea.Resources["TopNavigationViewItemForegroundPressed"] = brush;
 					navigationView.TopNavArea.Resources["TopNavigationViewItemForegroundDisabled"] = brush;
 				}
+
+				navigationView.TopNavArea.RefreshThemeResources();
 			}
 
 			if (navigationView.MenuItemsSource is IList<NavigationViewItemViewModel> items)
 			{
 				foreach (var item in items)
 				{
-					item.TitleColor = brush;
+					item.UnselectedTitleColor = brush;
+				}
+			}
+		}
+
+		internal static void UpdateTopNavigationViewItemTextSelectedColor(this MauiNavigationView navigationView, Paint? paint)
+		{
+			var brush = paint?.ToPlatform();
+
+			if (navigationView.TopNavArea is not null)
+			{
+				if (brush is null)
+				{
+					navigationView.TopNavArea.Resources.Remove("TopNavigationViewItemForegroundSelected");
+					navigationView.TopNavArea.Resources.Remove("TopNavigationViewItemForegroundSelectedPointerOver");
+					navigationView.TopNavArea.Resources.Remove("TopNavigationViewItemForegroundSelectedPressed");
+					navigationView.TopNavArea.Resources.Remove("TopNavigationViewItemForegroundSelectedDisabled");
+				}
+				else
+				{
+					navigationView.TopNavArea.Resources["TopNavigationViewItemForegroundSelected"] = brush;
+					navigationView.TopNavArea.Resources["TopNavigationViewItemForegroundSelectedPointerOver"] = brush;
+					navigationView.TopNavArea.Resources["TopNavigationViewItemForegroundSelectedPressed"] = brush;
+					navigationView.TopNavArea.Resources["TopNavigationViewItemForegroundSelectedDisabled"] = brush;
+				}
+
+				navigationView.TopNavArea.RefreshThemeResources();
+			}
+
+			if (navigationView.MenuItemsSource is IList<NavigationViewItemViewModel> items)
+			{
+				foreach (var item in items)
+				{
+					item.SelectedTitleColor = brush;
 				}
 			}
 		}
@@ -89,6 +116,11 @@ namespace Microsoft.Maui.Platform
 			}
 		}
 
+		/// <summary>
+		/// Sets the color of the Unselected NavigationViewItem Icon
+		/// </summary>
+		/// <param name="navigationView"></param>
+		/// <param name="paint"></param>
 		public static void UpdateTopNavigationViewItemUnselectedColor(this MauiNavigationView navigationView, Paint? paint)
 		{
 			var brush = paint?.ToPlatform();

--- a/src/Core/src/Platform/Windows/NavigationViewExtensions.cs
+++ b/src/Core/src/Platform/Windows/NavigationViewExtensions.cs
@@ -30,6 +30,44 @@ namespace Microsoft.Maui.Platform
 			{
 				if (brush is null)
 				{
+					navigationView.TopNavArea.Resources.Remove("TopNavigationViewItemForegroundSelected");
+					navigationView.TopNavArea.Resources.Remove("TopNavigationViewItemForegroundSelectedPointerOver");
+					navigationView.TopNavArea.Resources.Remove("TopNavigationViewItemForegroundSelectedPressed");
+					navigationView.TopNavArea.Resources.Remove("TopNavigationViewItemForegroundSelectedDisabled");
+
+					navigationView.TopNavArea.Resources.Remove("NavigationViewSelectionIndicatorForeground");
+				}
+				else
+				{
+					navigationView.TopNavArea.Resources["TopNavigationViewItemForegroundSelected"] = brush;
+					navigationView.TopNavArea.Resources["TopNavigationViewItemForegroundSelectedPointerOver"] = brush;
+					navigationView.TopNavArea.Resources["TopNavigationViewItemForegroundSelectedPressed"] = brush;
+					navigationView.TopNavArea.Resources["TopNavigationViewItemForegroundSelectedDisabled"] = brush;
+
+					// Use the TabBarForegroundColor to update the Indicator Brush
+					navigationView.TopNavArea.Resources["NavigationViewSelectionIndicatorForeground"] = brush;
+				}
+
+				navigationView.TopNavArea.RefreshThemeResources();
+			}
+
+			if (navigationView.MenuItemsSource is IList<NavigationViewItemViewModel> items)
+			{
+				foreach (var item in items)
+				{
+					item.Foreground = brush;
+				}
+			}
+		}
+		
+		public static void UpdateTopNavigationViewItemUnselectedColor(this MauiNavigationView navigationView, Paint? paint)
+		{
+			var brush = paint?.ToPlatform();
+
+			if (navigationView.TopNavArea != null)
+			{
+				if (brush is null)
+				{
 					navigationView.TopNavArea.Resources.Remove("TopNavigationViewItemForeground");
 					navigationView.TopNavArea.Resources.Remove("TopNavigationViewItemForegroundPointerOver");
 					navigationView.TopNavArea.Resources.Remove("TopNavigationViewItemForegroundPressed");

--- a/src/Core/src/Platform/Windows/NavigationViewExtensions.cs
+++ b/src/Core/src/Platform/Windows/NavigationViewExtensions.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Maui.Platform
 		{
 			var brush = paint?.ToPlatform();
 
-			if (navigationView.TopNavArea != null)
+			if (navigationView.TopNavArea is not null)
 			{
 				if (brush is null)
 				{
@@ -55,16 +55,16 @@ namespace Microsoft.Maui.Platform
 			{
 				foreach (var item in items)
 				{
-					item.Foreground = brush;
+					item.SelectedForeground = brush;
 				}
 			}
 		}
-		
+
 		public static void UpdateTopNavigationViewItemUnselectedColor(this MauiNavigationView navigationView, Paint? paint)
 		{
 			var brush = paint?.ToPlatform();
 
-			if (navigationView.TopNavArea != null)
+			if (navigationView.TopNavArea is not null)
 			{
 				if (brush is null)
 				{
@@ -88,7 +88,7 @@ namespace Microsoft.Maui.Platform
 			{
 				foreach (var item in items)
 				{
-					item.Foreground = brush;
+					item.UnselectedForeground = brush;
 				}
 			}
 		}
@@ -96,7 +96,7 @@ namespace Microsoft.Maui.Platform
 		public static void UpdateTopNavigationViewItemBackgroundUnselectedColor(this MauiNavigationView navigationView, Paint? paint)
 		{
 			var brush = paint?.ToPlatform();
-			if (navigationView.TopNavArea != null)
+			if (navigationView.TopNavArea is not null)
 			{
 				if (brush is null)
 				{
@@ -126,7 +126,7 @@ namespace Microsoft.Maui.Platform
 		public static void UpdateTopNavigationViewItemBackgroundSelectedColor(this MauiNavigationView navigationView, Paint? paint)
 		{
 			var brush = paint?.ToPlatform();
-			if (navigationView.TopNavArea != null)
+			if (navigationView.TopNavArea is not null)
 			{
 				if (brush is null)
 				{
@@ -182,7 +182,7 @@ namespace Microsoft.Maui.Platform
 		public static void UpdateFlyoutVerticalScrollMode(this MauiNavigationView navigationView, ScrollMode scrollMode)
 		{
 			var scrollViewer = navigationView.MenuItemsScrollViewer;
-			if (scrollViewer != null)
+			if (scrollViewer is not null)
 			{
 				switch (scrollMode)
 				{

--- a/src/Core/src/Platform/Windows/NavigationViewExtensions.cs
+++ b/src/Core/src/Platform/Windows/NavigationViewExtensions.cs
@@ -34,8 +34,10 @@ namespace Microsoft.Maui.Platform
 					navigationView.TopNavArea.Resources.Remove("TopNavigationViewItemForegroundSelectedPointerOver");
 					navigationView.TopNavArea.Resources.Remove("TopNavigationViewItemForegroundSelectedPressed");
 					navigationView.TopNavArea.Resources.Remove("TopNavigationViewItemForegroundSelectedDisabled");
-
-					navigationView.TopNavArea.Resources.Remove("NavigationViewSelectionIndicatorForeground");
+					navigationView.TopNavArea.Resources.Remove("TopNavigationViewItemForeground");
+					navigationView.TopNavArea.Resources.Remove("TopNavigationViewItemForegroundPointerOver");
+					navigationView.TopNavArea.Resources.Remove("TopNavigationViewItemForegroundPressed");
+					navigationView.TopNavArea.Resources.Remove("TopNavigationViewItemForegroundDisabled");
 				}
 				else
 				{
@@ -43,7 +45,34 @@ namespace Microsoft.Maui.Platform
 					navigationView.TopNavArea.Resources["TopNavigationViewItemForegroundSelectedPointerOver"] = brush;
 					navigationView.TopNavArea.Resources["TopNavigationViewItemForegroundSelectedPressed"] = brush;
 					navigationView.TopNavArea.Resources["TopNavigationViewItemForegroundSelectedDisabled"] = brush;
+					navigationView.TopNavArea.Resources["TopNavigationViewItemForeground"] = brush;
+					navigationView.TopNavArea.Resources["TopNavigationViewItemForegroundPointerOver"] = brush;
+					navigationView.TopNavArea.Resources["TopNavigationViewItemForegroundPressed"] = brush;
+					navigationView.TopNavArea.Resources["TopNavigationViewItemForegroundDisabled"] = brush;
+				}
+			}
 
+			if (navigationView.MenuItemsSource is IList<NavigationViewItemViewModel> items)
+			{
+				foreach (var item in items)
+				{
+					item.TitleColor = brush;
+				}
+			}
+		}
+
+		internal static void UpdateTopNavigationViewItemSelectedColor(this MauiNavigationView navigationView, Paint? paint)
+		{
+			var brush = paint?.ToPlatform();
+
+			if (navigationView.TopNavArea is not null)
+			{
+				if (brush is null)
+				{
+					navigationView.TopNavArea.Resources.Remove("NavigationViewSelectionIndicatorForeground");
+				}
+				else
+				{
 					// Use the TabBarForegroundColor to update the Indicator Brush
 					navigationView.TopNavArea.Resources["NavigationViewSelectionIndicatorForeground"] = brush;
 				}
@@ -63,26 +92,6 @@ namespace Microsoft.Maui.Platform
 		public static void UpdateTopNavigationViewItemUnselectedColor(this MauiNavigationView navigationView, Paint? paint)
 		{
 			var brush = paint?.ToPlatform();
-
-			if (navigationView.TopNavArea is not null)
-			{
-				if (brush is null)
-				{
-					navigationView.TopNavArea.Resources.Remove("TopNavigationViewItemForeground");
-					navigationView.TopNavArea.Resources.Remove("TopNavigationViewItemForegroundPointerOver");
-					navigationView.TopNavArea.Resources.Remove("TopNavigationViewItemForegroundPressed");
-					navigationView.TopNavArea.Resources.Remove("TopNavigationViewItemForegroundDisabled");
-				}
-				else
-				{
-					navigationView.TopNavArea.Resources["TopNavigationViewItemForeground"] = brush;
-					navigationView.TopNavArea.Resources["TopNavigationViewItemForegroundPointerOver"] = brush;
-					navigationView.TopNavArea.Resources["TopNavigationViewItemForegroundPressed"] = brush;
-					navigationView.TopNavArea.Resources["TopNavigationViewItemForegroundDisabled"] = brush;
-				}
-
-				navigationView.TopNavArea.RefreshThemeResources();
-			}
 
 			if (navigationView.MenuItemsSource is IList<NavigationViewItemViewModel> items)
 			{

--- a/src/Core/src/Platform/Windows/NavigationViewExtensions.cs
+++ b/src/Core/src/Platform/Windows/NavigationViewExtensions.cs
@@ -116,11 +116,6 @@ namespace Microsoft.Maui.Platform
 			}
 		}
 
-		/// <summary>
-		/// Sets the color of the Unselected NavigationViewItem Icon
-		/// </summary>
-		/// <param name="navigationView"></param>
-		/// <param name="paint"></param>
 		public static void UpdateTopNavigationViewItemUnselectedColor(this MauiNavigationView navigationView, Paint? paint)
 		{
 			var brush = paint?.ToPlatform();

--- a/src/Core/src/Platform/Windows/NavigationViewItemViewModel.cs
+++ b/src/Core/src/Platform/Windows/NavigationViewItemViewModel.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
+using Microsoft.UI.Xaml.Controls;
 using WBrush = Microsoft.UI.Xaml.Media.Brush;
 using WIconElement = Microsoft.UI.Xaml.Controls.IconElement;
 
@@ -79,10 +80,11 @@ namespace Microsoft.Maui.Platform
 		public event PropertyChangedEventHandler? PropertyChanged;
 
 		object? _content;
-		WBrush? _foreground;
 		bool _isSelected;
 		WBrush? _selectedBackground;
 		WBrush? _unselectedBackground;
+		WBrush? _selectedForeground;
+		WBrush? _unselectedForeground;
 		ObservableCollection<NavigationViewItemViewModel>? _menuItemsSource;
 		WIconElement? _icon;
 
@@ -100,8 +102,7 @@ namespace Microsoft.Maui.Platform
 
 		public WBrush? Foreground
 		{
-			get { return _foreground; }
-			set { this.SetProperty(ref _foreground, value, OnPropertyChanged); }
+			get => IsSelected ? SelectedForeground : UnselectedForeground;
 		}
 
 		public WBrush? Background
@@ -137,6 +138,36 @@ namespace Microsoft.Maui.Platform
 			}
 		}
 
+		public WBrush? SelectedForeground
+		{
+			get => _selectedForeground;
+			set
+			{
+				_selectedForeground = value;
+				UpdateForeground();
+			}
+		}
+
+		public WBrush? UnselectedForeground
+		{
+			get => _unselectedForeground;
+			set
+			{
+				_unselectedForeground = value;
+				UpdateForeground();
+			}
+		}
+
+		void UpdateForeground()
+		{
+			OnPropertyChanged(nameof(Foreground));
+
+			if (Icon is WIconElement bi)
+			{
+				bi.Foreground = Foreground;
+			}
+		}
+
 		public bool IsSelected
 		{
 			get => _isSelected;
@@ -144,6 +175,7 @@ namespace Microsoft.Maui.Platform
 			{
 				_isSelected = value;
 				OnPropertyChanged(nameof(Background));
+				UpdateForeground();
 			}
 		}
 

--- a/src/Core/src/Platform/Windows/NavigationViewItemViewModel.cs
+++ b/src/Core/src/Platform/Windows/NavigationViewItemViewModel.cs
@@ -84,6 +84,7 @@ namespace Microsoft.Maui.Platform
 		WBrush? _selectedBackground;
 		WBrush? _unselectedBackground;
 		WBrush? _selectedForeground;
+		WBrush? _titleColor;
 		WBrush? _unselectedForeground;
 		ObservableCollection<NavigationViewItemViewModel>? _menuItemsSource;
 		WIconElement? _icon;
@@ -135,6 +136,16 @@ namespace Microsoft.Maui.Platform
 			{
 				_unselectedBackground = value;
 				OnPropertyChanged(nameof(Background));
+			}
+		}
+
+		public WBrush? TitleColor
+		{
+			get => _titleColor;
+			set
+			{
+				_titleColor = value;
+				OnPropertyChanged(nameof(TitleColor));
 			}
 		}
 

--- a/src/Core/src/Platform/Windows/NavigationViewItemViewModel.cs
+++ b/src/Core/src/Platform/Windows/NavigationViewItemViewModel.cs
@@ -84,7 +84,8 @@ namespace Microsoft.Maui.Platform
 		WBrush? _selectedBackground;
 		WBrush? _unselectedBackground;
 		WBrush? _selectedForeground;
-		WBrush? _titleColor;
+		WBrush? _selectedTitleColor;
+		WBrush? _unselectedTitleColor;
 		WBrush? _unselectedForeground;
 		ObservableCollection<NavigationViewItemViewModel>? _menuItemsSource;
 		WIconElement? _icon;
@@ -141,10 +142,25 @@ namespace Microsoft.Maui.Platform
 
 		public WBrush? TitleColor
 		{
-			get => _titleColor;
+			get => IsSelected ? SelectedTitleColor : UnselectedTitleColor;
+		}
+
+		public WBrush? SelectedTitleColor
+		{
+			get => _selectedTitleColor;
 			set
 			{
-				_titleColor = value;
+				_selectedTitleColor = value;
+				OnPropertyChanged(nameof(TitleColor));
+			}
+		}
+
+		public WBrush? UnselectedTitleColor
+		{
+			get => _unselectedTitleColor;
+			set
+			{
+				_unselectedTitleColor = value;
 				OnPropertyChanged(nameof(TitleColor));
 			}
 		}

--- a/src/Core/src/Platform/iOS/TabbedViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/TabbedViewExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using Foundation;
 using Microsoft.Maui.Graphics;
 using UIKit;
 
@@ -48,54 +49,59 @@ namespace Microsoft.Maui.Platform
 			// Also, set ParagraphStyle explicitly. This seems to be an iOS bug. If we don't do this, tab titles will be truncat...
 
 			// Set SelectedTabColor
-			if (selectedTabColor != null)
+			if (selectedTabColor is not null)
 			{
 				var foregroundColor = selectedTabColor.ToPlatform();
-				_tabBarAppearance.StackedLayoutAppearance.Selected.TitleTextAttributes = new UIStringAttributes { ForegroundColor = foregroundColor, ParagraphStyle = NSParagraphStyle.Default };
+				var titleColor = effectiveBarTextColor ?? foregroundColor;
+
+				_tabBarAppearance.StackedLayoutAppearance.Selected.TitleTextAttributes = new UIStringAttributes { ForegroundColor = titleColor, ParagraphStyle = NSParagraphStyle.Default };
 				_tabBarAppearance.StackedLayoutAppearance.Selected.IconColor = foregroundColor;
 
-				_tabBarAppearance.InlineLayoutAppearance.Selected.TitleTextAttributes = new UIStringAttributes { ForegroundColor = foregroundColor, ParagraphStyle = NSParagraphStyle.Default };
+				_tabBarAppearance.InlineLayoutAppearance.Selected.TitleTextAttributes = new UIStringAttributes { ForegroundColor = titleColor, ParagraphStyle = NSParagraphStyle.Default };
 				_tabBarAppearance.InlineLayoutAppearance.Selected.IconColor = foregroundColor;
 
-				_tabBarAppearance.CompactInlineLayoutAppearance.Selected.TitleTextAttributes = new UIStringAttributes { ForegroundColor = foregroundColor, ParagraphStyle = NSParagraphStyle.Default };
+				_tabBarAppearance.CompactInlineLayoutAppearance.Selected.TitleTextAttributes = new UIStringAttributes { ForegroundColor = titleColor, ParagraphStyle = NSParagraphStyle.Default };
 				_tabBarAppearance.CompactInlineLayoutAppearance.Selected.IconColor = foregroundColor;
 			}
 			else
 			{
 				var foregroundColor = UITabBar.Appearance.TintColor;
-				_tabBarAppearance.StackedLayoutAppearance.Selected.TitleTextAttributes = new UIStringAttributes { ForegroundColor = foregroundColor, ParagraphStyle = NSParagraphStyle.Default };
+				var titleColor = effectiveBarTextColor ?? foregroundColor;
+				_tabBarAppearance.StackedLayoutAppearance.Selected.TitleTextAttributes = new UIStringAttributes { ForegroundColor = titleColor, ParagraphStyle = NSParagraphStyle.Default };
 				_tabBarAppearance.StackedLayoutAppearance.Selected.IconColor = foregroundColor;
 
-				_tabBarAppearance.InlineLayoutAppearance.Selected.TitleTextAttributes = new UIStringAttributes { ForegroundColor = foregroundColor, ParagraphStyle = NSParagraphStyle.Default };
+				_tabBarAppearance.InlineLayoutAppearance.Selected.TitleTextAttributes = new UIStringAttributes { ForegroundColor = titleColor, ParagraphStyle = NSParagraphStyle.Default };
 				_tabBarAppearance.InlineLayoutAppearance.Selected.IconColor = foregroundColor;
 
-				_tabBarAppearance.CompactInlineLayoutAppearance.Selected.TitleTextAttributes = new UIStringAttributes { ForegroundColor = foregroundColor, ParagraphStyle = NSParagraphStyle.Default };
+				_tabBarAppearance.CompactInlineLayoutAppearance.Selected.TitleTextAttributes = new UIStringAttributes { ForegroundColor = titleColor, ParagraphStyle = NSParagraphStyle.Default };
 				_tabBarAppearance.CompactInlineLayoutAppearance.Selected.IconColor = foregroundColor;
 			}
 
 			// Set UnselectedTabColor
-			if (unselectedTabColor != null)
+			if (unselectedTabColor is not null)
 			{
 				var foregroundColor = unselectedTabColor.ToPlatform();
-				_tabBarAppearance.StackedLayoutAppearance.Normal.TitleTextAttributes = new UIStringAttributes { ForegroundColor = foregroundColor, ParagraphStyle = NSParagraphStyle.Default };
+				var titleColor = effectiveBarTextColor ?? foregroundColor;
+				_tabBarAppearance.StackedLayoutAppearance.Normal.TitleTextAttributes = new UIStringAttributes { ForegroundColor = titleColor, ParagraphStyle = NSParagraphStyle.Default };
 				_tabBarAppearance.StackedLayoutAppearance.Normal.IconColor = foregroundColor;
 
-				_tabBarAppearance.InlineLayoutAppearance.Normal.TitleTextAttributes = new UIStringAttributes { ForegroundColor = foregroundColor, ParagraphStyle = NSParagraphStyle.Default };
+				_tabBarAppearance.InlineLayoutAppearance.Normal.TitleTextAttributes = new UIStringAttributes { ForegroundColor = titleColor, ParagraphStyle = NSParagraphStyle.Default };
 				_tabBarAppearance.InlineLayoutAppearance.Normal.IconColor = foregroundColor;
 
-				_tabBarAppearance.CompactInlineLayoutAppearance.Normal.TitleTextAttributes = new UIStringAttributes { ForegroundColor = foregroundColor, ParagraphStyle = NSParagraphStyle.Default };
+				_tabBarAppearance.CompactInlineLayoutAppearance.Normal.TitleTextAttributes = new UIStringAttributes { ForegroundColor = titleColor, ParagraphStyle = NSParagraphStyle.Default };
 				_tabBarAppearance.CompactInlineLayoutAppearance.Normal.IconColor = foregroundColor;
 			}
 			else
 			{
 				var foreground = UITabBar.Appearance.TintColor;
-				_tabBarAppearance.StackedLayoutAppearance.Normal.TitleTextAttributes = new UIStringAttributes { ForegroundColor = foreground, ParagraphStyle = NSParagraphStyle.Default };
+				var titleColor = effectiveBarTextColor ?? foreground;
+				_tabBarAppearance.StackedLayoutAppearance.Normal.TitleTextAttributes = new UIStringAttributes { ForegroundColor = titleColor, ParagraphStyle = NSParagraphStyle.Default };
 				_tabBarAppearance.StackedLayoutAppearance.Normal.IconColor = foreground;
 
-				_tabBarAppearance.InlineLayoutAppearance.Normal.TitleTextAttributes = new UIStringAttributes { ForegroundColor = foreground, ParagraphStyle = NSParagraphStyle.Default };
+				_tabBarAppearance.InlineLayoutAppearance.Normal.TitleTextAttributes = new UIStringAttributes { ForegroundColor = titleColor, ParagraphStyle = NSParagraphStyle.Default };
 				_tabBarAppearance.InlineLayoutAppearance.Normal.IconColor = foreground;
 
-				_tabBarAppearance.CompactInlineLayoutAppearance.Normal.TitleTextAttributes = new UIStringAttributes { ForegroundColor = foreground, ParagraphStyle = NSParagraphStyle.Default };
+				_tabBarAppearance.CompactInlineLayoutAppearance.Normal.TitleTextAttributes = new UIStringAttributes { ForegroundColor = titleColor, ParagraphStyle = NSParagraphStyle.Default };
 				_tabBarAppearance.CompactInlineLayoutAppearance.Normal.IconColor = foreground;
 			}
 

--- a/src/Core/src/Platform/iOS/TabbedViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/TabbedViewExtensions.cs
@@ -19,7 +19,8 @@ namespace Microsoft.Maui.Platform
 			Color? selectedTabColor,
 			Color? unselectedTabColor,
 			Color? barBackgroundColor,
-			Color? barTextColor)
+			Color? selectedBarTextColor,
+			Color? unSelectedBarTextColor)
 		{
 			if (_tabBarAppearance == null)
 			{
@@ -36,14 +37,8 @@ namespace Microsoft.Maui.Platform
 
 			// Set BarTextColor
 
-			var effectiveBarTextColor = (barTextColor == null) ? defaultBarTextColor : barTextColor.ToPlatform();
-			if (effectiveBarTextColor != null)
-			{
-				_tabBarAppearance.StackedLayoutAppearance.Normal.TitleTextAttributes = new UIStringAttributes
-				{
-					ForegroundColor = effectiveBarTextColor
-				};
-			}
+			var effectiveSelectedBarTextColor = (selectedBarTextColor == null) ? defaultBarTextColor : selectedBarTextColor.ToPlatform();
+			var effectiveUnselectedBarTextColor = (unSelectedBarTextColor == null) ? defaultBarTextColor : unSelectedBarTextColor.ToPlatform();
 
 			// Update colors for all variations of the appearance to also make it work for iPads, etc. which use different layouts for the tabbar
 			// Also, set ParagraphStyle explicitly. This seems to be an iOS bug. If we don't do this, tab titles will be truncat...
@@ -52,7 +47,7 @@ namespace Microsoft.Maui.Platform
 			if (selectedTabColor is not null)
 			{
 				var foregroundColor = selectedTabColor.ToPlatform();
-				var titleColor = effectiveBarTextColor ?? foregroundColor;
+				var titleColor = effectiveSelectedBarTextColor ?? foregroundColor;
 
 				_tabBarAppearance.StackedLayoutAppearance.Selected.TitleTextAttributes = new UIStringAttributes { ForegroundColor = titleColor, ParagraphStyle = NSParagraphStyle.Default };
 				_tabBarAppearance.StackedLayoutAppearance.Selected.IconColor = foregroundColor;
@@ -66,7 +61,7 @@ namespace Microsoft.Maui.Platform
 			else
 			{
 				var foregroundColor = UITabBar.Appearance.TintColor;
-				var titleColor = effectiveBarTextColor ?? foregroundColor;
+				var titleColor = effectiveSelectedBarTextColor ?? foregroundColor;
 				_tabBarAppearance.StackedLayoutAppearance.Selected.TitleTextAttributes = new UIStringAttributes { ForegroundColor = titleColor, ParagraphStyle = NSParagraphStyle.Default };
 				_tabBarAppearance.StackedLayoutAppearance.Selected.IconColor = foregroundColor;
 
@@ -81,7 +76,7 @@ namespace Microsoft.Maui.Platform
 			if (unselectedTabColor is not null)
 			{
 				var foregroundColor = unselectedTabColor.ToPlatform();
-				var titleColor = effectiveBarTextColor ?? foregroundColor;
+				var titleColor = effectiveUnselectedBarTextColor ?? foregroundColor;
 				_tabBarAppearance.StackedLayoutAppearance.Normal.TitleTextAttributes = new UIStringAttributes { ForegroundColor = titleColor, ParagraphStyle = NSParagraphStyle.Default };
 				_tabBarAppearance.StackedLayoutAppearance.Normal.IconColor = foregroundColor;
 
@@ -94,7 +89,7 @@ namespace Microsoft.Maui.Platform
 			else
 			{
 				var foreground = UITabBar.Appearance.TintColor;
-				var titleColor = effectiveBarTextColor ?? foreground;
+				var titleColor = effectiveUnselectedBarTextColor ?? foreground;
 				_tabBarAppearance.StackedLayoutAppearance.Normal.TitleTextAttributes = new UIStringAttributes { ForegroundColor = titleColor, ParagraphStyle = NSParagraphStyle.Default };
 				_tabBarAppearance.StackedLayoutAppearance.Normal.IconColor = foreground;
 

--- a/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -34,6 +34,7 @@ static Microsoft.Maui.Layouts.FlexBasis.operator !=(Microsoft.Maui.Layouts.FlexB
 static Microsoft.Maui.Layouts.FlexBasis.operator ==(Microsoft.Maui.Layouts.FlexBasis left, Microsoft.Maui.Layouts.FlexBasis right) -> bool
 static Microsoft.Maui.Layouts.LayoutExtensions.ArrangeContentUnbounded(this Microsoft.Maui.IContentView! contentView, Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
 static Microsoft.Maui.Handlers.SearchBarHandler.MapKeyboard(Microsoft.Maui.Handlers.ISearchBarHandler! handler, Microsoft.Maui.ISearchBar! searchBar) -> void
+static Microsoft.Maui.Platform.NavigationViewExtensions.UpdateTopNavigationViewItemUnselectedColor(this Microsoft.Maui.Platform.MauiNavigationView! navigationView, Microsoft.Maui.Graphics.Paint? paint) -> void
 static Microsoft.Maui.Platform.SearchBarExtensions.UpdateKeyboard(this Microsoft.UI.Xaml.Controls.AutoSuggestBox! platformControl, Microsoft.Maui.ISearchBar! searchBar) -> void
 Microsoft.Maui.IWebView.UserAgent.get -> string?
 Microsoft.Maui.IWebView.UserAgent.set -> void


### PR DESCRIPTION
### Description of Change

Update logic to update Shell TabBar appearance on Windows/iOS/Android to make the three platforms consistent.

In order to validate this original PR that was only against Windows I compared to iOS/Android and realized that all the platforms process these colors fairly different.


### Examples

Using the following for the Sandbox
```XAML
  <TabBar Shell.TabBarForegroundColor="Green"
        Shell.TabBarUnselectedColor="Red" 
        Shell.TabBarTitleColor="Yellow"
        Shell.TabBarDisabledColor="Purple"
        Shell.TabBarBackgroundColor="Orange">
        <Tab Title="MainPage1" Icon="groceries.png">
            <ShellContent Icon="groceries.png"
                        Title="Home"
                        ContentTemplate="{DataTemplate local:MainPage}"
                        Route="MainPage" />
        </Tab>
        <Tab Title="MainPage2" Icon="dotnet_bot.png">
            <ShellContent Icon="dotnet_bot.png"
                        Title="Home"
                        ContentTemplate="{DataTemplate local:MainPage}"
                        Route="MainPage" />
        </Tab>
    </TabBar>
```

#### Tests

![image](https://github.com/dotnet/maui/assets/6755973/c67a4853-d992-4da9-b644-58cc458f2b8a)

To validate the changes, launch the .NET MAUI Gallery using the Shell sample.

![image](https://github.com/dotnet/maui/assets/6755973/b535f0fc-1490-4bf5-9ec9-2437753721c0)

## Behavior Changes between platforms from NET7

### Shell

#### Priority of how the colors are applied.

This isn't the most ideal. The APIs available are fairly limiting in scope. Ideally, we would make this all work through the VSM and just use two APIs (ForegroundColor/TitleColor) but for now we are just making these APIs consistent between the platforms. 

The three properties users have to influence the `TabItem` coloring are: `TabBarUnselectedColor`, `TabBarTitleColor`, and `TabBarForegroundColor`

- If the user only sets `Shell.TabBarTitleColor` that will color the `Title` and `Icon` of the selected item. I realize this is a bit off but this is currently how Android works and it's not really worth breaking this until we just introduce new APIs.
- If `Shell.TabBarTitleColor` is not set then the `TitleColor` will match the `TabBarForegroundColor`
- If `TabBarForegroundColor` is set and `TabBarUnselectedColor` isn't set then `TabBarForegroundColor` will be the color used for the text/icon of the selected TabItem
- If `TabBarUnselectedColor` is the only thing set then that will be used for the text/icon color on the unselected Tab Item. 

#### Windows
- .NET7: Currently on windows, `Shell.TabBarForegroundColor` is the only API that appears to do anything. 
  - .NET8: If users have those other APIs set for Windows those will now start applying correctly to Windows.

#### Android
- .NET7: `Shell.TabBarForegroundColor` currently doesn't do anything in NET7.
  - .NET8: It will now be applied according to the rules above.

#### iOS 15+
- .NET7: AFAICT `Shell.TabBarTitleColor` currently doesn't do anything in NET7. I think this was a bug with how the color modifications were applied when we tried to fix these colors for iOS15+.
  - .NET8: `Shell.TabBarTitleColor` will now set according to the rules above.
- .NET7: `Shell.TabBarForegroundColor` works according to the rules above and matches windows.

#### iOS Pre 15
- .NET7: AFAICT the rules here match `Android` .NET7 so the changes here will be the same as `Android`

#### Summary
- The main behavior change here is how `Shell.TabBarForegroundColor` is applied. Currently on .NET7 that API is only applied to `Windows` and `iOS15+`. So, if users have `Shell.TabBarForegroundColor` or `Shell.ForegroundColor` set to a color that doesn't match `Shell.TabTitleColor` they will see the Icons on `Android` and pre iOS15+ now change to match `Shell.TabBarForegroundColor` or `Shell.ForegroundColor`. At a later point we need to enable the ability to apply a VSM to these colors so users can articulate more scenarios.

### TabbedPage

#### NET7 behavior 👎 
- iOS15+ `TabbedPage.BarTextColor` doesn't work at all currently on .NET7 and XF
- Pre iOS15 `TabbedPage.BarTextColor` only set the color of the selected text
- Android `TabbedPage.BarTextColor` sets the color of both titles (selected/unselected)
- Windows `TabbedPage.BarTextColor` sets the color of the unselected item 🤷‍♂️ 

#### NET8 behavior after this PR
- I've changed iOS15+ to match pre iOS15
  - AFAICT pre iOS15 worked how it did because we couldn't figure out how to make the text on each icon match `BarTextColor`. This is now possible with iOS15+ but we probably shouldn't change the behavior here between iOS versions.
- Android I've left alone
- `Windows` I've changed to match `Android`

I realize this makes `Android` the odd platform out here but from what I can tell this has always been broken even in XF times so until we add APIs I don't really want to change this behavior.

### Issues Fixed

Fixes #12386
Fixes #6929
Fixes #6718