### PR TITLE
Fixed Android RoundRectangle border logic

### DIFF
--- a/src/Controls/src/Core/Shapes/RoundRectangle.cs
+++ b/src/Controls/src/Core/Shapes/RoundRectangle.cs
@@ -55,23 +55,17 @@ namespace Microsoft.Maui.Controls.Shapes
 
 		public override PathF GetPath()
 		{
-			var width = WidthForPathComputation;
-			var height = HeightForPathComputation;
-
-			var path = new PathF();
-
-			float x = (float)StrokeThickness / 2;
-			float y = (float)StrokeThickness / 2;
-
-			float w = (float)(width - StrokeThickness);
-			float h = (float)(height - StrokeThickness);
+			float w = (float)WidthForPathComputation;
+			float h = (float)HeightForPathComputation;
 
 			float topLeftCornerRadius = (float)CornerRadius.TopLeft;
 			float topRightCornerRadius = (float)CornerRadius.TopRight;
 			float bottomLeftCornerRadius = (float)CornerRadius.BottomLeft;
 			float bottomRightCornerRadius = (float)CornerRadius.BottomRight;
 
-			path.AppendRoundedRectangle(x, y, w, h, topLeftCornerRadius, topRightCornerRadius, bottomLeftCornerRadius, bottomRightCornerRadius);
+			var path = new PathF();
+
+			path.AppendRoundedRectangle(0, 0, w, h, topLeftCornerRadius, topRightCornerRadius, bottomLeftCornerRadius, bottomRightCornerRadius);
 
 			return path;
 		}
@@ -88,35 +82,31 @@ namespace Microsoft.Maui.Controls.Shapes
 			return path;
 		}
 
-		internal PathF GetInnerPath(float strokeWidth)
+		internal PathF GetInnerPath(float strokeThickness)
 		{
-			var width = WidthForPathComputation;
-			var height = HeightForPathComputation;
+			float w = (float)(WidthForPathComputation - strokeThickness);
+			float h = (float)(HeightForPathComputation - strokeThickness);
+			float x = strokeThickness / 2;
+			float y = strokeThickness / 2;
+
+			float topLeftCornerRadius = (float)Math.Max(0, CornerRadius.TopLeft - strokeThickness);
+			float topRightCornerRadius = (float)Math.Max(0, CornerRadius.TopRight - strokeThickness);
+			float bottomLeftCornerRadius = (float)Math.Max(0, CornerRadius.BottomLeft - strokeThickness);
+			float bottomRightCornerRadius = (float)Math.Max(0, CornerRadius.BottomRight - strokeThickness);
 
 			var path = new PathF();
-
-			float x = (float)StrokeThickness / 2;
-			float y = (float)StrokeThickness / 2;
-
-			float w = (float)(width - StrokeThickness);
-			float h = (float)(height - StrokeThickness);
-
-			float topLeftCornerRadius = (float)Math.Max(0, CornerRadius.TopLeft - strokeWidth);
-			float topRightCornerRadius = (float)Math.Max(0, CornerRadius.TopRight - strokeWidth);
-			float bottomLeftCornerRadius = (float)Math.Max(0, CornerRadius.BottomLeft - strokeWidth);
-			float bottomRightCornerRadius = (float)Math.Max(0, CornerRadius.BottomRight - strokeWidth);
 
 			path.AppendRoundedRectangle(x, y, w, h, topLeftCornerRadius, topRightCornerRadius, bottomLeftCornerRadius, bottomRightCornerRadius);
 
 			return path;
 		}
 
