### PR TITLE
Improves performance of GetLayoutHandlerIndex

### DIFF
--- a/src/Core/src/Handlers/Layout/LayoutExtensions.cs
+++ b/src/Core/src/Handlers/Layout/LayoutExtensions.cs
@@ -9,14 +9,34 @@ namespace Microsoft.Maui.Handlers
 
 		public static int GetLayoutHandlerIndex(this ILayout layout, IView view)
 		{
-			switch (layout.Count)
+			var count = layout.Count;
+			switch (count)
 			{
 				case 0:
 					return -1;
 				case 1:
 					return view == layout[0] ? 0 : -1;
 				default:
-					return layout.OrderByZIndex().IndexOf(view);
+					var found = false;
+					var zIndex = view.ZIndex;
+					var lowerViews = 0;
+					
+					for (int i = 0; i < count; i++)
+					{
+						var child = layout[i];
+						var childZIndex = child.ZIndex;
+
+						if (child == view) {
+							found = true;
+						}
+
+						if (childZIndex < zIndex || !found && childZIndex == zIndex)
+						{
+							++lowerViews;
+						}
+					}
+
+					return found ? lowerViews : -1;
 			}
 		}
 	}

--- a/src/Core/src/Properties/AssemblyInfo.cs
+++ b/src/Core/src/Properties/AssemblyInfo.cs
@@ -25,6 +25,7 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("Microsoft.Maui.Controls.DeviceTests")]
 [assembly: InternalsVisibleTo("Microsoft.Maui.Controls.Core.UnitTests")]
 [assembly: InternalsVisibleTo("Microsoft.Maui.Benchmarks.Droid")]
+[assembly: InternalsVisibleTo("Core.Benchmarks")]
 [assembly: InternalsVisibleTo("Comet")]
 [assembly: InternalsVisibleTo("Comet.Tests")]
 [assembly: InternalsVisibleTo("CommunityToolkit.Maui")]

--- a/src/Core/tests/Benchmarks/Benchmarks/LayoutBenchmarker.cs
+++ b/src/Core/tests/Benchmarks/Benchmarks/LayoutBenchmarker.cs
@@ -1,0 +1,31 @@
+﻿using BenchmarkDotNet.Attributes;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Handlers;
+
+namespace Microsoft.Maui.Benchmarks
+{
+	[MemoryDiagnoser]
+	public class LayoutBenchmarker
+	{
+		static readonly Border[] Views = new[]
+		{
+			new Border(), new Border(), new Border(), new Border(), new Border(), new Border(), new Border(),
+			new Border(), new Border(), new Border(), new Border(), new Border(), new Border(), new Border()
+		};
+		
+		static readonly int Iterations = Views.Length;
+
+		[Benchmark]
+		public void GetLayoutHandlerIndex()
+		{
+			var layout = new VerticalStackLayout();
+			
+			for (int i = 0; i < Iterations; i++)
+			{
+				var view = Views[i];
+				layout.Add(view);
+				layout.GetLayoutHandlerIndex(view);
+			}
+		}
+	}
+}

--- a/src/Core/tests/UnitTests/Layouts/ZIndexTests.cs
+++ b/src/Core/tests/UnitTests/Layouts/ZIndexTests.cs
@@ -200,6 +200,41 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			Assert.Equal(2, layout.GetLayoutHandlerIndex(view2));
 			Assert.Equal(3, layout.GetLayoutHandlerIndex(view3));
 		}
+		
+		[Fact]
+		public void LayoutHandlerIndexIsNegativeWhenChildIsNotFound()
+		{
+			var layout = new FakeLayout();
+			var view0 = CreateTestView(zIndex: 0);
+
+			Assert.Equal(-1, layout.GetLayoutHandlerIndex(view0));
+			
+			layout.Add(CreateTestView(zIndex: 0));
+			Assert.Equal(-1, layout.GetLayoutHandlerIndex(view0));
+			
+			
+			layout.Add(CreateTestView(zIndex: 0));
+			Assert.Equal(-1, layout.GetLayoutHandlerIndex(view0));
+		}
+
+		[Fact]
+		public void LayoutHandlerIndexPreservesAddOrderForEqualZIndexes()
+		{
+			var layout = new FakeLayout();
+			var view0 = CreateTestView(zIndex: 10);
+			var view1 = CreateTestView(zIndex: 10);
+			var view2 = CreateTestView(zIndex: 10);
+			var view3 = CreateTestView(zIndex: 5);
+			layout.Add(view0);
+			layout.Add(view1);
+			layout.Add(view2);
+			layout.Add(view3);
+
+			Assert.Equal(1, layout.GetLayoutHandlerIndex(view0));
+			Assert.Equal(2, layout.GetLayoutHandlerIndex(view1));
+			Assert.Equal(3, layout.GetLayoutHandlerIndex(view2));
+			Assert.Equal(0, layout.GetLayoutHandlerIndex(view3));
+		}
 
 		[Fact]
 		public void ItemsOrderByZIndex()


### PR DESCRIPTION
### Description of Change

While examining [Lols Benchmark results](https://github.com/dotnet/maui/pull/17756#discussion_r1355819763) by @jonathanpeppers I've noticed that 6.4% of the total time is consumed by `LayoutExtensions.GetLayoutHandlerIndex`.

![image](https://github.com/dotnet/maui/assets/1423005/e4dbffc0-1509-4244-afd8-82314daffca1)

This function is being called every time a layout child is added while the layout is already attached to an handler.
The function uses `OrderBy` which internally creates a `SortedMap`, this has a cost in terms of memory (array allocation and resize/copy) and CPU (may vary depending on the sorting algorithm used there).

This PR replaces that `OrderBy` + `IndexOf` with a simple O(N) algorithm which counts views with a lower zIndex.
That count matches the actual zIndex of the view.

I've added a benchmark to test the internal method performance change.
Unit test of this method already exist.

**Before**
|                Method |     Mean |    Error |   StdDev |   Gen0 |   Gen1 |   Gen2 | Allocated |
|---------------------- |---------:|---------:|---------:|-------:|-------:|-------:|----------:|
| GetLayoutHandlerIndex | 27.24 us | 0.525 us | 0.645 us | 4.0283 | 3.9978 | 0.0916 |  24.86 KB |

**After**
|                Method |     Mean |    Error |   StdDev |   Gen0 |   Gen1 |   Gen2 | Allocated |
|---------------------- |---------:|---------:|---------:|-------:|-------:|-------:|----------:|
| GetLayoutHandlerIndex | 24.61 us | 0.478 us | 0.511 us | 3.1128 | 3.0823 | 0.0610 |  19.23 KB |