### PR TITLE
Added orientation property to slider

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Controls/SliderPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/SliderPage.xaml
@@ -6,76 +6,93 @@
     Title="Slider">
     <views:BasePage.Content>
         <ScrollView>
-        <VerticalStackLayout Margin="12" Spacing="6">
-            <Label Text="Default" Style="{StaticResource Headline}"/>
-            <Slider/>
-            <Label
-                Text="BackgroundColor"
-                Style="{StaticResource Headline}"/>
-            <Slider
-                BackgroundColor="Blue"/>
-            <Label
-                Text="Background"
-                Style="{StaticResource Headline}" />
-            <Slider>
-                <Slider.Background>
-                    <LinearGradientBrush EndPoint="1,0">
-                        <GradientStop Color="Yellow"
-                                      Offset="0.1" />
-                        <GradientStop Color="Green"
-                                      Offset="1.0" />
-                    </LinearGradientBrush>
-                </Slider.Background>
-            </Slider>
-            <Label Text="Minimum (5) and Maximum (15)" Style="{StaticResource Headline}"/>
-            <Slider x:Name="MinMaxSlider" Maximum="15" Minimum="5" ValueChanged="OnValueChanged"/>
-            <Label FontSize="Micro" Text="{Binding Source={x:Reference MinMaxSlider}, Path=Value}"/>
-            
-            <Label Text="Disabled" Style="{StaticResource Headline}"/>
-            <Slider IsEnabled="False"/>
+            <VerticalStackLayout Margin="12" Spacing="6">
+                <Label Text="Default" Style="{StaticResource Headline}"/>
+                <Slider/>
+                <Label
+                    Text="BackgroundColor"
+                    Style="{StaticResource Headline}"/>
+                <Slider
+                    BackgroundColor="Blue"/>
+                <Label
+                    Text="Background"
+                    Style="{StaticResource Headline}" />
+                <Slider>
+                    <Slider.Background>
+                        <LinearGradientBrush EndPoint="1,0">
+                            <GradientStop Color="Yellow"
+                                          Offset="0.1" />
+                            <GradientStop Color="Green"
+                                          Offset="1.0" />
+                        </LinearGradientBrush>
+                    </Slider.Background>
+                </Slider>
+                <Label Text="Minimum (5) and Maximum (15)" Style="{StaticResource Headline}"/>
+                <Slider x:Name="MinMaxSlider" Maximum="15" Minimum="5" ValueChanged="OnValueChanged"/>
+                <Label FontSize="Micro" Text="{Binding Source={x:Reference MinMaxSlider}, Path=Value}"/>
 
-            <Label Text="MinimumTrackColor=LightBlue" Style="{StaticResource Headline}"/>
-            <Slider MinimumTrackColor="LightBlue"/>
+                <Label Text="Disabled" Style="{StaticResource Headline}"/>
+                <Slider IsEnabled="False"/>
 
-            <Label Text="MaximumTrackColor=Pink" Style="{StaticResource Headline}"/>
-            <Slider MaximumTrackColor="Pink"/>
+                <Label Text="MinimumTrackColor=LightBlue" Style="{StaticResource Headline}"/>
+                <Slider MinimumTrackColor="LightBlue"/>
 
-            <Label Text="ThumbColor=Orange" Style="{StaticResource Headline}"/>
-            <Slider ThumbColor="Orange"/>
+                <Label Text="MaximumTrackColor=Pink" Style="{StaticResource Headline}"/>
+                <Slider MaximumTrackColor="Pink"/>
 
-            <Label Text="ThumbImageSource=thumb_image.png" Style="{StaticResource Headline}"/>
-            <Slider x:Name="ImageSlider" ThumbImageSource="thumb_image.png" />
-            <Button Text="Toggle Image" Clicked="ToggleImageSource" />
+                <Label Text="ThumbColor=Orange" Style="{StaticResource Headline}"/>
+                <Slider ThumbColor="Orange"/>
 
