### PR TITLE
Streamline ModalNavigation lifecycle events

### DIFF
--- a/src/Controls/src/Core/NavigationPage/NavigationPage.cs
+++ b/src/Controls/src/Core/NavigationPage/NavigationPage.cs
@@ -575,7 +575,23 @@ namespace Microsoft.Maui.Controls
 				else
 				{
 					// Is the root the window or is this part of a modal stack
-					var rootPage = this.FindParentWith(x => (x is IWindow te || Window.Navigation.ModalStack.Contains(x)), true);
+					Element rootPage;
+
+					var parentPages = this.GetParentPages();
+					parentPages.Insert(0, this);
+
+					// Is my top parent page the root page on the window?
+					// If so then we set the toolbar on the window
+					if (Window.Page == parentPages[parentPages.Count - 1])
+					{
+						rootPage = Window;
+					}
+					else
+					{
+						// This means the page is a modal page so we set the toolbar on the top level page
+						// of the modal
+						rootPage = parentPages[parentPages.Count - 1];
+					}
 
 					if (rootPage is Window w)
 					{

--- a/src/Controls/src/Core/NavigationPage/NavigationPage.cs
+++ b/src/Controls/src/Core/NavigationPage/NavigationPage.cs
@@ -575,30 +575,31 @@ namespace Microsoft.Maui.Controls
 				else
 				{
 					// Is the root the window or is this part of a modal stack
-					Element rootPage;
+					Element toolbarRoot;
 
 					var parentPages = this.GetParentPages();
 					parentPages.Insert(0, this);
+	 				var topLevelPage = parentPages[parentPages.Count - 1];
 
 					// Is my top parent page the root page on the window?
 					// If so then we set the toolbar on the window
-					if (Window.Page == parentPages[parentPages.Count - 1])
+					if (Window.Page == topLevelPage)
 					{
-						rootPage = Window;
+						toolbarRoot = Window;
 					}
 					else
 					{
 						// This means the page is a modal page so we set the toolbar on the top level page
 						// of the modal
-						rootPage = parentPages[parentPages.Count - 1];
+						toolbarRoot = topLevelPage;
 					}
 
-					if (rootPage is Window w)
+					if (toolbarRoot is Window w)
 					{
 						_toolbar = new NavigationPageToolbar(w, w.Page);
 						w.Toolbar = _toolbar;
 					}
-					else if (rootPage is Page p)
+					else if (toolbarRoot is Page p)
 					{
 						_toolbar = new NavigationPageToolbar(p, p);
 						p.Toolbar = _toolbar;

--- a/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.cs
+++ b/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.cs
@@ -213,22 +213,19 @@ namespace Microsoft.Maui.Controls.Platform
 				modal.SendNavigatingFrom(new NavigatingFromEventArgs());
 			}
 
+			modal.SendDisappearing();
+
 			// With shell we want to make sure to only fire the appearing event
 			// on the final page that will be visible after the pop has completed
 			if (_window.Page is Shell shell)
 			{
-				if (ModalStack.Count > 0)
-					ModalStack[ModalStack.Count - 1].SendDisappearing();
-
 				if (!shell.CurrentItem.CurrentItem.IsPoppingModalStack)
 				{
-					if (ModalStack.Count > 1)
-						ModalStack[ModalStack.Count - 2].SendAppearing();
+					CurrentPage?.SendAppearing();
 				}
 			}
 			else
 			{
-				modal.SendDisappearing();
 				CurrentPage?.SendAppearing();
 			}
 
@@ -271,12 +268,8 @@ namespace Microsoft.Maui.Controls.Platform
 				// on the final page that will be visible after the pop has completed
 				if (!shell.CurrentItem.CurrentItem.IsPushingModalStack)
 				{
-					if (ModalStack.Count > 0)
-					{
-						ModalStack[ModalStack.Count - 1].SendDisappearing();
-					}
-
-					modal.SendAppearing();
+					previousPage?.SendDisappearing();
+					CurrentPage?.SendAppearing();
 				}
 			}
 			else

--- a/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.cs
+++ b/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.cs
@@ -24,8 +24,18 @@ namespace Microsoft.Maui.Controls.Platform
 		Page CurrentPlatformModalPage =>
 			_platformModalPages.Count > 0 ? _platformModalPages[_platformModalPages.Count - 1] : throw new InvalidOperationException("Modal Stack is Empty");
 
-		Page? CurrentPage =>
-			_modalPages.Count > 0 ? _modalPages[_modalPages.Count - 1].Page : _window.Page;
+		Page? CurrentPage
+		{
+			get
+			{
+				var currentPage = _modalPages.Count > 0 ? _modalPages[_modalPages.Count - 1].Page : _window.Page;
+
+				if (currentPage is Shell shell)
+					currentPage = shell.CurrentPage;
+
+				return currentPage;
+			}
+		}
 
 		// Shell takes care of firing its own Modal life cycle events
 		// With shell you cam remove / add multiple modals at once
@@ -201,6 +211,23 @@ namespace Microsoft.Maui.Controls.Platform
 			if (FireLifeCycleEvents)
 			{
 				modal.SendNavigatingFrom(new NavigatingFromEventArgs());
+			}
+
+			// With shell we want to make sure to only fire the appearing event
+			// on the final page that will be visible after the pop has completed
+			if (_window.Page is Shell shell)
+			{
+				if (ModalStack.Count > 0)
+					ModalStack[ModalStack.Count - 1].SendDisappearing();
+
+				if (!shell.CurrentItem.CurrentItem.IsPoppingModalStack)
+				{
+					if (ModalStack.Count > 1)
+						ModalStack[ModalStack.Count - 2].SendAppearing();
+				}
+			}
+			else
+			{
 				modal.SendDisappearing();
 				CurrentPage?.SendAppearing();
 			}
@@ -236,6 +263,24 @@ namespace Microsoft.Maui.Controls.Platform
 			if (FireLifeCycleEvents)
 			{
 				previousPage?.SendNavigatingFrom(new NavigatingFromEventArgs());
+			}
+
+			if (_window.Page is Shell shell)
+			{
+				// With shell we want to make sure to only fire the appearing event
+				// on the final page that will be visible after the pop has completed
+				if (!shell.CurrentItem.CurrentItem.IsPushingModalStack)
+				{
+					if (ModalStack.Count > 0)
+					{
+						ModalStack[ModalStack.Count - 1].SendDisappearing();
+					}
+
+					modal.SendAppearing();
+				}
+			}
+			else
+			{
 				previousPage?.SendDisappearing();
 				CurrentPage?.SendAppearing();
 			}

--- a/src/Controls/src/Core/Shell/Shell.cs
+++ b/src/Controls/src/Core/Shell/Shell.cs
@@ -1697,21 +1697,11 @@ namespace Microsoft.Maui.Controls
 					return page;
 				}
 
-				if (ModalStack.Count > 0)
-					ModalStack[ModalStack.Count - 1].SendDisappearing();
-
-				if (!_shell.CurrentItem.CurrentItem.IsPoppingModalStack)
-				{
-					if (ModalStack.Count > 1)
-						ModalStack[ModalStack.Count - 2].SendAppearing();
-				}
-
 				var modalPopped = await base.OnPopModal(animated);
 
 				if (ModalStack.Count == 0 && !_shell.CurrentItem.CurrentItem.IsPoppingModalStack)
 					_shell.CurrentItem.SendAppearing();
 
-				modalPopped.Parent = null;
 				return modalPopped;
 			}
 
