### PR TITLE
Reinstate MediaPicker.CaptureVideo for Android (API 33)

### DIFF
--- a/src/Essentials/src/MediaPicker/MediaPicker.android.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.android.cs
@@ -66,7 +66,6 @@ namespace Microsoft.Maui.Media
 			if (!OperatingSystem.IsAndroidVersionAtLeast(33))
 				await Permissions.EnsureGrantedAsync<Permissions.StorageWrite>();
 
-
 			var capturePhotoIntent = new Intent(photo ? MediaStore.ActionImageCapture : MediaStore.ActionVideoCapture);
 
 			if (!PlatformUtils.IsIntentSupported(capturePhotoIntent))
@@ -86,24 +85,22 @@ namespace Microsoft.Maui.Media
 				var fileName = Guid.NewGuid().ToString("N") + ext;
 				var tmpFile = FileSystemUtils.GetTemporaryFile(Application.Context.CacheDir, fileName);
 
-				// Set up the content:// uri
-				AndroidUri outputUri = null;
-				void OnCreate(Intent intent)
+				string path = null;
+
+				void OnResult(Intent intent)
 				{
-					// Android requires that using a file provider to get a content:// uri for a file to be called
-					// from within the context of the actual activity which may share that uri with another intent
-					// it launches.
+					// The uri returned is only temporary and only lives as long as the Activity that requested it,
+					// so this means that it will always be cleaned up by the time we need it because we are using
+					// an intermediate activity.
 
-					outputUri ??= FileProvider.GetUriForFile(tmpFile);
-
-					intent.PutExtra(MediaStore.ExtraOutput, outputUri);
+					path = FileSystemUtils.EnsurePhysicalPath(intent.Data);
 				}
 
 				// Start the capture process
-				await IntermediateActivity.StartAsync(capturePhotoIntent, PlatformUtils.requestCodeMediaCapture, OnCreate);
-
+				await IntermediateActivity.StartAsync(capturePhotoIntent, PlatformUtils.requestCodeMediaCapture, onResult: OnResult);
+				
 				// Return the file that we just captured
-				return new FileResult(tmpFile.AbsolutePath);
+				return new FileResult(path);
 			}
 			catch (OperationCanceledException)
 			{


### PR DESCRIPTION
### Description of Change

As reported in #17977 `CaptureVideo` no longer works for API 33 and up. It seems like something has changed for Android in how this works. Originally, the code would go through `IntermediateActivity.OnActivityResult` but on Android 13 this always has the parameter value `resultCode == Result.Canceled`. Changing the code to use the inline callback function in `MediaPicker` and not depend on `IntermediateActivity` seems to work.

Interesting enough, for `CapturePhoto` this way already changed, but for video we didn't seem to have done that. This change makes `CaptureVideo` inline with `CapturePhoto` and makes it work again for all Android versions.

### Issues Fixed

Fixes #17977