### PR TITLE
Limit star expansion when measuring/arranging at constrained sizes

### DIFF
--- a/src/Core/src/Layouts/GridLayoutManager.cs
+++ b/src/Core/src/Layouts/GridLayoutManager.cs
@@ -813,12 +813,20 @@ namespace Microsoft.Maui.Layouts
 
 				if (expandStarRows)
 				{
-					ExpandStarDefinitions(_rows, targetSize.Height - _padding.VerticalThickness, GridMinimumHeight() - _padding.VerticalThickness, _rowSpacing, _rowStarCount, !double.IsInfinity(_gridHeightConstraint));
+					// If the grid is constrained vertically, we will need to limit the upper size of * rows;
+					// if not, they can be whatever size makes sense for the content
+					var limitStarRowHeights = !double.IsInfinity(_gridHeightConstraint);
+					ExpandStarDefinitions(_rows, targetSize.Height - _padding.VerticalThickness, GridMinimumHeight() - _padding.VerticalThickness, 
+						_rowSpacing, _rowStarCount, limitStarRowHeights);
 				}
 
 				if (expandStarColumns)
 				{
-					ExpandStarDefinitions(_columns, targetSize.Width - _padding.HorizontalThickness, GridMinimumWidth() - _padding.HorizontalThickness, _columnSpacing, _columnStarCount, !double.IsInfinity(_gridWidthConstraint));
+					// If the grid is constrained horizontally, we will need to limit the upper size of * columns;
+					// if not, they can be whatever size makes sense for the content
+					var limitStarRowWidths = !double.IsInfinity(_gridWidthConstraint);
+					ExpandStarDefinitions(_columns, targetSize.Width - _padding.HorizontalThickness, GridMinimumWidth() - _padding.HorizontalThickness, 
+						_columnSpacing, _columnStarCount, limitStarRowWidths);
 				}
 			}
 

--- a/src/Core/src/Layouts/GridLayoutManager.cs
+++ b/src/Core/src/Layouts/GridLayoutManager.cs
@@ -813,12 +813,12 @@ namespace Microsoft.Maui.Layouts
 
 				if (expandStarRows)
 				{
-					ExpandStarDefinitions(_rows, targetSize.Height - _padding.VerticalThickness, GridMinimumHeight() - _padding.VerticalThickness, _rowSpacing, _rowStarCount);
+					ExpandStarDefinitions(_rows, targetSize.Height - _padding.VerticalThickness, GridMinimumHeight() - _padding.VerticalThickness, _rowSpacing, _rowStarCount, !double.IsInfinity(_gridHeightConstraint));
 				}
 
 				if (expandStarColumns)
 				{
-					ExpandStarDefinitions(_columns, targetSize.Width - _padding.HorizontalThickness, GridMinimumWidth() - _padding.HorizontalThickness, _columnSpacing, _columnStarCount);
+					ExpandStarDefinitions(_columns, targetSize.Width - _padding.HorizontalThickness, GridMinimumWidth() - _padding.HorizontalThickness, _columnSpacing, _columnStarCount, !double.IsInfinity(_gridWidthConstraint));
 				}
 			}
 
@@ -833,16 +833,40 @@ namespace Microsoft.Maui.Layouts
 				}
 			}
 
-			void ExpandStarDefinitions(Definition[] definitions, double targetSize, double currentSize, double spacing, double starCount)
+			static void ExpandStarDefinitions(Definition[] definitions, double targetSize, double currentSize, double spacing, double starCount, bool limitStarSizes)
 			{
 				// Figure out what the star value should be at this size
 				var starSize = ComputeStarSizeForTarget(targetSize, definitions, spacing, starCount);
 
+				if (limitStarSizes)
+				{
+					// Before we expand the star values, we need to ensure that the size and minimum size of
+					// each star row/column do not exceed the value for starSize at the arranged size 
+					// (which may be smaller than the measured size)
+					EnsureSizeLimit(definitions, starSize);
+				}
+
 				// Inflate the stars so that we fill up the space at this size
-				GridStructure.ExpandStars(targetSize, currentSize, definitions, starSize, starCount);
+				ExpandStars(targetSize, currentSize, definitions, starSize, starCount);
 			}
 
