### PR TITLE
Remove calls to scoped services on root provider

### DIFF
--- a/src/Controls/src/Xaml/Hosting/AppHostBuilderExtensions.cs
+++ b/src/Controls/src/Xaml/Hosting/AppHostBuilderExtensions.cs
@@ -197,8 +197,8 @@ namespace Microsoft.Maui.Controls.Hosting
 			{
 #if WINDOWS
 				var dispatcher =
-					services.GetService<IDispatcher>() ??
-					IPlatformApplication.Current?.Services.GetRequiredService<IDispatcher>();
+					services.GetService<ApplicationDispatcher>()?.AppDispatcher ??
+					IPlatformApplication.Current?.Services?.GetRequiredService<IDispatcher>();
 
 				dispatcher
 					.DispatchIfRequired(() =>

--- a/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.cs
@@ -1,15 +1,18 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection.PortableExecutable;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Maui;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Handlers;
 using Microsoft.Maui.Controls.Platform;
 using Microsoft.Maui.Devices;
 using Microsoft.Maui.DeviceTests.Stubs;
+using Microsoft.Maui.Dispatching;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Hosting;
@@ -199,5 +202,29 @@ namespace Microsoft.Maui.DeviceTests
 		}
 #endif
 
+		[Fact(DisplayName = "Initial Dispatch from Background Thread Succeeds")]
+		public async Task InitialDispatchFromBackgroundThreadSucceeds()
+		{
+			EnsureHandlerCreated(builder =>
+			{
+				builder.Services.RemoveAll<IDispatcher>();
+				builder.ConfigureDispatching();
+			});
+
+			var firstPage = new ContentPage();
+			var window = new Window(firstPage);
+			bool passed = true;
+
+			await CreateHandlerAndAddToWindow<WindowHandlerStub>(window, async (handler) =>
+			{
+				await Task.Run(async () =>
+				{
+					await firstPage.Handler.MauiContext.Services.GetRequiredService<IDispatcher>()
+						.DispatchAsync(() => passed = true);
+				});
+			});
+
+			Assert.True(passed);
+		}
 	}
 }

--- a/src/Core/src/Hosting/Dispatching/AppHostBuilderExtensions.cs
+++ b/src/Core/src/Hosting/Dispatching/AppHostBuilderExtensions.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Maui.Hosting
 				return dispatch ?? svc.GetRequiredService<ApplicationDispatcher>().AppDispatcher;
 			});
 
-			builder.Services.AddSingleton<ApplicationDispatcher>();
+			builder.Services.TryAddSingleton<ApplicationDispatcher>();
 
 
 			builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IMauiInitializeService, DispatcherInitializer>());

--- a/src/Core/src/Hosting/Dispatching/AppHostBuilderExtensions.cs
+++ b/src/Core/src/Hosting/Dispatching/AppHostBuilderExtensions.cs
@@ -23,7 +23,6 @@ namespace Microsoft.Maui.Hosting
 
 				var dispatch = Dispatcher.GetForCurrentThread();
 
-				// Slight behavior change 
 				return dispatch ?? svc.GetRequiredService<ApplicationDispatcher>().AppDispatcher;
 			});
 

--- a/src/Core/src/Hosting/IMauiInitializeService.cs
+++ b/src/Core/src/Hosting/IMauiInitializeService.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Maui.Hosting
 		void Initialize(IServiceProvider services);
 	}
 
