### PR TITLE
[Windows] Adjust recycle check in ItemContentControl

### DIFF
--- a/src/Controls/src/Core/Platform/Windows/CollectionView/ItemContentControl.cs
+++ b/src/Controls/src/Core/Platform/Windows/CollectionView/ItemContentControl.cs
@@ -163,7 +163,7 @@ namespace Microsoft.Maui.Controls.Platform
 				return;
 			}
 
-			if (_handler?.ContainerView is null || _currentTemplate != formsTemplate)
+			if (Content is null || _currentTemplate != formsTemplate)
 			{
 				// If the content has never been realized (i.e., this is a new instance), 
 				// or if we need to switch DataTemplates (because this instance is being recycled)

--- a/src/Controls/src/Core/Platform/Windows/CollectionView/ItemContentControl.cs
+++ b/src/Controls/src/Core/Platform/Windows/CollectionView/ItemContentControl.cs
@@ -186,7 +186,6 @@ namespace Microsoft.Maui.Controls.Platform
 			else
 			{
 				// We are reusing this ItemContentControl and we can reuse the Element
-				_visualElement = _handler.VirtualView as VisualElement;
 				_visualElement.BindingContext = dataContext;
 			}
 


### PR DESCRIPTION
### Description of Change

Adjust recycle check in `ItemContentControl` to use Content property.

The logic is currently:
```csharp
if (_handler?.ContainerView is null || _currentTemplate != formsTemplate)
{
     // Create new item
}
else
{
     // Recycle
}
...
Content = _handler.ToPlatform();
```

But `_handler?.ContainerView` is always set to null (`_handler.HasContainer` is also always `false`), so the item never gets recycled. 

Looking [in the Compatibility project](https://github.com/dotnet/maui/blob/7dbe85388a5eb19a6e4bd1709b9d16a31d1a3bce/src/Compatibility/Core/src/Windows/CollectionView/ItemContentControl.cs#L13) we can see the logic used to be:
```csharp
if (_renderer?.ContainerElement == null || _currentTemplate != formsTemplate)
{
     // Create new item
}
else
{
     // Recycle
}
...
Content = _renderer.ContainerElement;
```

Therefore, I believe that the conditional check should be using the `Content` property rather than the `_handler.ContainerView`.

### Current Behavior

https://github.com/dotnet/maui/assets/890772/6d51f705-1a11-46ea-be05-f638eae3e96b

### Fixed Behavior

https://github.com/dotnet/maui/assets/890772/4b674ab2-da0a-4628-a536-ded5e16085f8

There's still a bit of flickering, but it's very brief and aligns more to how it behaves in WinUI

### Issues Fixed

Fixes #20043 
