### PR TITLE
[iOS] Set text color of unselected TabbedPage tabs

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/TabbedPage/iOS/TabbedRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/TabbedPage/iOS/TabbedRenderer.cs
@@ -211,6 +211,11 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 				SelectedViewController = controller;
 			}
+			else if (e.PropertyName == TabbedPage.UnselectedTabColorProperty.PropertyName)
+			{
+				UpdateBarTextColor();
+				UpdateSelectedTabColors();
+			}
 			else if (e.PropertyName == TabbedPage.BarBackgroundColorProperty.PropertyName)
 				UpdateBarBackgroundColor();
 			else if (e.PropertyName == TabbedPage.BarBackgroundProperty.PropertyName)
@@ -221,7 +226,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				UpdatePrefersStatusBarHiddenOnPages();
 			else if (e.PropertyName == PreferredStatusBarUpdateAnimationProperty.PropertyName)
 				UpdateCurrentPagePreferredStatusBarUpdateAnimation();
-			else if (e.PropertyName == TabbedPage.SelectedTabColorProperty.PropertyName || e.PropertyName == TabbedPage.UnselectedTabColorProperty.PropertyName)
+			else if (e.PropertyName == TabbedPage.SelectedTabColorProperty.PropertyName)
 				UpdateSelectedTabColors();
 			else if (e.PropertyName == PrefersHomeIndicatorAutoHiddenProperty.PropertyName)
 				UpdatePrefersHomeIndicatorAutoHiddenOnPages();
@@ -376,11 +381,13 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			else
 				tabBarTextColor = barTextColor.ToPlatform();
 
+			UIColor unselectedTabBarTextColor = Tabbed.UnselectedTabColor?.ToPlatform() ?? tabBarTextColor;
+
 			foreach (UITabBarItem item in TabBar.Items)
 			{
-				item.SetTitleTextAttributes(new UIStringAttributes() { ForegroundColor = tabBarTextColor }, UIControlState.Normal);
+				item.SetTitleTextAttributes(new UIStringAttributes() { ForegroundColor = unselectedTabBarTextColor }, UIControlState.Normal);
 				item.SetTitleTextAttributes(new UIStringAttributes() { ForegroundColor = tabBarTextColor }, UIControlState.Selected);
-				item.SetTitleTextAttributes(new UIStringAttributes() { ForegroundColor = tabBarTextColor }, UIControlState.Disabled);
+				item.SetTitleTextAttributes(new UIStringAttributes() { ForegroundColor = unselectedTabBarTextColor }, UIControlState.Disabled);
 			}
 
 			// set TintColor for selected icon
@@ -509,7 +516,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				Tabbed.IsSet(TabbedPage.UnselectedTabColorProperty) ? Tabbed.UnselectedTabColor : null,
 				Tabbed.IsSet(TabbedPage.BarBackgroundColorProperty) ? Tabbed.BarBackgroundColor : null,
 				Tabbed.IsSet(TabbedPage.BarTextColorProperty) ? Tabbed.BarTextColor : null,
-				null);
+				Tabbed.IsSet(TabbedPage.UnselectedTabColorProperty) ? Tabbed.UnselectedTabColor : Tabbed.IsSet(TabbedPage.BarTextColorProperty) ? Tabbed.BarTextColor : null);
 		}
 
 		#region IPlatformViewHandler

--- a/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.cs
@@ -86,6 +86,11 @@ namespace Microsoft.Maui.DeviceTests
 				new ContentPage() { Title = "Page 1" },
 				new ContentPage() { Title = "Page 2" }
 			});
+#if IOS || MACCATALYST
+			var shouldMatchUnselectedColor = true;
+#else
+			var shouldMatchUnselectedColor = false;
+#endif
 
 			tabbedPage.BarTextColor = Colors.Red;
 			await CreateHandlerAndAddToWindow<TabbedViewHandler>(tabbedPage, async handler =>
@@ -98,12 +103,13 @@ namespace Microsoft.Maui.DeviceTests
 				await ValidateTabBarTextColor(tabbedPage, tabbedPage.Children[1].Title, Colors.Blue, true);
 
 				tabbedPage.UnselectedTabColor = Colors.Lime;
+				var expectedUnselectedColor = shouldMatchUnselectedColor ? Colors.Lime : Colors.Blue;
 				await ValidateTabBarTextColor(tabbedPage, tabbedPage.Children[0].Title, Colors.Blue, true);
-				await ValidateTabBarTextColor(tabbedPage, tabbedPage.Children[1].Title, Colors.Lime, true);
+				await ValidateTabBarTextColor(tabbedPage, tabbedPage.Children[1].Title, expectedUnselectedColor, true);
 
 				tabbedPage.CurrentPage = tabbedPage.Children[1];
 				await OnNavigatedToAsync(tabbedPage.CurrentPage);
-				await ValidateTabBarTextColor(tabbedPage, tabbedPage.Children[0].Title, Colors.Lime, true);
+				await ValidateTabBarTextColor(tabbedPage, tabbedPage.Children[0].Title, expectedUnselectedColor, true);
 				await ValidateTabBarTextColor(tabbedPage, tabbedPage.Children[1].Title, Colors.Blue, true);
 			});
 		}

