### PR TITLE
Attempt to solve CI errors - could not copy / unable to copy with `<BuildInParallel>false</BuildInParallel>`

### DIFF
--- a/src/Graphics/src/Text.Markdig/Graphics.Text.Markdig.csproj
+++ b/src/Graphics/src/Text.Markdig/Graphics.Text.Markdig.csproj
@@ -7,6 +7,7 @@
     <IsTrimmable>false</IsTrimmable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);CS1591;RS0041</NoWarn>
+    <BuildInParallel>false</BuildInParallel>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Description of Change

Added

```xml
<BuildInParallel>false</BuildInParallel>
```

to `./src/Graphics/src/Text.Markdig/Graphics.Text.Markdig.csproj` in order to fix CI errors like:

```
2023-11-07T10:07:22.1279525Z   Core.DeviceTests.Shared -> D:\a\_work\1\s\src\Core\tests\DeviceTests.Shared\bin\Release\net8.0-windows10.0.19041\Microsoft.Maui.DeviceTests.Shared.dll
2023-11-07T10:07:22.9070391Z D:\a\_work\1\s\bin\dotnet\sdk\8.0.100-rc.2.23502.2\Microsoft.Common.CurrentVersion.targets(4725,5): error MSB3027: Could not copy "obj\Release\netstandard2.0\Microsoft.Maui.Graphics.Text.Markdig.dll" to "bin\Release\netstandard2.0\Microsoft.Maui.Graphics.Text.Markdig.dll". Exceeded retry count of 10. Failed.  [D:\a\_work\1\s\src\Graphics\src\Text.Markdig\Graphics.Text.Markdig.csproj]

... snip ...

2023-11-07T10:31:38.9228286Z D:\a\_work\1\s\bin\dotnet\sdk\8.0.100-rc.2.23502.2\Microsoft.Common.CurrentVersion.targets(4725,5): error MSB3027: Could not copy "obj\Release\netstandard2.0\Microsoft.Maui.Graphics.Text.Markdig.dll" to "bin\Release\netstandard2.0\Microsoft.Maui.Graphics.Text.Markdig.dll". Exceeded retry count of 10. Failed.  [D:\a\_work\1\s\src\Graphics\src\Text.Markdig\Graphics.Text.Markdig.csproj]
2023-11-07T10:31:38.9234909Z D:\a\_work\1\s\bin\dotnet\sdk\8.0.100-rc.2.23502.2\Microsoft.Common.CurrentVersion.targets(4725,5): error MSB3021: Unable to copy file "obj\Release\netstandard2.0\Microsoft.Maui.Graphics.Text.Markdig.dll" to "bin\Release\netstandard2.0\Microsoft.Maui.Graphics.Text.Markdig.dll". The requested operation cannot be performed on a file with a user-mapped section open. : 'D:\a\_work\1\s\src\Graphics\src\Text.Markdig\bin\Release\netstandard2.0\Microsoft.Maui.Graphics.Text.Markdig.dll' 
```

See:
https://github.com/dotnet/maui/pull/18561#issuecomment-1798340153

> This is an issue that we see happening a lot on CI. Retry the build normally fixes it .. But if you find out what causes it , that would be awesome.

See... I pretend to play cavalry and save the lady in trouble...


Notes to future me (even older than today):

``` 
Microsoft.Common.CurrentVersion.targets
error MSB3027: Could not copy "obj\Release\
error MSB3021: Unable to copy file "obj\Releas
Exceeded retry count of 10. Failed.
The requested operation cannot be performed on a file with a user-mapped section open.
```

Similar approach:

https://github.com/xamarin/xamarin-android/blob/8928f1168a74f9edad705f4851f3e9252a64f90e/src/r8/r8.csproj#L11-L15

```
  <ItemGroup>
    <!-- There isn't an actual dependency here, but we can only build one 'gradlew' project
         at a time, and adding <ProjectReference> between them ensures they run sequentially. -->
    <ProjectReference Include="..\manifestmerger\manifestmerger.csproj" ReferenceOutputAssembly="False" />
  </ItemGroup>
```

### Issues Fixed

Unreported CI transient errors, occurring frequently on AzDO with voodoo solves-all workaround called "restart build".