### PR TITLE
Filter GetVisualTreeDescendants to not check elements with null handlers

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/VisualElementTree/VisualElementTreeTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/VisualElementTree/VisualElementTreeTests.cs
@@ -49,14 +49,12 @@ namespace Microsoft.Maui.DeviceTests
 			SetupBuilder();
 
 			var border = new Border() { StrokeShape = new RoundRectangle() { CornerRadius = 5 } };
-			var borderLabel = new Label() { Text = "Border Label" };
-			border.AddLogicalChild(borderLabel);
-
 			var label = new Label() { Text = "Find Me" };
+			border.AddLogicalChild(label);
+
 			var page = new ContentPage() { Title = "Title Page" };
 			page.Content = new VerticalStackLayout()
 			{
-				label,
 				border
 			};
 
@@ -66,6 +64,7 @@ namespace Microsoft.Maui.DeviceTests
 
 			await CreateHandlerAndAddToWindow<IWindowHandler>(rootPage, async handler =>
 			{
+				await OnFrameSetToNotEmpty(border);
 				await OnFrameSetToNotEmpty(label);
 				var locationOnScreen = label.GetLocationOnScreen().Value;
 				var labelFrame = label.Frame;

--- a/src/Controls/tests/DeviceTests/Elements/VisualElementTree/VisualElementTreeTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/VisualElementTree/VisualElementTreeTests.cs
@@ -9,6 +9,8 @@ using Xunit;
 using System.Collections.Generic;
 using ContentView = Microsoft.Maui.Controls.ContentView;
 using Microsoft.Maui.Controls.Handlers.Items;
+using Microsoft.Maui.Controls.Shapes;
+
 #if ANDROID || IOS || MACCATALYST
 using ShellHandler = Microsoft.Maui.Controls.Handlers.Compatibility.ShellRenderer;
 #endif
@@ -45,11 +47,17 @@ namespace Microsoft.Maui.DeviceTests
 		public async Task GetVisualTreeElements()
 		{
 			SetupBuilder();
+
+			var border = new Border() { StrokeShape = new RoundRectangle() { CornerRadius = 5 } };
+			var borderLabel = new Label() { Text = "Border Label" };
+			border.AddLogicalChild(borderLabel);
+
 			var label = new Label() { Text = "Find Me" };
 			var page = new ContentPage() { Title = "Title Page" };
 			page.Content = new VerticalStackLayout()
 			{
-				label
+				label,
+				border
 			};
 
 			var rootPage = await InvokeOnMainThreadAsync(() =>

--- a/src/Controls/tests/DeviceTests/Elements/VisualElementTree/VisualElementTreeTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/VisualElementTree/VisualElementTreeTests.cs
@@ -39,6 +39,7 @@ namespace Microsoft.Maui.DeviceTests
 					handlers.AddHandler<NestingView, NestingViewHandler>();
 					handlers.AddHandler<ContentView, ContentViewHandler>();
 					handlers.AddHandler<CollectionView, CollectionViewHandler>();
+					handlers.AddHandler<Border, BorderHandler>();
 				});
 			});
 		}
@@ -48,13 +49,13 @@ namespace Microsoft.Maui.DeviceTests
 		{
 			SetupBuilder();
 
-			var border = new Border() { StrokeShape = new RoundRectangle() { CornerRadius = 5 } };
+			var border = new Border() { WidthRequest = 50, HeightRequest = 50, StrokeShape = new RoundRectangle() { CornerRadius = 5 } };
 			var label = new Label() { Text = "Find Me" };
-			border.AddLogicalChild(label);
 
 			var page = new ContentPage() { Title = "Title Page" };
 			page.Content = new VerticalStackLayout()
 			{
+				label,
 				border
 			};
 
@@ -64,6 +65,7 @@ namespace Microsoft.Maui.DeviceTests
 
 			await CreateHandlerAndAddToWindow<IWindowHandler>(rootPage, async handler =>
 			{
+				await OnFrameSetToNotEmpty(rootPage);
 				await OnFrameSetToNotEmpty(border);
 				await OnFrameSetToNotEmpty(label);
 				var locationOnScreen = label.GetLocationOnScreen().Value;

--- a/src/Core/src/Core/Extensions/VisualTreeElementExtensions.cs
+++ b/src/Core/src/Core/Extensions/VisualTreeElementExtensions.cs
@@ -146,7 +146,7 @@ namespace Microsoft.Maui
 			if (uiElement != null)
 			{
 				var uniqueElements = findChildren(uiElement).Distinct();
-				var viewTree = visualElement.GetVisualTreeDescendants().Where(n => n is IView).Select(n => new Tuple<IView, object?>((IView)n, ((IView)n).ToPlatform()));
+				var viewTree = visualElement.GetVisualTreeDescendants().Where(n => n is IView view && view.Handler is not null).Select(n => new Tuple<IView, object?>((IView)n, ((IView)n).ToPlatform()));
 				var testList = viewTree.Where(n => uniqueElements.Contains(n.Item2)).Select(n => n.Item1);
 				if (testList != null && testList.Any())
 					visualElements.AddRange(testList.Select(n => (IVisualTreeElement)n));
@@ -299,7 +299,7 @@ namespace Microsoft.Maui
 
 			static void Impl(IVisualTreeElement visualElement, Predicate<Rect> intersectElementBounds, List<IVisualTreeElement> elements)
 			{
-				if (visualElement is IView view)
+				if (visualElement is IView view && view.Handler is not null)
 				{
 					Rect bounds = view.GetBoundingBox();
 					if (intersectElementBounds(bounds))


### PR DESCRIPTION
### Description of Change

Filter VisualElements that don't have handlers set from being returned inside GetVisualTreeDescendants. Calls to this method that contain elements that don't have handlers set would throw Handler exceptions as it's null. 

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes https://github.com/dotnet/maui/issues/16919

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
