### PR TITLE
[CI] Move away from template parameters to help moving to a matrix strategy.

### DIFF
--- a/eng/pipelines/common/device-tests-steps.yml
+++ b/eng/pipelines/common/device-tests-steps.yml
@@ -13,7 +13,6 @@ parameters:
 steps:
   - template: provision.yml
     parameters:
-      platform: macos
       skipXcode: ${{ eq(parameters.platform, 'android') }}
       provisionatorChannel: ${{ parameters.provisionatorChannel }}
 

--- a/eng/pipelines/common/maui-templates.yml
+++ b/eng/pipelines/common/maui-templates.yml
@@ -76,7 +76,6 @@ jobs:
 
     - template: provision.yml
       parameters:
-        platform: ${{ BuildPlatform.name }}
         checkoutDirectory: ${{ parameters.checkoutDirectory }}
 
     - task: DownloadBuildArtifacts@0
@@ -135,7 +134,6 @@ jobs:
 
     - template: provision.yml
       parameters:
-        platform: macos
         skipXcode: ${{ eq(RunPlatform.testName, 'RunOnAndroid') }}
         checkoutDirectory: ${{ parameters.checkoutDirectory }}
 

--- a/eng/pipelines/common/pack.yml
+++ b/eng/pipelines/common/pack.yml
@@ -36,7 +36,6 @@ steps:
   - template: provision.yml
     parameters:
       checkoutDirectory: ${{ parameters.checkoutDirectory }}
-      platform: ${{ parameters.platform }}
       poolName: ${{ parameters.poolName }}
       provisionatorChannel: ${{ parameters.provisionatorChannel }}
       gitHubToken: ${{ parameters.gitHubToken }}

--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -1,5 +1,4 @@
 parameters:
-  platform : ''
   poolName: ''
   skipXcode: false
   skipVS: true
@@ -14,146 +13,160 @@ parameters:
 
 steps:
   # Prepare macOS
-  - ${{ if eq(parameters.platform, 'macos') }}:
-    - template: agent-cleanser/v1.yml@yaml-templates
-      parameters:
-        UninstallMono: false
-        UninstallXamarinMac: false
-        CleanseAgentToolsDotNet: true           # Cleanse all .NET versions under the agent tools directory and use only those provisioned by the pipeline
-        SelfHealPowerShell: false
-        AUTH_TOKEN_GITHUB_COM: $(github--pat--vs-mobiletools-engineering-service2)
-    # Provision Xcode
-    - ${{ if ne(parameters.skipXcode, 'true') }}:
-      - task: xamops.azdevex.provisionator-task.provisionator@2
-        displayName: 'Provision Xcode'
-        inputs:
-          provisioning_script: ${{ parameters.checkoutDirectory }}/${{ parameters.provisionatorXCodePath }}
-          provisioning_extra_args: ${{ parameters.provisionatorExtraArguments }}
-          github_token: ${{ parameters.gitHubToken }}
-        env:
-          PROVISIONATOR_CHANNEL: ${{ parameters.provisionatorChannel }}
-    # Provision Additional Software
-    - ${{ if ne(parameters.skipProvisioning, 'true') }}:
-      - task: xamops.azdevex.provisionator-task.provisionator@2
-        displayName: 'Provision Additional Software'
-        continueOnError: true 
-        inputs:
-          provisioning_script: ${{ parameters.checkoutDirectory }}/${{ parameters.provisionatorPath }}
-          provisioning_extra_args: ${{ parameters.provisionatorExtraArguments }}
-          github_token: ${{ parameters.gitHubToken }}
-        env:
-          PROVISIONATOR_CHANNEL: ${{ parameters.provisionatorChannel }}
+  - template: agent-cleanser/v1.yml@yaml-templates
+    parameters:
+      condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
+      UninstallMono: false
+      UninstallXamarinMac: false
+      CleanseAgentToolsDotNet: true           # Cleanse all .NET versions under the agent tools directory and use only those provisioned by the pipeline
+      SelfHealPowerShell: false
+      AUTH_TOKEN_GITHUB_COM: $(github--pat--vs-mobiletools-engineering-service2)
+  # Provision Xcode
+  - ${{ if ne(parameters.skipXcode, 'true') }}:
+    - task: xamops.azdevex.provisionator-task.provisionator@2
+      condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
+      displayName: 'Provision Xcode'
+      inputs:
+        provisioning_script: ${{ parameters.checkoutDirectory }}/${{ parameters.provisionatorXCodePath }}
+        provisioning_extra_args: ${{ parameters.provisionatorExtraArguments }}
+        github_token: ${{ parameters.gitHubToken }}
+      env:
+        PROVISIONATOR_CHANNEL: ${{ parameters.provisionatorChannel }}
+  # Provision Additional Software
+  - ${{ if ne(parameters.skipProvisioning, 'true') }}:
+    - task: xamops.azdevex.provisionator-task.provisionator@2
+      displayName: 'Provision Additional Software'
+      condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
+      continueOnError: true 
+      inputs:
+        provisioning_script: ${{ parameters.checkoutDirectory }}/${{ parameters.provisionatorPath }}
+        provisioning_extra_args: ${{ parameters.provisionatorExtraArguments }}
+        github_token: ${{ parameters.gitHubToken }}
+      env:
+        PROVISIONATOR_CHANNEL: ${{ parameters.provisionatorChannel }}
 
