### PR TITLE
Update Flyout when Shell.FlyoutContent changes

### DIFF
--- a/src/Controls/src/Core/Handlers/Shell/ShellHandler.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellHandler.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Maui.Controls.Handlers
 					[nameof(IFlyoutView.FlyoutWidth)] = MapFlyoutWidth,
 					[nameof(Shell.FlyoutBackground)] = MapFlyoutBackground,
 					[nameof(Shell.FlyoutBackgroundColor)] = MapFlyoutBackground,
+					[nameof(Shell.FlyoutContent)] = MapFlyout,
 					[nameof(Shell.CurrentItem)] = MapCurrentItem,
 					[nameof(Shell.FlyoutBackdrop)] = MapFlyoutBackdrop,
 					[nameof(Shell.FlyoutFooter)] = MapFlyoutFooter,

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellFlyoutTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellFlyoutTests.cs
@@ -17,6 +17,30 @@ namespace Microsoft.Maui.DeviceTests
 {
 	public partial class ShellTests : ControlsHandlerTestBase
 	{
+		[Fact]
+		public async Task FlyoutContentUpdatesAfterChange()
+		{
+			var flyoutContent = new VerticalStackLayout()
+			{
+				new Label() { Text = "Flyout Content" }
+			};
+
+			await RunShellTest(shell =>
+			{
+				shell.FlyoutBehavior = FlyoutBehavior.Locked;
+			},
+			async (shell, handler) =>
+			{
+				Assert.False(flyoutContent.IsLoaded);
+
+				shell.FlyoutContent = flyoutContent;
+				await OnLoadedAsync(flyoutContent);
+
+				shell.FlyoutContent = null;
+				await OnUnloadedAsync(flyoutContent);
+			});
+		}
+
 #if !MACCATALYST
 		[Fact]
 		public async Task LogicalChildrenPropagateCorrectly()
@@ -303,6 +327,8 @@ namespace Microsoft.Maui.DeviceTests
 			return Thickness.Zero;
 #endif
 		}
+#endif
+
 		async Task RunShellTest(Action<Shell> action, Func<Shell, ShellHandler, Task> testAction)
 		{
 			SetupBuilder();
@@ -319,6 +345,5 @@ namespace Microsoft.Maui.DeviceTests
 				await testAction(shell, handler);
 			});
 		}
-#endif
 	}
 }


### PR DESCRIPTION
### Description of Change

`Shell.FlyoutContent` allows users to change what the Shell's flyout looks like:
* https://learn.microsoft.com/en-us/dotnet/maui/fundamentals/shell/flyout#replace-flyout-content

If `FlyoutContent` changed at runtime, the UI didn't update (either going to custom content, or reverting back to default content when setting `FlyoutContent` to `null`).

The update functionality was already there, like when `IFlyoutView.Flyout` changed, but that property was also exposed as `Shell.FlyoutContent`.

### Issues Fixed

Fixes #9080 (Shell.FlyoutContent does not update with hot reload)
