### PR TITLE
Fix incorrect calculation of expansion size when *s have different scalars

### DIFF
--- a/src/Core/src/Layouts/GridLayoutManager.cs
+++ b/src/Core/src/Layouts/GridLayoutManager.cs
@@ -839,7 +839,7 @@ namespace Microsoft.Maui.Layouts
 				var starSize = ComputeStarSizeForTarget(targetSize, definitions, spacing, starCount);
 
 				// Inflate the stars so that we fill up the space at this size
-				ExpandStars(targetSize, currentSize, definitions, starSize, starCount);
+				GridStructure.ExpandStars(targetSize, currentSize, definitions, starSize, starCount);
 			}
 
 			double ComputeStarSizeForTarget(double targetSize, Definition[] defs, double spacing, double starCount)
@@ -858,7 +858,7 @@ namespace Microsoft.Maui.Layouts
 				return (targetSize - sum) / starCount;
 			}
 
-			void ExpandStars(double targetSize, double currentSize, Definition[] defs, double starSize, double starCount)
+			static void ExpandStars(double targetSize, double currentSize, Definition[] defs, double targetStarSize, double starCount)
 			{
 				Debug.Assert(starCount > 0, "Assume that the caller has already checked for the existence of star rows/columns before using this.");
 
@@ -869,15 +869,41 @@ namespace Microsoft.Maui.Layouts
 					return;
 				}
 
-				// Figure out which is the biggest star definition in this dimension
+				// Figure out which is the biggest star definition in this dimension (absolute value and star scale)
 				var maxCurrentSize = 0.0;
+				var maxCurrentStarSize = 0.0;
 				foreach (var definition in defs)
 				{
 					if (definition.IsStar)
 					{
-						maxCurrentSize = Math.Max(maxCurrentSize, definition.MinimumSize);
+						double definitionSize = definition.MinimumSize;
+						maxCurrentSize = Math.Max(maxCurrentSize, definitionSize);
+						maxCurrentStarSize = Math.Max(maxCurrentStarSize, definitionSize / definition.GridLength.Value);
 					}
 				}
+
+				// The targetStarSize is the size that star values would have to have in order for all
+				// the star rows/columns to fit in the targetSize. 
+
+				if (maxCurrentStarSize <= targetStarSize)
+				{
+					// If the biggest current star size we have in the definitions is less than the
+					// targetStarSize, that means we have enough room to expand all of our star rows/columns
+					// to their full size.
+			
+					foreach (var definition in defs)
+					{
+						if (definition.IsStar)
+						{
+							definition.Size = targetStarSize * definition.GridLength.Value;
+						}
+					}
+
+					return;
+				}
+
+				// We don't have enough room for all the star rows/columns to expand to their full size.
+				// But we still need to fill up the rest of the space, so we'll expand them proportionally.
 
 				// Work out the total difference in size between the largest star definition and all 
 				// the smaller ones; we'll need that later to distribute available space.
@@ -892,37 +918,21 @@ namespace Microsoft.Maui.Layouts
 
 				foreach (var definition in defs)
 				{
-					if (!definition.IsStar)
+					if (definition.IsStar)
 					{
-						continue;
-					}
-
-					// Figure out how large this definition would be at full size
-					double defStarValue = starSize * definition.GridLength.Value;
-
-					if (maxCurrentSize >= defStarValue)
-					{
-						// If that value at full size is less than the current biggest definition,
-						// then the total size isn't big enough for all the stars to expand; instead,
-						// we just need to fill up the remaining available space. How much we give to
-						// each star definition is inversely proportional to its size - the smaller
-						// definitions get expanded faster than the bigger ones.
-
-						// We ignore the biggest definitions - they can't expand until there's room for
-						// everyone to expand.
+						// Skip the largest star rows/columns; we want to expand the smaller ones first
 						if (maxCurrentSize > definition.MinimumSize)
 						{
 							// Figure out how small this definition is relative to the total difference,
 							// and use that to determine how much of the available space this definition gets
-							var scale = ((maxCurrentSize - definition.MinimumSize) / totaldiff);
+
+							// The goal is to have the smaller definitions expand faster than the bigger ones,
+							// so the amount we give to each definition is inversely proportional to its size
+
+							var scale = (maxCurrentSize - definition.MinimumSize) / totaldiff;
 							var portion = scale * availableSpace;
 							definition.Size = definition.MinimumSize + portion;
 						}
-					}
-					else
-					{
-						// Give the star row/column its full weighted star value
-						definition.Size = defStarValue;
 					}
 				}
 			}

--- a/src/Core/tests/UnitTests/Layouts/GridLayoutManagerTests.cs
+++ b/src/Core/tests/UnitTests/Layouts/GridLayoutManagerTests.cs
@@ -2948,5 +2948,117 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			// and the height of the view to be the height of the Grid minus all padding
 			AssertArranged(view0, new Rect(0, top, 200, 200 - top - bottom));
 		}
