### PR TITLE
[Windows] Fix Slider MinimumTrackColor (#16056)

### DIFF
--- a/src/Core/src/Platform/Windows/SliderExtensions.cs
+++ b/src/Core/src/Platform/Windows/SliderExtensions.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Maui.Platform
 		static readonly string[] MinimumTrackColorResourceKeys =
 		{
 			"SliderTrackValueFill",
-			"SliderTrackValueFilllPointerOver",
+			"SliderTrackValueFillPointerOver",
 			"SliderTrackValueFillPressed",
 			"SliderTrackValueFillDisabled",
 		};


### PR DESCRIPTION
### Description of Change

Fix typo that prevents MinimumTackColor being mapped to SliderTrackValueFillPointerOver on WinUI 3

### Issues Fixed

Fixes #16056
