### PR TITLE
Fix in templates for .DS_Store on MacOSX causing build failures

### DIFF
--- a/src/Templates/src/templates/maui-blazor/MauiApp.1.csproj
+++ b/src/Templates/src/templates/maui-blazor/MauiApp.1.csproj
@@ -20,6 +20,8 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <EnableDefaultCssItems>false</EnableDefaultCssItems>
 
+        <DefaultItemExcludes>$(DefaultItemExcludes);**\.DS_Store</DefaultItemExcludes>
+
         <!-- Display name -->
         <ApplicationTitle>MauiApp.1</ApplicationTitle>
 
@@ -46,11 +48,11 @@
         <MauiSplashScreen Include="Resources\Splash\splash.svg" Color="#512BD4" BaseSize="128,128" />
 
         <!-- Images -->
-        <MauiImage Include="Resources\Images\*" />
+        <MauiImage Include="Resources\Images\*" Exclude="$(DefaultItemExcludes)" />
         <MauiImage Update="Resources\Images\dotnet_bot.svg" BaseSize="168,208" />
 
         <!-- Custom Fonts -->
-        <MauiFont Include="Resources\Fonts\*" />
+        <MauiFont Include="Resources\Fonts\*" Exclude="$(DefaultItemExcludes)" />
 
         <!-- Raw Assets (also remove the "Resources\Raw" prefix) -->
         <MauiAsset Include="Resources\Raw\**" LogicalName="%(RecursiveDir)%(Filename)%(Extension)" />

--- a/src/Templates/src/templates/maui-lib/MauiLib1.csproj
+++ b/src/Templates/src/templates/maui-lib/MauiLib1.csproj
@@ -10,7 +10,9 @@
 		<SingleProject>true</SingleProject>
 		<ImplicitUsings>enable</ImplicitUsings>
 
-		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">11.0</SupportedOSPlatformVersion>
+    <DefaultItemExcludes>$(DefaultItemExcludes);**\.DS_Store</DefaultItemExcludes>
+
+    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">11.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">13.1</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>

--- a/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
+++ b/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
@@ -19,6 +19,8 @@
 		<SingleProject>true</SingleProject>
 		<ImplicitUsings>enable</ImplicitUsings>
 
+    <DefaultItemExcludes>$(DefaultItemExcludes);**\.DS_Store</DefaultItemExcludes>
+
 		<!-- Display name -->
 		<ApplicationTitle>MauiApp.1</ApplicationTitle>
 
@@ -45,11 +47,11 @@
 		<MauiSplashScreen Include="Resources\Splash\splash.svg" Color="#512BD4" BaseSize="128,128" />
 
 		<!-- Images -->
-		<MauiImage Include="Resources\Images\*" />
+		<MauiImage Include="Resources\Images\*" Exclude="$(DefaultItemExcludes)" />
 		<MauiImage Update="Resources\Images\dotnet_bot.svg" BaseSize="168,208" />
 
 		<!-- Custom Fonts -->
-		<MauiFont Include="Resources\Fonts\*" />
+		<MauiFont Include="Resources\Fonts\*" Exclude="$(DefaultItemExcludes)" />
 
 		<!-- Raw Assets (also remove the "Resources\Raw" prefix) -->
 		<MauiAsset Include="Resources\Raw\**" LogicalName="%(RecursiveDir)%(Filename)%(Extension)" />


### PR DESCRIPTION
### Description of Change

Context:

.DS_Store file is internal MacOSX file created by Finder and it is irrelevant for .NET builds, but can interfere with .NET builds.

Examples of build failures (dotnet/maui issues):

- https://github.com/dotnet/maui/issues/13452
  Resizetizer is not working if you get a .DS_Store file inside you Fonts files folder #13452
- https://github.com/dotnet/maui/issues/14279
  Microsoft.Maui.Resizetizer.targets breaks build on macOS #14279

Cause is globbing patterns which include `.DS_Store` on MacOSX:

https://github.com/dotnet/maui/blob/main/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj#L48 
https://github.com/dotnet/maui/blob/main/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj#L52

The workarounds in MAUI repo was:

1. to add `Exclude = "Resources\Images\.DS_Store" to MauiImage`
   ```
   <MauiImage Include="Resources\Images\*" Exclude = "Resources\Images\.DS_Store" />
   ```
2. to add property:
   ```
   <DefaultItemExcludes>$(DefaultItemExcludes);**\.DS_Store</DefaultItemExcludes>
   ```
   and use it for ItemGroups:
   ```
   <MauiImage Include="Resources\Images\*" Exclude="$(DefaultItemExcludes)" />
   ```

### Issues Fixed

- Fixes #13452
  Resizetizer is not working if you get a .DS_Store file inside you Fonts files folder #13452
- Fixes #14279
  Microsoft.Maui.Resizetizer.targets breaks build on macOS #14279

Also fix was proposed in dotnet/sdk

https://github.com/dotnet/sdk/pull/34666