### PR TITLE
[release/8.0.1xx-preview6] Bump to xamarin/xamarin-android/release/8.0.1xx-preview6@e55038e5

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,28 +1,16 @@
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.Dotnet.Sdk.Internal" Version="8.0.100-preview.6.23318.1" CoherentParentDependency="Microsoft.Android.Sdk.Windows">
+    <Dependency Name="Microsoft.Dotnet.Sdk.Internal" Version="8.0.100-preview.6.23326.6" CoherentParentDependency="Microsoft.Android.Sdk.Windows">
       <Uri>https://github.com/dotnet/installer</Uri>
-      <Sha>8d98e5a6ba7f7fbc157ebea6317d8e7418472920</Sha>
+      <Sha>11cc26c6e442fd63cdbd233467867cca37868d63</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="8.0.0-preview.6.23316.3" CoherentParentDependency="Microsoft.Android.Sdk.Windows">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="8.0.0-preview.6.23323.4" CoherentParentDependency="Microsoft.Android.Sdk.Windows">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>76da696f3ffdd81506b09dfc440ee6f4e1001868</Sha>
+      <Sha>edfe49168f3e6f3d30237a0afeabf5dcae2abad5</Sha>
     </Dependency>
-    <Dependency Name="System.Text.Json" Version="8.0.0-preview.6.23279.6" CoherentParentDependency="Microsoft.Android.Sdk.Windows">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha></Sha>
-    </Dependency>
-    <Dependency Name="System.Text.Encodings.Web" Version="8.0.0-preview.6.23279.6" CoherentParentDependency="Microsoft.Android.Sdk.Windows">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha></Sha>
-    </Dependency>
-    <Dependency Name="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0-preview.6.23279.6" CoherentParentDependency="Microsoft.Android.Sdk.Windows">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha></Sha>
-    </Dependency>
-    <Dependency Name="Microsoft.Android.Sdk.Windows" Version="34.0.0-preview.6.353">
+    <Dependency Name="Microsoft.Android.Sdk.Windows" Version="34.0.0-preview.6.359">
       <Uri>https://github.com/xamarin/xamarin-android</Uri>
-      <Sha>e08a44dd291f0c9daac12f29d6a4c8ecdeaa04bb</Sha>
+      <Sha>e55038e54e152d17158effdc45ce9431be96481f</Sha>
     </Dependency>
     <Dependency Name="Microsoft.MacCatalyst.Sdk" Version="16.4.8646-net8-p6">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
@@ -40,9 +28,9 @@
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
       <Sha>a18037e1779c3591e0818d36a2dca226e4a38283</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Workload.Emscripten.Current.Manifest-8.0.100.Transport" Version="8.0.0-preview.6.23312.1" CoherentParentDependency="Microsoft.NETCore.App.Ref">
+    <Dependency Name="Microsoft.NET.Workload.Emscripten.Current.Manifest-8.0.100.Transport" Version="8.0.0-preview.6.23321.4" CoherentParentDependency="Microsoft.NETCore.App.Ref">
       <Uri>https://github.com/dotnet/emsdk</Uri>
-      <Sha>1640faa87e2e7656bf20dfe38eb8ea3cc3b9e806</Sha>
+      <Sha>4ba5a69eae48bbffc4a8269905b326ba3356869c</Sha>
     </Dependency>
     <Dependency Name="Microsoft.WindowsAppSDK" Version="0.0.1">
       <Uri>https://dev.azure.com/microsoft/ProjectReunion/_git/ProjectReunionInternal</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -3,18 +3,18 @@
     <!-- Current previous .NET SDK major version's stable release of MAUI packages -->
     <MicrosoftMauiPreviousDotNetReleasedVersion>7.0.90</MicrosoftMauiPreviousDotNetReleasedVersion>
     <!-- dotnet/installer -->
-    <MicrosoftDotnetSdkInternalPackageVersion>8.0.100-preview.6.23318.1</MicrosoftDotnetSdkInternalPackageVersion>
+    <MicrosoftDotnetSdkInternalPackageVersion>8.0.100-preview.6.23326.6</MicrosoftDotnetSdkInternalPackageVersion>
     <!-- dotnet/runtime -->
