### PR TITLE
[Android] Correctly clear text tapping the clear button on Entry

### DIFF
--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issue17453.xaml
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issue17453.xaml
@@ -1,0 +1,50 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Maui.Controls.Sample.Issues.Issue17453">
+    <Grid RowDefinitions="*,*"
+          Padding="10,10">
+        <VerticalStackLayout FlowDirection="LeftToRight"
+                             Spacing="10">
+            <Label AutomationId="WaitForStubControl" 
+                   Text="#17453 (Entry inside a container with padding):" />
+            <VerticalStackLayout Padding="30,0">
+                <Entry AutomationId="LtrEntry" 
+                       Text="Simple text"
+                       ClearButtonVisibility="WhileEditing" />
+            </VerticalStackLayout>
+            <Label Text="#9954 (Entry inside a container with no padding):" />
+            <Border Stroke="black"
+                    StrokeThickness="1"
+                    BackgroundColor="Transparent">
+                <Border.StrokeShape>
+                    <RoundRectangle CornerRadius="10,10,10,10" />
+                </Border.StrokeShape>
+                <Entry AutomationId="BorderLtrEntry" 
+                       ClearButtonVisibility="WhileEditing"
+                       Text="Simple Text" />
+            </Border>
+        </VerticalStackLayout>
+        <VerticalStackLayout Grid.Row="1"
+                             Spacing="10"
+                             FlowDirection="RightToLeft">
+            <Label Text="#17453 (Entry inside a container with padding):" />
+            <VerticalStackLayout Padding="30,0">
+                <Entry AutomationId="RtlEntry" 
+                       Text="Simple text"
+                       ClearButtonVisibility="WhileEditing" />
+            </VerticalStackLayout>
+            <Label Text="#9954 (Entry inside a container with no padding):"/>
+            <Border Stroke="black"
+                    StrokeThickness="1"
+                    BackgroundColor="Transparent">
+                <Border.StrokeShape>
+                    <RoundRectangle CornerRadius="10,10,10,10" />
+                </Border.StrokeShape>
+                <Entry AutomationId="BorderRtlEntry" 
+                       ClearButtonVisibility="WhileEditing"
+                       Text="Simple Text" />
+            </Border>
+        </VerticalStackLayout>
+    </Grid>
+</ContentPage>

--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issue17453.xaml.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issue17453.xaml.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+using Microsoft.Maui.Platform;
+
+namespace Maui.Controls.Sample.Issues
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	[Issue(IssueTracker.Github, 17453, "Clear Entry text tapping the clear button not working", PlatformAffected.Android)]
+	public partial class Issue17453 : ContentPage
+	{
+		public Issue17453()
+		{
+			InitializeComponent();
+		}
+	}
+}

--- a/src/Controls/tests/UITests/Tests/Issues/Issue17453.cs
+++ b/src/Controls/tests/UITests/Tests/Issues/Issue17453.cs
@@ -21,11 +21,6 @@ namespace Microsoft.Maui.AppiumTests.Issues
 				TestDevice.Windows
 			});
 
-			if (App is not AppiumApp app2 || app2 is null || app2.Driver is null)
-			{
-				throw new InvalidOperationException("Cannot run test. Missing driver to run quick tap actions.");
-			}
-
 			App.WaitForElement("WaitForStubControl");
 			var rtlEntryRect = App.FindElement("RtlEntry").GetRect();
 
@@ -36,7 +31,7 @@ namespace Microsoft.Maui.AppiumTests.Issues
 			var margin = 30;
 			App.Click(rtlEntryRect.Width + margin, rtlEntryRect.Y + margin);
 
-			var ltrEntryText = App.FindElement("RtlEntry").GetText();
+			string? ltrEntryText = App.FindElement("RtlEntry").GetText();
 
 			Assert.IsEmpty(ltrEntryText);
 		}

--- a/src/Controls/tests/UITests/Tests/Issues/Issue17453.cs
+++ b/src/Controls/tests/UITests/Tests/Issues/Issue17453.cs
@@ -1,0 +1,44 @@
+﻿using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.AppiumTests.Issues
+{
+	class Issue17453 : _IssuesUITest
+	{
+		public Issue17453(TestDevice device) : base(device) { }
+
+		public override string Issue => "Clear Entry text tapping the clear button not working";
+
+		[Test]
+		public void EntryClearButtonWorks()
+		{
+			// https://github.com/dotnet/maui/issues/17453
+			this.IgnoreIfPlatforms(new[]
+			{
+				TestDevice.iOS,
+				TestDevice.Mac,
+				TestDevice.Windows
+			});
+
+			if (App is not AppiumApp app2 || app2 is null || app2.Driver is null)
+			{
+				throw new InvalidOperationException("Cannot run test. Missing driver to run quick tap actions.");
+			}
+
+			App.WaitForElement("WaitForStubControl");
+			var rtlEntryRect = App.FindElement("RtlEntry").GetRect();
+
+			// Set focus
+			App.Click(rtlEntryRect.X, rtlEntryRect.Y);
+
+			// Tap Clear Button
+			var margin = 30;
+			App.Click(rtlEntryRect.Width + margin, rtlEntryRect.Y + margin);
+
+			var ltrEntryText = App.FindElement("RtlEntry").GetText();
+
+			Assert.IsEmpty(ltrEntryText);
+		}
+	}
+}

