### PR TITLE
Use same type converter for Brush as for Color to enable XAML completion

### DIFF
--- a/src/Controls/src/Core.Design/AttributeTableBuilder.cs
+++ b/src/Controls/src/Core.Design/AttributeTableBuilder.cs
@@ -61,6 +61,7 @@ namespace Microsoft.Maui.Controls.Design
 			//new System.Windows.Markup.MarkupExtensionReturnTypeAttribute (),
 			);
 
+			AddTypeAttributes("Microsoft.Maui.Controls.Brush", new TypeConverterAttribute(typeof(ColorDesignTypeConverter)));
 			AddTypeAttributes("Microsoft.Maui.Graphics.Color", new TypeConverterAttribute(typeof(ColorDesignTypeConverter)));
 			AddTypeAttributes("Microsoft.Maui.GridLength", new TypeConverterAttribute(typeof(GridLengthDesignTypeConverter)));
 

--- a/src/Controls/src/Core.Design/AttributeTableBuilder.cs
+++ b/src/Controls/src/Core.Design/AttributeTableBuilder.cs
@@ -33,6 +33,12 @@ namespace Microsoft.Maui.Controls.Design
 			AddMemberAttributes("Microsoft.Maui.Controls.VisualElement", "FlowDirection",
 			   new TypeConverterAttribute(typeof(FlowDirectionDesignTypeConverter)));
 
+			// We need to supersede type converted declared on VisualElement.Background,
+			// otherwise VS will use generic "all strings allowed" converter which
+			// does not expose color values, i.e. no XAML intellisense popup
+			AddMemberAttributes("Microsoft.Maui.Controls.VisualElement", "Background",
+			   new TypeConverterAttribute(typeof(ColorDesignTypeConverter)));
+
 			AddMemberAttributes("Microsoft.Maui.Controls.ItemsView", "ItemsLayout",
 			   new TypeConverterAttribute(typeof(ItemsLayoutDesignTypeConverter)));
 


### PR DESCRIPTION
Use same type converter for Brush as for Color to enable XAML completion in VS

fixes #17636