### PR TITLE
[build] Bump XCode to 14.3.1

### DIFF
--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -8,9 +8,9 @@ variables:
 - name: DOTNET_VERSION
   value: 7.0.203
 - name: REQUIRED_XCODE
-  value: 14.3.0
+  value: 14.3.1
 - name: DEVICETESTS_REQUIRED_XCODE
-  value: 14.3.0
+  value: 14.3.1
 - name: LocBranchPrefix
   value: 'loc-hb'
 - name: isMainBranch


### PR DESCRIPTION
### Description of Change

Fixes warning:

```
ILLINK : warning MT0079: The recommended Xcode version for Microsoft.iOS 16.4.8690 is Xcode 14.3.1 or later. The current Xcode version (found in /Applications/Xcode_14.3.0.app/Contents/Developer) is 14.3. [/Users/builder/azdo/_work/3/s/src/TestUtils/samples/DeviceTests.Sample/TestUtils.DeviceTests.Sample.csproj::TargetFramework=net8.0-ios]
```