### PR TITLE
Fix iOS/Win InputTransparent layouts and add several UI tests

### DIFF
--- a/src/Controls/samples/Controls.Sample.UITests/Concepts/InputTransparencyGalleryPage.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/Concepts/InputTransparencyGalleryPage.cs
@@ -1,0 +1,239 @@
+﻿using System;
+using Microsoft.Maui.Controls;
+
+namespace Maui.Controls.Sample
+{
+	internal class InputTransparencyGalleryPage : CoreGalleryBasePage
+	{
+		protected override void Build()
+		{
+			// Basic test with view defaults, should be clickable
+			Add(Test.InputTransparency.Default, new Button { Text = "Click Me!" })
+				.With(t => t.View.Clicked += (s, e) => t.ReportSuccessEvent());
+
+			// Test when InputTransparent is explicitly set to False, should be clickable
+			Add(Test.InputTransparency.IsFalse, new Button { Text = "Click Me!", InputTransparent = false })
+				.With(t => t.View.Clicked += (s, e) => t.ReportSuccessEvent());
+
+			// Test when InputTransparent is explicitly set to True, should NOT be clickable
+			// and we emulate this by putting another button underneath that should be clickable
+			Add(Test.InputTransparency.IsTrue, () =>
+			{
+				var bottom = new Button { Text = "Bottom Button" };
+				var top = new Button { Text = "Click Me!", InputTransparent = true };
+				var grid = new Grid { bottom, top };
+				return (grid, new { Bottom = bottom, Top = top });
+			})
+			.With(t =>
+			{
+				var v = t.ViewContainer.View;
+				var bottom = t.Additional.Bottom;
+				var top = Annotate(t.Additional.Top, v);
+				bottom.Clicked += (s, e) => t.ViewContainer.ReportSuccessEvent();
+				top.Clicked += (s, e) => t.ViewContainer.ReportFailEvent();
+			});
+
+			// Test when there is an InputTransparent layout over the button, should be clickable
+			Add(Test.InputTransparency.TransLayoutOverlay, () =>
+			{
+				var button = new Button { Text = "Click Me!" };
+				var grid = new Grid
+				{
+					new Grid { button },
+					new Grid
+					{
+						InputTransparent = true,
+						Background = Brush.Red,
+						Opacity = 0.5,
+					}
+				};
+				return (grid, new { Button = button });
+			})
+			.With(t =>
+			{
+				var v = t.ViewContainer.View;
+				var button = Annotate(t.Additional.Button, v);
+				button.Clicked += (s, e) => t.ViewContainer.ReportSuccessEvent();
+			});
+
+			// Test when there is an InputTransparent layout over the button, should NOT be clickable
+			// but the button IN the layout should be clickable because it is not cascading
+			Add(Test.InputTransparency.TransLayoutOverlayWithButton, () =>
+			{
+				var bottom = new Button { Text = "Bottom Button" };
+				var top = new Button { Text = "Click Me!" };
+				var grid = new Grid
+				{
+					new Grid { bottom },
+					new Grid
+					{
+						InputTransparent = true,
+						CascadeInputTransparent = false,
+						Background = Brush.Red,
+						Opacity = 0.5,
+						Children = { top },
+					}
+				};
+				return (grid, new { Bottom = bottom, Top = top });
+			})
+			.With(t =>
+			{
+				var v = t.ViewContainer.View;
+				var bottom = t.Additional.Bottom;
+				var top = Annotate(t.Additional.Top, v);
+				bottom.Clicked += (s, e) => t.ViewContainer.ReportFailEvent();
+				top.Clicked += (s, e) => t.ViewContainer.ReportSuccessEvent();
+			});
+
+			// Test when there is an InputTransparent layout over the button, should be clickable
+			Add(Test.InputTransparency.CascadeTransLayoutOverlay, () =>
+			{
+				var button = new Button { Text = "Click Me!" };
+				var grid = new Grid
+				{
+					new Grid { button },
+					new Grid
+					{
+						InputTransparent = true,
+						CascadeInputTransparent = true,
+						Background = Brush.Red,
+						Opacity = 0.5,
+					}
+				};
+				return (grid, new { Button = button });
+			})
+			.With(t =>
+			{
+				var v = t.ViewContainer.View;
+				var button = Annotate(t.Additional.Button, v);
+				button.Clicked += (s, e) => t.ViewContainer.ReportSuccessEvent();
+			});
+
+			// Test when there is an InputTransparent layout over the button, should be clickable
+			// and the button IN the layout should NOT be clickable because it is cascading
+			Add(Test.InputTransparency.CascadeTransLayoutOverlayWithButton, () =>
+			{
+				var bottom = new Button { Text = "Bottom Button" };
+				var top = new Button { Text = "Click Me!" };
+				var grid = new Grid
+				{
+					new Grid { bottom },
+					new Grid
+					{
+						InputTransparent = true,
+						CascadeInputTransparent = true,
+						Background = Brush.Red,
+						Opacity = 0.5,
+						Children = { top },
+					}
+				};
+				return (grid, new { Bottom = bottom, Top = top });
+			})
+			.With(t =>
+			{
+				var v = t.ViewContainer.View;
+				var bottom = t.Additional.Bottom;
+				var top = Annotate(t.Additional.Top, v);
+				bottom.Clicked += (s, e) => t.ViewContainer.ReportSuccessEvent();
+				top.Clicked += (s, e) => t.ViewContainer.ReportFailEvent();
+			});
+
+			// Tests for a nested layout (root grid, nested grid, button) with some variations to ensure
+			// that all combinations are correctly clickable
+			foreach (var state in Test.InputTransparencyMatrix.States)
+			{
+				var (rt, rc, nt, nc, t) = state.Key;
+				var (clickable, passthru) = state.Value;
+
+				AddNesting(rt, rc, nt, nc, t, clickable, passthru);
+			}
+		}
+
+		void AddNesting(bool rootTrans, bool rootCascade, bool nestedTrans, bool nestedCascade, bool trans, bool isClickable, bool isPassThru) =>
+			Add(Test.InputTransparencyMatrix.GetKey(rootTrans, rootCascade, nestedTrans, nestedCascade, trans, isClickable, isPassThru), () =>
+			{
+				var bottom = new Button { Text = "Bottom Button" };
+				var top = new Button
+				{
+					InputTransparent = trans,
+					Text = "Click Me!"
+				};
+				var grid = new Grid
+				{
+					new Grid { bottom },
+					new Grid
+					{
+						InputTransparent = rootTrans,
+						CascadeInputTransparent = rootCascade,
+						Children =
+						{
+							new Grid
+							{
+								InputTransparent = nestedTrans,
+								CascadeInputTransparent = nestedCascade,
+								Children = { top }
+							}
+						},
+					}
+				};
+				return (grid, new { Bottom = bottom, Top = top });
+			})
+			.With(t =>
+			{
+				var v = t.ViewContainer.View;
+				var bottom = t.Additional.Bottom;
+				var top = Annotate(t.Additional.Top, v);
+				if (isClickable)
+				{
+					// if the button is clickable, then it should be clickable
+					bottom.Clicked += (s, e) => t.ViewContainer.ReportFailEvent();
+					top.Clicked += (s, e) => t.ViewContainer.ReportSuccessEvent();
+				}
+				else if (!isPassThru)
+				{
+					// if one of the parent layouts are NOT transparent, then
+					// the tap should NOT go through to the bottom button
+#if ANDROID
+					// TODO: Android is broken with everything passing through
+					// https://github.com/dotnet/maui/issues/10252
+					bottom.Clicked += (s, e) => t.ViewContainer.ReportSuccessEvent();
+					top.Clicked += (s, e) => t.ViewContainer.ReportFailEvent();
+#else
+					bottom.Clicked += (s, e) => t.ViewContainer.ReportFailEvent();
+					top.Clicked += (s, e) => t.ViewContainer.ReportFailEvent();
+#endif
+				}
+				else
+				{
+					// otherwise, the tap should go through
+					bottom.Clicked += (s, e) => t.ViewContainer.ReportSuccessEvent();
+					top.Clicked += (s, e) => t.ViewContainer.ReportFailEvent();
+				}
+			});
+
+		(ExpectedEventViewContainer<View> ViewContainer, T Additional) Add<T>(Test.InputTransparency test, Func<(View View, T Additional)> func) =>
+			Add(test.ToString(), func);
+
+		(ExpectedEventViewContainer<View> ViewContainer, T Additional) Add<T>(string test, Func<(View View, T Additional)> func)
+		{
+			var result = func();
+			var vc = new ExpectedEventViewContainer<View>(test, result.View);
+			Add(vc);
+			return (vc, result.Additional);
+		}
+
+		ExpectedEventViewContainer<Button> Add(Test.InputTransparency test, Button button) =>
+			Add(new ExpectedEventViewContainer<Button>(test, button));
+
+		static T Annotate<T>(T view, View desired)
+			where T : View
+		{
+#if WINDOWS
+			// Windows does not have layouts in the automation tree
+			// and some of the tests have the layout as the root
+			view.AutomationId = desired.AutomationId;
+#endif
+			return view;
+		}
+	}
+}

