### PR TITLE
make VisualElement.Focus() and VisualElement.Unfocus() virtual

### DIFF
--- a/src/Controls/src/Core/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement.cs
@@ -873,7 +873,7 @@ namespace Microsoft.Maui.Controls
 		public event EventHandler ChildrenReordered;
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/VisualElement.xml" path="//Member[@MemberName='Focus']/Docs/*" />
-		public bool Focus() =>
+		public virtual bool Focus() =>
 			this.RequestFocus();
 
 		public event EventHandler<FocusEventArgs> Focused;
@@ -959,7 +959,7 @@ namespace Microsoft.Maui.Controls
 		public event EventHandler SizeChanged;
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/VisualElement.xml" path="//Member[@MemberName='Unfocus']/Docs/*" />
-		public void Unfocus()
+		public virtual void Unfocus()
 		{
 			if (!IsFocused)
 				return;


### PR DESCRIPTION
And prevent the usage of new-keyoword in 3rd party libs and custom controls, when people want to override Focus().

### Description of Change

Currently custom controls, like SfTextInputLayout or Controls you write yourself must use the new keyword to override this method, which comes with a handful of drawbags.
![image](https://github.com/dotnet/maui/assets/11560817/58ce8c18-f883-4422-b867-ae37f385cb24)

### Issues Fixed

Fixes the mentioned problem.

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
