### PR TITLE
Optimize IndexOf lookups

### DIFF
--- a/src/Core/src/Extensions/EnumerableExtensions.cs
+++ b/src/Core/src/Extensions/EnumerableExtensions.cs
@@ -56,6 +56,12 @@ namespace Microsoft.Maui
 			if (enumerable == null)
 				throw new ArgumentNullException(nameof(enumerable));
 
+            if (enumerable is IList<T> list)
+                return list.IndexOf(item);
+
+            if (enumerable is T[] array)
+                return Array.IndexOf(array, item);
+
 			var i = 0;
 			foreach (T element in enumerable)
 			{

--- a/src/Core/tests/Benchmarks/Benchmarks/IndexOfBenchmarker.cs
+++ b/src/Core/tests/Benchmarks/Benchmarks/IndexOfBenchmarker.cs
@@ -1,0 +1,30 @@
+﻿namespace Microsoft.Maui.Benchmarks;
+
+using System.Collections.Generic;
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+
+[MemoryDiagnoser]
+public class IndexOfBenchmarker
+{
+    private List<int> list;
+    private int[] array;
+    private HashSet<int> hashSet;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        list = Enumerable.Range(0, 1000000).ToList();
+        array = list.ToArray();
+        hashSet = list.ToHashSet();
+    }
+
+    [Benchmark]
+    public void IndexOfList() => EnumerableExtensions.IndexOf(list, 999999);
+
+    [Benchmark]
+    public void IndexOfArray() => EnumerableExtensions.IndexOf(array, 999999);
+
+    [Benchmark]
+    public void IndexOfHashSet() => EnumerableExtensions.IndexOf(hashSet, 999999);
+}


### PR DESCRIPTION
This extension method in Core is referenced in at least 19 places.

With this change, the performance in some cases is orders of magnitude better.

https://dotnetfiddle.net/Anb4rA