### PR TITLE
Text needs to be set before other properties

### DIFF
--- a/src/Core/src/Handlers/Editor/EditorHandler.Android.cs
+++ b/src/Core/src/Handlers/Editor/EditorHandler.Android.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Maui.Handlers
 
 		public static void MapKeyboard(IEditorHandler handler, IEditor editor)
 		{
-			handler.UpdateValue(nameof(IEntry.Text));
+			handler.UpdateValue(nameof(IEditor.Text));
 
 			handler.PlatformView?.UpdateKeyboard(editor);
 		}

--- a/src/Core/src/Handlers/Editor/EditorHandler.Android.cs
+++ b/src/Core/src/Handlers/Editor/EditorHandler.Android.cs
@@ -102,8 +102,12 @@ namespace Microsoft.Maui.Handlers
 		public static void MapVerticalTextAlignment(IEditorHandler handler, IEditor editor) =>
 			handler.PlatformView?.UpdateVerticalTextAlignment(editor);
 
-		public static void MapKeyboard(IEditorHandler handler, IEditor editor) =>
+		public static void MapKeyboard(IEditorHandler handler, IEditor editor)
+		{
+			handler.UpdateValue(nameof(IEntry.Text));
+
 			handler.PlatformView?.UpdateKeyboard(editor);
+		}
 
 		public static void MapCursorPosition(IEditorHandler handler, ITextInput editor) =>
 			handler.PlatformView?.UpdateCursorPosition(editor);

--- a/src/Core/src/Handlers/Entry/EntryHandler.Android.cs
+++ b/src/Core/src/Handlers/Entry/EntryHandler.Android.cs
@@ -73,8 +73,12 @@ namespace Microsoft.Maui.Handlers
 		public static void MapTextColor(IEntryHandler handler, IEntry entry) =>
 			handler.PlatformView?.UpdateTextColor(entry);
 
-		public static void MapIsPassword(IEntryHandler handler, IEntry entry) =>
+		public static void MapIsPassword(IEntryHandler handler, IEntry entry)
+		{
+			handler.UpdateValue(nameof(IEntry.Text));
+
 			handler.PlatformView?.UpdateIsPassword(entry);
+		}
 
 		public static void MapHorizontalTextAlignment(IEntryHandler handler, IEntry entry) =>
 			handler.PlatformView?.UpdateHorizontalTextAlignment(entry);
@@ -103,11 +107,19 @@ namespace Microsoft.Maui.Handlers
 		public static void MapFont(IEntryHandler handler, IEntry entry) =>
 			handler.PlatformView?.UpdateFont(entry, handler.GetRequiredService<IFontManager>());
 
-		public static void MapIsReadOnly(IEntryHandler handler, IEntry entry) =>
-			handler.PlatformView?.UpdateIsReadOnly(entry);
+		public static void MapIsReadOnly(IEntryHandler handler, IEntry entry)
+		{
+			handler.UpdateValue(nameof(IEntry.Text));
 
-		public static void MapKeyboard(IEntryHandler handler, IEntry entry) =>
+			handler.PlatformView?.UpdateIsReadOnly(entry);
+		}
+
+		public static void MapKeyboard(IEntryHandler handler, IEntry entry)
+		{
+			handler.UpdateValue(nameof(IEntry.Text));
+
 			handler.PlatformView?.UpdateKeyboard(entry);
+		}
 
 		public static void MapReturnType(IEntryHandler handler, IEntry entry) =>
 			handler.PlatformView?.UpdateReturnType(entry);

--- a/src/Core/src/Handlers/SearchBar/SearchBarHandler.Android.cs
+++ b/src/Core/src/Handlers/SearchBar/SearchBarHandler.Android.cs
@@ -121,6 +121,8 @@ namespace Microsoft.Maui.Handlers
 
 		public static void MapKeyboard(ISearchBarHandler handler, ISearchBar searchBar)
 		{
+			handler.UpdateValue(nameof(IEntry.Text));
+
 			handler.PlatformView?.UpdateKeyboard(searchBar);
 		}
 

--- a/src/Core/src/Handlers/SearchBar/SearchBarHandler.Android.cs
+++ b/src/Core/src/Handlers/SearchBar/SearchBarHandler.Android.cs
@@ -121,7 +121,7 @@ namespace Microsoft.Maui.Handlers
 
 		public static void MapKeyboard(ISearchBarHandler handler, ISearchBar searchBar)
 		{
-			handler.UpdateValue(nameof(IEntry.Text));
+			handler.UpdateValue(nameof(ISearchBar.Text));
 
 			handler.PlatformView?.UpdateKeyboard(searchBar);
 		}

