### PR TITLE
Reenable WinUI Device Tests parallel running

### DIFF
--- a/src/Core/tests/DeviceTests.Shared/HandlerTests/TestBase.cs
+++ b/src/Core/tests/DeviceTests.Shared/HandlerTests/TestBase.cs
@@ -7,15 +7,12 @@ using Xunit;
 namespace Microsoft.Maui.DeviceTests
 {
 	// Uncomment these sections if you hit issues with parallel executions
+	// [CollectionDefinition("Non-Parallel Collection", DisableParallelization = true)]
+	// public class NonParallelCollectionDefinitionClass
+	// {
+	// }
 
-#if WINDOWS
-	[CollectionDefinition("Non-Parallel Collection", DisableParallelization = true)]
-	public class NonParallelCollectionDefinitionClass
-	{
-	}
-
-	[Collection("Non-Parallel Collection")]
-#endif
+	// [Collection("Non-Parallel Collection")]
 	public partial class TestBase
 	{
 		public const int EmCoefficientPrecision = 4;


### PR DESCRIPTION
### Description of Change

As part of #17221 one of the things we did is not run WinUI tests in parallel. We are now in a working state with that, but ideally we want to run it in parallel and speed things up a bit. This PR comments out the code that disables parallel running for WinUI tests.

### Issues Fixed

N/A
