### PR TITLE
Update sourcelink, set deterministic builds in CI

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -159,6 +159,7 @@
     <PackageOutputPath>$(MSBuildThisFileDirectory)artifacts</PackageOutputPath>
     <LicenseFile>$(MSBuildThisFileDirectory)LICENSE.TXT</LicenseFile>
     <PackageThirdPartyNoticesFile>$(MSBuildThisFileDirectory)THIRD-PARTY-NOTICES.TXT</PackageThirdPartyNoticesFile>
+    <ContinuousIntegrationBuild Condition=" '$(CI)' == 'true' ">true</ContinuousIntegrationBuild>
   </PropertyGroup>
   <!-- This target is replaced by GitInfo when restored. Allows Versions.targets to rely on it before restore. -->
   <Target Name="GitVersion" />

--- a/eng/SourceLink.Build.props
+++ b/eng/SourceLink.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <ItemGroup >
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-*" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
While investigating #4299 it seems we are potentially using an old version of sourcelink, and we are not building with the property to set the deterministic build flag on our nupkg's.
