### PR TITLE
Replace Deprecated BeginImageContextWithOptions with UIGraphicsImageRenderer

### DIFF
--- a/src/Compatibility/Core/src/iOS/Renderers/FormsCheckBox.cs
+++ b/src/Compatibility/Core/src/iOS/Renderers/FormsCheckBox.cs
@@ -176,60 +176,66 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 
 		internal virtual UIImage CreateCheckBox(UIImage check)
 		{
-			UIGraphics.BeginImageContextWithOptions(new CGSize(_defaultSize, _defaultSize), false, 0);
-			var context = UIGraphics.GetCurrentContext();
-			context.SaveState();
-
-			var checkedColor = CheckBoxTintUIColor;
-			checkedColor.SetFill();
-			checkedColor.SetStroke();
-
-			var vPadding = _lineWidth / 2;
-			var hPadding = _lineWidth / 2;
-			var diameter = _defaultSize - _lineWidth;
-
-			var backgroundRect = new CGRect(hPadding, vPadding, diameter, diameter);
-			var boxPath = CreateBoxPath(backgroundRect);
-			boxPath.LineWidth = _lineWidth;
-			boxPath.Stroke();
-
-			if (check != null)
+			var renderer = new UIGraphicsImageRenderer(new CGSize(_defaultSize, _defaultSize), new UIGraphicsImageRendererFormat()
 			{
-				boxPath.Fill();
-				check.Draw(new CGPoint(0, 0), CGBlendMode.DestinationOut, 1);
-			}
+				Opaque = false,
+				Scale = 0,
+			});
 
-			context.RestoreState();
-			var img = UIGraphics.GetImageFromCurrentImageContext();
-			UIGraphics.EndImageContext();
+			return renderer.CreateImage((context) =>
+			{
+				context.CGContext.SaveState();
+				
+				var checkedColor = CheckBoxTintUIColor;
+				checkedColor.SetFill();
+				checkedColor.SetStroke();
 
-			return img;
+				var vPadding = _lineWidth / 2;
+				var hPadding = _lineWidth / 2;
+				var diameter = _defaultSize - _lineWidth;
+
+				var backgroundRect = new CGRect(hPadding, vPadding, diameter, diameter);
+				var boxPath = CreateBoxPath(backgroundRect);
+
+				boxPath.LineWidth = _lineWidth;
+				boxPath.Stroke();
+
+				if (check != null)
+				{
+					boxPath.Fill();
+					check.Draw(new CGPoint(0, 0), CGBlendMode.DestinationOut, 1);
+				}
+
+				context.CGContext.RestoreState();
+			});
 		}
-
 
 		internal UIImage CreateCheckMark()
 		{
-			UIGraphics.BeginImageContextWithOptions(new CGSize(_defaultSize, _defaultSize), false, 0);
-			var context = UIGraphics.GetCurrentContext();
-			context.SaveState();
+			var renderer = new UIGraphicsImageRenderer(new CGSize(_defaultSize, _defaultSize), new UIGraphicsImageRendererFormat()
+			{
+				Opaque = false,
+				Scale = 0,
+			});
 
-			var vPadding = _lineWidth / 2;
-			var hPadding = _lineWidth / 2;
-			var diameter = _defaultSize - _lineWidth;
+			return renderer.CreateImage((context) =>
+			{
+				context.CGContext.SaveState();
 
-			var checkPath = CreateCheckPath();
+				var vPadding = _lineWidth / 2;
+				var hPadding = _lineWidth / 2;
+				var diameter = _defaultSize - _lineWidth;
 
-			context.TranslateCTM(hPadding + (nfloat)(0.05 * diameter), vPadding + (nfloat)(0.1 * diameter));
-			context.ScaleCTM(diameter, diameter);
-			DrawCheckMark(checkPath);
-			UIColor.White.SetStroke();
-			checkPath.Stroke();
+				var checkPath = CreateCheckPath();
 
-			context.RestoreState();
-			var img = UIGraphics.GetImageFromCurrentImageContext();
-			UIGraphics.EndImageContext();
+				context.CGContext.TranslateCTM(hPadding + (nfloat)(0.05 * diameter), vPadding + (nfloat)(0.1 * diameter));
+				context.CGContext.ScaleCTM(diameter, diameter);
+				DrawCheckMark(checkPath);
+				UIColor.White.SetStroke();
+				checkPath.Stroke();
 
-			return img;
+				context.CGContext.RestoreState();
+			});
 		}
 
 		protected override void Dispose(bool disposing)

