### PR TITLE
Fix has color to use maui context on passed in view

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.Windows.cs
@@ -118,30 +118,25 @@ namespace Microsoft.Maui.DeviceTests
 				shell.Items.Add(shellItem);
 			});
 
-			await InvokeOnMainThreadAsync(async () =>
+			await CreateHandlerAndAddToWindow<ShellHandler>(shell, async (handler) =>
 			{
-				await CreateHandlerAndAddToWindow<ShellHandler>(shell, (handler) =>
+				var rootNavView = handler.PlatformView;
+				var shellItemView = shell.CurrentItem.Handler.PlatformView as MauiNavigationView;
+				var expectedRoot = UI.Xaml.Controls.NavigationViewPaneDisplayMode.Left;
+				var expectedShellItems = UI.Xaml.Controls.NavigationViewPaneDisplayMode.LeftMinimal;
+
+				Assert.Equal(expectedRoot, rootNavView.PaneDisplayMode);
+				Assert.NotNull(shellItemView);
+				Assert.Equal(expectedShellItems, shellItemView.PaneDisplayMode);
+
+				await AssertionExtensions.AssertEventually(() =>
 				{
-					var rootNavView = handler.PlatformView;
-					var shellItemView = shell.CurrentItem.Handler.PlatformView as MauiNavigationView;
-					var expectedRoot = UI.Xaml.Controls.NavigationViewPaneDisplayMode.Left;
-					var expectedShellItems = UI.Xaml.Controls.NavigationViewPaneDisplayMode.LeftMinimal;
-
-					Assert.Equal(expectedRoot, rootNavView.PaneDisplayMode);
-					Assert.NotNull(shellItemView);
-					Assert.Equal(expectedShellItems, shellItemView.PaneDisplayMode);
-
-					return Task.CompletedTask;
+					var platformView = shell.CurrentPage.Handler.PlatformView as FrameworkElement;
+					return platformView is not null && (platformView.ActualHeight > 0 || platformView.ActualWidth > 0);
 				});
 
-				await AssertionExtensions.Wait(() =>
-				{
-					var platformView = shell.Handler.PlatformView as FrameworkElement;
-					return platformView is not null && (platformView.Height > 0 || platformView.Width > 0);
-				});
+				await ValidateHasColor(shell, expectedColor, typeof(ShellHandler));
 			});
-
-			await ValidateHasColor(shell, expectedColor, typeof(ShellHandler));
 		}
 
 		[Fact(DisplayName = "Back Button Enabled/Disabled")]

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
@@ -1025,7 +1025,9 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.False(pageReference.IsAlive, "Page should not be alive!");
 		}
 
-		[Fact(DisplayName = "HideSoftInputOnTapped Doesnt Crash If Entry Is Still Focused After Window Is Null")]
+		//HideSoftInputOnTapped doesn't currently do anything on windows
+#if !WINDOWS
+		[Fact(DisplayName = "HideSoftInputOnTapped Doesn't Crash If Entry Is Still Focused After Window Is Null")]
 		public async Task HideSoftInputOnTappedDoesntCrashIfEntryIsStillFocusedAfterWindowIsNull()
 		{
 			SetupBuilder();
@@ -1067,6 +1069,7 @@ namespace Microsoft.Maui.DeviceTests
 				};
 			}
 		}
+#endif
 
 		[Fact(DisplayName = "Can Reuse Pages")]
 		public async Task CanReusePages()

--- a/src/Core/tests/DeviceTests.Shared/HandlerTests/HandlerTestBasement.cs
+++ b/src/Core/tests/DeviceTests.Shared/HandlerTests/HandlerTestBasement.cs
@@ -166,22 +166,32 @@ namespace Microsoft.Maui.DeviceTests
 			return handler;
 		}
 
-		protected IPlatformViewHandler CreateHandler(IElement view, Type handlerType)
+		protected IPlatformViewHandler CreateHandler(IElement view, Type handlerType) =>
+			CreateHandler(view, handlerType, MauiContext);
+
+		protected IPlatformViewHandler CreateHandler(IElement view, Type handlerType, IMauiContext mauiContext)
 		{
 			if (view.Handler is IPlatformViewHandler t)
 				return t;
 
 			var handler = (IPlatformViewHandler)Activator.CreateInstance(handlerType);
-			InitializeViewHandler(view, handler, MauiContext);
+			InitializeViewHandler(view, handler, mauiContext);
 			return handler;
 
 		}
 
-		protected Task ValidateHasColor(IView view, Color color, Type handlerType, Action action = null, string updatePropertyValue = null, double? tolerance = null)
+		protected Task ValidateHasColor(
+			IView view, 
+			Color color, 
+			Type handlerType, 
+			Action action = null, 
+			string updatePropertyValue = null,
+			double? tolerance = null)
 		{
 			return InvokeOnMainThreadAsync(async () =>
 			{
-				var handler = CreateHandler(view, handlerType);
+				var mauiContext = view?.Handler?.MauiContext ?? MauiContext;
+				var handler = CreateHandler(view, handlerType, mauiContext);
 				var plaformView = handler.ToPlatform();
 				action?.Invoke();
 				if (!string.IsNullOrEmpty(updatePropertyValue))
@@ -189,7 +199,7 @@ namespace Microsoft.Maui.DeviceTests
 					handler.UpdateValue(updatePropertyValue);
 				}
 
-				await plaformView.AssertContainsColor(color, MauiContext, tolerance: tolerance);
+				await plaformView.AssertContainsColor(color, mauiContext, tolerance: tolerance);
 			});
 		}
 

--- a/src/TestUtils/src/DeviceTests/AssertionExtensions.Windows.cs
+++ b/src/TestUtils/src/DeviceTests/AssertionExtensions.Windows.cs
@@ -171,6 +171,9 @@ namespace Microsoft.Maui.DeviceTests
 				// Window is not a XAML type so is never on the hierarchy
 				var window = (Window)mauiContext!.Services!.GetService(typeof(Window))!;
 
+				Assert.True(window?.Content is not null, 
+					"Content on Window has not been set. Most likely the window under test isn't being registered against the test service being used. Check if you're passing the right MauiContext in");
+
 				if (window.Content.XamlRoot != view.XamlRoot)
 					throw new Exception("The window retrieved from the service is different than the window this view is attached to");
 


### PR DESCRIPTION
### Description of Change

On windows the has color check needs to attach the view under test to the visual tree in order to validate the color. If the view has already been attached to the window then AttachAndRun needs to be smart enough to use the already opened window. This PR make sure that the HasColor check will use the correct MauiContext for the passed in view so it can retrieve the already open window.

