### PR TITLE
Use runtime check for setting WKWebView inspectable flag

### DIFF
--- a/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
+++ b/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
@@ -21,7 +21,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 	public partial class BlazorWebViewHandler : ViewHandler<IBlazorWebView, WKWebView>
 	{
 		private IOSWebViewManager? _webviewManager;
-		
+
 		internal const string AppOrigin = "app://" + BlazorWebView.AppHostAddress + "/";
 		internal static readonly Uri AppOriginUri = new(AppOrigin);
 		private const string BlazorInitScript = @"

--- a/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
+++ b/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
@@ -21,7 +21,6 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 	public partial class BlazorWebViewHandler : ViewHandler<IBlazorWebView, WKWebView>
 	{
 		private IOSWebViewManager? _webviewManager;
-		private static bool IsiOS16OrNewer => UIDevice.CurrentDevice.CheckSystemVersion(16, 4);
 		internal const string AppOrigin = "app://" + BlazorWebView.AppHostAddress + "/";
 		internal static readonly Uri AppOriginUri = new(AppOrigin);
 		private const string BlazorInitScript = @"
@@ -100,7 +99,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 				// Enable Developer Extras for Catalyst/iOS builds for 16.4+
 				webview.SetValueForKey(NSObject.FromObject(DeveloperTools.Enabled), new NSString("inspectable"));
 			}
-			
+
 			VirtualView.BlazorWebViewInitialized(new BlazorWebViewInitializedEventArgs
 			{
 				WebView = webview

--- a/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
+++ b/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
@@ -21,7 +21,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 	public partial class BlazorWebViewHandler : ViewHandler<IBlazorWebView, WKWebView>
 	{
 		private IOSWebViewManager? _webviewManager;
-
+		private static bool IsiOS16OrNewer => UIDevice.CurrentDevice.CheckSystemVersion(16, 4);
 		internal const string AppOrigin = "app://" + BlazorWebView.AppHostAddress + "/";
 		internal static readonly Uri AppOriginUri = new(AppOrigin);
 		private const string BlazorInitScript = @"
@@ -95,10 +95,12 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 				AutosizesSubviews = true
 			};
 
-#if MACCATALYST13_3_OR_GREATER || IOS16_4_OR_GREATER
-			// Enable Developer Extras for Catalyst/iOS builds for 16.4+
-			webview.SetValueForKey(NSObject.FromObject(DeveloperTools.Enabled), new NSString("inspectable"));
-#endif
+			if (UIDevice.CurrentDevice.CheckSystemVersion(16, 4))
+			{
+				// Enable Developer Extras for Catalyst/iOS builds for 16.4+
+				webview.SetValueForKey(NSObject.FromObject(DeveloperTools.Enabled), new NSString("inspectable"));
+			}
+			
 			VirtualView.BlazorWebViewInitialized(new BlazorWebViewInitializedEventArgs
 			{
 				WebView = webview

--- a/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
+++ b/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
@@ -21,6 +21,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 	public partial class BlazorWebViewHandler : ViewHandler<IBlazorWebView, WKWebView>
 	{
 		private IOSWebViewManager? _webviewManager;
+		
 		internal const string AppOrigin = "app://" + BlazorWebView.AppHostAddress + "/";
 		internal static readonly Uri AppOriginUri = new(AppOrigin);
 		private const string BlazorInitScript = @"

--- a/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
+++ b/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
@@ -95,7 +95,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 				AutosizesSubviews = true
 			};
 
-			if (UIDevice.CurrentDevice.CheckSystemVersion(16, 4))
+			if (OperatingSystem.IsIOSVersionAtLeast(13) || OperatingSystem.IsMacCatalystVersionAtLeast(13, 1)) 
 			{
 				// Enable Developer Extras for Catalyst/iOS builds for 16.4+
 				webview.SetValueForKey(NSObject.FromObject(DeveloperTools.Enabled), new NSString("inspectable"));

--- a/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
+++ b/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
@@ -95,7 +95,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 				AutosizesSubviews = true
 			};
 
-			if (OperatingSystem.IsIOSVersionAtLeast(13) || OperatingSystem.IsMacCatalystVersionAtLeast(13, 1)) 
+			if (OperatingSystem.IsIOSVersionAtLeast(16, 4) || OperatingSystem.IsMacCatalystVersionAtLeast(13, 3)) 
 			{
 				// Enable Developer Extras for Catalyst/iOS builds for 16.4+
 				webview.SetValueForKey(NSObject.FromObject(DeveloperTools.Enabled), new NSString("inspectable"));


### PR DESCRIPTION
### Description of Change

I made a mistake with my original PR by using a compile-time check and not a runtime check. This original code wouldn't work as written.

This flag can only be set if run on Catalyst above 13.1 and iOS above 16.4. This check happens to work on MAUI Catalyst, which is compiled for Catalyst 13.1 support but does nothing for iOS, since it's compiled for 11. This should be checked at runtime which this should do.

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/16611

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
