### PR TITLE
[controls] fix memory leak with `CarouselView` & `INotifyCollectionChanged`

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/Android/ItemsSources/ItemsSourceFactory.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/ItemsSources/ItemsSourceFactory.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				case IList list when itemsSource is INotifyCollectionChanged:
 					return new ObservableItemsSource(new MarshalingObservableCollection(list), container, notifier);
 				case IEnumerable _ when itemsSource is INotifyCollectionChanged:
-					return new ObservableItemsSource(itemsSource as IEnumerable, container, notifier);
+					return new ObservableItemsSource(itemsSource, container, notifier);
 				case IList list:
 					return new ListSource(list);
 				case IEnumerable<object> generic:

--- a/src/Controls/src/Core/Handlers/Items/Android/ItemsSources/ObservableItemsSource.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/ItemsSources/ObservableItemsSource.cs
@@ -10,15 +10,19 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		readonly IEnumerable _itemsSource;
 		readonly BindableObject _container;
 		readonly ICollectionChangedNotifier _notifier;
+		readonly WeakNotifyCollectionChangedProxy _proxy = new();
+		readonly NotifyCollectionChangedEventHandler _collectionChanged;
 		bool _disposed;
+
+		~ObservableItemsSource() => _proxy.Unsubscribe();
 
 		public ObservableItemsSource(IEnumerable itemSource, BindableObject container, ICollectionChangedNotifier notifier)
 		{
-			_itemsSource = itemSource as IList ?? itemSource as IEnumerable;
+			_itemsSource = itemSource;
 			_container = container;
 			_notifier = notifier;
-
-			((INotifyCollectionChanged)itemSource).CollectionChanged += CollectionChanged;
+			_collectionChanged = CollectionChanged;
+			_proxy.Subscribe((INotifyCollectionChanged)itemSource, _collectionChanged);
 		}
 
 

--- a/src/Controls/src/Core/Handlers/Items/iOS/CarouselViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/CarouselViewController.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 	public class CarouselViewController : ItemsViewController<CarouselView>
 	{
 		[Obsolete("Use ItemsView property instead")]
-		[UnconditionalSuppressMessage("Memory", "MA0002", Justification = "Unused")]
+		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = "Unused")]
 		protected readonly CarouselView Carousel;
 
 		CarouselViewLoopManager _carouselViewLoopManager;
@@ -206,7 +206,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			return indexPath.Row;
 		}
 
