### PR TITLE
Break `ControlsHeadlessTestRunner.RunTestsAsync` method when discovering tests

### DIFF
--- a/src/TestUtils/src/DeviceTests.Runners/HeadlessRunner/Windows/ControlsHeadlessTestRunner.cs
+++ b/src/TestUtils/src/DeviceTests.Runners/HeadlessRunner/Windows/ControlsHeadlessTestRunner.cs
@@ -91,6 +91,7 @@ namespace Microsoft.Maui.TestUtils.DeviceTests.Runners.HeadlessRunner
 					File.WriteAllLines(_categoriesFilePath, categories.ToArray());
 
 					TerminateWithSuccess();
+					return null;
 				}
 
 				await RunAsync();


### PR DESCRIPTION
Because of limitations on Windows/WinUI we have a bit of a complicated setup to run our tests there. There is a limit on the number of windows (actual desktop windows) we can spawn, if we hit the limit, the app crashes. That's why we broke up the running of tests per category.

The process is roughly: the Windows app gets started with a startup argument of -1, that means: go discover the tests. Then, each consecutive run will have a number starting at 0 and looping until the count of the categories discovered.

This was a bit flaky as can be seen in the linked issue. Seemingly because we weren't stopping the running of tests with the -1 option where we just want to discover the tests. Adding this condition makes this more stable.

Fixes #19463