### PR TITLE
Fix PointerGesture CommandParameter properties

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Core/PointerGestureGalleryPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/PointerGestureGalleryPage.xaml
@@ -16,5 +16,8 @@
         <Label x:Name="positionLabel" Text="Hover above label to reveal pointer position"/>
         <Label x:Name="positionToWindow" />
         <Label x:Name="positionToThisLabel" />
+
+        <Label x:Name="colorfulHoverLabel" Text="Hover me green!" FontSize="24" />
+        <Label Text="Hover above label to make it turn green" />
     </StackLayout>
 </views:BasePage>

--- a/src/Controls/samples/Controls.Sample/Pages/Core/PointerGestureGalleryPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/PointerGestureGalleryPage.xaml.cs
@@ -1,12 +1,24 @@
 ﻿using Microsoft.Maui.Controls;
+using Microsoft.Maui.Graphics;
 
 namespace Maui.Controls.Sample.Pages
 {
 	public partial class PointerGestureGalleryPage
 	{
+		Command _hoverEnterCommand;
+
 		public PointerGestureGalleryPage()
 		{
 			InitializeComponent();
+
+			_hoverEnterCommand = new Command<Color>(HandleHoverEnterCommand);
+
+			var colorfulHoverEnterGesture = new PointerGestureRecognizer
+			{
+				PointerEnteredCommand = _hoverEnterCommand,
+				PointerEnteredCommandParameter = Colors.Green
+			};
+			colorfulHoverLabel.GestureRecognizers.Add(colorfulHoverEnterGesture);
 		}
 
 		void HoverBegan(object sender, PointerEventArgs e)
@@ -25,6 +37,11 @@ namespace Maui.Controls.Sample.Pages
 			positionLabel.Text = $"Pointer position is at: {e.GetPosition((View)sender)}";
 			positionToWindow.Text = $"Pointer position inside window: {e.GetPosition(null)}";
 			positionToThisLabel.Text = $"Pointer position relative to this label: {e.GetPosition(positionToThisLabel)}";
+		}
+
+		void HandleHoverEnterCommand(Color hoverColor)
+		{
+			colorfulHoverLabel.TextColor = hoverColor;
 		}
 	}
 }

--- a/src/Controls/src/Core/PointerGestureRecognizer.cs
+++ b/src/Controls/src/Core/PointerGestureRecognizer.cs
@@ -74,9 +74,9 @@ namespace Microsoft.Maui.Controls
 		/// <summary>
 		/// Identifies the PointerEnteredCommandParameter bindable property.
 		/// </summary>
-		public ICommand PointerEnteredCommandParameter
+		public object PointerEnteredCommandParameter
 		{
-			get { return (ICommand)GetValue(PointerEnteredCommandParameterProperty); }
+			get { return GetValue(PointerEnteredCommandParameterProperty); }
 			set { SetValue(PointerEnteredCommandParameterProperty, value); }
 		}
 
@@ -92,9 +92,9 @@ namespace Microsoft.Maui.Controls
 		/// <summary>
 		/// Identifies the PointerExitedCommandParameter bindable property.
 		/// </summary>
-		public ICommand PointerExitedCommandParameter
+		public object PointerExitedCommandParameter
 		{
-			get { return (ICommand)GetValue(PointerExitedCommandParameterProperty); }
+			get { return GetValue(PointerExitedCommandParameterProperty); }
 			set { SetValue(PointerExitedCommandParameterProperty, value); }
 		}
 
@@ -110,9 +110,9 @@ namespace Microsoft.Maui.Controls
 		/// <summary>
 		/// Identifies the PointerMovedCommandParameter bindable property.
 		/// </summary>
-		public ICommand PointerMovedCommandParameter
+		public object PointerMovedCommandParameter
 		{
-			get { return (ICommand)GetValue(PointerMovedCommandParameterProperty); }
+			get { return GetValue(PointerMovedCommandParameterProperty); }
 			set { SetValue(PointerMovedCommandParameterProperty, value); }
 		}
 

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -12,6 +12,12 @@ override Microsoft.Maui.Controls.Handlers.Items.ItemsViewHandler<TItemsView>.Get
 override Microsoft.Maui.Controls.Handlers.Items.ItemsViewHandler<TItemsView>.PlatformArrange(Microsoft.Maui.Graphics.Rect frame) -> void
 Microsoft.Maui.Controls.LayoutOptions.Equals(Microsoft.Maui.Controls.LayoutOptions other) -> bool
 Microsoft.Maui.Controls.Platform.ShapesExtensions
