### PR TITLE
Do not use underscores in the ApplicationId

### DIFF
--- a/src/Templates/src/templates/maui-blazor/.template.config/template.json
+++ b/src/Templates/src/templates/maui-blazor/.template.config/template.json
@@ -94,7 +94,7 @@
           "steps": [
             {
               "regex": "[^a-z0-9_\\.]",
-              "replacement": "_"
+              "replacement": ""
             }
           ]
         }

--- a/src/Templates/src/templates/maui-mobile/.template.config/template.json
+++ b/src/Templates/src/templates/maui-mobile/.template.config/template.json
@@ -98,7 +98,7 @@
           "steps": [
             {
               "regex": "[^a-z0-9_\\.]",
-              "replacement": "_"
+              "replacement": ""
             }
           ]
         }

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/DotnetInternal.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/DotnetInternal.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Maui.IntegrationTests
 	public static class DotnetInternal
 	{
 		static readonly string DotnetRoot = Path.Combine(TestEnvironment.GetMauiDirectory(), "bin", "dotnet");
-		static readonly string DotnetTool = "dotnet";
+		static readonly string DotnetTool = Path.Combine(DotnetRoot, "dotnet");
 		const int DEFAULT_TIMEOUT = 900;
 
 		private static string ConstructBuildArgs(string projectFile, string config, string target = "", string framework = "", IEnumerable<string>? properties = null, string binlogPath = "", string runtimeIdentifier = "", bool isPublishing = false)

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/DotnetInternal.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/DotnetInternal.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Maui.IntegrationTests
 	public static class DotnetInternal
 	{
 		static readonly string DotnetRoot = Path.Combine(TestEnvironment.GetMauiDirectory(), "bin", "dotnet");
-		static readonly string DotnetTool = Path.Combine(DotnetRoot, "dotnet");
+		static readonly string DotnetTool = "dotnet";
 		const int DEFAULT_TIMEOUT = 900;
 
 		private static string ConstructBuildArgs(string projectFile, string config, string target = "", string framework = "", IEnumerable<string>? properties = null, string binlogPath = "", string runtimeIdentifier = "", bool isPublishing = false)


### PR DESCRIPTION
### Description of Change

Underscores are not supported on Windows.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #19364

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
