### PR TITLE
[UITest] Add reset to test teardown if the app is not running anymore

### DIFF
--- a/src/Controls/tests/UITests/Tests/UITestBase.cs
+++ b/src/Controls/tests/UITests/Tests/UITestBase.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using Microsoft.Maui.Appium;
 using NUnit.Framework;
 using NUnit.Framework.Interfaces;
@@ -56,6 +56,18 @@ namespace Microsoft.Maui.AppiumTests
 		[TearDown]
 		public void UITestBaseTearDown()
 		{
+			if (App is IApp2 app2)
+			{
+				if (app2.AppState == ApplicationState.Not_Running)
+				{
+					// Assert.Fail will immediately exit the test which is desirable as the app is not
+					// running anymore so we don't want to log diagnostic data as there is nothing to collect from
+					Reset();
+					FixtureSetup();
+					Assert.Fail("The app was expected to be running still, investigate as possible crash");
+				}
+			}
+
 			var testOutcome = TestContext.CurrentContext.Result.Outcome;
 			if (testOutcome == ResultState.Error ||
 				testOutcome == ResultState.Failure)
@@ -179,7 +191,7 @@ namespace Microsoft.Maui.AppiumTests
 		private void SaveDiagnosticLogs()
 		{
 			var logDir = (Path.GetDirectoryName(Environment.GetEnvironmentVariable("APPIUM_LOG_FILE")) ?? Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location))!;
-			
+
 			// App could be null if UITestContext was not able to connect to the test process (e.g. port already in use etc...)
 			if (UITestContext is not null)
 			{

--- a/src/TestUtils/src/TestUtils.Appium.UITests/AppiumUITestApp.cs
+++ b/src/TestUtils/src/TestUtils.Appium.UITests/AppiumUITestApp.cs
@@ -101,6 +101,18 @@ namespace TestUtils.Appium.UITests
 
 		public string ElementTree => _driver?.PageSource ?? "";
 
+		public ApplicationState AppState
+		{
+			get
+			{
+				return IsWindows 
+					? GetWindowsAppState() 
+					: IsAndroid 
+						? GetUIAutomator2TestAppState() 
+						: GetXCUITestAppState();
+			}
+		}
+
 		public void ResetApp()
 		{
 			_driver?.ResetApp();
@@ -897,7 +909,7 @@ namespace TestUtils.Appium.UITests
 
 				// Try to handle the rest of the query string after marked:'{x}', e.g. "* marked:'Tab1Element' child android.webkit.WebView child android.widget.TextView"
 				var match = Regex.Match(query.Raw, "(.*)'((?:\\s)(\\S*))*");
-				if(match.Groups.Count > 3 && match.Groups[3].Captures.Count != 0)
+				if (match.Groups.Count > 3 && match.Groups[3].Captures.Count != 0)
 				{
 					int index = 0;
 					while (index < match.Groups[3].Captures.Count)
@@ -1160,6 +1172,62 @@ namespace TestUtils.Appium.UITests
 				var scrollAction = new TouchAction(_driver).Press(x, startY).MoveTo(x, endY).Release();
 				scrollAction.Perform();
 			}
+		}
+
+
+		ApplicationState GetXCUITestAppState()
+		{
+			var state = _driver?.ExecuteScript(IsMac ? "macos: queryAppState" : "mobile: queryAppState", new Dictionary<string, object>
+						{
+							{ "bundleId", _appId },
+						});
+
+			// https://developer.apple.com/documentation/xctest/xcuiapplicationstate?language=objc
+			return Convert.ToInt32(state) switch
+			{
+				1 => ApplicationState.Not_Running,
+				2 or
+				3 or
+				4 => ApplicationState.Running,
+				_ => ApplicationState.Unknown,
+			};
+		}
+
+		ApplicationState GetWindowsAppState()
+		{
+			try
+			{
+				// WinAppDriver doesn't support QueryAppState
+				_ = _driver?.CurrentWindowHandle;
+				return ApplicationState.Running;
+			}
+			catch (NoSuchWindowException)
+			{
+				return ApplicationState.Not_Running;
+			}
+		}
+
+		ApplicationState GetUIAutomator2TestAppState()
+		{
+			var state = _driver?.ExecuteScript("mobile: queryAppState", new Dictionary<string, object>
+						{
+							{ "appId", _appId },
+						});
+
+			// https://github.com/appium/appium-uiautomator2-driver#mobile-queryappstate
+			if (state == null)
+			{
+				return ApplicationState.Unknown;
+			}
+
+			return Convert.ToInt32(state) switch
+			{
+				0 => ApplicationState.Not_Installed,
+				1 => ApplicationState.Not_Running,
+				3 or
+				4 => ApplicationState.Running,
+				_ => ApplicationState.Unknown,
+			};
 		}
 	}
 }

--- a/src/TestUtils/src/TestUtils.Appium.UITests/ApplicationState.cs
+++ b/src/TestUtils/src/TestUtils.Appium.UITests/ApplicationState.cs
@@ -1,0 +1,11 @@
+﻿namespace TestUtils.Appium.UITests
+{
+	public enum ApplicationState
+	{
+		Not_Installed,
+		Installed,
+		Not_Running,
+		Running,
+		Unknown
+	}
+}

--- a/src/TestUtils/src/TestUtils.Appium.UITests/IApp2.cs
+++ b/src/TestUtils/src/TestUtils.Appium.UITests/IApp2.cs
@@ -7,6 +7,7 @@ namespace TestUtils.Appium.UITests
 		void ActivateApp();
 		void CloseApp();
 		string ElementTree { get; }
+		ApplicationState AppState { get; }
 		bool WaitForTextToBePresentInElement(string automationId, string text);
 		public byte[] Screenshot();
 	}


### PR DESCRIPTION
### Description of Change

With this change we will check the status of the app after each test to verify it is still running and restart it if necessary and log a failure to the appropriate test.

### Issues Fixed

- If the test project crashes during test execution currently it will cause all the tests in that class that follow it to fail.  

- If the test executes a command that causes the test project to crash and doesn't try to interact with the test project anymore, e.g. query a property/element, the app crash will not be caught until the next test setup, if any, and have to hunt down which test caused the failure.
