### PR TITLE
[android] Fixed ListView visibility and opacity on Android

### DIFF
--- a/src/Controls/samples/Controls.Sample.UITests/Controls.Sample.UITests.csproj
+++ b/src/Controls/samples/Controls.Sample.UITests/Controls.Sample.UITests.csproj
@@ -45,6 +45,30 @@
     <MauiSplashScreen Include="Resources\Splash\splash.svg" Color="#FFFFFF" BaseSize="168,208" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Update="Issues\Issue12211.xaml.cs">
+      <DependentUpon>Issue12211.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="Issues\Issue15357.xaml.cs">
+      <DependentUpon>Issue15357.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="Issues\Issue15826.xaml.cs">
+      <DependentUpon>Issue15826.xaml</DependentUpon>
+    </Compile>
+  </ItemGroup>
+
   <Import Project="$(MauiSrcDirectory)Maui.InTree.props" Condition=" '$(UseMaui)' != 'true' " />
+
+  <ItemGroup>
+    <MauiXaml Update="Issues\Issue12211.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </MauiXaml>
+    <MauiXaml Update="Issues\Issue15357.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </MauiXaml>
+    <MauiXaml Update="Issues\Issue15826.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </MauiXaml>
+  </ItemGroup>
 
 </Project>

--- a/src/Controls/samples/Controls.Sample.UITests/Controls.Sample.UITests.csproj
+++ b/src/Controls/samples/Controls.Sample.UITests/Controls.Sample.UITests.csproj
@@ -45,30 +45,6 @@
     <MauiSplashScreen Include="Resources\Splash\splash.svg" Color="#FFFFFF" BaseSize="168,208" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Compile Update="Issues\Issue12211.xaml.cs">
-      <DependentUpon>Issue12211.xaml</DependentUpon>
-    </Compile>
-    <Compile Update="Issues\Issue15357.xaml.cs">
-      <DependentUpon>Issue15357.xaml</DependentUpon>
-    </Compile>
-    <Compile Update="Issues\Issue15826.xaml.cs">
-      <DependentUpon>Issue15826.xaml</DependentUpon>
-    </Compile>
-  </ItemGroup>
-
   <Import Project="$(MauiSrcDirectory)Maui.InTree.props" Condition=" '$(UseMaui)' != 'true' " />
-
-  <ItemGroup>
-    <MauiXaml Update="Issues\Issue12211.xaml">
-      <Generator>MSBuild:Compile</Generator>
-    </MauiXaml>
-    <MauiXaml Update="Issues\Issue15357.xaml">
-      <Generator>MSBuild:Compile</Generator>
-    </MauiXaml>
-    <MauiXaml Update="Issues\Issue15826.xaml">
-      <Generator>MSBuild:Compile</Generator>
-    </MauiXaml>
-  </ItemGroup>
 
 </Project>

--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issue12211.xaml
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issue12211.xaml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Maui.Controls.Sample.Issues.Issue12211"
+             xmlns:ns="clr-namespace:Maui.Controls.Sample.Issues">
+    <ScrollView>
+        <VerticalStackLayout
+            Spacing="25"
+            Padding="30,0"
+            VerticalOptions="Center">
+            <BoxView Color="Blue" HeightRequest="100" WidthRequest="100" Background="Red" Opacity="{Binding CurrentOpacity}"/>
+            <Button x:Name="ChangeOpacity" AutomationId="ChangeOpacity" Text="Change Opacity" HorizontalOptions="Center" Clicked="OnChangedOpacity" />
+            <Label x:Name="CurrentOpacity" AutomationId="CurrentOpacity" Text="{Binding CurrentOpacityStatus}" />
+        </VerticalStackLayout>
+    </ScrollView>
+</ContentPage>

