### PR TITLE
[ios] fix memory leak in TimePicker

### DIFF
--- a/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
+++ b/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
@@ -25,7 +25,7 @@ public class MemoryTests : ControlsHandlerTestBase
 				handlers.AddHandler<RefreshView, RefreshViewHandler>();
 				handlers.AddHandler<IScrollView, ScrollViewHandler>();
 				handlers.AddHandler<SwipeView, SwipeViewHandler>();
-        handlers.AddHandler<TimePicker, TimePickerHandler>();
+				handlers.AddHandler<TimePicker, TimePickerHandler>();
 			});
 		});
 	}
@@ -41,7 +41,7 @@ public class MemoryTests : ControlsHandlerTestBase
 	[InlineData(typeof(RefreshView))]
 	[InlineData(typeof(ScrollView))]
 	[InlineData(typeof(SwipeView))]
-  [InlineData(typeof(TimePicker))]
+	[InlineData(typeof(TimePicker))]
 	public async Task HandlerDoesNotLeak(Type type)
 	{
 		SetupBuilder();

--- a/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
+++ b/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
@@ -24,6 +24,7 @@ public class MemoryTests : ControlsHandlerTestBase
 				handlers.AddHandler<Image, ImageHandler>();
 				handlers.AddHandler<RefreshView, RefreshViewHandler>();
 				handlers.AddHandler<IScrollView, ScrollViewHandler>();
+				handlers.AddHandler<TimePicker, TimePickerHandler>();
 			});
 		});
 	}
@@ -38,6 +39,7 @@ public class MemoryTests : ControlsHandlerTestBase
 	[InlineData(typeof(Label))]
 	[InlineData(typeof(RefreshView))]
 	[InlineData(typeof(ScrollView))]
+	[InlineData(typeof(TimePicker))]
 	public async Task HandlerDoesNotLeak(Type type)
 	{
 		SetupBuilder();

--- a/src/Core/src/Handlers/TimePicker/TimePickerHandler.iOS.cs
+++ b/src/Core/src/Handlers/TimePicker/TimePickerHandler.iOS.cs
@@ -5,13 +5,11 @@ namespace Microsoft.Maui.Handlers
 #if IOS && !MACCATALYST
 	public partial class TimePickerHandler : ViewHandler<ITimePicker, MauiTimePicker>
 	{
+		readonly MauiTimePickerProxy _proxy = new();
+
 		protected override MauiTimePicker CreatePlatformView()
 		{
-			return new MauiTimePicker(() =>
-			{
-				SetVirtualViewTime();
-				PlatformView?.ResignFirstResponder();
-			});
+			return new MauiTimePicker(_proxy.OnDateSelected);
 		}
 
 		internal bool UpdateImmediately { get; set; }
@@ -20,34 +18,15 @@ namespace Microsoft.Maui.Handlers
 		{
 			base.ConnectHandler(platformView);
 
-			if (platformView != null)
-			{
-				platformView.EditingDidBegin += OnStarted;
-				platformView.EditingDidEnd += OnEnded;
-				platformView.ValueChanged += OnValueChanged;
-				platformView.DateSelected += OnDateSelected;
-				platformView.Picker.ValueChanged += OnValueChanged;
-
-				platformView.UpdateTime(VirtualView.Time);
-			}
+			_proxy.Connect(this, VirtualView, platformView);
+			platformView.UpdateTime(VirtualView.Time);
 		}
 
 		protected override void DisconnectHandler(MauiTimePicker platformView)
 		{
 			base.DisconnectHandler(platformView);
 
-			if (platformView != null)
-			{
-				platformView.RemoveFromSuperview();
-
-				platformView.EditingDidBegin -= OnStarted;
-				platformView.EditingDidEnd -= OnEnded;
-				platformView.ValueChanged -= OnValueChanged;
-				platformView.DateSelected -= OnDateSelected;
-				platformView.Picker.ValueChanged -= OnValueChanged;
-
-				platformView.Dispose();
-			}
+			_proxy.Disconnect(platformView);
 		}
 
 		public static void MapFormat(ITimePickerHandler handler, ITimePicker timePicker)
@@ -83,29 +62,6 @@ namespace Microsoft.Maui.Handlers
 			handler.PlatformView?.UpdateTextAlignment(timePicker);
 		}
 
-		void OnStarted(object? sender, EventArgs eventArgs)
-		{
-			if (VirtualView is not null)
-				VirtualView.IsFocused = true;
-		}
-
-		void OnEnded(object? sender, EventArgs eventArgs)
-		{
-			if (VirtualView is not null)
-				VirtualView.IsFocused = false;
-		}
-
-		void OnValueChanged(object? sender, EventArgs e)
-		{
-			if (UpdateImmediately)  // Platform Specific
-				SetVirtualViewTime();
-		}
-
-		void OnDateSelected(object? sender, EventArgs e)
-		{
-			SetVirtualViewTime();
-		}
-
 		void SetVirtualViewTime()
 		{
 			if (VirtualView == null || PlatformView == null)
@@ -113,6 +69,63 @@ namespace Microsoft.Maui.Handlers
 
 			var datetime = PlatformView.Date.ToDateTime();
 			VirtualView.Time = new TimeSpan(datetime.Hour, datetime.Minute, 0);
+		}
+
+		class MauiTimePickerProxy
+		{
+			WeakReference<TimePickerHandler>? _handler;
+			WeakReference<ITimePicker>? _virtualView;
+
+			ITimePicker? VirtualView => _virtualView is not null && _virtualView.TryGetTarget(out var v) ? v : null;
+
+			public void Connect(TimePickerHandler handler, ITimePicker virtualView, MauiTimePicker platformView)
+			{
+				_handler = new(handler);
+				_virtualView = new(virtualView);
+
+				platformView.EditingDidBegin += OnStarted;
+				platformView.EditingDidEnd += OnEnded;
+				platformView.ValueChanged += OnValueChanged;
+				platformView.Picker.ValueChanged += OnValueChanged;
+			}
+
+			public void Disconnect(MauiTimePicker platformView)
+			{
+				_virtualView = null;
+
+				platformView.EditingDidBegin -= OnStarted;
+				platformView.EditingDidEnd -= OnEnded;
+				platformView.ValueChanged -= OnValueChanged;
+				platformView.Picker.ValueChanged -= OnValueChanged;
+				platformView.RemoveFromSuperview();
+			}
+
+			void OnStarted(object? sender, EventArgs eventArgs)
+			{
+				if (VirtualView is not null)
+					VirtualView.IsFocused = true;
+			}
+
+			void OnEnded(object? sender, EventArgs eventArgs)
+			{
+				if (VirtualView is not null)
+					VirtualView.IsFocused = false;
+			}
+
+			void OnValueChanged(object? sender, EventArgs e)
+			{
+				if (_handler is not null && _handler.TryGetTarget(out var handler) && handler.UpdateImmediately)  // Platform Specific
+					handler.SetVirtualViewTime();
+			}
+
+			public void OnDateSelected()
+			{
+				if (_handler is not null && _handler.TryGetTarget(out var handler))
+				{
+					handler.SetVirtualViewTime();
+					handler.PlatformView?.ResignFirstResponder();
+				}
+			}
 		}
 	}
 #endif


