### PR TITLE
Allow iOS Keyboard Scrolling to be turned off in Lifecycle Events

### DIFF
--- a/src/Core/src/Hosting/LifecycleEvents/AppHostBuilderExtensions.iOS.cs
+++ b/src/Core/src/Hosting/LifecycleEvents/AppHostBuilderExtensions.iOS.cs
@@ -19,7 +19,8 @@ namespace Microsoft.Maui.LifecycleEvents
 					.OnPlatformWindowCreated((window) =>
 					{
 						window.GetWindow()?.Created();
-						KeyboardAutoManagerScroll.Connect();
+						if (!KeyboardAutoManagerScroll.ShouldDisconnectLifecycle)
+							KeyboardAutoManagerScroll.Connect();
 					})
 					.WillTerminate(app =>
 					{

--- a/src/Core/src/Platform/iOS/KeyboardAutoManagerScroll.cs
+++ b/src/Core/src/Platform/iOS/KeyboardAutoManagerScroll.cs
@@ -32,15 +32,34 @@ public static class KeyboardAutoManagerScroll
 	static CGRect? CursorRect = null;
 	internal static bool IsKeyboardShowing = false;
 	static int TextViewTopDistance = 20;
-	static int DebounceCount = 0;
-	static NSObject? WillShowToken = null;
-	static NSObject? WillHideToken = null;
-	static NSObject? DidHideToken = null;
-	static NSObject? TextFieldToken = null;
-	static NSObject? TextViewToken = null;
+	static int DebounceCount;
+	static NSObject? WillShowToken;
+	static NSObject? WillHideToken;
+	static NSObject? DidHideToken;
+	static NSObject? TextFieldToken;
+	static NSObject? TextViewToken;
+	static bool? ShouldConnect;
 
+	/// <summary>
+	/// Enables automatic scrolling with keyboard interactions on iOS devices.
+	/// </summary>
+	/// <remarks>
+	/// This method is being called by default on iOS and will scroll the page when the keyboard
+	/// comes up. Call the method 'KeyboardAutoManagerScroll.Disconnect()'
+	/// to remove this scrolling behavior.
+	/// </remarks>
 	public static void Connect()
 	{
+		// if Disconnect was called prior to the first Connect
+		// call in the Created Lifecycle event, do not connect
+		if (ShouldConnect is false)
+		{
+			ShouldConnect = true;
+			return;
+		}
+
+		ShouldConnect = true;
+
 		if (TextFieldToken is not null)
 			return;
 
@@ -55,8 +74,19 @@ public static class KeyboardAutoManagerScroll
 		DidHideToken = NSNotificationCenter.DefaultCenter.AddObserver(new NSString("UIKeyboardDidHideNotification"), DidHideKeyboard);
 	}
 
+	/// <summary>
+	/// Disables automatic scrolling with keyboard interactions on iOS devices.
+	/// </summary>
+	/// <remarks>
+	/// When this method is called, scrolling will not automatically happen when the keyboard comes up.
+	/// </remarks>
 	public static void Disconnect()
 	{
+		// if Disconnect is called prior to Connect, signal to not
+		// Connect during the Created Lifecycle event
+		if (ShouldConnect is null)
+			ShouldConnect = false;
+
 		if (WillShowToken is not null)
 		{
 			NSNotificationCenter.DefaultCenter.RemoveObserver(WillShowToken);

--- a/src/Core/src/Platform/iOS/KeyboardAutoManagerScroll.cs
+++ b/src/Core/src/Platform/iOS/KeyboardAutoManagerScroll.cs
@@ -38,7 +38,7 @@ public static class KeyboardAutoManagerScroll
 	static NSObject? DidHideToken;
 	static NSObject? TextFieldToken;
 	static NSObject? TextViewToken;
-	static bool? ShouldConnect;
+	internal static bool ShouldDisconnectLifecycle;
 
 	/// <summary>
 	/// Enables automatic scrolling with keyboard interactions on iOS devices.
@@ -50,16 +50,6 @@ public static class KeyboardAutoManagerScroll
 	/// </remarks>
 	public static void Connect()
 	{
-		// if Disconnect was called prior to the first Connect
-		// call in the Created Lifecycle event, do not connect
-		if (ShouldConnect is false)
-		{
-			ShouldConnect = true;
-			return;
-		}
-
-		ShouldConnect = true;
-
 		if (TextFieldToken is not null)
 			return;
 
@@ -84,8 +74,7 @@ public static class KeyboardAutoManagerScroll
 	{
 		// if Disconnect is called prior to Connect, signal to not
 		// Connect during the Created Lifecycle event
-		if (ShouldConnect is null)
-			ShouldConnect = false;
+		ShouldDisconnectLifecycle = true;
 
 		if (WillShowToken is not null)
 		{


### PR DESCRIPTION
### Description of Change

<!-- Enter description of the fix in this section -->
The iOS Keyboard Scrolling can be turned off by customers if they would like to use custom code to control the scrolling. At this point, the Disconnect() method that turns off the scrolling has trouble when used in Lifecycle events since it would be overrided by the default Connect() method in the Lifecycle events. This change allows the user to call the Disconnect anywhere in the code and be respected. Also adds a little documentation to the Connect and Disconnect method.

This code for this fix comes from [this pending PR](https://github.com/dotnet/maui/pull/17670) but is in a bite-sized PR to help get in by GA :)



<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
