### PR TITLE
Setting binding on Label doesn't set text to incoming binding

### DIFF
--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2681.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2681.cs
@@ -75,8 +75,6 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
-		[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
-		[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		public void ListViewDoesntFreezeApp()
 		{
 			RunningApp.Tap(x => x.Marked(NavigateToPage));

--- a/src/Controls/src/Core/BindableObject.cs
+++ b/src/Controls/src/Core/BindableObject.cs
@@ -213,12 +213,10 @@ namespace Microsoft.Maui.Controls
 		public void SetBinding(BindableProperty targetProperty, BindingBase binding)
 			=> SetBinding(targetProperty, binding, SetterSpecificity.FromBinding);
 
-		//FIXME, use specificity
 		internal void SetBinding(BindableProperty targetProperty, BindingBase binding, SetterSpecificity specificity)
 		{
 			if (targetProperty == null)
 				throw new ArgumentNullException(nameof(targetProperty));
-
 
 			if (targetProperty.IsReadOnly && binding.Mode == BindingMode.OneWay)
 			{
@@ -227,6 +225,14 @@ namespace Microsoft.Maui.Controls
 			}
 
 			var context = GetOrCreateContext(targetProperty);
+
+			//if the value is manually set (has highest specificity than FromBinding), we reassign the specificity so it'll get replaced when the binding is applied
+			if (context.Values.Last().Key.CompareTo(SetterSpecificity.FromBinding) > 0)
+			{
+				var kvp = context.Values.Last();
+				context.Values.Remove(kvp.Key);
+				context.Values.Add(SetterSpecificity.FromBinding, kvp.Value);
+			}
 
 			context.Binding?.Unapply();
 			context.BindingSpecificity = specificity;
@@ -237,8 +243,6 @@ namespace Microsoft.Maui.Controls
 			targetProperty.BindingChanging?.Invoke(this, oldBinding, binding);
 
 			binding.Apply(BindingContext, this, targetProperty, false, specificity);
-
-
 		}
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/BindableObject.xml" path="//Member[@MemberName='SetInheritedBindingContext']/Docs/*" />

--- a/src/Controls/tests/Core.UnitTests/LabelTests.cs
+++ b/src/Controls/tests/Core.UnitTests/LabelTests.cs
@@ -178,6 +178,15 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.Equal(TextAlignment.End, labelVerticalTextAlignment.VerticalTextAlignment);
 		}
 
+		[Fact]
+		public void OriginalLabelTextNotUpdatingAfterBindingIsSet()
+		{
+			var label = new Label() { Text = "sassifrass" };
+			label.BindingContext = 1;
+			label.SetBinding(Label.TextProperty, ".");
+			Assert.Equal("1", label.Text);
+		}
+
 		sealed class ViewModel : INotifyPropertyChanged
 		{
 			TextAlignment horizontalAlignment;


### PR DESCRIPTION
### Description of Change

Fix `SetBinding` so it will replace any `manual` value set by a user.

Fixes #16723
Fixes #16722
Fixes #16720
Fixes #16721
Fixes #16636
Fixes #16859 