### PR TITLE
Fix Modal OnNavigatedTo

### DIFF
--- a/src/Controls/src/Core/Shell/ShellSection.cs
+++ b/src/Controls/src/Core/Shell/ShellSection.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Maui.Controls
 					if (Navigation.ModalStack[Navigation.ModalStack.Count - 1] is NavigationPage np)
 						return np.Navigation.NavigationStack[np.Navigation.NavigationStack.Count - 1];
 
-					return Navigation.ModalStack[0];
+					return Navigation.ModalStack[Navigation.ModalStack.Count - 1];
 				}
 
 				if (_navStack.Count > 1)

--- a/src/Controls/tests/Core.UnitTests/ShellModalTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellModalTests.cs
@@ -120,6 +120,17 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact]
+		public async Task ShellCurrentPageReturnsLastPageInModalStack()
+		{
+			Shell shell = new TestShell();
+			shell.Items.Add(CreateShellItem(shellContentRoute: "MainContent"));
+
+			await shell.GoToAsync($"ModalTestPage/ModalTestPage");
+			var navStack = shell.Items[0].Items[0].Navigation;
+			Assert.Equal(shell.CurrentPage, navStack.ModalStack.Last());
+		}
+
+		[Fact]
 		public async Task PoppingEntireModalStackDoesntFireAppearingOnMiddlePages()
 		{
 			Shell shell = new TestShell();


### PR DESCRIPTION
### Description of Change
When navigating between Modal pages, Shell was returning the first page in the stack as the current page, so that page was the one being notified about the navigation. Instead, we should return the last page from the stack.






<!-- Enter description of the fix in this section -->

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->
Fixes https://github.com/dotnet/maui/issues/17978

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
