### PR TITLE
Fix broadcast receiver register on android 14.0/34+

### DIFF
--- a/src/Essentials/src/Battery/Battery.android.cs
+++ b/src/Essentials/src/Battery/Battery.android.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Maui.Devices
 		void StartEnergySaverListeners()
 		{
 			powerReceiver = new EnergySaverBroadcastReceiver(OnEnergySaverChanged);
-			Application.Context.RegisterReceiver(powerReceiver, new IntentFilter(PowerManager.ActionPowerSaveModeChanged));
+			PlatformUtils.RegisterBroadcastReceiver(powerReceiver, new IntentFilter(PowerManager.ActionPowerSaveModeChanged), false);
 		}
 
 		void StopEnergySaverListeners()
@@ -50,7 +50,7 @@ namespace Microsoft.Maui.Devices
 			Permissions.EnsureDeclared<Permissions.Battery>();
 
 			batteryReceiver = new BatteryBroadcastReceiver(OnBatteryInfoChanged);
-			Application.Context.RegisterReceiver(batteryReceiver, new IntentFilter(Intent.ActionBatteryChanged));
+			PlatformUtils.RegisterBroadcastReceiver(batteryReceiver, new IntentFilter(Intent.ActionBatteryChanged), false);
 		}
 
 		void StopBatteryListeners()
@@ -74,7 +74,7 @@ namespace Microsoft.Maui.Devices
 				Permissions.EnsureDeclared<Permissions.Battery>();
 
 				using (var filter = new IntentFilter(Intent.ActionBatteryChanged))
-				using (var battery = Application.Context.RegisterReceiver(null, filter))
+				using (var battery = PlatformUtils.RegisterBroadcastReceiver(null, filter, false))
 				{
 					var level = battery.GetIntExtra(BatteryManager.ExtraLevel, -1);
 					var scale = battery.GetIntExtra(BatteryManager.ExtraScale, -1);
@@ -94,7 +94,7 @@ namespace Microsoft.Maui.Devices
 				Permissions.EnsureDeclared<Permissions.Battery>();
 
 				using (var filter = new IntentFilter(Intent.ActionBatteryChanged))
-				using (var battery = Application.Context.RegisterReceiver(null, filter))
+				using (var battery = PlatformUtils.RegisterBroadcastReceiver(null, filter, false))
 				{
 					var status = battery.GetIntExtra(BatteryManager.ExtraStatus, -1);
 					switch (status)
@@ -121,7 +121,7 @@ namespace Microsoft.Maui.Devices
 				Permissions.EnsureDeclared<Permissions.Battery>();
 
 				using (var filter = new IntentFilter(Intent.ActionBatteryChanged))
-				using (var battery = Application.Context.RegisterReceiver(null, filter))
+				using (var battery = PlatformUtils.RegisterBroadcastReceiver(null, filter, false))
 				{
 					var chargePlug = battery.GetIntExtra(BatteryManager.ExtraPlugged, -1);
 

--- a/src/Essentials/src/Connectivity/Connectivity.android.cs
+++ b/src/Essentials/src/Connectivity/Connectivity.android.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Maui.Networking
 
 			conectivityReceiver = new ConnectivityBroadcastReceiver(OnConnectivityChanged);
 
-			Application.Context.RegisterReceiver(conectivityReceiver, filter);
+			PlatformUtils.RegisterBroadcastReceiver(conectivityReceiver, filter, true);
 		}
 
 		void StopListeners()

--- a/src/Essentials/src/Connectivity/Connectivity.android.cs
+++ b/src/Essentials/src/Connectivity/Connectivity.android.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Maui.Networking
 
 			conectivityReceiver = new ConnectivityBroadcastReceiver(OnConnectivityChanged);
 
-			PlatformUtils.RegisterBroadcastReceiver(conectivityReceiver, filter, true);
+			PlatformUtils.RegisterBroadcastReceiver(conectivityReceiver, filter, false);
 		}
 
 		void StopListeners()

--- a/src/Essentials/src/Platform/PlatformUtils.android.cs
+++ b/src/Essentials/src/Platform/PlatformUtils.android.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using Android.App;
 using Android.Content;
@@ -28,10 +29,13 @@ namespace Microsoft.Maui.ApplicationModel
 		internal static bool HasSystemFeature(string systemFeature)
 		{
 			var packageManager = Application.Context.PackageManager;
-			foreach (var feature in packageManager.GetSystemAvailableFeatures())
+			if (packageManager is not null)
 			{
-				if (feature?.Name?.Equals(systemFeature, StringComparison.OrdinalIgnoreCase) ?? false)
-					return true;
+				foreach (var feature in packageManager.GetSystemAvailableFeatures())
+				{
+					if (feature?.Name?.Equals(systemFeature, StringComparison.OrdinalIgnoreCase) ?? false)
+						return true;
+				}
 			}
 			return false;
 		}
@@ -52,37 +56,16 @@ namespace Microsoft.Maui.ApplicationModel
 			return intent.ResolveActivity(pm) is ComponentName c && c.PackageName == expectedPackageName;
 		}
 
