### PR TITLE
[Android] Fix ScrollView filling layouts

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/ScrollView/ScrollViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/ScrollView/ScrollViewTests.cs
@@ -126,16 +126,17 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.True(parentLayout.Height < 500, "ScrollView should not make parent layout grow!"); 
 		}
 
-		[Fact (DisplayName = "ScrollView's viewport fills available space if set to fill")]
+		[Fact (DisplayName = "ScrollView's viewport fills available space if set to fill"
+#if MACCATALYST || IOS
+			, Skip = "See: https://github.com/dotnet/maui/issues/17700. If the issue is solved, re-enable the tests"
+#endif
+		)]
 		public async Task ShouldGrow()
 		{
 			var label = new Label() { Text = "Text inside a ScrollView"};
 			var childLayout = new VerticalStackLayout { label };
-			var scrollView = new ScrollView() { VerticalOptions = LayoutOptions.Fill, Content = childLayout , Background = Brush.Red };
+			var scrollView = new ScrollView() { VerticalOptions = LayoutOptions.Fill, Content = childLayout};
 			var parentLayout = new Grid { scrollView };
-
-			parentLayout.Background = Brush.Yellow;
-			childLayout.Background = Brush.AliceBlue;
 
 			var expectedHeight = 100;
 			parentLayout.HeightRequest = expectedHeight;
@@ -145,11 +146,7 @@ namespace Microsoft.Maui.DeviceTests
 			await CreateHandlerAsync<ScrollViewHandler>(scrollView);
 			var layoutHandler = await CreateHandlerAsync<LayoutHandler>(parentLayout);
 
-			await AttachAndRun(parentLayout, async (layoutHandler) => {
-#if IOS || MACCATALYST
-				await layoutHandler.PlatformView.ThrowScreenshot(MauiContext, "Throwing to see results");
-#endif
-			});
+			await AttachAndRun(parentLayout, (layoutHandler) => {});
 
 			// Android is usually off by one or two px. Hence that's why the condition has some tolerance
 			Assert.Equal(scrollView.Height, childLayout.Height, 2.0);

--- a/src/Controls/tests/DeviceTests/Elements/ScrollView/ScrollViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/ScrollView/ScrollViewTests.cs
@@ -110,6 +110,22 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.False(platformReference.IsAlive, "PlatformView should not be alive!");
 		}
 
