### PR TITLE
Add doc comments for common types used in templates, maps, webview

### DIFF
--- a/src/Controls/Maps/src/AppHostBuilderExtensions.cs
+++ b/src/Controls/Maps/src/AppHostBuilderExtensions.cs
@@ -16,6 +16,11 @@ namespace Microsoft.Maui.Controls.Hosting
 {
 	public static partial class AppHostBuilderExtensions
 	{
+		/// <summary>
+		/// Configures <see cref="MauiAppBuilder"/> to add support for the <see cref="Map"/> control.
+		/// </summary>
+		/// <param name="builder">The <see cref="MauiAppBuilder"/> to configure.</param>
+		/// <returns>The configured <see cref="MauiAppBuilder"/>.</returns>
 		public static MauiAppBuilder UseMauiMaps(this MauiAppBuilder builder)
 		{
 			builder

--- a/src/Controls/Maps/src/Controls.Maps.csproj
+++ b/src/Controls/Maps/src/Controls.Maps.csproj
@@ -9,6 +9,7 @@
     <_MauiDesignDllBuild Condition=" '$(OS)' != 'Unix' ">True</_MauiDesignDllBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);CS1591;RS0041;RS0026;RS0027;RS0022</NoWarn>
+    <WarningsAsErrors>$(WarningsAsErrors);CS1591</WarningsAsErrors>
 
     <!-- Add specifics for this NuGet -->
     <IsPackable>True</IsPackable>

--- a/src/Controls/Maps/src/Pin.cs
+++ b/src/Controls/Maps/src/Pin.cs
@@ -20,24 +20,30 @@ namespace Microsoft.Maui.Controls.Maps
 		public static readonly BindableProperty LabelProperty = BindableProperty.Create(nameof(Label), typeof(string), typeof(Pin), default(string));
 		private object? _markerId;
 
+		/// <inheritdoc />
 		public string Address
 		{
 			get { return (string)GetValue(AddressProperty); }
 			set { SetValue(AddressProperty, value); }
 		}
 
+		/// <inheritdoc />
 		public string Label
 		{
 			get { return (string)GetValue(LabelProperty); }
 			set { SetValue(LabelProperty, value); }
 		}
 
+		/// <inheritdoc />
 		public Location Location
 		{
 			get { return (Location)GetValue(LocationProperty); }
 			set { SetValue(LocationProperty, value); }
 		}
 
+		/// <summary>
+		/// The kind of pin.
+		/// </summary>
 		public PinType Type
 		{
 			get { return (PinType)GetValue(TypeProperty); }
@@ -53,8 +59,14 @@ namespace Microsoft.Maui.Controls.Maps
 			}
 		}
 
+		/// <summary>
+		/// Raised when this marker is clicked.
+		/// </summary>
 		public event EventHandler<PinClickedEventArgs>? MarkerClicked;
 
+		/// <summary>
+		/// Raised when the info window for this marker is clicked.
+		/// </summary>
 		public event EventHandler<PinClickedEventArgs>? InfoWindowClicked;
 
 		public override bool Equals(object? obj)

--- a/src/Controls/Maps/src/PinType.cs
+++ b/src/Controls/Maps/src/PinType.cs
@@ -1,10 +1,25 @@
 namespace Microsoft.Maui.Controls.Maps
 {
+	/// <summary>
+	/// Enumeration specifying the various kinds of <see cref="Pin"/>.
+	/// </summary>
 	public enum PinType
 	{
+		/// <summary>
+		/// A generic pin.
+		/// </summary>
 		Generic,
+		/// <summary>
+		/// Pin for a place.
+		/// </summary>
 		Place,
+		/// <summary>
+		/// Pin for a saved location.
+		/// </summary>
 		SavedPin,
+		/// <summary>
+		/// Pin for a search result.
+		/// </summary>
 		SearchResult
 	}
 }

--- a/src/Controls/src/Core/WebView/WebView.cs
+++ b/src/Controls/src/Core/WebView/WebView.cs
@@ -181,10 +181,17 @@ namespace Microsoft.Maui.Controls
 			_reloadRequested?.Invoke(this, EventArgs.Empty);
 		}
 
+		/// <summary>
+		/// Raised after web navigation completes.
+		/// </summary>
 		public event EventHandler<WebNavigatedEventArgs> Navigated;
 
