### PR TITLE
Changing value of Shell.NavBarIsVisible should change visibility of toolbar (ShellToolbar)

### DIFF
--- a/src/Controls/src/Core/Internals/PropertyPropagationExtensions.cs
+++ b/src/Controls/src/Core/Internals/PropertyPropagationExtensions.cs
@@ -17,9 +17,6 @@ namespace Microsoft.Maui.Controls.Internals
 			if (propertyName == null || propertyName == VisualElement.WindowProperty.PropertyName)
 				SetWindowFromParent(element);
 
-			if (propertyName == null || propertyName == Shell.NavBarIsVisibleProperty.PropertyName)
-				BaseShellItem.PropagateFromParent(Shell.NavBarIsVisibleProperty, element);
-
 			if (propertyName == null || propertyName == Shell.NavBarHasShadowProperty.PropertyName)
 				BaseShellItem.PropagateFromParent(Shell.NavBarHasShadowProperty, element);
 

--- a/src/Controls/src/Core/Shell/Shell.cs
+++ b/src/Controls/src/Core/Shell/Shell.cs
@@ -49,7 +49,18 @@ namespace Microsoft.Maui.Controls
 
 		/// <summary>Bindable property for attached property <c>NavBarIsVisible</c>.</summary>
 		public static readonly BindableProperty NavBarIsVisibleProperty =
-			BindableProperty.CreateAttached("NavBarIsVisible", typeof(bool), typeof(Shell), true);
+			BindableProperty.CreateAttached("NavBarIsVisible", typeof(bool), typeof(Shell), true, propertyChanged: OnNavBarIsVisibleChanged);
+
+		private static void OnNavBarIsVisibleChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			// Nav bar visibility change is only interesting from the Shell down to the current Page.
+			// Make sure the ShellToolbar knows about any possible change.
+			Shell shell = bindable as Shell
+				?? (bindable as BaseShellItem)?.FindParentOfType<Shell>()
+				?? (bindable as Page)?.FindParentOfType<Shell>();
+
+			shell.OnPropertyChanged(NavBarIsVisibleProperty.PropertyName);
+		}
 
 		/// <summary>Bindable property for attached property <c>NavBarHasShadow</c>.</summary>
 		public static readonly BindableProperty NavBarHasShadowProperty =

--- a/src/Controls/src/Core/Shell/Shell.cs
+++ b/src/Controls/src/Core/Shell/Shell.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Maui.Controls
 				?? (bindable as BaseShellItem)?.FindParentOfType<Shell>()
 				?? (bindable as Page)?.FindParentOfType<Shell>();
 
-			shell.OnPropertyChanged(NavBarIsVisibleProperty.PropertyName);
+			shell?.OnPropertyChanged(NavBarIsVisibleProperty.PropertyName);
 		}
 
 		/// <summary>Bindable property for attached property <c>NavBarHasShadow</c>.</summary>

--- a/src/Controls/src/Core/ShellToolbar.cs
+++ b/src/Controls/src/Core/ShellToolbar.cs
@@ -98,28 +98,29 @@ namespace Microsoft.Maui.Controls
 
 			UpdateTitle();
 
-			if (_currentPage != null &&
-				_currentPage.IsSet(Shell.NavBarIsVisibleProperty))
+			Func<bool> getDefaultNavBarIsVisible = () =>
 			{
-				IsVisible = Shell.GetNavBarIsVisible(_currentPage);
-			}
-			else
-			{
+				// Shell.GetEffectiveValue doesn't check the Shell itself, so check it here
+				if (_shell.IsSet(Shell.NavBarIsVisibleProperty))
+					return (bool)_shell.GetValue(Shell.NavBarIsVisibleProperty);
+
 				var flyoutBehavior = (_shell as IFlyoutView).FlyoutBehavior;
 #if WINDOWS
-				IsVisible = (!String.IsNullOrEmpty(Title) ||
+				return (!String.IsNullOrEmpty(Title) ||
 					TitleView != null ||
 					_toolbarTracker.ToolbarItems.Count > 0 ||
 					_menuBarTracker.ToolbarItems.Count > 0 ||
 					flyoutBehavior == FlyoutBehavior.Flyout);
 #else
-				IsVisible = (BackButtonVisible ||
+				return (BackButtonVisible ||
 					!String.IsNullOrEmpty(Title) ||
 					TitleView != null ||
 					_toolbarTracker.ToolbarItems.Count > 0 ||
 					flyoutBehavior == FlyoutBehavior.Flyout);
 #endif
-			}
+			};
+
+			IsVisible = _shell.GetEffectiveValue(Shell.NavBarIsVisibleProperty, getDefaultNavBarIsVisible, observer: null);
 
 			if (currentPage != null)
 				DynamicOverflowEnabled = PlatformConfiguration.WindowsSpecific.Page.GetToolbarDynamicOverflowEnabled(currentPage);

--- a/src/Controls/tests/Core.UnitTests/ShellToolbarTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellToolbarTests.cs
@@ -186,11 +186,27 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		public void NavBarIsVisibleUpdates()
 		{
 			var page = new ContentPage() { Title = "Test" };
-			TestShell testShell = new TestShell(page);
+			var testShell = new TestShell(page);
 			var toolBar = testShell.Toolbar;
-			Assert.True(toolBar.IsVisible);
+			Assert.True(toolBar.IsVisible); // visible by default
+
+			// Change the Shell
+			Shell.SetNavBarIsVisible(testShell, false);
+			Assert.False(toolBar.IsVisible);
+			testShell.ClearValue(Shell.NavBarIsVisibleProperty);
+			Assert.True(toolBar.IsVisible); // back to default
+
+			// Change the Page's parent
+			Shell.SetNavBarIsVisible(page.Parent, false);
+			Assert.False(toolBar.IsVisible);
+			page.Parent.ClearValue(Shell.NavBarIsVisibleProperty);
+			Assert.True(toolBar.IsVisible); // back to default
+
+			// Change the Page
 			Shell.SetNavBarIsVisible(page, false);
 			Assert.False(toolBar.IsVisible);
+			page.ClearValue(Shell.NavBarIsVisibleProperty);
+			Assert.True(toolBar.IsVisible); // back to default
 		}
 
 		[Fact]


### PR DESCRIPTION
### Description of Change

This change updates the visibility of the ShellToolbar as the value of Shell.NavBarIsVisible changes (either through XAML Hot Reload or through code).

For apps that use `Shell`: The `Shell.NavBarIsVisible` attached property can be set on any element from the root `Shell` down to the current `Page`. The value of `Shell.NavBarIsVisible` needs to act like its inherited down to the `Page`.

The old code would copy the value of `Shell.NavBarIsVisible` down through the element tree. Once it's copied, that's it, it won't be updated by inheritance again. I'm removing that inheritance copy, and instead have the `ShellToolbar` look for the value of `Shell.NavBarIsVisible` at the current `Page`, and go up through parents to the `Shell`.

`ShellToolbar` already listened for the `PropertyChanged` event on the `Shell`, so that event is being used to notify when any element has a change for `Shell.NavBarIsVisible`.

<!-- Enter description of the fix in this section -->

### Issues Fixed

Fixes #7459 (Shell.NavBarIsVisible does not update on hot reload)
