### PR TITLE
Use base Width and Height on Android PlatformGraphicsView

### DIFF
--- a/src/Graphics/src/Graphics/Platforms/Android/PlatformGraphicsView.cs
+++ b/src/Graphics/src/Graphics/Platforms/Android/PlatformGraphicsView.cs
@@ -8,7 +8,6 @@ namespace Microsoft.Maui.Graphics.Platform
 {
 	public class PlatformGraphicsView : View
 	{
-		private int _width, _height;
 		private readonly PlatformCanvas _canvas;
 		private readonly ScalingCanvas _scalingCanvas;
 		private IDrawable _drawable;
@@ -56,7 +55,7 @@ namespace Microsoft.Maui.Graphics.Platform
 			if (_drawable == null)
 				return;
 
-			var dirtyRect = new RectF(0, 0, _width, _height);
+			var dirtyRect = new RectF(0, 0, Width, Height);
 
 			_canvas.Canvas = androidCanvas;
 			if (_backgroundColor != null)
@@ -73,13 +72,6 @@ namespace Microsoft.Maui.Graphics.Platform
 			dirtyRect.Width /= _scale;
 			_drawable.Draw(_scalingCanvas, dirtyRect);
 			_canvas.Canvas = null;
-		}
-
-		protected override void OnSizeChanged(int width, int height, int oldWidth, int oldHeight)
-		{
-			base.OnSizeChanged(width, height, oldWidth, oldHeight);
-			_width = width;
-			_height = height;
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change

I noticed that this type is using some special OnSizeChanged interface, which is stored as an int but then turned back into a float.

Why not just use the Width and Height of the base class directly? This PR does that.

### Issues Fixed

I am troubleshooting an issue where some drawables are drawing based on an outdated size value. The GraphicsView itself has the proper dimensions after the rendering pass, but the drawable may not. 

I don't know if it fixes the issue, but it seems like it could.