### PR TITLE
PermissionStatus: Remove "ios only" from documentation of Restricted

### DIFF
--- a/src/Essentials/src/Permissions/Permissions.shared.enums.cs
+++ b/src/Essentials/src/Permissions/Permissions.shared.enums.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Maui.ApplicationModel
 		/// <summary>The user granted permission or is automatically granted.</summary>
 		Granted = 3,
 
-		/// <summary>In a restricted state (only iOS).</summary>
+		/// <summary>In a restricted state.</summary>
 		Restricted = 4,
 
 		/// <summary>In a limited state (only iOS).</summary>


### PR DESCRIPTION
### Description of Change

Restricted state isn't iOS only as shown in Android code here: https://github.com/dotnet/maui/blob/972b15ed45db627596b3ec0dd206e74624d3689f/src/Essentials/src/Permissions/Permissions.android.cs#L295

### Issues Fixed

Incorrect doc.

