### PR TITLE
Update dev getting started instructions

### DIFF
--- a/.github/DEVELOPMENT.md
+++ b/.github/DEVELOPMENT.md
@@ -3,10 +3,10 @@
 This page contains steps to build and run the .NET MAUI repository from source. If you are looking to build apps with .NET MAUI please head over to the links in the [README](https://github.com/dotnet/maui/blob/main/README.md) to get started.
 
 ## Visual Studio
-Install Visual Studio 17.8 latest preview or newer. Follow the instructions here to install .NET MAUI with Visual Studio:
-   - [Windows](https://learn.microsoft.com/dotnet/maui/get-started/installation?tabs=vswin)
-      - Select the 20348 SDK option inside Individual Components or [install 20348 manually](https://go.microsoft.com/fwlink/?linkid=2164145)
-      - If you know you have 20348 installed but are still getting an error around this SDK missing, trying uninstalling and reinstalling the SDK.
+Install Visual Studio with .NET8 support.
+   - Windows: install VS 17.8 latest preview or newer
+      - Follow [these steps](https://learn.microsoft.com/dotnet/maui/get-started/installation?tabs=vswin) to include MAUI
+      - Select the 20348 SDK option inside Individual Components or [install 20348 manually](https://go.microsoft.com/fwlink/?linkid=2164145). If you know you have 20348 installed but are still getting an error around this SDK missing, trying uninstalling and reinstalling the SDK.
    - [macOS](https://learn.microsoft.com/dotnet/maui/get-started/installation?tabs=vsmac)  
    
 ## iOS / MacCatalyst

--- a/.github/DEVELOPMENT.md
+++ b/.github/DEVELOPMENT.md
@@ -3,7 +3,7 @@
 This page contains steps to build and run the .NET MAUI repository from source. If you are looking to build apps with .NET MAUI please head over to the links in the [README](https://github.com/dotnet/maui/blob/main/README.md) to get started.
 
 ## Visual Studio
-Follow the instructions here to install .NET MAUI with Visual Studio Stable:
+Install Visual Studio 17.8 latest preview or newer. Follow the instructions here to install .NET MAUI with Visual Studio:
    - [Windows](https://learn.microsoft.com/dotnet/maui/get-started/installation?tabs=vswin)
       - Select the 20348 SDK option inside Individual Components or [install 20348 manually](https://go.microsoft.com/fwlink/?linkid=2164145)
       - If you know you have 20348 installed but are still getting an error around this SDK missing, trying uninstalling and reinstalling the SDK.


### PR DESCRIPTION
### Issues Fixed

Developing for MAUI on main now requires .NET8, so update the instructions to install VS 17.8 preview instead of 17.7 stable, to get .NET8 support.

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
