### PR TITLE
[ios] update MemoryAnalyzers and cleanup

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -5,7 +5,7 @@
   <Import Condition="'$(SampleProject)' != 'true' and '$(CI)' == 'true' " Project="eng\Versions.targets" />
   <Import Condition="'$(SampleProject)' != 'true' and '$(IsTestProject)' != 'true'" Project="eng\BannedApis.targets" />
   <Import Project="eng\AndroidX.targets" />
-  <Import Project="eng\Microsoft.Extensions.targets" />
+  <Import Project="eng\NuGetVersions.targets" />
 
   <PropertyGroup>
      <!-- Allows for MAUI Xaml Hot Reload Samples to run without checks  -->

--- a/eng/NuGetVersions.targets
+++ b/eng/NuGetVersions.targets
@@ -233,5 +233,10 @@
         Update="Fizzler"
         Version="$(FizzlerPackageVersion)"
     />
+    <PackageReference
+        Update="MemoryAnalyzers"
+        Version="0.1.0-beta.5"
+        PrivateAssets="All"
+    />
   </ItemGroup>
 </Project>

--- a/src/Controls/src/Core/ContentPage/HideSoftInputOnTappedChanged/ResignFirstResponderTouchGestureRecognizer.iOS.cs
+++ b/src/Controls/src/Core/ContentPage/HideSoftInputOnTappedChanged/ResignFirstResponderTouchGestureRecognizer.iOS.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Maui.Platform
 	internal class ResignFirstResponderTouchGestureRecognizer : UITapGestureRecognizer
 	{
 		readonly WeakReference<UIView> _targetView;
-		[UnconditionalSuppressMessage("Memory", "MA0002", Justification = "Proven safe in test: UIViewSubclassTests.ResignFirstResponderTouchGestureRecognizer")]
+		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = "Proven safe in test: UIViewSubclassTests.ResignFirstResponderTouchGestureRecognizer")]
 		Token? _token;
 
 		public ResignFirstResponderTouchGestureRecognizer(UIView targetView) :

--- a/src/Core/src/Core.csproj
+++ b/src/Core/src/Core.csproj
@@ -16,7 +16,7 @@
   <Import Project="$(MauiSrcDirectory)MultiTargeting.targets" />
 
   <ItemGroup>
-    <PackageReference Include="MemoryAnalyzers" Version="0.1.0-beta.4" PrivateAssets="All" />
+    <PackageReference Include="MemoryAnalyzers" />
     <PackageReference Include="Microsoft.Extensions.Configuration" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.Logging" />

--- a/src/Core/src/Handlers/SwipeItemMenuItem/SwipeItemMenuItemHandler.iOS.cs
+++ b/src/Core/src/Handlers/SwipeItemMenuItem/SwipeItemMenuItemHandler.iOS.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Maui.Handlers
 {
 	public class SwipeItemButton : UIButton
 	{
-		[UnconditionalSuppressMessage("Memory", "MA0001", Justification = "Proven safe in test: SwipeViewTests.ItemsDoNotLeak")]
+		[UnconditionalSuppressMessage("Memory", "MEM0001", Justification = "Proven safe in test: SwipeViewTests.ItemsDoNotLeak")]
 		public event EventHandler? FrameChanged;
 
 		public override CGRect Frame

--- a/src/Core/src/Platform/WrapperView.cs
+++ b/src/Core/src/Platform/WrapperView.cs
@@ -1,11 +1,15 @@
-﻿using Microsoft.Maui.Graphics;
+﻿using System.Diagnostics.CodeAnalysis;
+using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Platform
 {
 	public partial class WrapperView
 	{
+		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = "IShape is a non-NSObject in MAUI.")]
 		IShape? _clip;
+		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = "IShadow is a non-NSObject in MAUI.")]
 		IShadow? _shadow;
+		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = "IBorder is a non-NSObject in MAUI.")]
 		IBorderStroke? _border;
 
 #if WINDOWS

--- a/src/Core/src/Platform/iOS/ContainerViewController.cs
+++ b/src/Core/src/Platform/iOS/ContainerViewController.cs
@@ -8,14 +8,15 @@ namespace Microsoft.Maui.Platform
 {
 	public class ContainerViewController : UIViewController, IReloadHandler
 	{
+		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = "Proven safe in test: NavigationPageTests.DoesNotLeak")]
 		IElement? _view;
