### PR TITLE
Fix page swap from background

### DIFF
--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issue11501.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issue11501.cs
@@ -1,0 +1,183 @@
+﻿
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+
+namespace Maui.Controls.Sample.Issues
+{
+	[Issue(IssueTracker.Github, 11501, "Making Fragment Changes While App is Backgrounded Fails", PlatformAffected.Android)]
+	public class Issue11501 : TestContentPage
+	{
+		Func<Task> _currentTest;
+		Page _mainPage;
+		List<Page> _modalStack;
+		Window _window;
+		public Issue11501()
+		{
+			Loaded += OnLoaded;
+		}
+
+		private void OnLoaded(object sender, EventArgs e)
+		{
+			_window = Window;
+			_mainPage = Application.Current.MainPage;
+			_modalStack = Navigation.ModalStack.ToList();
+		}
+
+		private async void OnWindowActivated(object sender, EventArgs e)
+		{
+			DisconnectFromWindow();
+			if (_currentTest is not null)
+			{
+				await Task.Yield();
+				await _currentTest();
+				_currentTest = null;
+			}
+		}
+
+		void ConnectToWindow()
+		{
+			_window.Stopped -= OnWindowActivated;
+			_window.Stopped += OnWindowActivated;
+		}
+
+		void DisconnectFromWindow()
+		{
+			_window.Stopped -= OnWindowActivated;
+		}
+
+		protected override void Init()
+		{
+			Content = new VerticalStackLayout()
+			{
+				new Button()
+				{
+					Text = "Swap Main Page",
+					AutomationId = "SwapMainPage",
+					Command = new Command( () =>
+					{
+						Application.Current.MainPage =
+							new ContentPage() { Title = "Test", Content = new Label() { Text = "Background/Minimize the app" } };
+
+						ConnectToWindow();
+						_currentTest = () =>
+						{
+							Application.Current.MainPage = CreateDestinationPage();
+							return Task.CompletedTask;
+						};
+					})
+				},
+				new Button()
+				{
+					Text = "Changing Details/Flyout on FlyoutPage in Background",
+					AutomationId = "SwapFlyoutPage",
+					Command = new Command(()=>
+					{
+						var flyoutPage = new FlyoutPage()
+						{
+							Flyout = new ContentPage() { Title = "Test", Content = new Label(){Text = "Background/Minimize the app" } },
+							Detail = new NavigationPage(new ContentPage(){ Title = "Test", Content = new Label() { Text = "Background/Minimize the app" } })
+							{
+								Title = "Test"
+							},
+						};
+
+						Application.Current.MainPage = flyoutPage;
+						ConnectToWindow();
+
+						_currentTest = () =>
+						{
+							flyoutPage.Flyout = CreateDestinationPage();
+							flyoutPage.Detail = new NavigationPage(CreateDestinationPage());
+							return Task.CompletedTask;
+						};
+					})
+				},
+
+				new Button()
+				{
+					Text = "Swap Tabbed Page",
+					AutomationId = "SwapTabbedPage",
+					Command = new Command( () =>
+					{
+						Application.Current.MainPage = new ContentPage() { Title = "Test", Content = new Label() { Text = "Background/Minimize the app" } };
+						ConnectToWindow();
+						_currentTest = () =>
+						{
+							Application.Current.MainPage = new TabbedPage()
+							{
+								Children =
+								{
+									new ContentPage() { Title = "Test", Content = new Label(){Text = "Background/Minimize the app" } },
+									new NavigationPage(CreateDestinationPage())
+									{
+										Title = "Test"
+									}
+								}
+							};
+							return Task.CompletedTask;
+						};
+					})
+				},
+				new Button()
+				{
+					Text = "Removing and Changing Tabs",
+					AutomationId = "RemoveAddTabs",
+					Command = new Command(() =>
+					{
+						var tabbedPage = new TabbedPage()
+						{
+							Children =
+							{
+								new ContentPage() { Title = "Test", Content = new Label(){Text = "Background/Minimize the app" } },
+								new NavigationPage(CreateDestinationPage())
+								{
+									Title = "Test"
+								}
+							}
+						};
+
+						Application.Current.MainPage = tabbedPage;
+						ConnectToWindow();
+
+						_currentTest = () =>
+						{
+							tabbedPage.Children.RemoveAt(0);
+							tabbedPage.Children.Add(CreateDestinationPage());
+							return Task.CompletedTask;
+						};
+					})
+				},
+			};
+		}
+
+		ContentPage CreateDestinationPage()
+		{
+			return new ContentPage()
+			{
+				Title = "Test",
+				Content = new VerticalStackLayout()
+				{
+					new Button()
+					{
+						AutomationId = "Restore",
+						Text = "Restore",
+						Command = new Command(async ()=>
+						{
+							Application.Current.MainPage = _mainPage;
+
+							await Task.Yield();
+
+							foreach(var page in _modalStack)
+							{
+								await _mainPage.Navigation.PushModalAsync(page);
+							}
+						})
+					}
+				}
+			};
+		}
+	}
+}

