### PR TITLE
[Android] Fix Flyout toolbar

### DIFF
--- a/src/Controls/src/Core/NavigationPage/NavigationPage.cs
+++ b/src/Controls/src/Core/NavigationPage/NavigationPage.cs
@@ -550,7 +550,7 @@ namespace Microsoft.Maui.Controls
 					}
 
 					var flyoutPage = _toolbar.FindParentOfType<FlyoutPage>();
-					if (flyoutPage != null && flyoutPage.Parent is IWindow)
+					if (flyoutPage != null && flyoutPage.Parent is IWindow && flyoutPage.Toolbar == _toolbar)
 					{
 						flyoutPage.Toolbar = null;
 					}

--- a/src/Controls/src/Core/Page/Page.cs
+++ b/src/Controls/src/Core/Page/Page.cs
@@ -788,11 +788,7 @@ namespace Microsoft.Maui.Controls
 		internal Toolbar Toolbar
 		{
 			get => _toolbar;
-			set
-			{
-				_toolbar = value;
-				Handler?.UpdateValue(nameof(IToolbarElement.Toolbar));
-			}
+			set => ToolbarElement.SetValue(ref _toolbar, value, Handler);
 		}
 
 		internal void SendNavigatedTo(NavigatedToEventArgs args)

--- a/src/Controls/src/Core/Toolbar/ToolbarElement.cs
+++ b/src/Controls/src/Core/Toolbar/ToolbarElement.cs
@@ -1,0 +1,15 @@
+﻿namespace Microsoft.Maui.Controls
+{
+	static class ToolbarElement
+	{
+		internal static void SetValue(ref Toolbar? toolbar, Toolbar? value, IElementHandler handler)
+		{
+			if (toolbar == value)
+				return;
+
+			toolbar?.Handler?.DisconnectHandler();
+			toolbar = value;
+			handler?.UpdateValue(nameof(IToolbarElement.Toolbar));
+		}
+	}
+}

--- a/src/Controls/src/Core/Window/Window.cs
+++ b/src/Controls/src/Core/Window/Window.cs
@@ -71,15 +71,7 @@ namespace Microsoft.Maui.Controls
 		internal Toolbar? Toolbar
 		{
 			get => _toolbar;
-			set
-			{
-				if (_toolbar == value)
-					return;
-
-				_toolbar?.Handler?.DisconnectHandler();
-				_toolbar = value;
-				Handler?.UpdateValue(nameof(IToolbarElement.Toolbar));
-			}
+			set => ToolbarElement.SetValue(ref _toolbar, value, Handler);
 		}
 
 		public event EventHandler? SizeChanged;

--- a/src/Controls/tests/DeviceTests/Elements/FlyoutPage/FlyoutPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/FlyoutPage/FlyoutPageTests.cs
@@ -235,11 +235,7 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
-		[Fact(DisplayName = "Back Button Enabled Changes with push/pop + page change"
-#if MACCATALYST
-			, Skip = "Fails on Mac Catalyst, fixme"
-#endif
-		)]
+		[Fact(DisplayName = "Back Button Enabled Changes with push/pop + page change")]
 		public async Task BackButtonEnabledChangesWithPushPopAndPageChanges()
 		{
 			SetupBuilder();

--- a/src/Controls/tests/DeviceTests/Elements/FlyoutPage/FlyoutPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/FlyoutPage/FlyoutPageTests.cs
@@ -260,12 +260,14 @@ namespace Microsoft.Maui.DeviceTests
 				Assert.False(IsBackButtonVisible(handler));
 
 				await first.PushAsync(new ContentPage());
+				await AssertionExtensions.Wait(() => IsBackButtonVisible(handler));
 				Assert.True(IsBackButtonVisible(handler));
 
 				flyoutPage.Detail = second;
 				Assert.False(IsBackButtonVisible(handler));
 
 				await second.PushAsync(new ContentPage());
+				await AssertionExtensions.Wait(() => IsBackButtonVisible(handler));
 				Assert.True(IsBackButtonVisible(handler));
 			});
 		}

--- a/src/Controls/tests/DeviceTests/Elements/FlyoutPage/FlyoutPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/FlyoutPage/FlyoutPageTests.cs
@@ -235,16 +235,20 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
-		[Fact(DisplayName = "Back Button Enabled Changes with push/pop + page change")]
+		[Fact(DisplayName = "Back Button Enabled Changes with push/pop + page change"
+#if MACCATALYST
+			, Skip = "Fails on Mac Catalyst, fixme"
+#endif
+		)]
 		public async Task BackButtonEnabledChangesWithPushPopAndPageChanges()
 		{
 			SetupBuilder();
 
-			var flyoutPage = new FlyoutPage
+			var flyoutPage = await InvokeOnMainThreadAsync(() => new FlyoutPage
 			{
 				FlyoutLayoutBehavior = FlyoutLayoutBehavior.Split,
 				Flyout = new ContentPage() { Title = "Hello world" }
-			};
+			});
 
 			var first = new NavigationPage(new ContentPage());
 			var second = new NavigationPage(new ContentPage());

