### PR TITLE
Fix flaky Appium install

### DIFF
--- a/eng/pipelines/common/ui-tests-steps.yml
+++ b/eng/pipelines/common/ui-tests-steps.yml
@@ -38,9 +38,9 @@ steps:
       height: '1080'
     displayName: "Set screen resolution"
 
-  - task: NodeTool@0
+  - task: UseNode@1
     inputs:
-      versionSpec: "20.3.1"
+      version: "20.3.1"
     displayName: "Install node"
 
   - pwsh: ./eng/scripts/appium-install.ps1

--- a/eng/scripts/appium-install.ps1
+++ b/eng/scripts/appium-install.ps1
@@ -46,10 +46,6 @@ param
 )
 
 Write-Output  "Welcome to the Appium installer"
-node -v
-
-Write-Output  "Updating npm"
-npm install -g npm
 
 Write-Output  "Node version"
 node -v


### PR DESCRIPTION
### Description of Change

This PR attempts to fix the flaky Appium install during CI.

1. Use the latest version of the Node install task on Azure Pipelines, don't think this is related that much, but good to use a newer version of things while we're at it.
2. Do not attempt to upgrade npm in the PowerShell script that installs Appium

It will be hard to say if this is the definitive fix as it doesn't happen all the time. But I think this should help 🤞 

If we still see errors like

> npm ERR! code EBADENGINE
> npm ERR! engine Unsupported engine
> npm ERR! engine Not compatible with your version of node/npm: npm@10.2.4
> npm ERR! notsup Not compatible with your version of node/npm: npm@10.2.4
> npm ERR! notsup Required: {"node":"^18.17.0 || >=20.5.0"}
> npm ERR! notsup Actual:   {"npm":"9.6.7","node":"v20.3.1"}

in our `MAUI-UITests-public` pipeline then this didn't help.

### Issues Fixed

Fixes #19036