### PR TITLE
[Trimming] Replace trimming unsafe usage of implicit operators through reflection with IValueConverters

### DIFF
--- a/src/Compatibility/Core/src/Android/AppCompat/Platform.cs
+++ b/src/Compatibility/Core/src/Android/AppCompat/Platform.cs
@@ -16,6 +16,7 @@ using AView = Android.Views.View;
 namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 {
 	[Obsolete]
+	[ValueConverter(typeof(PlatformValueConverter))]
 	public class Platform : BindableObject, IPlatformLayout, INavigation
 	{
 		readonly Context _context;
@@ -859,5 +860,18 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 			}
 
 		}
+	}
+
+	internal sealed class PlatformValueConverter : IValueConverter
+	{
+		public object? Convert(object? value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+			=> value switch
+			{
+				Platform platform when targetType == typeof(ViewGroup) => (ViewGroup)platform,
+				_ => null,
+			};
+
+		public object? ConvertBack(object? value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+			=> null;
 	}
 }

--- a/src/Controls/src/Core/Accelerator.cs
+++ b/src/Controls/src/Core/Accelerator.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/Accelerator.xml" path="Type[@FullName='Microsoft.Maui.Controls.Accelerator']/Docs/*" />
 	[System.ComponentModel.TypeConverter(typeof(AcceleratorTypeConverter))]
+	[ValueConverter(typeof(AcceleratorValueConverter))]
 	[Obsolete("Use KeyboardAccelerator instead.")]
 	public class Accelerator
 	{
@@ -106,5 +107,21 @@ namespace Microsoft.Maui.Controls
 		{
 			return FromString(accelerator);
 		}
+	}
+
+#nullable enable
+	internal sealed class AcceleratorValueConverter : IValueConverter
+	{
+		public object? Convert(object? value, Type targetType, object? parameter, System.Globalization.CultureInfo culture)
+			=> null;
+
+		public object? ConvertBack(object? value, Type targetType, object? parameter, System.Globalization.CultureInfo culture)
+			=> value switch
+			{
+#pragma warning disable CS0618 // 'Accelerator' is obsolete: 'Use KeyboardAccelerator instead.'
+				string accelerator => (Accelerator)accelerator,
+#pragma warning restore CS0618
+				_ => null,
+			};
 	}
 }

--- a/src/Controls/src/Core/BindableProperty.cs
+++ b/src/Controls/src/Core/BindableProperty.cs
@@ -229,10 +229,9 @@ namespace Microsoft.Maui.Controls
 			if (returnType.IsAssignableFrom(valueType))
 				return true;
 
-			var cast = returnType.GetImplicitConversionOperator(fromType: valueType, toType: returnType) ?? valueType.GetImplicitConversionOperator(fromType: valueType, toType: returnType);
-			if (cast != null)
+			if (value.TryConvertValue(toType: returnType, out var convertedValue))
 			{
-				value = cast.Invoke(null, new[] { value });
+				value = convertedValue;
 				return true;
 			}
 			if (KnownIValueConverters.TryGetValue(returnType, out IValueConverter valueConverter))

--- a/src/Controls/src/Core/Brush/Brush.cs
+++ b/src/Controls/src/Core/Brush/Brush.cs
@@ -1,4 +1,5 @@
 ﻿#nullable disable
+using System;
 using Microsoft.Maui.Graphics;
 using GraphicsGradientStop = Microsoft.Maui.Graphics.PaintGradientStop;
 
@@ -9,6 +10,7 @@ namespace Microsoft.Maui.Controls
 	/// </summary>
 	/// <remarks>Derived classes describe different ways of painting an area.</remarks>
 	[System.ComponentModel.TypeConverter(typeof(BrushTypeConverter))]
+	[ValueConverter(typeof(BrushValueConverter))]
 	public abstract partial class Brush : Element
 	{
 		public static implicit operator Brush(Paint paint)
@@ -537,6 +539,26 @@ namespace Microsoft.Maui.Controls
 		static ImmutableBrush yellowGreen;
 		/// <summary>Gets a <see cref="SolidColorBrush"/> of the system-defined color <see cref="Colors.YellowGreen"/>.</summary>
 		public static SolidColorBrush YellowGreen => yellowGreen ??= new(Colors.YellowGreen);
+	}
 
+#nullable enable
+	internal sealed class BrushValueConverter : IValueConverter
+	{
+		public object? Convert(object? value, Type targetType, object? parameter, System.Globalization.CultureInfo culture)
+			=> value switch
+			{
+				Brush brush when targetType == typeof(Brush) => brush,
+				Brush brush when targetType == typeof(Paint) => (Paint)brush,
+				_ => null,
+			};
+
+		public object? ConvertBack(object? value, Type targetType, object? parameter, System.Globalization.CultureInfo culture)
+			=> value switch
+			{
+				Brush brush => brush,
+				Color color => (Brush)color,
+				Paint paint => (Paint)paint,
+				_ => null,
+			};
 	}
 }

--- a/src/Controls/src/Core/DoubleCollection.cs
+++ b/src/Controls/src/Core/DoubleCollection.cs
@@ -6,6 +6,7 @@ namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/DoubleCollection.xml" path="Type[@FullName='Microsoft.Maui.Controls.DoubleCollection']/Docs/*" />
 	[System.ComponentModel.TypeConverter(typeof(DoubleCollectionConverter))]
+	[ValueConverter(typeof(DoubleCollectionValueConverter))]
 	public sealed class DoubleCollection : ObservableCollection<double>
 	{
 		/// <include file="../../docs/Microsoft.Maui.Controls/DoubleCollection.xml" path="//Member[@MemberName='.ctor'][1]/Docs/*" />
@@ -30,5 +31,20 @@ namespace Microsoft.Maui.Controls
 				array[i] = (float)this[i];
 			return array;
 		}
+	}
+
+#nullable enable
+	internal sealed class DoubleCollectionValueConverter : IValueConverter
+	{
+		public object? Convert(object? value, Type targetType, object? parameter, System.Globalization.CultureInfo culture)
+			=> null;
+		
+		public object? ConvertBack(object? value, Type targetType, object? parameter, System.Globalization.CultureInfo culture)
+			=> value switch
+			{
+				double[] doubles => (DoubleCollection)doubles,
+				float[] floats => (DoubleCollection)floats,
+				_ => null,
+			};
 	}
 }

--- a/src/Controls/src/Core/FileImageSource.cs
+++ b/src/Controls/src/Core/FileImageSource.cs
@@ -1,10 +1,12 @@
 #nullable disable
+using System;
 using System.Threading.Tasks;
 
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/FileImageSource.xml" path="Type[@FullName='Microsoft.Maui.Controls.FileImageSource']/Docs/*" />
 	[System.ComponentModel.TypeConverter(typeof(FileImageSourceConverter))]
+	[ValueConverter(typeof(FileImageSourceValueConverter))]
 	public sealed partial class FileImageSource : ImageSource
 	{
 		/// <summary>Bindable property for <see cref="File"/>.</summary>
@@ -48,5 +50,23 @@ namespace Microsoft.Maui.Controls
 				OnSourceChanged();
 			base.OnPropertyChanged(propertyName);
 		}
+	}
+
+#nullable enable
+	internal sealed class FileImageSourceValueConverter : IValueConverter
+	{
+		public object? Convert(object? value, Type targetType, object? parameter, System.Globalization.CultureInfo culture)
+			=> value switch
+			{
+				FileImageSource fileImageSource when targetType == typeof(string) => (string)fileImageSource,
+				_ => null,
+			};
+
+		public object? ConvertBack(object? value, Type targetType, object? parameter, System.Globalization.CultureInfo culture)
+			=> value switch
+			{
+				string file => (FileImageSource)file,
+				_ => null,
+			};
 	}
 }

--- a/src/Controls/src/Core/FormattedString.cs
+++ b/src/Controls/src/Core/FormattedString.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/FormattedString.xml" path="Type[@FullName='Microsoft.Maui.Controls.FormattedString']/Docs/*" />
 	[ContentProperty("Spans")]
+	[ValueConverter(typeof(FormattedStringValueConverter))]
 	public class FormattedString : Element
 	{
 		readonly SpanCollection _spans = new SpanCollection();
@@ -87,5 +88,18 @@ namespace Microsoft.Maui.Controls
 				base.OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, removed));
 			}
 		}
+	}
+
+	internal sealed class FormattedStringValueConverter : IValueConverter
+	{
+		public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+			=> null;
+
+		public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+			=> value switch
+			{
+				string formattedString => (FormattedString)formattedString,
+				_ => null,
+			};
 	}
 }

--- a/src/Controls/src/Core/IWrappedValue.cs
+++ b/src/Controls/src/Core/IWrappedValue.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Globalization;
+
+namespace Microsoft.Maui.Controls
+{
+	internal interface IWrappedValue
+	{
+		object Value { get; }
+		Type Type { get; }
+	}
+
+	internal sealed class WrappedValueValueConverter : IValueConverter
+	{
+		public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+		{
+			if (value is IWrappedValue wrappedValue && targetType == wrappedValue.Type)
+				return wrappedValue.Value;
+
+			return null;
+		}
+
+		public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+			=> null;
+	}
+}

--- a/src/Controls/src/Core/ImageSource.cs
+++ b/src/Controls/src/Core/ImageSource.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/ImageSource.xml" path="Type[@FullName='Microsoft.Maui.Controls.ImageSource']/Docs/*" />
 	[System.ComponentModel.TypeConverter(typeof(ImageSourceConverter))]
+	[ValueConverter(typeof(ImageSourceValueConverter))]
 	public abstract partial class ImageSource : Element
 	{
 		readonly object _synchandle = new object();
@@ -153,5 +154,19 @@ namespace Microsoft.Maui.Controls
 			add { _weakEventManager.AddEventHandler(value); }
 			remove { _weakEventManager.RemoveEventHandler(value); }
 		}
+	}
+
+	internal sealed class ImageSourceValueConverter : IValueConverter
+	{
+		public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+			=> null;
+
+		public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+			=> value switch
+			{
+				string source => (ImageSource)source,
+				Uri uri => (ImageSource)uri,
+				_ => null,
+			};
 	}
 }

--- a/src/Controls/src/Core/OnIdiom.cs
+++ b/src/Controls/src/Core/OnIdiom.cs
@@ -1,9 +1,11 @@
 #nullable disable
+using System;
 using Microsoft.Maui.Devices;
 
 namespace Microsoft.Maui.Controls
 {
-	public class OnIdiom<T>
+	[ValueConverter(typeof(WrappedValueValueConverter))]
+	public class OnIdiom<T> : IWrappedValue
 	{
 		T _phone;
 		T _tablet;
@@ -87,5 +89,8 @@ namespace Microsoft.Maui.Controls
 			else
 				return onIdiom._isPhoneSet ? onIdiom.Phone : (onIdiom._isDefaultSet ? onIdiom.Default : default(T));
 		}
+
+		object IWrappedValue.Value => (T)this;
+		Type IWrappedValue.Type => typeof(T);
 	}
 }

--- a/src/Controls/src/Core/OnPlatform.cs
+++ b/src/Controls/src/Core/OnPlatform.cs
@@ -1,4 +1,5 @@
 #nullable disable
+using System;
 using System.Collections.Generic;
 using Microsoft.Maui.Controls.Xaml;
 using Microsoft.Maui.Devices;
@@ -6,7 +7,8 @@ using Microsoft.Maui.Devices;
 namespace Microsoft.Maui.Controls
 {
 	[ContentProperty("Platforms")]
-	public class OnPlatform<T>
+	[ValueConverter(typeof(WrappedValueValueConverter))]
+	public class OnPlatform<T> : IWrappedValue
 	{
 		public OnPlatform()
 		{
@@ -54,6 +56,9 @@ namespace Microsoft.Maui.Controls
 
 			return onPlatform.hasDefault ? onPlatform.@default : default(T);
 		}
+
+		object IWrappedValue.Value => (T)this;
+		Type IWrappedValue.Type => typeof(T);
 	}
 
 	/// <include file="../../docs/Microsoft.Maui.Controls/On.xml" path="Type[@FullName='Microsoft.Maui.Controls.On']/Docs/*" />

--- a/src/Controls/src/Core/PointCollection.cs
+++ b/src/Controls/src/Core/PointCollection.cs
@@ -1,4 +1,5 @@
 ﻿#nullable disable
+using System;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using Microsoft.Maui.Graphics;
@@ -6,6 +7,7 @@ using Microsoft.Maui.Graphics;
 namespace Microsoft.Maui.Controls
 {
 	[System.ComponentModel.TypeConverter(typeof(Shapes.PointCollectionConverter))]
+	[ValueConverter(typeof(PointCollectionValueConverter))]
 	public sealed class PointCollection : ObservableCollection<Point>
 	{
 		public PointCollection() : base()
@@ -19,5 +21,19 @@ namespace Microsoft.Maui.Controls
 
 		public static implicit operator PointCollection(Point[] d)
 			=> d == null ? new() : new(d);
+	}
+
+#nullable enable
+	internal sealed class PointCollectionValueConverter : IValueConverter
+	{
+		public object? Convert(object? value, Type targetType, object? parameter, System.Globalization.CultureInfo culture)
+			=> null;
+
+		public object? ConvertBack(object? value, Type targetType, object? parameter, System.Globalization.CultureInfo culture)
+			=> value switch
+			{
+				Point[] points => (PointCollection)points,
+				_ => null,
+			};
 	}
 }

--- a/src/Controls/src/Core/Shell/ShellContent.cs
+++ b/src/Controls/src/Core/Shell/ShellContent.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../../docs/Microsoft.Maui.Controls/ShellContent.xml" path="Type[@FullName='Microsoft.Maui.Controls.ShellContent']/Docs/*" />
 	[ContentProperty(nameof(Content))]
+	[ValueConverter(typeof(ShellContentValueConverter))]
 	public class ShellContent : BaseShellItem, IShellContentController, IVisualTreeElement
 	{
 		static readonly BindablePropertyKey MenuItemsPropertyKey =
@@ -344,5 +345,23 @@ namespace Microsoft.Maui.Controls
 					query.ResetToQueryParameters();
 			}
 		}
+	}
+
+#nullable enable
+	internal sealed class ShellContentValueConverter : IValueConverter
+	{
+		public object? Convert(object? value, Type targetType, object? parameter, System.Globalization.CultureInfo culture)
+			=> value switch
+			{
+				ShellContent shellContent when targetType == typeof(ShellSection) => (ShellSection)shellContent,
+				_ => null,
+			};
+
+		public object? ConvertBack(object? value, Type targetType, object? parameter, System.Globalization.CultureInfo culture)
+			=> value switch
+			{
+				TemplatedPage templatedPage => (ShellContent)templatedPage,
+				_ => null,
+			};
 	}
 }

--- a/src/Controls/src/Core/Shell/ShellItem.cs
+++ b/src/Controls/src/Core/Shell/ShellItem.cs
@@ -50,6 +50,7 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../../docs/Microsoft.Maui.Controls/ShellItem.xml" path="Type[@FullName='Microsoft.Maui.Controls.ShellItem']/Docs/*" />
 	[ContentProperty(nameof(Items))]
 	[EditorBrowsable(EditorBrowsableState.Never)]
+	[ValueConverter(typeof(ShellItemValueConverter))]
 	public class ShellItem : ShellGroupItem, IShellItemController, IElementConfiguration<ShellItem>, IPropertyPropagationController, IVisualTreeElement
 	{
 		#region PropertyKeys
@@ -342,5 +343,23 @@ namespace Microsoft.Maui.Controls
 			if (this.IsVisibleItem && CurrentItem != null)
 				((IShellController)Parent)?.AppearanceChanged(CurrentItem, false);
 		}
+	}
+
+#nullable enable
+
+	internal sealed class ShellItemValueConverter : IValueConverter
+	{
+		public object? Convert(object? value, Type targetType, object? parameter, System.Globalization.CultureInfo culture)
+			=> null;
+
+		public object? ConvertBack(object? value, Type targetType, object? parameter, System.Globalization.CultureInfo culture)
+			=> value switch
+			{
+				MenuItem menuItem => (ShellItem)menuItem,
+				ShellContent shellContent => (ShellItem)shellContent,
+				ShellSection shellSection => (ShellItem)shellSection,
+				TemplatedPage templatedPage => (ShellItem)templatedPage,
+				_ => null,
+			};
 	}
 }

--- a/src/Controls/src/Core/Shell/ShellNavigationState.cs
+++ b/src/Controls/src/Core/Shell/ShellNavigationState.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../../docs/Microsoft.Maui.Controls/ShellNavigationState.xml" path="Type[@FullName='Microsoft.Maui.Controls.ShellNavigationState']/Docs/*" />
 	[DebuggerDisplay("Location = {Location}")]
+	[ValueConverter(typeof(ShellNavigationStateValueConverter))]
 	public class ShellNavigationState
 	{
 		Uri _fullLocation;
@@ -97,5 +98,20 @@ namespace Microsoft.Maui.Controls
 			toKeep.Insert(0, "");
 			return new Uri(string.Join(Routing.PathSeparator, toKeep), UriKind.Relative);
 		}
+	}
+
+#nullable enable
+	internal sealed class ShellNavigationStateValueConverter : IValueConverter
+	{
+		public object? Convert(object? value, Type targetType, object? parameter, System.Globalization.CultureInfo culture)
+			=> null;
+
+		public object? ConvertBack(object? value, Type targetType, object? parameter, System.Globalization.CultureInfo culture)
+			=> value switch
+			{
+				Uri uri => (ShellNavigationState)uri,
+				string str => (ShellNavigationState)str,
+				_ => null,
+			};
 	}
 }

--- a/src/Controls/src/Core/TemplatedPage.cs
+++ b/src/Controls/src/Core/TemplatedPage.cs
@@ -6,6 +6,7 @@ namespace Microsoft.Maui.Controls
 {
 
 	/// <include file="../../docs/Microsoft.Maui.Controls/TemplatedPage.xml" path="Type[@FullName='Microsoft.Maui.Controls.TemplatedPage']/Docs/*" />
+	[ValueConverter(typeof(TemplatedPageValueConverter))]
 	public class TemplatedPage : Page, IControlTemplated
 	{
 		/// <summary>Bindable property for <see cref="ControlTemplate"/>.</summary>
@@ -68,5 +69,21 @@ namespace Microsoft.Maui.Controls
 		}
 
 		protected object GetTemplateChild(string name) => TemplateUtilities.GetTemplateChild(this, name);
+	}
+
+#nullable enable
+	internal sealed class TemplatedPageValueConverter : IValueConverter
+	{
+		public object? Convert(object? value, Type targetType, object? parameter, System.Globalization.CultureInfo culture)
+			=> value switch
+			{
+				TemplatedPage templatedPage when targetType == typeof(ShellContent) => (ShellContent)templatedPage,
+				TemplatedPage templatedPage when targetType == typeof(ShellItem) => (ShellItem)templatedPage,
+				TemplatedPage templatedPage when targetType == typeof(ShellSection) => (ShellSection)templatedPage,
+				_ => null,
+			};
+
+		public object? ConvertBack(object? value, Type targetType, object? parameter, System.Globalization.CultureInfo culture)
+			=> null;
 	}
 }

--- a/src/Controls/src/Core/ValueConverterAttribute.cs
+++ b/src/Controls/src/Core/ValueConverterAttribute.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.Maui.Controls
+{
+#pragma warning disable RS0016 // Symbol 'ValueConverterAttribute' is not part of the declared public API 
+	[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, AllowMultiple = false)]
+	public sealed class ValueConverterAttribute : Attribute
+	{
+		public ValueConverterAttribute([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type converterType)
+		{
+			Debug.Assert(typeof(IValueConverter).IsAssignableFrom(converterType));
+
+			ConverterType = converterType;
+		}
+
+		[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+		public Type ConverterType { get; }
+	}
+#pragma warning restore RS0016
+}

--- a/src/Controls/src/Core/WebView/WebViewSource.cs
+++ b/src/Controls/src/Core/WebView/WebViewSource.cs
@@ -5,6 +5,7 @@ using System.ComponentModel;
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/WebViewSource.xml" path="Type[@FullName='Microsoft.Maui.Controls.WebViewSource']/Docs/*" />
+	[ValueConverter(typeof(WebViewSourceValueConverter))]
 	public abstract class WebViewSource : BindableObject, IWebViewSource
 	{
 		public static implicit operator WebViewSource(Uri url)
@@ -29,5 +30,20 @@ namespace Microsoft.Maui.Controls
 		public abstract void Load(IWebViewDelegate renderer);
 
 		internal event EventHandler SourceChanged;
+	}
+
+#nullable enable
+	internal sealed class WebViewSourceValueConverter : IValueConverter
+	{
+		public object? Convert(object? value, Type targetType, object? parameter, System.Globalization.CultureInfo culture)
+			=> null;
+
+		public object? ConvertBack(object? value, Type targetType, object? parameter, System.Globalization.CultureInfo culture)
+			=> value switch
+			{
+				string url => (UrlWebViewSource)url,
+				Uri url => (WebViewSource)url,
+				_ => null,
+			};
 	}
 }

--- a/src/Controls/src/Core/Xaml/TypeConversionExtensions.cs
+++ b/src/Controls/src/Core/Xaml/TypeConversionExtensions.cs
@@ -34,6 +34,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Reflection;
 using Microsoft.Maui.Controls.Xaml.Internals;
+using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Controls.Xaml
 {
@@ -233,13 +234,9 @@ namespace Microsoft.Maui.Controls.Xaml
 			//if the value is not assignable and there's an implicit conversion, convert
 			if (value != null && !toType.IsAssignableFrom(value.GetType()))
 			{
-				var opImplicit = value.GetType().GetImplicitConversionOperator(fromType: value.GetType(), toType: toType)
-								?? toType.GetImplicitConversionOperator(fromType: value.GetType(), toType: toType);
-
-				if (opImplicit != null)
+				if (value.TryConvertValue(toType, out var convertedValue))
 				{
-					value = opImplicit.Invoke(null, new[] { value });
-					return value;
+					return convertedValue;
 				}
 			}
 
@@ -252,7 +249,150 @@ namespace Microsoft.Maui.Controls.Xaml
 			return value;
 		}
 
-		internal static MethodInfo GetImplicitConversionOperator(this Type onType, Type fromType, Type toType)
+#nullable enable
+		internal static bool TryConvertValue(this object value, Type toType, out object? convertedValue)
+		{
+			Type fromType = value.GetType();
+
+			if (toType.IsAssignableFrom(fromType))
+			{
+				convertedValue = value;
+				return true;
+			}
+
+			// TODO: Introduce the feature switch
+			// if (RuntimeFeature.IsImplicitConversionOperatorsCompatibilityEnabled)
+			// {
+			// 	return value.TryConvertUsingImplicitConversionOperator(toType, out convertedValue);
+			// }
+
+			convertedValue = value.TryConvertValueOfKnownTypes(toType);
+			if (convertedValue is not null)
+			{
+				return true;
+			}
+
+			ValueConverterAttribute? converterAttribute = value.GetType().GetCustomAttribute<ValueConverterAttribute>();
+			if (converterAttribute is not null)
+			{
+				var converter = (IValueConverter)Activator.CreateInstance(converterAttribute.ConverterType)!; // TODO: cache the converter?
+				convertedValue = converter.Convert(value, toType, null, CultureInfo.CurrentCulture);
+				if (convertedValue is not null)
+				{
+					return true;
+				}
+			}
+
+			converterAttribute = toType.GetCustomAttribute<ValueConverterAttribute>();
+			if (converterAttribute is not null)
+			{
+				var converter = (IValueConverter)Activator.CreateInstance(converterAttribute.ConverterType)!; // TODO: cache the converter?
+				convertedValue = converter.ConvertBack(value, toType, null, CultureInfo.CurrentCulture); // TODO: is ConvertBack the method to use here? I suppose it is, but I can't find good examples in the codebase.
+				if (convertedValue is not null)
+				{
+					return true;
+				}
+			}
+
+			// TODO: Introduce the feature switch
+			// if (RuntimeFeature.IsDebugConfiguration)
+			// {
+			// 	if (GetImplicitConversionOperator(fromType, toType) is MethodInfo method)
+			// 	{
+			// 		// There is an implicit cast which we would use to successfully convert the values if the feature switch
+			// 		// was enabled. Howerver, in some cases the app migth behave differently with and without trimming.
+			// 		// The developer should migrate to the new conversion mechanism.
+			// 		throw new InvalidOperationException($"Implicit conversion operators are not supported because their usage through reflection is not trimming friendly. Consider implementing an IValueConverter to implement conversion from {fromType} to {toType} instead of '{method}' declared on '{method.DeclaringType}'."); // TODO improve exception message
+			// 	}
+			// }
+
+			convertedValue = null;
+			return false;
+		}
+
+		private static bool TryConvertUsingImplicitConversionOperator(
+			this object value,
+			Type toType,
+			[NotNullWhen(true)] out object? convertedValue)
+		{
+			convertedValue = null;
+
+			var cast = GetImplicitConversionOperator(value.GetType(), toType);
+			if (cast is not null)
+			{
+				convertedValue = cast.Invoke(null, new[] { value });
+				return convertedValue is not null;
+			}
+
+			return false;
+		}
+
+		// The types converted by this method can't have [ValueConverter] attribute for some reason (for example because we don't control them
+		// or because they are in the Microsoft.Maui project and don't have access to the Microsoft.Maui.Controls).
+		private static object? TryConvertValueOfKnownTypes(this object inputValue, Type toType)
+		{
+			if (IsNumber(inputValue) && Convert.ChangeType(inputValue, typeof(double)) is double doubleValue)
+			{
+				if (toType == typeof(CornerRadius))
+					return (CornerRadius)doubleValue;
+				if (toType == typeof(GridLength))
+					return (GridLength)doubleValue;
+				if (toType == typeof(Thickness))
+					return (Thickness)doubleValue;
+				if (toType == typeof(Microsoft.Maui.Layouts.FlexBasis))
+					return (Microsoft.Maui.Layouts.FlexBasis)doubleValue;
+			}
+
+			return inputValue switch
+			{
+				Func<double, double> func when toType == typeof(Easing) => (Easing)func,
+				Point point when toType == typeof(PointF) => (PointF)point,
+				PointF point when toType == typeof(Point) => (Point)point,
+				Rect rect when toType == typeof(RectF) => (RectF)rect,
+				RectF rect when toType == typeof(Rect) => (Rect)rect,
+				Size size when toType == typeof(SizeF) => (SizeF)size,
+				Size size when toType == typeof(SizeRequest) => (SizeRequest)size,
+				Size size when toType == typeof(Thickness) => (Thickness)size,
+				SizeF size when toType == typeof(Size) => (Size)size,
+				SizeRequest sizeRequest when toType == typeof(Size) => (Size)sizeRequest,
+				System.Numerics.Vector2 vector when toType == typeof(Point) => (Point)vector,
+				System.Numerics.Vector2 vector when toType == typeof(PointF) => (PointF)vector,
+				System.Numerics.Vector4 vector when toType == typeof(Color) => (Color)vector,
+#if ANDROID
+				Point point when toType == typeof(global::Android.Graphics.Point) => (global::Android.Graphics.Point)point,
+				Point point when toType == typeof(global::Android.Graphics.PointF) => (global::Android.Graphics.PointF)point,
+				PointF point when toType == typeof(global::Android.Graphics.Point) => (global::Android.Graphics.Point)point,
+				PointF point when toType == typeof(global::Android.Graphics.PointF) => (global::Android.Graphics.PointF)point,
+				Rect rect when toType == typeof(global::Android.Graphics.Rect) => (global::Android.Graphics.Rect)rect,
+				Rect rect when toType == typeof(global::Android.Graphics.RectF) => (global::Android.Graphics.RectF)rect,
+				RectF rect when toType == typeof(global::Android.Graphics.Rect) => (global::Android.Graphics.Rect)rect,
+				RectF rect when toType == typeof(global::Android.Graphics.RectF) => (global::Android.Graphics.RectF)rect,
+#elif IOS
+				Point point when toType == typeof(global::CoreGraphics.CGPoint) => (global::CoreGraphics.CGPoint)point,
+				Point point when toType == typeof(global::CoreGraphics.CGSize) => (global::CoreGraphics.CGSize)point,
+				PointF point when toType == typeof(global::CoreGraphics.CGPoint) => (global::CoreGraphics.CGPoint)point,
+				PointF point when toType == typeof(global::CoreGraphics.CGSize) => (global::CoreGraphics.CGSize)point,
+				Rect rect when toType == typeof(global::CoreGraphics.CGRect) => (global::CoreGraphics.CGRect)rect,
+				RectF rect when toType == typeof(global::CoreGraphics.CGRect) => (global::CoreGraphics.CGRect)rect,
+				Size size when toType == typeof(global::CoreGraphics.CGPoint) => (global::CoreGraphics.CGPoint)size,
+				Size size when toType == typeof(global::CoreGraphics.CGSize) => (global::CoreGraphics.CGSize)size,
+				SizeF size when toType == typeof(global::CoreGraphics.CGPoint) => (global::CoreGraphics.CGPoint)size,
+				SizeF size when toType == typeof(global::CoreGraphics.CGSize) => (global::CoreGraphics.CGSize)size,
+#endif
+				_ => null,
+			};
+		}
+
+		private static bool IsNumber(object input)
+			=> input is sbyte || input is byte || input is short || input is ushort || input is int || input is uint
+				|| input is long || input is ulong || input is float || input is double || input is decimal;
+
+#nullable disable
+
+		private static MethodInfo GetImplicitConversionOperator(Type fromType, Type toType)
+			=> fromType.GetImplicitConversionOperator(fromType, toType) ?? toType.GetImplicitConversionOperator(fromType, toType);
+
+		private static MethodInfo GetImplicitConversionOperator(this Type onType, Type fromType, Type toType)
 		{
 			var bindingAttr = BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy;
 			IEnumerable<MethodInfo> mis = null;

--- a/src/Controls/src/Xaml/CreateValuesVisitor.cs
+++ b/src/Controls/src/Xaml/CreateValuesVisitor.cs
@@ -248,12 +248,13 @@ namespace Microsoft.Maui.Controls.Xaml
 				{
 					if ((p[i].ParameterType.IsAssignableFrom(types[i])))
 						continue;
-					var op_impl = p[i].ParameterType.GetImplicitConversionOperator(fromType: types[i], toType: p[i].ParameterType)
-								?? types[i].GetImplicitConversionOperator(fromType: types[i], toType: p[i].ParameterType);
 
-					if (op_impl == null)
+					if (!arguments[i].TryConvertValue(toType: p[i].ParameterType, out var convertedValue))
+					{
 						return false;
-					arguments[i] = op_impl.Invoke(null, new[] { arguments[i] });
+					}
+
+					arguments[i] = convertedValue;
 				}
 				return true;
 			}

--- a/src/Controls/src/Xaml/MarkupExtensions/StaticResourceExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/StaticResourceExtension.cs
@@ -42,21 +42,17 @@ namespace Microsoft.Maui.Controls.Xaml
 			if (propertyType is null || propertyType.IsAssignableFrom(valueType))
 				return value;
 
-			MethodInfo implicit_op;
-
-			//OnPlatform might need double cast
-			if (valueType.IsGenericType && valueType.Name == "OnPlatform`1")
+			//OnPlatform needs to unrwap the value first
+			if (value is IWrappedValue wrapped)
 			{
-				var onPlatType = valueType.GetGenericArguments()[0];
-				implicit_op = valueType.GetImplicitConversionOperator(fromType: valueType, toType: onPlatType);
-				value = implicit_op.Invoke(value, new[] { value });
+				value = wrapped.Value;
 				valueType = value.GetType();
 			}
 
-			implicit_op = valueType.GetImplicitConversionOperator(fromType: valueType, toType: propertyType)
-							?? propertyType.GetImplicitConversionOperator(fromType: valueType, toType: propertyType);
-			if (implicit_op != null)
-				return implicit_op.Invoke(value, new[] { value });
+			if (value.TryConvertValue(toType: propertyType, out var convertedValue))
+			{
+				return convertedValue;
+			}
 
 			return value;
 		}

--- a/src/Controls/tests/Core.UnitTests/BindableObjectUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/BindableObjectUnitTests.cs
@@ -1407,6 +1407,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.NotEqual(-42, bindable.GetValue(prop));
 		}
 
+		[ValueConverter(typeof(CastFromStringValueConverter))]
 		class CastFromString
 		{
 			public string Result { get; private set; }
@@ -1416,6 +1417,19 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 				o.Result = source;
 				return o;
 			}
+		}
+
+		class CastFromStringValueConverter : IValueConverter
+		{
+			public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+				=> null;
+
+			public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+				=> value switch
+				{
+					string str => (CastFromString)str,
+					_ => null,
+				};
 		}
 
 		[Fact]
@@ -1430,6 +1444,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.Equal("foo", ((CastFromString)bindable.GetValue(prop)).Result);
 		}
 
+		[ValueConverter(typeof(CastToStringValueConverter))]
 		class CastToString
 		{
 			string Result { get; set; }
@@ -1448,6 +1463,19 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			{
 				throw new InvalidOperationException();
 			}
+		}
+
+		class CastToStringValueConverter : IValueConverter
+		{
+			public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+				=> value switch
+				{
+					CastToString castToString when targetType == typeof(string) => (string)castToString,
+					_ => null,
+				};
+
+			public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+				=> null;
 		}
 
 		[Fact]

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/BuildWarningsUtilities.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/BuildWarningsUtilities.cs
@@ -171,22 +171,6 @@ namespace Microsoft.Maui.IntegrationTests
 			},
 			new WarningsPerFile
 			{
-				File = "src/Controls/src/Core/Xaml/TypeConversionExtensions.cs",
-				WarningsPerCode = new List<WarningsPerCode>
-				{
-					new WarningsPerCode
-					{
-						Code = "IL2070",
-						Messages = new List<string>
-						{
-							"Microsoft.Maui.Controls.Xaml.TypeConversionExtensions.GetImplicitConversionOperator(Type,Type,Type): 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicMethods' in call to 'System.Type.GetMethod(String,BindingFlags,Binder,Type[],ParameterModifier[])'. The parameter '#0' of method 'Microsoft.Maui.Controls.Xaml.TypeConversionExtensions.GetImplicitConversionOperator(Type,Type,Type)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.",
-							"Microsoft.Maui.Controls.Xaml.TypeConversionExtensions.GetImplicitConversionOperator(Type,Type,Type): 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicMethods' in call to 'System.Type.GetMethods(BindingFlags)'. The parameter '#0' of method 'Microsoft.Maui.Controls.Xaml.TypeConversionExtensions.GetImplicitConversionOperator(Type,Type,Type)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.",
-						}
-					},
-				}
-			},
-			new WarningsPerFile
-			{
 				File = "src/Controls/src/Core/Shell/ShellContent.cs",
 				WarningsPerCode = new List<WarningsPerCode>
 				{


### PR DESCRIPTION
### Description of Change

The way we've been using implicit operators through reflection is trimming unsafe. In this PR, I'm putting the reflection-based implict cast logic behind a feature switch and replaced all implicit casts in MAUI with a combination of pattern matching and IValueConverters:
- For all _primitives_ with implicit cast operators (mostly types in Microsoft.Maui and Microsoft.Maui.Graphics), the conversion is moved to a switch expression in `TryConvertValueOfKnownTypes`
- For all types in Microsoft.Maui.Controls with implicit cast operators, I've created a new value converter and attached it to the type through a `[ValueConverter]` attribute. This is my proposed new API (which hasn't been discussed or approved yet).

Customers who rely on implicit cast operators in their apps should be able to define their own IValueConverters. This change will need to be documented and mentioned in some migration guide.

/cc @jonathanpeppers @StephaneDelcroix @vitek-karas 

### Issues Fixed

Fixes #19922
Contributes to #19397

### TODO

- the `ValueConverterAttribute` class should be public but it is not part of the declared public API yet
- we will need at least one feature switch, possibly two, to allow developers to keep the current behavior. The mechanism for defining feature switches will be added in #19310 which has not been merged yet.
- the `TryConvertValue` method needs cleaning up and possibly also optimizing (caching of value converters?)
- update documentation or create a follow-up issue to update documentation
- There is a possibility that someone relies on an implicit cast between two types they don't control. This PR doesn't provide any solution for this scenario yet. Maybe the `[ValueConverter]` could be applied assembly-wide with a target type parameter?

### Notes
This PR targets net9.0 because it introduces breaking changes.
