### PR TITLE
Make Add/Remove Logical public

### DIFF
--- a/src/Controls/docs/Microsoft.Maui.Controls/ItemsView.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/ItemsView.xml
@@ -31,28 +31,6 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
-    <Member MemberName="AddLogicalChild">
-      <MemberSignature Language="C#" Value="public void AddLogicalChild (Microsoft.Maui.Controls.Element element);" />
-      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void AddLogicalChild(class Microsoft.Maui.Controls.Element element) cil managed" />
-      <MemberSignature Language="DocId" Value="M:Microsoft.Maui.Controls.ItemsView.AddLogicalChild(Microsoft.Maui.Controls.Element)" />
-      <MemberSignature Language="F#" Value="member this.AddLogicalChild : Microsoft.Maui.Controls.Element -&gt; unit" Usage="itemsView.AddLogicalChild element" />
-      <MemberType>Method</MemberType>
-      <AssemblyInfo>
-        <AssemblyName>Microsoft.Maui.Controls.Core</AssemblyName>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>System.Void</ReturnType>
-      </ReturnValue>
-      <Parameters>
-        <Parameter Name="element" Type="Microsoft.Maui.Controls.Element" />
-      </Parameters>
-      <Docs>
-        <param name="element">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
-      </Docs>
-    </Member>
     <Member MemberName="EmptyView">
       <MemberSignature Language="C#" Value="public object EmptyView { get; set; }" />
       <MemberSignature Language="ILAsm" Value=".property instance object EmptyView" />
@@ -526,28 +504,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
-      </Docs>
-    </Member>
-    <Member MemberName="RemoveLogicalChild">
-      <MemberSignature Language="C#" Value="public void RemoveLogicalChild (Microsoft.Maui.Controls.Element element);" />
-      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void RemoveLogicalChild(class Microsoft.Maui.Controls.Element element) cil managed" />
-      <MemberSignature Language="DocId" Value="M:Microsoft.Maui.Controls.ItemsView.RemoveLogicalChild(Microsoft.Maui.Controls.Element)" />
-      <MemberSignature Language="F#" Value="member this.RemoveLogicalChild : Microsoft.Maui.Controls.Element -&gt; unit" Usage="itemsView.RemoveLogicalChild element" />
-      <MemberType>Method</MemberType>
-      <AssemblyInfo>
-        <AssemblyName>Microsoft.Maui.Controls.Core</AssemblyName>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>System.Void</ReturnType>
-      </ReturnValue>
-      <Parameters>
-        <Parameter Name="element" Type="Microsoft.Maui.Controls.Element" />
-      </Parameters>
-      <Docs>
-        <param name="element">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
       </Docs>

--- a/src/Controls/src/Core/Application/Application.cs
+++ b/src/Controls/src/Core/Application/Application.cs
@@ -464,7 +464,7 @@ namespace Microsoft.Maui.Controls
 
 			if (window is Element windowElement)
 			{
-				RemoveLogicalChildInternal(windowElement);
+				RemoveLogicalChild(windowElement);
 			}
 
 			_windows.Remove(window);
@@ -518,7 +518,7 @@ namespace Microsoft.Maui.Controls
 
 			if (window is Element windowElement)
 			{
-				AddLogicalChildInternal(windowElement);
+				AddLogicalChild(windowElement);
 			}
 
 			if (window is NavigableElement ne)

--- a/src/Controls/src/Core/BindableObject.cs
+++ b/src/Controls/src/Core/BindableObject.cs
@@ -265,7 +265,6 @@ namespace Microsoft.Maui.Controls
 		{
 			BindingContextChanged?.Invoke(this, EventArgs.Empty);
 
-			// Should this be a logical child?
 			if (Shell.GetBackButtonBehavior(this) is BackButtonBehavior buttonBehavior)
 				SetInheritedBindingContext(buttonBehavior, BindingContext);
 

--- a/src/Controls/src/Core/BindableObject.cs
+++ b/src/Controls/src/Core/BindableObject.cs
@@ -264,17 +264,13 @@ namespace Microsoft.Maui.Controls
 		protected virtual void OnBindingContextChanged()
 		{
 			BindingContextChanged?.Invoke(this, EventArgs.Empty);
+
+			// Should this be a logical child?
 			if (Shell.GetBackButtonBehavior(this) is BackButtonBehavior buttonBehavior)
 				SetInheritedBindingContext(buttonBehavior, BindingContext);
 
 			if (Shell.GetSearchHandler(this) is SearchHandler searchHandler)
 				SetInheritedBindingContext(searchHandler, BindingContext);
-
-			if (Shell.GetTitleView(this) is View titleView)
-				SetInheritedBindingContext(titleView, BindingContext);
-
-			if (FlyoutBase.GetContextFlyout(this) is BindableObject contextFlyout)
-				SetInheritedBindingContext(contextFlyout, BindingContext);
 		}
 
 		protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = null)

--- a/src/Controls/src/Core/BindableObjectExtensions.cs
+++ b/src/Controls/src/Core/BindableObjectExtensions.cs
@@ -85,6 +85,18 @@ namespace Microsoft.Maui.Controls
 			return false;
 		}
 
+		internal static void AddRemoveLogicalChildren(this BindableObject bindable, object oldValue, object newValue)
+		{
+			if (!(bindable is Element owner))
+				return;
+			
+			if (oldValue is Element oldView)
+				owner.RemoveLogicalChild(oldView);
+
+			if (newValue is Element newView)
+				owner.AddLogicalChild(newView);
+		}
+
 		internal static bool TrySetAppTheme(
 			this BindableObject self,
 			string lightResourceKey,

--- a/src/Controls/src/Core/Border/Border.cs
+++ b/src/Controls/src/Core/Border/Border.cs
@@ -268,12 +268,12 @@ namespace Microsoft.Maui.Controls
 			{
 				if (oldValue is Element oldElement)
 				{
-					border.RemoveLogicalChildInternal(oldElement);
+					border.RemoveLogicalChild(oldElement);
 				}
 
 				if (newValue is Element newElement)
 				{
-					border.AddLogicalChildInternal(newElement);
+					border.AddLogicalChild(newElement);
 				}
 			}
 

--- a/src/Controls/src/Core/Border/Border.cs
+++ b/src/Controls/src/Core/Border/Border.cs
@@ -64,8 +64,7 @@ namespace Microsoft.Maui.Controls
 
 			if (strokeShape is VisualElement visualElement)
 			{
-				SetInheritedBindingContext(visualElement, BindingContext);
-				visualElement.Parent = this;
+				AddLogicalChild(visualElement);
 				_strokeShapeChanged ??= (sender, e) => OnPropertyChanged(nameof(StrokeShape));
 				_strokeShapeProxy ??= new();
 				_strokeShapeProxy.Subscribe(visualElement, _strokeShapeChanged);
@@ -78,8 +77,7 @@ namespace Microsoft.Maui.Controls
 
 			if (strokeShape is VisualElement visualElement)
 			{
-				SetInheritedBindingContext(visualElement, null);
-				visualElement.Parent = null;
+				RemoveLogicalChild(visualElement);
 				_strokeShapeProxy?.Unsubscribe();
 			}
 		}

--- a/src/Controls/src/Core/Cells/Cell.cs
+++ b/src/Controls/src/Core/Cells/Cell.cs
@@ -243,7 +243,7 @@ namespace Microsoft.Maui.Controls
 
 		void IPropertyPropagationController.PropagatePropertyChanged(string propertyName)
 		{
-			PropertyPropagationExtensions.PropagatePropertyChanged(propertyName, this, ((IElementController)this).LogicalChildren);
+			PropertyPropagationExtensions.PropagatePropertyChanged(propertyName, this, ((IVisualTreeElement)this).GetVisualChildren());
 		}
 
 		void OnContextActionsChanged(object sender, NotifyCollectionChangedEventArgs e)

--- a/src/Controls/src/Core/Cells/ViewCell.cs
+++ b/src/Controls/src/Core/Cells/ViewCell.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Maui.Controls
 
 				if (_view != null)
 				{
-					RemoveLogicalChildInternal(_view);
+					RemoveLogicalChild(_view);
 					_view.ComputedConstraint = LayoutConstraint.None;
 				}
 
@@ -32,7 +32,7 @@ namespace Microsoft.Maui.Controls
 				if (_view != null)
 				{
 					_view.ComputedConstraint = LayoutConstraint.Fixed;
-					AddLogicalChildInternal(_view);
+					AddLogicalChild(_view);
 				}
 
 				ForceUpdateSize();

--- a/src/Controls/src/Core/Compatibility/Handlers/TabbedPage/iOS/TabbedRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/TabbedPage/iOS/TabbedRenderer.cs
@@ -284,10 +284,10 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		void SetControllers()
 		{
 			var list = new List<UIViewController>();
-			var logicalChildren = ((IElementController)Element).LogicalChildren;
-			for (var i = 0; i < logicalChildren.Count; i++)
+			var pages = Tabbed.InternalChildren;
+			for (var i = 0; i < pages.Count; i++)
 			{
-				var child = logicalChildren[i];
+				var child = pages[i];
 				var v = child as Page;
 				if (v == null)
 					continue;

--- a/src/Controls/src/Core/ContentPage/ContentPage.cs
+++ b/src/Controls/src/Core/ContentPage/ContentPage.cs
@@ -1,6 +1,5 @@
 #nullable disable
 
-using System.Collections.Generic;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.HotReload;
 using Microsoft.Maui.Layouts;
@@ -20,10 +19,6 @@ namespace Microsoft.Maui.Controls
 			get { return (View)GetValue(ContentProperty); }
 			set { SetValue(ContentProperty, value); }
 		}
-
-		private protected override IList<Element> LogicalChildrenInternalBackingStore 
-			=> base.LogicalChildrenInternalBackingStore;
-
 
 		protected override void OnBindingContextChanged()
 		{

--- a/src/Controls/src/Core/ContentPage/ContentPage.cs
+++ b/src/Controls/src/Core/ContentPage/ContentPage.cs
@@ -1,5 +1,6 @@
 #nullable disable
 
+using System.Collections.Generic;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.HotReload;
 using Microsoft.Maui.Layouts;
@@ -19,6 +20,10 @@ namespace Microsoft.Maui.Controls
 			get { return (View)GetValue(ContentProperty); }
 			set { SetValue(ContentProperty, value); }
 		}
+
+		private protected override IList<Element> LogicalChildrenInternalBackingStore 
+			=> base.LogicalChildrenInternalBackingStore;
+
 
 		protected override void OnBindingContextChanged()
 		{

--- a/src/Controls/src/Core/Element/Element.cs
+++ b/src/Controls/src/Core/Element/Element.cs
@@ -146,7 +146,6 @@ namespace Microsoft.Maui.Controls
 			_logicalChildrenReadonly ??= new ReadOnlyCollection<Element>(LogicalChildrenInternalBackingStore);
 		}
 
-#pragma warning disable RS0016 // Add public types and members to the declared API
 		public void InsertLogicalChild(int index, Element element)
 		{
 			if (element is null)
@@ -218,7 +217,6 @@ namespace Microsoft.Maui.Controls
 
 			return true;
 		}
-#pragma warning restore RS0016 // Add public types and members to the declared API
 
 		internal bool Owned { get; set; }
 

--- a/src/Controls/src/Core/Element/Element.cs
+++ b/src/Controls/src/Core/Element/Element.cs
@@ -182,11 +182,11 @@ namespace Microsoft.Maui.Controls
 			if (LogicalChildrenInternalBackingStore is null)
 				return false;
 
-			var oldLogicalIndex = LogicalChildrenInternalBackingStore.IndexOf(element);
-			if (oldLogicalIndex < 0)
+			var index = LogicalChildrenInternalBackingStore.IndexOf(element);
+			if (index < 0)
 				return false;
 
-			RemoveLogicalChild(element, oldLogicalIndex);
+			RemoveLogicalChild(element, index);
 
 			return true;
 		}
@@ -207,13 +207,13 @@ namespace Microsoft.Maui.Controls
 		}
 
 		/// <summary>
-		/// This doesn't validate that the oldLogicalIndex is correct, so be sure you're passing in the
+		/// This doesn't validate that the index is correct, so be sure you're passing in the
 		/// correct index
 		/// </summary>
-		public bool RemoveLogicalChild(Element element, int oldLogicalIndex)
+		public bool RemoveLogicalChild(Element element, int index)
 		{
 			LogicalChildrenInternalBackingStore.Remove(element);
-			OnChildRemoved(element, oldLogicalIndex);
+			OnChildRemoved(element, index);
 
 			return true;
 		}

--- a/src/Controls/src/Core/Element/Element.cs
+++ b/src/Controls/src/Core/Element/Element.cs
@@ -146,7 +146,8 @@ namespace Microsoft.Maui.Controls
 			_logicalChildrenReadonly ??= new ReadOnlyCollection<Element>(LogicalChildrenInternalBackingStore);
 		}
 
