### PR TITLE
Fix ".SFUI" magic font string on iOS/MacCatalyst

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Controls/LabelPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/LabelPage.xaml
@@ -1,4 +1,4 @@
-<views:BasePage
+﻿<views:BasePage
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     x:Class="Maui.Controls.Sample.Pages.LabelPage"
@@ -16,6 +16,7 @@
                 Text="Defaults"/>
             <Label
                 Text="Label with Tooltip"
+                FontFamily=".SFUI-Bold"
                 ToolTipProperties.Text="This has a tooltip!"/>
             <Label
                 TextColor="Red"

--- a/src/Core/src/Fonts/FontManager.iOS.cs
+++ b/src/Core/src/Fonts/FontManager.iOS.cs
@@ -131,11 +131,6 @@ namespace Microsoft.Maui
 							return ApplyScaling(font, result);
 					}
 
-					var cleansedFont = CleanseFontName(family);
-					result = UIFont.FromName(cleansedFont, size);
-					if (result != null)
-						return ApplyScaling(font, result);
-
 					if (family.StartsWith(".SFUI", StringComparison.InvariantCultureIgnoreCase))
 					{
 						var weights = family.Split('-');
@@ -154,6 +149,11 @@ namespace Microsoft.Maui
 						if (result != null)
 							return ApplyScaling(font, result);
 					}
+
+					var cleansedFont = CleanseFontName(family);
+					result = UIFont.FromName(cleansedFont, size);
+					if (result != null)
+						return ApplyScaling(font, result);
 
 					result = UIFont.FromName(family, size);
 					if (result != null)

--- a/src/Core/tests/DeviceTests/Services/FontManagerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Services/FontManagerTests.iOS.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using UIKit;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests;
+
+[Category(TestCategory.Fonts)]
+public partial class FontManagerTests : TestBase
+{
+	[Theory]
+	[InlineData(".SFUI-Bold", ".AppleSystemUIFont")]
+	[InlineData(".SFUI-SemiBold", ".AppleSystemUIFont")]
+	[InlineData(".SFUI-Black", ".AppleSystemUIFont")]
+	[InlineData(".SFUI-Heavy", ".AppleSystemUIFont")]
+	[InlineData(".SFUI-Light", ".AppleSystemUIFont")]
+	public async System.Threading.Tasks.Task CanLoadSystemFonts(string fontName, string expectedFamilyName)
+	{
+		var registrar = new FontRegistrar(fontLoader: null);
+		var manager = new FontManager(registrar);
+
+		var font = await InvokeOnMainThreadAsync(() =>
+			manager.GetFont(Font.OfSize(fontName, manager.DefaultFontSize)));
+
+		Assert.Equal(expectedFamilyName, font.FamilyName);
+	}
+
+}


### PR DESCRIPTION
For some reason `UIFont.FromName` always returns _some_ font even if you specify an invalid name, but it may not be the _correct_ font.

There was some logic added in MAUI to clean up the font name and try and load by the cleaned up name, however since `UIFont.FromName` always returns a result and not null, it will always be used before we would even get to checking the ".SFUI" magic string.

This also probably means the final attempt to get a font by (non cleaned up) name actually never gets hit, but for now this is still an improvement.

Fixes #15882 

