### PR TITLE
Remove invalid files from MauiImage

### DIFF
--- a/src/SingleProject/Resizetizer/src/nuget/buildTransitive/Microsoft.Maui.Resizetizer.After.targets
+++ b/src/SingleProject/Resizetizer/src/nuget/buildTransitive/Microsoft.Maui.Resizetizer.After.targets
@@ -609,8 +609,12 @@
         BeforeTargets="$(ResizetizeBeforeTargets)"
         DependsOnTargets="$(ResizetizeDependsOnTargets)">
 
+        <ItemGroup>
+            <_MauiImageToProcess Include="@(MauiImage)" Exclude="$(DefaultItemExcludes)" />
+        </ItemGroup>
+
         <DetectInvalidResourceOutputFilenamesTask
-            Items="@(MauiImage)"
+            Items="@(_MauiImageToProcess)"
             ThrowsError="$(_ResizetizerThrowsErrorOnInvalidFilename)"
             ErrorMessage="$(_ResizetizerDefaultInvalidFilenamesErrorMessage)">
         </DetectInvalidResourceOutputFilenamesTask>
@@ -622,7 +626,7 @@
             PlatformType="$(ResizetizerPlatformType)"
             IntermediateOutputPath="$(_MauiIntermediateImages)"
             InputsFile="$(_ResizetizerInputsFile)"
-            Images="@(MauiImage)">
+            Images="@(_MauiImageToProcess)">
               <Output TaskParameter="CopiedResources" ItemName="_CopiedResources" />
         </ResizetizeImages>
 

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/TemplateTests.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/TemplateTests.cs
@@ -267,6 +267,22 @@ namespace Microsoft.Maui.IntegrationTests
 			CollectionAssert.AreEqual(expectedEntitlements, foundEntitlements, "Entitlements missing from executable.");
 		}
 
+		[Test]
+		public void BuildHandlesBadFilesInImages()
+		{
+			var projectDir = TestDirectory;
+			var projectFile = Path.Combine(projectDir, $"{Path.GetFileName(projectDir)}.csproj");
+
+			Assert.IsTrue(DotnetInternal.New("maui", projectDir, DotNetCurrent),
+				$"Unable to create template maui. Check test output for errors.");
+
+			EnableTizen(projectFile);
+			File.WriteAllText(Path.Combine(projectDir, "Resources", "Images", ".DS_Store"), "Boom!");
+
+			Assert.IsTrue(DotnetInternal.Build(projectFile, "Debug", properties: BuildProps, msbuildWarningsAsErrors: true),
+				$"Project {Path.GetFileName(projectFile)} failed to build. Check test output/attachments for errors.");
+		}
+
 		void EnableTizen(string projectFile)
 		{
 			FileUtilities.ReplaceInFile(projectFile, new Dictionary<string, string>()


### PR DESCRIPTION
### Description of Change

Most of the other assets don't care about this file as it is just a file. However, images are special on some platforms - Android - and need to be very specific. 

This PR just makes sure there are no known invalid files before generating images.

- Fixes #14279