### PR TITLE
Revert default for UseSafeAreaProperty to value from .NET 6 for iOS

### DIFF
--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/Page.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/Page.cs
@@ -72,7 +72,11 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 		}
 
 		/// <summary>Bindable property for attached property <c>UseSafeArea</c>.</summary>
+#if MACCATALYST
 		public static readonly BindableProperty UseSafeAreaProperty = BindableProperty.Create("UseSafeArea", typeof(bool), typeof(Page), true);
+#else
+		public static readonly BindableProperty UseSafeAreaProperty = BindableProperty.Create("UseSafeArea", typeof(bool), typeof(Page), false);
+#endif
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Page.xml" path="//Member[@MemberName='GetUseSafeArea']/Docs/*" />
 		public static bool GetUseSafeArea(BindableObject element)

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.iOS.cs
@@ -31,6 +31,9 @@ namespace Microsoft.Maui.DeviceTests
 			var pageWithTopTabs = new ContentPage() { Content = new Label() { Text = "Page With Top Tabs" } };
 			var pageWithoutTopTabs = new ContentPage() { Content = new Label() { Text = "Page With Bottom Tabs" } };
 
+			pageWithTopTabs.On<iOS>().SetUseSafeArea(true);
+			pageWithoutTopTabs.On<iOS>().SetUseSafeArea(true);
+
 			var mainTab1 = new Tab()
 			{
 				Items =

--- a/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.cs
@@ -251,7 +251,11 @@ namespace Microsoft.Maui.DeviceTests
 		}
 #endif
 
+#if IOS
+		[Theory(Skip = "Test doesn't work on iOS yet; probably because of https://github.com/dotnet/maui/issues/10591")]
+#else
 		[Theory]
+#endif
 #if ANDROID
 		[InlineData(true)]
 #endif


### PR DESCRIPTION
### Description of Change

#10083 modified the default value for the `UseSafeAreaProperty`; this change sets it back to the original value from .NET 6 for iOS.

This should be backported for 7 since the original PR caused a behavior change in 7.

### Issues Fixed

Fixes #12823