### PR TITLE
Set Simulator UDID explicitly for CG UI tests

### DIFF
--- a/src/Compatibility/ControlGallery/src/Issues.Shared/TestPages/TestPages.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/TestPages/TestPages.cs
@@ -164,9 +164,7 @@ namespace Microsoft.Maui.Controls.ControlGallery
 							.AppBundle(fullApkPath)
 							.Debug();
 
-			var appConfiguration = ConfigureApp.iOS.InstalledApp(AppPaths.BundleId).Debug();
-
-			if(!string.IsNullOrWhiteSpace(UDID))
+			if (!string.IsNullOrWhiteSpace(UDID))
 			{
 				appConfiguration = appConfiguration.DeviceIdentifier(UDID);
 			}

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/TestPages/TestPages.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/TestPages/TestPages.cs
@@ -162,7 +162,7 @@ namespace Microsoft.Maui.Controls.ControlGallery
 			var appConfiguration = ConfigureApp.iOS
 							.PreferIdeSettings()
 							.AppBundle(fullApkPath)
-							.Debug()
+							.Debug();
 
 			var appConfiguration = ConfigureApp.iOS.InstalledApp(AppPaths.BundleId).Debug();
 

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/TestPages/TestPages.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/TestPages/TestPages.cs
@@ -153,17 +153,25 @@ namespace Microsoft.Maui.Controls.ControlGallery
 
 
 			var enviOSPath = Environment.GetEnvironmentVariable("iOS_APP");
-
+			var UDID = Environment.GetEnvironmentVariable("DEVICE_UDID");
 
 			var fullApkPath = string.IsNullOrEmpty(enviOSPath) ? IOPath.Combine(TestContext.CurrentContext.TestDirectory, AppPaths.iOSPath)
 																: enviOSPath;
 
 			// Running on the simulator
-			var app = ConfigureApp.iOS
+			var appConfiguration = ConfigureApp.iOS
 							.PreferIdeSettings()
 							.AppBundle(fullApkPath)
 							.Debug()
-							.StartApp();
+
+			var appConfiguration = ConfigureApp.iOS.InstalledApp(AppPaths.BundleId).Debug();
+
+			if(!string.IsNullOrWhiteSpace(UDID))
+			{
+				appConfiguration = appConfiguration.DeviceIdentifier(UDID);
+			}
+							
+			var app = appConfiguration.StartApp();
 
 			return app;
 		}


### PR DESCRIPTION
This passes on the preferred Simulator UDID to the UI Test runner so it will always be able to find the (correct) Simulator to use