### PR TITLE
Ignore additional tests for iOS

### DIFF
--- a/src/Compatibility/ControlGallery/src/Issues.Shared/AddingMultipleItemsListView.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/AddingMultipleItemsListView.cs
@@ -132,6 +132,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 		}
 
 		[Test]
+		[FailsOnMauiIOS]
 		public void AddingMultipleListViewTests2AddOneElementToList()
 		{
 			RunningApp.Tap(q => q.Marked("Add One"));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla23942.xaml.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla23942.xaml.cs
@@ -61,6 +61,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Bugzilla23942Test()
 		{
 			RunningApp.WaitForElement(q => q.Marked("success"));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla24574.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla24574.cs
@@ -40,6 +40,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void TapThenDoubleTap()
 		{
 			RunningApp.Screenshot("I am at Issue 24574");

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla26233.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla26233.cs
@@ -49,6 +49,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[FailsOnMauiIOS]
 		public void DoesntCrashOnNavigatingBackToThePage()
 		{
 			RunningApp.WaitForElement(q => q.Marked("btnPush"));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla26993.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla26993.cs
@@ -97,6 +97,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 #if __MACOS__
 		[Ignore("Webview query is not implemented yet on UITEst desktop")]
 #endif
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Bugzilla26993Test()
 		{
 			RunningApp.Screenshot("I am at BZ26993");

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla29128.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla29128.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 #if UITEST
 		[Test]
 		[Category(UITestCategories.ManualReview)]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Bugzilla29128Test()
 		{
 			RunningApp.WaitForElement(q => q.Marked("SliderId"));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla29363.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla29363.cs
@@ -48,6 +48,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void PushButton()
 		{
 			RunningApp.Tap(q => q.Marked("Modal Push Pop Test"));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla31395.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla31395.cs
@@ -46,6 +46,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Bugzilla31395Test()
 		{
 			RunningApp.WaitForElement(q => q.Marked("Switch Main Page"));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla32040.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla32040.cs
@@ -58,6 +58,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 		}
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void TappedWorksForEntryAndSwithCellTest()
 		{
 			RunningApp.Tap(q => q.Marked("blahblah"));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla32148.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla32148.cs
@@ -233,6 +233,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Bugzilla32148Test()
 		{
 			RunningApp.WaitForElement(q => q.Marked("Contact0 LastName"));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla32206.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla32206.cs
@@ -23,8 +23,9 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 			PushAsync(new LandingPage32206());
 		}
 
-#if UITEST && __IOS__
+#if UITEST && IOS
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Bugzilla32206Test()
 		{
 			for (var n = 0; n < 10; n++)

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla32462.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla32462.cs
@@ -51,6 +51,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Bugzilla36729Test()
 		{
 			RunningApp.WaitForElement(q => q.Marked("Click!"));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla32615.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla32615.cs
@@ -60,6 +60,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public async Task Bugzilla32615Test()
 		{
 			RunningApp.Tap(q => q.Marked("btnModal"));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla33578.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla33578.cs
@@ -80,6 +80,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST && __IOS__
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void TableViewEntryCellShowsDefaultKeyboardThenNumericKeyboardAfterScrolling()
 		{
 			RunningApp.ScrollDown();

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla33870.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla33870.cs
@@ -121,6 +121,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Bugzilla33870Test()
 		{
 			RunningApp.WaitForElement(x => x.Marked(PageContentAutomatedId));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla34007.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla34007.cs
@@ -74,6 +74,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 #if UITEST
 		[Test]
 		[UiTest(typeof(Grid))]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Issue34007TestFirstElementHasLowestZOrder()
 		{
 			var buttonLocations = RunningApp.WaitForElement(q => q.Marked("Button 0"));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla34912.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla34912.cs
@@ -103,6 +103,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Bugzilla34912Test()
 		{
 			RunningApp.Tap(q => q.Marked("Allen"));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla35127.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla35127.cs
@@ -34,6 +34,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Issue35127Test()
 		{
 			RunningApp.WaitForElement(q => q.Marked("See me?"));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla35477.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla35477.cs
@@ -44,6 +44,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void TapGestureFiresOnFrame()
 		{
 			RunningApp.WaitForElement("No taps yet");

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla35733.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla35733.cs
@@ -57,6 +57,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Bugzilla35733Test()
 		{
 			RunningApp.WaitForElement(q => q.Marked("btnGo"));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla36171.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla36171.cs
@@ -84,6 +84,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 #if __MACOS__
 		[Ignore("Missing UITest for focus")]
 #endif
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void EntryTextDoesNotDisplayNonnumericInput ()
 		{
 			RunningApp.WaitForElement ("Start Entry");
@@ -107,6 +108,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 #if __MACOS__
 		[Ignore("Missing UITest for focus")]
 #endif
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void EditorTextDoesNotDisplayNonnumericInput ()
 		{
 			RunningApp.WaitForElement ("Start Editor");

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla36559.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla36559.cs
@@ -47,6 +47,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Bugzilla36559Test()
 		{
 			RunningApp.WaitForElement(q => q.Marked("entry"));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla36703.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla36703.cs
@@ -64,6 +64,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void _36703Test()
 		{
 			RunningApp.WaitForElement(TestImage);

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla36780.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla36780.cs
@@ -72,6 +72,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void MultipleTapGestures()
 		{
 			RunningApp.WaitForElement(TestImage);

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla36802.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla36802.cs
@@ -72,6 +72,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 #if (UITEST && __IOS__)
         [Test]
 		[Category(UITestCategories.ManualReview)]
+		[Compatibility.UITests.FailsOnMauiIOS]
         public void Bugzilla36802Test()
         {
 			RunningApp.WaitForElement("TestReady");

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla37625.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla37625.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 {
 #if UITEST
 	[NUnit.Framework.Category(Compatibility.UITests.UITestCategories.Bugzilla)]
+	[Compatibility.UITests.FailsOnMauiIOS]
 #endif
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Bugzilla, 37625, "App crashes when quickly adding/removing Image views (Windows UWP)")]

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla37841.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla37841.cs
@@ -139,6 +139,7 @@ The EntryCell should display '112358' and the TextCell should display '48151623'
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void TextAndEntryCellsDataBindInTableView()
 		{
 			RunningApp.WaitForElement("Generate");

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla38112.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla38112.cs
@@ -88,6 +88,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Bugzilla38112_SwitchIsStillOnScreen ()
 		{
 			RunningApp.WaitForElement (q => q.Marked ("Click"));
@@ -96,6 +97,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 		}
 
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Bugzilla38112_SwitchIsStillDisabled ()
 		{
 			RunningApp.WaitForElement (q => q.Marked ("Click"));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla38731.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla38731.cs
@@ -118,6 +118,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST && __IOS__
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Bugzilla38731Test ()
 		{
 			RunningApp.Tap(q => q.Marked("btn1"));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla38978.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla38978.cs
@@ -85,6 +85,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		[Category(UITestCategories.ManualReview)]
 		public void Bugzilla38978Test ()
 		{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla39530.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla39530.cs
@@ -70,6 +70,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 #if __MACOS__
 		[Ignore("UITest.Desktop doesn't return empty NSView yet so it can't find the frame")]
 #endif
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Bugzilla39530PanTest()
 		{
 			// Got to wait for the element to be visible to the UI test framework, otherwise we get occasional 
@@ -85,6 +86,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 #if __MACOS__
 		[Ignore("UITest.Desktop doesn't return empty NSView yet so it can't find the frame")]
 #endif
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Bugzilla39530PinchTest()
 		{
 			RunningApp.PinchToZoomIn ("frame");
@@ -95,6 +97,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 #if __MACOS__
 		[Ignore("UITest.Desktop doesn't return empty NSView yet so it can't find the frame")]
 #endif
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Bugzilla39530TapTest()
 		{
 			RunningApp.WaitForElement (q => q.Marked ("frame"));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla39636.xaml.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla39636.xaml.cs
@@ -42,6 +42,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void DoesNotCrash()
 		{
 			RunningApp.WaitForElement(q => q.Text("Success"));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla39668.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla39668.cs
@@ -50,6 +50,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Bugzilla39668Test ()
 		{
 			RunningApp.WaitForElement (q => q.Marked ("Success"));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla39702.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla39702.cs
@@ -60,6 +60,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public async Task ControlCanBeFocusedByUnfocusedEvent()
 		{
 			RunningApp.WaitForElement(TheEntry);

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla39987.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla39987.cs
@@ -69,6 +69,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST && __IOS__
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void MapViewInTabbedPage()
 		{
 			RunningApp.WaitForElement(Ok);

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla40161.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla40161.cs
@@ -128,6 +128,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Issue1Test()
 		{
 			RunningApp.Screenshot("I am at Issue 40161");

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla40911.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla40911.cs
@@ -31,6 +31,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST && __IOS__
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void CanFinishLoginWithoutNRE()
 		{
 			RunningApp.WaitForElement("Start");

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla41205.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla41205.cs
@@ -58,6 +58,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void CreateDefaultPassesStringInsteadOfObject()
 		{
 			RunningApp.WaitForElement(_success);

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla41619.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla41619.cs
@@ -71,6 +71,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void SliderBinding()
 		{
 			RunningApp.WaitForElement(_success.ToString());

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla42277.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla42277.cs
@@ -116,6 +116,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Bugzilla42277Test()
 		{
 			RunningApp.WaitForElement(q => q.Marked(Success1));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla42956.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla42956.cs
@@ -141,6 +141,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Bugzilla42956Test()
 		{
 			RunningApp.WaitForElement(q => q.Marked(Success));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla43161.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla43161.cs
@@ -58,6 +58,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST && __IOS__
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Bugzilla43161Test()
 		{
 			RunningApp.WaitForElement(q => q.Marked("0"));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla43469.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla43469.cs
@@ -53,6 +53,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 #if UITEST
 
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public async Task Bugzilla43469Test()
 		{
 			RunningApp.WaitForElement(q => q.Marked(kButtonText));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla44166.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla44166.cs
@@ -72,6 +72,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Bugzilla44166Test()
 		{
 			RunningApp.WaitForElement(q => q.Marked("Go"));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla44338.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla44338.cs
@@ -61,6 +61,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST && __IOS__
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Bugzilla44338Test()
 		{
 			RunningApp.SwipeRightToLeft(Items.First());

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla44461.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla44461.cs
@@ -70,6 +70,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST && __IOS__
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Bugzilla44461Test()
 		{
 			var positions = TapButton(0);

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla44886.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla44886.cs
@@ -89,6 +89,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Bugzilla44886Test()
 		{
 			RunningApp.WaitForElement(q => q.Marked(Item1));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla45027.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla45027.cs
@@ -101,6 +101,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST && __IOS__
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Bugzilla45027Test()
 		{
 			var firstItemList = List.First().ToString();

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla45743.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla45743.cs
@@ -64,6 +64,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if __IOS__
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Bugzilla45743Test()
 		{
 			RunningApp.WaitForElement(q => q.Marked("ActionSheet Title"));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla49069.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla49069.cs
@@ -55,6 +55,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Bugzilla49069Test()
 		{
 			RunningApp.WaitForElement(q => q.Marked("lblLong"));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla51173.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla51173.cs
@@ -79,6 +79,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 		}
 
 		[Test(Description = "Load a valid image")]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Bugzilla51173_ValidImage()
 		{
 			RunningApp.WaitForElement(q => q.Marked(ValidImage));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla51238.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla51238.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 	{
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Issue1Test()
 		{
 			RunningApp.WaitForElement("Tap Me!");

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla51825.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla51825.cs
@@ -51,6 +51,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Bugzilla51825Test()
 		{
 			RunningApp.WaitForElement(q => q.Marked("Bugzilla51825SearchBar"));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla52533.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla52533.cs
@@ -52,6 +52,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Bugzilla52533Test()
 		{
 			RunningApp.WaitForElement(q => q.Marked(LabelId));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla53445.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla53445.cs
@@ -87,6 +87,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Test()
 		{
 			RunningApp.WaitForElement(q => q.Marked("Success"));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla53834.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla53834.cs
@@ -86,6 +86,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 #if (UITEST && __IOS__)
 		[Test]
 		[Category(UITestCategories.ManualReview)]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Bugzilla53834Test()
 		{
 			RunningApp.WaitForElement("TestReady");

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla55365.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla55365.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void ForcingGCDoesNotCrash()
 		{
 			RunningApp.WaitForElement("Clear");

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla55745.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla55745.cs
@@ -160,6 +160,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Bugzilla55745Test()
 		{
 			RunningApp.WaitForElement(q => q.Marked(ButtonId));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla55912.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla55912.cs
@@ -83,6 +83,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void GestureBubblingInStackLayout()
 		{
 			RunningApp.WaitForElement(StackLabelId);
@@ -91,6 +92,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 		}
 
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void GestureBubblingInGrid()
 		{
 			RunningApp.WaitForElement(GridLabelId);

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla56298.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla56298.cs
@@ -112,6 +112,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Bugzilla56298Test()
 		{
 			RunningApp.WaitForElement(q => q.Marked("btnAdd"));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla56771.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla56771.cs
@@ -94,6 +94,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST && __IOS__
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Bugzilla56771Test()
 		{
 			RunningApp.WaitForElement(q => q.Marked(BtnAdd));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla56896.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla56896.cs
@@ -219,6 +219,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void ListViewsWithManyElementsPerformanceCheck()
 		{
 			RunningApp.WaitForElement(q => q.Marked(Instructions));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla57317.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla57317.cs
@@ -45,6 +45,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Bugzilla57317Test()
 		{
 			RunningApp.WaitForFirstElement("Cell");

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla57515.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla57515.cs
@@ -129,6 +129,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Bugzilla57515Test()
 		{
 			RunningApp.WaitForElement(ZoomContainer);

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla57674.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla57674.cs
@@ -46,6 +46,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Bugzilla57674Test()
 		{
 			RunningApp.Screenshot("Initial Status");

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla57749.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla57749.cs
@@ -41,6 +41,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public async Task Bugzilla57749Test()
 		{
 			await Task.Delay(500);

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla57758.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla57758.cs
@@ -47,6 +47,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void RemovingImageWithGestureFromLayoutWithinGestureHandlerDoesNotCrash()
 		{
 			RunningApp.WaitForElement(ImageId);

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla58645.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla58645.cs
@@ -136,6 +136,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Bugzilla58645Test()
 		{
 			RunningApp.WaitForElement(q => q.Marked(ButtonId));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla58779.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla58779.cs
@@ -62,6 +62,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Bugzilla58779Test()
 		{
 			RunningApp.WaitForElement(q => q.Marked(ButtonId));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla59580.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla59580.cs
@@ -44,6 +44,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void RaisingCommandCanExecuteChangedCausesCrashOnAndroid()
 		{
 			RunningApp.WaitForElement(c => c.Marked("Cell"));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla59718.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla59718.cs
@@ -130,6 +130,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Bugzilla59718Test()
 		{
 			RunningApp.WaitForElement(q => q.Marked(Target1));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla59863_0.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla59863_0.cs
@@ -64,6 +64,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void TapsCountShouldMatch()
 		{
 			// Gonna add this test because we'd want to know if it _did_ start failing
@@ -83,6 +84,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 		}
 
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void DoubleTapWithOnlySingleTapRecognizerShouldRegisterTwoTaps()
 		{
 			RunningApp.WaitForElement(SingleTapBoxId);

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla59863_1.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla59863_1.cs
@@ -67,6 +67,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void SingleTapWithOnlyDoubleTapRecognizerShouldRegisterNothing()
 		{
 			RunningApp.WaitForElement(DoubleTapBoxId);
@@ -76,6 +77,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 		}
 
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void DoubleTapWithOnlyDoubleTapRecognizerShouldRegisterOneDoubleTap()
 		{
 			RunningApp.WaitForElement(DoubleTapBoxId);

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla59863_2.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla59863_2.cs
@@ -82,6 +82,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void DoubleTapWithMixedRecognizersShouldRegisterDoubleTap()
 		{
 			RunningApp.WaitForElement(MixedTapBoxId);
@@ -91,6 +92,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 		}
 
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void SingleTapWithMixedRecognizersShouldRegisterSingleTap()
 		{
 			RunningApp.WaitForElement(MixedTapBoxId);

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla59896.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla59896.cs
@@ -92,6 +92,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Bugzilla59896Test()
 		{
 			RunningApp.WaitForElement(q => q.Marked(btnAdd));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla59925.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla59925.cs
@@ -57,6 +57,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Issue123456Test()
 		{
 			RunningApp.Screenshot("I am at Issue 59925");

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla60045.xaml.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla60045.xaml.cs
@@ -51,6 +51,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void CommandDoesNotFire()
 		{
 			RunningApp.WaitForElement(ClickThis);

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla60382.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla60382.cs
@@ -39,6 +39,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Issue1Test()
 		{
 			RunningApp.WaitForElement(q => q.Marked("ListView"));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla60524.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla60524.cs
@@ -175,6 +175,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Bugzilla60524Test()
 		{
 			RunningApp.WaitForElement(q => q.Marked("Group 1"));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/ButtonBackgroundColorTest.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/ButtonBackgroundColorTest.cs
@@ -37,6 +37,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void ButtonBackgroundColorAutomatedTest()
 		{
 			// With the original bug in place, we'll crash before we get this far

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/CollectionViewBindingErrors.xaml.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/CollectionViewBindingErrors.xaml.cs
@@ -43,6 +43,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void CollectionViewBindingErrorsShouldBeZero()
 		{
 			RunningApp.WaitForElement("Binding Errors: 0");

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/CollectionViewBoundMultiSelection.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/CollectionViewBoundMultiSelection.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void ItemsFromViewModelShouldBeSelected()
 		{
 			// Initially Items 1 and 2 should be selected (from the view model)

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/CollectionViewItemsSourceTypes.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/CollectionViewItemsSourceTypes.cs
@@ -52,6 +52,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void CollectionViewItemsSourceTypesDisplayAndDontCrash()
 		{
 			RunningApp.QueryUntilPresent(() =>

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/CollectionViewItemsUpdatingScrollMode.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/CollectionViewItemsUpdatingScrollMode.cs
@@ -42,6 +42,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 		}
 
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void KeepScrollOffset()
 		{
 			RunningApp.WaitForElement("SelectScrollMode");
@@ -56,6 +57,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 		}
 
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void KeepLastItemInView()
 		{
 			RunningApp.WaitForElement("SelectScrollMode");

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Github1625.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Github1625.cs
@@ -61,6 +61,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void SettingSliderToSpecificValueWorks()
 		{
 			RunningApp.WaitForElement("LabelValue");

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Github5623.xaml.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Github5623.xaml.cs
@@ -116,6 +116,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void CollectionViewInfiniteScroll()
 		{
 			RunningApp.WaitForElement("CollectionView5623");

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/HeaderFooterShellFlyout.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/HeaderFooterShellFlyout.cs
@@ -194,6 +194,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 #endif
 
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void FlyoutTests()
 		{
 			RunningApp.WaitForElement("PageLoaded");

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue10454.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue10454.cs
@@ -76,6 +76,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void ChildAddedShouldFire() 
 		{
 			RunningApp.WaitForElement(Success);

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue10563.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue10563.cs
@@ -145,6 +145,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST && (__ANDROID__ || __IOS__)
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Issue10563OpenSwipeViewTest ()
 		{
 			RunningApp.WaitForElement(OpenLeftId);

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue11107.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue11107.cs
@@ -136,6 +136,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void TabShouldntBeVisibleWhenThereIsOnlyOnePage()
 		{
 			RunTests();

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue11209.xaml.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue11209.xaml.cs
@@ -57,6 +57,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 #if UITEST
 		[Category(UITestCategories.SwipeView)]
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void TapSwipeViewAndNavigateTest()
 		{
 			RunningApp.WaitForElement(SwipeViewContent);

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue11381.xaml.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue11381.xaml.cs
@@ -78,6 +78,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST && __IOS__
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Issue11381RemoveListViewGroups()
 		{
 			RunningApp.WaitForElement("ListViewId", "Timed out waiting for the ListView.");

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue1146.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue1146.cs
@@ -41,6 +41,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void TestSwitchDisable()
 		{
 			RunningApp.WaitForElement(c => c.Marked("switch"));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue11969.xaml.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue11969.xaml.cs
@@ -65,6 +65,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 #if UITEST && __IOS__
 		[Test]
 		[Category(UITestCategories.SwipeView)]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void SwipeDisableChildButtonTest()
 		{
 			RunningApp.WaitForElement(q => q.Marked(Failed));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue12060.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue12060.cs
@@ -92,6 +92,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void AcceptedOperationNoneDisablesDropOperation()
 		{
 			RunningApp.WaitForElement("TestLoaded");

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue12153.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue12153.cs
@@ -43,6 +43,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void InvalidFontDoesntCauseAppToCrash()
 		{
 			RunningApp.WaitForElement("Success");

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue1219.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue1219.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 		protected override void Init() { }
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void ViewCellInTableViewDoesNotCrash()
 		{
 			// If we can see this element, then we didn't crash.

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue12193.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue12193.cs
@@ -67,6 +67,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public async Task RotatingCarouselViewHTMLShouldNotDisappear()
 		{
 			int delay = 3000;

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue12246.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue12246.cs
@@ -79,6 +79,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void UnfocusingPasswordDoesNotHang()
 		{
 			RunningApp.WaitForElement(Entry);

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue12374.xaml.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue12374.xaml.cs
@@ -115,7 +115,8 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
         [Test]
-        public void Issue12374Test()
+		[Compatibility.UITests.FailsOnMauiIOS]
+		public void Issue12374Test()
         {
             RunningApp.WaitForElement("TestReady");
             RunningApp.Tap("RemoveItems");

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue12574.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue12574.cs
@@ -94,6 +94,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Issue12574Test()
 		{
 			RunningApp.WaitForElement("0 item");
@@ -120,6 +121,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 		}
 
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void RemoveItemsQuickly()
 		{
 			RunningApp.WaitForElement("0 item");

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue12685.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue12685.cs
@@ -69,6 +69,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void ShapesPathReceiveGestureRecognizers()
 		{
 			var testLabel = RunningApp.WaitForFirstElement(StatusLabelId);

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue12714.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue12714.cs
@@ -45,6 +45,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void InitiallyInvisbleCollectionViewSurvivesiOSLayoutNonsense()
 		{
 			RunningApp.WaitForElement(Show);

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue12777.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue12777.cs
@@ -53,6 +53,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Issue12777Test()
 		{
 			RunningApp.WaitForElement("TestCarouselView");

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue13126.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue13126.cs
@@ -172,6 +172,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void CollectionViewShouldSourceShouldUpdateWhileInvisible()
 		{
 			RunningApp.WaitForElement(Success);

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue13126_2.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue13126_2.cs
@@ -65,6 +65,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void CollectionViewShouldSourceShouldResetWhileInvisible()
 		{
 			RunningApp.WaitForElement(Success);

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue1323.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue1323.cs
@@ -48,6 +48,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 #if UITEST
 		[Test]
 		[NUnit.Framework.Category(Compatibility.UITests.UITestCategories.TabbedPage)]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Issue1323Test()
 		{
 			RunningApp.WaitForElement(X => X.Marked("Page 1"));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue1436.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue1436.cs
@@ -101,6 +101,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		[Category(UITestCategories.ManualReview)]
 		public void Issue1436Test()
 		{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue1439.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue1439.cs
@@ -131,6 +131,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Issue1439Test()
 		{
 			RunningApp.WaitForElement(q => q.Marked(A));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue1469.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue1469.cs
@@ -55,6 +55,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Issue1469Test()
 		{
 			RunningApp.WaitForElement(Go);

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue1538.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue1538.cs
@@ -38,6 +38,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 #if UITEST
 		[Test]
 		[Category(UITestCategories.ScrollView)]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void MeasuringEmptyScrollViewDoesNotCrash()
 		{
 			Task.Delay(1000).Wait();

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue1583.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue1583.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Issue1583TitleIconTest()
 		{
 			RunningApp.WaitForElement(q => q.Marked("lblHello"));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue1590.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue1590.cs
@@ -57,6 +57,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 #if UITEST
 		[Test]
 		[Category(UITestCategories.ListView)]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void ListViewIsGroupingEnabledDoesNotCrash()
 		{
 			RunningApp.WaitForElement("First");

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue1601.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue1601.cs
@@ -49,6 +49,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Issue1601Test()
 		{
 			RunningApp.Screenshot("Start G1601");

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue1614.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue1614.cs
@@ -42,6 +42,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 		protected override bool Isolate => true;
 
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Issue1614Test()
 		{
 			RunningApp.SetOrientationPortrait();

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue1667.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue1667.cs
@@ -97,6 +97,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 #if UITEST
 		[Test]
 		[NUnit.Framework.Category(UITestCategories.ManualReview)]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void TestCursorPositionAndSelection()
 		{
 			RunningApp.WaitForElement("CursorTextEntry");

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue1700.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue1700.cs
@@ -45,6 +45,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 #if UITEST
 		[Test]
 		[Category(UITestCategories.Image)]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void LongImageURLsShouldNotCrash()
 		{
 			// Give the images some time to load (or fail)

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue1769.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue1769.cs
@@ -88,6 +88,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Issue1769Test()
 		{
 			RunningApp.WaitForElement(q => q.Marked(GoToPageTwoButtonText));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue1851.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue1851.cs
@@ -100,6 +100,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Issue1851Test() 
 		{
 			RunningApp.WaitForElement(q => q.Marked("btn"));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue1875.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue1875.cs
@@ -130,6 +130,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void NSRangeException()
 		{
 			RunningApp.WaitForElement(q => q.Marked("Load"));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue1900.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue1900.cs
@@ -49,6 +49,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Issue1900Test ()
 		{
 			RunningApp.WaitForElement (q => q.Marked ("ListView"));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue1909.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue1909.cs
@@ -60,6 +60,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 #if UITEST
 		[Test]
 		[Category(UITestCategories.ManualReview)]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Issue1909Test()
 		{
 			RunningApp.WaitForElement("TestReady");

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue1939.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue1939.cs
@@ -164,6 +164,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Issue1939Test()
 		{
 			RunningApp.WaitForElement(q => q.Marked("Group #1"));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2004.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2004.cs
@@ -298,6 +298,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void NoCrashFromDisposedBitmapWhenSwitchingPages()
 		{
 			RunningApp.WaitForElement("Success", timeout: TimeSpan.FromSeconds(20));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue206.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue206.cs
@@ -33,6 +33,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 		[Test]
 		[NUnit.Framework.Category("ManualReview")]
 		[UiTest(typeof(ViewCell))]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Issue206TestsTextInTextCellResizes()
 		{
 			RunningApp.WaitForElement(q => q.Marked("Click 9"));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2222.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2222.cs
@@ -41,6 +41,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void TestItDoesntCrashWithWrongIconName()
 		{
 			RunningApp.WaitForElement(c => c.Marked("Hello Toolbaritem"));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2272.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2272.cs
@@ -40,6 +40,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 #if __MACOS__
 		[Ignore("EnterText problems in UITest Desktop")]
 #endif
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void TestFocusIsOnTheEndAfterSettingText ()
 		{
 			RunningApp.WaitForElement("userNameEditorEmptyString");

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2339.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2339.cs
@@ -87,6 +87,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 #if WINDOWS
 		[Ignore("Focus Behavior is different on UWP")]
 #endif
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void FocusAndUnFocusMultipleTimes()
 		{
 			RunningApp.WaitForElement("btnFocusThenUnFocus");

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2399.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2399.cs
@@ -138,6 +138,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST && __IOS__
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void WaitForAllEffectsToDetach()
 		{
 			RunningApp.WaitForElement(q => q.Text("Success"));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2411.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2411.cs
@@ -83,6 +83,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 		[Test]
 		[Issue(IssueTracker.Github, 2411, "ScrollToPositon.End crashing in TabbedPage", PlatformAffected.Android)]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Issue2411ScrollToPositionWrongOnUneven()
 		{
 			RunningApp.Tap(q => q.Marked("Crash in ScrollToPosition.End"));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2414.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2414.cs
@@ -63,6 +63,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 #if UITEST
 		[Test]
 		[NUnit.Framework.Category(Compatibility.UITests.UITestCategories.UwpIgnore)]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void TestDoesntCrashShowingContextMenu()
 		{
 			RunningApp.ActivateContextMenu("Swipe ME");
@@ -72,6 +73,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 		}
 
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void TestShowContextMenuItemsInTheRightOrder()
 		{
 			RunningApp.ActivateContextMenu("Swipe ME");

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2499.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2499.cs
@@ -37,6 +37,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Issue2499Test()
 		{
 			RunningApp.WaitForElement("picker");

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2597.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2597.cs
@@ -68,6 +68,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 #if UITEST
 		[Test]
 		[NUnit.Framework.Category(Compatibility.UITests.UITestCategories.UwpIgnore)]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Issue2597Test()
 		{
 #if __IOS__

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue264.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue264.cs
@@ -49,6 +49,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Issue264TestsPushAndPopModal()
 		{
 			RunningApp.WaitForElement(q => q.Marked("Home"));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2653.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2653.cs
@@ -155,6 +155,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 		// https://github.com/xamarin/Xamarin.Forms/issues/2989
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void ZIndexWhenInsertingChildren()
 		{
 			RunningApp.WaitForElement(x => x.Marked(ButtonText));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2674.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2674.cs
@@ -37,6 +37,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Issue2674Test()
 		{
 			RunningApp.Screenshot("I am at Issue2674");

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2680ScrollView.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2680ScrollView.cs
@@ -84,6 +84,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 		[Test]
 		[NUnit.Framework.Category(Compatibility.UITests.UITestCategories.UwpIgnore)]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Issue2680Test_ScrollEnabled()
 		{
 			RunningApp.Tap(q => q.Button(ToggleButtonMark));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2728.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2728.cs
@@ -32,6 +32,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Issue2728TestsItalicLabel()
 		{
 			RunningApp.WaitForElement(q => q.Text(_lblHome));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2775.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2775.cs
@@ -120,6 +120,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Issue2775Test()
 		{
 			RunningApp.WaitForElement("TestReady");

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2777.xaml.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2777.xaml.cs
@@ -131,6 +131,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Issue2777Test()
 		{
 			RunningApp.Screenshot("I am at Issue 2965");

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2809.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2809.cs
@@ -35,6 +35,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void TestPageDoesntCrash()
 		{
 			ShouldShowMenu();

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2842.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2842.cs
@@ -63,6 +63,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Issue2842Test() 
 		{
 			RunningApp.WaitForElement (q => q.Marked ("btnClick"));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2927.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2927.cs
@@ -69,6 +69,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Issue2927Test()
 		{
 			RunningApp.Screenshot("I am at Issue 2927");

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2929.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2929.cs
@@ -41,6 +41,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void NullItemSourceDoesNotCrash()
 		{
 			// If we can see the Success label, it means we didn't crash. 
@@ -102,6 +103,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 #if UITEST
 		[Test]
 		[NUnit.Framework.Category(UITestCategories.ListView)]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void SettingItemsSourceToNullDoesNotCrash()
 		{
 			RunningApp.WaitForElement(Go);

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2951.xaml.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2951.xaml.cs
@@ -121,6 +121,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Issue2951Test()
 		{
 			RunningApp.WaitForElement("Ready");

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2953.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2953.cs
@@ -86,6 +86,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Issue2953Test()
 		{
 			RunningApp.Screenshot("I am at Issue 2953");

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2954.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2954.cs
@@ -52,6 +52,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Issue2954Test()
 		{
 			RunningApp.Screenshot("I am at Issue 2954");

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2963.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2963.cs
@@ -49,6 +49,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Issue2963Test ()
 		{
 			RunningApp.Screenshot ("I am at Issue 2963");

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2983.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2983.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void TestDoesNotCrash()
 		{
 			RunningApp.WaitForElement(c => c.Marked("footer"));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue3008.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue3008.cs
@@ -181,6 +181,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST && !__ANDROID__
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void EnsureListViewEmptiesOut()
 		{
 			RunningApp.Tap("Click Until Success");

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue3019.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue3019.cs
@@ -146,6 +146,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void MakeSureListGroupShowsUpAndItemsAreClickable()
 		{
 			RunningApp.WaitForElement("Group 1");

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue3049.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue3049.cs
@@ -60,6 +60,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST && __IOS__
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Issue3049Test()
 		{
 			RunningApp.WaitForElement(q => q.Marked(Button1Id));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue3273.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue3273.cs
@@ -72,6 +72,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Issue3273Test()
 		{
 			RunningApp.WaitForElement("Move items");

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue3275.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue3275.cs
@@ -220,6 +220,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Issue3275Test()
 		{
 			RunningApp.WaitForElement(q => q.Marked(_btnLeakId));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue3292.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue3292.cs
@@ -80,6 +80,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Issue3292Test()
 		{
 			RunningApp.WaitForElement(q => q.Marked("Hello World Changed"));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue3318.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue3318.cs
@@ -75,6 +75,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Issue3318Test()
 		{
 			RunningApp.WaitForElement(q => q.Marked("End"));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue3385.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue3385.cs
@@ -35,6 +35,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Issue3385Test()
 		{
 			RunningApp.WaitForElement("entry");

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue342.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue342.cs
@@ -33,6 +33,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Issue342NoSourceTestsLablePresentNoImage()
 		{
 			RunningApp.WaitForElement(q => q.Marked("Uninitialized image"), "Cannot see label");
@@ -80,6 +81,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 #if UITEST
 		[Test]
 		[Category(UITestCategories.ManualReview)]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Issue342DelayedLoadTestsImageLoads()
 		{
 			RunningApp.WaitForElement("TestReady");

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue3507.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue3507.cs
@@ -54,6 +54,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void NullContentOnScrollViewDoesntCrash()
 		{
 			RunningApp.WaitForElement("Success");

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue3524.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue3524.cs
@@ -67,6 +67,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void SpanGestureCommand()
 		{
 			RunningApp.WaitForElement(kText);

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue3525.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue3525.cs
@@ -64,6 +64,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void SpanRegionClicking()
 		{
 			var label = RunningApp.WaitForElement(kLabelTestAutomationId);

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue3667.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue3667.cs
@@ -77,6 +77,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Issue3667Tests ()
 		{
 			RunningApp.WaitForElement(query => query.Text(text));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue3788.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue3788.cs
@@ -99,6 +99,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void ReplaceItemScrollsListToTop()
 		{
 			RunningApp.WaitForElement(_replaceMe);

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue3798.xaml.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue3798.xaml.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 	{
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		[NUnit.Framework.Category(UITestCategories.ManualReview)]
 		public void Issue3798Test()
 		{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue3840.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue3840.cs
@@ -82,6 +82,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void TranslatingViewKeepsScrollViewPosition()
 		{
 			RunningApp.WaitForElement(_failedText);

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue3884.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue3884.cs
@@ -40,6 +40,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 #if UITEST
 		[Test]
 		[Category(UITestCategories.ManualReview)]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Issue3884Test()
 		{
 			RunningApp.WaitForElement("TestReady");

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue4138.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue4138.cs
@@ -35,6 +35,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST && __IOS__
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void TitleIconIsCentered()
 		{
 			var element = RunningApp.WaitForElement("coffee.png")[0];

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue4597.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue4597.cs
@@ -175,6 +175,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if !WINDOWS
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void ImageFromFileSourceAppearsAndDisappearsCorrectly()
 		{
 			RunTest(nameof(Image), true);
@@ -182,6 +183,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 		[Test]
 		[NUnit.Framework.Category(UITestCategories.RequiresInternetConnection)]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void ImageFromUriSourceAppearsAndDisappearsCorrectly()
 		{
 			RunTest(nameof(Image), false);
@@ -189,6 +191,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void ButtonFromFileSourceAppearsAndDisappearsCorrectly()
 		{
 			RunTest(nameof(Button), true);
@@ -203,12 +206,14 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void ImageButtonFromFileSourceAppearsAndDisappearsCorrectly()
 		{
 			RunTest(nameof(ImageButton), true);
 		}
 
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		[NUnit.Framework.Category(UITestCategories.RequiresInternetConnection)]
 		public void ImageButtonFromUriSourceAppearsAndDisappearsCorrectly()
 		{
@@ -216,6 +221,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 		}
 
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void ImageCellFromFileSourceAppearsAndDisappearsCorrectly()
 		{
 			ImageCellTest(true);

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue4720.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue4720.cs
@@ -31,6 +31,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 		protected override bool Isolate => true;
 
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void WebViewDoesntCrashWhenLoadingAHeavyPageAndUsingExecutionModeSeparateProcess()
 		{
 			//4 iterations were enough to run out of memory before the fix.

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue5239.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue5239.cs
@@ -32,6 +32,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST && __IOS__
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void PaddingEqualToSafeAreaWorks()
 		{
 			var somePadding = RunningApp.WaitForElement("Hello");

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue5354.xaml.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue5354.xaml.cs
@@ -75,6 +75,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void CollectionViewItemsLayoutUpdate()
 		{
 			RunningApp.WaitForElement("CollectionView5354");

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue5367.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue5367.cs
@@ -51,6 +51,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 #if UITEST
 		[Test]
 		[UiTest(typeof(Editor))]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Issue5367TestMaxLengthCrashesApp()
 		{
 			RunningApp.WaitForElement(MaxLengthEditor);

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue5470.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue5470.cs
@@ -58,6 +58,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST && __IOS__
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Issue5470Test() 
 		{
 			Thread.Sleep(500); // give it time to crash

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue5503.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue5503.cs
@@ -79,6 +79,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST && __IOS__
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void ToggleAppearanceApiBackgroundColorListView()
 		{
 			RunningApp.WaitForElement(ChangeBackgroundButtonAutomationId);

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue5518.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue5518.cs
@@ -77,6 +77,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void FrameTapGestureRecognizer()
 		{
 			RunningApp.WaitForElement("NoContentFrame");

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue5555.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue5555.cs
@@ -101,6 +101,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Issue5555Test()
 		{
 			RunningApp.Tap(q => q.Marked("Push page"));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue55555.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue55555.cs
@@ -82,6 +82,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void TGroupDisplayBindingPresentRecycleElementTest()
 		{
 			RunningApp.WaitForElement(q => q.Marked("vegetables"));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue5749.xaml.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue5749.xaml.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 	{
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void DisableScrollingOnCustomHorizontalListView()
 		{
 			RunningApp.WaitForElement("Button");

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue5830.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue5830.cs
@@ -47,6 +47,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 #if (UITEST && __IOS__)
         [Test]
 		[Category(UITestCategories.ManualReview)]
+		[Compatibility.UITests.FailsOnMauiIOS]
         public void Issue5830Test()
         {
 			RunningApp.WaitForElement("TestReady");

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue6334.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue6334.cs
@@ -37,6 +37,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST && __IOS__
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Issue6334Test() 
 		{
 			RunningApp.WaitForElement (q => q.Marked ("IssuePageLabel"));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue6368.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue6368.cs
@@ -55,6 +55,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST && __IOS__
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Issue6368Test() 
 		{
 			RunningApp.WaitForElement (q => q.Marked ("btnGo"));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue6705.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue6705.cs
@@ -59,6 +59,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Issue6705Test()
 		{
 			for (var i = 1; i < 6; i++)

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue6932.xaml.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue6932.xaml.cs
@@ -48,6 +48,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 		}
 
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void EmptyViewBecomesVisibleWhenItemsSourceIsEmptiedOneByOne()
 		{
 			RunningApp.Screenshot("Screen opens, items are shown");
@@ -63,6 +64,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 		}
 
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void EmptyViewHidesWhenItemsSourceIsFilled()
 		{
 			RunningApp.Screenshot("Screen opens, items are shown");

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue6932_emptyviewstring.xaml.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue6932_emptyviewstring.xaml.cs
@@ -35,6 +35,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void EmptyViewStringBecomesVisibleWhenItemsSourceIsCleared()
 		{
 			RunningApp.Screenshot("Screen opens, items are shown");
@@ -47,6 +48,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 		}
 
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void EmptyViewStringBecomesVisibleWhenItemsSourceIsEmptiedOneByOne()
 		{
 			RunningApp.Screenshot("Screen opens, items are shown");
@@ -62,6 +64,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 		}
 
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void EmptyViewStringHidesWhenItemsSourceIsFilled()
 		{
 			RunningApp.Screenshot("Screen opens, items are shown");

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue6932_emptyviewtemplate.xaml.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue6932_emptyviewtemplate.xaml.cs
@@ -34,6 +34,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void EmptyViewTemplateBecomesVisibleWhenItemsSourceIsCleared()
 		{
 			RunningApp.Screenshot("Screen opens, items are shown");
@@ -46,6 +47,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 		}
 
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void EmptyViewTemplateBecomesVisibleWhenItemsSourceIsEmptiedOneByOne()
 		{
 			RunningApp.Screenshot("Screen opens, items are shown");
@@ -61,6 +63,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 		}
 
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void EmptyViewTemplateHidesWhenItemsSourceIsFilled()
 		{
 			RunningApp.Screenshot("Screen opens, items are shown");

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue6945.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue6945.cs
@@ -66,6 +66,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void WrongTranslationBehaviorWhenChangingHeightRequestAndSettingAnchor()
 		{
 			var rect = RunningApp.WaitForElement(BoxViewId)[0].Rect;

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue6994.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue6994.cs
@@ -87,6 +87,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void NullPointerExceptionOnFastLabelTextColorChange()
 		{
 			RunningApp.WaitForElement(q => q.Marked("Click me"));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue7803.xaml.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue7803.xaml.cs
@@ -45,6 +45,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void DelayedIsRefreshingAndCommandTest_SwipeDown()
 		{
 			var collectionView = RunningApp.WaitForElement(q => q.Marked("CollectionView7803"))[0];

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue8004.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue8004.cs
@@ -74,6 +74,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public async Task AnimateScaleOfBoxView()
 		{
 			RunningApp.WaitForElement("TestReady");

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue8008.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue8008.cs
@@ -61,6 +61,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void RemovingShellItemCorrectlyPicksNextValidShellItemAsVisibleShellItem()
 		{
 			RunningApp.WaitForElement("Success");

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue8203.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue8203.cs
@@ -68,6 +68,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void SelectionChangedShouldBeRaisedOnceWhenSelectionChanges()
 		{
 			RunningApp.WaitForElement("one");

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue8461.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue8461.cs
@@ -88,6 +88,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST && __IOS__
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void ShellSwipeToDismiss()
 		{
 			var pushButton = RunningApp.WaitForElement(ButtonId);

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue8526.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue8526.cs
@@ -31,6 +31,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void DisplayPromptShouldWorkInPageLoad()
 		{
 			RunningApp.WaitForElement(Success);

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue8899.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue8899.cs
@@ -100,6 +100,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test, Category(UITestCategories.CollectionView)]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void ClearingGroupedCollectionViewShouldNotCrash()
 		{
 			RunningApp.WaitForElement(Go);

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue9196.xaml.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue9196.xaml.cs
@@ -34,6 +34,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test, Category(UITestCategories.CollectionView)]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void EmptyViewShouldNotCrash()
 		{
 			RunningApp.WaitForElement("Success");

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue9306.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue9306.cs
@@ -69,6 +69,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 		[Test]
 		[NUnit.Framework.Category(Compatibility.UITests.UITestCategories.UwpIgnore)]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Issue9306SwipeViewCloseSwiping()
 		{
 			RunningApp.WaitForElement(x => x.Marked(SwipeViewId));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue935.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue935.cs
@@ -91,6 +91,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 		[UiTest (typeof(ViewCell))]
 		[UiTest (typeof(ListView))]
 		[UiTest (typeof(ListView), "SelectedItem")]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Issue935TestsMultipleOnTappedViewCell ()
 		{
 			RunningApp.Tap (q => q.Marked ("I have been selected:"));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue9711.xaml.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue9711.xaml.cs
@@ -69,6 +69,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 		[Category(UITestCategories.ListView)]
 		[Category(UITestCategories.UwpIgnore)]
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void TestTappingHeaderDoesNotCrash()
 		{
 			// Usually, tapping one header is sufficient to produce the exception.

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue9929.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue9929.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void InsanelyWideHorizontalSpacingShouldNotCrash()
 		{
 			RunningApp.WaitForElement("entryUpdate_Spacing");

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/ListViewNRE.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/ListViewNRE.cs
@@ -40,6 +40,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void ListViewNRETest()
 		{
 			RunningApp.WaitForElement(q => q.Marked("1"));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/ListViewViewCellBinding.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/ListViewViewCellBinding.cs
@@ -114,6 +114,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void ListViewViewCellBindingTestsAllElementsPresent ()
 		{
 			RunningApp.WaitForElement (q => q.Marked ("Remove"));
@@ -129,6 +130,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 		}
 
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void ListViewViewCellBindingTestsAddListItem () 
 		{
 			RunningApp.Tap (q => q.Button ("Add"));
@@ -138,6 +140,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 		}
 
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void ListViewViewCellBindingTestsRemoveListItem () 
 		{
 			RunningApp.Tap (q => q.Button ("Remove"));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/RefreshViewTests.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/RefreshViewTests.cs
@@ -132,6 +132,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 		}
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void IsRefreshingAndCommandTest()
 		{
 			RunningApp.Tap(q => q.Button("Toggle Refresh"));
@@ -143,6 +144,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 		[Test]
 		[NUnit.Framework.Category(Compatibility.UITests.UITestCategories.UwpIgnore)]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void IsRefreshingAndCommandTest_SwipeDown()
 		{
 			RunningApp.WaitForElement(q => q.Marked("IsRefreshing: False"));
@@ -156,6 +158,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 		[Test]
 		[NUnit.Framework.Category(Compatibility.UITests.UITestCategories.UwpIgnore)]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void RefreshDisablesWithCommand()
 		{
 			RunningApp.WaitForElement("IsRefreshing: False");

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/RestartAppTest.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/RestartAppTest.cs
@@ -50,6 +50,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void ForcingRestartDoesNotCauseCrash()
 		{
 			RunningApp.WaitForElement(RestartButton);

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/ScrollToGroup.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/ScrollToGroup.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST && __IOS__ // Grouping for Android hasn't been merged yet
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void CanScrollToGroupAndItemIndex()
 		{
 			RunningApp.WaitForElement("GroupIndexEntry");
@@ -65,6 +66,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 		}
 
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void CanScrollToGroupAndItem()
 		{
 			RunningApp.WaitForElement("GroupNameEntry");

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/ShellBackButtonBehavior.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/ShellBackButtonBehavior.cs
@@ -283,6 +283,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 		}
 
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void BackButtonSetToTextStillNavigatesBack()
 		{
 			RunningApp.Tap(PushPageId);
@@ -293,6 +294,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 		}
 
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void BackButtonSetToTextStillOpensFlyout()
 		{
 			RunningApp.Tap(ToggleTextId);
@@ -315,6 +317,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 		}
 #else
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void FlyoutDisabledDoesntOpenFlyoutWhenSetToText()
 		{
 			RunningApp.WaitForElement("ToggleFlyoutBehavior");

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/ShellFlyoutHeaderBehavior.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/ShellFlyoutHeaderBehavior.cs
@@ -109,6 +109,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 		}
 
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void FlyoutHeaderBehaviorScroll()
 		{
 			RunningApp.Tap(nameof(FlyoutHeaderBehavior.Scroll));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/ShellInsets.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/ShellInsets.cs
@@ -367,6 +367,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 		}
 
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void SafeAreaOnBlankPage()
 		{
 			RunningApp.Tap(EmptyPageSafeAreaTest);
@@ -375,6 +376,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 		}
 
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void SafeArea()
 		{
 			RunningApp.Tap(SafeAreaTest);

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/ShellStoreTests.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/ShellStoreTests.cs
@@ -41,6 +41,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 		}
 
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void LoadsWithoutCrashing()
 		{
 			RunningApp.WaitForElement("Welcome to the HomePage");

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/_Template.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/_Template.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Issue1Test()
 		{
 			RunningApp.WaitForElement("Issue1Label");

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/issue3262.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/issue3262.cs
@@ -301,6 +301,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 		[Test]
 		[NUnit.Framework.Category(UITestCategories.RequiresInternetConnection)]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void LoadingPageWithoutCookiesSpecifiedDoesntCrash()
 		{
 			RunningApp.Tap("PageWithoutCookies");
@@ -309,6 +310,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 		[Test]
 		[NUnit.Framework.Category(UITestCategories.RequiresInternetConnection)]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void ChangeDuringNavigating()
 		{
 			RunningApp.WaitForElement("Loaded");
@@ -321,6 +323,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 		[Test]
 		[NUnit.Framework.Category(UITestCategories.RequiresInternetConnection)]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void AddAdditionalCookieToWebView()
 		{
 			RunningApp.WaitForElement("Loaded");
@@ -333,6 +336,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 		[Test]
 		[NUnit.Framework.Category(UITestCategories.RequiresInternetConnection)]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void SetToOneCookie()
 		{
 			RunningApp.WaitForElement("Loaded");
@@ -342,6 +346,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 		[Test]
 		[NUnit.Framework.Category(UITestCategories.RequiresInternetConnection)]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void SetCookieContainerToNullDisablesCookieManagement()
 		{
 			RunningApp.WaitForElement("Loaded");
@@ -354,6 +359,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 		[Test]
 		[NUnit.Framework.Category(UITestCategories.RequiresInternetConnection)]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void RemoveAllTheCookiesIAdded()
 		{
 			RunningApp.WaitForElement("Loaded");

--- a/src/Compatibility/ControlGallery/src/UITests.Shared/Tests/ScrollViewUITests.cs
+++ b/src/Compatibility/ControlGallery/src/UITests.Shared/Tests/ScrollViewUITests.cs
@@ -57,6 +57,7 @@ namespace Microsoft.Maui.Controls.Compatibility.UITests
 
 		[Test]
 		[Description("ScrollTo Y = 100")]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void ScrollToYTwice()
 		{
 			App.Tap(c => c.Marked("Scroll to 100"));


### PR DESCRIPTION
### Description of Change

Create baseline of passing legacy Xamarin.UITests on iOS