### PR TITLE
[Android] Fix issues setting Shell TabBar appearance.

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellBottomNavViewAppearanceTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellBottomNavViewAppearanceTracker.cs
@@ -24,7 +24,8 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 		static ColorStateList _defaultListDark;
 
 		bool _disposed;
-		ColorStateList _colorStateList;
+		ColorStateList _itemTextColor;
+		ColorStateList _itemIconTint;
 
 		public ShellBottomNavViewAppearanceTracker(IShellContext shellContext, ShellItem shellItem)
 		{
@@ -48,14 +49,23 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 		{
 			IShellAppearanceElement controller = appearance;
 			var backgroundColor = controller.EffectiveTabBarBackgroundColor;
-			var foregroundColor = controller.EffectiveTabBarForegroundColor; // currently unused
+			var foregroundColor = controller.EffectiveTabBarForegroundColor;
 			var disabledColor = controller.EffectiveTabBarDisabledColor;
 			var unselectedColor = controller.EffectiveTabBarUnselectedColor;
 			var titleColor = controller.EffectiveTabBarTitleColor;
 
-			_colorStateList = MakeColorStateList(titleColor, disabledColor, unselectedColor);
-			bottomView.ItemTextColor = _colorStateList;
-			bottomView.ItemIconTintList = _colorStateList;
+			_itemTextColor = MakeColorStateList(
+				titleColor ?? foregroundColor, 
+				disabledColor, 
+				unselectedColor);
+
+			_itemIconTint = MakeColorStateList(
+				foregroundColor ?? titleColor, 
+				disabledColor, 
+				unselectedColor);
+
+			bottomView.ItemTextColor = _itemTextColor;
+			bottomView.ItemIconTintList = _itemIconTint;
 
 			SetBackgroundColor(bottomView, backgroundColor);
 		}
@@ -162,11 +172,13 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 			if (disposing)
 			{
-				_colorStateList?.Dispose();
+				_itemTextColor?.Dispose();
+				_itemIconTint?.Dispose();
 
+				_itemIconTint = null;
 				_shellItem = null;
 				_shellContext = null;
-				_colorStateList = null;
+				_itemTextColor = null;
 			}
 		}
 

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTabBarTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTabBarTests.Android.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Android.Widget;
+using Google.Android.Material.BottomNavigation;
+using Google.Android.Material.TextView;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Handlers;
+using Microsoft.Maui.Controls.Handlers.Compatibility;
+using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Platform;
+using Xunit;
+
+
+namespace Microsoft.Maui.DeviceTests
+{
+	[Category(TestCategory.Shell)]
+	public partial class ShellTests
+	{
+		async Task ValidateTabBarItemColor(ShellSection item, Color expectedColor, bool hasColor)
+		{
+			var shell = item.FindParentOfType<Shell>();
+			var renderer = (ShellRenderer)shell.Handler;
+			var bottomView = GetDrawerLayout(renderer).GetFirstChildOfType<BottomNavigationView>();
+			var menu = bottomView.Menu;
+			var index = shell.CurrentItem.Items.IndexOf(item);
+
+			if (index < 0 || index >= menu.Size())
+				Assert.Fail("ShellSection not found in Shell");
+
+			if (index >= menu.Size())
+				Assert.Fail("Menu Item has not been created for this item");
+
+			var navigationMenu = (BottomNavigationMenuView)bottomView.MenuView;
+			var navItems = navigationMenu.GetChildrenOfType<BottomNavigationItemView>();
+
+			var navItemView =
+				navItems.Single(x =>
+				{
+					return x.GetChildrenOfType<TextView>()
+						.Where(tv => String.Equals(tv.Text, item.Title, StringComparison.OrdinalIgnoreCase))
+						.Count() > 0;
+				});
+
+			if (hasColor)
+				await navItemView.AssertContainsColor(expectedColor.ToPlatform(), item.FindMauiContext());
+			else
+				await navItemView.AssertDoesNotContainColor(expectedColor.ToPlatform(), item.FindMauiContext());
+		}
+	}
+}

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTabBarTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTabBarTests.Windows.cs
@@ -18,111 +18,6 @@ namespace Microsoft.Maui.DeviceTests
 	[Category(TestCategory.Shell)]
 	public partial class ShellTests
 	{
-		[Fact(DisplayName = "ForegroundColor sets icon and title color sets title")]
-		public async Task ForegroundColorSetsIconAndTitleColorSetsTitle()
-		{
-			SetupBuilder();
-
-			var titleColor = Color.FromArgb("#FFFF0000");
-			var foregroundColor = Color.FromArgb("#FF00FF00");
-			await RunShellTabBarTests(shell =>
-			{
-				Shell.SetTabBarTitleColor(shell, titleColor);
-				Shell.SetTabBarForegroundColor(shell, foregroundColor);
-			},
-			async (shell) =>
-			{
-				await ValidateTabBarItemColor(shell.CurrentSection, titleColor, true);
-				await ValidateTabBarItemColor(shell.CurrentSection, foregroundColor, true);
-				await ValidateTabBarItemColor(shell.Items[0].Items[1], titleColor, false);
-				await ValidateTabBarItemColor(shell.Items[0].Items[1], foregroundColor, false);
-			});
-		}
-
-		[Theory(DisplayName = "Shell TabBar Title Color Initializes Correctly")]
-		[InlineData("#FFFF0000")]
-		[InlineData("#FF00FF00")]
-
-		public async Task ShellTabBarTitleColorInitializesCorrectly(string colorHex)
-		{
-			SetupBuilder();
-
-			var expectedColor = Color.FromArgb(colorHex);
-			await RunShellTabBarTests(shell => Shell.SetTabBarTitleColor(shell, expectedColor),
-				async (shell) =>
-				{
-					await ValidateTabBarItemColor(shell.CurrentSection, expectedColor, true);
-					await ValidateTabBarItemColor(shell.Items[0].Items[1], expectedColor, false);
-				});
-		}
-
-		[Theory(DisplayName = "Shell TabBar Foreground Initializes Correctly")]
-		[InlineData("#FFFF0000")]
-		[InlineData("#FF00FF00")]
-		public async Task ShellTabBarForegroundInitializesCorrectly(string colorHex)
-		{
-			var expectedColor = Color.FromArgb(colorHex);
-			await RunShellTabBarTests(shell => Shell.SetTabBarForegroundColor(shell, expectedColor),
-				async (shell) =>
-				{
-					await ValidateTabBarItemColor(shell.CurrentSection, expectedColor, true);
-					await ValidateTabBarItemColor(shell.Items[0].Items[1], expectedColor, false);
-				});
-		}
-
-		[Theory(DisplayName = "Shell TabBar UnselectedColor Initializes Correctly")]
-		[InlineData("#FF0000")]
-		[InlineData("#0000FF")]
-		public async Task ShellTabBarUnselectedColorInitializesCorrectly(string colorHex)
-		{
-			var expectedColor = Color.FromArgb(colorHex);
-			await RunShellTabBarTests(shell => Shell.SetTabBarUnselectedColor(shell, expectedColor),
-				async (shell) =>
-				{
-					await ValidateTabBarItemColor(shell.CurrentSection, expectedColor, false);
-					await ValidateTabBarItemColor(shell.Items[0].Items[1], expectedColor, true);
-				});
-		}
-
-		async Task RunShellTabBarTests(Action<Shell> setup, Func<Shell, Task> runTest)
-		{
-			SetupBuilder();
-
-			var selectedContent = new ShellContent()
-			{
-				Route = "Tab1",
-				Title = "Tab1",
-				Content = new ContentPage(),
-				Icon = "white.png"
-			};
-
-			var unselectedContent = new ShellContent()
-			{
-				Route = "Tab2",
-				Title = "Tab2",
-				Content = new ContentPage(),
-				Icon = "white.png"
-			};
-
-			var shell = await CreateShellAsync((shell) =>
-			{
-				shell.Items.Add(new TabBar()
-				{
-					Items =
-					{
-						selectedContent,
-						unselectedContent,
-					}
-				});
-			});
-
-			setup.Invoke(shell);
-			await CreateHandlerAndAddToWindow<ShellHandler>(shell, async (handler) =>
-			{
-				await runTest(shell);
-			});
-		}
-
 		List<WNavigationViewItem> GetTabBarItems(Shell shell)
 		{
 			var shellItemHandler = shell.CurrentItem.Handler as ShellItemHandler;
@@ -130,6 +25,7 @@ namespace Microsoft.Maui.DeviceTests
 
 			return navView.TopNavArea.GetChildren<WNavigationViewItem>().ToList();
 		}
+
 		async Task ValidateTabBarItemColor(ShellSection item, Color expectedColor, bool hasColor)
 		{
 			var items = GetTabBarItems(item.FindParentOfType<Shell>());

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTabBarTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTabBarTests.cs
@@ -1,14 +1,130 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Handlers;
+using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Platform;
+using Xunit;
 
+#if ANDROID || IOS || MACCATALYST
+using ShellHandler = Microsoft.Maui.Controls.Handlers.Compatibility.ShellRenderer;
+#endif
 
 namespace Microsoft.Maui.DeviceTests
 {
 	[Category(TestCategory.Shell)]
 	public partial class ShellTests
 	{
+#if ANDROID || WINDOWS
+
+		[Fact(DisplayName = "ForegroundColor sets icon and title color sets title")]
+		public async Task ForegroundColorSetsIconAndTitleColorSetsTitle()
+		{
+			SetupBuilder();
+
+			var titleColor = Color.FromArgb("#FFFF0000");
+			var foregroundColor = Color.FromArgb("#FF00FF00");
+			await RunShellTabBarTests(shell =>
+			{
+				Shell.SetTabBarTitleColor(shell, titleColor);
+				Shell.SetTabBarForegroundColor(shell, foregroundColor);
+			},
+			async (shell) =>
+			{
+				await ValidateTabBarItemColor(shell.CurrentSection, titleColor, true);
+				await ValidateTabBarItemColor(shell.CurrentSection, foregroundColor, true);
+				await ValidateTabBarItemColor(shell.Items[0].Items[1], titleColor, false);
+				await ValidateTabBarItemColor(shell.Items[0].Items[1], foregroundColor, false);
+
+			});
+		}
+
+		[Theory(DisplayName = "Shell TabBar Title Color Initializes Correctly")]
+		[InlineData("#FFFF0000")]
+		[InlineData("#FF00FF00")]
+
+		public async Task ShellTabBarTitleColorInitializesCorrectly(string colorHex)
+		{
+			SetupBuilder();
+
+			var expectedColor = Color.FromArgb(colorHex);
+			await RunShellTabBarTests(shell => Shell.SetTabBarTitleColor(shell, expectedColor),
+				async (shell) =>
+				{
+					await ValidateTabBarItemColor(shell.CurrentSection, expectedColor, true);
+					await ValidateTabBarItemColor(shell.Items[0].Items[1], expectedColor, false);
+				});
+		}
+
+		[Theory(DisplayName = "Shell TabBar Foreground Initializes Correctly")]
+		[InlineData("#FFFF0000")]
+		[InlineData("#FF00FF00")]
+		public async Task ShellTabBarForegroundInitializesCorrectly(string colorHex)
+		{
+			var expectedColor = Color.FromArgb(colorHex);
+			await RunShellTabBarTests(shell => Shell.SetTabBarForegroundColor(shell, expectedColor),
+				async (shell) =>
+				{
+					await ValidateTabBarItemColor(shell.CurrentSection, expectedColor, true);
+					await ValidateTabBarItemColor(shell.Items[0].Items[1], expectedColor, false);
+				});
+		}
+
+		[Theory(DisplayName = "Shell TabBar UnselectedColor Initializes Correctly")]
+		[InlineData("#FF0000")]
+		[InlineData("#0000FF")]
+		public async Task ShellTabBarUnselectedColorInitializesCorrectly(string colorHex)
+		{
+			var expectedColor = Color.FromArgb(colorHex);
+			await RunShellTabBarTests(shell => Shell.SetTabBarUnselectedColor(shell, expectedColor),
+				async (shell) =>
+				{
+					await ValidateTabBarItemColor(shell.CurrentSection, expectedColor, false);
+					await ValidateTabBarItemColor(shell.Items[0].Items[1], expectedColor, true);
+				});
+		}
+
+		async Task RunShellTabBarTests(Action<Shell> setup, Func<Shell, Task> runTest)
+		{
+			SetupBuilder();
+
+			var selectedContent = new ShellContent()
+			{
+				Route = "Tab1",
+				Title = "Tab1",
+				Content = new ContentPage(),
+				Icon = "white.png"
+			};
+
+			var unselectedContent = new ShellContent()
+			{
+				Route = "Tab2",
+				Title = "Tab2",
+				Content = new ContentPage(),
+				Icon = "white.png"
+			};
+
+			var shell = await CreateShellAsync((shell) =>
+			{
+				shell.Items.Add(new TabBar()
+				{
+					Items =
+					{
+						selectedContent,
+						unselectedContent,
+					}
+				});
+			});
+
+			setup.Invoke(shell);
+			await CreateHandlerAndAddToWindow<ShellHandler>(shell, async (handler) =>
+			{
+				await runTest(shell);
+			});
+		}
+#endif
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.Android.cs
@@ -16,6 +16,7 @@ using Microsoft.Maui.Controls.Handlers.Compatibility;
 using Microsoft.Maui.Controls.Platform;
 using Microsoft.Maui.Controls.Platform.Compatibility;
 using Microsoft.Maui.DeviceTests.Stubs;
+using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Platform;
 using Xunit;


### PR DESCRIPTION
### Description of Change

Android portion of the following PR
https://github.com/dotnet/maui/pull/15447

#### Priority of how the colors are applied.

The APIs available to us are fairly limiting in scope. Ideally, we would make this all work through the VSM and just use two APIs (IconColor/TitleColor) but for now we are just making these APIs consistent between the platforms. 

The three properties users have to influence the `TabItem` coloring are: `TabBarUnselectedColor`, `TabBarTitleColor`, and `TabBarForegroundColor`

- If the user only sets `Shell.TabBarTitleColor` that will color the `Title` and `Icon` of the selected item. I realize this is a bit weird for TitleColor to change `Icon` color but this is currently how Android works and it's not really worth breaking this until we just introduce new APIs.
- If `Shell.TabBarTitleColor` is not set then the `TitleColor` will match the `TabBarForegroundColor`
- If `TabBarForegroundColor` is set and `TabBarUnselectedColor` isn't set then `TabBarForegroundColor` will be the color used for the text/icon of the selected TabItem
- If `TabBarUnselectedColor` is the only thing set then that will be used for the text/icon color on the unselected Tab Item. 

#### Examples
- `TabBarTitleColor`: Green
  - Selected Icon is Green, Selected Text is Green, Unselected item matches system colors
-  `TabBarForegroundColor`: Blue
  - Selected Icon is Blue, Selected Text is Blue, Unselected item matches system colors
-  `TabBarForegroundColor`: Blue, `TabBarTitleColor`: Green
  - Selected Icon is Blue, Selected Text is Green, Unselected item matches system colors
-  `Shell.ForegroundColor`: Blue, `TabBarTitleColor`: Green (ForegroundColor propagates to TabBarForegroundColor).
  - Selected Icon is Blue, Selected Text is Green, Unselected item matches system colors
-  `TabBarForegroundColor`: Blue, `TabBarTitleColor`: Green, `TabBarUnselectedColor`: Pink
  - Selected Icon is Blue, Selected Text is Green, Unselected text and Icon is `Pink`

#### Breaking changes
- Shell.ForegroundColor and Shell.TabBarForeGroundColor will now affect the android tab colors. If a user has `ForegroundColor` set, then the `tab` will match according to that color.
  


