### PR TITLE
[build] avoid NETSDK1195 error

### DIFF
--- a/src/Compatibility/Core/src/Compatibility.csproj
+++ b/src/Compatibility/Core/src/Compatibility.csproj
@@ -9,7 +9,7 @@
     <WindowsRoot>Windows\</WindowsRoot>
     <TizenRoot>Tizen\</TizenRoot>
     <IsPackable>true</IsPackable>
-    <IsTrimmable>true</IsTrimmable>
+    <IsTrimmable Condition="!$(TargetFramework.StartsWith('netstandard'))">true</IsTrimmable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <DefineConstants>$(DefineConstants);COMPATIBILITY</DefineConstants>

--- a/src/Essentials/src/Essentials.csproj
+++ b/src/Essentials/src/Essentials.csproj
@@ -6,7 +6,7 @@
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <WarningsNotAsErrors>BI1234</WarningsNotAsErrors>
     <IsPackable>true</IsPackable>
-    <IsTrimmable>true</IsTrimmable>
+    <IsTrimmable Condition="!$(TargetFramework.StartsWith('netstandard'))">true</IsTrimmable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);NU5104;RS0041;RS0026</NoWarn>
     <WarningsAsErrors>$(WarningsAsErrors);CS1591</WarningsAsErrors>


### PR DESCRIPTION
Context: https://github.com/dotnet/sdk/issues/30948

Building with VS 2022 17.8 Preview 1, I get the error:

    C:\Program Files\dotnet\sdk\8.0.100-preview.7.23376.3\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.FrameworkReferenceResolution.targets(90,5):
    error NETSDK1195: Trimming, or code compatibility analysis for trimming, single-file deployment, or ahead-of-time compilation is not supported for the target framework. For more information, see https://aka.ms/netsdk1195

It appears there is a new build warning if you set `IsTrimmable=true` in a `netstandard` project.

For now, this doesn't really matter to MAUI as these projects only *really* need to be trimmable for mobile. `net8.0-android`, `net8.0-ios`, etc. projects can remain trimmable if we add a condition:

    <IsTrimmable Condition="!$(TargetFramework.StartsWith('netstandard'))">true</IsTrimmable>