### PR TITLE
Allow for disabling default MAUI usings when embedding

### DIFF
--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.Globs.props
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.Globs.props
@@ -7,7 +7,7 @@
     </MauiXaml>
   </ItemDefinitionGroup>
 
-  <ItemGroup Condition=" ('$(MauiDisableMauiUsings)' != 'true') and ('$(ImplicitUsings)' == 'true' or '$(ImplicitUsings)' == 'enable') and '$(TargetFrameworkVersion)' != '' ">
+  <ItemGroup Condition=" ('$(MauiEnablePlatformUsings)' != 'true') and ('$(ImplicitUsings)' == 'true' or '$(ImplicitUsings)' == 'enable') and '$(TargetFrameworkVersion)' != '' ">
     <!-- %(Sdk) is only here if something later needs to identify these -->
     <Using Include="Microsoft.Extensions.DependencyInjection" Sdk="Maui" />
     <Using Include="Microsoft.Maui" Sdk="Maui" />

--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.Globs.props
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.Globs.props
@@ -7,7 +7,7 @@
     </MauiXaml>
   </ItemDefinitionGroup>
 
-  <ItemGroup Condition=" ('$(DisableDefaultMauiUsings)' != 'true') and ('$(ImplicitUsings)' == 'true' or '$(ImplicitUsings)' == 'enable') and '$(TargetFrameworkVersion)' != '' ">
+  <ItemGroup Condition=" ('$(MauiDisableMauiUsings)' != 'true') and ('$(ImplicitUsings)' == 'true' or '$(ImplicitUsings)' == 'enable') and '$(TargetFrameworkVersion)' != '' ">
     <!-- %(Sdk) is only here if something later needs to identify these -->
     <Using Include="Microsoft.Extensions.DependencyInjection" Sdk="Maui" />
     <Using Include="Microsoft.Maui" Sdk="Maui" />

--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.Globs.props
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.Globs.props
@@ -7,7 +7,7 @@
     </MauiXaml>
   </ItemDefinitionGroup>
 
-  <ItemGroup Condition=" ('$(ImplicitUsings)' == 'true' or '$(ImplicitUsings)' == 'enable') and '$(TargetFrameworkVersion)' != '' ">
+  <ItemGroup Condition=" ('$(DisableDefaultMauiUsings)' != 'true') and ('$(ImplicitUsings)' == 'true' or '$(ImplicitUsings)' == 'enable') and '$(TargetFrameworkVersion)' != '' ">
     <!-- %(Sdk) is only here if something later needs to identify these -->
     <Using Include="Microsoft.Extensions.DependencyInjection" Sdk="Maui" />
     <Using Include="Microsoft.Maui" Sdk="Maui" />


### PR DESCRIPTION
### Description of Change

Provide a way to disable the maui usings when embedding to avoid many ambiguities.

This is mainly for windows, but android does have a few as well.