### PR TITLE
Revert "[Windows] fixing window glitches while moving or resizing (#14861)"

### DIFF
--- a/src/Controls/src/Core/Window/Window.cs
+++ b/src/Controls/src/Core/Window/Window.cs
@@ -210,24 +210,15 @@ namespace Microsoft.Maui.Controls
 
 		void IWindow.FrameChanged(Rect frame)
 		{
-			var x = X;
-			var y = Y;
-			var width = Width;
-			var height = Height;
-			if (new Rect(x, y, width, height) == frame)
+			if (new Rect(X, Y, Width, Height) == frame)
 				return;
 
 			_batchFrameUpdate++;
 
-			SetPropertyChanging(XProperty, nameof(X), x, frame.X);
-			SetPropertyChanging(YProperty, nameof(Y), y, frame.Y);
-			SetPropertyChanging(WidthProperty, nameof(Width), width, frame.Width);
-			SetPropertyChanging(HeightProperty, nameof(Height), height, frame.Height);
-
-			SetValueCore(XProperty, frame.X, SetValueFlags.None, SetValuePrivateFlags.Silent);
-			SetValueCore(YProperty, frame.Y, SetValueFlags.None, SetValuePrivateFlags.Silent);
-			SetValueCore(WidthProperty, frame.Width, SetValueFlags.None, SetValuePrivateFlags.Silent);
-			SetValueCore(HeightProperty, frame.Height, SetValueFlags.None, SetValuePrivateFlags.Silent);
+			X = frame.X;
+			Y = frame.Y;
+			Width = frame.Width;
+			Height = frame.Height;
 
 			_batchFrameUpdate--;
 			if (_batchFrameUpdate < 0)
@@ -235,32 +226,7 @@ namespace Microsoft.Maui.Controls
 
 			if (_batchFrameUpdate == 0)
 			{
-				SetPropertyChanged(XProperty, nameof(X), x, frame.X);
-				SetPropertyChanged(YProperty, nameof(Y), y, frame.Y);
-				SetPropertyChanged(WidthProperty, nameof(Width), width, frame.Width);
-				SetPropertyChanged(HeightProperty, nameof(Height), height, frame.Height);
-
 				SizeChanged?.Invoke(this, EventArgs.Empty);
-			}
-
-			[MethodImpl(MethodImplOptions.AggressiveInlining)]
-			void SetPropertyChanging(BindableProperty property, string name, double oldValue, double newValue)
-			{
-				if (oldValue == newValue)
-					return;
-
-				property.PropertyChanging?.Invoke(this, oldValue, newValue);
-				OnPropertyChanging(name);
-			}
-
-			[MethodImpl(MethodImplOptions.AggressiveInlining)]
-			void SetPropertyChanged(BindableProperty property, string name, double oldValue, double newValue)
-			{
-				if (oldValue == newValue)
-					return;
-
-				OnPropertyChanged(name);
-				property.PropertyChanged?.Invoke(this, oldValue, newValue);
 			}
 		}
 

