### PR TITLE
Fix for button cornerradius 0 on android

### DIFF
--- a/src/Core/src/Platform/Android/ButtonExtensions.cs
+++ b/src/Core/src/Platform/Android/ButtonExtensions.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Maui.Platform
 				if (button.StrokeThickness > 0)
 					mauiDrawable.SetBorderWidth(button.StrokeThickness);
 
-				if (button.CornerRadius > 0)
+				if (button.CornerRadius >= 0)
 					mauiDrawable.SetCornerRadius(button.CornerRadius);
 				else
 				{

--- a/src/Core/tests/DeviceTests/Handlers/Button/ButtonHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Button/ButtonHandlerTests.Android.cs
@@ -76,6 +76,31 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.Equal(xplatCharacterSpacing, values.ViewValue);
 			Assert.Equal(expectedValue, values.PlatformViewValue, EmCoefficientPrecision);
 		}
+		
+		[Theory(DisplayName = "CornerRadius Initializes Correctly")]
+		[InlineData(0, 0)]
+		[InlineData(5, 5)]
+		public async Task CornerRadiusInitializesCorrectly(int viewRadius, int platformViewRadius)
+		{
+			var button = new ButtonStub
+			{
+				Background = new SolidPaintStub(Colors.Black),
+				ImageSource = new FileImageSourceStub("black.png"),
+				CornerRadius = viewRadius
+			};
+			
+			var values = await GetValueAsync(button, (handler) =>
+			{
+				return new
+				{
+					ViewValue = button.CornerRadius,
+					PlatformViewValue = GetNativeCornerRadius(handler)
+				};
+			});
+
+			Assert.Equal(viewRadius, values.ViewValue );
+			Assert.Equal(platformViewRadius, values.PlatformViewValue);
+		}
 
 		[Theory]
 		[InlineData("red.png", "#FF0000")]
@@ -107,6 +132,27 @@ namespace Microsoft.Maui.DeviceTests
 
 		string GetNativeText(ButtonHandler buttonHandler) =>
 			GetNativeButton(buttonHandler).Text;
+		
+		int GetNativeCornerRadius(ButtonHandler buttonHandler)
+		{
+			var appCompatButton = GetNativeButton(buttonHandler);
+
+			if (appCompatButton.Background is BorderDrawable)
+			{
+				var background = (BorderDrawable)appCompatButton.Background;
+
+				if (background != null)
+				{
+					// Cornerradius is applied in drawing the path, in PathF. But that takes a private value as input, here we check that that private value is correctly set
+					CornerRadius cr = (CornerRadius)typeof(BorderDrawable).GetField("_cornerRadius", 
+						System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance).GetValue(background);
+
+					return (int)cr.TopRight;
+				}
+			}
+			
+			return -1;
+		}
 
 		Color GetNativeTextColor(ButtonHandler buttonHandler)
 		{


### PR DESCRIPTION
### Description of Change

## Issue:
Cornerradius was ignored when equal to 0 on Android.

## Reason:
- The ButtonHandler.Android uses extension method UpdateCornerRadius in ButtonExtensions.
- If the platformView.Background is of type BorderDrawable, it calls UpdateBorderDrawable
- In that method it checks on > 0 instead of >= 0
- This is not an issue for iOS, because this > 0 check is only in Android in the specific path that reaches UpdateBorderDrawable.

## Fix:
- Set the check for applying CornerRadius to >= 0 instead of > 0, specifically in this path for Android

### Issues Fixed
Fixes #18807 
Fixes #18090
Fixed #19052 
Fixes #19421
