### PR TITLE
(Windows) Fix tabbar visibility test

### DIFF
--- a/src/Controls/src/Core/Handlers/Shell/ShellItemHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellItemHandler.Windows.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Maui.Controls.Handlers
 				PlatformView.Loaded -= OnNavigationViewLoaded;
 
 			UpdateSearchHandler();
-			MapMenuItems(true);
+			MapMenuItems();
 		}
 
 		protected override void ConnectHandler(FrameworkElement platformView)
@@ -123,9 +123,7 @@ namespace Microsoft.Maui.Controls.Handlers
 
 		private void OnItemsChanged(object? sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
 		{
-			// Flag to sync the selected item only after items changed fired, which will happen after modifications
-			// to the items list is finished
-			MapMenuItems(true);
+			MapMenuItems();
 		}
 
 		private void OnNavigationTabChanged(NavigationView sender, NavigationViewSelectionChangedEventArgs args)
@@ -145,7 +143,7 @@ namespace Microsoft.Maui.Controls.Handlers
 			}
 		}
 
-		void MapMenuItems(bool syncSelectedItem)
+		void MapMenuItems()
 		{
 			IShellItemController shellItemController = VirtualView;
 			var items = new List<BaseShellItem>();
@@ -222,7 +220,7 @@ namespace Microsoft.Maui.Controls.Handlers
 				}
 			});
 
-			if (syncSelectedItem && ShellItemNavigationView.SelectedItem != selectedItem)
+			if (ShellItemNavigationView.SelectedItem != selectedItem)
 				ShellItemNavigationView.SelectedItem = selectedItem;
 
 			UpdateValue(Shell.TabBarIsVisibleProperty.PropertyName);
@@ -373,7 +371,7 @@ namespace Microsoft.Maui.Controls.Handlers
 
 		internal void UpdateTitle()
 		{
-			MapMenuItems(true);
+			MapMenuItems();
 		}
 
 		void UpdateCurrentItem()
@@ -401,9 +399,7 @@ namespace Microsoft.Maui.Controls.Handlers
 
 			UpdateSearchHandler();
 
-			// Don't sync the selected item as this function can be called multiple times on item removal
-			// before the list has finished fully updating
-			MapMenuItems(false);
+			MapMenuItems();
 
 			if (_currentShellSection != null)
 			{

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTabBarTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTabBarTests.Windows.cs
@@ -47,11 +47,14 @@ namespace Microsoft.Maui.DeviceTests
 				var shellItemHandler = shell.CurrentItem.Handler as ShellItemHandler;
 				var navView = shellItemHandler.PlatformView as MauiNavigationView;
 
+				// Set page to have the tabbar be hidden, then switch to it
 				Shell.SetTabBarIsVisible(shell.Items[0].Items[1], false);
 				shell.CurrentItem = shell.Items[0].Items[1];
 
 				Assert.False(navView.IsPaneVisible);
 
+				// Tabbar should now be hidden, remove the current page which should cause
+				// us to switch to another page where the tabbar is not hidden (default)
 				shell.Items[0].Items.RemoveAt(1);
 
 				Assert.True(navView.IsPaneVisible);

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTabBarTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTabBarTests.cs
@@ -107,6 +107,14 @@ namespace Microsoft.Maui.DeviceTests
 				Icon = "white.png"
 			};
 
+			var unselectedContent_2 = new ShellContent()
+			{
+				Route = "Tab3",
+				Title = "Tab3",
+				Content = new ContentPage(),
+				Icon = "white.png"
+			};
+
 			var shell = await CreateShellAsync((shell) =>
 			{
 				shell.Items.Add(new TabBar()
@@ -115,6 +123,7 @@ namespace Microsoft.Maui.DeviceTests
 					{
 						selectedContent,
 						unselectedContent,
+						unselectedContent_2
 					}
 				});
 			});

--- a/src/Core/src/Platform/Windows/NavigationViewItemViewModel.cs
+++ b/src/Core/src/Platform/Windows/NavigationViewItemViewModel.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Maui.Platform
 
 			while (source.Count < dest.Count)
 			{
-				dest.RemoveAt(0);
+				dest.RemoveAt(dest.Count - 1);
 			}
 
 			for (var i = 0; i < source.Count; i++)


### PR DESCRIPTION
### Description of Change

* Remove need for MapMenuItems flag to sync selected item
* Fix the failing test `ShellTabBarVisibilityToggleWorksRemovingCurrentItem`
* Adjust the comments on the test to be more clear about what it's testing
