### PR TITLE
Fixed window not reacting to TitleBar wnd message

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.Windows.cs
@@ -147,26 +147,22 @@ namespace Microsoft.Maui.DeviceTests
 				var presenter = handler.PlatformView.AppWindow.Presenter as OverlappedPresenter;
 				var rootView = GetWindowRootView(handler);
 				var defaultTitleBarHeight = rootView.AppTitleBarActualHeight;
-				var screenPos = mauiToolBar.GetLocationOnScreen().Value.Y;
 				Assert.True(defaultTitleBarHeight > 0);
-				Assert.True(screenPos == 32);
+				Assert.True(mauiToolBar.GetLocationOnScreen().Value.Y == 32);
 
 				// Disable titlebar, maximize the window
 				presenter.SetBorderAndTitleBar(false, false);
 				presenter.Maximize();
 
 				// Wait for maximize animation to finish
-				await Task.Delay(350);
-				screenPos = mauiToolBar.GetLocationOnScreen().Value.Y;
-				Assert.True(screenPos == 0);
+				Assert.True(await AssertionExtensions.Wait(() => mauiToolBar.GetLocationOnScreen().Value.Y == 0));
 
 				// Now restore the window
 				presenter.SetBorderAndTitleBar(true, true);
 				presenter.Restore();
 				await Task.Delay(350);
 
-				screenPos = mauiToolBar.GetLocationOnScreen().Value.Y;
-				Assert.True(screenPos == 32);
+				Assert.True(await AssertionExtensions.Wait(() => mauiToolBar.GetLocationOnScreen().Value.Y == 32));
 			});
 		}
 

--- a/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.Windows.cs
@@ -160,7 +160,6 @@ namespace Microsoft.Maui.DeviceTests
 				// Now restore the window
 				presenter.SetBorderAndTitleBar(true, true);
 				presenter.Restore();
-				await Task.Delay(350);
 
 				Assert.True(await AssertionExtensions.Wait(() => mauiToolBar.GetLocationOnScreen().Value.Y == 32));
 			});

--- a/src/Core/src/Platform/Windows/ApplicationExtensions.cs
+++ b/src/Core/src/Platform/Windows/ApplicationExtensions.cs
@@ -26,9 +26,9 @@ namespace Microsoft.Maui.Platform
 			var window = application.CreateWindow(activationState);
 
 			winuiWindow.SetWindowHandler(window, mauiContext);
+			winuiWindow.SetWindow(window);
 
 			applicationContext.Services.InvokeLifecycleEvents<WindowsLifecycle.OnWindowCreated>(del => del(winuiWindow));
-			winuiWindow.SetWindow(window);
 			winuiWindow.Activate();
 		}
 	}

--- a/src/Core/src/Platform/Windows/MauiWinUIWindow.cs
+++ b/src/Core/src/Platform/Windows/MauiWinUIWindow.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Runtime.InteropServices;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui.ApplicationModel;
 using Microsoft.Maui.Devices;
 using Microsoft.Maui.LifecycleEvents;
@@ -132,6 +133,21 @@ namespace Microsoft.Maui
 						}
 
 						Marshal.StructureToPtr(rect, e.LParam, true);
+					}
+				}
+				else if (e.MessageId == PlatformMethods.MessageIds.WM_STYLECHANGING)
+				{
+					var styleChange = Marshal.PtrToStructure<PlatformMethods.STYLESTRUCT>(e.LParam);
+					if (e.WParam == (int)PlatformMethods.WindowLongFlags.GWL_STYLE)
+					{
+						bool hasTitleBar = (styleChange.StyleNew & (uint)PlatformMethods.WindowStyles.WS_CAPTION) != 0;
+
+						var mauiContext = Window?.Handler?.MauiContext;
+						if (mauiContext != null)
+						{
+							var navRootManager = mauiContext.Services.GetRequiredService<NavigationRootManager>();
+							navRootManager?.SetTitleBarVisibility(hasTitleBar);
+						}
 					}
 				}
 

