### PR TITLE
Handle Semantics flags more explicitly on iOS

### DIFF
--- a/eng/pipelines/device-tests.yml
+++ b/eng/pipelines/device-tests.yml
@@ -107,13 +107,13 @@ stages:
       agentPoolAccessToken: $(AgentPoolAccessToken)
       ${{ if or(parameters.BuildEverything, and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'devdiv'))) }}:
         androidApiLevels: [ 33, 30, 29, 28, 27, 26, 25, 24, 23 ]
-        iosVersions: [ '17.0' ]
+        iosVersions: [ '16.4', '15.5', '14.5']
         catalystVersions: [ 'latest' ]
         windowsVersions: ['packaged', 'unpackaged']
         provisionatorChannel: ${{ parameters.provisionatorChannel }}
       ${{ if not(or(parameters.BuildEverything, and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'devdiv')))) }}:
         androidApiLevels: [ 30, 23 ]
-        iosVersions: [ '17.0' ]
+        iosVersions: [ '16.4' ]
         catalystVersions: [ 'latest' ]
         windowsVersions: ['packaged', 'unpackaged']
         provisionatorChannel: ${{ parameters.provisionatorChannel }}

--- a/eng/pipelines/device-tests.yml
+++ b/eng/pipelines/device-tests.yml
@@ -107,13 +107,13 @@ stages:
       agentPoolAccessToken: $(AgentPoolAccessToken)
       ${{ if or(parameters.BuildEverything, and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'devdiv'))) }}:
         androidApiLevels: [ 33, 30, 29, 28, 27, 26, 25, 24, 23 ]
-        iosVersions: [ '16.4', '15.5', '14.5']
+        iosVersions: [ '17.0' ]
         catalystVersions: [ 'latest' ]
         windowsVersions: ['packaged', 'unpackaged']
         provisionatorChannel: ${{ parameters.provisionatorChannel }}
       ${{ if not(or(parameters.BuildEverything, and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'devdiv')))) }}:
         androidApiLevels: [ 30, 23 ]
-        iosVersions: [ '16.4' ]
+        iosVersions: [ '17.0' ]
         catalystVersions: [ 'latest' ]
         windowsVersions: ['packaged', 'unpackaged']
         provisionatorChannel: ${{ parameters.provisionatorChannel }}

--- a/src/Core/src/Platform/iOS/SemanticExtensions.cs
+++ b/src/Core/src/Platform/iOS/SemanticExtensions.cs
@@ -35,15 +35,22 @@ namespace Microsoft.Maui.Platform
 					platformView.IsAccessibilityElement = true;
 			}
 
+			var accessibilityTraits = platformView.AccessibilityTraits;
+			var hasHeader = (accessibilityTraits & UIAccessibilityTrait.Header) == UIAccessibilityTrait.Header;
+
 			if (semantics.IsHeading)
 			{
-				if ((platformView.AccessibilityTraits & UIAccessibilityTrait.Header) != UIAccessibilityTrait.Header)
-					platformView.AccessibilityTraits |= UIAccessibilityTrait.Header;
+				if (!hasHeader)
+				{
+					platformView.AccessibilityTraits = accessibilityTraits | UIAccessibilityTrait.Header;
+				}
 			}
 			else
 			{
-				if ((platformView.AccessibilityTraits & UIAccessibilityTrait.Header) == UIAccessibilityTrait.Header)
-					platformView.AccessibilityTraits &= ~UIAccessibilityTrait.Header;
+				if (hasHeader)
+				{
+					platformView.AccessibilityTraits = accessibilityTraits & ~UIAccessibilityTrait.Header;
+				}
 			}
 		}
 	}

