### PR TITLE
Copy Windows MauiAssets to the publish folder for Unpackaged

### DIFF
--- a/src/SingleProject/Resizetizer/src/nuget/buildTransitive/Microsoft.Maui.Resizetizer.After.targets
+++ b/src/SingleProject/Resizetizer/src/nuget/buildTransitive/Microsoft.Maui.Resizetizer.After.targets
@@ -346,28 +346,32 @@
 
     <Target Name="ProcessMauiAssets"
         Condition="'$(EnableMauiAssetProcessing)' == 'true'">
-        <PropertyGroup Condition="'$(_ResizetizerIsWindowsAppSdk)' == 'True'">
-            <_MauiAssetItemMetadata>TargetPath</_MauiAssetItemMetadata>
-        </PropertyGroup>
-        <ItemGroup Condition="'$(_ResizetizerIsWindowsAppSdk)' == 'True'">
-            <!-- Windows does not recognize %(LogicalName), so we must copy it to %(Link) -->
-            <MauiAsset Update="@(MauiAsset)" Link="%(MauiAsset.LogicalName)" Condition="'%(MauiAsset.Link)' == '' And '%(MauiAsset.LogicalName)' != ''" />
+        <ItemGroup>
+            <!--
+                The GetMauiAssetPath task uses the Link metadata or the ItemSpec, so make
+                sure all LogicalName items also have a Link value for this task.
+            -->
+            <_MauiAssetWithLinkMetadata Include="@(MauiAsset)" Link="%(MauiAsset.LogicalName)" Condition="'%(MauiAsset.Link)' == '' And '%(MauiAsset.LogicalName)' != ''" />
+            <_MauiAssetWithLinkMetadata Include="@(MauiAsset)" Condition="'%(MauiAsset.Link)' != '' Or '%(MauiAsset.LogicalName)' == ''" />
         </ItemGroup>
-        <PropertyGroup Condition="'$(_ResizetizerIsTizenApp)' == 'True'">
-            <_MauiAssetItemMetadata>TizenTpkFileName</_MauiAssetItemMetadata>
-        </PropertyGroup>
-      <ItemGroup Condition="'$(_ResizetizerIsTizenApp)' == 'True'">
-        <MauiAsset Update="@(MauiAsset)" Link="%(MauiAsset.LogicalName)" Condition="'%(MauiAsset.Link)' == '' And '%(MauiAsset.LogicalName)' != ''" />
-      </ItemGroup>
         <GetMauiAssetPath
             ProjectDirectory="$(MSBuildProjectDirectory)"
-            ItemMetadata="$(_MauiAssetItemMetadata)"
-            Input="@(MauiAsset)">
-            <Output ItemName="AndroidAsset"          TaskParameter="Output" Condition="'$(_ResizetizerIsAndroidApp)' == 'True'" />
-            <Output ItemName="Content"               TaskParameter="Output" Condition="'$(_ResizetizerIsiOSApp)' == 'True'" />
-            <Output ItemName="ContentWithTargetPath" TaskParameter="Output" Condition="'$(_ResizetizerIsWindowsAppSdk)' == 'True'" />
-            <Output ItemName="TizenResource" TaskParameter="Output" Condition="'$(_ResizetizerIsTizenApp)' == 'True'" />
+            ItemMetadata="MauiAssetTargetPath"
+            Input="@(_MauiAssetWithLinkMetadata)">
+            <Output ItemName="_MauiAssetItemWithMetadata" TaskParameter="Output" />
         </GetMauiAssetPath>
+        <ItemGroup Condition="'$(_ResizetizerIsAndroidApp)' == 'True'">
+            <AndroidAsset Include="@(_MauiAssetItemWithMetadata)" Link="%(MauiAssetTargetPath)" />
+        </ItemGroup>
+        <ItemGroup Condition="'$(_ResizetizerIsiOSApp)' == 'True'">
+            <Content Include="@(_MauiAssetItemWithMetadata)" Link="%(MauiAssetTargetPath)" />
+        </ItemGroup>
+        <ItemGroup Condition="'$(_ResizetizerIsWindowsAppSdk)' == 'True'">
+            <ContentWithTargetPath Include="@(_MauiAssetItemWithMetadata)" TargetPath="%(MauiAssetTargetPath)" CopyToPublishDirectory="PreserveNewest" />
+        </ItemGroup>
+        <ItemGroup Condition="'$(_ResizetizerIsTizenApp)' == 'True'">
+            <TizenResource Include="@(_MauiAssetItemWithMetadata)" TizenTpkFileName="%(MauiAssetTargetPath)" />
+        </ItemGroup>
     </Target>
 
     <Target Name="ProcessMauiSplashScreens"

