### PR TITLE
[Android] Only return path to font file if it exists, otherwise copy it again. Fixes #16923

### DIFF
--- a/src/Core/src/Fonts/FontRegistrar.Android.cs
+++ b/src/Core/src/Fonts/FontRegistrar.Android.cs
@@ -9,6 +9,6 @@ namespace Microsoft.Maui
 		// Return the filename as-is, as we load the font directly in FontManager
 		string? LoadNativeAppFont(string font, string filename, string? alias) => filename;
 
-		bool IsCachedFontValid(string? fontLoaderResult) => fontLoaderResult != null && File.Exists(fontLoaderResult);
+		bool IsCachedFontValid(string? fontLoaderResult) => fontLoaderResult == null || File.Exists(fontLoaderResult);
 	}
 }

--- a/src/Core/src/Fonts/FontRegistrar.Android.cs
+++ b/src/Core/src/Fonts/FontRegistrar.Android.cs
@@ -8,5 +8,7 @@ namespace Microsoft.Maui
 	{
 		// Return the filename as-is, as we load the font directly in FontManager
 		string? LoadNativeAppFont(string font, string filename, string? alias) => filename;
+
+		bool IsCachedFontValid(string? fontLoaderResult) => fontLoaderResult != null && File.Exists(fontLoaderResult);
 	}
 }

--- a/src/Core/src/Fonts/FontRegistrar.Standard.cs
+++ b/src/Core/src/Fonts/FontRegistrar.Standard.cs
@@ -6,5 +6,7 @@ namespace Microsoft.Maui
 	public partial class FontRegistrar : IFontRegistrar
 	{
 		string? LoadNativeAppFont(string font, string filename, string? alias) => null;
+
+		bool IsCachedFontValid(string? fontLoaderResult) => true;
 	}
 }

--- a/src/Core/src/Fonts/FontRegistrar.Tizen.cs
+++ b/src/Core/src/Fonts/FontRegistrar.Tizen.cs
@@ -23,5 +23,7 @@ namespace Microsoft.Maui
 
 			throw new FileNotFoundException($"Native font with the name {filename} was not found.");
 		}
+
+		bool IsCachedFontValid(string? fontLoaderResult) => true;
 	}
 }

--- a/src/Core/src/Fonts/FontRegistrar.Windows.cs
+++ b/src/Core/src/Fonts/FontRegistrar.Windows.cs
@@ -29,5 +29,7 @@ namespace Microsoft.Maui
 
 			throw new FileNotFoundException($"Native font with the name {filename} was not found.");
 		}
+
+		bool IsCachedFontValid(string? fontLoaderResult) => true;
 	}
 }

--- a/src/Core/src/Fonts/FontRegistrar.cs
+++ b/src/Core/src/Fonts/FontRegistrar.cs
@@ -50,9 +50,9 @@ namespace Microsoft.Maui
 		/// <inheritdoc/>
 		public string? GetFont(string font)
 		{
-			if (_fontLookupCache.TryGetValue(font, out var foundResult) && File.Exists(foundResult))
+			if (_fontLookupCache.TryGetValue(font, out var foundResult) && IsCachedFontValid(foundResult))
 				return foundResult;
-
+			
 			try
 			{
 				if (_embeddedFonts.TryGetValue(font, out var foundFont))

--- a/src/Core/src/Fonts/FontRegistrar.cs
+++ b/src/Core/src/Fonts/FontRegistrar.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Maui
 		/// <inheritdoc/>
 		public string? GetFont(string font)
 		{
-			if (_fontLookupCache.TryGetValue(font, out var foundResult))
+			if (_fontLookupCache.TryGetValue(font, out var foundResult) && File.Exists(foundResult))
 				return foundResult;
 
 			try

--- a/src/Core/src/Fonts/FontRegistrar.iOS.cs
+++ b/src/Core/src/Fonts/FontRegistrar.iOS.cs
@@ -57,5 +57,7 @@ namespace Microsoft.Maui
 
 			throw new FileNotFoundException($"Native font with the name {filename} was not found.");
 		}
+
+		bool IsCachedFontValid(string? fontLoaderResult) => true;
 	}
 }

--- a/src/Core/tests/DeviceTests/Services/FontManagerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Services/FontManagerTests.Android.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using Android.App;
 using Android.Graphics;
 using Xunit;
@@ -78,6 +79,33 @@ public partial class FontManagerTests : TestBase
 		Assert.NotEqual(Typeface.Default, expected);
 
 		Assert.False(expected.Equals(actual));
