### PR TITLE
[iOS] Figure a better EstimatedItemSize for HorizontalList

### DIFF
--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issues15815.xaml
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issues15815.xaml
@@ -4,13 +4,13 @@
              x:Class="Maui.Controls.Sample.Issues.Issues15815"
              Title="Issues15815">
     <Grid RowDefinitions="Auto,Auto, Auto" >
-        <Label Grid.Row="0" Text="The last cell (index 3) is not visible with MeasureAllItems if 1st cell is 50px width" />
+        <Label Grid.Row="0" Text="The last cell (index 2) is not visible with MeasureAllItems if 1st cell is 50px width" />
         <CollectionView x:Name="col" BackgroundColor="LightBlue" Grid.Row="1" ItemsLayout="HorizontalList"
                         ItemSizingStrategy="MeasureAllItems" HeightRequest="200">
             <CollectionView.ItemTemplate>
                 <DataTemplate>
                     <Grid BackgroundColor="{Binding Color}" WidthRequest="{Binding Width}" HeightRequest="200">
-                        <Label Text="{Binding Index}" FontSize="Header" TextColor="Black"/>
+                        <Label Text="{Binding Name}" FontSize="Header" TextColor="Black"/>
                     </Grid>
                 </DataTemplate>
             </CollectionView.ItemTemplate>

--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issues15815.xaml
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issues15815.xaml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="Maui.Controls.Sample.Issues.Issues15815"
@@ -10,7 +10,7 @@
             <CollectionView.ItemTemplate>
                 <DataTemplate>
                     <Grid BackgroundColor="{Binding Color}" WidthRequest="{Binding Width}" HeightRequest="200">
-                        <Label Text="{Binding Name}" FontSize="Header" TextColor="Black"/>
+                        <Label AutomationId="{Binding Id}" Text="{Binding Name}" FontSize="Header" TextColor="Black"/>
                     </Grid>
                 </DataTemplate>
             </CollectionView.ItemTemplate>

--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issues15815.xaml
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issues15815.xaml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Maui.Controls.Sample.Issues.Issues15815"
+             Title="Issues15815">
+    <Grid RowDefinitions="Auto,Auto, Auto" >
+        <Label Grid.Row="0" Text="The last cell (index 3) is not visible with MeasureAllItems if 1st cell is 50px width" />
+        <CollectionView x:Name="col" BackgroundColor="LightBlue" Grid.Row="1" ItemsLayout="HorizontalList"
+                        ItemSizingStrategy="MeasureAllItems" HeightRequest="200">
+            <CollectionView.ItemTemplate>
+                <DataTemplate>
+                    <Grid BackgroundColor="{Binding Color}" WidthRequest="{Binding Width}" HeightRequest="200">
+                        <Label Text="{Binding Index}" FontSize="Header" TextColor="Black"/>
+                    </Grid>
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+        </CollectionView>
+        <Label Grid.Row="2" Text="Last Cell Blue should be visible" />
+    </Grid>
+
+</ContentPage>

--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issues15815.xaml
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issues15815.xaml
@@ -5,7 +5,7 @@
              Title="Issues15815">
     <Grid RowDefinitions="Auto,Auto, Auto" >
         <Label Grid.Row="0" Text="The last cell (index 2) is not visible with MeasureAllItems if 1st cell is 50px width" />
-        <CollectionView x:Name="col" BackgroundColor="LightBlue" Grid.Row="1" ItemsLayout="HorizontalList"
+        <CollectionView x:Name="col" BackgroundColor="Pink" Grid.Row="1" ItemsLayout="HorizontalList"
                         ItemSizingStrategy="MeasureAllItems" HeightRequest="200">
             <CollectionView.ItemTemplate>
                 <DataTemplate>

--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issues15815.xaml.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issues15815.xaml.cs
@@ -27,6 +27,7 @@ namespace Maui.Controls.Sample.Issues
 			public Color Color { get; set; }
 			public int Width { get; set; }
 			public int Index { get; set; }
+			public string Name => $"Item {Index}";
 		}
 	}
 }

--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issues15815.xaml.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issues15815.xaml.cs
@@ -27,6 +27,7 @@ namespace Maui.Controls.Sample.Issues
 			public Color Color { get; set; }
 			public int Width { get; set; }
 			public int Index { get; set; }
+			public string Id => $"id-{Index}";
 			public string Name => $"Item {Index}";
 		}
 	}

--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issues15815.xaml.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issues15815.xaml.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.ObjectModel;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+using Microsoft.Maui.Graphics;
+
+namespace Maui.Controls.Sample.Issues
+{
+
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	[Issue(IssueTracker.Github, 15815, "Horizontal CollectionView does not show the last element under some condition", PlatformAffected.iOS)]
+	public partial class Issues15815 : ContentPage
+	{
+		public Issues15815()
+		{
+			InitializeComponent();
+			col.ItemsSource = new ObservableCollection<ItemViewModel>
+				{
+					new ItemViewModel { Index = 0, Color = Colors.Red, Width = 50 },
+					new ItemViewModel { Index = 1, Color = Colors.Green, Width = 100 },
+					new ItemViewModel { Index = 2, Color = Colors.Blue, Width = 100 },
+				};
+		}
+
+		class ItemViewModel
+		{
+			public Color Color { get; set; }
+			public int Width { get; set; }
+			public int Index { get; set; }
+		}
+	}
+}

