### PR TITLE
[Catalyst] Allow setting of CancelButtonColor on SearchBar when using Mac Idiom

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/SearchBar/SearchBarTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/SearchBar/SearchBarTests.cs
@@ -32,6 +32,25 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.Equal(expected, platformText);
 		}
 
+#if MACCATALYST || IOS
+		// Only Mac Catalyst and iOS needs the CancelButtonColor nuanced handling verifying
+		[Fact(DisplayName = "CancelButtonColor is set correctly")]
+		public async Task CancelButtonColorSetCorrectly()
+		{
+			var expected = Graphics.Colors.Red;
+
+			var searchBar = new SearchBar()
+			{
+				CancelButtonColor = expected,
+				Text = "CancelButtonColor is set correctly"
+			};
+
+			var actualColor = await GetPlatformCancelButtonColor(await CreateHandlerAsync<SearchBarHandler>(searchBar));
+
+			Assert.Equal(expected, actualColor);
+		}
+#endif
+
 #if WINDOWS
 		// Only Windows needs the IsReadOnly workaround for MaxLength==0 to prevent text from being entered
 		[Fact]

--- a/src/Controls/tests/DeviceTests/Elements/SearchBar/SearchBarTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/SearchBar/SearchBarTests.iOS.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading.Tasks;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Platform;
+using UIKit;
 
 namespace Microsoft.Maui.DeviceTests
 {
@@ -13,6 +14,14 @@ namespace Microsoft.Maui.DeviceTests
 		{
 			return InvokeOnMainThreadAsync(() => GetPlatformControl(handler).Text);
 		}
+
+		static Task<Graphics.Color> GetPlatformCancelButtonColor(SearchBarHandler handler) => InvokeOnMainThreadAsync(() =>
+		{
+			if (handler.PlatformView.TraitCollection.UserInterfaceIdiom == UIUserInterfaceIdiom.Mac)
+				return GetPlatformControl(handler).FindDescendantView<UIButton>().TintColor.ToColor();
+
+			return GetPlatformControl(handler).FindDescendantView<UIButton>().TitleColor(UIControlState.Normal).ToColor();
+		});
 
 		static int GetPlatformSelectionLength(SearchBarHandler searchBarHandler)
 		{

--- a/src/Core/src/Platform/iOS/SearchBarExtensions.cs
+++ b/src/Core/src/Platform/iOS/SearchBarExtensions.cs
@@ -124,6 +124,9 @@ namespace Microsoft.Maui.Platform
 				cancelButton.SetTitleColor(searchBar.CancelButtonColor.ToPlatform(), UIControlState.Normal);
 				cancelButton.SetTitleColor(searchBar.CancelButtonColor.ToPlatform(), UIControlState.Highlighted);
 				cancelButton.SetTitleColor(searchBar.CancelButtonColor.ToPlatform(), UIControlState.Disabled);
+
+				if (cancelButton.TraitCollection.UserInterfaceIdiom == UIUserInterfaceIdiom.Mac)
+					cancelButton.TintColor = searchBar.CancelButtonColor.ToPlatform();
 			}
 		}
 


### PR DESCRIPTION
### Description of Change

Update to ```SearchBarExtensions``` so ```UpdateCancelButton``` sets the  ```TintColor``` on the Cancel ```UIButton``` when using Mac idiom. Device test added verifying the changes for Mac Catalyst and iOS.

### Issues Fixed

Fixes [#18110](https://github.com/dotnet/maui/issues/18110)
