### PR TITLE
[android] fix DI registration for Frame, ListView, TableView

### DIFF
--- a/src/Controls/src/Xaml/Hosting/AppHostBuilderExtensions.cs
+++ b/src/Controls/src/Xaml/Hosting/AppHostBuilderExtensions.cs
@@ -112,11 +112,13 @@ namespace Microsoft.Maui.Controls.Hosting
 #pragma warning restore CA1416
 
 #if WINDOWS || ANDROID || IOS || MACCATALYST || TIZEN
-			handlersCollection.AddHandler<ListView>(svc => new Handlers.Compatibility.ListViewRenderer(
 #if ANDROID
-				svc.GetRequiredService<Android.Content.Context>()
+#pragma warning disable RS0030 // FIXME: Do not use banned APIs, only works due to MissingMethodException
+			handlersCollection.AddHandler(typeof(ListView), typeof(Handlers.Compatibility.ListViewRenderer));
+#pragma warning restore RS0030 // Do not use banned APIs
+#else
+			handlersCollection.AddHandler<ListView>(svc => new Handlers.Compatibility.ListViewRenderer());
 #endif
-			));
 #if !TIZEN
 			handlersCollection.AddHandler<ImageCell>(_ => new Handlers.Compatibility.ImageCellRenderer());
 			handlersCollection.AddHandler<EntryCell>(_ => new Handlers.Compatibility.EntryCellRenderer());
@@ -124,16 +126,20 @@ namespace Microsoft.Maui.Controls.Hosting
 			handlersCollection.AddHandler<ViewCell>(_ => new Handlers.Compatibility.ViewCellRenderer());
 			handlersCollection.AddHandler<SwitchCell>(_ => new Handlers.Compatibility.SwitchCellRenderer());
 #endif
-			handlersCollection.AddHandler<TableView>(svc => new Handlers.Compatibility.TableViewRenderer(
 #if ANDROID
-				svc.GetRequiredService<Android.Content.Context>()
+#pragma warning disable RS0030 // FIXME: Do not use banned APIs, only works due to MissingMethodException
+			handlersCollection.AddHandler(typeof(TableView), typeof(Handlers.Compatibility.TableViewRenderer));
+#pragma warning restore RS0030 // Do not use banned APIs
+#else
+			handlersCollection.AddHandler<TableView>(svc => new Handlers.Compatibility.TableViewRenderer());
 #endif
-			));
-			handlersCollection.AddHandler<Frame>(svc => new Handlers.Compatibility.FrameRenderer(
 #if ANDROID
-				svc.GetRequiredService<Android.Content.Context>()
+#pragma warning disable RS0030 // FIXME: Do not use banned APIs, only works due to MissingMethodException
+			handlersCollection.AddHandler(typeof(Frame), typeof(Handlers.Compatibility.FrameRenderer));
+#pragma warning restore RS0030 // Do not use banned APIs
+#else
+			handlersCollection.AddHandler<Frame>(svc => new Handlers.Compatibility.FrameRenderer());
 #endif
-			));
 #endif
 
 #if WINDOWS || MACCATALYST


### PR DESCRIPTION
This partially reverts b0bba51b.

When running:

    .\bin\dotnet\dotnet.exe build src\Controls\samples\Controls.Sample\Maui.Controls.Sample.csproj -f net7.0-android -t:Run

The app crashes on the "Compatibility" screen with:

    System.InvalidOperationException: No service for type 'Android.Content.Context' has been registered.

These are caused by the change:

    --handlersCollection.AddHandler(typeof(Frame), typeof(Handlers.Compatibility.FrameRenderer));
    ++handlersCollection.AddHandler<Frame>(svc => new Handlers.Compatibility.FrameRenderer(svc.GetRequiredService<Android.Content.Context>()));

It turns out this code path only works because:

1. Microsoft.Extensions.DI throws a `MissingMethodException`

2. MAUI has fallback logic to catch this and call:

```csharp
return (IElementHandler)Extensions.DependencyInjection.
    ActivatorUtilities.CreateInstance(mauiContext.Services, handlerType, mauiContext.Context);
```

`ActivatorUtilities` is part of Microsoft.Extensions.DI.

For now, let's just revert this change for Android for these three types: `Frame`, `ListView`, and `TableView`.

I spend some time trying to "unwind" this and avoid the `MissingMethodException` on startup. I couldn't solve it yet, but plan to come back to it later.