### PR TITLE
Various fixes for Border on Android

### DIFF
--- a/src/Controls/src/Core/Border/Border.cs
+++ b/src/Controls/src/Core/Border/Border.cs
@@ -251,8 +251,8 @@ namespace Microsoft.Maui.Controls
 
 		public Size CrossPlatformArrange(Graphics.Rect bounds)
 		{
-			bounds = bounds.Inset(StrokeThickness);
-			this.ArrangeContent(bounds);
+			var inset = bounds.Inset(StrokeThickness);
+			this.ArrangeContent(inset);
 			return bounds.Size;
 		}
 

--- a/src/Controls/tests/DeviceTests/Elements/Border/BorderTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Border/BorderTests.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Maui.DeviceTests
 	public partial class BorderTests : ControlsHandlerTestBase
 	{
 		[Fact(DisplayName = "Rounded Rectangle Border occupies correct space")]
-		public async Task RoundedRectangleBorderLayoutIsCorrect()
+		public Task RoundedRectangleBorderLayoutIsCorrect()
 		{
 			var expected = Colors.Red;
 
@@ -29,7 +29,46 @@ namespace Microsoft.Maui.DeviceTests
 				WidthRequest = 100
 			};
 
-			await AssertColorAtPoint(border, expected, typeof(BorderHandler), 10, 10);
+			return AssertColorAtPoint(border, expected, typeof(BorderHandler), 10, 10);
+		}
+
+		[Fact(DisplayName = "StrokeThickness does not inset stroke path")]
+		public async Task BorderStrokeThicknessDoesNotInsetStrokePath()
+		{
+			var grid = new Grid()
+			{
+				ColumnDefinitions = new ColumnDefinitionCollection()
+				{
+					new ColumnDefinition(GridLength.Star),
+					new ColumnDefinition(GridLength.Star)
+				},
+				RowDefinitions = new RowDefinitionCollection()
+				{
+					new RowDefinition(GridLength.Star),
+					new RowDefinition(GridLength.Star)
+				},
+				BackgroundColor = Colors.White
+			};
+
+			var border = new Border()
+			{
+				Stroke = Colors.Black,
+				StrokeThickness = 10,
+				BackgroundColor = Colors.Red
+			};
+
+			grid.Add(border, 0, 0);
+			grid.WidthRequest = 200;
+			grid.HeightRequest = 200;
+
+			await CreateHandlerAsync<BorderHandler>(border);
+			await CreateHandlerAsync<LayoutHandler>(grid);
+
+#if IOS
+			// FIXME: iOS seems to have a white boarder around the Border stroke
+#else
+			await AssertColorAtPoint(grid, Colors.Black, typeof(LayoutHandler), 1, 1);
+#endif
 		}
 	}
 }

--- a/src/Core/src/Platform/Android/ShapeExtensions.cs
+++ b/src/Core/src/Platform/Android/ShapeExtensions.cs
@@ -8,19 +8,30 @@ namespace Microsoft.Maui.Platform
 	{
 		public static Path ToPlatform(this IShape shape, Graphics.Rect bounds, float strokeThickness, bool innerPath = false)
 		{
-			float x = (float)bounds.X + strokeThickness / 2;
-			float y = (float)bounds.Y + strokeThickness / 2;
-			float width = (float)bounds.Width - strokeThickness;
-			float height = (float)bounds.Height - strokeThickness;
-
-			var pathBounds = new Graphics.Rect(x, y, width, height);
-
+			Graphics.Rect pathBounds;
 			PathF path;
 
-			if (innerPath && shape is IRoundRectangle roundRectangle)
-				path = roundRectangle.InnerPathForBounds(pathBounds, strokeThickness);
+			if (innerPath)
+			{
+				if (shape is IRoundRectangle roundRectangle)
+				{
+					path = roundRectangle.InnerPathForBounds(bounds, strokeThickness);
+					return path.AsAndroidPath();
+				}
+
+				float x = (float)bounds.X + strokeThickness / 2;
+				float y = (float)bounds.Y + strokeThickness / 2;
+				float width = (float)bounds.Width - strokeThickness;
+				float height = (float)bounds.Height - strokeThickness;
+
+				pathBounds = new Graphics.Rect(x, y, width, height);
+			}
 			else
-				path = shape.PathForBounds(pathBounds);
+			{
+				pathBounds = bounds;
+			}
+
+			path = shape.PathForBounds(pathBounds);
 
 			return path.AsAndroidPath();
 		}

--- a/src/TestUtils/src/DeviceTests/AssertionExtensions.iOS.cs
+++ b/src/TestUtils/src/DeviceTests/AssertionExtensions.iOS.cs
@@ -259,7 +259,7 @@ namespace Microsoft.Maui.DeviceTests
 			var cap = bitmap.ColorAtPoint(x, y);
 
 			if (!ColorComparison.ARGBEquivalent(cap, expectedColor, tolerance))
-				Assert.Equal(cap, expectedColor, new ColorComparison());
+				Assert.Equal(expectedColor, cap, new ColorComparison());
 
 			return bitmap;
 		}


### PR DESCRIPTION
### Description of Change

* Fixed Border.CrossPlatformArrange() logic
* Fixed Android's ShapeExtensions.ToPlatform() to not inset the path
  bounds *unless* innerPath is true.

### Issues Fixed

This is an attempt at fixing issue #15339
