### PR TITLE
Revert "Remove TargetIdiom"

### DIFF
--- a/src/Controls/src/Core/Device.cs
+++ b/src/Controls/src/Core/Device.cs
@@ -48,6 +48,27 @@ namespace Microsoft.Maui.Controls
 		[Obsolete("Use Microsoft.Maui.Devices.DevicePlatform.tvOS instead.")]
 		public const string tvOS = "tvOS";
 
+		/// <include file="../../docs/Microsoft.Maui.Controls/Device.xml" path="//Member[@MemberName='Idiom']/Docs/*" />
+		[Obsolete("Use Microsoft.Maui.Devices.DeviceInfo.Idiom instead.")]
+		public static TargetIdiom Idiom
+		{
+			get
+			{
+				var idiom = DeviceInfo.Idiom;
+				if (idiom == DeviceIdiom.Tablet)
+					return TargetIdiom.Tablet;
+				if (idiom == DeviceIdiom.Phone)
+					return TargetIdiom.Phone;
+				if (idiom == DeviceIdiom.Desktop)
+					return TargetIdiom.Desktop;
+				if (idiom == DeviceIdiom.TV)
+					return TargetIdiom.TV;
+				if (idiom == DeviceIdiom.Watch)
+					return TargetIdiom.Watch;
+				return TargetIdiom.Unsupported;
+			}
+		}
+
 		/// <include file="../../docs/Microsoft.Maui.Controls/Device.xml" path="//Member[@MemberName='RuntimePlatform']/Docs/*" />
 		[Obsolete("Use Microsoft.Maui.Devices.DeviceInfo.Platform instead.")]
 		public static string RuntimePlatform => DeviceInfo.Platform.ToString();

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -86,14 +86,6 @@ override Microsoft.Maui.Controls.SearchBar.IsEnabledCore.get -> bool
 *REMOVED*Microsoft.Maui.Controls.OpenGLView.HasRenderLoop.get -> bool
 *REMOVED*Microsoft.Maui.Controls.OpenGLView.HasRenderLoop.set -> void
 *REMOVED*Microsoft.Maui.Controls.OpenGLView.OpenGLView() -> void
-*REMOVED*Microsoft.Maui.Controls.TargetIdiom
-*REMOVED*Microsoft.Maui.Controls.TargetIdiom.Desktop = 3 -> Microsoft.Maui.Controls.TargetIdiom
-*REMOVED*Microsoft.Maui.Controls.TargetIdiom.Phone = 1 -> Microsoft.Maui.Controls.TargetIdiom
-*REMOVED*Microsoft.Maui.Controls.TargetIdiom.Tablet = 2 -> Microsoft.Maui.Controls.TargetIdiom
-*REMOVED*Microsoft.Maui.Controls.TargetIdiom.TV = 4 -> Microsoft.Maui.Controls.TargetIdiom
-*REMOVED*Microsoft.Maui.Controls.TargetIdiom.Unsupported = 0 -> Microsoft.Maui.Controls.TargetIdiom
-*REMOVED*Microsoft.Maui.Controls.TargetIdiom.Watch = 5 -> Microsoft.Maui.Controls.TargetIdiom
-*REMOVED*static Microsoft.Maui.Controls.Device.Idiom.get -> Microsoft.Maui.Controls.TargetIdiom
 *REMOVED*Microsoft.Maui.Controls.Application.SavePropertiesAsync() -> System.Threading.Tasks.Task!
 *REMOVED*Microsoft.Maui.Controls.Application.Properties.get -> System.Collections.Generic.IDictionary<string!, object!>!
 Microsoft.Maui.Controls.IValueConverter.Convert(object? value, System.Type! targetType, object? parameter, System.Globalization.CultureInfo! culture) -> object?

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -95,14 +95,6 @@ override Microsoft.Maui.Controls.SearchBar.IsEnabledCore.get -> bool
 *REMOVED*Microsoft.Maui.Controls.OpenGLView.HasRenderLoop.get -> bool
 *REMOVED*Microsoft.Maui.Controls.OpenGLView.HasRenderLoop.set -> void
 *REMOVED*Microsoft.Maui.Controls.OpenGLView.OpenGLView() -> void
