### PR TITLE
[windows] Fix Picker PointerOver TextColor (#16751)

### DIFF
--- a/src/Core/src/Platform/Windows/PickerExtensions.cs
+++ b/src/Core/src/Platform/Windows/PickerExtensions.cs
@@ -59,6 +59,7 @@ namespace Microsoft.Maui.Platform
 		static readonly string[] TextColorResourceKeys =
 		{
 			"ComboBoxForeground",
+			"ComboBoxForegroundPointerOver",
 			"ComboBoxForegroundDisabled",
 			"ComboBoxForegroundFocused",
 			"ComboBoxForegroundFocusedPressed",


### PR DESCRIPTION
### Description of Change

Add missing resource key to allow PointerOver style to work for Picker controls on Windows

### Issues Fixed

Fixes #16751
