### PR TITLE
Fix "Test attachment file path could not be found"

### DIFF
--- a/src/TestUtils/src/UITest.NUnit/UITestBase.cs
+++ b/src/TestUtils/src/UITest.NUnit/UITestBase.cs
@@ -118,13 +118,35 @@ namespace UITest.Appium.NUnit
 			{
 				string name = TestContext.CurrentContext.Test.MethodName ?? TestContext.CurrentContext.Test.Name;
 
-				var screenshotPath = Path.Combine(logDir, $"{name}-{_testDevice}{note}ScreenShot.png");
+				var screenshotPath = Path.Combine(logDir, $"{name}-{_testDevice}{note}ScreenShot");
 				_ = App.Screenshot(screenshotPath);
-				TestContext.AddTestAttachment(screenshotPath, Path.GetFileName(screenshotPath));
+				// App.Screenshot appends a ".png" extension always, so include that here
+				var screenshotPathWithExtension = screenshotPath + ".png";
+				AddTestAttachment(screenshotPathWithExtension, Path.GetFileName(screenshotPathWithExtension));
 
 				var pageSourcePath = Path.Combine(logDir, $"{name}-{_testDevice}{note}PageSource.txt");
 				File.WriteAllText(pageSourcePath, App.ElementTree);
-				TestContext.AddTestAttachment(pageSourcePath, Path.GetFileName(pageSourcePath));
+				AddTestAttachment(pageSourcePath, Path.GetFileName(pageSourcePath));
+			}
+		}
+
+		void AddTestAttachment(string filePath, string? description = null)
+		{
+			try
+			{
+				TestContext.AddTestAttachment(filePath, description);
+			}
+			catch (FileNotFoundException e)
+			{
+				// Add the file path to better troubleshoot when these errors occur
+				if (e.Message == "Test attachment file path could not be found.")
+				{
+					throw new FileNotFoundException($"{e.Message}: {filePath}");
+				}
+				else
+				{
+					throw;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Properly account for App.Screenshot appending a ".png" extension (always) to the passed in file path, fixing so that the attachment isn't added twice.

This fixes the "Test attachment file path could not be found" error that could show for UITest when they fail and SaveDiagnosticLogs tries to attach screenshots (caused because the actually file had a ".png.png" extension, so the file with just a ".png" extension wasn't found).