### PR TITLE
Add ReceiveSms permission if it's declared in manifest

### DIFF
--- a/src/Essentials/src/Permissions/Permissions.android.cs
+++ b/src/Essentials/src/Permissions/Permissions.android.cs
@@ -483,6 +483,8 @@ namespace Microsoft.Maui.ApplicationModel
 						permissions.Add((Manifest.Permission.ReceiveWapPush, true));
 					if (IsDeclaredInManifest(Manifest.Permission.ReceiveMms))
 						permissions.Add((Manifest.Permission.ReceiveMms, true));
+					if (IsDeclaredInManifest(Manifest.Permission.ReceiveSms))
+						permissions.Add((Manifest.Permission.ReceiveSms, true));
 
 					return permissions.ToArray();
 				}


### PR DESCRIPTION
### Description of Change

The PR #14203 Removed the permission for `ReceiveSms` that was added by default if you tried to use the `Sms` permission on Android, which was only partially correct.

We still want to add the `ReceiveSms` permission to the request if you have also defined it in your android manifest file, just like the other permissions optionally added.


### Issues Fixed

Fixes #19658
