### PR TITLE
[iOS] Avoid to use CornerCurve in iOS < 13

### DIFF
--- a/src/Core/src/Platform/iOS/ContentView.cs
+++ b/src/Core/src/Platform/iOS/ContentView.cs
@@ -13,7 +13,8 @@ namespace Microsoft.Maui.Platform
 
 		public ContentView()
 		{
-			Layer.CornerCurve = CACornerCurve.Continuous;
+			if (OperatingSystem.IsIOSVersionAtLeast(13) || OperatingSystem.IsMacCatalystVersionAtLeast(13, 1))
+				Layer.CornerCurve = CACornerCurve.Continuous; // Available from iOS 13. More info: https://developer.apple.com/documentation/quartzcore/calayercornercurve/3152600-continuous
 		}
 
 		public override void LayoutSubviews()


### PR DESCRIPTION
### Description of Change

Avoid to use `CornerCurve` in iOS < 13.

### Issues Fixed

Fixes #16097
