### PR TITLE
Fix the OnNavigatedTo event and the OnAppearing event to return the ScrollToAsync method call

### DIFF
--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Windows.cs
@@ -78,7 +78,15 @@ namespace Microsoft.Maui.Handlers
 		{
 			if (args is ScrollToRequest request)
 			{
-				handler.PlatformView.ChangeView(request.HorizontalOffset, request.VerticalOffset, null, request.Instant);
+				if (handler.PlatformView.HorizontalOffset == request.HorizontalOffset &&
+					handler.PlatformView.VerticalOffset == request.VerticalOffset)
+				{
+					handler.VirtualView.ScrollFinished();
+				}
+				else
+				{
+					handler.PlatformView.ChangeView(request.HorizontalOffset, request.VerticalOffset, null, request.Instant);
+				}
 			}
 		}
 


### PR DESCRIPTION
This PR fixes the problem that the call does not return when the ScrollToAsync method is 
called at the timing of OnNavigatedTo, OnAppearing events.

### Description of Change

If the ScrollToAsync method is called in the OnNavigatedTo or OnAppearing event, the Handler is null 
at this point, so I added code to handle the scroll request in the Loaded event.

[src\Controls\src\Core\ScrollView\ScrollView.cs]

    void OnScrollToRequested(ScrollToRequestedEventArgs e)
    {
        CheckTaskCompletionSource();
        ScrollToRequested?.Invoke(this, e);

        if (Handler is not null)
        {
            Handler.Invoke(nameof(IScrollView.RequestScrollTo), ConvertRequestMode(e).ToRequest());
        }
        else
        {
            Loaded += (sender, args) =>
            {
                Dispatcher.Dispatch(() =>
                {
                    Handler?.Invoke(nameof(IScrollView.RequestScrollTo), ConvertRequestMode(e).ToRequest());
                });
            };
        }
    }

On Windows, the ViewChanged event doesn't fire until the ScrollView's position is updated, so I added code to call the ScrollFinish method if the requested scroll position is the same as the current scroll position when processing a scroll request.

[src\Core\src\Handlers\ScrollView\ScrollViewHandler.Windows.cs]

    public static void MapRequestScrollTo(IScrollViewHandler handler, IScrollView scrollView, object? args)
    {
        if (args is ScrollToRequest request)
        {
            if (handler.PlatformView.HorizontalOffset == request.HorizontalOffset &&
                handler.PlatformView.VerticalOffset == request.VerticalOffset)
            {
                handler.VirtualView.ScrollFinished();
            }
            else
            {
                handler.PlatformView.ChangeView(request.HorizontalOffset, request.VerticalOffset, null, request.Instant);
            }
        }
    }

<!-- Enter description of the fix in this section -->

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #15387 

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->

I used the following code for testing.

https://github.com/cat0363/Maui-IssueScrollToAsync2.git

The following log is output to the Editor before and after calling the ScrollToAsync method.

        txtLog.Text += ("Before ScrollToAsync" + Environment.NewLine);
        await svTestItem.ScrollToAsync(0, 200, false);
        txtLog.Text += ("After ScrollToAsync" + Environment.NewLine);

Below is the execution result.

[iOS]

<table>
  <tr>
    <td>[OnNavigatedTo]</td>
    <td>[OnAppearing]</td>
  </tr>
  <tr>
    <td><video controls width="300" src="https://github.com/dotnet/maui/assets/125236133/b187cdd5-ccf2-4def-97b0-3e3f26724b45" /></td>
    <td><video controls width="300" src="https://github.com/dotnet/maui/assets/125236133/b1e835b9-b9b4-4a64-a3d6-99b26628671d" /></td>
  </tr>
</table>

[Android]

<table>
  <tr>
    <td>[OnNavigatedTo]</td>
    <td>[OnAppearing]</td>
  </tr>
  <tr>
    <td><video controls width="300" src="https://github.com/dotnet/maui/assets/125236133/711776f7-751a-47fd-8c0b-013c741781f9" /></td>
    <td><video controls width="300" src="https://github.com/dotnet/maui/assets/125236133/debbb7c3-bbc0-4c67-9448-e62869510a85" /></td>
  </tr>
</table>

[Windows]

<table>
  <tr>
    <td>[OnNavigatedTo]</td>
    <td>[OnAppearing]</td>
  </tr>
  <tr>
    <td><video controls width="300" src="https://github.com/dotnet/maui/assets/125236133/83c919e6-f30f-4995-96e4-b8f29a4c40e4" /></td>
    <td><video controls width="300" src="https://github.com/dotnet/maui/assets/125236133/497d9dc8-68c6-4a28-9852-a8a3fe29fbcf" /></td>
  </tr>
</table>

You can see that the ScrollToAsync method call is returned in the OnNavigatedTo event and OnAppearing event on all platforms.
The log is already displayed when the screen is started, but it is the log when the ScrollToAsync method is called in the OnNavigateTo event and OnAppearing event that is called when the screen is displayed for the first time.