### PR TITLE
Correctly identify headers/footers when using UngroupedItemsSource

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/Android/Adapters/EmptyViewAdapter.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/Adapters/EmptyViewAdapter.cs
@@ -10,12 +10,12 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 {
 	public class EmptyViewAdapter : RecyclerView.Adapter
 	{
-		int _headerHeight;
+		double _headerHeight;
 		int _headerViewType;
 		object _headerView;
 		DataTemplate _headerViewTemplate;
 
-		int _footerHeight;
+		double _footerHeight;
 		int _footerViewType;
 		object _footerView;
 		DataTemplate _footerViewTemplate;
@@ -301,18 +301,25 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			if (item == null)
 				return;
 
-			var sizeRequest = new SizeRequest(new Size(0, 0));
+			var size = Size.Zero;
 
-			if (item is View view)
-				sizeRequest = view.Measure(double.PositiveInfinity, double.PositiveInfinity, MeasureFlags.IncludeMargins);
+			if (item is IView view)
+			{
+				if (view.Handler == null)
+				{
+					TemplateHelpers.GetHandler(view as View, ItemsView.FindMauiContext());
+				}
+
+				size = view.Measure(double.PositiveInfinity, double.PositiveInfinity);
+			}
 
 			if (item is DataTemplate dataTemplate)
 			{
-				var content = dataTemplate.CreateContent() as View;
-				sizeRequest = content.Measure(double.PositiveInfinity, double.PositiveInfinity, MeasureFlags.IncludeMargins);
+				var content = dataTemplate.CreateContent() as IView;
+				size = content.Measure(double.PositiveInfinity, double.PositiveInfinity);
 			}
 
-			var itemHeight = (int)sizeRequest.Request.Height;
+			var itemHeight = size.Height;
 
 			if (isHeader)
 				_headerHeight = itemHeight;

--- a/src/Controls/src/Core/Handlers/Items/Android/ItemsSources/UngroupedItemsSource.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/ItemsSources/UngroupedItemsSource.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			_source = source;
 		}
 
-		public int Count => _source.Count;
+		public int Count => _source.Count + (HasHeader ? 1 : 0) + (HasFooter ? 1 : 0);
 
 		public bool HasHeader { get => _source.HasHeader; set => _source.HasHeader = value; }
 		public bool HasFooter { get => _source.HasFooter; set => _source.HasFooter = value; }

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.Android.cs
@@ -50,5 +50,37 @@ namespace Microsoft.Maui.DeviceTests
 			// Without Exceptions here, the test has passed.
 			Assert.Equal(0, (rootPage as IPageContainer<Page>).CurrentPage.Navigation.ModalStack.Count);
 		}
+
+		[Fact]
+		public async Task NullItemsSourceDisplaysHeaderFooterAndEmptyView() 
+		{
+			SetupBuilder();
+
+			var emptyView = new Label { Text = "Empty" };
+			var header = new Label { Text = "Header" };
+			var footer = new Label { Text = "Footer" };
+
+			var collectionView = new CollectionView
+			{
+				ItemsSource = null,
+				EmptyView = emptyView,
+				Header = header,
+				Footer = footer
+			};
+
+			ContentPage contentPage = new ContentPage() { Content = collectionView };
+
+			var frame = collectionView.Frame;
+
+			await CreateHandlerAndAddToWindow<IWindowHandler>(contentPage,
+				async (_) =>
+				{
+					await WaitForUIUpdate(frame, collectionView);
+
+					Assert.True(emptyView.Height > 0, "EmptyView is not displayed");
+					Assert.True(header.Height > 0, "Header is not displayed");
+					Assert.True(footer.Height > 0, "Footer is not displayed");
+				});
+		}
 	}
 }


### PR DESCRIPTION
### Description of Change

The UngroupedItemsSource's implementation of Count does not take header/footer indexes into account, which means that if a CollectionView is using an ItemsSource which gets wrapped by that class and the CollectionView sets a Header or Footer, the logic to identify whether the collection is empty fails; the EmptyView, Header, and Footer are not correctly displayed.

These changes add a test to detect the situation, a fix for the UngroupedItemsSource's Count implementation, and some cleanup of the EmptyViewAdpater's handling of Header/Footer.

### Issues Fixed

Fixes (but reverted) #8934
