### PR TITLE
Add properties to disable implicit things

### DIFF
--- a/src/Workload/Microsoft.Maui.Sdk/Sdk/BundledVersions.in.targets
+++ b/src/Workload/Microsoft.Maui.Sdk/Sdk/BundledVersions.in.targets
@@ -60,7 +60,7 @@
   </ItemGroup>
 
   <!-- These implicit <PackageReference/> pull dependencies from NuGet transitively -->
-  <ItemGroup Condition=" '$(UseMaui)' == 'true' or '$(UseMauiCore)' == 'true' ">
+  <ItemGroup Condition=" ('$(UseMaui)' == 'true' or '$(UseMauiCore)' == 'true') and ('$(DisableMauiImplicitPackageReferences)' != 'true') ">
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="@MicrosoftExtensionsServicingPackageVersion@" IsImplicitlyDefined="true">
       <PrivateAssets Condition=" '$(OutputType)' == 'Library' and '$(AndroidApplication)' != 'true' ">all</PrivateAssets>
     </PackageReference>
@@ -74,12 +74,12 @@
       <PrivateAssets Condition=" '$(OutputType)' == 'Library' and '$(AndroidApplication)' != 'true' ">all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
-  <ItemGroup Condition=" '$(UseMaui)' == 'true' or '$(UseMauiCore)' == 'true' or '$(UseMauiEssentials)' == 'true' ">
+  <ItemGroup Condition=" ('$(UseMaui)' == 'true' or '$(UseMauiCore)' == 'true' or '$(UseMauiEssentials)' == 'true') and ('$(DisableMauiImplicitPackageReferences)' != 'true') ">
     <PackageReference Include="Microsoft.Maui.Graphics" Version="$(MauiVersion)" IsImplicitlyDefined="true">
       <PrivateAssets Condition=" '$(OutputType)' == 'Library' and '$(AndroidApplication)' != 'true' ">all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
-  <ItemGroup Condition=" ('$(UseMaui)' == 'true' or '$(UseMauiCore)' == 'true'  or '$(UseMauiEssentials)' == 'true') and ('$(TargetPlatformIdentifier)' == 'android') ">
+  <ItemGroup Condition=" ('$(UseMaui)' == 'true' or '$(UseMauiCore)' == 'true'  or '$(UseMauiEssentials)' == 'true') and ('$(TargetPlatformIdentifier)' == 'android') and ('$(DisableMauiImplicitPackageReferences)' != 'true') ">
     <PackageReference Include="Xamarin.Android.Glide" Version="@_XamarinAndroidGlideVersion@" IsImplicitlyDefined="true">
       <PrivateAssets Condition=" '$(OutputType)' == 'Library' and '$(AndroidApplication)' != 'true' ">all</PrivateAssets>
     </PackageReference>
@@ -114,7 +114,7 @@
       <PrivateAssets Condition=" '$(OutputType)' == 'Library' and '$(AndroidApplication)' != 'true' ">all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
-  <ItemGroup Condition=" ('$(UseMaui)' == 'true' or '$(UseMauiCore)' == 'true' or '$(UseMauiEssentials)' == 'true') and ('$(TargetPlatformIdentifier)' == 'tizen') ">
+  <ItemGroup Condition=" ('$(UseMaui)' == 'true' or '$(UseMauiCore)' == 'true' or '$(UseMauiEssentials)' == 'true') and ('$(TargetPlatformIdentifier)' == 'tizen') and ('$(DisableMauiImplicitPackageReferences)' != 'true') ">
     <PackageReference Include="Tizen.UIExtensions.NUI" Version="@TizenUIExtensionsVersion@" IsImplicitlyDefined="true">
       <PrivateAssets Condition=" '$(OutputType)' == 'Library' ">all</PrivateAssets>
     </PackageReference>
@@ -122,12 +122,12 @@
       <PrivateAssets Condition=" '$(OutputType)' == 'Library' ">all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
