### PR TITLE
Add all platforms if build args don't restrict to a single platform

### DIFF
--- a/src/Controls/tests/UITests/Tests/UITestBase.cs
+++ b/src/Controls/tests/UITests/Tests/UITestBase.cs
@@ -14,6 +14,11 @@ namespace Microsoft.Maui.AppiumTests
 	[TestFixture(TestDevice.Mac)]
 #elif WINTEST
 	[TestFixture(TestDevice.Windows)]
+#else
+	[TestFixture(TestDevice.iOS)]
+	[TestFixture(TestDevice.Mac)]
+	[TestFixture(TestDevice.Windows)]
+	[TestFixture(TestDevice.Android)]
 #endif
 	public class UITestBase : UITestContextTestBase
 	{


### PR DESCRIPTION
### Description of Change

If we aren't building from the CLI and passing in any build arguments then just add all platforms as testfixtures so that we can run them from the test explorer.