### PR TITLE
Present to UIWindow associated with passed in page

### DIFF
--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issues16321.xaml
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issues16321.xaml
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Maui.Controls.Sample.Issues.Issue16321">
+    <VerticalStackLayout>
+        <Label Text="After clicking each button you should see an alert"></Label>
+        <Button Text="Open Alert With Modals" AutomationId="OpenAlertWithModals" Clicked="OpenAlertWithModals"></Button>
+        <Button Text="Open Alert With New UIWindow" AutomationId="OpenAlertWithNewUIWindow" Clicked="OpenAlertWithNewUIWindow"></Button>
+    </VerticalStackLayout>
+</ContentPage>

--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issues16321.xaml.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issues16321.xaml.cs
@@ -3,11 +3,11 @@ using Microsoft.Maui.Controls.Xaml;
 using Microsoft.Maui.Platform;
 using Microsoft.Maui;
 using System.Linq;
-using CoreGraphics;
 using System;
 
 #if IOS
 using UIKit;
+using CoreGraphics;
 #endif
 
 namespace Maui.Controls.Sample.Issues

--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issues16321.xaml.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issues16321.xaml.cs
@@ -1,0 +1,76 @@
+﻿using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+using Microsoft.Maui.Platform;
+using Microsoft.Maui;
+using System.Linq;
+using CoreGraphics;
+using System;
+
+#if IOS
+using UIKit;
+#endif
+
+namespace Maui.Controls.Sample.Issues
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	[Issue(IssueTracker.Github, 16321, "Alerts Open on top of current presented view", PlatformAffected.All)]
+	public partial class Issue16321 : ContentPage
+	{
+		public Issue16321()
+		{
+			InitializeComponent();
+		}
+
+		async void OpenAlertWithModals(System.Object sender, System.EventArgs e)
+		{
+			await Navigation.PushModalAsync(new ContentPage());
+			await Navigation.PushModalAsync(new ContentPage());
+			await this.DisplayAlert("hello", "message", "Cancel");
+			await Navigation.PopModalAsync();
+			await Navigation.PopModalAsync();
+		}
+
+#if IOS
+		async void OpenAlertWithNewUIWindow(System.Object sender, System.EventArgs e)
+		{
+			var uIWindow = new UIWindow();
+			var keyWindow = (this.Window.Handler.PlatformView as UIWindow);
+			if (keyWindow?.WindowLevel == UIWindowLevel.Normal)
+				keyWindow.WindowLevel = -1;
+
+			var page = new ContentPage();
+			this.AddLogicalChild(page);
+			var handler = page.ToHandler(this.Handler.MauiContext);
+			var popupVC = handler.ViewController;
+
+			uIWindow.RootViewController = new UIViewController();
+			uIWindow.WindowLevel = UIWindowLevel.Normal;
+			uIWindow.MakeKeyAndVisible();
+
+			popupVC.ModalPresentationStyle = UIModalPresentationStyle.OverCurrentContext;
+			popupVC.ModalTransitionStyle = UIModalTransitionStyle.CoverVertical;
+			await uIWindow.RootViewController.PresentViewControllerAsync(popupVC, false);
+
+			await page.DisplayAlert("hello", "message", "Cancel");
+
+			var rvc = uIWindow.RootViewController;
+
+			if (rvc != null)
+			{
+				await rvc.DismissViewControllerAsync(false);
+				rvc.Dispose();
+			}
+
+			uIWindow.RootViewController = null;
+			uIWindow.Hidden = true;
+			keyWindow.WindowLevel = UIWindowLevel.Normal;
+			this.RemoveLogicalChild(page);
+		}
+#else
+		async void OpenAlertWithNewUIWindow(System.Object sender, System.EventArgs e)
+		{
+			await this.DisplayAlert("hello", "message", "Cancel");
+		}
+#endif
+	}
+}

--- a/src/Controls/tests/UITests/Tests/Issues/Issue16321.cs
+++ b/src/Controls/tests/UITests/Tests/Issues/Issue16321.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.Maui.Appium;
+using NUnit.Framework;
+
+namespace Microsoft.Maui.AppiumTests.Issues
+{
+	public class Issue16321 : _IssuesUITest
+	{
+		public Issue16321(TestDevice device) : base(device) { }
+
+		public override string Issue => "Alerts Open on top of current presented view";
+
+		[Test]
+		public void OpenAlertWithModals()
+		{
+			App.Tap("OpenAlertWithModals");
+			App.Tap("Cancel");
+		}
+
+		[Test]
+		public void OpenAlertWithNewUIWindow()
+		{
+			App.Tap("OpenAlertWithNewUIWindow");
+			App.Tap("Cancel");
+		}
+	}
+}

--- a/src/Controls/tests/UITests/Tests/Issues/Issue16321.cs
+++ b/src/Controls/tests/UITests/Tests/Issues/Issue16321.cs
@@ -12,6 +12,11 @@ namespace Microsoft.Maui.AppiumTests.Issues
 		[Test]
 		public void OpenAlertWithModals()
 		{
+			UITestContext.IgnoreIfPlatforms(new[]
+			{
+				TestDevice.Mac, TestDevice.Windows, TestDevice.Android
+			});
+
 			App.Tap("OpenAlertWithModals");
 			App.Tap("Cancel");
 		}
@@ -19,6 +24,11 @@ namespace Microsoft.Maui.AppiumTests.Issues
 		[Test]
 		public void OpenAlertWithNewUIWindow()
 		{
+			UITestContext.IgnoreIfPlatforms(new[]
+			{
+				TestDevice.Mac, TestDevice.Windows, TestDevice.Android
+			});
+
 			App.Tap("OpenAlertWithNewUIWindow");
 			App.Tap("Cancel");
 		}


### PR DESCRIPTION
### Description of Change

- Modify the code to just locate the current presenting ViewController opposed to iterating over modal pages
- inspect the UIWindow on the incoming page. If that UIWindow is different from the current UIWindow then present the alert to that UIWindow. Mopups uses a new UIWindow to present its popups, so this will fix the issue by checking the UIWindow on the incoming page. This does require users to call "DisplayAlert" on the `ContentPage` that's used inside the `Mopup` popup itself, which seems acceptable for now instead of trying to be too smart and try to figure out what UIWindow to present from.


This scenario changed/broke when moving to MAUI because in XF we used a new UIWindow for all our alerts which always presented on top where as with MAUI we changed that code to just present as a new ViewController https://github.com/dotnet/maui/blob/108d1bc717d1c0940d8d81f567da6bfd61e83b39/src/Controls/src/Core/Platform/AlertManager/AlertManager.iOS.cs#L210

### Issues Fixed

Fixes #16321
