### PR TITLE
Add some properties/globs back into the NuGet for older workloads

### DIFF
--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.Build.Tasks.After.targets
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.Build.Tasks.After.targets
@@ -1,11 +1,23 @@
 <Project>
 
+  <!--
+  This is duplicated in the workload Microsoft.Maui.Sdk.After.targets for now because .NET MAUI
+  is also consumed via NuGet - machines that have older workloads need these globs to be present.
+  -->
+  <PropertyGroup>
+    <EnableDefaultMauiItems Condition=" '$(EnableDefaultMauiItems)' == '' ">$(EnableDefaultItems)</EnableDefaultMauiItems>
+    <EnableDefaultXamlItems Condition=" '$(EnableDefaultXamlItems)' == '' ">$(EnableDefaultMauiItems)</EnableDefaultXamlItems>
+    <EnableDefaultCssItems  Condition=" '$(EnableDefaultCssItems)' == '' ">$(EnableDefaultMauiItems)</EnableDefaultCssItems>
+    <EnableDefaultEmbeddedResourceItems Condition=" '$(EnableDefaultEmbeddedResourceItems)' == '' ">$(EnableDefaultMauiItems)</EnableDefaultEmbeddedResourceItems>
+  </PropertyGroup>
+
   <!-- Remove platform-based @(Using) unless $(MauiEnablePlatformUsings) flag is set -->
   <ItemGroup Condition=" '$(MauiEnablePlatformUsings)' != 'true' and ('$(ImplicitUsings)' == 'true' or '$(ImplicitUsings)' == 'enable') ">
     <Using Remove="@(Using->HasMetadata('Platform'))" />
   </ItemGroup>
 
   <Import Project="Microsoft.Maui.Controls.targets" />
+  <Import Project="Microsoft.Maui.Controls.DefaultItems.targets" />
   <Import Project="Microsoft.Maui.Controls.SingleProject.targets" />
 
 </Project>

--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.DefaultItems.targets
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.DefaultItems.targets
@@ -12,8 +12,8 @@
 	how the solution explorer "looks". As a result, we can leave it there for now as it is
 	useful to have in the packages for independent updates - if need be.
 	
-	This is duplicated in the build tasks NuGet in Microsoft.Maui.Controls.DefaultItems.targets
-	because older workloads also need these globs.
+	This is duplicated in the workload Microsoft.Maui.Sdk.DefaultItems.targets for now because .NET MAUI
+	is also consumed via NuGet - machines that have older workloads need to also update these items.
 	-->
 	<ItemGroup Condition="'$(EnableDefaultItems)'=='True' And '$(EnableDefaultXamlItems)'=='True' And '$(EnableDefaultEmbeddedResourceItems)'=='True'">
 		<Compile Update="**\*.xaml$(DefaultLanguageSourceExtension)" DependentUpon="%(Filename)" SubType="Code" />

--- a/src/Workload/Microsoft.Maui.Sdk/Sdk/Microsoft.Maui.Sdk.After.targets
+++ b/src/Workload/Microsoft.Maui.Sdk/Sdk/Microsoft.Maui.Sdk.After.targets
@@ -1,5 +1,13 @@
 <Project>
 
+  <!--
+  Enable the default css/xaml globs and nesting. Single project globs remain in the NuGet package
+  for now since they only come into play when the compile starts, and this means the packages have
+  been restored.
+
+  This is duplicated in Microsoft.Maui.Controls.Build.Tasks.After.targets for now because .NET MAUI
+  is also consumed via NuGet - machines that have older workloads need these globs to be present.
+  -->
   <PropertyGroup>
     <EnableDefaultMauiItems Condition=" '$(EnableDefaultMauiItems)' == '' ">$(EnableDefaultItems)</EnableDefaultMauiItems>
     <EnableDefaultXamlItems Condition=" '$(EnableDefaultXamlItems)' == '' ">$(EnableDefaultMauiItems)</EnableDefaultXamlItems>


### PR DESCRIPTION
### Description of Change

In order to fix https://github.com/dotnet/maui/issues/16501 where the .xaml.cs files were not nested under the .xaml files on a very fresh machine, we moved the globs into the workload in https://github.com/dotnet/maui/pull/16990

This was mostly correct, however this broke all the cases where the machine did not update the workloads to these new files. This PR adds back the globs in the NuGet (for older workloads) but also keeps it in the workload (for new  installs). This is "duplicated" code, but the duplication is minimal and result is the same regardless of order.

The 2 duplicated parts are:

```xml
<PropertyGroup>
  <EnableDefaultMauiItems Condition=" '$(EnableDefaultMauiItems)' == '' ">$(EnableDefaultItems)</EnableDefaultMauiItems>
  <EnableDefaultXamlItems Condition=" '$(EnableDefaultXamlItems)' == '' ">$(EnableDefaultMauiItems)</EnableDefaultXamlItems>
  <EnableDefaultCssItems  Condition=" '$(EnableDefaultCssItems)' == '' ">$(EnableDefaultMauiItems)</EnableDefaultCssItems>
  <EnableDefaultEmbeddedResourceItems Condition=" '$(EnableDefaultEmbeddedResourceItems)' == '' ">$(EnableDefaultMauiItems)</EnableDefaultEmbeddedResourceItems>
</PropertyGroup>
```

and 

```xml
<ItemGroup Condition="'$(EnableDefaultItems)'=='True' And '$(EnableDefaultXamlItems)'=='True' And '$(EnableDefaultEmbeddedResourceItems)'=='True'">
  <Compile Update="**\*.xaml$(DefaultLanguageSourceExtension)" DependentUpon="%(Filename)" SubType="Code" />
  <None Remove="**\*.xaml" Condition="'$(EnableDefaultNoneItems)'=='True'" />
</ItemGroup>

<ItemGroup Condition="'$(EnableDefaultItems)'=='True' And '$(EnableDefaultCssItems)'=='True' And '$(EnableDefaultEmbeddedResourceItems)'=='True'">
  <None Remove="**\*.css" Condition="'$(EnableDefaultNoneItems)'=='True'" />
</ItemGroup>
```

Regardless of order (from the NuGet or from the workload), the first set sets the same values but also only sets if it was not read set - so we do not even get duplicate setting. The second code is Updating the .xaml.cs files to the same `DependentUpon` value, and the None is just removing things. Both actions are running almost at the same time (in the after targets imports) as part of the evaluation, so this will not affect any targets the user may have had.


### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #17040

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