--- a/src/Compatibility/Core/src/iOS/Renderers/ImageRenderer.cs
+++ b/src/Compatibility/Core/src/iOS/Renderers/ImageRenderer.cs
@@ -255,16 +255,22 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 				var attString = new NSAttributedString(fontsource.Glyph, font: font, foregroundColor: iconcolor.ToPlatform());
 				var imagesize = ((NSString)fontsource.Glyph).GetSizeUsingAttributes(attString.GetUIKitAttributes(0, out _));
 
-				UIGraphics.BeginImageContextWithOptions(imagesize, false, 0f);
-				var ctx = new NSStringDrawingContext();
-				var boundingRect = attString.GetBoundingRect(imagesize, (NSStringDrawingOptions)0, ctx);
-				attString.DrawString(new RectangleF(
-					imagesize.Width / 2 - boundingRect.Size.Width / 2,
-					imagesize.Height / 2 - boundingRect.Size.Height / 2,
-					imagesize.Width,
-					imagesize.Height));
-				image = UIGraphics.GetImageFromCurrentImageContext();
-				UIGraphics.EndImageContext();
+				var renderer = new UIGraphicsImageRenderer(imagesize, new UIGraphicsImageRendererFormat()
+				{
+					Opaque = false,
+					Scale = 0,
+				});
+
+				image = renderer.CreateImage((context) =>
+				{
+					var ctx = new NSStringDrawingContext();
+					var boundingRect = attString.GetBoundingRect(imagesize, (NSStringDrawingOptions)0, ctx);
+					attString.DrawString(new RectangleF(
+						imagesize.Width / 2 - boundingRect.Size.Width / 2,
+						imagesize.Height / 2 - boundingRect.Size.Height / 2,
+						imagesize.Width,
+						imagesize.Height));
+				});
 
 				if (image != null && iconcolor != _defaultColor)
 					image = image.ImageWithRenderingMode(UIImageRenderingMode.AlwaysOriginal);

--- a/src/Compatibility/Core/src/iOS/Renderers/SwipeViewRenderer.cs
+++ b/src/Compatibility/Core/src/iOS/Renderers/SwipeViewRenderer.cs
@@ -724,12 +724,17 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 
 			var width = maxResizeFactor * sourceSize.Width;
 			var height = maxResizeFactor * sourceSize.Height;
-			UIGraphics.BeginImageContextWithOptions(new CGSize((nfloat)width, (nfloat)height), false, 0);
-			sourceImage.Draw(new CGRect(0, 0, (nfloat)width, (nfloat)height));
-			var resultImage = UIGraphics.GetImageFromCurrentImageContext();
-			UIGraphics.EndImageContext();
+			
+			var renderer = new UIGraphicsImageRenderer(new CGSize((nfloat)width, (nfloat)height), new UIGraphicsImageRendererFormat()
+			{
+				Opaque = false,
+				Scale = 0,
+			});
 
-			return resultImage;
+			return renderer.CreateImage((context) =>
+			{
+				sourceImage.Draw(new CGRect(0, 0, (nfloat)width, (nfloat)height));
+			});
 		}
 
 		void HandleTouchInteractions(GestureStatus status, CGPoint point)

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellPageRendererTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellPageRendererTracker.cs
@@ -443,25 +443,30 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 			var rect = new CGRect(0, 0, 23f, 23f);
 
