### PR TITLE
[tests] introduce `AssertionExtensions.WaitForGC()`

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Border/BorderTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Border/BorderTests.cs
@@ -105,19 +105,7 @@ namespace Microsoft.Maui.DeviceTests
 				platformViewReference = new WeakReference(label.Handler.PlatformView);
 			});
 
-			Assert.NotNull(handlerReference);
-			Assert.NotNull(platformViewReference);
-
-			// Several GCs required on iOS
-			for (int i = 0; i < 5; i++)
-			{
-				if (!handlerReference.IsAlive && !platformViewReference.IsAlive)
-					break;
-				await Task.Yield();
-				GC.Collect();
-				GC.WaitForPendingFinalizers();
-			}
-
+			await AssertionExtensions.WaitForGC(handlerReference, platformViewReference);
 			Assert.False(handlerReference.IsAlive, "Handler should not be alive!");
 			Assert.False(platformViewReference.IsAlive, "PlatformView should not be alive!");
 		}

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.cs
@@ -72,11 +72,7 @@ namespace Microsoft.Maui.DeviceTests
 				await Task.Delay(100);
 			});
 
-			await Task.Yield();
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
-
-			Assert.NotNull(weakReference);
+			await AssertionExtensions.WaitForGC(weakReference);
 			Assert.False(weakReference.IsAlive, "ObservableCollection should not be alive!");
 			Assert.NotNull(logicalChildren);
 			Assert.True(logicalChildren.Count <= 3, "_logicalChildren should not grow in size!");

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.iOS.cs
@@ -120,13 +120,9 @@ namespace Microsoft.Maui.DeviceTests
 				});
 
 				Assert.NotNull(cell);
-				Assert.NotEmpty(labels);
 			}
 
-			await Task.Yield();
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
-
+			await AssertionExtensions.WaitForGC(labels.ToArray());
 			foreach (var reference in labels)
 			{
 				Assert.False(reference.IsAlive, "View should not be alive!");

--- a/src/Controls/tests/DeviceTests/Elements/ContentView/ContentViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/ContentView/ContentViewTests.cs
@@ -97,18 +97,7 @@ namespace Microsoft.Maui.DeviceTests
 				});
 			}
 
-			Assert.NotNull(viewReference);
-			Assert.NotNull(platformReference);
-			Assert.NotNull(handlerReference);
-
-			// Multiple GCs are sometimes required on iOS
-			for (int i = 0; i < 3; i++)
-			{
-				await Task.Yield();
-				GC.Collect();
-				GC.WaitForPendingFinalizers();
-			}
-
+			await AssertionExtensions.WaitForGC(viewReference, handlerReference, platformReference);
 			Assert.False(viewReference.IsAlive, "View should not be alive!");
 			Assert.False(handlerReference.IsAlive, "Handler should not be alive!");
 			Assert.False(platformReference.IsAlive, "PlatformView should not be alive!");

--- a/src/Controls/tests/DeviceTests/Elements/Image/ImageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Image/ImageTests.cs
@@ -71,19 +71,7 @@ namespace Microsoft.Maui.DeviceTests
 				await image.Wait();
 			});
 
-			Assert.NotNull(handlerReference);
-			Assert.NotNull(platformViewReference);
-
-			// Several GCs required on iOS
-			for (int i = 0; i < 5; i++)
-			{
-				if (!handlerReference.IsAlive && !platformViewReference.IsAlive)
-					break;
-				await Task.Yield();
-				GC.Collect();
-				GC.WaitForPendingFinalizers();
-			}
-
+			await AssertionExtensions.WaitForGC(handlerReference, platformViewReference);
 			Assert.False(handlerReference.IsAlive, "Handler should not be alive!");
 			Assert.False(platformViewReference.IsAlive, "PlatformView should not be alive!");
 		}

--- a/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.cs
@@ -326,16 +326,7 @@ namespace Microsoft.Maui.DeviceTests
 				await navPage.Navigation.PopAsync();
 			});
 
