### PR TITLE
Use Cake for running integration tests

### DIFF
--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -31,7 +31,7 @@ ProcessTFMSwitches();
 // Tasks for CI
 
 Task("dotnet")
-    .Description("Provisions .NET 6 into bin/dotnet based on eng/Versions.props")
+    .Description("Provisions the .NET SDK into bin/dotnet based on eng/Versions.props")
     .Does(() =>
     {
         if (!localDotnet) 
@@ -50,7 +50,7 @@ Task("dotnet")
 
         DotNetBuild("./src/DotNet/DotNet.csproj", new DotNetBuildSettings
         {
-            MSBuildSettings = new DotNetCoreMSBuildSettings()
+            MSBuildSettings = new DotNetMSBuildSettings()
                 .EnableBinaryLogger($"{GetLogDirectory()}/dotnet-{configuration}-{DateTime.UtcNow.ToFileTimeUtc()}.binlog")
                 .SetConfiguration(configuration),
         });
@@ -65,9 +65,9 @@ Task("dotnet-local-workloads")
         //Workaround: https://github.com/dotnet/linker/issues/3012
         SetEnvironmentVariable("DOTNET_gcServer", "0");
 
-        DotNetCoreBuild("./src/DotNet/DotNet.csproj", new DotNetCoreBuildSettings
+        DotNetBuild("./src/DotNet/DotNet.csproj", new DotNetBuildSettings
         {
-            MSBuildSettings = new DotNetCoreMSBuildSettings()
+            MSBuildSettings = new DotNetMSBuildSettings()
                 .EnableBinaryLogger($"{GetLogDirectory()}/dotnet-{configuration}-{DateTime.UtcNow.ToFileTimeUtc()}.binlog")
                 .SetConfiguration(configuration)
                 .WithProperty("InstallWorkloadPacks", "false"),
@@ -75,7 +75,7 @@ Task("dotnet-local-workloads")
 
         DotNetBuild("./src/DotNet/DotNet.csproj", new DotNetBuildSettings
         {
-            MSBuildSettings = new DotNetCoreMSBuildSettings()
+            MSBuildSettings = new DotNetMSBuildSettings()
                 .EnableBinaryLogger($"{GetLogDirectory()}/dotnet-install-{configuration}-{DateTime.UtcNow.ToFileTimeUtc()}.binlog")
                 .SetConfiguration(configuration)
                 .WithTarget("Install"),
@@ -180,21 +180,23 @@ Task("dotnet-legacy-controlgallery-android")
         RunMSBuildWithDotNet("./src/Compatibility/ControlGallery/src/Android/Compatibility.ControlGallery.Android.csproj", properties, binlogPrefix: "controlgallery-android-");
     });
 
-Task("dotnet-samples-test")
+Task("dotnet-integration-build")
     .Does(() =>
     {
-        var buildSettings = new DotNetBuildSettings
-        {
-            MSBuildSettings = new DotNetMSBuildSettings()
-                .SetConfiguration(configuration)
-        };
-        DotNetBuild("./src/TestUtils/src/Microsoft.Maui.IntegrationTests/Microsoft.Maui.IntegrationTests.csproj", buildSettings);
+        var properties = new Dictionary<string, string>();
+        RunMSBuildWithDotNet("./src/TestUtils/src/Microsoft.Maui.IntegrationTests/Microsoft.Maui.IntegrationTests.csproj", properties, binlogPrefix: "integration-");
+    });
 
-        var testSettings = new DotNetTestSettings
-        {
-            Filter = "FullyQualifiedName=Microsoft.Maui.IntegrationTests.SampleTests"
-        };
-        DotNetTest($"./src/TestUtils/src/Microsoft.Maui.IntegrationTests/bin/{configuration}/net7.0/Microsoft.Maui.IntegrationTests.dll", testSettings);
+Task("dotnet-integration-test")
+    .Does(() =>
+    {
+        RunTestWithLocalDotNet(
+            "./src/TestUtils/src/Microsoft.Maui.IntegrationTests/Microsoft.Maui.IntegrationTests.csproj",
+            config: configuration,
+            pathDotnet: dotnetPath,
+            noBuild: true,
+            resultsFileNameWithoutExtension: Argument("resultsfilename", ""),
+            filter: Argument("filter", ""));
     });
 
 Task("dotnet-test")
@@ -715,7 +717,7 @@ void RunTestWithLocalDotNet(string csproj)
     RunTestWithLocalDotNet(csproj, configuration, dotnetPath, argsExtra: null, noBuild: true, resultsFileNameWithoutExtension: null);
 }
 
-void RunTestWithLocalDotNet(string csproj, string config, string pathDotnet = null, Dictionary<string,string> argsExtra = null, bool noBuild = false, string resultsFileNameWithoutExtension = null)
+void RunTestWithLocalDotNet(string csproj, string config, string pathDotnet = null, Dictionary<string,string> argsExtra = null, bool noBuild = false, string resultsFileNameWithoutExtension = null, string filter = "")
 {
     string binlog;
     string results;
@@ -739,6 +741,7 @@ void RunTestWithLocalDotNet(string csproj, string config, string pathDotnet = nu
         {
             Configuration = config,
             NoBuild = noBuild,
+            Filter = filter,
             Loggers = { 
                 $"trx;LogFileName={results}",
                 $"console;verbosity=normal"

--- a/eng/cake/helpers.cake
+++ b/eng/cake/helpers.cake
@@ -136,7 +136,7 @@ void RunTestsNunit(string unitTestLibrary, NUnit3Settings settings)
 
     SetTestResultsEnvironmentVariables(settings.Work?.ToString());
 
-    void SetTestResultsEnvironmentVariables(string? path)
+    void SetTestResultsEnvironmentVariables(string path)
     {
         var doc = new System.Xml.XmlDocument();
         if(string.IsNullOrEmpty(path))

--- a/eng/pipelines/common/maui-templates.yml
+++ b/eng/pipelines/common/maui-templates.yml
@@ -103,20 +103,19 @@ jobs:
       DOTNET_TOKEN: $(dotnetbuilds-internal-container-read-token)
       PRIVATE_BUILD: $(PrivateBuild)
 
-  - task: DotNetCoreCLI@2
-    inputs:
-      projects: ${{ parameters.checkoutDirectory }}/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Microsoft.Maui.IntegrationTests.csproj
+  - pwsh: ./build.ps1 --target=dotnet-integration-build --verbosity=diagnostic
     displayName: Build Microsoft.Maui.IntegrationTests
 
-  - task: DotNetCoreCLI@2
+  - pwsh: ./build.ps1 --target=dotnet-integration-test --filter="FullyQualifiedName=Microsoft.Maui.IntegrationTests.TemplateTests" --resultsfilename="integration-tests" --verbosity=diagnostic
+    displayName: Run $(PLATFORM_NAME) templates build tests
+
+  - task: PublishTestResults@2
+    displayName: Publish the $(PLATFORM_NAME) templates build tests
+    condition: always()
     inputs:
-      command: test
-      projects: ${{ parameters.checkoutDirectory }}/src/TestUtils/src/Microsoft.Maui.IntegrationTests/bin/Debug/net7.0/Microsoft.Maui.IntegrationTests.dll
-      arguments: --logger "console;verbosity=normal" --filter "FullyQualifiedName=Microsoft.Maui.IntegrationTests.TemplateTests"
-      publishTestResults: true
-      testRunTitle: $(PLATFORM_NAME) template build tests
-    displayName: $(PLATFORM_NAME) template build tests
-    continueOnError: true
+      testRunner: VSTest
+      testResultsFiles: '$(build.artifactstagingdirectory)/**/*.trx'
+      testRunTitle: $(PLATFORM_NAME) templates build tests
 
   - pwsh: |
       Write-Host "Current job status is: $env:AGENT_JOBSTATUS"
@@ -165,20 +164,20 @@ jobs:
     - script: dotnet tool update Microsoft.DotNet.XHarness.CLI --add-source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json --version "1.0.0-prerelease*" -g
       displayName: install xharness
 
-    - task: DotNetCoreCLI@2
-      inputs:
-        projects: ${{ parameters.checkoutDirectory }}/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Microsoft.Maui.IntegrationTests.csproj
+    - pwsh: ./build.ps1 --target=dotnet-integration-build --verbosity=diagnostic
       displayName: Build Microsoft.Maui.IntegrationTests
 
-    - task: DotNetCoreCLI@2
-      inputs:
-        command: test
-        projects: ${{ parameters.checkoutDirectory }}/src/TestUtils/src/Microsoft.Maui.IntegrationTests/bin/Debug/net7.0/Microsoft.Maui.IntegrationTests.dll
-        arguments: --logger "console;verbosity=normal" --filter "Name=${{ RunPlatform.testName }}"
-        publishTestResults: true
-        testRunTitle: ${{ RunPlatform.testName }} template run tests
-      displayName: ${{ RunPlatform.testName }} template run tests
+    - pwsh: ./build.ps1 --target=dotnet-integration-test --filter="Name=${{ RunPlatform.testName }}" --resultsfilename="integration-run-${{ RunPlatform.testName }}" --verbosity=diagnostic
+      displayName: Run $(PLATFORM_NAME) templates run tests
       continueOnError: true
+
+    - task: PublishTestResults@2
+      displayName: Publish the $(PLATFORM_NAME) templates run tests
+      condition: always()
+      inputs:
+        testRunner: VSTest
+        testResultsFiles: '$(build.artifactstagingdirectory)/**/*.trx'
+        testRunTitle: $(PLATFORM_NAME) templates run tests
 
     - pwsh: |
         Write-Host "Current job status is: $env:AGENT_JOBSTATUS"

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -250,18 +250,17 @@ stages:
               env:
                 DOTNET_TOKEN: $(dotnetbuilds-internal-container-read-token)
                 PRIVATE_BUILD: $(PrivateBuild)
-            - task: DotNetCoreCLI@2
-              inputs:
-                projects: $(Build.SourcesDirectory)/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Microsoft.Maui.IntegrationTests.csproj
+            - pwsh: ./build.ps1 --target=dotnet-integration-build --verbosity=diagnostic
               displayName: Build Microsoft.Maui.IntegrationTests
-            - task: DotNetCoreCLI@2
+            - pwsh: ./build.ps1 --target=dotnet-integration-test --filter="FullyQualifiedName=Microsoft.Maui.IntegrationTests.SampleTests" --resultsfilename="integration-samples" --verbosity=diagnostic
+              displayName: Run ${{ BuildPlatform.name }} sample build tests
+            - task: PublishTestResults@2
+              displayName: Publish the ${{ BuildPlatform.name }} sample build tests
+              condition: always()
               inputs:
-                command: test
-                projects: $(Build.SourcesDirectory)/src/TestUtils/src/Microsoft.Maui.IntegrationTests/bin/Debug/net7.0/Microsoft.Maui.IntegrationTests.dll
-                arguments: --logger "console;verbosity=normal" --filter "FullyQualifiedName=Microsoft.Maui.IntegrationTests.SampleTests"
-                publishTestResults: true
+                testRunner: VSTest
+                testResultsFiles: '$(build.artifactstagingdirectory)/**/*.trx'
                 testRunTitle: ${{ BuildPlatform.name }} sample build tests
-              displayName: ${{ BuildPlatform.name }} sample build tests
 
   - stage: templates_net
     displayName: Test Templates


### PR DESCRIPTION
### Description of Change

Use the cake script as that seems to know more about where and what .NET SDK to use.