### PR TITLE
[ci] Dependabot should only use nuget.org

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,12 @@
 version: 2
+registries:
+  public:
+    type: nuget-feed
+    url: https://api.nuget.org/v3/index.json
 updates:
 - package-ecosystem: nuget
   directory: "/"
+  registries: "public"
   schedule:
     interval: daily
   open-pull-requests-limit: 25


### PR DESCRIPTION
### Description of Change

Dependabot keeps updating from internal public feeds.