### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,41 +1,9 @@
-# Tizen
+*       @dotnet/dotnet-maui-reviewers
+
+# Tizen (this probably doesn't work since these do not have write access
 **/Tizen @rookiejava @myroot @shyunmin @sung-su @JoonghyunCho
 *.tizen.cs @rookiejava @myroot @shyunmin @sung-su @JoonghyunCho
 *.Tizen.cs @rookiejava @myroot @shyunmin @sung-su @JoonghyunCho
-
-# GTK
-/Xamarin.Forms.ControlGallery.GTK/ @jsuarezruiz
-/Stubs/Xamarin.Forms.Platform.GTK/ @jsuarezruiz
-/Xamarin.Forms.Platform.GTK/ @jsuarezruiz
-/Xamarin.Forms.Maps.GTK/ @jsuarezruiz
-/EmbeddingTestBeds/Embedding.GTK/ @jsuarezruiz
-/PagesGallery/PagesGallery.GTK/ @jsuarezruiz
-/Xamarin.Forms.Core/PlatformConfiguration/GTKSpecific @jsuarezruiz
-
-# WPF
-/Xamarin.Forms.ControlGallery.WPF/ @mohachouch
-/Stubs/Xamarin.Forms.Platform.WPF/ @mohachouch
-/Xamarin.Forms.Platform.WPF/ @mohachouch
-/Xamarin.Forms.Maps.WPF/ @mohachouch
-/EmbeddingTestBeds/Embedding.WPF/ @mohachouch
-/PagesGallery/PagesGallery.WPF/ @mohachouch
-/Xamarin.Forms.Core/PlatformConfiguration/WPFSpecific @mohachouch
-
-# macOS
-/Xamarin.Forms.ControlGallery.macOS/ @rmarinho
-/Stubs/Xamarin.Forms.Platform.macOS/ @rmarinho
-/Xamarin.Forms.Platform.macOS/ @rmarinho
-/Xamarin.Forms.Maps.macOS/ @rmarinho
-/EmbeddingTestBeds/Embedding.macOS/ @rmarinho
-/PagesGallery/PagesGallery.macOS/ @rmarinho
-/Xamarin.Forms.Core/PlatformConfiguration/macOSSpecific @rmarinho
-
-# XAML
-/Xamarin.Forms.Xaml/ @StephaneDelcroix
-/Xamarin.Forms.Build.Tasks/ @StephaneDelcroix
-
-# Core
-/Xamarin.Forms.Core/ @StephaneDelcroix
 
 # Blazor Desktop
 /src/BlazorWebView/                                     @dotnet/dotnet-maui-blazor-eng


### PR DESCRIPTION
### Description of Change

Theoretically set the codeowner to dotnet-maui-reviewers, which should auto-assign code reviews.

Removed all the cruft from Xamarin.Forms days.
