### PR TITLE
[WinUI] Fix resizing CV rows when content size changed

### DIFF
--- a/src/Controls/src/Core/Platform/Windows/CollectionView/ItemContentControl.cs
+++ b/src/Controls/src/Core/Platform/Windows/CollectionView/ItemContentControl.cs
@@ -295,7 +295,17 @@ namespace Microsoft.Maui.Controls.Platform
 
 			var width = ItemWidth == default ? availableSize.Width : ItemWidth;
 			var height = ItemHeight == default ? availableSize.Height : ItemHeight;
-			var measuredSize = base.MeasureOverride(new WSize(width, height));
+			var size = new WSize(width, height);
+
+			if (this.Content is FrameworkElement content 
+				&& CanMeasureContent(content) 
+				&& (content.DesiredSize.Height != content.Height || content.DesiredSize.Width != content.Width))
+			{
+				// Measure content to update its desired size if its Height/Width just changed
+				content.Measure(size);
+			}
+
+			var measuredSize = base.MeasureOverride(size);
 			var finalWidth = Max(measuredSize.Width, ItemWidth);
 			var finalHeight = Max(measuredSize.Height, ItemHeight);
 			var finalSize = new WSize(finalWidth, finalHeight);

--- a/src/Controls/src/Core/Platform/Windows/CollectionView/ItemContentControl.cs
+++ b/src/Controls/src/Core/Platform/Windows/CollectionView/ItemContentControl.cs
@@ -321,6 +321,14 @@ namespace Microsoft.Maui.Controls.Platform
 				if (double.IsFinite(availableSize.Height))
 					height = Max(height, availableSize.Height);
 			}
+			else
+			{
+				if (ItemHeight != default)
+					height = ItemHeight;
+
+				if (ItemWidth != default)
+					width = ItemWidth;
+			}
 
 			return new WSize(width, height);
 		}

--- a/src/Controls/src/Core/Platform/Windows/CollectionView/ItemContentControl.cs
+++ b/src/Controls/src/Core/Platform/Windows/CollectionView/ItemContentControl.cs
@@ -196,24 +196,10 @@ namespace Microsoft.Maui.Controls.Platform
 			}
 			else
 			{
-				Content = new ItemPanel(_renderer.VirtualView);
+				Content = new ContentLayoutPanel(_renderer.VirtualView);
 			}
 
 			itemsView?.AddLogicalChild(_visualElement);
-		}
-
-		class ItemPanel : Panel
-		{
-			IView _view;
-			public ItemPanel(IView view)
-			{
-				_view = view;
-				this.Children.Add(view.ToPlatform());
-			}
-
-			protected override WSize ArrangeOverride(WSize finalSize) => _view.Arrange(new Rect(0, 0, finalSize.Width, finalSize.Height)).ToPlatform();
-
-			protected override WSize MeasureOverride(WSize availableSize) => _view.Measure(availableSize.Width, availableSize.Height).ToPlatform();
 		}
 
 		void SetNativeStateConsistent(VisualElement visualElement)
@@ -324,5 +310,19 @@ namespace Microsoft.Maui.Controls.Platform
 		}
 
 		internal VisualElement GetVisualElement() => _visualElement;
+
+		class ContentLayoutPanel : Panel
+		{
+			IView _view;
+			public ContentLayoutPanel(IView view)
+			{
+				_view = view;
+				Children.Add(view.ToPlatform());
+			}
+
+			protected override WSize ArrangeOverride(WSize finalSize) => _view.Arrange(new Rect(0, 0, finalSize.Width, finalSize.Height)).ToPlatform();
+
+			protected override WSize MeasureOverride(WSize availableSize) => _view.Measure(availableSize.Width, availableSize.Height).ToPlatform();
+		}
 	}
 }

