### PR TITLE
[xaml] locate event handlers from base types

### DIFF
--- a/src/Controls/src/Xaml/ApplyPropertiesVisitor.cs
+++ b/src/Controls/src/Xaml/ApplyPropertiesVisitor.cs
@@ -483,9 +483,11 @@ namespace Microsoft.Maui.Controls.Xaml
 			if (addMethod == null)
 				return false;
 
-			foreach (var mi in rootElement.GetType().GetRuntimeMethods())
+			var rootElementType = rootElement.GetType();
+			do
 			{
-				if (mi.Name == (string)value)
+				var mi = rootElementType.GetMethod((string)value, BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+				if (mi != null)
 				{
 					try
 					{
@@ -497,7 +499,8 @@ namespace Microsoft.Maui.Controls.Xaml
 						// incorrect method signature
 					}
 				}
-			}
+				rootElementType = rootElementType.BaseType;
+			} while (rootElementType is not null);
 
 			exception = new XamlParseException($"No method {value} with correct signature found on type {rootElement.GetType()}", lineInfo);
 			return false;

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui11467/Maui11467.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui11467/Maui11467.xaml
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<local:ParentButton xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests"
+             x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui11467">
+</local:ParentButton>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui11467/Maui11467.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui11467/Maui11467.xaml.cs
@@ -1,0 +1,34 @@
+using Microsoft.Maui.ApplicationModel;
+using Microsoft.Maui.Controls.Core.UnitTests;
+using NUnit.Framework;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public partial class Maui11467 : ParentButton
+{
+	public Maui11467() => InitializeComponent();
+
+	public Maui11467(bool useCompiledXaml)
+	{
+		//this stub will be replaced at compile time
+	}
+
+	[TestFixture]
+	class Test
+	{
+		[SetUp] public void Setup() => AppInfo.SetCurrent(new MockAppInfo());
+		[TearDown] public void TearDown() => AppInfo.SetCurrent(null);
+
+		[Test]
+		public void EventHandlerFromBaseType([Values(false, true)] bool useCompiledXaml)
+		{
+			if (useCompiledXaml)
+				MockCompiler.Compile(typeof(Maui11467));
+
+			// Used to throw:
+			// XamlParseException : Position 5:9. No method ParentButton_OnClicked with correct signature found on type Microsoft.Maui.Controls.Xaml.UnitTests.Maui11467
+			var button = new Maui11467(useCompiledXaml);
+			Assert.That(button.MyEventSubscriberCount, Is.EqualTo(1));
+		}
+	}
+}

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui11467/ParentButton.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui11467/ParentButton.xaml
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Button xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+        x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.ParentButton"
+        Clicked="ParentButton_OnClicked"
+        MyEvent="ParentButton_OnMyEvent"
+        Text="Parent">
+</Button>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui11467/ParentButton.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui11467/ParentButton.xaml.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public partial class ParentButton : Button
+{
+	public ParentButton() => InitializeComponent();
+
+	public ParentButton(bool useCompiledXaml)
+	{
+		//this stub will be replaced at compile time
+	}
+
+	EventHandler _myEvent;
+
+	public event EventHandler MyEvent
+	{
+		add => _myEvent += value;
+		remove => _myEvent -= value;
+	}
+
+	public int MyEventSubscriberCount => _myEvent.GetInvocationList().Length;
+
+	private void ParentButton_OnClicked(object sender, EventArgs e) { }
+
+	private void ParentButton_OnMyEvent(object sender, EventArgs e) { }
+}


### PR DESCRIPTION
Fixes #11467
Context: https://github.com/maiia-kuzmishyna/MAUI-ProtectedEventHandlers

Reviewing the customer sample, it appears to be a valid case. Consider a `ChildButton` defined in XAML:

    <local:ParentButton
        xmlns="http://xamarin.com/schemas/2014/forms"
        xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
        xmlns:local="clr-namespace:foo"
        x:Class="foo.ChildButton">
    </local:ParentButton>

Where `ParentButton` is also defined in XAML:

    <Button
        xmlns="http://xamarin.com/schemas/2014/forms"
        xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
        x:Class="foo.ParentButton"
        Clicked="ParentButton_OnClicked">
    </Button>

Where `ParentButton_OnClicked` is of course private:

    private void ParentButton_OnClicked(object sender, EventArgs e) { }

Throws an exception at runtime with:

    No method ParentButton_OnClicked with correct signature found on type foo.ChildButton

What was also odd, it appears the problem just "goes away" in Release mode, meaning it works under XamlC. This kind of points to a bug with non-compiled XAML.

It appears the problem was the code:

    foreach (var mi in rootElement.GetType().GetRuntimeMethods())
    {
        //...
        if (mi.Name == (string)value)
        {
            addMethod.Invoke(element, new[] { mi.CreateDelegate(eventInfo.EventHandlerType, mi.IsStatic ? null : rootElement) });
            return true;
        }
        //...
    }

In this example, `rootElement` is of type `ChildButton` while the method is on type `ParentButton`. As mentioned on:

https://stackoverflow.com/a/2267299

You need to access `Type.BaseType` to find private methods on base types.

I changed this to instead:

* Iterate over `rootElement.GetType()` and its base types.

* Call `Type.GetMethod()` using the method name, passing the appropriate `BindingFlags`.

This appears to make the new test pass, solving the issue.