+		/// <summary>
+		/// Raised after web navigation begins.
+		/// </summary>
 		public event EventHandler<WebNavigatingEventArgs> Navigating;
 
+		/// <inheritdoc/>
 		protected override void OnBindingContextChanged()
 		{
 			base.OnBindingContextChanged();
@@ -196,6 +203,7 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
+		/// <inheritdoc/>
 		protected override void OnPropertyChanged(string propertyName)
 		{
 			if (propertyName == "BindingContext")
@@ -214,6 +222,8 @@ namespace Microsoft.Maui.Controls
 		}
 
 		event EventHandler<EvalRequested> _evalRequested;
+
+		/// <inheritdoc/>
 		event EventHandler<EvalRequested> IWebViewController.EvalRequested
 		{
 			add { _evalRequested += value; }
@@ -221,6 +231,8 @@ namespace Microsoft.Maui.Controls
 		}
 
 		event EvaluateJavaScriptDelegate _evaluateJavaScriptRequested;
+
+		/// <inheritdoc/>
 		event EvaluateJavaScriptDelegate IWebViewController.EvaluateJavaScriptRequested
 		{
 			add { _evaluateJavaScriptRequested += value; }
@@ -228,6 +240,8 @@ namespace Microsoft.Maui.Controls
 		}
 
 		event EventHandler _goBackRequested;
+
+		/// <inheritdoc/>
 		event EventHandler IWebViewController.GoBackRequested
 		{
 			add { _goBackRequested += value; }
@@ -235,23 +249,29 @@ namespace Microsoft.Maui.Controls
 		}
 
 		event EventHandler _goForwardRequested;
+
+		/// <inheritdoc/>
 		event EventHandler IWebViewController.GoForwardRequested
 		{
 			add { _goForwardRequested += value; }
 			remove { _goForwardRequested -= value; }
 		}
 
+		/// <inheritdoc/>
 		void IWebViewController.SendNavigated(WebNavigatedEventArgs args)
 		{
 			Navigated?.Invoke(this, args);
 		}
 
+		/// <inheritdoc/>
 		void IWebViewController.SendNavigating(WebNavigatingEventArgs args)
 		{
 			Navigating?.Invoke(this, args);
 		}
 
 		event EventHandler _reloadRequested;
+
+		/// <inheritdoc/>
 		event EventHandler IWebViewController.ReloadRequested
 		{
 			add { _reloadRequested += value; }
@@ -301,8 +321,10 @@ namespace Microsoft.Maui.Controls
 			return js;
 		}
 
+		/// <inheritdoc/>
 		IWebViewSource IWebView.Source => Source;
 
+		/// <inheritdoc/>
 		bool IWebView.CanGoBack
 		{
 			get => _canGoBack;
@@ -314,6 +336,7 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
+		/// <inheritdoc/>
 		bool IWebView.CanGoForward
 		{
 			get => _canGoForward;
@@ -325,6 +348,7 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
+		/// <inheritdoc/>
 		bool IWebView.Navigating(WebNavigationEvent evnt, string url)
 		{
 			var args = new WebNavigatingEventArgs(evnt, new UrlWebViewSource { Url = url }, url);
@@ -333,6 +357,7 @@ namespace Microsoft.Maui.Controls
 			return args.Cancel;
 		}
 
+		/// <inheritdoc/>
 		void IWebView.Navigated(WebNavigationEvent evnt, string url, WebNavigationResult result)
 		{
 			var args = new WebNavigatedEventArgs(evnt, new UrlWebViewSource { Url = url }, url, result);

--- a/src/Controls/src/Xaml/Hosting/AppHostBuilderExtensions.cs
+++ b/src/Controls/src/Xaml/Hosting/AppHostBuilderExtensions.cs
@@ -29,6 +29,12 @@ namespace Microsoft.Maui.Controls.Hosting
 {
 	public static partial class AppHostBuilderExtensions
 	{
+		/// <summary>
+		/// Configures the <see cref="MauiAppBuilder"/> to use the specified <typeparamref name="TApp"/> as the main application type.
+		/// </summary>
+		/// <typeparam name="TApp">The type to use as the application.</typeparam>
+		/// <param name="builder">The <see cref="MauiAppBuilder"/> to configure.</param>
+		/// <returns>The configured <see cref="MauiAppBuilder"/>.</returns>
 		public static MauiAppBuilder UseMauiApp<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TApp>(this MauiAppBuilder builder)
 			where TApp : class, IApplication
 		{
@@ -39,6 +45,13 @@ namespace Microsoft.Maui.Controls.Hosting
 			return builder;
 		}
 
+		/// <summary>
+		/// Configures the <see cref="MauiAppBuilder"/> to use the specified <typeparamref name="TApp"/> as the main application type.
+		/// </summary>
+		/// <typeparam name="TApp">The type to use as the application.</typeparam>
+		/// <param name="builder">The <see cref="MauiAppBuilder"/> to configure.</param>
+		/// <param name="implementationFactory">A factory to create the specified <typeparamref name="TApp"/> using the services provided in a <see cref="IServiceProvider"/>.</param>
+		/// <returns>The configured <see cref="MauiAppBuilder"/>.</returns>
 		public static MauiAppBuilder UseMauiApp<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TApp>(this MauiAppBuilder builder, Func<IServiceProvider, TApp> implementationFactory)
 			where TApp : class, IApplication
 		{

--- a/src/Core/maps/src/Core/IMap.cs
+++ b/src/Core/maps/src/Core/IMap.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Maui.Maps
 		void Clicked(Location position);
 
 		/// <summary>
-		/// Moves the map so that it displays the specified MapSpan region.
+		/// Moves the map so that it displays the specified <see cref="MapSpan"/> region.
 		/// </summary>
 		void MoveToRegion(MapSpan region);
 	}

--- a/src/Core/src/Hosting/Fonts/FontCollectionExtensions.cs
+++ b/src/Core/src/Hosting/Fonts/FontCollectionExtensions.cs
@@ -13,8 +13,8 @@ namespace Microsoft.Maui.Hosting
 		/// <param name="filename">The filename of the font to add, such as a True type format (TTF) or open type font (OTF) font file. Font files can be added to the 'Resources\Fonts' of a .NET MAUI project.</param>
 		/// <param name="alias">An optional alias that can also be used to reference this font.</param>
 		/// <returns></returns>
-		/// <exception cref="ArgumentNullException"></exception>
-		/// <exception cref="ArgumentException"></exception>
+		/// <exception cref="ArgumentNullException">The <paramref name="filename"/> parameter is <c>null</c>.</exception>
+		/// <exception cref="ArgumentException">The <paramref name="filename"/> parameter is empty or only whitespace.</exception>
 		public static IFontCollection AddFont(this IFontCollection fontCollection, string filename, string? alias = null)
 		{
 			_ = filename ?? throw new ArgumentNullException(nameof(filename));
@@ -33,8 +33,8 @@ namespace Microsoft.Maui.Hosting
 		/// <param name="filename">The embedded resource filename of the font to add, such as a True type format (TTF) or open type font (OTF) font file.</param>
 		/// <param name="alias">An optional alias that can also be used to reference this font.</param>
 		/// <returns></returns>
-		/// <exception cref="ArgumentNullException"></exception>
-		/// <exception cref="ArgumentException"></exception>
+		/// <exception cref="ArgumentNullException">The <paramref name="filename"/> parameter is <c>null</c>. -or- The <paramref name="assembly"/> parameter is <c>null</c>.</exception>
+		/// <exception cref="ArgumentException">The <paramref name="filename"/> parameter is empty or only whitespace.</exception>
 		public static IFontCollection AddEmbeddedResourceFont(this IFontCollection fontCollection, Assembly assembly, string filename, string? alias = null)
 		{
 			_ = assembly ?? throw new ArgumentNullException(nameof(assembly));

--- a/src/Core/src/Hosting/Fonts/FontCollectionExtensions.cs
+++ b/src/Core/src/Hosting/Fonts/FontCollectionExtensions.cs
@@ -6,6 +6,15 @@ namespace Microsoft.Maui.Hosting
 {
 	public static class FontCollectionExtensions
 	{
+		/// <summary>
+		/// Adds the font specified in <paramref name="filename"/> to the <paramref name="fontCollection"/>, with an optional font alias specified in <paramref name="alias"/>.
+		/// </summary>
+		/// <param name="fontCollection">The collection to add the font to.</param>
+		/// <param name="filename">The filename of the font to add, such as a True type format (TTF) or open type font (OTF) font file. Font files can be added to the 'Resources\Fonts' of a .NET MAUI project.</param>
+		/// <param name="alias">An optional alias that can also be used to reference this font.</param>
+		/// <returns></returns>
+		/// <exception cref="ArgumentNullException"></exception>
+		/// <exception cref="ArgumentException"></exception>
 		public static IFontCollection AddFont(this IFontCollection fontCollection, string filename, string? alias = null)
 		{
 			_ = filename ?? throw new ArgumentNullException(nameof(filename));
@@ -16,6 +25,16 @@ namespace Microsoft.Maui.Hosting
 			return fontCollection;
 		}
 
+		/// <summary>
+		/// Adds the font specified in <paramref name="filename"/> from an embedded resource in <paramref name="assembly"/> to the <paramref name="fontCollection"/>, with an optional font alias specified in <paramref name="alias"/>.
+		/// </summary>
+		/// <param name="fontCollection">The collection to add the font to.</param>
+		/// <param name="assembly">The assembly that contains the specified font as an embedded resource.</param>
+		/// <param name="filename">The embedded resource filename of the font to add, such as a True type format (TTF) or open type font (OTF) font file.</param>
+		/// <param name="alias">An optional alias that can also be used to reference this font.</param>
+		/// <returns></returns>
+		/// <exception cref="ArgumentNullException"></exception>
+		/// <exception cref="ArgumentException"></exception>
 		public static IFontCollection AddEmbeddedResourceFont(this IFontCollection fontCollection, Assembly assembly, string filename, string? alias = null)
 		{
 			_ = assembly ?? throw new ArgumentNullException(nameof(assembly));

--- a/src/Core/src/Hosting/Fonts/FontsMauiAppBuilderExtensions.cs
+++ b/src/Core/src/Hosting/Fonts/FontsMauiAppBuilderExtensions.cs
@@ -9,12 +9,23 @@ namespace Microsoft.Maui.Hosting
 {
 	public static class FontsMauiAppBuilderExtensions
 	{
+		/// <summary>
+		/// Configures the <see cref="MauiAppBuilder"/> with fonts.
+		/// </summary>
+		/// <param name="builder">The <see cref="MauiAppBuilder"/> to configure.</param>
+		/// <returns>The configured <see cref="MauiAppBuilder"/>.</returns>
 		public static MauiAppBuilder ConfigureFonts(this MauiAppBuilder builder)
 		{
 			builder.ConfigureFonts(configureDelegate: null);
 			return builder;
 		}
 
+		/// <summary>
+		/// Configures the <see cref="MauiAppBuilder"/> with a specified delegate <paramref name="configureDelegate"/> to register fonts in the application.
+		/// </summary>
+		/// <param name="builder">The <see cref="MauiAppBuilder"/> to configure.</param>
+		/// <param name="configureDelegate">A configuration delegate that can register fonts in the provided <see cref="IFontCollection"/>.</param>
+		/// <returns>The configured <see cref="MauiAppBuilder"/>.</returns>
 		public static MauiAppBuilder ConfigureFonts(this MauiAppBuilder builder, Action<IFontCollection>? configureDelegate)
 		{
 			builder.Services.TryAddSingleton<IEmbeddedFontLoader>(svc => new EmbeddedFontLoader(svc));

--- a/src/Core/src/Hosting/Fonts/IFontCollection.cs
+++ b/src/Core/src/Hosting/Fonts/IFontCollection.cs
@@ -3,6 +3,9 @@ using System.Collections.Generic;
 
 namespace Microsoft.Maui.Hosting
 {
+	/// <summary>
+	/// A collection of fonts.
+	/// </summary>
 	public interface IFontCollection : IList<FontDescriptor>, ICollection<FontDescriptor>, IEnumerable<FontDescriptor>, IEnumerable
 	{
 	}

--- a/src/Core/src/Hosting/MauiApp.cs
+++ b/src/Core/src/Hosting/MauiApp.cs
@@ -5,6 +5,9 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.Maui.Hosting
 {
+	/// <summary>
+	/// A .NET MAUI application with registered services and configuration data.
+	/// </summary>
 	public sealed class MauiApp : IDisposable, IAsyncDisposable
 	{
 		private readonly IServiceProvider _services;

--- a/src/Core/src/Platform/Android/MauiApplication.cs
+++ b/src/Core/src/Platform/Android/MauiApplication.cs
@@ -10,6 +10,9 @@ using Microsoft.Maui.LifecycleEvents;
 
 namespace Microsoft.Maui
 {
+	/// <summary>
+	/// Defines the core behavior of a .NET MAUI application running on Android.
+	/// </summary>
 	public abstract class MauiApplication : Application, IPlatformApplication
 	{
 		protected MauiApplication(IntPtr handle, JniHandleOwnership ownership) : base(handle, ownership)
@@ -18,6 +21,12 @@ namespace Microsoft.Maui
 			IPlatformApplication.Current = this;
 		}
 
+		/// <summary>
+		/// When overridden in a derived class, creates the <see cref="MauiApp"/> to be used in this application.
+		/// Typically a <see cref="MauiApp"/> is created by calling <see cref="MauiApp.CreateBuilder(bool)"/>, configuring
+		/// the returned <see cref="MauiAppBuilder"/>, and returning the built app by calling <see cref="MauiAppBuilder.Build"/>.
+		/// </summary>
+		/// <returns>The built <see cref="MauiApp"/>.</returns>
 		protected abstract MauiApp CreateMauiApp();
 
 		public override void OnCreate()

--- a/src/Core/src/Platform/Windows/MauiWinUIApplication.cs
+++ b/src/Core/src/Platform/Windows/MauiWinUIApplication.cs
@@ -5,8 +5,17 @@ using Microsoft.Maui.LifecycleEvents;
 
 namespace Microsoft.Maui
 {
+	/// <summary>
+	/// Defines the core behavior of a .NET MAUI application running on Windows.
+	/// </summary>
 	public abstract class MauiWinUIApplication : UI.Xaml.Application, IPlatformApplication
 	{
+		/// <summary>
+		/// When overridden in a derived class, creates the <see cref="MauiApp"/> to be used in this application.
+		/// Typically a <see cref="MauiApp"/> is created by calling <see cref="MauiApp.CreateBuilder(bool)"/>, configuring
+		/// the returned <see cref="MauiAppBuilder"/>, and returning the built app by calling <see cref="MauiAppBuilder.Build"/>.
+		/// </summary>
+		/// <returns>The built <see cref="MauiApp"/>.</returns>
 		protected abstract MauiApp CreateMauiApp();
 
 		protected override void OnLaunched(UI.Xaml.LaunchActivatedEventArgs args)

--- a/src/Core/src/Platform/iOS/MauiUIApplicationDelegate.cs
+++ b/src/Core/src/Platform/iOS/MauiUIApplicationDelegate.cs
@@ -8,6 +8,9 @@ using UIKit;
 
 namespace Microsoft.Maui
 {
+	/// <summary>
+	/// Defines the core behavior of a .NET MAUI application running on iOS and MacCatalyst.
+	/// </summary>
 	public abstract partial class MauiUIApplicationDelegate : UIResponder, IUIApplicationDelegate, IPlatformApplication
 	{
 		internal const string MauiSceneConfigurationKey = "__MAUI_DEFAULT_SCENE_CONFIGURATION__";
@@ -21,6 +24,12 @@ namespace Microsoft.Maui
 			IPlatformApplication.Current = this;
 		}
 
+		/// <summary>
+		/// When overridden in a derived class, creates the <see cref="MauiApp"/> to be used in this application.
+		/// Typically a <see cref="MauiApp"/> is created by calling <see cref="MauiApp.CreateBuilder(bool)"/>, configuring
+		/// the returned <see cref="MauiAppBuilder"/>, and returning the built app by calling <see cref="MauiAppBuilder.Build"/>.
+		/// </summary>
+		/// <returns>The built <see cref="MauiApp"/>.</returns>
 		protected abstract MauiApp CreateMauiApp();
 
 		[Export("application:willFinishLaunchingWithOptions:")]

--- a/src/Core/src/Primitives/LayoutAlignment.cs
+++ b/src/Core/src/Primitives/LayoutAlignment.cs
@@ -3,17 +3,17 @@
 	// We don't use Microsoft.Maui.Controls.LayoutAlignment directly because it has a Flags attribute, which we do not want
 
 	/// <summary>
-	/// Determines the position and size of an IView when arranged in a parent element
+	/// Determines the position and size of an IView when arranged in a parent element.
 	/// </summary>
 	public enum LayoutAlignment
 	{
 		/// <summary>
-		/// Fill the available space
+		/// Fill the available space.
 		/// </summary>
 		Fill,
 
 		/// <summary>
-		/// Align with the leading edge of the available space, as determined by FlowDirection
+		/// Align with the leading edge of the available space, as determined by FlowDirection.
 		/// </summary>
 		Start,
 
@@ -23,7 +23,7 @@
 		Center,
 
 		/// <summary>
-		/// Align with the trailing edge of the available space, as determined by FlowDirection
+		/// Align with the trailing edge of the available space, as determined by FlowDirection.
 		/// </summary>
 		End
 	}

--- a/src/Core/src/Primitives/LayoutAlignment.cs
+++ b/src/Core/src/Primitives/LayoutAlignment.cs
@@ -3,7 +3,7 @@
 	// We don't use Microsoft.Maui.Controls.LayoutAlignment directly because it has a Flags attribute, which we do not want
 
 	/// <summary>
-	/// Determines the position and size of an IView when arranged in a parent element.
+	/// Determines the position and size of an <see cref="IView"/> when arranged in a parent element.
 	/// </summary>
 	public enum LayoutAlignment
 	{
@@ -13,17 +13,17 @@
 		Fill,
 
 		/// <summary>
-		/// Align with the leading edge of the available space, as determined by FlowDirection.
+		/// Align with the leading edge of the available space, as determined by <see cref="FlowDirection"/>.
 		/// </summary>
 		Start,
 
 		/// <summary>
-		/// Center in the available space
+		/// Center in the available space.
 		/// </summary>
 		Center,
 
 		/// <summary>
-		/// Align with the trailing edge of the available space, as determined by FlowDirection.
+		/// Align with the trailing edge of the available space, as determined by <see cref="FlowDirection"/>.
 		/// </summary>
 		End
 	}

--- a/src/Core/src/Primitives/WebNavigationEvent.cs
+++ b/src/Core/src/Primitives/WebNavigationEvent.cs
@@ -1,10 +1,25 @@
 namespace Microsoft.Maui
 {
+	/// <summary>
+	/// Contains values that indicate why a navigation event was raised.
+	/// </summary>
 	public enum WebNavigationEvent
 	{
+		/// <summary>
+		/// Indicates that the navigation resulted from the user going back to a previous page in the navigation history.
+		/// </summary>
 		Back = 1,
+		/// <summary>
+		/// Indicates that the navigation resulted from the user going forward to a later page in the navigation history.
+		/// </summary>
 		Forward = 2,
+		/// <summary>
+		/// Indicates that the navigation was to a previously unvisited page, according to the navigation history.
+		/// </summary>
 		NewPage = 3,
+		/// <summary>
+		/// Indicates that the navigation resulted from a page refresh.
+		/// </summary>
 		Refresh = 4
 	}
 }

--- a/src/Core/src/Primitives/WebNavigationResult.cs
+++ b/src/Core/src/Primitives/WebNavigationResult.cs
@@ -1,10 +1,25 @@
 namespace Microsoft.Maui
 {
+	/// <summary>
+	/// Enumerates values that indicate the outcome of a web navigation.
+	/// </summary>
 	public enum WebNavigationResult
 	{
+		/// <summary>
+		/// The navigation was cancelled.
+		/// </summary>
 		Success = 1,
+		/// <summary>
+		/// The navigation failed.
+		/// </summary>
 		Cancel = 2,
+		/// <summary>
+		/// The navigation succeeded.
+		/// </summary>
 		Timeout = 3,
+		/// <summary>
+		/// The navigation timed out.
+		/// </summary>
 		Failure = 4
 	}
 }


### PR DESCRIPTION
I went through every type/method/etc. used in the default MAUI app template and ensured there are doc for all of them.

I also added a few miscellaneous docs for WebView types and Map (many were copied from Xamarin.Forms docs).
