### PR TITLE
Avoid zero-length array allocations

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -29,6 +29,7 @@ dotnet_diagnostic.CA1307.severity = error
 dotnet_diagnostic.CA1309.severity = error
 dotnet_diagnostic.CA1311.severity = error
 dotnet_diagnostic.CA1815.severity = error
+dotnet_diagnostic.CA1825.severity = error
 
 # nullability checks
 

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue4597.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue4597.cs
@@ -290,7 +290,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 				if (result[0].Rect.Height > 1)
 					return result;
 
-				return new Xamarin.UITest.Queries.AppResult[0];
+				return Array.Empty<Xamarin.UITest.Queries.AppResult>();
 			}, 10, 4000);
 
 			Assert.AreEqual(1, images.Length);

--- a/src/Compatibility/Core/src/Android/CollectionView/SelectableItemsViewAdapter.cs
+++ b/src/Compatibility/Core/src/Android/CollectionView/SelectableItemsViewAdapter.cs
@@ -81,13 +81,13 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 			switch (ItemsView.SelectionMode)
 			{
 				case SelectionMode.None:
-					return new int[0];
+					return Array.Empty<int>();
 
 				case SelectionMode.Single:
 					var selectedItem = ItemsView.SelectedItem;
 					if (selectedItem == null)
 					{
-						return new int[0];
+						return Array.Empty<int>();
 					}
 
 					return new int[1] { GetPositionForItem(selectedItem) };
@@ -104,7 +104,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 					return result;
 			}
 
-			return new int[0];
+			return Array.Empty<int>();
 		}
 
 		bool PositionIsSelected(int position)

