### PR TITLE
[Testing] Add swipe gestures methods to UITest

### DIFF
--- a/src/Controls/samples/Controls.Sample.UITests/CoreViews/CorePageView.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/CoreViews/CorePageView.cs
@@ -71,6 +71,7 @@ namespace Maui.Controls.Sample
 			new GalleryPageFactory(() => new SliderCoreGalleryPage(), "Slider Gallery"),
 			new GalleryPageFactory(() => new StepperCoreGalleryPage(), "Stepper Gallery"),
 			new GalleryPageFactory(() => new SwitchCoreGalleryPage(), "Switch Gallery"),
+			new GalleryPageFactory(() => new SwipeViewCoreGalleryPage(), "SwipeView Gallery"),
 			new GalleryPageFactory(() => new TimePickerCoreGalleryPage(), "Time Picker Gallery"),
 			new GalleryPageFactory(() => new WebViewCoreGalleryPage(), "WebView Gallery"),
 		};

--- a/src/Controls/samples/Controls.Sample.UITests/Elements/SwipeViewCoreGalleryPage.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/Elements/SwipeViewCoreGalleryPage.cs
@@ -1,0 +1,128 @@
+﻿using Microsoft.Maui;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Graphics;
+
+namespace Maui.Controls.Sample
+{
+	public class SwipeViewCoreGalleryPage : ContentPage
+	{
+		const string SwipeViewToRightId = "SwipeViewToRightId";
+		const string ResultToRightId = "ResultToRightId";
+		const string SwipeViewToLeftId = "SwipeViewToLeftId";
+		const string ResultToLeftId = "ResultToLeftId";
+
+		public SwipeViewCoreGalleryPage()
+		{
+			Title = "Issue 12079";
+
+			var layout = new StackLayout
+			{
+				Margin = new Thickness(12)
+			};
+
+			var swipeItemToRight = new SwipeItem
+			{
+				BackgroundColor = Colors.Red,
+				Text = "SwipeItem",
+			};
+
+			swipeItemToRight.Invoked += (sender, e) =>
+			{
+				DisplayAlert("SwipeView", "Invoked", "Ok");
+			};
+
+			var swipeToRightItems = new SwipeItems { swipeItemToRight };
+
+			swipeToRightItems.Mode = SwipeMode.Reveal;
+
+			var swipeToRightContent = new Grid
+			{
+				BackgroundColor = Colors.Gray
+			};
+
+			var swipeToRightLabel = new Label
+			{
+				HorizontalOptions = LayoutOptions.Center,
+				VerticalOptions = LayoutOptions.Center,
+				Text = "Swipe to Right"
+			};
+
+			swipeToRightContent.Children.Add(swipeToRightLabel);
+
+			var swipeToRightView = new SwipeView
+			{
+				AutomationId = SwipeViewToRightId,
+				HeightRequest = 60,
+				WidthRequest = 300,
+				LeftItems = swipeToRightItems,
+				Content = swipeToRightContent
+			};
+
+			var resultToRight = new Label
+			{
+				AutomationId = ResultToRightId
+			};
+
+			swipeToRightView.SwipeEnded += (sender, args) =>
+			{
+				resultToRight.Text = "Success";
+			};
+
+			var swipeItemToLeft = new SwipeItem
+			{
+				BackgroundColor = Colors.Green,
+				Text = "SwipeItem",
+			};
+
+			swipeItemToLeft.Invoked += (sender, e) =>
+			{
+				DisplayAlert("SwipeView", "Invoked", "Ok");
+			};
+
+			var swipeToLeftItems = new SwipeItems { swipeItemToLeft };
+
+			swipeToLeftItems.Mode = SwipeMode.Reveal;
+
+			var swipeToLeftContent = new Grid
+			{
+				BackgroundColor = Colors.Gray
+			};
+
+			var swipeToLeftLabel = new Label
+			{
+				HorizontalOptions = LayoutOptions.Center,
+				VerticalOptions = LayoutOptions.Center,
+				Text = "Swipe to Left"
+			};
+
+			swipeToLeftContent.Children.Add(swipeToLeftLabel);
+
+			var swipeToLeftView = new SwipeView
+			{
+				AutomationId = SwipeViewToLeftId,
+				HeightRequest = 60,
+				WidthRequest = 300,
+				RightItems = swipeToLeftItems,
+				Content = swipeToLeftContent
+			};
+
+			var resultToLeft = new Label
+			{
+				AutomationId = ResultToLeftId
+			};
+
+			swipeToLeftView.SwipeEnded += (sender, args) =>
+			{
+				resultToLeft.Text = "Success";
+			};
+
+			layout.Children.Add(swipeToRightView);
+			layout.Children.Add(resultToRight);
+
+			layout.Children.Add(swipeToLeftView);
+			layout.Children.Add(resultToLeft);
+
+			Content = layout;
+		}
+	}
+}