--- a/src/Core/src/Platform/Windows/MauiWinUIWindow.cs
+++ b/src/Core/src/Platform/Windows/MauiWinUIWindow.cs
@@ -142,11 +142,10 @@ namespace Microsoft.Maui
 					{
 						bool hasTitleBar = (styleChange.StyleNew & (uint)PlatformMethods.WindowStyles.WS_CAPTION) != 0;
 
-						var mauiContext = Window?.Handler?.MauiContext;
-						if (mauiContext != null)
+						var rootManager = Window?.Handler?.MauiContext?.GetNavigationRootManager();
+						if (rootManager != null)
 						{
-							var navRootManager = mauiContext.Services.GetRequiredService<NavigationRootManager>();
-							navRootManager?.SetTitleBarVisibility(hasTitleBar);
+							rootManager?.SetTitleBarVisibility(hasTitleBar);
 						}
 					}
 				}

--- a/src/Core/src/Platform/Windows/NavigationRootManager.cs
+++ b/src/Core/src/Platform/Windows/NavigationRootManager.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
@@ -24,7 +23,7 @@ namespace Microsoft.Maui.Platform
 			// This should always get set by the code after but
 			// we are setting it just in case
 			var appbarHeight = 32;
-			if (AppWindowTitleBar.IsCustomizationSupported())
+			if (UI.Windowing.AppWindowTitleBar.IsCustomizationSupported())
 			{
 				var density = _platformWindow.GetDisplayDensity();
 				appbarHeight = (int)(_platformWindow.AppWindow.TitleBar.Height / density);
@@ -32,11 +31,27 @@ namespace Microsoft.Maui.Platform
 
 			_rootView.UpdateAppTitleBar(
 					appbarHeight,
-					AppWindowTitleBar.IsCustomizationSupported() &&
+					UI.Windowing.AppWindowTitleBar.IsCustomizationSupported() &&
 					_platformWindow.AppWindow.TitleBar.ExtendsContentIntoTitleBar
 				);
 
 			_rootView.OnApplyTemplateFinished += WindowRootViewOnApplyTemplateFinished;
+		}
+
+		internal void SetTitleBarVisibility(bool isVisible)
+		{
+			var appbarHeight = isVisible ? 32 : 0;
+			if (isVisible && UI.Windowing.AppWindowTitleBar.IsCustomizationSupported())
+			{
+				var density = _platformWindow.GetDisplayDensity();
+				appbarHeight = (int)(_platformWindow.AppWindow.TitleBar.Height / density);
+			}
+
+			_rootView.UpdateAppTitleBar(
+					appbarHeight,
+                    UI.Windowing.AppWindowTitleBar.IsCustomizationSupported() &&
+					isVisible
+				);
 		}
 
 		void WindowRootViewOnWindowTitleBarContentSizeChanged(object? sender, EventArgs e)

--- a/src/Core/src/Platform/Windows/NavigationRootManager.cs
+++ b/src/Core/src/Platform/Windows/NavigationRootManager.cs
@@ -17,29 +17,17 @@ namespace Microsoft.Maui.Platform
 			_platformWindow = platformWindow;
 			_rootView = new WindowRootView();
 			_rootView.BackRequested += OnBackRequested;
-
-			// https://learn.microsoft.com/en-us/windows/apps/design/basics/titlebar-design
-			// Standard title bar height is 32px
-			// This should always get set by the code after but
-			// we are setting it just in case
-			var appbarHeight = 32;
-			if (UI.Windowing.AppWindowTitleBar.IsCustomizationSupported())
-			{
-				var density = _platformWindow.GetDisplayDensity();
-				appbarHeight = (int)(_platformWindow.AppWindow.TitleBar.Height / density);
-			}
-
-			_rootView.UpdateAppTitleBar(
-					appbarHeight,
-					UI.Windowing.AppWindowTitleBar.IsCustomizationSupported() &&
-					_platformWindow.AppWindow.TitleBar.ExtendsContentIntoTitleBar
-				);
-
 			_rootView.OnApplyTemplateFinished += WindowRootViewOnApplyTemplateFinished;
