### PR TITLE
[workload] Move default item updates to workload sdk

### DIFF
--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.Build.Tasks.After.targets
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.Build.Tasks.After.targets
@@ -1,18 +1,11 @@
 <Project>
 
-  <PropertyGroup>
-    <EnableDefaultMauiItems Condition=" '$(EnableDefaultMauiItems)' == '' ">$(EnableDefaultItems)</EnableDefaultMauiItems>
-    <EnableDefaultXamlItems Condition=" '$(EnableDefaultXamlItems)' == '' ">$(EnableDefaultMauiItems)</EnableDefaultXamlItems>
-    <EnableDefaultCssItems  Condition=" '$(EnableDefaultCssItems)' == '' ">$(EnableDefaultMauiItems)</EnableDefaultCssItems>
-    <EnableDefaultEmbeddedResourceItems Condition=" '$(EnableDefaultEmbeddedResourceItems)' == '' ">$(EnableDefaultMauiItems)</EnableDefaultEmbeddedResourceItems>
-  </PropertyGroup>
-
   <!-- Remove platform-based @(Using) unless $(MauiEnablePlatformUsings) flag is set -->
   <ItemGroup Condition=" '$(MauiEnablePlatformUsings)' != 'true' and ('$(ImplicitUsings)' == 'true' or '$(ImplicitUsings)' == 'enable') ">
     <Using Remove="@(Using->HasMetadata('Platform'))" />
   </ItemGroup>
 
   <Import Project="Microsoft.Maui.Controls.targets" />
-  <Import Project="Microsoft.Maui.Controls.DefaultItems.targets" />
+  <Import Project="Microsoft.Maui.Controls.SingleProject.targets" />
 
 </Project>

--- a/src/Workload/Microsoft.Maui.Sdk/Sdk/Microsoft.Maui.Sdk.After.targets
+++ b/src/Workload/Microsoft.Maui.Sdk/Sdk/Microsoft.Maui.Sdk.After.targets
@@ -1,28 +1,13 @@
 <Project>
 
-  <!--
-    The IDE uses the @(ProjectCapability) items to activate various features.
-  -->
+  <PropertyGroup>
+    <EnableDefaultMauiItems Condition=" '$(EnableDefaultMauiItems)' == '' ">$(EnableDefaultItems)</EnableDefaultMauiItems>
+    <EnableDefaultXamlItems Condition=" '$(EnableDefaultXamlItems)' == '' ">$(EnableDefaultMauiItems)</EnableDefaultXamlItems>
+    <EnableDefaultCssItems  Condition=" '$(EnableDefaultCssItems)' == '' ">$(EnableDefaultMauiItems)</EnableDefaultCssItems>
+    <EnableDefaultEmbeddedResourceItems Condition=" '$(EnableDefaultEmbeddedResourceItems)' == '' ">$(EnableDefaultMauiItems)</EnableDefaultEmbeddedResourceItems>
+  </PropertyGroup>
 
-  <!-- .NET MAUI features -->
-  <ItemGroup>
-    <ProjectCapability Include="Maui"           Condition=" '$(UseMaui)' == 'true' " />
-    <ProjectCapability Include="MauiAssets"     Condition=" '$(UseMaui)' == 'true' or '$(UseMauiAssets)' == 'true' " />
-    <ProjectCapability Include="MauiBlazor"     Condition=" '$(UsingMicrosoftNETSdkRazor)' == 'true' " />
-    <ProjectCapability Include="MauiCore"       Condition=" '$(UseMaui)' == 'true' or '$(UseMauiCore)' == 'true' " />
-    <ProjectCapability Include="MauiEssentials" Condition=" '$(UseMaui)' == 'true' or '$(UseMauiEssentials)' == 'true' " />
-  </ItemGroup>
-
-  <!-- SingleProject-specific features -->
-  <ItemGroup Condition=" '$(SingleProject)' == 'true' ">
-    <ProjectCapability Include="Msix" />
-    <ProjectCapability Include="MauiSingleProject" />
-    <ProjectCapability Include="LaunchProfiles" />
-    <!-- If VS is older than Dev17 -->
-    <ProjectCapability Include="XamarinStaticLaunchProfiles" Condition=" '$(VisualStudioVersion)' != '' and '$(VisualStudioVersion)' &lt; '17.0' " />
-    <!-- Otherwise define LaunchProfilesGroupByPlatformFilters by default -->
-    <ProjectCapability Include="LaunchProfilesGroupByPlatformFilters" Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &gt;= '17.0' " />
-    <ProjectCapability Include="SingleTargetBuildForStartupProjects" Condition=" '$(EnableSingleTargetBuildForStartupProjects)' != 'false' " />
-  </ItemGroup>
+  <Import Project="Microsoft.Maui.Sdk.ProjectCapabilities.targets" />
+  <Import Project="Microsoft.Maui.Sdk.DefaultItems.targets" />
 
 </Project>

