### PR TITLE
[iOS] Re-enable editor tests

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Editor/EditorTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Editor/EditorTests.cs
@@ -10,9 +10,6 @@ namespace Microsoft.Maui.DeviceTests
 	[Category(TestCategory.Editor)]
 	public partial class EditorTests : ControlsHandlerTestBase
 	{
-#if !IOS && !MACCATALYST
-		// iOS is broken until this point
-		// https://github.com/dotnet/maui/issues/3425
 		[Theory]
 		[InlineData(EditorAutoSizeOption.Disabled)]
 		[InlineData(EditorAutoSizeOption.TextChanges)]
@@ -32,23 +29,36 @@ namespace Microsoft.Maui.DeviceTests
 				}
 			};
 
-			await CreateHandlerAndAddToWindow<LayoutHandler>(layout, (_) =>
+			await CreateHandlerAndAddToWindow<LayoutHandler>(layout, async (_) =>
 			{
-				layout.Arrange(new Graphics.Rect(Graphics.Point.Zero, layout.Measure(1000, 1000)));
+				var frame = editor.Frame;
+
+				layout.Arrange(new Graphics.Rect(Graphics.Point.Zero, layout.Measure(100, 100)));
+				await WaitForUIUpdate(frame, editor);
+
 				var initialHeight = editor.Height;
-
-				editor.Text += Environment.NewLine + " Some new text" + Environment.NewLine;
+			
+				editor.Text += Environment.NewLine + " Some new text" + Environment.NewLine + " Some new text" + Environment.NewLine;
+				
 				layout.Arrange(new Graphics.Rect(Graphics.Point.Zero, layout.Measure(1000, 1000)));
+				await WaitForUIUpdate(frame, editor);
 
-				if (option == EditorAutoSizeOption.Disabled)
-					Assert.Equal(initialHeight, editor.Height);
-				else
+				if (option == EditorAutoSizeOption.TextChanges)
 					Assert.True(initialHeight < editor.Height);
-
-				return Task.CompletedTask;
+				else
+					Assert.Equal(initialHeight, editor.Height);
 			});
 		}
-#endif
+
+		static async Task WaitForUIUpdate(Graphics.Rect frame, Editor collectionView, int timeout = 1000, int interval = 100)
+		{
+			// Wait for layout to happen
+			while (collectionView.Frame == frame && timeout >= 0)
+			{
+				await Task.Delay(interval);
+				timeout -= interval;
+			}
+		}
 
 #if WINDOWS
 		// Only Windows needs the IsReadOnly workaround for MaxLength==0 to prevent text from being entered

--- a/src/Controls/tests/DeviceTests/Elements/Editor/EditorTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Editor/EditorTests.cs
@@ -21,32 +21,6 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
-		[Fact(DisplayName = "Does Not Leak")]
-		public async Task DoesNotLeak()
-		{
-			SetupBuilder();
-
-			WeakReference viewReference = null;
-			WeakReference platformViewReference = null;
-			WeakReference handlerReference = null;
-
-			await InvokeOnMainThreadAsync(() =>
-			{
-				var layout = new Grid();
-				var editor = new Editor();
-				layout.Add(editor);
-				var handler = CreateHandler<LayoutHandler>(layout);
-				viewReference = new WeakReference(editor);
-				handlerReference = new WeakReference(editor.Handler);
-				platformViewReference = new WeakReference(editor.Handler.PlatformView);
-			});
-
-			await AssertionExtensions.WaitForGC(viewReference, handlerReference, platformViewReference);
-			Assert.False(viewReference.IsAlive, "Editor should not be alive!");
-			Assert.False(handlerReference.IsAlive, "Handler should not be alive!");
-			Assert.False(platformViewReference.IsAlive, "PlatformView should not be alive!");
-		}
-    
 		[Theory]
 		[InlineData(EditorAutoSizeOption.Disabled)]
 		[InlineData(EditorAutoSizeOption.TextChanges)]
@@ -74,9 +48,9 @@ namespace Microsoft.Maui.DeviceTests
 				await WaitForUIUpdate(frame, editor);
 
 				var initialHeight = editor.Height;
-			
+
 				editor.Text += Environment.NewLine + " Some new text" + Environment.NewLine + " Some new text" + Environment.NewLine;
-				
+
 				layout.Arrange(new Graphics.Rect(Graphics.Point.Zero, layout.Measure(1000, 1000)));
 				await WaitForUIUpdate(frame, editor);
 


### PR DESCRIPTION
### Description of Change

Re-enable editor tests on iOS.

<img width="366" alt="Captura de pantalla 2023-07-26 a las 10 55 34" src="https://github.com/dotnet/maui/assets/6755973/501ad45c-7a30-49e1-b420-6c8c2b1a4cc7">

Also tested with the Gallery:
![testing-editor](https://github.com/dotnet/maui/assets/6755973/950cafe9-a73c-4c99-852f-344bb70eeaf6)

### Issues Fixed

Fixes #3425 
