### PR TITLE
Clear window from ContextStub after it's closed

### DIFF
--- a/src/Core/tests/DeviceTests.Shared/Stubs/ContextStub.cs
+++ b/src/Core/tests/DeviceTests.Shared/Stubs/ContextStub.cs
@@ -54,13 +54,34 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 				return _windowManager ??= new NavigationRootManager((UI.Xaml.Window)this.GetService(typeof(UI.Xaml.Window)));
 
 			if (serviceType == typeof(UI.Xaml.Window))
-				return _window ??= (_services.GetService<UI.Xaml.Window>() ?? new UI.Xaml.Window());
+			{
+				if (_window is not null)
+					return _window;
+
+				_window = (_services.GetService<UI.Xaml.Window>() ?? new UI.Xaml.Window());
+
+				// If a single test needs to open multiple windows then we need to clear the window
+				// once it's closed. This way, the next request will get a new window instead of
+				// trying to reuse a closed window and crashing.
+				_window.Closed += OnWindowClosed;
+				return _window;
+			}
 #endif
 			if (serviceType == typeof(IDispatcher))
 				return _services.GetService(serviceType) ?? TestDispatcher.Current;
 
 			return _services.GetService(serviceType);
 		}
+
+#if WINDOWS
+		void OnWindowClosed(object sender, UI.Xaml.WindowEventArgs args)
+		{
+			if (sender is UI.Xaml.Window w)
+				w.Closed -= OnWindowClosed;
+
+			_window = null;
+		}
+#endif
 
 		public IMauiHandlersFactory Handlers =>
 			Services.GetRequiredService<IMauiHandlersFactory>();


### PR DESCRIPTION
### Description of Change

There are a few tests (Label) where we call `AttachAndRun` more than once. The second call would always fail because it would return an already closed window. This code monitors when the window has been closed and then clears out the `window` we are returning.
