### PR TITLE
[iOS][NativeAOT] Adding NativeAOT RunOniOS device test

### DIFF
--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/AppleTemplateTests.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/AppleTemplateTests.cs
@@ -50,5 +50,29 @@ namespace Microsoft.Maui.IntegrationTests
 				$"Project {Path.GetFileName(projectFile)} failed to run. Check test output/attachments for errors.");
 		}
 
+		[Test]
+		[TestCase("maui", "Release", DotNetCurrent, "iossimulator-x64")]
+		public void RunOniOSNativeAOT(string id, string config, string framework, string runtimeIdentifier)
+		{
+			var projectDir = TestDirectory;
+			var projectFile = Path.Combine(projectDir, $"{Path.GetFileName(projectDir)}.csproj");
+
+			Assert.IsTrue(DotnetInternal.New(id, projectDir, framework),
+				$"Unable to create template {id}. Check test output for errors.");
+
+			var extendedBuildProps = BuildProps;
+			extendedBuildProps.Add("PublishAot=true");
+			extendedBuildProps.Add("PublishAotUsingRuntimePack=true"); // TODO: This parameter will become obsolete https://github.com/dotnet/runtime/issues/87060
+			extendedBuildProps.Add("_IsPublishing=true"); // using dotnet build with -p:_IsPublishing=true enables targeting simulators
+			extendedBuildProps.Add($"RuntimeIdentifier={runtimeIdentifier}");
+
+			Assert.IsTrue(DotnetInternal.Build(projectFile, config, framework: $"{framework}-ios", properties: BuildProps),
+				$"Project {Path.GetFileName(projectFile)} failed to build. Check test output/attachments for errors.");
+
+			var appFile = Path.Combine(projectDir, "bin", config, $"{framework}-ios", runtimeIdentifier, $"{Path.GetFileName(projectDir)}.app");
+
+			Assert.IsTrue(XHarness.RunAppleForTimeout(appFile, Path.Combine(projectDir, "xh-results"), TestSimulator.XHarnessID),
+				$"Project {Path.GetFileName(projectFile)} failed to run. Check test output/attachments for errors.");
+		}
 	}
 }

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/AppleTemplateTests.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/AppleTemplateTests.cs
@@ -25,15 +25,16 @@ namespace Microsoft.Maui.IntegrationTests
 		}
 
 		[Test]