-			UIGraphics.BeginImageContextWithOptions(rect.Size, false, 0);
-			var ctx = UIGraphics.GetCurrentContext();
-			ctx.SaveState();
-			ctx.SetStrokeColor(UIColor.Blue.CGColor);
-
-			float size = 3f;
-			float start = 4f;
-			ctx.SetLineWidth(size);
-
-			for (int i = 0; i < 3; i++)
+			var renderer = new UIGraphicsImageRenderer(rect.Size, new UIGraphicsImageRendererFormat()
 			{
-				ctx.MoveTo(1f, start + i * (size * 2));
-				ctx.AddLineToPoint(22f, start + i * (size * 2));
-				ctx.StrokePath();
-			}
+				Opaque = false,
+				Scale = 0,
+			});
 
-			ctx.RestoreState();
-			img = UIGraphics.GetImageFromCurrentImageContext();
-			UIGraphics.EndImageContext();
+			img = renderer.CreateImage((context) =>
+			{
+				context.CGContext.SaveState();
+				UIColor.Blue.SetStroke();
+
+				float size = 3f;
+				float start = 4f;
+				context.CGContext.SetLineWidth(size);
+
+				for (int i = 0; i < 3; i++)
+				{
+					context.CGContext.MoveTo(1f, start + i * (size * 2));
+					context.CGContext.AddLineToPoint(22f, start + i * (size * 2));
+					context.CGContext.StrokePath();
+				}
+
+				context.CGContext.RestoreState();
+			});
 
 			_nSCache.SetObjectforKey(img, (NSString)hamburgerKey);
 			return img;

--- a/src/Controls/src/Core/Platform/iOS/Extensions/BrushExtensions.cs
+++ b/src/Controls/src/Core/Platform/iOS/Extensions/BrushExtensions.cs
@@ -121,16 +121,13 @@ namespace Microsoft.Maui.Controls.Platform
 			if (backgroundLayer == null)
 				return null;
 
-			UIGraphics.BeginImageContextWithOptions(backgroundLayer.Bounds.Size, false, UIScreen.MainScreen.Scale);
+			var renderer = new UIGraphicsImageRenderer(backgroundLayer.Bounds.Size, new UIGraphicsImageRendererFormat()
+			{
+				Opaque = false,
+				Scale = UIScreen.MainScreen.Scale,
+			});
 
-			if (UIGraphics.GetCurrentContext() == null)
-				return null;
-
-			backgroundLayer.RenderInContext(UIGraphics.GetCurrentContext());
-			UIImage gradientImage = UIGraphics.GetImageFromCurrentImageContext();
-			UIGraphics.EndImageContext();
-
-			return gradientImage;
+			return renderer.CreateImage((context) => backgroundLayer.RenderInContext(context.CGContext));
 		}
 
 		public static void InsertBackgroundLayer(this UIView view, CALayer backgroundLayer, int index = -1)

--- a/src/Core/src/Handlers/SwipeItemMenuItem/SwipeItemMenuItemHandler.iOS.cs
+++ b/src/Core/src/Handlers/SwipeItemMenuItem/SwipeItemMenuItemHandler.iOS.cs
@@ -142,12 +142,17 @@ namespace Microsoft.Maui.Handlers
 
 				var width = maxResizeFactor * sourceSize.Width;
 				var height = maxResizeFactor * sourceSize.Height;
-				UIGraphics.BeginImageContextWithOptions(new CGSize((nfloat)width, (nfloat)height), false, 0);
-				sourceImage.Draw(new CGRect(0, 0, (nfloat)width, (nfloat)height));
-				var resultImage = UIGraphics.GetImageFromCurrentImageContext();
-				UIGraphics.EndImageContext();
 
-				return resultImage;
+				var renderer = new UIGraphicsImageRenderer(new CGSize((nfloat)width, (nfloat)height), new UIGraphicsImageRendererFormat()
+				{
+					Opaque = false,
+					Scale = 0,
+				});
+
+				return renderer.CreateImage((context) =>
+				{
+					sourceImage.Draw(new CGRect(0, 0, (nfloat)width, (nfloat)height));
+				});
 			}
 		}
 

