### PR TITLE
[ios] fix memory leak in `Switch`

### DIFF
--- a/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
+++ b/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
@@ -43,6 +43,7 @@ public class MemoryTests : ControlsHandlerTestBase
 				handlers.AddHandler<IScrollView, ScrollViewHandler>();
 				handlers.AddHandler<Stepper, StepperHandler>();
 				handlers.AddHandler<SwipeView, SwipeViewHandler>();
+				handlers.AddHandler<Switch, SwitchHandler>();
 				handlers.AddHandler<TimePicker, TimePickerHandler>();
 				handlers.AddHandler<WebView, WebViewHandler>();
 			});
@@ -71,6 +72,7 @@ public class MemoryTests : ControlsHandlerTestBase
 	[InlineData(typeof(ScrollView))]
 	[InlineData(typeof(Stepper))]
 	[InlineData(typeof(SwipeView))]
+	[InlineData(typeof(Switch))]
 	[InlineData(typeof(TimePicker))]
 	[InlineData(typeof(WebView))]
 	public async Task HandlerDoesNotLeak(Type type)


### PR DESCRIPTION
Context: https://github.com/dotnet/maui/issues/18365

Adding a parameter to the test:

    [Theory("Handler Does Not Leak")]
    [InlineData(typeof(Switch))]
    public async Task HandlerDoesNotLeak(Type type)

Shows a memory leak in `Switch`, caused by the cycle

* `SwitchHandler` ->
* `UISwitch.ValueChanged` event ->
* `SwitchHandler`

I could solve this problem by creating a `SwitchProxy` class -- the same pattern I've used in other PRs to avoid cycles. This makes an intermediate type to handle the events and breaks the cycle.

Still thinking if the analyzer could have caught this, issue filed at:

https://github.com/jonathanpeppers/memory-analyzers/issues/12