--- a/src/Controls/samples/Controls.Sample.UITests/CoreViews/CorePageView.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/CoreViews/CorePageView.cs
@@ -52,6 +52,7 @@ namespace Maui.Controls.Sample
 				new GalleryPageFactory(() => new LabelCoreGalleryPage(), "Label Gallery"),
 				new GalleryPageFactory(() => new GestureRecognizerGallery(), "Gesture Recognizer Gallery"),
 				new GalleryPageFactory(() => new ScrollViewCoreGalleryPage(), "ScrollView Gallery"),
+				new GalleryPageFactory(() => new InputTransparencyGalleryPage(), "Input Transparency Gallery"),
 		};
 
 		public CorePageView(Page rootPage)

--- a/src/Controls/samples/Controls.Sample.UITests/MauiProgram.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/MauiProgram.cs
@@ -61,8 +61,9 @@ namespace Maui.Controls.Sample
 			window.Width = desktopWindowWidth;
 			window.Height = desktopWindowHeight;
 
-			int screenWidth = (int)Microsoft.Maui.Devices.DeviceDisplay.MainDisplayInfo.Width;
-			int screenHeight = (int)Microsoft.Maui.Devices.DeviceDisplay.MainDisplayInfo.Height;
+			var info = Microsoft.Maui.Devices.DeviceDisplay.MainDisplayInfo;
+			int screenWidth = (int)(info.Width / info.Density);
+			int screenHeight = (int)(info.Height / info.Density);
 
 			// Center the window on the screen, to ensure no part of it goes off screen in CI
 			window.X = (screenWidth - desktopWindowWidth) / 2;