--- a/src/Core/src/ImageSources/iOS/ImageSourceExtensions.cs
+++ b/src/Core/src/ImageSources/iOS/ImageSourceExtensions.cs
@@ -24,20 +24,24 @@ namespace Microsoft.Maui
 			var attString = new NSAttributedString(glyph, font, color);
 			var imagesize = glyph.GetSizeUsingAttributes(attString.GetUIKitAttributes(0, out _)!);
 #pragma warning restore CS8604
-			UIGraphics.BeginImageContextWithOptions(imagesize, false, scale);
-			var ctx = new NSStringDrawingContext();
 
-			var boundingRect = attString.GetBoundingRect(imagesize, 0, ctx);
-			attString.DrawString(new CGRect(
+			var renderer = new UIGraphicsImageRenderer(imagesize, new UIGraphicsImageRendererFormat()
+			{
+				Opaque = false,
+				Scale = scale,
+			});
+
+			return renderer.CreateImage((context) =>
+			{
+				var ctx = new NSStringDrawingContext();
+				
+				var boundingRect = attString.GetBoundingRect(imagesize, 0, ctx);
+				attString.DrawString(new CGRect(
 				imagesize.Width / 2 - boundingRect.Size.Width / 2,
 				imagesize.Height / 2 - boundingRect.Size.Height / 2,
 				imagesize.Width,
 				imagesize.Height));
-
-			var image = UIGraphics.GetImageFromCurrentImageContext();
-			UIGraphics.EndImageContext();
-
-			return image.ImageWithRenderingMode(UIImageRenderingMode.AlwaysOriginal);
+			}).ImageWithRenderingMode(UIImageRenderingMode.AlwaysOriginal);
 		}
 
 		internal static UIImage? GetPlatformImage(this IFileImageSource imageSource)

--- a/src/Core/src/Platform/iOS/MauiCheckBox.cs
+++ b/src/Core/src/Platform/iOS/MauiCheckBox.cs
@@ -177,63 +177,69 @@ namespace Microsoft.Maui.Platform
 
 		UIImage CreateCheckBox(UIImage? check)
 		{
-			UIGraphics.BeginImageContextWithOptions(new CGSize(DefaultSize, DefaultSize), false, 0);
-			var context = UIGraphics.GetCurrentContext();
-			context.SaveState();
-
-			var checkedColor = CheckBoxTintUIColor;
-
-			if (checkedColor != null)
+			var renderer = new UIGraphicsImageRenderer(new CGSize(DefaultSize, DefaultSize), new UIGraphicsImageRendererFormat()
 			{
-				checkedColor.SetFill();
-				checkedColor.SetStroke();
-			}
+				Opaque = false,
+				Scale = 0,
+			});
 
-			var vPadding = LineWidth / 2;
-			var hPadding = LineWidth / 2;
-			var diameter = DefaultSize - LineWidth;
-
-			var backgroundRect = new CGRect(hPadding, vPadding, diameter, diameter);
-			var boxPath = CreateBoxPath(backgroundRect);
-			boxPath.LineWidth = LineWidth;
-			boxPath.Stroke();
-
-			if (check != null)
+			return renderer.CreateImage((context) =>
 			{
-				boxPath.Fill();
-				check.Draw(new CGPoint(0, 0), CGBlendMode.DestinationOut, 1);
-			}
+				context.CGContext.SaveState();
 
-			context.RestoreState();
-			var img = UIGraphics.GetImageFromCurrentImageContext();
-			UIGraphics.EndImageContext();
+				var checkedColor = CheckBoxTintUIColor;
 
-			return img;
+				if (checkedColor != null)
+				{
+					checkedColor.SetFill();
+					checkedColor.SetStroke();
+				}
+
+				var vPadding = LineWidth / 2;
+				var hPadding = LineWidth / 2;
+				var diameter = DefaultSize - LineWidth;
+
+				var backgroundRect = new CGRect(hPadding, vPadding, diameter, diameter);
+				var boxPath = CreateBoxPath(backgroundRect);
+				boxPath.LineWidth = LineWidth;
+				boxPath.Stroke();
+
+				if (check != null)
+				{
+					boxPath.Fill();
+					check.Draw(new CGPoint(0, 0), CGBlendMode.DestinationOut, 1);
+				}
+
+				context.CGContext.RestoreState();
+			});
 		}
 
 		static UIImage CreateCheckMark()
 		{
-			UIGraphics.BeginImageContextWithOptions(new CGSize(DefaultSize, DefaultSize), false, 0);
-			var context = UIGraphics.GetCurrentContext();
-			context.SaveState();
+			var renderer = new UIGraphicsImageRenderer(new CGSize(DefaultSize, DefaultSize), new UIGraphicsImageRendererFormat()
+			{
+				Opaque = false,
+				Scale = 0,
+			});
 
-			var vPadding = LineWidth / 2;
-			var hPadding = LineWidth / 2;
-			var diameter = DefaultSize - LineWidth;
+			return renderer.CreateImage((context) =>
+			{
+				context.CGContext.SaveState();
+				
+				var vPadding = LineWidth / 2;
+				var hPadding = LineWidth / 2;
+				var diameter = DefaultSize - LineWidth;
 
-			var checkPath = CreateCheckPath();
+				var checkPath = CreateCheckPath();
 
-			context.TranslateCTM(hPadding + (nfloat)(0.05 * diameter), vPadding + (nfloat)(0.1 * diameter));
-			context.ScaleCTM(diameter, diameter);
-			DrawCheckMark(checkPath);
-			UIColor.White.SetStroke();
-			checkPath.Stroke();
+				context.CGContext.TranslateCTM(hPadding + (nfloat)(0.05 * diameter), vPadding + (nfloat)(0.1 * diameter));
+				context.CGContext.ScaleCTM(diameter, diameter);
+				DrawCheckMark(checkPath);
+				UIColor.White.SetStroke();
+				checkPath.Stroke();
 
-			context.RestoreState();
-			var img = UIGraphics.GetImageFromCurrentImageContext();
-			UIGraphics.EndImageContext();
-
-			return img;
+				context.CGContext.RestoreState();
+			});
 		}
 
 		public override CGSize SizeThatFits(CGSize size)

