### PR TITLE
[ios] fix memory leak in RefreshView

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/RefreshView/RefreshViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/RefreshView/RefreshViewTests.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Hosting;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	[Category(TestCategory.RefreshView)]
+	public partial class RefreshViewTests : ControlsHandlerTestBase
+	{
+		void SetupBuilder()
+		{
+			EnsureHandlerCreated(builder =>
+			{
+				builder.ConfigureMauiHandlers(handlers =>
+				{
+					handlers.AddHandler<RefreshView, RefreshViewHandler>();
+				});
+			});
+		}
+
+		[Fact(DisplayName = "Does Not Leak")]
+		public async Task DoesNotLeak()
+		{
+			SetupBuilder();
+
+			WeakReference viewReference = null;
+			WeakReference platformViewReference = null;
+			WeakReference handlerReference = null;
+
+			await InvokeOnMainThreadAsync(() =>
+			{
+				var layout = new Grid();
+				var refreshView = new RefreshView();
+				layout.Add(refreshView);
+				var handler = CreateHandler<LayoutHandler>(layout);
+				viewReference = new WeakReference(refreshView);
+				handlerReference = new WeakReference(refreshView.Handler);
+				platformViewReference = new WeakReference(refreshView.Handler.PlatformView);
+			});
+
+			await AssertionExtensions.WaitForGC(viewReference, handlerReference, platformViewReference);
+			Assert.False(viewReference.IsAlive, "RefreshView should not be alive!");
+			Assert.False(handlerReference.IsAlive, "Handler should not be alive!");
+			Assert.False(platformViewReference.IsAlive, "PlatformView should not be alive!");
+		}
+	}
+}
+

--- a/src/Controls/tests/DeviceTests/TestCategory.cs
+++ b/src/Controls/tests/DeviceTests/TestCategory.cs
@@ -32,6 +32,7 @@
 		public const string Path = "Path";
 		public const string Picker = "Picker";
 		public const string RadioButton = "RadioButton";
+		public const string RefreshView = "RefreshView";
 		public const string ScrollView = "ScrollView";
 		public const string SearchBar = "SearchBar";
 		public const string Shape = "Shape";

--- a/src/Core/src/Platform/iOS/MauiRefreshView.cs
+++ b/src/Core/src/Platform/iOS/MauiRefreshView.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Collections.Generic;
 using System.Text;
 using CoreGraphics;
@@ -14,8 +15,11 @@ namespace Microsoft.Maui.Platform
 		bool _isRefreshing;
 		nfloat _originalY;
 		nfloat _refreshControlHeight;
+		[UnconditionalSuppressMessage("Memory", "MA0002", Justification = "Proven safe in test: RefreshViewTests.DoesNotLeak")]
 		UIView _refreshControlParent;
+		[UnconditionalSuppressMessage("Memory", "MA0002", Justification = "Proven safe in test: RefreshViewTests.DoesNotLeak")]
 		UIView? _contentView;
+		[UnconditionalSuppressMessage("Memory", "MA0002", Justification = "Proven safe in test: RefreshViewTests.DoesNotLeak")]
 		UIRefreshControl _refreshControl;
 		public UIRefreshControl RefreshControl => _refreshControl;
 


### PR DESCRIPTION
Context: https://github.com/dotnet/maui/pull/16346

This addresses the memory leak discovered by:

    src/Core/src/Platform/iOS/MauiRefreshView.cs(17,10): error MA0002: Member '_refreshControlParent' could cause memory leaks in an NSObject subclass. Remove the member, store the value as a WeakReference, or add the [UnconditionalSuppressMessage("Memory", "MA0002")] attribute with a justification as to why the member will not leak.
    src/Core/src/Platform/iOS/MauiRefreshView.cs(18,11): error MA0002: Member '_contentView' could cause memory leaks in an NSObject subclass. Remove the member, store the value as a WeakReference, or add the [UnconditionalSuppressMessage("Memory", "MA0002")] attribute with a justification as to why the member will not leak.
    src/Core/src/Platform/iOS/MauiRefreshView.cs(19,20): error MA0002: Member '_refreshControl' could cause memory leaks in an NSObject subclass. Remove the member, store the value as a WeakReference, or add the [UnconditionalSuppressMessage("Memory", "MA0002")] attribute with a justification as to why the member will not leak.

I could reproduce a leak in a test such as:

    await InvokeOnMainThreadAsync(() =>
    {
        var layout = new Grid();
        var refreshView = new RefreshView();
        layout.Add(refreshView);
        var handler = CreateHandler<LayoutHandler>(layout);
        viewReference = new WeakReference(refreshView);
        handlerReference = new WeakReference(refreshView.Handler);
        platformViewReference = new WeakReference(refreshView.Handler.PlatformView);
    });

    await AssertionExtensions.WaitForGC(viewReference, handlerReference, platformViewReference);
    Assert.False(viewReference.IsAlive, "RefreshView should not be alive!");
    Assert.False(handlerReference.IsAlive, "Handler should not be alive!");
    Assert.False(platformViewReference.IsAlive, "PlatformView should not be alive!");

Solved the issues by making a non-NSObject `MauiRefreshViewProxy` class.
