### PR TITLE
[iOS] Fix issues setting Shell TabBar appearance

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/SafeShellTabBarAppearanceTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/SafeShellTabBarAppearanceTracker.cs
@@ -71,32 +71,48 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 		{
 			IShellAppearanceElement appearanceElement = appearance;
 
+			var backgroundColor = appearanceElement.EffectiveTabBarBackgroundColor;
+			var foregroundColor = appearanceElement.EffectiveTabBarForegroundColor;
+			var unselectedColor = appearanceElement.EffectiveTabBarUnselectedColor;
+			var titleColor = appearanceElement.EffectiveTabBarTitleColor;
+
 			controller.TabBar
 				.UpdateiOS15TabBarAppearance(
 					ref _tabBarAppearance,
 					null,
 					null,
-					appearanceElement.EffectiveTabBarForegroundColor,
-					appearanceElement.EffectiveTabBarUnselectedColor,
-					appearanceElement.EffectiveTabBarBackgroundColor,
-					appearanceElement.EffectiveTabBarTitleColor);
+					foregroundColor ?? titleColor,
+					unselectedColor,
+					backgroundColor,
+					titleColor ?? foregroundColor,
+					unselectedColor);
 		}
 
 		void UpdateTabBarAppearance(UITabBarController controller, ShellAppearance appearance)
 		{
 			IShellAppearanceElement appearanceElement = appearance;
 			var backgroundColor = appearanceElement.EffectiveTabBarBackgroundColor;
+			var foregroundColor = appearanceElement.EffectiveTabBarForegroundColor;
 			var unselectedColor = appearanceElement.EffectiveTabBarUnselectedColor;
 			var titleColor = appearanceElement.EffectiveTabBarTitleColor;
 
 			var tabBar = controller.TabBar;
 
-			if (backgroundColor != null)
+			if (backgroundColor is not null && backgroundColor.IsNotDefault())
 				tabBar.BarTintColor = backgroundColor.ToPlatform();
-			if (titleColor.IsDefault != null)
-				tabBar.TintColor = titleColor.ToPlatform();
-			if (unselectedColor.IsDefault != null)
+
+			if (unselectedColor.IsDefault != null && unselectedColor.IsNotDefault())
+			{
 				tabBar.UnselectedItemTintColor = unselectedColor.ToPlatform();
+				UITabBarItem.Appearance.SetTitleTextAttributes(new UIStringAttributes { ForegroundColor = unselectedColor.ToPlatform() }, UIControlState.Normal);
+			}
+
+			if (titleColor.IsDefault != null && titleColor.IsNotDefault() ||
+				foregroundColor.IsDefault != null && foregroundColor.IsNotDefault())
+			{
+				tabBar.TintColor = (foregroundColor ?? titleColor).ToPlatform();
+				UITabBarItem.Appearance.SetTitleTextAttributes(new UIStringAttributes { ForegroundColor = (titleColor ?? foregroundColor).ToPlatform() }, UIControlState.Selected);
+			}
 		}
 	}
 }

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/SafeShellTabBarAppearanceTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/SafeShellTabBarAppearanceTracker.cs
@@ -101,14 +101,14 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			if (backgroundColor is not null && backgroundColor.IsNotDefault())
 				tabBar.BarTintColor = backgroundColor.ToPlatform();
 
-			if (unselectedColor.IsDefault != null && unselectedColor.IsNotDefault())
+			if (unselectedColor is not null && unselectedColor.IsNotDefault())
 			{
 				tabBar.UnselectedItemTintColor = unselectedColor.ToPlatform();
 				UITabBarItem.Appearance.SetTitleTextAttributes(new UIStringAttributes { ForegroundColor = unselectedColor.ToPlatform() }, UIControlState.Normal);
 			}
 
-			if (titleColor.IsDefault != null && titleColor.IsNotDefault() ||
-				foregroundColor.IsDefault != null && foregroundColor.IsNotDefault())
+			if (titleColor is not null && titleColor.IsNotDefault() ||
+				foregroundColor is not null && foregroundColor.IsNotDefault())
 			{
 				tabBar.TintColor = (foregroundColor ?? titleColor).ToPlatform();
 				UITabBarItem.Appearance.SetTitleTextAttributes(new UIStringAttributes { ForegroundColor = (titleColor ?? foregroundColor).ToPlatform() }, UIControlState.Selected);

--- a/src/Controls/src/Core/Compatibility/Handlers/TabbedPage/iOS/TabbedRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/TabbedPage/iOS/TabbedRenderer.cs
@@ -376,12 +376,11 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			else
 				tabBarTextColor = barTextColor.ToPlatform();
 
-			var attributes = new UIStringAttributes();
-			attributes.ForegroundColor = tabBarTextColor;
-
 			foreach (UITabBarItem item in TabBar.Items)
 			{
-				item.SetTitleTextAttributes(attributes, UIControlState.Normal);
+				item.SetTitleTextAttributes(new UIStringAttributes() { ForegroundColor = tabBarTextColor }, UIControlState.Normal);
+				item.SetTitleTextAttributes(new UIStringAttributes() { ForegroundColor = tabBarTextColor }, UIControlState.Selected);
+				item.SetTitleTextAttributes(new UIStringAttributes() { ForegroundColor = tabBarTextColor }, UIControlState.Disabled);
 			}
 
 			// set TintColor for selected icon
@@ -389,7 +388,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			if (OperatingSystem.IsIOSVersionAtLeast(15) || OperatingSystem.IsTvOSVersionAtLeast(15))
 				UpdateiOS15TabBarAppearance();
 			else
+			{
 				TabBar.TintColor = isDefaultColor ? _defaultBarTextColor : barTextColor.ToPlatform();
+			}
 		}
 
 		void UpdateBarTranslucent()
@@ -507,7 +508,8 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				Tabbed.IsSet(TabbedPage.SelectedTabColorProperty) ? Tabbed.SelectedTabColor : null,
 				Tabbed.IsSet(TabbedPage.UnselectedTabColorProperty) ? Tabbed.UnselectedTabColor : null,
 				Tabbed.IsSet(TabbedPage.BarBackgroundColorProperty) ? Tabbed.BarBackgroundColor : null,
-				Tabbed.IsSet(TabbedPage.BarTextColorProperty) ? Tabbed.BarTextColor : null);
+				Tabbed.IsSet(TabbedPage.BarTextColorProperty) ? Tabbed.BarTextColor : null,
+				null);
 		}
 
 		#region IPlatformViewHandler

--- a/src/Controls/src/Core/TabbedPage/TabbedPage.Windows.cs
+++ b/src/Controls/src/Core/TabbedPage/TabbedPage.Windows.cs
@@ -279,20 +279,30 @@ namespace Microsoft.Maui.Controls
 			MapBarBackground(handler, view);
 		}
 
