### PR TITLE
Don't run hide on tapped code if window is null

### DIFF
--- a/src/Controls/src/Core/ContentPage/HideSoftInputOnTappedChanged/HideSoftInputOnTappedChangedManager.Platform.cs
+++ b/src/Controls/src/Core/ContentPage/HideSoftInputOnTappedChanged/HideSoftInputOnTappedChangedManager.Platform.cs
@@ -79,6 +79,14 @@ namespace Microsoft.Maui.Controls
 				return null;
 			}
 
+			if (ve.Window is null)
+			{
+				// This means the xplat IsFocused value has lagged behind navigation events.
+				// This might happen if navigated has fired on the incoming page but the
+				// "LostFocus" event hasn't propagated from the previous one
+				return null;
+			}
+
 			IDisposable? platformToken = SetupHideSoftInputOnTapped(platformView);
 
 #if ANDROID

--- a/src/Controls/tests/DeviceTests/ControlsHandlerTestBase.cs
+++ b/src/Controls/tests/DeviceTests/ControlsHandlerTestBase.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Maui.DeviceTests
 		protected override MauiAppBuilder ConfigureBuilder(MauiAppBuilder mauiAppBuilder)
 		{
 			mauiAppBuilder.Services.AddSingleton<IApplication>((_) => new ApplicationStub());
+			mauiAppBuilder.Services.AddScoped(_ => new HideSoftInputOnTappedChangedManager());
 			return mauiAppBuilder.ConfigureTestBuilder();
 		}
 

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
@@ -40,6 +40,7 @@ namespace Microsoft.Maui.DeviceTests
 					SetupShellHandlers(handlers);
 					handlers.AddHandler(typeof(NavigationPage), typeof(NavigationViewHandler));
 					handlers.AddHandler(typeof(Button), typeof(ButtonHandler));
+					handlers.AddHandler(typeof(Entry), typeof(EntryHandler));
 					handlers.AddHandler(typeof(Controls.ContentView), typeof(ContentViewHandler));
 					handlers.AddHandler(typeof(ScrollView), typeof(ScrollViewHandler));
 					handlers.AddHandler(typeof(CollectionView), typeof(CollectionViewHandler));
@@ -999,6 +1000,49 @@ namespace Microsoft.Maui.DeviceTests
 
 			await AssertionExtensions.WaitForGC(pageReference);
 			Assert.False(pageReference.IsAlive, "Page should not be alive!");
+		}
+
+		[Fact(DisplayName = "HideSoftInputOnTapped Doesnt Crash If Entry Is Still Focused After Window Is Null")]
+		public async Task HideSoftInputOnTappedDoesntCrashIfEntryIsStillFocusedAfterWindowIsNull()
+		{
+			SetupBuilder();
+
+			Entry entry1;
+			Entry entry2;
+
+			var rootPage = CreatePage(out entry1);
+			var nextPage = CreatePage(out entry2);
+
+			var shell = await CreateShellAsync(shell =>
+			{
+				shell.CurrentItem = rootPage;
+			});
+
+			await CreateHandlerAndAddToWindow<IWindowHandler>(shell, async (handler) =>
+			{
+				entry1.Focus();
+				await entry1.WaitForFocused();
+
+				await rootPage.Navigation.PushAsync(nextPage);
+				entry2.Focus();
+				await entry2.WaitForFocused();
+
+				await shell.GoToAsync("..", false);
+			});
+
+			ContentPage CreatePage(out Entry entry)
+			{
+				entry = new Entry();
+
+				return new ContentPage()
+				{
+					HideSoftInputOnTapped = true,
+					Content = new VerticalStackLayout()
+					{
+						entry
+					}
+				};
+			}
 		}
 
 		[Fact(DisplayName = "Can Reuse Pages")]


### PR DESCRIPTION
### Description of Change

If navigation isn't animated the navigated event will sometimes fire on the incoming page before IsFocused has transitioned to false on the previous page. This could also happen if there's a bug with `Focus` propagation so it's important to guard against window being null.

Points to consider around if we should backport.
- the crash will only happen on android if you enable HideSoftInputOnTapped which is new functionality added for NET8
- It only crashes when navigating backwards without animation. By default, shell navigates back without animation if you don't use the parameter to tell it to use animation.
- technically you can work around it by setting HideSoftInputOnTapped false before navigating back
- It's a fairly light change that touches a very isolated area of the code

### Issues Fixed
Fixes #17681

