### PR TITLE
Fix discovering iOS 17 simulators on CI

### DIFF
--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -8,9 +8,9 @@ variables:
 - name: DOTNET_VERSION
   value: 7.0.401
 - name: REQUIRED_XCODE
-  value: 15.0.0
+  value: 15.0.1
 - name: DEVICETESTS_REQUIRED_XCODE
-  value: 15.0.0
+  value: 15.0.1
 - name: LocBranchPrefix
   value: 'loc-hb'
 - name: isMainBranch

--- a/eng/pipelines/device-tests.yml
+++ b/eng/pipelines/device-tests.yml
@@ -107,13 +107,13 @@ stages:
       agentPoolAccessToken: $(AgentPoolAccessToken)
       ${{ if or(parameters.BuildEverything, and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'devdiv'))) }}:
         androidApiLevels: [ 33, 30, 29, 28, 27, 26, 25, 24, 23 ]
-        iosVersions: [ '16.4', '15.5', '14.5']
+        iosVersions: [ '17.0', '16.4', '15.5', '14.5']
         catalystVersions: [ 'latest' ]
         windowsVersions: ['packaged', 'unpackaged']
         provisionatorChannel: ${{ parameters.provisionatorChannel }}
       ${{ if not(or(parameters.BuildEverything, and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'devdiv')))) }}:
         androidApiLevels: [ 30, 23 ]
-        iosVersions: [ '16.4' ]
+        iosVersions: [ '17.0', '16.4' ]
         catalystVersions: [ 'latest' ]
         windowsVersions: ['packaged', 'unpackaged']
         provisionatorChannel: ${{ parameters.provisionatorChannel }}

--- a/eng/pipelines/ui-tests.yml
+++ b/eng/pipelines/ui-tests.yml
@@ -133,13 +133,11 @@ stages:
       agentPoolAccessToken: $(AgentPoolAccessToken)
       ${{ if or(parameters.BuildEverything, and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'devdiv'))) }}:
         androidApiLevels: [ 30 ]
-        # androidApiLevels: [ 30, 29, 28, 27, 26, 25, 24, 23, 22, 21 ] # fix the issue of getting the test results off
-        iosVersions: [ '16.4' ]
+        iosVersions: [ '17.0', '16.4' ]
         provisionatorChannel: ${{ parameters.provisionatorChannel }}
       ${{ if not(or(parameters.BuildEverything, and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'devdiv')))) }}:
         androidApiLevels: [ 30 ]
-        # androidApiLevels: [ 30, 21 ] # fix the issue of getting the test results off
-        iosVersions: [ '16.4' ]
+        iosVersions: [ '17.0', '16.4' ]
         provisionatorChannel: ${{ parameters.provisionatorChannel }}
       ${{ if or(parameters.CompatibilityTests, ne(variables['Build.Reason'], 'PullRequest')) }}:
         runCompatibilityTests: true


### PR DESCRIPTION
### Description of Change

It seems simctl does not correctly discover iOS 17 simulators when both Xcode 15 and Xcode 15.0.1 are installed. Bumping to use Xcode 15.0.1 makes tests work again as simulators are correctly discovered.

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/19134



<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
