### PR TITLE
Fix DataTrigger behavior that can cause some strange inconsistencies

### DIFF
--- a/src/Controls/src/Core/Interactivity/TriggerBase.cs
+++ b/src/Controls/src/Core/Interactivity/TriggerBase.cs
@@ -108,8 +108,6 @@ namespace Microsoft.Maui.Controls
 			}
 			else
 			{
-				foreach (Setter setter in Setters)
-					setter.UnApply(bindable);
 				foreach (TriggerAction action in ExitActions)
 					action.DoInvoke(bindable);
 			}


### PR DESCRIPTION
I'd recommend reading #10189 first, the writeup is very clear and helpful for understanding this problem.

The problem here is simple, but the possible solutions to it are rather complicated depending on the expected behavior we're looking for.

### The problem
Multiple `DataTriggers` with identical `Binding` values causes inconsistent behavior.

Each `DataTrigger` is backed by a `TriggerBase`. This class gets notified whenever the associated trigger condition changes. It manages a `Setter` for the target property and will either [`Apply()` or `UnApply()`](https://github.com/dotnet/maui/blob/9b091fd530cf54bb8c756474fc7585ec125a9b66/src/Controls/src/Core/Interactivity/TriggerBase.cs#LL100C5-L100C6) the setter depending on the evaluation of the condition. Note that `UnApply()` will restore a property to its default value.

The problem is that `DataTriggers` are not ordered in any particular way (`OnPropertyChanged` is delivered through a C# `event`, which does not guarentee delivery order). Assume that we have two `DataTriggers`'s with the same `Binding` value. Let's say the `Binding` value changes, and one `DataTrigger` now evaluates to `true` and the other to `false`. Because their is no enforced execution order, the `DataTrigger` that evaluates to `true` may run first. If both `DataTrigger`'s target the same property, the first data trigger will `Apply()` its `Setter`, updating the value correctly but the second trigger will run its `UnApply()` which resets the target property to its default value.

### Possible solutions
The way I see it, there are several possible solutions:

1) Create an ordered event delivery system for `DataTriggers`s. The condition of each `DataTrigger` is first evaluated. All the `DataTriggers` whose conditions are false are executed first. This isn't perfect though - these `DataTriggers` will set their target properties back to their default value and then back again to a new value when the second `true` group of `DataTriggers` run. This could maybe cause the property to flicker, although I'm not entirely sure if all `OnPropertyChanged()` events are marshalled before a UI refresh event so maybe it'd be fine.
2) During XAML parsing detect if multiple `DataTriggers` are logical opposites (or mutually exclusive), if we can guarantee that one `DataTrigger` is _always_ active, no more, no less, than we could disable the `UnApply()` setters on the triggers. This just seems too complicated and not very practical. 
3) I think this is the easiest, but in my mind a trigger is really a causal thing - "When X becomes true, do Y". It doesn't really make sense to me that "when X becomes false, set undo Y". Instead I would think that should be another trigger. The pull request I attached makes this change -- the `DataTrigger` does not bother resetting the target property back to its default. This is _a_ solution, but not sure if it potentially breaks something else or if it's desired. I can certainly update this PR to solution 1 or 2 however it starts to add a lot of interdependency between components when it would be a lot cleaner design-wise to have them separated. 
4) Add a new XML attribute to `DataTrigger` that allows disabling the reset-to-default behavior when the condition is false. Something like `ResetWhenFalse`

Also, we could maybe add a note to the docs that having multiple triggers attached to the same target property could cause undefined behavior if multiple of their conditions evaluate to true at once (no execution order is guaranteed as explained above). 

### Description of Change

When the condition tracked by a `DataTrigger` becomes false, do not reset target property to default value.

### Issues Fixed 

Fixes #10189
Fixes #6849

