### PR TITLE
Fix the order of logical modifications

### DIFF
--- a/src/Controls/src/Core/Layout/Layout.cs
+++ b/src/Controls/src/Core/Layout/Layout.cs
@@ -54,12 +54,13 @@ namespace Microsoft.Maui.Controls
 					return;
 				}
 
+				_children.RemoveAt(index);
 				if (old is Element oldElement)
 				{
 					RemoveLogicalChild(oldElement);
 				}
 
-				_children[index] = value;
+				_children.Insert(index, value);
 
 				if (value is Element newElement)
 				{
@@ -129,11 +130,17 @@ namespace Microsoft.Maui.Controls
 			var index = _children.Count;
 			_children.Add(child);
 
+			if (child is Element element)
+			{
+				AddLogicalChild(element);
+			}
+
 			OnAdd(index, child);
 		}
 
 		public void Clear()
 		{
+			_children.Clear();
 			for (int i = _children.Count - 1; i >= 0; i--)
 			{
 				if (_children[i] is Element element)
@@ -141,7 +148,6 @@ namespace Microsoft.Maui.Controls
 					RemoveLogicalChild(element);
 				}
 			}
-			_children.Clear();
 			OnClear();
 		}
 
@@ -165,10 +171,10 @@ namespace Microsoft.Maui.Controls
 			if (child == null)
 				return;
 
+			_children.Insert(index, child);
+
 			if (child is Element element)
 				InsertLogicalChild(index, element);
-
-			_children.Insert(index, child);
 
 			OnInsert(index, child);
 		}
@@ -201,17 +207,17 @@ namespace Microsoft.Maui.Controls
 
 			_children.RemoveAt(index);
 
+			if (child is Element element)
+			{
+				RemoveLogicalChild(element);
+			}
+
 			OnRemove(index, child);
 		}
 
 		protected virtual void OnAdd(int index, IView view)
 		{
 			NotifyHandler(nameof(ILayoutHandler.Add), index, view);
-
-			if (view is Element element)
-			{
-				AddLogicalChild(element);
-			}
 		}
 
 		protected virtual void OnClear()
@@ -222,21 +228,11 @@ namespace Microsoft.Maui.Controls
 		protected virtual void OnRemove(int index, IView view)
 		{
 			NotifyHandler(nameof(ILayoutHandler.Remove), index, view);
-
-			if (view is Element element)
-			{
-				RemoveLogicalChild(element);
-			}
 		}
 
 		protected virtual void OnInsert(int index, IView view)
 		{
 			NotifyHandler(nameof(ILayoutHandler.Insert), index, view);
-
-			if (view is Element element)
-			{
-				AddLogicalChild(element);
-			}
 		}
 
 		protected virtual void OnUpdate(int index, IView view, IView oldView)
@@ -258,8 +254,6 @@ namespace Microsoft.Maui.Controls
 		{
 			return new Thickness(0);
 		}
-
-		IReadOnlyList<IVisualTreeElement> IVisualTreeElement.GetVisualChildren() => Children.Cast<IVisualTreeElement>().ToList().AsReadOnly();
 
 		public Graphics.Size CrossPlatformMeasure(double widthConstraint, double heightConstraint)
 		{

--- a/src/Controls/src/Core/Layout/Layout.cs
+++ b/src/Controls/src/Core/Layout/Layout.cs
@@ -140,9 +140,9 @@ namespace Microsoft.Maui.Controls
 
 		public void Clear()
 		{
-			_children.Clear();
 			for (int i = _children.Count - 1; i >= 0; i--)
 			{
+				_children.RemoveAt(i);
 				if (_children[i] is Element element)
 				{
 					RemoveLogicalChild(element);

--- a/src/Controls/src/Core/Layout/Layout.cs
+++ b/src/Controls/src/Core/Layout/Layout.cs
@@ -142,8 +142,9 @@ namespace Microsoft.Maui.Controls
 		{
 			for (int i = _children.Count - 1; i >= 0; i--)
 			{
+				var child = _children[i];
 				_children.RemoveAt(i);
-				if (_children[i] is Element element)
+				if (child is Element element)
 				{
 					RemoveLogicalChild(element);
 				}


### PR DESCRIPTION
### Description of Change

- fix the order that logical children modification operations are called
- remove the IVET mapping to `Children` because now that we're using the `Element` level storage we don't need to map to the internal `children` storage