### PR TITLE
Disallow `NaN`s in `Rect`'s `Width` and `Height` properties

### DIFF
--- a/src/Controls/src/Core/Window/Window.cs
+++ b/src/Controls/src/Core/Window/Window.cs
@@ -206,7 +206,7 @@ namespace Microsoft.Maui.Controls
 			var y = Y;
 			var width = Width;
 			var height = Height;
-			if (!double.IsNaN(width) && !double.IsNaN(height) && new Rect(x, y, width, height) == frame)
+			if (frame.X == x && frame.Y == y && frame.Width == width && frame.Height == height)
 				return;
 
 			_batchFrameUpdate++;

--- a/src/Controls/src/Core/Window/Window.cs
+++ b/src/Controls/src/Core/Window/Window.cs
@@ -206,7 +206,7 @@ namespace Microsoft.Maui.Controls
 			var y = Y;
 			var width = Width;
 			var height = Height;
-			if (new Rect(x, y, width, height) == frame)
+			if (!double.IsNaN(width) && !double.IsNaN(height) && new Rect(x, y, width, height) == frame)
 				return;
 
 			_batchFrameUpdate++;

--- a/src/Graphics/src/Graphics/Rect.cs
+++ b/src/Graphics/src/Graphics/Rect.cs
@@ -9,8 +9,8 @@ namespace Microsoft.Maui.Graphics
 	[TypeConverter(typeof(Converters.RectTypeConverter))]
 	public partial struct Rect
 	{
-		double _Height;
-		double _Width;
+		double _height;
+		double _width;
 
 		public double X { get; set; }
 

--- a/src/Graphics/src/Graphics/Rect.cs
+++ b/src/Graphics/src/Graphics/Rect.cs
@@ -18,23 +18,23 @@ namespace Microsoft.Maui.Graphics
 
 		public double Width
 		{
-			get => _Width;
+			get => _width;
 			set
 			{
 				if (double.IsNaN(value))
 					throw new ArgumentOutOfRangeException(nameof(value), value, "Cannot be NaN");
-				_Width = value;
+				_width = value;
 			}
 		}
 
 		public double Height
 		{
-			get => _Height;
+			get => _height;
 			set
 			{
 				if (double.IsNaN(value))
 					throw new ArgumentOutOfRangeException(nameof(value), value, "Cannot be NaN");
-				_Height = value;
+				_height = value;
 			}
 		}
 

--- a/src/Graphics/src/Graphics/Rect.cs
+++ b/src/Graphics/src/Graphics/Rect.cs
@@ -9,13 +9,34 @@ namespace Microsoft.Maui.Graphics
 	[TypeConverter(typeof(Converters.RectTypeConverter))]
 	public partial struct Rect
 	{
+		double _Height;
+		double _Width;
+
 		public double X { get; set; }
 
 		public double Y { get; set; }
 
-		public double Width { get; set; }
+		public double Width
+		{
+			get => _Width;
+			set
+			{
+				if (double.IsNaN(value))
+					throw new ArgumentOutOfRangeException(nameof(value), value, "Cannot be NaN");
+				_Width = value;
+			}
+		}
 
-		public double Height { get; set; }
+		public double Height
+		{
+			get => _Height;
+			set
+			{
+				if (double.IsNaN(value))
+					throw new ArgumentOutOfRangeException(nameof(value), value, "Cannot be NaN");
+				_Height = value;
+			}
+		}
 
 		public static Rect Zero = new Rect();
 
@@ -27,6 +48,10 @@ namespace Microsoft.Maui.Graphics
 		// constructors
 		public Rect(double x, double y, double width, double height) : this()
 		{
+			if (double.IsNaN(width))
+				throw new ArgumentOutOfRangeException(nameof(width), width, "Cannot be NaN");
+			if (double.IsNaN(height))
+				throw new ArgumentOutOfRangeException(nameof(height), height, "Cannot be NaN");
 			X = x;
 			Y = y;
 			Width = width;

--- a/src/Graphics/src/Graphics/Rect.cs
+++ b/src/Graphics/src/Graphics/Rect.cs
@@ -48,10 +48,6 @@ namespace Microsoft.Maui.Graphics
 		// constructors
 		public Rect(double x, double y, double width, double height) : this()
 		{
-			if (double.IsNaN(width))
-				throw new ArgumentOutOfRangeException(nameof(width), width, "Cannot be NaN");
-			if (double.IsNaN(height))
-				throw new ArgumentOutOfRangeException(nameof(height), height, "Cannot be NaN");
 			X = x;
 			Y = y;
 			Width = width;


### PR DESCRIPTION
### Description of Change

`Rect` has a `Size` property that returns a `Size` object that wraps the `Width` and `Height` properties. However, `Size` objects do not allow construction with `NaN` values. This means that `Rect`s can be created that have a property getter that throws an exception, which is against .Net design guidelines: https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/property

Apart from just being against guidelines, a downstream issue is that exceptions are thrown at the point of access, rather than the point of creation, inhibiting the ability to troubleshoot where these `NaN`s are coming from.

This change found one location in MAUI that was creating `Rect`s with `NaN`s, and includes a fix. There may well be more locations that require adjustment. This would potentially be a breaking change in `Graphics`.

Alternatively, if a breaking change is not desired, documenting the issue and ensuring any location that consumes the `Size` property guards against the Rect containing NaN values could be pursued. That would be tricky because of instances like `Element.Bounds.Size.ToSizeF()` being used.

### Issues Fixed

Fixes #16571

Possible alternative:

- https://github.com/dotnet/maui/pull/22890