### PR TITLE
Update ModalNavigationManager.cs

### DIFF
--- a/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.cs
+++ b/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.cs
@@ -393,7 +393,9 @@ namespace Microsoft.Maui.Controls.Platform
 				bool result =
 					_window?.Page?.Handler is not null &&
 					_window.IsActivated
+#if ANDROID
 					&& _window.Page.IsLoadedOnPlatform()
+#endif
 					&& CurrentPlatformPage?.Handler is not null
 					&& CurrentPlatformPage.IsLoadedOnPlatform();
 


### PR DESCRIPTION
### Description of Change

The following [PR](https://github.com/dotnet/maui/commit/210786b0342e2cf2f9fab2e42039d46002727714#diff-a02814d4c61d2347359752528537440308b21bb97f59d85a05bdd711553c149dR354-R361) added code that only applied to `Android` but didn't take into account how `Windows` modals work. 

The fix in that PR was to ensure that on `Android`, if the user swaps out the mainpage and Modals are open that the system finishes settling before processing modals. This doesn't really work on windows because with windows the root page isn't part of the visual hierarchy when modals are visible. 

fixes #15488

### Testing
This code already has tests on WinUI but it was missed because those tests weren't ran unfortunately against the latest bits.
