### PR TITLE
[ci] Execute build.ps1 from bash on Mac to avoid STDIO streams hang

### DIFF
--- a/eng/pipelines/common/device-tests-steps.yml
+++ b/eng/pipelines/common/device-tests-steps.yml
@@ -57,8 +57,9 @@ steps:
 
   - pwsh: |
       # Use Start-Process to help avoid error: The STDIO streams did not close within 10 seconds of the exit event from process '/usr/local/bin/pwsh'. This may indicate a child process inherited the STDIO streams and has not yet exited.
-      Write-Host "Start-Process -FilePath `"pwsh`" -ArgumentList `"-File ./build.ps1`" `"-Script `"eng/devices/${{ parameters.platform }}.cake --project=`"${{ parameters.path }}`" --device=${{ parameters.device }} --packageid=${{ parameters.windowsPackageId }} --results=`"$(TestResultsDirectory)`" --binlog=`"$(LogDirectory)`" ${{ parameters.cakeArgs }}`"`" -NoNewWindow -Wait"
-      Start-Process -FilePath "pwsh" -ArgumentList "-File ./build.ps1" "-Script `"eng/devices/${{ parameters.platform }}.cake --project=`"${{ parameters.path }}`" --device=${{ parameters.device }} --packageid=${{ parameters.windowsPackageId }} --results=`"$(TestResultsDirectory)`" --binlog=`"$(LogDirectory)`" ${{ parameters.cakeArgs }}`"" -NoNewWindow -Wait
+      Write-Host "Start-Process -FilePath `"pwsh`" -ArgumentList `"-File ./build.ps1`", `"-Script `"eng/devices/${{ parameters.platform }}.cake --project=`"${{ parameters.path }}`" --device=${{ parameters.device }} --packageid=${{ parameters.windowsPackageId }} --results=`"$(TestResultsDirectory)`" --binlog=`"$(LogDirectory)`" ${{ parameters.cakeArgs }}`"`" -NoNewWindow -Wait"
+      # ./build.ps1 -Script eng/devices/${{ parameters.platform }}.cake --project="${{ parameters.path }}" --device=${{ parameters.device }} --packageid=${{ parameters.windowsPackageId }} --results="$(TestResultsDirectory)" --binlog="$(LogDirectory)" ${{ parameters.cakeArgs }}
+      Start-Process -FilePath "pwsh" -ArgumentList "-File ./build.ps1", "-Script `"eng/devices/${{ parameters.platform }}.cake --project=`"${{ parameters.path }}`" --device=${{ parameters.device }} --packageid=${{ parameters.windowsPackageId }} --results=`"$(TestResultsDirectory)`" --binlog=`"$(LogDirectory)`" ${{ parameters.cakeArgs }}`"" -NoNewWindow -Wait
     displayName: $(Agent.JobName)
     workingDirectory: ${{ parameters.checkoutDirectory }}
     retryCountOnTaskFailure: 2

--- a/eng/pipelines/common/device-tests-steps.yml
+++ b/eng/pipelines/common/device-tests-steps.yml
@@ -57,9 +57,9 @@ steps:
 
   - pwsh: |
       # Use Start-Process to help avoid error: The STDIO streams did not close within 10 seconds of the exit event from process '/usr/local/bin/pwsh'. This may indicate a child process inherited the STDIO streams and has not yet exited.
