### PR TITLE
[WinUI] Fix exception when adding items to a linear layout CollectionView

### DIFF
--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issues16320.xaml
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issues16320.xaml
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Maui.Controls.Sample.Issues.Issue16320">
+    <Grid RowDefinitions="*, *">
+        <Grid RowDefinitions="Auto, *">
+            <CollectionView x:Name="cv1" AutomationId="cv" BackgroundColor="LightSalmon" >
+                <CollectionView.ItemTemplate>
+                    <DataTemplate>
+                        <Label Text="{Binding .}" AutomationId="{Binding .}" />
+                    </DataTemplate>
+                </CollectionView.ItemTemplate>
+                <CollectionView.ItemsLayout>
+                    <LinearItemsLayout Orientation="Horizontal" />
+                </CollectionView.ItemsLayout>
+            </CollectionView>
+            <Label Text="A Label under the CollectionView" Grid.Row="1" />
+        </Grid>
+        <Button Grid.Row="1" Text="Add" AutomationId="Add" Clicked="ButtonAdd_Clicked" HorizontalOptions="End" VerticalOptions="Start" />
+    </Grid>
+</ContentPage>

--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issues16320.xaml.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issues16320.xaml.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections.ObjectModel;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+
+namespace Maui.Controls.Sample.Issues
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	[Issue(IssueTracker.Github, 16320, "Adding an item to a CollectionView with linear layout crashes", PlatformAffected.UWP)]
+	public partial class Issue16320 : ContentPage
+	{
+		private ObservableCollection<string> items = new();
+
+		public Issue16320()
+		{
+			InitializeComponent();
+
+			items.Add("item: " + items.Count);
+
+			cv1.ItemsSource = items;
+		}
+
+		private void ButtonAdd_Clicked(object sender, System.EventArgs e)
+		{
+			items.Add("item: " + items.Count);
+		}
+	}
+}

--- a/src/Controls/src/Core/Platform/Windows/CollectionView/FormsGridView.cs
+++ b/src/Controls/src/Core/Platform/Windows/CollectionView/FormsGridView.cs
@@ -102,6 +102,9 @@ namespace Microsoft.Maui.Controls.Platform
 
 		void UpdateItemSize()
 		{
+			// Avoid the ItemWrapGrid grow beyond what this grid view is configured to
+			_wrapGrid.MaximumRowsOrColumns = Span;
+
 			if (_orientation == Orientation.Horizontal)
 			{
 				_wrapGrid.ItemHeight = _wrapGrid.ActualHeight / Span;

--- a/src/Controls/tests/UITests/Tests/Issues/Issue16320.cs
+++ b/src/Controls/tests/UITests/Tests/Issues/Issue16320.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.Maui.Appium;
+using NUnit.Framework;
+
+namespace Microsoft.Maui.AppiumTests.Issues
+{
+	public class Issue16320 : _IssuesUITest
+	{
+		public Issue16320(TestDevice device)
+			: base(device)
+		{ }
+
+		public override string Issue => "Adding an item to a CollectionView with linear layout crashes";
+
+		[Test]
+		public void Issue16320Test()
+		{
+			App.Tap("Add");
+
+			Assert.NotNull(App.WaitForElement("item: 1"));
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change

When having a `CollectionView` with a Linear horizontal layout in a `Grid` with a row definition set to Auto, adding an item would make rezising the inner `ItemsWrapGrid` enter in an inifinite loop making the height grow indefinetly. The same would happen for for vertical/column/width.

The problem was that when using a linear layout the wrap grid should never have more than one row (it shouldn't wrap the items after exceding its size), regardless of the space available, but the wrap grid was not aware of this. The cycle happened when the wrap grid total height (or width, depending on the orientation) increased, so then we update the item height, but as span is 1 because of linear layout, we ended up setting the total height as item height, forcing the wrap grid to grow again.

The fix is simply configure the `ItemsWrapGrid` to restrict the number of rows/columns it can have based on what's set for Span.

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/16320

Sample provided in the issue after this fix:
![image](https://github.com/dotnet/maui/assets/3286258/aa8db6e4-73ad-4312-8038-bd43a5ecb0ea)


