### PR TITLE
[tests] consolidate various DoesNotLeak tests

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Border/BorderTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Border/BorderTests.cs
@@ -84,7 +84,8 @@ namespace Microsoft.Maui.DeviceTests
 #endif
 		}
 
-
+		// NOTE: this test is slightly different than MemoryTests.HandlerDoesNotLeak
+		// It adds a child to the Border, which is a worthwhile test case.
 		[Fact("Border Does Not Leak")]
 		public async Task DoesNotLeak()
 		{

--- a/src/Controls/tests/DeviceTests/Elements/CheckBox/CheckBoxTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CheckBox/CheckBoxTests.cs
@@ -43,31 +43,5 @@ namespace Microsoft.Maui.DeviceTests
 
 			await ValidateHasColor<CheckBoxHandler>(checkBox, color);
 		}
-
-		[Fact(DisplayName = "Does Not Leak")]
-		public async Task DoesNotLeak()
-		{
-			SetupBuilder();
-
-			WeakReference viewReference = null;
-			WeakReference platformViewReference = null;
-			WeakReference handlerReference = null;
-
-			await InvokeOnMainThreadAsync(() =>
-			{
-				var layout = new Grid();
-				var checkBox = new CheckBox();
-				layout.Add(checkBox);
-				var handler = CreateHandler<LayoutHandler>(layout);
-				viewReference = new WeakReference(checkBox);
-				handlerReference = new WeakReference(checkBox.Handler);
-				platformViewReference = new WeakReference(checkBox.Handler.PlatformView);
-			});
-
-			await AssertionExtensions.WaitForGC(viewReference, handlerReference, platformViewReference);
-			Assert.False(viewReference.IsAlive, "CheckBox should not be alive!");
-			Assert.False(handlerReference.IsAlive, "Handler should not be alive!");
-			Assert.False(platformViewReference.IsAlive, "PlatformView should not be alive!");
-		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/ContentView/ContentViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/ContentView/ContentViewTests.cs
@@ -76,31 +76,5 @@ namespace Microsoft.Maui.DeviceTests
 				Assert.True(child.BindingContext == bindingContext);
 			});
 		}
-
-		[Fact(DisplayName = "ContentView Does Not Leak")]
-		public async Task DoesNotLeak()
-		{
-			SetupBuilder();
-			WeakReference viewReference = null;
-			WeakReference handlerReference = null;
-			WeakReference platformReference = null;
-
-			{
-				var view = new Microsoft.Maui.Controls.ContentView();
-				var page = new ContentPage { Content = view };
-				await CreateHandlerAndAddToWindow(page, () =>
-				{
-					viewReference = new(view);
-					handlerReference = new(view.Handler);
-					platformReference = new(view.Handler.PlatformView);
-					page.Content = null;
-				});
-			}
-
-			await AssertionExtensions.WaitForGC(viewReference, handlerReference, platformReference);
-			Assert.False(viewReference.IsAlive, "View should not be alive!");
-			Assert.False(handlerReference.IsAlive, "Handler should not be alive!");
-			Assert.False(platformReference.IsAlive, "PlatformView should not be alive!");
-		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Editor/EditorTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Editor/EditorTests.cs
@@ -21,32 +21,6 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
-		[Fact(DisplayName = "Does Not Leak")]
-		public async Task DoesNotLeak()
-		{
-			SetupBuilder();
-
-			WeakReference viewReference = null;
-			WeakReference platformViewReference = null;
-			WeakReference handlerReference = null;
-
-			await InvokeOnMainThreadAsync(() =>
-			{
-				var layout = new Grid();
-				var editor = new Editor();
-				layout.Add(editor);
-				var handler = CreateHandler<LayoutHandler>(layout);
-				viewReference = new WeakReference(editor);
-				handlerReference = new WeakReference(editor.Handler);
-				platformViewReference = new WeakReference(editor.Handler.PlatformView);
-			});
-
-			await AssertionExtensions.WaitForGC(viewReference, handlerReference, platformViewReference);
-			Assert.False(viewReference.IsAlive, "Editor should not be alive!");
-			Assert.False(handlerReference.IsAlive, "Handler should not be alive!");
-			Assert.False(platformViewReference.IsAlive, "PlatformView should not be alive!");
-		}
-
 #if !IOS && !MACCATALYST
 		// iOS is broken until this point
 		// https://github.com/dotnet/maui/issues/3425

--- a/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.cs
@@ -81,32 +81,6 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
-		[Fact(DisplayName = "Does Not Leak")]
-		public async Task DoesNotLeak()
-		{
-			SetupBuilder();
-
-			WeakReference viewReference = null;
-			WeakReference platformViewReference = null;
-			WeakReference handlerReference = null;
-
-			await InvokeOnMainThreadAsync(() =>
-			{
-				var layout = new Grid();
-				var entry = new Entry();
-				layout.Add(entry);
-				var handler = CreateHandler<LayoutHandler>(layout);
-				viewReference = new WeakReference(entry);
-				handlerReference = new WeakReference(entry.Handler);
-				platformViewReference = new WeakReference(entry.Handler.PlatformView);
-			});
-
-			await AssertionExtensions.WaitForGC(viewReference, handlerReference, platformViewReference);
-			Assert.False(viewReference.IsAlive, "Entry should not be alive!");
-			Assert.False(handlerReference.IsAlive, "Handler should not be alive!");
-			Assert.False(platformViewReference.IsAlive, "PlatformView should not be alive!");
-		}
-
 #if WINDOWS
 		// Only Windows needs the IsReadOnly workaround for MaxLength==0 to prevent text from being entered
 		[Fact]

--- a/src/Controls/tests/DeviceTests/Elements/Image/ImageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Image/ImageTests.cs
@@ -48,6 +48,8 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
+		// NOTE: this test is slightly different than MemoryTests.HandlerDoesNotLeak
+		// It sets image.Source and waits for it to load, a valid test case.
 		[Fact("Image Does Not Leak")]
 		public async Task DoesNotLeak()
 		{

--- a/src/Controls/tests/DeviceTests/Elements/RefreshView/RefreshViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/RefreshView/RefreshViewTests.cs
@@ -20,32 +20,6 @@ namespace Microsoft.Maui.DeviceTests
 				});
 			});
 		}
