### PR TITLE
Recreate the Navigation Host If It's been Destroyed

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.cs
@@ -204,7 +204,7 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		[Theory("Remove CurrentPage And Then Re-Add Doesnt Crash"
-#if WINDOWS || ANDROID
+#if WINDOWS
 		, Skip = "Fails on Windows and Android (https://github.com/dotnet/maui/issues/17444)"
 #endif
 		)]
@@ -225,7 +225,10 @@ namespace Microsoft.Maui.DeviceTests
 						Background = Colors.Purple
 					}
 				}
-			});
+			})
+			{
+				Title = "First Page"
+			};
 
 			tabbedPage.Children.Insert(0, firstPage);
 			tabbedPage.CurrentPage = firstPage;
@@ -236,13 +239,12 @@ namespace Microsoft.Maui.DeviceTests
 				await OnNavigatedToAsync(firstPage);
 				tabbedPage.Children.Remove(firstPage);
 				await OnNavigatedToAsync(secondPage);
-
+				await OnUnloadedAsync(firstPage);
 				// Validate that the second page becomes the current active page
 				Assert.Equal(secondPage, tabbedPage.CurrentPage);
 
 				// add the removed page back
 				tabbedPage.Children.Insert(0, firstPage);
-
 				// Validate that the second page is still the current active page
 				Assert.Equal(secondPage, tabbedPage.CurrentPage);
 

--- a/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.cs
@@ -205,7 +205,7 @@ namespace Microsoft.Maui.DeviceTests
 
 		[Theory("Remove CurrentPage And Then Re-Add Doesnt Crash"
 #if WINDOWS
-		, Skip = "Fails on Windows and Android (https://github.com/dotnet/maui/issues/17444)"
+		, Skip = "Fails on Windows"
 #endif
 		)]
 		[ClassData(typeof(TabbedPagePivots))]

--- a/src/Core/src/Handlers/NavigationPage/NavigationViewHandler.Android.cs
+++ b/src/Core/src/Handlers/NavigationPage/NavigationViewHandler.Android.cs
@@ -41,9 +41,6 @@ namespace Microsoft.Maui.Handlers
 
 			platformView.ViewAttachedToWindow += OnViewAttachedToWindow;
 			platformView.ViewDetachedFromWindow += OnViewDetachedFromWindow;
-
-			if (platformView is FragmentContainerView fcw)
-				fcw.ChildViewAdded += OnViewChildAdded;
 		}
 
 		void OnViewDetachedFromWindow(object? sender, View.ViewDetachedFromWindowEventArgs e)
@@ -69,9 +66,6 @@ namespace Microsoft.Maui.Handlers
 			platformView.ViewAttachedToWindow -= OnViewAttachedToWindow;
 			platformView.ViewDetachedFromWindow -= OnViewDetachedFromWindow;
 			platformView.LayoutChange -= OnLayoutChanged;
-
-			if (platformView is FragmentContainerView fcw)
-				fcw.ChildViewAdded -= OnViewChildAdded;
 
 			_stackNavigationManager?.Disconnect();
 			base.OnDisconnectHandler(platformView);

--- a/src/Core/src/Platform/Android/Navigation/StackNavigationManager.cs
+++ b/src/Core/src/Platform/Android/Navigation/StackNavigationManager.cs
@@ -324,7 +324,8 @@ namespace Microsoft.Maui.Platform
 		{
 			// If the previous Navigation Host Fragment was destroyed then we need to add a new one
 			if (_fragmentManager.IsDestroyed(MauiContext.Context) &&
-				_fragmentContainerView is not null)
+				_fragmentContainerView is not null &&
+				_fragmentContainerView.Fragment is null)
 			{
 				var fragmentManager = MauiContext.GetFragmentManager();
 

--- a/src/Core/src/Platform/Android/Navigation/StackNavigationManager.cs
+++ b/src/Core/src/Platform/Android/Navigation/StackNavigationManager.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Android.Content;
 using Android.OS;
+using Android.Views;
 using AndroidX.Fragment.App;
 using AndroidX.Navigation;
 using AndroidX.Navigation.Fragment;
@@ -279,6 +280,12 @@ namespace Microsoft.Maui.Platform
 			if (IsNavigating)
 				NavigationFinished(NavigationView);
 
+			if (_fragmentContainerView is not null)
+			{
+				_fragmentContainerView.ViewAttachedToWindow -= OnNavigationPlatformViewAttachedToWindow;
+				_fragmentContainerView.ChildViewAdded -= OnNavigationHostViewAdded;
+			}
+
 			_fragmentLifecycleCallbacks?.Disconnect();
 			_fragmentLifecycleCallbacks = null;
 
@@ -305,11 +312,45 @@ namespace Microsoft.Maui.Platform
 
 			if (_navHost == null)
 				throw new InvalidOperationException($"No NavHostFragment found");
+
+			if (_fragmentContainerView is not null)
+			{
+				_fragmentContainerView.ViewAttachedToWindow += OnNavigationPlatformViewAttachedToWindow;
+				_fragmentContainerView.ChildViewAdded += OnNavigationHostViewAdded;
+			}
 		}
 
