### PR TITLE
[proposal] Add IgnoreSafeArea

### DIFF
--- a/src/Controls/src/Core/ScrollView/ScrollView.cs
+++ b/src/Controls/src/Core/ScrollView/ScrollView.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/ScrollView.xml" path="Type[@FullName='Microsoft.Maui.Controls.ScrollView']/Docs/*" />
 	[ContentProperty(nameof(Content))]
-	public partial class ScrollView : Compatibility.Layout, IScrollViewController, IElementConfiguration<ScrollView>, IFlowDirectionController, IScrollView, IContentView
+	public partial class ScrollView : Compatibility.Layout, IScrollViewController, IElementConfiguration<ScrollView>, IFlowDirectionController, IScrollView, IContentView, ISafeAreaView
 	{
 		#region IScrollViewController
 
@@ -137,6 +137,7 @@ namespace Microsoft.Maui.Controls
 		View _content;
 		TaskCompletionSource<bool> _scrollCompletionSource;
 		Rect _layoutAreaOverride;
+		private bool _ignoreSafeArea;
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/ScrollView.xml" path="//Member[@MemberName='Content']/Docs/*" />
 		public View Content
@@ -430,6 +431,24 @@ namespace Microsoft.Maui.Controls
 				}
 			}
 		}
+
+#pragma warning disable RS0016 // Add public types and members to the declared API
+
+		public bool IgnoreSafeArea
+		{
+			get
+			{
+				return _ignoreSafeArea;
+			}
+
+			set
+			{
+				_ignoreSafeArea = value;
+				Handler?.UpdateValue(nameof(ISafeAreaView.IgnoreSafeArea));
+			}
+		}
+
+#pragma warning restore RS0016 // Add public types and members to the declared API
 
 		void IScrollView.RequestScrollTo(double horizontalOffset, double verticalOffset, bool instant)
 		{

--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.cs
@@ -22,8 +22,10 @@ namespace Microsoft.Maui.Handlers
 			[nameof(IScrollView.HorizontalScrollBarVisibility)] = MapHorizontalScrollBarVisibility,
 			[nameof(IScrollView.VerticalScrollBarVisibility)] = MapVerticalScrollBarVisibility,
 			[nameof(IScrollView.Orientation)] = MapOrientation,
-#if __IOS__
+#if IOS
 			[nameof(IScrollView.IsEnabled)] = MapIsEnabled,
+			[nameof(ISafeAreaView.IgnoreSafeArea)] = MapIgnoreSafeArea,
+
 #endif
 		};
 

--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.iOS.cs
@@ -136,6 +136,21 @@ namespace Microsoft.Maui.Handlers
 			}
 		}
 
+		static void MapIgnoreSafeArea(IScrollViewHandler handler, IScrollView view)
+		{
+			if (view is ISafeAreaView sav)
+			{
+				if (sav.IgnoreSafeArea)
+				{
+					handler.PlatformView.ContentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentBehavior.Automatic;
+				}
+				else
+				{
+					handler.PlatformView.ContentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentBehavior.Never;
+				}
+			}
+		}
+
 		// Find the internal ContentView; it may not be Subviews[0] because of the scrollbars
 		static ContentView? GetContentView(UIScrollView scrollView)
 		{


### PR DESCRIPTION
### Description of Change

On the template the ScrollView currently has scrollbars because the content is allowed to scroll into the navbar area. If we add IgnoreSafeArea and map this to `ContentInsetAdjustmentBehavior` then the ScrollView 

### Areas to Investigate
- are we going to get colliding behavior letting iOS manage these insets for us? should we be settings these insets ourselves to ensure that all inset related code is cooperative? 
- Should we just leave this alone until we get better defined safearea APIS and set the safearea platform specific on our templates to "True" so it doesn't have scrollbars?

### Issues Fixed
Fixes #17224
