### PR TITLE
[WinUI] Fixes window blinking when resizing

### DIFF
--- a/src/Controls/src/Core/Handlers/Shell/ShellItemHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellItemHandler.Windows.cs
@@ -476,7 +476,6 @@ namespace Microsoft.Maui.Controls.Handlers
 			var paneDisplayMode = GetNavigationViewPaneDisplayMode(item);
 			mauiNavView.PaneDisplayMode = paneDisplayMode;
 			mauiNavView.PinPaneDisplayModeTo = paneDisplayMode;
-			mauiNavView.IsPaneVisible = item.ShowTabs;
 		}
 
 		public static void MapTabBarIsVisible(ShellItemHandler handler, ShellItem item)


### PR DESCRIPTION
### Description of Change
This bug was introduced by https://github.com/dotnet/maui/pull/17069, but the underlying cause is a bug on WinUI that makes the window blink when setting `NavigationView.IsPaneVisible = false` (https://microsoft.visualstudio.com/DefaultCollection/OS/_workitems/edit/47131770).

After testing the samples attached on the issues the original commit fixed, this change does not seem to re-introduce those issues.

### Issues Fixed
Fixes #17724

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
