### PR TITLE
[ci] Run Codesign Verification after MSI creation

### DIFF
--- a/eng/automation/SignVerifyIgnore.txt
+++ b/eng/automation/SignVerifyIgnore.txt
@@ -1,0 +1,2 @@
+**\*.xml,ignore unsigned .xml
+**\cab*.cab.cab,ignore unsigned .cab

--- a/eng/pipelines/common/pack.yml
+++ b/eng/pipelines/common/pack.yml
@@ -75,6 +75,7 @@ steps:
         ${{ parameters.checkoutDirectory }}/artifacts/**/*.zip
         ${{ parameters.checkoutDirectory }}/artifacts/vs-workload.props
         ${{ parameters.checkoutDirectory }}/eng/automation/SignList.xml
+        ${{ parameters.checkoutDirectory }}/eng/automation/SignVerifyIgnore.txt
         !${{ parameters.checkoutDirectory}}/artifacts/docs-packs/**
       TargetFolder: $(build.artifactstagingdirectory)
       flattenFolders: true

--- a/eng/pipelines/common/sign.yml
+++ b/eng/pipelines/common/sign.yml
@@ -23,3 +23,19 @@ stages:
           artifactPath: signed
           propsArtifactName: nuget
           signType: Real
+          postConvertSteps:
+          - task: DownloadPipelineArtifact@2
+            inputs:
+              artifactName: nuget
+              downloadPath: $(Build.ArtifactStagingDirectory)\sign-verify
+              patterns: |
+                **/SignVerifyIgnore.txt
+
+          - task: MicroBuildCodesignVerify@3
+            displayName: verify signed msi content
+            inputs:
+              TargetFolders: |
+                $(Build.ArtifactStagingDirectory)\bin\manifests
+                $(Build.ArtifactStagingDirectory)\bin\manifests-multitarget
+              ExcludeSNVerify: true
+              ApprovalListPathForCerts: $(Build.ArtifactStagingDirectory)\sign-verify\SignVerifyIgnore.txt


### PR DESCRIPTION
The `MicroBuildCodesignVerify@3` task has been added to validate the
signing status of the MSI files required for VS insertions.  This will
allow us to identify any potential signing issues earlier.