### PR TITLE
Stop & Reset iOS Simulators in CI

### DIFF
--- a/eng/devices/ios.cake
+++ b/eng/devices/ios.cake
@@ -108,6 +108,12 @@ void Cleanup()
 			}
 		}
 	}
+
+	if (IsCIBuild()) {
+		Information("Stopping all Simulator processes and reset all Simulator states");
+		StartProcess("xcrun", "simctl shutdown all");
+		StartProcess("xcrun", "simctl erase all");
+	}
 }
 
 Task("Cleanup");


### PR DESCRIPTION
### Description of Change

In CI stop all Simulator processes and reset all Simulator states. Especially for our self-hosted build agents there seem to be errors with (un)installing apps etc. Maybe because state is retained? This change tries to fix that and make the pipeline more reliable.

### Issues Fixed

Related to #19343