### PR TITLE
Fixed the tab bar not hiding/showing if property changed

### DIFF
--- a/src/Controls/src/Core/Handlers/Shell/ShellItemHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellItemHandler.Windows.cs
@@ -70,6 +70,8 @@ namespace Microsoft.Maui.Controls.Handlers
 				platformView.Loaded += OnNavigationViewLoaded;
 
 			base.ConnectHandler(platformView);
+
+			
 			ShellItemNavigationView.SelectionChanged += OnNavigationTabChanged;
 		}
 
@@ -129,16 +131,12 @@ namespace Microsoft.Maui.Controls.Handlers
 			IShellItemController shellItemController = VirtualView;
 			var items = new List<BaseShellItem>();
 
-			// only add items if we should be showing the tabs
-			if (shellItemController.ShowTabs)
+			foreach (var item in shellItemController.GetItems())
 			{
-				foreach (var item in shellItemController.GetItems())
-				{
-					if (Routing.IsImplicit(item))
-						items.Add(item.CurrentItem);
-					else
-						items.Add(item);
-				}
+				if (Routing.IsImplicit(item))
+					items.Add(item.CurrentItem);
+				else
+					items.Add(item);
 			}
 
 			object? selectedItem = null;
@@ -431,6 +429,7 @@ namespace Microsoft.Maui.Controls.Handlers
 		public static void MapTabBarIsVisible(ShellItemHandler handler, ShellItem item)
 		{
 			handler.ShellItemNavigationView.PaneDisplayMode = handler.GetNavigationViewPaneDisplayMode(item);
+			handler.ShellItemNavigationView.IsPaneVisible = ((IShellItemController)item).ShowTabs;
 		}
 
 		NavigationViewPaneDisplayMode GetNavigationViewPaneDisplayMode(IShellItemController shellItemController)

--- a/src/Controls/src/Core/Handlers/Shell/ShellItemHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellItemHandler.Windows.cs
@@ -225,7 +225,7 @@ namespace Microsoft.Maui.Controls.Handlers
 			if (syncSelectedItem && ShellItemNavigationView.SelectedItem != selectedItem)
 				ShellItemNavigationView.SelectedItem = selectedItem;
 
-			UpdateTabBarVisibility(shellItemController);
+			UpdateValue(Shell.TabBarIsVisibleProperty.PropertyName);
 		}
 
 		void UpdateSearchHandler()
@@ -373,7 +373,7 @@ namespace Microsoft.Maui.Controls.Handlers
 
 		internal void UpdateTitle()
 		{
-			MapMenuItems();
+			MapMenuItems(true);
 		}
 
 		void UpdateCurrentItem()

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTabBarTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTabBarTests.Windows.cs
@@ -18,6 +18,25 @@ namespace Microsoft.Maui.DeviceTests
 	[Category(TestCategory.Shell)]
 	public partial class ShellTests
 	{
+		[Fact(DisplayName = "Shell TabBar Visibility Toggle")]
+		public async Task ShellTabBarVisibilityToggleWorks()
+		{
+			await RunShellTabBarTests(shell => { },
+			(shell) =>
+			{
+				var shellItemHandler = shell.CurrentItem.Handler as ShellItemHandler;
+				var navView = shellItemHandler.PlatformView as MauiNavigationView;
+
+				Shell.SetTabBarIsVisible(shell.CurrentPage, true);
+				Assert.True(navView.IsPaneVisible);
+
+				Shell.SetTabBarIsVisible(shell.CurrentPage, false);
+				Assert.False(navView.IsPaneVisible);
+
+				return Task.FromResult(true);
+			});
+		}
+
 		List<WNavigationViewItem> GetTabBarItems(Shell shell)
 		{
 			var shellItemHandler = shell.CurrentItem.Handler as ShellItemHandler;

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTabBarTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTabBarTests.Windows.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Maui.DeviceTests
 	[Category(TestCategory.Shell)]
 	public partial class ShellTests
 	{
-		[Fact(DisplayName = "Shell TabBar Visibility Toggle")]
+		[Fact(DisplayName = "Shell TabBar visibility toggle")]
 		public async Task ShellTabBarVisibilityToggleWorks()
 		{
 			await RunShellTabBarTests(shell => { },
@@ -27,12 +27,35 @@ namespace Microsoft.Maui.DeviceTests
 				var shellItemHandler = shell.CurrentItem.Handler as ShellItemHandler;
 				var navView = shellItemHandler.PlatformView as MauiNavigationView;
 
-				Shell.SetTabBarIsVisible(shell.CurrentPage, true);
-				Assert.True(navView.IsPaneVisible);
-
 				Shell.SetTabBarIsVisible(shell.CurrentPage, false);
 				Assert.False(navView.IsPaneVisible);
 
+				Shell.SetTabBarIsVisible(shell.CurrentPage, true);
+				Assert.True(navView.IsPaneVisible);
+				Assert.True(navView.PaneDisplayMode == UI.Xaml.Controls.NavigationViewPaneDisplayMode.Top);
+
+				return Task.FromResult(true);
+			});
+		}
+
+		[Fact(DisplayName = "Shell TabBar visibility toggles when removing current")]
+		public async Task ShellTabBarVisibilityToggleWorksRemovingCurrentItem()
+		{
+			await RunShellTabBarTests(shell => { },
+			(shell) =>
+			{
+				var shellItemHandler = shell.CurrentItem.Handler as ShellItemHandler;
+				var navView = shellItemHandler.PlatformView as MauiNavigationView;
+
+				Shell.SetTabBarIsVisible(shell.Items[0].Items[1], false);
+				shell.CurrentItem = shell.Items[0].Items[1];
+
+				Assert.False(navView.IsPaneVisible);
+
+				shell.Items[0].Items.RemoveAt(1);
+
+				Assert.True(navView.IsPaneVisible);
+				Assert.True(navView.PaneDisplayMode == UI.Xaml.Controls.NavigationViewPaneDisplayMode.Top);
 				return Task.FromResult(true);
 			});
 		}


### PR DESCRIPTION
### Description of Change

The tabbar on Windows wouldn't toggle visibility if modified, and would only hide/show on current item change. Now, either binding or setting the property `Shell.TabBarIsVisible` on a ContentPage will update the tabbar visibility.


### Issues Fixed

Fixes #12499
Fixes #14969
