### PR TITLE
Implement rate for TextToSpeech on supported platforms

### DIFF
--- a/src/Essentials/src/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -4,6 +4,8 @@ Microsoft.Maui.Authentication.IWebAuthenticatorResponseDecoder.DecodeResponse(Sy
 Microsoft.Maui.Authentication.WebAuthenticatorOptions.ResponseDecoder.get -> Microsoft.Maui.Authentication.IWebAuthenticatorResponseDecoder?
 Microsoft.Maui.Authentication.WebAuthenticatorOptions.ResponseDecoder.set -> void
 Microsoft.Maui.Devices.IFlashlight.IsSupportedAsync() -> System.Threading.Tasks.Task<bool>!
+Microsoft.Maui.Media.SpeechOptions.Rate.get -> float?
+Microsoft.Maui.Media.SpeechOptions.Rate.set -> void
 static Microsoft.Maui.Devices.Flashlight.IsSupportedAsync() -> System.Threading.Tasks.Task<bool>!
 ~Microsoft.Maui.Authentication.WebAuthenticatorResult.CallbackUri.get -> System.Uri
 ~Microsoft.Maui.Authentication.WebAuthenticatorResult.WebAuthenticatorResult(System.Uri uri, Microsoft.Maui.Authentication.IWebAuthenticatorResponseDecoder responseDecoder) -> void

--- a/src/Essentials/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -4,6 +4,8 @@ Microsoft.Maui.Authentication.IWebAuthenticatorResponseDecoder.DecodeResponse(Sy
 Microsoft.Maui.Authentication.WebAuthenticatorOptions.ResponseDecoder.get -> Microsoft.Maui.Authentication.IWebAuthenticatorResponseDecoder?
 Microsoft.Maui.Authentication.WebAuthenticatorOptions.ResponseDecoder.set -> void
 Microsoft.Maui.Devices.IFlashlight.IsSupportedAsync() -> System.Threading.Tasks.Task<bool>!
+Microsoft.Maui.Media.SpeechOptions.Rate.get -> float?
+Microsoft.Maui.Media.SpeechOptions.Rate.set -> void
 static Microsoft.Maui.Devices.Flashlight.IsSupportedAsync() -> System.Threading.Tasks.Task<bool>!
 ~Microsoft.Maui.Authentication.WebAuthenticatorResult.CallbackUri.get -> System.Uri
 ~Microsoft.Maui.Authentication.WebAuthenticatorResult.WebAuthenticatorResult(System.Uri uri, Microsoft.Maui.Authentication.IWebAuthenticatorResponseDecoder responseDecoder) -> void

--- a/src/Essentials/src/TextToSpeech/TextToSpeech.android.cs
+++ b/src/Essentials/src/TextToSpeech/TextToSpeech.android.cs
@@ -146,7 +146,10 @@ namespace Microsoft.Maui.Media
 			else
 				tts.SetPitch(TextToSpeechImplementation.PitchDefault);
 
-			tts.SetSpeechRate(1.0f);
+			if (options?.Rate.HasValue ?? false)
+				tts.SetSpeechRate(options.Rate.Value);
+			else
+				tts.SetSpeechRate(TextToSpeechImplementation.RateDefault);
 
 			var parts = TextToSpeech.SplitSpeak(text, max);
 

--- a/src/Essentials/src/TextToSpeech/TextToSpeech.ios.tvos.watchos.cs
+++ b/src/Essentials/src/TextToSpeech/TextToSpeech.ios.tvos.watchos.cs
@@ -40,6 +40,10 @@ namespace Microsoft.Maui.Media
 
 				if (options.Volume.HasValue)
 					speechUtterance.Volume = options.Volume.Value;
+
+				// range is from 0 to 1.0
+				if (options.Rate.HasValue)
+					speechUtterance.Rate = options.Rate.Value / 3.0f;
 			}
 
 			return speechUtterance;

--- a/src/Essentials/src/TextToSpeech/TextToSpeech.macos.cs
+++ b/src/Essentials/src/TextToSpeech/TextToSpeech.macos.cs
@@ -30,6 +30,10 @@ namespace Microsoft.Maui.Media
 					if (options.Volume.HasValue)
 						ss.Volume = NormalizeVolume(options.Volume);
 
+					// rate is in words per minute 180 being approx normal.
+					if (options.Rate.HasValue)
+						ss.Rate = Math.Round(180 * options.Rate);
+
 					if (options.Locale != null)
 						ss.Voice = options.Locale.Id;
 				}

