### PR TITLE
Setup legacy mappers

### DIFF
--- a/src/Controls/src/Core/Application/Application.Mapper.cs
+++ b/src/Controls/src/Core/Application/Application.Mapper.cs
@@ -1,5 +1,6 @@
 ﻿#nullable disable
 using System;
+using Microsoft.Maui.Controls.Compatibility;
 
 namespace Microsoft.Maui.Controls
 {
@@ -7,7 +8,7 @@ namespace Microsoft.Maui.Controls
 	{
 		[Obsolete("Use ApplicationHandler.Mapper instead.")]
 		public static IPropertyMapper<IApplication, ApplicationHandler> ControlsApplicationMapper =
-			new PropertyMapper<Application, ApplicationHandler>(ApplicationHandler.Mapper);
+			new ControlsMapper<Application, ApplicationHandler>(ApplicationHandler.Mapper);
 
 		internal static new void RemapForControls()
 		{

--- a/src/Controls/src/Core/Button/Button.Mapper.cs
+++ b/src/Controls/src/Core/Button/Button.Mapper.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using Microsoft.Maui.Controls.Compatibility;
 using Microsoft.Maui.Controls.Platform;
 using Microsoft.Maui.Handlers;
 
@@ -15,7 +16,7 @@ namespace Microsoft.Maui.Controls
 		/// The property mapper that maps the abstract properties to the platform-specific methods for further processing.
 		/// </summary>
 		[Obsolete("Use ButtonHandler.Mapper instead.")]
-		public static IPropertyMapper<IButton, ButtonHandler> ControlsButtonMapper = new PropertyMapper<Button, ButtonHandler>(ButtonHandler.Mapper);
+		public static IPropertyMapper<IButton, ButtonHandler> ControlsButtonMapper = new ControlsMapper<Button, ButtonHandler>(ButtonHandler.Mapper);
 
 		internal new static void RemapForControls()
 		{

--- a/src/Controls/src/Core/Compatibility/ControlsMapper.cs
+++ b/src/Controls/src/Core/Compatibility/ControlsMapper.cs
@@ -40,25 +40,5 @@ namespace Microsoft.Maui.Controls.Compatibility
 		{
 			_propertyMapper.UpdateProperty(elementHandler, virtualView, property);
 		}
-
-		/*protected override void SetPropertyCore(string key, Action<IElementHandler, IElement> action)
-		{
-			_propertyMapper.ReplaceMapping(key, action);
-		}
-
-		public override Action<IElementHandler, IElement>? GetProperty(string key)
-		{
-			return _propertyMapper?.GetProperty(key);
-		}
-
-		public override IEnumerable<string> GetKeys()
-		{
-			return _propertyMapper.GetKeys();
-		}
-
-		protected override void UpdatePropertyCore(string key, IElementHandler viewHandler, IElement virtualView)
-		{
-			_propertyMapper.UpdateProperty(viewHandler, virtualView, key);
-		}*/
 	}
 }

--- a/src/Controls/src/Core/Compatibility/ControlsMapper.cs
+++ b/src/Controls/src/Core/Compatibility/ControlsMapper.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Maui.Controls.Compatibility
+{
+	[Obsolete("Delete this for .NET9")]
+	class ControlsMapper<TVirtualView, TViewHandler> : IPropertyMapper<TVirtualView, TViewHandler>
+			where TVirtualView : IElement
+			where TViewHandler : IElementHandler
+	{
+		IPropertyMapper<IElement, IElementHandler> _propertyMapper;
+
+		public ControlsMapper(IPropertyMapper<IElement, IElementHandler> propertyMapper) : base()
+		{
+			_propertyMapper = propertyMapper;
+		}
+
+		public void Add(string key, Action<TViewHandler, TVirtualView> action)
+		{
+			_propertyMapper.ReplaceMapping(key, action);
+		}
+
+		public IEnumerable<string> GetKeys()
+		{
+			return _propertyMapper.GetKeys();
+		}
+
+		public Action<IElementHandler, IElement>? GetProperty(string key)
+		{
+			return _propertyMapper.GetProperty(key);
+		}
+
+		public void UpdateProperties(IElementHandler elementHandler, IElement virtualView)
+		{
+			_propertyMapper.UpdateProperties(elementHandler, virtualView);
+		}
+
+		public void UpdateProperty(IElementHandler elementHandler, IElement virtualView, string property)
+		{
+			_propertyMapper.UpdateProperty(elementHandler, virtualView, property);
+		}
+
+		/*protected override void SetPropertyCore(string key, Action<IElementHandler, IElement> action)
+		{
+			_propertyMapper.ReplaceMapping(key, action);
+		}
+
+		public override Action<IElementHandler, IElement>? GetProperty(string key)
+		{
+			return _propertyMapper?.GetProperty(key);
+		}
+
+		public override IEnumerable<string> GetKeys()
+		{
+			return _propertyMapper.GetKeys();
+		}
+
+		protected override void UpdatePropertyCore(string key, IElementHandler viewHandler, IElement virtualView)
+		{
+			_propertyMapper.UpdateProperty(viewHandler, virtualView, key);
+		}*/
+	}
+}

--- a/src/Controls/src/Core/DatePicker/DatePicker.Mapper.cs
+++ b/src/Controls/src/Core/DatePicker/DatePicker.Mapper.cs
@@ -1,12 +1,13 @@
 ﻿#nullable disable
 using System;
+using Microsoft.Maui.Controls.Compatibility;
 
 namespace Microsoft.Maui.Controls
 {
 	public partial class DatePicker
 	{
 		[Obsolete("Use DatePickerHandler.Mapper instead.")]
-		public static IPropertyMapper<IDatePicker, DatePickerHandler> ControlsDatePickerMapper = new PropertyMapper<DatePicker, DatePickerHandler>(DatePickerHandler.Mapper);
+		public static IPropertyMapper<IDatePicker, DatePickerHandler> ControlsDatePickerMapper = new ControlsMapper<DatePicker, DatePickerHandler>(DatePickerHandler.Mapper);
 
 		internal static new void RemapForControls()
 		{

--- a/src/Controls/src/Core/Editor/Editor.Mapper.cs
+++ b/src/Controls/src/Core/Editor/Editor.Mapper.cs
@@ -1,5 +1,6 @@
 ﻿#nullable disable
 using System;
+using Microsoft.Maui.Controls.Compatibility;
 
 namespace Microsoft.Maui.Controls
 {
@@ -7,7 +8,7 @@ namespace Microsoft.Maui.Controls
 	{
 		[Obsolete("Use EditorHandler.Mapper instead.")]
 		public static IPropertyMapper<IEditor, EditorHandler> ControlsEditorMapper =
-			new PropertyMapper<Editor, EditorHandler>(EditorHandler.Mapper);
+			new ControlsMapper<Editor, EditorHandler>(EditorHandler.Mapper);
 
 		internal static new void RemapForControls()
 		{

--- a/src/Controls/src/Core/Element/Element.Mapper.cs
+++ b/src/Controls/src/Core/Element/Element.Mapper.cs
@@ -1,6 +1,7 @@
 #nullable disable
 using System;
 using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Controls.Compatibility;
 
 
 namespace Microsoft.Maui.Controls
@@ -11,7 +12,7 @@ namespace Microsoft.Maui.Controls
 		/// Maps UI information to platform-specific implementations for accessibility services
 		/// </summary>
 		[Obsolete("Use ViewHandler.ViewMapper instead.")]
-		public static IPropertyMapper<Maui.IElement, IElementHandler> ControlsElementMapper = new PropertyMapper<IElement, IElementHandler>(ViewHandler.ViewMapper);
+		public static IPropertyMapper<Maui.IElement, IElementHandler> ControlsElementMapper = new ControlsMapper<IElement, IElementHandler>(ViewHandler.ViewMapper);
 
 		internal static void RemapForControls()
 		{

--- a/src/Controls/src/Core/Entry/Entry.Mapper.cs
+++ b/src/Controls/src/Core/Entry/Entry.Mapper.cs
@@ -1,5 +1,6 @@
 ﻿#nullable disable
 using System;
+using Microsoft.Maui.Controls.Compatibility;
 
 namespace Microsoft.Maui.Controls
 {
@@ -7,7 +8,7 @@ namespace Microsoft.Maui.Controls
 	{
 		[Obsolete("Use EntryHandler.Mapper instead.")]
 		public static IPropertyMapper<IEntry, EntryHandler> ControlsEntryMapper =
-			new PropertyMapper<Entry, EntryHandler>(EntryHandler.Mapper);
+			new ControlsMapper<Entry, EntryHandler>(EntryHandler.Mapper);
 
 		internal static new void RemapForControls()
 		{

--- a/src/Controls/src/Core/FlyoutPage/FlyoutPage.Mapper.cs
+++ b/src/Controls/src/Core/FlyoutPage/FlyoutPage.Mapper.cs
@@ -1,4 +1,5 @@
 using System;
+using Microsoft.Maui.Controls.Compatibility;
 
 namespace Microsoft.Maui.Controls
 {
@@ -6,7 +7,7 @@ namespace Microsoft.Maui.Controls
 	public partial class FlyoutPage
 	{
 		[Obsolete("Use FlyoutViewHandler.Mapper instead.")]
-		public static IPropertyMapper<IFlyoutView, FlyoutViewHandler> ControlsFlyoutPageMapper = new PropertyMapper<IFlyoutView, FlyoutViewHandler>(FlyoutViewHandler.Mapper);
+		public static IPropertyMapper<IFlyoutView, FlyoutViewHandler> ControlsFlyoutPageMapper = new ControlsMapper<IFlyoutView, FlyoutViewHandler>(FlyoutViewHandler.Mapper);
 
 		internal new static void RemapForControls()
 		{

--- a/src/Controls/src/Core/Label/Label.Mapper.cs
+++ b/src/Controls/src/Core/Label/Label.Mapper.cs
@@ -1,5 +1,7 @@
 #nullable disable
 using System;
+using System.Collections.Generic;
+using Microsoft.Maui.Controls.Compatibility;
 using Microsoft.Maui.Handlers;
 
 namespace Microsoft.Maui.Controls
@@ -8,7 +10,8 @@ namespace Microsoft.Maui.Controls
 	public partial class Label
 	{
 		[Obsolete("Use LabelHandler.Mapper instead.")]
-		public static IPropertyMapper<ILabel, LabelHandler> ControlsLabelMapper = new PropertyMapper<Label, LabelHandler>(LabelHandler.Mapper);
+		public static IPropertyMapper<ILabel, LabelHandler> ControlsLabelMapper = 
+			new ControlsMapper<ILabel, LabelHandler>(LabelHandler.Mapper);
 
 		internal static new void RemapForControls()
 		{

--- a/src/Controls/src/Core/NavigationPage/NavigationPage.Mapper.cs
+++ b/src/Controls/src/Core/NavigationPage/NavigationPage.Mapper.cs
@@ -1,5 +1,6 @@
 ﻿#nullable disable
 using System;
+using Microsoft.Maui.Controls.Compatibility;
 
 namespace Microsoft.Maui.Controls
 {
@@ -7,7 +8,7 @@ namespace Microsoft.Maui.Controls
 	{
 		[Obsolete("Use NavigationViewHandler.Mapper instead.")]
 		public static IPropertyMapper<IStackNavigationView, NavigationViewHandler> ControlsNavigationPageMapper =
-			new PropertyMapper<NavigationPage, NavigationViewHandler>(NavigationViewHandler.Mapper);
+			new ControlsMapper<NavigationPage, NavigationViewHandler>(NavigationViewHandler.Mapper);
 
 		internal static new void RemapForControls()
 		{

--- a/src/Controls/src/Core/Picker/Picker.Mapper.cs
+++ b/src/Controls/src/Core/Picker/Picker.Mapper.cs
@@ -1,12 +1,13 @@
 ﻿#nullable disable
 using System;
+using Microsoft.Maui.Controls.Compatibility;
 
 namespace Microsoft.Maui.Controls
 {
 	public partial class Picker
 	{
 		[Obsolete("Use PickerHandler.Mapper instead.")]
-		public static IPropertyMapper<IPicker, PickerHandler> ControlsPickerMapper = new PropertyMapper<Picker, PickerHandler>(PickerHandler.Mapper);
+		public static IPropertyMapper<IPicker, PickerHandler> ControlsPickerMapper = new ControlsMapper<Picker, PickerHandler>(PickerHandler.Mapper);
 
 		internal static new void RemapForControls()
 		{

--- a/src/Controls/src/Core/RadioButton/RadioButton.Mapper.cs
+++ b/src/Controls/src/Core/RadioButton/RadioButton.Mapper.cs
@@ -1,5 +1,6 @@
 #nullable disable
 using System;
+using Microsoft.Maui.Controls.Compatibility;
 
 namespace Microsoft.Maui.Controls
 {
@@ -10,7 +11,7 @@ namespace Microsoft.Maui.Controls
 
 		[Obsolete("Use RadioButtonHandler.Mapper instead.")]
 		public static IPropertyMapper<RadioButton, RadioButtonHandler> ControlsRadioButtonMapper =
-			new PropertyMapper<RadioButton, RadioButtonHandler>(RadioButtonHandler.Mapper);
+			new ControlsMapper<RadioButton, RadioButtonHandler>(RadioButtonHandler.Mapper);
 
 		internal new static void RemapForControls()
 		{

--- a/src/Controls/src/Core/RefreshView/RefreshView.Mapper.cs
+++ b/src/Controls/src/Core/RefreshView/RefreshView.Mapper.cs
@@ -1,12 +1,13 @@
 ﻿#nullable disable
 using System;
+using Microsoft.Maui.Controls.Compatibility;
 
 namespace Microsoft.Maui.Controls
 {
 	public partial class RefreshView
 	{
 		[Obsolete("Use RefreshViewHandler.Mapper instead.")]
-		public static IPropertyMapper<IRefreshView, RefreshViewHandler> ControlsRefreshViewMapper = new PropertyMapper<RefreshView, RefreshViewHandler>(RefreshViewHandler.Mapper);
+		public static IPropertyMapper<IRefreshView, RefreshViewHandler> ControlsRefreshViewMapper = new ControlsMapper<RefreshView, RefreshViewHandler>(RefreshViewHandler.Mapper);
 
 		internal static new void RemapForControls()
 		{

--- a/src/Controls/src/Core/ScrollView/ScrollView.Mapper.cs
+++ b/src/Controls/src/Core/ScrollView/ScrollView.Mapper.cs
@@ -1,5 +1,6 @@
 ﻿#nullable disable
 using System;
+using Microsoft.Maui.Controls.Compatibility;
 
 namespace Microsoft.Maui.Controls
 {
@@ -7,7 +8,7 @@ namespace Microsoft.Maui.Controls
 	{
 		[Obsolete("Use ScrollViewHandler.Mapper instead.")]
 		public static IPropertyMapper<IScrollView, ScrollViewHandler> ControlsScrollViewMapper =
-				new PropertyMapper<ScrollView, ScrollViewHandler>(ScrollViewHandler.Mapper);
+				new ControlsMapper<ScrollView, ScrollViewHandler>(ScrollViewHandler.Mapper);
 
 		internal static new void RemapForControls()
 		{

--- a/src/Controls/src/Core/SearchBar/SearchBar.Mapper.cs
+++ b/src/Controls/src/Core/SearchBar/SearchBar.Mapper.cs
@@ -1,5 +1,6 @@
 ﻿#nullable disable
 using System;
+using Microsoft.Maui.Controls.Compatibility;
 
 namespace Microsoft.Maui.Controls
 {
@@ -7,7 +8,7 @@ namespace Microsoft.Maui.Controls
 	{
 		[Obsolete("Use SearchBarHandler.Mapper instead.")]
 		public static IPropertyMapper<ISearchBar, SearchBarHandler> ControlsSearchBarMapper =
-			new PropertyMapper<SearchBar, SearchBarHandler>(SearchBarHandler.Mapper);
+			new ControlsMapper<SearchBar, SearchBarHandler>(SearchBarHandler.Mapper);
 
 		internal static new void RemapForControls()
 		{

--- a/src/Controls/src/Core/Shape/Shape.Mapper.cs
+++ b/src/Controls/src/Core/Shape/Shape.Mapper.cs
@@ -5,13 +5,14 @@ using System.Text;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Platform;
 using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Controls.Compatibility;
 
 namespace Microsoft.Maui.Controls.Shapes
 {
 	public partial class Shape
 	{
 		[Obsolete("Use ShapeViewHandler.Mapper instead.")]
-		public static IPropertyMapper<IShapeView, IShapeViewHandler> ControlsShapeViewMapper = new PropertyMapper<IShapeView, IShapeViewHandler>(ShapeViewHandler.Mapper);
+		public static IPropertyMapper<IShapeView, IShapeViewHandler> ControlsShapeViewMapper = new ControlsMapper<IShapeView, IShapeViewHandler>(ShapeViewHandler.Mapper);
 
 		internal new static void RemapForControls()
 		{

--- a/src/Controls/src/Core/TabbedPage/TabbedPage.Mapper.cs
+++ b/src/Controls/src/Core/TabbedPage/TabbedPage.Mapper.cs
@@ -2,13 +2,14 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using Microsoft.Maui.Controls.Compatibility;
 
 namespace Microsoft.Maui.Controls
 {
 	public partial class TabbedPage
 	{
 		[Obsolete("Use TabbedViewHandler.Mapper instead.")]
-		public static IPropertyMapper<ITabbedView, ITabbedViewHandler> ControlsTabbedPageMapper = new PropertyMapper<TabbedPage, ITabbedViewHandler>(TabbedViewHandler.Mapper);
+		public static IPropertyMapper<ITabbedView, ITabbedViewHandler> ControlsTabbedPageMapper = new ControlsMapper<TabbedPage, ITabbedViewHandler>(TabbedViewHandler.Mapper);
 
 		internal new static void RemapForControls()
 		{

--- a/src/Controls/src/Core/TimePicker/TimePicker.Mapper.cs
+++ b/src/Controls/src/Core/TimePicker/TimePicker.Mapper.cs
@@ -1,12 +1,13 @@
 ﻿#nullable disable
 using System;
+using Microsoft.Maui.Controls.Compatibility;
 
 namespace Microsoft.Maui.Controls
 {
 	public partial class TimePicker
 	{
 		[Obsolete("Use TimePickerHandler.Mapper instead.")]
-		public static IPropertyMapper<ITimePicker, TimePickerHandler> ControlsTimePickerMapper = new PropertyMapper<TimePicker, TimePickerHandler>(TimePickerHandler.Mapper);
+		public static IPropertyMapper<ITimePicker, TimePickerHandler> ControlsTimePickerMapper = new ControlsMapper<TimePicker, TimePickerHandler>(TimePickerHandler.Mapper);
 
 		internal static new void RemapForControls()
 		{

--- a/src/Controls/src/Core/Toolbar/Toolbar.Mapper.cs
+++ b/src/Controls/src/Core/Toolbar/Toolbar.Mapper.cs
@@ -4,6 +4,7 @@ using System.ComponentModel;
 using Microsoft.Maui.Controls.Platform;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Controls.Compatibility;
 
 namespace Microsoft.Maui.Controls
 {
@@ -14,7 +15,7 @@ namespace Microsoft.Maui.Controls
 
 		[Obsolete("Use ToolbarHandler.Mapper instead.")]
 		public static IPropertyMapper<Toolbar, ToolbarHandler> ControlsToolbarMapper =
-			new PropertyMapper<Toolbar, ToolbarHandler>(ToolbarHandler.Mapper);
+			new ControlsMapper<Toolbar, ToolbarHandler>(ToolbarHandler.Mapper);
 
 		internal static void RemapForControls()
 		{

--- a/src/Controls/src/Core/VisualElement/VisualElement.Mapper.cs
+++ b/src/Controls/src/Core/VisualElement/VisualElement.Mapper.cs
@@ -1,6 +1,7 @@
 #nullable disable
 using System;
 using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Controls.Compatibility;
 
 namespace Microsoft.Maui.Controls
 {
@@ -8,7 +9,7 @@ namespace Microsoft.Maui.Controls
 	public partial class VisualElement
 	{
 		[Obsolete("Use ViewHandler.ViewMapper instead.")]
-		public static IPropertyMapper<IView, IViewHandler> ControlsVisualElementMapper = new PropertyMapper<IView, IViewHandler>(Element.ControlsElementMapper);
+		public static IPropertyMapper<IView, IViewHandler> ControlsVisualElementMapper = new ControlsMapper<IView, IViewHandler>(Element.ControlsElementMapper);
 
 		internal static new void RemapForControls()
 		{

--- a/src/Controls/src/Core/VisualElement/VisualElement.Mapper.cs
+++ b/src/Controls/src/Core/VisualElement/VisualElement.Mapper.cs
@@ -11,23 +11,31 @@ namespace Microsoft.Maui.Controls
 		[Obsolete("Use ViewHandler.ViewMapper instead.")]
 		public static IPropertyMapper<IView, IViewHandler> ControlsVisualElementMapper = new ControlsMapper<IView, IViewHandler>(Element.ControlsElementMapper);
 
+
 		internal static new void RemapForControls()
 		{
+			RemapForControls(ViewHandler.ViewMapper, ViewHandler.ViewCommandMapper);
+		}
+
+		internal static void RemapForControls(
+			IPropertyMapper<IView, IViewHandler> viewMapper, 
+			CommandMapper<IView, IViewHandler> commandMapper)
+		{
 #if WINDOWS
-			ViewHandler.ViewMapper.ReplaceMapping<IView, IViewHandler>(PlatformConfiguration.WindowsSpecific.VisualElement.AccessKeyHorizontalOffsetProperty.PropertyName, MapAccessKeyHorizontalOffset);
-			ViewHandler.ViewMapper.ReplaceMapping<IView, IViewHandler>(PlatformConfiguration.WindowsSpecific.VisualElement.AccessKeyPlacementProperty.PropertyName, MapAccessKeyPlacement);
-			ViewHandler.ViewMapper.ReplaceMapping<IView, IViewHandler>(PlatformConfiguration.WindowsSpecific.VisualElement.AccessKeyProperty.PropertyName, MapAccessKey);
-			ViewHandler.ViewMapper.ReplaceMapping<IView, IViewHandler>(PlatformConfiguration.WindowsSpecific.VisualElement.AccessKeyVerticalOffsetProperty.PropertyName, MapAccessKeyVerticalOffset);
+			viewMapper.ReplaceMapping<IView, IViewHandler>(PlatformConfiguration.WindowsSpecific.VisualElement.AccessKeyHorizontalOffsetProperty.PropertyName, MapAccessKeyHorizontalOffset);
+			viewMapper.ReplaceMapping<IView, IViewHandler>(PlatformConfiguration.WindowsSpecific.VisualElement.AccessKeyPlacementProperty.PropertyName, MapAccessKeyPlacement);
+			viewMapper.ReplaceMapping<IView, IViewHandler>(PlatformConfiguration.WindowsSpecific.VisualElement.AccessKeyProperty.PropertyName, MapAccessKey);
+			viewMapper.ReplaceMapping<IView, IViewHandler>(PlatformConfiguration.WindowsSpecific.VisualElement.AccessKeyVerticalOffsetProperty.PropertyName, MapAccessKeyVerticalOffset);
 #endif
-			ViewHandler.ViewMapper.ReplaceMapping<IView, IViewHandler>(nameof(BackgroundColor), MapBackgroundColor);
-			ViewHandler.ViewMapper.ReplaceMapping<IView, IViewHandler>(nameof(Page.BackgroundImageSource), MapBackgroundImageSource);
-			ViewHandler.ViewMapper.ReplaceMapping<IView, IViewHandler>(SemanticProperties.DescriptionProperty.PropertyName, MapSemanticPropertiesDescriptionProperty);
-			ViewHandler.ViewMapper.ReplaceMapping<IView, IViewHandler>(SemanticProperties.HintProperty.PropertyName, MapSemanticPropertiesHintProperty);
-			ViewHandler.ViewMapper.ReplaceMapping<IView, IViewHandler>(SemanticProperties.HeadingLevelProperty.PropertyName, MapSemanticPropertiesHeadingLevelProperty);
+			viewMapper.ReplaceMapping<IView, IViewHandler>(nameof(BackgroundColor), MapBackgroundColor);
+			viewMapper.ReplaceMapping<IView, IViewHandler>(nameof(Page.BackgroundImageSource), MapBackgroundImageSource);
+			viewMapper.ReplaceMapping<IView, IViewHandler>(SemanticProperties.DescriptionProperty.PropertyName, MapSemanticPropertiesDescriptionProperty);
+			viewMapper.ReplaceMapping<IView, IViewHandler>(SemanticProperties.HintProperty.PropertyName, MapSemanticPropertiesHintProperty);
+			viewMapper.ReplaceMapping<IView, IViewHandler>(SemanticProperties.HeadingLevelProperty.PropertyName, MapSemanticPropertiesHeadingLevelProperty);
 
-			ViewHandler.ViewMapper.AppendToMapping<VisualElement, IViewHandler>(nameof(IViewHandler.ContainerView), MapContainerView);
+			viewMapper.AppendToMapping<VisualElement, IViewHandler>(nameof(IViewHandler.ContainerView), MapContainerView);
 
-			ViewHandler.ViewCommandMapper.ModifyMapping<VisualElement, IViewHandler>(nameof(IView.Focus), MapFocus);
+			commandMapper.ModifyMapping<VisualElement, IViewHandler>(nameof(IView.Focus), MapFocus);
 		}
 
 		public static void MapBackgroundColor(IViewHandler handler, IView view) =>

--- a/src/Controls/src/Core/WebView/WebView.Mapper.cs
+++ b/src/Controls/src/Core/WebView/WebView.Mapper.cs
@@ -1,12 +1,13 @@
 ﻿#nullable disable
 using System;
+using Microsoft.Maui.Controls.Compatibility;
 
 namespace Microsoft.Maui.Controls
 {
 	public partial class WebView
 	{
 		[Obsolete("Use WebViewHandler.Mapper instead.")]
-		public static IPropertyMapper<IWebView, WebViewHandler> ControlsWebViewMapper = new PropertyMapper<WebView, WebViewHandler>(WebViewHandler.Mapper);
+		public static IPropertyMapper<IWebView, WebViewHandler> ControlsWebViewMapper = new ControlsMapper<WebView, WebViewHandler>(WebViewHandler.Mapper);
 
 		internal static new void RemapForControls()
 		{

--- a/src/Controls/src/Core/Window/Window.Mapper.cs
+++ b/src/Controls/src/Core/Window/Window.Mapper.cs
@@ -1,6 +1,7 @@
 ﻿#nullable disable
 using System;
 using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Controls.Compatibility;
 
 namespace Microsoft.Maui.Controls
 {
@@ -8,7 +9,7 @@ namespace Microsoft.Maui.Controls
 	{
 		[Obsolete("Use WindowHandler.Mapper instead.")]
 		public static IPropertyMapper<IWindow, WindowHandler> ControlsWindowMapper =
-			new PropertyMapper<Window, WindowHandler>(WindowHandler.Mapper);
+			new ControlsMapper<Window, WindowHandler>(WindowHandler.Mapper);
 
 		internal static new void RemapForControls()
 		{

--- a/src/Controls/tests/Core.UnitTests/ControlsMapperTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ControlsMapperTests.cs
@@ -1,0 +1,158 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Microsoft.Maui.Controls.Hosting;
+using Microsoft.Maui.Controls.Internals;
+using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Hosting;
+using Microsoft.Maui.Platform;
+using Xunit;
+using Xunit.Sdk;
+using Microsoft.Maui.Controls.Compatibility;
+
+namespace Microsoft.Maui.Controls.Core.UnitTests
+{
+	[Collection("ControlsMapperTests")]
+	public class ControlsMapperTests : BaseTestFixture
+	{
+		MauiContext SetupMauiContext()
+		{
+			var mauiApp1 = MauiApp.CreateBuilder()
+				.UseMauiApp<ApplicationStub>()
+				.ConfigureMauiHandlers(handlers => handlers.AddHandler<ButtonWithControlsMapper, ButtonWithControlsMapperHandler>())
+				.Build();
+
+			// reset all the mappings
+			foreach(var item in ButtonWithControlsMapperHandler.Mapper.GetKeys())
+			{
+				ButtonWithControlsMapperHandler.Mapper[item] = ButtonWithControlsMapperHandler.MapperTest;
+			}
+
+
+			return new MauiContext(mauiApp1.Services);
+		}
+
+		[Fact]
+		public void Append()
+		{
+			MauiContext mauiContext1 = SetupMauiContext();
+
+			bool appendCalled = false;
+			bool originalMapperCalled = false;
+			ButtonWithControlsMapper.
+				ControlsButtonWithControlsMapper
+				.AppendToMapping("MapperTest", (_, _) =>
+				{
+					Assert.True(originalMapperCalled);
+					appendCalled = true;
+				});
+
+
+			var button = new ButtonWithControlsMapper(MapperCalled);
+			button.ToPlatform(mauiContext1);
+
+			Assert.True(appendCalled);
+
+			void MapperCalled()
+			{
+				originalMapperCalled = true;
+			}
+		}
+
+		[Fact]
+		public void Prepend()
+		{
+			MauiContext mauiContext1 = SetupMauiContext();
+
+			bool newMapperMethodCalled = false;
+			bool originalMapperCalled = false;
+			ButtonWithControlsMapper.
+				ControlsButtonWithControlsMapper
+				.PrependToMapping("MapperTest", (_, _) =>
+				{
+					Assert.False(originalMapperCalled);
+					newMapperMethodCalled = true;
+				});
+
+
+			var button = new ButtonWithControlsMapper(MapperCalled);
+			button.ToPlatform(mauiContext1);
+
+			Assert.True(newMapperMethodCalled);
+			Assert.True(originalMapperCalled);
+
+			void MapperCalled()
+			{
+				originalMapperCalled = true;
+			}
+		}
+
+		[Fact]
+		public void Replace()
+		{
+			MauiContext mauiContext1 = SetupMauiContext();
+
+			bool newMapperMethodCalled = false;
+			bool originalMapperCalled = false;
+			ButtonWithControlsMapper.
+				ControlsButtonWithControlsMapper
+				.ModifyMapping("MapperTest", (handler, view, previous) =>
+				{
+					Assert.False(originalMapperCalled);
+					previous.Invoke(handler, view);
+					Assert.True(originalMapperCalled);
+					newMapperMethodCalled = true;
+				});
+
+
+			var button = new ButtonWithControlsMapper(MapperCalled);
+			button.ToPlatform(mauiContext1);
+
+			Assert.True(newMapperMethodCalled);
+			Assert.True(originalMapperCalled);
+
+			void MapperCalled()
+			{
+				originalMapperCalled = true;
+			}
+		}
+
+		class ButtonWithControlsMapper : Button
+		{
+			public static IPropertyMapper<ButtonWithControlsMapper, ButtonWithControlsMapperHandler> ControlsButtonWithControlsMapper =
+				new ControlsMapper<ButtonWithControlsMapper, ButtonWithControlsMapperHandler>(ButtonWithControlsMapperHandler.Mapper);
+
+
+			public Action MapperCalled { get; private set; }
+			public ButtonWithControlsMapper(Action mapperCalled)
+			{
+				MapperCalled = mapperCalled;
+			}
+		}
+
+		class ButtonWithControlsMapperHandler : ViewHandler<ButtonWithControlsMapper, object>
+		{
+
+			public static PropertyMapper<IView> Mapper = new PropertyMapper<IView>()
+			{
+				["MapperTest"] = MapperTest
+			};
+
+			public static void MapperTest(IElementHandler handler, IView view)
+			{
+				((ButtonWithControlsMapper)view).MapperCalled.Invoke();
+			}
+
+			public ButtonWithControlsMapperHandler() : base(Mapper)
+			{
+			}
+
+			protected override object CreatePlatformView()
+			{
+				return new object();
+			}
+		}
+	}
+}

--- a/src/Controls/tests/Core.UnitTests/VisualElementTests.cs
+++ b/src/Controls/tests/Core.UnitTests/VisualElementTests.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls.Shapes;
 using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Primitives;
 using Xunit;
 using static Microsoft.Maui.Controls.Core.UnitTests.VisualStateTestHelpers;
@@ -90,7 +91,11 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		[Fact]
 		public void ContainerChangedFiresWhenMapContainerIsCalled()
 		{
-			var handlerStub = new HandlerStub((PropertyMapper)VisualElement.ControlsVisualElementMapper);
+			var mapper = new PropertyMapper<IView, IViewHandler>(ViewHandler.ViewMapper);
+			var commandMapper = new CommandMapper<IView, IViewHandler>(ViewHandler.ViewCommandMapper);
+
+			VisualElement.RemapForControls(mapper, commandMapper);
+			var handlerStub = new HandlerStub(mapper);
 			var button = new Button();
 			button.Handler = handlerStub;
 


### PR DESCRIPTION
### Description of Change

 We obsoleted the `ControlsMappers` because they were causing issues when the application was AOT'd https://github.com/dotnet/maui/pull/13836. This change disconnected the controls mappers completely from the core mappers, which meant that if someone was wiring into these their code would stop executing.
 
 This PR takes a minimal approach to proxy mapper modifications from the `ControlsMapper` to the `Core` mappers in order to not break users when they update to NET8.

If someone is wiring into the `ControlsMappers` inside `MauiProgram` before any of the builder extension methods are called their code still won't run. That path was already unreliable and broken with AOT.

### Issues Fixed
Fixes #18059

