### PR TITLE
[Windows] Avoid unexpected characters from WebView EvaluateScript

### DIFF
--- a/src/Controls/src/Core/WebView.cs
+++ b/src/Controls/src/Core/WebView.cs
@@ -116,12 +116,19 @@ namespace Microsoft.Maui.Controls
 			if (script == null)
 				return null;
 
-			//make all the platforms mimic Android's implementation, which is by far the most complete.
+			// Make all the platforms mimic Android's implementation, which is by far the most complete.
 			if (DeviceInfo.Platform != DevicePlatform.Android)
 			{
 				script = EscapeJsString(script);
-				script = "try{JSON.stringify(eval('" + script + "'))}catch(e){'null'};";
-			}
+
+				if (DeviceInfo.Platform != DevicePlatform.WinUI)
+				{
+					// Use JSON.stringify() method to converts a JavaScript value to a JSON string
+					script = "try{JSON.stringify(eval('" + script + "'))}catch(e){'null'};";
+				}
+				else
+					script = "try{eval('" + script + "')}catch(e){'null'};";
+			}   
 
 			string result;
 

--- a/src/Controls/tests/DeviceTests/Elements/WebView/WebViewTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/WebView/WebViewTests.Windows.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests
+{
+    [Category(TestCategory.WebView)]
+    public partial class WebViewTests : ControlsHandlerTestBase
+    {
+        [Fact(DisplayName = "Evaluate JavaScript")]
+        public async Task EvaluateJavaScript()
+        {
+            SetupBuilder();
+
+            string actual = string.Empty;
+
+            var pageLoadTimeout = TimeSpan.FromSeconds(2);
+
+            string html =
+                @"
+				<!DOCTYPE html>
+				<html>
+					<head>
+					</head>
+					<body>
+						<script>
+							function test() {
+								return 'Test';
+							}
+						</script>
+						<p>
+							WebView Unit Test
+						</p>
+					</body>
+				</html>
+				";
+            await InvokeOnMainThreadAsync(async () =>
+            {
+                var webView = new WebView()
+                {
+                    WidthRequest = 100,
+                    HeightRequest = 100,
+                    Source = new HtmlWebViewSource { Html = html }
+                };
+
+                var handler = CreateHandler(webView);
+
+                var platformView = handler.PlatformView;
+
+                // Setup the view to be displayed/parented and run our tests on it
+                await AttachAndRun(webView, async (handler) =>
+                {
+                    // Wait for the page to load
+                    var tcsLoaded = new TaskCompletionSource<bool>();
+                    var ctsTimeout = new CancellationTokenSource(pageLoadTimeout);
+                    ctsTimeout.Token.Register(() => tcsLoaded.TrySetException(new TimeoutException($"Failed to load HTML")));
+
+                    webView.Navigated += async (source, args) =>
+                    {
+                        // Set success when we have a successful nav result
+                        if (args.Result == WebNavigationResult.Success)
+                        {
+                            tcsLoaded.TrySetResult(args.Result == WebNavigationResult.Success);
+
+                            // Evaluate JavaScript
+                            var script = "test();";
+                            actual = await webView.EvaluateJavaScriptAsync(script);
+
+                            // If the result is equal to the script string result, the test has passed
+                            Assert.Equal("Test", actual);
+                        }
+                    };
+
+                    Assert.True(await tcsLoaded.Task);
+                });
+            });
+        }
+    }
+}

--- a/src/Controls/tests/DeviceTests/Elements/WebView/WebViewTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/WebView/WebViewTests.Windows.cs
@@ -9,8 +9,8 @@ namespace Microsoft.Maui.DeviceTests
     [Category(TestCategory.WebView)]
     public partial class WebViewTests : ControlsHandlerTestBase
     {
-        [Fact(DisplayName = "Evaluate JavaScript")]
-        public async Task EvaluateJavaScript()
+        [Fact(DisplayName = "Evaluate JavaScript returning a String value")]
+        public async Task EvaluateJavaScriptWithString()
         {
             SetupBuilder();
 
@@ -70,6 +70,75 @@ namespace Microsoft.Maui.DeviceTests
 
                             // If the result is equal to the script string result, the test has passed
                             Assert.Equal("Test", actual);
+                        }
+                    };
+
+                    Assert.True(await tcsLoaded.Task);
+                });
+            });
+        }
+
+        [Fact(DisplayName = "Evaluate JavaScript returning an Integer value")]
+        public async Task EvaluateJavaScriptWithInteger()
+        {
+            SetupBuilder();
+
+            string actual = string.Empty;
+
+            var pageLoadTimeout = TimeSpan.FromSeconds(2);
+
+            string html =
+                @"
+				<!DOCTYPE html>
+				<html>
+					<head>
+					</head>
+					<body>
+						<script>
+							function test() {
+								return 10;
+							}
+						</script>
+						<p>
+							WebView Unit Test
+						</p>
+					</body>
+				</html>
+				";
+            await InvokeOnMainThreadAsync(async () =>
+            {
+                var webView = new WebView()
+                {
+                    WidthRequest = 100,
+                    HeightRequest = 100,
+                    Source = new HtmlWebViewSource { Html = html }
+                };
+
+                var handler = CreateHandler(webView);
+
+                var platformView = handler.PlatformView;
+
+                // Setup the view to be displayed/parented and run our tests on it
+                await AttachAndRun(webView, async (handler) =>
+                {
+                    // Wait for the page to load
+                    var tcsLoaded = new TaskCompletionSource<bool>();
+                    var ctsTimeout = new CancellationTokenSource(pageLoadTimeout);
+                    ctsTimeout.Token.Register(() => tcsLoaded.TrySetException(new TimeoutException($"Failed to load HTML")));
+
+                    webView.Navigated += async (source, args) =>
+                    {
+                        // Set success when we have a successful nav result
+                        if (args.Result == WebNavigationResult.Success)
+                        {
+                            tcsLoaded.TrySetResult(args.Result == WebNavigationResult.Success);
+
+                            // Evaluate JavaScript
+                            var script = "test();";
+                            actual = await webView.EvaluateJavaScriptAsync(script);
+
+                            // If the result is equal to the script string result, the test has passed
+                            Assert.Equal(10, Convert.ToInt32(actual));
                         }
                     };
 

--- a/src/Controls/tests/DeviceTests/Elements/WebView/WebViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/WebView/WebViewTests.cs
@@ -1,0 +1,21 @@
+﻿using Microsoft.Maui.Controls;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Hosting;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	[Category(TestCategory.WebView)]
+	public partial class WebViewTests : ControlsHandlerTestBase
+	{
+		void SetupBuilder()
+		{
+			EnsureHandlerCreated(builder =>
+			{
+				builder.ConfigureMauiHandlers(handlers =>
+				{
+					handlers.AddHandler<WebView, WebViewHandler>();
+				});
+			});
+		}
+	}
+}

--- a/src/Controls/tests/DeviceTests/TestCategory.cs
+++ b/src/Controls/tests/DeviceTests/TestCategory.cs
@@ -44,6 +44,7 @@
 		public const string View = "View";
 		public const string VisualElement = "VisualElement";
 		public const string VisualElementTree = "VisualElementTree";
+		public const string WebView = "WebView";
 		public const string Window = "Window";
 	}
 }


### PR DESCRIPTION
### Description of Change

Avoid unexpected characters from WebView **EvaluateScriptAsync** method on Windows. Applied changes to not use JSON.stringify() on Windows.

![image](https://github.com/dotnet/maui/assets/6755973/f396f760-7487-447a-bb84-20788905d597)
 
### Issues Fixed

Fixes #15233