-*REMOVED*Microsoft.Maui.Controls.TargetIdiom
-*REMOVED*Microsoft.Maui.Controls.TargetIdiom.Desktop = 3 -> Microsoft.Maui.Controls.TargetIdiom
-*REMOVED*Microsoft.Maui.Controls.TargetIdiom.Phone = 1 -> Microsoft.Maui.Controls.TargetIdiom
-*REMOVED*Microsoft.Maui.Controls.TargetIdiom.Tablet = 2 -> Microsoft.Maui.Controls.TargetIdiom
-*REMOVED*Microsoft.Maui.Controls.TargetIdiom.TV = 4 -> Microsoft.Maui.Controls.TargetIdiom
-*REMOVED*Microsoft.Maui.Controls.TargetIdiom.Unsupported = 0 -> Microsoft.Maui.Controls.TargetIdiom
-*REMOVED*Microsoft.Maui.Controls.TargetIdiom.Watch = 5 -> Microsoft.Maui.Controls.TargetIdiom
-*REMOVED*static Microsoft.Maui.Controls.Device.Idiom.get -> Microsoft.Maui.Controls.TargetIdiom
 *REMOVED*Microsoft.Maui.Controls.Application.SavePropertiesAsync() -> System.Threading.Tasks.Task!
 *REMOVED*Microsoft.Maui.Controls.Application.Properties.get -> System.Collections.Generic.IDictionary<string!, object!>!
 Microsoft.Maui.Controls.IValueConverter.Convert(object? value, System.Type! targetType, object? parameter, System.Globalization.CultureInfo! culture) -> object?

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -91,14 +91,6 @@ override Microsoft.Maui.Controls.SearchBar.IsEnabledCore.get -> bool
 *REMOVED*Microsoft.Maui.Controls.OpenGLView.HasRenderLoop.get -> bool
 *REMOVED*Microsoft.Maui.Controls.OpenGLView.HasRenderLoop.set -> void
 *REMOVED*Microsoft.Maui.Controls.OpenGLView.OpenGLView() -> void
-*REMOVED*Microsoft.Maui.Controls.TargetIdiom
-*REMOVED*Microsoft.Maui.Controls.TargetIdiom.Desktop = 3 -> Microsoft.Maui.Controls.TargetIdiom
-*REMOVED*Microsoft.Maui.Controls.TargetIdiom.Phone = 1 -> Microsoft.Maui.Controls.TargetIdiom
-*REMOVED*Microsoft.Maui.Controls.TargetIdiom.Tablet = 2 -> Microsoft.Maui.Controls.TargetIdiom
-*REMOVED*Microsoft.Maui.Controls.TargetIdiom.TV = 4 -> Microsoft.Maui.Controls.TargetIdiom
-*REMOVED*Microsoft.Maui.Controls.TargetIdiom.Unsupported = 0 -> Microsoft.Maui.Controls.TargetIdiom
-*REMOVED*Microsoft.Maui.Controls.TargetIdiom.Watch = 5 -> Microsoft.Maui.Controls.TargetIdiom
-*REMOVED*static Microsoft.Maui.Controls.Device.Idiom.get -> Microsoft.Maui.Controls.TargetIdiom
 *REMOVED*Microsoft.Maui.Controls.Application.SavePropertiesAsync() -> System.Threading.Tasks.Task!
 *REMOVED*Microsoft.Maui.Controls.Application.Properties.get -> System.Collections.Generic.IDictionary<string!, object!>!
 Microsoft.Maui.Controls.IValueConverter.Convert(object? value, System.Type! targetType, object? parameter, System.Globalization.CultureInfo! culture) -> object?

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -70,14 +70,6 @@ override Microsoft.Maui.Controls.SearchBar.IsEnabledCore.get -> bool
 *REMOVED*Microsoft.Maui.Controls.OpenGLView.HasRenderLoop.get -> bool
 *REMOVED*Microsoft.Maui.Controls.OpenGLView.HasRenderLoop.set -> void
 *REMOVED*Microsoft.Maui.Controls.OpenGLView.OpenGLView() -> void
