### PR TITLE
[X] don't expand types to Extension for x:Static

### DIFF
--- a/src/Controls/src/Build.Tasks/CompiledMarkupExtensions/StaticExtension.cs
+++ b/src/Controls/src/Build.Tasks/CompiledMarkupExtensions/StaticExtension.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 			var typename = member.Substring(0, dotIdx);
 			var membername = member.Substring(dotIdx + 1);
 
-			var typeRef = module.ImportReference(XmlTypeExtensions.GetTypeReference(context.Cache, typename, module, node as BaseNode));
+			var typeRef = module.ImportReference(XmlTypeExtensions.GetTypeReference(context.Cache, typename, module, node as BaseNode, expandToExtension: false));
 			var fieldRef = GetFieldReference(context.Cache, typeRef, membername, module);
 			var propertyDef = GetPropertyDefinition(context.Cache, typeRef, membername, module);
 

--- a/src/Controls/src/Build.Tasks/ExpandMarkupsVisitor.cs
+++ b/src/Controls/src/Build.Tasks/ExpandMarkupsVisitor.cs
@@ -190,7 +190,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 
 				//The order of lookup is to look for the Extension-suffixed class name first and then look for the class name without the Extension suffix.
 				XmlType type = new XmlType(namespaceuri, name + "Extension", typeArguments);
-				if (!type.TryGetTypeReference(contextProvider.Context.Cache, contextProvider.Context.Module, null, out _))
+				if (!type.TryGetTypeReference(contextProvider.Context.Cache, contextProvider.Context.Module, null, expandToExtension: true, out _))
 					type = new XmlType(namespaceuri, name, typeArguments);
 
 				if (type == null)

--- a/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
+++ b/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
@@ -661,7 +661,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 			{
 				return GetParent(node) is IElementNode parentNode
 					&& node.TryGetPropertyName(parentNode, out XmlName propertyName)
-					&& parentNode.XmlType.TryGetTypeReference(context.Cache, module, (IXmlLineInfo)node, out TypeReference parentTypeRef)
+					&& parentNode.XmlType.TryGetTypeReference(context.Cache, module, (IXmlLineInfo)node, false, out TypeReference parentTypeRef)
 					&& parentTypeRef.ResolveCached(context.Cache) is TypeDefinition parentType
 					&& parentType.GetProperty(context.Cache, pd => pd.Name == propertyName.LocalName, out var propertyDeclaringTypeRef) is PropertyDefinition propertyDef
 					&& propertyDef.CustomAttributes.Any(ca => ca.AttributeType.FullName == "Microsoft.Maui.Controls.Xaml.DoesNotInheritDataTypeAttribute");

--- a/src/Controls/src/Build.Tasks/XmlTypeExtensions.cs
+++ b/src/Controls/src/Build.Tasks/XmlTypeExtensions.cs
@@ -50,12 +50,12 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 			return xmlnsDefinitions;
 		}
 
-		public static TypeReference GetTypeReference(XamlCache cache, string typeName, ModuleDefinition module, BaseNode node)
+		public static TypeReference GetTypeReference(XamlCache cache, string typeName, ModuleDefinition module, BaseNode node, bool expandToExtension = true)
 		{
 			try
 			{
 				XmlType xmlType = TypeArgumentsParser.ParseSingle(typeName, node.NamespaceResolver, (IXmlLineInfo)node);
-				return GetTypeReference(xmlType, cache, module, node as IXmlLineInfo);
+				return GetTypeReference(xmlType, cache, module, node as IXmlLineInfo, expandToExtension: expandToExtension);
 			}
 			catch (XamlParseException)
 			{
@@ -63,12 +63,12 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 			}
 		}
 
-		public static TypeReference GetTypeReference(XamlCache cache, string namespaceURI, string typename, ModuleDefinition module, IXmlLineInfo xmlInfo)
+		public static TypeReference GetTypeReference(XamlCache cache, string namespaceURI, string typename, ModuleDefinition module, IXmlLineInfo xmlInfo, bool expandToExtension = true)
 		{
 			return new XmlType(namespaceURI, typename, null).GetTypeReference(cache, module, xmlInfo);
 		}
 