--- a/src/Core/src/Platform/iOS/TextFieldExtensions.cs
+++ b/src/Core/src/Platform/iOS/TextFieldExtensions.cs
@@ -223,26 +223,23 @@ namespace Microsoft.Maui.Platform
 		{
 			var size = image.Size;
 
-			UIGraphics.BeginImageContextWithOptions(size, false, UIScreen.MainScreen.Scale);
+			var renderer = new UIGraphicsImageRenderer(size, new UIGraphicsImageRendererFormat()
+			{
+				Opaque = false,
+				Scale = UIScreen.MainScreen.Scale,
+			});
 
-			if (UIGraphics.GetCurrentContext() == null)
+			if (renderer is null)
 				return null;
 
-			var context = UIGraphics.GetCurrentContext();
+			return renderer.CreateImage((context) =>
+			{
+				image.Draw(CGPoint.Empty, CGBlendMode.Normal, 1.0f);
+				color.ColorWithAlpha(1.0f).SetFill();
 
-			image.Draw(CGPoint.Empty, CGBlendMode.Normal, 1.0f);
-			context?.SetFillColor(color.CGColor);
-			context?.SetBlendMode(CGBlendMode.SourceIn);
-			context?.SetAlpha(1.0f);
-
-			var rect = new CGRect(CGPoint.Empty.X, CGPoint.Empty.Y, image.Size.Width, image.Size.Height);
-			context?.FillRect(rect);
-
-			var tintedImage = UIGraphics.GetImageFromCurrentImageContext();
-
-			UIGraphics.EndImageContext();
-
-			return tintedImage;
+				var rect = new CGRect(CGPoint.Empty.X, CGPoint.Empty.Y, image.Size.Width, image.Size.Height);
+				context?.FillRect(rect, CGBlendMode.SourceIn);
+			});
 		}
 	}
 }

