### PR TITLE
Add SetupContent/UnhookContent to WinUI ListView.CellControl

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/Windows/CellControl.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/Windows/CellControl.cs
@@ -418,6 +418,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			{
 				oldCell.PropertyChanged -= _propertyChangedHandler;
 				oldCell.SendDisappearing();
+				(_listView.Value as ITemplatedItemsView<Cell>)?.UnhookContent(oldCell);
 			}
 
 			if (newCell != null)
@@ -427,7 +428,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				UpdateContent(newCell);
 				UpdateFlowDirection(newCell);
 				SetupContextMenu();
-
+				(_listView.Value as ITemplatedItemsView<Cell>)?.SetupContent(newCell, -1);
 				// 🚀 make sure we do not subscribe twice (OnLoaded!)
 				newCell.PropertyChanged -= _propertyChangedHandler;
 				newCell.PropertyChanged += _propertyChangedHandler;


### PR DESCRIPTION
Fixes https://github.com/dotnet/maui/issues/13900

![image](https://github.com/dotnet/maui/assets/898335/9992faf0-5c7e-4b0c-8e42-bd5daf24bf4b)

ListView has an internal VisualChildren list that IVisualTreeElement exposes. Android, iOS, and Catalyst call into ListView to add and remove items from this list, but WinUI did not. This is an attempt to add that support so those items appear. Having them appear in this list should allow for XAML Hot Reload to show those items in the Live Visual Tree correctly and for them to be hot reloadable.
