### PR TITLE
Cleanup SwipeView and Propagate BC until we can fix compat layout

### DIFF
--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -194,7 +194,6 @@ Microsoft.Maui.Controls.PlatformPointerEventArgs
 Microsoft.Maui.Controls.PlatformPointerEventArgs.MotionEvent.get -> Android.Views.MotionEvent!
 Microsoft.Maui.Controls.PlatformPointerEventArgs.Sender.get -> Android.Views.View!
 *REMOVED*override Microsoft.Maui.Controls.SwipeItems.OnBindingContextChanged() -> void
-*REMOVED*override Microsoft.Maui.Controls.SwipeView.OnBindingContextChanged() -> void
 ~static readonly Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTappedProperty -> Microsoft.Maui.Controls.BindableProperty
 Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTapped.get -> bool
 Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTapped.set -> void

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -210,7 +210,6 @@ Microsoft.Maui.Controls.ShellNavigationQueryParameters.Values.get -> System.Coll
 *REMOVED*~Microsoft.Maui.Controls.Shell.AddLogicalChild(Microsoft.Maui.Controls.Element element) -> void
 *REMOVED*~Microsoft.Maui.Controls.Shell.RemoveLogicalChild(Microsoft.Maui.Controls.Element element) -> void
 *REMOVED*override Microsoft.Maui.Controls.SwipeItems.OnBindingContextChanged() -> void
-*REMOVED*override Microsoft.Maui.Controls.SwipeView.OnBindingContextChanged() -> void
 ~static readonly Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTappedProperty -> Microsoft.Maui.Controls.BindableProperty
 Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTapped.get -> bool
 Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTapped.set -> void

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -210,7 +210,6 @@ Microsoft.Maui.Controls.PlatformPointerEventArgs
 Microsoft.Maui.Controls.PlatformPointerEventArgs.GestureRecognizer.get -> UIKit.UIGestureRecognizer!
 Microsoft.Maui.Controls.PlatformPointerEventArgs.Sender.get -> UIKit.UIView!
 *REMOVED*override Microsoft.Maui.Controls.SwipeItems.OnBindingContextChanged() -> void
-*REMOVED*override Microsoft.Maui.Controls.SwipeView.OnBindingContextChanged() -> void
 ~static readonly Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTappedProperty -> Microsoft.Maui.Controls.BindableProperty
 Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTapped.get -> bool
 Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTapped.set -> void

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -169,7 +169,6 @@ Microsoft.Maui.Controls.Element.ClearLogicalChildren() -> void
 Microsoft.Maui.Controls.PointerEventArgs.PlatformArgs.get -> Microsoft.Maui.Controls.PlatformPointerEventArgs?
 Microsoft.Maui.Controls.PlatformPointerEventArgs
 *REMOVED*override Microsoft.Maui.Controls.SwipeItems.OnBindingContextChanged() -> void
-*REMOVED*override Microsoft.Maui.Controls.SwipeView.OnBindingContextChanged() -> void
 Microsoft.Maui.Controls.Handlers.Compatibility.ViewRenderer<TElement, TPlatformView>.ViewRenderer(Microsoft.Maui.IPropertyMapper! mapper, Microsoft.Maui.CommandMapper? commandMapper = null) -> void
 Microsoft.Maui.Controls.Handlers.Compatibility.VisualElementRenderer<TElement>.VisualElementRenderer(Microsoft.Maui.IPropertyMapper! mapper, Microsoft.Maui.CommandMapper? commandMapper = null) -> void
 ~static readonly Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTappedProperty -> Microsoft.Maui.Controls.BindableProperty

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -206,7 +206,6 @@ Microsoft.Maui.Controls.PlatformPointerEventArgs
 Microsoft.Maui.Controls.PlatformPointerEventArgs.PointerRoutedEventArgs.get -> Microsoft.UI.Xaml.Input.PointerRoutedEventArgs!
 Microsoft.Maui.Controls.PlatformPointerEventArgs.Sender.get -> Microsoft.UI.Xaml.FrameworkElement!
 *REMOVED*override Microsoft.Maui.Controls.SwipeItems.OnBindingContextChanged() -> void
-*REMOVED*override Microsoft.Maui.Controls.SwipeView.OnBindingContextChanged() -> void
 ~static readonly Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTappedProperty -> Microsoft.Maui.Controls.BindableProperty
 Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTapped.get -> bool
 Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTapped.set -> void

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -171,7 +171,6 @@ Microsoft.Maui.Controls.ShellNavigationQueryParameters.Values.get -> System.Coll
 Microsoft.Maui.Controls.PointerEventArgs.PlatformArgs.get -> Microsoft.Maui.Controls.PlatformPointerEventArgs?
 Microsoft.Maui.Controls.PlatformPointerEventArgs
 *REMOVED*override Microsoft.Maui.Controls.SwipeItems.OnBindingContextChanged() -> void
