### PR TITLE
[Android] Allow setting Button CornerRadius to 0

### DIFF
--- a/src/Core/src/Platform/Android/ButtonExtensions.cs
+++ b/src/Core/src/Platform/Android/ButtonExtensions.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Maui.Platform
 				if (button.StrokeThickness > 0)
 					mauiDrawable.SetBorderWidth(button.StrokeThickness);
 
-				if (button.CornerRadius > 0)
+				if (button.CornerRadius >= 0)
 					mauiDrawable.SetCornerRadius(button.CornerRadius);
 				else
 				{


### PR DESCRIPTION
### Description of Change

Update to ```ButtonExtensions``` to allow the setting of ```CornerRadius``` to ```0``` for non-rounded corners. 

### Issues Fixed

Fixes [#19052](https://github.com/dotnet/maui/issues/19052)