### PR TITLE
Better ARM support device tests/CI pipeline in general

### DIFF
--- a/eng/devices/android.cake
+++ b/eng/devices/android.cake
@@ -12,7 +12,7 @@ const string dotnetVersion = "net8.0";
 // required
 FilePath PROJECT = Argument("project", EnvironmentVariable("ANDROID_TEST_PROJECT") ?? DEFAULT_PROJECT);
 string TEST_DEVICE = Argument("device", EnvironmentVariable("ANDROID_TEST_DEVICE") ?? $"android-emulator-64_{defaultVersion}");
-string DEVICE_SKIN = Argument("skin", EnvironmentVariable("ANDROID_TEST_SKIN") ?? "pixel_5");
+string DEVICE_SKIN = Argument("skin", EnvironmentVariable("ANDROID_TEST_SKIN") ?? "Nexus 5X");
 
 // optional
 var USE_DOTNET = Argument("dotnet", true);

--- a/eng/devices/android.cake
+++ b/eng/devices/android.cake
@@ -120,7 +120,7 @@ Setup(context =>
 				DEVICE_ARCH = "arm64-v8a";
 		}
 		var sdk = api >= 27 ? "google_apis_playstore" : "google_apis";
-		if (api == 27 && DEVICE_ARCH == "x86_64")
+		if (api == 27 && (DEVICE_ARCH == "x86_64" || DEVICE_ARCH == "arm64-v8a"))
 			sdk = "default";
 
 		ANDROID_AVD_IMAGE = $"system-images;android-{api};{sdk};{DEVICE_ARCH}";

--- a/eng/devices/android.cake
+++ b/eng/devices/android.cake
@@ -66,7 +66,8 @@ var emuSettings = new AndroidEmulatorToolSettings { SdkRoot = ANDROID_SDK_ROOT }
 if (IsCIBuild())
 	emuSettings.ArgumentCustomization = args => args.Append("-no-window");
 
-emuSettings.ArgumentCustomization = args => args.Append("-feature -Vulkan");
+emuSettings.ArgumentCustomization = args => args.Append("-gpu swiftshader_indirect");
+emuSettings.ArgumentCustomization = args => args.Append("-no-boot-anim");
 
 AndroidEmulatorProcess emulatorProcess = null;
 

--- a/eng/devices/android.cake
+++ b/eng/devices/android.cake
@@ -66,6 +66,8 @@ var emuSettings = new AndroidEmulatorToolSettings { SdkRoot = ANDROID_SDK_ROOT }
 if (IsCIBuild())
 	emuSettings.ArgumentCustomization = args => args.Append("-no-window");
 