### PR DESCRIPTION
After working on some tooling to proactively find memory leaks, I found a few in the `TimePicker`. This kind of highlights the pattern:

* `MauiTimePicker` is a subclass of `UIDatePicker`

* `TimePickerHandler` has a strong reference to `MauiTimePicker` as the `PlatformView`.

* `TimePickerHandler` subscribes to various events and has a strong reference to `MauiTimePicker`: creating a cycle.

This effectively causes entire pages to leak, because `TimePicker.Parent.Parent`, etc. will hold a strong reference up to the entire `Page`.

It is not enough to unsubscribe from these events in `DisconnectHandler`, because it is not called in many cases.

For example, take the test:

```csharp
    await InvokeOnMainThreadAsync(() =>
    {
        var layout = new Grid();
        var picker = new TimePicker();
        layout.Add(picker);
        var handler = CreateHandler<LayoutHandler>(layout);
        viewReference = new WeakReference(handler);
        handlerReference = new WeakReference(picker.Handler);
        platformViewReference = new WeakReference(picker.Handler.PlatformView);
    });

    await AssertionExtensions.WaitForGC(viewReference, handlerReference, platformViewReference);
    Assert.False(viewReference.IsAlive, "TimePicker should not be alive!");
    Assert.False(handlerReference.IsAlive, "Handler should not be alive!");
    Assert.False(platformViewReference.IsAlive, "PlatformView should not be alive!");
```

In this case, `Grid`'s `LayoutHandler.DisconnectHandler` is called, but not the `TimePickerHandler`.

To solve this problem, I moved 5 events to the `MauiTimePicker` class and was able to remove one.

I also found a similar problem with `MauiDoneAccessoryView` and converted various `Action` callbacks to use `WeakReference` instead.

The test did not pass until solving all of the above.