-      Write-Host "Start-Process -FilePath `"pwsh`" -ArgumentList `"-File ./build.ps1`", `"-Script `"eng/devices/${{ parameters.platform }}.cake --project=`"${{ parameters.path }}`" --device=${{ parameters.device }} --packageid=${{ parameters.windowsPackageId }} --results=`"$(TestResultsDirectory)`" --binlog=`"$(LogDirectory)`" ${{ parameters.cakeArgs }}`"`" -NoNewWindow -Wait"
+      Write-Host "Start-Process -FilePath `"pwsh`" -ArgumentList `"-File ./build.ps1`", `"-Script `"eng/devices/${{ parameters.platform }}.cake`"`", --project=`"${{ parameters.path }}`" --device=${{ parameters.device }} --packageid=${{ parameters.windowsPackageId }} --results=`"$(TestResultsDirectory)`" --binlog=`"$(LogDirectory)`" ${{ parameters.cakeArgs }}`"`" -NoNewWindow -Wait"
       # ./build.ps1 -Script eng/devices/${{ parameters.platform }}.cake --project="${{ parameters.path }}" --device=${{ parameters.device }} --packageid=${{ parameters.windowsPackageId }} --results="$(TestResultsDirectory)" --binlog="$(LogDirectory)" ${{ parameters.cakeArgs }}
-      Start-Process -FilePath "pwsh" -ArgumentList "-File ./build.ps1", "-Script `"eng/devices/${{ parameters.platform }}.cake --project=`"${{ parameters.path }}`" --device=${{ parameters.device }} --packageid=${{ parameters.windowsPackageId }} --results=`"$(TestResultsDirectory)`" --binlog=`"$(LogDirectory)`" ${{ parameters.cakeArgs }}`"" -NoNewWindow -Wait
+      Start-Process -FilePath "pwsh" -ArgumentList "-File ./build.ps1", "-Script `"eng/devices/${{ parameters.platform }}.cake`"", `"--project=`"${{ parameters.path }}`" --device=${{ parameters.device }} --packageid=${{ parameters.windowsPackageId }} --results=`"$(TestResultsDirectory)`" --binlog=`"$(LogDirectory)`" ${{ parameters.cakeArgs }}`"" -NoNewWindow -Wait
     displayName: $(Agent.JobName)
     workingDirectory: ${{ parameters.checkoutDirectory }}
     retryCountOnTaskFailure: 2

--- a/eng/pipelines/common/device-tests-steps.yml
+++ b/eng/pipelines/common/device-tests-steps.yml
@@ -56,10 +56,8 @@ steps:
       displayName: 'Build the MSBuild Tasks'
 
   - bash: |
-      # Use Start-Process to help avoid error: The STDIO streams did not close within 10 seconds of the exit event from process '/usr/local/bin/pwsh'. This may indicate a child process inherited the STDIO streams and has not yet exited.
-      # Write-Host "Start-Process -FilePath `"pwsh`" -ArgumentList `"-File ./build.ps1`", `"-Script `"eng/devices/${{ parameters.platform }}.cake`"`", `"--project=`"${{ parameters.path }}`" --device=${{ parameters.device }} --packageid=${{ parameters.windowsPackageId }} --results=`"$(TestResultsDirectory)`" --binlog=`"$(LogDirectory)`" ${{ parameters.cakeArgs }}`"`" -NoNewWindow -Wait"
+      # Execute the powershell script from a bash shell to avoid interference between powershell processes that lead to this error: The STDIO streams did not close within 10 seconds of the exit event from process '/usr/local/bin/pwsh'. This may indicate a child process inherited the STDIO streams and has not yet exited.
       pwsh ./build.ps1 -Script eng/devices/${{ parameters.platform }}.cake --project="${{ parameters.path }}" --device=${{ parameters.device }} --packageid=${{ parameters.windowsPackageId }} --results="$(TestResultsDirectory)" --binlog="$(LogDirectory)" ${{ parameters.cakeArgs }}
-      # Start-Process -FilePath "pwsh" -ArgumentList "-File ./build.ps1", "-Script `"eng/devices/${{ parameters.platform }}.cake`"", "--project=`"${{ parameters.path }}`" --device=${{ parameters.device }} --packageid=${{ parameters.windowsPackageId }} --results=`"$(TestResultsDirectory)`" --binlog=`"$(LogDirectory)`" ${{ parameters.cakeArgs }}`"" -NoNewWindow -Wait
     displayName: $(Agent.JobName)
     workingDirectory: ${{ parameters.checkoutDirectory }}
     retryCountOnTaskFailure: 2