--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issue11501.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issue11501.cs
@@ -59,7 +59,7 @@ namespace Maui.Controls.Sample.Issues
 					Command = new Command( () =>
 					{
 						Application.Current.MainPage =
-							new ContentPage() { Title = "Test", Content = new Label() { Text = "Background/Minimize the app" } };
+							new ContentPage() { Title = "Test", Content = new Label() { AutomationId = "BackgroundMe", Text = "Background/Minimize the app" } };
 
 						ConnectToWindow();
 						_currentTest = () =>
@@ -78,7 +78,7 @@ namespace Maui.Controls.Sample.Issues
 						var flyoutPage = new FlyoutPage()
 						{
 							Flyout = new ContentPage() { Title = "Test", Content = new Label(){Text = "Background/Minimize the app" } },
-							Detail = new NavigationPage(new ContentPage(){ Title = "Test", Content = new Label() { Text = "Background/Minimize the app" } })
+							Detail = new NavigationPage(new ContentPage(){ Title = "Test", Content = new Label() { AutomationId = "BackgroundMe", Text = "Background/Minimize the app" } })
 							{
 								Title = "Test"
 							},
@@ -102,7 +102,7 @@ namespace Maui.Controls.Sample.Issues
 					AutomationId = "SwapTabbedPage",
 					Command = new Command( () =>
 					{
-						Application.Current.MainPage = new ContentPage() { Title = "Test", Content = new Label() { Text = "Background/Minimize the app" } };
+						Application.Current.MainPage = new ContentPage() { Title = "Test", Content = new Label() {AutomationId = "BackgroundMe", Text = "Background/Minimize the app" } };
 						ConnectToWindow();
 						_currentTest = () =>
 						{
@@ -131,7 +131,7 @@ namespace Maui.Controls.Sample.Issues
 						{
 							Children =
 							{
-								new ContentPage() { Title = "Test", Content = new Label(){Text = "Background/Minimize the app" } },
+								new ContentPage() { Title = "Test", Content = new Label() { AutomationId = "BackgroundMe", Text = "Background/Minimize the app" } },
 								new NavigationPage(CreateDestinationPage())
 								{
 									Title = "Test"

--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issue11501.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issue11501.cs
@@ -110,11 +110,11 @@ namespace Maui.Controls.Sample.Issues
 							{
 								Children =
 								{
-									new ContentPage() { Title = "Test", Content = new Label(){Text = "Background/Minimize the app" } },
 									new NavigationPage(CreateDestinationPage())
 									{
 										Title = "Test"
-									}
+									},
+									new ContentPage() { Title = "Test", Content = new Label(){Text = "Second Page" } },
 								}
 							};
 							return Task.CompletedTask;

--- a/src/Controls/src/Core/Platform/Android/Extensions/ToolbarExtensions.cs
+++ b/src/Controls/src/Core/Platform/Android/Extensions/ToolbarExtensions.cs
@@ -84,10 +84,9 @@ namespace Microsoft.Maui.Controls.Platform
 					nativeToolbar.Context ??
 					toolbar.Handler?.MauiContext?.Context;
 
-				nativeToolbar.NavigationIcon ??= new DrawerArrowDrawable(context!)
-				{
-					Progress = 1
-				};
+				nativeToolbar.NavigationIcon ??= new DrawerArrowDrawable(context!);
+				if (nativeToolbar.NavigationIcon is DrawerArrowDrawable iconDrawable)
+					iconDrawable.Progress = 1;
 
 				var backButtonTitle = toolbar.BackButtonTitle;
 				ImageSource image = toolbar.TitleIcon;
@@ -110,6 +109,9 @@ namespace Microsoft.Maui.Controls.Platform
 				}
 				else
 				{
+					if (nativeToolbar.NavigationIcon is DrawerArrowDrawable iconDrawable)
+						iconDrawable.Progress = 0;
+
 					nativeToolbar.SetNavigationContentDescription(Resource.String.nav_app_bar_open_drawer_description);
 				}
 			}

--- a/src/Controls/tests/UITests/Tests/Issues/Issue11501.cs
+++ b/src/Controls/tests/UITests/Tests/Issues/Issue11501.cs
@@ -1,0 +1,39 @@
+﻿using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.AppiumTests.Issues
+{
+	public class Issue11501 : _IssuesUITest
+	{
+		public Issue11501(TestDevice device) : base(device)
+		{
+		}
+
+		public override string Issue => "Making Fragment Changes While App is Backgrounded Fails";
+
+		[TestCase("SwapMainPage")]
+		[TestCase("SwapFlyoutPage")]
+		[TestCase("SwapTabbedPage")]
+		[TestCase("RemoveAddTabs")]
+		public void MakingFragmentRelatedChangesWhileAppIsBackgroundedFails(string scenario)
+		{
+			try
+			{
+				App.WaitForElement(scenario);
+				App.Click(scenario);
+				App.BackgroundApp();
+				App.ForegroundApp();
+				App.WaitForElement("Restore");
+				App.Click("Restore");
+			}
+			catch
+			{
+				// Just in case these tests leave the app in an unreliable state
+				App.ResetApp();
+				FixtureSetup();
+				throw;
+			}
+		}
+	}
+}

--- a/src/Controls/tests/UITests/Tests/Issues/Issue11501.cs
+++ b/src/Controls/tests/UITests/Tests/Issues/Issue11501.cs
@@ -16,13 +16,19 @@ namespace Microsoft.Maui.AppiumTests.Issues
 		[TestCase("SwapFlyoutPage")]
 		[TestCase("SwapTabbedPage")]
 		[TestCase("RemoveAddTabs")]
-		public void MakingFragmentRelatedChangesWhileAppIsBackgroundedFails(string scenario)
+		public async Task MakingFragmentRelatedChangesWhileAppIsBackgroundedFails(string scenario)
 		{
+			this.IgnoreIfPlatforms(new TestDevice[] { TestDevice.Mac, TestDevice.Windows });
+
 			try
 			{
 				App.WaitForElement(scenario);
 				App.Click(scenario);
 				App.BackgroundApp();
+
+				// Wait for app to finish backgrounding
+				await Task.Yield();
+				App.WaitForNoElement("BackgroundMe");
 				App.ForegroundApp();
 				App.WaitForElement("Restore");
 				App.Click("Restore");

--- a/src/Core/src/Platform/Android/FragmentManagerExtensions.cs
+++ b/src/Core/src/Platform/Android/FragmentManagerExtensions.cs
@@ -108,6 +108,12 @@ namespace Microsoft.Maui.Platform
 				_context = context;
 			}
 
+			public override void OnFragmentDestroyed(FragmentManager fm, Fragment f)
+			{
+				base.OnFragmentDestroyed(fm, f);
+				Disconnect();
+			}
+
 			public override void OnFragmentResumed(FragmentManager fm, Fragment f)
 			{
 				base.OnFragmentResumed(fm, f);

--- a/src/Core/src/Platform/Android/FragmentManagerExtensions.cs
+++ b/src/Core/src/Platform/Android/FragmentManagerExtensions.cs
@@ -70,5 +70,65 @@ namespace Microsoft.Maui.Platform
 
 			return context.IsDestroyed();
 		}
+
+		public static IDisposable? RunOrWaitForResume(this FragmentManager obj, Context context, Action<FragmentManager> onResume)
+		{
+			if (obj.IsDestroyed(context))
+				return null;
+
+			if (obj.IsStateSaved)
+			{
+				var callback = new CallBacks(context, onResume, obj);
+				obj.RegisterFragmentLifecycleCallbacks(callback, false);
+				return new ActionDisposable(() =>
+				{
+					callback?.Disconnect();
+					callback = null;
+				});
+			}
+
+			onResume.Invoke(obj);
+			return null;
+		}
+
+		class CallBacks : FragmentManager.FragmentLifecycleCallbacks
+		{
+			FragmentManager? _fragmentManager;
+			Action<FragmentManager>? _onResume;
+			Context? _context;
+
+			public CallBacks(
+				Context context,
+				Action<FragmentManager> onResume,
+				FragmentManager fragmentManager)
+			{
+				_fragmentManager = fragmentManager;
+				_fragmentManager.RegisterFragmentLifecycleCallbacks(this, false);
+				_onResume = onResume;
+				_context = context;
+			}
+
+			public override void OnFragmentResumed(FragmentManager fm, Fragment f)
+			{
+				base.OnFragmentResumed(fm, f);
+				var resume = _onResume;
+				Disconnect();
+				resume?.Invoke(fm);
+			}
+
+			public void Disconnect()
+			{
+				if (_fragmentManager is not null &&
+					!_fragmentManager.IsDestroyed(_context))
+				{
+					_fragmentManager.UnregisterFragmentLifecycleCallbacks(this);
+				}
+
+				_fragmentManager = null;
+				_onResume = null;
+				_context = null;
+			}
+		}
+
 	}
 }


### PR DESCRIPTION
### Description of Change

With MAUI we stopped committing fragments with state loss. This makes it so you can't make fragment changes when the app is backgrounded. This PR injects some lifecycle logic into every part of our application where we are interacting with fragments and adds code that will wait until the resume has finished before processing the fragment changes. 

### Issues Fixed

Fixes #11501
