### PR TITLE
[Android] Make Flyout footer aware of header/content margin

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellFlyoutTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellFlyoutTests.cs
@@ -189,8 +189,6 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
-		// Skipping this for Android because there is a bug with the footer. Fix coming in a separate PR.
-#if IOS
 		[Theory]
 		[ClassData(typeof(ShellFlyoutHeaderBehaviorAndContentTestCases))]
 		public async Task FlyoutHeaderContentAndFooterAllMeasureCorrectly(
@@ -263,14 +261,13 @@ namespace Microsoft.Maui.DeviceTests
 				// validate footer position
 				var expectedFooterY = expectedContentY + contentMargin.Bottom + contentFrame.Height;
 				AssertionExtensions.CloseEnough(0, footerFrame.X, message: "Footer X");
-				AssertionExtensions.CloseEnough(expectedFooterY, footerFrame.Y, epsilon: 0.5, message: "Footer Y");
+				AssertionExtensions.CloseEnough(expectedFooterY, footerFrame.Y, epsilon: 0.6, message: "Footer Y");
 				AssertionExtensions.CloseEnough(flyoutFrame.Width, footerFrame.Width, message: "Footer Width");
 
 				//All three views should measure to the height of the flyout
 				AssertionExtensions.CloseEnough(expectedFooterY + footerFrame.Height, flyoutFrame.Height, epsilon: 0.5, message: "Total Height");
 			});
 		}
-#endif
 #endif
 
 #if ANDROID || IOS


### PR DESCRIPTION
### Description of Change

We were not considering the header and content positioning for the footer when the flyout view was a ScrollView and ViewGroup, but that's something we should always execute. The only extra thing we need to do in that case is set padding, as it was already explained in the code.

Also, re-enable the tests that discovered this issue (originally added by https://github.com/dotnet/maui/pull/19125)