--- a/eng/pipelines/common/device-tests-steps.yml
+++ b/eng/pipelines/common/device-tests-steps.yml
@@ -55,11 +55,30 @@ steps:
     - pwsh: ./build.ps1 --target=dotnet-buildtasks --configuration="Release"
       displayName: 'Build the MSBuild Tasks'
 
+  - pwsh: |
+      $platformName = 'Windows'
+      if ($IsMacOS) {
+        $platformName = 'Mac'
+      } elseif ($IsLinux) {
+        $platformName = 'Linux'
+      }
+      Write-Host "Platform.Name: ${platformName}"
+      Write-Host "##vso[task.setvariable variable=Platform.Name]${platformName}"
+    displayName: 'Set Platform.Name'
+
+  - pwsh: |
+      ./build.ps1 -Script eng/devices/${{ parameters.platform }}.cake --project="${{ parameters.path }}" --device=${{ parameters.device }} --packageid=${{ parameters.windowsPackageId }} --results="$(TestResultsDirectory)" --binlog="$(LogDirectory)" ${{ parameters.cakeArgs }}
+    displayName: $(Agent.JobName)
+    workingDirectory: ${{ parameters.checkoutDirectory }}
+    condition: and(succeeded(), ne(variables['Platform.Name'], 'Mac'))
+    retryCountOnTaskFailure: 2
+
   - bash: |
-      # Execute the powershell script from a bash shell to avoid interference between powershell processes that lead to this error: The STDIO streams did not close within 10 seconds of the exit event from process '/usr/local/bin/pwsh'. This may indicate a child process inherited the STDIO streams and has not yet exited.
+      # Execute the powershell script from a bash shell on Mac to avoid interference between powershell processes that lead to this error: The STDIO streams did not close within 10 seconds of the exit event from process '/usr/local/bin/pwsh'. This may indicate a child process inherited the STDIO streams and has not yet exited.
       pwsh ./build.ps1 -Script eng/devices/${{ parameters.platform }}.cake --project="${{ parameters.path }}" --device=${{ parameters.device }} --packageid=${{ parameters.windowsPackageId }} --results="$(TestResultsDirectory)" --binlog="$(LogDirectory)" ${{ parameters.cakeArgs }}
     displayName: $(Agent.JobName)
     workingDirectory: ${{ parameters.checkoutDirectory }}
+    condition: and(succeeded(), eq(variables['Platform.Name'], 'Mac'))
     retryCountOnTaskFailure: 2
 
   - task: PublishTestResults@2

--- a/eng/pipelines/common/device-tests-steps.yml
+++ b/eng/pipelines/common/device-tests-steps.yml
@@ -57,6 +57,7 @@ steps:
 
   - pwsh: |
       # Use Start-Process to help avoid error: The STDIO streams did not close within 10 seconds of the exit event from process '/usr/local/bin/pwsh'. This may indicate a child process inherited the STDIO streams and has not yet exited.
+      Write-Host "Start-Process -FilePath `"pwsh`" -ArgumentList `"-File ./build.ps1`" `"-Script `"eng/devices/${{ parameters.platform }}.cake --project=`"${{ parameters.path }}`" --device=${{ parameters.device }} --packageid=${{ parameters.windowsPackageId }} --results=`"$(TestResultsDirectory)`" --binlog=`"$(LogDirectory)`" ${{ parameters.cakeArgs }}`"`" -NoNewWindow -Wait"
       Start-Process -FilePath "pwsh" -ArgumentList "-File ./build.ps1" "-Script `"eng/devices/${{ parameters.platform }}.cake --project=`"${{ parameters.path }}`" --device=${{ parameters.device }} --packageid=${{ parameters.windowsPackageId }} --results=`"$(TestResultsDirectory)`" --binlog=`"$(LogDirectory)`" ${{ parameters.cakeArgs }}`"" -NoNewWindow -Wait
     displayName: $(Agent.JobName)
     workingDirectory: ${{ parameters.checkoutDirectory }}