--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
@@ -35,6 +35,9 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = "Proven safe in test: MemoryTests.HandlerDoesNotLeak")]
 		Func<UICollectionViewCell> _getPrototype;
+		
+		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = "Proven safe in test: MemoryTests.HandlerDoesNotLeak")]
+		Func<NSIndexPath, UICollectionViewCell> _getPrototypeForIndexPath;
 		CGSize _previousContentSize = CGSize.Empty;
 
 		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = "Proven safe in test: MemoryTests.HandlerDoesNotLeak")]
@@ -236,7 +239,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 					(ItemsView as IView)?.InvalidateMeasure();
 				}
 			}
-
 			_previousContentSize = contentSize.Value;
 		}
 
@@ -268,6 +270,9 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 			_getPrototype ??= GetPrototype;
 			ItemsViewLayout.GetPrototype = _getPrototype;
+
+			_getPrototypeForIndexPath ??= GetPrototypeForIndexPath;
+			ItemsViewLayout.GetPrototypeForIndexPath = _getPrototypeForIndexPath;
 
 			Delegator = CreateDelegator();
 			CollectionView.Delegate = Delegator;
@@ -476,6 +481,11 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 			var indexPath = NSIndexPath.Create(group, 0);
 
+			return GetPrototypeForIndexPath(indexPath);
+		}
+
+		internal UICollectionViewCell GetPrototypeForIndexPath(NSIndexPath indexPath)
+		{
 			return CreateMeasurementCell(indexPath);
 		}
 

--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewDelegator.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewDelegator.cs
@@ -123,20 +123,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 					templatedCell.Unbind();
 				}
 			}
-
-			if (ItemsViewLayout.ScrollDirection == UICollectionViewScrollDirection.Horizontal)
-			{
-				var actualWidth = collectionView.ContentSize.Width - collectionView.Bounds.Size.Width;
-				if (collectionView.ContentOffset.X >= actualWidth || collectionView.ContentOffset.X < 0)
-					return;
-			}
-			else
-			{
-				var actualHeight = collectionView.ContentSize.Height - collectionView.Bounds.Size.Height;
-
-				if (collectionView.ContentOffset.Y >= actualHeight || collectionView.ContentOffset.Y < 0)
-					return;
-			}
 		}
 
 		protected virtual (bool VisibleItems, NSIndexPath First, NSIndexPath Center, NSIndexPath Last) GetVisibleItemsIndexPath()

--- a/src/Controls/tests/UITests/Tests/Issues/Issue15815.cs
+++ b/src/Controls/tests/UITests/Tests/Issues/Issue15815.cs
@@ -10,12 +10,12 @@ public class Issue15815 : _IssuesUITest
 		: base(device)
 	{ }
 
-	public override string Issue => "MeasureAllItems not working in Horizontal CollectionView";
+	public override string Issue => "Horizontal CollectionView does not show the last element under some condition";
 
 	[Test]
 	public void LastItemIsVisilbe()
 	{
-		var lastItem = App.WaitForElement("Item 2");
-		Assert.IsNotNull(lastItem);
+		var lastItem = App.WaitForElement("id-2");
+		Assert.AreEqual("Item 2", lastItem.GetText());
 	}
 }

--- a/src/Controls/tests/UITests/Tests/Issues/Issue15815.cs
+++ b/src/Controls/tests/UITests/Tests/Issues/Issue15815.cs
@@ -1,0 +1,21 @@
+﻿using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.AppiumTests.Issues;
+
+public class Issue15815 : _IssuesUITest
+{
+	public Issue15815(TestDevice device)
+		: base(device)
+	{ }
+
+	public override string Issue => "MeasureAllItems not working in Horizontal CollectionView";
+
+	[Test]
+	public void LastItemIsVisilbe()
+	{
+		var lastItem = App.WaitForElement("Item 2");
+		Assert.IsNotNull(lastItem);
+	}
+}


### PR DESCRIPTION
### Description of Change

When we have Items with different width or height users should use `MeasureAllItems` for that we rely on AutoLayout of CollectionView . This works by setting the EstimatedItemSize to some value other then empty. 
We use the 1st cell as the prototype to be measured and use as `EstimatedItemSize`, but the problem that we see here, is that cell size is the smalles compared with the other cells that haver a wider width.  When CollectionView is calculating the ContentSize, it use the EstimatedItemSize and multiplies by the number of items of the section. IF the EstimatedItemSize is very small the ContentSize can hide items in the end of the collection. This is special an issue if we have a couple of items on the List. 

I can't reproduce this on VerticalList so I m not sure if this is or not a issue with how UICollectionView and EstimatedItemSize. Because the idea is even if we give it a "estimated size" if should call each item to get the real value (and it does) but to does not update the initial calculate ContentSize  We have seen other issues with horizontal scroll on UICollectionView so im not sure if this is also a bug related with that or not.

The fix here is simple, try to find the wider cell from the ones that are going to maybe be visible on the screen. That way the EstimatedItemSize will return a value that will fit all the cells.

Still need to write a test. 

### Issues Fixed

Fixes #15815