--- a/src/Compatibility/Core/src/Android/Renderers/EditorRenderer.cs
+++ b/src/Compatibility/Core/src/Android/Renderers/EditorRenderer.cs
@@ -293,7 +293,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 		[PortHandler]
 		void UpdateMaxLength()
 		{
-			var currentFilters = new List<IInputFilter>(EditText?.GetFilters() ?? new IInputFilter[0]);
+			var currentFilters = new List<IInputFilter>(EditText?.GetFilters() ?? Array.Empty<IInputFilter>());
 
 			for (var i = 0; i < currentFilters.Count; i++)
 			{

--- a/src/Compatibility/Core/src/Android/Renderers/EntryRenderer.cs
+++ b/src/Compatibility/Core/src/Android/Renderers/EntryRenderer.cs
@@ -379,7 +379,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 		[PortHandler]
 		void UpdateMaxLength()
 		{
-			var currentFilters = new List<IInputFilter>(EditText?.GetFilters() ?? new IInputFilter[0]);
+			var currentFilters = new List<IInputFilter>(EditText?.GetFilters() ?? Array.Empty<IInputFilter>());
 
 			for (var i = 0; i < currentFilters.Count; i++)
 			{

--- a/src/Compatibility/Core/src/Android/Renderers/SearchBarRenderer.cs
+++ b/src/Compatibility/Core/src/Android/Renderers/SearchBarRenderer.cs
@@ -290,7 +290,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 		{
 			_editText = _editText ?? Control.GetChildrenOfType<AppCompatAutoCompleteTextView>().FirstOrDefault();
 
-			var currentFilters = new List<IInputFilter>(_editText?.GetFilters() ?? new IInputFilter[0]);
+			var currentFilters = new List<IInputFilter>(_editText?.GetFilters() ?? Array.Empty<IInputFilter>());
 
 			for (var i = 0; i < currentFilters.Count; i++)
 			{

--- a/src/Compatibility/Core/src/Tizen/Forms.cs
+++ b/src/Compatibility/Core/src/Tizen/Forms.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Maui.Controls.Compatibility
 
 		public static Size PhysicalScreenSize => DeviceDisplay.MainDisplayInfo.GetScaledScreenSize();
 
-		public static IReadOnlyList<string> Flags => s_flags ?? (s_flags = new string[0]);
+		public static IReadOnlyList<string> Flags => s_flags ?? (s_flags = Array.Empty<string>());
 
 		public static IMauiContext MauiContext { get; internal set; }
 

--- a/src/Compatibility/Core/src/iOS/DragAndDropDelegate.cs
+++ b/src/Compatibility/Core/src/iOS/DragAndDropDelegate.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 			if (interaction.View is IVisualElementRenderer renderer && renderer.Element is View view)
 				return HandleDragStarting(view, renderer);
 
-			return new UIDragItem[0];
+			return Array.Empty<UIDragItem>();
 		}
 
 		[Export("dropInteraction:canHandleSession:")]
@@ -193,7 +193,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 			},
 			element);
 
-			return returnValue ?? new UIDragItem[0];
+			return returnValue ?? Array.Empty<UIDragItem>();
 		}
 
 		void HandleDropCompleted(View element)

--- a/src/Compatibility/Core/src/iOS/Extensions/DoubleCollectionExtensions.cs
+++ b/src/Compatibility/Core/src/iOS/Extensions/DoubleCollectionExtensions.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.MacOS
 		public static nfloat[] ToArray(this DoubleCollection doubleCollection)
 		{
 			if (doubleCollection == null || doubleCollection.Count == 0)
-				return new nfloat[0];
+				return Array.Empty<nfloat>();
 			else
 			{
 

--- a/src/Compatibility/Core/src/iOS/Extensions/PointCollectionExtensions.cs
+++ b/src/Compatibility/Core/src/iOS/Extensions/PointCollectionExtensions.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.MacOS
 		{
 			if (pointCollection == null || pointCollection.Count == 0)
 			{
-				return new CGPoint[0];
+				return System.Array.Empty<CGPoint>();
 			}
 
 			CGPoint[] points = new CGPoint[pointCollection.Count];

--- a/src/Compatibility/Core/src/iOS/Renderers/NavigationRenderer.cs
+++ b/src/Compatibility/Core/src/iOS/Renderers/NavigationRenderer.cs
@@ -1422,8 +1422,8 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 
 				if (primaries != null)
 					primaries.Reverse();
-				NavigationItem.SetRightBarButtonItems(primaries == null ? new UIBarButtonItem[0] : primaries.ToArray(), false);
-				ToolbarItems = secondaries == null ? new UIBarButtonItem[0] : secondaries.ToArray();
+				NavigationItem.SetRightBarButtonItems(primaries == null ? Array.Empty<UIBarButtonItem>() : primaries.ToArray(), false);
+				ToolbarItems = secondaries == null ? Array.Empty<UIBarButtonItem>() : secondaries.ToArray();
 
 				NavigationRenderer n;
 				if (_navigation.TryGetTarget(out n))

--- a/src/Compatibility/Core/src/iOS/Renderers/WkWebViewRenderer.cs
+++ b/src/Compatibility/Core/src/iOS/Renderers/WkWebViewRenderer.cs
@@ -358,7 +358,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 				}
 			}
 
-			_initialCookiesLoaded = _initialCookiesLoaded ?? new NSHttpCookie[0];
+			_initialCookiesLoaded = _initialCookiesLoaded ?? Array.Empty<NSHttpCookie>();
 
 			List<NSHttpCookie> existingCookies = new List<NSHttpCookie>();
 			string domain = CreateUriForCookies(url).Host;

--- a/src/Compatibility/Core/src/iOS/Shapes/ShapeRenderer.cs
+++ b/src/Compatibility/Core/src/iOS/Shapes/ShapeRenderer.cs
@@ -124,7 +124,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.MacOS
 		void UpdateStrokeDashArray()
 		{
 			if (Element.StrokeDashArray == null || Element.StrokeDashArray.Count == 0)
-				Control.ShapeLayer.UpdateStrokeDash(new nfloat[0]);
+				Control.ShapeLayer.UpdateStrokeDash(Array.Empty<nfloat>());
 			else
 			{
 				nfloat[] dashArray;

--- a/src/Controls/Foldable/src/DualScreenInfo.cs
+++ b/src/Controls/Foldable/src/DualScreenInfo.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Maui.Foldable
 
 		internal DualScreenInfo(VisualElement element, IFoldableService dualScreenService)
 		{
-			_spanningBounds = new Rect[0];
+			_spanningBounds = Array.Empty<Rect>();
 			Element = element;
 			_dualScreenService = dualScreenService;
 
@@ -179,10 +179,10 @@ namespace Microsoft.Maui.Foldable
 			var hinge = guide.Hinge;
 
 			if (hinge == Rect.Zero)
-				return new Rect[0];
+				return Array.Empty<Rect>();
 
 			if (guide.Pane2 == Rect.Zero)
-				return new Rect[0];
+				return Array.Empty<Rect>();
 
 			//TODO: I think this should this be checking SpanMode==Wide
 			if (IsLandscape)

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/CollectionModifier.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/CollectionModifier.cs
@@ -50,7 +50,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries
 		{
 			if (!int.TryParse(Entry.Text, out int index))
 			{
-				indexes = new int[0];
+				indexes = Array.Empty<int>();
 				return false;
 			}
 

--- a/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
@@ -1531,8 +1531,8 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 				if (primaries != null)
 					primaries.Reverse();
-				NavigationItem.SetRightBarButtonItems(primaries == null ? new UIBarButtonItem[0] : primaries.ToArray(), false);
-				ToolbarItems = secondaries == null ? new UIBarButtonItem[0] : secondaries.ToArray();
+				NavigationItem.SetRightBarButtonItems(primaries == null ? Array.Empty<UIBarButtonItem>() : primaries.ToArray(), false);
+				ToolbarItems = secondaries == null ? Array.Empty<UIBarButtonItem>() : secondaries.ToArray();
 
 				NavigationRenderer n;
 				if (_navigation.TryGetTarget(out n))

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellItemRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellItemRenderer.cs
@@ -14,6 +14,8 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 {
 	public class ShellItemRenderer : UITabBarController, IShellItemRenderer, IAppearanceObserver, IUINavigationControllerDelegate, IDisconnectable
 	{
+		readonly static UITableViewCell[] EmptyUITableViewCellArray = Array.Empty<UITableViewCell>();
+
 		#region IShellItemRenderer
 
 		public ShellItem ShellItem
@@ -346,7 +348,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				if (MoreNavigationController.TopViewController.View is UITableView uITableView)
 					return uITableView.VisibleCells;
 
-				return new UITableViewCell[0];
+				return EmptyUITableViewCellArray;
 			}
 		}
 

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellPageRendererTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellPageRendererTracker.cs
@@ -302,7 +302,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 					primaries.Reverse();
 			}
 
-			NavigationItem.SetRightBarButtonItems(primaries == null ? new UIBarButtonItem[0] : primaries.ToArray(), false);
+			NavigationItem.SetRightBarButtonItems(primaries == null ? Array.Empty<UIBarButtonItem>() : primaries.ToArray(), false);
 
 			UpdateLeftToolbarItems();
 		}

--- a/src/Controls/src/Core/Handlers/Items/Android/Adapters/SelectableItemsViewAdapter.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/Adapters/SelectableItemsViewAdapter.cs
@@ -81,13 +81,13 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			switch (ItemsView.SelectionMode)
 			{
 				case SelectionMode.None:
-					return new int[0];
+					return Array.Empty<int>();
 
 				case SelectionMode.Single:
 					var selectedItem = ItemsView.SelectedItem;
 					if (selectedItem == null)
 					{
-						return new int[0];
+						return Array.Empty<int>();
 					}
 
 					return new int[1] { GetPositionForItem(selectedItem) };
@@ -104,7 +104,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 					return result;
 			}
 
-			return new int[0];
+			return Array.Empty<int>();
 		}
 
 		bool PositionIsSelected(int position)

--- a/src/Controls/src/Core/LegacyLayouts/ConstraintExpression.cs
+++ b/src/Controls/src/Core/LegacyLayouts/ConstraintExpression.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Maui.Controls.Compatibility
 					if (string.IsNullOrEmpty(Property))
 						return null;
 					minfo = typeof(View).GetProperties().First(pi => pi.Name == Property && pi.CanRead && pi.GetMethod.IsPublic).GetMethod;
-					return Constraint.RelativeToParent(p => (double)minfo.Invoke(p, new object[] { }) * Factor + Constant);
+					return Constraint.RelativeToParent(p => (double)minfo.Invoke(p, Array.Empty<object>()) * Factor + Constant);
 				case ConstraintType.Constant:
 					return Constraint.Constant(Constant);
 				case ConstraintType.RelativeToView:
@@ -62,7 +62,7 @@ namespace Microsoft.Maui.Controls.Compatibility
 						view = ((INameScope)valueProvider.TargetObject).FindByName<View>(ElementName);
 					}
 					return Constraint.RelativeToView(view, delegate (RelativeLayout p, View v)
-					{ return (double)minfo.Invoke(v, new object[] { }) * Factor + Constant; });
+					{ return (double)minfo.Invoke(v, Array.Empty<object>()) * Factor + Constant; });
 			}
 		}
 	}

