### PR TITLE
[housekeeping] Group dependabot PR's by dependency area/type

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,10 @@ updates:
         - "Microsoft.Graphics.Win2D"
         - "Microsoft.Windows.SDK.BuildTools"
         - "Microsoft.WindowsAppSDK"
+    xunit:
+      patterns:
+        - "xunit"
+        - "xunit.runner.*"
   ignore:
     - dependency-name: "MicrosoftMauiGraphicsVersion"         # maestro
     - dependency-name: "Microsoft.Maui.Graphics*"             # maestro

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
     AndroidX:
       patterns:
         - "Xamarin.AndroidX.*"
+        - "Xamarin.Build.Download"
+        - "Xamarin.Google.Android.Material"
     AspNetCore:
       patterns:
         - "Microsoft.AspNetCore.*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,14 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 25
+  groups:
+    AndroidX:
+      patterns:
+        - "Xamarin.AndroidX.*"
+    AspNetCore:
+      patterns:
+        - "Microsoft.AspNetCore.*"
+        - "Microsoft.JSInterop"
   ignore:
     - dependency-name: "MicrosoftMauiGraphicsVersion"         # maestro
     - dependency-name: "Microsoft.Maui.Graphics*"             # maestro

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,10 +11,25 @@ updates:
         - "Xamarin.AndroidX.*"
         - "Xamarin.Build.Download"
         - "Xamarin.Google.Android.Material"
+        - "Xamarin.Google.Crypto.Tink.Android"
     AspNetCore:
       patterns:
         - "Microsoft.AspNetCore.*"
         - "Microsoft.JSInterop"
+    SkiaSharp:
+      patterns:
+        - "SkiaSharp.*"
+        - "Svg.*"
+        - "ShimSkiaSharp"
+        - "Fizzler"
+    MicrosoftExtensions:
+      patterns:
+        - "Microsoft.Extensions.*"
+    WindowsAppSDK:
+      patterns:
+        - "Microsoft.Graphics.Win2D"
+        - "Microsoft.Windows.SDK.BuildTools"
+        - "Microsoft.WindowsAppSDK"
   ignore:
     - dependency-name: "MicrosoftMauiGraphicsVersion"         # maestro
     - dependency-name: "Microsoft.Maui.Graphics*"             # maestro


### PR DESCRIPTION
This should start grouping PR's into single a single PR by matching the group patterns.  For example we want all AndroidX updates to come in via one PR, and probably all aspnet core as well.  

We still can add more rules for System.* and other dependencies