-  <ItemGroup Condition=" '$(UseMaui)' == 'true' and '$(UsingMicrosoftNETSdkRazor)' == 'true' ">
+  <ItemGroup Condition=" ('$(UseMaui)' == 'true' and '$(UsingMicrosoftNETSdkRazor)' == 'true') and ('$(DisableMauiImplicitPackageReferences)' != 'true') ">
     <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="$(MauiVersion)" IsImplicitlyDefined="true">
       <PrivateAssets Condition=" '$(OutputType)' == 'Library' and '$(AndroidApplication)' != 'true' ">all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
-  <ItemGroup Condition=" ('$(UseMaui)' == 'true' or '$(UseMauiCore)' == 'true') and ('$(TargetPlatformIdentifier)' == 'windows') ">
+  <ItemGroup Condition=" ('$(UseMaui)' == 'true' or '$(UseMauiCore)' == 'true') and ('$(TargetPlatformIdentifier)' == 'windows') and ('$(DisableMauiImplicitPackageReferences)' != 'true') ">
     <PackageReference Include="Microsoft.Maui.Graphics.Win2D.WinUI.Desktop" Version="$(MauiVersion)" IsImplicitlyDefined="true">
       <PrivateAssets Condition=" '$(OutputType)' == 'Library' ">all</PrivateAssets>
     </PackageReference>

--- a/src/Workload/Microsoft.Maui.Sdk/Sdk/Sdk.targets
+++ b/src/Workload/Microsoft.Maui.Sdk/Sdk/Sdk.targets
@@ -1,6 +1,6 @@
 <Project>
 
-  <ItemGroup Condition=" '$(UseMauiNuGets)' != 'true' and '$(DisableImplicitFrameworkReferences)' != 'true' ">
+  <ItemGroup Condition=" '$(UseMauiNuGets)' != 'true' and '$(DisableImplicitFrameworkReferences)' != 'true' and '$(DisableMauiImplicitFrameworkReferences)' != 'true' ">
     <FrameworkReference
         Condition=" '$(UseMaui)' == 'true' or '$(UseMauiCore)' == 'true' "
         Include="Microsoft.Maui.Core"


### PR DESCRIPTION
### Description of Change

Add two properties to allow disabling of things for various reasons:

 - `DisableMauiImplicitPackageReferences` will allow users to disable the package references and allow for updates (where possible)
 - `DisableMauiImplicitFrameworkReferences` will disable the implicit `FrameworkReference` items so potentially allowing for Essentials to be updated via NuGet

If you set these properties in your csproj, you will now have full control over the things that are added, so you will still need to do very similar versions. See more info in the issue.

But you can do something like this:


```xml
<ItemGroup>
	<FrameworkReference Include="Microsoft.Maui.Core" />
	<FrameworkReference Include="Microsoft.Maui.Controls" />
	<FrameworkReference Include="Microsoft.Maui.Essentials" />
</ItemGroup>

<ItemGroup>
	<PackageReference Include="Microsoft.Maui.Graphics" Version="$(MauiVersion)" />
</ItemGroup>

<ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">
	<PackageReference Include="Xamarin.Android.Glide" Version="4.13.2.2" />
	<PackageReference Include="Xamarin.AndroidX.Browser" Version="1.4.0.3"  />
	<PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.15" />
	<PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.5.1.1" />
	<PackageReference Include="Xamarin.AndroidX.Navigation.Common" Version="2.5.2.1" />
	<PackageReference Include="Xamarin.AndroidX.Navigation.Fragment" Version="2.5.2.1" />
	<PackageReference Include="Xamarin.AndroidX.Navigation.Runtime" Version="2.5.2.1" />
	<PackageReference Include="Xamarin.AndroidX.Navigation.UI" Version="2.5.2.1" />
	<PackageReference Include="Xamarin.AndroidX.Security.SecurityCrypto" Version="1.1.0-alpha03" />
	<PackageReference Include="Xamarin.Google.Android.Material" Version="1.7.0" />
	<PackageReference Include="Xamarin.Google.Crypto.Tink.Android" Version="1.7.0.1" />
</ItemGroup>
```
