### PR TITLE
Fix PlatformStringSizeService on iOS/Catalyst to use correct API

### DIFF
--- a/src/Graphics/src/Graphics/Platforms/iOS/PlatformStringSizeService.cs
+++ b/src/Graphics/src/Graphics/Platforms/iOS/PlatformStringSizeService.cs
@@ -15,21 +15,11 @@ namespace Microsoft.Maui.Graphics.Platform
 			var nsString = new NSString(value);
 			var uiFont = font?.ToPlatformFont(fontSize) ?? FontExtensions.GetDefaultPlatformFont();
 			
-			CGSize size;
-			if (OperatingSystem.IsIOSVersionAtLeast(14) || OperatingSystem.IsMacCatalystVersionAtLeast(13, 1))
-			{
-				size = nsString.GetBoundingRect(
-					CGSize.Empty,
-					NSStringDrawingOptions.UsesLineFragmentOrigin,
-					new UIStringAttributes { Font = uiFont },
-					null).Size;
-			}
-			else
-			{
-#pragma warning disable CA1422 // Validate platform compatibility
-				size = nsString.StringSize(uiFont, CGSize.Empty);
-#pragma warning restore CA1422 // Validate platform compatibility
-			}
+			CGSize size = nsString.GetBoundingRect(
+				CGSize.Empty,
+				NSStringDrawingOptions.UsesLineFragmentOrigin,
+				new UIStringAttributes { Font = uiFont },
+				null).Size;
 
 			uiFont.Dispose();
 			return new SizeF((float)size.Width, (float)size.Height);

--- a/src/Graphics/src/Graphics/Platforms/iOS/PlatformStringSizeService.cs
+++ b/src/Graphics/src/Graphics/Platforms/iOS/PlatformStringSizeService.cs
@@ -1,4 +1,5 @@
-﻿using CoreGraphics;
+﻿using System;
+using CoreGraphics;
 using Foundation;
 using UIKit;
 
@@ -13,14 +14,9 @@ namespace Microsoft.Maui.Graphics.Platform
 
 			var nsString = new NSString(value);
 			var uiFont = font?.ToPlatformFont(fontSize) ?? FontExtensions.GetDefaultPlatformFont();
-
-			var attributes = new NSMutableDictionary
-			{
-				{ new NSString("NSFontAttributeName"), uiFont }
-			};
-
+			
 			CGSize size;
-			if (!UIDevice.CurrentDevice.CheckSystemVersion(14, 0))
+			if (OperatingSystem.IsIOSVersionAtLeast(14) || OperatingSystem.IsMacCatalystVersionAtLeast(13, 1))
 			{
 				size = nsString.GetBoundingRect(
 					CGSize.Empty,


### PR DESCRIPTION
### Description of Change

<!-- Enter description of the fix in this section -->

There is a wrapper check around PlatformStringSizeService to either use BoundingBox or StringSize to get the size of a given string. The original implementation was intended for iOS apps greater than version 14.0 to use BoundingBox and StringSize for everything else.

A negation in the check meant that it would do the opposite, and only work on iOS versions below 14.0. The check itself should not be needed in any case, as the baseline versions of MAUI are above iOS 7.0, which is the first version where that API was deprecated.

Likewise for Catalyst, this code would also not work correctly.

We should be able to remove the check and run the bounding rect code as is.

<img width="1004" alt="スクリーンショット 2023-11-08 19 36 35" src="https://github.com/dotnet/maui/assets/898335/4e73dc1f-72be-4bc2-b951-f4c30b9ffaf6">


### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes https://github.com/dotnet/maui/issues/18572

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