--- a/src/Controls/src/Core/Menu/MenuItemTracker.cs
+++ b/src/Controls/src/Core/Menu/MenuItemTracker.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Maui.Controls
 			get
 			{
 				if (Target == null)
-					return new TMenuItem[0];
+					return Array.Empty<TMenuItem>();
 
 				// I realize this is sorting on every single get but we don't have 
 				// a mechanism in place currently to invalidate a stored version of this

--- a/src/Controls/src/Core/Platform/iOS/DragAndDropDelegate.cs
+++ b/src/Controls/src/Core/Platform/iOS/DragAndDropDelegate.cs
@@ -231,7 +231,7 @@ namespace Microsoft.Maui.Controls.Platform
 			},
 			element);
 
-			return returnValue ?? new UIDragItem[0];
+			return returnValue ?? Array.Empty<UIDragItem>();
 		}
 
 		void SetLocalObject(UIDragItem dragItem, IPlatformViewHandler handler, DataPackage data)

--- a/src/Controls/src/Core/Platform/iOS/Extensions/BrushExtensions.cs
+++ b/src/Controls/src/Core/Platform/iOS/Extensions/BrushExtensions.cs
@@ -1,4 +1,5 @@
 #nullable disable
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using CoreAnimation;
@@ -222,7 +223,7 @@ namespace Microsoft.Maui.Controls.Platform
 		static NSNumber[] GetCAGradientLayerLocations(List<GradientStop> gradientStops)
 		{
 			if (gradientStops == null || gradientStops.Count == 0)
-				return new NSNumber[0];
+				return Array.Empty<NSNumber>();
 
 			if (gradientStops.Count > 1 && gradientStops.Any(gt => gt.Offset != 0))
 				return gradientStops.Select(x => new NSNumber(x.Offset)).ToArray();
@@ -254,7 +255,7 @@ namespace Microsoft.Maui.Controls.Platform
 		static CGColor[] GetCAGradientLayerColors(List<GradientStop> gradientStops)
 		{
 			if (gradientStops == null || gradientStops.Count == 0)
-				return new CGColor[0];
+				return Array.Empty<CGColor>();
 
 			CGColor[] colors = new CGColor[gradientStops.Count];
 

--- a/src/Controls/src/Core/PlatformBindingHelpers.cs
+++ b/src/Controls/src/Core/PlatformBindingHelpers.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Maui.Controls.Internals
 			BindableObjectProxy<TPlatformView> proxy;
 			if (!BindableObjectProxy<TPlatformView>.BindableObjectProxies.TryGetValue(target, out proxy))
 				return;
-			SetValueFromRenderer(proxy, bindableProperty, target.GetType().GetProperty(targetProperty)?.GetMethod.Invoke(target, new object[] { }));
+			SetValueFromRenderer(proxy, bindableProperty, target.GetType().GetProperty(targetProperty)?.GetMethod.Invoke(target, Array.Empty<object>()));
 		}
 
 		static void SetValueFromRenderer(BindableObject bindable, BindableProperty property, object value)

--- a/src/Controls/src/Core/TemplatedItemsList.cs
+++ b/src/Controls/src/Core/TemplatedItemsList.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Maui.Controls.Internals
 			if (source != null)
 				ListProxy = new ListProxy(source, dispatcher: _itemsView.Dispatcher);
 			else
-				ListProxy = new ListProxy(new object[0], dispatcher: _itemsView.Dispatcher);
+				ListProxy = new ListProxy(Array.Empty<object>(), dispatcher: _itemsView.Dispatcher);
 		}
 
 		internal TemplatedItemsList(TemplatedItemsList<TView, TItem> parent, IEnumerable itemSource, TView itemsView, BindableProperty itemTemplateProperty, int windowSize = int.MaxValue)