-*REMOVED*override Microsoft.Maui.Controls.SwipeView.OnBindingContextChanged() -> void
 *REMOVED*~Microsoft.Maui.Controls.Editor.FontFamily.get -> string
 *REMOVED*~Microsoft.Maui.Controls.Editor.FontFamily.set -> void
 *REMOVED*Microsoft.Maui.Controls.Editor.CursorPosition.get -> int

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -168,7 +168,6 @@ Microsoft.Maui.Controls.IValueConverter.ConvertBack(object? value, System.Type! 
 Microsoft.Maui.Controls.PointerEventArgs.PlatformArgs.get -> Microsoft.Maui.Controls.PlatformPointerEventArgs?
 Microsoft.Maui.Controls.PlatformPointerEventArgs
 *REMOVED*override Microsoft.Maui.Controls.SwipeItems.OnBindingContextChanged() -> void
-*REMOVED*override Microsoft.Maui.Controls.SwipeView.OnBindingContextChanged() -> void
 ~static readonly Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTappedProperty -> Microsoft.Maui.Controls.BindableProperty
 Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTapped.get -> bool
 Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTapped.set -> void

--- a/src/Controls/src/Core/SwipeView/SwipeItems.cs
+++ b/src/Controls/src/Core/SwipeView/SwipeItems.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.Linq;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Maui.Controls
 {
@@ -18,7 +19,10 @@ namespace Microsoft.Maui.Controls
 		{
 			foreach (var item in swipeItems)
 				if (item is Element e)
+				{
+					CheckParent(e);
 					AddLogicalChild(e);
+				}
 
 			_swipeItems = new ObservableCollection<Maui.ISwipeItem>(swipeItems) ?? throw new ArgumentNullException(nameof(swipeItems));
 			_swipeItems.CollectionChanged += OnSwipeItemsChanged;
@@ -106,7 +110,7 @@ namespace Microsoft.Maui.Controls
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/SwipeItems.xml" path="//Member[@MemberName='Insert']/Docs/*" />
 		public void Insert(int index, ISwipeItem item)
-		{
+		{			
 			_swipeItems.Insert(index, item);
 		}
 
@@ -128,7 +132,10 @@ namespace Microsoft.Maui.Controls
 			{
 				foreach (var item in notifyCollectionChangedEventArgs.NewItems)
 					if (item is Element e)
+					{
+						CheckParent(e);
 						AddLogicalChild(e);
+					}
 			}
 
 			if (notifyCollectionChangedEventArgs.OldItems is not null)
@@ -144,6 +151,19 @@ namespace Microsoft.Maui.Controls
 		IEnumerator IEnumerable.GetEnumerator()
 		{
 			return _swipeItems.GetEnumerator();
+		}
+
+		// If a SwipeItem occupies multiple SwipeItems, we only want the logical hierarchy
+		// to wire up to the SwipeItems that are currently part of a SwipeView.
+		// We could throw an exception here but that would be too hostile of a breaking behavior.
+		// TODO NET9 This warning should probably be elevated to `Element` for NET9
+		void CheckParent(Element e)
+		{
+			if (e.Parent is not null && e.Parent != this)
+			{
+				this.CreateLogger<SwipeItems>()
+					?.LogWarning($"{e} is already part of {e.Parent}. Remove from {e.Parent} to avoid inconsistent behavior.");
+			}
 		}
 	}
 }

--- a/src/Controls/src/Core/SwipeView/SwipeView.cs
+++ b/src/Controls/src/Core/SwipeView/SwipeView.cs
@@ -100,6 +100,11 @@ namespace Microsoft.Maui.Controls
 		{
 			List<Maui.IVisualTreeElement> elements = new List<IVisualTreeElement>();
 
+			// I realize we are adding these all via AddLogicalChild but the base Compatibility.Layout
+			// Implements IVisualTreeElement.GetVisualChildren() and ruins that so we need to explicitly
+			// implement IVTE so we can collect up all the logical children for IVTE
+			// This is required for hot reload and live visual tree to work as well
+
 			elements.Add(LeftItems);
 			elements.Add(RightItems);
 			elements.Add(TopItems);

--- a/src/Controls/src/Core/SwipeView/SwipeView.cs
+++ b/src/Controls/src/Core/SwipeView/SwipeView.cs
@@ -22,6 +22,13 @@ namespace Microsoft.Maui.Controls
 
 			// This just disables any of the legacy layout code from running
 			DisableLayout = true;
+
+			// SwipeItems is an Element so it participates in the Visual Hierarchy.
+			// This is why we add each set of items to the logical children of swipeview
+			AddLogicalChild(RightItems);
+			AddLogicalChild(LeftItems);
+			AddLogicalChild(TopItems);
+			AddLogicalChild(BottomItems);
 		}
 
 		/// <summary>Bindable property for <see cref="Threshold"/>.</summary>
@@ -127,12 +134,14 @@ namespace Microsoft.Maui.Controls
 			{
 				oldItems.CollectionChanged -= SwipeItemsCollectionChanged;
 				oldItems.PropertyChanged -= SwipeItemsPropertyChanged;
+				swipeView.RemoveLogicalChild(oldItems);
 			}
 
 			if (newValue is SwipeItems newItems)
 			{
 				newItems.CollectionChanged += SwipeItemsCollectionChanged;
 				newItems.PropertyChanged += SwipeItemsPropertyChanged;
+				swipeView.AddLogicalChild(newItems);
 			}
 
 			void SwipeItemsPropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/src/Controls/src/Core/SwipeView/SwipeView.cs
+++ b/src/Controls/src/Core/SwipeView/SwipeView.cs
@@ -2,12 +2,14 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
+using System.Xml.Linq;
 
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/SwipeView.xml" path="Type[@FullName='Microsoft.Maui.Controls.SwipeView']/Docs/*" />
 	[ContentProperty(nameof(Content))]
-	public partial class SwipeView : ContentView, IElementConfiguration<SwipeView>, ISwipeViewController, ISwipeView
+	public partial class SwipeView : ContentView, IElementConfiguration<SwipeView>, ISwipeViewController, ISwipeView, IVisualTreeElement
 	{
 		readonly Lazy<PlatformConfigurationRegistry<SwipeView>> _platformConfigurationRegistry;
 
@@ -21,6 +23,8 @@ namespace Microsoft.Maui.Controls
 			// This just disables any of the legacy layout code from running
 			DisableLayout = true;
 
+			// SwipeItems is an Element so it participates in the Visual Hierarchy.
+			// This is why we add each set of items to the logical children of swipeview
 			AddLogicalChild(RightItems);
 			AddLogicalChild(LeftItems);
 			AddLogicalChild(TopItems);
@@ -92,6 +96,42 @@ namespace Microsoft.Maui.Controls
 			set => ((ISwipeView)this).IsOpen = value;
 		}
 
+		IReadOnlyList<Maui.IVisualTreeElement> IVisualTreeElement.GetVisualChildren()
+		{
+			List<Maui.IVisualTreeElement> elements = new List<IVisualTreeElement>();
+			LeftItems.ForEach(OnAdd);
+			RightItems.ForEach(OnAdd);
+			TopItems.ForEach(OnAdd);
+			BottomItems.ForEach(OnAdd);
+
+			void OnAdd(ISwipeItem item)
+			{
+				if (item is IVisualTreeElement vte)
+				{
+					elements.Add(vte);
+				}
+			}
+
+			foreach(var item in InternalChildren)
+			{
+				if (item is IVisualTreeElement vte)
+				{
+					elements.Add(vte);
+				}
+			}
+
+			return elements;
+		}
+
+		protected override void OnBindingContextChanged()
+		{
+			base.OnBindingContextChanged();
+			SetInheritedBindingContext(LeftItems, BindingContext);
+			SetInheritedBindingContext(RightItems, BindingContext);
+			SetInheritedBindingContext(TopItems, BindingContext);
+			SetInheritedBindingContext(BottomItems, BindingContext);
+		}
+
 		static void OnSwipeItemsChanged(BindableObject bindable, object oldValue, object newValue)
 		{
 			if (bindable is not SwipeView swipeView)
@@ -115,18 +155,12 @@ namespace Microsoft.Maui.Controls
 			{
 				if (sender is SwipeItems swipeItems)
 					SendChange(swipeItems);
-
-				if (sender is IEnumerable<ISwipeItem> enumerable)
-					SendChange(new SwipeItems(enumerable));
 			}
 
 			void SwipeItemsCollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
 			{
 				if (sender is SwipeItems swipeItems)
 					SendChange(swipeItems);
-
-				if (sender is IEnumerable<ISwipeItem> enumerable)
-					SendChange(new SwipeItems(enumerable));
 			}
 
 			void SendChange(SwipeItems swipeItems)

--- a/src/Controls/src/Core/SwipeView/SwipeView.cs
+++ b/src/Controls/src/Core/SwipeView/SwipeView.cs
@@ -22,13 +22,6 @@ namespace Microsoft.Maui.Controls
 
 			// This just disables any of the legacy layout code from running
 			DisableLayout = true;
-
-			// SwipeItems is an Element so it participates in the Visual Hierarchy.
-			// This is why we add each set of items to the logical children of swipeview
-			AddLogicalChild(RightItems);
-			AddLogicalChild(LeftItems);
-			AddLogicalChild(TopItems);
-			AddLogicalChild(BottomItems);
 		}
 
 		/// <summary>Bindable property for <see cref="Threshold"/>.</summary>
@@ -99,18 +92,11 @@ namespace Microsoft.Maui.Controls
 		IReadOnlyList<Maui.IVisualTreeElement> IVisualTreeElement.GetVisualChildren()
 		{
 			List<Maui.IVisualTreeElement> elements = new List<IVisualTreeElement>();
-			LeftItems.ForEach(OnAdd);
-			RightItems.ForEach(OnAdd);
-			TopItems.ForEach(OnAdd);
-			BottomItems.ForEach(OnAdd);
 
-			void OnAdd(ISwipeItem item)
-			{
-				if (item is IVisualTreeElement vte)
-				{
-					elements.Add(vte);
-				}
-			}
+			elements.Add(LeftItems);
+			elements.Add(RightItems);
+			elements.Add(TopItems);
+			elements.Add(BottomItems);
 
 			foreach(var item in InternalChildren)
 			{
@@ -141,14 +127,12 @@ namespace Microsoft.Maui.Controls
 			{
 				oldItems.CollectionChanged -= SwipeItemsCollectionChanged;
 				oldItems.PropertyChanged -= SwipeItemsPropertyChanged;
-				swipeView.RemoveLogicalChild(oldItems);
 			}
 
 			if (newValue is SwipeItems newItems)
 			{
 				newItems.CollectionChanged += SwipeItemsCollectionChanged;
 				newItems.PropertyChanged += SwipeItemsPropertyChanged;
-				swipeView.AddLogicalChild(newItems);
 			}
 
 			void SwipeItemsPropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/src/Controls/src/Core/ViewExtensions.cs
+++ b/src/Controls/src/Core/ViewExtensions.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Maui.Animations;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Graphics;
@@ -305,6 +306,9 @@ namespace Microsoft.Maui.Controls
 
 			return fallbackToAppMauiContext ? Application.Current?.FindMauiContext() : default;
 		}
+
+		internal static ILogger<T>? CreateLogger<T>(this Element element, bool fallbackToAppMauiContext = true) =>
+			element.FindMauiContext(fallbackToAppMauiContext)?.CreateLogger<T>();
 
 		internal static IFontManager RequireFontManager(this Element element, bool fallbackToAppMauiContext = false)
 			=> element.RequireMauiContext(fallbackToAppMauiContext).Services.GetRequiredService<IFontManager>();

--- a/src/Controls/tests/Core.UnitTests/SwipeViewTests.cs
+++ b/src/Controls/tests/Core.UnitTests/SwipeViewTests.cs
@@ -149,6 +149,44 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact]
+		public void BindingContextTransfersToNewSetOfSwipeItems()
+		{
+			var bc1 = new object();
+			var bc2 = new object();
+			
+			var swipeView = new SwipeView();
+			var leftItems = swipeView.LeftItems;
+			var swipeItem = new SwipeItem();
+			leftItems.Add(swipeItem);
+			swipeView.BindingContext = bc1;
+
+			Assert.Equal(leftItems.BindingContext, bc1);
+			Assert.Equal(swipeItem.BindingContext, bc1);
+
+			Assert.Equal(leftItems, swipeView.LeftItems);
+			Assert.Contains(leftItems, (swipeView as IVisualTreeElement).GetVisualChildren());
+			Assert.Equal(swipeItem, (leftItems as IVisualTreeElement).GetVisualChildren()[0]);
+
+			var leftItems2 = new SwipeItems();
+			leftItems2.Add(swipeItem);
+			swipeView.LeftItems = leftItems2;
+
+			// now that this isn't the logical child of SwipeItems the parent should be null
+			Assert.Null(leftItems.Parent);
+
+			// The parent on swipeItem should now be leftItems2 because that's been set on SwipeView
+			Assert.NotSame(swipeItem.Parent, leftItems);
+			Assert.NotSame(leftItems.Parent, swipeView);
+
+			Assert.Equal(swipeItem.Parent, leftItems2);
+			Assert.Equal(leftItems2.Parent, swipeView);
+
+			swipeView.BindingContext = bc2;
+			Assert.Equal(leftItems2.BindingContext, bc2);
+			Assert.Equal(swipeItem.BindingContext, bc2);
+		}
+
+		[Fact]
 		public void TestDefaultSwipeItems()
 		{
 			var swipeView = new SwipeView();


### PR DESCRIPTION
### Description of Change

Alternative PR for https://github.com/dotnet/maui/pull/17410 to avoid more changes inside the base layout class. 

Code inside SwipeView kept recreating new `SwipeItems` lists which would cause the SwipeItems to re-assign to new `SwipItems` lists instead of the ones that were part of the original xaml. I don't really know why that code was added. It was added in this https://github.com/dotnet/maui/pull/6053 but I tested the issue that PR was for and it works fine with these code changes. The result of that code is that every property change was triggering a new SwipeItems to get instantiated. 

### Issues Fixed

Fixes #17371