--- a/src/Controls/samples/Controls.Sample.UITests/Test.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/Test.cs
@@ -1,4 +1,6 @@
-﻿namespace Maui.Controls.Sample
+﻿using System.Collections.Generic;
+
+namespace Maui.Controls.Sample
 {
 	public static class Test
 	{
@@ -706,6 +708,63 @@
 			PeekAreaInsets,
 			Position,
 			IsBounceEnabled
+		}
+
+		public enum InputTransparency
+		{
+			Default,
+			IsFalse,
+			IsTrue,
+			TransLayoutOverlay,
+			TransLayoutOverlayWithButton,
+			CascadeTransLayoutOverlay,
+			CascadeTransLayoutOverlayWithButton,
+		}
+
+		public static class InputTransparencyMatrix
+		{
+			// this is both for color diff and cols
+			const bool truee = true;
+
+			public static readonly IReadOnlyDictionary<(bool RT, bool RC, bool NT, bool NC, bool T), (bool Clickable, bool PassThru)> States =
+				new Dictionary<(bool, bool, bool, bool, bool), (bool, bool)>
+				{
+					[(truee, truee, truee, truee, truee)] = (false, truee),
+					[(truee, truee, truee, truee, false)] = (false, truee),
+					[(truee, truee, truee, false, truee)] = (false, truee),
+					[(truee, truee, truee, false, false)] = (false, truee),
+					[(truee, truee, false, truee, truee)] = (false, truee),
+					[(truee, truee, false, truee, false)] = (false, truee),
+					[(truee, truee, false, false, truee)] = (false, truee),
+					[(truee, truee, false, false, false)] = (false, truee),
+					[(truee, false, truee, truee, truee)] = (false, truee),
+					[(truee, false, truee, truee, false)] = (false, truee),
+					[(truee, false, truee, false, truee)] = (false, truee),
+					[(truee, false, truee, false, false)] = (truee, false),
+					[(truee, false, false, truee, truee)] = (false, false),
+					[(truee, false, false, truee, false)] = (truee, false),
+					[(truee, false, false, false, truee)] = (false, false),
+					[(truee, false, false, false, false)] = (truee, false),
+					[(false, truee, truee, truee, truee)] = (false, false),
+					[(false, truee, truee, truee, false)] = (false, false),
+					[(false, truee, truee, false, truee)] = (false, false),
+					[(false, truee, truee, false, false)] = (truee, false),
+					[(false, truee, false, truee, truee)] = (false, false),
+					[(false, truee, false, truee, false)] = (truee, false),
+					[(false, truee, false, false, truee)] = (false, false),
+					[(false, truee, false, false, false)] = (truee, false),
+					[(false, false, truee, truee, truee)] = (false, false),
+					[(false, false, truee, truee, false)] = (false, false),
+					[(false, false, truee, false, truee)] = (false, false),
+					[(false, false, truee, false, false)] = (truee, false),
+					[(false, false, false, truee, truee)] = (false, false),
+					[(false, false, false, truee, false)] = (truee, false),
+					[(false, false, false, false, truee)] = (false, false),
+					[(false, false, false, false, false)] = (truee, false),
+				};
+
+			public static string GetKey(bool rootTrans, bool rootCascade, bool nestedTrans, bool nestedCascade, bool trans, bool isClickable, bool isPassThru) =>
+				$"Root{(rootTrans ? "Trans" : "")}{(rootCascade ? "Cascade" : "")}Nested{(nestedTrans ? "Trans" : "")}{(nestedCascade ? "Cascade" : "")}Control{(trans ? "Trans" : "")}Is{(isClickable ? "" : "Not")}ClickableIs{(isPassThru ? "" : "Not")}PassThru";
 		}
 	}
 }

