### PR TITLE
XamlC WarnAsErrors.

### DIFF
--- a/src/Controls/src/Build.Tasks/BuildException.cs
+++ b/src/Controls/src/Build.Tasks/BuildException.cs
@@ -41,56 +41,61 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 	class BuildExceptionCode
 	{
 		//Assemblies, Types, Members
-		public static BuildExceptionCode TypeResolution = new BuildExceptionCode("XFC0000", nameof(TypeResolution), "");
-		public static BuildExceptionCode PropertyResolution = new BuildExceptionCode("XFC0001", nameof(PropertyResolution), "");
-		public static BuildExceptionCode MissingEventHandler = new BuildExceptionCode("XFC0002", nameof(MissingEventHandler), "");
-		public static BuildExceptionCode PropertyMissing = new BuildExceptionCode("XFC0003", nameof(PropertyMissing), "");
-		public static BuildExceptionCode ConstructorDefaultMissing = new BuildExceptionCode("XFC0004", nameof(ConstructorDefaultMissing), "");
-		public static BuildExceptionCode ConstructorXArgsMissing = new BuildExceptionCode("XFC0005", nameof(ConstructorXArgsMissing), "");
-		public static BuildExceptionCode MethodStaticMissing = new BuildExceptionCode("XFC0006", nameof(MethodStaticMissing), "");
-		public static BuildExceptionCode EnumValueMissing = new BuildExceptionCode("XFC0007", nameof(EnumValueMissing), "");
-		public static BuildExceptionCode AdderMissing = new BuildExceptionCode("XFC0008", nameof(AdderMissing), "");
-		public static BuildExceptionCode MemberResolution = new BuildExceptionCode("XFC0009", nameof(MemberResolution), "");
-
+		public static BuildExceptionCode TypeResolution = new BuildExceptionCode("XFC", 0000, nameof(TypeResolution), "");
+		public static BuildExceptionCode PropertyResolution = new BuildExceptionCode("XFC", 0001, nameof(PropertyResolution), "");
+		public static BuildExceptionCode MissingEventHandler = new BuildExceptionCode("XFC", 0002, nameof(MissingEventHandler), "");
+		public static BuildExceptionCode PropertyMissing = new BuildExceptionCode("XFC", 0003, nameof(PropertyMissing), "");
+		public static BuildExceptionCode ConstructorDefaultMissing = new BuildExceptionCode("XFC", 0004, nameof(ConstructorDefaultMissing), "");
+		public static BuildExceptionCode ConstructorXArgsMissing = new BuildExceptionCode("XFC", 0005, nameof(ConstructorXArgsMissing), "");
+		public static BuildExceptionCode MethodStaticMissing = new BuildExceptionCode("XFC", 0006, nameof(MethodStaticMissing), "");
+		public static BuildExceptionCode EnumValueMissing = new BuildExceptionCode("XFC", 0007, nameof(EnumValueMissing), "");
+		public static BuildExceptionCode AdderMissing = new BuildExceptionCode("XFC", 0008, nameof(AdderMissing), "");
+		public static BuildExceptionCode MemberResolution = new BuildExceptionCode("XFC", 0009, nameof(MemberResolution), "");
 
 		//BP,BO
-		public static BuildExceptionCode BPName = new BuildExceptionCode("XFC0020", nameof(BPName), "");
-		public static BuildExceptionCode BPMissingGetter = new BuildExceptionCode("XFC0021", nameof(BPMissingGetter), "");
+		public static BuildExceptionCode BPName = new BuildExceptionCode("XFC", 0020, nameof(BPName), "");
+		public static BuildExceptionCode BPMissingGetter = new BuildExceptionCode("XFC", 0021, nameof(BPMissingGetter), "");
 
 		//Bindings, conversions
-		public static BuildExceptionCode Conversion = new BuildExceptionCode("XFC0040", nameof(Conversion), "");
-		public static BuildExceptionCode BindingIndexerNotClosed = new BuildExceptionCode("XFC0041", nameof(BindingIndexerNotClosed), "");
-		public static BuildExceptionCode BindingIndexerEmpty = new BuildExceptionCode("XFC0042", nameof(BindingIndexerEmpty), "");
-		public static BuildExceptionCode BindingIndexerTypeUnsupported = new BuildExceptionCode("XFC0043", nameof(BindingIndexerTypeUnsupported), "");
-		public static BuildExceptionCode BindingIndexerParse = new BuildExceptionCode("XFC0044", nameof(BindingIndexerParse), "");
-		public static BuildExceptionCode BindingPropertyNotFound = new BuildExceptionCode("XFC0045", nameof(BindingPropertyNotFound), "");
+		public static BuildExceptionCode Conversion = new BuildExceptionCode("XFC", 0040, nameof(Conversion), "");
+		public static BuildExceptionCode BindingIndexerNotClosed = new BuildExceptionCode("XFC", 0041, nameof(BindingIndexerNotClosed), "");
+		public static BuildExceptionCode BindingIndexerEmpty = new BuildExceptionCode("XFC", 0042, nameof(BindingIndexerEmpty), "");
+		public static BuildExceptionCode BindingIndexerTypeUnsupported = new BuildExceptionCode("XFC", 0043, nameof(BindingIndexerTypeUnsupported), "");
+		public static BuildExceptionCode BindingIndexerParse = new BuildExceptionCode("XFC", 0044, nameof(BindingIndexerParse), "");
+		public static BuildExceptionCode BindingPropertyNotFound = new BuildExceptionCode("XFC", 0045, nameof(BindingPropertyNotFound), "");
 
 		//XAML issues
-		public static BuildExceptionCode MarkupNotClosed = new BuildExceptionCode("XFC0060", nameof(MarkupNotClosed), "");
-		public static BuildExceptionCode MarkupParsingFailed = new BuildExceptionCode("XFC0061", nameof(MarkupParsingFailed), "");
-		public static BuildExceptionCode XmlnsUndeclared = new BuildExceptionCode("XFC0062", nameof(XmlnsUndeclared), "");
-		public static BuildExceptionCode SByteEnums = new BuildExceptionCode("XFC0063", nameof(SByteEnums), "");
-		public static BuildExceptionCode NamescopeDuplicate = new BuildExceptionCode("XFC0064", nameof(NamescopeDuplicate), "");
-		public static BuildExceptionCode ContentPropertyAttributeMissing = new BuildExceptionCode("XFC0065", nameof(ContentPropertyAttributeMissing), "");
-		public static BuildExceptionCode InvalidXaml = new BuildExceptionCode("XFC0066", nameof(InvalidXaml), "");
+		public static BuildExceptionCode MarkupNotClosed = new BuildExceptionCode("XFC", 0060, nameof(MarkupNotClosed), "");
+		public static BuildExceptionCode MarkupParsingFailed = new BuildExceptionCode("XFC", 0061, nameof(MarkupParsingFailed), "");
+		public static BuildExceptionCode XmlnsUndeclared = new BuildExceptionCode("XFC", 0062, nameof(XmlnsUndeclared), "");
+		public static BuildExceptionCode SByteEnums = new BuildExceptionCode("XFC", 0063, nameof(SByteEnums), "");
+		public static BuildExceptionCode NamescopeDuplicate = new BuildExceptionCode("XFC", 0064, nameof(NamescopeDuplicate), "");
+		public static BuildExceptionCode ContentPropertyAttributeMissing = new BuildExceptionCode("XFC", 0065, nameof(ContentPropertyAttributeMissing), "");
+		public static BuildExceptionCode InvalidXaml = new BuildExceptionCode("XFC", 0066, nameof(InvalidXaml), "");
 
 
 		//Extensions
-		public static BuildExceptionCode XStaticSyntax = new BuildExceptionCode("XFC0100", nameof(XStaticSyntax), "");
-		public static BuildExceptionCode XStaticResolution = new BuildExceptionCode("XFC0101", nameof(XStaticResolution), "");
-		public static BuildExceptionCode XDataTypeSyntax = new BuildExceptionCode("XFC0102", nameof(XDataTypeSyntax), "");
+		public static BuildExceptionCode XStaticSyntax = new BuildExceptionCode("XFC", 0100, nameof(XStaticSyntax), "");
+		public static BuildExceptionCode XStaticResolution = new BuildExceptionCode("XFC", 0101, nameof(XStaticResolution), "");
+		public static BuildExceptionCode XDataTypeSyntax = new BuildExceptionCode("XFC", 0102, nameof(XDataTypeSyntax), "");
 
 		//Style, StyleSheets, Resources
-		public static BuildExceptionCode StyleSheetSourceOrContent = new BuildExceptionCode("XFC0120", nameof(StyleSheetSourceOrContent), "");
-		public static BuildExceptionCode StyleSheetNoSourceOrContent = new BuildExceptionCode("XFC0121", nameof(StyleSheetNoSourceOrContent), "");
-		public static BuildExceptionCode StyleSheetStyleNotALiteral = new BuildExceptionCode("XFC0122", nameof(StyleSheetStyleNotALiteral), "");
-		public static BuildExceptionCode StyleSheetSourceNotALiteral = new BuildExceptionCode("XFC0123", nameof(StyleSheetSourceNotALiteral), "");
-		public static BuildExceptionCode ResourceMissing = new BuildExceptionCode("XFC0124", nameof(ResourceMissing), "");
-		public static BuildExceptionCode ResourceDictDuplicateKey = new BuildExceptionCode("XFC0125", nameof(ResourceDictDuplicateKey), "");
-		public static BuildExceptionCode ResourceDictMissingKey = new BuildExceptionCode("XFC0126", nameof(ResourceDictMissingKey), "");
-		public static BuildExceptionCode XKeyNotLiteral = new BuildExceptionCode("XFC0127", nameof(XKeyNotLiteral), "");
+		public static BuildExceptionCode StyleSheetSourceOrContent = new BuildExceptionCode("XFC", 0120, nameof(StyleSheetSourceOrContent), "");
+		public static BuildExceptionCode StyleSheetNoSourceOrContent = new BuildExceptionCode("XFC", 0121, nameof(StyleSheetNoSourceOrContent), "");
+		public static BuildExceptionCode StyleSheetStyleNotALiteral = new BuildExceptionCode("XFC", 0122, nameof(StyleSheetStyleNotALiteral), "");
+		public static BuildExceptionCode StyleSheetSourceNotALiteral = new BuildExceptionCode("XFC", 0123, nameof(StyleSheetSourceNotALiteral), "");
+		public static BuildExceptionCode ResourceMissing = new BuildExceptionCode("XFC", 0124, nameof(ResourceMissing), "");
+		public static BuildExceptionCode ResourceDictDuplicateKey = new BuildExceptionCode("XFC", 0125, nameof(ResourceDictDuplicateKey), "");
+		public static BuildExceptionCode ResourceDictMissingKey = new BuildExceptionCode("XFC", 0126, nameof(ResourceDictMissingKey), "");
+		public static BuildExceptionCode XKeyNotLiteral = new BuildExceptionCode("XFC", 0127, nameof(XKeyNotLiteral), "");
 
-		public string Code { get; private set; }
+		//CSC equivalents
+		public static BuildExceptionCode ObsoleteProperty = new BuildExceptionCode("XC", 0618, nameof(ObsoleteProperty), "");
+
+		public string Code { get; }
+		public string CodePrefix { get; }
+		public int CodeCode { get; }
+
 		public string ErrorMessageKey { get; private set; }
 		public string HelpLink { get; private set; }
 
@@ -98,10 +103,12 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 		{
 		}
 
-		BuildExceptionCode(string code, string errorMessage, string helpLink)
+		BuildExceptionCode(string codePrefix, int codeCode, string errorMessageKey, string helpLink)
 		{
-			Code = code;
-			ErrorMessageKey = errorMessage;
+			Code = $"{codePrefix}{codeCode:0000}";
+			CodePrefix = codePrefix;
+			CodeCode = codeCode;
+			ErrorMessageKey = errorMessageKey;
 			HelpLink = helpLink;
 		}
 	}

