### PR TITLE
[net8.0] Bump aspnet packages 8.0.0-preview.7

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -35,49 +35,49 @@
     <Dependency Name="Microsoft.WindowsAppSDK" Version="0.0.1">
       <Uri>https://dev.azure.com/microsoft/ProjectReunion/_git/ProjectReunionInternal</Uri>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authorization" Version="8.0.0-preview.6.23318.1">
+    <Dependency Name="Microsoft.AspNetCore.Authorization" Version="8.0.0-preview.7.23364.32">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>9178b9b117e64ca75821db1927e4857714c5da97</Sha>
+      <Sha>240377059ec25b4d9d86d4188a26722e55edc5a1</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.Facebook" Version="8.0.0-preview.6.23318.1">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.Facebook" Version="8.0.0-preview.7.23364.32">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>9178b9b117e64ca75821db1927e4857714c5da97</Sha>
+      <Sha>240377059ec25b4d9d86d4188a26722e55edc5a1</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.Google" Version="8.0.0-preview.6.23318.1">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.Google" Version="8.0.0-preview.7.23364.32">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>9178b9b117e64ca75821db1927e4857714c5da97</Sha>
+      <Sha>240377059ec25b4d9d86d4188a26722e55edc5a1</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="8.0.0-preview.6.23318.1">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="8.0.0-preview.7.23364.32">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>9178b9b117e64ca75821db1927e4857714c5da97</Sha>
+      <Sha>240377059ec25b4d9d86d4188a26722e55edc5a1</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components" Version="8.0.0-preview.6.23318.1">
+    <Dependency Name="Microsoft.AspNetCore.Components" Version="8.0.0-preview.7.23364.32">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>9178b9b117e64ca75821db1927e4857714c5da97</Sha>
+      <Sha>240377059ec25b4d9d86d4188a26722e55edc5a1</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Analyzers" Version="8.0.0-preview.6.23318.1">
+    <Dependency Name="Microsoft.AspNetCore.Components.Analyzers" Version="8.0.0-preview.7.23364.32">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>9178b9b117e64ca75821db1927e4857714c5da97</Sha>
+      <Sha>240377059ec25b4d9d86d4188a26722e55edc5a1</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Forms" Version="8.0.0-preview.6.23318.1">
+    <Dependency Name="Microsoft.AspNetCore.Components.Forms" Version="8.0.0-preview.7.23364.32">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>9178b9b117e64ca75821db1927e4857714c5da97</Sha>
+      <Sha>240377059ec25b4d9d86d4188a26722e55edc5a1</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebView" Version="8.0.0-preview.6.23318.1">
+    <Dependency Name="Microsoft.AspNetCore.Components.WebView" Version="8.0.0-preview.7.23364.32">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>9178b9b117e64ca75821db1927e4857714c5da97</Sha>
+      <Sha>240377059ec25b4d9d86d4188a26722e55edc5a1</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Web" Version="8.0.0-preview.6.23318.1">
+    <Dependency Name="Microsoft.AspNetCore.Components.Web" Version="8.0.0-preview.7.23364.32">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>9178b9b117e64ca75821db1927e4857714c5da97</Sha>
+      <Sha>240377059ec25b4d9d86d4188a26722e55edc5a1</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Metadata" Version="8.0.0-preview.6.23318.1">
+    <Dependency Name="Microsoft.AspNetCore.Metadata" Version="8.0.0-preview.7.23364.32">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>9178b9b117e64ca75821db1927e4857714c5da97</Sha>
+      <Sha>240377059ec25b4d9d86d4188a26722e55edc5a1</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.JSInterop" Version="8.0.0-preview.6.23318.1">
+    <Dependency Name="Microsoft.JSInterop" Version="8.0.0-preview.7.23364.32">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>9178b9b117e64ca75821db1927e4857714c5da97</Sha>
+      <Sha>240377059ec25b4d9d86d4188a26722e55edc5a1</Sha>
     </Dependency>
     <Dependency Name="Microsoft.TemplateEngine.Tasks" Version="7.0.100-preview.2.22102.8">
       <Uri>https://github.com/dotnet/templating</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -29,17 +29,17 @@
     <MicrosoftWindowsSDKBuildToolsPackageVersion>10.0.22621.756</MicrosoftWindowsSDKBuildToolsPackageVersion>
     <MicrosoftGraphicsWin2DPackageVersion>1.0.5.1</MicrosoftGraphicsWin2DPackageVersion>
     <!-- Everything else -->
