### PR TITLE
Don't reset App.Current OnResume if it's already set

### DIFF
--- a/src/Controls/src/Core/Application.cs
+++ b/src/Controls/src/Core/Application.cs
@@ -348,7 +348,9 @@ namespace Microsoft.Maui.Controls
 
 		internal void SendResume()
 		{
+			if (Current is null)
 			Current = this;
+
 			OnResume();
 		}
 


### PR DESCRIPTION
### Description of Change

During a device test run the `Current` application was getting reset to `ApplicationStub` whenever a test would minimize and then maximize a window as part of the test. This would then cause the `VisualRunner` to start failing.

This code was originally  added here https://github.com/xamarin/Xamarin.Forms/pull/5994