### PR TITLE
Android: recreate activity on dark mode change

### DIFF
--- a/src/Core/src/Platform/Android/MauiAppCompatActivity.Lifecycle.cs
+++ b/src/Core/src/Platform/Android/MauiAppCompatActivity.Lifecycle.cs
@@ -11,6 +11,8 @@ namespace Microsoft.Maui
 {
 	public partial class MauiAppCompatActivity
 	{
+		private UiMode currentNightMode = UiMode.NightUndefined;
+
 		protected override void OnActivityResult(int requestCode, Result resultCode, Intent? data)
 		{
 			base.OnActivityResult(requestCode, resultCode, data);
@@ -45,6 +47,13 @@ namespace Microsoft.Maui
 			base.OnConfigurationChanged(newConfig);
 
 			MauiApplication.Current?.Services?.InvokeLifecycleEvents<AndroidLifecycle.OnConfigurationChanged>(del => del(this, newConfig));
+
+			var newNightMode = newConfig.UiMode & UiMode.NightMask;
+			if (newNightMode != currentNightMode)
+			{
+				Recreate();
+				currentNightMode = newNightMode;
+			}
 		}
 
 		protected override void OnNewIntent(Intent? intent)


### PR DESCRIPTION
### Description of Change

Recreate activity every time dark mode is enabled or disabled.
This ensures that theme changes are reflected in UI.

### Issues Fixed

Fixes #15359
Fixes #15524
