### PR TITLE
[net7.0] Update dependencies from xamarin/xamarin-macios (#18361)

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -12,21 +12,21 @@
       <Uri>https://github.com/xamarin/xamarin-android</Uri>
       <Sha>6678e0213cbced08ab39aa1563b84068e751d836</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.MacCatalyst.Sdk" Version="16.4.7124">
+    <Dependency Name="Microsoft.MacCatalyst.Sdk" Version="16.4.7125">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>ac2134e66b0a68b2fe903890af4e670902e43e9c</Sha>
+      <Sha>24746c041e4925a94f2c9cbca38b5f80100db766</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.macOS.Sdk" Version="13.3.7124">
+    <Dependency Name="Microsoft.macOS.Sdk" Version="13.3.7125">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>ac2134e66b0a68b2fe903890af4e670902e43e9c</Sha>
+      <Sha>24746c041e4925a94f2c9cbca38b5f80100db766</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.iOS.Sdk" Version="16.4.7124">
+    <Dependency Name="Microsoft.iOS.Sdk" Version="16.4.7125">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>ac2134e66b0a68b2fe903890af4e670902e43e9c</Sha>
+      <Sha>24746c041e4925a94f2c9cbca38b5f80100db766</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.tvOS.Sdk" Version="16.4.7124">
+    <Dependency Name="Microsoft.tvOS.Sdk" Version="16.4.7125">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>ac2134e66b0a68b2fe903890af4e670902e43e9c</Sha>
+      <Sha>24746c041e4925a94f2c9cbca38b5f80100db766</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.Workload.Emscripten.net6.Manifest-7.0.100" Version="7.0.11" CoherentParentDependency="Microsoft.NETCore.App.Ref">
       <Uri>https://github.com/dotnet/emsdk</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -22,10 +22,10 @@
     <!-- xamarin/xamarin-android -->
     <MicrosoftAndroidSdkWindowsPackageVersion>33.0.95</MicrosoftAndroidSdkWindowsPackageVersion>
     <!-- xamarin/xamarin-macios -->
-    <MicrosoftMacCatalystSdkPackageVersion>16.4.7124</MicrosoftMacCatalystSdkPackageVersion>
-    <MicrosoftmacOSSdkPackageVersion>13.3.7124</MicrosoftmacOSSdkPackageVersion>
-    <MicrosoftiOSSdkPackageVersion>16.4.7124</MicrosoftiOSSdkPackageVersion>
-    <MicrosofttvOSSdkPackageVersion>16.4.7124</MicrosofttvOSSdkPackageVersion>
+    <MicrosoftMacCatalystSdkPackageVersion>16.4.7125</MicrosoftMacCatalystSdkPackageVersion>
+    <MicrosoftmacOSSdkPackageVersion>13.3.7125</MicrosoftmacOSSdkPackageVersion>
+    <MicrosoftiOSSdkPackageVersion>16.4.7125</MicrosoftiOSSdkPackageVersion>
+    <MicrosofttvOSSdkPackageVersion>16.4.7125</MicrosofttvOSSdkPackageVersion>
     <!-- Samsung/Tizen.NET -->
     <SamsungTizenSdkPackageVersion>7.0.120</SamsungTizenSdkPackageVersion>
     <!-- emsdk -->


### PR DESCRIPTION
### Description of Change

* Update dependencies from https://github.com/xamarin/xamarin-macios build 20231025.25

Microsoft.iOS.Sdk
 From Version 16.4.7124 -> To Version 16.4.7125

* Update dependencies from https://github.com/xamarin/xamarin-macios build 20231025.25

Microsoft.tvOS.Sdk
 From Version 16.4.7124 -> To Version 16.4.7125

* Update dependencies from https://github.com/xamarin/xamarin-macios build 20231025.25

Microsoft.macOS.Sdk
 From Version 13.3.7124 -> To Version 13.3.7125

* Update dependencies from https://github.com/xamarin/xamarin-macios build 20231025.25

Microsoft.MacCatalyst.Sdk
 From Version 16.4.7124 -> To Version 16.4.7125

---------

