### PR TITLE
Enable more legacy tests

### DIFF
--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla26171.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla26171.cs
@@ -96,6 +96,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 		public void Bugzilla26171Test()
 		{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla28001.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla28001.cs
@@ -49,6 +49,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 		public void Bugzilla28001Test()
 		{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla29453.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla29453.cs
@@ -67,6 +67,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 		public void Bugzilla29453Test()
 		{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla30324.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla30324.cs
@@ -92,6 +92,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 		public void Bugzilla30324Test ()
 		{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla31330.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla31330.cs
@@ -149,6 +149,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 		[Category(UITestCategories.UwpIgnore)]
 		public void Bugzilla31330Test()

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla31333.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla31333.cs
@@ -224,6 +224,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 #if __MACOS__
 		[Ignore("EnterText on UITest.Desktop not implemented")]
@@ -239,6 +240,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 		}
 
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 #if __MACOS__
 		[Ignore("EnterText on UITest.Desktop not implemented")]
@@ -255,6 +257,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 #if __MACOS__
 		[Ignore("EnterText on UITest.Desktop not implemented")]
@@ -270,6 +273,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 		}
 
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 #if __MACOS__
 		[Ignore("EnterText on UITest.Desktop not implemented")]

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla32801.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla32801.cs
@@ -83,6 +83,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 		}
 
 #if UITEST && __IOS__
+		[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 		public void Bugzilla32801Test()
 		{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla32898.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla32898.cs
@@ -84,6 +84,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 		public void Issu32898Test()
 		{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla36009.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla36009.cs
@@ -55,6 +55,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 		public void Bugzilla36009Test ()
 		{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla38723.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla38723.cs
@@ -57,6 +57,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 		public void Bugzilla38723Test()
 		{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla39331.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla39331.cs
@@ -80,6 +80,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 		public void Bugzilla39331Test()
 		{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla39489.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla39489.cs
@@ -33,6 +33,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 		protected override bool Isolate => true;
 
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 		public async Task Bugzilla39489Test()
 		{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla40005.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla40005.cs
@@ -138,6 +138,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 		public void Bugzilla40005Test()
 		{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla40173.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla40173.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 		public void ButtonBlocked()
 		{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla40704.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla40704.cs
@@ -226,12 +226,14 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 		public void Bugzilla40704HeaderPresentTest()
 		{
 			RunningApp.WaitForElement("Menu - 0");
 		}
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 #if __MACOS__
 		[Ignore("ScrollDownTo not implemented in UITest.Desktop")]

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla41842.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla41842.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 		public void Bugzilla41842Test()
 		{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla42620.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla42620.cs
@@ -309,6 +309,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 		}
 
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 		public void GridChildrenAddHorizontalDoesNotSpanAllRows()
 		{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla44096.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla44096.cs
@@ -150,6 +150,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 #if UITEST
 
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 		public void TestGrid()
 		{
@@ -157,6 +158,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 		}
 
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 		public void TestContentView()
 		{
@@ -164,6 +166,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 		}
 
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 		public void TestStackLayout()
 		{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla44176.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla44176.cs
@@ -123,6 +123,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 #if UITEST
 		[Test]
 		[Compatibility.UITests.FailsOnMauiAndroid]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Test()
 		{
 			RunningApp.WaitForElement(q => q.Marked("grid"));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla45125.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla45125.cs
@@ -238,6 +238,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 		public void Bugzilla45125Test()
 		{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla45874.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla45874.cs
@@ -32,6 +32,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 		public void Bugzilla45874Test()
 		{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla46363.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla46363.cs
@@ -96,6 +96,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 		public void _46363_Tap_Succeeds()
 		{
@@ -109,6 +110,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 		}
 
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 		public void _46363_ContextAction_Succeeds()
 		{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla46363_2.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla46363_2.cs
@@ -118,6 +118,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 		}
 
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 		public void _46363_2_ContextAction_Succeeds()
 		{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla46363_2.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla46363_2.cs
@@ -105,6 +105,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 		public void _46363_2_Tap_Succeeds()
 		{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla46458.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla46458.cs
@@ -100,6 +100,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 		public void GridIsEnabled()
 		{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla47923.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla47923.cs
@@ -130,6 +130,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 		public void Bugzilla47923Test()
 		{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla51173.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla51173.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 	{
 #if UITEST
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test(Description = "Attempt to load an image from a URI which does not exist")]
 		public void Bugzilla51173_NonexistentUri()
 		{
@@ -35,6 +36,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 		}
 
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test(Description = "The IImageSourceHandler itself throws an exception")]
 		public void Bugzilla51173_HandlerThrowsException()
 		{
@@ -46,6 +48,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 		}
 
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test(Description = "The URI is valid, but the image data is not")]
 		public void Bugzilla51173_RealUriWithInvalidImageData()
 		{
@@ -57,6 +60,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 		}
 
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test(Description = "Attempt to load a local image which does not exist")]
 		public void Bugzilla51173_NonexistentImage()
 		{
@@ -68,6 +72,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 		}
 
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test(Description = "Attempt to load a local image which exists, but has corrupt data")]
 		public void Bugzilla51173_InvalidImage()
 		{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla51505.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla51505.cs
@@ -43,6 +43,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 		public void Bugzilla51505Test()
 		{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla57114.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla57114.cs
@@ -103,6 +103,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 		public void _57114BothTypesOfGesturesFire()
 		{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla58406.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla58406.cs
@@ -49,6 +49,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 		public void EffectAppliesToLabel()
 		{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla60122.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla60122.cs
@@ -58,6 +58,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 		// (like LongPress) don't really work. The test should work manually on a touch screen, though.
 
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 		public void LongClickFiresOnCustomImageRenderer()
 		{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/DateTimePickerLocalizationTests.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/DateTimePickerLocalizationTests.cs
@@ -57,6 +57,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 		// Tests runs locally without issues but doesn't run successfully in a hosted agent yet
 		[Category(UITestCategories.UwpIgnore)]
 		[FailsOnMauiAndroid]
+		[FailsOnMauiIOS]
 		public void TimePicker24H()
 		{
 			RunningApp.Tap(x => x.Marked("TimePicker"));
@@ -74,6 +75,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 #if !WINDOWS
 		[Test]
 		[Compatibility.UITests.FailsOnMauiAndroid]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void TimePicker12H()
 		{
 			RunningApp.Tap(x => x.Marked("TimePicker"));
@@ -100,6 +102,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 		// Tests runs locally without issues but doesn't run successfully in a hosted agent yet
 		[Category(UITestCategories.UwpIgnore)]
 		[FailsOnMauiAndroid]
+		[FailsOnMauiIOS]
 		public void DatePickerDMY()
 		{
 			RunningApp.Tap(x => x.Marked("DatePicker"));
@@ -120,6 +123,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 		// Tests runs locally without issues but doesn't run successfully in a hosted agent yet
 		[Category(UITestCategories.UwpIgnore)]
 		[FailsOnMauiAndroid]
+		[FailsOnMauiIOS]
 		public void DatePickerMissing()
 		{
 			RunningApp.Tap(x => x.Marked("DatePicker"));
@@ -137,6 +141,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 #if !WINDOWS
 		[Test]
 		[FailsOnMauiAndroid]
+		[FailsOnMauiIOS]
 		public void DatePickerLetters()
 		{
 			RunningApp.Tap(x => x.Marked("DatePicker"));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/GestureBubblingTests.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/GestureBubblingTests.cs
@@ -36,6 +36,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS] // on iOS only menuItem=Slider, frameShouldRegisterTap=False fails
 		[Test, TestCaseSource(nameof(TestCases))]
 		[NUnit.Framework.Category(Compatibility.UITests.UITestCategories.UwpIgnore)]
 		public void VerifyTapBubbling(string menuItem, bool frameShouldRegisterTap)

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/GitHub1567.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/GitHub1567.cs
@@ -100,6 +100,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		public void GitHub1567Test()
 		{
 			RunningApp.WaitForElement(q => q.Marked("btnFillData"));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/InputTransparentTests.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/InputTransparentTests.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS] // Only menuItem=Frame fails on iOS
 		[Test, TestCaseSource(nameof(TestCases))]
 		public void VerifyInputTransparent(string menuItem)
 		{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/IsInvokeRequiredRaceCondition.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/IsInvokeRequiredRaceCondition.cs
@@ -58,6 +58,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		public void ShouldNotCrash()
 		{
 			RunningApp.Tap(q => q.Marked("crashButton"));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue10300.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue10300.cs
@@ -148,6 +148,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 		public void Issue10300Test() 
 		{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue11132.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue11132.cs
@@ -52,6 +52,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 		[Description("Verify that can use a CustomRenderer overriding the iOS View Layer properties")]
 		public void Issue11132CustomRendererLayerAndClip()

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue11224.xaml.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue11224.xaml.cs
@@ -66,6 +66,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 #if UITEST
 		[Test]
 		[Compatibility.UITests.FailsOnMauiAndroid]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void CarouselViewPositionFromVisibilityChangeTest()
 		{
 			RunningApp.WaitForElement(q => q.Marked("AppearButton"));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue11244.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue11244.cs
@@ -67,6 +67,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST && __SHELL__
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 		public void LeftToolbarItemTextDisplaysWhenFlyoutIsDisabled()
 		{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue12848.xaml.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue12848.xaml.cs
@@ -43,6 +43,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 #if UITEST
 		[Test]
 		[Compatibility.UITests.FailsOnMauiAndroid]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Issue12848Test()
 		{
 			RunningApp.WaitForElement("TestCarouselView");

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue15565.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue15565.cs
@@ -78,6 +78,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 		}
 
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 		public void ToolbarItemsWithTitleViewAreRendering()
 		{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue1683.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue1683.cs
@@ -191,6 +191,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 		public void Issue1683Test()
 		{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue1733.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue1733.cs
@@ -221,6 +221,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 		Dictionary<string, Size> results = null;
 
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 		public void EditorAutoResize()
 		{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue1763.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue1763.cs
@@ -36,6 +36,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 		public void TestIssue1763ItemTappedFiring()
 		{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2266.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2266.cs
@@ -94,6 +94,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 		public void SwapMainPageWithFlyoutPages()
 		{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2617.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2617.cs
@@ -136,6 +136,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 		public async Task BindingToValuesTypesAndScrollingNoCrash()
 		{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2653.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2653.cs
@@ -166,6 +166,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 		}
 
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 		public void InsertThenAddSetsZIndex()
 		{
@@ -186,6 +187,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 		public void MoveUpAndMoveDown()
 		{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2680ScrollView.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2680ScrollView.cs
@@ -73,6 +73,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 		public void Issue2680Test_ScrollDisabled()
 		{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2767.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2767.cs
@@ -46,6 +46,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 		public void Issue2767Test()
 		{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2858.xaml.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2858.xaml.cs
@@ -69,6 +69,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 #if UITEST
 		[Test]
 		[FailsOnMauiAndroid]
+		[FailsOnMauiIOS]
 		public void CascadeInputTransparentGrids()
 		{
 			RunningApp.WaitForElement(InnerGrid);

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2883.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2883.cs
@@ -115,6 +115,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 		public void Issue2883TestDisabled ()
 		{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2883.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2883.cs
@@ -128,6 +128,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 		}
 
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 		public void Issue2883TestEnabled ()
 		{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2894.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2894.cs
@@ -222,6 +222,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 		public void VariousSpanGesturePermutation()
 		{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2976.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2976.cs
@@ -37,6 +37,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 		public void Issue1Test()
 		{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue3000.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue3000.cs
@@ -117,6 +117,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 		public void RtlScrollViewStartsScrollToRight()
 		{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue3053.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue3053.cs
@@ -68,6 +68,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 		public void MovingItemInObservableCollectionBreaksListView()
 		{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue3089.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue3089.cs
@@ -121,6 +121,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
+		[FailsOnMauiIOS]
 		public void ResettingItemsOnRecycledListViewKeepsOldText()
 		{
 			RunningApp.Tap(reload);

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue3319.xaml.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue3319.xaml.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 #if UITEST
 		[Test]
 		[Compatibility.UITests.FailsOnMauiAndroid]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void Issue3319Test()
 		{
 			RunningApp.WaitForElement(q => q.Marked("Will this repo work?"));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue3408.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue3408.cs
@@ -82,6 +82,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 		public void Issue3408Test()
 		{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue3413.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue3413.cs
@@ -67,6 +67,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 		[Category(UITestCategories.ManualReview)]
 		public void Issue3413Test()

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue3475.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue3475.cs
@@ -66,6 +66,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 		public void Issue3475TestsLayoutCompressionPerformance()
 		{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue3548.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue3548.cs
@@ -76,6 +76,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 		public void CheckIsEffectAttached()
 		{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue3652.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue3652.cs
@@ -116,6 +116,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST && !WINDOWS
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 		public void TestRemovingContextMenuItems()
 		{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue4356.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue4356.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 	{
 #if UITEST
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 		public void Issue4356Test()
 		{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue5951.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue5951.cs
@@ -59,6 +59,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 		public void Issue5951Test()
 		{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue6262.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue6262.cs
@@ -77,6 +77,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 		public void ImageShouldLayoutOnTopOfButton()
 		{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue7290.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue7290.cs
@@ -66,6 +66,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 		public void DisplayActionSheetAndDisplayAlertFromOnAppearing()
 		{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue7329.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue7329.cs
@@ -59,6 +59,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 		public void ScrollListViewInsideScrollView()
 		{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue8262.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue8262.cs
@@ -90,6 +90,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 		public void ScrollingQuicklyOnCollectionViewDoesntCrashOnDestroyedImage()
 		{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue8263.xaml.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue8263.xaml.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 #if UITEST
 		[Test]
 		[Category(UITestCategories.ManualReview)]
+		[FailsOnMauiIOS]
 		public void SwitchOnOffVisualStatesTest()
 		{
 			RunningApp.WaitForElement("Switch");

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue8964.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue8964.cs
@@ -128,6 +128,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 		public void Issue8964Test()
 		{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue9682.xaml.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue9682.xaml.cs
@@ -41,6 +41,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 		[Test, NUnit.Framework.Category(UITestCategories.Image)]
 		[NUnit.Framework.Category(UITestCategories.RequiresInternetConnection)]
 		[Compatibility.UITests.FailsOnMauiAndroid]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void MonkiesShouldLoad()
 		{
 			RunningApp.WaitForElement("MonkeyLoadButton");

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue9686.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue9686.cs
@@ -181,6 +181,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 		[Category(UITestCategories.CollectionView)]
 		[Category(UITestCategories.UwpIgnore)]
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 		public void AddRemoveEmptyGroupsShouldNotCrashOnInsert()
 		{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/MapsModalCrash.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/MapsModalCrash.cs
@@ -75,6 +75,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 		public void CanDisplayModalOverMap()
 		{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/ScrollViewIsEnabled.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/ScrollViewIsEnabled.cs
@@ -81,6 +81,7 @@ Use the toggle button to check both values of 'IsEnabled'."
 
 #if UITEST
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 		public void ScrollViewInitiallyEnabled()
 		{
@@ -93,6 +94,7 @@ Use the toggle button to check both values of 'IsEnabled'."
 		}
 
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 		public void ScrollViewInitiallyEnabledThenDisabled()
 		{
@@ -110,6 +112,7 @@ Use the toggle button to check both values of 'IsEnabled'."
 		}
 
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 		public void ScrollViewInitiallyNotEnabled()
 		{
@@ -122,6 +125,7 @@ Use the toggle button to check both values of 'IsEnabled'."
 		}
 
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 		public void ScrollViewInitiallyNotEnabledThenEnabled()
 		{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/ScrollViewObjectDisposed.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/ScrollViewObjectDisposed.cs
@@ -56,6 +56,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 		public void ScrollViewObjectDisposedTest ()
 		{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/ShellFlyoutContentOffest.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/ShellFlyoutContentOffest.cs
@@ -106,6 +106,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 #if UITEST
 		[Test]
 		[Compatibility.UITests.FailsOnMauiAndroid]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void FlyoutContentOffsetsCorrectly()
 		{
 			RunningApp.WaitForElement("PageLoaded");

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/ShellFlyoutHeaderBehavior.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/ShellFlyoutHeaderBehavior.cs
@@ -96,6 +96,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 		}
 
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 		public void FlyoutHeaderBehaviorCollapseOnScroll()
 		{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/TransparentOverlayTests.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/TransparentOverlayTests.cs
@@ -182,6 +182,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
         [Test, TestCaseSource(nameof(GenerateTests))]
         public void VerifyInputTransparent(TestPoint test)
         {

--- a/src/Compatibility/ControlGallery/src/UITests.Shared/PlatformAutomatedTest.cs
+++ b/src/Compatibility/ControlGallery/src/UITests.Shared/PlatformAutomatedTest.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Maui.Controls.Compatibility.UITests.Shared
 		[Test]
 		[Category(UITestCategories.ViewBaseTests)]
 		[FailsOnMauiAndroid]
+		[FailsOnMauiIOS]
 		public void AutomatedTests()
 		{
 			App.WaitForElement("SUCCESS", timeout: TimeSpan.FromMinutes(2));

--- a/src/Compatibility/ControlGallery/src/UITests.Shared/Tests/EntryUITests.cs
+++ b/src/Compatibility/ControlGallery/src/UITests.Shared/Tests/EntryUITests.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Maui.Controls.Compatibility.UITests
 		}
 
 		[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+		[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
 		[Test]
 		[UiTest(typeof(Entry), "Focus")]
 		public override void _Focus()

--- a/src/Compatibility/ControlGallery/src/UITests.Shared/UITestCategories.cs
+++ b/src/Compatibility/ControlGallery/src/UITests.Shared/UITestCategories.cs
@@ -88,9 +88,7 @@ namespace Microsoft.Maui.Controls.Compatibility.UITests
 		}
 	}
 #else
-	// For now I'm just ignoring any tests that fail on one platform on all the platforms
-	// this is mainly to get a set of tests green and then I can parse between the platforms
-	public class FailsOnMauiAndroid : IgnoreAttribute//CategoryAttribute
+	public class FailsOnMauiAndroid : CategoryAttribute
 	{
 		public FailsOnMauiAndroid() : base(nameof(FailsOnMauiAndroid))
 		{


### PR DESCRIPTION
### Description of Change

Ignore the failing iOS tests for now on the legacy UI tests so that we can get the remaining tests going in an automated fashion.

### Related

https://github.com/dotnet/maui/pull/17971