### PR TITLE
Support finding nearest TFM to collect assets from

### DIFF
--- a/src/SingleProject/Resizetizer/src/nuget/buildTransitive/Microsoft.Maui.Resizetizer.After.targets
+++ b/src/SingleProject/Resizetizer/src/nuget/buildTransitive/Microsoft.Maui.Resizetizer.After.targets
@@ -256,28 +256,35 @@
         <CallTarget Targets="GetMauiItems" Condition="'$(ResizetizerIncludeSelfProject)' == 'True'">
             <Output
                 TaskParameter="TargetOutputs"
-                ItemName="ImportedMauiItem" />
+                ItemName="_ImportedMauiItem" />
         </CallTarget>
 
-        <!-- Invoke the GetMauiItems target on all project references -->
-        <!-- This will accumulate images into our MauiImage group -->
+        <!-- Invoke the GetMauiItems target on all project references. This will accumulate images into our MauiImage group -->
         <ItemGroup>
-            <ResizetizeCollectItemsProjectWithNTF Include="@(_ResolvedProjectReferencePaths->HasMetadata('NearestTargetFramework'))" />
-            <ResizetizeCollectItemsProject Include="@(ResizetizeCollectItemsProjectWithNTF->HasMetadata('OriginalProjectReferenceItemSpec'))" />
+            <!-- Filter out the items missing the OriginalProjectReferenceItemSpec because this is essential -->
+            <ResizetizeCollectItemsProjectWithOIS Include="@(_ResolvedProjectReferencePaths->HasMetadata('OriginalProjectReferenceItemSpec'))" />
+            <!-- Convert the Identity from the final assembly path to the ProjectReference -->
+            <ResizetizeCollectItemsProjectWithItemSpec Include="@(ResizetizeCollectItemsProjectWithOIS->'%(OriginalProjectReferenceItemSpec)')" />
+            <!-- Add the resolved references if and only if they have NearestTargetFramework defined -->
+            <ResizetizeCollectItemsProject Include="@(ResizetizeCollectItemsProjectWithItemSpec->HasMetadata('NearestTargetFramework'))" />
+            <!-- If any resolved paths were missing OriginalProjectReferenceItemSpec or NearestTargetFramework, fall back to the 
+                 previous functionality with using the ProjectReference items and the CURRENT project's TargetFramework -->
+            <ResizetizeCollectItemsProject Include="@(ProjectReference)" Exclude="@(ResizetizeCollectItemsProject)" NearestTargetFramework="$(TargetFramework)" />
         </ItemGroup>
         <MSBuild
             Targets="GetMauiItems"
-            Projects="%(ResizetizeCollectItemsProject.OriginalProjectReferenceItemSpec)"
+            Projects="%(ResizetizeCollectItemsProject.Identity)"
             BuildInParallel="true"
             Properties="TargetFramework=%(ResizetizeCollectItemsProject.NearestTargetFramework)"
             SkipNonexistentProjects="true"
             SkipNonexistentTargets="true">
             <Output
                 TaskParameter="TargetOutputs"
-                ItemName="ImportedMauiItem" />
+                ItemName="_ImportedMauiItem" />
         </MSBuild>
 
         <ItemGroup>
+            <ImportedMauiItem Include="@(_ImportedMauiItem)" />
             <MauiImage
                 Include="@(ImportedMauiItem)"
                 Condition="'%(ImportedMauiItem.ItemGroupName)' == 'MauiImage'" />

--- a/src/SingleProject/Resizetizer/src/nuget/buildTransitive/Microsoft.Maui.Resizetizer.After.targets
+++ b/src/SingleProject/Resizetizer/src/nuget/buildTransitive/Microsoft.Maui.Resizetizer.After.targets
@@ -262,20 +262,20 @@
         <!-- Invoke the GetMauiItems target on all project references. This will accumulate images into our MauiImage group -->
         <ItemGroup>
             <!-- Filter out the items missing the OriginalProjectReferenceItemSpec because this is essential -->
-            <ResizetizeCollectItemsProjectWithOIS Include="@(_ResolvedProjectReferencePaths->HasMetadata('OriginalProjectReferenceItemSpec'))" />
+            <_ResizetizeCollectItemsProjectWithOIS Include="@(_ResolvedProjectReferencePaths->HasMetadata('OriginalProjectReferenceItemSpec'))" />
             <!-- Convert the Identity from the final assembly path to the ProjectReference -->
-            <ResizetizeCollectItemsProjectWithItemSpec Include="@(ResizetizeCollectItemsProjectWithOIS->'%(OriginalProjectReferenceItemSpec)')" />
+            <_ResizetizeCollectItemsProjectWithItemSpec Include="@(_ResizetizeCollectItemsProjectWithOIS->'%(OriginalProjectReferenceItemSpec)')" />
             <!-- Add the resolved references if and only if they have NearestTargetFramework defined -->
