### PR TITLE
Fix some of the false GC test failures in Debug mode

### DIFF
--- a/src/Controls/tests/Core.UnitTests/BindableLayoutTests.cs
+++ b/src/Controls/tests/Core.UnitTests/BindableLayoutTests.cs
@@ -249,30 +249,32 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.True(IsLayoutWithItemsSource(itemsSource, layout));
 		}
 
-		[Fact]
+		[Fact, Category(TestCategory.Memory)] 
 		public async Task LayoutIsGarbageCollectedAfterItsRemoved()
 		{
-			var layout = new StackLayout
-			{
-				IsPlatformEnabled = true,
-			};
-
-			var itemsSource = new ObservableCollection<int>(Enumerable.Range(0, 10));
-			BindableLayout.SetItemsSource(layout, itemsSource);
-
 			var pageRoot = new Grid();
-			pageRoot.Children.Add(layout);
 			var page = new ContentPage() { Content = pageRoot };
 
-			var weakReference = new WeakReference(layout);
-			pageRoot.Children.Remove(layout);
-			layout = null;
+			WeakReference CreateReference()
+			{
+				var layout = new StackLayout { IsPlatformEnabled = true };
 
-			await Task.Yield();
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+				var itemsSource = new ObservableCollection<int>(Enumerable.Range(0, 10));
+				BindableLayout.SetItemsSource(layout, itemsSource);
+				pageRoot.Children.Add(layout);
+				var reference = new WeakReference(layout);
+				pageRoot.Children.Remove(layout);
+				return reference;
+			}
+
+			var weakReference = CreateReference();
+
+			await TestHelpers.Collect();
 
 			Assert.False(weakReference.IsAlive);
+
+			// Ensure that the ContentPage isn't collected during the test
+			GC.KeepAlive(page);
 		}
 
 		[Fact]

--- a/src/Controls/tests/Core.UnitTests/BindingUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/BindingUnitTests.cs
@@ -2054,7 +2054,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			}
 
 			CreateReference();
-			
+
 			Assert.Equal(1, viewModel.InvocationListSize());
 
 			await TestHelpers.Collect();
@@ -2067,7 +2067,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			GC.KeepAlive(viewModel);
 		}
 
-		[Fact] // Fixed
+		[Fact, Category(TestCategory.Memory)] 
 		public async Task BindingDoesNotStayAliveForDeadTarget()
 		{
 			var viewModel = new TestViewModel();
@@ -2087,9 +2087,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			Assert.Equal(1, viewModel.InvocationListSize());
 
-			await Task.Yield();
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+			await TestHelpers.Collect();
 
 			Assert.False(bindingRef.IsAlive, "Binding should not be alive!");
 

--- a/src/Controls/tests/Core.UnitTests/Layouts/GridLayoutTests.cs
+++ b/src/Controls/tests/Core.UnitTests/Layouts/GridLayoutTests.cs
@@ -187,24 +187,27 @@ namespace Microsoft.Maui.Controls.Core.UnitTests.Layouts
 			Assert.Equal(def2.BindingContext, context);
 		}
 
-		[Fact]
+		[Fact, Category(TestCategory.Memory)]
 		public async Task ColumnDefinitionDoesNotLeak()
 		{
 			// Long-lived column, like from a Style in App.Resources
-			var column = new ColumnDefinition();
-			WeakReference reference;
+			var columnDefinition = new ColumnDefinition();
 
+			WeakReference CreateReference()
 			{
 				var grid = new Grid();
-				grid.ColumnDefinitions.Add(column);
-				reference = new(grid);
+				grid.ColumnDefinitions.Add(columnDefinition);
+				return new(grid);
 			}
 
-			await Task.Yield();
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+			WeakReference reference = CreateReference();
+
+			await TestHelpers.Collect();
 
 			Assert.False(reference.IsAlive, "Grid should not be alive!");
+
+			// Ensure that the ColumnDefinition isn't collected during the test
+			GC.KeepAlive(columnDefinition);
 		}
 
 		[Fact]

--- a/src/Controls/tests/Core.UnitTests/MapTests.cs
+++ b/src/Controls/tests/Core.UnitTests/MapTests.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections;
 using System.Collections.ObjectModel;
+using System.Data.Common;
 using System.Linq;
