### PR TITLE
[xamlg] improve error for Xamarin.Forms namespace

### DIFF
--- a/src/Controls/src/SourceGen/CodeBehindGenerator.cs
+++ b/src/Controls/src/SourceGen/CodeBehindGenerator.cs
@@ -263,11 +263,13 @@ namespace Microsoft.Maui.Controls.SourceGen
 				return false;
 			}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			if (xmlDoc.DocumentElement.NamespaceURI == XamlParser.FormsUri)
 			{
 				exception = new Exception($"{XamlParser.FormsUri} is not a valid namespace. Use {XamlParser.MauiUri} instead");
 				return false;
 			}
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/Controls/src/SourceGen/CodeBehindGenerator.cs
+++ b/src/Controls/src/SourceGen/CodeBehindGenerator.cs
@@ -152,7 +152,10 @@ namespace Microsoft.Maui.Controls.SourceGen
 			if (!TryParseXaml(text, uid, compilation, caches, context.CancellationToken, projItem.TargetFramework, out var accessModifier, out var rootType, out var rootClrNamespace, out var generateDefaultCtor, out var addXamlCompilationAttribute, out var hideFromIntellisense, out var XamlResourceIdOnly, out var baseType, out var namedFields, out var parseException))
 			{
 				if (parseException != null)
-					context.ReportDiagnostic(Diagnostic.Create(Descriptors.XamlParserError, null, parseException.Message));
+				{
+					var location = projItem.RelativePath is not null ? Location.Create(projItem.RelativePath, new TextSpan(), new LinePositionSpan()) : null;
+					context.ReportDiagnostic(Diagnostic.Create(Descriptors.XamlParserError, location, parseException.Message));
+				}
 				return;
 			}
 			var sb = new StringBuilder();
@@ -257,6 +260,12 @@ namespace Microsoft.Maui.Controls.SourceGen
 			catch (XmlException xe)
 			{
 				exception = xe;
+				return false;
+			}
+
+			if (xmlDoc.DocumentElement.NamespaceURI == XamlParser.FormsUri)
+			{
+				exception = new Exception($"{XamlParser.FormsUri} is not a valid namespace. Use {XamlParser.MauiUri} instead");
 				return false;
 			}
 

--- a/src/Controls/src/Xaml/XamlParser.Namespaces.cs
+++ b/src/Controls/src/Xaml/XamlParser.Namespaces.cs
@@ -3,6 +3,7 @@ namespace Microsoft.Maui.Controls.Xaml
 {
 	static partial class XamlParser
 	{
+		public const string FormsUri = "http://xamarin.com/schemas/2014/forms";
 		public const string MauiUri = "http://schemas.microsoft.com/dotnet/2021/maui";
 		public const string MauiDesignUri = "http://schemas.microsoft.com/dotnet/2021/maui/design";
 		public const string X2006Uri = "http://schemas.microsoft.com/winfx/2006/xaml";

--- a/src/Controls/src/Xaml/XamlParser.Namespaces.cs
+++ b/src/Controls/src/Xaml/XamlParser.Namespaces.cs
@@ -1,8 +1,10 @@
-﻿#nullable disable
+﻿using System;
+
 namespace Microsoft.Maui.Controls.Xaml
 {
 	static partial class XamlParser
 	{
+		[Obsolete("Should not be used except for migration/error message purposes")]
 		public const string FormsUri = "http://xamarin.com/schemas/2014/forms";
 		public const string MauiUri = "http://schemas.microsoft.com/dotnet/2021/maui";
 		public const string MauiDesignUri = "http://schemas.microsoft.com/dotnet/2021/maui/design";

--- a/src/Controls/src/Xaml/XmlTypeXamlExtensions.cs
+++ b/src/Controls/src/Xaml/XmlTypeXamlExtensions.cs
@@ -84,7 +84,8 @@ namespace Microsoft.Maui.Controls.Xaml
 					potentialTypes.Add(new(typeName, xmlnsDefinitionAttribute.ClrNamespace, xmlnsDefinitionAttribute.AssemblyName));
 
 					// As a fallback, for assembly=mscorlib try assembly=System.Private.CoreLib
-					if (xmlnsDefinitionAttribute.AssemblyName == "mscorlib" || xmlnsDefinitionAttribute.AssemblyName.StartsWith("mscorlib,", StringComparison.Ordinal))
+					if (xmlnsDefinitionAttribute.AssemblyName is string assemblyName &&
+						(assemblyName == "mscorlib" || assemblyName.StartsWith("mscorlib,", StringComparison.Ordinal)))
 					{
 						potentialTypes.Add(new(typeName, xmlnsDefinitionAttribute.ClrNamespace, "System.Private.CoreLib"));
 					}


### PR DESCRIPTION
Fixes #18637

Using the old namespace `http://xamarin.com/schemas/2014/forms` was causing a NRE:

    System.NullReferenceException: Object reference not set to an instance of an object.
    at Microsoft.Maui.Controls.Xaml.XmlTypeXamlExtensions.GetTypeReference[T](XmlType xmlType, IEnumerable`1 xmlnsDefinitions, String defaultAssemblyName, Func`2 refFromTypeInfo)
    at Microsoft.Maui.Controls.SourceGen.CodeBehindGenerator.GetTypeNameFromCustomNamespace(XmlType xmlType, Compilation compilation, AssemblyCaches caches)
    at Microsoft.Maui.Controls.SourceGen.CodeBehindGenerator.GetTypeName(XmlType xmlType, Compilation compilation, AssemblyCaches caches)
    at Microsoft.Maui.Controls.SourceGen.CodeBehindGenerator.TryParseXaml(SourceText text, String uid, Compilation compilation, AssemblyCaches caches, CancellationToken cancellationToken, String targetFramework, String& accessModifier, String& rootType, String& rootClrNamespace, Boolean& generateDefaultCtor, Boolean& addXamlCompilationAttribute, Boolean& hideFromIntellisense, Boolean& xamlResourceIdOnly, String& baseType, IEnumerable`1& namedFields, Exception& exception)
    at Microsoft.Maui.Controls.SourceGen.CodeBehindGenerator.GenerateXamlCodeBehind(ProjectItem projItem, Compilation compilation, SourceProductionContext context, AssemblyCaches caches)
    at Microsoft.Maui.Controls.SourceGen.CodeBehindGenerator.<>c.<Initialize>b__1_1(SourceProductionContext sourceProductionContext, ValueTuple`3 provider)
    at Microsoft.CodeAnalysis.UserFunctionExtensions.<>c__DisplayClass3_0`2.<WrapUserAction>b__0(TInput1 input1, TInput2 input2, CancellationToken token)

In f939049f, I inadvertently introduced this NRE, but even after fixing it, I would instead get:

    FormsNamespace.xaml.sg.cs(15,48): error CS1001: Identifier expected

Due to the namespace, type, and base type all being `null` in this case, the generated C# is invalid.

Instead of generating C# *at all*, let's emit an error message that says to use the correct namespace.

I also provided a `Location` for the error message, so we will now know what file the error originated from.

I attempted to write some test here, but adding an invalid file like this causes the XAML unit tests project to fail to build. It feels like we actually need to create a unit test project for the source generator -- as there isn't one now.