--- a/src/Core/tests/DeviceTests.Shared/ImageAnalysis/RawBitmap.cs
+++ b/src/Core/tests/DeviceTests.Shared/ImageAnalysis/RawBitmap.cs
@@ -76,12 +76,19 @@ namespace Microsoft.Maui.DeviceTests.ImageAnalysis
 			var scale = UIScreen.MainScreen.Scale;
 			int width = (int)(rect.Width * scale);
 			int height = (int)(rect.Height * scale);
-			UIGraphics.BeginImageContextWithOptions(rect.Size, false, UIScreen.MainScreen.Scale);
-			using var context = UIGraphics.GetCurrentContext();
-			using var colorSpace = CGColorSpace.CreateDeviceRGB();
-			view.Layer.RenderInContext(context);
-			using var image = UIGraphics.GetImageFromCurrentImageContext();
-			UIGraphics.EndImageContext();
+
+			var renderer = new UIGraphicsImageRenderer(rect.Size, new UIGraphicsImageRendererFormat()
+			{
+				Opaque = false,
+				Scale = UIScreen.MainScreen.Scale,
+			});
+
+			using var image = renderer.CreateImage((context) =>
+			{
+				using var colorSpace = CGColorSpace.CreateDeviceRGB();
+				view.Layer.RenderInContext(context.CGContext);
+			});
+			
 			var cgimage = image.CGImage;
 			var buffer = cgimage.DataProvider.CopyData();
 			var pixelBuffer = buffer.ToArray();

