### PR TITLE
Avoid NRE if no shell items are visible

### DIFF
--- a/src/Controls/src/Core/Handlers/Shell/Windows/ShellView.cs
+++ b/src/Controls/src/Core/Handlers/Shell/Windows/ShellView.cs
@@ -195,12 +195,22 @@ namespace Microsoft.Maui.Controls.Platform
 		{
 			var navItems = FlyoutItems.OfType<NavigationViewItemViewModel>();
 
+			// newItem can be null in fringe scenarios where all items are hidden. Do
+			// nothing in that case, to avoid a NullReferenceException
+			if (newItem == null)
+			{
+				SelectedItem = null;
+				return;
+			}
+
 			// Implicit items aren't items that are surfaced to the user 
 			// or data structures. So, we just want to find the element
 			// the user defined on Shell
 			if (Routing.IsImplicit(newItem))
 			{
-				if (Routing.IsImplicit(newItem.CurrentItem))
+				if (newItem.CurrentItem == null)
+					SelectedItem = null;
+				else if (Routing.IsImplicit(newItem.CurrentItem))
 					SelectedItem = navItems.GetWithData(newItem.CurrentItem.CurrentItem);
 				else
 					SelectedItem = navItems.GetWithData(newItem.CurrentItem);


### PR DESCRIPTION
Fixes #16940

Add null checks to avoid an NRE if no shell items are currently visible. This can happen if for some strange reason the user has an empty <Shell> element in the XAML, with no children. It can also happen in a transient states where certain items are hidden, others are about to be shown, and between those two things happening no items are visible - that's the case with bug #16940

However, the app gets into this state it's better not to crash. With the null checks present, the UI behaves reasonably (at least on Windows) - the app window is blank with no current shell item selected.