### PR TITLE
[ios] fix memory leak in WindowOverlay

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Window/WindowOverlayTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Window/WindowOverlayTests.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.DeviceTests.Stubs;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests.Memory;
+
+[Category(TestCategory.WindowOverlay)]
+public class WindowOverlayTests : ControlsHandlerTestBase
+{
+	[Fact("Does Not Leak")]
+	public async Task DoesNotLeak()
+	{
+		WeakReference viewReference = null;
+
+		{
+			var window = new Window(new ContentPage());
+
+			await CreateHandlerAndAddToWindow<WindowHandlerStub>(window, _ =>
+			{
+				var overlay = new WindowOverlay(window);
+				viewReference = new(overlay);
+				window.AddOverlay(overlay);
+				window.RemoveOverlay(overlay);
+			});
+		}
+
+		await AssertionExtensions.WaitForGC(viewReference);
+		Assert.False(viewReference.IsAlive, "WindowOverlay should not be alive!");
+	}
+}
+

--- a/src/Controls/tests/DeviceTests/TestCategory.cs
+++ b/src/Controls/tests/DeviceTests/TestCategory.cs
@@ -47,5 +47,6 @@
 		public const string VisualElementTree = "VisualElementTree";
 		public const string WebView = "WebView";
 		public const string Window = "Window";
+		public const string WindowOverlay = "WindowOverlay";
 	}
 }

--- a/src/Core/src/WindowOverlay/WindowOverlay.iOS.cs
+++ b/src/Core/src/WindowOverlay/WindowOverlay.iOS.cs
@@ -51,8 +51,6 @@ namespace Microsoft.Maui
 			platformWindow.RootViewController.View.AddSubview(_passthroughView);
 			platformWindow.RootViewController.View.BringSubviewToFront(_passthroughView);
 
-			// Any time the passthrough view is touched, handle it.
-			_passthroughView.OnTouch += UIViewOnTouch;
 			IsPlatformViewInitialized = true;
 			return IsPlatformViewInitialized;
 		}
@@ -75,9 +73,6 @@ namespace Microsoft.Maui
 			IsPlatformViewInitialized = false;
 		}
 
-		void UIViewOnTouch(object? sender, CGPoint e) =>
-			OnTappedInternal(new Point(e.X, e.Y));
-
 		void FrameAction(Foundation.NSObservedChange obj)
 		{
 			HandleUIChange();
@@ -86,12 +81,7 @@ namespace Microsoft.Maui
 
 		class PassthroughView : UIView
 		{
-			/// <summary>
-			/// Event Handler for handling on touch events on the Passthrough View.
-			/// </summary>
-			public event EventHandler<CGPoint>? OnTouch;
-
-			WindowOverlay overlay;
+			readonly WeakReference<WindowOverlay> _overlay;
 
 			/// <summary>
 			/// Initializes a new instance of the <see cref="PassthroughView"/> class.
@@ -101,7 +91,7 @@ namespace Microsoft.Maui
 			public PassthroughView(WindowOverlay windowOverlay, CGRect frame)
 				: base(frame)
 			{
-				overlay = windowOverlay;
+				_overlay = new(windowOverlay);
 			}
 
 			public override bool PointInside(CGPoint point, UIEvent? uievent)
@@ -119,12 +109,16 @@ namespace Microsoft.Maui
 
 				var disableTouchEvent = false;
 
-				if (overlay.DisableUITouchEventPassthrough)
-					disableTouchEvent = true;
-				else if (overlay.EnableDrawableTouchHandling)
-					disableTouchEvent = overlay.WindowElements.Any(n => n.Contains(new Point(point.X, point.Y)));
+				if (_overlay.TryGetTarget(out var overlay))
+				{
+					if (overlay.DisableUITouchEventPassthrough)
+						disableTouchEvent = true;
+					else if (overlay.EnableDrawableTouchHandling)
+						disableTouchEvent = overlay.WindowElements.Any(n => n.Contains(new Point(point.X, point.Y)));
 
-				OnTouch?.Invoke(this, point);
+					overlay.OnTappedInternal(new Point(point.X, point.Y));
+				}
+
 				return disableTouchEvent;
 			}
 		}


### PR DESCRIPTION
Context: https://github.com/dotnet/maui/pull/16346

This addresses the memory leak discovered by:

    src/Core/src/WindowOverlay/WindowOverlay.iOS.cs(92,40): error MA0001: Event 'OnTouch' could cause memory leaks in an NSObject subclass. Remove the event or add the [UnconditionalSuppressMessage("Memory", "MA0001")] attribute with a justification as to why the event will not leak.

I could reproduce a leak by writing a custom test.

Solved the problem by:

* Removed the `PassthroughView.OnTouch` event completely. We could just call `WindowOverlay.OnTappedInternal()` directly instead of going through an intermediate event.

* `WindowOverlay overlay` is now a `WeakReference<WindowOverlay>`.