### PR TITLE
[ios] fix memory leak in `ImageButton`

### DIFF
--- a/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
+++ b/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
@@ -37,6 +37,7 @@ public class MemoryTests : ControlsHandlerTestBase
 				handlers.AddHandler<Polyline, PolylineHandler>();
 				handlers.AddHandler<IContentView, ContentViewHandler>();
 				handlers.AddHandler<Image, ImageHandler>();
+				handlers.AddHandler<ImageButton, ImageButtonHandler>();
 				handlers.AddHandler<IndicatorView, IndicatorViewHandler>();
 				handlers.AddHandler<RefreshView, RefreshViewHandler>();
 				handlers.AddHandler<IScrollView, ScrollViewHandler>();
@@ -59,6 +60,7 @@ public class MemoryTests : ControlsHandlerTestBase
 	[InlineData(typeof(Editor))]
 	[InlineData(typeof(GraphicsView))]
 	[InlineData(typeof(Image))]
+	[InlineData(typeof(ImageButton))]
 	[InlineData(typeof(IndicatorView))]
 	[InlineData(typeof(Label))]
 	[InlineData(typeof(Picker))]

--- a/src/Core/src/Platform/Android/ImageButtonExtensions.cs
+++ b/src/Core/src/Platform/Android/ImageButtonExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Android.Graphics.Drawables;
+﻿using System.Threading.Tasks;
+using Android.Graphics.Drawables;
 using Android.Widget;
 using Google.Android.Material.ImageView;
 using Google.Android.Material.Shape;
@@ -41,13 +42,12 @@ namespace Microsoft.Maui.Platform
 				.Build();
 		}
 
-		public static void UpdatePadding(this ShapeableImageView platformButton, IImageButton imageButton)
+		public static async void UpdatePadding(this ShapeableImageView platformButton, IImageButton imageButton)
 		{
 			platformButton.SetContentPadding(imageButton);
-			platformButton.Post(() =>
-			{
-				platformButton.SetContentPadding(imageButton);
-			});
+
+			// see: https://github.com/material-components/material-components-android/issues/2063
+			await Task.Yield();
 			platformButton.SetContentPadding(imageButton);
 		}
 


### PR DESCRIPTION
## iOS / Catalyst

Context: https://github.com/dotnet/maui/issues/18365

Adding a parameter to the test:

    [Theory("Handler Does Not Leak")]
    [InlineData(typeof(ImageButton))]
    public async Task HandlerDoesNotLeak(Type type)

Shows a memory leak in `ImageButton`, caused by the cycle

* `ImageButtonHandler` ->
* `UIButton` events like `TouchUpInside` ->
* `ImageButtonHandler`

I could solve this problem by creating a `ImageButtonProxy` class -- the same pattern I've used in other PRs to avoid cycles. This makes an intermediate type to handle the events and breaks the cycle.

Still thinking if the analyzer could have caught this, issue filed at:

https://github.com/jonathanpeppers/memory-analyzers/issues/12

## Android

Context: https://github.com/dotnet/maui/commit/a270ebdcc478578605d0a04fcf01c50eab7a3861
Context: https://github.com/dotnet/maui/commit/1bbe79de61f241217f88207b1272179ff66e6733
Context: https://github.com/material-components/material-components-android/issues/2063

Reviewing a GC dump of the device tests, I noticed a `System.Action`
keeping the `ImageButton` alive:

    Microsoft.Maui.Controls.ImageButton
        System.Action
            Java.Lang.Thread.RunnableImplementor

So next, I looked for `System.Action` and found the path on the
`ReferencedTypes` tab:

    System.Action
        Microsoft.Maui.Platform.ImageButtonExtensions.[]c__DisplayClass4_0
            Google.Android.Material.ImageView.ShapeableImageView
            Microsoft.Maui.Controls.ImageButton

Which led me to the code:

    public static async void UpdatePadding(this ShapeableImageView platformButton, IImageButton imageButton)
    {
        platformButton.SetContentPadding(imageButton);
        platformButton.Post(() =>
        {
            platformButton.SetContentPadding(imageButton);
        });
        platformButton.SetContentPadding(imageButton);
    }

?!? Why is this code calling `SetContentPadding` three times?

Reviewing the commit history:

* https://github.com/dotnet/maui/commit/a270ebdcc478578605d0a04fcf01c50eab7a3861
* https://github.com/dotnet/maui/commit/1bbe79de61f241217f88207b1272179ff66e6733
* https://github.com/material-components/material-components-android/issues/2063

I could comment out the code and the leak is solved, but I found I could
also change the code to use `await Task.Yield()` for the same result.