### PR TITLE
Split out sharable testing for non-element thing

### DIFF
--- a/src/Controls/samples/Controls.Sample.UITests/CoreViews/CoreGalleryBasePage.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/CoreViews/CoreGalleryBasePage.cs
@@ -1,0 +1,186 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Maui;
+using Microsoft.Maui.Controls;
+
+namespace Maui.Controls.Sample
+{
+	internal abstract class CoreGalleryBasePage : CoreGalleryBasePage<View>
+	{
+	}
+
+	internal abstract class CoreGalleryBasePage<TView> : ContentPage
+		where TView : View
+	{
+		readonly List<IViewContainer<TView>> _viewContainers = new();
+		int _currentIndex;
+
+		Picker _picker;
+		Entry _targetEntry;
+		Button _goButton;
+		Layout _layout;
+
+		/// <summary>
+		/// Gets a list of all the test view containers for this page.
+		/// </summary>
+		protected IReadOnlyList<IViewContainer<TView>> ViewContainers => _viewContainers;
+
+		/// <summary>
+		/// Gets the root layout for the page. This layout contains everything - including the test chrome.
+		/// </summary>
+		protected Layout Root { get; private set; }
+
+		/// <summary>
+		/// Gets a value indicating whether this gallery supports being hosted in a ScrollView.
+		/// </summary>
+		protected virtual bool SupportsScroll => true;
+
+		internal CoreGalleryBasePage()
+		{
+			Initialize();
+
+			Root = new StackLayout
+			{
+				Padding = new Thickness(20),
+				Children =
+				{
+					new Button()
+					{
+						Text = "Dismiss Page",
+						Command = new Command(async () =>
+						{
+							if (_picker.SelectedIndex == 0)
+								await Navigation.PopAsync();
+							else
+								_picker.SelectedIndex--;
+						})
+					},
+					BuildLayout(),
+				}
+			};
+
+			Build();
+
+			InitializeLayout();
+
+			if (SupportsScroll)
+			{
+				Content = new ScrollView
+				{
+					AutomationId = "GalleryScrollView",
+					Content = Root
+				};
+			}
+			else
+			{
+				Content = new Grid
+				{
+					AutomationId = "GalleryScrollView",
+					Children = { Root }
+				};
+			}
+		}
+
+		/// <summary>
+		/// Code that needs to run before the page is created goes here.
+		/// </summary>
+		protected virtual void Initialize() { }
+
+		/// <summary>
+		/// Add a test case to the gallery page.
+		/// </summary>
+		/// <param name="viewContainer">The test view container to add.</param>
+		protected TViewContainer Add<TViewContainer>(TViewContainer viewContainer)
+			where TViewContainer : IViewContainer<TView>
+		{
+			_viewContainers.Add(viewContainer);
+			_picker.Items.Add(viewContainer.TitleLabel.Text);
+			return viewContainer;
+		}
+
+		/// <summary>
+		/// Add all the test view containers to the gallery page.
+		/// </summary>
+		protected abstract void Build();
+
+		Layout BuildLayout()
+		{
+			_picker = new Picker();
+
+			_targetEntry = new Entry
+			{
+				AutomationId = "TargetViewContainer",
+				Placeholder = "Jump To ViewContainer"
+			};
+
+			_goButton = new Button
+			{
+				Text = "Go",
+				AutomationId = "GoButton",
+				Command = new Command(GoClicked)
+			};
+
+			_layout = new StackLayout
+			{
+				Children =
+				{
+					_picker,
+					_targetEntry,
+					_goButton,
+				}
+			};
+
+			return _layout;
+		}
+
+		void InitializeLayout()
+		{
+			_layout.Children.Add(_viewContainers[_currentIndex].ContainerLayout);
+
+			_picker.SelectedIndex = _currentIndex;
+			_picker.SelectedIndexChanged += PickerSelectedIndexChanged;
+		}
+
+		void GoClicked()
+		{
+			if (!_viewContainers.Any())
+				return;
+
+			var target = _targetEntry.Text;
+			if (string.IsNullOrEmpty(target))
+				return;
+
+			_targetEntry.Text = "";
+
+			var index = -1;
+			for (int n = 0; n < _viewContainers.Count; n++)
+			{
+				if (_viewContainers[n].View.AutomationId == target)
+				{
+					index = n;
+					break;
+				}
+			}
+			if (index < 0)
+				return;
+
+			var targetContainer = _viewContainers[index];
+
+			_layout.Children.RemoveAt(3);
+			_layout.Children.Add(targetContainer.ContainerLayout);
+
+			_picker.SelectedIndexChanged -= PickerSelectedIndexChanged;
+			_picker.SelectedIndex = index;
+			_picker.SelectedIndexChanged += PickerSelectedIndexChanged;
+		}
+
+		void PickerSelectedIndexChanged(object sender, EventArgs eventArgs)
+		{
+			_currentIndex = _picker.SelectedIndex;
+
+			_layout.Children.RemoveAt(3);
+			_layout.Children.Add(_viewContainers[_currentIndex].ContainerLayout);
+		}
+	}
+}

