### PR TITLE
[iOS] Make sure always call decisionHandler even if no handler

### DIFF
--- a/src/Core/src/Platform/iOS/MauiWebViewNavigationDelegate.cs
+++ b/src/Core/src/Platform/iOS/MauiWebViewNavigationDelegate.cs
@@ -93,8 +93,12 @@ namespace Microsoft.Maui.Platform
 		public void DecidePolicy(WKWebView webView, WKNavigationAction navigationAction, Action<WKNavigationActionPolicy> decisionHandler)
 		{
 			var handler = Handler;
+		
 			if (handler == null)
+			{
+				decisionHandler.Invoke(WKNavigationActionPolicy.Cancel);
 				return;
+			}
 
 			var navEvent = WebNavigationEvent.NewPage;
 			var navigationType = navigationAction.NavigationType;
@@ -130,7 +134,10 @@ namespace Microsoft.Maui.Platform
 			var virtualView = handler.VirtualView;
 
 			if (virtualView == null)
+			{
+				decisionHandler.Invoke(WKNavigationActionPolicy.Cancel);
 				return;
+			}
 
 			var request = navigationAction.Request;
 			var lastUrl = request.Url.ToString();


### PR DESCRIPTION
### Description of Change

When running DeviceTests on 15.4 to 14.5 we got some random failures like: 

```
Objective-C exception thrown.  Name: NSInternalInconsistencyException Reason: Completion handler passed to -[Microsoft_Maui_Platform_MauiWebViewNavigationDelegate webView:decidePolicyForNavigationAction:decisionHandler:] was not called
```

This makes sure we always call the `decisionHandler`

Fixes #18749