### PR TITLE
Set Nullable=enable in Control Samples projects

### DIFF
--- a/src/Controls/samples/Controls.Sample.Sandbox/Maui.Controls.Sample.Sandbox.csproj
+++ b/src/Controls/samples/Controls.Sample.Sandbox/Maui.Controls.Sample.Sandbox.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>$(MauiPlatforms)</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <SingleProject>true</SingleProject>
+    <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <!-- Disable multi-RID builds to workaround a parallel build issue -->
     <RuntimeIdentifier Condition="$(TargetFramework.Contains('-maccatalyst'))">maccatalyst-x64</RuntimeIdentifier>

--- a/src/Controls/samples/Controls.Sample.Sandbox/MauiProgram.cs
+++ b/src/Controls/samples/Controls.Sample.Sandbox/MauiProgram.cs
@@ -17,7 +17,7 @@ namespace Maui.Controls.Sample
 
 	class App : Application
 	{
-		protected override Window CreateWindow(IActivationState activationState)
+		protected override Window CreateWindow(IActivationState? activationState)
 		{
 			// To test shell scenarios, change this to true
 			bool useShell = false;

--- a/src/Controls/samples/Controls.Sample/Behaviors/NumericValidationBehavior.cs
+++ b/src/Controls/samples/Controls.Sample/Behaviors/NumericValidationBehavior.cs
@@ -17,10 +17,10 @@ namespace Controls.Sample.Behaviors
 			base.OnDetachingFrom(entry);
 		}
 
-		void OnEntryTextChanged(object sender, TextChangedEventArgs args)
+		void OnEntryTextChanged(object? sender, TextChangedEventArgs args)
 		{
 			bool isValid = double.TryParse(args.NewTextValue, out var result);
-			((Entry)sender).TextColor = isValid ? Colors.Transparent : Colors.Red;
+			((Entry)sender!).TextColor = isValid ? Colors.Transparent : Colors.Red;
 		}
 	}
 }

--- a/src/Controls/samples/Controls.Sample/Behaviors/TestWindowOverlay.cs
+++ b/src/Controls/samples/Controls.Sample/Behaviors/TestWindowOverlay.cs
@@ -20,16 +20,16 @@ namespace Maui.Controls.Sample
 			Tapped += OnTapped;
 		}
 
