### PR TITLE
[Controls] Move ITextInput and IFontElement to InputView

### DIFF
--- a/src/Controls/src/Core/Editor/Editor.cs
+++ b/src/Controls/src/Core/Editor/Editor.cs
@@ -7,22 +7,22 @@ using Microsoft.Maui.Graphics;
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/Editor.xml" path="Type[@FullName='Microsoft.Maui.Controls.Editor']/Docs/*" />
-	public partial class Editor : InputView, IEditorController, IFontElement, ITextAlignmentElement, IElementConfiguration<Editor>, IEditor
+	public partial class Editor : InputView, IEditorController, ITextAlignmentElement, IElementConfiguration<Editor>, IEditor
 	{
 		/// <include file="../../docs/Microsoft.Maui.Controls/Editor.xml" path="//Member[@MemberName='TextProperty']/Docs/*" />
 		public new static readonly BindableProperty TextProperty = InputView.TextProperty;
 
-		/// <summary>Bindable property for <see cref="FontFamily"/>.</summary>
-		public static readonly BindableProperty FontFamilyProperty = FontElement.FontFamilyProperty;
+		/// <inheritdoc cref="InputView.FontFamilyProperty"/>
+		public new static readonly BindableProperty FontFamilyProperty = InputView.FontFamilyProperty;
 
-		/// <summary>Bindable property for <see cref="FontSize"/>.</summary>
-		public static readonly BindableProperty FontSizeProperty = FontElement.FontSizeProperty;
+		/// <inheritdoc cref="InputView.FontSizeProperty"/>
+		public new static readonly BindableProperty FontSizeProperty = InputView.FontSizeProperty;
 
-		/// <summary>Bindable property for <see cref="FontAttributes"/>.</summary>
-		public static readonly BindableProperty FontAttributesProperty = FontElement.FontAttributesProperty;
+		/// <inheritdoc cref="InputView.FontAttributesProperty"/>
+		public new static readonly BindableProperty FontAttributesProperty = InputView.FontAttributesProperty;
 
-		/// <summary>Bindable property for <see cref="FontAutoScalingEnabled"/>.</summary>
-		public static readonly BindableProperty FontAutoScalingEnabledProperty = FontElement.FontAutoScalingEnabledProperty;
+		/// <inheritdoc cref="InputView.FontAutoScalingEnabledProperty"/>
+		public new static readonly BindableProperty FontAutoScalingEnabledProperty = InputView.FontAutoScalingEnabledProperty;
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/Editor.xml" path="//Member[@MemberName='TextColorProperty']/Docs/*" />
 		public new static readonly BindableProperty TextColorProperty = InputView.TextColorProperty;
@@ -36,16 +36,14 @@ namespace Microsoft.Maui.Controls
 		/// <include file="../../docs/Microsoft.Maui.Controls/Editor.xml" path="//Member[@MemberName='PlaceholderColorProperty']/Docs/*" />
 		public new static readonly BindableProperty PlaceholderColorProperty = InputView.PlaceholderColorProperty;
 
-		/// <summary>
-		/// Backing store for the <see cref="InputView.IsTextPredictionEnabled"/> property.
-		/// </summary>
-		public static new readonly BindableProperty IsTextPredictionEnabledProperty = InputView.IsTextPredictionEnabledProperty;
+		/// <inheritdoc cref="InputView.IsTextPredictionEnabledProperty"/>
+		public new static readonly BindableProperty IsTextPredictionEnabledProperty = InputView.IsTextPredictionEnabledProperty;
 
-		/// <summary>Bindable property for <see cref="CursorPosition"/>.</summary>
-		public static readonly BindableProperty CursorPositionProperty = BindableProperty.Create(nameof(CursorPosition), typeof(int), typeof(Editor), 0, validateValue: (b, v) => (int)v >= 0);
+		/// <inheritdoc cref="InputView.CursorPositionProperty"/>
+		public new static readonly BindableProperty CursorPositionProperty = InputView.CursorPositionProperty;
 
-		/// <summary>Bindable property for <see cref="SelectionLength"/>.</summary>
-		public static readonly BindableProperty SelectionLengthProperty = BindableProperty.Create(nameof(SelectionLength), typeof(int), typeof(Editor), 0, validateValue: (b, v) => (int)v >= 0);
+		/// <inheritdoc cref="InputView.SelectionLengthProperty"/>
+		public new static readonly BindableProperty SelectionLengthProperty = InputView.SelectionLengthProperty;
 
 		/// <summary>Bindable property for <see cref="AutoSize"/>.</summary>
 		public static readonly BindableProperty AutoSizeProperty = BindableProperty.Create(nameof(AutoSize), typeof(EditorAutoSizeOption), typeof(Editor), defaultValue: EditorAutoSizeOption.Disabled, propertyChanged: (bindable, oldValue, newValue)
@@ -66,40 +64,6 @@ namespace Microsoft.Maui.Controls
 			set { SetValue(AutoSizeProperty, value); }
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Editor.xml" path="//Member[@MemberName='FontAttributes']/Docs/*" />
-		public FontAttributes FontAttributes
-		{
-			get { return (FontAttributes)GetValue(FontAttributesProperty); }
-			set { SetValue(FontAttributesProperty, value); }
-		}
-
-		public int CursorPosition
-		{
-			get { return (int)GetValue(CursorPositionProperty); }
-			set { SetValue(CursorPositionProperty, value); }
-		}
-
-		public int SelectionLength
-		{
-			get { return (int)GetValue(SelectionLengthProperty); }
-			set { SetValue(SelectionLengthProperty, value); }
-		}
-
-		/// <include file="../../docs/Microsoft.Maui.Controls/Editor.xml" path="//Member[@MemberName='FontFamily']/Docs/*" />
-		public string FontFamily
-		{
-			get { return (string)GetValue(FontFamilyProperty); }
-			set { SetValue(FontFamilyProperty, value); }
-		}
-
-		/// <include file="../../docs/Microsoft.Maui.Controls/Editor.xml" path="//Member[@MemberName='FontSize']/Docs/*" />
-		[System.ComponentModel.TypeConverter(typeof(FontSizeConverter))]
-		public double FontSize
-		{
-			get { return (double)GetValue(FontSizeProperty); }
-			set { SetValue(FontSizeProperty, value); }
-		}
-
 		public TextAlignment HorizontalTextAlignment
 		{
 			get { return (TextAlignment)GetValue(HorizontalTextAlignmentProperty); }
@@ -112,32 +76,6 @@ namespace Microsoft.Maui.Controls
 			set { SetValue(VerticalTextAlignmentProperty, value); }
 		}
 
-		public bool FontAutoScalingEnabled
-		{
-			get => (bool)GetValue(FontAutoScalingEnabledProperty);
-			set => SetValue(FontAutoScalingEnabledProperty, value);
-		}
-
-		void IFontElement.OnFontFamilyChanged(string oldValue, string newValue) =>
-			HandleFontChanged();
-
-		void IFontElement.OnFontSizeChanged(double oldValue, double newValue) =>
-			HandleFontChanged();
-
-		double IFontElement.FontSizeDefaultValueCreator() =>
-			this.GetDefaultFontSize();
-
-		void IFontElement.OnFontAttributesChanged(FontAttributes oldValue, FontAttributes newValue) =>
-			HandleFontChanged();
-
-		void IFontElement.OnFontAutoScalingEnabledChanged(bool oldValue, bool newValue) =>
-			HandleFontChanged();
-
-		void HandleFontChanged()
-		{
-			Handler?.UpdateValue(nameof(ITextStyle.Font));
-			UpdateAutoSizeOption();
-		}
 
 		void UpdateAutoSizeOption()
 		{
@@ -180,8 +118,6 @@ namespace Microsoft.Maui.Controls
 		public void OnHorizontalTextAlignmentPropertyChanged(TextAlignment oldValue, TextAlignment newValue)
 		{
 		}
-
-		Font ITextStyle.Font => this.ToFont();
 
 		void IEditor.Completed()
 		{

--- a/src/Controls/src/Core/Entry/Entry.cs
+++ b/src/Controls/src/Core/Entry/Entry.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Maui.Controls
 	/// <summary>
 	/// Entry is a single line text entry. It is best used for collecting small discrete pieces of information, like usernames and passwords.
 	/// </summary>
-	public partial class Entry : InputView, IFontElement, ITextAlignmentElement, IEntryController, IElementConfiguration<Entry>, IEntry
+	public partial class Entry : InputView, ITextAlignmentElement, IEntryController, IElementConfiguration<Entry>, IEntry
 	{
 		/// <summary>
 		/// Backing store for the <see cref="ReturnType"/> property.
@@ -59,40 +59,26 @@ namespace Microsoft.Maui.Controls
 		/// </summary>
 		public static readonly BindableProperty VerticalTextAlignmentProperty = TextAlignmentElement.VerticalTextAlignmentProperty;
 
-		/// <summary>
-		/// Backing store for the <see cref="ReturnType"/> property.
-		/// </summary>
-		public static readonly BindableProperty FontFamilyProperty = FontElement.FontFamilyProperty;
+		/// <inheritdoc cref="InputView.FontFamilyProperty"/>
+		public static new readonly BindableProperty FontFamilyProperty = InputView.FontFamilyProperty;
 
-		/// <summary>
-		/// Backing store for the <see cref="ReturnType"/> property.
-		/// </summary>
-		public static readonly BindableProperty FontSizeProperty = FontElement.FontSizeProperty;
+		/// <inheritdoc cref="InputView.FontSizeProperty"/>
+		public static new readonly BindableProperty FontSizeProperty = InputView.FontSizeProperty;
 
-		/// <summary>
-		/// Backing store for the <see cref="ReturnType"/> property.
-		/// </summary>
-		public static readonly BindableProperty FontAttributesProperty = FontElement.FontAttributesProperty;
+		/// <inheritdoc cref="InputView.FontAttributesProperty"/>
+		public static new readonly BindableProperty FontAttributesProperty = InputView.FontAttributesProperty;
 
-		/// <summary>
-		/// Backing store for the <see cref="InputView.IsTextPredictionEnabled"/> property.
-		/// </summary>
+		/// <inheritdoc cref="InputView.FontAutoScalingEnabledProperty"/>
+		public static new readonly BindableProperty FontAutoScalingEnabledProperty = InputView.FontAutoScalingEnabledProperty;
+
+		/// <inheritdoc cref="InputView.IsTextPredictionEnabledProperty"/>
 		public static new readonly BindableProperty IsTextPredictionEnabledProperty = InputView.IsTextPredictionEnabledProperty;
+		
+		/// <inheritdoc cref="InputView.CursorPositionProperty"/>
+		public new static readonly BindableProperty CursorPositionProperty = InputView.CursorPositionProperty;
 
-		/// <summary>
-		/// Backing store for the <see cref="ReturnType"/> property.
-		/// </summary>
-		public static readonly BindableProperty FontAutoScalingEnabledProperty = FontElement.FontAutoScalingEnabledProperty;
-
-		/// <summary>
-		/// Backing store for the <see cref="CursorPosition"/> property.
-		/// </summary>
-		public static readonly BindableProperty CursorPositionProperty = BindableProperty.Create(nameof(CursorPosition), typeof(int), typeof(Entry), 0, validateValue: (b, v) => (int)v >= 0);
-
-		/// <summary>
-		/// Backing store for the <see cref="SelectionLength"/> property.
-		/// </summary>
-		public static readonly BindableProperty SelectionLengthProperty = BindableProperty.Create(nameof(SelectionLength), typeof(int), typeof(Entry), 0, validateValue: (b, v) => (int)v >= 0);
+		/// <inheritdoc cref="InputView.SelectionLengthProperty"/>
+		public new static readonly BindableProperty SelectionLengthProperty = InputView.SelectionLengthProperty;
 
 		/// <summary>
 		/// Backing store for the <see cref="ClearButtonVisibility"/> property.
@@ -140,72 +126,12 @@ namespace Microsoft.Maui.Controls
 		}
 
 		/// <summary>
-		/// Gets or sets a value that indicates whether the font for the text of this entry is bold, italic, or neither.
-		/// This is a bindable property.
-		/// </summary>
-		public FontAttributes FontAttributes
-		{
-			get { return (FontAttributes)GetValue(FontAttributesProperty); }
-			set { SetValue(FontAttributesProperty, value); }
-		}
-
-		/// <summary>
-		/// Gets or sets the font family for the text of this entry. This is a bindable property.
-		/// </summary>
-		public string FontFamily
-		{
-			get { return (string)GetValue(FontFamilyProperty); }
-			set { SetValue(FontFamilyProperty, value); }
-		}
-
-		/// <summary>
-		/// Gets or sets the size of the font for the text of this entry. This is a bindable property.
-		/// </summary>
-		[System.ComponentModel.TypeConverter(typeof(FontSizeConverter))]
-		public double FontSize
-		{
-			get { return (double)GetValue(FontSizeProperty); }
-			set { SetValue(FontSizeProperty, value); }
-		}
-
-		/// <summary>
-		/// Determines whether or not the font of this entry should scale automatically according to the operating system settings. Default value is <see langword="true"/>.
-		/// This is a bindable property.
-		/// </summary>
-		/// <remarks>Typically this should always be enabled for accessibility reasons.</remarks>
-		public bool FontAutoScalingEnabled
-		{
-			get => (bool)GetValue(FontAutoScalingEnabledProperty);
-			set => SetValue(FontAutoScalingEnabledProperty, value);
-		}
-
-		/// <summary>
 		/// Determines what the return key on the on-screen keyboard should look like. This is a bindable property.
 		/// </summary>
 		public ReturnType ReturnType
 		{
 			get => (ReturnType)GetValue(ReturnTypeProperty);
 			set => SetValue(ReturnTypeProperty, value);
-		}
-
-		/// <summary>
-		/// Gets or sets the position of the cursor. The value must be more than or equal to 0 and less or equal to the length of <see cref="InputView.Text"/>.
-		/// This is a bindable property.
-		/// </summary>
-		public int CursorPosition
-		{
-			get { return (int)GetValue(CursorPositionProperty); }
-			set { SetValue(CursorPositionProperty, value); }
-		}
-
-		/// <summary>
-		/// Gets or sets the length of the selection. The selection will start at <see cref="CursorPosition"/>.
-		/// This is a bindable property.
-		/// </summary>
-		public int SelectionLength
-		{
-			get { return (int)GetValue(SelectionLengthProperty); }
-			set { SetValue(SelectionLengthProperty, value); }
 		}
 
 		/// <summary>
@@ -235,27 +161,6 @@ namespace Microsoft.Maui.Controls
 		{
 			get => (ClearButtonVisibility)GetValue(ClearButtonVisibilityProperty);
 			set => SetValue(ClearButtonVisibilityProperty, value);
-		}
-
-		double IFontElement.FontSizeDefaultValueCreator() =>
-			this.GetDefaultFontSize();
-
-		void IFontElement.OnFontAttributesChanged(FontAttributes oldValue, FontAttributes newValue) =>
-			HandleFontChanged();
-
-		void IFontElement.OnFontFamilyChanged(string oldValue, string newValue) =>
-			HandleFontChanged();
-
-		void IFontElement.OnFontSizeChanged(double oldValue, double newValue) =>
-			HandleFontChanged();
-
-		void IFontElement.OnFontAutoScalingEnabledChanged(bool oldValue, bool newValue) =>
-			HandleFontChanged();
-
-		void HandleFontChanged()
-		{
-			Handler?.UpdateValue(nameof(ITextStyle.Font));
-			InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
 		}
 
 		/// <summary>
@@ -290,8 +195,6 @@ namespace Microsoft.Maui.Controls
 		void ITextAlignmentElement.OnHorizontalTextAlignmentPropertyChanged(TextAlignment oldValue, TextAlignment newValue)
 		{
 		}
-
-		Font ITextStyle.Font => this.ToFont();
 
 		void IEntry.Completed()
 		{

--- a/src/Controls/src/Core/InputView/InputView.cs
+++ b/src/Controls/src/Core/InputView/InputView.cs
@@ -6,7 +6,7 @@ using Microsoft.Maui.Graphics;
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/InputView.xml" path="Type[@FullName='Microsoft.Maui.Controls.InputView']/Docs/*" />
-	public partial class InputView : View, IPlaceholderElement, ITextElement
+	public partial class InputView : View, IPlaceholderElement, ITextElement, ITextInput, IFontElement
 	{
 		/// <summary>Bindable property for <see cref="Text"/>.</summary>
 		public static readonly BindableProperty TextProperty = BindableProperty.Create(nameof(Text), typeof(string), typeof(InputView), defaultBindingMode: BindingMode.TwoWay,
@@ -42,6 +42,20 @@ namespace Microsoft.Maui.Controls
 
 		/// <summary>Bindable property for <see cref="TextTransform"/>.</summary>
 		public static readonly BindableProperty TextTransformProperty = TextElement.TextTransformProperty;
+
+		/// <summary>Bindable property for <see cref="CursorPosition"/>.</summary>
+		public static readonly BindableProperty CursorPositionProperty = BindableProperty.Create(nameof(CursorPosition), typeof(int), typeof(InputView), 0, validateValue: (b, v) => (int)v >= 0);
+
+		/// <summary>Bindable property for <see cref="SelectionLength"/>.</summary>
+		public static readonly BindableProperty SelectionLengthProperty = BindableProperty.Create(nameof(SelectionLength), typeof(int), typeof(InputView), 0, validateValue: (b, v) => (int)v >= 0);
+
+		public static readonly BindableProperty FontFamilyProperty = FontElement.FontFamilyProperty;
+
+		public static readonly BindableProperty FontSizeProperty = FontElement.FontSizeProperty;
+
+		public static readonly BindableProperty FontAttributesProperty = FontElement.FontAttributesProperty;
+
+		public static readonly BindableProperty FontAutoScalingEnabledProperty = FontElement.FontAutoScalingEnabledProperty;
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/InputView.xml" path="//Member[@MemberName='MaxLength']/Docs/*" />
 		public int MaxLength
@@ -155,6 +169,107 @@ namespace Microsoft.Maui.Controls
 		public string UpdateFormsText(string original, TextTransform transform)
 		{
 			return TextTransformUtilites.GetTransformedText(original, transform);
+		}
+
+		/// <summary>
+		/// Gets or sets the position of the cursor. The value must be more than or equal to 0 and less or equal to the length of <see cref="InputView.Text"/>.
+		/// This is a bindable property.
+		/// </summary>
+		public int CursorPosition
+		{
+			get { return (int)GetValue(CursorPositionProperty); }
+			set { SetValue(CursorPositionProperty, value); }
+		}
+
+		/// <summary>
+		/// Gets or sets the length of the selection. The selection will start at <see cref="CursorPosition"/>.
+		/// This is a bindable property.
+		/// </summary>
+		public int SelectionLength
+		{
+			get { return (int)GetValue(SelectionLengthProperty); }
+			set { SetValue(SelectionLengthProperty, value); }
+		}
+
+		/// <summary>
+		/// Gets or sets a value that indicates whether the font for the text of this entry is bold, italic, or neither.
+		/// This is a bindable property.
+		/// </summary>
+		public FontAttributes FontAttributes
+		{
+			get { return (FontAttributes)GetValue(FontAttributesProperty); }
+			set { SetValue(FontAttributesProperty, value); }
+		}
+
+		/// <summary>
+		/// Gets or sets the font family for the text of this entry. This is a bindable property.
+		/// </summary>
+		public string FontFamily
+		{
+			get { return (string)GetValue(FontFamilyProperty); }
+			set { SetValue(FontFamilyProperty, value); }
+		}
+
+		/// <summary>
+		/// Gets or sets the size of the font for the text of this entry. This is a bindable property.
+		/// </summary>
+		[System.ComponentModel.TypeConverter(typeof(FontSizeConverter))]
+		public double FontSize
+		{
+			get { return (double)GetValue(FontSizeProperty); }
+			set { SetValue(FontSizeProperty, value); }
+		}
+
+		/// <summary>
+		/// Determines whether or not the font of this entry should scale automatically according to the operating system settings. Default value is <see langword="true"/>.
+		/// This is a bindable property.
+		/// </summary>
+		/// <remarks>Typically this should always be enabled for accessibility reasons.</remarks>
+		public bool FontAutoScalingEnabled
+		{
+			get => (bool)GetValue(FontAutoScalingEnabledProperty);
+			set => SetValue(FontAutoScalingEnabledProperty, value);
+		}
+
+		double IFontElement.FontSizeDefaultValueCreator() =>
+				this.GetDefaultFontSize();
+
+		void IFontElement.OnFontFamilyChanged(string oldValue, string newValue) =>
+			HandleFontChanged();
+
+		void IFontElement.OnFontSizeChanged(double oldValue, double newValue) =>
+			HandleFontChanged();
+
+		void IFontElement.OnFontAutoScalingEnabledChanged(bool oldValue, bool newValue) =>
+			HandleFontChanged();
+
+		void IFontElement.OnFontAttributesChanged(FontAttributes oldValue, FontAttributes newValue) =>
+			HandleFontChanged();
+	
+		void HandleFontChanged()
+		{
+			Handler?.UpdateValue(nameof(ITextStyle.Font));
+			InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
+		}
+
+		Font ITextStyle.Font => this.ToFont();
+
+		int ITextInput.SelectionLength
+		{
+			get => SelectionLength;
+			set => SetValue(SelectionLengthProperty, value, SetterSpecificity.FromHandler);
+		}
+
+		int ITextInput.CursorPosition
+		{
+			get => CursorPosition;
+			set => SetValue(CursorPositionProperty, value, SetterSpecificity.FromHandler);
+		}
+
+		string ITextInput.Text
+		{
+			get => Text;
+			set => SetValue(TextProperty, value, SetterSpecificity.FromHandler);
 		}
 	}
 }

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -18,6 +18,16 @@ Microsoft.Maui.Controls.DropEventArgs.Data.get -> Microsoft.Maui.Controls.DataPa
 Microsoft.Maui.Controls.DropEventArgs.DropEventArgs(Microsoft.Maui.Controls.DataPackageView! view) -> void
 Microsoft.Maui.Controls.Handlers.Compatibility.ViewRenderer<TElement, TPlatformView>.ViewRenderer(Android.Content.Context! context, Microsoft.Maui.IPropertyMapper! mapper, Microsoft.Maui.CommandMapper? commandMapper = null) -> void
 Microsoft.Maui.Controls.Handlers.Compatibility.VisualElementRenderer<TElement>.VisualElementRenderer(Android.Content.Context! context, Microsoft.Maui.IPropertyMapper! mapper, Microsoft.Maui.CommandMapper? commandMapper = null) -> void
+Microsoft.Maui.Controls.InputView.CursorPosition.get -> int
+Microsoft.Maui.Controls.InputView.CursorPosition.set -> void
+Microsoft.Maui.Controls.InputView.FontAttributes.get -> Microsoft.Maui.Controls.FontAttributes
+Microsoft.Maui.Controls.InputView.FontAttributes.set -> void
+Microsoft.Maui.Controls.InputView.FontAutoScalingEnabled.get -> bool
+Microsoft.Maui.Controls.InputView.FontAutoScalingEnabled.set -> void
+Microsoft.Maui.Controls.InputView.FontSize.get -> double
+Microsoft.Maui.Controls.InputView.FontSize.set -> void
+Microsoft.Maui.Controls.InputView.SelectionLength.get -> int
+Microsoft.Maui.Controls.InputView.SelectionLength.set -> void
 Microsoft.Maui.Controls.PointerGestureRecognizer.PointerPressed -> System.EventHandler<Microsoft.Maui.Controls.PointerEventArgs!>?
 Microsoft.Maui.Controls.PointerGestureRecognizer.PointerPressedCommand.get -> System.Windows.Input.ICommand!
 Microsoft.Maui.Controls.PointerGestureRecognizer.PointerPressedCommand.set -> void
@@ -85,6 +95,8 @@ Microsoft.Maui.Controls.VisualElement.RefreshIsEnabledProperty() -> void
 override Microsoft.Maui.Controls.Button.IsEnabledCore.get -> bool
 override Microsoft.Maui.Controls.ImageButton.IsEnabledCore.get -> bool
 override Microsoft.Maui.Controls.SearchBar.IsEnabledCore.get -> bool
+~Microsoft.Maui.Controls.InputView.FontFamily.get -> string
+~Microsoft.Maui.Controls.InputView.FontFamily.set -> void
 ~Microsoft.Maui.Controls.WebView.UserAgent.get -> string
 ~Microsoft.Maui.Controls.WebView.UserAgent.set -> void
 ~override Microsoft.Maui.Controls.Handlers.Items.ItemsViewHandler<TItemsView>.DisconnectHandler(AndroidX.RecyclerView.Widget.RecyclerView platformView) -> void
@@ -93,7 +105,13 @@ override Microsoft.Maui.Controls.SearchBar.IsEnabledCore.get -> bool
 ~override Microsoft.Maui.Controls.Region.Equals(object obj) -> bool
 ~override Microsoft.Maui.Controls.Shapes.Matrix.Equals(object obj) -> bool
 ~static Microsoft.Maui.Controls.Region.FromRectangles(System.Collections.Generic.IEnumerable<Microsoft.Maui.Graphics.Rect> rectangles) -> Microsoft.Maui.Controls.Region
+~static readonly Microsoft.Maui.Controls.InputView.CursorPositionProperty -> Microsoft.Maui.Controls.BindableProperty
+~static readonly Microsoft.Maui.Controls.InputView.FontAttributesProperty -> Microsoft.Maui.Controls.BindableProperty
+~static readonly Microsoft.Maui.Controls.InputView.FontAutoScalingEnabledProperty -> Microsoft.Maui.Controls.BindableProperty
+~static readonly Microsoft.Maui.Controls.InputView.FontFamilyProperty -> Microsoft.Maui.Controls.BindableProperty
+~static readonly Microsoft.Maui.Controls.InputView.FontSizeProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.InputView.IsTextPredictionEnabledProperty -> Microsoft.Maui.Controls.BindableProperty
+~static readonly Microsoft.Maui.Controls.InputView.SelectionLengthProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.WebView.UserAgentProperty -> Microsoft.Maui.Controls.BindableProperty
 ~virtual Microsoft.Maui.Controls.Platform.Compatibility.ShellItemRenderer.UpdateShellSectionIcon(Microsoft.Maui.Controls.ShellSection shellSection, Android.Views.IMenuItem menuItem) -> void
 ~virtual Microsoft.Maui.Controls.Platform.Compatibility.ShellItemRenderer.UpdateShellSectionTitle(Microsoft.Maui.Controls.ShellSection shellSection, Android.Views.IMenuItem menuItem) -> void
@@ -154,3 +172,42 @@ Microsoft.Maui.Controls.PlatformPointerEventArgs.Sender.get -> Android.Views.Vie
 ~static readonly Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTappedProperty -> Microsoft.Maui.Controls.BindableProperty
 Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTapped.get -> bool
 Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTapped.set -> void
+
+*REMOVED*~Microsoft.Maui.Controls.Editor.FontFamily.get -> string
+*REMOVED*~Microsoft.Maui.Controls.Editor.FontFamily.set -> void
+*REMOVED*Microsoft.Maui.Controls.Editor.CursorPosition.get -> int
+*REMOVED*Microsoft.Maui.Controls.Editor.CursorPosition.set -> void
+*REMOVED*Microsoft.Maui.Controls.Editor.FontAttributes.get -> Microsoft.Maui.Controls.FontAttributes
+*REMOVED*Microsoft.Maui.Controls.Editor.FontAttributes.set -> void
+*REMOVED*Microsoft.Maui.Controls.Editor.FontAutoScalingEnabled.get -> bool
+*REMOVED*Microsoft.Maui.Controls.Editor.FontAutoScalingEnabled.set -> void
+*REMOVED*Microsoft.Maui.Controls.Editor.FontSize.get -> double
+*REMOVED*Microsoft.Maui.Controls.Editor.FontSize.set -> void
+*REMOVED*Microsoft.Maui.Controls.Editor.SelectionLength.get -> int
+*REMOVED*Microsoft.Maui.Controls.Editor.SelectionLength.set -> void
+
+*REMOVED*~Microsoft.Maui.Controls.SearchBar.FontFamily.get -> string
+*REMOVED*~Microsoft.Maui.Controls.SearchBar.FontFamily.set -> void
+*REMOVED*Microsoft.Maui.Controls.SearchBar.CursorPosition.get -> int
+*REMOVED*Microsoft.Maui.Controls.SearchBar.CursorPosition.set -> void
+*REMOVED*Microsoft.Maui.Controls.SearchBar.FontAttributes.get -> Microsoft.Maui.Controls.FontAttributes
+*REMOVED*Microsoft.Maui.Controls.SearchBar.FontAttributes.set -> void
+*REMOVED*Microsoft.Maui.Controls.SearchBar.FontAutoScalingEnabled.get -> bool
+*REMOVED*Microsoft.Maui.Controls.SearchBar.FontAutoScalingEnabled.set -> void
+*REMOVED*Microsoft.Maui.Controls.SearchBar.FontSize.get -> double
+*REMOVED*Microsoft.Maui.Controls.SearchBar.FontSize.set -> void
+*REMOVED*Microsoft.Maui.Controls.SearchBar.SelectionLength.get -> int
+*REMOVED*Microsoft.Maui.Controls.SearchBar.SelectionLength.set -> void
+
+*REMOVED*~Microsoft.Maui.Controls.Entry.FontFamily.get -> string
+*REMOVED*~Microsoft.Maui.Controls.Entry.FontFamily.set -> void
+*REMOVED*Microsoft.Maui.Controls.Entry.CursorPosition.get -> int
+*REMOVED*Microsoft.Maui.Controls.Entry.CursorPosition.set -> void
+*REMOVED*Microsoft.Maui.Controls.Entry.FontAttributes.get -> Microsoft.Maui.Controls.FontAttributes
+*REMOVED*Microsoft.Maui.Controls.Entry.FontAttributes.set -> void
+*REMOVED*Microsoft.Maui.Controls.Entry.FontAutoScalingEnabled.get -> bool
+*REMOVED*Microsoft.Maui.Controls.Entry.FontAutoScalingEnabled.set -> void
+*REMOVED*Microsoft.Maui.Controls.Entry.FontSize.get -> double
+*REMOVED*Microsoft.Maui.Controls.Entry.FontSize.set -> void
+*REMOVED*Microsoft.Maui.Controls.Entry.SelectionLength.get -> int
+*REMOVED*Microsoft.Maui.Controls.Entry.SelectionLength.set -> void

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -5,6 +5,16 @@ Microsoft.Maui.Controls.DropEventArgs.Data.get -> Microsoft.Maui.Controls.DataPa
 Microsoft.Maui.Controls.DropEventArgs.DropEventArgs(Microsoft.Maui.Controls.DataPackageView! view) -> void
 Microsoft.Maui.Controls.Handlers.Compatibility.ViewRenderer<TElement, TPlatformView>.ViewRenderer(Microsoft.Maui.IPropertyMapper! mapper, Microsoft.Maui.CommandMapper? commandMapper = null) -> void
 Microsoft.Maui.Controls.Handlers.Compatibility.VisualElementRenderer<TElement>.VisualElementRenderer(Microsoft.Maui.IPropertyMapper! mapper, Microsoft.Maui.CommandMapper? commandMapper = null) -> void
+Microsoft.Maui.Controls.InputView.CursorPosition.get -> int
+Microsoft.Maui.Controls.InputView.CursorPosition.set -> void
+Microsoft.Maui.Controls.InputView.FontAttributes.get -> Microsoft.Maui.Controls.FontAttributes
+Microsoft.Maui.Controls.InputView.FontAttributes.set -> void
+Microsoft.Maui.Controls.InputView.FontAutoScalingEnabled.get -> bool
+Microsoft.Maui.Controls.InputView.FontAutoScalingEnabled.set -> void
+Microsoft.Maui.Controls.InputView.FontSize.get -> double
+Microsoft.Maui.Controls.InputView.FontSize.set -> void
+Microsoft.Maui.Controls.InputView.SelectionLength.get -> int
+Microsoft.Maui.Controls.InputView.SelectionLength.set -> void
 Microsoft.Maui.Controls.PlatformPointerEventArgs
 Microsoft.Maui.Controls.PlatformPointerEventArgs.GestureRecognizer.get -> UIKit.UIGestureRecognizer!
 Microsoft.Maui.Controls.PlatformPointerEventArgs.Sender.get -> UIKit.UIView!
@@ -86,6 +96,8 @@ static Microsoft.Maui.Controls.Shapes.Matrix.operator ==(Microsoft.Maui.Controls
 override Microsoft.Maui.Controls.View.ChangeVisualState() -> void
 Microsoft.Maui.Controls.Handlers.BoxViewHandler
 Microsoft.Maui.Controls.Handlers.BoxViewHandler.BoxViewHandler() -> void
+~Microsoft.Maui.Controls.InputView.FontFamily.get -> string
+~Microsoft.Maui.Controls.InputView.FontFamily.set -> void
 ~override Microsoft.Maui.Controls.Handlers.Items.CarouselViewController.DetermineCellReuseId(Foundation.NSIndexPath indexPath) -> string
 ~override Microsoft.Maui.Controls.ImageButton.OnPropertyChanged(string propertyName = null) -> void
 ~override Microsoft.Maui.Controls.Handlers.Compatibility.PhoneFlyoutPageRenderer.ViewWillTransitionToSize(CoreGraphics.CGSize toSize, UIKit.IUIViewControllerTransitionCoordinator coordinator) -> void
@@ -104,7 +116,13 @@ override Microsoft.Maui.Controls.SearchBar.IsEnabledCore.get -> bool
 ~override Microsoft.Maui.Controls.Region.Equals(object obj) -> bool
 ~override Microsoft.Maui.Controls.Shapes.Matrix.Equals(object obj) -> bool
 ~static Microsoft.Maui.Controls.Region.FromRectangles(System.Collections.Generic.IEnumerable<Microsoft.Maui.Graphics.Rect> rectangles) -> Microsoft.Maui.Controls.Region
+~static readonly Microsoft.Maui.Controls.InputView.CursorPositionProperty -> Microsoft.Maui.Controls.BindableProperty
+~static readonly Microsoft.Maui.Controls.InputView.FontAttributesProperty -> Microsoft.Maui.Controls.BindableProperty
+~static readonly Microsoft.Maui.Controls.InputView.FontAutoScalingEnabledProperty -> Microsoft.Maui.Controls.BindableProperty
+~static readonly Microsoft.Maui.Controls.InputView.FontFamilyProperty -> Microsoft.Maui.Controls.BindableProperty
+~static readonly Microsoft.Maui.Controls.InputView.FontSizeProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.InputView.IsTextPredictionEnabledProperty -> Microsoft.Maui.Controls.BindableProperty
+~static readonly Microsoft.Maui.Controls.InputView.SelectionLengthProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.WebView.UserAgentProperty -> Microsoft.Maui.Controls.BindableProperty
 *REMOVED*~Microsoft.Maui.Controls.OpenGLView.On<T>() -> Microsoft.Maui.Controls.IPlatformElementConfiguration<T, Microsoft.Maui.Controls.OpenGLView>
 *REMOVED*~Microsoft.Maui.Controls.OpenGLView.OnDisplay.get -> System.Action<Microsoft.Maui.Graphics.Rect>
@@ -162,3 +180,43 @@ Microsoft.Maui.Controls.ShellNavigationQueryParameters.Values.get -> System.Coll
 ~static readonly Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTappedProperty -> Microsoft.Maui.Controls.BindableProperty
 Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTapped.get -> bool
 Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTapped.set -> void
+
+*REMOVED*~Microsoft.Maui.Controls.Editor.FontFamily.get -> string
+*REMOVED*~Microsoft.Maui.Controls.Editor.FontFamily.set -> void
+*REMOVED*Microsoft.Maui.Controls.Editor.CursorPosition.get -> int
+*REMOVED*Microsoft.Maui.Controls.Editor.CursorPosition.set -> void
+*REMOVED*Microsoft.Maui.Controls.Editor.FontAttributes.get -> Microsoft.Maui.Controls.FontAttributes
+*REMOVED*Microsoft.Maui.Controls.Editor.FontAttributes.set -> void
+*REMOVED*Microsoft.Maui.Controls.Editor.FontAutoScalingEnabled.get -> bool
+*REMOVED*Microsoft.Maui.Controls.Editor.FontAutoScalingEnabled.set -> void
+*REMOVED*Microsoft.Maui.Controls.Editor.FontSize.get -> double
+*REMOVED*Microsoft.Maui.Controls.Editor.FontSize.set -> void
+*REMOVED*Microsoft.Maui.Controls.Editor.SelectionLength.get -> int
+*REMOVED*Microsoft.Maui.Controls.Editor.SelectionLength.set -> void
+
+*REMOVED*~Microsoft.Maui.Controls.SearchBar.FontFamily.get -> string
+*REMOVED*~Microsoft.Maui.Controls.SearchBar.FontFamily.set -> void
+*REMOVED*Microsoft.Maui.Controls.SearchBar.CursorPosition.get -> int
+*REMOVED*Microsoft.Maui.Controls.SearchBar.CursorPosition.set -> void
+*REMOVED*Microsoft.Maui.Controls.SearchBar.FontAttributes.get -> Microsoft.Maui.Controls.FontAttributes
+*REMOVED*Microsoft.Maui.Controls.SearchBar.FontAttributes.set -> void
+*REMOVED*Microsoft.Maui.Controls.SearchBar.FontAutoScalingEnabled.get -> bool
+*REMOVED*Microsoft.Maui.Controls.SearchBar.FontAutoScalingEnabled.set -> void
+*REMOVED*Microsoft.Maui.Controls.SearchBar.FontSize.get -> double
+*REMOVED*Microsoft.Maui.Controls.SearchBar.FontSize.set -> void
+*REMOVED*Microsoft.Maui.Controls.SearchBar.SelectionLength.get -> int
+*REMOVED*Microsoft.Maui.Controls.SearchBar.SelectionLength.set -> void
+
+*REMOVED*~Microsoft.Maui.Controls.Entry.FontFamily.get -> string
+*REMOVED*~Microsoft.Maui.Controls.Entry.FontFamily.set -> void
+*REMOVED*Microsoft.Maui.Controls.Entry.CursorPosition.get -> int
+*REMOVED*Microsoft.Maui.Controls.Entry.CursorPosition.set -> void
+*REMOVED*Microsoft.Maui.Controls.Entry.FontAttributes.get -> Microsoft.Maui.Controls.FontAttributes
+*REMOVED*Microsoft.Maui.Controls.Entry.FontAttributes.set -> void
+*REMOVED*Microsoft.Maui.Controls.Entry.FontAutoScalingEnabled.get -> bool
+*REMOVED*Microsoft.Maui.Controls.Entry.FontAutoScalingEnabled.set -> void
+*REMOVED*Microsoft.Maui.Controls.Entry.FontSize.get -> double
+*REMOVED*Microsoft.Maui.Controls.Entry.FontSize.set -> void
+*REMOVED*Microsoft.Maui.Controls.Entry.SelectionLength.get -> int
+*REMOVED*Microsoft.Maui.Controls.Entry.SelectionLength.set -> void
+

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -18,6 +18,16 @@ Microsoft.Maui.Controls.DropEventArgs.Data.get -> Microsoft.Maui.Controls.DataPa
 Microsoft.Maui.Controls.DropEventArgs.DropEventArgs(Microsoft.Maui.Controls.DataPackageView! view) -> void
 Microsoft.Maui.Controls.Handlers.Compatibility.ViewRenderer<TElement, TPlatformView>.ViewRenderer(Microsoft.Maui.IPropertyMapper! mapper, Microsoft.Maui.CommandMapper? commandMapper = null) -> void
 Microsoft.Maui.Controls.Handlers.Compatibility.VisualElementRenderer<TElement>.VisualElementRenderer(Microsoft.Maui.IPropertyMapper! mapper, Microsoft.Maui.CommandMapper? commandMapper = null) -> void
+Microsoft.Maui.Controls.InputView.CursorPosition.get -> int
+Microsoft.Maui.Controls.InputView.CursorPosition.set -> void
+Microsoft.Maui.Controls.InputView.FontAttributes.get -> Microsoft.Maui.Controls.FontAttributes
+Microsoft.Maui.Controls.InputView.FontAttributes.set -> void
+Microsoft.Maui.Controls.InputView.FontAutoScalingEnabled.get -> bool
+Microsoft.Maui.Controls.InputView.FontAutoScalingEnabled.set -> void
+Microsoft.Maui.Controls.InputView.FontSize.get -> double
+Microsoft.Maui.Controls.InputView.FontSize.set -> void
+Microsoft.Maui.Controls.InputView.SelectionLength.get -> int
+Microsoft.Maui.Controls.InputView.SelectionLength.set -> void
 Microsoft.Maui.Controls.PointerGestureRecognizer.PointerPressed -> System.EventHandler<Microsoft.Maui.Controls.PointerEventArgs!>?
 Microsoft.Maui.Controls.PointerGestureRecognizer.PointerPressedCommand.get -> System.Windows.Input.ICommand!
 Microsoft.Maui.Controls.PointerGestureRecognizer.PointerPressedCommand.set -> void
@@ -82,6 +92,8 @@ static Microsoft.Maui.Controls.Shapes.Matrix.operator ==(Microsoft.Maui.Controls
 override Microsoft.Maui.Controls.View.ChangeVisualState() -> void
 Microsoft.Maui.Controls.Handlers.BoxViewHandler
 Microsoft.Maui.Controls.Handlers.BoxViewHandler.BoxViewHandler() -> void
+~Microsoft.Maui.Controls.InputView.FontFamily.get -> string
+~Microsoft.Maui.Controls.InputView.FontFamily.set -> void
 ~override Microsoft.Maui.Controls.Handlers.Items.CarouselViewController.DetermineCellReuseId(Foundation.NSIndexPath indexPath) -> string
 ~override Microsoft.Maui.Controls.ImageButton.OnPropertyChanged(string propertyName = null) -> void
 ~override Microsoft.Maui.Controls.Handlers.Compatibility.PhoneFlyoutPageRenderer.ViewWillTransitionToSize(CoreGraphics.CGSize toSize, UIKit.IUIViewControllerTransitionCoordinator coordinator) -> void
@@ -100,7 +112,13 @@ override Microsoft.Maui.Controls.SearchBar.IsEnabledCore.get -> bool
 ~override Microsoft.Maui.Controls.Region.Equals(object obj) -> bool
 ~override Microsoft.Maui.Controls.Shapes.Matrix.Equals(object obj) -> bool
 ~static Microsoft.Maui.Controls.Region.FromRectangles(System.Collections.Generic.IEnumerable<Microsoft.Maui.Graphics.Rect> rectangles) -> Microsoft.Maui.Controls.Region
+~static readonly Microsoft.Maui.Controls.InputView.CursorPositionProperty -> Microsoft.Maui.Controls.BindableProperty
+~static readonly Microsoft.Maui.Controls.InputView.FontAttributesProperty -> Microsoft.Maui.Controls.BindableProperty
+~static readonly Microsoft.Maui.Controls.InputView.FontAutoScalingEnabledProperty -> Microsoft.Maui.Controls.BindableProperty
+~static readonly Microsoft.Maui.Controls.InputView.FontFamilyProperty -> Microsoft.Maui.Controls.BindableProperty
+~static readonly Microsoft.Maui.Controls.InputView.FontSizeProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.InputView.IsTextPredictionEnabledProperty -> Microsoft.Maui.Controls.BindableProperty
+~static readonly Microsoft.Maui.Controls.InputView.SelectionLengthProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.WebView.UserAgentProperty -> Microsoft.Maui.Controls.BindableProperty
 *REMOVED*~Microsoft.Maui.Controls.OpenGLView.On<T>() -> Microsoft.Maui.Controls.IPlatformElementConfiguration<T, Microsoft.Maui.Controls.OpenGLView>
 *REMOVED*~Microsoft.Maui.Controls.OpenGLView.OnDisplay.get -> System.Action<Microsoft.Maui.Graphics.Rect>
@@ -162,3 +180,43 @@ Microsoft.Maui.Controls.PlatformPointerEventArgs.Sender.get -> UIKit.UIView!
 ~static readonly Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTappedProperty -> Microsoft.Maui.Controls.BindableProperty
 Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTapped.get -> bool
 Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTapped.set -> void
+
+*REMOVED*~Microsoft.Maui.Controls.Editor.FontFamily.get -> string
+*REMOVED*~Microsoft.Maui.Controls.Editor.FontFamily.set -> void
+*REMOVED*Microsoft.Maui.Controls.Editor.CursorPosition.get -> int
+*REMOVED*Microsoft.Maui.Controls.Editor.CursorPosition.set -> void
+*REMOVED*Microsoft.Maui.Controls.Editor.FontAttributes.get -> Microsoft.Maui.Controls.FontAttributes
+*REMOVED*Microsoft.Maui.Controls.Editor.FontAttributes.set -> void
+*REMOVED*Microsoft.Maui.Controls.Editor.FontAutoScalingEnabled.get -> bool
+*REMOVED*Microsoft.Maui.Controls.Editor.FontAutoScalingEnabled.set -> void
+*REMOVED*Microsoft.Maui.Controls.Editor.FontSize.get -> double
+*REMOVED*Microsoft.Maui.Controls.Editor.FontSize.set -> void
+*REMOVED*Microsoft.Maui.Controls.Editor.SelectionLength.get -> int
+*REMOVED*Microsoft.Maui.Controls.Editor.SelectionLength.set -> void
+
+*REMOVED*~Microsoft.Maui.Controls.SearchBar.FontFamily.get -> string
+*REMOVED*~Microsoft.Maui.Controls.SearchBar.FontFamily.set -> void
+*REMOVED*Microsoft.Maui.Controls.SearchBar.CursorPosition.get -> int
+*REMOVED*Microsoft.Maui.Controls.SearchBar.CursorPosition.set -> void
+*REMOVED*Microsoft.Maui.Controls.SearchBar.FontAttributes.get -> Microsoft.Maui.Controls.FontAttributes
+*REMOVED*Microsoft.Maui.Controls.SearchBar.FontAttributes.set -> void
+*REMOVED*Microsoft.Maui.Controls.SearchBar.FontAutoScalingEnabled.get -> bool
+*REMOVED*Microsoft.Maui.Controls.SearchBar.FontAutoScalingEnabled.set -> void
+*REMOVED*Microsoft.Maui.Controls.SearchBar.FontSize.get -> double
+*REMOVED*Microsoft.Maui.Controls.SearchBar.FontSize.set -> void
+*REMOVED*Microsoft.Maui.Controls.SearchBar.SelectionLength.get -> int
+*REMOVED*Microsoft.Maui.Controls.SearchBar.SelectionLength.set -> void
+
+*REMOVED*~Microsoft.Maui.Controls.Entry.FontFamily.get -> string
+*REMOVED*~Microsoft.Maui.Controls.Entry.FontFamily.set -> void
+*REMOVED*Microsoft.Maui.Controls.Entry.CursorPosition.get -> int
+*REMOVED*Microsoft.Maui.Controls.Entry.CursorPosition.set -> void
+*REMOVED*Microsoft.Maui.Controls.Entry.FontAttributes.get -> Microsoft.Maui.Controls.FontAttributes
+*REMOVED*Microsoft.Maui.Controls.Entry.FontAttributes.set -> void
+*REMOVED*Microsoft.Maui.Controls.Entry.FontAutoScalingEnabled.get -> bool
+*REMOVED*Microsoft.Maui.Controls.Entry.FontAutoScalingEnabled.set -> void
+*REMOVED*Microsoft.Maui.Controls.Entry.FontSize.get -> double
+*REMOVED*Microsoft.Maui.Controls.Entry.FontSize.set -> void
+*REMOVED*Microsoft.Maui.Controls.Entry.SelectionLength.get -> int
+*REMOVED*Microsoft.Maui.Controls.Entry.SelectionLength.set -> void
+

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -16,6 +16,16 @@ Microsoft.Maui.Controls.DragGestureRecognizer.DropCompletedCommandParameter.set 
 Microsoft.Maui.Controls.DragStartingEventArgs.Data.get -> Microsoft.Maui.Controls.DataPackage!
 Microsoft.Maui.Controls.DropEventArgs.Data.get -> Microsoft.Maui.Controls.DataPackageView!
 Microsoft.Maui.Controls.DropEventArgs.DropEventArgs(Microsoft.Maui.Controls.DataPackageView! view) -> void
+Microsoft.Maui.Controls.InputView.CursorPosition.get -> int
+Microsoft.Maui.Controls.InputView.CursorPosition.set -> void
+Microsoft.Maui.Controls.InputView.FontAttributes.get -> Microsoft.Maui.Controls.FontAttributes
+Microsoft.Maui.Controls.InputView.FontAttributes.set -> void
+Microsoft.Maui.Controls.InputView.FontAutoScalingEnabled.get -> bool
+Microsoft.Maui.Controls.InputView.FontAutoScalingEnabled.set -> void
+Microsoft.Maui.Controls.InputView.FontSize.get -> double
+Microsoft.Maui.Controls.InputView.FontSize.set -> void
+Microsoft.Maui.Controls.InputView.SelectionLength.get -> int
+Microsoft.Maui.Controls.InputView.SelectionLength.set -> void
 Microsoft.Maui.Controls.PointerGestureRecognizer.PointerPressed -> System.EventHandler<Microsoft.Maui.Controls.PointerEventArgs!>?
 Microsoft.Maui.Controls.PointerGestureRecognizer.PointerPressedCommand.get -> System.Windows.Input.ICommand!
 Microsoft.Maui.Controls.PointerGestureRecognizer.PointerPressedCommand.set -> void
@@ -78,6 +88,8 @@ Microsoft.Maui.Controls.VisualElement.RefreshIsEnabledProperty() -> void
 override Microsoft.Maui.Controls.Button.IsEnabledCore.get -> bool
 override Microsoft.Maui.Controls.ImageButton.IsEnabledCore.get -> bool
 override Microsoft.Maui.Controls.SearchBar.IsEnabledCore.get -> bool
+~Microsoft.Maui.Controls.InputView.FontFamily.get -> string
+~Microsoft.Maui.Controls.InputView.FontFamily.set -> void
 ~Microsoft.Maui.Controls.WebView.UserAgent.get -> string
 ~Microsoft.Maui.Controls.WebView.UserAgent.set -> void
 ~static readonly Microsoft.Maui.Controls.WebView.UserAgentProperty -> Microsoft.Maui.Controls.BindableProperty
@@ -125,7 +137,13 @@ Microsoft.Maui.Controls.ShellNavigationQueryParameters.TryGetValue(string! key, 
 Microsoft.Maui.Controls.ShellNavigationQueryParameters.Values.get -> System.Collections.Generic.ICollection<object!>!
 ~Microsoft.Maui.Controls.Shell.GoToAsync(Microsoft.Maui.Controls.ShellNavigationState state, bool animate, Microsoft.Maui.Controls.ShellNavigationQueryParameters shellNavigationQueryParameters) -> System.Threading.Tasks.Task
 ~Microsoft.Maui.Controls.Shell.GoToAsync(Microsoft.Maui.Controls.ShellNavigationState state, Microsoft.Maui.Controls.ShellNavigationQueryParameters shellNavigationQueryParameters) -> System.Threading.Tasks.Task
+~static readonly Microsoft.Maui.Controls.InputView.CursorPositionProperty -> Microsoft.Maui.Controls.BindableProperty
+~static readonly Microsoft.Maui.Controls.InputView.FontAttributesProperty -> Microsoft.Maui.Controls.BindableProperty
+~static readonly Microsoft.Maui.Controls.InputView.FontAutoScalingEnabledProperty -> Microsoft.Maui.Controls.BindableProperty
+~static readonly Microsoft.Maui.Controls.InputView.FontFamilyProperty -> Microsoft.Maui.Controls.BindableProperty
+~static readonly Microsoft.Maui.Controls.InputView.FontSizeProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.InputView.IsTextPredictionEnabledProperty -> Microsoft.Maui.Controls.BindableProperty
+~static readonly Microsoft.Maui.Controls.InputView.SelectionLengthProperty -> Microsoft.Maui.Controls.BindableProperty
 ~Microsoft.Maui.Controls.Element.AddLogicalChild(Microsoft.Maui.Controls.Element element) -> void
 ~Microsoft.Maui.Controls.Element.InsertLogicalChild(int index, Microsoft.Maui.Controls.Element element) -> void
 ~Microsoft.Maui.Controls.Element.RemoveLogicalChild(Microsoft.Maui.Controls.Element element) -> bool
@@ -143,3 +161,42 @@ Microsoft.Maui.Controls.Handlers.Compatibility.VisualElementRenderer<TElement>.V
 ~static readonly Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTappedProperty -> Microsoft.Maui.Controls.BindableProperty
 Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTapped.get -> bool
 Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTapped.set -> void
+
+*REMOVED*~Microsoft.Maui.Controls.Editor.FontFamily.get -> string
+*REMOVED*~Microsoft.Maui.Controls.Editor.FontFamily.set -> void
+*REMOVED*Microsoft.Maui.Controls.Editor.CursorPosition.get -> int
+*REMOVED*Microsoft.Maui.Controls.Editor.CursorPosition.set -> void
+*REMOVED*Microsoft.Maui.Controls.Editor.FontAttributes.get -> Microsoft.Maui.Controls.FontAttributes
+*REMOVED*Microsoft.Maui.Controls.Editor.FontAttributes.set -> void
+*REMOVED*Microsoft.Maui.Controls.Editor.FontAutoScalingEnabled.get -> bool
+*REMOVED*Microsoft.Maui.Controls.Editor.FontAutoScalingEnabled.set -> void
+*REMOVED*Microsoft.Maui.Controls.Editor.FontSize.get -> double
+*REMOVED*Microsoft.Maui.Controls.Editor.FontSize.set -> void
+*REMOVED*Microsoft.Maui.Controls.Editor.SelectionLength.get -> int
+*REMOVED*Microsoft.Maui.Controls.Editor.SelectionLength.set -> void
+
+*REMOVED*~Microsoft.Maui.Controls.SearchBar.FontFamily.get -> string
+*REMOVED*~Microsoft.Maui.Controls.SearchBar.FontFamily.set -> void
+*REMOVED*Microsoft.Maui.Controls.SearchBar.CursorPosition.get -> int
+*REMOVED*Microsoft.Maui.Controls.SearchBar.CursorPosition.set -> void
+*REMOVED*Microsoft.Maui.Controls.SearchBar.FontAttributes.get -> Microsoft.Maui.Controls.FontAttributes
+*REMOVED*Microsoft.Maui.Controls.SearchBar.FontAttributes.set -> void
+*REMOVED*Microsoft.Maui.Controls.SearchBar.FontAutoScalingEnabled.get -> bool
+*REMOVED*Microsoft.Maui.Controls.SearchBar.FontAutoScalingEnabled.set -> void
+*REMOVED*Microsoft.Maui.Controls.SearchBar.FontSize.get -> double
+*REMOVED*Microsoft.Maui.Controls.SearchBar.FontSize.set -> void
+*REMOVED*Microsoft.Maui.Controls.SearchBar.SelectionLength.get -> int
+*REMOVED*Microsoft.Maui.Controls.SearchBar.SelectionLength.set -> void
+
+*REMOVED*~Microsoft.Maui.Controls.Entry.FontFamily.get -> string
+*REMOVED*~Microsoft.Maui.Controls.Entry.FontFamily.set -> void
+*REMOVED*Microsoft.Maui.Controls.Entry.CursorPosition.get -> int
+*REMOVED*Microsoft.Maui.Controls.Entry.CursorPosition.set -> void
+*REMOVED*Microsoft.Maui.Controls.Entry.FontAttributes.get -> Microsoft.Maui.Controls.FontAttributes
+*REMOVED*Microsoft.Maui.Controls.Entry.FontAttributes.set -> void
+*REMOVED*Microsoft.Maui.Controls.Entry.FontAutoScalingEnabled.get -> bool
+*REMOVED*Microsoft.Maui.Controls.Entry.FontAutoScalingEnabled.set -> void
+*REMOVED*Microsoft.Maui.Controls.Entry.FontSize.get -> double
+*REMOVED*Microsoft.Maui.Controls.Entry.FontSize.set -> void
+*REMOVED*Microsoft.Maui.Controls.Entry.SelectionLength.get -> int
+*REMOVED*Microsoft.Maui.Controls.Entry.SelectionLength.set -> void

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -16,6 +16,16 @@ Microsoft.Maui.Controls.DragGestureRecognizer.DropCompletedCommandParameter.set 
 Microsoft.Maui.Controls.DragStartingEventArgs.Data.get -> Microsoft.Maui.Controls.DataPackage!
 Microsoft.Maui.Controls.DropEventArgs.Data.get -> Microsoft.Maui.Controls.DataPackageView!
 Microsoft.Maui.Controls.DropEventArgs.DropEventArgs(Microsoft.Maui.Controls.DataPackageView! view) -> void
+Microsoft.Maui.Controls.InputView.CursorPosition.get -> int
+Microsoft.Maui.Controls.InputView.CursorPosition.set -> void
+Microsoft.Maui.Controls.InputView.FontAttributes.get -> Microsoft.Maui.Controls.FontAttributes
+Microsoft.Maui.Controls.InputView.FontAttributes.set -> void
+Microsoft.Maui.Controls.InputView.FontAutoScalingEnabled.get -> bool
+Microsoft.Maui.Controls.InputView.FontAutoScalingEnabled.set -> void
+Microsoft.Maui.Controls.InputView.FontSize.get -> double
+Microsoft.Maui.Controls.InputView.FontSize.set -> void
+Microsoft.Maui.Controls.InputView.SelectionLength.get -> int
+Microsoft.Maui.Controls.InputView.SelectionLength.set -> void
 static Microsoft.Maui.Controls.Handlers.ShellItemHandler.MapTitle(Microsoft.Maui.Controls.Handlers.ShellItemHandler! handler, Microsoft.Maui.Controls.ShellItem! item) -> void
 static Microsoft.Maui.Controls.Handlers.ShellSectionHandler.MapTitle(Microsoft.Maui.Controls.Handlers.ShellSectionHandler! handler, Microsoft.Maui.Controls.ShellSection! item) -> void
 Microsoft.Maui.Controls.Handlers.Compatibility.ViewRenderer<TElement, TNativeView>.ViewRenderer(Microsoft.Maui.IPropertyMapper! mapper, Microsoft.Maui.CommandMapper? commandMapper = null) -> void
@@ -96,6 +106,8 @@ Microsoft.Maui.Controls.VisualElement.RefreshIsEnabledProperty() -> void
 override Microsoft.Maui.Controls.Button.IsEnabledCore.get -> bool
 override Microsoft.Maui.Controls.ImageButton.IsEnabledCore.get -> bool
 override Microsoft.Maui.Controls.SearchBar.IsEnabledCore.get -> bool
+~Microsoft.Maui.Controls.InputView.FontFamily.get -> string
+~Microsoft.Maui.Controls.InputView.FontFamily.set -> void
 ~Microsoft.Maui.Controls.WebView.UserAgent.get -> string
 ~Microsoft.Maui.Controls.WebView.UserAgent.set -> void
 ~override Microsoft.Maui.Controls.Handlers.Items.StructuredItemsViewHandler<TItemsView>.ConnectHandler(Microsoft.UI.Xaml.Controls.ListViewBase platformView) -> void
@@ -106,7 +118,13 @@ override Microsoft.Maui.Controls.SearchBar.IsEnabledCore.get -> bool
 ~override Microsoft.Maui.Controls.Shapes.Matrix.Equals(object obj) -> bool
 ~static Microsoft.Maui.Controls.Handlers.ShellHandler.MapFlyoutIcon(Microsoft.Maui.Controls.Handlers.ShellHandler handler, Microsoft.Maui.Controls.Shell view) -> void
 ~static Microsoft.Maui.Controls.Region.FromRectangles(System.Collections.Generic.IEnumerable<Microsoft.Maui.Graphics.Rect> rectangles) -> Microsoft.Maui.Controls.Region
+~static readonly Microsoft.Maui.Controls.InputView.CursorPositionProperty -> Microsoft.Maui.Controls.BindableProperty
+~static readonly Microsoft.Maui.Controls.InputView.FontAttributesProperty -> Microsoft.Maui.Controls.BindableProperty
+~static readonly Microsoft.Maui.Controls.InputView.FontAutoScalingEnabledProperty -> Microsoft.Maui.Controls.BindableProperty
+~static readonly Microsoft.Maui.Controls.InputView.FontFamilyProperty -> Microsoft.Maui.Controls.BindableProperty
+~static readonly Microsoft.Maui.Controls.InputView.FontSizeProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.InputView.IsTextPredictionEnabledProperty -> Microsoft.Maui.Controls.BindableProperty
+~static readonly Microsoft.Maui.Controls.InputView.SelectionLengthProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.WebView.UserAgentProperty -> Microsoft.Maui.Controls.BindableProperty
 *REMOVED*~Microsoft.Maui.Controls.OpenGLView.On<T>() -> Microsoft.Maui.Controls.IPlatformElementConfiguration<T, Microsoft.Maui.Controls.OpenGLView>
 *REMOVED*~Microsoft.Maui.Controls.OpenGLView.OnDisplay.get -> System.Action<Microsoft.Maui.Graphics.Rect>
@@ -166,3 +184,42 @@ Microsoft.Maui.Controls.PlatformPointerEventArgs.Sender.get -> Microsoft.UI.Xaml
 ~static readonly Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTappedProperty -> Microsoft.Maui.Controls.BindableProperty
 Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTapped.get -> bool
 Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTapped.set -> void
+
+*REMOVED*~Microsoft.Maui.Controls.Editor.FontFamily.get -> string
+*REMOVED*~Microsoft.Maui.Controls.Editor.FontFamily.set -> void
+*REMOVED*Microsoft.Maui.Controls.Editor.CursorPosition.get -> int
+*REMOVED*Microsoft.Maui.Controls.Editor.CursorPosition.set -> void
+*REMOVED*Microsoft.Maui.Controls.Editor.FontAttributes.get -> Microsoft.Maui.Controls.FontAttributes
+*REMOVED*Microsoft.Maui.Controls.Editor.FontAttributes.set -> void
+*REMOVED*Microsoft.Maui.Controls.Editor.FontAutoScalingEnabled.get -> bool
+*REMOVED*Microsoft.Maui.Controls.Editor.FontAutoScalingEnabled.set -> void
+*REMOVED*Microsoft.Maui.Controls.Editor.FontSize.get -> double
+*REMOVED*Microsoft.Maui.Controls.Editor.FontSize.set -> void
+*REMOVED*Microsoft.Maui.Controls.Editor.SelectionLength.get -> int
+*REMOVED*Microsoft.Maui.Controls.Editor.SelectionLength.set -> void
+
+*REMOVED*~Microsoft.Maui.Controls.SearchBar.FontFamily.get -> string
+*REMOVED*~Microsoft.Maui.Controls.SearchBar.FontFamily.set -> void
+*REMOVED*Microsoft.Maui.Controls.SearchBar.CursorPosition.get -> int
+*REMOVED*Microsoft.Maui.Controls.SearchBar.CursorPosition.set -> void
+*REMOVED*Microsoft.Maui.Controls.SearchBar.FontAttributes.get -> Microsoft.Maui.Controls.FontAttributes
+*REMOVED*Microsoft.Maui.Controls.SearchBar.FontAttributes.set -> void
+*REMOVED*Microsoft.Maui.Controls.SearchBar.FontAutoScalingEnabled.get -> bool
+*REMOVED*Microsoft.Maui.Controls.SearchBar.FontAutoScalingEnabled.set -> void
+*REMOVED*Microsoft.Maui.Controls.SearchBar.FontSize.get -> double
+*REMOVED*Microsoft.Maui.Controls.SearchBar.FontSize.set -> void
+*REMOVED*Microsoft.Maui.Controls.SearchBar.SelectionLength.get -> int
+*REMOVED*Microsoft.Maui.Controls.SearchBar.SelectionLength.set -> void
+
+*REMOVED*~Microsoft.Maui.Controls.Entry.FontFamily.get -> string
+*REMOVED*~Microsoft.Maui.Controls.Entry.FontFamily.set -> void
+*REMOVED*Microsoft.Maui.Controls.Entry.CursorPosition.get -> int
+*REMOVED*Microsoft.Maui.Controls.Entry.CursorPosition.set -> void
+*REMOVED*Microsoft.Maui.Controls.Entry.FontAttributes.get -> Microsoft.Maui.Controls.FontAttributes
+*REMOVED*Microsoft.Maui.Controls.Entry.FontAttributes.set -> void
+*REMOVED*Microsoft.Maui.Controls.Entry.FontAutoScalingEnabled.get -> bool
+*REMOVED*Microsoft.Maui.Controls.Entry.FontAutoScalingEnabled.set -> void
+*REMOVED*Microsoft.Maui.Controls.Entry.FontSize.get -> double
+*REMOVED*Microsoft.Maui.Controls.Entry.FontSize.set -> void
+*REMOVED*Microsoft.Maui.Controls.Entry.SelectionLength.get -> int
+*REMOVED*Microsoft.Maui.Controls.Entry.SelectionLength.set -> void

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -18,6 +18,16 @@ Microsoft.Maui.Controls.DropEventArgs.Data.get -> Microsoft.Maui.Controls.DataPa
 Microsoft.Maui.Controls.DropEventArgs.DropEventArgs(Microsoft.Maui.Controls.DataPackageView! view) -> void
 Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTapped.get -> bool
 Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTapped.set -> void
+Microsoft.Maui.Controls.InputView.CursorPosition.get -> int
+Microsoft.Maui.Controls.InputView.CursorPosition.set -> void
+Microsoft.Maui.Controls.InputView.FontAttributes.get -> Microsoft.Maui.Controls.FontAttributes
+Microsoft.Maui.Controls.InputView.FontAttributes.set -> void
+Microsoft.Maui.Controls.InputView.FontAutoScalingEnabled.get -> bool
+Microsoft.Maui.Controls.InputView.FontAutoScalingEnabled.set -> void
+Microsoft.Maui.Controls.InputView.FontSize.get -> double
+Microsoft.Maui.Controls.InputView.FontSize.set -> void
+Microsoft.Maui.Controls.InputView.SelectionLength.get -> int
+Microsoft.Maui.Controls.InputView.SelectionLength.set -> void
 Microsoft.Maui.Controls.PointerGestureRecognizer.PointerPressed -> System.EventHandler<Microsoft.Maui.Controls.PointerEventArgs!>?
 Microsoft.Maui.Controls.PointerGestureRecognizer.PointerPressedCommand.get -> System.Windows.Input.ICommand!
 Microsoft.Maui.Controls.PointerGestureRecognizer.PointerPressedCommand.set -> void
@@ -76,6 +86,8 @@ Microsoft.Maui.Controls.VisualElement.RefreshIsEnabledProperty() -> void
 override Microsoft.Maui.Controls.Button.IsEnabledCore.get -> bool
 override Microsoft.Maui.Controls.ImageButton.IsEnabledCore.get -> bool
 override Microsoft.Maui.Controls.SearchBar.IsEnabledCore.get -> bool
+~Microsoft.Maui.Controls.InputView.FontFamily.get -> string
+~Microsoft.Maui.Controls.InputView.FontFamily.set -> void
 ~Microsoft.Maui.Controls.WebView.UserAgent.get -> string
 ~Microsoft.Maui.Controls.WebView.UserAgent.set -> void
 ~override Microsoft.Maui.Controls.ImageButton.OnPropertyChanged(string propertyName = null) -> void
@@ -86,7 +98,13 @@ override Microsoft.Maui.Controls.SearchBar.IsEnabledCore.get -> bool
 ~static Microsoft.Maui.Controls.RadioButton.MapContent(Microsoft.Maui.Handlers.RadioButtonHandler handler, Microsoft.Maui.Controls.RadioButton radioButton) -> void
 ~static Microsoft.Maui.Controls.Region.FromRectangles(System.Collections.Generic.IEnumerable<Microsoft.Maui.Graphics.Rect> rectangles) -> Microsoft.Maui.Controls.Region
 ~static readonly Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTappedProperty -> Microsoft.Maui.Controls.BindableProperty
+~static readonly Microsoft.Maui.Controls.InputView.CursorPositionProperty -> Microsoft.Maui.Controls.BindableProperty
+~static readonly Microsoft.Maui.Controls.InputView.FontAttributesProperty -> Microsoft.Maui.Controls.BindableProperty
+~static readonly Microsoft.Maui.Controls.InputView.FontAutoScalingEnabledProperty -> Microsoft.Maui.Controls.BindableProperty
+~static readonly Microsoft.Maui.Controls.InputView.FontFamilyProperty -> Microsoft.Maui.Controls.BindableProperty
+~static readonly Microsoft.Maui.Controls.InputView.FontSizeProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.InputView.IsTextPredictionEnabledProperty -> Microsoft.Maui.Controls.BindableProperty
+~static readonly Microsoft.Maui.Controls.InputView.SelectionLengthProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.WebView.UserAgentProperty -> Microsoft.Maui.Controls.BindableProperty
 *REMOVED*~Microsoft.Maui.Controls.OpenGLView.On<T>() -> Microsoft.Maui.Controls.IPlatformElementConfiguration<T, Microsoft.Maui.Controls.OpenGLView>
 *REMOVED*~Microsoft.Maui.Controls.OpenGLView.OnDisplay.get -> System.Action<Microsoft.Maui.Graphics.Rect>
@@ -140,3 +158,39 @@ Microsoft.Maui.Controls.PointerEventArgs.PlatformArgs.get -> Microsoft.Maui.Cont
 Microsoft.Maui.Controls.PlatformPointerEventArgs
 *REMOVED*override Microsoft.Maui.Controls.SwipeItems.OnBindingContextChanged() -> void
 *REMOVED*override Microsoft.Maui.Controls.SwipeView.OnBindingContextChanged() -> void
+*REMOVED*~Microsoft.Maui.Controls.Editor.FontFamily.get -> string
+*REMOVED*~Microsoft.Maui.Controls.Editor.FontFamily.set -> void
+*REMOVED*Microsoft.Maui.Controls.Editor.CursorPosition.get -> int
+*REMOVED*Microsoft.Maui.Controls.Editor.CursorPosition.set -> void
+*REMOVED*Microsoft.Maui.Controls.Editor.FontAttributes.get -> Microsoft.Maui.Controls.FontAttributes
+*REMOVED*Microsoft.Maui.Controls.Editor.FontAttributes.set -> void
+*REMOVED*Microsoft.Maui.Controls.Editor.FontAutoScalingEnabled.get -> bool
+*REMOVED*Microsoft.Maui.Controls.Editor.FontAutoScalingEnabled.set -> void
+*REMOVED*Microsoft.Maui.Controls.Editor.FontSize.get -> double
+*REMOVED*Microsoft.Maui.Controls.Editor.FontSize.set -> void
+*REMOVED*Microsoft.Maui.Controls.Editor.SelectionLength.get -> int
+*REMOVED*Microsoft.Maui.Controls.Editor.SelectionLength.set -> void
+*REMOVED*~Microsoft.Maui.Controls.SearchBar.FontFamily.get -> string
+*REMOVED*~Microsoft.Maui.Controls.SearchBar.FontFamily.set -> void
+*REMOVED*Microsoft.Maui.Controls.SearchBar.CursorPosition.get -> int
+*REMOVED*Microsoft.Maui.Controls.SearchBar.CursorPosition.set -> void
+*REMOVED*Microsoft.Maui.Controls.SearchBar.FontAttributes.get -> Microsoft.Maui.Controls.FontAttributes
+*REMOVED*Microsoft.Maui.Controls.SearchBar.FontAttributes.set -> void
+*REMOVED*Microsoft.Maui.Controls.SearchBar.FontAutoScalingEnabled.get -> bool
+*REMOVED*Microsoft.Maui.Controls.SearchBar.FontAutoScalingEnabled.set -> void
+*REMOVED*Microsoft.Maui.Controls.SearchBar.FontSize.get -> double
+*REMOVED*Microsoft.Maui.Controls.SearchBar.FontSize.set -> void
+*REMOVED*Microsoft.Maui.Controls.SearchBar.SelectionLength.get -> int
+*REMOVED*Microsoft.Maui.Controls.SearchBar.SelectionLength.set -> void
+*REMOVED*~Microsoft.Maui.Controls.Entry.FontFamily.get -> string
+*REMOVED*~Microsoft.Maui.Controls.Entry.FontFamily.set -> void
+*REMOVED*Microsoft.Maui.Controls.Entry.CursorPosition.get -> int
+*REMOVED*Microsoft.Maui.Controls.Entry.CursorPosition.set -> void
+*REMOVED*Microsoft.Maui.Controls.Entry.FontAttributes.get -> Microsoft.Maui.Controls.FontAttributes
+*REMOVED*Microsoft.Maui.Controls.Entry.FontAttributes.set -> void
+*REMOVED*Microsoft.Maui.Controls.Entry.FontAutoScalingEnabled.get -> bool
+*REMOVED*Microsoft.Maui.Controls.Entry.FontAutoScalingEnabled.set -> void
+*REMOVED*Microsoft.Maui.Controls.Entry.FontSize.get -> double
+*REMOVED*Microsoft.Maui.Controls.Entry.FontSize.set -> void
+*REMOVED*Microsoft.Maui.Controls.Entry.SelectionLength.get -> int
+*REMOVED*Microsoft.Maui.Controls.Entry.SelectionLength.set -> void

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -16,6 +16,16 @@ Microsoft.Maui.Controls.DragGestureRecognizer.DropCompletedCommandParameter.set 
 Microsoft.Maui.Controls.DragStartingEventArgs.Data.get -> Microsoft.Maui.Controls.DataPackage!
 Microsoft.Maui.Controls.DropEventArgs.Data.get -> Microsoft.Maui.Controls.DataPackageView!
 Microsoft.Maui.Controls.DropEventArgs.DropEventArgs(Microsoft.Maui.Controls.DataPackageView! view) -> void
+Microsoft.Maui.Controls.InputView.CursorPosition.get -> int
+Microsoft.Maui.Controls.InputView.CursorPosition.set -> void
+Microsoft.Maui.Controls.InputView.FontAttributes.get -> Microsoft.Maui.Controls.FontAttributes
+Microsoft.Maui.Controls.InputView.FontAttributes.set -> void
+Microsoft.Maui.Controls.InputView.FontAutoScalingEnabled.get -> bool
+Microsoft.Maui.Controls.InputView.FontAutoScalingEnabled.set -> void
+Microsoft.Maui.Controls.InputView.FontSize.get -> double
+Microsoft.Maui.Controls.InputView.FontSize.set -> void
+Microsoft.Maui.Controls.InputView.SelectionLength.get -> int
+Microsoft.Maui.Controls.InputView.SelectionLength.set -> void
 Microsoft.Maui.Controls.PointerGestureRecognizer.PointerPressed -> System.EventHandler<Microsoft.Maui.Controls.PointerEventArgs!>?
 Microsoft.Maui.Controls.PointerGestureRecognizer.PointerPressedCommand.get -> System.Windows.Input.ICommand!
 Microsoft.Maui.Controls.PointerGestureRecognizer.PointerPressedCommand.set -> void
@@ -98,6 +108,8 @@ override Microsoft.Maui.Controls.SearchBar.IsEnabledCore.get -> bool
 ~Microsoft.Maui.Controls.Element.AddLogicalChild(Microsoft.Maui.Controls.Element element) -> void
 ~Microsoft.Maui.Controls.Element.InsertLogicalChild(int index, Microsoft.Maui.Controls.Element element) -> void
 ~Microsoft.Maui.Controls.Element.RemoveLogicalChild(Microsoft.Maui.Controls.Element element) -> bool
+~Microsoft.Maui.Controls.InputView.FontFamily.get -> string
+~Microsoft.Maui.Controls.InputView.FontFamily.set -> void
 ~Microsoft.Maui.Controls.Shell.GoToAsync(Microsoft.Maui.Controls.ShellNavigationState state, bool animate, Microsoft.Maui.Controls.ShellNavigationQueryParameters shellNavigationQueryParameters) -> System.Threading.Tasks.Task
 ~Microsoft.Maui.Controls.Shell.GoToAsync(Microsoft.Maui.Controls.ShellNavigationState state, Microsoft.Maui.Controls.ShellNavigationQueryParameters shellNavigationQueryParameters) -> System.Threading.Tasks.Task
 ~Microsoft.Maui.Controls.WebView.UserAgent.get -> string
@@ -109,7 +121,13 @@ override Microsoft.Maui.Controls.SearchBar.IsEnabledCore.get -> bool
 ~static Microsoft.Maui.Controls.RadioButton.MapContent(Microsoft.Maui.Handlers.IRadioButtonHandler handler, Microsoft.Maui.Controls.RadioButton radioButton) -> void
 ~static Microsoft.Maui.Controls.RadioButton.MapContent(Microsoft.Maui.Handlers.RadioButtonHandler handler, Microsoft.Maui.Controls.RadioButton radioButton) -> void
 ~static Microsoft.Maui.Controls.Region.FromRectangles(System.Collections.Generic.IEnumerable<Microsoft.Maui.Graphics.Rect> rectangles) -> Microsoft.Maui.Controls.Region
+~static readonly Microsoft.Maui.Controls.InputView.CursorPositionProperty -> Microsoft.Maui.Controls.BindableProperty
+~static readonly Microsoft.Maui.Controls.InputView.FontAttributesProperty -> Microsoft.Maui.Controls.BindableProperty
+~static readonly Microsoft.Maui.Controls.InputView.FontAutoScalingEnabledProperty -> Microsoft.Maui.Controls.BindableProperty
+~static readonly Microsoft.Maui.Controls.InputView.FontFamilyProperty -> Microsoft.Maui.Controls.BindableProperty
+~static readonly Microsoft.Maui.Controls.InputView.FontSizeProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.InputView.IsTextPredictionEnabledProperty -> Microsoft.Maui.Controls.BindableProperty
+~static readonly Microsoft.Maui.Controls.InputView.SelectionLengthProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.WebView.UserAgentProperty -> Microsoft.Maui.Controls.BindableProperty
 *REMOVED*~Microsoft.Maui.Controls.OpenGLView.On<T>() -> Microsoft.Maui.Controls.IPlatformElementConfiguration<T, Microsoft.Maui.Controls.OpenGLView>
 *REMOVED*~Microsoft.Maui.Controls.OpenGLView.OnDisplay.get -> System.Action<Microsoft.Maui.Graphics.Rect>
@@ -140,3 +158,43 @@ Microsoft.Maui.Controls.PlatformPointerEventArgs
 ~static readonly Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTappedProperty -> Microsoft.Maui.Controls.BindableProperty
 Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTapped.get -> bool
 Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTapped.set -> void
+
+*REMOVED*~Microsoft.Maui.Controls.Editor.FontFamily.get -> string
+*REMOVED*~Microsoft.Maui.Controls.Editor.FontFamily.set -> void
+*REMOVED*Microsoft.Maui.Controls.Editor.CursorPosition.get -> int
+*REMOVED*Microsoft.Maui.Controls.Editor.CursorPosition.set -> void
+*REMOVED*Microsoft.Maui.Controls.Editor.FontAttributes.get -> Microsoft.Maui.Controls.FontAttributes
+*REMOVED*Microsoft.Maui.Controls.Editor.FontAttributes.set -> void
+*REMOVED*Microsoft.Maui.Controls.Editor.FontAutoScalingEnabled.get -> bool
+*REMOVED*Microsoft.Maui.Controls.Editor.FontAutoScalingEnabled.set -> void
+*REMOVED*Microsoft.Maui.Controls.Editor.FontSize.get -> double
+*REMOVED*Microsoft.Maui.Controls.Editor.FontSize.set -> void
+*REMOVED*Microsoft.Maui.Controls.Editor.SelectionLength.get -> int
+*REMOVED*Microsoft.Maui.Controls.Editor.SelectionLength.set -> void
+
+*REMOVED*~Microsoft.Maui.Controls.SearchBar.FontFamily.get -> string
+*REMOVED*~Microsoft.Maui.Controls.SearchBar.FontFamily.set -> void
+*REMOVED*Microsoft.Maui.Controls.SearchBar.CursorPosition.get -> int
+*REMOVED*Microsoft.Maui.Controls.SearchBar.CursorPosition.set -> void
+*REMOVED*Microsoft.Maui.Controls.SearchBar.FontAttributes.get -> Microsoft.Maui.Controls.FontAttributes
+*REMOVED*Microsoft.Maui.Controls.SearchBar.FontAttributes.set -> void
+*REMOVED*Microsoft.Maui.Controls.SearchBar.FontAutoScalingEnabled.get -> bool
+*REMOVED*Microsoft.Maui.Controls.SearchBar.FontAutoScalingEnabled.set -> void
+*REMOVED*Microsoft.Maui.Controls.SearchBar.FontSize.get -> double
+*REMOVED*Microsoft.Maui.Controls.SearchBar.FontSize.set -> void
+*REMOVED*Microsoft.Maui.Controls.SearchBar.SelectionLength.get -> int
+*REMOVED*Microsoft.Maui.Controls.SearchBar.SelectionLength.set -> void
+
+*REMOVED*~Microsoft.Maui.Controls.Entry.FontFamily.get -> string
+*REMOVED*~Microsoft.Maui.Controls.Entry.FontFamily.set -> void
+*REMOVED*Microsoft.Maui.Controls.Entry.CursorPosition.get -> int
+*REMOVED*Microsoft.Maui.Controls.Entry.CursorPosition.set -> void
+*REMOVED*Microsoft.Maui.Controls.Entry.FontAttributes.get -> Microsoft.Maui.Controls.FontAttributes
+*REMOVED*Microsoft.Maui.Controls.Entry.FontAttributes.set -> void
+*REMOVED*Microsoft.Maui.Controls.Entry.FontAutoScalingEnabled.get -> bool
+*REMOVED*Microsoft.Maui.Controls.Entry.FontAutoScalingEnabled.set -> void
+*REMOVED*Microsoft.Maui.Controls.Entry.FontSize.get -> double
+*REMOVED*Microsoft.Maui.Controls.Entry.FontSize.set -> void
+*REMOVED*Microsoft.Maui.Controls.Entry.SelectionLength.get -> int
+*REMOVED*Microsoft.Maui.Controls.Entry.SelectionLength.set -> void
+

--- a/src/Controls/src/Core/SearchBar/SearchBar.cs
+++ b/src/Controls/src/Core/SearchBar/SearchBar.cs
@@ -8,7 +8,7 @@ using Microsoft.Maui.Graphics;
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/SearchBar.xml" path="Type[@FullName='Microsoft.Maui.Controls.SearchBar']/Docs/*" />
-	public partial class SearchBar : InputView, IFontElement, ITextAlignmentElement, ISearchBarController, IElementConfiguration<SearchBar>, ICommandElement, ISearchBar
+	public partial class SearchBar : InputView, ITextAlignmentElement, ISearchBarController, IElementConfiguration<SearchBar>, ICommandElement, ISearchBar
 	{
 		/// <summary>Bindable property for <see cref="SearchCommand"/>.</summary>
 		public static readonly BindableProperty SearchCommandProperty = BindableProperty.Create(
@@ -32,28 +32,28 @@ namespace Microsoft.Maui.Controls
 		/// <include file="../../docs/Microsoft.Maui.Controls/SearchBar.xml" path="//Member[@MemberName='PlaceholderColorProperty']/Docs/*" />
 		public new static readonly BindableProperty PlaceholderColorProperty = InputView.PlaceholderColorProperty;
 
-		/// <summary>Bindable property for <see cref="FontFamily"/>.</summary>
-		public static readonly BindableProperty FontFamilyProperty = FontElement.FontFamilyProperty;
+		/// <inheritdoc cref="InputView.FontFamilyProperty"/>
+		public new static readonly BindableProperty FontFamilyProperty = InputView.FontFamilyProperty;
 
-		/// <summary>Bindable property for <see cref="FontSize"/>.</summary>
-		public static readonly BindableProperty FontSizeProperty = FontElement.FontSizeProperty;
+		/// <inheritdoc cref="InputView.FontSizeProperty"/>
+		public new static readonly BindableProperty FontSizeProperty = InputView.FontSizeProperty;
 
-		/// <summary>Bindable property for <see cref="FontAttributes"/>.</summary>
-		public static readonly BindableProperty FontAttributesProperty = FontElement.FontAttributesProperty;
+		/// <inheritdoc cref="InputView.FontAttributesProperty"/>
+		public new static readonly BindableProperty FontAttributesProperty = InputView.FontAttributesProperty;
+
+		/// <inheritdoc cref="InputView.FontAutoScalingEnabledProperty"/>
+		public new static readonly BindableProperty FontAutoScalingEnabledProperty = InputView.FontAutoScalingEnabledProperty;
 
 		/// <summary>
 		/// Backing store for the <see cref="InputView.IsTextPredictionEnabled"/> property.
 		/// </summary>
 		public static new readonly BindableProperty IsTextPredictionEnabledProperty = InputView.IsTextPredictionEnabledProperty;
 
-		/// <summary>Bindable property for <see cref="CursorPosition"/>.</summary>
-		public static readonly BindableProperty CursorPositionProperty = BindableProperty.Create(nameof(CursorPosition), typeof(int), typeof(SearchBar), 0, validateValue: (b, v) => (int)v >= 0);
+		/// <inheritdoc cref="InputView.CursorPositionProperty"/>
+		public new static readonly BindableProperty CursorPositionProperty = InputView.CursorPositionProperty;
 
-		/// <summary>Bindable property for <see cref="SelectionLength"/>.</summary>
-		public static readonly BindableProperty SelectionLengthProperty = BindableProperty.Create(nameof(SelectionLength), typeof(int), typeof(SearchBar), 0, validateValue: (b, v) => (int)v >= 0);
-
-		/// <summary>Bindable property for <see cref="FontAutoScalingEnabled"/>.</summary>
-		public static readonly BindableProperty FontAutoScalingEnabledProperty = FontElement.FontAutoScalingEnabledProperty;
+		/// <inheritdoc cref="InputView.SelectionLengthProperty"/>
+		public new static readonly BindableProperty SelectionLengthProperty = InputView.SelectionLengthProperty;
 
 		/// <summary>Bindable property for <see cref="HorizontalTextAlignment"/>.</summary>
 		public static readonly BindableProperty HorizontalTextAlignmentProperty = TextAlignmentElement.HorizontalTextAlignmentProperty;
@@ -104,67 +104,6 @@ namespace Microsoft.Maui.Controls
 			set { SetValue(SearchCommandParameterProperty, value); }
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/SearchBar.xml" path="//Member[@MemberName='FontAttributes']/Docs/*" />
-		public FontAttributes FontAttributes
-		{
-			get { return (FontAttributes)GetValue(FontAttributesProperty); }
-			set { SetValue(FontAttributesProperty, value); }
-		}
-
-		public int CursorPosition
-		{
-			get { return (int)GetValue(CursorPositionProperty); }
-			set { SetValue(CursorPositionProperty, value); }
-		}
-
-		public int SelectionLength
-		{
-			get { return (int)GetValue(SelectionLengthProperty); }
-			set { SetValue(SelectionLengthProperty, value); }
-		}
-
-		/// <include file="../../docs/Microsoft.Maui.Controls/SearchBar.xml" path="//Member[@MemberName='FontFamily']/Docs/*" />
-		public string FontFamily
-		{
-			get { return (string)GetValue(FontFamilyProperty); }
-			set { SetValue(FontFamilyProperty, value); }
-		}
-
-		/// <include file="../../docs/Microsoft.Maui.Controls/SearchBar.xml" path="//Member[@MemberName='FontSize']/Docs/*" />
-		[System.ComponentModel.TypeConverter(typeof(FontSizeConverter))]
-		public double FontSize
-		{
-			get { return (double)GetValue(FontSizeProperty); }
-			set { SetValue(FontSizeProperty, value); }
-		}
-
-		public bool FontAutoScalingEnabled
-		{
-			get => (bool)GetValue(FontAutoScalingEnabledProperty);
-			set => SetValue(FontAutoScalingEnabledProperty, value);
-		}
-
-		double IFontElement.FontSizeDefaultValueCreator() =>
-			this.GetDefaultFontSize();
-
-		void IFontElement.OnFontAttributesChanged(FontAttributes oldValue, FontAttributes newValue) =>
-			HandleFontChanged();
-
-		void IFontElement.OnFontFamilyChanged(string oldValue, string newValue) =>
-			HandleFontChanged();
-
-		void IFontElement.OnFontSizeChanged(double oldValue, double newValue) =>
-			HandleFontChanged();
-
-		void IFontElement.OnFontAutoScalingEnabledChanged(bool oldValue, bool newValue) =>
-			HandleFontChanged();
-
-		void HandleFontChanged()
-		{
-			Handler?.UpdateValue(nameof(ITextStyle.Font));
-			InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
-		}
-
 		public event EventHandler SearchButtonPressed;
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/SearchBar.xml" path="//Member[@MemberName='.ctor']/Docs/*" />
@@ -205,8 +144,6 @@ namespace Microsoft.Maui.Controls
 		void ITextAlignmentElement.OnHorizontalTextAlignmentPropertyChanged(TextAlignment oldValue, TextAlignment newValue)
 		{
 		}
-
-		Font ITextStyle.Font => this.ToFont();
 
 		bool ITextInput.IsTextPredictionEnabled => true;
 

--- a/src/Controls/tests/Core.UnitTests/InputViewTests.cs
+++ b/src/Controls/tests/Core.UnitTests/InputViewTests.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Maui.Controls.Core.UnitTests
+{
+	public class InputViewTests : BaseTestFixture
+	{
+
+		[Theory]
+		[InlineData(typeof(Entry))]
+		[InlineData(typeof(Editor))]
+		[InlineData(typeof(SearchBar))]
+		public void TwoWayBindingsStayWorking(Type type)
+		{
+			var inputView = Activator.CreateInstance(type) as InputView;
+			var bindInputView = Activator.CreateInstance(type) as InputView;
+
+			inputView.BindingContext = bindInputView;
+			inputView.SetBinding(InputView.TextProperty, nameof(InputView.Text), BindingMode.TwoWay);
+			(inputView as ITextInput).Text = "Some other text";
+
+			Assert.Equal(inputView.Text, bindInputView.Text);
+			bindInputView.Text = "Different Text";
+			Assert.Equal(inputView.Text, bindInputView.Text);
+		}
+
+		[Theory]
+		[InlineData(typeof(Entry))]
+		[InlineData(typeof(Editor))]
+		[InlineData(typeof(SearchBar))]
+		public void TwoWayBindingsStayWorkingSelectionLength(Type type)
+		{
+			var inputView = Activator.CreateInstance(type) as InputView;
+			var bindToInputView = Activator.CreateInstance(type) as InputView;
+
+			inputView.Text = "This is some text";
+			bindToInputView.Text = "This is some other text";
+
+			inputView.BindingContext = bindToInputView;
+			inputView.SetBinding(InputView.SelectionLengthProperty, nameof(InputView.SelectionLength), BindingMode.TwoWay);
+			(inputView as ITextInput).SelectionLength = 10;
+
+			Assert.Equal(inputView.SelectionLength, bindToInputView.SelectionLength);
+			bindToInputView.SelectionLength = 5;
+			Assert.Equal(inputView.SelectionLength, bindToInputView.SelectionLength);
+		}
+
+		[Theory]
+		[InlineData(typeof(Entry))]
+		[InlineData(typeof(Editor))]
+		[InlineData(typeof(SearchBar))]
+		public void TwoWayBindingsStayWorkingCursorPosition(Type type)
+		{
+			var inputView = Activator.CreateInstance(type) as InputView;
+			var bindToInputView = Activator.CreateInstance(type) as InputView;
+
+			inputView.Text = "This is some text";
+			bindToInputView.Text = "This is some other text";
+
+			inputView.BindingContext = bindToInputView;
+			inputView.SetBinding(InputView.CursorPositionProperty, nameof(InputView.CursorPosition), BindingMode.TwoWay);
+			(inputView as ITextInput).CursorPosition = 10;
+
+			Assert.Equal(inputView.CursorPosition, bindToInputView.CursorPosition);
+			bindToInputView.CursorPosition = 5;
+			Assert.Equal(inputView.CursorPosition, bindToInputView.CursorPosition);
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change

- Moves ITextInput and IFontElement to InputView
- Set specifiy when setting the value back from the Handlers the following text related properties:
   -Text
   -CursorPosition
   -SelectionLength
   
   this is work to get https://github.com/dotnet/maui/issues/16654