### PR TITLE
Removes dead code from type conversion

### DIFF
--- a/src/Controls/src/Core/Xaml/TypeConversionExtensions.cs
+++ b/src/Controls/src/Core/Xaml/TypeConversionExtensions.cs
@@ -172,19 +172,6 @@ namespace Microsoft.Maui.Controls.Xaml
 					return null;
 				}
 
-				if (converter != null)
-				{
-					try
-					{
-						return converter.ConvertFromInvariantString(str);
-					}
-					catch (Exception e)
-					{
-						exception = new XamlParseException("Type conversion failed", serviceProvider, e);
-						return null;
-					}
-				}
-
 				var ignoreCase = (serviceProvider?.GetService(typeof(IConverterOptions)) as IConverterOptions)?.IgnoreCase ?? false;
 
 				//If the type is nullable, as the value is not null, it's safe to assume we want the built-in conversion


### PR DESCRIPTION
### Description of Change

The removed code would only run if `converter` was not null. But in that case the if on line 166 would match and it would return from the method. So the removed code can only be reached if `converter` is null.