### PR TITLE
Copy Windows assets to the output folder for Unpackaged

### DIFF
--- a/src/SingleProject/Resizetizer/src/nuget/buildTransitive/Microsoft.Maui.Resizetizer.After.targets
+++ b/src/SingleProject/Resizetizer/src/nuget/buildTransitive/Microsoft.Maui.Resizetizer.After.targets
@@ -462,6 +462,7 @@
             <_MauiSplashAssets Include="$(_MauiIntermediateSplashScreen)**\*" />
             <ContentWithTargetPath Include="@(_MauiSplashAssets)">
                 <TargetPath>%(_MauiSplashAssets.Filename)%(_MauiSplashAssets.Extension)</TargetPath>
+                <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
             </ContentWithTargetPath>
         </ItemGroup>
 
@@ -548,6 +549,7 @@
 
             <ContentWithTargetPath Include="@(_MauiFontCopied)" Condition="'@(_MauiFontCopied)' != ''">
                 <TargetPath>$([System.IO.Path]::GetFileName(%(_MauiFontCopied.Identity)))</TargetPath>
+                <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
             </ContentWithTargetPath>
 
         </ItemGroup>
@@ -654,6 +656,7 @@
         <ItemGroup Condition="'$(_ResizetizerIsWindowsAppSdk)' == 'True'">
             <ContentWithTargetPath Include="@(_ResizetizerCollectedImages)">
                 <TargetPath>%(_ResizetizerCollectedImages.Filename)%(_ResizetizerCollectedImages.Extension)</TargetPath>
+                <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
             </ContentWithTargetPath>
 
             <FileWrites Include="@(_ResizetizerCollectedImages)" />

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/BaseBuildTest.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/BaseBuildTest.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Maui.IntegrationTests
 		public string TestNuGetConfig => Path.Combine(TestEnvironment.GetTestDirectoryRoot(), "NuGet.config");
 
 		// Properties that ensure we don't use cached packages, and *only* the empty NuGet.config
-		protected string[] BuildProps => new[]
+		protected List<string> BuildProps => new()
 		{
 			"RestoreNoCache=true",
 			//"GenerateAppxPackageOnBuild=true",

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/TemplateTests.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/TemplateTests.cs
@@ -73,6 +73,39 @@ namespace Microsoft.Maui.IntegrationTests
 		}
 
 		[Test]
+		[TestCase("maui", "net7.0", "Release")]
+		public void PublishUnpackaged(string id, string framework, string config)
+		{
+			if (!TestEnvironment.IsWindows)
+				Assert.Ignore("Running Windows templates is only supported on Windows.");
+
+			var projectDir = TestDirectory;
+			var projectFile = Path.Combine(projectDir, $"{Path.GetFileName(projectDir)}.csproj");
+
+			Assert.IsTrue(DotnetInternal.New(id, projectDir, framework),
+				$"Unable to create template {id}. Check test output for errors.");
+
+			BuildProps.Add("WindowsPackageType=None");
+
+			Assert.IsTrue(DotnetInternal.Publish(projectFile, config, framework: $"{framework}-windows10.0.19041.0", properties: BuildProps),
+				$"Project {Path.GetFileName(projectFile)} failed to build. Check test output/attachments for errors.");
+
+			var assetsRoot = Path.Combine(projectDir, $"bin/{config}/{framework}-windows10.0.19041.0/win10-x64/publish");
+
+			AssetExists("dotnet_bot.scale-100.png");
+			AssetExists("appiconLogo.scale-100.png");
+			AssetExists("OpenSans-Regular.ttf");
+			AssetExists("splashSplashScreen.scale-100.png");
+
+			void AssetExists(string filename)
+			{
+				var fullpath = Path.Combine(assetsRoot!, filename);
+				Assert.IsTrue(File.Exists(fullpath),
+					$"Unable to find expected asset: {fullpath}");
+			}
+		}
+
+		[Test]
 		[TestCase("mauilib", "net6.0", "Debug")]
 		[TestCase("mauilib", "net6.0", "Release")]
 		[TestCase("mauilib", "net7.0", "Debug")]

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/DotnetInternal.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/DotnetInternal.cs
@@ -37,6 +37,36 @@ namespace Microsoft.Maui.IntegrationTests
 			return Run("build", $"{buildArgs} -bl:\"{binlogPath}\"");
 		}
 
+		public static bool Publish(string projectFile, string config, string target = "", string framework = "", IEnumerable<string>? properties = null, string binlogPath = "")
+		{
+			var binlogName = $"publish-{DateTime.UtcNow.ToFileTimeUtc()}.binlog";
+			var buildArgs = $"\"{projectFile}\" -c {config}";
+
+			if (!string.IsNullOrEmpty(target))
+			{
+				binlogName = $"{target}-{DateTime.UtcNow.ToFileTimeUtc()}.binlog";
+				buildArgs += $" -t:{target}";
+			}
+
+			if (!string.IsNullOrEmpty(framework))
+				buildArgs += $" -f:{framework}";
+
+			if (properties != null)
+			{
+				foreach (var p in properties)
+				{
+					buildArgs += $" -p:{p}";
+				}
+			}
+
+			if (string.IsNullOrEmpty(binlogPath))
+			{
+				binlogPath = Path.Combine(Path.GetDirectoryName(projectFile) ?? "", binlogName);
+			}
+
+			return Run("publish", $"{buildArgs} -bl:\"{binlogPath}\"");
+		}
+
 		public static bool New(string shortName, string outputDirectory, string framework = "")
 		{
 			var args = $"{shortName} -o \"{outputDirectory}\"";


### PR DESCRIPTION
### Description of Change


I noticed that when publishing unpackaged apps, the content was not copied to the publish folder.

This PR makes sure we indicate that we want to do this.

MSIX apps automatically know to copy it, but unpackaged follows the default .NET SDK rules and requires more instructions.