--- a/src/Core/tests/DeviceTests/Services/ImageSource/BaseImageSourceServiceTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Services/ImageSource/BaseImageSourceServiceTests.iOS.cs
@@ -56,17 +56,17 @@ namespace Microsoft.Maui.DeviceTests
 		{
 			var rect = new CGRect(0, 0, width, height);
 
-			UIGraphics.BeginImageContextWithOptions(rect.Size, false, 1);
-			var context = UIGraphics.GetCurrentContext();
+			var renderer = new UIGraphicsImageRenderer(rect, new UIGraphicsImageRendererFormat()
+			{
+				Opaque = false,
+				Scale = 1,
+			});
 
-			color.SetFill();
-			context.FillRect(rect);
-
-			var image = UIGraphics.GetImageFromCurrentImageContext();
-
-			UIGraphics.EndImageContext();
-
-			return image.ImageWithRenderingMode(UIImageRenderingMode.AlwaysOriginal);
+			return renderer.CreateImage((context) =>
+			{
+				color.SetFill();
+				context.FillRect(rect);
+			}).ImageWithRenderingMode(UIImageRenderingMode.AlwaysOriginal);
 		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Stubs/CountedImageSourceServiceStub.iOS.cs
+++ b/src/Core/tests/DeviceTests/Stubs/CountedImageSourceServiceStub.iOS.cs
@@ -40,17 +40,17 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 		{
 			var rect = new CGRect(0, 0, 100, 100);
 
-			UIGraphics.BeginImageContextWithOptions(rect.Size, false, scale);
-			var context = UIGraphics.GetCurrentContext();
+			var renderer = new UIGraphicsImageRenderer(rect.Size, new UIGraphicsImageRendererFormat()
+			{
+				Opaque = false,
+				Scale = scale,
+			});
 
-			color.SetFill();
-			context.FillRect(rect);
-
-			var image = UIGraphics.GetImageFromCurrentImageContext();
-
-			UIGraphics.EndImageContext();
-
-			return image.ImageWithRenderingMode(UIImageRenderingMode.AlwaysOriginal);
+			return renderer.CreateImage((context) =>
+			{
+				color.SetFill();
+				context.FillRect(rect);
+			}).ImageWithRenderingMode(UIImageRenderingMode.AlwaysOriginal);
 		}
 
 		class Result : ImageSourceServiceResult

--- a/src/Core/tests/DeviceTests/Stubs/CustomImageCacheStub.iOS.cs
+++ b/src/Core/tests/DeviceTests/Stubs/CustomImageCacheStub.iOS.cs
@@ -22,17 +22,18 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 
 			var rect = new CGRect(0, 0, 100, 100);
 
-			UIGraphics.BeginImageContextWithOptions(rect.Size, false, 1);
-			var context = UIGraphics.GetCurrentContext();
 
-			color.ToPlatform().SetFill();
-			context.FillRect(rect);
+			var renderer = new UIGraphicsImageRenderer(rect.Size, new UIGraphicsImageRendererFormat()
+			{
+				Opaque = false,
+				Scale = 1,
+			});
 
-			var image = UIGraphics.GetImageFromCurrentImageContext();
-
-			UIGraphics.EndImageContext();
-
-			image = image.ImageWithRenderingMode(UIImageRenderingMode.AlwaysOriginal);
+			var image = renderer.CreateImage((context) =>
+			{
+				color.ToPlatform().SetFill();
+				context.FillRect(rect);
+			}).ImageWithRenderingMode(UIImageRenderingMode.AlwaysOriginal);
 
 			_cache[color] = (image, 1);
 

--- a/src/Essentials/src/Screenshot/Screenshot.ios.cs
+++ b/src/Essentials/src/Screenshot/Screenshot.ios.cs
@@ -32,19 +32,23 @@ namespace Microsoft.Maui.Media
 			_ = window ?? throw new ArgumentNullException(nameof(window));
 
 			// NOTE: We rely on the window frame having been set to the correct size when this method is invoked.
-			UIGraphics.BeginImageContextWithOptions(window.Bounds.Size, false, window.Screen.Scale);
-			var ctx = UIGraphics.GetCurrentContext();
+			var renderer = new UIGraphicsImageRenderer(window.Bounds.Size, new UIGraphicsImageRendererFormat()
+			{
+				Opaque = false,
+				Scale = window.Screen.Scale,
+			});
 
-			// ctx will be null if the width/height of the view is zero
-			if (ctx is not null && !TryRender(window, out _))
+			// renderer will be null if the width/height of the view is zero
+			if (renderer is not null && !TryRender(window, out _))
 			{
 				// TODO: test/handle this case
 			}
 
-			var image = UIGraphics.GetImageFromCurrentImageContext();
-			UIGraphics.EndImageContext();
+			var image = renderer?.CreateImage((context) =>
+			{
+			});
 
-			var result = new ScreenshotResult(image);
+			var result = new ScreenshotResult(image ?? new UIImage());
 
 			return Task.FromResult<IScreenshotResult>(result);
 		}
@@ -54,17 +58,21 @@ namespace Microsoft.Maui.Media
 			_ = view ?? throw new ArgumentNullException(nameof(view));
 
 			// NOTE: We rely on the view frame having been set to the correct size when this method is invoked.
-			UIGraphics.BeginImageContextWithOptions(view.Bounds.Size, false, view.Window.Screen.Scale);
-			var ctx = UIGraphics.GetCurrentContext();
+			var renderer = new UIGraphicsImageRenderer(view.Bounds.Size, new UIGraphicsImageRendererFormat()
+			{
+				Opaque = false,
+				Scale = view.Window.Screen.Scale,
+			});
 
-			// ctx will be null if the width/height of the view is zero
-			if (ctx is not null && !TryRender(view, out _))
+			// renderer will be null if the width/height of the view is zero
+			if (renderer is not null && !TryRender(view, out _))
 			{
 				// TODO: test/handle this case
 			}
 
-			var image = UIGraphics.GetImageFromCurrentImageContext();
-			UIGraphics.EndImageContext();
+			var image = renderer?.CreateImage((context) =>
+			{
+			});
 
 			var result = image is null ? null : new ScreenshotResult(image);
 
