### PR TITLE
Improve appium install on CI build agents

### DIFF
--- a/eng/pipelines/common/ui-tests-steps.yml
+++ b/eng/pipelines/common/ui-tests-steps.yml
@@ -42,9 +42,44 @@ steps:
     inputs:
       version: "20.3.1"
     displayName: "Install node"
+    
+  - bash: |
+      echo "##[group]Running ls -al $(npm root -g)"
+      ls -al $(npm root -g)
+      echo "##[endgroup]"
+
+      echo "##[group]Running ls -al $(npm root -g)/appium"
+      ls -al $(npm root -g)/appium
+      echo "##[endgroup]"
+
+      echo "##[group]Running ls -al $(npm root -g)/.appium-????????"
+      ls -al $(npm root -g)/.appium-????????
+      echo "##[endgroup]"
+
+      echo "##[group]Running ls -al $(npm root -g)/appium-doctor"
+      ls -al $(npm root -g)/appium-doctor
+      echo "##[endgroup]"
+
+      echo "##[group]Running ls -al $(npm root -g)/.appium-doctor-????????"
+      ls -al $(npm root -g)/.appium-doctor-????????
+      echo "##[endgroup]"
+
+      echo "##[group]Running ps aux"
+      ps aux
+      echo "##[endgroup]"
+    displayName: "Debugging output"
+    continueOnError: true
+    condition: startsWith(variables['Agent.Name'], 'XAMBOT')
+
+  # Clean up any leftover cached folders of appium and appium-doctor node modules
+  - bash: |
+      rm -rf $(npm root -g)/.appium-????????
+      rm -rf $(npm root -g)/.appium-doctor-????????
+    displayName: "Delete temp .appium-???????? and .appium-doctor-???????? folders"
+    continueOnError: true
 
   - pwsh: ./eng/scripts/appium-install.ps1
-    displayName: "Install Appium"
+    displayName: "Install Appium (Drivers)"
     continueOnError: false
     retryCountOnTaskFailure: 1
 

--- a/eng/scripts/appium-install.ps1
+++ b/eng/scripts/appium-install.ps1
@@ -35,7 +35,7 @@ PS> .\appium-install.ps1 '2.1.1' 2.7.2 2.25.1 4.30.2 1.6.1
 This would install or update Appium version 2.1.1, the windows driver 2.7.2, the uiautomator2 driver with 2.25.1, the xcuitest driver with 4.30.2 and mac2 driver with 1.6.1
 
 Versions for these steps are pinned and ideally stay in sync with the script that initializes the XAMBOT agents.
-You can find the script for that here: https://devdiv.visualstudio.com/Engineering/_git/BotDeploy.PackageGeneration?path=/bootstrap_bundle_appium/ROOT/Users/Shared/bootstrap/uuuu_bundle_appium/appium-install.ps1&version=GBmain&_a=contents
+Find the script for that on the DevDiv Azure DevOps instance, Engineering team, BotDeploy.PackageGeneration repo.
 #>
 
 param

--- a/eng/scripts/appium-install.ps1
+++ b/eng/scripts/appium-install.ps1
@@ -33,8 +33,10 @@ The mac2 driver version to update or install
 PS> .\appium-install.ps1 '2.1.1' 2.7.2 2.25.1 4.30.2 1.6.1
 
 This would install or update Appium version 2.1.1, the windows driver 2.7.2, the uiautomator2 driver with 2.25.1, the xcuitest driver with 4.30.2 and mac2 driver with 1.6.1
-#>
 
+Versions for these steps are pinned and ideally stay in sync with the script that initializes the XAMBOT agents.
+You can find the script for that here: https://devdiv.visualstudio.com/Engineering/_git/BotDeploy.PackageGeneration?path=/bootstrap_bundle_appium/ROOT/Users/Shared/bootstrap/uuuu_bundle_appium/appium-install.ps1&version=GBmain&_a=contents
+#>
 
 param
 (
@@ -52,11 +54,13 @@ node -v
 
 Write-Output  "Installing appium $appiumVersion"
 npm install -g appium@$appiumVersion
+
 write-Output  "Installed appium"
 appium -v
 
 Write-Output  "Installing appium doctor"
 npm install -g appium-doctor
+
 Write-Output  "Installed appium doctor"
 
 $existingDrivers = appium driver list --installed --json  | ConvertFrom-Json
@@ -64,25 +68,25 @@ Write-Output "List of installed drivers $existingDrivers"
 if ($existingDrivers.windows) {
     Write-Output  "Uninstalling appium driver windows"
     appium driver uninstall windows
-    Write-Output  "Unistalled appium driver windows"
+    Write-Output  "Uninstalled appium driver windows"
 }
 
 if ($existingDrivers.uiautomator2) {
     Write-Output  "Uninstalling appium driver uiautomator2"
     appium driver uninstall uiautomator2
-    Write-Output  "Unistalled appium driver uiautomator2"
+    Write-Output  "Uninstalled appium driver uiautomator2"
 }
 
 if ($existingDrivers.xcuitest) {
     Write-Output  "Uninstalling appium driver xcuitest"
     appium driver uninstall xcuitest
-    Write-Output  "Unistalled appium driver xcuitest"
+    Write-Output  "Uninstalled appium driver xcuitest"
 }
 
 if ($existingDrivers.mac2) {
     Write-Output  "Uninstalling appium driver mac2"
     appium driver uninstall mac2
-    Write-Output  "Unistalled appium driver mac2"
+    Write-Output  "Uninstalled appium driver mac2"
 }
 
 $drivers = appium driver list --installed --json  | ConvertFrom-Json


### PR DESCRIPTION
### Description of Change

As a follow up on https://github.com/dotnet/maui/issues/19036, as reported by #19239 this still happens in some variations. This change adds a task to cleanup any `.appium-????????` and `.appium-doctor-????????` folders from the `node_modules` folder. These seem to be some leftover artifacts that will cause the initialization to fail.

Technically this is only needed for our self-hosted build agents, but it shouldn't hurt to also do this on the publicly hosted agents.

It also adds some debugging info that might prove useful for when issues arise later on, so I decided to leave that in here.

I ran the UI tests pipeline a couple of times over which now succeeded each time, where if I disable the `rm -rf` call it would fail immediately again so I'm pretty confident this will work.

### Issues Fixed

Fixes #19239