### PR TITLE
Tests: Add support for connected component analysis

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Border/BorderTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Border/BorderTests.cs
@@ -130,18 +130,18 @@ namespace Microsoft.Maui.DeviceTests
 				await platformView.AttachAndRun<object>(async (window) =>
 				{
 					var bitmap = await border.AsRawBitmapAsync();
-					Assert.Equal(200, bitmap.Width, 1);
-					Assert.Equal(100, bitmap.Height, 2);
+					Assert.Equal(200, bitmap.Width, 1d);
+					Assert.Equal(100, bitmap.Height, 2d);
 
 					// Analyze blue border - we expect it to fill the 200x100 area
 					var blueBlob = ConnectedComponentAnalysis.FindConnectedPixels(bitmap, (c) => c.Blue > .5).Single();
-					Assert.Equal(200, blueBlob.Width, 2);
-					Assert.Equal(100, blueBlob.Height, 2);
+					Assert.Equal(200, blueBlob.Width, 2d);
+					Assert.Equal(100, blueBlob.Height, 2d);
 
 					// Analyze red inside- we expect it to fill the area minus the stroke thickness
 					var redBlob = ConnectedComponentAnalysis.FindConnectedPixels(bitmap, (c) => c.Red > .5).Single();
-					Assert.Equal(180, redBlob.Width, 2);
-					Assert.Equal(80, redBlob.Height, 2);
+					Assert.Equal(180, redBlob.Width, 2d);
+					Assert.Equal(80, redBlob.Height, 2d);
 					return null;
 				}, MauiContext);
 			});

--- a/src/Controls/tests/DeviceTests/Elements/Border/BorderTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Border/BorderTests.cs
@@ -124,7 +124,7 @@ namespace Microsoft.Maui.DeviceTests
 			border.StrokeThickness = borderThickness;
 
 			var bitmap = await GetRawBitmap(border, typeof(BorderHandler));
-			Assert.Equal(200, bitmap.Width, 1d);
+			Assert.Equal(200, bitmap.Width, 2d);
 			Assert.Equal(100, bitmap.Height, 2d);
 
 			// Analyze blue border - we expect it to fill the 200x100 area

--- a/src/Controls/tests/DeviceTests/Elements/Border/BorderTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Border/BorderTests.cs
@@ -114,7 +114,6 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.False(platformViewReference.IsAlive, "PlatformView should not be alive!");
 		}
 
-
 		[Fact("Ensures the border renders the expected size - Issue 15339")]
 		public async Task BorderAndStrokeIsCorrectSize()
 		{
@@ -124,27 +123,19 @@ namespace Microsoft.Maui.DeviceTests
 			border.Stroke = Colors.Blue;
 			border.StrokeThickness = borderThickness;
 
-			await InvokeOnMainThreadAsync(async () =>
-			{
-				var platformView = CreateHandler(border, typeof(BorderHandler)).ToPlatform();
-				await platformView.AttachAndRun<object>(async (window) =>
-				{
-					var bitmap = await border.AsRawBitmapAsync();
-					Assert.Equal(200, bitmap.Width, 1d);
-					Assert.Equal(100, bitmap.Height, 2d);
+			var bitmap = await GetRawBitmap(border, typeof(BorderHandler));
+			Assert.Equal(200, bitmap.Width, 1d);
+			Assert.Equal(100, bitmap.Height, 2d);
 
-					// Analyze blue border - we expect it to fill the 200x100 area
-					var blueBlob = ConnectedComponentAnalysis.FindConnectedPixels(bitmap, (c) => c.Blue > .5).Single();
-					Assert.Equal(200, blueBlob.Width, 2d);
-					Assert.Equal(100, blueBlob.Height, 2d);
+			// Analyze blue border - we expect it to fill the 200x100 area
+			var blueBlob = ConnectedComponentAnalysis.FindConnectedPixels(bitmap, (c) => c.Blue > .5).Single();
+			Assert.Equal(200, blueBlob.Width, 2d);
+			Assert.Equal(100, blueBlob.Height, 2d);
 
-					// Analyze red inside- we expect it to fill the area minus the stroke thickness
-					var redBlob = ConnectedComponentAnalysis.FindConnectedPixels(bitmap, (c) => c.Red > .5).Single();
-					Assert.Equal(180, redBlob.Width, 2d);
-					Assert.Equal(80, redBlob.Height, 2d);
-					return null;
-				}, MauiContext);
-			});
+			// Analyze red inside- we expect it to fill the area minus the stroke thickness
+			var redBlob = ConnectedComponentAnalysis.FindConnectedPixels(bitmap, (c) => c.Red > .5).Single();
+			Assert.Equal(180, redBlob.Width, 2d);
+			Assert.Equal(80, redBlob.Height, 2d);
 		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Border/BorderTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Border/BorderTests.cs
@@ -114,6 +114,7 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.False(platformViewReference.IsAlive, "PlatformView should not be alive!");
 		}
 
+		/* Commented out for now until border issues are fixed
 		[Fact("Ensures the border renders the expected size - Issue 15339")]
 		public async Task BorderAndStrokeIsCorrectSize()
 		{
@@ -136,6 +137,6 @@ namespace Microsoft.Maui.DeviceTests
 			var redBlob = ConnectedComponentAnalysis.FindConnectedPixels(bitmap, (c) => c.Red > .5).Single();
 			Assert.Equal(180, redBlob.Width, 2d);
 			Assert.Equal(80, redBlob.Height, 2d);
-		}
+		}*/
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/BoxView/BoxViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/BoxView/BoxViewTests.cs
@@ -26,7 +26,6 @@ namespace Microsoft.Maui.DeviceTests
 				WidthRequest = 200
 			};
 
-			
 			await ValidateHasColor(boxView, expected, typeof(ShapeViewHandler));
 		}
 	}

--- a/src/Controls/tests/DeviceTests/Elements/BoxView/BoxViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/BoxView/BoxViewTests.cs
@@ -44,7 +44,12 @@ namespace Microsoft.Maui.DeviceTests
 				});
 			});
 
-			Grid grid = new Grid() { BackgroundColor = Colors.Cyan };
+			Grid grid = new Grid()
+			{
+				BackgroundColor = Colors.Cyan,
+				WidthRequest = 200,  // TODO: I really don't want to set size - need to hit iOS safe area too
+				HeightRequest = 500
+			};
 			grid.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Star));
 			grid.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Star));
 			grid.RowDefinitions.Add(new RowDefinition(GridLength.Star));
@@ -78,34 +83,34 @@ namespace Microsoft.Maui.DeviceTests
 					var bitmap = await grid.AsRawBitmapAsync();
 
 					var yellowBlob = ConnectedComponentAnalysis.FindConnectedPixels(bitmap, Colors.Yellow).Single();
-					Assert.Equal(bitmap.Width / 2, yellowBlob.Width, 2);
-					Assert.Equal(bitmap.Height / 3, yellowBlob.Height, 2);
-					Assert.Equal(0, yellowBlob.MinColumn, 2);
-					Assert.Equal(0, yellowBlob.MinRow, 2);
+					Assert.Equal(bitmap.Width / 2, yellowBlob.Width, 2d);
+					Assert.Equal(bitmap.Height / 3, yellowBlob.Height, 2d);
+					Assert.Equal(0, yellowBlob.MinColumn, 2d);
+					Assert.Equal(0, yellowBlob.MinRow, 2d);
 
 					var redBlob = ConnectedComponentAnalysis.FindConnectedPixels(bitmap, Colors.Red).Single();
-					Assert.Equal(bitmap.Width / 2, redBlob.Width, 2);
-					Assert.Equal(bitmap.Height / 3, redBlob.Height, 2);
-					Assert.Equal(bitmap.Width / 2, redBlob.MinColumn, 2);
+					Assert.Equal(bitmap.Width / 2, redBlob.Width, 2d);
+					Assert.Equal(bitmap.Height / 3, redBlob.Height, 2d);
+					Assert.Equal(bitmap.Width / 2, redBlob.MinColumn, 2d);
 					Assert.Equal(0, redBlob.MinRow);
 
 					var limeBlob = ConnectedComponentAnalysis.FindConnectedPixels(bitmap, Colors.Lime).Single();
-					Assert.Equal(bitmap.Width / 2, limeBlob.Width, 2);
-					Assert.Equal(bitmap.Height / 3, limeBlob.Height, 2);
-					Assert.Equal(0, limeBlob.MinColumn, 2);
-					Assert.Equal(bitmap.Height / 3, limeBlob.MinRow, 2);
+					Assert.Equal(bitmap.Width / 2, limeBlob.Width, 2d);
+					Assert.Equal(bitmap.Height / 3, limeBlob.Height, 2d);
+					Assert.Equal(0, limeBlob.MinColumn, 2d);
+					Assert.Equal(bitmap.Height / 3, limeBlob.MinRow, 2d);
 
 					var violetBlob = ConnectedComponentAnalysis.FindConnectedPixels(bitmap, Colors.Violet).Single();
-					Assert.Equal(bitmap.Width / 2, violetBlob.Width, 2);
-					Assert.Equal(bitmap.Height / 3 * 2, violetBlob.Height, 2);
-					Assert.Equal(bitmap.Width / 2, violetBlob.MinColumn, 2);
-					Assert.Equal(bitmap.Height / 3, violetBlob.MinRow, 2);
+					Assert.Equal(bitmap.Width / 2, violetBlob.Width, 2d);
+					Assert.Equal(bitmap.Height / 3 * 2, violetBlob.Height, 2d);
+					Assert.Equal(bitmap.Width / 2, violetBlob.MinColumn, 2d);
+					Assert.Equal(bitmap.Height / 3, violetBlob.MinRow, 2d);
 
 					var cyanBlob = ConnectedComponentAnalysis.FindConnectedPixels(bitmap, Colors.Cyan).Single();
-					Assert.Equal(bitmap.Width / 2, cyanBlob.Width, 2);
-					Assert.Equal(bitmap.Height / 3, cyanBlob.Height, 2);
-					Assert.Equal(0, cyanBlob.MinColumn, 2);
-					Assert.Equal(bitmap.Height / 3 * 2, cyanBlob.MinRow, 2);
+					Assert.Equal(bitmap.Width / 2, cyanBlob.Width, 2d);
+					Assert.Equal(bitmap.Height / 3, cyanBlob.Height, 2d);
+					Assert.Equal(0, cyanBlob.MinColumn, 2d);
+					Assert.Equal(bitmap.Height / 3 * 2, cyanBlob.MinRow, 2d);
 					return null;
 				}, MauiContext);
 			});

