### PR TITLE
`sealed` some `internal` classes in `Controls.Core` that are not inherited from (2)

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/ViewCellRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/ViewCellRenderer.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			c?.DisconnectHandler();
 		}
 
-		internal class ViewCellContainer : ViewGroup, INativeElementView
+		internal sealed class ViewCellContainer : ViewGroup, INativeElementView
 		{
 			readonly View _parent;
 			readonly BindableProperty _rowHeight;
@@ -147,20 +147,11 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				UpdateWatchForLongPress();
 			}
 
-			protected bool ParentHasUnevenRows
-			{
-				get { return (bool)_parent.GetValue(_unevenRows); }
-			}
+			private bool ParentHasUnevenRows => (bool)_parent.GetValue(_unevenRows);
 
-			protected int ParentRowHeight
-			{
-				get { return (int)_parent.GetValue(_rowHeight); }
-			}
+			private int ParentRowHeight => (int)_parent.GetValue(_rowHeight);
 
-			public Element Element
-			{
-				get { return _viewCell; }
-			}
+			public Element Element => _viewCell;
 
 			public override bool OnInterceptTouchEvent(MotionEvent ev)
 			{
@@ -370,7 +361,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				ListViewRenderer?.LongClickOn(this);
 			}
 
-			internal class TapGestureListener : Java.Lang.Object, GestureDetector.IOnGestureListener
+			internal sealed class TapGestureListener : Java.Lang.Object, GestureDetector.IOnGestureListener
 			{
 				readonly Action _onClick;
 
@@ -415,7 +406,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				}
 			}
 
-			internal class LongPressGestureListener : Java.Lang.Object, GestureDetector.IOnGestureListener
+			internal sealed class LongPressGestureListener : Java.Lang.Object, GestureDetector.IOnGestureListener
 			{
 				readonly Action _onLongClick;
 

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/Windows/ListViewRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/Windows/ListViewRenderer.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			AutoPackage = false;
 		}
 