-            <ResizetizeCollectItemsProject Include="@(ResizetizeCollectItemsProjectWithItemSpec->HasMetadata('NearestTargetFramework'))" />
+            <_ResizetizeCollectItemsProject Include="@(_ResizetizeCollectItemsProjectWithItemSpec->HasMetadata('NearestTargetFramework'))" />
             <!-- If any resolved paths were missing OriginalProjectReferenceItemSpec or NearestTargetFramework, fall back to the 
                  previous functionality with using the ProjectReference items and the CURRENT project's TargetFramework -->
-            <ResizetizeCollectItemsProject Include="@(ProjectReference)" Exclude="@(ResizetizeCollectItemsProject)" NearestTargetFramework="$(TargetFramework)" />
+            <_ResizetizeCollectItemsProject Include="@(ProjectReference)" Exclude="@(_ResizetizeCollectItemsProject)" NearestTargetFramework="$(TargetFramework)" />
         </ItemGroup>
         <MSBuild
             Targets="GetMauiItems"
-            Projects="%(ResizetizeCollectItemsProject.Identity)"
+            Projects="%(_ResizetizeCollectItemsProject.Identity)"
             BuildInParallel="true"
-            Properties="TargetFramework=%(ResizetizeCollectItemsProject.NearestTargetFramework)"
+            Properties="TargetFramework=%(_ResizetizeCollectItemsProject.NearestTargetFramework)"
             SkipNonexistentProjects="true"
             SkipNonexistentTargets="true">
             <Output

--- a/src/SingleProject/Resizetizer/src/nuget/buildTransitive/Microsoft.Maui.Resizetizer.After.targets
+++ b/src/SingleProject/Resizetizer/src/nuget/buildTransitive/Microsoft.Maui.Resizetizer.After.targets
@@ -261,12 +261,11 @@
 
         <!-- Invoke the GetMauiItems target on all project references -->
         <!-- This will accumulate images into our MauiImage group -->
-        <!--<MSBuild Targets="GetMauiItems" Projects="@(_MSBuildProjectReferenceExistent)">-->
         <MSBuild
             Targets="GetMauiItems"
-            Projects="@(ProjectReference)"
+            Projects="%(_ResolvedProjectReferencePaths.OriginalProjectReferenceItemSpec)"
             BuildInParallel="true"
-            Properties="TargetFramework=$(TargetFramework)"
+            Properties="TargetFramework=%(_ResolvedProjectReferencePaths.NearestTargetFramework)"
             SkipNonexistentProjects="true"
             SkipNonexistentTargets="true">
             <Output

--- a/src/SingleProject/Resizetizer/src/nuget/buildTransitive/Microsoft.Maui.Resizetizer.After.targets
+++ b/src/SingleProject/Resizetizer/src/nuget/buildTransitive/Microsoft.Maui.Resizetizer.After.targets
@@ -261,11 +261,15 @@
 
         <!-- Invoke the GetMauiItems target on all project references -->
         <!-- This will accumulate images into our MauiImage group -->
+        <ItemGroup>
+            <ResizetizeCollectItemsProjectWithNTF Include="@(_ResolvedProjectReferencePaths->HasMetadata('NearestTargetFramework'))" />
+            <ResizetizeCollectItemsProject Include="@(ResizetizeCollectItemsProjectWithNTF->HasMetadata('OriginalProjectReferenceItemSpec'))" />
+        </ItemGroup>
         <MSBuild
             Targets="GetMauiItems"
-            Projects="%(_ResolvedProjectReferencePaths.OriginalProjectReferenceItemSpec)"
+            Projects="%(ResizetizeCollectItemsProject.OriginalProjectReferenceItemSpec)"
             BuildInParallel="true"
