### PR TITLE
[ios] fix memory leak in `TableView`

### DIFF
--- a/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
+++ b/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
@@ -46,6 +46,7 @@ public class MemoryTests : ControlsHandlerTestBase
 				handlers.AddHandler<Stepper, StepperHandler>();
 				handlers.AddHandler<SwipeView, SwipeViewHandler>();
 				handlers.AddHandler<Switch, SwitchHandler>();
+				handlers.AddHandler<TableView, TableViewRenderer>();
 				handlers.AddHandler<TimePicker, TimePickerHandler>();
 				handlers.AddHandler<WebView, WebViewHandler>();
 			});
@@ -78,6 +79,7 @@ public class MemoryTests : ControlsHandlerTestBase
 	[InlineData(typeof(SwipeView))]
 	[InlineData(typeof(Switch))]
 	[InlineData(typeof(TimePicker))]
+	[InlineData(typeof(TableView))]
 	[InlineData(typeof(WebView))]
 	public async Task HandlerDoesNotLeak(Type type)
 	{


### PR DESCRIPTION
Context: https://github.com/dotnet/maui/issues/18365

I could reproduce a leak in `TableView` by adding a parameterized test:

    [InlineData(typeof(TableView))]
    public async Task HandlerDoesNotLeak(Type type)

`TableViewModelRenderer` has two cycles:

* `TableView` ->
* `TableViewRenderer` ->
* `TableViewModelRenderer` ->
* `TableView` via `View` field

Second:

* `UITableView.Source` ->
* `TableViewModelRenderer` ->
* `UITableView` via `Table` field

I left the `Table` and `View` fields in place to not break any public APIs. They are now unused and marked `[Obsolete]`. I used `WeakReference<T>` to solve these two cycles and the test now passes.

The analyzer warned about these locations, but we don't have the analyzer enabled on `Microsoft.Maui.Controls` yet:

https://github.com/dotnet/maui/pull/18318#issuecomment-1779316240