+		[Fact(DisplayName = "ScrollView inside layouts do not grow")]
+		public async Task DoesNotGrow()
+		{
+			var label = new Label() { Text = "Text inside a ScrollView" };
+			var scrollView = new ScrollView() { MaximumHeightRequest = 500, Content = label };
+			var parentLayout = new VerticalStackLayout { scrollView };
+
+			await CreateHandlerAsync<LabelHandler>(label);
+			await CreateHandlerAsync<ScrollViewHandler>(scrollView);
+			var layoutHandler = await CreateHandlerAsync<LayoutHandler>(parentLayout);
+
+			await AttachAndRun(parentLayout, (layoutHandler) => {});
+			Assert.True(parentLayout.Height > 0, "Parent layout should have non-zero height!");
+			Assert.True(parentLayout.Height < 500, "ScrollView should not make parent layout grow!"); 
+		}
+
 		void SetupBuilder()
 		{
 			EnsureHandlerCreated(builder =>

--- a/src/Controls/tests/DeviceTests/Elements/ScrollView/ScrollViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/ScrollView/ScrollViewTests.cs
@@ -129,11 +129,16 @@ namespace Microsoft.Maui.DeviceTests
 		[Fact (DisplayName = "ScrollView's viewport fills available space if set to fill")]
 		public async Task ShouldGrow()
 		{
-			var label = new Label() { Text = "Text inside a ScrollView" };
+			var label = new Label() { Text = "Text inside a ScrollView", Margin = 0, Padding = 0 };
 			var childLayout = new VerticalStackLayout { label };
-			var scrollView = new ScrollView() { VerticalOptions = LayoutOptions.Fill, Content = childLayout};
+			var scrollView = new ScrollView() { VerticalOptions = LayoutOptions.Fill, Content = childLayout, Margin = 0, Padding = 0 };
 			var parentLayout = new Grid { scrollView };
-			parentLayout.HeightRequest = 300;
+			parentLayout.HeightRequest = 500;
+
+			childLayout.Margin = 0;
+			childLayout.Padding = 0;
+			parentLayout.Margin = 0;
+			parentLayout.Padding = 0;
 
 			await CreateHandlerAsync<LabelHandler>(label);
 			await CreateHandlerAsync<LayoutHandler>(childLayout);
@@ -141,11 +146,11 @@ namespace Microsoft.Maui.DeviceTests
 			var layoutHandler = await CreateHandlerAsync<LayoutHandler>(parentLayout);
 
 			await AttachAndRun(parentLayout, (layoutHandler) => { });
-			Assert.True(childLayout.Height == scrollView.Height, $"Child VerticalStackLayout should fill ScrollView and have the same height! Expected: {scrollView.Height}, was: {parentLayout.Height}");
-			Assert.True(scrollView.Height == parentLayout.Height, $"ScrollView should fill parent Grid's height! Expected: {parentLayout.Height}, was: {scrollView.Height}");
+			Assert.True(childLayout.Height == scrollView.Height, $"Child VerticalStackLayout should fill ScrollView and have the same height! Expected: {scrollView.Height}, was: {childLayout.Height}");
+			Assert.True(scrollView.Height == parentLayout.Height, $"ScrollView should fill parent Grid's height! Expected: {parentLayout.Height}, was: {scrollView.Height}. Inner label height: {label.Height}");
 
 			// Android is usually off by one or two px. Hence that's why the condition is less strict
-			Assert.True(parentLayout.Height > 295 && parentLayout.Height < 305, $"Parent should be ~500px tall! Was: {parentLayout.Height}");
+			Assert.True(parentLayout.Height > 495 && parentLayout.Height < 505, $"Parent should be ~500px tall! Was: {parentLayout.Height}");
 		}
 
 		void SetupBuilder()

--- a/src/Controls/tests/DeviceTests/Elements/ScrollView/ScrollViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/ScrollView/ScrollViewTests.cs
@@ -150,9 +150,9 @@ namespace Microsoft.Maui.DeviceTests
 			await AttachAndRun(parentLayout, (layoutHandler) => { });
 
 			// Android is usually off by one or two px. Hence that's why the condition has some tolerance
-			Assert.Equal(scrollView.Height, childLayout.Height, 2);
-			Assert.Equal(parentLayout.Height, scrollView.Height, 2);
-			Assert.Equal(expectedHeight, parentLayout.Height, 2);
+			Assert.Equal(scrollView.Height, childLayout.Height, 2.0);
+			Assert.Equal(parentLayout.Height, scrollView.Height, 2.0);
+			Assert.Equal(expectedHeight, parentLayout.Height, 2.0);
 		}
 
 		void SetupBuilder()

--- a/src/Controls/tests/DeviceTests/Elements/ScrollView/ScrollViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/ScrollView/ScrollViewTests.cs
@@ -126,6 +126,26 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.True(parentLayout.Height < 500, "ScrollView should not make parent layout grow!"); 
 		}
 