--- a/src/Core/tests/DeviceTests.Shared/HandlerTests/HandlerTestBaseOfT.Tests.cs
+++ b/src/Core/tests/DeviceTests.Shared/HandlerTests/HandlerTestBaseOfT.Tests.cs
@@ -79,9 +79,9 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		[Fact(DisplayName = "Setting Semantic Description makes element accessible"
-#if IOS
-			, Skip = "This is failing on iOS: https://github.com/dotnet/maui/issues/19122"
-#endif
+//#if IOS
+//			, Skip = "This is failing on iOS: https://github.com/dotnet/maui/issues/19122"
+//#endif
 		)]
 		public async virtual Task SettingSemanticDescriptionMakesElementAccessible()
 		{
@@ -95,9 +95,9 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		[Fact(DisplayName = "Setting Semantic Hint makes element accessible"
-#if IOS
-			, Skip = "This is failing on iOS: https://github.com/dotnet/maui/issues/19122"
-#endif
+//#if IOS
+//			, Skip = "This is failing on iOS: https://github.com/dotnet/maui/issues/19122"
+//#endif
 		)]
 		public async virtual Task SettingSemanticHintMakesElementAccessible()
 		{
@@ -137,14 +137,15 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		[Fact(DisplayName = "Semantic Heading is set correctly"
-#if IOS
-			, Skip = "This is failing on iOS: https://github.com/dotnet/maui/issues/19122"
-#endif
+//#if IOS
+//			, Skip = "This is failing on iOS: https://github.com/dotnet/maui/issues/19122"
+//#endif
 		)]
 		public async Task SetSemanticHeading()
 		{
 			var view = new TStub();
 			view.Semantics.HeadingLevel = SemanticHeadingLevel.Level1;
+			
 			var id = await GetValueAsync(view, handler => GetSemanticHeading(handler));
 			Assert.Equal(view.Semantics.HeadingLevel, id);
 		}

--- a/src/Core/tests/DeviceTests.Shared/HandlerTests/HandlerTestBaseOfT.Tests.cs
+++ b/src/Core/tests/DeviceTests.Shared/HandlerTests/HandlerTestBaseOfT.Tests.cs
@@ -78,11 +78,7 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.Equal(view.Visibility, id);
 		}
 
-		[Fact(DisplayName = "Setting Semantic Description makes element accessible"
-//#if IOS
-//			, Skip = "This is failing on iOS: https://github.com/dotnet/maui/issues/19122"
-//#endif
-		)]
+		[Fact(DisplayName = "Setting Semantic Description makes element accessible")]
 		public async virtual Task SettingSemanticDescriptionMakesElementAccessible()
 		{
 			var view = new TStub();
@@ -94,11 +90,7 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.True(important);
 		}
 
-		[Fact(DisplayName = "Setting Semantic Hint makes element accessible"
-//#if IOS
-//			, Skip = "This is failing on iOS: https://github.com/dotnet/maui/issues/19122"
-//#endif
-		)]
+		[Fact(DisplayName = "Setting Semantic Hint makes element accessible")]
 		public async virtual Task SettingSemanticHintMakesElementAccessible()
 		{
 			var view = new TStub();
@@ -136,11 +128,7 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.Equal(view.Semantics.Hint, id);
 		}
 
-		[Fact(DisplayName = "Semantic Heading is set correctly"
-//#if IOS
-//			, Skip = "This is failing on iOS: https://github.com/dotnet/maui/issues/19122"
-//#endif
-		)]
+		[Fact(DisplayName = "Semantic Heading is set correctly")]
 		public async Task SetSemanticHeading()
 		{
 			var view = new TStub();

--- a/src/Core/tests/DeviceTests.Shared/HandlerTests/HandlerTestBasementOfT.iOS.cs
+++ b/src/Core/tests/DeviceTests.Shared/HandlerTests/HandlerTestBasementOfT.iOS.cs
@@ -63,9 +63,14 @@ namespace Microsoft.Maui.DeviceTests
 		protected string GetSemanticHint(IViewHandler viewHandler) =>
 			GetAccessiblePlatformView(viewHandler).AccessibilityHint;
 
-		protected SemanticHeadingLevel GetSemanticHeading(IViewHandler viewHandler) =>
-			GetAccessiblePlatformView(viewHandler).AccessibilityTraits.HasFlag(UIAccessibilityTrait.Header)
-				? SemanticHeadingLevel.Level1 : SemanticHeadingLevel.None;
+		protected SemanticHeadingLevel GetSemanticHeading(IViewHandler viewHandler)
+		{
+			var accessibilityTraits = GetAccessiblePlatformView(viewHandler).AccessibilityTraits;
+
+			var hasHeader = (accessibilityTraits & UIAccessibilityTrait.Header) == UIAccessibilityTrait.Header;
+
+			return hasHeader ? SemanticHeadingLevel.Level1 : SemanticHeadingLevel.None;
+		}
 
 		protected nfloat GetOpacity(IViewHandler viewHandler) =>
 			((UIView)viewHandler.ToPlatform()).Alpha;


### PR DESCRIPTION
### Description of Change

Restores the Semantics tests which were disabled for iOS 17. Updates the handling of the semantics flags (and checking for them during testing) to avoid `Enum.HasFlags()` and compound assignment operators, as these have some subtle behaviors that seem to be causing the tests to fail on iOS 17. 
