### PR TITLE
[X] do not register srcinfo for xaml-defined values

### DIFF
--- a/src/Controls/src/Core/AppThemeBinding.cs
+++ b/src/Controls/src/Core/AppThemeBinding.cs
@@ -12,14 +12,22 @@ namespace Microsoft.Maui.Controls
 		bool _attached;
 		SetterSpecificity specificity;
 
-		internal override BindingBase Clone() => new AppThemeBinding
+		internal override BindingBase Clone()
 		{
-			Light = Light,
-			_isLightSet = _isLightSet,
-			Dark = Dark,
-			_isDarkSet = _isDarkSet,
-			Default = Default
-		};
+			var clone =  new AppThemeBinding
+			{
+				Light = Light,
+				_isLightSet = _isLightSet,
+				Dark = Dark,
+				_isDarkSet = _isDarkSet,
+				Default = Default
+			};
+
+			if (DebuggerHelper.DebuggerIsAttached && VisualDiagnostics.GetSourceInfo(this) is SourceInfo info)
+				VisualDiagnostics.RegisterSourceInfo(clone, info.SourceUri, info.LineNumber, info.LinePosition);
+
+			return clone;
+		}
 
 		internal override void Apply(bool fromTarget)
 		{

--- a/src/Controls/src/Core/Binding.cs
+++ b/src/Controls/src/Core/Binding.cs
@@ -285,7 +285,7 @@ namespace Microsoft.Maui.Controls
 
 		internal override BindingBase Clone()
 		{
-			return new Binding(Path, Mode)
+			var clone = new Binding(Path, Mode)
 			{
 				Converter = Converter,
 				ConverterParameter = ConverterParameter,
@@ -295,6 +295,11 @@ namespace Microsoft.Maui.Controls
 				TargetNullValue = TargetNullValue,
 				FallbackValue = FallbackValue,
 			};
+
+			if (DebuggerHelper.DebuggerIsAttached && VisualDiagnostics.GetSourceInfo(this) is SourceInfo info)
+				VisualDiagnostics.RegisterSourceInfo(clone, info.SourceUri, info.LineNumber, info.LinePosition);
+
+			return clone;
 		}
 
 		internal override object GetSourceValue(object value, Type targetPropertyType)

--- a/src/Controls/src/Core/MultiBinding.cs
+++ b/src/Controls/src/Core/MultiBinding.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Maui.Controls
 			foreach (var b in Bindings)
 				bindingsclone.Add(b.Clone());
 
-			return new MultiBinding()
+			var clone = new MultiBinding()
 			{
 				Converter = Converter,
 				ConverterParameter = ConverterParameter,
@@ -69,6 +69,11 @@ namespace Microsoft.Maui.Controls
 				TargetNullValue = TargetNullValue,
 				StringFormat = StringFormat,
 			};
+
+			if (DebuggerHelper.DebuggerIsAttached && VisualDiagnostics.GetSourceInfo(this) is SourceInfo info)
+				VisualDiagnostics.RegisterSourceInfo(clone, info.SourceUri, info.LineNumber, info.LinePosition);
+
+			return clone;
 		}
 
 		internal override void Apply(bool fromTarget)

--- a/src/Controls/src/Core/TemplateBinding.cs
+++ b/src/Controls/src/Core/TemplateBinding.cs
@@ -97,7 +97,12 @@ namespace Microsoft.Maui.Controls
 
 		internal override BindingBase Clone()
 		{
-			return new TemplateBinding(Path, Mode) { Converter = Converter, ConverterParameter = ConverterParameter, StringFormat = StringFormat };
+			var clone = new TemplateBinding(Path, Mode) { Converter = Converter, ConverterParameter = ConverterParameter, StringFormat = StringFormat };
+
+			if (DebuggerHelper.DebuggerIsAttached && VisualDiagnostics.GetSourceInfo(this) is SourceInfo info)
+				VisualDiagnostics.RegisterSourceInfo(clone, info.SourceUri, info.LineNumber, info.LinePosition);
+
+			return clone;
 		}
 
 		internal override object GetSourceValue(object value, Type targetPropertyType)

