### PR TITLE
[ios] fix memory leak in GraphicsView

### DIFF
--- a/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
+++ b/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
@@ -19,6 +19,7 @@ public class MemoryTests : ControlsHandlerTestBase
 				handlers.AddHandler<CheckBox, CheckBoxHandler>();
 				handlers.AddHandler<Entry, EntryHandler>();
 				handlers.AddHandler<Editor, EditorHandler>();
+				handlers.AddHandler<GraphicsView, GraphicsViewHandler>();
 				handlers.AddHandler<Label, LabelHandler>();
 				handlers.AddHandler<IContentView, ContentViewHandler>();
 				handlers.AddHandler<Image, ImageHandler>();
@@ -34,6 +35,7 @@ public class MemoryTests : ControlsHandlerTestBase
 	[InlineData(typeof(CheckBox))]
 	[InlineData(typeof(Entry))]
 	[InlineData(typeof(Editor))]
+	[InlineData(typeof(GraphicsView))]
 	[InlineData(typeof(Image))]
 	[InlineData(typeof(Label))]
 	[InlineData(typeof(RefreshView))]


### PR DESCRIPTION
Context: https://github.com/dotnet/maui/pull/16346

This addresses the memory leak discovered by:

    src/Core/src/Platform/iOS/PlatformTouchGraphicsView.cs(12,29): error MA0002: Member '_hoverGesture' could cause memory leaks in an NSObject subclass. Remove the member, store the value as a WeakReference, or add the [UnconditionalSuppressMessage("Memory", "MA0002")] attribute with a justification as to why the member will not leak.

I could reproduce a leak in `MemoryTests.cs`:

    ++[InlineData(typeof(GraphicsView))]
    public async Task HandlerDoesNotLeak(Type type)

Solved the problem by fixing two places:

* `PlatformTouchGraphicsView` now stores the `IGraphicsView` as a `WeakReference`.

* A `UIHoverGestureRecognizerProxy` is used for callbacks to the `UIHoverGestureRecognizer`.