--- a/src/Workload/Microsoft.Maui.Sdk/Sdk/Microsoft.Maui.Sdk.DefaultItems.targets
+++ b/src/Workload/Microsoft.Maui.Sdk/Sdk/Microsoft.Maui.Sdk.DefaultItems.targets
@@ -16,6 +16,4 @@
 		<None Remove="**\*.css" Condition="'$(EnableDefaultNoneItems)'=='True'" />
 	</ItemGroup>
 
-	<Import Project="Microsoft.Maui.Controls.SingleProject.targets" />
-
 </Project>

--- a/src/Workload/Microsoft.Maui.Sdk/Sdk/Microsoft.Maui.Sdk.ProjectCapabilities.targets
+++ b/src/Workload/Microsoft.Maui.Sdk/Sdk/Microsoft.Maui.Sdk.ProjectCapabilities.targets
@@ -1,0 +1,37 @@
+<!--
+***********************************************************************************************
+Microsoft.Maui.Sdk.ProjectCapabilities.targets
+
+The IDE uses the @(ProjectCapability) items to activate various features.
+
+Docs about @(ProjectCapability):
+
+* https://github.com/microsoft/VSProjectSystem/blob/3312e0a7fc4ba0acb67ad64b0bf8564db082e8f1/doc/overview/about_project_capabilities.md
+* https://github.com/microsoft/VSProjectSystem/blob/3312e0a7fc4ba0acb67ad64b0bf8564db082e8f1/doc/overview/project_capabilities.md
+
+***********************************************************************************************
+-->
+<Project>
+
+  <!-- .NET MAUI features -->
+  <ItemGroup>
+    <ProjectCapability Include="Maui"           Condition=" '$(UseMaui)' == 'true' " />
+    <ProjectCapability Include="MauiAssets"     Condition=" '$(UseMaui)' == 'true' or '$(UseMauiAssets)' == 'true' " />
+    <ProjectCapability Include="MauiBlazor"     Condition=" '$(UsingMicrosoftNETSdkRazor)' == 'true' " />
+    <ProjectCapability Include="MauiCore"       Condition=" '$(UseMaui)' == 'true' or '$(UseMauiCore)' == 'true' " />
+    <ProjectCapability Include="MauiEssentials" Condition=" '$(UseMaui)' == 'true' or '$(UseMauiEssentials)' == 'true' " />
+  </ItemGroup>
+
+  <!-- SingleProject-specific features -->
+  <ItemGroup Condition=" '$(SingleProject)' == 'true' ">
+    <ProjectCapability Include="Msix" />
+    <ProjectCapability Include="MauiSingleProject" />
+    <ProjectCapability Include="LaunchProfiles" />
+    <!-- If VS is older than Dev17 -->
+    <ProjectCapability Include="XamarinStaticLaunchProfiles" Condition=" '$(VisualStudioVersion)' != '' and '$(VisualStudioVersion)' &lt; '17.0' " />
+    <!-- Otherwise define LaunchProfilesGroupByPlatformFilters by default -->
+    <ProjectCapability Include="LaunchProfilesGroupByPlatformFilters" Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &gt;= '17.0' " />
+    <ProjectCapability Include="SingleTargetBuildForStartupProjects" Condition=" '$(EnableSingleTargetBuildForStartupProjects)' != 'false' " />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Fixes #16501
Context: https://github.com/dotnet/maui/commit/95913ed760f25da0bb78c16e74fab25296eb98f2
Context: https://github.com/dotnet/maui/commit/2dcc148208c8e805a732f897568baa339304bec4

Attempts to improve xaml.cs file nesting by moving xaml.cs item updates
back into the workload SDK.  Some of this logic was moved out of
`Microsoft.Maui.Sdk.After.targets` in commit 95913ed7, and subsequently
moved out of the workload and into a NuGet package in commit 2dcc1482.

I believe it should be harmless to move these default item properties
and the Compile / None item updates back into the workload SDK to avoid
solution explorer display issues on first run.