-		internal void InsertLogicalChildInternal(int index, Element element)
+#pragma warning disable RS0016 // Add public types and members to the declared API
+		public void InsertLogicalChild(int index, Element element)
 		{
 			if (element is null)
 			{
@@ -159,7 +160,7 @@ namespace Microsoft.Maui.Controls
 			OnChildAdded(element);
 		}
 
-		internal void AddLogicalChildInternal(Element element)
+		public void AddLogicalChild(Element element)
 		{
 			if (element is null)
 			{
@@ -172,7 +173,7 @@ namespace Microsoft.Maui.Controls
 			OnChildAdded(element);
 		}
 
-		internal bool RemoveLogicalChildInternal(Element element)
+		public bool RemoveLogicalChild(Element element)
 		{
 			if (element is null)
 			{
@@ -186,12 +187,12 @@ namespace Microsoft.Maui.Controls
 			if (oldLogicalIndex < 0)
 				return false;
 
-			RemoveLogicalChildInternal(element, oldLogicalIndex);
+			RemoveLogicalChild(element, oldLogicalIndex);
 
 			return true;
 		}
 
-		internal void ClearLogicalChildren()
+		public void ClearLogicalChildren()
 		{
 			if (LogicalChildrenInternalBackingStore is null)
 				return;
@@ -202,7 +203,7 @@ namespace Microsoft.Maui.Controls
 			// Reverse for-loop, so children can be removed while iterating
 			for (int i = LogicalChildrenInternalBackingStore.Count - 1; i >= 0; i--)
 			{
-				RemoveLogicalChildInternal(LogicalChildrenInternalBackingStore[i], i);
+				RemoveLogicalChild(LogicalChildrenInternalBackingStore[i], i);
 			}
 		}
 
@@ -210,32 +211,14 @@ namespace Microsoft.Maui.Controls
 		/// This doesn't validate that the oldLogicalIndex is correct, so be sure you're passing in the
 		/// correct index
 		/// </summary>
-		internal bool RemoveLogicalChildInternal(Element element, int oldLogicalIndex)
+		public bool RemoveLogicalChild(Element element, int oldLogicalIndex)
 		{
 			LogicalChildrenInternalBackingStore.Remove(element);
 			OnChildRemoved(element, oldLogicalIndex);
 
 			return true;
 		}
-
-		internal IEnumerable<Element> AllChildren
-		{
-			get
-			{
-				foreach (var child in LogicalChildrenInternal)
-					yield return child;
-
-				var childrenNotDrawnByThisElement = ChildrenNotDrawnByThisElement;
-				if (childrenNotDrawnByThisElement is not null)
-				{
-					foreach (var child in childrenNotDrawnByThisElement)
-						yield return child;
-				}
-			}
-		}
-
-		// return null by default so we don't need to foreach over an empty collection in OnPropertyChanged
-		internal virtual IEnumerable<Element> ChildrenNotDrawnByThisElement => null;
+#pragma warning restore RS0016 // Add public types and members to the declared API
 
 		internal bool Owned { get; set; }
 
@@ -494,16 +477,6 @@ namespace Microsoft.Maui.Controls
 			base.OnPropertyChanged(propertyName);
 
 			Handler?.UpdateValue(propertyName);
-
-			var childrenNotDrawnByThisElement = ChildrenNotDrawnByThisElement;
-			if (childrenNotDrawnByThisElement is not null)
-			{
-				foreach (var logicalChildren in childrenNotDrawnByThisElement)
-				{
-					if (logicalChildren is IPropertyPropagationController controller)
-						PropertyPropagationExtensions.PropagatePropertyChanged(propertyName, this, new[] { logicalChildren });
-				}
-			}
 
 			if (_effects?.Count > 0)
 			{

--- a/src/Controls/src/Core/Element/Element.cs
+++ b/src/Controls/src/Core/Element/Element.cs
@@ -269,29 +269,7 @@ namespace Microsoft.Maui.Controls
 		public Element Parent
 		{
 			get { return _parentOverride ?? RealParent; }
-			set
-			{
-				if (RealParent == value)
-					return;
-
-				if (value is null)
-				{
-					RealParent.RemoveLogicalChild(this);
-				}
-				else
-				{
-					// TODO Add test for switching parents
-					if (RealParent is not null && RealParent != value)
-					{
-						RealParent.RemoveLogicalChild(this);
-					}
-
-					if (!value.LogicalChildrenInternalBackingStore.Contains(this))
-						value.AddLogicalChild(this);
-				}
-
-				RealParent = value;
-			}
+			set => SetParent(value);
 		}
 
 		void SetParent(Element value)
@@ -299,7 +277,7 @@ namespace Microsoft.Maui.Controls
 			if (RealParent == value)
 				return;
 
-			OnPropertyChanging();
+			OnPropertyChanging(nameof(Parent));
 
 			if (_parentOverride == null)
 				OnParentChangingCore(Parent, value);
@@ -334,7 +312,7 @@ namespace Microsoft.Maui.Controls
 			if (_parentOverride == null)
 				OnParentChangedCore();
 
-			OnPropertyChanged();
+			OnPropertyChanged(nameof(Parent));
 		}
 
 		internal bool IsTemplateRoot { get; set; }

--- a/src/Controls/src/Core/Element/Element.cs
+++ b/src/Controls/src/Core/Element/Element.cs
@@ -146,6 +146,11 @@ namespace Microsoft.Maui.Controls
 			_logicalChildrenReadonly ??= new ReadOnlyCollection<Element>(LogicalChildrenInternalBackingStore);
 		}
 
+		/// <summary>
+		/// Inserts an <see cref="Element"/> to the logical children at the specified index.
+		/// </summary>
+		/// <param name="index">The zero-based index at which <see cref="Element"/> should be inserted.</param>
+		/// <param name="element">The <see cref="Element"/> to insert into the logical children.</param>
 		public void InsertLogicalChild(int index, Element element)
 		{
 			if (element is null)
@@ -159,6 +164,10 @@ namespace Microsoft.Maui.Controls
 			OnChildAdded(element);
 		}
 
+		/// <summary>
+		/// Adds an <see cref="Element"/> to the logical children.
+		/// </summary>
+		/// <param name="element">The <see cref="Element"/> to add to the logical children.</param>
 		public void AddLogicalChild(Element element)
 		{
 			if (element is null)
@@ -172,6 +181,14 @@ namespace Microsoft.Maui.Controls
 			OnChildAdded(element);
 		}
 
+		/// <summary>
+		/// Removes the first occurrence of a specific <see cref="Element"/> from the logical children.
+		/// </summary>
+		/// <param name="element">The <see cref="Element"/> to remove.</param>
+		/// <returns>
+		///	true if item was successfully removed from the logical children;
+		/// otherwise, false. This method also returns false if <see cref="Element"/> is not found.
+		///	</returns>
 		public bool RemoveLogicalChild(Element element)
 		{
 			if (element is null)
@@ -191,6 +208,9 @@ namespace Microsoft.Maui.Controls
 			return true;
 		}
 
+		/// <summary>
+		///  Removes all <see cref="Element"/>s.
+		/// </summary>
 		public void ClearLogicalChildren()
 		{
 			if (LogicalChildrenInternalBackingStore is null)
@@ -206,11 +226,7 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		/// <summary>
-		/// This doesn't validate that the index is correct, so be sure you're passing in the
-		/// correct index
-		/// </summary>
-		public bool RemoveLogicalChild(Element element, int index)
+		internal bool RemoveLogicalChild(Element element, int index)
 		{
 			LogicalChildrenInternalBackingStore.Remove(element);
 			OnChildRemoved(element, index);

--- a/src/Controls/src/Core/Element/Element_StyleSheets.cs
+++ b/src/Controls/src/Core/Element/Element_StyleSheets.cs
@@ -54,17 +54,15 @@ namespace Microsoft.Maui.Controls
 			ApplyStyleSheets(sheets, this);
 		}
 
-		void ApplyStyleSheets(List<StyleSheet> sheets, Element element)
+		void ApplyStyleSheets(List<StyleSheet> sheets, IVisualTreeElement element)
 		{
-			if (element is not IVisualTreeElement vte)
-				return;
-
 			for (var i = (sheets?.Count ?? 0) - 1; i >= 0; i--)
 			{
-				((IStyle)sheets[i]).Apply(element);
+				if (element is BindableObject bo)
+					((IStyle)sheets[i]).Apply(bo);
 			}
 
-			foreach (Element child in vte.GetVisualChildren())
+			foreach (var child in element.GetVisualChildren())
 			{
 				var mergedSheets = sheets;
 				var resourceProvider = child as IResourcesProvider;

--- a/src/Controls/src/Core/Element/Element_StyleSheets.cs
+++ b/src/Controls/src/Core/Element/Element_StyleSheets.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Maui.Controls
 
 		void ApplyStyleSheets(List<StyleSheet> sheets, Element element)
 		{
-			if (element == null)
+			if (element is not IVisualTreeElement vte)
 				return;
 
 			for (var i = (sheets?.Count ?? 0) - 1; i >= 0; i--)
@@ -64,7 +64,7 @@ namespace Microsoft.Maui.Controls
 				((IStyle)sheets[i]).Apply(element);
 			}
 
-			foreach (Element child in element.AllChildren)
+			foreach (Element child in vte.GetVisualChildren())
 			{
 				var mergedSheets = sheets;
 				var resourceProvider = child as IResourcesProvider;

--- a/src/Controls/src/Core/FormattedString.cs
+++ b/src/Controls/src/Core/FormattedString.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Maui.Controls
 					var bo = item as Span;
 					if (bo != null)
 					{
-						bo.Parent = null;
+						bo.Parent?.RemoveLogicalChild(bo);
 						bo.PropertyChanging -= OnItemPropertyChanging;
 						bo.PropertyChanged -= OnItemPropertyChanged;
 					}
@@ -59,7 +59,7 @@ namespace Microsoft.Maui.Controls
 					var bo = item as Span;
 					if (bo != null)
 					{
-						bo.Parent = this;
+						this.AddLogicalChild(bo);
 						bo.PropertyChanging += OnItemPropertyChanging;
 						bo.PropertyChanged += OnItemPropertyChanged;
 					}

--- a/src/Controls/src/Core/Items/ItemsView.cs
+++ b/src/Controls/src/Core/Items/ItemsView.cs
@@ -108,14 +108,6 @@ namespace Microsoft.Maui.Controls
 			set => SetValue(RemainingItemsThresholdProperty, value);
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/ItemsView.xml" path="//Member[@MemberName='AddLogicalChild']/Docs/*" />
-		public new void AddLogicalChild(Element element) =>
-			base.AddLogicalChild(element);
-
-		/// <include file="../../../docs/Microsoft.Maui.Controls/ItemsView.xml" path="//Member[@MemberName='RemoveLogicalChild']/Docs/*" />
-		public new void RemoveLogicalChild(Element element)
-			=> base.RemoveLogicalChild(element);
-
 		internal static readonly BindableProperty InternalItemsLayoutProperty =
 			BindableProperty.Create(nameof(ItemsLayout), typeof(IItemsLayout), typeof(ItemsView),
 				LinearItemsLayout.Vertical, propertyChanged: OnInternalItemsLayoutPropertyChanged);

--- a/src/Controls/src/Core/Items/ItemsView.cs
+++ b/src/Controls/src/Core/Items/ItemsView.cs
@@ -109,12 +109,12 @@ namespace Microsoft.Maui.Controls
 		}
 
 		/// <include file="../../../docs/Microsoft.Maui.Controls/ItemsView.xml" path="//Member[@MemberName='AddLogicalChild']/Docs/*" />
-		public void AddLogicalChild(Element element) =>
-			AddLogicalChildInternal(element);
+		public new void AddLogicalChild(Element element) =>
+			base.AddLogicalChild(element);
 
 		/// <include file="../../../docs/Microsoft.Maui.Controls/ItemsView.xml" path="//Member[@MemberName='RemoveLogicalChild']/Docs/*" />
-		public void RemoveLogicalChild(Element element)
-			=> RemoveLogicalChildInternal(element);
+		public new void RemoveLogicalChild(Element element)
+			=> base.RemoveLogicalChild(element);
 
 		internal static readonly BindableProperty InternalItemsLayoutProperty =
 			BindableProperty.Create(nameof(ItemsLayout), typeof(IItemsLayout), typeof(ItemsView),

--- a/src/Controls/src/Core/Layout/Layout.cs
+++ b/src/Controls/src/Core/Layout/Layout.cs
@@ -59,16 +59,12 @@ namespace Microsoft.Maui.Controls
 
 				if (old is Element oldElement)
 				{
-					oldElement.Parent = null;
-					VisualDiagnostics.OnChildRemoved(this, oldElement, index);
+					RemoveLogicalChild(oldElement, index);
 				}
-
-				_children[index] = value;
 
 				if (value is Element newElement)
 				{
-					newElement.Parent = this;
-					VisualDiagnostics.OnChildAdded(this, newElement);
+					InsertLogicalChild(index, newElement);
 				}
 
 				OnUpdate(index, value, old);
@@ -132,22 +128,13 @@ namespace Microsoft.Maui.Controls
 				return;
 
 			var index = _children.Count;
-			_children.Add(child);
-
+			InsertLogicalChild(index, (Element)child);
 			OnAdd(index, child);
 		}
 
 		public void Clear()
 		{
-			for (var index = Count - 1; index >= 0; index--)
-			{
-				if (this[index] is Element element)
-				{
-					OnChildRemoved(element, index);
-				}
-			}
-
-			_children.Clear();
+			ClearLogicalChildren();
 			OnClear();
 		}
 
@@ -171,8 +158,7 @@ namespace Microsoft.Maui.Controls
 			if (child == null)
 				return;
 
-			_children.Insert(index, child);
-
+			InsertLogicalChild(index, (Element)child);
 			OnInsert(index, child);
 		}
 
@@ -201,9 +187,7 @@ namespace Microsoft.Maui.Controls
 			}
 
 			var child = _children[index];
-
-			_children.RemoveAt(index);
-
+			RemoveLogicalChild((Element)child, index);
 			OnRemove(index, child);
 		}
 
@@ -226,12 +210,6 @@ namespace Microsoft.Maui.Controls
 		protected virtual void OnRemove(int index, IView view)
 		{
 			NotifyHandler(nameof(ILayoutHandler.Remove), index, view);
-
-			// Take care of the Element internal bookkeeping
-			if (view is Element element)
-			{
-				OnChildRemoved(element, index);
-			}
 		}
 
 		protected virtual void OnInsert(int index, IView view)

--- a/src/Controls/src/Core/Layout/Layout.cs
+++ b/src/Controls/src/Core/Layout/Layout.cs
@@ -66,6 +66,10 @@ namespace Microsoft.Maui.Controls
 				{
 					InsertLogicalChild(index, newElement);
 				}
+				else
+				{
+					_children[index] = value;
+				}
 
 				OnUpdate(index, value, old);
 			}
@@ -128,7 +132,12 @@ namespace Microsoft.Maui.Controls
 				return;
 
 			var index = _children.Count;
-			InsertLogicalChild(index, (Element)child);
+
+			if (child is Element element)
+				InsertLogicalChild(index, element);
+			else
+				_children.Add(child);
+
 			OnAdd(index, child);
 		}
 
@@ -158,7 +167,11 @@ namespace Microsoft.Maui.Controls
 			if (child == null)
 				return;
 
-			InsertLogicalChild(index, (Element)child);
+			if (child is Element element)
+				InsertLogicalChild(index, element);
+			else 
+				_children.Insert(index, child);
+
 			OnInsert(index, child);
 		}
 
@@ -187,7 +200,12 @@ namespace Microsoft.Maui.Controls
 			}
 
 			var child = _children[index];
-			RemoveLogicalChild((Element)child, index);
+
+			if (child is Element element)
+				RemoveLogicalChild(element, index);
+			else
+				_children.RemoveAt(index);
+
 			OnRemove(index, child);
 		}
 

--- a/src/Controls/src/Core/Layout/Layout.cs
+++ b/src/Controls/src/Core/Layout/Layout.cs
@@ -212,12 +212,6 @@ namespace Microsoft.Maui.Controls
 		protected virtual void OnAdd(int index, IView view)
 		{
 			NotifyHandler(nameof(ILayoutHandler.Add), index, view);
-
-			// Take care of the Element internal bookkeeping
-			if (view is Element element)
-			{
-				OnChildAdded(element);
-			}
 		}
 
 		protected virtual void OnClear()
