### PR TITLE
[build] Remove LangVersion

### DIFF
--- a/src/Core/tests/Benchmarks/Core.Benchmarks.csproj
+++ b/src/Core/tests/Benchmarks/Core.Benchmarks.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>$(_MauiDotNetTfm)</TargetFramework>
-    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Graphics/samples/GraphicsTester.Android/GraphicsTester.Android.csproj
+++ b/src/Graphics/samples/GraphicsTester.Android/GraphicsTester.Android.csproj
@@ -5,7 +5,6 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>GraphicsTester.Android</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
-    <LangVersion>10.0</LangVersion>
     <SupportedOSPlatformVersion>23.0</SupportedOSPlatformVersion>
     <ApplicationId>com.microsoft.maui.graphicstester</ApplicationId>
     <ApplicationVersion>1</ApplicationVersion>

--- a/src/Graphics/samples/GraphicsTester.Mac/GraphicsTester.Mac.csproj
+++ b/src/Graphics/samples/GraphicsTester.Mac/GraphicsTester.Mac.csproj
@@ -5,7 +5,6 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>GraphicsTester.Mac</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
-    <LangVersion>10.0</LangVersion>
     <SupportedOSPlatformVersion>10.14</SupportedOSPlatformVersion>
     <IsPackable>false</IsPackable>
     <EnableCodeSigning>false</EnableCodeSigning>

--- a/src/Graphics/samples/GraphicsTester.MacCatalyst/GraphicsTester.MacCatalyst.csproj
+++ b/src/Graphics/samples/GraphicsTester.MacCatalyst/GraphicsTester.MacCatalyst.csproj
@@ -5,7 +5,6 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>GraphicsTester.MacCatalyst</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
-    <LangVersion>10.0</LangVersion>
     <SupportedOSPlatformVersion>14.2</SupportedOSPlatformVersion>
     <IsPackable>false</IsPackable>
     <!-- Disable multi-RID builds to workaround a parallel build issue -->

--- a/src/Graphics/samples/GraphicsTester.Skia.Mac/GraphicsTester.Skia.Mac.csproj
+++ b/src/Graphics/samples/GraphicsTester.Skia.Mac/GraphicsTester.Skia.Mac.csproj
@@ -4,7 +4,6 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>$(_MauiDotNetTfm)-macos</TargetFramework>
     <RootNamespace>GraphicsTester.Skia.Mac</RootNamespace>
-    <LangVersion>10.0</LangVersion>
     <SupportedOSPlatformVersion>10.14</SupportedOSPlatformVersion>
     <EnableCodeSigning>false</EnableCodeSigning>
     <UseSGen>false</UseSGen>

--- a/src/Graphics/samples/GraphicsTester.iOS/GraphicsTester.iOS.csproj
+++ b/src/Graphics/samples/GraphicsTester.iOS/GraphicsTester.iOS.csproj
@@ -5,7 +5,6 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>GraphicsTester.iOS</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
-    <LangVersion>10.0</LangVersion>
     <SupportedOSPlatformVersion>14.2</SupportedOSPlatformVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Graphics/tests/Graphics.Benchmarks/Graphics.Benchmarks.csproj
+++ b/src/Graphics/tests/Graphics.Benchmarks/Graphics.Benchmarks.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>$(_MauiDotNetTfm)</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Description of Change

Remove LangVersion from some projects and use the global setting on Directory.build.props.
Fixes iOS rc2 