### PR TITLE
[uitests] Don't continue pipeline if appium install fails

### DIFF
--- a/eng/pipelines/common/ui-tests-steps.yml
+++ b/eng/pipelines/common/ui-tests-steps.yml
@@ -38,7 +38,8 @@ steps:
 
   - pwsh: ./eng/scripts/appium-install.ps1
     displayName: "Install Appium"
-    continueOnError: true
+    continueOnError: false
+    retryCountOnTaskFailure: 2
 
   - pwsh: ./build.ps1 --target=dotnet --configuration="${{ parameters.configuration }}" --verbosity=diagnostic
     displayName: 'Install .NET'

--- a/eng/pipelines/common/ui-tests-steps.yml
+++ b/eng/pipelines/common/ui-tests-steps.yml
@@ -39,7 +39,7 @@ steps:
   - pwsh: ./eng/scripts/appium-install.ps1
     displayName: "Install Appium"
     continueOnError: false
-    retryCountOnTaskFailure: 2
+    retryCountOnTaskFailure: 1
 
   - pwsh: ./build.ps1 --target=dotnet --configuration="${{ parameters.configuration }}" --verbosity=diagnostic
     displayName: 'Install .NET'


### PR DESCRIPTION
### Description of Change

The Appium install scripts fails a couple of times, but it allows to continue the pipeline, we are changing that so if it fails we will retry to install again, but if keeps failing we just fail the pipeline. 

Work on the script should be done to make it more resilient 