### PR TITLE
Enable requesting the full preview size on iOS drag shadow & iOS and Windows Samples

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Windows/WindowsDragAndDropCustomization.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Windows/WindowsDragAndDropCustomization.xaml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="Maui.Controls.Sample.Pages.WindowsDragAndDropCustomization"
+    Title="Drag and Drop Windows Platform-Specific">
+    <Grid Margin="20" RowDefinitions="290,*">
+
+        <Border Margin="15" Grid.Row="0">
+            <StackLayout>
+                <Label Text="Drag and Drop the items below" FontSize="Large" FontAttributes="Bold"/>
+                <CollectionView x:Name="CollectionView1">
+                    <CollectionView.ItemTemplate>
+                        <DataTemplate>
+                                <Label Text="{Binding Name}" Background="LightGray" HeightRequest="30" HorizontalOptions="Fill" Margin="3">
+                                    <Label.GestureRecognizers>
+                                        <DragGestureRecognizer />
+                                    </Label.GestureRecognizers>
+                                </Label>
+                        </DataTemplate>
+                    </CollectionView.ItemTemplate>
+                </CollectionView>
+            </StackLayout>
+        </Border>
+
+        <TableView Intent="Settings" Grid.Row="1" >
+            <TableRoot>
+                <TableSection Title="Drag Customization">
+
+                    <ViewCell>
+                        <Grid ColumnDefinitions="3*,*" VerticalOptions="Center" Margin="10,0,5,0">
+                            <Label Text="Show Glyph" VerticalTextAlignment="Center" Grid.Column="0"/>
+                            <Switch HorizontalOptions="End" x:Name="ShowGlyphSwitch" IsToggled="True" Grid.Column="1"/>
+                        </Grid>
+                    </ViewCell>
+
+                    <ViewCell>
+                        <Grid ColumnDefinitions="3*,*" VerticalOptions="Center" Margin="10,0,5,0">
+                            <Label Text="Custom Caption" VerticalTextAlignment="Center" Grid.Column="0"/>
+                            <Entry HorizontalOptions="End" WidthRequest="300" Placeholder="Copy" x:Name="CustomCaptionEntry" Grid.Column="1"/>
+                        </Grid>
+                    </ViewCell>
+
+                    <ViewCell>
+                        <Grid ColumnDefinitions="3*,*" VerticalOptions="Center" Margin="10,0,5,0">
+                            <Label Text="Show Caption" VerticalTextAlignment="Center" Grid.Column="0"/>
+                            <Switch HorizontalOptions="End" x:Name="ShowCaptionSwitch" IsToggled="True" Grid.Column="1"/>
+                        </Grid>
+                    </ViewCell>
+
+                    <ViewCell>
+                        <Grid ColumnDefinitions="3*,*" VerticalOptions="Center" Margin="10,0,5,0">
+                            <Label Text="Show Content" VerticalTextAlignment="Center" Grid.Column="0"/>
+                            <Switch HorizontalOptions="End" x:Name="ShowContentSwitch" Grid.Column="1" IsToggled="True"/>
+                        </Grid>
+                    </ViewCell>
+                </TableSection>
+
+            </TableRoot>
+        </TableView>
+        <Grid.GestureRecognizers>
+            <DropGestureRecognizer DragOver="DropGestureRecognizer_DragOver" />
+        </Grid.GestureRecognizers>
+    </Grid>
+</ContentPage>

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Windows/WindowsDragAndDropCustomization.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Windows/WindowsDragAndDropCustomization.xaml.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using Maui.Controls.Sample.ViewModels;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.PlatformConfiguration;
+using Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific;
+
+namespace Maui.Controls.Sample.Pages
+{
+	public partial class WindowsDragAndDropCustomization : ContentPage
+	{
+		public WindowsDragAndDropCustomization()
+		{
+			InitializeComponent();
+
+			CollectionView1.ItemsSource = new NameObject[]
+			{
+				new NameObject ("First Item"),
+				new NameObject ("Second Item"),
+				new NameObject ("Third Item"),
+				new NameObject ("Fourth Item"),
+				new NameObject ("Fifth Item"),
+				new NameObject ("Sixth Item"),
+			};
+		}
+
+		void DropGestureRecognizer_DragOver(System.Object sender, Microsoft.Maui.Controls.DragEventArgs e)
+		{
+#if WINDOWS
+			var dragUI = e.PlatformArgs.DragEventArgs.DragUIOverride;
+			dragUI.IsCaptionVisible = ShowCaptionSwitch.IsToggled;
+			dragUI.IsGlyphVisible = ShowGlyphSwitch.IsToggled;
+			dragUI.IsContentVisible = ShowContentSwitch.IsToggled;
+
+			dragUI.Caption = string.IsNullOrEmpty (CustomCaptionEntry.Text) ? "Copy" : CustomCaptionEntry.Text;
+#endif
+		}
+	}
+
+
+	public class NameObject
+	{
+		public NameObject(string name)
+		{
+			Name = name;
+		}
+
+		public string Name { get; set; }
+	}
+}

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Windows/WindowsDragAndDropCustomization.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Windows/WindowsDragAndDropCustomization.xaml.cs
@@ -34,16 +34,15 @@ namespace Maui.Controls.Sample.Pages
 			dragUI.Caption = string.IsNullOrEmpty (CustomCaptionEntry.Text) ? "Copy" : CustomCaptionEntry.Text;
 #endif
 		}
