### PR TITLE
Do not use the powershell step

### DIFF
--- a/eng/pipelines/common/device-tests-steps.yml
+++ b/eng/pipelines/common/device-tests-steps.yml
@@ -21,7 +21,7 @@ steps:
       skipProvisioning: ${{ eq(parameters.platform, 'windows') }}
       provisionatorChannel: ${{ parameters.provisionatorChannel }}
 
-  - pwsh: ./build.ps1 --target=dotnet --configuration="Release" --verbosity=diagnostic
+  - script: pwsh build.ps1 --target=dotnet --configuration="Release" --verbosity=diagnostic
     displayName: 'Install .NET'
     retryCountOnTaskFailure: 3
     env:
@@ -43,7 +43,7 @@ steps:
     - pwsh: Move-Item -Path artifacts\${{ parameters.artifactName }}\*.nupkg -Destination artifacts -Force
       displayName: Move the downloaded artifacts
 
-    - pwsh: ./build.ps1 --target=dotnet-local-workloads --verbosity=diagnostic
+    - script: pwsh build.ps1 --target=dotnet-local-workloads --verbosity=diagnostic
       displayName: 'Install .NET (Local Workloads)'
       retryCountOnTaskFailure: 3
       workingDirectory: ${{ parameters.checkoutDirectory }}
@@ -52,10 +52,10 @@ steps:
         PRIVATE_BUILD: $(PrivateBuild)
 
   - ${{ else }}:
-    - pwsh: ./build.ps1 --target=dotnet-buildtasks --configuration="Release"
+    - script: pwsh build.ps1 --target=dotnet-buildtasks --configuration="Release"
       displayName: 'Build the MSBuild Tasks'
 
-  - pwsh: ./build.ps1 -Script eng/devices/${{ parameters.platform }}.cake --project="${{ parameters.path }}" --device=${{ parameters.device }} --packageid=${{ parameters.windowsPackageId }} --results="$(TestResultsDirectory)" --binlog="$(LogDirectory)" ${{ parameters.cakeArgs }}
+  - script: pwsh build.ps1 -Script eng/devices/${{ parameters.platform }}.cake --project="${{ parameters.path }}" --device=${{ parameters.device }} --packageid=${{ parameters.windowsPackageId }} --results="$(TestResultsDirectory)" --binlog="$(LogDirectory)" ${{ parameters.cakeArgs }}
     displayName: $(Agent.JobName)
     workingDirectory: ${{ parameters.checkoutDirectory }}
     retryCountOnTaskFailure: 2


### PR DESCRIPTION
### Description of Change

Alternative to https://github.com/dotnet/maui/pull/19257


This is to address a reliability issue involving `MAUI-DeviceTests`.  Tests run on Mac sporadically hang then fail (timeout) due to the following error:
```
The STDIO streams did not close within 10 seconds of the exit event from process '/usr/local/bin/pwsh'. This may indicate a child process inherited the STDIO streams and has not yet exited.
```
It seems that build.ps1 is getting executed as a powershell subprocess and in turn interfering with the IO stream for the pwsh step. As a mitigation, run build.ps1 under a bash step on Mac. This avoids flakiness and in turn avoids having to rerun failed tests.