+		[Fact (DisplayName = "ScrollView's viewport fills available space if set to fill")]
+		public async Task ShouldGrow()
+		{
+			var label = new Label() { Text = "Text inside a ScrollView" };
+			var childLayout = new VerticalStackLayout { label };
+			var scrollView = new ScrollView() { VerticalOptions = LayoutOptions.Fill, Content = childLayout};
+			var parentLayout = new Grid { scrollView };
+			parentLayout.HeightRequest = 500;
+
+			await CreateHandlerAsync<LabelHandler>(label);
+			await CreateHandlerAsync<LayoutHandler>(childLayout);
+			await CreateHandlerAsync<ScrollViewHandler>(scrollView);
+			var layoutHandler = await CreateHandlerAsync<LayoutHandler>(parentLayout);
+
+			await AttachAndRun(parentLayout, (layoutHandler) => { });
+			Assert.True(parentLayout.Height == 500, "Parent be 500px tall");
+			Assert.True(scrollView.Height == 500, "ScrollView should fill parent layout" );
+			Assert.True(childLayout.Height == 500, "Child VerticalStackLayout should fill available space");
+		}
+
 		void SetupBuilder()
 		{
 			EnsureHandlerCreated(builder =>

--- a/src/Controls/tests/DeviceTests/Elements/ScrollView/ScrollViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/ScrollView/ScrollViewTests.cs
@@ -143,7 +143,9 @@ namespace Microsoft.Maui.DeviceTests
 			await AttachAndRun(parentLayout, (layoutHandler) => { });
 			Assert.True(childLayout.Height == scrollView.Height, $"Child VerticalStackLayout should fill ScrollView and have the same height! Expected: {scrollView.Height}, was: {parentLayout.Height}");
 			Assert.True(scrollView.Height == parentLayout.Height, $"ScrollView should fill parent Grid's height! Expected: {parentLayout.Height}, was: {scrollView.Height}");
-			Assert.True(parentLayout.Height == 500, $"Parent should be 500px tall! Was: {parentLayout.Height}");
+
+			// iOS and Mac return heights of ~460 as of writing this test. Android is usually off by one or two px. Hence that's why the condition is less strict
+			Assert.True(parentLayout.Height > 450 && parentLayout.Height < 550, $"Parent should be ~500px tall! Was: {parentLayout.Height}");
 		}
 
 		void SetupBuilder()

--- a/src/Controls/tests/DeviceTests/Elements/ScrollView/ScrollViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/ScrollView/ScrollViewTests.cs
@@ -133,7 +133,7 @@ namespace Microsoft.Maui.DeviceTests
 			var childLayout = new VerticalStackLayout { label };
 			var scrollView = new ScrollView() { VerticalOptions = LayoutOptions.Fill, Content = childLayout};
 			var parentLayout = new Grid { scrollView };
-			parentLayout.HeightRequest = 500;
+			parentLayout.HeightRequest = 300;
 
 			await CreateHandlerAsync<LabelHandler>(label);
 			await CreateHandlerAsync<LayoutHandler>(childLayout);
@@ -144,8 +144,8 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.True(childLayout.Height == scrollView.Height, $"Child VerticalStackLayout should fill ScrollView and have the same height! Expected: {scrollView.Height}, was: {parentLayout.Height}");
 			Assert.True(scrollView.Height == parentLayout.Height, $"ScrollView should fill parent Grid's height! Expected: {parentLayout.Height}, was: {scrollView.Height}");
 
-			// iOS and Mac return heights of ~460 as of writing this test. Android is usually off by one or two px. Hence that's why the condition is less strict
-			Assert.True(parentLayout.Height > 450 && parentLayout.Height < 550, $"Parent should be ~500px tall! Was: {parentLayout.Height}");
+			// Android is usually off by one or two px. Hence that's why the condition is less strict
+			Assert.True(parentLayout.Height > 295 && parentLayout.Height < 305, $"Parent should be ~500px tall! Was: {parentLayout.Height}");
 		}
 
 		void SetupBuilder()

--- a/src/Controls/tests/DeviceTests/Elements/ScrollView/ScrollViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/ScrollView/ScrollViewTests.cs
@@ -129,18 +129,13 @@ namespace Microsoft.Maui.DeviceTests
 		[Fact (DisplayName = "ScrollView's viewport fills available space if set to fill")]
 		public async Task ShouldGrow()
 		{
-			var label = new Label() { Text = "Text inside a ScrollView", Margin = 0, Padding = 0 };
+			var label = new Label() { Text = "Text inside a ScrollView"};
 			var childLayout = new VerticalStackLayout { label };
-			var scrollView = new ScrollView() { VerticalOptions = LayoutOptions.Fill, Content = childLayout, Margin = 0, Padding = 0 };
+			var scrollView = new ScrollView() { VerticalOptions = LayoutOptions.Fill, Content = childLayout };
 			var parentLayout = new Grid { scrollView };
 
-			var expectedHeight = 500;
+			var expectedHeight = 100;
 			parentLayout.HeightRequest = expectedHeight;
-
-			childLayout.Margin = 0;
-			childLayout.Padding = 0;
-			parentLayout.Margin = 0;
-			parentLayout.Padding = 0;
 
 			await CreateHandlerAsync<LabelHandler>(label);
 			await CreateHandlerAsync<LayoutHandler>(childLayout);

--- a/src/Controls/tests/DeviceTests/Elements/ScrollView/ScrollViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/ScrollView/ScrollViewTests.cs
@@ -141,9 +141,9 @@ namespace Microsoft.Maui.DeviceTests
 			var layoutHandler = await CreateHandlerAsync<LayoutHandler>(parentLayout);
 
 			await AttachAndRun(parentLayout, (layoutHandler) => { });
-			Assert.True(parentLayout.Height == 500, "Parent be 500px tall");
-			Assert.True(scrollView.Height == 500, "ScrollView should fill parent layout" );
-			Assert.True(childLayout.Height == 500, "Child VerticalStackLayout should fill available space");
+			Assert.True(childLayout.Height == scrollView.Height, $"Child VerticalStackLayout should fill ScrollView and have the same height! Expected: {scrollView.Height}, was: {parentLayout.Height}");
+			Assert.True(scrollView.Height == parentLayout.Height, $"ScrollView should fill parent Grid's height! Expected: {parentLayout.Height}, was: {scrollView.Height}");
+			Assert.True(parentLayout.Height == 500, $"Parent should be 500px tall! Was: {parentLayout.Height}");
 		}
 
 		void SetupBuilder()

