### PR TITLE
Fixes BindableLayout BindingContext inheritance

### DIFF
--- a/src/Controls/tests/Core.UnitTests/BindableLayoutTests.cs
+++ b/src/Controls/tests/Core.UnitTests/BindableLayoutTests.cs
@@ -388,6 +388,71 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.Equal(itemTemplateSelector, BindableLayout.GetItemTemplateSelector(layout));
 			Assert.Equal(itemTemplateSelector, layout.GetValue(BindableLayout.ItemTemplateSelectorProperty));
 		}
+		
+		[Fact]
+		public async Task ItemViewBindingContextIsSetToNullOnClear()
+		{
+			var list = new ObservableCollection<string> { "Foo" };
+
+			var layout = new StackLayout { IsPlatformEnabled = true };
+			BindableLayout.SetItemTemplate(layout, new DataTemplate(() => new Label()));
+			BindableLayout.SetItemsSource(layout, list);
+
+			// Verify that the item view is bound to collection item
+			var itemView = layout.Children.FirstOrDefault() as Label;
+			Assert.NotNull(itemView);
+			Assert.Equal(list[0], itemView.BindingContext);
+
+			// Clear collection by setting it to null
+			BindableLayout.SetItemsSource(layout, null);
+
+			// Verify item view binding context is null
+			Assert.Null(itemView.BindingContext);
+		}
+		
+		[Fact]
+		public async Task ItemViewBindingContextIsSetToNullOnRemove()
+		{
+			var list = new ObservableCollection<string> { "Foo" };
+
+			var layout = new StackLayout { IsPlatformEnabled = true };
+			BindableLayout.SetItemTemplate(layout, new DataTemplate(() => new Label()));
+			BindableLayout.SetItemsSource(layout, list);
+
+			// Verify that the item view is bound to collection item
+			var itemView = layout.Children.FirstOrDefault() as Label;
+			Assert.NotNull(itemView);
+			Assert.Equal(list[0], itemView.BindingContext);
+
+			// Remove the item
+			list.RemoveAt(0);
+
+			// Verify item view binding context is null
+			Assert.Null(itemView.BindingContext);
+		}
+		
+		[Fact]
+		public async Task EmptyViewTemplateContentInheritsLayoutBindingContext()
+		{
+			var list = new ObservableCollection<string>();
+
+			var bindingContext = "Foo";
+
+			var layout = new StackLayout { IsPlatformEnabled = true, BindingContext = bindingContext };
+			BindableLayout.SetEmptyViewTemplate(layout, new DataTemplate(() => new Label()));
+			BindableLayout.SetItemsSource(layout, list);
+
+			// Verify that the empty view is bound to layout's binding context
+			var emptyView = layout.Children.FirstOrDefault() as Label;
+			Assert.NotNull(emptyView);
+			Assert.Equal(bindingContext, emptyView.BindingContext);
+
+			// Change binding context on layout
+			layout.BindingContext = bindingContext = "Bar";
+
+			// Verify empty view inherited the binding context
+			Assert.Equal(bindingContext, emptyView.BindingContext);
+		}
 
 		[Fact]
 		public async Task DoesNotLeak()


### PR DESCRIPTION
### Description of Change

Usually the `BindingContext` is automatically inherited via `Element.SetParent` using `SetChildInheritedBindingContext`.
When an element is removed from a `Layout`, the `Element.SetParent` takes care of clearing `BindingContext` automatically.

```cs
		void SetParent(Element value) {
			// ..
			object context = value?.BindingContext;
			if (value != null)
			{
				value.SetChildInheritedBindingContext(this, context);
			}
			else
			{
				SetInheritedBindingContext(this, null);
			}
```

We can see that setting the `BindingContext` to `null` is an explicit behavior when the parent (`value`) is set to `null` (a.k.a. child removed).

`BindableLayout` sets the `BindingContext` manually on each created child, so it is its responsibility to clear the `BindingContext` once the item is removed.

Not clearing the `BindingContext` might cause unwanted side-effects and leaks if the child view attached to some of its events (i.e. `PropertyChanged`).

```cs
// inside child view class
private MyViewModel _current;
protected override void OnBindingContextChanged() {
    if (_current != null) { 
        // I see no other way to unsubscribe to that event
        // Even if the event is backed by a WeakEventManager there's a risk
        // that an event is invoke before GC finishes cleaning up resources
        _current.MyEvent -= MyHandler;
        _current = null;
    }


    if (BindingContext != null) {
        // Subscribing to an event is totally legit here
        _current = BindingContext;
        _current.MyEvent += MyHandler;
    }
}
```

On top of that, the view created by `EmptyViewTemplate` should not have the `BindingContext` set manually, because it matches the parent one: we should rely on the automatic inheritance.

### Issues Fixed

Issue #10904 does not represent a leak itself, but in a more complex scenario where a child attaches to some events on the `BindingContext` it would create issues.
Issue #19142