### PR TITLE
Don't use loaded/unloaded on FlyoutPage

### DIFF
--- a/src/Controls/src/Core/FlyoutPage/FlyoutPage.cs
+++ b/src/Controls/src/Core/FlyoutPage/FlyoutPage.cs
@@ -331,7 +331,8 @@ namespace Microsoft.Maui.Controls
 		{
 			if (Window is null)
 			{
-				this.SizeChanged += OnSizeChanged;
+				SizeChanged -= OnSizeChanged;
+				SizeChanged += OnSizeChanged;
 				DeviceDisplay.MainDisplayInfoChanged -= OnMainDisplayInfoChanged;
 			}
 			else

--- a/src/Controls/src/Core/FlyoutPage/FlyoutPage.cs
+++ b/src/Controls/src/Core/FlyoutPage/FlyoutPage.cs
@@ -306,9 +306,8 @@ namespace Microsoft.Maui.Controls
 		public FlyoutPage()
 		{
 			_platformConfigurationRegistry = new Lazy<PlatformConfigurationRegistry<FlyoutPage>>(() => new PlatformConfigurationRegistry<FlyoutPage>(this));
-
-			this.Loaded += OnLoaded;
-			this.Unloaded += OnUnloaded;
+			(this as IControlsVisualElement).WindowChanged += OnWindowChanged;
+			this.SizeChanged += OnSizeChanged;
 		}
 
 		readonly Lazy<PlatformConfigurationRegistry<FlyoutPage>> _platformConfigurationRegistry;
@@ -319,15 +318,26 @@ namespace Microsoft.Maui.Controls
 			return _platformConfigurationRegistry.Value.On<T>();
 		}
 
-		void OnUnloaded(object sender, EventArgs e)
+		void OnSizeChanged(object sender, EventArgs e)
 		{
-			DeviceDisplay.MainDisplayInfoChanged -= OnMainDisplayInfoChanged;
+			if (Handler is not null)
+			{
+				Handler?.UpdateValue(nameof(FlyoutBehavior));
+				SizeChanged -= OnSizeChanged;
+			}
 		}
 
-		void OnLoaded(object sender, EventArgs e)
+		void OnWindowChanged(object sender, EventArgs e)
 		{
-			DeviceDisplay.MainDisplayInfoChanged += OnMainDisplayInfoChanged;
-			Handler?.UpdateValue(nameof(FlyoutBehavior));
+			if (Window is null)
+			{
+				this.SizeChanged += OnSizeChanged;
+				DeviceDisplay.MainDisplayInfoChanged -= OnMainDisplayInfoChanged;
+			}
+			else
+			{
+				DeviceDisplay.MainDisplayInfoChanged += OnMainDisplayInfoChanged;
+			}
 		}
 
 		void OnMainDisplayInfoChanged(object sender, DisplayInfoChangedEventArgs e)


### PR DESCRIPTION
### Description of Change

The Legacy Gallery does a lot of page churn when it first starts up. It basically goes through the follow stages

- Load a FlyoutPage
- Load another FlyoutPage
- Push a Modal Navigation Page (During OnAppearing. If you push any later it all works fine)

The PR around LogicalChildren looks to have adjusted the timing just enough that we're hitting a race condition with the observers used to watch for loaded events on iOS. 

We are going to remove these observers for RC1 so the race condition should become irrelevant at that point.