### PR TITLE
Fix UI drag & drop tests

### DIFF
--- a/src/Controls/samples/Controls.Sample.UITests/Elements/DragAndDropBetweenLayouts.xaml
+++ b/src/Controls/samples/Controls.Sample.UITests/Elements/DragAndDropBetweenLayouts.xaml
@@ -21,22 +21,22 @@
                             Drop="OnDrop">
                         </DropGestureRecognizer>
                     </StackLayout.GestureRecognizers>
-                    <Label HeightRequest="75" Background="Red" Text="Red" AutomationId="Red">
+                    <Label HeightRequest="50" Background="Red" Text="Red" AutomationId="Red">
                         <Label.GestureRecognizers>
                             <DragGestureRecognizer DropCompleted="OnDropCompleted" DragStarting="OnDragStarting"/>
                         </Label.GestureRecognizers>
                     </Label>
-                    <Label HeightRequest="75" Background="Purple" Text="Purple" AutomationId="Purple">
+                    <Label HeightRequest="50" Background="Purple" Text="Purple" AutomationId="Purple">
                         <Label.GestureRecognizers>
                             <DragGestureRecognizer DropCompleted="OnDropCompleted" DragStarting="OnDragStarting"/>
                         </Label.GestureRecognizers>
                     </Label>
-                    <Label HeightRequest="75" Background="Yellow" Text="Yellow" AutomationId="Yellow">
+                    <Label HeightRequest="50" Background="Yellow" Text="Yellow" AutomationId="Yellow">
                         <Label.GestureRecognizers>
                             <DragGestureRecognizer DropCompleted="OnDropCompleted" DragStarting="OnDragStarting"/>
                         </Label.GestureRecognizers>
                     </Label>
-                    <Label HeightRequest="75" Background="Blue" Text="Blue" AutomationId="Blue">
+                    <Label HeightRequest="50" Background="Blue" Text="Blue" AutomationId="Blue">
                         <Label.GestureRecognizers>
                             <DragGestureRecognizer DropCompleted="OnDropCompleted" DragStarting="OnDragStarting"/>
                         </Label.GestureRecognizers>
@@ -55,7 +55,7 @@
                             Drop="OnDrop">
                         </DropGestureRecognizer>
                     </StackLayout.GestureRecognizers>
-                    <Label HeightRequest="75" Background="Green" Text="Green" AutomationId="Green">
+                    <Label HeightRequest="50" Background="Green" Text="Green" AutomationId="Green">
                         <Label.GestureRecognizers>
                             <DragGestureRecognizer DropCompleted="OnDropCompleted" DragStarting="OnDragStarting"/>
                         </Label.GestureRecognizers>

--- a/src/Controls/samples/Controls.Sample.UITests/Elements/DragAndDropBetweenLayouts.xaml
+++ b/src/Controls/samples/Controls.Sample.UITests/Elements/DragAndDropBetweenLayouts.xaml
@@ -4,6 +4,7 @@
              AutomationId="DragAndDropBetweenLayouts"
              x:Class="Maui.Controls.Sample.DragAndDropBetweenLayouts">
     <StackLayout>
+        <Button AutomationId="ResetButton" Text="Reset View" Clicked="ResetLayouts"/>
         <Grid BackgroundColor="Purple">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*"/>
@@ -20,22 +21,22 @@
                             Drop="OnDrop">
                         </DropGestureRecognizer>
                     </StackLayout.GestureRecognizers>
-                    <Label HeightRequest="100" Background="Red" Text="Red" AutomationId="Red">
+                    <Label HeightRequest="75" Background="Red" Text="Red" AutomationId="Red">
                         <Label.GestureRecognizers>
                             <DragGestureRecognizer DropCompleted="OnDropCompleted" DragStarting="OnDragStarting"/>
                         </Label.GestureRecognizers>
                     </Label>
-                    <Label HeightRequest="100" Background="Purple" Text="Purple" AutomationId="Purple">
+                    <Label HeightRequest="75" Background="Purple" Text="Purple" AutomationId="Purple">
                         <Label.GestureRecognizers>
                             <DragGestureRecognizer DropCompleted="OnDropCompleted" DragStarting="OnDragStarting"/>
                         </Label.GestureRecognizers>
                     </Label>
