### PR TITLE
Stop DispatcherTimer after Tick fires if IsRepeating is false

### DIFF
--- a/src/Core/src/Dispatching/Dispatcher.Android.cs
+++ b/src/Core/src/Dispatching/Dispatcher.Android.cs
@@ -87,6 +87,8 @@ namespace Microsoft.Maui.Dispatching
 
 			if (IsRepeating)
 				_handler.PostDelayed(OnTimerTick, (long)Interval.TotalMilliseconds);
+			else
+				Stop();
 		}
 	}
 

--- a/src/Core/src/Dispatching/Dispatcher.iOS.cs
+++ b/src/Core/src/Dispatching/Dispatcher.iOS.cs
@@ -91,8 +91,17 @@ namespace Microsoft.Maui.Dispatching
 
 			Tick?.Invoke(this, EventArgs.Empty);
 
-			if (IsRepeating && _dispatchBlock is not null)
-				_dispatchQueue.DispatchAfter(new DispatchTime(DispatchTime.Now, Interval), _dispatchBlock);
+			if (IsRepeating)
+			{
+				if (_dispatchBlock is not null)
+				{
+					_dispatchQueue.DispatchAfter(new DispatchTime(DispatchTime.Now, Interval), _dispatchBlock);
+				}
+			}
+			else
+			{
+				Stop();
+			}
 		}
 	}
 

--- a/src/Core/tests/DeviceTests/Services/Dispatching/DispatcherTests.cs
+++ b/src/Core/tests/DeviceTests/Services/Dispatching/DispatcherTests.cs
@@ -211,6 +211,28 @@ namespace Microsoft.Maui.DeviceTests
 				Assert.True(ticks > 1, $"# of Ticks: {ticks}, expected > 1");
 			});
 
+		[Fact]
+		public async Task NonRepeatingTimerIsStoppedAfterFiring()
+		{
+			await InvokeOnMainThreadAsync(async () =>
+			{
+				var dispatcher = Dispatcher.GetForCurrentThread();
+				var timer = dispatcher.CreateTimer();
+				using var disposer = new TimerDisposer(timer);
+				
+				Assert.False(timer.IsRunning);
+				
+				timer.Interval = TimeSpan.FromMilliseconds(200);
+				timer.IsRepeating = false;
+				
+				timer.Tick += (_, _) => { };
+				timer.Start();
+
+				await Task.Delay(TimeSpan.FromSeconds(1));
+				Assert.False(timer.IsRunning, "The timer is not repeating, so it should no longer be marked as running after the first tick.");
+			});
+		}
+
 		class TimerDisposer : IDisposable
 		{
 			IDispatcherTimer _timer;


### PR DESCRIPTION
### Description of Change

The Android and iOS DispatcherTimers stop firing after the first interval if `IsRepeating` is `false`, but they don't update the value of `IsRunning`.

These changes fix the problem on both platforms. 

### Issues Fixed

Fixes #16171
