### PR TITLE
Streamline SwipeView Children

### DIFF
--- a/src/Controls/src/Core/Layout.cs
+++ b/src/Controls/src/Core/Layout.cs
@@ -266,8 +266,20 @@ namespace Microsoft.Maui.Controls.Compatibility
 			var oldBounds = new Rect[LogicalChildrenInternal.Count];
 			for (var index = 0; index < oldBounds.Length; index++)
 			{
-				var c = (VisualElement)LogicalChildrenInternal[index];
-				oldBounds[index] = c.Bounds;
+				if (LogicalChildrenInternal[index] is VisualElement c)
+				{
+					oldBounds[index] = c.Bounds;
+				}
+				else
+				{
+					// The Logical Children Of the Layout aren't VisualElements
+					// This means layout won't automatically be performed by this code
+					// This is really only relevant for controls that still inherit from the 
+					// legacy layouts. I think SwipeView is the only control that runs into this
+					// Because the children of SwipeView are all logical elements handled by the handler
+					// not by this code.
+					return;
+				}
 			}
 
 			double width = Width;

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -154,3 +154,5 @@ Microsoft.Maui.Controls.PointerEventArgs.PlatformArgs.get -> Microsoft.Maui.Cont
 Microsoft.Maui.Controls.PlatformPointerEventArgs
 Microsoft.Maui.Controls.PlatformPointerEventArgs.MotionEvent.get -> Android.Views.MotionEvent!
 Microsoft.Maui.Controls.PlatformPointerEventArgs.Sender.get -> Android.Views.View!
+*REMOVED*override Microsoft.Maui.Controls.SwipeItems.OnBindingContextChanged() -> void
+*REMOVED*override Microsoft.Maui.Controls.SwipeView.OnBindingContextChanged() -> void

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -156,3 +156,5 @@ Microsoft.Maui.Controls.ShellNavigationQueryParameters.Values.get -> System.Coll
 *REMOVED*~Microsoft.Maui.Controls.ItemsView.RemoveLogicalChild(Microsoft.Maui.Controls.Element element) -> void
 *REMOVED*~Microsoft.Maui.Controls.Shell.AddLogicalChild(Microsoft.Maui.Controls.Element element) -> void
 *REMOVED*~Microsoft.Maui.Controls.Shell.RemoveLogicalChild(Microsoft.Maui.Controls.Element element) -> void
+*REMOVED*override Microsoft.Maui.Controls.SwipeItems.OnBindingContextChanged() -> void
+*REMOVED*override Microsoft.Maui.Controls.SwipeView.OnBindingContextChanged() -> void

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -156,3 +156,5 @@ Microsoft.Maui.Controls.PointerEventArgs.PlatformArgs.get -> Microsoft.Maui.Cont
 Microsoft.Maui.Controls.PlatformPointerEventArgs
 Microsoft.Maui.Controls.PlatformPointerEventArgs.GestureRecognizer.get -> UIKit.UIGestureRecognizer!
 Microsoft.Maui.Controls.PlatformPointerEventArgs.Sender.get -> UIKit.UIView!
+*REMOVED*override Microsoft.Maui.Controls.SwipeItems.OnBindingContextChanged() -> void
+*REMOVED*override Microsoft.Maui.Controls.SwipeView.OnBindingContextChanged() -> void

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -137,3 +137,5 @@ Microsoft.Maui.Controls.Element.ClearLogicalChildren() -> void
 *REMOVED*~Microsoft.Maui.Controls.Shell.RemoveLogicalChild(Microsoft.Maui.Controls.Element element) -> void
 Microsoft.Maui.Controls.PointerEventArgs.PlatformArgs.get -> Microsoft.Maui.Controls.PlatformPointerEventArgs?
 Microsoft.Maui.Controls.PlatformPointerEventArgs
+*REMOVED*override Microsoft.Maui.Controls.SwipeItems.OnBindingContextChanged() -> void
+*REMOVED*override Microsoft.Maui.Controls.SwipeView.OnBindingContextChanged() -> void

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -157,3 +157,5 @@ Microsoft.Maui.Controls.PointerEventArgs.PlatformArgs.get -> Microsoft.Maui.Cont
 Microsoft.Maui.Controls.PlatformPointerEventArgs
 Microsoft.Maui.Controls.PlatformPointerEventArgs.RoutedEventArgs.get -> Microsoft.UI.Xaml.RoutedEventArgs!
 Microsoft.Maui.Controls.PlatformPointerEventArgs.Sender.get -> Microsoft.UI.Xaml.FrameworkElement!
