### PR TITLE
Fix DragAndDropCleanupCode

### DIFF
--- a/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.iOS.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.iOS.cs
@@ -101,9 +101,12 @@ namespace Microsoft.Maui.Controls.Platform
 					PlatformView.RemoveInteraction(interaction);
 				}
 			}
+
+			_interactions.Clear();
 			_gestureRecognizers.Clear();
 
 			_dragAndDropDelegate?.Disconnect();
+			_dragAndDropDelegate = null;
 
 			Disconnect();
 
@@ -608,6 +611,7 @@ namespace Microsoft.Maui.Controls.Platform
 					{
 						var interaction = new UIDragInteraction(_dragAndDropDelegate);
 						interaction.Enabled = true;
+						_interactions.Add(interaction);
 						PlatformView.AddInteraction(interaction);
 					}
 				}
@@ -619,10 +623,12 @@ namespace Microsoft.Maui.Controls.Platform
 					if (uIDropInteraction == null && PlatformView != null)
 					{
 						var interaction = new UIDropInteraction(_dragAndDropDelegate);
+						_interactions.Add(interaction);
 						PlatformView.AddInteraction(interaction);
 					}
 				}
 			}
+
 			if (OperatingSystem.IsIOSVersionAtLeast(11))
 			{
 				if (!dragFound && uIDragInteraction != null && PlatformView != null)


### PR DESCRIPTION
### Description of Change

https://github.com/dotnet/maui/pull/17282 introduced some cleanup code of the gesture delegate. This revealed that the cleanup code for the DragAndDropRecognizer wasn't correctly removing all of the UIInteractions when disposing of the GesturePlatformManager