--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issue12211.xaml.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issue12211.xaml.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.ComponentModel;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+
+namespace Maui.Controls.Sample.Issues
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	[Issue(IssueTracker.Github, 12211, "[Android] BoxView Opacity not working", PlatformAffected.Android)]
+	public partial class Issue12211 : ContentPage
+	{
+		private int clicks;
+		private Issue12211Settings settings;
+
+		public Issue12211()
+		{
+			settings = new Issue12211Settings();
+
+			InitializeComponent();
+			BindingContext = settings;
+			SetCurrentOpacity(0.7);
+		}
+
+		private void OnChangedOpacity(object sender, EventArgs e)
+		{
+			clicks++;
+
+			double opacity = clicks % 2 == 0 ? 0 : 1;
+
+			SetCurrentOpacity(opacity);
+		}
+
+		void SetCurrentOpacity(double opacity)
+		{
+			settings.CurrentOpacity = (float)opacity;
+			settings.CurrentOpacityStatus = $"Current opacity is {settings.CurrentOpacity}";
+		}
+	}
+
+	internal class Issue12211Settings : INotifyPropertyChanged
+	{
+		private float currentOpacity;
+		private string currentOpacityStatus;
+
+		public event PropertyChangedEventHandler PropertyChanged;
+
+		public float CurrentOpacity
+		{
+			get => currentOpacity;
+			set
+			{
+				currentOpacity = value;
+				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(CurrentOpacity)));
+			}
+		}
+
+		public string CurrentOpacityStatus
+		{
+			get => currentOpacityStatus;
+			set
+			{
+				currentOpacityStatus = value;
+				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(CurrentOpacityStatus)));
+			}
+		}
+	}
+}

--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issue15357.xaml
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issue15357.xaml
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Maui.Controls.Sample.Issues.Issue15357"
+             xmlns:ns="clr-namespace:Maui.Controls.Sample.Issues">
+    <ContentPage.Resources>
+        <Style TargetType="Button">
+            <Setter Property="Shadow">
+                <Shadow Brush="Black" Offset="4,4" Opacity="0.9" />
+            </Setter>
+        </Style>
+    </ContentPage.Resources>
+    <ScrollView>
+        <VerticalStackLayout
+            Spacing="25"
+            Padding="30,0"
+            VerticalOptions="Center">
+            <Button x:Name="ButtonClick" AutomationId="ButtonClick" Text="Click" Clicked="OnButtonClicked" HorizontalOptions="Center" />
+            <Button x:Name="ButtonTest" AutomationId="ButtonTest" IsVisible="{Binding ShouldShow}" Text="Test" HorizontalOptions="Center" />
+            <Label x:Name="LabelStatus" AutomationId="LabelStatus" Text="{Binding LabelStatus}" />
+        </VerticalStackLayout>
+    </ScrollView>
+</ContentPage>

--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issue15357.xaml.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issue15357.xaml.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.ComponentModel;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+
+namespace Maui.Controls.Sample.Issues
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	[Issue(IssueTracker.Github, 15357, "IsVisible binding not showing items again if Shadow is set", PlatformAffected.Android)]
+	public partial class Issue15357 : ContentPage
+	{
+		private int clicks;
+		private Issue15357Settings settings;
+
+		public Issue15357()
+		{
+			settings = new Issue15357Settings();
+
+			InitializeComponent();
+			BindingContext = settings;
+			SetButtonStatus();
+		}
+
+		private void OnButtonClicked(object sender, EventArgs e)
+		{
+			clicks++;
+			settings.ShouldShow = clicks % 2 == 0;
+			SetButtonStatus();
+		}
+
+		void SetButtonStatus()
+		{
+			var buttonStatus = ButtonTest.IsVisible ? "is visible" : "is not visible";
+
+			settings.LabelStatus = $"Test Button {buttonStatus}";
+		}
+	}
+
+	internal class Issue15357Settings : INotifyPropertyChanged
+	{
+		private bool shouldShow;
+		private string labelStatus;
+
+		public Issue15357Settings()
+		{
+			ShouldShow = true;
+		}
+
+		public event PropertyChangedEventHandler PropertyChanged;
+
+		public bool ShouldShow
+		{
+			get => shouldShow;
+			set
+			{
+				shouldShow = value;
+				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(ShouldShow)));
+			}
+		}
+
+		public string LabelStatus
+		{
+			get => labelStatus;
+			set
+			{
+				labelStatus = value;
+				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(LabelStatus)));
+			}
+		}
+	}
+}

