### PR TITLE
[ios] fix memory leak in Border

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Border/BorderTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Border/BorderTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
@@ -11,6 +12,18 @@ namespace Microsoft.Maui.DeviceTests
 	[Category(TestCategory.Border)]
 	public partial class BorderTests : ControlsHandlerTestBase
 	{
+		void SetupBuilder()
+		{
+			EnsureHandlerCreated(builder =>
+			{
+				builder.ConfigureMauiHandlers(handlers =>
+				{
+					handlers.AddHandler<Label, LabelHandler>();
+					handlers.AddHandler<Border, BorderHandler>();
+				});
+			});
+		}
+
 		[Fact(DisplayName = "Rounded Rectangle Border occupies correct space")]
 		public async Task RoundedRectangleBorderLayoutIsCorrect()
 		{
@@ -30,6 +43,44 @@ namespace Microsoft.Maui.DeviceTests
 			};
 
 			await AssertColorAtPoint(border, expected, typeof(BorderHandler), 10, 10);
+		}
+
+
+		[Fact("Border Does Not Leak")]
+		public async Task DoesNotLeak()
+		{
+			SetupBuilder();
+			WeakReference platformViewReference = null;
+			WeakReference handlerReference = null;
+
+			await InvokeOnMainThreadAsync(() =>
+			{
+				var layout = new Grid();
+				var border = new Border();
+				var label = new Label();
+				border.Content = label;
+				layout.Add(border);
+
+				var handler = CreateHandler<LayoutHandler>(layout);
+				handlerReference = new WeakReference(label.Handler);
+				platformViewReference = new WeakReference(label.Handler.PlatformView);
+			});
+
+			Assert.NotNull(handlerReference);
+			Assert.NotNull(platformViewReference);
+
+			// Several GCs required on iOS
+			for (int i = 0; i < 5; i++)
+			{
+				if (!handlerReference.IsAlive && !platformViewReference.IsAlive)
+					break;
+				await Task.Yield();
+				GC.Collect();
+				GC.WaitForPendingFinalizers();
+			}
+
+			Assert.False(handlerReference.IsAlive, "Handler should not be alive!");
+			Assert.False(platformViewReference.IsAlive, "PlatformView should not be alive!");
 		}
 	}
 }

--- a/src/Core/src/Handlers/Border/BorderHandler.iOS.cs
+++ b/src/Core/src/Handlers/Border/BorderHandler.iOS.cs
@@ -21,15 +21,11 @@ namespace Microsoft.Maui.Handlers
 		protected override void ConnectHandler(ContentView platformView)
 		{
 			base.ConnectHandler(platformView);
-
-			platformView.LayoutSubviewsChanged += OnLayoutSubviewsChanged;
 		}
 
 		protected override void DisconnectHandler(ContentView platformView)
 		{
 			base.DisconnectHandler(platformView);
-
-			platformView.LayoutSubviewsChanged -= OnLayoutSubviewsChanged;
 		}
 
 		public override void SetVirtualView(IView view)
@@ -62,11 +58,6 @@ namespace Microsoft.Maui.Handlers
 		public static void MapContent(IBorderHandler handler, IBorderView border)
 		{
 			UpdateContent(handler);
-		}
-
-		void OnLayoutSubviewsChanged(object? sender, EventArgs e)
-		{
-			PlatformView?.UpdateMauiCALayer();
 		}
 	}
 }

--- a/src/Core/src/Platform/iOS/ContentView.cs
+++ b/src/Core/src/Platform/iOS/ContentView.cs
@@ -10,7 +10,6 @@ namespace Microsoft.Maui.Platform
 	{
 		WeakReference<IBorderStroke>? _clip;
 		CAShapeLayer? _childMaskLayer;
-		internal event EventHandler? LayoutSubviewsChanged;
 
 		public ContentView()
 		{
@@ -27,8 +26,7 @@ namespace Microsoft.Maui.Platform
 				ChildMaskLayer.Frame = bounds;
 
 			SetClip();
-
-			LayoutSubviewsChanged?.Invoke(this, EventArgs.Empty);
+			this.UpdateMauiCALayer();
 		}
 
 		internal IBorderStroke? Clip


### PR DESCRIPTION
Context: https://github.com/dotnet/maui/issues/14664
Context: https://github.com/nacompllo/MemoryLeakEverywhere/tree/bugfix/memoryLeakItemsSource

While looking at the customer sample, we found an issue with `BorderHandler`:

* `ContentView` -> via `LayoutSubviewsChanged`
* `BorderHandler` ->
* `ContentView`

Creating a cycle & memory leak on iOS and Catalyst. We could reproduce this in a device test.

It appears the event only did this:

    void OnLayoutSubviewsChanged(object? sender, EventArgs e)
    {
        PlatformView?.UpdateMauiCALayer();
    }

And so instead, we can just call the extension method directly:

    this.UpdateMauiCALayer();

And the leak is gone!

We are not sure if #14664 will be fully solved by this change, but it is one issue in the sample.