-		[UnconditionalSuppressMessage("Memory", "MA0002", Justification = "Proven safe in test: NavigationPageTests.DoesNotLeak")]
+		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = "Proven safe in test: NavigationPageTests.DoesNotLeak")]
 		UIView? currentPlatformView;
 
 		// The handler needs this view before LoadView is called on the controller
 		// So this is used to create the first view that the handler will use
 		// without forcing the VC to call LoadView
-		[UnconditionalSuppressMessage("Memory", "MA0002", Justification = "Proven safe in test: NavigationPageTests.DoesNotLeak")]
+		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = "Proven safe in test: NavigationPageTests.DoesNotLeak")]
 		UIView? _pendingLoadedView;
 
 		public IElement? CurrentView
@@ -27,6 +28,7 @@ namespace Microsoft.Maui.Platform
 		public UIView? CurrentPlatformView
 			=> _pendingLoadedView ?? currentPlatformView;
 
+		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = "IMauiContext is a non-NSObject in MAUI.")]
 		public IMauiContext? Context { get; set; }
 
 		void SetView(IElement? view, bool forceRefresh = false)

--- a/src/Core/src/Platform/iOS/MauiActivityIndicator.cs
+++ b/src/Core/src/Platform/iOS/MauiActivityIndicator.cs
@@ -43,9 +43,7 @@ namespace Microsoft.Maui.Platform
 			base.Dispose(disposing);
 		}
 
-		readonly WeakEventManager _weakEventManager = new();
-
-		[UnconditionalSuppressMessage("Memory", "MA0002", Justification = IUIViewLifeCycleEvents.UnconditionalSuppressMessage)]
+		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = IUIViewLifeCycleEvents.UnconditionalSuppressMessage)]
 		EventHandler? _movedToWindow;
 		event EventHandler IUIViewLifeCycleEvents.MovedToWindow
 		{

--- a/src/Core/src/Platform/iOS/MauiBoxView.cs
+++ b/src/Core/src/Platform/iOS/MauiBoxView.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Maui.Platform
 			BackgroundColor = UIColor.Clear;
 		}
 
-		[UnconditionalSuppressMessage("Memory", "MA0002", Justification = IUIViewLifeCycleEvents.UnconditionalSuppressMessage)]
+		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = IUIViewLifeCycleEvents.UnconditionalSuppressMessage)]
 		EventHandler? _movedToWindow;
 		event EventHandler IUIViewLifeCycleEvents.MovedToWindow
 		{

--- a/src/Core/src/Platform/iOS/MauiCALayer.cs
+++ b/src/Core/src/Platform/iOS/MauiCALayer.cs
@@ -1,5 +1,6 @@
 ﻿#nullable enable
 using System;
+using System.Diagnostics.CodeAnalysis;
 using CoreAnimation;
 using CoreGraphics;
 using Microsoft.Maui.Graphics;
@@ -12,7 +13,7 @@ namespace Microsoft.Maui.Platform
 	public class MauiCALayer : CALayer
 	{
 		CGRect _bounds;
-
+		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = "IShape is a non-NSObject in MAUI.")]
 		IShape? _shape;
 
 		UIColor? _backgroundColor;

--- a/src/Core/src/Platform/iOS/MauiCheckBox.cs
+++ b/src/Core/src/Platform/iOS/MauiCheckBox.cs
@@ -302,7 +302,7 @@ namespace Microsoft.Maui.Platform
 			set { }
 		}
 
-		[UnconditionalSuppressMessage("Memory", "MA0002", Justification = IUIViewLifeCycleEvents.UnconditionalSuppressMessage)]
+		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = IUIViewLifeCycleEvents.UnconditionalSuppressMessage)]
 		EventHandler? _movedToWindow;
 		event EventHandler IUIViewLifeCycleEvents.MovedToWindow
 		{

--- a/src/Core/src/Platform/iOS/MauiImageView.cs
+++ b/src/Core/src/Platform/iOS/MauiImageView.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Maui.Platform
 		{
 		}
 
-		[UnconditionalSuppressMessage("Memory", "MA0002", Justification = IUIViewLifeCycleEvents.UnconditionalSuppressMessage)]
+		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = IUIViewLifeCycleEvents.UnconditionalSuppressMessage)]
 		EventHandler? _movedToWindow;
 		event EventHandler IUIViewLifeCycleEvents.MovedToWindow
 		{

--- a/src/Core/src/Platform/iOS/MauiLabel.cs
+++ b/src/Core/src/Platform/iOS/MauiLabel.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Maui.Platform
 			width: size.Width + TextInsets.Left + TextInsets.Right,
 			height: size.Height + TextInsets.Top + TextInsets.Bottom);
 
