### PR TITLE
Add .editorconfig to Core for specifying CA rules

### DIFF
--- a/src/Core/src/.editorconfig
+++ b/src/Core/src/.editorconfig
@@ -1,5 +1,6 @@
 # Enforce performance code analyzers
 # We can gradually add to this list until we're ready to activate enforcement
 # for the entire project
+# To run the performance CA on all files, replace the list of files with [*.cs]
 [{Flex.cs,PlatformTouchGraphicsView.cs}]
 dotnet_analyzer_diagnostic.category-Performance.severity = warning

--- a/src/Core/src/.editorconfig
+++ b/src/Core/src/.editorconfig
@@ -1,0 +1,5 @@
+# Enforce performance code analyzers
+# We can gradually add to this list until we're ready to activate enforcement
+# for the entire project
+[{Flex.cs,PlatformTouchGraphicsView.cs}]
+dotnet_analyzer_diagnostic.category-Performance.severity = warning

--- a/src/Core/src/Layouts/Flex.cs
+++ b/src/Core/src/Layouts/Flex.cs
@@ -198,7 +198,7 @@ namespace Microsoft.Maui.Layouts.Flex
 		/// <summary>
 		/// Auto basis.
 		/// </summary>
-		public static Basis Auto = new Basis();
+		public static Basis Auto;
 		/// <summary>
 		/// Whether the basis length is relative to parent's size.
 		/// </summary>
@@ -274,7 +274,7 @@ namespace Microsoft.Maui.Layouts.Flex
 		/// <summary>This property defines the grow factor of the item; the amount of available space it should use on the main-axis. If this property is set to 0, the item will not grow.</summary>
 		/// <value>The item grow factor.</value>
 		/// <remarks>The default value for this property is 0 (does not take any available space).</remarks>
-		public float Grow { get; set; } = 0f;
+		public float Grow { get; set; }
 
 		/// <summary>This property defines the height size dimension of the item.</summary>
 		/// <value>The height size dimension.</value>
@@ -296,22 +296,22 @@ namespace Microsoft.Maui.Layouts.Flex
 		/// <summary>This property defines the margin space required on the bottom edge of the item.</summary>
 		/// <value>The top edge margin space (negative values are allowed).</value>
 		/// <remarks>The default value for this property is 0.</remarks>
-		public float MarginBottom { get; set; } = 0f;
+		public float MarginBottom { get; set; } 
 
 		/// <summary>This property defines the margin space required on the left edge of the item.</summary>
 		/// <value>The top edge margin space (negative values are allowed).</value>
 		/// <remarks>The default value for this property is 0.</remarks>
-		public float MarginLeft { get; set; } = 0f;
+		public float MarginLeft { get; set; } 
 
 		/// <summary>This property defines the margin space required on the right edge of the item.</summary>
 		/// <value>The top edge margin space (negative values are allowed).</value>
 		/// <remarks>The default value for this property is 0.</remarks>
-		public float MarginRight { get; set; } = 0f;
+		public float MarginRight { get; set; } 
 
 		/// <summary>This property defines the margin space required on the top edge of the item.</summary>
 		/// <value>The top edge margin space (negative values are allowed).</value>
 		/// <remarks>The default value for this property is 0.</remarks>
-		public float MarginTop { get; set; } = 0f;
+		public float MarginTop { get; set; }
 
 		int order;
 
@@ -330,19 +330,19 @@ namespace Microsoft.Maui.Layouts.Flex
 
 		/// <summary>This property defines the height of the item's bottom edge padding space that should be used when laying out child items.</summary>
 		/// <value>The bottom edge padding space.Negative values are not allowed.</value>
-		public float PaddingBottom { get; set; } = 0f;
+		public float PaddingBottom { get; set; } 
 
 		/// <summary>This property defines the height of the item's left edge padding space that should be used when laying out child items.</summary>
 		/// <value>The bottom edge padding space.Negative values are not allowed.</value>
-		public float PaddingLeft { get; set; } = 0f;
+		public float PaddingLeft { get; set; } 
 
 		/// <summary>This property defines the height of the item's right edge padding space that should be used when laying out child items.</summary>
 		/// <value>The bottom edge padding space.Negative values are not allowed.</value>
