### PR TITLE
[iOS] Fix Flyout layout

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellFlyoutHeaderContainer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellFlyoutHeaderContainer.cs
@@ -1,7 +1,4 @@
 #nullable disable
-using System;
-using CoreGraphics;
-using Microsoft.Maui.Platform;
 using UIKit;
 
 namespace Microsoft.Maui.Controls.Platform.Compatibility
@@ -21,6 +18,9 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			{
 				if (View.IsSet(View.MarginProperty))
 					return View.Margin;
+
+				if (View is ISafeAreaView sav && sav.IgnoreSafeArea)
+					return Thickness.Zero;
 
 				var safeArea = UIApplication.SharedApplication.GetSafeAreaInsetsForWindow();
 

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellFlyoutHeaderContainer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellFlyoutHeaderContainer.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 					safeArea.Left,
 					safeArea.Top,
 					safeArea.Right,
-					safeArea.Left);
+					safeArea.Bottom);
 			}
 		}
 

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellFlyoutHeaderContainer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellFlyoutHeaderContainer.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 	internal class ShellFlyoutHeaderContainer : UIContainerView
 	{
 		Thickness _safearea = Thickness.Zero;
+		
 		public ShellFlyoutHeaderContainer(View view) : base(view)
 		{
 			UpdateSafeAreaMargin();
@@ -23,11 +24,13 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 				var safeArea = UIApplication.SharedApplication.GetSafeAreaInsetsForWindow();
 
+				// As the safe area is for the entire window, we should not account for the bottom area for the header, 
+				// otherwise it will be treated as margin added in between the header and content
 				return new Thickness(
 					safeArea.Left,
 					safeArea.Top,
 					safeArea.Right,
-					safeArea.Bottom);
+					0); 
 			}
 		}
 

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellFlyoutHeaderContainer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellFlyoutHeaderContainer.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 					safeArea.Left,
 					safeArea.Top,
 					safeArea.Right,