-			double ComputeStarSizeForTarget(double targetSize, Definition[] defs, double spacing, double starCount)
+			static void EnsureSizeLimit(Definition[] definitions, double starSize)
+			{
+				for (int n = 0; n < definitions.Length; n++)
+				{
+					var def = definitions[n];
+					if (!def.IsStar)
+					{
+						continue;
+					}
+
+					var maxSize = starSize * def.GridLength.Value;
+					def.Size = Math.Min(maxSize, def.Size);
+					def.MinimumSize = Math.Min(maxSize, def.MinimumSize);
+				}
+			}
+
+			static double ComputeStarSizeForTarget(double targetSize, Definition[] defs, double spacing, double starCount)
 			{
 				var sum = SumDefinitions(defs, spacing, true);
 

--- a/src/Core/tests/UnitTests/Layouts/GridLayoutManagerTests.cs
+++ b/src/Core/tests/UnitTests/Layouts/GridLayoutManagerTests.cs
@@ -3170,5 +3170,73 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			// Ensure that the * Column width was updated to include the wider view
 			AssertArranged(view0, new Rect(0, 0, 40, 20));
 		}
+
+
+		// TODO cut down test below, then dupe it for width
+		// Might be able to make this work single column with the oversized item in col 0
+
+		[Theory, Category(GridStarSizing)]
+		[InlineData(926, 845)]
+		//[InlineData(926, 926)]
+		//[InlineData(926, 1026)]
+		public void StarsAdjustWhenArrangeAndMeasureHeightDiffer(double heightConstraint, double arrangedHeight)
+		{
+			var grid = CreateGridLayout(rows: "*, *", columns: "*");
+
+			var smallerView = CreateTestView(new Size(20, 20));
+			var largerView = CreateTestView(new Size(20, 500));
+
+			SubstituteChildren(grid, largerView, smallerView);
+
+			SetLocation(grid, smallerView, col: 0, row: 0);
+			SetLocation(grid, largerView, row: 1, col: 0);
+
+			var gridLayoutManager = new GridLayoutManager(grid);
+
+			double widthConstraint = 400;
+			double yOffset = 40;
+
+			_ = gridLayoutManager.Measure(widthConstraint, heightConstraint);
+
+			// Arranging at a different size than the measurement constraints
+			gridLayoutManager.ArrangeChildren(new Rect(0, yOffset, widthConstraint, arrangedHeight));
+
+			double expectedHeight = arrangedHeight / 2;
+
+			AssertArranged(smallerView, new Rect(0, yOffset, widthConstraint, expectedHeight));
+			AssertArranged(largerView, new Rect(0, expectedHeight + yOffset, widthConstraint, expectedHeight));
+		}
+
+		[Theory, Category(GridStarSizing)]
+		[InlineData(926, 845)]
+		[InlineData(926, 926)]
+		[InlineData(926, 1026)]
+		public void StarsAdjustWhenArrangeAndMeasureWidthDiffer(double widthConstraint, double arrangedWidth)
+		{
+			var grid = CreateGridLayout(rows: "*", columns: "*, *");
+
+			var smallerView = CreateTestView(new Size(20, 20));
+			var largerView = CreateTestView(new Size(500, 20));
+
+			SubstituteChildren(grid, largerView, smallerView);
+
+			SetLocation(grid, smallerView, col: 0, row: 0);
+			SetLocation(grid, largerView, row: 0, col: 1);
+
+			var gridLayoutManager = new GridLayoutManager(grid);
+
+			double heightConstraint = 400;
+			double xOffset = 40;
+
+			_ = gridLayoutManager.Measure(widthConstraint, heightConstraint);
+
+			// Arranging at a different size than the measurement constraints
+			gridLayoutManager.ArrangeChildren(new Rect(xOffset, 0, arrangedWidth, heightConstraint));
+
+			double expectedWidth = arrangedWidth / 2;
+
+			AssertArranged(smallerView, new Rect(xOffset, 0, expectedWidth, heightConstraint));
+			AssertArranged(largerView, new Rect(expectedWidth + xOffset, 0, expectedWidth, heightConstraint));
+		}
 	}
 }

