### PR TITLE
Remove width on example items so we can actually see them

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/ExampleTemplates.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/ExampleTemplates.cs
@@ -278,7 +278,6 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries
 				{
 					BackgroundColor = Colors.Bisque,
 					RowDefinitions = new RowDefinitionCollection { new RowDefinition { Height = GridLength.Auto } },
-					WidthRequest = 100,
 					HeightRequest = 140
 				};
 


### PR DESCRIPTION
### Description of Change

For some reason the template for the propagation examples on CollectionView was set to a width of 100, which means you can't actually see most of the content. This just removes the width so the content is visible.