--- a/src/Controls/src/Build.Tasks/ErrorMessages.Designer.cs
+++ b/src/Controls/src/Build.Tasks/ErrorMessages.Designer.cs
@@ -383,5 +383,14 @@ namespace Microsoft.Maui.Controls.Build.Tasks {
                 return ResourceManager.GetString("XStaticSyntax", resourceCulture);
             }
         }
+
+        /// <summary>
+        /// Gets the error message for the obsolete property.
+        /// </summary>
+        internal static string ObsoleteProperty {
+            get {
+                return ResourceManager.GetString("ObsoleteProperty", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Controls/src/Build.Tasks/ErrorMessages.resx
+++ b/src/Controls/src/Build.Tasks/ErrorMessages.resx
@@ -193,6 +193,9 @@
     <value>An element with the name "{0}" already exists in this NameScope.</value>
     <comment>0 is the duplicated key</comment>
   </data>
+  <data name="ObsoleteProperty" xml:space="preserve">
+    <value>Property, Property setter or BindableProperty "{0}" is deprecated.</value>
+  </data>  
   <data name="PropertyMissing" xml:space="preserve">
     <value>Missing mandatory property "{0}" on "{1}".</value>
     <comment>0 is a property name, 1 is a type</comment>

--- a/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
+++ b/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
@@ -1011,7 +1011,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 
 			var isObsolete = bpDef.CustomAttributes.Any(ca => ca.AttributeType.FullName == "System.ObsoleteAttribute");
 			if (isObsolete)
-				context.LoggingHelper.LogWarningOrError("0618", context.XamlFilePath, iXmlLineInfo.LineNumber, iXmlLineInfo.LinePosition, 0, 0, $"BindableProperty {localName} is deprecated.", null);
+				context.LoggingHelper.LogWarningOrError(618, context.XamlFilePath, iXmlLineInfo.LineNumber, iXmlLineInfo.LinePosition, 0, 0, $"BindableProperty {localName} is deprecated.", null);
 
 			return bpRef;
 		}
@@ -1351,12 +1351,12 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 			var property = parent.VariableType.GetProperty(context.Cache, pd => pd.Name == localName, out declaringTypeReference);
 			var propertyIsObsolete = property.CustomAttributes.Any(ca => ca.AttributeType.FullName == "System.ObsoleteAttribute");
 			if (propertyIsObsolete)
-				context.LoggingHelper.LogWarningOrError("0618", context.XamlFilePath, iXmlLineInfo.LineNumber, iXmlLineInfo.LinePosition, 0, 0, $"Property {localName} is deprecated.", null);
+				context.LoggingHelper.LogWarningOrError(618, context.XamlFilePath, iXmlLineInfo.LineNumber, iXmlLineInfo.LinePosition, 0, 0, $"Property {localName} is deprecated.", null);
 
 			var propertySetter = property.SetMethod;
 			var propertySetterIsObsolete = propertySetter.CustomAttributes.Any(ca => ca.AttributeType.FullName == "System.ObsoleteAttribute");
 			if (propertySetterIsObsolete)
-				context.LoggingHelper.LogWarningOrError("0618", context.XamlFilePath, iXmlLineInfo.LineNumber, iXmlLineInfo.LinePosition, 0, 0, $"Property setter for {localName} is deprecated.", null);
+				context.LoggingHelper.LogWarningOrError(618, context.XamlFilePath, iXmlLineInfo.LineNumber, iXmlLineInfo.LinePosition, 0, 0, $"Property setter for {localName} is deprecated.", null);
 
 			//			IL_0007:  ldloc.0
 			//			IL_0008:  ldstr "foo"

--- a/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
+++ b/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
@@ -1011,7 +1011,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 
 			var isObsolete = bpDef.CustomAttributes.Any(ca => ca.AttributeType.FullName == "System.ObsoleteAttribute");
 			if (isObsolete)
-				context.LoggingHelper.LogWarning("XamlC", null, null, context.XamlFilePath, iXmlLineInfo.LineNumber, iXmlLineInfo.LinePosition, 0, 0, $"BindableProperty {localName} is deprecated.", null);
+				context.LoggingHelper.LogWarningOrError("0618", context.XamlFilePath, iXmlLineInfo.LineNumber, iXmlLineInfo.LinePosition, 0, 0, $"BindableProperty {localName} is deprecated.", null);
 
 			return bpRef;
 		}
@@ -1351,12 +1351,12 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 			var property = parent.VariableType.GetProperty(context.Cache, pd => pd.Name == localName, out declaringTypeReference);
 			var propertyIsObsolete = property.CustomAttributes.Any(ca => ca.AttributeType.FullName == "System.ObsoleteAttribute");
 			if (propertyIsObsolete)
-				context.LoggingHelper.LogWarning("XamlC", null, null, context.XamlFilePath, iXmlLineInfo.LineNumber, iXmlLineInfo.LinePosition, 0, 0, $"Property {localName} is deprecated.", null);
+				context.LoggingHelper.LogWarningOrError("0618", context.XamlFilePath, iXmlLineInfo.LineNumber, iXmlLineInfo.LinePosition, 0, 0, $"Property {localName} is deprecated.", null);
 
 			var propertySetter = property.SetMethod;
 			var propertySetterIsObsolete = propertySetter.CustomAttributes.Any(ca => ca.AttributeType.FullName == "System.ObsoleteAttribute");
 			if (propertySetterIsObsolete)
-				context.LoggingHelper.LogWarning("XamlC", null, null, context.XamlFilePath, iXmlLineInfo.LineNumber, iXmlLineInfo.LinePosition, 0, 0, $"Property setter for {localName} is deprecated.", null);
+				context.LoggingHelper.LogWarningOrError("0618", context.XamlFilePath, iXmlLineInfo.LineNumber, iXmlLineInfo.LinePosition, 0, 0, $"Property setter for {localName} is deprecated.", null);
 
 			//			IL_0007:  ldloc.0
 			//			IL_0008:  ldstr "foo"

--- a/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
+++ b/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
@@ -1011,7 +1011,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 
 			var isObsolete = bpDef.CustomAttributes.Any(ca => ca.AttributeType.FullName == "System.ObsoleteAttribute");
 			if (isObsolete)
-				context.LoggingHelper.LogWarningOrError(618, context.XamlFilePath, iXmlLineInfo.LineNumber, iXmlLineInfo.LinePosition, 0, 0, $"BindableProperty {localName} is deprecated.", null);
+				context.LoggingHelper.LogWarningOrError(BuildExceptionCode.ObsoleteProperty, context.XamlFilePath, iXmlLineInfo.LineNumber, iXmlLineInfo.LinePosition, 0, 0, localName);
 
 			return bpRef;
 		}
