### PR TITLE
Add the drag and drop gestures back to the appium ui tests for mac/ios targets

### DIFF
--- a/eng/devices/android.cake
+++ b/eng/devices/android.cake
@@ -373,7 +373,7 @@ Task("uitest")
 			
 	});
 
-	SetEnvironmentVariable("APPIUM_LOG_FILE", $"{BINLOG_ARG}/appium_android.log");
+	SetEnvironmentVariable("APPIUM_LOG_FILE", $"{BINLOG_DIR}/appium_android.log");
 
 	Information("Run UITests project {0}",PROJECT.FullPath);
 	RunTestWithLocalDotNet(PROJECT.FullPath, CONFIGURATION, noBuild: true);

--- a/eng/devices/catalyst.cake
+++ b/eng/devices/catalyst.cake
@@ -90,7 +90,7 @@ Task("uitest")
 				//.Append("/tl")
 	});
 
-	SetEnvironmentVariable("APPIUM_LOG_FILE", $"{BINLOG_ARG}/appium_mac.log");
+	SetEnvironmentVariable("APPIUM_LOG_FILE", $"{BINLOG_DIR}/appium_mac.log");
 
 	Information("Run UITests project {0}",PROJECT.FullPath);
 	RunTestWithLocalDotNet(PROJECT.FullPath, CONFIGURATION, noBuild: true);

--- a/eng/devices/ios.cake
+++ b/eng/devices/ios.cake
@@ -263,7 +263,7 @@ Task("uitest")
 			
 	});
 
-	SetEnvironmentVariable("APPIUM_LOG_FILE", $"{BINLOG_ARG}/appium_ios.log");
+	SetEnvironmentVariable("APPIUM_LOG_FILE", $"{BINLOG_DIR}/appium_ios.log");
 
 	Information("Run UITests project {0}",PROJECT.FullPath);
 	RunTestWithLocalDotNet(PROJECT.FullPath, CONFIGURATION, noBuild: true);

--- a/eng/devices/windows.cake
+++ b/eng/devices/windows.cake
@@ -97,7 +97,7 @@ Task("uitest")
 	});
 
 	SetEnvironmentVariable("WINDOWS_APP_PATH", TEST_APP);
-	SetEnvironmentVariable("APPIUM_LOG_FILE", $"{BINLOG_ARG}/appium_windows.log");
+	SetEnvironmentVariable("APPIUM_LOG_FILE", $"{BINLOG_DIR}/appium_windows.log");
 
 	Information("Run UITests project {0}",PROJECT.FullPath);
 	RunTestWithLocalDotNet(PROJECT.FullPath, CONFIGURATION, toolPath, noBuild: true);

