### PR TITLE
Optimize performance of Flex.Item

### DIFF
--- a/src/Controls/src/Core/Layout/FlexExtensions.cs
+++ b/src/Controls/src/Core/Layout/FlexExtensions.cs
@@ -7,26 +7,6 @@ namespace Microsoft.Maui.Controls
 {
 	static class FlexExtensions
 	{
-		public static int IndexOf(this Flex.Item parent, Flex.Item child)
-		{
-			var index = -1;
-			foreach (var it in parent)
-			{
-				index++;
-				if (it == child)
-					return index;
-			}
-			return -1;
-		}
-
-		public static void Remove(this Flex.Item parent, Flex.Item child)
-		{
-			var index = parent.IndexOf(child);
-			if (index < 0)
-				return;
-			parent.RemoveAt((uint)index);
-		}
-
 		public static Rect GetFrame(this Flex.Item item)
 		{
 			return new Rect(item.Frame[0], item.Frame[1], item.Frame[2], item.Frame[3]);

--- a/src/Controls/src/Core/Layout/FlexExtensions.cs
+++ b/src/Controls/src/Core/Layout/FlexExtensions.cs
@@ -1,5 +1,4 @@
-﻿#nullable disable
-using Microsoft.Maui.Graphics;
+﻿using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Layouts;
 using Flex = Microsoft.Maui.Layouts.Flex;
 

--- a/src/Core/src/Layouts/Flex.cs
+++ b/src/Core/src/Layouts/Flex.cs
@@ -228,7 +228,7 @@ namespace Microsoft.Maui.Layouts.Flex
 	/// <summary>
 	/// An item with flexbox properties. Items can also contain other items and be enumerated.
 	/// </summary>
-	class Item : IEnumerable<Item>
+	class Item : List<Item>
 	{
 		/// <summary>
 		/// Gets the frame (x, y, w, h).
@@ -239,7 +239,6 @@ namespace Microsoft.Maui.Layouts.Flex
 		/// <summary>The parent item.</summary>
 		/// <value>The parent item, or null if the item is a root item.</value>
 		public Item? Parent { get; private set; }
-		List<Item>? Children { get; set; }
 		bool ShouldOrderChildren { get; set; }
 
 		///<summary>This property defines how the layout engine will distribute space between and around child items that have been laid out on multiple lines. This property is ignored if the root item does not have its <see cref="P:Microsoft.Maui.Controls.Flex.Item.Wrap" /> property set to Wrap or WrapReverse.</summary>
@@ -392,10 +391,10 @@ namespace Microsoft.Maui.Layouts.Flex
 			Height = height;
 		}
 
-		public void Add(Item child)
+		public new void Add(Item child)
 		{
 			ValidateChild(child);
-			(Children ?? (Children = new List<Item>())).Add(child);
+			base.Add(child);
 			child.Parent = this;
 			ShouldOrderChildren |= child.Order != 0;
 		}
@@ -403,28 +402,17 @@ namespace Microsoft.Maui.Layouts.Flex
 		public void InsertAt(int index, Item child)
 		{
 			ValidateChild(child);
-			(Children ?? (Children = new List<Item>())).Insert(index, child);
+			base.Insert(index, child);
 			child.Parent = this;
 			ShouldOrderChildren |= child.Order != 0;
 		}
 
 		public Item RemoveAt(uint index)
 		{
-			var child = Children![(int)index];
+			var child = this[(int)index];
 			child.Parent = null;
-			Children.RemoveAt((int)index);
+			base.RemoveAt((int)index);
 			return child;
-		}
-
-		public int Count =>
-			(Children?.Count ?? 0);
-
-		public Item ItemAt(int index) =>
-			Children![index];
-
-		public Item this[int index]
-		{
-			get => ItemAt(index);
 		}
 
 		public Item Root
@@ -453,12 +441,6 @@ namespace Microsoft.Maui.Layouts.Flex
 
 		public SelfSizingDelegate? SelfSizing { get; set; }
 
-		IEnumerator IEnumerable.GetEnumerator() =>
-			((IEnumerable<Item>)this).GetEnumerator();
-
-		IEnumerator<Item> IEnumerable<Item>.GetEnumerator() =>
-			(Children ?? global::System.Linq.Enumerable.Empty<Item>()).GetEnumerator();
-
 		void ValidateChild(Item child)
 		{
 			if (this == child)
@@ -469,7 +451,7 @@ namespace Microsoft.Maui.Layouts.Flex
 
 		static void layout_item(Item item, float width, float height)
 		{
-			if (item.Children == null || item.Children.Count == 0)
+			if (item == null || item.Count == 0)
 				return;
 
 			var layout = new flex_layout();
@@ -1021,7 +1003,7 @@ namespace Microsoft.Maui.Layouts.Flex
 						{
 							int prev = indices[j - 1];
 							int curr = indices[j];
-							if (item.Children![prev].Order <= item.Children[curr].Order)
+							if (item[prev].Order <= item[curr].Order)
 							{
 								break;
 							}
@@ -1057,7 +1039,7 @@ namespace Microsoft.Maui.Layouts.Flex
 			}
 
 			public Item child_at(Item item, int i) =>
-				item.Children![(ordered_indices?[i] ?? i)];
+				item[ordered_indices?[i] ?? i];
 
 			public void cleanup()
 			{

--- a/src/Core/src/Layouts/Flex.cs
+++ b/src/Core/src/Layouts/Flex.cs
@@ -667,7 +667,7 @@ namespace Microsoft.Maui.Layouts.Flex
 		static void layout_align(Justify align, float flex_dim, int children_count, ref float pos_p, ref float spacing_p)
 		{
 			if (flex_dim < 0)
-				throw new ArgumentException();
+				throw new ArgumentException($"{nameof(flex_dim)} must not be negative", nameof(flex_dim));
 			pos_p = 0;
 			spacing_p = 0;
 
@@ -700,14 +700,14 @@ namespace Microsoft.Maui.Layouts.Flex
 					}
 					return;
 				default:
-					throw new ArgumentException();
+					throw new ArgumentException($"{nameof(Justify)} option not handled", nameof(align));
 			}
 		}
 
 		static void layout_align(AlignContent align, float flex_dim, uint children_count, ref float pos_p, ref float spacing_p)
 		{
 			if (flex_dim < 0)
-				throw new ArgumentException();
+				throw new ArgumentException($"{nameof(flex_dim)} must not be negative", nameof(flex_dim));
 			pos_p = 0;
 			spacing_p = 0;
 
@@ -743,14 +743,14 @@ namespace Microsoft.Maui.Layouts.Flex
 					spacing_p = flex_dim / children_count;
 					return;
 				default:
-					throw new ArgumentException();
+					throw new ArgumentException($"{nameof(AlignContent)} option not handled", nameof(align));
 			}
 		}
 
 		static void layout_items(Item item, int child_begin, int child_end, int children_count, ref flex_layout layout)
 		{
 			if (children_count > (child_end - child_begin))
-				throw new ArgumentException();
+				throw new ArgumentException($"The {children_count} must not be smaller than the requested range between {child_begin} and {child_end}", nameof(children_count));
 			if (children_count <= 0)
 				return;
 			if (layout.flex_dim > 0 && layout.extra_flex_dim > 0)
@@ -975,7 +975,7 @@ namespace Microsoft.Maui.Layouts.Flex
 					|| item.PaddingRight < 0
 					|| item.PaddingTop < 0
 					|| item.PaddingBottom < 0)
-					throw new ArgumentException();
+					throw new ArgumentException($"The padding on {nameof(item)} must not be negative", nameof(item));
 
 				width = Math.Max(0, width - item.PaddingLeft + item.PaddingRight);
 				height = Math.Max(0, height - item.PaddingTop + item.PaddingBottom);

--- a/src/Core/tests/Benchmarks/Benchmarks/FlexLayoutBenchmarker.cs
+++ b/src/Core/tests/Benchmarks/Benchmarks/FlexLayoutBenchmarker.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using BenchmarkDotNet.Attributes;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Layouts;
+
+namespace Microsoft.Maui.Benchmarks
+{
+	[MemoryDiagnoser]
+	public class FlexLayoutBenchmarker
+	{
+		readonly Border[] _views =
+		[
+			new Border(), new Border(), new Border(), new Border(), new Border(), new Border(), new Border(),
+			new Border(), new Border(), new Border(), new Border(), new Border(), new Border(), new Border()
+		];
+
+		const int Iterations = 100;
+
+		[GlobalSetup]
+		public void Setup()
+		{
+			foreach (var view in _views)
+			{
+				view.WidthRequest = 100 * Random.Shared.NextDouble();
+				view.HeightRequest = 100 * Random.Shared.NextDouble();
+			}
+		}
+
+		[Benchmark]
+		public void LayoutLotsOfItemsWithWrap()
+		{
+			var layout = new FlexLayout { Wrap = FlexWrap.Wrap };
+
+			LayoutLotsOfItems(layout);
+		}
+
+		[Benchmark]
+		public void LayoutLotsOfItemsNoWrap()
+		{
+			var layout = new FlexLayout { Wrap = FlexWrap.NoWrap };
+
+			LayoutLotsOfItems(layout);
+		}
+
+		private void LayoutLotsOfItems(FlexLayout layout)
+		{
+			var parent = new Grid();
+
+			layout.Parent = parent;
+
+			for (int x = 0; x < Iterations; x++)
+			{
+				foreach (var view in _views)
+				{
+					layout.Add(view);
+
+					// Vary the size of the layout and the views
+					double layoutWidth = x * 10 * Random.Shared.NextDouble();
+            		double layoutHeight = x * 10 * Random.Shared.NextDouble();
+					layout.WidthRequest = layoutWidth;
+					layout.HeightRequest = layoutHeight;
+					view.WidthRequest = x * Random.Shared.NextDouble();
+					view.HeightRequest = x * Random.Shared.NextDouble();
+
+					// Vary the properties of the views
+					FlexLayout.SetBasis(view, (x % 2 == 0) ? FlexBasis.Auto : new FlexBasis(1, true));
+					FlexLayout.SetOrder(view, x % 5);
+					FlexLayout.SetGrow(view, x % 3);
+					FlexLayout.SetShrink(view, x % 4);
+
+            		layout.Layout(new Rect(0, 0, layoutWidth, layoutHeight));
+
+					// Remove every 10th view
+					if (x % 10 == 0)
+					{
+						layout.Remove(view);
+					}
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Flex.Item was an IEnumerable but internally stored a collection of Children as a List.

It seemed much simpler to just inherit from a list and remove all of the IEnumerable implementation and related extension methods.

Added a benchmark to confirm the suspicion.

Before:

| Method                    | Mean     | Error     | StdDev    | Gen0     | Gen1     | Gen2    | Allocated |
|-------------------------- |---------:|----------:|----------:|---------:|---------:|--------:|----------:|
| LayoutLotsOfItemsWithWrap | 5.038 ms | 0.1739 ms | 0.5074 ms | 171.8750 | 125.0000 | 62.5000 |   1.56 MB |
| LayoutLotsOfItemsNoWrap   | 4.280 ms | 0.0836 ms | 0.1057 ms | 171.8750 | 125.0000 | 70.3125 |   1.56 MB |


After:


| Method                    | Mean     | Error     | StdDev    | Gen0     | Gen1     | Gen2    | Allocated |
|-------------------------- |---------:|----------:|----------:|---------:|---------:|--------:|----------:|
| LayoutLotsOfItemsWithWrap | 4.384 ms | 0.0805 ms | 0.1930 ms | 171.8750 | 156.2500 | 85.9375 |   1.57 MB |
| LayoutLotsOfItemsNoWrap   | 4.331 ms | 0.0845 ms | 0.0829 ms | 171.8750 | 156.2500 | 85.9375 |   1.57 MB |