### PR TITLE
Fix typo on Resizetizer After.targets

### DIFF
--- a/src/SingleProject/Resizetizer/src/nuget/buildTransitive/Microsoft.Maui.Resizetizer.After.targets
+++ b/src/SingleProject/Resizetizer/src/nuget/buildTransitive/Microsoft.Maui.Resizetizer.After.targets
@@ -148,7 +148,7 @@
         <ResizetizerPlatformType>android</ResizetizerPlatformType>
 
         <ResizetizeCollectItemsBeforeTargets>
-            $(ResizetizeCollectItemsAfterTargets);
+            $(ResizetizeCollectItemsBeforeTargets);
             _ComputeAndroidResourcePaths;
         </ResizetizeCollectItemsBeforeTargets>
 


### PR DESCRIPTION
The Resizetizer.After.targets was using
`ResizetizeCollectItemsAfterTargets` rather than
`ResizetizeCollectItemsBeforeTargets` in its PropertyGroup. So lets fix that up.