-    <MicrosoftNETCoreAppRefPackageVersion>8.0.0-preview.6.23316.3</MicrosoftNETCoreAppRefPackageVersion>
-    <SystemTextJsonPackageVersion>8.0.0-preview.6.23279.6</SystemTextJsonPackageVersion>
-    <SystemTextEncodingsWebPackageVersion>8.0.0-preview.6.23279.6</SystemTextEncodingsWebPackageVersion>
-    <MicrosoftBclAsyncInterfacesPackageVersion>8.0.0-preview.6.23279.6</MicrosoftBclAsyncInterfacesPackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>8.0.0-preview.6.23323.4</MicrosoftNETCoreAppRefPackageVersion>
+    <SystemTextJsonPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemTextJsonPackageVersion>
+    <SystemTextEncodingsWebPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemTextEncodingsWebPackageVersion>
+    <MicrosoftBclAsyncInterfacesPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</MicrosoftBclAsyncInterfacesPackageVersion>
     <!-- NOTE: should eventually revert back to $(MicrosoftNETCoreAppRefPackageVersion) in .NET 7 -->
     <MicrosoftExtensionsPackageVersion>8.0.0-preview.6.23317.4</MicrosoftExtensionsPackageVersion>
     <MicrosoftExtensionsServicingPackageVersion>8.0.0-preview.6.23317.4</MicrosoftExtensionsServicingPackageVersion>
     <SystemCodeDomPackageVersion>8.0.0-preview.6.23317.4</SystemCodeDomPackageVersion>
     <!-- xamarin/xamarin-android -->
-    <MicrosoftAndroidSdkWindowsPackageVersion>34.0.0-preview.6.353</MicrosoftAndroidSdkWindowsPackageVersion>
+    <MicrosoftAndroidSdkWindowsPackageVersion>34.0.0-preview.6.359</MicrosoftAndroidSdkWindowsPackageVersion>
     <!-- xamarin/xamarin-macios -->
     <MicrosoftMacCatalystSdkPackageVersion>16.4.8646-net8-p6</MicrosoftMacCatalystSdkPackageVersion>
     <MicrosoftmacOSSdkPackageVersion>13.3.8646-net8-p6</MicrosoftmacOSSdkPackageVersion>
@@ -23,7 +23,7 @@
     <!-- Samsung/Tizen.NET -->
     <SamsungTizenSdkPackageVersion>7.0.112</SamsungTizenSdkPackageVersion>
     <!-- emsdk -->
-    <MicrosoftNETWorkloadEmscriptenCurrentManifest80100TransportVersion>8.0.0-preview.6.23312.1</MicrosoftNETWorkloadEmscriptenCurrentManifest80100TransportVersion>
+    <MicrosoftNETWorkloadEmscriptenCurrentManifest80100TransportVersion>8.0.0-preview.6.23321.4</MicrosoftNETWorkloadEmscriptenCurrentManifest80100TransportVersion>
     <MicrosoftNETWorkloadEmscriptenPackageVersion>$(MicrosoftNETWorkloadEmscriptenCurrentManifest80100TransportVersion)</MicrosoftNETWorkloadEmscriptenPackageVersion>
     <!-- wasdk -->
     <MicrosoftWindowsAppSDKPackageVersion>1.3.230602002</MicrosoftWindowsAppSDKPackageVersion>

--- a/eng/provisioning/provisioning.csx
+++ b/eng/provisioning/provisioning.csx
@@ -20,6 +20,7 @@ if(String.IsNullOrWhiteSpace(ANDROID_API_SDKS))
 		.ApiLevel((AndroidApiLevel)31)
 		.ApiLevel((AndroidApiLevel)32)
 		.ApiLevel((AndroidApiLevel)33)
