### PR TITLE
[Android] Fix-Issue-With-Refresh-Indicator-Not-Hiding

### DIFF
--- a/src/Core/src/Handlers/RefreshView/RefreshViewHandler.Android.cs
+++ b/src/Core/src/Handlers/RefreshView/RefreshViewHandler.Android.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Maui.Handlers
 		{
 			base.ConnectHandler(platformView);
 			platformView.Refresh += OnSwipeRefresh;
+			platformView.SetProgressViewEndTarget(true, 50);
 		}
 
 		void OnSwipeRefresh(object? sender, System.EventArgs e)


### PR DESCRIPTION
### Description of Change
This is unrelated to #16910, as this is an older issue from .NET 7.

Added a call to SetProgressViewEndTarget in RefreshViewHandler.ConnectHandler to specify scaling down the Refresh Indicator as user swipes up, and a pixel offset for the indicator to stop at.

This makes the behavior consistent to what you would do if you if you drag down midway and then let go. The "bubble" scales to 0 and shrinks. 

Behavior Before (Scrub through it manually if you can't see the refresh indicator. Thanks @jknaudt21 for before capture):
![](https://user-images.githubusercontent.com/32918747/263416984-20eac7f8-9a4c-4386-8f08-e906bd199a97.gif)
Behavior After (Scrub through it manually if you can't see the refresh indicator)
![after_ind.webm](https://github.com/dotnet/maui/assets/89540402/fff45f73-d106-40d4-827d-204b029b588f)

This might be a candidate for the new Manual Testing because I don't think issues with Progress Indicator are easily testable with current unit/device tests.

### Issues Fixed
Fixes #8926 