@@ -91,7 +91,7 @@ namespace Microsoft.Maui.Controls.Internals
 				ListProxy.CollectionChanged += OnProxyCollectionChanged;
 			}
 			else
-				ListProxy = new ListProxy(new object[0], dispatcher: _itemsView.Dispatcher);
+				ListProxy = new ListProxy(Array.Empty<object>(), dispatcher: _itemsView.Dispatcher);
 		}
 
 		event PropertyChangedEventHandler ITemplatedItemsList<TItem>.PropertyChanged
@@ -944,7 +944,7 @@ namespace Microsoft.Maui.Controls.Internals
 
 			IEnumerable itemSource = GetItemsViewSource();
 			if (itemSource == null)
-				ListProxy = new ListProxy(new object[0], dispatcher: _itemsView.Dispatcher);
+				ListProxy = new ListProxy(Array.Empty<object>(), dispatcher: _itemsView.Dispatcher);
 			else
 				ListProxy = new ListProxy(itemSource, dispatcher: _itemsView.Dispatcher);
 

--- a/src/Controls/src/Xaml/ApplyPropertiesVisitor.cs
+++ b/src/Controls/src/Xaml/ApplyPropertiesVisitor.cs
@@ -727,7 +727,7 @@ namespace Microsoft.Maui.Controls.Xaml
 			if (!IsVisibleFrom(getter, rootElement))
 				return false;
 