-    # Setup SDK Paths
-    - bash: |
-        echo "##vso[task.prependpath]/Library/Frameworks/Mono.framework/Versions/Current/Commands/"
-        echo "##vso[task.prependpath]~/Library/Developer/Xamarin/android-sdk-macosx"
-      displayName: 'Setup SDK Paths'
-      condition: ne(variables['osx2019VmPool'], 'Azure Pipelines')
-    # Setup JDK Paths
-    - bash: |
-        echo "##vso[task.setvariable variable=JI_JAVA_HOME]$(JAVA_HOME_11_X64)"
-        echo "##vso[task.setvariable variable=JAVA_HOME]$(JAVA_HOME_11_X64)"
-      displayName: 'Setup JDK Paths'
-    # Configure VS Mac for Xcode
-    - bash: |
-        set -x
-        mkdir -p ~/Library/Preferences/Xamarin
-        rm -f ~/Library/Preferences/Xamarin/Settings.plist
-        /usr/libexec/PlistBuddy -c "add :AppleSdkRoot string $(dirname $(dirname $(xcode-select -p)))" ~/Library/Preferences/Xamarin/Settings.plist || true
-        cat ~/Library/Preferences/Xamarin/Settings.plist || true
-      displayName: 'Configure Visual Studio'
-    # Install Certificates and Provisioning Profiles
-    - task: InstallAppleProvisioningProfile@1
-      displayName: 'Install the iOS provisioning profile'
-      inputs:
-        provProfileSecureFile: 'Components iOS Provisioning.mobileprovision'
-    - task: InstallAppleProvisioningProfile@1
-      displayName: 'Install the macOS provisioning profile'
-      inputs:
-        provProfileSecureFile: 'Components Mac Provisioning.mobileprovision'
-    - task: InstallAppleProvisioningProfile@1
-      displayName: 'Install the tvOS provisioning profile'
-      inputs:
-        provProfileSecureFile: 'Components tvOS Provisioning.mobileprovision'
-    - task: InstallAppleCertificate@2
-      displayName: 'Install the iOS certificate'
-      inputs:
-        certSecureFile: 'Components iOS Certificate.p12'
-    - task: InstallAppleCertificate@2
-      condition: eq(variables['System.JobName'], 'macos')
-      displayName: 'Install the macOS certificate'
-      inputs:
-        certSecureFile: 'Components Mac Certificate.p12'
+  # Setup SDK Paths
+  - bash: |
+      echo "##vso[task.prependpath]/Library/Frameworks/Mono.framework/Versions/Current/Commands/"
+      echo "##vso[task.prependpath]~/Library/Developer/Xamarin/android-sdk-macosx"
+    displayName: 'Setup SDK Paths'
+    condition: and(succeeded(), ne(variables['osx2019VmPool'], 'Azure Pipelines'), eq(variables['Agent.OS'], 'Darwin'))
+  # Setup JDK Paths
+  - bash: |
+      echo "##vso[task.setvariable variable=JI_JAVA_HOME]$(JAVA_HOME_11_X64)"
+      echo "##vso[task.setvariable variable=JAVA_HOME]$(JAVA_HOME_11_X64)"
+    displayName: 'Setup JDK Paths'
+    condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
+  # Configure VS Mac for Xcode
+  - bash: |
+      set -x
+      mkdir -p ~/Library/Preferences/Xamarin
+      rm -f ~/Library/Preferences/Xamarin/Settings.plist
+      /usr/libexec/PlistBuddy -c "add :AppleSdkRoot string $(dirname $(dirname $(xcode-select -p)))" ~/Library/Preferences/Xamarin/Settings.plist || true
+      cat ~/Library/Preferences/Xamarin/Settings.plist || true
+    displayName: 'Configure Visual Studio'
+    condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
+  # Install Certificates and Provisioning Profiles
+  - task: InstallAppleProvisioningProfile@1
+    displayName: 'Install the iOS provisioning profile'
+    condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
+    inputs:
+      provProfileSecureFile: 'Components iOS Provisioning.mobileprovision'
+  - task: InstallAppleProvisioningProfile@1
+    displayName: 'Install the macOS provisioning profile'
+    condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
+    inputs:
+      provProfileSecureFile: 'Components Mac Provisioning.mobileprovision'
+  - task: InstallAppleProvisioningProfile@1
+    displayName: 'Install the tvOS provisioning profile'
+    condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
+    inputs:
+      provProfileSecureFile: 'Components tvOS Provisioning.mobileprovision'
+  - task: InstallAppleCertificate@2
+    displayName: 'Install the iOS certificate'
+    condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
+    inputs:
+      certSecureFile: 'Components iOS Certificate.p12'
+  - task: InstallAppleCertificate@2
+    condition: eq(variables['System.JobName'], 'macos')
+    displayName: 'Install the macOS certificate'
+    inputs:
+      certSecureFile: 'Components Mac Certificate.p12'
 
   # Prepare Windows
