### PR TITLE
Handle setting of DesiredSize in Measure implementations, rather than MeasureOverride

### DIFF
--- a/src/Controls/src/Core/ContentPage/ContentPage.cs
+++ b/src/Controls/src/Core/ContentPage/ContentPage.cs
@@ -70,8 +70,7 @@ namespace Microsoft.Maui.Controls
 
 		protected override Size MeasureOverride(double widthConstraint, double heightConstraint)
 		{
-			DesiredSize = this.ComputeDesiredSize(widthConstraint, heightConstraint);
-			return DesiredSize;
+			return this.ComputeDesiredSize(widthConstraint, heightConstraint);
 		}
 
 		protected override Size ArrangeOverride(Rect bounds)

--- a/src/Controls/src/Core/ContentPresenter.cs
+++ b/src/Controls/src/Core/ContentPresenter.cs
@@ -102,8 +102,7 @@ namespace Microsoft.Maui.Controls
 
 		protected override Size MeasureOverride(double widthConstraint, double heightConstraint)
 		{
-			DesiredSize = this.ComputeDesiredSize(widthConstraint, heightConstraint);
-			return DesiredSize;
+			return this.ComputeDesiredSize(widthConstraint, heightConstraint);
 		}
 
 		Size ICrossPlatformLayout.CrossPlatformMeasure(double widthConstraint, double heightConstraint)

--- a/src/Controls/src/Core/Layout.cs
+++ b/src/Controls/src/Core/Layout.cs
@@ -236,14 +236,14 @@ namespace Microsoft.Maui.Controls.Compatibility
 
 		Size IView.Measure(double widthConstraint, double heightConstraint)
 		{
-			return MeasureOverride(widthConstraint, heightConstraint);
+			DesiredSize = MeasureOverride(widthConstraint, heightConstraint);
+			return DesiredSize;
 		}
 
 		protected override Size MeasureOverride(double widthConstraint, double heightConstraint)
 		{
 			var sansMargins = OnMeasure(widthConstraint, heightConstraint).Request;
-			DesiredSize = new Size(sansMargins.Width + Margin.HorizontalThickness, sansMargins.Height + Margin.VerticalThickness);
-			return DesiredSize;
+			return new Size(sansMargins.Width + Margin.HorizontalThickness, sansMargins.Height + Margin.VerticalThickness);
 		}
 
 		protected override void OnSizeAllocated(double width, double height)

--- a/src/Controls/src/Core/ScrollView/ScrollView.cs
+++ b/src/Controls/src/Core/ScrollView/ScrollView.cs
@@ -441,8 +441,7 @@ namespace Microsoft.Maui.Controls
 
 		protected override Size MeasureOverride(double widthConstraint, double heightConstraint)
 		{
-			DesiredSize = this.ComputeDesiredSize(widthConstraint, heightConstraint);
-			return DesiredSize;
+			return this.ComputeDesiredSize(widthConstraint, heightConstraint);
 		}
 
 		Size ICrossPlatformLayout.CrossPlatformMeasure(double widthConstraint, double heightConstraint)

--- a/src/Controls/src/Core/Shapes/Shape.cs
+++ b/src/Controls/src/Core/Shapes/Shape.cs
@@ -430,7 +430,6 @@ namespace Microsoft.Maui.Controls.Shapes
 			result.Height += StrokeThickness;
 			result.Width += StrokeThickness;
 
-			DesiredSize = result;
 			return result;
 		}
 

--- a/src/Controls/src/Core/TemplatedView/TemplatedView.cs
+++ b/src/Controls/src/Core/TemplatedView/TemplatedView.cs
@@ -120,8 +120,7 @@ namespace Microsoft.Maui.Controls
 
 		protected override Size MeasureOverride(double widthConstraint, double heightConstraint)
 		{
-			DesiredSize = this.ComputeDesiredSize(widthConstraint, heightConstraint);
-			return DesiredSize;
+			return this.ComputeDesiredSize(widthConstraint, heightConstraint);
 		}
 
 		Size ICrossPlatformLayout.CrossPlatformMeasure(double widthConstraint, double heightConstraint)

--- a/src/Controls/src/Core/VisualElement/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement/VisualElement.cs
@@ -1847,7 +1847,8 @@ namespace Microsoft.Maui.Controls
 		/// <inheritdoc/>
 		Size IView.Measure(double widthConstraint, double heightConstraint)
 		{
-			return MeasureOverride(widthConstraint, heightConstraint);
+			DesiredSize = MeasureOverride(widthConstraint, heightConstraint);
+			return DesiredSize;
 		}
 
 		/// <summary>
@@ -1859,8 +1860,7 @@ namespace Microsoft.Maui.Controls
 		/// <returns>The requested size that an element wants in order to be displayed on the device.</returns>
 		protected virtual Size MeasureOverride(double widthConstraint, double heightConstraint)
 		{
-			DesiredSize = this.ComputeDesiredSize(widthConstraint, heightConstraint);
-			return DesiredSize;
+			return this.ComputeDesiredSize(widthConstraint, heightConstraint);
 		}
 
 		/// <inheritdoc/>


### PR DESCRIPTION
### Description of Change

At the moment, anyone creating a custom control is responsible for explicitly setting the value of `DesiredSize` during the measure step. This is confusing for implementers - it's not obvious that this is required. And honestly, it's only required because we didn't handle it in the `IView.Measure()` implementations, which would make a lot more sense than forcing everyone to handle it themselves. 

These changes set the `DesiredSize` value to whatever gets returned from `MeasureOverride()` (which is what all the implementations were already doing).

### Issues Fixed

Doesn't _fix_ #7613 exactly, because the issue reported there isn't really a bug. But it does make the creation of custom controls based on ContentView much more intuitive. 

