### PR TITLE
Set the handler to Border StrokeShape

### DIFF
--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issues16919.xaml
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issues16919.xaml
@@ -1,0 +1,25 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Maui.Controls.Sample.Issues.Issue16919">
+    <StackLayout>
+        <Border
+            x:Name="TestBorder"
+            Stroke="Black" 
+            StrokeThickness="4">
+            <Border.StrokeShape>
+                <RoundRectangle CornerRadius="10" />
+            </Border.StrokeShape>
+            <Label
+                 Text="Issue 16919"
+                 FontSize="32"
+                 HorizontalOptions="Center" />
+        </Border>
+        <Button
+            x:Name="TestButton"
+            AutomationId="TestButton"
+            Text="Test"
+            Clicked="OnTestClicked"
+            HorizontalOptions="Center" />
+    </StackLayout>
+</ContentPage>

--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issues16919.xaml.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issues16919.xaml.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+using Microsoft.Maui.Controls.Shapes;
+
+namespace Maui.Controls.Sample.Issues
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	[Issue(IssueTracker.Github, 16919, "Shapes without handlers shouldn't be added as LogicalChildren", PlatformAffected.All)]
+	public partial class Issue16919 : ContentPage
+	{
+		public Issue16919()
+		{
+			InitializeComponent();
+		}
+
+		void OnTestClicked(object sender, EventArgs e)
+		{
+			var strokeShape = TestBorder.StrokeShape as RoundRectangle;
+
+			if (strokeShape is not null)
+			{
+				var handler = strokeShape.Handler;
+
+				if (handler is not null)
+					TestButton.Text = "Passed";
+				else
+					TestButton.Text = "Failed";
+			}
+		}
+	}
+}

--- a/src/Controls/tests/UITests/Tests/Issues/Issue16919.cs
+++ b/src/Controls/tests/UITests/Tests/Issues/Issue16919.cs
@@ -1,0 +1,27 @@
+﻿using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.AppiumTests.Issues
+{
+	class Issue16919 : _IssuesUITest
+	{
+		string buttonId = "TestButton";
+
+		public Issue16919(TestDevice device) : base(device)
+		{
+		}
+
+		public override string Issue => "Shapes without handlers shouldn't be added as LogicalChildren";
+
+		[Test]
+		public void StrokeShapeHandlerIsNotNull()
+		{
+			App.WaitForElement(buttonId);
+			App.Click(buttonId);
+			var result = App.FindElement(buttonId).GetText();
+
+			Assert.AreEqual("Passed", result);
+		}
+	}
+}

--- a/src/Core/src/Handlers/Border/BorderHandler.cs
+++ b/src/Core/src/Handlers/Border/BorderHandler.cs
@@ -77,7 +77,8 @@ namespace Microsoft.Maui.Handlers
 		/// <param name="border">The associated <see cref="IBorderView"/> instance.</param>
 		public static void MapStrokeShape(IBorderHandler handler, IBorderView border)
 		{
-			((PlatformView?)handler.PlatformView)?.UpdateStrokeShape(border);
+			((PlatformView?)handler.PlatformView)?.UpdateStrokeShape(border, handler.MauiContext!);
+
 			MapBackground(handler, border);
 		}
 

--- a/src/Core/src/Platform/Android/StrokeExtensions.cs
+++ b/src/Core/src/Platform/Android/StrokeExtensions.cs
@@ -37,6 +37,17 @@ namespace Microsoft.Maui.Platform
 			platformView.UpdateMauiDrawable(border);
 		}
 
