### PR TITLE
[X] Warn on non compiled bindings

### DIFF
--- a/src/Compatibility/ControlGallery/src/Core/Compatibility.ControlGallery.Core.csproj
+++ b/src/Compatibility/ControlGallery/src/Core/Compatibility.ControlGallery.Core.csproj
@@ -3,6 +3,9 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Microsoft.Maui.Controls.Compatibility.ControlGallery</AssemblyName>
     <RootNamespace>Microsoft.Maui.Controls.Compatibility.ControlGallery</RootNamespace>
+    <WarningLevel>4</WarningLevel>
+    <NoWarn>0114;0108;0109;4014;0649;0169;0472;0414;0168;0219;0429;0618;0612</NoWarn>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);XC10101;XC10102</WarningsNotAsErrors>
   </PropertyGroup>
   <PropertyGroup>
     <XFDisableTargetsValidation>True</XFDisableTargetsValidation>
@@ -10,14 +13,10 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DefineConstants>TRACE;DEBUG;PERF;APP</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <NoWarn>0114;0108;0109;4014;0649;0169;0472;0414;0168;0219;0429;0618;0612</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DefineConstants>TRACE;APP</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <NoWarn>0114;0108;0109;4014;0649;0169;0472;0414;0168;0219;0429;0618;0612</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="$(TargetFramework.StartsWith('uap10.0'))">
     <DefineConstants>$(DefineConstants);WINDOWS</DefineConstants>

--- a/src/Compatibility/ControlGallery/src/Core/Compatibility.ControlGallery.Core.csproj
+++ b/src/Compatibility/ControlGallery/src/Core/Compatibility.ControlGallery.Core.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>Microsoft.Maui.Controls.Compatibility.ControlGallery</RootNamespace>
     <WarningLevel>4</WarningLevel>
     <NoWarn>0114;0108;0109;4014;0649;0169;0472;0414;0168;0219;0429;0618;0612</NoWarn>
-    <WarningsNotAsErrors>$(WarningsNotAsErrors);XC10101;XC10102</WarningsNotAsErrors>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);XC0022;XC0023</WarningsNotAsErrors>
   </PropertyGroup>
   <PropertyGroup>
     <XFDisableTargetsValidation>True</XFDisableTargetsValidation>

--- a/src/Controls/samples/Directory.Build.props
+++ b/src/Controls/samples/Directory.Build.props
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <SampleProject>true</SampleProject>
     <UseMaui Condition=" '$(UseWorkload)' == 'true' ">true</UseMaui>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);XC10101;XC10102</WarningsNotAsErrors>
   </PropertyGroup>
   <Import Project="../../../Directory.Build.props" />
 </Project>

--- a/src/Controls/samples/Directory.Build.props
+++ b/src/Controls/samples/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <SampleProject>true</SampleProject>
     <UseMaui Condition=" '$(UseWorkload)' == 'true' ">true</UseMaui>
-    <WarningsNotAsErrors>$(WarningsNotAsErrors);XC10101;XC10102</WarningsNotAsErrors>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);XC0022;XC0023</WarningsNotAsErrors>
   </PropertyGroup>
   <Import Project="../../../Directory.Build.props" />
 </Project>

--- a/src/Controls/src/Build.Tasks/BuildException.cs
+++ b/src/Controls/src/Build.Tasks/BuildException.cs
@@ -55,6 +55,8 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 		//BP,BO
 		public static BuildExceptionCode BPName = new BuildExceptionCode("XFC", 0020, nameof(BPName), "");
 		public static BuildExceptionCode BPMissingGetter = new BuildExceptionCode("XFC", 0021, nameof(BPMissingGetter), "");
+		public static BuildExceptionCode BindingWithoutDataType = new BuildExceptionCode("XC", 0022, nameof(BindingWithoutDataType), ""); //warning
+		public static BuildExceptionCode BindingWithNullDataType = new BuildExceptionCode("XC", 0023, nameof(BindingWithNullDataType), ""); //warning
 
 		//Bindings, conversions
 		public static BuildExceptionCode Conversion = new BuildExceptionCode("XFC", 0040, nameof(Conversion), "");
@@ -90,7 +92,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 		public static BuildExceptionCode XKeyNotLiteral = new BuildExceptionCode("XFC", 0127, nameof(XKeyNotLiteral), "");
 
 		//CSC equivalents
-		public static BuildExceptionCode ObsoleteProperty = new BuildExceptionCode("XC", 0618, nameof(ObsoleteProperty), "");
+		public static BuildExceptionCode ObsoleteProperty = new BuildExceptionCode("XC", 0618, nameof(ObsoleteProperty), ""); //warning
 
 		public string Code { get; }
 		public string CodePrefix { get; }

--- a/src/Controls/src/Build.Tasks/ErrorMessages.Designer.cs
+++ b/src/Controls/src/Build.Tasks/ErrorMessages.Designer.cs
@@ -385,11 +385,30 @@ namespace Microsoft.Maui.Controls.Build.Tasks {
         }
 
         /// <summary>
