### PR TITLE
Remove Previous TitleView from Toolbar

### DIFF
--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issue16499.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issue16499.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.Maui.Controls;
+
+namespace Maui.Controls.Sample.Issues
+{
+	[Issue(IssueTracker.Github, 16499, "Crash when using NavigationPage.TitleView and Restarting App", PlatformAffected.Android)]
+	public class Issue16499 : TestContentPage
+	{
+		protected override void Init()
+		{
+			var contentPage = new ContentPage();
+			var navPage = new NavigationPage(contentPage);
+
+			NavigationPage.SetTitleView(contentPage, new Label());
+
+			NavigatedTo += Issue16499_NavigatedTo;
+
+			async void Issue16499_NavigatedTo(object sender, NavigatedToEventArgs e)
+			{
+				NavigatedTo -= Issue16499_NavigatedTo;
+				await Navigation.PushModalAsync(navPage);
+				await Navigation.PopModalAsync();
+				await Navigation.PushModalAsync(navPage);
+				await Navigation.PopModalAsync();
+				this.Content = new VerticalStackLayout()
+				{
+					new Label()
+					{
+						Text = "If the app didn't crash this test was a success",
+						AutomationId = "SuccessLabel"
+					}
+				};
+			}
+		}
+	}
+}

--- a/src/Controls/src/Core/Toolbar/Toolbar.Android.cs
+++ b/src/Controls/src/Core/Toolbar/Toolbar.Android.cs
@@ -36,6 +36,11 @@ namespace Microsoft.Maui.Controls
 					ToolbarItems,
 					OnToolbarItemPropertyChanged);
 			}
+			else if (newHandler.MauiContext?.Context != oldHandler?.MauiContext?.Context)
+			{
+				// Platform Title View is from a previous activity context so we just want to null it out
+				_platformTitleView = null;
+			}
 		}
 
 		void OnToolbarItemPropertyChanged(object? sender, PropertyChangedEventArgs e)
@@ -81,7 +86,7 @@ namespace Microsoft.Maui.Controls
 			titleView.ToPlatform(MauiContext);
 			_platformTitleViewHandler = titleView.Handler;
 
-			if (_platformTitleView == null)
+			if (_platformTitleView == null || _platformTitleView.Context != MauiContext.Context)
 			{
 				var context = MauiContext.Context!;
 				_platformTitleView = new Container(context);
@@ -91,6 +96,7 @@ namespace Microsoft.Maui.Controls
 
 			if (_platformTitleView.Parent != PlatformView)
 			{
+				_platformTitleView.RemoveFromParent();
 				PlatformView.AddView(_platformTitleView);
 			}
 

--- a/src/Controls/tests/UITests/Tests/Issues/Issue16499.cs
+++ b/src/Controls/tests/UITests/Tests/Issues/Issue16499.cs
@@ -1,0 +1,24 @@
+﻿using System.Drawing;
+using Microsoft.Maui.Appium;
+using NUnit.Framework;
+using OpenQA.Selenium.Appium.MultiTouch;
+using TestUtils.Appium.UITests;
+
+namespace Microsoft.Maui.AppiumTests.Issues
+{
+	public class Issue16499 : _IssuesUITest
+	{
+		public Issue16499(TestDevice device) : base(device)
+		{
+		}
+
+		public override string Issue => "Crash when using NavigationPage.TitleView and Restarting App";
+
+		[Test]
+		public void AppDoesntCrashWhenReusingSameTitleView()
+		{
+			App.WaitForElement("SuccessLabel");
+			App.WaitForElement("SuccessLabel");
+		}
+	}
+}

--- a/src/Controls/tests/UITests/Tests/Issues/Issue16499.cs
+++ b/src/Controls/tests/UITests/Tests/Issues/Issue16499.cs
@@ -18,7 +18,6 @@ namespace Microsoft.Maui.AppiumTests.Issues
 		public void AppDoesntCrashWhenReusingSameTitleView()
 		{
 			App.WaitForElement("SuccessLabel");
-			App.WaitForElement("SuccessLabel");
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change

If a Toolbar is reused after an activity is recreated or if you push the same `NavigationPAge` on to the stack the code wasn't correctly removing it from the previous platform toolbar. 

### Issues Fixed

Fixes #16499 
