### PR TITLE
[android] fix memory leak in Window

### DIFF
--- a/src/Controls/src/Core/Window/Window.cs
+++ b/src/Controls/src/Core/Window/Window.cs
@@ -506,6 +506,7 @@ namespace Microsoft.Maui.Controls
 			Destroying?.Invoke(this, EventArgs.Empty);
 			OnDestroying();
 
+			AlertManager.Unsubscribe();
 			Application?.RemoveWindow(this);
 			Handler?.DisconnectHandler();
 		}

--- a/src/Core/src/Hosting/LifecycleEvents/AppHostBuilderExtensions.Android.cs
+++ b/src/Core/src/Hosting/LifecycleEvents/AppHostBuilderExtensions.Android.cs
@@ -56,18 +56,8 @@ namespace Microsoft.Maui.LifecycleEvents
 				})
 				.OnDestroy(activity =>
 				{
-					// There are cases IsFinishing was false in OnStop,
-					// and in OnDestroy we actually need to clean up the Window.
-					// In this case, it is possible to destroy the Window twice,
-					// so let's handle InvalidOperationException.
-					try
-					{
-						activity.GetWindow()?.Destroying();
-					}
-					catch (InvalidOperationException)
-					{
-						// if we somehow got "Window was already destroyed", ignore it
-					}
+					// If we tried to call window.Destroying() before, GetWindow() should return null
+					activity.GetWindow()?.Destroying();
 				})
 				.OnBackPressed(activity =>
 				{

--- a/src/Core/src/Hosting/LifecycleEvents/AppHostBuilderExtensions.Android.cs
+++ b/src/Core/src/Hosting/LifecycleEvents/AppHostBuilderExtensions.Android.cs
@@ -1,3 +1,4 @@
+using System;
 using AndroidX.AppCompat.App;
 using AndroidX.Window.Layout;
 using Microsoft.Maui.ApplicationModel;
@@ -55,14 +56,17 @@ namespace Microsoft.Maui.LifecycleEvents
 				})
 				.OnDestroy(activity =>
 				{
-					// If the activity is being recreated from a configuration change
-					// or something like the inspector getting attached then
-					// IsFinishing will be set to false so we still need to call
-					// Destroying to remove the xplat Window from Application
-					if (!activity.IsFinishing)
+					// There are cases IsFinishing was false in OnStop,
+					// and in OnDestroy we actually need to clean up the Window.
+					// In this case, it is possible to destroy the Window twice,
+					// so let's handle InvalidOperationException.
+					try
 					{
-						var window = activity.GetWindow();
-						window?.Destroying();
+						activity.GetWindow()?.Destroying();
+					}
+					catch (InvalidOperationException)
+					{
+						// if we somehow got "Window was already destroyed", ignore it
 					}
 				})
 				.OnBackPressed(activity =>

--- a/src/Core/src/Hosting/LifecycleEvents/AppHostBuilderExtensions.Android.cs
+++ b/src/Core/src/Hosting/LifecycleEvents/AppHostBuilderExtensions.Android.cs
@@ -1,4 +1,3 @@
-using System;
 using AndroidX.AppCompat.App;
 using AndroidX.Window.Layout;
 using Microsoft.Maui.ApplicationModel;


### PR DESCRIPTION
Fixes #15972
Context: https://github.com/markusroessler/MauiWindowScopeSample

In the above sample, `android.permission.FOREGROUND_SERVICE` is utilized to keep the app running even when terminated by the user.

Unfortunately, in this case `Window` & various other objects live forever. When running the sample, the `InstanceCount` grows each time you close & launch the app again:

    07-07 16:08:32.281 22562 22562 I DOTNET  : ScopedService InstanceCount: 3
    07-07 16:08:32.291 22562 22562 I DOTNET  : MainWindow InstanceCount: 3

The first issue I noticed was `IWindow.Destroying()` was never called because of this code in `OnDestroy()`:

    if (!activity.IsFinishing)
    {
        var window = activity.GetWindow();
        window?.Destroying();
    }

`IsFinishing` was always `true` from my debugging in this spot.

`OnStop()` had the code:

    // As of Ice Cream Sandwich, Stopped is guaranteed to be called
    // even when the activity is finishing or being destroyed
    // We check for finishing and call destroying here if so
    if (activity.IsFinishing)
        window?.Destroying();

In this case `IsFinishing` was `false`.

I think the solution here is that `OnDestroy()` should attempt to destroy the `Window` in all cases. There isn't a case you would *not* want to destroy it. The only problem being we can now destroy it twice -- and there is no `IWindow.IsDestroyed` value to check. We can simply handle `InvalidOperationException`, as this should be rare.

With this change in place, I still saw a leak. Reviewing a `.gcdump` of the app, I saw the object tree:

    Microsoft.Maui.Controls.Platform.AlertManager.AlertRequestHelper
        List<Microsoft.Maui.Controls.Platform.AlertManager.AlertRequestHelper>
            Microsoft.Maui.Controls.Platform.AlertManager
                MauiWindowScopeSample.MainWindow
        Microsoft.Maui.Controls.MessagingCenter.MaybeWeakReference
            Microsoft.Maui.Controls.MessagingCenter.Subscription
                List<Microsoft.Maui.Controls.MessagingCenter.Subscription>
                    Dictionary<Microsoft.Maui.Controls.MessagingCenter.Sender, List<Microsoft.Maui.Controls.MessagingCenter.Subscription>>
                        Microsoft.Maui.Controls.MessagingCenter
                            Other Roots

Where `MessagingCenter` appears to keep `AlertRequestHelper` alive, which keeps the `Window` alive.

After these changes, we instead get this every time:

    07-07 16:08:38.967 22562 22562 I DOTNET  : ScopedService InstanceCount: 2
    07-07 16:08:38.978 22562 22562 I DOTNET  : MainWindow InstanceCount: 2
    07-07 16:08:39.015 22562 22562 I DOTNET  : Lifecycle event: OnStart
    07-07 16:08:39.072 22562 22562 I DOTNET  : Lifecycle event: OnPostCreate
    07-07 16:08:39.073 22562 22562 I DOTNET  : Lifecycle event: OnResume
    07-07 16:08:39.074 22562 22562 I DOTNET  : Lifecycle event: OnPostResume
    07-07 16:08:39.411 22562 22585 I DOTNET  : MainWindow InstanceCount: 1
    07-07 16:08:39.414 22562 22585 I DOTNET  : ScopedService InstanceCount: 1

The `InstanceCount` returns to 1 as the finalizers run for these types.

I have yet to figure out how to write a test for this scenario -- I've only been able to validate this fix manually testing the app.