### PR TITLE
Fix support for VisualDiagnosticsOverlay/IWindowOverlay on Android Shell Apps

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellRenderer.cs
@@ -214,6 +214,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			((IShellController)shell).AddAppearanceObserver(this, shell);
 
 			SwitchFragment(FragmentManager, _frameLayout, shell.CurrentItem, false);
+
+			var rootManager = _mauiContext.GetNavigationRootManager();
+			rootManager?.OnWindowContentPlatformViewCreated();
 		}
 
 		IShellItemRenderer _currentView;

--- a/src/Core/src/Platform/Android/Navigation/NavigationRootManager.cs
+++ b/src/Core/src/Platform/Android/Navigation/NavigationRootManager.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Maui.Platform
 		// this is called after the Window.Content is created by
 		// the fragment. We can't just create views on demand
 		// need to let the fragments fall
-		void OnWindowContentPlatformViewCreated()
+		internal void OnWindowContentPlatformViewCreated()
 		{
 			RootViewChanged?.Invoke(this, EventArgs.Empty);
 


### PR DESCRIPTION
![image](https://github.com/dotnet/maui/assets/898335/e40c2aab-3616-4b9c-81ad-2923db191ddb)

With MAUI Shell Apps on Android, WindowOverlay and VisualDiagnosticOverlay don't work. If you try to hover over the live visual tree in Visual Studio, the elements that should be highlighted are not. If you try and add your own WindowOverlay to an existing window (Which you can do but is not documented anywhere, but trust me when I say that it is!) it does not appear.

This, I believe, is do to the way Shell and Non-Shell apps handle the initial Window startup.

https://github.com/dotnet/maui/blob/43b9397bf3b58e75f1ae4e0dc68014f060de2457/src/Core/src/Platform/Android/Navigation/NavigationRootManager.cs#L123-L152

When setting the initial NavigationRootManager for Android, the delegate `OnWindowContentPlatformViewCreated` gets called  when the initial Fragment for the application gets made. This gets called back into the Window Handler code, which invokes the VisualDiagnosticOverlay handler initialization, allowing Window Overlay code to work. For Shell apps though, this code doesn't get fired, the view in SetContent is null.

This is called out in the comment above,
https://github.com/dotnet/maui/blob/43b9397bf3b58e75f1ae4e0dc68014f060de2457/src/Core/src/Platform/Android/Navigation/NavigationRootManager.cs#L79-L84

Shell apps handle their fragments through other means. Still, because of this, the RootViewChanged logic in the Window Handler never gets called, meaning the VisualDiagnosticsOverlay code never gets run, meaning overlays won't work. The overlay logic has to be run after the initial views are laid out to be placed on top of the existing views., so there needs to be similar logic in place for shell apps.

I tried putting it inside of the ShellRenderer, after its logic is run and the fragments are switched, that means the views should have been loaded and should be safe for us to call the VisualDiagnosticOverlay logic on the Window to get it to run.

I'm not sure if this is the right thing to do here, but hopefully, this shows the issue at hand for why it's happening.  

Fixes https://github.com/dotnet/maui/issues/10781