-            Properties="TargetFramework=%(_ResolvedProjectReferencePaths.NearestTargetFramework)"
+            Properties="TargetFramework=%(ResizetizeCollectItemsProject.NearestTargetFramework)"
             SkipNonexistentProjects="true"
             SkipNonexistentTargets="true">
             <Output

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/ResizetizerTests.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/ResizetizerTests.cs
@@ -1,0 +1,96 @@
+using Microsoft.Maui.IntegrationTests.Apple;
+
+namespace Microsoft.Maui.IntegrationTests;
+
+public class ResizetizerTests : BaseBuildTest
+{
+	const string BlankSvgContents =
+		"""
+		<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+		<svg width="456" height="456" viewBox="0 0 456 456" version="1.1" xmlns="http://www.w3.org/2000/svg">
+			<rect x="0" y="0" width="456" height="456" fill="#512BD4" />
+		</svg>
+		""";
+
+	[Test]
+	// windows unpackaged/exe
+	[TestCase("maui", "classlib", true)] // net8.0
+	[TestCase("maui", "mauilib", true)] // net8.0-xxx
+	[TestCase("maui-blazor", "classlib", true)] // net8.0
+	[TestCase("maui-blazor", "mauilib", true)] // net8.0-xxx
+	// windows packaged/msix
+	[TestCase("maui", "classlib", false)] // net8.0
+	[TestCase("maui", "mauilib", false)] // net8.0-xxx
+	[TestCase("maui-blazor", "classlib", false)] // net8.0
+	[TestCase("maui-blazor", "mauilib", false)] // net8.0-xxx
+	public void CollectsAssets(string id, string libid, bool unpackaged)
+	{
+		// new app
+		var appDir = Path.Combine(TestDirectory, "theapp");
+		var appFile = Path.Combine(appDir, $"{Path.GetFileName(appDir)}.csproj");
+		Assert.IsTrue(DotnetInternal.New(id, appDir, DotNetCurrent),
+			$"Unable to create template {id}. Check test output for errors.");
+
+		// new lib
+		var libDir = Path.Combine(TestDirectory, "thelib");
+		var libFile = Path.Combine(libDir, $"{Path.GetFileName(libDir)}.csproj");
+		Assert.IsTrue(DotnetInternal.New(libid, libDir, DotNetCurrent),
+			$"Unable to create template {libid}. Check test output for errors.");
+
+		// add a project reference
+		FileUtilities.ReplaceInFile(appFile,
+			"</Project>",
+			"""
+			<ItemGroup>
+				<ProjectReference Include="..\thelib\thelib.csproj" />
+			</ItemGroup>
+			</Project>
+			""");
+
+		// toggle packaged / unpackaged
+		if (unpackaged)
+		{
+			FileUtilities.ReplaceInFile(appFile,
+				"</Project>",
+				"""
+				<PropertyGroup>
+					<WindowsPackageType>None</WindowsPackageType>
+				</PropertyGroup>
+				</Project>
+				""");
+
+		}
+
+		// add the svg file
+		File.WriteAllText(Path.Combine(libDir, "the_image.svg"), BlankSvgContents);
+
+		// add the <MauiImage>
+		FileUtilities.ReplaceInFile(libFile,
+			"</Project>",
+			"""
+			<PropertyGroup>
+				<UseMaui>true</UseMaui>
+				<SingleProject>true</SingleProject>
+			</PropertyGroup>
+			<ItemGroup>
+				<MauiImage Include="the_image.svg" />
+			</ItemGroup>
+			</Project>
+			""");
+
+		// build
+		Assert.IsTrue(DotnetInternal.Build(appFile, "Debug", properties: BuildProps),
+			$"Project {Path.GetFileName(appFile)} failed to build. Check test output/attachments for errors.");
+
+		// assert
+		Assert.True(File.Exists(Path.Combine(appDir, $"obj\\Debug\\{DotNetCurrent}-android\\resizetizer\\r\\drawable-mdpi\\the_image.png")),
+			"Android was missing the image file.");
+		Assert.True(File.Exists(Path.Combine(appDir, $"obj\\Debug\\{DotNetCurrent}-ios\\iossimulator-x64\\resizetizer\\r\\the_image.png")),
+			"iOS was missing the image file.");
+		Assert.True(File.Exists(Path.Combine(appDir, $"obj\\Debug\\{DotNetCurrent}-maccatalyst\\maccatalyst-x64\\resizetizer\\r\\the_image.png")),
+			"Mac Catalyst was missing the image file.");
+		if (TestEnvironment.IsWindows)
+			Assert.True(File.Exists(Path.Combine(appDir, $"obj\\Debug\\{DotNetCurrent}-windows10.0.19041.0\\win10-x64\\resizetizer\\r\\the_image.scale-100.png")),
+				"Windows was missing the image file.");
+	}
+}


### PR DESCRIPTION
### Description of Change

When building a maui app that references a maui class library with assets, only the exact match of the TFMs will be used. This PR adds support for falling back to the nearest match. The same TFM used in a project reference will also be used for the assets.

In the scenario:
* App: net8.0-windows;net8.0-android
* Library: net8.0;net8.0-android

Before:
 * Windows: only the assets from the app project
 * Android: assets from both

After:
 * Windows: assets from both
 * Android: assets from both


Implementation was based on these docs: https://github.com/dotnet/msbuild/blob/main/documentation/ProjectReference-Protocol.md