-  - ${{ if eq(parameters.platform, 'windows') }}:
-    - powershell: |
-        if (-not $(where.exe pwsh)) {
-          $url = "https://github.com/PowerShell/PowerShell/releases/download/v$env:POWERSHELL_VERSION/PowerShell-$env:POWERSHELL_VERSION-win-x64.msi"
-          $output = "$env:TEMP\PowerShell.msi"
-          Remove-Item -Force $output -ErrorAction Ignore
-          Invoke-WebRequest -Uri $url -OutFile $output
-          msiexec.exe /package $output /quiet ADD_EXPLORER_CONTEXT_MENU_OPENPOWERSHELL=1 ENABLE_PSREMOTING=1 REGISTER_MANIFEST=1
-        }
-      displayName: 'Install PowerShell Core'
-    - ${{ if ne(parameters.skipVS, 'true') }}:
-      - task: xamops.azdevex.provisionator-task.provisionator@2
-        displayName: 'Provision Visual Studio'
-        inputs:
-          provisioning_script: ${{ parameters.checkoutDirectory }}/${{ parameters.provisionatorVSPath }}
-          provisioning_extra_args: ${{ parameters.provisionatorExtraArguments }}
-          github_token: ${{ parameters.gitHubToken }}
-        env:
-          PROVISIONATOR_CHANNEL: ${{ parameters.provisionatorChannel }}
-      - pwsh: |
-          $msbuild = "$env:ProgramFiles/Microsoft Visual Studio/2022/Preview/MSBuild/Current/Bin/MSBuild.exe"
-          echo "##vso[task.setvariable variable=MSBUILD_EXE]$msbuild"
-        displayName: 'Setup MSBuild Paths'
+  - powershell: |
+      if (-not $(where.exe pwsh)) {
+        $url = "https://github.com/PowerShell/PowerShell/releases/download/v$env:POWERSHELL_VERSION/PowerShell-$env:POWERSHELL_VERSION-win-x64.msi"
+        $output = "$env:TEMP\PowerShell.msi"
+        Remove-Item -Force $output -ErrorAction Ignore
+        Invoke-WebRequest -Uri $url -OutFile $output
+        msiexec.exe /package $output /quiet ADD_EXPLORER_CONTEXT_MENU_OPENPOWERSHELL=1 ENABLE_PSREMOTING=1 REGISTER_MANIFEST=1
+      }
+    displayName: 'Install PowerShell Core'
+    condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
 
