### PR TITLE
Run daily code formatting on .NET SDK 7.0.304

### DIFF
--- a/.github/workflows/dotnet-format-daily.yml
+++ b/.github/workflows/dotnet-format-daily.yml
@@ -18,7 +18,7 @@ jobs:
           ref: ${{ github.head_ref }}
 
       - name: Run dotnet format
-        run: dotnet format .\Microsoft.Maui.sln --no-restore --exclude Templates/src BlazorWebView/src/SharedSource/BlazorWebViewDeveloperTools.cs BlazorWebView/src/SharedSource/BlazorWebViewServiceCollectionExtensions.cs Graphics/src/Graphics.Win2D/W2DCanvas.cs Graphics/src/Graphics.Win2D/W2DExtensions.cs
+        run: dotnet format .\Microsoft.Maui.sln --exclude Templates/src BlazorWebView/src/SharedSource/BlazorWebViewDeveloperTools.cs BlazorWebView/src/SharedSource/BlazorWebViewServiceCollectionExtensions.cs Graphics/src/Graphics.Win2D/W2DCanvas.cs Graphics/src/Graphics.Win2D/W2DExtensions.cs
     
       - name: Commit files
         if: steps.format.outputs.has-changes == 'true'
@@ -28,7 +28,7 @@ jobs:
           git commit -a -m 'Automated dotnet-format update'
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v5
         with:
           title: '[housekeeping] Automated PR to fix formatting errors'
           body: |

--- a/.github/workflows/dotnet-format-daily.yml
+++ b/.github/workflows/dotnet-format-daily.yml
@@ -28,7 +28,7 @@ jobs:
           git commit -a -m 'Automated dotnet-format update'
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v3
         with:
           title: '[housekeeping] Automated PR to fix formatting errors'
           body: |

--- a/.github/workflows/dotnet-format-daily.yml
+++ b/.github/workflows/dotnet-format-daily.yml
@@ -17,6 +17,11 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
 
+      - name: Setup .NET Core SDK
+        uses: actions/setup-dotnet@v3.2.0
+        with:
+          dotnet-version: 7.0.304
+
       - name: Run dotnet format
         run: dotnet format .\Microsoft.Maui.sln --no-restore --exclude Templates/src BlazorWebView/src/SharedSource/BlazorWebViewDeveloperTools.cs BlazorWebView/src/SharedSource/BlazorWebViewServiceCollectionExtensions.cs Graphics/src/Graphics.Win2D/W2DCanvas.cs Graphics/src/Graphics.Win2D/W2DExtensions.cs
     

--- a/.github/workflows/dotnet-format-daily.yml
+++ b/.github/workflows/dotnet-format-daily.yml
@@ -18,7 +18,7 @@ jobs:
           ref: ${{ github.head_ref }}
 
       - name: Run dotnet format
-        run: dotnet format .\Microsoft.Maui.sln --exclude Templates/src BlazorWebView/src/SharedSource/BlazorWebViewDeveloperTools.cs BlazorWebView/src/SharedSource/BlazorWebViewServiceCollectionExtensions.cs Graphics/src/Graphics.Win2D/W2DCanvas.cs Graphics/src/Graphics.Win2D/W2DExtensions.cs
+        run: dotnet format .\Microsoft.Maui.sln --no-restore --exclude Templates/src BlazorWebView/src/SharedSource/BlazorWebViewDeveloperTools.cs BlazorWebView/src/SharedSource/BlazorWebViewServiceCollectionExtensions.cs Graphics/src/Graphics.Win2D/W2DCanvas.cs Graphics/src/Graphics.Win2D/W2DExtensions.cs
     
       - name: Commit files
         if: steps.format.outputs.has-changes == 'true'


### PR DESCRIPTION
There seems to be a [bug](https://github.com/dotnet/format/issues/1861) in `dotnet format` currently which is fixed in 7.0.304, but that version is not on the hosted build agents yet.

In order to restore the daily code formatting now, adding the install step for 7.0.304 specifically