### PR TITLE
Fix Action Sheets for macOS

### DIFF
--- a/src/Controls/src/Core/Page/Page.cs
+++ b/src/Controls/src/Core/Page/Page.cs
@@ -282,7 +282,7 @@ namespace Microsoft.Maui.Controls
 		/// Displays a platform action sheet, allowing the application user to choose from several buttons.
 		/// </summary>
 		/// <param name="title">Title of the displayed action sheet. Can be <see langword="null"/> to hide the title.</param>
-		/// <param name="cancel">Text to be displayed in the 'Cancel' button. Can be null to hide the <see langword="null"/> action.</param>
+		/// <param name="cancel">Text to be displayed in the 'Cancel' button. Can be null to hide the cancel action.</param>
 		/// <param name="destruction">Text to be displayed in the 'Destruct' button. Can be <see langword="null"/> to hide the destructive option.</param>
 		/// <param name="flowDirection">The flow direction to be used by the action sheet.</param>
 		/// <param name="buttons">Text labels for additional buttons.</param>

--- a/src/Controls/src/Core/Platform/AlertManager/AlertManager.iOS.cs
+++ b/src/Controls/src/Core/Platform/AlertManager/AlertManager.iOS.cs
@@ -187,12 +187,15 @@ namespace Microsoft.Maui.Controls.Platform
 					presentingWindow = senderPageWindow;
 				}
 
