### PR TITLE
Fix issue with ListView not firing SelectedItemChanged

### DIFF
--- a/src/Controls/src/Core/ListView/ListView.cs
+++ b/src/Controls/src/Core/ListView/ListView.cs
@@ -517,9 +517,7 @@ namespace Microsoft.Maui.Controls
 
 			// Set SelectedItem before any events so we don't override any changes they may have made.
 			if (SelectionMode != ListViewSelectionMode.None)
-#pragma warning disable CS0618 // Type or member is obsolete
-				SetValueCore(SelectedItemProperty, cell?.BindingContext, SetValueFlags.ClearOneWayBindings | SetValueFlags.ClearDynamicResource | (changed ? SetValueFlags.RaiseOnEqual : 0));
-#pragma warning restore CS0618 // Type or member is obsolete
+				SetValueCore(SelectedItemProperty, cell?.BindingContext, SetValueFlags.ClearOneWayBindings | SetValueFlags.ClearDynamicResource | (changed ? SetValueFlags.RaiseOnEqual : 0), SetValuePrivateFlags.Default, SetterSpecificity.FromHandler );
 
 			cell?.OnTapped();
 
@@ -545,9 +543,7 @@ namespace Microsoft.Maui.Controls
 
 			// Set SelectedItem before any events so we don't override any changes they may have made.
 			if (SelectionMode != ListViewSelectionMode.None)
-#pragma warning disable CS0618 // Type or member is obsolete
-				SetValueCore(SelectedItemProperty, cell?.BindingContext, SetValueFlags.ClearOneWayBindings | SetValueFlags.ClearDynamicResource | (changed ? SetValueFlags.RaiseOnEqual : 0));
-#pragma warning restore CS0618 // Type or member is obsolete
+				SetValueCore(SelectedItemProperty, cell?.BindingContext, SetValueFlags.ClearOneWayBindings | SetValueFlags.ClearDynamicResource | (changed ? SetValueFlags.RaiseOnEqual : 0), SetValuePrivateFlags.Default, SetterSpecificity.FromHandler);
 
 			if (isContextMenuRequested || cell == null)
 			{

--- a/src/Controls/tests/Core.UnitTests/ListViewTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ListViewTests.cs
@@ -203,6 +203,33 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.Equal(((TextCell)cell).Text, items[0].ToString());
 		}
 
+
+		[Fact]
+		public void SettingSelectItemManuallyBetweenTwoTapsFiresPropertyChanged()
+		{
+			var listView = new ListView
+			{
+				ItemsSource = new[] {
+					"item1",
+					"item2",
+					"item3"
+				}
+			};
+
+			listView.NotifyRowTapped(0);
+			listView.SelectedItem = null;
+
+			bool raised = false;
+			listView.PropertyChanged += (sender, arg) =>
+			{
+				if (arg.PropertyName == ListView.SelectedItemProperty.PropertyName)
+					raised = true;
+			};
+
+			listView.NotifyRowTapped(1);
+			Assert.True(raised);
+		}
+
 		[Fact("Tapping a different item (row) that is equal to the current item selection should still raise ItemSelected")]
 		public void NotifyRowTappedDifferentIndex()
 		{


### PR DESCRIPTION
### Description of Change

Fix firing of property change for LV SelectedItem, by using the new API instead of the obsolete one