--- a/src/Core/tests/DeviceTests.Shared/HandlerTests/HandlerTestBasementOfT.cs
+++ b/src/Core/tests/DeviceTests.Shared/HandlerTests/HandlerTestBasementOfT.cs
@@ -74,6 +74,26 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
+		protected Task<TValue> GetValueAsync<TValue, TCustomHandler>(IView view, Func<TCustomHandler, TValue> func)
+			where TCustomHandler : IElementHandler, new()
+		{
+			return InvokeOnMainThreadAsync(() =>
+			{
+				var handler = CreateHandler<TCustomHandler>(view);
+				return func(handler);
+			});
+		}
+
+		protected Task<TValue> GetValueAsync<TValue, TCustomHandler>(IView view, Func<TCustomHandler, Task<TValue>> func)
+			where TCustomHandler : IElementHandler, new()
+		{
+			return InvokeOnMainThreadAsync(() =>
+			{
+				var handler = CreateHandler<TCustomHandler>(view);
+				return func(handler);
+			});
+		}
+
 		protected Task SetValueAsync<TValue>(IView view, TValue value, Action<THandler, TValue> func)
 		{
 			return SetValueAsync<TValue, THandler>(view, value, func);
@@ -98,6 +118,26 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.Equal(expectedValue, values.PlatformViewValue);
 		}
 
