### PR TITLE
fix using local asset files on windows

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Windows/WindowsWebViewPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Windows/WindowsWebViewPage.xaml
@@ -7,10 +7,14 @@
     Title="WebView Platform-Specifics">
     <StackLayout Margin="20">
         <WebView x:Name="_webView" 
-                 HeightRequest="50" 
+                 HeightRequest="300" 
                  windows:WebView.IsJavaScriptAlertEnabled="true"
                  windows:WebView.ExecutionMode="SeparateThread" />
         <Button Text="Toggle JavaScript alert" 
                 Clicked="OnToggleButtonClicked" />
+        <Button Text="Load local asset with HtmlWebViewSource and BaseUrl"
+                Clicked="OnLoadLocalAssetWithHtmlSourceAndBaseUrl" />
+        <Button Text="Load local asset with UrlWebViewSource"
+                Clicked="OnLoadLocalAssetWithUrlSource" />
     </StackLayout>
 </ContentPage>

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Windows/WindowsWebViewPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Windows/WindowsWebViewPage.xaml.cs
@@ -20,5 +20,22 @@ namespace Maui.Controls.Sample.Pages
 		{
 			_webView.On<Microsoft.Maui.Controls.PlatformConfiguration.Windows>().SetIsJavaScriptAlertEnabled(!_webView.On<Microsoft.Maui.Controls.PlatformConfiguration.Windows>().IsJavaScriptAlertEnabled());
 		}
+
+		void OnLoadLocalAssetWithHtmlSourceAndBaseUrl(object sender, EventArgs e)
+		{
+			_webView.Source = new HtmlWebViewSource
+			{
+				Html = "<html><body><video muted loop playsinline autoplay><source src=\"webview-test-video.mp4\" type=\"video/mp4\"></video></body></html>",
+				BaseUrl = "https://appdir/",
+			};
+		}
+
+		void OnLoadLocalAssetWithUrlSource(object sender, EventArgs e)
+		{
+			_webView.Source = new UrlWebViewSource
+			{
+				Url = "https://appdir/video.html",
+			};
+		}
 	}
 }

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Windows/WindowsWebViewPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Windows/WindowsWebViewPage.xaml.cs
@@ -25,7 +25,7 @@ namespace Maui.Controls.Sample.Pages
 		{
 			_webView.Source = new HtmlWebViewSource
 			{
-				Html = "<html><body><video muted loop playsinline autoplay><source src=\"webview-test-video.mp4\" type=\"video/mp4\"></video></body></html>",
+				Html = """<html><body><video muted loop playsinline autoplay><source src="webview-test-video.mp4" type="video/mp4"></video></body></html>""",
 				BaseUrl = "https://appdir/",
 			};
 		}

--- a/src/Core/src/Platform/Windows/MauiWebView.cs
+++ b/src/Core/src/Platform/Windows/MauiWebView.cs
@@ -113,7 +113,8 @@ namespace Microsoft.Maui.Platform
 		{
 			Uri uri = new Uri(url ?? string.Empty, UriKind.RelativeOrAbsolute);
 
-			if (!uri.IsAbsoluteUri)
+			if (!uri.IsAbsoluteUri ||
+				uri.AbsoluteUri.ToLowerInvariant().StartsWith(LocalScheme.TrimEnd('/').ToLowerInvariant()) == true)
 			{
 				await EnsureCoreWebView2Async();
 
@@ -122,7 +123,8 @@ namespace Microsoft.Maui.Platform
 					ApplicationPath,
 					Web.WebView2.Core.CoreWebView2HostResourceAccessKind.Allow);
 
-				uri = new Uri(LocalScheme + url, UriKind.RelativeOrAbsolute);
+				if (!uri.IsAbsoluteUri)
+					uri = new Uri(LocalScheme + url, UriKind.RelativeOrAbsolute);
 			}
 
 			if (_handler?.TryGetTarget(out var handler) ?? false)

--- a/src/Core/src/Platform/Windows/MauiWebView.cs
+++ b/src/Core/src/Platform/Windows/MauiWebView.cs
@@ -181,10 +181,7 @@ namespace Microsoft.Maui.Platform
 
 		static bool IsDataUri(string? uri)
 		{
-			return uri?
-				.StartsWith(
-					"data:text/html",
-					StringComparison.OrdinalIgnoreCase) ?? false;
+			return uri?.StartsWith("data:text/html", StringComparison.OrdinalIgnoreCase) ?? false;
 		}
 	}
 }

