### PR TITLE
Configure an explicit time/zone in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,9 @@ updates:
     - custom-nuget
   schedule:
     interval: daily
+    # Run at 10pm Pacific time
+    time: "22:00"
+    timezone: "America/Los_Angeles"
   open-pull-requests-limit: 25
   groups:
     AndroidX:


### PR DESCRIPTION
The [docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#scheduletime) suggest that by default dependabot runs at 05:00 UTC but that does not seem to be true based on observing PR updates to the repo at 21:00 UTC.

This is an attempt to explicitly state the time (10PM PST / 22:00 UTC) and timezone (Pacific / America/Los_Angeles) so that it runs when there's less developer activity and it's less likely to starve our CI agent pool with many builds.

