### PR TITLE
[ci] Bump XCode to 15.2.0

### DIFF
--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -8,9 +8,9 @@ variables:
 - name: DOTNET_VERSION
   value: 7.0.401
 - name: REQUIRED_XCODE
-  value: 15.1.0
+  value: 15.2.0
 - name: DEVICETESTS_REQUIRED_XCODE
-  value: 15.1.0
+  value: 15.2.0
 - name: LocBranchPrefix
   value: 'loc-hb'
 - name: isMainBranch

--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -8,9 +8,9 @@ variables:
 - name: DOTNET_VERSION
   value: 7.0.401
 - name: REQUIRED_XCODE
-  value: 15.0.0
+  value: 15.1.0
 - name: DEVICETESTS_REQUIRED_XCODE
-  value: 15.0.0
+  value: 15.1.0
 - name: LocBranchPrefix
   value: 'loc-hb'
 - name: isMainBranch

--- a/eng/pipelines/device-tests.yml
+++ b/eng/pipelines/device-tests.yml
@@ -107,7 +107,7 @@ stages:
       agentPoolAccessToken: $(AgentPoolAccessToken)
       ${{ if or(parameters.BuildEverything, and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'devdiv'))) }}:
         androidApiLevels: [ 33, 30, 29, 28, 27, 26, 25, 24, 23 ]
-        iosVersions: [ 'simulator-16.4','simulator-15.5','simulator-14.5' ]
+        iosVersions: [ 'simulator-16.4','simulator-15.5' ]
         catalystVersions: [ 'latest' ]
         windowsVersions: ['packaged', 'unpackaged']
         provisionatorChannel: ${{ parameters.provisionatorChannel }}


### PR DESCRIPTION
### Description of Change

Move to use Xcode 15.2

Seems Xcode 15.1 or above drops support for iOS 14.5 simulators, so removing 
<img width="1003" alt="Screenshot 2024-01-12 at 00 23 33" src="https://github.com/dotnet/maui/assets/1235097/b23d530d-3af8-4799-848d-de1d6397cad5">