-            <Label Text="Custom Slider (Red MinimumTrackColor, Green MaximumTrackColor, Blue ThumbColor)" Style="{StaticResource Headline}"/>
-            <Slider MinimumTrackColor="Red" MaximumTrackColor="Green" ThumbColor="Blue"/>
-            <Label
-                Text="Dynamically update Slider"
-                Style="{StaticResource Headline}"/>
-            <Slider 
-                x:Name="DynamicSlider"
-                Minimum="0"
-                Maximum="10"
-                Value="5" 
-                ValueChanged="OnDynamicValueChanged"/>
-            <Label
-                x:Name="DynamicInfoLabel"
-                FontSize="9" />
-            <HorizontalStackLayout>
-                <Button
-                    Text="Update Minimum"
-                    Clicked="OnUpdateMinimumButtonClicked" />
-                <Button
-                    Text="Update Maximum"
-                    Clicked="OnUpdateMaximumButtonClicked" />
+                <Label Text="ThumbImageSource=thumb_image.png" Style="{StaticResource Headline}"/>
+                <Slider x:Name="ImageSlider" ThumbImageSource="thumb_image.png" />
+                <Button Text="Toggle Image" Clicked="ToggleImageSource" />
+
+                <Label Text="Custom Slider (Red MinimumTrackColor, Green MaximumTrackColor, Blue ThumbColor)" Style="{StaticResource Headline}"/>
+                <Slider MinimumTrackColor="Red" MaximumTrackColor="Green" ThumbColor="Blue"/>
+                <Label
+                    Text="Dynamically update Slider"
+                    Style="{StaticResource Headline}"/>
+                <Slider 
+                    x:Name="DynamicSlider"
+                    Minimum="0"
+                    Maximum="10"
+                    Value="5" 
+                    ValueChanged="OnDynamicValueChanged"/>
+                <Label
+                    x:Name="DynamicInfoLabel"
+                    FontSize="9" />
+                <HorizontalStackLayout>
+                    <Button
+                        Text="Update Minimum"
+                        Clicked="OnUpdateMinimumButtonClicked" />
+                    <Button
+                        Text="Update Maximum"
+                        Clicked="OnUpdateMaximumButtonClicked" />
                 </HorizontalStackLayout>
                 <Label
-                    Text="Edge case - Same Minimum, Maximum and Value"
-                    Style="{StaticResource Headline}"/>
+                Text="Edge case - Same Minimum, Maximum and Value"
+                Style="{StaticResource Headline}"/>
                 <Slider 
                     Maximum="100"
                     Minimum="100" 
                     Value="100" />
+
+                <VerticalStackLayout HeightRequest="150">
+                    <Label Text="Vertical at Start" HorizontalOptions="Start" Style="{StaticResource Headline}"/>
+                    <Slider HorizontalOptions="Start" Orientation="Vertical" WidthRequest="100" Margin="10,0,0,0" />
+                </VerticalStackLayout> 
+                <VerticalStackLayout HeightRequest="150">
+                    <Label Text="Vertical Centered" HorizontalOptions="Start" Style="{StaticResource Headline}"/>
+                    <Slider HorizontalOptions="Center" Orientation="Vertical" WidthRequest="100" Margin="10,0,0,0" />
+                </VerticalStackLayout>
+                <VerticalStackLayout HeightRequest="150">
+                    <Label Text="Vertical at End" HorizontalOptions="Start" Style="{StaticResource Headline}"/>
+                    <Slider HorizontalOptions="End" Orientation="Vertical" WidthRequest="100" Margin="10,0,0,0" />
+                </VerticalStackLayout>
+                <VerticalStackLayout HeightRequest="150">
+                    <Label Text="Vertical Fill" HorizontalOptions="Start" Style="{StaticResource Headline}"/>
+                    <Slider HorizontalOptions="Fill" Orientation="Vertical" WidthRequest="100" Margin="10,0,0,0" />
+                </VerticalStackLayout>
             </VerticalStackLayout>
         </ScrollView>
     </views:BasePage.Content>

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -63,6 +63,9 @@ Microsoft.Maui.Controls.PointerGestureRecognizer.PointerReleasedCommand.get -> S
 Microsoft.Maui.Controls.PointerGestureRecognizer.PointerReleasedCommand.set -> void
 Microsoft.Maui.Controls.PointerGestureRecognizer.PointerReleasedCommandParameter.get -> object!
 Microsoft.Maui.Controls.PointerGestureRecognizer.PointerReleasedCommandParameter.set -> void