+		.ApiLevel((AndroidApiLevel)34)
 		.VirtualDevice(
 			"Android_API23",
 			(AndroidApiLevel)23,

--- a/src/Controls/src/Core/Compatibility/Handlers/Android/FrameRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Android/FrameRenderer.cs
@@ -197,6 +197,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		public override void Draw(Canvas? canvas)
 		{
+			ArgumentNullException.ThrowIfNull(canvas);
 			Controls.Compatibility.Platform.Android.CanvasExtensions.ClipShape(canvas, Context, Element);
 
 			base.Draw(canvas);

--- a/src/Core/src/Platform/Android/MauiScrollView.cs
+++ b/src/Core/src/Platform/Android/MauiScrollView.cs
@@ -327,12 +327,11 @@ namespace Microsoft.Maui.Platform
 
 		internal bool IsBidirectional { get; set; }
 
-		public override void Draw(Canvas? canvas)
+		public override void Draw(Canvas canvas)
 		{
 			try
 			{
-				if (canvas != null)
-					canvas.ClipRect(canvas.ClipBounds);
+				canvas.ClipRect(canvas.ClipBounds);
 
 				base.Draw(canvas);
 			}

--- a/src/Essentials/src/Geolocation/Geolocation.android.cs
+++ b/src/Essentials/src/Geolocation/Geolocation.android.cs
@@ -230,6 +230,9 @@ namespace Microsoft.Maui.Devices.Sensors
 			continuousListener = null;
 		}
 
+// TODO: android.location.Criteria deprecated in API 34
+// https://developer.android.com/reference/android/location/Criteria
+#pragma warning disable CA1422
 		static (string? Provider, float Accuracy) GetBestProvider(LocationManager locationManager, GeolocationAccuracy accuracy)
 		{
 			// Criteria: https://developer.android.com/reference/android/location/Criteria
@@ -282,6 +285,7 @@ namespace Microsoft.Maui.Devices.Sensors
 
 			return (provider, accuracyDistance);
 		}
+#pragma warning restore CA1422
 
 		internal static bool IsBetterLocation(AndroidLocation location, AndroidLocation? bestLocation)
 		{

--- a/src/TestUtils/src/DeviceTests/AssertionExtensions.Android.cs
+++ b/src/TestUtils/src/DeviceTests/AssertionExtensions.Android.cs
@@ -271,7 +271,7 @@ namespace Microsoft.Maui.DeviceTests
 		public static string ToBase64String(this Bitmap bitmap)
 		{
 			using var ms = new MemoryStream();
-			bitmap.Compress(Bitmap.CompressFormat.Png, 0, ms);
+			bitmap.Compress(Bitmap.CompressFormat.Png!, 0, ms);
 			return Convert.ToBase64String(ms.ToArray());
 		}
 


### PR DESCRIPTION
Changes: https://github.com/xamarin/xamarin-android/compare/e08a44dd...e55038e5

I had to make this bump manually due to `darc` giving errors:

    Coherency updates failed for the following dependencies:
    Unable to update System.Text.Json to have coherency with Microsoft.Android.Sdk.Windows: https://github.com/xamarin/xamarin-android @ e55038e54e152d17158effdc45ce9431be96481f does not contain dependency System.Text.Json
        - Add the dependency to https://github.com/xamarin/xamarin-android.
        - Pin the dependency.
        - Remove the CoherentParentDependency attribute.
    Unable to update System.Text.Encodings.Web to have coherency with Microsoft.Android.Sdk.Windows: https://github.com/xamarin/xamarin-android @ e55038e54e152d17158effdc45ce9431be96481f does not contain dependency System.Text.Encodings.Web
        - Add the dependency to https://github.com/xamarin/xamarin-android.
        - Pin the dependency.
        - Remove the CoherentParentDependency attribute.
    Unable to update Microsoft.Bcl.AsyncInterfaces to have coherency with Microsoft.Android.Sdk.Windows: https://github.com/xamarin/xamarin-android @ e55038e54e152d17158effdc45ce9431be96481f does not contain dependency Microsoft.Bcl.AsyncInterfaces
        - Add the dependency to https://github.com/xamarin/xamarin-android.
        - Pin the dependency.
        - Remove the CoherentParentDependency attribute.

These entries are not listed in:

https://github.com/dotnet/installer/blob/release/8.0.1xx-preview6/eng/Version.Details.xml

So, we don't really have a way to track these dependencies right now.

To solve this, I removed the entries in `Version.Details.xml` for these packages and used the version number from `$(MicrosoftNETCoreAppRefPackageVersion)` instead. They should have the same number anyway for .NET 8. Only in servicing would these numbers potentially be different.

Then ran:

    > darc update-dependencies --id 183469
    Looking up build with BAR id 183469
    Updating 'Microsoft.Android.Sdk.Windows': '34.0.0-preview.6.353' => '34.0.0-preview.6.359' (from build '8.0.1xx-preview6-e55038e54e152d17158effdc45ce9431be96481f-1' of 'https://github.com/xamarin/xamarin-android')
    Checking for coherency updates...
    Using 'Strict' coherency mode. If this fails, a second attempt utilizing 'Legacy' Coherency mode will be made.
    Updating 'Microsoft.Dotnet.Sdk.Internal': '8.0.100-preview.6.23318.1' => '8.0.100-preview.6.23326.6' to ensure coherency with Microsoft.Android.Sdk.Windows@34.0.0-preview.6.359
    Updating 'Microsoft.NETCore.App.Ref': '8.0.0-preview.6.23316.3' => '8.0.0-preview.6.23323.4' to ensure coherency with Microsoft.Android.Sdk.Windows@34.0.0-preview.6.359
    Updating 'Microsoft.NET.Workload.Emscripten.Current.Manifest-8.0.100.Transport': '8.0.0-preview.6.23312.1' => '8.0.0-preview.6.23321.4' to ensure coherency with Microsoft.NETCore.App.Ref@8.0.0-preview.6.23316.3
    Local dependencies updated based on build with BAR id 183469 (8.0.1xx-preview6-e55038e54e152d17158effdc45ce9431be96481f-1 from https://github.com/xamarin/xamarin-android@release/8.0.1xx-preview6)

I got the build number from:

https://maestro-prod.westus2.cloudapp.azure.com/3710/https:%2F%2Fgithub.com%2Fxamarin%2Fxamarin-android/latest/graph
