### PR TITLE
[ci] Add MSI transport nugets to sign verify

### DIFF
--- a/eng/pipelines/common/sign.yml
+++ b/eng/pipelines/common/sign.yml
@@ -37,5 +37,6 @@ stages:
               TargetFolders: |
                 $(Build.ArtifactStagingDirectory)\bin\manifests
                 $(Build.ArtifactStagingDirectory)\bin\manifests-multitarget
+                $(Build.ArtifactStagingDirectory)\bin\msi-nupkgs
               ExcludeSNVerify: true
               ApprovalListPathForCerts: $(Build.ArtifactStagingDirectory)\sign-verify\SignVerifyIgnore.txt


### PR DESCRIPTION
The `msi-nupkgs` output directory contains the NUPKG files used for MSI
based CLI .NET workload installs.  While we are already verifying the
signing of the MSI files included in these nugets, we should also run
sign verification against this output folder.