### PR TITLE
Fix default constructors for many control handlers

### DIFF
--- a/src/Core/src/Handlers/CheckBox/CheckBoxHandler.cs
+++ b/src/Core/src/Handlers/CheckBox/CheckBoxHandler.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Maui.Handlers
 		{
 		};
 
-		public CheckBoxHandler() : base(Mapper)
+		public CheckBoxHandler() : base(Mapper, CommandMapper)
 		{
 
 		}

--- a/src/Core/src/Handlers/DatePicker/DatePickerHandler.cs
+++ b/src/Core/src/Handlers/DatePicker/DatePickerHandler.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Maui.Handlers
 		{
 		};
 
-		public DatePickerHandler() : base(Mapper)
+		public DatePickerHandler() : base(Mapper, CommandMapper)
 		{
 		}
 

--- a/src/Core/src/Handlers/FlyoutView/FlyoutViewHandler.cs
+++ b/src/Core/src/Handlers/FlyoutView/FlyoutViewHandler.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Maui.Handlers
 		{
 		};
 
-		public FlyoutViewHandler() : base(Mapper)
+		public FlyoutViewHandler() : base(Mapper, CommandMapper)
 		{
 		}
 

--- a/src/Core/src/Handlers/Image/ImageHandler.cs
+++ b/src/Core/src/Handlers/Image/ImageHandler.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Maui.Handlers
 		public ImageSourcePartLoader SourceLoader =>
 			_imageSourcePartLoader ??= new ImageSourcePartLoader(this);
 
-		public ImageHandler() : base(Mapper)
+		public ImageHandler() : base(Mapper, CommandMapper)
 		{
 		}
 

--- a/src/Core/src/Handlers/ImageButton/ImageButtonHandler.cs
+++ b/src/Core/src/Handlers/ImageButton/ImageButtonHandler.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Maui.Handlers
 		public ImageSourcePartLoader SourceLoader =>
 			_imageSourcePartLoader ??= new ImageSourcePartLoader(this);
 
-		public ImageButtonHandler() : base(Mapper)
+		public ImageButtonHandler() : base(Mapper, CommandMapper)
 		{
 		}
 

--- a/src/Core/src/Handlers/IndicatorView/IndicatorViewHandler.cs
+++ b/src/Core/src/Handlers/IndicatorView/IndicatorViewHandler.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Maui.Handlers
 		{
 		};
 
-		public IndicatorViewHandler() : base(Mapper)
+		public IndicatorViewHandler() : base(Mapper, CommandMapper)
 		{
 		}
 

--- a/src/Core/src/Handlers/Label/LabelHandler.cs
+++ b/src/Core/src/Handlers/Label/LabelHandler.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Maui.Handlers
 		{
 		};
 
-		public LabelHandler() : base(Mapper)
+		public LabelHandler() : base(Mapper, CommandMapper)
 		{
 		}
 

--- a/src/Core/src/Handlers/ProgressBar/ProgressBarHandler.cs
+++ b/src/Core/src/Handlers/ProgressBar/ProgressBarHandler.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Maui.Handlers
 		{
 		};
 
-		public ProgressBarHandler() : base(Mapper)
+		public ProgressBarHandler() : base(Mapper, CommandMapper)
 		{
 		}
 

--- a/src/Core/src/Handlers/RadioButton/RadioButtonHandler.cs
+++ b/src/Core/src/Handlers/RadioButton/RadioButtonHandler.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Maui.Handlers
 		{
 		};
 
-		public RadioButtonHandler() : base(Mapper)
+		public RadioButtonHandler() : base(Mapper, CommandMapper)
 		{
 		}
 

--- a/src/Core/src/Handlers/ShapeView/ShapeViewHandler.cs
+++ b/src/Core/src/Handlers/ShapeView/ShapeViewHandler.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Maui.Handlers
 		{
 		};
 
-		public ShapeViewHandler() : base(Mapper)
+		public ShapeViewHandler() : base(Mapper, CommandMapper)
 		{
 		}
 

--- a/src/Core/src/Handlers/Slider/SliderHandler.cs
+++ b/src/Core/src/Handlers/Slider/SliderHandler.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Maui.Handlers
 		{
 		};
 
-		public SliderHandler() : base(Mapper)
+		public SliderHandler() : base(Mapper, CommandMapper)
 		{
 		}
 

--- a/src/Core/src/Handlers/Stepper/StepperHandler.cs
+++ b/src/Core/src/Handlers/Stepper/StepperHandler.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Maui.Handlers
 		{
 		};
 
-		public StepperHandler() : base(Mapper)
+		public StepperHandler() : base(Mapper, CommandMapper)
 		{
 		}
 

--- a/src/Core/src/Handlers/Switch/SwitchHandler.cs
+++ b/src/Core/src/Handlers/Switch/SwitchHandler.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Maui.Handlers
 		{
 		};
 
-		public SwitchHandler() : base(Mapper)
+		public SwitchHandler() : base(Mapper, CommandMapper)
 		{
 		}
 

--- a/src/Core/src/Handlers/TimePicker/TimePickerHandler.cs
+++ b/src/Core/src/Handlers/TimePicker/TimePickerHandler.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Maui.Handlers
 		{
 		};
 
-		public TimePickerHandler() : base(Mapper)
+		public TimePickerHandler() : base(Mapper, CommandMapper)
 		{
 		}
 


### PR DESCRIPTION
### Description of Change

This PR fixes the default, no-args constructors for 14 different view/control _handler_ classes, which were not passing their `CommandMapper` to the base constructor.  The issue was that any commands registered in the `CommandMapper` were _not_ getting invoked. Many of the handlers were already doing this correctly, so this PR brings consistency to those that were not.

### Issues Fixed

This should resolve: [#16268 - Custom commands are not invoked for some controls](https://github.com/dotnet/maui/issues/16268)
fixes #16268