### PR TITLE
Set CancelsTouchesInView for custom PGR

### DIFF
--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issue19283.xaml
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issue19283.xaml
@@ -1,0 +1,26 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Maui.Controls.Sample.Issues.Issue19283">
+    <VerticalStackLayout x:Name="layout">
+        <Button 
+            BackgroundColor="LightBlue"
+            AutomationId="btn"
+            Text="Click Me and a Label Should Appear"
+            x:Name="btn">
+            <Button.GestureRecognizers>
+                <PointerGestureRecognizer />
+            </Button.GestureRecognizers>
+            <VisualStateManager.VisualStateGroups>
+                <VisualStateGroup x:Name="CommonStates">
+                    <VisualState x:Name="Normal" />
+                    <VisualState x:Name="PointerOver">
+                        <VisualState.Setters>
+                            <Setter Property="BackgroundColor" Value="Yellow" />
+                        </VisualState.Setters>
+                    </VisualState>
+                </VisualStateGroup>
+            </VisualStateManager.VisualStateGroups>
+        </Button>
+    </VerticalStackLayout>
+</ContentPage>

--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issue19283.xaml
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issue19283.xaml
@@ -8,9 +8,6 @@
             AutomationId="btn"
             Text="Click Me and a Label Should Appear"
             x:Name="btn">
-            <Button.GestureRecognizers>
-                <PointerGestureRecognizer />
-            </Button.GestureRecognizers>
             <VisualStateManager.VisualStateGroups>
                 <VisualStateGroup x:Name="CommonStates">
                     <VisualState x:Name="Normal" />

--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issue19283.xaml.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issue19283.xaml.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.ObjectModel;
+﻿using System;
+using System.Collections.ObjectModel;
 using Microsoft.Maui;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Graphics;
@@ -11,6 +12,12 @@ namespace Maui.Controls.Sample.Issues
 		public Issue19283()
 		{
 			InitializeComponent();
+
+			// https://github.com/dotnet/maui/issues/19289
+			if (!OperatingSystem.IsAndroid())
+			{
+				btn.GestureRecognizers.Add(new PointerGestureRecognizer());
+			}
 
 			btn.Clicked += (sender, args) => 
 			{ 

--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issue19283.xaml.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issue19283.xaml.cs
@@ -1,0 +1,21 @@
+﻿using System.Collections.ObjectModel;
+using Microsoft.Maui;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Graphics;
+
+namespace Maui.Controls.Sample.Issues
+{
+	[Issue(IssueTracker.Github, 19283, "PointerOver VSM Breaks Button", PlatformAffected.iOS)]
+	public partial class Issue19283 : ContentPage
+	{
+		public Issue19283()
+		{
+			InitializeComponent();
+
+			btn.Clicked += (sender, args) => 
+			{ 
+				layout.Children.Add(new Label { Text = "Success", AutomationId = "Success" });
+			};
+		}
+	}
+}

--- a/src/Controls/src/Core/Platform/iOS/CustomPressGestureRecognizer.cs
+++ b/src/Controls/src/Core/Platform/iOS/CustomPressGestureRecognizer.cs
@@ -14,6 +14,7 @@ internal class CustomPressGestureRecognizer : UIGestureRecognizer
 	public CustomPressGestureRecognizer(NSObject target, Selector action) : base(target, action)
 	{
 		_target = target;
+		CancelsTouchesInView = false;
 	}
 
 	public CustomPressGestureRecognizer(Action<UIGestureRecognizer> action)

--- a/src/Controls/tests/UITests/Tests/Issues/Issue19283.cs
+++ b/src/Controls/tests/UITests/Tests/Issues/Issue19283.cs
@@ -1,0 +1,20 @@
+﻿using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.AppiumTests.Issues
+{
+	public class Issue19283 : _IssuesUITest
+	{
+		public Issue19283(TestDevice device) : base(device) { }
+
+		public override string Issue => "PointerOver VSM Breaks Button";
+
+		[Test]
+		public void ButtonStillWorksWhenItHasPointerOverVSMSet()
+		{
+			App.Click("btn");
+			App.WaitForElement("Success");
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change

The MAUI template add a `PointerOver` VSM to Buttons which causes a `PointerGestureRecognizer` to get added. The new code that we're using to perform the "Pressed/Released" adds a gesture that was cancelling the touch. 

### Issues Fixed
Fixes #19154