+
+		[Fact]
+		public void StarRowExpansionWorksWithDifferingScalars()
+		{
+			var grid = CreateGridLayout(rows: "*, 4.5*, *, 4.5*");
+			
+			grid.VerticalLayoutAlignment.Returns(LayoutAlignment.Fill);
+
+			var view0 = CreateTestView(new Size(100, 20));
+			var view1 = CreateTestView(new Size(100, 100));
+			var view2 = CreateTestView(new Size(100, 20));
+			var view3 = CreateTestView(new Size(100, 100));
+
+			SubstituteChildren(grid, view0, view1, view2, view3);
+
+			SetLocation(grid, view0, row: 0);
+			SetLocation(grid, view1, row: 1);
+			SetLocation(grid, view2, row: 2);
+			SetLocation(grid, view3, row: 3);
+
+			// Measure the Grid with no constraints			
+			var manager = new GridLayoutManager(grid);
+			var measure = manager.Measure(double.PositiveInfinity, double.PositiveInfinity);
+
+			// Our expected height, unconstrained, where all the views get their desired height:
+			double expectedHeight = 20 + 100 + 20 + 100;
+			Assert.Equal(expectedHeight, measure.Height);
+
+			// Now we'll arrange it at a larger height (as if we were filling up the height of a layout)
+			double arrangeHeight = measure.Height + 100; 
+			manager.ArrangeChildren(new Rect(0, 0, measure.Width, arrangeHeight));
+
+			// Determine the destination Rect values that the manager passed in when calling Arrange() for each view
+			var view0Dest = GetArrangedRect(view0);
+			var view1Dest = GetArrangedRect(view1);
+			var view2Dest = GetArrangedRect(view2);
+			var view3Dest = GetArrangedRect(view3);
+
+			// We have four rows: 1*, 4.5*, 1*, 4.5*
+			double starCount = 1 + 4.5 + 1 + 4.5;
+
+			// We expect the odd rows to get 1* each
+			double expectedOddRowHeight = arrangeHeight / starCount;
+
+			// And the event rows to get 4.5* each
+			double expectedEvenRowHeight = expectedOddRowHeight * 4.5;
+
+			// Verify that the views were arranged at those sizes (within tolerance)
+			Assert.Equal(expectedOddRowHeight, view0Dest.Height, 1.0);
+			Assert.Equal(expectedEvenRowHeight, view1Dest.Height, 1.0);
+			Assert.Equal(expectedOddRowHeight, view2Dest.Height, 1.0);
+			Assert.Equal(expectedEvenRowHeight, view3Dest.Height, 1.0);
+		}
+
+		[Fact]
+		public void StarColumnExpansionWorksWithDifferingScalars()
+		{
+			var grid = CreateGridLayout(columns: "*, 4.5*, *, 4.5*");
+
+			grid.VerticalLayoutAlignment.Returns(LayoutAlignment.Fill);
+
+			var view0 = CreateTestView(new Size(20, 100));
+			var view1 = CreateTestView(new Size(100, 100));
+			var view2 = CreateTestView(new Size(20, 100));
+			var view3 = CreateTestView(new Size(100, 100));
+
+			SubstituteChildren(grid, view0, view1, view2, view3);
+
+			SetLocation(grid, view0, col: 0);
+			SetLocation(grid, view1, col: 1);
+			SetLocation(grid, view2, col: 2);
+			SetLocation(grid, view3, col: 3);
+
+			// Measure the Grid with no constraints
+			var manager = new GridLayoutManager(grid);
+			var measure = manager.Measure(double.PositiveInfinity, double.PositiveInfinity);
+
+			// Our expected width, unconstrained, where all the views get their desired width:
+			double expectedWidth = 20 + 100 + 20 + 100;
+			Assert.Equal(expectedWidth, measure.Width);
+
+			// Now we'll arrange it at a larger width (as if we were filling up the width of a layout)
+			double arrangeWidth = measure.Width + 100;
+			manager.ArrangeChildren(new Rect(0, 0, arrangeWidth, measure.Height));
+
+			// Determine the destination Rect values that the manager passed in when calling Arrange() for each view
+			var view0Dest = GetArrangedRect(view0);
+			var view1Dest = GetArrangedRect(view1);
+			var view2Dest = GetArrangedRect(view2);
+			var view3Dest = GetArrangedRect(view3);
+
+			// We have four columns: 1*, 4.5*, 1*, 4.5*
+			double starCount = 1 + 4.5 + 1 + 4.5;
+
+			// We expect the odd columns to get 1* each
+			double expectedOddRowWidth = arrangeWidth / starCount;
+
+			// And the event columns to get 4.5* each
+			double expectedEvenRowWidth = expectedOddRowWidth * 4.5;
+
+			// Verify that the views were arranged at those sizes (within tolerance)
+			Assert.Equal(expectedOddRowWidth, view0Dest.Width, 1.0);
+			Assert.Equal(expectedEvenRowWidth, view1Dest.Width, 1.0);
+			Assert.Equal(expectedOddRowWidth, view2Dest.Width, 1.0);
+			Assert.Equal(expectedEvenRowWidth, view3Dest.Width, 1.0);
+		}
+
+		static Rect GetArrangedRect(IView view) 
+		{
+			var args = view.ReceivedCalls().Single(c => c.GetMethodInfo().Name == nameof(IView.Arrange)).GetArguments();
+			return (Rect)args[0];
+		}
 	}
 }


### PR DESCRIPTION
### Description of Change

In situations where a Grid:

- Is inside a ScrollView
- Has multiple rows/columns with * values
- Has mixed scalars for the * values (e.g., some are 1* while others are 4.5*)
- Has a measured size smaller than the ScrollView's viewport
- Is set to Fill the ScrollView's viewport

The size calculations for expanding the * rows/columns to fill the space are incorrect, and cause the smaller rows/columns to be laid out with incorrect sizes. This pushes content outside the viewport of the ScrollView while reporting the viewport size as its measure, so the ScrollView doesn't know there's scrollable content (because technically, there isn't). This makes it appear as if the scrolling is broken.

These changes fix the expansion size calculations for this scenario.

### Issues Fixed

Fixes #15494
