### PR TITLE
[tests] Enable TreatWarningsAsErrors=true

### DIFF
--- a/src/Templates/src/templates/maui-lib/Class1.cs
+++ b/src/Templates/src/templates/maui-lib/Class1.cs
@@ -3,4 +3,5 @@
 // All the code in this file is included in all platforms.
 public class Class1
 {
+    int unused;
 }

--- a/src/Templates/src/templates/maui-lib/Class1.cs
+++ b/src/Templates/src/templates/maui-lib/Class1.cs
@@ -3,5 +3,4 @@
 // All the code in this file is included in all platforms.
 public class Class1
 {
-    int unused;
 }

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/BaseBuildTest.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/BaseBuildTest.cs
@@ -35,6 +35,8 @@ namespace Microsoft.Maui.IntegrationTests
 			$"CustomBeforeMicrosoftCSharpTargets={Path.Combine(TestEnvironment.GetMauiDirectory(), "src", "Templates", "TemplateTestExtraTargets.targets")}",
 			//Try not restore dependencies of 6.0.10
 			$"DisableTransitiveFrameworkReferenceDownloads=true",
+			// Surface warnings as build errors
+			"TreatWarningsAsErrors=true",
 		};
 
 

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/SampleTests.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/SampleTests.cs
@@ -33,6 +33,8 @@ namespace Microsoft.Maui.IntegrationTests
 			{
 				"UseWorkload=true",
 				$"RestoreConfigFile={TestNuGetConfig}",
+				// Surface warnings as build errors
+				"TreatWarningsAsErrors=true",
 			};
 
 			Assert.IsTrue(DotnetInternal.Build(projectFile, config, properties: sampleProps, binlogPath: binlog),


### PR DESCRIPTION
Fixes #16709
Sets `TreatWarningsAsErrors` to true when building template and sample
projects to ensure that warnings are not missed.