--- a/src/Controls/samples/Controls.Sample/Converters/NegativeConverter.cs
+++ b/src/Controls/samples/Controls.Sample/Converters/NegativeConverter.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Globalization;
+using Microsoft.Maui.Controls;
+
+namespace Controls.Sample.Converters
+{
+	public class NegativeConverter : IValueConverter
+	{
+		public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+		{
+			if (value is bool v)
+				return !v;
+			else
+				return false;
+		}
+
+		public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+		{
+			if (value is bool v)
+				return !v;
+			else
+				return true;
+		}
+	}
+}

--- a/src/Controls/samples/Controls.Sample/Pages/Core/InputTransparentPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/InputTransparentPage.xaml
@@ -2,16 +2,12 @@
 <ContentPage 
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:local="clr-namespace:Controls.Sample.Converters"
     x:Class="Maui.Controls.Sample.Pages.InputTransparentPage">
 
     <ContentPage.Resources>
         <ResourceDictionary>
-            <Style TargetType="Label">
-            </Style>
-            <Style TargetType="Button">
-                <!-- <Setter Property="Padding" Value="14,10" /> -->
-                <!-- <Setter Property="WidthRequest" Value="200"/> -->
-            </Style>
+            <local:NegativeConverter x:Key="NegativeConverter" />
         </ResourceDictionary>
     </ContentPage.Resources>
 
@@ -65,11 +61,15 @@
 
                 <Grid Margin="10" HeightRequest="100" BackgroundColor="LightBlue">
 