--- a/src/Essentials/src/TextToSpeech/TextToSpeech.shared.cs
+++ b/src/Essentials/src/TextToSpeech/TextToSpeech.shared.cs
@@ -148,6 +148,10 @@ namespace Microsoft.Maui.Media
 		internal const float VolumeDefault = 0.5f;
 		internal const float VolumeMin = 0.0f;
 
+		internal const float RateMax = 3.0f;
+		internal const float RateDefault = 1.0f;
+		internal const float RateMin = 0.2f;
+
 		SemaphoreSlim? semaphore;
 
 		public Task<IEnumerable<Locale>> GetLocalesAsync() =>
@@ -167,7 +171,13 @@ namespace Microsoft.Maui.Media
 			if (options?.Pitch.HasValue ?? false)
 			{
 				if (options.Pitch.Value < PitchMin || options.Pitch.Value > PitchMax)
-					throw new ArgumentOutOfRangeException($"Pitch must be >= {PitchMin} and <= {PitchMin}");
+					throw new ArgumentOutOfRangeException($"Pitch must be >= {PitchMin} and <= {PitchMax}");
+			}
+
+			if (options?.Rate.HasValue ?? false)
+			{
+				if (options.Rate.Value < RateMin || options.Rate.Value > RateMax)
+					throw new ArgumentOutOfRangeException($"Rate must be >= {RateMin} and <= {RateMax}");
 			}
 
 			if (semaphore == null)
@@ -245,5 +255,11 @@ namespace Microsoft.Maui.Media
 		/// </summary>
 		/// <remarks>This value should be between <c>0f</c> and <c>1.0f</c>.</remarks>
 		public float? Volume { get; set; }
+
+		/// <summary>
+		/// The rate to use when speaking.
+		/// </summary>
+		/// <remarks>This value should be between <c>1.0f</c> and <c>3.0f</c>.</remarks>
+		public float? Rate { get; set; }
 	}
 }

--- a/src/Essentials/src/TextToSpeech/TextToSpeech.uwp.cs
+++ b/src/Essentials/src/TextToSpeech/TextToSpeech.uwp.cs
@@ -82,6 +82,9 @@ namespace Microsoft.Maui.Media
 			if (options?.Pitch.HasValue ?? false)
 				pitch = ProsodyPitch(options.Pitch);
 
+			if (options?.Rate.HasValue ?? false)
+				rate = (options.Rate.Value / 0.01f).ToString(CultureInfo.InvariantCulture) + "%";
+
 			// SSML generation
 			var ssml = new StringBuilder();
 			ssml.AppendLine($"<speak version='1.0' xmlns='http://www.w3.org/2001/10/synthesis' xml:lang='{locale}'>");
@@ -109,5 +112,6 @@ namespace Microsoft.Maui.Media
 
 			return "default";
 		}
+
 	}
 }


### PR DESCRIPTION
### Description of Change

Attempting to dosome good and implement a Rate option on TextToSpeech.  Rate is not supported for all platforms, but on most.

### Issues Fixed

#14851 

Fixes #

- Implemented Additional Rate option
- Implementation for Android
- Implemenetation for UWP
- Implementation for macos
- Implementation for watchos

It might be possible to implement for Tizen as well, but Pitch is being used already to specify rate, so don't want to change that at this stage. Unable to test all platforms.