--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issue15826.xaml
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issue15826.xaml
@@ -1,0 +1,38 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="Maui.Controls.Sample.Issues.Issue15826"
+    xmlns:ns="clr-namespace:Maui.Controls.Sample.Issues">
+    <ScrollView>
+        <VerticalStackLayout>
+            <Button x:Name="Swap" AutomationId="Swap" Text="Swap List" Clicked="Button_Clicked"/>
+            <ListView x:Name="List1" AutomationId="List1" IsVisible="{Binding List1Visible}"
+                ItemsSource="{Binding List1Data}"
+                RowHeight="40"
+                SeparatorVisibility="None"
+                VerticalOptions="Fill">
+                <ListView.ItemTemplate>
+                    <DataTemplate x:DataType="ns:ListData">
+                        <ViewCell>
+                            <Label Text="{Binding Text}" />
+                        </ViewCell>
+                    </DataTemplate>
+                </ListView.ItemTemplate>
+            </ListView>
+            <ListView x:Name="List2" AutomationId="List2" IsVisible="{Binding List2Visible}"
+                ItemsSource="{Binding List2Data}"
+                RowHeight="40"
+                SeparatorVisibility="None"
+                VerticalOptions="Fill">
+                <ListView.ItemTemplate>
+                    <DataTemplate x:DataType="ns:ListData">
+                        <ViewCell>
+                            <Label Text="{Binding Text}" />
+                        </ViewCell>
+                    </DataTemplate>
+                </ListView.ItemTemplate>
+            </ListView>
+            <Label x:Name="LabelStatus" AutomationId="LabelStatus" Text="{Binding ListsStatus}" />
+        </VerticalStackLayout>
+    </ScrollView>
+</ContentPage>

--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issue15826.xaml.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issue15826.xaml.cs
@@ -1,0 +1,123 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+
+namespace Maui.Controls.Sample.Issues
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	[Issue(IssueTracker.Github, 15826, "ListView visibility doesn't work well", PlatformAffected.Android)]
+	public partial class Issue15826 : ContentPage
+	{
+		private Issue15826Settings settings;
+
+		public Issue15826()
+		{
+			settings = new Issue15826Settings();
+
+			InitializeComponent();
+			BindingContext = settings;
+			SetListsStatus();
+		}
+
+		private void Button_Clicked(object sender, EventArgs e)
+		{
+			if (settings.List1Visible)
+			{
+				settings.List1Visible = false;
+				settings.List2Visible = true;
+			}
+			else
+			{
+				settings.List1Visible = true;
+				settings.List2Visible = false;
+			}
+
+			SetListsStatus();
+		}
+
+		private void SetListsStatus()
+		{
+			var listName = List1.IsVisible && !List2.IsVisible ? "List 1" : !List1.IsVisible && List2.IsVisible ? "List 2" : "";
+
+			settings.ListsStatus = string.IsNullOrEmpty(listName) ? "No lists are visible" : $"{listName} is now visible";
+		}
+	}
+
+	internal class Issue15826Settings : INotifyPropertyChanged
+	{
+		private List<ListData> list1Data = new List<ListData> {
+			new ListData{ Text = "List 1 - Item 1" },
+			new ListData{ Text = "List 1 - Item 2" },
+			new ListData{ Text = "List 1 - Item 3" }
+		};
+		private List<ListData> list2Data = new List<ListData> {
+			new ListData{ Text = "List 2 - Item 1" },
+			new ListData{ Text = "List 2 - Item 2" },
+			new ListData{ Text = "List 2 - Item 3" }
+		};
+		private bool list1Visible = true;
+		private bool list2Visible = false;
+		private string listsStatus;
+
+		public event PropertyChangedEventHandler PropertyChanged;
+
+		public List<ListData> List1Data
+		{
+			get => list1Data;
+			set
+			{
+				list1Data = value;
+				OnPropertyChanged(nameof(List1Data));
+			}
+		}
+
+		public List<ListData> List2Data
+		{
+			get => list2Data;
+			set
+			{
+				list2Data = value;
+				OnPropertyChanged(nameof(List2Data));
+			}
+		}
+
+		public bool List1Visible
+		{
+			get => list1Visible;
+			set
+			{
+				list1Visible = value;
+				OnPropertyChanged(nameof(List1Visible));
+			}
+		}
+
+		public bool List2Visible
+		{
+			get => list2Visible;
+			set
+			{
+				list2Visible = value;
+				OnPropertyChanged(nameof(List2Visible));
+			}
+		}
+
+		public string ListsStatus
+		{
+			get => listsStatus;
+			set
+			{
+				listsStatus = value;
+				OnPropertyChanged(nameof(ListsStatus));
+			}
+		}
+
+		private void OnPropertyChanged(string propertyName) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+	}
+
+	internal class ListData
+	{
+		public string Text { get; set; }
+	}
+}

