### PR TITLE
[Windows] Address CollectionView virtualization

### DIFF
--- a/src/Controls/src/Core/Platform/Windows/CollectionView/ItemContentControl.cs
+++ b/src/Controls/src/Core/Platform/Windows/CollectionView/ItemContentControl.cs
@@ -284,6 +284,10 @@ namespace Microsoft.Maui.Controls.Platform
 		{
 			if (_renderer == null)
 			{
+				// Make sure we supply a real number for height otherwise virtualization won't function
+				if (double.IsFinite(availableSize.Width) && !double.IsFinite(availableSize.Height))
+					return new WSize(availableSize.Width, 32);
+
 				return base.MeasureOverride(availableSize);
 			}
 

--- a/src/Controls/src/Core/Platform/Windows/CollectionView/ItemContentControl.cs
+++ b/src/Controls/src/Core/Platform/Windows/CollectionView/ItemContentControl.cs
@@ -284,9 +284,11 @@ namespace Microsoft.Maui.Controls.Platform
 		{
 			if (_renderer == null)
 			{
-				// Make sure we supply a real number for height otherwise virtualization won't function
+				// Make sure we supply a real number for sizes otherwise virtualization won't function
 				if (double.IsFinite(availableSize.Width) && !double.IsFinite(availableSize.Height))
 					return new WSize(availableSize.Width, 32);
+				else if (!double.IsFinite(availableSize.Width) && double.IsFinite(availableSize.Height))
+					return new WSize(88, availableSize.Height);
 
 				return base.MeasureOverride(availableSize);
 			}


### PR DESCRIPTION
### Description of Change

This PR some-what addresses virtualization being broken in `CollectionView` due to a lack of `MinHeight` on the items, the initial `MeasureOverride` call returning an infinite height, and creating the ListView items at the DataBinding-time. 

You can see the behavior in an isolated WinUI context here: https://github.com/Foda/ListViewVirtualization/tree/master

The fix for this issue is to just return a real-number value (32) when the initial call to `MeasureOverride` is done. It's not perfect, but very large lists will benefit from it.

Note: this behavior was regressed due to https://github.com/dotnet/maui/pull/18356

### Issues Fixed

Fixes #18639 #18510