+Microsoft.Maui.Controls.PointerGestureRecognizer.PointerEnteredCommandParameter.get -> object!
+Microsoft.Maui.Controls.PointerGestureRecognizer.PointerExitedCommandParameter.get -> object!
+Microsoft.Maui.Controls.PointerGestureRecognizer.PointerMovedCommandParameter.get -> object!
+*REMOVED*Microsoft.Maui.Controls.PointerGestureRecognizer.PointerEnteredCommandParameter.get -> System.Windows.Input.ICommand!
+*REMOVED*Microsoft.Maui.Controls.PointerGestureRecognizer.PointerExitedCommandParameter.get -> System.Windows.Input.ICommand!
+*REMOVED*Microsoft.Maui.Controls.PointerGestureRecognizer.PointerMovedCommandParameter.get -> System.Windows.Input.ICommand!
 Microsoft.Maui.Controls.Region.Equals(Microsoft.Maui.Controls.Region other) -> bool
 Microsoft.Maui.Controls.Shapes.Matrix.Equals(Microsoft.Maui.Controls.Shapes.Matrix other) -> bool
 Microsoft.Maui.Controls.Shapes.Shape.~Shape() -> void

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -7,6 +7,12 @@ Microsoft.Maui.Controls.Handlers.Compatibility.PhoneFlyoutPageRenderer.FlyoutOve
 Microsoft.Maui.Controls.Handlers.Compatibility.PhoneFlyoutPageRenderer.FlyoutOverlapsDetailsInPopoverMode.set -> void
 Microsoft.Maui.Controls.LayoutOptions.Equals(Microsoft.Maui.Controls.LayoutOptions other) -> bool
 Microsoft.Maui.Controls.Platform.ShapesExtensions
+Microsoft.Maui.Controls.PointerGestureRecognizer.PointerEnteredCommandParameter.get -> object!
+Microsoft.Maui.Controls.PointerGestureRecognizer.PointerExitedCommandParameter.get -> object!
+Microsoft.Maui.Controls.PointerGestureRecognizer.PointerMovedCommandParameter.get -> object!
+*REMOVED*Microsoft.Maui.Controls.PointerGestureRecognizer.PointerEnteredCommandParameter.get -> System.Windows.Input.ICommand!
+*REMOVED*Microsoft.Maui.Controls.PointerGestureRecognizer.PointerExitedCommandParameter.get -> System.Windows.Input.ICommand!
+*REMOVED*Microsoft.Maui.Controls.PointerGestureRecognizer.PointerMovedCommandParameter.get -> System.Windows.Input.ICommand!
 Microsoft.Maui.Controls.Region.Equals(Microsoft.Maui.Controls.Region other) -> bool
 Microsoft.Maui.Controls.Shapes.Matrix.Equals(Microsoft.Maui.Controls.Shapes.Matrix other) -> bool
 Microsoft.Maui.Controls.Shapes.Shape.~Shape() -> void

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -7,6 +7,12 @@ Microsoft.Maui.Controls.Handlers.Compatibility.PhoneFlyoutPageRenderer.FlyoutOve
 Microsoft.Maui.Controls.Handlers.Compatibility.PhoneFlyoutPageRenderer.FlyoutOverlapsDetailsInPopoverMode.set -> void
 Microsoft.Maui.Controls.LayoutOptions.Equals(Microsoft.Maui.Controls.LayoutOptions other) -> bool
 Microsoft.Maui.Controls.Platform.ShapesExtensions
+Microsoft.Maui.Controls.PointerGestureRecognizer.PointerEnteredCommandParameter.get -> object!
+Microsoft.Maui.Controls.PointerGestureRecognizer.PointerExitedCommandParameter.get -> object!
+Microsoft.Maui.Controls.PointerGestureRecognizer.PointerMovedCommandParameter.get -> object!
+*REMOVED*Microsoft.Maui.Controls.PointerGestureRecognizer.PointerEnteredCommandParameter.get -> System.Windows.Input.ICommand!
+*REMOVED*Microsoft.Maui.Controls.PointerGestureRecognizer.PointerExitedCommandParameter.get -> System.Windows.Input.ICommand!
+*REMOVED*Microsoft.Maui.Controls.PointerGestureRecognizer.PointerMovedCommandParameter.get -> System.Windows.Input.ICommand!
 Microsoft.Maui.Controls.Region.Equals(Microsoft.Maui.Controls.Region other) -> bool
 Microsoft.Maui.Controls.Shapes.Matrix.Equals(Microsoft.Maui.Controls.Shapes.Matrix other) -> bool
 Microsoft.Maui.Controls.Shapes.Shape.~Shape() -> void

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -3,6 +3,12 @@ Microsoft.Maui.Controls.Border.~Border() -> void
 Microsoft.Maui.Controls.IWindowCreator
 Microsoft.Maui.Controls.IWindowCreator.CreateWindow(Microsoft.Maui.Controls.Application! app, Microsoft.Maui.IActivationState? activationState) -> Microsoft.Maui.Controls.Window!
 Microsoft.Maui.Controls.LayoutOptions.Equals(Microsoft.Maui.Controls.LayoutOptions other) -> bool
