### PR TITLE
Make ALL template warnings show up as test errors (not just C# warnings), and produce more diagnostic artifacts

### DIFF
--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/BaseBuildTest.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/BaseBuildTest.cs
@@ -98,25 +98,10 @@ namespace Microsoft.Maui.IntegrationTests
 		[TearDown]
 		public void BuildTestTearDown()
 		{
-			// Clean up test or attach content from failed tests
-			if (TestContext.CurrentContext.Result.Outcome.Status == NUnit.Framework.Interfaces.TestStatus.Passed ||
-				TestContext.CurrentContext.Result.Outcome.Status == NUnit.Framework.Interfaces.TestStatus.Skipped)
+			// Attach test content and logs as artifacts
+			foreach (var log in Directory.GetFiles(Path.Combine(TestDirectory), "*log", SearchOption.AllDirectories))
 			{
-				try
-				{
-					if (Directory.Exists(TestDirectory))
-						Directory.Delete(TestDirectory, recursive: true);
-				}
-				catch (IOException)
-				{
-				}
-			}
-			else
-			{
-				foreach (var log in Directory.GetFiles(Path.Combine(TestDirectory), "*log", SearchOption.AllDirectories))
-				{
-					TestContext.AddTestAttachment(log, Path.GetFileName(TestDirectory));
-				}
+				TestContext.AddTestAttachment(log, Path.GetFileName(TestDirectory));
 			}
 		}
 

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/TemplateTests.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/TemplateTests.cs
@@ -124,12 +124,20 @@ namespace Microsoft.Maui.IntegrationTests
 				$"Unable to create template {id}. Check test output for errors.");
 
 			EnableTizen(projectFile);
-			FileUtilities.ReplaceInFile(projectFile, new Dictionary<string, string>()
+
+			var projectSectionsToReplace = new Dictionary<string, string>()
 			{
 				{ "UseMaui", "UseMauiCore" }, // This is the key part of the test
-				{ "Include=\"Microsoft.Maui.Controls\"", "Include=\"Microsoft.Maui.Core\"" }, // And this part is to ensure the version of the MAUI Core package is specified
 				{ "SingleProject", "EnablePreviewMsixTooling" },
-			});
+			};
+			if (framework != "net6.0")
+			{
+				// On versions after net6.0 this package reference also has to be updated to ensure the version of the MAUI Core package
+				// is specified and avoids the MA002 warning.
+				projectSectionsToReplace.Add("Include=\"Microsoft.Maui.Controls\"", "Include=\"Microsoft.Maui.Core\"");
+			}
+
+			FileUtilities.ReplaceInFile(projectFile, projectSectionsToReplace);
 			Directory.Delete(Path.Combine(projectDir, "Platforms"), recursive: true);
 
 			Assert.IsTrue(DotnetInternal.Build(projectFile, config, properties: BuildProps, msbuildWarningsAsErrors: true),

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/TemplateTests.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/TemplateTests.cs
@@ -107,6 +107,9 @@ namespace Microsoft.Maui.IntegrationTests
 			}
 		}
 
+		/// <summary>
+		/// Tests the scenario where a .NET MAUI Library specifically uses UseMauiCore instead of UseMaui.
+		/// </summary>
 		[Test]
 		[TestCase("mauilib", DotNetPrevious, "Debug")]
 		[TestCase("mauilib", DotNetPrevious, "Release")]
@@ -123,6 +126,8 @@ namespace Microsoft.Maui.IntegrationTests
 			EnableTizen(projectFile);
 			FileUtilities.ReplaceInFile(projectFile, new Dictionary<string, string>()
 			{
+				{ "UseMaui", "UseMauiCore" }, // This is the key part of the test
+				{ "Include=\"Microsoft.Maui.Controls\"", "Include=\"Microsoft.Maui.Core\"" }, // And this part is to ensure the version of the MAUI Core package is specified
 				{ "SingleProject", "EnablePreviewMsixTooling" },
 			});
 			Directory.Delete(Path.Combine(projectDir, "Platforms"), recursive: true);

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/TemplateTests.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/TemplateTests.cs
@@ -123,7 +123,6 @@ namespace Microsoft.Maui.IntegrationTests
 			EnableTizen(projectFile);
 			FileUtilities.ReplaceInFile(projectFile, new Dictionary<string, string>()
 			{
-				//{ "UseMaui", "UseMauiCore" },
 				{ "SingleProject", "EnablePreviewMsixTooling" },
 			});
 			Directory.Delete(Path.Combine(projectDir, "Platforms"), recursive: true);

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/TemplateTests.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/TemplateTests.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Maui.IntegrationTests
 					"<PropertyGroup><Version>1.0.0-preview.1</Version></PropertyGroup></Project>");
 
 			string target = shouldPack ? "Pack" : "";
-			Assert.IsTrue(DotnetInternal.Build(projectFile, config, target: target, properties: BuildProps),
+			Assert.IsTrue(DotnetInternal.Build(projectFile, config, target: target, properties: BuildProps, msbuildWarningsAsErrors: true),
 				$"Project {Path.GetFileName(projectFile)} failed to build. Check test output/attachments for errors.");
 		}
 