+Microsoft.Maui.Controls.Slider.Orientation.get -> Microsoft.Maui.Controls.ItemsLayoutOrientation
+Microsoft.Maui.Controls.Slider.Orientation.set -> void
+override Microsoft.Maui.Controls.Slider.OnSizeAllocated(double width, double height) -> void
 static readonly Microsoft.Maui.Controls.KeyboardAccelerator.KeyProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.KeyboardAccelerator.ModifiersProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.DragGestureRecognizer.CanDragProperty -> Microsoft.Maui.Controls.BindableProperty!
@@ -138,6 +141,7 @@ override Microsoft.Maui.Controls.SearchBar.IsEnabledCore.get -> bool
 ~static readonly Microsoft.Maui.Controls.InputView.FontSizeProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.InputView.IsTextPredictionEnabledProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.InputView.SelectionLengthProperty -> Microsoft.Maui.Controls.BindableProperty
+~static readonly Microsoft.Maui.Controls.Slider.OrientationProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.WebView.UserAgentProperty -> Microsoft.Maui.Controls.BindableProperty
 ~virtual Microsoft.Maui.Controls.Platform.Compatibility.ShellItemRenderer.UpdateShellSectionIcon(Microsoft.Maui.Controls.ShellSection shellSection, Android.Views.IMenuItem menuItem) -> void
 ~virtual Microsoft.Maui.Controls.Platform.Compatibility.ShellItemRenderer.UpdateShellSectionTitle(Microsoft.Maui.Controls.ShellSection shellSection, Android.Views.IMenuItem menuItem) -> void
@@ -197,7 +201,6 @@ Microsoft.Maui.Controls.PlatformPointerEventArgs.Sender.get -> Android.Views.Vie
 ~static readonly Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTappedProperty -> Microsoft.Maui.Controls.BindableProperty
 Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTapped.get -> bool
 Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTapped.set -> void
-
 *REMOVED*~Microsoft.Maui.Controls.Editor.FontFamily.get -> string
 *REMOVED*~Microsoft.Maui.Controls.Editor.FontFamily.set -> void
 *REMOVED*Microsoft.Maui.Controls.Editor.CursorPosition.get -> int
@@ -210,7 +213,6 @@ Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTapped.set -> void
 *REMOVED*Microsoft.Maui.Controls.Editor.FontSize.set -> void
 *REMOVED*Microsoft.Maui.Controls.Editor.SelectionLength.get -> int
 *REMOVED*Microsoft.Maui.Controls.Editor.SelectionLength.set -> void
-
 *REMOVED*~Microsoft.Maui.Controls.SearchBar.FontFamily.get -> string
 *REMOVED*~Microsoft.Maui.Controls.SearchBar.FontFamily.set -> void
 *REMOVED*Microsoft.Maui.Controls.SearchBar.CursorPosition.get -> int
@@ -223,7 +225,6 @@ Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTapped.set -> void
 *REMOVED*Microsoft.Maui.Controls.SearchBar.FontSize.set -> void
 *REMOVED*Microsoft.Maui.Controls.SearchBar.SelectionLength.get -> int
 *REMOVED*Microsoft.Maui.Controls.SearchBar.SelectionLength.set -> void
-
 *REMOVED*~Microsoft.Maui.Controls.Entry.FontFamily.get -> string
 *REMOVED*~Microsoft.Maui.Controls.Entry.FontFamily.set -> void
 *REMOVED*Microsoft.Maui.Controls.Entry.CursorPosition.get -> int

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -72,6 +72,9 @@ Microsoft.Maui.Controls.PointerGestureRecognizer.PointerReleasedCommand.get -> S
 Microsoft.Maui.Controls.PointerGestureRecognizer.PointerReleasedCommand.set -> void
 Microsoft.Maui.Controls.PointerGestureRecognizer.PointerReleasedCommandParameter.get -> object!
 Microsoft.Maui.Controls.PointerGestureRecognizer.PointerReleasedCommandParameter.set -> void
+Microsoft.Maui.Controls.Slider.Orientation.get -> Microsoft.Maui.Controls.ItemsLayoutOrientation
+Microsoft.Maui.Controls.Slider.Orientation.set -> void
+override Microsoft.Maui.Controls.Slider.OnSizeAllocated(double width, double height) -> void
 static readonly Microsoft.Maui.Controls.KeyboardAccelerator.KeyProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.KeyboardAccelerator.ModifiersProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.DragGestureRecognizer.CanDragProperty -> Microsoft.Maui.Controls.BindableProperty!
