### PR TITLE
[Android] FlyoutIsPresented property opens the Flyout

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Core/ShellGalleries/ShellChromeGallery.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/ShellGalleries/ShellChromeGallery.cs
@@ -76,6 +76,11 @@ namespace Maui.Controls.Sample.Pages.ShellGalleries
 			AppShell!.FlyoutHeaderBehavior = (FlyoutHeaderBehavior)flyoutHeaderBehavior.SelectedIndex;
 		}
 
+		void OnToggleFlyoutIsPresented(object sender, EventArgs e)
+		{
+			AppShell!.FlyoutIsPresented = !AppShell!.FlyoutIsPresented;
+		}
+		
 		void OnToggleFlyoutBackgroundColor(object sender, EventArgs e)
 		{
 			AppShell!.RemoveBinding(Shell.FlyoutBackgroundProperty);

--- a/src/Controls/samples/Controls.Sample/Pages/Core/ShellGalleries/ShellChromeGallery.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/ShellGalleries/ShellChromeGallery.xaml
@@ -14,6 +14,10 @@
                 Style="{StaticResource Headline}"/>
             <Picker x:Name="flyoutBehavior" />
             <Label
+                Text="FlyoutIsPresented"
+                Style="{StaticResource Headline}"/>
+            <Button Text="Toggle FlyoutIsPresented" x:Name="flyoutIsPresented" Clicked="OnToggleFlyoutIsPresented" />
+            <Label
                 Text="Flyout Background Color"
                 Style="{StaticResource Headline}"/>
             <Button Text="Toggle Flyout Background" x:Name="flyoutBackgroundColor" Clicked="OnToggleFlyoutBackgroundColor" />

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFlyoutRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFlyoutRenderer.cs
@@ -183,9 +183,9 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				canvas.DrawRect(0, 0, Width, Height, _scrimPaint);
 			}
 
-			if (!FlyoutFirstDrawPassFinished && _flyoutContent != null)
+			if (!FlyoutFirstDrawPassFinished && _flyoutContent is not null)
 			{
-				if (child == _flyoutContent?.AndroidView)
+				if (_flyoutContent?.AndroidView is not null)
 					FlyoutFirstDrawPassFinished = true;
 
 				if (this.IsDrawerOpen(_flyoutContent.AndroidView) != _shellContext.Shell.FlyoutIsPresented)

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFlyoutRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFlyoutRenderer.cs
@@ -185,6 +185,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 			if (!FlyoutFirstDrawPassFinished && _flyoutContent is not null)
 			{
+				// If the AndroidView property which is the DrawerLayout is initialized at this point, the Flyout first draw pass finished.
 				if (_flyoutContent?.AndroidView is not null)
 					FlyoutFirstDrawPassFinished = true;
 

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellFlyoutTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellFlyoutTests.Android.cs
@@ -14,24 +14,21 @@ namespace Microsoft.Maui.DeviceTests
 			await RunShellTest(shell =>
 			{
 				shell.FlyoutContent = new VerticalStackLayout() { new Label() { Text = "Flyout Content" } };
-
-				// 1. Set FlyoutIsPresented=true to make the Shell Flyout visible.
-				shell.FlyoutIsPresented = true;
 			},
 			async (shell, handler) =>
 			{
-				await Task.Delay(100);
+				// 1. Set FlyoutIsPresented=true to make the Shell Flyout visible.
+				shell.FlyoutIsPresented = true;
 
 				var dl = GetDrawerLayout(handler) as DrawerLayout;
 				Assert.NotNull(dl);
 
-				// 2. Check that the Flyout has size.
-				var flyoutFrame = GetFlyoutFrame(handler);
-				Assert.True(flyoutFrame.Width > 0);
-				Assert.True(flyoutFrame.Height > 0);
-
-				// 3. Check that the Flyout status. It must be open.
-				Assert.True(dl.IsOpen);
+				await AssertionExtensions.AssertEventually(() =>
+				{
+					// 2. Check that the Flyout has size.
+					var flyoutFrame = GetFlyoutFrame(handler);
+					return flyoutFrame.Width > 0 && flyoutFrame.Height > 0 && dl.IsOpen;
+				});
 			});
 		}
 	}

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellFlyoutTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellFlyoutTests.Android.cs
@@ -1,0 +1,38 @@
+﻿using AndroidX.DrawerLayout.Widget;
+using Microsoft.Maui.Controls;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	[Category(TestCategory.Shell)]
+	public partial class ShellTests
+	{
+		[Fact(DisplayName = "FlyoutIsPresented=true sets the visible status of the Shell Flyout.")]
+		public async Task FlyoutIsPresentedOpenDrawer()
+		{
+			await RunShellTest(shell =>
+			{
+				shell.FlyoutContent = new VerticalStackLayout() { new Label() { Text = "Flyout Content" } };
+
+				// 1. Set FlyoutIsPresented=true to make the Shell Flyout visible.
+				shell.FlyoutIsPresented = true;
+			},
+			async (shell, handler) =>
+			{
+				await Task.Delay(100);
+
+				var dl = GetDrawerLayout(handler) as DrawerLayout;
+				Assert.NotNull(dl);
+
+				// 2. Check that the Flyout has size.
+				var flyoutFrame = GetFlyoutFrame(handler);
+				Assert.True(flyoutFrame.Width > 0);
+				Assert.True(flyoutFrame.Height > 0);
+
+				// 3. Check that the Flyout status. It must be open.
+				Assert.True(dl.IsOpen);
+			});
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change

`FlyoutIsPresented` property opens the Flyout correctly.

![fix-8226](https://github.com/dotnet/maui/assets/6755973/96e4e0ca-78fb-48e5-a5da-0bc2602cddb3)

### Issues Fixed

Fixes #8226
