### PR TITLE
Simplify ShapeUpdatesBrushCorrectly

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Shape/ShapeTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shape/ShapeTests.cs
@@ -68,29 +68,26 @@ namespace Microsoft.Maui.DeviceTests
 				line.Stroke = expected;
 			};
 
-			await PerformClick(button);
-
-			Assert.True(clicked);
-
-			await InvokeOnMainThreadAsync(async () =>
+			await AttachAndRun<LineHandler>(line, async (handler) =>
 			{
-				await CreateHandlerAndAddToWindow<LineHandler>(line, async (handler) =>
-				{
-					await AssertionExtensions.Wait(
-						() =>
-						handler.PlatformView is not null &&
-						handler.PlatformView.Drawable is not null);
+				await PerformClick(button);
 
-					var mauiShapeView = handler.PlatformView;
-					Assert.NotNull(mauiShapeView);
-					var shapeDrawable = mauiShapeView.Drawable as ShapeDrawable;
-					Assert.NotNull(shapeDrawable);
-					var shape = shapeDrawable.ShapeView.Shape as Shape;
-					Assert.NotNull(shape);
+				Assert.True(clicked);
 
-					var shapeStroke = shape.Stroke as SolidColorBrush;
-					Assert.Equal(expected, shapeStroke?.Color);
-				});
+				await AssertionExtensions.AssertEventually(
+					() =>
+					handler.PlatformView is not null &&
+					handler.PlatformView.Drawable is not null);
+
+				var mauiShapeView = handler.PlatformView;
+				Assert.NotNull(mauiShapeView);
+				var shapeDrawable = mauiShapeView.Drawable as ShapeDrawable;
+				Assert.NotNull(shapeDrawable);
+				var shape = shapeDrawable.ShapeView.Shape as Shape;
+				Assert.NotNull(shape);
+
+				var shapeStroke = shape.Stroke as SolidColorBrush;
+				Assert.Equal(expected, shapeStroke?.Color);
 			});
 		}
 	}


### PR DESCRIPTION
### Description of Change

- Convert code over to using AttachAndRun vs CreateHandlerAndAddToWindow. It doesn't need the full wiring of CreateHandlerAndAddToWindow to work
- Move perform click into AttachAndRun


### Fixes

- #19443 
