### PR TITLE
[net7.0] "Revert default for UseSafeAreaProperty to value from .NET 6 for iOS

### DIFF
--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/Page.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/Page.cs
@@ -71,11 +71,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 		}
 
 		/// <summary>Bindable property for attached property <c>UseSafeArea</c>.</summary>
-#if MACCATALYST
 		public static readonly BindableProperty UseSafeAreaProperty = BindableProperty.Create("UseSafeArea", typeof(bool), typeof(Page), true);
-#else
-		public static readonly BindableProperty UseSafeAreaProperty = BindableProperty.Create("UseSafeArea", typeof(bool), typeof(Page), false);
-#endif
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Page.xml" path="//Member[@MemberName='GetUseSafeArea']/Docs/*" />
 		public static bool GetUseSafeArea(BindableObject element)

--- a/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.cs
@@ -58,11 +58,7 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
-#if IOS
-		[Theory(Skip = "Test doesn't work on iOS yet; probably because of https://github.com/dotnet/maui/issues/10591")]
-#else
 		[Theory]
-#endif
 #if ANDROID
 		[InlineData(true)]
 #endif


### PR DESCRIPTION
### Description of Change

This reverts commit d47c215f96823871264cbfdba992ff6a601c7130.