-		[UnconditionalSuppressMessage("Memory", "MA0002", Justification = IUIViewLifeCycleEvents.UnconditionalSuppressMessage)]
+		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = IUIViewLifeCycleEvents.UnconditionalSuppressMessage)]
 		EventHandler _movedToWindow;
 		event EventHandler IUIViewLifeCycleEvents.MovedToWindow
 		{

--- a/src/Core/src/Platform/iOS/MauiPageControl.cs
+++ b/src/Core/src/Platform/iOS/MauiPageControl.cs
@@ -146,7 +146,7 @@ namespace Microsoft.Maui.Platform
 
 		}
 
-		[UnconditionalSuppressMessage("Memory", "MA0002", Justification = IUIViewLifeCycleEvents.UnconditionalSuppressMessage)]
+		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = IUIViewLifeCycleEvents.UnconditionalSuppressMessage)]
 		EventHandler? _movedToWindow;
 		event EventHandler IUIViewLifeCycleEvents.MovedToWindow
 		{

--- a/src/Core/src/Platform/iOS/MauiPicker.cs
+++ b/src/Core/src/Platform/iOS/MauiPicker.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Maui.Platform
 			_enableActions = new HashSet<string>(actions);
 		}
 
-		[UnconditionalSuppressMessage("Memory", "MA0002", Justification = "Proven safe in test: MemoryTests.HandlerDoesNotLeak")]
+		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = "Proven safe in test: MemoryTests.HandlerDoesNotLeak")]
 		public UIPickerView? UIPickerView { get; set; }
 
 		public override bool CanPerform(Selector action, NSObject? withSender)

--- a/src/Core/src/Platform/iOS/MauiRefreshView.cs
+++ b/src/Core/src/Platform/iOS/MauiRefreshView.cs
@@ -15,11 +15,11 @@ namespace Microsoft.Maui.Platform
 		bool _isRefreshing;
 		nfloat _originalY;
 		nfloat _refreshControlHeight;
-		[UnconditionalSuppressMessage("Memory", "MA0002", Justification = "Proven safe in test: MemoryTests.HandlerDoesNotLeak")]
+		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = "Proven safe in test: MemoryTests.HandlerDoesNotLeak")]
 		UIView _refreshControlParent;
-		[UnconditionalSuppressMessage("Memory", "MA0002", Justification = "Proven safe in test: MemoryTests.HandlerDoesNotLeak")]
+		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = "Proven safe in test: MemoryTests.HandlerDoesNotLeak")]
 		UIView? _contentView;
-		[UnconditionalSuppressMessage("Memory", "MA0002", Justification = "Proven safe in test: MemoryTests.HandlerDoesNotLeak")]
+		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = "Proven safe in test: MemoryTests.HandlerDoesNotLeak")]
 		UIRefreshControl _refreshControl;
 		public UIRefreshControl RefreshControl => _refreshControl;
 
@@ -199,7 +199,7 @@ namespace Microsoft.Maui.Platform
 			this.GetNavigationController()?.NavigationBar?.PrefersLargeTitles ?? true;
 #pragma warning restore CA1416
 
-		[UnconditionalSuppressMessage("Memory", "MA0002", Justification = IUIViewLifeCycleEvents.UnconditionalSuppressMessage)]
+		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = IUIViewLifeCycleEvents.UnconditionalSuppressMessage)]
 		EventHandler? _movedToWindow;
 		event EventHandler IUIViewLifeCycleEvents.MovedToWindow
 		{

--- a/src/Core/src/Platform/iOS/MauiScrollView.cs
+++ b/src/Core/src/Platform/iOS/MauiScrollView.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Maui.Platform
 				base.ScrollRectToVisible(rect, animated);
 		}
 
