### PR TITLE
Enforce preference of braces for code blocks (IDE0011) in .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -106,6 +106,7 @@ dotnet_naming_style.camel_case_underscore_style.capitalization = camel_case
 dotnet_sort_system_directives_first = true
 csharp_preserve_single_line_blocks = true
 csharp_preserve_single_line_statements = false
+csharp_prefer_braces = true:error
 
 # Expression-level preferences
 dotnet_style_object_initializer = true:suggestion


### PR DESCRIPTION
### Description of Change

Enables the preference of braces (also for single line) [IDE0011](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0011)