@@ -233,12 +227,6 @@ namespace Microsoft.Maui.Controls
 		protected virtual void OnInsert(int index, IView view)
 		{
 			NotifyHandler(nameof(ILayoutHandler.Insert), index, view);
-
-			// Take care of the Element internal bookkeeping
-			if (view is Element element)
-			{
-				OnChildAdded(element);
-			}
 		}
 
 		protected virtual void OnUpdate(int index, IView view, IView oldView)

--- a/src/Controls/src/Core/ListView/ListView.cs
+++ b/src/Controls/src/Core/ListView/ListView.cs
@@ -17,10 +17,9 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../docs/Microsoft.Maui.Controls/ListView.xml" path="Type[@FullName='Microsoft.Maui.Controls.ListView']/Docs/*" />
 	public class ListView : ItemsView<Cell>, IListViewController, IElementConfiguration<ListView>, IVisualTreeElement
 	{
-		readonly List<Element> _logicalChildren = new List<Element>();
-		IReadOnlyList<IVisualTreeElement> IVisualTreeElement.GetVisualChildren() => _logicalChildren;
-
-		internal override IEnumerable<Element> ChildrenNotDrawnByThisElement => _logicalChildren;
+		// TODO comment about iOS listview issue
+		readonly List<Element> _visualChildren = new List<Element>();
+		IReadOnlyList<IVisualTreeElement> IVisualTreeElement.GetVisualChildren() => _visualChildren;
 
 		/// <summary>Bindable property for <see cref="IsPullToRefreshEnabled"/>.</summary>
 		public static readonly BindableProperty IsPullToRefreshEnabledProperty = BindableProperty.Create("IsPullToRefreshEnabled", typeof(bool), typeof(ListView), false);
@@ -445,7 +444,7 @@ namespace Microsoft.Maui.Controls
 
 			if (content != null)
 			{
-				_logicalChildren.Add(content);
+				_visualChildren.Add(content);
 				content.Parent = this;
 				VisualDiagnostics.OnChildAdded(this, content);
 			}
@@ -457,10 +456,10 @@ namespace Microsoft.Maui.Controls
 
 			if (content == null)
 				return;
-			var index = _logicalChildren.IndexOf(content);
+			var index = _visualChildren.IndexOf(content);
 			if (index == -1)
 				return;
-			_logicalChildren.RemoveAt(index);
+			_visualChildren.RemoveAt(index);
 			content.Parent = null;
 			VisualDiagnostics.OnChildRemoved(this, content, index);
 

--- a/src/Controls/src/Core/ListView/ListView.cs
+++ b/src/Controls/src/Core/ListView/ListView.cs
@@ -17,7 +17,9 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../docs/Microsoft.Maui.Controls/ListView.xml" path="Type[@FullName='Microsoft.Maui.Controls.ListView']/Docs/*" />
 	public class ListView : ItemsView<Cell>, IListViewController, IElementConfiguration<ListView>, IVisualTreeElement
 	{
-		// TODO comment about iOS listview issue
+		// The ListViewRenderer has some odd behavior with LogicalChildren
+		// https://github.com/xamarin/Xamarin.Forms/pull/12057
+		// Ideally we'd fix the ListViewRenderer so we don't have this separation
 		readonly List<Element> _visualChildren = new List<Element>();
 		IReadOnlyList<IVisualTreeElement> IVisualTreeElement.GetVisualChildren() => _visualChildren;
 

--- a/src/Controls/src/Core/Menu/FlyoutBase.cs
+++ b/src/Controls/src/Core/Menu/FlyoutBase.cs
@@ -7,12 +7,7 @@ namespace Microsoft.Maui.Controls
 		public static readonly BindableProperty ContextFlyoutProperty = BindableProperty.CreateAttached("ContextFlyout", typeof(FlyoutBase), typeof(FlyoutBase), null,
 			propertyChanged: (bo, oldV, newV) =>
 			{
-				if (oldV is BindableObject oldMenu)
-					VisualElement.SetInheritedBindingContext(oldMenu, null);
-
-				if (newV is BindableObject newMenu)
-					VisualElement.SetInheritedBindingContext(newMenu, bo.BindingContext);
-
+				bo.AddRemoveLogicalChildren(oldV, newV);
 			});
 
 		public static void SetContextFlyout(BindableObject b, FlyoutBase value)

--- a/src/Controls/src/Core/Menu/MenuBarItem.cs
+++ b/src/Controls/src/Core/Menu/MenuBarItem.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Maui.Controls
 		public void Add(IMenuElement item)
 		{
 			var index = _menus.Count;
-			AddLogicalChildInternal((Element)item);
+			AddLogicalChild((Element)item);
 			NotifyHandler(nameof(IMenuBarItemHandler.Add), index, item);
 		}
 
@@ -91,14 +91,14 @@ namespace Microsoft.Maui.Controls
 
 		public void Insert(int index, IMenuElement item)
 		{
-			InsertLogicalChildInternal(index, (Element)item);
+			InsertLogicalChild(index, (Element)item);
 			NotifyHandler(nameof(IMenuBarItemHandler.Insert), index, item);
 		}
 
 		public bool Remove(IMenuElement item)
 		{
 			var index = _menus.IndexOf(item);
-			var result = RemoveLogicalChildInternal((Element)item, index);
+			var result = RemoveLogicalChild((Element)item, index);
 			NotifyHandler(nameof(IMenuFlyoutHandler.Remove), index, item);
 
 			return result;
@@ -107,7 +107,7 @@ namespace Microsoft.Maui.Controls
 		public void RemoveAt(int index)
 		{
 			var item = _menus[index];
-			RemoveLogicalChildInternal((Element)item, index);
+			RemoveLogicalChild((Element)item, index);
 			NotifyHandler(nameof(IMenuFlyoutHandler.Remove), index, item);
 		}
 

--- a/src/Controls/src/Core/Menu/MenuBarTracker.cs
+++ b/src/Controls/src/Core/Menu/MenuBarTracker.cs
@@ -29,11 +29,11 @@ namespace Microsoft.Maui.Controls
 
 			if (_menuBar.Count == 0)
 			{
-				_menuBar.Parent = null;
+				_menuBar.Parent?.RemoveLogicalChild(_menuBar);
 			}
 			else if (_menuBar.Parent != _parent)
 			{
-				_menuBar.Parent = _parent;
+				_parent.AddLogicalChild(_menuBar);
 			}
 
 			if (_handlerProperty != null)

--- a/src/Controls/src/Core/Menu/MenuBarTracker.cs
+++ b/src/Controls/src/Core/Menu/MenuBarTracker.cs
@@ -18,7 +18,6 @@ namespace Microsoft.Maui.Controls
 		public MenuBarTracker(Element parent, string handlerProperty)
 		{
 			_menuBar = new MenuBar();
-			_menuBar.Parent = parent;
 			_parent = parent;
 			_handlerProperty = handlerProperty;
 			CollectionChanged += OnMenuBarItemCollectionChanged;
@@ -27,6 +26,15 @@ namespace Microsoft.Maui.Controls
 		void OnMenuBarItemCollectionChanged(object sender, EventArgs e)
 		{
 			_menuBar.SyncMenuBarItemsFromPages(ToolbarItems);
+
+			if (_menuBar.Count == 0)
+			{
+				_menuBar.Parent = null;
+			}
+			else if (_menuBar.Parent != _parent)
+			{
+				_menuBar.Parent = _parent;
+			}
 
 			if (_handlerProperty != null)
 			{

--- a/src/Controls/src/Core/Menu/MenuFlyout.cs
+++ b/src/Controls/src/Core/Menu/MenuFlyout.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Maui.Controls
 		public void Add(IMenuElement item)
 		{
 			var index = _menus.Count;
-			AddLogicalChildInternal((Element)item);
+			AddLogicalChild((Element)item);
 			NotifyHandler(nameof(IMenuFlyoutHandler.Add), index, item);
 
 			// Take care of the Element internal bookkeeping
@@ -69,14 +69,14 @@ namespace Microsoft.Maui.Controls
 
 		public void Insert(int index, IMenuElement item)
 		{
-			InsertLogicalChildInternal(index, (Element)item);
+			InsertLogicalChild(index, (Element)item);
 			NotifyHandler(nameof(IMenuFlyoutHandler.Insert), index, item);
 		}
 
 		public bool Remove(IMenuElement item)
 		{
 			var index = _menus.IndexOf(item);
-			var result = RemoveLogicalChildInternal((Element)item, index);
+			var result = RemoveLogicalChild((Element)item, index);
 			NotifyHandler(nameof(IMenuFlyoutHandler.Remove), index, item);
 
 			return result;
@@ -85,7 +85,7 @@ namespace Microsoft.Maui.Controls
 		public void RemoveAt(int index)
 		{
 			var item = _menus[index];
-			RemoveLogicalChildInternal((Element)item, index);
+			RemoveLogicalChild((Element)item, index);
 			NotifyHandler(nameof(IMenuFlyoutHandler.Remove), index, item);
 		}
 

--- a/src/Controls/src/Core/Menu/MenuFlyoutSubItem.cs
+++ b/src/Controls/src/Core/Menu/MenuFlyoutSubItem.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Maui.Controls
 		public void Add(IMenuElement item)
 		{
 			var index = _menus.Count;
-			AddLogicalChildInternal((Element)item);
+			AddLogicalChild((Element)item);
 			NotifyHandler(nameof(IMenuBarItemHandler.Add), index, item);
 		}
 
@@ -66,14 +66,14 @@ namespace Microsoft.Maui.Controls
 
 		public void Insert(int index, IMenuElement item)
 		{
-			InsertLogicalChildInternal(index, (Element)item);
+			InsertLogicalChild(index, (Element)item);
 			NotifyHandler(nameof(IMenuFlyoutSubItemHandler.Insert), index, item);
 		}
 
 		public bool Remove(IMenuElement item)
 		{
 			var index = _menus.IndexOf(item);
-			var result = RemoveLogicalChildInternal((Element)item, index);
+			var result = RemoveLogicalChild((Element)item, index);
 			NotifyHandler(nameof(IMenuFlyoutHandler.Remove), index, item);
 
 			return result;
@@ -82,7 +82,7 @@ namespace Microsoft.Maui.Controls
 		public void RemoveAt(int index)
 		{
 			var item = _menus[index];
-			RemoveLogicalChildInternal((Element)item, index);
+			RemoveLogicalChild((Element)item, index);
 			NotifyHandler(nameof(IMenuFlyoutHandler.Remove), index, item);
 		}
 

--- a/src/Controls/src/Core/NavigationPage/NavigationPage.cs
+++ b/src/Controls/src/Core/NavigationPage/NavigationPage.cs
@@ -159,11 +159,6 @@ namespace Microsoft.Maui.Controls
 			{
 				page.SetTitleView((View)oldValue, (View)newValue);
 			}
-			else if (oldValue != null)
-			{
-				var oldElem = (View)oldValue;
-				oldElem.Parent = null;
-			}
 		}
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/NavigationPage.xml" path="//Member[@MemberName='GetBackButtonTitle']/Docs/*" />

--- a/src/Controls/src/Core/NavigationPage/NavigationPage.cs
+++ b/src/Controls/src/Core/NavigationPage/NavigationPage.cs
@@ -40,7 +40,8 @@ namespace Microsoft.Maui.Controls
 		public static readonly BindableProperty IconColorProperty = BindableProperty.CreateAttached("IconColor", typeof(Color), typeof(NavigationPage), null);
 
 		/// <summary>Bindable property for attached property <c>TitleView</c>.</summary>
-		public static readonly BindableProperty TitleViewProperty = BindableProperty.CreateAttached("TitleView", typeof(View), typeof(NavigationPage), null, propertyChanging: TitleViewPropertyChanging);
+		public static readonly BindableProperty TitleViewProperty = BindableProperty.CreateAttached("TitleView", typeof(View), typeof(NavigationPage), null,
+			propertyChanging: TitleViewPropertyChanging, propertyChanged: (bo, oldV, newV) => bo.AddRemoveLogicalChildren(oldV, newV));
 
 		static readonly BindablePropertyKey CurrentPagePropertyKey = BindableProperty.CreateReadOnly("CurrentPage", typeof(Page), typeof(NavigationPage), null, propertyChanged: OnCurrentPageChanged);
 

--- a/src/Controls/src/Core/Page/Page.cs
+++ b/src/Controls/src/Core/Page/Page.cs
@@ -609,12 +609,6 @@ namespace Microsoft.Maui.Controls
 
 		internal void SetTitleView(View oldTitleView, View newTitleView)
 		{
-			if (oldTitleView != null)
-				oldTitleView.Parent = null;
-
-			if (newTitleView != null)
-				newTitleView.Parent = this;
-
 			_titleView = newTitleView;
 		}
 

--- a/src/Controls/src/Core/Page/Page.cs
+++ b/src/Controls/src/Core/Page/Page.cs
@@ -536,19 +536,25 @@ namespace Microsoft.Maui.Controls
 			if (e.NewItems != null)
 			{
 				int index = e.NewStartingIndex;
+
 				foreach (Element item in e.NewItems)
 				{
+					int insertIndex = index;
+					if (insertIndex < 0)
+						insertIndex = InternalChildren.IndexOf(item);
+
 					if (item is VisualElement visual)
 					{
 						visual.MeasureInvalidated += OnChildMeasureInvalidated;
 
-						InsertLogicalChild(index, visual);
+						InsertLogicalChild(insertIndex, visual);
 						InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
 					}
 					else
-						InsertLogicalChild(index, item);
+						InsertLogicalChild(insertIndex, item);
 
-					index++;
+					if (index >= 0)
+						index++;
 				}
 			}
 		}

--- a/src/Controls/src/Core/Page/Page.cs
+++ b/src/Controls/src/Core/Page/Page.cs
@@ -535,17 +535,20 @@ namespace Microsoft.Maui.Controls
 
 			if (e.NewItems != null)
 			{
+				int index = e.NewStartingIndex;
 				foreach (Element item in e.NewItems)
 				{
 					if (item is VisualElement visual)
 					{
 						visual.MeasureInvalidated += OnChildMeasureInvalidated;
 
-						AddLogicalChild(visual);
+						InsertLogicalChild(index, visual);
 						InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
 					}
 					else
-						AddLogicalChild(item);
+						InsertLogicalChild(index, item);
+
+					index++;
 				}
 			}
 		}

--- a/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.cs
+++ b/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.cs
@@ -157,7 +157,7 @@ namespace Microsoft.Maui.Controls.Platform
 					}
 
 					var page = await PopModalPlatformAsync(animated);
-					page.Parent.RemoveLogicalChild(page);
+					page.Parent?.RemoveLogicalChild(page);
 					syncAgain = true;
 				}
 

--- a/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.cs
+++ b/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.cs
@@ -157,7 +157,7 @@ namespace Microsoft.Maui.Controls.Platform
 					}
 
 					var page = await PopModalPlatformAsync(animated);
-					page.Parent = null;
+					page.Parent.RemoveLogicalChild(page);
 					syncAgain = true;
 				}
 
@@ -234,7 +234,7 @@ namespace Microsoft.Maui.Controls.Platform
 				(isPlatformReady && !syncing) ? PopModalPlatformAsync(animated) : Task.CompletedTask;
 
 			await popTask;
-			modal.Parent = null;
+			modal.Parent?.RemoveLogicalChild(modal);
 			_window.OnModalPopped(modal);
 
 			if (FireLifeCycleEvents)
@@ -255,7 +255,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 			var previousPage = CurrentPage;
 			_modalPages.Add(new NavigationStepRequest(modal, true, animated));
-			modal.Parent = _window;
+			_window.AddLogicalChild(modal);
 
 			if (FireLifeCycleEvents)
 			{

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -109,7 +109,7 @@ Microsoft.Maui.Controls.IValueConverter.ConvertBack(object? value, System.Type! 
 ~Microsoft.Maui.Controls.Element.AddLogicalChild(Microsoft.Maui.Controls.Element element) -> void
 ~Microsoft.Maui.Controls.Element.InsertLogicalChild(int index, Microsoft.Maui.Controls.Element element) -> void
 ~Microsoft.Maui.Controls.Element.RemoveLogicalChild(Microsoft.Maui.Controls.Element element) -> bool
-~Microsoft.Maui.Controls.Element.RemoveLogicalChild(Microsoft.Maui.Controls.Element element, int oldLogicalIndex) -> bool
+~Microsoft.Maui.Controls.Element.RemoveLogicalChild(Microsoft.Maui.Controls.Element element, int index) -> bool
 Microsoft.Maui.Controls.Element.ClearLogicalChildren() -> void
 Microsoft.Maui.Controls.ShellNavigationQueryParameters
 Microsoft.Maui.Controls.ShellNavigationQueryParameters.Add(string! key, object! value) -> void

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -106,6 +106,11 @@ Microsoft.Maui.Controls.IValueConverter.Convert(object? value, System.Type! targ
 Microsoft.Maui.Controls.IValueConverter.ConvertBack(object? value, System.Type! targetType, object? parameter, System.Globalization.CultureInfo! culture) -> object?
 ~static Microsoft.Maui.Controls.GridExtensions.Add(this Microsoft.Maui.Controls.Grid grid, Microsoft.Maui.IView view, int left, int right, int top, int bottom) -> void
 ~static Microsoft.Maui.Controls.GridExtensions.AddWithSpan(this Microsoft.Maui.Controls.Grid grid, Microsoft.Maui.IView view, int row = 0, int column = 0, int rowSpan = 1, int columnSpan = 1) -> void
+~Microsoft.Maui.Controls.Element.AddLogicalChild(Microsoft.Maui.Controls.Element element) -> void
+~Microsoft.Maui.Controls.Element.InsertLogicalChild(int index, Microsoft.Maui.Controls.Element element) -> void
+~Microsoft.Maui.Controls.Element.RemoveLogicalChild(Microsoft.Maui.Controls.Element element) -> bool
+~Microsoft.Maui.Controls.Element.RemoveLogicalChild(Microsoft.Maui.Controls.Element element, int oldLogicalIndex) -> bool
+Microsoft.Maui.Controls.Element.ClearLogicalChildren() -> void
 Microsoft.Maui.Controls.ShellNavigationQueryParameters
 Microsoft.Maui.Controls.ShellNavigationQueryParameters.Add(string! key, object! value) -> void
 Microsoft.Maui.Controls.ShellNavigationQueryParameters.Add(System.Collections.Generic.KeyValuePair<string!, object!> item) -> void

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -109,7 +109,6 @@ Microsoft.Maui.Controls.IValueConverter.ConvertBack(object? value, System.Type! 
 ~Microsoft.Maui.Controls.Element.AddLogicalChild(Microsoft.Maui.Controls.Element element) -> void
 ~Microsoft.Maui.Controls.Element.InsertLogicalChild(int index, Microsoft.Maui.Controls.Element element) -> void
 ~Microsoft.Maui.Controls.Element.RemoveLogicalChild(Microsoft.Maui.Controls.Element element) -> bool
-~Microsoft.Maui.Controls.Element.RemoveLogicalChild(Microsoft.Maui.Controls.Element element, int index) -> bool
 Microsoft.Maui.Controls.Element.ClearLogicalChildren() -> void
 Microsoft.Maui.Controls.ShellNavigationQueryParameters
 Microsoft.Maui.Controls.ShellNavigationQueryParameters.Add(string! key, object! value) -> void
@@ -133,3 +132,7 @@ Microsoft.Maui.Controls.ShellNavigationQueryParameters.TryGetValue(string! key, 
 Microsoft.Maui.Controls.ShellNavigationQueryParameters.Values.get -> System.Collections.Generic.ICollection<object!>!
 ~Microsoft.Maui.Controls.Shell.GoToAsync(Microsoft.Maui.Controls.ShellNavigationState state, bool animate, Microsoft.Maui.Controls.ShellNavigationQueryParameters shellNavigationQueryParameters) -> System.Threading.Tasks.Task
 ~Microsoft.Maui.Controls.Shell.GoToAsync(Microsoft.Maui.Controls.ShellNavigationState state, Microsoft.Maui.Controls.ShellNavigationQueryParameters shellNavigationQueryParameters) -> System.Threading.Tasks.Task
+*REMOVED*~Microsoft.Maui.Controls.ItemsView.AddLogicalChild(Microsoft.Maui.Controls.Element element) -> void
+*REMOVED*~Microsoft.Maui.Controls.ItemsView.RemoveLogicalChild(Microsoft.Maui.Controls.Element element) -> void
+*REMOVED*~Microsoft.Maui.Controls.Shell.AddLogicalChild(Microsoft.Maui.Controls.Element element) -> void
+*REMOVED*~Microsoft.Maui.Controls.Shell.RemoveLogicalChild(Microsoft.Maui.Controls.Element element) -> void

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -111,7 +111,6 @@ override Microsoft.Maui.Controls.Handlers.Items.ItemsViewHandler<TItemsView>.Get
 ~Microsoft.Maui.Controls.Element.AddLogicalChild(Microsoft.Maui.Controls.Element element) -> void
 ~Microsoft.Maui.Controls.Element.InsertLogicalChild(int index, Microsoft.Maui.Controls.Element element) -> void
 ~Microsoft.Maui.Controls.Element.RemoveLogicalChild(Microsoft.Maui.Controls.Element element) -> bool
-~Microsoft.Maui.Controls.Element.RemoveLogicalChild(Microsoft.Maui.Controls.Element element, int index) -> bool
 Microsoft.Maui.Controls.Element.ClearLogicalChildren() -> void
 Microsoft.Maui.Controls.ShellNavigationQueryParameters
 Microsoft.Maui.Controls.ShellNavigationQueryParameters.Add(string! key, object! value) -> void
@@ -135,3 +134,7 @@ Microsoft.Maui.Controls.ShellNavigationQueryParameters.TryGetValue(string! key, 
 Microsoft.Maui.Controls.ShellNavigationQueryParameters.Values.get -> System.Collections.Generic.ICollection<object!>!
 ~Microsoft.Maui.Controls.Shell.GoToAsync(Microsoft.Maui.Controls.ShellNavigationState state, bool animate, Microsoft.Maui.Controls.ShellNavigationQueryParameters shellNavigationQueryParameters) -> System.Threading.Tasks.Task
 ~Microsoft.Maui.Controls.Shell.GoToAsync(Microsoft.Maui.Controls.ShellNavigationState state, Microsoft.Maui.Controls.ShellNavigationQueryParameters shellNavigationQueryParameters) -> System.Threading.Tasks.Task
+*REMOVED*~Microsoft.Maui.Controls.ItemsView.AddLogicalChild(Microsoft.Maui.Controls.Element element) -> void
+*REMOVED*~Microsoft.Maui.Controls.ItemsView.RemoveLogicalChild(Microsoft.Maui.Controls.Element element) -> void
+*REMOVED*~Microsoft.Maui.Controls.Shell.AddLogicalChild(Microsoft.Maui.Controls.Element element) -> void
+*REMOVED*~Microsoft.Maui.Controls.Shell.RemoveLogicalChild(Microsoft.Maui.Controls.Element element) -> void

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -108,6 +108,11 @@ Microsoft.Maui.Controls.IValueConverter.ConvertBack(object? value, System.Type! 
 *REMOVED*override Microsoft.Maui.Controls.Handlers.Compatibility.PhoneFlyoutPageRenderer.WillRotate(UIKit.UIInterfaceOrientation toInterfaceOrientation, double duration) -> void
 ~virtual Microsoft.Maui.Controls.Handlers.Items.ItemsViewController<TItemsView>.DetermineCellReuseId(Foundation.NSIndexPath indexPath) -> string
 override Microsoft.Maui.Controls.Handlers.Items.ItemsViewHandler<TItemsView>.GetDesiredSize(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
+~Microsoft.Maui.Controls.Element.AddLogicalChild(Microsoft.Maui.Controls.Element element) -> void
+~Microsoft.Maui.Controls.Element.InsertLogicalChild(int index, Microsoft.Maui.Controls.Element element) -> void
+~Microsoft.Maui.Controls.Element.RemoveLogicalChild(Microsoft.Maui.Controls.Element element) -> bool
+~Microsoft.Maui.Controls.Element.RemoveLogicalChild(Microsoft.Maui.Controls.Element element, int oldLogicalIndex) -> bool
+Microsoft.Maui.Controls.Element.ClearLogicalChildren() -> void
 Microsoft.Maui.Controls.ShellNavigationQueryParameters
 Microsoft.Maui.Controls.ShellNavigationQueryParameters.Add(string! key, object! value) -> void
 Microsoft.Maui.Controls.ShellNavigationQueryParameters.Add(System.Collections.Generic.KeyValuePair<string!, object!> item) -> void

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -111,7 +111,7 @@ override Microsoft.Maui.Controls.Handlers.Items.ItemsViewHandler<TItemsView>.Get
 ~Microsoft.Maui.Controls.Element.AddLogicalChild(Microsoft.Maui.Controls.Element element) -> void
 ~Microsoft.Maui.Controls.Element.InsertLogicalChild(int index, Microsoft.Maui.Controls.Element element) -> void
 ~Microsoft.Maui.Controls.Element.RemoveLogicalChild(Microsoft.Maui.Controls.Element element) -> bool
-~Microsoft.Maui.Controls.Element.RemoveLogicalChild(Microsoft.Maui.Controls.Element element, int oldLogicalIndex) -> bool
+~Microsoft.Maui.Controls.Element.RemoveLogicalChild(Microsoft.Maui.Controls.Element element, int index) -> bool
 Microsoft.Maui.Controls.Element.ClearLogicalChildren() -> void
 Microsoft.Maui.Controls.ShellNavigationQueryParameters
 Microsoft.Maui.Controls.ShellNavigationQueryParameters.Add(string! key, object! value) -> void

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -111,7 +111,6 @@ override Microsoft.Maui.Controls.Handlers.Items.ItemsViewHandler<TItemsView>.Get
 ~Microsoft.Maui.Controls.Element.AddLogicalChild(Microsoft.Maui.Controls.Element element) -> void
 ~Microsoft.Maui.Controls.Element.InsertLogicalChild(int index, Microsoft.Maui.Controls.Element element) -> void
 ~Microsoft.Maui.Controls.Element.RemoveLogicalChild(Microsoft.Maui.Controls.Element element) -> bool
-~Microsoft.Maui.Controls.Element.RemoveLogicalChild(Microsoft.Maui.Controls.Element element, int index) -> bool
 Microsoft.Maui.Controls.Element.ClearLogicalChildren() -> void
 Microsoft.Maui.Controls.ShellNavigationQueryParameters
 Microsoft.Maui.Controls.ShellNavigationQueryParameters.Add(string! key, object! value) -> void
@@ -135,3 +134,7 @@ Microsoft.Maui.Controls.ShellNavigationQueryParameters.TryGetValue(string! key, 
 Microsoft.Maui.Controls.ShellNavigationQueryParameters.Values.get -> System.Collections.Generic.ICollection<object!>!
 ~Microsoft.Maui.Controls.Shell.GoToAsync(Microsoft.Maui.Controls.ShellNavigationState state, bool animate, Microsoft.Maui.Controls.ShellNavigationQueryParameters shellNavigationQueryParameters) -> System.Threading.Tasks.Task
 ~Microsoft.Maui.Controls.Shell.GoToAsync(Microsoft.Maui.Controls.ShellNavigationState state, Microsoft.Maui.Controls.ShellNavigationQueryParameters shellNavigationQueryParameters) -> System.Threading.Tasks.Task
+*REMOVED*~Microsoft.Maui.Controls.ItemsView.AddLogicalChild(Microsoft.Maui.Controls.Element element) -> void
+*REMOVED*~Microsoft.Maui.Controls.ItemsView.RemoveLogicalChild(Microsoft.Maui.Controls.Element element) -> void
+*REMOVED*~Microsoft.Maui.Controls.Shell.AddLogicalChild(Microsoft.Maui.Controls.Element element) -> void
+*REMOVED*~Microsoft.Maui.Controls.Shell.RemoveLogicalChild(Microsoft.Maui.Controls.Element element) -> void

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -108,6 +108,11 @@ Microsoft.Maui.Controls.IValueConverter.ConvertBack(object? value, System.Type! 
 *REMOVED*override Microsoft.Maui.Controls.Handlers.Compatibility.PhoneFlyoutPageRenderer.WillRotate(UIKit.UIInterfaceOrientation toInterfaceOrientation, double duration) -> void
 ~virtual Microsoft.Maui.Controls.Handlers.Items.ItemsViewController<TItemsView>.DetermineCellReuseId(Foundation.NSIndexPath indexPath) -> string
 override Microsoft.Maui.Controls.Handlers.Items.ItemsViewHandler<TItemsView>.GetDesiredSize(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
+~Microsoft.Maui.Controls.Element.AddLogicalChild(Microsoft.Maui.Controls.Element element) -> void
+~Microsoft.Maui.Controls.Element.InsertLogicalChild(int index, Microsoft.Maui.Controls.Element element) -> void
+~Microsoft.Maui.Controls.Element.RemoveLogicalChild(Microsoft.Maui.Controls.Element element) -> bool
+~Microsoft.Maui.Controls.Element.RemoveLogicalChild(Microsoft.Maui.Controls.Element element, int oldLogicalIndex) -> bool
+Microsoft.Maui.Controls.Element.ClearLogicalChildren() -> void
 Microsoft.Maui.Controls.ShellNavigationQueryParameters
 Microsoft.Maui.Controls.ShellNavigationQueryParameters.Add(string! key, object! value) -> void
 Microsoft.Maui.Controls.ShellNavigationQueryParameters.Add(System.Collections.Generic.KeyValuePair<string!, object!> item) -> void

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -111,7 +111,7 @@ override Microsoft.Maui.Controls.Handlers.Items.ItemsViewHandler<TItemsView>.Get
 ~Microsoft.Maui.Controls.Element.AddLogicalChild(Microsoft.Maui.Controls.Element element) -> void
 ~Microsoft.Maui.Controls.Element.InsertLogicalChild(int index, Microsoft.Maui.Controls.Element element) -> void
 ~Microsoft.Maui.Controls.Element.RemoveLogicalChild(Microsoft.Maui.Controls.Element element) -> bool
-~Microsoft.Maui.Controls.Element.RemoveLogicalChild(Microsoft.Maui.Controls.Element element, int oldLogicalIndex) -> bool
+~Microsoft.Maui.Controls.Element.RemoveLogicalChild(Microsoft.Maui.Controls.Element element, int index) -> bool
 Microsoft.Maui.Controls.Element.ClearLogicalChildren() -> void
 Microsoft.Maui.Controls.ShellNavigationQueryParameters
 Microsoft.Maui.Controls.ShellNavigationQueryParameters.Add(string! key, object! value) -> void

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -116,5 +116,5 @@ Microsoft.Maui.Controls.ShellNavigationQueryParameters.Values.get -> System.Coll
 ~Microsoft.Maui.Controls.Element.AddLogicalChild(Microsoft.Maui.Controls.Element element) -> void
 ~Microsoft.Maui.Controls.Element.InsertLogicalChild(int index, Microsoft.Maui.Controls.Element element) -> void
 ~Microsoft.Maui.Controls.Element.RemoveLogicalChild(Microsoft.Maui.Controls.Element element) -> bool
-~Microsoft.Maui.Controls.Element.RemoveLogicalChild(Microsoft.Maui.Controls.Element element, int oldLogicalIndex) -> bool
+~Microsoft.Maui.Controls.Element.RemoveLogicalChild(Microsoft.Maui.Controls.Element element, int index) -> bool
 Microsoft.Maui.Controls.Element.ClearLogicalChildren() -> void

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -113,3 +113,8 @@ Microsoft.Maui.Controls.ShellNavigationQueryParameters.Values.get -> System.Coll
 ~Microsoft.Maui.Controls.Shell.GoToAsync(Microsoft.Maui.Controls.ShellNavigationState state, bool animate, Microsoft.Maui.Controls.ShellNavigationQueryParameters shellNavigationQueryParameters) -> System.Threading.Tasks.Task
 ~Microsoft.Maui.Controls.Shell.GoToAsync(Microsoft.Maui.Controls.ShellNavigationState state, Microsoft.Maui.Controls.ShellNavigationQueryParameters shellNavigationQueryParameters) -> System.Threading.Tasks.Task
 ~static readonly Microsoft.Maui.Controls.InputView.IsTextPredictionEnabledProperty -> Microsoft.Maui.Controls.BindableProperty
+~Microsoft.Maui.Controls.Element.AddLogicalChild(Microsoft.Maui.Controls.Element element) -> void
+~Microsoft.Maui.Controls.Element.InsertLogicalChild(int index, Microsoft.Maui.Controls.Element element) -> void
+~Microsoft.Maui.Controls.Element.RemoveLogicalChild(Microsoft.Maui.Controls.Element element) -> bool
+~Microsoft.Maui.Controls.Element.RemoveLogicalChild(Microsoft.Maui.Controls.Element element, int oldLogicalIndex) -> bool
+Microsoft.Maui.Controls.Element.ClearLogicalChildren() -> void

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -116,5 +116,8 @@ Microsoft.Maui.Controls.ShellNavigationQueryParameters.Values.get -> System.Coll
 ~Microsoft.Maui.Controls.Element.AddLogicalChild(Microsoft.Maui.Controls.Element element) -> void
 ~Microsoft.Maui.Controls.Element.InsertLogicalChild(int index, Microsoft.Maui.Controls.Element element) -> void
 ~Microsoft.Maui.Controls.Element.RemoveLogicalChild(Microsoft.Maui.Controls.Element element) -> bool
-~Microsoft.Maui.Controls.Element.RemoveLogicalChild(Microsoft.Maui.Controls.Element element, int index) -> bool
 Microsoft.Maui.Controls.Element.ClearLogicalChildren() -> void
+*REMOVED*~Microsoft.Maui.Controls.ItemsView.AddLogicalChild(Microsoft.Maui.Controls.Element element) -> void
+*REMOVED*~Microsoft.Maui.Controls.ItemsView.RemoveLogicalChild(Microsoft.Maui.Controls.Element element) -> void
+*REMOVED*~Microsoft.Maui.Controls.Shell.AddLogicalChild(Microsoft.Maui.Controls.Element element) -> void
+*REMOVED*~Microsoft.Maui.Controls.Shell.RemoveLogicalChild(Microsoft.Maui.Controls.Element element) -> void

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -110,7 +110,6 @@ Microsoft.Maui.Controls.IValueConverter.ConvertBack(object? value, System.Type! 
 ~Microsoft.Maui.Controls.Element.AddLogicalChild(Microsoft.Maui.Controls.Element element) -> void
 ~Microsoft.Maui.Controls.Element.InsertLogicalChild(int index, Microsoft.Maui.Controls.Element element) -> void
 ~Microsoft.Maui.Controls.Element.RemoveLogicalChild(Microsoft.Maui.Controls.Element element) -> bool
-~Microsoft.Maui.Controls.Element.RemoveLogicalChild(Microsoft.Maui.Controls.Element element, int index) -> bool
 Microsoft.Maui.Controls.Element.ClearLogicalChildren() -> void
 Microsoft.Maui.Controls.ShellNavigationQueryParameters
 Microsoft.Maui.Controls.ShellNavigationQueryParameters.Add(string! key, object! value) -> void
@@ -133,3 +132,9 @@ Microsoft.Maui.Controls.ShellNavigationQueryParameters.this[string! key].set -> 
 Microsoft.Maui.Controls.ShellNavigationQueryParameters.Values.get -> System.Collections.Generic.ICollection<object!>!
 ~Microsoft.Maui.Controls.Shell.GoToAsync(Microsoft.Maui.Controls.ShellNavigationState state, bool animate, Microsoft.Maui.Controls.ShellNavigationQueryParameters shellNavigationQueryParameters) -> System.Threading.Tasks.Task
 ~Microsoft.Maui.Controls.Shell.GoToAsync(Microsoft.Maui.Controls.ShellNavigationState state, Microsoft.Maui.Controls.ShellNavigationQueryParameters shellNavigationQueryParameters) -> System.Threading.Tasks.Task
+*REMOVED*~Microsoft.Maui.Controls.ItemsView.AddLogicalChild(Microsoft.Maui.Controls.Element element) -> void
+*REMOVED*~Microsoft.Maui.Controls.ItemsView.RemoveLogicalChild(Microsoft.Maui.Controls.Element element) -> void
+*REMOVED*~Microsoft.Maui.Controls.Shell.AddLogicalChild(Microsoft.Maui.Controls.Element element) -> void
+*REMOVED*~Microsoft.Maui.Controls.Shell.RemoveLogicalChild(Microsoft.Maui.Controls.Element element) -> void
+*REMOVED*~Microsoft.Maui.Controls.Shell.AddLogicalChild(Microsoft.Maui.Controls.Element element) -> void
+*REMOVED*~Microsoft.Maui.Controls.Shell.RemoveLogicalChild(Microsoft.Maui.Controls.Element element) -> void

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -110,7 +110,7 @@ Microsoft.Maui.Controls.IValueConverter.ConvertBack(object? value, System.Type! 
 ~Microsoft.Maui.Controls.Element.AddLogicalChild(Microsoft.Maui.Controls.Element element) -> void
 ~Microsoft.Maui.Controls.Element.InsertLogicalChild(int index, Microsoft.Maui.Controls.Element element) -> void
 ~Microsoft.Maui.Controls.Element.RemoveLogicalChild(Microsoft.Maui.Controls.Element element) -> bool
-~Microsoft.Maui.Controls.Element.RemoveLogicalChild(Microsoft.Maui.Controls.Element element, int oldLogicalIndex) -> bool
+~Microsoft.Maui.Controls.Element.RemoveLogicalChild(Microsoft.Maui.Controls.Element element, int index) -> bool
 Microsoft.Maui.Controls.Element.ClearLogicalChildren() -> void
 Microsoft.Maui.Controls.ShellNavigationQueryParameters
 Microsoft.Maui.Controls.ShellNavigationQueryParameters.Add(string! key, object! value) -> void

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -107,6 +107,11 @@ Microsoft.Maui.Controls.IValueConverter.Convert(object? value, System.Type! targ
 Microsoft.Maui.Controls.IValueConverter.ConvertBack(object? value, System.Type! targetType, object? parameter, System.Globalization.CultureInfo! culture) -> object?
 ~static Microsoft.Maui.Controls.GridExtensions.Add(this Microsoft.Maui.Controls.Grid grid, Microsoft.Maui.IView view, int left, int right, int top, int bottom) -> void
 ~static Microsoft.Maui.Controls.GridExtensions.AddWithSpan(this Microsoft.Maui.Controls.Grid grid, Microsoft.Maui.IView view, int row = 0, int column = 0, int rowSpan = 1, int columnSpan = 1) -> void
+~Microsoft.Maui.Controls.Element.AddLogicalChild(Microsoft.Maui.Controls.Element element) -> void
+~Microsoft.Maui.Controls.Element.InsertLogicalChild(int index, Microsoft.Maui.Controls.Element element) -> void
+~Microsoft.Maui.Controls.Element.RemoveLogicalChild(Microsoft.Maui.Controls.Element element) -> bool
+~Microsoft.Maui.Controls.Element.RemoveLogicalChild(Microsoft.Maui.Controls.Element element, int oldLogicalIndex) -> bool
+Microsoft.Maui.Controls.Element.ClearLogicalChildren() -> void
 Microsoft.Maui.Controls.ShellNavigationQueryParameters
 Microsoft.Maui.Controls.ShellNavigationQueryParameters.Add(string! key, object! value) -> void
 Microsoft.Maui.Controls.ShellNavigationQueryParameters.Add(System.Collections.Generic.KeyValuePair<string!, object!> item) -> void

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -94,6 +94,11 @@ Microsoft.Maui.Controls.IValueConverter.Convert(object? value, System.Type! targ
 Microsoft.Maui.Controls.IValueConverter.ConvertBack(object? value, System.Type! targetType, object? parameter, System.Globalization.CultureInfo! culture) -> object?
 ~static Microsoft.Maui.Controls.GridExtensions.Add(this Microsoft.Maui.Controls.Grid grid, Microsoft.Maui.IView view, int left, int right, int top, int bottom) -> void
 ~static Microsoft.Maui.Controls.GridExtensions.AddWithSpan(this Microsoft.Maui.Controls.Grid grid, Microsoft.Maui.IView view, int row = 0, int column = 0, int rowSpan = 1, int columnSpan = 1) -> void
+~Microsoft.Maui.Controls.Element.AddLogicalChild(Microsoft.Maui.Controls.Element element) -> void
+~Microsoft.Maui.Controls.Element.InsertLogicalChild(int index, Microsoft.Maui.Controls.Element element) -> void
+~Microsoft.Maui.Controls.Element.RemoveLogicalChild(Microsoft.Maui.Controls.Element element) -> bool
+~Microsoft.Maui.Controls.Element.RemoveLogicalChild(Microsoft.Maui.Controls.Element element, int oldLogicalIndex) -> bool
+Microsoft.Maui.Controls.Element.ClearLogicalChildren() -> void
 Microsoft.Maui.Controls.ShellNavigationQueryParameters
 Microsoft.Maui.Controls.ShellNavigationQueryParameters.Add(string! key, object! value) -> void
 Microsoft.Maui.Controls.ShellNavigationQueryParameters.Add(System.Collections.Generic.KeyValuePair<string!, object!> item) -> void

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -97,7 +97,7 @@ Microsoft.Maui.Controls.IValueConverter.ConvertBack(object? value, System.Type! 
 ~Microsoft.Maui.Controls.Element.AddLogicalChild(Microsoft.Maui.Controls.Element element) -> void
 ~Microsoft.Maui.Controls.Element.InsertLogicalChild(int index, Microsoft.Maui.Controls.Element element) -> void
 ~Microsoft.Maui.Controls.Element.RemoveLogicalChild(Microsoft.Maui.Controls.Element element) -> bool
-~Microsoft.Maui.Controls.Element.RemoveLogicalChild(Microsoft.Maui.Controls.Element element, int oldLogicalIndex) -> bool
+~Microsoft.Maui.Controls.Element.RemoveLogicalChild(Microsoft.Maui.Controls.Element element, int index) -> bool
 Microsoft.Maui.Controls.Element.ClearLogicalChildren() -> void
 Microsoft.Maui.Controls.ShellNavigationQueryParameters
 Microsoft.Maui.Controls.ShellNavigationQueryParameters.Add(string! key, object! value) -> void

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -97,7 +97,6 @@ Microsoft.Maui.Controls.IValueConverter.ConvertBack(object? value, System.Type! 
 ~Microsoft.Maui.Controls.Element.AddLogicalChild(Microsoft.Maui.Controls.Element element) -> void
 ~Microsoft.Maui.Controls.Element.InsertLogicalChild(int index, Microsoft.Maui.Controls.Element element) -> void
 ~Microsoft.Maui.Controls.Element.RemoveLogicalChild(Microsoft.Maui.Controls.Element element) -> bool
-~Microsoft.Maui.Controls.Element.RemoveLogicalChild(Microsoft.Maui.Controls.Element element, int index) -> bool
 Microsoft.Maui.Controls.Element.ClearLogicalChildren() -> void
 Microsoft.Maui.Controls.ShellNavigationQueryParameters
 Microsoft.Maui.Controls.ShellNavigationQueryParameters.Add(string! key, object! value) -> void
@@ -121,3 +120,7 @@ Microsoft.Maui.Controls.ShellNavigationQueryParameters.TryGetValue(string! key, 
 Microsoft.Maui.Controls.ShellNavigationQueryParameters.Values.get -> System.Collections.Generic.ICollection<object!>!
 ~Microsoft.Maui.Controls.Shell.GoToAsync(Microsoft.Maui.Controls.ShellNavigationState state, bool animate, Microsoft.Maui.Controls.ShellNavigationQueryParameters shellNavigationQueryParameters) -> System.Threading.Tasks.Task
 ~Microsoft.Maui.Controls.Shell.GoToAsync(Microsoft.Maui.Controls.ShellNavigationState state, Microsoft.Maui.Controls.ShellNavigationQueryParameters shellNavigationQueryParameters) -> System.Threading.Tasks.Task
+*REMOVED*~Microsoft.Maui.Controls.ItemsView.AddLogicalChild(Microsoft.Maui.Controls.Element element) -> void
+*REMOVED*~Microsoft.Maui.Controls.ItemsView.RemoveLogicalChild(Microsoft.Maui.Controls.Element element) -> void
+*REMOVED*~Microsoft.Maui.Controls.Shell.AddLogicalChild(Microsoft.Maui.Controls.Element element) -> void
+*REMOVED*~Microsoft.Maui.Controls.Shell.RemoveLogicalChild(Microsoft.Maui.Controls.Element element) -> void

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -1,6 +1,7 @@
 #nullable enable
 *REMOVED*~Microsoft.Maui.Controls.Accelerator.Modifiers.set -> void
 *REMOVED*~Microsoft.Maui.Controls.Accelerator.Keys.set -> void
+Microsoft.Maui.Controls.Element.ClearLogicalChildren() -> void
 ~Microsoft.Maui.Controls.Accelerator.Key.get -> string
 *REMOVED*override Microsoft.Maui.Controls.RefreshView.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 Microsoft.Maui.Controls.Border.~Border() -> void
@@ -65,6 +66,10 @@ Microsoft.Maui.Controls.VisualElement.RefreshIsEnabledProperty() -> void
 override Microsoft.Maui.Controls.Button.IsEnabledCore.get -> bool
 override Microsoft.Maui.Controls.ImageButton.IsEnabledCore.get -> bool
 override Microsoft.Maui.Controls.SearchBar.IsEnabledCore.get -> bool
+~Microsoft.Maui.Controls.Element.AddLogicalChild(Microsoft.Maui.Controls.Element element) -> void
+~Microsoft.Maui.Controls.Element.InsertLogicalChild(int index, Microsoft.Maui.Controls.Element element) -> void
+~Microsoft.Maui.Controls.Element.RemoveLogicalChild(Microsoft.Maui.Controls.Element element) -> bool
+~Microsoft.Maui.Controls.Element.RemoveLogicalChild(Microsoft.Maui.Controls.Element element, int oldLogicalIndex) -> bool
 ~Microsoft.Maui.Controls.Shell.GoToAsync(Microsoft.Maui.Controls.ShellNavigationState state, bool animate, Microsoft.Maui.Controls.ShellNavigationQueryParameters shellNavigationQueryParameters) -> System.Threading.Tasks.Task
 ~Microsoft.Maui.Controls.Shell.GoToAsync(Microsoft.Maui.Controls.ShellNavigationState state, Microsoft.Maui.Controls.ShellNavigationQueryParameters shellNavigationQueryParameters) -> System.Threading.Tasks.Task
 ~Microsoft.Maui.Controls.WebView.UserAgent.get -> string

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -69,7 +69,6 @@ override Microsoft.Maui.Controls.SearchBar.IsEnabledCore.get -> bool
 ~Microsoft.Maui.Controls.Element.AddLogicalChild(Microsoft.Maui.Controls.Element element) -> void
 ~Microsoft.Maui.Controls.Element.InsertLogicalChild(int index, Microsoft.Maui.Controls.Element element) -> void
 ~Microsoft.Maui.Controls.Element.RemoveLogicalChild(Microsoft.Maui.Controls.Element element) -> bool
-~Microsoft.Maui.Controls.Element.RemoveLogicalChild(Microsoft.Maui.Controls.Element element, int index) -> bool
 ~Microsoft.Maui.Controls.Shell.GoToAsync(Microsoft.Maui.Controls.ShellNavigationState state, bool animate, Microsoft.Maui.Controls.ShellNavigationQueryParameters shellNavigationQueryParameters) -> System.Threading.Tasks.Task
 ~Microsoft.Maui.Controls.Shell.GoToAsync(Microsoft.Maui.Controls.ShellNavigationState state, Microsoft.Maui.Controls.ShellNavigationQueryParameters shellNavigationQueryParameters) -> System.Threading.Tasks.Task
 ~Microsoft.Maui.Controls.WebView.UserAgent.get -> string
@@ -115,3 +114,7 @@ Microsoft.Maui.Controls.IValueConverter.Convert(object? value, System.Type! targ
 Microsoft.Maui.Controls.IValueConverter.ConvertBack(object? value, System.Type! targetType, object? parameter, System.Globalization.CultureInfo! culture) -> object?
 ~static Microsoft.Maui.Controls.GridExtensions.Add(this Microsoft.Maui.Controls.Grid grid, Microsoft.Maui.IView view, int left, int right, int top, int bottom) -> void
 ~static Microsoft.Maui.Controls.GridExtensions.AddWithSpan(this Microsoft.Maui.Controls.Grid grid, Microsoft.Maui.IView view, int row = 0, int column = 0, int rowSpan = 1, int columnSpan = 1) -> void
+*REMOVED*~Microsoft.Maui.Controls.ItemsView.AddLogicalChild(Microsoft.Maui.Controls.Element element) -> void
+*REMOVED*~Microsoft.Maui.Controls.ItemsView.RemoveLogicalChild(Microsoft.Maui.Controls.Element element) -> void
+*REMOVED*~Microsoft.Maui.Controls.Shell.AddLogicalChild(Microsoft.Maui.Controls.Element element) -> void
+*REMOVED*~Microsoft.Maui.Controls.Shell.RemoveLogicalChild(Microsoft.Maui.Controls.Element element) -> void

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -69,7 +69,7 @@ override Microsoft.Maui.Controls.SearchBar.IsEnabledCore.get -> bool
 ~Microsoft.Maui.Controls.Element.AddLogicalChild(Microsoft.Maui.Controls.Element element) -> void
 ~Microsoft.Maui.Controls.Element.InsertLogicalChild(int index, Microsoft.Maui.Controls.Element element) -> void
 ~Microsoft.Maui.Controls.Element.RemoveLogicalChild(Microsoft.Maui.Controls.Element element) -> bool
-~Microsoft.Maui.Controls.Element.RemoveLogicalChild(Microsoft.Maui.Controls.Element element, int oldLogicalIndex) -> bool
+~Microsoft.Maui.Controls.Element.RemoveLogicalChild(Microsoft.Maui.Controls.Element element, int index) -> bool
 ~Microsoft.Maui.Controls.Shell.GoToAsync(Microsoft.Maui.Controls.ShellNavigationState state, bool animate, Microsoft.Maui.Controls.ShellNavigationQueryParameters shellNavigationQueryParameters) -> System.Threading.Tasks.Task
 ~Microsoft.Maui.Controls.Shell.GoToAsync(Microsoft.Maui.Controls.ShellNavigationState state, Microsoft.Maui.Controls.ShellNavigationQueryParameters shellNavigationQueryParameters) -> System.Threading.Tasks.Task
 ~Microsoft.Maui.Controls.WebView.UserAgent.get -> string

--- a/src/Controls/src/Core/Shell/BaseShellItem.cs
+++ b/src/Controls/src/Core/Shell/BaseShellItem.cs
@@ -26,10 +26,6 @@ namespace Microsoft.Maui.Controls
 		const string DefaultFlyoutItemLayoutStyle = "Default_FlyoutItemLayoutStyle";
 
 		protected private ObservableCollection<Element> DeclaredChildren { get; } = new ObservableCollection<Element>();
-		readonly ObservableCollection<Element> _logicalChildren = new ObservableCollection<Element>();
-
-		private protected override IList<Element> LogicalChildrenInternalBackingStore
-			=> _logicalChildren;
 
 		#region PropertyKeys
 
@@ -262,43 +258,9 @@ namespace Microsoft.Maui.Controls
 				to.SetValue(property, from.GetValue(property));
 		}
 
-		internal void AddLogicalChild(Element element)
-		{
-			if (element == null)
-			{
-				return;
-			}
-
-			if (_logicalChildren.Contains(element))
-				return;
-
-			_logicalChildren.Add(element);
-			element.Parent = this;
-			OnChildAdded(element);
-			VisualDiagnostics.OnChildAdded(this, element);
-		}
-
-		internal void RemoveLogicalChild(Element element)
-		{
-			if (element == null)
-			{
-				return;
-			}
-
-			element.Parent = null;
-
-			if (!_logicalChildren.Contains(element))
-				return;
-
-			var oldLogicalIndex = _logicalChildren.IndexOf(element);
-			_logicalChildren.Remove(element);
-			OnChildRemoved(element, oldLogicalIndex);
-			VisualDiagnostics.OnChildRemoved(this, element, oldLogicalIndex);
-		}
-
 		void IPropertyPropagationController.PropagatePropertyChanged(string propertyName)
 		{
-			PropertyPropagationExtensions.PropagatePropertyChanged(propertyName, this, ((IElementController)this).LogicalChildren);
+			PropertyPropagationExtensions.PropagatePropertyChanged(propertyName, this, ((IVisualTreeElement)this).GetVisualChildren());
 		}
 
 		EffectiveFlowDirection _effectiveFlowDirection = default(EffectiveFlowDirection);

--- a/src/Controls/src/Core/Shell/Shell.cs
+++ b/src/Controls/src/Core/Shell/Shell.cs
@@ -803,7 +803,6 @@ namespace Microsoft.Maui.Controls
 			Navigation = new NavigationImpl(this);
 			Route = Routing.GenerateImplicitRoute("shell");
 			Initialize();
-			//InternalChildren.CollectionChanged += OnInternalChildrenCollectionChanged;
 
 			if (Application.Current != null)
 			{

--- a/src/Controls/src/Core/Shell/Shell.cs
+++ b/src/Controls/src/Core/Shell/Shell.cs
@@ -714,12 +714,6 @@ namespace Microsoft.Maui.Controls
 			return _navigationManager.GoToAsync(state, animate, false, parameters: new ShellRouteParameters(shellNavigationQueryParameters));
 		}
 
-		public new void AddLogicalChild(Element element) =>
-			base.AddLogicalChild(element);
-
-		public new void RemoveLogicalChild(Element element) =>
-			base.RemoveLogicalChild(element);
-
 		/// <summary>Bindable property for <see cref="CurrentItem"/>.</summary>
 		public static readonly BindableProperty CurrentItemProperty =
 			BindableProperty.Create(nameof(CurrentItem), typeof(ShellItem), typeof(Shell), null, BindingMode.TwoWay,
@@ -1432,7 +1426,7 @@ namespace Microsoft.Maui.Controls
 				FlyoutHeaderTemplate,
 				ref _flyoutHeaderView,
 				newVal,
-				RemoveLogicalChild,
+				(element) => RemoveLogicalChild(element),
 				AddLogicalChild);
 		}
 
@@ -1442,7 +1436,7 @@ namespace Microsoft.Maui.Controls
 				newValue,
 				ref _flyoutHeaderView,
 				FlyoutHeader,
-				RemoveLogicalChild,
+				(element) => RemoveLogicalChild(element),
 				AddLogicalChild,
 				this);
 		}
@@ -1453,7 +1447,7 @@ namespace Microsoft.Maui.Controls
 				FlyoutFooterTemplate,
 				ref _flyoutFooterView,
 				newVal,
-				RemoveLogicalChild,
+				(element) => RemoveLogicalChild(element),
 				AddLogicalChild);
 		}
 
@@ -1463,7 +1457,7 @@ namespace Microsoft.Maui.Controls
 				newValue,
 				ref _flyoutFooterView,
 				FlyoutFooter,
-				RemoveLogicalChild,
+				(element) => RemoveLogicalChild(element),
 				AddLogicalChild,
 				this);
 		}
@@ -1591,7 +1585,7 @@ namespace Microsoft.Maui.Controls
 				FlyoutContentTemplate,
 				ref _flyoutContentView,
 				newVal,
-				RemoveLogicalChild,
+				(element) => RemoveLogicalChild(element),
 				AddLogicalChild);
 		}
 
@@ -1601,7 +1595,7 @@ namespace Microsoft.Maui.Controls
 				newValue,
 				ref _flyoutContentView,
 				FlyoutContent,
-				RemoveLogicalChild,
+				(element) => RemoveLogicalChild(element),
 				AddLogicalChild,
 				this);
 		}

--- a/src/Controls/src/Core/Shell/Shell.cs
+++ b/src/Controls/src/Core/Shell/Shell.cs
@@ -1415,18 +1415,6 @@ namespace Microsoft.Maui.Controls
 			return null;
 		}
 
-
-		//void OnInternalChildrenCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
-		//{
-		//	if (e.NewItems != null)
-		//		foreach (Element element in e.NewItems)
-		//			AddLogicalChild(element);
-
-		//	if (e.OldItems != null)
-		//		foreach (Element element in e.OldItems)
-		//			RemoveLogicalChild(element);
-		//}
-
 		void NotifyFlyoutBehaviorObservers()
 		{
 			if (CurrentItem == null || GetVisiblePage() == null)

--- a/src/Controls/src/Core/Shell/Shell.cs
+++ b/src/Controls/src/Core/Shell/Shell.cs
@@ -714,39 +714,11 @@ namespace Microsoft.Maui.Controls
 			return _navigationManager.GoToAsync(state, animate, false, parameters: new ShellRouteParameters(shellNavigationQueryParameters));
 		}
 
-		public void AddLogicalChild(Element element)
-		{
-			if (element == null)
-			{
-				return;
-			}
+		public new void AddLogicalChild(Element element) =>
+			base.AddLogicalChild(element);
 
-			if (_logicalChildren.Contains(element))
-				return;
-
-			_logicalChildren.Add(element);
-			element.Parent = this;
-			OnChildAdded(element);
-			VisualDiagnostics.OnChildAdded(this, element);
-		}
-
-		public void RemoveLogicalChild(Element element)
-		{
-			if (element == null)
-			{
-				return;
-			}
-
-			element.Parent = null;
-
-			var oldLogicalIndex = _logicalChildren.IndexOf(element);
-			if (oldLogicalIndex == -1)
-				return;
-
-			_logicalChildren.RemoveAt(oldLogicalIndex);
-			OnChildRemoved(element, oldLogicalIndex);
-			VisualDiagnostics.OnChildRemoved(this, element, oldLogicalIndex);
-		}
+		public new void RemoveLogicalChild(Element element) =>
+			base.RemoveLogicalChild(element);
 
 		/// <summary>Bindable property for <see cref="CurrentItem"/>.</summary>
 		public static readonly BindableProperty CurrentItemProperty =
@@ -818,12 +790,6 @@ namespace Microsoft.Maui.Controls
 		ShellFlyoutItemsManager _flyoutManager;
 		Page _previousPage;
 
-		ObservableCollection<Element> _logicalChildren
-			= new ObservableCollection<Element>();
-
-		private protected override IList<Element> LogicalChildrenInternalBackingStore
-			=> _logicalChildren;
-
 		/// <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='.ctor']/Docs/*" />
 		public Shell()
 		{
@@ -837,7 +803,7 @@ namespace Microsoft.Maui.Controls
 			Navigation = new NavigationImpl(this);
 			Route = Routing.GenerateImplicitRoute("shell");
 			Initialize();
-			InternalChildren.CollectionChanged += OnInternalChildrenCollectionChanged;
+			//InternalChildren.CollectionChanged += OnInternalChildrenCollectionChanged;
 
 			if (Application.Current != null)
 			{
@@ -1336,27 +1302,8 @@ namespace Microsoft.Maui.Controls
 			shell.OnFlyoutFooterTemplateChanged((DataTemplate)oldValue, (DataTemplate)newValue);
 		}
 
-		static void OnTitleViewChanged(BindableObject bindable, object oldValue, object newValue)
-		{
-			if (!(bindable is Element owner))
-				return;
-
-			var oldView = (View)oldValue;
-			var newView = (View)newValue;
-			var shell = bindable as Shell;
-
-			if (oldView != null)
-			{
-				shell?.RemoveLogicalChild(oldView);
-				oldView.Parent = null;
-			}
-
-			if (newView != null)
-			{
-				newView.Parent = owner;
-				shell?.AddLogicalChild(newView);
-			}
-		}
+		static void OnTitleViewChanged(BindableObject bindable, object oldValue, object newValue) =>
+			bindable.AddRemoveLogicalChildren(oldValue, newValue);
 
 		internal FlyoutBehavior GetEffectiveFlyoutBehavior()
 		{
@@ -1469,16 +1416,16 @@ namespace Microsoft.Maui.Controls
 		}
 
 
-		void OnInternalChildrenCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
-		{
-			if (e.NewItems != null)
-				foreach (Element element in e.NewItems)
-					AddLogicalChild(element);
+		//void OnInternalChildrenCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+		//{
+		//	if (e.NewItems != null)
+		//		foreach (Element element in e.NewItems)
+		//			AddLogicalChild(element);
 
-			if (e.OldItems != null)
-				foreach (Element element in e.OldItems)
-					RemoveLogicalChild(element);
-		}
+		//	if (e.OldItems != null)
+		//		foreach (Element element in e.OldItems)
+		//			RemoveLogicalChild(element);
+		//}
 
 		void NotifyFlyoutBehaviorObservers()
 		{
@@ -1589,13 +1536,7 @@ namespace Microsoft.Maui.Controls
 
 		void IPropertyPropagationController.PropagatePropertyChanged(string propertyName)
 		{
-			PropertyPropagationExtensions.PropagatePropertyChanged(propertyName, this, ((IElementController)this).LogicalChildren);
-			if (FlyoutHeaderView != null)
-				PropertyPropagationExtensions.PropagatePropertyChanged(propertyName, this, new[] { FlyoutHeaderView });
-			if (FlyoutFooterView != null)
-				PropertyPropagationExtensions.PropagatePropertyChanged(propertyName, this, new[] { FlyoutFooterView });
-			if (FlyoutContentView != null)
-				PropertyPropagationExtensions.PropagatePropertyChanged(propertyName, this, new[] { FlyoutContentView });
+			PropertyPropagationExtensions.PropagatePropertyChanged(propertyName, this, ((IVisualTreeElement)this).GetVisualChildren());
 		}
 
 		protected override void LayoutChildren(double x, double y, double width, double height)

--- a/src/Controls/src/Core/Shell/ShellItem.cs
+++ b/src/Controls/src/Core/Shell/ShellItem.cs
@@ -132,7 +132,7 @@ namespace Microsoft.Maui.Controls
 		#region IPropertyPropagationController
 		void IPropertyPropagationController.PropagatePropertyChanged(string propertyName)
 		{
-			PropertyPropagationExtensions.PropagatePropertyChanged(propertyName, this, Items);
+			PropertyPropagationExtensions.PropagatePropertyChanged(propertyName, this, ((IVisualTreeElement)this).GetVisualChildren());
 		}
 		#endregion
 

--- a/src/Controls/src/Core/Shell/ShellSection.cs
+++ b/src/Controls/src/Core/Shell/ShellSection.cs
@@ -194,7 +194,7 @@ namespace Microsoft.Maui.Controls
 		#region IPropertyPropagationController
 		void IPropertyPropagationController.PropagatePropertyChanged(string propertyName)
 		{
-			PropertyPropagationExtensions.PropagatePropertyChanged(propertyName, this, Items);
+			PropertyPropagationExtensions.PropagatePropertyChanged(propertyName, this, ((IVisualTreeElement)this).GetVisualChildren());
 		}
 		#endregion
 
@@ -1214,8 +1214,6 @@ namespace Microsoft.Maui.Controls
 				return ShellNavigationManager.GetNavigationState(shellItem, shellSection, shellContent, stack, modalStack);
 			}
 		}
-
-		IReadOnlyList<Maui.IVisualTreeElement> IVisualTreeElement.GetVisualChildren() => AllChildren.ToList();
 
 #nullable enable
 		// This code only runs for shell bits that are running through a proper

--- a/src/Controls/src/Core/StyleSheets/Style.cs
+++ b/src/Controls/src/Core/StyleSheets/Style.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Maui.Controls.StyleSheets
 				}
 			}
 
-			foreach (var child in styleable.LogicalChildrenInternal)
+			foreach (var child in ((IVisualTreeElement)styleable).GetVisualChildren())
 			{
 				var ve = child as VisualElement;
 				if (ve == null)

--- a/src/Controls/src/Core/SwipeView/SwipeView.cs
+++ b/src/Controls/src/Core/SwipeView/SwipeView.cs
@@ -419,7 +419,7 @@ namespace Microsoft.Maui.Controls
 				return;
 
 			foreach (var swipeItem in swipeItems)
-				AddLogicalChildInternal((Element)swipeItem);
+				AddLogicalChild((Element)swipeItem);
 		}
 
 		SwipeItems? GetSwipeItemsByDirection(SwipeDirection? swipeDirection)

--- a/src/Controls/src/Core/VisualElement/VisualElement.Platform.cs
+++ b/src/Controls/src/Core/VisualElement/VisualElement.Platform.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Maui.Controls
 			_loadedUnloadedToken = null;
 
 			// Window and this VisualElement both have a handler to work with
-			if (Window?.Handler?.PlatformView != null &&
+			if (Window?.Handler?.PlatformView is not null &&
 				Handler?.PlatformView is PlatformView view)
 			{
 				if (view.IsLoaded())
@@ -40,7 +40,7 @@ namespace Microsoft.Maui.Controls
 			{
 				// My handler is still set but the window handler isn't set.
 				// This means I'm starting to detach from the platform window
-				// So we wait for the platform detatch events to fire before calling 
+				// So we wait for the platform detach events to fire before calling 
 				// OnUnloaded
 				if (Handler?.PlatformView is PlatformView detachingView &&
 					detachingView.IsLoaded())

--- a/src/Controls/src/Core/VisualElement/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement/VisualElement.cs
@@ -1866,13 +1866,27 @@ namespace Microsoft.Maui.Controls
 			UpdatePlatformUnloadedLoadedWiring(Window);
 		}
 
+		void SetupWindowHandlerChanged(bool connect, Window window)
+		{
+			if (connect)
+			{
+				window.HandlerChanged += OnWindowHandlerChanged;
+				_watchingPlatformLoaded = true;
+			}
+			else
+			{
+				window.HandlerChanged -= OnWindowHandlerChanged;
+				_watchingPlatformLoaded = false;
+			}
+		}
+
 		static void OnWindowChanged(BindableObject bindable, object? oldValue, object? newValue)
 		{
 			if (bindable is not VisualElement visualElement)
 				return;
 
 			if (visualElement._watchingPlatformLoaded && oldValue is Window oldWindow)
-				oldWindow.HandlerChanged -= visualElement.OnWindowHandlerChanged;
+				visualElement.SetupWindowHandlerChanged(false, oldWindow);
 
 			visualElement.UpdatePlatformUnloadedLoadedWiring(newValue as Window);
 			visualElement.InvalidateStateTriggers(newValue != null);
@@ -1899,7 +1913,7 @@ namespace Microsoft.Maui.Controls
 			if (_unloaded is null && _loaded is null)
 			{
 				if (window is not null)
-					window.HandlerChanged -= OnWindowHandlerChanged;
+					SetupWindowHandlerChanged(false, window);
 
 #if PLATFORM
 				_loadedUnloadedToken?.Dispose();
@@ -1913,9 +1927,7 @@ namespace Microsoft.Maui.Controls
 			if (!_watchingPlatformLoaded)
 			{
 				if (window is not null)
-					window.HandlerChanged += OnWindowHandlerChanged;
-
-				_watchingPlatformLoaded = true;
+					SetupWindowHandlerChanged(true, window);
 			}
 
 			HandlePlatformUnloadedLoaded();

--- a/src/Controls/src/Core/VisualElement/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement/VisualElement.cs
@@ -1847,6 +1847,10 @@ namespace Microsoft.Maui.Controls
 
 			_isLoadedFired = true;
 			_loaded?.Invoke(this, EventArgs.Empty);
+
+			// If the user is also watching unloaded we need to verify
+			// unloaded is still correctly being watched for.
+			UpdatePlatformUnloadedLoadedWiring(Window);
 		}
 
 		void OnUnloadedCore()
@@ -1856,6 +1860,10 @@ namespace Microsoft.Maui.Controls
 
 			_isLoadedFired = false;
 			_unloaded?.Invoke(this, EventArgs.Empty);
+
+			// If the user is also watching loaded we need to verify
+			// loaded is still correctly being watched for.
+			UpdatePlatformUnloadedLoadedWiring(Window);
 		}
 
 		static void OnWindowChanged(BindableObject bindable, object? oldValue, object? newValue)
@@ -1885,10 +1893,10 @@ namespace Microsoft.Maui.Controls
 			// If I'm not attached to a window and I haven't started watching any platform events
 			// then it's not useful to wire anything up. We will just wait until
 			// This VE gets connected to the xplat Window before wiring up any events
-			if (!_watchingPlatformLoaded && window == null)
+			if (!_watchingPlatformLoaded && window is null)
 				return;
 
-			if (_unloaded == null && _loaded == null)
+			if (_unloaded is null && _loaded is null)
 			{
 				if (window is not null)
 					window.HandlerChanged -= OnWindowHandlerChanged;

--- a/src/Controls/src/Core/Window/Window.cs
+++ b/src/Controls/src/Core/Window/Window.cs
@@ -13,7 +13,7 @@ using Microsoft.Maui.Graphics;
 namespace Microsoft.Maui.Controls
 {
 	[ContentProperty(nameof(Page))]
-	public partial class Window : NavigableElement, IWindow, IVisualTreeElement, IToolbarElement, IMenuBarElement, IFlowDirectionController, IWindowController
+	public partial class Window : NavigableElement, IWindow/*, IVisualTreeElement*/, IToolbarElement, IMenuBarElement, IFlowDirectionController, IWindowController
 	{
 		/// <summary>Bindable property for <see cref="Title"/>.</summary>
 		public static readonly BindableProperty TitleProperty = BindableProperty.Create(
@@ -412,8 +412,6 @@ namespace Microsoft.Maui.Controls
 			ModalPopped?.Invoke(this, args);
 			Application?.NotifyOfWindowModalEvent(args);
 
-			VisualDiagnostics.OnChildRemoved(this, modalPage, index);
-
 #if WINDOWS
 			this.Handler?.UpdateValue(nameof(IWindow.TitleBarDragRectangles));
 			this.Handler?.UpdateValue(nameof(ITitledElement.Title));
@@ -434,7 +432,6 @@ namespace Microsoft.Maui.Controls
 			var args = new ModalPushedEventArgs(modalPage);
 			ModalPushed?.Invoke(this, args);
 			Application?.NotifyOfWindowModalEvent(args);
-			VisualDiagnostics.OnChildAdded(this, modalPage);
 
 #if WINDOWS
 			this.Handler?.UpdateValue(nameof(IWindow.TitleBarDragRectangles));
@@ -573,8 +570,8 @@ namespace Microsoft.Maui.Controls
 		// Currently this returns MainPage + ModalStack
 		// Depending on how we want this to show up inside LVT
 		// we might want to change this to only return the currently visible page
-		IReadOnlyList<IVisualTreeElement> IVisualTreeElement.GetVisualChildren() =>
-			_visualChildren;
+		//IReadOnlyList<IVisualTreeElement> IVisualTreeElement.GetVisualChildren() =>
+		//	base.get;
 
 		static void OnPageChanging(BindableObject bindable, object oldValue, object newValue)
 		{

--- a/src/Controls/src/Core/Window/Window.cs
+++ b/src/Controls/src/Core/Window/Window.cs
@@ -367,7 +367,7 @@ namespace Microsoft.Maui.Controls
 			PropertyPropagationExtensions.PropagatePropertyChanged(
 				FlowDirectionProperty.PropertyName,
 				(Element)bindable,
-				((IElementController)bindable).LogicalChildren);
+				((IVisualTreeElement)bindable).GetVisualChildren());
 		}
 
 		bool IFlowDirectionController.ApplyEffectiveFlowDirectionToChildContainer => true;
@@ -588,7 +588,7 @@ namespace Microsoft.Maui.Controls
 			{
 				_menuBarTracker.Target = null;
 				_visualChildren.Remove(oldPage);
-				RemoveLogicalChildInternal(oldPage);
+				RemoveLogicalChild(oldPage);
 				oldPage.HandlerChanged -= OnPageHandlerChanged;
 				oldPage.HandlerChanging -= OnPageHandlerChanging;
 			}
@@ -599,7 +599,7 @@ namespace Microsoft.Maui.Controls
 			if (newPage != null)
 			{
 				_visualChildren.Add(newPage);
-				AddLogicalChildInternal(newPage);
+				AddLogicalChild(newPage);
 				newPage.NavigationProxy.Inner = NavigationProxy;
 				_menuBarTracker.Target = newPage;
 

--- a/src/Controls/src/Core/Window/Window.cs
+++ b/src/Controls/src/Core/Window/Window.cs
@@ -13,7 +13,7 @@ using Microsoft.Maui.Graphics;
 namespace Microsoft.Maui.Controls
 {
 	[ContentProperty(nameof(Page))]
-	public partial class Window : NavigableElement, IWindow/*, IVisualTreeElement*/, IToolbarElement, IMenuBarElement, IFlowDirectionController, IWindowController
+	public partial class Window : NavigableElement, IWindow, IToolbarElement, IMenuBarElement, IFlowDirectionController, IWindowController
 	{
 		/// <summary>Bindable property for <see cref="Title"/>.</summary>
 		public static readonly BindableProperty TitleProperty = BindableProperty.Create(
@@ -566,12 +566,6 @@ namespace Microsoft.Maui.Controls
 				FlowController.EffectiveFlowDirection = flowDirection.ToEffectiveFlowDirection(true);
 			}
 		}
-
-		// Currently this returns MainPage + ModalStack
-		// Depending on how we want this to show up inside LVT
-		// we might want to change this to only return the currently visible page
-		//IReadOnlyList<IVisualTreeElement> IVisualTreeElement.GetVisualChildren() =>
-		//	base.get;
 
 		static void OnPageChanging(BindableObject bindable, object oldValue, object newValue)
 		{

--- a/src/Controls/tests/Core.UnitTests/ListViewTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ListViewTests.cs
@@ -552,7 +552,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			{
 				list.ItemsSource = i % 2 > 0 ? newList1 : newList2;
 
-				// grab a header just so we can be sure its reailized
+				// grab a header just so we can be sure its realized
 				var header = list.TemplatedItems.GetGroup(0).HeaderContent;
 			}
 
@@ -560,7 +560,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			GC.WaitForPendingFinalizers();
 
 			// use less or equal because mono will keep the last header var alive no matter what
-			Assert.True(TestCell.NumberOfCells <= 6);
+			Assert.True(TestCell.NumberOfCells <= 6, $"{TestCell.NumberOfCells} <= 6");
 
 			var keepAlive = list.ToString();
 		}

--- a/src/Controls/tests/Core.UnitTests/PageTests.cs
+++ b/src/Controls/tests/Core.UnitTests/PageTests.cs
@@ -559,5 +559,25 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.True(sentNav);
 			Assert.True(sent);
 		}
+
+		[Fact]
+		public void LogicalChildrenDontAddToPagesInternalChildren()
+		{
+			var page = new ContentPage()
+			{
+				Content = new VerticalStackLayout()
+			};
+
+			var window = new TestWindow(page);
+
+			var customControl = new VerticalStackLayout();
+			Shell.SetTitleView(page, new VerticalStackLayout());
+			page.AddLogicalChild(customControl);
+
+			Assert.Equal(window, customControl.Window);
+			Assert.Single(page.InternalChildren);
+			Assert.Contains(customControl, page.LogicalChildrenInternal);
+			Assert.Contains(customControl, ((IVisualTreeElement)page).GetVisualChildren());
+		}
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/ShellTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellTests.cs
@@ -771,7 +771,9 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Shell.SetTitleView(page, layout);
 
 
-			Assert.Contains(layout, page.ChildrenNotDrawnByThisElement);
+			Assert.Contains(layout, page.LogicalChildren);
+			Assert.DoesNotContain(layout, page.InternalChildren);
+			Assert.Contains(layout, ((IVisualTreeElement)page).GetVisualChildren());
 		}
 
 		[Fact]

--- a/src/Controls/tests/Core.UnitTests/TabbedFormUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/TabbedFormUnitTests.cs
@@ -28,5 +28,22 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			Assert.Empty(page.Children);
 		}
