### PR TITLE
Allow GesturePlatformManager to be created for views with null window…

### DIFF
--- a/src/Controls/src/Core/Platform/GestureManager/GestureManager.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GestureManager.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Maui.Controls.Platform
 		object? _containerView;
 		object? _platformView;
 		object? _handler;
+		object? _window;
 
 		public bool IsConnected => GesturePlatformManager != null;
 		public GesturePlatformManager? GesturePlatformManager { get; private set; }
@@ -56,17 +57,19 @@ namespace Microsoft.Maui.Controls.Platform
 		{
 			var handler = _view.Handler;
 			var window = _view.Window;
-
-			if (handler == null ||
-				window == null)
+			
+			if (handler == null || 
+			    // Window disconnected
+			    (_window != null && window == null))
 			{
 				DisconnectGestures();
 				return;
 			}
 
 			if (_containerView != handler.ContainerView ||
-				_platformView != handler.PlatformView ||
-				_handler != handler)
+			    _platformView != handler.PlatformView ||
+			    _handler != handler ||
+			    _window != window)
 			{
 				DisconnectGestures();
 			}
@@ -79,6 +82,7 @@ namespace Microsoft.Maui.Controls.Platform
 			_handler = handler;
 			_containerView = handler.ContainerView;
 			_platformView = handler.PlatformView;
+			_window = window;
 		}
 	}
 }

--- a/src/Controls/src/Core/Platform/GestureManager/GestureManager.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GestureManager.cs
@@ -65,9 +65,9 @@ namespace Microsoft.Maui.Controls.Platform
 				return;
 			}
 
-			if (_containerView != handler.ContainerView ||
-			    _platformView != handler.PlatformView ||
-			    _handler != handler)
+			if (_containerView != handler.ContainerView || 
+				_platformView != handler.PlatformView || 
+				_handler != handler)
 			{
 				DisconnectGestures();
 			}

--- a/src/Controls/src/Core/Platform/GestureManager/GestureManager.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GestureManager.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Maui.Controls.Platform
 		object? _containerView;
 		object? _platformView;
 		object? _handler;
-		object? _window;
+		bool _didHaveWindow;
 
 		public bool IsConnected => GesturePlatformManager != null;
 		public GesturePlatformManager? GesturePlatformManager { get; private set; }
@@ -49,7 +49,7 @@ namespace Microsoft.Maui.Controls.Platform
 			GesturePlatformManager?.Dispose();
 			GesturePlatformManager = null;
 			_handler = null;
-			_window = null;
+			_didHaveWindow = false;
 			_containerView = null;
 			_platformView = null;
 		}
@@ -57,11 +57,9 @@ namespace Microsoft.Maui.Controls.Platform
 		void SetupGestureManager()
 		{
 			var handler = _view.Handler;
-			var window = _view.Window;
 			
 			if (handler == null || 
-			    // Window disconnected
-			    (_window != null && window == null))
+			    (_didHaveWindow && _view.Window == null))
 			{
 				DisconnectGestures();
 				return;
@@ -69,8 +67,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 			if (_containerView != handler.ContainerView ||
 			    _platformView != handler.PlatformView ||
-			    _handler != handler ||
-			    _window != window)
+			    _handler != handler)
 			{
 				DisconnectGestures();
 			}
@@ -83,7 +80,7 @@ namespace Microsoft.Maui.Controls.Platform
 			_handler = handler;
 			_containerView = handler.ContainerView;
 			_platformView = handler.PlatformView;
-			_window = window;
+			_didHaveWindow = _view.Window != null;
 		}
 	}
 }

--- a/src/Controls/src/Core/Platform/GestureManager/GestureManager.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GestureManager.cs
@@ -49,6 +49,7 @@ namespace Microsoft.Maui.Controls.Platform
 			GesturePlatformManager?.Dispose();
 			GesturePlatformManager = null;
 			_handler = null;
+			_window = null;
 			_containerView = null;
 			_platformView = null;
 		}