--- a/src/Controls/tests/UITests/Tests/Issues/Issue12211.cs
+++ b/src/Controls/tests/UITests/Tests/Issues/Issue12211.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.Maui.Appium;
+using NUnit.Framework;
+
+namespace Microsoft.Maui.AppiumTests.Issues
+{
+	public class Issue12211 : _IssuesUITest
+	{
+		private string buttonId = "ChangeOpacity";
+
+		public Issue12211(TestDevice device) : base(device)
+		{ 
+		}
+
+		public override string Issue => "[Android] BoxView Opacity not working";
+
+		[Test]
+		public void WhenChangingBoxViewOpacityThenValueIsCorrectlySet()
+		{
+			App.WaitForElement(buttonId);
+
+			var initialOpacity = GetCurrentOpacityStatus();
+			var secondOpacity = ChangeOpacityAndGetCurrentStatus();
+			var thirdOpacity = ChangeOpacityAndGetCurrentStatus();
+
+			Assert.AreEqual(GetExpectedCurrentOpacityStatus(0.7), initialOpacity);
+			Assert.AreEqual(GetExpectedCurrentOpacityStatus(1), secondOpacity);
+			Assert.AreEqual(GetExpectedCurrentOpacityStatus(0), thirdOpacity);
+		}
+
+		string ChangeOpacityAndGetCurrentStatus()
+		{
+			App.Tap(buttonId);
+
+			return GetCurrentOpacityStatus();
+		}
+
+		string GetCurrentOpacityStatus() => App.Query(x => x.Marked("CurrentOpacity"))[0].Text;
+
+		string GetExpectedCurrentOpacityStatus(double expectedOpacity) => $"Current opacity is {expectedOpacity}";
+	}
+}

