### PR TITLE
Disable flaky compat test

### DIFF
--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Github6384.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Github6384.cs
@@ -73,6 +73,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 [Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiAndroid]
+[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiiOS]
 		[Test]
 		public void Github6384Test()
 		{


### PR DESCRIPTION
Disabled a flaky compatibility test to get the pipeline more reliable.

Since it's marked with this attribute it will pop up later when we revisit those.