### PR TITLE
[XC] only generate the services that'll be used

### DIFF
--- a/src/Controls/src/Build.Tasks/BuildException.cs
+++ b/src/Controls/src/Build.Tasks/BuildException.cs
@@ -80,6 +80,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 		public static BuildExceptionCode XStaticSyntax = new BuildExceptionCode("XFC", 0100, nameof(XStaticSyntax), "");
 		public static BuildExceptionCode XStaticResolution = new BuildExceptionCode("XFC", 0101, nameof(XStaticResolution), "");
 		public static BuildExceptionCode XDataTypeSyntax = new BuildExceptionCode("XFC", 0102, nameof(XDataTypeSyntax), "");
+		public static BuildExceptionCode UnattributedMarkupType = new BuildExceptionCode("XC", 0103, nameof(UnattributedMarkupType), ""); //warning
 
 		//Style, StyleSheets, Resources
 		public static BuildExceptionCode StyleSheetSourceOrContent = new BuildExceptionCode("XFC", 0120, nameof(StyleSheetSourceOrContent), "");

--- a/src/Controls/src/Build.Tasks/CompiledValueProviders/SetterValueProvider.cs
+++ b/src/Controls/src/Build.Tasks/CompiledValueProviders/SetterValueProvider.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Maui.Controls.XamlC
 				yield return instruction;
 
 			//push the value
-			foreach (var instruction in ((ValueNode)valueNode).PushConvertedValue(context, bpRef, valueNode.PushServiceProvider(context, bpRef: bpRef), boxValueTypes: true, unboxValueTypes: false))
+			foreach (var instruction in ((ValueNode)valueNode).PushConvertedValue(context, bpRef, (requiredServices) => valueNode.PushServiceProvider(context, requiredServices, bpRef: bpRef), boxValueTypes: true, unboxValueTypes: false))
 				yield return instruction;
 
 			//set the value

--- a/src/Controls/src/Build.Tasks/CreateObjectVisitor.cs
+++ b/src/Controls/src/Build.Tasks/CreateObjectVisitor.cs
@@ -172,7 +172,8 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 				{
 					//<Color>Purple</Color>
 					Context.IL.Append(vnode.PushConvertedValue(Context, typeref, new ICustomAttributeProvider[] { typedef },
-						node.PushServiceProvider(Context), false, true));
+						(requiredServices) => node.PushServiceProvider(Context, requiredServices),
+						false, true));
 					Context.IL.Emit(OpCodes.Stloc, vardef);
 				}
 				else if (node.CollectionItems.Count == 1 && (vnode = node.CollectionItems.First() as ValueNode) != null &&
@@ -309,7 +310,8 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 					foreach (var instruction in vnode.PushConvertedValue(Context,
 						parameter.ParameterType,
 						new ICustomAttributeProvider[] { parameter, parameter.ParameterType.ResolveCached(Context.Cache) },
-						enode.PushServiceProvider(Context), false, true))
+						(requiredServices) => enode.PushServiceProvider(Context, requiredServices),
+						false, true))
 						yield return instruction;
 				}
 			}
@@ -346,7 +348,8 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 					foreach (var instruction in vnode.PushConvertedValue(Context,
 						parameter.ParameterType,
 						new ICustomAttributeProvider[] { parameter, parameter.ParameterType.ResolveCached(Context.Cache) },
-						enode.PushServiceProvider(Context), false, true))
+						(requiredServices) => enode.PushServiceProvider(Context, requiredServices),
+						false, true))
 						yield return instruction;
 				}
 			}

--- a/src/Controls/src/Build.Tasks/ErrorMessages.Designer.cs
+++ b/src/Controls/src/Build.Tasks/ErrorMessages.Designer.cs
@@ -382,6 +382,15 @@ namespace Microsoft.Maui.Controls.Build.Tasks {
             get {
                 return ResourceManager.GetString("XStaticSyntax", resourceCulture);
             }
+        }        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Consider attributing the markup extension with [AcceptEmptyServiceProvider] or [RequireService]..
+        /// </summary>
+        internal static string UnattributedMarkupType {
+            get {
+                return ResourceManager.GetString("UnattributedMarkupType", resourceCulture);
+            }
         }
 
         /// <summary>

--- a/src/Controls/src/Build.Tasks/ErrorMessages.resx
+++ b/src/Controls/src/Build.Tasks/ErrorMessages.resx
@@ -243,6 +243,11 @@
   <data name="XDataTypeSyntax" xml:space="preserve">
     <value>x:DataType expects a string literal, an {{x:Type}} markup or {{x:Nul}l}.</value>
   </data>
+  <data name="UnattributedMarkupType" xml:space="preserve">
+    <value>Consider attributing the markup extension "{0}" with [RequireService] or [AcceptEmptyServiceProvider] if it doesn't require any.</value>
+    <comment>0 is type name</comment>
+  </data>
+
   <data name="XmlnsUndeclared" xml:space="preserve">
     <value>Undeclared xmlns prefix "{0}".</value>
     <comment>0 is the xmlns prefix</comment>

--- a/src/Controls/src/Build.Tasks/NodeILExtensions.cs
+++ b/src/Controls/src/Build.Tasks/NodeILExtensions.cs
@@ -98,7 +98,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 
 		public static IEnumerable<Instruction> PushConvertedValue(this ValueNode node, ILContext context,
 			TypeReference targetTypeRef, IEnumerable<ICustomAttributeProvider> attributeProviders,
-			IEnumerable<Instruction> pushServiceProvider, bool boxValueTypes, bool unboxValueTypes)
+			Func<TypeReference[],IEnumerable<Instruction>> pushServiceProvider, bool boxValueTypes, bool unboxValueTypes)
 		{
 			TypeReference typeConverter = null;
 			foreach (var attributeProvider in attributeProviders)
@@ -119,7 +119,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 		}
 
 		public static IEnumerable<Instruction> PushConvertedValue(this ValueNode node, ILContext context, FieldReference bpRef,
-			IEnumerable<Instruction> pushServiceProvider, bool boxValueTypes, bool unboxValueTypes)
+			Func<TypeReference[],IEnumerable<Instruction>> pushServiceProvider, bool boxValueTypes, bool unboxValueTypes)
 		{
 			var module = context.Body.Method.Module;
 			var targetTypeRef = bpRef.GetBindablePropertyType(context.Cache, node, module);
@@ -142,7 +142,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 		}
 
 		public static IEnumerable<Instruction> PushConvertedValue(this ValueNode node, ILContext context,
-			TypeReference targetTypeRef, TypeReference typeConverter, IEnumerable<Instruction> pushServiceProvider,
+			TypeReference targetTypeRef, TypeReference typeConverter, Func<TypeReference[],IEnumerable<Instruction>> pushServiceProvider,
 			bool boxValueTypes, bool unboxValueTypes)
 		{
 			var module = context.Body.Method.Module;
@@ -197,7 +197,10 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 
 				if (isExtendedConverter)
 				{
-					foreach (var instruction in pushServiceProvider)
+					var requireServiceAttribute = typeConverter.GetCustomAttribute(context.Cache, module, ("Microsoft.Maui.Controls", "Microsoft.Maui.Controls.Xaml", "RequireServiceAttribute"));
+					var requiredServiceType = (requireServiceAttribute?.ConstructorArguments[0].Value as CustomAttributeArgument[])?.Select(ca => ca.Value as TypeReference).ToArray();
+
+					foreach (var instruction in pushServiceProvider(requiredServiceType))
 						yield return instruction;
 				}
 
@@ -583,14 +586,12 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 			}
 		}
 
