### PR TITLE
Fixed Android's Border background to use a Transparent bg if not othe…

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Border/BorderTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Border/BorderTests.cs
@@ -27,7 +27,9 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
+#if ANDROID || WINDOWS
 		[Fact("Checks that the default background is transparent")]
+#endif
 		public async Task DefaultBackgroundIsTransparent ()
 		{
 			// We use a Grid container to set a background color and then make sure that the Border background

--- a/src/Controls/tests/DeviceTests/Elements/Border/BorderTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Border/BorderTests.cs
@@ -29,7 +29,6 @@ namespace Microsoft.Maui.DeviceTests
 
 #if ANDROID
 		[Fact("Checks that the default background is transparent")]
-#endif
 		public async Task DefaultBackgroundIsTransparent ()
 		{
 			// We use a Grid container to set a background color and then make sure that the Border background
@@ -86,6 +85,7 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.Equal(180, innerBlob.Width, 2d);
 			Assert.Equal(180, innerBlob.Height, 2d);
 		}
+#endif
 
 		[Fact(DisplayName = "Rounded Rectangle Border occupies correct space")]
 		public async Task RoundedRectangleBorderLayoutIsCorrect()

--- a/src/Controls/tests/DeviceTests/Elements/Border/BorderTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Border/BorderTests.cs
@@ -27,6 +27,64 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
+		[Fact("Checks that the default background is transparent")]
+		public async Task DefaultBackgroundIsTransparent ()
+		{
+			// We use a Grid container to set a background color and then make sure that the Border background
+			// is transparent by making sure that the parent Grid's Blue background shows through.
+			var grid = new Grid
+			{
+				ColumnDefinitions = new ColumnDefinitionCollection()
+				{
+					new ColumnDefinition(GridLength.Star)
+				},
+				RowDefinitions = new RowDefinitionCollection()
+				{
+					new RowDefinition(GridLength.Star)
+				},
+				BackgroundColor = Colors.Blue,
+				WidthRequest = 200,
+				HeightRequest = 200
+			};
+
+			var border = new Border {
+				WidthRequest = 200,
+				HeightRequest = 200,
+				Stroke = Colors.Red,
+				StrokeThickness = 10
+			};
+
+			grid.Add(border, 0, 0);
+
+			await CreateHandlerAsync<BorderHandler>(border);
+			await CreateHandlerAsync<LayoutHandler>(grid);
+
+			var bitmap = await GetRawBitmap(grid, typeof(LayoutHandler));
+			Assert.Equal(200, bitmap.Width, 2d);
+			Assert.Equal(200, bitmap.Height, 2d);
+
+			// Analyze red border - we expect it to fill a 200x200 area
+			var redBlob = ConnectedComponentAnalysis.FindConnectedPixels(bitmap, (c) => c.Red > .5).Single();
+			Assert.Equal(200, redBlob.Width, 2d);
+			Assert.Equal(200, redBlob.Height, 2d);
+
+			// Analyze the blue blob - it should fill the inside of the border (minus the stroke thickness)
+			var blueBlobs = ConnectedComponentAnalysis.FindConnectedPixels(bitmap, (c) => c.Blue > .5);
+
+			// Note: There is a 1px blue border around the red border, so we need to find the one
+			// that represents the inner bounds of the border.
+			var innerBlob = blueBlobs[0];
+
+			for (int i = 1; i < blueBlobs.Count; i++)
+			{
+				if (blueBlobs[i].MinColumn > innerBlob.MinColumn && blueBlobs[i].MaxColumn < innerBlob.MaxColumn)
+					innerBlob = blueBlobs[i];
+			}
+
+			Assert.Equal(180, innerBlob.Width, 2d);
+			Assert.Equal(180, innerBlob.Height, 2d);
+		}
+
 		[Fact(DisplayName = "Rounded Rectangle Border occupies correct space")]
 		public async Task RoundedRectangleBorderLayoutIsCorrect()
 		{

--- a/src/Controls/tests/DeviceTests/Elements/Border/BorderTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Border/BorderTests.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
-#if ANDROID || WINDOWS
+#if ANDROID
 		[Fact("Checks that the default background is transparent")]
 #endif
 		public async Task DefaultBackgroundIsTransparent ()

--- a/src/Core/src/Graphics/MauiDrawable.Android.cs
+++ b/src/Core/src/Graphics/MauiDrawable.Android.cs
@@ -522,10 +522,13 @@ namespace Microsoft.Maui.Graphics
 					platformPaint.Color = _backgroundColor.Value;
 #pragma warning restore CA1416
 				}
+				else if (_background != null)
+				{
+					SetPaint(platformPaint, _background);
+				}
 				else
 				{
-					if (_background != null)
-						SetPaint(platformPaint, _background);
+					platformPaint.Color = AColor.Transparent;
 				}
 			}
 		}


### PR DESCRIPTION
### Description of Change

Fixed Android's Border implementation to use a transparent bg when painting the border if a bg color is left unspecified.

### Issues Fixed

Fixes #17547
Fixes #17506
Fixes https://github.com/dotnet/maui/issues/16547