### PR TITLE
Correctly expand rows/columns when grid padding

### DIFF
--- a/src/Core/src/Layouts/GridLayoutManager.cs
+++ b/src/Core/src/Layouts/GridLayoutManager.cs
@@ -813,12 +813,12 @@ namespace Microsoft.Maui.Layouts
 
 				if (expandStarRows)
 				{
-					ExpandStarDefinitions(_rows, targetSize.Height - _padding.VerticalThickness, GridMinimumHeight(), _rowSpacing, _rowStarCount);
+					ExpandStarDefinitions(_rows, targetSize.Height - _padding.VerticalThickness, GridMinimumHeight() - _padding.VerticalThickness, _rowSpacing, _rowStarCount);
 				}
 
 				if (expandStarColumns)
 				{
-					ExpandStarDefinitions(_columns, targetSize.Width - _padding.HorizontalThickness, GridMinimumWidth(), _columnSpacing, _columnStarCount);
+					ExpandStarDefinitions(_columns, targetSize.Width - _padding.HorizontalThickness, GridMinimumWidth() - _padding.HorizontalThickness, _columnSpacing, _columnStarCount);
 				}
 			}
 


### PR DESCRIPTION
### Description of Change

When expanding star definitions, the `targetSize` parameter contains the padding (which is removed). 
However, the calculation for the the `GridMinimum[Width|Height]()` also has the padding which also needs to be removed.

If the padding is not removed, then as soon as the grid width/height reaches the point where the "extra padding" is, then there is a fail fast path in `ExpandStars` which determines that there is no difference in size so skips the calculations for the star expansion. It also appears that the parameter with the "extra padding" (`currentSize`) is _just_ used for this fail fast path.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #16815
Fixes #18160

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