--- a/src/Controls/tests/DeviceTests/Elements/BoxView/BoxViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/BoxView/BoxViewTests.cs
@@ -1,8 +1,5 @@
-﻿using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
-using Microsoft.Maui.Controls.Handlers;
-using Microsoft.Maui.DeviceTests.ImageAnalysis;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Hosting;
@@ -29,81 +26,8 @@ namespace Microsoft.Maui.DeviceTests
 				WidthRequest = 200
 			};
 
+			
 			await ValidateHasColor(boxView, expected, typeof(ShapeViewHandler));
-		}
-
-		[Fact("Ensures grid rows renders the correct size - Issue 15330")]
-		public async Task Issue15330()
-		{
-			EnsureHandlerCreated(builder =>
-			{
-				builder.ConfigureMauiHandlers(handlers =>
-				{
-					handlers.AddHandler<Grid, LayoutHandler>();
-					handlers.AddHandler<BoxView, BoxViewHandler>();
-				});
-			});
-
-			Grid grid = new Grid()
-			{
-				BackgroundColor = Colors.Cyan,
-				WidthRequest = 200,  // TODO: I really don't want to set size - need to hit iOS safe area too
-				HeightRequest = 500
-			};
-			grid.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Star));
-			grid.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Star));
-			grid.RowDefinitions.Add(new RowDefinition(GridLength.Star));
-			grid.RowDefinitions.Add(new RowDefinition(GridLength.Star));
-			grid.RowDefinitions.Add(new RowDefinition(GridLength.Star));
-			BoxView boxView1 = new BoxView() { Color = Colors.Red };
-			Grid.SetColumn(boxView1, 1);
-			grid.Children.Add(boxView1);
-			var boxView2 = new BoxView() { Color = Colors.Lime };
-			Grid.SetRow(boxView2, 1);
-			grid.Children.Add(boxView2);
-			var boxView3 = new BoxView() { Color = Colors.Violet };
-			Grid.SetColumn(boxView3, 1);
-			Grid.SetRow(boxView3, 1);
-			Grid.SetRowSpan(boxView3, 2);
-			grid.Children.Add(boxView3);
-			var boxView4 = new BoxView() { Color = Colors.Yellow };
-			grid.Children.Add(boxView4);
-
-			await CreateHandlerAsync<BoxViewHandler>(boxView1);
-			await CreateHandlerAsync<BoxViewHandler>(boxView2);
-			await CreateHandlerAsync<BoxViewHandler>(boxView3);
-			await CreateHandlerAsync<BoxViewHandler>(boxView4);
-
-			var bitmap = await GetRawBitmap(grid, typeof(LayoutHandler));
-			var yellowBlob = ConnectedComponentAnalysis.FindConnectedPixels(bitmap, Colors.Yellow).Single();
-			Assert.Equal(bitmap.Width / 2, yellowBlob.Width, 2d);
-			Assert.Equal(bitmap.Height / 3, yellowBlob.Height, 2d);
-			Assert.Equal(0, yellowBlob.MinColumn, 2d);
-			Assert.Equal(0, yellowBlob.MinRow, 2d);
-
-			var redBlob = ConnectedComponentAnalysis.FindConnectedPixels(bitmap, Colors.Red).Single();
-			Assert.Equal(bitmap.Width / 2, redBlob.Width, 2d);
-			Assert.Equal(bitmap.Height / 3, redBlob.Height, 2d);
-			Assert.Equal(bitmap.Width / 2, redBlob.MinColumn, 2d);
-			Assert.Equal(0, redBlob.MinRow);
-
-			var limeBlob = ConnectedComponentAnalysis.FindConnectedPixels(bitmap, Colors.Lime).Single();
-			Assert.Equal(bitmap.Width / 2, limeBlob.Width, 2d);
-			Assert.Equal(bitmap.Height / 3, limeBlob.Height, 2d);
-			Assert.Equal(0, limeBlob.MinColumn, 2d);
-			Assert.Equal(bitmap.Height / 3, limeBlob.MinRow, 2d);
-
-			var violetBlob = ConnectedComponentAnalysis.FindConnectedPixels(bitmap, Colors.Violet).Single();
-			Assert.Equal(bitmap.Width / 2, violetBlob.Width, 2d);
-			Assert.Equal(bitmap.Height / 3 * 2, violetBlob.Height, 2d);
-			Assert.Equal(bitmap.Width / 2, violetBlob.MinColumn, 2d);
-			Assert.Equal(bitmap.Height / 3, violetBlob.MinRow, 2d);
-
-			var cyanBlob = ConnectedComponentAnalysis.FindConnectedPixels(bitmap, Colors.Cyan).Single();
-			Assert.Equal(bitmap.Width / 2, cyanBlob.Width, 2d);
-			Assert.Equal(bitmap.Height / 3, cyanBlob.Height, 2d);
-			Assert.Equal(0, cyanBlob.MinColumn, 2d);
-			Assert.Equal(bitmap.Height / 3 * 2, cyanBlob.MinRow, 2d);
 		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/BoxView/BoxViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/BoxView/BoxViewTests.cs
@@ -73,47 +73,37 @@ namespace Microsoft.Maui.DeviceTests
 			await CreateHandlerAsync<BoxViewHandler>(boxView2);
 			await CreateHandlerAsync<BoxViewHandler>(boxView3);
 			await CreateHandlerAsync<BoxViewHandler>(boxView4);
-			//await CreateHandlerAsync<LayoutHandler>(grid);
 
-			await InvokeOnMainThreadAsync(async () =>
-			{
-				var platformView = CreateHandler(grid, typeof(LayoutHandler)).ToPlatform();
-				await platformView.AttachAndRun<object>(async (window) =>
-				{
-					var bitmap = await grid.AsRawBitmapAsync();
+			var bitmap = await GetRawBitmap(grid, typeof(LayoutHandler));
+			var yellowBlob = ConnectedComponentAnalysis.FindConnectedPixels(bitmap, Colors.Yellow).Single();
+			Assert.Equal(bitmap.Width / 2, yellowBlob.Width, 2d);
+			Assert.Equal(bitmap.Height / 3, yellowBlob.Height, 2d);
+			Assert.Equal(0, yellowBlob.MinColumn, 2d);
+			Assert.Equal(0, yellowBlob.MinRow, 2d);
 
-					var yellowBlob = ConnectedComponentAnalysis.FindConnectedPixels(bitmap, Colors.Yellow).Single();
-					Assert.Equal(bitmap.Width / 2, yellowBlob.Width, 2d);
-					Assert.Equal(bitmap.Height / 3, yellowBlob.Height, 2d);
-					Assert.Equal(0, yellowBlob.MinColumn, 2d);
-					Assert.Equal(0, yellowBlob.MinRow, 2d);
+			var redBlob = ConnectedComponentAnalysis.FindConnectedPixels(bitmap, Colors.Red).Single();
+			Assert.Equal(bitmap.Width / 2, redBlob.Width, 2d);
+			Assert.Equal(bitmap.Height / 3, redBlob.Height, 2d);
+			Assert.Equal(bitmap.Width / 2, redBlob.MinColumn, 2d);
+			Assert.Equal(0, redBlob.MinRow);
 
-					var redBlob = ConnectedComponentAnalysis.FindConnectedPixels(bitmap, Colors.Red).Single();
-					Assert.Equal(bitmap.Width / 2, redBlob.Width, 2d);
-					Assert.Equal(bitmap.Height / 3, redBlob.Height, 2d);
-					Assert.Equal(bitmap.Width / 2, redBlob.MinColumn, 2d);
-					Assert.Equal(0, redBlob.MinRow);
+			var limeBlob = ConnectedComponentAnalysis.FindConnectedPixels(bitmap, Colors.Lime).Single();
+			Assert.Equal(bitmap.Width / 2, limeBlob.Width, 2d);
+			Assert.Equal(bitmap.Height / 3, limeBlob.Height, 2d);
+			Assert.Equal(0, limeBlob.MinColumn, 2d);
+			Assert.Equal(bitmap.Height / 3, limeBlob.MinRow, 2d);
 
-					var limeBlob = ConnectedComponentAnalysis.FindConnectedPixels(bitmap, Colors.Lime).Single();
-					Assert.Equal(bitmap.Width / 2, limeBlob.Width, 2d);
-					Assert.Equal(bitmap.Height / 3, limeBlob.Height, 2d);
-					Assert.Equal(0, limeBlob.MinColumn, 2d);
-					Assert.Equal(bitmap.Height / 3, limeBlob.MinRow, 2d);
+			var violetBlob = ConnectedComponentAnalysis.FindConnectedPixels(bitmap, Colors.Violet).Single();
+			Assert.Equal(bitmap.Width / 2, violetBlob.Width, 2d);
+			Assert.Equal(bitmap.Height / 3 * 2, violetBlob.Height, 2d);
+			Assert.Equal(bitmap.Width / 2, violetBlob.MinColumn, 2d);
+			Assert.Equal(bitmap.Height / 3, violetBlob.MinRow, 2d);
 
-					var violetBlob = ConnectedComponentAnalysis.FindConnectedPixels(bitmap, Colors.Violet).Single();
-					Assert.Equal(bitmap.Width / 2, violetBlob.Width, 2d);
-					Assert.Equal(bitmap.Height / 3 * 2, violetBlob.Height, 2d);
-					Assert.Equal(bitmap.Width / 2, violetBlob.MinColumn, 2d);
-					Assert.Equal(bitmap.Height / 3, violetBlob.MinRow, 2d);
-
-					var cyanBlob = ConnectedComponentAnalysis.FindConnectedPixels(bitmap, Colors.Cyan).Single();
-					Assert.Equal(bitmap.Width / 2, cyanBlob.Width, 2d);
-					Assert.Equal(bitmap.Height / 3, cyanBlob.Height, 2d);
-					Assert.Equal(0, cyanBlob.MinColumn, 2d);
-					Assert.Equal(bitmap.Height / 3 * 2, cyanBlob.MinRow, 2d);
-					return null;
-				}, MauiContext);
-			});
+			var cyanBlob = ConnectedComponentAnalysis.FindConnectedPixels(bitmap, Colors.Cyan).Single();
+			Assert.Equal(bitmap.Width / 2, cyanBlob.Width, 2d);
+			Assert.Equal(bitmap.Height / 3, cyanBlob.Height, 2d);
+			Assert.Equal(0, cyanBlob.MinColumn, 2d);
+			Assert.Equal(bitmap.Height / 3 * 2, cyanBlob.MinRow, 2d);
 		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Layout/LayoutTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Layout/LayoutTests.cs