-		public static IEnumerable<Instruction> PushServiceProvider(this INode node, ILContext context, FieldReference bpRef = null, PropertyReference propertyRef = null, TypeReference declaringTypeReference = null)
+		public static IEnumerable<Instruction> PushServiceProvider(this INode node, ILContext context, TypeReference[] requiredServices, FieldReference bpRef = null, PropertyReference propertyRef = null, TypeReference declaringTypeReference = null)
 		{
 			var module = context.Body.Method.Module;
 
-#if NOSERVICEPROVIDER
-			yield return Instruction.Create (OpCodes.Ldnull);
-			yield break;
-#endif
+			var createAllServices = requiredServices is null;
+			var alreadyContainsProvideValueTarget = false;
 
 			var addService = module.ImportMethodReference(context.Cache, ("Microsoft.Maui.Controls.Xaml", "Microsoft.Maui.Controls.Xaml.Internals", "XamlServiceProvider"),
 														  methodName: "Add",
@@ -601,43 +602,69 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 
 			yield return Create(Newobj, module.ImportCtorReference(context.Cache, ("Microsoft.Maui.Controls.Xaml", "Microsoft.Maui.Controls.Xaml.Internals", "XamlServiceProvider"), parameterTypes: null));
 
-			//Add a SimpleValueTargetProvider and register it as IProvideValueTarget and IReferenceProvider
-			var pushParentIl = node.PushParentObjectsArray(context).ToList();
-			if (pushParentIl[pushParentIl.Count - 1].OpCode != Ldnull)
+			//Add a SimpleValueTargetProvider and register it as IProvideValueTarget, IReferenceProvider and IProvideParentValues
+			if (   createAllServices
+				|| requiredServices.Contains(module.ImportReference(context.Cache, ("Microsoft.Maui.Controls", "Microsoft.Maui.Controls.Xaml", "IProvideParentValues")), TypeRefComparer.Default)
+				|| requiredServices.Contains(module.ImportReference(context.Cache, ("Microsoft.Maui.Controls", "Microsoft.Maui.Controls.Xaml", "IReferenceProvider")), TypeRefComparer.Default))
+			{
+				alreadyContainsProvideValueTarget = true;
+				var pushParentIl = node.PushParentObjectsArray(context).ToList();
+				if (pushParentIl[pushParentIl.Count - 1].OpCode != Ldnull)
+				{
+					yield return Create(Dup); //Keep the serviceProvider on the stack
+					yield return Create(Ldtoken, module.ImportReference(context.Cache, ("Microsoft.Maui.Controls", "Microsoft.Maui.Controls.Xaml", "IProvideValueTarget")));
+					yield return Create(Call, module.ImportMethodReference(context.Cache, ("mscorlib", "System", "Type"), methodName: "GetTypeFromHandle", parameterTypes: new[] { ("mscorlib", "System", "RuntimeTypeHandle") }, isStatic: true));
+
+					foreach (var instruction in pushParentIl)
+						yield return instruction;
+
+					foreach (var instruction in PushTargetProperty(context, bpRef, propertyRef, declaringTypeReference, module))
+						yield return instruction;
+
+					foreach (var instruction in PushNamescopes(node, context, module))
+						yield return instruction;
+
+					yield return Create(Ldc_I4_0); //don't ask
+					yield return Create(Newobj, module.ImportCtorReference(context.Cache,
+						("Microsoft.Maui.Controls.Xaml", "Microsoft.Maui.Controls.Xaml.Internals", "SimpleValueTargetProvider"), paramCount: 4));
+
+					//store the provider so we can register it again with a different key
+					yield return Create(Dup);
+					var refProvider = new VariableDefinition(module.ImportReference(context.Cache, ("mscorlib", "System", "Object")));
+					context.Body.Variables.Add(refProvider);
+					yield return Create(Stloc, refProvider);
+					yield return Create(Callvirt, addService);
+
+					yield return Create(Dup); //Keep the serviceProvider on the stack
+					yield return Create(Ldtoken, module.ImportReference(context.Cache, ("Microsoft.Maui.Controls", "Microsoft.Maui.Controls.Xaml", "IReferenceProvider")));
+					yield return Create(Call, module.ImportMethodReference(context.Cache, ("mscorlib", "System", "Type"), methodName: "GetTypeFromHandle", parameterTypes: new[] { ("mscorlib", "System", "RuntimeTypeHandle") }, isStatic: true));
+					yield return Create(Ldloc, refProvider);
+					yield return Create(Callvirt, addService);
+				}
+			}
+
+			//Add an even simpler ValueTargetProvider and register it as IProvideValueTarget
+			if (!alreadyContainsProvideValueTarget && requiredServices.Contains(module.ImportReference(context.Cache, ("Microsoft.Maui.Controls", "Microsoft.Maui.Controls.Xaml", "IProvideValueTarget")), TypeRefComparer.Default))
 			{
 				yield return Create(Dup); //Keep the serviceProvider on the stack
 				yield return Create(Ldtoken, module.ImportReference(context.Cache, ("Microsoft.Maui.Controls", "Microsoft.Maui.Controls.Xaml", "IProvideValueTarget")));
 				yield return Create(Call, module.ImportMethodReference(context.Cache, ("mscorlib", "System", "Type"), methodName: "GetTypeFromHandle", parameterTypes: new[] { ("mscorlib", "System", "RuntimeTypeHandle") }, isStatic: true));
 
-				foreach (var instruction in pushParentIl)
-					yield return instruction;
-
+				if (node.Parent is IElementNode elementNode)
+					foreach (var instruction in context.Variables[elementNode].LoadAs(context.Cache, module.TypeSystem.Object, module))
+						yield return instruction;
+				else
+					yield return Create(Ldnull);
+				
 				foreach (var instruction in PushTargetProperty(context, bpRef, propertyRef, declaringTypeReference, module))
 					yield return instruction;
 
-				foreach (var instruction in PushNamescopes(node, context, module))
-					yield return instruction;
-
-				yield return Create(Ldc_I4_0); //don't ask
-				yield return Create(Newobj, module.ImportCtorReference(context.Cache,
-					("Microsoft.Maui.Controls.Xaml", "Microsoft.Maui.Controls.Xaml.Internals", "SimpleValueTargetProvider"), paramCount: 4));
-
-				//store the provider so we can register it again with a different key
-				yield return Create(Dup);
-				var refProvider = new VariableDefinition(module.ImportReference(context.Cache, ("mscorlib", "System", "Object")));
-				context.Body.Variables.Add(refProvider);
-				yield return Create(Stloc, refProvider);
-				yield return Create(Callvirt, addService);
-
-				yield return Create(Dup); //Keep the serviceProvider on the stack
-				yield return Create(Ldtoken, module.ImportReference(context.Cache, ("Microsoft.Maui.Controls", "Microsoft.Maui.Controls.Xaml", "IReferenceProvider")));
-				yield return Create(Call, module.ImportMethodReference(context.Cache, ("mscorlib", "System", "Type"), methodName: "GetTypeFromHandle", parameterTypes: new[] { ("mscorlib", "System", "RuntimeTypeHandle") }, isStatic: true));
-				yield return Create(Ldloc, refProvider);
+				yield return Create(Newobj, module.ImportCtorReference(context.Cache, ("Microsoft.Maui.Controls.Xaml", "Microsoft.Maui.Controls.Xaml.Internals", "ValueTargetProvider"), paramCount: 2));
 				yield return Create(Callvirt, addService);
 			}
 
-			//Add a XamlTypeResolver
-			if (node.NamespaceResolver != null)
+			//Add a IXamlTypeResolver
+			if (node.NamespaceResolver != null && createAllServices || requiredServices.Contains(module.ImportReference(context.Cache, ("Microsoft.Maui.Controls", "Microsoft.Maui.Controls.Xaml", "IXamlTypeResolver")), TypeRefComparer.Default))
 			{
 				yield return Create(Dup); //Duplicate the serviceProvider
 				yield return Create(Ldtoken, module.ImportReference(context.Cache, ("Microsoft.Maui.Controls", "Microsoft.Maui.Controls.Xaml", "IXamlTypeResolver")));
@@ -662,7 +689,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 				yield return Create(Callvirt, addService);
 			}
 
-			if (node is IXmlLineInfo)
+			if (node is IXmlLineInfo && createAllServices || requiredServices.Contains(module.ImportReference(context.Cache, ("Microsoft.Maui.Controls", "Microsoft.Maui.Controls.Xaml", "IXmlLineInfoProvider")), TypeRefComparer.Default))
 			{
 				yield return Create(Dup); //Duplicate the serviceProvider
 				yield return Create(Ldtoken, module.ImportReference(context.Cache, ("Microsoft.Maui.Controls", "Microsoft.Maui.Controls.Xaml", "IXmlLineInfoProvider")));
@@ -672,6 +699,8 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 				yield return Create(Newobj, module.ImportCtorReference(context.Cache, ("Microsoft.Maui.Controls.Xaml", "Microsoft.Maui.Controls.Xaml.Internals", "XmlLineInfoProvider"), parameterTypes: new[] { ("System.Xml.ReaderWriter", "System.Xml", "IXmlLineInfo") }));
 				yield return Create(Callvirt, addService);
 			}
+
+			//and... we end up with the serviceProvider on the stack, as expected
 		}
 	}
 }