-	}
 
-
-	public class NameObject
-	{
-		public NameObject(string name)
+		public class NameObject
 		{
-			Name = name;
-		}
+			public NameObject(string name)
+			{
+				Name = name;
+			}
 
-		public string Name { get; set; }
+			public string Name { get; set; }
+		}
 	}
 }

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/iOS/iOSDragAndDropRequestFullSize.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/iOS/iOSDragAndDropRequestFullSize.xaml
@@ -1,0 +1,79 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage 
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui" 
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"            
+    x:Class="Maui.Controls.Sample.Pages.iOSDragAndDropRequestFullSize"
+    Title="Drag and Drop iOS Platform-Specific">
+    <Grid Margin="20" RowDefinitions="300,*">
+
+        <Border Margin="15" Grid.Row="0">
+            <StackLayout>
+                <Label Text="Drag and Drop the items below" FontSize="Large" FontAttributes="Bold"/>
+                <CollectionView x:Name="CollectionView1">
+                    <CollectionView.ItemTemplate>
+                        <DataTemplate>
+                            <Entry Text="{Binding Name}">
+                                <Entry.GestureRecognizers>
+                                    <DragGestureRecognizer DragStarting="DragGestureRecognizer_DragStarting" />
+                                    <DropGestureRecognizer DragOver="DropGestureRecognizer_DragOver" />
+                                </Entry.GestureRecognizers>
+                            </Entry>
+                        </DataTemplate>
+                    </CollectionView.ItemTemplate>
+                </CollectionView>
+            </StackLayout>
+        </Border>
+
+        <TableView Intent="Settings" Grid.Row="1" >
+            <TableRoot>
+                <TableSection Title="Drag size option">
+                    <ViewCell>
+                        <Grid ColumnDefinitions="3*,*" VerticalOptions="Center" Margin="10,0,5,0">
+                            <Label Text="Request Full-Sized Drag Previews" VerticalTextAlignment="Center" Grid.Column="0"/>
+                            <Switch HorizontalOptions="End" x:Name="fullSizedSwitch" Toggled="FullSized_Switch_Toggled" Grid.Column="1"/>
+                        </Grid>
+                    </ViewCell>
+                </TableSection>
+
+                <TableSection Title="Content Options">
+                    <ViewCell>
+                        <Grid ColumnDefinitions="3*,*" VerticalOptions="Center" Margin="10,0,5,0">
+                            <Label Text="Use drawn image" VerticalTextAlignment="Center" Grid.Column="0"/>
+                            <Switch HorizontalOptions="End" x:Name="drawnImageSwitch" Toggled="Drawn_Switch_Toggled" Grid.Column="1"/>
+                        </Grid>
+                    </ViewCell>
+
+                    <ViewCell>
+                        <Grid ColumnDefinitions="3*,*"  VerticalOptions="Center" Margin="10,0,5,0">
+                            <Label Text="Use dotnet bot image" VerticalTextAlignment="Center" Grid.Column="0"/>
+                            <Switch HorizontalOptions="End" x:Name="dotnetBotImageSwitch" Toggled="DotnetBot_Switch_Toggled" Grid.Column="1"/>
+                        </Grid>
+                    </ViewCell>
+                </TableSection>
+                    <TableSection Title="Drop Types">
+                    <ViewCell>
+                        <Grid ColumnDefinitions="3*,*" VerticalOptions="Center" Margin="10,0,5,0">
+                            <Label Text="UIDropProposal - Copy" VerticalTextAlignment="Center" Grid.Column="0"/>
+                            <Switch HorizontalOptions="End" x:Name="copySwitch" IsToggled="True" Toggled="Copy_Switch_Toggled" Grid.Column="1"/>
+                        </Grid>
+                    </ViewCell>
+
+                    <ViewCell>
+                        <Grid ColumnDefinitions="3*,*" VerticalOptions="Center" Margin="10,0,5,0">
+                            <Label Text="UIDropProposal - Move" VerticalTextAlignment="Center" Grid.Column="0"/>
+                            <Switch HorizontalOptions="End" x:Name="moveSwitch" Toggled="Move_Switch_Toggled" Grid.Column="1"/>
+                        </Grid>
+                    </ViewCell>
+
+                    <ViewCell>
+                        <Grid ColumnDefinitions="3*,*" VerticalOptions="Center" Margin="10,0,5,0">
+                            <Label Text="UIDropProposal - Forbidden" VerticalTextAlignment="Center" Grid.Column="0"/>
+                            <Switch HorizontalOptions="End" x:Name="forbiddenSwitch" Toggled="Forbidden_Switch_Toggled" Grid.Column="1"/>
+                        </Grid>
+                    </ViewCell>
+
+                </TableSection>
+            </TableRoot>
+        </TableView>
+    </Grid>
+</ContentPage>

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/iOS/iOSDragAndDropRequestFullSize.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/iOS/iOSDragAndDropRequestFullSize.xaml.cs
@@ -1,0 +1,143 @@
+using System;
+using Maui.Controls.Sample.ViewModels;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.PlatformConfiguration;
+using Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific;
+
+namespace Maui.Controls.Sample.Pages
+{
+	public partial class iOSDragAndDropRequestFullSize : ContentPage
+	{
+		public iOSDragAndDropRequestFullSize()
+		{
+			InitializeComponent();
+
+			CollectionView1.ItemsSource = new NameObject[]
+			{
+				new NameObject ("First Item"),
+				new NameObject ("Second Item"),
+				new NameObject ("Third Item"),
+				new NameObject ("Fourth Item"),
+				new NameObject ("Fifth Item"),
+				new NameObject ("Sixth Item"),
+			};
+
+			// Changing the drag preview is not observed working the same as in iOS
+#if MACCATALYST
+			fullSizedSwitch.IsEnabled = false;
+			drawnImageSwitch.IsEnabled = false;
+			dotnetBotImageSwitch.IsEnabled = false;
+#endif
+		}
+
+		void DragGestureRecognizer_DragStarting(System.Object sender, Microsoft.Maui.Controls.DragStartingEventArgs e)
+		{
+#if IOS || MACCATALYST
+			if (drawnImageSwitch.IsToggled)
+			{
+				Func<UIKit.UIDragPreview> action = () =>
+				{
+					var previewParameters = new UIKit.UIDragPreviewParameters();
+					var funkyPath = new UIKit.UIBezierPath();
+					funkyPath.MoveTo(new CoreGraphics.CGPoint(0, 0));
+					funkyPath.AddLineTo(new CoreGraphics.CGPoint(300, 0));
+					funkyPath.AddLineTo(new CoreGraphics.CGPoint(225, 150));
+					funkyPath.AddLineTo(new CoreGraphics.CGPoint(300, 300));
+					funkyPath.AddLineTo(new CoreGraphics.CGPoint(0, 300));
+					funkyPath.ClosePath();
+					previewParameters.VisiblePath = funkyPath;
+
+					return new UIKit.UIDragPreview(e.PlatformArgs.Sender, previewParameters);
+				};
+
+				e.PlatformArgs.SetPreviewProvider(action);
+			}
+
+			else if (dotnetBotImageSwitch.IsToggled)
+			{
+				Func<UIKit.UIDragPreview> action = () =>
+				{
+					var image = UIKit.UIImage.FromFile("dotnet_bot.png");
+
+					UIKit.UIImageView imageView = new UIKit.UIImageView(image);
+					imageView.ContentMode = UIKit.UIViewContentMode.Center;
+					imageView.Frame = new CoreGraphics.CGRect(0, 0, 250, 250);
+
+					return new UIKit.UIDragPreview(imageView);
+				};
+
+				e.PlatformArgs.SetPreviewProvider(action);
+			}
+
+
+			e.PlatformArgs.SetPrefersFullSizePreviews((interaction, session) => { return fullSizedSwitch.IsToggled; });
+#endif
+		}
+
+		void Drawn_Switch_Toggled(object sender, ToggledEventArgs e)
+		{
+			if (e.Value)
+				dotnetBotImageSwitch.IsToggled = false;
+		}
+
+		void DotnetBot_Switch_Toggled(object sender, ToggledEventArgs e)
+		{
+			if (e.Value)
+				drawnImageSwitch.IsToggled = false;
+		}
+
+		void DropGestureRecognizer_DragOver(System.Object sender, Microsoft.Maui.Controls.DragEventArgs e)
+		{
+#if IOS || MACCATALYST
+			if (copySwitch.IsToggled)
+				e.PlatformArgs.SetDropProposal(new UIKit.UIDropProposal(UIKit.UIDropOperation.Copy));
+			else if (moveSwitch.IsToggled)
+				e.PlatformArgs.SetDropProposal(new UIKit.UIDropProposal(UIKit.UIDropOperation.Move));
+			else if (forbiddenSwitch.IsToggled)
+				e.PlatformArgs.SetDropProposal(new UIKit.UIDropProposal(UIKit.UIDropOperation.Forbidden));
+#endif
+		}
+
+		void FullSized_Switch_Toggled(object sender, ToggledEventArgs e)
+		{
+		}
+
+		void Copy_Switch_Toggled(object sender, ToggledEventArgs e)
+		{
+			if (e.Value)
+			{
+				moveSwitch.IsToggled = false;
+				forbiddenSwitch.IsToggled = false;
+			}
+		}
+
+		void Move_Switch_Toggled(object sender, ToggledEventArgs e)
+		{
+			if (e.Value)
+			{
+				copySwitch.IsToggled = false;
+				forbiddenSwitch.IsToggled = false;
+			}
+		}
+
+		void Forbidden_Switch_Toggled(object sender, ToggledEventArgs e)
+		{
+			if (e.Value)
+			{
+				moveSwitch.IsToggled = false;
+				copySwitch.IsToggled = false;
+			}
+		}
+	}
+
+
+	public class NameObject
+	{
+		public NameObject(string name)
+		{
+			Name = name;
+		}
+
+		public string Name { get; set; }
+	}
+}

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/iOS/iOSDragAndDropRequestFullSize.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/iOS/iOSDragAndDropRequestFullSize.xaml.cs
@@ -128,16 +128,18 @@ namespace Maui.Controls.Sample.Pages
 				copySwitch.IsToggled = false;
 			}
 		}