--- a/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.cs
@@ -90,20 +90,21 @@ namespace Microsoft.Maui.DeviceTests
 			tabbedPage.BarTextColor = Colors.Red;
 			await CreateHandlerAndAddToWindow<TabbedViewHandler>(tabbedPage, async handler =>
 			{
-				// Pre iOS15 you couldn't set the text color of the unselected tab
-				// so only android/windows currently set the color of both
-
-#if IOS
-				bool unselectedMatchesSelected = false;
-#else
-				bool unselectedMatchesSelected = true;
-#endif
-
 				await ValidateTabBarTextColor(tabbedPage, tabbedPage.Children[0].Title, Colors.Red, true);
-				await ValidateTabBarTextColor(tabbedPage, tabbedPage.Children[1].Title, Colors.Red, unselectedMatchesSelected);
+				await ValidateTabBarTextColor(tabbedPage, tabbedPage.Children[1].Title, Colors.Red, true);
+
 				tabbedPage.BarTextColor = Colors.Blue;
 				await ValidateTabBarTextColor(tabbedPage, tabbedPage.Children[0].Title, Colors.Blue, true);
-				await ValidateTabBarTextColor(tabbedPage, tabbedPage.Children[1].Title, Colors.Blue, unselectedMatchesSelected);
+				await ValidateTabBarTextColor(tabbedPage, tabbedPage.Children[1].Title, Colors.Blue, true);
+
+				tabbedPage.UnselectedTabColor = Colors.Lime;
+				await ValidateTabBarTextColor(tabbedPage, tabbedPage.Children[0].Title, Colors.Blue, true);
+				await ValidateTabBarTextColor(tabbedPage, tabbedPage.Children[1].Title, Colors.Lime, true);
+
+				tabbedPage.CurrentPage = tabbedPage.Children[1];
+				await OnNavigatedToAsync(tabbedPage.CurrentPage);
+				await ValidateTabBarTextColor(tabbedPage, tabbedPage.Children[0].Title, Colors.Lime, true);
+				await ValidateTabBarTextColor(tabbedPage, tabbedPage.Children[1].Title, Colors.Blue, true);
 			});
 		}
 
@@ -123,15 +124,8 @@ namespace Microsoft.Maui.DeviceTests
 
 			await CreateHandlerAndAddToWindow<TabbedViewHandler>(tabbedPage, async handler =>
 			{
-				// Pre iOS15 you couldn't set the text color of the unselected tab
-				// so only android/windows currently set the color of both
-#if IOS
-				bool unselectedMatchesTabColor = false;
-#else
-				bool unselectedMatchesTabColor = true;
-#endif
 				await ValidateTabBarTextColor(tabbedPage, tabbedPage.Children[0].Title, Colors.Red, true);
-				await ValidateTabBarTextColor(tabbedPage, tabbedPage.Children[1].Title, Colors.Purple, unselectedMatchesTabColor);
+				await ValidateTabBarTextColor(tabbedPage, tabbedPage.Children[1].Title, Colors.Purple, true);
 				await ValidateTabBarIconColor(tabbedPage, tabbedPage.Children[0].Title, Colors.Red, true);
 				await ValidateTabBarIconColor(tabbedPage, tabbedPage.Children[1].Title, Colors.Purple, true);
 
@@ -139,7 +133,7 @@ namespace Microsoft.Maui.DeviceTests
 				await OnNavigatedToAsync(tabbedPage.CurrentPage);
 
 				await ValidateTabBarTextColor(tabbedPage, tabbedPage.Children[0].Title, Colors.Purple, true);
-				await ValidateTabBarTextColor(tabbedPage, tabbedPage.Children[1].Title, Colors.Red, unselectedMatchesTabColor);
+				await ValidateTabBarTextColor(tabbedPage, tabbedPage.Children[1].Title, Colors.Red, true);
 				await ValidateTabBarIconColor(tabbedPage, tabbedPage.Children[0].Title, Colors.Purple, true);
 				await ValidateTabBarIconColor(tabbedPage, tabbedPage.Children[1].Title, Colors.Red, true);
 			});


### PR DESCRIPTION
### Description of Change

Currently, the text color of unselected tabs is set to a internal default value and cannot be controlled. This is a regression from the .NET7 versions of MAUI, where it matched the icon color of the tab. This change updates the iOS-specific code for TabbedPage so that the text color is set to `UnselectedTabColor`.

### Issues Fixed

https://github.com/dotnet/maui/issues/18775

