### PR TITLE
Fix Clear Button size calculation

### DIFF
--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issue17453.xaml
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issue17453.xaml
@@ -2,7 +2,7 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="Maui.Controls.Sample.Issues.Issue17453">
-    <Grid RowDefinitions="*,*"
+    <Grid RowDefinitions="Auto,*"
           Padding="10,10">
         <VerticalStackLayout FlowDirection="LeftToRight"
                              Spacing="10">

--- a/src/Controls/tests/UITests/Tests/Issues/Issue17453.cs
+++ b/src/Controls/tests/UITests/Tests/Issues/Issue17453.cs
@@ -22,6 +22,11 @@ namespace Microsoft.Maui.AppiumTests.Issues
 			});
 
 			App.WaitForElement("WaitForStubControl");
+			string? rtlEntryText = App.FindElement("RtlEntry").GetText();
+
+			if (String.IsNullOrWhiteSpace(rtlEntryText))
+				App.EnterText("RtlEntry", "Simple Text");
+
 			var rtlEntryRect = App.FindElement("RtlEntry").GetRect();
 			App.EnterText("RtlEntry", "Simple Text");
 
@@ -31,9 +36,9 @@ namespace Microsoft.Maui.AppiumTests.Issues
 			// Tap on the entry but not on the clear button
 			App.Click(rtlEntryRect.CenterX(), rtlEntryRect.CenterY());
 
-			string? ltrEntryText = App.FindElement("RtlEntry").GetText();
+			rtlEntryText = App.FindElement("RtlEntry").GetText();
 
-			Assert.IsNotEmpty(ltrEntryText);
+			Assert.IsNotEmpty(rtlEntryText);
 		}
 
 		[Test]
@@ -48,7 +53,12 @@ namespace Microsoft.Maui.AppiumTests.Issues
 			});
 
 			App.WaitForElement("WaitForStubControl");
-			App.EnterText("RtlEntry", "Simple Text");
+
+			string? rtlEntryText = App.FindElement("RtlEntry").GetText();
+
+			if (String.IsNullOrWhiteSpace(rtlEntryText))
+				App.EnterText("RtlEntry", "Simple Text");
+
 			var rtlEntryRect = App.FindElement("RtlEntry").GetRect();
 
 			// Set focus
@@ -56,11 +66,11 @@ namespace Microsoft.Maui.AppiumTests.Issues
 
 			// Tap Clear Button
 			var margin = 30;
-			App.Click(rtlEntryRect.Width + margin, rtlEntryRect.Y + margin);
+			App.Click(rtlEntryRect.X + margin, rtlEntryRect.Y + margin);
 
-			string? ltrEntryText = App.FindElement("RtlEntry").GetText();
+			rtlEntryText = App.FindElement("RtlEntry").GetText();
 
-			Assert.IsEmpty(ltrEntryText);
+			Assert.IsEmpty(rtlEntryText);
 		}
 	}
 }

--- a/src/Controls/tests/UITests/Tests/Issues/Issue17453.cs
+++ b/src/Controls/tests/UITests/Tests/Issues/Issue17453.cs
@@ -11,6 +11,32 @@ namespace Microsoft.Maui.AppiumTests.Issues
 		public override string Issue => "Clear Entry text tapping the clear button not working";
 
 		[Test]
+		public void EntryClearButtonWorksEntryDoesntClearWhenNotClickingOnClear()
+		{
+			// https://github.com/dotnet/maui/issues/17453
+			this.IgnoreIfPlatforms(new[]
+			{
+				TestDevice.iOS,
+				TestDevice.Mac,
+				TestDevice.Windows
+			});
+
+			App.WaitForElement("WaitForStubControl");
+			var rtlEntryRect = App.FindElement("RtlEntry").GetRect();
+			App.EnterText("RtlEntry", "Simple Text");
+
+			// Set focus
+			App.Click(rtlEntryRect.X, rtlEntryRect.Y);
+
+			// Tap on the entry but not on the clear button
+			App.Click(rtlEntryRect.CenterX(), rtlEntryRect.CenterY());
+
+			string? ltrEntryText = App.FindElement("RtlEntry").GetText();
+
+			Assert.IsNotEmpty(ltrEntryText);
+		}
+
+		[Test]
 		public void EntryClearButtonWorks()
 		{
 			// https://github.com/dotnet/maui/issues/17453
@@ -22,6 +48,7 @@ namespace Microsoft.Maui.AppiumTests.Issues
 			});
 
 			App.WaitForElement("WaitForStubControl");
+			App.EnterText("RtlEntry", "Simple Text");
 			var rtlEntryRect = App.FindElement("RtlEntry").GetRect();
 
 			// Set focus

--- a/src/Core/src/Platform/Android/EditTextExtensions.cs
+++ b/src/Core/src/Platform/Android/EditTextExtensions.cs
@@ -416,7 +416,7 @@ namespace Microsoft.Maui.Platform
 			else
 			{
 				var leftEdge = platformView.PaddingLeft;
-				var rightEdge = leftEdge + platformView.Width;
+				var rightEdge = leftEdge + buttonRect.Width();
 
 				return new Android.Graphics.Rect(leftEdge, topEdge, rightEdge, bottomEdge);
 			}


### PR DESCRIPTION
### Description of Change

It looks like https://github.com/dotnet/maui/pull/17543 used the incorrect value for the width of the clear button. The code accidently is using the entire view width opposed to the drawables width. 

### Issues Fixed


Fixes #19481