+
+		[Fact]
+		public void LogicalAndInternalChildrenMaintainOrder()
+		{
+			TabbedPage tabbedPage = new TabbedPage();
+
+			ContentPage page1 = new ContentPage();
+			ContentPage page2 = new ContentPage();
+
+			tabbedPage.Children.Add(page2);
+			tabbedPage.Children.Insert(0, page1);
+			tabbedPage.Children.Remove(page1);
+			tabbedPage.Children.Insert(0, page1);
+
+			Assert.Equal(tabbedPage.LogicalChildren[0], tabbedPage.InternalChildren[0]);
+			Assert.Equal(tabbedPage.LogicalChildren[1], tabbedPage.InternalChildren[1]);
+		}
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/VisualTreeHelperTests.cs
+++ b/src/Controls/tests/Core.UnitTests/VisualTreeHelperTests.cs
@@ -26,6 +26,10 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 		void OnVisualTreeChanged(object? sender, VisualTreeChangeEventArgs e)
 		{
+			// TODO CLEANUP
+			if (sender is IWindow)
+				return;
+
 			Assert.True(e.ChildIndex >= 0, "Visual Tree inaccurate when OnVisualTreeChanged called");
 			_treeEvents.Add((sender as Element, e));
 			VisualTreeChanged?.Invoke(sender as Element, e);

--- a/src/Controls/tests/Core.UnitTests/VisualTreeHelperTests.cs
+++ b/src/Controls/tests/Core.UnitTests/VisualTreeHelperTests.cs
@@ -26,11 +26,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 		void OnVisualTreeChanged(object? sender, VisualTreeChangeEventArgs e)
 		{
-			// TODO CLEANUP
-			if (sender is IWindow)
-				return;
-
-			Assert.True(e.ChildIndex >= 0, "Visual Tree inaccurate when OnVisualTreeChanged called");
+			Assert.True(e.ChildIndex >= 0,$"Visual Tree inaccurate when OnVisualTreeChanged called. ChildIndex: {e.ChildIndex}");
 			_treeEvents.Add((sender as Element, e));
 			VisualTreeChanged?.Invoke(sender as Element, e);
 		}

--- a/src/Controls/tests/Core.UnitTests/WindowsTests.cs
+++ b/src/Controls/tests/Core.UnitTests/WindowsTests.cs
@@ -422,8 +422,9 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.Equal(window, window.Page.Parent);
 			Assert.Single(app.Windows);
 			Assert.Equal(app.LogicalChildrenInternal[0], window);
-			Assert.Contains(page, window.LogicalChildrenInternal);
+			Assert.Equal(window.LogicalChildrenInternal[0], page);
 			Assert.Single(app.LogicalChildrenInternal);
+			Assert.Single(window.LogicalChildrenInternal);
 			Assert.Single(window.LogicalChildrenInternal.OfType<Page>());
 			Assert.Equal(app.NavigationProxy, window.NavigationProxy.Inner);
 			Assert.Equal(window.NavigationProxy, page.NavigationProxy.Inner);

--- a/src/Controls/tests/Core.UnitTests/WindowsTests.cs
+++ b/src/Controls/tests/Core.UnitTests/WindowsTests.cs
@@ -422,9 +422,9 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.Equal(window, window.Page.Parent);
 			Assert.Single(app.Windows);
 			Assert.Equal(app.LogicalChildrenInternal[0], window);
-			Assert.Equal(window.LogicalChildrenInternal[0], page);
+			Assert.Contains(page, window.LogicalChildrenInternal);
 			Assert.Single(app.LogicalChildrenInternal);
-			Assert.Single(window.LogicalChildrenInternal);
+			Assert.Single(window.LogicalChildrenInternal.OfType<Page>());
 			Assert.Equal(app.NavigationProxy, window.NavigationProxy.Inner);
 			Assert.Equal(window.NavigationProxy, page.NavigationProxy.Inner);
 		}