+                    <Button Text="Bottom Button" IsVisible="{Binding InputTransparent, Source={Reference testButton}}" Clicked="ClickSuccess" HorizontalOptions="Center" VerticalOptions="Center" />
+                    <Button Text="Bottom Button" IsVisible="{Binding InputTransparent, Source={Reference testButton}, Converter={StaticResource NegativeConverter}}" Clicked="ClickFail" HorizontalOptions="Center" VerticalOptions="Center" />
+
                     <Grid x:Name="rootLayout">
                         <Grid x:Name="nestedLayout">
                             <Button x:Name="testButton" Text="Test Button" Clicked="ClickSuccess" HorizontalOptions="Center" VerticalOptions="Center" />
                         </Grid>
                     </Grid>
+
                 </Grid>
 
                 <Grid ColumnDefinitions="Auto,Auto,Auto,Auto,Auto,2" RowDefinitions="Auto,Auto,Auto" ColumnSpacing="12" RowSpacing="6" Margin="10,0,10,0">

--- a/src/Controls/tests/UITests/Tests/Concepts/InputTransparencyGalleryTests.cs
+++ b/src/Controls/tests/UITests/Tests/Concepts/InputTransparencyGalleryTests.cs
@@ -1,0 +1,73 @@
+﻿using Maui.Controls.Sample;
+using Microsoft.Maui.Appium;
+using NUnit.Framework;
+
+namespace Microsoft.Maui.AppiumTests
+{
+	public class InputTransparencyGalleryTests : CoreGalleryBasePageTest
+	{
+		const string ButtonGallery = "* marked:'Input Transparency Gallery'";
+
+		public InputTransparencyGalleryTests(TestDevice device)
+			: base(device)
+		{
+		}
+
+		protected override void NavigateToGallery()
+		{
+			App.NavigateToGallery(ButtonGallery);
+		}
+
+		[Test]
+		public void Simple([Values] Test.InputTransparency test) => RunTest(test.ToString());
+
+		[Test]
+		[Combinatorial]
+		public void Matrix([Values] bool rootTrans, [Values] bool rootCascade, [Values] bool nestedTrans, [Values] bool nestedCascade, [Values] bool trans)
+		{
+			var (clickable, passthru) = Test.InputTransparencyMatrix.States[(rootTrans, rootCascade, nestedTrans, nestedCascade, trans)];
+			var key = Test.InputTransparencyMatrix.GetKey(rootTrans, rootCascade, nestedTrans, nestedCascade, trans, clickable, passthru);
+
+			RunTest(key, clickable, passthru);
+		}
+
+		static void RunTest(string test, bool? clickable = null, bool? passthru = null)
+		{
+			var remote = new EventViewContainerRemote(UITestContext, test);
+			remote.GoTo(test.ToString());
+
+			var textBeforeClick = remote.GetEventLabel().Text;
+			Assert.AreEqual($"Event: {test} (none)", textBeforeClick);
+
+			remote.TapView();
+
+			var textAfterClick = remote.GetEventLabel().Text;
+
+			if (clickable is null || passthru is null)
+			{
+				// some tests are really basic so have no need for fancy checks
+				Assert.AreEqual($"Event: {test} (SUCCESS 1)", textAfterClick);
+			}
+			else if (clickable == true || passthru == true)
+			{
+				// if the button is clickable or taps pass through to the base button
+				Assert.AreEqual($"Event: {test} (SUCCESS 1)", textAfterClick);
+			}
+			else if (Device == TestDevice.Android)
+			{
+				// TODO: Android is broken with everything passing through so we just use that
+				// to test the bottom button was clickable
+				// https://github.com/dotnet/maui/issues/10252
+				Assert.AreEqual($"Event: {test} (SUCCESS 1)", textAfterClick);
+			}
+			else
+			{
+				// sometimes nothing can happen, so try test that
+				Task.Delay(500).Wait(); // just make sure that nothing happened
+
+				textAfterClick = remote.GetEventLabel().Text;
+				Assert.AreEqual($"Event: {test} (none)", textBeforeClick);
+			}
+		}
+	}
+}

--- a/src/Core/src/Handlers/Layout/LayoutHandler.Android.cs
+++ b/src/Core/src/Handlers/Layout/LayoutHandler.Android.cs
@@ -148,7 +148,12 @@ namespace Microsoft.Maui.Handlers
 			return -1;
 		}
 
