### PR TITLE
use raw string literals

### DIFF
--- a/src/BlazorWebView/samples/WebViewAppShared/StaticFilesContents.cs
+++ b/src/BlazorWebView/samples/WebViewAppShared/StaticFilesContents.cs
@@ -6,31 +6,31 @@
 	/// </summary>
 	public static class StaticFilesContents
 	{
-		public static readonly string CustomIndexHtmlContent = @"
-<!DOCTYPE html>
-<html>
-<head>
-    <meta charset=""utf-8"" />
-    <meta name=""viewport"" content=""width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"" />
-    <title>Blazor Desktop app</title>
-    <base href=""/"" />
-    <link href=""css/app.css"" rel=""stylesheet"" />
-</head>
+		public static readonly string CustomIndexHtmlContent = """
+			<!DOCTYPE html>
+			<html>
+			<head>
+			    <meta charset="utf-8" />
+			    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+			    <title>Blazor Desktop app</title>
+			    <base href="/" />
+			    <link href="css/app.css" rel="stylesheet" />
+			</head>
 
-<body>
-	This HTML is coming from a custom provider!
-    <div id=""app""></div>
+			<body>
+				This HTML is coming from a custom provider!
+			    <div id="app"></div>
 
-    <div id=""blazor-error-ui"">
-        An unhandled error has occurred.
-        <a href="""" class=""reload"">Reload</a>
-        <a class=""dismiss"">🗙</a>
-    </div>
-    <script src=""_framework/blazor.webview.js""></script>
+			    <div id="blazor-error-ui">
+			        An unhandled error has occurred.
+			        <a href="" class="reload">Reload</a>
+			        <a class="dismiss">🗙</a>
+			    </div>
+			    <script src="_framework/blazor.webview.js"></script>
 
-</body>
+			</body>
 
-</html>
-";
+			</html>
+			""";
 	}
 }

--- a/src/BlazorWebView/tests/MauiDeviceTests/Elements/BlazorWebViewTests.cs
+++ b/src/BlazorWebView/tests/MauiDeviceTests/Elements/BlazorWebViewTests.cs
@@ -246,31 +246,31 @@ namespace Microsoft.Maui.MauiBlazorWebView.DeviceTests.Elements
 
 		public static class TestStaticFilesContents
 		{
-			public static readonly string DefaultMauiIndexHtmlContent = @"
-<!DOCTYPE html>
-<html>
-<head testhtmlloaded=""true"">
-    <meta charset=""utf-8"" />
-    <meta name=""viewport"" content=""width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"" />
-    <title>Blazor app</title>
-    <base href=""/"" />
-</head>
+			public static readonly string DefaultMauiIndexHtmlContent = """
+				<!DOCTYPE html>
+				<html>
+				<head testhtmlloaded="true">
+				    <meta charset="utf-8" />
+				    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+				    <title>Blazor app</title>
+				    <base href="/" />
+				</head>
 
-<body>
-	This test HTML is coming from a custom provider!
-    <div id=""app""></div>
+				<body>
+					This test HTML is coming from a custom provider!
+				    <div id="app"></div>
 
-    <div id=""blazor-error-ui"">
-        An unhandled error has occurred.
-        <a href="""" class=""reload"">Reload</a>
-        <a class=""dismiss"">🗙</a>
-    </div>
-    <script src=""_framework/blazor.webview.js"" autostart=""false""></script>
+				    <div id="blazor-error-ui">
+				        An unhandled error has occurred.
+				        <a href="" class="reload">Reload</a>
+				        <a class="dismiss">🗙</a>
+				    </div>
+				    <script src="_framework/blazor.webview.js" autostart="false"></script>
 
-</body>
+				</body>
 
-</html>
-";
+				</html>
+				""";
 		}
 
 		private sealed class BlazorWebViewWithCustomFiles : BlazorWebView

--- a/src/Compatibility/ControlGallery/src/Core/CoreGalleryPages/WebViewCoreGalleryPage.cs
+++ b/src/Compatibility/ControlGallery/src/Core/CoreGalleryPages/WebViewCoreGalleryPage.cs
@@ -51,18 +51,20 @@ namespace Microsoft.Maui.Controls.ControlGallery
 				{
 					Source = new HtmlWebViewSource
 					{
-						Html = @"<!DOCTYPE html><html>
-<head>
-<meta name='viewport' content='width=device-width,initial-scale=1.0'>
-<link rel=""stylesheet"" href=""default.css"">
-</head>
-<body>
-<h1>Xamarin.Forms</h1>
-<p>The CSS and image are loaded from local files!</p>
-<img src='WebImages/XamarinLogo.png'/>
-<p><a href=""local.html"">next page</a></p>
-</body>
-</html>"
+						Html = """
+							<!DOCTYPE html><html>
+							<head>
+								<meta name='viewport' content='width=device-width,initial-scale=1.0'>
+								<link rel="stylesheet" href="default.css">
+							</head>
+							<body>
+								<h1>Xamarin.Forms</h1>
+								<p>The CSS and image are loaded from local files!</p>
+								<img src='WebImages/XamarinLogo.png'/>
+								<p><a href="local.html">next page</a></p>
+							</body>
+							</html>
+							"""
 					},
 					HeightRequest = 200
 				}
@@ -125,15 +127,17 @@ namespace Microsoft.Maui.Controls.ControlGallery
 			{
 				Source = new HtmlWebViewSource
 				{
-					Html = @"<!DOCTYPE html><html>
-<head>
-<meta name='viewport' content='width=device-width,initial-scale=1.0'>
-<link rel=""stylesheet"" href=""default.css"">
-</head>
-<body>
-<button onclick=""window.alert('foo');"">Click</button>
-</body>
-</html>"
+					Html = 	"""
+							<!DOCTYPE html><html>
+							<head>
+							<meta name='viewport' content='width=device-width,initial-scale=1.0'>
+							<link rel="stylesheet" href="default.css">
+							</head>
+							<body>
+							<button onclick="window.alert('foo');">Click</button>
+							</body>
+							</html>
+							"""
 				},
 				HeightRequest = 200
 			};

--- a/src/Compatibility/ControlGallery/src/Core/CoreGalleryPages/WkWebViewCoreGalleryPage.cs
+++ b/src/Compatibility/ControlGallery/src/Core/CoreGalleryPages/WkWebViewCoreGalleryPage.cs
@@ -34,9 +34,16 @@ namespace Microsoft.Maui.Controls.ControlGallery
 				}
 			);
 
-			const string html = "<!DOCTYPE html><html>" +
-				"<head><meta name='viewport' content='width=device-width,initial-scale=1.0'></head>" +
-				"<body><div class=\"test\"><h2>I am raw html</h2></div></body></html>";
+			const string html = """
+				<!DOCTYPE html><html>
+				<head>
+					<meta name='viewport' content='width=device-width,initial-scale=1.0'>
+				</head>
+				<body>
+					<div class="test"><h2>I am raw html</h2></div>
+				</body>
+				</html>
+				""";
 
 			var htmlWebViewSourceContainer = new ViewContainer<WkWebView>(Test.WebView.HtmlWebViewSource,
 				new WkWebView
@@ -51,18 +58,20 @@ namespace Microsoft.Maui.Controls.ControlGallery
 				{
 					Source = new HtmlWebViewSource
 					{
-						Html = @"<!DOCTYPE html><html>
-<head>
-<meta name='viewport' content='width=device-width,initial-scale=1.0'>
-<link rel=""stylesheet"" href=""default.css"">
-</head>
-<body>
-<h1>Xamarin.Forms</h1>
-<p>The CSS and image are loaded from local files!</p>
-<img src='WebImages/XamarinLogo.png'/>
-<p><a href=""local.html"">next page</a></p>
-</body>
-</html>"
+						Html = """
+							<!DOCTYPE html><html>
+							<head>
+								<meta name='viewport' content='width=device-width,initial-scale=1.0'>
+								<link rel="stylesheet" href="default.css">
+							</head>
+							<body>
+								<h1>Xamarin.Forms</h1>
+								<p>The CSS and image are loaded from local files!</p>
+								<img src='WebImages/XamarinLogo.png'/>
+								<p><a href="local.html">next page</a></p>
+							</body>
+							</html>
+							"""
 					},
 					HeightRequest = 200
 				}
@@ -101,15 +110,17 @@ namespace Microsoft.Maui.Controls.ControlGallery
 			{
 				Source = new HtmlWebViewSource
 				{
-					Html = @"<!DOCTYPE html><html>
-<head>
-<meta name='viewport' content='width=device-width,initial-scale=1.0'>
-<link rel=""stylesheet"" href=""default.css"">
-</head>
-<body>
-<button onclick=""window.alert('foo');"">Click</button>
-</body>
-</html>"
+					Html = 	"""
+							<!DOCTYPE html><html>
+							<head>
+								<meta name='viewport' content='width=device-width,initial-scale=1.0'>
+								<link rel="stylesheet" href="default.css">
+							</head>
+							<body>
+								<button onclick="window.alert('foo');">Click</button>
+							</body>
+							</html>
+							"""
 				},
 				HeightRequest = 200
 			};

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla32033.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla32033.cs
@@ -82,17 +82,19 @@ Clicking that link should navigate to a page with the heading 'Xamarin Forms' an
 				VerticalOptions = LayoutOptions.Fill,
 				Source = new HtmlWebViewSource
 				{
-					Html = @"<html>
-<head>
-<link rel=""stylesheet"" href=""default.css"">
-</head>
-<body>
-<h1>Xamarin.Forms</h1>
-<p>The CSS and image are loaded from local files!</p>
-<img src='WebImages/XamarinLogo.png'/>
-<p><a href=""local.html"">next page</a></p>
-</body>
-</html>"
+					Html = """
+						<html>
+						<head>
+							<link rel="stylesheet" href="default.css">
+						</head>
+						<body>
+							<h1>Xamarin.Forms</h1>
+							<p>The CSS and image are loaded from local files!</p>
+							<img src='WebImages/XamarinLogo.png'/>
+							<p><a href="local.html">next page</a></p>
+						</body>
+						</html>
+						"""
 				}
 			};
 