-		public static bool TryGetTypeReference(this XmlType xmlType, XamlCache cache, ModuleDefinition module, IXmlLineInfo xmlInfo, out TypeReference typeReference)
+		public static bool TryGetTypeReference(this XmlType xmlType, XamlCache cache, ModuleDefinition module, IXmlLineInfo xmlInfo, bool expandToExtension, out TypeReference typeReference)
 		{
 			IList<XmlnsDefinitionAttribute> xmlnsDefinitions = cache.GetXmlsDefinitions(module, GatherXmlnsDefinitionAttributes);
 
@@ -81,7 +81,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 				if (type is not null && type.IsPublicOrVisibleInternal(module))
 					return type;
 				return null;
-			});
+			}, expandToExtension: expandToExtension);
 
 			if (type != null && typeArguments != null && type.HasGenericParameters)
 				type = module.ImportReference(type).MakeGenericInstanceType(typeArguments.Select(x => x.GetTypeReference(cache, module, xmlInfo)).ToArray());
@@ -89,9 +89,9 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 			return (typeReference = (type == null) ? null : module.ImportReference(type)) != null;
 		}
 
-		public static TypeReference GetTypeReference(this XmlType xmlType, XamlCache cache, ModuleDefinition module, IXmlLineInfo xmlInfo)
+		public static TypeReference GetTypeReference(this XmlType xmlType, XamlCache cache, ModuleDefinition module, IXmlLineInfo xmlInfo, bool expandToExtension = true)
 		{
-			if (TryGetTypeReference(xmlType, cache, module, xmlInfo, out TypeReference typeReference))
+			if (TryGetTypeReference(xmlType, cache, module, xmlInfo, expandToExtension: expandToExtension, out TypeReference typeReference))
 				return typeReference;
 
 			throw new BuildException(BuildExceptionCode.TypeResolution, xmlInfo, null, $"{xmlType.NamespaceUri}:{xmlType.Name}");

--- a/src/Controls/src/Core/IXamlTypeResolver.cs
+++ b/src/Controls/src/Core/IXamlTypeResolver.cs
@@ -5,7 +5,12 @@ namespace Microsoft.Maui.Controls.Xaml
 {
 	public interface IXamlTypeResolver
 	{
+#if NETSTANDARD2_0
 		Type Resolve(string qualifiedTypeName, IServiceProvider serviceProvider = null);
+#else
+		Type Resolve(string qualifiedTypeName, IServiceProvider serviceProvider = null) => Resolve(qualifiedTypeName, serviceProvider, true);
+#endif
+		Type Resolve(string qualifiedTypeName, IServiceProvider serviceProvider = null, bool expandToExtension = true);
 		bool TryResolve(string qualifiedTypeName, out Type type);
 	}
 }

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -13,6 +13,7 @@ Microsoft.Maui.Controls.HybridWebView.SetInvokeJavaScriptTarget<T>(T! target) ->
 Microsoft.Maui.Controls.StyleableElement.Style.get -> Microsoft.Maui.Controls.Style?
 ~Microsoft.Maui.Controls.ResourceDictionary.SetAndCreateSource<T>(System.Uri value) -> void
 ~Microsoft.Maui.Controls.Internals.TypedBindingBase.UpdateSourceEventName.set -> void
+~Microsoft.Maui.Controls.Xaml.IXamlTypeResolver.Resolve(string qualifiedTypeName, System.IServiceProvider serviceProvider = null, bool expandToExtension = true) -> System.Type
 ~Microsoft.Maui.Controls.WebViewProcessTerminatedEventArgs.PlatformArgs.get -> Microsoft.Maui.Controls.PlatformWebViewProcessTerminatedEventArgs
 ~Microsoft.Maui.Controls.Xaml.RequireServiceAttribute.RequireServiceAttribute(System.Type[] serviceTypes) -> void
 ~Microsoft.Maui.Controls.Xaml.RequireServiceAttribute.ServiceTypes.get -> System.Type[]

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -65,6 +65,7 @@ override Microsoft.Maui.Controls.Handlers.Items2.ItemsViewHandler2<TItemsView>.G
 Microsoft.Maui.Controls.HybridWebView.SetInvokeJavaScriptTarget<T>(T! target) -> void
 ~Microsoft.Maui.Controls.ResourceDictionary.SetAndCreateSource<T>(System.Uri value) -> void
 ~Microsoft.Maui.Controls.WebViewProcessTerminatedEventArgs.PlatformArgs.get -> Microsoft.Maui.Controls.PlatformWebViewProcessTerminatedEventArgs
+~Microsoft.Maui.Controls.Xaml.IXamlTypeResolver.Resolve(string qualifiedTypeName, System.IServiceProvider serviceProvider = null, bool expandToExtension = true) -> System.Type
 ~Microsoft.Maui.Controls.Xaml.RequireServiceAttribute.RequireServiceAttribute(System.Type[] serviceTypes) -> void
 ~Microsoft.Maui.Controls.Xaml.RequireServiceAttribute.ServiceTypes.get -> System.Type[]
 ~override Microsoft.Maui.Controls.Handlers.Items2.CarouselViewController2.CreateDelegator() -> UIKit.UICollectionViewDelegateFlowLayout

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -65,6 +65,7 @@ override Microsoft.Maui.Controls.Handlers.Items2.ItemsViewHandler2<TItemsView>.G
 Microsoft.Maui.Controls.HybridWebView.SetInvokeJavaScriptTarget<T>(T! target) -> void
 ~Microsoft.Maui.Controls.ResourceDictionary.SetAndCreateSource<T>(System.Uri value) -> void
 ~Microsoft.Maui.Controls.Internals.TypedBindingBase.UpdateSourceEventName.set -> void
+~Microsoft.Maui.Controls.Xaml.IXamlTypeResolver.Resolve(string qualifiedTypeName, System.IServiceProvider serviceProvider = null, bool expandToExtension = true) -> System.Type
 ~Microsoft.Maui.Controls.WebViewProcessTerminatedEventArgs.PlatformArgs.get -> Microsoft.Maui.Controls.PlatformWebViewProcessTerminatedEventArgs
 ~Microsoft.Maui.Controls.Xaml.RequireServiceAttribute.RequireServiceAttribute(System.Type[] serviceTypes) -> void
 ~Microsoft.Maui.Controls.Xaml.RequireServiceAttribute.ServiceTypes.get -> System.Type[]

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -13,6 +13,7 @@ Microsoft.Maui.Controls.HybridWebView.SetInvokeJavaScriptTarget<T>(T! target) ->
 Microsoft.Maui.Controls.StyleableElement.Style.get -> Microsoft.Maui.Controls.Style?
 ~Microsoft.Maui.Controls.ResourceDictionary.SetAndCreateSource<T>(System.Uri value) -> void
 ~Microsoft.Maui.Controls.Internals.TypedBindingBase.UpdateSourceEventName.set -> void
+~Microsoft.Maui.Controls.Xaml.IXamlTypeResolver.Resolve(string qualifiedTypeName, System.IServiceProvider serviceProvider = null, bool expandToExtension = true) -> System.Type
 ~Microsoft.Maui.Controls.WebViewProcessTerminatedEventArgs.PlatformArgs.get -> Microsoft.Maui.Controls.PlatformWebViewProcessTerminatedEventArgs
 ~Microsoft.Maui.Controls.Xaml.RequireServiceAttribute.RequireServiceAttribute(System.Type[] serviceTypes) -> void
 ~Microsoft.Maui.Controls.Xaml.RequireServiceAttribute.ServiceTypes.get -> System.Type[]

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -14,6 +14,7 @@ override Microsoft.Maui.Controls.Handlers.Items.SelectableItemsViewHandler<TItem
 Microsoft.Maui.Controls.StyleableElement.Style.get -> Microsoft.Maui.Controls.Style?
 ~Microsoft.Maui.Controls.ResourceDictionary.SetAndCreateSource<T>(System.Uri value) -> void
 ~Microsoft.Maui.Controls.Internals.TypedBindingBase.UpdateSourceEventName.set -> void
+~Microsoft.Maui.Controls.Xaml.IXamlTypeResolver.Resolve(string qualifiedTypeName, System.IServiceProvider serviceProvider = null, bool expandToExtension = true) -> System.Type
 ~Microsoft.Maui.Controls.WebViewProcessTerminatedEventArgs.PlatformArgs.get -> Microsoft.Maui.Controls.PlatformWebViewProcessTerminatedEventArgs
 ~Microsoft.Maui.Controls.Xaml.RequireServiceAttribute.RequireServiceAttribute(System.Type[] serviceTypes) -> void
 ~Microsoft.Maui.Controls.Xaml.RequireServiceAttribute.ServiceTypes.get -> System.Type[]

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -13,6 +13,7 @@ Microsoft.Maui.Controls.HybridWebView.SetInvokeJavaScriptTarget<T>(T! target) ->
 Microsoft.Maui.Controls.StyleableElement.Style.get -> Microsoft.Maui.Controls.Style?
 ~Microsoft.Maui.Controls.Internals.TypedBindingBase.UpdateSourceEventName.set -> void
 ~Microsoft.Maui.Controls.ResourceDictionary.SetAndCreateSource<T>(System.Uri value) -> void
+~Microsoft.Maui.Controls.Xaml.IXamlTypeResolver.Resolve(string qualifiedTypeName, System.IServiceProvider serviceProvider = null, bool expandToExtension = true) -> System.Type
 ~Microsoft.Maui.Controls.WebViewProcessTerminatedEventArgs.PlatformArgs.get -> Microsoft.Maui.Controls.PlatformWebViewProcessTerminatedEventArgs
 ~Microsoft.Maui.Controls.Xaml.RequireServiceAttribute.RequireServiceAttribute(System.Type[] serviceTypes) -> void
 ~Microsoft.Maui.Controls.Xaml.RequireServiceAttribute.ServiceTypes.get -> System.Type[]

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -13,6 +13,7 @@ Microsoft.Maui.Controls.HybridWebView.SetInvokeJavaScriptTarget<T>(T! target) ->
 Microsoft.Maui.Controls.StyleableElement.Style.get -> Microsoft.Maui.Controls.Style?
 ~Microsoft.Maui.Controls.ResourceDictionary.SetAndCreateSource<T>(System.Uri value) -> void
 ~Microsoft.Maui.Controls.Internals.TypedBindingBase.UpdateSourceEventName.set -> void
+~Microsoft.Maui.Controls.Xaml.IXamlTypeResolver.Resolve(string qualifiedTypeName, System.IServiceProvider serviceProvider = null, bool expandToExtension = true) -> System.Type
 ~Microsoft.Maui.Controls.WebViewProcessTerminatedEventArgs.PlatformArgs.get -> Microsoft.Maui.Controls.PlatformWebViewProcessTerminatedEventArgs
 ~Microsoft.Maui.Controls.Xaml.RequireServiceAttribute.RequireServiceAttribute(System.Type[] serviceTypes) -> void
 ~Microsoft.Maui.Controls.Xaml.RequireServiceAttribute.ServiceTypes.get -> System.Type[]

--- a/src/Controls/src/Xaml/ApplyPropertiesVisitor.cs
+++ b/src/Controls/src/Xaml/ApplyPropertiesVisitor.cs
@@ -306,7 +306,7 @@ namespace Microsoft.Maui.Controls.Xaml
 				localname = localname.Substring(dotIdx + 1);
 				XamlParseException xpe;
 				elementType = XamlParser.GetElementType(new XmlType(namespaceURI, typename, null), lineInfo,
-					rootElement.GetType().Assembly, out xpe);
+					rootElement.GetType().Assembly, true, out xpe);
 
 				if (xpe != null)
 					throw xpe;