--- a/eng/pipelines/common/device-tests-steps.yml
+++ b/eng/pipelines/common/device-tests-steps.yml
@@ -55,7 +55,9 @@ steps:
     - pwsh: ./build.ps1 --target=dotnet-buildtasks --configuration="Release"
       displayName: 'Build the MSBuild Tasks'
 
-  - pwsh: ./build.ps1 -Script eng/devices/${{ parameters.platform }}.cake --project="${{ parameters.path }}" --device=${{ parameters.device }} --packageid=${{ parameters.windowsPackageId }} --results="$(TestResultsDirectory)" --binlog="$(LogDirectory)" ${{ parameters.cakeArgs }}
+  - pwsh: |
+      # Use Start-Process to help avoid error: The STDIO streams did not close within 10 seconds of the exit event from process '/usr/local/bin/pwsh'. This may indicate a child process inherited the STDIO streams and has not yet exited.
+      Start-Process -FilePath "pwsh" -ArgumentList "-File ./build.ps1" "-Script `"eng/devices/${{ parameters.platform }}.cake --project=`"${{ parameters.path }}`" --device=${{ parameters.device }} --packageid=${{ parameters.windowsPackageId }} --results=`"$(TestResultsDirectory)`" --binlog=`"$(LogDirectory)`" ${{ parameters.cakeArgs }}`"" -NoNewWindow -Wait
     displayName: $(Agent.JobName)
     workingDirectory: ${{ parameters.checkoutDirectory }}
     retryCountOnTaskFailure: 2

--- a/eng/pipelines/common/device-tests-steps.yml
+++ b/eng/pipelines/common/device-tests-steps.yml
@@ -57,9 +57,9 @@ steps:
 
   - pwsh: |
       # Use Start-Process to help avoid error: The STDIO streams did not close within 10 seconds of the exit event from process '/usr/local/bin/pwsh'. This may indicate a child process inherited the STDIO streams and has not yet exited.
-      Write-Host "Start-Process -FilePath `"pwsh`" -ArgumentList `"-File ./build.ps1`", `"-Script `"eng/devices/${{ parameters.platform }}.cake`"`", --project=`"${{ parameters.path }}`" --device=${{ parameters.device }} --packageid=${{ parameters.windowsPackageId }} --results=`"$(TestResultsDirectory)`" --binlog=`"$(LogDirectory)`" ${{ parameters.cakeArgs }}`"`" -NoNewWindow -Wait"
+      # Write-Host "Start-Process -FilePath `"pwsh`" -ArgumentList `"-File ./build.ps1`", `"-Script `"eng/devices/${{ parameters.platform }}.cake`"`", `"--project=`"${{ parameters.path }}`" --device=${{ parameters.device }} --packageid=${{ parameters.windowsPackageId }} --results=`"$(TestResultsDirectory)`" --binlog=`"$(LogDirectory)`" ${{ parameters.cakeArgs }}`"`" -NoNewWindow -Wait"
       # ./build.ps1 -Script eng/devices/${{ parameters.platform }}.cake --project="${{ parameters.path }}" --device=${{ parameters.device }} --packageid=${{ parameters.windowsPackageId }} --results="$(TestResultsDirectory)" --binlog="$(LogDirectory)" ${{ parameters.cakeArgs }}
-      Start-Process -FilePath "pwsh" -ArgumentList "-File ./build.ps1", "-Script `"eng/devices/${{ parameters.platform }}.cake`"", `"--project=`"${{ parameters.path }}`" --device=${{ parameters.device }} --packageid=${{ parameters.windowsPackageId }} --results=`"$(TestResultsDirectory)`" --binlog=`"$(LogDirectory)`" ${{ parameters.cakeArgs }}`"" -NoNewWindow -Wait
+      Start-Process -FilePath "pwsh" -ArgumentList "-File ./build.ps1", "-Script `"eng/devices/${{ parameters.platform }}.cake`"", "--project=`"${{ parameters.path }}`" --device=${{ parameters.device }} --packageid=${{ parameters.windowsPackageId }} --results=`"$(TestResultsDirectory)`" --binlog=`"$(LogDirectory)`" ${{ parameters.cakeArgs }}`"" -NoNewWindow -Wait
     displayName: $(Agent.JobName)
     workingDirectory: ${{ parameters.checkoutDirectory }}
     retryCountOnTaskFailure: 2

