### PR TITLE
Android has issues with Entry

### DIFF
--- a/src/Controls/src/Core/Entry/Entry.Mapper.cs
+++ b/src/Controls/src/Core/Entry/Entry.Mapper.cs
@@ -8,7 +8,6 @@ namespace Microsoft.Maui.Controls
 			{
 #if ANDROID
 				[PlatformConfiguration.AndroidSpecific.Entry.ImeOptionsProperty.PropertyName] = MapImeOptions,
-				[nameof(Entry.Keyboard)] = EntryHandler.MapKeyboard,
 #elif WINDOWS
 				[PlatformConfiguration.WindowsSpecific.InputView.DetectReadingOrderFromContentProperty.PropertyName] = MapDetectReadingOrderFromContent,
 #elif IOS

--- a/src/Controls/src/Core/Entry/Entry.Mapper.cs
+++ b/src/Controls/src/Core/Entry/Entry.Mapper.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Maui.Controls
 			{
 #if ANDROID
 				[PlatformConfiguration.AndroidSpecific.Entry.ImeOptionsProperty.PropertyName] = MapImeOptions,
+				[nameof(Entry.Keyboard)] = EntryHandler.MapKeyboard,
 #elif WINDOWS
 				[PlatformConfiguration.WindowsSpecific.InputView.DetectReadingOrderFromContentProperty.PropertyName] = MapDetectReadingOrderFromContent,
 #elif IOS

--- a/src/Core/src/Handlers/Editor/EditorHandler.cs
+++ b/src/Core/src/Handlers/Editor/EditorHandler.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Maui.Handlers
 	{
 		public static IPropertyMapper<IEditor, IEditorHandler> Mapper = new PropertyMapper<IEditor, IEditorHandler>(ViewHandler.ViewMapper)
 		{
+			[nameof(IEditor.Text)] = MapText,
 			[nameof(IEditor.Background)] = MapBackground,
 			[nameof(IEditor.CharacterSpacing)] = MapCharacterSpacing,
 			[nameof(IEditor.Font)] = MapFont,
@@ -26,7 +27,6 @@ namespace Microsoft.Maui.Handlers
 			[nameof(IEditor.MaxLength)] = MapMaxLength,
 			[nameof(IEditor.Placeholder)] = MapPlaceholder,
 			[nameof(IEditor.PlaceholderColor)] = MapPlaceholderColor,
-			[nameof(IEditor.Text)] = MapText,
 			[nameof(IEditor.TextColor)] = MapTextColor,
 			[nameof(IEditor.HorizontalTextAlignment)] = MapHorizontalTextAlignment,
 			[nameof(IEditor.VerticalTextAlignment)] = MapVerticalTextAlignment,

--- a/src/Core/src/Handlers/Entry/EntryHandler.cs
+++ b/src/Core/src/Handlers/Entry/EntryHandler.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Maui.Handlers
 	{
 		public static IPropertyMapper<IEntry, IEntryHandler> Mapper = new PropertyMapper<IEntry, IEntryHandler>(ViewHandler.ViewMapper)
 		{
+			[nameof(IEntry.Text)] = MapText,
 			[nameof(IEntry.Background)] = MapBackground,
 			[nameof(IEntry.CharacterSpacing)] = MapCharacterSpacing,
 			[nameof(IEntry.ClearButtonVisibility)] = MapClearButtonVisibility,
@@ -34,7 +35,6 @@ namespace Microsoft.Maui.Handlers
 			[nameof(IEntry.Placeholder)] = MapPlaceholder,
 			[nameof(IEntry.PlaceholderColor)] = MapPlaceholderColor,
 			[nameof(IEntry.ReturnType)] = MapReturnType,
-			[nameof(IEntry.Text)] = MapText,
 			[nameof(IEntry.TextColor)] = MapTextColor,
 			[nameof(IEntry.CursorPosition)] = MapCursorPosition,
 			[nameof(IEntry.SelectionLength)] = MapSelectionLength

--- a/src/Core/src/Handlers/SearchBar/SearchBarHandler.cs
+++ b/src/Core/src/Handlers/SearchBar/SearchBarHandler.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Maui.Handlers
 	{
 		public static IPropertyMapper<ISearchBar, ISearchBarHandler> Mapper = new PropertyMapper<ISearchBar, ISearchBarHandler>(ViewHandler.ViewMapper)
 		{
+			[nameof(ISearchBar.Text)] = MapText,
 #if __IOS__
 			[nameof(ISearchBar.IsEnabled)] = MapIsEnabled,
 #endif
@@ -31,7 +32,6 @@ namespace Microsoft.Maui.Handlers
 			[nameof(ISearchBar.MaxLength)] = MapMaxLength,
 			[nameof(ISearchBar.Placeholder)] = MapPlaceholder,
 			[nameof(ISearchBar.PlaceholderColor)] = MapPlaceholderColor,
-			[nameof(ISearchBar.Text)] = MapText,
 			[nameof(ISearchBar.TextColor)] = MapTextColor,
 			[nameof(ISearchBar.CancelButtonColor)] = MapCancelButtonColor,
 			[nameof(ISearchBar.Keyboard)] = MapKeyboard


### PR DESCRIPTION
### Description of Change

It appears that setting `EditText.InputType` will trigger the `TextChanged` event. This could - and does - happen in https://github.com/dotnet/maui/pull/15058 when we no longer chain the mappers forcing the `Text` mapper to always run first.

The reason the order matters for us is that `EditText` is a generic text input control and the default mode is actually multiline. We remove the multiline support for `Entry` and this will always require setting the `InputType`. However, this is really a very short term solution as other things touch that property: `IsPassword`, `Keyboard`, `IsReadOnly` and even spell check things. As a result, we would have to move all those thing to happen _after_ the text is set.

The simplest is to reorder the keys so that `Text` is the very first. When the `InputType` is set later, and thus triggering the `TextChanged` event, the platform view already has the text and thus the text change is updated.

After that PR lands, the order is really based on the order in the `EntryHandler` in Core. This PR will fix it for that PR so that `Text` is first and then everyone is happy.