### PR TITLE
Rectify the scopes in the builder

### DIFF
--- a/src/Controls/samples/Controls.Sample/MauiProgram.cs
+++ b/src/Controls/samples/Controls.Sample/MauiProgram.cs
@@ -45,6 +45,13 @@ namespace Maui.Controls.Sample
 		public static MauiApp CreateMauiApp()
 		{
 			var appBuilder = MauiApp.CreateBuilder();
+
+			appBuilder.ConfigureContainer(new DefaultServiceProviderFactory(new ServiceProviderOptions
+			{
+				ValidateOnBuild = true,
+				ValidateScopes = true,
+			}));
+
 #if __ANDROID__ || __IOS__
 			appBuilder.UseMauiMaps();
 #endif

--- a/src/Controls/samples/Controls.Sample/XamlApp.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/XamlApp.xaml.cs
@@ -19,6 +19,9 @@ namespace Maui.Controls.Sample
 
 			Debug.WriteLine($"The injected text service had a message: '{textService.GetText()}'");
 
+			var requested = services.GetRequiredService<ITextService>();
+			Debug.WriteLine($"The requested text service had a message: '{requested.GetText()}'");
+
 			Debug.WriteLine($"Current app theme: {RequestedTheme}");
 
 			RequestedThemeChanged += (sender, args) =>
@@ -48,7 +51,8 @@ namespace Maui.Controls.Sample
 		// Must not use MainPage for multi-window
 		protected override Window CreateWindow(IActivationState? activationState)
 		{
-			var window = new MauiWindow(Services.GetRequiredService<Page>())
+			var services = activationState!.Context.Services;
+			var window = new MauiWindow(services.GetRequiredService<Page>())
 			{
 				Title = ".NET MAUI Samples Gallery"
 			};

--- a/src/Controls/src/Xaml/Hosting/AppHostBuilderExtensions.cs
+++ b/src/Controls/src/Xaml/Hosting/AppHostBuilderExtensions.cs
@@ -196,9 +196,7 @@ namespace Microsoft.Maui.Controls.Hosting
 			public void Initialize(IServiceProvider services)
 			{
 #if WINDOWS
-				var dispatcher =
-					services.GetService<IDispatcher>() ??
-					IPlatformApplication.Current?.Services.GetRequiredService<IDispatcher>();
+				var dispatcher = services.GetRequiredApplicationDispatcher();
 
 				dispatcher
 					.DispatchIfRequired(() =>

--- a/src/Core/src/Dispatching/ApplicationDispatcher.cs
+++ b/src/Core/src/Dispatching/ApplicationDispatcher.cs
@@ -1,0 +1,22 @@
+﻿namespace Microsoft.Maui.Dispatching
+{
+	/// <summary>
+	/// The default service provider does not support a single service type for
+	/// BOTH a singleton (for the root app) AND a scoped (for the window scope).
+	/// This is a small wrapper so we can do the same thing. The preferred way is
+	/// actually a keyed service, but this is a new feature that existing factories
+	/// may not yet support. Also, this wrapper is not public so it is hard to 
+	/// replace/substitute in tests.
+	/// 
+	/// TODO: Remove in net9 and require a keyed service - or some other way.
+	/// </summary>
+	internal class ApplicationDispatcher
+	{
+		public IDispatcher Dispatcher { get; }
+
+		public ApplicationDispatcher(IDispatcher dispatcher)
+		{
+			Dispatcher = dispatcher;
+		}
+	}
+}

--- a/src/Core/src/Hosting/Dispatching/AppHostBuilderExtensions.cs
+++ b/src/Core/src/Hosting/Dispatching/AppHostBuilderExtensions.cs
@@ -10,22 +10,70 @@ namespace Microsoft.Maui.Hosting
 	{
 		public static MauiAppBuilder ConfigureDispatching(this MauiAppBuilder builder)
 		{
+			// register the DispatcherProvider as a singleton for the entire app
 			builder.Services.TryAddSingleton<IDispatcherProvider>(svc =>
 				// the DispatcherProvider might have already been initialized, so ensure that we are grabbing the
 				// Current and putting it in the DI container.
 				DispatcherProvider.Current);
 
-			builder.Services.TryAddScoped(svc =>
-			{
-				var provider = svc.GetRequiredService<IDispatcherProvider>();
-				if (DispatcherProvider.SetCurrent(provider))
-					svc.CreateLogger<Dispatcher>()?.LogWarning("Replaced an existing DispatcherProvider with one from the service provider.");
+			// register a fallback dispatcher when the service provider does not support keyed services
+			builder.Services.TryAddSingleton<ApplicationDispatcher>((svc) => new ApplicationDispatcher(GetDispatcher(svc)));
+			// register the initializer so we can init the dispatcher in the app thread for the app
+			builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IMauiInitializeService, ApplicationDispatcherInitializer>());
 
-				return Dispatcher.GetForCurrentThread()!;
-			});
+			// register the Dispatcher as a scoped service as there may be different dispatchers per window
+			builder.Services.TryAddScoped<IDispatcher>((svc) => GetDispatcher(svc));
+			// register the initializer so we can init the dispatcher in the window thread for that window
 			builder.Services.TryAddEnumerable(ServiceDescriptor.Scoped<IMauiInitializeScopedService, DispatcherInitializer>());
 
 			return builder;
+		}
+
+		internal static IDispatcher GetRequiredApplicationDispatcher(this IServiceProvider provider)
+		{
+			if (provider is IKeyedServiceProvider keyed)
+			{
+				var dispatcher = keyed.GetKeyedService<IDispatcher>(typeof(IApplication));
+				if (dispatcher is not null)
+				{
+					return dispatcher;
+				}
+			}
+
+			return provider.GetRequiredService<ApplicationDispatcher>().Dispatcher;
+		}
+
+		internal static IDispatcher? GetOptionalApplicationDispatcher(this IServiceProvider provider)
+		{
+			if (provider is IKeyedServiceProvider keyed)
+			{
+				var dispatcher = keyed.GetKeyedService<IDispatcher>(typeof(IApplication));
+				if (dispatcher is not null)
+				{
+					return dispatcher;
+				}
+			}
+
+			return provider.GetService<ApplicationDispatcher>()?.Dispatcher;
+		}
+
+		static IDispatcher GetDispatcher(IServiceProvider services)
+		{
+			var provider = services.GetRequiredService<IDispatcherProvider>();
+			if (DispatcherProvider.SetCurrent(provider))
+			{
+				services.CreateLogger<Dispatcher>()?.LogWarning("Replaced an existing DispatcherProvider with one from the service provider.");
+			}
+
+			return Dispatcher.GetForCurrentThread()!;
+		}
+
+		class ApplicationDispatcherInitializer : IMauiInitializeService
+		{
+			public void Initialize(IServiceProvider services)
+			{
+				_ = services.GetOptionalApplicationDispatcher();
+			}
 		}
 
 		class DispatcherInitializer : IMauiInitializeScopedService

--- a/src/Core/src/Hosting/IMauiInitializeService.cs
+++ b/src/Core/src/Hosting/IMauiInitializeService.cs
@@ -2,11 +2,25 @@
 
 namespace Microsoft.Maui.Hosting
 {
+	/// <summary>
+	/// Represents a service that is initialized during the application construction.
+	/// </summary>
+	/// <remarks>
+	/// This service is initialized during the MauiAppBuilder.Build() method. It is
+	/// executed once per application using the root service provider.
+	/// </remarks>
 	public interface IMauiInitializeService
 	{
 		void Initialize(IServiceProvider services);
 	}
 
+	/// <summary>
+	/// Represents a service that is initialized during the window construction.
+	/// </summary>
+	/// <remarks>
+	/// This service is initialized during the creation of a window. It is
+	/// executed once per window using the window-scoped service provider.
+	/// </remarks>
 	public interface IMauiInitializeScopedService
 	{
 		void Initialize(IServiceProvider services);

--- a/src/Core/src/Hosting/MauiAppBuilder.cs
+++ b/src/Core/src/Hosting/MauiAppBuilder.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Maui.Hosting
 #if WINDOWS
 				// WORKAROUND: use the MAUI dispatcher instead of the OS dispatcher to
 				// avoid crashing: https://github.com/microsoft/WindowsAppSDK/issues/2451
-				var dispatcher = services.GetRequiredService<IDispatcher>();
+				var dispatcher = services.GetRequiredApplicationDispatcher();
 				if (dispatcher.IsDispatchRequired)
 					dispatcher.Dispatch(() => SetupResources());
 				else
@@ -150,19 +150,13 @@ namespace Microsoft.Maui.Hosting
 				? _createServiceProvider()
 				: _services.BuildServiceProvider();
 
-			MauiApp builtApplication = new MauiApp(serviceProvider);
-
 			// Mark the service collection as read-only to prevent future modifications
 			_services.MakeReadOnly();
 
-			var initServices = builtApplication.Services.GetServices<IMauiInitializeService>();
-			if (initServices != null)
-			{
-				foreach (var instance in initServices)
-				{
-					instance.Initialize(builtApplication.Services);
-				}
-			}
+			MauiApp builtApplication = new MauiApp(serviceProvider);
+
+			// Initialize any singleton/app services, for example the OS hooks
+			builtApplication.InitializeAppServices();
 
 			return builtApplication;
 		}

--- a/src/Core/tests/DeviceTests.Shared/HandlerTests/HandlerTestBasement.cs
+++ b/src/Core/tests/DeviceTests.Shared/HandlerTests/HandlerTestBasement.cs
@@ -39,6 +39,7 @@ namespace Microsoft.Maui.DeviceTests
 			var appBuilder = MauiApp.CreateBuilder();
 
 			appBuilder.Services.AddSingleton<IDispatcherProvider>(svc => TestDispatcher.Provider);
+			appBuilder.Services.AddKeyedSingleton<IDispatcher>(typeof(IApplication), (svc, key) => TestDispatcher.Current);
 			appBuilder.Services.AddScoped<IDispatcher>(svc => TestDispatcher.Current);
 			appBuilder.Services.AddSingleton<IApplication>((_) => new CoreApplicationStub());
 

--- a/src/Core/tests/DeviceTests.Shared/MauiProgramDefaults.cs
+++ b/src/Core/tests/DeviceTests.Shared/MauiProgramDefaults.cs
@@ -69,6 +69,12 @@ namespace Microsoft.Maui.DeviceTests
 #endif
 			appBuilder.UseVisualRunner();
 
+			appBuilder.ConfigureContainer(new DefaultServiceProviderFactory(new ServiceProviderOptions
+			{
+				ValidateOnBuild = true,
+				ValidateScopes = true,
+			}));
+
 			var mauiApp = appBuilder.Build();
 
 			DefaultTestApp = mauiApp.Services.GetRequiredService<IApplication>();

--- a/src/TestUtils/src/DeviceTests.Runners/TestDispatcher.cs
+++ b/src/TestUtils/src/DeviceTests.Runners/TestDispatcher.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Maui.TestUtils.DeviceTests.Runners
 			get
 			{
 				if (s_dispatcher is null)
-					s_dispatcher = TestServices.Services.GetService<IDispatcher>();
+					s_dispatcher = TestServices.Services.GetService<ApplicationDispatcher>()?.Dispatcher;
 
 				if (s_dispatcher is null)
 					throw new InvalidOperationException($"Test app did not provide a dispatcher.");


### PR DESCRIPTION
### Description of Change

An alternate alternative to #18492 and an alternative to #19593

Alteratives:

- #18492
- #19593

This PR makes sure that our scopes are correct:
 - The appliation is the root and is _not_ a scope.
 - There is a unique scope for _each_ window.
 
 I would have preferred to have a singleton service for the app and a scoped service for window, but it appears the default DI container does not support the same type as BOTH a singleton AND a scoped. One thought would be to use keyed services but this does not yet appear to be 100% supported in the IoC container libraries that are used in a MAUI app. For now we just register a placeholder type to hold the singleton dispatcher and we use that.

The issue is that an app may not only have different dispatchers per window, but also for the app. In all existing apps _today_, there is a single dispatcher for all things. However, WinUI used to - and may in future - have different dispatchers for each window. 

This could mean that at startup, the app and window have the same dispatcher, but if a new window was created, it would have a new, second dispatcher. And if the first window was closed, the app would retain the first dispatcher. As a result, we could have different dispatchers for the app and for the window. This is academic now since WinUI dropped the support for different window-threads.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

- Fixes #11457
- Fixes #19591

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
