### PR TITLE
Restore & obsolete Windows MauiWebView ctor

### DIFF
--- a/src/Core/src/Platform/Windows/MauiWebView.cs
+++ b/src/Core/src/Platform/Windows/MauiWebView.cs
@@ -13,7 +13,10 @@ namespace Microsoft.Maui.Platform
 
 		[Obsolete("Constructor is no longer used, please use an overloaded version.")]
 #pragma warning disable CS8618
-		public MauiWebView() { }
+		public MauiWebView()
+		{
+			SetupPlatformEvents();
+		}
 #pragma warning restore CS8618
 
 		public MauiWebView(WebViewHandler handler)
@@ -21,22 +24,7 @@ namespace Microsoft.Maui.Platform
 			ArgumentNullException.ThrowIfNull(handler, nameof(handler));
 			_handler = new WeakReference<WebViewHandler>(handler);
 
-			NavigationStarting += (sender, args) =>
-			{
-				// Auto map local virtual app dir host, e.g. if navigating back to local site from a link to an external site
-				if (args?.Uri?.ToLowerInvariant().StartsWith(LocalScheme.TrimEnd('/').ToLowerInvariant()) == true)
-				{
-					CoreWebView2.SetVirtualHostNameToFolderMapping(
-						LocalHostName,
-						ApplicationPath,
-						Web.WebView2.Core.CoreWebView2HostResourceAccessKind.Allow);
-				}
-				// Auto unmap local virtual app dir host if navigating to any other potentially unsafe domain
-				else
-				{
-					CoreWebView2.ClearVirtualHostNameToFolderMapping(LocalHostName);
-				}
-			};
+			SetupPlatformEvents();
 		}
 
 		WebView2? _internalWebView;
@@ -137,7 +125,7 @@ namespace Microsoft.Maui.Platform
 				uri = new Uri(LocalScheme + url, UriKind.RelativeOrAbsolute);
 			}
 
-			if (_handler.TryGetTarget(out var handler))
+			if (_handler?.TryGetTarget(out var handler) ?? false)
 				await handler.SyncPlatformCookies(uri.AbsoluteUri);
 
 			try
@@ -148,6 +136,26 @@ namespace Microsoft.Maui.Platform
 			{
 				Debug.WriteLine(nameof(MauiWebView), $"Failed to load: {uri} {exc}");
 			}
+		}
+
+		void SetupPlatformEvents()
+		{
+			NavigationStarting += (sender, args) =>
+			{
+				// Auto map local virtual app dir host, e.g. if navigating back to local site from a link to an external site
+				if (args?.Uri?.ToLowerInvariant().StartsWith(LocalScheme.TrimEnd('/').ToLowerInvariant()) == true)
+				{
+					CoreWebView2.SetVirtualHostNameToFolderMapping(
+						LocalHostName,
+						ApplicationPath,
+						Web.WebView2.Core.CoreWebView2HostResourceAccessKind.Allow);
+				}
+				// Auto unmap local virtual app dir host if navigating to any other potentially unsafe domain
+				else
+				{
+					CoreWebView2.ClearVirtualHostNameToFolderMapping(LocalHostName);
+				}
+			};
 		}
 	}
 }

--- a/src/Core/src/Platform/Windows/MauiWebView.cs
+++ b/src/Core/src/Platform/Windows/MauiWebView.cs
@@ -11,6 +11,11 @@ namespace Microsoft.Maui.Platform
 	{
 		readonly WeakReference<WebViewHandler> _handler;
 
+		[Obsolete("Constructor is no longer used, please use an overloaded version.")]
+#pragma warning disable CS8618
+		public MauiWebView() { }
+#pragma warning restore CS8618
+
 		public MauiWebView(WebViewHandler handler)
 		{
 			ArgumentNullException.ThrowIfNull(handler, nameof(handler));

--- a/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -44,4 +44,3 @@ static Microsoft.Maui.PropertyMapperExtensions.PrependToMapping<TVirtualView, TV
 static Microsoft.Maui.PropertyMapperExtensions.ReplaceMapping<TVirtualView, TViewHandler>(this Microsoft.Maui.IPropertyMapper<Microsoft.Maui.IElement!, Microsoft.Maui.IElementHandler!>! propertyMapper, string! key, System.Action<TViewHandler, TVirtualView>! method) -> void
 static Microsoft.Maui.SizeRequest.operator !=(Microsoft.Maui.SizeRequest left, Microsoft.Maui.SizeRequest right) -> bool
 static Microsoft.Maui.SizeRequest.operator ==(Microsoft.Maui.SizeRequest left, Microsoft.Maui.SizeRequest right) -> bool
-*REMOVED*Microsoft.Maui.Platform.MauiWebView.MauiWebView() -> void


### PR DESCRIPTION
### Description of Change

Restores the original constructor for the Windows MauiWebView to prevent an ABI break. Added the obsolete attribute to direct people to the overloaded version.

### Issues Fixed

NA