-                    <Label HeightRequest="100" Background="Yellow" Text="Yellow" AutomationId="Yellow">
+                    <Label HeightRequest="75" Background="Yellow" Text="Yellow" AutomationId="Yellow">
                         <Label.GestureRecognizers>
                             <DragGestureRecognizer DropCompleted="OnDropCompleted" DragStarting="OnDragStarting"/>
                         </Label.GestureRecognizers>
                     </Label>
-                    <Label HeightRequest="100" Background="Blue" Text="Blue" AutomationId="Blue">
+                    <Label HeightRequest="75" Background="Blue" Text="Blue" AutomationId="Blue">
                         <Label.GestureRecognizers>
                             <DragGestureRecognizer DropCompleted="OnDropCompleted" DragStarting="OnDragStarting"/>
                         </Label.GestureRecognizers>
@@ -54,7 +55,7 @@
                             Drop="OnDrop">
                         </DropGestureRecognizer>
                     </StackLayout.GestureRecognizers>
-                    <Label HeightRequest="100" Background="Green" Text="Green" AutomationId="Green">
+                    <Label HeightRequest="75" Background="Green" Text="Green" AutomationId="Green">
                         <Label.GestureRecognizers>
                             <DragGestureRecognizer DropCompleted="OnDropCompleted" DragStarting="OnDragStarting"/>
                         </Label.GestureRecognizers>
@@ -62,7 +63,7 @@
                 </StackLayout>
             </ScrollView>
         </Grid>
-        <Label x:Name="events" AutomationId="DragEventsLabel" Text="EventsLabel"/>
+        <Label x:Name="events" AutomationId="DragEventsLabel" Text="EventsLabel: "/>
         <!-- DragStarting Labels-->
         <Label x:Name="dragStartRelativeSelf" AutomationId="DragStartRelativeSelf" Text="Drag Start relative to self:"/>
         <Label x:Name="dragStartRelativeScreen" AutomationId="DragStartRelativeScreen" Text="Drag Start relative to screen:"/>

--- a/src/Controls/samples/Controls.Sample.UITests/Elements/DragAndDropBetweenLayouts.xaml.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/Elements/DragAndDropBetweenLayouts.xaml.cs
@@ -132,5 +132,58 @@ namespace Maui.Controls.Sample
 
 			AddEvent(nameof(OnDrop));
 		}
-	}
+
+		private void ResetLayouts(object sender, System.EventArgs e)
+		{
+			SLAllColors.Clear();
+			SLRainbow.Clear();
+
+			var leftLayoutColors = new string[] { "Red", "Purple", "Yellow", "Blue"};
+			foreach (var color in leftLayoutColors)
+			{
+				SLAllColors.Add(RegenerateColorLabel(color));
+			}
+
+			SLRainbow.Add(RegenerateColorLabel("Green"));
+			ResetTestLabels();
+		}
+
+		private Label RegenerateColorLabel(string color)
+		{
+			var label = new Label { Text = color, AutomationId = color, HeightRequest = 75, BackgroundColor = Colors.AliceBlue };
+			label.BackgroundColor = color switch
+			{
+				"Red" => Colors.Red,
+				"Purple" => Colors.Purple,
+				"Yellow" => Colors.Yellow,
+				"Blue" => Colors.Blue,
+				"Green" => Colors.Green,
+				_ => Colors.White
+			};
+
+			var dragRecognizer = new DragGestureRecognizer();
+			dragRecognizer.DragStarting += OnDragStarting;
+			dragRecognizer.DropCompleted += OnDropCompleted;
+			label.GestureRecognizers.Add(dragRecognizer);
+
+			return label;
+		}
+
+		private void ResetTestLabels()
+		{
+			events.Text = "EventsLabel: ";
+
+			dragStartRelativeSelf.Text = "Drag Start relative to self:";
+			dragStartRelativeScreen.Text = "Drag Start relative to screen:";
+			dragStartRelativeLabel.Text = "Drag Start relative to this label:";
+
+			dragRelativeDrop.Text = "Drag relative to receiving layout:";
+			dragRelativeScreen.Text = "Drag relative to screen:";
+			dragRelativeLabel.Text = "Drag relative to this label:";
+
+			dropRelativeLayout.Text = "Drop relative to receiving layout:";
+			dropRelativeScreen.Text = "Drop relative to screen:";
+			dropRelativeLabel.Text = "Drop relative to this label:";
+		}
+    }
 }

