### PR TITLE
[BuildTasks] Fix resolution for nested types

### DIFF
--- a/src/Controls/src/Build.Tasks/TypeDefinitionExtensions.cs
+++ b/src/Controls/src/Build.Tasks/TypeDefinitionExtensions.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 
 		public static bool IsPublicOrVisibleInternal(this TypeDefinition self, ModuleDefinition module)
 		{
-			if (self.IsPublic)
+			if (self.IsPublic || self.IsNestedPublic)
 				return true;
 			if (self.Module == module)
 				return true;

--- a/src/Controls/src/Xaml/XamlParser.cs
+++ b/src/Controls/src/Xaml/XamlParser.cs
@@ -430,7 +430,7 @@ namespace Microsoft.Maui.Controls.Xaml
 
 		public static bool IsPublicOrVisibleInternal(this Type type, Assembly assembly)
 		{
-			if (type.IsPublic)
+			if (type.IsPublic || type.IsNestedPublic)
 				return true;
 			if (type.Assembly == assembly)
 				return true;

--- a/src/Controls/tests/Xaml.UnitTests.ExternalAssembly/Issues/Maui16923/Gh16923Library.cs
+++ b/src/Controls/tests/Xaml.UnitTests.ExternalAssembly/Issues/Maui16923/Gh16923Library.cs
@@ -1,0 +1,12 @@
+namespace Microsoft.Maui.Controls.Xaml.UnitTests.ExternalAssembly
+{
+	public static class Gh16923Library
+	{
+		public const string LibraryConstant = nameof(LibraryConstant);
+
+		public static class Nested
+		{
+			public const string NestedLibraryConstant = nameof(NestedLibraryConstant);
+		}
+	}
+}

--- a/src/Controls/tests/Xaml.UnitTests.InternalsVisibleAssembly/Issues/Maui16923/Gh16923InternalLibrary.cs
+++ b/src/Controls/tests/Xaml.UnitTests.InternalsVisibleAssembly/Issues/Maui16923/Gh16923InternalLibrary.cs
@@ -1,0 +1,12 @@
+namespace Microsoft.Maui.Controls.Xaml.UnitTests.InternalsVisibleAssembly
+{
+	internal static class Gh16923InternalLibrary
+	{
+		internal const string InternalLibraryConstant = nameof(InternalLibraryConstant);
+
+		internal static class Nested
+		{
+			internal const string InternalNestedLibraryConstant = nameof(InternalNestedLibraryConstant);
+		}
+	}
+}

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Gh16293.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Gh16293.xaml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ContentPage
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:library="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests.ExternalAssembly;assembly=Microsoft.Maui.Controls.Xaml.UnitTests.ExternalAssembly"
+    xmlns:ilibrary="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests.InternalsVisibleAssembly;assembly=Microsoft.Maui.Controls.Xaml.UnitTests.InternalsVisibleAssembly"
+    x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Gh16293">
+    <StackLayout x:Name="Root">
+        <Label x:Name="Label1" Text="{x:Static library:Gh16923Library.LibraryConstant}" />
+        <Label x:Name="Label2" Text="{x:Static library:Gh16923Library+Nested.NestedLibraryConstant}" />
+        <Label x:Name="Label3" Text="{x:Static ilibrary:Gh16923InternalLibrary.InternalLibraryConstant}" />
+        <Label x:Name="Label4" Text="{x:Static ilibrary:Gh16923InternalLibrary+Nested.InternalNestedLibraryConstant}" />
+    </StackLayout>
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Gh16293.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Gh16293.xaml.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Core.UnitTests;
+using Microsoft.Maui.Graphics;
+using NUnit.Framework;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests
+{
+	public partial class Gh16293 : ContentPage
+	{
+		public Gh16293() => InitializeComponent();
+		public Gh16293(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		class Tests
+		{
+			[TestCase(true), TestCase(false)]
+			public void ShouldResolveNested(bool useCompiledXaml)
+			{
+				if (useCompiledXaml)
+					Assert.DoesNotThrow(() => MockCompiler.Compile(typeof(Gh16293)));
+
+				var layout = new Gh16293(useCompiledXaml);
+				Assert.That(layout.Label1.Text, Is.EqualTo("LibraryConstant"));
+				Assert.That(layout.Label2.Text, Is.EqualTo("NestedLibraryConstant"));
+			}
+
+			[TestCase(true), TestCase(false)]
+			public void ShouldResolveInternalNested(bool useCompiledXaml)
+			{
+				if (useCompiledXaml)
+					Assert.DoesNotThrow(() => MockCompiler.Compile(typeof(Gh16293)));
+
+				var layout = new Gh16293(useCompiledXaml);
+				Assert.That(layout.Label3.Text, Is.EqualTo("InternalLibraryConstant"));
+				Assert.That(layout.Label4.Text, Is.EqualTo("InternalNestedLibraryConstant"));
+			}
+		}
+	}
+}


### PR DESCRIPTION
Fixes #16293
Context: https://github.com/dotnet/maui/commit/db74ff7411d20524180d13f07805fc1a574e1c44

The `XamlC` task was failing to resolve public nested types from a class
library.  Fix this by updating the `IsPublicOrVisibleInternal` checks
added in commit db74ff74 to also accept public nested types.
