### PR TITLE
Enable <Nullable> in .NET MAUI project templates

### DIFF
--- a/src/Templates/src/templates/maui-blazor/Components/Pages/Weather.razor
+++ b/src/Templates/src/templates/maui-blazor/Components/Pages/Weather.razor
@@ -34,7 +34,7 @@ else
 }
 
 @code {
-    private WeatherForecast[] forecasts;
+    private WeatherForecast[]? forecasts;
 
     protected override async Task OnInitializedAsync()
     {
@@ -55,7 +55,7 @@ else
     {
         public DateOnly Date { get; set; }
         public int TemperatureC { get; set; }
-        public string Summary { get; set; }
+        public string? Summary { get; set; }
         public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
     }
 }

--- a/src/Templates/src/templates/maui-blazor/MauiApp.1.csproj
+++ b/src/Templates/src/templates/maui-blazor/MauiApp.1.csproj
@@ -6,12 +6,12 @@
         <!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
         <!-- <TargetFrameworks>$(TargetFrameworks);DOTNET_TFM-tizen</TargetFrameworks> -->
 
-         <!-- Note for MacCatalyst:
+        <!-- Note for MacCatalyst:
             The default runtime is maccatalyst-x64, except in Release config, in which case the default is maccatalyst-x64;maccatalyst-arm64.
             When specifying both architectures, use the plural <RuntimeIdentifiers> instead of the singular <RuntimeIdentifer>.
             The Mac App Store will NOT accept apps with ONLY maccatalyst-arm64 indicated;
             either BOTH runtimes must be indicated or ONLY macatalyst-x64. -->
-         <!-- For example: <RuntimeIdentifiers>maccatalyst-x64;maccatalyst-arm64</RuntimeIdentifiers> -->
+        <!-- For example: <RuntimeIdentifiers>maccatalyst-x64;maccatalyst-arm64</RuntimeIdentifiers> -->
 
         <OutputType>Exe</OutputType>
         <RootNamespace>MauiApp._1</RootNamespace>
@@ -19,6 +19,7 @@
         <SingleProject>true</SingleProject>
         <ImplicitUsings>enable</ImplicitUsings>
         <EnableDefaultCssItems>false</EnableDefaultCssItems>
+        <Nullable>enable</Nullable>
 
         <!-- Display name -->
         <ApplicationTitle>MauiApp.1</ApplicationTitle>

--- a/src/Templates/src/templates/maui-lib/MauiLib1.csproj
+++ b/src/Templates/src/templates/maui-lib/MauiLib1.csproj
@@ -9,6 +9,7 @@
 		<UseMaui>true</UseMaui>
 		<SingleProject>true</SingleProject>
 		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
 
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">11.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">13.1</SupportedOSPlatformVersion>

--- a/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
+++ b/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
@@ -18,6 +18,7 @@
 		<UseMaui>true</UseMaui>
 		<SingleProject>true</SingleProject>
 		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
 
 		<!-- Display name -->
 		<ApplicationTitle>MauiApp.1</ApplicationTitle>

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/TestResources/TemplateLaunchInstrumentation.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/TestResources/TemplateLaunchInstrumentation.cs
@@ -8,13 +8,13 @@ namespace mauitemplate
     [Instrumentation(Name = "com.microsoft.mauitemplate.Launch")]
     public class TemplateLaunchInstrumentation : Instrumentation
     {
-        protected TemplateLaunchInstrumentation ()
-        {}
+        protected TemplateLaunchInstrumentation()
+        { }
 
-        protected TemplateLaunchInstrumentation (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer)
-        {}
+        protected TemplateLaunchInstrumentation(IntPtr handle, JniHandleOwnership transfer) : base(handle, transfer)
+        { }
 
-        public override void OnCreate(Bundle arguments)
+        public override void OnCreate(Bundle? arguments)
         {
             base.OnCreate(arguments);
             Start();
@@ -24,14 +24,14 @@ namespace mauitemplate
         {
             base.OnStart();
 
-            Bundle results = new Bundle ();
+            Bundle results = new Bundle();
             var activityName = "com.microsoft.mauitemplate.MainActivity";
-            ActivityMonitor monitor = AddMonitor(activityName, null, false);
+            var monitor = AddMonitor(activityName, null, false);
             Intent intent = new Intent(Intent.ActionMain);
             intent.SetFlags(ActivityFlags.NewTask);
-            intent.SetClassName(TargetContext, activityName);
+            intent.SetClassName(TargetContext!, activityName);
             StartActivitySync(intent);
-            Activity currentActivity = WaitForMonitor(monitor);
+            var currentActivity = WaitForMonitor(monitor);
             var resultCode = currentActivity is not null ? Result.Ok : Result.Canceled;
             results.PutString("return-code", resultCode.ToString("D"));
             Finish(resultCode, results);

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/TestResources/TemplateLaunchInstrumentation.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/TestResources/TemplateLaunchInstrumentation.cs
@@ -1,4 +1,5 @@
-﻿using Android.App;
+﻿#nullable enable
+using Android.App;
 using Android.Content;
 using Android.OS;
 using Android.Runtime;


### PR DESCRIPTION
Tested locally, everything builds and runs fine, no warnings. I also tried adding various MAUI *Item* templates to the nullable-enabled projects and they're all fine (they don't have much code in them to begin with).

Fixes #17987