--- a/src/Controls/samples/Controls.Sample.UITests/CoreViews/CoreGalleryPage.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/CoreViews/CoreGalleryPage.cs
@@ -1,69 +1,24 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.Maui;
-using Microsoft.Maui.Controls;
+﻿using Microsoft.Maui.Controls;
 using Microsoft.Maui.Graphics;
 
 namespace Maui.Controls.Sample
 {
-	internal class CoreGalleryPage<T> : ContentPage
+	internal class CoreGalleryPage<T> : CoreGalleryBasePage<T>
 		where T : View, new()
 	{
-		List<ViewContainer<T>> _viewContainers;
-
-		int _currentIndex;
-		Picker _picker;
-		Entry _targetEntry;
-		StackLayout _layout;
-
 		protected StateViewContainer<T> IsEnabledStateViewContainer { get; private set; }
 
-		protected new StackLayout Layout { get; private set; }
+		protected virtual bool SupportsTapGestureRecognizer => true;
 
-		internal CoreGalleryPage()
-		{
-			Initialize();
+		protected virtual bool SupportsFocus => true;
 
-			Layout = new StackLayout
-			{
-				Padding = new Thickness(20)
-			};
-
-			var modalDismissButton = new Button()
-			{
-				Text = "Dismiss Page",
-				Command = new Command(async () =>
-				{
-					if (_picker.SelectedIndex == 0)
-					{
-						await Navigation.PopAsync();
-					}
-					else
-					{
-						_picker.SelectedIndex--;
-					}
-				})
-			};
-			Layout.Children.Add(modalDismissButton);
-
-			Build(Layout);
-
-			if (SupportsScroll)
-				Content = new ScrollView { AutomationId = "GalleryScrollView", Content = Layout };
-			else
-			{
-				var content = new Grid { AutomationId = "GalleryScrollView" };
-				content.Children.Add(Layout);
-				Content = content;
-			}
-		}
-
-		protected virtual void Initialize() { }
-
+		/// <summary>
+		/// Code that needs to run for each element that was added during the build.
+		/// </summary>
+		/// <param name="element">The element to initialize.</param>
 		protected virtual void InitializeElement(T element) { }
 
-		protected virtual void Build(StackLayout stackLayout)
+		protected override void Build()
 		{
 			var isFocusedView = new T();
 			isFocusedView.SetValueFromRenderer(IsFocusedPropertyKey.BindableProperty, true);
@@ -83,7 +38,6 @@ namespace Maui.Controls.Sample
 			var isFocusedStateViewContainer = new StateViewContainer<T>(Test.VisualElement.IsFocused, isFocusedView);
 			isFocusedStateViewContainer.StateChangeButton.Command = new Command(() =>
 			{
-
 				if ((bool)isFocusedView.GetValue(VisualElement.IsFocusedProperty))
 				{
 					isFocusedView.SetValueFromRenderer(IsFocusedPropertyKey.BindableProperty, false);
@@ -118,149 +72,50 @@ namespace Maui.Controls.Sample
 				new TapGestureRecognizer
 				{
 					Command = new Command(() => gestureRecognizerEventViewContainer.EventFired())
-				}
-			);
+				});
 
-			_viewContainers = new List<ViewContainer<T>> {
-			isFocusedStateViewContainer,
-			new ViewContainer<T> (Test.VisualElement.BackgroundColor, new T { BackgroundColor = Colors.Blue }),
-			new ViewContainer<T>(Test.VisualElement.Background, new T { Background = new LinearGradientBrush
+			if (SupportsFocus)
 			{
+				Add(isFocusedStateViewContainer);
+				Add(focusStateViewContainer);
+			}
+
+			Add(new ViewContainer<T>(Test.VisualElement.BackgroundColor, new T { BackgroundColor = Colors.Blue }));
+			Add(new ViewContainer<T>(Test.VisualElement.Background, new T
+			{
+				Background = new LinearGradientBrush
+				{
 					StartPoint = new Point(0, 0),
 					EndPoint = new Point(1, 0),
 					GradientStops = new GradientStopCollection
-					{
-						new GradientStop(Colors.Yellow, 0.0f),
-						new GradientStop(Colors.Orange, 0.5f),
-						new GradientStop(Colors.Red, 1.0f)
-					}
-				} }),
-				focusStateViewContainer,
-			gestureRecognizerEventViewContainer,
-				new LayeredViewContainer<T> (Test.VisualElement.InputTransparent, new T { InputTransparent = true }),
-				IsEnabledStateViewContainer,
-				focusedEventViewContainer,
-				unfocusedEventViewContainer,
-			isVisibleStateViewContainer,
-			new ViewContainer<T> (Test.VisualElement.Opacity, new T { Opacity = 0.5 }),
-			new ViewContainer<T> (Test.VisualElement.Rotation, new T { Rotation = 10 }),
-			new ViewContainer<T> (Test.VisualElement.RotationX, new T { RotationX = 33 }),
-			new ViewContainer<T> (Test.VisualElement.RotationY, new T { RotationY = 10 }),
-			new ViewContainer<T> (Test.VisualElement.Scale, new T { Scale = 0.5 }),
-			new ViewContainer<T> (Test.VisualElement.TranslationX, new T { TranslationX = 30 }),
-			new ViewContainer<T> (Test.VisualElement.TranslationY, new T { TranslationY = 30 }),
-		};
-			_layout = new StackLayout();
+						{
+							new GradientStop(Colors.Yellow, 0.0f),
+							new GradientStop(Colors.Orange, 0.5f),
+							new GradientStop(Colors.Red, 1.0f)
+						}
+				}
+			}));
 
-			_targetEntry = new Entry { AutomationId = "TargetViewContainer", Placeholder = "Jump To ViewContainer" };
+			if (SupportsTapGestureRecognizer)
+				Add(gestureRecognizerEventViewContainer);
 
-			var goButton = new Button
-			{
-				Text = "Go",
-				AutomationId = "GoButton"
-			};
-			goButton.Clicked += GoClicked;
+			Add(new LayeredViewContainer<T>(Test.VisualElement.InputTransparent, new T { InputTransparent = true }));
+			Add(IsEnabledStateViewContainer);
+			Add(focusedEventViewContainer);
+			Add(unfocusedEventViewContainer);
+			Add(isVisibleStateViewContainer);
+			Add(new ViewContainer<T>(Test.VisualElement.Opacity, new T { Opacity = 0.5 }));
+			Add(new ViewContainer<T>(Test.VisualElement.Rotation, new T { Rotation = 10 }));
+			Add(new ViewContainer<T>(Test.VisualElement.RotationX, new T { RotationX = 33 }));
+			Add(new ViewContainer<T>(Test.VisualElement.RotationY, new T { RotationY = 10 }));
+			Add(new ViewContainer<T>(Test.VisualElement.Scale, new T { Scale = 0.5 }));
+			Add(new ViewContainer<T>(Test.VisualElement.TranslationX, new T { TranslationX = 30 }));
+			Add(new ViewContainer<T>(Test.VisualElement.TranslationY, new T { TranslationY = 30 }));
 
-			_picker = new Picker();
-			foreach (var container in _viewContainers)
-			{
-				_picker.Items.Add(container.TitleLabel.Text);
-			}
-
-			_picker.SelectedIndex = _currentIndex;
-
-			_picker.SelectedIndexChanged += PickerSelectedIndexChanged;
-
-			_layout.Children.Add(_picker);
-			_layout.Children.Add(_targetEntry);
-			_layout.Children.Add(goButton);
-			_layout.Children.Add(_viewContainers[_currentIndex].ContainerLayout);
-
-			stackLayout.Children.Add(_layout);
-
-			if (!SupportsFocus)
-			{
-				stackLayout.Children.Remove(focusStateViewContainer.ContainerLayout);
-				stackLayout.Children.Remove(isFocusedStateViewContainer.ContainerLayout);
-			}
-
-			if (!SupportsTapGestureRecognizer)
-			{
-				stackLayout.Children.Remove(gestureRecognizerEventViewContainer.ContainerLayout);
-			}
-
-			foreach (var element in _viewContainers)
+			foreach (var element in ViewContainers)
 			{
 				InitializeElement(element.View);
 			}
-		}
-
-		void GoClicked(object sender, EventArgs e)
-		{
-			if (!_viewContainers.Any())
-			{
-				return;
-			}
-
-			var target = _targetEntry.Text;
-			_targetEntry.Text = "";
-			var index = -1;
-
-			if (string.IsNullOrEmpty(target))
-			{
-				return;
-			}
-
-			for (int n = 0; n < _viewContainers.Count; n++)
-			{
-				if (_viewContainers[n].View.AutomationId == target)
-				{
-					index = n;
-					break;
-				}
-			}
-
-			if (index < 0)
-			{
-				return;
-			}
-
-			var targetContainer = _viewContainers[index];
-
-			_layout.Children.RemoveAt(3);
-			_layout.Children.Add(targetContainer.ContainerLayout);
-
-			_picker.SelectedIndexChanged -= PickerSelectedIndexChanged;
-			_picker.SelectedIndex = index;
-			_picker.SelectedIndexChanged += PickerSelectedIndexChanged;
-		}
-
-		void PickerSelectedIndexChanged(object sender, EventArgs eventArgs)
-		{
-			_currentIndex = _picker.SelectedIndex;
-			_layout.Children.RemoveAt(3);
-			_layout.Children.Add(_viewContainers[_currentIndex].ContainerLayout);
-		}
-
-		protected virtual bool SupportsTapGestureRecognizer
-		{
-			get { return true; }
-		}
-
-		protected virtual bool SupportsFocus
-		{
-			get { return true; }
-		}
-
-		protected virtual bool SupportsScroll
-		{
-			get { return true; }
-		}
-
-		protected void Add(ViewContainer<T> viewContainer)
-		{
-			_viewContainers.Add(viewContainer);
-			_picker.Items.Add(viewContainer.TitleLabel.Text);
 		}
 	}
 }

