### PR TITLE
[dependabot] Limit to 0 pr's

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
     - custom-nuget
   schedule:
     interval: daily
-  open-pull-requests-limit: 25
+  open-pull-requests-limit: 0
   groups:
     AndroidX:
       patterns:


### PR DESCRIPTION
### Description of Change

We have tried a couple of things to try force Dependabot to just update our packages from nuget.or, but we aren't having any luck with this. It always public the public dotnet8 feeds from our nuget.config. 

So for now just disabling opening pr's but keep the file around. 