+Microsoft.Maui.Controls.PointerGestureRecognizer.PointerEnteredCommandParameter.get -> object!
+Microsoft.Maui.Controls.PointerGestureRecognizer.PointerExitedCommandParameter.get -> object!
+Microsoft.Maui.Controls.PointerGestureRecognizer.PointerMovedCommandParameter.get -> object!
+*REMOVED*Microsoft.Maui.Controls.PointerGestureRecognizer.PointerEnteredCommandParameter.get -> System.Windows.Input.ICommand!
+*REMOVED*Microsoft.Maui.Controls.PointerGestureRecognizer.PointerExitedCommandParameter.get -> System.Windows.Input.ICommand!
+*REMOVED*Microsoft.Maui.Controls.PointerGestureRecognizer.PointerMovedCommandParameter.get -> System.Windows.Input.ICommand!
 Microsoft.Maui.Controls.Region.Equals(Microsoft.Maui.Controls.Region other) -> bool
 Microsoft.Maui.Controls.Shapes.Matrix.Equals(Microsoft.Maui.Controls.Shapes.Matrix other) -> bool
 Microsoft.Maui.Controls.VisualElement.~VisualElement() -> void

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -5,6 +5,12 @@ Microsoft.Maui.Controls.IWindowCreator
 Microsoft.Maui.Controls.IWindowCreator.CreateWindow(Microsoft.Maui.Controls.Application! app, Microsoft.Maui.IActivationState? activationState) -> Microsoft.Maui.Controls.Window!
 Microsoft.Maui.Controls.Platform.CollectionViewExtensions
 Microsoft.Maui.Controls.Platform.ShapesExtensions
+Microsoft.Maui.Controls.PointerGestureRecognizer.PointerEnteredCommandParameter.get -> object!
+Microsoft.Maui.Controls.PointerGestureRecognizer.PointerExitedCommandParameter.get -> object!
+Microsoft.Maui.Controls.PointerGestureRecognizer.PointerMovedCommandParameter.get -> object!
+*REMOVED*Microsoft.Maui.Controls.PointerGestureRecognizer.PointerEnteredCommandParameter.get -> System.Windows.Input.ICommand!
+*REMOVED*Microsoft.Maui.Controls.PointerGestureRecognizer.PointerExitedCommandParameter.get -> System.Windows.Input.ICommand!
+*REMOVED*Microsoft.Maui.Controls.PointerGestureRecognizer.PointerMovedCommandParameter.get -> System.Windows.Input.ICommand!
 Microsoft.Maui.Controls.Handlers.Items.StructuredItemsViewHandler<TItemsView>.~StructuredItemsViewHandler() -> void
 override Microsoft.Maui.Controls.Handlers.BoxViewHandler.NeedsContainer.get -> bool
 Microsoft.Maui.Controls.Handlers.BoxViewHandler

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -4,6 +4,12 @@ Microsoft.Maui.Controls.Border.~Border() -> void
 Microsoft.Maui.Controls.IWindowCreator
 Microsoft.Maui.Controls.IWindowCreator.CreateWindow(Microsoft.Maui.Controls.Application! app, Microsoft.Maui.IActivationState? activationState) -> Microsoft.Maui.Controls.Window!
 Microsoft.Maui.Controls.LayoutOptions.Equals(Microsoft.Maui.Controls.LayoutOptions other) -> bool