--- a/src/Controls/tests/UITests/Tests/Issues/Issue15357.cs
+++ b/src/Controls/tests/UITests/Tests/Issues/Issue15357.cs
@@ -1,0 +1,46 @@
+﻿using Microsoft.Maui.Appium;
+using NUnit.Framework;
+
+namespace Microsoft.Maui.AppiumTests.Issues
+{
+	public class Issue15357 : _IssuesUITest
+	{
+		private string buttonId = "ButtonClick";
+
+		public Issue15357(TestDevice device) : base(device)
+		{ 
+		}
+
+		public override string Issue => "IsVisible binding not showing items again if Shadow is set";
+
+		[Test]
+		public void WhenTapButtonThenListViewsChangesVisibility()
+		{
+			App.WaitForElement(buttonId);
+
+			var initialStatus = GetStatus();
+			var secondStatus = TapButtonAndGetStatus();
+			var thirdStatus = TapButtonAndGetStatus();
+
+			Assert.AreEqual(GetExpectedButtonStatus(isVisible: true), initialStatus);
+			Assert.AreEqual(GetExpectedButtonStatus(isVisible: false), secondStatus);
+			Assert.AreEqual(GetExpectedButtonStatus(isVisible: true), thirdStatus);
+		}
+
+		string TapButtonAndGetStatus()
+		{
+			App.Tap(buttonId);
+
+			return GetStatus();
+		}
+
+		string GetStatus() => App.Query(x => x.Marked("LabelStatus"))[0].Text;
+
+		string GetExpectedButtonStatus(bool isVisible)
+		{
+			var buttonStatus = isVisible ? "is visible" : "is not visible";
+
+			return $"Test Button {buttonStatus}";
+		}
+	}
+}

--- a/src/Controls/tests/UITests/Tests/Issues/Issue15826.cs
+++ b/src/Controls/tests/UITests/Tests/Issues/Issue15826.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.Maui.Appium;
+using NUnit.Framework;
+
+namespace Microsoft.Maui.AppiumTests.Issues
+{
+	public class Issue15826 : _IssuesUITest
+	{
+		private string buttonId = "Swap";
+
+		public Issue15826(TestDevice device) : base(device)
+		{ 
+		}
+
+		public override string Issue => "ListView visibility doesn't work well";
+
+		[Test]
+		public void WhenTapButtonThenListViewsChangesVisibility()
+		{
+			App.WaitForElement(buttonId);
+
+			var initialStatus = GetStatus();
+			var secondStatus = TapButtonAndGetStatus();
+			var thirdStatus = TapButtonAndGetStatus();
+
+			Assert.AreEqual(GetExpectedListsStatus("List 1"), initialStatus);
+			Assert.AreEqual(GetExpectedListsStatus("List 2"), secondStatus);
+			Assert.AreEqual(GetExpectedListsStatus("List 1"), thirdStatus);
+		}
+
+		string TapButtonAndGetStatus()
+		{
+			App.Tap(buttonId);
+
+			return GetStatus();
+		}
+
+		string GetStatus() => App.Query(x => x.Marked("LabelStatus"))[0].Text;
+
+		string GetExpectedListsStatus(string listName) => $"{listName} is now visible";
+	}
+}

--- a/src/Core/src/Handlers/View/ViewHandler.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.cs
@@ -204,8 +204,8 @@ namespace Microsoft.Maui.Handlers
 		{
 			if (handler.HasContainer)
 				((PlatformView?)handler.ContainerView)?.UpdateVisibility(view);
-			else
-				((PlatformView?)handler.PlatformView)?.UpdateVisibility(view);
+
+			((PlatformView?)handler.PlatformView)?.UpdateVisibility(view);
 		}
 
 		public static void MapBackground(IViewHandler handler, IView view)
@@ -234,7 +234,11 @@ namespace Microsoft.Maui.Handlers
 		public static void MapOpacity(IViewHandler handler, IView view)
 		{
 			if (handler.HasContainer)
+			{
 				((PlatformView?)handler.ContainerView)?.UpdateOpacity(view);
+				//We don't want the control opacity to be reduced by the container one, so we always set 100% to the control if it has a container
+				((PlatformView?)handler.PlatformView)?.UpdateOpacity(1);
+			}
 			else
 				((PlatformView?)handler.PlatformView)?.UpdateOpacity(view);
 		}

--- a/src/Core/src/Platform/Android/ViewExtensions.cs
+++ b/src/Core/src/Platform/Android/ViewExtensions.cs
@@ -276,10 +276,9 @@ namespace Microsoft.Maui.Platform
 			}
 		}
 