-		public float PaddingRight { get; set; } = 0f;
+		public float PaddingRight { get; set; } 
 
 		/// <summary>This property defines the height of the item's top edge padding space that should be used when laying out child items.</summary>
 		/// <value>The bottom edge padding space.Negative values are not allowed.</value>
-		public float PaddingTop { get; set; } = 0f;
+		public float PaddingTop { get; set; } 
 
 		/// <summary>This property defines whether the item should be positioned by the flexbox rules of the layout engine(Relative) or have an absolute fixed position (Absolute). If this property is set to Absolute, the<see cref="P:Microsoft.Maui.Controls.Flex.Item.Left" />, <see cref = "P:Microsoft.Maui.Controls.Flex.Item.Right" />, <see cref = "P:Microsoft.Maui.Controls.Flex.Item.Top" /> and <see cref= "P:Microsoft.Maui.Controls.Flex.Item.Bottom" /> properties will then be used to determine the item's fixed position in its container.</summary>
 		/// <value>Any value part of the<see cref="T:Microsoft.Maui.Controls.Flex.Position" /> enumeration.</value>

--- a/src/Core/src/Platform/Android/PlatformTouchGraphicsView.cs
+++ b/src/Core/src/Platform/Android/PlatformTouchGraphicsView.cs
@@ -13,9 +13,9 @@ namespace Microsoft.Maui.Platform
 		IGraphicsView? _graphicsView;
 		RectF _bounds;
 		bool _dragStarted;
-		PointF[] _lastMovedViewPoints = new PointF[0];
+		PointF[] _lastMovedViewPoints = Array.Empty<PointF>();
 		float _scale = 1;
-		bool _pressedContained = false;
+		bool _pressedContained;
 
 		public PlatformTouchGraphicsView(Context context) : base(context)
 		{

--- a/src/Core/src/Platform/Tizen/PlatformTouchGraphicsView.cs
+++ b/src/Core/src/Platform/Tizen/PlatformTouchGraphicsView.cs
@@ -10,8 +10,8 @@ namespace Microsoft.Maui.Platform
 		IGraphicsView? _graphicsView;
 		RectF _bounds;
 		bool _dragStarted;
-		PointF[] _lastMovedViewPoints = new PointF[0];
-		bool _pressedContained = false;
+		PointF[] _lastMovedViewPoints = Array.Empty<PointF>();
+		bool _pressedContained;
 
 		public PlatformTouchGraphicsView(IDrawable? drawable = null) : base(drawable)
 		{

--- a/src/Core/src/Platform/Windows/PlatformTouchGraphicsView.cs
+++ b/src/Core/src/Platform/Windows/PlatformTouchGraphicsView.cs
@@ -10,8 +10,8 @@ namespace Microsoft.Maui.Platform
 	{
 		IGraphicsView? _graphicsView;
 		readonly W2DGraphicsView _platformGraphicsView;
-		bool _isTouching = false;
-		bool _isInBounds = false;
+		bool _isTouching;
+		bool _isInBounds;
 
 		public PlatformTouchGraphicsView()
 		{

--- a/src/Core/src/Platform/iOS/PlatformTouchGraphicsView.cs
+++ b/src/Core/src/Platform/iOS/PlatformTouchGraphicsView.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Maui.Platform
 		[UnconditionalSuppressMessage("Memory", "MA0002", Justification = "Proven safe in test: MemoryTests.HandlerDoesNotLeak")]
 		UIHoverGestureRecognizer? _hoverGesture;
 		RectF _rect;
-		bool _pressedContained = false;
+		bool _pressedContained;
 
 		public PlatformTouchGraphicsView()
 		{


### PR DESCRIPTION
## Description of Change

For various reasons, the default code analysis rules have never been fully enforced in this repository. We would like to change that, but turning on all the rules for all projects at once is simply not an option with our current resources. 

As an alternative, we can incrementally being enforcing these rules per-project, per-category, per-rule, and per-file via `.editorconfig`. 

While it's tempting to mass-fix violations for a particular rule or category, doing so may generate changes across dozens or even hundreds of files at once. This makes for confusing change histories and conflicts. Instead, we can fix violations in smaller, easily reviewed subsets and prevent future violations in those areas using `.editorconfig`. By doing this incrementally, we can ratchet up the level of enforcement until we can turn it on for entire projects. 

This change adds CA performance rule enforcement for Flex and PlatformTouchGraphicsView.