+	// Obsolete/rework for NET9: https://github.com/dotnet/maui/issues/19591
 	public interface IMauiInitializeScopedService
 	{
 		void Initialize(IServiceProvider services);

--- a/src/Core/src/Hosting/MauiAppBuilder.cs
+++ b/src/Core/src/Hosting/MauiAppBuilder.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Maui.Hosting
 #if WINDOWS
 				// WORKAROUND: use the MAUI dispatcher instead of the OS dispatcher to
 				// avoid crashing: https://github.com/microsoft/WindowsAppSDK/issues/2451
-				var dispatcher = services.GetRequiredService<IDispatcher>();
+				var dispatcher = services.GetRequiredService<ApplicationDispatcher>().AppDispatcher;
 				if (dispatcher.IsDispatchRequired)
 					dispatcher.Dispatch(() => SetupResources());
 				else

--- a/src/Core/src/MauiContextExtensions.cs
+++ b/src/Core/src/MauiContextExtensions.cs
@@ -6,20 +6,20 @@ using Microsoft.Maui.Hosting;
 using Microsoft.Maui.ApplicationModel;
 
 #if WINDOWS
-using NativeApplication = Microsoft.UI.Xaml.Application;
-using NativeWindow = Microsoft.UI.Xaml.Window;
+using PlatformApplication = Microsoft.UI.Xaml.Application;
+using PlatformWindow = Microsoft.UI.Xaml.Window;
 #elif __IOS__ || __MACCATALYST__
-using NativeApplication = UIKit.IUIApplicationDelegate;
-using NativeWindow = UIKit.UIWindow;
+using PlatformApplication = UIKit.IUIApplicationDelegate;
+using PlatformWindow = UIKit.UIWindow;
 #elif __ANDROID__
-using NativeApplication = Android.App.Application;
-using NativeWindow = Android.App.Activity;
+using PlatformApplication = Android.App.Application;
+using PlatformWindow = Android.App.Activity;
 #elif TIZEN
-using NativeApplication = Tizen.Applications.CoreApplication;
-using NativeWindow = Tizen.NUI.Window;
+using PlatformApplication = Tizen.Applications.CoreApplication;
+using PlatformWindow = Tizen.NUI.Window;
 #else
-using NativeApplication = System.Object;
-using NativeWindow = System.Object;
+using PlatformApplication = System.Object;
+using PlatformWindow = System.Object;
 #endif
 
 namespace Microsoft.Maui
@@ -35,7 +35,7 @@ namespace Microsoft.Maui
 		public static IDispatcher? GetOptionalDispatcher(this IMauiContext mauiContext) =>
 			mauiContext.Services.GetService<IDispatcher>();
 
-		public static IMauiContext MakeApplicationScope(this IMauiContext mauiContext, NativeApplication platformApplication)
+		public static IMauiContext MakeApplicationScope(this IMauiContext mauiContext, PlatformApplication platformApplication)
 		{
 			var scopedContext = new MauiContext(mauiContext.Services);
 
@@ -46,7 +46,7 @@ namespace Microsoft.Maui
 			return scopedContext;
 		}
 
-		public static IMauiContext MakeWindowScope(this IMauiContext mauiContext, NativeWindow platformWindow, out IServiceScope scope)
+		public static IMauiContext MakeWindowScope(this IMauiContext mauiContext, PlatformWindow platformWindow, out IServiceScope scope)
 		{
 			scope = mauiContext.Services.CreateScope();
 
@@ -65,6 +65,10 @@ namespace Microsoft.Maui
 			scopedContext.AddSpecific(new NavigationRootManager(platformWindow));
 #endif
 
+			// Capture the window level dispatcher.
+			// If the user first retrieves the IDispatcher from the window on a background thread
+			// it'll just return null and be permanently null if we don't saturate this for them.
+			_ = scope.ServiceProvider.GetService<IDispatcher>();
 			return scopedContext;
 		}
 

--- a/src/Core/src/Platform/Windows/MauiWinUIWindow.cs
+++ b/src/Core/src/Platform/Windows/MauiWinUIWindow.cs
@@ -28,8 +28,8 @@ namespace Microsoft.Maui
 		{
 			_windowManager = WindowMessageManager.Get(this);
 			_viewSettings = new ViewManagement.UISettings();
-
 			Activated += OnActivated;
+			Activated += AssignDispatcher;
 			Closed += OnClosedPrivate;
 			VisibilityChanged += OnVisibilityChanged;
 
@@ -56,6 +56,12 @@ namespace Microsoft.Maui
 
 			SubClassingWin32();
 			SetIcon();
+		}
+
+		void AssignDispatcher(object sender, UI.Xaml.WindowActivatedEventArgs args)
+		{
+			Activated -= AssignDispatcher;
+			Window?.Handler?.MauiContext?.SetupDispatcher();
 		}
 
 		protected virtual void OnActivated(object sender, UI.Xaml.WindowActivatedEventArgs args)

--- a/src/Core/tests/DeviceTests.Shared/HandlerTests/HandlerTestBasement.cs
+++ b/src/Core/tests/DeviceTests.Shared/HandlerTests/HandlerTestBasement.cs
@@ -40,6 +40,7 @@ namespace Microsoft.Maui.DeviceTests
 
 			appBuilder.Services.AddSingleton<IDispatcherProvider>(svc => TestDispatcher.Provider);
 			appBuilder.Services.AddScoped<IDispatcher>(svc => TestDispatcher.Current);
+			appBuilder.Services.AddSingleton<ApplicationDispatcher>(svc => new ApplicationDispatcher(TestDispatcher.Current));
 			appBuilder.Services.AddSingleton<IApplication>((_) => new CoreApplicationStub());
 
 			appBuilder = ConfigureBuilder(appBuilder);

--- a/src/Core/tests/DeviceTests.Shared/MauiProgramDefaults.cs
+++ b/src/Core/tests/DeviceTests.Shared/MauiProgramDefaults.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Maui.Hosting;
 using Microsoft.Maui.LifecycleEvents;
 using Microsoft.Maui.TestUtils.DeviceTests.Runners;
@@ -68,6 +69,12 @@ namespace Microsoft.Maui.DeviceTests
 			});
 #endif
 			appBuilder.UseVisualRunner();