-		static void MapInputTransparent(ILayoutHandler handler, ILayout layout)
+		public static partial void MapBackground(ILayoutHandler handler, ILayout layout)
+		{
+			handler.PlatformView?.UpdateBackground(layout);
+		}
+
+		public static partial void MapInputTransparent(ILayoutHandler handler, ILayout layout)
 		{
 			if (handler.PlatformView is LayoutViewGroup layoutViewGroup)
 			{

--- a/src/Core/src/Handlers/Layout/LayoutHandler.Standard.cs
+++ b/src/Core/src/Handlers/Layout/LayoutHandler.Standard.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Maui.Handlers
 		public void Update(int index, IView view) => throw new NotImplementedException();
 		public void UpdateZIndex(IView view) => throw new NotImplementedException();
 
+		public static partial void MapBackground(ILayoutHandler handler, ILayout layout) => throw new NotImplementedException();
+
 		protected override object CreatePlatformView() => throw new NotImplementedException();
 	}
 }

--- a/src/Core/src/Handlers/Layout/LayoutHandler.Tizen.cs
+++ b/src/Core/src/Handlers/Layout/LayoutHandler.Tizen.cs
@@ -176,6 +176,12 @@ namespace Microsoft.Maui.Handlers
 			}
 		}
 
+		public static partial void MapBackground(ILayoutHandler handler, ILayout layout)
+		{
+			handler.UpdateValue(nameof(handler.ContainerView));
+			handler.ToPlatform()?.UpdateBackground(layout);
+		}
+
 		protected override void Dispose(bool disposing)
 		{
 			if (disposing)

--- a/src/Core/src/Handlers/Layout/LayoutHandler.Windows.cs
+++ b/src/Core/src/Handlers/Layout/LayoutHandler.Windows.cs
@@ -123,12 +123,14 @@ namespace Microsoft.Maui.Handlers
 			}
 		}
 
-		static void MapInputTransparent(ILayoutHandler handler, ILayout layout)
+		public static partial void MapBackground(ILayoutHandler handler, ILayout layout)
 		{
-			if (handler.PlatformView is LayoutPanel layoutPanel && layout != null)
-			{
-				layoutPanel.UpdatePlatformViewBackground(layout);
-			}
+			handler.PlatformView?.UpdatePlatformViewBackground(layout);
+		}
+
+		public static partial void MapInputTransparent(ILayoutHandler handler, ILayout layout)
+		{
+			handler.PlatformView?.UpdatePlatformViewBackground(layout);
 		}
 	}
 }

--- a/src/Core/src/Handlers/Layout/LayoutHandler.cs
+++ b/src/Core/src/Handlers/Layout/LayoutHandler.cs
@@ -13,6 +13,10 @@ using PlatformView = System.Object;
 
 namespace Microsoft.Maui.Handlers
 {
+	/// <summary>
+	/// Represents the view handler for the abstract <see cref="ILayout"/> view and its platform-specific implementation.
+	/// </summary>
+	/// <seealso href="https://learn.microsoft.com/dotnet/maui/user-interface/handlers/">Conceptual documentation on handlers</seealso>
 	public partial class LayoutHandler : ILayoutHandler
 	{
 		public static IPropertyMapper<ILayout, ILayoutHandler> Mapper = new PropertyMapper<ILayout, ILayoutHandler>(ViewMapper)
@@ -48,15 +52,27 @@ namespace Microsoft.Maui.Handlers
 
 		PlatformView ILayoutHandler.PlatformView => PlatformView;
 
-		public static void MapBackground(ILayoutHandler handler, ILayout layout)
-		{
-#if TIZEN
-			handler.UpdateValue(nameof(handler.ContainerView));
-			handler.ToPlatform()?.UpdateBackground(layout);
-#endif
-			((PlatformView?)handler.PlatformView)?.UpdateBackground(layout);
-		}
+		/// <summary>
+		/// Maps the abstract <see cref="IView.Background"/> property to the platform-specific implementations.
+		/// </summary>
+		/// <param name="handler">The associated handler.</param>
+		/// <param name="layout">The associated <see cref="ILayout"/> instance.</param>
+		public static partial void MapBackground(ILayoutHandler handler, ILayout layout);
 
+#if ANDROID || WINDOWS
+		/// <summary>
+		/// Maps the abstract <see cref="IView.InputTransparent"/> property to the platform-specific implementations.
+		/// </summary>
+		/// <param name="handler">The associated handler.</param>
+		/// <param name="layout">The associated <see cref="ILayout"/> instance.</param>
+		public static partial void MapInputTransparent(ILayoutHandler handler, ILayout layout);
+#endif
+
+		/// <summary>
+		/// Maps the abstract <see cref="ILayout.ClipsToBounds"/> property to the platform-specific implementations.
+		/// </summary>
+		/// <param name="handler">The associated handler.</param>
+		/// <param name="layout">The associated <see cref="ILayout"/> instance.</param>
 		public static void MapClipsToBounds(ILayoutHandler handler, ILayout layout)
 		{
 			((PlatformView?)handler.PlatformView)?.UpdateClipsToBounds(layout);

--- a/src/Core/src/Handlers/Layout/LayoutHandler.iOS.cs
+++ b/src/Core/src/Handlers/Layout/LayoutHandler.iOS.cs
@@ -139,5 +139,10 @@ namespace Microsoft.Maui.Handlers
 				PlatformView.InsertSubview(nativeChildView, targetIndex);
 			}
 		}
+
+		public static partial void MapBackground(ILayoutHandler handler, ILayout layout)
+		{
+			handler.PlatformView?.UpdateBackground(layout);
+		}
 	}
 }

