### PR TITLE
[Windows] Fix setting flyout width (#19068)

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
@@ -156,6 +156,28 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.True(finished);
 		}
 
+		[Fact(DisplayName = "Flyout Width Does Not Crash")]
+		public async Task FlyoutWidthDoesNotCrash()
+		{
+			SetupBuilder();
+
+			var shell = await CreateShellAsync(shell =>
+			{
+				shell.CurrentItem = new ContentPage();
+				shell.FlyoutBehavior = FlyoutBehavior.Flyout;
+			});
+
+			bool finished = false;
+			await CreateHandlerAndAddToWindow<IWindowHandler>(shell, (_) =>
+			{
+				finished = true;
+				shell.FlyoutWidth = 1;
+				return Task.CompletedTask;
+			});
+
+			Assert.True(finished);
+		}
+
 		[Fact(DisplayName = "Appearing Fires Before NavigatedTo")]
 		public async Task AppearingFiresBeforeNavigatedTo()
 		{

--- a/src/Core/src/Platform/Windows/RootNavigationView.cs
+++ b/src/Core/src/Platform/Windows/RootNavigationView.cs
@@ -329,8 +329,11 @@ namespace Microsoft.Maui.Platform
 			if (PaneContentGrid == null)
 				return;
 
-			var newSize = new Size(OpenPaneLength, PaneContentGrid.ActualHeight - PaneContentGrid.RowDefinitions[1].Height.Value);
+			var newHeight = PaneContentGrid.ActualHeight - PaneContentGrid.RowDefinitions[1].Height.Value;
+			if (newHeight < 0)
+				return;
 
+			var newSize = new Size(OpenPaneLength, newHeight);
 			if (newSize == FlyoutPaneSize)
 				return;
 


### PR DESCRIPTION
PaneContentGrid width/height will be zero if the flyout has not yet been shown

### Description of Change

Ensures a valid size is calculated for the PaneContentGrid if the flyout has not been shown

### Issues Fixed

Fixes #19068
