### PR TITLE
Fix condition to bundle Microsoft.Maui.Essentials.dll in app extensions on Apple platforms. Fixes #19756.

### DIFF
--- a/src/Workload/Microsoft.Maui.Sdk/Sdk/BundledVersions.in.targets
+++ b/src/Workload/Microsoft.Maui.Sdk/Sdk/BundledVersions.in.targets
@@ -43,19 +43,19 @@
   <ItemGroup Condition=" '$(DisableMauiImplicitPackageReferences)' != 'true' and '$(UseMauiNuGets)' != 'true' ">
     <_MauiImplicitPackageReference Include="Microsoft.Maui.Resizetizer" Version="$(MauiVersion)" PrivateAssets="all" Condition=" '$(UseMauiAssets)' == 'true' " />
     <_MauiImplicitPackageReference Include="Microsoft.Maui.Essentials" Version="$(MauiVersion)" Condition=" '$(UseMauiEssentials)' == 'true' ">
-      <PrivateAssets Condition=" '$(OutputType)' == 'Library' and '$(AndroidApplication)' != 'true' ">all</PrivateAssets>
+      <PrivateAssets Condition=" '$(OutputType)' == 'Library' and '$(AndroidApplication)' != 'true' and '$(IsAppExtension)' != 'true'">all</PrivateAssets>
     </_MauiImplicitPackageReference>
     <_MauiImplicitPackageReference Include="Microsoft.Maui.Core" Version="$(MauiVersion)" Condition=" '$(UseMauiCore)' == 'true' ">
-      <PrivateAssets Condition=" '$(OutputType)' == 'Library' and '$(AndroidApplication)' != 'true' ">all</PrivateAssets>
+      <PrivateAssets Condition=" '$(OutputType)' == 'Library' and '$(AndroidApplication)' != 'true'  and '$(IsAppExtension)' != 'true'">all</PrivateAssets>
     </_MauiImplicitPackageReference>
     <_MauiImplicitPackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" Condition=" '$(UseMaui)' == 'true' ">
-      <PrivateAssets Condition=" '$(OutputType)' == 'Library' and '$(AndroidApplication)' != 'true' ">all</PrivateAssets>
+      <PrivateAssets Condition=" '$(OutputType)' == 'Library' and '$(AndroidApplication)' != 'true'  and '$(IsAppExtension)' != 'true'">all</PrivateAssets>
     </_MauiImplicitPackageReference>
     <_MauiImplicitPackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" IsMauiImplicitOptionalPackageReference="true" Condition=" '$(UseMaui)' == 'true' and '$(UseMauiCompat)' == 'true' ">
-      <PrivateAssets Condition=" '$(OutputType)' == 'Library' and '$(AndroidApplication)' != 'true' ">all</PrivateAssets>
+      <PrivateAssets Condition=" '$(OutputType)' == 'Library' and '$(AndroidApplication)' != 'true'  and '$(IsAppExtension)' != 'true'">all</PrivateAssets>
     </_MauiImplicitPackageReference>
     <_MauiImplicitPackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="$(MauiVersion)" Condition=" '$(UseMaui)' == 'true' and '$(UsingMicrosoftNETSdkRazor)' == 'true' ">
-      <PrivateAssets Condition=" '$(OutputType)' == 'Library' and '$(AndroidApplication)' != 'true' ">all</PrivateAssets>
+      <PrivateAssets Condition=" '$(OutputType)' == 'Library' and '$(AndroidApplication)' != 'true'  and '$(IsAppExtension)' != 'true'">all</PrivateAssets>
     </_MauiImplicitPackageReference>
   </ItemGroup>
   <!-- Install the nuget packages if we are allowed to -->


### PR DESCRIPTION
### Description of Change

App Extensions have OutputType=Library (just like Android applications), and
as such they need to be treated accordingly: keep bundling assets.

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/19756.