### PR TITLE
Compatibility should depend on Controls

### DIFF
--- a/src/Compatibility/Core/src/Compatibility.csproj
+++ b/src/Compatibility/Core/src/Compatibility.csproj
@@ -59,6 +59,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\Controls\src\Core\Controls.Core.csproj" />
     <ProjectReference Include="..\..\..\Controls\src\Xaml\Controls.Xaml.csproj" />
+    <ProjectReference Include="..\..\..\Controls\src\NuGet\Controls.NuGet.csproj" />
   </ItemGroup>
 
   <Import Project="$(MauiSrcDirectory)Workload\Shared\LibraryPacks.targets" />


### PR DESCRIPTION
### Description of Change

This is needed to prevent the installation of Controls (the root package) as a different version to Compatibility. Right now, we can install Controls and Compat with mismatching versions - and the highest version wins for most of the dependencies.

This PR will cause a mismatch to result in a NuGet restore error and it will be far clearer than a hidden upgrade.