### PR TITLE
Revert changes to setting context and add tests

### DIFF
--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issue16787.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issue16787.cs
@@ -1,0 +1,48 @@
+﻿using Microsoft.Maui.Controls;
+
+namespace Maui.Controls.Sample.Issues
+{
+	[Issue(IssueTracker.Github, 16787, "CollectionView runtime binding errors when loading the ItemSource asynchronously", PlatformAffected.UWP)]
+	public class Issue16787 : TestContentPage
+	{
+		protected override void OnBindingContextChanged()
+		{
+			base.OnBindingContextChanged();
+		}
+		protected override void Init()
+		{
+			var cv = new CollectionView();
+			cv.BindingContextChanged += Cv_BindingContextChanged;
+			this.BindingContext = this;
+			cv.ItemTemplate = new DataTemplate(() =>
+			{
+				int bindingContextChanges = 0;
+				var label = new Label();
+				label.BindingContextChanged += (_, _) =>
+				{
+					bindingContextChanges++;
+					label.Text = bindingContextChanges.ToString();
+				};
+				label.AutomationId = "LabelBindingCount";
+				return label;
+			});
+
+			cv.ItemsSource = new[] { "random" };
+
+
+			var layout = new VerticalStackLayout()
+			{
+				new Label()
+				{
+					Text = "The value below this label should be a 1. That's how many times the BindingContext has changed on the Templated element"
+				}
+			};
+
+			Content = cv;
+		}
+
+		private void Cv_BindingContextChanged(object sender, System.EventArgs e)
+		{
+		}
+	}
+}

--- a/src/Controls/src/Core/Platform/Windows/CollectionView/ItemContentControl.cs
+++ b/src/Controls/src/Core/Platform/Windows/CollectionView/ItemContentControl.cs
@@ -169,6 +169,7 @@ namespace Microsoft.Maui.Controls.Platform
 				// or if we need to switch DataTemplates (because this instance is being recycled)
 				// then we'll need to create the content from the template 
 				_visualElement = formsTemplate.CreateContent(dataContext, container) as VisualElement;
+				_visualElement.BindingContext = dataContext;
 				_renderer = _visualElement.ToHandler(mauiContext);
 
 				// We need to set IsPlatformStateConsistent explicitly; otherwise, it won't be set until the renderer's Loaded 
@@ -186,11 +187,11 @@ namespace Microsoft.Maui.Controls.Platform
 			{
 				// We are reusing this ItemContentControl and we can reuse the Element
 				_visualElement = _renderer.VirtualView as VisualElement;
+				_visualElement.BindingContext = dataContext;
 			}
 
 			Content = _renderer.ToPlatform();
 			itemsView?.AddLogicalChild(_visualElement);
-			_visualElement.BindingContext = dataContext;
 		}
 
 		void SetNativeStateConsistent(VisualElement visualElement)

--- a/src/Controls/tests/UITests/Tests/Issues/Issue16787.cs
+++ b/src/Controls/tests/UITests/Tests/Issues/Issue16787.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.Maui.Appium;
+using NUnit.Framework;
+
+namespace Microsoft.Maui.AppiumTests.Issues
+{
+	public class Issue16787 : _IssuesUITest
+	{
+		public Issue16787(TestDevice device) : base(device)
+		{
+		}
+
+		public override string Issue => "CollectionView runtime binding errors when loading the ItemSource asynchronously";
+
+		[Test]
+		public void CollectionViewBindingContextOnlyChangesOnce()
+		{
+			Assert.AreEqual("1", App.WaitForElement("LabelBindingCount")[0].ReadText());
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change

Reverting https://github.com/dotnet/maui/pull/10999 until we can figure out the best approach here. 

Logged issue [here](https://github.com/dotnet/maui/issues/17349)

The process of setting the BindingContext on cells of any list element goes as follows

```C#
createdCell.BindingContext = item
collectionView?.AddLogicalChild(_visualElement);
```

We do it in this order so that the BC of collectionViewdoesn't propagate to the createdCell, but this causes the bindings to all get applied twice due to this code.

[maui/src/Controls/src/Core/Element/Element.cs at d4d86c2f224cfde2f35cb12e61ef76190cc8ce3f · dotnet/maui (github.com)](https://github.com/dotnet/maui/blob/d4d86c2f224cfde2f35cb12e61ef76190cc8ce3f/src/Controls/src/Core/Element/Element.cs#L527)

 
is there a way to handle this flow so that the bindings only get applied once?
Can we Add the logical child and set the binding all as one atomic operation? We have a lot of places in code that have this particular workflow so it would be ideal if we would just standardize this workflow. 

### Issues Fixed


Fixes #16787