-	}
 
-
-	public class NameObject
-	{
-		public NameObject(string name)
+		public class NameObject
 		{
-			Name = name;
-		}
+			public NameObject(string name)
+			{
+				Name = name;
+			}
 
-		public string Name { get; set; }
+			public string Name { get; set; }
+		}
 	}
+
+
+	
 }

--- a/src/Controls/samples/Controls.Sample/ViewModels/PlatformSpecificsViewModel.cs
+++ b/src/Controls/samples/Controls.Sample/ViewModels/PlatformSpecificsViewModel.cs
@@ -60,6 +60,9 @@ namespace Maui.Controls.Sample.ViewModels
 				new SectionModel(typeof(iOSFlyoutPage), "FlyoutPage Shadow",
 					"This platform-specific controls whether the detail page of a FlyoutPage has shadow applied to it, when revealing the flyout page."),
 
+				new SectionModel(typeof(iOSDragAndDropRequestFullSize), "Drag and Drop Gesture Recognizer Platform-Specific",
+					"This iOS platform-specific controls whether to request full-sized drag shadows and the UIDropProposal types."),
+
 				new SectionModel(typeof(iOSHideHomeIndicatorPage), "Hide Home Indicator",
 					"This iOS platform-specific sets the visibility of the home indicator on a Page."),
 

