### PR TITLE
[ios] fix memory leak in `Slider`

### DIFF
--- a/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
+++ b/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
@@ -41,6 +41,7 @@ public class MemoryTests : ControlsHandlerTestBase
 				handlers.AddHandler<IndicatorView, IndicatorViewHandler>();
 				handlers.AddHandler<RefreshView, RefreshViewHandler>();
 				handlers.AddHandler<IScrollView, ScrollViewHandler>();
+				handlers.AddHandler<Slider, SliderHandler>();
 				handlers.AddHandler<Stepper, StepperHandler>();
 				handlers.AddHandler<SwipeView, SwipeViewHandler>();
 				handlers.AddHandler<TimePicker, TimePickerHandler>();
@@ -69,6 +70,7 @@ public class MemoryTests : ControlsHandlerTestBase
 	[InlineData(typeof(Polyline))]
 	[InlineData(typeof(RefreshView))]
 	[InlineData(typeof(ScrollView))]
+	[InlineData(typeof(Slider))]
 	[InlineData(typeof(Stepper))]
 	[InlineData(typeof(SwipeView))]
 	[InlineData(typeof(TimePicker))]

--- a/src/Core/src/Handlers/Slider/SliderHandler.iOS.cs
+++ b/src/Core/src/Handlers/Slider/SliderHandler.iOS.cs
@@ -6,6 +6,8 @@ namespace Microsoft.Maui.Handlers
 {
 	public partial class SliderHandler : ViewHandler<ISlider, UISlider>
 	{
+		readonly SliderProxy _proxy = new();
+
 		protected override UISlider CreatePlatformView()
 		{
 			var platformSlider = new UISlider { Continuous = true };
@@ -19,19 +21,13 @@ namespace Microsoft.Maui.Handlers
 		protected override void ConnectHandler(UISlider platformView)
 		{
 			base.ConnectHandler(platformView);
-
-			platformView.ValueChanged += OnControlValueChanged;
-			platformView.AddTarget(OnTouchDownControlEvent, UIControlEvent.TouchDown);
-			platformView.AddTarget(OnTouchUpControlEvent, UIControlEvent.TouchUpInside | UIControlEvent.TouchUpOutside);
+			_proxy.Connect(VirtualView, platformView);
 		}
 
 		protected override void DisconnectHandler(UISlider platformView)
 		{
 			base.DisconnectHandler(platformView);
-
-			platformView.ValueChanged -= OnControlValueChanged;
-			platformView.RemoveTarget(OnTouchDownControlEvent, UIControlEvent.TouchDown);
-			platformView.RemoveTarget(OnTouchUpControlEvent, UIControlEvent.TouchUpInside | UIControlEvent.TouchUpOutside);
+			_proxy.Disconnect(platformView);	
 		}
 
 		public static void MapMinimum(ISliderHandler handler, ISlider slider)
@@ -72,22 +68,42 @@ namespace Microsoft.Maui.Handlers
 				.FireAndForget(handler);
 		}
 
-		void OnControlValueChanged(object? sender, EventArgs eventArgs)
+		class SliderProxy
 		{
-			if (PlatformView == null || VirtualView == null)
-				return;
+			WeakReference<ISlider>? _virtualView;
 
-			VirtualView.Value = PlatformView.Value;
-		}
+			ISlider? VirtualView => _virtualView is not null && _virtualView.TryGetTarget(out var v) ? v : null;
 
-		void OnTouchDownControlEvent(object? sender, EventArgs e)
-		{
-			VirtualView?.DragStarted();
-		}
+			public void Connect(ISlider virtualView, UISlider platformView)
+			{
+				_virtualView = new(virtualView);
+				platformView.ValueChanged += OnControlValueChanged;
+				platformView.AddTarget(OnTouchDownControlEvent, UIControlEvent.TouchDown);
+				platformView.AddTarget(OnTouchUpControlEvent, UIControlEvent.TouchUpInside | UIControlEvent.TouchUpOutside);
+			}
 
-		void OnTouchUpControlEvent(object? sender, EventArgs e)
-		{
-			VirtualView?.DragCompleted();
+			public void Disconnect(UISlider platformView)
+			{
+				platformView.ValueChanged -= OnControlValueChanged;
+				platformView.RemoveTarget(OnTouchDownControlEvent, UIControlEvent.TouchDown);
+				platformView.RemoveTarget(OnTouchUpControlEvent, UIControlEvent.TouchUpInside | UIControlEvent.TouchUpOutside);
+			}
+
+			void OnControlValueChanged(object? sender, EventArgs eventArgs)
+			{
+				if (VirtualView is ISlider virtualView && sender is UISlider platformView)
+					virtualView.Value = platformView.Value;
+			}
+
+			void OnTouchDownControlEvent(object? sender, EventArgs e)
+			{
+				VirtualView?.DragStarted();
+			}
+
+			void OnTouchUpControlEvent(object? sender, EventArgs e)
+			{
+				VirtualView?.DragCompleted();
+			}
 		}
 	}
 }


### PR DESCRIPTION
Context: https://github.com/dotnet/maui/issues/18365

Adding a parameter to the test:

    [Theory("Handler Does Not Leak")]
    [InlineData(typeof(Slider))]
    public async Task HandlerDoesNotLeak(Type type)

Shows a memory leak in `Slider`, caused by the cycle

* `SliderHandler` ->
* `UISlider` events ->
* `SliderHandler`

I could solve this problem by creating a `SliderProxy` class -- the same pattern I've used in other PRs to avoid cycles. This makes an intermediate type to handle the events and breaks the cycle.

Still thinking if the analyzer could have caught this, issue filed at:

https://github.com/jonathanpeppers/memory-analyzers/issues/12