@@ -1733,18 +1723,6 @@ namespace Microsoft.Maui.Controls
 
 				if (ModalStack.Count == 0)
 					_shell.CurrentItem.SendDisappearing();
-
-				modal.Parent = (Element)_shell.FindParentOfType<IWindow>();
-
-				if (!_shell.CurrentItem.CurrentItem.IsPushingModalStack)
-				{
-					if (ModalStack.Count > 0)
-					{
-						ModalStack[ModalStack.Count - 1].SendDisappearing();
-					}
-
-					modal.SendAppearing();
-				}
 
 				await base.OnPushModal(modal, animated);
 

--- a/src/Controls/tests/Core.UnitTests/NavigationModelTests.cs
+++ b/src/Controls/tests/Core.UnitTests/NavigationModelTests.cs
@@ -12,6 +12,20 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 	public class NavigationModelTests : BaseTestFixture
 	{
 		[Fact]
+		public async Task ParentSetsWhenPushingAndUnsetsWhenPopping()
+		{
+			var mainPage = new ContentPage() { Title = "Main Page" };
+			var modal1 = new ContentPage() { Title = "Modal 1" };
+			TestWindow testWindow = new TestWindow(mainPage);
+
+			await mainPage.Navigation.PushModalAsync(modal1);
+
+			Assert.Equal(testWindow, modal1.Parent);
+			await mainPage.Navigation.PopModalAsync();
+			Assert.Null(modal1.Parent);
+		}
+
+		[Fact]
 		public async Task ModalsWireUpInCorrectOrderWhenPushedBeforeWindowHasBeenCreated()
 		{
 			var mainPage = new ContentPage() { Title = "Main Page" };

--- a/src/Controls/tests/Core.UnitTests/ShellModalTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellModalTests.cs
@@ -350,6 +350,20 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact]
+		public async Task ParentSetsWhenPushingAndUnsetsWhenPopping()
+		{
+			var shell = new TestShell();
+
+			var item = CreateShellItem(shellSectionRoute: "section2");
+			shell.Items.Add(item);
+			await shell.GoToAsync($"ModalTestPage");
+			var modal1 = (shell.CurrentItem.CurrentItem as IShellSectionController).PresentedPage as ModalTestPageBase;
+			Assert.Equal(shell.Window, modal1.Parent);
+			await shell.GoToAsync("..");
+			Assert.Null(modal1.Parent);
+		}
+
+		[Fact]
 		public async Task BasicQueryStringTest()
 		{
 			var shell = new TestShell();

--- a/src/Controls/tests/DeviceTests/ControlsHandlerTestBase.Android.cs
+++ b/src/Controls/tests/DeviceTests/ControlsHandlerTestBase.Android.cs
@@ -123,6 +123,11 @@ namespace Microsoft.Maui.DeviceTests
 
 		protected MaterialToolbar GetPlatformToolbar(IElementHandler handler)
 		{
+			if (handler.VirtualView is VisualElement e)
+			{
+				handler = e.Window?.Handler ?? handler;
+			}
+
 			if (handler is IWindowHandler wh)
 			{
 				handler = wh.VirtualView.Content.Handler;

--- a/src/Controls/tests/DeviceTests/ControlsHandlerTestBase.iOS.cs
+++ b/src/Controls/tests/DeviceTests/ControlsHandlerTestBase.iOS.cs
@@ -108,7 +108,7 @@ namespace Microsoft.Maui.DeviceTests
 		protected object GetTitleView(IElementHandler handler)
 		{
 			var activeVC = GetVisibleViewController(handler);
-			if (activeVC.NavigationItem.TitleView is
+			if (activeVC?.NavigationItem?.TitleView is
 				ShellPageRendererTracker.TitleViewContainer tvc)
 			{
 				return tvc.Subviews[0];
@@ -125,7 +125,10 @@ namespace Microsoft.Maui.DeviceTests
 			}
 
 			if (handler.VirtualView is Page page)
-				handler = page.GetCurrentPage().Handler;
+				handler = page.GetCurrentPage()?.Handler;
+
+			if (handler is null)
+				return new UIViewController[0];
 
 			var navControllerResponder = (handler.PlatformView as UIView).FindResponder<UINavigationController>();
 

--- a/src/Controls/tests/DeviceTests/ControlsHandlerTestBase.iOS.cs
+++ b/src/Controls/tests/DeviceTests/ControlsHandlerTestBase.iOS.cs
@@ -119,6 +119,14 @@ namespace Microsoft.Maui.DeviceTests
 
 		UIViewController[] GetActiveChildViewControllers(IElementHandler handler)
 		{
+			if (handler.VirtualView is IWindow window)
+			{
+				handler = window.Content.Handler;
+			}
+
+			if (handler.VirtualView is Page page)
+				handler = page.GetCurrentPage().Handler;
+
 			var navControllerResponder = (handler.PlatformView as UIView).FindResponder<UINavigationController>();
 
 			if (navControllerResponder?.ChildViewControllers is not null)

--- a/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.cs
@@ -36,24 +36,12 @@ namespace Microsoft.Maui.DeviceTests
 			{
 				builder.ConfigureMauiHandlers(handlers =>
 				{
-					handlers.AddHandler(typeof(Toolbar), typeof(ToolbarHandler));
 					handlers.AddHandler(typeof(NavigationPage), typeof(NavigationViewHandler));
 					handlers.AddHandler(typeof(FlyoutPage), typeof(FlyoutViewHandler));
 					handlers.AddHandler(typeof(TabbedPage), typeof(TabbedViewHandler));
-					handlers.AddHandler<Page, PageHandler>();
 					handlers.AddHandler<Window, WindowHandlerStub>();
-
-					handlers.AddHandler(typeof(Controls.Shell), typeof(ShellHandler));
-					handlers.AddHandler<Layout, LayoutHandler>();
 					handlers.AddHandler<Entry, EntryHandler>();
-					handlers.AddHandler<Image, ImageHandler>();
-					handlers.AddHandler<Label, LabelHandler>();
-					handlers.AddHandler<Toolbar, ToolbarHandler>();
-#if WINDOWS
-					handlers.AddHandler<ShellItem, ShellItemHandler>();
-					handlers.AddHandler<ShellSection, ShellSectionHandler>();
-					handlers.AddHandler<ShellContent, ShellContentHandler>();
-#endif
+					SetupShellHandlers(handlers);
 				});
 			});
 		}
@@ -169,6 +157,50 @@ namespace Microsoft.Maui.DeviceTests
 
 			Assert.Equal(2, windowAppearing);
 			Assert.Equal(2, windowDisappearing);
+		}
+
+		[Fact]
+		public async Task PushingNavigationPageModallyWithShellShowsToolbarCorrectly()
+		{
+			SetupBuilder();
+			var windowPage = new LifeCycleTrackingPage()
+			{
+				Title = "Window Page Title"
+			};
+
+			var modalPage = new NavigationPage(new LifeCycleTrackingPage()
+			{
+				Content = new Label() { Text = "Modal page with navigation" }
+			})
+			{ Title = "modal page" };
+
+			Window window = new Window(new Shell() { CurrentItem = windowPage })
+			{
+				Title = "PushingNavigationPageModallyWithShellShowsToolbarCorrectly Window Title"
+			};
+
+			await CreateHandlerAndAddToWindow<IWindowHandler>(window,
+				async (_) =>
+				{
+					await windowPage.Navigation.PushAsync(new ContentPage() { Title = "Second Page on PushingNavigationPageModallyWithShellShowsToolbarCorrectly" });
+					await windowPage.Navigation.PushModalAsync(modalPage);
+
+					// Navigation Bar is visible
+					Assert.True(await AssertionExtensions.Wait(() => IsNavigationBarVisible(modalPage.Handler)));
+					Assert.False(IsBackButtonVisible(modalPage.Handler));
+
+					// Verify that new navigation bar can gain a back button
+					var secondModalPage = new ContentPage();
+					await modalPage.Navigation.PushAsync(secondModalPage);
+					Assert.True(await AssertionExtensions.Wait(() => IsBackButtonVisible(secondModalPage.Handler)));
+					await secondModalPage.Navigation.PopAsync();
+
+					// Remove the modal page and validate the root window pages toolbar is still setup correctly
+					await modalPage.Navigation.PopModalAsync();
+
+					Assert.True(await AssertionExtensions.Wait(() => IsNavigationBarVisible(windowPage.Handler)));
+					Assert.True(IsBackButtonVisible(windowPage.Handler));
+				});
 		}
 
 		[Theory]

--- a/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.cs
@@ -199,7 +199,7 @@ namespace Microsoft.Maui.DeviceTests
 					await modalPage.Navigation.PopModalAsync();
 
 					Assert.True(await AssertionExtensions.Wait(() => IsNavigationBarVisible(windowPage.Handler)));
-					Assert.True(IsBackButtonVisible(windowPage.Handler));
+					Assert.True(await AssertionExtensions.Wait(() => IsBackButtonVisible(windowPage.Handler)));
 				});
 		}
 

--- a/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.cs
@@ -130,7 +130,7 @@ namespace Microsoft.Maui.DeviceTests
 
 				// Wait for back button to reveal itself
 				Assert.True(await AssertionExtensions.Wait(() => IsBackButtonVisible(handler)));
-			}, timeOut: TimeSpan.FromMinutes(2));
+			});
 		}
 
 		[Fact(DisplayName = "Back Button Visibility Changes with push/pop")]

