### PR TITLE
[windows] Fixed CarouselView items rendering

### DIFF
--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issue12567.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issue12567.cs
@@ -1,0 +1,135 @@
+﻿using System.Collections.ObjectModel;
+using Microsoft.Maui;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Graphics;
+
+namespace Maui.Controls.Sample.Issues
+{
+	[Issue(IssueTracker.Github, 12567, "Carousel View does not behave properly in Windows", PlatformAffected.UWP)]
+	public class Issue12567 : TestContentPage
+	{
+		protected override void Init()
+		{
+			var carouselItemsCount = 10;
+			var viewModel = new CarouselViewModel();
+
+			viewModel.GenerateItems(carouselItemsCount);
+
+			BindingContext = viewModel;
+
+			var itemsLayout = new LinearItemsLayout(ItemsLayoutOrientation.Horizontal)
+			{
+				SnapPointsType = SnapPointsType.MandatorySingle,
+				SnapPointsAlignment = SnapPointsAlignment.Center
+			};
+			var itemTemplate = GetCarouselItemTemplate();
+			var carouselView = new CarouselView
+			{
+				ItemsLayout = itemsLayout,
+				ItemTemplate = itemTemplate,
+				Margin = new Thickness(0, 10, 0, 10),
+				BackgroundColor = Colors.Grey,
+				AutomationId = "TestCarouselView",
+				PeekAreaInsets = new Thickness(30, 0, 30, 0)
+			};
+			var button = new Button
+			{
+				Text = "Get Last Item",
+				AutomationId = "GetLast",
+				Margin = new Thickness(0, 10, 0, 10)
+			};
+			var carouselContent = new Grid();
+
+			carouselContent.Children.Add(carouselView);
+
+			var layout = new StackLayout
+			{
+				Orientation = StackOrientation.Vertical,
+				VerticalOptions = LayoutOptions.Fill,
+			};
+
+			button.Clicked += (sender, args) =>
+			{
+				carouselView.ScrollTo(carouselItemsCount - 1, position: ScrollToPosition.End, animate: true);
+			};
+
+			carouselView.SetBinding(ItemsView.ItemsSourceProperty, "Items");
+			layout.Children.Add(button);
+			layout.Children.Add(carouselContent);
+
+			Content = layout;
+		}
+
+		DataTemplate GetCarouselItemTemplate()
+		{
+			return new DataTemplate(() =>
+			{
+				var layout = new StackLayout
+				{
+					Orientation = StackOrientation.Vertical,
+					VerticalOptions = LayoutOptions.Fill
+				};
+				var nameLabel = new Label
+				{
+					HorizontalOptions = LayoutOptions.Center,
+					Margin = new Thickness(10),
+					AutomationId = "NameLabel"
+				};
+				var numberLabel = new Label
+				{
+					HorizontalOptions = LayoutOptions.Center,
+					Margin = new Thickness(10),
+					AutomationId = "NumberLabel"
+				};
+
+				nameLabel.SetBinding(Label.TextProperty, new Binding("Name"));
+				numberLabel.SetBinding(Label.TextProperty, new Binding("Number"));
+
+				layout.Children.Add(nameLabel);
+				layout.Children.Add(numberLabel);
+
+				return new Frame
+				{
+					Content = layout,
+					HasShadow = false
+				};
+			});
+		}
+	}
+
+	class CarouselData
+	{
+		public string Name { get; set; }
+
+		public int Number { get; set; }
+	}
+
+	class CarouselViewModel : BindableObject
+	{
+		ObservableCollection<CarouselData> items;
+
+		public ObservableCollection<CarouselData> Items
+		{
+			get => items;
+			set
+			{
+				items = value;
+				OnPropertyChanged();
+			}
+		}
+
+		public void GenerateItems(int itemsCount)
+		{
+			Items = [];
+
+			for (var i = 1; i <= itemsCount; i++)
+			{
+				Items.Add(new CarouselData
+				{
+					Name = $"Test Item {i}",
+					Number = i
+				});
+			}
+		}
+	}
+}

