### PR TITLE
[Templates] Remove get-task-allow entitlement from Templates

### DIFF
--- a/src/Templates/src/templates/maui-blazor/Platforms/MacCatalyst/Entitlements.plist
+++ b/src/Templates/src/templates/maui-blazor/Platforms/MacCatalyst/Entitlements.plist
@@ -9,10 +9,6 @@
         <!-- When App Sandbox is enabled, this value is required to open outgoing network connections. -->
         <key>com.apple.security.network.client</key>
         <true/>
-        <!-- Enable this value to use browser developer tools while debugging. -->
-        <!-- See https://aka.ms/blazor-hybrid-developer-tools -->
-        <key>com.apple.security.get-task-allow</key>
-        <true/>
     </dict>
 </plist>
 

--- a/src/Templates/src/templates/maui-mobile/Platforms/MacCatalyst/Entitlements.plist
+++ b/src/Templates/src/templates/maui-mobile/Platforms/MacCatalyst/Entitlements.plist
@@ -9,10 +9,6 @@
         <!-- When App Sandbox is enabled, this value is required to open outgoing network connections. -->
         <key>com.apple.security.network.client</key>
         <true/>
-        <!-- Enable this value to use browser developer tools while debugging. -->
-        <!-- See https://aka.ms/blazor-hybrid-developer-tools -->
-        <!-- <key>com.apple.security.get-task-allow</key> -->
-        <!-- <true/> -->
     </dict>
 </plist>
 

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/TemplateTests.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/TemplateTests.cs
@@ -248,9 +248,8 @@ namespace Microsoft.Maui.IntegrationTests
 			Assert.IsTrue(DotnetInternal.Build(projectFile, config, framework: $"{framework}-maccatalyst", properties: buildWithCodeSignProps),
 				$"Project {Path.GetFileName(projectFile)} failed to build. Check test output/attachments for errors.");
 
-			List<string> expectedEntitlements = config == "Release" ?
-				new() { "com.apple.security.app-sandbox", "com.apple.security.network.client" } :
-				new() { "com.apple.security.app-sandbox", "com.apple.security.network.client", "com.apple.security.get-task-allow" };
+			List<string> expectedEntitlements =
+				new() { "com.apple.security.app-sandbox", "com.apple.security.network.client" };
 			List<string> foundEntitlements = Codesign.SearchForExpectedEntitlements(entitlementsPath, appLocation, expectedEntitlements);
 
 			CollectionAssert.AreEqual(expectedEntitlements, foundEntitlements, "Entitlements missing from executable.");


### PR DESCRIPTION
### Description of Change
@davidbritch brought this to my attention in this issue: https://github.com/dotnet/maui/issues/18259#issuecomment-1775338370. 

Some time ago, the solution was to add this entitlement to a project: https://github.com/dotnet/maui/issues/7706#issuecomment-1210106684

There had been some recent developments, and the issue was correctly addressed by https://github.com/dotnet/maui/pull/14610 and https://github.com/dotnet/maui/pull/16631.

Indeed, to test this, I created a template in NET8 for Blazor Hybrid, removed the entitlement from the entitlements.plist file, and then rebuilt the application and verified I could still use the developer tools.

Being that the entitlement is no longer necessary, we should remove it entirely from the templates.
