### PR TITLE
Add better exception for missing Maps on Windows

### DIFF
--- a/src/Controls/Maps/src/AppHostBuilderExtensions.cs
+++ b/src/Controls/Maps/src/AppHostBuilderExtensions.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Maui.Controls.Hosting
 
 #if WINDOWS
 			throw new NotImplementedException(".NET MAUI Maps is currently not implemented for Windows. For more information, please see: https://aka.ms/maui-maps-no-windows");
-#elif
+#else
 			return handlersCollection;
 #endif
 		}

--- a/src/Controls/Maps/src/AppHostBuilderExtensions.cs
+++ b/src/Controls/Maps/src/AppHostBuilderExtensions.cs
@@ -63,7 +63,12 @@ namespace Microsoft.Maui.Controls.Hosting
 			handlersCollection.AddHandler<Pin, MapPinHandler>();
 			handlersCollection.AddHandler<MapElement, MapElementHandler>();
 #endif
+
+#if WINDOWS
+			throw new NotImplementedException(".NET MAUI Maps is currently not implemented for Windows. For more information, please see: https://aka.ms/maui-maps-no-windows");
+#elif
 			return handlersCollection;
+#endif
 		}
 	}
 }

--- a/src/Controls/samples/Controls.Sample.UITests/MauiProgram.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/MauiProgram.cs
@@ -11,7 +11,9 @@ namespace Maui.Controls.Sample
 		public static MauiApp CreateMauiApp() =>
 			MauiApp
 				.CreateBuilder()
+#if IOS || ANDROID
 				.UseMauiMaps()
+#endif
 				.UseMauiApp<App>()
 				.Build();
 	}


### PR DESCRIPTION
### Description of Change

Adds a more descriptive error message to the missing .NET MAUI Maps implementation for Windows. This points to the docs where it says: no implementation right now, the .NET MAUI Community Toolkit has one.

It's an aka.ms link so we can adjust it if needed without changing the code later on.

### Issues Fixed

Related to #19040 (and others that came earlier)