--- a/src/Controls/tests/DeviceTests/Elements/FlyoutPage/FlyoutPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/FlyoutPage/FlyoutPageTests.cs
@@ -235,6 +235,37 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
+		[Fact(DisplayName = "Back Button Enabled Changes with push/pop + page change")]
+		public async Task BackButtonEnabledChangesWithPushPopAndPageChanges()
+		{
+			SetupBuilder();
+
+			var flyoutPage = new FlyoutPage
+			{
+				FlyoutLayoutBehavior = FlyoutLayoutBehavior.Split,
+				Flyout = new ContentPage() { Title = "Hello world" }
+			};
+
+			var first = new NavigationPage(new ContentPage());
+			var second = new NavigationPage(new ContentPage());
+			
+			flyoutPage.Detail = first;
+
+			await CreateHandlerAndAddToWindow<FlyoutViewHandler>(flyoutPage, async (handler) =>
+			{
+				Assert.False(IsBackButtonVisible(handler));
+
+				await first.PushAsync(new ContentPage());
+				Assert.True(IsBackButtonVisible(handler));
+
+				flyoutPage.Detail = second;
+				Assert.False(IsBackButtonVisible(handler));
+
+				await second.PushAsync(new ContentPage());
+				Assert.True(IsBackButtonVisible(handler));
+			});
+		}
+
 		bool CanDeviceDoSplitMode(FlyoutPage page)
 		{
 			return ((IFlyoutPageController)page).ShouldShowSplitMode;

--- a/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.Windows.cs
@@ -38,37 +38,6 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
-		[Fact(DisplayName = "Back Button Enabled Changes with push/pop + page change")]
-		public async Task BackButtonEnabledChangesWithPushPopAndPageChanges()
-		{
-			SetupBuilder();
-
-			var flyoutPage = new FlyoutPage();
-			flyoutPage.Title = "Hello world";
-			flyoutPage.FlyoutLayoutBehavior = FlyoutLayoutBehavior.Split;
-			flyoutPage.Flyout = new ContentPage() { Title = "Hello world" };
-
-			var first = new NavigationPage(new ContentPage());
-			var second = new NavigationPage(new ContentPage());
-
-			flyoutPage.Detail = first;
-
-			await CreateHandlerAndAddToWindow<FlyoutViewHandler>(flyoutPage, async (handler) =>
-			{
-				var navView = (RootNavigationView)GetMauiNavigationView(handler.MauiContext);
-				Assert.False(navView.IsBackEnabled);
-
-				await first.PushAsync(new ContentPage());
-				Assert.True(navView.IsBackEnabled);
-
-				flyoutPage.Detail = second;
-				Assert.False(navView.IsBackEnabled);
-
-				await second.PushAsync(new ContentPage());
-				Assert.True(navView.IsBackEnabled);
-			});
-		}
-
 		[Fact(DisplayName = "App Title Bar Margin Sets when Back Button Visible")]
 		public async Task AppTitleBarMarginSetsWhenBackButtonVisible()
 		{

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
@@ -792,6 +792,7 @@ namespace Microsoft.Maui.DeviceTests
 				};
 
 				Shell.SetBackButtonBehavior(secondPage, behavior);
+				await AssertionExtensions.Wait(() => !IsBackButtonVisible(shell.Handler));
 				Assert.False(IsBackButtonVisible(shell.Handler));
 				behavior.IsVisible = true;
 				NavigationPage.SetHasBackButton(shell.CurrentPage, true);

--- a/src/TestUtils/src/DeviceTests/AssertionExtensions.iOS.cs
+++ b/src/TestUtils/src/DeviceTests/AssertionExtensions.iOS.cs
@@ -703,7 +703,7 @@ namespace Microsoft.Maui.DeviceTests
 
 		public static bool HasBackButton(this UINavigationBar uINavigationBar)
 		{
-			return uINavigationBar.BackItem is not null;
+			return uINavigationBar.BackItem is not null && uINavigationBar.Items.Last().LeftBarButtonItem is null;
 		}
 
 		public static UIView GetBackButton(this UINavigationBar uINavigationBar)

--- a/src/TestUtils/src/DeviceTests/AssertionExtensions.iOS.cs
+++ b/src/TestUtils/src/DeviceTests/AssertionExtensions.iOS.cs
@@ -703,7 +703,13 @@ namespace Microsoft.Maui.DeviceTests
 
 		public static bool HasBackButton(this UINavigationBar uINavigationBar)
 		{
-			return uINavigationBar.BackItem is not null && uINavigationBar.Items.Last().LeftBarButtonItem is null;
+			var currentNavItem = uINavigationBar.Items.LastOrDefault();
+			
+			return 
+				uINavigationBar.BackItem is not null &&				
+				currentNavItem is not null &&
+				currentNavItem.LeftBarButtonItem is null &&
+				!currentNavItem.HidesBackButton;
 		}
 
 		public static UIView GetBackButton(this UINavigationBar uINavigationBar)

--- a/src/TestUtils/src/DeviceTests/AssertionExtensions.iOS.cs
+++ b/src/TestUtils/src/DeviceTests/AssertionExtensions.iOS.cs
@@ -703,12 +703,7 @@ namespace Microsoft.Maui.DeviceTests
 
 		public static bool HasBackButton(this UINavigationBar uINavigationBar)
 		{
-			var item = uINavigationBar.FindDescendantView<UIView>(result =>
-			{
-				return result.Class.Name?.Contains("UIButtonBarButton", StringComparison.OrdinalIgnoreCase) == true;
-			});
-
-			return item is not null;
+			return uINavigationBar.BackItem is not null;
 		}
 
 		public static UIView GetBackButton(this UINavigationBar uINavigationBar)


### PR DESCRIPTION
### Description of Change

This fix complements https://github.com/dotnet/maui/commit/fb82b8353865a75d0f60e0f94fc58d6d5d595970 to fix toolbar issues when swapping Detail pages. That commit was necessary, but on Android we also need to make sure the `Toolbar.Handler` is disconnected, otherwise the old toolbar is never removed and we start stacking them.

This was already happening for `Window`  but not for `Page` . This code is now shared between both to avoid this problem where only one place is changed.

<!-- Enter description of the fix in this section -->

### Issues Fixed
Fixes https://github.com/dotnet/maui/issues/18050
<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->


<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
