### PR TITLE
Fix connectivity broadcast receiver never triggered on android 14.0/34+

### DIFF
--- a/src/Essentials/src/Connectivity/Connectivity.android.cs
+++ b/src/Essentials/src/Connectivity/Connectivity.android.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Maui.Networking
 
 			conectivityReceiver = new ConnectivityBroadcastReceiver(OnConnectivityChanged);
 
-			PlatformUtils.RegisterBroadcastReceiver(conectivityReceiver, filter, false);
+			PlatformUtils.RegisterBroadcastReceiver(conectivityReceiver, filter, true);
 		}
 
 		void StopListeners()


### PR DESCRIPTION
### Description of Change

For connectivity, we need to set the broadcastreceiver parameter to `EXPORTED`.

As you can see, the `EXPORTED` parameter is required for broadcasts sent from the system: https://developer.android.com/develop/background-work/background-tasks/broadcasts#context-registered-receivers

Without the parameter, the `ConnectivityChanged` event is never triggered.

I've tested the fix on a Google Pixel 8 Pro in ANDROID 14 and it works.

### Issues Fixed

Fix issue #19949 
