### PR TITLE
Only use custom image sizing with ImageButtons

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Button/ButtonTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Button/ButtonTests.iOS.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
+using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
 using UIKit;
 using Xunit;
@@ -35,6 +36,47 @@ namespace Microsoft.Maui.DeviceTests
 
 			await InvokeOnMainThreadAsync(() => handler.PlatformView.SendActionForControlEvents(UIControlEvent.TouchUpInside));
 			Assert.True(fired, "Button.Clicked did not fire!");
+		}
+
+		[Theory("Button with image lays out correctly")]
+		[InlineData(true)]
+		[InlineData(false)]
+		public async Task ButtonWithImage(bool includeText)
+		{
+			var gridHeight = 300;
+			var gridWidth = 300;
+
+			var button = new Button {BackgroundColor = Colors.Yellow, VerticalOptions = LayoutOptions.Center, HorizontalOptions = LayoutOptions.Center};
+			if (includeText)
+			{
+				button.Text = "Hello world!";
+			}
+
+			var layout = new Grid() {HeightRequest = gridHeight, WidthRequest = gridWidth, BackgroundColor = Colors.Blue };
+			layout.Add(button);
+
+			var buttonHandler = await CreateHandlerAsync<ButtonHandler>(button);
+			var handler = await CreateHandlerAsync<LayoutHandler>(layout);
+
+			await InvokeOnMainThreadAsync(async () =>
+			{
+				button.ImageSource = ImageSource.FromFile("red.png"); 
+
+				// Wait for image to load and force the grid to measure itself again
+				await Task.Delay(1000);
+				layout.Measure(double.PositiveInfinity, double.PositiveInfinity);
+
+				await handler.ToPlatform().AssertContainsColor(Colors.Blue, MauiContext); // Grid renders
+				await handler.ToPlatform().AssertContainsColor(Colors.Red, MauiContext); // Image within button renders
+				await handler.ToPlatform().AssertContainsColor(Colors.Yellow, MauiContext); // Button renders
+			});
+
+			// red.png is 100x100
+			Assert.True(button.Width > 100, $"Button should have larger width than its image. Exepected: 100>, was {button.Width}");
+			Assert.True(button.Height > 100, $"Button should have larger height than its image. Exepected: 100>, was {button.Height}");
+
+			Assert.True(button.Width < gridWidth, $"Button shouldn't occupy entire layout width. Expected: {gridWidth}<, was {button.Width}");
+			Assert.True(button.Height < gridHeight, $"Button shouldn't occupy entire layout height. Expected: {gridHeight}<, was {button.Height}");
 		}
 	}
 }

--- a/src/Core/src/Handlers/ViewHandlerExtensions.iOS.cs
+++ b/src/Core/src/Handlers/ViewHandlerExtensions.iOS.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Maui
 
 				sizeThatFits = imageView.SizeThatFitsImage(new CGSize((float)widthConstraint, (float)heightConstraint));
 			}
-			else if (platformView is UIButton imageButton && imageButton.ImageView?.Image is not null)
+			else if (platformView is UIButton imageButton && imageButton.ImageView?.Image is not null && imageButton.CurrentTitle is null)
 			{
 				widthConstraint = IsExplicitSet(virtualView.Width) ? virtualView.Width : widthConstraint;
 				heightConstraint = IsExplicitSet(virtualView.Height) ? virtualView.Height : heightConstraint;

--- a/src/Core/src/Platform/iOS/WrapperView.cs
+++ b/src/Core/src/Platform/iOS/WrapperView.cs
@@ -126,7 +126,7 @@ namespace Microsoft.Maui.Platform
 			{
 				return imageView.SizeThatFitsImage(size);
 			}
-			else if (child is UIButton imageButton && imageButton.ImageView?.Image is not null)
+			else if (child is UIButton imageButton && imageButton.ImageView?.Image is not null && imageButton.CurrentTitle is null)
 			{
 				return imageButton.ImageView.SizeThatFitsImage(size);
 			}
@@ -141,7 +141,7 @@ namespace Microsoft.Maui.Platform
 
 			var child = Subviews[0];
 
-			if (child is UIImageView || (child is UIButton imageButton && imageButton.ImageView?.Image is not null))
+			if (child is UIImageView || (child is UIButton imageButton && imageButton.ImageView?.Image is not null && imageButton.CurrentTitle is null))
 			{
 				var widthConstraint = IsExplicitSet(virtualViewWidth) ? virtualViewWidth : originalSpec.Width;
 				var heightConstraint = IsExplicitSet(virtualViewHeight) ? virtualViewHeight : originalSpec.Height;


### PR DESCRIPTION
### Problem

Updates on the image resizing #17120 affected normal buttons with images, causing them to call the custom image sizing logic. The updates made images to occupy the space they are provided in respect to their constraints. This fixed `ImageButton` and `Image` but adversely affected `Button`.

Standard `Buttons` don't have control over their image dimensions, but _do_ have control on how they want to lay these images out them out. Calling the new logic removes this functionality and causes buttons to occupy their available space/occupy the space requested by the image (which would ignore the text in the button).

### Solution

Use the old sizing logic with normal `Buttons` but still use the new sizing logic for `ImageButton`. We can differentiate them based on the value of the native view's `CurrentTitle`. `ImageButtons` can't have text and have a `null` value for `CurrentTitle`, so we add this check before using the image resizing logic. 

**Note:** Even if a `Button` has no `Text` value (or its ""), the native control will have a non-null `CurrentTitle` that'll just be the empty string. This is included in the tests I'm adding

### Before & After

<details> <summary> 18504  (click me!) </summary> 

```
    <Grid WidthRequest="500" BackgroundColor="Red">
        <Button HorizontalOptions="Center" VerticalOptions="Center" BackgroundColor="AliceBlue" ImageSource="dotnet_bot.png" Text="Hello world!"/>
    </Grid>
```
| Before | After | 
|  -- | -- | 
|   <img width="556" alt="image" src="https://github.com/dotnet/maui/assets/32918747/884b6689-cd60-4f8c-a838-443b56c7aa62"> | <img width="561" alt="image" src="https://github.com/dotnet/maui/assets/32918747/65b2b8ee-0697-449c-b8c9-d81cc983dd8f"> |

</details>

<details> <summary> 18655  (click me!) </summary> 

Copy source from sample project: https://github.com/zwikk/maui-playground/blob/main/Source/ButtonImageSource/ButtonImageSource/MainPage.xaml

| Before | After | 
|  -- | -- | 
|   <img width="595" alt="image" src="https://github.com/dotnet/maui/assets/32918747/726a7a79-e9f6-47e1-abbb-8a414472a38e"> | <img width="602" alt="image" src="https://github.com/dotnet/maui/assets/32918747/65561ad0-fd49-46b2-9bbd-948d94d6d0a5"> |

</details>

### Issues Fixed

Fixes #18504
Fixes #18655

### Remaining work

- [x] Add tests
- [x] Add screenshots
