### PR TITLE
Fail UI test run when all tests are inconclusive

### DIFF
--- a/eng/devices/android.cake
+++ b/eng/devices/android.cake
@@ -365,7 +365,11 @@ Task("cg-uitest")
 		Information("Add Where filter to NUnit {0}", TEST_WHERE);
 		nunitSettings.Where = TEST_WHERE;
 	}
+
 	RunTestsNunit(testLibDllPath, nunitSettings);
+
+	// When all tests are inconclusive the run does not fail, check if this is the case and fail the pipeline so we get notified
+	FailRunOnOnlyInconclusiveTests(System.IO.Path.Combine(nunitSettings.Work.FullPath, "TestResult.xml"));
 });
 
 RunTarget(TARGET);

--- a/eng/devices/devices-shared.cake
+++ b/eng/devices/devices-shared.cake
@@ -8,3 +8,15 @@ if (string.Equals(TARGET, "uitest", StringComparison.OrdinalIgnoreCase))
     DEFAULT_PROJECT = "../../src/Controls/tests/UITests/Controls.AppiumTests.csproj";
     DEFAULT_APP_PROJECT = "../../src/Controls/samples/Controls.Sample.UITests/Controls.Sample.UITests.csproj";
 }
+
+void FailRunOnOnlyInconclusiveTests(string testResultsFile)
+{
+    // When all tests are inconclusive the run does not fail, check if this is the case and fail the pipeline so we get notified
+	var totalTestCount = XmlPeek(testResultsFile, "/test-run/@total");
+	var inconclusiveTestCount = XmlPeek(testResultsFile, "/test-run/@inconclusive");
+	
+	if (totalTestCount.Equals(inconclusiveTestCount))
+    {
+		throw new Exception("All tests are marked inconclusive, no tests ran. There is probably something wrong with running the tests.");
+	}
+}

--- a/eng/devices/ios.cake
+++ b/eng/devices/ios.cake
@@ -292,6 +292,9 @@ Task("cg-uitest")
 		nunitSettings.Where = TEST_WHERE;
 	}
 	RunTestsNunit(testLibDllPath, nunitSettings);
+
+	// When all tests are inconclusive the run does not fail, check if this is the case and fail the pipeline so we get notified	
+	FailRunOnOnlyInconclusiveTests(System.IO.Path.Combine(nunitSettings.Work.FullPath, "TestResult.xml"));
 });
 
 RunTarget(TARGET);


### PR DESCRIPTION
### Description of Change

After upgrading our UITest dependency to a new version suddenly all tests would pass on iOS. Upon further inspection we noticed that the tests in fact didn't run, but they were all marked inconclusive. However, that would not fail the test run/pipeline and so the no running of tests might go undetected.

This adds a safeguard that looks at the test results XML file and check if the number of total tests ran and the number of inconclusive tests are the same. If they are, no tests ran and we thrown an exception.

### Issues Fixed

Fixes #17945

### Related

#17931

