### PR TITLE
Fix for Spinner not disappearing in RefreshView

### DIFF
--- a/src/Controls/src/Core/RefreshView/RefreshView.cs
+++ b/src/Controls/src/Core/RefreshView/RefreshView.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Maui.Controls
 		public bool IsRefreshing
 		{
 			get { return (bool)GetValue(IsRefreshingProperty); }
-			set { SetValue(IsRefreshingProperty, value); }
+			set { SetValue(IsRefreshingProperty, value, SetterSpecificity.FromHandler); }
 		}
 
 		/// <summary>Bindable property for <see cref="Command"/>.</summary>

--- a/src/Controls/src/Core/RefreshView/RefreshView.cs
+++ b/src/Controls/src/Core/RefreshView/RefreshView.cs
@@ -62,6 +62,12 @@ namespace Microsoft.Maui.Controls
 		public bool IsRefreshing
 		{
 			get { return (bool)GetValue(IsRefreshingProperty); }
+			set { SetValue(IsRefreshingProperty, value); }
+		}
+
+		bool IRefreshView.IsRefreshing
+		{
+			get { return (bool)GetValue(IsRefreshingProperty); }
 			set { SetValue(IsRefreshingProperty, value, SetterSpecificity.FromHandler); }
 		}
 

--- a/src/Controls/src/Core/RefreshView/RefreshView.cs
+++ b/src/Controls/src/Core/RefreshView/RefreshView.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Maui.Controls
 		public bool IsRefreshing
 		{
 			get => (bool)GetValue(IsRefreshingProperty);
-			set => SetValue(IsRefreshingProperty, value, SetterSpecificity.FromBinding);
+			set => SetValue(IsRefreshingProperty, value);
 		}
 
 		bool IRefreshView.IsRefreshing

--- a/src/Controls/src/Core/RefreshView/RefreshView.cs
+++ b/src/Controls/src/Core/RefreshView/RefreshView.cs
@@ -61,14 +61,14 @@ namespace Microsoft.Maui.Controls
 		/// <include file="../../docs/Microsoft.Maui.Controls/RefreshView.xml" path="//Member[@MemberName='IsRefreshing']/Docs/*" />
 		public bool IsRefreshing
 		{
-			get { return (bool)GetValue(IsRefreshingProperty); }
-			set { SetValue(IsRefreshingProperty, value); }
+			get => (bool)GetValue(IsRefreshingProperty);
+			set => SetValue(IsRefreshingProperty, value, SetterSpecificity.FromBinding);
 		}
 
 		bool IRefreshView.IsRefreshing
 		{
-			get { return (bool)GetValue(IsRefreshingProperty); }
-			set { SetValue(IsRefreshingProperty, value, SetterSpecificity.FromHandler); }
+			get => IsRefreshing;
+			set => SetValue(IsRefreshingProperty, value, SetterSpecificity.FromHandler);
 		}
 
 		/// <summary>Bindable property for <see cref="Command"/>.</summary>


### PR DESCRIPTION
### Description of Change
After some investigation, I found the PR where the spinner in Refresh Views would not disappear after IsRefreshing was set to false. After looking at the PR, I believe that the IsRefreshing property isn't utilizing the correct SetValue method.

Before (fast forward with scrubber to see the spinner, otherwise webm player won't show it):
[before.webm](https://github.com/dotnet/maui/assets/89540402/c6c4826b-a8cc-4fe2-acbd-109e6171fd47)
After:
[after.webm](https://github.com/dotnet/maui/assets/89540402/058a1834-9570-4d17-b73c-4c06e072397f)

There still seems to be a case where the spinner's outline remains but the inner animation disappears, and it predates the Specificity PR by almost a year (yet was fixed at some later point, apparently). I haven't been able to reproduce that particular issue, and want to test some more, but figure I'd get some feedback on this one.


### Issues Fixed

Fixes #16910 

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
