### PR TITLE
Update DEVELOPMENT.md

### DIFF
--- a/.github/DEVELOPMENT.md
+++ b/.github/DEVELOPMENT.md
@@ -180,7 +180,7 @@ public static int foo = 2130771968;
 
 ### Compile using a local `bin\dotnet`
 
-This method ensures that the workloads installed by Visual Studio won't get changed. This is usually the best method to use if you want to preserve the global state of your machine. This method will also use the versions that are specific to the branch you are on which is a good way to ensure compatibility.
+This method will use the .NET and workload versions that are specific to the branch you are on, which is a good way to ensure compatibility.
 
 #### Cake
 

--- a/.github/DEVELOPMENT.md
+++ b/.github/DEVELOPMENT.md
@@ -19,28 +19,29 @@ iOS and MacCatalyst will require current stable Xcode. You can get this [here](h
 
 If you're missing any of the Android SDKs, Visual Studio should prompt you to install them. If it doesn't prompt you then use the [Android SDK Manager](https://learn.microsoft.com/xamarin/android/get-started/installation/android-sdk) to install the necessary SDKs.
 
-### Opening the Repository
+### Building the Build Tasks
+Before opening the solution in Visual Studio you **MUST** build the build tasks:
 
 ```dotnetcli
 dotnet tool restore
-dotnet cake --target=VS --workloads=global
+dotnet cake --target=dotnet-buildtasks
 ```
-
-*NOTE*: Intellisense takes a decent amount of time to fully process your solution. It will eventually work through all the necessary tasks. If you are having intellisense issues, usually unloading/reloading the `maui.core` and `maui.controls` projects will resolve. 
 
 #### MacOS
 
 All of the above cake commands should work fine on `MacOS`.
 
-#### Solutions
+#### Open the Solution
 - Microsoft.Maui.sln
   - Kitchen sink solution. This includes all of the `Compatibility` projects and all of the platforms that we compile for. It is very unlikely you will need to use this solution for development. 
 - Microsoft.Maui-dev.sln
   - `Microsoft.Maui.sln` but without the `Compatibility` projects. Because we can't detect solution filters inside `MSBuild` we had to create a separate `sln` without the `Compatibility` projects. 
-- Microsoft.Maui-mac.slnf
-  - `Microsoft.Maui-dev.sln` with all of the `Windows` targets filtered out
 - Microsoft.Maui-windows.slnf
   - `Microsoft.Maui-dev.sln` with all of the targets you can't build on `Windows` removed (GTK/Catalyst).
+- Microsoft.Maui-mac.slnf
+  - `Microsoft.Maui-dev.sln` with all of the `Windows` targets filtered out
+
+*NOTE*: IntelliSense takes a decent amount of time to fully process your solution. It will eventually work through all the necessary tasks. If you are having IntelliSense issues, usually unloading/reloading the `maui.core` and `maui.controls` projects will resolve. 
 
 ## What branch should I use?
 - main

--- a/.github/DEVELOPMENT.md
+++ b/.github/DEVELOPMENT.md
@@ -2,44 +2,49 @@
 
 This page contains steps to build and run the .NET MAUI repository from source. If you are looking to build apps with .NET MAUI please head over to the links in the [README](https://github.com/dotnet/maui/blob/main/README.md) to get started.
 
-## Requirements
-
-### Visual Studio
+## Visual Studio
 Follow the instructions here to install .NET MAUI with Visual Studio Stable:
    - [Windows](https://learn.microsoft.com/dotnet/maui/get-started/installation?tabs=vswin)
       - Select the 20348 SDK option inside Individual Components or [install 20348 manually](https://go.microsoft.com/fwlink/?linkid=2164145)
       - If you know you have 20348 installed but are still getting an error around this SDK missing, trying uninstalling and reinstalling the SDK.
    - [macOS](https://learn.microsoft.com/dotnet/maui/get-started/installation?tabs=vsmac)  
    
-### iOS / MacCatalyst
+## iOS / MacCatalyst
 
 iOS and MacCatalyst will require current stable Xcode. You can get this [here](https://developer.apple.com/download/more/?name=Xcode).
 
-### Android
+## Android
 
 If you're missing any of the Android SDKs, Visual Studio should prompt you to install them. If it doesn't prompt you then use the [Android SDK Manager](https://learn.microsoft.com/xamarin/android/get-started/installation/android-sdk) to install the necessary SDKs.
 
-### Building the Build Tasks
-Before opening the solution in Visual Studio you **MUST** build the build tasks:
+## Building the Build Tasks
+Before opening the solution in Visual Studio you **MUST** build the build tasks. You have two options:
 
-```dotnetcli
-dotnet tool restore
-dotnet cake --target=dotnet-buildtasks
-```
+- Do this to build the build tasks and launch Visual Studio, automatically opening the default solution:
 
-#### MacOS
+   ```dotnetcli
+   dotnet tool restore
+   dotnet cake --target=VS --workloads=global
+   ```
 
-All of the above cake commands should work fine on `MacOS`.
+   *NOTE*: `--workloads=global` means use the normal (globally installed) .NET workloads.
 
-#### Open the Solution
+- OR do this to just build the build tasks. You can then launch Visual Studio manually and open the solution of your choosing:
+
+   ```dotnetcli
+   dotnet tool restore
+   dotnet build ./Microsoft.Maui.BuildTasks.slnf
+   ```
+
+## Available Solutions
 - Microsoft.Maui.sln
   - Kitchen sink solution. This includes all of the `Compatibility` projects and all of the platforms that we compile for. It is very unlikely you will need to use this solution for development. 
 - Microsoft.Maui-dev.sln
   - `Microsoft.Maui.sln` but without the `Compatibility` projects. Because we can't detect solution filters inside `MSBuild` we had to create a separate `sln` without the `Compatibility` projects. 
 - Microsoft.Maui-windows.slnf
-  - `Microsoft.Maui-dev.sln` with all of the targets you can't build on `Windows` removed (GTK/Catalyst).
+  - `Microsoft.Maui-dev.sln` with all of the targets you can't build on `Windows` removed (GTK/Catalyst). Default solution on Windows.
 - Microsoft.Maui-mac.slnf
-  - `Microsoft.Maui-dev.sln` with all of the `Windows` targets filtered out
+  - `Microsoft.Maui-dev.sln` with all of the `Windows` targets filtered out. Default solution on Mac.
 
 *NOTE*: IntelliSense takes a decent amount of time to fully process your solution. It will eventually work through all the necessary tasks. If you are having IntelliSense issues, usually unloading/reloading the `maui.core` and `maui.controls` projects will resolve. 
 


### PR DESCRIPTION
Make these build doc updates:
- Emphasize the need to build the build tasks first - that you MUST do this before opening the solution. We suspect that many externals complaining that they can't build MAUI get tripped up on this step, just opening the solution. So it's good to make it clearer (for internals too).
- Update the initial build command (building build tasks) so that it doesn't also launch VS. This is more convenential for open source projects, and it also allows folks to choose the VS version and solution to open.
- Moved text around IntelliSense being slow to update, as a consequence of the above changes. Do we still need this text at all? I'm not sure.

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
