### PR TITLE
Prevent refresh command from executing when CanExecute is false

### DIFF
--- a/src/Controls/src/Core/RefreshView/RefreshView.cs
+++ b/src/Controls/src/Core/RefreshView/RefreshView.cs
@@ -37,7 +37,11 @@ namespace Microsoft.Maui.Controls
 
 			var refreshView = (RefreshView)bindable;
 			refreshView.Refreshing?.Invoke(bindable, EventArgs.Empty);
-			refreshView.Command?.Execute(refreshView.CommandParameter);
+
+			if (refreshView.Command is not null && refreshView.Command.CanExecute(refreshView.CommandParameter))
+			{
+				refreshView.Command.Execute(refreshView.CommandParameter);
+			}
 		}
 
 		static object OnIsRefreshingPropertyCoerced(BindableObject bindable, object value)


### PR DESCRIPTION
### Description of Change
When the value for `RefreshView.IsRefreshing` is set to `true`, we execute whatever `Command` is attached to the `RefreshView` (if there is one). However, we do not check if `Command.CanExecute()` returns `true` before executing the `Command`.

This is problematic in situations where a user wants to not execute a `Command`, for example:

```XAML
<ContentPage x:Class="Maui.Controls.Sample.MainPage"
             xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
             xmlns:local="clr-namespace:Maui.Controls.Sample">
       <RefreshView x:Name="RefreshView" Command="{Binding RefreshCommand}">
            <ScrollView BackgroundColor="Purple" />
        </RefreshView>
</ContentPage>
```

```C#
public partial class MainPage : ContentPage
{
	public MainPage()
	{
		InitializeComponent();
		RefreshCommand = new Command(async () => await HandleRefreshCommandAsync(), RefreshCommandCanExecute);
		BindingContext = this;

		// Execute the command manually.
		if (RefreshCommandCanExecute())
		{
			RefreshCommand.Execute(null);
		}
	}

	public ICommand RefreshCommand { get; set; }

	private async Task HandleRefreshCommandAsync()
	{
		Console.WriteLine("handleRefreshCommandAsync");

		// Initiate UI loading animation.
		RefreshView.IsRefreshing = true;

		await Task.Delay(3000);

		RefreshView.IsRefreshing = false;
	}

	private bool RefreshCommandCanExecute()
	{
		return !RefreshView.IsRefreshing;
	}
}
```

In this example, we manually call the `RefreshCommand` when the page loads and use `IsRefreshing` to control the UI load animation. However, without the fix in this PR, the `RefreshCommand` would be executed twice: once by us manually and again when `IsRefreshing` is set to `true`.

With the fix in this PR, the `RefreshCommandCanExecute()` function will prevent the second `RefreshCommand` execution from happening as `IsRefreshing` will be `true`.

**Note:** This is only an issue when `CanExecute` is reliant on `IsRefreshing` because the `CanExecuteChanged` event is not aware of changes to `IsRefreshing`. It's also not possible to use `Command.ChangeCanExecute()` to invoke the `CanExecuteChanged` event because by the time `IsRefreshing` has changed, the `Command` has already been executed.

### Issues Fixed
Fixes #6456
