### PR TITLE
Set supported version on iOS Gallery

### DIFF
--- a/src/Compatibility/ControlGallery/src/iOS/Compatibility.ControlGallery.iOS.csproj
+++ b/src/Compatibility/ControlGallery/src/iOS/Compatibility.ControlGallery.iOS.csproj
@@ -11,6 +11,7 @@
     <!--<MtouchLink Condition="'$(CI)' == 'true'">Full</MtouchLink>-->
     <NoWarn>0612</NoWarn>
     <SupportedOSPlatformVersion>11.0</SupportedOSPlatformVersion>
+    <TargetPlatformMinVersion>11.0</TargetPlatformMinVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">

--- a/src/Compatibility/ControlGallery/src/iOS/Compatibility.ControlGallery.iOS.csproj
+++ b/src/Compatibility/ControlGallery/src/iOS/Compatibility.ControlGallery.iOS.csproj
@@ -10,6 +10,7 @@
     <!--<DefineConstants>$(DefineConstants);HAVE_OPENTK</DefineConstants>-->
     <!--<MtouchLink Condition="'$(CI)' == 'true'">Full</MtouchLink>-->
     <NoWarn>0612</NoWarn>
+    <SupportedOSPlatformVersion>11.0</SupportedOSPlatformVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">


### PR DESCRIPTION
### Description of Change

Set iOS Compatibility gallery to support versions lower than the current Xcode version installed