+*REMOVED*override Microsoft.Maui.Controls.SwipeItems.OnBindingContextChanged() -> void
+*REMOVED*override Microsoft.Maui.Controls.SwipeView.OnBindingContextChanged() -> void

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -142,3 +142,5 @@ Microsoft.Maui.Controls.ShellNavigationQueryParameters.Values.get -> System.Coll
 *REMOVED*~Microsoft.Maui.Controls.Shell.RemoveLogicalChild(Microsoft.Maui.Controls.Element element) -> void
 Microsoft.Maui.Controls.PointerEventArgs.PlatformArgs.get -> Microsoft.Maui.Controls.PlatformPointerEventArgs?
 Microsoft.Maui.Controls.PlatformPointerEventArgs
+*REMOVED*override Microsoft.Maui.Controls.SwipeItems.OnBindingContextChanged() -> void
+*REMOVED*override Microsoft.Maui.Controls.SwipeView.OnBindingContextChanged() -> void

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -136,3 +136,5 @@ Microsoft.Maui.Controls.IValueConverter.ConvertBack(object? value, System.Type! 
 *REMOVED*~Microsoft.Maui.Controls.Shell.RemoveLogicalChild(Microsoft.Maui.Controls.Element element) -> void
 Microsoft.Maui.Controls.PointerEventArgs.PlatformArgs.get -> Microsoft.Maui.Controls.PlatformPointerEventArgs?
 Microsoft.Maui.Controls.PlatformPointerEventArgs
+*REMOVED*override Microsoft.Maui.Controls.SwipeItems.OnBindingContextChanged() -> void
+*REMOVED*override Microsoft.Maui.Controls.SwipeView.OnBindingContextChanged() -> void

--- a/src/Controls/src/Core/SwipeView/SwipeItems.cs
+++ b/src/Controls/src/Core/SwipeView/SwipeItems.cs
@@ -16,6 +16,10 @@ namespace Microsoft.Maui.Controls
 		/// <include file="../../docs/Microsoft.Maui.Controls/SwipeItems.xml" path="//Member[@MemberName='.ctor']/Docs/*" />
 		public SwipeItems(IEnumerable<ISwipeItem> swipeItems)
 		{
+			foreach (var item in swipeItems)
+				if (item is Element e)
+					AddLogicalChild(e);
+
 			_swipeItems = new ObservableCollection<Maui.ISwipeItem>(swipeItems) ?? throw new ArgumentNullException(nameof(swipeItems));
 			_swipeItems.CollectionChanged += OnSwipeItemsChanged;
 		}
@@ -68,6 +72,10 @@ namespace Microsoft.Maui.Controls
 		/// <include file="../../docs/Microsoft.Maui.Controls/SwipeItems.xml" path="//Member[@MemberName='Clear']/Docs/*" />
 		public void Clear()
 		{
+			foreach (var item in _swipeItems)
+				if (item is Element e)
+					RemoveLogicalChild(e);
+
 			_swipeItems.Clear();
 		}
 
@@ -114,24 +122,22 @@ namespace Microsoft.Maui.Controls
 			_swipeItems.RemoveAt(index);
 		}
 
-		protected override void OnBindingContextChanged()
-		{
-			base.OnBindingContextChanged();
-
-			object bc = BindingContext;
-
-			foreach (BindableObject item in _swipeItems)
-				SetInheritedBindingContext(item, bc);
-		}
-
 		void OnSwipeItemsChanged(object sender, NotifyCollectionChangedEventArgs notifyCollectionChangedEventArgs)
 		{
-			if (notifyCollectionChangedEventArgs.NewItems != null)
+			if (notifyCollectionChangedEventArgs.NewItems is not null)
 			{
-				object bc = BindingContext;
-				foreach (BindableObject item in notifyCollectionChangedEventArgs.NewItems)
-					SetInheritedBindingContext(item, bc);
+				foreach (var item in notifyCollectionChangedEventArgs.NewItems)
+					if (item is Element e)
+						AddLogicalChild(e);
 			}
+
+			if (notifyCollectionChangedEventArgs.OldItems is not null)
+			{
+				foreach (var item in notifyCollectionChangedEventArgs.OldItems)
+					if (item is Element e)
+						RemoveLogicalChild(e);
+			}
+
 			CollectionChanged?.Invoke(this, notifyCollectionChangedEventArgs);
 		}
 

