### PR TITLE
Propagate the app theme to all children

### DIFF
--- a/src/Controls/src/Core/Application/Application.cs
+++ b/src/Controls/src/Core/Application/Application.cs
@@ -15,7 +15,7 @@ using Microsoft.Maui.Handlers;
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/Application.xml" path="Type[@FullName='Microsoft.Maui.Controls.Application']/Docs/*" />
-	public partial class Application : Element, IResourcesProvider, IApplicationController, IElementConfiguration<Application>, IVisualTreeElement, IApplication
+	public partial class Application : Element, IResourcesProvider, IApplicationController, IElementConfiguration<Application>, IVisualTreeElement, IApplication, IRequestedThemeController
 	{
 		readonly WeakEventManager _weakEventManager = new WeakEventManager();
 		readonly Lazy<PlatformConfigurationRegistry<Application>> _platformConfigurationRegistry;
@@ -243,12 +243,20 @@ namespace Microsoft.Maui.Controls
 				_themeChangedFiring = true;
 				_lastAppTheme = newTheme;
 
+				PropertyPropagationExtensions.PropagatePropertyChanged(VisualElement.RequestedThemeProperty, this);
+
 				_weakEventManager.HandleEvent(this, new AppThemeChangedEventArgs(newTheme), nameof(RequestedThemeChanged));
 			}
 			finally
 			{
 				_themeChangedFiring = false;
 			}
+		}
+
+		AppTheme IRequestedThemeController.RequestedTheme
+		{
+			get => RequestedTheme;
+			set { /* do nothing as this API is not really meant to work this way */ }
 		}
 
 		public event EventHandler<ModalPoppedEventArgs>? ModalPopped;

--- a/src/Controls/src/Core/IRequestedThemeController.cs
+++ b/src/Controls/src/Core/IRequestedThemeController.cs
@@ -1,0 +1,9 @@
+﻿using Microsoft.Maui.ApplicationModel;
+
+namespace Microsoft.Maui.Controls
+{
+	interface IRequestedThemeController
+	{
+		AppTheme RequestedTheme { get; set; }
+	}
+}

--- a/src/Controls/src/Core/Internals/PropertyPropagationExtensions.cs
+++ b/src/Controls/src/Core/Internals/PropertyPropagationExtensions.cs
@@ -1,11 +1,18 @@
 #nullable disable
 using System.Collections;