--- a/src/Core/src/Platform/Android/EditTextExtensions.cs
+++ b/src/Core/src/Platform/Android/EditTextExtensions.cs
@@ -349,32 +349,77 @@ namespace Microsoft.Maui.Platform
 				return false;
 
 			var rBounds = getClearButtonDrawable?.Invoke()?.Bounds;
-			var buttonWidth = rBounds?.Width();
 
-			if (buttonWidth <= 0)
+			if (rBounds is null)
+			{
+				// The button doesn't exist, or we can't retrieve it. 
 				return false;
+			}
 
-			var x = motionEvent.RawX;
-			var y = motionEvent.GetY();
+			var buttonRect = GetClearButtonLocation(rBounds, platformView);
 
-			var flowDirection = platformView.LayoutDirection;
-
-			if ((flowDirection != LayoutDirection.Ltr
-				|| x < platformView.Right - buttonWidth
-				|| x > platformView.Right - platformView.PaddingRight
-				|| y < platformView.PaddingTop
-				|| y > platformView.Height - platformView.PaddingBottom) &&
-				(flowDirection != LayoutDirection.Rtl
-				|| x < platformView.Left + platformView.PaddingLeft
-				|| x > platformView.Left + buttonWidth
-				|| y < platformView.PaddingTop
-				|| y > platformView.Height - platformView.PaddingBottom))
+			if (!RectContainsMotionEvent(buttonRect, motionEvent))
 			{
 				return false;
 			}
 
 			platformView.Text = null;
 			return true;
+		}
+
+		// Android.Graphics.Rect has a Containts(x,y) method, but it only takes `int` and the coordinates from
+		// the motion event are `float`. The we use GetX() and GetY() so our coordinates are relative to the
+		// bounds of the EditText.
+		static bool RectContainsMotionEvent(Android.Graphics.Rect rect, MotionEvent motionEvent)
+		{
+			var x = motionEvent.GetX();
+
+			if (x < rect.Left || x > rect.Right)
+			{
+				return false;
+			}
+
+			var y = motionEvent.GetY();
+
+			if (y < rect.Top || y > rect.Bottom)
+			{
+				return false;
+			}
+
+			return true;
+		}
+
+		// Gets the location of the "Clear" button relative to the bounds of the EditText
+		static Android.Graphics.Rect GetClearButtonLocation(Android.Graphics.Rect buttonRect, EditText platformView)
+		{
+			// Determine the top and bottom edges of the button
+			// This assumes the button is vertically centered within the padded area of the EditText
+
+			var buttonHeight = buttonRect.Height();
+			var editAreaTop = platformView.Top + platformView.PaddingTop;
+			var editAreaHeight = (platformView.Bottom - platformView.PaddingBottom) - (editAreaTop);
+			var editAreaVerticalCenter = editAreaTop + (editAreaHeight / 2);
+
+			var topEdge = editAreaVerticalCenter - (buttonHeight / 2);
+			var bottomEdge = topEdge + buttonHeight;
+
+			// The horizontal location of the button depends on the layout direction
+			var flowDirection = platformView.LayoutDirection;
+
+			if (flowDirection == LayoutDirection.Ltr)
+			{
+				var rightEdge = platformView.Width - platformView.PaddingRight;
+				var leftEdge = rightEdge - buttonRect.Width();
+
+				return new Android.Graphics.Rect(leftEdge, topEdge, rightEdge, bottomEdge);
+			}
+			else
+			{
+				var leftEdge = platformView.PaddingLeft;
+				var rightEdge = leftEdge + platformView.Width;
+
+				return new Android.Graphics.Rect(leftEdge, topEdge, rightEdge, bottomEdge);
+			}
 		}
 	}
 }

--- a/src/Core/src/Platform/Android/EditTextExtensions.cs
+++ b/src/Core/src/Platform/Android/EditTextExtensions.cs
@@ -354,7 +354,7 @@ namespace Microsoft.Maui.Platform
 			if (buttonWidth <= 0)
 				return false;
 
-			var x = motionEvent.GetX();
+			var x = motionEvent.RawX;
 			var y = motionEvent.GetY();
 
 			var flowDirection = platformView.LayoutDirection;


### PR DESCRIPTION
### Description of Change

Correctly clear text tapping the clear button on Android Entry.
![fix-17453](https://github.com/dotnet/maui/assets/6755973/25d12a33-a5f3-4a2b-8f03-55e3b59de354)

### Issues Fixed

Fixes #17453 
Fixes #18803
