### PR TITLE
[workload] Only install the WinUI pack on Windows

### DIFF
--- a/src/Workload/Microsoft.NET.Sdk.Maui/WorkloadManifest.in.json
+++ b/src/Workload/Microsoft.NET.Sdk.Maui/WorkloadManifest.in.json
@@ -76,7 +76,7 @@
       "description": ".NET MAUI SDK for Windows",
       "extends": [ "maui-blazor" ],
       "packs": [
-          "Microsoft.Maui.Graphics.Win2D.WinUI.Desktop"
+          "Microsoft.Maui.Graphics.Windows"
       ]
     },
     "maui-tizen": {
@@ -123,9 +123,14 @@
       "kind": "library",
       "version": "@VERSION@"
     },
-    "Microsoft.Maui.Graphics.Win2D.WinUI.Desktop": {
+    "Microsoft.Maui.Graphics.Windows": {
       "kind": "library",
-      "version": "@VERSION@"
+      "version": "@VERSION@",
+      "alias-to": {
+        "win-x86": "Microsoft.Maui.Graphics.Win2D.WinUI.Desktop",
+        "win-x64": "Microsoft.Maui.Graphics.Win2D.WinUI.Desktop",
+        "win-arm64": "Microsoft.Maui.Graphics.Win2D.WinUI.Desktop"
+      }
     },
     "Microsoft.Maui.Resizetizer": {
       "kind": "library",


### PR DESCRIPTION
When building on macOS I've been hitting a workload install issue:

    Workload installation failed. Rolling back installed packs...
      Rolling back pack Microsoft.Maui.Graphics.Win2D.WinUI.Desktop installation...
      Workload installation failed: microsoft.maui.graphics.win2d.winui.desktop::7.0.100-dev is not found in NuGet feeds ...

The project that produces this pack doesn't seem to be built on macOS,
and it's not available in the local artifacts feed after a build.

We can take advantage of [alias packs][0] to fix this issue.  This will
also simplify workload installs for customers not on Windows, as the
pack will now be ignored entirely on other platforms.

[0]: https://github.com/dotnet/designs/blob/37718c66f403f7a5d25517cdac3ec2d2553100a6/accepted/2020/workloads/workload-manifest.md#alias-packs