### PR TITLE
[tests] make Windows memory leak tests consistent

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.cs
@@ -294,11 +294,7 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
-		[Fact(DisplayName = "NavigationPage Does Not Leak"
-#if WINDOWS
-			,Skip = "Failing"
-#endif
-			)]
+		[Fact(DisplayName = "NavigationPage Does Not Leak")]
 		public async Task DoesNotLeak()
 		{
 			SetupBuilder();
@@ -324,15 +320,14 @@ namespace Microsoft.Maui.DeviceTests
 				await navPage.Navigation.PopAsync();
 			});
 
-			// As we add more controls to this test, more GCs will be required
-			for (int i = 0; i < 16; i++)
+			// Windows requires an actual delay
+			// Android/iOS require multiple GCs
+			await AssertionExtensions.Wait(() =>
 			{
-				if (!pageReference.IsAlive)
-					break;
-				await Task.Yield();
 				GC.Collect();
 				GC.WaitForPendingFinalizers();
-			}
+				return !pageReference.IsAlive;
+			}, timeout: 5000);
 
 			Assert.NotNull(pageReference);
 			Assert.False(pageReference.IsAlive, "Page should not be alive!");

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
@@ -962,11 +962,7 @@ namespace Microsoft.Maui.DeviceTests
 		}
 #endif
 
-		[Fact(DisplayName = "Pages Do Not Leak"
-#if WINDOWS
-			,Skip = "Failing"
-#endif
-			)]
+		[Fact(DisplayName = "Pages Do Not Leak")]
 		public async Task PagesDoNotLeak()
 		{
 			SetupBuilder();
@@ -999,15 +995,14 @@ namespace Microsoft.Maui.DeviceTests
 				await shell.Navigation.PopAsync();
 			});
 
-			// As we add more controls to this test, more GCs will be required
-			for (int i = 0; i < 16; i++)
+			// Windows requires an actual delay
+			// Android/iOS require multiple GCs
+			await AssertionExtensions.Wait(() =>
 			{
-				if (!pageReference.IsAlive)
-					break;
-				await Task.Yield();
 				GC.Collect();
 				GC.WaitForPendingFinalizers();
-			}
+				return !pageReference.IsAlive;
+			}, timeout: 5000);
 
 			Assert.NotNull(pageReference);
 			Assert.False(pageReference.IsAlive, "Page should not be alive!");


### PR DESCRIPTION
Fixes part of: https://github.com/dotnet/maui/issues/15530

These would fail randomly for me when I ran them. But after reviewing memory snapshots, I didn't find an actual issue the tests were just flaky.

I found I could rework the tests to do:

    await AssertionExtensions.Wait(() =>
    {
        GC.Collect();
        GC.WaitForPendingFinalizers();
        return !pageReference.IsAlive;
    }, timeout: 5000);

And now they pass every time for me locally.

So, it waits up to 5 seconds, and quits early if the page is gone.

If this still passes on all platforms -- we can probably use this instead.