@@ -157,6 +160,7 @@ override Microsoft.Maui.Controls.SearchBar.IsEnabledCore.get -> bool
 ~static readonly Microsoft.Maui.Controls.InputView.FontSizeProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.InputView.IsTextPredictionEnabledProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.InputView.SelectionLengthProperty -> Microsoft.Maui.Controls.BindableProperty
+~static readonly Microsoft.Maui.Controls.Slider.OrientationProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.WebView.UserAgentProperty -> Microsoft.Maui.Controls.BindableProperty
 *REMOVED*~Microsoft.Maui.Controls.OpenGLView.On<T>() -> Microsoft.Maui.Controls.IPlatformElementConfiguration<T, Microsoft.Maui.Controls.OpenGLView>
 *REMOVED*~Microsoft.Maui.Controls.OpenGLView.OnDisplay.get -> System.Action<Microsoft.Maui.Graphics.Rect>

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -71,6 +71,9 @@ Microsoft.Maui.Controls.PointerGestureRecognizer.PointerReleasedCommand.get -> S
 Microsoft.Maui.Controls.PointerGestureRecognizer.PointerReleasedCommand.set -> void
 Microsoft.Maui.Controls.PointerGestureRecognizer.PointerReleasedCommandParameter.get -> object!
 Microsoft.Maui.Controls.PointerGestureRecognizer.PointerReleasedCommandParameter.set -> void
+Microsoft.Maui.Controls.Slider.Orientation.get -> Microsoft.Maui.Controls.ItemsLayoutOrientation
+Microsoft.Maui.Controls.Slider.Orientation.set -> void
+override Microsoft.Maui.Controls.Slider.OnSizeAllocated(double width, double height) -> void
 static readonly Microsoft.Maui.Controls.KeyboardAccelerator.KeyProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.KeyboardAccelerator.ModifiersProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.DragGestureRecognizer.CanDragProperty -> Microsoft.Maui.Controls.BindableProperty!
@@ -153,6 +156,7 @@ override Microsoft.Maui.Controls.SearchBar.IsEnabledCore.get -> bool
 ~static readonly Microsoft.Maui.Controls.InputView.FontSizeProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.InputView.IsTextPredictionEnabledProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.InputView.SelectionLengthProperty -> Microsoft.Maui.Controls.BindableProperty
+~static readonly Microsoft.Maui.Controls.Slider.OrientationProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.WebView.UserAgentProperty -> Microsoft.Maui.Controls.BindableProperty
 *REMOVED*~Microsoft.Maui.Controls.OpenGLView.On<T>() -> Microsoft.Maui.Controls.IPlatformElementConfiguration<T, Microsoft.Maui.Controls.OpenGLView>
 *REMOVED*~Microsoft.Maui.Controls.OpenGLView.OnDisplay.get -> System.Action<Microsoft.Maui.Graphics.Rect>

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -51,6 +51,9 @@ Microsoft.Maui.Controls.InputView.FontSize.get -> double
 Microsoft.Maui.Controls.InputView.FontSize.set -> void
 Microsoft.Maui.Controls.InputView.SelectionLength.get -> int
 Microsoft.Maui.Controls.InputView.SelectionLength.set -> void
+Microsoft.Maui.Controls.Slider.Orientation.get -> Microsoft.Maui.Controls.ItemsLayoutOrientation
+Microsoft.Maui.Controls.Slider.Orientation.set -> void
+override Microsoft.Maui.Controls.Slider.OnSizeAllocated(double width, double height) -> void
 static Microsoft.Maui.Controls.Handlers.ShellItemHandler.MapTitle(Microsoft.Maui.Controls.Handlers.ShellItemHandler! handler, Microsoft.Maui.Controls.ShellItem! item) -> void
 static Microsoft.Maui.Controls.Handlers.ShellSectionHandler.MapTitle(Microsoft.Maui.Controls.Handlers.ShellSectionHandler! handler, Microsoft.Maui.Controls.ShellSection! item) -> void
 Microsoft.Maui.Controls.Handlers.Compatibility.ViewRenderer<TElement, TNativeView>.ViewRenderer(Microsoft.Maui.IPropertyMapper! mapper, Microsoft.Maui.CommandMapper? commandMapper = null) -> void
