### PR TITLE
Windows apps should be --self-contained

### DIFF
--- a/eng/devices/windows.cake
+++ b/eng/devices/windows.cake
@@ -139,81 +139,90 @@ Task("Build")
 
 	SetDotNetEnvironmentVariables(DOTNET_PATH);
 
+	var dd = MakeAbsolute(Directory("../../bin/dotnet/"));
+	Information("DOTNET_PATH: {0}", dd);
+
+	var toolPath = $"{dd}/dotnet.exe";
+
+	Information("toolPath: {0}", toolPath);
+
 	Information("Building and publishing device test app");
 
 	// Build the app in publish mode
 	// Using the certificate thumbprint for the cert we just created
 	var s = new DotNetPublishSettings();
+	s.ToolPath = toolPath;
 	s.Configuration = CONFIGURATION;
 	s.Framework = TARGET_FRAMEWORK;
 	s.MSBuildSettings = new DotNetMSBuildSettings();
 	s.MSBuildSettings.Properties.Add("RuntimeIdentifierOverride", new List<string> { "win10-x64" });
 	s.MSBuildSettings.Properties.Add("PackageCertificateThumbprint", new List<string> { certificateThumbprint });
 	s.MSBuildSettings.Properties.Add("AppxPackageSigningEnabled", new List<string> { "True" });
-	
+	s.MSBuildSettings.Properties.Add("SelfContained", new List<string> { "True" });
+
 	DotNetPublish(PROJECT.FullPath, s);
 });
 
 Task("Test")
-    .IsDependentOn("Build")
+	.IsDependentOn("Build")
 	.IsDependentOn("SetupTestPaths")
 	.Does(() =>
 {
 	CleanDirectories(TEST_RESULTS);
 
-    Information("Cleaned directories");
+	Information("Cleaned directories");
 
 	// Try to uninstall the app if it exists from before
 	uninstallPS();
 
-    Information("Uninstalled previously deployed app");
+	Information("Uninstalled previously deployed app");
 	var projectDir = PROJECT.GetDirectory();
 	var cerPath = GetFiles(projectDir.FullPath + "/**/AppPackages/*/*.cer").First();
 	var msixPath = GetFiles(projectDir.FullPath + "/**/AppPackages/*/*.msix").First();
 
-    var testResultsFile = MakeAbsolute((DirectoryPath)TEST_RESULTS).FullPath.Replace("/", "\\") + $"\\TestResults-{PACKAGEID.Replace(".", "_")}.xml";
+	var testResultsFile = MakeAbsolute((DirectoryPath)TEST_RESULTS).FullPath.Replace("/", "\\") + $"\\TestResults-{PACKAGEID.Replace(".", "_")}.xml";
 
 	Information($"Found MSIX, installing: {msixPath}");
-    Information($"Test Results File: {testResultsFile}");
+	Information($"Test Results File: {testResultsFile}");
 
-    if (FileExists(testResultsFile))
+	if (FileExists(testResultsFile))
 	{
-        DeleteFile(testResultsFile);
+		DeleteFile(testResultsFile);
 	}
 
 	// Install dependencies
 	var dependencies = GetFiles(projectDir.FullPath + "/**/AppPackages/**/Dependencies/x64/*.msix");
-    foreach (var dep in dependencies) {
-        Information("Installing Dependency MSIX: {0}", dep);
-        StartProcess("powershell", "Add-AppxPackage -Path \"" + MakeAbsolute(dep).FullPath + "\"");
-    }
+	foreach (var dep in dependencies) {
+		Information("Installing Dependency MSIX: {0}", dep);
+		StartProcess("powershell", "Add-AppxPackage -Path \"" + MakeAbsolute(dep).FullPath + "\"");
+	}
 
 	// Install the DeviceTests app
 	StartProcess("powershell", "Add-AppxPackage -Path \"" + MakeAbsolute(msixPath).FullPath + "\"");
 
-    var startArgs = "Start-Process shell:AppsFolder\\$((Get-AppxPackage -Name \"" + PACKAGEID + "\").PackageFamilyName)!App -Args \"" + testResultsFile + "\"";
+	var startArgs = "Start-Process shell:AppsFolder\\$((Get-AppxPackage -Name \"" + PACKAGEID + "\").PackageFamilyName)!App -Args \"" + testResultsFile + "\"";
 
-    Information(startArgs);
+	Information(startArgs);
 
 	// Start the DeviceTests app
 	StartProcess("powershell", startArgs);
 
-    var waited = 0;
-    while (!FileExists(testResultsFile)) {
-        System.Threading.Thread.Sleep(1000);
-        waited++;
+	var waited = 0;
+	while (!FileExists(testResultsFile)) {
+		System.Threading.Thread.Sleep(1000);
+		waited++;
 
-        Information($"Waiting {waited} second(s) for tests to finish...");
-        if (waited >= 120)
-            break;
-    }
+		Information($"Waiting {waited} second(s) for tests to finish...");
+		if (waited >= 120)
+			break;
+	}
 
 	if(!FileExists(testResultsFile))
 	{
 		throw new Exception($"Test results file not found after {waited} seconds, process might have crashed or not completed yet.");
 	}
 
-    Information($"Tests Finished");
+	Information($"Tests Finished");
 });
 
 
@@ -287,9 +296,10 @@ Task("uitest")
 			ToolPath = toolPath,
 			ArgumentCustomization = args => args
 				.Append("/p:ExtraDefineConstants=WINTEST")
+				.Append("/p:SelfContained=True")
 				.Append("/bl:" + binlog)
 				.Append("/maxcpucount:1")
-				//.Append("/tl")	
+				//.Append("/tl")
 	});
 
 	SetEnvironmentVariable("WINDOWS_APP_PATH", TEST_APP);

--- a/eng/devices/windows.cake
+++ b/eng/devices/windows.cake
@@ -296,7 +296,6 @@ Task("uitest")
 			ToolPath = toolPath,
 			ArgumentCustomization = args => args
 				.Append("/p:ExtraDefineConstants=WINTEST")
-				.Append("/p:SelfContained=True")
 				.Append("/bl:" + binlog)
 				.Append("/maxcpucount:1")
 				//.Append("/tl")


### PR DESCRIPTION
### Description of Change

MSIX apps should be self-contained because they need to bring their runtime along with them to the Store.