-			value = getter.Invoke(element, new object[] { });
+			value = getter.Invoke(element, Array.Empty<object>());
 			return true;
 		}
 

--- a/src/Controls/src/Xaml/CreateValuesVisitor.cs
+++ b/src/Controls/src/Xaml/CreateValuesVisitor.cs
@@ -233,7 +233,7 @@ namespace Microsoft.Maui.Controls.Xaml
 			}
 
 			var factoryMethod = ((string)((ValueNode)node.Properties[XmlName.xFactoryMethod]).Value);
-			Type[] types = arguments == null ? new Type[0] : arguments.Select(a => a.GetType()).ToArray();
+			Type[] types = arguments == null ? Array.Empty<Type>() : arguments.Select(a => a.GetType()).ToArray();
 
 			bool isMatch(MethodInfo m)
 			{

--- a/src/Controls/src/Xaml/MarkupExtensions/StaticExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/StaticExtension.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Maui.Controls.Xaml
 
 			var pinfo = type.GetRuntimeProperties().FirstOrDefault(pi => pi.Name == membername && pi.GetMethod.IsStatic);
 			if (pinfo != null)
-				return pinfo.GetMethod.Invoke(null, new object[] { });
+				return pinfo.GetMethod.Invoke(null, Array.Empty<object>());
 
 			var finfo = type.GetRuntimeFields().FirstOrDefault(fi => fi.Name == membername && fi.IsStatic);
 			if (finfo != null)

--- a/src/Controls/tests/Core.UnitTests/BindableLayoutTests.cs
+++ b/src/Controls/tests/Core.UnitTests/BindableLayoutTests.cs
@@ -369,7 +369,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 
 			// ItemsSourceProperty
-			IEnumerable itemsSource = new object[0];
+			IEnumerable itemsSource = Array.Empty<object>();
 			BindableLayout.SetItemsSource(layout, itemsSource);
 
 			Assert.Equal(itemsSource, BindableLayout.GetItemsSource(layout));

--- a/src/Controls/tests/Core.UnitTests/BindingBaseUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/BindingBaseUnitTests.cs
@@ -696,9 +696,9 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		{
 			Assert.Throws<ArgumentNullException>(() => BindingBase.EnableCollectionSynchronization(null, new object(),
 			   (collection, context, method, access) => { }));
-			Assert.Throws<ArgumentNullException>(() => BindingBase.EnableCollectionSynchronization(new string[0], new object(), null));
+			Assert.Throws<ArgumentNullException>(() => BindingBase.EnableCollectionSynchronization(Array.Empty<string>(), new object(), null));
 
-			BindingBase.EnableCollectionSynchronization(new string[0], null, (collection, context, method, access) => { });
+			BindingBase.EnableCollectionSynchronization(Array.Empty<string>(), null, (collection, context, method, access) => { });
 		}
 
 		[Fact]

--- a/src/Controls/tests/Core.UnitTests/DynamicBindingContextTests.cs
+++ b/src/Controls/tests/Core.UnitTests/DynamicBindingContextTests.cs
@@ -124,7 +124,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 					public override ParameterInfo[] GetIndexParameters()
 					{
-						return new ParameterInfo[0];
+						return Array.Empty<ParameterInfo>();
 					}
 
 					public override object GetValue(object obj, BindingFlags invokeAttr, Binder binder, object[] index, System.Globalization.CultureInfo culture)
@@ -247,7 +247,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 					public override ParameterInfo[] GetParameters()
 					{
-						return new ParameterInfo[0];
+						return Array.Empty<ParameterInfo>();
 					}
 
 					public override RuntimeMethodHandle MethodHandle
@@ -262,12 +262,12 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 					public override object[] GetCustomAttributes(Type attributeType, bool inherit)
 					{
-						return new object[0];
+						return Array.Empty<object>();
 					}
 
 					public override object[] GetCustomAttributes(bool inherit)
 					{
-						return new object[0];
+						return Array.Empty<object>();
 					}
 
 					public override bool IsDefined(Type attributeType, bool inherit)

--- a/src/Controls/tests/Core.UnitTests/NotifiedPropertiesTests.cs
+++ b/src/Controls/tests/Core.UnitTests/NotifiedPropertiesTests.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 					return init();
 				if (typeof(TView) == typeof(View))
 					return new View();
-				return (TView)Activator.CreateInstance(typeof(TView), new object[] { });
+				return (TView)Activator.CreateInstance(typeof(TView), Array.Empty<object>());
 			}
 
 			public override string DebugName

