### PR TITLE
Refactor `IsRefreshing` property to separate animation and command execution responsibilities

### DIFF
--- a/src/Controls/src/Core/RefreshView.cs
+++ b/src/Controls/src/Core/RefreshView.cs
@@ -37,7 +37,6 @@ namespace Microsoft.Maui.Controls
 
 			var refreshView = (RefreshView)bindable;
 			refreshView.Refreshing?.Invoke(bindable, EventArgs.Empty);
-			refreshView.Command?.Execute(refreshView.CommandParameter);
 		}
 
 		static object OnIsRefreshingPropertyCoerced(BindableObject bindable, object value)

--- a/src/Core/src/Core/IRefreshView.cs
+++ b/src/Core/src/Core/IRefreshView.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Maui.Graphics;
+﻿using System.Windows.Input;
+using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui
 {
@@ -21,5 +22,15 @@ namespace Microsoft.Maui
 		/// The scrollable content to refresh.
 		/// </summary>
 		IView Content { get; }
+
+		/// <summary>
+		/// Gets the command to be executed when the refresh is triggered.
+		/// </summary>
+		ICommand Command { get; }
+
+		/// <summary>
+		/// Gets the parameter to be passed to the command when it is executed.
+		/// </summary>
+		object CommandParameter { get; }
 	}
 }

--- a/src/Core/src/Handlers/RefreshView/RefreshViewHandler.Android.cs
+++ b/src/Core/src/Handlers/RefreshView/RefreshViewHandler.Android.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Maui.Handlers
 		void OnSwipeRefresh(object? sender, System.EventArgs e)
 		{
 			VirtualView.IsRefreshing = true;
+			VirtualView.Command?.Execute(VirtualView.CommandParameter);
 		}
 
 		protected override void DisconnectHandler(MauiSwipeRefreshLayout platformView)

--- a/src/Core/src/Handlers/RefreshView/RefreshViewHandler.Tizen.cs
+++ b/src/Core/src/Handlers/RefreshView/RefreshViewHandler.Tizen.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Maui.Handlers
 		void OnRefreshing(object? sender, EventArgs e)
 		{
 			VirtualView.IsRefreshing = true;
+			VirtualView.Command?.Execute(VirtualView.CommandParameter);
 		}
 
 		protected override void DisconnectHandler(MauiRefreshLayout platformView)

--- a/src/Core/src/Handlers/RefreshView/RefreshViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/RefreshView/RefreshViewHandler.Windows.cs
@@ -114,21 +114,18 @@ namespace Microsoft.Maui.Handlers
 		{
 			CompleteRefresh();
 			_refreshCompletionDeferral = args.GetDeferral();
-
-			if (VirtualView != null)
-				VirtualView.IsRefreshing = true;
 		}
 
 		void OnManipulationDelta(object sender, UI.Xaml.Input.ManipulationDeltaRoutedEventArgs e)
 		{
-			if (e.PointerDeviceType is UI.Input.PointerDeviceType.Touch)
-				return; // Already managed by the RefreshContainer control itself
-
 			const double minimumCumulativeY = 20;
 			double cumulativeY = e.Cumulative.Translation.Y;
 
 			if (cumulativeY > minimumCumulativeY && VirtualView is not null && !VirtualView.IsRefreshing)
+			{
 				VirtualView.IsRefreshing = true;
+				VirtualView.Command?.Execute(VirtualView.CommandParameter);
+			}
 		}
 
 		void CompleteRefresh()

--- a/src/Core/src/Handlers/RefreshView/RefreshViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/RefreshView/RefreshViewHandler.iOS.cs
@@ -46,6 +46,7 @@ namespace Microsoft.Maui.Handlers
 		void OnRefresh(object? sender, EventArgs e)
 		{
 			VirtualView.IsRefreshing = true;
+			VirtualView.Command?.Execute(VirtualView.CommandParameter);
 		}
 
 		static void UpdateIsRefreshing(IRefreshViewHandler handler)

