### PR TITLE
Fix accent color missing in title bar

### DIFF
--- a/src/Core/src/Platform/Windows/MauiWinUIWindow.cs
+++ b/src/Core/src/Platform/Windows/MauiWinUIWindow.cs
@@ -2,12 +2,13 @@
 using System.Runtime.InteropServices;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui.ApplicationModel;
-using Microsoft.Maui.Devices;
 using Microsoft.Maui.LifecycleEvents;
 using Microsoft.UI;
+using Microsoft.UI.Composition.SystemBackdrops;
 using Microsoft.UI.Windowing;
-using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
 using Windows.Graphics;
+using ViewManagement = Windows.UI.ViewManagement;
 
 namespace Microsoft.Maui
 {
@@ -21,10 +22,12 @@ namespace Microsoft.Maui
 		IntPtr _windowIcon;
 		bool _enableResumeEvent;
 		bool _isActivated;
+		ViewManagement.UISettings _viewSettings;
 
 		public MauiWinUIWindow()
 		{
 			_windowManager = WindowMessageManager.Get(this);
+			_viewSettings = new ViewManagement.UISettings();
 
 			Activated += OnActivated;
 			Closed += OnClosedPrivate;
@@ -34,7 +37,16 @@ namespace Microsoft.Maui
 			// set to false we know the user toggled this to false 
 			// and then we can react accordingly
 			if (AppWindowTitleBar.IsCustomizationSupported())
+			{
 				base.AppWindow.TitleBar.ExtendsContentIntoTitleBar = true;
+				_viewSettings.ColorValuesChanged += _viewSettings_ColorValuesChanged;
+				SetTileBarButtonColors();
+			}
+
+			if (MicaController.IsSupported())
+			{
+				base.SystemBackdrop = new MicaBackdrop() { Kind = MicaKind.Base };
+			}
 
 			SubClassingWin32();
 			SetIcon();
@@ -68,6 +80,8 @@ namespace Microsoft.Maui
 		private void OnClosedPrivate(object sender, UI.Xaml.WindowEventArgs args)
 		{
 			OnClosed(sender, args);
+
+			_viewSettings.ColorValuesChanged -= _viewSettings_ColorValuesChanged;
 
 			if (_windowIcon != IntPtr.Zero)
 			{
@@ -176,6 +190,21 @@ namespace Microsoft.Maui
 						appWindow.SetIcon(iconId);
 					}
 				}
+			}
+		}
+
+		private void _viewSettings_ColorValuesChanged(ViewManagement.UISettings sender, object args)
+		{
+			DispatcherQueue.TryEnqueue(SetTileBarButtonColors);
+		}
+
+		private void SetTileBarButtonColors()
+		{
+			if (AppWindowTitleBar.IsCustomizationSupported())
+			{
+				base.AppWindow.TitleBar.ButtonBackgroundColor = Colors.Transparent;
+				base.AppWindow.TitleBar.ButtonInactiveBackgroundColor = Colors.Transparent;
+				base.AppWindow.TitleBar.ButtonForegroundColor = _viewSettings.GetColorValue(ViewManagement.UIColorType.Foreground);
 			}
 		}
 

--- a/src/Core/src/Platform/Windows/MauiWinUIWindow.cs
+++ b/src/Core/src/Platform/Windows/MauiWinUIWindow.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Maui
 
 			if (MicaController.IsSupported())
 			{
-				base.SystemBackdrop = new MicaBackdrop() { Kind = MicaKind.Base };
+				base.SystemBackdrop = new MicaBackdrop() { Kind = MicaKind.BaseAlt };
 			}
 
 			SubClassingWin32();

--- a/src/Core/src/Platform/Windows/Styles/WindowRootViewStyle.xaml
+++ b/src/Core/src/Platform/Windows/Styles/WindowRootViewStyle.xaml
@@ -3,15 +3,6 @@
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 	xmlns:maui="using:Microsoft.Maui.Platform">
 
-    <ResourceDictionary.ThemeDictionaries>
-        <ResourceDictionary x:Key="Default">
-            <SolidColorBrush x:Key="TitleBarBackgroundColor" Color="#FF000000" />
-        </ResourceDictionary>
-        <ResourceDictionary x:Key="Light">
-            <SolidColorBrush x:Key="TitleBarBackgroundColor" Color="#FFFFFFFF" />
-        </ResourceDictionary>
-    </ResourceDictionary.ThemeDictionaries>
-    
     <maui:DefaultOrUserDataTemplateSelector 
         UserTemplateName="MauiAppTitleBarTemplate" 
         DefaultTemplateName="MauiAppTitleBarTemplateDefault"
@@ -26,7 +17,6 @@
         <Border
             Canvas.ZIndex="1" 
             VerticalAlignment="Stretch"
-            Background="{ThemeResource TitleBarBackgroundColor}"
             Margin="0,0,0,0">
             <StackPanel Orientation="Horizontal" Margin="12, 0, 0, 0" x:Name="RootStackPanel">
                 <Image 


### PR DESCRIPTION
### Description of Change

* Apply user accent color to the title bar when the setting "Show accent color on title bars and windows borders" is enabled
* React to changes in user accent color
* When accent color on title bars are disabled: align the default title bar color to use the Mica material when supported



| Before      | After |
| ----------- | ----------- |
|![before_dark](https://github.com/dotnet/maui/assets/890772/2a85c32c-5b81-47e9-92f2-939bfec38e8a) | ![after_dark](https://github.com/dotnet/maui/assets/890772/8f6a7626-dc2b-4c3e-91ab-4130f825d108) |
|![before_dark_accent](https://github.com/dotnet/maui/assets/890772/397fd23d-9645-4001-b316-6c0f7ce31007) | ![after_dark_accent](https://github.com/dotnet/maui/assets/890772/8a668776-8eca-4689-9e02-8e39fb549b43) |
|![before_light](https://github.com/dotnet/maui/assets/890772/78dcc229-4a23-4de4-ad4e-53b839ce4dfc) |![after_light](https://github.com/dotnet/maui/assets/890772/e19390f9-4ea2-4cc1-8728-376f0b50217f)|
|![before_light_accent](https://github.com/dotnet/maui/assets/890772/ab68eef6-8707-487f-9178-eacdcd886914)|![after_light_accent](https://github.com/dotnet/maui/assets/890772/e82065b4-b024-4441-8755-7a1677acf043)|


### Visual Reference: Notepad

**Dark**
![ref_notepad_dark](https://github.com/dotnet/maui/assets/890772/d77be3d8-006d-4dcb-8146-3a71c0f560dc)

**Light**
![ref_notepad_light](https://github.com/dotnet/maui/assets/890772/f082a144-c9e9-45f7-8343-078803d39187)

### Issues Fixed

Fixes #16969