--- a/src/Controls/tests/Core.UnitTests/TemplatedItemsListTests.cs
+++ b/src/Controls/tests/Core.UnitTests/TemplatedItemsListTests.cs
@@ -494,7 +494,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 					raised = true;
 			};
 
-			bindable.ItemsSource = new object[0];
+			bindable.ItemsSource = Array.Empty<object>();
 
 			Assert.True(raised, "INPC not raised for ItemsSource");
 		}

--- a/src/Controls/tests/DeviceTests/ControlsHandlerTestBase.iOS.cs
+++ b/src/Controls/tests/DeviceTests/ControlsHandlerTestBase.iOS.cs
@@ -128,7 +128,7 @@ namespace Microsoft.Maui.DeviceTests
 				handler = page.GetCurrentPage()?.Handler;
 
 			if (handler is null)
-				return new UIViewController[0];
+				return Array.Empty<UIViewController>();
 
 			var navControllerResponder = (handler.PlatformView as UIView).FindResponder<UINavigationController>();
 
@@ -140,7 +140,7 @@ namespace Microsoft.Maui.DeviceTests
 			if (contentResponder?.NavigationController is not null)
 				return contentResponder.NavigationController.ChildViewControllers;
 
-			return new UIViewController[0];
+			return Array.Empty<UIViewController>();
 		}
 
 		UIViewController GetVisibleViewController(IElementHandler handler)

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Gh4516.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Gh4516.xaml.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 {
 	public class Gh4516VM
 	{
-		public Uri[] Images { get; } = { };
+		public Uri[] Images { get; } = Array.Empty<Uri>();
 	}
 
 	public partial class Gh4516 : ContentPage

--- a/src/Controls/tests/Xaml.UnitTests/NativeViewsAndBindings.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/NativeViewsAndBindings.xaml.cs
@@ -73,7 +73,7 @@ public static class NativeBindingHelpers
 		BindableProperty bindableProperty = null;
 		propertyChanged ??= target as INotifyPropertyChanged;
 		var propertyType = target.GetType().GetProperty(targetProperty)?.PropertyType;
-		var defaultValue = target.GetType().GetProperty(targetProperty)?.GetMethod.Invoke(target, new object[] { });
+		var defaultValue = target.GetType().GetProperty(targetProperty)?.GetMethod.Invoke(target, Array.Empty<object>());
 		bindableProperty = CreateBindableProperty<TNativeView>(targetProperty, propertyType, defaultValue);
 		if (binding != null && binding.Mode != BindingMode.OneWay && propertyChanged != null)
 			propertyChanged.PropertyChanged += (sender, e) =>
@@ -123,7 +123,7 @@ public static class NativeBindingHelpers
 		BindableObjectProxy<TNativeView> proxy;
 		if (!BindableObjectProxy<TNativeView>.BindableObjectProxies.TryGetValue(target, out proxy))
 			return;
-		SetValueFromRenderer(proxy, bindableProperty, target.GetType().GetProperty(targetProperty)?.GetMethod.Invoke(target, new object[] { }));
+		SetValueFromRenderer(proxy, bindableProperty, target.GetType().GetProperty(targetProperty)?.GetMethod.Invoke(target, Array.Empty<object>()));
 	}
 
 	static void SetValueFromRenderer(BindableObject bindable, BindableProperty property, object value) => bindable.SetValueCore(property, value);