--- a/src/Core/src/Handlers/View/ViewHandler.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.cs
@@ -321,6 +321,14 @@ namespace Microsoft.Maui.Handlers
 			if (handler.ContainerView is WrapperView wrapper)
 				wrapper.InputTransparent = view.InputTransparent;
 #else
+
+#if IOS || MACCATALYST
+			// Containers on iOS/Mac Catalyst may be hit testable, so we need to
+			// propagate the the view's values to its container view.
+			if (handler.ContainerView is WrapperView wrapper)
+				wrapper.UpdateInputTransparent(handler, view);
+#endif
+
 			((PlatformView?)handler.PlatformView)?.UpdateInputTransparent(handler, view);
 #endif
 		}

--- a/src/Core/src/Platform/Windows/ViewExtensions.cs
+++ b/src/Core/src/Platform/Windows/ViewExtensions.cs
@@ -261,10 +261,12 @@ namespace Microsoft.Maui.Platform
 			ToolTipService.SetToolTip(platformView, tooltip?.Content);
 		}
 
+		/// <summary>
+		/// Background and InputTransparent for Windows layouts are heavily intertwined, so setting one
+		/// usually requires setting the other at the same time.
+		/// </summary>
 		internal static void UpdatePlatformViewBackground(this LayoutPanel layoutPanel, ILayout layout)
 		{
-			// Background and InputTransparent for Windows layouts are heavily intertwined, so setting one
-			// usuall requires setting the other at the same time
 			layoutPanel.UpdateInputTransparent(layout.InputTransparent, layout?.Background?.ToPlatform());
 		}
 

