### PR TITLE
[tests] fix DeviceTests on Windows, maybe other platforms?

### DIFF
--- a/src/Controls/src/Core/Platform/AlertManager/AlertManager.Android.cs
+++ b/src/Controls/src/Core/Platform/AlertManager/AlertManager.Android.cs
@@ -39,9 +39,11 @@ namespace Microsoft.Maui.Controls.Platform
 
 		internal void Unsubscribe(Window window)
 		{
-			IMauiContext mauiContext = window?.MauiContext;
+			IMauiContext mauiContext = window?.Handler?.MauiContext;
 			Context context = mauiContext?.Context;
-			Activity activity = context.GetActivity();
+			Activity activity = context?.GetActivity();
+			if (activity == null)
+				return;
 
 			var toRemove = Subscriptions.Where(s => s.Activity == activity).ToList();
 

--- a/src/Controls/src/Core/Platform/AlertManager/AlertManager.Tizen.cs
+++ b/src/Controls/src/Core/Platform/AlertManager/AlertManager.Tizen.cs
@@ -26,9 +26,12 @@ namespace Microsoft.Maui.Controls.Platform
 
 		internal void Unsubscribe(Window window)
 		{
-			var nativeWindow = window?.MauiContext.GetPlatformWindow();
+			IMauiContext mauiContext = window?.Handler?.MauiContext;
+			var platformWindow = mauiContext?.GetPlatformWindow();
+			if (platformWindow == null)
+				return;
 
-			var toRemove = Subscriptions.Where(s => s.Window == nativeWindow).ToList();
+			var toRemove = Subscriptions.Where(s => s.Window == platformWindow).ToList();
 
 			foreach (AlertRequestHelper alertRequestHelper in toRemove)
 			{

--- a/src/Controls/src/Core/Platform/AlertManager/AlertManager.Windows.cs
+++ b/src/Controls/src/Core/Platform/AlertManager/AlertManager.Windows.cs
@@ -24,7 +24,10 @@ namespace Microsoft.Maui.Controls.Platform
 
 		internal void Unsubscribe(Window window)
 		{
-			var platformWindow = window.MauiContext.GetPlatformWindow();
+			IMauiContext? mauiContext = window?.Handler?.MauiContext;
+			var platformWindow = mauiContext?.GetPlatformWindow();
+			if (platformWindow == null)
+				return;
 
 			var toRemove = Subscriptions.Where(s => s.PlatformView == platformWindow).ToList();
 

--- a/src/Controls/src/Core/Platform/AlertManager/AlertManager.iOS.cs
+++ b/src/Controls/src/Core/Platform/AlertManager/AlertManager.iOS.cs
@@ -28,7 +28,10 @@ namespace Microsoft.Maui.Controls.Platform
 
 		internal void Unsubscribe(Window window)
 		{
-			var platformWindow = window?.MauiContext.GetPlatformWindow();
+			IMauiContext mauiContext = window?.Handler?.MauiContext;
+			var platformWindow = mauiContext?.GetPlatformWindow();
+			if (platformWindow == null)
+				return;
 
 			var toRemove = Subscriptions.Where(s => s.PlatformView == platformWindow).ToList();
 


### PR DESCRIPTION
Since ac16ce63 was merged, I found several tests related to `Window` fail on Windows with:

    InvalidOperationException: MauiContext is null.

In this case, `AlertManager.Unsubscribe()` is called after `Window.Handler` is null:

    internal IMauiContext MauiContext =>
        Handler?.MauiContext ?? throw new InvalidOperationException("MauiContext is null.");

I updated `AlertManager.Unsubscribe()` on each platform to check for this case and `return` instead of throwing an exception.

I am not sure if regular apps could ever hit this issue or just the DeviceTests. .NET MAUI project templates seemed OK, so I think this might be due to how `CreateHandlerAndAddToWindow()` works in tests?