@@ -151,6 +154,7 @@ override Microsoft.Maui.Controls.SearchBar.IsEnabledCore.get -> bool
 ~static readonly Microsoft.Maui.Controls.InputView.FontSizeProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.InputView.IsTextPredictionEnabledProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.InputView.SelectionLengthProperty -> Microsoft.Maui.Controls.BindableProperty
+~static readonly Microsoft.Maui.Controls.Slider.OrientationProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.WebView.UserAgentProperty -> Microsoft.Maui.Controls.BindableProperty
 *REMOVED*~Microsoft.Maui.Controls.OpenGLView.On<T>() -> Microsoft.Maui.Controls.IPlatformElementConfiguration<T, Microsoft.Maui.Controls.OpenGLView>
 *REMOVED*~Microsoft.Maui.Controls.OpenGLView.OnDisplay.get -> System.Action<Microsoft.Maui.Graphics.Rect>
@@ -209,7 +213,6 @@ Microsoft.Maui.Controls.PlatformPointerEventArgs.Sender.get -> Microsoft.UI.Xaml
 ~static readonly Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTappedProperty -> Microsoft.Maui.Controls.BindableProperty
 Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTapped.get -> bool
 Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTapped.set -> void
-
 *REMOVED*~Microsoft.Maui.Controls.Editor.FontFamily.get -> string
 *REMOVED*~Microsoft.Maui.Controls.Editor.FontFamily.set -> void
 *REMOVED*Microsoft.Maui.Controls.Editor.CursorPosition.get -> int
@@ -222,7 +225,6 @@ Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTapped.set -> void
 *REMOVED*Microsoft.Maui.Controls.Editor.FontSize.set -> void
 *REMOVED*Microsoft.Maui.Controls.Editor.SelectionLength.get -> int
 *REMOVED*Microsoft.Maui.Controls.Editor.SelectionLength.set -> void
-
 *REMOVED*~Microsoft.Maui.Controls.SearchBar.FontFamily.get -> string
 *REMOVED*~Microsoft.Maui.Controls.SearchBar.FontFamily.set -> void
 *REMOVED*Microsoft.Maui.Controls.SearchBar.CursorPosition.get -> int
@@ -235,7 +237,6 @@ Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTapped.set -> void
 *REMOVED*Microsoft.Maui.Controls.SearchBar.FontSize.set -> void
 *REMOVED*Microsoft.Maui.Controls.SearchBar.SelectionLength.get -> int
 *REMOVED*Microsoft.Maui.Controls.SearchBar.SelectionLength.set -> void
-
 *REMOVED*~Microsoft.Maui.Controls.Entry.FontFamily.get -> string
 *REMOVED*~Microsoft.Maui.Controls.Entry.FontFamily.set -> void
 *REMOVED*Microsoft.Maui.Controls.Entry.CursorPosition.get -> int

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -51,6 +51,9 @@ Microsoft.Maui.Controls.PointerGestureRecognizer.PointerReleasedCommand.get -> S
 Microsoft.Maui.Controls.PointerGestureRecognizer.PointerReleasedCommand.set -> void
 Microsoft.Maui.Controls.PointerGestureRecognizer.PointerReleasedCommandParameter.get -> object!
 Microsoft.Maui.Controls.PointerGestureRecognizer.PointerReleasedCommandParameter.set -> void
+Microsoft.Maui.Controls.Slider.Orientation.get -> Microsoft.Maui.Controls.ItemsLayoutOrientation
+Microsoft.Maui.Controls.Slider.Orientation.set -> void
+override Microsoft.Maui.Controls.Slider.OnSizeAllocated(double width, double height) -> void
 static readonly Microsoft.Maui.Controls.KeyboardAccelerator.KeyProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.KeyboardAccelerator.ModifiersProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.DragGestureRecognizer.CanDragProperty -> Microsoft.Maui.Controls.BindableProperty!
