### PR TITLE
[Windows] Fix verification of test count in CI

### DIFF
--- a/eng/devices/windows.cake
+++ b/eng/devices/windows.cake
@@ -327,7 +327,7 @@ Task("Test")
 			Information($"Test category to run: {cat}");
 		}
 
-		var expectedCategoriesRanCount = System.IO.File.ReadAllLines(testsToRunFile).Length-1;
+		var expectedCategoriesRanCount = System.IO.File.ReadAllLines(testsToRunFile).Length;
 		var actualResultFileCount = System.IO.Directory.GetFiles(testResultsPath, "TestResults-*.xml").Length;
 
 		Information($"ExpectedCategoriesRanCount: {expectedCategoriesRanCount}");

--- a/eng/devices/windows.cake
+++ b/eng/devices/windows.cake
@@ -326,9 +326,6 @@ Task("Test")
 		var expectedCategoriesRanCount = expectedCategories.Length;
 		var actualResultFileCount = System.IO.Directory.GetFiles(testResultsPath, "TestResults-*.xml").Length;
 
-		Information($"ExpectedCategoriesRanCount: {expectedCategoriesRanCount}");
-		Information($"ActualResultFileCount: {actualResultFileCount}");
-
 		while (actualResultFileCount < expectedCategoriesRanCount) {
 			actualResultFileCount = System.IO.Directory.GetFiles(testResultsPath, "TestResults-*.xml").Length;
 			System.Threading.Thread.Sleep(1000);

--- a/eng/devices/windows.cake
+++ b/eng/devices/windows.cake
@@ -322,8 +322,16 @@ Task("Test")
 	// and if the categories we expected to run match the test result files
 	if (isControlsProjectTestRun)
 	{
+		foreach(var cat in System.IO.File.ReadAllLines(testsToRunFile))
+		{
+			Information($"Test category to run: {cat}");
+		}
+
 		var expectedCategoriesRanCount = System.IO.File.ReadAllLines(testsToRunFile).Length-1;
 		var actualResultFileCount = System.IO.Directory.GetFiles(testResultsPath, "TestResults-*.xml").Length;
+
+		Information($"ExpectedCategoriesRanCount: {expectedCategoriesRanCount}");
+		Information($"ActualResultFileCount: {actualResultFileCount}");
 
 		while (actualResultFileCount < expectedCategoriesRanCount) {
 			actualResultFileCount = System.IO.Directory.GetFiles(testResultsPath, "TestResults-*.xml").Length;


### PR DESCRIPTION
## Description of Change

This PR fixes an off-by-one in the build script that detects if a test runner process has crashed. This logic compares the "tests we want to run" vs "output files from tests that actually ran". The PR fixes the issue, and adds additional logging to try and figure out which output category was missing

## Issues Fixed

Fixes #19703