### PR TITLE
[X] Double cast for OnPlat in StaticResource

### DIFF
--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui16327.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui16327.xaml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests"
+             x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui16327">
+    <ContentPage.Resources>
+        <ResourceDictionary>
+            <OnPlatform x:TypeArguments="x:Int32" x:Key="DefaultCornerRadius">
+                <On Platform="iOS" Value="10" />
+                <On Platform="MacCatalyst" Value="50" />
+                <On Platform="WinUI" Value="10" />
+                <On Platform="Android" Value="30" />
+            </OnPlatform>
+
+            <Style TargetType="Border">
+                <Setter Property="StrokeShape">
+                    <Setter.Value>
+                        <RoundRectangle CornerRadius="{StaticResource DefaultCornerRadius}" />
+                    </Setter.Value>
+                </Setter>
+            </Style>
+        </ResourceDictionary>
+    </ContentPage.Resources>
+
+
+    <Border x:Name="border" HeightRequest="100"/>
+
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui16327.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui16327.xaml.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using Microsoft.Maui.ApplicationModel;
+using Microsoft.Maui.Controls.Core.UnitTests;
+using Microsoft.Maui.Controls.Shapes;
+using Microsoft.Maui.Devices;
+using Microsoft.Maui.Graphics;
+using NUnit.Framework;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public partial class Maui16327 : ContentPage
+{
+
+	public Maui16327() => InitializeComponent();
+
+	public Maui16327(bool useCompiledXaml)
+	{
+		//this stub will be replaced at compile time
+	}
+
+	[TestFixture]
+	class Test
+	{
+		MockDeviceInfo mockDeviceInfo;
+
+		[SetUp]
+		public void Setup()
+		{
+			AppInfo.SetCurrent(new MockAppInfo());
+			DeviceInfo.SetCurrent(mockDeviceInfo = new MockDeviceInfo());
+
+		}
+
+		[TearDown]
+		public void TearDown()
+		{
+			DeviceInfo.SetCurrent(mockDeviceInfo = null);
+			AppInfo.SetCurrent(null);
+		}
+
+		[Test]
+		public void ConversionOfResources([Values(false, true)] bool useCompiledXaml)
+		{
+			mockDeviceInfo.Platform = DevicePlatform.iOS;
+
+			var page = new Maui16327(useCompiledXaml);
+			var border = page.border;
+
+			var shape = border.StrokeShape as RoundRectangle;
+			Assert.That(shape.CornerRadius.BottomLeft, Is.EqualTo(10));
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change

When OnPlatform<T> is used as a StaticResource, cast it first to T (extract the Onplatform value), then process as usual, and cast it again to propertyType if needed

### Issues Fixed

- fixes #16327