### PR TITLE
Ensure templates create a proper AppID

### DIFF
--- a/src/Templates/src/templates/maui-blazor/.template.config/template.json
+++ b/src/Templates/src/templates/maui-blazor/.template.config/template.json
@@ -85,6 +85,20 @@
           "toLower": true
         }
       },
+      "nameToAppId": {
+        "type": "generated",
+        "generator": "regex",
+        "dataType": "string",
+        "parameters": {
+          "source": "nameToLower",
+          "steps": [
+            {
+              "regex": "[^a-z0-9_\\.]",
+              "replacement": "_"
+            }
+          ]
+        }
+      },
       "defaultAppId":{
         "type": "generated",
         "generator": "join",
@@ -96,7 +110,7 @@
             },
             {
               "type": "ref",
-              "value": "nameToLower"
+              "value": "nameToAppId"
             }
           ]
         }

--- a/src/Templates/src/templates/maui-mobile/.template.config/template.json
+++ b/src/Templates/src/templates/maui-mobile/.template.config/template.json
@@ -89,6 +89,20 @@
           "toLower": true
         }
       },
+      "nameToAppId": {
+        "type": "generated",
+        "generator": "regex",
+        "dataType": "string",
+        "parameters": {
+          "source": "nameToLower",
+          "steps": [
+            {
+              "regex": "[^a-z0-9_\\.]",
+              "replacement": "_"
+            }
+          ]
+        }
+      },
       "defaultAppId":{
         "type": "generated",
         "generator": "join",
@@ -100,7 +114,7 @@
             },
             {
               "type": "ref",
-              "value": "nameToLower"
+              "value": "nameToAppId"
             }
           ]
         }


### PR DESCRIPTION
### Problem
After a template change that allowed new apps to specify the ApplicationID through the command line (#13509), if new apps created with spaces or non-alphanumeric characters in the name _**didn't**_ specify an ApplicationID, they would be generated with an invalid ApplicationID.

### Solution
Added an extra symbol created during template processing `nameToAppId` that grabs the app's lowercased name and creates a valid AppID that:
- replaces any non-alphanumeric character that's not an underscore or period with "_"

Example: `123 Cats.Fishy+)` => `123_cats.fishy__`
 
### Issues Fixed

Fixes #18177