-		PathF IRoundRectangle.InnerPathForBounds(Rect viewBounds, float strokeWidth)
+		PathF IRoundRectangle.InnerPathForBounds(Rect viewBounds, float strokeThickness)
 		{
 			_fallbackHeight = viewBounds.Height;
 			_fallbackWidth = viewBounds.Width;
 
-			var path = GetInnerPath(strokeWidth);
+			var path = GetInnerPath(strokeThickness);
 
 			TransformPathForBounds(path, viewBounds);
 

--- a/src/Controls/tests/DeviceTests/Elements/Border/BorderTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Border/BorderTests.cs
@@ -77,13 +77,13 @@ namespace Microsoft.Maui.DeviceTests
 			var xy = radius - (radius / Math.Sqrt(2));
 
 			// This marks the outside edge of the rounded corner.
-			var outerXY = xy - (strokeThickness / 2);
+			var outerXY = xy;
 
-			// Add half the stroke thickness to find the inner edge of the rounded corner.
-			var innerXY = xy + (strokeThickness / 2);
+			// Add stroke thickness to find the inner edge of the rounded corner.
+			var innerXY = outerXY + strokeThickness;
 
 #if IOS
-			// FIXME: iOS seems to have a white boarder around the Border stroke
+			// FIXME: iOS seems to have a white border around the Border stroke
 
 			// Verify that the color outside of the rounded corner is the parent's color (White)
 			points[0] = new Point(5, 5);
@@ -160,11 +160,11 @@ namespace Microsoft.Maui.DeviceTests
 #endif
 
 			// Verify that the stroke is where we expect
-			points[0] = new Point(1 + offset, 1 + offset);
+			points[0] = new Point(offset + 1, offset + 1);
 			colors[0] = Colors.Black;
 
 			// Verify that the stroke is only as thick as we expect
-			points[1] = new Point(10 + offset, 10 + offset);
+			points[1] = new Point(offset + border.StrokeThickness + 1, offset + border.StrokeThickness + 1);
 			colors[1] = Colors.Red;
 
 			await AssertColorsAtPoints(grid, typeof(LayoutHandler), colors, points);

--- a/src/Controls/tests/DeviceTests/Elements/Border/BorderTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Border/BorderTests.cs
@@ -2,11 +2,11 @@
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Shapes;
 using Microsoft.Maui.DeviceTests.ImageAnalysis;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Hosting;
-using Microsoft.Maui.Platform;
 using Xunit;
 
 namespace Microsoft.Maui.DeviceTests
@@ -28,24 +28,93 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		[Fact(DisplayName = "Rounded Rectangle Border occupies correct space")]
-		public Task RoundedRectangleBorderLayoutIsCorrect()
+		public async Task RoundedRectangleBorderLayoutIsCorrect()
 		{
-			var expected = Colors.Red;
+			Color stroke = Colors.Black;
+			const int strokeThickness = 4;
+			const int radius = 20;
 
-			var container = new Grid();
-			container.WidthRequest = 100;
-			container.HeightRequest = 100;
+			var grid = new Grid()
+			{
+				ColumnDefinitions = new ColumnDefinitionCollection()
+				{
+					new ColumnDefinition(GridLength.Star),
+					new ColumnDefinition(GridLength.Star)
+				},
+				RowDefinitions = new RowDefinitionCollection()
+				{
+					new RowDefinition(GridLength.Star),
+					new RowDefinition(GridLength.Star)
+				},
+				BackgroundColor = Colors.White
+			};
+
+			var shape = new RoundRectangle()
+			{
+				CornerRadius = new CornerRadius(radius),
+			};
 
 			var border = new Border()
 			{
-				Stroke = Colors.Red,
-				StrokeThickness = 1,
+				StrokeShape = shape,
+				Stroke = stroke,
+				StrokeThickness = strokeThickness,
 				BackgroundColor = Colors.Red,
-				HeightRequest = 100,
-				WidthRequest = 100
 			};
 
-			return AssertColorAtPoint(border, expected, typeof(BorderHandler), 10, 10);
+			grid.Add(border, 0, 0);
+			grid.WidthRequest = 200;
+			grid.HeightRequest = 200;
+
+			await CreateHandlerAsync<BorderHandler>(border);
+			await CreateHandlerAsync<LayoutHandler>(grid);
+
+			var points = new Point[4];
+			var colors = new Color[4];
+
+			// To calculate the x and y offsets (from the center) for a 45-45-90 triangle, we can use the radius as the hypotenuse
+			// which means that the x and y offsets would be radius / sqrt(2).
+			var xy = radius - (radius / Math.Sqrt(2));
+
+			// This marks the outside edge of the rounded corner.
+			var outerXY = xy - (strokeThickness / 2);
+
+			// Add half the stroke thickness to find the inner edge of the rounded corner.
+			var innerXY = xy + (strokeThickness / 2);
+
+#if IOS
+			// FIXME: iOS seems to have a white boarder around the Border stroke
+
+			// Verify that the color outside of the rounded corner is the parent's color (White)
+			points[0] = new Point(5, 5);
+			colors[0] = Colors.White;
+
+			// Verify that the rounded corner stroke is where we expect it to be
+			points[1] = new Point(7, 7);
+			colors[1] = stroke;
+			points[2] = new Point(8, 8);
+			colors[2] = stroke;
+
+			// Verify that the background color starts where we'd expect it to start
+			points[3] = new Point(10, 10);
+			colors[3] = border.BackgroundColor;
+#else
+			// Verify that the color outside of the rounded corner is the parent's color (White)
+			points[0] = new Point(outerXY - 0.25, outerXY - 0.25);
+			colors[0] = Colors.White;
+
+			// Verify that the rounded corner stroke is where we expect it to be
+			points[1] = new Point(outerXY + 1.25, outerXY + 1.25);
+			colors[1] = stroke;
+			points[2] = new Point(innerXY - 1.25, innerXY - 1.25);
+			colors[2] = stroke;
+
+			// Verify that the background color starts where we'd expect it to start
+			points[3] = new Point(innerXY + 0.25, innerXY + 0.25);
+			colors[3] = border.BackgroundColor;
+#endif
+
+			await AssertColorsAtPoints(grid, typeof(LayoutHandler), colors, points);
 		}
 
 		[Fact(DisplayName = "StrokeThickness does not inset stroke path")]
@@ -80,11 +149,25 @@ namespace Microsoft.Maui.DeviceTests
 			await CreateHandlerAsync<BorderHandler>(border);
 			await CreateHandlerAsync<LayoutHandler>(grid);
 
+			var points = new Point[2];
+			var colors = new Color[2];
+
 #if IOS
 			// FIXME: iOS seems to have a white boarder around the Border stroke
+			int offset = 1;
 #else
-			await AssertColorAtPoint(grid, Colors.Black, typeof(LayoutHandler), 1, 1);
+			int offset = 0;
 #endif
+
+			// Verify that the stroke is where we expect
+			points[0] = new Point(1 + offset, 1 + offset);
+			colors[0] = Colors.Black;
+
+			// Verify that the stroke is only as thick as we expect
+			points[1] = new Point(10 + offset, 10 + offset);
+			colors[1] = Colors.Red;
+
+			await AssertColorsAtPoints(grid, typeof(LayoutHandler), colors, points);
 		}
 
 		// NOTE: this test is slightly different than MemoryTests.HandlerDoesNotLeak

