### PR TITLE
[ios] fix memory leak in CollectionView cells

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/iOS/TemplatedCell.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/TemplatedCell.cs
@@ -33,7 +33,13 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		{
 		}
 
-		internal IPlatformViewHandler PlatformHandler { get; private set; }
+		WeakReference<IPlatformViewHandler> _handler;
+
+		internal IPlatformViewHandler PlatformHandler
+		{
+			get => _handler is not null && _handler.TryGetTarget(out var h) ? h : null;
+			set => _handler = value == null ? null : new(value);
+		}
 
 		public override void ConstrainTo(CGSize constraint)
 		{

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.iOS.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Reflection;
@@ -89,6 +89,48 @@ namespace Microsoft.Maui.DeviceTests
 
 				Assert.Equal(margin, absPoint.X);
 			});
+		}
+
+		[Fact("Cells Do Not Leak")]
+		public async Task CellsDoNotLeak()
+		{
+			SetupBuilder();
+
+			var labels = new List<WeakReference>();
+			VerticalCell cell = null;
+
+			{
+				var bindingContext = "foo";
+				var collectionView = new CollectionView
+				{
+					ItemTemplate = new DataTemplate(() =>
+					{
+						var label = new Label();
+						labels.Add(new(label));
+						return label;
+					}),
+				};
+
+				var handler = await CreateHandlerAsync(collectionView);
+
+				await InvokeOnMainThreadAsync(() =>
+				{
+					cell = new VerticalCell(CGRect.Empty);
+					cell.Bind(collectionView.ItemTemplate, bindingContext, collectionView);
+				});
+
+				Assert.NotNull(cell);
+				Assert.NotEmpty(labels);
+			}
+
+			await Task.Yield();
+			GC.Collect();
+			GC.WaitForPendingFinalizers();
+
+			foreach (var reference in labels)
+			{
+				Assert.False(reference.IsAlive, "View should not be alive!");
+			}
 		}
 	}
 }


### PR DESCRIPTION
Context: https://github.com/dotnet/maui/issues/14664
Context: https://github.com/nacompllo/MemoryLeakEverywhere/tree/bugfix/memoryLeakItemsSource

In reviewing our latest changes in main with the above customer sample, I found that there appeared to be leaks related to MAUI's `UITableViewCell` subclasses when using `CollectionView`.

I was able to reproduce the issue in a test, such as:

    // DataTemplate saves WeakReference to the View in a list
    collectionView.ItemTemplate = new DataTemplate(() =>
    {
        var label = new Label();
        labels.Add(new(label));
        return label;
    });

    // Create a cell and bind it to the template:
    cell = new VerticalCell(CGRect.Empty);
    cell.Bind(collectionView.ItemTemplate, bindingContext, collectionView);

    // Check we have no leaks
    foreach (var reference in labels)
    {
        Assert.False(reference.IsAlive, "View should not be alive!");
    }

After isolating the issue, I found the issue was the `TemplatedCell.PlatformHandler` property:

    internal IPlatformViewHandler PlatformHandler { get; private set; }

This stores a copy of the `LabelHandler` in our test/example.

The problem with `UITableViewCell` is that UIKit holds onto these and reuses them. This means that UIKit may keep the `LabelHandler` alive longer than needed.

It also appears to be a somewhat complex circular reference:

* `CollectionView` -> handlers / etc. -> `TemplatedCell` -> `LabelHandler` -> `Label` -> `CollectionView`

I made the `PlatformHandler` use a `WeakReference` as its backing field and the problem goes away!

I will retest #14664 to verify if it is fully solved.