--- a/src/Controls/src/Core/Platform/Windows/CollectionView/ItemContentControl.cs
+++ b/src/Controls/src/Core/Platform/Windows/CollectionView/ItemContentControl.cs
@@ -294,6 +294,12 @@ namespace Microsoft.Maui.Controls.Platform
 
 			var width = ItemWidth == default ? availableSize.Width : ItemWidth;
 			var height = ItemHeight == default ? availableSize.Height : ItemHeight;
+
+			// I realize if ItemWidth and ItemHeight are set that this call seems pointless, but it's not.
+			// From what I can tell, calling `base.MeasureOverride` causes the `ContentControl` to realize its content
+			// and build its visual tree. So, in order to just play nice with the WinUI `ContentControl` we always
+			// call base.MeasureOverride, so that we don't short circuit whatever bookkeeping it needs to do.
+. 
 			var measureSize = base.MeasureOverride(new WSize(width, height));
 
 			return new WSize(Max(measureSize.Width, width), Max(measureSize.Height, height));

--- a/src/Controls/src/Core/Platform/Windows/CollectionView/ItemContentControl.cs
+++ b/src/Controls/src/Core/Platform/Windows/CollectionView/ItemContentControl.cs
@@ -310,27 +310,7 @@ namespace Microsoft.Maui.Controls.Platform
 			var height = ItemHeight == default ? availableSize.Height : ItemHeight;
 			var measureSize = base.MeasureOverride(new WSize(width, height));
 
-			width = measureSize.Width;
-			height = measureSize.Height;
-
-			if (ItemHeight == default && ItemWidth == default)
-			{
-				if(double.IsFinite(availableSize.Width))
-					width = Max(width, availableSize.Width);
-
-				if (double.IsFinite(availableSize.Height))
-					height = Max(height, availableSize.Height);
-			}
-			else
-			{
-				if (ItemHeight != default)
-					height = ItemHeight;
-
-				if (ItemWidth != default)
-					width = ItemWidth;
-			}
-
-			return new WSize(width, height);
+			return new WSize(Max(measureSize.Width, width), Max(measureSize.Height, height));
 		}
 
 		double Max(double requested, double available)

--- a/src/Controls/src/Core/Platform/Windows/CollectionView/ItemContentControl.cs
+++ b/src/Controls/src/Core/Platform/Windows/CollectionView/ItemContentControl.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Maui.Controls.Platform
 	public class ItemContentControl : ContentControl
 	{
 		VisualElement _visualElement;
-		IViewHandler _renderer;
+		IViewHandler _handler;
 		DataTemplate _currentTemplate;
 
 		public ItemContentControl()
@@ -153,7 +153,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 			var itemsView = container as ItemsView;
 
-			if (itemsView != null && _renderer?.VirtualView is Element e)
+			if (itemsView != null && _handler?.VirtualView is Element e)
 			{
 				itemsView.RemoveLogicalChild(e);
 			}
@@ -163,14 +163,14 @@ namespace Microsoft.Maui.Controls.Platform
 				return;
 			}
 
