### PR TITLE
Arrange content based on arrangement bounds rather than viewport bounds 

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/ScrollView/ScrollViewTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/ScrollView/ScrollViewTests.iOS.cs
@@ -7,7 +7,6 @@ using Microsoft.Maui.Controls;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Hosting;
-using UIKit;
 using Xunit;
 
 namespace Microsoft.Maui.DeviceTests
@@ -81,6 +80,72 @@ namespace Microsoft.Maui.DeviceTests
 					Assert.Equal(viewportSize.Height, contentSize.Height);
 					Assert.Equal(viewportSize.Width, contentSize.Width);
 				});
+			});
+		}
+
+		internal class TestStackLayout : VerticalStackLayout 
+		{
+			public Rect LastArrangeBounds { get; set; }
+
+			protected override Size ArrangeOverride(Rect bounds)
+			{
+				LastArrangeBounds = bounds;
+				return base.ArrangeOverride(bounds);
+			}
+		}
+
+		[Fact]
+		public async Task ContentChangeDoesNotResetScrollPosition()
+		{
+			var topLabel = new Label
+			{
+				WidthRequest = 100,
+				HeightRequest = 5000,
+				Text = "Hello",
+				BackgroundColor = Colors.LightBlue
+			};
+
+			var bottomLabel = new Label { Text = "Howdy" };
+
+			var layout = new TestStackLayout
+			{
+				topLabel,
+				bottomLabel
+			};
+
+			var scroll = new ScrollView
+			{
+				Content = layout,
+				HeightRequest = 400
+			};
+
+			var topLabelHandler = await CreateHandlerAsync<LabelHandler>(topLabel);
+			var bottomLabelHandler = await CreateHandlerAsync<LabelHandler>(bottomLabel);
+			var layoutHandler = await CreateHandlerAsync<LayoutHandler>(layout);
+			var scrollHandler = await CreateHandlerAsync<ScrollViewHandler>(scroll);
+
+			await AttachAndRun(scroll, async (handler) =>
+			{
+				var platformView = scrollHandler.PlatformView;
+
+				// Scroll down by 5000
+				scrollHandler.VirtualView.RequestScrollTo(0, 5000, true);
+
+				// Give it time to update
+				await Task.Delay(100);
+
+				// Verify that the content layout didn't pick up any incorrect offsets
+				// The arrangement for the actual _content_ should always start at Y=0 because
+				// of the ContentView shim. If we ever stop using the ContentView shim for 
+				// the iOS ScrollView implementation, this test will likely become invalid.
+				Assert.Equal(0, layout.LastArrangeBounds.Top);
+
+				// Change the text of the bottom label; this _should_ have no effect on scrolling
+				bottomLabel.Text = "Changed";
+				await Task.Delay(100);
+
+				// The content should still be arranged at Y=0
+				Assert.Equal(0, layout.LastArrangeBounds.Top);
 			});
 		}
 	}

--- a/src/Controls/tests/DeviceTests/Elements/ScrollView/ScrollViewTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/ScrollView/ScrollViewTests.iOS.cs
@@ -7,6 +7,7 @@ using Microsoft.Maui.Controls;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Hosting;
+using UIKit;
 using Xunit;
 
 namespace Microsoft.Maui.DeviceTests

--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.iOS.cs
@@ -352,8 +352,6 @@ namespace Microsoft.Maui.Handlers
 				// Ensure the container is at least the size of the UIScrollView itself, so that the 
 				// cross-platform layout logic makes sense and the contents don't arrange outside the 
 				// container. (Everything will look correct if they do, but hit testing won't work properly.)
-
-				var scrollViewBounds = uiScrollView.Bounds;
 				var containerBounds = contentSize;
 
 				container.Bounds = new CGRect(0, 0,

--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.iOS.cs
@@ -1,13 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Drawing;
-using System.Text;
 using CoreGraphics;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Layouts;
-using Microsoft.Maui.Platform;
-using ObjCRuntime;
 using UIKit;
 using Size = Microsoft.Maui.Graphics.Size;
 
@@ -338,14 +332,12 @@ namespace Microsoft.Maui.Handlers
 			var crossPlatformLayout = scrollView as ICrossPlatformLayout;
 			var platformScrollView = PlatformView;
 
-			var contentSize = crossPlatformLayout.CrossPlatformArrange(bounds);
-
 			// The UIScrollView's bounds are available, so we can use them to make sure the ContentSize makes sense
 			// for the ScrollView orientation
 			var viewportSize = GetViewportSize(platformScrollView);
 
 			// Get a Rect for doing the CrossPlatformArrange of the Content
-			var viewportRect = new Rect(Point.Zero, viewportSize.ToSize());
+			var viewportRect = new Rect(Graphics.Point.Zero, viewportSize.ToSize());
 
 			var contentSize = crossPlatformLayout.CrossPlatformArrange(viewportRect);
 


### PR DESCRIPTION
### Description of Change

The final content arrangement was being done using the viewport bounds, which are offset by the scroll distance. The arrangement _should_ be done by the ScrollView's arrangement bounds, as passed into the `CrossPlatformArrange()` method.

### Issues Fixed

Fixes #18513
