### PR TITLE
Add `dotnet-local` scripts to make using in tree dotnet easier.

### DIFF
--- a/.github/DEVELOPMENT.md
+++ b/.github/DEVELOPMENT.md
@@ -190,9 +190,11 @@ public static int foo = 2130771968;
 
 # Advanced Scenarios
 
-### Compile using a local `bin\dotnet`
+### Compile using a local `bin\dotnet` via `dotnet-local.*`
 
 This method will use the .NET and workload versions that are specific to the branch you are on, which is a good way to ensure compatibility.
+
+Use `dotnet-local.cmd` on Windows or `dotnet-local.sh` on Unix to ensure that `PATH` is set consistently.
 
 #### Cake
 

--- a/dotnet-local.cmd
+++ b/dotnet-local.cmd
@@ -5,5 +5,5 @@ IF EXIST "%ROOT%\bin\dotnet\dotnet.exe" (
     SET PATH=%DOTNET_ROOT%;%PATH%
     call "%ROOT%\bin\dotnet\dotnet.exe" %*
 ) ELSE (
-    echo "You need to run 'build.ps1' first."
+    echo "You must build MAUI first. Please see '.github/DEVELOPMENT.md' for details."
 )

--- a/dotnet-local.cmd
+++ b/dotnet-local.cmd
@@ -1,0 +1,9 @@
+@echo off
+SET ROOT=%~dp0
+IF EXIST "%ROOT%\bin\dotnet\dotnet.exe" (
+    SET DOTNET_ROOT=%ROOT%\bin\dotnet
+    SET PATH=%DOTNET_ROOT%;%PATH%
+    call "%ROOT%\bin\dotnet\dotnet.exe" %*
+) ELSE (
+    echo "You need to run 'build.ps1' first."
+)

--- a/dotnet-local.sh
+++ b/dotnet-local.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+ROOT="$(dirname "${BASH_SOURCE}")"
+FULLROOT="$(cd "${ROOT}"; pwd)"
+
+if [[ ! -x "${ROOT}/bin/dotnet/dotnet" ]] ; then
+    echo "You need to run 'build.sh' first." 1>&2
+    exit 1
+fi
+
+export DOTNET_ROOT="${FULLROOT}/bin/dotnet"
+export PATH="${DOTNET_ROOT}:${PATH}"
+exec "${ROOT}/bin/dotnet/dotnet" "$@"

--- a/dotnet-local.sh
+++ b/dotnet-local.sh
@@ -3,7 +3,7 @@ ROOT="$(dirname "${BASH_SOURCE}")"
 FULLROOT="$(cd "${ROOT}"; pwd)"
 
 if [[ ! -x "${ROOT}/bin/dotnet/dotnet" ]] ; then
-    echo "You need to run 'build.sh' first." 1>&2
+    echo 'You must build MAUI first. Please see `.github/DEVELOPMENT.md` for details.' 1>&2
     exit 1
 fi
 


### PR DESCRIPTION
Using `dotnet` may require setting `%PATH%` to prefer `bin\dotnet\dotnet` over any other `dotnet` in `%PATH%`.

Usage:

	# Unix
	path/to/maui/dotnet-local.sh build App.sln

	rem Windows
	path\to\maui\dotnet-local.cmd build App.sln

If MAUI hasn't been built yet, an error message stating that `build.sh` or `build.ps1` should be executed is printed.
