### PR TITLE
Revert "[vs-workload][net8.0] Set EnableSideBySideManifests=true 

### DIFF
--- a/eng/automation/vs-workload.template.props
+++ b/eng/automation/vs-workload.template.props
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetName>Microsoft.NET.Sdk.Maui.Workload.@VSMAN_VERSION@</TargetName>
     <ManifestBuildVersion>@VS_COMPONENT_VERSION@</ManifestBuildVersion>
-    <EnableSideBySideManifests>true</EnableSideBySideManifests>
   </PropertyGroup>
   <ItemGroup>
     <!-- Shorten package names to avoid long path caching issues in Visual Studio -->


### PR DESCRIPTION
This reverts commit b80c7f122c5a445737887434469c42f511aaade7, reversing changes made to cc49293c26675ea6379b7838b89d4f384e2ff167.

We don't want this on a preview6 build