+		void UpdateBarTextColor()
+		{
+			var unselected = (BarTextColor ?? UnselectedTabColor);
+			var selected = (BarTextColor ?? SelectedTabColor);
+
+			_navigationView?.UpdateTopNavigationViewItemTextColor(unselected?.AsPaint());
+			_navigationView?.UpdateTopNavigationViewItemTextSelectedColor(selected?.AsPaint());
+		}
+
 		internal static void MapBarTextColor(ITabbedViewHandler handler, TabbedPage view)
 		{
-			view._navigationView?.UpdateTopNavigationViewItemTextColor(view.BarTextColor?.AsPaint());
-			view._navigationView?.UpdateTopNavigationViewItemTextSelectedColor(view.BarTextColor?.AsPaint());
+			view.UpdateBarTextColor();
 		}
 
 		internal static void MapUnselectedTabColor(ITabbedViewHandler handler, TabbedPage view)
 		{
 			view._navigationView?.UpdateTopNavigationViewItemUnselectedColor(view.UnselectedTabColor?.AsPaint());
+			view.UpdateBarTextColor();
 		}
 
 		internal static void MapSelectedTabColor(ITabbedViewHandler handler, TabbedPage view)
 		{
 			view._navigationView?.UpdateTopNavigationViewItemSelectedColor(view.SelectedTabColor?.AsPaint());
+			view.UpdateBarTextColor();
 		}
 
 		internal static void MapItemsSource(ITabbedViewHandler handler, TabbedPage view)

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTabBarTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTabBarTests.Android.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Maui.DeviceTests
 	[Category(TestCategory.Shell)]
 	public partial class ShellTests
 	{
-		BottomNavigationItemView GetTab(ShellSection item)
+		BottomNavigationView GetTab(ShellSection item)
 		{
 			var shell = item.FindParentOfType<Shell>();
 			var renderer = (ShellRenderer)shell.Handler;
@@ -34,38 +34,41 @@ namespace Microsoft.Maui.DeviceTests
 			if (index >= menu.Size())
 				Assert.Fail("Menu Item has not been created for this item");
 
-			var navigationMenu = (BottomNavigationMenuView)bottomView.MenuView;
-			var navItems = navigationMenu.GetChildrenOfType<BottomNavigationItemView>();
-
-			var navItemView =
-				navItems.Single(x =>
-				{
-					return x.GetChildrenOfType<TextView>()
-						.Where(tv => String.Equals(tv.Text, item.Title, StringComparison.OrdinalIgnoreCase))
-						.Count() > 0;
-				});
-
-			return navItemView;
+			return bottomView;
 		}
 
-		async Task ValidateTabBarIconColor(ShellSection item, Color expectedColor, bool hasColor)
+		async Task ValidateTabBarIconColor(
+			ShellSection item,
+			Color iconColor,
+			bool hasColor)
 		{
-			var navItemView = (AView)GetTab(item).GetFirstChildOfType<ImageView>().Parent;
-
 			if (hasColor)
-				await navItemView.AssertContainsColor(expectedColor.ToPlatform(), item.FindMauiContext());
+			{
+				await AssertionExtensions.AssertTabItemIconContainsColor(GetTab(item),
+					item.Title, iconColor, MauiContext);
+			}
 			else
-				await navItemView.AssertDoesNotContainColor(expectedColor.ToPlatform(), item.FindMauiContext());
+			{
+				await AssertionExtensions.AssertTabItemIconDoesNotContainColor(GetTab(item),
+					item.Title, iconColor, MauiContext);
+			}
 		}
 
-		async Task ValidateTabBarTextColor(ShellSection item, Color expectedColor, bool hasColor)
+		async Task ValidateTabBarTextColor(
+				ShellSection item,
+				Color textColor,
+				bool hasColor)
 		{
-			var navItemView = (AView)GetTab(item).GetFirstChildOfType<TextView>().Parent;
-
 			if (hasColor)
-				await navItemView.AssertContainsColor(expectedColor.ToPlatform(), item.FindMauiContext());
+			{
+				await AssertionExtensions.AssertTabItemTextContainsColor(GetTab(item),
+					item.Title, textColor, MauiContext);
+			}
 			else
-				await navItemView.AssertDoesNotContainColor(expectedColor.ToPlatform(), item.FindMauiContext());
+			{
+				await AssertionExtensions.AssertTabItemTextDoesNotContainColor(GetTab(item),
+					item.Title, textColor, MauiContext);
+			}
 		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTabBarTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTabBarTests.Android.cs
@@ -12,6 +12,7 @@ using Microsoft.Maui.Controls.Handlers.Compatibility;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Platform;
 using Xunit;
+using AView = Android.Views.View;
 
 
 namespace Microsoft.Maui.DeviceTests
@@ -19,7 +20,7 @@ namespace Microsoft.Maui.DeviceTests
 	[Category(TestCategory.Shell)]
 	public partial class ShellTests
 	{
-		async Task ValidateTabBarItemColor(ShellSection item, Color expectedColor, bool hasColor)
+		BottomNavigationItemView GetTab(ShellSection item)
 		{
 			var shell = item.FindParentOfType<Shell>();
 			var renderer = (ShellRenderer)shell.Handler;
@@ -43,6 +44,23 @@ namespace Microsoft.Maui.DeviceTests
 						.Where(tv => String.Equals(tv.Text, item.Title, StringComparison.OrdinalIgnoreCase))
 						.Count() > 0;
 				});
+
+			return navItemView;
+		}
+
+		async Task ValidateTabBarIconColor(ShellSection item, Color expectedColor, bool hasColor)
+		{
+			var navItemView = (AView)GetTab(item).GetFirstChildOfType<ImageView>().Parent;
+
+			if (hasColor)
+				await navItemView.AssertContainsColor(expectedColor.ToPlatform(), item.FindMauiContext());
+			else
+				await navItemView.AssertDoesNotContainColor(expectedColor.ToPlatform(), item.FindMauiContext());
+		}
+
+		async Task ValidateTabBarTextColor(ShellSection item, Color expectedColor, bool hasColor)
+		{
+			var navItemView = (AView)GetTab(item).GetFirstChildOfType<TextView>().Parent;
 
 			if (hasColor)
 				await navItemView.AssertContainsColor(expectedColor.ToPlatform(), item.FindMauiContext());

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTabBarTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTabBarTests.Windows.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTabBarTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTabBarTests.Windows.cs
@@ -59,39 +59,46 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
-		List<WNavigationViewItem> GetTabBarItems(Shell shell)
+		NavigationView GetTabBarItems(ShellSection section)
 		{
-			var shellItemHandler = shell.CurrentItem.Handler as ShellItemHandler;
+			var shellItemHandler = section.FindParentOfType<Shell>().CurrentItem.Handler as ShellItemHandler;
 			var navView = shellItemHandler.PlatformView as MauiNavigationView;
 
-			return navView.TopNavArea.GetChildren<WNavigationViewItem>().ToList();
+			return navView;
 		}
 
-		async Task ValidateTabBarTextColor(ShellSection item, Color expectedColor, bool hasColor)
+		async Task ValidateTabBarIconColor(
+			ShellSection item,
+			Color iconColor,
+			bool hasColor)
 		{
-			var items = GetTabBarItems(item.FindParentOfType<Shell>());
-			var platformItem =
-				items.FirstOrDefault(x => x.Content.ToString().Equals(item.Title, StringComparison.OrdinalIgnoreCase))
-				.GetDescendantByName<UI.Xaml.Controls.Grid>("ContentGrid")
-				.GetDescendantByName<UI.Xaml.Controls.ContentPresenter>("ContentPresenter");
-
 			if (hasColor)
-				await AssertionExtensions.AssertContainsColor(platformItem, expectedColor, item.FindMauiContext());
+			{
+				await AssertionExtensions.AssertTabItemIconContainsColor(GetTabBarItems(item),
+					item.Title, iconColor, MauiContext);
+			}
 			else
-				await AssertionExtensions.AssertDoesNotContainColor(platformItem, expectedColor, item.FindMauiContext());
+			{
+				await AssertionExtensions.AssertTabItemIconDoesNotContainColor(GetTabBarItems(item),
+					item.Title, iconColor, MauiContext);
+			}
 		}
 
-		async Task ValidateTabBarIconColor(ShellSection item, Color expectedColor, bool hasColor)
+		async Task ValidateTabBarTextColor(
+				ShellSection item,
+				Color textColor,
+				bool hasColor)
 		{
-			var items = GetTabBarItems(item.FindParentOfType<Shell>());
-			var platformItem =
-				items.FirstOrDefault(x => x.Content.ToString().Equals(item.Title, StringComparison.OrdinalIgnoreCase))
-				.GetDescendantByName<UI.Xaml.Controls.ContentPresenter>("Icon");
-
 			if (hasColor)
-				await AssertionExtensions.AssertContainsColor(platformItem, expectedColor, item.FindMauiContext());
+			{
+				await AssertionExtensions.AssertTabItemTextContainsColor(GetTabBarItems(item),
+					item.Title, textColor, MauiContext);
+			}
 			else
-				await AssertionExtensions.AssertDoesNotContainColor(platformItem, expectedColor, item.FindMauiContext());
+			{
+				await AssertionExtensions.AssertTabItemTextDoesNotContainColor(GetTabBarItems(item),
+					item.Title, textColor, MauiContext);
+			}
 		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTabBarTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTabBarTests.Windows.cs
@@ -67,11 +67,26 @@ namespace Microsoft.Maui.DeviceTests
 			return navView.TopNavArea.GetChildren<WNavigationViewItem>().ToList();
 		}
 
-		async Task ValidateTabBarItemColor(ShellSection item, Color expectedColor, bool hasColor)
+		async Task ValidateTabBarTextColor(ShellSection item, Color expectedColor, bool hasColor)
 		{
 			var items = GetTabBarItems(item.FindParentOfType<Shell>());
 			var platformItem =
-				items.FirstOrDefault(x => x.Content.ToString().Equals(item.Title, StringComparison.OrdinalIgnoreCase));
+				items.FirstOrDefault(x => x.Content.ToString().Equals(item.Title, StringComparison.OrdinalIgnoreCase))
+				.GetDescendantByName<UI.Xaml.Controls.Grid>("ContentGrid")
+				.GetDescendantByName<UI.Xaml.Controls.ContentPresenter>("ContentPresenter");
+
+			if (hasColor)
+				await AssertionExtensions.AssertContainsColor(platformItem, expectedColor, item.FindMauiContext());
+			else
+				await AssertionExtensions.AssertDoesNotContainColor(platformItem, expectedColor, item.FindMauiContext());
+		}
+
+		async Task ValidateTabBarIconColor(ShellSection item, Color expectedColor, bool hasColor)
+		{
+			var items = GetTabBarItems(item.FindParentOfType<Shell>());
+			var platformItem =
+				items.FirstOrDefault(x => x.Content.ToString().Equals(item.Title, StringComparison.OrdinalIgnoreCase))
+				.GetDescendantByName<UI.Xaml.Controls.ContentPresenter>("Icon");
 
 			if (hasColor)
 				await AssertionExtensions.AssertContainsColor(platformItem, expectedColor, item.FindMauiContext());

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTabBarTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTabBarTests.Windows.cs
@@ -75,12 +75,12 @@ namespace Microsoft.Maui.DeviceTests
 			if (hasColor)
 			{
 				await AssertionExtensions.AssertTabItemIconContainsColor(GetTabBarItems(item),
-					item.Title, iconColor, MauiContext);
+					item.Title, iconColor, item.FindMauiContext());
 			}
 			else
 			{
 				await AssertionExtensions.AssertTabItemIconDoesNotContainColor(GetTabBarItems(item),
-					item.Title, iconColor, MauiContext);
+					item.Title, iconColor, item.FindMauiContext());
 			}
 		}
 