-			if (_renderer?.ContainerView is null || _currentTemplate != formsTemplate)
+			if (_handler?.ContainerView is null || _currentTemplate != formsTemplate)
 			{
 				// If the content has never been realized (i.e., this is a new instance), 
 				// or if we need to switch DataTemplates (because this instance is being recycled)
 				// then we'll need to create the content from the template 
 				_visualElement = formsTemplate.CreateContent(dataContext, container) as VisualElement;
 				_visualElement.BindingContext = dataContext;
-				_renderer = _visualElement.ToHandler(mauiContext);
+				_handler = _visualElement.ToHandler(mauiContext);
 
 				// We need to set IsPlatformStateConsistent explicitly; otherwise, it won't be set until the renderer's Loaded 
 				// event. If the CollectionView is in a Layout, the Layout won't measure or layout the CollectionView until
@@ -186,17 +186,17 @@ namespace Microsoft.Maui.Controls.Platform
 			else
 			{
 				// We are reusing this ItemContentControl and we can reuse the Element
-				_visualElement = _renderer.VirtualView as VisualElement;
+				_visualElement = _handler.VirtualView as VisualElement;
 				_visualElement.BindingContext = dataContext;
 			}
 
-			if (_renderer.VirtualView is ICrossPlatformLayout)
+			if (_handler.VirtualView is ICrossPlatformLayout)
 			{
-				Content = _renderer.ToPlatform();
+				Content = _handler.ToPlatform();
 			}
 			else
 			{
-				Content = new ContentLayoutPanel(_renderer.VirtualView);
+				Content = new ContentLayoutPanel(_handler.VirtualView);
 			}
 
 			itemsView?.AddLogicalChild(_visualElement);
@@ -219,7 +219,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 		internal void UpdateIsSelected(bool isSelected)
 		{
-			var formsElement = _renderer?.VirtualView as VisualElement;
+			var formsElement = _handler?.VirtualView as VisualElement;
 
 			if (formsElement == null)
 				return;
@@ -281,7 +281,7 @@ namespace Microsoft.Maui.Controls.Platform
 		/// <inheritdoc/>
 		protected override WSize MeasureOverride(WSize availableSize)
 		{
-			if (_renderer is null)
+			if (_handler is null)
 			{
 				// Make sure we supply a real number for sizes otherwise virtualization won't function
 				if (double.IsFinite(availableSize.Width) && !double.IsFinite(availableSize.Height))

--- a/src/Controls/src/Core/Platform/Windows/CollectionView/ItemContentControl.cs
+++ b/src/Controls/src/Core/Platform/Windows/CollectionView/ItemContentControl.cs
@@ -299,7 +299,7 @@ namespace Microsoft.Maui.Controls.Platform
 			// From what I can tell, calling `base.MeasureOverride` causes the `ContentControl` to realize its content
 			// and build its visual tree. So, in order to just play nice with the WinUI `ContentControl` we always
 			// call base.MeasureOverride, so that we don't short circuit whatever bookkeeping it needs to do.
-. 
+
 			var measureSize = base.MeasureOverride(new WSize(width, height));
 
 			return new WSize(Max(measureSize.Width, width), Max(measureSize.Height, height));

--- a/src/Controls/src/Core/Platform/Windows/CollectionView/ItemContentControl.cs
+++ b/src/Controls/src/Core/Platform/Windows/CollectionView/ItemContentControl.cs
@@ -323,7 +323,14 @@ namespace Microsoft.Maui.Controls.Platform
 			public ContentLayoutPanel(IView view)
 			{
 				_view = view;
-				Children.Add(view.ToPlatform());
+
+				var platformView = view.ToPlatform();
+
+				// Just in case this view is already parented to a wrapper that's been cycled out
+				if (platformView.Parent is ContentLayoutPanel clp)
+					clp.Children.Remove(platformView);
+
+				Children.Add(platformView);
 			}
 
 			protected override WSize ArrangeOverride(WSize finalSize) => _view.Arrange(new Rect(0, 0, finalSize.Width, finalSize.Height)).ToPlatform();

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.Android.cs
@@ -1,6 +1,9 @@
 ﻿using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Handlers.Items;
+using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Platform;
 using Xunit;
 
 namespace Microsoft.Maui.DeviceTests
@@ -81,6 +84,11 @@ namespace Microsoft.Maui.DeviceTests
 					Assert.True(header.Height > 0, "Header should be laid out");
 					Assert.True(footer.Height > 0, "Footer should be laid out");
 				});
+		}
+
+		Rect GetCollectionViewCellBounds(IView cellContent)
+		{
+			return cellContent.ToPlatform().GetParentOfType<ItemContentView>().GetBoundingBox();
 		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.Android.cs
@@ -88,6 +88,11 @@ namespace Microsoft.Maui.DeviceTests
 
 		Rect GetCollectionViewCellBounds(IView cellContent)
 		{
+			if (!cellContent.ToPlatform().IsLoaded())
+			{
+				throw new System.Exception("The cell is not in the visual tree");
+			}
+
 			return cellContent.ToPlatform().GetParentOfType<ItemContentView>().GetBoundingBox();
 		}
 	}

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.Windows.cs
@@ -198,5 +198,52 @@ namespace Microsoft.Maui.DeviceTests
 				Assert.True(data.Count == 30);
 			});
 		}
