### PR TITLE
Ensure that the navigation page renderer measures its current Page

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
@@ -174,7 +174,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			var toolbarY = NavigationBarHidden || NavigationBar.Translucent || !_hasNavigationBar ? 0 : navBarFrameBottom;
 			toolbar.Frame = new RectangleF(0, toolbarY, View.Frame.Width, toolbar.Frame.Height);
 
-			(Element as IView).Arrange(View.Bounds.ToRectangle());
+			(Current as IView)?.Measure(View.Bounds.Width, View.Bounds.Height - navBarFrameBottom);
 		}
 
 		public override void ViewDidLoad()


### PR DESCRIPTION
### Description of Change

The navigation page renderer on iOS never deliberately measures the current page at a size which accounts for the navigation bar; Instead, it ends up measuring it at the full size of the navigation Page, which by default is the full size of the screen. It then arranges the current Page at a smaller size (to account for the navigation bar). This mostly works, but it means that if any ScrollView in the hierarchy needs to expand its content to fill the ScrollView, it's doing so under the assumption that the content size needs to be expanded to the larger, navigation-bar-free size at which it was measured. 

The upshot is that the ScrollView upsizes its content to a size slightly larger than it needs to, making the content scrollable when it should not be. 

This change fixes the issue by forcing the NavigationPageRenderer to measure the content at the target size.