### PR TITLE
Null check small refactoring

### DIFF
--- a/src/Controls/src/Core/Page/Page.cs
+++ b/src/Controls/src/Core/Page/Page.cs
@@ -231,7 +231,7 @@ namespace Microsoft.Maui.Controls
 #pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
 		{
 			if (string.IsNullOrEmpty(cancel))
-				throw new ArgumentNullException("cancel");
+				throw new ArgumentNullException(nameof(cancel));
 
 			var args = new AlertArguments(title, message, accept, cancel);
 			args.FlowDirection = flowDirection;


### PR DESCRIPTION
### Description of Change

Changed null check from string literal to using nameof() operator

### Issues Fixed

There is no bug as such. This is a small improvement to the style of the code
