### PR TITLE
Recreate Details Fragment, if its been destroyed

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Toolbar/ToolbarTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Toolbar/ToolbarTests.cs
@@ -119,27 +119,27 @@ namespace Microsoft.Maui.DeviceTests
 
 		[Theory]
 		[InlineData($"{nameof(FlyoutPage)}WithNavigationPage, {nameof(ContentPage)}, {nameof(FlyoutPage)}WithNavigationPage"
-#if ANDROID || WINDOWS
+#if WINDOWS
 			, Skip = "Currently Failing on Android & Windows https://github.com/dotnet/maui/issues/17444"
 #endif
 			)]
 		[InlineData($"{nameof(FlyoutPage)}WithNavigationPage, {nameof(FlyoutPage)}, {nameof(FlyoutPage)}WithNavigationPage"
-#if ANDROID || WINDOWS
+#if WINDOWS
 			, Skip = "Currently Failing on Android & Windows https://github.com/dotnet/maui/issues/17444"
 #endif
 			)]
 		[InlineData($"{nameof(FlyoutPage)}WithNavigationPage, {nameof(NavigationPage)}, {nameof(FlyoutPage)}WithNavigationPage"
-#if ANDROID || WINDOWS
+#if WINDOWS
 			, Skip = "Currently Failing on Android & Windows https://github.com/dotnet/maui/issues/17444"
 #endif
 			)]
 		[InlineData($"{nameof(Shell)}, {nameof(ContentPage)}, {nameof(Shell)}"
-#if ANDROID || WINDOWS
+#if WINDOWS
 			, Skip = "Currently Failing on Android & Windows https://github.com/dotnet/maui/issues/17444"
 #endif
 			)]
 		[InlineData($"FlyoutPageWithNavigationPage, NavigationPageWithFlyoutPage, FlyoutPageWithNavigationPage"
-#if ANDROID || WINDOWS
+#if WINDOWS
 			, Skip = "Currently Failing on Android & Windows https://github.com/dotnet/maui/issues/17444"
 #endif
 			)]

--- a/src/Controls/tests/DeviceTests/Elements/Toolbar/ToolbarTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Toolbar/ToolbarTests.cs
@@ -120,27 +120,27 @@ namespace Microsoft.Maui.DeviceTests
 		[Theory]
 		[InlineData($"{nameof(FlyoutPage)}WithNavigationPage, {nameof(ContentPage)}, {nameof(FlyoutPage)}WithNavigationPage"
 #if WINDOWS
-			, Skip = "Currently Failing on Android & Windows https://github.com/dotnet/maui/issues/17444"
+			, Skip = "Currently Failing on Windows https://github.com/dotnet/maui/issues/15530"
 #endif
 			)]
 		[InlineData($"{nameof(FlyoutPage)}WithNavigationPage, {nameof(FlyoutPage)}, {nameof(FlyoutPage)}WithNavigationPage"
 #if WINDOWS
-			, Skip = "Currently Failing on Android & Windows https://github.com/dotnet/maui/issues/17444"
+			, Skip = "Currently Failing on Windows https://github.com/dotnet/maui/issues/15530"
 #endif
 			)]
 		[InlineData($"{nameof(FlyoutPage)}WithNavigationPage, {nameof(NavigationPage)}, {nameof(FlyoutPage)}WithNavigationPage"
 #if WINDOWS
-			, Skip = "Currently Failing on Android & Windows https://github.com/dotnet/maui/issues/17444"
+			, Skip = "Currently Failing on Windows https://github.com/dotnet/maui/issues/15530"
 #endif
 			)]
 		[InlineData($"{nameof(Shell)}, {nameof(ContentPage)}, {nameof(Shell)}"
 #if WINDOWS
-			, Skip = "Currently Failing on Android & Windows https://github.com/dotnet/maui/issues/17444"
+			, Skip = "Currently Failing on  Windows https://github.com/dotnet/maui/issues/15530"
 #endif
 			)]
 		[InlineData($"FlyoutPageWithNavigationPage, NavigationPageWithFlyoutPage, FlyoutPageWithNavigationPage"
 #if WINDOWS
-			, Skip = "Currently Failing on Android & Windows https://github.com/dotnet/maui/issues/17444"
+			, Skip = "Currently Failing on Windows https://github.com/dotnet/maui/issues/15530"
 #endif
 			)]
 		public async Task ToolbarUpdatesCorrectlyWhenSwappingMainPageWithAlreadyUsedPage(string pages)

--- a/src/Core/src/Platform/Android/Navigation/ScopedFragment.cs
+++ b/src/Core/src/Platform/Android/Navigation/ScopedFragment.cs
@@ -8,7 +8,8 @@ namespace Microsoft.Maui.Platform
 	{
 		readonly IMauiContext _mauiContext;
 
-		public IView DetailView { get; private set; }
+		public bool IsDestroyed { get; private set; }
+		public IView DetailView { get; private set; }		
 
 		public ScopedFragment(IView detailView, IMauiContext mauiContext)
 		{
@@ -16,10 +17,25 @@ namespace Microsoft.Maui.Platform
 			_mauiContext = mauiContext;
 		}
 
+		public override void OnViewStateRestored(Bundle? savedInstanceState)
+		{
+			// Fragments have the potential to "undestroy" if you reuse them
+			IsDestroyed = false;
+			base.OnViewStateRestored(savedInstanceState);
+		}
+
 		public override View OnCreateView(LayoutInflater inflater, ViewGroup? container, Bundle? savedInstanceState)
 		{
+			// Fragments have the potential to "undestroy" if you reuse them
+			IsDestroyed = false;
 			var pageMauiContext = _mauiContext.MakeScoped(layoutInflater: inflater, fragmentManager: ChildFragmentManager);
 			return DetailView.ToPlatform(pageMauiContext);
+		}
+
+		public override void OnDestroy()
+		{
+			base.OnDestroy();
+			IsDestroyed = true;
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change

If a FlyoutPage is reused after being removed, we need to just recreate the DetailsViewFragment

### Issues Fixed


Fixes #17444
