### PR TITLE
Resizetizer Regex Fix

### DIFF
--- a/src/SingleProject/Resizetizer/src/Utils.cs
+++ b/src/SingleProject/Resizetizer/src/Utils.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Maui.Resizetizer
 	internal class Utils
 	{
 		static readonly Regex rxResourceFilenameValidation
-			= new Regex(@"^[a-z]+[a-z0-9_]{0,}[^_]$", RegexOptions.Singleline | RegexOptions.Compiled);
+			= new Regex(@"^[a-z]([a-z0-9_]*[a-z0-9])?$", RegexOptions.Singleline | RegexOptions.Compiled);
 
 		public static bool IsValidResourceFilename(string filename)
 			=> rxResourceFilenameValidation.IsMatch(Path.GetFileNameWithoutExtension(filename));

--- a/src/SingleProject/Resizetizer/test/UnitTests/FilenameTests.cs
+++ b/src/SingleProject/Resizetizer/test/UnitTests/FilenameTests.cs
@@ -36,6 +36,7 @@ namespace Microsoft.Maui.Resizetizer.Tests
 		[InlineData("t_w_o2.png")]
 		[InlineData("t_3_hree.png")]
 		[InlineData("f4_our5.png")]
+		[InlineData("a.png")]
 		public void ValidFilenames(string filename)
 			=> Assert.True(IsValidFilename(filename));
 
@@ -65,6 +66,8 @@ namespace Microsoft.Maui.Resizetizer.Tests
 		[InlineData("f4our 5.png")]
 		[InlineData("_1one.png")]
 		[InlineData("o1_.png")]
+		[InlineData("o=.png")]
+		[InlineData("1a.png")]
 		public void InvalidFilenames(string filename)
 			=> Assert.False(IsValidFilename(filename));
 


### PR DESCRIPTION
#19574 
Fixed Resizetizer Regex not allowing single letter characters. "a"
I also fixed another part of the regex where a the following input was allowed when it shouldnt have. "a="

The regex is based off the error given by regex. Requirements are:
1. First char should be a lowercase letter between a-z
2. The rest can be a lowercase letter or a number 0-9 or an underscore.
3. Lastly, the last character is NOT an underscore.


### Description of Change
Changed the regex from
`^[a-z]+[a-z0-9_]{0,}[^_]$`
to
`^[a-z]([a-z0-9_]*[a-z0-9])?$`

### Issues Fixed
Fixes #19574 