--- a/src/Controls/tests/DeviceTests/Elements/Border/BorderTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Border/BorderTests.cs
@@ -198,11 +198,11 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.False(platformViewReference.IsAlive, "PlatformView should not be alive!");
 		}
 
-#if IOS
+#if IOS || ANDROID
 		[Fact("Ensures the border renders the expected size - Issue 15339")]
 #else
 		[Fact("Ensures the border renders the expected size - Issue 15339", 
-			Skip = "Current fails on platforms other than iOS; we're working on it.")]
+			Skip = "Current fails on platforms other than iOS and Android; we're working on it.")]
 #endif
 		public async Task BorderAndStrokeIsCorrectSize()
 		{

--- a/src/Core/src/Graphics/MauiDrawable.Android.cs
+++ b/src/Core/src/Graphics/MauiDrawable.Android.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Maui.Graphics
 	public class MauiDrawable : PaintDrawable
 	{
 		readonly AContext? _context;
-		readonly double _density;
+		readonly float _density;
 
 		bool _invalidatePath;
 
@@ -407,8 +407,14 @@ namespace Microsoft.Maui.Graphics
 
 					if (_shape != null)
 					{
-						var bounds = new Graphics.Rect(0, 0, _width, _height);
-						var clipPath = _shape?.ToPlatform(bounds, _strokeThickness);
+						float strokeThickness = _strokeThickness / _density;
+						float w = (_width / _density) - strokeThickness;
+						float h = (_height / _density) - strokeThickness;
+						float x = strokeThickness / 2;
+						float y = strokeThickness / 2;
+
+						var bounds = new Graphics.Rect(x, y, w, h);
+						var clipPath = _shape?.ToPlatform(bounds, strokeThickness, _density);
 
 						if (clipPath == null)
 							return;

--- a/src/Core/src/Platform/Android/BorderDrawable.cs
+++ b/src/Core/src/Platform/Android/BorderDrawable.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Maui.Platform
 	public class BorderDrawable : PaintDrawable
 	{
 		readonly AContext? _context;
-		readonly double _density;
+		readonly float _density;
 
 		bool _invalidatePath;
 
@@ -292,6 +292,7 @@ namespace Microsoft.Maui.Platform
 			{
 				_invalidatePath = false;
 
+				// TODO: Should this do the same thing as MauiDrawable.Android.cs? I suspect it should.
 				var path = GetPath(_width, _height, _cornerRadius, _strokeThickness);
 				var clipPath = path?.AsAndroidPath();
 

--- a/src/Core/src/Platform/Android/ContentViewGroup.cs
+++ b/src/Core/src/Platform/Android/ContentViewGroup.cs
@@ -116,19 +116,16 @@ namespace Microsoft.Maui.Platform
 				return null;
 
 			float density = _context.GetDisplayDensity();
-
-			float strokeThickness = (float)(Clip.StrokeThickness * density);
-
-			IShape clipShape = Clip.Shape;
-
+			float strokeThickness = (float)Clip.StrokeThickness;
+			float w = (width / density) - strokeThickness;
+			float h = (height / density) - strokeThickness;
 			float x = strokeThickness / 2;
 			float y = strokeThickness / 2;
-			float w = width - strokeThickness;
-			float h = height - strokeThickness;
+			IShape clipShape = Clip.Shape;
 
 			var bounds = new Graphics.RectF(x, y, w, h);
 
-			Path? platformPath = clipShape.ToPlatform(bounds, strokeThickness, true);
+			Path? platformPath = clipShape.ToPlatform(bounds, strokeThickness, density, true);
 			return platformPath;
 		}
 

--- a/src/Core/src/Platform/Android/ShapeExtensions.cs
+++ b/src/Core/src/Platform/Android/ShapeExtensions.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Maui.Platform
 {
 	public static class ShapeExtensions
 	{
-		public static Path ToPlatform(this IShape shape, Graphics.Rect bounds, float strokeThickness, bool innerPath = false)
+		public static Path ToPlatform(this IShape shape, Graphics.Rect bounds, float strokeThickness, float density, bool innerPath = false)
 		{
 			Graphics.Rect pathBounds;
 			PathF path;
@@ -16,7 +16,7 @@ namespace Microsoft.Maui.Platform
 				if (shape is IRoundRectangle roundRectangle)
 				{
 					path = roundRectangle.InnerPathForBounds(bounds, strokeThickness);
-					return path.AsAndroidPath();
+					return path.AsAndroidPath(scaleX: density, scaleY: density);
 				}
 
 				float x = (float)bounds.X + strokeThickness / 2;
@@ -33,7 +33,7 @@ namespace Microsoft.Maui.Platform
 
 			path = shape.PathForBounds(pathBounds);
 
-			return path.AsAndroidPath();
+			return path.AsAndroidPath(scaleX: density, scaleY: density);
 		}
 	}
 }

--- a/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -99,7 +99,7 @@ Microsoft.Maui.IWebView.UserAgent.get -> string?
 Microsoft.Maui.IWebView.UserAgent.set -> void
 static Microsoft.Maui.Handlers.WebViewHandler.MapUserAgent(Microsoft.Maui.Handlers.IWebViewHandler! handler, Microsoft.Maui.IWebView! webView) -> void
 static Microsoft.Maui.Platform.ApplicationExtensions.UpdateNightMode(this Microsoft.Maui.IApplication! application) -> void
-static Microsoft.Maui.Platform.ShapeExtensions.ToPlatform(this Microsoft.Maui.Graphics.IShape! shape, Microsoft.Maui.Graphics.Rect bounds, float strokeThickness, bool innerPath = false) -> Android.Graphics.Path!
+static Microsoft.Maui.Platform.ShapeExtensions.ToPlatform(this Microsoft.Maui.Graphics.IShape! shape, Microsoft.Maui.Graphics.Rect bounds, float strokeThickness, float density, bool innerPath = false) -> Android.Graphics.Path!
 static Microsoft.Maui.Platform.ViewGroupExtensions.TryGetFirstChildOfType<T>(this Android.Views.ViewGroup! viewGroup, out T? result) -> bool
 static Microsoft.Maui.Platform.WebViewExtensions.UpdateUserAgent(this Android.Webkit.WebView! platformWebView, Microsoft.Maui.IWebView! webView) -> void
 *REMOVED*Microsoft.Maui.WeakEventManager.HandleEvent(object! sender, object! args, string! eventName) -> void

--- a/src/Core/tests/DeviceTests.Shared/HandlerTests/HandlerTestBasement.cs
+++ b/src/Core/tests/DeviceTests.Shared/HandlerTests/HandlerTestBasement.cs
@@ -272,6 +272,15 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
+		protected Task AssertColorsAtPoints(IView view, Type handlerType, Color[] colors, Point[] points)
+		{
+			return InvokeOnMainThreadAsync(async () =>
+			{
+				var plaformView = CreateHandler(view, handlerType).ToPlatform();
+				await plaformView.AssertColorsAtPointsAsync(colors, points, MauiContext);
+			});
+		}
+
 		protected Task<ImageAnalysis.RawBitmap> GetRawBitmap(Controls.VisualElement view, Type handlerType)
 		{
 			return InvokeOnMainThreadAsync<RawBitmap>(async () =>

--- a/src/TestUtils/src/DeviceTests/AssertionExtensions.Android.cs
+++ b/src/TestUtils/src/DeviceTests/AssertionExtensions.Android.cs
@@ -523,6 +523,19 @@ namespace Microsoft.Maui.DeviceTests
 			return bitmap.AssertColorAtPoint(expectedColor, x, y);
 		}
 
+		public static async Task<Bitmap> AssertColorsAtPointsAsync(this AView view, Graphics.Color[] colors, Graphics.Point[] points, IMauiContext mauiContext)
+		{
+			var density = mauiContext.Context.GetDisplayDensity();
+			var bitmap = await view.ToBitmap(mauiContext);
+
+			for (int i = 0; i < points.Length; i++)
+			{
+				bitmap.AssertColorAtPoint(colors[i].ToPlatform(), (int)(points[i].X * density), (int)(points[i].Y * density));
+			}
+
+			return bitmap;
+		}
+
 		public static async Task<Bitmap> AssertColorAtCenterAsync(this AView view, AColor expectedColor, IMauiContext mauiContext)
 		{
 			var bitmap = await view.ToBitmap(mauiContext);

--- a/src/TestUtils/src/DeviceTests/AssertionExtensions.Android.cs
+++ b/src/TestUtils/src/DeviceTests/AssertionExtensions.Android.cs
@@ -276,7 +276,7 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		public static string CreateColorAtPointError(this Bitmap bitmap, AColor expectedColor, int x, int y) =>
-			CreateColorError(bitmap, $"Expected {expectedColor} at point {x},{y} in renderered view.");
+			CreateColorError(bitmap, $"Expected {expectedColor} at point {x},{y} in rendered view.");
 
 		public static string CreateColorError(this Bitmap bitmap, string message) =>
 			$"{message} This is what it looked like:<img>{bitmap.ToBase64String()}</img>";
@@ -412,7 +412,7 @@ namespace Microsoft.Maui.DeviceTests
 			var actualColor = bitmap.ColorAtPoint(x, y);
 
 			if (!actualColor.IsEquivalent(expectedColor))
-				Assert.Equal(expectedColor, actualColor);
+				throw new XunitException(CreateColorAtPointError(bitmap, expectedColor, x, y));
 
 			return bitmap;
 		}

--- a/src/TestUtils/src/DeviceTests/AssertionExtensions.Windows.cs
+++ b/src/TestUtils/src/DeviceTests/AssertionExtensions.Windows.cs
@@ -394,6 +394,18 @@ namespace Microsoft.Maui.DeviceTests
 			return bitmap.AssertColorAtPoint(expectedColor, x, y);
 		}
 
+		public static async Task<CanvasBitmap> AssertColorsAtPointsAsync(this FrameworkElement view, Graphics.Color[] colors, Graphics.Point[] points, IMauiContext mauiContext)
+		{
+			var bitmap = await view.ToBitmap(mauiContext);
+
+			for (int i = 0; i < points.Length; i++)
+			{
+				bitmap.AssertColorAtPoint(colors[i].ToWindowsColor(), (int)points[i].X, (int)points[i].Y);
+			}
+
+			return bitmap;
+		}
+
 		public static async Task<CanvasBitmap> AssertColorAtCenterAsync(this FrameworkElement view, WColor expectedColor, IMauiContext mauiContext)
 		{
 			var bitmap = await view.ToBitmap(mauiContext);

--- a/src/TestUtils/src/DeviceTests/AssertionExtensions.iOS.cs
+++ b/src/TestUtils/src/DeviceTests/AssertionExtensions.iOS.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Drawing;
 using System.Linq;
 using System.Threading.Tasks;
 using CoreAnimation;
@@ -259,7 +260,7 @@ namespace Microsoft.Maui.DeviceTests
 			var cap = bitmap.ColorAtPoint(x, y);
 
 			if (!ColorComparison.ARGBEquivalent(cap, expectedColor, tolerance))
-				Assert.Equal(expectedColor, cap, new ColorComparison());
+				throw new XunitException(CreateColorAtPointError(bitmap, expectedColor, x, y));
 
 			return bitmap;
 		}
@@ -294,6 +295,18 @@ namespace Microsoft.Maui.DeviceTests
 		{
 			var bitmap = await view.ToBitmap(mauiContext);
 			return bitmap.AssertColorAtPoint(expectedColor, x, y);
+		}
+
+		public static async Task<UIImage> AssertColorsAtPointsAsync(this UIView view, Graphics.Color[] colors, Graphics.Point[] points, IMauiContext mauiContext)
+		{
+			var bitmap = await view.ToBitmap(mauiContext);
+
+			for (int i = 0; i < points.Length; i++)
+			{
+				bitmap.AssertColorAtPoint(colors[i].ToPlatform(), (int)points[i].X, (int)points[i].Y);
+			}
+
+			return bitmap;
 		}
 
 		public static async Task<UIImage> AssertColorAtCenterAsync(this UIView view, UIColor expectedColor, IMauiContext mauiContext)


### PR DESCRIPTION
### Description of Change

1. RoundRectangle.GetPath() should not do ANY comepnsation for StrokeThickness because our callers do that for us. All we need to do is draw the rounded rectangle path using the width and height as-is.
2. RoundedRectangle.GetInnerPath() needs to be consistent about using the strokeThickness argument instead of (sometimes) using the StrokeThickness property which *may* be different. e.g. MauiDrawable.Android.cs's _shape's StrokeThickness is always 1 even when that is not the StrokeThickness that has been set on the Border).
3. MauiDrawable.Android.cs MUST pass a bounds argument to _shape?.ToPlatform() because that's what is expected if we want the stroke path (which we do, despite the 'clipPath' name suggesting otherwise).
4. MauiDrawable.Android.cs's _strokeThickness, _width, and _height member variables have already been multiplied by the pixel density on the Android device, so we must divide by _density to get back "MAUI pixels" that the RoundRectangle logic needs.
5. ContentViewGroup *also* needs to divide width and height by the pixel density instead of multiplying the StrokeThickness by the pixel density because clipShape.ToPlatform() calls RoundRectangle.InnerPathForBounds() which expects "MAUI pixels" rather than Android pixel coordinates.
6. ShapeExtensions.ToPlatform() now requires a 'float density` argument that represents the Android device's pixel density so that it can scale the "MAUI pixels" to "Android pixels".
7. I suspect that BorderDrawable.cs also needs to do this, but I'm not sure how to test that theory.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #14276
Fixes #14936

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->

![BorderAlignment](https://github.com/dotnet/maui/assets/338984/d3d02d1a-e194-4a6d-b06b-f635ec7ef7c8)

https://github.com/dotnet/maui/assets/338984/ee6c90a3-6a59-406f-be79-12e75a171f13

![BorderStrokeOptions](https://github.com/dotnet/maui/assets/338984/2a6f72e1-35f9-42b7-9550-7836ad03f419)

https://github.com/dotnet/maui/assets/338984/3678cb32-c83c-4e19-a2b3-068f58af831b


https://github.com/dotnet/maui/assets/338984/075d242e-c26e-40e1-851f-b122d4488d39


https://github.com/dotnet/maui/assets/338984/4fc7e5e1-c7cb-41f9-8550-910884ff9bcf


https://github.com/dotnet/maui/assets/338984/d7c6d7af-1e79-41e2-b559-d80981537873


