### PR TITLE
Fix TableView rendering on Android

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ templatesTest/
 
 # Mono auto generated files
 mono_crash.*
+.mono/
 
 # Build results
 [Dd]ebug/

--- a/src/Controls/samples/Controls.Sample/Pages/Compatibility/TableViewPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Compatibility/TableViewPage.xaml
@@ -5,13 +5,8 @@
     xmlns:views="clr-namespace:Maui.Controls.Sample.Pages.Base"
     Title="TableView">
     <views:BasePage.Content>
-        <VerticalStackLayout
-            Margin="12">
-            <Label
-                Text="Default"
-                Style="{StaticResource Headline}"/>
             <TableView 
-                Intent="Form">
+                Intent="Form" Margin="12">
                 <TableRoot 
                     Title="TableView Title">
                     <TableSection
@@ -30,9 +25,19 @@
                         <ViewCell>
                             <Label Text="A View Cell can be anything you want!" />
                         </ViewCell>
+                        <ViewCell>
+                            <Picker Title="Choose">
+                                <Picker.ItemsSource>
+                                    <x:Array Type="{x:Type x:String}">
+                                        <x:String>AAA</x:String>
+                                        <x:String>BBB</x:String>
+                                        <x:String>CCC</x:String>
+                                    </x:Array>
+                                </Picker.ItemsSource>
+                            </Picker>
+                        </ViewCell>
                     </TableSection>
                 </TableRoot>
             </TableView>
-        </VerticalStackLayout>
     </views:BasePage.Content>
 </views:BasePage>

--- a/src/Controls/src/Core/Compatibility/Handlers/TableView/Android/TableViewRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/TableView/Android/TableViewRenderer.cs
@@ -126,6 +126,21 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			return base.GetDesiredSize(widthConstraint, heightConstraint);
 		}
 
+		protected override void OnMeasure(int widthMeasureSpec, int heightMeasureSpec)
+		{
+			int width = MeasureSpec.GetSize(widthMeasureSpec);
+			int height = MeasureSpec.GetSize(heightMeasureSpec);
+
+			SetMeasuredDimension(width, height);
+
+			for (int i = 0; i < ChildCount; i++)
+			{
+				AView child = GetChildAt(i);
+				child.Measure(MeasureSpec.MakeMeasureSpec(width, MeasureSpecMode.Exactly),
+					MeasureSpec.MakeMeasureSpec(height, MeasureSpecMode.Exactly));
+			}
+		}
+
 		protected override void Dispose(bool disposing)
 		{
 			if (_disposed)

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Shipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Shipped.txt
@@ -7486,6 +7486,7 @@ override Microsoft.Maui.Controls.Handlers.Compatibility.TableViewRenderer.Dispos
 override Microsoft.Maui.Controls.Handlers.Compatibility.TableViewRenderer.GetDesiredSize(double widthConstraint, double heightConstraint) -> Microsoft.Maui.SizeRequest
 override Microsoft.Maui.Controls.Handlers.Compatibility.TableViewRenderer.MinimumSize() -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.Handlers.Compatibility.TableViewRenderer.OnAttachedToWindow() -> void
+override Microsoft.Maui.Controls.Handlers.Compatibility.TableViewRenderer.OnMeasure(int widthMeasureSpec, int heightMeasureSpec) -> void
 override Microsoft.Maui.Controls.Handlers.Compatibility.VisualElementRenderer<TElement>.OnLayout(bool changed, int l, int t, int r, int b) -> void
 override Microsoft.Maui.Controls.Handlers.Compatibility.VisualElementRenderer<TElement>.OnMeasure(int widthMeasureSpec, int heightMeasureSpec) -> void
 override Microsoft.Maui.Controls.Handlers.Items.CarouselViewAdapter<TItemsView, TItemsViewSource>.ItemCount.get -> int


### PR DESCRIPTION
### Description of Change

This PR overrides the method `TableViewRenderer.OnMeasure`, in order to fix bad rendering of TableViews on Android (when custom cells are involved, e.g. with a Picker).

### Issues Fixed

Fixes #5924

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