@@ -1351,12 +1351,12 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 			var property = parent.VariableType.GetProperty(context.Cache, pd => pd.Name == localName, out declaringTypeReference);
 			var propertyIsObsolete = property.CustomAttributes.Any(ca => ca.AttributeType.FullName == "System.ObsoleteAttribute");
 			if (propertyIsObsolete)
-				context.LoggingHelper.LogWarningOrError(618, context.XamlFilePath, iXmlLineInfo.LineNumber, iXmlLineInfo.LinePosition, 0, 0, $"Property {localName} is deprecated.", null);
+				context.LoggingHelper.LogWarningOrError(BuildExceptionCode.ObsoleteProperty, context.XamlFilePath, iXmlLineInfo.LineNumber, iXmlLineInfo.LinePosition, 0, 0, localName);
 
 			var propertySetter = property.SetMethod;
 			var propertySetterIsObsolete = propertySetter.CustomAttributes.Any(ca => ca.AttributeType.FullName == "System.ObsoleteAttribute");
 			if (propertySetterIsObsolete)
-				context.LoggingHelper.LogWarningOrError(618, context.XamlFilePath, iXmlLineInfo.LineNumber, iXmlLineInfo.LinePosition, 0, 0, $"Property setter for {localName} is deprecated.", null);
+				context.LoggingHelper.LogWarningOrError(BuildExceptionCode.ObsoleteProperty, context.XamlFilePath, iXmlLineInfo.LineNumber, iXmlLineInfo.LinePosition, 0, 0, localName);
 
 			//			IL_0007:  ldloc.0
 			//			IL_0008:  ldstr "foo"