--- a/src/Controls/src/Core/VisualStateManager.cs
+++ b/src/Controls/src/Core/VisualStateManager.cs
@@ -484,6 +484,9 @@ namespace Microsoft.Maui.Controls
 				clone.States.Add(state.Clone());
 			}
 
+			if (DebuggerHelper.DebuggerIsAttached && VisualDiagnostics.GetSourceInfo(this) is SourceInfo info)
+				VisualDiagnostics.RegisterSourceInfo(clone, info.SourceUri, info.LineNumber, info.LinePosition);
+
 			return clone;
 		}
 
@@ -595,6 +598,9 @@ namespace Microsoft.Maui.Controls
 				clone.StateTriggers.Add(stateTrigger);
 			}
 
+			if (DebuggerHelper.DebuggerIsAttached && VisualDiagnostics.GetSourceInfo(this) is SourceInfo info)
+				VisualDiagnostics.RegisterSourceInfo(clone, info.SourceUri, info.LineNumber, info.LinePosition);
+
 			return clone;
 		}
 
@@ -651,15 +657,18 @@ namespace Microsoft.Maui.Controls
 	{
 		internal static IList<VisualStateGroup> Clone(this IList<VisualStateGroup> groups)
 		{
-			var actual = new VisualStateGroupList();
+			var clone = new VisualStateGroupList();
 
 			foreach (var group in groups)
 			{
-				group.VisualElement = actual.VisualElement;
-				actual.Add(group.Clone());
+				group.VisualElement = clone.VisualElement;
+				clone.Add(group.Clone());
 			}
 
-			return actual;
+			if (DebuggerHelper.DebuggerIsAttached && VisualDiagnostics.GetSourceInfo(groups) is SourceInfo info)
+				VisualDiagnostics.RegisterSourceInfo(clone, info.SourceUri, info.LineNumber, info.LinePosition);
+
+			return clone;
 		}
 
 		internal static bool HasVisualState(this VisualElement element, string name)

--- a/src/Controls/src/Xaml/ApplyPropertiesVisitor.cs
+++ b/src/Controls/src/Xaml/ApplyPropertiesVisitor.cs
@@ -387,6 +387,8 @@ namespace Microsoft.Maui.Controls.Xaml
 
 			void registerSourceInfo(object target, string path)
 			{
+				if (VisualDiagnostics.GetSourceInfo(target) != null)
+					return;
 				var assemblyName = rootElement.GetType().Assembly?.GetName().Name;
 				if (lineInfo != null)
 					VisualDiagnostics.RegisterSourceInfo(target, new Uri($"{path};assembly={assemblyName}", UriKind.Relative), lineInfo.LineNumber, lineInfo.LinePosition);

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui17222.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui17222.xaml
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests"
+             x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui17222">
+    <Button x:Name="button" Style="{StaticResource MainButtonStyle}" />
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui17222.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui17222.xaml.cs
@@ -67,28 +67,6 @@ public partial class Maui17222 : ContentPage
 			Assert.AreEqual(new Uri("Issues/Maui17222BaseStyle.xaml;assembly=Microsoft.Maui.Controls.Xaml.UnitTests", UriKind.Relative), info.SourceUri);
 			Assert.AreEqual(5, info.LineNumber);
 			Assert.AreEqual(6, info.LinePosition);
-
-			//while (style != null)
-			//{
-			//	// Requirement #3 Getting SourceInfo for Style Object
-			//	info = VisualDiagnostics.GetSourceInfo(style);
-			//	Debug.WriteLine($"Style Name:{style.BaseResourceKey} SourceUri:{info.SourceUri}, Line:{info.LineNumber}, Column:{info.LinePosition}");
-			//	// Output: Error!!!, Wrong Source URI Style Name: SourceUri:MainPage.xaml;assembly=MAUI, Line:18, Column:17
-
-			//	IEnumerable<Setter> setters = style.Setters.Reverse();
-			//	// Requirement #3 Walking the setters
-			//	foreach (Setter setter in setters)
-			//	{
-			//		Debug.WriteLine($"Setter Property:{setter.Property.PropertyName}, Setter Value:{setter.Value.ToString()}");
-
-			//		// Output: OK! Setter Property:TextColor, Setter Value:[Color: Red=1, Green=0, Blue=0, Alpha=1] (MainStyle.xaml)
-			//		// Output: OK! Setter Property:WidthRequest, Setter Value:100 (BaseStyle.xaml)
-			//		// Output: OK! Setter Property:HeightRequest, Setter Value:100 (BaseStyle.xaml)
-			//		// Output: OK! Setter Property:TextColor, Setter Value:[Color: Red=0, Green=0, Blue=1, Alpha=1]
-			//	}
-
-			//	// Requirement #4, Walking the Style Parent Chain
-			//	style = style.BasedOn;
 		}
 	}
 }

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui17222.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui17222.xaml.cs
@@ -1,0 +1,94 @@
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System;
+using Microsoft.Maui.ApplicationModel;
+using Microsoft.Maui.Controls.Core.UnitTests;
+using Microsoft.Maui.Controls.Shapes;
+using Microsoft.Maui.Devices;
+using Microsoft.Maui.Graphics;
+using NUnit.Framework;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public partial class Maui17222 : ContentPage
+{
+
+	public Maui17222() => InitializeComponent();
+
+	public Maui17222(bool useCompiledXaml)
+	{
+		//this stub will be replaced at compile time
+	}
+
+	[TestFixture]
+	class Test
+	{
+		[SetUp] public void Setup() => AppInfo.SetCurrent(new MockAppInfo());
+		[TearDown] public void TearDown() => AppInfo.SetCurrent(null);
+
+		[Test]
+		public void GetsourceInfo([Values(false)] bool useCompiledXaml)
+		{
+			var app = new MockApplication();
+			app.Resources.Add(new Maui17222BaseStyle(useCompiledXaml));
+			app.Resources.Add(new Maui17222Style(useCompiledXaml));
+			Application.SetCurrentApplication(app);
+
+			var page = new Maui17222(useCompiledXaml);
+			SourceInfo info = VisualDiagnostics.GetSourceInfo(page);
+			Assert.AreEqual(new Uri("Issues/Maui17222.xaml;assembly=Microsoft.Maui.Controls.Xaml.UnitTests", UriKind.Relative), info.SourceUri);
+			Assert.AreEqual(2, info.LineNumber);
+			Assert.AreEqual(2, info.LinePosition);
+
+			var button = page.button;
+			info = VisualDiagnostics.GetSourceInfo(button);
+			Assert.AreEqual(new Uri("Issues/Maui17222.xaml;assembly=Microsoft.Maui.Controls.Xaml.UnitTests", UriKind.Relative), info.SourceUri);
+			Assert.AreEqual(6, info.LineNumber);
+			Assert.AreEqual(6, info.LinePosition);
+
+			Style style = button.Style;
+			info = VisualDiagnostics.GetSourceInfo(style);
+			Assert.AreEqual(new Uri("Issues/Maui17222Style.xaml;assembly=Microsoft.Maui.Controls.Xaml.UnitTests", UriKind.Relative), info.SourceUri);
+			Assert.AreEqual(5, info.LineNumber);
+			Assert.AreEqual(6, info.LinePosition);
+
+			var setter = style.Setters[0];
+			Assert.AreEqual(setter.Property, Button.TextColorProperty);
+			Assert.AreEqual(setter.Value, Colors.Red);
+			info = VisualDiagnostics.GetSourceInfo(setter);
+			Assert.AreEqual(new Uri("Issues/Maui17222Style.xaml;assembly=Microsoft.Maui.Controls.Xaml.UnitTests", UriKind.Relative), info.SourceUri);
+			Assert.AreEqual(6, info.LineNumber);
+			Assert.AreEqual(10, info.LinePosition);
+
+
+			style = style.BasedOn;
+			info = VisualDiagnostics.GetSourceInfo(style);
+			Assert.AreEqual(new Uri("Issues/Maui17222BaseStyle.xaml;assembly=Microsoft.Maui.Controls.Xaml.UnitTests", UriKind.Relative), info.SourceUri);
+			Assert.AreEqual(5, info.LineNumber);
+			Assert.AreEqual(6, info.LinePosition);
+
+			//while (style != null)
+			//{
+			//	// Requirement #3 Getting SourceInfo for Style Object
+			//	info = VisualDiagnostics.GetSourceInfo(style);
+			//	Debug.WriteLine($"Style Name:{style.BaseResourceKey} SourceUri:{info.SourceUri}, Line:{info.LineNumber}, Column:{info.LinePosition}");
+			//	// Output: Error!!!, Wrong Source URI Style Name: SourceUri:MainPage.xaml;assembly=MAUI, Line:18, Column:17
+
+			//	IEnumerable<Setter> setters = style.Setters.Reverse();
+			//	// Requirement #3 Walking the setters
+			//	foreach (Setter setter in setters)
+			//	{
+			//		Debug.WriteLine($"Setter Property:{setter.Property.PropertyName}, Setter Value:{setter.Value.ToString()}");
+
+			//		// Output: OK! Setter Property:TextColor, Setter Value:[Color: Red=1, Green=0, Blue=0, Alpha=1] (MainStyle.xaml)
+			//		// Output: OK! Setter Property:WidthRequest, Setter Value:100 (BaseStyle.xaml)
+			//		// Output: OK! Setter Property:HeightRequest, Setter Value:100 (BaseStyle.xaml)
+			//		// Output: OK! Setter Property:TextColor, Setter Value:[Color: Red=0, Green=0, Blue=1, Alpha=1]
+			//	}
+
+			//	// Requirement #4, Walking the Style Parent Chain
+			//	style = style.BasedOn;
+		}
+	}
+}

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui17222.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui17222.xaml.cs
@@ -24,9 +24,9 @@ public partial class Maui17222 : ContentPage
 	[TestFixture]
 	class Test
 	{
+#if DEBUG
 		[SetUp] public void Setup() => AppInfo.SetCurrent(new MockAppInfo());
 		[TearDown] public void TearDown() => AppInfo.SetCurrent(null);
-
 		[Test]
 		public void GetsourceInfo([Values(false)] bool useCompiledXaml)
 		{
@@ -68,5 +68,6 @@ public partial class Maui17222 : ContentPage
 			Assert.AreEqual(5, info.LineNumber);
 			Assert.AreEqual(6, info.LinePosition);
 		}
+#endif
 	}
 }

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui17222BaseStyle.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui17222BaseStyle.xaml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ResourceDictionary xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui17222BaseStyle">
+    <Style TargetType="Button" x:Key="BaseButtonStyle">
+        <Setter Property="TextColor" Value="Blue" />
+        <Setter Property="Background" Value="Green" />
+        <Setter Property="HeightRequest" Value="100" />
+        <Setter Property="WidthRequest" Value="100" />
+    </Style>
+</ResourceDictionary>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui17222BaseStyle.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui17222BaseStyle.xaml.cs
@@ -1,0 +1,17 @@
+using Microsoft.Maui.ApplicationModel;
+using Microsoft.Maui.Controls.Core.UnitTests;
+using Microsoft.Maui.Controls.Shapes;
+using Microsoft.Maui.Devices;
+using NUnit.Framework;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public partial class Maui17222BaseStyle : ResourceDictionary
+{
+	public Maui17222BaseStyle() => InitializeComponent();
+
+	public Maui17222BaseStyle(bool useCompiledXaml)
+	{
+		//this stub will be replaced at compile time
+	}
+}

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui17222Style.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui17222Style.xaml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ResourceDictionary xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui17222Style">
+    <Style TargetType="Button" x:Key="MainButtonStyle" BasedOn="{StaticResource BaseButtonStyle}">
+        <Setter Property="TextColor" Value="Red" />
+    </Style>
+</ResourceDictionary>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui17222Style.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui17222Style.xaml.cs
@@ -1,0 +1,17 @@
+using Microsoft.Maui.ApplicationModel;
+using Microsoft.Maui.Controls.Core.UnitTests;
+using Microsoft.Maui.Controls.Shapes;
+using Microsoft.Maui.Devices;
+using NUnit.Framework;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public partial class Maui17222Style : ResourceDictionary
+{
+	public Maui17222Style() => InitializeComponent();
+
+	public Maui17222Style(bool useCompiledXaml)
+	{
+		//this stub will be replaced at compile time
+	}
+}


### PR DESCRIPTION
### Description of Change

For values defined in other XAML file, the source info of the actual source is the correct one. Keep th eold path for values defined in XAML

### Issues Fixed

- fixes #17222