+		void OnNavigationPlatformViewAttachedToWindow(object? sender, AView.ViewAttachedToWindowEventArgs e)
+		{
+			// If the previous Navigation Host Fragment was destroyed then we need to add a new one
+			if (_fragmentManager?.IsDestroyed == true && _fragmentContainerView is not null)
+			{
+				CheckForFragmentChange();
+				var fragmentManager = MauiContext.GetFragmentManager();
+				var navHostFragment = new MauiNavHostFragment()
+				{
+					StackNavigationManager = this
+				};
+
+				// We can't call CheckForFragmentChange right away. The Fragment has to finish attaching
+				// before we can start interacting with the Navigation Host
+				fragmentManager
+					.BeginTransactionEx()
+					.Add(_fragmentContainerView.Id, navHostFragment)
+					.Commit();
+			}
+		}
+
+		void OnNavigationHostViewAdded(object? sender, ViewGroup.ChildViewAddedEventArgs e)
+		{
+			CheckForFragmentChange();
+		}
 
 		internal void CheckForFragmentChange()
 		{
+			if (_fragmentContainerView?.Fragment is null)
+				return;
+
 			var fragmentManager = MauiContext.GetFragmentManager();
 			var navHostFragment = _fragmentContainerView?.Fragment;
 

--- a/src/Core/src/Platform/Android/Navigation/StackNavigationManager.cs
+++ b/src/Core/src/Platform/Android/Navigation/StackNavigationManager.cs
@@ -323,20 +323,26 @@ namespace Microsoft.Maui.Platform
 		void OnNavigationPlatformViewAttachedToWindow(object? sender, AView.ViewAttachedToWindowEventArgs e)
 		{
 			// If the previous Navigation Host Fragment was destroyed then we need to add a new one
-			if (_fragmentManager?.IsDestroyed == true && _fragmentContainerView is not null)
+			if (_fragmentManager.IsDestroyed(MauiContext.Context) &&
+				_fragmentContainerView is not null)
 			{
-				CheckForFragmentChange();
 				var fragmentManager = MauiContext.GetFragmentManager();
+
+				if (fragmentManager.IsDestroyed(MauiContext.Context))
+					return;
+
 				var navHostFragment = new MauiNavHostFragment()
 				{
 					StackNavigationManager = this
 				};
 
 				// We can't call CheckForFragmentChange right away. The Fragment has to finish attaching
-				// before we can start interacting with the Navigation Host
+				// before we can start interacting with the Navigation Host.
+				// OnNavigationHostViewAdded takes care of calling CheckForFragmentChange once the
+				// view has been added
 				fragmentManager
 					.BeginTransactionEx()
-					.Add(_fragmentContainerView.Id, navHostFragment)
+					.AddEx(_fragmentContainerView.Id, navHostFragment)
 					.Commit();
 			}
 		}


### PR DESCRIPTION
### Description of Change

If a `NavigationPage` is removed, and then reused, we need to re-add the Navigation Host Fragment to the Navigations `FragmentViewContainer`. `FragmentViewContainer` appears to just remove the Fragment/View that it was inflated with whenever it's removed from the visual hierarchy, so we have to add it back if the user wants to reuse the same `NavigationPage` instance.

### Issues Fixed

Fixes #17589 