--- a/src/Controls/tests/DeviceTests/Elements/ScrollView/ScrollViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/ScrollView/ScrollViewTests.cs
@@ -133,7 +133,9 @@ namespace Microsoft.Maui.DeviceTests
 			var childLayout = new VerticalStackLayout { label };
 			var scrollView = new ScrollView() { VerticalOptions = LayoutOptions.Fill, Content = childLayout, Margin = 0, Padding = 0 };
 			var parentLayout = new Grid { scrollView };
-			parentLayout.HeightRequest = 500;
+
+			var expectedHeight = 500;
+			parentLayout.HeightRequest = expectedHeight;
 
 			childLayout.Margin = 0;
 			childLayout.Padding = 0;
@@ -146,11 +148,11 @@ namespace Microsoft.Maui.DeviceTests
 			var layoutHandler = await CreateHandlerAsync<LayoutHandler>(parentLayout);
 
 			await AttachAndRun(parentLayout, (layoutHandler) => { });
-			Assert.True(childLayout.Height == scrollView.Height, $"Child VerticalStackLayout should fill ScrollView and have the same height! Expected: {scrollView.Height}, was: {childLayout.Height}");
-			Assert.True(scrollView.Height == parentLayout.Height, $"ScrollView should fill parent Grid's height! Expected: {parentLayout.Height}, was: {scrollView.Height}. Inner label height: {label.Height}");
 
-			// Android is usually off by one or two px. Hence that's why the condition is less strict
-			Assert.True(parentLayout.Height > 495 && parentLayout.Height < 505, $"Parent should be ~500px tall! Was: {parentLayout.Height}");
+			// Android is usually off by one or two px. Hence that's why the condition has some tolerance
+			Assert.Equal(scrollView.Height, childLayout.Height, 2);
+			Assert.Equal(parentLayout.Height, scrollView.Height, 2);
+			Assert.Equal(expectedHeight, parentLayout.Height, 2);
 		}
 
 		void SetupBuilder()