-
-		[Fact(DisplayName = "Does Not Leak")]
-		public async Task DoesNotLeak()
-		{
-			SetupBuilder();
-
-			WeakReference viewReference = null;
-			WeakReference platformViewReference = null;
-			WeakReference handlerReference = null;
-
-			await InvokeOnMainThreadAsync(() =>
-			{
-				var layout = new Grid();
-				var refreshView = new RefreshView();
-				layout.Add(refreshView);
-				var handler = CreateHandler<LayoutHandler>(layout);
-				viewReference = new WeakReference(refreshView);
-				handlerReference = new WeakReference(refreshView.Handler);
-				platformViewReference = new WeakReference(refreshView.Handler.PlatformView);
-			});
-
-			await AssertionExtensions.WaitForGC(viewReference, handlerReference, platformViewReference);
-			Assert.False(viewReference.IsAlive, "RefreshView should not be alive!");
-			Assert.False(handlerReference.IsAlive, "Handler should not be alive!");
-			Assert.False(platformViewReference.IsAlive, "PlatformView should not be alive!");
-		}
 	}
 }
 

--- a/src/Controls/tests/DeviceTests/Elements/ScrollView/ScrollViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/ScrollView/ScrollViewTests.cs
@@ -78,6 +78,8 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
+		// NOTE: this test is slightly different than MemoryTests.HandlerDoesNotLeak
+		// It calls CreateHandlerAndAddToWindow(), a valid test case.
 		[Fact(DisplayName = "ScrollView Does Not Leak")]
 		public async Task DoesNotLeak()
 		{

--- a/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
+++ b/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Hosting;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests.Memory;
+
+public class MemoryTests : ControlsHandlerTestBase
+{
+	void SetupBuilder()
+	{
+		EnsureHandlerCreated(builder =>
+		{
+			builder.ConfigureMauiHandlers(handlers =>
+			{
+				handlers.AddHandler<Border, BorderHandler>();
+				handlers.AddHandler<CheckBox, CheckBoxHandler>();
+				handlers.AddHandler<Entry, EntryHandler>();
+				handlers.AddHandler<Editor, EditorHandler>();
+				handlers.AddHandler<Label, LabelHandler>();
+				handlers.AddHandler<IContentView, ContentViewHandler>();
+				handlers.AddHandler<Image, ImageHandler>();
+				handlers.AddHandler<RefreshView, RefreshViewHandler>();
+				handlers.AddHandler<IScrollView, ScrollViewHandler>();
+			});
+		});
+	}
+
+	[Theory("Handler Does Not Leak")]
+	[InlineData(typeof(Border))]
+	[InlineData(typeof(ContentView))]
+	[InlineData(typeof(CheckBox))]
+	[InlineData(typeof(Entry))]
+	[InlineData(typeof(Editor))]
+	[InlineData(typeof(Image))]
+	[InlineData(typeof(Label))]
+	[InlineData(typeof(RefreshView))]
+	[InlineData(typeof(ScrollView))]
+	public async Task HandlerDoesNotLeak(Type type)
+	{
+		SetupBuilder();
+
+		WeakReference viewReference = null;
+		WeakReference platformViewReference = null;
+		WeakReference handlerReference = null;
+
+		await InvokeOnMainThreadAsync(() =>
+		{
+			var layout = new Grid();
+			var view = (View)Activator.CreateInstance(type);
+			layout.Add(view);
+			var handler = CreateHandler<LayoutHandler>(layout);
+			viewReference = new WeakReference(view);
+			handlerReference = new WeakReference(view.Handler);
+			platformViewReference = new WeakReference(view.Handler.PlatformView);
+		});
+
+		await AssertionExtensions.WaitForGC(viewReference, handlerReference, platformViewReference);
+		Assert.False(viewReference.IsAlive, $"{type} should not be alive!");
+		Assert.False(handlerReference.IsAlive, "Handler should not be alive!");
+		Assert.False(platformViewReference.IsAlive, "PlatformView should not be alive!");
+	}
+}
+

--- a/src/Core/src/Platform/iOS/MauiCheckBox.cs
+++ b/src/Core/src/Platform/iOS/MauiCheckBox.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Maui.Platform
 
 		readonly WeakEventManager _weakEventManager = new WeakEventManager();
 
-		[UnconditionalSuppressMessage("Memory", "MA0001", Justification = "Proven safe in test: CheckBoxTests.DoesNotLeak")]
+		[UnconditionalSuppressMessage("Memory", "MA0001", Justification = "Proven safe in test: MemoryTests.DoesNotLeak")]
 		public event EventHandler? CheckedChanged
 		{
 			add => _weakEventManager.AddEventHandler(value);

--- a/src/Core/src/Platform/iOS/MauiRefreshView.cs
+++ b/src/Core/src/Platform/iOS/MauiRefreshView.cs
@@ -15,11 +15,11 @@ namespace Microsoft.Maui.Platform
 		bool _isRefreshing;
 		nfloat _originalY;
 		nfloat _refreshControlHeight;
-		[UnconditionalSuppressMessage("Memory", "MA0002", Justification = "Proven safe in test: RefreshViewTests.DoesNotLeak")]
+		[UnconditionalSuppressMessage("Memory", "MA0002", Justification = "Proven safe in test: MemoryTests.DoesNotLeak")]
 		UIView _refreshControlParent;
-		[UnconditionalSuppressMessage("Memory", "MA0002", Justification = "Proven safe in test: RefreshViewTests.DoesNotLeak")]
+		[UnconditionalSuppressMessage("Memory", "MA0002", Justification = "Proven safe in test: MemoryTests.DoesNotLeak")]
 		UIView? _contentView;
-		[UnconditionalSuppressMessage("Memory", "MA0002", Justification = "Proven safe in test: RefreshViewTests.DoesNotLeak")]
+		[UnconditionalSuppressMessage("Memory", "MA0002", Justification = "Proven safe in test: MemoryTests.DoesNotLeak")]
 		UIRefreshControl _refreshControl;
 		public UIRefreshControl RefreshControl => _refreshControl;
 

--- a/src/Core/src/Platform/iOS/MauiTextField.cs
+++ b/src/Core/src/Platform/iOS/MauiTextField.cs
@@ -66,9 +66,9 @@ namespace Microsoft.Maui.Platform
 			}
 		}
 