--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issue12567.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issue12567.cs
@@ -120,7 +120,7 @@ namespace Maui.Controls.Sample.Issues
 
 		public void GenerateItems(int itemsCount)
 		{
-			Items = [];
+			Items = new ObservableCollection<CarouselData>();
 
 			for (var i = 1; i <= itemsCount; i++)
 			{

--- a/src/Controls/src/Core/Handlers/Items/CarouselViewHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Items/CarouselViewHandler.Windows.cs
@@ -12,6 +12,7 @@ using WScrollBarVisibility = Microsoft.UI.Xaml.Controls.ScrollBarVisibility;
 using WScrollMode = Microsoft.UI.Xaml.Controls.ScrollMode;
 using WSnapPointsAlignment = Microsoft.UI.Xaml.Controls.Primitives.SnapPointsAlignment;
 using WSnapPointsType = Microsoft.UI.Xaml.Controls.SnapPointsType;
+using Windows.Foundation;
 
 namespace Microsoft.Maui.Controls.Handlers.Items
 {
@@ -21,6 +22,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		ScrollViewer _scrollViewer;
 		WScrollBarVisibility? _horizontalScrollBarVisibilityWithoutLoop;
 		WScrollBarVisibility? _verticalScrollBarVisibilityWithoutLoop;
+		Size _currentSize;
 
 		protected override IItemsLayout Layout { get; }
 
@@ -30,7 +32,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		protected override void ConnectHandler(ListViewBase platformView)
 		{
 			ItemsView.Scrolled += CarouselScrolled;
-			ListViewBase.SizeChanged += InitialSetup;
+			ListViewBase.SizeChanged += OnListViewSizeChanged;
 
 			UpdateScrollBarVisibilityForLoop();
 
@@ -44,7 +46,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 			if (ListViewBase != null)
 			{
-				ListViewBase.SizeChanged -= InitialSetup;
+				ListViewBase.SizeChanged -= OnListViewSizeChanged;
 
 				if (CollectionViewSource?.Source is ObservableItemTemplateCollection observableItemsSource)
 					observableItemsSource.CollectionChanged -= OnCollectionItemsSourceChanged;
@@ -54,7 +56,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			{
 				_scrollViewer.ViewChanging -= OnScrollViewChanging;
 				_scrollViewer.ViewChanged -= OnScrollViewChanged;
-				_scrollViewer.SizeChanged -= InitialSetup;
+				_scrollViewer.SizeChanged -= OnScrollViewSizeChanged;
 			}
 
 			base.DisconnectHandler(platformView);
@@ -62,12 +64,12 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		protected override void UpdateItemsSource()
 		{
-			var itemsSource = ItemsView.ItemsSource;
+			var itemsSource = ItemsView?.ItemsSource;
 
 			if (itemsSource == null)
 				return;
 
-			var itemTemplate = ItemsView.ItemTemplate;
+			var itemTemplate = ItemsView?.ItemTemplate;
 
 			if (itemTemplate == null)
 				return;
@@ -90,7 +92,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			_scrollViewer = scrollViewer;
 			_scrollViewer.ViewChanging += OnScrollViewChanging;
 			_scrollViewer.ViewChanged += OnScrollViewChanged;
-			_scrollViewer.SizeChanged += InitialSetup;
+			_scrollViewer.SizeChanged += OnScrollViewSizeChanged;
 
 			UpdateScrollBarVisibilityForLoop();
 		}
@@ -331,6 +333,11 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		void UpdateCarouselViewInitialPosition()
 		{
+			if (ListViewBase == null)
+			{
+				return;
+			}
+
 			if (ListViewBase.Items.Count > 0)
 			{
 				if (Element.Loop)
@@ -406,7 +413,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		void UpdateSnapPointsType()
 		{
-			if (_scrollViewer == null)
+			if (_scrollViewer == null || CarouselItemsLayout == null)
 				return;
 
 			if (CarouselItemsLayout.Orientation == ItemsLayoutOrientation.Horizontal)
@@ -418,7 +425,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		void UpdateSnapPointsAlignment()
 		{
-			if (_scrollViewer == null)
+			if (_scrollViewer == null || CarouselItemsLayout == null)
 				return;
 
 			if (CarouselItemsLayout.Orientation == ItemsLayoutOrientation.Horizontal)
@@ -521,14 +528,20 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			SetCarouselViewPosition(carouselPosition);
 		}
 
-		void InitialSetup(object sender, SizeChangedEventArgs e)
-		{
-			if (e.NewSize.Width > 0 && e.NewSize.Height > 0)
-			{
-				ListViewBase.SizeChanged -= InitialSetup;
+		void OnListViewSizeChanged(object sender, SizeChangedEventArgs e) => Resize(e.NewSize);
 
-				if (_scrollViewer != null)
-					_scrollViewer.SizeChanged -= InitialSetup;
+		void OnScrollViewSizeChanged(object sender, SizeChangedEventArgs e)
+		{
+			//If there's a scroll viewer, it's enough to resize based on its size changed event, so we can avoid two event handlers doing the same
+			ListViewBase.SizeChanged -= OnListViewSizeChanged;
+			Resize(e.NewSize);
+		}
+
+		void Resize(Size newSize)
+		{
+			if (newSize != _currentSize && newSize.Width > 0 && newSize.Height > 0)
+			{
+				_currentSize = newSize;
 
 				UpdateItemsSource();
 				UpdateSnapPointsType();

--- a/src/Controls/src/Core/Platform/Windows/CollectionView/ItemContentControl.cs
+++ b/src/Controls/src/Core/Platform/Windows/CollectionView/ItemContentControl.cs
@@ -275,9 +275,7 @@ namespace Microsoft.Maui.Controls.Platform
 			var height = ItemHeight == default ? finalSize.Height : ItemHeight;
 			var size = new WSize(width, height);
 
-			base.ArrangeOverride(size);
-
-			return size;
+			return base.ArrangeOverride(size);
 		}
 
 		/// <inheritdoc/>
@@ -288,18 +286,25 @@ namespace Microsoft.Maui.Controls.Platform
 				return base.MeasureOverride(availableSize);
 			}
 
-			var frameworkElement = Content as FrameworkElement;
-			var margin = _renderer.VirtualView.Margin;
-
-			frameworkElement.Margin = WinUIHelpers.CreateThickness(margin.Left, margin.Top, margin.Right, margin.Bottom);
-
 			var width = ItemWidth == default ? availableSize.Width : ItemWidth;
 			var height = ItemHeight == default ? availableSize.Height : ItemHeight;
 			var measuredSize = base.MeasureOverride(new WSize(width, height));
 			var finalWidth = Max(measuredSize.Width, ItemWidth);
 			var finalHeight = Max(measuredSize.Height, ItemHeight);
+			var finalSize = new WSize(finalWidth, finalHeight);
+			var frameworkElement = Content as FrameworkElement;
+			var visualElement = _renderer.VirtualView as VisualElement;
+			var margin = _renderer.VirtualView.Margin;
 
-			return new WSize(finalWidth, finalHeight);
+			frameworkElement.Margin = WinUIHelpers.CreateThickness(margin.Left, margin.Top, margin.Right, margin.Bottom);
+			visualElement.Layout(new Rect(0, 0, finalWidth, finalHeight));
+
+			if (CanMeasureContent(frameworkElement))
+			{
+				frameworkElement.Measure(finalSize);
+			}
+
+			return finalSize;
 		}
 
 		double Max(double requested, double available)

--- a/src/Controls/src/Core/Platform/Windows/CollectionView/ItemContentControl.cs
+++ b/src/Controls/src/Core/Platform/Windows/CollectionView/ItemContentControl.cs
@@ -263,9 +263,8 @@ namespace Microsoft.Maui.Controls.Platform
 			this.SetAutomationPropertiesAccessibilityView(_visualElement, defaultAccessibilityView);
 		}
 
-#pragma warning disable RS0016 // Add public types and members to the declared API
+		/// <inheritdoc/>
 		protected override WSize ArrangeOverride(WSize finalSize)
-#pragma warning restore RS0016 // Add public types and members to the declared API
 		{
 			if (_renderer == null)
 			{
@@ -281,6 +280,7 @@ namespace Microsoft.Maui.Controls.Platform
 			return size;
 		}
 
+		/// <inheritdoc/>
 		protected override WSize MeasureOverride(WSize availableSize)
 		{
 			if (_renderer == null)

--- a/src/Controls/src/Core/Platform/Windows/CollectionView/ItemContentControl.cs
+++ b/src/Controls/src/Core/Platform/Windows/CollectionView/ItemContentControl.cs
@@ -263,6 +263,24 @@ namespace Microsoft.Maui.Controls.Platform
 			this.SetAutomationPropertiesAccessibilityView(_visualElement, defaultAccessibilityView);
 		}
 
+#pragma warning disable RS0016 // Add public types and members to the declared API
+		protected override WSize ArrangeOverride(WSize finalSize)
+#pragma warning restore RS0016 // Add public types and members to the declared API
+		{
+			if (_renderer == null)
+			{
+				return base.ArrangeOverride(finalSize);
+			}
+
+			var width = ItemWidth == default ? finalSize.Width : ItemWidth;
+			var height = ItemHeight == default ? finalSize.Height : ItemHeight;
+			var size = new WSize(width, height);
+
+			base.ArrangeOverride(size);
+
+			return size;
+		}
+
 		protected override WSize MeasureOverride(WSize availableSize)
 		{
 			if (_renderer == null)
@@ -271,50 +289,17 @@ namespace Microsoft.Maui.Controls.Platform
 			}
 
 			var frameworkElement = Content as FrameworkElement;
-			var formsElement = _renderer.VirtualView as VisualElement;
 			var margin = _renderer.VirtualView.Margin;
 
-			if (ItemHeight != default || ItemWidth != default)
-			{
-				formsElement.Layout(new Rect(0, 0, ItemWidth, ItemHeight));
+			frameworkElement.Margin = WinUIHelpers.CreateThickness(margin.Left, margin.Top, margin.Right, margin.Bottom);
 
-				var wsize = new WSize(ItemWidth, ItemHeight);
+			var width = ItemWidth == default ? availableSize.Width : ItemWidth;
+			var height = ItemHeight == default ? availableSize.Height : ItemHeight;
+			var measuredSize = base.MeasureOverride(new WSize(width, height));
+			var finalWidth = Max(measuredSize.Width, ItemWidth);
+			var finalHeight = Max(measuredSize.Height, ItemHeight);
 
-				frameworkElement.Margin =
-					WinUIHelpers.CreateThickness(
-						margin.Left + ItemSpacing.Left,
-						margin.Top + ItemSpacing.Top,
-						margin.Right + ItemSpacing.Right,
-						margin.Bottom + ItemSpacing.Bottom);
-
-				if (CanMeasureContent(frameworkElement))
-					frameworkElement.Measure(wsize);
-
-				return base.MeasureOverride(wsize);
-			}
-			else
-			{
-				var (width, height) = formsElement.Measure(availableSize.Width, availableSize.Height,
-					MeasureFlags.IncludeMargins).Request;
-
-				width = Max(width, availableSize.Width);
-				height = Max(height, availableSize.Height);
-
-				formsElement.Layout(new Rect(0, 0, width, height));
-
-				var wsize = new WSize(width, height);
-
-				frameworkElement.Margin = WinUIHelpers.CreateThickness(
-					margin.Left,
-					margin.Top,
-					margin.Right,
-					margin.Bottom);
-
-				if (CanMeasureContent(frameworkElement))
-					frameworkElement.Measure(wsize);
-
-				return base.MeasureOverride(wsize);
-			}
+			return new WSize(finalWidth, finalHeight);
 		}
 
 		double Max(double requested, double available)

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -13,6 +13,7 @@ Microsoft.Maui.Controls.PointerGestureRecognizer.PointerReleasedCommand.get -> S
 Microsoft.Maui.Controls.PointerGestureRecognizer.PointerReleasedCommand.set -> void
 Microsoft.Maui.Controls.PointerGestureRecognizer.PointerReleasedCommandParameter.get -> object!
 Microsoft.Maui.Controls.PointerGestureRecognizer.PointerReleasedCommandParameter.set -> void
+override Microsoft.Maui.Controls.Platform.ItemContentControl.ArrangeOverride(Windows.Foundation.Size finalSize) -> Windows.Foundation.Size
 static readonly Microsoft.Maui.Controls.PointerGestureRecognizer.PointerPressedCommandParameterProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.PointerGestureRecognizer.PointerPressedCommandProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.PointerGestureRecognizer.PointerReleasedCommandParameterProperty -> Microsoft.Maui.Controls.BindableProperty!

--- a/src/Controls/tests/UITests/Tests/Issues/Issue12567.cs
+++ b/src/Controls/tests/UITests/Tests/Issues/Issue12567.cs
@@ -1,0 +1,51 @@
+﻿using Microsoft.Maui.Appium;
+using NUnit.Framework;
+using Xamarin.UITest.Queries;
+
+namespace Microsoft.Maui.AppiumTests.Issues
+{
+	public class Issue12567 : _IssuesUITest
+	{
+		public Issue12567(TestDevice device) : base(device) { }
+
+		public override string Issue => "Carousel View does not behave properly in Windows";
+
+		[Test]
+		public void WhenQueryingCarouselItemsInViewThenSingleItemIsRetrieved()
+		{
+			//Assert the initial item is the only one displayed
+			AssertSingleCarouselItem();
+
+			//Tap the button so it goes to the last item in the carousel
+			App.Tap("GetLast");
+
+			//Assert the last item is the only one displayed
+			AssertSingleCarouselItem();
+
+			var itemNumber = GetCurrentItemNumber();
+
+			Assert.AreEqual(10, itemNumber);
+		}
+
+		int GetCurrentItemNumber()
+		{
+			var numberLabel = App.Query(element => element.Marked("NumberLabel")).Where(IsActiveCarouselItem).First();
+
+			return int.Parse(numberLabel.Text);
+		}
+
+		void AssertSingleCarouselItem()
+		{
+			// Get the visible labels in the carousel (should be one if everything is OK)
+			var labels = App.Query(element => element.Marked("NameLabel")).Where(IsActiveCarouselItem);
+
+			Assert.NotNull(labels);
+			Assert.IsNotEmpty(labels);
+			//Only one item should be visible at a time in the carousel
+			Assert.AreEqual(1, labels.Count());
+		}
+
+		//Only the active item in the window should have a size greater than zero
+		bool IsActiveCarouselItem(AppResult carouselItem) => carouselItem.Rect.Width > 0 && carouselItem.Rect.Height > 0;
+	}
+}


### PR DESCRIPTION
### Description of Change

Added ArrangeOverride override and changed MeasureOverride in ItemContentControl to not call the base implementation when the ItemHeight and ItemWidth are already defined.

When the height and width of the items are already defined, it's likely that the base.MeasureOverride (WinUI) call reduces the original size, causing issues like the items in a CarouselView not fitting the container, which causes more items to be displayed at once. This fix makes sure that we always return the max height and width between the measured override and the existing items height and width. Also, adding ArrangeOverride from WinUI base class to control the layout correctly and completely on our side.

CarouselView before the fix:

![CarouselBroken](https://github.com/dotnet/maui/assets/2921919/bc34d0b7-e0ab-4408-bb17-1921aa34389b)

CarouselView after the fix:

![CarouselFixed](https://github.com/dotnet/maui/assets/2921919/e261d073-6988-4a0d-8026-85c9db8f956c)

Also added Apium tests to validate that a single item is always shown in the carousel.

- Fixes #12567 
- Fixes #13057
- Fixes #12850