### PR TITLE
[net8.0] Update packages for rtm

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -21,7 +21,7 @@
       ]
     },
     "microsoft.dotnet.xharness.cli": {
-      "version": "8.0.0-prerelease.23471.1",
+      "version": "8.0.0-prerelease.23516.1",
       "commands": [
         "xharness"
       ]

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,32 +1,32 @@
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.Dotnet.Sdk.Internal" Version="8.0.100-rtm.23512.1">
+    <Dependency Name="Microsoft.Dotnet.Sdk.Internal" Version="8.0.100-rtm.23513.4">
       <Uri>https://github.com/dotnet/installer</Uri>
-      <Sha>dfe59b6c4dec70fef72f18010dc8606ce8fb141a</Sha>
+      <Sha>c65382f00216756e0fb192cc2fd6513448d2679d</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NETCore.App.Ref" Version="8.0.0-rtm.23511.16">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>256bf22a3ddf920516752701da2b95e1847ff708</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Android.Sdk.Windows" Version="34.99.0-preview.1.10">
+    <Dependency Name="Microsoft.Android.Sdk.Windows" Version="34.0.25">
       <Uri>https://github.com/xamarin/xamarin-android</Uri>
-      <Sha>1a309b63345d64356a68805c2e20f1c4fd794e42</Sha>
+      <Sha>64a691934fd41f9209d87bce59407407eca49257</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.MacCatalyst.Sdk" Version="17.0.8432">
+    <Dependency Name="Microsoft.MacCatalyst.Sdk" Version="17.0.8438">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>12463e78a75a1b94331aa0f31d7f02ab8767c817</Sha>
+      <Sha>4b3282e3e395ace9e0fe7a2573c0f035dfa77a61</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.macOS.Sdk" Version="14.0.8432">
+    <Dependency Name="Microsoft.macOS.Sdk" Version="14.0.8438">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>12463e78a75a1b94331aa0f31d7f02ab8767c817</Sha>
+      <Sha>4b3282e3e395ace9e0fe7a2573c0f035dfa77a61</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.iOS.Sdk" Version="17.0.8432">
+    <Dependency Name="Microsoft.iOS.Sdk" Version="17.0.8438">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>12463e78a75a1b94331aa0f31d7f02ab8767c817</Sha>
+      <Sha>4b3282e3e395ace9e0fe7a2573c0f035dfa77a61</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.tvOS.Sdk" Version="17.0.8432">
+    <Dependency Name="Microsoft.tvOS.Sdk" Version="17.0.8438">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>12463e78a75a1b94331aa0f31d7f02ab8767c817</Sha>
+      <Sha>4b3282e3e395ace9e0fe7a2573c0f035dfa77a61</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.Workload.Emscripten.Current.Manifest-8.0.100.Transport" Version="8.0.0-rtm.23504.4" CoherentParentDependency="Microsoft.NETCore.App.Ref">
       <Uri>https://github.com/dotnet/emsdk</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -4,9 +4,9 @@
       <Uri>https://github.com/dotnet/installer</Uri>
       <Sha>0ffc9fdc93e578268a09b0dccdc4c3527f4697f3</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="8.0.0-rtm.23509.5">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="8.0.0-rtm.23511.16">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>a9cc3c80fe43d19a38cacda4c1aecc51fb6eabb1</Sha>
+      <Sha>256bf22a3ddf920516752701da2b95e1847ff708</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Android.Sdk.Windows" Version="34.0.12">
       <Uri>https://github.com/xamarin/xamarin-android</Uri>
@@ -35,49 +35,49 @@
     <Dependency Name="Microsoft.WindowsAppSDK" Version="0.0.1">
       <Uri>https://dev.azure.com/microsoft/ProjectReunion/_git/ProjectReunionInternal</Uri>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authorization" Version="8.0.0-rtm.23509.3">
+    <Dependency Name="Microsoft.AspNetCore.Authorization" Version="8.0.0-rtm.23512.7">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>cfc7ac66d89f8e38def01cc19c6d15f4c010c630</Sha>
+      <Sha>b5bb62782261908880f9755bc9478a914a2c4953</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.Facebook" Version="8.0.0-rtm.23509.3">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.Facebook" Version="8.0.0-rtm.23512.7">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>cfc7ac66d89f8e38def01cc19c6d15f4c010c630</Sha>
+      <Sha>b5bb62782261908880f9755bc9478a914a2c4953</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.Google" Version="8.0.0-rtm.23509.3">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.Google" Version="8.0.0-rtm.23512.7">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>cfc7ac66d89f8e38def01cc19c6d15f4c010c630</Sha>
+      <Sha>b5bb62782261908880f9755bc9478a914a2c4953</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="8.0.0-rtm.23509.3">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="8.0.0-rtm.23512.7">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>cfc7ac66d89f8e38def01cc19c6d15f4c010c630</Sha>
+      <Sha>b5bb62782261908880f9755bc9478a914a2c4953</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components" Version="8.0.0-rtm.23509.3">
+    <Dependency Name="Microsoft.AspNetCore.Components" Version="8.0.0-rtm.23512.7">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>cfc7ac66d89f8e38def01cc19c6d15f4c010c630</Sha>
+      <Sha>b5bb62782261908880f9755bc9478a914a2c4953</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Analyzers" Version="8.0.0-rtm.23509.3">
+    <Dependency Name="Microsoft.AspNetCore.Components.Analyzers" Version="8.0.0-rtm.23512.7">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>cfc7ac66d89f8e38def01cc19c6d15f4c010c630</Sha>
+      <Sha>b5bb62782261908880f9755bc9478a914a2c4953</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Forms" Version="8.0.0-rtm.23509.3">
+    <Dependency Name="Microsoft.AspNetCore.Components.Forms" Version="8.0.0-rtm.23512.7">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>cfc7ac66d89f8e38def01cc19c6d15f4c010c630</Sha>
+      <Sha>b5bb62782261908880f9755bc9478a914a2c4953</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebView" Version="8.0.0-rtm.23509.3">
+    <Dependency Name="Microsoft.AspNetCore.Components.WebView" Version="8.0.0-rtm.23512.7">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>cfc7ac66d89f8e38def01cc19c6d15f4c010c630</Sha>
+      <Sha>b5bb62782261908880f9755bc9478a914a2c4953</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Web" Version="8.0.0-rtm.23509.3">
+    <Dependency Name="Microsoft.AspNetCore.Components.Web" Version="8.0.0-rtm.23512.7">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>cfc7ac66d89f8e38def01cc19c6d15f4c010c630</Sha>
+      <Sha>b5bb62782261908880f9755bc9478a914a2c4953</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Metadata" Version="8.0.0-rtm.23509.3">
+    <Dependency Name="Microsoft.AspNetCore.Metadata" Version="8.0.0-rtm.23512.7">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>cfc7ac66d89f8e38def01cc19c6d15f4c010c630</Sha>
+      <Sha>b5bb62782261908880f9755bc9478a914a2c4953</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.JSInterop" Version="8.0.0-rtm.23509.3">
+    <Dependency Name="Microsoft.JSInterop" Version="8.0.0-rtm.23512.7">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>cfc7ac66d89f8e38def01cc19c6d15f4c010c630</Sha>
+      <Sha>b5bb62782261908880f9755bc9478a914a2c4953</Sha>
     </Dependency>
     <Dependency Name="Microsoft.TemplateEngine.Tasks" Version="7.0.100-preview.2.22102.8">
       <Uri>https://github.com/dotnet/templating</Uri>
@@ -95,49 +95,49 @@
       <Uri>https://github.com/dotnet/xharness</Uri>
       <Sha>06fd591dc00862e415eddbec734ae9ea77d35486</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration" Version="8.0.0-rtm.23509.5">
+    <Dependency Name="Microsoft.Extensions.Configuration" Version="8.0.0-rtm.23511.16">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>a9cc3c80fe43d19a38cacda4c1aecc51fb6eabb1</Sha>
+      <Sha>256bf22a3ddf920516752701da2b95e1847ff708</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0-rtm.23509.5">
+    <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0-rtm.23511.16">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>a9cc3c80fe43d19a38cacda4c1aecc51fb6eabb1</Sha>
+      <Sha>256bf22a3ddf920516752701da2b95e1847ff708</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Json" Version="8.0.0-rtm.23509.5">
+    <Dependency Name="Microsoft.Extensions.Configuration.Json" Version="8.0.0-rtm.23511.16">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>a9cc3c80fe43d19a38cacda4c1aecc51fb6eabb1</Sha>
+      <Sha>256bf22a3ddf920516752701da2b95e1847ff708</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="8.0.0-rtm.23509.5">
+    <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="8.0.0-rtm.23511.16">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>a9cc3c80fe43d19a38cacda4c1aecc51fb6eabb1</Sha>
+      <Sha>256bf22a3ddf920516752701da2b95e1847ff708</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0-rtm.23509.5">
+    <Dependency Name="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0-rtm.23511.16">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>a9cc3c80fe43d19a38cacda4c1aecc51fb6eabb1</Sha>
+      <Sha>256bf22a3ddf920516752701da2b95e1847ff708</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.FileProviders.Abstractions" Version="8.0.0-rtm.23509.5">
+    <Dependency Name="Microsoft.Extensions.FileProviders.Abstractions" Version="8.0.0-rtm.23511.16">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>a9cc3c80fe43d19a38cacda4c1aecc51fb6eabb1</Sha>
+      <Sha>256bf22a3ddf920516752701da2b95e1847ff708</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0-rtm.23509.5">
+    <Dependency Name="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0-rtm.23511.16">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>a9cc3c80fe43d19a38cacda4c1aecc51fb6eabb1</Sha>
+      <Sha>256bf22a3ddf920516752701da2b95e1847ff708</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging" Version="8.0.0-rtm.23509.5">
+    <Dependency Name="Microsoft.Extensions.Logging" Version="8.0.0-rtm.23511.16">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>a9cc3c80fe43d19a38cacda4c1aecc51fb6eabb1</Sha>
+      <Sha>256bf22a3ddf920516752701da2b95e1847ff708</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Console" Version="8.0.0-rtm.23509.5">
+    <Dependency Name="Microsoft.Extensions.Logging.Console" Version="8.0.0-rtm.23511.16">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>a9cc3c80fe43d19a38cacda4c1aecc51fb6eabb1</Sha>
+      <Sha>256bf22a3ddf920516752701da2b95e1847ff708</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Debug" Version="8.0.0-rtm.23509.5">
+    <Dependency Name="Microsoft.Extensions.Logging.Debug" Version="8.0.0-rtm.23511.16">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>a9cc3c80fe43d19a38cacda4c1aecc51fb6eabb1</Sha>
+      <Sha>256bf22a3ddf920516752701da2b95e1847ff708</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Primitives" Version="8.0.0-rtm.23509.5">
+    <Dependency Name="Microsoft.Extensions.Primitives" Version="8.0.0-rtm.23511.16">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>a9cc3c80fe43d19a38cacda4c1aecc51fb6eabb1</Sha>
+      <Sha>256bf22a3ddf920516752701da2b95e1847ff708</Sha>
     </Dependency>
   </ProductDependencies>
 </Dependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,32 +1,32 @@
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.Dotnet.Sdk.Internal" Version="8.0.100-rtm.23506.1">
+    <Dependency Name="Microsoft.Dotnet.Sdk.Internal" Version="8.0.100-rtm.23512.1">
       <Uri>https://github.com/dotnet/installer</Uri>
-      <Sha>0ffc9fdc93e578268a09b0dccdc4c3527f4697f3</Sha>
+      <Sha>dfe59b6c4dec70fef72f18010dc8606ce8fb141a</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NETCore.App.Ref" Version="8.0.0-rtm.23511.16">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>256bf22a3ddf920516752701da2b95e1847ff708</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Android.Sdk.Windows" Version="34.0.12">
+    <Dependency Name="Microsoft.Android.Sdk.Windows" Version="34.99.0-preview.1.10">
       <Uri>https://github.com/xamarin/xamarin-android</Uri>
-      <Sha>27347a7c258a62b9bf212f27f5492b4a7d16ac7b</Sha>
+      <Sha>1a309b63345d64356a68805c2e20f1c4fd794e42</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.MacCatalyst.Sdk" Version="16.4.8966-net8-rtm">
+    <Dependency Name="Microsoft.MacCatalyst.Sdk" Version="17.0.8432">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>468c3dd14d283162ab345491392fc185cc8f3168</Sha>
+      <Sha>12463e78a75a1b94331aa0f31d7f02ab8767c817</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.macOS.Sdk" Version="13.3.8966-net8-rtm">
+    <Dependency Name="Microsoft.macOS.Sdk" Version="14.0.8432">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>468c3dd14d283162ab345491392fc185cc8f3168</Sha>
+      <Sha>12463e78a75a1b94331aa0f31d7f02ab8767c817</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.iOS.Sdk" Version="16.4.8966-net8-rtm">
+    <Dependency Name="Microsoft.iOS.Sdk" Version="17.0.8432">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>468c3dd14d283162ab345491392fc185cc8f3168</Sha>
+      <Sha>12463e78a75a1b94331aa0f31d7f02ab8767c817</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.tvOS.Sdk" Version="16.4.8966-net8-rtm">
+    <Dependency Name="Microsoft.tvOS.Sdk" Version="17.0.8432">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>468c3dd14d283162ab345491392fc185cc8f3168</Sha>
+      <Sha>12463e78a75a1b94331aa0f31d7f02ab8767c817</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.Workload.Emscripten.Current.Manifest-8.0.100.Transport" Version="8.0.0-rtm.23504.4" CoherentParentDependency="Microsoft.NETCore.App.Ref">
       <Uri>https://github.com/dotnet/emsdk</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -83,17 +83,17 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>3f4da9ced34942d83054e647f3b1d9d7dde281e8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XHarness.TestRunners.Common" Version="8.0.0-prerelease.23471.1">
+    <Dependency Name="Microsoft.DotNet.XHarness.TestRunners.Common" Version="8.0.0-prerelease.23516.1">
       <Uri>https://github.com/dotnet/xharness</Uri>
-      <Sha>06fd591dc00862e415eddbec734ae9ea77d35486</Sha>
+      <Sha>02098f6cf81169134770ee47acc2aca0910635bb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="8.0.0-prerelease.23471.1">
+    <Dependency Name="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="8.0.0-prerelease.23516.1">
       <Uri>https://github.com/dotnet/xharness</Uri>
-      <Sha>06fd591dc00862e415eddbec734ae9ea77d35486</Sha>
+      <Sha>02098f6cf81169134770ee47acc2aca0910635bb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XHarness.CLI" Version="8.0.0-prerelease.23471.1">
+    <Dependency Name="Microsoft.DotNet.XHarness.CLI" Version="8.0.0-prerelease.23516.1">
       <Uri>https://github.com/dotnet/xharness</Uri>
-      <Sha>06fd591dc00862e415eddbec734ae9ea77d35486</Sha>
+      <Sha>02098f6cf81169134770ee47acc2aca0910635bb</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Configuration" Version="8.0.0-rtm.23511.16">
       <Uri>https://github.com/dotnet/runtime</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -12,19 +12,19 @@
       <Uri>https://github.com/xamarin/xamarin-android</Uri>
       <Sha>27347a7c258a62b9bf212f27f5492b4a7d16ac7b</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.MacCatalyst.Sdk.net8.0_16.4" Version="16.4.8966-net8-rtm">
+    <Dependency Name="Microsoft.MacCatalyst.Sdk" Version="16.4.8966-net8-rtm">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
       <Sha>468c3dd14d283162ab345491392fc185cc8f3168</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.macOS.Sdk.net8.0_13.3" Version="13.3.8966-net8-rtm">
+    <Dependency Name="Microsoft.macOS.Sdk" Version="13.3.8966-net8-rtm">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
       <Sha>468c3dd14d283162ab345491392fc185cc8f3168</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.iOS.Sdk.net8.0_16.4" Version="16.4.8966-net8-rtm">
+    <Dependency Name="Microsoft.iOS.Sdk" Version="16.4.8966-net8-rtm">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
       <Sha>468c3dd14d283162ab345491392fc185cc8f3168</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.tvOS.Sdk.net8.0_16.4" Version="16.4.8966-net8-rtm">
+    <Dependency Name="Microsoft.tvOS.Sdk" Version="16.4.8966-net8-rtm">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
       <Sha>468c3dd14d283162ab345491392fc185cc8f3168</Sha>
     </Dependency>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -3,7 +3,7 @@
     <!-- Current previous .NET SDK major version's stable release of MAUI packages -->
     <MicrosoftMauiPreviousDotNetReleasedVersion>7.0.96</MicrosoftMauiPreviousDotNetReleasedVersion>
     <!-- dotnet/installer -->
-    <MicrosoftDotnetSdkInternalPackageVersion>8.0.100-rtm.23506.1</MicrosoftDotnetSdkInternalPackageVersion>
+    <MicrosoftDotnetSdkInternalPackageVersion>8.0.100-rtm.23512.3</MicrosoftDotnetSdkInternalPackageVersion>
     <!-- dotnet/runtime -->
     <MicrosoftNETCoreAppRefPackageVersion>8.0.0-rtm.23511.16</MicrosoftNETCoreAppRefPackageVersion>
     <SystemTextJsonPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemTextJsonPackageVersion>
@@ -23,12 +23,12 @@
     <MicrosoftExtensionsLoggingDebugVersion>8.0.0-rtm.23511.16</MicrosoftExtensionsLoggingDebugVersion>
     <MicrosoftExtensionsPrimitivesVersion>8.0.0-rtm.23511.16</MicrosoftExtensionsPrimitivesVersion>
     <!-- xamarin/xamarin-android -->
-    <MicrosoftAndroidSdkWindowsPackageVersion>34.0.12</MicrosoftAndroidSdkWindowsPackageVersion>
+    <MicrosoftAndroidSdkWindowsPackageVersion>34.0.13</MicrosoftAndroidSdkWindowsPackageVersion>
     <!-- xamarin/xamarin-macios -->
-    <MicrosoftMacCatalystSdkPackageVersion>16.4.8966-net8-rtm</MicrosoftMacCatalystSdkPackageVersion>
-    <MicrosoftmacOSSdkPackageVersion>13.3.8966-net8-rtm</MicrosoftmacOSSdkPackageVersion>
-    <MicrosoftiOSSdkPackageVersion>16.4.8966-net8-rtm</MicrosoftiOSSdkPackageVersion>
-    <MicrosofttvOSSdkPackageVersion>16.4.8966-net8-rtm</MicrosofttvOSSdkPackageVersion>
+    <MicrosoftMacCatalystSdkPackageVersion>17.0.8432</MicrosoftMacCatalystSdkPackageVersion>
+    <MicrosoftmacOSSdkPackageVersion>14.0.8432</MicrosoftmacOSSdkPackageVersion>
+    <MicrosoftiOSSdkPackageVersion>17.0.8432</MicrosoftiOSSdkPackageVersion>
+    <MicrosofttvOSSdkPackageVersion>17.0.8432</MicrosofttvOSSdkPackageVersion>
     <!-- Samsung/Tizen.NET -->
     <SamsungTizenSdkPackageVersion>7.0.125</SamsungTizenSdkPackageVersion>
     <!-- emsdk -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -3,7 +3,7 @@
     <!-- Current previous .NET SDK major version's stable release of MAUI packages -->
     <MicrosoftMauiPreviousDotNetReleasedVersion>7.0.96</MicrosoftMauiPreviousDotNetReleasedVersion>
     <!-- dotnet/installer -->
-    <MicrosoftDotnetSdkInternalPackageVersion>8.0.100-rtm.23512.3</MicrosoftDotnetSdkInternalPackageVersion>
+    <MicrosoftDotnetSdkInternalPackageVersion>8.0.100-rtm.23513.4</MicrosoftDotnetSdkInternalPackageVersion>
     <!-- dotnet/runtime -->
     <MicrosoftNETCoreAppRefPackageVersion>8.0.0-rtm.23511.16</MicrosoftNETCoreAppRefPackageVersion>
     <SystemTextJsonPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemTextJsonPackageVersion>
@@ -23,12 +23,12 @@
     <MicrosoftExtensionsLoggingDebugVersion>8.0.0-rtm.23511.16</MicrosoftExtensionsLoggingDebugVersion>
     <MicrosoftExtensionsPrimitivesVersion>8.0.0-rtm.23511.16</MicrosoftExtensionsPrimitivesVersion>
     <!-- xamarin/xamarin-android -->
-    <MicrosoftAndroidSdkWindowsPackageVersion>34.0.13</MicrosoftAndroidSdkWindowsPackageVersion>
+    <MicrosoftAndroidSdkWindowsPackageVersion>34.0.25</MicrosoftAndroidSdkWindowsPackageVersion>
     <!-- xamarin/xamarin-macios -->
-    <MicrosoftMacCatalystSdkPackageVersion>17.0.8432</MicrosoftMacCatalystSdkPackageVersion>
-    <MicrosoftmacOSSdkPackageVersion>14.0.8432</MicrosoftmacOSSdkPackageVersion>
-    <MicrosoftiOSSdkPackageVersion>17.0.8432</MicrosoftiOSSdkPackageVersion>
-    <MicrosofttvOSSdkPackageVersion>17.0.8432</MicrosofttvOSSdkPackageVersion>
+    <MicrosoftMacCatalystSdkPackageVersion>17.0.8438</MicrosoftMacCatalystSdkPackageVersion>
+    <MicrosoftmacOSSdkPackageVersion>14.0.8438</MicrosoftmacOSSdkPackageVersion>
+    <MicrosoftiOSSdkPackageVersion>17.0.8438</MicrosoftiOSSdkPackageVersion>
+    <MicrosofttvOSSdkPackageVersion>17.0.8438</MicrosofttvOSSdkPackageVersion>
     <!-- Samsung/Tizen.NET -->
     <SamsungTizenSdkPackageVersion>7.0.125</SamsungTizenSdkPackageVersion>
     <!-- emsdk -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -5,23 +5,23 @@
     <!-- dotnet/installer -->
     <MicrosoftDotnetSdkInternalPackageVersion>8.0.100-rtm.23506.1</MicrosoftDotnetSdkInternalPackageVersion>
     <!-- dotnet/runtime -->
-    <MicrosoftNETCoreAppRefPackageVersion>8.0.0-rtm.23509.5</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>8.0.0-rtm.23511.16</MicrosoftNETCoreAppRefPackageVersion>
     <SystemTextJsonPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemTextJsonPackageVersion>
     <SystemTextEncodingsWebPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemTextEncodingsWebPackageVersion>
     <MicrosoftBclAsyncInterfacesPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</MicrosoftBclAsyncInterfacesPackageVersion>
     <!-- Microsoft/Extensions -->
     <SystemCodeDomPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemCodeDomPackageVersion>
-    <MicrosoftExtensionsConfigurationVersion>8.0.0-rtm.23509.5</MicrosoftExtensionsConfigurationVersion>
-    <MicrosoftExtensionsConfigurationAbstractionsVersion>8.0.0-rtm.23509.5</MicrosoftExtensionsConfigurationAbstractionsVersion>
-    <MicrosoftExtensionsConfigurationJsonVersion>8.0.0-rtm.23509.5</MicrosoftExtensionsConfigurationJsonVersion>
-    <MicrosoftExtensionsDependencyInjectionVersion>8.0.0-rtm.23509.5</MicrosoftExtensionsDependencyInjectionVersion>
-    <MicrosoftExtensionsDependencyInjectionAbstractionsVersion>8.0.0-rtm.23509.5</MicrosoftExtensionsDependencyInjectionAbstractionsVersion>
-    <MicrosoftExtensionsFileProvidersAbstractionsVersion>8.0.0-rtm.23509.5</MicrosoftExtensionsFileProvidersAbstractionsVersion>
-    <MicrosoftExtensionsLoggingAbstractionsVersion>8.0.0-rtm.23509.5</MicrosoftExtensionsLoggingAbstractionsVersion>
-    <MicrosoftExtensionsLoggingVersion>8.0.0-rtm.23509.5</MicrosoftExtensionsLoggingVersion>
-    <MicrosoftExtensionsLoggingConsoleVersion>8.0.0-rtm.23509.5</MicrosoftExtensionsLoggingConsoleVersion>
-    <MicrosoftExtensionsLoggingDebugVersion>8.0.0-rtm.23509.5</MicrosoftExtensionsLoggingDebugVersion>
-    <MicrosoftExtensionsPrimitivesVersion>8.0.0-rtm.23509.5</MicrosoftExtensionsPrimitivesVersion>
+    <MicrosoftExtensionsConfigurationVersion>8.0.0-rtm.23511.16</MicrosoftExtensionsConfigurationVersion>
+    <MicrosoftExtensionsConfigurationAbstractionsVersion>8.0.0-rtm.23511.16</MicrosoftExtensionsConfigurationAbstractionsVersion>
+    <MicrosoftExtensionsConfigurationJsonVersion>8.0.0-rtm.23511.16</MicrosoftExtensionsConfigurationJsonVersion>
+    <MicrosoftExtensionsDependencyInjectionVersion>8.0.0-rtm.23511.16</MicrosoftExtensionsDependencyInjectionVersion>
+    <MicrosoftExtensionsDependencyInjectionAbstractionsVersion>8.0.0-rtm.23511.16</MicrosoftExtensionsDependencyInjectionAbstractionsVersion>
+    <MicrosoftExtensionsFileProvidersAbstractionsVersion>8.0.0-rtm.23511.16</MicrosoftExtensionsFileProvidersAbstractionsVersion>
+    <MicrosoftExtensionsLoggingAbstractionsVersion>8.0.0-rtm.23511.16</MicrosoftExtensionsLoggingAbstractionsVersion>
+    <MicrosoftExtensionsLoggingVersion>8.0.0-rtm.23511.16</MicrosoftExtensionsLoggingVersion>
+    <MicrosoftExtensionsLoggingConsoleVersion>8.0.0-rtm.23511.16</MicrosoftExtensionsLoggingConsoleVersion>
+    <MicrosoftExtensionsLoggingDebugVersion>8.0.0-rtm.23511.16</MicrosoftExtensionsLoggingDebugVersion>
+    <MicrosoftExtensionsPrimitivesVersion>8.0.0-rtm.23511.16</MicrosoftExtensionsPrimitivesVersion>
     <!-- xamarin/xamarin-android -->
     <MicrosoftAndroidSdkWindowsPackageVersion>34.0.12</MicrosoftAndroidSdkWindowsPackageVersion>
     <!-- xamarin/xamarin-macios -->
@@ -39,17 +39,17 @@
     <MicrosoftWindowsSDKBuildToolsPackageVersion>10.0.22621.756</MicrosoftWindowsSDKBuildToolsPackageVersion>
     <MicrosoftGraphicsWin2DPackageVersion>1.0.5.1</MicrosoftGraphicsWin2DPackageVersion>
     <!-- Everything else -->
-    <MicrosoftAspNetCoreAuthorizationPackageVersion>8.0.0-rtm.23509.3</MicrosoftAspNetCoreAuthorizationPackageVersion>
-    <MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>8.0.0-rtm.23509.3</MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>
-    <MicrosoftAspNetCoreAuthenticationGooglePackageVersion>8.0.0-rtm.23509.3</MicrosoftAspNetCoreAuthenticationGooglePackageVersion>
-    <MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>8.0.0-rtm.23509.3</MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>
-    <MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>8.0.0-rtm.23509.3</MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>
-    <MicrosoftAspNetCoreComponentsFormsPackageVersion>8.0.0-rtm.23509.3</MicrosoftAspNetCoreComponentsFormsPackageVersion>
-    <MicrosoftAspNetCoreComponentsPackageVersion>8.0.0-rtm.23509.3</MicrosoftAspNetCoreComponentsPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebPackageVersion>8.0.0-rtm.23509.3</MicrosoftAspNetCoreComponentsWebPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebViewPackageVersion>8.0.0-rtm.23509.3</MicrosoftAspNetCoreComponentsWebViewPackageVersion>
-    <MicrosoftAspNetCoreMetadataPackageVersion>8.0.0-rtm.23509.3</MicrosoftAspNetCoreMetadataPackageVersion>
-    <MicrosoftJSInteropPackageVersion>8.0.0-rtm.23509.3</MicrosoftJSInteropPackageVersion>
+    <MicrosoftAspNetCoreAuthorizationPackageVersion>8.0.0-rtm.23512.7</MicrosoftAspNetCoreAuthorizationPackageVersion>
+    <MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>8.0.0-rtm.23512.7</MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>
+    <MicrosoftAspNetCoreAuthenticationGooglePackageVersion>8.0.0-rtm.23512.7</MicrosoftAspNetCoreAuthenticationGooglePackageVersion>
+    <MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>8.0.0-rtm.23512.7</MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>
+    <MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>8.0.0-rtm.23512.7</MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>
+    <MicrosoftAspNetCoreComponentsFormsPackageVersion>8.0.0-rtm.23512.7</MicrosoftAspNetCoreComponentsFormsPackageVersion>
+    <MicrosoftAspNetCoreComponentsPackageVersion>8.0.0-rtm.23512.7</MicrosoftAspNetCoreComponentsPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebPackageVersion>8.0.0-rtm.23512.7</MicrosoftAspNetCoreComponentsWebPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebViewPackageVersion>8.0.0-rtm.23512.7</MicrosoftAspNetCoreComponentsWebViewPackageVersion>
+    <MicrosoftAspNetCoreMetadataPackageVersion>8.0.0-rtm.23512.7</MicrosoftAspNetCoreMetadataPackageVersion>
+    <MicrosoftJSInteropPackageVersion>8.0.0-rtm.23512.7</MicrosoftJSInteropPackageVersion>
     <!-- Other packages -->
     <MicrosoftCodeAnalysisNetAnalyzersVersion>8.0.0-preview1.23067.2</MicrosoftCodeAnalysisNetAnalyzersVersion>
     <MicrosoftCodeAnalysisPublicApiAnalyzersVersion>3.3.4</MicrosoftCodeAnalysisPublicApiAnalyzersVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -25,14 +25,10 @@
     <!-- xamarin/xamarin-android -->
     <MicrosoftAndroidSdkWindowsPackageVersion>34.0.12</MicrosoftAndroidSdkWindowsPackageVersion>
     <!-- xamarin/xamarin-macios -->
-    <MicrosoftMacCatalystSdknet80_164PackageVersion>16.4.8966-net8-rtm</MicrosoftMacCatalystSdknet80_164PackageVersion>
-    <MicrosoftmacOSSdknet80_133PackageVersion>13.3.8966-net8-rtm</MicrosoftmacOSSdknet80_133PackageVersion>
-    <MicrosoftiOSSdknet80_164PackageVersion>16.4.8966-net8-rtm</MicrosoftiOSSdknet80_164PackageVersion>
-    <MicrosofttvOSSdknet80_164PackageVersion>16.4.8966-net8-rtm</MicrosofttvOSSdknet80_164PackageVersion>
-    <MicrosoftMacCatalystSdkPackageVersion>$(MicrosoftMacCatalystSdknet80_164PackageVersion)</MicrosoftMacCatalystSdkPackageVersion>
-    <MicrosoftmacOSSdkPackageVersion>$(MicrosoftmacOSSdknet80_133PackageVersion)</MicrosoftmacOSSdkPackageVersion>
-    <MicrosoftiOSSdkPackageVersion>$(MicrosoftiOSSdknet80_164PackageVersion)</MicrosoftiOSSdkPackageVersion>
-    <MicrosofttvOSSdkPackageVersion>$(MicrosofttvOSSdknet80_164PackageVersion)</MicrosofttvOSSdkPackageVersion>
+    <MicrosoftMacCatalystSdkPackageVersion>16.4.8966-net8-rtm</MicrosoftMacCatalystSdkPackageVersion>
+    <MicrosoftmacOSSdkPackageVersion>13.3.8966-net8-rtm</MicrosoftmacOSSdkPackageVersion>
+    <MicrosoftiOSSdkPackageVersion>16.4.8966-net8-rtm</MicrosoftiOSSdkPackageVersion>
+    <MicrosofttvOSSdkPackageVersion>16.4.8966-net8-rtm</MicrosofttvOSSdkPackageVersion>
     <!-- Samsung/Tizen.NET -->
     <SamsungTizenSdkPackageVersion>7.0.125</SamsungTizenSdkPackageVersion>
     <!-- emsdk -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -79,9 +79,9 @@
     <_HarfBuzzSharpVersion>7.3.0</_HarfBuzzSharpVersion>
     <_SkiaSharpNativeAssetsVersion>0.0.0-commit.e2c5c86249621857107c779af0f79b4d06613766.655</_SkiaSharpNativeAssetsVersion>
     <MicrosoftTemplateEngineTasksVersion>7.0.100-preview.5.22226.1</MicrosoftTemplateEngineTasksVersion>
-    <MicrosoftDotNetXHarnessTestRunnersCommonVersion>8.0.0-prerelease.23471.1</MicrosoftDotNetXHarnessTestRunnersCommonVersion>
-    <MicrosoftDotNetXHarnessTestRunnersXunitVersion>8.0.0-prerelease.23471.1</MicrosoftDotNetXHarnessTestRunnersXunitVersion>
-    <MicrosoftDotNetXHarnessCLIVersion>8.0.0-prerelease.23471.1</MicrosoftDotNetXHarnessCLIVersion>
+    <MicrosoftDotNetXHarnessTestRunnersCommonVersion>8.0.0-prerelease.23516.1</MicrosoftDotNetXHarnessTestRunnersCommonVersion>
+    <MicrosoftDotNetXHarnessTestRunnersXunitVersion>8.0.0-prerelease.23516.1</MicrosoftDotNetXHarnessTestRunnersXunitVersion>
+    <MicrosoftDotNetXHarnessCLIVersion>8.0.0-prerelease.23516.1</MicrosoftDotNetXHarnessCLIVersion>
     <TizenUIExtensionsVersion>0.9.0</TizenUIExtensionsVersion>
     <SvgSkiaPackageVersion>0.5.13</SvgSkiaPackageVersion>
     <FizzlerPackageVersion>1.2.0</FizzlerPackageVersion>

--- a/eng/pipelines/common/device-tests-steps.yml
+++ b/eng/pipelines/common/device-tests-steps.yml
@@ -28,6 +28,9 @@ steps:
       DOTNET_TOKEN: $(dotnetbuilds-internal-container-read-token)
       PRIVATE_BUILD: $(PrivateBuild)
 
+  - pwsh: echo "##vso[task.prependpath]$(DotNet.Dir)"
+    displayName: 'Add .NET to PATH'
+
   - ${{ if eq(parameters.useArtifacts, true) }}:
 
     - task: DownloadBuildArtifacts@0
@@ -49,7 +52,7 @@ steps:
         PRIVATE_BUILD: $(PrivateBuild)
 
   - ${{ else }}:
-    - pwsh: dotnet cake --target=dotnet-buildtasks --configuration="Release"
+    - pwsh: ./build.ps1 --target=dotnet-buildtasks --configuration="Release"
       displayName: 'Build the MSBuild Tasks'
 
   - pwsh: ./build.ps1 -Script eng/devices/${{ parameters.platform }}.cake --project="${{ parameters.path }}" --device=${{ parameters.device }} --packageid=${{ parameters.windowsPackageId }} --results="$(TestResultsDirectory)" --binlog="$(LogDirectory)" ${{ parameters.cakeArgs }}

--- a/eng/pipelines/common/maui-templates.yml
+++ b/eng/pipelines/common/maui-templates.yml
@@ -162,7 +162,7 @@ jobs:
         DOTNET_TOKEN: $(dotnetbuilds-internal-container-read-token)
         PRIVATE_BUILD: $(PrivateBuild)
 
-    - script: dotnet tool update Microsoft.DotNet.XHarness.CLI --add-source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json --version "1.0.0-prerelease*" -g
+    - script: dotnet tool update Microsoft.DotNet.XHarness.CLI --add-source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json --version "8.0.0-prerelease*" -g
       displayName: install xharness
 
     - task: DotNetCoreCLI@2

--- a/eng/pipelines/common/maui-templates.yml
+++ b/eng/pipelines/common/maui-templates.yml
@@ -24,15 +24,10 @@ parameters:
     - name: Windows
       poolName: $(windowsNet6VmPool)
       vmImage: $(windowsNet6VmImage)
-      bootsAndroid: $(Android.Msi)
-      bootsiOS: $(iOS.Msi)
       artifact: templates-windows
     - name: macOS
       poolName: $(macOSXNet6VmPool)
       vmImage: $(macOSXNet6VmImage)
-      bootsAndroid: $(Android.Pkg)
-      bootsiOS: $(iOS.Pkg)
-      bootsMacCatalyst: $(MacCatalyst.Pkg)
       artifact: templates-macos
 
   - name: RunPlatforms
@@ -75,6 +70,7 @@ jobs:
     demands:
       - macOS.Name -equals Ventura
       - macOS.Architecture -equals x64
+      - Agent.OSVersion -equals 13.5
   steps:
 
   - ${{ each step in parameters.prepareSteps }}:

--- a/eng/pipelines/common/ui-tests-compatibility-steps.yml
+++ b/eng/pipelines/common/ui-tests-compatibility-steps.yml
@@ -22,7 +22,7 @@ steps:
       ${{ if ne(parameters.platform, 'windows') }}:
         platform: macos
         skipProvisioning: false
-      skipXcode: false
+      skipXcode: ${{ or(eq(parameters.platform, 'android'), eq(parameters.platform, 'windows')) }}
       provisionatorChannel: ${{ parameters.provisionatorChannel }}
  
   - pwsh: ./build.ps1 --target=dotnet --configuration="${{ parameters.configuration }}" --verbosity=diagnostic

--- a/eng/pipelines/common/ui-tests-steps.yml
+++ b/eng/pipelines/common/ui-tests-steps.yml
@@ -13,15 +13,9 @@ steps:
 
   - template: provision.yml
     parameters:
-      ${{ if eq(parameters.platform, 'windows') }}:
-        skipProvisioning: true
-      ${{ if ne(parameters.platform, 'windows') }}:
-        skipProvisioning: false
-      ${{ if eq(parameters.platform, 'android') }}:
-        skipAndroidSdks : false
-      ${{ if ne(parameters.platform, 'android') }}:
-        skipAndroidSdks: false
-      skipXcode: false
+      skipProvisioning:  ${{ eq(parameters.platform, 'windows') }}
+      skipAndroidSdks: ${{ ne(parameters.platform, 'android') }}
+      skipXcode: ${{ or(eq(parameters.platform, 'android'), eq(parameters.platform, 'windows')) }}
       provisionatorChannel: ${{ parameters.provisionatorChannel }}
 
   - task: PowerShell@2

--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -8,9 +8,9 @@ variables:
 - name: DOTNET_VERSION
   value: 7.0.401
 - name: REQUIRED_XCODE
-  value: 14.3.1
+  value: 15.0.0
 - name: DEVICETESTS_REQUIRED_XCODE
-  value: 14.3.1
+  value: 15.0.0
 - name: LocBranchPrefix
   value: 'loc-hb'
 - name: isMainBranch

--- a/eng/pipelines/device-tests.yml
+++ b/eng/pipelines/device-tests.yml
@@ -74,6 +74,7 @@ parameters:
       demands:
         - macOS.Name -equals Ventura
         - macOS.Architecture -equals x64
+        - Agent.OSVersion -equals 13.5
 
   - name: catalystPool
     type: object

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -106,6 +106,7 @@ parameters:
       demands:
         - macOS.Name -equals Ventura
         - macOS.Architecture -equals x64
+        - Agent.OSVersion -equals 13.5
       testName: RunOnAndroid
       artifact: templates-run-android
     - name: $(iosTestsVmPool)
@@ -113,6 +114,7 @@ parameters:
       demands:
         - macOS.Name -equals Ventura
         - macOS.Architecture -equals x64
+        - Agent.OSVersion -equals 13.5
       testName: RunOniOS
       artifact: templates-run-ios
 
@@ -162,6 +164,7 @@ stages:
               demands:
                 - macOS.Name -equals Ventura
                 - macOS.Architecture -equals x64
+                - Agent.OSVersion -equals 13.5
             steps:
               - template: common/provision.yml
                 parameters:
@@ -204,8 +207,7 @@ stages:
             demands:
               - macOS.Name -equals Ventura
               - macOS.Architecture -equals x64
-              - Agent.HasDevices -equals False
-              - Agent.IsPaired -equals False
+              - Agent.OSVersion -equals 13.5
           steps:
             - template: common/pack.yml
               parameters:
@@ -231,6 +233,7 @@ stages:
             demands:
               - macOS.Name -equals Ventura
               - macOS.Architecture -equals x64
+              - Agent.OSVersion -equals 13.5
           steps:
             - template: common/provision.yml
               parameters:

--- a/eng/pipelines/ui-tests.yml
+++ b/eng/pipelines/ui-tests.yml
@@ -78,6 +78,7 @@ parameters:
       demands:
         - macOS.Name -equals Ventura
         - macOS.Architecture -equals x64
+        - Agent.OSVersion -equals 13.5
   
   - name: windowsPool
     type: object
@@ -108,6 +109,7 @@ parameters:
       demands:
         - macOS.Name -equals Ventura
         - macOS.Architecture -equals x64
+        - Agent.OSVersion -equals 13.5
 
 
 resources:

--- a/eng/provisioning/xcode.csx
+++ b/eng/provisioning/xcode.csx
@@ -36,12 +36,11 @@ else
     item = Xcode(desiredXcode);
 
 Console.WriteLine("Selected version: {0}", item.Version);
-item.XcodeSelect();
-
-// if(desiredXcode == "13.3")
-// {
-//     XcodeSimulator ("iOS", "15.4");
-// }
+item.XcodeSelect() 
+        .SimulatorRuntime(SimRuntime.iOS)
+       // .SimulatorRuntime(SimRuntime.watchOS)
+     //   .SimulatorRuntime(SimRuntime.visionOS);
+        .SimulatorRuntime(SimRuntime.tvOS);
 
 LogInstalledXcodes();
 

--- a/src/Essentials/src/Permissions/Permissions.ios.watchos.cs
+++ b/src/Essentials/src/Permissions/Permissions.ios.watchos.cs
@@ -28,8 +28,15 @@ namespace Microsoft.Maui.ApplicationModel
 			{
 				var eventStore = new EKEventStore();
 
-				var results = await eventStore.RequestAccessAsync(entityType);
-
+				Tuple<bool, NSError> results = null;
+#if NET7_0
+				results = await eventStore.RequestAccessAsync(entityType);
+#else
+				if (entityType == EKEntityType.Reminder)
+					results = await eventStore.RequestFullAccessToRemindersAsync();
+				if (entityType == EKEntityType.Event)
+					results = await eventStore.RequestFullAccessToEventsAsync();
+#endif
 				return results.Item1 ? PermissionStatus.Granted : PermissionStatus.Denied;
 			}
 		}


### PR DESCRIPTION
### Description of Change

Updated version of https://github.com/dotnet/maui/pull/17933

We've reverted the renaming of the xamarin-macios dependencies for .NET 8.

References:

https://github.com/dotnet/maui/pull/17267
https://github.com/xamarin/xamarin-macios/pull/19145