### PR TITLE
[Blazor] Fix static file handling so that it special cases modules.json (7.0)

### DIFF
--- a/src/BlazorWebView/samples/MauiRazorClassLibrarySample/wwwroot/MauiRazorClassLibrarySample.lib.module.js
+++ b/src/BlazorWebView/samples/MauiRazorClassLibrarySample/wwwroot/MauiRazorClassLibrarySample.lib.module.js
@@ -1,0 +1,3 @@
+﻿const element = document.createElement('p');
+element.innerHTML = 'Hello from Razor Class Library';
+document.body.appendChild(element);

--- a/src/Controls/samples/Controls.Sample/wwwroot/Maui.Controls.Sample.lib.module.js
+++ b/src/Controls/samples/Controls.Sample/wwwroot/Maui.Controls.Sample.lib.module.js
@@ -1,0 +1,3 @@
+﻿const element = document.createElement('p');
+element.innerHTML = 'Hello from App';
+document.body.appendChild(element);


### PR DESCRIPTION
## Issue: Microsoft.AspNetCore.Components.WebView.props is not imported by Maui applications

This issue pertains to the non-importation of Microsoft.AspNetCore.Components.WebView.props by Maui applications. The file has been relocated within the package to ensure its correct pickup and importation during the restore/build process.

Fixes #42348.

## Description

The inability of Maui applications to rely on JavaScript (JS) initializers, particularly in the case of Fluent UI, is impacted by this issue. The runtime searches for the initializer's definition in a specific location, which is configured in the props file of the package.

## Impact on Customers

The malfunction of JS initializers in Blazor Hybrid has significant implications for both library authors and end users.

Library authors may find their libraries' functionality restricted due to this bug. JS initializers, a feature in Blazor, enable library authors to inject scripts onto the page at the start of the app. These scripts can augment functionality, enhance user interfaces, or facilitate third-party service integration. For instance, a library author might employ a JS initializer to inject a script that integrates with a mapping service, thereby providing real-time location updates within a Blazor app. This functionality would be unavailable in Blazor Hybrid apps due to this bug.

End users may be unable to use certain libraries, or those libraries may not function as anticipated in Blazor Hybrid apps. If a user were to use a Blazor Hybrid app that relies on the aforementioned mapping library, they would not receive the real-time location updates that they would in a regular Blazor app. This could result in an inferior user experience, and in some cases, render the app unusable.

Users and library authors are compelled to manually inject the script onto the page, and some functionality (like configuring Blazor before it starts) is not available in this mode.

## Regression?

- [ ] Yes
- [X] No

## Risk

- [ ] High
- [ ] Medium
- [X] Low

The failure to load a file from a NuGet package impacts the build. The change causes the file to load at build time, enabling the rest of the pipeline to function as expected.

## Verification

- [X] Manual (required)
- [ ] Automated

The changes were made locally on the package cache and ensured the file got imported.

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A

## When servicing release/2.1

- [ ] Make necessary changes in eng/PatchConfig.props
