### PR TITLE
Enable default xcode path

### DIFF
--- a/eng/devices/ios.cake
+++ b/eng/devices/ios.cake
@@ -166,14 +166,20 @@ Task("Test")
 		DeleteFiles(Directory(TEST_RESULTS).Path.Combine("*.*").FullPath);
 	}
 
-	var XCODE_PATH = "/Applications/Xcode_14.3.0.app";
+	var XCODE_PATH =  Argument("xcode_path", "/Applications/Xcode_14.3.0.app");
+	string xcode_args = "";
+	if (DirectoryExists(XCODE_PATH))
+	{
+		xcode_args = $"--xcode=\"{XCODE_PATH}\" ";
+	}
+
 	var settings = new DotNetToolSettings {
 		DiagnosticOutput = true,
 		ArgumentCustomization = args => args.Append("run xharness apple test " +
 		$"--app=\"{TEST_APP}\" " +
 		$"--targets=\"{TEST_DEVICE}\" " +
 		$"--output-directory=\"{TEST_RESULTS}\" " +
-		$"--xcode=\"{XCODE_PATH}\" " +
+		xcode_args +
 		$"--verbosity=\"Debug\" ")
 	};
 

--- a/eng/devices/ios.cake
+++ b/eng/devices/ios.cake
@@ -168,7 +168,7 @@ Task("Test")
 
 	var XCODE_PATH =  Argument("xcode_path", "/Applications/Xcode_14.3.0.app");
 	string xcode_args = "";
-	if (DirectoryExists(XCODE_PATH))
+	if (DirectoryExists(XCODE_PATH) || IsCIBuild())
 	{
 		xcode_args = $"--xcode=\"{XCODE_PATH}\" ";
 	}

--- a/eng/devices/ios.cake
+++ b/eng/devices/ios.cake
@@ -166,12 +166,18 @@ Task("Test")
 		DeleteFiles(Directory(TEST_RESULTS).Path.Combine("*.*").FullPath);
 	}
 
-	var XCODE_PATH =  Argument("xcode_path", "/Applications/Xcode_14.3.0.app");
+	var XCODE_PATH =  Argument("xcode_path", "");
+
+	if (String.IsNullOrEmpty(XCODE_PATH) && IsCIBuild())
+		XCODE_PATH = "/Applications/Xcode_14.3.0.app";
+		
 	string xcode_args = "";
-	if (DirectoryExists(XCODE_PATH) || IsCIBuild())
+	if (!String.IsNullOrEmpty(XCODE_PATH))
 	{
 		xcode_args = $"--xcode=\"{XCODE_PATH}\" ";
 	}
+
+	Information("XCODE PATH: {0}", XCODE_PATH);
 
 	var settings = new DotNetToolSettings {
 		DiagnosticOutput = true,


### PR DESCRIPTION
### Description of Change

When running device tests the Xcode path is hardcoded to a specific XCODE with a suffix of the version. This change makes it so when running locally we just leave that off or the user can pass in the XCODE argument themselves