### PR TITLE
[WinUI] Fix DateTimeFormatter for "ddd"

### DIFF
--- a/src/Compatibility/Core/src/Windows/DatePickerRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/DatePickerRenderer.cs
@@ -202,7 +202,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 				if (day == 0)
 					Control.DayVisible = false;
 				else if (day == 3)
-					Control.DayFormat = "day dayofweek.abbreviated";
+					Control.DayFormat = "dayofweek.abbreviated";
 				else if (day == 4)
 					Control.DayFormat = "dayofweek.full";
 				else

--- a/src/Core/src/Platform/Windows/CalendarDatePickerExtensions.cs
+++ b/src/Core/src/Platform/Windows/CalendarDatePickerExtensions.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Maui.Platform
 				var day = format.Count(x => x == 'd');
 
 				if (day == 3)
-					return "{day.integer} {dayofweek.abbreviated}";
+					return "{dayofweek.abbreviated}";
 				else if (day == 4)
 					return "{dayofweek.full}";
 				else

--- a/src/Core/tests/DeviceTests/Handlers/DatePicker/DatePickerHandlerTests.Windows.cs
+++ b/src/Core/tests/DeviceTests/Handlers/DatePicker/DatePickerHandlerTests.Windows.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Maui.DeviceTests
 		[Theory(DisplayName = "Format Initializes Correctly")]
 		[InlineData("dd/MM/yyyy", "{day.integer(2)}/{month.integer(2)}/{year.full}")]
 		[InlineData("d/M/yy", "{day.integer}/{month.integer(1)}/{year.abbreviated}")]
-		[InlineData("ddd/MMM/yyyy", "{day.integer} {dayofweek.abbreviated}/{month.abbreviated}/{year.full}")]
+		[InlineData("ddd/MMM/yyyy", "{dayofweek.abbreviated}/{month.abbreviated}/{year.full}")]
 		[InlineData("dddd/MMMM/yyyy", "{dayofweek.full}/{month.full}/{year.full}")]
 		public async Task FormatInitializesCorrectly(string format, string nativeFormat)
 		{


### PR DESCRIPTION
### Description of Change

The WinUI controller for DatePicker uses a CalendarDatePicker. That uses a special [Windows Globalization](https://learn.microsoft.com/en-us/uwp/api/Windows.Globalization.DateTimeFormatting.DateTimeFormatter?redirectedfrom=MSDN&view=winrt-22621#code-snippet-2) format, which included the day and abbreviated day for `ddd`. Going by that doc, that's wrong. It should only be the abbreviated date.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes https://github.com/dotnet/maui/issues/19967

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->