--- a/src/Controls/src/Build.Tasks/XamlCTask.cs
+++ b/src/Controls/src/Build.Tasks/XamlCTask.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 	/// <summary>
 	/// Provides extension methods for the <see cref="TaskLoggingHelper"/> class to assist with logging warnings and errors.
 	/// </summary>
-	public static class LoggingHelperExtensions
+	static class LoggingHelperExtensions
 	{
 		class LoggingHelperContext
 		{
@@ -74,19 +74,18 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 			}).Where(i => i != -1).ToList();
 		}
 
-		public static void LogWarningOrError(this TaskLoggingHelper loggingHelper, int code, string xamlFilePath, int lineNumber, int linePosition, int endLineNumber, int endLinePosition, string message, params object[] messageArgs)
+		public static void LogWarningOrError(this TaskLoggingHelper loggingHelper, BuildExceptionCode code, string xamlFilePath, int lineNumber, int linePosition, int endLineNumber, int endLinePosition, params object[] messageArgs)
 		{
 			if (Context == null)
 				Context = new LoggingHelperContext();
-			if (Context.NoWarn != null && Context.NoWarn.Contains(code))
+			if (Context.NoWarn != null && Context.NoWarn.Contains(code.CodeCode))
 				return;
-			if (   (Context.TreatWarningsAsErrors && (Context.WarningsNotAsErrors == null || !Context.WarningsNotAsErrors.Contains(code)))
-				|| (Context.WarningsAsErrors!= null && Context.WarningsAsErrors.Contains(code)))
-				loggingHelper.LogError($"XamlC {code:0000}" , null, null, xamlFilePath, lineNumber, linePosition, endLineNumber, endLinePosition, message, messageArgs);
+			if (   (Context.TreatWarningsAsErrors && (Context.WarningsNotAsErrors == null || !Context.WarningsNotAsErrors.Contains(code.CodeCode)))
+				|| (Context.WarningsAsErrors!= null && Context.WarningsAsErrors.Contains(code.CodeCode)))
+				loggingHelper.LogError($"XamlC {code.CodePrefix}{code.CodeCode:0000}" , null, null, xamlFilePath, lineNumber, linePosition, endLineNumber, endLinePosition, ErrorMessages.ResourceManager.GetString(code.ErrorMessageKey), messageArgs);
 			else
-				loggingHelper.LogWarning($"XamlC {code:0000}", null, null, xamlFilePath, lineNumber, linePosition, endLineNumber, endLinePosition, message, messageArgs);
+				loggingHelper.LogWarning($"XamlC {code.CodePrefix}{code.CodeCode:0000}", null, null, xamlFilePath, lineNumber, linePosition, endLineNumber, endLinePosition, ErrorMessages.ResourceManager.GetString(code.ErrorMessageKey), messageArgs);
 		}