--- a/eng/pipelines/common/device-tests-steps.yml
+++ b/eng/pipelines/common/device-tests-steps.yml
@@ -55,11 +55,11 @@ steps:
     - pwsh: ./build.ps1 --target=dotnet-buildtasks --configuration="Release"
       displayName: 'Build the MSBuild Tasks'
 
-  - pwsh: |
+  - bash: |
       # Use Start-Process to help avoid error: The STDIO streams did not close within 10 seconds of the exit event from process '/usr/local/bin/pwsh'. This may indicate a child process inherited the STDIO streams and has not yet exited.
       # Write-Host "Start-Process -FilePath `"pwsh`" -ArgumentList `"-File ./build.ps1`", `"-Script `"eng/devices/${{ parameters.platform }}.cake`"`", `"--project=`"${{ parameters.path }}`" --device=${{ parameters.device }} --packageid=${{ parameters.windowsPackageId }} --results=`"$(TestResultsDirectory)`" --binlog=`"$(LogDirectory)`" ${{ parameters.cakeArgs }}`"`" -NoNewWindow -Wait"
-      # ./build.ps1 -Script eng/devices/${{ parameters.platform }}.cake --project="${{ parameters.path }}" --device=${{ parameters.device }} --packageid=${{ parameters.windowsPackageId }} --results="$(TestResultsDirectory)" --binlog="$(LogDirectory)" ${{ parameters.cakeArgs }}
-      Start-Process -FilePath "pwsh" -ArgumentList "-File ./build.ps1", "-Script `"eng/devices/${{ parameters.platform }}.cake`"", "--project=`"${{ parameters.path }}`" --device=${{ parameters.device }} --packageid=${{ parameters.windowsPackageId }} --results=`"$(TestResultsDirectory)`" --binlog=`"$(LogDirectory)`" ${{ parameters.cakeArgs }}`"" -NoNewWindow -Wait
+      pwsh ./build.ps1 -Script eng/devices/${{ parameters.platform }}.cake --project="${{ parameters.path }}" --device=${{ parameters.device }} --packageid=${{ parameters.windowsPackageId }} --results="$(TestResultsDirectory)" --binlog="$(LogDirectory)" ${{ parameters.cakeArgs }}
+      # Start-Process -FilePath "pwsh" -ArgumentList "-File ./build.ps1", "-Script `"eng/devices/${{ parameters.platform }}.cake`"", "--project=`"${{ parameters.path }}`" --device=${{ parameters.device }} --packageid=${{ parameters.windowsPackageId }} --results=`"$(TestResultsDirectory)`" --binlog=`"$(LogDirectory)`" ${{ parameters.cakeArgs }}`"" -NoNewWindow -Wait
     displayName: $(Agent.JobName)
     workingDirectory: ${{ parameters.checkoutDirectory }}
     retryCountOnTaskFailure: 2


### PR DESCRIPTION
### Description of Change

This is to address a reliability issue involving `MAUI-DeviceTests`.  Tests run on Mac sporadically hang then fail (timeout) due to the following error:
```
The STDIO streams did not close within 10 seconds of the exit event from process '/usr/local/bin/pwsh'. This may indicate a child process inherited the STDIO streams and has not yet exited.
```
It seems that build.ps1 is getting executed as a powershell subprocess and in turn interfering with the IO stream for the pwsh step. As a mitigation, run build.ps1 under a bash step on Mac. This avoids flakiness and in turn avoids having to rerun failed tests.