@@ -119,6 +122,7 @@ override Microsoft.Maui.Controls.SearchBar.IsEnabledCore.get -> bool
 ~static readonly Microsoft.Maui.Controls.InputView.FontSizeProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.InputView.IsTextPredictionEnabledProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.InputView.SelectionLengthProperty -> Microsoft.Maui.Controls.BindableProperty
+~static readonly Microsoft.Maui.Controls.Slider.OrientationProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.WebView.UserAgentProperty -> Microsoft.Maui.Controls.BindableProperty
 *REMOVED*~Microsoft.Maui.Controls.OpenGLView.On<T>() -> Microsoft.Maui.Controls.IPlatformElementConfiguration<T, Microsoft.Maui.Controls.OpenGLView>
 *REMOVED*~Microsoft.Maui.Controls.OpenGLView.OnDisplay.get -> System.Action<Microsoft.Maui.Graphics.Rect>

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -49,6 +49,9 @@ Microsoft.Maui.Controls.PointerGestureRecognizer.PointerReleasedCommand.get -> S
 Microsoft.Maui.Controls.PointerGestureRecognizer.PointerReleasedCommand.set -> void
 Microsoft.Maui.Controls.PointerGestureRecognizer.PointerReleasedCommandParameter.get -> object!
 Microsoft.Maui.Controls.PointerGestureRecognizer.PointerReleasedCommandParameter.set -> void
+Microsoft.Maui.Controls.Slider.Orientation.get -> Microsoft.Maui.Controls.ItemsLayoutOrientation
+Microsoft.Maui.Controls.Slider.Orientation.set -> void
+override Microsoft.Maui.Controls.Slider.OnSizeAllocated(double width, double height) -> void
 static readonly Microsoft.Maui.Controls.KeyboardAccelerator.KeyProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.KeyboardAccelerator.ModifiersProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.DragGestureRecognizer.CanDragProperty -> Microsoft.Maui.Controls.BindableProperty!
@@ -142,6 +145,7 @@ override Microsoft.Maui.Controls.SearchBar.IsEnabledCore.get -> bool
 ~static readonly Microsoft.Maui.Controls.InputView.FontSizeProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.InputView.IsTextPredictionEnabledProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.InputView.SelectionLengthProperty -> Microsoft.Maui.Controls.BindableProperty
+~static readonly Microsoft.Maui.Controls.Slider.OrientationProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.WebView.UserAgentProperty -> Microsoft.Maui.Controls.BindableProperty
 *REMOVED*~Microsoft.Maui.Controls.OpenGLView.On<T>() -> Microsoft.Maui.Controls.IPlatformElementConfiguration<T, Microsoft.Maui.Controls.OpenGLView>
 *REMOVED*~Microsoft.Maui.Controls.OpenGLView.OnDisplay.get -> System.Action<Microsoft.Maui.Graphics.Rect>
@@ -171,7 +175,6 @@ Microsoft.Maui.Controls.PlatformPointerEventArgs
 ~static readonly Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTappedProperty -> Microsoft.Maui.Controls.BindableProperty
 Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTapped.get -> bool
 Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTapped.set -> void
-
 *REMOVED*~Microsoft.Maui.Controls.Editor.FontFamily.get -> string
 *REMOVED*~Microsoft.Maui.Controls.Editor.FontFamily.set -> void
 *REMOVED*Microsoft.Maui.Controls.Editor.CursorPosition.get -> int
@@ -184,7 +187,6 @@ Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTapped.set -> void
 *REMOVED*Microsoft.Maui.Controls.Editor.FontSize.set -> void
 *REMOVED*Microsoft.Maui.Controls.Editor.SelectionLength.get -> int
 *REMOVED*Microsoft.Maui.Controls.Editor.SelectionLength.set -> void
-
 *REMOVED*~Microsoft.Maui.Controls.SearchBar.FontFamily.get -> string
 *REMOVED*~Microsoft.Maui.Controls.SearchBar.FontFamily.set -> void
 *REMOVED*Microsoft.Maui.Controls.SearchBar.CursorPosition.get -> int
@@ -197,7 +199,6 @@ Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTapped.set -> void
 *REMOVED*Microsoft.Maui.Controls.SearchBar.FontSize.set -> void
 *REMOVED*Microsoft.Maui.Controls.SearchBar.SelectionLength.get -> int
 *REMOVED*Microsoft.Maui.Controls.SearchBar.SelectionLength.set -> void
