### PR TITLE
Expose generic delegates for BindableProperty via Create method

### DIFF
--- a/src/Controls/src/Core/BindableProperty.cs
+++ b/src/Controls/src/Core/BindableProperty.cs
@@ -148,6 +148,44 @@ namespace Microsoft.Maui.Controls
 				defaultValueCreator: defaultValueCreator);
 		}
 
+		public static BindableProperty Create<TDeclaringType, TReturnType>(string propertyName, TReturnType defaultValue = default, BindingMode defaultBindingMode = BindingMode.OneWay, ValidateValueDelegate<TReturnType> validateValue = null,
+										BindingPropertyChangedDelegate<TReturnType> propertyChanged = null, BindingPropertyChangingDelegate<TReturnType> propertyChanging = null, CoerceValueDelegate<TReturnType> coerceValue = null,
+										CreateDefaultValueDelegate<TDeclaringType, TReturnType> defaultValueCreator = null)
+		{
+			ValidateValueDelegate untypedValidateValue = null;
+			if (validateValue != null)
+			{
+				untypedValidateValue = (bindable, value) => validateValue(bindable, value is TReturnType typedValue ? typedValue : default);
+			}
+
+			BindingPropertyChangedDelegate untypedPropertyChanged = null;
+			if (propertyChanged != null)
+			{
+				untypedPropertyChanged = (bindable, o, n) => propertyChanged(bindable, o is TReturnType typedOldValue ? typedOldValue : default, n is TReturnType typedNewValue ? typedNewValue : default);
+			}
+
+			BindingPropertyChangingDelegate untypedPropertyChanging = null;
+			if (propertyChanging != null)
+			{
+				untypedPropertyChanging = (bindable, o, n) => propertyChanging(bindable, o is TReturnType typedOldValue ? typedOldValue : default, n is TReturnType typedNewValue ? typedNewValue : default);
+			}
+
+			CoerceValueDelegate untypedCoerceValue = null;
+			if (coerceValue != null)
+			{
+				untypedCoerceValue = (bindable, value) => coerceValue(bindable, value is TReturnType typedValue ? typedValue : default);
+			}
+
+			CreateDefaultValueDelegate untypedDefaultValueCreator = null;
+			if (defaultValueCreator != null)
+			{
+				untypedDefaultValueCreator = (bindable) => defaultValueCreator(bindable is TDeclaringType typedBindable ? typedBindable : default);
+			}
+
+			return new BindableProperty(propertyName, typeof(TReturnType), typeof(TDeclaringType), defaultValue, defaultBindingMode, untypedValidateValue, untypedPropertyChanged, untypedPropertyChanging, untypedCoerceValue,
+				defaultValueCreator: untypedDefaultValueCreator);
+		}
+
 		/// <include file="../../docs/Microsoft.Maui.Controls/BindableProperty.xml" path="//Member[@MemberName='CreateAttached']/Docs/*" />
 		public static BindableProperty CreateAttached(string propertyName, Type returnType, [DynamicallyAccessedMembers(DeclaringTypeMembers)] Type declaringType, object defaultValue, BindingMode defaultBindingMode = BindingMode.OneWay,
 													  ValidateValueDelegate validateValue = null, BindingPropertyChangedDelegate propertyChanged = null, BindingPropertyChangingDelegate propertyChanging = null,

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -132,6 +132,7 @@ override Microsoft.Maui.Controls.SearchBar.IsEnabledCore.get -> bool
 ~override Microsoft.Maui.Controls.LayoutOptions.Equals(object obj) -> bool
 ~override Microsoft.Maui.Controls.Region.Equals(object obj) -> bool
 ~override Microsoft.Maui.Controls.Shapes.Matrix.Equals(object obj) -> bool
+~static Microsoft.Maui.Controls.BindableProperty.Create<TDeclaringType, TReturnType>(string propertyName, TReturnType defaultValue = default(TReturnType), Microsoft.Maui.Controls.BindingMode defaultBindingMode = Microsoft.Maui.Controls.BindingMode.OneWay, Microsoft.Maui.Controls.BindableProperty.ValidateValueDelegate<TReturnType> validateValue = null, Microsoft.Maui.Controls.BindableProperty.BindingPropertyChangedDelegate<TReturnType> propertyChanged = null, Microsoft.Maui.Controls.BindableProperty.BindingPropertyChangingDelegate<TReturnType> propertyChanging = null, Microsoft.Maui.Controls.BindableProperty.CoerceValueDelegate<TReturnType> coerceValue = null, Microsoft.Maui.Controls.BindableProperty.CreateDefaultValueDelegate<TDeclaringType, TReturnType> defaultValueCreator = null) -> Microsoft.Maui.Controls.BindableProperty
 ~static Microsoft.Maui.Controls.RadioButton.MapContent(Microsoft.Maui.Handlers.IRadioButtonHandler handler, Microsoft.Maui.Controls.RadioButton radioButton) -> void
 ~static Microsoft.Maui.Controls.RadioButton.MapContent(Microsoft.Maui.Handlers.RadioButtonHandler handler, Microsoft.Maui.Controls.RadioButton radioButton) -> void
 ~static Microsoft.Maui.Controls.Region.FromRectangles(System.Collections.Generic.IEnumerable<Microsoft.Maui.Graphics.Rect> rectangles) -> Microsoft.Maui.Controls.Region
@@ -171,7 +172,6 @@ Microsoft.Maui.Controls.PlatformPointerEventArgs
 ~static readonly Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTappedProperty -> Microsoft.Maui.Controls.BindableProperty
 Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTapped.get -> bool
 Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTapped.set -> void
-
 *REMOVED*~Microsoft.Maui.Controls.Editor.FontFamily.get -> string
 *REMOVED*~Microsoft.Maui.Controls.Editor.FontFamily.set -> void
 *REMOVED*Microsoft.Maui.Controls.Editor.CursorPosition.get -> int
@@ -184,7 +184,6 @@ Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTapped.set -> void
 *REMOVED*Microsoft.Maui.Controls.Editor.FontSize.set -> void
 *REMOVED*Microsoft.Maui.Controls.Editor.SelectionLength.get -> int
 *REMOVED*Microsoft.Maui.Controls.Editor.SelectionLength.set -> void
-
 *REMOVED*~Microsoft.Maui.Controls.SearchBar.FontFamily.get -> string
 *REMOVED*~Microsoft.Maui.Controls.SearchBar.FontFamily.set -> void
 *REMOVED*Microsoft.Maui.Controls.SearchBar.CursorPosition.get -> int
@@ -197,7 +196,6 @@ Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTapped.set -> void
 *REMOVED*Microsoft.Maui.Controls.SearchBar.FontSize.set -> void
 *REMOVED*Microsoft.Maui.Controls.SearchBar.SelectionLength.get -> int
 *REMOVED*Microsoft.Maui.Controls.SearchBar.SelectionLength.set -> void
-
 *REMOVED*~Microsoft.Maui.Controls.Entry.FontFamily.get -> string
 *REMOVED*~Microsoft.Maui.Controls.Entry.FontFamily.set -> void
 *REMOVED*Microsoft.Maui.Controls.Entry.CursorPosition.get -> int
@@ -210,4 +208,3 @@ Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTapped.set -> void
 *REMOVED*Microsoft.Maui.Controls.Entry.FontSize.set -> void
 *REMOVED*Microsoft.Maui.Controls.Entry.SelectionLength.get -> int
 *REMOVED*Microsoft.Maui.Controls.Entry.SelectionLength.set -> void
-

--- a/src/Controls/tests/Core.UnitTests/BindablePropertyUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/BindablePropertyUnitTests.cs
@@ -25,6 +25,24 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact]
+		public void CreateGeneric()
+		{
+			const BindingMode mode = BindingMode.OneWayToSource;
+			const string dvalue = "default";
+			BindableProperty.CoerceValueDelegate<string> coerce = (bindable, value) => value;
+			BindableProperty.ValidateValueDelegate<string> validate = (b, v) => true;
+			BindableProperty.BindingPropertyChangedDelegate<string> changed = (b, ov, nv) => { };
+			BindableProperty.BindingPropertyChangingDelegate<string> changing = (b, ov, nv) => { };
+
+			var prop = BindableProperty.Create<Button, string>(nameof(Button.Text), dvalue, mode, validate, changed, changing, coerce);
+			Assert.Equal("Text", prop.PropertyName);
+			Assert.Equal(typeof(Button), prop.DeclaringType);
+			Assert.Equal(typeof(string), prop.ReturnType);
+			Assert.Equal(dvalue, prop.DefaultValue);
+			Assert.Equal(mode, prop.DefaultBindingMode);
+		}
+
+		[Fact]
 		public void CreateWithDefaultMode()
 		{
 			const BindingMode mode = BindingMode.Default;


### PR DESCRIPTION
This just adds a convenience method that exposes the generic delegates that are defined in this file via the commonly-used static Create method.

When you are writing the delegate functions, it is nice to have the types already there for you, and this also prevents errors because the default value and the delegates are type checked at compile time.

See discussion: https://github.com/dotnet/maui/discussions/16302