--- a/src/Controls/samples/Controls.Sample.UITests/CoreViews/CorePageView.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/CoreViews/CorePageView.cs
@@ -44,7 +44,7 @@ namespace Maui.Controls.Sample
 
 		List<GalleryPageFactory> _pages = new List<GalleryPageFactory> {
 				new GalleryPageFactory(() => new ButtonCoreGalleryPage(), "Button Gallery"),
-		new GalleryPageFactory(() => new CarouselViewCoreGalleryPage(), "CarouselView Gallery"),
+				new GalleryPageFactory(() => new CarouselViewCoreGalleryPage(), "CarouselView Gallery"),
 				new GalleryPageFactory(() => new CheckBoxCoreGalleryPage(), "CheckBox Gallery"),
 				new GalleryPageFactory(() => new EditorCoreGalleryPage(), "Editor Gallery"),
 				new GalleryPageFactory(() => new RadioButtonCoreGalleryPage(), "RadioButton Core Gallery"),

--- a/src/Controls/samples/Controls.Sample.UITests/CoreViews/ViewContainers/ExpectedEventViewContainer.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/CoreViews/ViewContainers/ExpectedEventViewContainer.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using Microsoft.Maui.Controls;
+
+namespace Maui.Controls.Sample
+{
+	internal class ExpectedEventViewContainer<T> : ViewContainer<T>
+		where T : View
+	{
+		readonly string _key;
+		readonly Label _eventLabel;
+
+		int _numberOfTimesSuccessFired = 0;
+		int _numberOfTimesFailedFired = 0;
+
+		public ExpectedEventViewContainer(Enum key, Func<T> view)
+			: this(key.ToString(), view)
+		{
+		}
+
+		public ExpectedEventViewContainer(Enum key, T view)
+			: this(key.ToString(), view)
+		{
+		}
+
+		public ExpectedEventViewContainer(string key, T view)
+			: this(key, () => view)
+		{
+		}
+
+		public ExpectedEventViewContainer(string key, Func<T> view)
+			: base(key, view())
+		{
+			_key = key.ToString();
+
+			_eventLabel = new Label
+			{
+				AutomationId = $"{key}EventLabel",
+				Text = $"Event: {key} (none)"
+			};
+
+			ContainerLayout.Children.Add(_eventLabel);
+		}
+
+		public void ReportSuccessEvent()
+		{
+			if (_numberOfTimesFailedFired > 0)
+				return;
+
+			_numberOfTimesSuccessFired++;
+			_eventLabel.Text = $"Event: {_key} (SUCCESS {_numberOfTimesSuccessFired})";
+		}
+
+		public void ReportFailEvent()
+		{
+			_numberOfTimesFailedFired++;
+			_eventLabel.Text = $"Event: {_key} (FAIL {_numberOfTimesFailedFired})";
+		}
+	}
+}

--- a/src/Controls/samples/Controls.Sample.UITests/CoreViews/ViewContainers/IViewContainer.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/CoreViews/ViewContainers/IViewContainer.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.Maui.Controls;
+
+namespace Maui.Controls.Sample
+{
+	internal interface IViewContainer<out T>
+		where T : View
+	{
+		Label TitleLabel { get; }
+
+		Label BoundsLabel { get; }
+
+		T View { get; }
+
+		Layout ContainerLayout { get; }
+	}
+}

--- a/src/Controls/samples/Controls.Sample.UITests/CoreViews/ViewContainers/ViewContainer.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/CoreViews/ViewContainers/ViewContainer.cs
@@ -3,7 +3,8 @@ using Microsoft.Maui.Controls;
 
 namespace Maui.Controls.Sample
 {
-	internal class ViewContainer<T> where T : View
+	internal class ViewContainer<T> : IViewContainer<T>
+		where T : View
 	{
 		public Label TitleLabel { get; private set; }
 		public Label BoundsLabel { get; private set; }
@@ -12,25 +13,32 @@ namespace Maui.Controls.Sample
 		// May want to override the container layout in subclasses
 		public StackLayout ContainerLayout { get; protected set; }
 
-		public ViewContainer(Enum formsMember, T view)
+		Layout IViewContainer<T>.ContainerLayout => ContainerLayout;
+
+		public ViewContainer(Enum key, T view)
+			: this(key.ToString(), view)
 		{
-			view.AutomationId = formsMember + "VisualElement";
+		}
+
+		public ViewContainer(string key, T view)
+		{
+			view.AutomationId = $"{key}VisualElement";
 			View = view;
 
 			TitleLabel = new Label
 			{
-				Text = formsMember + " View"
+				Text = $"{key} View"
 			};
 
 			BoundsLabel = new Label
 			{
 				BindingContext = new MultiBindingHack(view)
 			};
-			BoundsLabel.SetBinding(Label.TextProperty, "LabelWithBounds");
+			BoundsLabel.SetBinding(Label.TextProperty, nameof(MultiBindingHack.LabelWithBounds));
 
 			ContainerLayout = new StackLayout
 			{
-				AutomationId = formsMember + "Container",
+				AutomationId = $"{key}Container",
 				Padding = 10,
 				Children = { TitleLabel, BoundsLabel, view }
 			};

--- a/src/Controls/samples/Controls.Sample.UITests/Elements/ButtonCoreGalleryPage.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/Elements/ButtonCoreGalleryPage.cs
@@ -25,9 +25,9 @@ namespace Maui.Controls.Sample
 			element.Text = "Button";
 		}
 
-		protected override void Build(StackLayout stackLayout)
+		protected override void Build()
 		{
-			base.Build(stackLayout);
+			base.Build();
 
 			IsEnabledStateViewContainer.View.Clicked += (sender, args) => IsEnabledStateViewContainer.TitleLabel.Text += " (Tapped)";
 

--- a/src/Controls/samples/Controls.Sample.UITests/Elements/CheckBoxCoreGalleryPage.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/Elements/CheckBoxCoreGalleryPage.cs
@@ -15,9 +15,9 @@ namespace Maui.Controls.Sample
 			get { return false; }
 		}
 
-		protected override void Build(StackLayout stackLayout)
+		protected override void Build()
 		{
-			base.Build(stackLayout);
+			base.Build();
 
 			var isCheckedContainer = new ValueViewContainer<CheckBox>(Test.CheckBox.IsChecked, new CheckBox() { IsChecked = true, HorizontalOptions = LayoutOptions.Start }, "IsChecked", value => value.ToString());
 			Add(isCheckedContainer);

--- a/src/Controls/samples/Controls.Sample.UITests/Elements/EditorCoreGalleryPage.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/Elements/EditorCoreGalleryPage.cs
@@ -11,9 +11,9 @@ namespace Maui.Controls.Sample
 			get { return false; }
 		}
 
-		protected override void Build(StackLayout stackLayout)
+		protected override void Build()
 		{
-			base.Build(stackLayout);
+			base.Build();
 
 			var completedContainer = new EventViewContainer<Editor>(Test.Editor.Completed, new Editor());
 			completedContainer.View.Completed += (sender, args) => completedContainer.EventFired();

--- a/src/Controls/samples/Controls.Sample.UITests/Elements/LabelCoreGalleryPage.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/Elements/LabelCoreGalleryPage.cs
@@ -13,9 +13,9 @@ internal class LabelCoreGalleryPage : CoreGalleryPage<Label>
 		element.Text = "I am a label's text.";
 	}
 
-	protected override void Build(StackLayout stackLayout)
+	protected override void Build()
 	{
-		base.Build(stackLayout);
+		base.Build();
 
 		// demonstrates that formatted text appears correctly
 		{

--- a/src/Controls/samples/Controls.Sample.UITests/Elements/RadioButtonCoreGalleryPage.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/Elements/RadioButtonCoreGalleryPage.cs
@@ -13,9 +13,9 @@ namespace Maui.Controls.Sample
 			element.Content = "RadioButton";
 		}
 
-		protected override void Build(StackLayout stackLayout)
+		protected override void Build()
 		{
-			base.Build(stackLayout);
+			base.Build();
 
 			IsEnabledStateViewContainer.View.CheckedChanged += (sender, args) => IsEnabledStateViewContainer.TitleLabel.Text += " (Checked Changed)";
 

--- a/src/Controls/samples/Controls.Sample.UITests/Utils/Utils.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/Utils/Utils.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Maui;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Graphics;
+
+namespace Maui.Controls.Sample
+{
+	public static class Utils
+	{
+		public static T With<T>(this T that, Action<T> action)
+		{
+			action(that);
+			return that;
+		}
+	}
+}

--- a/src/Controls/tests/UITests/Tests/ButtonUITests.cs
+++ b/src/Controls/tests/UITests/Tests/ButtonUITests.cs
@@ -6,12 +6,11 @@ namespace Microsoft.Maui.AppiumTests
 {
 	public class ButtonUITests : _ViewUITests
 	{
-		static readonly string Button = "android.widget.Button";
 		const string ButtonGallery = "* marked:'Button Gallery'";
+
 		public ButtonUITests(TestDevice device)
 			: base(device)
 		{
-			PlatformViewType = Button;
 		}
 
 		protected override void NavigateToGallery()
@@ -22,7 +21,7 @@ namespace Microsoft.Maui.AppiumTests
 		[Test]
 		public void Clicked()
 		{
-			var remote = new EventViewContainerRemote(UITestContext, Test.Button.Clicked, PlatformViewType);
+			var remote = new EventViewContainerRemote(UITestContext, Test.Button.Clicked);
 			remote.GoTo();
 
 			var textBeforeClick = remote.GetEventLabel().Text;

--- a/src/Controls/tests/UITests/Tests/CheckBoxUITests.cs
+++ b/src/Controls/tests/UITests/Tests/CheckBoxUITests.cs
@@ -5,13 +5,11 @@ namespace Microsoft.Maui.AppiumTests
 {
 	public class CheckBoxUITests : _ViewUITests
 	{
-		static readonly string CheckBox = "android.widget.CheckBox";
 		const string CheckBoxGallery = "* marked:'CheckBox Gallery'";
 
 		public CheckBoxUITests(TestDevice device)
 			: base(device)
 		{
-			PlatformViewType = CheckBox;
 		}
 
 		protected override void NavigateToGallery()

--- a/src/Controls/tests/UITests/Tests/CoreGalleryBasePageTest.cs
+++ b/src/Controls/tests/UITests/Tests/CoreGalleryBasePageTest.cs
@@ -1,0 +1,52 @@
+﻿using Microsoft.Maui.Appium;
+using NUnit.Framework;
+
+namespace Microsoft.Maui.AppiumTests
+{
+	public abstract class CoreGalleryBasePageTest : UITestBase
+	{
+		public CoreGalleryBasePageTest(TestDevice device) : base(device) { }
+
+		protected override void FixtureSetup()
+		{
+			int retries = 0;
+			while (true)
+			{
+				try
+				{
+					base.FixtureSetup();
+					NavigateToGallery();
+					break;
+				}
+				catch (Exception e)
+				{
+					TestContext.Error.WriteLine($">>>>> The FixtureSetup threw an exception. Attempt {retries}/{SetupMaxRetries}.{Environment.NewLine}Exception details: {e}");
+					if (retries++ < SetupMaxRetries)
+					{
+						Reset();
+					}
+					else
+					{
+						throw;
+					}
+				}
+			}
+		}
+
+		protected override void FixtureTeardown()
+		{
+			base.FixtureTeardown();
+			try
+			{
+				App.NavigateBack();
+			}
+			catch (Exception e)
+			{
+				var name = TestContext.CurrentContext.Test.MethodName ?? TestContext.CurrentContext.Test.Name;
+				TestContext.Error.WriteLine($">>>>> The FixtureTeardown threw an exception during {name}.{Environment.NewLine}Exception details: {e}");
+			}
+		}
+
+		protected abstract void NavigateToGallery();
+	}
+}

--- a/src/Controls/tests/UITests/Tests/EditorUITests.cs
+++ b/src/Controls/tests/UITests/Tests/EditorUITests.cs
@@ -5,13 +5,11 @@ namespace Microsoft.Maui.AppiumTests
 {
 	public class EditorUITests : _ViewUITests
 	{
-		public static readonly string Editor = "android.widget.EditorEditText";
 		public const string EditorGallery = "* marked:'Editor Gallery'";
 
 		public EditorUITests(TestDevice device)
 			: base(device)
 		{
-			PlatformViewType = Editor;
 		}
 
 		protected override void NavigateToGallery()

--- a/src/Controls/tests/UITests/Tests/LabelUITests.cs
+++ b/src/Controls/tests/UITests/Tests/LabelUITests.cs
@@ -6,13 +6,11 @@ namespace Microsoft.Maui.AppiumTests;
 
 public class LabelUITests : _ViewUITests
 {
-	static readonly string Label = "android.widget.TextView";
 	const string LabelGallery = "* marked:'Label Gallery'";
 
 	public LabelUITests(TestDevice device)
 		: base(device)
 	{
-		PlatformViewType = Label;
 	}
 
 	protected override void NavigateToGallery() =>
@@ -33,7 +31,7 @@ public class LabelUITests : _ViewUITests
 			Assert.Ignore("This test is failing on iOS/Mac Catalyst/Windows because the feature is not yet implemented: https://github.com/dotnet/maui/issues/4734");
 		}
 
-		var remote = new EventViewContainerRemote(UITestContext, Test.FormattedString.SpanTapped, PlatformViewType);
+		var remote = new EventViewContainerRemote(UITestContext, Test.FormattedString.SpanTapped);
 		remote.GoTo();
 
 		var textBeforeClick = remote.GetEventLabel().Text;

--- a/src/Controls/tests/UITests/Tests/RadioButtonUITests.cs
+++ b/src/Controls/tests/UITests/Tests/RadioButtonUITests.cs
@@ -5,13 +5,11 @@ namespace Microsoft.Maui.AppiumTests
 {
 	public class RadioButtonUITests : _ViewUITests
 	{
-		public static readonly string RadioButton = "android.widget.RadioButton";
 		public const string RadioButtonGallery = "* marked:'RadioButton Core Gallery'";
 
 		public RadioButtonUITests(TestDevice device)
 			: base(device)
 		{
-			PlatformViewType = RadioButton;
 		}
 
 		protected override void NavigateToGallery()

--- a/src/Controls/tests/UITests/Tests/_ViewUITests.cs
+++ b/src/Controls/tests/UITests/Tests/_ViewUITests.cs
@@ -5,58 +5,14 @@ using NUnit.Framework;
 
 namespace Microsoft.Maui.AppiumTests
 {
-	public abstract class _ViewUITests : UITestBase
+	public abstract class _ViewUITests : CoreGalleryBasePageTest
 	{
-		public string? PlatformViewType { get; protected set; }
-
 		public _ViewUITests(TestDevice device) : base(device) { }
-
-		protected override void FixtureSetup()
-		{
-			int retries = 0;
-			while (true)
-			{
-				try
-				{
-					base.FixtureSetup();
-					NavigateToGallery();
-					break;
-				}
-				catch (Exception e)
-				{
-					TestContext.Error.WriteLine($">>>>> The FixtureSetup threw an exception. Attempt {retries}/{SetupMaxRetries}.{Environment.NewLine}Exception details: {e}");
-					if (retries++ < SetupMaxRetries)
-					{
-						Reset();
-					}
-					else
-					{
-						throw;
-					}
-				}
-			}
-		}
-
-		protected override void FixtureTeardown()
-		{
-			base.FixtureTeardown();
-			try
-			{
-				App.NavigateBack();
-			}
-			catch (Exception e)
-			{
-				var name = TestContext.CurrentContext.Test.MethodName ?? TestContext.CurrentContext.Test.Name;
-				TestContext.Error.WriteLine($">>>>> The FixtureTeardown threw an exception during {name}.{Environment.NewLine}Exception details: {e}");
-			}
-		}
-
-		protected abstract void NavigateToGallery();
 
 		[Test]
 		public virtual void _IsEnabled()
 		{
-			var remote = new StateViewContainerRemote(UITestContext, Test.VisualElement.IsEnabled, PlatformViewType);
+			var remote = new StateViewContainerRemote(UITestContext, Test.VisualElement.IsEnabled);
 			remote.GoTo();
 
 			var enabled = remote.GetProperty<bool>(View.IsEnabledProperty);
@@ -81,7 +37,7 @@ namespace Microsoft.Maui.AppiumTests
 		[Test]
 		public virtual void _IsVisible()
 		{
-			var remote = new StateViewContainerRemote(UITestContext, Test.VisualElement.IsVisible, PlatformViewType);
+			var remote = new StateViewContainerRemote(UITestContext, Test.VisualElement.IsVisible);
 			remote.GoTo();
 
 			var viewPre = remote.GetViews();

--- a/src/Controls/tests/UITests/ViewContainers/BaseViewContainerRemote.cs
+++ b/src/Controls/tests/UITests/ViewContainers/BaseViewContainerRemote.cs
@@ -23,7 +23,12 @@ namespace Microsoft.Maui.AppiumTests
 
 		protected IUITestContext _uiTestContext;
 
-		protected BaseViewContainerRemote(IUITestContext? testContext, Enum formsType, string? platformViewType)
+		protected BaseViewContainerRemote(IUITestContext? testContext, Enum formsType)
+			: this(testContext, formsType.ToString())
+		{
+		}
+
+		protected BaseViewContainerRemote(IUITestContext? testContext, string formsType)
 		{
 			_uiTestContext = testContext ?? throw new ArgumentNullException(nameof(testContext));
 			App = testContext.App;

--- a/src/Controls/tests/UITests/ViewContainers/EventViewContainerRemote.cs
+++ b/src/Controls/tests/UITests/ViewContainers/EventViewContainerRemote.cs
@@ -5,8 +5,13 @@ namespace Microsoft.Maui.AppiumTests
 {
 	internal sealed class EventViewContainerRemote : BaseViewContainerRemote
 	{
-		public EventViewContainerRemote(IUITestContext? testContext, Enum formsType, string? platformViewType)
-			: base(testContext, formsType, platformViewType)
+		public EventViewContainerRemote(IUITestContext? testContext, string formsType)
+			: base(testContext, formsType)
+		{
+		}
+
+		public EventViewContainerRemote(IUITestContext? testContext, Enum formsType)
+			: base(testContext, formsType)
 		{
 		}
 

--- a/src/Controls/tests/UITests/ViewContainers/StateViewContainerRemote.cs
+++ b/src/Controls/tests/UITests/ViewContainers/StateViewContainerRemote.cs
@@ -5,8 +5,8 @@ namespace Microsoft.Maui.AppiumTests
 {
 	internal sealed class StateViewContainerRemote : BaseViewContainerRemote
 	{
-		public StateViewContainerRemote(IUITestContext? testContext, Enum formsType, string? platformViewType)
-			: base(testContext, formsType, platformViewType)
+		public StateViewContainerRemote(IUITestContext? testContext, Enum formsType)
+			: base(testContext, formsType)
 		{
 		}
 


### PR DESCRIPTION
### Description of Change

This PR extracts the core idea of a "gallery" and makes it usable for non-one-element tests. I will be adding some input transparency tests and I can leverage this a fair bit.

An example usgae:

```cs
internal class InputTransparencyGalleryPage : CoreGalleryBasePage
{
    protected override void Build()
    {
        Add(Test.Thing1, new ViewContainer(<test here>));
        Add(Test.Thing2, new ViewContainer(<test here>));
    }
}
```

```cs
public class InputTransparencyGalleryTests : CoreGalleryBasePageTest
{
    const string ButtonGallery = "* marked:'Input Transparency Gallery'";

    public InputTransparencyGalleryTests(TestDevice device)
        : base(device)
    {
    }

    protected override void NavigateToGallery() =>
        App.NavigateToGallery(ButtonGallery);

    [Test]
    public void Thing1()
    {
        // ui test code
    }
    [Test]
    public void Thing2()
    {
        // ui test code
    }
}
```