+Microsoft.Maui.Controls.PointerGestureRecognizer.PointerEnteredCommandParameter.get -> object!
+Microsoft.Maui.Controls.PointerGestureRecognizer.PointerExitedCommandParameter.get -> object!
+Microsoft.Maui.Controls.PointerGestureRecognizer.PointerMovedCommandParameter.get -> object!
+*REMOVED*Microsoft.Maui.Controls.PointerGestureRecognizer.PointerEnteredCommandParameter.get -> System.Windows.Input.ICommand!
+*REMOVED*Microsoft.Maui.Controls.PointerGestureRecognizer.PointerExitedCommandParameter.get -> System.Windows.Input.ICommand!
+*REMOVED*Microsoft.Maui.Controls.PointerGestureRecognizer.PointerMovedCommandParameter.get -> System.Windows.Input.ICommand!
 Microsoft.Maui.Controls.Region.Equals(Microsoft.Maui.Controls.Region other) -> bool
 Microsoft.Maui.Controls.Shapes.Matrix.Equals(Microsoft.Maui.Controls.Shapes.Matrix other) -> bool
 Microsoft.Maui.Controls.Shapes.Shape.~Shape() -> void

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -4,6 +4,12 @@ Microsoft.Maui.Controls.Border.~Border() -> void
 Microsoft.Maui.Controls.IWindowCreator
 Microsoft.Maui.Controls.IWindowCreator.CreateWindow(Microsoft.Maui.Controls.Application! app, Microsoft.Maui.IActivationState? activationState) -> Microsoft.Maui.Controls.Window!
 Microsoft.Maui.Controls.LayoutOptions.Equals(Microsoft.Maui.Controls.LayoutOptions other) -> bool
+Microsoft.Maui.Controls.PointerGestureRecognizer.PointerEnteredCommandParameter.get -> object!
+Microsoft.Maui.Controls.PointerGestureRecognizer.PointerExitedCommandParameter.get -> object!
+Microsoft.Maui.Controls.PointerGestureRecognizer.PointerMovedCommandParameter.get -> object!
+*REMOVED*Microsoft.Maui.Controls.PointerGestureRecognizer.PointerEnteredCommandParameter.get -> System.Windows.Input.ICommand!
+*REMOVED*Microsoft.Maui.Controls.PointerGestureRecognizer.PointerExitedCommandParameter.get -> System.Windows.Input.ICommand!
+*REMOVED*Microsoft.Maui.Controls.PointerGestureRecognizer.PointerMovedCommandParameter.get -> System.Windows.Input.ICommand!
 Microsoft.Maui.Controls.Region.Equals(Microsoft.Maui.Controls.Region other) -> bool
 Microsoft.Maui.Controls.Shapes.Matrix.Equals(Microsoft.Maui.Controls.Shapes.Matrix other) -> bool
 Microsoft.Maui.Controls.Shapes.Shape.~Shape() -> void

--- a/src/Controls/tests/Core.UnitTests/Gestures/PointerGestureRecognizerTests.cs
+++ b/src/Controls/tests/Core.UnitTests/Gestures/PointerGestureRecognizerTests.cs
@@ -61,6 +61,51 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.Null(gestureRecognizer.Parent);
 		}
 
+		[Fact]
+		public void PointerEnteredCommandFires()
+		{
+			var gesture = new PointerGestureRecognizer();
+			var parameter = new object();
+			object commandExecuted = null;
+			Command cmd = new Command(() => commandExecuted = parameter);
+
+			gesture.PointerEnteredCommand = cmd;
+			gesture.PointerEnteredCommandParameter = parameter;
+			cmd?.Execute(parameter);
+
+			Assert.Equal(commandExecuted, parameter);
+		}
+
+		[Fact]
+		public void PointerExitedCommandFires()
+		{
+			var gesture = new PointerGestureRecognizer();
+			var parameter = new object();
+			object commandExecuted = null;
+			Command cmd = new Command(() => commandExecuted = parameter);
+
+			gesture.PointerExitedCommand = cmd;
+			gesture.PointerExitedCommandParameter = parameter;
+			cmd?.Execute(parameter);
+
+			Assert.Equal(commandExecuted, parameter);
+		}
+
+		[Fact]
+		public void PointerMovedCommandFires()
+		{
+			var gesture = new PointerGestureRecognizer();
+			var parameter = new object();
+			object commandExecuted = null;
+			Command cmd = new Command(() => commandExecuted = parameter);
+
+			gesture.PointerMovedCommand = cmd;
+			gesture.PointerMovedCommandParameter = parameter;
+			cmd?.Execute(parameter);
+
+			Assert.Equal(commandExecuted, parameter);
+		}
+
 		VisualStateGroupList AddPointerOverVisualState(VisualElement visualElement)
 		{
 			VisualStateGroupList visualStateGroups = new VisualStateGroupList();


### PR DESCRIPTION
### Description of Change

Change PointerEnteredCommandParameter, PointerExitedCommandParameter, PointerMovedCommandParameter  types to object. 
Properties are working as expected.

### Issues Fixed

Fixes #15466
