### PR TITLE
[Testing] Added lifecycle methods to UITest

### DIFF
--- a/src/TestUtils/src/UITest.Appium/Actions/AppiumLifecycleActions.cs
+++ b/src/TestUtils/src/UITest.Appium/Actions/AppiumLifecycleActions.cs
@@ -1,0 +1,84 @@
+﻿using UITest.Core;
+
+namespace UITest.Appium
+{
+	public class AppiumLifecycleActions : ICommandExecutionGroup
+	{
+		const string LaunchAppCommand = "launchApp";
+		const string BackgroundAppCommand = "backgroundApp";
+		const string ResetAppCommand = "resetApp";
+		const string CloseAppCommand = "closeApp";
+
+		protected readonly AppiumApp _app;
+
+		readonly List<string> _commands = new()
+		{
+			LaunchAppCommand,
+			BackgroundAppCommand,
+			ResetAppCommand,
+			CloseAppCommand,
+		};
+
+		public AppiumLifecycleActions(AppiumApp app)
+		{
+			_app = app;
+		}
+
+		public bool IsCommandSupported(string commandName)
+		{
+			return _commands.Contains(commandName, StringComparer.OrdinalIgnoreCase);
+		}
+
+		public CommandResponse Execute(string commandName, IDictionary<string, object> parameters)
+		{
+			return commandName switch
+			{
+				LaunchAppCommand => LaunchApp(parameters),
+				BackgroundAppCommand => BackgroundApp(parameters),
+				ResetAppCommand => ResetApp(parameters),
+				CloseAppCommand => CloseApp(parameters),
+				_ => CommandResponse.FailedEmptyResponse,
+			};
+		}
+
+		CommandResponse LaunchApp(IDictionary<string, object> parameters)
+		{
+			if (_app?.Driver is null)
+				return CommandResponse.FailedEmptyResponse;
+
+			_app.Driver.LaunchApp();
+
+			return CommandResponse.SuccessEmptyResponse;
+		}
+
+		CommandResponse BackgroundApp(IDictionary<string, object> parameters)
+		{
+			if (_app?.Driver is null)
+				return CommandResponse.FailedEmptyResponse;
+
+			_app.Driver.BackgroundApp();
+
+			return CommandResponse.SuccessEmptyResponse;
+		}
+
+		CommandResponse ResetApp(IDictionary<string, object> parameters)
+		{
+			if (_app?.Driver is null)
+				return CommandResponse.FailedEmptyResponse;
+
+			_app.Driver.ResetApp();
+
+			return CommandResponse.SuccessEmptyResponse;
+		}
+
+		CommandResponse CloseApp(IDictionary<string, object> parameters)
+		{
+			if (_app?.Driver is null)
+				return CommandResponse.FailedEmptyResponse;
+
+			_app.Driver.CloseApp();
+
+			return CommandResponse.SuccessEmptyResponse;
+		}
+	}
+}

--- a/src/TestUtils/src/UITest.Appium/AppiumApp.cs
+++ b/src/TestUtils/src/UITest.Appium/AppiumApp.cs
@@ -1,4 +1,4 @@
-﻿using OpenQA.Selenium;
+using OpenQA.Selenium;
 using OpenQA.Selenium.Appium;
 using OpenQA.Selenium.Appium.Enums;
 using UITest.Core;
@@ -23,6 +23,7 @@ namespace UITest.Appium
 			_commandExecutor.AddCommandGroup(new AppiumVirtualKeyboardActions(this));
 			_commandExecutor.AddCommandGroup(new AppiumSwipeActions(this));
 			_commandExecutor.AddCommandGroup(new AppiumOrientationActions(this));
+			_commandExecutor.AddCommandGroup(new AppiumLifecycleActions(this));
 		}
 
 		public abstract ApplicationState AppState { get; }

--- a/src/TestUtils/src/UITest.Appium/HelperExtensions.cs
+++ b/src/TestUtils/src/UITest.Appium/HelperExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Immutable;
+using System.Collections.Immutable;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Drawing;
@@ -300,6 +300,43 @@ namespace UITest.Appium
 				{ "x", x },
 				{ "y", y }
 			});
+		}
+
+		/// <summary>
+		/// Executes an existing application on the device. 
+		/// If the application is already running then it will be brought to the foreground.
+		/// </summary>
+		/// <param name="app">Represents the main gateway to interact with an app.</param>
+		public static void LaunchApp(this IApp app)
+		{
+			app.CommandExecutor.Execute("launchApp", ImmutableDictionary<string, object>.Empty);
+		}
+
+		/// <summary>
+		/// Send the currently running app for this session to the background.
+		/// </summary>
+		/// <param name="app">Represents the main gateway to interact with an app.</param>
+		public static void BackgroundApp(this IApp app)
+		{
+			app.CommandExecutor.Execute("backgroundApp", ImmutableDictionary<string, object>.Empty);
+		}
+
+		/// <summary>
+		/// Reset the currently running app for this session.
+		/// </summary>
+		/// <param name="app">Represents the main gateway to interact with an app.</param>
+		public static void ResetApp(this IApp app)
+		{
+			app.CommandExecutor.Execute("resetApp", ImmutableDictionary<string, object>.Empty);
+		}
+
+		/// <summary>
+		/// Close an app on device.
+		/// </summary>
+		/// <param name="app">Represents the main gateway to interact with an app.</param>
+		public static void CloseApp(this IApp app)
+		{
+			app.CommandExecutor.Execute("closeApp", ImmutableDictionary<string, object>.Empty);
 		}
 
 		static IUIElement Wait(Func<IUIElement> query,


### PR DESCRIPTION
### Description of Change

We have gaps in our UITests with appium compared to Xamarin.UITest. When carrying legacy test we have certain needs such as rotating device, suspending and resuming apps, etc.
This PR include methods to manange the **App lifecycle**.

Added methods to:
- Launch and App or move to foreground.
- Move to background an App.
- Close a running App.