--- a/src/Controls/samples/Controls.Sample.UITests/Elements/DragAndDropBetweenLayouts.xaml.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/Elements/DragAndDropBetweenLayouts.xaml.cs
@@ -22,7 +22,7 @@ namespace Maui.Controls.Sample
 			events.Text += $"{name},";
 		}
 
-		private void OnDragStarting(object sender, DragStartingEventArgs e)
+		void OnDragStarting(object sender, DragStartingEventArgs e)
 		{
 			_emittedDragOver = false;
 			var label = (Label)(sender as Element).Parent;
@@ -42,7 +42,7 @@ namespace Maui.Controls.Sample
 			dragStartRelativeLabel.Text = $"Drag Start relative to this label: {(int)e.GetPosition(dragStartRelativeLabel).Value.X},{(int)e.GetPosition(dragStartRelativeLabel).Value.Y}";
 		}
 
-		private void OnDropCompleted(object sender, DropCompletedEventArgs e)
+		void OnDropCompleted(object sender, DropCompletedEventArgs e)
 		{
 			var sl = (sender as Element).Parent.Parent as StackLayout;
 
@@ -54,7 +54,7 @@ namespace Maui.Controls.Sample
 			AddEvent(nameof(OnDropCompleted));
 		}
 
-		private void OnDragOver(object sender, DragEventArgs e)
+		void OnDragOver(object sender, DragEventArgs e)
 		{
 			if (!e.Data.Properties.ContainsKey("Source"))
 				return;
@@ -80,7 +80,7 @@ namespace Maui.Controls.Sample
 			dragRelativeLabel.Text = $"Drag relative to this label: {(int)e.GetPosition(dragRelativeLabel).Value.X},{(int)e.GetPosition(dragRelativeLabel).Value.Y}";
 		}
 
-		private void OnDragLeave(object sender, DragEventArgs e)
+		void OnDragLeave(object sender, DragEventArgs e)
 		{
 			if (!e.Data.Properties.ContainsKey("Source"))
 				return;
@@ -97,7 +97,7 @@ namespace Maui.Controls.Sample
 			AddEvent(nameof(OnDragLeave));
 		}
 
-		private void OnDrop(object sender, DropEventArgs e)
+		void OnDrop(object sender, DropEventArgs e)
 		{
 			if (!e.Data.Properties.ContainsKey("Source"))
 				return;
@@ -133,7 +133,7 @@ namespace Maui.Controls.Sample
 			AddEvent(nameof(OnDrop));
 		}
 
-		private void ResetLayouts(object sender, System.EventArgs e)
+		void ResetLayouts(object sender, System.EventArgs e)
 		{
 			SLAllColors.Clear();
 			SLRainbow.Clear();
@@ -148,9 +148,9 @@ namespace Maui.Controls.Sample
 			ResetTestLabels();
 		}
 