--- a/src/Controls/tests/UITests/Tests/SwipeViewUITests.cs
+++ b/src/Controls/tests/UITests/Tests/SwipeViewUITests.cs
@@ -1,0 +1,63 @@
+﻿using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.AppiumTests
+{
+	public class SwipeViewUITests : UITest
+	{
+		const string ScrollViewGallery = "SwipeView Gallery";
+
+		const string SwipeViewToRightId = "SwipeViewToRightId";
+		const string ResultToRightId = "ResultToRightId";
+		const string SwipeViewToLeftId = "SwipeViewToLeftId";
+		const string ResultToLeftId = "ResultToLeftId";
+
+		public SwipeViewUITests(TestDevice device)
+			: base(device)
+		{
+		}
+
+		protected override void FixtureSetup()
+		{
+			base.FixtureSetup();
+			App.NavigateToGallery(ScrollViewGallery);
+		}
+
+		protected override void FixtureTeardown()
+		{
+			base.FixtureTeardown();
+			this.Back();
+		}
+
+		[Test]
+		[Description("Swipe to right the SwipeView")]
+		public void SwipeToRight()
+		{
+			// 1. Open the SwipeView using a gesture.
+			App.WaitForElement(SwipeViewToRightId);
+			App.SwipeLeftToRight(SwipeViewToRightId);
+
+			// 2. Check if the SwipeView has been opened correctly.
+			var result = App.FindElement(ResultToRightId).GetText();
+			Assert.AreEqual("Success", result);
+
+			App.Screenshot("The SwipeView is Open");
+		}
+
+		[Test]
+		[Description("Swipe to left the SwipeView")]
+		public void SwipeToLeft()
+		{
+			// 1. Open the SwipeView using a gesture.
+			App.WaitForElement(SwipeViewToLeftId);
+			App.SwipeRightToLeft(SwipeViewToLeftId);
+
+			// 2. Check if the SwipeView has been opened correctly.
+			var result = App.FindElement(ResultToLeftId).GetText();
+			Assert.AreEqual("Success", result);
+
+			App.Screenshot("The SwipeView is Open");
+		}
+	}
+}