-
 *REMOVED*~Microsoft.Maui.Controls.Entry.FontFamily.get -> string
 *REMOVED*~Microsoft.Maui.Controls.Entry.FontFamily.set -> void
 *REMOVED*Microsoft.Maui.Controls.Entry.CursorPosition.get -> int
@@ -210,4 +211,3 @@ Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTapped.set -> void
 *REMOVED*Microsoft.Maui.Controls.Entry.FontSize.set -> void
 *REMOVED*Microsoft.Maui.Controls.Entry.SelectionLength.get -> int
 *REMOVED*Microsoft.Maui.Controls.Entry.SelectionLength.set -> void
-

--- a/src/Controls/src/Core/Slider/Slider.cs
+++ b/src/Controls/src/Core/Slider/Slider.cs
@@ -53,12 +53,45 @@ namespace Microsoft.Maui.Controls
 		/// <summary>Bindable property for <see cref="DragCompletedCommand"/>.</summary>
 		public static readonly BindableProperty DragCompletedCommandProperty = BindableProperty.Create(nameof(DragCompletedCommand), typeof(ICommand), typeof(Slider), default(ICommand));
 
+		/// <summary>Bindable property for <see cref="Orientation"/>.</summary>
+		public static readonly BindableProperty OrientationProperty = BindableProperty.Create(nameof(Orientation), typeof(ItemsLayoutOrientation), typeof(Slider), ItemsLayoutOrientation.Horizontal, coerceValue: (bindable, value) =>
+		{
+			var slider = (Slider)bindable;
+			if ((ItemsLayoutOrientation)value == ItemsLayoutOrientation.Vertical)
+			{
+				slider.Rotation = -90;
+			}
+			return value;
+		});
+
 		readonly Lazy<PlatformConfigurationRegistry<Slider>> _platformConfigurationRegistry;
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/Slider.xml" path="//Member[@MemberName='.ctor'][1]/Docs/*" />
 		public Slider()
 		{
 			_platformConfigurationRegistry = new Lazy<PlatformConfigurationRegistry<Slider>>(() => new PlatformConfigurationRegistry<Slider>(this));
+		}
+
+		/// <summary>
+		/// If the orientation is set to <see cref="ItemsLayoutOrientation.Vertical"/>, the slider's position is translated to its original origin.
+		/// This is necessary because the rotation is performed in the middle of the slider./>
+		/// </summary>
+		/// <param name="width">The new width of the element.</param>
+		/// <param name="height">The new height of the element.</param>
+		protected override void OnSizeAllocated(double width, double height)
+		{
+			if (Orientation != ItemsLayoutOrientation.Vertical)
+			{
+				return;
+			}
+			if (HorizontalOptions == LayoutOptions.Start)
+			{
+				TranslationX = -width / 2;
+			}
+			if (HorizontalOptions == LayoutOptions.End)
+				TranslationX = width / 2;
+
+			TranslationY = height;
 		}
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/Slider.xml" path="//Member[@MemberName='.ctor'][2]/Docs/*" />
@@ -141,6 +174,16 @@ namespace Microsoft.Maui.Controls
 		{
 			get { return (double)GetValue(ValueProperty); }
 			set { SetValue(ValueProperty, value); }
+		}
+
+		/// <summary>
+		/// Orientation of the Slider that can be "Horizontal" or "Vertical" <see cref="ItemsLayoutOrientation"/>.
+		/// This is a bindable property.
+		/// </summary>
+		public ItemsLayoutOrientation Orientation
+		{
+			get { return (ItemsLayoutOrientation)GetValue(OrientationProperty); }
+			set { SetValue(OrientationProperty, value); }
 		}
 
 		public event EventHandler<ValueChangedEventArgs> ValueChanged;


### PR DESCRIPTION
### Description of Change

I added a bindable property to the slider to set its orientation, so the slider can be used also vertically. 
To adjust the sliders position depending on the `HorizontalOptions` I have also overwritten the `OnSizeAllocated` method. 

### Issues Fixed

The slider can now be used vertically.

This is demonstrated in the Maui.Controls.Sample project.

![image](https://github.com/dotnet/maui/assets/37597561/22938f04-ec4b-4ef0-824a-068c0d795291)

Fixes #2843
