### PR TITLE
Null guard in `ShellFlyoutTemplatedContentRenderer.HeaderContainer.UpdateMinimumHeight`

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFlyoutTemplatedContentRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFlyoutTemplatedContentRenderer.cs
@@ -789,7 +789,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 					frameLayoutView.SetMinimumHeight(minHeight);
 				}
 
-				if (PlatformView.MinimumHeight != minHeight)
+				if (PlatformView?.MinimumHeight != minHeight)
 				{
 					PlatformView.SetMinimumHeight(minHeight);
 				}

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFlyoutTemplatedContentRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFlyoutTemplatedContentRenderer.cs
@@ -789,7 +789,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 					frameLayoutView.SetMinimumHeight(minHeight);
 				}
 
-				if (PlatformView?.MinimumHeight != minHeight)
+				if (PlatformView is not nulll && PlatformView.MinimumHeight != minHeight)
 				{
 					PlatformView.SetMinimumHeight(minHeight);
 				}

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFlyoutTemplatedContentRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFlyoutTemplatedContentRenderer.cs
@@ -789,7 +789,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 					frameLayoutView.SetMinimumHeight(minHeight);
 				}
 
-				if (PlatformView is not nulll && PlatformView.MinimumHeight != minHeight)
+				if (PlatformView is not null && PlatformView.MinimumHeight != minHeight)
 				{
 					PlatformView.SetMinimumHeight(minHeight);
 				}


### PR DESCRIPTION
### Description of Change

Regular NullReferenceExceptions here, as described in #13825 
Absent guidance, trying to push this ahead. Hopefully it can be backported to 7.0.

### Issues Fixed

Fixes #13825