### PR TITLE
Grid distribution fix

### DIFF
--- a/src/Core/src/Layouts/GridLayoutManager.cs
+++ b/src/Core/src/Layouts/GridLayoutManager.cs
@@ -905,14 +905,16 @@ namespace Microsoft.Maui.Layouts
 				// We don't have enough room for all the star rows/columns to expand to their full size.
 				// But we still need to fill up the rest of the space, so we'll expand them proportionally.
 
-				// Work out the total difference in size between the largest star definition and all 
-				// the smaller ones; we'll need that later to distribute available space.
+				// Work out the total difference in size between the full star size targets and the 
+				// minimum sizes for all definitions; we'll need that later to distribute available space.
 				double totaldiff = 0;
 				foreach (var definition in defs)
 				{
 					if (definition.IsStar)
 					{
-						totaldiff += maxCurrentSize - definition.MinimumSize;
+						double fullTargetSize = targetStarSize * definition.GridLength.Value;
+						if (definition.MinimumSize < fullTargetSize)
+							totaldiff += fullTargetSize - definition.MinimumSize;
 					}
 				}
 
@@ -920,16 +922,18 @@ namespace Microsoft.Maui.Layouts
 				{
 					if (definition.IsStar)
 					{
-						// Skip the largest star rows/columns; we want to expand the smaller ones first
-						if (maxCurrentSize > definition.MinimumSize)
+						// Skip the star rows/columns whose minimums are at or higher than the target sizes
+						double fullTargetSize = targetStarSize * definition.GridLength.Value;
+
+						if (definition.MinimumSize < fullTargetSize)
 						{
 							// Figure out how small this definition is relative to the total difference,
 							// and use that to determine how much of the available space this definition gets
 
-							// The goal is to have the smaller definitions expand faster than the bigger ones,
-							// so the amount we give to each definition is inversely proportional to its size
+							// The goal is to have the definitions expand proportionate to their deficit from
+							// their full target sizes
 
-							var scale = (maxCurrentSize - definition.MinimumSize) / totaldiff;
+							var scale = (fullTargetSize - definition.MinimumSize) / totaldiff;
 							var portion = scale * availableSpace;
 							definition.Size = definition.MinimumSize + portion;
 						}

--- a/src/Core/src/Layouts/GridLayoutManager.cs
+++ b/src/Core/src/Layouts/GridLayoutManager.cs
@@ -906,7 +906,8 @@ namespace Microsoft.Maui.Layouts
 				// But we still need to fill up the rest of the space, so we'll expand them proportionally.
 
 				// Work out the total difference in size between the full star size targets and the 
-				// minimum sizes for all definitions; we'll need that later to distribute available space.
+				// minimum sizes for all definitions where the minimum is less than the full star size
+				// target; we'll need that later to distribute available space.
 				double totaldiff = 0;
 				foreach (var definition in defs)
 				{


### PR DESCRIPTION
### Description of Change

Modifies the GridLayoutManager to fix an issue that occurs when the minimum size of one of the star definitions is larger than the star size that would be allocated to it under optimal conditions. In the previous implementation, the sizes are adjusted to make them as evenly distributed as possible, which does not fit well with the expectations for a star row/column, where the user will expect the sizes to be as close to the proportions given by the stars as possible. The current implementation uses the a similar adjustment as before, but according to the amount that the minimum differs from the target, in order to reach a value that approximates the target as closely as possible.

### Issues Fixed

Fixes #16857 