+		async protected Task ValidatePropertyInitValue<TValue, TCustomHandler>(
+			IView view,
+			Func<TValue> GetValue,
+			Func<TCustomHandler, TValue> GetPlatformValue,
+			TValue expectedValue)
+			where TCustomHandler : IElementHandler, new()
+		{
+			var values = await GetValueAsync(view, (TCustomHandler handler) =>
+			{
+				return new
+				{
+					ViewValue = GetValue(),
+					PlatformViewValue = GetPlatformValue(handler)
+				};
+			});
+
+			Assert.Equal(expectedValue, values.ViewValue);
+			Assert.Equal(expectedValue, values.PlatformViewValue);
+		}
+
 		async protected Task ValidatePropertyInitValue<TValue>(
 			IView view,
 			Func<TValue> GetValue,
@@ -106,6 +146,27 @@ namespace Microsoft.Maui.DeviceTests
 			TValue expectedPlatformValue)
 		{
 			var values = await GetValueAsync(view, (handler) =>
+			{
+				return new
+				{
+					ViewValue = GetValue(),
+					PlatformViewValue = GetPlatformValue(handler)
+				};
+			});
+
+			Assert.Equal(expectedValue, values.ViewValue);
+			Assert.Equal(expectedPlatformValue, values.PlatformViewValue);
+		}
+
+		async protected Task ValidatePropertyInitValue<TValue, TCustomHandler>(
+			IView view,
+			Func<TValue> GetValue,
+			Func<TCustomHandler, TValue> GetPlatformValue,
+			TValue expectedValue,
+			TValue expectedPlatformValue)
+			where TCustomHandler : IElementHandler, new()
+		{
+			var values = await GetValueAsync(view, (TCustomHandler handler) =>
 			{
 				return new
 				{

--- a/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.cs
@@ -21,6 +21,22 @@ namespace Microsoft.Maui.DeviceTests
 			await ValidatePropertyInitValue(editor, () => editor.Text, GetNativeText, editor.Text);
 		}
 
+		[Fact(DisplayName = "Text Initializes Correctly when Keyboard is Before Text")]
+		public async Task TextInitializesCorrectlyWhenKeyboardIsBeforeText()
+		{
+			var editor = new EditorStub()
+			{
+				Text = "Test Text Here"
+			};
+
+			CustomEditorHandler.TestMapper = new PropertyMapper<IEditor, IEditorHandler>
+			{
+				[nameof(IEditor.Keyboard)] = EditorHandler.MapKeyboard
+			};
+
+			await ValidatePropertyInitValue<string, CustomEditorHandler>(editor, () => editor.Text, GetNativeText, editor.Text);
+		}
+
 		[Theory(DisplayName = "Text Updates Correctly")]
 		[InlineData(null, null)]
 		[InlineData(null, "Hello")]
@@ -514,6 +530,19 @@ namespace Microsoft.Maui.DeviceTests
 
 			protected override void UpdateCursorStartPosition(EditorHandler editorHandler, int position) =>
 				EditorHandlerTests.UpdateCursorStartPosition(editorHandler, position);
+		}
+
+		class CustomEditorHandler : EditorHandler
+		{
+			// make a copy of the Core mappers because we don't want any Controls changes or to override us
+			public static PropertyMapper<IEditor, IEditorHandler> TestMapper = new(Mapper);
+			public static CommandMapper<IEditor, IEditorHandler> TestCommandMapper = new(CommandMapper);
+
+			// make sure to use our mappers
+			public CustomEditorHandler()
+				: base(TestMapper, TestCommandMapper)
+			{
+			}
 		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Maui.DeviceTests
 			await ValidatePropertyInitValue(editor, () => editor.Text, GetNativeText, editor.Text);
 		}
 
-		[Fact(DisplayName = "Text Initializes Correctly when Keyboard is Before Text")]
+		[Fact(DisplayName = "Text Property Initializes Correctly when Keyboard Mapper is Executed Before Text Mapper")]
 		public async Task TextInitializesCorrectlyWhenKeyboardIsBeforeText()
 		{
 			var editor = new EditorStub()
@@ -31,6 +31,7 @@ namespace Microsoft.Maui.DeviceTests
 
 			CustomEditorHandler.TestMapper = new PropertyMapper<IEditor, IEditorHandler>(EditorHandler.Mapper)
 			{
+				// this mapper is run first and then the ones in the ctor arg (EditorHandler.Mapper)
 				[nameof(IEditor.Keyboard)] = EditorHandler.MapKeyboard
 			};
 

--- a/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Maui.DeviceTests
 				Text = "Test Text Here"
 			};
 
-			CustomEditorHandler.TestMapper = new PropertyMapper<IEditor, IEditorHandler>
+			CustomEditorHandler.TestMapper = new PropertyMapper<IEditor, IEditorHandler>(EditorHandler.Mapper)
 			{
 				[nameof(IEditor.Keyboard)] = EditorHandler.MapKeyboard
 			};

--- a/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.cs
@@ -23,6 +23,54 @@ namespace Microsoft.Maui.DeviceTests
 			await ValidatePropertyInitValue(entry, () => entry.Text, GetNativeText, entry.Text);
 		}
 
+		[Fact(DisplayName = "Text Initializes Correctly when Keyboard is Before Text")]
+		public async Task TextInitializesCorrectlyWhenKeyboardIsBeforeText()
+		{
+			var entry = new EntryStub()
+			{
+				Text = "Test Text Here"
+			};
+
+			CustomEntryHandler.TestMapper = new PropertyMapper<IEntry, IEntryHandler>
+			{
+				[nameof(IEntry.Keyboard)] = EntryHandler.MapKeyboard
+			};
+
+			await ValidatePropertyInitValue<string, CustomEntryHandler>(entry, () => entry.Text, GetNativeText, entry.Text);
+		}
+
+		[Fact(DisplayName = "Text Initializes Correctly when IsReadOnly is Before Text")]
+		public async Task TextInitializesCorrectlyWhenIsReadOnlyIsBeforeText()
+		{
+			var entry = new EntryStub()
+			{
+				Text = "Test Text Here"
+			};
+
+			CustomEntryHandler.TestMapper = new PropertyMapper<IEntry, IEntryHandler>
+			{
+				[nameof(IEntry.IsReadOnly)] = EntryHandler.MapIsReadOnly
+			};
+
+			await ValidatePropertyInitValue<string, CustomEntryHandler>(entry, () => entry.Text, GetNativeText, entry.Text);
+		}
+
+		[Fact(DisplayName = "Text Initializes Correctly when IsPassword is Before Text")]
+		public async Task TextInitializesCorrectlyWhenIsPasswordIsBeforeText()
+		{
+			var entry = new EntryStub()
+			{
+				Text = "Test Text Here"
+			};
+
+			CustomEntryHandler.TestMapper = new PropertyMapper<IEntry, IEntryHandler>
+			{
+				[nameof(IEntry.IsPassword)] = EntryHandler.MapIsPassword
+			};
+
+			await ValidatePropertyInitValue<string, CustomEntryHandler>(entry, () => entry.Text, GetNativeText, entry.Text);
+		}
+
 		[Fact(DisplayName = "TextColor Initializes Correctly")]
 		public async Task TextColorInitializesCorrectly()
 		{
@@ -733,6 +781,19 @@ namespace Microsoft.Maui.DeviceTests
 
 			protected override void UpdateCursorStartPosition(EntryHandler entryHandler, int position) =>
 				EntryHandlerTests.UpdateCursorStartPosition(entryHandler, position);
+		}
+
+		class CustomEntryHandler : EntryHandler
+		{
+			// make a copy of the Core mappers because we don't want any Controls changes or to override us
+			public static PropertyMapper<IEntry, IEntryHandler> TestMapper = new(Mapper);
+			public static CommandMapper<IEntry, IEntryHandler> TestCommandMapper = new(CommandMapper);
+
+			// make sure to use our mappers
+			public CustomEntryHandler()
+				: base(TestMapper, TestCommandMapper)
+			{
+			}
 		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Maui.DeviceTests
 				Text = "Test Text Here"
 			};
 
-			CustomEntryHandler.TestMapper = new PropertyMapper<IEntry, IEntryHandler>
+			CustomEntryHandler.TestMapper = new PropertyMapper<IEntry, IEntryHandler>(EntryHandler.Mapper)
 			{
 				[nameof(IEntry.Keyboard)] = EntryHandler.MapKeyboard
 			};
@@ -47,7 +47,7 @@ namespace Microsoft.Maui.DeviceTests
 				Text = "Test Text Here"
 			};
 
