### PR TITLE
[Blazor] Fix concurrency problem in Android builds

### DIFF
--- a/src/BlazorWebView/src/Maui/build/Microsoft.AspNetCore.Components.WebView.Maui.props
+++ b/src/BlazorWebView/src/Maui/build/Microsoft.AspNetCore.Components.WebView.Maui.props
@@ -1,2 +1,5 @@
 ﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <StaticWebAssetsEnabled Condition="'$(_OuterIntermediateOutputPath)' != ''">false</StaticWebAssetsEnabled>
+  </PropertyGroup>
 </Project>

--- a/src/BlazorWebView/src/Maui/build/Microsoft.AspNetCore.Components.WebView.Maui.targets
+++ b/src/BlazorWebView/src/Maui/build/Microsoft.AspNetCore.Components.WebView.Maui.targets
@@ -121,13 +121,4 @@
     </ItemGroup>
   </Target>
 
-  <!-- Microsoft.Android.Sdk.AssemblyResolution.targets _ResolveAssemblies triggers a nested build to
-       resolve publish files in a Maui specific way and that breaks elements depending on the '$(IntermediateOutputPath)'.
-       This target detects we are running inside one of such builds and adjust the relevant paths. -->
-  <Target Name="_AdjustStaticWebAssetPathBaseWhenBuildingWithRid" BeforeTargets="ResolveStaticWebAssetsConfiguration" Condition="'$(_OuterIntermediateOutputPath)' != ''">
-    <PropertyGroup>
-      <_StaticWebAssetsManifestBase>$(_OuterIntermediateOutputPath)</_StaticWebAssetsManifestBase>
-    </PropertyGroup>
-  </Target>
-
 </Project>

--- a/src/BlazorWebView/tests/MauiDeviceTests/MauiBlazorWebView.DeviceTests.csproj
+++ b/src/BlazorWebView/tests/MauiDeviceTests/MauiBlazorWebView.DeviceTests.csproj
@@ -1,5 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
+<Import Condition=" '$(UseMaui)' != 'true' " Project="..\..\src\Maui\build\Microsoft.AspNetCore.Components.WebView.Maui.props" />
+
   <PropertyGroup>
     <TargetFrameworks>$(MauiDeviceTestsPlatforms)</TargetFrameworks>
     <OutputType>Exe</OutputType>

--- a/src/BlazorWebView/tests/MauiDeviceTests/MauiBlazorWebView.DeviceTests.csproj
+++ b/src/BlazorWebView/tests/MauiDeviceTests/MauiBlazorWebView.DeviceTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
-<Import Condition=" '$(UseMaui)' != 'true' " Project="..\..\src\Maui\build\Microsoft.AspNetCore.Components.WebView.Maui.props" />
+  <Import Condition=" '$(UseMaui)' != 'true' " Project="..\..\src\Maui\build\Microsoft.AspNetCore.Components.WebView.Maui.props" />
 
   <PropertyGroup>
     <TargetFrameworks>$(MauiDeviceTestsPlatforms)</TargetFrameworks>

--- a/src/Controls/samples/Controls.Sample/Maui.Controls.Sample.csproj
+++ b/src/Controls/samples/Controls.Sample/Maui.Controls.Sample.csproj
@@ -1,5 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
+  <Import Condition=" '$(UseMaui)' != 'true' " Project="..\..\..\BlazorWebView\src\Maui\build\Microsoft.AspNetCore.Components.WebView.Maui.props" />
+
   <PropertyGroup>
     <TargetFrameworks>$(MauiPlatforms);$(_MauiDotNetTfm)</TargetFrameworks>
     <OutputType Condition="$(TargetFramework.Contains('-'))">Exe</OutputType>


### PR DESCRIPTION
* Disable static web assets on nested Rid builds as its not necessary it runs there.
* The outer build already collects the assets and transforms them into Maui assets.

https://github.com/dotnet/aspnetcore/issues/52460