--- a/src/Core/src/.editorconfig
+++ b/src/Core/src/.editorconfig
@@ -10,7 +10,6 @@ dotnet_diagnostic.CA1307.severity = error
 dotnet_diagnostic.CA1805.severity = error
 dotnet_diagnostic.CA1806.severity = error
 dotnet_diagnostic.CA1822.severity = error
-dotnet_diagnostic.CA1825.severity = error
 dotnet_diagnostic.CA1834.severity = error
 dotnet_diagnostic.CA1845.severity = error
 dotnet_diagnostic.CA1846.severity = error

--- a/src/Essentials/samples/Samples/Model/SampleItem.cs
+++ b/src/Essentials/samples/Samples/Model/SampleItem.cs
@@ -10,7 +10,7 @@ namespace Samples.Model
 			Name = name;
 			Description = description;
 			PageType = pageType;
-			Tags = tags ?? new string[0];
+			Tags = tags ?? Array.Empty<string>();
 		}
 
 		public string Icon { get; }

--- a/src/Essentials/src/Sms/Sms.ios.cs
+++ b/src/Essentials/src/Sms/Sms.ios.cs
@@ -1,6 +1,7 @@
-using System.Linq;
 using System.Threading.Tasks;
 #if !(MACCATALYST || MACOS)