-		private Label RegenerateColorLabel(string color)
+		Label RegenerateColorLabel(string color)
 		{
-			var label = new Label { Text = color, AutomationId = color, HeightRequest = 75, BackgroundColor = Colors.AliceBlue };
+			var label = new Label { Text = color, AutomationId = color, HeightRequest = 50, BackgroundColor = Colors.AliceBlue };
 			label.BackgroundColor = color switch
 			{
 				"Red" => Colors.Red,
@@ -169,7 +169,7 @@ namespace Maui.Controls.Sample
 			return label;
 		}
 
-		private void ResetTestLabels()
+		void ResetTestLabels()
 		{
 			events.Text = "EventsLabel: ";
 

--- a/src/Controls/tests/UITests/Tests/DragAndDropUITests.cs
+++ b/src/Controls/tests/UITests/Tests/DragAndDropUITests.cs
@@ -54,6 +54,7 @@ namespace Microsoft.Maui.AppiumTests
 			App.Tap("ResetButton");
 
 			App.WaitForElement("Red");
+			App.WaitForElement("Green");
 			App.DragAndDrop("Red", "Green");
 			App.WaitForElement("DragEventsLabel");
 
@@ -74,6 +75,7 @@ namespace Microsoft.Maui.AppiumTests
 			App.Tap("ResetButton");
 
 			App.WaitForElement("Blue");
+			App.WaitForElement("Green");
 			App.DragAndDrop("Blue", "Green");
 
 			var dragStartRelativeToSelf  = GetCoordinatesFromLabel(App.Query("DragStartRelativeSelf").First().Text);
@@ -106,6 +108,7 @@ namespace Microsoft.Maui.AppiumTests
 			App.Tap("ResetButton");
 
 			App.WaitForElement("Blue");
+			App.WaitForElement("Green");
 			App.DragAndDrop("Blue", "Green");
 
 			var dragRelativeToDrop = GetCoordinatesFromLabel(App.Query("DragRelativeDrop").First().Text);
@@ -117,7 +120,6 @@ namespace Microsoft.Maui.AppiumTests
 			Assert.NotNull(dragRelativeToScreen);
 			Assert.NotNull(dragRelativeToLabel);
 			Assert.NotNull(dragStartRelativeToScreen);
-
 
 			Assert.True(dragRelativeToDrop!.Value.X > 0 && dragRelativeToDrop!.Value.Y > 0);
 			Assert.True(dragRelativeToScreen!.Value.X > 0 && dragRelativeToScreen!.Value.Y > 0);
@@ -144,6 +146,7 @@ namespace Microsoft.Maui.AppiumTests
 			App.Tap("ResetButton");
 
 			App.WaitForElement("Blue");
+			App.WaitForElement("Green");
 			App.DragAndDrop("Blue", "Green");
 
 			var dropRelativeToLayout = GetCoordinatesFromLabel(App.Query("DropRelativeLayout").First().Text);
@@ -152,7 +155,6 @@ namespace Microsoft.Maui.AppiumTests
 			
 			var dragRelativeToLabel = GetCoordinatesFromLabel(App.Query("DragRelativeLabel").First().Text);
 			var dragStartRelativeToScreen = GetCoordinatesFromLabel(App.Query("DragStartRelativeScreen").First().Text);
-
 
 			Assert.NotNull(dropRelativeToLayout);
 			Assert.NotNull(dropRelativeToScreen);

--- a/src/Controls/tests/UITests/Tests/DragAndDropUITests.cs
+++ b/src/Controls/tests/UITests/Tests/DragAndDropUITests.cs
@@ -51,6 +51,8 @@ namespace Microsoft.Maui.AppiumTests
 			App.EnterText("TargetView", "DragAndDropBetweenLayouts");
 			App.Tap("GoButton");
 
+			App.Tap("ResetButton");
+
 			App.WaitForElement("Red");
 			App.DragAndDrop("Red", "Green");
 			App.WaitForElement("DragEventsLabel");
@@ -68,6 +70,8 @@ namespace Microsoft.Maui.AppiumTests
 			App.WaitForElement("TargetView");
 			App.EnterText("TargetView", "DragAndDropBetweenLayouts");
 			App.Tap("GoButton");
+
+			App.Tap("ResetButton");
 
 			App.WaitForElement("Blue");
 			App.DragAndDrop("Blue", "Green");
@@ -98,6 +102,8 @@ namespace Microsoft.Maui.AppiumTests
 			App.WaitForElement("TargetView");
 			App.EnterText("TargetView", "DragAndDropBetweenLayouts");
 			App.Tap("GoButton");
+
+			App.Tap("ResetButton");
 
 			App.WaitForElement("Blue");
 			App.DragAndDrop("Blue", "Green");
@@ -134,6 +140,8 @@ namespace Microsoft.Maui.AppiumTests
 			App.WaitForElement("TargetView");
 			App.EnterText("TargetView", "DragAndDropBetweenLayouts");
 			App.Tap("GoButton");
+
+			App.Tap("ResetButton");
 
 			App.WaitForElement("Blue");
 			App.DragAndDrop("Blue", "Green");


### PR DESCRIPTION
### Description of Change

When running UI tests, I naively ran each individual test one by one instead of considering that the application state will remain after each test. This caused the drag & drop tests to fail because when the tests run in sequence, the expected coordinates of the events differ from what the tests were originally designed to check. 

### Issues Fixed

Added a "Reset" button to the view that gets clicked on each test run. The button regenerates the necessary layouts and text back to a base state so that every test is run under the same conditions.

The button is pressed at the **start** of every test run in case previous tests failed and were unable to set back the views to their original state. 

I also made the layouts slightly smaller to better fit within the screen. 
