### PR TITLE
[X] avoid AmbiguousMatchException

### DIFF
--- a/src/Controls/src/Xaml/ApplyPropertiesVisitor.cs
+++ b/src/Controls/src/Xaml/ApplyPropertiesVisitor.cs
@@ -583,17 +583,7 @@ namespace Microsoft.Maui.Controls.Xaml
 					}
 				};
 			else
-				minforetriever = () =>
-				{
-					try
-					{
-						return property.DeclaringType.GetRuntimeProperty(property.PropertyName);
-					}
-					catch (AmbiguousMatchException e)
-					{
-						throw new XamlParseException($"Multiple properties with name '{property.DeclaringType}.{property.PropertyName}' found.", lineInfo, innerException: e);
-					}
-				};
+				minforetriever = () => property.DeclaringType.GetRuntimeProperties().FirstOrDefault(pi => pi.Name == property.PropertyName);
 			var convertedValue = value.ConvertTo(property.ReturnType, minforetriever, serviceProvider, out exception);
 			if (exception != null)
 				return false;

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui13962.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui13962.xaml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests"
+             x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui13962">
+    <local:Maui13962CustomCheckBox IsChecked="false" /> 
+</ContentView>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui13962.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui13962.xaml.cs
@@ -1,0 +1,44 @@
+using Microsoft.Maui.ApplicationModel;
+using Microsoft.Maui.Controls.Core.UnitTests;
+using Microsoft.Maui.Controls.Shapes;
+using Microsoft.Maui.Devices;
+using NUnit.Framework;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public class Maui13962CustomCheckBox : CheckBox
+{
+	public static new readonly BindableProperty IsCheckedProperty =
+	BindableProperty.Create(nameof(IsChecked), typeof(bool?), typeof(Maui13962CustomCheckBox), false, BindingMode.TwoWay);
+
+	public new bool? IsChecked
+	{
+		get { return (bool?)this.GetValue(IsCheckedProperty); }
+		set { this.SetValue(IsCheckedProperty, value); }
+	}
+}
+
+public partial class Maui13962 : ContentView
+{
+
+	public Maui13962() => InitializeComponent();
+
+	public Maui13962(bool useCompiledXaml)
+	{
+		//this stub will be replaced at compile time
+	}
+
+	[TestFixture]
+	class Test
+	{
+		[SetUp] public void Setup() => AppInfo.SetCurrent(new MockAppInfo());
+		[TearDown] public void TearDown() => AppInfo.SetCurrent(null);
+
+		[Test]
+		public void ResolutionOfOverridenBP([Values(false, true)] bool useCompiledXaml)
+		{
+			//shouln't throw
+			var page = new Maui13962(useCompiledXaml);
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change

with XamlC disabled, setting an overriden property throws a AmbiguousMatchException. This fixes the mismatch between the 2 inflaters.

### Issues Fixed
- fixes #13962