### PR TITLE
Android x nuget bumps

### DIFF
--- a/eng/AndroidX.targets
+++ b/eng/AndroidX.targets
@@ -18,19 +18,19 @@
     />
     <PackageReference
         Update="Xamarin.AndroidX.Navigation.UI"
-        Version="2.5.3.3"
+        Version="2.6.0"
     />
     <PackageReference
         Update="Xamarin.AndroidX.Navigation.Fragment"
-        Version="2.5.3.3"
+        Version="2.6.0"
     />
     <PackageReference
         Update="Xamarin.AndroidX.Navigation.Runtime"
-        Version="2.5.3.3"
+        Version="2.6.0"
     />
     <PackageReference
         Update="Xamarin.AndroidX.Navigation.Common"
-        Version="2.5.3.3"
+        Version="2.6.0"
     />
     <PackageReference
         Update="Xamarin.AndroidX.MediaRouter"
@@ -59,7 +59,7 @@
     />
     <PackageReference
         Update="Xamarin.AndroidX.Window.WindowJava"
-        Version="1.0.0.13"
+        Version="1.1.0"
     />
   </ItemGroup>
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -55,7 +55,7 @@
     <!-- GLIDE - the android maven artifact in /src/Core/AndroidNative/maui/build.gradle -->
     <!-- must be kept in sync with the binding library version to it here: -->
     <_XamarinAndroidGlideVersion>4.15.1</_XamarinAndroidGlideVersion>
-    <_XamarinAndroidXSecurityVersion>1.1.0-alpha05</_XamarinAndroidXSecurityVersion>
+    <_XamarinAndroidXSecurityVersion>1.1.0-alpha06</_XamarinAndroidXSecurityVersion>
     <_XamarinGoogleCryptoTinkAndroidVersion>1.9.0.1</_XamarinGoogleCryptoTinkAndroidVersion>
     <!-- Android Maps -->
     <XamarinGooglePlayServicesMaps>118.1.0.2</XamarinGooglePlayServicesMaps>

--- a/src/Controls/src/Core/NavigationPage/NavigationPage.cs
+++ b/src/Controls/src/Core/NavigationPage/NavigationPage.cs
@@ -467,6 +467,7 @@ namespace Microsoft.Maui.Controls
 				SyncToNavigationStack(newStack);
 				CurrentPage = (Page)newStack[newStack.Count - 1];
 				RootPage = (Page)newStack[0];
+				FindMyToolbar()?.Handler?.UpdateValue(nameof(IToolbar.BackButtonVisible));
 			}
 
 			var completionSource = _currentNavigationCompletionSource;