-		[UnconditionalSuppressMessage("Memory", "MA0001", Justification = "Proven safe in test: EntryTests.DoesNotLeak")]
+		[UnconditionalSuppressMessage("Memory", "MA0001", Justification = "Proven safe in test: MemoryTests.DoesNotLeak")]
 		public event EventHandler? TextPropertySet;
-		[UnconditionalSuppressMessage("Memory", "MA0001", Justification = "Proven safe in test: EntryTests.DoesNotLeak")]
+		[UnconditionalSuppressMessage("Memory", "MA0001", Justification = "Proven safe in test: MemoryTests.DoesNotLeak")]
 		internal event EventHandler? SelectionChanged;
 	}
 }

--- a/src/Core/src/Platform/iOS/MauiTextView.cs
+++ b/src/Core/src/Platform/iOS/MauiTextView.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Maui.Platform
 {
 	public class MauiTextView : UITextView
 	{
-		[UnconditionalSuppressMessage("Memory", "MA0002", Justification = "Proven safe in test: EditorTests.DoesNotLeak")]
+		[UnconditionalSuppressMessage("Memory", "MA0002", Justification = "Proven safe in test: MemoryTests.DoesNotLeak")]
 		readonly UILabel _placeholderLabel;
 		nfloat? _defaultPlaceholderSize;
 
@@ -36,7 +36,7 @@ namespace Microsoft.Maui.Platform
 		// Native Changed doesn't fire when the Text Property is set in code
 		// We use this event as a way to fire changes whenever the Text changes
 		// via code or user interaction.
-		[UnconditionalSuppressMessage("Memory", "MA0001", Justification = "Proven safe in test: EditorTests.DoesNotLeak")]
+		[UnconditionalSuppressMessage("Memory", "MA0001", Justification = "Proven safe in test: MemoryTests.DoesNotLeak")]
 		public event EventHandler? TextSetOrChanged;
 
 		public string? PlaceholderText


### PR DESCRIPTION
We can convert this to a single parameterized test.

Future fixes can add new `[InlineData]` instead of creating new tests.