### PR TITLE
ScrollView content needs layout when ScrollView.InvalidateMeasure is called

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/ScrollView/ScrollViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/ScrollView/ScrollViewTests.cs
@@ -60,7 +60,11 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
-		[Fact]
+		[Fact(
+#if ANDROID
+			Skip = "Fails on Android"
+#endif
+		)]
 		public async Task TestContentHorizontalOptionsChanged()
 		{
 			var label = new Label

--- a/src/Controls/tests/DeviceTests/Elements/ScrollView/ScrollViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/ScrollView/ScrollViewTests.cs
@@ -60,6 +60,37 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
+		[Fact]
+		public async Task TestContentHorizontalOptionsChanged()
+		{
+			var label = new Label
+			{
+				BackgroundColor = Colors.LightBlue,
+				HorizontalOptions = LayoutOptions.Start,
+				Text = "Hello",
+				WidthRequest = 50,
+			};
+
+			var scrollView = new ScrollView
+			{
+				BackgroundColor = Colors.DarkBlue,
+				Content = label,
+				WidthRequest = 300,
+				HeightRequest = 200,
+			};
+
+			_ = await CreateHandlerAsync<LabelHandler>(label);
+			_ = await CreateHandlerAsync<ScrollViewHandler>(scrollView);
+
+			await AttachAndRun(scrollView, async (handler) =>
+			{
+				await WaitAssert(() => CloseEnough(scrollView.Content.Frame.Left, 0.0));
+
+				scrollView.Content.HorizontalOptions = LayoutOptions.End;
+				await WaitAssert(() => CloseEnough(scrollView.Content.Frame.Right, 300.0));
+			});
+		}
+
 		[Theory]
 		[InlineData(ScrollOrientation.Vertical, 100, 300, 0, 100)]
 		[InlineData(ScrollOrientation.Horizontal, 0, 100, 100, 300)]
@@ -188,22 +219,17 @@ namespace Microsoft.Maui.DeviceTests
 
 		static async Task AssertContentSize(Func<Size> actual, Size expected)
 		{
-			await WaitAssert(() => CloseEnough(actual(), expected, 0.2), timeout: 5000, message: $"ContentSize was {actual()}, expected {expected}");
+			await WaitAssert(() => CloseEnough(actual(), expected), timeout: 5000, message: $"ContentSize was {actual()}, expected {expected}");
 		}
 
-		static bool CloseEnough(Size a, Size b, double tolerance)
+		static bool CloseEnough(double a, double b, double tolerance = 0.2)
 		{
-			if (System.Math.Abs(a.Width - b.Width) > tolerance)
-			{
-				return false;
-			}
+			return System.Math.Abs(a - b) <= tolerance;
+		}
 
-			if (System.Math.Abs(a.Height - b.Height) > tolerance)
-			{
-				return false;
-			}
-
-			return true;
+		static bool CloseEnough(Size a, Size b, double tolerance = 0.2)
+		{
+			return CloseEnough(a.Width, b.Width, tolerance) && CloseEnough(a.Height, b.Height, tolerance);
 		}
 
 		static Task<bool> WatchContentSizeChanged(ScrollView scrollView)

--- a/src/Controls/tests/DeviceTests/Elements/ScrollView/ScrollViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/ScrollView/ScrollViewTests.cs
@@ -60,11 +60,7 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
-		[Fact(
-#if ANDROID
-			Skip = "Fails on Android"
-#endif
-		)]
+		[Fact]
 		public async Task TestContentHorizontalOptionsChanged()
 		{
 			var label = new Label
@@ -87,8 +83,10 @@ namespace Microsoft.Maui.DeviceTests
 
 			await AttachAndRun(scrollView, async (handler) =>
 			{
-				await WaitAssert(() => CloseEnough(scrollView.Content.Frame.Left, 0.0));
+				// Without this delay, the UI didn't render and the bug didn't repro
+				await Task.Delay(100);
 
+				await WaitAssert(() => CloseEnough(scrollView.Content.Frame.Left, 0.0));
 				scrollView.Content.HorizontalOptions = LayoutOptions.End;
 				await WaitAssert(() => CloseEnough(scrollView.Content.Frame.Right, 300.0));
 			});

--- a/src/Controls/tests/DeviceTests/Elements/ScrollView/ScrollViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/ScrollView/ScrollViewTests.cs
@@ -83,8 +83,7 @@ namespace Microsoft.Maui.DeviceTests
 				HeightRequest = 200,
 			};
 
-			_ = await CreateHandlerAsync<LabelHandler>(label);
-			_ = await CreateHandlerAsync<ScrollViewHandler>(scrollView);
+			SetupBuilder();
 
 			await AttachAndRun(scrollView, async (handler) =>
 			{

--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Windows.cs
@@ -20,6 +20,16 @@ namespace Microsoft.Maui.Handlers
 			return new ScrollViewer();
 		}
 
+		internal static void MapInvalidateMeasure(IScrollViewHandler handler, IView view, object? args)
+		{
+			handler.PlatformView.InvalidateMeasure(view);
+
+			if (handler.PlatformView.Content is FrameworkElement content)
+			{
+				content.InvalidateMeasure();
+			}
+		}
+
 		protected override void ConnectHandler(ScrollViewer platformView)
 		{
 			base.ConnectHandler(platformView);

--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.cs
@@ -29,7 +29,8 @@ namespace Microsoft.Maui.Handlers
 
 		public static CommandMapper<IScrollView, IScrollViewHandler> CommandMapper = new(ViewCommandMapper)
 		{
-			[nameof(IScrollView.RequestScrollTo)] = MapRequestScrollTo
+			[nameof(IScrollView.RequestScrollTo)] = MapRequestScrollTo,
+			[nameof(IView.InvalidateMeasure)] = MapInvalidateMeasure,
 		};
 
 		public ScrollViewHandler() : base(Mapper, CommandMapper)

--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.cs
@@ -30,7 +30,9 @@ namespace Microsoft.Maui.Handlers
 		public static CommandMapper<IScrollView, IScrollViewHandler> CommandMapper = new(ViewCommandMapper)
 		{
 			[nameof(IScrollView.RequestScrollTo)] = MapRequestScrollTo,
+#if WINDOWS
 			[nameof(IView.InvalidateMeasure)] = MapInvalidateMeasure,
+#endif
 		};
 
 		public ScrollViewHandler() : base(Mapper, CommandMapper)


### PR DESCRIPTION
### Description of Change

When `ScrollView.Content` changes its alignment (like `HorizontalOptions` change from `Start` to `End`), then the `ScrollView`'s layout needs to properly update. It worked on Android and Mac/iOS, but Windows would not update layout until the window was resized.

After `HorizontalOptions` changed on the content, Windows would call `InvalidateMeasure` on the WinUI `ScrollView`, but the child content didn't get updated. This change makes sure that the content also gets measured.

This fix is helpful for XAML Hot Reload, so the layout will update as `HorizontalOptions` changes.

### Issues Fixed

Fixes #14377