-    # Provision Additional Software
-    - ${{ if ne(parameters.skipProvisioning, 'true') }}:
-      - task: xamops.azdevex.provisionator-task.provisionator@2
-        displayName: 'Provision Additional Software'
-        inputs:
-          provisioning_script: ${{ parameters.checkoutDirectory }}/${{ parameters.provisionatorPath }}
-          provisioning_extra_args: ${{ parameters.provisionatorExtraArguments }}
-          github_token: ${{ parameters.gitHubToken }}
-        env:
-          PROVISIONATOR_CHANNEL: ${{ parameters.provisionatorChannel }}
-
+  - ${{ if ne(parameters.skipVS, 'true') }}:
+    - task: xamops.azdevex.provisionator-task.provisionator@2
+      displayName: 'Provision Visual Studio'
+      condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
+      inputs:
+        provisioning_script: ${{ parameters.checkoutDirectory }}/${{ parameters.provisionatorVSPath }}
+        provisioning_extra_args: ${{ parameters.provisionatorExtraArguments }}
+        github_token: ${{ parameters.gitHubToken }}
+      env:
+        PROVISIONATOR_CHANNEL: ${{ parameters.provisionatorChannel }}
     - pwsh: |
-        if ($env:JAVA_HOME_11_X64) {
-          $env:JAVA_HOME = $env:JAVA_HOME_11_X64
-        } else {
-          $path = (Get-ChildItem $env:ProgramFiles\Microsoft\jdk-11.*\bin\java.exe) | Select-Object -First 1
-          if ($path -and (Test-Path $path)) {
-            $env:JAVA_HOME = $path.Directory.Parent.FullName
-          }
-        }
-        if ($env:JAVA_HOME) {
-          echo "##vso[task.setvariable variable=JAVA_HOME]$env:JAVA_HOME"
-          echo "JAVA_HOME set to '$env:JAVA_HOME'"
-        } else {
-          echo "Unable to set JAVA_HOME"
-        }
-      displayName: 'Setup JDK Paths'
+        $msbuild = "$env:ProgramFiles/Microsoft Visual Studio/2022/Preview/MSBuild/Current/Bin/MSBuild.exe"
+        echo "##vso[task.setvariable variable=MSBUILD_EXE]$msbuild"
+      displayName: 'Setup MSBuild Paths'
+      condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
 
