### PR TITLE
Save device logs when UI Tests fail

### DIFF
--- a/src/Controls/tests/UITests/Tests/Concepts/InputTransparencyGalleryTests.cs
+++ b/src/Controls/tests/UITests/Tests/Concepts/InputTransparencyGalleryTests.cs
@@ -20,17 +20,17 @@ namespace Microsoft.Maui.AppiumTests
 		}
 
 		[Test]
-		public void Simple([Values] Test.InputTransparency test) => RunTest(test.ToString());
+		public void InputTransparencySimple([Values] Test.InputTransparency test) => RunTest(test.ToString());
 
-		// [Test]
-		// [Combinatorial]
-		// public void Matrix([Values] bool rootTrans, [Values] bool rootCascade, [Values] bool nestedTrans, [Values] bool nestedCascade, [Values] bool trans)
-		// {
-		// 	var (clickable, passthru) = Test.InputTransparencyMatrix.States[(rootTrans, rootCascade, nestedTrans, nestedCascade, trans)];
-		// 	var key = Test.InputTransparencyMatrix.GetKey(rootTrans, rootCascade, nestedTrans, nestedCascade, trans, clickable, passthru);
+		[Test]
+		[Combinatorial]
+		public void InputTransparencyMatrix([Values] bool rootTrans, [Values] bool rootCascade, [Values] bool nestedTrans, [Values] bool nestedCascade, [Values] bool trans)
+		{
+			var (clickable, passthru) = Test.InputTransparencyMatrix.States[(rootTrans, rootCascade, nestedTrans, nestedCascade, trans)];
+			var key = Test.InputTransparencyMatrix.GetKey(rootTrans, rootCascade, nestedTrans, nestedCascade, trans, clickable, passthru);
 
-		// 	RunTest(key, clickable, passthru);
-		// }
+			RunTest(key, clickable, passthru);
+		}
 
 		void RunTest(string test, bool? clickable = null, bool? passthru = null)
 		{

--- a/src/TestUtils/src/UITest.Appium/AppiumApp.cs
+++ b/src/TestUtils/src/UITest.Appium/AppiumApp.cs
@@ -5,7 +5,7 @@ using UITest.Core;
 
 namespace UITest.Appium
 {
-	public abstract class AppiumApp : IApp, IScreenshotSupportedApp
+	public abstract class AppiumApp : IApp, IScreenshotSupportedApp, ILogsSupportedApp
 	{
 		protected readonly AppiumDriver _driver;
 		protected readonly IConfig _config;
@@ -47,6 +47,20 @@ namespace UITest.Appium
 		{
 			Screenshot screenshot = _driver.GetScreenshot();
 			return screenshot.AsByteArray;
+		}
+
+		public IEnumerable<string> GetLogTypes()
+		{
+			return _driver.Manage().Logs.AvailableLogTypes;
+		}
+
+		public IEnumerable<string> GetLogEntries(string logType)
+		{
+			var entries = _driver.Manage().Logs.GetLog(logType);
+			foreach (var entry in entries)
+			{
+				yield return entry.Message;
+			}
 		}
 
 #nullable disable

--- a/src/TestUtils/src/UITest.Core/IApp.cs
+++ b/src/TestUtils/src/UITest.Core/IApp.cs
@@ -21,6 +21,12 @@
 		byte[] Screenshot();
 	}
 
+	public interface ILogsSupportedApp : IApp
+	{
+		IEnumerable<string> GetLogTypes();
+		IEnumerable<string> GetLogEntries(string logType);
+	}
+
 	public static class AppExtensions
 	{
 		public static void Click(this IApp app, float x, float y)
@@ -50,5 +56,14 @@
 
 		public static byte[] Screenshot(this IApp app) =>
 			app.As<IScreenshotSupportedApp>().Screenshot();
+	}
+
+	public static class LogsSupportedAppExtensions
+	{
+		public static IEnumerable<string> GetLogTypes(this IApp app) =>
+			app.As<ILogsSupportedApp>().GetLogTypes();
+
+		public static IEnumerable<string> GetLogEntries(this IApp app, string logType) =>
+			app.As<ILogsSupportedApp>().GetLogEntries(logType);
 	}
 }

--- a/src/TestUtils/src/UITest.NUnit/UITestBase.cs
+++ b/src/TestUtils/src/UITest.NUnit/UITestBase.cs
@@ -70,6 +70,7 @@ namespace UITest.Appium.NUnit
 			if (testOutcome == ResultState.Error ||
 				testOutcome == ResultState.Failure)
 			{
+				SaveDeviceDiagnosticInfo();
 				SaveUIDiagnosticInfo();
 			}
 		}
@@ -85,6 +86,7 @@ namespace UITest.Appium.NUnit
 			}
 			catch
 			{
+				SaveDeviceDiagnosticInfo();
 				SaveUIDiagnosticInfo();
 				throw;
 			}
@@ -99,10 +101,32 @@ namespace UITest.Appium.NUnit
 			if (outcome.Status == ResultState.SetUpFailure.Status &&
 				outcome.Site == ResultState.SetUpFailure.Site)
 			{
+				SaveDeviceDiagnosticInfo();
 				SaveUIDiagnosticInfo();
 			}
 
 			FixtureTeardown();
+		}
+
+		void SaveDeviceDiagnosticInfo([CallerMemberName] string? note = null)
+		{
+			var types = App.GetLogTypes().ToArray();
+			TestContext.Progress.WriteLine($">>>>> {DateTime.Now} Log types: {string.Join(", ", types)}");
+
+			foreach (var logType in new[] { "logcat" })
+			{
+				if (!types.Contains(logType, StringComparer.InvariantCultureIgnoreCase))
+					continue;
+
+				var logsPath = GetGeneratedFilePath($"AppLogs-{logType}.log", note);
+				if (logsPath is not null)
+				{
+					var entries = App.GetLogEntries(logType);
+					File.WriteAllLines(logsPath, entries);
+
+					AddTestAttachment(logsPath, Path.GetFileName(logsPath));
+				}
+			}
 		}
 
 		void SaveUIDiagnosticInfo([CallerMemberName] string? note = null)


### PR DESCRIPTION
### Description of Change

Our tests are not so stable. Some cases the test wail fail because the app stopped running. There does not appear to be an issue with the next test, just the app is gone...

Hopefully adding some logs will show where things are crashing.

This PR just adds `logcat` - Android logs - but we can add other platforms if the need arises.

Some of the known logs:

- Android: `logcat`, `bugreport`, `server`
- Mac: _seems to have none_
- iOS: `syslog`, `crashlog`, `performance`, `safariConsole`, `safariNetwork`, `server`
- Windows: TBD

Issues fixed:

 - Fixes #19038
 - Fixes #18735