### PR TITLE
[net8.0] Add permission for high-speed sensors

### DIFF
--- a/src/Essentials/test/DeviceTests/Platforms/Android/AndroidManifest.xml
+++ b/src/Essentials/test/DeviceTests/Platforms/Android/AndroidManifest.xml
@@ -13,6 +13,7 @@
 	<uses-permission android:name="android.permission.INTERNET" />
 	<uses-permission android:name="android.permission.VIBRATE" />
 	<uses-permission android:name="android.permission.READ_CONTACTS" />
+  <uses-permission android:name="android.permission.HIGH_SAMPLING_RATE_SENSORS" />
 	<queries>
 		<!-- Email -->
 		<intent>


### PR DESCRIPTION
### Description of Change

Fixes for the new permissions needed on Android 31+

release/8.0.1xx-rc2.1: https://github.com/dotnet/maui/pull/18182