### PR TITLE
Obsolete VisualElement.FocusChangeRequested event

### DIFF
--- a/src/Controls/src/Core/VisualElement/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement/VisualElement.cs
@@ -1075,7 +1075,7 @@ namespace Microsoft.Maui.Controls
 
 		internal virtual void ComputeConstraintForView(View view) => view.ComputedConstraint = LayoutConstraint.None;
 
-		// TODO: Obsolete in favor of MapFocus https://github.com/dotnet/maui/issues/14299
+		[Obsolete("This is now handled through VisualElement.MapFocus, this event handler will be removed in the future.")]
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public event EventHandler<FocusRequestArgs> FocusChangeRequested;
 		internal void InvokeFocusChangeRequested(FocusRequestArgs args) =>


### PR DESCRIPTION
### Description of Change

As indicated by a todo in code, obsoletes the `VisualElement.FocusChangeRequested` event. This is now handled through the `VisualElement` mapper with `MapFocus` by setting the `IView.Focus` property.

### Issues Fixed

Fixes #14299