### PR TITLE
[UITest] Add a timeout to the appium server startup

### DIFF
--- a/src/Controls/tests/UITests/Tests/Issues/_IssuesUITest.cs
+++ b/src/Controls/tests/UITests/Tests/Issues/_IssuesUITest.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Maui.AppiumTests
 				}
 				catch (Exception e)
 				{
-					TestContext.Error.WriteLine($"The FixtureSetup threw an exception. Attempt {retries}/{SetupMaxRetries}.{Environment.NewLine}Exception details: {e}");
+					TestContext.Error.WriteLine($">>>>> The FixtureSetup threw an exception. Attempt {retries}/{SetupMaxRetries}.{Environment.NewLine}Exception details: {e}");
 					if (retries++ < SetupMaxRetries)
 					{
 						Reset();
@@ -45,7 +45,7 @@ namespace Microsoft.Maui.AppiumTests
 			catch (Exception e)
 			{
 				var name = TestContext.CurrentContext.Test.MethodName ?? TestContext.CurrentContext.Test.Name;
-				TestContext.Error.WriteLine($"The FixtureTeardown threw an exception during {name}.{Environment.NewLine}Exception details: {e}");
+				TestContext.Error.WriteLine($">>>>> The FixtureTeardown threw an exception during {name}.{Environment.NewLine}Exception details: {e}");
 			}
 		}
 

--- a/src/Controls/tests/UITests/Tests/_ViewUITests.cs
+++ b/src/Controls/tests/UITests/Tests/_ViewUITests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Maui.Controls.Sample;
+﻿using Maui.Controls.Sample;
 using Microsoft.Maui.Appium;
 using Microsoft.Maui.Controls;
 using NUnit.Framework;
@@ -25,7 +24,7 @@ namespace Microsoft.Maui.AppiumTests
 				}
 				catch (Exception e)
 				{
-					TestContext.Error.WriteLine($"The FixtureSetup threw an exception. Attempt {retries}/{SetupMaxRetries}.{Environment.NewLine}Exception details: {e}");
+					TestContext.Error.WriteLine($">>>>> The FixtureSetup threw an exception. Attempt {retries}/{SetupMaxRetries}.{Environment.NewLine}Exception details: {e}");
 					if (retries++ < SetupMaxRetries)
 					{
 						Reset();
@@ -48,7 +47,7 @@ namespace Microsoft.Maui.AppiumTests
 			catch (Exception e)
 			{
 				var name = TestContext.CurrentContext.Test.MethodName ?? TestContext.CurrentContext.Test.Name;
-				TestContext.Error.WriteLine($"The FixtureTeardown threw an exception during {name}.{Environment.NewLine}Exception details: {e}");
+				TestContext.Error.WriteLine($">>>>> The FixtureTeardown threw an exception during {name}.{Environment.NewLine}Exception details: {e}");
 			}
 		}
 

--- a/src/TestUtils/src/TestUtils.Appium.UITests/AppiumContext.cs
+++ b/src/TestUtils/src/TestUtils.Appium.UITests/AppiumContext.cs
@@ -17,6 +17,9 @@ namespace TestUtils.Appium.UITests
 		const int Port = 4723;
 		readonly AppiumOptions _appiumOptions;
 		readonly List<UITestContext> _contexts; // Since tests don't know when they are done, we need to keep track of all the contexts we create so we can dispose them
+		readonly int _serverStartWaitDelay = 1000;
+		readonly TimeSpan _maxServerWaitTime = TimeSpan.FromSeconds(15);
+		readonly object _serverLock = new object();
 		AppiumLocalService? _server;
 
 		public AppiumContext()
@@ -27,27 +30,51 @@ namespace TestUtils.Appium.UITests
 
 		public void CreateAndStartServer(int port = Port)
 		{
-			var arguments = new OpenQA.Selenium.Appium.Service.Options.OptionCollector();
-			arguments.AddArguments(new KeyValuePair<string, string>("--base-path", "/wd/hub"));
+			lock (_serverLock)
+			{
+				_server?.Dispose();
 
-			var logFile = Environment.GetEnvironmentVariable("APPIUM_LOG_FILE") ?? "appium.log";
+				var arguments = new OpenQA.Selenium.Appium.Service.Options.OptionCollector();
+				arguments.AddArguments(new KeyValuePair<string, string>("--base-path", "/wd/hub"));
 
-			var service = new AppiumServiceBuilder()
-				.WithArguments(arguments)
-				.UsingPort(port)
-				.WithLogFile(new FileInfo(logFile))
-				.Build();
+				var logFile = Environment.GetEnvironmentVariable("APPIUM_LOG_FILE") ?? "appium.log";
 
-			service.OutputDataReceived += (s, e) => Debug.WriteLine($"Appium {e.Data}");
-			service.Start();
-			_server = service;
+				var service = new AppiumServiceBuilder()
+					.WithArguments(arguments)
+					.UsingPort(port)
+					.WithLogFile(new FileInfo(logFile))
+					.Build();
+
+				service.OutputDataReceived += (s, e) => Debug.WriteLine($"Appium {e.Data}");
+				service.Start();
+				_server = service;
+
+				DateTime start = DateTime.Now;
+
+				while (!_server.IsRunning)
+				{
+					long elapsed = DateTime.Now.Subtract(start).Ticks;
+					if (elapsed >= _maxServerWaitTime.Ticks)
+					{
+						Debug.WriteLine($">>>>> {elapsed} ticks elapsed, timeout value is {_maxServerWaitTime.Ticks}");
+
+						throw new TimeoutException($"Timed out waiting for Appium server to start after waiting for {_maxServerWaitTime.Seconds}s");
+					}
+
+					Task.Delay(_serverStartWaitDelay).Wait();
+				}
+			}
 		}
 
 		public UITestContext CreateUITestContext(TestConfig testConfig)
 		{
-			if (_server == null)
+			lock (_serverLock)
 			{
-				throw new InvalidOperationException("Server is not initialized. Call CreateAndStartServer() first.");
+				if (_server == null || !_server.IsRunning)
+				{
+					TestContext.Error.WriteLine($">>>>> Server was not running when calling {nameof(CreateUITestContext)}, starting it ourselves...");
+					CreateAndStartServer();
+				}
 			}
 
 			if (testConfig == null)
@@ -55,11 +82,6 @@ namespace TestUtils.Appium.UITests
 
 			SetGeneralAppiumOptions(testConfig, _appiumOptions);
 			SetPlatformAppiumOptions(testConfig, _appiumOptions);
-
-			while (!_server.IsRunning)
-			{
-				Task.Delay(1000).Wait();
-			}
 
 			var driverUri = new Uri($"http://localhost:{Port}/wd/hub");
 
@@ -87,7 +109,7 @@ namespace TestUtils.Appium.UITests
 					// Default command timeout is 60 seconds when executing the NewSessionCommand
 					if (retries++ < 10)
 					{
-						TestContext.Error.WriteLine($"Retrying to create the driver, attempt #{retries}");
+						TestContext.Error.WriteLine($">>>>> Retrying to create the driver, attempt #{retries}");
 					}
 					else
 					{
@@ -153,8 +175,11 @@ namespace TestUtils.Appium.UITests
 
 			_contexts.Clear();
 
-			_server?.Dispose();
-			_server = null;
+			lock (_serverLock)
+			{
+				_server?.Dispose();
+				_server = null;
+			}
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change

Add a timeout to waiting for the appium server to start and start the server if it is not running in the CreateUITestContextSetup method.

### Issues Fixed

We recently encountered an issue where the appium server was crashing due to a bug in appium and this would cause the test to fail rightfully but then we would end up hanging indefinitely in the CreateUITestContextSetup method.