--- a/src/Controls/src/Core/SwipeView/SwipeView.cs
+++ b/src/Controls/src/Core/SwipeView/SwipeView.cs
@@ -13,13 +13,15 @@ namespace Microsoft.Maui.Controls
 
 		readonly List<ISwipeItem> _swipeItems = new List<ISwipeItem>();
 
-		private protected override IList<Element> LogicalChildrenInternalBackingStore
-			=> new CastingList<Element, ISwipeItem>(_swipeItems);
-
 		/// <include file="../../docs/Microsoft.Maui.Controls/SwipeView.xml" path="//Member[@MemberName='.ctor']/Docs/*" />
 		public SwipeView()
 		{
 			_platformConfigurationRegistry = new Lazy<PlatformConfigurationRegistry<SwipeView>>(() => new PlatformConfigurationRegistry<SwipeView>(this));
+
+			AddLogicalChild(RightItems);
+			AddLogicalChild(LeftItems);
+			AddLogicalChild(TopItems);
+			AddLogicalChild(BottomItems);
 		}
 
 		/// <summary>Bindable property for <see cref="Threshold"/>.</summary>
@@ -92,18 +94,18 @@ namespace Microsoft.Maui.Controls
 			if (bindable is not SwipeView swipeView)
 				return;
 
-			swipeView.UpdateSwipeItemsParent((SwipeItems)newValue);
-
 			if (oldValue is SwipeItems oldItems)
 			{
 				oldItems.CollectionChanged -= SwipeItemsCollectionChanged;
 				oldItems.PropertyChanged -= SwipeItemsPropertyChanged;
+				swipeView.RemoveLogicalChild(oldItems);
 			}
 
 			if (newValue is SwipeItems newItems)
 			{
 				newItems.CollectionChanged += SwipeItemsCollectionChanged;
 				newItems.PropertyChanged += SwipeItemsPropertyChanged;
+				swipeView.AddLogicalChild(newItems);
 			}
 
 			void SwipeItemsPropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -172,48 +174,18 @@ namespace Microsoft.Maui.Controls
 
 		void ISwipeViewController.SendSwipeEnded(SwipeEndedEventArgs args) => SwipeEnded?.Invoke(this, args);
 
-		protected override void OnBindingContextChanged()
-		{
-			base.OnBindingContextChanged();
-
-			object bc = BindingContext;
-
-			if (LeftItems != null)
-				SetInheritedBindingContext(LeftItems, bc);
-
-			if (RightItems != null)
-				SetInheritedBindingContext(RightItems, bc);
-
-			if (TopItems != null)
-				SetInheritedBindingContext(TopItems, bc);
-
-			if (BottomItems != null)
-				SetInheritedBindingContext(BottomItems, bc);
-		}
-
 		SwipeItems SwipeItemsDefaultValueCreator() => new SwipeItems();
 
 		static object SwipeItemsDefaultValueCreator(BindableObject bindable)
 		{
-			return ((SwipeView)bindable).SwipeItemsDefaultValueCreator();
+			var swipeView = ((SwipeView)bindable);
+			return swipeView.SwipeItemsDefaultValueCreator();
 		}
 
 		/// <inheritdoc/>
 		public IPlatformElementConfiguration<T, SwipeView> On<T>() where T : IConfigPlatform
 		{
 			return _platformConfigurationRegistry.Value.On<T>();
-		}
-
-		void UpdateSwipeItemsParent(SwipeItems swipeItems)
-		{
-			if (swipeItems.Parent == null)
-				swipeItems.Parent = this;
-
-			foreach (var item in swipeItems)
-			{
-				if (item is Element swipeItem && swipeItem.Parent == null)
-					swipeItem.Parent = swipeItems;
-			}
 		}
 
 #nullable enable
@@ -241,7 +213,6 @@ namespace Microsoft.Maui.Controls
 				if (_isOpen != value)
 				{
 					_isOpen = value;
-					UpdateLogicalChildren();
 					Handler?.UpdateValue(nameof(ISwipeView.IsOpen));
 				}
 			}
