### PR TITLE
[tests] Move integration tests to use MauiDotNetTfm

### DIFF
--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Microsoft.Maui.IntegrationTests.csproj
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Microsoft.Maui.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>$(_MauiDotNetTfm)</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/XHarness.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/XHarness.cs
@@ -68,11 +68,7 @@ namespace Microsoft.Maui.IntegrationTests
 
 		public static string RunForOutput(string args, out int exitCode, int timeoutInSeconds = DEFAULT_TIMEOUT)
 		{
-			var dotnetToolUserPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".dotnet", "tools");
-			var xharnessToolPath = Path.Combine(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".dotnet", "tools"),
-				TestEnvironment.IsWindows ? "xharness.exe" : XHarnessTool);
-			var xharnessTool = File.Exists(xharnessToolPath) ? xharnessToolPath : XHarnessTool;
-			return ToolRunner.Run(xharnessTool, args, out exitCode, timeoutInSeconds: timeoutInSeconds);
+			return DotnetInternal.RunForOutput(XHarnessTool, args, out exitCode, timeoutInSeconds);
 		}
 
 	}


### PR DESCRIPTION
### Description of Change

This pull request modifies the `TargetFramework` property in the `Microsoft.Maui.IntegrationTests.csproj` file to allow dynamic setting of the target framework based on the `_MauiDotNetTfm` property.
It also fixes the way we find xharness

* [`src/TestUtils/src/Microsoft.Maui.IntegrationTests/Microsoft.Maui.IntegrationTests.csproj`](diffhunk://#diff-6217bf868d2f5becd59b54ebc870918a327ba104527942503f6399f280cf83dfL4-R4): Modified the `TargetFramework` property to allow dynamic setting based on the `_MauiDotNetTfm` property.


Tries to fix failing running the tests on Devdiv

``` 
   System.ComponentModel.Win32Exception : An error occurred trying to start process 'xharness' with working directory '/Users/builder/azdo/_work/2/s/src/TestUtils/src/Microsoft.Maui.IntegrationTests/bin/DEBUG/net7.0'. No such file or directory
```

https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=8954048&view=logs&j=5577a1a6-5922-5c8f-f8aa-3ff6c6e2bbde&t=130587ab-98ab-5170-d5f6-c4278540db71&l=579


Fixes #20103