-		[UnconditionalSuppressMessage("Memory", "MA0002", Justification = IUIViewLifeCycleEvents.UnconditionalSuppressMessage)]
+		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = IUIViewLifeCycleEvents.UnconditionalSuppressMessage)]
 		EventHandler? _movedToWindow;
 		event EventHandler IUIViewLifeCycleEvents.MovedToWindow
 		{

--- a/src/Core/src/Platform/iOS/MauiSearchBar.cs
+++ b/src/Core/src/Platform/iOS/MauiSearchBar.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Maui.Platform
 		// Native Changed doesn't fire when the Text Property is set in code
 		// We use this event as a way to fire changes whenever the Text changes
 		// via code or user interaction.
-		[UnconditionalSuppressMessage("Memory", "MA0001", Justification = "FIXME: https://github.com/dotnet/maui/pull/16383")]
+		[UnconditionalSuppressMessage("Memory", "MEM0001", Justification = "FIXME: https://github.com/dotnet/maui/pull/16383")]
 		public event EventHandler<UISearchBarTextChangedEventArgs>? TextSetOrChanged;
 
 		public override string? Text
@@ -52,9 +52,9 @@ namespace Microsoft.Maui.Platform
 			}
 		}
 
-		[UnconditionalSuppressMessage("Memory", "MA0001", Justification = "FIXME: https://github.com/dotnet/maui/pull/16383")]
+		[UnconditionalSuppressMessage("Memory", "MEM0001", Justification = "FIXME: https://github.com/dotnet/maui/pull/16383")]
 		internal event EventHandler? OnMovedToWindow;
-		[UnconditionalSuppressMessage("Memory", "MA0001", Justification = "FIXME: https://github.com/dotnet/maui/pull/16383")]
+		[UnconditionalSuppressMessage("Memory", "MEM0001", Justification = "FIXME: https://github.com/dotnet/maui/pull/16383")]
 		internal event EventHandler? EditingChanged;
 
 		public override void WillMoveToWindow(UIWindow? window)
@@ -74,13 +74,13 @@ namespace Microsoft.Maui.Platform
 				OnMovedToWindow?.Invoke(this, EventArgs.Empty);
 		}
 
-		[UnconditionalSuppressMessage("Memory", "MA0003", Justification = "FIXME: https://github.com/dotnet/maui/pull/16383")]
+		[UnconditionalSuppressMessage("Memory", "MEM0003", Justification = "FIXME: https://github.com/dotnet/maui/pull/16383")]
 		void OnEditingChanged(object? sender, EventArgs e)
 		{
 			EditingChanged?.Invoke(this, EventArgs.Empty);
 		}
 
-		[UnconditionalSuppressMessage("Memory", "MA0002", Justification = IUIViewLifeCycleEvents.UnconditionalSuppressMessage)]
+		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = IUIViewLifeCycleEvents.UnconditionalSuppressMessage)]
 		EventHandler? _movedToWindow;
 		event EventHandler IUIViewLifeCycleEvents.MovedToWindow
 		{

--- a/src/Core/src/Platform/iOS/MauiShapeView.cs
+++ b/src/Core/src/Platform/iOS/MauiShapeView.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Maui.Platform
 			BackgroundColor = UIColor.Clear;
 		}
 
-		[UnconditionalSuppressMessage("Memory", "MA0002", Justification = IUIViewLifeCycleEvents.UnconditionalSuppressMessage)]
+		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = IUIViewLifeCycleEvents.UnconditionalSuppressMessage)]
 		EventHandler? _movedToWindow;
 		event EventHandler IUIViewLifeCycleEvents.MovedToWindow
 		{

--- a/src/Core/src/Platform/iOS/MauiSwipeView.cs
+++ b/src/Core/src/Platform/iOS/MauiSwipeView.cs
@@ -17,13 +17,13 @@ namespace Microsoft.Maui.Platform
 
 		readonly SwipeRecognizerProxy _proxy;
 		readonly Dictionary<ISwipeItem, object> _swipeItems;
-		[UnconditionalSuppressMessage("Memory", "MA0002", Justification = "Proven safe in test: MemoryTests.HandlerDoesNotLeak")]
+		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = "Proven safe in test: MemoryTests.HandlerDoesNotLeak")]
 		readonly UITapGestureRecognizer _tapGestureRecognizer;
-		[UnconditionalSuppressMessage("Memory", "MA0002", Justification = "Proven safe in test: MemoryTests.HandlerDoesNotLeak")]
+		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = "Proven safe in test: MemoryTests.HandlerDoesNotLeak")]
 		readonly UIPanGestureRecognizer _panGestureRecognizer;
-		[UnconditionalSuppressMessage("Memory", "MA0002", Justification = "Proven safe in test: MemoryTests.HandlerDoesNotLeak")]
+		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = "Proven safe in test: MemoryTests.HandlerDoesNotLeak")]
 		UIView _contentView;