+
+			appBuilder.ConfigureContainer(new DefaultServiceProviderFactory(new ServiceProviderOptions
+			{
+				ValidateOnBuild = true,
+				ValidateScopes = true,
+			}));
 
 			var mauiApp = appBuilder.Build();
 

--- a/src/TestUtils/src/DeviceTests.Runners/TestDispatcher.cs
+++ b/src/TestUtils/src/DeviceTests.Runners/TestDispatcher.cs
@@ -29,7 +29,9 @@ namespace Microsoft.Maui.TestUtils.DeviceTests.Runners
 			get
 			{
 				if (s_dispatcher is null)
-					s_dispatcher = TestServices.Services.GetService<IDispatcher>();
+				{
+					s_dispatcher = TestServices.Services.GetRequiredService<Hosting.ApplicationDispatcher>().AppDispatcher;
+				}
 
 				if (s_dispatcher is null)
 					throw new InvalidOperationException($"Test app did not provide a dispatcher.");


### PR DESCRIPTION
### Description of Change

Alternative approach for https://github.com/dotnet/maui/pull/18492.

This approach opts for changing current behavior as little as possible for NET8. Instead of changing the behavior of `IMauiInitializeScopedService` this just stops using it. AFAICT it's not really providing any current value for us. We can just use `IMauiInitializeService` to achieve the same workaround for WinUI.


The main behavior change here is how to handle the first call to `IDispatcher` from the service provider scoped to the window.

### Behavior Change
Currently in MAUI if you try to retrieve the `Dispatcher` from the scoped service provider on a background thread it just returns null, but this captures the dispatcher when the window scope is created. Which is probably a better experience.

https://github.com/dotnet/maui/pull/19593/files#diff-500f3422fdff10304272c2e7985ec98941543f788bef70ac1fb1b23776bb1104R49-R55


Added issue [here](https://github.com/dotnet/maui/issues/19591) to evaluate the correctness of `IMauiInitializeScopedService` because this interface currently only initializes once at the application level, it doesn't actually initialize for each scoped service we create. 



### Issues Fixed

Fixes #11457


