### PR TITLE
[vs-workload][net8.0] Set EnableSideBySideManifests=true

### DIFF
--- a/eng/automation/vs-workload.template.props
+++ b/eng/automation/vs-workload.template.props
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetName>Microsoft.NET.Sdk.Maui.Workload.@VSMAN_VERSION@</TargetName>
     <ManifestBuildVersion>@VS_COMPONENT_VERSION@</ManifestBuildVersion>
+    <EnableSideBySideManifests>true</EnableSideBySideManifests>
   </PropertyGroup>
   <ItemGroup>
     <!-- Shorten package names to avoid long path caching issues in Visual Studio -->


### PR DESCRIPTION
Context: https://github.com/xamarin/yaml-templates/pull/274

Enables side by side workload manifest support when generating workload MSIs.

This should only be enabled for builds shipping with .NET 8 Preview 7 or later.