--- a/src/Controls/src/Xaml/CreateValuesVisitor.cs
+++ b/src/Controls/src/Xaml/CreateValuesVisitor.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Maui.Controls.Xaml
 		{
 			object value = null;
 
-			var type = XamlParser.GetElementType(node.XmlType, node, Context.RootElement?.GetType().Assembly,
+			var type = XamlParser.GetElementType(node.XmlType, node, Context.RootElement?.GetType().Assembly, true,
 				out XamlParseException xpe);
 			if (xpe != null)
 			{

--- a/src/Controls/src/Xaml/MarkupExtensions/StaticExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/StaticExtension.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Maui.Controls.Xaml
 			var typename = Member.Substring(0, dotIdx);
 			var membername = Member.Substring(dotIdx + 1);
 
-			var type = typeResolver.Resolve(typename, serviceProvider);
+			var type = typeResolver.Resolve(typename, serviceProvider, expandToExtension: false);
 
 			var pinfo = type.GetRuntimeProperties().FirstOrDefault(pi => pi.Name == membername && pi.GetMethod.IsStatic);
 			if (pinfo != null)

--- a/src/Controls/src/Xaml/XamlParser.cs
+++ b/src/Controls/src/Xaml/XamlParser.cs
@@ -361,7 +361,7 @@ namespace Microsoft.Maui.Controls.Xaml
 #if !NETSTANDARD
 		[RequiresDynamicCode(TrimmerConstants.XamlRuntimeParsingNotSupportedWarning)]
 #endif
-		public static Type GetElementType(XmlType xmlType, IXmlLineInfo xmlInfo, Assembly currentAssembly,
+		public static Type GetElementType(XmlType xmlType, IXmlLineInfo xmlInfo, Assembly currentAssembly, bool expandToExtension,
 			out XamlParseException exception)
 		{
 			bool hasRetriedNsSearch = false;
@@ -379,7 +379,8 @@ namespace Microsoft.Maui.Controls.Xaml
 					if (t is not null && t.IsPublicOrVisibleInternal(currentAssembly))
 						return t;
 					return null;
-				});
+				},
+				expandToExtension);
 
 			var typeArguments = xmlType.TypeArguments;
 			exception = null;
@@ -403,7 +404,7 @@ namespace Microsoft.Maui.Controls.Xaml
 				XamlParseException innerexception = null;
 				var args = typeArguments.Select(delegate (XmlType xmltype)
 				{
-					var t = GetElementType(xmltype, xmlInfo, currentAssembly, out XamlParseException xpe);
+					var t = GetElementType(xmltype, xmlInfo, currentAssembly, true, out XamlParseException xpe);
 					if (xpe != null)
 					{
 						innerexception = xpe;

--- a/src/Controls/src/Xaml/XamlServiceProvider.cs
+++ b/src/Controls/src/Xaml/XamlServiceProvider.cs
@@ -207,9 +207,13 @@ namespace Microsoft.Maui.Controls.Xaml.Internals
 			this.getTypeFromXmlName = getTypeFromXmlName ?? throw new ArgumentNullException();
 		}
 
-		Type IXamlTypeResolver.Resolve(string qualifiedTypeName, IServiceProvider serviceProvider)
+#if NETSTANDARD2_0
+		Type IXamlTypeResolver.Resolve(string qualifiedTypeName, IServiceProvider serviceProvider) => ((IXamlTypeResolver)this).Resolve(qualifiedTypeName, serviceProvider, true);
+#endif
+
+		Type IXamlTypeResolver.Resolve(string qualifiedTypeName, IServiceProvider serviceProvider, bool expandToExtension)
 		{
-			var type = Resolve(qualifiedTypeName, serviceProvider, out XamlParseException e);
+			var type = Resolve(qualifiedTypeName, serviceProvider, expandToExtension: expandToExtension, out XamlParseException e);
 			if (e != null)
 				throw e;
 			return type;
@@ -217,18 +221,18 @@ namespace Microsoft.Maui.Controls.Xaml.Internals
 
 		bool IXamlTypeResolver.TryResolve(string qualifiedTypeName, out Type type)
 		{
-			type = Resolve(qualifiedTypeName, null, out XamlParseException exception);
+			type = Resolve(qualifiedTypeName, null, true, out XamlParseException exception);
 			return exception == null;
 		}
 
 		internal bool TryResolve(XmlType xmlType, out Type type)
 		{
 			XamlParseException exception;
-			type = getTypeFromXmlName(xmlType, null, currentAssembly, out exception);
+			type = getTypeFromXmlName(xmlType, null, currentAssembly, true, out exception);
 			return exception == null;
 		}
 
-		Type Resolve(string qualifiedTypeName, IServiceProvider serviceProvider, out XamlParseException exception)
+		Type Resolve(string qualifiedTypeName, IServiceProvider serviceProvider, bool expandToExtension, out XamlParseException exception)
 		{
 			IXmlLineInfo xmlLineInfo = null;
 			if (serviceProvider != null)
@@ -238,10 +242,10 @@ namespace Microsoft.Maui.Controls.Xaml.Internals
 			}
 
 			var xmlType = TypeArgumentsParser.ParseSingle(qualifiedTypeName, namespaceResolver, xmlLineInfo);
-			return getTypeFromXmlName(xmlType, xmlLineInfo, currentAssembly, out exception);
+			return getTypeFromXmlName(xmlType, xmlLineInfo, currentAssembly, expandToExtension, out exception);
 		}
 
-		internal delegate Type GetTypeFromXmlName(XmlType xmlType, IXmlLineInfo xmlInfo, Assembly currentAssembly, out XamlParseException exception);
+		internal delegate Type GetTypeFromXmlName(XmlType xmlType, IXmlLineInfo xmlInfo, Assembly currentAssembly, bool expandToExtension, out XamlParseException exception);
 	}
 
 	class XamlRootObjectProvider : IRootObjectProvider
@@ -328,9 +332,9 @@ namespace Microsoft.Maui.Controls.Xaml.Internals
 			{
 				if (node.TryGetPropertyName(node.Parent, out XmlName name)
 					&& node.Parent is IElementNode parent
-					&& XamlParser.GetElementType(parent.XmlType,
-												 new XmlLineInfo(((IXmlLineInfo)node).LineNumber, ((IXmlLineInfo)node).LinePosition),
-												 context.RootElement.GetType().Assembly, out var xpe) is Type parentType
+					&& XamlParser.GetElementType(parent.XmlType, 
+												 new XmlLineInfo(((IXmlLineInfo)node).LineNumber, ((IXmlLineInfo)node).LinePosition), 
+												 context.RootElement.GetType().Assembly, true, out var xpe) is Type parentType
 					&& parentType.GetRuntimeProperties().FirstOrDefault(p => p.Name == name.LocalName) is PropertyInfo propertyInfo
 					&& propertyInfo.CustomAttributes.Any(ca => ca.AttributeType == typeof(DoesNotInheritDataTypeAttribute)))
 				{

--- a/src/Controls/src/Xaml/XmlTypeXamlExtensions.cs
+++ b/src/Controls/src/Xaml/XmlTypeXamlExtensions.cs
@@ -37,7 +37,8 @@ namespace Microsoft.Maui.Controls.Xaml
 			this XmlType xmlType,
 			IEnumerable<XmlnsDefinitionAttribute> xmlnsDefinitions,
 			string defaultAssemblyName,
-			Func<(string typeName, string clrNamespace, string assemblyName), T> refFromTypeInfo)
+			Func<(string typeName, string clrNamespace, string assemblyName), T> refFromTypeInfo,
+			bool expandToExtension = true)
 			where T : class
 		{
 			var lookupAssemblies = new List<XmlnsDefinitionAttribute>();
@@ -61,7 +62,7 @@ namespace Microsoft.Maui.Controls.Xaml
 			}
 
 			var lookupNames = new List<string>(capacity: 2);
-			if (elementName != "DataTemplate" && !elementName.EndsWith("Extension", StringComparison.Ordinal))
+			if (expandToExtension && elementName != "DataTemplate" && !elementName.EndsWith("Extension", StringComparison.Ordinal))
 				lookupNames.Add(elementName + "Extension");
 			lookupNames.Add(elementName);
 

--- a/src/Controls/tests/Xaml.UnitTests/LoaderTests.cs
+++ b/src/Controls/tests/Xaml.UnitTests/LoaderTests.cs
@@ -792,7 +792,7 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		public void BindingIsResolvedAsBindingExtension()
 		// https://github.com/xamarin/Microsoft.Maui.Controls/issues/3606#issuecomment-422377338
 		{
-			var bindingType = XamlParser.GetElementType(new XmlType("http://schemas.microsoft.com/dotnet/2021/maui", "Binding", null), null, null, out var ex);
+			var bindingType = XamlParser.GetElementType(new XmlType("http://schemas.microsoft.com/dotnet/2021/maui", "Binding", null), null, null, true, out var ex);
 			Assert.That(ex, Is.Null);
 			Assert.That(bindingType, Is.EqualTo(typeof(BindingExtension)));
 			var module = ModuleDefinition.CreateModule("foo", new ModuleParameters()


### PR DESCRIPTION
### Description of Change

if a type name exists with an Extension suffix, xaml rules require us to use that. But not for x:Static


### Issues Fixed

- fixes #11833



<!-- Enter description of the fix in this section -->


<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->


<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
