### PR TITLE
Remove pinning to NET7 SDK

### DIFF
--- a/global.json
+++ b/global.json
@@ -5,10 +5,5 @@
   "msbuild-sdks": {
     "MSBuild.Sdk.Extras": "3.0.44",
     "Microsoft.Build.NoTargets": "3.3.0"
-  },
-  "sdk": {
-    "version": "7.0.200",
-    "allowPrerelease": true,
-    "rollForward": "major"
   }
 }


### PR DESCRIPTION
### Description of Change

The main branch builds find with the .NET 8 SDK, so there's no reason to require/pin it to NET7.