--- a/src/Controls/samples/Controls.Sample.UITests/Elements/DragAndDropBetweenLayouts.xaml.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/Elements/DragAndDropBetweenLayouts.xaml.cs
@@ -9,6 +9,7 @@ namespace Maui.Controls.Sample
 	[XamlCompilation(XamlCompilationOptions.Compile)]
 	public partial class DragAndDropBetweenLayouts : ContentView
 	{
+		bool _emittedDragOver = false;
 		public ObservableCollection<Brush> AllColors { get; }
 		public ObservableCollection<Brush> RainbowColors { get; }
 		public DragAndDropBetweenLayouts()
@@ -23,7 +24,7 @@ namespace Maui.Controls.Sample
 
 		private void OnDragStarting(object sender, DragStartingEventArgs e)
 		{
-			// e.Cancel = true;
+			_emittedDragOver = false;
 			var label = (sender as Element).Parent as Label;
 			var sl = label.Parent as StackLayout;
 			e.Data.Properties.Add("Color", label);
@@ -64,7 +65,11 @@ namespace Maui.Controls.Sample
 
 			sl.Background = SolidColorBrush.LightPink;
 
-			AddEvent(nameof(OnDragOver));
+			if (!_emittedDragOver) // This can generate a lot of noise, only add it once
+			{
+				AddEvent(nameof(OnDragOver));
+				_emittedDragOver = true;
+			}
 		}
 
 		private void OnDragLeave(object sender, DragEventArgs e)

--- a/src/Controls/samples/Controls.Sample.UITests/Elements/DragAndDropEvents.xaml.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/Elements/DragAndDropEvents.xaml.cs
@@ -6,6 +6,7 @@ namespace Maui.Controls.Sample
 	[XamlCompilation(XamlCompilationOptions.Compile)]
 	public partial class DragAndDropEvents : ContentView
 	{
+		bool _emittedDragOver = false;
 		public DragAndDropEvents()
 		{
 			InitializeComponent();
@@ -18,6 +19,7 @@ namespace Maui.Controls.Sample
 
 		void DragStarting(object sender, DragStartingEventArgs e)
 		{
+			_emittedDragOver = false;
 			AddEvent(nameof(DragStarting));
 		}
 
@@ -33,7 +35,11 @@ namespace Maui.Controls.Sample
 
 		void DragOver(object sender, DragEventArgs e)
 		{
-			AddEvent(nameof(DragOver));
+			if (!_emittedDragOver) // This can generate a lot of noise, only add it once
+			{
+				AddEvent(nameof(DragOver));
+				_emittedDragOver = true;
+			}
 		}
 
 		void Drop(object sender, DropEventArgs e)

--- a/src/Controls/tests/UITests/Tests/DragAndDropUITests.cs
+++ b/src/Controls/tests/UITests/Tests/DragAndDropUITests.cs
@@ -28,12 +28,6 @@ namespace Microsoft.Maui.AppiumTests
 		[Test]
 		public void DragEvents()
 		{
-			if (UITestContext.TestConfig.TestDevice == TestDevice.Mac ||
-				UITestContext.TestConfig.TestDevice == TestDevice.iOS)
-			{
-				Assert.Ignore("Still trying to figure out the mouse operations with catalyst/ios");
-			}
-
 			App.WaitForElement("TargetView");
 			App.EnterText("TargetView", "DragAndDropEvents");
 			App.Tap("GoButton");
@@ -51,12 +45,6 @@ namespace Microsoft.Maui.AppiumTests
 		[Test]
 		public void DragAndDropBetweenLayouts()
 		{
-			if (UITestContext.TestConfig.TestDevice == TestDevice.Mac ||
-				UITestContext.TestConfig.TestDevice == TestDevice.iOS)
-			{
-				Assert.Ignore("Still trying to figure out the mouse operations with catalyst/ios");
-			}
-
 			App.WaitForElement("TargetView");
 			App.EnterText("TargetView", "DragAndDropBetweenLayouts");
 			App.Tap("GoButton");

--- a/src/TestUtils/src/TestUtils.Appium.UITests/AppiumUITestApp.cs
+++ b/src/TestUtils/src/TestUtils.Appium.UITests/AppiumUITestApp.cs
@@ -240,28 +240,82 @@ namespace TestUtils.Appium.UITests
 
 		public void DragAndDrop(AppiumElement source, AppiumElement destination)
 		{
-			OpenQA.Selenium.Appium.Interactions.PointerInputDevice touchDevice = new OpenQA.Selenium.Appium.Interactions.PointerInputDevice(PointerType);
-			ActionSequence sequence = new ActionSequence(touchDevice, 0);
-			sequence.AddAction(touchDevice.CreatePointerMove(source, 0, 0, TimeSpan.FromMilliseconds(5)));
-			sequence.AddAction(touchDevice.CreatePointerDown(PointerButton.TouchContact));
-			sequence.AddAction(touchDevice.CreatePause(TimeSpan.FromSeconds(1))); // Have to pause so the device doesn't think we are scrolling
-			sequence.AddAction(touchDevice.CreatePointerMove(destination, 0, 0, TimeSpan.FromSeconds(1)));
-			sequence.AddAction(touchDevice.CreatePointerUp(PointerButton.TouchContact));
-			_driver?.PerformActions(new List<ActionSequence> { sequence });
-			Thread.Sleep(1000); // Give time for app to re-act to the drop
+			if (IsiOS)
+			{
+				var sourceCenterX = source.Location.X + (source.Size.Width / 2);
+				var sourceCenterY = source.Location.Y + (source.Size.Height / 2);
+				var destCenterX = destination.Location.X + (destination.Size.Width / 2);
+				var destCenterY = destination.Location.Y + (destination.Size.Height / 2);
+				DragCoordinates(sourceCenterX, sourceCenterY, destCenterX, destCenterY);
+			}
+			else if (IsMac)
+			{
+				// Mac will work with 'Actions' but if you add a 'Pause' action it will deadlock
+				_driver?.ExecuteScript("macos: clickAndDragAndHold", new Dictionary<string, object>
+				{
+					{ "holdDuration", .1 }, // Length of time to hold before releasing
+					{ "duration", 1 }, // Length of time to hold after click before start dragging
+					{ "velocity", 2500 }, // How fast to drag
+					{ "sourceElementId", source.Id },
+					{ "destinationElementId", destination.Id },
+				});
+			}
+			else
+			{
+				OpenQA.Selenium.Appium.Interactions.PointerInputDevice touchDevice = new OpenQA.Selenium.Appium.Interactions.PointerInputDevice(PointerType);
+				ActionSequence sequence = new ActionSequence(touchDevice, 0);
+				sequence.AddAction(touchDevice.CreatePointerMove(source, 0, 0, TimeSpan.FromMilliseconds(5)));
+				sequence.AddAction(touchDevice.CreatePointerDown(PointerButton.TouchContact));
+				sequence.AddAction(touchDevice.CreatePause(TimeSpan.FromSeconds(1))); // Have to pause so the device doesn't think we are scrolling
+				sequence.AddAction(touchDevice.CreatePointerMove(destination, 0, 0, TimeSpan.FromSeconds(1)));
+				sequence.AddAction(touchDevice.CreatePointerUp(PointerButton.TouchContact));
+				_driver?.PerformActions(new List<ActionSequence> { sequence });
+			}
+
+			Thread.Sleep(500);
 		}
 
 		public void DragCoordinates(float fromX, float fromY, float toX, float toY)
 		{
-			OpenQA.Selenium.Appium.Interactions.PointerInputDevice touchDevice = new OpenQA.Selenium.Appium.Interactions.PointerInputDevice(PointerType);
-			ActionSequence sequence = new ActionSequence(touchDevice, 0);
-			sequence.AddAction(touchDevice.CreatePointerMove(CoordinateOrigin.Viewport, (int)fromX, (int)fromY, TimeSpan.FromMilliseconds(5)));
-			sequence.AddAction(touchDevice.CreatePointerDown(PointerButton.TouchContact));
-			sequence.AddAction(touchDevice.CreatePause(TimeSpan.FromSeconds(1))); // Have to pause so the device doesn't think we are scrolling
-			sequence.AddAction(touchDevice.CreatePointerMove(CoordinateOrigin.Viewport, (int)toX, (int)toY, TimeSpan.FromSeconds(1)));
-			sequence.AddAction(touchDevice.CreatePointerUp(PointerButton.TouchContact));
-			_driver?.PerformActions(new List<ActionSequence> { sequence });
-			Thread.Sleep(1000);
+			if (IsiOS)
+			{
+				// iOS doesn't seem to work with the action API, so we are using script calls
+				_driver?.ExecuteScript("mobile: dragFromToForDuration", new Dictionary<string, object>
+				{
+					{ "duration", 1 }, // Length of time to hold after click before start dragging
+					// from/to are absolute screen coordinates unless 'element' is specified then everything will be relative
+					{ "fromX", fromX},
+					{ "fromY", fromY },
+					{ "toX", toX },
+					{ "toY", toY }
+				});
+			}
+			else if(IsMac)
+			{
+				_driver?.ExecuteScript("macos: clickAndDragAndHold", new Dictionary<string, object>
+				{
+					{ "holdDuration", .1 }, // Length of time to hold before releasing
+					{ "duration", 1 }, // Length of time to hold after click before start dragging
+					{ "velocity", 2500 }, // How fast to drag
+					{ "fromX", fromX},
+					{ "fromY", fromY },
+					{ "endX", toX },
+					{ "endY", toY }
+				});
+			}
+			else
+			{
+				OpenQA.Selenium.Appium.Interactions.PointerInputDevice touchDevice = new OpenQA.Selenium.Appium.Interactions.PointerInputDevice(PointerType);
+				ActionSequence sequence = new ActionSequence(touchDevice, 0);
+				sequence.AddAction(touchDevice.CreatePointerMove(CoordinateOrigin.Viewport, (int)fromX, (int)fromY, TimeSpan.FromMilliseconds(5)));
+				sequence.AddAction(touchDevice.CreatePointerDown(PointerButton.TouchContact));
+				sequence.AddAction(touchDevice.CreatePause(TimeSpan.FromSeconds(1))); // Have to pause so the device doesn't think we are scrolling
+				sequence.AddAction(touchDevice.CreatePointerMove(CoordinateOrigin.Viewport, (int)toX, (int)toY, TimeSpan.FromSeconds(1)));
+				sequence.AddAction(touchDevice.CreatePointerUp(PointerButton.TouchContact));
+				_driver?.PerformActions(new List<ActionSequence> { sequence });
+			}
+
+			Thread.Sleep(500);
 		}
 
 		public void EnterText(string text)


### PR DESCRIPTION
### Description of Change

Use appium script calls for ios/mac to enable gestures for drag/drop in UITests
