### PR TITLE
Process the hardware enter key as "Done"

### DIFF
--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issue16386.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issue16386.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.Maui.Controls;
+
+namespace Maui.Controls.Sample.Issues
+{
+	[Issue(IssueTracker.Github, 16386, "Process the hardware enter key as \"Done\"", PlatformAffected.Android)]
+	public class Issue16386 : TestContentPage
+	{
+		protected override void Init()
+		{
+			var entry = new Entry()
+			{
+				AutomationId = "HardwareEnterKeyEntry"
+			};
+
+			Content = 
+				new VerticalStackLayout() 
+				{ 
+					new Label()
+					{
+						Text = "Focus entry and hit the Enter key on the hardware keyboard. A success label should appear."
+					},
+					entry
+				};
+		
+			entry.Completed += (sender, args) =>
+			{
+				(Content as VerticalStackLayout)
+					.Children.Add(new Label() { Text = "Success", AutomationId = "Success" });
+			};
+		}
+	}
+}

--- a/src/Controls/tests/UITests/Tests/Issues/Issue16386.cs
+++ b/src/Controls/tests/UITests/Tests/Issues/Issue16386.cs
@@ -1,0 +1,33 @@
+﻿using NUnit.Framework;
+using OpenQA.Selenium;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.AppiumTests.Issues
+{
+	public class Issue16386 : _IssuesUITest
+	{
+		public Issue16386(TestDevice device)
+			: base(device)
+		{ }
+
+		public override string Issue => "Process the hardware enter key as \"Done\"";
+
+		[Test]
+		public void HittingEnterKeySendsDone()
+		{
+			App.Click("HardwareEnterKeyEntry");
+			
+			if (Device == TestDevice.Android || Device == TestDevice.Windows)
+			{
+				App.SendKeys(66);
+			}
+			else
+			{
+				App.WaitForElement("HardwareEnterKeyEntry").SendKeys(Keys.Enter);
+			}
+
+			App.WaitForElement("Success");
+		}
+	}
+}

--- a/src/Controls/tests/UITests/Tests/Issues/Issue16386.cs
+++ b/src/Controls/tests/UITests/Tests/Issues/Issue16386.cs
@@ -17,16 +17,14 @@ namespace Microsoft.Maui.AppiumTests.Issues
 		public void HittingEnterKeySendsDone()
 		{
 			App.Click("HardwareEnterKeyEntry");
-			
-			if (Device == TestDevice.Android || Device == TestDevice.Windows)
+			this.IgnoreIfPlatforms(new[]
 			{
-				App.SendKeys(66);
-			}
-			else
-			{
-				App.WaitForElement("HardwareEnterKeyEntry").SendKeys(Keys.Enter);
-			}
+				TestDevice.Mac,
+				TestDevice.iOS,
+				TestDevice.Windows,
+			});
 
+			App.SendKeys(66);
 			App.WaitForElement("Success");
 		}
 	}

--- a/src/Controls/tests/UITests/Tests/Issues/Issue16386.cs
+++ b/src/Controls/tests/UITests/Tests/Issues/Issue16386.cs
@@ -16,7 +16,6 @@ namespace Microsoft.Maui.AppiumTests.Issues
 		[Test]
 		public void HittingEnterKeySendsDone()
 		{
-			App.Click("HardwareEnterKeyEntry");
 			this.IgnoreIfPlatforms(new[]
 			{
 				TestDevice.Mac,
@@ -24,6 +23,7 @@ namespace Microsoft.Maui.AppiumTests.Issues
 				TestDevice.Windows,
 			});
 
+			App.Click("HardwareEnterKeyEntry");
 			App.SendKeys(66);
 			App.WaitForElement("Success");
 		}

--- a/src/Core/src/Handlers/Entry/EntryHandler.Android.cs
+++ b/src/Core/src/Handlers/Entry/EntryHandler.Android.cs
@@ -2,6 +2,7 @@
 using Android.Graphics.Drawables;
 using Android.Text;
 using Android.Views;
+using Android.Views.InputMethods;
 using AndroidX.AppCompat.Widget;
 using AndroidX.Core.Content;
 using static Android.Views.View;
@@ -193,17 +194,40 @@ namespace Microsoft.Maui.Handlers
 		{
 			var returnType = VirtualView?.ReturnType;
 
+			// Inside of the android implementations that map events to listeners, the default return value for "Handled" is always true
+			// This means, just by subscribing to EditorAction/KeyPressed/etc.. you change the behavior of the control
+			// So, we are setting handled to false here in order to maintain default behavior
+			bool handled = false;
 			if (returnType != null)
 			{
-				var currentInputImeFlag = returnType.Value.ToPlatform();
+				var actionId = e.ActionId;
+				var evt = e.Event;
+				ImeAction currentInputImeFlag = PlatformView.ImeOptions;
 
-				if (e.IsCompletedAction(currentInputImeFlag))
+				// On API 34 it looks like they fixed the issue where the actionId is ImeAction.ImeNull when using a keyboard
+				// so I'm just setting the actionId here to the current ImeOptions so the logic can all be simplified
+				if (actionId == ImeAction.ImeNull && evt?.KeyCode == Keycode.Enter)
+				{
+					actionId = currentInputImeFlag;
+				}
+
+				// keyboard path
+				if (evt?.KeyCode == Keycode.Enter && evt?.Action == KeyEventActions.Down)
+				{
+					handled = true;
+				}
+				else if (evt?.KeyCode == Keycode.Enter && evt?.Action == KeyEventActions.Up)
+				{
+					VirtualView?.Completed();
+				}
+				// InputPaneView Path
+				else if(evt?.KeyCode is null && (actionId == ImeAction.Done || actionId == currentInputImeFlag))
 				{
 					VirtualView?.Completed();
 				}
 			}
 
-			e.Handled = false;
+			e.Handled = handled;
 		}
 
 		private void OnSelectionChanged(object? sender, EventArgs e)