--- a/src/Controls/samples/Controls.Sample/ViewModels/PlatformSpecificsViewModel.cs
+++ b/src/Controls/samples/Controls.Sample/ViewModels/PlatformSpecificsViewModel.cs
@@ -126,6 +126,9 @@ namespace Maui.Controls.Sample.ViewModels
 				new SectionModel(typeof(WindowsCollapseWidthAdjusterPage), "FlyoutPage Navigation Bar",
 					"This WinUI platform-specific is used to collapse the navigation bar on a FlyoutPage."),
 
+				new SectionModel(typeof(WindowsDragAndDropCustomization), "Drag and Drop Gesture Recognizer Platform-Specific",
+					"This WinUI platform-specific displays drag and drop customization such as custom drag gylph and text."),
+
 				new SectionModel(typeof(WindowsListViewPage), "ListView Selection Mode",
 					"This WinUI platform-specific controls whether items in a ListView can respond to tap gestures, and hence whether the native ListView fires the ItemClick or Tapped event."),
 

--- a/src/Controls/src/Core/DragAndDrop/PlatformDragStartingEventArgs.cs
+++ b/src/Controls/src/Core/DragAndDrop/PlatformDragStartingEventArgs.cs
@@ -26,6 +26,7 @@ public class PlatformDragStartingEventArgs
 	internal Foundation.NSItemProvider? ItemProvider { get; private set; }
 	internal Func<UIKit.UIDragPreview?>? PreviewProvider { get; private set; }
 	internal UIKit.UIDragItem[]? DragItems { get; private set; }
