### PR TITLE
Override CA1822 for Android interface implementation in MauiScrollView

### DIFF
--- a/src/Core/src/Platform/Android/MauiScrollView.cs
+++ b/src/Core/src/Platform/Android/MauiScrollView.cs
@@ -291,7 +291,9 @@ namespace Microsoft.Maui.Platform
 			animator.Start();
 		}
 
+#pragma warning disable CA1822 // DO NOT REMOVE! Needed because dotnet format will else try to make this static and break things
 		void IOnScrollChangeListener.OnScrollChange(NestedScrollView v, int scrollX, int scrollY, int oldScrollX, int oldScrollY)
+#pragma warning restore CA1822
 		{
 			OnScrollChanged(scrollX, scrollY, oldScrollX, oldScrollY);
 		}


### PR DESCRIPTION
### Description of Change

Ignore the CA1822 result for this explicit Android interface implementation. The daily `dotnet format` run will pick this line up and make it static which will break the build. See #17640.

Interesting enough this warning is not triggered in VS or when `dotnet format` is ran locally. Reported that here to hopefully get some clarity on that: https://github.com/dotnet/format/issues/1960

### Issues Fixed

NA