### PR TITLE
[release/8.0.1xx-rx1] Bump xamarin-macios rc1 packages

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -12,21 +12,21 @@
       <Uri>https://github.com/xamarin/xamarin-android</Uri>
       <Sha>53654ed1e5434d90137470c2ebe09331c614d18f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.MacCatalyst.Sdk" Version="16.4.8779-net8-rc1">
+    <Dependency Name="Microsoft.MacCatalyst.Sdk" Version="16.4.8824-net8-rc1">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>1a65c85978d78f3dc0e701165c7f06b6b44e7ed1</Sha>
+      <Sha>8cdd132b7b002b88358fa3f9dffa53f5de9bd411</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.macOS.Sdk" Version="13.3.8779-net8-rc1">
+    <Dependency Name="Microsoft.macOS.Sdk" Version="13.3.8824-net8-rc1">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>1a65c85978d78f3dc0e701165c7f06b6b44e7ed1</Sha>
+      <Sha>8cdd132b7b002b88358fa3f9dffa53f5de9bd411</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.iOS.Sdk" Version="16.4.8779-net8-rc1">
+    <Dependency Name="Microsoft.iOS.Sdk" Version="16.4.8824-net8-rc1">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>1a65c85978d78f3dc0e701165c7f06b6b44e7ed1</Sha>
+      <Sha>8cdd132b7b002b88358fa3f9dffa53f5de9bd411</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.tvOS.Sdk" Version="16.4.8779-net8-rc1">
+    <Dependency Name="Microsoft.tvOS.Sdk" Version="16.4.8824-net8-rc1">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>1a65c85978d78f3dc0e701165c7f06b6b44e7ed1</Sha>
+      <Sha>8cdd132b7b002b88358fa3f9dffa53f5de9bd411</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.Workload.Emscripten.Current.Manifest-8.0.100.Transport" Version="8.0.0-rc.1.23415.5" CoherentParentDependency="Microsoft.NETCore.App.Ref">
       <Uri>https://github.com/dotnet/emsdk</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -25,10 +25,10 @@
     <!-- xamarin/xamarin-android -->
     <MicrosoftAndroidSdkWindowsPackageVersion>34.0.0-rc.1.432</MicrosoftAndroidSdkWindowsPackageVersion>
     <!-- xamarin/xamarin-macios -->
-    <MicrosoftMacCatalystSdkPackageVersion>16.4.8779-net8-rc1</MicrosoftMacCatalystSdkPackageVersion>
-    <MicrosoftmacOSSdkPackageVersion>13.3.8779-net8-rc1</MicrosoftmacOSSdkPackageVersion>
-    <MicrosoftiOSSdkPackageVersion>16.4.8779-net8-rc1</MicrosoftiOSSdkPackageVersion>
-    <MicrosofttvOSSdkPackageVersion>16.4.8779-net8-rc1</MicrosofttvOSSdkPackageVersion>
+    <MicrosoftMacCatalystSdkPackageVersion>16.4.8824-net8-rc1</MicrosoftMacCatalystSdkPackageVersion>
+    <MicrosoftmacOSSdkPackageVersion>13.3.8824-net8-rc1</MicrosoftmacOSSdkPackageVersion>
+    <MicrosoftiOSSdkPackageVersion>16.4.8824-net8-rc1</MicrosoftiOSSdkPackageVersion>
+    <MicrosofttvOSSdkPackageVersion>16.4.8824-net8-rc1</MicrosofttvOSSdkPackageVersion>
     <!-- Samsung/Tizen.NET -->
     <SamsungTizenSdkPackageVersion>7.0.124</SamsungTizenSdkPackageVersion>
     <!-- emsdk -->

--- a/src/Graphics/samples/GraphicsTester.Android/GraphicsTester.Android.csproj
+++ b/src/Graphics/samples/GraphicsTester.Android/GraphicsTester.Android.csproj
@@ -5,7 +5,6 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>GraphicsTester.Android</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
-    <LangVersion>10.0</LangVersion>
     <SupportedOSPlatformVersion>23.0</SupportedOSPlatformVersion>
     <ApplicationId>com.microsoft.maui.graphicstester</ApplicationId>
     <ApplicationVersion>1</ApplicationVersion>

--- a/src/Graphics/samples/GraphicsTester.Mac/GraphicsTester.Mac.csproj
+++ b/src/Graphics/samples/GraphicsTester.Mac/GraphicsTester.Mac.csproj
@@ -5,7 +5,6 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>GraphicsTester.Mac</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
-    <LangVersion>10.0</LangVersion>
     <SupportedOSPlatformVersion>10.14</SupportedOSPlatformVersion>
     <IsPackable>false</IsPackable>
     <EnableCodeSigning>false</EnableCodeSigning>

--- a/src/Graphics/samples/GraphicsTester.MacCatalyst/GraphicsTester.MacCatalyst.csproj
+++ b/src/Graphics/samples/GraphicsTester.MacCatalyst/GraphicsTester.MacCatalyst.csproj
@@ -5,7 +5,6 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>GraphicsTester.MacCatalyst</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
-    <LangVersion>10.0</LangVersion>
     <SupportedOSPlatformVersion>14.2</SupportedOSPlatformVersion>
     <IsPackable>false</IsPackable>
     <!-- Disable multi-RID builds to workaround a parallel build issue -->

--- a/src/Graphics/samples/GraphicsTester.Skia.Mac/GraphicsTester.Skia.Mac.csproj
+++ b/src/Graphics/samples/GraphicsTester.Skia.Mac/GraphicsTester.Skia.Mac.csproj
@@ -4,7 +4,6 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>$(_MauiDotNetTfm)-macos</TargetFramework>
     <RootNamespace>GraphicsTester.Skia.Mac</RootNamespace>
-    <LangVersion>10.0</LangVersion>
     <SupportedOSPlatformVersion>10.14</SupportedOSPlatformVersion>
     <EnableCodeSigning>false</EnableCodeSigning>
     <UseSGen>false</UseSGen>

--- a/src/Graphics/samples/GraphicsTester.iOS/GraphicsTester.iOS.csproj
+++ b/src/Graphics/samples/GraphicsTester.iOS/GraphicsTester.iOS.csproj
@@ -5,7 +5,6 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>GraphicsTester.iOS</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
-    <LangVersion>10.0</LangVersion>
     <SupportedOSPlatformVersion>14.2</SupportedOSPlatformVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Graphics/tests/Graphics.Benchmarks/Graphics.Benchmarks.csproj
+++ b/src/Graphics/tests/Graphics.Benchmarks/Graphics.Benchmarks.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>$(_MauiDotNetTfm)</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Description of Change
This pull request updates the following dependencies

[marker]: <> (Begin:ae56f5d4-bfc0-4667-f347-08db9e4292c7)
## From https://github.com/xamarin/xamarin-macios
- **Subscription**: ae56f5d4-bfc0-4667-f347-08db9e4292c7
- **Build**: 20230827.1
- **Date Produced**: August 27, 2023 1:09:08 AM UTC
- **Commit**: 8cdd132b7b002b88358fa3f9dffa53f5de9bd411
- **Branch**: refs/heads/release/8.0.1xx-rc1

[DependencyUpdate]: <> (Begin)

- **Updates**:
  - **Microsoft.macOS.Sdk**: [from 13.3.8779-net8-rc1 to 13.3.8824-net8-rc1][8]

[8]: https://github.com/xamarin/xamarin-macios/compare/1a65c85978...8cdd132b7b

[DependencyUpdate]: <> (End)


[marker]: <> (End:ae56f5d4-bfc0-4667-f347-08db9e4292c7)
