### PR TITLE
Add buttons to copy error messages and stack traces to the test runner

### DIFF
--- a/src/TestUtils/src/DeviceTests.Runners/VisualRunner/Pages/TestResultPage.xaml
+++ b/src/TestUtils/src/DeviceTests.Runners/VisualRunner/Pages/TestResultPage.xaml
@@ -17,8 +17,18 @@
             </Frame>
 
             <Image Source="{Binding ErrorImage}"></Image>
-            <Label Text="{Binding ErrorMessage}" FontAttributes="Bold" />
-            <Label Text="{Binding ErrorStackTrace}"/>
+            
+            <Label Text="{Binding ErrorMessage}" FontAttributes="Bold" x:Name="ErrorMessage" />
+            <Label Text="{Binding ErrorStackTrace}"
+                   x:Name="ErrorTrace" />
+
+            <HorizontalStackLayout Spacing="5">
+                <Button Text="Copy Message"
+                        x:Name="CopyMessage" />
+
+                <Button Text="Copy StackTrace"
+                        x:Name="CopyTrace" />
+            </HorizontalStackLayout>
         </StackLayout>
     </ScrollView>
 

--- a/src/TestUtils/src/DeviceTests.Runners/VisualRunner/Pages/TestResultPage.xaml.cs
+++ b/src/TestUtils/src/DeviceTests.Runners/VisualRunner/Pages/TestResultPage.xaml.cs
@@ -1,5 +1,6 @@
 ﻿#nullable enable
 using Microsoft.Maui.Controls;
+using Microsoft.Maui.ApplicationModel.DataTransfer;
 
 namespace Microsoft.Maui.TestUtils.DeviceTests.Runners.VisualRunner.Pages
 {
@@ -8,6 +9,19 @@ namespace Microsoft.Maui.TestUtils.DeviceTests.Runners.VisualRunner.Pages
 		public TestResultPage()
 		{
 			InitializeComponent();
+
+			CopyMessage.Clicked += CopyMessageClicked;
+			CopyTrace.Clicked += CopyTraceClicked;
+		}
+
+		async void CopyMessageClicked(object? sender, System.EventArgs e)
+		{
+			await Clipboard.Default.SetTextAsync(ErrorMessage.Text);
+		}
+
+		async void CopyTraceClicked(object? sender, System.EventArgs e)
+		{
+			await Clipboard.Default.SetTextAsync(ErrorTrace.Text);
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change

The test runner displays the error info in Labels, which can't be selected or copied easily. This adds copy buttons below the messages so we can easily copy test failure info to the clipboard.