--- a/src/Controls/tests/DeviceTests/ControlsHandlerTestBase.cs
+++ b/src/Controls/tests/DeviceTests/ControlsHandlerTestBase.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
@@ -355,12 +356,13 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.Equal(expectedSetValue, nativeVal);
 		}
 
-		protected Task OnLoadedAsync(VisualElement frameworkElement, TimeSpan? timeOut = null)
+		protected async Task OnLoadedAsync(VisualElement frameworkElement, TimeSpan? timeOut = null)
 		{
 			timeOut = timeOut ?? TimeSpan.FromSeconds(2);
 			var source = new TaskCompletionSource();
 			if (frameworkElement.IsLoaded && frameworkElement.IsLoadedOnPlatform())
 			{
+				await Task.Yield();
 				source.TrySetResult();
 			}
 			else
@@ -378,15 +380,16 @@ namespace Microsoft.Maui.DeviceTests
 				frameworkElement.Loaded += loaded;
 			}
 
-			return HandleLoadedUnloadedIssue(source.Task, timeOut.Value, () => frameworkElement.IsLoaded && frameworkElement.IsLoadedOnPlatform());
+			await HandleLoadedUnloadedIssue(source.Task, timeOut.Value, () => frameworkElement.IsLoaded && frameworkElement.IsLoadedOnPlatform());
 		}
 
