### PR TITLE
Just run the pack every time

### DIFF
--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -467,6 +467,13 @@ bool RunPackTarget()
     // Does the user want to run a pack as part of a different target?
     if (HasArgument("pack"))
         return true;
+        
+    // If the request is to open a different sln then let's see if pack has ever run
+    // if it hasn't then lets pack maui so the sln will open
+    if (Argument<string>("sln", null) != null)
+    {
+        return Argument<string>("pack", "true") == "true";
+    }
 
     return false;
 }

--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -467,15 +467,6 @@ bool RunPackTarget()
     // Does the user want to run a pack as part of a different target?
     if (HasArgument("pack"))
         return true;
-        
-    // If the request is to open a different sln then let's see if pack has ever run
-    // if it hasn't then lets pack maui so the sln will open
-    if (Argument<string>("sln", null) != null)
-    {
-        var mauiPacks = MakeAbsolute(Directory("./bin/dotnet/packs/Microsoft.Maui.Sdk")).ToString();
-        if (!DirectoryExists(mauiPacks))
-            return true;
-    }
 
     return false;
 }

--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -465,7 +465,7 @@ bool RunPackTarget()
         return true;
 
     // Does the user want to run a pack as part of a different target?
-    if (HasArgument("pack"))
+    if (HasArgument("pack") && Argument<string>("pack", "true") != "false")
         return true;
         
     // If the request is to open a different sln then let's see if pack has ever run

--- a/eng/cake/helpers.cake
+++ b/eng/cake/helpers.cake
@@ -1,4 +1,4 @@
-bool isCleanSet = (HasArgument("clean") && Argument<string>("clean", "true") != "false") || IsTarget("clean");
+bool isCleanSet = HasArgument("clean") || IsTarget("clean");
 
 Task("Clean")
     .WithCriteria(isCleanSet)

--- a/eng/cake/helpers.cake
+++ b/eng/cake/helpers.cake
@@ -1,4 +1,4 @@
-bool isCleanSet = HasArgument("clean") || IsTarget("clean");
+bool isCleanSet = (HasArgument("clean") && Argument<string>("clean", "true") != "false") || IsTarget("clean");
 
 Task("Clean")
     .WithCriteria(isCleanSet)


### PR DESCRIPTION
### Description of Change

I added code so that if you've already ran pack with an external solution, it won't run pack every time.  This has led to too much confusion when users are trying to make incremental changes and then repack. 

I've set it up so the default will just pack every time and if you don't want it to then you can pass false as a setting to the pack argument.

`--pack=false`