@@ -92,12 +92,12 @@ namespace Microsoft.Maui.DeviceTests
 			if (hasColor)
 			{
 				await AssertionExtensions.AssertTabItemTextContainsColor(GetTabBarItems(item),
-					item.Title, textColor, MauiContext);
+					item.Title, textColor, item.FindMauiContext());
 			}
 			else
 			{
 				await AssertionExtensions.AssertTabItemTextDoesNotContainColor(GetTabBarItems(item),
-					item.Title, textColor, MauiContext);
+					item.Title, textColor, item.FindMauiContext());
 			}
 		}
 	}

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTabBarTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTabBarTests.cs
@@ -19,7 +19,11 @@ namespace Microsoft.Maui.DeviceTests
 	public partial class ShellTests
 	{
 #if IOS || MACCATALYST || WINDOWS || ANDROID
-		[Fact(DisplayName = "ForegroundColor sets icon and title color sets title")]
+		[Fact(DisplayName = "ForegroundColor sets icon and title color sets title"
+#if IOS || MACCATALYST
+			, Skip = "On iOS if we set the TitleBar, is used instead the ForegroundColor."
+#endif
+			)]
 		public async Task ForegroundColorSetsIconAndTitleColorSetsTitle()
 		{
 			SetupBuilder();

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTabBarTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTabBarTests.cs
@@ -11,6 +11,8 @@ using Xunit;
 
 #if ANDROID || IOS || MACCATALYST
 using ShellHandler = Microsoft.Maui.Controls.Handlers.Compatibility.ShellRenderer;
+#elif WINDOWS
+using Microsoft.Maui.Controls.Handlers;
 #endif
 
 namespace Microsoft.Maui.DeviceTests

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTabBarTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTabBarTests.cs
@@ -4,9 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
-using Microsoft.Maui.Controls.Handlers;
 using Microsoft.Maui.Graphics;
-using Microsoft.Maui.Platform;
 using Xunit;
 
 #if ANDROID || IOS || MACCATALYST

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTabBarTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTabBarTests.cs
@@ -18,8 +18,7 @@ namespace Microsoft.Maui.DeviceTests
 	[Category(TestCategory.Shell)]
 	public partial class ShellTests
 	{
-#if ANDROID || WINDOWS
-
+#if IOS || MACCATALYST || WINDOWS || ANDROID
 		[Fact(DisplayName = "ForegroundColor sets icon and title color sets title")]
 		public async Task ForegroundColorSetsIconAndTitleColorSetsTitle()
 		{
@@ -38,7 +37,6 @@ namespace Microsoft.Maui.DeviceTests
 				await ValidateTabBarItemColor(shell.CurrentSection, foregroundColor, true);
 				await ValidateTabBarItemColor(shell.Items[0].Items[1], titleColor, false);
 				await ValidateTabBarItemColor(shell.Items[0].Items[1], foregroundColor, false);
-
 			});
 		}
 

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTabBarTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTabBarTests.cs
@@ -18,12 +18,7 @@ namespace Microsoft.Maui.DeviceTests
 	[Category(TestCategory.Shell)]
 	public partial class ShellTests
 	{
-#if IOS || MACCATALYST || WINDOWS || ANDROID
-		[Fact(DisplayName = "ForegroundColor sets icon and title color sets title"
-#if IOS || MACCATALYST
-			, Skip = "On iOS if we set the TitleBar, is used instead the ForegroundColor."
-#endif
-			)]
+		[Fact(DisplayName = "ForegroundColor sets icon and title color sets title")]
 		public async Task ForegroundColorSetsIconAndTitleColorSetsTitle()
 		{
 			SetupBuilder();
@@ -37,10 +32,11 @@ namespace Microsoft.Maui.DeviceTests
 			},
 			async (shell) =>
 			{
-				await ValidateTabBarItemColor(shell.CurrentSection, titleColor, true);
-				await ValidateTabBarItemColor(shell.CurrentSection, foregroundColor, true);
-				await ValidateTabBarItemColor(shell.Items[0].Items[1], titleColor, false);
-				await ValidateTabBarItemColor(shell.Items[0].Items[1], foregroundColor, false);
+				await ValidateTabBarIconColor(shell.CurrentSection, foregroundColor, true);
+				await ValidateTabBarTextColor(shell.CurrentSection, titleColor, true);
+
+				await ValidateTabBarIconColor(shell.Items[0].Items[1], titleColor, false);
+				await ValidateTabBarTextColor(shell.Items[0].Items[1], foregroundColor, false);
 			});
 		}
 
@@ -56,8 +52,10 @@ namespace Microsoft.Maui.DeviceTests
 			await RunShellTabBarTests(shell => Shell.SetTabBarTitleColor(shell, expectedColor),
 				async (shell) =>
 				{
-					await ValidateTabBarItemColor(shell.CurrentSection, expectedColor, true);
-					await ValidateTabBarItemColor(shell.Items[0].Items[1], expectedColor, false);
+					await ValidateTabBarTextColor(shell.CurrentSection, expectedColor, true);
+					await ValidateTabBarIconColor(shell.CurrentSection, expectedColor, true);
+					await ValidateTabBarTextColor(shell.Items[0].Items[1], expectedColor, false);
+					await ValidateTabBarIconColor(shell.Items[0].Items[1], expectedColor, false);
 				});
 		}
 
@@ -70,22 +68,26 @@ namespace Microsoft.Maui.DeviceTests
 			await RunShellTabBarTests(shell => Shell.SetTabBarForegroundColor(shell, expectedColor),
 				async (shell) =>
 				{
-					await ValidateTabBarItemColor(shell.CurrentSection, expectedColor, true);
-					await ValidateTabBarItemColor(shell.Items[0].Items[1], expectedColor, false);
+					await ValidateTabBarTextColor(shell.CurrentSection, expectedColor, true);
+					await ValidateTabBarIconColor(shell.CurrentSection, expectedColor, true);
+					await ValidateTabBarTextColor(shell.Items[0].Items[1], expectedColor, false);
+					await ValidateTabBarIconColor(shell.Items[0].Items[1], expectedColor, false);
 				});
 		}
 
 		[Theory(DisplayName = "Shell TabBar UnselectedColor Initializes Correctly")]
 		[InlineData("#FF0000")]
-		[InlineData("#0000FF")]
+		[InlineData("#00FF00")]
 		public async Task ShellTabBarUnselectedColorInitializesCorrectly(string colorHex)
 		{
 			var expectedColor = Color.FromArgb(colorHex);
 			await RunShellTabBarTests(shell => Shell.SetTabBarUnselectedColor(shell, expectedColor),
 				async (shell) =>
 				{
-					await ValidateTabBarItemColor(shell.CurrentSection, expectedColor, false);
-					await ValidateTabBarItemColor(shell.Items[0].Items[1], expectedColor, true);
+					await ValidateTabBarTextColor(shell.CurrentSection, expectedColor, false);
+					await ValidateTabBarIconColor(shell.CurrentSection, expectedColor, false);
+					await ValidateTabBarTextColor(shell.Items[0].Items[1], expectedColor, true);
+					await ValidateTabBarIconColor(shell.Items[0].Items[1], expectedColor, true);
 				});
 		}
 
@@ -127,6 +129,5 @@ namespace Microsoft.Maui.DeviceTests
 				await runTest(shell);
 			});
 		}
-#endif
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTabBarTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTabBarTests.iOS.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Maui.DeviceTests
 				.PlatformView.FindParent(x => x.NextResponder is UITabBarController);
 
 			var tabBar = pagerParent.Subviews.FirstOrDefault(v => v.GetType() == typeof(UITabBar)) as UITabBar;
-	
+
 			Assert.NotNull(tabBar);
 
 			var tabBarItem = tabBar.Items.Single(t => string.Equals(t.Title, item.Title, StringComparison.OrdinalIgnoreCase));
@@ -29,7 +29,8 @@ namespace Microsoft.Maui.DeviceTests
 
 			Assert.NotNull(tabBarItemView);
 
-			await tabBar.AssertContainsColor(expectedColor, MauiContext);
+			if (hasColor)
+				await tabBar.AssertContainsColor(expectedColor, MauiContext);
 		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTabBarTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTabBarTests.iOS.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Platform.Compatibility;
+using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Platform;
+using UIKit;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	[Category(TestCategory.Shell)]
+	public partial class ShellTests
+	{
+		Task ValidateTabBarItemColor(ShellSection item, Color expectedColor, bool hasColor)
+		{
+			var shellItem = item.Parent as ShellItem;
+			var shell = shellItem.Parent as Shell;
+
+			var pagerParent = (shell.CurrentPage.Handler as IPlatformViewHandler)
+				.PlatformView.FindParent(x => x.NextResponder is UITabBarController);
+
+			var tabBar = pagerParent.Subviews.FirstOrDefault(v => v.GetType() == typeof(UITabBar)) as UITabBar;
+	
+			Assert.NotNull(tabBar);
+
+			var tabBarItem = tabBar.Items.Single(t => string.Equals(t.Title, item.Title, StringComparison.OrdinalIgnoreCase));
+			var tabBarItemView = tabBarItem.ValueForKey(new Foundation.NSString("view")) as UIView;
+
+			Assert.NotNull(tabBarItemView);
+
+			// TODO: Validate UITabBarItem color
+			//await tabBarItemView.AssertContainsColor(expectedColor, MauiContext);
+
+			return Task.CompletedTask;
+		}
+	}
+}

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTabBarTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTabBarTests.iOS.cs
@@ -2,7 +2,6 @@
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
-using Microsoft.Maui.Controls.Platform.Compatibility;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Platform;
 using UIKit;
