### PR TITLE
[msbuild] fix NuGet Central Package Management (CPM)

### DIFF
--- a/src/Workload/Microsoft.Maui.Sdk/Sdk/BundledVersions.in.targets
+++ b/src/Workload/Microsoft.Maui.Sdk/Sdk/BundledVersions.in.targets
@@ -12,6 +12,12 @@
       however Visual Studio currently depends on this assembly being loaded for Live Visual Tree.
     -->
     <UseMauiCompat Condition=" '$(UseMauiCompat)' == '' and '$(UseMaui)' == 'true' ">true</UseMauiCompat>
+
+    <!--
+      If opted into NuGet Central Package Management, $(DisableMauiImplicitPackageReferences) defaults to true
+      https://learn.microsoft.com/nuget/consume-packages/Central-Package-Management
+    -->
+    <DisableMauiImplicitPackageReferences Condition=" '$(ManagePackageVersionsCentrally)' == 'true' and '$(DisableMauiImplicitPackageReferences)' == '' ">true</DisableMauiImplicitPackageReferences>
   </PropertyGroup>
 
   <!--
@@ -20,16 +26,16 @@
     packages. Then the packages that were specified by the user are removed from the list. Finally,
     the remaining implicit packages are added into the project.
 
-    This logic only installs packages if and only if $(EnableMauiImplicitPackageReferences) is not
+    This logic only installs packages if and only if $(DisableMauiImplicitPackageReferences) is not
     true. This property allows the user to totally override all the default nugets installed. This
     should not be needed as the $(MauiVersion) should be sufficient. However, there may be a case
     to test various CI builds of .NET MAUI.
 
     One thing to note: the old and unsupported $(UseMauiNuGets) property is the same as the new
-    $(EnableMauiImplicitPackageReferences) property and is just kept for compatibility. It should
+    $(DisableMauiImplicitPackageReferences) property and is just kept for compatibility. It should
     not be used any any project, but there are some existing projects that have used them.
   -->
-  <ItemGroup Condition=" '$(EnableMauiImplicitPackageReferences)' != 'false' and '$(UseMauiNuGets)' != 'true' ">
+  <ItemGroup Condition=" '$(DisableMauiImplicitPackageReferences)' != 'true' and '$(UseMauiNuGets)' != 'true' ">
     <_MauiImplicitPackageReference Include="Microsoft.Maui.Resizetizer" Version="$(MauiVersion)" PrivateAssets="all" Condition=" '$(UseMauiAssets)' == 'true' " />
     <_MauiImplicitPackageReference Include="Microsoft.Maui.Essentials" Version="$(MauiVersion)" Condition=" '$(UseMauiEssentials)' == 'true' ">
       <PrivateAssets Condition=" '$(OutputType)' == 'Library' and '$(AndroidApplication)' != 'true' ">all</PrivateAssets>
@@ -48,7 +54,7 @@
     </_MauiImplicitPackageReference>
   </ItemGroup>
   <!-- Install the nuget packages if we are allowed to -->
-  <ItemGroup Condition=" '$(EnableMauiImplicitPackageReferences)' != 'false' and '$(UseMauiNuGets)' != 'true' ">
+  <ItemGroup Condition=" '$(DisableMauiImplicitPackageReferences)' != 'true' and '$(UseMauiNuGets)' != 'true' ">
     <_MauiImplicitPackageReference Remove="@(PackageReference)" />
     <PackageReference Include="@(_MauiImplicitPackageReference)" IsMauiImplicitPackageReference="true" />
     <_MauiImplicitRequiredPackageReference Include="@(_MauiImplicitPackageReference->WithMetadataValue('IsMauiImplicitOptionalPackageReference',''))" />
@@ -59,7 +65,7 @@
     AfterTargets="CollectPackageReferences"
     Condition="
       ('$(SkipValidateMauiImplicitPackageReferences)' != 'true') and