-		[UnconditionalSuppressMessage("Memory", "MA0003", Justification = "Proven safe in test: MemoryTests.HandlerDoesNotLeak")]
+		[UnconditionalSuppressMessage("Memory", "MEM0003", Justification = "Proven safe in test: MemoryTests.HandlerDoesNotLeak")]
 		void CarouselViewScrolled(object sender, ItemsViewScrolledEventArgs e)
 		{
 			if (_updatingScrollOffset)
@@ -224,7 +224,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		int _positionAfterUpdate = -1;
 
-		[UnconditionalSuppressMessage("Memory", "MA0003", Justification = "Proven safe in test: MemoryTests.HandlerDoesNotLeak")]
+		[UnconditionalSuppressMessage("Memory", "MEM0003", Justification = "Proven safe in test: MemoryTests.HandlerDoesNotLeak")]
 		void CollectionViewUpdating(object sender, NotifyCollectionChangedEventArgs e)
 		{
 			if (ItemsView is not CarouselView carousel)
@@ -245,7 +245,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				_positionAfterUpdate = GetPositionWhenAddingItems(carouselPosition, currentItemPosition);
 		}
 
-		[UnconditionalSuppressMessage("Memory", "MA0003", Justification = "Proven safe in test: MemoryTests.HandlerDoesNotLeak")]
+		[UnconditionalSuppressMessage("Memory", "MEM0003", Justification = "Proven safe in test: MemoryTests.HandlerDoesNotLeak")]
 		void CollectionViewUpdated(object sender, NotifyCollectionChangedEventArgs e)
 		{
 			if (_positionAfterUpdate == -1)

--- a/src/Controls/src/Core/Handlers/Items/iOS/CarouselViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/CarouselViewController.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.Diagnostics.CodeAnalysis;
 using CoreGraphics;
 using Foundation;
 using ObjCRuntime;
@@ -11,6 +12,8 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 {
 	public class CarouselViewController : ItemsViewController<CarouselView>
 	{
+		[Obsolete("Use ItemsView property instead")]
+		[UnconditionalSuppressMessage("Memory", "MA0002", Justification = "Unused")]
 		protected readonly CarouselView Carousel;
 
 		CarouselViewLoopManager _carouselViewLoopManager;
@@ -24,10 +27,9 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		public CarouselViewController(CarouselView itemsView, ItemsViewLayout layout) : base(itemsView, layout)
 		{
-			Carousel = itemsView;
 			CollectionView.AllowsSelection = false;
 			CollectionView.AllowsMultipleSelection = false;
-			Carousel.Scrolled += CarouselViewScrolled;
+			itemsView.Scrolled += CarouselViewScrolled;
 			_oldViews = new List<View>();
 		}
 
@@ -35,7 +37,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		{
 			UICollectionViewCell cell;
 
-			if (Carousel?.Loop == true && _carouselViewLoopManager != null)
+			if (ItemsView?.Loop == true && _carouselViewLoopManager != null)
 			{
 				var cellAndCorrectedIndex = _carouselViewLoopManager.GetCellAndCorrectIndex(collectionView, indexPath, DetermineCellReuseId(indexPath));
 				cell = cellAndCorrectedIndex.cell;
@@ -78,7 +80,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		{
 			base.ViewDidLayoutSubviews();
 
-			if (Carousel?.Loop == true && _carouselViewLoopManager != null)
+			if (ItemsView?.Loop == true && _carouselViewLoopManager != null)
 			{
 				_updatingScrollOffset = true;
 				_carouselViewLoopManager.CenterIfNeeded(CollectionView, IsHorizontal);
@@ -98,19 +100,22 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		void BoundsSizeChanged()
 		{
-			//if the size changed center the item	
-			Carousel.ScrollTo(Carousel.Position, position: Microsoft.Maui.Controls.ScrollToPosition.Center, animate: false);
+			//if the size changed center the item
+			if (ItemsView is CarouselView carousel)
+			{
+				carousel.ScrollTo(carousel.Position, position: Microsoft.Maui.Controls.ScrollToPosition.Center, animate: false);
+			}
 		}
 
 		public override void DraggingStarted(UIScrollView scrollView)
 		{
 			_isDragging = true;
-			Carousel.SetIsDragging(true);
+			ItemsView?.SetIsDragging(true);
 		}
 
 		public override void DraggingEnded(UIScrollView scrollView, bool willDecelerate)
 		{
-			Carousel.SetIsDragging(false);
+			ItemsView?.SetIsDragging(false);
 			_isDragging = false;
 		}
 
@@ -121,24 +126,24 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			//we don't need to Subscribe because base calls CreateItemsViewSource
 			_carouselViewLoopManager?.SetItemsSource(LoopItemsSource);
 
-			if (_initialPositionSet)
+			if (_initialPositionSet && ItemsView is CarouselView carousel)
 			{
-				Carousel.SetValueFromRenderer(CarouselView.CurrentItemProperty, null);
-				Carousel.SetValueFromRenderer(CarouselView.PositionProperty, 0);
+				carousel.SetValueFromRenderer(CarouselView.CurrentItemProperty, null);
+				carousel.SetValueFromRenderer(CarouselView.PositionProperty, 0);
 			}
 
 			_initialPositionSet = false;
 			UpdateInitialPosition();
 		}
 
-		protected override bool IsHorizontal => (Carousel?.ItemsLayout)?.Orientation == ItemsLayoutOrientation.Horizontal;
+		protected override bool IsHorizontal => ItemsView?.ItemsLayout?.Orientation == ItemsLayoutOrientation.Horizontal;
 
 		protected override UICollectionViewDelegateFlowLayout CreateDelegator() => new CarouselViewDelegator(ItemsViewLayout, this);
 
 		[Obsolete("Use DetermineCellReuseId(NSIndexPath indexPath) instead.")]
 		protected override string DetermineCellReuseId()
 		{
-			if (Carousel.ItemTemplate != null)
+			if (ItemsView?.ItemTemplate != null)
 				return CarouselTemplatedCell.ReuseId;
 
 			return base.DetermineCellReuseId();
@@ -158,7 +163,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		protected override IItemsViewSource CreateItemsViewSource()
 		{
-			var itemsSource = ItemsSourceFactory.CreateForCarouselView(Carousel.ItemsSource, this, Carousel.Loop);
+			var itemsSource = ItemsSourceFactory.CreateForCarouselView(ItemsView.ItemsSource, this, ItemsView.Loop);
 			_carouselViewLoopManager?.SetItemsSource(itemsSource);
 			SubscribeCollectionItemsSourceChanged(itemsSource);
 			return itemsSource;
@@ -172,17 +177,22 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		internal void TearDown()
 		{
-			Carousel.Scrolled -= CarouselViewScrolled;
+			if (ItemsView is CarouselView carousel)
+				carousel.Scrolled -= CarouselViewScrolled;
 			UnsubscribeCollectionItemsSourceChanged(ItemsSource);
 			_carouselViewLoopManager?.Dispose();
 			_carouselViewLoopManager = null;
 		}
 
-		internal void UpdateIsScrolling(bool isScrolling) => Carousel.IsScrolling = isScrolling;
+		internal void UpdateIsScrolling(bool isScrolling)
+		{
+			if (ItemsView is CarouselView carousel)
+				carousel.IsScrolling = isScrolling;
+		}
 
 		internal NSIndexPath GetScrollToIndexPath(int position)
 		{
-			if (Carousel?.Loop == true && _carouselViewLoopManager != null)
+			if (ItemsView?.Loop == true && _carouselViewLoopManager != null)
 				return _carouselViewLoopManager.GetGoToIndex(CollectionView, position);
 
 			return NSIndexPath.FromItemSection(position, 0);
@@ -190,12 +200,13 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		internal int GetIndexFromIndexPath(NSIndexPath indexPath)
 		{
-			if (Carousel?.Loop == true && _carouselViewLoopManager != null)
+			if (ItemsView?.Loop == true && _carouselViewLoopManager != null)
 				return _carouselViewLoopManager.GetCorrectedIndexFromIndexPath(indexPath);
 
 			return indexPath.Row;
 		}
 
+		[UnconditionalSuppressMessage("Memory", "MA0003", Justification = "Proven safe in test: MemoryTests.HandlerDoesNotLeak")]
 		void CarouselViewScrolled(object sender, ItemsViewScrolledEventArgs e)
 		{
 			if (_updatingScrollOffset)
@@ -213,11 +224,15 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		int _positionAfterUpdate = -1;
 
+		[UnconditionalSuppressMessage("Memory", "MA0003", Justification = "Proven safe in test: MemoryTests.HandlerDoesNotLeak")]
 		void CollectionViewUpdating(object sender, NotifyCollectionChangedEventArgs e)
 		{
-			int carouselPosition = Carousel.Position;
+			if (ItemsView is not CarouselView carousel)
+				return;
+
+			int carouselPosition = carousel.Position;
 			_positionAfterUpdate = carouselPosition;
-			var currentItemPosition = ItemsSource.GetIndexForItem(Carousel.CurrentItem).Row;
+			var currentItemPosition = ItemsSource.GetIndexForItem(carousel.CurrentItem).Row;
 			var count = ItemsSource.ItemCount;
 
 			if (e.Action == NotifyCollectionChangedAction.Remove)
@@ -230,6 +245,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				_positionAfterUpdate = GetPositionWhenAddingItems(carouselPosition, currentItemPosition);
 		}
 
+		[UnconditionalSuppressMessage("Memory", "MA0003", Justification = "Proven safe in test: MemoryTests.HandlerDoesNotLeak")]
 		void CollectionViewUpdated(object sender, NotifyCollectionChangedEventArgs e)
 		{
 			if (_positionAfterUpdate == -1)
@@ -255,7 +271,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		int GetPositionWhenResetItems()
 		{
 			//If we are reseting the collection Position should go to 0
-			Carousel.SetValueFromRenderer(CarouselView.CurrentItemProperty, null);
+			ItemsView?.SetValueFromRenderer(CarouselView.CurrentItemProperty, null);
 			return 0;
 		}
 
@@ -266,11 +282,12 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			bool removingFirstElement = oldStartingIndex == 0;
 			bool removingLastElement = oldStartingIndex == count;
 
-			bool removingCurrentElementAndLast = removingCurrentElement && removingLastElement && Carousel.Position > 0;
+			int currentPosition = ItemsView?.Position ?? 0;
+			bool removingCurrentElementAndLast = removingCurrentElement && removingLastElement && currentPosition > 0;
 			if (removingCurrentElementAndLast)
 			{
 				//If we are removing the last element update the position
-				carouselPosition = Carousel.Position - 1;
+				carouselPosition = currentPosition - 1;
 			}
 			else if (removingFirstElement && !removingCurrentElement)
 			{
@@ -301,10 +318,13 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		internal void UpdateLoop()
 		{
-			var carouselPosition = Carousel.Position;
+			if (ItemsView is not CarouselView carousel)
+				return;
+
+			var carouselPosition = carousel.Position;
 
 			if (LoopItemsSource != null)
-				LoopItemsSource.Loop = Carousel.Loop;
+				LoopItemsSource.Loop = carousel.Loop;
 
 			CollectionView.ReloadData();
 
@@ -313,18 +333,21 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		void ScrollToPosition(int goToPosition, int carouselPosition, bool animate, bool forceScroll = false)
 		{
-			if (Carousel.Loop)
+			if (ItemsView is not CarouselView carousel)
+				return;
+
+			if (carousel.Loop)
 				carouselPosition = _carouselViewLoopManager?.GetCorrectPositionForCenterItem(CollectionView) ?? -1;
 
 			//no center item found, collection could be empty
 			//also if we are dragging we don't need to ScrollTo
-			if (Carousel.IsDragging || carouselPosition == -1)
+			if (carousel.IsDragging || carouselPosition == -1)
 				return;
 
 			if (_gotoPosition == -1 && (goToPosition != carouselPosition || forceScroll))
 			{
 				_gotoPosition = goToPosition;
-				Carousel.ScrollTo(goToPosition, position: Microsoft.Maui.Controls.ScrollToPosition.Center, animate: animate);
+				carousel.ScrollTo(goToPosition, position: Microsoft.Maui.Controls.ScrollToPosition.Center, animate: animate);
 			}
 		}
 
@@ -332,14 +355,16 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		{
 			if (position == -1)
 				return;
+			if (ItemsView is not CarouselView carousel)
+				return;
 
 			//we arrived center
 			if (position == _gotoPosition)
 				_gotoPosition = -1;
 
 			//If _gotoPosition is != -1 we are scrolling to that possition
-			if (_gotoPosition == -1 && Carousel.Position != position)
-				Carousel.SetValueFromRenderer(CarouselView.PositionProperty, position);
+			if (_gotoPosition == -1 && carousel.Position != position)
+				carousel.SetValueFromRenderer(CarouselView.PositionProperty, position);
 
 		}
 
@@ -349,34 +374,38 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				return;
 
 			var item = GetItemAtIndex(NSIndexPath.FromItemSection(carouselPosition, 0));
-			Carousel.SetValueFromRenderer(CarouselView.CurrentItemProperty, item);
+			ItemsView?.SetValueFromRenderer(CarouselView.CurrentItemProperty, item);
 			UpdateVisualStates();
 		}
 
 		internal void UpdateFromCurrentItem()
 		{
-			if (Carousel?.CurrentItem == null || ItemsSource == null || ItemsSource.ItemCount == 0)
+			if (ItemsView is not CarouselView carousel)
+				return;
+			if (carousel.CurrentItem == null || ItemsSource == null || ItemsSource.ItemCount == 0)
 				return;
 
-			var currentItemPosition = GetIndexForItem(Carousel.CurrentItem).Row;
+			var currentItemPosition = GetIndexForItem(carousel.CurrentItem).Row;
 
-			ScrollToPosition(currentItemPosition, Carousel.Position, Carousel.AnimateCurrentItemChanges);
+			ScrollToPosition(currentItemPosition, carousel.Position, carousel.AnimateCurrentItemChanges);
 
 			UpdateVisualStates();
 		}
 
 		internal void UpdateFromPosition()
 		{
+			if (ItemsView is not CarouselView carousel)
+				return;
 			var itemsCount = ItemsSource?.ItemCount;
 			if (itemsCount == 0)
 				return;
 
-			var currentItemPosition = GetIndexForItem(Carousel.CurrentItem).Row;
-			var carouselPosition = Carousel.Position;
+			var currentItemPosition = GetIndexForItem(carousel.CurrentItem).Row;
+			var carouselPosition = carousel.Position;
 			if (carouselPosition == _gotoPosition)
 				_gotoPosition = -1;
 
-			ScrollToPosition(carouselPosition, currentItemPosition, Carousel.AnimatePositionChanges);
+			ScrollToPosition(carouselPosition, currentItemPosition, carousel.AnimatePositionChanges);
 
 			SetCurrentItem(carouselPosition);
 		}
@@ -390,11 +419,14 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 			if (!_initialPositionSet)
 			{
+				if (ItemsView is not CarouselView carousel)
+					return;
+
 				System.Diagnostics.Debug.WriteLine($"UpdateInitialPosition");
 				_initialPositionSet = true;
 
-				int position = Carousel.Position;
-				var currentItem = Carousel.CurrentItem;
+				int position = carousel.Position;
+				var currentItem = carousel.CurrentItem;
 				if (currentItem != null)
 				{
 					position = ItemsSource.GetIndexForItem(currentItem).Row;
@@ -404,7 +436,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 					SetCurrentItem(position);
 				}
 
-				Carousel.ScrollTo(position, -1, Microsoft.Maui.Controls.ScrollToPosition.Center, false);
+				carousel.ScrollTo(position, -1, Microsoft.Maui.Controls.ScrollToPosition.Center, false);
 			}
 
 			UpdateVisualStates();
@@ -412,11 +444,13 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		void UpdateVisualStates()
 		{
+			if (ItemsView is not CarouselView carousel)
+				return;
 			var cells = CollectionView.VisibleCells;
 
 			var newViews = new List<View>();
 
-			var carouselPosition = Carousel.Position;
+			var carouselPosition = carousel.Position;
 			var previousPosition = carouselPosition - 1;
 			var nextPosition = carouselPosition + 1;
 
@@ -447,9 +481,9 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 				newViews.Add(itemView);
 
-				if (!Carousel.VisibleViews.Contains(itemView))
+				if (!carousel.VisibleViews.Contains(itemView))
 				{
-					Carousel.VisibleViews.Add(itemView);
+					carousel.VisibleViews.Add(itemView);
 				}
 			}
 
@@ -458,9 +492,9 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				if (!newViews.Contains(itemView))
 				{
 					VisualStateManager.GoToState(itemView, CarouselView.DefaultItemVisualState);
-					if (Carousel.VisibleViews.Contains(itemView))
+					if (carousel.VisibleViews.Contains(itemView))
 					{
-						Carousel.VisibleViews.Remove(itemView);
+						carousel.VisibleViews.Remove(itemView);
 					}
 				}
 			}

--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using CoreGraphics;
 using Foundation;
 using Microsoft.Maui.Controls.Internals;
@@ -15,15 +16,17 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 	where TItemsView : ItemsView
 	{
 		public const int EmptyTag = 333;
+		readonly WeakReference<TItemsView> _itemsView;
 
 		public IItemsViewSource ItemsSource { get; protected set; }
-		public TItemsView ItemsView { get; }
+		public TItemsView ItemsView => _itemsView.GetTargetOrDefault();
 
 		// ItemsViewLayout provides an accessor to the typed UICollectionViewLayout. It's also important to note that the
 		// initial UICollectionViewLayout which is passed in to the ItemsViewController (and accessed via the Layout property)
 		// _does not_ get updated when the layout is updated for the CollectionView. That property only refers to the
 		// original layout. So it's unlikely that you would ever want to use .Layout; use .ItemsViewLayout instead.
 		// See https://developer.apple.com/documentation/uikit/uicollectionviewcontroller/1623980-collectionviewlayout
+		[UnconditionalSuppressMessage("Memory", "MA0002", Justification = "Proven safe in test: MemoryTests.HandlerDoesNotLeak")]
 		protected ItemsViewLayout ItemsViewLayout { get; set; }
 
 		bool _initialized;
@@ -31,19 +34,22 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		bool _emptyViewDisplayed;
 		bool _disposed;
 
+		[UnconditionalSuppressMessage("Memory", "MA0002", Justification = "Proven safe in test: MemoryTests.HandlerDoesNotLeak")]
 		Func<UICollectionViewCell> _getPrototype;
 		CGSize _previousContentSize = CGSize.Empty;
 
+		[UnconditionalSuppressMessage("Memory", "MA0002", Justification = "Proven safe in test: MemoryTests.HandlerDoesNotLeak")]
 		UIView _emptyUIView;
 		VisualElement _emptyViewFormsElement;
 		Dictionary<object, TemplatedCell> _measurementCells = new Dictionary<object, TemplatedCell>();
 		List<string> _cellReuseIds = new List<string>();
 
+		[UnconditionalSuppressMessage("Memory", "MA0002", Justification = "Proven safe in test: MemoryTests.HandlerDoesNotLeak")]
 		protected UICollectionViewDelegateFlowLayout Delegator { get; set; }
 
 		protected ItemsViewController(TItemsView itemsView, ItemsViewLayout layout) : base(layout)
 		{
-			ItemsView = itemsView;
+			_itemsView = new(itemsView);
 			ItemsViewLayout = layout;
 		}
 
@@ -368,6 +374,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			return ItemsSource[index];
 		}
 
+		[UnconditionalSuppressMessage("Memory", "MA0003", Justification = "Proven safe in test: MemoryTests.HandlerDoesNotLeak")]
 		void CellContentSizeChanged(object sender, EventArgs e)
 		{
 			if (_disposed)
@@ -390,6 +397,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			}
 		}
 
+		[UnconditionalSuppressMessage("Memory", "MA0003", Justification = "Proven safe in test: MemoryTests.HandlerDoesNotLeak")]
 		void CellLayoutAttributesChanged(object sender, LayoutAttributesChangedEventArgs args)
 		{
 			CacheCellAttributes(args.NewAttributes.IndexPath, args.NewAttributes.Size);

--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		// _does not_ get updated when the layout is updated for the CollectionView. That property only refers to the
 		// original layout. So it's unlikely that you would ever want to use .Layout; use .ItemsViewLayout instead.
 		// See https://developer.apple.com/documentation/uikit/uicollectionviewcontroller/1623980-collectionviewlayout
-		[UnconditionalSuppressMessage("Memory", "MA0002", Justification = "Proven safe in test: MemoryTests.HandlerDoesNotLeak")]
+		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = "Proven safe in test: MemoryTests.HandlerDoesNotLeak")]
 		protected ItemsViewLayout ItemsViewLayout { get; set; }
 
 		bool _initialized;
@@ -34,17 +34,17 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		bool _emptyViewDisplayed;
 		bool _disposed;
 
-		[UnconditionalSuppressMessage("Memory", "MA0002", Justification = "Proven safe in test: MemoryTests.HandlerDoesNotLeak")]
+		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = "Proven safe in test: MemoryTests.HandlerDoesNotLeak")]
 		Func<UICollectionViewCell> _getPrototype;
 		CGSize _previousContentSize = CGSize.Empty;
 
-		[UnconditionalSuppressMessage("Memory", "MA0002", Justification = "Proven safe in test: MemoryTests.HandlerDoesNotLeak")]
+		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = "Proven safe in test: MemoryTests.HandlerDoesNotLeak")]
 		UIView _emptyUIView;
 		VisualElement _emptyViewFormsElement;
 		Dictionary<object, TemplatedCell> _measurementCells = new Dictionary<object, TemplatedCell>();
 		List<string> _cellReuseIds = new List<string>();
 
-		[UnconditionalSuppressMessage("Memory", "MA0002", Justification = "Proven safe in test: MemoryTests.HandlerDoesNotLeak")]
+		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = "Proven safe in test: MemoryTests.HandlerDoesNotLeak")]
 		protected UICollectionViewDelegateFlowLayout Delegator { get; set; }
 
 		protected ItemsViewController(TItemsView itemsView, ItemsViewLayout layout) : base(layout)
@@ -374,7 +374,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			return ItemsSource[index];
 		}
 
-		[UnconditionalSuppressMessage("Memory", "MA0003", Justification = "Proven safe in test: MemoryTests.HandlerDoesNotLeak")]
+		[UnconditionalSuppressMessage("Memory", "MEM0003", Justification = "Proven safe in test: MemoryTests.HandlerDoesNotLeak")]
 		void CellContentSizeChanged(object sender, EventArgs e)
 		{
 			if (_disposed)
@@ -397,7 +397,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			}
 		}
 
-		[UnconditionalSuppressMessage("Memory", "MA0003", Justification = "Proven safe in test: MemoryTests.HandlerDoesNotLeak")]
+		[UnconditionalSuppressMessage("Memory", "MEM0003", Justification = "Proven safe in test: MemoryTests.HandlerDoesNotLeak")]
 		void CellLayoutAttributesChanged(object sender, LayoutAttributesChangedEventArgs args)
 		{
 			CacheCellAttributes(args.NewAttributes.IndexPath, args.NewAttributes.Size);

--- a/src/Controls/src/Core/Platform/Windows/CollectionView/ItemTemplateContext.cs
+++ b/src/Controls/src/Core/Platform/Windows/CollectionView/ItemTemplateContext.cs
@@ -1,12 +1,16 @@
 #nullable disable
+using System;
+
 namespace Microsoft.Maui.Controls.Platform
 {
 	internal class ItemTemplateContext
 	{
+		readonly WeakReference<BindableObject> _container;
+
 		public DataTemplate FormsDataTemplate { get; }
 		public IMauiContext MauiContext { get; }
 		public object Item { get; }
-		public BindableObject Container { get; }
+		public BindableObject Container => _container.TryGetTarget(out var c) ? c : null;
 		public double ItemHeight { get; }
 		public double ItemWidth { get; }
 		public Thickness ItemSpacing { get; }
@@ -16,7 +20,7 @@ namespace Microsoft.Maui.Controls.Platform
 		{
 			FormsDataTemplate = formsDataTemplate;
 			Item = item;
-			Container = container;
+			_container = new(container);
 			MauiContext = mauiContext;
 
 			if (height.HasValue)

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -1,4 +1,5 @@
 #nullable enable
+Microsoft.Maui.Controls.Handlers.Items.CarouselViewHandler.~CarouselViewHandler() -> void
 Microsoft.Maui.Controls.PlatformDragStartingEventArgs
 Microsoft.Maui.Controls.PlatformDragStartingEventArgs.Sender.get -> Microsoft.UI.Xaml.UIElement!
 Microsoft.Maui.Controls.PlatformDragStartingEventArgs.DragStartingEventArgs.get -> Microsoft.UI.Xaml.DragStartingEventArgs!

--- a/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
+++ b/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
@@ -1,7 +1,9 @@
 ﻿using System;
+using System.Collections.ObjectModel;
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Handlers.Compatibility;
+using Microsoft.Maui.Controls.Handlers.Items;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Hosting;
 using Xunit;
@@ -18,6 +20,7 @@ public class MemoryTests : ControlsHandlerTestBase
 			builder.ConfigureMauiHandlers(handlers =>
 			{
 				handlers.AddHandler<Border, BorderHandler>();
+				handlers.AddHandler<CarouselView, CarouselViewHandler>();
 				handlers.AddHandler<CheckBox, CheckBoxHandler>();
 				handlers.AddHandler<DatePicker, DatePickerHandler>();
 				handlers.AddHandler<Entry, EntryHandler>();
@@ -38,6 +41,7 @@ public class MemoryTests : ControlsHandlerTestBase
 
 	[Theory("Handler Does Not Leak")]
 	[InlineData(typeof(Border))]
+	[InlineData(typeof(CarouselView))]
 	[InlineData(typeof(ContentView))]
 	[InlineData(typeof(CheckBox))]
 	[InlineData(typeof(DatePicker))]
@@ -65,11 +69,22 @@ public class MemoryTests : ControlsHandlerTestBase
 		WeakReference platformViewReference = null;
 		WeakReference handlerReference = null;
 
+		var observable = new ObservableCollection<int> { 1, 2, 3 };
+
 		await InvokeOnMainThreadAsync(() =>
 		{
 			var layout = new Grid();
 			var view = (View)Activator.CreateInstance(type);
 			layout.Add(view);
+			if (view is ContentView content)
+			{
+				content.Content = new Label();
+			}
+			else if (view is ItemsView items)
+			{
+				items.ItemTemplate = new DataTemplate(() => new Label());
+				items.ItemsSource = observable;
+			}
 			var handler = CreateHandler<LayoutHandler>(layout);
 			viewReference = new WeakReference(view);
 			handlerReference = new WeakReference(view.Handler);


### PR DESCRIPTION
Context: https://github.com/dotnet/maui/issues/17726

In investigating #17726, I found a memory leak with `CarouselView`:

1. Have a long-lived `INotifyCollectionChanged` like
   `ObservableCollection`, that lives the life of the application.

2. Set `CarouselView.ItemsSource` to the collection.

3. `CarouselView` will live forever, even if the page is popped, etc.

I further expanded upon `MemoryTests` to assert more things for each
control, and was able to reproduce this issue.

To fully solve this, I had to fix issues on each platform.

### Android ###

`ObservableItemsSource` subscribes to the `INotifyCollectionChanged`
event, making it live forever in this case.

To fix this, I used the same technique in 58a42e59:
`WeakNotifyCollectionChangedProxy`. `ObservableItemsSource` is used for
`ItemsView`-like controls, so this may fix other leaks as well.

### Windows ###

Windows has the same issue as Android, but for the following types:

* `CarouselViewHandler` subscribes to `INotifyCollectionChanged`

* `ObservableItemTemplateCollection` subscribes to
  `INotifyCollectionChanged`

These could be fixed with `WeakNotifyCollectionChangedProxy`.

Then I found another issue with `ItemTemplateContext`, it holds a strong
reference to `BindableObject Container`, the `CarouselView`. I found
this kept the `CarouselView` alive indefinitely, but changing to a
`WeakReference` solved this issue.

These three types are used for other `ItemsView`-like controls, so this
may fix other leaks as well.

### iOS/Catalyst ###

These platforms suffered from multiple circular references:

* `CarouselViewController` -> `CarouselView` -> `CarouselViewHandler` ->
  `CarouselViewController`

* `ItemsViewController` -> `CarouselView` -> `CarouselViewHandler` ->
  `ItemsViewController` (`CarouselViewController` subclasses this)

* `CarouselViewLayout` -> `CarouselView` -> `CarouselViewHandler` ->
  `CarouselViewLayout`

The analyzer added in 2e656264 did not yet catch these because I only
added the analyzer so far for `Microsoft.Maui.dll` and these issues were
in `Microsoft.Maui.Controls.dll`. In a future PR, we can proactively try
to add the analyzer to all projects.

### Conclusion ###

Unfortunately, this does not fully solve #17726, as there is at least
one further leak on Android from my testing. But this is a good step
forward.