+using System.Security.Principal;
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls.Maps;
 using Microsoft.Maui.Devices.Sensors;
@@ -326,37 +328,45 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.True(IsMapWithItemsSource(itemsSource, map));
 		}
 
-		[Fact]
+		[Fact, Category(TestCategory.Memory)] 
 		public async Task ElementIsGarbageCollectedAfterItsRemoved()
 		{
-			var map = new Map()
-			{
-				ItemTemplate = GetItemTemplate()
-			};
-
-			// Create a view-model and bind the map to it
-			map.SetBinding(Map.ItemsSourceProperty, new Binding(nameof(MockViewModel.Items)));
-			map.BindingContext = new MockViewModel(new ObservableCollection<int>(Enumerable.Range(0, 10)));
-
-			// Set ItemsSource
-			var itemsSource = new ObservableCollection<int>(Enumerable.Range(0, 10));
-			Assert.True(IsMapWithItemsSource(itemsSource, map));
-			itemsSource = null;
-
-			// Remove map from container
 			var pageRoot = new Grid();
-			pageRoot.Children.Add(map);
 			var page = new ContentPage() { Content = pageRoot };
 
-			var weakReference = new WeakReference(map);
-			pageRoot.Children.Remove(map);
-			map = null;
+			WeakReference CreateReference()
+			{
+				var map = new Map()
+				{
+					ItemTemplate = GetItemTemplate()
+				};
 
-			await Task.Yield();
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+				// Create a view-model and bind the map to it
+				map.SetBinding(Map.ItemsSourceProperty, new Binding(nameof(MockViewModel.Items)));
+				map.BindingContext = new MockViewModel(new ObservableCollection<int>(Enumerable.Range(0, 10)));
+
+				// Set ItemsSource
+				var itemsSource = new ObservableCollection<int>(Enumerable.Range(0, 10));
+				Assert.True(IsMapWithItemsSource(itemsSource, map));
+
+				// Add the map to the container
+				pageRoot.Children.Add(map);
+
+				var weakReference = new WeakReference(map);
+
+				// Remove map from container
+				pageRoot.Children.Remove(map);
+
+				return weakReference;
+			}
+
+			var weakReference = CreateReference();
+
+			await TestHelpers.Collect();
 
 			Assert.False(weakReference.IsAlive);
+
+			GC.KeepAlive(page);
 		}
 
 		[Fact]

--- a/src/Controls/tests/Core.UnitTests/MessagingCenterTests.cs
+++ b/src/Controls/tests/Core.UnitTests/MessagingCenterTests.cs
@@ -262,27 +262,32 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.True(((TestSubcriber)wr.Target).Successful);  // Since it's still alive, the subscriber should still have received the message and updated the property
 		}
 
-		[Fact]
+		[Fact, Category(TestCategory.Memory)] 
 		public async Task SubscriberCollectableAfterUnsubscribeEvenIfHeldByClosure()
 		{
-			WeakReference wr = null;
-
-			new Action(() =>
+			WeakReference CreateReference()
 			{
-				var subscriber = new TestSubcriber();
+				WeakReference wr = null;
 
-				wr = new WeakReference(subscriber);
+				new Action(() =>
+				{
+					var subscriber = new TestSubcriber();
 
-				MessagingCenter.Subscribe<TestPublisher>(subscriber, "test", p => subscriber.SetSuccess());
-			})();
+					wr = new WeakReference(subscriber);
 
-			Assert.NotNull(wr.Target as TestSubcriber);
+					MessagingCenter.Subscribe<TestPublisher>(subscriber, "test", p => subscriber.SetSuccess());
+				})();
 
-			MessagingCenter.Unsubscribe<TestPublisher>(wr.Target, "test");
+				Assert.NotNull(wr.Target as TestSubcriber);
 
-			await Task.Yield();
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+				MessagingCenter.Unsubscribe<TestPublisher>(wr.Target, "test");
+
+				return wr;
+			}
+
+			var wr = CreateReference();
+
+			await TestHelpers.Collect();
 
 			Assert.False(wr.IsAlive); // The Action target and subscriber were the same object, so both could be collected
 		}

--- a/src/Controls/tests/Core.UnitTests/TestCategory.cs
+++ b/src/Controls/tests/Core.UnitTests/TestCategory.cs
@@ -1,0 +1,7 @@
+﻿namespace Microsoft.Maui.Controls.Core.UnitTests
+{
+	internal static class TestCategory
+	{
+		public const string Memory = "Memory";
+	}
+}

