### PR TITLE
Make sure to not call new APIs on old iOS

### DIFF
--- a/src/Core/src/Platform/iOS/ApplicationExtensions.cs
+++ b/src/Core/src/Platform/iOS/ApplicationExtensions.cs
@@ -129,6 +129,9 @@ namespace Microsoft.Maui.Platform
 
 		public static void UpdateUserInterfaceStyle(this IApplication application)
 		{
+			if (!OperatingSystem.IsIOSVersionAtLeast(13) && !OperatingSystem.IsMacCatalystVersionAtLeast(13, 1))
+				return;
+
 			if (application is null)
 				return;
 


### PR DESCRIPTION

### Description of Change

The `overrideUserInterfaceStyle` is only available on iOS 13 and Mac Catalyst 13.1

<img width="690" alt="image" src="https://github.com/dotnet/maui/assets/1096616/77d9be78-c39a-49af-bbb6-cf39352a60c5">


### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #17892
Fixes #17268

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
