### PR TITLE
Source Generator Performance Improvements

### DIFF
--- a/src/Controls/samples/Controls.Sample/Maui.Controls.Sample.csproj
+++ b/src/Controls/samples/Controls.Sample/Maui.Controls.Sample.csproj
@@ -52,6 +52,13 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference
+      Include="..\..\..\Controls\src\Core\Controls.SourceGen.csproj"
+      OutputItemType="Analyzer"
+      ReferenceOutputAssembly="false"/>
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\..\BlazorWebView\samples\MauiRazorClassLibrarySample\MauiRazorClassLibrarySample.csproj" />
   </ItemGroup>
 

--- a/src/Controls/src/SourceGen/Properties/launchSettings.json
+++ b/src/Controls/src/SourceGen/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "SourceGen - Maui.Controls.Sample": {
+      "commandName": "DebugRoslynComponent",
+      "targetProject": "..\\..\\samples\\Controls.Sample\\Maui.Controls.Sample.csproj"
+    }
+  }
+}

--- a/src/Controls/src/Xaml/XamlNode.cs
+++ b/src/Controls/src/Xaml/XamlNode.cs
@@ -1,4 +1,5 @@
 #nullable disable
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -69,7 +70,17 @@ namespace Microsoft.Maui.Controls.Xaml
 
 		public override int GetHashCode()
 		{
-			return NamespaceUri.GetHashCode() ^ Name.GetHashCode();
+			unchecked
+			{
+#if NETSTANDARD2_0
+				int hashCode = NamespaceUri.GetHashCode();
+				hashCode = (hashCode * 397) ^ Name.GetHashCode();
+#else
+				int hashCode = NamespaceUri.GetHashCode(StringComparison.Ordinal);
+				hashCode = (hashCode * 397) ^ Name.GetHashCode(StringComparison.Ordinal);
+#endif
+				return hashCode;
+			}
 		}
 	}
 

--- a/src/Controls/src/Xaml/XamlNode.cs
+++ b/src/Controls/src/Xaml/XamlNode.cs
@@ -53,6 +53,24 @@ namespace Microsoft.Maui.Controls.Xaml
 		public string NamespaceUri { get; }
 		public string Name { get; }
 		public IList<XmlType> TypeArguments { get; }
+
+		public override bool Equals(object obj)
+		{
+			if (obj is not XmlType other)
+			{
+				return false;
+			}
+
+			return
+				NamespaceUri == other.NamespaceUri &&
+				Name == other.Name &&
+				(TypeArguments == null && other.TypeArguments == null || TypeArguments.SequenceEqual(other.TypeArguments));
+		}
+
+		public override int GetHashCode()
+		{
+			return NamespaceUri.GetHashCode() ^ Name.GetHashCode();
+		}
 	}
 
 	abstract class BaseNode : IXmlLineInfo, INode

--- a/src/Controls/src/Xaml/XmlTypeXamlExtensions.cs
+++ b/src/Controls/src/Xaml/XmlTypeXamlExtensions.cs
@@ -61,9 +61,9 @@ namespace Microsoft.Maui.Controls.Xaml
 			}
 
 			var lookupNames = new List<string>(capacity: 2);
-			lookupNames.Add(elementName);
 			if (elementName != "DataTemplate" && !elementName.EndsWith("Extension", StringComparison.Ordinal))
 				lookupNames.Add(elementName + "Extension");
+			lookupNames.Add(elementName);
 
 			for (var i = 0; i < lookupNames.Count; i++)
 			{

--- a/src/Controls/src/Xaml/XmlTypeXamlExtensions.cs
+++ b/src/Controls/src/Xaml/XmlTypeXamlExtensions.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Maui.Controls.Xaml
 					lookupAssemblies.Add(new XmlnsDefinitionAttribute(namespaceURI, ns) { AssemblyName = asmstring });
 			}
 
-			var lookupNames = new List<string>();
+			var lookupNames = new List<string>(capacity: 2);
 			lookupNames.Add(elementName);
 			if (elementName != "DataTemplate" && !elementName.EndsWith("Extension", StringComparison.Ordinal))
 				lookupNames.Add(elementName + "Extension");

--- a/src/Controls/src/Xaml/XmlTypeXamlExtensions.cs
+++ b/src/Controls/src/Xaml/XmlTypeXamlExtensions.cs
@@ -61,9 +61,9 @@ namespace Microsoft.Maui.Controls.Xaml
 			}
 
 			var lookupNames = new List<string>();
+			lookupNames.Add(elementName);
 			if (elementName != "DataTemplate" && !elementName.EndsWith("Extension", StringComparison.Ordinal))
 				lookupNames.Add(elementName + "Extension");
-			lookupNames.Add(elementName);
 
 			for (var i = 0; i < lookupNames.Count; i++)
 			{


### PR DESCRIPTION
### Description of Change

<!-- Enter description of the fix in this section -->

Source Generator Performance Improvements:
- Reversed lookup order (Extension second)
- Introduced type cache
- Restored lookup order (Extension first again)

```
PERF PROGRESS
Updated numbers. Not quite as dramatic but still a good improvement. The original measurements had a TracePoint skewing the timing results quite heavily. The new numbers only use a StopWatch in code with the TracePoint disabled.

SourceGen - Maui.Controls.Sample (262 XAML files)

1) Unchanged:
- 15640 GetTypeByMetadata calls
~ 4s

2) Extensions lookup in XmlTypeXamlExtensions.GetTypeReference() second
- 6232 GetTypeByMetadata calls (~60% reduction)
~ 2.6s                         (~35% reduction)

3) With type cache and Extension lookup second
- 203 GetTypeByMetadata calls  (~99% reduction)
~ 1.5s                         (~62% reduction => ~2.6 times faster)

4) With just a type cache
- 523 GetTypeByMetadata calls  (~97% reduction)
~ 1.5s                         (~62% reduction => ~2.6 times faster)
```

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #19944 GetTypeNameFromCustomNamespace does not cache duplicate results

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