--- a/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -14,6 +14,8 @@ Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>.Add(string! key, Syste
 Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>.Add(string! key, System.Action<TViewHandler, TVirtualView>! action) -> void
 Microsoft.Maui.Handlers.IImageSourcePartSetter
 Microsoft.Maui.Handlers.IImageSourcePartSetter.SetImageSource(Android.Graphics.Drawables.Drawable? obj) -> void
+Microsoft.Maui.IRefreshView.Command.get -> System.Windows.Input.ICommand!
+Microsoft.Maui.IRefreshView.CommandParameter.get -> object!
 Microsoft.Maui.Layouts.FlexBasis.Equals(Microsoft.Maui.Layouts.FlexBasis other) -> bool
 Microsoft.Maui.Platform.ImageSourcePartLoader.ImageSourcePartLoader(Microsoft.Maui.Handlers.IImageSourcePartSetter! handler) -> void
 Microsoft.Maui.Platform.ShapeExtensions

--- a/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -16,6 +16,8 @@ Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>.Add(string! key, Syste
 Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>.Add(string! key, System.Action<TViewHandler, TVirtualView>! action) -> void
 Microsoft.Maui.Handlers.IImageSourcePartSetter
 Microsoft.Maui.Handlers.IImageSourcePartSetter.SetImageSource(UIKit.UIImage? obj) -> void
+Microsoft.Maui.IRefreshView.Command.get -> System.Windows.Input.ICommand!
+Microsoft.Maui.IRefreshView.CommandParameter.get -> object!
 Microsoft.Maui.Layouts.FlexBasis.Equals(Microsoft.Maui.Layouts.FlexBasis other) -> bool
 Microsoft.Maui.LifecycleEvents.iOSLifecycle.PerformFetch
 Microsoft.Maui.Platform.ImageSourcePartLoader.ImageSourcePartLoader(Microsoft.Maui.Handlers.IImageSourcePartSetter! handler) -> void

--- a/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -16,6 +16,8 @@ Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>.Add(string! key, Syste
 Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>.Add(string! key, System.Action<TViewHandler, TVirtualView>! action) -> void
 Microsoft.Maui.Handlers.IImageSourcePartSetter
 Microsoft.Maui.Handlers.IImageSourcePartSetter.SetImageSource(UIKit.UIImage? obj) -> void
+Microsoft.Maui.IRefreshView.Command.get -> System.Windows.Input.ICommand!
+Microsoft.Maui.IRefreshView.CommandParameter.get -> object!
 Microsoft.Maui.Layouts.FlexBasis.Equals(Microsoft.Maui.Layouts.FlexBasis other) -> bool
 Microsoft.Maui.Platform.ImageSourcePartLoader.ImageSourcePartLoader(Microsoft.Maui.Handlers.IImageSourcePartSetter! handler) -> void
 Microsoft.Maui.Platform.MauiImageView.MauiImageView(Microsoft.Maui.Handlers.IImageHandler! handler) -> void

--- a/src/Core/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -14,6 +14,8 @@ Microsoft.Maui.SizeRequest.Equals(Microsoft.Maui.SizeRequest other) -> bool
 Microsoft.Maui.Handlers.IImageSourcePartSetter
 Microsoft.Maui.Handlers.IImageSourcePartSetter.SetImageSource(Microsoft.Maui.Platform.MauiImageSource? obj) -> void
 Microsoft.Maui.Platform.ImageSourcePartLoader.ImageSourcePartLoader(Microsoft.Maui.Handlers.IImageSourcePartSetter! handler) -> void
+Microsoft.Maui.IRefreshView.Command.get -> System.Windows.Input.ICommand!
+Microsoft.Maui.IRefreshView.CommandParameter.get -> object!
 override Microsoft.Maui.Layouts.FlexBasis.Equals(object? obj) -> bool
 override Microsoft.Maui.Layouts.FlexBasis.GetHashCode() -> int
 override Microsoft.Maui.SizeRequest.Equals(object? obj) -> bool

--- a/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -5,6 +5,8 @@ Microsoft.Maui.IApplication.UserAppTheme.get -> Microsoft.Maui.ApplicationModel.
 Microsoft.Maui.Hosting.MauiApp.DisposeAsync() -> System.Threading.Tasks.ValueTask
 Microsoft.Maui.Handlers.IImageSourcePartSetter
 Microsoft.Maui.Handlers.IImageSourcePartSetter.SetImageSource(Microsoft.UI.Xaml.Media.ImageSource? obj) -> void
+Microsoft.Maui.IRefreshView.Command.get -> System.Windows.Input.ICommand!
+Microsoft.Maui.IRefreshView.CommandParameter.get -> object!
 Microsoft.Maui.IWindow.TitleBarDragRectangles.get -> Microsoft.Maui.Graphics.Rect[]?
 Microsoft.Maui.ICommandMapper
 Microsoft.Maui.ICommandMapper.GetCommand(string! key) -> System.Action<Microsoft.Maui.IElementHandler!, Microsoft.Maui.IElement!, object?>?

--- a/src/Core/src/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -11,6 +11,8 @@ Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>.Add(string! key, Syste
 Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>.Add(string! key, System.Action<TViewHandler, TVirtualView>! action) -> void
 Microsoft.Maui.Handlers.IImageSourcePartSetter
 Microsoft.Maui.Handlers.IImageSourcePartSetter.SetImageSource(object? obj) -> void
+Microsoft.Maui.IRefreshView.Command.get -> System.Windows.Input.ICommand!
+Microsoft.Maui.IRefreshView.CommandParameter.get -> object!
 Microsoft.Maui.Layouts.FlexBasis.Equals(Microsoft.Maui.Layouts.FlexBasis other) -> bool
 Microsoft.Maui.Platform.ImageSourcePartLoader.ImageSourcePartLoader(Microsoft.Maui.Handlers.IImageSourcePartSetter! handler) -> void
 Microsoft.Maui.SizeRequest.Equals(Microsoft.Maui.SizeRequest other) -> bool

--- a/src/Core/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -11,6 +11,8 @@ Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>.Add(string! key, Syste
 Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>.Add(string! key, System.Action<TViewHandler, TVirtualView>! action) -> void
 Microsoft.Maui.Handlers.IImageSourcePartSetter
 Microsoft.Maui.Handlers.IImageSourcePartSetter.SetImageSource(object? obj) -> void
+Microsoft.Maui.IRefreshView.Command.get -> System.Windows.Input.ICommand!
+Microsoft.Maui.IRefreshView.CommandParameter.get -> object!
 Microsoft.Maui.Layouts.FlexBasis.Equals(Microsoft.Maui.Layouts.FlexBasis other) -> bool
 Microsoft.Maui.Platform.ImageSourcePartLoader.ImageSourcePartLoader(Microsoft.Maui.Handlers.IImageSourcePartSetter! handler) -> void
 Microsoft.Maui.SizeRequest.Equals(Microsoft.Maui.SizeRequest other) -> bool

--- a/src/Core/src/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -11,6 +11,8 @@ Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>.Add(string! key, Syste
 Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>.Add(string! key, System.Action<TViewHandler, TVirtualView>! action) -> void
 Microsoft.Maui.Handlers.IImageSourcePartSetter
 Microsoft.Maui.Handlers.IImageSourcePartSetter.SetImageSource(object? obj) -> void
+Microsoft.Maui.IRefreshView.Command.get -> System.Windows.Input.ICommand!
+Microsoft.Maui.IRefreshView.CommandParameter.get -> object!
 Microsoft.Maui.Layouts.FlexBasis.Equals(Microsoft.Maui.Layouts.FlexBasis other) -> bool
 Microsoft.Maui.Platform.ImageSourcePartLoader.ImageSourcePartLoader(Microsoft.Maui.Handlers.IImageSourcePartSetter! handler) -> void
 Microsoft.Maui.SizeRequest.Equals(Microsoft.Maui.SizeRequest other) -> bool


### PR DESCRIPTION
### Description of Change
This pull request proposes a modification to the behavior of the `RefreshView` control.

Currently, setting the `IsRefreshing` property to true in the `RefreshView` control not only enables the loading animation but also triggers the associated command.

To address this issue, the proposed change involves separating the responsibilities of the `IsRefreshing` property to achieve the desired behavior:

1. IsRefreshing will solely control the animation enable/disable feature.
2. Command execution will only be executed when the user initiates the refresh through the control UI or at their discretion within their view model.

But why is separating the responsibilities necessary?

As @janseris notes,
> We could set IsRefreshing=true in the ViewModel instead of calling ReloadData to achieve the correct behavior but that is not a good idea because we cannot assume from the ViewModel that setting property IsRefreshing will call the ReloadData method by coincidence (we don't know in ViewModel that IsRefreshing is bound to a RefreshView control in the View which also by coincidence calls ReloadData via a registered Command).

We could possibly rename the `IsRefreshing` property to better reflect its behavior, but this would create a breaking change. Some possibilities would be:
1. IsAnimating
2. IsAnimationInProgress
3. IsRefreshingAnimationActive
4. IsRefreshAnimationVisible

If this change is accepted, I will also update the documentation which states:
> Manually setting the IsRefreshing property to true will trigger the refresh visualization, and will execute the ICommand defined by the Command property.

Source: [learn.microsoft.com/en-us/dotnet/maui/user-interface/controls/refreshview?view=net-maui-7.0](https://learn.microsoft.com/en-us/dotnet/maui/user-interface/controls/refreshview?view=net-maui-7.0)

### Issues Fixed
Fixes #6456
Fixes #1171