--- a/src/SingleProject/Resizetizer/src/nuget/buildTransitive/Microsoft.Maui.Resizetizer.After.targets
+++ b/src/SingleProject/Resizetizer/src/nuget/buildTransitive/Microsoft.Maui.Resizetizer.After.targets
@@ -354,23 +354,31 @@
             <_MauiAssetWithLinkMetadata Include="@(MauiAsset)" Link="%(MauiAsset.LogicalName)" Condition="'%(MauiAsset.Link)' == '' And '%(MauiAsset.LogicalName)' != ''" />
             <_MauiAssetWithLinkMetadata Include="@(MauiAsset)" Condition="'%(MauiAsset.Link)' != '' Or '%(MauiAsset.LogicalName)' == ''" />
         </ItemGroup>
+        <!-- pick the destination property to assign the final path -->
+        <PropertyGroup>
+            <_MauiAssetItemMetadata Condition="'$(_ResizetizerIsAndroidApp)' == 'True'">Link</_MauiAssetItemMetadata>
+            <_MauiAssetItemMetadata Condition="'$(_ResizetizerIsiOSApp)' == 'True'">Link</_MauiAssetItemMetadata>
+            <_MauiAssetItemMetadata Condition="'$(_ResizetizerIsWindowsAppSdk)' == 'True'">TargetPath</_MauiAssetItemMetadata>
+            <_MauiAssetItemMetadata Condition="'$(_ResizetizerIsTizenApp)' == 'True'">TizenTpkFileName</_MauiAssetItemMetadata>
+        </PropertyGroup>
         <GetMauiAssetPath
             ProjectDirectory="$(MSBuildProjectDirectory)"
-            ItemMetadata="MauiAssetTargetPath"
+            ItemMetadata="$(_MauiAssetItemMetadata)"
             Input="@(_MauiAssetWithLinkMetadata)">
             <Output ItemName="_MauiAssetItemWithMetadata" TaskParameter="Output" />
         </GetMauiAssetPath>
+        <!-- add the processed assets to the correct itme groups and add any additional properties -->
         <ItemGroup Condition="'$(_ResizetizerIsAndroidApp)' == 'True'">
-            <AndroidAsset Include="@(_MauiAssetItemWithMetadata)" Link="%(MauiAssetTargetPath)" />
+            <AndroidAsset Include="@(_MauiAssetItemWithMetadata)" />
         </ItemGroup>
         <ItemGroup Condition="'$(_ResizetizerIsiOSApp)' == 'True'">
-            <Content Include="@(_MauiAssetItemWithMetadata)" Link="%(MauiAssetTargetPath)" />
+            <Content Include="@(_MauiAssetItemWithMetadata)" />
         </ItemGroup>
         <ItemGroup Condition="'$(_ResizetizerIsWindowsAppSdk)' == 'True'">
-            <ContentWithTargetPath Include="@(_MauiAssetItemWithMetadata)" TargetPath="%(MauiAssetTargetPath)" CopyToPublishDirectory="PreserveNewest" />
+            <ContentWithTargetPath Include="@(_MauiAssetItemWithMetadata)" CopyToPublishDirectory="PreserveNewest" />
         </ItemGroup>
         <ItemGroup Condition="'$(_ResizetizerIsTizenApp)' == 'True'">
-            <TizenResource Include="@(_MauiAssetItemWithMetadata)" TizenTpkFileName="%(MauiAssetTargetPath)" />
+            <TizenResource Include="@(_MauiAssetItemWithMetadata)" />
         </ItemGroup>
     </Target>
 

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/TemplateTests.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/TemplateTests.cs
@@ -96,6 +96,7 @@ namespace Microsoft.Maui.IntegrationTests
 			AssetExists("appiconLogo.scale-100.png");
 			AssetExists("OpenSans-Regular.ttf");
 			AssetExists("splashSplashScreen.scale-100.png");
+			AssetExists("AboutAssets.txt");
 
 			void AssetExists(string filename)
 			{


### PR DESCRIPTION
### Description of Change

I noticed that when publishing unpackaged apps, the content was not copied to the publish folder.

We fixed the resources (images, icons, and fonts) in  https://github.com/dotnet/maui/pull/17238, but missed the maui asset assets. This PR fixes that so all resources and assets are copied.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #17260 

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