@@ -403,46 +374,6 @@ namespace Microsoft.Maui.Controls
 		void ISwipeView.RequestClose(SwipeViewCloseRequest swipeCloseRequest)
 		{
 			Handler?.Invoke(nameof(ISwipeView.RequestClose), swipeCloseRequest);
-		}
-
-		void UpdateLogicalChildren()
-		{
-			if (!_isOpen)
-			{
-				ClearLogicalChildren();
-				return;
-			}
-
-			var swipeItems = GetSwipeItemsByDirection(_swipeDirection);
-
-			if (swipeItems is null)
-				return;
-
-			foreach (var swipeItem in swipeItems)
-				AddLogicalChild((Element)swipeItem);
-		}
-
-		SwipeItems? GetSwipeItemsByDirection(SwipeDirection? swipeDirection)
-		{
-			SwipeItems? swipeItems = null;
-
-			switch (swipeDirection)
-			{
-				case SwipeDirection.Left:
-					swipeItems = RightItems;
-					break;
-				case SwipeDirection.Right:
-					swipeItems = LeftItems;
-					break;
-				case SwipeDirection.Up:
-					swipeItems = BottomItems;
-					break;
-				case SwipeDirection.Down:
-					swipeItems = TopItems;
-					break;
-			}
-
-			return swipeItems;
 		}
 
 		class HandlerSwipeItems : List<Maui.ISwipeItem>, ISwipeItems