@@ -280,6 +280,7 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.True(grid.Height <= grid.MaximumHeightRequest);
 		}
 
+		/* Commented out of for now due to inconsistent platform behavior
 		[Fact("Ensures grid rows renders the correct size - Issue 15330")]
 		public async Task Issue15330()
 		{
@@ -352,6 +353,6 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.Equal(bitmap.Height / 3, cyanBlob.Height, 2d);
 			Assert.Equal(0, cyanBlob.MinColumn, 2d);
 			Assert.Equal(bitmap.Height / 3 * 2, cyanBlob.MinRow, 2d);
-		}
+		}*/
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Layout/LayoutTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Layout/LayoutTests.cs
@@ -1,6 +1,9 @@
 ﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Handlers;
+using Microsoft.Maui.DeviceTests.ImageAnalysis;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Hosting;
@@ -277,5 +280,78 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.True(grid.Height <= grid.MaximumHeightRequest);
 		}
 
+		[Fact("Ensures grid rows renders the correct size - Issue 15330")]
+		public async Task Issue15330()
+		{
+			EnsureHandlerCreated(builder =>
+			{
+				builder.ConfigureMauiHandlers(handlers =>
+				{
+					handlers.AddHandler<Grid, LayoutHandler>();
+					handlers.AddHandler<BoxView, BoxViewHandler>();
+				});
+			});
+
+			Grid grid = new Grid()
+			{
+				BackgroundColor = Colors.Cyan,
+				WidthRequest = 200,  // TODO: I really don't want to set size - need to hit iOS safe area too
+				HeightRequest = 500
+			};
+			grid.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Star));
+			grid.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Star));
+			grid.RowDefinitions.Add(new RowDefinition(GridLength.Star));
+			grid.RowDefinitions.Add(new RowDefinition(GridLength.Star));
+			grid.RowDefinitions.Add(new RowDefinition(GridLength.Star));
+			BoxView boxView1 = new BoxView() { Color = Colors.Red };
+			Grid.SetColumn(boxView1, 1);
+			grid.Children.Add(boxView1);
+			var boxView2 = new BoxView() { Color = Colors.Lime };
+			Grid.SetRow(boxView2, 1);
+			grid.Children.Add(boxView2);
+			var boxView3 = new BoxView() { Color = Colors.Violet };
+			Grid.SetColumn(boxView3, 1);
+			Grid.SetRow(boxView3, 1);
+			Grid.SetRowSpan(boxView3, 2);
+			grid.Children.Add(boxView3);
+			var boxView4 = new BoxView() { Color = Colors.Yellow };
+			grid.Children.Add(boxView4);
+
+			await CreateHandlerAsync<BoxViewHandler>(boxView1);
+			await CreateHandlerAsync<BoxViewHandler>(boxView2);
+			await CreateHandlerAsync<BoxViewHandler>(boxView3);
+			await CreateHandlerAsync<BoxViewHandler>(boxView4);
+
+			var bitmap = await GetRawBitmap(grid, typeof(LayoutHandler));
+			var yellowBlob = ConnectedComponentAnalysis.FindConnectedPixels(bitmap, Colors.Yellow).Single();
+			Assert.Equal(bitmap.Width / 2, yellowBlob.Width, 2d);
+			Assert.Equal(bitmap.Height / 3, yellowBlob.Height, 2d);
+			Assert.Equal(0, yellowBlob.MinColumn, 2d);
+			Assert.Equal(0, yellowBlob.MinRow, 2d);
+
+			var redBlob = ConnectedComponentAnalysis.FindConnectedPixels(bitmap, Colors.Red).Single();
+			Assert.Equal(bitmap.Width / 2, redBlob.Width, 2d);
+			Assert.Equal(bitmap.Height / 3, redBlob.Height, 2d);
+			Assert.Equal(bitmap.Width / 2, redBlob.MinColumn, 2d);
+			Assert.Equal(0, redBlob.MinRow);
+
+			var limeBlob = ConnectedComponentAnalysis.FindConnectedPixels(bitmap, Colors.Lime).Single();
+			Assert.Equal(bitmap.Width / 2, limeBlob.Width, 2d);
+			Assert.Equal(bitmap.Height / 3, limeBlob.Height, 2d);
+			Assert.Equal(0, limeBlob.MinColumn, 2d);
+			Assert.Equal(bitmap.Height / 3, limeBlob.MinRow, 2d);
+
+			var violetBlob = ConnectedComponentAnalysis.FindConnectedPixels(bitmap, Colors.Violet).Single();
+			Assert.Equal(bitmap.Width / 2, violetBlob.Width, 2d);
+			Assert.Equal(bitmap.Height / 3 * 2, violetBlob.Height, 2d);
+			Assert.Equal(bitmap.Width / 2, violetBlob.MinColumn, 2d);
+			Assert.Equal(bitmap.Height / 3, violetBlob.MinRow, 2d);
+
+			var cyanBlob = ConnectedComponentAnalysis.FindConnectedPixels(bitmap, Colors.Cyan).Single();
+			Assert.Equal(bitmap.Width / 2, cyanBlob.Width, 2d);
+			Assert.Equal(bitmap.Height / 3, cyanBlob.Height, 2d);
+			Assert.Equal(0, cyanBlob.MinColumn, 2d);
+			Assert.Equal(bitmap.Height / 3 * 2, cyanBlob.MinRow, 2d);
+		}
 	}
 }

--- a/src/Core/tests/DeviceTests.Shared/HandlerTests/HandlerTestBasement.cs
+++ b/src/Core/tests/DeviceTests.Shared/HandlerTests/HandlerTestBasement.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Maui.DeviceTests.ImageAnalysis;
 using Microsoft.Maui.DeviceTests.Stubs;
 using Microsoft.Maui.Dispatching;
 using Microsoft.Maui.Graphics;
@@ -267,6 +268,19 @@ namespace Microsoft.Maui.DeviceTests
 				await plaformView.AssertColorAtPointAsync(color.ToWindowsColor(), x, y, MauiContext);
 #else
 				await plaformView.AssertColorAtPointAsync(color.ToPlatform(), x, y, MauiContext);
+#endif
+			});
+		}
+
+		protected Task<ImageAnalysis.RawBitmap> GetRawBitmap(Controls.VisualElement view, Type handlerType)
+		{
+			return InvokeOnMainThreadAsync<RawBitmap>(async () =>
+			{
+				var platformView = CreateHandler(view, handlerType).ToPlatform();
+#if WINDOWS
+				return await platformView.AttachAndRun<RawBitmap>(async (window) => await view.AsRawBitmapAsync(), MauiContext);
+#else
+				return await platformView.AttachAndRun<RawBitmap>(async () => await view.AsRawBitmapAsync());
 #endif
 			});
 		}