-
 	}
 
 	public class XamlCTask : XamlTask

--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
@@ -160,10 +160,14 @@
 			DefaultCompile = "true"
 			ValidateOnly = "$(_MauiXamlCValidateOnly)"
 			TargetFramework = "$(TargetFramework)"
-			KeepXamlResources = "$(MauiKeepXamlResources)" 
+			KeepXamlResources = "$(MauiKeepXamlResources)"
+
+      WarningLevel = "$(WarningLevel)"
       TreatWarningsAsErrors = "$(TreatWarningsAsErrors)"
       NoWarn = "$(NoWarn)"
-      WarningLevel = "$(WarningLevel)" />
+      WarningsAsErrors = "$(WarningsAsErrors)"
+      WarningsNotAsErrors = "$(WarningsNotAsErrors)" />
+      
 		<Touch Files="$(IntermediateOutputPath)XamlC.stamp" AlwaysCreate="True" />
 		<ItemGroup>
 			<FileWrites Include="$(IntermediateOutputPath)XamlC.stamp" />

--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
@@ -160,7 +160,10 @@
 			DefaultCompile = "true"
 			ValidateOnly = "$(_MauiXamlCValidateOnly)"
 			TargetFramework = "$(TargetFramework)"
-			KeepXamlResources = "$(MauiKeepXamlResources)" />
+			KeepXamlResources = "$(MauiKeepXamlResources)" 
+      TreatWarningsAsErrors = "$(TreatWarningsAsErrors)"
+      NoWarn = "$(NoWarn)"
+      WarningLevel = "$(WarningLevel)" />
 		<Touch Files="$(IntermediateOutputPath)XamlC.stamp" AlwaysCreate="True" />
 		<ItemGroup>
 			<FileWrites Include="$(IntermediateOutputPath)XamlC.stamp" />

