### PR TITLE
Added integration test for maui blazor maccatalyst codesign verification.

### DIFF
--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Apple/Codesign.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Apple/Codesign.cs
@@ -1,0 +1,33 @@
+﻿using System.Diagnostics;
+
+namespace Microsoft.Maui.IntegrationTests.Apple
+{
+	public static class Codesign
+	{
+		public static List<string> SearchForExpectedEntitlements(
+			string entitlementsPath,
+			string appLocation,
+			List<string> expectedEntitlements)
+		{
+			List<string> foundEntitlements = new();
+			string procOutput = ToolRunner.Run(new ProcessStartInfo()
+			{
+				FileName = "/usr/bin/codesign",
+				Arguments = $"-d --entitlements {entitlementsPath} --xml {appLocation}"
+			}, out int errorCode);
+
+			Assert.AreEqual(errorCode, 0, procOutput);
+			Assert.IsTrue(File.Exists(entitlementsPath));
+
+			string fileContent = File.ReadAllText(entitlementsPath);
+			foreach (string entitlement in expectedEntitlements)
+			{
+				if (fileContent.Contains(entitlement, StringComparison.OrdinalIgnoreCase))
+					foundEntitlements.Add(entitlement);
+			}
+
+			return foundEntitlements;
+		}
+	}
+}
+

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/TemplateTests.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/TemplateTests.cs
@@ -188,6 +188,9 @@ namespace Microsoft.Maui.IntegrationTests
 		[TestCase("maui-blazor", "Release", DotNetCurrent)]
 		public void CheckEntitlementsForMauiBlazorOnMacCatalyst(string id, string config, string framework)
 		{
+			if(TestEnvironment.IsWindows)
+				Assert.Ignore("Running MacCatalyst templates is only supported on Mac.");
+
 			string projectDir = TestDirectory;
 			string projectFile = Path.Combine(projectDir, $"{Path.GetFileName(projectDir)}.csproj");
 			// Note: Debug app is stored in the maccatalyst-x64 folder, while the Release is in parent directory

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/TemplateTests.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/TemplateTests.cs
@@ -1,4 +1,4 @@
-using System.Diagnostics;
+using Microsoft.Maui.IntegrationTests.Apple;
 
 namespace Microsoft.Maui.IntegrationTests
 {
@@ -182,28 +182,6 @@ namespace Microsoft.Maui.IntegrationTests
 				$"Project {Path.GetFileName(projectFile)} failed to build. Check test output/attachments for errors.");
 		}
 
-		List<string> SearchForExpectedEntitlements(string entitlementsPath, string appLocation, List<string> expectedEntitlements)
-		{
-			List<string> foundEntitlements = new();
-			string procOutput = ToolRunner.Run(new ProcessStartInfo()
-			{
-				FileName = "/usr/bin/codesign",
-				Arguments = $"-d --entitlements {entitlementsPath} --xml {appLocation}"
-			}, out int errorCode);
-
-			Assert.AreEqual(errorCode, 0, procOutput);
-			Assert.IsTrue(File.Exists(entitlementsPath));
-
-			string fileContent = File.ReadAllText(entitlementsPath);
-			foreach (string entitlement in expectedEntitlements)
-			{
-				if (fileContent.Contains(entitlement, StringComparison.OrdinalIgnoreCase))
-					foundEntitlements.Add(entitlement);
-			}
-
-			return foundEntitlements;
-		}
-
 		[Test]
 		[TestCase("maui-blazor", "Debug", "net8.0")]
 		[TestCase("maui-blazor", "Release", "net8.0")]
@@ -229,7 +207,7 @@ namespace Microsoft.Maui.IntegrationTests
 			List<string> expectedEntitlements = config == "Release" ?
 				new() { "com.apple.security.app-sandbox", "com.apple.security.network.client" } :
 				new() { "com.apple.security.get-task-allow" };
-			List<string> foundEntitlements = SearchForExpectedEntitlements(entitlementsPath, appLocation, expectedEntitlements);
+			List<string> foundEntitlements = Codesign.SearchForExpectedEntitlements(entitlementsPath, appLocation, expectedEntitlements);
 
 			CollectionAssert.AreEqual(expectedEntitlements, foundEntitlements, "Entitlements missing from executable.");
 		}

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/TemplateTests.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/TemplateTests.cs
@@ -184,8 +184,8 @@ namespace Microsoft.Maui.IntegrationTests
 		}
 
 		[Test]
-		[TestCase("maui-blazor", "Debug", "net8.0")]
-		[TestCase("maui-blazor", "Release", "net8.0")]
+		[TestCase("maui-blazor", "Debug", DotNetCurrent)]
+		[TestCase("maui-blazor", "Release", DotNetCurrent)]
 		public void CheckEntitlementsForMauiBlazorOnMacCatalyst(string id, string config, string framework)
 		{
 			string projectDir = TestDirectory;


### PR DESCRIPTION
### Description of Change
We needed an integration test to ensure that compiled Maui Blazor MacCatalyst apps have the correct entitlements set based on their configuration.
