### PR TITLE
Allow * rows/columns treated as Auto to expand during 2nd measure pass

### DIFF
--- a/src/Core/src/Layouts/GridLayoutManager.cs
+++ b/src/Core/src/Layouts/GridLayoutManager.cs
@@ -480,7 +480,7 @@ namespace Microsoft.Maui.Layouts
 					}
 					else if (cell.ColumnSpan == 1)
 					{
-						if (_columns[cell.Column].IsAuto)
+						if (TreatCellWidthAsAuto(cell))
 						{
 							_columns[cell.Column].Update(measure.Width);
 						}
@@ -492,7 +492,7 @@ namespace Microsoft.Maui.Layouts
 					}
 					else if (cell.RowSpan == 1)
 					{
-						if (_rows[cell.Row].IsAuto)
+						if (TreatCellHeightAsAuto(cell))
 						{
 							_rows[cell.Row].Update(measure.Height);
 						}

--- a/src/Core/tests/UnitTests/Layouts/GridLayoutManagerTests.cs
+++ b/src/Core/tests/UnitTests/Layouts/GridLayoutManagerTests.cs
@@ -3060,5 +3060,50 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			var args = view.ReceivedCalls().Single(c => c.GetMethodInfo().Name == nameof(IView.Arrange)).GetArguments();
 			return (Rect)args[0];
 		}
+
+		// The next two tests look at a corner case where the Grid is measured in one dimension without constraint
+		// (for instance, inside of a StackLayout); the Star in the unconstrained dimension should be treated
+		// as an Auto value. The explicit Auto value in the constrained dimension forces us to make a second measure
+		// pass to resolve all the measurements; we have to ensure that this second measure pass is updating
+		// the measurement of the unconstrained Star if the Views measured during the second pass are larger
+		// in that dimension.
+
+		[Fact]
+		public void AutoColumnIntersectionWithUnconstrainedMeasure()
+		{
+			var grid = CreateGridLayout(columns: "*, Auto", rows: "*"); 
+
+			var view0 = CreateTestView(new Size(20, 40));
+			var view1 = CreateTestView(new Size(20, 20));
+
+			SubstituteChildren(grid, view0, view1);
+			SetLocation(grid, view0, col: 0);
+			SetLocation(grid, view1, col: 1);
+
+			// The infinite height means we treat the * Row as Auto
+			_ = MeasureAndArrange(grid, widthConstraint: 200, heightConstraint: double.PositiveInfinity);
+			
+			// Ensure that the * Row height was updated to include the taller view
+			AssertArranged(view0, new Rect(0, 0, 20, 40));
+		}
+
+		[Fact]
+		public void AutoRowIntersectionWithUnconstrainedMeasure()
+		{
+			var grid = CreateGridLayout(rows: "*, Auto", columns: "*");
+
+			var view0 = CreateTestView(new Size(40, 20));
+			var view1 = CreateTestView(new Size(20, 20));
+
+			SubstituteChildren(grid, view0, view1);
+			SetLocation(grid, view0, row: 0);
+			SetLocation(grid, view1, row: 1);
+
+			// The infinite width means we treat the * Column as Auto
+			_ = MeasureAndArrange(grid, widthConstraint: double.PositiveInfinity, heightConstraint: 200);
+
+			// Ensure that the * Column width was updated to include the wider view
+			AssertArranged(view0, new Rect(0, 0, 40, 20));
+		}
 	}
 }

--- a/src/Core/tests/UnitTests/Layouts/LayoutTestHelpers.cs
+++ b/src/Core/tests/UnitTests/Layouts/LayoutTestHelpers.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Microsoft.Maui.Graphics;
 using NSubstitute;
 using NSubstitute.Core;
+using NSubstitute.ReceivedExtensions;
 
 namespace Microsoft.Maui.UnitTests.Layouts
 {
@@ -22,8 +23,12 @@ namespace Microsoft.Maui.UnitTests.Layouts
 		{
 			var view = CreateTestView();
 
-			view.Measure(Arg.Any<double>(), Arg.Any<double>()).Returns(viewSize);
-			view.DesiredSize.Returns(viewSize);
+			// Prior to being measured, the View has no DesiredSize set
+			view.DesiredSize.Returns(Size.Zero);
+
+			// After the first time Measure is called, the View has a DesiredSize
+			view.Measure(Arg.Any<double>(), Arg.Any<double>()).Returns(viewSize)
+				.AndDoes(ci => view.DesiredSize.Returns(viewSize));
 
 			return view;
 		}


### PR DESCRIPTION
### Description of Change

A confluence of Auto columns/rows in one dimension and de facto Auto columns/rows in the other dimension (because of a container layout which gives that dimension an unconstrained measurement) is causing an erroneous size value for a Star row/column. This change allows the Star row/column value to be updated to account for the size of the largest child View. 

Our unit tests were technically covering a slight variation of this situation, but an error in the test setup meant that the two tests covering the scenario were passing inaccurately. This PR updates the test methods to account for the problem (by disallowing the test Views' `DesiredSize` property to return the test value prior to calling `Measure()`). This PR also adds two additional tests specific to this scenario just in case. 

### Issues Fixed

Fixes #16368
Fixes #16334
