### PR TITLE
Revert new packaged names for macios dependencies for RC 2.

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -12,21 +12,21 @@
       <Uri>https://github.com/xamarin/xamarin-android</Uri>
       <Sha>52d15704a8837d4b7621c560342a2bae0d090a94</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.MacCatalyst.Sdk.net8.0_16.4" Version="16.4.8911-net8-rc2">
+    <Dependency Name="Microsoft.MacCatalyst.Sdk" Version="16.4.8967-net8-rc2">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>c901665f345c21cdf29601e76a7e84cdec0d5482</Sha>
+      <Sha>b96cc8ff0594e321d7970c99275ac7113012b7e9</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.macOS.Sdk.net8.0_13.3" Version="13.3.8911-net8-rc2">
+    <Dependency Name="Microsoft.macOS.Sdk" Version="13.3.8967-net8-rc2">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>c901665f345c21cdf29601e76a7e84cdec0d5482</Sha>
+      <Sha>b96cc8ff0594e321d7970c99275ac7113012b7e9</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.iOS.Sdk.net8.0_16.4" Version="16.4.8911-net8-rc2">
+    <Dependency Name="Microsoft.iOS.Sdk" Version="16.4.8967-net8-rc2">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>c901665f345c21cdf29601e76a7e84cdec0d5482</Sha>
+      <Sha>b96cc8ff0594e321d7970c99275ac7113012b7e9</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.tvOS.Sdk.net8.0_16.4" Version="16.4.8911-net8-rc2">
+    <Dependency Name="Microsoft.tvOS.Sdk" Version="16.4.8967-net8-rc2">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>c901665f345c21cdf29601e76a7e84cdec0d5482</Sha>
+      <Sha>b96cc8ff0594e321d7970c99275ac7113012b7e9</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.Workload.Emscripten.Current.Manifest-8.0.100.Transport" Version="8.0.0-rc.2.23455.4" CoherentParentDependency="Microsoft.NETCore.App.Ref">
       <Uri>https://github.com/dotnet/emsdk</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -25,14 +25,10 @@
     <!-- xamarin/xamarin-android -->
     <MicrosoftAndroidSdkWindowsPackageVersion>34.0.0-rc.2.440</MicrosoftAndroidSdkWindowsPackageVersion>
     <!-- xamarin/xamarin-macios -->
-    <MicrosoftMacCatalystSdknet80_164PackageVersion>16.4.8911-net8-rc2</MicrosoftMacCatalystSdknet80_164PackageVersion>
-    <MicrosoftmacOSSdknet80_133PackageVersion>13.3.8911-net8-rc2</MicrosoftmacOSSdknet80_133PackageVersion>
-    <MicrosoftiOSSdknet80_164PackageVersion>16.4.8911-net8-rc2</MicrosoftiOSSdknet80_164PackageVersion>
-    <MicrosofttvOSSdknet80_164PackageVersion>16.4.8911-net8-rc2</MicrosofttvOSSdknet80_164PackageVersion>
-    <MicrosoftMacCatalystSdkPackageVersion>$(MicrosoftMacCatalystSdknet80_164PackageVersion)</MicrosoftMacCatalystSdkPackageVersion>
-    <MicrosoftmacOSSdkPackageVersion>$(MicrosoftmacOSSdknet80_133PackageVersion)</MicrosoftmacOSSdkPackageVersion>
-    <MicrosoftiOSSdkPackageVersion>$(MicrosoftiOSSdknet80_164PackageVersion)</MicrosoftiOSSdkPackageVersion>
-    <MicrosofttvOSSdkPackageVersion>$(MicrosofttvOSSdknet80_164PackageVersion)</MicrosofttvOSSdkPackageVersion>
+    <MicrosoftMacCatalystSdkPackageVersion>16.4.8967-net8-rc2</MicrosoftMacCatalystSdkPackageVersion>
+    <MicrosoftmacOSSdkPackageVersion>13.3.8967-net8-rc2</MicrosoftmacOSSdkPackageVersion>
+    <MicrosoftiOSSdkPackageVersion>16.4.8967-net8-rc2</MicrosoftiOSSdkPackageVersion>
+    <MicrosofttvOSSdkPackageVersion>16.4.8967-net8-rc2</MicrosofttvOSSdkPackageVersion>
     <!-- Samsung/Tizen.NET -->
     <SamsungTizenSdkPackageVersion>7.0.125</SamsungTizenSdkPackageVersion>
     <!-- emsdk -->


### PR DESCRIPTION
We've reverted the renaming of the xamarin-macios dependencies for RC 2 (ref: #17267).

Note: this is only needed for .NET 8 RC 2, our `net8.0` branch (aka the
`.NET 8.0.1xx SDK` maestro channel) is still using the updated package
names (and is now producing `rtm` builds - see #17402).

PD: I believe `net8.0` is not the correct target branch, you'll have to update
the PR once you branch for RC 2.