-		async void OnTapped(object sender, WindowOverlayTappedEventArgs e)
+		async void OnTapped(object? sender, WindowOverlayTappedEventArgs e)
 		{
 			if (!e.WindowOverlayElements.Contains(_testWindowDrawable))
 				return;
 
-			var window = Application.Current.Windows.FirstOrDefault(w => w == Window);
+			var window = Application.Current!.Windows.FirstOrDefault(w => w == Window);
 
 			System.Diagnostics.Debug.WriteLine($"Tapped the test overlay button.");
 
-			var result = await window.Page.DisplayActionSheet(
+			var result = await window!.Page!.DisplayActionSheet(
 				"Greetings from Visual Studio Client Experiences!",
 				"Goodbye!",
 				null,

--- a/src/Controls/samples/Controls.Sample/Controls/BordelessEntry/BordelessEntryAppHostBuilderExtensions.cs
+++ b/src/Controls/samples/Controls.Sample/Controls/BordelessEntry/BordelessEntryAppHostBuilderExtensions.cs
@@ -8,7 +8,7 @@ namespace Maui.Controls.Sample.Controls
 {
 	static class BordelessEntryAppHostBuilderExtensions
 	{
-		public static MauiAppBuilder UseBordelessEntry(this MauiAppBuilder builder, Action<BordelessEntryServiceBuilder> configureDelegate = null)
+		public static MauiAppBuilder UseBordelessEntry(this MauiAppBuilder builder, Action<BordelessEntryServiceBuilder>? configureDelegate = null)
 		{
 			builder.Services.TryAddSingleton<IMauiInitializeService, BorderlessEntryInitializer>();
 

--- a/src/Controls/samples/Controls.Sample/Controls/BordelessEntry/BordelessEntryHandler.cs
+++ b/src/Controls/samples/Controls.Sample/Controls/BordelessEntry/BordelessEntryHandler.cs
@@ -15,7 +15,7 @@ namespace Maui.Controls.Sample.Controls
 		{
 		}
 
-		public BordelessEntryHandler(PropertyMapper mapper = null)
+		public BordelessEntryHandler(PropertyMapper? mapper = null)
 			: base(mapper ?? BorderlessEntryMapper)
 		{
 		}

--- a/src/Controls/samples/Controls.Sample/Controls/BordelessEntry/BordelessEntryServiceBuilder.cs
+++ b/src/Controls/samples/Controls.Sample/Controls/BordelessEntry/BordelessEntryServiceBuilder.cs
@@ -23,7 +23,7 @@ namespace Maui.Controls.Sample.Controls
 
 	class BordelessEntryServiceBuilder
 	{
-		internal static IMauiHandlersCollection HandlersCollection;
+		internal static IMauiHandlersCollection? HandlersCollection;
 		internal static readonly Dictionary<Type, Type> PendingHandlers = new();
 
 		public static void TryAddHandler<TType, TTypeRender>()

--- a/src/Controls/samples/Controls.Sample/Controls/FocusEffect/FocusPlatformEffect.cs
+++ b/src/Controls/samples/Controls.Sample/Controls/FocusEffect/FocusPlatformEffect.cs
@@ -12,11 +12,11 @@ namespace Maui.Controls.Sample.Controls
 	{
 #if __ANDROID__
 		Android.Graphics.Color originalBackgroundColor = new Android.Graphics.Color(0, 0, 0, 0);
-		Android.Graphics.Color backgroundColor;
+		Android.Graphics.Color backgroundColor = default!;
 #elif __IOS__
-		UIKit.UIColor backgroundColor;
+		UIKit.UIColor backgroundColor = default!;
 #elif TIZEN
-		Tizen.NUI.Color backgroundColor;
+		Tizen.NUI.Color backgroundColor = default!;
 #endif
 
 		public FocusPlatformEffect()
@@ -29,7 +29,7 @@ namespace Maui.Controls.Sample.Controls
 			try
 			{
 #if WINDOWS
-				(Control as Microsoft.UI.Xaml.Controls.Control).Background = new Microsoft.UI.Xaml.Media.SolidColorBrush(Microsoft.UI.Colors.Cyan);
+				(Control as Microsoft.UI.Xaml.Controls.Control)!.Background = new Microsoft.UI.Xaml.Media.SolidColorBrush(Microsoft.UI.Colors.Cyan);
 #elif __ANDROID__
 				backgroundColor = Android.Graphics.Color.LightGreen;
 				Control.SetBackgroundColor(backgroundColor);
@@ -58,7 +58,7 @@ namespace Maui.Controls.Sample.Controls
 #if __ANDROID__
 				if (args.PropertyName == "IsFocused")
 				{
-					if (((Android.Graphics.Drawables.ColorDrawable)Control.Background).Color == backgroundColor)
+					if (((Android.Graphics.Drawables.ColorDrawable)Control.Background!).Color == backgroundColor)
 					{
 						Control.SetBackgroundColor(originalBackgroundColor);
 					}

--- a/src/Controls/samples/Controls.Sample/Controls/Rate/Rate.cs
+++ b/src/Controls/samples/Controls.Sample/Controls/Rate/Rate.cs
@@ -11,7 +11,7 @@ namespace Maui.Controls.Sample.Controls
 	{
 		const string ElementPanel = "PART_Panel";
 
-		StackLayout _rateLayout;
+		StackLayout _rateLayout = default!;
 
 		public static readonly BindableProperty IconProperty =
 			BindableProperty.Create(nameof(Icon), typeof(Geometry), typeof(Rate), GetDefaultIcon());
@@ -24,7 +24,7 @@ namespace Maui.Controls.Sample.Controls
 
 		static Geometry GetDefaultIcon()
 		{
-			Application.Current.Resources.TryGetValue("StarGeometry", out object resource);
+			Application.Current!.Resources.TryGetValue("StarGeometry", out object resource);
 			PathGeometry pathGeometry = (PathGeometry)resource;
 
 			return pathGeometry;
@@ -144,18 +144,18 @@ namespace Maui.Controls.Sample.Controls
 			set => SetValue(ValueProperty, value);
 		}
 
-		public event EventHandler<ValueChangedEventArgs> ValueChanged;
+		public event EventHandler<ValueChangedEventArgs>? ValueChanged;
 
 		protected override void OnApplyTemplate()
 		{
 			base.OnApplyTemplate();
 
-			_rateLayout = GetTemplateChild(ElementPanel) as StackLayout;
+			_rateLayout = (GetTemplateChild(ElementPanel) as StackLayout)!;
 
 			UpdateRateItems();
 		}
 
-		protected override void OnPropertyChanged([CallerMemberName] string propertyName = null)
+		protected override void OnPropertyChanged([CallerMemberName] string propertyName = "")
 		{
 			base.OnPropertyChanged(propertyName);
 
@@ -282,9 +282,9 @@ namespace Maui.Controls.Sample.Controls
 			ValueChanged?.Invoke(this, new ValueChangedEventArgs(Value));
 		}
 
-		void OnTapped(object sender, EventArgs e)
+		void OnTapped(object? sender, EventArgs e)
 		{
-			var star = (IView)sender;
+			var star = (IView)sender!;
 			var index = _rateLayout.Children.IndexOf(star);
 
 			Value = index + 1;

--- a/src/Controls/samples/Controls.Sample/Controls/Rate/RateItem.cs
+++ b/src/Controls/samples/Controls.Sample/Controls/Rate/RateItem.cs
@@ -8,7 +8,7 @@ namespace Maui.Controls.Sample.Controls
 	{
 		const string ElementIcon = "PART_Icon";
 
-		View _icon;
+		View _icon = default!;
 
 		public static readonly BindableProperty ItemSizeProperty =
 			BindableProperty.Create(nameof(ItemSize), typeof(double), typeof(RateItem), 30.0d);
@@ -104,7 +104,7 @@ namespace Maui.Controls.Sample.Controls
 		{
 			base.OnApplyTemplate();
 
-			_icon = GetTemplateChild(ElementIcon) as View;
+			_icon = (GetTemplateChild(ElementIcon) as View)!;
 			_icon.WidthRequest = Width;
 		}
 	}

--- a/src/Controls/samples/Controls.Sample/Converters/BoolToCustomValueConverter.cs
+++ b/src/Controls/samples/Controls.Sample/Converters/BoolToCustomValueConverter.cs
@@ -6,15 +6,15 @@ namespace Controls.Sample.Converters
 {
 	public class BoolToCustomValueConverter : IValueConverter
 	{
-		public object ValueIfTrue { get; set; }
-		public object ValueIfFalse { get; set; }
+		public object? ValueIfTrue { get; set; }
+		public object? ValueIfFalse { get; set; }
 
-		public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+		public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
 		{
 			return value is bool boolValue && boolValue ? ValueIfTrue : ValueIfFalse;
 		}
 
-		public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+		public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
 		{
 			return null;
 		}

--- a/src/Controls/samples/Controls.Sample/Converters/NegativeConverter.cs
+++ b/src/Controls/samples/Controls.Sample/Converters/NegativeConverter.cs
@@ -6,7 +6,7 @@ namespace Controls.Sample.Converters
 {
 	public class NegativeConverter : IValueConverter
 	{
-		public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+		public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
 		{
 			if (value is bool v)
 				return !v;
@@ -14,7 +14,7 @@ namespace Controls.Sample.Converters
 				return false;
 		}
 
-		public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+		public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
 		{
 			if (value is bool v)
 				return !v;

--- a/src/Controls/samples/Controls.Sample/Converters/ThicknessConverter.cs
+++ b/src/Controls/samples/Controls.Sample/Converters/ThicknessConverter.cs
@@ -10,11 +10,11 @@ namespace Controls.Sample.Converters
 	{
 		readonly ThicknessTypeConverter _converter = new();
 
-		public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+		public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
 		{
 			try
 			{
-				return _converter.ConvertFrom(value);
+				return _converter.ConvertFrom(value!);
 			}
 			catch
 			{
@@ -22,7 +22,7 @@ namespace Controls.Sample.Converters
 			}
 		}
 
-		public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) =>
+		public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
 			_converter.ConvertTo(value, targetType);
 	}
 }

--- a/src/Controls/samples/Controls.Sample/Extensions/StringToBrushConverter.cs
+++ b/src/Controls/samples/Controls.Sample/Extensions/StringToBrushConverter.cs
@@ -11,16 +11,16 @@ namespace Maui.Controls.Sample
 {
 	public class StringToBrushConverter : IValueConverter
 	{
-		public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+		public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
 		{
 			if (string.IsNullOrEmpty(value?.ToString()))
 				return null;
 
-			var color = GetColorFromString(value.ToString());
+			var color = GetColorFromString(value!.ToString()!);
 			return new SolidColorBrush(color);
 		}
 
-		public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+		public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
 		{
 			return null;
 		}

--- a/src/Controls/samples/Controls.Sample/Maui.Controls.Sample.csproj
+++ b/src/Controls/samples/Controls.Sample/Maui.Controls.Sample.csproj
@@ -8,6 +8,7 @@
     <AssemblyName>Maui.Controls.Sample</AssemblyName>
     <IsPackable>false</IsPackable>
     <NoWarn>$(NoWarn),CA1416</NoWarn>
+    <Nullable>enable</Nullable>
     <!-- Disable multi-RID builds to workaround a parallel build issue -->
     <RuntimeIdentifier Condition="$(TargetFramework.Contains('-maccatalyst'))">maccatalyst-x64</RuntimeIdentifier>
     <RuntimeIdentifier Condition="$(TargetFramework.Contains('-maccatalyst')) and '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'arm64'">maccatalyst-arm64</RuntimeIdentifier>

--- a/src/Controls/samples/Controls.Sample/MauiProgram.cs
+++ b/src/Controls/samples/Controls.Sample/MauiProgram.cs
@@ -97,7 +97,7 @@ namespace Maui.Controls.Sample
 			});
 
 			appBuilder.Configuration.AddInMemoryCollection(
-				new Dictionary<string, string>
+				new Dictionary<string, string?>
 					{
 						{"MyKey", "Dictionary MyKey Value"},
 						{":Title", "Dictionary_Title"},
@@ -260,7 +260,7 @@ namespace Maui.Controls.Sample
 						.OnTerminate((a) => LogEvent(nameof(TizenLifecycle.OnTerminate))));
 #endif
 
-					static bool LogEvent(string eventName, string type = null)
+					static bool LogEvent(string eventName, string? type = null)
 					{
 						Debug.WriteLine($"Lifecycle event: {eventName}{(type == null ? "" : $" ({type})")}");
 						return true;

--- a/src/Controls/samples/Controls.Sample/Models/ContextMenuItem.cs
+++ b/src/Controls/samples/Controls.Sample/Models/ContextMenuItem.cs
@@ -5,6 +5,6 @@
 		public ContextMenuItemType Type { get; set; }
 		public string Item1Text { get; set; } = "Item 1";
 		public string Item2Text { get; set; } = "Item 2";
-		public string Text { get; set; }
+		public string? Text { get; set; }
 	}
 }

--- a/src/Controls/samples/Controls.Sample/Models/RefreshItem.cs
+++ b/src/Controls/samples/Controls.Sample/Models/RefreshItem.cs
@@ -4,7 +4,7 @@ namespace Controls.Sample.Models
 {
 	public class RefreshItem
 	{
-		public string Name { get; set; }
-		public Color Color { get; set; }
+		public string? Name { get; set; }
+		public Color? Color { get; set; }
 	}
 }

--- a/src/Controls/samples/Controls.Sample/Models/SectionModel.cs
+++ b/src/Controls/samples/Controls.Sample/Models/SectionModel.cs
@@ -4,7 +4,7 @@ namespace Maui.Controls.Sample.Models
 {
 	public sealed class SectionModel
 	{
-		public SectionModel(Type type, string title, string description, object viewModel = null)
+		public SectionModel(Type type, string title, string description, object? viewModel = null)
 		{
 			Type = type;
 			Title = title;
@@ -18,6 +18,6 @@ namespace Maui.Controls.Sample.Models
 
 		public string Description { get; }
 
-		public object ViewModel { get; }
+		public object? ViewModel { get; }
 	}
 }

--- a/src/Controls/samples/Controls.Sample/Pages/AppShell.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/AppShell.xaml.cs
@@ -29,7 +29,7 @@ namespace Maui.Controls.Sample.Pages
 	public class PageSearchHandler : SearchHandler
 	{
 		public IList<Data> Pages { get; set; }
-		public Type SelectedItemNavigationTarget { get; set; }
+		public Type? SelectedItemNavigationTarget { get; set; }
 
 		public PageSearchHandler()
 		{
@@ -63,7 +63,7 @@ namespace Maui.Controls.Sample.Pages
 
 			var thing = (Data)item;
 
-			var result = Shell.Current.Handler.MauiContext.Services.GetService(thing.Type) ??
+			var result = Shell.Current.Handler!.MauiContext!.Services.GetService(thing.Type) ??
 				Activator.CreateInstance(thing.Type);
 
 			await Shell.Current.Navigation.PushAsync(result as Page);

--- a/src/Controls/samples/Controls.Sample/Pages/Base/BasePage.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Base/BasePage.cs
@@ -9,12 +9,12 @@ namespace Maui.Controls.Sample.Pages.Base
 {
 	public class BasePage : ContentPage
 	{
-		SectionModel _selectedItem;
+		SectionModel? _selectedItem;
 
 		public BasePage()
 		{
-			Application.Current.Resources.TryGetValue("LightBackgroundColor", out object lightBackgroundResource);
-			Application.Current.Resources.TryGetValue("DarkBackgroundColor", out object darkBackgroundResource);
+			Application.Current!.Resources.TryGetValue("LightBackgroundColor", out object lightBackgroundResource);
+			Application.Current!.Resources.TryGetValue("DarkBackgroundColor", out object darkBackgroundResource);
 
 			if (lightBackgroundResource is Color lightBackgroundColor && darkBackgroundResource is Color darkBackgroundColor)
 				this.SetAppThemeColor(BackgroundColorProperty, lightBackgroundColor, darkBackgroundColor);
@@ -57,7 +57,7 @@ namespace Maui.Controls.Sample.Pages.Base
 
 		public ICommand NavigateCommand { get; }
 
-		public SectionModel SelectedItem
+		public SectionModel? SelectedItem
 		{
 			get { return _selectedItem; }
 			set
@@ -69,7 +69,7 @@ namespace Maui.Controls.Sample.Pages.Base
 
 		Page PreparePage(SectionModel model)
 		{
-			var page = (Handler?.MauiContext?.Services?.GetService(model.Type) as Page) ?? (Page)Activator.CreateInstance(model.Type);
+			var page = (Handler?.MauiContext?.Services?.GetService(model.Type) as Page) ?? (Page)Activator.CreateInstance(model.Type)!;
 			page.Title = model.Title;
 
 			if (model.ViewModel != null)

--- a/src/Controls/samples/Controls.Sample/Pages/Blazor/CustomBlazorWebView.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Blazor/CustomBlazorWebView.cs
@@ -64,7 +64,7 @@ namespace Maui.Controls.Sample.Pages.Blazor
 				=> new InMemoryFileInfo(_fileContentsMap, Path.Combine(_contentRootDir, subpath));
 
 			public IChangeToken Watch(string filter)
-				=> null;
+				=> null!;
 
 			private sealed class InMemoryFileInfo : IFileInfo
 			{
@@ -76,7 +76,9 @@ namespace Maui.Controls.Sample.Pages.Blazor
 				{
 					_fileContentsMap = fileContentsMap;
 					_filePath = filePath;
-					Exists = fileContentsMap.TryGetValue(_filePath.Replace('\\', '/'), out _contents);
+					string? contents;
+					Exists = fileContentsMap.TryGetValue(_filePath.Replace('\\', '/'), out contents);
+					_contents = contents!;
 					Length = Exists ? _contents.Length : -1;
 
 					Name = Path.GetFileName(filePath);

--- a/src/Controls/samples/Controls.Sample/Pages/Compatibility/ListViewGalleries/ListViewRefresh.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Compatibility/ListViewGalleries/ListViewRefresh.cs
@@ -66,7 +66,7 @@ namespace Maui.Controls.Sample.Pages.ListViewGalleries
 			});
 
 			var lbl = new Label { Text = string.Format("Refreshing {0}", refreshingCount) };
-			lv.Refreshing += (object sender, EventArgs e) =>
+			lv.Refreshing += (object? sender, EventArgs e) =>
 			{
 				refreshingCount++;
 				lbl.Text = string.Format("Refreshing {0}", refreshingCount);
@@ -89,7 +89,7 @@ namespace Maui.Controls.Sample.Pages.ListViewGalleries
 
 		public class FooViewModel
 		{
-			List<Group<string>> _things;
+			List<Group<string>>? _things;
 			public List<Group<string>> Things
 			{
 				get
@@ -115,7 +115,7 @@ namespace Maui.Controls.Sample.Pages.ListViewGalleries
 				}
 			}
 
-			Command _refreshThingsCommand;
+			Command? _refreshThingsCommand;
 			public Command RefreshThingsCommand
 			{
 				get { return _refreshThingsCommand ?? (_refreshThingsCommand = new Command(BeginRefreshThings, () => _canExecute)); }
@@ -131,7 +131,7 @@ namespace Maui.Controls.Sample.Pages.ListViewGalleries
 		{
 			public Group(IEnumerable<T> seed) : base(seed) { }
 
-			public string Name
+			public string? Name
 			{
 				get;
 				set;

--- a/src/Controls/samples/Controls.Sample/Pages/Compatibility/TabbedPageGalleryMainPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Compatibility/TabbedPageGalleryMainPage.xaml.cs
@@ -14,12 +14,12 @@ namespace Maui.Controls.Sample.Pages
 			InitializeComponent();
 		}
 
-		TabbedPage _tabbedPage;
+		TabbedPage? _tabbedPage;
 		TabbedPage GetTabbedPage() => _tabbedPage ??= (TabbedPage)Parent;
 
 		void SetNewMainPage(Page page)
 		{
-			Application.Current.Windows[0].Page = page;
+			Application.Current!.Windows[0].Page = page;
 		}
 
 		void OnTabbedPageAsRoot(object sender, EventArgs e)
@@ -29,7 +29,7 @@ namespace Maui.Controls.Sample.Pages
 				{
 					Children =
 					{
-						Handler.MauiContext.Services.GetRequiredService<Page>(),
+						Handler!.MauiContext!.Services.GetRequiredService<Page>(),
 						new NavigationPage(new Pages.NavigationGallery()) { Title = "Navigation Gallery" }
 					}
 				};
@@ -43,14 +43,14 @@ namespace Maui.Controls.Sample.Pages
 			{
 				Children =
 				{
-					Handler.MauiContext.Services.GetRequiredService<Page>(),
+					Handler!.MauiContext!.Services.GetRequiredService<Page>(),
 					new NavigationPage(new Pages.NavigationGallery()) { Title = "Navigation Gallery" }
 				}
 			};
 
 			SetNewMainPage(bottomTabs);
 			AndroidSpecific.TabbedPage.SetToolbarPlacement(bottomTabs, AndroidSpecific.ToolbarPlacement.Bottom);
-			Application.Current.MainPage = bottomTabs;
+			Application.Current!.MainPage = bottomTabs;
 		}
 
 		void OnChangeTabIndex(object sender, EventArgs e)

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CarouselViewGalleries/CarouselCodeGallery.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CarouselViewGalleries/CarouselCodeGallery.cs
@@ -127,7 +127,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.CarouselViewGalleri
 			positionControl.UpdatePosition(1);
 		}
 
-		void CarouselViewScrolled(object sender, ItemsViewScrolledEventArgs e)
+		void CarouselViewScrolled(object? sender, ItemsViewScrolledEventArgs e)
 		{
 			_scrollInfoLabel.Text = $"First item: {e.FirstVisibleItemIndex}, Last item: {e.LastVisibleItemIndex}";
 

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CarouselViewGalleries/CarouselItemsGallery.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CarouselViewGalleries/CarouselItemsGallery.cs
@@ -109,7 +109,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.CarouselViewGalleri
 
 			changePositionButton.Clicked += (sender, e) =>
 			{
-				_viewModel.CarouselPosition = Random.Shared.Next(_viewModel.Items.Count);
+				_viewModel.CarouselPosition = Random.Shared.Next(_viewModel.Items!.Count);
 			};
 
 			var addItemButton = new Button
@@ -119,7 +119,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.CarouselViewGalleri
 
 			addItemButton.Clicked += (sender, e) =>
 			{
-				_viewModel.Items.Add(new CarouselData
+				_viewModel.Items!.Add(new CarouselData
 				{
 					Color = Colors.Red,
 					Name = $"{_viewModel.Items.Count + 1}"
@@ -134,10 +134,10 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.CarouselViewGalleri
 
 			removeItemButton.Clicked += (sender, e) =>
 			{
-				if (_viewModel.Items.Any())
-					_viewModel.Items.RemoveAt(_viewModel.Items.Count - 1);
+				if (_viewModel.Items!.Any())
+					_viewModel.Items!.RemoveAt(_viewModel.Items.Count - 1);
 
-				if (_viewModel.Items.Count > 0)
+				if (_viewModel.Items!.Count > 0)
 					_viewModel.CarouselPosition = _viewModel.Items.Count - 1;
 			};
 
@@ -148,7 +148,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.CarouselViewGalleri
 
 			clearItemsButton.Clicked += (sender, e) =>
 			{
-				_viewModel.Items.Clear();
+				_viewModel.Items!.Clear();
 			};
 
 			var lbl = new Label
@@ -224,7 +224,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.CarouselViewGalleri
 	[Preserve(AllMembers = true)]
 	public class CarouselItemsGalleryViewModel : BindableObject
 	{
-		ObservableCollection<CarouselData> _items;
+		ObservableCollection<CarouselData>? _items;
 		int _carouselPosition;
 
 		public CarouselItemsGalleryViewModel(bool empty, bool async)
@@ -268,7 +268,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.CarouselViewGalleri
 			};
 		}
 
-		public ObservableCollection<CarouselData> Items
+		public ObservableCollection<CarouselData>? Items
 		{
 			get { return _items; }
 			set

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CarouselViewGalleries/CarouselXamlGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CarouselViewGalleries/CarouselXamlGallery.xaml.cs
@@ -32,7 +32,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.CarouselViewGalleri
 		bool _isLoop;
 		int _count;
 		int _position;
-		ObservableCollection<CarouselItem> _items;
+		ObservableCollection<CarouselItem>? _items;
 		CarouselXamlSampleType _type;
 		public CarouselViewModel(CarouselXamlSampleType type, bool loop, int initialItems = 5, int startCurrentItem = -1)
 		{
@@ -53,7 +53,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.CarouselViewGalleri
 				}
 			}
 
-			WeakReferenceMessenger.Default.Register<ExampleTemplateCarousel, string>(this, "remove", (_, obj) => Items.Remove(obj.BindingContext as CarouselItem));
+			WeakReferenceMessenger.Default.Register<ExampleTemplateCarousel, string>(this, "remove", (_, obj) => Items!.Remove((obj.BindingContext as CarouselItem)!));
 
 			Items = new ObservableCollection<CarouselItem>(items);
 			Count = Items.Count - 1;
@@ -80,14 +80,14 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.CarouselViewGalleri
 			set { SetProperty(ref _position, value); }
 		}
 
-		public ObservableCollection<CarouselItem> Items
+		public ObservableCollection<CarouselItem>? Items
 		{
 			get { return _items; }
 			set { SetProperty(ref _items, value); }
 		}
 
-		CarouselItem _selected;
-		public CarouselItem Selected
+		CarouselItem? _selected;
+		public CarouselItem? Selected
 		{
 			get { return _selected; }
 			set { SetProperty(ref _selected, value); }
@@ -95,13 +95,13 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.CarouselViewGalleri
 
 		public ICommand RemoveCommand => new Command(() =>
 		{
-			Items.Remove(Selected);
+			Items!.Remove(Selected!);
 			Count = Items.Count - 1;
 		});
 
 		public ICommand PreviousCommand => new Command(() =>
 		{
-			var indexCurrent = Items.IndexOf(Selected);
+			var indexCurrent = Items!.IndexOf(Selected!);
 			if (indexCurrent > 0)
 			{
 				var newItem = Items[indexCurrent - 1];
@@ -116,7 +116,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.CarouselViewGalleri
 
 		public ICommand NextCommand => new Command(() =>
 		{
-			var indexCurrent = Items.IndexOf(Selected);
+			var indexCurrent = Items!.IndexOf(Selected!);
 			if (indexCurrent < Items.Count - 1)
 			{
 				var newItem = Items[indexCurrent + 1];
@@ -133,7 +133,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.CarouselViewGalleri
 	[Preserve(AllMembers = true)]
 	internal class CarouselItem
 	{
-		public CarouselItem(int index, string image = null)
+		public CarouselItem(int index, string? image = null)
 		{
 			if (!string.IsNullOrEmpty(image))
 				FeaturedImage = image;
@@ -145,18 +145,18 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.CarouselViewGalleri
 
 		public string Image { get; set; }
 
-		public string FeaturedImage { get; set; }
+		public string? FeaturedImage { get; set; }
 	}
 
 	[Preserve(AllMembers = true)]
 	public class ViewModelBase2 : INotifyPropertyChanged
 	{
-		public event PropertyChangedEventHandler PropertyChanged;
+		public event PropertyChangedEventHandler? PropertyChanged;
 
-		protected virtual ViewModelBase2 SetProperty<T>(ref T field, T value, [CallerMemberName] string propertyName = null)
+		protected virtual ViewModelBase2 SetProperty<T>(ref T field, T value, [CallerMemberName] string propertyName = "")
 		{
 			field = value;
-			PropertyChangedEventHandler handler = PropertyChanged;
+			var handler = PropertyChanged;
 			if (handler != null)
 				handler(this, new PropertyChangedEventArgs(propertyName));
 			return this;

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CarouselViewGalleries/CollectionCarouselViewGallery.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CarouselViewGalleries/CollectionCarouselViewGallery.cs
@@ -152,14 +152,14 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.CarouselViewGalleri
 	public class CollectionCarouselViewGalleryViewModel : BindableObject
 	{
 		readonly Random _random;
-		ObservableCollection<CarouselData> _items;
+		ObservableCollection<CarouselData>? _items;
 
 		public CollectionCarouselViewGalleryViewModel()
 		{
 			_random = new Random();
 		}
 
-		public ObservableCollection<CarouselData> Items
+		public ObservableCollection<CarouselData>? Items
 		{
 			get { return _items; }
 			set

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CarouselViewGalleries/EmptyCarouselGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CarouselViewGalleries/EmptyCarouselGallery.xaml.cs
@@ -22,14 +22,14 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.CarouselViewGalleri
 	[Preserve(AllMembers = true)]
 	public class EmptyCarouselGalleryViewModel : BindableObject
 	{
-		ObservableCollection<CarouselData> _items;
+		ObservableCollection<CarouselData>? _items;
 
 		public EmptyCarouselGalleryViewModel()
 		{
 			Items = new ObservableCollection<CarouselData>();
 		}
 
-		public ObservableCollection<CarouselData> Items
+		public ObservableCollection<CarouselData>? Items
 		{
 			get { return _items; }
 			set
@@ -66,7 +66,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.CarouselViewGalleri
 			{
 				for (int n = 0; n < 5; n++)
 				{
-					Items.Add(new CarouselData
+					Items!.Add(new CarouselData
 					{
 						Color = Color.FromRgb(random.Next(0, 255), random.Next(0, 255), random.Next(0, 255)),
 						Name = $"{n + 1}"

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CarouselViewGalleries/IndicatorCodeGallery.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CarouselViewGalleries/IndicatorCodeGallery.cs
@@ -62,7 +62,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.CarouselViewGalleri
 			generator.GenerateItems();
 
 			_carouselView.PropertyChanged += CarouselViewPropertyChanged;
-			(_carouselView.ItemsSource as ObservableCollection<CollectionViewGalleryTestItem>).CollectionChanged += IndicatorCodeGalleryCollectionChanged;
+			(_carouselView.ItemsSource as ObservableCollection<CollectionViewGalleryTestItem>)!.CollectionChanged += IndicatorCodeGalleryCollectionChanged;
 
 			var indicatorView = new IndicatorView
 			{
@@ -205,7 +205,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.CarouselViewGalleri
 				Padding = new Thickness(5),
 				Command = new Command(() =>
 				{
-					var items = (_carouselView.ItemsSource as ObservableCollection<CollectionViewGalleryTestItem>);
+					var items = (_carouselView.ItemsSource as ObservableCollection<CollectionViewGalleryTestItem>)!;
 					items.Remove(items[0]);
 				})
 			};
@@ -238,7 +238,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.CarouselViewGalleri
 					_carouselView.Position++;
 				}, () =>
 				{
-					var items = (_carouselView.ItemsSource as ObservableCollection<CollectionViewGalleryTestItem>);
+					var items = (_carouselView.ItemsSource as ObservableCollection<CollectionViewGalleryTestItem>)!;
 					return _carouselView.Position < items.Count - 1;
 				})
 			};
@@ -252,7 +252,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.CarouselViewGalleri
 				Padding = new Thickness(5),
 				Command = new Command(() =>
 				{
-					var items = (_carouselView.ItemsSource as ObservableCollection<CollectionViewGalleryTestItem>);
+					var items = (_carouselView.ItemsSource as ObservableCollection<CollectionViewGalleryTestItem>)!;
 					var indexToRemove = items.Count - 1;
 					items.Remove(items[indexToRemove]);
 				})
@@ -268,12 +268,12 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.CarouselViewGalleri
 			Content = layout;
 		}
 
-		void IndicatorCodeGalleryCollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+		void IndicatorCodeGalleryCollectionChanged(object? sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
 		{
 			UpdateButtons();
 		}
 
-		void CarouselViewPropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+		void CarouselViewPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
 		{
 			UpdateButtons();
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/AdaptiveCollectionView.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/AdaptiveCollectionView.xaml.cs
@@ -25,7 +25,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries
 			SizeChanged -= OnAdaptiveCollectionViewSizeChanged;
 		}
 
-		void OnAdaptiveCollectionViewSizeChanged(object sender, System.EventArgs e)
+		void OnAdaptiveCollectionViewSizeChanged(object? sender, System.EventArgs e)
 		{
 			CollectionView.ItemsLayout = Width > 600
 				? new GridItemsLayout(3, ItemsLayoutOrientation.Vertical)

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/CarouselData.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/CarouselData.cs
@@ -7,7 +7,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries
 {
 	public class CarouselData
 	{
-		public Color Color { get; set; }
-		public string Name { get; set; }
+		public Color? Color { get; set; }
+		public string? Name { get; set; }
 	}
 }

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/CollectionModifier.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/CollectionModifier.cs
@@ -33,7 +33,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries
 			Content = layout;
 		}
 
-		void ButtonOnClicked(object sender, EventArgs e)
+		void ButtonOnClicked(object? sender, EventArgs e)
 		{
 			OnButtonClicked();
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/CollectionViewGalleryTestItem.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/CollectionViewGalleryTestItem.cs
@@ -10,11 +10,11 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries
 	[Preserve(AllMembers = true)]
 	public class CollectionViewGalleryTestItem : INotifyPropertyChanged
 	{
-		string _caption;
+		string? _caption;
 
 		public DateTime Date { get; set; }
 
-		public string Caption
+		public string? Caption
 		{
 			get => _caption;
 			set
@@ -51,14 +51,14 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries
 			});
 		}
 
-		public event PropertyChangedEventHandler PropertyChanged;
+		public event PropertyChangedEventHandler? PropertyChanged;
 
 		public override string ToString()
 		{
 			return $"Item: {Index}";
 		}
 
-		protected void OnPropertyChanged([CallerMemberName] string propertyName = null)
+		protected void OnPropertyChanged([CallerMemberName] string propertyName = "")
 		{
 			PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/DataTemplateSelectorGalleries/VariedSizeDataTemplateSelectorGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/DataTemplateSelectorGalleries/VariedSizeDataTemplateSelectorGallery.xaml.cs
@@ -80,7 +80,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.DataTemplateSelecto
 			Items.Add(CreateDrink());
 		}
 
-		void SetValue<T>(ref T backingField, in T value, [CallerMemberName] string callerName = null)
+		void SetValue<T>(ref T backingField, in T value, [CallerMemberName] string callerName = "")
 		{
 			if (Equals(backingField, value))
 				return;
@@ -134,9 +134,9 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.DataTemplateSelecto
 
 	class DrinkTemplateSelector : DataTemplateSelector
 	{
-		public DataTemplate CoffeeTemplate { get; set; }
-		public DataTemplate MilkTemplate { get; set; }
-		public DataTemplate LatteTemplate { get; set; }
+		public DataTemplate CoffeeTemplate { get; set; } = default!;
+		public DataTemplate MilkTemplate { get; set; } = default!;
+		public DataTemplate LatteTemplate { get; set; } = default!;
 
 		protected override DataTemplate OnSelectTemplate(object item, BindableObject container)
 		{

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/DataTemplateSelectorGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/DataTemplateSelectorGallery.xaml.cs
@@ -42,31 +42,31 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries
 
 	public class WeekendSelector : DataTemplateSelector
 	{
-		public DataTemplate FridayTemplate { get; set; }
-		public DataTemplate DefaultTemplate { get; set; }
+		public DataTemplate? FridayTemplate { get; set; }
+		public DataTemplate? DefaultTemplate { get; set; }
 
 		protected override DataTemplate OnSelectTemplate(object item, BindableObject container)
 		{
 			var dow = ((CollectionViewGalleryTestItem)item).Date.DayOfWeek;
 
 			return dow == DayOfWeek.Saturday || dow == DayOfWeek.Sunday
-				? FridayTemplate
-				: DefaultTemplate;
+				? FridayTemplate!
+				: DefaultTemplate!;
 		}
 	}
 
 	public class SearchTermSelector : DataTemplateSelector
 	{
-		public DataTemplate DefaultTemplate { get; set; }
-		public DataTemplate SymbolsTemplate { get; set; }
+		public DataTemplate? DefaultTemplate { get; set; }
+		public DataTemplate? SymbolsTemplate { get; set; }
 
 		protected override DataTemplate OnSelectTemplate(object item, BindableObject container)
 		{
 			var search = ((string)item);
 
 			return search.Any(c => !char.IsLetter(c))
-				? SymbolsTemplate
-				: DefaultTemplate;
+				? SymbolsTemplate!
+				: DefaultTemplate!;
 		}
 	}
 }

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/DemoFilteredItemSource.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/DemoFilteredItemSource.cs
@@ -12,7 +12,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries
 
 		public ObservableCollection<CollectionViewGalleryTestItem> Items { get; }
 
-		public DemoFilteredItemSource(int count = 50, Func<string, CollectionViewGalleryTestItem, bool> filter = null)
+		public DemoFilteredItemSource(int count = 50, Func<string, CollectionViewGalleryTestItem, bool>? filter = null)
 		{
 			_source = new List<CollectionViewGalleryTestItem>();
 
@@ -66,7 +66,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries
 		bool ItemMatches(string filter, CollectionViewGalleryTestItem item)
 		{
 			filter = filter ?? "";
-			return item.Caption.Contains(filter, StringComparison.OrdinalIgnoreCase);
+			return item.Caption!.Contains(filter, StringComparison.OrdinalIgnoreCase);
 		}
 	}
 }

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/EmptyViewGalleries/EmptyViewGalleryFilterInfo.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/EmptyViewGalleries/EmptyViewGalleryFilterInfo.cs
@@ -7,9 +7,9 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.EmptyViewGalleries
 	[Preserve(AllMembers = true)]
 	public class EmptyViewGalleryFilterInfo : INotifyPropertyChanged
 	{
-		string _filter;
+		string? _filter;
 
-		public string Filter
+		public string? Filter
 		{
 			get => _filter;
 			set
@@ -19,9 +19,9 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.EmptyViewGalleries
 			}
 		}
 
-		public event PropertyChangedEventHandler PropertyChanged;
+		public event PropertyChangedEventHandler? PropertyChanged;
 
-		void OnPropertyChanged([CallerMemberName] string propertyName = null)
+		void OnPropertyChanged([CallerMemberName] string propertyName = "")
 		{
 			PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/EmptyViewGalleries/EmptyViewSwapGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/EmptyViewGalleries/EmptyViewSwapGallery.xaml.cs
@@ -29,12 +29,12 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.EmptyViewGalleries
 			SwitchEmptyView();
 		}
 
-		private void SearchBarTextChanged(object sender, TextChangedEventArgs e)
+		private void SearchBarTextChanged(object? sender, TextChangedEventArgs e)
 		{
 			_demoFilteredItemSource.FilterItems(SearchBar.Text);
 		}
 
-		private void EmptyViewSwitchToggled(object sender, ToggledEventArgs e)
+		private void EmptyViewSwitchToggled(object? sender, ToggledEventArgs e)
 		{
 			SwitchEmptyView();
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/EnumSelector.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/EnumSelector.cs
@@ -40,7 +40,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries
 			Content = layout;
 		}
 
-		void PickerOnSelectedIndexChanged(object sender, EventArgs e)
+		void PickerOnSelectedIndexChanged(object? sender, EventArgs e)
 		{
 			if (Enum.TryParse(_picker.SelectedItem.ToString(), true, out T enumValue))
 			{

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/ExampleTemplates.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/ExampleTemplates.cs
@@ -570,14 +570,14 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries
 				_highValue = highValue;
 			}
 
-			public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+			public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
 			{
-				var index = (int)value;
+				var index = (int)value!;
 
 				return index < _cutoff ? _lowValue : (object)_highValue;
 			}
 
-			public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => throw new NotImplementedException();
+			public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => throw new NotImplementedException();
 		}
 
 		class IndexRequestRandomConverter : IValueConverter
@@ -594,9 +594,9 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries
 				_random = new Random(DateTime.UtcNow.Millisecond);
 			}
 
-			public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+			public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
 			{
-				var index = (int)value;
+				var index = (int)value!;
 				if (!_dictionary.ContainsKey(index))
 				{
 					_dictionary[index] = _random.Next(_lowValue, _highValue);
@@ -605,20 +605,20 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries
 				return _dictionary[index];
 			}
 
-			public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => throw new NotImplementedException();
+			public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => throw new NotImplementedException();
 		}
 
 		class IndexColorConverter : IValueConverter
 		{
 			Color[] _colors = new Color[] { Colors.Red, Colors.Green, Colors.Blue, Colors.Orange, Colors.BlanchedAlmond };
 
-			public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+			public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
 			{
-				var index = (int)value;
+				var index = (int)value!;
 				return _colors[index % _colors.Length];
 			}
 
-			public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => throw new NotImplementedException();
+			public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => throw new NotImplementedException();
 		}
 	}
 }

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/FilterCollectionView.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/FilterCollectionView.xaml.cs
@@ -24,7 +24,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries
 			UpdateEmptyView();
 		}
 
-		void UseEmptyViewOnToggled(object sender, ToggledEventArgs e)
+		void UseEmptyViewOnToggled(object? sender, ToggledEventArgs e)
 		{
 			UpdateEmptyView();
 		}
@@ -49,7 +49,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries
 			}
 		}
 
-		void SearchBarOnTextChanged(object sender, TextChangedEventArgs e)
+		void SearchBarOnTextChanged(object? sender, TextChangedEventArgs e)
 		{
 			_demoFilteredItemSource.FilterItems(e.NewTextValue);
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/GroupingGalleries/ObservableGrouping.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/GroupingGalleries/ObservableGrouping.cs
@@ -55,7 +55,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.GroupingGalleries
 			{
 				var selectedMember = collectionView.SelectedItem as Member;
 				var team = FindTeam(itemsSource, selectedMember);
-				team?.Remove(selectedMember);
+				team?.Remove(selectedMember!);
 			};
 
 			var adder = new Button { Text = "Add After Selected", AutomationId = "AddItem", Style = buttonStyle };
@@ -69,7 +69,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.GroupingGalleries
 					return;
 				}
 
-				team.Insert(team.IndexOf(selectedMember) + 1, new Member("Spider-Man"));
+				team.Insert(team.IndexOf(selectedMember!) + 1, new Member("Spider-Man"));
 			};
 
 			AddStuffToGridRow(layout, 0, remover, adder);
@@ -85,8 +85,8 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.GroupingGalleries
 					return;
 				}
 
-				team.Insert(team.IndexOf(selectedMember) + 1, new Member("Spider-Man"));
-				team.Remove(selectedMember);
+				team.Insert(team.IndexOf(selectedMember!) + 1, new Member("Spider-Man"));
+				team.Remove(selectedMember!);
 			};
 
 			var mover = new Button
@@ -105,8 +105,8 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.GroupingGalleries
 					return;
 				}
 
-				team.Remove(selectedMember);
-				itemsSource[0].Add(selectedMember);
+				team.Remove(selectedMember!);
+				itemsSource[0].Add(selectedMember!);
 			};
 
 			AddStuffToGridRow(layout, 1, replacer, mover);
@@ -120,7 +120,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.GroupingGalleries
 			groupRemover.Clicked += (obj, args) =>
 			{
 				itemsSource?.Remove(itemsSource[0]);
-				if (itemsSource.Count > 0)
+				if (itemsSource!.Count > 0)
 				{
 					groupRemover.Text = $"Remove {itemsSource[0].Name}";
 				}
@@ -242,7 +242,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.GroupingGalleries
 			});
 		}
 
-		ObservableTeam FindTeam(ObservableSuperTeams teams, Member member)
+		ObservableTeam? FindTeam(ObservableSuperTeams teams, Member? member)
 		{
 			if (member == null)
 			{

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/HeaderFooterGalleries/HeaderFooterGrid.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/HeaderFooterGalleries/HeaderFooterGrid.xaml.cs
@@ -9,8 +9,8 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.HeaderFooterGalleri
 	{
 		readonly DemoFilteredItemSource _demoFilteredItemSource = new DemoFilteredItemSource(10);
 
-		object header = null;
-		object footer = null;
+		object? header;
+		object? footer;
 
 		public HeaderFooterGrid()
 		{

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/HeaderFooterGalleries/HeaderFooterGridHorizontal.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/HeaderFooterGalleries/HeaderFooterGridHorizontal.xaml.cs
@@ -13,8 +13,8 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.HeaderFooterGalleri
 	public partial class HeaderFooterGridHorizontal : ContentPage
 	{
 		readonly DemoFilteredItemSource _demoFilteredItemSource = new DemoFilteredItemSource(10);
-		object header;
-		object footer;
+		object? header;
+		object? footer;
 
 		public HeaderFooterGridHorizontal()
 		{

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/HeaderFooterGalleries/HeaderFooterTemplate.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/HeaderFooterGalleries/HeaderFooterTemplate.xaml.cs
@@ -27,14 +27,14 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.HeaderFooterGalleri
 			readonly DemoFilteredItemSource _demoFilteredItemSource = new DemoFilteredItemSource(3);
 			DateTime _currentTime;
 
-			public event PropertyChangedEventHandler PropertyChanged;
+			public event PropertyChangedEventHandler? PropertyChanged;
 
 			public HeaderFooterDemoModel()
 			{
 				CurrentTime = DateTime.Now;
 			}
 
-			void OnPropertyChanged([CallerMemberName] string property = null)
+			void OnPropertyChanged([CallerMemberName] string property = "")
 			{
 				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(property));
 			}

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/HeaderFooterGalleries/HeaderFooterView.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/HeaderFooterGalleries/HeaderFooterView.xaml.cs
@@ -22,7 +22,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.HeaderFooterGalleri
 
 	internal class HeaderFooterViewModel : DemoFilteredItemSource
 	{
-		public HeaderFooterViewModel(int count = 50, Func<string, CollectionViewGalleryTestItem, bool> filter = null) : base(count, filter)
+		public HeaderFooterViewModel(int count = 50, Func<string, CollectionViewGalleryTestItem, bool>? filter = null) : base(count, filter)
 		{
 		}
 

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/ItemSizeGalleries/ChatExample.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/ItemSizeGalleries/ChatExample.xaml.cs
@@ -22,19 +22,19 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.ItemSizeGalleries
 			Lots.Clicked += LotsOfMessages;
 		}
 
-		void AppendRandomChatMessage(object sender, EventArgs e)
+		void AppendRandomChatMessage(object? sender, EventArgs e)
 		{
 			_vm.ChatMessages.Add(GenerateRandomMessage());
 		}
 
-		void LotsOfMessages(object sender, EventArgs e)
+		void LotsOfMessages(object? sender, EventArgs e)
 		{
 			var newVm = new ChatExampleViewModel(GenerateMessages(1000));
 			_vm = newVm;
 			BindingContext = _vm;
 		}
 
-		void ClearMessages(object sender, EventArgs e)
+		void ClearMessages(object? sender, EventArgs e)
 		{
 			_vm.ChatMessages.Clear();
 		}
@@ -95,8 +95,8 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.ItemSizeGalleries
 
 	class ChatTemplateSelector : DataTemplateSelector
 	{
-		public DataTemplate LocalTemplate { get; set; }
-		public DataTemplate RemoteTemplate { get; set; }
+		public DataTemplate? LocalTemplate { get; set; }
+		public DataTemplate? RemoteTemplate { get; set; }
 
 		protected override DataTemplate OnSelectTemplate(object item, BindableObject container)
 		{
@@ -104,10 +104,10 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.ItemSizeGalleries
 			{
 				if (message.IsLocal)
 				{
-					return LocalTemplate;
+					return LocalTemplate!;
 				}
 
-				return RemoteTemplate;
+				return RemoteTemplate!;
 			}
 
 			throw new ArgumentOutOfRangeException();

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/ItemsSourceGenerator.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/ItemsSourceGenerator.cs
@@ -20,13 +20,13 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries
 
 	internal class ItemsSourceGenerator : ContentView
 	{
-		public event EventHandler<NotifyCollectionChangedEventArgs> CollectionChanged;
+		public event EventHandler<NotifyCollectionChangedEventArgs>? CollectionChanged;
 		readonly ItemsView _cv;
 		private ItemsSourceType _itemsSourceType;
 		readonly Entry _entry;
 		int _count = 0;
 
-		CarouselView carousel => _cv as CarouselView;
+		CarouselView? carousel => _cv as CarouselView;
 
 		public int Count => _count;
 
@@ -57,7 +57,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries
 			button.Clicked += GenerateItems;
 			WeakReferenceMessenger.Default.Register<ExampleTemplateCarousel, string>(this, "remove", (_, obj) =>
 			{
-				(cv.ItemsSource as ObservableCollection<CollectionViewGalleryTestItem>).Remove(obj.BindingContext as CollectionViewGalleryTestItem);
+				(cv.ItemsSource as ObservableCollection<CollectionViewGalleryTestItem>)!.Remove((obj.BindingContext as CollectionViewGalleryTestItem)!);
 			});
 
 			Content = layout;
@@ -114,7 +114,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries
 			}
 		}
 
-		ObservableCollection<CollectionViewGalleryTestItem> _obsCollection;
+		ObservableCollection<CollectionViewGalleryTestItem>? _obsCollection;
 		void GenerateObservableCollection()
 		{
 			if (int.TryParse(_entry.Text, out int count))
@@ -180,7 +180,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries
 		}
 
 
-		void GenerateItems(object sender, EventArgs e)
+		void GenerateItems(object? sender, EventArgs e)
 		{
 			GenerateItems();
 

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/MultiTestObservableCollection.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/MultiTestObservableCollection.cs
@@ -14,7 +14,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries
 		// This is a testing class which implements INotifyCollectionChanged and, unlike the regular
 		// ObservableCollection, will actually fire Add and Remove with multiple items at once
 
-		public event NotifyCollectionChangedEventHandler CollectionChanged;
+		public event NotifyCollectionChangedEventHandler? CollectionChanged;
 
 		public void TestAddWithList(IEnumerable<T> newItems, int insertAt)
 		{

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/ScrollModeGalleries/ItemsUpdatingScrollModeGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/ScrollModeGalleries/ItemsUpdatingScrollModeGallery.xaml.cs
@@ -8,8 +8,8 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.ScrollModeGalleries
 {
 	public class ItemsUpdatingScrollModeItem
 	{
-		public string Text1 { get; set; }
-		public string Text2 { get; set; }
+		public string? Text1 { get; set; }
+		public string? Text2 { get; set; }
 	}
 
 	public class ItemsUpdatingScrollModeViewModel : BindableObject
@@ -50,7 +50,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.ScrollModeGalleries
 
 		void OnItemsUpdatingScrollModeChanged(object sender, EventArgs e)
 		{
-			CollectionView.ItemsUpdatingScrollMode = (ItemsUpdatingScrollMode)(sender as EnumPicker).SelectedItem;
+			CollectionView.ItemsUpdatingScrollMode = (ItemsUpdatingScrollMode)(sender! as EnumPicker)!.SelectedItem;
 		}
 	}
 }

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/ScrollModeGalleries/ScrollModeTestGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/ScrollModeGalleries/ScrollModeTestGallery.xaml.cs
@@ -10,7 +10,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.ScrollModeGalleries
 		readonly DemoFilteredItemSource _demoFilteredItemSource = new DemoFilteredItemSource(20);
 		CollectionView _collectionView;
 
-		public ScrollModeTestGallery(IItemsLayout itemsLayout = null, Func<DataTemplate> dataTemplate = null, Func<CollectionView> createCollectionView = null)
+		public ScrollModeTestGallery(IItemsLayout? itemsLayout = null, Func<DataTemplate>? dataTemplate = null, Func<CollectionView>? createCollectionView = null)
 		{
 			InitializeComponent();
 

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/ScrollToCodeGallery.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/ScrollToCodeGallery.cs
@@ -6,7 +6,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries
 {
 	internal class ScrollToCodeGallery : ContentPage
 	{
-		public ScrollToCodeGallery(IItemsLayout itemsLayout, ScrollToMode mode = ScrollToMode.Position, Func<DataTemplate> dataTemplate = null, Func<CollectionView> createCollectionView = null)
+		public ScrollToCodeGallery(IItemsLayout itemsLayout, ScrollToMode mode = ScrollToMode.Position, Func<DataTemplate>? dataTemplate = null, Func<CollectionView>? createCollectionView = null)
 		{
 			createCollectionView = createCollectionView ?? (() => new CollectionView());
 

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/ScrollToGalleries/ScrollToGroup.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/ScrollToGalleries/ScrollToGroup.xaml.cs
@@ -20,7 +20,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.ScrollToGalleries
 			ScrollToItem.Clicked += ScrollToItemClicked;
 		}
 
-		void ScrollToItemClicked(object sender, EventArgs e)
+		void ScrollToItemClicked(object? sender, EventArgs e)
 		{
 			var groupName = GroupName.Text;
 			var itemName = ItemName.Text;
@@ -37,7 +37,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.ScrollToGalleries
 			CollectionView.ScrollTo(member, team);
 		}
 
-		void ScrollToClicked(object sender, EventArgs e)
+		void ScrollToClicked(object? sender, EventArgs e)
 		{
 			var groupIndex = int.Parse(GroupIndex.Text);
 			var itemIndex = int.Parse(ItemIndex.Text);

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/ScrollToIndexControl.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/ScrollToIndexControl.cs
@@ -104,7 +104,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries
 			}
 		}
 
-		void ScrollTo(object sender, EventArgs e)
+		void ScrollTo(object? sender, EventArgs e)
 		{
 			ScrollTo();
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/ScrollToItemControl.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/ScrollToItemControl.cs
@@ -28,7 +28,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries
 						items.Add(item);
 					}
 
-					_picker.ItemsSource = items;
+					_picker!.ItemsSource = items;
 				}
 			};
 
@@ -81,7 +81,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries
 			}
 		}
 
-		void ScrollTo(object sender, EventArgs e)
+		void ScrollTo(object? sender, EventArgs e)
 		{
 			ScrollTo();
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/SelectionGalleries/BoundSelectionModel.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/SelectionGalleries/BoundSelectionModel.cs
@@ -9,11 +9,11 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.SelectionGalleries
 	[Preserve(AllMembers = true)]
 	internal class BoundSelectionModel : INotifyPropertyChanged
 	{
-		private CollectionViewGalleryTestItem _selectedItem;
-		private ObservableCollection<CollectionViewGalleryTestItem> _items;
-		private ObservableCollection<object> _selectedItems;
+		private CollectionViewGalleryTestItem? _selectedItem;
+		private ObservableCollection<CollectionViewGalleryTestItem>? _items;
+		private ObservableCollection<object>? _selectedItems;
 
-		public event PropertyChangedEventHandler PropertyChanged;
+		public event PropertyChangedEventHandler? PropertyChanged;
 
 		public BoundSelectionModel()
 		{
@@ -32,17 +32,17 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.SelectionGalleries
 			};
 		}
 
-		private void SelectedItemsCollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+		private void SelectedItemsCollectionChanged(object? sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
 		{
 			OnPropertyChanged(nameof(SelectedItemsText));
 		}
 
-		void OnPropertyChanged([CallerMemberName] string propertyName = null)
+		void OnPropertyChanged([CallerMemberName] string propertyName = "")
 		{
 			PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
 		}
 
-		public CollectionViewGalleryTestItem SelectedItem
+		public CollectionViewGalleryTestItem? SelectedItem
 		{
 			get => _selectedItem;
 			set
@@ -52,7 +52,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.SelectionGalleries
 			}
 		}
 
-		public ObservableCollection<object> SelectedItems
+		public ObservableCollection<object>? SelectedItems
 		{
 			get => _selectedItems;
 			set
@@ -64,19 +64,19 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.SelectionGalleries
 
 				_selectedItems = value;
 
-				_selectedItems.CollectionChanged += SelectedItemsCollectionChanged;
+				_selectedItems!.CollectionChanged += SelectedItemsCollectionChanged;
 
 				OnPropertyChanged();
 				OnPropertyChanged(nameof(SelectedItemsText));
 			}
 		}
 
-		public ObservableCollection<CollectionViewGalleryTestItem> Items
+		public ObservableCollection<CollectionViewGalleryTestItem>? Items
 		{
 			get => _items;
 			set { _items = value; OnPropertyChanged(); }
 		}
 
-		public string SelectedItemsText => SelectedItems.ToCommaSeparatedList();
+		public string SelectedItemsText => SelectedItems!.ToCommaSeparatedList();
 	}
 }

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/SelectionGalleries/FilterSelection.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/SelectionGalleries/FilterSelection.xaml.cs
@@ -23,7 +23,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.SelectionGalleries
 			ResetButton.Clicked += ResetButtonClicked;
 		}
 
-		void ResetButtonClicked(object sender, EventArgs e)
+		void ResetButtonClicked(object? sender, EventArgs e)
 		{
 			_demoFilteredItemSource = new DemoFilteredItemSource(new Random().Next(3, 50));
 			CollectionView.ItemsSource = _demoFilteredItemSource.Items;

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/SelectionGalleries/MultipleBoundSelection.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/SelectionGalleries/MultipleBoundSelection.xaml.cs
@@ -19,25 +19,25 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.SelectionGalleries
 
 		private void ClearAndAdd(object sender, EventArgs e)
 		{
-			_vm.SelectedItems.Clear();
-			_vm.SelectedItems.Add(_vm.Items[1]);
-			_vm.SelectedItems.Add(_vm.Items[2]);
+			_vm.SelectedItems!.Clear();
+			_vm.SelectedItems!.Add(_vm.Items![1]);
+			_vm.SelectedItems!.Add(_vm.Items![2]);
 		}
 
 		private void ResetClicked(object sender, EventArgs e)
 		{
 			_vm.SelectedItems = new ObservableCollection<object>
 			{
-				_vm.Items[1],
-				_vm.Items[2]
+				_vm.Items![1],
+				_vm.Items![2]
 			};
 		}
 
 		private void DirectUpdateClicked(object sender, EventArgs e)
 		{
 			CollectionView.SelectedItems.Clear();
-			CollectionView.SelectedItems.Add(_vm.Items[0]);
-			CollectionView.SelectedItems.Add(_vm.Items[3]);
+			CollectionView.SelectedItems.Add(_vm.Items![0]);
+			CollectionView.SelectedItems.Add(_vm.Items![3]);
 		}
 	}
 }

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/SelectionGalleries/SelectionChangedCommandParameter.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/SelectionGalleries/SelectionChangedCommandParameter.xaml.cs
@@ -26,23 +26,23 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.SelectionGalleries
 	[Preserve(AllMembers = true)]
 	class Item
 	{
-		public string Id { get; set; }
-		public string Text { get; set; }
-		public string Description { get; set; }
+		public string? Id { get; set; }
+		public string? Text { get; set; }
+		public string? Description { get; set; }
 	}
 
 	[Preserve(AllMembers = true)]
 	class ItemsViewModel : INotifyPropertyChanged
 	{
 		public ObservableCollection<Item> Items { get; set; }
-		public Command LoadItemsCommand { get; set; }
+		public Command? LoadItemsCommand { get; set; }
 
-		Item _selectedItem;
-		readonly Label _result;
+		Item? _selectedItem;
+		readonly Label _result = default!;
 
-		public event PropertyChangedEventHandler PropertyChanged;
+		public event PropertyChangedEventHandler? PropertyChanged;
 
-		public Item SelectedItem
+		public Item? SelectedItem
 		{
 			get => _selectedItem;
 			set { _selectedItem = value; OnPropertyChanged(); }
@@ -82,7 +82,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.SelectionGalleries
 					_result.Text = "Success";
 				}
 			});
-			_result = result;
+			_result = result ?? throw new ArgumentNullException(nameof(result));
 		}
 	}
 }

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/SelectionGalleries/SelectionModeGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/SelectionGalleries/SelectionModeGallery.xaml.cs
@@ -29,7 +29,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.SelectionGalleries
 			UpdateSelectionInfoCommand();
 		}
 
-		void CollectionViewOnSelectionChanged(object sender, SelectionChangedEventArgs args)
+		void CollectionViewOnSelectionChanged(object? sender, SelectionChangedEventArgs args)
 		{
 			UpdateSelectionInfo(args.CurrentSelection, args.PreviousSelection);
 		}
@@ -59,11 +59,11 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.SelectionGalleries
 
 			if (CollectionView.SelectionMode == SelectionMode.Multiple)
 			{
-				current = CollectionView?.SelectedItems.ToCommaSeparatedList();
+				current = CollectionView.SelectedItems.ToCommaSeparatedList();
 			}
 			else if (CollectionView.SelectionMode == SelectionMode.Single)
 			{
-				current = ((CollectionViewGalleryTestItem)CollectionView?.SelectedItem)?.Caption;
+				current = ((CollectionViewGalleryTestItem)CollectionView.SelectedItem)?.Caption;
 			}
 
 			SelectedItemsCommand.Text = $"Selection (command): {current}";

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/SelectionGalleries/SingleBoundSelection.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/SelectionGalleries/SingleBoundSelection.xaml.cs
@@ -18,7 +18,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.SelectionGalleries
 
 		private void ResetClicked(object sender, EventArgs e)
 		{
-			_vm.SelectedItem = _vm.Items[0];
+			_vm.SelectedItem = _vm.Items![0];
 		}
 
 		private void ClearClicked(object sender, EventArgs e)

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/SelectionGalleries/VisualStatesGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/SelectionGalleries/VisualStatesGallery.xaml.cs
@@ -36,8 +36,8 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.SelectionGalleries
 
 	public class LineItem
 	{
-		public string ItemName { get; set; }
+		public string? ItemName { get; set; }
 
-		public override string ToString() => ItemName;
+		public override string? ToString() => ItemName;
 	}
 }

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/SnapPointsGallery.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/SnapPointsGallery.cs
@@ -21,9 +21,9 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries
 					{
 						descriptionLabel,
 						GalleryBuilder.NavButton("Snap Points (Code, Horizontal List)", () =>
-							new SnapPointsCodeGallery(LinearItemsLayout.Horizontal as ItemsLayout), Navigation),
+							new SnapPointsCodeGallery((LinearItemsLayout.Horizontal as ItemsLayout)!)!, Navigation),
 						GalleryBuilder.NavButton("Snap Points (Code, Vertical List)", () =>
-							new SnapPointsCodeGallery(LinearItemsLayout.Vertical as ItemsLayout), Navigation),
+							new SnapPointsCodeGallery((LinearItemsLayout.Vertical as ItemsLayout)!)!, Navigation),
 						GalleryBuilder.NavButton("Snap Points (Code, Horizontal Grid)", () =>
 							new SnapPointsCodeGallery(new GridItemsLayout(2, ItemsLayoutOrientation.Horizontal)), Navigation),
 						GalleryBuilder.NavButton("Snap Points (Code, Vertical Grid)", () =>

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/SpacingGalleries/SpacingModifier.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/SpacingGalleries/SpacingModifier.cs
@@ -33,7 +33,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.SpacingGalleries
 			Content = layout;
 		}
 
-		void ButtonOnClicked(object sender, EventArgs e)
+		void ButtonOnClicked(object? sender, EventArgs e)
 		{
 			OnButtonClicked();
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/SpanSetter.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/SpanSetter.cs
@@ -43,7 +43,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries
 			}
 		}
 
-		public void UpdateSpan(object sender, EventArgs e)
+		public void UpdateSpan(object? sender, EventArgs e)
 		{
 			UpdateSpan();
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/EntryPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/EntryPage.xaml.cs
@@ -38,20 +38,20 @@ namespace Maui.Controls.Sample.Pages
 			entrySelection.SelectionLength = (int)e.NewValue;
 		}
 
-		void OnEntryPropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+		void OnEntryPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
 		{
 			if (e.PropertyName == nameof(Entry.CursorPosition))
-				lblCursor.Text = $"CursorPosition = {((Entry)sender).CursorPosition}";
+				lblCursor.Text = $"CursorPosition = {((Entry)sender!).CursorPosition}";
 			if (e.PropertyName == nameof(Entry.Text))
-				sldCursorPosition.Maximum = ((Entry)sender).Text.Length;
+				sldCursorPosition.Maximum = ((Entry)sender!).Text.Length;
 		}
 
-		void OnEntrySelectionPropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+		void OnEntrySelectionPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
 		{
 			if (e.PropertyName == nameof(Entry.SelectionLength))
-				lblSelection.Text = $"SelectionLength = {((Entry)sender).SelectionLength}";
+				lblSelection.Text = $"SelectionLength = {((Entry)sender!).SelectionLength}";
 			if (e.PropertyName == nameof(Entry.Text))
-				sldSelection.Maximum = ((Entry)sender).Text.Length;
+				sldSelection.Maximum = ((Entry)sender!).Text.Length;
 		}
 
 		void OnEntryCompleted(object sender, EventArgs e)

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/MapPinsGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/MapPinsGallery.xaml.cs
@@ -64,13 +64,13 @@ namespace Maui.Controls.Sample.Pages.MapsGalleries
 
 			microsoftPin.MarkerClicked += (sender, args) =>
 			{
-				DisplayAlert("Marker", $"Marker Clicked: {((Pin)sender).Label}", "OK");
+				DisplayAlert("Marker", $"Marker Clicked: {((Pin)sender!).Label}", "OK");
 			};
 
 			// TODO this doesn't seem to work on iOS?
 			microsoftPin.InfoWindowClicked += (sender, args) =>
 			{
-				DisplayAlert("Info", $"Info Window Clicked: {((Pin)sender).Label}", "OK");
+				DisplayAlert("Info", $"Info Window Clicked: {((Pin)sender!).Label}", "OK");
 			};
 
 			pinsMap.Pins.Add(microsoftPin);

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/PinItemsSourceGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/PinItemsSourceGallery.xaml.cs
@@ -104,7 +104,7 @@ namespace Maui.Controls.Sample.Pages.MapsGalleries
 
 	public class Location : INotifyPropertyChanged
 	{
-		Position _position;
+		Position _position = default!;
 
 		public string Address { get; }
 		public string Description { get; }
@@ -128,7 +128,7 @@ namespace Maui.Controls.Sample.Pages.MapsGalleries
 
 		#region INotifyPropertyChanged
 
-		public event PropertyChangedEventHandler PropertyChanged;
+		public event PropertyChangedEventHandler? PropertyChanged;
 
 		#endregion
 	}

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/PickerPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/PickerPage.xaml.cs
@@ -156,8 +156,8 @@ namespace Maui.Controls.Sample.Pages
 
 	public class PickerData
 	{
-		public string Name { get; set; }
+		public string? Name { get; set; }
 
-		public ObservableCollection<PickerData> PickerItems { get; set; }
+		public ObservableCollection<PickerData>? PickerItems { get; set; }
 	}
 }

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/RadioButtonGalleries/RadioButtonGroupBindingGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/RadioButtonGalleries/RadioButtonGroupBindingGallery.xaml.cs
@@ -23,17 +23,17 @@ namespace Maui.Controls.Sample.Pages.RadioButtonGalleries
 
 	public class RadioButtonGroupBindingModel : INotifyPropertyChanged
 	{
-		private string _groupName;
-		private object _selection;
+		private string? _groupName;
+		private object? _selection;
 
-		public event PropertyChangedEventHandler PropertyChanged;
+		public event PropertyChangedEventHandler? PropertyChanged;
 
 		void OnPropertyChanged(string propertyName)
 		{
 			PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
 		}
 
-		public string GroupName
+		public string? GroupName
 		{
 			get => _groupName;
 			set
@@ -43,7 +43,7 @@ namespace Maui.Controls.Sample.Pages.RadioButtonGalleries
 			}
 		}
 
-		public object Selection
+		public object? Selection
 		{
 			get => _selection;
 			set

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/ShapesGalleries/AddRemoveClipGallery.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/ShapesGalleries/AddRemoveClipGallery.cs
@@ -83,7 +83,7 @@ namespace Maui.Controls.Sample.Pages.ShapesGalleries
 			Content = layout;
 		}
 
-		void OnAddButtonClicked(object sender, EventArgs e)
+		void OnAddButtonClicked(object? sender, EventArgs e)
 		{
 			var ellipseGeometry = new EllipseGeometry
 			{
@@ -95,7 +95,7 @@ namespace Maui.Controls.Sample.Pages.ShapesGalleries
 			_image.Clip = _grid.Clip = ellipseGeometry;
 		}
 
-		void OnRemoveButtonClicked(object sender, EventArgs e)
+		void OnRemoveButtonClicked(object? sender, EventArgs e)
 		{
 			_image.Clip = _grid.Clip = null;
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/ShapesGalleries/AnimateShapeGallery.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/ShapesGalleries/AnimateShapeGallery.cs
@@ -33,7 +33,7 @@ namespace Maui.Controls.Sample.Pages.ShapesGalleries
 			SizeChanged += OnPageSizeChanged;
 		}
 
-		void OnPageSizeChanged(object sender, EventArgs e)
+		void OnPageSizeChanged(object? sender, EventArgs e)
 		{
 			if (Width <= 0 || Height <= 0)
 			{
@@ -63,7 +63,7 @@ namespace Maui.Controls.Sample.Pages.ShapesGalleries
 
 	public class AnimateShapeGallery : SpiralDemoPage
 	{
-		IDispatcherTimer _timer;
+		IDispatcherTimer? _timer;
 
 		public AnimateShapeGallery()
 		{
@@ -92,7 +92,7 @@ namespace Maui.Controls.Sample.Pages.ShapesGalleries
 
 		protected override void OnDisappearing()
 		{
-			_timer.Stop();
+			_timer!.Stop();
 			_timer = null;
 		}
 	}

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/ShapesGalleries/InvalidateBrushGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/ShapesGalleries/InvalidateBrushGallery.xaml.cs
@@ -33,7 +33,7 @@ namespace Maui.Controls.Sample.Pages.ShapesGalleries
 			MyButton.Clicked -= OnButtonClicked;
 		}
 
-		void OnButtonClicked(object sender, System.EventArgs e)
+		void OnButtonClicked(object? sender, System.EventArgs e)
 		{
 			UpdateBrush();
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/ShapesGalleries/UpdatePathDataGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/ShapesGalleries/UpdatePathDataGallery.xaml.cs
@@ -22,7 +22,7 @@ namespace Maui.Controls.Sample.Pages.ShapesGalleries
 			string pathData = $"M 10,100 C 10,{300 + _counter} {300 + _counter},-200 {300 + _counter},100";
 
 			var pathGeometry = new PathGeometry();
-			PathFigureCollection figures = _pathFigureCollectionConverter.ConvertFromInvariantString(pathData) as PathFigureCollection;
+			var figures = _pathFigureCollectionConverter.ConvertFromInvariantString(pathData) as PathFigureCollection;
 			pathGeometry.Figures = figures;
 
 			Path.Data = pathGeometry;

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/SliderPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/SliderPage.xaml.cs
@@ -5,7 +5,7 @@ namespace Maui.Controls.Sample.Pages
 {
 	public partial class SliderPage
 	{
-		ImageSource _imageSource;
+		ImageSource? _imageSource;
 
 		public SliderPage()
 		{

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/SwipeViewGalleries/SwipeBindableLayoutGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/SwipeViewGalleries/SwipeBindableLayoutGallery.xaml.cs
@@ -24,16 +24,16 @@ namespace Maui.Controls.Sample.Pages.SwipeViewGalleries
 	[Preserve(AllMembers = true)]
 	public class Message
 	{
-		public string Title { get; set; }
-		public string SubTitle { get; set; }
-		public string Description { get; set; }
-		public string Date { get; set; }
+		public string? Title { get; set; }
+		public string? SubTitle { get; set; }
+		public string? Description { get; set; }
+		public string? Date { get; set; }
 	}
 
 	[Preserve(AllMembers = true)]
 	public class SwipeViewGalleryViewModel : BindableObject
 	{
-		ObservableCollection<Message> _messages;
+		ObservableCollection<Message>? _messages;
 
 		public SwipeViewGalleryViewModel()
 		{
@@ -41,7 +41,7 @@ namespace Maui.Controls.Sample.Pages.SwipeViewGalleries
 			LoadMessages();
 		}
 
-		public ObservableCollection<Message> Messages
+		public ObservableCollection<Message>? Messages
 		{
 			get { return _messages; }
 			set
@@ -59,7 +59,7 @@ namespace Maui.Controls.Sample.Pages.SwipeViewGalleries
 		{
 			for (int i = 0; i < 100; i++)
 			{
-				Messages.Add(new Message { Title = $"Lorem ipsum {i + 1}", SubTitle = "Lorem ipsum dolor sit amet", Date = "Yesterday", Description = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua." });
+				Messages!.Add(new Message { Title = $"Lorem ipsum {i + 1}", SubTitle = "Lorem ipsum dolor sit amet", Date = "Yesterday", Description = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua." });
 			}
 		}
 

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/SwipeViewGalleries/SwipeItemsDisposeGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/SwipeViewGalleries/SwipeItemsDisposeGallery.xaml.cs
@@ -14,8 +14,8 @@ namespace Maui.Controls.Sample.Pages.SwipeViewGalleries
 
 	public class SwipeItemsDisposeModel
 	{
-		public string Title { get; set; }
-		public string SubTitle { get; set; }
+		public string? Title { get; set; }
+		public string? SubTitle { get; set; }
 	}
 
 	public class SwipeItemsDisposeViewModel : BindableObject

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/SwipeViewGalleries/SwipeViewBindingContextGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/SwipeViewGalleries/SwipeViewBindingContextGallery.xaml.cs
@@ -19,15 +19,15 @@ namespace Maui.Controls.Sample.Pages.SwipeViewGalleries
 	[Preserve(AllMembers = true)]
 	public class SwipeViewBindingContextGalleryModel : BindableObject
 	{
-		public string Title { get; set; }
-		public string SubTitle { get; set; }
+		public string? Title { get; set; }
+		public string? SubTitle { get; set; }
 	}
 
 	[Preserve(AllMembers = true)]
 	public class SwipeViewBindingContextGalleryViewModel : BindableObject
 	{
-		ObservableCollection<SwipeViewBindingContextGalleryModel> _items;
-		SwipeViewBindingContextGalleryModel _tappedItem;
+		ObservableCollection<SwipeViewBindingContextGalleryModel>? _items;
+		SwipeViewBindingContextGalleryModel? _tappedItem;
 
 		public SwipeViewBindingContextGalleryViewModel()
 		{
@@ -35,7 +35,7 @@ namespace Maui.Controls.Sample.Pages.SwipeViewGalleries
 			LoadItems();
 		}
 
-		public ObservableCollection<SwipeViewBindingContextGalleryModel> Items
+		public ObservableCollection<SwipeViewBindingContextGalleryModel>? Items
 		{
 			get { return _items; }
 			set
@@ -45,7 +45,7 @@ namespace Maui.Controls.Sample.Pages.SwipeViewGalleries
 			}
 		}
 
-		public SwipeViewBindingContextGalleryModel TappedItem
+		public SwipeViewBindingContextGalleryModel? TappedItem
 		{
 			get { return _tappedItem; }
 			set
@@ -61,7 +61,7 @@ namespace Maui.Controls.Sample.Pages.SwipeViewGalleries
 		{
 			for (int i = 0; i < 100; i++)
 			{
-				Items.Add(new SwipeViewBindingContextGalleryModel
+				Items!.Add(new SwipeViewBindingContextGalleryModel
 				{
 					Title = $"Lorem ipsum {i + 1}",
 					SubTitle = "Lorem ipsum dolor sit amet"

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/WebViewPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/WebViewPage.xaml.cs
@@ -66,12 +66,12 @@ namespace Maui.Controls.Sample.Pages
 			MauiWebView.Eval("alert('text')");
 		}
 
-		void OnMauiWebViewNavigating(object sender, Microsoft.Maui.Controls.WebNavigatingEventArgs e)
+		void OnMauiWebViewNavigating(object? sender, Microsoft.Maui.Controls.WebNavigatingEventArgs e)
 		{
 			Debug.WriteLine($"Navigating - Url: {e.Url}, Event: {e.NavigationEvent}");
 		}
 
-		void OnMauiWebViewNavigated(object sender, Microsoft.Maui.Controls.WebNavigatedEventArgs e)
+		void OnMauiWebViewNavigated(object? sender, Microsoft.Maui.Controls.WebNavigatedEventArgs e)
 		{
 			Debug.WriteLine($"Navigated - Url: {e.Url}, Event: {e.NavigationEvent}, Result: {e.Result}");
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/Core/ApplicationControlPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/ApplicationControlPage.xaml.cs
@@ -12,7 +12,7 @@ namespace Maui.Controls.Sample.Pages
 
 		void OnTerminateClicked(object sender, EventArgs e)
 		{
-			Application.Current.Quit();
+			Application.Current!.Quit();
 		}
 	}
 }

--- a/src/Controls/samples/Controls.Sample/Pages/Core/BorderGalleries/BorderStyles.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/BorderGalleries/BorderStyles.xaml.cs
@@ -20,8 +20,8 @@ namespace Maui.Controls.Sample.Pages
 
 		void ChangeCornerRadius(double delta)
 		{
-			RoundRectangle rr = (RoundRectangle)UpdateStrokeShapeBorder.StrokeShape;
-			double radius = Math.Max(0, rr.CornerRadius.TopLeft + delta);
+			var rr = (RoundRectangle)(UpdateStrokeShapeBorder.StrokeShape!);
+			double radius = Math.Max(0, rr!.CornerRadius.TopLeft + delta);
 			rr.CornerRadius = new CornerRadius(radius);
 			UpdateStrokeShapeInfo.Text = $"Border.StrokeShape is RoundRectangle with {radius} radius";
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/Core/BrushesPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/BrushesPage.xaml.cs
@@ -45,7 +45,7 @@ namespace Maui.Controls.Sample.Pages
 			UpdateGradientStopColor(LinearBrushPolygon.Fill as LinearGradientBrush, gradientStop, color);
 		}
 
-		void UpdateGradientStopColor(GradientBrush gradientBrush, int index, Color color)
+		void UpdateGradientStopColor(GradientBrush? gradientBrush, int index, Color color)
 		{
 			if (gradientBrush is null)
 				return;

--- a/src/Controls/samples/Controls.Sample/Pages/Core/ContextFlyoutPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/ContextFlyoutPage.xaml.cs
@@ -50,15 +50,15 @@ namespace Maui.Controls.Sample.Pages
 			bbb.KeyboardAccelerators.Add(new KeyboardAccelerator() { Key = "C" });
 		}
 
-		void OnWebViewHandlerChanged(object sender, EventArgs e)
+		void OnWebViewHandlerChanged(object? sender, EventArgs e)
 		{
 			if (ContextMenuWebView.Handler != null)
 			{
 #if WINDOWS
-				var webView2 = (Microsoft.UI.Xaml.Controls.WebView2)ContextMenuWebView.Handler.PlatformView;
+				var webView2 = (Microsoft.UI.Xaml.Controls.WebView2)ContextMenuWebView.Handler.PlatformView!;
 				webView2.CoreWebView2Initialized += OnWebView2CoreWebView2Initialized;
 #elif MACCATALYST
-				var wkWebView = (WebKit.WKWebView)ContextMenuWebView.Handler.PlatformView;
+				var wkWebView = (WebKit.WKWebView)ContextMenuWebView.Handler.PlatformView!;
 				// TODO: Need to figure out how to disable default WKWebView context menu so that
 				// the custom context flyout is shown instead. (It does sometimes show up for a second
 				// but then it goes back to the default web context menu.)
@@ -148,7 +148,7 @@ namespace Maui.Controls.Sample.Pages
 
 		void OnAddMenuClicked(object sender, EventArgs e)
 		{
-			var contextFlyout = ((MenuFlyoutItem)sender).Parent as MenuFlyout;
+			var contextFlyout = (((MenuFlyoutItem)sender).Parent as MenuFlyout)!;
 			AddNewMenu(contextFlyout, "top-level");
 		}
 

--- a/src/Controls/samples/Controls.Sample/Pages/Core/DispatcherPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/DispatcherPage.xaml.cs
@@ -56,7 +56,7 @@ namespace Maui.Controls.Sample.Pages
 			laterLabel.Text = "Started!";
 		}
 
-		IDispatcherTimer _timer;
+		IDispatcherTimer? _timer;
 
 		void OnTimerClicked(object sender, EventArgs e)
 		{

--- a/src/Controls/samples/Controls.Sample/Pages/Core/DragAndDropBetweenLayouts.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/DragAndDropBetweenLayouts.xaml.cs
@@ -36,11 +36,11 @@ namespace Maui.Controls.Sample.Pages
 
 		private void OnDragStarting(object sender, DragStartingEventArgs e)
 		{
-			var boxView = (View)(sender as Element).Parent;
+			var boxView = (View)(sender as Element)!.Parent;
 			DragStartingTitle.IsVisible = true;
-			DragStartingPositionLabel.Text = $"- Self X:{(int)e.GetPosition(boxView).Value.X}, Y:{(int)e.GetPosition(boxView).Value.Y}";
-			DragStartingScreenPositionLabel.Text = $"- Screen X:{(int)e.GetPosition(null).Value.X}, Y:{(int)e.GetPosition(null).Value.Y}";
-			DragStartingRelativePositionLabel.Text = $"- This label X:{(int)e.GetPosition(DragStartingRelativePositionLabel).Value.X}, Y:{(int)e.GetPosition(DragStartingRelativePositionLabel).Value.Y}";
+			DragStartingPositionLabel.Text = $"- Self X:{(int)e.GetPosition(boxView)!.Value.X}, Y:{(int)e.GetPosition(boxView)!.Value.Y}";
+			DragStartingScreenPositionLabel.Text = $"- Screen X:{(int)e.GetPosition(null)!.Value.X}, Y:{(int)e.GetPosition(null)!.Value.Y}";
+			DragStartingRelativePositionLabel.Text = $"- This label X:{(int)e.GetPosition(DragStartingRelativePositionLabel)!.Value.X}, Y:{(int)e.GetPosition(DragStartingRelativePositionLabel)!.Value.Y}";
 
 			var sl = boxView.Parent as StackLayout;
 			e.Data.Properties.Add("Color", boxView.Background);
@@ -54,7 +54,7 @@ namespace Maui.Controls.Sample.Pages
 
 		private void OnDropCompleted(object sender, DropCompletedEventArgs e)
 		{
-			var sl = (sender as Element).Parent as StackLayout;
+			var sl = (sender as Element)!.Parent as StackLayout;
 
 			if (sl == SLAllColors)
 				SLRainbow.Background = SolidColorBrush.White;
@@ -65,15 +65,15 @@ namespace Maui.Controls.Sample.Pages
 
 		private void OnDragOver(object sender, DragEventArgs e)
 		{
-			var sl = (StackLayout)(sender as Element).Parent;
+			var sl = (StackLayout)(sender as Element)!.Parent;
 
 			if (!e.Data.Properties.ContainsKey("Source"))
 				return;
 
 			DragTitle.IsVisible = true;
-			DragPositionLabel.Text = $"- Receiving layout X: {(int)e.GetPosition(sl).Value.X}, Y:{(int)e.GetPosition(sl).Value.Y}";
-			DragScreenPositionLabel.Text = $"- Screen X: {(int)e.GetPosition(null).Value.X}, Y:{(int)e.GetPosition(null).Value.Y}";
-			DragRelativePositionLabel.Text = $"- This label X: {(int)e.GetPosition(DragRelativePositionLabel).Value.X}, Y:{(int)e.GetPosition(DragRelativePositionLabel).Value.Y}";
+			DragPositionLabel.Text = $"- Receiving layout X: {(int)e.GetPosition(sl)!.Value.X}, Y:{(int)e.GetPosition(sl)!.Value.Y}";
+			DragScreenPositionLabel.Text = $"- Screen X: {(int)e.GetPosition(null)!.Value.X}, Y:{(int)e.GetPosition(null)!.Value.Y}";
+			DragRelativePositionLabel.Text = $"- This label X: {(int)e.GetPosition(DragRelativePositionLabel)!.Value.X}, Y:{(int)e.GetPosition(DragRelativePositionLabel)!.Value.Y}";
 
 			if (e.Data.Properties["Source"] == sl)
 			{
@@ -86,15 +86,15 @@ namespace Maui.Controls.Sample.Pages
 
 		private void OnDragLeave(object sender, DragEventArgs e)
 		{
-			var sl = (StackLayout)(sender as Element).Parent;
+			var sl = (StackLayout)(sender as Element)!.Parent;
 
 			if (!e.Data.Properties.ContainsKey("Source"))
 				return;
 
 			DragTitle.IsVisible = true;
-			DragPositionLabel.Text = $"- Receiving layout: Y:{(int)e.GetPosition(sl).Value.X}, Y:{(int)e.GetPosition(sl).Value.Y}";
-			DragScreenPositionLabel.Text = $"- Screen: X:{(int)e.GetPosition(null).Value.X}, Y:{(int)e.GetPosition(null).Value.Y}";
-			DragRelativePositionLabel.Text = $"- This label: X:{(int)e.GetPosition(DragRelativePositionLabel).Value.X}, Y:{(int)e.GetPosition(DragRelativePositionLabel).Value.Y}";
+			DragPositionLabel.Text = $"- Receiving layout: Y:{(int)e.GetPosition(sl)!.Value.X}, Y:{(int)e.GetPosition(sl)!.Value.Y}";
+			DragScreenPositionLabel.Text = $"- Screen: X:{(int)e.GetPosition(null)!.Value.X}, Y:{(int)e.GetPosition(null)!.Value.Y}";
+			DragRelativePositionLabel.Text = $"- This label: X:{(int)e.GetPosition(DragRelativePositionLabel)!.Value.X}, Y:{(int)e.GetPosition(DragRelativePositionLabel)!.Value.Y}";
 
 			if (e.Data.Properties["Source"] == sl)
 			{
@@ -107,7 +107,7 @@ namespace Maui.Controls.Sample.Pages
 
 		private void OnDrop(object sender, DropEventArgs e)
 		{
-			var sl = (sender as Element).Parent as StackLayout;
+			var sl = (sender as Element)!.Parent as StackLayout;
 
 			if (!e.Data.Properties.ContainsKey("Source"))
 				return;
@@ -118,11 +118,11 @@ namespace Maui.Controls.Sample.Pages
 			}
 
 			DropTitle.IsVisible = true;
-			DropPositionLabel.Text = $"- Receiving layout: Y:{(int)e.GetPosition(sl).Value.X}, Y:{(int)e.GetPosition(sl).Value.Y}";
-			DropScreenPositionLabel.Text = $"- Screen: X:{(int)e.GetPosition(null).Value.X}, Y:{(int)e.GetPosition(null).Value.Y}";
-			DropRelativePositionLabel.Text = $"- This label: X:{(int)e.GetPosition(DropRelativePositionLabel).Value.X}, Y:{(int)e.GetPosition(DropRelativePositionLabel).Value.Y}";
+			DropPositionLabel.Text = $"- Receiving layout: Y:{(int)e.GetPosition(sl)!.Value.X}, Y:{(int)e.GetPosition(sl)!.Value.Y}";
+			DropScreenPositionLabel.Text = $"- Screen: X:{(int)e.GetPosition(null)!.Value.X}, Y:{(int)e.GetPosition(null)!.Value.Y}";
+			DropRelativePositionLabel.Text = $"- This label: X:{(int)e.GetPosition(DropRelativePositionLabel)!.Value.X}, Y:{(int)e.GetPosition(DropRelativePositionLabel)!.Value.Y}";
 
-			var color = e.Data.Properties["Color"] as SolidColorBrush;
+			var color = (e.Data.Properties["Color"] as SolidColorBrush)!;
 
 			if (AllColors.Contains(color))
 			{

--- a/src/Controls/samples/Controls.Sample/Pages/Core/FlyoutPageGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/FlyoutPageGallery.xaml.cs
@@ -6,7 +6,7 @@ namespace Maui.Controls.Sample.Pages
 	public partial class FlyoutPageGallery
 	{
 
-		FlyoutPage FlyoutPage => Application.Current.MainPage as FlyoutPage;
+		FlyoutPage? FlyoutPage => Application.Current!.MainPage as FlyoutPage;
 		public FlyoutPageGallery()
 		{
 			InitializeComponent();
@@ -20,7 +20,7 @@ namespace Maui.Controls.Sample.Pages
 			if (FlyoutPage == null)
 				return;
 
-			FlyoutPage.IsGestureEnabled = (sender as CheckBox).IsChecked;
+			FlyoutPage.IsGestureEnabled = (sender as CheckBox)!.IsChecked;
 		}
 
 		protected override void OnNavigatedTo(NavigatedToEventArgs args)
@@ -33,7 +33,7 @@ namespace Maui.Controls.Sample.Pages
 			FlyoutPage.IsPresentedChanged += OnPresentedChanged;
 		}
 
-		private void OnPresentedChanged(object sender, EventArgs e)
+		private void OnPresentedChanged(object? sender, EventArgs e)
 		{
 			UpdatePresentedLabel();
 		}
@@ -54,7 +54,7 @@ namespace Maui.Controls.Sample.Pages
 			lblPresented.Text = $"Flyout Is Currently: {FlyoutPage.IsPresented}";
 		}
 
-		void OnFlyoutBehaviorPickerSelectedIndexChanged(object sender, EventArgs e)
+		void OnFlyoutBehaviorPickerSelectedIndexChanged(object? sender, EventArgs e)
 		{
 			if (FlyoutPage == null)
 				return;

--- a/src/Controls/samples/Controls.Sample/Pages/Core/MenuBarPage.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/MenuBarPage.cs
@@ -37,7 +37,7 @@ namespace Maui.Controls.Sample.Pages
 
 		void OnToggleMenuBarItem(object sender, EventArgs e)
 		{
-			MenuBarItem barItem =
+			var barItem =
 				MenuBarItems.FirstOrDefault(x => x.Text == "Added Menu");
 
 			if (barItem == null)

--- a/src/Controls/samples/Controls.Sample/Pages/Core/ModalPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/ModalPage.xaml.cs
@@ -7,7 +7,7 @@ namespace Maui.Controls.Sample.Pages
 	public partial class ModalPage
 	{
 		static int s_instanceCount = 0;
-		string _previousTitle;
+		string? _previousTitle;
 		public ModalPage()
 		{
 			InitializeComponent();

--- a/src/Controls/samples/Controls.Sample/Pages/Core/MultiWindowPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/MultiWindowPage.xaml.cs
@@ -16,12 +16,12 @@ namespace Maui.Controls.Sample.Pages
 
 		void OnNewWindowClicked(object sender, EventArgs e)
 		{
-			Application.Current.OpenWindow(new Window(new MultiWindowPage()));
+			Application.Current!.OpenWindow(new Window(new MultiWindowPage()));
 		}
 
 		void OnCloseWindowClicked(object sender, EventArgs e)
 		{
-			Application.Current.CloseWindow(Window);
+			Application.Current!.CloseWindow(Window);
 		}
 
 		async void OnOpenDialogClicked(object sender, EventArgs e)

--- a/src/Controls/samples/Controls.Sample/Pages/Core/NavigationGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/NavigationGallery.xaml.cs
@@ -13,7 +13,7 @@ namespace Maui.Controls.Sample.Pages
 	{
 		static int pageCount = 0;
 
-		static List<Page> _currentNavStack;
+		static List<Page>? _currentNavStack;
 		public NavigationGallery()
 		{
 			InitializeComponent();
@@ -86,7 +86,7 @@ namespace Maui.Controls.Sample.Pages
 				if (stackNavigationView == null && Parent is FlyoutPage fp)
 					stackNavigationView = fp.Detail as IStackNavigationView;
 
-				stackNavigationView.RequestNavigation(
+				stackNavigationView!.RequestNavigation(
 					new NavigationRequest(
 						new List<NavigationGallery>
 						{
@@ -95,7 +95,7 @@ namespace Maui.Controls.Sample.Pages
 			}
 			else
 			{
-				(Parent as IStackNavigationView).RequestNavigation(
+				(Parent as IStackNavigationView)!.RequestNavigation(
 				   new NavigationRequest(_currentNavStack, true));
 
 				_currentNavStack = null;

--- a/src/Controls/samples/Controls.Sample/Pages/Core/PanGestureGalleryPage.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/PanGestureGalleryPage.cs
@@ -26,7 +26,7 @@ namespace Maui.Controls.Sample.Pages
 			double _x, _y;
 			double _currentScale = 1;
 
-			public EventHandler<PanCompleteArgs> PanCompleted;
+			public EventHandler<PanCompleteArgs>? PanCompleted;
 
 			public PanContainer()
 			{

--- a/src/Controls/samples/Controls.Sample/Pages/Core/PinchGestureTestPage.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/PinchGestureTestPage.cs
@@ -14,7 +14,7 @@ namespace Maui.Controls.Sample.Pages
 
 		}
 
-		public View Content
+		public View? Content
 		{
 			get => Children.OfType<View>().LastOrDefault();
 			set
@@ -40,7 +40,7 @@ namespace Maui.Controls.Sample.Pages
 
 				if (e.Status == GestureStatus.Started)
 				{
-					startScale = Content.Scale;
+					startScale = Content!.Scale;
 					Content.AnchorX = Content.AnchorY = 0;
 				}
 				if (e.Status == GestureStatus.Running)
@@ -49,7 +49,7 @@ namespace Maui.Controls.Sample.Pages
 					_currentScale += (e.Scale - 1) * startScale;
 					_currentScale = Math.Max(1, _currentScale);
 
-					var renderedX = Content.X + xOffset;
+					var renderedX = Content!.X + xOffset;
 					var deltaX = renderedX / Width;
 					var deltaWidth = Width / (Content.Width * startScale);
 					var originX = (e.ScaleOrigin.X - deltaX) * deltaWidth;
@@ -69,8 +69,8 @@ namespace Maui.Controls.Sample.Pages
 				}
 				if (e.Status == GestureStatus.Completed)
 				{
-					xOffset = Content.TranslationX;
-					yOffset = Content.TranslationY;
+					xOffset = Content!.TranslationX;
+					yOffset = Content!.TranslationY;
 				}
 			};
 

--- a/src/Controls/samples/Controls.Sample/Pages/Core/SemanticsPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/SemanticsPage.xaml.cs
@@ -20,7 +20,7 @@ namespace Maui.Controls.Sample.Pages
 			}
 		}
 
-		private async void PopButton_Clicked(object sender, System.EventArgs e)
+		private async void PopButton_Clicked(object? sender, System.EventArgs e)
 		{
 			if (Navigation.ModalStack.Count > 0)
 				await Navigation.PopModalAsync();
@@ -28,7 +28,7 @@ namespace Maui.Controls.Sample.Pages
 				await Navigation.PopAsync();
 		}
 
-		private async void PushButton_Clicked(object sender, System.EventArgs e)
+		private async void PushButton_Clicked(object? sender, System.EventArgs e)
 		{
 			await Navigation.PushAsync(new SemanticsPage());
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/Core/ShadowGalleries/ShadowPlaygroundPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/ShadowGalleries/ShadowPlaygroundPage.xaml.cs
@@ -14,7 +14,7 @@ namespace Maui.Controls.Sample.Pages
 
 		void RemoveShadowClicked(object sender, EventArgs e)
 		{
-			ClippedShadowView.Shadow = ShadowView.Shadow = ShadowViewGradient.Shadow = LabelShadowView.Shadow = null;
+			ClippedShadowView.Shadow = ShadowView.Shadow = ShadowViewGradient.Shadow = LabelShadowView.Shadow = null!;
 		}
 
 		void OnShadowOffsetXChanged(object sender, ValueChangedEventArgs e)

--- a/src/Controls/samples/Controls.Sample/Pages/Core/ShellGalleries/ShellChromeGallery.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/ShellGalleries/ShellChromeGallery.cs
@@ -12,7 +12,7 @@ namespace Maui.Controls.Sample.Pages.ShellGalleries
 {
 	public partial class ShellChromeGallery
 	{
-		AppShell AppShell => Application.Current.MainPage as AppShell;
+		AppShell? AppShell => Application.Current!.MainPage as AppShell;
 
 		public ShellChromeGallery()
 		{
@@ -60,25 +60,25 @@ namespace Maui.Controls.Sample.Pages.ShellGalleries
 
 
 
-		void OnFlyoutHeaderBehaviorSelectedIndexChanged(object sender, EventArgs e)
+		void OnFlyoutHeaderBehaviorSelectedIndexChanged(object? sender, EventArgs e)
 		{
-			AppShell.FlyoutHeaderBehavior = (FlyoutHeaderBehavior)flyoutHeaderBehavior.SelectedIndex;
+			AppShell!.FlyoutHeaderBehavior = (FlyoutHeaderBehavior)flyoutHeaderBehavior.SelectedIndex;
 		}
 
-		void OnFlyoutBehaviorSelectedIndexChanged(object sender, EventArgs e)
+		void OnFlyoutBehaviorSelectedIndexChanged(object? sender, EventArgs e)
 		{
-			AppShell.FlyoutBehavior = (FlyoutBehavior)flyoutBehavior.SelectedIndex;
+			AppShell!.FlyoutBehavior = (FlyoutBehavior)flyoutBehavior.SelectedIndex;
 		}
 
 		protected override void OnAppearing()
 		{
-			AppShell.FlyoutBehavior = (FlyoutBehavior)flyoutBehavior.SelectedIndex;
-			AppShell.FlyoutHeaderBehavior = (FlyoutHeaderBehavior)flyoutHeaderBehavior.SelectedIndex;
+			AppShell!.FlyoutBehavior = (FlyoutBehavior)flyoutBehavior.SelectedIndex;
+			AppShell!.FlyoutHeaderBehavior = (FlyoutHeaderBehavior)flyoutHeaderBehavior.SelectedIndex;
 		}
 
 		void OnToggleFlyoutBackgroundColor(object sender, EventArgs e)
 		{
-			AppShell.RemoveBinding(Shell.FlyoutBackgroundProperty);
+			AppShell!.RemoveBinding(Shell.FlyoutBackgroundProperty);
 			if (AppShell.FlyoutBackground.IsEmpty ||
 				AppShell.FlyoutBackground == SolidColorBrush.Purple)
 			{

--- a/src/Controls/samples/Controls.Sample/Pages/Core/SwipeGestureGalleryPage.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/SwipeGestureGalleryPage.cs
@@ -11,29 +11,29 @@ namespace Maui.Controls.Sample.Pages
 	{
 		public class SwipeContainer : VerticalStackLayout
 		{
-			public EventHandler SwipeLeft;
-			public EventHandler SwipeRight;
-			public EventHandler SwipeUp;
-			public EventHandler SwipeDown;
+			public EventHandler? SwipeLeft;
+			public EventHandler? SwipeRight;
+			public EventHandler? SwipeUp;
+			public EventHandler? SwipeDown;
 
 			public SwipeContainer()
 			{
 			}
 
 
-			public View Content
+			public View? Content
 			{
-				get => (View)Children.LastOrDefault();
+				get => (View)(Children.LastOrDefault()!);
 				set
 				{
 					if (Children.Count > 0)
 						Remove(Children[0]);
 
 					Add(value);
-					value.GestureRecognizers.Add(GetSwipeRight());
-					value.GestureRecognizers.Add(GetSwipeLeft());
-					value.GestureRecognizers.Add(GetSwipeUp());
-					value.GestureRecognizers.Add(GetSwipeDown());
+					value!.GestureRecognizers.Add(GetSwipeRight());
+					value!.GestureRecognizers.Add(GetSwipeLeft());
+					value!.GestureRecognizers.Add(GetSwipeUp());
+					value!.GestureRecognizers.Add(GetSwipeDown());
 				}
 			}
 

--- a/src/Controls/samples/Controls.Sample/Pages/Core/TapGestureGalleryPage.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/TapGestureGalleryPage.cs
@@ -172,10 +172,10 @@ namespace Maui.Controls.Sample.Pages
 			Content = vertical;
 		}
 
-		void OnTapped(object sender, System.EventArgs e)
+		void OnTapped(object? sender, System.EventArgs e)
 		{
 			var args = (TappedEventArgs)e;
-			var view = (View)sender;
+			var view = (View)sender!;
 
 			windowPosition.Text = $"Position inside window: {args.GetPosition(null)}";
 			relativeToToggleButtonPosition.Text = $"Position relative to toggle button: {args.GetPosition(toggleButton)}";

--- a/src/Controls/samples/Controls.Sample/Pages/CustomFlyoutPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/CustomFlyoutPage.xaml.cs
@@ -15,11 +15,11 @@ namespace Maui.Controls.Sample.Pages
 			Flyout.BindingContext = viewModel;
 		}
 
-		private void Detail_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+		private void Detail_PropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
 		{
 			if (e.PropertyName == nameof(NavigationPage.CurrentPage))
 			{
-				Flyout.BindingContext = (Detail as NavigationPage).CurrentPage.BindingContext;
+				Flyout.BindingContext = (Detail as NavigationPage)!.CurrentPage.BindingContext;
 			}
 		}
 	}

--- a/src/Controls/samples/Controls.Sample/Pages/HitTestingPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/HitTestingPage.xaml.cs
@@ -16,8 +16,8 @@ namespace Maui.Controls.Sample.Pages
 			RectangleSelectionPickSecond
 		}
 
-		Microsoft.Maui.Controls.Window _window;
-		WindowOverlay _overlay;
+		Microsoft.Maui.Controls.Window? _window;
+		WindowOverlay? _overlay;
 		double _firstPosX;
 		double _firstPosY;
 		double _currentMousePosX;
@@ -25,7 +25,7 @@ namespace Maui.Controls.Sample.Pages
 		State _state = State.SingleSelection;
 		bool _tappedWithoutMove;
 
-		Microsoft.Maui.Controls.View[] _allChildren = null;
+		Microsoft.Maui.Controls.View[]? _allChildren = null;
 
 		public HitTestingPage()
 		{
@@ -49,7 +49,7 @@ namespace Maui.Controls.Sample.Pages
 				.Where(x => x != RectangleSelectionCheckBox)
 				.ToArray();
 #if WINDOWS
-			var platformChildren = _allChildren.Select(v => v.Handler.PlatformView).OfType<Microsoft.UI.Xaml.UIElement>();
+			var platformChildren = _allChildren.Select(v => v.Handler!.PlatformView).OfType<Microsoft.UI.Xaml.UIElement>();
 			foreach (var element in platformChildren)
 			{
 				Debug.Print(element.GetType().FullName);
@@ -73,10 +73,10 @@ namespace Maui.Controls.Sample.Pages
 			RectangleSelectionCheckBox.IsEnabled = false;
 			_overlay.Tapped += DoHandleOverlayTapped;
 
-			void DoHandleOverlayTapped(object sender, WindowOverlayTappedEventArgs e)
+			void DoHandleOverlayTapped(object? sender, WindowOverlayTappedEventArgs e)
 			{
 				var p = e.Point;
-				Debug.Print($"{sender.GetType().Name} tapped! ({p.X};{p.Y})");
+				Debug.Print($"{sender!.GetType().Name} tapped! ({p.X};{p.Y})");
 				_tappedWithoutMove = false; // No mouse move on iOS/Android
 				HandleTapped(p.X, p.Y);
 			}
@@ -87,8 +87,8 @@ namespace Maui.Controls.Sample.Pages
 
 		private void ContentPage_Unloaded(object sender, EventArgs e)
 		{
-			_overlay.RemoveWindowElement(this);
-			_window.RemoveOverlay(_overlay);
+			_overlay!.RemoveWindowElement(this);
+			_window!.RemoveOverlay(_overlay);
 		}
 
 		private void HandlePointerMoved(double x, double y)
@@ -99,7 +99,7 @@ namespace Maui.Controls.Sample.Pages
 
 			if (_state == State.RectangleSelectionPickSecond)
 			{
-				_overlay.Invalidate();
+				_overlay!.Invalidate();
 			}
 		}
 
@@ -109,7 +109,7 @@ namespace Maui.Controls.Sample.Pages
 				return;
 
 			_tappedWithoutMove = true;
-			IEnumerable<IVisualTreeElement> elements = null;
+			IEnumerable<IVisualTreeElement>? elements = null;
 
 			if (_state == State.SingleSelection)
 			{
@@ -127,16 +127,16 @@ namespace Maui.Controls.Sample.Pages
 				var rect = GetCurrentRect();
 				elements = VisualTreeElementExtensions.GetVisualTreeElements(this.Window, rect.Left, rect.Top, rect.Right, rect.Bottom);
 				_state = State.RectangleSelectionPickFirst;
-				_overlay.Invalidate();
+				_overlay!.Invalidate();
 			}
 
-			foreach (var c in _allChildren)
+			foreach (var c in _allChildren!)
 			{
 				c.BackgroundColor = null;
 			}
 
-			SelectionLabel.Text = "Selected: " + string.Join(" <- ", elements.Select(x => x.GetType().Name));
-			var e = elements.FirstOrDefault() as Microsoft.Maui.Controls.View;
+			SelectionLabel.Text = "Selected: " + string.Join(" <- ", elements!.Select(x => x.GetType().Name));
+			var e = elements!.FirstOrDefault() as Microsoft.Maui.Controls.View;
 
 			if (e != null)
 			{

--- a/src/Controls/samples/Controls.Sample/Pages/Layouts/ZIndexPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Layouts/ZIndexPage.xaml.cs
@@ -10,7 +10,7 @@ namespace Maui.Controls.Sample.Pages
 		{
 			InitializeComponent();
 
-			Label target = null;
+			Label? target = null;
 
 			for (int n = 0; n < 10; n++)
 			{
@@ -35,7 +35,7 @@ namespace Maui.Controls.Sample.Pages
 				}
 			}
 
-			CurrentZIndex.Text = $"Z-Index of Label 5: {target.ZIndex}";
+			CurrentZIndex.Text = $"Z-Index of Label 5: {target!.ZIndex}";
 			ZIndexStepper.Value = target.ZIndex;
 			ZIndexStepper.ValueChanged += (sender, args) =>
 			{

--- a/src/Controls/samples/Controls.Sample/Pages/MainPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/MainPage.xaml.cs
@@ -8,8 +8,8 @@ namespace Maui.Controls.Sample.Pages
 {
 	public partial class MainPage
 	{
-		readonly IServiceProvider _services;
-		readonly MainViewModel _viewModel;
+		readonly IServiceProvider? _services;
+		readonly MainViewModel? _viewModel;
 
 		public MainPage(IServiceProvider services, MainViewModel viewModel)
 		{

--- a/src/Controls/samples/Controls.Sample/Pages/Others/LargeTitlesPageiOS.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Others/LargeTitlesPageiOS.cs
@@ -45,7 +45,7 @@ namespace Maui.Controls.Sample.Pages
 					{
 						Text = "Tooggle UseLargeTitles on Navigation",
 						Command = new Command( () =>{
-							var navPage = (Parent as NavigationPage);
+							var navPage = (Parent as NavigationPage)!;
 							navPage.On<iOS>().SetPrefersLargeTitles(!navPage.On<iOS>().PrefersLargeTitles());
 						} )
 					},
@@ -54,7 +54,7 @@ namespace Maui.Controls.Sample.Pages
 					{
 						Text = "UseLargeTitles on Navigation with safe Area",
 						Command = new Command( () =>{
-							var navPage = (Parent as NavigationPage);
+							var navPage = (Parent as NavigationPage)!;
 							navPage.On<iOS>().SetPrefersLargeTitles(true);
 							var page = new ContentPage { Title = "New Title", BackgroundColor = Colors.Red };
 							page.On<iOS>().SetUseSafeArea(true);

--- a/src/Controls/samples/Controls.Sample/Pages/Others/TwoPaneViewPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Others/TwoPaneViewPage.xaml.cs
@@ -1,5 +1,6 @@
 ﻿namespace Maui.Controls.Sample.Pages
 {
+	using System;
 	using Microsoft.Maui;
 	using Microsoft.Maui.Controls.Foldable;
 	using Microsoft.Maui.Foldable;
@@ -28,10 +29,10 @@
 			TallModeConfiguration.ItemsSource = System.Enum.GetValues(typeof(TwoPaneViewTallModeConfiguration));
 			WideModeConfiguration.ItemsSource = System.Enum.GetValues(typeof(TwoPaneViewWideModeConfiguration));
 
-			OnReset(null, null);
+			OnReset(null, EventArgs.Empty);
 		}
 
-		private void PaneLength_ValueChanged(object sender, Microsoft.Maui.Controls.ValueChangedEventArgs e)
+		private void PaneLength_ValueChanged(object? sender, Microsoft.Maui.Controls.ValueChangedEventArgs e)
 		{
 			twoPaneView.Pane1Length = new GridLength(Pane1Length.Value, GridUnitType.Star);
 			twoPaneView.Pane2Length = new GridLength(Pane2Length.Value, GridUnitType.Star);
@@ -51,7 +52,7 @@
 			hingeLabel.Text = "Hinge prepped " + await DualScreenInfo.Current.GetHingeAngleAsync();
 		}
 
-		private void Current_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+		private void Current_PropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
 		{
 			spanLabel.Text += "Spanmode: " + DualScreenInfo.Current.SpanMode;
 		}
@@ -61,14 +62,14 @@
 			DualScreenInfo.Current.HingeAngleChanged -= Current_HingeAngleChanged;
 			DualScreenInfo.Current.PropertyChanged -= Current_PropertyChanged;
 		}
-		private void Current_HingeAngleChanged(object sender, HingeAngleChangedEventArgs e)
+		private void Current_HingeAngleChanged(object? sender, HingeAngleChangedEventArgs e)
 		{
 			System.Diagnostics.Debug.Write("TwoPaneViewPage.Current_HingeAngleChanged - " + e.HingeAngleInDegrees, "JWM");
 
 			hingeLabel.Text = "Hinge angle: " + e.HingeAngleInDegrees + " degrees";
 		}
 
-		void OnReset(object sender, System.EventArgs e)
+		void OnReset(object? sender, System.EventArgs e)
 		{
 			PanePriority.SelectedIndex = 0;
 			Pane1Length.Value = 0.5;

--- a/src/Controls/samples/Controls.Sample/Pages/OthersPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/OthersPage.xaml.cs
@@ -4,7 +4,7 @@ namespace Maui.Controls.Sample.Pages
 {
 	public partial class OthersPage
 	{
-		TestWindowOverlay overlay;
+		TestWindowOverlay? overlay;
 
 		public OthersPage()
 		{

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Android/AndroidEntryPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Android/AndroidEntryPage.xaml.cs
@@ -14,7 +14,7 @@ namespace Maui.Controls.Sample.Pages
 
 		void OnSelectedIndexChanged(object sender, EventArgs e)
 		{
-			ImeFlags flag = (ImeFlags)Enum.Parse(typeof(ImeFlags), _picker.SelectedItem.ToString());
+			ImeFlags flag = (ImeFlags)Enum.Parse(typeof(ImeFlags), _picker.SelectedItem.ToString()!);
 			_entry.On<Microsoft.Maui.Controls.PlatformConfiguration.Android>().SetImeOptions(flag);
 			_label.Text = $"ImeOptions: {_entry.On<Microsoft.Maui.Controls.PlatformConfiguration.Android>().ImeOptions()}";
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Android/AndroidSoftInputModeAdjustPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Android/AndroidSoftInputModeAdjustPage.xaml.cs
@@ -14,12 +14,12 @@ namespace Maui.Controls.Sample.Pages
 
 		void OnPanButtonClicked(object sender, EventArgs e)
 		{
-			Microsoft.Maui.Controls.Application.Current.On<Microsoft.Maui.Controls.PlatformConfiguration.Android>().UseWindowSoftInputModeAdjust(WindowSoftInputModeAdjust.Pan);
+			Microsoft.Maui.Controls.Application.Current!.On<Microsoft.Maui.Controls.PlatformConfiguration.Android>().UseWindowSoftInputModeAdjust(WindowSoftInputModeAdjust.Pan);
 		}
 
 		void OnResizeButtonClicked(object sender, EventArgs e)
 		{
-			Microsoft.Maui.Controls.Application.Current.On<Microsoft.Maui.Controls.PlatformConfiguration.Android>().UseWindowSoftInputModeAdjust(WindowSoftInputModeAdjust.Resize);
+			Microsoft.Maui.Controls.Application.Current!.On<Microsoft.Maui.Controls.PlatformConfiguration.Android>().UseWindowSoftInputModeAdjust(WindowSoftInputModeAdjust.Resize);
 		}
 	}
 }

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Android/AndroidSwipeViewTransitionModePage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Android/AndroidSwipeViewTransitionModePage.xaml.cs
@@ -16,7 +16,7 @@ namespace Maui.Controls.Sample.Pages
 
 		void OnSwipeViewTransitionModeChanged(object sender, EventArgs e)
 		{
-			SwipeTransitionMode transitionMode = (SwipeTransitionMode)(sender as EnumPicker).SelectedItem;
+			SwipeTransitionMode transitionMode = (SwipeTransitionMode)(sender as EnumPicker)!.SelectedItem;
 			swipeView.On<Microsoft.Maui.Controls.PlatformConfiguration.Android>().SetSwipeTransitionMode(transitionMode);
 		}
 

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Android/AndroidTabbedPageSwipePage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Android/AndroidTabbedPageSwipePage.xaml.cs
@@ -8,7 +8,7 @@ namespace Maui.Controls.Sample.Pages
 {
 	public partial class AndroidTabbedPageSwipePage : Microsoft.Maui.Controls.TabbedPage
 	{
-		ICommand _returnToPlatformSpecificsPage;
+		ICommand? _returnToPlatformSpecificsPage;
 
 		public AndroidTabbedPageSwipePage()
 		{

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Android/AndroidTitleViewPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Android/AndroidTitleViewPage.xaml.cs
@@ -6,7 +6,7 @@ namespace Maui.Controls.Sample.Pages
 {
 	public partial class AndroidTitleViewPage : ContentPage
 	{
-		readonly ICommand _returnToPlatformSpecificsPage;
+		readonly ICommand? _returnToPlatformSpecificsPage;
 
 		public AndroidTitleViewPage()
 		{

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Windows/WindowsAddRemoveToolbarItemsPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Windows/WindowsAddRemoveToolbarItemsPage.xaml.cs
@@ -14,7 +14,7 @@ namespace Maui.Controls.Sample.Pages
 			set { SetValue(ParentPageProperty, value); }
 		}
 
-		readonly Action _action;
+		readonly Action? _action;
 
 		public WindowsAddRemoveToolbarItemsPage()
 		{

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Windows/WindowsCollapseStyleChangerPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Windows/WindowsCollapseStyleChangerPage.xaml.cs
@@ -40,7 +40,7 @@ namespace Maui.Controls.Sample.Pages
 			if (newValue != null)
 			{
 				var enumType = typeof(CollapseStyle);
-				var instance = element as WindowsCollapseStyleChangerPage;
+				var instance = (element as WindowsCollapseStyleChangerPage)!;
 				instance.picker.SelectedIndex = Array.IndexOf(Enum.GetNames(enumType), Enum.GetName(enumType, instance.ParentPage.On<Microsoft.Maui.Controls.PlatformConfiguration.Windows>().GetCollapseStyle()));
 			}
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Windows/WindowsCollapseWidthAdjusterPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Windows/WindowsCollapseWidthAdjusterPage.xaml.cs
@@ -33,7 +33,7 @@ namespace Maui.Controls.Sample.Pages
 			if (newValue != null)
 			{
 				var instance = element as WindowsCollapseWidthAdjusterPage;
-				instance.entry.Text = instance.ParentPage.On<Microsoft.Maui.Controls.PlatformConfiguration.Windows>().CollapsedPaneWidth().ToString();
+				instance!.entry.Text = instance.ParentPage.On<Microsoft.Maui.Controls.PlatformConfiguration.Windows>().CollapsedPaneWidth().ToString();
 			}
 		}
 	}

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Windows/WindowsDragAndDropCustomization.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Windows/WindowsDragAndDropCustomization.xaml.cs
@@ -26,7 +26,7 @@ namespace Maui.Controls.Sample.Pages
 		void DropGestureRecognizer_DragOver(System.Object sender, Microsoft.Maui.Controls.DragEventArgs e)
 		{
 #if WINDOWS
-			var dragUI = e.PlatformArgs.DragEventArgs.DragUIOverride;
+			var dragUI = e.PlatformArgs!.DragEventArgs.DragUIOverride;
 			dragUI.IsCaptionVisible = ShowCaptionSwitch.IsToggled;
 			dragUI.IsGlyphVisible = ShowGlyphSwitch.IsToggled;
 			dragUI.IsContentVisible = ShowContentSwitch.IsToggled;

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Windows/WindowsPlatformSpecificsHelpers.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Windows/WindowsPlatformSpecificsHelpers.cs
@@ -55,7 +55,7 @@ namespace Maui.Controls.Sample.Pages
 		{
 			var enumType = typeof(ToolbarPlacement);
 
-			return CreateChanger(enumType, Enum.GetName(enumType, page.On<Microsoft.Maui.Controls.PlatformConfiguration.Windows>().GetToolbarPlacement()), picker =>
+			return CreateChanger(enumType, Enum.GetName(enumType, page.On<Microsoft.Maui.Controls.PlatformConfiguration.Windows>().GetToolbarPlacement())!, picker =>
 			{
 				page.On<Microsoft.Maui.Controls.PlatformConfiguration.Windows>().SetToolbarPlacement((ToolbarPlacement)Enum.Parse(enumType, picker.Items[picker.SelectedIndex]));
 			}, "Select Toolbar Placement");

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Windows/WindowsToolbarPlacementChangerPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Windows/WindowsToolbarPlacementChangerPage.xaml.cs
@@ -41,7 +41,7 @@ namespace Maui.Controls.Sample.Pages
 			{
 				var enumType = typeof(ToolbarPlacement);
 				var instance = element as WindowsToolbarPlacementChangerPage;
-				instance.picker.SelectedIndex = Array.IndexOf(Enum.GetNames(enumType), Enum.GetName(enumType, instance.ParentPage.On<Microsoft.Maui.Controls.PlatformConfiguration.Windows>().GetToolbarPlacement()));
+				instance!.picker.SelectedIndex = Array.IndexOf(Enum.GetNames(enumType), Enum.GetName(enumType, instance.ParentPage.On<Microsoft.Maui.Controls.PlatformConfiguration.Windows>().GetToolbarPlacement()));
 			}
 		}
 	}

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/iOS/iOSDragAndDropRequestFullSize.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/iOS/iOSDragAndDropRequestFullSize.xaml.cs
@@ -47,10 +47,10 @@ namespace Maui.Controls.Sample.Pages
 					funkyPath.ClosePath();
 					previewParameters.VisiblePath = funkyPath;
 
-					return new UIKit.UIDragPreview(e.PlatformArgs.Sender, previewParameters);
+					return new UIKit.UIDragPreview(e.PlatformArgs!.Sender!, previewParameters);
 				};
 
-				e.PlatformArgs.SetPreviewProvider(action);
+				e.PlatformArgs!.SetPreviewProvider(action);
 			}
 
 			else if (dotnetBotImageSwitch.IsToggled)
@@ -66,11 +66,11 @@ namespace Maui.Controls.Sample.Pages
 					return new UIKit.UIDragPreview(imageView);
 				};
 
-				e.PlatformArgs.SetPreviewProvider(action);
+				e.PlatformArgs!.SetPreviewProvider(action);
 			}
 
 
-			e.PlatformArgs.SetPrefersFullSizePreviews((interaction, session) => { return fullSizedSwitch.IsToggled; });
+			e.PlatformArgs!.SetPrefersFullSizePreviews((interaction, session) => { return fullSizedSwitch.IsToggled; });
 #endif
 		}
 
@@ -90,11 +90,11 @@ namespace Maui.Controls.Sample.Pages
 		{
 #if IOS || MACCATALYST
 			if (copySwitch.IsToggled)
-				e.PlatformArgs.SetDropProposal(new UIKit.UIDropProposal(UIKit.UIDropOperation.Copy));
+				e.PlatformArgs!.SetDropProposal(new UIKit.UIDropProposal(UIKit.UIDropOperation.Copy));
 			else if (moveSwitch.IsToggled)
-				e.PlatformArgs.SetDropProposal(new UIKit.UIDropProposal(UIKit.UIDropOperation.Move));
+				e.PlatformArgs!.SetDropProposal(new UIKit.UIDropProposal(UIKit.UIDropOperation.Move));
 			else if (forbiddenSwitch.IsToggled)
-				e.PlatformArgs.SetDropProposal(new UIKit.UIDropProposal(UIKit.UIDropOperation.Forbidden));
+				e.PlatformArgs!.SetDropProposal(new UIKit.UIDropProposal(UIKit.UIDropOperation.Forbidden));
 #endif
 		}
 

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/iOS/iOSPanGestureRecognizerPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/iOS/iOSPanGestureRecognizerPage.xaml.cs
@@ -16,8 +16,8 @@ namespace Maui.Controls.Sample.Pages
 
 		void OnButtonClicked(object sender, EventArgs e)
 		{
-			Microsoft.Maui.Controls.Application.Current.On<iOS>().SetPanGestureRecognizerShouldRecognizeSimultaneously(
-				!Microsoft.Maui.Controls.Application.Current.On<iOS>().GetPanGestureRecognizerShouldRecognizeSimultaneously());
+			Microsoft.Maui.Controls.Application.Current!.On<iOS>().SetPanGestureRecognizerShouldRecognizeSimultaneously(
+				!Microsoft.Maui.Controls.Application.Current!.On<iOS>().GetPanGestureRecognizerShouldRecognizeSimultaneously());
 		}
 
 		void OnPanUpdated(object sender, PanUpdatedEventArgs e)

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/iOS/iOSSafeAreaPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/iOS/iOSSafeAreaPage.xaml.cs
@@ -15,7 +15,7 @@ namespace Maui.Controls.Sample.Pages
 		void OnButtonClicked(object sender, EventArgs e)
 		{
 			On<iOS>().SetUseSafeArea(false);
-			(sender as Button).IsEnabled = false;
+			(sender as Button)!.IsEnabled = false;
 		}
 	}
 }

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/iOS/iOSSwipeViewTransitionModePage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/iOS/iOSSwipeViewTransitionModePage.xaml.cs
@@ -16,7 +16,7 @@ namespace Maui.Controls.Sample.Pages
 
 		void OnSwipeViewTransitionModeChanged(object sender, EventArgs e)
 		{
-			SwipeTransitionMode transitionMode = (SwipeTransitionMode)(sender as EnumPicker).SelectedItem;
+			SwipeTransitionMode transitionMode = (SwipeTransitionMode)(sender as EnumPicker)!.SelectedItem;
 			swipeView.On<iOS>().SetSwipeTransitionMode(transitionMode);
 		}
 

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/iOS/iOSTranslucentNavigationBarPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/iOS/iOSTranslucentNavigationBarPage.xaml.cs
@@ -18,7 +18,7 @@ namespace Maui.Controls.Sample.Pages
 
 		void OnTranslucentNavigationBarButtonClicked(object sender, EventArgs e)
 		{
-			(Microsoft.Maui.Controls.Application.Current.MainPage as Microsoft.Maui.Controls.NavigationPage).On<iOS>().SetIsNavigationBarTranslucent(!(Microsoft.Maui.Controls.Application.Current.MainPage as Microsoft.Maui.Controls.NavigationPage).On<iOS>().IsNavigationBarTranslucent());
+			(Microsoft.Maui.Controls.Application.Current!.MainPage as Microsoft.Maui.Controls.NavigationPage)!.On<iOS>().SetIsNavigationBarTranslucent(!(Microsoft.Maui.Controls.Application.Current!.MainPage as Microsoft.Maui.Controls.NavigationPage)!.On<iOS>().IsNavigationBarTranslucent());
 		}
 
 		void OnReturnButtonClicked(object sender, EventArgs e)

--- a/src/Controls/samples/Controls.Sample/Pages/SettingsPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/SettingsPage.xaml.cs
@@ -18,7 +18,7 @@ namespace Maui.Controls.Sample.Pages
 
 		void OnRTLToggled(object sender, ToggledEventArgs e)
 		{
-			var mainPage = Application.Current.MainPage;
+			var mainPage = Application.Current!.MainPage;
 
 			if (mainPage == null)
 				return;

--- a/src/Controls/samples/Controls.Sample/ViewModels/AndroidViewCellPageViewModel.cs
+++ b/src/Controls/samples/Controls.Sample/ViewModels/AndroidViewCellPageViewModel.cs
@@ -59,9 +59,9 @@ namespace Maui.Controls.Sample.ViewModels
 
 		#region INotifyPropertyChanged
 
-		public event PropertyChangedEventHandler PropertyChanged;
+		public event PropertyChangedEventHandler? PropertyChanged;
 
-		void OnPropertyChanged([CallerMemberName] string propertyName = null)
+		void OnPropertyChanged([CallerMemberName] string propertyName = "")
 		{
 			PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
 		}

--- a/src/Controls/samples/Controls.Sample/ViewModels/Base/BaseGalleryViewModel.cs
+++ b/src/Controls/samples/Controls.Sample/ViewModels/Base/BaseGalleryViewModel.cs
@@ -7,7 +7,7 @@ namespace Maui.Controls.Sample.ViewModels.Base
 {
 	public abstract class BaseGalleryViewModel : BaseViewModel
 	{
-		string _filterValue;
+		string? _filterValue;
 
 		public BaseGalleryViewModel()
 		{
@@ -19,9 +19,9 @@ namespace Maui.Controls.Sample.ViewModels.Base
 			Filter();
 		}
 
-		public IReadOnlyList<SectionModel> Items { get; }
+		public IReadOnlyList<SectionModel>? Items { get; }
 
-		public string FilterValue
+		public string? FilterValue
 		{
 			get { return _filterValue; }
 			set
@@ -38,7 +38,7 @@ namespace Maui.Controls.Sample.ViewModels.Base
 		void Filter()
 		{
 			FilterValue ??= string.Empty;
-			FilteredItems = string.IsNullOrEmpty(FilterValue) ? Items : Items.Where(item => item.Title.IndexOf(FilterValue, StringComparison.InvariantCultureIgnoreCase) >= 0);
+			FilteredItems = string.IsNullOrEmpty(FilterValue) ? Items! : Items!.Where(item => item.Title.IndexOf(FilterValue, StringComparison.InvariantCultureIgnoreCase) >= 0);
 			OnPropertyChanged(nameof(FilteredItems));
 		}
 	}

--- a/src/Controls/samples/Controls.Sample/ViewModels/Base/BaseViewModel.cs
+++ b/src/Controls/samples/Controls.Sample/ViewModels/Base/BaseViewModel.cs
@@ -9,7 +9,7 @@ namespace Maui.Controls.Sample.ViewModels.Base
 	{
 		protected bool SetProperty<T>(ref T backingStore, T value,
 		[CallerMemberName] string propertyName = "",
-		Action onChanged = null)
+		Action? onChanged = null)
 		{
 			if (EqualityComparer<T>.Default.Equals(backingStore, value))
 				return false;
@@ -22,7 +22,7 @@ namespace Maui.Controls.Sample.ViewModels.Base
 
 		#region INotifyPropertyChanged
 
-		public event PropertyChangedEventHandler PropertyChanged;
+		public event PropertyChangedEventHandler? PropertyChanged;
 		protected void OnPropertyChanged([CallerMemberName] string propertyName = "")
 		{
 			PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));

--- a/src/Controls/samples/Controls.Sample/ViewModels/LabelViewModel.cs
+++ b/src/Controls/samples/Controls.Sample/ViewModels/LabelViewModel.cs
@@ -4,12 +4,7 @@ namespace Maui.Controls.Sample.ViewModels
 {
 	public class LabelViewModel : BaseViewModel
 	{
-		string _htmlString;
-
-		public LabelViewModel()
-		{
-			HtmlString = "Html, &lt;b&gt;from ViewModel!&lt;/b&gt;";
-		}
+		string _htmlString = "Html, &lt;b&gt;from ViewModel!&lt;/b&gt;";
 
 		public string HtmlString
 		{

--- a/src/Controls/samples/Controls.Sample/ViewModels/RefreshViewModel.cs
+++ b/src/Controls/samples/Controls.Sample/ViewModels/RefreshViewModel.cs
@@ -77,9 +77,9 @@ namespace Maui.Controls.Sample.ViewModels
 
 		#region INotifyPropertyChanged
 
-		public event PropertyChangedEventHandler PropertyChanged;
+		public event PropertyChangedEventHandler? PropertyChanged;
 
-		void OnPropertyChanged([CallerMemberName] string propertyName = null)
+		void OnPropertyChanged([CallerMemberName] string propertyName = "")
 		{
 			PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
 		}

--- a/src/Controls/samples/Controls.Sample/ViewModels/WindowsRefreshViewPageViewModel.cs
+++ b/src/Controls/samples/Controls.Sample/ViewModels/WindowsRefreshViewPageViewModel.cs
@@ -61,9 +61,9 @@ namespace Maui.Controls.Sample.ViewModels
 
 		#region INotifyPropertyChanged
 
-		public event PropertyChangedEventHandler PropertyChanged;
+		public event PropertyChangedEventHandler? PropertyChanged;
 
-		void OnPropertyChanged([CallerMemberName] string propertyName = null)
+		void OnPropertyChanged([CallerMemberName] string propertyName = "")
 		{
 			PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
 		}

--- a/src/Controls/samples/Controls.Sample/XamlApp.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/XamlApp.xaml.cs
@@ -46,7 +46,7 @@ namespace Maui.Controls.Sample
 		}
 
 		// Must not use MainPage for multi-window
-		protected override Window CreateWindow(IActivationState activationState)
+		protected override Window CreateWindow(IActivationState? activationState)
 		{
 			var window = new MauiWindow(Services.GetRequiredService<Page>())
 			{


### PR DESCRIPTION
This was to see if anything particularly unexpected happens due to making the templates have Nullable=enable by looking to see what happens in relatively large/complex projects. The conclusion is that it all seems to be just fine.

Note: I tried my best to not change any _functionality_ or _behavior_ of the samples. That is, if something could have been `null` before this change, it still could be after the change. Aside from setting `<Nullable>enable</Nullable>` in Maui.Controls.Sample and Maui.Controls.Sample.Sandbox, I mostly just added annotations such as `?` and `!`.

BTW this is how it started when I enabled Nullable:

> ![image](https://github.com/dotnet/maui/assets/202643/f426346a-2160-42a5-997e-dad7b7c838cc)