-      ('$(EnableMauiImplicitPackageReferences)' != 'false' and '$(UseMauiNuGets)' != 'true') and
+      ('$(DisableMauiImplicitPackageReferences)' != 'true' and '$(UseMauiNuGets)' != 'true') and
       ('$(UseMaui)' == 'true' or '$(UseMauiCore)' == 'true' or '$(UseMauiEssentials)' == 'true' or '$(UseMauiAssets)' == 'true') and
       ('@(_MauiImplicitRequiredPackageReference->Count())' != '0') ">
 

--- a/src/Workload/README.md
+++ b/src/Workload/README.md
@@ -214,3 +214,57 @@ These folders are all .NET 6 specific, so they won't affect .NET 5 or
 older versions.
 
 After this you can install .NET 6 with a fresh install of your choice.
+
+## NuGet Central Package Management
+
+You can leverage [NuGet's central package management (CPM)][cpm] to manage all
+of your dependencies from a single location.
+
+To do this, you will need a `Directory.Packages.props` file with:
+
+```xml
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <MauiVersion>8.0.0</MauiVersion>
+    <MicrosoftExtensionsVersion>8.0.0</MicrosoftExtensionsVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.Maui.Core" Version="$(MauiVersion)" />
+    <PackageVersion Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
+    <PackageVersion Include="Microsoft.Maui.Controls.Core" Version="$(MauiVersion)" />
+    <PackageVersion Include="Microsoft.Maui.Controls.Build.Tasks" Version="$(MauiVersion)" />
+    <PackageVersion Include="Microsoft.Maui.Controls.Xaml" Version="$(MauiVersion)" />
+    <PackageVersion Include="Microsoft.Maui.Essentials" Version="$(MauiVersion)" />
+    <PackageVersion Include="Microsoft.Maui.Resizetizer" Version="$(MauiVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="$(MicrosoftExtensionsVersion)" />
+  </ItemGroup>
+</Project>
+```
+
+For the correct value for `$(MauiVersion)` and `$(MicrosoftExtensionsVersion)`
+you will need to find a valid version number from one of:
+
+* NuGet, such as: https://www.nuget.org/packages/Microsoft.Maui.Sdk
+
+* GitHub releases, such as: https://github.com/dotnet/maui/releases
+
+Using properties like `$(MauiVersion)` and `$(MicrosoftExtensionsVersion)` are
+also completely optional, you can put the version numbers directly in the
+`%(PackageVersion.Version)` item metadata.
+
+Then in your .NET MAUI application's `.csproj` file:
+
+```xml
+<PackageReference Include="Microsoft.Maui.Core" />
+<PackageReference Include="Microsoft.Maui.Controls" />
+<PackageReference Include="Microsoft.Maui.Essentials" />
+<PackageReference Include="Microsoft.Maui.Resizetizer" />
+<PackageReference Include="Microsoft.Extensions.Logging.Debug" />
+```
+
+Note that `%(PackageReference.Version)` is intentionally left blank. See the
+documentation on [NuGet Central Package Management][cpm] for more information
+about this feature.
+
+[cpm]: https://learn.microsoft.com/nuget/consume-packages/Central-Package-Management


### PR DESCRIPTION
Context: https://learn.microsoft.com/nuget/consume-packages/Central-Package-Management
Fixes #12953

@mattleibow has already made a few changes to improve this scenario, by introducing `$(DisableMauiImplicitPackageReferences)`.

I think the main thing missing is to change default values when `$(ManagePackageVersionsCentrally)` is true. This setting, that enables CPM, should automatically turn off all implicit `@(PackageReference)`.

I renamed `$(EnableMauiImplicitPackageReferences)` to `$(DisableMauiImplicitPackageReferences)` to better align with the changes we made in MAUI in .NET 7 for a future servicing release:

https://github.com/dotnet/maui/pull/17046

I tested these changes in a sample application here:

https://github.com/hypdeb/repros/compare/master...jonathanpeppers:MauiNuGetCPMRepro:peppers

I also updated `Workload/README.md` to have a section showing how to setup NuGet CPM.