--- a/src/Core/tests/DeviceTests.Shared/ImageAnalysis/ConnectedComponentAnalysis.cs
+++ b/src/Core/tests/DeviceTests.Shared/ImageAnalysis/ConnectedComponentAnalysis.cs
@@ -1,0 +1,241 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Graphics;
+
+namespace Microsoft.Maui.DeviceTests.ImageAnalysis;
+
+
+// Method for finding pixels connected to each other. Great for finding UI Elements on the screen
+// based on pixel color filter.
+// A good explanation of the Connected Component Analysis can be seen here: https://www.youtube.com/watch?v=ticZclUYy88
+// Uses a 4-connectivity 2-pass Hoshen-Kopelman algorithm
+public static class ConnectedComponentAnalysis
+{
+    /// <summary>
+    /// Finds a set of pixels that are connected to each other, Looks at any pixels that are not black and/or transparent
+    /// </summary>
+    /// <param name="image"></param>
+    /// <returns></returns>
+    public static IList<Blob> FindConnectedPixels(RawBitmap image)
+    {
+        return FindConnectedPixels(image, (c) => (c.Red > 0 || c.Green > 0 || c.Blue > 0) && c.Alpha > 0);
+    }
+
+    public static async Task<IList<Blob>> FindConnectedPixelsAsync(VisualElement element, Func<Color, bool> includePixelFunction)
+    {
+        var bitmap = await element.AsRawBitmapAsync();
+        return FindConnectedPixels(bitmap, includePixelFunction);
+    }
+
+    public static IList<Blob> FindConnectedPixels(RawBitmap image, Color color)
+    {
+        return FindConnectedPixels(image, c => c.ToUint() == color.ToUint());
+    }
+
+    public static IList<Blob> FindConnectedPixels(RawBitmap image, Func<Color, bool> includePixelFunction)
+    {
+        int width = image.PixelWidth;
+        int height = image.PixelHeight;
+        bool[] pixels = new bool[width * height];
+
+        int bitsPerPixel = 32;
+        int stride = image.PixelWidth * bitsPerPixel / 8;
+        byte[] pixelbuffer = image.PixelBuffer;
+
+        for (int row = 0; row < height; row++)
+        {
+            for (int col = 0; col < width; col++)
+            {
+                byte b = pixelbuffer[row * stride + col * 4];
+                byte g = pixelbuffer[row * stride + col * 4 + 1];
+                byte r = pixelbuffer[row * stride + col * 4 + 2];
+                byte a = pixelbuffer[row * stride + col * 4 + 3];
+
+                pixels[col + row * width] = includePixelFunction(Color.FromRgba(r, g, b, a));
+            }
+        }
+
+        Func<Color, bool> ismatch = includePixelFunction;
+        int[] labels = new int[pixels.Length];
+        int currentLabel = 0;
+        // First pass - Label pixels
+        UnionFind<int> sets = new UnionFind<int>();
+        for (int i = 0; i < height; i++)
+        {
+            for (int j = 0; j < width; j++)
+            {
+                var idx = j + i * width;
+                bool v = pixels[idx];
+                if (v)
+                {
+                    var l1 = i == 0 ? 0 : labels[j + (i - 1) * width];
+                    var l2 = j == 0 ? 0 : labels[j + i * width - 1];
+                    if (l1 == 0 && l2 == 0)
+                    {
+                        //Assign new label
+                        currentLabel++;
+                        labels[idx] = currentLabel;
+                        sets.MakeSet(currentLabel);
+                    }
+                    else if (l1 > 0 && l2 == 0)
+                        labels[idx] = l1; //Copy label from neighbor
+                    else if (l1 == 0 && l2 > 0)
+                        labels[idx] = l2; //Copy label from neighbor
+                    else
+                    {
+                        labels[idx] = l1 < l2 ? l1 : l2; // Both neighbors have values. Grab the smallest label
+                        if (l1 != l2)
+                            sets.Union(sets.Find(l1), sets.Find(l2)); //store L1 is equivalent to L2
+                    }
+                }
+            }
+        }
+        // Second pass: Update equivalent labels
+        for (int i = 0; i < height; i++)
+        {
+            for (int j = 0; j < width; j++)
+            {
+                var idx = j + i * width;
+                var lbl = labels[idx];
+                if (lbl > 0)
+                {
+                    var l = sets.Find(lbl);
+                    labels[idx] = l.Value;
+                }
+            }
+        }
+        // Generate blobs
+        var blobs = new List<Blob>();
+        for (int i = 0; i < height; i++)
+        {
+            for (int j = 0; j < width; j++)
+            {
+                var idx = j + i * width;
+                var lbl = labels[idx];
+                if (lbl > 0)
+                {
+                    var blob = blobs.Where(b => b.Id == lbl).FirstOrDefault();
+                    if (blob != null)
+                    {
+                        blob.MinColumn = Math.Min(blob.MinColumn, j);
+                        blob.MaxColumn = Math.Max(blob.MaxColumn, j);
+                        blob.MinRow = Math.Min(blob.MinRow, i);
+                        blob.MaxRow = Math.Max(blob.MaxRow, i);
+                    }
+                    else
+                    {
+                        blob = new Blob() { Id = lbl, MinColumn = j, MaxColumn = j, MinRow = i, MaxRow = i };
+                        blobs.Add(blob);
+                    }
+                    blob.Pixels.Add(new System.Drawing.Point(j, i));
+                }
+            }
+        }
+        foreach (var b in blobs)
+        {
+            b.MinColumn /= image.Density;
+            b.MaxColumn /= image.Density;
+            b.MinRow /= image.Density;
+            b.MaxRow /= image.Density;
+        }
+        return blobs;
+    }
+
+    private class UnionFind<T>
+    {
+        // A generic Union Find Data Structure 
+        // Based on https://github.com/thomas-villagers/unionfind.cs
+        private Dictionary<T, SetElement> dict;
+
+        public class SetElement
+        {
+            public SetElement Parent { get; internal set; }
+            public T Value { get; }
+            public int Size { get; internal set; }
+            public SetElement(T value)
+            {
+                Value = value;
+                Parent = this;
+                Size = 1;
+            }
+            public override string ToString() => string.Format("{0}, size:{1}", Value, Size);
+        }
+
+        public UnionFind()
+        {
+            dict = new Dictionary<T, SetElement>();
+        }
+
+        public SetElement MakeSet(T value)
+        {
+            SetElement element = new SetElement(value);
+            dict[value] = element;
+            return element;
+        }
+
+        public SetElement Find(T value)
+        {
+            SetElement element = dict[value];
+            SetElement root = element;
+            while (root.Parent != root)
+            {
+                root = root.Parent;
+            }
+            SetElement z = element;
+            while (z.Parent != z)
+            {
+                SetElement temp = z;
+                z = z.Parent;
+                temp.Parent = root;
+            }
+            return root;
+        }
+
+        public SetElement Union(SetElement root1, SetElement root2)
+        {
+            if (root2.Size > root1.Size)
+            {
+                root2.Size += root1.Size;
+                root1.Parent = root2;
+                return root2;
+            }
+            else
+            {
+                root1.Size += root2.Size;
+                root2.Parent = root1;
+                return root1;
+            }
+        }
+    }
+
+    public class Blob
+    {
+        public int Id;
+        public double MinColumn;
+        public double MaxColumn;
+        public double MinRow;
+        public double MaxRow;
+        public double Width => MaxColumn - MinColumn + 1;
+        public double Height => MaxRow - MinRow + 1;
+        public double VerticalCenter => (MaxRow + MinRow) / 2;
+        public double HorizontalCenter => (MaxColumn + MinColumn) / 2;
+        public List<System.Drawing.Point> Pixels { get; } = new List<System.Drawing.Point>();
+    }
+
+    public static Blob Union(this IEnumerable<Blob> blobs)
+    {
+        var b = blobs.FirstOrDefault();
+        if (b != null)
+            foreach (var bl in blobs.Skip(1))
+            {
+                b.MinColumn = Math.Min(bl.MinColumn, b.MinColumn);
+                b.MinRow = Math.Min(bl.MinRow, b.MinRow);
+                b.MaxColumn = Math.Max(bl.MaxColumn, b.MaxColumn);
+                b.MaxRow = Math.Max(bl.MaxRow, b.MaxRow);
+            }
+        return b;
+    }
+}

--- a/src/Core/tests/DeviceTests.Shared/ImageAnalysis/ConnectedComponentAnalysis.cs
+++ b/src/Core/tests/DeviceTests.Shared/ImageAnalysis/ConnectedComponentAnalysis.cs
@@ -1,13 +1,4 @@
-﻿//
-// ConnectedComponentAnalysis.cs
-//
-// Author:
-//       Morten Nielsen (https://xaml.dev)
-//       Copyright (c) 2006-2023 Morten Nielsen
-//
-// Licensed under the MIT License.
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/Core/tests/DeviceTests.Shared/ImageAnalysis/ConnectedComponentAnalysis.cs
+++ b/src/Core/tests/DeviceTests.Shared/ImageAnalysis/ConnectedComponentAnalysis.cs
@@ -1,241 +1,297 @@
-﻿using System;
+﻿//
+// ConnectedComponentAnalysis.cs
+//
+// Author:
+//       Morten Nielsen (https://xaml.dev)
+//       Copyright (c) 2006-2023 Morten Nielsen
+//
+// Licensed under the MIT License.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
-using Microsoft.Maui.Graphics;
 