+using System;
+using System.Linq;
 using MessageUI;
 #endif
 
@@ -26,7 +27,7 @@ namespace Microsoft.Maui.ApplicationModel.Communication
 			if (!string.IsNullOrWhiteSpace(message?.Body))
 				messageController.Body = message.Body;
 
-			messageController.Recipients = message?.Recipients?.ToArray() ?? new string[] { };
+			messageController.Recipients = message?.Recipients?.ToArray() ?? Array.Empty<string>();
 
 			// show the controller
 			var tcs = new TaskCompletionSource<bool>();

--- a/src/Essentials/src/VersionTracking/VersionTracking.shared.cs
+++ b/src/Essentials/src/VersionTracking/VersionTracking.shared.cs
@@ -326,7 +326,7 @@ namespace Microsoft.Maui.ApplicationModel
 		}
 
 		string[] ReadHistory(string key)
-			=> preferences.Get<string?>(key, null, sharedName)?.Split(new[] { '|' }, StringSplitOptions.RemoveEmptyEntries) ?? new string[0];
+			=> preferences.Get<string?>(key, null, sharedName)?.Split(new[] { '|' }, StringSplitOptions.RemoveEmptyEntries) ?? Array.Empty<string>();
 
 		void WriteHistory(string key, IEnumerable<string> history)
 			=> preferences.Set(key, string.Join("|", history), sharedName);

--- a/src/Graphics/src/Graphics/PathF.cs
+++ b/src/Graphics/src/Graphics/PathF.cs
@@ -666,7 +666,7 @@ namespace Microsoft.Maui.Graphics
 					{
 						if (segment == segmentIndex)
 						{
-							return new PointF[] { };
+							return Array.Empty<PointF>();
 						}
 					}
 				}

--- a/src/Graphics/src/Graphics/Platforms/MaciOS/PlatformCanvas.cs
+++ b/src/Graphics/src/Graphics/Platforms/MaciOS/PlatformCanvas.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Maui.Graphics.Platform
 {
 	public partial class PlatformCanvas : AbstractCanvas<PlatformCanvasState>
 	{
-		private static readonly nfloat[] EmptyNFloatArray = { };
+		private static readonly nfloat[] EmptyNFloatArray = Array.Empty<nfloat>();
 		private static readonly CGAffineTransform FlipTransform = new CGAffineTransform(1.0f, 0.0f, 0.0f, -1.0f, 0.0f, 0.0f);
 
 		private bool _antialias = true;

--- a/src/Graphics/src/Graphics/Platforms/Windows/PlatformCanvasState.cs
+++ b/src/Graphics/src/Graphics/Platforms/Windows/PlatformCanvasState.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Maui.Graphics.Platform
 #endif
 		: CanvasState
 	{
-		private static readonly float[] _emptyFloatArray = new float[] { };
+		private static readonly float[] _emptyFloatArray = Array.Empty<float>();
 
 		private readonly PlatformCanvas _owner;
 		private readonly PlatformCanvasState _parentState;

--- a/src/Graphics/src/Graphics/Platforms/iOS/UIViewExtensions.cs
+++ b/src/Graphics/src/Graphics/Platforms/iOS/UIViewExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using Foundation;
 using UIKit;
 
@@ -10,7 +11,7 @@ namespace Microsoft.Maui.Graphics.Platform
 			var touchSet = touchEvent.TouchesForView(target);
 			if (touchSet.Count == 0)
 			{
-				return new PointF[0];
+				return Array.Empty<PointF>();
 			}
 
 			var touches = touchSet.ToArray<UITouch>();


### PR DESCRIPTION
### Description of Change

Noticed while looking at another issue that CA1825 is configured as an error in .editorconfig, but there are various violations.
Pretty minor, but looks like it saves a reasonable number of allocations in some bindings scenarios at least. Thought the blanket fix-all should be reasonable since it should be a non-breaking change.