--- a/src/Core/src/Platform/Windows/MauiWebView.cs
+++ b/src/Core/src/Platform/Windows/MauiWebView.cs
@@ -153,10 +153,8 @@ namespace Microsoft.Maui.Platform
 			NavigationStarting += (sender, args) =>
 			{
 				// Auto map local virtual app dir host, e.g. if navigating back to local site from a link to an external site
-				bool isDataUrl = args?.Uri?.StartsWith("data:text/html") ?? false;
-
 				if (IsUriWithLocalScheme(args?.Uri) ||
-					(isDataUrl && _navigatingToHtmlWithBaseUrl))
+					(IsDataUri(args?.Uri) && _navigatingToHtmlWithBaseUrl))
 				{
 					CoreWebView2.SetVirtualHostNameToFolderMapping(
 						LocalHostName,
@@ -179,6 +177,12 @@ namespace Microsoft.Maui.Platform
 				.ToLowerInvariant()
 				.StartsWith(
 					LocalScheme.TrimEnd('/').ToLowerInvariant()) == true;
+		}
+
+		static bool IsDataUri(string? uri)
+		{
+			return uri?
+				.StartsWith("data:text/html") ?? false;
 		}
 	}
 }

--- a/src/Core/src/Platform/Windows/MauiWebView.cs
+++ b/src/Core/src/Platform/Windows/MauiWebView.cs
@@ -122,7 +122,7 @@ namespace Microsoft.Maui.Platform
 			Uri uri = new Uri(url ?? string.Empty, UriKind.RelativeOrAbsolute);
 
 			if (!uri.IsAbsoluteUri ||
-				uri.AbsoluteUri.ToLowerInvariant().StartsWith(LocalScheme.TrimEnd('/').ToLowerInvariant()) == true)
+				IsUriWithLocalScheme(uri.AbsoluteUri))
 			{
 				await EnsureCoreWebView2Async();
 
@@ -153,10 +153,9 @@ namespace Microsoft.Maui.Platform
 			NavigationStarting += (sender, args) =>
 			{
 				// Auto map local virtual app dir host, e.g. if navigating back to local site from a link to an external site
-				bool isUrlWithLocalScheme = args?.Uri?.ToLowerInvariant().StartsWith(LocalScheme.TrimEnd('/').ToLowerInvariant()) == true;
 				bool isDataUrl = args?.Uri?.StartsWith("data:text/html") ?? false;
 
-				if (isUrlWithLocalScheme ||
+				if (IsUriWithLocalScheme(args?.Uri) ||
 					(isDataUrl && _navigatingToHtmlWithBaseUrl))
 				{
 					CoreWebView2.SetVirtualHostNameToFolderMapping(
@@ -172,6 +171,14 @@ namespace Microsoft.Maui.Platform
 					CoreWebView2.ClearVirtualHostNameToFolderMapping(LocalHostName);
 				}
 			};
+		}
+
+		static bool IsUriWithLocalScheme(string? uri)
+		{
+			return uri?
+				.ToLowerInvariant()
+				.StartsWith(
+					LocalScheme.TrimEnd('/').ToLowerInvariant()) == true;
 		}
 	}
 }

--- a/src/Core/src/Platform/Windows/MauiWebView.cs
+++ b/src/Core/src/Platform/Windows/MauiWebView.cs
@@ -174,15 +174,17 @@ namespace Microsoft.Maui.Platform
 		static bool IsUriWithLocalScheme(string? uri)
 		{
 			return uri?
-				.ToLowerInvariant()
 				.StartsWith(
-					LocalScheme.TrimEnd('/').ToLowerInvariant()) == true;
+					LocalScheme.TrimEnd('/'),
+					StringComparison.OrdinalIgnoreCase) == true;
 		}
 
 		static bool IsDataUri(string? uri)
 		{
 			return uri?
-				.StartsWith("data:text/html") ?? false;
+				.StartsWith(
+					"data:text/html",
+					StringComparison.OrdinalIgnoreCase) ?? false;
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change

This PR fixes both issues in #16646 on the windows platform.
The first commit fixes loading `WebView` content using `UrlWebViewSource` when the `LocalScheme` is used, which is `https://appdir/`.
The second commit fixes the case when using `HtmlWebViewSource` and the specified `BaseUrl` has a `LocalScheme`, but the virtual host name to folder mapping is first set and then cleared again.

### Issues Fixed

Fixes #16646