-*REMOVED*Microsoft.Maui.Controls.TargetIdiom
-*REMOVED*Microsoft.Maui.Controls.TargetIdiom.Desktop = 3 -> Microsoft.Maui.Controls.TargetIdiom
-*REMOVED*Microsoft.Maui.Controls.TargetIdiom.Phone = 1 -> Microsoft.Maui.Controls.TargetIdiom
-*REMOVED*Microsoft.Maui.Controls.TargetIdiom.Tablet = 2 -> Microsoft.Maui.Controls.TargetIdiom
-*REMOVED*Microsoft.Maui.Controls.TargetIdiom.TV = 4 -> Microsoft.Maui.Controls.TargetIdiom
-*REMOVED*Microsoft.Maui.Controls.TargetIdiom.Unsupported = 0 -> Microsoft.Maui.Controls.TargetIdiom
-*REMOVED*Microsoft.Maui.Controls.TargetIdiom.Watch = 5 -> Microsoft.Maui.Controls.TargetIdiom
-*REMOVED*static Microsoft.Maui.Controls.Device.Idiom.get -> Microsoft.Maui.Controls.TargetIdiom
 *REMOVED*Microsoft.Maui.Controls.Application.SavePropertiesAsync() -> System.Threading.Tasks.Task!
 *REMOVED*Microsoft.Maui.Controls.Application.Properties.get -> System.Collections.Generic.IDictionary<string!, object!>!
 Microsoft.Maui.Controls.IValueConverter.Convert(object? value, System.Type! targetType, object? parameter, System.Globalization.CultureInfo! culture) -> object?

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -95,14 +95,6 @@ override Microsoft.Maui.Controls.SearchBar.IsEnabledCore.get -> bool
 *REMOVED*Microsoft.Maui.Controls.OpenGLView.HasRenderLoop.get -> bool
 *REMOVED*Microsoft.Maui.Controls.OpenGLView.HasRenderLoop.set -> void
 *REMOVED*Microsoft.Maui.Controls.OpenGLView.OpenGLView() -> void
-*REMOVED*Microsoft.Maui.Controls.TargetIdiom
-*REMOVED*Microsoft.Maui.Controls.TargetIdiom.Desktop = 3 -> Microsoft.Maui.Controls.TargetIdiom
-*REMOVED*Microsoft.Maui.Controls.TargetIdiom.Phone = 1 -> Microsoft.Maui.Controls.TargetIdiom
-*REMOVED*Microsoft.Maui.Controls.TargetIdiom.Tablet = 2 -> Microsoft.Maui.Controls.TargetIdiom
-*REMOVED*Microsoft.Maui.Controls.TargetIdiom.TV = 4 -> Microsoft.Maui.Controls.TargetIdiom
-*REMOVED*Microsoft.Maui.Controls.TargetIdiom.Unsupported = 0 -> Microsoft.Maui.Controls.TargetIdiom
-*REMOVED*Microsoft.Maui.Controls.TargetIdiom.Watch = 5 -> Microsoft.Maui.Controls.TargetIdiom
-*REMOVED*static Microsoft.Maui.Controls.Device.Idiom.get -> Microsoft.Maui.Controls.TargetIdiom
 *REMOVED*Microsoft.Maui.Controls.Application.SavePropertiesAsync() -> System.Threading.Tasks.Task!
 *REMOVED*Microsoft.Maui.Controls.Application.Properties.get -> System.Collections.Generic.IDictionary<string!, object!>!
 Microsoft.Maui.Controls.IValueConverter.Convert(object? value, System.Type! targetType, object? parameter, System.Globalization.CultureInfo! culture) -> object?

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -77,14 +77,6 @@ override Microsoft.Maui.Controls.SearchBar.IsEnabledCore.get -> bool
 *REMOVED*Microsoft.Maui.Controls.OpenGLView.HasRenderLoop.get -> bool
 *REMOVED*Microsoft.Maui.Controls.OpenGLView.HasRenderLoop.set -> void
 *REMOVED*Microsoft.Maui.Controls.OpenGLView.OpenGLView() -> void