-namespace Microsoft.Maui.DeviceTests.ImageAnalysis;
-
-
-// Method for finding pixels connected to each other. Great for finding UI Elements on the screen
-// based on pixel color filter.
-// A good explanation of the Connected Component Analysis can be seen here: https://www.youtube.com/watch?v=ticZclUYy88
-// Uses a 4-connectivity 2-pass Hoshen-Kopelman algorithm
-public static class ConnectedComponentAnalysis
+namespace Microsoft.Maui.DeviceTests.ImageAnalysis
 {
-    /// <summary>
-    /// Finds a set of pixels that are connected to each other, Looks at any pixels that are not black and/or transparent
-    /// </summary>
-    /// <param name="image"></param>
-    /// <returns></returns>
-    public static IList<Blob> FindConnectedPixels(RawBitmap image)
-    {
-        return FindConnectedPixels(image, (c) => (c.Red > 0 || c.Green > 0 || c.Blue > 0) && c.Alpha > 0);
-    }
+	/// <summary>
+	/// Helper methods for finding pixels connected to each other. Great for finding UI Elements on the screen based on pixel color filter.
+	/// </summary>
+	/// <remarks>
+	/// A good explanation of the Connected Component Analysis can be seen here: https://www.youtube.com/watch?v=ticZclUYy88
+	/// Uses a 4-connectivity 2-pass Hoshen-Kopelman algorithm.
+	/// </remarks>
+	public static class ConnectedComponentAnalysis
+	{
+		/// <summary>
+		/// Finds a set of pixels that are connected to each other, Looks at any pixels that are not black and/or transparent
+		/// </summary>
+		/// <param name="image"></param>
+		/// <returns></returns>
+		public static IList<Blob> FindConnectedPixels(RawBitmap image)
+		{
+			return FindConnectedPixels(image, (c) => (c.Red > 0 || c.Green > 0 || c.Blue > 0) && c.Alpha > 0);
+		}
 
-    public static async Task<IList<Blob>> FindConnectedPixelsAsync(VisualElement element, Func<Color, bool> includePixelFunction)
-    {
-        var bitmap = await element.AsRawBitmapAsync();
-        return FindConnectedPixels(bitmap, includePixelFunction);
-    }
+		/// <summary>
+		/// Finds a set of pixels that are connected to each other, connecting any pixels that matches <paramref name="includePixelFunction"/>.
+		/// </summary>
+		/// <param name="element">Visual Element to analyze</param>
+		/// <param name="includePixelFunction">Pixel filter</param>
+		/// <returns>List of blobs</returns>
+		public static async Task<IList<Blob>> FindConnectedPixelsAsync(VisualElement element, Func<Color, bool> includePixelFunction)
+		{
+			var bitmap = await element.AsRawBitmapAsync();
+			return FindConnectedPixels(bitmap, includePixelFunction);
+		}
 
-    public static IList<Blob> FindConnectedPixels(RawBitmap image, Color color)
-    {
-        return FindConnectedPixels(image, c => c.ToUint() == color.ToUint());
-    }
+		/// <summary>
+		/// Finds a set of pixels that are connected to each other, connecting any pixels of the specific color.
+		/// </summary>
+		/// <param name="image">Image to analyze</param>
+		/// <param name="color">Pixel color filter</param>
+		/// <returns>List of blobs</returns>
+		public static IList<Blob> FindConnectedPixels(RawBitmap image, Color color)
+		{
+			return FindConnectedPixels(image, c => c.ToUint() == color.ToUint());
+		}
 
-    public static IList<Blob> FindConnectedPixels(RawBitmap image, Func<Color, bool> includePixelFunction)
-    {
-        int width = image.PixelWidth;
-        int height = image.PixelHeight;
-        bool[] pixels = new bool[width * height];
+		/// <summary>
+		/// Finds a set of pixels that are connected to each other, connecting any pixels that matches <paramref name="includePixelFunction"/>.
+		/// </summary>
+		/// <param name="image">Image to analyze</param>
+		/// <param name="includePixelFunction">Pixel filter</param>
+		/// <returns>List of blobs</returns>
+		public static IList<Blob> FindConnectedPixels(RawBitmap image, Func<Color, bool> includePixelFunction)
+		{
+			int width = image.PixelWidth;
+			int height = image.PixelHeight;
+			bool[] pixels = new bool[width * height];
 
-        int bitsPerPixel = 32;
-        int stride = image.PixelWidth * bitsPerPixel / 8;
-        byte[] pixelbuffer = image.PixelBuffer;
+			int bitsPerPixel = 32;
+			int stride = image.PixelWidth * bitsPerPixel / 8;
+			byte[] pixelbuffer = image.PixelBuffer;
 
-        for (int row = 0; row < height; row++)
-        {
-            for (int col = 0; col < width; col++)
-            {
-                byte b = pixelbuffer[row * stride + col * 4];
-                byte g = pixelbuffer[row * stride + col * 4 + 1];
-                byte r = pixelbuffer[row * stride + col * 4 + 2];
-                byte a = pixelbuffer[row * stride + col * 4 + 3];
+			for (int row = 0; row < height; row++)
+			{
+				for (int col = 0; col < width; col++)
+				{
+					byte b = pixelbuffer[row * stride + col * 4];
+					byte g = pixelbuffer[row * stride + col * 4 + 1];
+					byte r = pixelbuffer[row * stride + col * 4 + 2];
+					byte a = pixelbuffer[row * stride + col * 4 + 3];
 
-                pixels[col + row * width] = includePixelFunction(Color.FromRgba(r, g, b, a));
-            }
-        }
+					pixels[col + row * width] = includePixelFunction(Color.FromRgba(r, g, b, a));
+				}
+			}
 
-        Func<Color, bool> ismatch = includePixelFunction;
-        int[] labels = new int[pixels.Length];
-        int currentLabel = 0;
-        // First pass - Label pixels
-        UnionFind<int> sets = new UnionFind<int>();
-        for (int i = 0; i < height; i++)
-        {
-            for (int j = 0; j < width; j++)
-            {
-                var idx = j + i * width;
-                bool v = pixels[idx];
-                if (v)
-                {
-                    var l1 = i == 0 ? 0 : labels[j + (i - 1) * width];
-                    var l2 = j == 0 ? 0 : labels[j + i * width - 1];
-                    if (l1 == 0 && l2 == 0)
-                    {
-                        //Assign new label
-                        currentLabel++;
-                        labels[idx] = currentLabel;
-                        sets.MakeSet(currentLabel);
-                    }
-                    else if (l1 > 0 && l2 == 0)
-                        labels[idx] = l1; //Copy label from neighbor
-                    else if (l1 == 0 && l2 > 0)
-                        labels[idx] = l2; //Copy label from neighbor
-                    else
-                    {
-                        labels[idx] = l1 < l2 ? l1 : l2; // Both neighbors have values. Grab the smallest label
-                        if (l1 != l2)
-                            sets.Union(sets.Find(l1), sets.Find(l2)); //store L1 is equivalent to L2
-                    }
-                }
-            }
-        }
-        // Second pass: Update equivalent labels
-        for (int i = 0; i < height; i++)
-        {
-            for (int j = 0; j < width; j++)
-            {
-                var idx = j + i * width;
-                var lbl = labels[idx];
-                if (lbl > 0)
-                {
-                    var l = sets.Find(lbl);
-                    labels[idx] = l.Value;
-                }
-            }
-        }
-        // Generate blobs
-        var blobs = new List<Blob>();
-        for (int i = 0; i < height; i++)
-        {
-            for (int j = 0; j < width; j++)
-            {
-                var idx = j + i * width;
-                var lbl = labels[idx];
-                if (lbl > 0)
-                {
-                    var blob = blobs.Where(b => b.Id == lbl).FirstOrDefault();
-                    if (blob != null)
-                    {
-                        blob.MinColumn = Math.Min(blob.MinColumn, j);
-                        blob.MaxColumn = Math.Max(blob.MaxColumn, j);
-                        blob.MinRow = Math.Min(blob.MinRow, i);
-                        blob.MaxRow = Math.Max(blob.MaxRow, i);
-                    }
-                    else
-                    {
-                        blob = new Blob() { Id = lbl, MinColumn = j, MaxColumn = j, MinRow = i, MaxRow = i };
-                        blobs.Add(blob);
-                    }
-                    blob.Pixels.Add(new System.Drawing.Point(j, i));
-                }
-            }
-        }
-        foreach (var b in blobs)
-        {
-            b.MinColumn /= image.Density;
-            b.MaxColumn /= image.Density;
-            b.MinRow /= image.Density;
-            b.MaxRow /= image.Density;
-        }
-        return blobs;
-    }
+			Func<Color, bool> ismatch = includePixelFunction;
+			int[] labels = new int[pixels.Length];
+			int currentLabel = 0;
+			// First pass - Label pixels
+			UnionFind<int> sets = new UnionFind<int>();
+			for (int i = 0; i < height; i++)
+			{
+				for (int j = 0; j < width; j++)
+				{
+					var idx = j + i * width;
+					bool v = pixels[idx];
+					if (v)
+					{
+						var l1 = i == 0 ? 0 : labels[j + (i - 1) * width];
+						var l2 = j == 0 ? 0 : labels[j + i * width - 1];
+						if (l1 == 0 && l2 == 0)
+						{
+							//Assign new label
+							currentLabel++;
+							labels[idx] = currentLabel;
+							sets.MakeSet(currentLabel);
+						}
+						else if (l1 > 0 && l2 == 0)
+							labels[idx] = l1; //Copy label from neighbor
+						else if (l1 == 0 && l2 > 0)
+							labels[idx] = l2; //Copy label from neighbor
+						else
+						{
+							labels[idx] = l1 < l2 ? l1 : l2; // Both neighbors have values. Grab the smallest label
+							if (l1 != l2)
+								sets.Union(sets.Find(l1), sets.Find(l2)); //store L1 is equivalent to L2
+						}
+					}
+				}
+			}
+			// Second pass: Update equivalent labels
+			for (int i = 0; i < height; i++)
+			{
+				for (int j = 0; j < width; j++)
+				{
+					var idx = j + i * width;
+					var lbl = labels[idx];
+					if (lbl > 0)
+					{
+						var l = sets.Find(lbl);
+						labels[idx] = l.Value;
+					}
+				}
+			}
+			// Generate blobs
+			var blobs = new List<Blob>();
+			for (int i = 0; i < height; i++)
+			{
+				for (int j = 0; j < width; j++)
+				{
+					var idx = j + i * width;
+					var lbl = labels[idx];
+					if (lbl > 0)
+					{
+						var blob = blobs.Where(b => b.Id == lbl).FirstOrDefault();
+						if (blob != null)
+						{
+							blob.MinColumn = Math.Min(blob.MinColumn, j);
+							blob.MaxColumn = Math.Max(blob.MaxColumn, j);
+							blob.MinRow = Math.Min(blob.MinRow, i);
+							blob.MaxRow = Math.Max(blob.MaxRow, i);
+						}
+						else
+						{
+							blob = new Blob() { Id = lbl, MinColumn = j, MaxColumn = j, MinRow = i, MaxRow = i };
+							blobs.Add(blob);
+						}
+						blob.Pixels.Add(new System.Drawing.Point(j, i));
+					}
+				}
+			}
+			foreach (var b in blobs)
+			{
+				b.MinColumn /= image.Density;
+				b.MaxColumn /= image.Density;
+				b.MinRow /= image.Density;
+				b.MaxRow /= image.Density;
+			}
+			return blobs;
+		}
 
-    private class UnionFind<T>
-    {
-        // A generic Union Find Data Structure 
-        // Based on https://github.com/thomas-villagers/unionfind.cs
-        private Dictionary<T, SetElement> dict;
+		private class UnionFind<T>
+		{
+			// A generic Union Find Data Structure 
+			// Based on https://github.com/thomas-villagers/unionfind.cs
+			private Dictionary<T, SetElement> dict;
 
-        public class SetElement
-        {
-            public SetElement Parent { get; internal set; }
-            public T Value { get; }
-            public int Size { get; internal set; }
-            public SetElement(T value)
-            {
-                Value = value;
-                Parent = this;
-                Size = 1;
-            }
-            public override string ToString() => string.Format("{0}, size:{1}", Value, Size);
-        }
+			public class SetElement
+			{
+				public SetElement Parent { get; internal set; }
+				public T Value { get; }
+				public int Size { get; internal set; }
+				public SetElement(T value)
+				{
+					Value = value;
+					Parent = this;
+					Size = 1;
+				}
+				public override string ToString() => string.Format("{0}, size:{1}", Value, Size);
+			}
 
-        public UnionFind()
-        {
-            dict = new Dictionary<T, SetElement>();
-        }
+			public UnionFind()
+			{
+				dict = new Dictionary<T, SetElement>();
+			}
 
-        public SetElement MakeSet(T value)
-        {
-            SetElement element = new SetElement(value);
-            dict[value] = element;
-            return element;
-        }
+			public SetElement MakeSet(T value)
+			{
+				SetElement element = new SetElement(value);
+				dict[value] = element;
+				return element;
+			}
 
-        public SetElement Find(T value)
-        {
-            SetElement element = dict[value];
-            SetElement root = element;
-            while (root.Parent != root)
-            {
-                root = root.Parent;
-            }
-            SetElement z = element;
-            while (z.Parent != z)
-            {
-                SetElement temp = z;
-                z = z.Parent;
-                temp.Parent = root;
-            }
-            return root;
-        }
+			public SetElement Find(T value)
+			{
+				SetElement element = dict[value];
+				SetElement root = element;
+				while (root.Parent != root)
+				{
+					root = root.Parent;
+				}
+				SetElement z = element;
+				while (z.Parent != z)
+				{
+					SetElement temp = z;
+					z = z.Parent;
+					temp.Parent = root;
+				}
+				return root;
+			}
 
-        public SetElement Union(SetElement root1, SetElement root2)
-        {
-            if (root2.Size > root1.Size)
-            {
-                root2.Size += root1.Size;
-                root1.Parent = root2;
-                return root2;
-            }
-            else
-            {
-                root1.Size += root2.Size;
-                root2.Parent = root1;
-                return root1;
-            }
-        }
-    }
+			public SetElement Union(SetElement root1, SetElement root2)
+			{
+				if (root2.Size > root1.Size)
+				{
+					root2.Size += root1.Size;
+					root1.Parent = root2;
+					return root2;
+				}
+				else
+				{
+					root1.Size += root2.Size;
+					root2.Parent = root1;
+					return root1;
+				}
+			}
+		}
 
-    public class Blob
-    {
-        public int Id;
-        public double MinColumn;
-        public double MaxColumn;
-        public double MinRow;
-        public double MaxRow;
-        public double Width => MaxColumn - MinColumn + 1;
-        public double Height => MaxRow - MinRow + 1;
-        public double VerticalCenter => (MaxRow + MinRow) / 2;
-        public double HorizontalCenter => (MaxColumn + MinColumn) / 2;
-        public List<System.Drawing.Point> Pixels { get; } = new List<System.Drawing.Point>();
-    }
+		/// <summary>
+		/// Combines the bounding box of a set of blobs.
+		/// </summary>
+		/// <param name="blobs"></param>
+		/// <returns></returns>
+		public static Blob Union(this IEnumerable<Blob> blobs)
+		{
+			var b = blobs.FirstOrDefault();
+			if (b != null)
+				foreach (var bl in blobs.Skip(1))
+				{
+					b.MinColumn = Math.Min(bl.MinColumn, b.MinColumn);
+					b.MinRow = Math.Min(bl.MinRow, b.MinRow);
+					b.MaxColumn = Math.Max(bl.MaxColumn, b.MaxColumn);
+					b.MaxRow = Math.Max(bl.MaxRow, b.MaxRow);
+				}
+			return b;
+		}
+	}
 
-    public static Blob Union(this IEnumerable<Blob> blobs)
-    {
-        var b = blobs.FirstOrDefault();
-        if (b != null)
-            foreach (var bl in blobs.Skip(1))
-            {
-                b.MinColumn = Math.Min(bl.MinColumn, b.MinColumn);
-                b.MinRow = Math.Min(bl.MinRow, b.MinRow);
-                b.MaxColumn = Math.Max(bl.MaxColumn, b.MaxColumn);
-                b.MaxRow = Math.Max(bl.MaxRow, b.MaxRow);
-            }
-        return b;
-    }
+	/// <summary>
+	/// Represents a blob of connected pixels found by <see cref="ConnectedComponentAnalysis"/>'s <c>FindConnectedPixels</c> methods.
+	/// </summary>
+	public class Blob
+	{
+		/// <summary>Blob ID</summary>
+		public int Id;
+
+		/// <summary>Starting column in device independent pixels.</summary>
+		public double MinColumn;
+
+		/// <summary>Ending columns in device independent pixels.</summary>
+		public double MaxColumn;
+
+		/// <summary>Starting row in device independent pixels.</summary>
+		public double MinRow;
+
+		/// <summary>Ending row in device independent pixels.</summary>
+		public double MaxRow;
+
+		/// <summary>Bounding box width in device independent pixels.</summary>
+		public double Width => MaxColumn - MinColumn + 1;
+
+		/// <summary>Bounding box height in device independent pixels.</summary>
+		public double Height => MaxRow - MinRow + 1;
+
+		/// <summary>Vertical center in device independent pixels.</summary>
+		public double VerticalCenter => (MaxRow + MinRow) / 2;
+
+		/// <summary>Horizontal center in device independent pixels.</summary>
+		public double HorizontalCenter => (MaxColumn + MinColumn) / 2;
+
+		/// <summary>List of pixels part of the blob.</summary>
+		public List<System.Drawing.Point> Pixels { get; } = new List<System.Drawing.Point>();
+	}
 }

