### PR TITLE
[Blazor] Fix static file handling so that it special cases modules.json (6.0)

### DIFF
--- a/src/BlazorWebView/samples/MauiRazorClassLibrarySample/wwwroot/MauiRazorClassLibrarySample.lib.module.js
+++ b/src/BlazorWebView/samples/MauiRazorClassLibrarySample/wwwroot/MauiRazorClassLibrarySample.lib.module.js
@@ -1,0 +1,3 @@
+﻿const element = document.createElement('p');
+element.innerHTML = 'Hello from Razor Class Library';
+document.body.appendChild(element);

--- a/src/Controls/samples/Controls.Sample/wwwroot/Maui.Controls.Sample.lib.module.js
+++ b/src/Controls/samples/Controls.Sample/wwwroot/Maui.Controls.Sample.lib.module.js
@@ -1,0 +1,3 @@
+﻿const element = document.createElement('p');
+element.innerHTML = 'Hello from App';
+document.body.appendChild(element);


### PR DESCRIPTION
blazor.modules.json from the build wasn't being picked up because the framework ships a built-in fallback version in case no file is present. 

The existing logic always returned the fallback as it was checked first.

I've updated the logic to special case blazor.modules.json and check first, otherwise use the fallback as before.