--- a/src/Core/src/Platform/iOS/LayoutView.cs
+++ b/src/Core/src/Platform/iOS/LayoutView.cs
@@ -25,11 +25,30 @@ namespace Microsoft.Maui.Platform
 		{
 			var result = base.HitTest(point, uievent);
 
+			if (result is null)
+				return null!;
+
 			if (!_userInteractionEnabled && this.Equals(result))
 			{
 				// If user interaction is disabled (IOW, if the corresponding Layout is InputTransparent),
 				// then we exclude the LayoutView itself from hit testing. But it's children are valid
 				// hit testing targets.
+
+				return null!;
+			}
+
+			if (!result.UserInteractionEnabled)
+			{
+				// If the child also has user interaction disabled (IOW the child is InputTransparent),
+				// then we also want to exclude it from the hit testing.
+
+				return null!;
+			}
+
+			if (result is LayoutView layoutView && !layoutView.UserInteractionEnabledOverride)
+			{
+				// If the child is a layout then we need to check the UserInteractionEnabledOverride
+				// since layouts always have user interaction enabled.
 
 				return null!;
 			}

--- a/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -89,6 +89,7 @@ static Microsoft.Maui.GridLength.operator ==(Microsoft.Maui.GridLength left, Mic
 static Microsoft.Maui.Handlers.EditorHandler.MapIsSpellCheckEnabled(Microsoft.Maui.Handlers.IEditorHandler! handler, Microsoft.Maui.IEditor! editor) -> void
 static Microsoft.Maui.Handlers.EntryHandler.MapIsSpellCheckEnabled(Microsoft.Maui.Handlers.IEntryHandler! handler, Microsoft.Maui.IEntry! entry) -> void
 static Microsoft.Maui.Handlers.ImageButtonHandler.MapBackground(Microsoft.Maui.Handlers.IImageButtonHandler! handler, Microsoft.Maui.IImageButton! imageButton) -> void
+static Microsoft.Maui.Handlers.LayoutHandler.MapInputTransparent(Microsoft.Maui.ILayoutHandler! handler, Microsoft.Maui.ILayout! layout) -> void
 static Microsoft.Maui.Handlers.SearchBarHandler.MapFocus(Microsoft.Maui.Handlers.ISearchBarHandler! handler, Microsoft.Maui.ISearchBar! searchBar, object? args) -> void
 static Microsoft.Maui.Handlers.SearchBarHandler.MapIsSpellCheckEnabled(Microsoft.Maui.Handlers.ISearchBarHandler! handler, Microsoft.Maui.ISearchBar! searchBar) -> void
 static Microsoft.Maui.Handlers.StepperHandler.MapIsEnabled(Microsoft.Maui.Handlers.IStepperHandler! handler, Microsoft.Maui.IStepper! stepper) -> void

--- a/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -62,6 +62,7 @@ static Microsoft.Maui.GridLength.operator !=(Microsoft.Maui.GridLength left, Mic
 static Microsoft.Maui.GridLength.operator ==(Microsoft.Maui.GridLength left, Microsoft.Maui.GridLength right) -> bool
 static Microsoft.Maui.Handlers.EditorHandler.MapIsSpellCheckEnabled(Microsoft.Maui.Handlers.IEditorHandler! handler, Microsoft.Maui.IEditor! editor) -> void
 static Microsoft.Maui.Handlers.EntryHandler.MapIsSpellCheckEnabled(Microsoft.Maui.Handlers.IEntryHandler! handler, Microsoft.Maui.IEntry! entry) -> void
+static Microsoft.Maui.Handlers.LayoutHandler.MapInputTransparent(Microsoft.Maui.ILayoutHandler! handler, Microsoft.Maui.ILayout! layout) -> void
 static Microsoft.Maui.Handlers.SearchBarHandler.MapIsSpellCheckEnabled(Microsoft.Maui.Handlers.ISearchBarHandler! handler, Microsoft.Maui.ISearchBar! searchBar) -> void
 static Microsoft.Maui.Handlers.SwipeItemMenuItemHandler.MapSourceAsync(Microsoft.Maui.Handlers.ISwipeItemMenuItemHandler! handler, Microsoft.Maui.ISwipeItemMenuItem! image) -> System.Threading.Tasks.Task!
 static Microsoft.Maui.Hosting.MauiHandlersCollectionExtensions.AddHandler<TType>(this Microsoft.Maui.Hosting.IMauiHandlersCollection! handlersCollection, System.Func<System.IServiceProvider!, Microsoft.Maui.IElementHandler!>! handlerImplementationFactory) -> Microsoft.Maui.Hosting.IMauiHandlersCollection!


### PR DESCRIPTION
### Description of Change

This PR is just adding a bunch of input transparency tests so we can be suer all the combinations are working - without the need for manual tests.

This should have been part of #14846, but we did not have any UI tests at the time. This finally makes the world of InputTransparent and CascadeInputTransparent complete.

There was also a bug in the way some input transparent controls did not allow taps to pass through because the container was not transparent. And, the layout always blocked taps - even when the controls were transparent - because it was not first checking if the controls inside should block.