--- a/src/Core/tests/DeviceTests.Shared/ImageAnalysis/RawBitmap.cs
+++ b/src/Core/tests/DeviceTests.Shared/ImageAnalysis/RawBitmap.cs
@@ -33,7 +33,6 @@ namespace Microsoft.Maui.DeviceTests.ImageAnalysis
 			if (element.IsLoaded)
 				load.TrySetResult();
 			await load.Task;
-			var size = element.Width;
 			TaskCompletionSource<IViewHandler> tcs = new();
 			element.HandlerChanged += (s, e) => { if (element.Handler != null) tcs.TrySetResult(element.Handler); };
 			if (element.Handler is not null)

--- a/src/Core/tests/DeviceTests.Shared/ImageAnalysis/RawBitmap.cs
+++ b/src/Core/tests/DeviceTests.Shared/ImageAnalysis/RawBitmap.cs
@@ -1,13 +1,4 @@
-﻿//
-// RawBitmap.cs
-//
-// Author:
-//       Morten Nielsen (https://xaml.dev)
-//       Copyright (c) 2023 Morten Nielsen
-//
-// Licensed under the MIT License.
-
-using System;
+﻿using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls;

--- a/src/Core/tests/DeviceTests.Shared/ImageAnalysis/RawBitmap.cs
+++ b/src/Core/tests/DeviceTests.Shared/ImageAnalysis/RawBitmap.cs
@@ -1,8 +1,16 @@
-﻿using System;
+﻿//
+// RawBitmap.cs
+//
+// Author:
+//       Morten Nielsen (https://xaml.dev)
+//       Copyright (c) 2023 Morten Nielsen
+//
+// Licensed under the MIT License.
+
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
-using Microsoft.Maui.Platform;
 #if WINDOWS
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Media.Imaging;
@@ -13,162 +21,165 @@ using CoreImage;
 using UIKit;
 #endif
 
-namespace Microsoft.Maui.DeviceTests.ImageAnalysis;
-
-public class RawBitmap
+namespace Microsoft.Maui.DeviceTests.ImageAnalysis
 {
-	public int PixelHeight { get; internal set; }
-	public int PixelWidth { get; internal set; }
-	public double Height => PixelHeight / Density;
-	public double Width => PixelWidth / Density;
-	public byte[] PixelBuffer { get; internal set; }
-	public double Density { get; internal set; }
-}
+	public class RawBitmap
+	{
+		public int PixelHeight { get; internal set; }
+		public int PixelWidth { get; internal set; }
+		public double Height => PixelHeight / Density;
+		public double Width => PixelWidth / Density;
+		public byte[] PixelBuffer { get; internal set; }
+		public double Density { get; internal set; }
+	}
 
