### PR TITLE
[tests] Ignore appium visual test #15330  while we investigate

### DIFF
--- a/src/Controls/tests/UITests/Tests/Issues/Issue15330.cs
+++ b/src/Controls/tests/UITests/Tests/Issues/Issue15330.cs
@@ -14,8 +14,8 @@ namespace Microsoft.Maui.AppiumTests.Issues
 		[Test]
 		public void Issue15330Test()
 		{
-			// TODO: We are looking at assure that row height is 100% correct
-			Assert.Ignore("We are not sure the images are correct, ignoring as we investigate");
+			UITestContext.IgnoreIfPlatforms(new TestDevice[] { TestDevice.iOS },
+				"Currently fails on iOS; see https://github.com/dotnet/maui/issues/17125");
 
 			App.WaitForElement("WaitForStubControl");
 			VerifyScreenshot();

--- a/src/Controls/tests/UITests/Tests/Issues/Issue15330.cs
+++ b/src/Controls/tests/UITests/Tests/Issues/Issue15330.cs
@@ -14,6 +14,9 @@ namespace Microsoft.Maui.AppiumTests.Issues
 		[Test]
 		public void Issue15330Test()
 		{
+			// TODO: We are looking at assure that row height is 100% correct
+			Assert.Ignore("We are not sure the images are correct, ignoring as we investigate");
+
 			App.WaitForElement("WaitForStubControl");
 			VerifyScreenshot();
 		}


### PR DESCRIPTION
### Description of Change

Ignore the failing test on iOS till we make sure it's validating the correct row height. 

We should enable this back when https://github.com/dotnet/maui/issues/17125 is fixed