### PR TITLE
Add 8.0.0-preview.5.8529 to bug report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -54,6 +54,7 @@ body:
         - 8.0.0-preview.2.7871
         - 8.0.0-preview.3.8149
         - 8.0.0-preview.4.8333
+        - 8.0.0-preview.5.8529
         - Unknown/Other
     validations:
       required: true
@@ -74,6 +75,7 @@ body:
         - 8.0.0-preview.2.7871
         - 8.0.0-preview.3.8149
         - 8.0.0-preview.4.8333
+        - 8.0.0-preview.5.8529
         - Unknown/Other
     validations:
       required: true


### PR DESCRIPTION
### Description of Change
Adds the latest .NET 8 preview release (8.0.0-preview.5.8529) to bug report issue template. Wasn't sure if I should also add it to `Last version that worked well` section, but I was worried I'd forget to in the future.

### Issues Fixed
Fixes #
