### PR TITLE
Remove reference to concrete native host app

### DIFF
--- a/src/Compatibility/ControlGallery/src/Android/Issue10182Activity.cs
+++ b/src/Compatibility/ControlGallery/src/Android/Issue10182Activity.cs
@@ -30,7 +30,7 @@
 //			base.OnCreate(savedInstanceState);
 
 //#pragma warning disable CS0612 // Type or member is obsolete
-//			Forms.Init(new MauiContext(MauiApplication.Current.Services, this));
+//			Forms.Init(new MauiContext(IPlatformApplication.Current.Services, this));
 //#pragma warning restore CS0612 // Type or member is obsolete
 //			LoadApplication(new Issue10182Application());
 

--- a/src/Compatibility/Core/src/AppHostBuilderExtensions.Android.cs
+++ b/src/Compatibility/Core/src/AppHostBuilderExtensions.Android.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Hosting
 					// any UI has appeared.
 					// This creates a dummy MauiContext that wraps the Application.
 
-					var services = MauiApplication.Current.Services;
+					var services = IPlatformApplication.Current.Services;
 					var mauiContext = new MauiContext(services, app);
 					var state = new ActivationState(mauiContext);
 #pragma warning disable CS0612 // Type or member is obsolete

--- a/src/Compatibility/Core/src/AppHostBuilderExtensions.Tizen.cs
+++ b/src/Compatibility/Core/src/AppHostBuilderExtensions.Tizen.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Hosting
 				// Forms.Init(). This happens before any UI has appeared.
 				// This creates a dummy MauiContext.
 
-				var services = MauiApplication.Current.Services;
+				var services = IPlatformApplication.Current.Services;
 				MauiContext mauiContext = new MauiContext(services);
 				ActivationState state = new ActivationState(mauiContext);
 

--- a/src/Compatibility/Core/src/AppHostBuilderExtensions.Windows.cs
+++ b/src/Compatibility/Core/src/AppHostBuilderExtensions.Windows.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Hosting
 				// Inside OnLaunched we grab the MauiContext that's on the window so we can have the correct
 				// MauiContext inside Forms
 
-				var services = IPlatformApplication.Current?.Services ?? throw new Exception("IPlatformApplication.Current must be initialized.");
+				var services = IPlatformApplication.Current?.Services ?? throw new InvalidOperationException("Unable to find Application Services");
 				var mauiContext = new MauiContext(services);
 				var state = new ActivationState(mauiContext, args);
 #pragma warning disable CS0612 // Type or member is obsolete

--- a/src/Compatibility/Core/src/AppHostBuilderExtensions.Windows.cs
+++ b/src/Compatibility/Core/src/AppHostBuilderExtensions.Windows.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Hosting
 				// Inside OnLaunched we grab the MauiContext that's on the window so we can have the correct
 				// MauiContext inside Forms
 
-				var services = MauiWinUIApplication.Current.Services;
+				var services = IPlatformApplication.Current?.Services ?? throw new Exception("IPlatformApplication.Current must be initialized.");
 				var mauiContext = new MauiContext(services);
 				var state = new ActivationState(mauiContext, args);
 #pragma warning disable CS0612 // Type or member is obsolete

--- a/src/Compatibility/Core/src/AppHostBuilderExtensions.cs
+++ b/src/Compatibility/Core/src/AppHostBuilderExtensions.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Hosting
 #if WINDOWS
 				var dispatcher =
 					services.GetService<IDispatcher>() ??