--- a/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.cs
@@ -92,6 +92,45 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 #if !IOS && !MACCATALYST
+
+		[Fact(DisplayName = "Swapping Navigation Toggles BackButton Correctly")]
+		public async Task SwappingNavigationTogglesBackButtonCorrectly()
+		{
+			SetupBuilder();
+			var navPage = new NavigationPage(new ContentPage());
+
+			await CreateHandlerAndAddToWindow<WindowHandlerStub>(new Window(navPage), async (handler) =>
+			{
+				await navPage.PushAsync(new ContentPage());
+				var navigation = navPage.Navigation;
+				var stackNavigationView = navPage as IStackNavigationView;
+				List<Page> _currentNavStack = navigation.NavigationStack.ToList();
+
+				var singlePage = new ContentPage();
+				stackNavigationView.RequestNavigation(
+						new NavigationRequest(
+							new List<ContentPage>
+							{
+								singlePage
+							}, false));
+
+				await OnLoadedAsync(singlePage);
+				await (navPage.CurrentNavigationTask ?? Task.CompletedTask);
+
+				// Wait for back button to hide
+				Assert.True(await AssertionExtensions.Wait(() => !IsBackButtonVisible(handler)));
+
+				stackNavigationView.RequestNavigation(
+					   new NavigationRequest(_currentNavStack, true));
+
+				await OnLoadedAsync(_currentNavStack.Last());
+				await (navPage.CurrentNavigationTask ?? Task.CompletedTask);
+
+				// Wait for back button to reveal itself
+				Assert.True(await AssertionExtensions.Wait(() => IsBackButtonVisible(handler)));
+			}, timeOut: TimeSpan.FromMinutes(2));
+		}
+
 		[Fact(DisplayName = "Back Button Visibility Changes with push/pop")]
 		public async Task BackButtonVisibilityChangesWithPushPop()
 		{

--- a/src/Core/src/Platform/Android/Navigation/StackNavigationManager.cs
+++ b/src/Core/src/Platform/Android/Navigation/StackNavigationManager.cs
@@ -7,6 +7,7 @@ using AndroidX.Navigation;
 using AndroidX.Navigation.Fragment;
 using AndroidX.Navigation.UI;
 using Java.Interop;
+using Java.Lang;
 using AToolbar = AndroidX.AppCompat.Widget.Toolbar;
 using AView = Android.Views.View;
 
@@ -140,17 +141,8 @@ namespace Microsoft.Maui.Platform
 
 			IsAnimated = animated;
 
-			var iterator = NavController.BackQueue.Iterator();
 			var fragmentNavDestinations = new List<FragmentNavigator.Destination>();
-
-			while (iterator.HasNext)
-			{
-				if (iterator.Next() is NavBackStackEntry nbse &&
-					nbse.Destination is FragmentNavigator.Destination nvd)
-				{
-					fragmentNavDestinations.Add(nvd);
-				}
-			}
+			IterateBackStack(NavController.Graph, d => fragmentNavDestinations.Add(d));
 
 			// Current BackStack has less entries then incoming new page stack
 			// This will add Back Stack Entries until the back stack and the new stack 
@@ -183,19 +175,16 @@ namespace Microsoft.Maui.Platform
 			// We only keep destinations around that are on the backstack
 			// This iterates over the new backstack and removes any destinations
 			// that are no longer apart of the back stack
-			var iterateNewStack = NavController.BackQueue.Iterator();
-			int startId = -1;
-			while (iterateNewStack.HasNext)
-			{
-				if (iterateNewStack.Next() is NavBackStackEntry nbse &&
-					nbse.Destination is FragmentNavigator.Destination nvd)
-				{
-					fragmentNavDestinations.Remove(nvd);
 
-					if (startId == -1)
-						startId = nvd.Id;
-				}
-			}
+			var iterateNewStack = NavController.Graph.Iterator();
+			int startId = -1;
+
+			IterateBackStack(NavController.Graph, nvd =>
+			{
+				if (startId == -1)
+					startId = nvd.Id;
+				fragmentNavDestinations.Remove(nvd);
+			});
 
 			foreach (var activeDestinations in fragmentNavDestinations)
 			{
@@ -241,19 +230,30 @@ namespace Microsoft.Maui.Platform
 			navigationView?.NavigationFinished(NavigationStack);
 		}
 
+		void IterateBackStack(NavGraph navGraph, Action<FragmentNavigator.Destination> action)
+		{
+			var iterator = NavController.Graph.Iterator();
+			var fragmentNavDestinations = new List<FragmentNavigator.Destination>();
+
+			while (iterator.HasNext)
+			{
+				if (iterator.Next() is FragmentNavigator.Destination nvd)
+				{
+					try
+					{
+						if (NavController.GetBackStackEntry(nvd.Id).Destination is FragmentNavigator.Destination found)
+							action.Invoke(found);
+					}
+					catch (IllegalArgumentException) { }
+				}
+			}
+		}
+
 		// This occurs when the navigation page is first being renderer so we sync up the
 		// Navigation Stack on the INavigationView to our platform stack
 		List<int> Initialize(IReadOnlyList<IView> pages)
 		{
 			var navController = NavController;
-
-			// We are subtracting one because the navgraph itself is the first item on the stack
-			int PlatformNavigationStackCount = navController.BackQueue.Size() - 1;
-
-			// set this to one because when the graph is first attached to the controller
-			// it will add the graph and the first destination
-			if (PlatformNavigationStackCount < 0)
-				PlatformNavigationStackCount = 1;
 
 			List<int> destinations = new List<int>();
 
@@ -267,6 +267,15 @@ namespace Microsoft.Maui.Platform
 
 			NavGraph.StartDestination = destinations[0];
 			navController.SetGraph(NavGraph, null);
+
+			int PlatformNavigationStackCount = 0;
+
+			IterateBackStack(NavController.Graph, _ => PlatformNavigationStackCount++);
+
+			// set this to one because when the graph is first attached to the controller
+			// it will add the graph and the first destination
+			if (PlatformNavigationStackCount < 0)
+				PlatformNavigationStackCount = 1;
 
 			for (var i = PlatformNavigationStackCount; i < pages.Count; i++)
 			{

--- a/src/Core/src/Platform/Android/Navigation/StackNavigationManager.cs
+++ b/src/Core/src/Platform/Android/Navigation/StackNavigationManager.cs
@@ -142,7 +142,7 @@ namespace Microsoft.Maui.Platform
 			IsAnimated = animated;
 
 			var fragmentNavDestinations = new List<FragmentNavigator.Destination>();
-			IterateBackStack(NavController.Graph, d => fragmentNavDestinations.Add(d));
+			navController.IterateBackStack(d => fragmentNavDestinations.Add(d));
 
 			// Current BackStack has less entries then incoming new page stack
 			// This will add Back Stack Entries until the back stack and the new stack 
@@ -179,7 +179,7 @@ namespace Microsoft.Maui.Platform
 			var iterateNewStack = NavController.Graph.Iterator();
 			int startId = -1;
 
-			IterateBackStack(NavController.Graph, nvd =>
+			navController.IterateBackStack(nvd =>
 			{
 				if (startId == -1)
 					startId = nvd.Id;
@@ -230,25 +230,6 @@ namespace Microsoft.Maui.Platform
 			navigationView?.NavigationFinished(NavigationStack);
 		}
 
-		void IterateBackStack(NavGraph navGraph, Action<FragmentNavigator.Destination> action)
-		{
-			var iterator = NavController.Graph.Iterator();
-			var fragmentNavDestinations = new List<FragmentNavigator.Destination>();
-
-			while (iterator.HasNext)
-			{
-				if (iterator.Next() is FragmentNavigator.Destination nvd)
-				{
-					try
-					{
-						if (NavController.GetBackStackEntry(nvd.Id).Destination is FragmentNavigator.Destination found)
-							action.Invoke(found);
-					}
-					catch (IllegalArgumentException) { }
-				}
-			}
-		}
-
 		// This occurs when the navigation page is first being renderer so we sync up the
 		// Navigation Stack on the INavigationView to our platform stack
 		List<int> Initialize(IReadOnlyList<IView> pages)
@@ -270,7 +251,7 @@ namespace Microsoft.Maui.Platform
 
 			int PlatformNavigationStackCount = 0;
 
-			IterateBackStack(NavController.Graph, _ => PlatformNavigationStackCount++);
+			navController.IterateBackStack(_ => PlatformNavigationStackCount++);
 
 			// set this to one because when the graph is first attached to the controller
 			// it will add the graph and the first destination

--- a/src/Core/src/Platform/Android/NavigationViewExtensions.cs
+++ b/src/Core/src/Platform/Android/NavigationViewExtensions.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using AndroidX.Navigation.Fragment;
+using AndroidX.Navigation;
+using Java.Lang;
+using Microsoft.Maui.Graphics;
+
+namespace Microsoft.Maui.Platform
+{
+	internal static partial class NavigationViewExtensions
+	{
+
+		public static void IterateBackStack(this NavController navController, Action<FragmentNavigator.Destination> action)
+		{
+			var iterator = navController.Graph.Iterator();
+
+			while (iterator.HasNext)
+			{
+				if (iterator.Next() is FragmentNavigator.Destination nvd)
+				{
+					try
+					{
+						if (navController.GetBackStackEntry(nvd.Id).Destination is FragmentNavigator.Destination found)
+							action.Invoke(found);
+					}
+					catch (IllegalArgumentException) { }
+				}
+			}
+		}
+	}
+}

--- a/src/Core/tests/DeviceTests/Handlers/Navigation/NavigationViewHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Navigation/NavigationViewHandlerTests.Android.cs
@@ -6,6 +6,9 @@ using Android.Views;
 using AndroidX.AppCompat.App;
 using AndroidX.AppCompat.Widget;
 using AndroidX.Fragment.App;
+using AndroidX.Navigation.Fragment;
+using AndroidX.Navigation;
+using Java.Lang;
 using Microsoft.Maui.DeviceTests.Stubs;
 using Microsoft.Maui.Handlers;
 using Xunit;
@@ -15,8 +18,14 @@ namespace Microsoft.Maui.DeviceTests
 {
 	public partial class NavigationViewHandlerTests
 	{
-		int GetNativeNavigationStackCount(NavigationViewHandler navigationViewHandler) =>
-			navigationViewHandler.StackNavigationManager.NavHost.NavController.BackQueue.Size() - 1;
+		int GetNativeNavigationStackCount(NavigationViewHandler navigationViewHandler)
+		{
+			int i = 0;
+			var navController = navigationViewHandler.StackNavigationManager.NavHost.NavController;
+			navController.IterateBackStack(_ => i++);
+
+			return i;
+		}
 
 		Task CreateNavigationViewHandlerAsync(IStackNavigationView navigationView, Func<NavigationViewHandler, Task> action)
 		{


### PR DESCRIPTION
### Description of Change

This PR removes the use of any private APIs that we are using on the NavigationController. 

With 2.6.0 google completely removed the `BackQueue` API so we needed to find a more "official" way to do the same thing. The code we switched to isn't great because it throws as it's iterating but currently that's the best way I've found to iterate over the current back stack.

Fixes for https://github.com/dotnet/maui/pull/15685