-        /// Gets the error message for the obsolete property.
+        /// Looks up a localized message for the obsolete property.
         /// </summary>
         internal static string ObsoleteProperty {
             get {
                 return ResourceManager.GetString("ObsoleteProperty", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        /// Looks up a localized message for when a binding is used without specifying a data type.
+        /// </summary>
+        internal static string BindingWithoutDataType {
+            get {
+                return ResourceManager.GetString("BindingWithoutDataType", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        /// Looks up a localized message for binding with null data type.
+        /// </summary>
+        /// <returns>The error message.</returns>
+        internal static string BindingWithNullDataType {
+            get {
+                return ResourceManager.GetString("BindingWithNullDataType", resourceCulture);
             }
         }
     }

--- a/src/Controls/src/Build.Tasks/ErrorMessages.resx
+++ b/src/Controls/src/Build.Tasks/ErrorMessages.resx
@@ -135,6 +135,12 @@
     <value>Binding: Unsupported indexer index type: "{0}".</value>
     <comment>0 is indexer type name</comment>
   </data>
+  <data name="BindingWithoutDataType" xml:space="preserve">
+    <value>Binding could be compiled if x:DataType is specified.</value>
+  </data>  
+  <data name="BindingWithNullDataType" xml:space="preserve">
+    <value>Binding could be compiled if x:DataType is not explicitly null.</value>
+  </data>  
   <data name="BindingPropertyNotFound" xml:space="preserve">
     <value>Binding: Property "{0}" not found on "{1}".</value>
     <comment>0 is property name, 1 is type name</comment>

--- a/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
+++ b/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
@@ -389,8 +389,10 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 				n = n.Parent as IElementNode;
 			}
 
-			if (dataTypeNode is null)
+			if (dataTypeNode is null) {
+				context.LoggingHelper.LogWarningOrError(10101, context.XamlFilePath, node.LineNumber, node.LinePosition, 0, 0, $"Binding could be compiled if x:DataType is specified", null);
 				yield break;
+			}
 
 			if (dataTypeNode is ElementNode enode
 				&& enode.XmlType.NamespaceUri == XamlParser.X2009Uri

--- a/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
+++ b/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
@@ -397,7 +397,10 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 			if (dataTypeNode is ElementNode enode
 				&& enode.XmlType.NamespaceUri == XamlParser.X2009Uri
 				&& enode.XmlType.Name == nameof(Microsoft.Maui.Controls.Xaml.NullExtension))
+			{
+				context.LoggingHelper.LogWarningOrError(10102, context.XamlFilePath, node.LineNumber, node.LinePosition, 0, 0, $"Binding could be compiled if x:DataType is not explicitly null", null);
 				yield break;
+			}
 
 			string dataType = null;
 

--- a/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
+++ b/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
@@ -390,7 +390,8 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 			}
 
 			if (dataTypeNode is null) {
-				context.LoggingHelper.LogWarningOrError(10101, context.XamlFilePath, node.LineNumber, node.LinePosition, 0, 0, $"Binding could be compiled if x:DataType is specified", null);
+				context.LoggingHelper.LogWarningOrError(BuildExceptionCode.BindingWithoutDataType, context.XamlFilePath, node.LineNumber, node.LinePosition, 0, 0, null);
+
 				yield break;
 			}
 
@@ -398,7 +399,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 				&& enode.XmlType.NamespaceUri == XamlParser.X2009Uri
 				&& enode.XmlType.Name == nameof(Microsoft.Maui.Controls.Xaml.NullExtension))
 			{
-				context.LoggingHelper.LogWarningOrError(10102, context.XamlFilePath, node.LineNumber, node.LinePosition, 0, 0, $"Binding could be compiled if x:DataType is not explicitly null", null);
+				context.LoggingHelper.LogWarningOrError(BuildExceptionCode.BindingWithNullDataType, context.XamlFilePath, node.LineNumber, node.LinePosition, 0, 0, null);
 				yield break;
 			}
 

--- a/src/Controls/tests/Xaml.UnitTests/Controls.Xaml.UnitTests.csproj
+++ b/src/Controls/tests/Xaml.UnitTests/Controls.Xaml.UnitTests.csproj
@@ -5,8 +5,8 @@
     <RootNamespace>Microsoft.Maui.Controls.Xaml.UnitTests</RootNamespace>
     <AssemblyName>Microsoft.Maui.Controls.Xaml.UnitTests</AssemblyName>
     <WarningLevel>4</WarningLevel>
-    <NoWarn>0672;0219;0414;CS0436;CS0618</NoWarn>
-    <WarningsNotAsErrors>XC0618;XC10101</WarningsNotAsErrors>
+    <NoWarn>$(NoWarn);0672;0219;0414;CS0436;CS0618</NoWarn>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);XC0618;XC10101;XC10102</WarningsNotAsErrors>
     <IsPackable>false</IsPackable>
     <DisableMSBuildAssemblyCopyCheck>true</DisableMSBuildAssemblyCopyCheck>
   </PropertyGroup>

--- a/src/Controls/tests/Xaml.UnitTests/Controls.Xaml.UnitTests.csproj
+++ b/src/Controls/tests/Xaml.UnitTests/Controls.Xaml.UnitTests.csproj
@@ -6,7 +6,7 @@
     <AssemblyName>Microsoft.Maui.Controls.Xaml.UnitTests</AssemblyName>
     <WarningLevel>4</WarningLevel>
     <NoWarn>0672;0219;0414;CS0436;CS0618</NoWarn>
-    <WarningsNotAsErrors>XC0618</WarningsNotAsErrors>
+    <WarningsNotAsErrors>XC0618;XC10101</WarningsNotAsErrors>
     <IsPackable>false</IsPackable>
     <DisableMSBuildAssemblyCopyCheck>true</DisableMSBuildAssemblyCopyCheck>
   </PropertyGroup>

--- a/src/Controls/tests/Xaml.UnitTests/Controls.Xaml.UnitTests.csproj
+++ b/src/Controls/tests/Xaml.UnitTests/Controls.Xaml.UnitTests.csproj
@@ -6,7 +6,7 @@
     <AssemblyName>Microsoft.Maui.Controls.Xaml.UnitTests</AssemblyName>
     <WarningLevel>4</WarningLevel>
     <NoWarn>$(NoWarn);0672;0219;0414;CS0436;CS0618</NoWarn>
-    <WarningsNotAsErrors>$(WarningsNotAsErrors);XC0618;XC10101;XC10102</WarningsNotAsErrors>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);XC0618;XC0022;XC0023</WarningsNotAsErrors>
     <IsPackable>false</IsPackable>
     <DisableMSBuildAssemblyCopyCheck>true</DisableMSBuildAssemblyCopyCheck>
   </PropertyGroup>

--- a/src/Essentials/samples/Directory.Build.props
+++ b/src/Essentials/samples/Directory.Build.props
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <SampleProject>true</SampleProject>
     <UseMaui Condition=" '$(UseWorkload)' == 'true' ">true</UseMaui>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);XC10101;XC10102</WarningsNotAsErrors>
   </PropertyGroup>
   <Import Project="../../../Directory.Build.props" />
 </Project>

