### PR TITLE
[WIN] Add Switch.ShowStatusLabel Platform-Specific

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Controls/SwitchPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/SwitchPage.xaml
@@ -3,6 +3,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     x:Class="Maui.Controls.Sample.Pages.SwitchPage"
     xmlns:views="clr-namespace:Maui.Controls.Sample.Pages.Base"
+    xmlns:windows="clr-namespace:Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific;assembly=Microsoft.Maui.Controls"
     Title="Switch">
     <views:BasePage.Content>
         <VerticalStackLayout
@@ -44,6 +45,21 @@
                 Style="{StaticResource Headline}"/>
             <Switch
                 ThumbColor="Orange"/>
+            <Label
+                IsVisible="{OnPlatform False, WinUI=True}"
+                Text="Show Status Label (Windows)"
+                Style="{StaticResource Headline}"/>
+            <Switch
+                x:Name="statusLabelSwitch"
+                IsVisible="{OnPlatform False, WinUI=True}"
+                windows:Switch.ShowStatusLabel="False"/>
+            <HorizontalStackLayout IsVisible="{OnPlatform False, WinUI=True}">
+            <Switch                
+                Toggled="Switch_Toggled"/>
+            <Label
+                Text="Toggle Above Status Label"
+                VerticalOptions="Center" />
+            </HorizontalStackLayout>
         </VerticalStackLayout>
     </views:BasePage.Content>
 </views:BasePage>

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/SwitchPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/SwitchPage.xaml.cs
@@ -1,10 +1,17 @@
-﻿namespace Maui.Controls.Sample.Pages
+﻿using Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific;
+
+namespace Maui.Controls.Sample.Pages
 {
 	public partial class SwitchPage
 	{
 		public SwitchPage()
 		{
 			InitializeComponent();
+		}
+
+		private void Switch_Toggled(object sender, Microsoft.Maui.Controls.ToggledEventArgs e)
+		{
+			statusLabelSwitch.On<Microsoft.Maui.Controls.PlatformConfiguration.Windows>().SetShowStatusLabel(e.Value);
 		}
 	}
 }

--- a/src/Controls/src/Core/Platform/Windows/Extensions/SwitchExtensions.cs
+++ b/src/Controls/src/Core/Platform/Windows/Extensions/SwitchExtensions.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.UI.Xaml.Controls;
+
+namespace Microsoft.Maui.Controls.Platform
+{
+	public static class SwitchExtensions
+	{
+		static object? OnContent;
+		static object? OffContent;
+
+		public static void UpdateShowStatusLabel(this ToggleSwitch platformView, Switch switchControl,
+			bool shouldShow)
+		{
+			// Save the platform default objects so we can restore it later
+			if (OnContent is null && platformView.OnContent is not null)
+			{
+				OnContent = platformView.OnContent;
+			}
+
+			if (OffContent is null && platformView.OffContent is not null)
+			{
+				OffContent = platformView.OffContent;
+			}
+
+			if (shouldShow)
+			{
+				platformView.OnContent = OnContent;
+				platformView.OffContent = OffContent;
+
+				return;
+			}
+
+			platformView.OnContent = platformView.OffContent = null;
+		}
+	}
+}

