### PR TITLE
[ci] Remove DeviceTests on iOS13.7 add Android 33

### DIFF
--- a/eng/pipelines/device-tests.yml
+++ b/eng/pipelines/device-tests.yml
@@ -106,9 +106,8 @@ stages:
       windowsPool: ${{ parameters.windowsPool }}
       agentPoolAccessToken: $(AgentPoolAccessToken)
       ${{ if or(parameters.BuildEverything, and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'devdiv'))) }}:
-        androidApiLevels: [ 30, 29, 28, 27, 26, 25, 24, 23 ]
-        # androidApiLevels: [ 30, 29, 28, 27, 26, 25, 24, 23, 22, 21 ] # fix the issue of getting the test results off
-        iosVersions: [ '16.4', '15.5', '14.5', '13.7']
+        androidApiLevels: [ 33, 30, 29, 28, 27, 26, 25, 24, 23 ]
+        iosVersions: [ '16.4', '15.5', '14.5']
         catalystVersions: [ 'latest' ]
         windowsVersions: ['packaged', 'unpackaged']
         provisionatorChannel: ${{ parameters.provisionatorChannel }}


### PR DESCRIPTION
### Description of Change

On XCode15 we can't install  iOS13.7 simulators.

Adding Android 33 to full run.