### PR TITLE
Make ALL template warnings show up as test errors (not just C# warnings), and produce more diagnostic artifacts

### DIFF
--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/BaseBuildTest.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/BaseBuildTest.cs
@@ -98,25 +98,10 @@ namespace Microsoft.Maui.IntegrationTests
 		[TearDown]
 		public void BuildTestTearDown()
 		{
-			// Clean up test or attach content from failed tests
-			if (TestContext.CurrentContext.Result.Outcome.Status == NUnit.Framework.Interfaces.TestStatus.Passed ||
-				TestContext.CurrentContext.Result.Outcome.Status == NUnit.Framework.Interfaces.TestStatus.Skipped)
+			// Attach test content and logs as artifacts
+			foreach (var log in Directory.GetFiles(Path.Combine(TestDirectory), "*log", SearchOption.AllDirectories))
 			{
-				try
-				{
-					if (Directory.Exists(TestDirectory))
-						Directory.Delete(TestDirectory, recursive: true);
-				}
-				catch (IOException)
-				{
-				}
-			}
-			else
-			{
-				foreach (var log in Directory.GetFiles(Path.Combine(TestDirectory), "*log", SearchOption.AllDirectories))
-				{
-					TestContext.AddTestAttachment(log, Path.GetFileName(TestDirectory));
-				}
+				TestContext.AddTestAttachment(log, Path.GetFileName(TestDirectory));
 			}
 		}
 


### PR DESCRIPTION
Right now we correctly set `TreatWarningsAsErrors=true` for template tests, but that catches only C# compiler warnings and converts those to errors. It does not treat _MSBuild_ warnings as errors. So, any warning during build/publish/whatever that isn't a C# compiler warning is ignored during our tests. And I think this is why https://github.com/dotnet/maui/issues/17561 lingered un-caught for a while.

This PR will end up having up to three parts:
1. DONE: Make sure MSBuild warnings fail the build. There's info here on that: https://stackoverflow.com/a/47448331/31668
2. Fix any current warnings that we've been missing (not sure if there are any - hopefully not!)
3. DONE: Have the build produce more artifacts even during successful runs. I spent hours trying to get a binlog for _successful_ template test runs (I can't run them locally for an unknown reason).

With part of what's in this PR now, you can download binlogs for any template test (and then view locally with https://msbuildlog.com/):

![image](https://github.com/dotnet/maui/assets/202643/fe25358b-0c80-46c8-adaf-449e68ffb770)

cc @mattleibow @PureWeen 