### PR TITLE
If NavigationRenderer is Disposed don't UpdateFrames

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
@@ -243,6 +243,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 			if (disposing)
 			{
+				Delegate = null;
 				foreach (var childViewController in ViewControllers)
 					childViewController.Dispose();
 
@@ -1146,7 +1147,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				// the animation changing the frame during navigation
 				if (_navigation.TryGetTarget(out n) &&
 					ChildViewControllers.Length > 0 &&
-					!n._navigating)
+					!n._disposed &&
+					!n._navigating
+					)
 				{
 					nfloat offset = 0;
 

--- a/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.cs
@@ -339,12 +339,8 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
-#if !WINDOWS && !MACCATALYST
-		[Theory(
-#if IOS
-		Skip = "Test crashes on iOS, potential fix: https://github.com/dotnet/maui/pull/17544"
-#endif
-		)]
+#if !WINDOWS
+		[Theory]
 		[ClassData(typeof(TabbedPagePivots))]
 		public async Task RemovingAllPagesDoesntCrash(bool bottomTabs, bool isSmoothScrollEnabled)
 		{


### PR DESCRIPTION
### Description of Change

Re-enable iOS test that found a crasher on iOS. The following work added a `NavigationDelegate` https://github.com/dotnet/maui/pull/4576/files#diff-89cd9c087deb8f5b7d8eb8cd3f32deb41f6e37883264dff452ace37e8a3da5a8R953-R962 but we never clear out that `Delegate`. This sometimes leads to navigation events firing after the Navigation Renderer has been disabled
