### PR TITLE
Add Obsolete tag for old IndexOf

### DIFF
--- a/src/Core/src/Extensions/EnumerableExtensions.cs
+++ b/src/Core/src/Extensions/EnumerableExtensions.cs
@@ -20,14 +20,7 @@ namespace Microsoft.Maui
 			}
 		}
 
-		/// <summary>
-		/// 
-		/// </summary>
-		/// <typeparam name="TSource"></typeparam>
-		/// <typeparam name="TKey"></typeparam>
-		/// <param name="enumeration"></param>
-		/// <param name="func"></param>
-		/// <returns></returns>
+		[Obsolete("Legacy API used in previous versions of XAML Hot Reload. Do not use.")]
 		public static IDictionary<TKey, List<TSource>> GroupToDictionary<TSource, TKey>(this IEnumerable<TSource> enumeration, Func<TSource, TKey> func)
 			where TKey : notnull
 		{
@@ -76,6 +69,7 @@ namespace Microsoft.Maui
 
 		/// <summary>
 		/// Find the index for the first occurrence of an item within the collection as matched through the specified predicate.
+		/// Used by XAML Hot Reload.
 		/// </summary>
 		/// <typeparam name="T">The type of object contained in this collection.</typeparam>
 		/// <param name="enumerable">The collection in which to look for the item.</param>
@@ -83,6 +77,7 @@ namespace Microsoft.Maui
 		/// The item currently evaluated of type <typeparamref name="T"/> is provided as an input parameter.
 		/// The resulting value should be a <see cref="bool"/> which is <see langword="true"/> if this is the item to match, otherwise <see langword="false"/>.</param>
 		/// <returns>The index of the first item to match through <paramref name="predicate"/> in the collection or -1 when no match is not found.</returns>
+		[Obsolete("Use IndexOf<T>(IEnumerable<T>, T item) instead.")]
 		public static int IndexOf<T>(this IEnumerable<T> enumerable, Func<T, bool> predicate)
 		{
 			var i = 0;

--- a/src/Core/src/Extensions/EnumerableExtensions.cs
+++ b/src/Core/src/Extensions/EnumerableExtensions.cs
@@ -20,6 +20,17 @@ namespace Microsoft.Maui
 			}
 		}
 
+		/// <summary>
+		/// Groups elements from an IEnumerable based on a specified key selector function and returns a dictionary
+		/// where keys are the computed keys and values are lists of elements with the same key.
+		/// Used by XAML Hot Reload.
+		/// </summary>
+		/// <typeparam name="TSource">The type of elements in the input enumeration.</typeparam>
+		/// <typeparam name="TKey">The type of keys produced by the key selector function.</typeparam>
+		/// <param name="enumeration">The input IEnumerable of elements to be grouped.</param>
+		/// <param name="func">A function that extracts a key from an element of the input enumeration.</param>
+		/// <returns>A dictionary with keys as computed by the key selector function and values as lists of elements
+		/// that share the same key.</returns>
 		[Obsolete("Legacy API used in previous versions of XAML Hot Reload. Do not use.")]
 		public static IDictionary<TKey, List<TSource>> GroupToDictionary<TSource, TKey>(this IEnumerable<TSource> enumeration, Func<TSource, TKey> func)
 			where TKey : notnull


### PR DESCRIPTION
### Description of Change

For https://github.com/dotnet/maui/pull/20050, we needed to revert the change to not break XAML Hot Reload. This adds obsolete tags around the old methods to make sure they are not used.

These are internal APIs, but used in a "public" way by XAML Hot Reload, so removing them breaks ABI. We need to keep them around so we can move off it gradually.