--- a/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.cs
@@ -301,6 +301,12 @@ namespace Microsoft.Maui.DeviceTests
 			)]
 		public async Task DoesNotLeak()
 		{
+
+#if ANDROID
+			if (!OperatingSystem.IsAndroidVersionAtLeast(30))
+				return;
+#endif
+
 			SetupBuilder();
 			WeakReference pageReference = null;
 			var navPage = new NavigationPage(new ContentPage { Title = "Page 1" });

--- a/src/TestUtils/src/DeviceTests/AssertionExtensions.iOS.cs
+++ b/src/TestUtils/src/DeviceTests/AssertionExtensions.iOS.cs
@@ -613,7 +613,17 @@ namespace Microsoft.Maui.DeviceTests
 			return platformView;
 		}
 
-		static UIView GetBackButton(this UINavigationBar uINavigationBar)
+		public static bool HasBackButton(this UINavigationBar uINavigationBar)
+		{
+			var item = uINavigationBar.FindDescendantView<UIView>(result =>
+			{
+				return result.Class.Name?.Contains("UIButtonBarButton", StringComparison.OrdinalIgnoreCase) == true;
+			});
+
+			return item is not null;
+		}
+
+		public static UIView GetBackButton(this UINavigationBar uINavigationBar)
 		{
 			var item = uINavigationBar.FindDescendantView<UIView>(result =>
 			{


### PR DESCRIPTION
### Description of Change
When the toolbar code was modified to wire up during the windows changed event, this wasn't properly accounted for inside the `Shell` modal workflow. This PR consolidates the lifecycle handling of modals a bit more into the `ModalNavigationManager` to ensure that parents are set and LC events are thrown all in the correct order. 

### Issues Fixed
Fixes #15498 

