### PR TITLE
[iOS] Add updates for LineHeight, TextDecorations, CharacterSpacing

### DIFF
--- a/src/Controls/src/Core/Label/Label.iOS.cs
+++ b/src/Controls/src/Core/Label/Label.iOS.cs
@@ -95,6 +95,7 @@ namespace Microsoft.Maui.Controls
 		{
 			handler.UpdateValue(nameof(ILabel.TextColor));
 			handler.UpdateValue(nameof(ILabel.Font));
+			LabelHandler.MapFormatting(handler, label);
 		}
 
 		static bool IsDefaultFont(Label label)

--- a/src/Controls/src/Core/Label/Label.iOS.cs
+++ b/src/Controls/src/Core/Label/Label.iOS.cs
@@ -95,6 +95,10 @@ namespace Microsoft.Maui.Controls
 		{
 			handler.UpdateValue(nameof(ILabel.TextColor));
 			handler.UpdateValue(nameof(ILabel.Font));
+
+			if (!IsPlainText(label))
+				return;
+
 			LabelHandler.MapFormatting(handler, label);
 		}
 

--- a/src/Controls/tests/DeviceTests/Elements/Label/LabelTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Label/LabelTests.iOS.cs
@@ -45,20 +45,17 @@ namespace Microsoft.Maui.DeviceTests
 		[Fact(DisplayName = "Using CharacterSpacing with LineHeight and TextDecorations works Correctly")]
 		public async Task CharacterSpacingWithLineHeightWithTextDecorationsWorksCorrectly()
 		{
-			var expectedCharacterSpacing1 = 5;
+			var expectedCharacterSpacing1 = 5d;
+			var expectedCharacterSpacing2 = 5d;
+			var expectedCharacterSpacing3 = 0d;
+			var expectedCharacterSpacing4 = 0d;
 			var expectedLineHeight1 = 1.5d;
-			var expectedTextDecorations1 = TextDecorations.Underline;
-
-			var expectedCharacterSpacing2 = 5;
 			var expectedLineHeight2 = 1.5d;
+			var expectedLineHeight3 = 0d;
+			var expectedLineHeight4 = 0d;
+			var expectedTextDecorations1 = TextDecorations.Underline;
 			var expectedTextDecorations2 = TextDecorations.Strikethrough;
-
-			var expectedCharacterSpacing3 = 0;
-			var expectedLineHeight3 = 0;
 			var expectedTextDecorations3 = TextDecorations.None;
-
-			var expectedCharacterSpacing4 = 0;
-			var expectedLineHeight4 = 0;
 			var expectedTextDecorations4 = TextDecorations.None;
 
 			var label1 = new Label()
@@ -79,13 +76,16 @@ namespace Microsoft.Maui.DeviceTests
 
 			var label3 = new Label()
 			{
-				FormattedText = new FormattedString()
+				FormattedText = new FormattedString(),
+				CharacterSpacing = 5d,
+				LineHeight = 1.5d,
+				TextDecorations = TextDecorations.Underline
 			};
 			label3.FormattedText.AddLogicalChild(
 				new Span()
 				{
 					Text = "This is label tests.",
-					CharacterSpacing = 5,
+					CharacterSpacing = 5d,
 					LineHeight = 1.5d,
 					TextDecorations = TextDecorations.Underline
 				}
@@ -94,7 +94,10 @@ namespace Microsoft.Maui.DeviceTests
 			var label4 = new Label()
 			{
 				TextType = TextType.Html,
-				Text = "This is <strong style=\"color:red\">label</strong> tests."
+				Text = "<h1>This is label tests.</h1>",
+				CharacterSpacing = 5d,
+				LineHeight = 1.5d,
+				TextDecorations = TextDecorations.Underline
 			};
 
 			var handler1 = await CreateHandlerAsync<LabelHandler>(label1);

--- a/src/Controls/tests/DeviceTests/Elements/Label/LabelTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Label/LabelTests.iOS.cs
@@ -42,36 +42,22 @@ namespace Microsoft.Maui.DeviceTests
 			return textDecorations;
 		}
 
-		[Fact(DisplayName = "Using CharacterSpacing with LineHeight and TextDecorations works Correctly")]
-		public async Task CharacterSpacingWithLineHeightWithTextDecorationsWorksCorrectly()
+		public static IEnumerable<object[]> GetCharacterSpacingWithLineHeightWithTextDecorationsWorksTestData()
 		{
-			var expectedCharacterSpacing1 = 5d;
-			var expectedCharacterSpacing2 = 5d;
-			var expectedCharacterSpacing3 = 0d;
-			var expectedCharacterSpacing4 = 0d;
-			var expectedLineHeight1 = 1.5d;
-			var expectedLineHeight2 = 1.5d;
-			var expectedLineHeight3 = 0d;
-			var expectedLineHeight4 = 0d;
-			var expectedTextDecorations1 = TextDecorations.Underline;
-			var expectedTextDecorations2 = TextDecorations.Strikethrough;
-			var expectedTextDecorations3 = TextDecorations.None;
-			var expectedTextDecorations4 = TextDecorations.None;
-
 			var label1 = new Label()
 			{
 				Text = "This is label tests.",
-				CharacterSpacing = expectedCharacterSpacing1,
-				LineHeight = expectedLineHeight1,
-				TextDecorations = expectedTextDecorations1
+				CharacterSpacing = 5d,
+				LineHeight = 1.5d,
+				TextDecorations = TextDecorations.Underline
 			};
 
 			var label2 = new Label()
 			{
 				Text = "This is label tests.",
-				CharacterSpacing = expectedCharacterSpacing2,
-				LineHeight = expectedLineHeight2,
-				TextDecorations = expectedTextDecorations2
+				CharacterSpacing = 5d,
+				LineHeight = 1.5d,
+				TextDecorations = TextDecorations.Strikethrough
 			};
 
 			var label3 = new Label()
@@ -81,7 +67,7 @@ namespace Microsoft.Maui.DeviceTests
 				LineHeight = 1.5d,
 				TextDecorations = TextDecorations.Underline
 			};
-			label3.FormattedText.AddLogicalChild(
+			label3.AddLogicalChild(
 				new Span()
 				{
 					Text = "This is label tests.",
@@ -100,37 +86,26 @@ namespace Microsoft.Maui.DeviceTests
 				TextDecorations = TextDecorations.Underline
 			};
 
-			var handler1 = await CreateHandlerAsync<LabelHandler>(label1);
-			var actualCharacterSpacing1 = await InvokeOnMainThreadAsync(() => GetPlatformCharacterSpacing(handler1));
-			Assert.Equal(expectedCharacterSpacing1, actualCharacterSpacing1);
-			var actualLineHeight1 = await InvokeOnMainThreadAsync(() => GetPlatformLineHeight(handler1));
-			Assert.Equal(expectedLineHeight1, actualLineHeight1);
-			var actualTextDecorations1 = await InvokeOnMainThreadAsync(() => GetPlatformTextDecorations(handler1));
-			Assert.Equal(expectedTextDecorations1, actualTextDecorations1);
+			return new List<object[]>()
+			{
+				new object[] { label1, 5d, 1.5d, TextDecorations.Underline },
+				new object[] { label2, 5d, 1.5d, TextDecorations.Strikethrough },
+				new object[] { label3, 0d, 0d, TextDecorations.None },
+				new object[] { label4, 0d, 0d, TextDecorations.None }
+			};
+		}
 
-			var handler2 = await CreateHandlerAsync<LabelHandler>(label2);
-			var actualCharacterSpacing2 = await InvokeOnMainThreadAsync(() => GetPlatformCharacterSpacing(handler2));
-			Assert.Equal(expectedCharacterSpacing2, actualCharacterSpacing2);
-			var actualLineHeight2 = await InvokeOnMainThreadAsync(() => GetPlatformLineHeight(handler2));
-			Assert.Equal(expectedLineHeight2, actualLineHeight2);
-			var actualTextDecorations2 = await InvokeOnMainThreadAsync(() => GetPlatformTextDecorations(handler2));
-			Assert.Equal(expectedTextDecorations2, actualTextDecorations2);
-
-			var handler3 = await CreateHandlerAsync<LabelHandler>(label3);
-			var actualCharacterSpacing3 = await InvokeOnMainThreadAsync(() => GetPlatformCharacterSpacing(handler3));
-			Assert.Equal(expectedCharacterSpacing3, actualCharacterSpacing3);
-			var actualLineHeight3 = await InvokeOnMainThreadAsync(() => GetPlatformLineHeight(handler3));
-			Assert.Equal(expectedLineHeight3, actualLineHeight3);
-			var actualTextDecorations3 = await InvokeOnMainThreadAsync(() => GetPlatformTextDecorations(handler3));
-			Assert.Equal(expectedTextDecorations3, actualTextDecorations3);
-
-			var handler4 = await CreateHandlerAsync<LabelHandler>(label4);
-			var actualCharacterSpacing4 = await InvokeOnMainThreadAsync(() => GetPlatformCharacterSpacing(handler4));
-			Assert.Equal(expectedCharacterSpacing4, actualCharacterSpacing4);
-			var actualLineHeight4 = await InvokeOnMainThreadAsync(() => GetPlatformLineHeight(handler4));
-			Assert.Equal(expectedLineHeight4, actualLineHeight4);
-			var actualTextDecorations4 = await InvokeOnMainThreadAsync(() => GetPlatformTextDecorations(handler4));
-			Assert.Equal(expectedTextDecorations4, actualTextDecorations4);
+		[Theory(DisplayName = "Using CharacterSpacing with LineHeight and TextDecorations works Correctly")]
+		[MemberData(nameof(GetCharacterSpacingWithLineHeightWithTextDecorationsWorksTestData))]
+		public async Task CharacterSpacingWithLineHeightWithTextDecorationsWorksCorrectly(Label label, double expectedCharacterSpacing, double expectedLineHeight, TextDecorations expectedTextDecorations)
+		{
+			var handler = await CreateHandlerAsync<LabelHandler>(label);
+			var actualCharacterSpacing = await InvokeOnMainThreadAsync(() => GetPlatformCharacterSpacing(handler));
+			Assert.Equal(expectedCharacterSpacing, actualCharacterSpacing);
+			var actualLineHeight = await InvokeOnMainThreadAsync(() => GetPlatformLineHeight(handler));
+			Assert.Equal(expectedLineHeight, actualLineHeight);
+			var actualTextDecorations = await InvokeOnMainThreadAsync(() => GetPlatformTextDecorations(handler));
+			Assert.Equal(expectedTextDecorations, actualTextDecorations);
 		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Label/LabelTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Label/LabelTests.iOS.cs
@@ -3,8 +3,10 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
 using Microsoft.Maui.Handlers;
 using UIKit;
+using Xunit;
 
 namespace Microsoft.Maui.DeviceTests
 {
@@ -18,5 +20,114 @@ namespace Microsoft.Maui.DeviceTests
 
 		int GetPlatformMaxLines(LabelHandler labelHandler) =>
  			(int)GetPlatformLabel(labelHandler).Lines;
+
+		double GetPlatformCharacterSpacing(LabelHandler labelHandler)
+		{
+			var attributedText = GetPlatformLabel(labelHandler).AttributedText;
+			var characterSpacing = attributedText.GetCharacterSpacing();
+			return characterSpacing;
+		}
+
+		double GetPlatformLineHeight(LabelHandler labelHandler)
+		{
+			var attributedText = GetPlatformLabel(labelHandler).AttributedText;
+			var lineHeight = attributedText.GetLineHeight();
+			return lineHeight;
+		}
+
+		TextDecorations GetPlatformTextDecorations(LabelHandler labelHandler)
+		{
+			var attributedText = GetPlatformLabel(labelHandler).AttributedText;
+			var textDecorations = attributedText.GetTextDecorations();
+			return textDecorations;
+		}
+
+		[Fact(DisplayName = "Using CharacterSpacing with LineHeight and TextDecorations works Correctly")]
+		public async Task CharacterSpacingWithLineHeightWithTextDecorationsWorksCorrectly()
+		{
+			var expectedCharacterSpacing1 = 5;
+			var expectedLineHeight1 = 1.5d;
+			var expectedTextDecorations1 = TextDecorations.Underline;
+
+			var expectedCharacterSpacing2 = 5;
+			var expectedLineHeight2 = 1.5d;
+			var expectedTextDecorations2 = TextDecorations.Strikethrough;
+
+			var expectedCharacterSpacing3 = 0;
+			var expectedLineHeight3 = 0;
+			var expectedTextDecorations3 = TextDecorations.None;
+
+			var expectedCharacterSpacing4 = 0;
+			var expectedLineHeight4 = 0;
+			var expectedTextDecorations4 = TextDecorations.None;
+
+			var label1 = new Label()
+			{
+				Text = "This is label tests.",
+				CharacterSpacing = expectedCharacterSpacing1,
+				LineHeight = expectedLineHeight1,
+				TextDecorations = expectedTextDecorations1
+			};
+
+			var label2 = new Label()
+			{
+				Text = "This is label tests.",
+				CharacterSpacing = expectedCharacterSpacing2,
+				LineHeight = expectedLineHeight2,
+				TextDecorations = expectedTextDecorations2
+			};
+
+			var label3 = new Label()
+			{
+				FormattedText = new FormattedString()
+			};
+			label3.FormattedText.AddLogicalChild(
+				new Span()
+				{
+					Text = "This is label tests.",
+					CharacterSpacing = 5,
+					LineHeight = 1.5d,
+					TextDecorations = TextDecorations.Underline
+				}
+			);
+
+			var label4 = new Label()
+			{
+				TextType = TextType.Html,
+				Text = "This is <strong style=\"color:red\">label</strong> tests."
+			};
+
+			var handler1 = await CreateHandlerAsync<LabelHandler>(label1);
+			var actualCharacterSpacing1 = await InvokeOnMainThreadAsync(() => GetPlatformCharacterSpacing(handler1));
+			Assert.Equal(expectedCharacterSpacing1, actualCharacterSpacing1);
+			var actualLineHeight1 = await InvokeOnMainThreadAsync(() => GetPlatformLineHeight(handler1));
+			Assert.Equal(expectedLineHeight1, actualLineHeight1);
+			var actualTextDecorations1 = await InvokeOnMainThreadAsync(() => GetPlatformTextDecorations(handler1));
+			Assert.Equal(expectedTextDecorations1, actualTextDecorations1);
+
+			var handler2 = await CreateHandlerAsync<LabelHandler>(label2);
+			var actualCharacterSpacing2 = await InvokeOnMainThreadAsync(() => GetPlatformCharacterSpacing(handler2));
+			Assert.Equal(expectedCharacterSpacing2, actualCharacterSpacing2);
+			var actualLineHeight2 = await InvokeOnMainThreadAsync(() => GetPlatformLineHeight(handler2));
+			Assert.Equal(expectedLineHeight2, actualLineHeight2);
+			var actualTextDecorations2 = await InvokeOnMainThreadAsync(() => GetPlatformTextDecorations(handler2));
+			Assert.Equal(expectedTextDecorations2, actualTextDecorations2);
+
+			var handler3 = await CreateHandlerAsync<LabelHandler>(label3);
+			var actualCharacterSpacing3 = await InvokeOnMainThreadAsync(() => GetPlatformCharacterSpacing(handler3));
+			Assert.Equal(expectedCharacterSpacing3, actualCharacterSpacing3);
+			var actualLineHeight3 = await InvokeOnMainThreadAsync(() => GetPlatformLineHeight(handler3));
+			Assert.Equal(expectedLineHeight3, actualLineHeight3);
+			var actualTextDecorations3 = await InvokeOnMainThreadAsync(() => GetPlatformTextDecorations(handler3));
+			Assert.Equal(expectedTextDecorations3, actualTextDecorations3);
+
+			var handler4 = await CreateHandlerAsync<LabelHandler>(label4);
+			var actualCharacterSpacing4 = await InvokeOnMainThreadAsync(() => GetPlatformCharacterSpacing(handler4));
+			Assert.Equal(expectedCharacterSpacing4, actualCharacterSpacing4);
+			var actualLineHeight4 = await InvokeOnMainThreadAsync(() => GetPlatformLineHeight(handler4));
+			Assert.Equal(expectedLineHeight4, actualLineHeight4);
+			var actualTextDecorations4 = await InvokeOnMainThreadAsync(() => GetPlatformTextDecorations(handler4));
+			Assert.Equal(expectedTextDecorations4, actualTextDecorations4);
+		}
 	}
 }

--- a/src/TestUtils/src/DeviceTests/AssertionExtensions.iOS.cs
+++ b/src/TestUtils/src/DeviceTests/AssertionExtensions.iOS.cs
@@ -444,6 +444,9 @@ namespace Microsoft.Maui.DeviceTests
 			if (text == null)
 				return 0;
 
+			if (text.Length == 0)
+				return 0;
+
 			var value = text.GetAttribute(UIStringAttributeKey.KerningAdjustment, 0, out var range);
 			if (value == null)
 				return 0;
@@ -454,6 +457,57 @@ namespace Microsoft.Maui.DeviceTests
 			var kerning = Assert.IsType<NSNumber>(value);
 
 			return kerning.DoubleValue;
+		}
+
+		public static double GetLineHeight(this NSAttributedString text)
+		{
+			if (text == null)
+				return 0;
+
+			if (text.Length == 0)
+				return 0;
+
+			var value = text.GetAttribute(UIStringAttributeKey.ParagraphStyle, 0, out var range);
+			if (value == null)
+				return 0;
+
+			Assert.Equal(0, range.Location);
+			Assert.Equal(text.Length, range.Length);
+
+			var paragraphStyle = Assert.IsType<NSMutableParagraphStyle>(value);
+
+			return paragraphStyle.LineHeightMultiple;
+		}
+
+		public static TextDecorations GetTextDecorations(this NSAttributedString text)
+		{
+			var textDecorations = TextDecorations.None;
+
+			if (text == null)
+				return textDecorations;
+
+			if (text.Length == 0)
+				return textDecorations;
+
+			var valueUnderline = text.GetAttribute(UIStringAttributeKey.UnderlineStyle, 0, out var rangeUnderline);
+			var valueStrikethrough = text.GetAttribute(UIStringAttributeKey.StrikethroughStyle, 0, out var rangeStrikethrough);
+
+			Assert.Equal(0, rangeUnderline.Location);
+			Assert.Equal(text.Length, rangeUnderline.Length);
+
+			Assert.Equal(0, rangeStrikethrough.Location);
+			Assert.Equal(text.Length, rangeStrikethrough.Length);
+
+			if (NSNumber.FromInt32((int)NSUnderlineStyle.Single) == (NSNumber)valueUnderline)
+			{
+				textDecorations = TextDecorations.Underline;
+			}
+			else if (NSNumber.FromInt32((int)NSUnderlineStyle.Single) == (NSNumber)valueStrikethrough)
+			{
+				textDecorations = TextDecorations.Strikethrough;
+			}
+
+			return textDecorations;
 		}
 
 		public static void AssertHasUnderline(this NSAttributedString attributedString)


### PR DESCRIPTION
### Description of Change

<!-- Enter description of the fix in this section -->
This PR fixes the problem that the LineHeight, TextDecorations, CharacterSpacing properties are not reflected when the label is displayed for the first time. 

Called the MapFormatting method of LabelHandler in the MapFormatting method of Label.iOS.cs so that the values ​​of LineHeight, TextDecorations, and CharacterSpacing are reflected. I used a similar condition because LineHeight, TextDecorations, CharacterSpacing were updating only when the Text set on the Label was PlainText.

[src\Controls\src\Core\Label\Label.iOS.cs]

    static void MapFormatting(ILabelHandler handler, Label label)
    {
        handler.UpdateValue(nameof(ILabel.TextColor));
        handler.UpdateValue(nameof(ILabel.Font));

        if (!IsPlainText(label))
            return;

        LabelHandler.MapFormatting(handler, label);
    }

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #16204 

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->

Below is the execution result.

![2023-07-19_12-36-41-午後](https://github.com/dotnet/maui/assets/125236133/0b8c00d6-480b-4047-91f1-4be32edf2e31)
