### PR TITLE
MauiEmbedding extensions should use specified TApp type

### DIFF
--- a/src/Compatibility/Core/src/AppHostBuilderExtensions.Embedding.cs
+++ b/src/Compatibility/Core/src/AppHostBuilderExtensions.Embedding.cs
@@ -11,9 +11,9 @@ namespace Microsoft.Maui.Embedding
 	{
 		public static MauiAppBuilder UseMauiEmbedding<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TApp>(this MauiAppBuilder builder)
 			where TApp : class, IApplication
-				=> builder.UseMauiApp<Controls.Application>();
+				=> builder.UseMauiApp<TApp>();
 
-		public static MauiAppBuilder UseMauiEmbedding<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TApp>(this MauiAppBuilder builder, Func<IServiceProvider, Controls.Application> implementationFactory)
+		public static MauiAppBuilder UseMauiEmbedding<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TApp>(this MauiAppBuilder builder, Func<IServiceProvider, TApp> implementationFactory)
 			where TApp : class, IApplication
 				=> builder.UseMauiApp(implementationFactory);
 	}


### PR DESCRIPTION
### Description of Change

Fixes registration extensions for UseMauiEmbedding. The extensions now use the TApp specified in the extension.

### Issues Fixed

Fixes #16757
