### PR TITLE
Makes KeyboardAutoManager.GoToNextResponderOrResign public

### DIFF
--- a/src/Core/src/Platform/iOS/KeyboardAutoManager.cs
+++ b/src/Core/src/Platform/iOS/KeyboardAutoManager.cs
@@ -10,9 +10,9 @@ using UIKit;
 
 namespace Microsoft.Maui.Platform;
 
-internal static class KeyboardAutoManager
+public static class KeyboardAutoManager
 {
-	internal static void GoToNextResponderOrResign(UIView view, UIView? customSuperView = null)
+	public static void GoToNextResponderOrResign(UIView view, UIView? customSuperView = null)
 	{
 		if (!view.CheckIfEligible())
 		{


### PR DESCRIPTION
### Description of Change

The PR changes access modifiers of the KeyboardAutoManager class and the GoToNextResponderOrResign method to public.

It helps implementing of custom text fields easily.
As the GoToNextResponderOrResign method refers to a lot of other internal methods (that refer to other internal ones as well), it's challenging to just copy (or make own implementation) of that method. 
So, making this method public helps finding a next responder for iOS in custom text fields much easer. 

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #16949

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
