### PR TITLE
Generalize HideSoftInputOnTapped on Android and iOS to support 3rd party input controls

### DIFF
--- a/src/Controls/src/Core/ContentPage/HideSoftInputOnTappedChanged/HideSoftInputOnTappedChangedManager.Android.cs
+++ b/src/Controls/src/Core/ContentPage/HideSoftInputOnTappedChanged/HideSoftInputOnTappedChangedManager.Android.cs
@@ -3,6 +3,7 @@ using Android.Views;
 using Android.Widget;
 using Microsoft.Maui.Graphics;
 using AView = Android.Views.View;
+using AViewGroup = Android.Views.ViewGroup;
 
 namespace Microsoft.Maui.Controls
 {
@@ -43,20 +44,11 @@ namespace Microsoft.Maui.Controls
 		// This is called from InputViews as they are added to the visual tree
 		IDisposable? SetupHideSoftInputOnTapped(AView aView)
 		{
-			if (aView is SearchView sv &&
-				sv.GetFirstChildOfType<EditText>() is EditText editText)
+			if (aView is AViewGroup vg &&
+				vg.GetFirstChildOfType<EditText>() is {} editText)
 			{
 				aView = editText;
 			}
-
-			if (aView is AndroidX.AppCompat.Widget.SearchView svX &&
-				svX.GetFirstChildOfType<EditText>() is EditText editTextX)
-			{
-				aView = editTextX;
-			}
-
-			if (aView is null)
-				return null;
 
 			if (!FeatureEnabled)
 				return null;

--- a/src/Controls/src/Core/ContentPage/HideSoftInputOnTappedChanged/HideSoftInputOnTappedChangedManager.iOS.cs
+++ b/src/Controls/src/Core/ContentPage/HideSoftInputOnTappedChanged/HideSoftInputOnTappedChangedManager.iOS.cs
@@ -7,22 +7,18 @@ namespace Microsoft.Maui.Controls
 {
 	partial class HideSoftInputOnTappedChangedManager
 	{
-		internal IDisposable? SetupHideSoftInputOnTapped(UIView uIView)
+		internal IDisposable? SetupHideSoftInputOnTapped(UIView uiView)
 		{
-			if (!FeatureEnabled || uIView.Window is null)
+			if (!FeatureEnabled || uiView.Window is null)
 				return null;
 
-			if (uIView is UISearchBar searchBar &&
-				searchBar.GetSearchTextField() is UIView textField)
-			{
-				uIView = textField;
-			}
+			var firstResponder = uiView.FindFirstResponder(v => v is UITextField or UITextView);
 
-			if (uIView is null)
+			if (firstResponder is null)
 				return null;
 
 			return ResignFirstResponderTouchGestureRecognizer
-					.Update(uIView);
+					.Update(firstResponder);
 		}
 	}
 }

--- a/src/Controls/src/Core/ContentPage/HideSoftInputOnTappedChanged/HideSoftInputOnTappedChangedManager.iOS.cs
+++ b/src/Controls/src/Core/ContentPage/HideSoftInputOnTappedChanged/HideSoftInputOnTappedChangedManager.iOS.cs
@@ -10,12 +10,16 @@ namespace Microsoft.Maui.Controls
 		internal IDisposable? SetupHideSoftInputOnTapped(UIView uiView)
 		{
 			if (!FeatureEnabled || uiView.Window is null)
+			{
 				return null;
+			}
 
-			var firstResponder = uiView.FindFirstResponder(v => v is UITextField or UITextView);
+			var firstResponder = uiView.FindFirstResponder();
 
-			if (firstResponder is null)
+			if (firstResponder is not (UITextField or UITextView))
+			{
 				return null;
+			}
 
 			return ResignFirstResponderTouchGestureRecognizer
 					.Update(firstResponder);

--- a/src/Controls/src/Core/ContentPage/HideSoftInputOnTappedChanged/HideSoftInputOnTappedChangedManager.iOS.cs
+++ b/src/Controls/src/Core/ContentPage/HideSoftInputOnTappedChanged/HideSoftInputOnTappedChangedManager.iOS.cs
@@ -14,15 +14,20 @@ namespace Microsoft.Maui.Controls
 				return null;
 			}
 
-			var firstResponder = uiView.FindFirstResponder();
+			UIView? uiText = uiView;
 
-			if (firstResponder is not (UITextField or UITextView))
+			if (uiText is not (UITextField or UITextView))
+			{
+				uiText = uiView.FindDescendantView<UIView>((view) => view is (UITextField or UITextView));
+			}
+
+			if (uiText is null)
 			{
 				return null;
 			}
 
 			return ResignFirstResponderTouchGestureRecognizer
-					.Update(firstResponder);
+					.Update(uiText);
 		}
 	}
 }

--- a/src/Core/src/Platform/iOS/ViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/ViewExtensions.cs
@@ -889,12 +889,12 @@ namespace Microsoft.Maui.Platform
 			return null;
 		}
 
-		internal static UIView? FindFirstResponder(this UIView? superview)
+		internal static UIView? FindFirstResponder(this UIView? superview, Func<UIView, bool>? predicate = null)
 		{
 			if (superview is null)
 				return null;
 
-			if (superview.IsFirstResponder)
+			if (superview.IsFirstResponder && (predicate?.Invoke(superview) ?? true))
 				return superview;
 
 			foreach (var subview in superview.Subviews)

--- a/src/Core/src/Platform/iOS/ViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/ViewExtensions.cs
@@ -889,12 +889,12 @@ namespace Microsoft.Maui.Platform
 			return null;
 		}
 
-		internal static UIView? FindFirstResponder(this UIView? superview, Func<UIView, bool>? predicate = null)
+		internal static UIView? FindFirstResponder(this UIView? superview)
 		{
 			if (superview is null)
 				return null;
 
-			if (superview.IsFirstResponder && (predicate?.Invoke(superview) ?? true))
+			if (superview.IsFirstResponder)
 				return superview;
 
 			foreach (var subview in superview.Subviews)


### PR DESCRIPTION
### Description of Change

Generalize recognition of text inputs in `HideSoftInputOnTappedChangedManager` so that 3rd party libraries with native handlers can leverage this new feature of `ContentPage` by simply adding a mapper the same way `InputView` does.

```cs
internal static void MapIsFocused(IViewHandler handler, IView view)
{
	handler
		?.GetService<HideSoftInputOnTappedChangedManager>()
		?.UpdateFocusForView(iv);
}
```

Unfortunately `HideSoftInputOnTappedChangedManager` is internal, but they can still use it via reflection.

I know it's suboptimal but I didn't want to change public API.

See more at: https://supportcenter.devexpress.com/ticket/details/t1201718/the-keyboard-remains-visible-on-a-click-outside-editors-even-if-the-contentpage