### PR TITLE
[ios] fix memory leak in `Stepper`

### DIFF
--- a/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
+++ b/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
@@ -40,6 +40,7 @@ public class MemoryTests : ControlsHandlerTestBase
 				handlers.AddHandler<IndicatorView, IndicatorViewHandler>();
 				handlers.AddHandler<RefreshView, RefreshViewHandler>();
 				handlers.AddHandler<IScrollView, ScrollViewHandler>();
+				handlers.AddHandler<Stepper, StepperHandler>();
 				handlers.AddHandler<SwipeView, SwipeViewHandler>();
 				handlers.AddHandler<TimePicker, TimePickerHandler>();
 				handlers.AddHandler<WebView, WebViewHandler>();
@@ -66,6 +67,7 @@ public class MemoryTests : ControlsHandlerTestBase
 	[InlineData(typeof(Polyline))]
 	[InlineData(typeof(RefreshView))]
 	[InlineData(typeof(ScrollView))]
+	[InlineData(typeof(Stepper))]
 	[InlineData(typeof(SwipeView))]
 	[InlineData(typeof(TimePicker))]
 	[InlineData(typeof(WebView))]


### PR DESCRIPTION
Context: https://github.com/dotnet/maui/issues/18365

Adding a parameter to the test:

    [Theory("Handler Does Not Leak")]
    [InlineData(typeof(Stepper))]
    public async Task HandlerDoesNotLeak(Type type)

Shows a memory leak in `Stepper`, caused by the cycle

* `StepperHandler` ->
* `UIStepper.ValueChanged` event ->
* `StepperHandler`

I could solve this problem by creating a `StepperProxy` class -- the same pattern I've used in other PRs to avoid cycles. This makes an intermediate type to handle the events and breaks the cycle.

Still thinking if the analyzer could have caught this, issue filed at:

https://github.com/jonathanpeppers/memory-analyzers/issues/12