### PR TITLE
Fix events not firing for `Scrolled` and `RemainingItemsThresholdReached`

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/ItemsViewHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Items/ItemsViewHandler.Windows.cs
@@ -54,12 +54,19 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		protected override void ConnectHandler(ListViewBase platformView)
 		{
 			base.ConnectHandler(platformView);
+			FindScrollViewer(platformView);
 			VirtualView.ScrollToRequested += ScrollToRequested;
 		}
 
 		protected override void DisconnectHandler(ListViewBase platformView)
 		{
 			VirtualView.ScrollToRequested -= ScrollToRequested;
+
+			if (_scrollViewer != null)
+			{
+				_scrollViewer.ViewChanged -= ScrollViewChanged;
+			}
+
 			base.DisconnectHandler(platformView);
 		}
 

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.Windows.cs
@@ -101,7 +101,7 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.Equal(0d, minHeight);
 		}
 
-		[Fact(Skip = "FIX FOR .NET8")]
+		[Fact(DisplayName = "CollectionView SendRemainingItemsThresholdReached")]
 		public async Task ValidateSendRemainingItemsThresholdReached()
 		{
 			SetupBuilder();
@@ -120,6 +120,11 @@ namespace Microsoft.Maui.DeviceTests
 				collectionView
 			};
 
+			bool didGetScrollEvent = false;
+			collectionView.Scrolled += (s, e) =>
+			{
+				didGetScrollEvent = true;
+			};
 			collectionView.RemainingItemsThreshold = 1;
 			collectionView.RemainingItemsThresholdReached += (s, e) =>
 			{
@@ -135,6 +140,7 @@ namespace Microsoft.Maui.DeviceTests
 				collectionView.ScrollTo(19, -1, position: ScrollToPosition.End, false);
 				await Task.Delay(200);
 				Assert.True(data.Count == 30);
+				Assert.True(didGetScrollEvent);
 			});
 		}
 	}


### PR DESCRIPTION
Fix events not firing for `Scrolled` and `RemainingItemsThresholdReached` for CollectionView on Windows (regression via https://github.com/dotnet/maui/pull/15601)

### Issues Fixed
Fixes #15529
CC https://github.com/dotnet/maui/pull/14391