### PR TITLE
Split daily code formatting check in 2: .NET 7 branch and main branch

### DIFF
--- a/.github/workflows/dotnet-format-daily-main.yml
+++ b/.github/workflows/dotnet-format-daily-main.yml
@@ -46,3 +46,4 @@ jobs:
           assignees: rmarinho, jsuarezruiz
           reviewers: rmarinho, jsuarezruiz
           branch: housekeeping/fix-codeformatting
+          base: main

--- a/.github/workflows/dotnet-format-daily-main.yml
+++ b/.github/workflows/dotnet-format-daily-main.yml
@@ -1,0 +1,48 @@
+name: Daily code format check
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: 0 0 * * * # Every day at midnight (UTC)
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  dotnet-format:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          ref: main
+
+      - name: Setup .NET Core SDK
+        uses: actions/setup-dotnet@v3.2.0
+        with:
+          dotnet-version: 8.x
+
+      - name: Run dotnet format
+        run: dotnet format .\Microsoft.Maui.sln --no-restore --exclude Templates/src BlazorWebView/src/SharedSource/BlazorWebViewDeveloperTools.cs BlazorWebView/src/SharedSource/BlazorWebViewServiceCollectionExtensions.cs Graphics/src/Graphics.Win2D/W2DCanvas.cs Graphics/src/Graphics.Win2D/W2DExtensions.cs
+    
+      - name: Commit files
+        if: steps.format.outputs.has-changes == 'true'
+        run: |
+          git config --local user.name "github-actions[bot]"
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -a -m 'Automated dotnet-format update'
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          title: '[housekeeping] Automated PR to fix formatting errors'
+          body: |
+            Automated PR to fix formatting errors
+          committer: GitHub <noreply@github.com>
+          author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          labels: |
+            t/housekeeping ♻︎
+            area/infrastructure 🏗️
+          assignees: rmarinho, jsuarezruiz
+          reviewers: rmarinho, jsuarezruiz
+          branch: housekeeping/fix-codeformatting

--- a/.github/workflows/dotnet-format-daily-net7.yml
+++ b/.github/workflows/dotnet-format-daily-net7.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
         with:
-          ref: ${{ github.head_ref }}
+          ref: net7.0
 
       - name: Setup .NET Core SDK
         uses: actions/setup-dotnet@v3.2.0

--- a/.github/workflows/dotnet-format-daily-net7.yml
+++ b/.github/workflows/dotnet-format-daily-net7.yml
@@ -46,3 +46,4 @@ jobs:
           assignees: rmarinho, jsuarezruiz
           reviewers: rmarinho, jsuarezruiz
           branch: housekeeping/fix-codeformatting
+          base: net7.0


### PR DESCRIPTION
This splits the daily code formatting action into 2:

1. Running on the .NET 7 branch with .NET 7.0.304
2. Running on the main branch with .NET 8.x

This way it should run correctly for the right .NET SDK version. Downside is that we have an extra point of maintenance.

This is hard to test from a fork/PR etc. so no guarantees this will work in one shot.