@@ -13,7 +12,7 @@ namespace Microsoft.Maui.DeviceTests
 	[Category(TestCategory.Shell)]
 	public partial class ShellTests
 	{
-		Task ValidateTabBarItemColor(ShellSection item, Color expectedColor, bool hasColor)
+		async Task ValidateTabBarItemColor(ShellSection item, Color expectedColor, bool hasColor)
 		{
 			var shellItem = item.Parent as ShellItem;
 			var shell = shellItem.Parent as Shell;
@@ -30,10 +29,7 @@ namespace Microsoft.Maui.DeviceTests
 
 			Assert.NotNull(tabBarItemView);
 
-			// TODO: Validate UITabBarItem color
-			//await tabBarItemView.AssertContainsColor(expectedColor, MauiContext);
-
-			return Task.CompletedTask;
+			await tabBar.AssertContainsColor(expectedColor, MauiContext);
 		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTabBarTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTabBarTests.iOS.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Maui.DeviceTests
 	[Category(TestCategory.Shell)]
 	public partial class ShellTests
 	{
-		async Task ValidateTabBarItemColor(ShellSection item, Color expectedColor, bool hasColor)
+		UIView GetTabItemView(ShellSection item)
 		{
 			var shellItem = item.Parent as ShellItem;
 			var shell = shellItem.Parent as Shell;
@@ -26,11 +26,46 @@ namespace Microsoft.Maui.DeviceTests
 
 			var tabBarItem = tabBar.Items.Single(t => string.Equals(t.Title, item.Title, StringComparison.OrdinalIgnoreCase));
 			var tabBarItemView = tabBarItem.ValueForKey(new Foundation.NSString("view")) as UIView;
+			return tabBarItemView;
+		}
 
+		async Task ValidateTabBarIconColor(
+			ShellSection item,
+			Color iconColor,
+			bool hasColor)
+		{
+			var tabBarItemView = GetTabItemView(item);
 			Assert.NotNull(tabBarItemView);
 
 			if (hasColor)
-				await tabBar.AssertContainsColor(expectedColor, MauiContext);
+			{
+				await tabBarItemView.FindDescendantView<UIImageView>().AssertContainsColor(iconColor, MauiContext);
+			}
+			else
+			{
+				await tabBarItemView.FindDescendantView<UIImageView>()
+					.AssertDoesNotContainColor(iconColor, MauiContext);
+			}
+		}
+
+		async Task ValidateTabBarTextColor(
+				ShellSection item,
+				Color textColor,
+				bool hasColor)
+		{
+			var tabBarItemView = GetTabItemView(item);
+			Assert.NotNull(tabBarItemView);
+
+			if (hasColor)
+			{
+				await tabBarItemView.FindDescendantView<UILabel>()
+					.AssertContainsColor(textColor, MauiContext, 0.1);
+			}
+			else
+			{
+				await tabBarItemView.FindDescendantView<UILabel>()
+					.AssertDoesNotContainColor(textColor, MauiContext);
+			}
 		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTabBarTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTabBarTests.iOS.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Maui.DeviceTests
 	[Category(TestCategory.Shell)]
 	public partial class ShellTests
 	{
-		UIView GetTabItemView(ShellSection item)
+		UITabBar GetTabBar(ShellSection item)
 		{
 			var shellItem = item.Parent as ShellItem;
 			var shell = shellItem.Parent as Shell;
@@ -20,13 +20,7 @@ namespace Microsoft.Maui.DeviceTests
 			var pagerParent = (shell.CurrentPage.Handler as IPlatformViewHandler)
 				.PlatformView.FindParent(x => x.NextResponder is UITabBarController);
 
-			var tabBar = pagerParent.Subviews.FirstOrDefault(v => v.GetType() == typeof(UITabBar)) as UITabBar;
-
-			Assert.NotNull(tabBar);
-
-			var tabBarItem = tabBar.Items.Single(t => string.Equals(t.Title, item.Title, StringComparison.OrdinalIgnoreCase));
-			var tabBarItemView = tabBarItem.ValueForKey(new Foundation.NSString("view")) as UIView;
-			return tabBarItemView;
+			return pagerParent.Subviews.FirstOrDefault(v => v.GetType() == typeof(UITabBar)) as UITabBar;
 		}
 
 		async Task ValidateTabBarIconColor(
@@ -34,17 +28,15 @@ namespace Microsoft.Maui.DeviceTests
 			Color iconColor,
 			bool hasColor)
 		{
-			var tabBarItemView = GetTabItemView(item);
-			Assert.NotNull(tabBarItemView);
-
 			if (hasColor)
 			{
-				await tabBarItemView.FindDescendantView<UIImageView>().AssertContainsColor(iconColor, MauiContext);
+				await AssertionExtensions.AssertTabItemIconContainsColor(GetTabBar(item),
+					item.Title, iconColor, MauiContext);
 			}
 			else
 			{
-				await tabBarItemView.FindDescendantView<UIImageView>()
-					.AssertDoesNotContainColor(iconColor, MauiContext);
+				await AssertionExtensions.AssertTabItemIconDoesNotContainColor(GetTabBar(item),
+					item.Title, iconColor, MauiContext);
 			}
 		}
 
@@ -53,18 +45,15 @@ namespace Microsoft.Maui.DeviceTests
 				Color textColor,
 				bool hasColor)
 		{
-			var tabBarItemView = GetTabItemView(item);
-			Assert.NotNull(tabBarItemView);
-
 			if (hasColor)
 			{
-				await tabBarItemView.FindDescendantView<UILabel>()
-					.AssertContainsColor(textColor, MauiContext, 0.1);
+				await AssertionExtensions.AssertTabItemTextContainsColor(GetTabBar(item),
+					item.Title, textColor, MauiContext);
 			}
 			else
 			{
-				await tabBarItemView.FindDescendantView<UILabel>()
-					.AssertDoesNotContainColor(textColor, MauiContext);
+				await AssertionExtensions.AssertTabItemTextDoesNotContainColor(GetTabBar(item),
+					item.Title, textColor, MauiContext);
 			}
 		}
 	}

--- a/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.Android.cs
@@ -111,12 +111,52 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
-		BottomNavigationView GetBottomNavigationView(TabbedViewHandler tabViewHandler)
+		BottomNavigationView GetBottomNavigationView(IPlatformViewHandler tabViewHandler)
 		{
 			var layout = tabViewHandler.PlatformView.FindParent((view) => view is CoordinatorLayout)
 				as CoordinatorLayout;
 
 			return layout.GetFirstChildOfType<BottomNavigationView>();
+		}
+
+		async Task ValidateTabBarIconColor(
+			TabbedPage tabbedPage,
+			string tabText,
+			Color iconColor,
+			bool hasColor)
+		{
+			if (hasColor)
+			{
+				await AssertionExtensions.AssertTabItemIconContainsColor(
+					GetBottomNavigationView((tabbedPage.Handler as IPlatformViewHandler)),
+					tabText, iconColor, MauiContext);
+			}
+			else
+			{
+				await AssertionExtensions.AssertTabItemIconDoesNotContainColor(
+					GetBottomNavigationView((tabbedPage.Handler as IPlatformViewHandler)),
+					tabText, iconColor, MauiContext);
+			}
+		}
+
+		async Task ValidateTabBarTextColor(
+			TabbedPage tabbedPage,
+			string tabText,
+			Color iconColor,
+			bool hasColor)
+		{
+			if (hasColor)
+			{
+				await AssertionExtensions.AssertTabItemTextContainsColor(
+					GetBottomNavigationView((tabbedPage.Handler as IPlatformViewHandler)),
+					tabText, iconColor, MauiContext);
+			}
+			else
+			{
+				await AssertionExtensions.AssertTabItemTextDoesNotContainColor(
+					GetBottomNavigationView((tabbedPage.Handler as IPlatformViewHandler)),
+					tabText, iconColor, MauiContext);
+			}
 		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.Windows.cs
@@ -151,6 +151,12 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
+		MauiNavigationView GetMauiNavigationView(TabbedPage tabbedPage)
+		{
+			return (tabbedPage.Handler as IPlatformViewHandler)
+				.PlatformView
+				.GetParentOfType<MauiNavigationView>();
+		}
 
 		async Task ValidateTabBarIconColor(
 			TabbedPage tabbedPage,
@@ -161,14 +167,14 @@ namespace Microsoft.Maui.DeviceTests
 			if (hasColor)
 			{
 				await AssertionExtensions.AssertTabItemIconContainsColor(
-					GetMauiNavigationView(MauiContext),
-					tabText, iconColor, MauiContext);
+					GetMauiNavigationView(tabbedPage),
+					tabText, iconColor, tabbedPage.FindMauiContext());
 			}
 			else
 			{
 				await AssertionExtensions.AssertTabItemIconDoesNotContainColor(
-					GetMauiNavigationView(MauiContext),
-					tabText, iconColor, MauiContext);
+					GetMauiNavigationView(tabbedPage),
+					tabText, iconColor, tabbedPage.FindMauiContext());
 			}
 		}
 
@@ -181,14 +187,14 @@ namespace Microsoft.Maui.DeviceTests
 			if (hasColor)
 			{
 				await AssertionExtensions.AssertTabItemTextContainsColor(
-					GetMauiNavigationView(MauiContext),
-					tabText, iconColor, MauiContext);
+					GetMauiNavigationView(tabbedPage),
+					tabText, iconColor, tabbedPage.FindMauiContext());
 			}
 			else
 			{
 				await AssertionExtensions.AssertTabItemTextDoesNotContainColor(
-					GetMauiNavigationView(MauiContext),
-					tabText, iconColor, MauiContext);
+					GetMauiNavigationView(tabbedPage),
+					tabText, iconColor, tabbedPage.FindMauiContext());
 			}
 		}
 	}