+	internal Func<UIKit.UIDragInteraction, UIKit.IUIDragSession, bool>? PrefersFullSizePreviews { get; private set; }
 
 	internal PlatformDragStartingEventArgs(UIKit.UIView? sender, UIKit.UIDragInteraction dragInteraction,
 		UIKit.IUIDragSession dragSession)
@@ -69,6 +70,21 @@ public class PlatformDragStartingEventArgs
 	public void SetDragItems(UIKit.UIDragItem[] dragItems)
 	{
 		DragItems = dragItems;
+	}
+
+	/// <summary>
+	/// Sets the func that requests to keep drag previews full-sized when dragging begins.
+	/// </summary>
+	/// <param name="prefersFullSizePreviews">Func that returns whether to request full size previews.</param>
+	/// <remarks>
+	/// The default behavior on iOS is to reduce the size of the drag shadow if not requested here.
+	/// Even if requested, it is up to the system whether or not to fulfill the request.
+	/// This method exists inside <see cref="PlatformDragStartingEventArgs"/> since the preview must
+	/// have this value set when dragging begins.
+	/// </remarks>
+	public void SetPrefersFullSizePreviews(Func<UIKit.UIDragInteraction, UIKit.IUIDragSession, bool>? prefersFullSizePreviews)
+	{
+		PrefersFullSizePreviews = prefersFullSizePreviews;
 	}
 
 #elif ANDROID

--- a/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.iOS.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.iOS.cs
@@ -103,6 +103,8 @@ namespace Microsoft.Maui.Controls.Platform
 			}
 			_gestureRecognizers.Clear();
 
+			_dragAndDropDelegate?.Disconnect();
+
 			Disconnect();
 
 			_platformView = null;

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -10,6 +10,7 @@ Microsoft.Maui.Controls.PlatformDragStartingEventArgs.DragInteraction.get -> UIK
 Microsoft.Maui.Controls.PlatformDragStartingEventArgs.DragSession.get -> UIKit.IUIDragSession!
 Microsoft.Maui.Controls.PlatformDragStartingEventArgs.Sender.get -> UIKit.UIView?
 Microsoft.Maui.Controls.PlatformDragStartingEventArgs.SetItemProvider(Foundation.NSItemProvider! itemProvider) -> void
+Microsoft.Maui.Controls.PlatformDragStartingEventArgs.SetPrefersFullSizePreviews(System.Func<UIKit.UIDragInteraction!, UIKit.IUIDragSession!, bool>? prefersFullSizePreviews) -> void
 Microsoft.Maui.Controls.PlatformDragStartingEventArgs.SetPreviewProvider(System.Func<UIKit.UIDragPreview?>! previewProvider) -> void
 Microsoft.Maui.Controls.PlatformDragStartingEventArgs.SetDragItems(UIKit.UIDragItem![]! dragItems) -> void
 Microsoft.Maui.Controls.PlatformDropCompletedEventArgs
