### PR TITLE
Add/Remove CarouselView Layout Listener when view is add/removed from window

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/Android/MauiCarouselRecyclerView.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/MauiCarouselRecyclerView.cs
@@ -90,6 +90,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		{
 			base.SetUpNewElement(newElement);
 
+			AddLayoutListener();
 			UpdateItemSpacing();
 			UpdateInitialPosition();
 		}
@@ -103,6 +104,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			if (ItemsView != null)
 				ItemsView.Scrolled -= CarouselViewScrolled;
 
+			ClearLayoutListener();
 			base.TearDownOldElement(oldElement);
 		}
 
@@ -523,7 +525,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		void AddLayoutListener()
 		{
-			if (_carouselViewLayoutListener != null)
+			if (_carouselViewLayoutListener is not null)
 				return;
 
 			_carouselViewLayoutListener = new CarouselViewOnGlobalLayoutListener(this);

--- a/src/Controls/src/Core/Handlers/Items/Android/MauiCarouselRecyclerView.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/MauiCarouselRecyclerView.cs
@@ -603,7 +603,8 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 			public void OnGlobalLayout()
 			{
-				if (_recyclerView.TryGetTarget(out var recyclerView))
+				if (_recyclerView.TryGetTarget(out var recyclerView) &&
+					recyclerView.IsAlive())
 				{
 					recyclerView.LayoutReady();
 				}

--- a/src/Controls/src/Core/Handlers/Items/Android/MauiCarouselRecyclerView.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/MauiCarouselRecyclerView.cs
@@ -532,6 +532,9 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		void LayoutReady()
 		{
+			if (ItemsView is null)
+				return;
+
 			if (!_initialized)
 			{
 				ItemsView.Scrolled += CarouselViewScrolled;

--- a/src/Controls/src/Core/Handlers/Items/Android/MauiCarouselRecyclerView.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/MauiCarouselRecyclerView.cs
@@ -90,7 +90,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		{
 			base.SetUpNewElement(newElement);
 
-			AddLayoutListener();
 			UpdateItemSpacing();
 			UpdateInitialPosition();
 		}
@@ -104,8 +103,19 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			if (ItemsView != null)
 				ItemsView.Scrolled -= CarouselViewScrolled;
 
-			ClearLayoutListener();
 			base.TearDownOldElement(oldElement);
+		}
+
+		protected override void OnAttachedToWindow()
+		{
+			base.OnAttachedToWindow();
+			AddLayoutListener();
+		}
+
+		protected override void OnDetachedFromWindow()
+		{
+			base.OnDetachedFromWindow();
+			ClearLayoutListener();
 		}
 
 		public override void UpdateAdapter()

--- a/src/Controls/src/Core/Handlers/Items/Android/MauiCarouselRecyclerView.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/MauiCarouselRecyclerView.cs
@@ -110,14 +110,14 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		protected override void OnAttachedToWindow()
 		{
-			base.OnAttachedToWindow();
 			AddLayoutListener();
+			base.OnAttachedToWindow();
 		}
 
 		protected override void OnDetachedFromWindow()
 		{
-			base.OnDetachedFromWindow();
 			ClearLayoutListener();
+			base.OnDetachedFromWindow();
 		}
 
 		public override void UpdateAdapter()

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -63,6 +63,8 @@ Microsoft.Maui.Controls.PointerGestureRecognizer.PointerReleasedCommand.get -> S
 Microsoft.Maui.Controls.PointerGestureRecognizer.PointerReleasedCommand.set -> void
 Microsoft.Maui.Controls.PointerGestureRecognizer.PointerReleasedCommandParameter.get -> object!
 Microsoft.Maui.Controls.PointerGestureRecognizer.PointerReleasedCommandParameter.set -> void
+override Microsoft.Maui.Controls.Handlers.Items.MauiCarouselRecyclerView.OnAttachedToWindow() -> void
+override Microsoft.Maui.Controls.Handlers.Items.MauiCarouselRecyclerView.OnDetachedFromWindow() -> void
 static readonly Microsoft.Maui.Controls.KeyboardAccelerator.KeyProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.KeyboardAccelerator.ModifiersProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.DragGestureRecognizer.CanDragProperty -> Microsoft.Maui.Controls.BindableProperty!
@@ -197,7 +199,6 @@ Microsoft.Maui.Controls.PlatformPointerEventArgs.Sender.get -> Android.Views.Vie
 ~static readonly Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTappedProperty -> Microsoft.Maui.Controls.BindableProperty
 Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTapped.get -> bool
 Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTapped.set -> void
-
 *REMOVED*~Microsoft.Maui.Controls.Editor.FontFamily.get -> string
 *REMOVED*~Microsoft.Maui.Controls.Editor.FontFamily.set -> void
 *REMOVED*Microsoft.Maui.Controls.Editor.CursorPosition.get -> int
@@ -210,7 +211,6 @@ Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTapped.set -> void
 *REMOVED*Microsoft.Maui.Controls.Editor.FontSize.set -> void
 *REMOVED*Microsoft.Maui.Controls.Editor.SelectionLength.get -> int
 *REMOVED*Microsoft.Maui.Controls.Editor.SelectionLength.set -> void
-
 *REMOVED*~Microsoft.Maui.Controls.SearchBar.FontFamily.get -> string
 *REMOVED*~Microsoft.Maui.Controls.SearchBar.FontFamily.set -> void
 *REMOVED*Microsoft.Maui.Controls.SearchBar.CursorPosition.get -> int
@@ -223,7 +223,6 @@ Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTapped.set -> void
 *REMOVED*Microsoft.Maui.Controls.SearchBar.FontSize.set -> void
 *REMOVED*Microsoft.Maui.Controls.SearchBar.SelectionLength.get -> int
 *REMOVED*Microsoft.Maui.Controls.SearchBar.SelectionLength.set -> void
-
 *REMOVED*~Microsoft.Maui.Controls.Entry.FontFamily.get -> string
 *REMOVED*~Microsoft.Maui.Controls.Entry.FontFamily.set -> void
 *REMOVED*Microsoft.Maui.Controls.Entry.CursorPosition.get -> int


### PR DESCRIPTION
### Description of Change

https://github.com/dotnet/maui/pull/18584 modified the `CarouselViewOnGlobalLayoutListener` so that it only retains a weak reference to the recycler view. Because this layout listener no longer participates in keeping the `CarouselView` from being collected there's a chance that it could still get triggered from android.

We also need to tie the lifetime of the `CarouselViewOnGlobalLayoutListener` to something otherwise it will continue to fire even beyond the lifetime of the `CarouselView.` Because `GlobalLayoutListeners` are added to the `ViewTreeObserver` they are essentially being added to a resilient static container. This PR makes it so the `GlobalLayoutListener` is only added when the `CarouselView` is part of the Visual Tree. 


### Issues Fixed


Fixes #18733

