### PR TITLE
Fix EntryCellRenderer to use FromHandler for text changes

### DIFF
--- a/src/Compatibility/Core/src/Android/Cells/EntryCellRenderer.cs
+++ b/src/Compatibility/Core/src/Android/Cells/EntryCellRenderer.cs
@@ -92,7 +92,8 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 		void OnTextChanged(string text)
 		{
 			var entryCell = (EntryCell)Cell;
-			entryCell.Text = text;
+			entryCell
+				.SetValue(EntryCell.TextProperty, text, specificity: SetterSpecificity.FromHandler);
 		}
 
 		void UpdateHeight()

--- a/src/Compatibility/Core/src/iOS/Cells/EntryCellRenderer.cs
+++ b/src/Compatibility/Core/src/iOS/Cells/EntryCellRenderer.cs
@@ -90,7 +90,8 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 			var cell = (EntryCellTableViewCell)sender;
 			var model = (EntryCell)cell.Cell;
 
-			model.Text = cell.TextField.Text;
+			model
+				.SetValue(EntryCell.TextProperty, cell.TextField.Text, specificity: SetterSpecificity.FromHandler);
 		}
 
 		static void UpdateHorizontalTextAlignment(EntryCellTableViewCell cell, EntryCell entryCell)

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/EntryCellRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/EntryCellRenderer.cs
@@ -90,7 +90,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		void OnTextChanged(string text)
 		{
 			var entryCell = (EntryCell)Cell;
-			entryCell.Text = text;
+
+			entryCell
+				.SetValue(EntryCell.TextProperty, text, specificity: SetterSpecificity.FromHandler);
 		}
 
 		void UpdateHeight()

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/iOS/EntryCellRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/iOS/EntryCellRenderer.cs
@@ -95,7 +95,8 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			var cell = (EntryCellTableViewCell)sender;
 			var model = (EntryCell)cell.Cell;
 
-			model.Text = cell.TextField.Text;
+			model
+				.SetValue(EntryCell.TextProperty, cell.TextField.Text, specificity: SetterSpecificity.FromHandler);
 		}
 
 		static void UpdateHorizontalTextAlignment(EntryCellTableViewCell cell, EntryCell entryCell)

--- a/src/Controls/tests/DeviceTests/Elements/ListView/ListViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/ListView/ListViewTests.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.ObjectModel;
+﻿using System;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
@@ -19,6 +21,7 @@ namespace Microsoft.Maui.DeviceTests
 			{
 				builder.ConfigureMauiHandlers(handlers =>
 				{
+					handlers.AddHandler<EntryCell, EntryCellRenderer>();
 					handlers.AddHandler<ViewCell, ViewCellRenderer>();
 					handlers.AddHandler<TextCell, TextCellRenderer>();
 					handlers.AddHandler<ListView, ListViewRenderer>();
@@ -111,6 +114,62 @@ namespace Microsoft.Maui.DeviceTests
 				await Task.Delay(100);
 				ValidatePlatformCells(listView);
 			});
+		}
+
+		[Fact]
+		public async Task EntryCellBindingCorrectlyUpdates()
+		{
+			SetupBuilder();
+			var vm = new EntryCellBindingCorrectlyUpdatesVM();
+			var data = new[]
+			{
+				vm
+			};
+
+			var listView = new ListView()
+			{
+				ItemTemplate = new DataTemplate(() =>
+				{
+					var cell = new EntryCell();
+					cell.SetBinding(EntryCell.TextProperty, "Value");
+					return cell;
+				}),
+				ItemsSource = data
+			};
+
+			var layout = new VerticalStackLayout()
+			{
+				listView
+			};
+
+			await CreateHandlerAndAddToWindow<LayoutHandler>(layout, async (handler) =>
+			{
+				await Task.Yield();
+				var entryCell = listView.TemplatedItems[0] as EntryCell;
+
+				// Initial Value is correct
+				Assert.Equal(vm.Value, entryCell.Text);
+
+				// Validate that the binding stays operational
+				for (int i = 0; i < 3; i++)
+				{
+					vm.ChangeValue();
+					await Task.Yield();
+					Assert.Equal(vm.Value, entryCell.Text);
+				}
+			});
+		}
+		class EntryCellBindingCorrectlyUpdatesVM : INotifyPropertyChanged
+		{
+			public event PropertyChangedEventHandler PropertyChanged;
+
+			public string Value { get; set; }
+
+			public void ChangeValue()
+			{
+				Value = Guid.NewGuid().ToString();
+				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Value)));
+			}
 		}
 
 		[Fact]


### PR DESCRIPTION
### Description of Change

When text changes happen inside EntryCellRenderer we need to propagate those up via "FromHandler" so they don't appear as manual and wipe out the binding