--- a/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
+++ b/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
@@ -15,15 +15,15 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 {
 	class SetPropertiesVisitor : IXamlNodeVisitor
 	{
-		static readonly IList<XmlName> skips = new List<XmlName>
-		{
+		static readonly IList<XmlName> skips =
+		[
 			XmlName.xKey,
 			XmlName.xTypeArguments,
 			XmlName.xArguments,
 			XmlName.xFactoryMethod,
 			XmlName.xName,
 			XmlName.xDataType
-		};
+		];
 
 		public SetPropertiesVisitor(ILContext context, bool stopOnResourceDictionary = false)
 		{
@@ -51,8 +51,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 		public void Visit(ValueNode node, INode parentNode)
 		{
 			//TODO support Label text as element
-			XmlName propertyName;
-			if (!TryGetPropertyName(node, parentNode, out propertyName))
+			if (!TryGetPropertyName(node, parentNode, out XmlName propertyName))
 			{
 				if (!IsCollectionItem(node, parentNode))
 					return;
@@ -275,8 +274,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 					vardefref.VariableDefinition = new VariableDefinition(module.ImportReference(genericArguments.First()));
 				foreach (var instruction in context.Variables[node].LoadAs(context.Cache, markupExtension, module))
 					yield return instruction;
-				foreach (var instruction in node.PushServiceProvider(context, bpRef, propertyRef, propertyDeclaringTypeRef))
-					yield return instruction;
+				yield return Instruction.Create(OpCodes.Ldnull); //ArrayExtension does not require ServiceProvider
 				yield return Instruction.Create(OpCodes.Callvirt, provideValue);
 
 				if (arrayTypeRef != null)
@@ -287,6 +285,12 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 				out markupExtension, out genericArguments))
 			{
 				var acceptEmptyServiceProvider = vardefref.VariableDefinition.VariableType.GetCustomAttribute(context.Cache, module, ("Microsoft.Maui.Controls", "Microsoft.Maui.Controls.Xaml", "AcceptEmptyServiceProviderAttribute")) != null;
+				var requireServiceAttribute = vardefref.VariableDefinition.VariableType.GetCustomAttribute(context.Cache, module, ("Microsoft.Maui.Controls", "Microsoft.Maui.Controls.Xaml", "RequireServiceAttribute"));
+				var requiredServiceType = (requireServiceAttribute?.ConstructorArguments[0].Value as CustomAttributeArgument[])?.Select(ca => ca.Value as TypeReference).ToArray();
+
+				if (!acceptEmptyServiceProvider && requireServiceAttribute == null)
+					context.LoggingHelper.LogWarningOrError(BuildExceptionCode.UnattributedMarkupType, context.XamlFilePath, node.LineNumber, node.LinePosition, 0, 0, vardefref.VariableDefinition.VariableType);
+
 				if (vardefref.VariableDefinition.VariableType.FullName == "Microsoft.Maui.Controls.Xaml.BindingExtension"
 					&& (node.Properties == null || !node.Properties.ContainsKey(new XmlName("", "Source"))) //do not compile bindings if Source is set
 					&& bpRef != null //do not compile bindings if we're not gonna SetBinding
@@ -304,9 +308,9 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 				foreach (var instruction in context.Variables[node].LoadAs(context.Cache, markupExtension, module))
 					yield return instruction;
 				if (acceptEmptyServiceProvider)
-					yield return Instruction.Create(OpCodes.Ldnull);
+					yield return Create(Ldnull);
 				else
-					foreach (var instruction in node.PushServiceProvider(context, bpRef, propertyRef, propertyDeclaringTypeRef))
+					foreach (var instruction in node.PushServiceProvider(context, requiredServiceType, bpRef, propertyRef, propertyDeclaringTypeRef))
 						yield return instruction;
 				yield return Instruction.Create(OpCodes.Callvirt, provideValue);
 				yield return Instruction.Create(OpCodes.Stloc, vardefref.VariableDefinition);
@@ -314,6 +318,12 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 			else if (context.Variables[node].VariableType.ImplementsInterface(context.Cache, module.ImportReference(context.Cache, ("Microsoft.Maui.Controls", "Microsoft.Maui.Controls.Xaml", "IMarkupExtension"))))
 			{
 				var acceptEmptyServiceProvider = context.Variables[node].VariableType.GetCustomAttribute(context.Cache, module, ("Microsoft.Maui.Controls", "Microsoft.Maui.Controls.Xaml", "AcceptEmptyServiceProviderAttribute")) != null;
+				var requireServiceAttribute = vardefref.VariableDefinition.VariableType.GetCustomAttribute(context.Cache, module, ("Microsoft.Maui.Controls", "Microsoft.Maui.Controls.Xaml", "RequireServiceAttribute"));
+				var requiredServiceType = (requireServiceAttribute?.ConstructorArguments[0].Value as CustomAttributeArgument[])?.Select(ca => ca.Value as TypeReference).ToArray();
+
+				if (!acceptEmptyServiceProvider && requireServiceAttribute == null)
+					context.LoggingHelper.LogWarningOrError(BuildExceptionCode.UnattributedMarkupType, context.XamlFilePath, node.LineNumber, node.LinePosition, 0, 0, vardefref.VariableDefinition.VariableType);
+
 				var markupExtensionType = ("Microsoft.Maui.Controls", "Microsoft.Maui.Controls.Xaml", "IMarkupExtension");
 				vardefref.VariableDefinition = new VariableDefinition(module.TypeSystem.Object);
 				foreach (var instruction in context.Variables[node].LoadAs(context.Cache, module.GetTypeDefinition(context.Cache, markupExtensionType), module))
@@ -321,7 +331,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 				if (acceptEmptyServiceProvider)
 					yield return Create(Ldnull);
 				else
-					foreach (var instruction in node.PushServiceProvider(context, bpRef, propertyRef, propertyDeclaringTypeRef))
+					foreach (var instruction in node.PushServiceProvider(context, requiredServiceType, bpRef, propertyRef, propertyDeclaringTypeRef))
 						yield return instruction;
 				yield return Create(Callvirt, module.ImportMethodReference(context.Cache,
 																		   markupExtensionType,
@@ -332,6 +342,12 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 			else if (context.Variables[node].VariableType.ImplementsInterface(context.Cache, module.ImportReference(context.Cache, ("Microsoft.Maui.Controls", "Microsoft.Maui.Controls.Xaml", "IValueProvider"))))
 			{
 				var acceptEmptyServiceProvider = context.Variables[node].VariableType.GetCustomAttribute(context.Cache, module, ("Microsoft.Maui.Controls", "Microsoft.Maui.Controls.Xaml", "AcceptEmptyServiceProviderAttribute")) != null;
+				var requireServiceAttribute = vardefref.VariableDefinition.VariableType.GetCustomAttribute(context.Cache, module, ("Microsoft.Maui.Controls", "Microsoft.Maui.Controls.Xaml", "RequireServiceAttribute"));
+				var requiredServiceType = (requireServiceAttribute?.ConstructorArguments[0].Value as CustomAttributeArgument[])?.Select(ca => ca.Value as TypeReference).ToArray();
+
+				if (!acceptEmptyServiceProvider && requireServiceAttribute == null)
+					context.LoggingHelper.LogWarningOrError(BuildExceptionCode.UnattributedMarkupType, context.XamlFilePath, node.LineNumber, node.LinePosition, 0, 0, vardefref.VariableDefinition.VariableType);
+
 				var valueProviderType = context.Variables[node].VariableType;
 				//If the IValueProvider has a ProvideCompiledAttribute that can be resolved, shortcut this
 				var compiledValueProviderName = valueProviderType?.GetCustomAttribute(context.Cache, module, ("Microsoft.Maui.Controls", "Microsoft.Maui.Controls.Xaml", "ProvideCompiledAttribute"))?.ConstructorArguments?[0].Value as string;
@@ -357,7 +373,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 				if (acceptEmptyServiceProvider)
 					yield return Create(Ldnull);
 				else
-					foreach (var instruction in node.PushServiceProvider(context, bpRef, propertyRef, propertyDeclaringTypeRef))
+					foreach (var instruction in node.PushServiceProvider(context, requiredServiceType, bpRef, propertyRef, propertyDeclaringTypeRef))
 						yield return instruction;
 				yield return Create(Callvirt, module.ImportMethodReference(context.Cache,
 																		   valueProviderInterface,
@@ -1253,7 +1269,8 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 
 			if (valueNode != null)
 			{
-				foreach (var instruction in valueNode.PushConvertedValue(context, bpRef, valueNode.PushServiceProvider(context, bpRef: bpRef), true, false))
+				//FIXME which services are required here ?
+				foreach (var instruction in valueNode.PushConvertedValue(context, bpRef, (requiredServices) => valueNode.PushServiceProvider(context, requiredServices, bpRef: bpRef), true, false))
 					yield return instruction;
 			}
 			else if (elementNode != null)
@@ -1384,7 +1401,8 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 
 			if (valueNode != null)
 			{
-				foreach (var instruction in valueNode.PushConvertedValue(context, propertyType, new ICustomAttributeProvider[] { property, propertyType.ResolveCached(context.Cache) }, valueNode.PushServiceProvider(context, propertyRef: property), false, true))
+				//FIXME which services are required here ?
+				foreach (var instruction in valueNode.PushConvertedValue(context, propertyType, new ICustomAttributeProvider[] { property, propertyType.ResolveCached(context.Cache) }, (requiredServices) => valueNode.PushServiceProvider(context, requiredServices, propertyRef: property), false, true))
 					yield return instruction;
 				if (parent.VariableType.IsValueType)
 					yield return Instruction.Create(OpCodes.Call, propertySetterRef);

--- a/src/Controls/src/Core/IMarkupExtension.cs
+++ b/src/Controls/src/Core/IMarkupExtension.cs
@@ -18,4 +18,14 @@ namespace Microsoft.Maui.Controls.Xaml
 	public sealed class AcceptEmptyServiceProviderAttribute : Attribute
 	{
 	}
+
+	[AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
+	public sealed class RequireServiceAttribute : Attribute
+	{
+		public RequireServiceAttribute(Type[] serviceTypes)
+		{
+			ServiceTypes = serviceTypes;
+		}
+		public Type[] ServiceTypes { get; }
+	}
 }

--- a/src/Controls/src/Core/LegacyLayouts/ConstraintExpression.cs
+++ b/src/Controls/src/Core/LegacyLayouts/ConstraintExpression.cs
@@ -8,6 +8,7 @@ using Microsoft.Maui.Controls.Xaml;
 
 namespace Microsoft.Maui.Controls.Compatibility
 {
+	[RequireService([typeof(IReferenceProvider), typeof(IProvideValueTarget)])]
 	public class ConstraintExpression : IMarkupExtension<Constraint>
 	{
 		public ConstraintExpression()

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -238,3 +238,6 @@ Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTapped.set -> void
 *REMOVED*Microsoft.Maui.Controls.Entry.FontSize.set -> void
 *REMOVED*Microsoft.Maui.Controls.Entry.SelectionLength.get -> int
 *REMOVED*Microsoft.Maui.Controls.Entry.SelectionLength.set -> void
+Microsoft.Maui.Controls.Xaml.RequireServiceAttribute
+~Microsoft.Maui.Controls.Xaml.RequireServiceAttribute.RequireServiceAttribute(System.Type[] serviceTypes) -> void
+~Microsoft.Maui.Controls.Xaml.RequireServiceAttribute.ServiceTypes.get -> System.Type[]

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -250,3 +250,6 @@ Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTapped.set -> void
 *REMOVED*Microsoft.Maui.Controls.Entry.FontSize.set -> void
 *REMOVED*Microsoft.Maui.Controls.Entry.SelectionLength.get -> int
 *REMOVED*Microsoft.Maui.Controls.Entry.SelectionLength.set -> void
+Microsoft.Maui.Controls.Xaml.RequireServiceAttribute
+~Microsoft.Maui.Controls.Xaml.RequireServiceAttribute.RequireServiceAttribute(System.Type[] serviceTypes) -> void
+~Microsoft.Maui.Controls.Xaml.RequireServiceAttribute.ServiceTypes.get -> System.Type[]

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -254,3 +254,6 @@ Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTapped.set -> void
 *REMOVED*Microsoft.Maui.Controls.Entry.SelectionLength.get -> int
 *REMOVED*Microsoft.Maui.Controls.Entry.SelectionLength.set -> void
 
+Microsoft.Maui.Controls.Xaml.RequireServiceAttribute
+~Microsoft.Maui.Controls.Xaml.RequireServiceAttribute.RequireServiceAttribute(System.Type[] serviceTypes) -> void
+~Microsoft.Maui.Controls.Xaml.RequireServiceAttribute.ServiceTypes.get -> System.Type[]

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -213,3 +213,6 @@ Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTapped.set -> void
 *REMOVED*Microsoft.Maui.Controls.Entry.FontSize.set -> void
 *REMOVED*Microsoft.Maui.Controls.Entry.SelectionLength.get -> int
 *REMOVED*Microsoft.Maui.Controls.Entry.SelectionLength.set -> void
+Microsoft.Maui.Controls.Xaml.RequireServiceAttribute
+~Microsoft.Maui.Controls.Xaml.RequireServiceAttribute.RequireServiceAttribute(System.Type[] serviceTypes) -> void
+~Microsoft.Maui.Controls.Xaml.RequireServiceAttribute.ServiceTypes.get -> System.Type[]

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -245,3 +245,6 @@ Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTapped.set -> void
 *REMOVED*Microsoft.Maui.Controls.Entry.FontSize.set -> void
 *REMOVED*Microsoft.Maui.Controls.Entry.SelectionLength.get -> int
 *REMOVED*Microsoft.Maui.Controls.Entry.SelectionLength.set -> void
+Microsoft.Maui.Controls.Xaml.RequireServiceAttribute
+~Microsoft.Maui.Controls.Xaml.RequireServiceAttribute.RequireServiceAttribute(System.Type[] serviceTypes) -> void
+~Microsoft.Maui.Controls.Xaml.RequireServiceAttribute.ServiceTypes.get -> System.Type[]

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -207,3 +207,6 @@ Microsoft.Maui.Controls.PlatformPointerEventArgs
 *REMOVED*Microsoft.Maui.Controls.Entry.FontSize.set -> void
 *REMOVED*Microsoft.Maui.Controls.Entry.SelectionLength.get -> int
 *REMOVED*Microsoft.Maui.Controls.Entry.SelectionLength.set -> void
+Microsoft.Maui.Controls.Xaml.RequireServiceAttribute
+~Microsoft.Maui.Controls.Xaml.RequireServiceAttribute.RequireServiceAttribute(System.Type[] serviceTypes) -> void
+~Microsoft.Maui.Controls.Xaml.RequireServiceAttribute.ServiceTypes.get -> System.Type[]

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -128,6 +128,9 @@ override Microsoft.Maui.Controls.SearchBar.IsEnabledCore.get -> bool
 ~Microsoft.Maui.Controls.Shell.GoToAsync(Microsoft.Maui.Controls.ShellNavigationState state, Microsoft.Maui.Controls.ShellNavigationQueryParameters shellNavigationQueryParameters) -> System.Threading.Tasks.Task
 ~Microsoft.Maui.Controls.WebView.UserAgent.get -> string
 ~Microsoft.Maui.Controls.WebView.UserAgent.set -> void
+Microsoft.Maui.Controls.Xaml.RequireServiceAttribute
+~Microsoft.Maui.Controls.Xaml.RequireServiceAttribute.RequireServiceAttribute(System.Type[] serviceTypes) -> void
+~Microsoft.Maui.Controls.Xaml.RequireServiceAttribute.ServiceTypes.get -> System.Type[]
 ~override Microsoft.Maui.Controls.ImageButton.OnPropertyChanged(string propertyName = null) -> void
 ~override Microsoft.Maui.Controls.LayoutOptions.Equals(object obj) -> bool
 ~override Microsoft.Maui.Controls.Region.Equals(object obj) -> bool

--- a/src/Controls/src/Core/ReferenceTypeConverter.cs
+++ b/src/Controls/src/Core/ReferenceTypeConverter.cs
@@ -10,6 +10,7 @@ using Microsoft.Maui.Controls.Xaml.Internals;
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/ReferenceTypeConverter.xml" path="Type[@FullName='Microsoft.Maui.Controls.ReferenceTypeConverter']/Docs/*" />
+	[RequireService([typeof(IReferenceProvider), typeof(IProvideParentValues)])]
 	public sealed class ReferenceTypeConverter : TypeConverter, IExtendedTypeConverter
 	{
 

--- a/src/Controls/src/Core/Setter.cs
+++ b/src/Controls/src/Core/Setter.cs
@@ -11,6 +11,9 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../docs/Microsoft.Maui.Controls/Setter.xml" path="Type[@FullName='Microsoft.Maui.Controls.Setter']/Docs/*" />
 	[ContentProperty(nameof(Value))]
 	[ProvideCompiled("Microsoft.Maui.Controls.XamlC.SetterValueProvider")]
+	[RequireService(
+		[typeof(IValueConverterProvider),
+		 typeof(IXmlLineInfoProvider)])]
 	public sealed class Setter : IValueProvider
 	{
 		/// <include file="../../docs/Microsoft.Maui.Controls/Setter.xml" path="//Member[@MemberName='TargetName']/Docs/*" />

--- a/src/Controls/src/Xaml/MarkupExtensions/AppThemeBindingExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/AppThemeBindingExtension.cs
@@ -6,6 +6,11 @@ using Microsoft.Extensions.DependencyInjection;
 namespace Microsoft.Maui.Controls.Xaml
 {
 	[ContentProperty(nameof(Default))]
+		[RequireService(
+		[typeof(IProvideValueTarget),
+		 typeof(IValueConverterProvider),
+		 typeof(IXmlLineInfoProvider),
+		 typeof(IConverterOptions)])]
 	public class AppThemeBindingExtension : IMarkupExtension<BindingBase>
 	{
 		object _default;

--- a/src/Controls/src/Xaml/MarkupExtensions/DynamicResourceExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/DynamicResourceExtension.cs
@@ -4,6 +4,7 @@ using Microsoft.Maui.Controls.Internals;
 namespace Microsoft.Maui.Controls.Xaml
 {
 	[ContentProperty(nameof(Key))]
+	[RequireService([typeof(IXmlLineInfoProvider)])]
 	public sealed class DynamicResourceExtension : IMarkupExtension<DynamicResource>
 	{
 		public string Key { get; set; }

--- a/src/Controls/src/Xaml/MarkupExtensions/OnIdiomExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/OnIdiomExtension.cs
@@ -8,6 +8,11 @@ using Microsoft.Maui.Devices;
 namespace Microsoft.Maui.Controls.Xaml
 {
 	[ContentProperty(nameof(Default))]
+	[RequireService(
+		[typeof(IProvideValueTarget),
+		 typeof(IValueConverterProvider),
+		 typeof(IXmlLineInfoProvider),
+		 typeof(IConverterOptions)])]
 	public class OnIdiomExtension : IMarkupExtension
 	{
 		// See Device.Idiom

--- a/src/Controls/src/Xaml/MarkupExtensions/OnPlatformExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/OnPlatformExtension.cs
@@ -7,6 +7,11 @@ using Microsoft.Maui.Devices;
 namespace Microsoft.Maui.Controls.Xaml
 {
 	[ContentProperty(nameof(Default))]
+	[RequireService(
+		[typeof(IProvideValueTarget),
+		 typeof(IValueConverterProvider),
+		 typeof(IXmlLineInfoProvider),
+		 typeof(IConverterOptions)])]
 	public class OnPlatformExtension : IMarkupExtension
 	{
 		static object s_notset = new object();

--- a/src/Controls/src/Xaml/MarkupExtensions/ReferenceExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/ReferenceExtension.cs
@@ -6,6 +6,7 @@ using Microsoft.Maui.Controls.Xaml.Internals;
 namespace Microsoft.Maui.Controls.Xaml
 {
 	[ContentProperty(nameof(Name))]
+	[RequireService([typeof(IReferenceProvider), typeof(IProvideValueTarget)])]
 	public class ReferenceExtension : IMarkupExtension
 	{
 		public string Name { get; set; }

--- a/src/Controls/src/Xaml/MarkupExtensions/StaticResourceExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/StaticResourceExtension.cs
@@ -6,6 +6,7 @@ using Microsoft.Maui.Controls.Xaml.Internals;
 namespace Microsoft.Maui.Controls.Xaml
 {
 	[ContentProperty(nameof(Key))]
+	[RequireService([typeof(IXmlLineInfoProvider), typeof(IProvideParentValues)])]
 	public sealed class StaticResourceExtension : IMarkupExtension
 	{
 		public string Key { get; set; }

--- a/src/Controls/src/Xaml/MarkupExtensions/StyleSheetExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/StyleSheetExtension.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Maui.Controls.Xaml
 {
 	[ContentProperty(nameof(Style))]
 	[ProvideCompiled("Microsoft.Maui.Controls.XamlC.StyleSheetProvider")]
+	[RequireService([typeof(IXmlLineInfoProvider), typeof(IRootObjectProvider)])]
 	public sealed class StyleSheetExtension : IValueProvider
 	{
 		public string Style { get; set; }

--- a/src/Controls/src/Xaml/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Xaml/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -1,2 +1,4 @@
 #nullable enable
 ~Microsoft.Maui.Controls.Xaml.Internals.SimpleValueTargetProvider.SimpleValueTargetProvider(object[] objectAndParents, object targetProperty, Microsoft.Maui.Controls.Internals.INameScope[] scopes, bool notused) -> void
+Microsoft.Maui.Controls.Xaml.Internals.ValueTargetProvider
+Microsoft.Maui.Controls.Xaml.Internals.ValueTargetProvider.ValueTargetProvider(object! targetObject, object! targetProperty) -> void

--- a/src/Controls/src/Xaml/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Xaml/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -1,2 +1,4 @@
 #nullable enable
 ~Microsoft.Maui.Controls.Xaml.Internals.SimpleValueTargetProvider.SimpleValueTargetProvider(object[] objectAndParents, object targetProperty, Microsoft.Maui.Controls.Internals.INameScope[] scopes, bool notused) -> void
+Microsoft.Maui.Controls.Xaml.Internals.ValueTargetProvider
+Microsoft.Maui.Controls.Xaml.Internals.ValueTargetProvider.ValueTargetProvider(object! targetObject, object! targetProperty) -> void

--- a/src/Controls/src/Xaml/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Xaml/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,2 +1,4 @@
 #nullable enable
 ~Microsoft.Maui.Controls.Xaml.Internals.SimpleValueTargetProvider.SimpleValueTargetProvider(object[] objectAndParents, object targetProperty, Microsoft.Maui.Controls.Internals.INameScope[] scopes, bool notused) -> void
+Microsoft.Maui.Controls.Xaml.Internals.ValueTargetProvider
+Microsoft.Maui.Controls.Xaml.Internals.ValueTargetProvider.ValueTargetProvider(object! targetObject, object! targetProperty) -> void

--- a/src/Controls/src/Xaml/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Xaml/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -1,2 +1,4 @@
 #nullable enable
 ~Microsoft.Maui.Controls.Xaml.Internals.SimpleValueTargetProvider.SimpleValueTargetProvider(object[] objectAndParents, object targetProperty, Microsoft.Maui.Controls.Internals.INameScope[] scopes, bool notused) -> void
+Microsoft.Maui.Controls.Xaml.Internals.ValueTargetProvider
+Microsoft.Maui.Controls.Xaml.Internals.ValueTargetProvider.ValueTargetProvider(object! targetObject, object! targetProperty) -> void

--- a/src/Controls/src/Xaml/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Xaml/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -1,2 +1,4 @@
 #nullable enable
 ~Microsoft.Maui.Controls.Xaml.Internals.SimpleValueTargetProvider.SimpleValueTargetProvider(object[] objectAndParents, object targetProperty, Microsoft.Maui.Controls.Internals.INameScope[] scopes, bool notused) -> void
+Microsoft.Maui.Controls.Xaml.Internals.ValueTargetProvider
+Microsoft.Maui.Controls.Xaml.Internals.ValueTargetProvider.ValueTargetProvider(object! targetObject, object! targetProperty) -> void

--- a/src/Controls/src/Xaml/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Xaml/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -1,2 +1,4 @@
 #nullable enable
 ~Microsoft.Maui.Controls.Xaml.Internals.SimpleValueTargetProvider.SimpleValueTargetProvider(object[] objectAndParents, object targetProperty, Microsoft.Maui.Controls.Internals.INameScope[] scopes, bool notused) -> void
+Microsoft.Maui.Controls.Xaml.Internals.ValueTargetProvider
+Microsoft.Maui.Controls.Xaml.Internals.ValueTargetProvider.ValueTargetProvider(object! targetObject, object! targetProperty) -> void

--- a/src/Controls/src/Xaml/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Xaml/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -1,2 +1,4 @@
 #nullable enable
+Microsoft.Maui.Controls.Xaml.Internals.ValueTargetProvider
+Microsoft.Maui.Controls.Xaml.Internals.ValueTargetProvider.ValueTargetProvider(object! targetObject, object! targetProperty) -> void
 ~Microsoft.Maui.Controls.Xaml.Internals.SimpleValueTargetProvider.SimpleValueTargetProvider(object[] objectAndParents, object targetProperty, Microsoft.Maui.Controls.Internals.INameScope[] scopes, bool notused) -> void

--- a/src/Controls/src/Xaml/XamlServiceProvider.cs
+++ b/src/Controls/src/Xaml/XamlServiceProvider.cs
@@ -11,6 +11,8 @@ namespace Microsoft.Maui.Controls.Xaml.Internals
 	{
 		readonly Dictionary<Type, object> services = new Dictionary<Type, object>();
 
+		static IValueConverterProvider defaultValueConverterProvider = new ValueConverterProvider();
+
 		internal XamlServiceProvider(INode node, HydrationContext context)
 		{
 			if (context != null && node != null && node.Parent != null && context.Values.TryGetValue(node.Parent, out object targetObject))
@@ -26,10 +28,10 @@ namespace Microsoft.Maui.Controls.Xaml.Internals
 			if (node is IXmlLineInfo xmlLineInfo)
 				IXmlLineInfoProvider = new XmlLineInfoProvider(xmlLineInfo);
 
-			IValueConverterProvider = new ValueConverterProvider();
+			IValueConverterProvider = defaultValueConverterProvider;
 		}
 
-		public XamlServiceProvider() => IValueConverterProvider = new ValueConverterProvider();
+		public XamlServiceProvider() => IValueConverterProvider = defaultValueConverterProvider;
 
 		internal IProvideValueTarget IProvideValueTarget
 		{
@@ -107,6 +109,22 @@ namespace Microsoft.Maui.Controls.Xaml.Internals
 			}
 		}
 	}
+
+#nullable enable
+	public class ValueTargetProvider : IProvideValueTarget
+	{
+		private object targetObject;
+		private object targetProperty;
+
+		public ValueTargetProvider(object targetObject, object targetProperty)
+		{
+			this.targetObject = targetObject;
+			this.targetProperty = targetProperty;
+		}
+		object IProvideValueTarget.TargetObject => targetObject;
+		object IProvideValueTarget.TargetProperty => targetProperty;
+	}
+#nullable restore
 
 	public class SimpleValueTargetProvider : IProvideParentValues, IProvideValueTarget, IReferenceProvider
 	{

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Bz34037.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Bz34037.xaml.cs
@@ -6,6 +6,7 @@ using NUnit.Framework;
 
 namespace Microsoft.Maui.Controls.Xaml.UnitTests
 {
+	[AcceptEmptyServiceProvider]
 	public class Bz34037Converter0 : IValueConverter, IMarkupExtension
 	{
 		public static int Invoked { get; set; }
@@ -27,7 +28,7 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 			return new Bz34037Converter0();
 		}
 	}
-
+	[AcceptEmptyServiceProvider]
 	public class Bz34037Converter1 : IValueConverter, IMarkupExtension
 	{
 		public static int Invoked { get; set; }

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Bz53275.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Bz53275.xaml.cs
@@ -5,6 +5,7 @@ using NUnit.Framework;
 
 namespace Microsoft.Maui.Controls.Xaml.UnitTests
 {
+	[RequireService([typeof(IProvideValueTarget)])]
 	public class TargetPropertyExtension : IMarkupExtension
 	{
 		public object ProvideValue(IServiceProvider serviceProvider)

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Gh2171.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Gh2171.xaml.cs
@@ -32,6 +32,7 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		}
 	}
 
+	[AcceptEmptyServiceProvider]
 	public class Gh2171Extension : IMarkupExtension
 	{
 		public string Foo { get; set; }

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Gh4760.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Gh4760.xaml.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		  ProvideValue(serviceProvider);
 	}
 
+	[AcceptEmptyServiceProvider]
 	public class Gh4760MultiplyExtension : Gh4760Base<double>
 	{
 		public double Base { get; set; }

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Gh9212.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Gh9212.xaml.cs
@@ -9,6 +9,7 @@ using NUnit.Framework;
 namespace Microsoft.Maui.Controls.Xaml.UnitTests
 {
 	[ContentProperty(nameof(Text))]
+	[AcceptEmptyServiceProvider]
 	public class Gh9212MarkupExtension : IMarkupExtension
 	{
 		public string Text { get; set; }

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Unreported005.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Unreported005.xaml.cs
@@ -5,7 +5,8 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 {
 	using Constraint = Microsoft.Maui.Controls.Compatibility.Constraint;
 	using RelativeLayout = Microsoft.Maui.Controls.Compatibility.RelativeLayout;
-
+	
+	[RequireService([typeof(IReferenceProvider), typeof(IProvideValueTarget)])]
 	public abstract class Unreported005RelativeToView : IMarkupExtension
 	{
 		protected Unreported005RelativeToView()

--- a/src/Controls/tests/Xaml.UnitTests/MarkupExtensionTests.cs
+++ b/src/Controls/tests/Xaml.UnitTests/MarkupExtensionTests.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		}
 	}
 
+	[AcceptEmptyServiceProvider]
 	public class AppendMarkupExtension : IMarkupExtension
 	{
 		public object Value0 { get; set; }

--- a/src/Controls/tests/Xaml.UnitTests/ServiceProviderTests.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/ServiceProviderTests.xaml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage 
+	xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+	xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests"
+	x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.ServiceProviderTests">
+    <StackLayout>
+        <Label x:Name="label0" Text="{local:SPMarkup0}"/>
+        <Label x:Name="label1" Text="{local:SPMarkup1}"/>
+        <Label x:Name="label2" Text="{local:SPMarkup2}"/>
+        <Label x:Name="label3" Text="{local:SPMarkup3}"/>
+    </StackLayout>
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/ServiceProviderTests.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/ServiceProviderTests.xaml.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Maui.Controls.Core.UnitTests;
+using Microsoft.Maui.Dispatching;
+using Microsoft.Maui.Graphics;
+using Microsoft.Maui.UnitTests;
+using NUnit.Framework;
+using AbsoluteLayoutFlags = Microsoft.Maui.Layouts.AbsoluteLayoutFlags;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public class MarkupExtensionBase : IMarkupExtension
+{
+	public object ProvideValue(IServiceProvider serviceProvider)
+	{
+        if (serviceProvider == null)
+            return null;
+        var services = new List<string> ();
+        if (serviceProvider.GetService(typeof(IProvideValueTarget)) != null)
+            services.Add("IProvideValueTarget");
+        if (serviceProvider.GetService(typeof(IXamlTypeResolver)) != null)          
+            services.Add("IXamlTypeResolver"); 
+        if (serviceProvider.GetService(typeof(IRootObjectProvider)) != null)
+            services.Add("IRootObjectProvider");
+        if (serviceProvider.GetService(typeof(IXmlLineInfoProvider)) != null)
+            services.Add("IXmlLineInfoProvider");
+        if (serviceProvider.GetService(typeof(IValueConverterProvider)) != null)
+            services.Add("IValueConverterProvider");
+        if (serviceProvider.GetService(typeof(IProvideParentValues)) != null)
+            services.Add("IProvideParentValues");
+        if (serviceProvider.GetService(typeof(IReferenceProvider)) != null)
+            services.Add("IReferenceProvider");        
+		
+        return string.Join(",", services);
+	}
+}
+
+[AcceptEmptyServiceProvider]
+public class SPMarkup0 : MarkupExtensionBase { }
+
+[RequireService([typeof(IProvideValueTarget)])]
+public class SPMarkup1 : MarkupExtensionBase { }
+
+[RequireService([typeof(IProvideParentValues)])]
+public class SPMarkup2 : MarkupExtensionBase { }
+
+[RequireService([typeof(IXmlLineInfoProvider)])]
+public class SPMarkup3 : MarkupExtensionBase { }
+
+
+
+public partial class ServiceProviderTests : ContentPage
+{
+	public ServiceProviderTests() => InitializeComponent();
+
+	public ServiceProviderTests(bool useCompiledXaml)
+    {
+        //this stub will be replaced at compile time
+    }
+
+    [TestFixture]
+    public class Tests
+    {
+        [SetUp] public void Setup() => DispatcherProvider.SetCurrent(new DispatcherProviderStub());
+        [TearDown] public void TearDown() => DispatcherProvider.SetCurrent(null);
+
+        [TestCase(true)]
+        public void TestServiceProviders(bool useCompiledXaml)
+        {
+            var page = new ServiceProviderTests(useCompiledXaml);
+            MockCompiler.Compile(typeof(ServiceProviderTests));
+
+            //IValueConverterProvider is builtin for free
+            Assert.AreEqual(null, page.label0.Text);
+            Assert.AreEqual("IProvideValueTarget,IValueConverterProvider", page.label1.Text);
+            Assert.AreEqual("IProvideValueTarget,IValueConverterProvider,IReferenceProvider", page.label2.Text);
+            Assert.AreEqual("IXmlLineInfoProvider,IValueConverterProvider", page.label3.Text);
+        }
+    }
+}

--- a/src/Controls/tests/Xaml.UnitTests/TypeExtension.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/TypeExtension.xaml.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 	}
 
 	[ContentProperty(nameof(Operation))]
+	[AcceptEmptyServiceProvider]
 	public class NavigateExtension : IMarkupExtension<ICommand>
 	{
 		public NavigationOperation Operation { get; set; }

--- a/src/TestUtils/src/DeviceTests.Runners/TestUtils.DeviceTests.Runners.csproj
+++ b/src/TestUtils/src/DeviceTests.Runners/TestUtils.DeviceTests.Runners.csproj
@@ -7,7 +7,7 @@
     <AssemblyName>Microsoft.Maui.TestUtils.DeviceTests.Runners</AssemblyName>
     <!--<Nullable>enable</Nullable>-->
     <NoWarn>$(NoWarn);CA1416</NoWarn>
-    <WarningsNotAsErrors>$(WarningsNotAsErrors);XC0022;XC0023</WarningsNotAsErrors>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);XC0022;XC0023;XC0103</WarningsNotAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/BuildWarningsUtilities.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/BuildWarningsUtilities.cs
@@ -125,37 +125,6 @@ namespace Microsoft.Maui.IntegrationTests
 		{
 			new WarningsPerFile
 			{
-				File = "src/Controls/src/Xaml/XamlParser.cs",
-				WarningsPerCode = new List<WarningsPerCode>
-				{
-					new WarningsPerCode
-					{
-						Code = "IL2055",
-						Messages = new List<string>
-						{
-							"Microsoft.Maui.Controls.Xaml.XamlParser.GetElementType(XmlType,IXmlLineInfo,Assembly,XamlParseException&): Call to 'System.Type.MakeGenericType(Type[])' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic type.",
-						}
-					},
-					new WarningsPerCode
-					{
-						Code = "IL3050",
-						Messages = new List<string>
-						{
-							"Microsoft.Maui.Controls.Xaml.XamlParser.GetElementType(XmlType,IXmlLineInfo,Assembly,XamlParseException&): Using member 'System.Type.MakeGenericType(Type[])' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling. The native code for this instantiation might not be available at runtime.",
-						}
-					},
-					new WarningsPerCode
-					{
-						Code = "IL2057",
-						Messages = new List<string>
-						{
-							"Microsoft.Maui.Controls.Xaml.XamlParser.<>c__DisplayClass11_0.<GetElementType>b__0(ValueTuple`3<String,String,String>): Unrecognized value passed to the parameter 'typeName' of method 'System.Type.GetType(String)'. It's not possible to guarantee the availability of the target type.",
-						}
-					},
-				}
-			},
-			new WarningsPerFile
-			{
 				File = "src/Controls/src/Core/Xaml/TypeConversionExtensions.cs",
 				WarningsPerCode = new List<WarningsPerCode>
 				{


### PR DESCRIPTION
### Description of Change

MarkupExtensions, ValueProviders and some TypeConverters require a serviceProvider. Only add the services that are actually required. This will reduce IL size, time to JIT, number of allocations, ...

Also add a warning when users do not attribute their MarkupExctensions

### Issues Fixed

- fixes #19650
