### PR TITLE
[iOS] Set AutoKeyboardManagerScroll's Tokens to null when disconnecting

### DIFF
--- a/src/Core/src/Platform/iOS/KeyboardAutoManagerScroll.cs
+++ b/src/Core/src/Platform/iOS/KeyboardAutoManagerScroll.cs
@@ -58,15 +58,30 @@ public static class KeyboardAutoManagerScroll
 	public static void Disconnect()
 	{
 		if (WillShowToken is not null)
+		{
 			NSNotificationCenter.DefaultCenter.RemoveObserver(WillShowToken);
+			WillShowToken = null;
+		}
 		if (WillHideToken is not null)
+		{
 			NSNotificationCenter.DefaultCenter.RemoveObserver(WillHideToken);
+			WillHideToken = null;
+		}
 		if (DidHideToken is not null)
+		{
 			NSNotificationCenter.DefaultCenter.RemoveObserver(DidHideToken);
+			DidHideToken = null;
+		}
 		if (TextFieldToken is not null)
+		{
 			NSNotificationCenter.DefaultCenter.RemoveObserver(TextFieldToken);
+			TextFieldToken = null;
+		}
 		if (TextViewToken is not null)
+		{
 			NSNotificationCenter.DefaultCenter.RemoveObserver(TextViewToken);
+			TextViewToken = null;
+		}
 
 		IsKeyboardAutoScrollHandling = false;
 	}


### PR DESCRIPTION
### Description of Change

<!-- Enter description of the fix in this section -->
As mentioned here: https://github.com/PureWeen/ShanedlerSamples/pull/12 by busec0, the Disconnect method was not changing the tokens to null so we currently cannot reconnect after disconnecting. Tested locally and am now able to disconnect and reconnect as wanted.