--- a/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.Windows.cs
@@ -66,22 +66,6 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
-		[Fact(DisplayName = "BarBackground Color")]
-		public async Task BarBackgroundColor()
-		{
-			SetupBuilder();
-			var tabbedPage = CreateBasicTabbedPage();
-			tabbedPage.BarBackground = SolidColorBrush.Purple;
-
-			await CreateHandlerAndAddToWindow<WindowHandlerStub>(new Window(tabbedPage), (handler) =>
-			{
-				var navView = GetMauiNavigationView(tabbedPage.Handler.MauiContext);
-				var platformBrush = (WSolidColorBrush)((Paint)tabbedPage.BarBackground).ToPlatform();
-				Assert.Equal(platformBrush.Color, ((WSolidColorBrush)navView.TopNavArea.Background).Color);
-				return Task.CompletedTask;
-			});
-		}
-
 		[Fact(DisplayName = "Swapping Root Window Content for New Tabbed Page")]
 		public async Task SwapWindowContentForNewTabbedPage()
 		{
@@ -107,26 +91,6 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
-
-		[Fact(DisplayName = "Bar Text Color")]
-		public async Task BarTextColor()
-		{
-			SetupBuilder();
-			var tabbedPage = CreateBasicTabbedPage();
-			tabbedPage.BarTextColor = Colors.Red;
-			await CreateHandlerAndAddToWindow<TabbedViewHandler>(tabbedPage, handler =>
-			{
-				var navView = GetMauiNavigationView(handler.MauiContext);
-				var navItem = GetNavigationViewItems(navView).ToList()[0];
-
-				Assert.Equal(Colors.Red, ((WSolidColorBrush)navItem.Foreground).ToColor());
-				tabbedPage.BarTextColor = Colors.Blue;
-				Assert.Equal(Colors.Blue, ((WSolidColorBrush)navItem.Foreground).ToColor());
-
-				return Task.CompletedTask;
-			});
-		}
-
 		[Fact(DisplayName = "Tab Title")]
 		public async Task TabTitle()
 		{
@@ -138,34 +102,6 @@ namespace Microsoft.Maui.DeviceTests
 				Assert.Equal("Page 1", navItem.Content);
 				(handler.VirtualView as TabbedPage).Children[0].Title = "New Page Name";
 				Assert.Equal("New Page Name", navItem.Content);
-				return Task.CompletedTask;
-			});
-		}
-
-		[Fact(DisplayName = "Selected/Unselected Color")]
-		public async Task SelectedAndUnselectedTabColor()
-		{
-			SetupBuilder();
-			var tabbedPage = CreateBasicTabbedPage();
-			tabbedPage.Children.Add(new ContentPage() { Title = "Page 2" });
-
-			tabbedPage.SelectedTabColor = Colors.Red;
-			tabbedPage.UnselectedTabColor = Colors.Purple;
-
-			await CreateHandlerAndAddToWindow<TabbedViewHandler>(tabbedPage, handler =>
-			{
-				var navView = GetMauiNavigationView(handler.MauiContext);
-				var navItem1 = GetNavigationViewItems(navView).ToList()[0];
-				var navItem2 = GetNavigationViewItems(navView).ToList()[1];
-
-				Assert.Equal(Colors.Red, ((WSolidColorBrush)navItem1.Background).ToColor());
-				Assert.Equal(Colors.Purple, ((WSolidColorBrush)navItem2.Background).ToColor());
-
-				tabbedPage.CurrentPage = tabbedPage.Children[1];
-
-				Assert.Equal(Colors.Purple, ((WSolidColorBrush)navItem1.Background).ToColor());
-				Assert.Equal(Colors.Red, ((WSolidColorBrush)navItem2.Background).ToColor());
-
 				return Task.CompletedTask;
 			});
 		}
@@ -213,6 +149,47 @@ namespace Microsoft.Maui.DeviceTests
 				Assert.Equal(tabbedPage.CurrentPage, tabbedPage.Children[1]);
 				return Task.CompletedTask;
 			});
