### PR TITLE
Reflect default value of IsClippedToBounds property

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Android/FrameRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Android/FrameRenderer.cs
@@ -239,7 +239,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			if (Element == null)
 				return;
 
-			var shouldClip = Element.IsClippedToBoundsSet(Element.CornerRadius > 0f);
+			var shouldClip = Element.IsClippedToBoundsSet(Element.IsClippedToBounds);
 
 			this.SetClipToOutline(shouldClip);
 		}

--- a/src/Controls/src/Core/Compatibility/Handlers/iOS/FrameRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/iOS/FrameRenderer.cs
@@ -136,7 +136,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 			_actualView.Layer.RasterizationScale = UIScreen.MainScreen.Scale;
 			_actualView.Layer.ShouldRasterize = true;
-			_actualView.Layer.MasksToBounds = Element.IsClippedToBoundsSet(true);
+			_actualView.Layer.MasksToBounds = Element.IsClippedToBoundsSet(Element.IsClippedToBounds);
 		}
 
 		void UpdateShadow()


### PR DESCRIPTION
### Description of Change

<!-- Enter description of the fix in this section -->
In PR #11352, the default value is true when the IsClippedToBounds property value on the iOS side is not set, but the default value when the IsClippedToBounds property value is not set on the Android side is Element.CornerRadius > 0f.

This PR unifies the different default values ​​for both iOS and Android.

If the IsClippedToBounds property is not specified on XAML, the default value is false as shown below.

[src\Controls\src\Core\Layout.cs]

    public static readonly BindableProperty IsClippedToBoundsProperty =
        BindableProperty.Create(nameof(IsClippedToBounds), typeof(bool), typeof(Layout), false,
            propertyChanged: IsClippedToBoundsPropertyChanged);

Even in Xamarin.Forms, the default value of the Frame.IsClippedBounds property was false.

https://learn.microsoft.com/en-us/dotnet/api/xamarin.forms.layout.isclippedtobounds?view=xamarin-forms#xamarin-forms-layout-isclippedtobounds

At least the current behavior does not correctly reflect the default value of IsClippedToBoundsProperty.

Below is the source code before the change.

[src\Controls\src\Core\Compatibility\Handlers\iOS\FrameRenderer.cs]

    public virtual void SetupLayer()
    {
        omit ...

        _actualView.Layer.RasterizationScale = UIScreen.MainScreen.Scale;
        _actualView.Layer.ShouldRasterize = true;
        _actualView.Layer.MasksToBounds = Element.IsClippedToBoundsSet(true);
    }

[src\Controls\src\Core\Compatibility\Handlers\Android\FrameRenderer.cs]

    void UpdateClippedToBounds()
    {
        if (Element == null)
            return;

        var shouldClip = Element.IsClippedToBoundsSet(Element.CornerRadius > 0f);

        this.SetClipToOutline(shouldClip);
    }


Below is the modified source code.

[src\Controls\src\Core\Compatibility\Handlers\iOS\FrameRenderer.cs]

    public virtual void SetupLayer()
    {
        omit ...

        _actualView.Layer.RasterizationScale = UIScreen.MainScreen.Scale;
        _actualView.Layer.ShouldRasterize = true;
        _actualView.Layer.MasksToBounds = Element.IsClippedToBoundsSet(Element.IsClippedToBounds);
    }

[src\Controls\src\Core\Compatibility\Handlers\Android\FrameRenderer.cs]

    void UpdateClippedToBounds()
    {
        if (Element == null)
            return;

        var shouldClip = Element.IsClippedToBoundsSet(Element.IsClippedToBounds);

        this.SetClipToOutline(shouldClip);
    }

Applying this PR has implications if the IsClippedToBounds property is not specified on the XAML.

Since iOS expects true as the default value, applying this PR results in false, which is different from the expected result.

Android expects to be true when CornerRadius is greater than 0, so applying this PR will result in a different result than expected.

Either way, on both iOS and Android, the results are different from what you might have expected so far.

Before applying this PR, you should consider what the default value of IsClippedToBounds should be.
After consideration, this PR should be applied if the current default value of false for the IsClippedToBounds property is followed.

I'll leave it up to you how you decide, because it has a big impact.

From the above, the execution results for Android and iOS are as follows.

[Android IsClippedToBounds unspecified]

<img src="https://github.com/dotnet/maui/assets/125236133/b96cd6b2-8b32-43a2-8ab2-c09540825bda" height="500">

[Android IsClippedToBounds = "True"]

<img src="https://github.com/dotnet/maui/assets/125236133/e9a8000c-24d8-4757-b7b7-c7d84173b40c" height="500">

[Android IsClippedToBounds = "False"]

<img src="https://github.com/dotnet/maui/assets/125236133/a777cbe4-6249-420e-9bca-b8be43b1c7e3" height="500">

[iOS IsClippedToBounds unspecified]

<img src="https://github.com/dotnet/maui/assets/125236133/88c79087-c47e-4d6f-aba8-9fb92a502153" height="500">

[iOS IsClippedToBounds = "True"]

<img src="https://github.com/dotnet/maui/assets/125236133/fb586a17-8f14-4d61-b049-946bf6cccc4d" height="500">

[iOS IsClippedToBounds = "False"]

<img src="https://github.com/dotnet/maui/assets/125236133/569eaca3-f2ca-4f02-b080-fdedb5566fa2" height="500">

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #15029

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
