### PR TITLE
Drag and Drop move suppression for older android builds

### DIFF
--- a/src/Controls/src/Core/Platform/Android/DragAndDropGestureHandler.cs
+++ b/src/Controls/src/Core/Platform/Android/DragAndDropGestureHandler.cs
@@ -342,13 +342,15 @@ namespace Microsoft.Maui.Controls.Platform
 				int dragFlags;
 				if (args.PlatformArgs?.DragFlags is ADragFlags d)
 					dragFlags = (int)d;
-				else
-#pragma warning disable CS0618, CA1416 // DragFlags.Global added in API 24: https://developer.android.com/reference/android/view/View#DRAG_FLAG_GLOBAL
+				else if (OperatingSystem.IsAndroidVersionAtLeast(24))
 					dragFlags = (int)ADragFlags.Global | (int)ADragFlags.GlobalUriRead;
+				else
+					dragFlags = 256 | 1; // use the value of enums since the enums are not supported here
 
 				if (OperatingSystem.IsAndroidVersionAtLeast(24))
 					v.StartDragAndDrop(data, dragShadowBuilder, localData, dragFlags);
 				else
+#pragma warning disable CS0618, CA1416 // DragFlags.Global added in API 24: https://developer.android.com/reference/android/view/View#DRAG_FLAG_GLOBAL
 					v.StartDrag(data, dragShadowBuilder, localData, dragFlags);
 #pragma warning restore CS0618, CA1416
 			});

--- a/src/Controls/src/Core/Platform/Android/DragAndDropGestureHandler.cs
+++ b/src/Controls/src/Core/Platform/Android/DragAndDropGestureHandler.cs
@@ -343,12 +343,12 @@ namespace Microsoft.Maui.Controls.Platform
 				if (args.PlatformArgs?.DragFlags is ADragFlags d)
 					dragFlags = (int)d;
 				else
+#pragma warning disable CS0618, CA1416 // DragFlags.Global added in API 24: https://developer.android.com/reference/android/view/View#DRAG_FLAG_GLOBAL
 					dragFlags = (int)ADragFlags.Global | (int)ADragFlags.GlobalUriRead;
 
 				if (OperatingSystem.IsAndroidVersionAtLeast(24))
 					v.StartDragAndDrop(data, dragShadowBuilder, localData, dragFlags);
 				else
-#pragma warning disable CS0618, CA1416 // DragFlags.Global added in API 24: https://developer.android.com/reference/android/view/View#DRAG_FLAG_GLOBAL
 					v.StartDrag(data, dragShadowBuilder, localData, dragFlags);
 #pragma warning restore CS0618, CA1416
 			});


### PR DESCRIPTION
### Description of Change

<!-- Enter description of the fix in this section -->
This PR is just a one line move in the error suppression. Things were rearranged in this recent PR: https://github.com/dotnet/maui/pull/16962/files#diff-d941a5fc5e0c30a3a5e00deb3c21ce5164eec37be1a30cef8b9868fbcc4063bdR342-R353 and the suppression currently does not cover all the parts it needs to in order to pass older android builds.

