### PR TITLE
[iOS] Allow to remove the Image from Button

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Controls/ButtonPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/ButtonPage.xaml
@@ -130,9 +130,10 @@
                 <Label
                     Text="Image Source"
                     Style="{StaticResource Headline}"/>
-                <Button 
+                <Button
+                    x:Name="ImageSourceButton"
                     ContentLayout="Top" TextColor="White" Background="Black" 
-                    ImageSource="settings.png" />
+                    ImageSource="settings.png" Clicked="Button_Clicked" />
                 <Label
                     Text="Image Source with Positioning"
                     Style="{StaticResource Headline}"/>

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/ButtonPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/ButtonPage.xaml.cs
@@ -21,6 +21,18 @@ namespace Maui.Controls.Sample.Pages
 			Debug.WriteLine("Clicked");
 		}
 
+		void Button_Clicked(System.Object sender, System.EventArgs e)
+		{
+			if (ImageSourceButton.ImageSource is null)
+			{
+				ImageSourceButton.ImageSource = "settings.png";
+			}
+			else
+			{
+				ImageSourceButton.ImageSource = null;
+			}
+		}
+
 		void OnPositionChange(object sender, System.EventArgs e)
 		{
 			var newPosition = ((int)positionChange.ContentLayout.Position) + 1;

--- a/src/Core/src/Handlers/Button/ButtonHandler.iOS.cs
+++ b/src/Core/src/Handlers/Button/ButtonHandler.iOS.cs
@@ -146,11 +146,6 @@ namespace Microsoft.Maui.Handlers
 
 		public static Task MapImageSourceAsync(IButtonHandler handler, IImage image)
 		{
-			if (image.Source == null)
-			{
-				return Task.CompletedTask;
-			}
-
 			return handler.ImageSourceLoader.UpdateImageSourceAsync();
 		}
 


### PR DESCRIPTION
### Description of Change

Allow to remove the Image from iOS Button.

![fix-15006](https://github.com/dotnet/maui/assets/6755973/938c559d-2cef-4edb-a036-c815c5a0154d)

To validate the changes can use the Button samples from the .NET MAUI Gallery.

### Issues Fixed

Fixes #15006
