### PR TITLE
Ignore use of obsolete iOS/Catalyst API until we update to iOS bump with new APIs

### DIFF
--- a/src/Essentials/src/Permissions/Permissions.ios.watchos.cs
+++ b/src/Essentials/src/Permissions/Permissions.ios.watchos.cs
@@ -28,7 +28,9 @@ namespace Microsoft.Maui.ApplicationModel
 			{
 				var eventStore = new EKEventStore();
 
+#pragma warning disable CA1422 // Validate platform compatibility
 				var results = await eventStore.RequestAccessAsync(entityType);
+#pragma warning restore CA1422 // Validate platform compatibility
 
 				return results.Item1 ? PermissionStatus.Granted : PermissionStatus.Denied;
 			}


### PR DESCRIPTION
### Description of Change
The APIs we need to switch to aren't available yet inside the currently public iOS workloads.  Once those workloads are inserted into a released version of VS we will switch this code to use those new APIs
