### PR TITLE
(Windows) Fix backbutton not being drawn for other NavigationPages

### DIFF
--- a/src/Controls/src/Core/NavigationPage/NavigationPage.cs
+++ b/src/Controls/src/Core/NavigationPage/NavigationPage.cs
@@ -548,6 +548,12 @@ namespace Microsoft.Maui.Controls
 					{
 						w.Toolbar = null;
 					}
+					
+					var flyoutPage = _toolbar.FindParentOfType<FlyoutPage>();
+					if (flyoutPage != null && flyoutPage.Parent is IWindow)
+					{
+						flyoutPage.Toolbar = null;
+					}
 
 					_toolbar.Disconnect();
 					_toolbar = null;

--- a/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.Windows.cs
@@ -38,6 +38,37 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
+		[Fact(DisplayName = "Back Button Enabled Changes with push/pop + page change")]
+		public async Task BackButtonEnabledChangesWithPushPopAndPageChanges()
+		{
+			SetupBuilder();
+
+			var flyoutPage = new FlyoutPage();
+			flyoutPage.Title = "Hello world";
+            flyoutPage.FlyoutLayoutBehavior = FlyoutLayoutBehavior.Split;
+			flyoutPage.Flyout = new ContentPage() { Title = "Hello world" };
+
+			var first = new NavigationPage(new ContentPage());
+			var second = new NavigationPage(new ContentPage());
+
+            flyoutPage.Detail = first;
+
+            await CreateHandlerAndAddToWindow<FlyoutViewHandler>(flyoutPage, async (handler) =>
+			{
+				var navView = (RootNavigationView)GetMauiNavigationView(handler.MauiContext);
+				Assert.False(navView.IsBackEnabled);
+
+				await first.PushAsync(new ContentPage());
+				Assert.True(navView.IsBackEnabled);
+
+				flyoutPage.Detail = second;
+				Assert.False(navView.IsBackEnabled);
+
+				await second.PushAsync(new ContentPage());
+				Assert.True(navView.IsBackEnabled);
+			});
+		}
+
 		[Fact(DisplayName = "App Title Bar Margin Sets when Back Button Visible")]
 		public async Task AppTitleBarMarginSetsWhenBackButtonVisible()
 		{

--- a/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.cs
@@ -31,7 +31,8 @@ namespace Microsoft.Maui.DeviceTests
 					handlers.AddHandler(typeof(NavigationPage), typeof(NavigationViewHandler));
 					handlers.AddHandler(typeof(TabbedPage), typeof(TabbedViewHandler));
 #endif
-					handlers.AddHandler<Page, PageHandler>();
+                    handlers.AddHandler(typeof(FlyoutPage), typeof(FlyoutViewHandler));
+                    handlers.AddHandler<Page, PageHandler>();
 					handlers.AddHandler<Window, WindowHandlerStub>();
 					handlers.AddHandler<Frame, FrameRenderer>();
 					handlers.AddHandler<Label, LabelHandler>();

--- a/src/Core/src/Platform/Windows/RootNavigationView.cs
+++ b/src/Core/src/Platform/Windows/RootNavigationView.cs
@@ -54,6 +54,7 @@ namespace Microsoft.Maui.Platform
 				}
 
 				UpdateToolbarPlacement();
+				UpdateHeaderPropertyBinding();
 			}
 		}
 


### PR DESCRIPTION
### Description of Change

Fix backbutton not being updated on some NavigationPages. The issue is caused in `RootNavigationView`: we don't update the back button and header bindings when the toolbar changes, which happens when the active `NavigationPage` is set.

### Issues Fixed
Fixes #18064