-		[TestCase("maui", "Debug", DotNetPrevious)]
-		[TestCase("maui", "Release", DotNetPrevious)]
-		[TestCase("maui", "Debug", DotNetCurrent)]
-		[TestCase("maui", "Release", DotNetCurrent)]
-		[TestCase("maui-blazor", "Debug", DotNetPrevious)]
-		[TestCase("maui-blazor", "Release", DotNetPrevious)]
-		[TestCase("maui-blazor", "Debug", DotNetCurrent)]
-		[TestCase("maui-blazor", "Release", DotNetCurrent)]
-		public void RunOniOS(string id, string config, string framework)
+		[TestCase("maui", "Debug", DotNetPrevious, "iossimulator-x64", RuntimeVariant.Mono)]
+		[TestCase("maui", "Release", DotNetPrevious, "iossimulator-x64", RuntimeVariant.Mono)]
+		[TestCase("maui", "Debug", DotNetCurrent, "iossimulator-x64", RuntimeVariant.Mono)]
+		[TestCase("maui", "Release", DotNetCurrent, "iossimulator-x64", RuntimeVariant.Mono)]
+		[TestCase("maui-blazor", "Debug", DotNetPrevious, "iossimulator-x64", RuntimeVariant.Mono)]
+		[TestCase("maui-blazor", "Release", DotNetPrevious, "iossimulator-x64", RuntimeVariant.Mono)]
+		[TestCase("maui-blazor", "Debug", DotNetCurrent, "iossimulator-x64", RuntimeVariant.Mono)]
+		[TestCase("maui-blazor", "Release", DotNetCurrent, "iossimulator-x64", RuntimeVariant.Mono)]
+		[TestCase("maui", "Release", DotNetCurrent, "iossimulator-x64", RuntimeVariant.NativeAOT)]
+		public void RunOniOS(string id, string config, string framework, string runtimeIdentifier, RuntimeVariant runtimeVariant)
 		{
 			var projectDir = TestDirectory;
 			var projectFile = Path.Combine(projectDir, $"{Path.GetFileName(projectDir)}.csproj");
@@ -41,32 +42,16 @@ namespace Microsoft.Maui.IntegrationTests
 			Assert.IsTrue(DotnetInternal.New(id, projectDir, framework),
 				$"Unable to create template {id}. Check test output for errors.");
 
-			Assert.IsTrue(DotnetInternal.Build(projectFile, config, framework: $"{framework}-ios", properties: BuildProps),
-				$"Project {Path.GetFileName(projectFile)} failed to build. Check test output/attachments for errors.");
+			var buildProps = BuildProps;
+			if (runtimeVariant == RuntimeVariant.NativeAOT)
+			{
+				buildProps.Add("PublishAot=true");
+				buildProps.Add("PublishAotUsingRuntimePack=true"); // TODO: This parameter will become obsolete https://github.com/dotnet/runtime/issues/87060
+				buildProps.Add("_IsPublishing=true"); // using dotnet build with -p:_IsPublishing=true enables targeting simulators
+				buildProps.Add($"RuntimeIdentifier={runtimeIdentifier}");
+			}
 
-			var appFile = Path.Combine(projectDir, "bin", config, $"{framework}-ios", "iossimulator-x64", $"{Path.GetFileName(projectDir)}.app");
-
-			Assert.IsTrue(XHarness.RunAppleForTimeout(appFile, Path.Combine(projectDir, "xh-results"), TestSimulator.XHarnessID),
-				$"Project {Path.GetFileName(projectFile)} failed to run. Check test output/attachments for errors.");
-		}
-
-		[Test]
-		[TestCase("maui", "Release", DotNetCurrent, "iossimulator-x64")]
-		public void RunOniOSNativeAOT(string id, string config, string framework, string runtimeIdentifier)
-		{
-			var projectDir = TestDirectory;
-			var projectFile = Path.Combine(projectDir, $"{Path.GetFileName(projectDir)}.csproj");
-
-			Assert.IsTrue(DotnetInternal.New(id, projectDir, framework),
-				$"Unable to create template {id}. Check test output for errors.");
-
-			var extendedBuildProps = BuildProps;
-			extendedBuildProps.Add("PublishAot=true");
-			extendedBuildProps.Add("PublishAotUsingRuntimePack=true"); // TODO: This parameter will become obsolete https://github.com/dotnet/runtime/issues/87060
-			extendedBuildProps.Add("_IsPublishing=true"); // using dotnet build with -p:_IsPublishing=true enables targeting simulators
-			extendedBuildProps.Add($"RuntimeIdentifier={runtimeIdentifier}");
-
-			Assert.IsTrue(DotnetInternal.Build(projectFile, config, framework: $"{framework}-ios", properties: BuildProps),
+			Assert.IsTrue(DotnetInternal.Build(projectFile, config, framework: $"{framework}-ios", properties: buildProps),
 				$"Project {Path.GetFileName(projectFile)} failed to build. Check test output/attachments for errors.");
 
 			var appFile = Path.Combine(projectDir, "bin", config, $"{framework}-ios", runtimeIdentifier, $"{Path.GetFileName(projectDir)}.app");

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/BaseBuildTest.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/BaseBuildTest.cs
@@ -1,6 +1,12 @@
 ﻿
 namespace Microsoft.Maui.IntegrationTests
 {
+	public enum RuntimeVariant
+	{
+		Mono,
+		NativeAOT
+	}
+
 	public class BaseBuildTest
 	{
 		public const string DotNetCurrent = "net8.0";


### PR DESCRIPTION
### Description

This PR adds an integration test for testing NativeAOT running on iOS by extending the existing `RunOniOS` test method with two new parameters:
- `runtimeIdentifier` - string denoting the target runtime identifier i.e., on which platform the test will be executed. Since currently CI only runs these tests on simulators (note: referring to `iossimulator-x64` in the target path below) https://github.com/dotnet/maui/blob/f9a885219953dd67171b0986f9746795fc5fc207/src/TestUtils/src/Microsoft.Maui.IntegrationTests/AppleTemplateTests.cs#L47 we are passing the same value `iossimulator-x64` in all cases for the time being.
-  `runtimeVariant` - new enum type - `RuntimeVariant` differentiating runtime variants to run the test with (at the moment supported variants are `Mono` and `NativeAOT`).

---
Contributes to https://github.com/dotnet/maui/issues/19817

/cc: @jonathanpeppers @simonrozsival 