--- a/src/Controls/tests/UITests/Tests/SwipeViewUITests.cs
+++ b/src/Controls/tests/UITests/Tests/SwipeViewUITests.cs
@@ -34,6 +34,8 @@ namespace Microsoft.Maui.AppiumTests
 		[Description("Swipe to right the SwipeView")]
 		public void SwipeToRight()
 		{
+			this.IgnoreIfPlatforms(new TestDevice[] { TestDevice.Mac, TestDevice.Windows });
+
 			// 1. Open the SwipeView using a gesture.
 			App.WaitForElement(SwipeViewToRightId);
 			App.SwipeLeftToRight(SwipeViewToRightId);
@@ -49,6 +51,8 @@ namespace Microsoft.Maui.AppiumTests
 		[Description("Swipe to left the SwipeView")]
 		public void SwipeToLeft()
 		{
+			this.IgnoreIfPlatforms(new TestDevice[] { TestDevice.Mac, TestDevice.Windows });
+
 			// 1. Open the SwipeView using a gesture.
 			App.WaitForElement(SwipeViewToLeftId);
 			App.SwipeRightToLeft(SwipeViewToLeftId);

--- a/src/TestUtils/src/UITest.Appium/Actions/AppiumSwipeActions.cs
+++ b/src/TestUtils/src/UITest.Appium/Actions/AppiumSwipeActions.cs
@@ -39,7 +39,9 @@ namespace UITest.Appium
 
 		CommandResponse SwipeLeftToRight(IDictionary<string, object> parameters)
 		{
-			var element = GetAppiumElement(parameters["element"]);
+			parameters.TryGetValue("element", out var value);
+			var element = GetAppiumElement(value);
+
 			double swipePercentage = (double)parameters["swipePercentage"];
 			int swipeSpeed = (int)parameters["swipeSpeed"];
 			bool withInertia = (bool)parameters["withInertia"];
@@ -51,7 +53,9 @@ namespace UITest.Appium
 
 		CommandResponse SwipeRightToLeft(IDictionary<string, object> parameters)
 		{
-			var element = GetAppiumElement(parameters["element"]);
+			parameters.TryGetValue("element", out var value);
+			var element = GetAppiumElement(value);
+
 			double swipePercentage = (double)parameters["swipePercentage"];
 			int swipeSpeed = (int)parameters["swipeSpeed"];
 			bool withInertia = (bool)parameters["withInertia"];
@@ -61,7 +65,7 @@ namespace UITest.Appium
 			return CommandResponse.SuccessEmptyResponse;
 		}
 
-		static AppiumElement? GetAppiumElement(object element)
+		static AppiumElement? GetAppiumElement(object? element)
 		{
 			if (element is AppiumElement appiumElement)
 			{

--- a/src/TestUtils/src/UITest.Appium/Actions/AppiumSwipeActions.cs
+++ b/src/TestUtils/src/UITest.Appium/Actions/AppiumSwipeActions.cs
@@ -1,0 +1,116 @@
+﻿using OpenQA.Selenium.Appium;
+using OpenQA.Selenium.Appium.MultiTouch;
+using UITest.Core;
+
+namespace UITest.Appium
+{
+	public class AppiumSwipeActions : ICommandExecutionGroup
+	{
+		const string SwipeLeftToRightCommand = "swipeLeftToRight";
+		const string SwipeRightToLeftCommand = "swipeRightToLeft";
+
+		protected readonly AppiumApp _app;
+
+		readonly List<string> _commands = new()
+		{
+			SwipeLeftToRightCommand,
+			SwipeRightToLeftCommand
+		};
+
+		public AppiumSwipeActions(AppiumApp app)
+		{
+			_app = app;
+		}
+
+		public bool IsCommandSupported(string commandName)
+		{
+			return _commands.Contains(commandName, StringComparer.OrdinalIgnoreCase);
+		}
+
+		public CommandResponse Execute(string commandName, IDictionary<string, object> parameters)
+		{
+			return commandName switch
+			{
+				SwipeLeftToRightCommand => SwipeLeftToRight(parameters),
+				SwipeRightToLeftCommand => SwipeRightToLeft(parameters),
+				_ => CommandResponse.FailedEmptyResponse,
+			};
+		}
+
+		CommandResponse SwipeLeftToRight(IDictionary<string, object> parameters)
+		{
+			var element = GetAppiumElement(parameters["element"]);
+			double swipePercentage = (double)parameters["swipePercentage"];
+			int swipeSpeed = (int)parameters["swipeSpeed"];
+			bool withInertia = (bool)parameters["withInertia"];
+
+			SwipeToRight(_app.Driver, element, swipePercentage, swipeSpeed, withInertia);
+
+			return CommandResponse.SuccessEmptyResponse;
+		}
+
+		CommandResponse SwipeRightToLeft(IDictionary<string, object> parameters)
+		{
+			var element = GetAppiumElement(parameters["element"]);
+			double swipePercentage = (double)parameters["swipePercentage"];
+			int swipeSpeed = (int)parameters["swipeSpeed"];
+			bool withInertia = (bool)parameters["withInertia"];
+
+			SwipeToLeft(_app.Driver, element, swipePercentage, swipeSpeed, withInertia);
+
+			return CommandResponse.SuccessEmptyResponse;
+		}
+
+		static AppiumElement? GetAppiumElement(object element)
+		{
+			if (element is AppiumElement appiumElement)
+			{
+				return appiumElement;
+			}
+			else if (element is AppiumDriverElement driverElement)
+			{
+				return driverElement.AppiumElement;
+			}
+
+			return null;
+		}
+
+		static void SwipeToRight(AppiumDriver driver, AppiumElement? element, double swipePercentage, int swipeSpeed, bool withInertia = true)
+		{
+			var position = element is not null ? element.Location : System.Drawing.Point.Empty;
+			var size = element is not null ? element.Size : driver.Manage().Window.Size;
+
+			int startX = (int)(position.X + (size.Width * 0.05));
+			int startY = position.Y + size.Height / 2;
+
+			int endX = (int)(position.X + (size.Width * swipePercentage));
+			int endY = startY;
+
+			new TouchAction(driver)
+				.Press(startX, startY)
+				.Wait(swipeSpeed)
+				.MoveTo(endX, endY)
+				.Release()
+				.Perform();
+		}
+
+		static void SwipeToLeft(AppiumDriver driver, AppiumElement? element, double swipePercentage, int swipeSpeed, bool withInertia = true)
+		{
+			var position = element is not null ? element.Location : System.Drawing.Point.Empty;
+			var size = element is not null ? element.Size : driver.Manage().Window.Size;
+
+			int startX = (int)(position.X + (size.Width * swipePercentage));
+			int startY = position.Y + size.Height / 2;
+			
+			int endX = (int)(position.X + (size.Width * 0.05));	
+			int endY = startY;
+
+			new TouchAction(driver)
+				.Press(startX, startY)
+				.Wait(swipeSpeed)
+				.MoveTo(endX, endY)
+				.Release()
+				.Perform();
+		}
+	}
+}

--- a/src/TestUtils/src/UITest.Appium/AppiumApp.cs
+++ b/src/TestUtils/src/UITest.Appium/AppiumApp.cs
@@ -21,6 +21,7 @@ namespace UITest.Appium
 			_commandExecutor.AddCommandGroup(new AppiumTextActions());
 			_commandExecutor.AddCommandGroup(new AppiumGeneralActions());
 			_commandExecutor.AddCommandGroup(new AppiumVirtualKeyboardActions(this));
+			_commandExecutor.AddCommandGroup(new AppiumSwipeActions(this));
 		}
 
 		public abstract ApplicationState AppState { get; }

--- a/src/TestUtils/src/UITest.Appium/HelperExtensions.cs
+++ b/src/TestUtils/src/UITest.Appium/HelperExtensions.cs
@@ -175,7 +175,25 @@ namespace UITest.Appium
 		}
 
 		/// <summary>
-		/// 
+		/// Performs a left to right swipe gesture on the screen. 
+		/// </summary>
+		/// <param name="app">Represents the main gateway to interact with an app.</param>
+		/// <param name="swipePercentage">How far across the element to swipe (from 0.0 to 1.0).</param>
+		/// <param name="swipeSpeed">The speed of the gesture.</param>
+		/// <param name="withInertia">Whether swipes should cause inertia.</param>
+		public static void SwipeLeftToRight(this IApp app, double swipePercentage = 0.67, int swipeSpeed = 500, bool withInertia = true)
+		{
+			app.CommandExecutor.Execute("swipeLeftToRight", new Dictionary<string, object>
+			{
+				{ "swipePercentage", swipePercentage },
+				{ "swipeSpeed", swipeSpeed },
+				{ "withInertia", withInertia }
+			});
+		}
+
+		/// <summary>
+		/// Performs a left to right swipe gesture on the matching element. 
+		/// If multiple elements are matched, the first one will be used.
 		/// </summary>
 		/// <param name="app">Represents the main gateway to interact with an app.</param>
 		/// <param name="marked">Marked selector to match.</param>
@@ -189,6 +207,23 @@ namespace UITest.Appium
 			app.CommandExecutor.Execute("swipeLeftToRight", new Dictionary<string, object>
 			{
 				{ "element", elementToSwipe},
+				{ "swipePercentage", swipePercentage },
+				{ "swipeSpeed", swipeSpeed },
+				{ "withInertia", withInertia }
+			});
+		}
+
+		/// <summary>
+		///  Performs a right to left swipe gesture on the screen. 
+		/// </summary>
+		/// <param name="app">Represents the main gateway to interact with an app.</param>
+		/// <param name="swipePercentage">How far across the element to swipe (from 0.0 to 1.0).</param>
+		/// <param name="swipeSpeed">The speed of the gesture.</param>
+		/// <param name="withInertia">Whether swipes should cause inertia.</param>
+		public static void SwipeRightToLeft(this IApp app, double swipePercentage = 0.67, int swipeSpeed = 500, bool withInertia = true)
+		{
+			app.CommandExecutor.Execute("swipeRightToLeft", new Dictionary<string, object>
+			{
 				{ "swipePercentage", swipePercentage },
 				{ "swipeSpeed", swipeSpeed },
 				{ "withInertia", withInertia }

--- a/src/TestUtils/src/UITest.Appium/HelperExtensions.cs
+++ b/src/TestUtils/src/UITest.Appium/HelperExtensions.cs
@@ -174,6 +174,49 @@ namespace UITest.Appium
 			}
 		}
 
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="app">Represents the main gateway to interact with an app.</param>
+		/// <param name="marked">Marked selector to match.</param>
+		/// <param name="swipePercentage">How far across the element to swipe (from 0.0 to 1.0).</param>
+		/// <param name="swipeSpeed">The speed of the gesture.</param>
+		/// <param name="withInertia">Whether swipes should cause inertia.</param>
+		public static void SwipeLeftToRight(this IApp app, string marked, double swipePercentage = 0.67, int swipeSpeed = 500, bool withInertia = true)
+		{
+			var elementToSwipe = app.FindElement(marked);
+
+			app.CommandExecutor.Execute("swipeLeftToRight", new Dictionary<string, object>
+			{
+				{ "element", elementToSwipe},
+				{ "swipePercentage", swipePercentage },
+				{ "swipeSpeed", swipeSpeed },
+				{ "withInertia", withInertia }
+			});
+		}
+
+		/// <summary>
+		/// Performs a right to left swipe gesture on the matching element. 
+		/// If multiple elements are matched, the first one will be used.
+		/// </summary>
+		/// <param name="app">Represents the main gateway to interact with an app.</param>
+		/// <param name="marked">Marked selector to match.</param>
+		/// <param name="swipePercentage">How far across the element to swipe (from 0.0 to 1.0).</param>
+		/// <param name="swipeSpeed">The speed of the gesture.</param>
+		/// <param name="withInertia">Whether swipes should cause inertia.</param>
+		public static void SwipeRightToLeft(this IApp app, string marked, double swipePercentage = 0.67, int swipeSpeed = 500, bool withInertia = true)
+		{
+			var elementToSwipe = app.FindElement(marked);
+
+			app.CommandExecutor.Execute("swipeRightToLeft", new Dictionary<string, object>
+			{
+				{ "element", elementToSwipe},
+				{ "swipePercentage", swipePercentage },
+				{ "swipeSpeed", swipeSpeed },
+				{ "withInertia", withInertia }
+			});
+		}
+
 		static IUIElement Wait(Func<IUIElement> query,
 			Func<IUIElement, bool> satisfactory,
 			string? timeoutMessage = null,


### PR DESCRIPTION
### Description of Change

We have gaps in our UITests with appium compared to Xamarin.UITest. We continue adding options and filling gaps.
This PR include swipe gesture methods.

- SwipeLeftToRight 
- SwipeRightToLeft

Taking advantage of adding these options, UITests are added for SwipeView validating the swipe both right and left.
![swipe-gesture-uitest](https://github.com/dotnet/maui/assets/6755973/1ec4573d-6f03-4cdd-bce9-7d3a0c32aa77)
NOTE: The gif is one the added UI Test running.

