### PR TITLE
[net7.0] Remove ScrollView Leak Test 

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/ScrollView/ScrollViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/ScrollView/ScrollViewTests.cs
@@ -115,12 +115,13 @@ namespace Microsoft.Maui.DeviceTests
 			{
 				var view = new Microsoft.Maui.Controls.ScrollView();
 				var page = new ContentPage { Content = view };
-				await CreateHandlerAndAddToWindow(page, () =>
+				await CreateHandlerAndAddToWindow(page, async () =>
 				{
 					viewReference = new(view);
 					handlerReference = new(view.Handler);
 					platformReference = new(view.Handler.PlatformView);
 					page.Content = null;
+					await Task.Delay(1000);
 				});
 			}
 

--- a/src/Controls/tests/DeviceTests/Elements/ScrollView/ScrollViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/ScrollView/ScrollViewTests.cs
@@ -102,48 +102,6 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
-		// NOTE: this test is slightly different than MemoryTests.HandlerDoesNotLeak
-		// It calls CreateHandlerAndAddToWindow(), a valid test case.
-		[Fact(DisplayName = "ScrollView Does Not Leak")]
-		public async Task DoesNotLeak()
-		{
-			SetupBuilder();
-
-			WeakReference viewReference = null;
-			WeakReference handlerReference = null;
-			WeakReference platformReference = null;
-			{
-				var view = new Microsoft.Maui.Controls.ScrollView();
-				var page = new ContentPage { Content = view };
-				await CreateHandlerAndAddToWindow(page, async () =>
-				{
-					viewReference = new(view);
-					handlerReference = new(view.Handler);
-					platformReference = new(view.Handler.PlatformView);
-					page.Content = null;
-					await Task.Delay(1000);
-				});
-			}
-
-			await AssertionExtensions.WaitForGC(viewReference, handlerReference, platformReference);
-			Assert.False(viewReference.IsAlive, "ScrollView should not be alive!");
-			Assert.False(handlerReference.IsAlive, "Handler should not be alive!");
-			Assert.False(platformReference.IsAlive, "PlatformView should not be alive!");
-		}
-
-		void SetupBuilder()
-		{
-			EnsureHandlerCreated(builder =>
-			{
-				builder.ConfigureMauiHandlers(handlers =>
-				{
-					handlers.AddHandler<Label, LabelHandler>();
-					handlers.AddHandler<IScrollView, ScrollViewHandler>();
-					handlers.AddHandler<Grid, LayoutHandler>();
-				});
-			});
-		}
-
 		static async Task AssertContentSizeChanged(Task<bool> changed)
 		{
 			await WaitAssert(() => changed.IsCompleted && changed.Result, timeout: 5000, message: "PropertyChanged event with PropertyName 'ContentSize' did not fire").ConfigureAwait(false);


### PR DESCRIPTION
### Description of Change

The ScrollViewLeakTest was brought over by the following [PR](https://github.com/dotnet/maui/pull/17093). That test isn't valid on NET7 due to the vast number of PRs on NET8 that were created to fix leak issues with `ScrollView`. 

I reverted https://github.com/dotnet/maui/pull/17093, ran the same leak test, and it still failed so that PR doesn't introduce anything that would cause that test to fail on net7. 