@@ -123,14 +125,16 @@ Clicking that link should navigate to a page with the heading 'Xamarin Forms' an
 				VerticalOptions = LayoutOptions.Fill,
 				Source = new HtmlWebViewSource
 				{
-					Html = @"<html>
-<body>
-<h1>Xamarin.Forms</h1>
-<p>The CSS and image are loaded from local files!</p>
-<img src='WebImages/XamarinLogo.png'/>
-<p><a href=""local.html"">next page</a></p>
-</body>
-</html>"
+					Html = """
+						<html>
+						<body>
+							<h1>Xamarin.Forms</h1>
+							<p>The CSS and image are loaded from local files!</p>
+							<img src='WebImages/XamarinLogo.png'/>
+							<p><a href="local.html">next page</a></p>
+						</body>
+						</html>
+						"""
 				}
 			};
 

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla44500.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla44500.cs
@@ -12,19 +12,20 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 		PlatformAffected.iOS)]
 	public class Bugzilla44500 : TestNavigationPage
 	{
-		const string Html = @"
-<html>
-	<head>
-		<title></title>
-	</head>
-	<body>
-		<form>
-			<p>Please select a file:<br>
-				<input type=""file"" name=""datafile"" size=""40"">
-			</p>
-		</form>
-	</body>
-</html>";
+		const string Html = """
+			<html>
+				<head>
+					<title></title>
+				</head>
+				<body>
+					<form>
+						<p>Please select a file:<br>
+							<input type="file" name="datafile" size="40">
+						</p>
+					</form>
+				</body>
+			</html>
+			""";
 
 		protected override async void Init()
 		{

--- a/src/Controls/samples/Controls.Sample/Pages/Blazor/CustomBlazorWebView.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Blazor/CustomBlazorWebView.cs
@@ -10,33 +10,34 @@ namespace Maui.Controls.Sample.Pages.Blazor
 {
 	public class CustomBlazorWebView : BlazorWebView
 	{
-		const string IndexHtml = @"
-<!DOCTYPE html>
-<html>
-<head>
-    <meta charset=""utf-8"" />
-    <meta name=""viewport"" content=""width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"" />
-    <title>Blazor Desktop app</title>
-    <base href=""/"" />
-    <link href=""css/app.css"" rel=""stylesheet"" />
-    <link href=""Maui.Controls.Sample.styles.css"" rel=""stylesheet"" />
-</head>
+		const string IndexHtml = """
+			<!DOCTYPE html>
+			<html>
+			<head>
+			    <meta charset="utf-8" />
+			    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+			    <title>Blazor Desktop app</title>
+			    <base href="/" />
+			    <link href="css/app.css" rel="stylesheet" />
+			    <link href="Maui.Controls.Sample.styles.css" rel="stylesheet" />
+			</head>
 
-<body>
-	This HTML is coming from a custom provider!
-    <div id=""app""></div>
+			<body>
+				This HTML is coming from a custom provider!
+			    <div id="app"></div>
 
-    <div id=""blazor-error-ui"">
-        An unhandled error has occurred.
-        <a href="""" class=""reload"">Reload</a>
-        <a class=""dismiss"">🗙</a>
-    </div>
-    <script src=""_framework/blazor.webview.js"" autostart=""false""></script>
+			    <div id="blazor-error-ui">
+			        An unhandled error has occurred.
+			        <a href="" class="reload">Reload</a>
+			        <a class="dismiss">🗙</a>
+			    </div>
+			    <script src="_framework/blazor.webview.js" autostart="false"></script>
 
-</body>
+			</body>
 
-</html>
-";
+			</html>
+			""";
+
 		public override IFileProvider CreateFileProvider(string contentRootDir)
 		{
 			var inMemoryFiles = new InMemoryFileProvider(new Dictionary<string, string>

--- a/src/Controls/tests/Xaml.UnitTests/DesignPropertiesTests.cs
+++ b/src/Controls/tests/Xaml.UnitTests/DesignPropertiesTests.cs
@@ -10,15 +10,16 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[Test]
 		public void DesignProperties()
 		{
-			var xaml = @"
+			var xaml = """
 				<ContentPage
-						xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
-						xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
-						xmlns:d=""http://schemas.microsoft.com/dotnet/2021/maui/design""
-						xmlns:mc=""http://schemas.openxmlformats.org/markup-compatibility/2006""
-						mc:Ignorable=""d"">
-					<Label  d:Text=""Bar"" Text=""Foo"" x:Name=""label"" />
-				</ContentPage>";
+						xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+						xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+						xmlns:d="http://schemas.microsoft.com/dotnet/2021/maui/design"
+						xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+						mc:Ignorable="d">
+					<Label  d:Text="Bar" Text="Foo" x:Name="label" />
+				</ContentPage>
+				""";
 
 			var view = new ContentPage();
 			XamlLoader.Load(view, xaml, useDesignProperties: true); //this is equiv as LoadFromXaml, but with the bool set

--- a/src/Controls/tests/Xaml.UnitTests/FontConverterTests.cs
+++ b/src/Controls/tests/Xaml.UnitTests/FontConverterTests.cs
@@ -11,10 +11,11 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[TestCase("Bold, Italic", Controls.FontAttributes.Bold | Controls.FontAttributes.Italic)]
 		public void FontAttributes(string attributeString, FontAttributes result)
 		{
-			var xaml = @"
-			<Label 
-				xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
-				xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml"" FontAttributes=""" + result + @""" />";
+			var xaml = $"""
+				<Label 
+					xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" FontAttributes="{result}" />
+				""";
 
 			var label = new Label().LoadFromXaml(xaml);
 

--- a/src/Controls/tests/Xaml.UnitTests/GenericsTests.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/GenericsTests.xaml.cs
@@ -25,17 +25,19 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 			[Test]
 			public void NoGenericsOnXaml2006()
 			{
-				var xaml = @"
-				<ContentPage 
-				xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
-				xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
-				xmlns:scg=""clr-namespace:System.Collections.Generic;assembly=mscorlib"">
-					<ContentPage.Resources>
-						<ResourceDictionary>
-							<scg:List x:TypeArguments=""Button"" x:Key=""genericList""/>
-						</ResourceDictionary>
-					</ContentPage.Resources>
-				</ContentPage>";
+				var xaml = """
+					<ContentPage 
+					xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+					xmlns:scg="clr-namespace:System.Collections.Generic;assembly=mscorlib">
+						<ContentPage.Resources>
+							<ResourceDictionary>
+								<scg:List x:TypeArguments="Button" x:Key="genericList"/>
+							</ResourceDictionary>
+						</ContentPage.Resources>
+					</ContentPage>
+					""";
+
 				Assert.Throws(new XamlParseExceptionConstraint(8, 9), () => new ContentPage().LoadFromXaml(xaml));
 			}
 

--- a/src/Controls/tests/Xaml.UnitTests/HRTests.cs
+++ b/src/Controls/tests/Xaml.UnitTests/HRTests.cs
@@ -17,16 +17,17 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[Test]
 		public void LoadResources()
 		{
-			var app = @"
-				<Application xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
-					xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml"">
+			var app = """
+				<Application xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+					xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
 					<Application.Resources>
 						<ResourceDictionary>
-							<Color x:Key=""almostPink"">HotPink</Color>
+							<Color x:Key="almostPink">HotPink</Color>
 						</ResourceDictionary>
 					</Application.Resources>
-				</Application>
-			";
+				</Application>	
+				""";
+
 			Assert.That(Application.Current, Is.Null);
 			var mockApplication = new MockApplication();
 			var rd = XamlLoader.LoadResources(app, mockApplication);
@@ -41,15 +42,15 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[Test]
 		public void LoadMultipleResources()
 		{
-			var app = @"
-				<Application xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
-					xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml"">
+			var app = """
+				<Application xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+					xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
 					<Application.Resources>
-						<Color x:Key=""almostPink"">HotPink</Color>
-						<Color x:Key=""yellowOrGreen"">Chartreuse</Color>
+						<Color x:Key="almostPink">HotPink</Color>
+						<Color x:Key="yellowOrGreen">Chartreuse</Color>
 					</Application.Resources>
 				</Application>
-			";
+				""";
 
 			Assert.That(Application.Current, Is.Null);
 			var mockApplication = new MockApplication();
@@ -65,14 +66,14 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[Test]
 		public void LoadSingleImplicitResources()
 		{
-			var app = @"
-				<Application xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
-					xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml"">
+			var app = """
+				<Application xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+					xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
 					<Application.Resources>
-						<Color x:Key=""almostPink"">HotPink</Color>
+						<Color x:Key="almostPink">HotPink</Color>
 					</Application.Resources>
 				</Application>
-			";
+				""";
 
 			Assert.That(Application.Current, Is.Null);
 			var mockApplication = new MockApplication();

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Issue1493.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Issue1493.cs
@@ -27,13 +27,16 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		{
 			System.Threading.Thread.CurrentThread.CurrentCulture = new System.Globalization.CultureInfo(culture);
 
-			var xaml = @"<?xml version=""1.0"" encoding=""utf-8"" ?>
-						<View 
-							xmlns=""http://schemas.microsoft.com/dotnet/2021/maui"" 
-							xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml""
-							xmlns:cmp=""clr-namespace:Microsoft.Maui.Controls.Compatibility;assembly=Microsoft.Maui.Controls""
-							cmp:RelativeLayout.HeightConstraint=""{cmp:ConstraintExpression Type=RelativeToParent, Property=Height, Factor=0.25}""
-							cmp:RelativeLayout.WidthConstraint=""{cmp:ConstraintExpression Type=RelativeToParent, Property=Width, Factor=0.6}""/>";
+			var xaml = """
+				<?xml version="1.0" encoding="utf-8" ?>
+				<View 
+					xmlns="http://schemas.microsoft.com/dotnet/2021/maui" 
+					xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+					xmlns:cmp="clr-namespace:Microsoft.Maui.Controls.Compatibility;assembly=Microsoft.Maui.Controls"
+					cmp:RelativeLayout.HeightConstraint="{cmp:ConstraintExpression Type=RelativeToParent, Property=Height, Factor=0.25}"
+					cmp:RelativeLayout.WidthConstraint="{cmp:ConstraintExpression Type=RelativeToParent, Property=Width, Factor=0.6}"/>
+				""";
+
 			View view = new View();
 			view.LoadFromXaml(xaml);
 			Assert.DoesNotThrow(() => view.LoadFromXaml(xaml));

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Issue1497.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Issue1497.cs
@@ -10,14 +10,16 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[Test]
 		public void BPCollectionsWithSingleElement()
 		{
-			var xaml = @"<?xml version=""1.0"" encoding=""utf-8"" ?>
-						<Grid
-							xmlns=""http://schemas.microsoft.com/dotnet/2021/maui"" 
-							xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml"">	 
-							<Grid.ColumnDefinitions>
-								<ColumnDefinition Width=""*""/>
-							</Grid.ColumnDefinitions>
-					    </Grid>";
+			var xaml = """
+				<?xml version="1.0" encoding="utf-8" ?>
+				<Grid
+					xmlns="http://schemas.microsoft.com/dotnet/2021/maui" 
+					xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">	 
+					<Grid.ColumnDefinitions>
+						<ColumnDefinition Width="*"/>
+					</Grid.ColumnDefinitions>
+				</Grid>
+				""";
 
 			var grid = new Grid().LoadFromXaml(xaml);
 			Assert.AreEqual(1, grid.ColumnDefinitions.Count);

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Issue1501.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Issue1501.cs
@@ -19,15 +19,16 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[Test]
 		public void ConnectEventsInGestureRecognizers()
 		{
-			var xaml = @"
+			var xaml = """
 				<BoxView 
-					xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
-					xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml""
-					x:Class=""Microsoft.Maui.Controls.Xaml.UnitTests.BoxView1501"" >
-				    <BoxView.GestureRecognizers>
-				      <TapGestureRecognizer Tapped=""OnBoxViewTapped"" />
-				    </BoxView.GestureRecognizers>
-				</BoxView>";
+					xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+					xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+					x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.BoxView1501" >
+					<BoxView.GestureRecognizers>
+						<TapGestureRecognizer Tapped="OnBoxViewTapped" />
+					</BoxView.GestureRecognizers>
+				</BoxView>
+				""";
 
 			BoxView1501 layout = null;
 			Assert.DoesNotThrow(() => { layout = new BoxView1501().LoadFromXaml(xaml); });

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Issue1545.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Issue1545.cs
@@ -31,17 +31,19 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[Test]
 		public void BindingCanNotBeReused()
 		{
-			string xaml = @"<ContentPage xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
-						 xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml""
-						 x:Class=""Microsoft.Maui.Controls.ControlGallery.Issue1545"">
-						<ListView x:Name=""List"" ItemsSource=""{Binding}"">
-							<ListView.ItemTemplate>
-								<DataTemplate>
-									<TextCell Text=""{Binding}"" />
-								</DataTemplate>
-							</ListView.ItemTemplate>
-						</ListView>
-				</ContentPage>";
+			string xaml = """
+				<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+							 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+							 x:Class="Microsoft.Maui.Controls.ControlGallery.Issue1545">
+					<ListView x:Name="List" ItemsSource="{Binding}">
+						<ListView.ItemTemplate>
+							<DataTemplate>
+								<TextCell Text="{Binding}" />
+							</DataTemplate>
+						</ListView.ItemTemplate>
+					</ListView>
+				</ContentPage>
+				""";
 
 			ContentPage page = new ContentPage().LoadFromXaml(xaml);
 
@@ -60,29 +62,31 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[Test]
 		public void ElementsCanNotBeReused()
 		{
-			string xaml = @"<ContentPage xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
-						 xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml""
-						 xmlns:local=""clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests;assembly=Microsoft.Maui.Controls.Xaml.UnitTests""
-						 xmlns:cmp=""clr-namespace:Microsoft.Maui.Controls.Compatibility;assembly=Microsoft.Maui.Controls""
-						 x:Class=""Microsoft.Maui.Controls.ControlGallery.Issue1545"">
-							<ContentPage.Resources>
+			string xaml = """
+				<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+							 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+							 xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests;assembly=Microsoft.Maui.Controls.Xaml.UnitTests"
+							 xmlns:cmp="clr-namespace:Microsoft.Maui.Controls.Compatibility;assembly=Microsoft.Maui.Controls"
+							 x:Class="Microsoft.Maui.Controls.ControlGallery.Issue1545">
+						<ContentPage.Resources>
 							<ResourceDictionary>
-							<Color x:Key=""color"">#ff00aa</Color>
+								<Color x:Key="color">#ff00aa</Color>
 							</ResourceDictionary>
-							</ContentPage.Resources>
+						</ContentPage.Resources>
 
-						<ListView x:Name=""List"" ItemsSource=""{Binding}"">
+						<ListView x:Name="List" ItemsSource="{Binding}">
 							<ListView.ItemTemplate>
 								<DataTemplate>
 									<ViewCell>
 									<cmp:StackLayout>
-										<Label Text=""{Binding}"" BackgroundColor=""{StaticResource color}""/>
+										<Label Text="{Binding}" BackgroundColor="{StaticResource color}"/>
 									</cmp:StackLayout>
 									</ViewCell>
 								</DataTemplate>
 							</ListView.ItemTemplate>
 						</ListView>
-				</ContentPage>";
+				</ContentPage>
+				""";
 
 			ContentPage page = new ContentPage().LoadFromXaml(xaml);
 
@@ -108,24 +112,26 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[Test]
 		public void ElementsFromCollectionsAreNotReused()
 		{
-			var xaml = @"<ListView 
-						xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
-						xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml""
-						xmlns:local=""clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests;assembly=Microsoft.Maui.Controls.Xaml.UnitTests""
-						ItemsSource=""{Binding}"">
-							<ListView.ItemTemplate>
-								<DataTemplate>
-									<local:ViewCellWithCollection>
-										<local:ViewCellWithCollection.Children>
-											<local:ViewList>
-												<Label />
-												<Label />
-											</local:ViewList>
-										</local:ViewCellWithCollection.Children>
-									</local:ViewCellWithCollection>
-								</DataTemplate>
-							</ListView.ItemTemplate>
-						</ListView>";
+			var xaml = """
+				<ListView 
+				xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+				xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+				xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests;assembly=Microsoft.Maui.Controls.Xaml.UnitTests"
+				ItemsSource="{Binding}">
+					<ListView.ItemTemplate>
+						<DataTemplate>
+							<local:ViewCellWithCollection>
+								<local:ViewCellWithCollection.Children>
+									<local:ViewList>
+										<Label />
+										<Label />
+									</local:ViewList>
+								</local:ViewCellWithCollection.Children>
+							</local:ViewCellWithCollection>
+						</DataTemplate>
+					</ListView.ItemTemplate>
+				</ListView>
+				""";
 
 			var listview = new ListView();
 			var items = new[] { "Foo", "Bar", "Baz" };
@@ -143,25 +149,27 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[Test]
 		public void ResourcesDeclaredInDataTemplatesAreNotShared()
 		{
-			var xaml = @"<ListView 
-						xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
-						xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml""
-						xmlns:sys=""clr-namespace:System;assembly=mscorlib""
-						ItemsSource=""{Binding}"">
-							<ListView.ItemTemplate>
-								<DataTemplate>
-									<ViewCell>
-										<Label Text=""{Binding}"">
-											<Label.Resources>
-												<ResourceDictionary>
-													<sys:Object x:Key=""object""/>
-												</ResourceDictionary>
-											</Label.Resources>
-										</Label>
-									</ViewCell>
-								</DataTemplate>
-							</ListView.ItemTemplate>
-						</ListView>";
+			var xaml = """
+				<ListView 
+				xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+				xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+				xmlns:sys="clr-namespace:System;assembly=mscorlib"
+				ItemsSource="{Binding}">
+					<ListView.ItemTemplate>
+						<DataTemplate>
+							<ViewCell>
+								<Label Text="{Binding}">
+									<Label.Resources>
+										<ResourceDictionary>
+											<sys:Object x:Key="object"/>
+										</ResourceDictionary>
+									</Label.Resources>
+								</Label>
+							</ViewCell>
+						</DataTemplate>
+					</ListView.ItemTemplate>
+				</ListView>
+				""";
 
 			var listview = new ListView();
 			var items = new[] { "Foo", "Bar", "Baz" };

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Issue1549.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Issue1549.cs
@@ -71,24 +71,25 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[Test]
 		public void ConverterIsInvoked()
 		{
-			var xaml = @"
-<ContentPage 							
-xmlns=""http://schemas.microsoft.com/dotnet/2021/maui"" 
-							xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml""
-							xmlns:local=""clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests;assembly=Microsoft.Maui.Controls.Xaml.UnitTests"">
+			var xaml = """
+				<ContentPage 							
+					xmlns="http://schemas.microsoft.com/dotnet/2021/maui" 
+					xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+					xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests;assembly=Microsoft.Maui.Controls.Xaml.UnitTests">
 
-<ContentPage.Resources>
-<ResourceDictionary>
-<local:SeverityColorConverter x:Key=""SeverityColorConverter"" />
-</ResourceDictionary>
-</ContentPage.Resources>
-				<Label Text=""{Binding value, StringFormat='{0}'}"" 
-					WidthRequest=""50"" 
-					TextColor=""Black""
-					x:Name=""label""
-					BackgroundColor=""{Binding Severity, Converter={StaticResource SeverityColorConverter}}""
-					HorizontalTextAlignment=""Center"" VerticalTextAlignment=""Center""/>
-</ContentPage>";
+					<ContentPage.Resources>
+						<ResourceDictionary>
+							<local:SeverityColorConverter x:Key="SeverityColorConverter" />
+						</ResourceDictionary>
+					</ContentPage.Resources>
+					<Label Text="{Binding value, StringFormat='{0}'}" 
+						WidthRequest="50" 
+						TextColor="Black"
+						x:Name="label"
+						BackgroundColor="{Binding Severity, Converter={StaticResource SeverityColorConverter}}"
+						HorizontalTextAlignment="Center" VerticalTextAlignment="Center"/>
+				</ContentPage>
+				""";
 
 			var layout = new ContentPage().LoadFromXaml(xaml);
 			layout.BindingContext = new { Value = "Foo", Severity = "Bar" };
@@ -100,24 +101,25 @@ xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
 		[Test]
 		public void ConverterIsInvoked_Escaped()
 		{
-			var xaml = @"
-<ContentPage 							
-xmlns=""http://schemas.microsoft.com/dotnet/2021/maui"" 
-							xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml""
-							xmlns:local=""clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests;assembly=Microsoft.Maui.Controls.Xaml.UnitTests"">
+			var xaml = """
+				<ContentPage 							
+					xmlns="http://schemas.microsoft.com/dotnet/2021/maui" 
+					xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+					xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests;assembly=Microsoft.Maui.Controls.Xaml.UnitTests">
 
-<ContentPage.Resources>
-<ResourceDictionary>
-<local:SeverityColorConverter x:Key=""SeverityColorConverter"" />
-</ResourceDictionary>
-</ContentPage.Resources>
-				<Label Text=""{Binding value, StringFormat='{}{0}'}"" 
-					WidthRequest=""50"" 
-					TextColor=""Black""
-					x:Name=""label""
-					BackgroundColor=""{Binding Severity, Converter={StaticResource SeverityColorConverter}}""
-					HorizontalTextAlignment=""Center"" VerticalTextAlignment=""Center""/>
-</ContentPage>";
+					<ContentPage.Resources>
+						<ResourceDictionary>
+							<local:SeverityColorConverter x:Key="SeverityColorConverter" />
+						</ResourceDictionary>
+					</ContentPage.Resources>
+					<Label Text="{Binding value, StringFormat='{}{0}'}" 
+						WidthRequest="50" 
+						TextColor="Black"
+						x:Name="label"
+						BackgroundColor="{Binding Severity, Converter={StaticResource SeverityColorConverter}}"
+						HorizontalTextAlignment="Center" VerticalTextAlignment="Center"/>
+				</ContentPage>
+				""";
 
 			var layout = new ContentPage().LoadFromXaml(xaml);
 			layout.BindingContext = new { Value = "Foo", Severity = "Bar" };
@@ -129,39 +131,39 @@ xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
 		[Test]
 		public void ResourcesInNonXFBaseClassesAreFound()
 		{
-			var xaml = @"<local:BaseView 
-	xmlns=""http://schemas.microsoft.com/dotnet/2021/maui"" 
-	xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml"" 
-	xmlns:cmp=""clr-namespace:Microsoft.Maui.Controls.Compatibility;assembly=Microsoft.Maui.Controls""
-  	xmlns:local=""clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests;assembly=Microsoft.Maui.Controls.Xaml.UnitTests""
-	Padding=""0,40,0,0"">
-    <local:BaseView.Resources>
-    <ResourceDictionary>
-     	<local:InvertBoolenConverter x:Key=""cnvInvert""></local:InvertBoolenConverter>
-    </ResourceDictionary>
-    </local:BaseView.Resources>
-	<local:BaseView.Content>
-		<ListView x:Name=""lst"" VerticalOptions=""FillAndExpand""
-        		HorizontalOptions=""FillAndExpand""
-			
-				ItemsSource=""{Binding Items}""
+			var xaml = """
+				<local:BaseView 
+					xmlns="http://schemas.microsoft.com/dotnet/2021/maui" 
+					xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" 
+					xmlns:cmp="clr-namespace:Microsoft.Maui.Controls.Compatibility;assembly=Microsoft.Maui.Controls"
+				  	xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests;assembly=Microsoft.Maui.Controls.Xaml.UnitTests"
+					Padding="0,40,0,0">
+				    <local:BaseView.Resources>
+				    <ResourceDictionary>
+				     	<local:InvertBoolenConverter x:Key="cnvInvert"></local:InvertBoolenConverter>
+				    </ResourceDictionary>
+				    </local:BaseView.Resources>
+					<local:BaseView.Content>
+						<ListView x:Name="lst" VerticalOptions="FillAndExpand"
+				        		HorizontalOptions="FillAndExpand"
+								ItemsSource="{Binding Items}">
+						<ListView.ItemTemplate >
+							<DataTemplate> 
+								<ViewCell >
+								<ViewCell.View>
+									<cmp:Grid  VerticalOptions="FillAndExpand" HorizontalOptions="FillAndExpand"  >			
+									<Label  IsVisible="{Binding IsLocked}"  Text="Show Is Locked"  />
+									<Label  IsVisible="{Binding IsLocked, Converter={StaticResource cnvInvert}}" Text="Show Is Not locked" />
+								</cmp:Grid>
+								</ViewCell.View>
+								</ViewCell>
+							</DataTemplate>
+						</ListView.ItemTemplate>
+						</ListView>
+					</local:BaseView.Content>
+				</local:BaseView>
+				""";
 
-			>
-		<ListView.ItemTemplate >
-			<DataTemplate> 
-				<ViewCell >
-				<ViewCell.View>
-					<cmp:Grid  VerticalOptions=""FillAndExpand"" HorizontalOptions=""FillAndExpand""  >			
-					<Label  IsVisible=""{Binding IsLocked}""  Text=""Show Is Locked""  />
-					<Label  IsVisible=""{Binding IsLocked, Converter={StaticResource cnvInvert}}"" Text=""Show Is Not locked"" />
-				</cmp:Grid>
-				</ViewCell.View>
-				</ViewCell>
-			</DataTemplate>
-		</ListView.ItemTemplate>
-		</ListView>
-	</local:BaseView.Content>
-</local:BaseView>";
 			var page = new Issue1549Page().LoadFromXaml(xaml);
 			var lst = page.FindByName<ListView>("lst");
 			ObservableCollection<Item> items;

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Issue1554.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Issue1554.cs
@@ -15,24 +15,27 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[Test]
 		public void CollectionItemsInDataTemplate()
 		{
-			var xaml = @"<?xml version=""1.0"" encoding=""UTF-8""?>
+			var xaml = """
+				<?xml version="1.0" encoding="UTF-8"?>
 				<ListView 
-					xmlns=""http://schemas.microsoft.com/dotnet/2021/maui"" 
-					xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml"" 
-					ItemsSource=""{Binding}"">
-			        <ListView.ItemTemplate>
-			          <DataTemplate>
-			            <ViewCell>
-			              <ViewCell.View>
-			                <StackLayout>
-			                  <Label Text=""{Binding}""></Label>
-			                  <Label Text=""{Binding}""></Label>
-			                </StackLayout>
-			              </ViewCell.View>
-			            </ViewCell>
-			          </DataTemplate>
-			        </ListView.ItemTemplate>
-			      </ListView>";
+					xmlns="http://schemas.microsoft.com/dotnet/2021/maui" 
+					xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" 
+					ItemsSource="{Binding}">
+					<ListView.ItemTemplate>
+						<DataTemplate>
+						<ViewCell>
+							<ViewCell.View>
+							<StackLayout>
+								<Label Text="{Binding}"></Label>
+								<Label Text="{Binding}"></Label>
+							</StackLayout>
+							</ViewCell.View>
+						</ViewCell>
+						</DataTemplate>
+					</ListView.ItemTemplate>
+				</ListView>
+				""";
+
 			var listview = new ListView();
 			var items = new[] { "Foo", "Bar", "Baz" };
 			listview.BindingContext = items;

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Issue1564.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Issue1564.cs
@@ -9,17 +9,20 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[Test]
 		public void ViewCellAsXamlRoot()
 		{
-			var xaml = @"<?xml version=""1.0"" encoding=""UTF-8""?>
+			var xaml = """
+				<?xml version="1.0" encoding="UTF-8"?>
 				<ViewCell 
-					xmlns=""http://schemas.microsoft.com/dotnet/2021/maui"" 
-					xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml"" 
-					x:Class=""m.transport.VehicleCell"">
-				    <ViewCell.View>
-				        <StackLayout>
-					        <Label Text=""This is my label""></Label>
-				        </StackLayout>
-				    </ViewCell.View>
-				</ViewCell>";
+					xmlns="http://schemas.microsoft.com/dotnet/2021/maui" 
+					xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" 
+					x:Class="m.transport.VehicleCell">
+					<ViewCell.View>
+						<StackLayout>
+							<Label Text="This is my label"></Label>
+						</StackLayout>
+					</ViewCell.View>
+				</ViewCell>
+				""";
+
 			var cell = new ViewCell().LoadFromXaml(xaml);
 			Assert.NotNull(cell);
 			Assert.AreEqual("This is my label", ((cell.View as StackLayout).Children[0] as Label).Text);

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Issue1594.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Issue1594.cs
@@ -25,20 +25,21 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[Test]
 		public void OnPlatformForButtonHeight()
 		{
-			var xaml = @"
+			var xaml = """
 				<Button 
-					xmlns=""http://schemas.microsoft.com/dotnet/2021/maui"" 
-					xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml"" 
-					xmlns:sys=""clr-namespace:System;assembly=mscorlib""
-					x:Name=""activateButton"" Text=""ACTIVATE NOW"" TextColor=""White"" BackgroundColor=""#00A0FF"">
-				        <Button.HeightRequest>
-				           <OnPlatform x:TypeArguments=""sys:Double"">
-				                   <On Platform=""iOS"">33</On>
-				                   <On Platform=""Android"">44</On>
-				                   <On Platform=""UWP"">44</On>
-				         	</OnPlatform>
-				         </Button.HeightRequest>
-				 </Button>";
+					xmlns="http://schemas.microsoft.com/dotnet/2021/maui" 
+					xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" 
+					xmlns:sys="clr-namespace:System;assembly=mscorlib"
+					x:Name="activateButton" Text="ACTIVATE NOW" TextColor="White" BackgroundColor="#00A0FF">
+						<Button.HeightRequest>
+							<OnPlatform x:TypeArguments="sys:Double">
+									<On Platform="iOS">33</On>
+									<On Platform="Android">44</On>
+									<On Platform="UWP">44</On>
+							</OnPlatform>
+						</Button.HeightRequest>
+				</Button>
+				""";
 
 			mockDeviceInfo.Platform = DevicePlatform.iOS;
 			var button = new Button().LoadFromXaml(xaml);

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Issue1637.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Issue1637.cs
@@ -9,12 +9,14 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[Test]
 		public void ImplicitCollectionWithSingleElement()
 		{
-			var xaml = @"
-				<Grid xmlns=""http://schemas.microsoft.com/dotnet/2021/maui"">
+			var xaml = """
+				<Grid xmlns="http://schemas.microsoft.com/dotnet/2021/maui">
 					<Grid.RowDefinitions>
-						<RowDefinition Height=""*"" />
-			        </Grid.RowDefinitions>
-				</Grid>";
+						<RowDefinition Height="*" />
+					</Grid.RowDefinitions>
+				</Grid>
+				""";
+
 			var grid = new Grid();
 			Assert.DoesNotThrow(() => grid.LoadFromXaml<Grid>(xaml));
 			Assert.AreEqual(1, grid.RowDefinitions.Count);

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Issue1641.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Issue1641.cs
@@ -9,24 +9,26 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[Test]
 		public void StaticResourceInTableView()
 		{
-			var xaml = @"
-					<ContentPage
-					xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
-					xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml"">
-						<ContentPage.Resources>
-					        <ResourceDictionary>
-					          <x:String x:Key=""caption"" >Hello there!</x:String>
-					        </ResourceDictionary>
-						</ContentPage.Resources>
+			var xaml = """
+				<ContentPage
+				xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+				xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+					<ContentPage.Resources>
+						<ResourceDictionary>
+							<x:String x:Key="caption" >Hello there!</x:String>
+						</ResourceDictionary>
+					</ContentPage.Resources>
 
-					    <TableView>                 
-					        <TableRoot Title=""x"">
-					            <TableSection Title=""y"">
-					                <TextCell Text=""{StaticResource caption}"" />
-					            </TableSection>
-					        </TableRoot>
-					    </TableView>
-					</ContentPage>";
+					<TableView>                 
+						<TableRoot Title="x">
+							<TableSection Title="y">
+								<TextCell Text="{StaticResource caption}" />
+							</TableSection>
+						</TableRoot>
+					</TableView>
+				</ContentPage>
+				""";
+
 			var page = new ContentPage().LoadFromXaml(xaml);
 			var table = page.Content as TableView;
 			Assert.AreEqual("Hello there!", page.Resources["caption"] as string);

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Issue1794.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Issue1794.cs
@@ -14,45 +14,46 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[Test]
 		public void FindNameInDT()
 		{
-			var xaml = @"<?xml version=""1.0"" encoding=""utf-8"" ?>
-				<ContentPage xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
-						 xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml""
-						 xmlns:cmp=""clr-namespace:Microsoft.Maui.Controls.Compatibility;assembly=Microsoft.Maui.Controls""
-						 xmlns:local=""clr-namespace:Microsoft.Maui.ControlsFormsXamlSample;assembly=Microsoft.Maui.ControlsFormsXamlSample""
-						 xmlns:constants=""clr-namespace:Microsoft.Maui.ControlsFormsSample;assembly=Microsoft.Maui.ControlsFormsXamlSample""
-						 x:Class=""UxDemoAppXF.Layouts.Menu""
-						 Title=""Employee List"">
- 
-					<ListView x:Name=""listView""
-						IsVisible=""true""
-						ItemsSource=""{Binding MenuItems}""
-						SelectedItem=""{Binding ListItemSelected}"">
+			var xaml = """
+				<?xml version="1.0" encoding="utf-8" ?>
+				<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+							xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+							xmlns:cmp="clr-namespace:Microsoft.Maui.Controls.Compatibility;assembly=Microsoft.Maui.Controls"
+							xmlns:local="clr-namespace:Microsoft.Maui.ControlsFormsXamlSample;assembly=Microsoft.Maui.ControlsFormsXamlSample"
+							xmlns:constants="clr-namespace:Microsoft.Maui.ControlsFormsSample;assembly=Microsoft.Maui.ControlsFormsXamlSample"
+							x:Class="UxDemoAppXF.Layouts.Menu"
+							Title="Employee List">
+	
+					<ListView x:Name="listView"
+						IsVisible="true"
+						ItemsSource="{Binding MenuItems}"
+						SelectedItem="{Binding ListItemSelected}">
 		
 						<ListView.ItemTemplate>
 							<DataTemplate>
 								<ViewCell>
 									<cmp:RelativeLayout>
-										<Label x:Name=""LinkText""
-													 Text=""{Binding Name}""
-													 cmp:RelativeLayout.XConstraint=
-														""{cmp:ConstraintExpression  Type=RelativeToParent, 
-																										Property=Width, 
-																										Factor=0.5}""/>
-										<Image x:Name=""LinkImage"" 
-													 Source=""{Binding ImageSource}""
-													 cmp:RelativeLayout.XConstraint=
-														""{cmp:ConstraintExpression  Type=RelativeToView,
-																				Property=Width, 
-																				ElementName=LinkText,
-																				Constant=5}""/>
-									 
-				 
+										<Label x:Name="LinkText"
+														Text="{Binding Name}"
+														cmp:RelativeLayout.XConstraint=
+														"{cmp:ConstraintExpression 	Type=RelativeToParent, 
+																					Property=Width, 
+																					Factor=0.5}"/>
+										<Image x:Name="LinkImage" 
+														Source="{Binding ImageSource}"
+														cmp:RelativeLayout.XConstraint=
+														"{cmp:ConstraintExpression 	Type=RelativeToView,
+																					Property=Width, 
+																					ElementName=LinkText,
+																					Constant=5}"/>
 									</cmp:RelativeLayout>
 								</ViewCell>
 							</DataTemplate>
 						</ListView.ItemTemplate>
 					</ListView> 
-				</ContentPage>";
+				</ContentPage>
+				""";
+
 			var layout = new ContentPage().LoadFromXaml(xaml);
 			var list = layout.FindByName<ListView>("listView");
 			var item0 = list.TemplatedItems.GetOrCreateContent(0, null);

--- a/src/Controls/tests/Xaml.UnitTests/Issues/TestCases.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/TestCases.cs
@@ -49,27 +49,30 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[Test]
 		public void TestCase001()
 		{
-			var xaml = @"<?xml version=""1.0"" encoding=""UTF-8"" ?>
-			<ContentPage
-			xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
-			xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
-			xmlns:local=""clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests;assembly=Microsoft.Maui.Controls.Xaml.UnitTests""
-			xmlns:cmp=""clr-namespace:Microsoft.Maui.Controls.Compatibility;assembly=Microsoft.Maui.Controls""
-			Title=""Home"">
-				<local:TestCases.InnerView>
-					<Label x:Name=""innerView""/>
-				</local:TestCases.InnerView>
-				<ContentPage.Content>
-					<cmp:Grid RowSpacing=""9"" ColumnSpacing=""6"" Padding=""6,9"" VerticalOptions=""Fill"" HorizontalOptions=""Fill"" BackgroundColor=""Red"">
-						<cmp:Grid.Children>
-							<Label x:Name=""label0""/>
-							<Label x:Name=""label1""/>
-							<Label x:Name=""label2""/>
-							<Label x:Name=""label3""/>
-						</cmp:Grid.Children>
-					</cmp:Grid>
-				</ContentPage.Content>
-			</ContentPage>";
+			var xaml = """
+				<?xml version="1.0" encoding="UTF-8" ?>
+				<ContentPage
+				xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+				xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+				xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests;assembly=Microsoft.Maui.Controls.Xaml.UnitTests"
+				xmlns:cmp="clr-namespace:Microsoft.Maui.Controls.Compatibility;assembly=Microsoft.Maui.Controls"
+				Title="Home">
+					<local:TestCases.InnerView>
+						<Label x:Name="innerView"/>
+					</local:TestCases.InnerView>
+					<ContentPage.Content>
+						<cmp:Grid RowSpacing="9" ColumnSpacing="6" Padding="6,9" VerticalOptions="Fill" HorizontalOptions="Fill" BackgroundColor="Red">
+							<cmp:Grid.Children>
+								<Label x:Name="label0"/>
+								<Label x:Name="label1"/>
+								<Label x:Name="label2"/>
+								<Label x:Name="label3"/>
+							</cmp:Grid.Children>
+						</cmp:Grid>
+					</ContentPage.Content>
+				</ContentPage>
+				""";
+
 			var contentPage = new ContentPage().LoadFromXaml(xaml);
 			var label0 = contentPage.FindByName<Label>("label0");
 			var label1 = contentPage.FindByName<Label>("label1");
@@ -86,16 +89,19 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[Test]
 		public void TestCase002()
 		{
-			var xaml = @"<?xml version=""1.0"" encoding=""UTF-8"" ?>
-            <local:BasePage
-                xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
-                xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
-			    xmlns:local=""clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests;assembly=Microsoft.Maui.Controls.Xaml.UnitTests""
-                x:Class=""Tramchester.App.Views.HomeView"">
-                <local:BasePage.Content>
-                  <Label Text=""Hi There!"" />
-                </local:BasePage.Content>
-           </local:BasePage>";
+			var xaml = """
+				<?xml version="1.0" encoding="UTF-8" ?>
+				<local:BasePage
+					xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+					xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests;assembly=Microsoft.Maui.Controls.Xaml.UnitTests"
+					x:Class="Tramchester.App.Views.HomeView">
+					<local:BasePage.Content>
+						<Label Text="Hi There!" />
+					</local:BasePage.Content>
+				</local:BasePage>
+				""";
+
 			var contentPage = new ContentPage().LoadFromXaml(xaml);
 			Assert.That(contentPage.Content, Is.InstanceOf<Label>());
 		}
@@ -103,33 +109,34 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[Test]
 		public void TestCase003()
 		{
-			var xaml = @"<?xml version=""1.0"" encoding=""UTF-8"" ?>
+			var xaml = """
+				<?xml version="1.0" encoding="UTF-8" ?>
 				<ContentPage
-					xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
-					xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
-					xmlns:cmp=""clr-namespace:Microsoft.Maui.Controls.Compatibility;assembly=Microsoft.Maui.Controls""
-					Title=""People"">
+					xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+					xmlns:cmp="clr-namespace:Microsoft.Maui.Controls.Compatibility;assembly=Microsoft.Maui.Controls"
+					Title="People">
 
-					<cmp:StackLayout Spacing=""0"">
-						<SearchBar x:Name=""searchBar""/>
-						<ListView ItemsSource=""{Binding Path=.}"" RowHeight=""42"" x:Name=""listview"">
+					<cmp:StackLayout Spacing="0">
+						<SearchBar x:Name="searchBar"/>
+						<ListView ItemsSource="{Binding Path=.}" RowHeight="42" x:Name="listview">
 							<ListView.ItemTemplate>
 								<DataTemplate>
 									<ViewCell>
 										<ViewCell.View>
-											<cmp:StackLayout Orientation=""Horizontal"" HorizontalOptions=""FillAndExpand"" VerticalOptions=""CenterAndExpand"" BackgroundColor=""#fff4f4f4"">
-												<BoxView WidthRequest=""10""/>
-												<cmp:Grid WidthRequest=""42"" HeightRequest=""32"" VerticalOptions=""CenterAndExpand"" HorizontalOptions=""Start"">
-													<Image WidthRequest=""32"" HeightRequest=""32"" Aspect=""AspectFill"" HorizontalOptions=""FillAndExpand"" Source=""Images/icone_nopic_members_42.png""/>
-													<!--<Image WidthRequest=""32"" HeightRequest=""32"" Aspect=""AspectFill"" HorizontalOptions=""FillAndExpand"">
+											<cmp:StackLayout Orientation="Horizontal" HorizontalOptions="FillAndExpand" VerticalOptions="CenterAndExpand" BackgroundColor="#fff4f4f4">
+												<BoxView WidthRequest="10"/>
+												<cmp:Grid WidthRequest="42" HeightRequest="32" VerticalOptions="CenterAndExpand" HorizontalOptions="Start">
+													<Image WidthRequest="32" HeightRequest="32" Aspect="AspectFill" HorizontalOptions="FillAndExpand" Source="Images/icone_nopic_members_42.png"/>
+													<!--<Image WidthRequest="32" HeightRequest="32" Aspect="AspectFill" HorizontalOptions="FillAndExpand">
 														<Image.Source>
-															<UriImageSource Uri=""{Binding Picture}"" CacheValidity=""30""/>
+															<UriImageSource Uri="{Binding Picture}" CacheValidity="30"/>
 														</Image.Source>
 													</Image>-->
-													<Image Source=""Images/cropcircle.png"" HorizontalOptions=""FillAndExpand"" VerticalOptions=""FillAndExpand"" WidthRequest=""32"" HeightRequest=""32"" Aspect=""Fill""/>
+													<Image Source="Images/cropcircle.png" HorizontalOptions="FillAndExpand" VerticalOptions="FillAndExpand" WidthRequest="32" HeightRequest="32" Aspect="Fill"/>
 												</cmp:Grid>
-												<Label Text=""{Binding FirstName}"" VerticalOptions=""CenterAndExpand""/>
-												<Label Text=""{Binding LastName}"" FontFamily=""HelveticaNeue-Bold"" FontSize=""Medium"" VerticalOptions=""CenterAndExpand"" />
+												<Label Text="{Binding FirstName}" VerticalOptions="CenterAndExpand"/>
+												<Label Text="{Binding LastName}" FontFamily="HelveticaNeue-Bold" FontSize="Medium" VerticalOptions="CenterAndExpand" />
 											</cmp:StackLayout>
 										</ViewCell.View>
 									</ViewCell>
@@ -137,7 +144,9 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 							</ListView.ItemTemplate>
 						</ListView>
 					</cmp:StackLayout>
-				</ContentPage>";
+				</ContentPage>
+				""";
+
 			var page = new ContentPage().LoadFromXaml(xaml);
 			var model = new List<object> {
 				new {FirstName = "John", LastName="Lennon", Picture="http://www.johnlennon.com/wp-content/themes/jl/images/home-gallery/2.jpg"},
@@ -158,28 +167,30 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[Test]
 		public void TestCase004()
 		{
-			var xaml = @"<?xml version=""1.0"" encoding=""UTF-8"" ?>
+			var xaml = """
+				<?xml version="1.0" encoding="UTF-8" ?>
 				<ContentPage
-					xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
-					xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml"">
+					xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 					<ContentPage.Content>
-					    <ScrollView Orientation=""Horizontal"">
-					        <ScrollView.Content>
-					            <Grid>
-					                <Grid.ColumnDefinitions>
-					                    <ColumnDefinition />
-					                    <ColumnDefinition />
-					                </Grid.ColumnDefinitions>
-					                <Image Grid.Column=""0"" Grid.Row=""0"" Aspect=""AspectFill"">
-					                    <Image.Source>
-					                        <StreamImageSource Stream=""{Binding HeroPicture.Stream}"" />
-					                    </Image.Source>
-					                </Image>
-					            </Grid>
-					        </ScrollView.Content>
-					    </ScrollView>
+						<ScrollView Orientation="Horizontal">
+							<ScrollView.Content>
+								<Grid>
+									<Grid.ColumnDefinitions>
+										<ColumnDefinition />
+										<ColumnDefinition />
+									</Grid.ColumnDefinitions>
+									<Image Grid.Column="0" Grid.Row="0" Aspect="AspectFill">
+										<Image.Source>
+											<StreamImageSource Stream="{Binding HeroPicture.Stream}" />
+										</Image.Source>
+									</Image>
+								</Grid>
+							</ScrollView.Content>
+						</ScrollView>
 					</ContentPage.Content>
-				</ContentPage>";
+				</ContentPage>
+				""";
 
 			var page = new ContentPage();
 			Assert.DoesNotThrow(() => page.LoadFromXaml(xaml));
@@ -188,14 +199,17 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[Test]
 		public void Issue1415()
 		{
-			var xaml = @"<?xml version=""1.0"" encoding=""utf-8"" ?>
-						<ContentPage 
-							xmlns=""http://schemas.microsoft.com/dotnet/2021/maui"" 
-							xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml""
-							xmlns:cmp=""clr-namespace:Microsoft.Maui.Controls.Compatibility;assembly=Microsoft.Maui.Controls""
-							xmlns:local=""clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests;assembly=Microsoft.Maui.Controls.Xaml.UnitTests"">
-							<Label x:Name=""label"" Text=""{Binding Converter={x:Static local:ReverseConverter.Instance}, Mode=TwoWay}""/>
-						</ContentPage>";
+			var xaml = """
+				<?xml version="1.0" encoding="utf-8" ?>
+				<ContentPage 
+					xmlns="http://schemas.microsoft.com/dotnet/2021/maui" 
+					xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+					xmlns:cmp="clr-namespace:Microsoft.Maui.Controls.Compatibility;assembly=Microsoft.Maui.Controls"
+					xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests;assembly=Microsoft.Maui.Controls.Xaml.UnitTests">
+					<Label x:Name="label" Text="{Binding Converter={x:Static local:ReverseConverter.Instance}, Mode=TwoWay}"/>
+				</ContentPage>
+				""";
+
 			var page = new ContentPage().LoadFromXaml(xaml);
 			var label = page.FindByName<Label>("label");
 			Assert.NotNull(label);
@@ -209,13 +223,16 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		{
 			System.Threading.Thread.CurrentThread.CurrentCulture = new System.Globalization.CultureInfo(culture);
 
-			var xaml = @"<?xml version=""1.0"" encoding=""utf-8"" ?>
-						<View 
-							xmlns=""http://schemas.microsoft.com/dotnet/2021/maui"" 
-							xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml""
-							xmlns:cmp=""clr-namespace:Microsoft.Maui.Controls.Compatibility;assembly=Microsoft.Maui.Controls""
-							cmp:RelativeLayout.HeightConstraint=""{cmp:ConstraintExpression Type=RelativeToParent, Property=Height, Factor=0.25}""
-							cmp:RelativeLayout.WidthConstraint=""{cmp:ConstraintExpression Type=RelativeToParent, Property=Width, Factor=0.6}""/>";
+			var xaml = """
+				<?xml version="1.0" encoding="utf-8" ?>
+				<View 
+					xmlns="http://schemas.microsoft.com/dotnet/2021/maui" 
+					xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+					xmlns:cmp="clr-namespace:Microsoft.Maui.Controls.Compatibility;assembly=Microsoft.Maui.Controls"
+					cmp:RelativeLayout.HeightConstraint="{cmp:ConstraintExpression Type=RelativeToParent, Property=Height, Factor=0.25}"
+					cmp:RelativeLayout.WidthConstraint="{cmp:ConstraintExpression Type=RelativeToParent, Property=Width, Factor=0.6}"/>
+				""";
+
 			View view = new View();
 			view.LoadFromXaml(xaml);
 			Assert.DoesNotThrow(() => view.LoadFromXaml(xaml));

--- a/src/Controls/tests/Xaml.UnitTests/LoaderTests.cs
+++ b/src/Controls/tests/Xaml.UnitTests/LoaderTests.cs
@@ -94,13 +94,13 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[Test]
 		public void TestRootName()
 		{
-			var xaml = @"
+			var xaml = """
 				<View
-				xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
-				xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
-				x:Class=""Microsoft.Maui.Controls.Xaml.UnitTests.CustomView"" 
-				x:Name=""customView"" 
-				/>";
+				xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+				xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+				x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.CustomView" 
+				x:Name="customView" />
+				""";
 
 			var view = new CustomView();
 			view.LoadFromXaml(xaml);
@@ -111,14 +111,15 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[Test]
 		public void TestFindByXName()
 		{
-			var xaml = @"
+			var xaml = """
 				<StackLayout 
-				xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
-				xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml"">
+				xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+				xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 					<StackLayout.Children>
-						<Label x:Name=""label0"" Text=""Foo""/>
+						<Label x:Name="label0" Text="Foo"/>
 					</StackLayout.Children>
-				</StackLayout>";
+				</StackLayout>
+				""";
 
 			var stacklayout = new StackLayout();
 			stacklayout.LoadFromXaml(xaml);
@@ -131,12 +132,12 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[Test]
 		public void TestUnknownPropertyShouldThrow()
 		{
-			var xaml = @"
+			var xaml = """
 				<Label 
-				xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
-				Text=""Foo""
-				UnknownProperty=""Bar""
-			    />";
+				xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+				Text="Foo"
+				UnknownProperty="Bar" />
+				""";
 
 			var label = new Label();
 			Assert.Throws(new XamlParseExceptionConstraint(5, 5), () => label.LoadFromXaml(xaml));
@@ -145,11 +146,11 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[Test]
 		public void TestSetValueToBindableProperty()
 		{
-			var xaml = @"
-			<Label 
-			xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
-			Text=""Foo""
-			/>";
+			var xaml = """
+				<Label 
+				xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+				Text="Foo" />
+				""";
 
 			var label = new Label();
 
@@ -161,11 +162,11 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[Test]
 		public void TestSetBindingToBindableProperty()
 		{
-			var xaml = @"
-			<Label 
-			xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
-			Text=""{Binding Path=labeltext}""
-			/>";
+			var xaml = """
+				<Label 
+				xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+				Text="{Binding Path=labeltext}" />
+				""";
 
 			var label = new Label();
 			label.LoadFromXaml(xaml);
@@ -179,14 +180,14 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[Test]
 		public void TestSetBindingToNonBindablePropertyShouldThrow()
 		{
-			var xaml = @"
+			var xaml = """
 				<View 
-				xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
-				xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
-				x:Class=""Microsoft.Maui.Controls.Xaml.UnitTests.CustomView"" 
-				Name=""customView"" 
-				NotBindable=""{Binding text}""
-				/>";
+				xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+				xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+				x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.CustomView" 
+				Name="customView" 
+				NotBindable="{Binding text}" />
+				""";
 
 			var view = new CustomView();
 			Assert.Throws(new XamlParseExceptionConstraint(6, 5), () => view.LoadFromXaml(xaml));
@@ -195,16 +196,17 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[Test]
 		public void TestBindingPath()
 		{
-			var xaml = @"
+			var xaml = """
 				<cmp:StackLayout 
-				xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
-				xmlns:cmp=""clr-namespace:Microsoft.Maui.Controls.Compatibility;assembly=Microsoft.Maui.Controls""
-				xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml"">
+				xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+				xmlns:cmp="clr-namespace:Microsoft.Maui.Controls.Compatibility;assembly=Microsoft.Maui.Controls"
+				xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 					<cmp:StackLayout.Children>
-						<Label x:Name=""label0"" Text=""{Binding text}""/>
-						<Label x:Name=""label1"" Text=""{Binding Path=text}""/>
+						<Label x:Name="label0" Text="{Binding text}"/>
+						<Label x:Name="label1" Text="{Binding Path=text}"/>
 					</cmp:StackLayout.Children>
-				</cmp:StackLayout>";
+				</cmp:StackLayout>
+				""";
 
 			var stacklayout = new Compatibility.StackLayout();
 			stacklayout.LoadFromXaml(xaml);
@@ -229,26 +231,27 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[Test]
 		public void TestBindingModeAndConverter()
 		{
-			var xaml = @"
+			var xaml = """
 				<ContentPage 
-				xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
-				xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
-				xmlns:cmp=""clr-namespace:Microsoft.Maui.Controls.Compatibility;assembly=Microsoft.Maui.Controls""
-				xmlns:local=""clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests;assembly=Microsoft.Maui.Controls.Xaml.UnitTests"">
+				xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+				xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+				xmlns:cmp="clr-namespace:Microsoft.Maui.Controls.Compatibility;assembly=Microsoft.Maui.Controls"
+				xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests;assembly=Microsoft.Maui.Controls.Xaml.UnitTests">
 					<ContentPage.Resources>
 						<ResourceDictionary>
-							<local:ReverseConverter x:Key=""reverseConverter""/>
+							<local:ReverseConverter x:Key="reverseConverter"/>
 						</ResourceDictionary>
 					</ContentPage.Resources>
 					<ContentPage.Content>
-						<cmp:StackLayout Orientation=""Vertical"">
+						<cmp:StackLayout Orientation="Vertical">
 							<cmp:StackLayout.Children>
-								<Label x:Name=""label0"" Text=""{Binding Text, Converter={StaticResource reverseConverter}}""/>
-								<Label x:Name=""label1"" Text=""{Binding Text, Mode=TwoWay}""/>
+								<Label x:Name="label0" Text="{Binding Text, Converter={StaticResource reverseConverter}}"/>
+								<Label x:Name="label1" Text="{Binding Text, Mode=TwoWay}"/>
 							</cmp:StackLayout.Children>
 						</cmp:StackLayout>
 					</ContentPage.Content>
-				</ContentPage>";
+				</ContentPage>
+				""";
 
 			var contentPage = new ContentPage();
 			contentPage.LoadFromXaml(xaml);
@@ -264,17 +267,18 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[Test]
 		public void TestNonEmptyCollectionMembers()
 		{
-			var xaml = @"
+			var xaml = """
 				<StackLayout 
-				xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
-				xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml"">
+				xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+				xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 					<StackLayout.Children>
-						<Grid x:Name=""grid0"">
+						<Grid x:Name="grid0">
 						</Grid>
-						<Grid x:Name=""grid1"">
+						<Grid x:Name="grid1">
 						</Grid>
 					</StackLayout.Children>
-				</StackLayout>";
+				</StackLayout>
+				""";
 
 			var stacklayout = new StackLayout();
 			stacklayout.LoadFromXaml(xaml);
@@ -287,14 +291,15 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[Test]
 		public void TestUnknownType()
 		{
-			var xaml = @"
+			var xaml = """
 				<StackLayout 
-				xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
-				xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml"">
+				xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+				xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 					<StackLayout.Children>
 						<CustomView />
 					</StackLayout.Children>
-				</StackLayout>";
+				</StackLayout>
+				""";
 
 			var stacklayout = new StackLayout();
 			Assert.Throws(new XamlParseExceptionConstraint(6, 8), () => stacklayout.LoadFromXaml(xaml));
@@ -303,17 +308,18 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[Test]
 		public void TestResources()
 		{
-			var xaml = @"
+			var xaml = """
 				<Label 
-				xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
-				xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
-				xmlns:local=""clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests;assembly=Microsoft.Maui.Controls.Xaml.UnitTests"">
+				xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+				xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+				xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests;assembly=Microsoft.Maui.Controls.Xaml.UnitTests">
 					<Label.Resources>
 						<ResourceDictionary>
-							<local:ReverseConverter x:Key=""reverseConverter""/>
+							<local:ReverseConverter x:Key="reverseConverter"/>
 						</ResourceDictionary>
 					</Label.Resources>
-				</Label>";
+				</Label>
+				""";
 
 			var label = new Label().LoadFromXaml(xaml);
 			Assert.NotNull(label.Resources);
@@ -324,17 +330,19 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[Test]
 		public void TestResourceDoesRequireKey()
 		{
-			var xaml = @"
+			var xaml = """
 				<Label 
-				xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
-				xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
-				xmlns:local=""clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests;assembly=Microsoft.Maui.Controls.Xaml.UnitTests"">
+				xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+				xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+				xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests;assembly=Microsoft.Maui.Controls.Xaml.UnitTests">
 					<Label.Resources>
 						<ResourceDictionary>
 							<local:ReverseConverter />
 						</ResourceDictionary>
 					</Label.Resources>
-				</Label>";
+				</Label>
+				""";
+
 			var label = new Label();
 			Assert.Throws(new XamlParseExceptionConstraint(8, 9), () => label.LoadFromXaml(xaml));
 		}
@@ -342,19 +350,20 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[Test]
 		public void UseResourcesOutsideOfBinding()
 		{
-			var xaml = @"
+			var xaml = """
 				<ContentView
-				  xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
-				  xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml"">
-				  <ContentView.Resources>
-                    <ResourceDictionary>
-                      <Label Text=""Foo"" x:Key=""bar""/>
-                    </ResourceDictionary>
-				  </ContentView.Resources>
-				<ContentView.Content>
-                  <ContentView Content=""{StaticResource bar}""/>
-				</ContentView.Content>
-                </ContentView>";
+					xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+					<ContentView.Resources>
+						<ResourceDictionary>
+							<Label Text="Foo" x:Key="bar"/>
+						</ResourceDictionary>
+					</ContentView.Resources>
+					<ContentView.Content>
+						<ContentView Content="{StaticResource bar}"/>
+					</ContentView.Content>
+				</ContentView>
+				""";
 
 			var contentView = new ContentView().LoadFromXaml(xaml);
 			Assert.AreEqual("Foo", (((ContentView)(contentView.Content)).Content as Label).Text);
@@ -397,20 +406,22 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		{
 			Application.Current = null;
 			Application.Current = new MyApp();
-			var xaml = @"
+			var xaml = """
 				<ContentView
-				  xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
-				  xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml"">
-				  <ContentView.Resources>
-                    <ResourceDictionary>
-                      <x:String x:Key=""bar"">BAZ</x:String>
-                    </ResourceDictionary>
-				  </ContentView.Resources>
-				  <StackLayout>
-				    <Label x:Name=""label0"" Text=""{StaticResource foo}""/>
-				    <Label x:Name=""label1"" Text=""{StaticResource bar}""/>
-				  </StackLayout>
-                </ContentView>";
+					xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+					<ContentView.Resources>
+					<ResourceDictionary>
+						<x:String x:Key="bar">BAZ</x:String>
+					</ResourceDictionary>
+					</ContentView.Resources>
+					<StackLayout>
+					<Label x:Name="label0" Text="{StaticResource foo}"/>
+					<Label x:Name="label1" Text="{StaticResource bar}"/>
+					</StackLayout>
+				</ContentView>
+				""";
+
 			var layout = new ContentView().LoadFromXaml(xaml);
 			var label0 = layout.FindByName<Label>("label0");
 			var label1 = layout.FindByName<Label>("label1");
@@ -425,12 +436,14 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[Test]
 		public void TestEvent()
 		{
-			var xaml = @"
+			var xaml = """
 				<Button 
-				xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
-				xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
-				x:Class=""Microsoft.Maui.Controls.Xaml.UnitTests.CustView"" Clicked=""onButtonClicked"" />
-				</Button>";
+				xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+				xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+				x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.CustView" Clicked="onButtonClicked" />
+				</Button>
+				""";
+
 			var view = new CustView();
 			view.LoadFromXaml(xaml);
 			Assert.False(view.fired);
@@ -441,12 +454,14 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[Test]
 		public void TestFailingEvent()
 		{
-			var xaml = @"
+			var xaml = """
 				<View 
-				xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
-				xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
-				x:Class=""Microsoft.Maui.Controls.Xaml.UnitTests.CustView"" Clicked=""missingMethod"" />
-				</View>";
+				xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+				xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+				x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.CustView" Clicked="missingMethod" />
+				</View>
+				""";
+
 			var view = new CustView();
 			Assert.Throws(new XamlParseExceptionConstraint(5, 63), () => view.LoadFromXaml(xaml));
 		}
@@ -454,12 +469,14 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[Test]
 		public void TestConnectingEventOnMethodWithWrongSignature()
 		{
-			var xaml = @"
+			var xaml = """
 				<View 
-				xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
-				xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
-				x:Class=""Microsoft.Maui.Controls.Xaml.UnitTests.CustView"" Clicked=""wrongSignature"" />
-				</View>";
+				xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+				xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+				x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.CustView" Clicked="wrongSignature" />
+				</View>
+				""";
+
 			var view = new CustView();
 
 			Assert.Throws(new XamlParseExceptionConstraint(5, 63), () => view.LoadFromXaml(xaml));
@@ -479,28 +496,32 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[Test]
 		public void TestEventWithCustomEventArgs()
 		{
-			var xaml = @"
-			<Entry
-				xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
-				xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
-				x:Class=""Microsoft.Maui.Controls.Xaml.UnitTests.CustEntry"" TextChanged=""onValueChanged"" />
-			</Entry>";
+			var xaml = """
+				<Entry
+					xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+					x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.CustEntry" TextChanged="onValueChanged" />
+				</Entry>
+				""";
+
 			new CustEntry().LoadFromXaml(xaml);
 		}
 
 		[Test]
 		public void TestEmptyTemplate()
 		{
-			var xaml = @"
-			<ContentPage
-				xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
-				xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml"">
-				<ContentPage.Resources>
-					<ResourceDictionary>
-						<DataTemplate x:Key=""datatemplate""/>
-					</ResourceDictionary>
-				</ContentPage.Resources>
-			</ContentPage>";
+			var xaml = """
+				<ContentPage
+					xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+					<ContentPage.Resources>
+						<ResourceDictionary>
+							<DataTemplate x:Key="datatemplate"/>
+						</ResourceDictionary>
+					</ContentPage.Resources>
+				</ContentPage>
+				""";
+
 			var page = new ContentPage();
 			page.LoadFromXaml(xaml);
 			var template = page.Resources["datatemplate"] as Maui.Controls.DataTemplate;
@@ -511,11 +532,12 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[Test]
 		public void TestBoolValue()
 		{
-			var xaml = @"
+			var xaml = """
 				<Image 
-				xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
-				xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
-				IsOpaque=""true""/>";
+				xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+				xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+				IsOpaque="true"/>
+				""";
 
 			var image = new Image();
 			Assert.AreEqual(Image.IsOpaqueProperty.DefaultValue, image.IsOpaque);
@@ -526,13 +548,15 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[Test]
 		public void TestAttachedBP()
 		{
-			var xaml = @"
+			var xaml = """
 				<View 
-				xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
-				xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
-				Grid.Column=""1"">
+				xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+				xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+				Grid.Column="1">
 					<Grid.Row>2</Grid.Row>
-				</View>";
+				</View>
+				""";
+
 			var view = new View().LoadFromXaml(xaml);
 			Assert.AreEqual(1, Grid.GetColumn(view));
 			Assert.AreEqual(2, Grid.GetRow(view));
@@ -542,12 +566,14 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		public void TestAttachedBPWithDifferentNS()
 		{
 			//If this looks very similar to Vernacular, well... it's on purpose :)
-			var xaml = @"
+			var xaml = """
 				<Label
-				xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
-				xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
-				xmlns:local=""clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests;assembly=Microsoft.Maui.Controls.Xaml.UnitTests"" 
-				local:Catalog.Message=""foobar""/>";
+				xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+				xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+				xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests;assembly=Microsoft.Maui.Controls.Xaml.UnitTests" 
+				local:Catalog.Message="foobar"/>
+				""";
+
 			var label = new Label().LoadFromXaml(xaml);
 			Assert.AreEqual("raboof", label.Text);
 		}
@@ -555,12 +581,14 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[Test]
 		public void TestBindOnAttachedBP()
 		{
-			var xaml = @"
+			var xaml = """
 				<Label
-				xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
-				xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
-				xmlns:local=""clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests;assembly=Microsoft.Maui.Controls.Xaml.UnitTests"" 
-				local:Catalog.Message=""{Binding .}""/>";
+				xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+				xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+				xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests;assembly=Microsoft.Maui.Controls.Xaml.UnitTests" 
+				local:Catalog.Message="{Binding .}"/>
+				""";
+
 			var label = new Label().LoadFromXaml(xaml);
 			label.BindingContext = "foobar";
 			Assert.AreEqual("raboof", label.Text);
@@ -569,13 +597,14 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[Test]
 		public void TestContentProperties()
 		{
-			var xaml = @"
+			var xaml = """
 				<local:CustomView
-				xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
-				xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
-				xmlns:local=""clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests;assembly=Microsoft.Maui.Controls.Xaml.UnitTests"" >
-					<Label x:Name=""contentview""/>
-				</local:CustomView>";
+				xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+				xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+				xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests;assembly=Microsoft.Maui.Controls.Xaml.UnitTests" >
+					<Label x:Name="contentview"/>
+				</local:CustomView>
+				""";
 			CustomView customView = null;
 			Assert.DoesNotThrow(() => customView = new CustomView().LoadFromXaml(xaml));
 			Assert.NotNull(customView.Content);
@@ -585,11 +614,13 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[Test]
 		public void TestCollectionContentProperties()
 		{
-			var xaml = @"
-				<StackLayout xmlns=""http://schemas.microsoft.com/dotnet/2021/maui"">
-					<Label Text=""Foo""/>
-					<Label Text=""Bar""/>
-				</StackLayout>";
+			var xaml = """
+				<StackLayout xmlns="http://schemas.microsoft.com/dotnet/2021/maui">
+					<Label Text="Foo"/>
+					<Label Text="Bar"/>
+				</StackLayout>
+				""";
+
 			var layout = new StackLayout().LoadFromXaml(xaml);
 			Assert.AreEqual(2, layout.Children.Count);
 			Assert.AreEqual("Foo", ((Label)(layout.Children[0])).Text);
@@ -599,10 +630,12 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[Test]
 		public void TestCollectionContentPropertiesWithSingleElement()
 		{
-			var xaml = @"
-				<StackLayout xmlns=""http://schemas.microsoft.com/dotnet/2021/maui"">
-					<Label Text=""Foo""/>
-				</StackLayout>";
+			var xaml = """
+				<StackLayout xmlns="http://schemas.microsoft.com/dotnet/2021/maui">
+					<Label Text="Foo"/>
+				</StackLayout>
+				""";
+
 			var layout = new StackLayout().LoadFromXaml(xaml);
 			Assert.AreEqual(1, layout.Children.Count);
 			Assert.AreEqual("Foo", ((Label)(layout.Children[0])).Text);
@@ -611,13 +644,15 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[Test]
 		public void TestPropertiesWithContentProperties()
 		{
-			var xaml = @"
+			var xaml = """
 				<ContentPage
-				xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
-				xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml"">
+				xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+				xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 				<Grid.Row>1</Grid.Row>
-				<Label Text=""foo""></Label>
-				</ContentPage>";
+				<Label Text="foo"></Label>
+				</ContentPage>
+				""";
+
 			var contentPage = new ContentPage().LoadFromXaml(xaml);
 			Assert.AreEqual(1, Grid.GetRow(contentPage));
 			Assert.NotNull(contentPage.Content);
@@ -643,18 +678,20 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[Test]
 		public void CreateNewChildrenCollection()
 		{
-			var xaml = @"
+			var xaml = """
 				<local:ViewWithChildrenContent
-				xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
-				xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
-				xmlns:local=""clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests;assembly=Microsoft.Maui.Controls.Xaml.UnitTests"" >
+				xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+				xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+				xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests;assembly=Microsoft.Maui.Controls.Xaml.UnitTests" >
 					<local:ViewWithChildrenContent.Children>
 						<local:ViewList>
-							<Label x:Name=""child0""/>
-							<Label x:Name=""child1""/>
+							<Label x:Name="child0"/>
+							<Label x:Name="child1"/>
 						</local:ViewList>
 					</local:ViewWithChildrenContent.Children>
-				</local:ViewWithChildrenContent>";
+				</local:ViewWithChildrenContent>
+				""";
+
 			ViewWithChildrenContent layout = null;
 			Assert.DoesNotThrow(() => layout = new ViewWithChildrenContent().LoadFromXaml(xaml));
 			Assert.IsNotNull(layout);
@@ -666,14 +703,16 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[Test]
 		public void AddChildrenToCollectionContentProperty()
 		{
-			var xaml = @"
+			var xaml = """
 				<local:ViewWithChildrenContent
-				xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
-				xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
-				xmlns:local=""clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests;assembly=Microsoft.Maui.Controls.Xaml.UnitTests"" >
-					<Label x:Name=""child0""/>
-					<Label x:Name=""child1""/>
-				</local:ViewWithChildrenContent>";
+				xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+				xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+				xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests;assembly=Microsoft.Maui.Controls.Xaml.UnitTests" >
+					<Label x:Name="child0"/>
+					<Label x:Name="child1"/>
+				</local:ViewWithChildrenContent>
+				""";
+
 			ViewWithChildrenContent layout = null;
 			Assert.DoesNotThrow(() => layout = new ViewWithChildrenContent().LoadFromXaml(xaml));
 			Assert.IsNotNull(layout);
@@ -685,16 +724,18 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[Test]
 		public void AddChildrenToExistingCollection()
 		{
-			var xaml = @"
+			var xaml = """
 				<local:ViewWithChildrenContent
-				xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
-				xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
-				xmlns:local=""clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests;assembly=Microsoft.Maui.Controls.Xaml.UnitTests"" >
+				xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+				xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+				xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests;assembly=Microsoft.Maui.Controls.Xaml.UnitTests" >
 					<local:ViewWithChildrenContent.Children>
-						<Label x:Name=""child0""/>
-						<Label x:Name=""child1""/>
+						<Label x:Name="child0"/>
+						<Label x:Name="child1"/>
 					</local:ViewWithChildrenContent.Children>
-				</local:ViewWithChildrenContent>";
+				</local:ViewWithChildrenContent>
+				""";
+
 			ViewWithChildrenContent layout = null;
 			Assert.DoesNotThrow(() => layout = new ViewWithChildrenContent().LoadFromXaml(xaml));
 			Assert.IsNotNull(layout);
@@ -707,13 +748,15 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[Test]
 		public void AddSingleChildToCollectionContentProperty()
 		{
-			var xaml = @"
+			var xaml = """
 				<local:ViewWithChildrenContent
-				xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
-				xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
-				xmlns:local=""clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests;assembly=Microsoft.Maui.Controls.Xaml.UnitTests"" >
-					<Label x:Name=""child0""/>
-				</local:ViewWithChildrenContent>";
+				xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+				xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+				xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests;assembly=Microsoft.Maui.Controls.Xaml.UnitTests" >
+					<Label x:Name="child0"/>
+				</local:ViewWithChildrenContent>
+				""";
+
 			ViewWithChildrenContent layout = null;
 			Assert.DoesNotThrow(() => layout = new ViewWithChildrenContent().LoadFromXaml(xaml));
 			Assert.IsNotNull(layout);
@@ -724,18 +767,19 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[Test]
 		public void FindResourceByName()
 		{
-			var xaml = @"
+			var xaml = """
 				<ContentPage
-				    xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
-				    xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml"" 
-				    x:Class=""Resources"">
-				    <ContentPage.Resources>
+					xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" 
+					x:Class="Resources">
+					<ContentPage.Resources>
 						<ResourceDictionary>
-						    <Button x:Key=""buttonKey"" x:Name=""buttonName""/>
+							<Button x:Key="buttonKey" x:Name="buttonName"/>
 						</ResourceDictionary>
-				    </ContentPage.Resources>
-				    <Label x:Name=""label""/>
-				</ContentPage>";
+					</ContentPage.Resources>
+					<Label x:Name="label"/>
+				</ContentPage>
+				""";
 
 			var layout = new ContentPage().LoadFromXaml(xaml);
 			Assert.True(layout.Resources.ContainsKey("buttonKey"));
@@ -747,13 +791,15 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[Test]
 		public void ParseEnum()
 		{
-			var xaml = @"
+			var xaml = """
 				<local:CustomView
-				xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
-				xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
-				xmlns:local=""clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests;assembly=Microsoft.Maui.Controls.Xaml.UnitTests"" 
-				MockFlags=""Bar""
-				/>";
+				xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+				xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+				xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests;assembly=Microsoft.Maui.Controls.Xaml.UnitTests" 
+				MockFlags="Bar"
+				/>
+				""";
+
 			var view = new CustomView().LoadFromXaml(xaml);
 			Assert.AreEqual(MockFlags.Bar, view.MockFlags);
 
@@ -762,13 +808,15 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[Test]
 		public void ParseFlags()
 		{
-			var xaml = @"
+			var xaml = """
 				<local:CustomView
-				xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
-				xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
-				xmlns:local=""clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests;assembly=Microsoft.Maui.Controls.Xaml.UnitTests"" 
-				MockFlags=""Baz,Bar""
-				/>";
+				xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+				xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+				xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests;assembly=Microsoft.Maui.Controls.Xaml.UnitTests" 
+				MockFlags="Baz,Bar"
+				/>
+				""";
+
 			var view = new CustomView().LoadFromXaml(xaml);
 			Assert.AreEqual(MockFlags.Bar | MockFlags.Baz, view.MockFlags);
 		}
@@ -776,14 +824,16 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[Test]
 		public void StyleWithoutTargetTypeThrows()
 		{
-			var xaml = @"
-				<Label xmlns=""http://schemas.microsoft.com/dotnet/2021/maui"">
+			var xaml = """
+				<Label xmlns="http://schemas.microsoft.com/dotnet/2021/maui">
 					<Label.Style>
 						<Style>
-							<Setter Property=""Text"" Value=""Foo"" />
+							<Setter Property="Text" Value="Foo" />
 						</Style>
 					</Label.Style>
-				</Label>";
+				</Label>
+				""";
+
 			var label = new Label();
 			Assert.Throws(new XamlParseExceptionConstraint(4, 8), () => label.LoadFromXaml(xaml));
 		}

--- a/src/Controls/tests/Xaml.UnitTests/MSBuild/MSBuildTests.cs
+++ b/src/Controls/tests/Xaml.UnitTests/MSBuild/MSBuildTests.cs
@@ -29,21 +29,23 @@ namespace Microsoft.Maui.Controls.MSBuild.UnitTests
 			const string MicrosoftMauiControlsFormsDefaultNamespace = "http://schemas.microsoft.com/dotnet/2021/maui";
 			const string MicrosoftMauiControlsFormsXNamespace = "http://schemas.microsoft.com/winfx/2006/xaml";
 
-			public static readonly string MainPage = $@"
+			public static readonly string MainPage = $"""
 				<ContentPage
-					xmlns=""{MicrosoftMauiControlsFormsDefaultNamespace}""
-					xmlns:x=""{MicrosoftMauiControlsFormsXNamespace}""
-					x:Class=""Microsoft.Maui.Controls.Xaml.UnitTests.MainPage"">
-					<Label x:Name=""label0""/>
-				</ContentPage>";
+					xmlns="{MicrosoftMauiControlsFormsDefaultNamespace}"
+					xmlns:x="{MicrosoftMauiControlsFormsXNamespace}"
+					x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.MainPage">
+					<Label x:Name="label0"/>
+				</ContentPage>
+				""";
 
-			public static readonly string CustomView = $@"
+			public static readonly string CustomView = $"""
 				<ContentView
-					xmlns=""{MicrosoftMauiControlsFormsDefaultNamespace}""
-					xmlns:x=""{MicrosoftMauiControlsFormsXNamespace}""
-					x:Class=""Microsoft.Maui.Controls.Xaml.UnitTests.CustomView"">
-					<Label x:Name=""label0""/>
-				</ContentView>";
+					xmlns="{MicrosoftMauiControlsFormsDefaultNamespace}"
+					xmlns:x="{MicrosoftMauiControlsFormsXNamespace}"
+					x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.CustomView">
+					<Label x:Name="label0"/>
+				</ContentView>
+				""";
 		}
 
 		class Css

--- a/src/Controls/tests/Xaml.UnitTests/MarkupExtensionTests.cs
+++ b/src/Controls/tests/Xaml.UnitTests/MarkupExtensionTests.cs
@@ -148,13 +148,14 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[Test]
 		public void TestInXaml()
 		{
-			var xaml = @"
-			<Label 
-				xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
-				xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
-				xmlns:local=""clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests;assembly=Microsoft.Maui.Controls.Xaml.UnitTests""
-				Text=""{local:AppendMarkupExtension Value0=Foo, Value1=Bar}""
-			/>";
+			var xaml = """
+				<Label 
+					xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+					xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests;assembly=Microsoft.Maui.Controls.Xaml.UnitTests"
+					Text="{local:AppendMarkupExtension Value0=Foo, Value1=Bar}"
+				/>
+				""";
 
 			var label = new Label();
 			label.LoadFromXaml(xaml);
@@ -164,13 +165,14 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[Test]
 		public void TestMarkupExtensionInDefaultNamespace()
 		{
-			var xaml = @"
-			<forms:Label 
-				xmlns=""clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests;assembly=Microsoft.Maui.Controls.Xaml.UnitTests""
-				xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
-				xmlns:forms=""http://schemas.microsoft.com/dotnet/2021/maui""
-				Text=""{AppendMarkupExtension Value0=Foo, Value1=Bar}""
-			/>";
+			var xaml = """
+				<forms:Label 
+					xmlns="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests;assembly=Microsoft.Maui.Controls.Xaml.UnitTests"
+					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+					xmlns:forms="http://schemas.microsoft.com/dotnet/2021/maui"
+					Text="{AppendMarkupExtension Value0=Foo, Value1=Bar}"
+				/>
+				""";
 
 			var label = new Label();
 			label.LoadFromXaml(xaml);
@@ -180,12 +182,13 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[Test]
 		public void TestDocumentationCode()
 		{
-			var xaml = @"
-			<Label
-				xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
-				xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
-				xmlns:local=""clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests;assembly=Microsoft.Maui.Controls.Xaml.UnitTests""
-				TextColor=""{local:ColorMarkup R=100, G=80, B=60}""/>";
+			var xaml = """
+				<Label
+					xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+					xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests;assembly=Microsoft.Maui.Controls.Xaml.UnitTests"
+					TextColor="{local:ColorMarkup R=100, G=80, B=60}"/>
+				""";
 
 			var label = new Label().LoadFromXaml(xaml);
 			Assert.AreEqual(Color.FromRgb(100, 80, 60), label.TextColor);

--- a/src/Controls/tests/Xaml.UnitTests/NameScopeTests.cs
+++ b/src/Controls/tests/Xaml.UnitTests/NameScopeTests.cs
@@ -12,10 +12,11 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[Test]
 		public void TopLevelObjectsHaveANameScope()
 		{
-			var xaml = @"
+			var xaml = """
 				<View 
-				xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
-				xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml"" />";
+				xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+				xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" />
+				""";
 
 			var view = new CustomView().LoadFromXaml(xaml);
 
@@ -26,13 +27,14 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[Test]
 		public void NameScopeAreSharedWithChildren()
 		{
-			var xaml = @"
+			var xaml = """
 				<StackLayout 
-				xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
-				xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml"" >
+				xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+				xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" >
 					<Label />
 					<Label />
-				</StackLayout>";
+				</StackLayout>
+				""";
 
 			var layout = new Controls.Compatibility.StackLayout().LoadFromXaml(xaml);
 
@@ -51,17 +53,18 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		{
 			DispatcherProvider.SetCurrent(new DispatcherProviderStub());
 
-			var xaml = @"
+			var xaml = """
 				<ListView
-				xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
-				xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
-				x:Name=""listview"">
+				xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+				xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+				x:Name="listview">
 					<ListView.ItemTemplate>
 						<DataTemplate>
-						    <TextCell Text=""{Binding name}"" x:Name=""textcell""/>
+							<TextCell Text="{Binding name}" x:Name="textcell"/>
 						</DataTemplate>
 					</ListView.ItemTemplate>
-				</ListView>";
+				</ListView>
+				""";
 
 			var listview = new ListView();
 			listview.LoadFromXaml(xaml);
@@ -75,17 +78,18 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		{
 			DispatcherProvider.SetCurrent(new DispatcherProviderStub());
 
-			var xaml = @"
+			var xaml = """
 				<ListView
-				xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
-				xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
-				x:Name=""listview"">
+				xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+				xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+				x:Name="listview">
 					<ListView.ItemTemplate>
 						<DataTemplate>
-						    <TextCell Text=""{Binding name}"" x:Name=""textcell""/>
+							<TextCell Text="{Binding name}" x:Name="textcell"/>
 						</DataTemplate>
 					</ListView.ItemTemplate>
-				</ListView>";
+				</ListView>
+				""";
 
 			var listview = new ListView();
 			listview.LoadFromXaml(xaml);

--- a/src/Controls/tests/Xaml.UnitTests/OnAppThemeTests.cs
+++ b/src/Controls/tests/Xaml.UnitTests/OnAppThemeTests.cs
@@ -31,11 +31,12 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[Test]
 		public void OnAppThemeExtensionLightDarkColor()
 		{
-			var xaml = @"
-			<Label 
-			xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
-			xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml"" TextColor=""{AppThemeBinding Light = Green, Dark = Red}
-			"">This text is green or red depending on Light (or default) or Dark</Label>";
+			var xaml = """
+				<Label 
+				xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+				xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" TextColor="{AppThemeBinding Light = Green, Dark = Red}
+				">This text is green or red depending on Light (or default) or Dark</Label>
+				""";
 
 			SetAppTheme(AppTheme.Light);
 			var label = new Label().LoadFromXaml(xaml);
@@ -49,15 +50,16 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[Test]
 		public void OnAppThemeLightDarkColor()
 		{
-			var xaml = @"
-			<Label
-			xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
-			xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml""
-			Text=""This text is green or red depending on Light(or default) or Dark"">
-                <Label.TextColor>
-                    <AppThemeBinding Light=""Green"" Dark=""Red"" />
-				</Label.TextColor>
-			</Label> ";
+			var xaml = """
+				<Label
+				xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+				xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+				Text="This text is green or red depending on Light(or default) or Dark">
+					<Label.TextColor>
+						<AppThemeBinding Light="Green" Dark="Red" />
+					</Label.TextColor>
+				</Label> 
+				""";
 
 			SetAppTheme(AppTheme.Light);
 			var label = new Label().LoadFromXaml(xaml);
@@ -71,15 +73,16 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[Test]
 		public void OnAppThemeUnspecifiedThemeDefaultsToLightColor()
 		{
-			var xaml = @"
-			<Label
-			xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
-			xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml""
-			Text=""This text is green or red depending on Light(or default) or Dark"">
-                <Label.TextColor>
-                    <AppThemeBinding Light=""Green"" Dark=""Red"" />
-				</Label.TextColor>
-			</Label> ";
+			var xaml = """
+				<Label
+				xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+				xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+				Text="This text is green or red depending on Light(or default) or Dark">
+					<Label.TextColor>
+						<AppThemeBinding Light="Green" Dark="Red" />
+					</Label.TextColor>
+				</Label> 
+				""";
 
 			SetAppTheme(AppTheme.Unspecified);
 			var label = new Label().LoadFromXaml(xaml);
@@ -89,15 +92,16 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[Test]
 		public void OnAppThemeUnspecifiedLightColorDefaultsToDefault()
 		{
-			var xaml = @"
-			<Label
-			xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
-			xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml""
-			Text=""This text is green or red depending on Light(or default) or Dark"">
-                <Label.TextColor>
-                    <AppThemeBinding Default=""Green"" Dark=""Red"" />
-				</Label.TextColor>
-			</Label> ";
+			var xaml = """
+				<Label
+				xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+				xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+				Text="This text is green or red depending on Light(or default) or Dark">
+					<Label.TextColor>
+						<AppThemeBinding Default="Green" Dark="Red" />
+					</Label.TextColor>
+				</Label> 
+				""";
 
 			SetAppTheme(AppTheme.Light);
 			var label = new Label().LoadFromXaml(xaml);
@@ -107,15 +111,16 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[Test]
 		public void AppThemeColorLightDark()
 		{
-			var xaml = @"
-			<Label
-			xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
-			xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml""
-			Text=""This text is green or red depending on Light(or default) or Dark"">
-                <Label.TextColor>
-                    <AppThemeBinding Light=""Green"" Dark=""Red"" />
-				</Label.TextColor>
-			</Label> ";
+			var xaml = """
+				<Label
+				xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+				xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+				Text="This text is green or red depending on Light(or default) or Dark">
+					<Label.TextColor>
+						<AppThemeBinding Light="Green" Dark="Red" />
+					</Label.TextColor>
+				</Label> 
+				""";
 
 			SetAppTheme(AppTheme.Light);
 			var label = new Label().LoadFromXaml(xaml);
@@ -129,15 +134,16 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[Test]
 		public void AppThemeColorUnspecifiedThemeDefaultsToLightColor()
 		{
-			var xaml = @"
-			<Label
-			xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
-			xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml""
-			Text=""This text is green or red depending on Light(or default) or Dark"">
-                <Label.TextColor>
-                    <AppThemeBinding Light=""Green"" Dark=""Red"" />
-				</Label.TextColor>
-			</Label> ";
+			var xaml = """
+				<Label
+				xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+				xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+				Text="This text is green or red depending on Light(or default) or Dark">
+					<Label.TextColor>
+						<AppThemeBinding Light="Green" Dark="Red" />
+					</Label.TextColor>
+				</Label> 
+				""";
 
 			SetAppTheme(AppTheme.Unspecified);
 			var label = new Label().LoadFromXaml(xaml);
@@ -147,15 +153,16 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[Test]
 		public void AppThemeColorUnspecifiedLightColorDefaultsToDefault()
 		{
-			var xaml = @"
-			<Label
-			xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
-			xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml""
-			Text=""This text is green or red depending on Light(or default) or Dark"">
-                <Label.TextColor>
-                    <AppThemeBinding Default=""Green"" Dark=""Red"" />
-				</Label.TextColor>
-			</Label> ";
+			var xaml = """
+				<Label
+				xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+				xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+				Text="This text is green or red depending on Light(or default) or Dark">
+					<Label.TextColor>
+						<AppThemeBinding Default="Green" Dark="Red" />
+					</Label.TextColor>
+				</Label> 
+				""";
 
 			SetAppTheme(AppTheme.Unspecified);
 			var label = new Label().LoadFromXaml(xaml);

--- a/src/Controls/tests/Xaml.UnitTests/OnPlatformTests.cs
+++ b/src/Controls/tests/Xaml.UnitTests/OnPlatformTests.cs
@@ -20,17 +20,19 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		public void ApplyToProperty()
 		{
 			mockDeviceInfo.Platform = DevicePlatform.iOS;
-			var xaml = @"
-			<ContentPage 
-			xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
-			xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml""
-			xmlns:scg=""clr-namespace:System.Collections.Generic;assembly=mscorlib"">
-				<OnPlatform x:TypeArguments=""View"">
-					<On Platform=""iOS""><Button Text=""iOS""/></On>
-					<On Platform=""Android""><Button Text=""Android""/></On>
-					<On Platform=""UWP""><Button Text=""UWP""/></On>
-				</OnPlatform>
-			</ContentPage>";
+			var xaml = """
+				<ContentPage 
+				xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+				xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+				xmlns:scg="clr-namespace:System.Collections.Generic;assembly=mscorlib">
+					<OnPlatform x:TypeArguments="View">
+						<On Platform="iOS"><Button Text="iOS"/></On>
+						<On Platform="Android"><Button Text="Android"/></On>
+						<On Platform="UWP"><Button Text="UWP"/></On>
+					</OnPlatform>
+				</ContentPage>
+				""";
+
 			var layout = new ContentPage().LoadFromXaml(xaml);
 			Assert.NotNull(layout.Content);
 		}
@@ -38,24 +40,25 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[Test]
 		public void UseTypeConverters()
 		{
-			var xaml = @"
-			<ContentPage xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
-             xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml""
-             Title=""Grid Demo Page"">
-			  <ContentPage.Padding>
-			    <OnPlatform x:TypeArguments=""Thickness"">
-			      <On Platform=""iOS"">
-			        0, 20, 0, 0
-			      </On>
-			      <On Platform=""Android"">
-			        0, 0, 10, 0
-			      </On>
-			      <On Platform=""UWP"">
-			        0, 20, 0, 20
-			      </On>
-			    </OnPlatform>
-			  </ContentPage.Padding>  
-			</ContentPage>";
+			var xaml = """
+				<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+					xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+					Title="Grid Demo Page">
+					<ContentPage.Padding>
+					<OnPlatform x:TypeArguments="Thickness">
+						<On Platform="iOS">
+						0, 20, 0, 0
+						</On>
+						<On Platform="Android">
+						0, 0, 10, 0
+						</On>
+						<On Platform="UWP">
+						0, 20, 0, 20
+						</On>
+					</OnPlatform>
+					</ContentPage.Padding>  
+				</ContentPage>
+				""";
 
 			ContentPage layout;
 
@@ -76,17 +79,18 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		//Issue 1480
 		public void TypeConverterAndDerivedTypes()
 		{
-			var xaml = @"
-			<Image xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
-             xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml"">
-				<Image.Source>
-	                <OnPlatform x:TypeArguments=""ImageSource"">
-	                    <On Platform=""iOS"">icon_twitter.png</On>
-	                    <On Platform=""Android"">icon_twitter.png</On>
-	                    <On Platform=""UWP"">Images/icon_twitter.png</On>
-	                </OnPlatform>
-	            </Image.Source>
-			</Image>";
+			var xaml = """
+				<Image xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+					xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+					<Image.Source>
+						<OnPlatform x:TypeArguments="ImageSource">
+							<On Platform="iOS">icon_twitter.png</On>
+							<On Platform="Android">icon_twitter.png</On>
+							<On Platform="UWP">Images/icon_twitter.png</On>
+						</OnPlatform>
+					</Image.Source>
+				</Image>
+				""";
 
 			Image image;
 
@@ -98,17 +102,18 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[Test]
 		public void UWPisWinUI()
 		{
-			var xaml = @"
-			<Image xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
-				xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml"">
-				<Image.Source>
-					<OnPlatform x:TypeArguments=""ImageSource"">
-						<On Platform=""iOS"">icon_twitter.png</On>
-						<On Platform=""Android"">icon_twitter.png</On>
-						<On Platform=""UWP"">Images/icon_twitter.png</On>
-					</OnPlatform>
-				</Image.Source>
-			</Image>";
+			var xaml = """
+				<Image xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+					xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+					<Image.Source>
+						<OnPlatform x:TypeArguments="ImageSource">
+							<On Platform="iOS">icon_twitter.png</On>
+							<On Platform="Android">icon_twitter.png</On>
+							<On Platform="UWP">Images/icon_twitter.png</On>
+						</OnPlatform>
+					</Image.Source>
+				</Image>
+				""";
 
 			Image image;
 
@@ -120,18 +125,19 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[Test]
 		public void ChecksPreferWinUI()
 		{
-			var xaml = @"
-			<Image xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
-				xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml"">
-				<Image.Source>
-					<OnPlatform x:TypeArguments=""ImageSource"">
-						<On Platform=""iOS"">icon_twitter.png</On>
-						<On Platform=""Android"">icon_twitter.png</On>
-						<On Platform=""UWP"">Images/icon_twitter.png</On>
-						<On Platform=""WinUI"">Images/icon_twitter_preferred.png</On>
-					</OnPlatform>
-				</Image.Source>
-			</Image>";
+			var xaml = """
+				<Image xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+					xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+					<Image.Source>
+						<OnPlatform x:TypeArguments="ImageSource">
+							<On Platform="iOS">icon_twitter.png</On>
+							<On Platform="Android">icon_twitter.png</On>
+							<On Platform="UWP">Images/icon_twitter.png</On>
+							<On Platform="WinUI">Images/icon_twitter_preferred.png</On>
+						</OnPlatform>
+					</Image.Source>
+				</Image>
+				""";
 
 			Image image;
 
@@ -156,19 +162,20 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[Test]
 		public void StackLayoutOrientation()
 		{
-			var xaml = @"
-			<StackLayout 
-			xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
-			xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml"">
-				<StackLayout.Orientation>
-				<OnIdiom x:TypeArguments=""StackOrientation"">
-					<OnIdiom.Phone>Vertical</OnIdiom.Phone>
-					<OnIdiom.Tablet>Horizontal</OnIdiom.Tablet>
-				</OnIdiom>
-				</StackLayout.Orientation>
-				<Label Text=""child0""/>
-				<Label Text=""child1""/>			
-			</StackLayout>";
+			var xaml = """
+				<StackLayout 
+				xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+				xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+					<StackLayout.Orientation>
+					<OnIdiom x:TypeArguments="StackOrientation">
+						<OnIdiom.Phone>Vertical</OnIdiom.Phone>
+						<OnIdiom.Tablet>Horizontal</OnIdiom.Tablet>
+					</OnIdiom>
+					</StackLayout.Orientation>
+					<Label Text="child0"/>
+					<Label Text="child1"/>			
+				</StackLayout>
+				""";
 
 			mockDeviceInfo.Idiom = DeviceIdiom.Phone;
 			var layout = new StackLayout().LoadFromXaml(xaml);

--- a/src/Controls/tests/Xaml.UnitTests/TextTransformTests.cs
+++ b/src/Controls/tests/Xaml.UnitTests/TextTransformTests.cs
@@ -12,10 +12,11 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[TestCase(TextTransform.Uppercase)]
 		public void LabelTextTransform(TextTransform result)
 		{
-			var xaml = @"
-			<Label 
-				xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
-				xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml"" TextTransform=""" + result + @""" />";
+			var xaml = $"""
+				<Label 
+					xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" TextTransform="{result}" />
+				""";
 
 			var label = new Label().LoadFromXaml(xaml);
 

--- a/src/Graphics/samples/GraphicsTester.Portable/Scenarios/DrawMarkdigAttributedText.cs
+++ b/src/Graphics/samples/GraphicsTester.Portable/Scenarios/DrawMarkdigAttributedText.cs
@@ -19,14 +19,16 @@ namespace GraphicsTester.Scenarios
 
 			canvas.SaveState();
 
-			var value = @"This is *italic* and __underline__ and **bold** and __*underline italic*__ and __**underline bold**__ and ***bold italic*** and __***underline bold italic***__.
-This is ~~strike through~~.
-This is ~sub~script and this is ^super^script.
-This is <span style=""color:blue"">blue text</span> and <span style=""background:yellow"">highlighted text</span>
+			var value = """
+				This is *italic* and __underline__ and **bold** and __*underline italic*__ and __**underline bold**__ and ***bold italic*** and __***underline bold italic***__.
+				This is ~~strike through~~.
+				This is ~sub~script and this is ^super^script.
+				This is <span style="color:blue">blue text</span> and <span style="background:yellow">highlighted text</span>
 
-This is a list:
-* line 1
-* line 2";
+				This is a list:
+				* line 1
+				* line 2
+				""";
 
 			var attributedText = MarkdownAttributedTextReader.Read(value);
 			canvas.Translate(0, 10);

--- a/src/SingleProject/Resizetizer/src/AndroidAdaptiveIconGenerator.cs
+++ b/src/SingleProject/Resizetizer/src/AndroidAdaptiveIconGenerator.cs
@@ -23,13 +23,14 @@ namespace Microsoft.Maui.Resizetizer
 
 		public string AppIconName { get; }
 
-		const string AdaptiveIconDrawableXml =
-@"<?xml version=""1.0"" encoding=""utf-8""?>
-<adaptive-icon xmlns:android=""http://schemas.android.com/apk/res/android"">
-	<background android:drawable=""@mipmap/{name}_background""/>
-	<foreground android:drawable=""@mipmap/{name}_foreground""/>
-	<monochrome android:drawable=""@mipmap/{name}_foreground"" />
-</adaptive-icon>";
+		const string AdaptiveIconDrawableXml = """
+			<?xml version="1.0" encoding="utf-8"?>
+			<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+				<background android:drawable="@mipmap/{name}_background"/>
+				<foreground android:drawable="@mipmap/{name}_foreground"/>
+				<monochrome android:drawable="@mipmap/{name}_foreground" />
+			</adaptive-icon>
+			""";
 
 		public IEnumerable<ResizedImageInfo> Generate()
 		{

--- a/src/SingleProject/Resizetizer/src/CreatePartialInfoPlistTask.cs
+++ b/src/SingleProject/Resizetizer/src/CreatePartialInfoPlistTask.cs
@@ -16,14 +16,17 @@ namespace Microsoft.Maui.Resizetizer
 
 		public string Storyboard { get; set; }
 
-		const string plistHeader =
-@"<?xml version=""1.0"" encoding=""UTF-8""?>
-<!DOCTYPE plist PUBLIC ""-//Apple//DTD PLIST 1.0//EN"" ""http://www.apple.com/DTDs/PropertyList-1.0.dtd"">
-<plist version=""1.0"">
-<dict>";
-		const string plistFooter = @"
-</dict>
-</plist>";
+		const string plistHeader = """
+			<?xml version="1.0" encoding="UTF-8"?>
+			<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+			<plist version="1.0">
+			<dict>
+			""";
+
+		const string plistFooter = """
+			</dict>
+			</plist>
+			""";
 
 		public override bool Execute()
 		{


### PR DESCRIPTION
Raw string literals are a cool feature of C# 11 that will improve code readability and maintainability. Preserving a lot of code indenting ability, and eliminating a lot of need for escape characters.

I implemented this mainly using auto-refactoring