### PR TITLE
[android] CollectionView logical children grows with Header/Footer

### DIFF
--- a/src/Controls/src/Core/Element/Element.cs
+++ b/src/Controls/src/Core/Element/Element.cs
@@ -189,9 +189,6 @@ namespace Microsoft.Maui.Controls
 			_logicalChildrenReadonly ??= new ReadOnlyCollection<Element>(LogicalChildrenInternalBackingStore);
 		}
 
-		internal bool ContainsLogicalChild(Element element) =>
-			LogicalChildrenInternalBackingStore.Contains(element);
-
 		/// <summary>
 		/// Inserts an <see cref="Element"/> to the logical children at the specified index.
 		/// </summary>

--- a/src/Controls/src/Core/Element/Element.cs
+++ b/src/Controls/src/Core/Element/Element.cs
@@ -189,6 +189,9 @@ namespace Microsoft.Maui.Controls
 			_logicalChildrenReadonly ??= new ReadOnlyCollection<Element>(LogicalChildrenInternalBackingStore);
 		}
 
+		internal bool ContainsLogicalChild(Element element) =>
+			LogicalChildrenInternalBackingStore.Contains(element);
+
 		/// <summary>
 		/// Inserts an <see cref="Element"/> to the logical children at the specified index.
 		/// </summary>

--- a/src/Controls/src/Core/Handlers/Items/Android/Adapters/StructuredItemsViewAdapter.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/Adapters/StructuredItemsViewAdapter.cs
@@ -139,7 +139,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				var viewHolder = SimpleViewHolder.FromFormsView(formsView, context, ItemsView);
 
 				// Propagate the binding context, visual, etc. from the ItemsView to the header/footer
-				if (!ItemsView.ContainsLogicalChild(viewHolder.View))
+				if (viewHolder.View.Parent != ItemsView)
 				{
 					ItemsView.AddLogicalChild(viewHolder.View);
 				}

--- a/src/Controls/src/Core/Handlers/Items/Android/Adapters/StructuredItemsViewAdapter.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/Adapters/StructuredItemsViewAdapter.cs
@@ -139,7 +139,10 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				var viewHolder = SimpleViewHolder.FromFormsView(formsView, context, ItemsView);
 
 				// Propagate the binding context, visual, etc. from the ItemsView to the header/footer
-				ItemsView.AddLogicalChild(viewHolder.View);
+				if (!ItemsView.ContainsLogicalChild(viewHolder.View))
+				{
+					ItemsView.AddLogicalChild(viewHolder.View);
+				}
 
 				return viewHolder;
 			}

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.cs
@@ -47,6 +47,8 @@ namespace Microsoft.Maui.DeviceTests
 			WeakReference weakReference = null;
 			var collectionView = new CollectionView
 			{
+				Header = new Label { Text = "Header" },
+				Footer = new Label { Text = "Footer" },
 				ItemTemplate = new DataTemplate(() => new Label())
 			};
 
@@ -75,7 +77,7 @@ namespace Microsoft.Maui.DeviceTests
 			await AssertionExtensions.WaitForGC(weakReference);
 			Assert.False(weakReference.IsAlive, "ObservableCollection should not be alive!");
 			Assert.NotNull(logicalChildren);
-			Assert.True(logicalChildren.Count <= 3, "_logicalChildren should not grow in size!");
+			Assert.True(logicalChildren.Count <= 5, "_logicalChildren should not grow in size!");
 		}
 
 		[Theory]


### PR DESCRIPTION
Fixes #16961

Debugging the `ItemsSourceDoesNotLeak()` test with a new `Header` and `Footer` on Android, there was some very odd behavior...

At the end of the test, `_logicalChildren` contained 9 items!

    Header
    Footer
    Header
    Footer
    Header
    null
    null
    null
    Footer

Where I would expect it to contain 5?!?

It appears the problem is:

* `CollectionView.ItemsSource` changes

* We notify Android's `RecyclerView` to refresh

* `RecyclerView` calls `OnCreateViewHolder()` for the header, footer, and all rows.

* `CreateHeaderFooterViewHolder()` is called again for the header & footer.

* Duplicate `viewHolder.View` items are added as logical children.

To fix this, an idea:

* Create a new `internal ContainsLogicalChild()` method

* Call this before adding the same `View` in `CreateHeaderFooterViewHolder()`

This isn't the *best*, because it will iterate over the `_logicalChildren` to decide if the list contains the view. But this is better than what strange behavior might result from this?