### PR TITLE
Enable .NET 7 <MauiVersion> to work in .NET 8 SDK projects

### DIFF
--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/BaseBuildTest.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/BaseBuildTest.cs
@@ -6,6 +6,9 @@ namespace Microsoft.Maui.IntegrationTests
 		public const string DotNetCurrent = "net8.0";
 		public const string DotNetPrevious = "net7.0";
 
+		public const string MauiVersionCurrent = "8.0.0-rc.1.9171"; // this should not be the same as the last release
+		public const string MauiVersionPrevious = "7.0.86"; // this should not be the same version as the default. aka: MicrosoftMauiPreviousDotNetReleasedVersion in eng/Versions.props
+
 		char[] invalidChars = { '{', '}', '(', ')', '$', ':', ';', '\"', '\'', ',', '=', '.', '-', };
 
 		public string TestName

--- a/src/Workload/Microsoft.NET.Sdk.Maui/WorkloadManifest.in.targets
+++ b/src/Workload/Microsoft.NET.Sdk.Maui/WorkloadManifest.in.targets
@@ -40,21 +40,21 @@
   <ItemGroup Condition=" $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '@MAUI_PREVIOUS_DOTNET_VERSION@')) and ('$(SkipMauiWorkloadManifest)' != 'true') ">
     <KnownFrameworkReference
         Update="Microsoft.Maui.Core"
-        DefaultRuntimeFrameworkVersion="@MAUI_PREVIOUS_DOTNET_RELEASED_NUGET_VERSION@"
-        LatestRuntimeFrameworkVersion="@MAUI_PREVIOUS_DOTNET_RELEASED_NUGET_VERSION@"
-        TargetingPackVersion="@MAUI_PREVIOUS_DOTNET_RELEASED_NUGET_VERSION@"
+        DefaultRuntimeFrameworkVersion="$(MauiVersion)"
+        LatestRuntimeFrameworkVersion="$(MauiVersion)"
+        TargetingPackVersion="$(MauiVersion)"
     />
     <KnownFrameworkReference
         Update="Microsoft.Maui.Controls"
-        DefaultRuntimeFrameworkVersion="@MAUI_PREVIOUS_DOTNET_RELEASED_NUGET_VERSION@"
-        LatestRuntimeFrameworkVersion="@MAUI_PREVIOUS_DOTNET_RELEASED_NUGET_VERSION@"
-        TargetingPackVersion="@MAUI_PREVIOUS_DOTNET_RELEASED_NUGET_VERSION@"
+        DefaultRuntimeFrameworkVersion="$(MauiVersion)"
+        LatestRuntimeFrameworkVersion="$(MauiVersion)"
+        TargetingPackVersion="$(MauiVersion)"
     />
     <KnownFrameworkReference
         Update="Microsoft.Maui.Essentials"
-        DefaultRuntimeFrameworkVersion="@MAUI_PREVIOUS_DOTNET_RELEASED_NUGET_VERSION@"
-        LatestRuntimeFrameworkVersion="@MAUI_PREVIOUS_DOTNET_RELEASED_NUGET_VERSION@"
-        TargetingPackVersion="@MAUI_PREVIOUS_DOTNET_RELEASED_NUGET_VERSION@"
+        DefaultRuntimeFrameworkVersion="$(MauiVersion)"
+        LatestRuntimeFrameworkVersion="$(MauiVersion)"
+        TargetingPackVersion="$(MauiVersion)"
     />
   </ItemGroup>
 


### PR DESCRIPTION
### Description of Change

For .NET 7, we had MauiVersion as a way to control the version of maui to use. When we moved to .NET 8, this still works - but for the .NET 8 workload.

However, if you have a .NET 8 SDK and use a .NET 7 TFM, the MauiVersion still only applies to .NET 8.

This PR makes it work again for .NET 7 TFMs on a .NET 8 SDK. My initial fears of a .NET 7 MauiVersion breaking the .NET 8 workload were unfounded as the .NET 7 TFM only loads the .NET 7 maui targets - this means that when you set a number, it still only affects the .NET 7 maui. The reverse is also true, the build still works with this change because the block to load the .NET 7 framework references only applies to .NET 7 and thus will not load accidentally.

If you use a .NET 8 number for a .NET 7 TFM, the compiler complains that there are missing packs and thins is expected - there is no .NET 7 maui workload SDK for .NET 8 TFMs. 