-					0); 
+					0);
 			}
 		}
 

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellFlyoutLayoutManager.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellFlyoutLayoutManager.cs
@@ -294,7 +294,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 		{
 			// Initially we offset the content by the header's offset (which could include the safe area) + the calculated top margin for the content
 			var contentViewYOffset = HeaderViewVerticalOffset + ContentTopMargin;
-			if (Content?.IsSet(View.MarginProperty) == false && HeaderView is not null)
+			if (Content?.IsSet(View.MarginProperty) == false && HeaderView is null)
 			{
 					// If HeaderView is null, we need add the SafeArea.Top explicitly. 
 					// We get this value through HeaderViewVerticalOffset when there is a HeaderView.

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellFlyoutLayoutManager.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellFlyoutLayoutManager.cs
@@ -302,7 +302,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 			if (HeaderView is not null && !double.IsNaN(ArrangedHeaderViewHeightWithNoMargin))
 			{
-				HeaderView.Frame = new CGRect(0, _headerOffset + HeaderTopMargin, parent.Frame.Width, ArrangedHeaderViewHeightWithNoMargin + HeaderTopMargin);
+				HeaderView.Frame = new CGRect(0, _headerOffset + HeaderTopMargin, parent.Frame.Width, ArrangedHeaderViewHeightWithNoMargin);
 
 				if (_context.Shell.FlyoutHeaderBehavior == FlyoutHeaderBehavior.Scroll && HeaderTopMargin > 0 && _headerOffset < 0)
 				{

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellFlyoutLayoutManager.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellFlyoutLayoutManager.cs
@@ -294,14 +294,11 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 		{
 			// Initially we offset the content by the header's offset (which could include the safe area) + the calculated top margin for the content
 			var contentViewYOffset = HeaderViewVerticalOffset + ContentTopMargin;
-			if (Content?.IsSet(View.MarginProperty) == false)
+			if (Content?.IsSet(View.MarginProperty) == false && HeaderView is not null)
 			{
-				if (HeaderView is null)
-				{
 					// If HeaderView is null, we need add the SafeArea.Top explicitly. 
 					// We get this value through HeaderViewVerticalOffset when there is a HeaderView.
 					contentViewYOffset += (float)UIApplication.SharedApplication.GetSafeAreaInsetsForWindow().Top;
-				}
 			}
 
 			if (ScrollView is null)

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellFlyoutLayoutManager.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellFlyoutLayoutManager.cs
@@ -190,13 +190,13 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				return;
 
 			// If the HeaderView hasn't been measured we need to measure it
-			if (double.IsNaN(MeasuredHeaderViewHeightWithOutMargin))
+			if (double.IsNaN(MeasuredHeaderViewHeightWithMargin))
 			{
 				HeaderView.SizeThatFits(new CGSize(ContentView.Superview.Frame.Width, double.PositiveInfinity));
 			}
 
-			SetHeaderContentInset();
 			UpdateHeaderMaximumSize(ScrollView?.ContentOffset.Y);
+			SetHeaderContentInset();
 			LayoutParallax();
 		}
 
@@ -210,12 +210,12 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 			if (HeaderView is not null)
 			{
-				if (double.IsNaN(MeasuredHeaderViewHeightWithOutMargin))
+				if (double.IsNaN(ArrangedHeaderViewHeightWithMargin))
 				{
 					return;
 				}
 
-				ScrollView.ContentInset = new UIEdgeInsets((nfloat)MeasuredHeaderViewHeightWithOutMargin, 0, 0, 0);
+				ScrollView.ContentInset = new UIEdgeInsets((nfloat)ArrangedHeaderViewHeightWithMargin, 0, 0, 0);
 			}
 			else
 			{
@@ -300,7 +300,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 		void LayoutHeader(CGRect parentFrame)
 		{
-			if (HeaderView is not null && !double.IsNaN(ArrangedHeaderViewHeightWithOutMargin))
+			if (HeaderView is not null && !double.IsNaN(ArrangedHeaderViewHeightWithMargin))
 			{
 				nfloat safeArea = 0;
 				if (!HeaderView.View.IsSet(View.MarginProperty))
@@ -309,11 +309,11 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				}
 
 				// We should not consider margin as part of the header's frame since that will be handled by MAUI layout system through the header's subviews
-				HeaderView.Frame = new CGRect(0, _headerOffset + safeArea, parentFrame.Width, ArrangedHeaderViewHeightWithOutMargin);
+				HeaderView.Frame = new CGRect(0, _headerOffset + safeArea, parentFrame.Width, ArrangedHeaderViewHeightWithMargin);
 
 				if (_context.Shell.FlyoutHeaderBehavior == FlyoutHeaderBehavior.Scroll && HeaderViewVerticalOffset > 0 && _headerOffset < 0)
 				{
-					var headerHeight = Math.Max(HeaderMinimumHeight, ArrangedHeaderViewHeightWithOutMargin + _headerOffset);
+					var headerHeight = Math.Max(HeaderMinimumHeight, ArrangedHeaderViewHeightWithMargin + _headerOffset);
 					CAShapeLayer shapeLayer = new CAShapeLayer();
 					CGRect rect = new CGRect(0, _headerOffset * -1, parentFrame.Width, headerHeight);
 					var path = CGPath.FromRect(rect);
@@ -354,13 +354,13 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			{
 				case FlyoutHeaderBehavior.Default:
 				case FlyoutHeaderBehavior.Fixed:
-					ArrangedHeaderViewHeightWithOutMargin = MeasuredHeaderViewHeightWithOutMargin;
+					ArrangedHeaderViewHeightWithMargin = MeasuredHeaderViewHeightWithMargin;
 					_headerOffset = 0;
 					break;
 
 				case FlyoutHeaderBehavior.Scroll:
-					ArrangedHeaderViewHeightWithOutMargin = MeasuredHeaderViewHeightWithOutMargin;
-					_headerOffset = Math.Min(0, -(MeasuredHeaderViewHeightWithOutMargin + contentOffsetY));
+					ArrangedHeaderViewHeightWithMargin = MeasuredHeaderViewHeightWithMargin;
+					_headerOffset = Math.Min(0, -(MeasuredHeaderViewHeightWithMargin + contentOffsetY));
 					break;
 
 				case FlyoutHeaderBehavior.CollapseOnScroll:
@@ -377,25 +377,22 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			if (HeaderView is not null)
 			{
 				if (ScrollView is not null && contentOffsetY is not null && _context.Shell.FlyoutHeaderBehavior == FlyoutHeaderBehavior.CollapseOnScroll)
-					ArrangedHeaderViewHeightWithOutMargin = Math.Max(HeaderMinimumHeight, -contentOffsetY.Value);
+					ArrangedHeaderViewHeightWithMargin = Math.Max(HeaderMinimumHeight, -contentOffsetY.Value);
 				else
-				{
-					HeaderView.Height = HeaderView.MeasuredHeight;
-					ArrangedHeaderViewHeightWithOutMargin = MeasuredHeaderViewHeightWithOutMargin;
-				}
+					ArrangedHeaderViewHeightWithMargin = MeasuredHeaderViewHeightWithMargin;
 			}
 		}
 
-		double ArrangedHeaderViewHeightWithOutMargin
+		double ArrangedHeaderViewHeightWithMargin
 		{
 			get => _headerSize;
 			set
 			{
-				// if (HeaderView is not null &&
-				// 	HeaderView.Height != value)
-				// {
-				// 	HeaderView.Height = value;
-				// }
+				if (HeaderView is not null &&
+					HeaderView.Height != value)
+				{
+					HeaderView.Height = value;
+				}
 
 				_headerSize = value;
 			}
@@ -421,22 +418,22 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 		double MeasuredHeaderViewHeightWithMargin =>
 			HeaderView?.MeasuredHeight ?? 0;
 
-		double MeasuredHeaderViewHeightWithOutMargin 
-		{
-			get
-			{
-				var headerHeight = HeaderView?.MeasuredHeight ?? 0;
+		// double MeasuredHeaderViewHeightWithOutMargin 
+		// {
+		// 	get
+		// 	{
+		// 		var headerHeight = MeasuredHeaderViewHeightWithMargin;
 
-				// We only subtract the margin if it was explicitly set, otherwise we would be subtracting the safe area 
-				// which is not accounted for in MeasuredHeaderViewHeightWithMargin
-				if (!double.IsNaN(headerHeight) && HeaderView?.View.IsSet(View.MarginProperty) == true)
-				{
-					headerHeight -= HeaderView.View.Margin.VerticalThickness;
-				}
+		// 		// We only subtract the margin if it was explicitly set, otherwise we would be subtracting the safe area 
+		// 		// which is not accounted for in MeasuredHeaderViewHeightWithMargin
+		// 		if (!double.IsNaN(MeasuredHeaderViewHeightWithMargin) && HeaderView?.View.IsSet(View.MarginProperty) == true)
+		// 		{
+		// 			headerHeight -= HeaderView.View.Margin.VerticalThickness;
+		// 		}
 
-				return headerHeight;
-			}
-		}
+		// 		return headerHeight;
+		// 	}
+		// }
 
 		double HeaderMinimumHeight
 		{

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellFlyoutLayoutManager.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellFlyoutLayoutManager.cs
@@ -277,7 +277,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			if (HeaderView is not null && !double.IsNaN(ArrangedHeaderViewHeightWithMargin))
 			{
 				nfloat safeArea = 0;
-				if (!HeaderView.View.IsSet(View.MarginProperty))
+				if (ShouldHonorSafeArea(HeaderView.View))
 				{
 					// We add the safe area if margin is not explicitly set.
 					safeArea = UIApplication.SharedApplication.GetSafeAreaInsetsForWindow().Top;
@@ -306,8 +306,8 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 		{
 			double contentYOffset = 0;
 			
-			if (HeaderView?.View.IsSet(View.MarginProperty) == false || 
-				(HeaderView is null && Content?.IsSet(View.MarginProperty) == false))
+			if (ShouldHonorSafeArea(HeaderView.View) || 
+				(HeaderView is null && ShouldHonorSafeArea(Content)))
 			{
 				// We add the safe area if margin is not explicitly set. This matches the header behavior.
 				contentYOffset += (float)UIApplication.SharedApplication.GetSafeAreaInsetsForWindow().Top;
@@ -337,6 +337,13 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			{
 				(Content as IView)?.Arrange(contentFrame);
 			}
+		}
+
+		bool ShouldHonorSafeArea(View view)
+		{
+			return view != null 
+				&& !view.IsSet(View.MarginProperty) 
+				&& !(view is ISafeAreaView sav && sav.IgnoreSafeArea);
 		}
 		
 		void OnStructureChanged(object sender, EventArgs e) => UpdateVerticalScrollMode();

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellFlyoutLayoutManager.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellFlyoutLayoutManager.cs
@@ -206,7 +206,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 
 		internal void SetHeaderContentInset()
-				{
+		{
 			if (ScrollView is null)
 				return;
 

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellFlyoutLayoutManager.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellFlyoutLayoutManager.cs
@@ -269,13 +269,13 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 			LayoutContent(parent.Bounds, footerHeight);
 
-			if (HeaderView is not null && !double.IsNaN(ArrangedHeaderViewHeightWithMargin))
+			if (HeaderView is not null && !double.IsNaN(ArrangedHeaderViewHeightWithOutMargin))
 			{
-				HeaderView.Frame = new CGRect(0, _headerOffset + HeaderViewVerticalOffset, parent.Frame.Width, ArrangedHeaderViewHeightWithMargin);
+				HeaderView.Frame = new CGRect(0, _headerOffset + HeaderViewVerticalOffset, parent.Frame.Width, ArrangedHeaderViewHeightWithOutMargin);
 
 				if (_context.Shell.FlyoutHeaderBehavior == FlyoutHeaderBehavior.Scroll && HeaderViewVerticalOffset > 0 && _headerOffset < 0)
 				{
-					var headerHeight = Math.Max(HeaderMinimumHeight, ArrangedHeaderViewHeightWithMargin + _headerOffset);
+					var headerHeight = Math.Max(HeaderMinimumHeight, ArrangedHeaderViewHeightWithOutMargin + _headerOffset);
 					CAShapeLayer shapeLayer = new CAShapeLayer();
 					CGRect rect = new CGRect(0, _headerOffset * -1, parent.Frame.Width, headerHeight);
 					var path = CGPath.FromRect(rect);
@@ -378,12 +378,29 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			set
 			{
 				if (HeaderView is not null &&
-					HeaderView.Height != (value))
+					HeaderView.Height != value)
 				{
 					HeaderView.Height = value;
 				}
 
 				_headerSize = value;
+			}
+		}
+
+		double ArrangedHeaderViewHeightWithOutMargin
+		{
+			get
+			{
+				var headerHeight = ArrangedHeaderViewHeightWithMargin;
+
+				// We only subtract the margin if it was explicitly set, otherwise we would be subtracting the safe area 
+				// which is not accounted for in ArrangedHeaderViewHeightWithMargin
+				if (!double.IsNaN(ArrangedHeaderViewHeightWithMargin) && HeaderView?.View.IsSet(View.MarginProperty) == true)
+				{
+					headerHeight -= HeaderView.View.Margin.VerticalThickness;
+				}
+
+				return headerHeight;
 			}
 		}
 

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellFlyoutLayoutManager.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellFlyoutLayoutManager.cs
@@ -293,20 +293,20 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 		void LayoutContent(CGRect parentBounds, nfloat footerHeight)
 		{
 			// Initially we offset the content by the header's offset (which could include the safe area) + the calculated top margin for the content
-			var contentViewYOffset = HeaderViewVerticalOffset + ContentTopMargin;
+			var contentYOffset = HeaderViewVerticalOffset + ContentTopMargin;
 			if (Content?.IsSet(View.MarginProperty) == false && HeaderView is null)
 			{
 					// If HeaderView is null, we need add the SafeArea.Top explicitly. 
 					// We get this value through HeaderViewVerticalOffset when there is a HeaderView.
-					contentViewYOffset += (float)UIApplication.SharedApplication.GetSafeAreaInsetsForWindow().Top;
+					contentYOffset += (float)UIApplication.SharedApplication.GetSafeAreaInsetsForWindow().Top;
 			}
 
 			if (ScrollView is null)
 			{
-				contentViewYOffset += HeaderView?.Frame.Height ?? 0;
+				contentYOffset += HeaderView?.Frame.Height ?? 0;
 			}
 
-			var contentFrame = new Rect(parentBounds.X, contentViewYOffset, parentBounds.Width, parentBounds.Height - contentViewYOffset - footerHeight);
+			var contentFrame = new Rect(parentBounds.X, contentYOffset, parentBounds.Width, parentBounds.Height - contentYOffset - footerHeight);
 			if (Content is null)
 			{
 				ContentView.Frame = contentFrame.AsCGRect();

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellFlyoutLayoutManager.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellFlyoutLayoutManager.cs
@@ -130,7 +130,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 					ScrollView = sv;
 				else if (ContentView is IPlatformViewHandler ver && ver.PlatformView is UIScrollView uIScroll)
 					ScrollView = uIScroll;
-				else if (ContentView.Subviews.Length > 0 && ContentView.Subviews[0] is UICollectionView cv)
+				else if (Content is ItemsView && ContentView.Subviews.Length > 0 && ContentView.Subviews[0] is UICollectionView cv)
 					ScrollView = cv;
 
 				if (ScrollView is not null && (OperatingSystem.IsIOSVersionAtLeast(11) || OperatingSystem.IsMacCatalystVersionAtLeast(11)

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellFlyoutLayoutManager.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellFlyoutLayoutManager.cs
@@ -306,7 +306,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 		{
 			double contentYOffset = 0;
 			
-			if (ShouldHonorSafeArea(HeaderView.View) || 
+			if (ShouldHonorSafeArea(HeaderView?.View) || 
 				(HeaderView is null && ShouldHonorSafeArea(Content)))
 			{
 				// We add the safe area if margin is not explicitly set. This matches the header behavior.

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellFlyoutLayoutManager.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellFlyoutLayoutManager.cs
@@ -196,7 +196,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				return;
 
 			// If the HeaderView hasn't been measured we need to measure it
-			if (double.IsNaN(MeasuredHeaderViewHeightWithNoMargin))
+			if (double.IsNaN(MeasuredHeaderViewHeightWithMargin))
 			{
 				HeaderView.SizeThatFits(new CGSize(ContentView.Superview.Frame.Width, double.PositiveInfinity));
 			}
@@ -216,12 +216,12 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 			if (HeaderView is not null)
 			{
-				if (double.IsNaN(MeasuredHeaderViewHeightWithNoMargin))
+				if (double.IsNaN(MeasuredHeaderViewHeightWithMargin))
 				{
 					return;
 				}
 
-				ScrollView.ContentInset = new UIEdgeInsets((nfloat)(MeasuredHeaderViewHeightWithNoMargin), 0, 0, 0);
+				ScrollView.ContentInset = new UIEdgeInsets((nfloat)(MeasuredHeaderViewHeightWithMargin), 0, 0, 0);
 			}
 			else
 			{
@@ -300,13 +300,13 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				(Content as IView)?.Arrange(contentFrame);
 			}
 
-			if (HeaderView is not null && !double.IsNaN(ArrangedHeaderViewHeightWithNoMargin))
+			if (HeaderView is not null && !double.IsNaN(ArrangedHeaderViewHeightWithMargin))
 			{
-				HeaderView.Frame = new CGRect(0, _headerOffset + HeaderTopMargin, parent.Frame.Width, ArrangedHeaderViewHeightWithNoMargin);
+				HeaderView.Frame = new CGRect(0, _headerOffset + HeaderTopMargin, parent.Frame.Width, ArrangedHeaderViewHeightWithMargin);
 
 				if (_context.Shell.FlyoutHeaderBehavior == FlyoutHeaderBehavior.Scroll && HeaderTopMargin > 0 && _headerOffset < 0)
 				{
-					var headerHeight = Math.Max(HeaderMinimumHeight, ArrangedHeaderViewHeightWithNoMargin + _headerOffset + HeaderTopMargin);
+					var headerHeight = Math.Max(HeaderMinimumHeight, ArrangedHeaderViewHeightWithMargin + _headerOffset + HeaderTopMargin);
 					CAShapeLayer shapeLayer = new CAShapeLayer();
 					CGRect rect = new CGRect(0, _headerOffset * -1, parent.Frame.Width, headerHeight);
 					var path = CGPath.FromRect(rect);
@@ -345,13 +345,13 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			{
 				case FlyoutHeaderBehavior.Default:
 				case FlyoutHeaderBehavior.Fixed:
-					ArrangedHeaderViewHeightWithNoMargin = MeasuredHeaderViewHeightWithNoMargin;
+					ArrangedHeaderViewHeightWithMargin = MeasuredHeaderViewHeightWithMargin;
 					_headerOffset = 0;
 					break;
 
 				case FlyoutHeaderBehavior.Scroll:
-					ArrangedHeaderViewHeightWithNoMargin = MeasuredHeaderViewHeightWithNoMargin;
-					_headerOffset = Math.Min(0, -(MeasuredHeaderViewHeightWithNoMargin + contentOffsetY));
+					ArrangedHeaderViewHeightWithMargin = MeasuredHeaderViewHeightWithMargin;
+					_headerOffset = Math.Min(0, -(MeasuredHeaderViewHeightWithMargin + contentOffsetY));
 					break;
 
 				case FlyoutHeaderBehavior.CollapseOnScroll:
@@ -368,13 +368,13 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			if (HeaderView is not null)
 			{
 				if (ScrollView is not null && contentOffsetY is not null && _context.Shell.FlyoutHeaderBehavior == FlyoutHeaderBehavior.CollapseOnScroll)
-					ArrangedHeaderViewHeightWithNoMargin = Math.Max(HeaderMinimumHeight, -contentOffsetY.Value);
+					ArrangedHeaderViewHeightWithMargin = Math.Max(HeaderMinimumHeight, -contentOffsetY.Value);
 				else
-					ArrangedHeaderViewHeightWithNoMargin = MeasuredHeaderViewHeightWithNoMargin;
+					ArrangedHeaderViewHeightWithMargin = MeasuredHeaderViewHeightWithMargin;
 			}
 		}
 
-		double ArrangedHeaderViewHeightWithNoMargin
+		double ArrangedHeaderViewHeightWithMargin
 		{
 			get => _headerSize;
 			set
@@ -389,7 +389,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			}
 		}
 
-		double MeasuredHeaderViewHeightWithNoMargin =>
+		double MeasuredHeaderViewHeightWithMargin =>
 			HeaderView?.MeasuredHeight ?? 0;
 
 		double HeaderMinimumHeight

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellFlyoutLayoutManager.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellFlyoutLayoutManager.cs
@@ -277,11 +277,11 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				if (Content is null)
 				{
 					ContentView.Frame =
-							new CGRect(parent.Bounds.X, HeaderTopMargin, parent.Bounds.Width, parent.Bounds.Height - HeaderTopMargin - footerHeight);
+							new CGRect(parent.Bounds.X, ContentTopMargin, parent.Bounds.Width, parent.Bounds.Height - ContentTopMargin - footerHeight);
 				}
 				else
 				{
-					var contentFrame = new Rect(parent.Bounds.X, HeaderTopMargin, parent.Bounds.Width, parent.Bounds.Height - HeaderTopMargin - footerHeight);
+					var contentFrame = new Rect(parent.Bounds.X, ContentTopMargin, parent.Bounds.Width, parent.Bounds.Height - ContentTopMargin - footerHeight);
 					(Content as IView)?.Arrange(contentFrame);
 				}
 			}
@@ -294,7 +294,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 						topMargin = (float)UIApplication.SharedApplication.GetSafeAreaInsetsForWindow().Top;
 				}
 				else
-					contentViewYOffset -= (nfloat)HeaderTopMargin;
+					contentViewYOffset -= (nfloat)ContentTopMargin;
 
 				var contentFrame = new Rect(parent.Bounds.X, topMargin + contentViewYOffset, parent.Bounds.Width, parent.Bounds.Height - topMargin - footerHeight - contentViewYOffset);
 				(Content as IView)?.Arrange(contentFrame);
@@ -410,8 +410,9 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			}
 		}
 
-		double HeaderTopMargin => (HeaderView is not null) ?
-			HeaderView.Margin.Top - HeaderView.Margin.Bottom : 0;
+		double HeaderTopMargin => HeaderView?.Margin.Top ?? 0;
+
+		double ContentTopMargin => HeaderView?.Margin.Bottom ?? 0 + Content?.Margin.Top ?? 0;
 
 		public void TearDown()
 		{

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellFlyoutHeaderBehaviorAndContentTestCases.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellFlyoutHeaderBehaviorAndContentTestCases.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using Microsoft.Maui.Controls;
+using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.DeviceTests
 {
@@ -52,9 +53,9 @@ namespace Microsoft.Maui.DeviceTests
 			switch (name)
 			{
 				case "ScrollView":
-					return new ScrollView() { Content = new Label() { Text = "ScrollView" }, Margin = margin };
+					return new ScrollView() { Content = new Label() { Text = "ScrollView" }, Margin = margin, BackgroundColor = Colors.Orange };
 				case "VerticalStackLayout":
-					return new VerticalStackLayout() { Margin = margin, Children = { new Label() { Text = "VerticalStackLayout" } } };
+					return new VerticalStackLayout() { Margin = margin, Children = { new Label() { Text = "VerticalStackLayout" } }, BackgroundColor = Colors.Orange };
 			}
 
 			throw new ArgumentException(nameof(name));

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellFlyoutHeaderBehaviorAndContentTestCases.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellFlyoutHeaderBehaviorAndContentTestCases.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using Microsoft.Maui.Controls;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	public class ShellFlyoutHeaderBehaviorAndContentTestCases : IEnumerable<object[]>
+	{
+		public IEnumerator<object[]> GetEnumerator()
+		{
+			foreach (var behavior in Enum.GetValues(typeof(FlyoutHeaderBehavior)))
+			{
+				// FlyoutHeaderBehavior, content type, header margin top (null is safe area), header margin bottom, content margin top, content margin bottom
+				yield return new object[] { (FlyoutHeaderBehavior)behavior, "ScrollView", null, null, 0, 0 };
+				yield return new object[] { (FlyoutHeaderBehavior)behavior, "ScrollView", 10, 0, 0, 0 };
+				yield return new object[] { (FlyoutHeaderBehavior)behavior, "ScrollView", 10, 20, 0, 0 };
+				yield return new object[] { (FlyoutHeaderBehavior)behavior, "ScrollView", 0, 20, 0, 0 };
+				yield return new object[] { (FlyoutHeaderBehavior)behavior, "ScrollView", null, null, 30, 0 };
+				yield return new object[] { (FlyoutHeaderBehavior)behavior, "ScrollView", 10, 0, 30, 0 };
+				yield return new object[] { (FlyoutHeaderBehavior)behavior, "ScrollView", 10, 20, 30, 0 };
+				yield return new object[] { (FlyoutHeaderBehavior)behavior, "ScrollView", 0, 20, 30, 0 };
+				yield return new object[] { (FlyoutHeaderBehavior)behavior, "ScrollView", null, null, 0, 40 };
+				yield return new object[] { (FlyoutHeaderBehavior)behavior, "ScrollView", 10, 0, 0, 40 };
+				yield return new object[] { (FlyoutHeaderBehavior)behavior, "ScrollView", 10, 20, 0, 40 };
+				yield return new object[] { (FlyoutHeaderBehavior)behavior, "ScrollView", 0, 20, 0, 40 };
+				yield return new object[] { (FlyoutHeaderBehavior)behavior, "ScrollView", null, null, 30, 40 };
+				yield return new object[] { (FlyoutHeaderBehavior)behavior, "ScrollView", 10, 0, 30, 40 };
+				yield return new object[] { (FlyoutHeaderBehavior)behavior, "ScrollView", 10, 20, 30, 40 };
+				yield return new object[] { (FlyoutHeaderBehavior)behavior, "ScrollView", 0, 20, 30, 40 };
+				yield return new object[] { (FlyoutHeaderBehavior)behavior, "VerticalStackLayout", null, null, 0, 0 };
+				yield return new object[] { (FlyoutHeaderBehavior)behavior, "VerticalStackLayout", 10, 0, 0, 0 };
+				yield return new object[] { (FlyoutHeaderBehavior)behavior, "VerticalStackLayout", 10, 20, 0, 0 };
+				yield return new object[] { (FlyoutHeaderBehavior)behavior, "VerticalStackLayout", 0, 20, 0, 0 };
+				yield return new object[] { (FlyoutHeaderBehavior)behavior, "VerticalStackLayout", null, null, 30, 0 };
+				yield return new object[] { (FlyoutHeaderBehavior)behavior, "VerticalStackLayout", 10, 0, 30, 0 };
+				yield return new object[] { (FlyoutHeaderBehavior)behavior, "VerticalStackLayout", 10, 20, 30, 0 };
+				yield return new object[] { (FlyoutHeaderBehavior)behavior, "VerticalStackLayout", 0, 20, 30, 0 };
+				yield return new object[] { (FlyoutHeaderBehavior)behavior, "VerticalStackLayout", null, null, 0, 40 };
+				yield return new object[] { (FlyoutHeaderBehavior)behavior, "VerticalStackLayout", 10, 0, 0, 40 };
+				yield return new object[] { (FlyoutHeaderBehavior)behavior, "VerticalStackLayout", 10, 20, 0, 40 };
+				yield return new object[] { (FlyoutHeaderBehavior)behavior, "VerticalStackLayout", 0, 20, 0, 40 };
+				yield return new object[] { (FlyoutHeaderBehavior)behavior, "VerticalStackLayout", null, null, 30, 40 };
+				yield return new object[] { (FlyoutHeaderBehavior)behavior, "VerticalStackLayout", 10, 0, 30, 40 };
+				yield return new object[] { (FlyoutHeaderBehavior)behavior, "VerticalStackLayout", 10, 20, 30, 40 };
+				yield return new object[] { (FlyoutHeaderBehavior)behavior, "VerticalStackLayout", 0, 20, 30, 40 };
+			}
+		}
+
+		public static object GetFlyoutContentAction(string name, Thickness margin)
+		{
+			switch (name)
+			{
+				case "ScrollView":
+					return new ScrollView() { Content = new Label() { Text = "ScrollView" }, Margin = margin };
+				case "VerticalStackLayout":
+					return new VerticalStackLayout() { Margin = margin, Children = { new Label() { Text = "VerticalStackLayout" } } };
+			}
+
+			throw new ArgumentException(nameof(name));
+		}
+
+		IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+	}
+}

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellFlyoutHeaderScrollTestCases.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellFlyoutHeaderScrollTestCases.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Graphics;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	public class ShellFlyoutHeaderScrollTestCases : IEnumerable<object[]>
+	{
+		string[] ContentType = ["ShellItems", "CollectionView", "ScrollView"];
+
+		public IEnumerator<object[]> GetEnumerator()
+		{
+			foreach (var behavior in Enum.GetValues(typeof(FlyoutHeaderBehavior)))
+			{
+				foreach (var contentType in ContentType)
+				{
+					yield return new object[] { (FlyoutHeaderBehavior)behavior, contentType };
+				}
+			}
+		}
+
+		public static void SetFlyoutContent(string contentType, Shell shell)
+		{
+			switch (contentType)
+			{
+				case "ShellItems":
+					AddShellItems(shell);
+					break;
+				case "CollectionView":
+					AddCollectionView(shell);
+					break;
+				case "ScrollView":
+					AddScrollView(shell);
+					break;
+			}
+		}
+	
+		static void AddShellItems(Shell shell)
+		{
+			Enumerable.Range(0, 100)
+					.ForEach(i =>
+					{
+						shell.Items.Add(new FlyoutItem() { Title = $"FlyoutItem {i}", Items = { new ContentPage() } });
+					});
+		}
+
+		static void AddCollectionView(Shell shell)
+		{
+			shell.FlyoutContent = new CollectionView() 
+			{
+				ItemsSource = Enumerable.Range(0,100).ToList(),
+				BackgroundColor = Colors.Orange
+			};
+		}
+
+		static void AddScrollView(Shell shell)
+		{
+			var grid = new Grid
+			{
+				BackgroundColor = Colors.Orange
+			};
+
+			for (int i = 0; i < 100; i++)
+			{
+				var item = new Label() { Text = $"Item {i}" };
+				grid.RowDefinitions.Add(new RowDefinition() { Height = 40 });
+				grid.SetRow(item, i);
+				grid.Add(item);
+			}
+
+            shell.FlyoutContent = new ScrollView()
+			{
+				Content = grid
+			};
+		}
+	
+		IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+	}
+}

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellFlyoutTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellFlyoutTests.cs
@@ -2,8 +2,6 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
-using Microsoft.Maui.Graphics;
-using Microsoft.Maui.Platform;
 using Xunit;
 
 #if IOS
@@ -12,7 +10,12 @@ using UIKit;
 
 #if ANDROID || IOS || MACCATALYST
 using ShellHandler = Microsoft.Maui.Controls.Handlers.Compatibility.ShellRenderer;
+using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Platform;
+#else
+using Microsoft.Maui.Controls.Handlers;
 #endif
+
 
 namespace Microsoft.Maui.DeviceTests
 {

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellFlyoutTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellFlyoutTests.cs
@@ -320,7 +320,9 @@ namespace Microsoft.Maui.DeviceTests
 					
 					if (flyoutHeaderBehavior == FlyoutHeaderBehavior.Scroll)
 					{
-						Assert.True(scrolledBox.Y <= headerRequestedHeight * -1, $"Scrolled Header Position: {scrolledBox.Y} <= {scrolledBox.Height * -1}");
+						// scrolledBoy.Y is negative because the header is scrolled up
+						var diff = scrolledBox.Y + headerRequestedHeight;
+						Assert.True(diff <= 0.3, $"Scrolled Header Position: {scrolledBox.Y} <= {scrolledBox.Height * -1}");
 					}
 					else
 					{

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellFlyoutTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellFlyoutTests.cs
@@ -186,18 +186,33 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		[Theory]
-		[ClassData(typeof(ShellFlyoutHeaderBehaviorTestCases))]
-		public async Task FlyoutHeaderContentAndFooterAllMeasureCorrectly(FlyoutHeaderBehavior behavior)
+		[ClassData(typeof(ShellFlyoutHeaderBehaviorAndContentTestCases))]
+		public async Task FlyoutHeaderContentAndFooterAllMeasureCorrectly(
+			FlyoutHeaderBehavior behavior, 
+			string contentType, 
+			int? headerMarginTop, 
+			int? headerMarginBottom, 
+			int contentMarginTop, 
+			int contentMarginBottom)
 		{
 			// flyoutHeader.Margin.Top gets set to the SafeAreaPadding
 			// so we have to account for that in the default setup
+			var headerMargin = new Thickness(0, headerMarginTop ?? GetSafeArea().Top, 0, headerMarginBottom ?? 0);
+			var contentMargin = new Thickness(0, contentMarginTop, 0, contentMarginBottom);
 			var flyoutHeader = new Label() { Text = "Flyout Header" };
+
+			// If margin top is null we don't set anything so safe area is added automatically
+			if (headerMarginTop.HasValue)
+			{
+				flyoutHeader.Margin = headerMargin;
+			}
+
 			await RunShellTest(shell =>
 			{
 				shell.FlyoutHeader = flyoutHeader;
 				shell.FlyoutFooter = new Label() { Text = "Flyout Footer" };
-				shell.FlyoutContent = new VerticalStackLayout() { new Label() { Text = "Flyout Content" } };
 				shell.FlyoutHeaderBehavior = behavior;
+				shell.FlyoutContent = ShellFlyoutHeaderBehaviorAndContentTestCases.GetFlyoutContentAction(contentType, contentMargin);
 			},
 			async (shell, handler) =>
 			{
@@ -210,21 +225,27 @@ namespace Microsoft.Maui.DeviceTests
 
 				// validate header position
 				AssertionExtensions.CloseEnough(0, headerFrame.X, message: "Header X");
-				AssertionExtensions.CloseEnough(GetSafeArea().Top, headerFrame.Y, message: "Header Y");
+				AssertionExtensions.CloseEnough(headerMargin.Top, headerFrame.Y, message: "Header Y");
 				AssertionExtensions.CloseEnough(flyoutFrame.Width, headerFrame.Width, message: "Header Width");
 
 				// validate content position
+				var expectedContentY = headerMargin.Top + headerMargin.Bottom + contentMargin.Top;
+				if (contentType != "ScrollView")
+				{
+					expectedContentY += headerFrame.Height;
+				}
 				AssertionExtensions.CloseEnough(0, contentFrame.X, message: "Content X");
-				AssertionExtensions.CloseEnough(headerFrame.Height + GetSafeArea().Top, contentFrame.Y, epsilon: 0.5, message: "Content Y");
+				AssertionExtensions.CloseEnough(expectedContentY, contentFrame.Y, epsilon: 0.5, message: "Content Y");
 				AssertionExtensions.CloseEnough(flyoutFrame.Width, contentFrame.Width, message: "Content Width");
 
 				// validate footer position
+				var expectedFooterY = expectedContentY + contentMargin.Bottom + contentFrame.Height;
 				AssertionExtensions.CloseEnough(0, footerFrame.X, message: "Footer X");
-				AssertionExtensions.CloseEnough(headerFrame.Height + contentFrame.Height + GetSafeArea().Top, footerFrame.Y, epsilon: 0.5, message: "Footer Y");
+				AssertionExtensions.CloseEnough(expectedFooterY, footerFrame.Y, epsilon: 0.5, message: "Footer Y");
 				AssertionExtensions.CloseEnough(flyoutFrame.Width, footerFrame.Width, message: "Footer Width");
 
 				//All three views should measure to the height of the flyout
-				AssertionExtensions.CloseEnough(headerFrame.Height + contentFrame.Height + footerFrame.Height + GetSafeArea().Top, flyoutFrame.Height, epsilon: 0.5, message: "Total Height");
+				AssertionExtensions.CloseEnough(expectedFooterY + footerFrame.Height, flyoutFrame.Height, epsilon: 0.5, message: "Total Height");
 			});
 		}
 #endif

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellFlyoutTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellFlyoutTests.cs
@@ -197,7 +197,7 @@ namespace Microsoft.Maui.DeviceTests
 		{
 			// flyoutHeader.Margin.Top gets set to the SafeAreaPadding
 			// so we have to account for that in the default setup
-			var headerMargin = new Thickness(0, headerMarginTop ?? GetSafeArea().Top, 0, headerMarginBottom ?? 0);
+			var headerMargin = new Thickness(0, headerMarginTop ?? 0, 0, headerMarginBottom ?? 0);
 			var contentMargin = new Thickness(0, contentMarginTop, 0, contentMarginBottom);
 			var flyoutHeader = new Label() { Text = "Flyout Header" };
 
@@ -216,6 +216,11 @@ namespace Microsoft.Maui.DeviceTests
 			},
 			async (shell, handler) =>
 			{
+				if (!headerMarginTop.HasValue)
+				{
+					headerMargin.Top = GetSafeArea().Top;
+				}
+
 				await OpenFlyout(handler);
 
 				var flyoutFrame = GetFlyoutFrame(handler);

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellFlyoutTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellFlyoutTests.cs
@@ -273,7 +273,7 @@ namespace Microsoft.Maui.DeviceTests
 #endif
 #endif
 
-#if ANDROID
+#if ANDROID || IOS
 		[Fact]
 		public async Task FlyoutHeaderCollapsesOnScroll()
 		{

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellFlyoutTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellFlyoutTests.cs
@@ -9,6 +9,10 @@ using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Platform;
 using Xunit;
 
+#if IOS
+using UIKit;
+#endif
+
 #if ANDROID || IOS || MACCATALYST
 using ShellHandler = Microsoft.Maui.Controls.Handlers.Compatibility.ShellRenderer;
 #endif
@@ -199,7 +203,7 @@ namespace Microsoft.Maui.DeviceTests
 			// so we have to account for that in the default setup
 			var headerMargin = new Thickness(0, headerMarginTop ?? 0, 0, headerMarginBottom ?? 0);
 			var contentMargin = new Thickness(0, contentMarginTop, 0, contentMarginBottom);
-			var flyoutHeader = new Label() { Text = "Flyout Header" };
+			var flyoutHeader = new Label() { Text = "Flyout Header", BackgroundColor = Colors.AliceBlue };
 
 			// If margin top is null we don't set anything so safe area is added automatically
 			if (headerMarginTop.HasValue)
@@ -224,7 +228,7 @@ namespace Microsoft.Maui.DeviceTests
 				await OpenFlyout(handler);
 
 				var flyoutFrame = GetFlyoutFrame(handler);
-				var headerFrame = GetFrameRelativeToFlyout(handler, (IView)shell.FlyoutHeader);
+ 				var headerFrame = GetFrameRelativeToFlyout(handler, (IView)shell.FlyoutHeader);
 				var contentFrame = GetFrameRelativeToFlyout(handler, (IView)shell.FlyoutContent);
 				var footerFrame = GetFrameRelativeToFlyout(handler, (IView)shell.FlyoutFooter);
 
@@ -238,6 +242,13 @@ namespace Microsoft.Maui.DeviceTests
 				if (contentType != "ScrollView")
 				{
 					expectedContentY += headerFrame.Height;
+				}
+				else
+				{
+#if IOS
+					var scrollViewContentInsetTop = ((UIScrollView)((IView)shell.FlyoutContent).Handler.PlatformView).ContentInset.Top;
+					AssertionExtensions.CloseEnough(headerFrame.Height, scrollViewContentInsetTop, message: "Content ScrollView Inset Y");
+#endif
 				}
 				AssertionExtensions.CloseEnough(0, contentFrame.X, message: "Content X");
 				AssertionExtensions.CloseEnough(expectedContentY, contentFrame.Y, epsilon: 0.5, message: "Content Y");

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellFlyoutTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellFlyoutTests.cs
@@ -189,6 +189,8 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
+// Skipping this for Android because there is a bug with the footer. Fix coming in a separate PR.
+#if IOS
 		[Theory]
 		[ClassData(typeof(ShellFlyoutHeaderBehaviorAndContentTestCases))]
 		public async Task FlyoutHeaderContentAndFooterAllMeasureCorrectly(
@@ -268,6 +270,7 @@ namespace Microsoft.Maui.DeviceTests
 				AssertionExtensions.CloseEnough(expectedFooterY + footerFrame.Height, flyoutFrame.Height, epsilon: 0.5, message: "Total Height");
 			});
 		}
+#endif
 #endif
 
 #if ANDROID

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellFlyoutTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellFlyoutTests.cs
@@ -320,7 +320,7 @@ namespace Microsoft.Maui.DeviceTests
 					
 					if (flyoutHeaderBehavior == FlyoutHeaderBehavior.Scroll)
 					{
-						Assert.True(scrolledBox.Y <= scrolledBox.Height * -1, $"Scrolled Header Position: {scrolledBox.Y} <= {scrolledBox.Height * -1}");
+						Assert.True(scrolledBox.Y <= headerRequestedHeight * -1, $"Scrolled Header Position: {scrolledBox.Y} <= {scrolledBox.Height * -1}");
 					}
 					else
 					{

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellFlyoutTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellFlyoutTests.cs
@@ -322,7 +322,8 @@ namespace Microsoft.Maui.DeviceTests
 					{
 						// scrolledBoy.Y is negative because the header is scrolled up
 						var diff = scrolledBox.Y + headerRequestedHeight;
-						Assert.True(diff <= 0.3, $"Scrolled Header Position: {scrolledBox.Y} <= {scrolledBox.Height * -1}");
+						var epsilon = 0.3;
+						Assert.True(diff <= epsilon, $"Scrolled Header: position {scrolledBox.Y} is no enough to cover height ({scrolledBox.Height * -1}). Epsilon: {epsilon}");
 					}
 					else
 					{

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellFlyoutTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellFlyoutTests.cs
@@ -312,19 +312,19 @@ namespace Microsoft.Maui.DeviceTests
 
 				if (flyoutHeaderBehavior == FlyoutHeaderBehavior.CollapseOnScroll)
 				{
-					AssertionExtensions.CloseEnough(headerMinHeight, scrolledBox.Height, 0.3);
+					AssertionExtensions.CloseEnough(headerMinHeight, scrolledBox.Height, 0.3, "Collapsed Header Height");
 				}
 				else
 				{
-					AssertionExtensions.CloseEnough(headerRequestedHeight, scrolledBox.Height, 0.3);
+					AssertionExtensions.CloseEnough(headerRequestedHeight, scrolledBox.Height, 0.3, "Header Height");
 					
 					if (flyoutHeaderBehavior == FlyoutHeaderBehavior.Scroll)
 					{
-						Assert.True(scrolledBox.Y <= scrolledBox.Height * -1);
+						Assert.True(scrolledBox.Y <= scrolledBox.Height * -1, $"Scrolled Header Position: {scrolledBox.Y} <= {scrolledBox.Height * -1}");
 					}
 					else
 					{
-						AssertionExtensions.CloseEnough(GetSafeArea().Top, scrolledBox.Y, 0.3);
+						AssertionExtensions.CloseEnough(GetSafeArea().Top, scrolledBox.Y, 0.3, "Header position");
 					}
 				}
 			});

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellFlyoutTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellFlyoutTests.cs
@@ -234,22 +234,26 @@ namespace Microsoft.Maui.DeviceTests
 
 				// validate header position
 				AssertionExtensions.CloseEnough(0, headerFrame.X, message: "Header X");
-				AssertionExtensions.CloseEnough(headerMargin.Top, headerFrame.Y, message: "Header Y");
+				AssertionExtensions.CloseEnough(headerMargin.Top, headerFrame.Y, epsilon: 0.3, message: "Header Y");
 				AssertionExtensions.CloseEnough(flyoutFrame.Width, headerFrame.Width, message: "Header Width");
 
 				// validate content position
 				var expectedContentY = headerMargin.Top + headerMargin.Bottom + contentMargin.Top;
+
+#if IOS
 				if (contentType != "ScrollView")
+#endif
 				{
 					expectedContentY += headerFrame.Height;
 				}
+#if IOS
 				else
 				{
-#if IOS
 					var scrollViewContentInsetTop = ((UIScrollView)((IView)shell.FlyoutContent).Handler.PlatformView).ContentInset.Top;
 					AssertionExtensions.CloseEnough(headerFrame.Height, scrollViewContentInsetTop, message: "Content ScrollView Inset Y");
-#endif
 				}
+#endif
+
 				AssertionExtensions.CloseEnough(0, contentFrame.X, message: "Content X");
 				AssertionExtensions.CloseEnough(expectedContentY, contentFrame.Y, epsilon: 0.5, message: "Content Y");
 				AssertionExtensions.CloseEnough(flyoutFrame.Width, contentFrame.Width, message: "Content Width");

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellFlyoutTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellFlyoutTests.iOS.cs
@@ -1,0 +1,49 @@
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Platform.Compatibility;
+using Microsoft.Maui.Graphics;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	public partial class ShellTests : ControlsHandlerTestBase
+    {
+        [Theory]
+		[InlineData(0)]
+		[InlineData(100)]
+		public async Task FlyoutHeaderRendererDoesNotGoOverContent(int topMargin)
+		{
+			var flyoutItem = new FlyoutItem() { Items = { new ContentPage() } };
+			var flyoutItemGrid = new Grid();
+			var flyoutHeaderHeight = 250;
+			var layout = new Grid() { BackgroundColor = Colors.Pink, HeightRequest = flyoutHeaderHeight };
+			layout.Children.Add(new Button() { HorizontalOptions = LayoutOptions.Fill, VerticalOptions = LayoutOptions.Fill, BackgroundColor = Colors.Orange });
+			
+			if (topMargin > 0)
+			{
+				layout.Margin = new Thickness(0, topMargin, 0, 0);
+			}
+			
+			Shell.SetItemTemplate(flyoutItem, new DataTemplate(() => flyoutItemGrid));
+
+			await RunShellTest(shell =>
+			{
+				shell.FlyoutBehavior = FlyoutBehavior.Flyout;
+				shell.FlyoutHeader = layout;
+				shell.Items.Add(flyoutItem);
+			},
+			async (shell, handler) =>
+			{
+				await OpenFlyout(handler);
+                var flyout = GetFlyoutPlatformView(handler);
+				var header = flyout.Subviews.OfType<ShellFlyoutHeaderContainer>().First();
+
+				// The flyout header's height should be equal to the requested height + the top margin.
+				// The safe area should not be accounted for.
+				Assert.Equal(flyoutHeaderHeight + topMargin, header.Frame.Height);
+                Assert.Equal(topMargin > 0 ? topMargin : GetSafeArea().Top, header.Frame.Top);
+			});
+		}
+    }
+}

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellFlyoutTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellFlyoutTests.iOS.cs
@@ -12,17 +12,18 @@ namespace Microsoft.Maui.DeviceTests
     {
 #if !MACCATALYST
         [Theory]
+		[InlineData(null)]
 		[InlineData(0)]
 		[InlineData(100)]
-		public async Task FlyoutHeaderRendererHasTheRightHeight(int topMargin)
+		public async Task FlyoutHeaderRendererHasTheRightHeight(int? topMargin)
 		{
 			var flyoutHeaderHeight = 250;
 			var layout = new Grid() { HeightRequest = flyoutHeaderHeight };
 			layout.Children.Add(new Button() { HorizontalOptions = LayoutOptions.Fill, VerticalOptions = LayoutOptions.Fill });
 			
-			if (topMargin > 0)
+			if (topMargin is not null)
 			{
-				layout.Margin = new Thickness(0, topMargin, 0, 0);
+				layout.Margin = new Thickness(0, topMargin.Value, 0, 0);
 			}
 
 			await RunShellTest(shell =>
@@ -39,8 +40,7 @@ namespace Microsoft.Maui.DeviceTests
 
 				// The flyout header's height should be equal to the requested height + the top margin.
 				// The safe area should not be accounted for.
-				Assert.Equal(flyoutHeaderHeight + topMargin, header.Frame.Height);
-                Assert.Equal(topMargin > 0 ? topMargin : GetSafeArea().Top, header.Frame.Top);
+				Assert.Equal(flyoutHeaderHeight + (topMargin ?? 0), header.Frame.Height);
 			});
 		}
 #endif

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellFlyoutTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellFlyoutTests.iOS.cs
@@ -14,26 +14,22 @@ namespace Microsoft.Maui.DeviceTests
         [Theory]
 		[InlineData(0)]
 		[InlineData(100)]
-		public async Task FlyoutHeaderRendererDoesNotGoOverContent(int topMargin)
+		public async Task FlyoutHeaderRendererHasTheRightHeight(int topMargin)
 		{
-			var flyoutItem = new FlyoutItem() { Items = { new ContentPage() } };
-			var flyoutItemGrid = new Grid();
 			var flyoutHeaderHeight = 250;
-			var layout = new Grid() { BackgroundColor = Colors.Pink, HeightRequest = flyoutHeaderHeight };
-			layout.Children.Add(new Button() { HorizontalOptions = LayoutOptions.Fill, VerticalOptions = LayoutOptions.Fill, BackgroundColor = Colors.Orange });
+			var layout = new Grid() { HeightRequest = flyoutHeaderHeight };
+			layout.Children.Add(new Button() { HorizontalOptions = LayoutOptions.Fill, VerticalOptions = LayoutOptions.Fill });
 			
 			if (topMargin > 0)
 			{
 				layout.Margin = new Thickness(0, topMargin, 0, 0);
 			}
-			
-			Shell.SetItemTemplate(flyoutItem, new DataTemplate(() => flyoutItemGrid));
 
 			await RunShellTest(shell =>
 			{
 				shell.FlyoutBehavior = FlyoutBehavior.Flyout;
 				shell.FlyoutHeader = layout;
-				shell.Items.Add(flyoutItem);
+				shell.FlyoutContent = new ScrollView() { Content = new Label() { Text = "FlyoutContent" } };
 			},
 			async (shell, handler) =>
 			{

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellFlyoutTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellFlyoutTests.iOS.cs
@@ -7,8 +7,10 @@ using Xunit;
 
 namespace Microsoft.Maui.DeviceTests
 {
-	public partial class ShellTests : ControlsHandlerTestBase
+	[Category(TestCategory.Shell)]
+	public partial class ShellTests
     {
+#if !MACCATALYST
         [Theory]
 		[InlineData(0)]
 		[InlineData(100)]
@@ -45,5 +47,6 @@ namespace Microsoft.Maui.DeviceTests
                 Assert.Equal(topMargin > 0 ? topMargin : GetSafeArea().Top, header.Frame.Top);
 			});
 		}
+#endif
     }
 }

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.Android.cs
@@ -1,13 +1,13 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Android.Views;
 using AndroidX.AppCompat.Widget;
 using AndroidX.CoordinatorLayout.Widget;
 using AndroidX.Core.View;
+using AndroidX.Core.Widget;
 using AndroidX.DrawerLayout.Widget;
+using AndroidX.RecyclerView.Widget;
 using AndroidX.ViewPager2.Widget;
 using Google.Android.Material.AppBar;
 using Google.Android.Material.BottomNavigation;
@@ -16,7 +16,6 @@ using Microsoft.Maui.Controls.Handlers.Compatibility;
 using Microsoft.Maui.Controls.Platform;
 using Microsoft.Maui.Controls.Platform.Compatibility;
 using Microsoft.Maui.DeviceTests.Stubs;
-using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Platform;
 using Xunit;
@@ -415,10 +414,29 @@ namespace Microsoft.Maui.DeviceTests
 			}
 		}
 
-		protected async Task ScrollFlyoutToBottom(ShellRenderer shellRenderer)
+		protected async Task<double> ScrollFlyoutToBottom(ShellRenderer shellRenderer)
 		{
-			var flyoutItems = GetFlyoutMenuReyclerView(shellRenderer);
+			IShellContext shellContext = shellRenderer;
+			DrawerLayout dl = shellContext.CurrentDrawerLayout;
+			var viewGroup = dl.GetChildAt(1) as ViewGroup;
+			var scrollView = viewGroup?.GetChildAt(0);
 
+			if (scrollView is RecyclerView rv)
+			{
+				return await ScrollRecyclerViewToBottom(rv);
+			}
+			else if (scrollView is MauiScrollView mauisv)
+			{
+				return await ScrollMauiScrollViewToBottom(mauisv);
+			}
+			else
+			{
+				throw new Exception("RecyclerView or MauiScrollView not found");
+			}
+		}
+
+		async Task<double> ScrollRecyclerViewToBottom(RecyclerView flyoutItems)
+		{
 			TaskCompletionSource<object> result = new TaskCompletionSource<object>();
 			flyoutItems.ScrollChange += OnFlyoutItemsScrollChange;
 			flyoutItems.ScrollToPosition(flyoutItems.GetAdapter().ItemCount - 1);
@@ -444,6 +462,39 @@ namespace Microsoft.Maui.DeviceTests
 			var verticalOffset = flyoutItems.ComputeVerticalScrollOffset();
 			behavior.OnNestedPreScroll(coordinatorLayout, appbarLayout, flyoutItems, 0, verticalOffset, new int[2], ViewCompat.TypeTouch);
 			await Task.Delay(10);
+
+			return verticalOffset;
+		}
+
+		async Task<double> ScrollMauiScrollViewToBottom(MauiScrollView flyoutItems)
+		{
+			TaskCompletionSource<object> result = new TaskCompletionSource<object>();
+			flyoutItems.ScrollChange +=	OnFlyoutItemsScrollChange;
+			flyoutItems.ScrollTo(0, flyoutItems.Height);
+			await result.Task.WaitAsync(TimeSpan.FromSeconds(2));
+			await Task.Delay(10);
+
+			void OnFlyoutItemsScrollChange(object sender, NestedScrollView.ScrollChangeEventArgs e)
+			{
+				flyoutItems.ScrollChange -= OnFlyoutItemsScrollChange;
+				result.TrySetResult(true);
+			}
+
+			// The appbar layout won't offset if you programmatically scroll the RecyclerView
+			// I haven't found a way to match the exact behavior when you touch and scroll
+			// I think we'd have to actually send touch events through adb
+
+			var coordinatorLayout = flyoutItems.Parent.GetParentOfType<CoordinatorLayout>();
+			var appbarLayout = coordinatorLayout.GetFirstChildOfType<AppBarLayout>();
+			var clLayoutParams = appbarLayout.LayoutParameters as CoordinatorLayout.LayoutParams;
+			var behavior = clLayoutParams.Behavior as AppBarLayout.Behavior;
+			var headerContainer = appbarLayout.GetFirstChildOfType<HeaderContainer>();
+
+			var verticalOffset = flyoutItems.ComputeVerticalScrollOffset();
+			behavior.OnNestedPreScroll(coordinatorLayout, appbarLayout, flyoutItems, 0, verticalOffset, new int[2], ViewCompat.TypeTouch);
+			await Task.Delay(10);
+
+			return verticalOffset;
 		}
 
 		ShellFlyoutRenderer GetDrawerLayout(ShellRenderer shellRenderer)
@@ -452,16 +503,19 @@ namespace Microsoft.Maui.DeviceTests
 			return (ShellFlyoutRenderer)shellContext.CurrentDrawerLayout;
 		}
 
-		RecyclerViewContainer GetFlyoutMenuReyclerView(ShellRenderer shellRenderer)
+		RecyclerView GetFlyoutMenuReyclerView(ShellRenderer shellRenderer)
 		{
 			IShellContext shellContext = shellRenderer;
 			DrawerLayout dl = shellContext.CurrentDrawerLayout;
 
 			var flyout = dl.GetChildAt(0);
-			RecyclerViewContainer flyoutContainer = null;
+			RecyclerView flyoutContainer = null;
 
+			var ViewGroup = dl.GetChildAt(1) as ViewGroup;
+			var rc = ViewGroup.GetChildAt(0) as RecyclerView;
+			
 			if (dl.GetChildAt(1) is ViewGroup vg1 &&
-				vg1.GetChildAt(0) is RecyclerViewContainer rvc)
+				vg1.GetChildAt(0) is RecyclerView rvc)
 			{
 				flyoutContainer = rvc;
 			}

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.Android.cs
@@ -469,7 +469,7 @@ namespace Microsoft.Maui.DeviceTests
 		async Task<double> ScrollMauiScrollViewToBottom(MauiScrollView flyoutItems)
 		{
 			TaskCompletionSource<object> result = new TaskCompletionSource<object>();
-			flyoutItems.ScrollChange +=	OnFlyoutItemsScrollChange;
+			flyoutItems.ScrollChange += OnFlyoutItemsScrollChange;
 			flyoutItems.ScrollTo(0, flyoutItems.Height);
 			await result.Task.WaitAsync(TimeSpan.FromSeconds(2));
 			await Task.Delay(10);

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.iOS.cs
@@ -323,15 +323,17 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 
-		protected async Task ScrollFlyoutToBottom(ShellRenderer shellRenderer)
+		protected async Task<double> ScrollFlyoutToBottom(ShellHandler shellHandler)
 		{
-			var platformView = GetFlyoutPlatformView(shellRenderer);
-			var tableView = platformView.FindDescendantView<UITableView>();
-			var bottomOffset = new CGPoint(0, tableView.ContentSize.Height - tableView.Bounds.Height + tableView.ContentInset.Bottom);
-			tableView.SetContentOffset(bottomOffset, false);
-			await Task.Delay(1);
+			var platformView = GetFlyoutPlatformView(shellHandler);
+			var scrollView = platformView.FindDescendantView<UIScrollView>();
+			var bottomOffset = new CGPoint(0, scrollView.ContentSize.Height - scrollView.Bounds.Height + scrollView.ContentInset.Bottom);
+			
+			scrollView.SetContentOffset(bottomOffset, false);
+			
+			await Task.Delay(10);
 
-			return;
+			return bottomOffset.Y;
 		}
 #if IOS
 		[Fact(DisplayName = "Back Button Text Has Correct Default")]

--- a/src/TestUtils/src/DeviceTests.Runners/VisualRunner/ViewModels/TestAssemblyViewModel.cs
+++ b/src/TestUtils/src/DeviceTests.Runners/VisualRunner/ViewModels/TestAssemblyViewModel.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Maui.TestUtils.DeviceTests.Runners.VisualRunner
 		TestState _result;
 		TestState _resultFilter;
 		RunStatus _runStatus;
-		string? _searchQuery;
+		string? _searchQuery = "FlyoutHeaderContentAndFooterAllMeasureCorrectly";
 
 		string? _detailText;
 		string? _displayName;

--- a/src/TestUtils/src/DeviceTests.Runners/VisualRunner/ViewModels/TestAssemblyViewModel.cs
+++ b/src/TestUtils/src/DeviceTests.Runners/VisualRunner/ViewModels/TestAssemblyViewModel.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Maui.TestUtils.DeviceTests.Runners.VisualRunner
 		TestState _result;
 		TestState _resultFilter;
 		RunStatus _runStatus;
-		string? _searchQuery = "FlyoutHeaderContentAndFooterAllMeasureCorrectly";
+		string? _searchQuery;
 
 		string? _detailText;
 		string? _displayName;


### PR DESCRIPTION
### Description of Change

This was initially motivated by https://github.com/dotnet/maui/issues/17965, but expanding our tests I found many other issues.

Most of those were related to the usage of properties that were assumed to not include margin or safe area, but they actually did.

Changes:
- Both properties initially named `MeasuredHeaderViewHeightWithNoMargin` and `ArrangedHeaderViewHeightWithNoMargin` did include margin values, so those were renamed to `MeasuredHeaderViewHeightWithMargin` and `ArrangedHeaderViewHeightWithMargin`.
- `HeaderTopMargin` was wrongly assumed to be just top margin. If margin was not explicitly set, it represented the top safe area. This made us account for the safe area in cases were it shouldn't be accounted for.
- The ScrollView content inset was not considering `HeaderMinimumHeight`, so the content was ending up under the header in scenarios where the measured height was smaller than the minimum height.
- Layout header: all the changes are around not adding margin in either the height or Y offset of the HeaderView Frame to avoid accounting for it twice. For the Y offset it is already handled by MAUI's layout system based on the subviews.
- Layout content: similar to the header, we were accounting for maring twice. 
- Fixed SafeArea.Bottom value for the header, which should be 0 (instead of SafeArea.Left) since the header doesn't need to consider it.
- The MAUI `CollectionView` platform view was not found so all the calculations around `ScrollView` were ignored (i.e., content inset, collapsing header, etc.). Its platform view is not a `UIScrollView` directly, but instead `UICollectionViewControllerWrapperView -> Subviews -> UICollectionView`.
- For `CollectionView` we need to fix up the offset when scrolling, because we expect the offset to be declared in the same way as `ScrollView.ScrollY`, which is a negative offset based on the header height (relative to its Y position value).

Also expanded `FlyoutHeaderContentAndFooterAllMeasureCorrectly` Controls.DeviceTest to include scenarios with different margin settings and ScrollView. All these new combinations added over 100 test cases.

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/17965

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