--- a/src/Essentials/samples/Directory.Build.props
+++ b/src/Essentials/samples/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <SampleProject>true</SampleProject>
     <UseMaui Condition=" '$(UseWorkload)' == 'true' ">true</UseMaui>
-    <WarningsNotAsErrors>$(WarningsNotAsErrors);XC10101;XC10102</WarningsNotAsErrors>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);XC0022;XC0023</WarningsNotAsErrors>
   </PropertyGroup>
   <Import Project="../../../Directory.Build.props" />
 </Project>

--- a/src/TestUtils/src/DeviceTests.Runners/TestUtils.DeviceTests.Runners.csproj
+++ b/src/TestUtils/src/DeviceTests.Runners/TestUtils.DeviceTests.Runners.csproj
@@ -7,7 +7,7 @@
     <AssemblyName>Microsoft.Maui.TestUtils.DeviceTests.Runners</AssemblyName>
     <!--<Nullable>enable</Nullable>-->
     <NoWarn>$(NoWarn);CA1416</NoWarn>
-    <WarningsNotAsErrors>XC10101</WarningsNotAsErrors>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);XC10101;XC10102</WarningsNotAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/TestUtils/src/DeviceTests.Runners/TestUtils.DeviceTests.Runners.csproj
+++ b/src/TestUtils/src/DeviceTests.Runners/TestUtils.DeviceTests.Runners.csproj
@@ -6,7 +6,8 @@
     <RootNamespace>Microsoft.Maui.TestUtils.DeviceTests.Runners</RootNamespace>
     <AssemblyName>Microsoft.Maui.TestUtils.DeviceTests.Runners</AssemblyName>
     <!--<Nullable>enable</Nullable>-->
-    <NoWarn>$(NoWarn),CA1416</NoWarn>
+    <NoWarn>$(NoWarn);CA1416</NoWarn>
+    <WarningsNotAsErrors>XC10101</WarningsNotAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/TestUtils/src/DeviceTests.Runners/TestUtils.DeviceTests.Runners.csproj
+++ b/src/TestUtils/src/DeviceTests.Runners/TestUtils.DeviceTests.Runners.csproj
@@ -7,7 +7,7 @@
     <AssemblyName>Microsoft.Maui.TestUtils.DeviceTests.Runners</AssemblyName>
     <!--<Nullable>enable</Nullable>-->
     <NoWarn>$(NoWarn);CA1416</NoWarn>
-    <WarningsNotAsErrors>$(WarningsNotAsErrors);XC10101;XC10102</WarningsNotAsErrors>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);XC0022;XC0023</WarningsNotAsErrors>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Description of Change

When XamlC can't compile a Binding due to missing x:DataType, log a
warning.

If you use TreatWarningsAsErrors, add XC0022 and XC0023 to WarningsNotAsErrors to
avoid the build failing
### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

!  this is based on top of #19337. Merge that one then rebase.

Fixes #

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