-		protected Task OnUnloadedAsync(VisualElement frameworkElement, TimeSpan? timeOut = null)
+		protected async Task OnUnloadedAsync(VisualElement frameworkElement, TimeSpan? timeOut = null)
 		{
 			timeOut = timeOut ?? TimeSpan.FromSeconds(2);
 			var source = new TaskCompletionSource();
 			if (!frameworkElement.IsLoaded && !frameworkElement.IsLoadedOnPlatform())
 			{
+				await Task.Yield();
 				source.TrySetResult();
 			}
 			// in the xplat code we switch Loaded to Unloaded if the window property is removed.
@@ -411,7 +414,7 @@ namespace Microsoft.Maui.DeviceTests
 				frameworkElement.Unloaded += unloaded;
 			}
 
-			return HandleLoadedUnloadedIssue(source.Task, timeOut.Value, () => !frameworkElement.IsLoaded && !frameworkElement.IsLoadedOnPlatform());
+			await HandleLoadedUnloadedIssue(source.Task, timeOut.Value, () => !frameworkElement.IsLoaded && !frameworkElement.IsLoadedOnPlatform());
 		}
 
 		// Modal Page's appear to currently not fire loaded/unloaded

--- a/src/Controls/tests/DeviceTests/ControlsHandlerTestBase.cs
+++ b/src/Controls/tests/DeviceTests/ControlsHandlerTestBase.cs
@@ -122,7 +122,10 @@ namespace Microsoft.Maui.DeviceTests
 		{
 			mauiContext ??= MauiContext;
 
-			timeOut ??= TimeSpan.FromSeconds(15);
+			if (System.Diagnostics.Debugger.IsAttached)
+				timeOut ??= TimeSpan.FromHours(1);
+			else
+				timeOut ??= TimeSpan.FromSeconds(15);
 
 			return InvokeOnMainThreadAsync(async () =>
 			{

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.cs
@@ -143,7 +143,7 @@ namespace Microsoft.Maui.DeviceTests
 					await WaitForUIUpdate(frame, collectionView);
 					frame = collectionView.Frame;
 
-#if WINDOWS
+#if WINDOWS || ANDROID
 					// On Windows, the ListView pops in and changes the frame, then actually
 					// loads in the data, which updates it again. So we need to wait for the second
 					// update before checking the size

--- a/src/Controls/tests/DeviceTests/Elements/VisualElementTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/VisualElementTests.cs
@@ -154,6 +154,7 @@ namespace Microsoft.Maui.DeviceTests
 
 					await navPage.PopAsync();
 
+					await AssertionExtensions.Wait(() => loaded == 1 && unloaded == 1);
 					Assert.Equal(1, loaded);
 					Assert.Equal(1, unloaded);
 				});

--- a/src/Controls/tests/DeviceTests/Elements/VisualElementTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/VisualElementTests.cs
@@ -106,7 +106,7 @@ namespace Microsoft.Maui.DeviceTests
 					Assert.Equal(1, unloaded);
 				});
 