-		public static void UpdateOpacity(this AView platformView, IView view)
-		{
-			platformView.Alpha = (float)view.Opacity;
-		}
+		public static void UpdateOpacity(this AView platformView, IView view) => platformView.UpdateOpacity(view.Opacity);
+
+		internal static void UpdateOpacity(this AView platformView, double opacity) => platformView.Alpha = (float)opacity;
 
 		public static void UpdateFlowDirection(this AView platformView, IView view)
 		{

--- a/src/Core/src/Platform/Standard/ViewExtensions.cs
+++ b/src/Core/src/Platform/Standard/ViewExtensions.cs
@@ -29,6 +29,8 @@ namespace Microsoft.Maui.Platform
 
 		public static void UpdateOpacity(this object platformView, IView view) { }
 
+		internal static void UpdateOpacity(this object platformView, double opacity) { }
+
 		public static void UpdateSemantics(this object platformView, IView view) { }
 
 		public static void UpdateFlowDirection(this object platformView, IView view) { }

--- a/src/Core/src/Platform/Tizen/ViewExtensions.cs
+++ b/src/Core/src/Platform/Tizen/ViewExtensions.cs
@@ -134,10 +134,9 @@ namespace Microsoft.Maui.Platform
 				wrapperView.Border = border.Border;
 		}
 
-		public static void UpdateOpacity(this NView platformView, IView view)
-		{
-			platformView.Opacity = (float)view.Opacity;
-		}
+		public static void UpdateOpacity(this NView platformView, IView view) => platformView.UpdateOpacity(view.Opacity);
+
+		internal static void UpdateOpacity(this NView platformView, double opacity) => platformView.Opacity = (float)opacity;
 
 		public static void UpdateClip(this NView platformView, IView view)
 		{

--- a/src/Core/src/Platform/Windows/ViewExtensions.cs
+++ b/src/Core/src/Platform/Windows/ViewExtensions.cs
@@ -92,8 +92,12 @@ namespace Microsoft.Maui.Platform
 
 		public static void UpdateOpacity(this FrameworkElement platformView, IView view)
 		{
-			platformView.Opacity = view.Visibility == Visibility.Hidden ? 0 : view.Opacity;
+			var opacity = view.Visibility == Visibility.Hidden ? 0 : view.Opacity;
+
+			platformView.UpdateOpacity(opacity);
 		}
+
+		internal static void UpdateOpacity(this FrameworkElement platformView, double opacity) => platformView.Opacity = (float)opacity;
 
 		public static void UpdateBackground(this ContentPanel platformView, IBorderStroke border)
 		{

--- a/src/Core/src/Platform/iOS/ViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/ViewExtensions.cs
@@ -195,10 +195,9 @@ namespace Microsoft.Maui.Platform
 			}
 		}
 
-		public static void UpdateOpacity(this UIView platformView, IView view)
-		{
-			platformView.Alpha = (float)view.Opacity;
-		}
+		public static void UpdateOpacity(this UIView platformView, IView view) => platformView.UpdateOpacity(view.Opacity);
+
+		internal static void UpdateOpacity(this UIView platformView, double opacity) => platformView.Alpha = (float)opacity;
 
 		public static void UpdateAutomationId(this UIView platformView, IView view) =>
 			platformView.AccessibilityIdentifier = view.AutomationId;


### PR DESCRIPTION
### Description of Change

Visibility and Opacity settings were not working correctly when the control was inside a container.
For the case of visibility, it was only being set for the container when it needed to be set for both the container and the control.
For the case of opacity, it was also only being set for the container, which could reduce the opacity of the control as a side effect because it's a value affected by its parent value. In this case, we need to ensure the control has 100% opacity so it gets and uses the correct value of the container.

Also added Appium tests to test both issues.

fixes #15826
fixes #15357
fixes #16718
fixes #10303
fixes #16729
fixes #11499
fixes #12211