### PR TITLE
Add hooks to disconnect/connect handler where developers can easily wire up handlers

### DIFF
--- a/src/Core/src/Handlers/IElementHandler.cs
+++ b/src/Core/src/Handlers/IElementHandler.cs
@@ -1,4 +1,6 @@
-﻿namespace Microsoft.Maui
+﻿using System.Collections.Generic;
+
+namespace Microsoft.Maui
 {
 	public interface IElementHandler
 	{
@@ -17,5 +19,17 @@
 		IElement? VirtualView { get; }
 
 		IMauiContext? MauiContext { get; }
+
+#pragma warning disable RS0016 // Add public types and members to the declared API
+
+#if NETSTANDARD2_0
+		void Disconnect(bool isDestroying);
+		void Connect();
+#else
+		void Disconnect(bool isDestroying) { }
+		void Connect() { }
+#endif
+
+#pragma warning restore RS0016 // Add public types and members to the declared API
 	}
 }

--- a/src/Core/tests/UnitTests/HandlerTests.cs
+++ b/src/Core/tests/UnitTests/HandlerTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Microsoft.Maui.Hosting;
 using Microsoft.Maui.Platform;
 using Xunit;
@@ -35,6 +36,115 @@ namespace Microsoft.Maui.UnitTests.Hosting
 				new ViewStub().ToPlatform(mauiContext)
 			);
 		}
+
+		[Fact]
+		public void BasicConnectAndDisconnect()
+		{
+			var mauiApp = MauiApp.CreateBuilder()
+				.ConfigureMauiHandlers(handlers => handlers.AddHandler<ViewStub, ViewHandlerWithConnectTracking>())
+				.Build();
+
+			var stub = new ViewStub();
+			var mauiContext = new MauiContext(mauiApp.Services);
+			var handler = stub.ToHandler(mauiContext) as ViewHandlerWithConnectTracking;
+			Assert.Empty(handler.DisconnectFrom);
+			Assert.Single(handler.ConnectedTo);
+			Assert.Contains(stub, handler.ConnectedTo);
+
+			(handler as IElementHandler).Disconnect(false);
+
+			Assert.Single(handler.DisconnectFrom);
+			Assert.Single(handler.ConnectedTo);
+			Assert.Contains(stub, handler.ConnectedTo);
+		}
+
+		[Fact]
+		public void SettingNewVirtualViewFiresConnectAndDisconnect()
+		{
+			var mauiApp = MauiApp.CreateBuilder()
+				.ConfigureMauiHandlers(handlers => handlers.AddHandler<ViewStub, ViewHandlerWithConnectTracking>())
+				.Build();
+
+			var stub = new ViewStub();
+			var stub2 = new ViewStub();
+
+			var mauiContext = new MauiContext(mauiApp.Services);
+			var handler = stub.ToHandler(mauiContext) as ViewHandlerWithConnectTracking;
+
+			handler.SetVirtualView(stub2);
+
+			Assert.Contains(stub, handler.ConnectedTo);
+			Assert.Contains(stub2, handler.ConnectedTo);
+			Assert.Contains(stub, handler.DisconnectFrom);
+		}
+
+		[Fact]
+		public void DisconnectWontFireTwice()
+		{
+			var mauiApp = MauiApp.CreateBuilder()
+				.ConfigureMauiHandlers(handlers => handlers.AddHandler<ViewStub, ViewHandlerWithConnectTracking>())
+				.Build();
+
+			var stub = new ViewStub();
+			var mauiContext = new MauiContext(mauiApp.Services);
+			var handler = stub.ToHandler(mauiContext) as ViewHandlerWithConnectTracking;
+
+			(handler as IElementHandler).Disconnect(false);
+			(handler as IElementHandler).Disconnect(false);
+
+			Assert.Single(handler.DisconnectFrom);
+		}
+
+		[Fact]
+		public void ConnectWontFireTwice()
+		{
+			var mauiApp = MauiApp.CreateBuilder()
+				.ConfigureMauiHandlers(handlers => handlers.AddHandler<ViewStub, ViewHandlerWithConnectTracking>())
+				.Build();
+
+			var stub = new ViewStub();
+			var mauiContext = new MauiContext(mauiApp.Services);
+			var handler = stub.ToHandler(mauiContext) as ViewHandlerWithConnectTracking;
+
+			(handler as IElementHandler).Connect();
+			(handler as IElementHandler).Connect();
+
+			Assert.Single(handler.ConnectedTo);
+		}
+
+		class ViewHandlerWithConnectTracking : ViewHandlerStub
+		{
+			public bool IsDestroyed { get; set; }
+			public bool IsConnected { get; set; }
+
+			public List<object> ConnectedTo = new List<object>();
+			public List<object> DisconnectFrom = new List<object>();
+
+			protected override void Connect()
+			{
+				if (IsConnected)
+					throw new Exception("Handler has already been connected");
+
+				if (IsDestroyed)
+					throw new Exception("Handler has already been destroyed");
+
+				base.Connect();
+				ConnectedTo.Add(VirtualView);
+				IsConnected = true;
+			}
+
+			protected override void Disconnect(bool isDestroying)
+			{
+				if (IsDestroyed)
+					throw new Exception("Handler has already been destroyed");
+
+				IsDestroyed = isDestroying;
+				base.Disconnect(isDestroying);
+				DisconnectFrom.Add(VirtualView);
+				IsConnected = false;
+			}
+		}
+
 
 		class ViewHandlerWithChildException : ViewHandlerStub
 		{


### PR DESCRIPTION
### Description of Change

Create a set of Handler hooks where the UI Framework can inform the `Handler` that this might be a good time to disconnect itself from any parts of a `PlatformView` that might lead to memory leaks.

### Fixed

- #16332
