### PR TITLE
[android] support more system font names

### DIFF
--- a/src/Core/src/Fonts/FontManager.Android.cs
+++ b/src/Core/src/Fonts/FontManager.Android.cs
@@ -143,6 +143,11 @@ namespace Microsoft.Maui
 				case "serif":
 					return Typeface.Serif;
 				default:
+					if (fontfamily.StartsWith("sansserif-", StringComparison.OrdinalIgnoreCase) ||
+						fontfamily.StartsWith("sans-serif-", StringComparison.OrdinalIgnoreCase))
+					{
+						return Typeface.Create(fontfamily, TypefaceStyle.Normal);
+					}
 					return null;
 			}
 		}


### PR DESCRIPTION
Context: https://github.com/dotnet/maui/issues/10713
Context: https://github.com/supershopping/ShellFlyoutLagging
Fixes #13239

In reviewing the above customer sample, I noticed time spent in:

    79.52ms microsoft.maui!Microsoft.Maui.Handlers.LabelHandler.MapFont(Microsoft.Maui.Handlers.ILabelHandler,Microsoft.Maui.ILabel)
    20.71ms microsoft.extensions.logging.abstractions!Microsoft.Extensions.Logging.LoggerExtensions.LogWarning(Microsoft.Extensions

What warning are we trying to log? It seems like it is impacting the time it takes for the first Shell flyout to open.

Adding more logging, I found:

    06-19 15:31:19.834  5706  5706 I DOTNET  : Unable to load font 'sans-serif-medium' from assets.
    06-19 15:31:19.840  5706  5706 I DOTNET  : Unable to load font 'sans-serif-medium.ttf' from assets.
    06-19 15:31:19.840  5706  5706 I DOTNET  : Unable to load font 'Fonts/sans-serif-medium.ttf' from assets.
    06-19 15:31:19.841  5706  5706 I DOTNET  : Unable to load font 'fonts/sans-serif-medium.ttf' from assets.
    06-19 15:31:19.841  5706  5706 I DOTNET  : Unable to load font 'sans-serif-medium.otf' from assets.
    06-19 15:31:19.842  5706  5706 I DOTNET  : Unable to load font 'Fonts/sans-serif-medium.otf' from assets.
    06-19 15:31:19.842  5706  5706 I DOTNET  : Unable to load font 'fonts/sans-serif-medium.otf' from assets.

Which is likely just trying to load one of:

* https://github.com/dotnet/maui/blob/0543e03cbe7331ae2c106c67a9eaefc575f75945/src/Controls/src/Core/Shell/BaseShellItem.cs#L517
* https://github.com/dotnet/maui/blob/0543e03cbe7331ae2c106c67a9eaefc575f75945/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellItemRenderer.cs#L248

In 2d354d10, we added support for certain Android system fonts. I think we should just expand this further to support various Android fonts like:

    sans-serif-black
    sans-serif-condensed
    sans-serif-condensed-light
    sans-serif-light
    sans-serif-medium

You can use these in Android such as:

    android:fontFamily="sans-serif-medium"

We can load this `Typeface` from C# such as:

    Typeface.Create("sans-serif-medium", TypefaceStyle.Normal)

See: https://stackoverflow.com/a/14344132

In MAUI apps, customers are likely using a `Fonts/` folder, so if they use these names, they are likely trying to load a system font.

After these changes, I see this result on a Pixel 5:

    Before:
    79.52ms microsoft.maui!Microsoft.Maui.Handlers.LabelHandler.MapFont(Microsoft.Maui.Handlers.ILabelHandler,Microsoft.Maui.ILabel)
    After:
    26.91ms microsoft.maui!Microsoft.Maui.Handlers.LabelHandler.MapFont(Microsoft.Maui.Handlers.ILabelHandler,Microsoft.Maui.ILabel)

So, I think this saves ~52ms of time for the first Shell flyout opening in this sample.