### PR TITLE
Fix BlazorWebView tests on Windows

### DIFF
--- a/src/BlazorWebView/tests/MauiDeviceTests/Elements/BlazorWebViewTests.cs
+++ b/src/BlazorWebView/tests/MauiDeviceTests/Elements/BlazorWebViewTests.cs
@@ -59,11 +59,7 @@ namespace Microsoft.Maui.MauiBlazorWebView.DeviceTests.Elements
 			});
 		}
 
-		[Fact
-#if WINDOWS
-			(Skip = "Times out on CoreWebView2.DOMContentLoaded")
-#endif
-			]
+		[Fact]
 		public async Task BlazorWebViewLogsRequests()
 		{
 			var testLoggerProvider = new TestLoggerProvider();
@@ -108,11 +104,7 @@ namespace Microsoft.Maui.MauiBlazorWebView.DeviceTests.Elements
 		}
 
 
-		[Fact
-#if WINDOWS
-			(Skip= "Times out on CoreWebView2.DOMContentLoaded")
-#endif
-			]
+		[Fact]
 		public async Task BlazorWebViewUsesStartPath()
 		{
 			EnsureHandlerCreated(additionalCreationActions: appBuilder =>
@@ -147,7 +139,7 @@ namespace Microsoft.Maui.MauiBlazorWebView.DeviceTests.Elements
 			public static readonly string DefaultMauiIndexHtmlContent = @"
 <!DOCTYPE html>
 <html>
-<head>
+<head testhtmlloaded=""true"">
     <meta charset=""utf-8"" />
     <meta name=""viewport"" content=""width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"" />
     <title>Blazor app</title>

--- a/src/BlazorWebView/tests/MauiDeviceTests/HandlerTestBase.cs
+++ b/src/BlazorWebView/tests/MauiDeviceTests/HandlerTestBase.cs
@@ -1,12 +1,12 @@
 using System;
 using System.Threading.Tasks;
-using Microsoft.Maui.Controls;
-using Microsoft.Maui.Controls.Hosting;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui.DeviceTests;
 using Microsoft.Maui.DeviceTests.Stubs;
+using Microsoft.Maui.Dispatching;
 using Microsoft.Maui.Graphics;
-using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Hosting;
+using Microsoft.Maui.TestUtils.DeviceTests.Runners;
 
 namespace Microsoft.Maui.MauiBlazorWebView.DeviceTests
 {
@@ -26,6 +26,10 @@ namespace Microsoft.Maui.MauiBlazorWebView.DeviceTests
 			_isCreated = true;
 			var appBuilder = MauiApp
 				.CreateBuilder();
+
+			appBuilder.Services.AddSingleton<IDispatcherProvider>(svc => TestDispatcher.Provider);
+			appBuilder.Services.AddScoped<IDispatcher>(svc => TestDispatcher.Current);
+			appBuilder.Services.AddSingleton<IApplication>((_) => new CoreApplicationStub());
 
 			additionalCreationActions?.Invoke(appBuilder);
 

--- a/src/BlazorWebView/tests/MauiDeviceTests/WebViewHelpers.Windows.cs
+++ b/src/BlazorWebView/tests/MauiDeviceTests/WebViewHelpers.Windows.cs
@@ -42,7 +42,16 @@ namespace Microsoft.Maui.MauiBlazorWebView.DeviceTests
 
 			if (!domLoaded)
 			{
-				throw new Exception($"Waited {MaxWaitTimes * WaitTimeInMS}ms but couldn't get CoreWebView2.DOMContentLoaded to complete.");
+				// It's possible that the DOMContentLoaded event won't fire because it's already loaded by the time we got here. To check
+				// for that, we inspect an arbitrary custom HTML element attribute to see if we can find it. If we can find it, then surely
+				// the DOM content is loaded, so we can continue with the test.
+				var testHtmlLoadedAttributeValue = await wv2.CoreWebView2.ExecuteScriptAsync("(document.head.attributes['testhtmlloaded']?.value === 'true')");
+
+				if (testHtmlLoadedAttributeValue != "true")
+				{
+					// If the event didn't fire, AND we couldn't find the custom HTML element attribute, then the test content didn't load
+					throw new Exception($"Waited {MaxWaitTimes * WaitTimeInMS}ms but couldn't get CoreWebView2.DOMContentLoaded to complete.");
+				}
 			}
 			return;
 		}

--- a/src/Core/tests/DeviceTests.Shared/Stubs/CoreApplicationStub.cs
+++ b/src/Core/tests/DeviceTests.Shared/Stubs/CoreApplicationStub.cs
@@ -3,7 +3,7 @@ using Microsoft.Maui.ApplicationModel;
 
 namespace Microsoft.Maui.DeviceTests.Stubs
 {
-	class CoreApplicationStub : IApplication
+	public class CoreApplicationStub : IApplication
 	{
 		readonly List<IWindow> _windows = new List<IWindow>();
 


### PR DESCRIPTION
It seems that the test sometimes waits for an event that already happened, so it doesn't see it happen, and fails. I added a check to evaluate the state of the test to see if it doesn't need to wait for the event and allows the test to continue.

Fixes #16187
