### PR TITLE
Added Device ID to Essentials.DeviceInfo

### DIFF
--- a/src/Essentials/samples/Samples/View/DeviceInfoPage.xaml
+++ b/src/Essentials/samples/Samples/View/DeviceInfoPage.xaml
@@ -14,6 +14,7 @@
         <ScrollView Grid.Row="1">
             <StackLayout Padding="12,0,12,12" Spacing="6">
                 <Label Text="Device Info:" FontAttributes="Bold" Margin="0,6,0,0" />
+                <Label Text="{Binding DeviceId, StringFormat='Device ID: {0}'}" />
                 <Label Text="{Binding Model, StringFormat='Model: {0}'}" />
                 <Label Text="{Binding Manufacturer, StringFormat='Manufacturer: {0}'}" />
                 <Label Text="{Binding Name, StringFormat='Device Name: {0}'}" />

--- a/src/Essentials/samples/Samples/ViewModel/DeviceInfoViewModel.cs
+++ b/src/Essentials/samples/Samples/ViewModel/DeviceInfoViewModel.cs
@@ -6,6 +6,8 @@ namespace Samples.ViewModel
 	{
 		DisplayInfo screenMetrics;
 
+		public string DeviceId => DeviceInfo.DeviceId;
+
 		public string Model => DeviceInfo.Model;
 
 		public string Manufacturer => DeviceInfo.Manufacturer;

--- a/src/Essentials/src/DeviceInfo/DeviceInfo.android.cs
+++ b/src/Essentials/src/DeviceInfo/DeviceInfo.android.cs
@@ -11,6 +11,17 @@ namespace Microsoft.Maui.Devices
 	{
 		const int tabletCrossover = 600;
 
+		public string DeviceId
+		{
+			get
+			{
+				var context = Application.Context;
+				var id = Settings.Secure.GetString(context.ContentResolver, Settings.Secure.AndroidId);
+
+				return id;
+			}
+		}
+
 		public string Model => Build.Model;
 
 		public string Manufacturer => Build.Manufacturer;

--- a/src/Essentials/src/DeviceInfo/DeviceInfo.ios.tvos.watchos.cs
+++ b/src/Essentials/src/DeviceInfo/DeviceInfo.ios.tvos.watchos.cs
@@ -14,6 +14,8 @@ namespace Microsoft.Maui.Devices
 {
 	class DeviceInfoImplementation : IDeviceInfo
 	{
+		public string DeviceId => UIDevice.CurrentDevice.IdentifierForVendor.AsString();
+
 		public string Model
 		{
 			get

--- a/src/Essentials/src/DeviceInfo/DeviceInfo.macos.cs
+++ b/src/Essentials/src/DeviceInfo/DeviceInfo.macos.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Runtime.InteropServices;
+using CoreFoundation;
 using Foundation;
 using ObjCRuntime;
 
@@ -12,6 +13,42 @@ namespace Microsoft.Maui.Devices
 
 		[DllImport(Constants.CoreFoundationLibrary)]
 		static extern void CFRelease(IntPtr cf);
+
+		[DllImport("/System/Library/Frameworks/IOKit.framework/IOKit")]
+        static extern uint IOServiceGetMatchingService(uint masterPort, IntPtr matching);
+
+        [DllImport("/System/Library/Frameworks/IOKit.framework/IOKit")]
+        static extern IntPtr IOServiceMatching(string s);
+
+        [DllImport("/System/Library/Frameworks/IOKit.framework/IOKit")]
+        static extern IntPtr IORegistryEntryCreateCFProperty(uint entry, IntPtr key, IntPtr allocator, uint options);
+
+        [DllImport("/System/Library/Frameworks/IOKit.framework/IOKit")]
+        static extern int IOObjectRelease(uint o);
+
+        public string DeviceId
+        {
+            get
+            {
+                var serial = string.Empty;
+                var platformExpert = IOServiceGetMatchingService(0, IOServiceMatching("IOPlatformExpertDevice"));
+
+                if (platformExpert != 0)
+                {
+                    var key = (CFString)"IOPlatformSerialNumber";
+                    var serialNumber = IORegistryEntryCreateCFProperty(platformExpert, key.Handle, IntPtr.Zero, 0);
+
+                    if (serialNumber != IntPtr.Zero)
+                    {
+                        serial = CFString.FromHandle(serialNumber);
+                    }
+
+                    IOObjectRelease(platformExpert);
+                }
+
+                return serial;
+            }
+        }
 
 		public string Model =>
 			IOKit.GetPlatformExpertPropertyValue<NSData>("model")?.ToString() ?? string.Empty;

--- a/src/Essentials/src/DeviceInfo/DeviceInfo.netstandard.cs
+++ b/src/Essentials/src/DeviceInfo/DeviceInfo.netstandard.cs
@@ -5,6 +5,8 @@ namespace Microsoft.Maui.Devices
 {
 	class DeviceInfoImplementation : IDeviceInfo
 	{
+		public string DeviceId => throw ExceptionUtils.NotSupportedOrImplementedException;
+
 		public string Model => throw ExceptionUtils.NotSupportedOrImplementedException;
 
 		public string Manufacturer => throw ExceptionUtils.NotSupportedOrImplementedException;

--- a/src/Essentials/src/DeviceInfo/DeviceInfo.shared.cs
+++ b/src/Essentials/src/DeviceInfo/DeviceInfo.shared.cs
@@ -24,6 +24,11 @@ namespace Microsoft.Maui.Devices
 	public interface IDeviceInfo
 	{
 		/// <summary>
+		/// Gets the unique ID of the device.
+		/// </summary>
+		string DeviceId { get; }
+
+		/// <summary>
 		/// Gets the model of the device.
 		/// </summary>
 		string Model { get; }
@@ -70,6 +75,11 @@ namespace Microsoft.Maui.Devices
 	/// </summary>
 	public static class DeviceInfo
 	{
+		/// <summary>
+		/// Gets the unique ID of the device.
+		/// </summary>
+		public static string DeviceId => Current.DeviceId;
+
 		/// <summary>
 		/// Gets the model of the device.
 		/// </summary>

--- a/src/Essentials/src/DeviceInfo/DeviceInfo.tizen.cs
+++ b/src/Essentials/src/DeviceInfo/DeviceInfo.tizen.cs
@@ -5,6 +5,8 @@ namespace Microsoft.Maui.Devices
 {
 	class DeviceInfoImplementation : IDeviceInfo
 	{
+		public string DeviceId => PlatformUtils.GetSystemInfo("tizenid");
+
 		public string Model => PlatformUtils.GetSystemInfo("model_name");
 
 		public string Manufacturer => PlatformUtils.GetSystemInfo("manufacturer");

--- a/src/Essentials/src/DeviceInfo/DeviceInfo.uwp.cs
+++ b/src/Essentials/src/DeviceInfo/DeviceInfo.uwp.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using Microsoft.Maui.ApplicationModel;
+using Windows.Security.Cryptography;
 using Windows.Security.ExchangeActiveSyncProvisioning;
 using Windows.System.Profile;
 using Windows.UI.ViewManagement;
@@ -29,6 +30,19 @@ namespace Microsoft.Maui.Devices
 			catch (Exception ex)
 			{
 				Debug.WriteLine($"Unable to get system product name. {ex.Message}");
+			}
+		}
+
+		public string DeviceId
+		{
+			get
+			{
+				var systemIdentificationInfo = SystemIdentification.GetSystemIdForPublisher();
+
+				if (systemIdentificationInfo == null)
+					return string.Empty;
+
+				return CryptographicBuffer.EncodeToHexString(systemIdentificationInfo.Id);
 			}
 		}
 

--- a/src/Essentials/src/PublicAPI/net-android/PublicAPI.Shipped.txt
+++ b/src/Essentials/src/PublicAPI/net-android/PublicAPI.Shipped.txt
@@ -573,6 +573,7 @@ Microsoft.Maui.Devices.IDeviceDisplay.KeepScreenOn.set -> void
 Microsoft.Maui.Devices.IDeviceDisplay.MainDisplayInfo.get -> Microsoft.Maui.Devices.DisplayInfo
 Microsoft.Maui.Devices.IDeviceDisplay.MainDisplayInfoChanged -> System.EventHandler<Microsoft.Maui.Devices.DisplayInfoChangedEventArgs!>!
 Microsoft.Maui.Devices.IDeviceInfo
+Microsoft.Maui.Devices.IDeviceInfo.DeviceId.get -> string!
 Microsoft.Maui.Devices.IDeviceInfo.DeviceType.get -> Microsoft.Maui.Devices.DeviceType
 Microsoft.Maui.Devices.IDeviceInfo.Idiom.get -> Microsoft.Maui.Devices.DeviceIdiom
 Microsoft.Maui.Devices.IDeviceInfo.Manufacturer.get -> string!
@@ -1072,6 +1073,7 @@ static Microsoft.Maui.Devices.DeviceIdiom.TV.get -> Microsoft.Maui.Devices.Devic
 static Microsoft.Maui.Devices.DeviceIdiom.Unknown.get -> Microsoft.Maui.Devices.DeviceIdiom
 static Microsoft.Maui.Devices.DeviceIdiom.Watch.get -> Microsoft.Maui.Devices.DeviceIdiom
 static Microsoft.Maui.Devices.DeviceInfo.Current.get -> Microsoft.Maui.Devices.IDeviceInfo!
+static Microsoft.Maui.Devices.DeviceInfo.DeviceId.get -> string!
 static Microsoft.Maui.Devices.DeviceInfo.DeviceType.get -> Microsoft.Maui.Devices.DeviceType
 static Microsoft.Maui.Devices.DeviceInfo.Idiom.get -> Microsoft.Maui.Devices.DeviceIdiom
 static Microsoft.Maui.Devices.DeviceInfo.Manufacturer.get -> string!

--- a/src/Essentials/src/PublicAPI/net-ios/PublicAPI.Shipped.txt
+++ b/src/Essentials/src/PublicAPI/net-ios/PublicAPI.Shipped.txt
@@ -568,6 +568,7 @@ Microsoft.Maui.Devices.IDeviceDisplay.KeepScreenOn.set -> void
 Microsoft.Maui.Devices.IDeviceDisplay.MainDisplayInfo.get -> Microsoft.Maui.Devices.DisplayInfo
 Microsoft.Maui.Devices.IDeviceDisplay.MainDisplayInfoChanged -> System.EventHandler<Microsoft.Maui.Devices.DisplayInfoChangedEventArgs!>!
 Microsoft.Maui.Devices.IDeviceInfo
+Microsoft.Maui.Devices.IDeviceInfo.DeviceId.get -> string!
 Microsoft.Maui.Devices.IDeviceInfo.DeviceType.get -> Microsoft.Maui.Devices.DeviceType
 Microsoft.Maui.Devices.IDeviceInfo.Idiom.get -> Microsoft.Maui.Devices.DeviceIdiom
 Microsoft.Maui.Devices.IDeviceInfo.Manufacturer.get -> string!
@@ -1066,6 +1067,7 @@ static Microsoft.Maui.Devices.DeviceIdiom.TV.get -> Microsoft.Maui.Devices.Devic
 static Microsoft.Maui.Devices.DeviceIdiom.Unknown.get -> Microsoft.Maui.Devices.DeviceIdiom
 static Microsoft.Maui.Devices.DeviceIdiom.Watch.get -> Microsoft.Maui.Devices.DeviceIdiom
 static Microsoft.Maui.Devices.DeviceInfo.Current.get -> Microsoft.Maui.Devices.IDeviceInfo!
+static Microsoft.Maui.Devices.DeviceInfo.DeviceId.get -> string!
 static Microsoft.Maui.Devices.DeviceInfo.DeviceType.get -> Microsoft.Maui.Devices.DeviceType
 static Microsoft.Maui.Devices.DeviceInfo.Idiom.get -> Microsoft.Maui.Devices.DeviceIdiom
 static Microsoft.Maui.Devices.DeviceInfo.Manufacturer.get -> string!

--- a/src/Essentials/src/PublicAPI/net-maccatalyst/PublicAPI.Shipped.txt
+++ b/src/Essentials/src/PublicAPI/net-maccatalyst/PublicAPI.Shipped.txt
@@ -568,6 +568,7 @@ Microsoft.Maui.Devices.IDeviceDisplay.KeepScreenOn.set -> void
 Microsoft.Maui.Devices.IDeviceDisplay.MainDisplayInfo.get -> Microsoft.Maui.Devices.DisplayInfo
 Microsoft.Maui.Devices.IDeviceDisplay.MainDisplayInfoChanged -> System.EventHandler<Microsoft.Maui.Devices.DisplayInfoChangedEventArgs!>!
 Microsoft.Maui.Devices.IDeviceInfo
+Microsoft.Maui.Devices.IDeviceInfo.DeviceId.get -> string!
 Microsoft.Maui.Devices.IDeviceInfo.DeviceType.get -> Microsoft.Maui.Devices.DeviceType
 Microsoft.Maui.Devices.IDeviceInfo.Idiom.get -> Microsoft.Maui.Devices.DeviceIdiom
 Microsoft.Maui.Devices.IDeviceInfo.Manufacturer.get -> string!
@@ -1066,6 +1067,7 @@ static Microsoft.Maui.Devices.DeviceIdiom.TV.get -> Microsoft.Maui.Devices.Devic
 static Microsoft.Maui.Devices.DeviceIdiom.Unknown.get -> Microsoft.Maui.Devices.DeviceIdiom
 static Microsoft.Maui.Devices.DeviceIdiom.Watch.get -> Microsoft.Maui.Devices.DeviceIdiom
 static Microsoft.Maui.Devices.DeviceInfo.Current.get -> Microsoft.Maui.Devices.IDeviceInfo!
+static Microsoft.Maui.Devices.DeviceInfo.DeviceId.get -> string!
 static Microsoft.Maui.Devices.DeviceInfo.DeviceType.get -> Microsoft.Maui.Devices.DeviceType
 static Microsoft.Maui.Devices.DeviceInfo.Idiom.get -> Microsoft.Maui.Devices.DeviceIdiom
 static Microsoft.Maui.Devices.DeviceInfo.Manufacturer.get -> string!

--- a/src/Essentials/src/PublicAPI/net-tizen/PublicAPI.Shipped.txt
+++ b/src/Essentials/src/PublicAPI/net-tizen/PublicAPI.Shipped.txt
@@ -530,6 +530,7 @@ Microsoft.Maui.Devices.IDeviceDisplay.KeepScreenOn.set -> void
 Microsoft.Maui.Devices.IDeviceDisplay.MainDisplayInfo.get -> Microsoft.Maui.Devices.DisplayInfo
 Microsoft.Maui.Devices.IDeviceDisplay.MainDisplayInfoChanged -> System.EventHandler<Microsoft.Maui.Devices.DisplayInfoChangedEventArgs!>!
 Microsoft.Maui.Devices.IDeviceInfo
+Microsoft.Maui.Devices.IDeviceInfo.DeviceId.get -> string!
 Microsoft.Maui.Devices.IDeviceInfo.DeviceType.get -> Microsoft.Maui.Devices.DeviceType
 Microsoft.Maui.Devices.IDeviceInfo.Idiom.get -> Microsoft.Maui.Devices.DeviceIdiom
 Microsoft.Maui.Devices.IDeviceInfo.Manufacturer.get -> string!
@@ -1015,6 +1016,7 @@ static Microsoft.Maui.Devices.DeviceIdiom.TV.get -> Microsoft.Maui.Devices.Devic
 static Microsoft.Maui.Devices.DeviceIdiom.Unknown.get -> Microsoft.Maui.Devices.DeviceIdiom
 static Microsoft.Maui.Devices.DeviceIdiom.Watch.get -> Microsoft.Maui.Devices.DeviceIdiom
 static Microsoft.Maui.Devices.DeviceInfo.Current.get -> Microsoft.Maui.Devices.IDeviceInfo!
+static Microsoft.Maui.Devices.DeviceInfo.DeviceId.get -> string!
 static Microsoft.Maui.Devices.DeviceInfo.DeviceType.get -> Microsoft.Maui.Devices.DeviceType
 static Microsoft.Maui.Devices.DeviceInfo.Idiom.get -> Microsoft.Maui.Devices.DeviceIdiom
 static Microsoft.Maui.Devices.DeviceInfo.Manufacturer.get -> string!

--- a/src/Essentials/src/PublicAPI/net-windows/PublicAPI.Shipped.txt
+++ b/src/Essentials/src/PublicAPI/net-windows/PublicAPI.Shipped.txt
@@ -528,6 +528,7 @@ Microsoft.Maui.Devices.IDeviceDisplay.KeepScreenOn.set -> void
 Microsoft.Maui.Devices.IDeviceDisplay.MainDisplayInfo.get -> Microsoft.Maui.Devices.DisplayInfo
 Microsoft.Maui.Devices.IDeviceDisplay.MainDisplayInfoChanged -> System.EventHandler<Microsoft.Maui.Devices.DisplayInfoChangedEventArgs!>!
 Microsoft.Maui.Devices.IDeviceInfo
+Microsoft.Maui.Devices.IDeviceInfo.DeviceId.get -> string!
 Microsoft.Maui.Devices.IDeviceInfo.DeviceType.get -> Microsoft.Maui.Devices.DeviceType
 Microsoft.Maui.Devices.IDeviceInfo.Idiom.get -> Microsoft.Maui.Devices.DeviceIdiom
 Microsoft.Maui.Devices.IDeviceInfo.Manufacturer.get -> string!
@@ -1016,6 +1017,7 @@ static Microsoft.Maui.Devices.DeviceIdiom.TV.get -> Microsoft.Maui.Devices.Devic
 static Microsoft.Maui.Devices.DeviceIdiom.Unknown.get -> Microsoft.Maui.Devices.DeviceIdiom
 static Microsoft.Maui.Devices.DeviceIdiom.Watch.get -> Microsoft.Maui.Devices.DeviceIdiom
 static Microsoft.Maui.Devices.DeviceInfo.Current.get -> Microsoft.Maui.Devices.IDeviceInfo!
+static Microsoft.Maui.Devices.DeviceInfo.DeviceId.get -> string!
 static Microsoft.Maui.Devices.DeviceInfo.DeviceType.get -> Microsoft.Maui.Devices.DeviceType
 static Microsoft.Maui.Devices.DeviceInfo.Idiom.get -> Microsoft.Maui.Devices.DeviceIdiom
 static Microsoft.Maui.Devices.DeviceInfo.Manufacturer.get -> string!

--- a/src/Essentials/src/PublicAPI/net/PublicAPI.Shipped.txt
+++ b/src/Essentials/src/PublicAPI/net/PublicAPI.Shipped.txt
@@ -515,6 +515,7 @@ Microsoft.Maui.Devices.IDeviceDisplay.KeepScreenOn.set -> void
 Microsoft.Maui.Devices.IDeviceDisplay.MainDisplayInfo.get -> Microsoft.Maui.Devices.DisplayInfo
 Microsoft.Maui.Devices.IDeviceDisplay.MainDisplayInfoChanged -> System.EventHandler<Microsoft.Maui.Devices.DisplayInfoChangedEventArgs!>!
 Microsoft.Maui.Devices.IDeviceInfo
+Microsoft.Maui.Devices.IDeviceInfo.DeviceId.get -> string!
 Microsoft.Maui.Devices.IDeviceInfo.DeviceType.get -> Microsoft.Maui.Devices.DeviceType
 Microsoft.Maui.Devices.IDeviceInfo.Idiom.get -> Microsoft.Maui.Devices.DeviceIdiom
 Microsoft.Maui.Devices.IDeviceInfo.Manufacturer.get -> string!
@@ -993,6 +994,7 @@ static Microsoft.Maui.Devices.DeviceIdiom.TV.get -> Microsoft.Maui.Devices.Devic
 static Microsoft.Maui.Devices.DeviceIdiom.Unknown.get -> Microsoft.Maui.Devices.DeviceIdiom
 static Microsoft.Maui.Devices.DeviceIdiom.Watch.get -> Microsoft.Maui.Devices.DeviceIdiom
 static Microsoft.Maui.Devices.DeviceInfo.Current.get -> Microsoft.Maui.Devices.IDeviceInfo!
+static Microsoft.Maui.Devices.DeviceInfo.DeviceId.get -> string!
 static Microsoft.Maui.Devices.DeviceInfo.DeviceType.get -> Microsoft.Maui.Devices.DeviceType
 static Microsoft.Maui.Devices.DeviceInfo.Idiom.get -> Microsoft.Maui.Devices.DeviceIdiom
 static Microsoft.Maui.Devices.DeviceInfo.Manufacturer.get -> string!

--- a/src/Essentials/src/PublicAPI/netstandard/PublicAPI.Shipped.txt
+++ b/src/Essentials/src/PublicAPI/netstandard/PublicAPI.Shipped.txt
@@ -515,6 +515,7 @@ Microsoft.Maui.Devices.IDeviceDisplay.KeepScreenOn.set -> void
 Microsoft.Maui.Devices.IDeviceDisplay.MainDisplayInfo.get -> Microsoft.Maui.Devices.DisplayInfo
 Microsoft.Maui.Devices.IDeviceDisplay.MainDisplayInfoChanged -> System.EventHandler<Microsoft.Maui.Devices.DisplayInfoChangedEventArgs!>!
 Microsoft.Maui.Devices.IDeviceInfo
+Microsoft.Maui.Devices.IDeviceInfo.DeviceId.get -> string!
 Microsoft.Maui.Devices.IDeviceInfo.DeviceType.get -> Microsoft.Maui.Devices.DeviceType
 Microsoft.Maui.Devices.IDeviceInfo.Idiom.get -> Microsoft.Maui.Devices.DeviceIdiom
 Microsoft.Maui.Devices.IDeviceInfo.Manufacturer.get -> string!
@@ -993,6 +994,7 @@ static Microsoft.Maui.Devices.DeviceIdiom.TV.get -> Microsoft.Maui.Devices.Devic
 static Microsoft.Maui.Devices.DeviceIdiom.Unknown.get -> Microsoft.Maui.Devices.DeviceIdiom
 static Microsoft.Maui.Devices.DeviceIdiom.Watch.get -> Microsoft.Maui.Devices.DeviceIdiom
 static Microsoft.Maui.Devices.DeviceInfo.Current.get -> Microsoft.Maui.Devices.IDeviceInfo!
+static Microsoft.Maui.Devices.DeviceInfo.DeviceId.get -> string!
 static Microsoft.Maui.Devices.DeviceInfo.DeviceType.get -> Microsoft.Maui.Devices.DeviceType
 static Microsoft.Maui.Devices.DeviceInfo.Idiom.get -> Microsoft.Maui.Devices.DeviceIdiom
 static Microsoft.Maui.Devices.DeviceInfo.Manufacturer.get -> string!

--- a/src/Essentials/test/DeviceTests/Tests/DeviceInfo_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/DeviceInfo_Tests.cs
@@ -10,6 +10,24 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 	public class DeviceInfo_Tests
 	{
 		[Fact]
+		public void IdIsSet()
+		{
+			var id = DeviceInfo.DeviceId;
+
+			Assert.NotNull(id);
+			Assert.NotEmpty(id);
+		}
+
+		[Fact]
+		public void IdIsRetained()
+		{
+			var id1 = DeviceInfo.DeviceId;
+			var id2 = DeviceInfo.DeviceId;
+
+			Assert.Equal(id1, id2);
+		}
+
+		[Fact]
 		public void Versions_Are_Correct()
 		{
 #if WINDOWS_UWP || WINDOWS


### PR DESCRIPTION
### Description of Change

Added Device ID to Essentials.DeviceInfo. Useful for distinguishing between various devices a user owns that your app may be installed on.

### API Changes

Added:

- `string IDeviceInfo.DeviceId { get; }`
- `static string DeviceInfo.DeviceId { get; }`
