### PR TITLE
Correct InputView.MaxLengthProperty declaring type

### DIFF
--- a/src/Controls/src/Core/InputView/InputView.cs
+++ b/src/Controls/src/Core/InputView/InputView.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Maui.Controls
 		public static readonly BindableProperty IsTextPredictionEnabledProperty = BindableProperty.Create(nameof(IsTextPredictionEnabled), typeof(bool), typeof(InputView), true);
 
 		/// <summary>Bindable property for <see cref="MaxLength"/>.</summary>
-		public static readonly BindableProperty MaxLengthProperty = BindableProperty.Create(nameof(MaxLength), typeof(int), typeof(int), int.MaxValue);
+		public static readonly BindableProperty MaxLengthProperty = BindableProperty.Create(nameof(MaxLength), typeof(int), typeof(InputView), int.MaxValue);
 
 		/// <summary>Bindable property for <see cref="IsReadOnly"/>.</summary>
 		public static readonly BindableProperty IsReadOnlyProperty = BindableProperty.Create(nameof(IsReadOnly), typeof(bool), typeof(InputView), false);


### PR DESCRIPTION
### Description of Change

This corrects the declaring type of `InputView.MaxLengthProperty`. It's set to `int` right now, but should be `InputView`.

### Issues Fixed

Fixes #17780