-		[UnconditionalSuppressMessage("Memory", "MA0002", Justification = "Proven safe in test: MemoryTests.HandlerDoesNotLeak")]
+		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = "Proven safe in test: MemoryTests.HandlerDoesNotLeak")]
 		UIStackView _actionView;
 		SwipeTransitionMode _swipeTransitionMode;
 		SwipeDirection? _swipeDirection;

--- a/src/Core/src/Platform/iOS/MauiTextField.cs
+++ b/src/Core/src/Platform/iOS/MauiTextField.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Maui.Platform
 			}
 		}
 
-		[UnconditionalSuppressMessage("Memory", "MA0002", Justification = IUIViewLifeCycleEvents.UnconditionalSuppressMessage)]
+		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = IUIViewLifeCycleEvents.UnconditionalSuppressMessage)]
 		EventHandler? _movedToWindow;
 		event EventHandler IUIViewLifeCycleEvents.MovedToWindow
 		{
@@ -80,9 +80,9 @@ namespace Microsoft.Maui.Platform
 			_movedToWindow?.Invoke(this, EventArgs.Empty);
 		}
 
-		[UnconditionalSuppressMessage("Memory", "MA0001", Justification = "Proven safe in test: MemoryTests.HandlerDoesNotLeak")]
+		[UnconditionalSuppressMessage("Memory", "MEM0001", Justification = "Proven safe in test: MemoryTests.HandlerDoesNotLeak")]
 		public event EventHandler? TextPropertySet;
-		[UnconditionalSuppressMessage("Memory", "MA0001", Justification = "Proven safe in test: MemoryTests.HandlerDoesNotLeak")]
+		[UnconditionalSuppressMessage("Memory", "MEM0001", Justification = "Proven safe in test: MemoryTests.HandlerDoesNotLeak")]
 		internal event EventHandler? SelectionChanged;
 	}
 }

--- a/src/Core/src/Platform/iOS/MauiTextView.cs
+++ b/src/Core/src/Platform/iOS/MauiTextView.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Maui.Platform
 {
 	public class MauiTextView : UITextView, IUIViewLifeCycleEvents
 	{
-		[UnconditionalSuppressMessage("Memory", "MA0002", Justification = "Proven safe in test: MemoryTests.HandlerDoesNotLeak")]
+		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = "Proven safe in test: MemoryTests.HandlerDoesNotLeak")]
 		readonly MauiLabel _placeholderLabel;
 		nfloat? _defaultPlaceholderSize;
 
@@ -37,7 +37,7 @@ namespace Microsoft.Maui.Platform
 		// Native Changed doesn't fire when the Text Property is set in code
 		// We use this event as a way to fire changes whenever the Text changes
 		// via code or user interaction.
-		[UnconditionalSuppressMessage("Memory", "MA0001", Justification = "Proven safe in test: MemoryTests.HandlerDoesNotLeak")]
+		[UnconditionalSuppressMessage("Memory", "MEM0001", Justification = "Proven safe in test: MemoryTests.HandlerDoesNotLeak")]
 		public event EventHandler? TextSetOrChanged;
 
 		public string? PlaceholderText
@@ -181,7 +181,7 @@ namespace Microsoft.Maui.Platform
 				value?.PointSize ?? _defaultPlaceholderSize.Value);
 		}
 
-		[UnconditionalSuppressMessage("Memory", "MA0002", Justification = IUIViewLifeCycleEvents.UnconditionalSuppressMessage)]
+		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = IUIViewLifeCycleEvents.UnconditionalSuppressMessage)]
 		EventHandler? _movedToWindow;
 		event EventHandler IUIViewLifeCycleEvents.MovedToWindow
 		{

--- a/src/Core/src/Platform/iOS/MauiTimePicker.cs
+++ b/src/Core/src/Platform/iOS/MauiTimePicker.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Maui.Platform
 {
 	public class MauiTimePicker : NoCaretField
 	{
-		[UnconditionalSuppressMessage("Memory", "MA0002", Justification = "Proven safe in test: MemoryTests.HandlerDoesNotLeak")]
+		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = "Proven safe in test: MemoryTests.HandlerDoesNotLeak")]
 		readonly UIDatePicker _picker;
 
 #if !MACCATALYST

--- a/src/Core/src/Platform/iOS/MauiUIApplicationDelegate.Menu.cs
+++ b/src/Core/src/Platform/iOS/MauiUIApplicationDelegate.Menu.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Versioning;
 using Foundation;
 using Microsoft.Extensions.DependencyInjection;
@@ -12,6 +13,7 @@ namespace Microsoft.Maui
 {
 	public partial class MauiUIApplicationDelegate
 	{
+		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = "There is a single MauiUIApplicationDelegate")]
 		internal IUIMenuBuilder? MenuBuilder { get; private set; }
 
 		[SupportedOSPlatform("ios13.0")]

--- a/src/Core/src/Platform/iOS/MauiUIApplicationDelegate.cs
+++ b/src/Core/src/Platform/iOS/MauiUIApplicationDelegate.cs
@@ -17,10 +17,12 @@ namespace Microsoft.Maui
 		internal const string MauiSceneConfigurationKey = "__MAUI_DEFAULT_SCENE_CONFIGURATION__";
 		internal const string GetConfigurationSelectorName = "application:configurationForConnectingSceneSession:options:";
 
+		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = "IMauiContext is a non-NSObject in MAUI.")]
 		IMauiContext _applicationContext = null!;
 