+using Microsoft.Maui.ApplicationModel;
 
 namespace Microsoft.Maui.Controls.Internals
 {
 	/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/PropertyPropagationExtensions.xml" path="Type[@FullName='Microsoft.Maui.Controls.Internals.PropertyPropagationExtensions']/Docs/*" />
 	public static class PropertyPropagationExtensions
 	{
+		internal static void PropagatePropertyChanged<T>(BindableProperty property, T element) where T : Element, IVisualTreeElement =>
+			PropagatePropertyChanged(property.PropertyName, element);
+
+		internal static void PropagatePropertyChanged<T>(string propertyName, T element) where T : Element, IVisualTreeElement =>
+			PropagatePropertyChanged(propertyName, element, element.GetVisualChildren());
+
 		internal static void PropagatePropertyChanged(string propertyName, Element element, IEnumerable children)
 		{
 			if (propertyName == null || propertyName == VisualElement.FlowDirectionProperty.PropertyName)
@@ -16,6 +23,9 @@ namespace Microsoft.Maui.Controls.Internals
 
 			if (propertyName == null || propertyName == VisualElement.WindowProperty.PropertyName)
 				SetWindowFromParent(element);
+
+			if (propertyName == null || propertyName == VisualElement.RequestedThemeProperty.PropertyName)
+				SetRequestedThemeFromParent(element);
 
 			if (propertyName == null || propertyName == Shell.NavBarHasShadowProperty.PropertyName)
 				BaseShellItem.PropagateFromParent(Shell.NavBarHasShadowProperty, element);
@@ -41,6 +51,9 @@ namespace Microsoft.Maui.Controls.Internals
 
 			if (propertyName == null || propertyName == VisualElement.WindowProperty.PropertyName)
 				PropagateWindow(target, source);
+
+			if (propertyName == null || propertyName == VisualElement.RequestedThemeProperty.PropertyName)
+				PropagateRequestedTheme(target, source);
 
 			if (target is IPropertyPropagationController view)
 				view.PropagatePropertyChanged(propertyName);
@@ -109,6 +122,21 @@ namespace Microsoft.Maui.Controls.Internals
 		internal static void SetWindowFromParent(Element child)
 		{
 			PropagateWindow(child, child.Parent);
+		}
+
+		internal static void PropagateRequestedTheme(Element target, Element source)
+		{
+			if (target is not IRequestedThemeController controller)
+				return;
+
+			var sourceController = source as IRequestedThemeController;
+
+			controller.RequestedTheme = sourceController?.RequestedTheme ?? AppTheme.Unspecified;
+		}
+
+		internal static void SetRequestedThemeFromParent(Element child)
+		{
+			PropagateRequestedTheme(child, child.Parent);
 		}
 	}
 }

--- a/src/Controls/src/Core/VisualElement/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement/VisualElement.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;
+using Microsoft.Maui.ApplicationModel;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Controls.Shapes;
 using Microsoft.Maui.Graphics;
@@ -18,7 +19,7 @@ namespace Microsoft.Maui.Controls
 	/// <remarks>
 	/// The base class for most Microsoft.Maui.Controls on-screen elements. Provides most properties, events, and methods for presenting an item on screen.
 	/// </remarks>
-	public partial class VisualElement : NavigableElement, IAnimatable, IVisualElementController, IResourcesProvider, IStyleElement, IFlowDirectionController, IPropertyPropagationController, IVisualController, IWindowController, IView, IControlsVisualElement
+	public partial class VisualElement : NavigableElement, IAnimatable, IVisualElementController, IResourcesProvider, IStyleElement, IFlowDirectionController, IPropertyPropagationController, IVisualController, IWindowController, IRequestedThemeController, IView, IControlsVisualElement
 	{
 		/// <summary>Bindable property for <see cref="NavigableElement.Navigation"/>.</summary>
 		public new static readonly BindableProperty NavigationProperty = NavigableElement.NavigationProperty;
@@ -478,6 +479,19 @@ namespace Microsoft.Maui.Controls
 		{
 			get => (Window)GetValue(WindowProperty);
 			set => SetValue(WindowPropertyKey, value);
+		}
+
+		static readonly BindablePropertyKey RequestedThemePropertyKey = BindableProperty.CreateReadOnly(
+			nameof(RequestedTheme), typeof(AppTheme), typeof(VisualElement), AppTheme.Unspecified, propertyChanged: OnRequestedThemeChanged);
+
+		internal static readonly BindableProperty RequestedThemeProperty = RequestedThemePropertyKey.BindableProperty;
+
+		internal AppTheme RequestedTheme => (AppTheme)GetValue(RequestedThemeProperty);
+
+		AppTheme IRequestedThemeController.RequestedTheme
+		{
+			get => (AppTheme)GetValue(RequestedThemeProperty);
+			set => SetValue(RequestedThemePropertyKey, value);
 		}
 
 		readonly Dictionary<Size, SizeRequest> _measureCache = new Dictionary<Size, SizeRequest>();
@@ -2190,6 +2204,16 @@ namespace Microsoft.Maui.Controls
 		{
 			UpdatePlatformUnloadedLoadedWiring(Window);
 		}
+
+		static void OnRequestedThemeChanged(BindableObject bindable, object? oldValue, object? newValue)
+		{
+			if (bindable is not VisualElement visualElement)
+				return;
+
+			visualElement.RequestedThemeChanged?.Invoke(visualElement, EventArgs.Empty);
+		}
+
+		internal event EventHandler RequestedThemeChanged;
 
 		// We only want to wire up to platform loaded events
 		// if the user is watching for them. Otherwise

--- a/src/Controls/src/Core/Window/Window.cs
+++ b/src/Controls/src/Core/Window/Window.cs
@@ -13,7 +13,7 @@ using Microsoft.Maui.Graphics;
 namespace Microsoft.Maui.Controls
 {
 	[ContentProperty(nameof(Page))]
-	public partial class Window : NavigableElement, IWindow, IToolbarElement, IMenuBarElement, IFlowDirectionController, IWindowController
+	public partial class Window : NavigableElement, IWindow, IToolbarElement, IMenuBarElement, IFlowDirectionController, IWindowController, IRequestedThemeController, IPropertyPropagationController
 	{
 		/// <summary>Bindable property for <see cref="Title"/>.</summary>
 		public static readonly BindableProperty TitleProperty = BindableProperty.Create(
@@ -401,8 +401,17 @@ namespace Microsoft.Maui.Controls
 		Window IWindowController.Window
 		{
 			get => this;
-			set => throw new InvalidOperationException("A window cannot set a window.");
+			set { /* do nothing as Window does have a parent Window */ }
 		}
+
+		AppTheme IRequestedThemeController.RequestedTheme
+		{
+			get => Application?.RequestedTheme ?? Application.Current?.RequestedTheme ?? AppInfo.Current.RequestedTheme;
+			set { /* do nothing as we are not storing this value locally at all */ }
+		}
+
+		void IPropertyPropagationController.PropagatePropertyChanged(string propertyName) =>
+			PropertyPropagationExtensions.PropagatePropertyChanged(propertyName, this);
 
 		IView IWindow.Content =>
 			Page ?? throw new InvalidOperationException("No page was set on the window.");

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui16538.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui16538.xaml.cs
@@ -1,5 +1,6 @@
 using Microsoft.Maui.ApplicationModel;
 using Microsoft.Maui.Controls.Core.UnitTests;
+using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Controls.Shapes;
 using Microsoft.Maui.Devices;
 using Microsoft.Maui.Dispatching;
@@ -29,19 +30,23 @@ public partial class Maui16538
 			DispatcherProvider.SetCurrent(new DispatcherProviderStub());
 		}
 
-
 		[TearDown] public void TearDown() => AppInfo.SetCurrent(null);
 
 		[Test]
 		public void VSMandAppTheme([Values(false, true)] bool useCompiledXaml)
 		{
-
 			Application.Current.UserAppTheme = AppTheme.Dark;
+
 			var page = new Maui16538(useCompiledXaml);
 			Button button = page.button0;
 			Assert.That(button.BackgroundColor, Is.EqualTo(Color.FromHex("404040")));
+
+			Application.Current.LoadPage(page);
+			Assert.That(button.BackgroundColor, Is.EqualTo(Color.FromHex("404040")));
+
 			button.IsEnabled = true;
 			Assert.That(button.BackgroundColor, Is.EqualTo(Colors.White));
+
 			Application.Current.UserAppTheme = AppTheme.Light;
 			Assert.That(button.BackgroundColor, Is.EqualTo(Color.FromHex("512BD4")));
 		}


### PR DESCRIPTION
### Description of Change

Subscribing to `Application.RequestedThemeChanged` is fairly expensive because it uses a weak event. This PR tries an alternative by propagating the value to all children.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

- Related to #8713
- Fixes #18505

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
