### PR TITLE
Grab device logs if app stops running

### DIFF
--- a/src/TestUtils/src/UITest.NUnit/UITestBase.cs
+++ b/src/TestUtils/src/UITest.NUnit/UITestBase.cs
@@ -58,10 +58,11 @@ namespace UITest.Appium.NUnit
 		{
 			if (App.AppState == ApplicationState.NotRunning)
 			{
+				SaveDeviceDiagnosticInfo();
+
 				Reset();
 				FixtureSetup();
 
-				SaveDeviceDiagnosticInfo();
 				// Assert.Fail will immediately exit the test which is desirable as the app is not
 				// running anymore so we can't capture any UI structures or any screenshots
 				Assert.Fail("The app was expected to be running still, investigate as possible crash");

--- a/src/TestUtils/src/UITest.NUnit/UITestBase.cs
+++ b/src/TestUtils/src/UITest.NUnit/UITestBase.cs
@@ -61,6 +61,7 @@ namespace UITest.Appium.NUnit
 				Reset();
 				FixtureSetup();
 
+				SaveDeviceDiagnosticInfo();
 				// Assert.Fail will immediately exit the test which is desirable as the app is not
 				// running anymore so we can't capture any UI structures or any screenshots
 				Assert.Fail("The app was expected to be running still, investigate as possible crash");


### PR DESCRIPTION
### Description of Change

If the app stops running, we currently don't grab any device logs. 
