### PR TITLE
[WinUI] Fix resizing CV rows when content size changed

### DIFF
--- a/src/Controls/src/Core/Platform/Windows/CollectionView/ItemContentControl.cs
+++ b/src/Controls/src/Core/Platform/Windows/CollectionView/ItemContentControl.cs
@@ -289,7 +289,17 @@ namespace Microsoft.Maui.Controls.Platform
 
 			var width = ItemWidth == default ? availableSize.Width : ItemWidth;
 			var height = ItemHeight == default ? availableSize.Height : ItemHeight;
-			var measuredSize = base.MeasureOverride(new WSize(width, height));
+			var size = new WSize(width, height);
+
+			if (this.Content is FrameworkElement content 
+				&& CanMeasureContent(content) 
+				&& (content.DesiredSize.Height != content.Height || content.DesiredSize.Width != content.Width))
+			{
+				// Measure content to update its desired size if its Height/Width just changed
+				content.Measure(size);
+			}
+
+			var measuredSize = base.MeasureOverride(size);
 			var finalWidth = Max(measuredSize.Width, ItemWidth);
 			var finalHeight = Max(measuredSize.Height, ItemHeight);
 			var finalSize = new WSize(finalWidth, finalHeight);


### PR DESCRIPTION
### Description of Change

When measuring the ItemContentControl we might not get the right value if the size of its content just changed. In order to ensure we get the up to date value, we first measure the content (to update DesiredSize), and then we measure the ItemContentControl.

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/18078

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
