### PR TITLE
Fix for #11991 - CollectionView SelectedItem BackgroundColor is always Gray on iOS

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/iOS/TemplatedCell.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/TemplatedCell.cs
@@ -153,16 +153,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				// emit a bunch of needless binding errors
 				itemsView.AddLogicalChild(view);
 
-				// Prevents the use of default color when there are VisualStateManager with Selected state setting the background color
-				// First we check whether the cell has the default selected background color; if it does, then we should check
-				// to see if the cell content is the VSM to set a selected color 
-				if (SelectedBackgroundView.BackgroundColor == Maui.Platform.ColorExtensions.Gray && IsUsingVSMForSelectionColor(view))
-				{
-					SelectedBackgroundView = new UIView
-					{
-						BackgroundColor = UIColor.Clear
-					};
-				}
+				UpdateSelectionColor(view);
 			}
 			else
 			{
@@ -257,6 +248,12 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				base.Selected = value;
 
 				UpdateVisualStates();
+
+				if (base.Selected)
+				{
+					// This must be called here otherwise the first item will have a gray background
+					UpdateSelectionColor();
+				}
 			}
 		}
 
@@ -314,6 +311,28 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				VisualStateManager.GoToState(element, Selected
 					? VisualStateManager.CommonStates.Selected
 					: VisualStateManager.CommonStates.Normal);
+			}
+		}
+
+		void UpdateSelectionColor()
+		{
+			if (PlatformHandler.VirtualView is not View view)
+			{
+				return;
+			}
+
+			UpdateSelectionColor(view);
+		}
+
+		void UpdateSelectionColor(View view)
+		{
+			// Prevents the use of default color when there are VisualStateManager with Selected state setting the background color
+			// First we check whether the cell has the default selected background color; if it does, then we should check
+			// to see if the cell content is the VSM to set a selected color
+
+			if (ColorExtensions.AreEqual(SelectedBackgroundView.BackgroundColor, ColorExtensions.Gray) && IsUsingVSMForSelectionColor(view))
+			{
+				SelectedBackgroundView.BackgroundColor = UIColor.Clear;
 			}
 		}
 	}

--- a/src/Core/src/Platform/iOS/ColorExtensions.cs
+++ b/src/Core/src/Platform/iOS/ColorExtensions.cs
@@ -170,5 +170,18 @@ namespace Microsoft.Maui.Platform
 
 		public static UIColor ToPlatform(this Color? color, UIColor defaultColor)
 			=> color?.ToPlatform() ?? defaultColor;
+
+		internal static bool AreEqual(UIColor a, UIColor b)
+		{
+			a.GetRGBA(out nfloat aRed, out nfloat aGreen, out nfloat aBlue, out nfloat aAlpha);
+			b.GetRGBA(out nfloat bRed, out nfloat bGreen, out nfloat bBlue, out nfloat bAlpha);
+
+			var redMatches = aRed == bRed;
+			var greenMatches = aGreen == bGreen;
+			var blueMatches = aBlue == bBlue;
+			var alphaMatches = aAlpha == bAlpha;
+
+			return redMatches && greenMatches && blueMatches && alphaMatches;
+		}
 	}
 }


### PR DESCRIPTION
### Description of Change

See #11991

This issue has been incredibly annoying when working with `CollectionView` making many designs look bad because of the lack of color customizability. I originally looked into using handlers to fix this issue but when it became apparent this couldn't be worked around I investigated the root cause of the issue.

The root cause was when applying the selected item color via VSM, the check to clear the default gray color always failed because `UIColor` check always returned false. I have added a more robust way of checking `UIColor` equivalence (by comparing RGBA values), this fixed 90% of this issue.

I noticed after applying the fix to the color compare, the first item in the collection **always** had a gray background. The only way i could fix this was by adding an extra check whenever the selection changed to clear the color (when VSM is set), this fully fixes the issue and the behavior can be seen below.

| Before                                                                                                   | After                                                                                                   |
|----------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------|
| ![bugged selection](https://github.com/dotnet/maui/assets/33064621/445959d1-e997-4527-a8ac-2889612d9cfc) | ![fixed selection](https://github.com/dotnet/maui/assets/33064621/3a6811fb-7d44-465a-97ce-9475de7082d1) |

I am open to any feedback on this although I may need some help as it takes ~10-15 mins to build & deploy any changes to test on my machine 🙈

### Issues Fixed

- fixes #11991 