### PR TITLE
[X] revert #5611

### DIFF
--- a/src/Controls/src/Xaml/SimplifyOnPlatformVisitor.cs
+++ b/src/Controls/src/Xaml/SimplifyOnPlatformVisitor.cs
@@ -76,57 +76,57 @@ namespace Microsoft.Maui.Controls.Xaml
 			}
 
 			//`<OnPlatform>` elements
-			if (node.XmlType.Name == "OnPlatform" && node.XmlType.NamespaceUri == XamlParser.MauiUri)
-			{
-				var onNode = GetOnNode(node, Target) ?? GetDefault(node);
+			//if (node.XmlType.Name == "OnPlatform" && node.XmlType.NamespaceUri == XamlParser.MauiUri)
+			//{
+			//	var onNode = GetOnNode(node, Target) ?? GetDefault(node);
 
-				//Property node
-				if (ApplyPropertiesVisitor.TryGetPropertyName(node, parentNode, out XmlName name)
-					&& parentNode is IElementNode parentEnode)
-				{
-					if (onNode != null)
-						parentEnode.Properties[name] = onNode;
-					else
-						parentEnode.Properties.Remove(name);
-					return;
-				}
+			//	//Property node
+			//	if (ApplyPropertiesVisitor.TryGetPropertyName(node, parentNode, out XmlName name)
+			//		&& parentNode is IElementNode parentEnode)
+			//	{
+			//		if (onNode != null)
+			//			parentEnode.Properties[name] = onNode;
+			//		else
+			//			parentEnode.Properties.Remove(name);
+			//		return;
+			//	}
 
-				//Collection item
-				if (onNode != null && parentNode is IElementNode parentEnode2)
-					parentEnode2.CollectionItems[parentEnode2.CollectionItems.IndexOf(node)] = onNode;
+			//	//Collection item
+			//	if (onNode != null && parentNode is IElementNode parentEnode2)
+			//		parentEnode2.CollectionItems[parentEnode2.CollectionItems.IndexOf(node)] = onNode;
 
-			}
+			//}
 
-			INode GetOnNode(ElementNode onPlatform, string target)
-			{
-				foreach (var onNode in onPlatform.CollectionItems)
-				{
-					if ((onNode as ElementNode).Properties.TryGetValue(new XmlName("", "Platform"), out var platform))
-					{
-						var splits = ((platform as ValueNode).Value as string).Split(',');
-						foreach (var split in splits)
-						{
-							if (string.IsNullOrWhiteSpace(split))
-								continue;
-							if (split.Trim() == target)
-							{
-								if ((onNode as ElementNode).Properties.TryGetValue(new XmlName("", "Value"), out var node))
-									return node;
+			//INode GetOnNode(ElementNode onPlatform, string target)
+			//{
+			//	foreach (var onNode in onPlatform.CollectionItems)
+			//	{
+			//		if ((onNode as ElementNode).Properties.TryGetValue(new XmlName("", "Platform"), out var platform))
+			//		{
+			//			var splits = ((platform as ValueNode).Value as string).Split(',');
+			//			foreach (var split in splits)
+			//			{
+			//				if (string.IsNullOrWhiteSpace(split))
+			//					continue;
+			//				if (split.Trim() == target)
+			//				{
+			//					if ((onNode as ElementNode).Properties.TryGetValue(new XmlName("", "Value"), out var node))
+			//						return node;
 
-								return (onNode as ElementNode).CollectionItems.FirstOrDefault();
-							}
-						}
-					}
-				}
-				return null;
-			}
+			//					return (onNode as ElementNode).CollectionItems.FirstOrDefault();
+			//				}
+			//			}
+			//		}
+			//	}
+			//	return null;
+			//}
 
-			INode GetDefault(ElementNode onPlatform)
-			{
-				if (node.Properties.TryGetValue(new XmlName("", "Default"), out INode defaultNode))
-					return defaultNode;
-				return null;
-			}
+			//INode GetDefault(ElementNode onPlatform)
+			//{
+			//	if (node.Properties.TryGetValue(new XmlName("", "Default"), out INode defaultNode))
+			//		return defaultNode;
+			//	return null;
+			//}
 
 		}
 

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui17461.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui17461.xaml
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests"
+             x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui17461">
+    <ContentPage.Resources>
+        <!--<Color x:Key="LightSmoke">#4FFFFFFF</Color>-->
+        <OnPlatform x:Key="EntryBackgroundColor" x:TypeArguments="Color">
+            <On Platform="iOS" Value="{StaticResource LightSmoke}" />
+            <On Platform="Android" Value="Transparent" />
+        </OnPlatform>
+    </ContentPage.Resources>    
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui17461.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui17461.xaml.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using Microsoft.Maui.ApplicationModel;
+using Microsoft.Maui.Controls.Core.UnitTests;
+using Microsoft.Maui.Controls.Shapes;
+using Microsoft.Maui.Devices;
+using Microsoft.Maui.Graphics;
+using NUnit.Framework;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public partial class Maui17461 : ContentPage
+{
+
+	public Maui17461() => InitializeComponent();
+
+	public Maui17461(bool useCompiledXaml)
+	{
+		//this stub will be replaced at compile time
+	}
+
+	[TestFixture]
+	class Test
+	{
+		[SetUp] public void Setup() => AppInfo.SetCurrent(new MockAppInfo());
+
+
+		[TearDown] public void TearDown() => AppInfo.SetCurrent(null);
+
+		[Test]
+		public void MissingKeyException([Values("net7.0-ios", "net7.0-android", "net7.0-macos")] string targetFramework)
+		{
+			MockCompiler.Compile(typeof(Maui17461), out var methodDef, targetFramework: targetFramework);
+		}
+	}
+}

--- a/src/Controls/tests/Xaml.UnitTests/OnPlatformOptimization.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/OnPlatformOptimization.xaml.cs
@@ -45,6 +45,7 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 			}
 
 			[Test]
+			[Ignore("capability disabled for now")]
 			public void OnPlatformAreSimplified([Values("net6.0-ios", "net6.0-android")] string targetFramework)
 			{
 				MockCompiler.Compile(typeof(OnPlatformOptimization), out var methodDef, targetFramework);


### PR DESCRIPTION
### Description of Change

As reported in #17461, OnPlatform simplification cause some issues
- while used as a Resource (#17461, unable to unit test for now)
- doesn't type convert. "On" nodes shouldn't be replaced by the Value, but an element node (`<On Platform="..." Value="Red" />` should generate `<Color x:Key="foo">Red</Color>`. right now it only generate "Red"

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

- fixes #17461

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
