### PR TITLE
Adding MauiContextAccessor

### DIFF
--- a/src/Core/src/Hosting/MauiContextAccessor.cs
+++ b/src/Core/src/Hosting/MauiContextAccessor.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.ComponentModel;
+
+namespace Microsoft.Maui.Hosting
+{
+	public static class MauiContextAccessor
+	{
+		public static IServiceProvider Services { get; [EditorBrowsable(EditorBrowsableState.Never)]set; } = default!;
+
+		public static IApplication Application { get; [EditorBrowsable(EditorBrowsableState.Never)]set; } = default!;
+	}
+}

--- a/src/Core/src/Platform/Android/MauiApplication.cs
+++ b/src/Core/src/Platform/Android/MauiApplication.cs
@@ -75,9 +75,17 @@ namespace Microsoft.Maui
 
 		public static MauiApplication Current { get; private set; } = null!;
 
-		public IServiceProvider Services { get; protected set; } = null!;
+		public IServiceProvider Services
+		{
+			get => MauiContextAccessor.Services;
+			protected set => MauiContextAccessor.Services = value;
+		}
 
-		public IApplication Application { get; protected set; } = null!;
+		public IApplication Application
+		{
+			get => MauiContextAccessor.Application;
+			protected set => MauiContextAccessor.Application = value;
+		}
 
 		public class ActivityLifecycleCallbacks : Java.Lang.Object, IActivityLifecycleCallbacks
 		{

--- a/src/Core/src/Platform/Tizen/MauiApplication.cs
+++ b/src/Core/src/Platform/Tizen/MauiApplication.cs
@@ -126,8 +126,16 @@ namespace Microsoft.Maui
 
 		public static new MauiApplication Current { get; private set; } = null!;
 
-		public IServiceProvider Services { get; protected set; } = null!;
+		public IServiceProvider Services
+		{
+			get => MauiContextAccessor.Services;
+			protected set => MauiContextAccessor.Services = value;
+		}
 
-		public IApplication Application { get; protected set; } = null!;
+		public IApplication Application
+		{
+			get => MauiContextAccessor.Application;
+			protected set => MauiContextAccessor.Application = value;
+		}
 	}
 }

--- a/src/Core/src/Platform/Windows/MauiWinUIApplication.cs
+++ b/src/Core/src/Platform/Windows/MauiWinUIApplication.cs
@@ -52,8 +52,16 @@ namespace Microsoft.Maui
 
 		public UI.Xaml.LaunchActivatedEventArgs LaunchActivatedEventArgs { get; protected set; } = null!;
 
-		public IServiceProvider Services { get; protected set; } = null!;
+		public IServiceProvider Services
+		{
+			get => MauiContextAccessor.Services;
+			protected set => MauiContextAccessor.Services = value;
+		}
 
-		public IApplication Application { get; protected set; } = null!;
+		public IApplication Application
+		{
+			get => MauiContextAccessor.Application;
+			protected set => MauiContextAccessor.Application = value;
+		}
 	}
 }

--- a/src/Core/src/Platform/iOS/MauiUIApplicationDelegate.cs
+++ b/src/Core/src/Platform/iOS/MauiUIApplicationDelegate.cs
@@ -163,8 +163,16 @@ namespace Microsoft.Maui
 		[Export("window")]
 		public virtual UIWindow? Window { get; set; }
 
-		public IServiceProvider Services { get; protected set; } = null!;
+		public IServiceProvider Services
+		{
+			get => MauiContextAccessor.Services;
+			protected set => MauiContextAccessor.Services = value;
+		}
 
-		public IApplication Application { get; protected set; } = null!;
+		public IApplication Application
+		{
+			get => MauiContextAccessor.Application;
+			protected set => MauiContextAccessor.Application = value;
+		}
 	}
 }


### PR DESCRIPTION
### Description of Change

Adds the MauiContextAccessor. This provides the base reference to the IServiceProvider and IApplication which currently exists in the Maui native app classes. This provides a uniform cross platform way of accessing these values which is also compatible with Embedding scenarios where the Maui native app class will not exist and therefore cannot be referenced.

### Issues Fixed

Fixes #16759 