+		// TODO: Consider making this public for .NET 9
+		internal static void UpdateStrokeShape(this AView platformView, IBorderStroke border, IMauiContext context)
+		{
+			IShape? borderShape = border.Shape;
+
+			if (borderShape is IView shapeView && shapeView.Handler is null)
+				shapeView.Handler = shapeView.ToHandler(context);
+
+			platformView.UpdateStrokeShape(border);
+		}
+		
 		public static void UpdateStroke(this AView platformView, IBorderStroke border)
 		{
 			var stroke = border.Stroke;

--- a/src/Core/src/Platform/Standard/StrokeExtensions.cs
+++ b/src/Core/src/Platform/Standard/StrokeExtensions.cs
@@ -4,6 +4,8 @@
 	{
 		public static void UpdateStrokeShape(this object platformView, IBorderStroke border) { }
 
+		internal static void UpdateStrokeShape(this object platformView, IBorderStroke border, IMauiContext context) { }
+
 		public static void UpdateStroke(this object platformView, IBorderStroke border) { }
 
 		public static void UpdateStrokeThickness(this object platformView, IBorderStroke border) { }

--- a/src/Core/src/Platform/Tizen/StrokeExtensions.cs
+++ b/src/Core/src/Platform/Tizen/StrokeExtensions.cs
@@ -13,6 +13,21 @@ namespace Microsoft.Maui.Platform
 			wrapperView.UpdateMauiDrawable(border);
 		}
 
+		internal static void UpdateStrokeShape(this NView platformView, IBorderStroke border, IMauiContext context)
+		{
+			var wrapperView = platformView.GetParent() as WrapperView;
+
+			if (wrapperView == null)
+				return;
+
+			IShape? borderShape = border.Shape;
+
+			if (borderShape is IView shapeView && shapeView.Handler is null)
+				shapeView.Handler = shapeView.ToHandler(context);
+
+			platformView.UpdateStrokeShape(border);
+		}
+	
 		public static void UpdateStroke(this NView platformView, IBorderStroke border)
 		{
 			var wrapperView = platformView.GetParent() as WrapperView;

--- a/src/Core/src/Platform/Windows/StrokeExtensions.cs
+++ b/src/Core/src/Platform/Windows/StrokeExtensions.cs
@@ -9,6 +9,17 @@
 
 			platformView.UpdateBorderStroke(border);
 		}
+		
+		// TODO: Consider making this public for .NET 9
+		internal static void UpdateStrokeShape(this ContentPanel platformView, IBorderStroke border, IMauiContext context)
+		{
+			Graphics.IShape? borderShape = border.Shape;
+
+			if (borderShape is IView shapeView && shapeView.Handler is null)
+				shapeView.Handler = shapeView.ToHandler(context);
+
+			platformView.UpdateStrokeShape(border);
+		}
 
 		public static void UpdateStroke(this ContentPanel platformView, IBorderStroke border)
 		{

--- a/src/Core/src/Platform/iOS/StrokeExtensions.cs
+++ b/src/Core/src/Platform/iOS/StrokeExtensions.cs
@@ -19,6 +19,17 @@ namespace Microsoft.Maui.Platform
 			platformView.UpdateMauiCALayer(border);
 		}
 
+		// TODO: Consider making this public for .NET 9
+		internal static void UpdateStrokeShape(this UIView platformView, IBorderStroke border, IMauiContext context)
+		{
+			IShape? borderShape = border.Shape;
+
+			if (borderShape is IView shapeView && shapeView.Handler is null)
+				shapeView.Handler = shapeView.ToHandler(context);
+
+			platformView.UpdateStrokeShape(border);
+		}
+
 		public static void UpdateStroke(this UIView platformView, IBorderStroke border)
 		{
 			var borderBrush = border.Stroke;


### PR DESCRIPTION
### Description of Change

Set the handler to Border `StrokeShape`.

Border have the StrokeShape property using an IShape but is not literal "Shapes" added to the visual hierarchy, so Handlers are not set on StrokeShape objects because they are not really a "Shape." In this PR we applied changes to set the StrokeShape Handler, but is the correct approach?. The other option would be to make changes so that StrokeShape allows defining the Shape of the Border without being an Element, for example, using Geometries.

Feedback?

Related with https://github.com/dotnet/maui/pull/18539

### Issues Fixed

Fixes #16919
