### PR TITLE
[build] allow main to be built with a .NET 8 SDK

### DIFF
--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -253,6 +253,7 @@ Task("dotnet-pack-maui")
         DotNetTool("pwsh", new DotNetToolSettings
         {
             DiagnosticOutput = true,
+            ToolPath = dotnetPath,
             ArgumentCustomization = args => args.Append($"-NoProfile ./eng/package.ps1 -configuration \"{configuration}\"")
         });
     });

--- a/global.json
+++ b/global.json
@@ -9,6 +9,6 @@
   "sdk": {
     "version": "7.0.200",
     "allowPrerelease": true,
-    "rollForward": "latestMinor"
+    "rollForward": "major"
   }
 }

--- a/src/DotNet/DotNet.csproj
+++ b/src/DotNet/DotNet.csproj
@@ -169,8 +169,8 @@
     <RemoveDir Directories="$(_WorkloadManifestDir);@(_WorkloadDirectoriesToRemove)" />
     <MakeDir Directories="$(_WorkloadManifestDir)" />
     <Exec
-        Command="&quot;$(DotNetToolPath)&quot; restore &quot;$(MSBuildThisFileDirectory)Dependencies/Workloads.csproj&quot; -bl:$(PackageOutputPath)/DotNetWorkloads.binlog"
-        EnvironmentVariables="NUGET_PACKAGES=$(_WorkloadManifestDir);DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1"
+        Command="&quot;$(DotNetToolPath)&quot; restore &quot;$(MSBuildThisFileDirectory)Dependencies/Workloads.csproj&quot; -bl:$(PackageOutputPath)/logs/DotNetWorkloads.binlog"
+        EnvironmentVariables="MSBuildSDKsPath=;NUGET_PACKAGES=$(_WorkloadManifestDir);DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1"
     />
     <!--
       NOTE: Workloads need to go in dotnet/sdk-manifests/6.0.100/microsoft.net.*/


### PR DESCRIPTION
I've been testing our latest .NET 8 release, and I noticed it was not currently possible to build dotnet/maui/main if you only have .NET 8 installed.

The first issue to get past is `global.json`:

    "sdk": {
        "version": "7.0.200",
        "allowPrerelease": true,
        "rollForward": "latestMinor"
    }

`latestMinor` does not allow it to "roll forward" to a .NET 8 SDK as it stops at any `7.0.x` version. I changed this to `major`, so it can use `8.x` or future versions. Alternatively we could completely remove the `sdk` block here, but I thought this was a reasonable change for now.

The next error I got was:

    The "CheckForImplicitPackageReferenceOverrides" task could not be loaded from the assembly C:\Program Files\dotnet\sdk\8.0.100-preview.7.23376.3\Sdks\Microsoft.NET.Sdk\targets\..\tools\net8.0\Microsoft.NET.Build.Tasks.dll. Could not load file or assembly 'System.Runtime, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'.
    The system cannot find the file specified. Confirm that the <UsingTask> declaration is correct, that the assembly and all its dependencies are available, and that the task contains a public class that implements Microsoft.Build.Framework.ITask.

This was quite confusing, but what I found was:

* `dotnet cake` -> uses .NET 8 SDK from my system

* A .NET 7 SDK is provisioned in `.\bin\dotnet\`

* An `<Exec/>` task runs:

* `.\bin\dotnet\dotnet restore src\DotNet\Dependencies\Workloads.csproj` which fails

It looks like the issue is the outer/system .NET SDK passes the `$MSBuildSDKsPath` environment variable. This makes a .NET 7 SDK import .NET 8 MSBuild targets files -- and everything breaks. I could get past this error by clearing the env var. I also fixed the `.binlog` location for this command, so it goes in `artifacts/logs` now.

The last issue I found was:

    ========================================
    dotnet-pack-maui
    ========================================
    Process terminated. The type initializer for 'System.Management.Automation.PSObject' threw an exception.
    at System.Environment.FailFast(System.String, System.Exception)
    at Microsoft.PowerShell.UnmanagedPSEntry.Start(System.String[], Int32)
    at Microsoft.PowerShell.ManagedPSEntry.Main(System.String[])
    System.TypeInitializationException: The type initializer for 'System.Management.Automation.PSObject' threw an exception.
    ---> System.IO.FileNotFoundException: Could not load file or assembly 'Microsoft.Management.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'. The system cannot find the file specified.
    File name: 'Microsoft.Management.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'
    at System.Management.Automation.PSObject..cctor()
    --- End of inner exception stack trace ---
    at System.Management.Automation.PSObject.get_Properties()
    at System.Management.Automation.HostUtilities.GetDollarProfile(String allUsersAllHosts, String allUsersCurrentHost, String currentUserAllHosts, String currentUserCurrentHost)
    at Microsoft.PowerShell.ConsoleHost.DoRunspaceInitialization(RunspaceCreationEventArgs args)
    at Microsoft.PowerShell.ConsoleHost.DoCreateRunspace(RunspaceCreationEventArgs args)
    at Microsoft.PowerShell.ConsoleHost.CreateRunspace(RunspaceCreationEventArgs runspaceCreationArgs)
    at Microsoft.PowerShell.ConsoleHost.DoRunspaceLoop(String initialCommand, Boolean skipProfiles, Collection`1 initialCommandArgs, Boolean staMode, String configurationName, String configurationFilePath)
    at Microsoft.PowerShell.ConsoleHost.Run(CommandLineParameterParser cpp, Boolean isPrestartWarned)
    at Microsoft.PowerShell.ConsoleHost.Start(String bannerText, String helpText, Boolean issProvidedExternally)
    at Microsoft.PowerShell.UnmanagedPSEntry.Start(String[] args, Int32 argc)

It appears that the `pwsh` .NET global tool basically doesn't run at all on .NET 8 yet?

https://www.nuget.org/packages/PowerShell/7.3.6

This fails in this way (if you have .NET 8):

    dotnet pwsh eng/package.ps1

While this one succeeds:

    ./bin/dotnet/dotnet pwsh eng/package.ps1

I could fix this in MAUI's build by setting `ToolPath` in `dotnet.cake`:

    DotNetTool("pwsh", new DotNetToolSettings
    {
        ToolPath = dotnetPath,
        //...
    });

This makes the command use `./bin/dotnet/dotnet pwsh`, which works.

This last change we might have to undo/revert on the `net8.0` branch until they fix the `pwsh` global tool.