--- a/src/Controls/tests/Core.UnitTests/TestHelpers.cs
+++ b/src/Controls/tests/Core.UnitTests/TestHelpers.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace Microsoft.Maui.Controls.Core.UnitTests
+{
+	internal static class TestHelpers
+	{
+		public static async Task Collect() 
+		{
+			await Task.Yield();
+			GC.Collect();
+			GC.WaitForPendingFinalizers();
+		}
+	}
+}

--- a/src/Controls/tests/Core.UnitTests/TypedBindingUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/TypedBindingUnitTests.cs
@@ -1437,7 +1437,9 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			Assert.Equal(1, viewmodel.InvocationListSize());
 
-			await TestHelpers.Collect();
+			await Task.Yield();
+			GC.Collect();
+			GC.WaitForPendingFinalizers();
 
 			viewmodel.OnPropertyChanged("Foo");
 

--- a/src/Controls/tests/Core.UnitTests/TypedBindingUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/TypedBindingUnitTests.cs
@@ -1406,7 +1406,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			}
 		}
 
-		[Fact]
+		[Fact, Category(TestCategory.Memory)]
 		public async Task BindingUnsubscribesForDeadTarget()
 		{
 			var viewmodel = new TestViewModel();
@@ -1437,9 +1437,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			Assert.Equal(1, viewmodel.InvocationListSize());
 
-			await Task.Yield();
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+			await TestHelpers.Collect();
 
 			viewmodel.OnPropertyChanged("Foo");
 

--- a/src/Controls/tests/Core.UnitTests/VisualElementTests.cs
+++ b/src/Controls/tests/Core.UnitTests/VisualElementTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Data.Common;
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls.Shapes;
 using Microsoft.Maui.Graphics;
@@ -100,7 +101,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.True(fired);
 		}
 
-		[Theory]
+		[Theory, Category(TestCategory.Memory)] 
 		[InlineData(typeof(ImmutableBrush), false)]
 		[InlineData(typeof(SolidColorBrush), false)]
 		[InlineData(typeof(LinearGradientBrush), true)]
@@ -111,13 +112,18 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 				(Brush)Activator.CreateInstance(type) :
 				(Brush)Activator.CreateInstance(type, Colors.CornflowerBlue);
 
-			var reference = new WeakReference(new VisualElement { Background = brush });
+			WeakReference CreateReference()
+			{
+				return new WeakReference(new VisualElement { Background = brush });
+			}
 
-			await Task.Yield();
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+			var reference = CreateReference();
+
+			await TestHelpers.Collect();
 
 			Assert.False(reference.IsAlive, "VisualElement should not be alive!");
+
+			GC.KeepAlive(brush);
 		}
 
 		[Fact]

--- a/src/Controls/tests/Core.UnitTests/WindowsTests.cs
+++ b/src/Controls/tests/Core.UnitTests/WindowsTests.cs
@@ -638,26 +638,28 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.Equal(outH, coreWindow.MinimumHeight);
 		}
 
-		[Fact]
+		[Fact, Category(TestCategory.Memory)]
 		public async Task WindowDoesNotLeak()
 		{
 			var application = new Application();
-			WeakReference reference;
 
-			// Scope for window
+			WeakReference CreateReference()
 			{
 				var window = new Window { Page = new ContentPage() };
-				reference = new WeakReference(window);
+				var reference = new WeakReference(window);
 				application.OpenWindow(window);
 				((IWindow)window).Destroying();
+				return reference;
 			}
 
+			var reference = CreateReference();
+
 			// GC
-			await Task.Yield();
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+			await TestHelpers.Collect();
 
 			Assert.False(reference.IsAlive, "Window should not be alive!");
+
+			GC.KeepAlive(application);
 		}
 
 		// NOTE: this test is here to show `ConditionalWeakTable _requestedWindows` was a bad idea


### PR DESCRIPTION
### Description of Change

Running the unit tests for Controls locally with a Debug build is annoying because of the intermittent GC test failures. These changes make the GC tests more consistent when run locally in Debug mode.

Also adds category class for Controls tests and de-duplicates the forced GC code.

### Issues Fixed

None, it was just bugging me.