### PR TITLE
Revert UITest dependency version bump

### DIFF
--- a/src/Compatibility/ControlGallery/test/Android.UITests/Compatibility.ControlGallery.Android.UITests.csproj
+++ b/src/Compatibility/ControlGallery/test/Android.UITests/Compatibility.ControlGallery.Android.UITests.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="Xam.Plugin.DeviceInfo" Version="4.1.1" />
-    <PackageReference Include="Xamarin.UITest" Version="4.3.0" />
+    <PackageReference Include="Xamarin.UITest" Version="4.1.4" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
   </ItemGroup>
 

--- a/src/Compatibility/ControlGallery/test/WinUI.UITests/WinUI.UITests.csproj
+++ b/src/Compatibility/ControlGallery/test/WinUI.UITests/WinUI.UITests.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Selenium.Support" Version="4.1.1" />
     <PackageReference Include="Selenium.WebDriver" Version="4.1.1" />
     <PackageReference Include="Xam.Plugin.DeviceInfo" Version="4.1.1" />
-    <PackageReference Include="Xamarin.UITest" Version="4.3.0" />
+    <PackageReference Include="Xamarin.UITest" Version="4.1.4" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
   </ItemGroup>
 

--- a/src/Compatibility/ControlGallery/test/iOS.UITests/Compatibility.ControlGallery.iOS.UITests.csproj
+++ b/src/Compatibility/ControlGallery/test/iOS.UITests/Compatibility.ControlGallery.iOS.UITests.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="Xam.Plugin.DeviceInfo" Version="4.1.1" />
-    <PackageReference Include="Xamarin.UITest" Version="4.3.0" />
+    <PackageReference Include="Xamarin.UITest" Version="4.1.4" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
   </ItemGroup>
 


### PR DESCRIPTION
### Description of Change

By merging #17794 our iOS tests suddenly all show inconclusive when running in CI. Let's make sure our tests start running again while we figure out what is going on.

### Related

* https://github.com/dotnet/maui/pull/17971
* https://github.com/dotnet/maui/pull/17931