### PR TITLE
Fix CharacterSpacing on SearchBar on iOS to be actually set

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Controls/SearchBarPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/SearchBarPage.xaml
@@ -44,6 +44,12 @@
                     FontSize="24"
                     FontAttributes="Italic"/>
                 <Label
+                    Text="CharacterSpacing"
+                    Style="{StaticResource Headline}"/>
+                <SearchBar
+                    CharacterSpacing="8"
+                    Placeholder="Placeholder"/>
+                <Label
                     Text="SearchCommand"
                     Style="{StaticResource Headline}"/>
                 <SearchBar

--- a/src/Core/src/Platform/iOS/SearchBarExtensions.cs
+++ b/src/Core/src/Platform/iOS/SearchBarExtensions.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Maui.Platform
 				? new NSAttributedString(placeholder)
 				: new NSAttributedString(str: placeholder, foregroundColor: foregroundColor.ToPlatform());
 
-			textField.AttributedPlaceholder.WithCharacterSpacing(searchBar.CharacterSpacing);
+			textField.AttributedPlaceholder = textField.AttributedPlaceholder.WithCharacterSpacing(searchBar.CharacterSpacing);
 		}
 
 		public static void UpdateFont(this UISearchBar uiSearchBar, ITextStyle textStyle, IFontManager fontManager)


### PR DESCRIPTION
### Description of Change

Fix CharacterSpacing on SearchBar on iOS to be actually set

### Issues Fixed

None. This was spotted during random browsing of the source code.