### PR TITLE
Update MSBuild.StructuredLogger

### DIFF
--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Microsoft.Maui.IntegrationTests.csproj
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Microsoft.Maui.IntegrationTests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="MSBuild.StructuredLogger" Version="2.2.100" />
+    <PackageReference Include="MSBuild.StructuredLogger" Version="2.2.158" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
FYI @KirillOsenkov 


### Context

This is update to the latest version of MSBuild.StructuredLogger, that contains the forward compatibility reading support.
The initial MSBuild change to forward compatible logs reading is **breaking** (log data format needs to be adjusted in order to allow forward compatibile reading for the future) - hence updating the reading code ahead of MSBuild pushing the updated version of binlog writing (https://github.com/dotnet/msbuild/pull/9307) is advisable.