-				if (UIDevice.CurrentDevice.UserInterfaceIdiom == UIUserInterfaceIdiom.Pad && arguments != null)
+				if (UIDevice.CurrentDevice.UserInterfaceIdiom == UIUserInterfaceIdiom.Pad &&
+					arguments is not null &&
+					alert.PopoverPresentationController is not null &&
+					platformView.RootViewController?.View is not null)
 				{
 					var topViewController = GetTopUIViewController(presentingWindow);
 					UIDevice.CurrentDevice.BeginGeneratingDeviceOrientationNotifications();
 					var observer = NSNotificationCenter.DefaultCenter.AddObserver(UIDevice.OrientationDidChangeNotification,
-						n => { alert.PopoverPresentationController.SourceRect = topViewController.View.Bounds; });
+						n => alert.PopoverPresentationController.SourceRect = topViewController.View.Bounds);
 
 					arguments.Result.Task.ContinueWith(t =>
 					{
@@ -216,7 +219,7 @@ namespace Microsoft.Maui.Controls.Platform
 			static UIViewController GetTopUIViewController(UIWindow platformWindow)
 			{
 				var topUIViewController = platformWindow.RootViewController;
-				while (topUIViewController.PresentedViewController is not null)
+				while (topUIViewController?.PresentedViewController is not null)
 				{
 					topUIViewController = topUIViewController.PresentedViewController;
 				}

--- a/src/Controls/tests/CustomAttributes/Test.cs
+++ b/src/Controls/tests/CustomAttributes/Test.cs
@@ -743,6 +743,16 @@ public static class Test
 		CascadeTransLayoutOverlayWithButton,
 	}
 
+	public enum Alerts
+	{
+		AlertCancel,
+		AlertAcceptCancelClickAccept,
+		AlertAcceptCancelClickCancel,
+		ActionSheetClickItem,
+		ActionSheetClickCancel,
+		ActionSheetClickDestroy,
+	}
+
 	public static class InputTransparencyMatrix
 	{
 		// this is both for color diff and cols

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Concepts/AlertsGalleryTests.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Concepts/AlertsGalleryTests.cs
@@ -1,0 +1,149 @@
+﻿using NUnit.Framework;
+using NUnit.Framework.Legacy;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests
+{
+	public class AlertsGalleryTests : CoreGalleryBasePageTest
+	{
+		public AlertsGalleryTests(TestDevice device)
+			: base(device)
+		{
+		}
+
+		protected override void NavigateToGallery()
+		{
+			App.NavigateToGallery("Alerts Gallery");
+		}
+
+// TODO: UI testing alert code is not yet implemented on Windows.
+#if !WINDOWS
+		[Test]
+		public void AlertCancel()
+		{
+			var test = Test.Alerts.AlertCancel;
+
+			var remote = new EventViewContainerRemote(UITestContext, test);
+			remote.GoTo(test.ToString());
+
+			var textBeforeClick = remote.GetEventLabel().GetText();
+			ClassicAssert.AreEqual($"Event: {test} (none)", textBeforeClick);
+
+			remote.TapView();
+
+			var alert = App.WaitForElement(() => App.GetAlert());
+			ClassicAssert.NotNull(alert);
+
+			var alertText = alert.GetAlertText();
+			CollectionAssert.Contains(alertText, "Alert Title Here");
+			CollectionAssert.Contains(alertText, "Alert Message Here");
+
+			var buttons = alert.GetAlertButtons();
+			CollectionAssert.IsNotEmpty(buttons);
+			ClassicAssert.True(buttons.Count == 1, $"Expected 1 buttonText, found {buttons.Count}.");
+
+			var cancel = buttons.First();
+			ClassicAssert.AreEqual("CANCEL", cancel.GetText());
+
+			cancel.Click();
+
+			App.WaitForNoElement(() => App.GetAlert());
+
+			var textAfterClick = remote.GetEventLabel().GetText();
+			ClassicAssert.AreEqual($"Event: {test} (SUCCESS 1)", textAfterClick);
+		}
+
+		[Test]
+		[TestCase(Test.Alerts.AlertAcceptCancelClickAccept, "ACCEPT")]
+		[TestCase(Test.Alerts.AlertAcceptCancelClickCancel, "CANCEL")]
+		public void AlertAcceptCancel(Test.Alerts test, string buttonText)
+		{
+			var remote = new EventViewContainerRemote(UITestContext, test);
+			remote.GoTo(test.ToString());
+
+			var textBeforeClick = remote.GetEventLabel().GetText();
+			ClassicAssert.AreEqual($"Event: {test} (none)", textBeforeClick);
+
+			remote.TapView();
+
+			var alert = App.WaitForElement(() => App.GetAlert());
+			ClassicAssert.NotNull(alert);
+
+			var alertText = alert.GetAlertText();
+			CollectionAssert.Contains(alertText, "Alert Title Here");
+			CollectionAssert.Contains(alertText, "Alert Message Here");
+
+			var buttons = alert.GetAlertButtons()
+				.Select(b => (Element: b, Text: b.GetText()))
+				.ToList();
+			CollectionAssert.IsNotEmpty(buttons);
+			ClassicAssert.True(buttons.Count == 2, $"Expected 2 buttons, found {buttons.Count}.");
+			CollectionAssert.Contains(buttons.Select(b => b.Text), "ACCEPT");
+			CollectionAssert.Contains(buttons.Select(b => b.Text), "CANCEL");
+
+			var button = buttons.Single(b => b.Text == buttonText);
+			button.Element.Click();
+
+			App.WaitForNoElement(() => App.GetAlert());
+
+			var textAfterClick = remote.GetEventLabel().GetText();
+			ClassicAssert.AreEqual($"Event: {test} (SUCCESS 1)", textAfterClick);
+		}
+
+		[Test]
+		[TestCase(Test.Alerts.ActionSheetClickItem, "ITEM 2")]
+		[TestCase(Test.Alerts.ActionSheetClickCancel, "CANCEL")]
+		[TestCase(Test.Alerts.ActionSheetClickDestroy, "DESTROY")]
+		public void ActionSheetClickItem(Test.Alerts test, string itemText)
+		{
+			var remote = new EventViewContainerRemote(UITestContext, test);
+			remote.GoTo(test.ToString());
+
+			var textBeforeClick = remote.GetEventLabel().GetText();
+			ClassicAssert.AreEqual($"Event: {test} (none)", textBeforeClick);
+
+			remote.TapView();
+
+			var alert = App.WaitForElement(() => App.GetAlert());
+			ClassicAssert.NotNull(alert);
+
+			var alertText = alert.GetAlertText();
+			CollectionAssert.Contains(alertText, "Action Sheet Title Here");
+
+			var buttons = alert.GetAlertButtons()
+				.Select(b => (Element: b, Text: b.GetText()))
+				.ToList();
+			CollectionAssert.IsNotEmpty(buttons);
+			ClassicAssert.True(buttons.Count >= 4 && buttons.Count <= 5, $"Expected 4 or 5 buttons, found {buttons.Count}.");
+			CollectionAssert.Contains(buttons.Select(b => b.Text), "DESTROY");
+			CollectionAssert.Contains(buttons.Select(b => b.Text), "ITEM 1");
+			CollectionAssert.Contains(buttons.Select(b => b.Text), "ITEM 2");
+			CollectionAssert.Contains(buttons.Select(b => b.Text), "ITEM 3");
+
+			// handle the case where the dismiss button is an actual button
+			if (buttons.Count == 5)
+				CollectionAssert.Contains(buttons.Select(b => b.Text), "CANCEL");
+
+			if (buttons.Count == 4 && itemText == "CANCEL")
+			{
+				// handle the case where the dismiss button is a "click outside the popup"
+
+				alert.DismissAlert();
+			}
+			else
+			{
+				// handle the case where the dismiss button is an actual button
+
+				var button = buttons.Single(b => b.Text == itemText);
+				button.Element.Click();
+			}
+
+			App.WaitForNoElement(() => App.GetAlert());
+
+			var textAfterClick = remote.GetEventLabel().GetText();
+			ClassicAssert.AreEqual($"Event: {test} (SUCCESS 1)", textAfterClick);
+		}
+#endif
+	}
+}

--- a/src/Controls/tests/TestCases/Concepts/AlertsGalleryPage.cs
+++ b/src/Controls/tests/TestCases/Concepts/AlertsGalleryPage.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+
+namespace Maui.Controls.Sample
+{
+	internal class AlertsGalleryPage : CoreGalleryBasePage
+	{
+		protected override void Build()
+		{
+			// ALERTS
+
+			// Test with a single button alert that can be dismissed by tapping the button
+			Add(Test.Alerts.AlertCancel, async t =>
+			{
+				await DisplayAlert(
+					"Alert Title Here",
+					"Alert Message Here",
+					"CANCEL");
+				t.ReportSuccessEvent();
+			});
+
+			// Test alert with options to Accept or Cancel, Accept is the correct option
+			Add(Test.Alerts.AlertAcceptCancelClickAccept, async t =>
+			{
+				var result = await DisplayAlert(
+					"Alert Title Here",
+					"Alert Message Here",
+					"ACCEPT", "CANCEL");
+				if (result)
+					t.ReportSuccessEvent();
+				else
+					t.ReportFailEvent();
+			});
+
+			// Test alert with options to Accept or Cancel, Cancel is the correct option
+			Add(Test.Alerts.AlertAcceptCancelClickCancel, async t =>
+			{
+				var result = await DisplayAlert(
+					"Alert Title Here",
+					"Alert Message Here",
+					"ACCEPT", "CANCEL");
+				if (result)
+					t.ReportFailEvent();
+				else
+					t.ReportSuccessEvent();
+			});
+
+			// ACTION SHEETS
+
+			// Test action sheet with items and Cancel, Item 2 is the correct option
+			Add(Test.Alerts.ActionSheetClickItem, async t =>
+			{
+				var result = await DisplayActionSheet(
+					"Action Sheet Title Here",
+					"CANCEL", "DESTROY",
+					"ITEM 1", "ITEM 2", "ITEM 3");
+				if (result == "ITEM 2")
+					t.ReportSuccessEvent();
+				else
+					t.ReportFailEvent();
+			});
+
+			// Test action sheet with items and Cancel, Cancel is the correct option
+			Add(Test.Alerts.ActionSheetClickCancel, async t =>
+			{
+				var result = await DisplayActionSheet(
+					"Action Sheet Title Here",
+					"CANCEL", "DESTROY",
+					"ITEM 1", "ITEM 2", "ITEM 3");
+				if (result == "CANCEL")
+					t.ReportSuccessEvent();
+				else
+					t.ReportFailEvent();
+			});
+
+			// Test action sheet with items and Cancel, Destroy is the correct option
+			Add(Test.Alerts.ActionSheetClickDestroy, async t =>
+			{
+				var result = await DisplayActionSheet(
+					"Action Sheet Title Here",
+					"CANCEL", "DESTROY",
+					"ITEM 1", "ITEM 2", "ITEM 3");
+				if (result == "DESTROY")
+					t.ReportSuccessEvent();
+				else
+					t.ReportFailEvent();
+			});
+		}
+
+		ExpectedEventViewContainer<Button>
+			Add(Test.Alerts test, Func<ExpectedEventViewContainer<Button>, Task> action) =>
+			Add(new ExpectedEventViewContainer<Button>(test, new Button { Text = "Click Me!" }))
+				.With(t => t.View.Clicked += (_, _) => action(t));
+	}
+}

--- a/src/Controls/tests/TestCases/CoreViews/CorePageView.cs
+++ b/src/Controls/tests/TestCases/CoreViews/CorePageView.cs
@@ -51,6 +51,7 @@ namespace Maui.Controls.Sample
 			new GalleryPageFactory(() => new GestureRecognizerGallery(), "Gesture Recognizer Gallery"),
 			new GalleryPageFactory(() => new InputTransparencyGalleryPage(), "Input Transparency Gallery"),
 			new GalleryPageFactory(() => new ImageLoadingGalleryPage(), "Image Loading Gallery"),
+			new GalleryPageFactory(() => new AlertsGalleryPage(), "Alerts Gallery"),
 			// Elements
 			new GalleryPageFactory(() => new ActivityIndicatorCoreGalleryPage(), "ActivityIndicator Gallery"),
 			new GalleryPageFactory(() => new BoxViewCoreGalleryPage(), "Box Gallery"),

--- a/src/TestUtils/src/UITest.Appium/Actions/AppiumAndroidAlertActions.cs
+++ b/src/TestUtils/src/UITest.Appium/Actions/AppiumAndroidAlertActions.cs
@@ -1,0 +1,92 @@
+﻿using OpenQA.Selenium.Appium;
+using UITest.Core;
+
+namespace UITest.Appium;
+
+public class AppiumAndroidAlertActions : ICommandExecutionGroup
+{
+	const string GetAlertsCommand = "getAlerts";
+	const string GetAlertButtonsCommand = "getAlertButtons";
+	const string GetAlertTextCommand = "getAlertText";
+
+	readonly List<string> _commands = new()
+	{
+		GetAlertsCommand,
+		GetAlertButtonsCommand,
+		GetAlertTextCommand,
+	};
+	readonly AppiumApp _appiumApp;
+
+	public AppiumAndroidAlertActions(AppiumApp appiumApp)
+	{
+		_appiumApp = appiumApp;
+	}
+
+	public bool IsCommandSupported(string commandName)
+	{
+		return _commands.Contains(commandName, StringComparer.OrdinalIgnoreCase);
+	}
+
+	public CommandResponse Execute(string commandName, IDictionary<string, object> parameters)
+	{
+		return commandName switch
+		{
+			GetAlertsCommand => GetAlerts(parameters),
+			GetAlertButtonsCommand => GetAlertButtons(parameters),
+			GetAlertTextCommand => GetAlertText(parameters),
+			_ => CommandResponse.FailedEmptyResponse,
+		};
+	}
+
+	CommandResponse GetAlerts(IDictionary<string, object> parameters)
+	{
+		var alerts = _appiumApp.Query.ById("parentPanel");
+
+		if (alerts is null || alerts.Count == 0)
+			return CommandResponse.FailedEmptyResponse;
+
+		return new CommandResponse(alerts, CommandResponseResult.Success);
+	}
+
+	CommandResponse GetAlertButtons(IDictionary<string, object> parameters)
+	{
+		var alert = GetAppiumElement(parameters["element"]);
+		if (alert is null)
+			return CommandResponse.FailedEmptyResponse;
+
+		var items = AppiumQuery.ByClass("android.widget.ListView")
+			.FindElements(alert, _appiumApp)
+			.FirstOrDefault()
+			?.ByClass("android.widget.TextView");
+
+		var buttons = AppiumQuery.ByClass("android.widget.Button")
+			.FindElements(alert, _appiumApp);
+
+		var all = new List<IUIElement>();
+		if (items is not null)
+			all.AddRange(items);
+		all.AddRange(buttons);
+
+		return new CommandResponse(all, CommandResponseResult.Success);
+	}
+
+	CommandResponse GetAlertText(IDictionary<string, object> parameters)
+	{
+		var alert = GetAppiumElement(parameters["element"]);
+		if (alert is null)
+			return CommandResponse.FailedEmptyResponse;
+
+		var text = AppiumQuery.ByClass("android.widget.TextView").FindElements(alert, _appiumApp);
+		var strings = text.Select(t => t.GetText()).ToList();
+
+		return new CommandResponse(strings, CommandResponseResult.Success);
+	}
+
+	static AppiumElement? GetAppiumElement(object element) =>
+		element switch
+		{
+			AppiumElement appiumElement => appiumElement,
+			AppiumDriverElement driverElement => driverElement.AppiumElement,
+			_ => null
+		};
+}

--- a/src/TestUtils/src/UITest.Appium/Actions/AppiumAppleAlertActions.cs
+++ b/src/TestUtils/src/UITest.Appium/Actions/AppiumAppleAlertActions.cs
@@ -1,0 +1,80 @@
+﻿using OpenQA.Selenium.Appium;
+using UITest.Core;
+
+namespace UITest.Appium;
+
+public abstract class AppiumAppleAlertActions : ICommandExecutionGroup
+{
+	const string GetAlertsCommand = "getAlerts";
+	const string GetAlertButtonsCommand = "getAlertButtons";
+	const string GetAlertTextCommand = "getAlertText";
+
+	readonly List<string> _commands = new()
+	{
+		GetAlertsCommand,
+		GetAlertButtonsCommand,
+		GetAlertTextCommand,
+	};
+
+	protected readonly AppiumApp _appiumApp;
+
+	public AppiumAppleAlertActions(AppiumApp appiumApp)
+	{
+		_appiumApp = appiumApp;
+	}
+
+	public virtual bool IsCommandSupported(string commandName) =>
+		_commands.Contains(commandName, StringComparer.OrdinalIgnoreCase);
+
+	public virtual CommandResponse Execute(string commandName, IDictionary<string, object> parameters) =>
+		commandName switch
+		{
+			GetAlertsCommand => GetAlerts(parameters),
+			GetAlertButtonsCommand => GetAlertButtons(parameters),
+			GetAlertTextCommand => GetAlertText(parameters),
+			_ => CommandResponse.FailedEmptyResponse,
+		};
+
+	protected abstract IReadOnlyCollection<IUIElement> OnGetAlerts(AppiumApp appiumApp, IDictionary<string, object> parameters);
+
+	CommandResponse GetAlerts(IDictionary<string, object> parameters)
+	{
+		var alerts = OnGetAlerts(_appiumApp, parameters);
+		
+		if (alerts is null || alerts.Count == 0)
+			return CommandResponse.FailedEmptyResponse;
+
+		return new CommandResponse(alerts, CommandResponseResult.Success);
+	}
+
+	CommandResponse GetAlertButtons(IDictionary<string, object> parameters)
+	{
+		var alert = GetAppiumElement(parameters["element"]);
+		if (alert is null)
+			return CommandResponse.FailedEmptyResponse;
+
+		var buttons = AppiumQuery.ByClass("XCUIElementTypeButton").FindElements(alert, _appiumApp);
+
+		return new CommandResponse(buttons, CommandResponseResult.Success);
+	}
+
+	CommandResponse GetAlertText(IDictionary<string, object> parameters)
+	{
+		var alert = GetAppiumElement(parameters["element"]);
+		if (alert is null)
+			return CommandResponse.FailedEmptyResponse;
+
+		var text = AppiumQuery.ByClass("XCUIElementTypeStaticText").FindElements(alert, _appiumApp);
+		var strings = text.Select(t => t.GetText()).ToList();
+
+		return new CommandResponse(strings, CommandResponseResult.Success);
+	}
+
+	protected static AppiumElement? GetAppiumElement(object element) =>
+		element switch
+		{
+			AppiumElement appiumElement => appiumElement,
+			AppiumDriverElement driverElement => driverElement.AppiumElement,
+			_ => null
+		};
+}

--- a/src/TestUtils/src/UITest.Appium/Actions/AppiumCatalystAlertActions.cs
+++ b/src/TestUtils/src/UITest.Appium/Actions/AppiumCatalystAlertActions.cs
@@ -1,0 +1,68 @@
+﻿using UITest.Core;
+
+namespace UITest.Appium;
+
+public class AppiumCatalystAlertActions : AppiumAppleAlertActions
+{
+	// Selects the inner "popover contents" of a popover window.
+	const string PossibleActionSheetXPath = 
+		"/XCUIElementTypeApplication/XCUIElementTypeWindow/XCUIElementTypePopover";
+
+	const string DismissAlertCommand = "dismissAlert";
+
+	readonly List<string> _commands = new()
+	{
+		DismissAlertCommand,
+	};
+
+	public AppiumCatalystAlertActions(AppiumApp appiumApp)
+		: base(appiumApp)
+	{
+	}
+
+	public override bool IsCommandSupported(string commandName) =>
+		_commands.Contains(commandName, StringComparer.OrdinalIgnoreCase) || base.IsCommandSupported(commandName);
+
+	public override CommandResponse Execute(string commandName, IDictionary<string, object> parameters) =>
+		commandName switch
+		{
+			DismissAlertCommand => DismissAlert(parameters),
+			_ => base.Execute(commandName, parameters),
+		};
+
+	CommandResponse DismissAlert(IDictionary<string, object> parameters)
+	{
+		var alert = GetAppiumElement(parameters["element"]);
+		if (alert is null)
+			return CommandResponse.FailedEmptyResponse;
+
+		// XCUIElementTypePopover == 18
+		if (!"18".Equals(alert.GetAttribute("elementType"), StringComparison.OrdinalIgnoreCase))
+			return CommandResponse.FailedEmptyResponse;
+
+		var dismissRegions = AppiumQuery.ById("PopoverDismissRegion").FindElements(_appiumApp).ToList();
+		for (var i = dismissRegions.Count - 1; i >= 0; i--)
+		{
+			var region = GetAppiumElement(dismissRegions[i])!;
+			if ("true".Equals(region.GetAttribute("enabled"), StringComparison.OrdinalIgnoreCase))
+			{
+				region.Click();
+				return CommandResponse.SuccessEmptyResponse;
+			}
+		}
+
+		return CommandResponse.FailedEmptyResponse;
+	}
+
+	protected override IReadOnlyCollection<IUIElement> OnGetAlerts(AppiumApp appiumApp, IDictionary<string, object> parameters)
+	{
+		// Catalyst uses action sheets for alerts and macOS 14
+		var alerts = appiumApp.FindElements(AppiumQuery.ByClass("XCUIElementTypeSheet"));
+
+		// But it also uses popovers for action sheets on macOS 13
+		if (alerts is null || alerts.Count == 0)
+			alerts = appiumApp.FindElements(AppiumQuery.ByXPath(PossibleActionSheetXPath));
+
+		return alerts;
+	}
+}

--- a/src/TestUtils/src/UITest.Appium/Actions/AppiumIOSAlertActions.cs
+++ b/src/TestUtils/src/UITest.Appium/Actions/AppiumIOSAlertActions.cs
@@ -1,0 +1,29 @@
+﻿using UITest.Core;
+
+namespace UITest.Appium;
+
+public class AppiumIOSAlertActions : AppiumAppleAlertActions
+{
+	// Selects VISIBLE "Other" elements that are the direct child of
+	// a VISIBLE window AND are OVERLAYED on top of the first window.
+	const string PossibleAlertXPath = 
+		"//XCUIElementTypeWindow[@visible='true']/XCUIElementTypeOther[@visible='true' and @index > 0]";
+
+	public AppiumIOSAlertActions(AppiumApp appiumApp)
+		: base(appiumApp)
+	{
+	}
+
+	protected override IReadOnlyCollection<IUIElement> OnGetAlerts(AppiumApp appiumApp, IDictionary<string, object> parameters)
+	{
+		// First try the type used on iOS.
+		var alerts = appiumApp.FindElements(AppiumQuery.ByClass("XCUIElementTypeAlert"));
+
+		// It appears iOS sometimes uses the XCUIElementTypeOther class for action sheets
+		// so we need a way to do a more fuzzy check.
+		if (alerts is null || alerts.Count == 0)
+			alerts = appiumApp.FindElements(AppiumQuery.ByXPath(PossibleAlertXPath));
+
+		return alerts;
+	}
+}

--- a/src/TestUtils/src/UITest.Appium/AppiumAndroidApp.cs
+++ b/src/TestUtils/src/UITest.Appium/AppiumAndroidApp.cs
@@ -11,6 +11,7 @@ namespace UITest.Appium
 			: base(new AndroidDriver(remoteAddress, GetOptions(config)), config)
 		{
 			_commandExecutor.AddCommandGroup(new AppiumAndroidVirtualKeyboardActions(this));
+			_commandExecutor.AddCommandGroup(new AppiumAndroidAlertActions(this));
 		}
 
 		public static AppiumAndroidApp CreateAndroidApp(Uri remoteAddress, IConfig config)

--- a/src/TestUtils/src/UITest.Appium/AppiumCatalystApp.cs
+++ b/src/TestUtils/src/UITest.Appium/AppiumCatalystApp.cs
@@ -12,6 +12,7 @@ namespace UITest.Appium
 		{
 			_commandExecutor.AddCommandGroup(new AppiumCatalystMouseActions(this));
 			_commandExecutor.AddCommandGroup(new AppiumCatalystTouchActions(this));
+			_commandExecutor.AddCommandGroup(new AppiumCatalystAlertActions(this));
 		}
 
 		public override ApplicationState AppState

--- a/src/TestUtils/src/UITest.Appium/AppiumIOSApp.cs
+++ b/src/TestUtils/src/UITest.Appium/AppiumIOSApp.cs
@@ -14,6 +14,7 @@ namespace UITest.Appium
 			_commandExecutor.AddCommandGroup(new AppiumIOSMouseActions(this));
 			_commandExecutor.AddCommandGroup(new AppiumIOSTouchActions(this));
 			_commandExecutor.AddCommandGroup(new AppiumIOSVirtualKeyboardActions(this));
+			_commandExecutor.AddCommandGroup(new AppiumIOSAlertActions(this));
 		}
 
 		public override ApplicationState AppState

--- a/src/TestUtils/src/UITest.Appium/AppiumQuery.cs
+++ b/src/TestUtils/src/UITest.Appium/AppiumQuery.cs
@@ -11,11 +11,13 @@ namespace UITest.Appium
 		const string IdToken = "id";
 		const string NameToken = "name";
 		const string AccessibilityToken = "accessibilityid";
+		const string XPathToken = "xpath";
 		const string QuerySeparatorToken = "&";
 		const string IdQuery = IdToken + "={0}";
 		const string NameQuery = NameToken + "={0}";
 		const string AccessibilityQuery = AccessibilityToken + "={0}";
 		const string ClassQuery = ClassToken + "={0}";
+		const string XPathQuery = XPathToken + "={0}";
 		readonly string _queryStr;
 
 		public AppiumQuery(string queryStr)
@@ -48,6 +50,11 @@ namespace UITest.Appium
 			return new AppiumQuery(this, string.Format(NameQuery, nameQuery));
 		}
 
+		IQuery IQuery.ByXPath(string xpath)
+		{
+			return new AppiumQuery(this, string.Format(XPathQuery, Uri.EscapeDataString(xpath)));
+		}
+
 		public static AppiumQuery ById(string id)
 		{
 			return new AppiumQuery(string.Format(IdQuery, id));
@@ -66,6 +73,11 @@ namespace UITest.Appium
 		public static AppiumQuery ByClass(string classQuery)
 		{
 			return new AppiumQuery(string.Format(ClassQuery, classQuery));
+		}
+
+		public static AppiumQuery ByXPath(string xpath)
+		{
+			return new AppiumQuery(string.Format(XPathQuery, Uri.EscapeDataString(xpath)));
 		}
 
 #nullable disable
@@ -184,6 +196,7 @@ namespace UITest.Appium
 				NameToken => MobileBy.Name(value),
 				AccessibilityToken => MobileBy.AccessibilityId(value),
 				IdToken => MobileBy.Id(value),
+				XPathToken => MobileBy.XPath(Uri.UnescapeDataString(value)),
 				_ => throw new ArgumentException("Unknown query type"),
 			};
 		}

--- a/src/TestUtils/src/UITest.Core/IQuery.cs
+++ b/src/TestUtils/src/UITest.Core/IQuery.cs
@@ -6,5 +6,6 @@
 		IQuery ByName(string name);
 		IQuery ByClass(string className);
 		IQuery ByAccessibilityId(string id);
+		IQuery ByXPath(string xpath);
 	}
 }


### PR DESCRIPTION
### Description of Change

The macOS implementation of action sheets do not have/need a PopoverPresentationController. This PR makes sure to first check if this property is set, and only if there is a popover do we set the properties.

I have also added an implementation to get/process alerts/popovers/action sheets to the UI tests so we can see exactly what is visible and press bottons/select items.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #18156

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->

### Tasks

- [x] Code
- [ ] UI Tests
   - [x] iOS
   - [x] macOS
   - [x] Android
   - [ ] Windows