--- a/src/Controls/tests/Core.UnitTests/Gestures/GestureManagerTests.cs
+++ b/src/Controls/tests/Core.UnitTests/Gestures/GestureManagerTests.cs
@@ -33,6 +33,18 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact]
+		public void ConnectsWithOnlyHandlerSet()
+		{
+			var handler = Substitute.For<IViewHandler>();
+			var view = Substitute.For<IControlsView>();
+
+			view.Handler.Returns(handler);
+
+			GestureManager gestureManager = new GestureManager(view);
+			Assert.True(gestureManager.IsConnected);
+		}
+
+		[Fact]
 		public void DisconnectsWhenWindowIsRemoved()
 		{
 			var handler = Substitute.For<IViewHandler>();
@@ -93,25 +105,6 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			handler.ContainerView.Returns(new object());
 			view.PlatformContainerViewChanged += Raise.Event<EventHandler>(view, EventArgs.Empty);
-
-			Assert.NotEqual(gestureManager.GesturePlatformManager, platformManagerForHandler1);
-		}
-		
-		[Fact]
-		public void PlatformManagerChangesWhenWindowChanged()
-		{
-			var view = Substitute.For<IControlsView>();
-			var handler = Substitute.For<IViewHandler>();
-
-			handler.ContainerView.Returns(null);
-			view.Window.Returns(new Window());
-			view.Handler.Returns(handler);
-
-			GestureManager gestureManager = new GestureManager(view);
-			var platformManagerForHandler1 = gestureManager.GesturePlatformManager;
-
-			view.Window.Returns(new Window());
-			view.WindowChanged += Raise.Event<EventHandler>(view, EventArgs.Empty);
 
 			Assert.NotEqual(gestureManager.GesturePlatformManager, platformManagerForHandler1);
 		}

--- a/src/Controls/tests/Core.UnitTests/Gestures/GestureManagerTests.cs
+++ b/src/Controls/tests/Core.UnitTests/Gestures/GestureManagerTests.cs
@@ -33,18 +33,6 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact]
-		public void DoesntConnectWithOnlyHandlerSet()
-		{
-			var handler = Substitute.For<IViewHandler>();
-			var view = Substitute.For<IControlsView>();
-
-			view.Handler.Returns(handler);
-
-			GestureManager gestureManager = new GestureManager(view);
-			Assert.False(gestureManager.IsConnected);
-		}
-
-		[Fact]
 		public void DisconnectsWhenWindowIsRemoved()
 		{
 			var handler = Substitute.For<IViewHandler>();
@@ -105,6 +93,25 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			handler.ContainerView.Returns(new object());
 			view.PlatformContainerViewChanged += Raise.Event<EventHandler>(view, EventArgs.Empty);
+
+			Assert.NotEqual(gestureManager.GesturePlatformManager, platformManagerForHandler1);
+		}
+		
+		[Fact]
+		public void PlatformManagerChangesWhenWindowChanged()
+		{
+			var view = Substitute.For<IControlsView>();
+			var handler = Substitute.For<IViewHandler>();
+
+			handler.ContainerView.Returns(null);
+			view.Window.Returns(new Window());
+			view.Handler.Returns(handler);
+
+			GestureManager gestureManager = new GestureManager(view);
+			var platformManagerForHandler1 = gestureManager.GesturePlatformManager;
+
+			view.Window.Returns(new Window());
+			view.WindowChanged += Raise.Event<EventHandler>(view, EventArgs.Empty);
 
 			Assert.NotEqual(gestureManager.GesturePlatformManager, platformManagerForHandler1);
 		}


### PR DESCRIPTION
### Description of Change

In the case of Maui Embedding, there is no window, and the gesture manager is always skipping the initialization of PlatformManager.
My changes allow a GestureManager to be created with a null window. I also keep the behavior of recreating/clearing the GesturePlatformManager when the window is removed or replaced.

### Issues Fixed
Fixes [[regression/8.0.0] TapGestureRecognizers not working in maui embedded](https://github.com/dotnet/maui/issues/17948)