@@ -69,7 +69,7 @@ namespace Microsoft.Maui.IntegrationTests
 				"<UseMaui>true</UseMaui>",
 				"<UseMaui>true</UseMaui><WindowsPackageType>None</WindowsPackageType>");
 
-			Assert.IsTrue(DotnetInternal.Build(projectFile, config, properties: BuildProps),
+			Assert.IsTrue(DotnetInternal.Build(projectFile, config, properties: BuildProps, msbuildWarningsAsErrors: true),
 				$"Project {Path.GetFileName(projectFile)} failed to build. Check test output/attachments for errors.");
 		}
 
@@ -123,12 +123,12 @@ namespace Microsoft.Maui.IntegrationTests
 			EnableTizen(projectFile);
 			FileUtilities.ReplaceInFile(projectFile, new Dictionary<string, string>()
 			{
-				{ "UseMaui", "UseMauiCore" },
+				//{ "UseMaui", "UseMauiCore" },
 				{ "SingleProject", "EnablePreviewMsixTooling" },
 			});
 			Directory.Delete(Path.Combine(projectDir, "Platforms"), recursive: true);
 
-			Assert.IsTrue(DotnetInternal.Build(projectFile, config, properties: BuildProps),
+			Assert.IsTrue(DotnetInternal.Build(projectFile, config, properties: BuildProps, msbuildWarningsAsErrors: true),
 				$"Project {Path.GetFileName(projectFile)} failed to build. Check test output/attachments for errors.");
 		}
 
@@ -152,7 +152,7 @@ namespace Microsoft.Maui.IntegrationTests
 				"<PackageReference Include=\"Microsoft.Maui.Controls\" Version=\"$(MauiVersion)\" />",
 				"");
 
-			Assert.IsTrue(DotnetInternal.Build(projectFile, config, properties: BuildProps),
+			Assert.IsTrue(DotnetInternal.Build(projectFile, config, properties: BuildProps, msbuildWarningsAsErrors: true),
 				$"Project {Path.GetFileName(projectFile)} failed to build. Check test output/attachments for errors.");
 		}
 
@@ -179,7 +179,7 @@ namespace Microsoft.Maui.IntegrationTests
 				$"<ApplicationVersion>1</ApplicationVersion>",
 				$"<ApplicationVersion>{version}</ApplicationVersion>");
 
-			Assert.IsTrue(DotnetInternal.Build(projectFile, config, properties: BuildProps),
+			Assert.IsTrue(DotnetInternal.Build(projectFile, config, properties: BuildProps, msbuildWarningsAsErrors: true),
 				$"Project {Path.GetFileName(projectFile)} failed to build. Check test output/attachments for errors.");
 		}
 
@@ -205,7 +205,7 @@ namespace Microsoft.Maui.IntegrationTests
 			};
 
 			Assert.IsTrue(DotnetInternal.New(id, projectDir, framework), $"Unable to create template {id}. Check test output for errors.");
-			Assert.IsTrue(DotnetInternal.Build(projectFile, config, framework: $"{framework}-maccatalyst", properties: buildWithCodeSignProps),
+			Assert.IsTrue(DotnetInternal.Build(projectFile, config, framework: $"{framework}-maccatalyst", properties: buildWithCodeSignProps, msbuildWarningsAsErrors: true),
 				$"Project {Path.GetFileName(projectFile)} failed to build. Check test output/attachments for errors.");
 
 			List<string> expectedEntitlements = config == "Release" ?

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/DotnetInternal.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/DotnetInternal.cs
@@ -34,6 +34,23 @@ namespace Microsoft.Maui.IntegrationTests
 				binlogPath = Path.Combine(Path.GetDirectoryName(projectFile) ?? "", binlogName);
 			}
 
+			// We set WarnAsError to specifically cause *MSBuild* warnings to be errors (setting TreatWarningsAsErrors
+			// affect only C# compiler warnings).
+			buildArgs += " -warnaserror";
+
+			// However, we need to ignore specific MSBuild warnings that are acceptable in these tests:
+			var csWarningsToIgnore = new string[]
+			{
+				"NETSDK1201", // Details: "For projects targeting .NET 8.0 and higher, specifying a RuntimeIdentifier
+							  // will no longer produce a self contained app by default. To continue building
+							  // self-contained apps, set the SelfContained property to true or use the --self-contained
+							  // argument."
+							  // Justification: This warning isn't meaningful in this test scenario.
+				"CS1591", // Details: "Missing XML comment for publicly visible type or member 'XYZ'"
+						  // Justification: It's OK for templates to have missing doc comments.
+			};
+			buildArgs += " " + string.Join(" ", csWarningsToIgnore.Select(csWarning => $"-p:nowarn={csWarning}"));
+
 			return Run("build", $"{buildArgs} -bl:\"{binlogPath}\"");
 		}
 
