### PR TITLE
Fix some UI Test timings

### DIFF
--- a/src/Controls/tests/UITests/Tests/DragAndDropUITests.cs
+++ b/src/Controls/tests/UITests/Tests/DragAndDropUITests.cs
@@ -57,6 +57,7 @@ namespace Microsoft.Maui.AppiumTests
 			App.EnterText("TargetView", "DragAndDropBetweenLayouts");
 			App.Click("GoButton");
 
+			App.WaitForElement("ResetButton");
 			App.Click("ResetButton");
 
 			App.WaitForElement("Red");

--- a/src/Controls/tests/UITests/Tests/Issues/Issue14257.cs
+++ b/src/Controls/tests/UITests/Tests/Issues/Issue14257.cs
@@ -18,6 +18,8 @@ namespace Microsoft.Maui.AppiumTests.Issues
 
 			// Scroll down to the Test button. When the bug is present, the button cannot be tapped.
 			App.ScrollTo("Test");
+
+			App.WaitForElement("Test");
 			App.Click("Test");
 
 			// If we can successfully tap the button, the Success label will be displayed

--- a/src/Controls/tests/UITests/Tests/_ViewUITests.cs
+++ b/src/Controls/tests/UITests/Tests/_ViewUITests.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Maui.AppiumTests
 		{
 			var remote = new StateViewContainerRemote(UITestContext, Test.VisualElement.IsVisible);
 			remote.GoTo();
-
+			App.WaitForElement($"IsVisibleStateButton");
 			var viewPre = remote.GetViews();
 
 			Assert.AreEqual(1, viewPre.Count);


### PR DESCRIPTION
### Description of Change

Wait for navigation to complete before querying some views. It seems like on some faster devices, the test is proceeding too quickly before the UI has finished resolving. 
