### PR TITLE
Add VS Feedback and VS Code links to bug report template list

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,11 @@
 blank_issues_enabled: true
 contact_links:
   - name: .NET MAUI Community Support
-    url: https://docs.microsoft.com/answers/topics/dotnet-maui.html
+    url: https://learn.microsoft.com/answers/topics/dotnet-maui.html
     about: Please ask and answer questions here.
   - name: Bug report or feature request for Visual Studio for Windows and Mac
     url: https://learn.microsoft.com/visualstudio/ide/how-to-report-a-problem-with-visual-studio?view=vs-2022
     about: Use Visual Studio's Report a Problem feature for issues and suggestions with Visual Studio tooling
   - name: Bug report or feature request for Visual Studio Code (including C# Dev Kit)
-    url: https://github.com/microsoft/vscode-dotnettools
+    url: https://github.com/microsoft/vscode-dotnettools/issues
     about: Use the microsoft/vscode-dotnettools repo to report issues with Visual Studio Code

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,6 +3,9 @@ contact_links:
   - name: .NET MAUI Community Support
     url: https://docs.microsoft.com/answers/topics/dotnet-maui.html
     about: Please ask and answer questions here.
-  - name: Bug report or feature request for Visual Studio
+  - name: Bug report or feature request for Visual Studio for Windows and Mac
     url: https://learn.microsoft.com/visualstudio/ide/how-to-report-a-problem-with-visual-studio?view=vs-2022
     about: Use Visual Studio's Report a Problem feature for issues and suggestions with Visual Studio tooling
+  - name: Bug report or feature request for Visual Studio Code (including C# Dev Kit)
+    url: https://github.com/microsoft/vscode-dotnettools
+    about: Use the microsoft/vscode-dotnettools repo to report issues with Visual Studio Code

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,3 +3,6 @@ contact_links:
   - name: .NET MAUI Community Support
     url: https://docs.microsoft.com/answers/topics/dotnet-maui.html
     about: Please ask and answer questions here.
+  - name: Bug report or feature request for Visual Studio
+    url: https://learn.microsoft.com/visualstudio/ide/how-to-report-a-problem-with-visual-studio?view=vs-2022
+    about: Use Visual Studio's Report a Problem feature for issues and suggestions with Visual Studio tooling


### PR DESCRIPTION
Maybe this will help direct VS-specific issues to the most appropriate location.

Do we think this might help? Or worth trying it for a while?