-*REMOVED*Microsoft.Maui.Controls.TargetIdiom
-*REMOVED*Microsoft.Maui.Controls.TargetIdiom.Desktop = 3 -> Microsoft.Maui.Controls.TargetIdiom
-*REMOVED*Microsoft.Maui.Controls.TargetIdiom.Phone = 1 -> Microsoft.Maui.Controls.TargetIdiom
-*REMOVED*Microsoft.Maui.Controls.TargetIdiom.Tablet = 2 -> Microsoft.Maui.Controls.TargetIdiom
-*REMOVED*Microsoft.Maui.Controls.TargetIdiom.TV = 4 -> Microsoft.Maui.Controls.TargetIdiom
-*REMOVED*Microsoft.Maui.Controls.TargetIdiom.Unsupported = 0 -> Microsoft.Maui.Controls.TargetIdiom
-*REMOVED*Microsoft.Maui.Controls.TargetIdiom.Watch = 5 -> Microsoft.Maui.Controls.TargetIdiom
-*REMOVED*static Microsoft.Maui.Controls.Device.Idiom.get -> Microsoft.Maui.Controls.TargetIdiom
 *REMOVED*Microsoft.Maui.Controls.Application.SavePropertiesAsync() -> System.Threading.Tasks.Task!
 *REMOVED*Microsoft.Maui.Controls.Application.Properties.get -> System.Collections.Generic.IDictionary<string!, object!>!
 Microsoft.Maui.Controls.IValueConverter.Convert(object? value, System.Type! targetType, object? parameter, System.Globalization.CultureInfo! culture) -> object?

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -100,14 +100,6 @@ override Microsoft.Maui.Controls.SearchBar.IsEnabledCore.get -> bool
 *REMOVED*Microsoft.Maui.Controls.OpenGLView.HasRenderLoop.get -> bool
 *REMOVED*Microsoft.Maui.Controls.OpenGLView.HasRenderLoop.set -> void
 *REMOVED*Microsoft.Maui.Controls.OpenGLView.OpenGLView() -> void
-*REMOVED*Microsoft.Maui.Controls.TargetIdiom
-*REMOVED*Microsoft.Maui.Controls.TargetIdiom.Desktop = 3 -> Microsoft.Maui.Controls.TargetIdiom
-*REMOVED*Microsoft.Maui.Controls.TargetIdiom.Phone = 1 -> Microsoft.Maui.Controls.TargetIdiom
-*REMOVED*Microsoft.Maui.Controls.TargetIdiom.Tablet = 2 -> Microsoft.Maui.Controls.TargetIdiom
-*REMOVED*Microsoft.Maui.Controls.TargetIdiom.TV = 4 -> Microsoft.Maui.Controls.TargetIdiom
-*REMOVED*Microsoft.Maui.Controls.TargetIdiom.Unsupported = 0 -> Microsoft.Maui.Controls.TargetIdiom
-*REMOVED*Microsoft.Maui.Controls.TargetIdiom.Watch = 5 -> Microsoft.Maui.Controls.TargetIdiom
-*REMOVED*static Microsoft.Maui.Controls.Device.Idiom.get -> Microsoft.Maui.Controls.TargetIdiom
 *REMOVED*Microsoft.Maui.Controls.Application.SavePropertiesAsync() -> System.Threading.Tasks.Task!
 *REMOVED*Microsoft.Maui.Controls.Application.Properties.get -> System.Collections.Generic.IDictionary<string!, object!>!
 Microsoft.Maui.Controls.IValueConverter.Convert(object? value, System.Type! targetType, object? parameter, System.Globalization.CultureInfo! culture) -> object?

--- a/src/Controls/src/Core/TargetIdiom.cs
+++ b/src/Controls/src/Core/TargetIdiom.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace Microsoft.Maui.Controls
+{
+	/// <include file="../../docs/Microsoft.Maui.Controls/TargetIdiom.xml" path="Type[@FullName='Microsoft.Maui.Controls.TargetIdiom']/Docs/*" />
+	[Obsolete("Use Microsoft.Maui.Devices.DeviceIdiom instead.")]
+	public enum TargetIdiom
+	{
+		/// <include file="../../docs/Microsoft.Maui.Controls/TargetIdiom.xml" path="//Member[@MemberName='Unsupported']/Docs/*" />
+		Unsupported,
+		/// <include file="../../docs/Microsoft.Maui.Controls/TargetIdiom.xml" path="//Member[@MemberName='Phone']/Docs/*" />
+		Phone,
+		/// <include file="../../docs/Microsoft.Maui.Controls/TargetIdiom.xml" path="//Member[@MemberName='Tablet']/Docs/*" />
+		Tablet,
+		/// <include file="../../docs/Microsoft.Maui.Controls/TargetIdiom.xml" path="//Member[@MemberName='Desktop']/Docs/*" />
+		Desktop,
+		/// <include file="../../docs/Microsoft.Maui.Controls/TargetIdiom.xml" path="//Member[@MemberName='TV']/Docs/*" />
+		TV,
+		/// <include file="../../docs/Microsoft.Maui.Controls/TargetIdiom.xml" path="//Member[@MemberName='Watch']/Docs/*" />
+		Watch
+	}
+}


### PR DESCRIPTION
Reverts dotnet/maui#13090

This makes migration a bit harder, and we don't want that.