--- a/src/Controls/tests/Core.UnitTests/WindowsTests.cs
+++ b/src/Controls/tests/Core.UnitTests/WindowsTests.cs
@@ -434,82 +434,70 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		public void SettingCoreFrameOnlyFiresEventOnce()
 		{
 			var sizeChangedCount = 0;
-			var changingProperties = new List<string>();
-			var changedProperties = new List<string>();
+			var propertyChanges = new List<string>();
 
 			var window = new TestWindow();
 			window.SizeChanged += (sender, e) => sizeChangedCount++;
-			window.PropertyChanging += (sender, e) => changingProperties.Add(e.PropertyName);
-			window.PropertyChanged += (sender, e) => changedProperties.Add(e.PropertyName);
+			window.PropertyChanged += (sender, e) => propertyChanges.Add(e.PropertyName);
 
 			((IWindow)window).FrameChanged(new Rect(100, 200, 300, 400));
 
 			Assert.Equal(1, sizeChangedCount);
-			Assert.Equal(new[] { "X", "Y", "Width", "Height" }, changingProperties);
-			Assert.Equal(new[] { "X", "Y", "Width", "Height" }, changedProperties);
+			Assert.Equal(new[] { "X", "Y", "Width", "Height" }, propertyChanges);
 		}
 
 		[Fact]
 		public void SettingSameCoreFrameDoesNothing()
 		{
 			var sizeChangedCount = 0;
-			var changingProperties = new List<string>();
-			var changedProperties = new List<string>();
+			var propertyChanges = new List<string>();
 
 			var window = new TestWindow();
 			((IWindow)window).FrameChanged(new Rect(100, 200, 300, 400));
 
 			window.SizeChanged += (sender, e) => sizeChangedCount++;
-			window.PropertyChanging += (sender, e) => changingProperties.Add(e.PropertyName);
-			window.PropertyChanged += (sender, e) => changedProperties.Add(e.PropertyName);
+			window.PropertyChanged += (sender, e) => propertyChanges.Add(e.PropertyName);
 
 			((IWindow)window).FrameChanged(new Rect(100, 200, 300, 400));
 
 			Assert.Equal(0, sizeChangedCount);
-			Assert.Empty(changingProperties);
-			Assert.Empty(changedProperties);
+			Assert.Empty(propertyChanges);
 		}
 
 		[Fact]
 		public void UpdatingSingleCoordinateOnlyFiresSinglePropertyAndFrameEvent()
 		{
 			var sizeChangedCount = 0;
-			var changingProperties = new List<string>();
-			var changedProperties = new List<string>();
+			var propertyChanges = new List<string>();
 
 			var window = new TestWindow();
 			((IWindow)window).FrameChanged(new Rect(100, 200, 300, 400));
 
 			window.SizeChanged += (sender, e) => sizeChangedCount++;
-			window.PropertyChanging += (sender, e) => changingProperties.Add(e.PropertyName);
-			window.PropertyChanged += (sender, e) => changedProperties.Add(e.PropertyName);
+			window.PropertyChanged += (sender, e) => propertyChanges.Add(e.PropertyName);
 
 			((IWindow)window).FrameChanged(new Rect(100, 250, 300, 400));
 
 			Assert.Equal(1, sizeChangedCount);
-			Assert.Equal(new[] { "Y" }, changingProperties);
-			Assert.Equal(new[] { "Y" }, changedProperties);
+			Assert.Equal(new[] { "Y" }, propertyChanges);
 		}
 
 		[Fact]
 		public void UpdatingSingleBoundOnlyFiresSingleProperty()
 		{
 			var sizeChangedCount = 0;
-			var changingProperties = new List<string>();
-			var changedProperties = new List<string>();
+			var propertyChanges = new List<string>();
 
 			var window = new TestWindow();
 			((IWindow)window).FrameChanged(new Rect(100, 200, 300, 400));
 
 			window.SizeChanged += (sender, e) => sizeChangedCount++;
-			window.PropertyChanging += (sender, e) => changingProperties.Add(e.PropertyName);
-			window.PropertyChanged += (sender, e) => changedProperties.Add(e.PropertyName);
+			window.PropertyChanged += (sender, e) => propertyChanges.Add(e.PropertyName);
 
 			((IWindow)window).FrameChanged(new Rect(100, 200, 350, 400));
 
 			Assert.Equal(1, sizeChangedCount);
-			Assert.Equal(new[] { "Width" }, changingProperties);
-			Assert.Equal(new[] { "Width" }, changedProperties);
+			Assert.Equal(new[] { "Width" }, propertyChanges);
 		}
 
 		[Fact]


### PR DESCRIPTION
This reverts commit e093edf24bfd4260d350619140231f65e1bc816b.

### Description of Change

This reverts a PR that broke the unit tests. Still investigating why it was green on the public instance. 

### Issues Fixed

Fixes failing unit tests:

UpdatingSingleCoordinateOnlyFiresSinglePropertyAndFrameEvent
UpdatingSingleBoundOnlyFiresSingleProperty
SettingCoreFrameOnlyFiresEventOnce