+		}
+
+
+		async Task ValidateTabBarIconColor(
+			TabbedPage tabbedPage,
+			string tabText,
+			Color iconColor,
+			bool hasColor)
+		{
+			if (hasColor)
+			{
+				await AssertionExtensions.AssertTabItemIconContainsColor(
+					GetMauiNavigationView(MauiContext),
+					tabText, iconColor, MauiContext);
+			}
+			else
+			{
+				await AssertionExtensions.AssertTabItemIconDoesNotContainColor(
+					GetMauiNavigationView(MauiContext),
+					tabText, iconColor, MauiContext);
+			}
+		}
+
+		async Task ValidateTabBarTextColor(
+			TabbedPage tabbedPage,
+			string tabText,
+			Color iconColor,
+			bool hasColor)
+		{
+			if (hasColor)
+			{
+				await AssertionExtensions.AssertTabItemTextContainsColor(
+					GetMauiNavigationView(MauiContext),
+					tabText, iconColor, MauiContext);
+			}
+			else
+			{
+				await AssertionExtensions.AssertTabItemTextDoesNotContainColor(
+					GetMauiNavigationView(MauiContext),
+					tabText, iconColor, MauiContext);
+			}
 		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.cs
@@ -47,6 +47,62 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
+
+#if WINDOWS
+		[Fact(DisplayName = "BarBackground Color")]
+		public async Task BarBackgroundColor()
+		{
+			SetupBuilder();
+			var tabbedPage = CreateBasicTabbedPage();
+			tabbedPage.BarBackground = SolidColorBrush.Purple;
+
+			await CreateHandlerAndAddToWindow<WindowHandlerStub>(new Window(tabbedPage), (handler) =>
+			{
+				var navView = GetMauiNavigationView(tabbedPage.Handler.MauiContext);
+				var platformBrush = (WSolidColorBrush)((Paint)tabbedPage.BarBackground).ToPlatform();
+				Assert.Equal(platformBrush.Color, ((WSolidColorBrush)navView.TopNavArea.Background).Color);
+				return Task.CompletedTask;
+			});
+		}
+#endif
+
+
+		[Fact(DisplayName = "Bar Text Color")]
+		public async Task BarTextColor()
+		{
+			SetupBuilder();
+			var tabbedPage = CreateBasicTabbedPage();
+			tabbedPage.BarTextColor = Colors.Red;
+			await CreateHandlerAndAddToWindow<TabbedViewHandler>(tabbedPage, async handler =>
+			{
+				await ValidateTabBarTextColor(tabbedPage, tabbedPage.Children[0].Title, Colors.Red, true);
+				tabbedPage.BarTextColor = Colors.Blue;
+				await ValidateTabBarTextColor(tabbedPage, tabbedPage.Children[0].Title, Colors.Blue, true);
+			});
+		}
+
+		[Fact(DisplayName = "Selected/Unselected Color")]
+		public async Task SelectedAndUnselectedTabColor()
+		{
+			SetupBuilder();
+			var tabbedPage = CreateBasicTabbedPage();
+			tabbedPage.Children.Add(new ContentPage() { Title = "Page 2" });
+
+			tabbedPage.SelectedTabColor = Colors.Red;
+			tabbedPage.UnselectedTabColor = Colors.Purple;
+
+			await CreateHandlerAndAddToWindow<TabbedViewHandler>(tabbedPage, async handler =>
+			{
+				await ValidateTabBarTextColor(tabbedPage, tabbedPage.Children[0].Title, Colors.Red, true);
+				await ValidateTabBarTextColor(tabbedPage, tabbedPage.Children[1].Title, Colors.Purple, true);
+
+				tabbedPage.CurrentPage = tabbedPage.Children[1];
+
+				await ValidateTabBarTextColor(tabbedPage, tabbedPage.Children[0].Title, Colors.Purple, true);
+				await ValidateTabBarTextColor(tabbedPage, tabbedPage.Children[1].Title, Colors.Red, true);
+			});
+		}
+
 #if !IOS && !MACCATALYST
 		// iOS currently can't handle recreating a handler if it's disconnecting
 		// This is left over behavior from Forms and will be fixed by a different PR

--- a/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Maui.DeviceTests
 		public async Task BarBackgroundColor()
 		{
 			SetupBuilder();
-			var tabbedPage = CreateBasicTabbedPage();
+			var tabbedPage = CreateBasicTabbedPage(true);
 			tabbedPage.BarBackground = SolidColorBrush.Purple;
 
 			await CreateHandlerAndAddToWindow<WindowHandlerStub>(new Window(tabbedPage), (handler) =>
@@ -71,7 +71,7 @@ namespace Microsoft.Maui.DeviceTests
 		public async Task BarTextColor()
 		{
 			SetupBuilder();
-			var tabbedPage = CreateBasicTabbedPage();
+			var tabbedPage = CreateBasicTabbedPage(true);
 			tabbedPage.BarTextColor = Colors.Red;
 			await CreateHandlerAndAddToWindow<TabbedViewHandler>(tabbedPage, async handler =>
 			{
@@ -85,7 +85,7 @@ namespace Microsoft.Maui.DeviceTests
 		public async Task SelectedAndUnselectedTabColor()
 		{
 			SetupBuilder();
-			var tabbedPage = CreateBasicTabbedPage();
+			var tabbedPage = CreateBasicTabbedPage(true);
 			tabbedPage.Children.Add(new ContentPage() { Title = "Page 2" });
 
 			tabbedPage.SelectedTabColor = Colors.Red;

--- a/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.cs
@@ -15,6 +15,9 @@ using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Hosting;
 using Microsoft.Maui.Platform;
 using Xunit;
+#if IOS
+using TabbedViewHandler = Microsoft.Maui.Controls.Handlers.Compatibility.TabbedRenderer;
+#endif
 
 namespace Microsoft.Maui.DeviceTests
 {

--- a/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.cs
@@ -18,6 +18,9 @@ using Xunit;
 #if IOS
 using TabbedViewHandler = Microsoft.Maui.Controls.Handlers.Compatibility.TabbedRenderer;
 #endif
+#if WINDOWS
+using WSolidColorBrush = Microsoft.UI.Xaml.Media.SolidColorBrush;
+#endif
 
 namespace Microsoft.Maui.DeviceTests
 {

--- a/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.iOS.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Platform;
+using UIKit;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	[Category(TestCategory.TabbedPage)]
+	public partial class TabbedPageTests
+	{
+		UITabBar GetTabBar(TabbedPage tabbedPage)
+		{
+			var pagerParent = (tabbedPage.CurrentPage.Handler as IPlatformViewHandler)
+				.PlatformView.FindParent(x => x.NextResponder is UITabBarController);
+
+			return pagerParent.Subviews.FirstOrDefault(v => v.GetType() == typeof(UITabBar)) as UITabBar;
+		}
+
+		async Task ValidateTabBarIconColor(
+			TabbedPage tabbedPage,
+			string tabText,
+			Color iconColor,
+			bool hasColor)
+		{
+			if (hasColor)
+			{
+				await AssertionExtensions.AssertTabItemIconContainsColor(
+					GetTabBar(tabbedPage),
+					tabText, iconColor, MauiContext);
+			}
+			else
+			{
+				await AssertionExtensions.AssertTabItemIconDoesNotContainColor(
+					GetTabBar(tabbedPage),
+					tabText, iconColor, MauiContext);
+			}
+		}
+
+		async Task ValidateTabBarTextColor(
+			TabbedPage tabbedPage,
+			string tabText,
+			Color iconColor,
+			bool hasColor)
+		{
+			if (hasColor)
+			{
+				await AssertionExtensions.AssertTabItemTextContainsColor(
+					GetTabBar(tabbedPage),
+					tabText, iconColor, MauiContext);
+			}
+			else
+			{
+				await AssertionExtensions.AssertTabItemTextDoesNotContainColor(
+					GetTabBar(tabbedPage),
+					tabText, iconColor, MauiContext);
+			}
+		}
+	}
+}

--- a/src/Core/src/Platform/iOS/TabbedViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/TabbedViewExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using Foundation;
 using Microsoft.Maui.Graphics;
 using UIKit;
 
@@ -18,7 +19,8 @@ namespace Microsoft.Maui.Platform
 			Color? selectedTabColor,
 			Color? unselectedTabColor,
 			Color? barBackgroundColor,
-			Color? barTextColor)
+			Color? selectedBarTextColor,
+			Color? unSelectedBarTextColor)
 		{
 			if (_tabBarAppearance == null)
 			{
@@ -35,67 +37,66 @@ namespace Microsoft.Maui.Platform
 
 			// Set BarTextColor
 
-			var effectiveBarTextColor = (barTextColor == null) ? defaultBarTextColor : barTextColor.ToPlatform();
-			if (effectiveBarTextColor != null)
-			{
-				_tabBarAppearance.StackedLayoutAppearance.Normal.TitleTextAttributes = new UIStringAttributes
-				{
-					ForegroundColor = effectiveBarTextColor
-				};
-			}
+			var effectiveSelectedBarTextColor = (selectedBarTextColor == null) ? defaultBarTextColor : selectedBarTextColor.ToPlatform();
+			var effectiveUnselectedBarTextColor = (unSelectedBarTextColor == null) ? defaultBarTextColor : unSelectedBarTextColor.ToPlatform();
 
 			// Update colors for all variations of the appearance to also make it work for iPads, etc. which use different layouts for the tabbar
 			// Also, set ParagraphStyle explicitly. This seems to be an iOS bug. If we don't do this, tab titles will be truncat...
 
 			// Set SelectedTabColor
-			if (selectedTabColor != null)
+			if (selectedTabColor is not null)
 			{
 				var foregroundColor = selectedTabColor.ToPlatform();
-				_tabBarAppearance.StackedLayoutAppearance.Selected.TitleTextAttributes = new UIStringAttributes { ForegroundColor = foregroundColor, ParagraphStyle = NSParagraphStyle.Default };
+				var titleColor = effectiveSelectedBarTextColor ?? foregroundColor;
+
+				_tabBarAppearance.StackedLayoutAppearance.Selected.TitleTextAttributes = new UIStringAttributes { ForegroundColor = titleColor, ParagraphStyle = NSParagraphStyle.Default };
 				_tabBarAppearance.StackedLayoutAppearance.Selected.IconColor = foregroundColor;
 
-				_tabBarAppearance.InlineLayoutAppearance.Selected.TitleTextAttributes = new UIStringAttributes { ForegroundColor = foregroundColor, ParagraphStyle = NSParagraphStyle.Default };
+				_tabBarAppearance.InlineLayoutAppearance.Selected.TitleTextAttributes = new UIStringAttributes { ForegroundColor = titleColor, ParagraphStyle = NSParagraphStyle.Default };
 				_tabBarAppearance.InlineLayoutAppearance.Selected.IconColor = foregroundColor;
 
-				_tabBarAppearance.CompactInlineLayoutAppearance.Selected.TitleTextAttributes = new UIStringAttributes { ForegroundColor = foregroundColor, ParagraphStyle = NSParagraphStyle.Default };
+				_tabBarAppearance.CompactInlineLayoutAppearance.Selected.TitleTextAttributes = new UIStringAttributes { ForegroundColor = titleColor, ParagraphStyle = NSParagraphStyle.Default };
 				_tabBarAppearance.CompactInlineLayoutAppearance.Selected.IconColor = foregroundColor;
 			}
 			else
 			{
 				var foregroundColor = UITabBar.Appearance.TintColor;
-				_tabBarAppearance.StackedLayoutAppearance.Selected.TitleTextAttributes = new UIStringAttributes { ForegroundColor = foregroundColor, ParagraphStyle = NSParagraphStyle.Default };
+				var titleColor = effectiveSelectedBarTextColor ?? foregroundColor;
+				_tabBarAppearance.StackedLayoutAppearance.Selected.TitleTextAttributes = new UIStringAttributes { ForegroundColor = titleColor, ParagraphStyle = NSParagraphStyle.Default };
 				_tabBarAppearance.StackedLayoutAppearance.Selected.IconColor = foregroundColor;
 
-				_tabBarAppearance.InlineLayoutAppearance.Selected.TitleTextAttributes = new UIStringAttributes { ForegroundColor = foregroundColor, ParagraphStyle = NSParagraphStyle.Default };
+				_tabBarAppearance.InlineLayoutAppearance.Selected.TitleTextAttributes = new UIStringAttributes { ForegroundColor = titleColor, ParagraphStyle = NSParagraphStyle.Default };
 				_tabBarAppearance.InlineLayoutAppearance.Selected.IconColor = foregroundColor;
 
-				_tabBarAppearance.CompactInlineLayoutAppearance.Selected.TitleTextAttributes = new UIStringAttributes { ForegroundColor = foregroundColor, ParagraphStyle = NSParagraphStyle.Default };
+				_tabBarAppearance.CompactInlineLayoutAppearance.Selected.TitleTextAttributes = new UIStringAttributes { ForegroundColor = titleColor, ParagraphStyle = NSParagraphStyle.Default };
 				_tabBarAppearance.CompactInlineLayoutAppearance.Selected.IconColor = foregroundColor;
 			}
 
 			// Set UnselectedTabColor
-			if (unselectedTabColor != null)
+			if (unselectedTabColor is not null)
 			{
 				var foregroundColor = unselectedTabColor.ToPlatform();
-				_tabBarAppearance.StackedLayoutAppearance.Normal.TitleTextAttributes = new UIStringAttributes { ForegroundColor = foregroundColor, ParagraphStyle = NSParagraphStyle.Default };
+				var titleColor = effectiveUnselectedBarTextColor ?? foregroundColor;
+				_tabBarAppearance.StackedLayoutAppearance.Normal.TitleTextAttributes = new UIStringAttributes { ForegroundColor = titleColor, ParagraphStyle = NSParagraphStyle.Default };
 				_tabBarAppearance.StackedLayoutAppearance.Normal.IconColor = foregroundColor;
 
-				_tabBarAppearance.InlineLayoutAppearance.Normal.TitleTextAttributes = new UIStringAttributes { ForegroundColor = foregroundColor, ParagraphStyle = NSParagraphStyle.Default };
+				_tabBarAppearance.InlineLayoutAppearance.Normal.TitleTextAttributes = new UIStringAttributes { ForegroundColor = titleColor, ParagraphStyle = NSParagraphStyle.Default };
 				_tabBarAppearance.InlineLayoutAppearance.Normal.IconColor = foregroundColor;
 
-				_tabBarAppearance.CompactInlineLayoutAppearance.Normal.TitleTextAttributes = new UIStringAttributes { ForegroundColor = foregroundColor, ParagraphStyle = NSParagraphStyle.Default };
+				_tabBarAppearance.CompactInlineLayoutAppearance.Normal.TitleTextAttributes = new UIStringAttributes { ForegroundColor = titleColor, ParagraphStyle = NSParagraphStyle.Default };
 				_tabBarAppearance.CompactInlineLayoutAppearance.Normal.IconColor = foregroundColor;
 			}
 			else
 			{
 				var foreground = UITabBar.Appearance.TintColor;
-				_tabBarAppearance.StackedLayoutAppearance.Normal.TitleTextAttributes = new UIStringAttributes { ForegroundColor = foreground, ParagraphStyle = NSParagraphStyle.Default };
+				var titleColor = effectiveUnselectedBarTextColor ?? foreground;
+				_tabBarAppearance.StackedLayoutAppearance.Normal.TitleTextAttributes = new UIStringAttributes { ForegroundColor = titleColor, ParagraphStyle = NSParagraphStyle.Default };
 				_tabBarAppearance.StackedLayoutAppearance.Normal.IconColor = foreground;
 
-				_tabBarAppearance.InlineLayoutAppearance.Normal.TitleTextAttributes = new UIStringAttributes { ForegroundColor = foreground, ParagraphStyle = NSParagraphStyle.Default };
+				_tabBarAppearance.InlineLayoutAppearance.Normal.TitleTextAttributes = new UIStringAttributes { ForegroundColor = titleColor, ParagraphStyle = NSParagraphStyle.Default };
 				_tabBarAppearance.InlineLayoutAppearance.Normal.IconColor = foreground;
 
-				_tabBarAppearance.CompactInlineLayoutAppearance.Normal.TitleTextAttributes = new UIStringAttributes { ForegroundColor = foreground, ParagraphStyle = NSParagraphStyle.Default };
+				_tabBarAppearance.CompactInlineLayoutAppearance.Normal.TitleTextAttributes = new UIStringAttributes { ForegroundColor = titleColor, ParagraphStyle = NSParagraphStyle.Default };
 				_tabBarAppearance.CompactInlineLayoutAppearance.Normal.IconColor = foreground;
 			}
 

--- a/src/TestUtils/src/DeviceTests/AssertionExtensions.Android.cs
+++ b/src/TestUtils/src/DeviceTests/AssertionExtensions.Android.cs
@@ -8,6 +8,7 @@ using Android.Text;
 using Android.Views;
 using Android.Views.InputMethods;
 using Android.Widget;
+using Google.Android.Material.Navigation;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Platform;
 using Xunit;
@@ -15,6 +16,9 @@ using Xunit.Sdk;
 using AColor = Android.Graphics.Color;
 using AView = Android.Views.View;
 using SearchView = AndroidX.AppCompat.Widget.SearchView;
+using MColor = Microsoft.Maui.Graphics.Color;
+using Google.Android.Material.BottomNavigation;
+using System.Linq;
 
 namespace Microsoft.Maui.DeviceTests
 {
@@ -642,5 +646,81 @@ namespace Microsoft.Maui.DeviceTests
 
 		public static bool IsExcludedWithChildren(this AView view) =>
 			view.GetSemanticPlatformElement().ImportantForAccessibility == ImportantForAccessibility.NoHideDescendants;
+
+		static public Task AssertTabItemTextDoesNotContainColor(
+			this BottomNavigationView navigationView,
+			string tabText,
+			MColor expectedColor,
+			IMauiContext mauiContext) => AssertTabItemTextColor(navigationView, tabText, expectedColor, false, mauiContext);
+
+		static public Task AssertTabItemTextContainsColor(
+			this BottomNavigationView navigationView,
+			string tabText,
+			MColor expectedColor,
+			IMauiContext mauiContext) => AssertTabItemTextColor(navigationView, tabText, expectedColor, true, mauiContext);
+
+		static async Task AssertTabItemTextColor(
+			this BottomNavigationView navigationView,
+			string tabText,
+			MColor expectedColor,
+			bool hasColor,
+			IMauiContext mauiContext)
+		{
+			var navItemView = (AView?)GetTab(navigationView, tabText)?.GetFirstChildOfType<TextView>()?.Parent;
+
+			if (navItemView is null)
+				throw new Exception("Unable to locate Tab Item Text Container");
+
+			if (hasColor)
+				await navItemView.AssertContainsColor(expectedColor.ToPlatform(), mauiContext);
+			else
+				await navItemView.AssertDoesNotContainColor(expectedColor.ToPlatform(), mauiContext);
+		}
+
+		static async Task AssertTabItemIconColor(
+			this BottomNavigationView navigationView, string tabText, MColor expectedColor, bool hasColor,
+			IMauiContext mauiContext)
+		{
+			var navItemView = (AView?)GetTab(navigationView, tabText)?.GetFirstChildOfType<ImageView>()?.Parent;
+
+			if (navItemView is null)
+				throw new Exception("Unable to locate Tab Item Icon Container");
+
+			if (hasColor)
+				await navItemView.AssertContainsColor(expectedColor.ToPlatform(), mauiContext);
+			else
+				await navItemView.AssertDoesNotContainColor(expectedColor.ToPlatform(), mauiContext);
+		}
+
+		static public Task AssertTabItemIconDoesNotContainColor(
+			this BottomNavigationView navigationView,
+			string tabText,
+			MColor expectedColor,
+			IMauiContext mauiContext) => AssertTabItemIconColor(navigationView, tabText, expectedColor, false, mauiContext);
+
+		static public Task AssertTabItemIconContainsColor(
+			this BottomNavigationView navigationView,
+			string tabText,
+			MColor expectedColor,
+			IMauiContext mauiContext) => AssertTabItemIconColor(navigationView, tabText, expectedColor, true, mauiContext);
+
+		static BottomNavigationItemView GetTab(
+			this BottomNavigationView bottomView, string tabText)
+		{
+			var menu = bottomView.Menu;
+
+			var navigationMenu = (BottomNavigationMenuView)bottomView.MenuView;
+			var navItems = navigationMenu.GetChildrenOfType<BottomNavigationItemView>();
+
+			var navItemView =
+				navItems.Single(x =>
+				{
+					return x.GetChildrenOfType<TextView>()
+						.Where(tv => String.Equals(tv.Text, tabText, StringComparison.OrdinalIgnoreCase))
+						.Count() > 0;
+				});
+
+			return navItemView;
+		}
 	}
 }

--- a/src/TestUtils/src/DeviceTests/AssertionExtensions.Windows.cs
+++ b/src/TestUtils/src/DeviceTests/AssertionExtensions.Windows.cs
@@ -1,8 +1,11 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Graphics.Canvas;
+using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Platform;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Automation;
@@ -10,10 +13,11 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media.Imaging;
 using Windows.Graphics.DirectX;
 using Windows.Storage.Streams;
-using Windows.UI;
 using Xunit;
 using Xunit.Sdk;
 using WColor = Windows.UI.Color;
+using WHorizontalAlignment = Microsoft.UI.Xaml.HorizontalAlignment;
+using WVerticalAlignment = Microsoft.UI.Xaml.VerticalAlignment;
 
 namespace Microsoft.Maui.DeviceTests
 {
@@ -187,8 +191,8 @@ namespace Microsoft.Maui.DeviceTests
 
 					window.Content = new Grid
 					{
-						HorizontalAlignment = HorizontalAlignment.Center,
-						VerticalAlignment = VerticalAlignment.Center,
+						HorizontalAlignment = WHorizontalAlignment.Center,
+						VerticalAlignment = WVerticalAlignment.Center,
 						Children =
 						{
 							(grid = new Grid
@@ -488,5 +492,83 @@ namespace Microsoft.Maui.DeviceTests
 		{
 			throw new NotImplementedException();
 		}
+
+		static List<NavigationViewItem?> GetTabBarItems(this NavigationView navigationView)
+		{
+			StackPanel? topNavArea;
+			if (navigationView is MauiNavigationView mauiNavView)
+				topNavArea = mauiNavView.TopNavArea;
+			else
+				topNavArea = navigationView.FindName("TopNavArea") as StackPanel;
+
+			if (topNavArea is null)
+				throw new Exception("Unable to find Top Nav Area");
+
+			return topNavArea.GetChildren<NavigationViewItem>().ToList();
+		}
+
+		static public Task AssertTabItemTextDoesNotContainColor(
+			this NavigationView navigationView,
+			string tabText,
+			Color expectedColor,
+			IMauiContext mauiContext) => AssertTabItemTextColor(navigationView, tabText, expectedColor, false, mauiContext);
+
+		static public Task AssertTabItemTextContainsColor(
+			this NavigationView navigationView,
+			string tabText,
+			Color expectedColor,
+			IMauiContext mauiContext) => AssertTabItemTextColor(navigationView, tabText, expectedColor, true, mauiContext);
+
+		static async Task AssertTabItemTextColor(
+			this NavigationView navigationView,
+			string tabText,
+			Color expectedColor,
+			bool hasColor,
+			IMauiContext mauiContext)
+		{
+			var items = navigationView.GetTabBarItems();
+			var platformItem =
+				items.FirstOrDefault(x => x?.Content?.ToString()?.Equals(tabText, StringComparison.OrdinalIgnoreCase) == true)
+				?.GetDescendantByName<UI.Xaml.Controls.Grid>("ContentGrid")
+				?.GetDescendantByName<UI.Xaml.Controls.ContentPresenter>("ContentPresenter");
+
+			if (platformItem is null)
+				throw new Exception("Unable to locate Tab Item Text Container");
+
+			if (hasColor)
+				await AssertContainsColor(platformItem, expectedColor, mauiContext);
+			else
+				await AssertDoesNotContainColor(platformItem, expectedColor, mauiContext);
+		}
+
+		static async Task AssertTabItemIconColor(
+			this NavigationView navigationView, string tabText, Color expectedColor, bool hasColor,
+			IMauiContext mauiContext)
+		{
+			var items = navigationView.GetTabBarItems();
+			var platformItem =
+				items.FirstOrDefault(x => x?.Content?.ToString()?.Equals(tabText, StringComparison.OrdinalIgnoreCase) == true)
+				?.GetDescendantByName<UI.Xaml.Controls.ContentPresenter>("Icon");
+
+			if (platformItem is null)
+				throw new Exception("Unable to locate Tab Item Icon Container");
+
+			if (hasColor)
+				await AssertContainsColor(platformItem, expectedColor, mauiContext);
+			else
+				await AssertDoesNotContainColor(platformItem, expectedColor, mauiContext);
+		}
+
+		static public Task AssertTabItemIconDoesNotContainColor(
+			this NavigationView navigationView,
+			string tabText,
+			Color expectedColor,
+			IMauiContext mauiContext) => AssertTabItemIconColor(navigationView, tabText, expectedColor, false, mauiContext);
+
+		static public Task AssertTabItemIconContainsColor(
+			this NavigationView navigationView,
+			string tabText,
+			Color expectedColor,
+			IMauiContext mauiContext) => AssertTabItemIconColor(navigationView, tabText, expectedColor, true, mauiContext);
 	}
 }

--- a/src/TestUtils/src/DeviceTests/AssertionExtensions.iOS.cs
+++ b/src/TestUtils/src/DeviceTests/AssertionExtensions.iOS.cs
@@ -1,11 +1,11 @@
 ﻿using System;
-using System.Drawing;
 using System.Linq;
 using System.Threading.Tasks;
 using CoreAnimation;
 using CoreGraphics;
 using Foundation;
 using Microsoft.Maui.Platform;
+using Microsoft.Maui.Graphics;
 using UIKit;
 using Xunit;
 using Xunit.Sdk;
@@ -745,6 +745,84 @@ namespace Microsoft.Maui.DeviceTests
 
 			_ = item ?? throw new Exception("Unable to locate BackButton UILabel Inside UINavigationBar");
 			return titleLabel?.Text;
+		}
+
+		static public Task AssertTabItemTextDoesNotContainColor(
+			this UITabBar navigationView,
+			string tabText,
+			Color expectedColor,
+			IMauiContext mauiContext) => AssertTabItemTextColor(navigationView, tabText, expectedColor, false, mauiContext);
+
+		static public Task AssertTabItemTextContainsColor(
+			this UITabBar navigationView,
+			string tabText,
+			Color expectedColor,
+			IMauiContext mauiContext) => AssertTabItemTextColor(navigationView, tabText, expectedColor, true, mauiContext);
+
+		static async Task AssertTabItemTextColor(
+			this UITabBar navigationView,
+			string tabText,
+			Color expectedColor,
+			bool hasColor,
+			IMauiContext mauiContext)
+		{
+			var tabBarItemView = GetTabItemView(navigationView, tabText).FindDescendantView<UILabel>();
+			if (tabBarItemView is null)
+				throw new Exception($"Unable to locate Tab Item Icon Container: {tabText}");
+
+			if (hasColor)
+			{
+				await tabBarItemView.AssertContainsColor(expectedColor, mauiContext, 0.1);
+			}
+			else
+			{
+				await tabBarItemView.AssertDoesNotContainColor(expectedColor, mauiContext);
+			}
+		}
+
+		static async Task AssertTabItemIconColor(
+			this UITabBar navigationView, string tabText, Color expectedColor, bool hasColor,
+			IMauiContext mauiContext)
+		{
+			var tabBarItemView = GetTabItemView(navigationView, tabText).FindDescendantView<UIImageView>();
+			if (tabBarItemView is null)
+				throw new Exception($"Unable to locate Tab Item Icon Container: {tabText}");
+
+			if (hasColor)
+			{
+				await tabBarItemView.AssertContainsColor(expectedColor, mauiContext);
+			}
+			else
+			{
+				await tabBarItemView.AssertDoesNotContainColor(expectedColor, mauiContext);
+			}
+		}
+
+		static public Task AssertTabItemIconDoesNotContainColor(
+			this UITabBar navigationView,
+			string tabText,
+			Color expectedColor,
+			IMauiContext mauiContext) => AssertTabItemIconColor(navigationView, tabText, expectedColor, false, mauiContext);
+
+		static public Task AssertTabItemIconContainsColor(
+			this UITabBar navigationView,
+			string tabText,
+			Color expectedColor,
+			IMauiContext mauiContext) => AssertTabItemIconColor(navigationView, tabText, expectedColor, true, mauiContext);
+
+		static UIView GetTabItemView(this UITabBar tabBar, string tabText)
+		{
+			var tabBarItem = tabBar.Items?.Single(t => string.Equals(t.Title, tabText, StringComparison.OrdinalIgnoreCase));
+
+			if (tabBarItem is null)
+				throw new Exception($"Unable to find tab bar item: {tabText}");
+
+			var tabBarItemView = tabBarItem.ValueForKey(new Foundation.NSString("view")) as UIView;
+
+			if (tabBarItemView is null)
+				throw new Exception($"Unable to find tab bar item: {tabText}");
+
+			return tabBarItemView;
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change

iOS portion of the following PR
https://github.com/dotnet/maui/pull/15447

#### Priority of how the colors are applied.

The APIs available to us are fairly limiting in scope. Ideally, we would make this all work through the VSM and just use two APIs (IconColor/TitleColor) but for now we are just making these APIs consistent between the platforms. 

The three properties users have to influence the `TabItem` coloring are: `TabBarUnselectedColor`, `TabBarTitleColor`, and `TabBarForegroundColor`

- If the user only sets `Shell.TabBarTitleColor` that will color the `Title` and `Icon` of the selected item. I realize this is a bit weird for TitleColor to change `Icon` color but this is currently how Android works and it's not really worth breaking this until we just introduce new APIs.
- If `Shell.TabBarTitleColor` is not set then the `TitleColor` will match the `TabBarForegroundColor`
- If `TabBarForegroundColor` is set and `TabBarUnselectedColor` isn't set then `TabBarForegroundColor` will be the color used for the text/icon of the selected TabItem
- If `TabBarUnselectedColor` is the only thing set then that will be used for the text/icon color on the unselected Tab Item. 

#### Examples
- `TabBarTitleColor`: Green
  - Selected Icon is Green, Selected Text is Green, Unselected item matches system colors
-  `TabBarForegroundColor`: Blue
  - Selected Icon is Blue, Selected Text is Blue, Unselected item matches system colors
-  `TabBarForegroundColor`: Blue, `TabBarTitleColor`: Green
  - Selected Icon is Blue, Selected Text is Green, Unselected item matches system colors
-  `Shell.ForegroundColor`: Blue, `TabBarTitleColor`: Green (ForegroundColor propagates to TabBarForegroundColor).
  - Selected Icon is Blue, Selected Text is Green, Unselected item matches system colors
-  `TabBarForegroundColor`: Blue, `TabBarTitleColor`: Green, `TabBarUnselectedColor`: Pink
  - Selected Icon is Blue, Selected Text is Green, Unselected text and Icon is `Pink`

#### Breaking changes
- Shell.ForegroundColor and Shell.TabBarForeGroundColor will now affect the android tab colors. If a user has `ForegroundColor` set, then the `tab` will match according to that color.
  

Fixes (partially) #6718
Fixes #16551
