### PR TITLE
[ci] Don't install xharness globally

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -9,11 +9,11 @@ Param(
 )
 
 # Restore Cake tool
-# & dotnet tool restore
-$tools = Get-Content ".config/dotnet-tools.json" | ConvertFrom-Json
-foreach ($tool in $tools.tools.PsObject.Properties) {
-    & dotnet tool install $tool.Name --version $tool.Value.version
-}
+& dotnet tool restore
+# $tools = Get-Content ".config/dotnet-tools.json" | ConvertFrom-Json
+# foreach ($tool in $tools.tools.PsObject.Properties) {
+#     & dotnet tool install $tool.Name --version $tool.Value.version
+# }
 
 # Build Cake arguments
 $cakeArguments = @("$Script");

--- a/eng/pipelines/common/maui-templates.yml
+++ b/eng/pipelines/common/maui-templates.yml
@@ -157,8 +157,8 @@ jobs:
         DOTNET_TOKEN: $(dotnetbuilds-internal-container-read-token)
         PRIVATE_BUILD: $(PrivateBuild)
 
-    - script: dotnet tool update Microsoft.DotNet.XHarness.CLI --add-source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json --version "8.0.0-prerelease*" -g
-      displayName: install xharness
+    # - script: dotnet tool update Microsoft.DotNet.XHarness.CLI --add-source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json --version "9.0.0-prerelease*" -g
+    #   displayName: install xharness
 
     - pwsh: ./build.ps1 --target=dotnet-integration-build --verbosity=diagnostic
       displayName: Build Microsoft.Maui.IntegrationTests

--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -6,7 +6,7 @@ variables:
 - name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE
   value: true
 - name: DOTNET_VERSION
-  value: 7.0.401
+  value: 8.0.101
 - name: REQUIRED_XCODE
   value: 15.0.0
 - name: DEVICETESTS_REQUIRED_XCODE
@@ -52,7 +52,7 @@ variables:
 - name: TeamName
   value: Maui
 - name: POWERSHELL_VERSION
-  value: 7.1.3
+  value: 7.4.0
 - name: Codeql.Enabled
   value: false
 - group: Xamarin-Secrets


### PR DESCRIPTION
### Description of Change

We can't rely on using xharness globally. we can have different versions. The template tests need to use the version that was restore by cake on the tools folder of bin/dotnet.

fixes: https://github.com/dotnet/maui/issues/19864

cc @pjcollins @mattleibow 