### PR TITLE
Pin main branch to net7

### DIFF
--- a/global.json
+++ b/global.json
@@ -5,5 +5,10 @@
   "msbuild-sdks": {
     "MSBuild.Sdk.Extras": "3.0.44",
     "Microsoft.Build.NoTargets": "3.3.0"
+  },
+  "sdk": {
+    "version": "7.0.200",
+    "allowPrerelease": true,
+    "rollForward": "latestMinor"
   }
 }


### PR DESCRIPTION
### Description of Change

The current workload/sdks installed with .NET8 and public versions of Visual Studio can't build our main branch which still targets .NET7. There are fixes in the pipeline, but these haven't been released yet. Once these fixes are released, then we can revert this change.