### PR TITLE
[GraphicsTester] only build for maccatalyst-x64

### DIFF
--- a/src/Graphics/samples/GraphicsTester.MacCatalyst/GraphicsTester.MacCatalyst.csproj
+++ b/src/Graphics/samples/GraphicsTester.MacCatalyst/GraphicsTester.MacCatalyst.csproj
@@ -8,6 +8,8 @@
     <LangVersion>10.0</LangVersion>
     <SupportedOSPlatformVersion>14.2</SupportedOSPlatformVersion>
     <IsPackable>false</IsPackable>
+    <!-- Disable multi-RID builds to workaround a parallel build issue -->
+    <RuntimeIdentifier Condition="$(TargetFramework.Contains('-maccatalyst'))">maccatalyst-x64</RuntimeIdentifier>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Context: https://dev.azure.com/xamarin/public/_build/results?buildId=89153&view=logs&j=5239058e-6f59-5db5-6c0e-6f79eefcd049&s=b7e1043e-3af4-5003-8e7a-4a0d8ac920f3&t=5a96ad5f-9988-5704-46b8-08f3710aee54&l=9849

Sometimes the MAUI build randomly fails with:

    error MSB3021: Unable to copy file "obj\Release\netstandard2.0\Microsoft.Maui.Graphics.Text.Markdig.dll" to "bin\Release\netstandard2.0\Microsoft.Maui.Graphics.Text.Markdig.dll"

Looking at the `.binlog` this happens inside of:

    Target Name=_RunRidSpecificBuild Project=GraphicsTester.MacCatalyst.csproj
    MSBuild
        Project Name=GraphicsTester.MacCatalyst.csproj File=D:\a\_work\1\s\src\Graphics\samples\GraphicsTester.MacCatalyst\GraphicsTester.MacCatalyst.csproj Targets=[_BuildRidSpecificAppBundle] GlobalProperties=[Configuration=Release, BuildingSolutionFile=true, CurrentSolutionConfigurationContents=<SolutionConfiguration>..., SolutionDir=D:\a\_work\1\s\, SolutionExt=.sln, SolutionFileName=Microsoft.Maui.sln, SolutionName=Microsoft.Maui, SolutionPath=D:\a\_work\1\s\Microsoft.Maui.sln, Platform=AnyCPU, RuntimeIdentifier=maccatalyst-x64, _CodesignItemsPath=obj\Release\net7.0-maccatalyst\codesignitems-maccatalyst-x64.items, _MtouchSymbolsList=, _UserFrameworksWithoutDebugSymbolsPath=obj\Release\net7.0-maccatalyst\user-frameworks-without-dsym-maccatalyst-x64.list, _IsMultiRidBuild=true, RuntimeIdentifiers=, _ProcessedBundleResourcesPath=obj\Release\net7.0-maccatalyst\\_ProcessedBundleResourcesPath.items, _ProcessedContentPath=obj\Release\net7.0-maccatalyst\\_ProcessedContentPath.items, _ProcessedImageAssetsPath=obj\Release\net7.0-maccatalyst\actool\_ProcessedImageAssetsPath.items, _ProcessedInterfaceDefinitionsPath=obj\Release\net7.0-maccatalyst\ibtool\_ProcessedInterfaceDefinitionsPath.items, _ProcessedSceneKitAssetsPath=obj\Release\net7.0-maccatalyst\copySceneKitAssets\_ProcessedSceneKitAssetsPath.items, _ProcessedColladaAssetsPath=obj\Release\net7.0-maccatalyst\collada\_ProcessedColladaAssetsPath.items, _ProcessedTextureAtlasesPath=obj\Release\net7.0-maccatalyst\atlas\_ProcessedTextureAtlasesPath.items, _ProcessedCoreMLModelsPath=obj\Release\net7.0-maccatalyst\coremlc\_ProcessedCoreMLModelsPath.items, _CompiledEntitlementsPath=obj\Release\net7.0-maccatalyst\Entitlements.xcent]
    MSBuild
        Project Name=GraphicsTester.MacCatalyst.csproj File=D:\a\_work\1\s\src\Graphics\samples\GraphicsTester.MacCatalyst\GraphicsTester.MacCatalyst.csproj Targets=[_BuildRidSpecificAppBundle] GlobalProperties=[Configuration=Release, BuildingSolutionFile=true, CurrentSolutionConfigurationContents=<SolutionConfiguration>..., SolutionDir=D:\a\_work\1\s\, SolutionExt=.sln, SolutionFileName=Microsoft.Maui.sln, SolutionName=Microsoft.Maui, SolutionPath=D:\a\_work\1\s\Microsoft.Maui.sln, Platform=AnyCPU, RuntimeIdentifier=maccatalyst-arm64, _CodesignItemsPath=obj\Release\net7.0-maccatalyst\codesignitems-maccatalyst-arm64.items, _MtouchSymbolsList=, _UserFrameworksWithoutDebugSymbolsPath=obj\Release\net7.0-maccatalyst\user-frameworks-without-dsym-maccatalyst-arm64.list, _IsMultiRidBuild=true, RuntimeIdentifiers=, _ProcessedBundleResourcesPath=obj\Release\net7.0-maccatalyst\\_ProcessedBundleResourcesPath.items, _ProcessedContentPath=obj\Release\net7.0-maccatalyst\\_ProcessedContentPath.items, _ProcessedImageAssetsPath=obj\Release\net7.0-maccatalyst\actool\_ProcessedImageAssetsPath.items, _ProcessedInterfaceDefinitionsPath=obj\Release\net7.0-maccatalyst\ibtool\_ProcessedInterfaceDefinitionsPath.items, _ProcessedSceneKitAssetsPath=obj\Release\net7.0-maccatalyst\copySceneKitAssets\_ProcessedSceneKitAssetsPath.items, _ProcessedColladaAssetsPath=obj\Release\net7.0-maccatalyst\collada\_ProcessedColladaAssetsPath.items, _ProcessedTextureAtlasesPath=obj\Release\net7.0-maccatalyst\atlas\_ProcessedTextureAtlasesPath.items, _ProcessedCoreMLModelsPath=obj\Release\net7.0-maccatalyst\coremlc\_ProcessedCoreMLModelsPath.items, _CompiledEntitlementsPath=obj\Release\net7.0-maccatalyst\Entitlements.xcent]

This workaround is in several projects, but not this one:

    <!-- Disable multi-RID builds to workaround a parallel build issue -->
    <RuntimeIdentifier Condition="$(TargetFramework.Contains('-maccatalyst'))">maccatalyst-x64</RuntimeIdentifier>

Let's see if this solves the issue.