### PR TITLE
[ios] fix memory leak in ResignFirstResponderTouchGestureRecognizer

### DIFF
--- a/src/Core/tests/DeviceTests/Memory/UIViewSubclassTests.cs
+++ b/src/Core/tests/DeviceTests/Memory/UIViewSubclassTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using UIKit;
 using Xunit;
 
 #if IOS || MACCATALYST
@@ -47,6 +48,26 @@ namespace Microsoft.Maui.DeviceTests.Memory
 			Assert.False(reference.IsAlive, "MauiDoneAccessoryView should not be alive!");
 		}
 #endif
+
+		[Fact]
+		public async Task ResignFirstResponderTouchGestureRecognizer()
+		{
+			WeakReference viewReference = null;
+			WeakReference recognizerReference = null;
+
+			await InvokeOnMainThreadAsync(() =>
+			{
+				var view = new UIView();
+				var recognizer = new ResignFirstResponderTouchGestureRecognizer(view);
+				view.AddGestureRecognizer(recognizer);
+				viewReference = new(view);
+				recognizerReference = new(recognizer);
+			});
+
+			await AssertionExtensions.WaitForGC(viewReference, recognizerReference);
+			Assert.False(viewReference.IsAlive, "UIView should not be alive!");
+			Assert.False(recognizerReference.IsAlive, "ResignFirstResponderTouchGestureRecognizer should not be alive!");
+		}
 	}
 }
 


### PR DESCRIPTION
Context: https://github.com/dotnet/maui/pull/16346

This addresses the memory leak discovered by:

    src/Core/src/Platform/iOS/ResignFirstResponderTouchGestureRecognizer.cs(10,10): error MA0002: Member '_token' could cause memory leaks in an NSObject subclass. Remove the member, store the value as a WeakReference, or add the [UnconditionalSuppressMessage("Memory", "MA0002")] attribute with a justification as to why the member will not leak.
    src/Core/src/Platform/iOS/ResignFirstResponderTouchGestureRecognizer.cs(9,11): error MA0002: Member '_targetView' could cause memory leaks in an NSObject subclass. Remove the member, store the value as a WeakReference, or add the [UnconditionalSuppressMessage("Memory", "MA0002")] attribute with a justification as to why the member will not leak.

I could reproduce a leak in a test:

    WeakReference viewReference = null;
    WeakReference recognizerReference = null;

    await InvokeOnMainThreadAsync(() =>
    {
        var view = new UIView();
        var recognizer = new ResignFirstResponderTouchGestureRecognizer(view);
        view.AddGestureRecognizer(recognizer);
        viewReference = new(view);
        recognizerReference = new(recognizer);
    });

    await AssertionExtensions.WaitForGC(viewReference, recognizerReference);
    Assert.False(viewReference.IsAlive, "UIView should not be alive!");
    Assert.False(recognizerReference.IsAlive, "ResignFirstResponderTouchGestureRecognizer should not be alive!");

Solved the problem by making a `UIView _targetView` a `WeakReference`.

I also made a few methods `static` that were able to be.

This looks like it would affect the following controls:

* `Editor`
* `Entry`
* `SearchBar`
