### PR TITLE
Force ShapeHandler to exist when adding shape to border

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Border/BorderTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Border/BorderTests.cs
@@ -88,32 +88,6 @@ namespace Microsoft.Maui.DeviceTests
 		}
 #endif
 
-		[Fact(DisplayName = "Rounded Rectangle Has Handler")]
-		public async Task RoundedRectangleHasHandler()
-		{
-			Color stroke = Colors.Black;
-			const int strokeThickness = 4;
-			const int radius = 20;
-
-			var shape = new RoundRectangle()
-			{
-				CornerRadius = new CornerRadius(radius),
-			};
-
-			var border = new Border()
-			{
-				StrokeShape = shape,
-				Stroke = stroke,
-				StrokeThickness = strokeThickness,
-				BackgroundColor = Colors.Red,
-			};
-
-			await CreateHandlerAsync<BorderHandler>(border);
-
-			Assert.NotNull(border.Handler);
-			Assert.NotNull(shape.Handler);
-		}
-
 		[Fact(DisplayName = "Rounded Rectangle Border occupies correct space")]
 		public async Task RoundedRectangleBorderLayoutIsCorrect()
 		{

--- a/src/Controls/tests/DeviceTests/Elements/Border/BorderTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Border/BorderTests.cs
@@ -7,6 +7,7 @@ using Microsoft.Maui.DeviceTests.ImageAnalysis;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Hosting;
+using Microsoft.Maui.Platform;
 using Xunit;
 
 namespace Microsoft.Maui.DeviceTests
@@ -86,6 +87,32 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.Equal(180, innerBlob.Height, 2d);
 		}
 #endif
+
+		[Fact(DisplayName = "Rounded Rectangle Has Handler")]
+		public async Task RoundedRectangleHasHandler()
+		{
+			Color stroke = Colors.Black;
+			const int strokeThickness = 4;
+			const int radius = 20;
+
+			var shape = new RoundRectangle()
+			{
+				CornerRadius = new CornerRadius(radius),
+			};
+
+			var border = new Border()
+			{
+				StrokeShape = shape,
+				Stroke = stroke,
+				StrokeThickness = strokeThickness,
+				BackgroundColor = Colors.Red,
+			};
+
+			await CreateHandlerAsync<BorderHandler>(border);
+
+			Assert.NotNull(border.Handler);
+			Assert.NotNull(shape.Handler);
+		}
 
 		[Fact(DisplayName = "Rounded Rectangle Border occupies correct space")]
 		public async Task RoundedRectangleBorderLayoutIsCorrect()

--- a/src/Core/src/Handlers/Border/BorderHandler.Android.cs
+++ b/src/Core/src/Handlers/Border/BorderHandler.Android.cs
@@ -43,6 +43,9 @@ namespace Microsoft.Maui.Handlers
 
 			if (handler.VirtualView.PresentedContent is IView view)
 				handler.PlatformView.AddView(view.ToPlatform(handler.MauiContext));
+
+			if (handler.VirtualView.Shape is IView shapeView && shapeView.Handler is null)
+				shapeView.ToHandler(handler.MauiContext);
 		}
 
 		public static partial void MapHeight(IBorderHandler handler, IBorderView border)

--- a/src/Core/src/Handlers/Border/BorderHandler.Windows.cs
+++ b/src/Core/src/Handlers/Border/BorderHandler.Windows.cs
@@ -25,6 +25,12 @@ namespace Microsoft.Maui.Handlers
 
 			if (handler.VirtualView.PresentedContent is IView view)
 				handler.PlatformView.Content = view.ToPlatform(handler.MauiContext);
+
+			if (handler.VirtualView.Shape is IView shapeView)
+			{
+				var platformShape = shapeView.ToPlatform(handler.MauiContext);
+				platformShape.XamlRoot = handler.PlatformView.XamlRoot;
+			}
 		}
 
 		protected override ContentPanel CreatePlatformView()

--- a/src/Core/src/Handlers/Border/BorderHandler.iOS.cs
+++ b/src/Core/src/Handlers/Border/BorderHandler.iOS.cs
@@ -59,6 +59,9 @@ namespace Microsoft.Maui.Handlers
 				platformContent.Tag = ContentView.ContentTag;
 				platformView.AddSubview(platformContent);
 			}
+
+			if (handler.VirtualView.Shape is IView shapeView && shapeView.Handler is null)
+				shapeView.ToHandler(handler.MauiContext);
 		}
 
 		public override void PlatformArrange(Rect rect)

--- a/src/Core/src/Platform/Windows/ViewExtensions.cs
+++ b/src/Core/src/Platform/Windows/ViewExtensions.cs
@@ -324,7 +324,11 @@ namespace Microsoft.Maui.Platform
 			if (platformView == null)
 				return new Rect();
 
-			var rootView = platformView.XamlRoot.Content;
+			var rootView = platformView.XamlRoot?.Content;
+
+			if (rootView is null)
+				return new Rect();
+
 			if (platformView == rootView)
 			{
 				if (rootView is not FrameworkElement el)


### PR DESCRIPTION
### Description of Change

TL;DR: If a border has an attached Shape and the shape handler is null, fire a `ToHandler` or `ToPlatform` to force it to exist. This will then let the underlying APIs that assume the handler to exist to work.

When Shapes are added as part of another item (Ex. Border), the handlers are never fired. The shapes themselves do exist and in .NET 8, with our recent changes to LogicalChildren, they now (correctly) appear as underlying elements. But because the handlers are null, any tooling that touches them will explode. Handlers should, as far as I can tell, always exist on a given element after they are created. These shapes are created, but the handlers are never attached.

This PR attempts to force that to happen. Whenever the border gets created, if a shape is attached as is null, it will force it to exist. This should fix Visual Diagnostic tooling and others who depend on it.

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/18070
Fixes https://github.com/dotnet/maui/issues/16919

Fixes #

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
