### PR TITLE
Revert "Bump Xamarin.UITest from 4.1.4 to 4.2.0"

### DIFF
--- a/src/Compatibility/ControlGallery/test/Android.UITests/Compatibility.ControlGallery.Android.UITests.csproj
+++ b/src/Compatibility/ControlGallery/test/Android.UITests/Compatibility.ControlGallery.Android.UITests.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="Xam.Plugin.DeviceInfo" Version="4.1.1" />
-    <PackageReference Include="Xamarin.UITest" Version="4.2.0" />
+    <PackageReference Include="Xamarin.UITest" Version="4.1.4" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
   </ItemGroup>
 

--- a/src/Compatibility/ControlGallery/test/WinUI.UITests/WinUI.UITests.csproj
+++ b/src/Compatibility/ControlGallery/test/WinUI.UITests/WinUI.UITests.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Selenium.Support" Version="4.1.1" />
     <PackageReference Include="Selenium.WebDriver" Version="4.1.1" />
     <PackageReference Include="Xam.Plugin.DeviceInfo" Version="4.1.1" />
-    <PackageReference Include="Xamarin.UITest" Version="4.2.0" />
+    <PackageReference Include="Xamarin.UITest" Version="4.1.4" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
   </ItemGroup>
 

--- a/src/Compatibility/ControlGallery/test/iOS.UITests/Compatibility.ControlGallery.iOS.UITests.csproj
+++ b/src/Compatibility/ControlGallery/test/iOS.UITests/Compatibility.ControlGallery.iOS.UITests.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="Xam.Plugin.DeviceInfo" Version="4.1.1" />
-    <PackageReference Include="Xamarin.UITest" Version="4.2.0" />
+    <PackageReference Include="Xamarin.UITest" Version="4.1.4" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
   </ItemGroup>
 

--- a/src/Controls/tests/UITests/Controls.AppiumTests.csproj
+++ b/src/Controls/tests/UITests/Controls.AppiumTests.csproj
@@ -37,7 +37,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
-    <PackageReference Include="Xamarin.UITest" Version="4.2.0" />
+    <PackageReference Include="Xamarin.UITest" Version="4.1.4" />
   </ItemGroup>
 
 </Project>

--- a/src/TestUtils/src/TestUtils.Appium.UITests/TestUtils.Appium.UITests.csproj
+++ b/src/TestUtils/src/TestUtils.Appium.UITests/TestUtils.Appium.UITests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Xamarin.UITest" Version="4.2.0" />
+    <PackageReference Include="Xamarin.UITest" Version="4.1.4" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Reverts dotnet/maui#15987

All the iOS UI Tests stopped running. This will revert and get it going so we can catch issues. We can update later and figure out why it stopped the ios runs.