-					MauiWinUIApplication.Current.Services.GetRequiredService<IDispatcher>();
+					IPlatformApplication.Current.Services.GetRequiredService<IDispatcher>();
 
 					dispatcher.DispatchIfRequired(() =>
 					{

--- a/src/Compatibility/Core/src/AppHostBuilderExtensions.cs
+++ b/src/Compatibility/Core/src/AppHostBuilderExtensions.cs
@@ -125,7 +125,8 @@ namespace Microsoft.Maui.Controls.Compatibility.Hosting
 #if WINDOWS
 				var dispatcher =
 					services.GetService<IDispatcher>() ??
-					IPlatformApplication.Current.Services.GetRequiredService<IDispatcher>();
+					IPlatformApplication.Current?.Services.GetRequiredService<IDispatcher>() ??
+					throw new InvalidOperationException("Unable to find Application Services");
 
 					dispatcher.DispatchIfRequired(() =>
 					{

--- a/src/Compatibility/Core/src/AppHostBuilderExtensions.iOS.cs
+++ b/src/Compatibility/Core/src/AppHostBuilderExtensions.iOS.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Hosting
 					// Forms.Init(). This happens before any UI has appeared.
 					// This creates a dummy MauiContext.
 
-					var services = MauiUIApplicationDelegate.Current.Services;
+					var services = IPlatformApplication.Current.Services;
 					var mauiContext = new MauiContext(services);
 					var state = new ActivationState(mauiContext);
 #pragma warning disable CS0612 // Type or member is obsolete

--- a/src/Controls/src/Xaml/Hosting/AppHostBuilderExtensions.cs
+++ b/src/Controls/src/Xaml/Hosting/AppHostBuilderExtensions.cs
@@ -198,7 +198,7 @@ namespace Microsoft.Maui.Controls.Hosting
 #if WINDOWS
 				var dispatcher =
 					services.GetService<IDispatcher>() ??
-					MauiWinUIApplication.Current.Services.GetRequiredService<IDispatcher>();
+					IPlatformApplication.Current?.Services.GetRequiredService<IDispatcher>();
 
 				dispatcher
 					.DispatchIfRequired(() =>

--- a/src/Core/src/Hosting/EssentialsMauiAppBuilderExtensions.cs
+++ b/src/Core/src/Hosting/EssentialsMauiAppBuilderExtensions.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Maui.Hosting
 			builder.ConfigureLifecycleEvents(life =>
 			{
 #if __ANDROID__
+				// TODO: Refactor this to not require MauiApplication.Current
 				ApplicationModel.Platform.Init(MauiApplication.Current);
 
 				life.AddAndroid(android => android

--- a/src/Core/src/Hosting/EssentialsMauiAppBuilderExtensions.cs
+++ b/src/Core/src/Hosting/EssentialsMauiAppBuilderExtensions.cs
@@ -27,8 +27,7 @@ namespace Microsoft.Maui.Hosting
 			builder.ConfigureLifecycleEvents(life =>
 			{
 #if __ANDROID__
-				// TODO: Refactor this to not require MauiApplication.Current
-				ApplicationModel.Platform.Init(MauiApplication.Current);
+				ApplicationModel.Platform.Init((Android.App.Application)Android.App.Application.Context);
 
 				life.AddAndroid(android => android
 					.OnCreate((activity, savedInstanceState) =>

--- a/src/Core/src/Platform/Android/MauiAppCompatActivity.Lifecycle.cs
+++ b/src/Core/src/Platform/Android/MauiAppCompatActivity.Lifecycle.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Maui
 			base.OnActivityResult(requestCode, resultCode, data);
 
 			ActivityResultCallbackRegistry.InvokeCallback(requestCode, resultCode, data);
-			MauiApplication.Current?.Services?.InvokeLifecycleEvents<AndroidLifecycle.OnActivityResult>(del => del(this, requestCode, resultCode, data));
+			IPlatformApplication.Current?.Services?.InvokeLifecycleEvents<AndroidLifecycle.OnActivityResult>(del => del(this, requestCode, resultCode, data));
 		}
 
 		// TODO: Investigate whether the new AndroidX way is actually useful:
@@ -27,7 +27,7 @@ namespace Microsoft.Maui
 #pragma warning restore 809
 		{
 			var preventBackPropagation = false;
-			MauiApplication.Current?.Services?.InvokeLifecycleEvents<AndroidLifecycle.OnBackPressed>(del =>
+			IPlatformApplication.Current?.Services?.InvokeLifecycleEvents<AndroidLifecycle.OnBackPressed>(del =>
 			{
 				preventBackPropagation = del(this) || preventBackPropagation;
 			});
@@ -44,41 +44,41 @@ namespace Microsoft.Maui
 		{
 			base.OnConfigurationChanged(newConfig);
 
-			MauiApplication.Current?.Services?.InvokeLifecycleEvents<AndroidLifecycle.OnConfigurationChanged>(del => del(this, newConfig));
+			IPlatformApplication.Current?.Services?.InvokeLifecycleEvents<AndroidLifecycle.OnConfigurationChanged>(del => del(this, newConfig));
 		}
 
 		protected override void OnNewIntent(Intent? intent)
 		{
 			base.OnNewIntent(intent);
 
-			MauiApplication.Current?.Services?.InvokeLifecycleEvents<AndroidLifecycle.OnNewIntent>(del => del(this, intent));
+			IPlatformApplication.Current?.Services?.InvokeLifecycleEvents<AndroidLifecycle.OnNewIntent>(del => del(this, intent));
 		}
 
 		protected override void OnPostCreate(Bundle? savedInstanceState)
 		{
 			base.OnPostCreate(savedInstanceState);
 
-			MauiApplication.Current?.Services?.InvokeLifecycleEvents<AndroidLifecycle.OnPostCreate>(del => del(this, savedInstanceState));
+			IPlatformApplication.Current?.Services?.InvokeLifecycleEvents<AndroidLifecycle.OnPostCreate>(del => del(this, savedInstanceState));
 		}
 
 		protected override void OnPostResume()
 		{
 			base.OnPostResume();
 
-			MauiApplication.Current?.Services?.InvokeLifecycleEvents<AndroidLifecycle.OnPostResume>(del => del(this));
+			IPlatformApplication.Current?.Services?.InvokeLifecycleEvents<AndroidLifecycle.OnPostResume>(del => del(this));
 		}
 
 		protected override void OnRestart()
 		{
 			base.OnRestart();
 
-			MauiApplication.Current?.Services?.InvokeLifecycleEvents<AndroidLifecycle.OnRestart>(del => del(this));
+			IPlatformApplication.Current?.Services?.InvokeLifecycleEvents<AndroidLifecycle.OnRestart>(del => del(this));
 		}
 
 		[System.Runtime.Versioning.SupportedOSPlatform("android23.0")]
 		public override void OnRequestPermissionsResult(int requestCode, string[] permissions, Permission[] grantResults)
 		{
-			MauiApplication.Current?.Services?.InvokeLifecycleEvents<AndroidLifecycle.OnRequestPermissionsResult>(del => del(this, requestCode, permissions, grantResults));
+			IPlatformApplication.Current?.Services?.InvokeLifecycleEvents<AndroidLifecycle.OnRequestPermissionsResult>(del => del(this, requestCode, permissions, grantResults));
 
 			base.OnRequestPermissionsResult(requestCode, permissions, grantResults);
 		}
@@ -87,7 +87,7 @@ namespace Microsoft.Maui
 		{
 			base.OnRestoreInstanceState(savedInstanceState);
 
-			MauiApplication.Current?.Services?.InvokeLifecycleEvents<AndroidLifecycle.OnRestoreInstanceState>(del => del(this, savedInstanceState));
+			IPlatformApplication.Current?.Services?.InvokeLifecycleEvents<AndroidLifecycle.OnRestoreInstanceState>(del => del(this, savedInstanceState));
 		}
 	}
 }

--- a/src/Core/src/Platform/Android/MauiAppCompatActivity.cs
+++ b/src/Core/src/Platform/Android/MauiAppCompatActivity.cs
@@ -30,7 +30,10 @@ namespace Microsoft.Maui
 
 			base.OnCreate(savedInstanceState);
 
-			this.CreatePlatformWindow(MauiApplication.Current.Application, savedInstanceState);
+			if (IPlatformApplication.Current?.Application is not null)
+			{
+				this.CreatePlatformWindow(IPlatformApplication.Current.Application, savedInstanceState);
+			}
 		}
 
 		public override bool DispatchTouchEvent(MotionEvent? e)

--- a/src/Core/src/Platform/Android/MauiApplication.cs
+++ b/src/Core/src/Platform/Android/MauiApplication.cs
@@ -39,68 +39,86 @@ namespace Microsoft.Maui
 
 			var applicationContext = rootContext.MakeApplicationScope(this);
 
-			Services = applicationContext.Services;
+			_services = applicationContext.Services;
 
-			Current.Services?.InvokeLifecycleEvents<AndroidLifecycle.OnApplicationCreating>(del => del(this));
+			_services.InvokeLifecycleEvents<AndroidLifecycle.OnApplicationCreating>(del => del(this));
 
-			Application = Services.GetRequiredService<IApplication>();
+			_application = _services.GetRequiredService<IApplication>();
 
-			this.SetApplicationHandler(Application, applicationContext);
+			this.SetApplicationHandler(_application, applicationContext);
 
-			Current.Services?.InvokeLifecycleEvents<AndroidLifecycle.OnApplicationCreate>(del => del(this));
+			_services?.InvokeLifecycleEvents<AndroidLifecycle.OnApplicationCreate>(del => del(this));
 
 			base.OnCreate();
 		}
 
 		public override void OnLowMemory()
 		{
-			Current.Services?.InvokeLifecycleEvents<AndroidLifecycle.OnApplicationLowMemory>(del => del(this));
+			_services?.InvokeLifecycleEvents<AndroidLifecycle.OnApplicationLowMemory>(del => del(this));
 
 			base.OnLowMemory();
 		}
 
 		public override void OnTrimMemory(TrimMemory level)
 		{
-			Current.Services?.InvokeLifecycleEvents<AndroidLifecycle.OnApplicationTrimMemory>(del => del(this, level));
+			_services?.InvokeLifecycleEvents<AndroidLifecycle.OnApplicationTrimMemory>(del => del(this, level));
 
 			base.OnTrimMemory(level);
 		}
 
 		public override void OnConfigurationChanged(Configuration newConfig)
 		{
-			Current.Services?.InvokeLifecycleEvents<AndroidLifecycle.OnApplicationConfigurationChanged>(del => del(this, newConfig));
+			_services?.InvokeLifecycleEvents<AndroidLifecycle.OnApplicationConfigurationChanged>(del => del(this, newConfig));
 
 			base.OnConfigurationChanged(newConfig);
 		}
 
 		public static MauiApplication Current { get; private set; } = null!;
 
-		public IServiceProvider Services { get; protected set; } = null!;
+		IServiceProvider _services = null!;
 
-		public IApplication Application { get; protected set; } = null!;
+		IApplication _application = null!;
+
+		IServiceProvider IPlatformApplication.Services => _services;
+
+		IApplication IPlatformApplication.Application => _application;
+
+		[Obsolete("Use the IPlatformApplication.Current.Application instead.")]
+		public IServiceProvider Services
+		{
+			get => _services;
+			protected set => _services = value;
+		}
+
+		[Obsolete("Use the IPlatformApplication.Current.Application instead.")]
+		public IApplication Application
+		{
+			get => _application;
+			protected set => _application = value;
+		}
 
 		public class ActivityLifecycleCallbacks : Java.Lang.Object, IActivityLifecycleCallbacks
 		{
 			public void OnActivityCreated(Activity activity, Bundle? savedInstanceState) =>
-				Current.Services?.InvokeLifecycleEvents<AndroidLifecycle.OnCreate>(del => del(activity, savedInstanceState));
+				IPlatformApplication.Current?.Services?.InvokeLifecycleEvents<AndroidLifecycle.OnCreate>(del => del(activity, savedInstanceState));
 
 			public void OnActivityStarted(Activity activity) =>
-				Current.Services?.InvokeLifecycleEvents<AndroidLifecycle.OnStart>(del => del(activity));
+				IPlatformApplication.Current?.Services?.InvokeLifecycleEvents<AndroidLifecycle.OnStart>(del => del(activity));
 
 			public void OnActivityResumed(Activity activity) =>
-				Current.Services?.InvokeLifecycleEvents<AndroidLifecycle.OnResume>(del => del(activity));
+				IPlatformApplication.Current?.Services?.InvokeLifecycleEvents<AndroidLifecycle.OnResume>(del => del(activity));
 
 			public void OnActivityPaused(Activity activity) =>
-				Current.Services?.InvokeLifecycleEvents<AndroidLifecycle.OnPause>(del => del(activity));
+				IPlatformApplication.Current?.Services?.InvokeLifecycleEvents<AndroidLifecycle.OnPause>(del => del(activity));
 
 			public void OnActivityStopped(Activity activity) =>
-				Current.Services?.InvokeLifecycleEvents<AndroidLifecycle.OnStop>(del => del(activity));
+				IPlatformApplication.Current?.Services?.InvokeLifecycleEvents<AndroidLifecycle.OnStop>(del => del(activity));
 
 			public void OnActivitySaveInstanceState(Activity activity, Bundle outState) =>
-				Current.Services?.InvokeLifecycleEvents<AndroidLifecycle.OnSaveInstanceState>(del => del(activity, outState));
+				IPlatformApplication.Current?.Services?.InvokeLifecycleEvents<AndroidLifecycle.OnSaveInstanceState>(del => del(activity, outState));
 
 			public void OnActivityDestroyed(Activity activity) =>
-				Current.Services?.InvokeLifecycleEvents<AndroidLifecycle.OnDestroy>(del => del(activity));
+				IPlatformApplication.Current?.Services?.InvokeLifecycleEvents<AndroidLifecycle.OnDestroy>(del => del(activity));
 		}
 	}
 }

--- a/src/Core/src/Platform/Android/MauiApplication.cs
+++ b/src/Core/src/Platform/Android/MauiApplication.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Maui
 
 		IApplication IPlatformApplication.Application => _application!;
 
-		[Obsolete("Use the IPlatformApplication.Current.Application instead.")]
+		[Obsolete("Use the IPlatformApplication.Current.Services instead.")]
 		public IServiceProvider Services
 		{
 			get => _services!;

--- a/src/Core/src/Platform/Android/MauiApplication.cs
+++ b/src/Core/src/Platform/Android/MauiApplication.cs
@@ -75,25 +75,26 @@ namespace Microsoft.Maui
 
 		public static MauiApplication Current { get; private set; } = null!;
 
-		IServiceProvider _services = null!;
+		IServiceProvider? _services;
 
-		IApplication _application = null!;
+		IApplication? _application;
 
-		IServiceProvider IPlatformApplication.Services => _services;
+		// TODO: we should investigate throwing an exception or changing the public API
+		IServiceProvider IPlatformApplication.Services => _services!;
 
-		IApplication IPlatformApplication.Application => _application;
+		IApplication IPlatformApplication.Application => _application!;
 
 		[Obsolete("Use the IPlatformApplication.Current.Application instead.")]
 		public IServiceProvider Services
 		{
-			get => _services;
+			get => _services!;
 			protected set => _services = value;
 		}
 
 		[Obsolete("Use the IPlatformApplication.Current.Application instead.")]
 		public IApplication Application
 		{
-			get => _application;
+			get => _application!;
 			protected set => _application = value;
 		}
 

--- a/src/Core/src/Platform/Android/MauiContextExtensions.cs
+++ b/src/Core/src/Platform/Android/MauiContextExtensions.cs
@@ -98,8 +98,8 @@ namespace Microsoft.Maui.Platform
 
 		internal static IServiceProvider GetApplicationServices(this IMauiContext mauiContext)
 		{
-			if (mauiContext.Context?.ApplicationContext is MauiApplication ma)
-				return ma.Services;
+			if (IPlatformApplication.Current?.Services is not null)
+				return IPlatformApplication.Current.Services;
 
 			throw new InvalidOperationException("Unable to find Application Services");
 		}

--- a/src/Core/src/Platform/Tizen/CoreAppExtensions.cs
+++ b/src/Core/src/Platform/Tizen/CoreAppExtensions.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Maui.Platform
 	{
 		public static IWindow GetWindow(this CoreApplication application)
 		{
-			foreach (var window in IPlatformApplication.Current.Application.Windows)
+			foreach (var window in IPlatformApplication.Current?.Application?.Windows ?? Array.Empty<IWindow>())
 			{
 				if (window?.Handler?.PlatformView is Window win && win == GetDefaultWindow())
 					return window;
@@ -23,7 +23,7 @@ namespace Microsoft.Maui.Platform
 			if (platformWindow == null)
 				return null;
 
-			foreach (var window in IPlatformApplication.Current.Application.Windows)
+			foreach (var window in IPlatformApplication.Current?.Application?.Windows ?? Array.Empty<IWindow>())
 			{
 				if (window?.Handler?.PlatformView is Window win && win == platformWindow)
 					return window;

--- a/src/Core/src/Platform/Tizen/CoreAppExtensions.cs
+++ b/src/Core/src/Platform/Tizen/CoreAppExtensions.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Maui.Platform
 	{
 		public static IWindow GetWindow(this CoreApplication application)
 		{
-			foreach (var window in MauiApplication.Current.Application.Windows)
+			foreach (var window in IPlatformApplication.Current.Application.Windows)
 			{
 				if (window?.Handler?.PlatformView is Window win && win == GetDefaultWindow())
 					return window;
@@ -23,7 +23,7 @@ namespace Microsoft.Maui.Platform
 			if (platformWindow == null)
 				return null;
 
-			foreach (var window in MauiApplication.Current.Application.Windows)
+			foreach (var window in IPlatformApplication.Current.Application.Windows)
 			{
 				if (window?.Handler?.PlatformView is Window win && win == platformWindow)
 					return window;

--- a/src/Core/src/Platform/Tizen/MauiApplication.cs
+++ b/src/Core/src/Platform/Tizen/MauiApplication.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Maui
 
 		IApplication? _application;
 
-		IServiceProvider _services;
+		IServiceProvider? _services;
 
 		protected MauiApplication()
 		{
@@ -60,13 +60,16 @@ namespace Microsoft.Maui
 		{
 			base.OnCreate();
 
-			_application = _services!.GetRequiredService<IApplication>();
+			if (_services == null)
+				throw new InvalidOperationException($"The {nameof(IServiceProvider)} instance was not found.");
+
+			_application = _services.GetRequiredService<IApplication>();
 
 			this.SetApplicationHandler(_application, _applicationContext);
 
 			this.CreatePlatformWindow(_application);
 
-			_services?.InvokeLifecycleEvents<TizenLifecycle.OnCreate>(del => del(this));
+			_services.InvokeLifecycleEvents<TizenLifecycle.OnCreate>(del => del(this));
 		}
 
 		public void SetBackButtonPressedHandler(Func<bool> handler)

--- a/src/Core/src/Platform/Tizen/MauiApplication.cs
+++ b/src/Core/src/Platform/Tizen/MauiApplication.cs
@@ -62,9 +62,9 @@ namespace Microsoft.Maui
 
 			_application = _services.GetRequiredService<IApplication>();
 
-			this.SetApplicationHandler(Application, _applicationContext);
+			this.SetApplicationHandler(_application, _applicationContext);
 
-			this.CreatePlatformWindow(Application);
+			this.CreatePlatformWindow(_application);
 
 			_services?.InvokeLifecycleEvents<TizenLifecycle.OnCreate>(del => del(this));
 		}

--- a/src/Core/src/Platform/Tizen/MauiApplication.cs
+++ b/src/Core/src/Platform/Tizen/MauiApplication.cs
@@ -141,7 +141,7 @@ namespace Microsoft.Maui
 
 		IApplication IPlatformApplication.Application => _application!;
 
-		[Obsolete("Use the IPlatformApplication.Current.Application instead.")]
+		[Obsolete("Use the IPlatformApplication.Current.Services instead.")]
 		public IServiceProvider Services
 		{
 			get => _services!;

--- a/src/Core/src/Platform/Tizen/MauiApplication.cs
+++ b/src/Core/src/Platform/Tizen/MauiApplication.cs
@@ -18,6 +18,10 @@ namespace Microsoft.Maui
 
 		IMauiContext _applicationContext = null!;
 
+		IApplication _application = default!;
+
+		IServiceProvider _services = default!;
+
 		protected MauiApplication()
 		{
 			Current = this;
@@ -44,25 +48,25 @@ namespace Microsoft.Maui
 
 			_applicationContext = rootContext.MakeApplicationScope(this);
 
-			Services = _applicationContext.Services;
+			_services = _applicationContext.Services;
 
-			if (Services == null)
+			if (_services == null)
 				throw new InvalidOperationException($"The {nameof(IServiceProvider)} instance was not found.");
 
-			Current.Services.InvokeLifecycleEvents<TizenLifecycle.OnPreCreate>(del => del(this));
+			_services.InvokeLifecycleEvents<TizenLifecycle.OnPreCreate>(del => del(this));
 		}
 
 		protected override void OnCreate()
 		{
 			base.OnCreate();
 
-			Application = Services.GetRequiredService<IApplication>();
+			_application = _services.GetRequiredService<IApplication>();
 
 			this.SetApplicationHandler(Application, _applicationContext);
 
 			this.CreatePlatformWindow(Application);
 
-			Current.Services?.InvokeLifecycleEvents<TizenLifecycle.OnCreate>(del => del(this));
+			_services?.InvokeLifecycleEvents<TizenLifecycle.OnCreate>(del => del(this));
 		}
 
 		public void SetBackButtonPressedHandler(Func<bool> handler)
@@ -73,61 +77,75 @@ namespace Microsoft.Maui
 		protected override void OnAppControlReceived(AppControlReceivedEventArgs e)
 		{
 			base.OnAppControlReceived(e);
-			Current.Services?.InvokeLifecycleEvents<TizenLifecycle.OnAppControlReceived>(del => del(this, e));
+			_services?.InvokeLifecycleEvents<TizenLifecycle.OnAppControlReceived>(del => del(this, e));
 		}
 
 		protected override void OnDeviceOrientationChanged(DeviceOrientationEventArgs e)
 		{
 			base.OnDeviceOrientationChanged(e);
-			Current.Services?.InvokeLifecycleEvents<TizenLifecycle.OnDeviceOrientationChanged>(del => del(this, e));
+			_services?.InvokeLifecycleEvents<TizenLifecycle.OnDeviceOrientationChanged>(del => del(this, e));
 		}
 
 		protected override void OnLocaleChanged(LocaleChangedEventArgs e)
 		{
 			base.OnLocaleChanged(e);
-			Current.Services?.InvokeLifecycleEvents<TizenLifecycle.OnLocaleChanged>(del => del(this, e));
+			_services?.InvokeLifecycleEvents<TizenLifecycle.OnLocaleChanged>(del => del(this, e));
 		}
 
 		protected override void OnLowBattery(LowBatteryEventArgs e)
 		{
 			base.OnLowBattery(e);
-			Current.Services?.InvokeLifecycleEvents<TizenLifecycle.OnLowBattery>(del => del(this, e));
+			_services?.InvokeLifecycleEvents<TizenLifecycle.OnLowBattery>(del => del(this, e));
 		}
 
 		protected override void OnLowMemory(LowMemoryEventArgs e)
 		{
 			base.OnLowMemory(e);
-			Current.Services?.InvokeLifecycleEvents<TizenLifecycle.OnLowMemory>(del => del(this, e));
+			_services?.InvokeLifecycleEvents<TizenLifecycle.OnLowMemory>(del => del(this, e));
 		}
 
 		protected override void OnPause()
 		{
 			base.OnPause();
-			Current.Services?.InvokeLifecycleEvents<TizenLifecycle.OnPause>(del => del(this));
+			_services?.InvokeLifecycleEvents<TizenLifecycle.OnPause>(del => del(this));
 		}
 
 		protected override void OnRegionFormatChanged(RegionFormatChangedEventArgs e)
 		{
 			base.OnRegionFormatChanged(e);
-			Current.Services?.InvokeLifecycleEvents<TizenLifecycle.OnRegionFormatChanged>(del => del(this, e));
+			_services?.InvokeLifecycleEvents<TizenLifecycle.OnRegionFormatChanged>(del => del(this, e));
 		}
 
 		protected override void OnResume()
 		{
 			base.OnResume();
-			Current.Services?.InvokeLifecycleEvents<TizenLifecycle.OnResume>(del => del(this));
+			_services?.InvokeLifecycleEvents<TizenLifecycle.OnResume>(del => del(this));
 		}
 
 		protected override void OnTerminate()
 		{
 			base.OnTerminate();
-			Current.Services?.InvokeLifecycleEvents<TizenLifecycle.OnTerminate>(del => del(this));
+			_services?.InvokeLifecycleEvents<TizenLifecycle.OnTerminate>(del => del(this));
 		}
 
 		public static new MauiApplication Current { get; private set; } = null!;
 
-		public IServiceProvider Services { get; protected set; } = null!;
+		IServiceProvider IPlatformApplication.Services => _services;
 
-		public IApplication Application { get; protected set; } = null!;
+		IApplication IPlatformApplication.Application => _application;
+
+		[Obsolete("Use the IPlatformApplication.Current.Application instead.")]
+		public IServiceProvider Services
+		{
+			get => _services;
+			protected set => _services = value;
+		}
+
+		[Obsolete("Use the IPlatformApplication.Current.Application instead.")]
+		public IApplication Application
+		{
+			get => _application;
+			protected set => _application = value;
+		}
 	}
 }

--- a/src/Core/src/Platform/Tizen/MauiApplication.cs
+++ b/src/Core/src/Platform/Tizen/MauiApplication.cs
@@ -63,6 +63,9 @@ namespace Microsoft.Maui
 			if (_services == null)
 				throw new InvalidOperationException($"The {nameof(IServiceProvider)} instance was not found.");
 
+			if (_applicationContext == null)
+				throw new InvalidOperationException($"The {nameof(IMauiContext)} instance was not found.");
+
 			_application = _services.GetRequiredService<IApplication>();
 
 			this.SetApplicationHandler(_application, _applicationContext);

--- a/src/Core/src/Platform/Tizen/MauiApplication.cs
+++ b/src/Core/src/Platform/Tizen/MauiApplication.cs
@@ -16,11 +16,11 @@ namespace Microsoft.Maui
 
 		internal Func<bool>? _handleBackButtonPressed;
 
-		IMauiContext _applicationContext = null!;
+		IMauiContext? _applicationContext = null!;
 
-		IApplication _application = default!;
+		IApplication? _application;
 
-		IServiceProvider _services = default!;
+		IServiceProvider _services;
 
 		protected MauiApplication()
 		{
@@ -60,7 +60,7 @@ namespace Microsoft.Maui
 		{
 			base.OnCreate();
 
-			_application = _services.GetRequiredService<IApplication>();
+			_application = _services!.GetRequiredService<IApplication>();
 
 			this.SetApplicationHandler(_application, _applicationContext);
 
@@ -130,21 +130,22 @@ namespace Microsoft.Maui
 
 		public static new MauiApplication Current { get; private set; } = null!;
 
-		IServiceProvider IPlatformApplication.Services => _services;
+		// TODO: we should investigate throwing an exception or changing the public API
+		IServiceProvider IPlatformApplication.Services => _services!;
 
-		IApplication IPlatformApplication.Application => _application;
+		IApplication IPlatformApplication.Application => _application!;
 
 		[Obsolete("Use the IPlatformApplication.Current.Application instead.")]
 		public IServiceProvider Services
 		{
-			get => _services;
+			get => _services!;
 			protected set => _services = value;
 		}
 
 		[Obsolete("Use the IPlatformApplication.Current.Application instead.")]
 		public IApplication Application
 		{
-			get => _application;
+			get => _application!;
 			protected set => _application = value;
 		}
 	}

--- a/src/Core/src/Platform/Windows/MauiContextExtensions.cs
+++ b/src/Core/src/Platform/Windows/MauiContextExtensions.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Maui.Platform
 
 		public static IServiceProvider GetApplicationServices(this IMauiContext mauiContext)
 		{
-			return MauiWinUIApplication.Current.Services
+			return IPlatformApplication.Current?.Services
 				?? throw new InvalidOperationException("Unable to find Application Services");
 		}
 

--- a/src/Core/src/Platform/Windows/MauiWinUIApplication.cs
+++ b/src/Core/src/Platform/Windows/MauiWinUIApplication.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Maui
 		protected override void OnLaunched(UI.Xaml.LaunchActivatedEventArgs args)
 		{
 			// Windows running on a different thread will "launch" the app again
-			if (_application != null)
+			if (_application != null && _services != null)
 			{
 				_services.InvokeLifecycleEvents<WindowsLifecycle.OnLaunching>(del => del(this, args));
 				_services.InvokeLifecycleEvents<WindowsLifecycle.OnLaunched>(del => del(this, args));
@@ -52,25 +52,26 @@ namespace Microsoft.Maui
 
 		public UI.Xaml.LaunchActivatedEventArgs LaunchActivatedEventArgs { get; protected set; } = null!;
 
-		IServiceProvider _services = null!;
+		IServiceProvider? _services;
 
-		IApplication _application = null!;
+		IApplication? _application;
 
-		IServiceProvider IPlatformApplication.Services => _services;
+		// TODO: we should investigate throwing an exception or changing the public API
+		IServiceProvider IPlatformApplication.Services => _services!;
 
-		IApplication IPlatformApplication.Application => _application;
+		IApplication IPlatformApplication.Application => _application!;
 
 		[Obsolete("Use the IPlatformApplication.Current.Application instead.")]
 		public IServiceProvider Services
 		{
-			get => _services;
+			get => _services!;
 			protected set => _services = value;
 		}
 
 		[Obsolete("Use the IPlatformApplication.Current.Application instead.")]
 		public IApplication Application
 		{
-			get => _application;
+			get => _application!;
 			protected set => _application = value;
 		}
 	}

--- a/src/Core/src/Platform/Windows/MauiWinUIApplication.cs
+++ b/src/Core/src/Platform/Windows/MauiWinUIApplication.cs
@@ -21,10 +21,10 @@ namespace Microsoft.Maui
 		protected override void OnLaunched(UI.Xaml.LaunchActivatedEventArgs args)
 		{
 			// Windows running on a different thread will "launch" the app again
-			if (Application != null)
+			if (_application != null)
 			{
-				Services.InvokeLifecycleEvents<WindowsLifecycle.OnLaunching>(del => del(this, args));
-				Services.InvokeLifecycleEvents<WindowsLifecycle.OnLaunched>(del => del(this, args));
+				_services.InvokeLifecycleEvents<WindowsLifecycle.OnLaunching>(del => del(this, args));
+				_services.InvokeLifecycleEvents<WindowsLifecycle.OnLaunched>(del => del(this, args));
 				return;
 			}
 
@@ -35,25 +35,43 @@ namespace Microsoft.Maui
 
 			var applicationContext = rootContext.MakeApplicationScope(this);
 
-			Services = applicationContext.Services;
+			_services = applicationContext.Services;
 
-			Services.InvokeLifecycleEvents<WindowsLifecycle.OnLaunching>(del => del(this, args));
+			_services.InvokeLifecycleEvents<WindowsLifecycle.OnLaunching>(del => del(this, args));
 
-			Application = Services.GetRequiredService<IApplication>();
+			_application = _services.GetRequiredService<IApplication>();
 
-			this.SetApplicationHandler(Application, applicationContext);
+			this.SetApplicationHandler(_application, applicationContext);
 
-			this.CreatePlatformWindow(Application, args);
+			this.CreatePlatformWindow(_application, args);
 
-			Services.InvokeLifecycleEvents<WindowsLifecycle.OnLaunched>(del => del(this, args));
+			_services.InvokeLifecycleEvents<WindowsLifecycle.OnLaunched>(del => del(this, args));
 		}
 
 		public static new MauiWinUIApplication Current => (MauiWinUIApplication)UI.Xaml.Application.Current;
 
 		public UI.Xaml.LaunchActivatedEventArgs LaunchActivatedEventArgs { get; protected set; } = null!;
 
-		public IServiceProvider Services { get; protected set; } = null!;
+		IServiceProvider _services = null!;
 
-		public IApplication Application { get; protected set; } = null!;
+		IApplication _application = null!;
+
+		IServiceProvider IPlatformApplication.Services => _services;
+
+		IApplication IPlatformApplication.Application => _application;
+
+		[Obsolete("Use the IPlatformApplication.Current.Application instead.")]
+		public IServiceProvider Services
+		{
+			get => _services;
+			protected set => _services = value;
+		}
+
+		[Obsolete("Use the IPlatformApplication.Current.Application instead.")]
+		public IApplication Application
+		{
+			get => _application;
+			protected set => _application = value;
+		}
 	}
 }

--- a/src/Core/src/Platform/Windows/MauiWinUIApplication.cs
+++ b/src/Core/src/Platform/Windows/MauiWinUIApplication.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Maui
 
 		IApplication IPlatformApplication.Application => _application!;
 
-		[Obsolete("Use the IPlatformApplication.Current.Application instead.")]
+		[Obsolete("Use the IPlatformApplication.Current.Services instead.")]
 		public IServiceProvider Services
 		{
 			get => _services!;

--- a/src/Core/src/Platform/Windows/MauiWinUIWindow.cs
+++ b/src/Core/src/Platform/Windows/MauiWinUIWindow.cs
@@ -172,7 +172,7 @@ namespace Microsoft.Maui
 
 		internal IServiceProvider? Services =>
 			Window?.Handler?.GetServiceProvider() ??
-			MauiWinUIApplication.Current.Services;
+			IPlatformApplication.Current?.Services;
 
 		[DllImport("shell32.dll", CharSet = CharSet.Auto)]
 		static extern IntPtr ExtractAssociatedIcon(IntPtr hInst, string iconPath, ref IntPtr index);

--- a/src/Core/src/Platform/iOS/MauiContextExtensions.cs
+++ b/src/Core/src/Platform/iOS/MauiContextExtensions.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Maui.Platform
 
 		public static IServiceProvider GetApplicationServices(this IMauiContext mauiContext)
 		{
-			return MauiUIApplicationDelegate.Current.Services ??
+			return IPlatformApplication.Current?.Services ??
 				throw new InvalidOperationException("Unable to find Application Services");
 		}
 	}

--- a/src/Core/src/Platform/iOS/MauiUIApplicationDelegate.cs
+++ b/src/Core/src/Platform/iOS/MauiUIApplicationDelegate.cs
@@ -19,9 +19,9 @@ namespace Microsoft.Maui
 
 		IMauiContext _applicationContext = null!;
 
-		IServiceProvider _services = null!;
+		IServiceProvider? _services;
 
-		IApplication _application = null!;
+		IApplication? _application;
 
 		protected MauiUIApplicationDelegate() : base()
 		{
@@ -56,7 +56,7 @@ namespace Microsoft.Maui
 		[Export("application:didFinishLaunchingWithOptions:")]
 		public virtual bool FinishedLaunching(UIApplication application, NSDictionary launchOptions)
 		{
-			_application = _services.GetRequiredService<IApplication>();
+			_application = _services!.GetRequiredService<IApplication>();
 
 			this.SetApplicationHandler(_application, _applicationContext);
 
@@ -169,21 +169,22 @@ namespace Microsoft.Maui
 		[Export("window")]
 		public virtual UIWindow? Window { get; set; }
 
-		IServiceProvider IPlatformApplication.Services => _services;
+		// TODO: we should investigate throwing an exception or changing the public API
+		IServiceProvider IPlatformApplication.Services => _services!;
 
-		IApplication IPlatformApplication.Application => _application;
+		IApplication IPlatformApplication.Application => _application!;
 
 		[Obsolete("Use the IPlatformApplication.Current.Application instead.")]
 		public IServiceProvider Services
 		{
-			get => _services;
+			get => _services!;
 			protected set => _services = value;
 		}
 
 		[Obsolete("Use the IPlatformApplication.Current.Application instead.")]
 		public IApplication Application
 		{
-			get => _application;
+			get => _application!;
 			protected set => _application = value;
 		}
 	}

--- a/src/Core/src/Platform/iOS/MauiUIApplicationDelegate.cs
+++ b/src/Core/src/Platform/iOS/MauiUIApplicationDelegate.cs
@@ -174,7 +174,7 @@ namespace Microsoft.Maui
 
 		IApplication IPlatformApplication.Application => _application!;
 
-		[Obsolete("Use the IPlatformApplication.Current.Application instead.")]
+		[Obsolete("Use the IPlatformApplication.Current.Services instead.")]
 		public IServiceProvider Services
 		{
 			get => _services!;

--- a/src/Core/src/Platform/iOS/MauiUIApplicationDelegate.cs
+++ b/src/Core/src/Platform/iOS/MauiUIApplicationDelegate.cs
@@ -19,6 +19,10 @@ namespace Microsoft.Maui
 
 		IMauiContext _applicationContext = null!;
 
+		IServiceProvider _services = null!;
+
+		IApplication _application = null!;
+
 		protected MauiUIApplicationDelegate() : base()
 		{
 			Current = this;
@@ -42,9 +46,9 @@ namespace Microsoft.Maui
 
 			_applicationContext = rootContext.MakeApplicationScope(this);
 
-			Services = _applicationContext.Services;
+			_services = _applicationContext.Services;
 
-			Services?.InvokeLifecycleEvents<iOSLifecycle.WillFinishLaunching>(del => del(application, launchOptions));
+			_services?.InvokeLifecycleEvents<iOSLifecycle.WillFinishLaunching>(del => del(application, launchOptions));
 
 			return true;
 		}
@@ -52,20 +56,20 @@ namespace Microsoft.Maui
 		[Export("application:didFinishLaunchingWithOptions:")]
 		public virtual bool FinishedLaunching(UIApplication application, NSDictionary launchOptions)
 		{
-			Application = Services.GetRequiredService<IApplication>();
+			_application = _services.GetRequiredService<IApplication>();
 
-			this.SetApplicationHandler(Application, _applicationContext);
+			this.SetApplicationHandler(_application, _applicationContext);
 
 			// if there is no scene delegate or support for scene delegates, then we set up the window here
 			if (!this.HasSceneManifest())
 			{
-				this.CreatePlatformWindow(Application, application, launchOptions);
+				this.CreatePlatformWindow(_application, application, launchOptions);
 
 				if (Window != null)
-					Services?.InvokeLifecycleEvents<iOSLifecycle.OnPlatformWindowCreated>(del => del(Window));
+					_services?.InvokeLifecycleEvents<iOSLifecycle.OnPlatformWindowCreated>(del => del(Window));
 			}
 
-			Services?.InvokeLifecycleEvents<iOSLifecycle.FinishedLaunching>(del => del(application!, launchOptions!));
+			_services?.InvokeLifecycleEvents<iOSLifecycle.FinishedLaunching>(del => del(application!, launchOptions!));
 
 			return true;
 		}
@@ -88,7 +92,7 @@ namespace Microsoft.Maui
 		[Export("application:performActionForShortcutItem:completionHandler:")]
 		public virtual void PerformActionForShortcutItem(UIApplication application, UIApplicationShortcutItem shortcutItem, UIOperationHandler completionHandler)
 		{
-			Services?.InvokeLifecycleEvents<iOSLifecycle.PerformActionForShortcutItem>(del => del(application, shortcutItem, completionHandler));
+			_services?.InvokeLifecycleEvents<iOSLifecycle.PerformActionForShortcutItem>(del => del(application, shortcutItem, completionHandler));
 		}
 
 		[Export("application:openURL:options:")]
@@ -96,7 +100,7 @@ namespace Microsoft.Maui
 		{
 			var wasHandled = false;
 
-			Services?.InvokeLifecycleEvents<iOSLifecycle.OpenUrl>(del =>
+			_services?.InvokeLifecycleEvents<iOSLifecycle.OpenUrl>(del =>
 			{
 				wasHandled = del(application, url, options) || wasHandled;
 			});
@@ -109,7 +113,7 @@ namespace Microsoft.Maui
 		{
 			var wasHandled = false;
 
-			Services?.InvokeLifecycleEvents<iOSLifecycle.ContinueUserActivity>(del =>
+			_services?.InvokeLifecycleEvents<iOSLifecycle.ContinueUserActivity>(del =>
 			{
 				wasHandled = del(application, userActivity, completionHandler) || wasHandled;
 			});
@@ -120,43 +124,43 @@ namespace Microsoft.Maui
 		[Export("applicationDidBecomeActive:")]
 		public virtual void OnActivated(UIApplication application)
 		{
-			Services?.InvokeLifecycleEvents<iOSLifecycle.OnActivated>(del => del(application));
+			_services?.InvokeLifecycleEvents<iOSLifecycle.OnActivated>(del => del(application));
 		}
 
 		[Export("applicationWillResignActive:")]
 		public virtual void OnResignActivation(UIApplication application)
 		{
-			Services?.InvokeLifecycleEvents<iOSLifecycle.OnResignActivation>(del => del(application));
+			_services?.InvokeLifecycleEvents<iOSLifecycle.OnResignActivation>(del => del(application));
 		}
 
 		[Export("applicationWillTerminate:")]
 		public virtual void WillTerminate(UIApplication application)
 		{
-			Services?.InvokeLifecycleEvents<iOSLifecycle.WillTerminate>(del => del(application));
+			_services?.InvokeLifecycleEvents<iOSLifecycle.WillTerminate>(del => del(application));
 		}
 
 		[Export("applicationDidEnterBackground:")]
 		public virtual void DidEnterBackground(UIApplication application)
 		{
-			Services?.InvokeLifecycleEvents<iOSLifecycle.DidEnterBackground>(del => del(application));
+			_services?.InvokeLifecycleEvents<iOSLifecycle.DidEnterBackground>(del => del(application));
 		}
 
 		[Export("applicationWillEnterForeground:")]
 		public virtual void WillEnterForeground(UIApplication application)
 		{
-			Services?.InvokeLifecycleEvents<iOSLifecycle.WillEnterForeground>(del => del(application));
+			_services?.InvokeLifecycleEvents<iOSLifecycle.WillEnterForeground>(del => del(application));
 		}
 
 		[Export("applicationSignificantTimeChange:")]
 		public virtual void ApplicationSignificantTimeChange(UIApplication application)
 		{
-			Services?.InvokeLifecycleEvents<iOSLifecycle.ApplicationSignificantTimeChange>(del => del(application));
+			_services?.InvokeLifecycleEvents<iOSLifecycle.ApplicationSignificantTimeChange>(del => del(application));
 		}
 
 		[Export("application:performFetchWithCompletionHandler:")]
 		public virtual void PerformFetch(UIApplication application, Action<UIBackgroundFetchResult> completionHandler)
 		{
-			Services?.InvokeLifecycleEvents<iOSLifecycle.PerformFetch>(del => del(application, completionHandler));
+			_services?.InvokeLifecycleEvents<iOSLifecycle.PerformFetch>(del => del(application, completionHandler));
 		}
 
 		[UnconditionalSuppressMessage("Memory", "MA0002", Justification = "There can only be one MauiUIApplicationDelegate.")]
@@ -165,8 +169,22 @@ namespace Microsoft.Maui
 		[Export("window")]
 		public virtual UIWindow? Window { get; set; }
 
-		public IServiceProvider Services { get; protected set; } = null!;
+		IServiceProvider IPlatformApplication.Services => _services;
 
-		public IApplication Application { get; protected set; } = null!;
+		IApplication IPlatformApplication.Application => _application;
+
+		[Obsolete("Use the IPlatformApplication.Current.Application instead.")]
+		public IServiceProvider Services
+		{
+			get => _services;
+			protected set => _services = value;
+		}
+
+		[Obsolete("Use the IPlatformApplication.Current.Application instead.")]
+		public IApplication Application
+		{
+			get => _application;
+			protected set => _application = value;
+		}
 	}
 }

--- a/src/Core/src/Platform/iOS/MauiUISceneDelegate.cs
+++ b/src/Core/src/Platform/iOS/MauiUISceneDelegate.cs
@@ -17,11 +17,11 @@ namespace Microsoft.Maui
 		[Export("scene:willConnectToSession:options:")]
 		public virtual void WillConnect(UIScene scene, UISceneSession session, UISceneConnectionOptions connectionOptions)
 		{
-			MauiUIApplicationDelegate.Current?.Services?.InvokeLifecycleEvents<iOSLifecycle.SceneWillConnect>(del => del(scene, session, connectionOptions));
+			IPlatformApplication.Current?.Services?.InvokeLifecycleEvents<iOSLifecycle.SceneWillConnect>(del => del(scene, session, connectionOptions));
 
-			if (session.Configuration.Name == MauiUIApplicationDelegate.MauiSceneConfigurationKey && MauiUIApplicationDelegate.Current?.Application != null)
+			if (session.Configuration.Name == MauiUIApplicationDelegate.MauiSceneConfigurationKey && IPlatformApplication.Current?.Application != null)
 			{
-				this.CreatePlatformWindow(MauiUIApplicationDelegate.Current.Application, scene, session, connectionOptions);
+				this.CreatePlatformWindow(IPlatformApplication.Current.Application, scene, session, connectionOptions);
 
 				if (Window != null)
 					GetServiceProvider()?.InvokeLifecycleEvents<iOSLifecycle.OnPlatformWindowCreated>(del => del(Window));
@@ -31,7 +31,7 @@ namespace Microsoft.Maui
 		[Export("sceneDidDisconnect:")]
 		public virtual void DidDisconnect(UIScene scene)
 		{
-			MauiUIApplicationDelegate.Current?.Services?.InvokeLifecycleEvents<iOSLifecycle.SceneDidDisconnect>(del => del(scene));
+			IPlatformApplication.Current?.Services?.InvokeLifecycleEvents<iOSLifecycle.SceneDidDisconnect>(del => del(scene));
 
 			// for iOS 13 only where active apperance is not supported yet
 			// for iOS 14+, see DidUpdateCoordinateSpace

--- a/src/Core/src/Platform/iOS/UIApplicationExtensions.cs
+++ b/src/Core/src/Platform/iOS/UIApplicationExtensions.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Maui.Platform
 			if (platformWindow is null)
 				return null;
 
-			foreach (var window in MauiUIApplicationDelegate.Current.Application.Windows)
+			foreach (var window in IPlatformApplication.Current?.Application?.Windows ?? Array.Empty<IWindow>())
 			{
 				if (window?.Handler?.PlatformView == platformWindow)
 					return window;

--- a/src/TestUtils/src/DeviceTests.Runners/HeadlessRunner/Android/MauiTestInstrumentation.cs
+++ b/src/TestUtils/src/DeviceTests.Runners/HeadlessRunner/Android/MauiTestInstrumentation.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Maui.TestUtils.DeviceTests.Runners.HeadlessRunner
 
 			await _waitForApplication.Task;
 
-			Services = MauiApplication.Current.Services;
+			Services = IPlatformApplication.Current?.Services ?? throw new NullReferenceException("IPlatformApplication.Current must be initialized.");
 			Options = Services.GetRequiredService<TestOptions>();
 			RunnerOptions = Services.GetRequiredService<HeadlessRunnerOptions>();
 

--- a/src/TestUtils/src/DeviceTests.Runners/HeadlessRunner/Android/MauiTestInstrumentation.cs
+++ b/src/TestUtils/src/DeviceTests.Runners/HeadlessRunner/Android/MauiTestInstrumentation.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Maui.TestUtils.DeviceTests.Runners.HeadlessRunner
 
 			await _waitForApplication.Task;
 
-			Services = IPlatformApplication.Current?.Services ?? throw new NullReferenceException("IPlatformApplication.Current must be initialized.");
+			Services = IPlatformApplication.Current?.Services ?? throw new InvalidOperationException("Unable to find Application Services");
 			Options = Services.GetRequiredService<TestOptions>();
 			RunnerOptions = Services.GetRequiredService<HeadlessRunnerOptions>();
 

--- a/src/TestUtils/src/DeviceTests.Runners/TestServices.cs
+++ b/src/TestUtils/src/DeviceTests.Runners/TestServices.cs
@@ -15,11 +15,11 @@ namespace Microsoft.Maui.TestUtils.DeviceTests.Runners
 				if (s_services is null)
 				{
 #if __ANDROID__
-					s_services = MauiTestInstrumentation.Current?.Services ?? MauiApplication.Current.Services;
+					s_services = MauiTestInstrumentation.Current?.Services ?? IPlatformApplication.Current.Services;
 #elif __IOS__
-					s_services = MauiTestApplicationDelegate.Current?.Services ?? MauiUIApplicationDelegate.Current.Services;
+					s_services = MauiTestApplicationDelegate.Current?.Services ?? IPlatformApplication.Current?.Services;
 #elif WINDOWS
-					s_services = MauiWinUIApplication.Current.Services;
+					s_services = IPlatformApplication.Current.Services;
 #endif
 				}
 

--- a/src/TestUtils/src/DeviceTests.Runners/TestServices.cs
+++ b/src/TestUtils/src/DeviceTests.Runners/TestServices.cs
@@ -15,11 +15,11 @@ namespace Microsoft.Maui.TestUtils.DeviceTests.Runners
 				if (s_services is null)
 				{
 #if __ANDROID__
-					s_services = MauiTestInstrumentation.Current?.Services ?? IPlatformApplication.Current.Services;
+					s_services = MauiTestInstrumentation.Current?.Services ?? IPlatformApplication.Current?.Services;
 #elif __IOS__
 					s_services = MauiTestApplicationDelegate.Current?.Services ?? IPlatformApplication.Current?.Services;
 #elif WINDOWS
-					s_services = IPlatformApplication.Current.Services;
+					s_services = IPlatformApplication.Current?.Services;
 #endif
 				}
 


### PR DESCRIPTION
### Description of Change

Removes references to concrete native host apps in favor of using `IPlatformApplication.Current` as this properly supports embedding scenarios.

### Issues Fixed

Fixes #16759

I've added a TODO for Maui Essentials to find a better way to address the reference to MauiApplication.Current for the native Android Application.

