### PR TITLE
Fix the case where silent was requested

### DIFF
--- a/src/Controls/src/Core/BindableObject.cs
+++ b/src/Controls/src/Core/BindableObject.cs
@@ -444,8 +444,9 @@ namespace Microsoft.Maui.Controls
 			}
 			else
 			{
+				var silent = (privateAttributes & SetValuePrivateFlags.Silent) != 0;
 				context.Attributes |= BindableContextAttributes.IsBeingSet;
-				SetValueActual(property, context, value, currentlyApplying, attributes, specificity);
+				SetValueActual(property, context, value, currentlyApplying, attributes, specificity, silent);
 
 				Queue<SetValueArgs> delayQueue = context.DelayedSetters;
 				if (delayQueue != null)
@@ -453,7 +454,7 @@ namespace Microsoft.Maui.Controls
 					while (delayQueue.Count > 0)
 					{
 						SetValueArgs s = delayQueue.Dequeue();
-						SetValueActual(s.Property, s.Context, s.Value, s.CurrentlyApplying, s.Attributes, s.Specificity);
+						SetValueActual(s.Property, s.Context, s.Value, s.CurrentlyApplying, s.Attributes, s.Specificity, silent);
 					}
 
 					context.DelayedSetters = null;

--- a/src/Controls/tests/Core.UnitTests/BindableObjectUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/BindableObjectUnitTests.cs
@@ -627,7 +627,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 				changing = true;
 			};
 
-			bool changed = true;
+			bool changed = false;
 			mock.PropertyChanged += (o, e) =>
 			{
 				Assert.Equal(e.PropertyName, MockBindable.TextProperty.PropertyName);
@@ -639,8 +639,72 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 				BindableObject.SetValuePrivateFlags.Default,
 				SetterSpecificity.ManualValueSetter);
 
-			Assert.True(changing); // "PropertyChanging event did not fire"
-			Assert.True(changed); // "PropertyChanged event did not fire"
+			Assert.True(changing, "PropertyChanging event did not fire");
+			Assert.True(changed, "PropertyChanged event did not fire");
+		}
+
+		[Fact]
+		public void DoesNotRaiseOnSilent()
+		{
+			const string OldValue = "foo";
+			const string NewValue = "foo too";
+
+			var mock = new MockBindable();
+			mock.SetValue(MockBindable.TextProperty, OldValue);
+
+			bool changing = false;
+			mock.PropertyChanging += (o, e) =>
+			{
+				changing = true;
+			};
+
+			bool changed = false;
+			mock.PropertyChanged += (o, e) =>
+			{
+				changed = true;
+			};
+
+			mock.SetValueCore(MockBindable.TextProperty, NewValue,
+				SetValueFlags.None,
+				BindableObject.SetValuePrivateFlags.Silent,
+				SetterSpecificity.ManualValueSetter);
+
+			Assert.False(changing, "PropertyChanging event fired.");
+			Assert.False(changed, "PropertyChanged event fired");
+			Assert.Equal(NewValue, mock.Text);
+			Assert.Equal(NewValue, mock.GetValue(MockBindable.TextProperty));
+		}
+
+		[Fact]
+		public void DoesNotRaiseOnSilentEvenWithRaiseOnEqual()
+		{
+			const string OldValue = "foo";
+			const string NewValue = "foo too";
+
+			var mock = new MockBindable();
+			mock.SetValue(MockBindable.TextProperty, OldValue);
+
+			bool changing = false;
+			mock.PropertyChanging += (o, e) =>
+			{
+				changing = true;
+			};
+
+			bool changed = false;
+			mock.PropertyChanged += (o, e) =>
+			{
+				changed = true;
+			};
+
+			mock.SetValueCore(MockBindable.TextProperty, NewValue,
+				SetValueFlags.RaiseOnEqual,
+				BindableObject.SetValuePrivateFlags.Silent,
+				SetterSpecificity.ManualValueSetter);
+
+			Assert.False(changing, "PropertyChanging event fired.");
+			Assert.False(changed, "PropertyChanged event fired");
+			Assert.Equal(NewValue, mock.Text);
+			Assert.Equal(NewValue, mock.GetValue(MockBindable.TextProperty));
 		}
 
 		[Fact]


### PR DESCRIPTION
### Description of Change

This PR fixes the case where a silent update was requested, but events were still fired.

Code from @StephaneDelcroix in this PR: https://github.com/dotnet/maui/pull/16637/commits/107261f4c2115fe11079d6aeeb4c9be0838609fd

Tests as per request from @rmarinho 