### PR TITLE
Bump Xamarin.UITest from 4.1.4 to 4.3.3

### DIFF
--- a/src/Compatibility/ControlGallery/src/Issues.Shared/TestPages/TestPages.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/TestPages/TestPages.cs
@@ -159,7 +159,7 @@ namespace Microsoft.Maui.Controls.ControlGallery
 																: enviOSPath;
 
 			// Running on the simulator
-			var app = ConfigureApp.iOS
+			var appConfiguration = ConfigureApp.iOS
 							.PreferIdeSettings()
 							.AppBundle(fullApkPath)
 							.Debug()

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/TestPages/TestPages.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/TestPages/TestPages.cs
@@ -159,7 +159,7 @@ namespace Microsoft.Maui.Controls.ControlGallery
 																: enviOSPath;
 
 			// Running on the simulator
-			var appConfiguration = ConfigureApp.iOS
+			var app = ConfigureApp.iOS
 							.PreferIdeSettings()
 							.AppBundle(fullApkPath)
 							.Debug()

--- a/src/Compatibility/ControlGallery/test/Android.UITests/Compatibility.ControlGallery.Android.UITests.csproj
+++ b/src/Compatibility/ControlGallery/test/Android.UITests/Compatibility.ControlGallery.Android.UITests.csproj
@@ -15,10 +15,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="Xam.Plugin.DeviceInfo" Version="4.1.1" />
-    <PackageReference Include="Xamarin.UITest" Version="4.1.4" />
+    <PackageReference Include="Xamarin.UITest" Version="4.3.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
   </ItemGroup>
 

--- a/src/Compatibility/ControlGallery/test/WinUI.UITests/WinUI.UITests.csproj
+++ b/src/Compatibility/ControlGallery/test/WinUI.UITests/WinUI.UITests.csproj
@@ -18,12 +18,12 @@
     <PackageReference Include="Appium.WebDriver" Version="4.3.1" />
     <PackageReference Include="Castle.Core" Version="5.1.1" />
     <PackageReference Include="DotNetSeleniumExtras.PageObjects" Version="3.11.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="Selenium.Support" Version="4.1.1" />
     <PackageReference Include="Selenium.WebDriver" Version="4.1.1" />
     <PackageReference Include="Xam.Plugin.DeviceInfo" Version="4.1.1" />
-    <PackageReference Include="Xamarin.UITest" Version="4.1.4" />
+    <PackageReference Include="Xamarin.UITest" Version="4.3.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
   </ItemGroup>
 

--- a/src/Compatibility/ControlGallery/test/iOS.UITests/Compatibility.ControlGallery.iOS.UITests.csproj
+++ b/src/Compatibility/ControlGallery/test/iOS.UITests/Compatibility.ControlGallery.iOS.UITests.csproj
@@ -15,10 +15,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="Xam.Plugin.DeviceInfo" Version="4.1.1" />
-    <PackageReference Include="Xamarin.UITest" Version="4.1.4" />
+    <PackageReference Include="Xamarin.UITest" Version="4.3.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
   </ItemGroup>
 


### PR DESCRIPTION
### Description of Change

In continuation of #18592 we have a new version of Xamarin.UITest that should work with all the latest versions of things.

Additionally, v4.3.3 uses `idb` to interact with the Simulator. This change adds some code to set that up in our pipeline.

Fixes #19343
