### PR TITLE
[net8.0] Update CoherentParentDependency

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,10 +1,10 @@
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.Dotnet.Sdk.Internal" Version="8.0.100-rtm.23513.4">
+    <Dependency Name="Microsoft.Dotnet.Sdk.Internal" Version="8.0.100-rtm.23513.4" >
       <Uri>https://github.com/dotnet/installer</Uri>
       <Sha>c65382f00216756e0fb192cc2fd6513448d2679d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="8.0.0-rtm.23511.16">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="8.0.0-rtm.23511.16"  CoherentParentDependency="Microsoft.AspNetCore.Components.Web">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>256bf22a3ddf920516752701da2b95e1847ff708</Sha>
     </Dependency>
@@ -35,7 +35,7 @@
     <Dependency Name="Microsoft.WindowsAppSDK" Version="0.0.1">
       <Uri>https://dev.azure.com/microsoft/ProjectReunion/_git/ProjectReunionInternal</Uri>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authorization" Version="8.0.0-rtm.23512.7">
+    <Dependency Name="Microsoft.AspNetCore.Authorization" Version="8.0.0-rtm.23512.7" >
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
       <Sha>b5bb62782261908880f9755bc9478a914a2c4953</Sha>
     </Dependency>
@@ -95,47 +95,47 @@
       <Uri>https://github.com/dotnet/xharness</Uri>
       <Sha>02098f6cf81169134770ee47acc2aca0910635bb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration" Version="8.0.0-rtm.23511.16">
+    <Dependency Name="Microsoft.Extensions.Configuration" Version="8.0.0-rtm.23511.16"  CoherentParentDependency="Microsoft.AspNetCore.Components.Web">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>256bf22a3ddf920516752701da2b95e1847ff708</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0-rtm.23511.16">
+    <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0-rtm.23511.16"  CoherentParentDependency="Microsoft.AspNetCore.Components.Web">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>256bf22a3ddf920516752701da2b95e1847ff708</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Json" Version="8.0.0-rtm.23511.16">
+    <Dependency Name="Microsoft.Extensions.Configuration.Json" Version="8.0.0-rtm.23511.16" CoherentParentDependency="Microsoft.AspNetCore.Components.Web">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>256bf22a3ddf920516752701da2b95e1847ff708</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="8.0.0-rtm.23511.16">
+    <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="8.0.0-rtm.23511.16" CoherentParentDependency="Microsoft.AspNetCore.Components.Web" >
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>256bf22a3ddf920516752701da2b95e1847ff708</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0-rtm.23511.16">
+    <Dependency Name="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0-rtm.23511.16" CoherentParentDependency="Microsoft.AspNetCore.Components.Web">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>256bf22a3ddf920516752701da2b95e1847ff708</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.FileProviders.Abstractions" Version="8.0.0-rtm.23511.16">
+    <Dependency Name="Microsoft.Extensions.FileProviders.Abstractions" Version="8.0.0-rtm.23511.16" CoherentParentDependency="Microsoft.AspNetCore.Components.Web">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>256bf22a3ddf920516752701da2b95e1847ff708</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0-rtm.23511.16">
+    <Dependency Name="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0-rtm.23511.16" CoherentParentDependency="Microsoft.AspNetCore.Components.Web">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>256bf22a3ddf920516752701da2b95e1847ff708</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging" Version="8.0.0-rtm.23511.16">
+    <Dependency Name="Microsoft.Extensions.Logging" Version="8.0.0-rtm.23511.16" CoherentParentDependency="Microsoft.AspNetCore.Components.Web">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>256bf22a3ddf920516752701da2b95e1847ff708</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Console" Version="8.0.0-rtm.23511.16">
+    <Dependency Name="Microsoft.Extensions.Logging.Console" Version="8.0.0-rtm.23511.16" CoherentParentDependency="Microsoft.AspNetCore.Components.Web">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>256bf22a3ddf920516752701da2b95e1847ff708</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Debug" Version="8.0.0-rtm.23511.16">
+    <Dependency Name="Microsoft.Extensions.Logging.Debug" Version="8.0.0-rtm.23511.16" CoherentParentDependency="Microsoft.AspNetCore.Components.Web">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>256bf22a3ddf920516752701da2b95e1847ff708</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Primitives" Version="8.0.0-rtm.23511.16">
+    <Dependency Name="Microsoft.Extensions.Primitives" Version="8.0.0-rtm.23511.16" CoherentParentDependency="Microsoft.AspNetCore.Components.Web">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>256bf22a3ddf920516752701da2b95e1847ff708</Sha>
     </Dependency>


### PR DESCRIPTION
### Description of Change

When we get maestro aspnet updates https://github.com/dotnet/maui/pull/18079 normally they are out of sync from the runtime.

``` 
D:\a\_work\1\s\src\Controls\samples\Controls.Sample\Maui.Controls.Sample.csproj : error NU1605: Warning As Error: Detected package downgrade: Microsoft.Extensions.DependencyInjection from 8.0.0-rtm.23513.17 to 8.0.0-rtm.23511.16. Reference the package directly from the project to select a different version.  [D:\a\_work\1\s\Microsoft.Maui.sln]
D:\a\_work\1\s\src\Controls\samples\Controls.Sample\Maui.Controls.Sample.csproj : error NU1605:  Maui.Controls.Sample -> MauiRazorClassLibrarySample -> Microsoft.AspNetCore.Components.Web 8.0.0-rtm.23516.6 -> Microsoft.Extensions.DependencyInjection (>= 8.0.0-rtm.23513.17)  [D:\a\_work\1\s\Microsoft.Maui.sln]
```

This change tries to fix the issue ... 

The problem is it doesn't seem to work

```
C:\repos\dotnet\maui> darc update-dependencies --channel '.NET 8' --coherency-only
Checking for coherency updates...
Using 'Strict' coherency mode. If this fails, a second attempt utilizing 'Legacy' Coherency mode will be made.
Found no dependencies to update.
PS C:\repos\dotnet\maui> darc update-dependencies --channel '.NET 8.0.1xx SDK' --coherency-only
Checking for coherency updates...
Using 'Strict' coherency mode. If this fails, a second attempt utilizing 'Legacy' Coherency mode will be made.
Found no dependencies to update.
PS C:\repos\dotnet\maui>
```