-			CustomEntryHandler.TestMapper = new PropertyMapper<IEntry, IEntryHandler>
+			CustomEntryHandler.TestMapper = new PropertyMapper<IEntry, IEntryHandler>(EntryHandler.Mapper)
 			{
 				[nameof(IEntry.IsReadOnly)] = EntryHandler.MapIsReadOnly
 			};
@@ -63,7 +63,7 @@ namespace Microsoft.Maui.DeviceTests
 				Text = "Test Text Here"
 			};
 
-			CustomEntryHandler.TestMapper = new PropertyMapper<IEntry, IEntryHandler>
+			CustomEntryHandler.TestMapper = new PropertyMapper<IEntry, IEntryHandler>(EntryHandler.Mapper)
 			{
 				[nameof(IEntry.IsPassword)] = EntryHandler.MapIsPassword
 			};

--- a/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Maui.DeviceTests
 			await ValidatePropertyInitValue(entry, () => entry.Text, GetNativeText, entry.Text);
 		}
 
-		[Fact(DisplayName = "Text Initializes Correctly when Keyboard is Before Text")]
+		[Fact(DisplayName = "Text Property Initializes Correctly when Keyboard Mapper is Executed Before Text Mapper")]
 		public async Task TextInitializesCorrectlyWhenKeyboardIsBeforeText()
 		{
 			var entry = new EntryStub()
@@ -33,13 +33,14 @@ namespace Microsoft.Maui.DeviceTests
 
 			CustomEntryHandler.TestMapper = new PropertyMapper<IEntry, IEntryHandler>(EntryHandler.Mapper)
 			{
+				// this mapper is run first and then the ones in the ctor arg (EntryHandler.Mapper)
 				[nameof(IEntry.Keyboard)] = EntryHandler.MapKeyboard
 			};
 
 			await ValidatePropertyInitValue<string, CustomEntryHandler>(entry, () => entry.Text, GetNativeText, entry.Text);
 		}
 
-		[Fact(DisplayName = "Text Initializes Correctly when IsReadOnly is Before Text")]
+		[Fact(DisplayName = "Text Property Initializes Correctly when IsReadOnly Mapper is Executed Before Text Mapper")]
 		public async Task TextInitializesCorrectlyWhenIsReadOnlyIsBeforeText()
 		{
 			var entry = new EntryStub()
@@ -49,13 +50,14 @@ namespace Microsoft.Maui.DeviceTests
 
 			CustomEntryHandler.TestMapper = new PropertyMapper<IEntry, IEntryHandler>(EntryHandler.Mapper)
 			{
+				// this mapper is run first and then the ones in the ctor arg (EntryHandler.Mapper)
 				[nameof(IEntry.IsReadOnly)] = EntryHandler.MapIsReadOnly
 			};
 
 			await ValidatePropertyInitValue<string, CustomEntryHandler>(entry, () => entry.Text, GetNativeText, entry.Text);
 		}
 