+		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = "IServiceProvider is a non-NSObject from Microsoft.Extensions.DependencyInjection.")]
 		IServiceProvider? _services;
-
+		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = "IApplication is a non-NSObject in MAUI.")]
 		IApplication? _application;
 
 		protected MauiUIApplicationDelegate() : base()
@@ -163,7 +165,7 @@ namespace Microsoft.Maui
 			_services?.InvokeLifecycleEvents<iOSLifecycle.PerformFetch>(del => del(application, completionHandler));
 		}
 
-		[UnconditionalSuppressMessage("Memory", "MA0002", Justification = "There can only be one MauiUIApplicationDelegate.")]
+		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = "There can only be one MauiUIApplicationDelegate.")]
 		public static MauiUIApplicationDelegate Current { get; private set; } = null!;
 
 		[Export("window")]

--- a/src/Core/src/Platform/iOS/MauiUIContextMenuInteraction.cs
+++ b/src/Core/src/Platform/iOS/MauiUIContextMenuInteraction.cs
@@ -13,13 +13,9 @@ namespace Microsoft.Maui.Platform
 	{
 		WeakReference<IElementHandler> _handler;
 
-		// Store a reference to the platform delegate so that it is not garbage collected
-		IUIContextMenuInteractionDelegate? _uiContextMenuInteractionDelegate;
-
 		public MauiUIContextMenuInteraction(IElementHandler handler)
 			: base(new FlyoutUIContextMenuInteractionDelegate())
 		{
-			_uiContextMenuInteractionDelegate = Delegate;
 			_handler = new WeakReference<IElementHandler>(handler);
 		}
 

--- a/src/Core/src/Platform/iOS/MauiUIContextMenuInteraction.cs
+++ b/src/Core/src/Platform/iOS/MauiUIContextMenuInteraction.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Versioning;
 using CoreGraphics;
 using Foundation;
@@ -13,11 +14,19 @@ namespace Microsoft.Maui.Platform
 	{
 		WeakReference<IElementHandler> _handler;
 
+		// Store a reference to the platform delegate so that it is not garbage collected
+		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = "Delegate is weak on Objective-C side")]
+		readonly IUIContextMenuInteractionDelegate? _uiContextMenuInteractionDelegate;
+
 		public MauiUIContextMenuInteraction(IElementHandler handler)
-			: base(new FlyoutUIContextMenuInteractionDelegate())
+			: base(CreateDelegate (out var del))
 		{
+			_uiContextMenuInteractionDelegate = del;
 			_handler = new WeakReference<IElementHandler>(handler);
 		}
+
+		static IUIContextMenuInteractionDelegate CreateDelegate (out IUIContextMenuInteractionDelegate del) =>
+			del = new FlyoutUIContextMenuInteractionDelegate();
 
 		public UIContextMenuConfiguration? GetConfigurationForMenu()
 		{

--- a/src/Core/src/Platform/iOS/MauiView.cs
+++ b/src/Core/src/Platform/iOS/MauiView.cs
@@ -158,7 +158,7 @@ namespace Microsoft.Maui.Platform
 			return null;
 		}
 