--- a/src/Core/tests/UnitTests/Layouts/GridLayoutManagerTests.cs
+++ b/src/Core/tests/UnitTests/Layouts/GridLayoutManagerTests.cs
@@ -3171,14 +3171,10 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			AssertArranged(view0, new Rect(0, 0, 40, 20));
 		}
 
-
-		// TODO cut down test below, then dupe it for width
-		// Might be able to make this work single column with the oversized item in col 0
-
 		[Theory, Category(GridStarSizing)]
-		[InlineData(926, 845)]
-		//[InlineData(926, 926)]
-		//[InlineData(926, 1026)]
+		[InlineData(926, 845)] 
+		[InlineData(926, 926)]
+		[InlineData(926, 1026)]
 		public void StarsAdjustWhenArrangeAndMeasureHeightDiffer(double heightConstraint, double arrangedHeight)
 		{
 			var grid = CreateGridLayout(rows: "*, *", columns: "*");
@@ -3194,17 +3190,16 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			var gridLayoutManager = new GridLayoutManager(grid);
 
 			double widthConstraint = 400;
-			double yOffset = 40;
 
 			_ = gridLayoutManager.Measure(widthConstraint, heightConstraint);
 
 			// Arranging at a different size than the measurement constraints
-			gridLayoutManager.ArrangeChildren(new Rect(0, yOffset, widthConstraint, arrangedHeight));
+			gridLayoutManager.ArrangeChildren(new Rect(0, 0, widthConstraint, arrangedHeight));
 
 			double expectedHeight = arrangedHeight / 2;
 
-			AssertArranged(smallerView, new Rect(0, yOffset, widthConstraint, expectedHeight));
-			AssertArranged(largerView, new Rect(0, expectedHeight + yOffset, widthConstraint, expectedHeight));
+			AssertArranged(smallerView, new Rect(0, 0, widthConstraint, expectedHeight));
+			AssertArranged(largerView, new Rect(0, expectedHeight, widthConstraint, expectedHeight));
 		}
 
 		[Theory, Category(GridStarSizing)]
@@ -3226,17 +3221,16 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			var gridLayoutManager = new GridLayoutManager(grid);
 
 			double heightConstraint = 400;
-			double xOffset = 40;
 
 			_ = gridLayoutManager.Measure(widthConstraint, heightConstraint);
 
 			// Arranging at a different size than the measurement constraints
-			gridLayoutManager.ArrangeChildren(new Rect(xOffset, 0, arrangedWidth, heightConstraint));
+			gridLayoutManager.ArrangeChildren(new Rect(0, 0, arrangedWidth, heightConstraint));
 
 			double expectedWidth = arrangedWidth / 2;
 
-			AssertArranged(smallerView, new Rect(xOffset, 0, expectedWidth, heightConstraint));
-			AssertArranged(largerView, new Rect(expectedWidth + xOffset, 0, expectedWidth, heightConstraint));
+			AssertArranged(smallerView, new Rect(0, 0, expectedWidth, heightConstraint));
+			AssertArranged(largerView, new Rect(expectedWidth, 0, expectedWidth, heightConstraint));
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change

For constrained measurement, when definition sizes are determined during the measure pass the star sizes are limited by the number of stars which can fit into the constraint. During arrange, if the actual arrange size is different, then the size of a star definition needs to be limited by the number of stars which can fit into the arranged size. 

Proposing this as an alternative to #17199 - this is a less extensive change to achieve the same effect.

### Issues Fixed

Fixes #17125