@@ -76,17 +84,25 @@ namespace Microsoft.Maui.Media
 			_ = layer ?? throw new ArgumentNullException(nameof(layer));
 
 			// NOTE: We rely on the layer frame having been set to the correct size when this method is invoked.
-			UIGraphics.BeginImageContextWithOptions(layer.Bounds.Size, false, layer.RasterizationScale);
-			var ctx = UIGraphics.GetCurrentContext();
+			var renderer = new UIGraphicsImageRenderer(layer.Bounds.Size, new UIGraphicsImageRendererFormat()
+			{
+				Opaque = false,
+				Scale = layer.RasterizationScale,
+			});
 
-			// ctx will be null if the width/height of the view is zero
-			if (ctx is not null && !TryRender(layer, ctx, skipChildren, out _))
+			// renderer will be null if the width/height of the view is zero
+			if (renderer is not null)
 			{
 				// TODO: test/handle this case
 			}
 
-			var image = UIGraphics.GetImageFromCurrentImageContext();
-			UIGraphics.EndImageContext();
+			var image = renderer?.CreateImage((context) =>
+			{
+				if (!TryRender(layer, context.CGContext, skipChildren, out _))
+				{
+					// TODO: test/handle this case
+				}
+			});
 
 			var result = image is null ? null : new ScreenshotResult(image);
 

--- a/src/Essentials/src/Screenshot/Screenshot.ios.cs
+++ b/src/Essentials/src/Screenshot/Screenshot.ios.cs
@@ -44,8 +44,9 @@ namespace Microsoft.Maui.Media
 				// TODO: test/handle this case
 			}
 
-			var image = renderer?.CreateImage((context) =>
+			var image = renderer?.CreateImage((_) =>
 			{
+				window.DrawViewHierarchy(window.Bounds, true);
 			});
 
 			var result = new ScreenshotResult(image ?? new UIImage());
@@ -70,8 +71,9 @@ namespace Microsoft.Maui.Media
 				// TODO: test/handle this case
 			}
 
-			var image = renderer?.CreateImage((context) =>
+			var image = renderer?.CreateImage((_) =>
 			{
+				view.DrawViewHierarchy(view.Bounds, true);
 			});
 
 			var result = image is null ? null : new ScreenshotResult(image);
@@ -102,6 +104,8 @@ namespace Microsoft.Maui.Media
 				{
 					// TODO: test/handle this case
 				}
+
+				layer.RenderInContext(context.CGContext);
 			});
 
 			var result = image is null ? null : new ScreenshotResult(image);

--- a/src/Graphics/src/Graphics/Platforms/iOS/UIImageExtensions.cs
+++ b/src/Graphics/src/Graphics/Platforms/iOS/UIImageExtensions.cs
@@ -47,11 +47,17 @@ namespace Microsoft.Maui.Graphics.Platform
 				return target;
 			}
 
-			UIGraphics.BeginImageContextWithOptions(target.Size, false, target.CurrentScale);
-			target.Draw(CGPoint.Empty);
-			var image = UIGraphics.GetImageFromCurrentImageContext();
-			UIGraphics.EndImageContext();
+			var renderer = new UIGraphicsImageRenderer(target.Size, new UIGraphicsImageRendererFormat()
+			{
+				Opaque = false,
+				Scale = target.CurrentScale,
+			});
 
+			var image = renderer.CreateImage((context) =>
+			{
+				target.Draw(CGPoint.Empty);
+			});
+			
 			if (disposeOriginal)
 			{
 				target.Dispose();


### PR DESCRIPTION
### Description of Change

In iOS 17 the `UIGraphics.BeginImageContextWithOptions` API is [deprecated](https://developer.apple.com/documentation/uikit/1623912-uigraphicsbeginimagecontextwitho) and we're using that in a couple of places. This change replaces those with the new thing that we should be using.

### Issues Fixed

Related https://github.com/xamarin/Xamarin.Forms/pull/15833 & https://github.com/xamarin/Xamarin.Forms/issues/15827