@@ -82,8 +99,10 @@ namespace Microsoft.Maui.IntegrationTests
 		public static bool Run(string command, string args, int timeoutinSeconds = DEFAULT_TIMEOUT)
 		{
 			var runOutput = RunForOutput(command, args, out int exitCode, timeoutinSeconds);
-			if (exitCode != 0)
-				TestContext.WriteLine(runOutput);
+			TestContext.WriteLine($"Process exit code: {exitCode}");
+			TestContext.WriteLine($"-------- Process output start --------");
+			TestContext.WriteLine(runOutput);
+			TestContext.WriteLine($"-------- Process output end --------");
 
 			return exitCode == 0;
 		}

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/DotnetInternal.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/DotnetInternal.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Maui.IntegrationTests
 		static readonly string DotnetTool = Path.Combine(TestEnvironment.GetMauiDirectory(), "bin", "dotnet", "dotnet");
 		const int DEFAULT_TIMEOUT = 900;
 
-		public static bool Build(string projectFile, string config, string target = "", string framework = "", IEnumerable<string>? properties = null, string binlogPath = "")
+		public static bool Build(string projectFile, string config, string target = "", string framework = "", IEnumerable<string>? properties = null, string binlogPath = "", bool msbuildWarningsAsErrors = false)
 		{
 			var binlogName = $"build-{DateTime.UtcNow.ToFileTimeUtc()}.binlog";
 			var buildArgs = $"\"{projectFile}\" -c {config}";
@@ -34,22 +34,25 @@ namespace Microsoft.Maui.IntegrationTests
 				binlogPath = Path.Combine(Path.GetDirectoryName(projectFile) ?? "", binlogName);
 			}
 
-			// We set WarnAsError to specifically cause *MSBuild* warnings to be errors (setting TreatWarningsAsErrors
-			// affect only C# compiler warnings).
-			buildArgs += " -warnaserror";
-
-			// However, we need to ignore specific MSBuild warnings that are acceptable in these tests:
-			var csWarningsToIgnore = new string[]
+			if (msbuildWarningsAsErrors)
 			{
-				"NETSDK1201", // Details: "For projects targeting .NET 8.0 and higher, specifying a RuntimeIdentifier
-							  // will no longer produce a self contained app by default. To continue building
-							  // self-contained apps, set the SelfContained property to true or use the --self-contained
-							  // argument."
-							  // Justification: This warning isn't meaningful in this test scenario.
-				"CS1591", // Details: "Missing XML comment for publicly visible type or member 'XYZ'"
-						  // Justification: It's OK for templates to have missing doc comments.
-			};
-			buildArgs += " " + string.Join(" ", csWarningsToIgnore.Select(csWarning => $"-p:nowarn={csWarning}"));
+				// We set WarnAsError to specifically cause *MSBuild* warnings to be errors (setting TreatWarningsAsErrors
+				// affect only C# compiler warnings).
+				buildArgs += " -warnaserror";
+
+				// However, we need to ignore specific MSBuild warnings that are acceptable in these tests:
+				var csWarningsToIgnore = new string[]
+				{
+					"NETSDK1201", // Details: "For projects targeting .NET 8.0 and higher, specifying a RuntimeIdentifier
+								// will no longer produce a self contained app by default. To continue building
+								// self-contained apps, set the SelfContained property to true or use the --self-contained
+								// argument."
+								// Justification: This warning isn't meaningful in this test scenario.
+					"CS1591", // Details: "Missing XML comment for publicly visible type or member 'XYZ'"
+							// Justification: It's OK for templates to have missing doc comments.
+				};
+				buildArgs += " " + string.Join(" ", csWarningsToIgnore.Select(csWarning => $"-p:nowarn={csWarning}"));
+			}
 
 			return Run("build", $"{buildArgs} -bl:\"{binlogPath}\"");
 		}


### PR DESCRIPTION
Right now we correctly set `TreatWarningsAsErrors=true` for template tests, but that catches only C# compiler warnings and converts those to errors. It does not treat _MSBuild_ warnings as errors. So, any warning during build/publish/whatever that isn't a C# compiler warning is ignored during our tests. And I think this is why https://github.com/dotnet/maui/issues/17561 lingered un-caught for a while.

This PR has a few parts:
1. Make sure MSBuild warnings fail the build with a specific `warnaserror` MSBuild option. This is different from the C# `TreatWarningsAsErrors=true` option. There's info here on that: https://stackoverflow.com/a/47448331/31668
2. Address current warnings that we've been missing or aren't worried about: there are two of these, which you can see in the excluded warnings in the test code.
3. Have the build produce more artifacts even during successful runs. I spent hours trying to get a binlog for _successful_ template test runs (I can't run them locally for an unknown reason). We now attach artifacts for all test runs (success or failure) and you can get test console output as well as binlogs to view/download. With this PR you can download binlogs for any template test and then view locally with https://msbuildlog.com/ online or with an installable app

![image](https://github.com/dotnet/maui/assets/202643/fe25358b-0c80-46c8-adaf-449e68ffb770)

cc @mattleibow @PureWeen 

(This PR is a replacement for #17586.)