### PR TITLE
Daily code formatting task: use different branch for net7.0 branch

### DIFF
--- a/.github/workflows/dotnet-format-daily-net7.yml
+++ b/.github/workflows/dotnet-format-daily-net7.yml
@@ -1,4 +1,4 @@
-name: Daily code format check
+name: Daily code format check net7.0 branch
 on:
   workflow_dispatch:
   schedule:
@@ -45,5 +45,5 @@ jobs:
             area/infrastructure 🏗️
           assignees: rmarinho, jsuarezruiz
           reviewers: rmarinho, jsuarezruiz
-          branch: housekeeping/fix-codeformatting
+          branch: housekeeping/fix-codeformatting-net7.0
           base: net7.0


### PR DESCRIPTION
The way the 2 daily code formatting checks are now setup they were using the same branch to make a PR and that would update the PR branch and suddenly we were pushing all changes from main to net7.0. See #15864

This change makes sure that the daily task for net7.0 has a different branch to create the PR so the two aren't confused.