### PR TITLE
- [Android] Fix ShouldShowToolbarButton for FlyoutPage

### DIFF
--- a/src/Controls/src/Core/NavigationPage/NavigationPageToolbar.cs
+++ b/src/Controls/src/Core/NavigationPage/NavigationPageToolbar.cs
@@ -151,7 +151,7 @@ namespace Microsoft.Maui.Controls
 
 			// Set this before BackButtonVisible triggers an update to the handler
 			// This way all useful information is present
-			if (Parent is FlyoutPage && !anyPagesPushed.Value)
+			if (Parent is FlyoutPage flyout && flyout.ShouldShowToolbarButton() && !anyPagesPushed.Value)
 				_drawerToggleVisible = true;
 			else
 				_drawerToggleVisible = false;


### PR DESCRIPTION
### Description of Change

Fixes an issue where overriding `ShouldShowToolbarButton()` in a `FlyoutPage` does not hide the hamburger icon (drawer toggle) on Android.

In the `NavigationPageToolbar`, the drawer toggle is marked visible if the parent is a `FlyoutPage` and there are no pages pushed on to the stack ([here](https://github.com/dotnet/maui/blob/main/src/Controls/src/Core/NavigationPage/NavigationPageToolbar.cs#L155)).

There should also be a call made to `ShouldShowToolbarButton` in cases where you want to explicitly hide the toolbar button, which is the hamburger icon.

This has no effect on the back button, which is handled separately. 

On iOS, `ShouldShowToolbarButton` is [called in the compatibility `NavigationRenderer`](https://github.com/dotnet/maui/blob/5dcb3406afc89d075c61606d85d2b284ff189fa0/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs#L856), which is still used as the primary handler today and explains why it's only broken in Android.

### Issues Fixed

Fixes #15111

---

Hope this helps! Let me know if you need further adjustments.