-		[Fact(DisplayName = "Text Initializes Correctly when IsPassword is Before Text")]
+		[Fact(DisplayName = "Text Property Initializes Correctly when IsPassword Mapper is Executed Before Text Mapper")]
 		public async Task TextInitializesCorrectlyWhenIsPasswordIsBeforeText()
 		{
 			var entry = new EntryStub()
@@ -65,6 +67,7 @@ namespace Microsoft.Maui.DeviceTests
 
 			CustomEntryHandler.TestMapper = new PropertyMapper<IEntry, IEntryHandler>(EntryHandler.Mapper)
 			{
+				// this mapper is run first and then the ones in the ctor arg (EntryHandler.Mapper)
 				[nameof(IEntry.IsPassword)] = EntryHandler.MapIsPassword
 			};
 

--- a/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.cs
@@ -41,6 +41,22 @@ namespace Microsoft.Maui.DeviceTests
 			await ValidatePropertyInitValue(searchBar, () => searchBar.Text, GetNativeText, searchBar.Text);
 		}
 
+		[Fact(DisplayName = "Text Initializes Correctly when Keyboard is Before Text")]
+		public async Task TextInitializesCorrectlyWhenKeyboardIsBeforeText()
+		{
+			var searchBar = new SearchBarStub()
+			{
+				Text = "Test Text Here"
+			};
+
+			CustomSearchBarHandler.TestMapper = new PropertyMapper<ISearchBar, ISearchBarHandler>
+			{
+				[nameof(ISearchBar.Keyboard)] = SearchBarHandler.MapKeyboard
+			};
+
+			await ValidatePropertyInitValue<string, CustomSearchBarHandler>(searchBar, () => searchBar.Text, GetNativeText, searchBar.Text);
+		}
+
 		[Theory(DisplayName = "Query Text Updates Correctly")]
 		[InlineData(null, null)]
 		[InlineData(null, "Query")]
@@ -451,5 +467,18 @@ namespace Microsoft.Maui.DeviceTests
 			}
 		}
 #endif
+
+		class CustomSearchBarHandler : SearchBarHandler
+		{
+			// make a copy of the Core mappers because we don't want any Controls changes or to override us
+			public static PropertyMapper<ISearchBar, ISearchBarHandler> TestMapper = new(Mapper);
+			public static CommandMapper<ISearchBar, ISearchBarHandler> TestCommandMapper = new(CommandMapper);
+
+			// make sure to use our mappers
+			public CustomSearchBarHandler()
+				: base(TestMapper, TestCommandMapper)
+			{
+			}
+		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Maui.DeviceTests
 				Text = "Test Text Here"
 			};
 
-			CustomSearchBarHandler.TestMapper = new PropertyMapper<ISearchBar, ISearchBarHandler>
+			CustomSearchBarHandler.TestMapper = new PropertyMapper<ISearchBar, ISearchBarHandler>(SearchBarHandler.Mapper)
 			{
 				[nameof(ISearchBar.Keyboard)] = SearchBarHandler.MapKeyboard
 			};

--- a/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Maui.DeviceTests
 			await ValidatePropertyInitValue(searchBar, () => searchBar.Text, GetNativeText, searchBar.Text);
 		}
 
-		[Fact(DisplayName = "Text Initializes Correctly when Keyboard is Before Text")]
+		[Fact(DisplayName = "Text Property Initializes Correctly when Keyboard Mapper is Executed Before Text Mapper")]
 		public async Task TextInitializesCorrectlyWhenKeyboardIsBeforeText()
 		{
 			var searchBar = new SearchBarStub()
@@ -51,6 +51,7 @@ namespace Microsoft.Maui.DeviceTests
 
 			CustomSearchBarHandler.TestMapper = new PropertyMapper<ISearchBar, ISearchBarHandler>(SearchBarHandler.Mapper)
 			{
+				// this mapper is run first and then the ones in the ctor arg (SearchBarHandler.Mapper)
 				[nameof(ISearchBar.Keyboard)] = SearchBarHandler.MapKeyboard
 			};
 


### PR DESCRIPTION
### Description of Change

It appears that setting `EditText.InputType` will trigger the `TextChanged` event. This could - and does - happen in https://github.com/dotnet/maui/pull/15058 when we no longer chain the mappers forcing the `Text` mapper to always run first.

The reason the order matters for us is that `EditText` is a generic text input control and the default mode is actually multiline. We remove the multiline support for `Entry` and this will always require setting the `InputType`. However, this is really a very short term solution as other things touch that property: `IsPassword`, `Keyboard`, `IsReadOnly` and even spell check things. As a result, we would have to move all those thing to happen _after_ the text is set.

This PR is the correct fix that was in #16077