--- a/src/Controls/tests/DeviceTests/Elements/ScrollView/ScrollViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/ScrollView/ScrollViewTests.cs
@@ -131,8 +131,11 @@ namespace Microsoft.Maui.DeviceTests
 		{
 			var label = new Label() { Text = "Text inside a ScrollView"};
 			var childLayout = new VerticalStackLayout { label };
-			var scrollView = new ScrollView() { VerticalOptions = LayoutOptions.Fill, Content = childLayout };
+			var scrollView = new ScrollView() { VerticalOptions = LayoutOptions.Fill, Content = childLayout , Background = Brush.Red };
 			var parentLayout = new Grid { scrollView };
+
+			parentLayout.Background = Brush.Yellow;
+			childLayout.Background = Brush.AliceBlue;
 
 			var expectedHeight = 100;
 			parentLayout.HeightRequest = expectedHeight;

--- a/src/Controls/tests/DeviceTests/Elements/ScrollView/ScrollViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/ScrollView/ScrollViewTests.cs
@@ -142,7 +142,11 @@ namespace Microsoft.Maui.DeviceTests
 			await CreateHandlerAsync<ScrollViewHandler>(scrollView);
 			var layoutHandler = await CreateHandlerAsync<LayoutHandler>(parentLayout);
 
-			await AttachAndRun(parentLayout, (layoutHandler) => { });
+			await AttachAndRun(parentLayout, async (layoutHandler) => {
+#if IOS || MACCATALYST
+				await layoutHandler.PlatformView.ThrowScreenshot(MauiContext, "Throwing to see results");
+#endif
+			});
 
 			// Android is usually off by one or two px. Hence that's why the condition has some tolerance
 			Assert.Equal(scrollView.Height, childLayout.Height, 2.0);

--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Android.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Android.cs
@@ -50,8 +50,6 @@ namespace Microsoft.Maui.Handlers
 			var widthSpec = Context.CreateMeasureSpec(widthConstraint, virtualView.Width, virtualView.MaximumWidth);
 			var heightSpec = Context.CreateMeasureSpec(heightConstraint, virtualView.Height, virtualView.MaximumHeight);
 
-			// If the ScrollView is inside of a layout it shouldn't have to fill all the space it can
-			// See: https://github.com/dotnet/maui/issues/16464
 			if (platformView.FillViewport)
 			{
 				/*	With FillViewport active, the Android ScrollView will measure the content at least once; if it is 

--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Android.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Android.cs
@@ -50,7 +50,9 @@ namespace Microsoft.Maui.Handlers
 			var widthSpec = Context.CreateMeasureSpec(widthConstraint, virtualView.Width, virtualView.MaximumWidth);
 			var heightSpec = Context.CreateMeasureSpec(heightConstraint, virtualView.Height, virtualView.MaximumHeight);
 
-			if (platformView.FillViewport)
+			// If the ScrollView is inside of a layout it shouldn't have to fill all the space it can
+			// See: https://github.com/dotnet/maui/issues/16464
+			if (platformView.FillViewport && virtualView.Parent?.Handler is not ILayoutHandler)
 			{
 				/*	With FillViewport active, the Android ScrollView will measure the content at least once; if it is 
 					smaller than the ScrollView's viewport, it measure a second time at the size of the viewport

--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Android.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Android.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Maui.Handlers
 
 			// If the ScrollView is inside of a layout it shouldn't have to fill all the space it can
 			// See: https://github.com/dotnet/maui/issues/16464
-			if (platformView.FillViewport && virtualView.Parent?.Handler is not ILayoutHandler)
+			if (platformView.FillViewport)
 			{
 				/*	With FillViewport active, the Android ScrollView will measure the content at least once; if it is 
 					smaller than the ScrollView's viewport, it measure a second time at the size of the viewport
@@ -63,12 +63,12 @@ namespace Microsoft.Maui.Handlers
 
 				var orientation = virtualView.Orientation;
 
-				if (orientation == ScrollOrientation.Both || orientation == ScrollOrientation.Vertical)
+				if (!double.IsInfinity(heightConstraint) && (orientation == ScrollOrientation.Both || orientation == ScrollOrientation.Vertical))
 				{
 					heightSpec = AdjustSpecForAlignment(heightSpec, virtualView.VerticalLayoutAlignment);
 				}
 
-				if (orientation == ScrollOrientation.Both || orientation == ScrollOrientation.Horizontal)
+				if (!double.IsInfinity(widthConstraint) && (orientation == ScrollOrientation.Both || orientation == ScrollOrientation.Horizontal))
 				{
 					widthSpec = AdjustSpecForAlignment(widthSpec, virtualView.HorizontalLayoutAlignment);
 				}


### PR DESCRIPTION
### Problem

`ScrollView` controls would try to fill their parent container on Android even thought that wasn't the expected behavior. In cases where the `MaximumHeight` property was set, the `ScrollView` would grow to that size.

The problem was being caused by additional logic placed to make `ScrollView` fill an entire page (and thereby size child elements correctly) when it is the topmost element. More specifically, we would[ set the height's MeasureSpec to ](https://github.com/dotnet/maui/blob/main/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Android.cs#L53-L73)`MeasureSpecMode.Exactly`. This caused the layout to grow to _exactly_ its largest constraint, i.e the MaximumHeight. For more context on why this was originally done, see #7514

### Solution
We check if the `ScrollView` has a explicitly set width or height. If it does, we don't change the `MeasureSpec`. Otherwise, we use the old logic.

### Before & After
```
    <VerticalStackLayout>
        <ScrollView MaximumHeightRequest="300" BackgroundColor="LightBlue">
            <Label Text="Hello world" />
        </ScrollView>
    </VerticalStackLayout>
```
| Before | After | 
| -- | -- | 
| ![image](https://github.com/dotnet/maui/assets/32918747/3a6fbbdc-0062-4ca3-9504-782139bb27a1) | ![image](https://github.com/dotnet/maui/assets/32918747/4dd242bb-1d59-4442-af4e-4b038103b56b) |


### Issues Fixed

Fixes #16464