-			// Windows requires an actual delay
-			// Android/iOS require multiple GCs
-			await AssertionExtensions.Wait(() =>
-			{
-				GC.Collect();
-				GC.WaitForPendingFinalizers();
-				return !pageReference.IsAlive;
-			}, timeout: 5000);
-
-			Assert.NotNull(pageReference);
+			await AssertionExtensions.WaitForGC(pageReference);
 			Assert.False(pageReference.IsAlive, "Page should not be alive!");
 		}
 

--- a/src/Controls/tests/DeviceTests/Elements/ScrollView/ScrollViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/ScrollView/ScrollViewTests.cs
@@ -98,19 +98,7 @@ namespace Microsoft.Maui.DeviceTests
 				});
 			}
 
-			Assert.NotNull(viewReference);
-			Assert.NotNull(platformReference);
-			Assert.NotNull(handlerReference);
-
-			// Android requires an actual 2-second day
-			// iOS requires multiple GCs
-			await AssertionExtensions.Wait(() =>
-			{
-				GC.Collect();
-				GC.WaitForPendingFinalizers();
-				return !viewReference.IsAlive && !handlerReference.IsAlive && !platformReference.IsAlive;
-			}, timeout: 3000);
-
+			await AssertionExtensions.WaitForGC(viewReference, handlerReference, platformReference);
 			Assert.False(viewReference.IsAlive, "View should not be alive!");
 			Assert.False(handlerReference.IsAlive, "Handler should not be alive!");
 			Assert.False(platformReference.IsAlive, "PlatformView should not be alive!");

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
@@ -995,16 +995,7 @@ namespace Microsoft.Maui.DeviceTests
 				await shell.Navigation.PopAsync();
 			});
 
-			// Windows requires an actual delay
-			// Android/iOS require multiple GCs
-			await AssertionExtensions.Wait(() =>
-			{
-				GC.Collect();
-				GC.WaitForPendingFinalizers();
-				return !pageReference.IsAlive;
-			}, timeout: 5000);
-
-			Assert.NotNull(pageReference);
+			await AssertionExtensions.WaitForGC(pageReference);
 			Assert.False(pageReference.IsAlive, "Page should not be alive!");
 		}
 

--- a/src/TestUtils/src/DeviceTests/AssertionExtensions.cs
+++ b/src/TestUtils/src/DeviceTests/AssertionExtensions.cs
@@ -27,6 +27,30 @@ namespace Microsoft.Maui.DeviceTests
 			return exitCondition.Invoke();
 		}
 
+		public static Task<bool> WaitForGC(params WeakReference[] references)
+		{
+			// Check all the WeakReference values are non-null
+			Assert.NotEmpty(references);
+			foreach (var reference in references)
+			{
+				Assert.NotNull(reference);
+			}
+
+			return Wait(() =>
+			{
+				GC.Collect();
+				GC.WaitForPendingFinalizers();
+
+				foreach (var reference in references)
+				{
+					if (reference.IsAlive)
+						return false;
+				}
+
+				return true; // No references alive
+			}, timeout: 5000);
+		}
+
 		public static void AssertHasFlag(this Enum self, Enum flag)
 		{
 			var hasFlag = self.HasFlag(flag);


### PR DESCRIPTION
I've found the most reliable way to make DeviceTests run the GC for all platforms is:

    Assert.NotNull(pageReference);
    await AssertionExtensions.Wait(() =>
    {
        GC.Collect();
        GC.WaitForPendingFinalizers();
        return !pageReference.IsAlive;
    }, timeout: 5000);

Let's standardize on this, so we can instead do:

    await AssertionExtensions.WaitForGC(pageReference);

And if you have multiple:

    await AssertionExtensions.WaitForGC(pageReference, handlerReference);

The helper method also checks if the `params WeakReference[]` is empty, or any `WeakReference` are null. I simplified various tests with this change.