### PR TITLE
iOS/CollectionView - Remove GetSizeForItem and use newer AutomaticSize

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/TextCodeCollectionViewGallery.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/TextCodeCollectionViewGallery.cs
@@ -23,7 +23,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries
 				AutomationId = "collectionview"
 			};
 
-			var generator = new ItemsSourceGenerator(collectionView);
+			var generator = new ItemsSourceGenerator(collectionView, 200000);
 
 			layout.Children.Add(generator);
 

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/TextCodeCollectionViewGridGallery.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/TextCodeCollectionViewGridGallery.cs
@@ -21,7 +21,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries
 
 			var collectionView = new CollectionView { ItemsLayout = itemsLayout, AutomationId = "collectionview" };
 
-			var generator = new ItemsSourceGenerator(collectionView);
+			var generator = new ItemsSourceGenerator(collectionView, 200000);
 			var spanSetter = new SpanSetter(collectionView);
 
 			layout.Children.Add(generator);

--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewDelegator.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewDelegator.cs
@@ -174,9 +174,9 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			return centerItemIndex;
 		}
 
-		public override CGSize GetSizeForItem(UICollectionView collectionView, UICollectionViewLayout layout, NSIndexPath indexPath)
-		{
-			return ViewController?.GetSizeForItem(indexPath) ?? CGSize.Empty;
-		}
+		// public override CGSize GetSizeForItem(UICollectionView collectionView, UICollectionViewLayout layout, NSIndexPath indexPath)
+		// {
+		// 	return ViewController?.GetSizeForItem(indexPath) ?? CGSize.Empty;
+		// }
 	}
 }

--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewLayout.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewLayout.cs
@@ -249,6 +249,9 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		void Initialize(UICollectionViewScrollDirection scrollDirection)
 		{
+			EstimatedItemSize = UICollectionViewFlowLayout.AutomaticSize;
+			ItemSize = UICollectionViewFlowLayout.AutomaticSize;
+			
 			ScrollDirection = scrollDirection;
 		}
 

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Shipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Shipped.txt
@@ -2048,7 +2048,6 @@
 ~override Microsoft.Maui.Controls.Handlers.Items.ItemsViewDelegator<TItemsView, TViewController>.GetInsetForSection(UIKit.UICollectionView collectionView, UIKit.UICollectionViewLayout layout, nint section) -> UIKit.UIEdgeInsets
 ~override Microsoft.Maui.Controls.Handlers.Items.ItemsViewDelegator<TItemsView, TViewController>.GetMinimumInteritemSpacingForSection(UIKit.UICollectionView collectionView, UIKit.UICollectionViewLayout layout, nint section) -> System.Runtime.InteropServices.NFloat
 ~override Microsoft.Maui.Controls.Handlers.Items.ItemsViewDelegator<TItemsView, TViewController>.GetMinimumLineSpacingForSection(UIKit.UICollectionView collectionView, UIKit.UICollectionViewLayout layout, nint section) -> System.Runtime.InteropServices.NFloat
-~override Microsoft.Maui.Controls.Handlers.Items.ItemsViewDelegator<TItemsView, TViewController>.GetSizeForItem(UIKit.UICollectionView collectionView, UIKit.UICollectionViewLayout layout, Foundation.NSIndexPath indexPath) -> CoreGraphics.CGSize
 ~override Microsoft.Maui.Controls.Handlers.Items.ItemsViewDelegator<TItemsView, TViewController>.Scrolled(UIKit.UIScrollView scrollView) -> void
 ~override Microsoft.Maui.Controls.Handlers.Items.ItemsViewHandler<TItemsView>.ConnectHandler(UIKit.UIView platformView) -> void
 ~override Microsoft.Maui.Controls.Handlers.Items.ItemsViewHandler<TItemsView>.CreatePlatformView() -> UIKit.UIView

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Shipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Shipped.txt
@@ -2048,7 +2048,6 @@
 ~override Microsoft.Maui.Controls.Handlers.Items.ItemsViewDelegator<TItemsView, TViewController>.GetInsetForSection(UIKit.UICollectionView collectionView, UIKit.UICollectionViewLayout layout, nint section) -> UIKit.UIEdgeInsets
 ~override Microsoft.Maui.Controls.Handlers.Items.ItemsViewDelegator<TItemsView, TViewController>.GetMinimumInteritemSpacingForSection(UIKit.UICollectionView collectionView, UIKit.UICollectionViewLayout layout, nint section) -> System.Runtime.InteropServices.NFloat
 ~override Microsoft.Maui.Controls.Handlers.Items.ItemsViewDelegator<TItemsView, TViewController>.GetMinimumLineSpacingForSection(UIKit.UICollectionView collectionView, UIKit.UICollectionViewLayout layout, nint section) -> System.Runtime.InteropServices.NFloat
-~override Microsoft.Maui.Controls.Handlers.Items.ItemsViewDelegator<TItemsView, TViewController>.GetSizeForItem(UIKit.UICollectionView collectionView, UIKit.UICollectionViewLayout layout, Foundation.NSIndexPath indexPath) -> CoreGraphics.CGSize
 ~override Microsoft.Maui.Controls.Handlers.Items.ItemsViewDelegator<TItemsView, TViewController>.Scrolled(UIKit.UIScrollView scrollView) -> void
 ~override Microsoft.Maui.Controls.Handlers.Items.ItemsViewHandler<TItemsView>.ConnectHandler(UIKit.UIView platformView) -> void
 ~override Microsoft.Maui.Controls.Handlers.Items.ItemsViewHandler<TItemsView>.CreatePlatformView() -> UIKit.UIView


### PR DESCRIPTION
### Description of Change

Basically having GetSizeForItem causes the layout to always call this for every item in the source. This is fine if we cache item sizes, and don't have huge data sources, but if you have something like 200,000 items, just the act of doing the interop to this platform call for each item has some overhead that adds up.

In iOS10+ we have `UICollectionViewFlowLayout.AutomaticSize` which we can set for `EstimatedItemSize` (and `ItemSize`, although I'm not sure if this is strictly necessary). Setting this, as well as removing the `GetSizeForItem` implementation allows more dynamic calculation of the individual sizes without calling the method for every item in the source.

> Note that in the sample, there's still a few seconds delay but this I have measured to be the call to generate the item source, as it's an observable collection that we are adding 200,000 items to.  The actual CollectionView initialization is fast.

Related to investigations in #18891 
