### PR TITLE
iOS/Mac Catalyst 17+ Support for new Calendar Permissions

### DIFF
--- a/src/Essentials/samples/Samples/Platforms/MacCatalyst/Info.plist
+++ b/src/Essentials/samples/Samples/Platforms/MacCatalyst/Info.plist
@@ -58,5 +58,11 @@
 	<array>
 		<string>mailto</string>
 	</array>
+	<key>NSCalendarsFullAccessUsageDescription</key>
+	<string>Full access to the Calendar is needed to sign you up for parties!</string>
+	<key>NSCalendarsWriteOnlyAccessUsageDescription</key>
+	<string>Just writing events to the Calendar, nothing to see here.</string>
+	<key>NSRemindersFullAccessUsageDescription</key>
+	<string>Just so you will remember</string>
 </dict>
 </plist>

--- a/src/Essentials/samples/Samples/Platforms/iOS/Info.plist
+++ b/src/Essentials/samples/Samples/Platforms/iOS/Info.plist
@@ -45,7 +45,7 @@
 	<key>NSLocationAlwaysUsageDescription</key>
 	<string>Get Location</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>
-  <string>Add Photos</string>
+  	<string>Add Photos</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Pick Photos</string>
 	<key>NSMicrophoneUsageDescription</key>
@@ -58,5 +58,11 @@
 	<array>
 		<string>mailto</string>
 	</array>
+	<key>NSCalendarsFullAccessUsageDescription</key>
+	<string>Full access to the Calendar is needed to sign you up for parties!</string>
+	<key>NSCalendarsWriteOnlyAccessUsageDescription</key>
+	<string>Just writing events to the Calendar, nothing to see here.</string>
+	<key>NSRemindersFullAccessUsageDescription</key>
+	<string>Just so you will remember</string>
 </dict>
 </plist>

--- a/src/Essentials/src/Permissions/Permissions.ios.watchos.cs
+++ b/src/Essentials/src/Permissions/Permissions.ios.watchos.cs
@@ -49,8 +49,20 @@ namespace Microsoft.Maui.ApplicationModel
 		public partial class CalendarRead : BasePlatformPermission
 		{
 			/// <inheritdoc/>
-			protected override Func<IEnumerable<string>> RequiredInfoPlistKeys =>
-				() => new string[] { "NSCalendarsUsageDescription" };
+			protected override Func<IEnumerable<string>> RequiredInfoPlistKeys
+			{
+				get
+				{
+					if (OperatingSystem.IsIOSVersionAtLeast(17) || OperatingSystem.IsMacCatalystVersionAtLeast(17))
+					{
+						return () => new string[] { "NSCalendarsFullAccessUsageDescription" };
+					}
+					else
+					{
+						return () => new string[] { "NSCalendarsUsageDescription" };
+					}
+				}
+			}
 
 			/// <inheritdoc/>
 			public override Task<PermissionStatus> CheckStatusAsync()
@@ -76,8 +88,20 @@ namespace Microsoft.Maui.ApplicationModel
 		public partial class CalendarWrite : BasePlatformPermission
 		{
 			/// <inheritdoc/>
-			protected override Func<IEnumerable<string>> RequiredInfoPlistKeys =>
-				() => new string[] { "NSCalendarsUsageDescription" };
+			protected override Func<IEnumerable<string>> RequiredInfoPlistKeys
+			{
+				get
+				{
+					if (OperatingSystem.IsIOSVersionAtLeast(17) || OperatingSystem.IsMacCatalystVersionAtLeast(17))
+					{
+						return () => new string[] { "NSCalendarsWriteOnlyAccessUsageDescription" };
+					}
+					else
+					{
+						return () => new string[] { "NSCalendarsUsageDescription" };
+					}
+				}
+			}
 
 			/// <inheritdoc/>
 			public override Task<PermissionStatus> CheckStatusAsync()
@@ -103,8 +127,20 @@ namespace Microsoft.Maui.ApplicationModel
 		public partial class Reminders : BasePlatformPermission
 		{
 			/// <inheritdoc/>
-			protected override Func<IEnumerable<string>> RequiredInfoPlistKeys =>
-				() => new string[] { "NSRemindersUsageDescription" };
+			protected override Func<IEnumerable<string>> RequiredInfoPlistKeys
+			{
+				get
+				{
+					if (OperatingSystem.IsIOSVersionAtLeast(17) || OperatingSystem.IsMacCatalystVersionAtLeast(17))
+					{
+						return () => new string[] { "NSRemindersFullAccessUsageDescription" };
+					}
+					else
+					{
+						return () => new string[] { "NSRemindersUsageDescription" };
+					}
+				}
+			}
 
 			/// <inheritdoc/>
 			public override Task<PermissionStatus> CheckStatusAsync()


### PR DESCRIPTION
### Description of Change

Part of the work to support the [new EventKit APIs](https://developer.apple.com/documentation/technotes/tn3153-adopting-api-changes-for-eventkit-in-ios-macos-and-watchos/) on iOS 17+ was already done, but it was not checking the correct plist entries yet. That is what this change adds.

> [!NOTE]
> To use the new EventKit APIs in your iOS or macOS app, make sure to add the new `[NSCalendarsWriteOnlyAccessUsageDescription` and/or `NSCalendarsFullAccessUsageDescription` according to your needs, else you might get unexpected results.

### Issues Fixed

Fixes #18737