### PR TITLE
[tests] Fix run Compatibility on iOS

### DIFF
--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -47,20 +47,7 @@ steps:
       env:
         PROVISIONATOR_CHANNEL: ${{ parameters.provisionatorChannel }}
         AUTH_TOKEN_COMPONENTS_MAC_IOS_CERTIFICATE_P12: ${{ parameters.certPass }}
-
-  # Setup SDK Paths
-  - bash: |
-      echo "##vso[task.prependpath]/Library/Frameworks/Mono.framework/Versions/Current/Commands/"
-      echo "##vso[task.prependpath]~/Library/Developer/Xamarin/android-sdk-macosx"
-    displayName: 'Setup SDK Paths'
-    condition: and(succeeded(), ne(variables['osx2019VmPool'], 'Azure Pipelines'), eq(variables['Agent.OS'], 'Darwin'))
-  # Setup JDK Paths
-  - bash: |
-      echo "##vso[task.setvariable variable=JI_JAVA_HOME]$(JAVA_HOME_11_X64)"
-      echo "##vso[task.setvariable variable=JAVA_HOME]$(JAVA_HOME_11_X64)"
-    displayName: 'Setup JDK Paths'
-    condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
-
+        
   # Prepare Windows
   - powershell: |
       if (-not $(where.exe pwsh)) {

--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -47,7 +47,14 @@ steps:
       env:
         PROVISIONATOR_CHANNEL: ${{ parameters.provisionatorChannel }}
         AUTH_TOKEN_COMPONENTS_MAC_IOS_CERTIFICATE_P12: ${{ parameters.certPass }}
-        
+
+  # Setup JDK Paths (gradle needs it)
+  - bash: |
+      echo "##vso[task.setvariable variable=JI_JAVA_HOME]$(JAVA_HOME_11_X64)"
+      echo "##vso[task.setvariable variable=JAVA_HOME]$(JAVA_HOME_11_X64)"
+    displayName: 'Setup JDK Paths'
+    condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
+
   # Prepare Windows
   - powershell: |
       if (-not $(where.exe pwsh)) {

--- a/eng/pipelines/ui-tests.yml
+++ b/eng/pipelines/ui-tests.yml
@@ -132,12 +132,12 @@ stages:
       ${{ if or(parameters.BuildEverything, and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'devdiv'))) }}:
         androidApiLevels: [ 30 ]
         # androidApiLevels: [ 30, 29, 28, 27, 26, 25, 24, 23, 22, 21 ] # fix the issue of getting the test results off
-        iosVersions: [ '15.5' ]
+        iosVersions: [ 'latest' ]
         provisionatorChannel: ${{ parameters.provisionatorChannel }}
       ${{ if not(or(parameters.BuildEverything, and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'devdiv')))) }}:
         androidApiLevels: [ 30 ]
         # androidApiLevels: [ 30, 21 ] # fix the issue of getting the test results off
-        iosVersions: [ '15.5' ]
+        iosVersions: [ 'latest' ]
         provisionatorChannel: ${{ parameters.provisionatorChannel }}
       ${{ if or(parameters.CompatibilityTests, ne(variables['Build.Reason'], 'PullRequest')) }}:
         runCompatibilityTests: true


### PR DESCRIPTION
### Description of Change

- The legacy control gallery can't run on 15.5, so go back to use "latest" since we are pining Xcode. 
- Remove extra set mono on path since we now use on provisionator. 