--- a/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/Switch.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/Switch.cs
@@ -3,13 +3,13 @@
 namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 {
 	using Microsoft.Maui.Graphics;
-	using FormsElement = Maui.Controls.Switch;
+	using MauiElement = Maui.Controls.Switch;
 
 	/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Switch.xml" path="Type[@FullName='Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific.Switch']/Docs/*" />
 	public static class Switch
 	{
 		/// <summary>Bindable property for <see cref="Color"/>.</summary>
-		public static readonly BindableProperty ColorProperty = BindableProperty.Create(nameof(Color), typeof(Color), typeof(FormsElement), null);
+		public static readonly BindableProperty ColorProperty = BindableProperty.Create(nameof(Color), typeof(Color), typeof(MauiElement), null);
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Switch.xml" path="//Member[@MemberName='GetColor'][1]/Docs/*" />
 		public static Color GetColor(BindableObject element)
@@ -24,13 +24,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 		}
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Switch.xml" path="//Member[@MemberName='GetColor'][2]/Docs/*" />
-		public static Color GetColor(this IPlatformElementConfiguration<Tizen, FormsElement> config)
+		public static Color GetColor(this IPlatformElementConfiguration<Tizen, MauiElement> config)
 		{
 			return GetColor(config.Element);
 		}
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Switch.xml" path="//Member[@MemberName='SetColor'][2]/Docs/*" />
-		public static IPlatformElementConfiguration<Tizen, FormsElement> SetColor(this IPlatformElementConfiguration<Tizen, FormsElement> config, Color color)
+		public static IPlatformElementConfiguration<Tizen, MauiElement> SetColor(this IPlatformElementConfiguration<Tizen, MauiElement> config, Color color)
 		{
 			SetColor(config.Element, color);
 			return config;

--- a/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/Switch.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/Switch.cs
@@ -1,0 +1,34 @@
+﻿namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
+{
+	using MauiElement = Controls.Switch;
+#pragma warning disable RS0016 // Add public types and members to the declared API
+
+	public static class Switch
+	{
+		/// <summary>Bindable property for <c>ShowStatusLabel</c>.</summary>
+		public static readonly BindableProperty ShowStatusLabelProperty = BindableProperty.Create("ShowStatusLabel", typeof(bool), typeof(MauiElement), true);
+
+		public static bool GetShowStatusLabel(BindableObject element)
+		{
+			return (bool)element.GetValue(ShowStatusLabelProperty);
+		}
+
+		public static void SetShowStatusLabel(BindableObject element, bool showLabel)
+		{
+			element.SetValue(ShowStatusLabelProperty, showLabel);
+		}
+
+		public static bool GetShowStatusLabel(this IPlatformElementConfiguration<Windows, MauiElement> config)
+		{
+			return GetShowStatusLabel(config.Element);
+		}
+
+		public static IPlatformElementConfiguration<Windows, MauiElement> SetShowStatusLabel(this IPlatformElementConfiguration<Windows, MauiElement> config, bool showLabel)
+		{
+			SetShowStatusLabel(config.Element, showLabel);
+			return config;
+		}
+#pragma warning restore RS0016 // Add public types and members to the declared API
+
+	}
+}

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -1,6 +1,7 @@
 #nullable enable
 *REMOVED*~Microsoft.Maui.Controls.Accelerator.Modifiers.set -> void
 *REMOVED*~Microsoft.Maui.Controls.Accelerator.Keys.set -> void
+static Microsoft.Maui.Controls.Switch.ControlsSwitchMapper -> Microsoft.Maui.IPropertyMapper<Microsoft.Maui.ISwitch!, Microsoft.Maui.Handlers.SwitchHandler!>!
 ~Microsoft.Maui.Controls.Accelerator.Key.get -> string
 *REMOVED*override Microsoft.Maui.Controls.RefreshView.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 Microsoft.Maui.Controls.Border.~Border() -> void

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -1,6 +1,7 @@
 #nullable enable
 *REMOVED*~Microsoft.Maui.Controls.Accelerator.Modifiers.set -> void
 *REMOVED*~Microsoft.Maui.Controls.Accelerator.Keys.set -> void
+static Microsoft.Maui.Controls.Switch.ControlsSwitchMapper -> Microsoft.Maui.IPropertyMapper<Microsoft.Maui.ISwitch!, Microsoft.Maui.Handlers.SwitchHandler!>!
 ~Microsoft.Maui.Controls.Accelerator.Key.get -> string
 *REMOVED*override Microsoft.Maui.Controls.RefreshView.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 Microsoft.Maui.Controls.Border.~Border() -> void

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,6 +1,7 @@
 #nullable enable
 *REMOVED*~Microsoft.Maui.Controls.Accelerator.Modifiers.set -> void
 *REMOVED*~Microsoft.Maui.Controls.Accelerator.Keys.set -> void
+static Microsoft.Maui.Controls.Switch.ControlsSwitchMapper -> Microsoft.Maui.IPropertyMapper<Microsoft.Maui.ISwitch!, Microsoft.Maui.Handlers.SwitchHandler!>!
 ~Microsoft.Maui.Controls.Accelerator.Key.get -> string
 *REMOVED*override Microsoft.Maui.Controls.RefreshView.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 Microsoft.Maui.Controls.Border.~Border() -> void

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -1,6 +1,7 @@
 #nullable enable
 *REMOVED*~Microsoft.Maui.Controls.Accelerator.Modifiers.set -> void
 *REMOVED*~Microsoft.Maui.Controls.Accelerator.Keys.set -> void
+static Microsoft.Maui.Controls.Switch.ControlsSwitchMapper -> Microsoft.Maui.IPropertyMapper<Microsoft.Maui.ISwitch!, Microsoft.Maui.Handlers.SwitchHandler!>!
 ~Microsoft.Maui.Controls.Accelerator.Key.get -> string
 Microsoft.Maui.Controls.Border.~Border() -> void
 Microsoft.Maui.Controls.IWindowCreator

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -1,6 +1,11 @@
 #nullable enable
 *REMOVED*~Microsoft.Maui.Controls.Accelerator.Modifiers.set -> void
 *REMOVED*~Microsoft.Maui.Controls.Accelerator.Keys.set -> void
+Microsoft.Maui.Controls.Platform.SwitchExtensions
+static Microsoft.Maui.Controls.Platform.SwitchExtensions.UpdateShowStatusLabel(this Microsoft.UI.Xaml.Controls.ToggleSwitch! platformView, Microsoft.Maui.Controls.Switch! switchControl, bool shouldShow) -> void
+static Microsoft.Maui.Controls.Switch.ControlsSwitchMapper -> Microsoft.Maui.IPropertyMapper<Microsoft.Maui.ISwitch!, Microsoft.Maui.Handlers.SwitchHandler!>!
+static Microsoft.Maui.Controls.Switch.MapShowStatusLabel(Microsoft.Maui.Handlers.ISwitchHandler! handler, Microsoft.Maui.Controls.Switch! switchControl) -> void
+static Microsoft.Maui.Controls.Switch.MapShowStatusLabel(Microsoft.Maui.Handlers.SwitchHandler! handler, Microsoft.Maui.Controls.Switch! switchControl) -> void
 ~Microsoft.Maui.Controls.Accelerator.Key.get -> string
 *REMOVED*override Microsoft.Maui.Controls.RefreshView.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 Microsoft.Maui.Controls.Border.~Border() -> void

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -1,6 +1,7 @@
 #nullable enable
 *REMOVED*~Microsoft.Maui.Controls.Accelerator.Modifiers.set -> void
 *REMOVED*~Microsoft.Maui.Controls.Accelerator.Keys.set -> void
+static Microsoft.Maui.Controls.Switch.ControlsSwitchMapper -> Microsoft.Maui.IPropertyMapper<Microsoft.Maui.ISwitch!, Microsoft.Maui.Handlers.SwitchHandler!>!
 ~Microsoft.Maui.Controls.Accelerator.Key.get -> string
 *REMOVED*override Microsoft.Maui.Controls.RefreshView.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 Microsoft.Maui.Controls.Border.~Border() -> void

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -1,6 +1,7 @@
 #nullable enable
 *REMOVED*~Microsoft.Maui.Controls.Accelerator.Modifiers.set -> void
 *REMOVED*~Microsoft.Maui.Controls.Accelerator.Keys.set -> void
+static Microsoft.Maui.Controls.Switch.ControlsSwitchMapper -> Microsoft.Maui.IPropertyMapper<Microsoft.Maui.ISwitch!, Microsoft.Maui.Handlers.SwitchHandler!>!
 ~Microsoft.Maui.Controls.Accelerator.Key.get -> string
 *REMOVED*override Microsoft.Maui.Controls.RefreshView.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 Microsoft.Maui.Controls.Border.~Border() -> void

--- a/src/Controls/src/Core/Switch/Switch.Mapper.cs
+++ b/src/Controls/src/Core/Switch/Switch.Mapper.cs
@@ -1,0 +1,18 @@
+﻿namespace Microsoft.Maui.Controls
+{
+	public partial class Switch
+	{
+		public static IPropertyMapper<ISwitch, SwitchHandler> ControlsSwitchMapper = new PropertyMapper<Switch, SwitchHandler>(SwitchHandler.Mapper)
+		{
+#if WINDOWS
+			[PlatformConfiguration.WindowsSpecific.Switch.ShowStatusLabelProperty.PropertyName] = MapShowStatusLabel,
+#endif
+		};
+
+		internal static new void RemapForControls()
+		{
+			// Enable platform-specifics
+			SwitchHandler.Mapper = ControlsSwitchMapper;
+		}
+	}
+}

--- a/src/Controls/src/Core/Switch/Switch.Windows.cs
+++ b/src/Controls/src/Core/Switch/Switch.Windows.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific;
+
+namespace Microsoft.Maui.Controls
+{
+	public partial class Switch
+	{
+		public static void MapShowStatusLabel(ISwitchHandler handler, Switch switchControl)
+		{
+			Platform.SwitchExtensions.UpdateShowStatusLabel(handler.PlatformView, switchControl,
+				switchControl.On<PlatformConfiguration.Windows>().GetShowStatusLabel());
+		}
+
+		public static void MapShowStatusLabel(SwitchHandler handler, Switch switchControl) =>
+			MapShowStatusLabel((ISwitchHandler)handler, switchControl);
+	}
+}

--- a/src/Controls/src/Xaml/Hosting/AppHostBuilderExtensions.cs
+++ b/src/Controls/src/Xaml/Hosting/AppHostBuilderExtensions.cs
@@ -238,6 +238,7 @@ namespace Microsoft.Maui.Controls.Hosting
 			ScrollView.RemapForControls();
 			RefreshView.RemapForControls();
 			Shape.RemapForControls();
+			Switch.RemapForControls();
 			WebView.RemapForControls();
 
 			return builder;


### PR DESCRIPTION
### Description of Change

This adds a platform-specific for Windows that allows to show/hide the On/Off label on the Windows Switch control.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #6177
