### PR TITLE
[android] fix memory leak with `CarouselView`

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/Android/MauiCarouselRecyclerView.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/MauiCarouselRecyclerView.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		bool _disposed;
 
 		List<View> _oldViews;
-		CarouselViewwOnGlobalLayoutListener _carouselViewLayoutListener;
+		CarouselViewOnGlobalLayoutListener _carouselViewLayoutListener;
 
 		protected CarouselView Carousel => ItemsView as CarouselView;
 
@@ -516,13 +516,11 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			if (_carouselViewLayoutListener != null)
 				return;
 
-			_carouselViewLayoutListener = new CarouselViewwOnGlobalLayoutListener();
-			_carouselViewLayoutListener.LayoutReady += LayoutReady;
-
+			_carouselViewLayoutListener = new CarouselViewOnGlobalLayoutListener(this);
 			ViewTreeObserver.AddOnGlobalLayoutListener(_carouselViewLayoutListener);
 		}
 
-		void LayoutReady(object sender, EventArgs e)
+		void LayoutReady()
 		{
 			if (!_initialized)
 			{
@@ -546,7 +544,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				return;
 
 			ViewTreeObserver?.RemoveOnGlobalLayoutListener(_carouselViewLayoutListener);
-			_carouselViewLayoutListener.LayoutReady -= LayoutReady;
 			_carouselViewLayoutListener = null;
 		}
 
@@ -594,14 +591,23 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 			base.OnMeasure(widthMeasureSpec, heightMeasureSpec);
 		}
-	}
 
-	class CarouselViewwOnGlobalLayoutListener : Java.Lang.Object, ViewTreeObserver.IOnGlobalLayoutListener
-	{
-		public EventHandler<EventArgs> LayoutReady;
-		public void OnGlobalLayout()
+		class CarouselViewOnGlobalLayoutListener : Java.Lang.Object, ViewTreeObserver.IOnGlobalLayoutListener
 		{
-			LayoutReady?.Invoke(this, new EventArgs());
+			readonly WeakReference<MauiCarouselRecyclerView> _recyclerView;
+
+			public CarouselViewOnGlobalLayoutListener(MauiCarouselRecyclerView recyclerView)
+			{
+				_recyclerView = new(recyclerView);
+			}
+
+			public void OnGlobalLayout()
+			{
+				if (_recyclerView.TryGetTarget(out var recyclerView))
+				{
+					recyclerView.LayoutReady();
+				}
+			}
 		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.cs
@@ -37,6 +37,7 @@ namespace Microsoft.Maui.DeviceTests
 					handlers.AddHandler<Frame, FrameRenderer>();
 					handlers.AddHandler<Label, LabelHandler>();
 					handlers.AddHandler<Button, ButtonHandler>();
+					handlers.AddHandler<CarouselView, CarouselViewHandler>();
 					handlers.AddHandler<CollectionView, CollectionViewHandler>();
 					handlers.AddHandler(typeof(Controls.ContentView), typeof(ContentViewHandler));
 					handlers.AddHandler(typeof(ScrollView), typeof(ScrollViewHandler));
@@ -315,11 +316,12 @@ namespace Microsoft.Maui.DeviceTests
 					Title = "Page 2",
 					Content = new VerticalStackLayout
 					{
-						new Label(),
 						new Button(),
+						new CarouselView(),
 						new CollectionView(),
+						new ContentView(),
+						new Label(),
 						new ScrollView(),
-						new ContentView()
 					}
 				};
 				pageReference = new WeakReference(page);


### PR DESCRIPTION
Fixes: https://github.com/dotnet/maui/issues/17726
Related: https://github.com/dotnet/maui/issues/18365

Adding `CarouselView` to a page and navigating away from it keeps the page alive forever on Android. I was able to reproduce this in a test.

It took me a while to actually track this one down, but the problem boils down to `MauiCarouselRecyclerView` doing:

    _carouselViewLayoutListener = new CarouselViewwOnGlobalLayoutListener();
    _carouselViewLayoutListener.LayoutReady += LayoutReady;
    ViewTreeObserver.AddOnGlobalLayoutListener(_carouselViewLayoutListener);

The `ViewTreeObserver` lives longer than the page, and so:

* `ViewTreeObserver` -> `CarouselViewwOnGlobalLayoutListener`
* `event LayoutReady` -> `MauiCarouselRecyclerView`
* `MauiCarouselRecyclerView` -> `CarouselView`
* `CarouselView` -> `Parent.Parent.Parent.*` -> `Page`

Thus the `Page` lives forever.

If we remove the `LayoutReady` event, instead:

* `CarouselViewwOnGlobalLayoutListener` saves `MauiCarouselRecyclerView` in a weak reference.

* It can just call `LayoutReady()` directly.

* `MauiCarouselRecyclerView` is able to be GC'd now.

* `MauiCarouselRecyclerView.Dispose()` already appropriately will call `ClearLayoutListener()`

* Lastly, `ViewTreeObserver?.RemoveOnGlobalLayoutListener(_carouselViewLayoutListener)`

With these changes, the test passes and I don't think anything will leak now. :)

Other changes:

* I fixed the typo in `CarouselViewwOnGlobalLayoutListener`.
* I sorted the type names in the test alphabetically.