-		[UnconditionalSuppressMessage("Memory", "MA0002", Justification = IUIViewLifeCycleEvents.UnconditionalSuppressMessage)]
+		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = IUIViewLifeCycleEvents.UnconditionalSuppressMessage)]
 		EventHandler? _movedToWindow;
 		event EventHandler? IUIViewLifeCycleEvents.MovedToWindow
 		{

--- a/src/Core/src/Platform/iOS/MauiWKWebView.cs
+++ b/src/Core/src/Platform/iOS/MauiWKWebView.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Maui.Platform
 {
 	public class MauiWKWebView : WKWebView, IWebViewDelegate, IUIViewLifeCycleEvents
 	{
-		[UnconditionalSuppressMessage("Memory", "MA0002", Justification = "Used to persist cookies across WebView instances. Not a leak.")]
+		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = "Used to persist cookies across WebView instances. Not a leak.")]
 		static WKProcessPool? SharedPool;
 
 		string? _pendingUrl;
@@ -200,7 +200,7 @@ namespace Microsoft.Maui.Platform
 			return false;
 		}
 
-		[UnconditionalSuppressMessage("Memory", "MA0002", Justification = IUIViewLifeCycleEvents.UnconditionalSuppressMessage)]
+		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = IUIViewLifeCycleEvents.UnconditionalSuppressMessage)]
 		EventHandler? _movedToWindow;
 		event EventHandler IUIViewLifeCycleEvents.MovedToWindow
 		{

--- a/src/Core/src/Platform/iOS/NoCaretField.cs
+++ b/src/Core/src/Platform/iOS/NoCaretField.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Maui.Platform
 			return RectangleF.Empty;
 		}
 
-		[UnconditionalSuppressMessage("Memory", "MA0002", Justification = IUIViewLifeCycleEvents.UnconditionalSuppressMessage)]
+		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = IUIViewLifeCycleEvents.UnconditionalSuppressMessage)]
 		EventHandler? _movedToWindow;
 		event EventHandler? IUIViewLifeCycleEvents.MovedToWindow
 		{

--- a/src/Core/src/Platform/iOS/PlatformTouchGraphicsView.cs
+++ b/src/Core/src/Platform/iOS/PlatformTouchGraphicsView.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Maui.Platform
 	{
 		readonly UIHoverGestureRecognizerProxy _proxy;
 		WeakReference<IGraphicsView>? _graphicsView;
-		[UnconditionalSuppressMessage("Memory", "MA0002", Justification = "Proven safe in test: MemoryTests.HandlerDoesNotLeak")]
+		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = "Proven safe in test: MemoryTests.HandlerDoesNotLeak")]
 		UIHoverGestureRecognizer? _hoverGesture;
 		RectF _rect;
 		bool _pressedContained;

--- a/src/Core/src/Platform/iOS/WrapperView.cs
+++ b/src/Core/src/Platform/iOS/WrapperView.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Maui.Platform
 		CAShapeLayer? _maskLayer;
 		CAShapeLayer? _backgroundMaskLayer;
 		CAShapeLayer? _shadowLayer;
-		[UnconditionalSuppressMessage("Memory", "MA0002", Justification = "_borderView is a SubView")]
+		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = "_borderView is a SubView")]
 		UIView? _borderView;
 
 		public WrapperView()
@@ -248,7 +248,7 @@ namespace Microsoft.Maui.Platform
 			return Layer;
 		}
 
-		[UnconditionalSuppressMessage("Memory", "MA0002", Justification = IUIViewLifeCycleEvents.UnconditionalSuppressMessage)]
+		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = IUIViewLifeCycleEvents.UnconditionalSuppressMessage)]
 		EventHandler? _movedToWindow;
 		event EventHandler? IUIViewLifeCycleEvents.MovedToWindow
 		{


### PR DESCRIPTION
`MemoryAnalyzers` 0.1.0-beta.5 now warns about interfaces like:

    public class MyView : UIView
    {
        IFoo foo;
    }

Since another `UIView` subclass could be assigned to `foo` at runtime, creating a circular reference -- it should be good to warn about this going forward. This is what allowed some of the leaks to slip through in a589b120.

A few new warnings appeared, but I don't think they are real issues except for `src\Core\src\Platform\iOS\MauiUIContextMenuInteraction.cs`, which I think we can just remove the field.

I also changed the warning code from `MA*` to `MEM*`, as there were already error codes in the `MA*` range.

Lastly, I renamed `Microsoft.Extensions.targets` to `NuGetVersions.targets` as we have many packages in there beyond `Microsoft.Extensions`. We can also start tracking the `MemoryAnalyzers` version here as we start adding it to more projects.