--- a/src/Controls/tests/Xaml.UnitTests/Controls.Xaml.UnitTests.csproj
+++ b/src/Controls/tests/Xaml.UnitTests/Controls.Xaml.UnitTests.csproj
@@ -5,7 +5,8 @@
     <RootNamespace>Microsoft.Maui.Controls.Xaml.UnitTests</RootNamespace>
     <AssemblyName>Microsoft.Maui.Controls.Xaml.UnitTests</AssemblyName>
     <WarningLevel>4</WarningLevel>
-    <NoWarn>0672;0219;0414;CS0436;0618</NoWarn>
+    <NoWarn>0672;0219;0414;CS0436;CS0618</NoWarn>
+    <WarningsNotAsErrors>XC0618</WarningsNotAsErrors>
     <IsPackable>false</IsPackable>
     <DisableMSBuildAssemblyCopyCheck>true</DisableMSBuildAssemblyCopyCheck>
   </PropertyGroup>


### PR DESCRIPTION
### Description of Change

Reuse the following compiler options:
- WarningLevel (unused, but in this PR to avoid breaking the API next time)
- TreatWarningsAsErrors
- NoWarn
- WarningsAsErrors
- WarningsNotAsErrors

In NoWarn, WarningsAsErrors, WarningsNotAsErrors lists, the following rules applies:
- codes without a prefix, or with the 'XC' prefix are handled, other are ignored. (CS0618 is ignored, 0618 and XC0618 are handled)
- codes are compared as integer, so 0618, 618, XC0618 and XC618 are all equivalent

If TreatWarningsAsErrors is set (as it should) in your project and you want to avoid failing after this change, add 'XC0618' in WarningsNotAsErrors (or in NoWarn, but you'll miss the warning)

Deprecated properties and BP are now potentially logged as errors, with the same (0618) code as the c# compiler

### Issues Fixed

- fixes #18704 

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
