### PR TITLE
Fix sizing issues with CollectionView on Windows

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/ItemsViewHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Items/ItemsViewHandler.Windows.cs
@@ -337,8 +337,19 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		void UpdateVerticalScrollBarVisibility()
 		{
+			if (Element.VerticalScrollBarVisibility != ScrollBarVisibility.Default)
+			{
+				// If the value is changing to anything other than the default, record the default 
+				if (_defaultVerticalScrollVisibility == null)
+					_defaultVerticalScrollVisibility = ScrollViewer.GetVerticalScrollBarVisibility(Control);
+			}
+
 			if (_defaultVerticalScrollVisibility == null)
-				_defaultVerticalScrollVisibility = ScrollViewer.GetVerticalScrollBarVisibility(Control);
+			{
+				// If the default has never been recorded, then this has never been set to anything but the 
+				// default value; there's nothing to do.
+				return;
+			}
 
 			switch (Element.VerticalScrollBarVisibility)
 			{

--- a/src/Controls/src/Core/Platform/Windows/CollectionView/ItemsViewStyles.xaml
+++ b/src/Controls/src/Core/Platform/Windows/CollectionView/ItemsViewStyles.xaml
@@ -99,7 +99,7 @@
     get to a point where we don't have to support these earlier versions, we can replace this style with just the 
     template. (See also FormsGridView.cs) -->
     <Style TargetType="local:FormsGridView">
-        <Setter Property="Padding" Value="0,0,0,10" />
+        <Setter Property="Padding" Value="0,0,0,0" />
         <Setter Property="IsTabStop" Value="False" />
         <Setter Property="TabNavigation" Value="Once" />
         <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled" />

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.cs
@@ -111,6 +111,7 @@ namespace Microsoft.Maui.DeviceTests
 			var collectionView = new CollectionView
 			{
 				ItemsLayout = itemsLayout,
+				Background = Colors.Red,
 				ItemTemplate = new DataTemplate(() => new Label() { HeightRequest = templateHeight, WidthRequest = templateWidth }),
 			};
 
@@ -142,6 +143,13 @@ namespace Microsoft.Maui.DeviceTests
 					await WaitForUIUpdate(frame, collectionView);
 					frame = collectionView.Frame;
 
+#if WINDOWS
+					// On Windows, the ListView pops in and changes the frame, then actually
+					// loads in the data, which updates it again. So we need to wait for the second
+					// update before checking the size
+					await WaitForUIUpdate(frame, collectionView);
+					frame = collectionView.Frame;
+#endif
 					double expectedWidth = layoutOptions == LayoutOptions.Fill
 						? containerWidth
 						: Math.Min(itemsCount * templateWidth, containerWidth);
@@ -164,13 +172,7 @@ namespace Microsoft.Maui.DeviceTests
 
 		public static IEnumerable<object[]> GenerateLayoutOptionsCombos()
 		{
-			var layoutOptions = new LayoutOptions[] {
-
-#if !WINDOWS
-				LayoutOptions.Center, LayoutOptions.Start, LayoutOptions.End,
-#endif
-
-				LayoutOptions.Fill };
+			var layoutOptions = new LayoutOptions[] { LayoutOptions.Center, LayoutOptions.Start, LayoutOptions.End, LayoutOptions.Fill };
 
 			foreach (var option in layoutOptions)
 			{


### PR DESCRIPTION
### Description of Change

Fixes the ignored tests from #15530.

Removes a extra 10-point padding from the bottom of the backing GridView used for the CollectionView.

Updates the logic for updating the scrollbar visibility in the CollectionView to preserve the default value from the control template. This prevents the vertical scrollbar from being made always visible by default (rather than the intended default of `Auto`). 

This won't prevent the ultimate issue of the default being corrupted if the user sets a non-default value in the cross-platform code, but it will prevent the most common problem (the default being set to `Visible` instead of `Auto` when the user tries to use the defaults).



