### PR TITLE
[UITest] Get the tabbedpage UI test working

### DIFF
--- a/src/Controls/samples/Controls.Sample.UITests/Elements/TabbedPageScrollConflictsPage.xaml
+++ b/src/Controls/samples/Controls.Sample.UITests/Elements/TabbedPageScrollConflictsPage.xaml
@@ -1,41 +1,38 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <TabbedPage 
-    x:Name="ScrollConflicsTabbedPage"
+    x:Name="ScrollConflictsTabbedPage"
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     x:Class="Maui.Controls.Sample.TabbedPageScrollConflictsPage"
-    AutomationId="TabbedPageElement"
     Title="TabbedPage ScrollConflicts Gallery"
     CurrentPageChanged="OnTabbedPageCurrentPageChanged">
-    <ContentPage 
-        AutomationId="Tab1Element" 
-        Title="Tab1">
-        <StackLayout       
-            Padding="6, 24">
-            <WebView         
-                AutomationId="WebViewElement">
+    <ContentPage AutomationId="Tab1Element" Title="Tab1">
+        <StackLayout Padding="6, 24">
+            <WebView AutomationId="WebViewElement">
                 <WebView.Source>
                     <HtmlWebViewSource>
                         <HtmlWebViewSource.Html>
                             <![CDATA[
-                            <HTML>
-                            <BODY>
-                            <div style="overflow-x: scroll">
-                            <div style="width: 3000px">Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test </div>
-                            </div>
-                            </BODY>
-                            </HTML>
-                            ]]>
+                <HTML>
+                <BODY>
+                <div style="overflow-x: scroll;user-select: none">
+                <div style="width: 3000px">Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test </div>
+                </div>
+                </BODY>
+                </HTML>
+                ]]>
                         </HtmlWebViewSource.Html>
                     </HtmlWebViewSource>
                 </WebView.Source>
             </WebView>
+            <Label x:Name="tab1Label" AutomationId="Tab1Label" Text="Passed" />
         </StackLayout>
     </ContentPage>
-    <ContentPage 
-        AutomationId="Tab2Element" 
-        Title="Tab2">
-        <Grid 
-            BackgroundColor="Red"/>
+    <ContentPage Title="Tab2">
+        <StackLayout>
+            <Grid BackgroundColor="Red">
+                <Label x:Name="tab2Label" AutomationId="Tab2Label" Text="Failed" />
+            </Grid>
+        </StackLayout>
     </ContentPage>
 </TabbedPage>

--- a/src/Controls/samples/Controls.Sample.UITests/Elements/TabbedPageScrollConflictsPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/Elements/TabbedPageScrollConflictsPage.xaml.cs
@@ -14,7 +14,10 @@ namespace Maui.Controls.Sample
 
 		void OnTabbedPageCurrentPageChanged(object sender, EventArgs e)
 		{
-			ScrollConflicsTabbedPage.Title = "Failed";
+			if (ScrollConflictsTabbedPage != null)
+			{
+				tab1Label.Text = "Failed";
+			}
 		}
 	}
 }

--- a/src/Controls/tests/UITests/Tests/TabbedPageScrollConflictsTests.cs
+++ b/src/Controls/tests/UITests/Tests/TabbedPageScrollConflictsTests.cs
@@ -25,13 +25,16 @@ namespace Microsoft.Maui.AppiumTests
 		}
 
 		[Test]
-		[Ignore("Crash navigating to the sample from the test but not launching the sample")]
 		public void NoScrollConflicts()
 		{
 			if (Device == TestDevice.Android)
 			{
-				App.WaitForElement("WebViewElement");
-				App.SwipeRightToLeft("WebViewElement");
+				App.WaitForElement("Tab1Element");
+
+				App.SwipeRightToLeft(e => e.Marked("Tab1Element").Child("android.webkit.WebView").Child("android.widget.TextView"));
+
+				var element = App.Query("Tab1Label").FirstOrDefault();
+				Assert.True(element != null && element.Text.Equals("Passed", StringComparison.OrdinalIgnoreCase));
 			}
 			else
 			{


### PR DESCRIPTION
### Description of Change

- Remove [Ignore] from tabbed UITest
- Make webview non-selectable so that we can scroll without selecting the text
- Query for the children using class as automationId doesn't seem to be working for the webview

This test will pass as long as the event for switching to the 2nd tab does not get fired which will change the label text.
There is currently nothing verifying that the webview actually scrolled though, @jsuarezruiz not sure if you know a way to verify that to make sure the test is doing the right thing.