--- a/src/Controls/src/Core/SwipeView/SwipeView.cs
+++ b/src/Controls/src/Core/SwipeView/SwipeView.cs
@@ -18,6 +18,9 @@ namespace Microsoft.Maui.Controls
 		{
 			_platformConfigurationRegistry = new Lazy<PlatformConfigurationRegistry<SwipeView>>(() => new PlatformConfigurationRegistry<SwipeView>(this));
 
+			// This just disables any of the legacy layout code from running
+			DisableLayout = true;
+
 			AddLogicalChild(RightItems);
 			AddLogicalChild(LeftItems);
 			AddLogicalChild(TopItems);

--- a/src/Controls/src/Core/TemplatedView/TemplatedView.cs
+++ b/src/Controls/src/Core/TemplatedView/TemplatedView.cs
@@ -41,9 +41,9 @@ namespace Microsoft.Maui.Controls
 			double heightRequest = HeightRequest;
 			var childRequest = new SizeRequest();
 
-			if ((widthRequest == -1 || heightRequest == -1) && InternalChildren.Count > 0)
+			if ((widthRequest == -1 || heightRequest == -1) && InternalChildren.Count > 0 && InternalChildren[0] is View view)
 			{
-				childRequest = ((View)InternalChildren[0]).Measure(widthConstraint, heightConstraint, MeasureFlags.IncludeMargins);
+				childRequest = view.Measure(widthConstraint, heightConstraint, MeasureFlags.IncludeMargins);
 			}
 
 			return new SizeRequest

--- a/src/Controls/tests/Core.UnitTests/SwipeViewTests.cs
+++ b/src/Controls/tests/Core.UnitTests/SwipeViewTests.cs
@@ -1,5 +1,7 @@
 using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Platform;
 using Xunit;
+using Xunit.Sdk;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests
 {
@@ -15,6 +17,116 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.Empty(swipeView.TopItems);
 			Assert.Empty(swipeView.RightItems);
 			Assert.Empty(swipeView.BottomItems);
+		}
+
+		[Fact]
+		public void TestSwipeViewBindingContextChangedEvent()
+		{
+			var swipeView = new SwipeView();
+			bool passed = false;
+			swipeView.BindingContextChanged += (sender, args) => passed = true;
+
+			swipeView.BindingContext = new object();
+
+			if (!passed)
+			{
+				throw new XunitException("The BindingContextChanged event was not fired.");
+			}
+		}
+
+		[Fact]
+		public void TestContentBindingContextChangedEvent()
+		{
+			var content = new Label();
+			var swipeView = new SwipeView
+			{
+				Content = content
+			};
+
+			bool passed = false;
+			content.BindingContextChanged += (sender, args) => passed = true;
+
+			swipeView.BindingContext = new object();
+
+			if (!passed)
+			{
+				throw new XunitException("The BindingContextChanged event was not fired.");
+			}
+		}
+
+		[Fact]
+		public void ClearRemovesLogicalChildren()
+		{
+			var swipeView = new SwipeView();
+
+			swipeView.LeftItems = new SwipeItems
+			{
+				new SwipeItem(),
+				new SwipeItem(),
+				new SwipeItem(),
+				new SwipeItem(),
+				new SwipeItem()
+			};
+
+			swipeView.LeftItems.Clear();
+			Assert.Empty((swipeView.LeftItems as IVisualTreeElement).GetVisualChildren());
+		}
+
+		[Fact]
+		public void TestContentBindingContextPropagatesToNewSwipeItems()
+		{
+			var swipeView = new SwipeView();
+
+			swipeView.LeftItems = new SwipeItems
+			{
+				new SwipeItem()
+			};
+			swipeView.RightItems = new SwipeItems
+			{
+				new SwipeItem()
+			};
+			swipeView.TopItems = new SwipeItems
+			{
+				new SwipeItem()
+			};
+			swipeView.BottomItems = new SwipeItems
+			{
+				new SwipeItem()
+			};
+
+			swipeView.BindingContext = new object();
+			Assert.Equal(swipeView.BindingContext, ((BindableObject)swipeView.LeftItems[0]).BindingContext);
+			Assert.Equal(swipeView.BindingContext, ((BindableObject)swipeView.RightItems[0]).BindingContext);
+			Assert.Equal(swipeView.BindingContext, ((BindableObject)swipeView.TopItems[0]).BindingContext);
+			Assert.Equal(swipeView.BindingContext, ((BindableObject)swipeView.BottomItems[0]).BindingContext);
+		}
+
+		[Fact]
+		public void TestContentBindingContextPropagatesToPassedInSwipeItem()
+		{
+			var swipeView = new SwipeView();
+
+			swipeView.LeftItems = new SwipeItems(new[] { new SwipeItem() }); 
+
+			swipeView.BindingContext = new object();
+			Assert.Equal(swipeView.BindingContext, ((BindableObject)swipeView.LeftItems[0]).BindingContext);
+		}
+
+		[Fact]
+		public void TestContentBindingContextPropagatesToAddedSwipeItems()
+		{
+			var swipeView = new SwipeView();
+
+			swipeView.LeftItems.Add(new SwipeItem());
+			swipeView.RightItems.Add(new SwipeItem());
+			swipeView.TopItems.Add(new SwipeItem());
+			swipeView.BottomItems.Add(new SwipeItem());
+
+			swipeView.BindingContext = new object();
+			Assert.Equal(swipeView.BindingContext, ((BindableObject)swipeView.LeftItems[0]).BindingContext);
+			Assert.Equal(swipeView.BindingContext, ((BindableObject)swipeView.RightItems[0]).BindingContext);
+			Assert.Equal(swipeView.BindingContext, ((BindableObject)swipeView.TopItems[0]).BindingContext);
+			Assert.Equal(swipeView.BindingContext, ((BindableObject)swipeView.BottomItems[0]).BindingContext);
 		}
 
 		[Fact]

--- a/src/Controls/tests/Core.UnitTests/SwipeViewTests.cs
+++ b/src/Controls/tests/Core.UnitTests/SwipeViewTests.cs
@@ -55,6 +55,25 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact]
+		public void TestTemplatedContentBindingContextChangedEvent()
+		{
+			var content = new Label();
+			var swipeView = new SwipeView();
+
+			swipeView.ControlTemplate = new ControlTemplate(() => content);
+
+			bool passed = false;
+			content.BindingContextChanged += (sender, args) => passed = true;
+
+			swipeView.BindingContext = new object();
+
+			if (!passed)
+			{
+				throw new XunitException("The BindingContextChanged event was not fired.");
+			}
+		}
+
+		[Fact]
 		public void ClearRemovesLogicalChildren()
 		{
 			var swipeView = new SwipeView();
@@ -106,7 +125,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		{
 			var swipeView = new SwipeView();
 
-			swipeView.LeftItems = new SwipeItems(new[] { new SwipeItem() }); 
+			swipeView.LeftItems = new SwipeItems(new[] { new SwipeItem() });
 
 			swipeView.BindingContext = new object();
 			Assert.Equal(swipeView.BindingContext, ((BindableObject)swipeView.LeftItems[0]).BindingContext);


### PR DESCRIPTION
### Description of Change

Alternate PR for https://github.com/dotnet/maui/pull/16632

Remove all the special code setting up the parents/children/BC propagation. Just lean into `AddLogicalChildren`

The original bug was that `OnBindingContextChanged` on `SwipeView` was overridden and we weren't called `base.OnBindingContextChanged` which meant nothing would propagate down.

### Issues Fixed

Fixes #16345
Fixes #16742
Fixes #16855
