### PR TITLE
[build] Don't use internal feeds on main

### DIFF
--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -59,10 +59,10 @@ variables:
   value: false
 - group: Xamarin-Secrets
 # Variable groups required for private builds
-- ${{ if or(eq(variables['System.TeamProject'], 'DevDiv'), eq(variables['Build.DefinitionName'], 'dotnet-maui')) }}:
-  - name: PrivateBuild
-    value: true
-  # For eng/common/SetupNugetSources.ps1
-  - group: DotNetBuilds storage account read tokens
-  - group: AzureDevOps-Artifact-Feeds-Pats
+# - ${{ if or(eq(variables['System.TeamProject'], 'DevDiv'), eq(variables['Build.DefinitionName'], 'dotnet-maui')) }}:
+#   - name: PrivateBuild
+#     value: true
+#   # For eng/common/SetupNugetSources.ps1
+#   - group: DotNetBuilds storage account read tokens
+#   - group: AzureDevOps-Artifact-Feeds-Pats
 


### PR DESCRIPTION
### Description of Change

We use stable feeds on main not internal.

When this reaches a release branch and we want to switch to internal we just uncomment these lines 