### PR TITLE
[ios] fix memory leak in `Frame`, `VisualElementRenderer`

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/iOS/FrameRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/iOS/FrameRenderer.cs
@@ -83,8 +83,10 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		{
 			if (_actualView == null)
 				return;
+			if (Element is not Frame element)
+				return;
 
-			float cornerRadius = Element.CornerRadius;
+			float cornerRadius = element.CornerRadius;
 
 			if (cornerRadius == -1f)
 				cornerRadius = 5f; // default corner radius
@@ -92,21 +94,21 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			_actualView.Layer.CornerRadius = cornerRadius;
 			_actualView.Layer.MasksToBounds = cornerRadius > 0;
 
-			if (Element.BackgroundColor == null)
+			if (element.BackgroundColor == null)
 				_actualView.Layer.BackgroundColor = Microsoft.Maui.Platform.ColorExtensions.BackgroundColor.CGColor;
 			else
 			{
 				// BackgroundColor gets set on the base class too which messes with
 				// the corner radius, shadow, etc. so override that behaviour here
 				BackgroundColor = UIColor.Clear;
-				_actualView.Layer.BackgroundColor = Element.BackgroundColor.ToCGColor();
+				_actualView.Layer.BackgroundColor = element.BackgroundColor.ToCGColor();
 			}
 
 			_actualView.Layer.RemoveBackgroundLayer();
 
-			if (!Brush.IsNullOrEmpty(Element.Background))
+			if (!Brush.IsNullOrEmpty(element.Background))
 			{
-				var backgroundLayer = this.GetBackgroundLayer(Element.Background);
+				var backgroundLayer = this.GetBackgroundLayer(element.Background);
 
 				if (backgroundLayer != null)
 				{
@@ -116,17 +118,17 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				}
 			}
 
-			if (Element.BorderColor == null)
+			if (element.BorderColor == null)
 			{
 				_actualView.Layer.BorderColor = UIColor.Clear.CGColor;
 				_actualView.Layer.BorderWidth = 0;
 			}
 			else
 			{
-				var borderWidth = (int)(Element is IBorderElement be ? be.BorderWidth : 1);
+				var borderWidth = (int)(element is IBorderElement be ? be.BorderWidth : 1);
 				borderWidth = Math.Max(1, borderWidth);
 
-				_actualView.Layer.BorderColor = Element.BorderColor.ToCGColor();
+				_actualView.Layer.BorderColor = element.BorderColor.ToCGColor();
 				_actualView.Layer.BorderWidth = borderWidth;
 			}
 
@@ -136,7 +138,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 			_actualView.Layer.RasterizationScale = UIScreen.MainScreen.Scale;
 			_actualView.Layer.ShouldRasterize = true;
-			_actualView.Layer.MasksToBounds = Element.IsClippedToBoundsSet(true);
+			_actualView.Layer.MasksToBounds = element.IsClippedToBoundsSet(true);
 		}
 
 		void UpdateShadow()

--- a/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
+++ b/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
@@ -26,6 +26,7 @@ public class MemoryTests : ControlsHandlerTestBase
 				handlers.AddHandler<DatePicker, DatePickerHandler>();
 				handlers.AddHandler<Entry, EntryHandler>();
 				handlers.AddHandler<Editor, EditorHandler>();
+				handlers.AddHandler<Frame, FrameRenderer>();
 				handlers.AddHandler<GraphicsView, GraphicsViewHandler>();
 				handlers.AddHandler<Label, LabelHandler>();
 				handlers.AddHandler<ListView, ListViewRenderer>();
@@ -53,6 +54,7 @@ public class MemoryTests : ControlsHandlerTestBase
 	[InlineData(typeof(DatePicker))]
 	[InlineData(typeof(Entry))]
 	[InlineData(typeof(Editor))]
+	[InlineData(typeof(Frame))]
 	[InlineData(typeof(GraphicsView))]
 	[InlineData(typeof(Image))]
 	[InlineData(typeof(IndicatorView))]


### PR DESCRIPTION
Context: https://github.com/dotnet/maui/issues/18365

I could reproduce a leak in `Frame` by adding a parameterized test:

    [InlineData(typeof(Frame))]
    public async Task HandlerDoesNotLeak(Type type)

`FrameRenderer` has a circular reference via its base type, `VisualElementRenderer`:

* `Frame` ->
* `FrameRenderer` / `VisualElementRenderer` ->
* `Frame` (via `VisualElementRenderer._virtualView`)

To solve this issue, I made `_virtualView` a `WeakReference`, but only on iOS or MacCatalyst platforms. We don't necessarily need this treatment for Windows or Android.

My initial attempt threw a `NullReferenceException`, because the `Element` property is accessed before `SetVirtualView()` returns. I had to create a `_tempElement` field to hold the value temporarily, clearing it to avoid a circular reference.

The Roslyn analyzer didn't catch this cycle because it doesn't warn about `IPlatformViewHandler`, only `NSObject`'s. Will investigate further on this example here:

https://github.com/jonathanpeppers/memory-analyzers/issues/12