+emuSettings.ArgumentCustomization = args => args.Append("-feature -Vulkan");
+
 AndroidEmulatorProcess emulatorProcess = null;
 
 Setup(context =>

--- a/eng/devices/android.cake
+++ b/eng/devices/android.cake
@@ -66,9 +66,6 @@ var emuSettings = new AndroidEmulatorToolSettings { SdkRoot = ANDROID_SDK_ROOT }
 if (IsCIBuild())
 	emuSettings.ArgumentCustomization = args => args.Append("-no-window");
 
-emuSettings.ArgumentCustomization = args => args.Append("-gpu swiftshader_indirect");
-emuSettings.ArgumentCustomization = args => args.Append("-no-boot-anim");
-
 AndroidEmulatorProcess emulatorProcess = null;
 
 Setup(context =>

--- a/eng/devices/ios.cake
+++ b/eng/devices/ios.cake
@@ -36,7 +36,8 @@ string DEVICE_OS = "";
 string PLATFORM = TEST_DEVICE.ToLower().Contains("simulator") ? "iPhoneSimulator" : "iPhone";
 string DOTNET_PLATFORM = TEST_DEVICE.ToLower().Contains("simulator") ? 
 	$"iossimulator-{System.Runtime.InteropServices.RuntimeInformation.OSArchitecture.ToString().ToLower()}"
-  : $"ios-arm64";
+  : $"ios-{System.Runtime.InteropServices.RuntimeInformation.OSArchitecture.ToString().ToLower()}";
+
 string CONFIGURATION = Argument("configuration", "Debug");
 bool DEVICE_CLEANUP = Argument("cleanup", !IsCIBuild());
 string TEST_FRAMEWORK = "net472";
@@ -64,7 +65,6 @@ Setup(context =>
 	Cleanup();
 
 	Information($"DOTNET_TOOL_PATH {DOTNET_TOOL_PATH}");
-	
 	Information("Host OS System Arch: {0}", System.Runtime.InteropServices.RuntimeInformation.OSArchitecture);
 	Information("Host Processor System Arch: {0}", System.Runtime.InteropServices.RuntimeInformation.ProcessArchitecture);
 

--- a/eng/provisioning/provisioning.csx
+++ b/eng/provisioning/provisioning.csx
@@ -42,7 +42,7 @@ if(String.IsNullOrWhiteSpace(ANDROID_API_SDKS) && String.IsNullOrWhiteSpace(SKIP
 		.VirtualDevice("Android_x64_API24",   (AndroidApiLevel)24, AndroidSystemImageApi.Google,          AndroidSystemImageAbi.x86_64,    AndroidVirtualDevice.NEXUS_5X)
 		.VirtualDevice("Android_x64_API25",   (AndroidApiLevel)25, AndroidSystemImageApi.Google,          AndroidSystemImageAbi.x86_64,    AndroidVirtualDevice.NEXUS_5X)
 		.VirtualDevice("Android_x64_API26",   (AndroidApiLevel)26, AndroidSystemImageApi.Google,          AndroidSystemImageAbi.x86_64,    AndroidVirtualDevice.NEXUS_5X)
-		.VirtualDevice("Android_x86_API27",   (AndroidApiLevel)27, AndroidSystemImageApi.GooglePlayStore,  AndroidSystemImageAbi.x86,       AndroidVirtualDevice.NEXUS_5X)
+		.VirtualDevice("Android_x86_API27",   (AndroidApiLevel)27, AndroidSystemImageApi.GooglePlayStore, AndroidSystemImageAbi.x86,       AndroidVirtualDevice.NEXUS_5X)
 		.VirtualDevice("Android_x64_API28",   (AndroidApiLevel)28, AndroidSystemImageApi.GooglePlayStore, AndroidSystemImageAbi.x86_64,    AndroidVirtualDevice.NEXUS_5X)
 		.VirtualDevice("Android_x64_API29",   (AndroidApiLevel)29, AndroidSystemImageApi.GooglePlayStore, AndroidSystemImageAbi.x86_64,    AndroidVirtualDevice.NEXUS_5X)
 		.VirtualDevice("Android_x64_API30",   (AndroidApiLevel)30, AndroidSystemImageApi.GooglePlayStore, AndroidSystemImageAbi.x86_64,    AndroidVirtualDevice.NEXUS_5X)

--- a/src/Essentials/test/DeviceTests/Tests/DeviceInfo_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/DeviceInfo_Tests.cs
@@ -29,7 +29,15 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 #elif __IOS__
 			if (DeviceInfo.DeviceType == DeviceType.Virtual)
 			{
-				Assert.Equal("x86_64", DeviceInfo.Model);
+				// The architecture of the Simulator is linked to what actual architecture the Mac is running on
+				if (System.Runtime.InteropServices.RuntimeInformation.ProcessArchitecture == System.Runtime.InteropServices.Architecture.X64)
+				{
+					Assert.Equal("x86_64", DeviceInfo.Model);
+				}
+				else
+				{
+					Assert.Equal("arm64", DeviceInfo.Model);
+				}
 			}
 #elif __ANDROID__
 
@@ -38,6 +46,9 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 				var isEmulator =
 					DeviceInfo.Model.Contains("sdk_gphone_x86", StringComparison.Ordinal) ||
 					DeviceInfo.Model.Contains("sdk_gphone64_x86_64", StringComparison.Ordinal) ||
+					DeviceInfo.Model.Contains("sdk_gphone64_arm64", StringComparison.Ordinal) ||
+					DeviceInfo.Model.Contains("sdk_gphone_arm64", StringComparison.Ordinal) ||
+					DeviceInfo.Model.Contains("Android SDK built for arm64", StringComparison.Ordinal) ||
 					DeviceInfo.Model.Contains("google_sdk", StringComparison.Ordinal) ||
 					DeviceInfo.Model.Contains("Emulator", StringComparison.Ordinal) ||
 					DeviceInfo.Model.Contains("Android SDK built for x86", StringComparison.Ordinal);


### PR DESCRIPTION
### Description of Change

While running the device tests locally on my M1 Mac Mini, I had to make adjustments for the tests to run and a test to pass on Essentials. This makes some minor adjustments so it runs smoothly on both ARM and x86.

### Issues Fixed

Related to #18378