### PR TITLE
Hook up ScrollViewer event tracking in Windows CollectionView

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/ItemsViewHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Items/ItemsViewHandler.Windows.cs
@@ -378,6 +378,16 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		protected virtual void OnScrollViewerFound(ScrollViewer scrollViewer)
 		{
+			if (_scrollViewer == scrollViewer)
+			{
+				return;
+			}
+
+			if (_scrollViewer != null)
+			{
+				_scrollViewer.ViewChanged -= ScrollViewChanged;
+			}
+
 			_scrollViewer = scrollViewer;
 			_scrollViewer.ViewChanged += ScrollViewChanged;
 		}

--- a/src/Controls/src/Core/Handlers/Items/ItemsViewHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Items/ItemsViewHandler.Windows.cs
@@ -55,6 +55,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		{
 			base.ConnectHandler(platformView);
 			VirtualView.ScrollToRequested += ScrollToRequested;
+			FindScrollViewer(ListViewBase);
 		}
 
 		protected override void DisconnectHandler(ListViewBase platformView)
@@ -313,6 +314,8 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 					}
 				}
 			}
+
+			FindScrollViewer(ListViewBase);
 		}
 
 		void FindScrollViewer(ListViewBase listView)

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.Windows.cs
@@ -101,7 +101,7 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.Equal(0d, minHeight);
 		}
 
-		[Fact(Skip = "FIX FOR .NET8")]
+		[Fact]
 		public async Task ValidateSendRemainingItemsThresholdReached()
 		{
 			SetupBuilder();


### PR DESCRIPTION
### Description of Change

Calls FindScrollViewer to hook up the ScrollViewer event tracking so that things like RemainingItemsThreshold will work.

Makes the `ValidateSendRemainingItemsThresholdReached` test on Windows pass.