### PR TITLE
[Windows] Show the Raw HTML for Html Label in case of error

### DIFF
--- a/src/Controls/samples/Controls.Sample.UITests/Elements/LabelCoreGalleryPage.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/Elements/LabelCoreGalleryPage.cs
@@ -275,6 +275,16 @@ internal class LabelCoreGalleryPage : CoreGalleryPage<Label>
 		{
 			var label = new Label
 			{
+				Text = "<h1>Broken Html!<h1>",
+				TextType = TextType.Html
+			};
+			var htmlLabelContainer = new ViewContainer<Label>(Test.Label.BrokenHtmlTextType, label);
+			Add(htmlLabelContainer);
+		}
+
+		{
+			var label = new Label
+			{
 				Text = "<h1>Hello world!</h1><p>Lorem <strong>ipsum</strong> bla di bla <i>blabla</i> blablabl&nbsp;ablabla & blablablablabl ablabl ablablabl ablablabla blablablablablablab lablablabla blablab lablablabla blablabl ablablablab lablabla blab lablablabla blablab lablabla blablablablab lablabla blablab lablablabl ablablabla blablablablablabla blablabla</p>",
 				TextType = TextType.Html,
 				MaxLines = 3

--- a/src/Controls/samples/Controls.Sample.UITests/Test.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/Test.cs
@@ -472,6 +472,7 @@
 			VerticalTextAlignmentEnd,
 			MaxLines,
 			HtmlTextType,
+			BrokenHtmlTextType,
 			HtmlTextTypeMultipleLines,
 			HtmlTextLabelProperties,
 			TextTypeToggle,

--- a/src/Core/src/Platform/Windows/TextBlockExtensions.cs
+++ b/src/Core/src/Platform/Windows/TextBlockExtensions.cs
@@ -119,7 +119,7 @@ namespace Microsoft.Maui.Platform
 			catch (Exception)
 			{
 				// If anything goes wrong just show the html
-				platformControl.Text = global::Windows.Data.Html.HtmlUtilities.ConvertToText(label.Text);
+				platformControl.Text = label.Text;
 			}
 		}
 


### PR DESCRIPTION
### Description of Change

Fixes https://github.com/dotnet/maui/issues/17457

If you call `Windows.Data.Html.HtmlUtilities.ConvertToText` with malformed HTML (where the tags are close to being correct, but not complete) the call fails on a crash. No exceptions are thrown, it just stops working. I think it's a native crash.

Instead of calling the converter, we can set the text directly to show the raw html.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