-public static partial class RawBitmapExtensions
-{
-    public static async Task<RawBitmap> AsRawBitmapAsync(this VisualElement element)
-    {
-        TaskCompletionSource load = new();
-        element.Loaded += (s, e) => load.TrySetResult();
-        if (element.IsLoaded) load.TrySetResult();
-        await load.Task;
-        var size = element.Width;
-        TaskCompletionSource<IViewHandler> tcs = new();
-        element.HandlerChanged += (s, e) => { if (element.Handler != null) tcs.TrySetResult(element.Handler); };
-        if (element.Handler is not null) tcs.TrySetResult(element.Handler);
-        var getHandler = await tcs.Task;
-        var platformView = getHandler.PlatformView;
+	public static partial class RawBitmapExtensions
+	{
+		public static async Task<RawBitmap> AsRawBitmapAsync(this VisualElement element)
+		{
+			TaskCompletionSource load = new();
+			element.Loaded += (s, e) => load.TrySetResult();
+			if (element.IsLoaded)
+				load.TrySetResult();
+			await load.Task;
+			var size = element.Width;
+			TaskCompletionSource<IViewHandler> tcs = new();
+			element.HandlerChanged += (s, e) => { if (element.Handler != null) tcs.TrySetResult(element.Handler); };
+			if (element.Handler is not null)
+				tcs.TrySetResult(element.Handler);
+			var getHandler = await tcs.Task;
+			var platformView = getHandler.PlatformView;
 #if WINDOWS
-        return await CaptureView(platformView as UIElement);
+			return await CaptureView(platformView as UIElement);
 #elif ANDROID
-        return await CaptureView(platformView as Android.Views.View);
+			return await CaptureView(platformView as Android.Views.View);
 #elif IOS
-        return await CaptureView(platformView as UIKit.UIView);
+			return await CaptureView(platformView as UIKit.UIView);
 #else
-        throw new PlatformNotSupportedException("TODO");
+			throw new PlatformNotSupportedException("TODO");
 #endif
-    }
+		}
 
 #if WINDOWS
-    private static async Task<RawBitmap> CaptureView(UIElement view)
-    {
-        var renderTargetBitmap = new RenderTargetBitmap();
-        await renderTargetBitmap.RenderAsync(view);
-        var pixelBuffer = await renderTargetBitmap.GetPixelsAsync();
-        var pixels = pixelBuffer.ToArray();
-        var width = (int)renderTargetBitmap.PixelWidth;
-        var height = (int)renderTargetBitmap.PixelHeight;
+		private static async Task<RawBitmap> CaptureView(UIElement view)
+		{
+			var renderTargetBitmap = new RenderTargetBitmap();
+			await renderTargetBitmap.RenderAsync(view);
+			var pixelBuffer = await renderTargetBitmap.GetPixelsAsync();
+			var pixels = pixelBuffer.ToArray();
+			var width = (int)renderTargetBitmap.PixelWidth;
+			var height = (int)renderTargetBitmap.PixelHeight;
 
-        return new RawBitmap
-        {
-            PixelBuffer = pixels,
-            PixelHeight = height,
-            PixelWidth = width,
-            Density = view.XamlRoot.RasterizationScale
-        };
-    }
+			return new RawBitmap
+			{
+				PixelBuffer = pixels,
+				PixelHeight = height,
+				PixelWidth = width,
+				Density = view.XamlRoot.RasterizationScale
+			};
+		}
 #elif IOS
-    private static async Task<RawBitmap> CaptureView(UIView view)
-    {
-        await Task.Delay(1000); // TODO: Wait for UI to render
-        var rect = view.Bounds;
-        var scale = UIScreen.MainScreen.Scale;
-        int width = (int)(rect.Width * scale);
-        int height = (int)(rect.Height * scale);
-        UIGraphics.BeginImageContextWithOptions(rect.Size, false, UIScreen.MainScreen.Scale);
-         using var context = UIGraphics.GetCurrentContext();
-        using var colorSpace = CGColorSpace.CreateDeviceRGB();
-        view.Layer.RenderInContext(context);
-        using var image = UIGraphics.GetImageFromCurrentImageContext();
-        UIGraphics.EndImageContext();
-        var cgimage = image.CGImage;
-        var buffer = cgimage.DataProvider.CopyData();
-        var pixelBuffer = buffer.ToArray();
-        var bytesPerPixel = cgimage.BitsPerPixel / 8;
-        if (cgimage.ByteOrderInfo != CGImageByteOrderInfo.ByteOrder32Little)
-            throw new NotImplementedException($"ByteOrderInfo CGImageByteOrderInfo.{cgimage.ByteOrderInfo} not implemented");
-        
-        byte[] rawData = new byte[(int)(cgimage.Width * cgimage.Height * 4)];
-        int index = 0;
-        for (int i = 0; i < cgimage.Height; i++)
-        {
-            var a = i * cgimage.BytesPerRow;
-            for (int j = 0; j < cgimage.Width; j++)
-            {
-                rawData[index++] = pixelBuffer[a + j * bytesPerPixel + 0]; //B
-                rawData[index++] = pixelBuffer[a + j * bytesPerPixel + 1]; //G
-                rawData[index++] = pixelBuffer[a + j * bytesPerPixel + 2]; //R
-                rawData[index++] = pixelBuffer[a + j * bytesPerPixel + 3]; //A
-            }
-        }
-        return new RawBitmap()
-        {
-            PixelBuffer = rawData,
-            PixelWidth = width,
-            PixelHeight = height,
-            Density = scale
-        };
-    }
+		private static async Task<RawBitmap> CaptureView(UIView view)
+		{
+			await Task.Delay(1000); // TODO: Wait for UI to render
+			var rect = view.Bounds;
+			var scale = UIScreen.MainScreen.Scale;
+			int width = (int)(rect.Width * scale);
+			int height = (int)(rect.Height * scale);
+			UIGraphics.BeginImageContextWithOptions(rect.Size, false, UIScreen.MainScreen.Scale);
+			using var context = UIGraphics.GetCurrentContext();
+			using var colorSpace = CGColorSpace.CreateDeviceRGB();
+			view.Layer.RenderInContext(context);
+			using var image = UIGraphics.GetImageFromCurrentImageContext();
+			UIGraphics.EndImageContext();
+			var cgimage = image.CGImage;
+			var buffer = cgimage.DataProvider.CopyData();
+			var pixelBuffer = buffer.ToArray();
+			var bytesPerPixel = cgimage.BitsPerPixel / 8;
+			if (cgimage.ByteOrderInfo != CGImageByteOrderInfo.ByteOrder32Little)
+				throw new NotImplementedException($"ByteOrderInfo CGImageByteOrderInfo.{cgimage.ByteOrderInfo} not implemented");
+
+			byte[] rawData = new byte[(int)(cgimage.Width * cgimage.Height * 4)];
+			int index = 0;
+			for (int i = 0; i < cgimage.Height; i++)
+			{
+				var a = i * cgimage.BytesPerRow;
+				for (int j = 0; j < cgimage.Width; j++)
+				{
+					rawData[index++] = pixelBuffer[a + j * bytesPerPixel + 0]; //B
+					rawData[index++] = pixelBuffer[a + j * bytesPerPixel + 1]; //G
+					rawData[index++] = pixelBuffer[a + j * bytesPerPixel + 2]; //R
+					rawData[index++] = pixelBuffer[a + j * bytesPerPixel + 3]; //A
+				}
+			}
+			return new RawBitmap()
+			{
+				PixelBuffer = rawData,
+				PixelWidth = width,
+				PixelHeight = height,
+				Density = scale
+			};
+		}
 #elif ANDROID
-    private static async Task<RawBitmap> CaptureView(Android.Views.View view)
-    {
-        while (!AndroidX.Core.View.ViewCompat.IsLaidOut(view))
-            await Task.Delay(10); // Wait for Android to render the view
-        var bitmap = Android.Graphics.Bitmap.CreateBitmap(view.Width, view.Height, Android.Graphics.Bitmap.Config.Argb8888);
-        Android.Graphics.Canvas canvas = new (bitmap);
-        view.Draw(canvas);
-        int[] pixels = new int[bitmap.Width * bitmap.Height];        
-        bitmap.GetPixels(pixels, 0, bitmap.Width, 0, 0, bitmap.Width, bitmap.Height);
-        return new RawBitmap
-        {
-            PixelBuffer = pixels.SelectMany(p => BitConverter.GetBytes(p)).ToArray(),
-            PixelHeight = bitmap.Height,
-            PixelWidth = bitmap.Width,
-            Density = bitmap.Density / 160d
-        };
-    }
-    /*
-    [System.Runtime.Versioning.SupportedOSPlatform("android26.0")]
-    private static Task<BitmapSource> CaptureView2(Android.Views.View view)
-    {
-        var activity = Microsoft.Maui.ApplicationModel.Platform.CurrentActivity;
-        var loc = new int[2];
-        view.GetLocationInWindow(loc);
-        var bitmap = Android.Graphics.Bitmap.CreateBitmap(view.Width, view.Height, Android.Graphics.Bitmap.Config.Argb8888);
-        OnPixelCopyFinishedListener listener = new OnPixelCopyFinishedListener(view);
-        Android.Views.PixelCopy.Request(activity.Window, new Android.Graphics.Rect(loc[0], loc[1], view.Width + loc[0], view.Height + loc[1]), bitmap, listener, view.Handler);
-        return listener.Task;
-    }
-    private class OnPixelCopyFinishedListener : Java.Lang.Object, Android.Views.PixelCopy.IOnPixelCopyFinishedListener
-    {
-        private readonly TaskCompletionSource<BitmapSource> _tcs = new();
-        private readonly Android.Views.View _view;
-        public OnPixelCopyFinishedListener(Android.Views.View view)
-        {
-            _view = view;
-        }
-        public Task<BitmapSource> Task => _tcs.Task;
-        void Android.Views.PixelCopy.IOnPixelCopyFinishedListener.OnPixelCopyFinished(int copyResult)
-        {
-            if (copyResult == 0)
-            {
-                var bitmap = Android.Graphics.Bitmap.CreateBitmap(_view.Width, _view.Height, Android.Graphics.Bitmap.Config.Argb8888);
-                int[] pixels = new int[bitmap.Width * bitmap.Height];
-                bitmap.GetPixels(pixels, 0, bitmap.Width, 0, 0, bitmap.Width, bitmap.Height);
-                _tcs.TrySetResult(new BitmapSource
-                {
-                    PixelBuffer = pixels.SelectMany(p => BitConverter.GetBytes(p)).ToArray(),
-                    PixelHeight = bitmap.Height,
-                    PixelWidth = bitmap.Width,
-                    Density = bitmap.Density / 160d
-                });
-            }
-            else
-            {
-                _tcs.TrySetException(new Exception($"Failed to copy pixels: {copyResult}"));
-            }
-        }
-    }*/
+		private static async Task<RawBitmap> CaptureView(Android.Views.View view)
+		{
+			while (!AndroidX.Core.View.ViewCompat.IsLaidOut(view))
+				await Task.Delay(10); // Wait for Android to render the view
+			var bitmap = Android.Graphics.Bitmap.CreateBitmap(view.Width, view.Height, Android.Graphics.Bitmap.Config.Argb8888);
+			Android.Graphics.Canvas canvas = new (bitmap);
+			view.Draw(canvas);
+			int[] pixels = new int[bitmap.Width * bitmap.Height];        
+			bitmap.GetPixels(pixels, 0, bitmap.Width, 0, 0, bitmap.Width, bitmap.Height);
+			return new RawBitmap
+			{
+				PixelBuffer = pixels.SelectMany(p => BitConverter.GetBytes(p)).ToArray(),
+				PixelHeight = bitmap.Height,
+				PixelWidth = bitmap.Width,
+				Density = bitmap.Density / 160d
+			};
+		}
+		/*
+		[System.Runtime.Versioning.SupportedOSPlatform("android26.0")]
+		private static Task<BitmapSource> CaptureView2(Android.Views.View view)
+		{
+			var activity = Microsoft.Maui.ApplicationModel.Platform.CurrentActivity;
+			var loc = new int[2];
+			view.GetLocationInWindow(loc);
+			var bitmap = Android.Graphics.Bitmap.CreateBitmap(view.Width, view.Height, Android.Graphics.Bitmap.Config.Argb8888);
+			OnPixelCopyFinishedListener listener = new OnPixelCopyFinishedListener(view);
+			Android.Views.PixelCopy.Request(activity.Window, new Android.Graphics.Rect(loc[0], loc[1], view.Width + loc[0], view.Height + loc[1]), bitmap, listener, view.Handler);
+			return listener.Task;
+		}
+		private class OnPixelCopyFinishedListener : Java.Lang.Object, Android.Views.PixelCopy.IOnPixelCopyFinishedListener
+		{
+			private readonly TaskCompletionSource<BitmapSource> _tcs = new();
+			private readonly Android.Views.View _view;
+			public OnPixelCopyFinishedListener(Android.Views.View view)
+			{
+				_view = view;
+			}
+			public Task<BitmapSource> Task => _tcs.Task;
+			void Android.Views.PixelCopy.IOnPixelCopyFinishedListener.OnPixelCopyFinished(int copyResult)
+			{
+				if (copyResult == 0)
+				{
+					var bitmap = Android.Graphics.Bitmap.CreateBitmap(_view.Width, _view.Height, Android.Graphics.Bitmap.Config.Argb8888);
+					int[] pixels = new int[bitmap.Width * bitmap.Height];
+					bitmap.GetPixels(pixels, 0, bitmap.Width, 0, 0, bitmap.Width, bitmap.Height);
+					_tcs.TrySetResult(new BitmapSource
+					{
+						PixelBuffer = pixels.SelectMany(p => BitConverter.GetBytes(p)).ToArray(),
+						PixelHeight = bitmap.Height,
+						PixelWidth = bitmap.Width,
+						Density = bitmap.Density / 160d
+					});
+				}
+				else
+				{
+					_tcs.TrySetException(new Exception($"Failed to copy pixels: {copyResult}"));
+				}
+			}
+		}*/
 #endif
+	}
 }