-		internal class ListViewTransparent : WListView
+		internal sealed class ListViewTransparent : WListView
 		{
 			internal ListViewRenderer ListViewRenderer { get; }
 			public ListViewTransparent(ListViewRenderer listViewRenderer) : base()

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/iOS/ContextActionCell.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/iOS/ContextActionCell.cs
@@ -14,7 +14,7 @@ using SizeF = CoreGraphics.CGSize;
 
 namespace Microsoft.Maui.Controls.Handlers.Compatibility
 {
-	internal class ContextActionsCell : UITableViewCell, INativeElementView
+	internal sealed class ContextActionsCell : UITableViewCell, INativeElementView
 	{
 		public const string Key = "ContextActionsCell";
 
@@ -58,15 +58,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		public UITableViewCell ContentCell { get; private set; }
 
-		public bool IsOpen
-		{
-			get { return ScrollDelegate.IsOpen; }
-		}
+		public bool IsOpen => ScrollDelegate.IsOpen;
 
-		ContextScrollViewDelegate ScrollDelegate
-		{
-			get { return (ContextScrollViewDelegate)_scroller.Delegate; }
-		}
+		ContextScrollViewDelegate ScrollDelegate => (ContextScrollViewDelegate)_scroller.Delegate;
 
 		Element INativeElementView.Element
 		{
@@ -628,7 +622,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			table.AddGestureRecognizer(new SelectGestureRecognizer());
 		}
 
-		class SelectGestureRecognizer : UITapGestureRecognizer
+		private sealed class SelectGestureRecognizer : UITapGestureRecognizer
 		{
 			NSIndexPath _lastPath;
 
@@ -663,12 +657,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			}
 		}
 
-		class MoreActionSheetController : UIAlertController
+		private sealed class MoreActionSheetController : UIAlertController
 		{
-			public override UIAlertControllerStyle PreferredStyle
-			{
-				get { return UIAlertControllerStyle.ActionSheet; }
-			}
+			public override UIAlertControllerStyle PreferredStyle => UIAlertControllerStyle.ActionSheet;
 
 			public override void WillRotate(UIInterfaceOrientation toInterfaceOrientation, double duration)
 			{

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/iOS/ContextScrollViewDelegate.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/iOS/ContextScrollViewDelegate.cs
@@ -9,7 +9,7 @@ using RectangleF = CoreGraphics.CGRect;
 
 namespace Microsoft.Maui.Controls.Handlers.Compatibility
 {
-	internal class iOS7ButtonContainer : UIView
+	internal sealed class iOS7ButtonContainer : UIView
 	{
 		readonly nfloat _buttonWidth;
 
@@ -37,7 +37,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		}
 	}
 
-	internal class ContextScrollViewDelegate : UIScrollViewDelegate
+	internal sealed class ContextScrollViewDelegate : UIScrollViewDelegate
 	{
 		readonly nfloat _finalButtonSize;
 		UIView _backgroundView;

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/iOS/ListViewRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/iOS/ListViewRenderer.cs
@@ -786,7 +786,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			}
 		}
 
-		internal class UnevenListViewDataSource : ListViewDataSource
+		internal sealed class UnevenListViewDataSource : ListViewDataSource
 		{
 			IPlatformViewHandler _prototype;
 			bool _disposed;
@@ -1500,7 +1500,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		}
 	}
 
-	internal class FormsUITableViewController : UITableViewController
+	internal sealed class FormsUITableViewController : UITableViewController
 	{
 		ListView _list;
 		UIRefreshControl _refresh;

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/iOS/ViewCellRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/iOS/ViewCellRenderer.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			return cell;
 		}
 
-		internal class ViewTableCell : UITableViewCell, INativeElementView
+		internal sealed class ViewTableCell : UITableViewCell, INativeElementView
 		{
 			IMauiContext MauiContext => _viewCell.FindMauiContext();
 			WeakReference<IPlatformViewHandler> _rendererRef;

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellContentView.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellContentView.cs
@@ -14,7 +14,7 @@ using LP = Android.Views.ViewGroup.LayoutParams;
 namespace Microsoft.Maui.Controls.Platform.Compatibility
 {
 	// This is used to monitor an xplat View and apply layout changes
-	internal class ShellViewRenderer
+	internal sealed class ShellViewRenderer
 	{
 		public IViewHandler Handler { get; private set; }
 		IView _view;
@@ -96,7 +96,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			return ((IPlatformViewHandler)_view.Handler).MeasureVirtualView(widthMeasureSpec, heightMeasureSpec);
 		}
 
-		public virtual void OnViewSet(IView view)
+		public void OnViewSet(IView view)
 		{
 			if (view == View)
 				return;

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFlyoutTemplatedContentRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFlyoutTemplatedContentRenderer.cs
@@ -829,7 +829,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 		}
 	}
 
-	internal class ScrollLayoutManager : LinearLayoutManager
+	internal sealed class ScrollLayoutManager : LinearLayoutManager
 	{
 		public ScrollMode ScrollVertically { get; set; } = ScrollMode.Auto;
 

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFragmentContainer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFragmentContainer.cs
@@ -7,7 +7,7 @@ using LP = Android.Views.ViewGroup.LayoutParams;
 
 namespace Microsoft.Maui.Controls.Platform.Compatibility
 {
-	internal class ShellFragmentContainer : Fragment
+	internal sealed class ShellFragmentContainer : Fragment
 	{
 		Page _page;
 		IMauiContext _mauiContext;

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFragmentStateAdapter.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFragmentStateAdapter.cs
@@ -11,7 +11,7 @@ using Java.Lang;
 
 namespace Microsoft.Maui.Controls.Platform.Compatibility
 {
-	internal class ShellFragmentStateAdapter : FragmentStateAdapter
+	internal sealed class ShellFragmentStateAdapter : FragmentStateAdapter
 	{
 		bool _disposed;
 		ShellSection _shellSection;


### PR DESCRIPTION
### Description of Change
Sealed some classes. They are not part of the public API, but this change can help us better track code invariants