--- a/src/Core/src/Handlers/Entry/EntryHandler.Windows.cs
+++ b/src/Core/src/Handlers/Entry/EntryHandler.Windows.cs
@@ -123,10 +123,6 @@ namespace Microsoft.Maui.Handlers
 			{
 				PlatformView?.TryMoveFocus(FocusNavigationDirection.Next);
 			}
-			else
-			{
-				// TODO: Hide the soft keyboard; this matches the behavior of .NET MAUI on Android/iOS
-			}
 
 			VirtualView?.Completed();
 		}

--- a/src/Core/src/Platform/Android/EditTextExtensions.cs
+++ b/src/Core/src/Platform/Android/EditTextExtensions.cs
@@ -320,10 +320,17 @@ namespace Microsoft.Maui.Platform
 			editText.SetSelection(previousCursorPosition);
 		}
 
-		internal static bool IsCompletedAction(this EditorActionEventArgs e, ImeAction? currentInputImeFlag)
+		internal static bool IsCompletedAction(this EditorActionEventArgs e, ImeAction currentInputImeFlag)
 		{
 			var actionId = e.ActionId;
 			var evt = e.Event;
+
+			// On API 34 it looks like they fixed the issue where the actionId is ImeAction.ImeNull when using a keyboard
+			// so I'm just setting the actionId here to whatever the user has 
+			if (actionId == ImeAction.ImeNull && evt?.KeyCode == Keycode.Enter)
+			{
+				actionId = currentInputImeFlag;
+			}
 
 			return
 				actionId == ImeAction.Done ||

--- a/src/TestUtils/src/UITest.Appium/HelperExtensions.cs
+++ b/src/TestUtils/src/UITest.Appium/HelperExtensions.cs
@@ -1,11 +1,7 @@
 using System.Collections.Immutable;
-using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Drawing;
-using System.Xml.Linq;
-using OpenQA.Selenium;
-using OpenQA.Selenium.Appium;
-using OpenQA.Selenium.Appium.MultiTouch;
+using OpenQA.Selenium.Appium.Interfaces;
 using UITest.Core;
 
 namespace UITest.Appium
@@ -78,6 +74,22 @@ namespace UITest.Appium
 			var response = app.CommandExecutor.Execute("isKeyboardShown", ImmutableDictionary<string, object>.Empty);
 			var responseValue = response?.Value ?? false;
 			return (bool)responseValue;
+		}
+
+		public static void SendKeys(this IApp app, int keyCode, int metastate = 0)
+		{
+			if (app is not AppiumApp aaa)
+			{
+				throw new InvalidOperationException($"SendKeys is only supported on AppiumApp");
+			}
+
+			if (aaa.Driver is ISendsKeyEvents ske)
+			{
+				ske.PressKeyCode(keyCode, metastate);
+				return;
+			}
+			
+			throw new InvalidOperationException($"SendKeys is not supported on {aaa.Driver}");
 		}
 
 		public static void ClearText(this IApp app, string element)

--- a/src/TestUtils/src/UITest.Appium/HelperExtensions.cs
+++ b/src/TestUtils/src/UITest.Appium/HelperExtensions.cs
@@ -76,6 +76,13 @@ namespace UITest.Appium
 			return (bool)responseValue;
 		}
 
+		/// <summary>
+		/// (Android Only) Sends a device key event with meta state.
+		/// </summary>
+		/// <param name="app"></param>
+		/// <param name="keyCode"> Code for the key pressed on the Android device</param>
+		/// <param name="metastate">metastate for the key press</param>
+		/// <exception cref="InvalidOperationException"></exception>
 		public static void SendKeys(this IApp app, int keyCode, int metastate = 0)
 		{
 			if (app is not AppiumApp aaa)


### PR DESCRIPTION
### Description of Change

Alternative PR from https://github.com/dotnet/maui/pull/14972

This makes android fire completed anytime a user hits the enter key. This behavior now matches iOS and Windows when hitting the enter key on a physical keyboard. This behavior is still different than XF because the focus will still move to the next input control. I realize that behavior will somewhat frustrate XF migration, but keyboard users expect the keyboard to navigate forward so for us to break that default behavior for keyboard users isn't ideal. If the developer wants the entry to capture the keyboard then it's on them to subscribe to the platform view and mark the event as handled.

We'll still need the manual tests because from what I can tell we can't write an automated test for WinUI/iOS/Catalyst

The ultimate fix here would probably be to add our own EditorActions or once we actually have keyboard events in MAUI then users could just interpret these events themselves.

### Issues Fixed

Fixes #13921
Fixes #18370