--- a/src/Core/tests/DeviceTests.Shared/ImageAnalysis/RawBitmap.cs
+++ b/src/Core/tests/DeviceTests.Shared/ImageAnalysis/RawBitmap.cs
@@ -1,0 +1,174 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Platform;
+#if WINDOWS
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Media.Imaging;
+using System.Runtime.InteropServices.WindowsRuntime;
+#elif IOS
+using CoreGraphics;
+using CoreImage;
+using UIKit;
+#endif
+
+namespace Microsoft.Maui.DeviceTests.ImageAnalysis;
+
+public class RawBitmap
+{
+	public int PixelHeight { get; internal set; }
+	public int PixelWidth { get; internal set; }
+	public double Height => PixelHeight / Density;
+	public double Width => PixelWidth / Density;
+	public byte[] PixelBuffer { get; internal set; }
+	public double Density { get; internal set; }
+}
+
+public static partial class RawBitmapExtensions
+{
+    public static async Task<RawBitmap> AsRawBitmapAsync(this VisualElement element)
+    {
+        TaskCompletionSource load = new();
+        element.Loaded += (s, e) => load.TrySetResult();
+        if (element.IsLoaded) load.TrySetResult();
+        await load.Task;
+        var size = element.Width;
+        TaskCompletionSource<IViewHandler> tcs = new();
+        element.HandlerChanged += (s, e) => { if (element.Handler != null) tcs.TrySetResult(element.Handler); };
+        if (element.Handler is not null) tcs.TrySetResult(element.Handler);
+        var getHandler = await tcs.Task;
+        var platformView = getHandler.PlatformView;
+#if WINDOWS
+        return await CaptureView(platformView as UIElement);
+#elif ANDROID
+        return await CaptureView(platformView as Android.Views.View);
+#elif IOS
+        return await CaptureView(platformView as UIKit.UIView);
+#else
+        throw new PlatformNotSupportedException("TODO");
+#endif
+    }
+
+#if WINDOWS
+    private static async Task<RawBitmap> CaptureView(UIElement view)
+    {
+        var renderTargetBitmap = new RenderTargetBitmap();
+        await renderTargetBitmap.RenderAsync(view);
+        var pixelBuffer = await renderTargetBitmap.GetPixelsAsync();
+        var pixels = pixelBuffer.ToArray();
+        var width = (int)renderTargetBitmap.PixelWidth;
+        var height = (int)renderTargetBitmap.PixelHeight;
+
+        return new RawBitmap
+        {
+            PixelBuffer = pixels,
+            PixelHeight = height,
+            PixelWidth = width,
+            Density = view.XamlRoot.RasterizationScale
+        };
+    }
+#elif IOS
+    private static async Task<RawBitmap> CaptureView(UIView view)
+    {
+        await Task.Delay(1000); // TODO: Wait for UI to render
+        var rect = view.Bounds;
+        var scale = UIScreen.MainScreen.Scale;
+        int width = (int)(rect.Width * scale);
+        int height = (int)(rect.Height * scale);
+        UIGraphics.BeginImageContextWithOptions(rect.Size, false, UIScreen.MainScreen.Scale);
+         using var context = UIGraphics.GetCurrentContext();
+        using var colorSpace = CGColorSpace.CreateDeviceRGB();
+        view.Layer.RenderInContext(context);
+        using var image = UIGraphics.GetImageFromCurrentImageContext();
+        UIGraphics.EndImageContext();
+        var cgimage = image.CGImage;
+        var buffer = cgimage.DataProvider.CopyData();
+        var pixelBuffer = buffer.ToArray();
+        var bytesPerPixel = cgimage.BitsPerPixel / 8;
+        if (cgimage.ByteOrderInfo != CGImageByteOrderInfo.ByteOrder32Little)
+            throw new NotImplementedException($"ByteOrderInfo CGImageByteOrderInfo.{cgimage.ByteOrderInfo} not implemented");
+        
+        byte[] rawData = new byte[(int)(cgimage.Width * cgimage.Height * 4)];
+        int index = 0;
+        for (int i = 0; i < cgimage.Height; i++)
+        {
+            var a = i * cgimage.BytesPerRow;
+            for (int j = 0; j < cgimage.Width; j++)
+            {
+                rawData[index++] = pixelBuffer[a + j * bytesPerPixel + 0]; //B
+                rawData[index++] = pixelBuffer[a + j * bytesPerPixel + 1]; //G
+                rawData[index++] = pixelBuffer[a + j * bytesPerPixel + 2]; //R
+                rawData[index++] = pixelBuffer[a + j * bytesPerPixel + 3]; //A
+            }
+        }
+        return new RawBitmap()
+        {
+            PixelBuffer = rawData,
+            PixelWidth = width,
+            PixelHeight = height,
+            Density = scale
+        };
+    }
+#elif ANDROID
+    private static async Task<RawBitmap> CaptureView(Android.Views.View view)
+    {
+        while (!AndroidX.Core.View.ViewCompat.IsLaidOut(view))
+            await Task.Delay(10); // Wait for Android to render the view
+        var bitmap = Android.Graphics.Bitmap.CreateBitmap(view.Width, view.Height, Android.Graphics.Bitmap.Config.Argb8888);
+        Android.Graphics.Canvas canvas = new (bitmap);
+        view.Draw(canvas);
+        int[] pixels = new int[bitmap.Width * bitmap.Height];        
+        bitmap.GetPixels(pixels, 0, bitmap.Width, 0, 0, bitmap.Width, bitmap.Height);
+        return new RawBitmap
+        {
+            PixelBuffer = pixels.SelectMany(p => BitConverter.GetBytes(p)).ToArray(),
+            PixelHeight = bitmap.Height,
+            PixelWidth = bitmap.Width,
+            Density = bitmap.Density / 160d
+        };
+    }
+    /*
+    [System.Runtime.Versioning.SupportedOSPlatform("android26.0")]
+    private static Task<BitmapSource> CaptureView2(Android.Views.View view)
+    {
+        var activity = Microsoft.Maui.ApplicationModel.Platform.CurrentActivity;
+        var loc = new int[2];
+        view.GetLocationInWindow(loc);
+        var bitmap = Android.Graphics.Bitmap.CreateBitmap(view.Width, view.Height, Android.Graphics.Bitmap.Config.Argb8888);
+        OnPixelCopyFinishedListener listener = new OnPixelCopyFinishedListener(view);
+        Android.Views.PixelCopy.Request(activity.Window, new Android.Graphics.Rect(loc[0], loc[1], view.Width + loc[0], view.Height + loc[1]), bitmap, listener, view.Handler);
+        return listener.Task;
+    }
+    private class OnPixelCopyFinishedListener : Java.Lang.Object, Android.Views.PixelCopy.IOnPixelCopyFinishedListener
+    {
+        private readonly TaskCompletionSource<BitmapSource> _tcs = new();
+        private readonly Android.Views.View _view;
+        public OnPixelCopyFinishedListener(Android.Views.View view)
+        {
+            _view = view;
+        }
+        public Task<BitmapSource> Task => _tcs.Task;
+        void Android.Views.PixelCopy.IOnPixelCopyFinishedListener.OnPixelCopyFinished(int copyResult)
+        {
+            if (copyResult == 0)
+            {
+                var bitmap = Android.Graphics.Bitmap.CreateBitmap(_view.Width, _view.Height, Android.Graphics.Bitmap.Config.Argb8888);
+                int[] pixels = new int[bitmap.Width * bitmap.Height];
+                bitmap.GetPixels(pixels, 0, bitmap.Width, 0, 0, bitmap.Width, bitmap.Height);
+                _tcs.TrySetResult(new BitmapSource
+                {
+                    PixelBuffer = pixels.SelectMany(p => BitConverter.GetBytes(p)).ToArray(),
+                    PixelHeight = bitmap.Height,
+                    PixelWidth = bitmap.Width,
+                    Density = bitmap.Density / 160d
+                });
+            }
+            else
+            {
+                _tcs.TrySetException(new Exception($"Failed to copy pixels: {copyResult}"));
+            }
+        }
+    }*/
+#endif
+}


### PR DESCRIPTION
### Description of Change

This introduces the ability to analyze pixels as a set of connected pixels, allowing you to measure the size and location of UI elements, independent of device, screen size and DPI.
It will help ensure consistent layout across all supported .NET MAUI platforms.

A quick introduction to the algorithm used can be found here: https://www.youtube.com/watch?v=ticZclUYy88

### Issues Fixed

While this specific issue doesn't actually fix any issue, the two included example tests does verify regressions and fixes.
The border test specifically is currently failing on Windows due to #16667 and on Android it finds the border to be too thin (it was made to validate #15339 and shows the result is closer to correct, but still needs tweak -cc @jstedfast ).

This is the initial PR submitted, as discussed in a recent meeting with @BretJohnson @PureWeen @mattleibow and @jstedfast

Please let me know what you'd like to change/improve/remove and I'd be more than happy to work with you on getting it to a point where you can start using it.

A few things that could be improved:
- Replace RawBitmap with the code already there for grabbing screenshots of VisualElements (will need support for getting the entire pixel buffer in a consistent byte order)
- One of the unit tests exposes an issue on iOS where the grid renders under the safe-area, but doesn't adjust rows for it, however I wasn't able to get the specific test UI elements to scale to the entire screen, so hard to hardcode a fixed height or the test would fail on all platforms (unspecified width/height not supported)
- Disable the two tests for now, since they don't actually pass on all platforms just yet due to other bugs.

Fails on Windows due to #16667:
<img width="637" alt="image" src="https://github.com/dotnet/maui/assets/1378165/fb3c76d6-c7b7-4439-a86f-c8574adc4096">

Fails on Android because border is too thin:
<img width="654" alt="image" src="https://github.com/dotnet/maui/assets/1378165/f9a672b7-6ed0-4a97-8d94-62d9edc1f9a3">

iOS passed (but second would fail if we could expand the view to the full screen, since safe area affects outcome):
<img width="455" alt="image" src="https://github.com/dotnet/maui/assets/1378165/68d27b6e-e718-4d3c-b3e0-34a17a902235">