-    <MicrosoftAspNetCoreAuthorizationPackageVersion>8.0.0-preview.6.23318.1</MicrosoftAspNetCoreAuthorizationPackageVersion>
-    <MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>8.0.0-preview.6.23318.1</MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>
-    <MicrosoftAspNetCoreAuthenticationGooglePackageVersion>8.0.0-preview.6.23318.1</MicrosoftAspNetCoreAuthenticationGooglePackageVersion>
-    <MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>8.0.0-preview.6.23318.1</MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>
-    <MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>8.0.0-preview.6.23318.1</MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>
-    <MicrosoftAspNetCoreComponentsFormsPackageVersion>8.0.0-preview.6.23318.1</MicrosoftAspNetCoreComponentsFormsPackageVersion>
-    <MicrosoftAspNetCoreComponentsPackageVersion>8.0.0-preview.6.23318.1</MicrosoftAspNetCoreComponentsPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebPackageVersion>8.0.0-preview.6.23318.1</MicrosoftAspNetCoreComponentsWebPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebViewPackageVersion>8.0.0-preview.6.23318.1</MicrosoftAspNetCoreComponentsWebViewPackageVersion>
-    <MicrosoftAspNetCoreMetadataPackageVersion>8.0.0-preview.6.23318.1</MicrosoftAspNetCoreMetadataPackageVersion>
-    <MicrosoftJSInteropPackageVersion>8.0.0-preview.6.23318.1</MicrosoftJSInteropPackageVersion>
+    <MicrosoftAspNetCoreAuthorizationPackageVersion>8.0.0-preview.7.23364.32</MicrosoftAspNetCoreAuthorizationPackageVersion>
+    <MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>8.0.0-preview.7.23364.32</MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>
+    <MicrosoftAspNetCoreAuthenticationGooglePackageVersion>8.0.0-preview.7.23364.32</MicrosoftAspNetCoreAuthenticationGooglePackageVersion>
+    <MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>8.0.0-preview.7.23364.32</MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>
+    <MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>8.0.0-preview.7.23364.32</MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>
+    <MicrosoftAspNetCoreComponentsFormsPackageVersion>8.0.0-preview.7.23364.32</MicrosoftAspNetCoreComponentsFormsPackageVersion>
+    <MicrosoftAspNetCoreComponentsPackageVersion>8.0.0-preview.7.23364.32</MicrosoftAspNetCoreComponentsPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebPackageVersion>8.0.0-preview.7.23364.32</MicrosoftAspNetCoreComponentsWebPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebViewPackageVersion>8.0.0-preview.7.23364.32</MicrosoftAspNetCoreComponentsWebViewPackageVersion>
+    <MicrosoftAspNetCoreMetadataPackageVersion>8.0.0-preview.7.23364.32</MicrosoftAspNetCoreMetadataPackageVersion>
+    <MicrosoftJSInteropPackageVersion>8.0.0-preview.7.23364.32</MicrosoftJSInteropPackageVersion>
     <!-- Other packages -->
     <MicrosoftCodeAnalysisNetAnalyzersVersion>8.0.0-preview1.23067.2</MicrosoftCodeAnalysisNetAnalyzersVersion>
     <MicrosoftCodeAnalysisPublicApiAnalyzersVersion>3.3.3</MicrosoftCodeAnalysisPublicApiAnalyzersVersion>


### PR DESCRIPTION
### Description of Change

Manually bump to a previous version of AspNetCore packages to version 8.0.0-preview.7.23364.32. Get this instead of #16340 .

