### PR TITLE
Grid rows ios fix

### DIFF
--- a/src/Core/src/Layouts/GridLayoutManager.cs
+++ b/src/Core/src/Layouts/GridLayoutManager.cs
@@ -869,28 +869,28 @@ namespace Microsoft.Maui.Layouts
 					return;
 				}
 
-				// Figure out which is the biggest star definition in this dimension (absolute value and star scale)
-				var maxCurrentSize = 0.0;
-				var maxCurrentStarSize = 0.0;
+				// Check if all the star rows/columns fit within the full target sizes.
+				bool allStarsFit = true;
 				foreach (var definition in defs)
 				{
 					if (definition.IsStar)
 					{
-						double definitionSize = definition.MinimumSize;
-						maxCurrentSize = Math.Max(maxCurrentSize, definitionSize);
-						maxCurrentStarSize = Math.Max(maxCurrentStarSize, definitionSize / definition.GridLength.Value);
+						// The targetStarSize is the size that star values would have to have in order for all
+						// the star rows/columns to fit in the targetSize.
+						double fullTargetSize = targetStarSize * definition.GridLength.Value;
+
+						if (definition.MinimumSize > fullTargetSize)
+						{
+							allStarsFit = false;
+							break;
+						}
 					}
 				}
-
-				// The targetStarSize is the size that star values would have to have in order for all
-				// the star rows/columns to fit in the targetSize. 
-
-				if (maxCurrentStarSize <= targetStarSize)
+				
+				if (allStarsFit)
 				{
-					// If the biggest current star size we have in the definitions is less than the
-					// targetStarSize, that means we have enough room to expand all of our star rows/columns
-					// to their full size.
-
+					// If all of the stars fit, that means we have enough room to expand all of our star
+					// rows/columns to their full size.
 					foreach (var definition in defs)
 					{
 						if (definition.IsStar)


### PR DESCRIPTION
### Description of Change

Adjusted the DetermineMinimumStarSizesInSpan function to distribute the space needed relative to the target sizes associated with the star values using the same method as the ExpandStars method.

In the Measure method, the height constraint doesn't take the safe area into consideration for iOS, and this results in the Size value of the definitions to be higher than what is actually available in the safe area for each row. Then when the DetermineMinimumStarSizesInSpan was called with dimensions that were consistent with the safe area, it would apportion the space needed among the star rows without regard for how much of the Minimum size already existed for a row.

In the test code, this occurs when splitting the space needed into the second and third rows. The first row wasn't affected, so its height was the optimal, but the second row already had an optimal value and the third was empty. The old method made it such that the rows were 1.0, 1.5, 0.5 optimal height respectively, and then the second row was truncated to the optimal value that it would be without the safe area taken into account (so, slightly larger than optimal). The new method splits the space needed with the star sizes taken into account, and results in the rows being 1.0, 1.0, 1.0 optimal height respectively, consistent with the safe area.

As a result, the values sent into the ExpandStars method no longer include sizes that are inconsistent with the safe area, and now produce the expected results.

### Issues Fixed

Fixes #17125