-				await Task.Delay(1000);
+				await AssertionExtensions.Wait(() => loaded == 2 && unloaded == 2);
 
 				Assert.Equal(2, loaded);
 				Assert.Equal(2, unloaded);

--- a/src/Controls/tests/Xaml.UnitTests/FontImageExtension.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/FontImageExtension.xaml.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 			public void FontImageExtension_Positive(bool useCompiledXaml)
 			{
 				var layout = new FontImageExtension(useCompiledXaml);
-				var tabs = layout.AllChildren;
+				var tabs = ((IVisualTreeElement)layout).GetVisualChildren();
 
 				int i = 0;
 				foreach (var tab in tabs)
@@ -53,7 +53,7 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 			public void FontImageExtension_Negative(bool useCompiledXaml)
 			{
 				var layout = new FontImageExtension(useCompiledXaml);
-				var tabs = layout.AllChildren;
+				var tabs = ((IVisualTreeElement)layout).GetVisualChildren();
 
 				foreach (var tab in tabs)
 				{


### PR DESCRIPTION
### Description of Change

```
~Microsoft.Maui.Controls.Element.AddLogicalChild(Microsoft.Maui.Controls.Element element) -> void
~Microsoft.Maui.Controls.Element.InsertLogicalChild(int index, Microsoft.Maui.Controls.Element element) -> void
~Microsoft.Maui.Controls.Element.RemoveLogicalChild(Microsoft.Maui.Controls.Element element) -> bool
Microsoft.Maui.Controls.Element.ClearLogicalChildren() -> void
```


- Adds a set of APIs (AddLogicalChild, RemoveLogicalChild, ClearLogicalChildren, InsertLogicalChild) to streamline our setup of parent/child relationships and also allow for outside developers to opt into the benefits of becoming a logical child.

- Expose a set of public APIs on `Element` that allow users to add/remove logical children to any `Element`.  There are a number of features we have that rely on `LogicalChildren`: LiveVisualTree, HotReload, Style propagation, etc.  The `LogicalChildren` structure is currently closed off from the outside world. If someone implements a custom control based off of `Element`, there's not really an easy way for them to setup `LogicalChildren`. This makes it almost impossible for 3rd party controls to setup a proper hierarchy that will benefit from LiveVisualTree, HotReload, Style propagation, BC propagation, etc.

- Rework internal code to use these new APIs

### Examples

For example, the MCT has a `popup` control that lives on a `Page`. Because that popup can't add itself to the `LogicalChidlren` of a `Page` the `popup` control doesn't work with Hot Reload or Live Visual Tree

https://github.com/CommunityToolkit/Maui/issues/1168


```C#
var page = new ContentPage()
{
	Content = new VerticalStackLayout()
};

var customControl = new MyCustomControl();
page.AddLogicalChild(customControl);
```

fixes #3745
fixes #15760 