+			
+			SetTitleBarVisibility(_platformWindow.AppWindow.TitleBar.ExtendsContentIntoTitleBar);
 		}
 
 		internal void SetTitleBarVisibility(bool isVisible)
 		{
+			// https://learn.microsoft.com/en-us/windows/apps/design/basics/titlebar-design
+			// Standard title bar height is 32px
+			// This should always get set by the code after but
+			// we are setting it just in case
 			var appbarHeight = isVisible ? 32 : 0;
 			if (isVisible && UI.Windowing.AppWindowTitleBar.IsCustomizationSupported())
 			{

--- a/src/Core/src/Platform/Windows/WindowRootView.cs
+++ b/src/Core/src/Platform/Windows/WindowRootView.cs
@@ -103,14 +103,11 @@ namespace Microsoft.Maui.Platform
 		{
 			_useCustomAppTitleBar = useCustomAppTitleBar;
 			WindowTitleBarContentControlMinHeight = appTitleBarHeight;
-			double topMargin = 0;
+			
+			double topMargin = appTitleBarHeight;
 			if (AppTitleBarContentControl != null)
 			{
-				topMargin = AppTitleBarContentControl.ActualHeight;
-			}
-			else
-			{
-				topMargin = appTitleBarHeight;
+				topMargin = Math.Min(appTitleBarHeight, AppTitleBarContentControl.ActualHeight);
 			}
 
 			if (useCustomAppTitleBar)
@@ -123,6 +120,7 @@ namespace Microsoft.Maui.Platform
 			}
 
 			UpdateRootNavigationViewMargins(topMargin);
+			this.RefreshThemeResources();
 		}
 
 		protected override void OnApplyTemplate()

--- a/src/Essentials/src/Platform/PlatformMethods.uwp.cs
+++ b/src/Essentials/src/Platform/PlatformMethods.uwp.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Maui.ApplicationModel
 			public const int WM_SETTINGCHANGE = 0x001A;
 			public const int WM_THEMECHANGE = 0x031A;
 			public const int WM_GETMINMAXINFO = 0x0024;
+			public const int WM_STYLECHANGING = 0x007C;
 		}
 
 		public delegate IntPtr WindowProc(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam);
@@ -166,6 +167,19 @@ namespace Microsoft.Maui.ApplicationModel
 		}
 
 		[Flags]
+		public enum WindowStyles : uint
+		{
+			WS_BORDER = 0x00800000,
+			WS_CAPTION = 0x00C00000,
+			WS_SYSMENU = 0x00080000,
+			WS_THICKFRAME = 0x00040000,
+			WS_MINIMIZEBOX = 0x00020000,
+			WS_MAXIMIZEBOX = 0x00020000,
+			WS_OVERLAPPED = 0x00000000,
+			WS_OVERLAPPEDWINDOW = WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU | WS_THICKFRAME | WS_MINIMIZEBOX | WS_MAXIMIZEBOX
+		}
+
+		[Flags]
 		public enum ExtendedWindowStyles : uint
 		{
 			WS_EX_RTLREADING = 0x00002000,
@@ -216,6 +230,13 @@ namespace Microsoft.Maui.ApplicationModel
 			public POINT MaxPosition;
 			public POINT MinTrackSize;
 			public POINT MaxTrackSize;
+		}
+
+		[StructLayout(LayoutKind.Sequential)]
+		public struct STYLESTRUCT
+		{
+			public uint StyleOld;
+			public uint StyleNew;
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change

Previously, when attempting to hide the titlebar using a WinUI call to `OverlappedPresenter.SetBorderAndTitleBar(false, false)`, we wouldn't properly adjust the height of the titlebar to be hidden. This PR adds logic to handle the window style change that signals when the titlebar has been hidden, and sets the height to 0.

Note: this PR no longer requires the need to call `TitleBar.ExtendsContentIntoTitleBar` to hide/show the titlebar. To make a window fullscreen without a titlebar do the following:

```
presenter.SetBorderAndTitleBar(false, false);
presenter.Maximize();;
```

### Issues Fixed

Fixes #15676