Found the aspnet commit by looking at versions on the dotnet8 feed https://dev.azure.com/dnceng/public/_artifacts/feed/dotnet8/NuGet/Microsoft.AspNetCore.Components.Web/overview/8.0.0-preview.7.23364.32 
I used the following `darc` commands.

```
PS C:\repos\dotnet\maui> darc get-build --commit 240377059ec25b4d9d86d4188a26722e55edc5a1 --repo https://github.com/dotnet/aspnetcore
Repository:    https://github.com/dotnet/aspnetcore
Branch:        main
Commit:        240377059ec25b4d9d86d4188a26722e55edc5a1
Build Number:  20230714.32
Date Produced: 7/15/2023 1:17 AM
Build Link:    https://dev.azure.com/dnceng/internal/_build/results?buildId=2222507
AzDO Build Id: 2222507
BAR Build Id:  185142
Released:      False
Channels:
- .NET 8

darc get-build --commit 240377059ec25b4d9d86d4188a26722e55edc5a1 --repo https://github.com/dotnet/aspnetcore
PS C:\repos\dotnet\maui> darc update-dependencies --channel ".NET 8 Preview 7" --id 185142
Looking up build with BAR id 185142
Updating 'Microsoft.AspNetCore.Authentication.Facebook': '8.0.0-preview.6.23318.1' => '8.0.0-preview.7.23364.32' (from build '20230714.32' of 'https://github.com/dotnet/aspnetcore')
Updating 'Microsoft.AspNetCore.Authentication.Google': '8.0.0-preview.6.23318.1' => '8.0.0-preview.7.23364.32' (from build '20230714.32' of 'https://github.com/dotnet/aspnetcore')
Updating 'Microsoft.AspNetCore.Authentication.MicrosoftAccount': '8.0.0-preview.6.23318.1' => '8.0.0-preview.7.23364.32' (from build '20230714.32' of 'https://github.com/dotnet/aspnetcore')
Updating 'Microsoft.AspNetCore.Authorization': '8.0.0-preview.6.23318.1' => '8.0.0-preview.7.23364.32' (from build '20230714.32' of 'https://github.com/dotnet/aspnetcore')
Updating 'Microsoft.AspNetCore.Components': '8.0.0-preview.6.23318.1' => '8.0.0-preview.7.23364.32' (from build '20230714.32' of 'https://github.com/dotnet/aspnetcore')
Updating 'Microsoft.AspNetCore.Components.Analyzers': '8.0.0-preview.6.23318.1' => '8.0.0-preview.7.23364.32' (from build '20230714.32' of 'https://github.com/dotnet/aspnetcore')
Updating 'Microsoft.AspNetCore.Components.Forms': '8.0.0-preview.6.23318.1' => '8.0.0-preview.7.23364.32' (from build '20230714.32' of 'https://github.com/dotnet/aspnetcore')
Updating 'Microsoft.AspNetCore.Components.Web': '8.0.0-preview.6.23318.1' => '8.0.0-preview.7.23364.32' (from build '20230714.32' of 'https://github.com/dotnet/aspnetcore')
Updating 'Microsoft.AspNetCore.Components.WebView': '8.0.0-preview.6.23318.1' => '8.0.0-preview.7.23364.32' (from build '20230714.32' of 'https://github.com/dotnet/aspnetcore')
Updating 'Microsoft.AspNetCore.Metadata': '8.0.0-preview.6.23318.1' => '8.0.0-preview.7.23364.32' (from build '20230714.32' of 'https://github.com/dotnet/aspnetcore')
Updating 'Microsoft.JSInterop': '8.0.0-preview.6.23318.1' => '8.0.0-preview.7.23364.32' (from build '20230714.32' of 'https://github.com/dotnet/aspnetcore')
Checking for coherency updates...
Using 'Strict' coherency mode. If this fails, a second attempt utilizing 'Legacy' Coherency mode will be made.
Local dependencies updated based on build with BAR id 185142 (20230714.32 from https://github.com/dotnet/aspnetcore@main)
```
