### PR TITLE
Backport #16762 - [windows] fix memory leak in ListView

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/Windows/CellControl.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/Windows/CellControl.cs
@@ -68,6 +68,8 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			Cell.SendDisappearing();
 			// 🚀 unsubscribe from propertychanged
 			Cell.PropertyChanged -= _propertyChangedHandler;
+			// Allows the Cell to unsubscribe from Parent.PropertyChanged
+			Cell.Parent = null;
 		}
 
 

--- a/src/Controls/tests/DeviceTests/Elements/ListView/ListViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/ListView/ListViewTests.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.ObjectModel;
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
@@ -19,7 +22,9 @@ namespace Microsoft.Maui.DeviceTests
 			{
 				builder.ConfigureMauiHandlers(handlers =>
 				{
+					handlers.AddHandler<EntryCell, EntryCellRenderer>();
 					handlers.AddHandler<ViewCell, ViewCellRenderer>();
+					handlers.AddHandler<TextCell, TextCellRenderer>();
 					handlers.AddHandler<ListView, ListViewRenderer>();
 					handlers.AddHandler<VerticalStackLayout, LayoutHandler>();
 					handlers.AddHandler<Label, LabelHandler>();
@@ -113,6 +118,62 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		[Fact]
+		public async Task EntryCellBindingCorrectlyUpdates()
+		{
+			SetupBuilder();
+			var vm = new EntryCellBindingCorrectlyUpdatesVM();
+			var data = new[]
+			{
+				vm
+			};
+
+			var listView = new ListView()
+			{
+				ItemTemplate = new DataTemplate(() =>
+				{
+					var cell = new EntryCell();
+					cell.SetBinding(EntryCell.TextProperty, "Value");
+					return cell;
+				}),
+				ItemsSource = data
+			};
+
+			var layout = new VerticalStackLayout()
+			{
+				listView
+			};
+
+			await CreateHandlerAndAddToWindow<LayoutHandler>(layout, async (handler) =>
+			{
+				await Task.Yield();
+				var entryCell = listView.TemplatedItems[0] as EntryCell;
+
+				// Initial Value is correct
+				Assert.Equal(vm.Value, entryCell.Text);
+
+				// Validate that the binding stays operational
+				for (int i = 0; i < 3; i++)
+				{
+					vm.ChangeValue();
+					await Task.Yield();
+					Assert.Equal(vm.Value, entryCell.Text);
+				}
+			});
+		}
+		class EntryCellBindingCorrectlyUpdatesVM : INotifyPropertyChanged
+		{
+			public event PropertyChangedEventHandler PropertyChanged;
+
+			public string Value { get; set; }
+
+			public void ChangeValue()
+			{
+				Value = Guid.NewGuid().ToString();
+				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Value)));
+			}
+		}
+
+		[Fact]
 		public async Task ClearItemsListViewDoesntCrash()
 		{
 			SetupBuilder();
@@ -150,6 +211,83 @@ namespace Microsoft.Maui.DeviceTests
 				ValidatePlatformCells(listView);
 				data.Clear();
 				await Task.Delay(100);
+			});
+		}
+
+		[Fact("Cells Do Not Leak"
+#if !WINDOWS
+			, Skip = "Skip for now on other platforms, due to how cells are recycled this does not pass."
+#endif
+		)]
+		public async Task CellsDoNotLeak()
+		{
+			SetupBuilder();
+
+			var references = new List<WeakReference>();
+			var listView = new ListView
+			{
+				ItemTemplate = new DataTemplate(() =>
+				{
+					var cell = new TextCell();
+					references.Add(new(cell));
+					return cell;
+				})
+			};
+
+			await CreateHandlerAndAddToWindow<ListViewRenderer>(listView, async _ =>
+			{
+				listView.ItemsSource = new[] { 1, 2, 3 };
+				await Task.Delay(100);
+				ValidatePlatformCells(listView);
+				listView.ItemsSource = null;
+				await Task.Delay(100);
+				ValidatePlatformCells(listView);
+			});
+
+			await AssertionExtensions.WaitForGC(references.ToArray());
+			foreach (var reference in references)
+			{
+				Assert.False(reference.IsAlive, "Cell should not be alive!");
+			}
+		}
+
+		[Fact("Cells Repopulate After Null ItemsSource")]
+		public async Task CellsRepopulateAfterNullItemsSource()
+		{
+			SetupBuilder();
+
+			List<TextCell> cells = null;
+
+			var listView = new ListView
+			{
+				ItemTemplate = new DataTemplate(() =>
+				{
+					var cell = new TextCell();
+					cell.SetBinding(TextCell.TextProperty, new Binding("."));
+					cells?.Add(cell);
+					return cell;
+				})
+			};
+
+			await CreateHandlerAndAddToWindow<ListViewRenderer>(listView, async _ =>
+			{
+				listView.ItemsSource = new[] { 1, 2, 3 };
+				await Task.Delay(100);
+				ValidatePlatformCells(listView);
+				listView.ItemsSource = null;
+				await Task.Delay(100);
+				ValidatePlatformCells(listView);
+
+				// Now track the new cells
+				cells = new();
+				listView.ItemsSource = new[] { 4, 5, 6 };
+				await Task.Delay(100);
+				ValidatePlatformCells(listView);
+
+				Assert.Equal(3, cells.Count);
+				Assert.Equal("4", cells[0].Text);
+				Assert.Equal("5", cells[1].Text);
+				Assert.Equal("6", cells[2].Text);
 			});
 		}
 	}


### PR DESCRIPTION
Backports #16762 which helps prevent some memory leaking of cells in ListView scenarios on windows .

Also adds a couple other tests that have since been added in net8.0, but also port over cleanly to net7.0