+
+		[Fact]
+		public async Task CollectionViewContentHeightChanged()
+		{
+			// Tests that when a control's HeightRequest is changed, the control is rendered using the new value https://github.com/dotnet/maui/issues/18078
+
+			SetupBuilder();
+
+			var collectionView = new CollectionView
+			{
+				ItemTemplate = new Controls.DataTemplate(() => {
+					var label = new Label { WidthRequest = 450 };
+					label.SetBinding(Label.TextProperty, new Binding("."));
+					return label;
+				}),
+				ItemsSource = new ObservableCollection<string>()
+				{
+					"Item 1",
+				}
+			};
+
+			var layout = new Grid
+			{
+				collectionView
+			};
+
+			var frame = collectionView.Frame;
+
+			await CreateHandlerAndAddToWindow<LayoutHandler>(layout, async handler =>
+			{
+				await WaitForUIUpdate(frame, collectionView);
+				frame = collectionView.Frame;
+
+				var labels = collectionView.LogicalChildrenInternal;
+				var originalHeight = ((Label)labels[0]).Height;
+				var expectedHeight = originalHeight + 10;
+
+				((Label)labels[0]).HeightRequest = expectedHeight;
+				
+				await WaitForUIUpdate(frame, collectionView);
+
+				var finalHeight = ((Label)labels[0]).Height;
+
+				// The first label's height should be smaller than the second one since the text won't wrap
+				Assert.Equal(expectedHeight, finalHeight);
+			});
+		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.Windows.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Handlers.Items;
+using Microsoft.Maui.Controls.Platform;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Platform;
@@ -209,7 +210,8 @@ namespace Microsoft.Maui.DeviceTests
 
 			var collectionView = new CollectionView
 			{
-				ItemTemplate = new Controls.DataTemplate(() => {
+				ItemTemplate = new Controls.DataTemplate(() =>
+				{
 					var label = new Label { WidthRequest = 450 };
 					label.SetBinding(Label.TextProperty, new Binding("."));
 					return label;
@@ -237,7 +239,7 @@ namespace Microsoft.Maui.DeviceTests
 				var expectedHeight = originalHeight + 10;
 
 				((Label)labels[0]).HeightRequest = expectedHeight;
-				
+
 				await WaitForUIUpdate(frame, collectionView);
 
 				var finalHeight = ((Label)labels[0]).Height;
@@ -248,7 +250,12 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		Rect GetCollectionViewCellBounds(IView cellContent)
-		{			
+		{
+			if (!cellContent.ToPlatform().IsLoaded())
+			{
+				throw new System.Exception("The cell is not in the visual tree");
+			}
+
 			return cellContent.ToPlatform().GetParentOfType<ItemContentControl>().GetBoundingBox();
 		}
 	}

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.Windows.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Handlers.Items;
+using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Platform;
 using Microsoft.UI.Xaml;
@@ -244,6 +245,11 @@ namespace Microsoft.Maui.DeviceTests
 				// The first label's height should be smaller than the second one since the text won't wrap
 				Assert.Equal(expectedHeight, finalHeight);
 			});
+		}
+
+		Rect GetCollectionViewCellBounds(IView cellContent)
+		{			
+			return cellContent.ToPlatform().GetParentOfType<ItemContentControl>().GetBoundingBox();
 		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.cs
@@ -34,6 +34,8 @@ namespace Microsoft.Maui.DeviceTests
 					handlers.AddHandler<VerticalStackLayout, LayoutHandler>();
 					handlers.AddHandler<Grid, LayoutHandler>();
 					handlers.AddHandler<Label, LabelHandler>();
+					handlers.AddHandler<SwipeView, SwipeViewHandler>();
+					handlers.AddHandler<SwipeItem, SwipeItemMenuItemHandler>();
 
 #if IOS && !MACCATALYST
 					handlers.AddHandler<CacheTestCollectionView, CacheTestCollectionViewHandler>();
@@ -275,6 +277,36 @@ namespace Microsoft.Maui.DeviceTests
 
 				// The first label's height should be smaller than the second one since the text won't wrap
 				Assert.True(0 < firstLabelHeight && firstLabelHeight < secondLabelHeight);
+			});
+		}
+
+		[Fact(DisplayName = "SwipeView in CollectionView does not crash")]
+		public async Task SwipeViewInCollectionViewDoesNotCrash()
+		{
+			SetupBuilder();
+
+			var collectionView = new CollectionView
+			{
+				ItemTemplate = new DataTemplate(() =>
+				{
+					var swipeItem = new SwipeItem { BackgroundColor = Colors.Red };
+					swipeItem.SetBinding(SwipeItem.TextProperty, new Binding("."));
+					var swipeView = new SwipeView { RightItems = [swipeItem] };
+
+					return swipeView;
+				}),
+				ItemsSource = new ObservableCollection<string>()
+				{
+					"Item 1",
+					"Item 2",
+				}
+			};
+
+			await CreateHandlerAndAddToWindow<CollectionViewHandler>(collectionView, async handler =>
+			{
+				await WaitForUIUpdate(collectionView.Frame, collectionView);
+
+				Assert.NotNull(handler.PlatformView);
 			});
 		}
 

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.cs
@@ -47,7 +47,11 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
-		[Fact]
+		[Fact(
+#if IOS || MACCATALYST
+		Skip = "Fails on iOS/macOS: https://github.com/dotnet/maui/issues/19240"
+#endif
+		)]
 		public async Task CellSizeAccountsForMargin()
 		{
 			SetupBuilder();
@@ -78,7 +82,9 @@ namespace Microsoft.Maui.DeviceTests
 				await AssertionExtensions.Wait(() => buttons.Count > 1 && buttons.Last().Frame.Height > 0);
 				var button = buttons.Last();
 				var bounds = GetCollectionViewCellBounds(button);
+				var buttonBounds = button.GetBoundingBox();
 
+				Assert.Equal(50, buttonBounds.Height, 1d);
 				Assert.Equal(70, bounds.Height, 1d);
 				Assert.Equal(50, button.Frame.Height, 1d);
 				Assert.Equal(10, button.Frame.X, 1d);

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.cs
@@ -47,11 +47,7 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
-		[Fact
-#if IOS || MACCATALYST || ANDROID
-		(Skip = "Fails on iOS/macOS: https://github.com/dotnet/maui/issues/18517")
-#endif
-		]
+		[Fact]
 		public async Task CellSizeAccountsForMargin()
 		{
 			SetupBuilder();
@@ -77,16 +73,16 @@ namespace Microsoft.Maui.DeviceTests
 				WidthRequest = 200
 			};
 
-			//var platformView = (await CreateHandlerAsync<CollectionViewHandler>(collectionView)).PlatformView;
-
 			await collectionView.AttachAndRun<CollectionViewHandler>(async (handler) =>
 			{
-				await Task.Delay(1000);
-#if WINDOWS
-				var bounds = buttons[0].ToPlatform().GetParentOfType<ItemContentControl>().GetPlatformViewBounds();
-				Assert.Equal(70, bounds.Height);
+				await AssertionExtensions.Wait(() => buttons.Count > 1 && buttons.Last().Frame.Height > 0);
+				var button = buttons.Last();
+				var bounds = GetCollectionViewCellBounds(button);
 
-#endif
+				Assert.Equal(70, bounds.Height, 1d);
+				Assert.Equal(50, button.Frame.Height, 1d);
+				Assert.Equal(10, button.Frame.X, 1d);
+				Assert.Equal(10, button.Frame.Y, 1d);
 
 			}, MauiContext, (view) => CreateHandlerAsync<CollectionViewHandler>(view));
 		}

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Maui.DeviceTests
 
 			await collectionView.AttachAndRun<CollectionViewHandler>(async (handler) =>
 			{
-				await AssertionExtensions.Wait(() => buttons.Count > 1 && buttons.Last().Frame.Height > 0);
+				await AssertionExtensions.Wait(() => buttons.Count > 1 && buttons.Last().Frame.Height > 0 && buttons.Last().IsLoaded);
 				var button = buttons.Last();
 				var bounds = GetCollectionViewCellBounds(button);
 				var buttonBounds = button.GetBoundingBox();

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.cs
@@ -37,6 +37,7 @@ namespace Microsoft.Maui.DeviceTests
 					handlers.AddHandler<VerticalStackLayout, LayoutHandler>();
 					handlers.AddHandler<Grid, LayoutHandler>();
 					handlers.AddHandler<Label, LabelHandler>();
+					handlers.AddHandler<Button, ButtonHandler>();
 					handlers.AddHandler<SwipeView, SwipeViewHandler>();
 					handlers.AddHandler<SwipeItem, SwipeItemMenuItemHandler>();
 
@@ -56,12 +57,12 @@ namespace Microsoft.Maui.DeviceTests
 		{
 			SetupBuilder();
 
-			List<Label> buttons = new List<Label>();
+			List<Button> buttons = new List<Button>();
 			var collectionView = new CollectionView
 			{
 				ItemTemplate = new DataTemplate(() =>
 				{
-					var button = new Label()
+					var button = new Button()
 					{
 						Text = "Margin Test",
 						Margin = new Thickness(10, 10, 10, 10),

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.iOS.cs
@@ -131,11 +131,11 @@ namespace Microsoft.Maui.DeviceTests
 
 		Rect GetCollectionViewCellBounds(IView cellContent)
 		{
-			if (cellContent.ToPlatform().Window is null)
+			if (!cellContent.ToPlatform().IsLoaded())
 			{
 				throw new System.Exception("The cell is not in the visual tree");
 			}
-			
+
 			return cellContent.ToPlatform().GetParentOfType<UIKit.UICollectionViewCell>().GetBoundingBox();
 		}
 	}

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.iOS.cs
@@ -5,6 +5,8 @@ using System.Threading.Tasks;
 using CoreGraphics;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Handlers.Items;
+using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Platform;
 using UIKit;
 using Xunit;
 using Xunit.Sdk;
@@ -125,6 +127,16 @@ namespace Microsoft.Maui.DeviceTests
 			{
 				Assert.False(reference.IsAlive, "View should not be alive!");
 			}
+		}
+
+		Rect GetCollectionViewCellBounds(IView cellContent)
+		{
+			if (cellContent.ToPlatform().Window is null)
+			{
+				throw new System.Exception("The cell is not in the visual tree");
+			}
+			
+			return cellContent.ToPlatform().GetParentOfType<UIKit.UICollectionViewCell>().GetBoundingBox();
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change

Rework the `ItemContentControl` so that the Content is of the `ContentControl` is always MAUI layout aware. If the `ContentControl` contains a control that always knows how to ask the `IView` to measure and arrange then that also takes cares of cases like `Margin` which we were previously just setting on the control ourselves. 

I tried a few variations of this PR, where we wouldn't need to sometimes wrap the control we are setting as the `Content` but I couldn't make those work with the design of the `ContentControl`. From what I can tell, you have to call `base.measureoverride` on the `ContentControl` in order for it to construct its visual tree (for it to realize the ContentPresenter and then add the Content to the ContentPresenter). If you try to call `IView.Measure` before you've called `base.measureoverride` then the resulting measure will be incorrect because that control is just floating in space. 

For example, if you just have a Button for the template

```XAML
<ItemTemplate>
<Button/>
</ItemTemplate>
```

If you don't call `base.meaureoverride` and just call `IView.Measure`, then if you inspect MauiButton.Parent you'll see that it's null. 

If we just force everything to play ball with the MAUI layout system it appears to just simplify everything down. 

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/18078
