### PR TITLE
[ios] fix memory leaks in various controls

### DIFF
--- a/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
+++ b/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Handlers;
 using Microsoft.Maui.Controls.Handlers.Compatibility;
+using Microsoft.Maui.Controls.Shapes;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Hosting;
 using Xunit;
@@ -17,7 +19,9 @@ public class MemoryTests : ControlsHandlerTestBase
 		{
 			builder.ConfigureMauiHandlers(handlers =>
 			{
+				handlers.AddHandler<ActivityIndicator, ActivityIndicatorHandler>();
 				handlers.AddHandler<Border, BorderHandler>();
+				handlers.AddHandler<BoxView, BoxViewHandler>();
 				handlers.AddHandler<CheckBox, CheckBoxHandler>();
 				handlers.AddHandler<DatePicker, DatePickerHandler>();
 				handlers.AddHandler<Entry, EntryHandler>();
@@ -26,18 +30,24 @@ public class MemoryTests : ControlsHandlerTestBase
 				handlers.AddHandler<Label, LabelHandler>();
 				handlers.AddHandler<ListView, ListViewRenderer>();
 				handlers.AddHandler<Picker, PickerHandler>();
+				handlers.AddHandler<Polygon, PolygonHandler>();
+				handlers.AddHandler<Polyline, PolylineHandler>();
 				handlers.AddHandler<IContentView, ContentViewHandler>();
 				handlers.AddHandler<Image, ImageHandler>();
+				handlers.AddHandler<IndicatorView, IndicatorViewHandler>();
 				handlers.AddHandler<RefreshView, RefreshViewHandler>();
 				handlers.AddHandler<IScrollView, ScrollViewHandler>();
 				handlers.AddHandler<SwipeView, SwipeViewHandler>();
 				handlers.AddHandler<TimePicker, TimePickerHandler>();
+				handlers.AddHandler<WebView, WebViewHandler>();
 			});
 		});
 	}
 
 	[Theory("Handler Does Not Leak")]
+	[InlineData(typeof(ActivityIndicator))]
 	[InlineData(typeof(Border))]
+	[InlineData(typeof(BoxView))]
 	[InlineData(typeof(ContentView))]
 	[InlineData(typeof(CheckBox))]
 	[InlineData(typeof(DatePicker))]
@@ -45,12 +55,16 @@ public class MemoryTests : ControlsHandlerTestBase
 	[InlineData(typeof(Editor))]
 	[InlineData(typeof(GraphicsView))]
 	[InlineData(typeof(Image))]
+	[InlineData(typeof(IndicatorView))]
 	[InlineData(typeof(Label))]
 	[InlineData(typeof(Picker))]
+	[InlineData(typeof(Polygon))]
+	[InlineData(typeof(Polyline))]
 	[InlineData(typeof(RefreshView))]
 	[InlineData(typeof(ScrollView))]
 	[InlineData(typeof(SwipeView))]
 	[InlineData(typeof(TimePicker))]
+	[InlineData(typeof(WebView))]
 	public async Task HandlerDoesNotLeak(Type type)
 	{
 		SetupBuilder();

--- a/src/Core/src/Platform/iOS/MauiActivityIndicator.cs
+++ b/src/Core/src/Platform/iOS/MauiActivityIndicator.cs
@@ -8,18 +8,21 @@ namespace Microsoft.Maui.Platform
 {
 	public class MauiActivityIndicator : UIActivityIndicatorView, IUIViewLifeCycleEvents
 	{
-		IActivityIndicator? _virtualView;
+		readonly WeakReference<IActivityIndicator>? _virtualView;
+
+		bool IsRunning => _virtualView is not null && _virtualView.TryGetTarget(out var a) ? a.IsRunning : false;
 
 		public MauiActivityIndicator(CGRect rect, IActivityIndicator? virtualView) : base(rect)
 		{
-			_virtualView = virtualView;
+			if (virtualView is not null)
+				_virtualView = new(virtualView);
 		}
 
 		public override void Draw(CGRect rect)
 		{
 			base.Draw(rect);
 
-			if (_virtualView?.IsRunning == true)
+			if (IsRunning)
 				StartAnimating();
 			else
 				StopAnimating();
@@ -29,7 +32,7 @@ namespace Microsoft.Maui.Platform
 		{
 			base.LayoutSubviews();
 
-			if (_virtualView?.IsRunning == true)
+			if (IsRunning)
 				StartAnimating();
 			else
 				StopAnimating();
@@ -38,9 +41,9 @@ namespace Microsoft.Maui.Platform
 		protected override void Dispose(bool disposing)
 		{
 			base.Dispose(disposing);
-
-			_virtualView = null;
 		}
+
+		readonly WeakEventManager _weakEventManager = new();
 
 		[UnconditionalSuppressMessage("Memory", "MA0002", Justification = IUIViewLifeCycleEvents.UnconditionalSuppressMessage)]
 		EventHandler? _movedToWindow;


### PR DESCRIPTION
Context: https://github.com/dotnet/maui/issues/18365

* `ActivityIndicator`
* `BoxView`
* `Polygon`
* `Polyline`
* `IndicatorView`

Some of these were based on `PlatformGraphicsView`, which had a circular reference, for example:

* `BoxView` -> `BoxViewHandler`/`PlatformGraphicsViewHandler` -> `PlatformGraphicsView` -> `BoxView`

* It appears both `IDrawable` and `IGraphicsRenderer` values in `PlatformGraphicsView` were circular references.

Various shapes were based on `PlatformGraphicsView`. We don't have the iOS memory analyzer running on `Microsoft.Maui.Graphics.dll` yet.

Similarly:

* `ActivityIndicator` -> `ActivityIndicatorHandler` -> `MauiActivityIndicator` -> `ActivityIndicator`

* `IndicatorView` -> `IndicatorViewHandler` -> `MauiPageControl` -> `IndicatorView`

*Open question*: Why didn't the analyzer catch the issues with `ActivityIndicator` and `IndicatorView`? Investigating why.