### PR TITLE
[Android] Fix toolbar OverflowIcon color not getting properly set.

### DIFF
--- a/src/Controls/src/Core/Platform/Android/Extensions/ToolbarExtensions.cs
+++ b/src/Controls/src/Core/Platform/Android/Extensions/ToolbarExtensions.cs
@@ -154,6 +154,11 @@ namespace Microsoft.Maui.Controls.Platform
 
 				nativeToolbar.NavigationIcon.SetColorFilter(navIconColor, FilterMode.SrcAtop);
 			}
+
+			if(navIconColor != null && nativeToolbar.OverflowIcon != null)
+			{
+				nativeToolbar.OverflowIcon.SetColorFilter(navIconColor, FilterMode.SrcAtop);
+			}
 		}
 
 		public static void UpdateBarTextColor(this AToolbar nativeToolbar, Toolbar toolbar)


### PR DESCRIPTION
### Description of Change

The toolbar overflow icon would not follow the toolbar icon color and often appear as a bit of an awkward color for certain primary colors. This changes makes the overflow icon follow the same icon color as the navigation icon.

I updated the `UpdateIconColor` function in `ToolbarExtensions` to also set the tint color for the overflow icon.

Before:
![image](https://github.com/dotnet/maui/assets/11671115/3de16a77-7227-4ae2-ae2e-28e873e5fd5b)

After:
![image](https://github.com/dotnet/maui/assets/11671115/4db1be09-b839-494b-b19b-a3769964f5ac)


### Issues Fixed

Fixes inconsistent toolbar coloring

Fixes #9240


