### PR TITLE
Use strong type for PointerGestureRecognizer Windows PlatformArgs

### DIFF
--- a/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
@@ -510,11 +510,13 @@ namespace Microsoft.Maui.Controls.Platform
 
 		void OnPgrPointerPressed(object sender, PointerRoutedEventArgs e)
 			=> HandlePgrPointerEvent(e, (view, recognizer)
-				=> recognizer.SendPointerPressed(view, (relativeTo) => GetPosition(relativeTo, e)));
+				=> recognizer.SendPointerPressed(view, (relativeTo)
+					=> GetPosition(relativeTo, e), _control is null ? null : new PlatformPointerEventArgs(_control, e)));
 
 		void OnPgrPointerReleased(object sender, PointerRoutedEventArgs e)
 			=> HandlePgrPointerEvent(e, (view, recognizer)
-				=> recognizer.SendPointerReleased(view, (relativeTo) => GetPosition(relativeTo, e)));
+				=> recognizer.SendPointerReleased(view, (relativeTo)
+					=> GetPosition(relativeTo, e), _control is null ? null : new PlatformPointerEventArgs(_control, e)));
 
 		private void HandlePgrPointerEvent(PointerRoutedEventArgs e, Action<View, PointerGestureRecognizer> SendPointerEvent)
 		{

--- a/src/Controls/src/Core/PlatformPointerEventArgs.cs
+++ b/src/Controls/src/Core/PlatformPointerEventArgs.cs
@@ -49,12 +49,12 @@ public class PlatformPointerEventArgs
 	/// <summary>
 	/// Gets the native event or handler attached to the view.
 	/// </summary>
-	public Microsoft.UI.Xaml.PointerRoutedEventArgs RoutedEventArgs { get; }
+	public Microsoft.UI.Xaml.Input.PointerRoutedEventArgs PointerRoutedEventArgs { get; }
 
-	internal PlatformPointerEventArgs(Microsoft.UI.Xaml.FrameworkElement sender, Microsoft.UI.Xaml.PointerRoutedEventArgs routedEventArgs)
+	internal PlatformPointerEventArgs(Microsoft.UI.Xaml.FrameworkElement sender, Microsoft.UI.Xaml.Input.PointerRoutedEventArgs pointerRoutedEventArgs)
 	{
 		Sender = sender;
-		RoutedEventArgs = routedEventArgs;
+		PointerRoutedEventArgs = pointerRoutedEventArgs;
 	}
 
 #else

--- a/src/Controls/src/Core/PlatformPointerEventArgs.cs
+++ b/src/Controls/src/Core/PlatformPointerEventArgs.cs
@@ -49,9 +49,9 @@ public class PlatformPointerEventArgs
 	/// <summary>
 	/// Gets the native event or handler attached to the view.
 	/// </summary>
-	public Microsoft.UI.Xaml.RoutedEventArgs RoutedEventArgs { get; }
+	public Microsoft.UI.Xaml.PointerRoutedEventArgs RoutedEventArgs { get; }
 
-	internal PlatformPointerEventArgs(Microsoft.UI.Xaml.FrameworkElement sender, Microsoft.UI.Xaml.RoutedEventArgs routedEventArgs)
+	internal PlatformPointerEventArgs(Microsoft.UI.Xaml.FrameworkElement sender, Microsoft.UI.Xaml.PointerRoutedEventArgs routedEventArgs)
 	{
 		Sender = sender;
 		RoutedEventArgs = routedEventArgs;

--- a/src/Controls/src/Core/PointerGestureRecognizer.cs
+++ b/src/Controls/src/Core/PointerGestureRecognizer.cs
@@ -225,27 +225,27 @@ namespace Microsoft.Maui.Controls
 		/// <summary>
 		/// For internal use by the .NET MAUI platform.
 		/// </summary>
-		internal void SendPointerPressed(View sender, Func<IElement?, Point?>? getPosition)
+		internal void SendPointerPressed(View sender, Func<IElement?, Point?>? getPosition, PlatformPointerEventArgs? platformArgs = null)
 		{
 			ICommand cmd = PointerPressedCommand;
 			if (cmd?.CanExecute(PointerPressedCommandParameter) == true)
 				cmd.Execute(PointerPressedCommandParameter);
 
 			EventHandler<PointerEventArgs>? handler = PointerPressed;
-			handler?.Invoke(sender, new PointerEventArgs(getPosition));
+			handler?.Invoke(sender, new PointerEventArgs(getPosition, platformArgs));
 		}
 
 		/// <summary>
 		/// For internal use by the .NET MAUI platform.
 		/// </summary>
-		internal void SendPointerReleased(View sender, Func<IElement?, Point?>? getPosition)
+		internal void SendPointerReleased(View sender, Func<IElement?, Point?>? getPosition, PlatformPointerEventArgs? platformArgs = null)
 		{
 			ICommand cmd = PointerReleasedCommand;
 			if (cmd?.CanExecute(PointerReleasedCommandParameter) == true)
 				cmd.Execute(PointerReleasedCommandParameter);
 
 			EventHandler<PointerEventArgs>? handler = PointerReleased;
-			handler?.Invoke(sender, new PointerEventArgs(getPosition));
+			handler?.Invoke(sender, new PointerEventArgs(getPosition, platformArgs));
 		}
 
 		internal static void SetupForPointerOverVSM(

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -203,7 +203,7 @@ Microsoft.Maui.Controls.ShellNavigationQueryParameters.Values.get -> System.Coll
 *REMOVED*~Microsoft.Maui.Controls.Shell.RemoveLogicalChild(Microsoft.Maui.Controls.Element element) -> void
 Microsoft.Maui.Controls.PointerEventArgs.PlatformArgs.get -> Microsoft.Maui.Controls.PlatformPointerEventArgs?
 Microsoft.Maui.Controls.PlatformPointerEventArgs
-Microsoft.Maui.Controls.PlatformPointerEventArgs.RoutedEventArgs.get -> Microsoft.UI.Xaml.PointerRoutedEventArgs!
+Microsoft.Maui.Controls.PlatformPointerEventArgs.PointerRoutedEventArgs.get -> Microsoft.UI.Xaml.Input.PointerRoutedEventArgs!
 Microsoft.Maui.Controls.PlatformPointerEventArgs.Sender.get -> Microsoft.UI.Xaml.FrameworkElement!
 *REMOVED*override Microsoft.Maui.Controls.SwipeItems.OnBindingContextChanged() -> void
 *REMOVED*override Microsoft.Maui.Controls.SwipeView.OnBindingContextChanged() -> void

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -203,7 +203,7 @@ Microsoft.Maui.Controls.ShellNavigationQueryParameters.Values.get -> System.Coll
 *REMOVED*~Microsoft.Maui.Controls.Shell.RemoveLogicalChild(Microsoft.Maui.Controls.Element element) -> void
 Microsoft.Maui.Controls.PointerEventArgs.PlatformArgs.get -> Microsoft.Maui.Controls.PlatformPointerEventArgs?
 Microsoft.Maui.Controls.PlatformPointerEventArgs
-Microsoft.Maui.Controls.PlatformPointerEventArgs.RoutedEventArgs.get -> Microsoft.UI.Xaml.RoutedEventArgs!
+Microsoft.Maui.Controls.PlatformPointerEventArgs.RoutedEventArgs.get -> Microsoft.UI.Xaml.PointerRoutedEventArgs!
 Microsoft.Maui.Controls.PlatformPointerEventArgs.Sender.get -> Microsoft.UI.Xaml.FrameworkElement!
 *REMOVED*override Microsoft.Maui.Controls.SwipeItems.OnBindingContextChanged() -> void
 *REMOVED*override Microsoft.Maui.Controls.SwipeView.OnBindingContextChanged() -> void


### PR DESCRIPTION
### Description of Change

<!-- Enter description of the fix in this section -->
This PR changes the PlatformPointerEventArgs Windows property from RoutedEventArgs to a stronger PointerRoutedEventArgs. This is something that should have probably been done originally and will allow customers to have a more specific class for the Pointer Arguments. This PR also extends this pattern to the PointerPressed and PointerReleased events.