-		internal static Java.Util.Locale GetLocale()
+		internal static Intent? RegisterBroadcastReceiver(BroadcastReceiver? receiver, IntentFilter filter, bool exported)
 		{
-			var resources = Application.Context.Resources;
-			var config = resources.Configuration;
-
-#if __ANDROID_24__
-			if (OperatingSystem.IsAndroidVersionAtLeast(24))
-				return config.Locales.Get(0);
+#if ANDROID34_0_OR_GREATER
+			if (OperatingSystem.IsAndroidVersionAtLeast(34))
+			{
+				var flags = exported ? ReceiverFlags.Exported : ReceiverFlags.NotExported;
+				return Application.Context.RegisterReceiver(receiver, filter, flags);
+			}
 #endif
-
-#pragma warning disable CS0618 // Type or member is obsolete
-			return config.Locale;
-#pragma warning restore CS0618 // Type or member is obsolete
-		}
-
-		internal static void SetLocale(Java.Util.Locale locale)
-		{
-			Java.Util.Locale.Default = locale;
-			var resources = Application.Context.Resources;
-			var config = resources.Configuration;
-#pragma warning disable CS0618 // Type or member is obsolete
-#pragma warning disable CA1422 // Validate platform compatibility
-#pragma warning disable CA1416 // Validate platform compatibility
-			if (OperatingSystem.IsAndroidVersionAtLeast(24))
-				config.SetLocale(locale);
-			else
-				config.Locale = locale;
-			resources.UpdateConfiguration(config, resources.DisplayMetrics);
-#pragma warning restore CA1422 // Validate platform compatibility
-#pragma warning restore CA1416 // Validate platform compatibility
-#pragma warning restore CS0618 // Type or member is obsolete
+			return Application.Context.RegisterReceiver(receiver, filter);
 		}
 	}
 }

--- a/src/Essentials/src/Platform/PlatformUtils.android.cs
+++ b/src/Essentials/src/Platform/PlatformUtils.android.cs
@@ -26,6 +26,18 @@ namespace Microsoft.Maui.ApplicationModel
 			return requestCode;
 		}
 
+		internal static Intent? RegisterBroadcastReceiver(BroadcastReceiver? receiver, IntentFilter filter, bool exported)
+		{
+#if ANDROID34_0_OR_GREATER
+			if (OperatingSystem.IsAndroidVersionAtLeast(34))
+			{
+				var flags = exported ? ReceiverFlags.Exported : ReceiverFlags.NotExported;
+				return Application.Context.RegisterReceiver(receiver, filter, flags);
+			}
+#endif
+			return Application.Context.RegisterReceiver(receiver, filter);
+		}
+
 		internal static bool HasSystemFeature(string systemFeature)
 		{
 			var packageManager = Application.Context.PackageManager;
@@ -54,18 +66,6 @@ namespace Microsoft.Maui.ApplicationModel
 				return false;
 
 			return intent.ResolveActivity(pm) is ComponentName c && c.PackageName == expectedPackageName;
-		}
-
-		internal static Intent? RegisterBroadcastReceiver(BroadcastReceiver? receiver, IntentFilter filter, bool exported)
-		{
-#if ANDROID34_0_OR_GREATER
-			if (OperatingSystem.IsAndroidVersionAtLeast(34))
-			{
-				var flags = exported ? ReceiverFlags.Exported : ReceiverFlags.NotExported;
-				return Application.Context.RegisterReceiver(receiver, filter, flags);
-			}
-#endif
-			return Application.Context.RegisterReceiver(receiver, filter);
 		}
 	}
 }

--- a/src/Essentials/test/DeviceTests/Tests/Battery_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/Battery_Tests.cs
@@ -1,4 +1,5 @@
 using Microsoft.Maui.Devices;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Microsoft.Maui.Essentials.DeviceTests
@@ -52,6 +53,38 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 		public void App_Is_Not_Lower_Power_mode()
 		{
 			Assert.Equal(EnergySaverStatus.Off, Battery.EnergySaverStatus);
+		}
+
+		[Fact]
+		public async Task EnergySaverStatusChanged_Does_Not_Crash()
+		{
+			Battery.EnergySaverStatusChanged += Battery_EnergySaverStatusChanged;
+
+			// just ensure there is no need for the OS to "respond" to a new subscription
+			await Task.Delay(1000);
+
+			Battery.EnergySaverStatusChanged -= Battery_EnergySaverStatusChanged;
+
+			static void Battery_EnergySaverStatusChanged(object sender, EnergySaverStatusChangedEventArgs e)
+			{
+				// do nothing
+			}
+		}
+
+		[Fact]
+		public async Task BatteryInfoChanged_Does_Not_Crash()
+		{
+			Battery.BatteryInfoChanged += Battery_BatteryInfoChanged;
+
+			// just ensure there is no need for the OS to "respond" to a new subscription
+			await Task.Delay(1000);
+
+			Battery.BatteryInfoChanged -= Battery_BatteryInfoChanged;
+
+			static void Battery_BatteryInfoChanged(object sender, BatteryInfoChangedEventArgs e)
+			{
+				// do nothing
+			}
 		}
 	}
 }

--- a/src/Essentials/test/DeviceTests/Tests/Connectivity_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/Connectivity_Tests.cs
@@ -24,6 +24,22 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 		}
 
 		[Fact]
+		public async Task ConnectivityChanged_Does_Not_Crash()
+		{
+			Connectivity.ConnectivityChanged += Connectivity_ConnectivityChanged;
+
+			// just ensure there is no need for the OS to "respond" to a new subscription
+			await Task.Delay(1000);
+
+			Connectivity.ConnectivityChanged -= Connectivity_ConnectivityChanged;
+
+			static void Connectivity_ConnectivityChanged(object sender, ConnectivityChangedEventArgs e)
+			{
+				// do nothing
+			}
+		}
+
+		[Fact]
 		public async Task Test()
 		{
 			var current = Connectivity.Current.NetworkAccess;


### PR DESCRIPTION
This adds a new helper method for registering broadcast receivers, which takes a bool for exporting the service or not, and on API 34 and higher, it calls the newer overload which takes the `ReceiverFlags` and passes the corresponding `NotExported` or `Exported` value to the bool parameter of the util method.

This allows us to call the right overload if we are on API 34 (Android 14.0) or newer where the declaration is required.

Also some older GetLocale()/SetLocale() methods are removed which were unused.

Fixes #17861
