### PR TITLE
Fix so updating FlyoutItemIsVisible hides/shows shell menu item

### DIFF
--- a/src/Controls/src/Core/Shell/MenuShellItem.cs
+++ b/src/Controls/src/Core/Shell/MenuShellItem.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Maui.Controls
 				Shell.SetMenuItemTemplate(this, Shell.GetMenuItemTemplate(MenuItem));
 			else if (e.PropertyName == TitleProperty.PropertyName)
 				OnPropertyChanged(MenuItem.TextProperty.PropertyName);
-			else if (e.PropertyName == FlyoutItem.IsVisibleProperty.PropertyName)
+			else if (e.PropertyName == Shell.FlyoutItemIsVisibleProperty.PropertyName)
 				Shell.SetFlyoutItemIsVisible(this, Shell.GetFlyoutItemIsVisible(MenuItem));
 		}
 
@@ -40,6 +40,8 @@ namespace Microsoft.Maui.Controls
 			base.OnPropertyChanged(propertyName);
 			if (propertyName == nameof(Title))
 				OnPropertyChanged(nameof(Text));
+			else if (propertyName == Shell.FlyoutItemIsVisibleProperty.PropertyName && MenuItem != null)
+				Shell.SetFlyoutItemIsVisible(MenuItem, Shell.GetFlyoutItemIsVisible(this));
 		}
 
 		public MenuItem MenuItem { get; }

--- a/src/Controls/tests/Core.UnitTests/ShellTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellTests.cs
@@ -757,6 +757,25 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact]
+		public void FlyoutMenuItemIsVisibleSynchronized()
+		{
+			Shell shell = new Shell();
+			ContentPage page = new ContentPage();
+			shell.Items.Add(CreateShellItem(page));
+
+			var menuItem = new MenuItem();
+			Shell.SetFlyoutItemIsVisible(menuItem, false);
+			var menuShellItem = new MenuShellItem(menuItem);
+			shell.Items.Add(menuShellItem);
+			
+			Shell.SetFlyoutItemIsVisible(menuItem, true);
+			Assert.True(Shell.GetFlyoutItemIsVisible(menuShellItem), "If menuItem visibility changes, menuShellItem visibility should change as well");
+			
+			Shell.SetFlyoutItemIsVisible(menuShellItem, false);
+			Assert.False(Shell.GetFlyoutItemIsVisible(menuItem), "If menuShellItem visibility changes, menuItem visibility should change as well");
+		}
+
+		[Fact]
 		public async Task TitleViewLogicalChild()
 		{
 			Shell shell = new Shell();


### PR DESCRIPTION
MenuShellItem wraps a MenuItem. Shell related properties should be synchronized between the two objects, always the same values. Add code so that FlyoutItemIsVisible is also synchronized. Most properties are synchroned via bindings, but FlyoutItemIsVisible is an attached property so we need to have code that runs on property changes instead.

Fixes issue #10468

Note that normally the MenuItem is specified in XAML while MenuShellItem is accessed in code behind, thus the need to synchronize when FlyoutItemIsVisible is initialized in XAML then updated later via code behind, like in the bug.