+	}
+
+	[Fact]
+	public void CanLoadEmbeddedFontIfItWasDeletedDuringRuntime()
+	{
+		// skip on older androids for now
+		// https://github.com/dotnet/maui/issues/5903
+		if (!OperatingSystem.IsAndroidVersionAtLeast(28))
+			return;
+
+		var fontName = "FooBarFont";
+		var fontWeight = FontWeight.Regular;
+
+		var registrar = new FontRegistrar(new EmbeddedFontLoader());
+		registrar.Register("dokdo_regular.ttf", fontName, GetType().Assembly);
+		var manager = new FontManager(registrar);
+		manager.GetTypeface(Font.OfSize(fontName, 12, fontWeight));
+
+		var fontPath = registrar.GetFont(fontName);
+		Assert.True(File.Exists(fontPath));
+
+		File.Delete(fontPath);
+
+		manager.GetTypeface(Font.OfSize(fontName, 12, fontWeight));
+
+		fontPath = registrar.GetFont(fontName);
+		Assert.True(File.Exists(fontPath));
 	}
 
 	[Theory]

--- a/src/Core/tests/UnitTests/Hosting/HostBuilderFontsTests.cs
+++ b/src/Core/tests/UnitTests/Hosting/HostBuilderFontsTests.cs
@@ -60,6 +60,42 @@ namespace Microsoft.Maui.UnitTests.Hosting
 		}
 
 		[Fact]
+		public void FontShouldBeCopiedAgainIfTempFolderIsClearedDuringRuntime()
+		{
+			var root = Path.Combine(Path.GetTempPath(), "Microsoft.Maui.UnitTests", "ConfigureFontsRegistersFonts", Guid.NewGuid().ToString());
+			var filename = "Dokdo-Regular.ttf";
+			var alias = "Dokdo";
+
+			var builder = MauiApp
+				.CreateBuilder()
+				.ConfigureFonts(fonts => fonts.AddEmbeddedResourceFont(GetType().Assembly, filename, alias));
+			builder.Services.AddSingleton<IEmbeddedFontLoader>(_ => new FileSystemEmbeddedFontLoader(root));
+			var mauiApp = builder.Build();
+
+			var registrar = mauiApp.Services.GetRequiredService<IFontRegistrar>();
+
+			var path = registrar.GetFont(filename);
+			Assert.True(File.Exists(path));
+
+			File.Delete(path);
+
+			path = registrar.GetFont(alias);
+			Assert.True(File.Exists(path));
+
+			File.Delete(path);
+
+			path = registrar.GetFont(filename);
+			Assert.True(File.Exists(path));
+
+			File.Delete(path);
+
+			path = registrar.GetFont(alias);
+			Assert.True(File.Exists(path));
+
+			Directory.Delete(root, true);
+		}
+
+		[Fact]
 		public void NullAssemblyForEmbeddedFontThrows()
 		{
 			var builder = MauiApp

--- a/src/Core/tests/UnitTests/Hosting/HostBuilderFontsTests.cs
+++ b/src/Core/tests/UnitTests/Hosting/HostBuilderFontsTests.cs
@@ -60,42 +60,6 @@ namespace Microsoft.Maui.UnitTests.Hosting
 		}
 
 		[Fact]
-		public void FontShouldBeCopiedAgainIfTempFolderIsClearedDuringRuntime()
-		{
-			var root = Path.Combine(Path.GetTempPath(), "Microsoft.Maui.UnitTests", "ConfigureFontsRegistersFonts", Guid.NewGuid().ToString());
-			var filename = "Dokdo-Regular.ttf";
-			var alias = "Dokdo";
-
-			var builder = MauiApp
-				.CreateBuilder()
-				.ConfigureFonts(fonts => fonts.AddEmbeddedResourceFont(GetType().Assembly, filename, alias));
-			builder.Services.AddSingleton<IEmbeddedFontLoader>(_ => new FileSystemEmbeddedFontLoader(root));
-			var mauiApp = builder.Build();
-
-			var registrar = mauiApp.Services.GetRequiredService<IFontRegistrar>();
-
-			var path = registrar.GetFont(filename);
-			Assert.True(File.Exists(path));
-
-			File.Delete(path);
-
-			path = registrar.GetFont(alias);
-			Assert.True(File.Exists(path));
-
-			File.Delete(path);
-
-			path = registrar.GetFont(filename);
-			Assert.True(File.Exists(path));
-
-			File.Delete(path);
-
-			path = registrar.GetFont(alias);
-			Assert.True(File.Exists(path));
-
-			Directory.Delete(root, true);
-		}
-
-		[Fact]
 		public void NullAssemblyForEmbeddedFontThrows()
 		{
 			var builder = MauiApp


### PR DESCRIPTION
### Description of Change

Ensure font file exists before returning the path to it.

### Issues Fixed

Fixes this issue: https://github.com/dotnet/maui/issues/16923
Originally reported in Xamarin repo here: https://github.com/xamarin/Xamarin.Forms/issues/15012

Fixes #16923