### PR TITLE
Fix WinUI Tests

### DIFF
--- a/src/Controls/tests/DeviceTests/Stubs/MauiAppNewWindowStub.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Stubs/MauiAppNewWindowStub.Windows.cs
@@ -51,12 +51,7 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 
 		void InvokeWindowCreated()
 		{
-			if (Window is not null)
-			{
-				if (!Window.IsCreated)
-					_window.Created();
-			}
-			else
+			if (Window is null && _window is not null)
 			{
 				_window.Created();
 			}


### PR DESCRIPTION
### Description of Change

https://github.com/dotnet/maui/pull/17041 changed the order SetWindow so that it's available inside `OnCreateWindow`. This made the extra call here inside our stub not necessary.

This was caught by https://github.com/dotnet/maui/pull/17221 which we'll hopefully get merged tomorrow. :-) 