### PR TITLE
Fix Developer Tools option setting for Blazor Hybrid Mac Catalyst view.

### DIFF
--- a/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
+++ b/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
@@ -96,9 +96,9 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 				AutosizesSubviews = true
 			};
 
-			if (OperatingSystem.IsIOSVersionAtLeast(16, 4) || OperatingSystem.IsMacCatalystVersionAtLeast(13, 3))
+			if (OperatingSystem.IsIOSVersionAtLeast(16, 4) || OperatingSystem.IsMacCatalystVersionAtLeast(16, 6))
 			{
-				// Enable Developer Extras for Catalyst/iOS builds for 16.4+
+				// Enable Developer Extras for iOS builds for 16.4+ and Mac Catalyst builds for 16.6 (macOS 13.5)+
 				webview.SetValueForKey(NSObject.FromObject(DeveloperTools.Enabled), new NSString("inspectable"));
 			}
 

--- a/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
+++ b/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
@@ -80,9 +80,6 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 				Configuration = config
 			});
 
-			// Legacy Developer Extras setting.
-			config.Preferences.SetValueForKey(NSObject.FromObject(DeveloperTools.Enabled), new NSString("developerExtrasEnabled"));
-
 			config.UserContentController.AddScriptMessageHandler(new WebViewScriptMessageHandler(MessageReceived), "webwindowinterop");
 			config.UserContentController.AddUserScript(new WKUserScript(
 				new NSString(BlazorInitScript), WKUserScriptInjectionTime.AtDocumentEnd, true));
@@ -96,10 +93,16 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 				AutosizesSubviews = true
 			};
 
-			if (OperatingSystem.IsIOSVersionAtLeast(16, 4) || OperatingSystem.IsMacCatalystVersionAtLeast(16, 6))
+			if (DeveloperTools.Enabled)
 			{
-				// Enable Developer Extras for iOS builds for 16.4+ and Mac Catalyst builds for 16.6 (macOS 13.5)+
-				webview.SetValueForKey(NSObject.FromObject(DeveloperTools.Enabled), new NSString("inspectable"));
+				// Legacy Developer Extras setting.
+				config.Preferences.SetValueForKey(NSObject.FromObject(true), new NSString("developerExtrasEnabled"));
+
+				if (OperatingSystem.IsIOSVersionAtLeast(16, 4) || OperatingSystem.IsMacCatalystVersionAtLeast(16, 6))
+				{
+					// Enable Developer Extras for iOS builds for 16.4+ and Mac Catalyst builds for 16.6 (macOS 13.5)+
+					webview.SetValueForKey(NSObject.FromObject(true), new NSString("inspectable"));
+				}
 			}
 
 			VirtualView.BlazorWebViewInitialized(new BlazorWebViewInitializedEventArgs


### PR DESCRIPTION
### Description of Change

I had accidently set the version of the `OperatingSystem.IsMacCatalystVersionAtLeast` check to match the literal version of macOS, when it needed to be the version of iOS that that specific Mac Catalyst version was targeting, which should be 16.6. Changing it should make it so it no longer throws for the platform. It was not caught as a regression as all of the tests for Blazor run on Macs new enough to support that flag.

Also, since we need to use selectors to trigger that setting, and to be totally sure there can't be a crash should that number still be incorrect, it will only be enabled now if `DeveloperTools.Enabled` is set, instead of calling that method and setting the bool all the time. Since it's false by default, this should be fine.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes https://github.com/dotnet/maui/issues/19613

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