-    - pwsh: |
+  # Provision Additional Software
+  - ${{ if ne(parameters.skipProvisioning, 'true') }}:
+    - task: xamops.azdevex.provisionator-task.provisionator@2
+      displayName: 'Provision Additional Software'
+      condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
+      inputs:
+        provisioning_script: ${{ parameters.checkoutDirectory }}/${{ parameters.provisionatorPath }}
+        provisioning_extra_args: ${{ parameters.provisionatorExtraArguments }}
+        github_token: ${{ parameters.gitHubToken }}
+      env:
+        PROVISIONATOR_CHANNEL: ${{ parameters.provisionatorChannel }}
+
+  - pwsh: |
+      if ($env:JAVA_HOME_11_X64) {
+        $env:JAVA_HOME = $env:JAVA_HOME_11_X64
+      } else {
+        $path = (Get-ChildItem $env:ProgramFiles\Microsoft\jdk-11.*\bin\java.exe) | Select-Object -First 1
+        if ($path -and (Test-Path $path)) {
+          $env:JAVA_HOME = $path.Directory.Parent.FullName
+        }
+      }
+      if ($env:JAVA_HOME) {
+        echo "##vso[task.setvariable variable=JAVA_HOME]$env:JAVA_HOME"
+        echo "JAVA_HOME set to '$env:JAVA_HOME'"
+      } else {
+        echo "Unable to set JAVA_HOME"
+      }
+    displayName: 'Setup JDK Paths'
+    condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
+
+  - pwsh: |
+      if ($env:ANDROID_SDK_ROOT) {
+        echo "ANDROID_SDK_ROOT already set to '$env:ANDROID_SDK_ROOT'"
+      } else {
+        if ((Test-Path "${env:ProgramFiles(x86)}\Android\android-sdk")) {
+          $env:ANDROID_SDK_ROOT = "${env:ProgramFiles(x86)}\Android\android-sdk"
+        }
         if ($env:ANDROID_SDK_ROOT) {
-          echo "ANDROID_SDK_ROOT already set to '$env:ANDROID_SDK_ROOT'"
+          echo "##vso[task.setvariable variable=ANDROID_SDK_ROOT]$env:ANDROID_SDK_ROOT"
+          echo "ANDROID_SDK_ROOT set to '$env:ANDROID_SDK_ROOT'"
         } else {
-          if ((Test-Path "${env:ProgramFiles(x86)}\Android\android-sdk")) {
-            $env:ANDROID_SDK_ROOT = "${env:ProgramFiles(x86)}\Android\android-sdk"
-          }
-          if ($env:ANDROID_SDK_ROOT) {
-            echo "##vso[task.setvariable variable=ANDROID_SDK_ROOT]$env:ANDROID_SDK_ROOT"
-            echo "ANDROID_SDK_ROOT set to '$env:ANDROID_SDK_ROOT'"
-          } else {
-            echo "Unable to set ANDROID_SDK_ROOT"
-          }
+          echo "Unable to set ANDROID_SDK_ROOT"
         }
-      displayName: 'Setup ANDROID_SDK_ROOT Paths'
+      }
+    displayName: 'Setup ANDROID_SDK_ROOT Paths'
+    condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
 
   # Prepare Both
   - task: UseDotNet@2                 # https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/tool/dotnet-core-tool-installer?view=azure-devops

--- a/eng/pipelines/common/ui-tests-steps.yml
+++ b/eng/pipelines/common/ui-tests-steps.yml
@@ -14,13 +14,10 @@ steps:
   - template: provision.yml
     parameters:
       ${{ if eq(parameters.platform, 'windows') }}:
-        platform: windows
         skipProvisioning: true
       ${{ if ne(parameters.platform, 'windows') }}:
-        platform: macos
         skipProvisioning: false
       skipXcode: false
-        
       provisionatorChannel: ${{ parameters.provisionatorChannel }}
 
   - task: PowerShell@2

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -150,7 +150,6 @@ stages:
             steps:
               - template: common/provision.yml
                 parameters:
-                  platform: ${{ BuildPlatform.name }}
                   poolName: ${{ BuildPlatform.poolName }}
                   gitHubToken: $(github--pat--vs-mobiletools-engineering-service2)
               - pwsh: ./build.ps1 --target=dotnet --configuration="${{ BuildConfiguration }}" --verbosity=diagnostic
@@ -220,7 +219,6 @@ stages:
           steps:
             - template: common/provision.yml
               parameters:
-                platform: ${{ BuildPlatform.name }}
                 poolName: ${{ BuildPlatform.poolName }}
 
             - task: DownloadBuildArtifacts@0


### PR DESCRIPTION
We are tyring to minimize the size of the yaml so that we get to a point in which we can have all templates in a single pipeline. To do so, we can move to use matrix strategies that minimize the size of the generated code, but this comes at a price.

One of the issues with using a matrix strategy is that it gets expanded at runtime, but not at compile time. That results in a problem, which is that templates need to know all its parameters at COMPILE time. This supposes a problem when using the provision tempalte, because we cannot expand the matrix at compile time. We can fix that using conditions at runtime. The side effect of this is that there are going to be more steps in the pipeline that get skipped, yet it is a small price to pay for the final goal.

