### PR TITLE
[Testing] Added methods to set the device orientation from UITests

### DIFF
--- a/src/TestUtils/src/UITest.Appium/Actions/AppiumOrientationActions.cs
+++ b/src/TestUtils/src/UITest.Appium/Actions/AppiumOrientationActions.cs
@@ -1,0 +1,48 @@
+﻿using UITest.Core;
+
+namespace UITest.Appium
+{
+	public class AppiumOrientationActions : ICommandExecutionGroup
+	{
+		const string SetOrientationPortraitCommand = "setOrientationPortrait";
+		const string SetOrientationLandscapeCommand = "setOrientationLandscape";
+
+		protected readonly AppiumApp _app;
+
+		readonly List<string> _commands = new()
+		{
+			SetOrientationPortraitCommand,
+			SetOrientationLandscapeCommand,
+		};
+
+		public AppiumOrientationActions(AppiumApp app)
+		{
+			_app = app;
+		}
+
+		public bool IsCommandSupported(string commandName)
+		{
+			return _commands.Contains(commandName, StringComparer.OrdinalIgnoreCase);
+		}
+
+		public CommandResponse Execute(string commandName, IDictionary<string, object> parameters)
+		{
+			return commandName switch
+			{
+				SetOrientationPortraitCommand => SetOrientationPortrait(parameters),
+				SetOrientationLandscapeCommand => SetOrientationLandscape(parameters),
+				_ => CommandResponse.FailedEmptyResponse,
+			};
+		}
+
+		CommandResponse SetOrientationPortrait(IDictionary<string, object> parameters)
+		{
+			return new CommandResponse(_app.Driver.Orientation = OpenQA.Selenium.ScreenOrientation.Portrait, CommandResponseResult.Success);
+		}
+
+		CommandResponse SetOrientationLandscape(IDictionary<string, object> parameters)
+		{
+			return new CommandResponse(_app.Driver.Orientation = OpenQA.Selenium.ScreenOrientation.Landscape, CommandResponseResult.Success);
+		}
+	}
+}

--- a/src/TestUtils/src/UITest.Appium/AppiumApp.cs
+++ b/src/TestUtils/src/UITest.Appium/AppiumApp.cs
@@ -21,6 +21,7 @@ namespace UITest.Appium
 			_commandExecutor.AddCommandGroup(new AppiumTextActions());
 			_commandExecutor.AddCommandGroup(new AppiumGeneralActions());
 			_commandExecutor.AddCommandGroup(new AppiumVirtualKeyboardActions(this));
+			_commandExecutor.AddCommandGroup(new AppiumOrientationActions(this));
 		}
 
 		public abstract ApplicationState AppState { get; }

--- a/src/TestUtils/src/UITest.Appium/HelperExtensions.cs
+++ b/src/TestUtils/src/UITest.Appium/HelperExtensions.cs
@@ -174,6 +174,24 @@ namespace UITest.Appium
 			}
 		}
 
+		/// <summary>
+		/// Changes the device orientation to landscape mode.
+		/// </summary>
+		/// <param name="app">Represents the main gateway to interact with an app.</param>
+		public static void SetOrientationLandscape(this IApp app)
+		{
+			app.CommandExecutor.Execute("setOrientationLandscape", ImmutableDictionary<string, object>.Empty);
+		}
+
+		/// <summary>
+		/// Changes the device orientation to portrait mode.
+		/// </summary>
+		/// <param name="app">Represents the main gateway to interact with an app.</param>
+		public static void SetOrientationPortrait(this IApp app)
+		{
+			app.CommandExecutor.Execute("setOrientationPortrait", ImmutableDictionary<string, object>.Empty);
+		}
+
 		static IUIElement Wait(Func<IUIElement> query,
 			Func<IUIElement, bool> satisfactory,
 			string? timeoutMessage = null,


### PR DESCRIPTION
### Description of Change

We have gaps in our UITests with appium compared to Xamarin.UITest. When carrying legacy test we have certain needs such as rotating device, suspending and resuming apps, etc.
This PR include methods to set the device **orientation** from UITests.

This changes have been tested with a fake test (just rotating) and with the ScrollView tests.