@@ -213,7 +214,6 @@ Microsoft.Maui.Controls.ShellNavigationQueryParameters.Values.get -> System.Coll
 ~static readonly Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTappedProperty -> Microsoft.Maui.Controls.BindableProperty
 Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTapped.get -> bool
 Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTapped.set -> void
-
 *REMOVED*~Microsoft.Maui.Controls.Editor.FontFamily.get -> string
 *REMOVED*~Microsoft.Maui.Controls.Editor.FontFamily.set -> void
 *REMOVED*Microsoft.Maui.Controls.Editor.CursorPosition.get -> int
@@ -226,7 +226,6 @@ Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTapped.set -> void
 *REMOVED*Microsoft.Maui.Controls.Editor.FontSize.set -> void
 *REMOVED*Microsoft.Maui.Controls.Editor.SelectionLength.get -> int
 *REMOVED*Microsoft.Maui.Controls.Editor.SelectionLength.set -> void
-
 *REMOVED*~Microsoft.Maui.Controls.SearchBar.FontFamily.get -> string
 *REMOVED*~Microsoft.Maui.Controls.SearchBar.FontFamily.set -> void
 *REMOVED*Microsoft.Maui.Controls.SearchBar.CursorPosition.get -> int
@@ -239,7 +238,6 @@ Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTapped.set -> void
 *REMOVED*Microsoft.Maui.Controls.SearchBar.FontSize.set -> void
 *REMOVED*Microsoft.Maui.Controls.SearchBar.SelectionLength.get -> int
 *REMOVED*Microsoft.Maui.Controls.SearchBar.SelectionLength.set -> void
-
 *REMOVED*~Microsoft.Maui.Controls.Entry.FontFamily.get -> string
 *REMOVED*~Microsoft.Maui.Controls.Entry.FontFamily.set -> void
 *REMOVED*Microsoft.Maui.Controls.Entry.CursorPosition.get -> int
@@ -252,4 +250,3 @@ Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTapped.set -> void
 *REMOVED*Microsoft.Maui.Controls.Entry.FontSize.set -> void
 *REMOVED*Microsoft.Maui.Controls.Entry.SelectionLength.get -> int
 *REMOVED*Microsoft.Maui.Controls.Entry.SelectionLength.set -> void
-

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -10,6 +10,7 @@ Microsoft.Maui.Controls.PlatformDropCompletedEventArgs
 Microsoft.Maui.Controls.PlatformDropCompletedEventArgs.DragInteraction.get -> UIKit.UIDragInteraction?
 Microsoft.Maui.Controls.PlatformDropCompletedEventArgs.DragSession.get -> UIKit.IUIDragSession?
 Microsoft.Maui.Controls.PlatformDropCompletedEventArgs.DropInteraction.get -> UIKit.UIDropInteraction?
+Microsoft.Maui.Controls.PlatformDragStartingEventArgs.SetPrefersFullSizePreviews(System.Func<UIKit.UIDragInteraction!, UIKit.IUIDragSession!, bool>? prefersFullSizePreviews) -> void
 Microsoft.Maui.Controls.PlatformDropCompletedEventArgs.DropOperation.get -> UIKit.UIDropOperation?
 Microsoft.Maui.Controls.PlatformDropCompletedEventArgs.DropSession.get -> UIKit.IUIDropSession?
 Microsoft.Maui.Controls.PlatformDropCompletedEventArgs.Sender.get -> UIKit.UIView?


### PR DESCRIPTION
### Description of Change

<!-- Enter description of the fix in this section -->
On iOS, when you drag an item inside the drag and drop context, the system automatically resizes the item so that you can more easily see where it is going. However, if we have say a collectionview with custom functionality, we may want to request to keep the drag items the same size. This PR allows the customer to throw in a func and request to keep their items the full size when dragging.

I also added in a sample to the gallery to see how this request full preview, using custom PreviewProviders, and different UIDropProposals interact with each other!

https://github.com/dotnet/maui/assets/50846373/104d0a26-fe50-46df-8a19-27e2ff9e6bf1

___

edit: I also added a sample for Windows showing some platform-specific code to change the drag caption and glyph!


https://github.com/dotnet/maui/assets/50846373/0fab10de-65f6-4032-a0a8-9ea3f7e79638




### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #17281

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
