### PR TITLE
More IndexOf() optimization

### DIFF
--- a/src/Compatibility/ControlGallery/src/Core/GalleryPages/GroupedListContactsGallery.cs
+++ b/src/Compatibility/ControlGallery/src/Core/GalleryPages/GroupedListContactsGallery.cs
@@ -200,25 +200,11 @@ namespace Microsoft.Maui.Controls.ControlGallery
 				InsertBasedOnSort(collection, contact, c => GetSortString(c)[0]);
 		}
 
-		int IndexOf<T>(IEnumerable<T> elements, T element)
-		{
-			int i = 0;
-			foreach (T e in elements)
-			{
-				if (Equals(e, element))
-					return i;
-
-				i++;
-			}
-
-			return -1;
-		}
-
 		void InsertBasedOnSort<T, TSort>(IList<T> items, T item, Func<T, TSort> sortBy)
 		{
 			List<T> newItems = new List<T>(items);
 			newItems.Add(item);
-			int index = IndexOf(newItems.OrderBy(sortBy), item);
+			int index = newItems.OrderBy(sortBy).IndexOf(item);
 			items.Insert(index, item);
 		}
 

--- a/src/Compatibility/Core/src/Android/CollectionView/ObservableItemsSource.cs
+++ b/src/Compatibility/Core/src/Android/CollectionView/ObservableItemsSource.cs
@@ -137,7 +137,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 
 		void Add(NotifyCollectionChangedEventArgs args)
 		{
-			var startIndex = args.NewStartingIndex > -1 ? args.NewStartingIndex : IndexOf(args.NewItems[0]);
+			var startIndex = args.NewStartingIndex > -1 ? args.NewStartingIndex : _itemsSource.IndexOf(args.NewItems[0]);
 			startIndex = AdjustPositionForHeader(startIndex);
 			var count = args.NewItems.Count;
 
@@ -178,7 +178,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 
 		void Replace(NotifyCollectionChangedEventArgs args)
 		{
-			var startIndex = args.NewStartingIndex > -1 ? args.NewStartingIndex : IndexOf(args.NewItems[0]);
+			var startIndex = args.NewStartingIndex > -1 ? args.NewStartingIndex : _itemsSource.IndexOf(args.NewItems[0]);
 			startIndex = AdjustPositionForHeader(startIndex);
 			var newCount = args.NewItems.Count;
 
@@ -224,22 +224,6 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 			{
 				if (count == index)
 					return item;
-				count++;
-			}
-
-			return -1;
-		}
-
-		internal int IndexOf(object item)
-		{
-			if (_itemsSource is IList list)
-				return list.IndexOf(item);
-
-			int count = 0;
-			foreach (var i in _itemsSource)
-			{
-				if (i == item)
-					return count;
 				count++;
 			}
 

--- a/src/Compatibility/Core/src/iOS/CollectionView/ObservableItemsSource.cs
+++ b/src/Compatibility/Core/src/iOS/CollectionView/ObservableItemsSource.cs
@@ -154,7 +154,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 		{
 			var count = args.NewItems.Count;
 			Count += count;
-			var startIndex = args.NewStartingIndex > -1 ? args.NewStartingIndex : IndexOf(args.NewItems[0]);
+			var startIndex = args.NewStartingIndex > -1 ? args.NewStartingIndex : _itemsSource.IndexOf(args.NewItems[0]);
 
 			// Queue up the updates to the UICollectionView
 			Update(() => CollectionView.InsertItems(CreateIndexesFrom(startIndex, count)), args);
@@ -185,7 +185,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 
 			if (newCount == args.OldItems.Count)
 			{
-				var startIndex = args.NewStartingIndex > -1 ? args.NewStartingIndex : IndexOf(args.NewItems[0]);
+				var startIndex = args.NewStartingIndex > -1 ? args.NewStartingIndex : _itemsSource.IndexOf(args.NewItems[0]);
 
 				// We are replacing one set of items with a set of equal size; we can do a simple item range update
 
@@ -239,22 +239,6 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 			{
 				if (count == index)
 					return item;
-				count++;
-			}
-
-			return -1;
-		}
-
-		internal int IndexOf(object item)
-		{
-			if (_itemsSource is IList list)
-				return list.IndexOf(item);
-
-			int count = 0;
-			foreach (var i in _itemsSource)
-			{
-				if (i == item)
-					return count;
 				count++;
 			}
 

--- a/src/Controls/src/Core/Handlers/Items/Android/ItemsSources/ObservableItemsSource.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/ItemsSources/ObservableItemsSource.cs
@@ -149,7 +149,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		void Add(NotifyCollectionChangedEventArgs args)
 		{
-			var startIndex = args.NewStartingIndex > -1 ? args.NewStartingIndex : IndexOf(args.NewItems[0]);
+			var startIndex = args.NewStartingIndex > -1 ? args.NewStartingIndex : _itemsSource.IndexOf(args.NewItems[0]);
 			startIndex = AdjustPositionForHeader(startIndex);
 			var count = args.NewItems.Count;
 
@@ -190,7 +190,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		void Replace(NotifyCollectionChangedEventArgs args)
 		{
-			var startIndex = args.NewStartingIndex > -1 ? args.NewStartingIndex : IndexOf(args.NewItems[0]);
+			var startIndex = args.NewStartingIndex > -1 ? args.NewStartingIndex : _itemsSource.IndexOf(args.NewItems[0]);
 			startIndex = AdjustPositionForHeader(startIndex);
 			var newCount = args.NewItems.Count;
 
@@ -236,22 +236,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			{
 				if (count == index)
 					return item;
-				count++;
-			}
-
-			return -1;
-		}
-
-		internal int IndexOf(object item)
-		{
-			if (_itemsSource is IList list)
-				return list.IndexOf(item);
-
-			int count = 0;
-			foreach (var i in _itemsSource)
-			{
-				if (i == item)
-					return count;
 				count++;
 			}
 

--- a/src/Core/src/Extensions/EnumerableExtensions.cs
+++ b/src/Core/src/Extensions/EnumerableExtensions.cs
@@ -36,13 +36,13 @@ namespace Microsoft.Maui
 			foreach (TSource item in enumeration)
 			{
 				var group = func(item);
-				if (!result.ContainsKey(group))
+				if (!result.TryGetValue(group, out List<TSource>? value))
 				{
 					result.Add(group, new List<TSource> { item });
 				}
 				else
 				{
-					result[group].Add(item);
+					value.Add(item);
 				}
 			}
 			return result;

--- a/src/Core/src/Extensions/EnumerableExtensions.cs
+++ b/src/Core/src/Extensions/EnumerableExtensions.cs
@@ -116,6 +116,12 @@ namespace Microsoft.Maui
 		/// <returns>The index of the first item to match through <paramref name="predicate"/> in the collection or -1 when no match is not found.</returns>
 		public static int IndexOf<T>(this IEnumerable<T> enumerable, Func<T, bool> predicate)
 		{
+			if (enumerable == null)
+				throw new ArgumentNullException(nameof(enumerable));
+
+            if (enumerable is IList<T> list)
+                return list.IndexOf(predicate);
+
 			var i = 0;
 			foreach (T element in enumerable)
 			{

--- a/src/Core/src/Extensions/EnumerableExtensions.cs
+++ b/src/Core/src/Extensions/EnumerableExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 
 namespace Microsoft.Maui
@@ -64,6 +65,36 @@ namespace Microsoft.Maui
 
 			var i = 0;
 			foreach (T element in enumerable)
+			{
+				if (Equals(element, item))
+					return i;
+
+				i++;
+			}
+
+			return -1;
+		}
+
+		/// <summary>
+		/// Find the index of a specific item within the collection.
+		/// </summary>
+		/// <param name="enumerable">The collection in which to look for <paramref name="item"/>.</param>
+		/// <param name="item">The object to be located in this collection.</param>
+		/// <returns>The index of <paramref name="item"/> in the collection or -1 when the item is not found.</returns>
+		/// <exception cref="ArgumentNullException">Throws when <paramref name="enumerable"/> is <see langword="null"/>.</exception>
+		public static int IndexOf(this IEnumerable enumerable, object item)
+		{
+			if (enumerable == null)
+				throw new ArgumentNullException(nameof(enumerable));
+
+            if (enumerable is IList list)
+                return list.IndexOf(item);
+
+            if (enumerable is Array array)
+                return Array.IndexOf(array, item);
+
+			var i = 0;
+			foreach (object element in enumerable)
 			{
 				if (Equals(element, item))
 					return i;

--- a/src/Core/src/Extensions/EnumerableExtensions.cs
+++ b/src/Core/src/Extensions/EnumerableExtensions.cs
@@ -37,9 +37,13 @@ namespace Microsoft.Maui
 			{
 				var group = func(item);
 				if (!result.ContainsKey(group))
+				{
 					result.Add(group, new List<TSource> { item });
+				}
 				else
+				{
 					result[group].Add(item);
+				}
 			}
 			return result;
 		}
@@ -55,19 +59,27 @@ namespace Microsoft.Maui
 		public static int IndexOf<T>(this IEnumerable<T> enumerable, T item)
 		{
 			if (enumerable == null)
+			{
 				throw new ArgumentNullException(nameof(enumerable));
+			}
 
-            if (enumerable is IList<T> list)
-                return list.IndexOf(item);
+			if (enumerable is IList<T> list)
+			{
+				return list.IndexOf(item);
+			}
 
-            if (enumerable is T[] array)
-                return Array.IndexOf(array, item);
+			if (enumerable is T[] array)
+			{
+				return Array.IndexOf(array, item);
+			}
 
 			var i = 0;
 			foreach (T element in enumerable)
 			{
 				if (Equals(element, item))
+				{
 					return i;
+				}
 
 				i++;
 			}
@@ -85,19 +97,27 @@ namespace Microsoft.Maui
 		public static int IndexOf(this IEnumerable enumerable, object item)
 		{
 			if (enumerable == null)
+			{
 				throw new ArgumentNullException(nameof(enumerable));
+			}
 
-            if (enumerable is IList list)
-                return list.IndexOf(item);
+			if (enumerable is IList list)
+			{
+				return list.IndexOf(item);
+			}
 
-            if (enumerable is Array array)
-                return Array.IndexOf(array, item);
+			if (enumerable is Array array)
+			{
+				return Array.IndexOf(array, item);
+			}
 
 			var i = 0;
 			foreach (object element in enumerable)
 			{
 				if (Equals(element, item))
+				{
 					return i;
+				}
 
 				i++;
 			}
@@ -117,16 +137,22 @@ namespace Microsoft.Maui
 		public static int IndexOf<T>(this IEnumerable<T> enumerable, Func<T, bool> predicate)
 		{
 			if (enumerable == null)
+			{
 				throw new ArgumentNullException(nameof(enumerable));
+			}
 
-            if (enumerable is IList<T> list)
-                return list.IndexOf(predicate);
+			if (enumerable is IList<T> list)
+			{
+				return list.IndexOf(predicate);
+			}
 
 			var i = 0;
 			foreach (T element in enumerable)
 			{
 				if (predicate(element))
+				{
 					return i;
+				}
 
 				i++;
 			}

--- a/src/Core/src/Handlers/Layout/LayoutHandler.Android.cs
+++ b/src/Core/src/Handlers/Layout/LayoutHandler.Android.cs
@@ -119,7 +119,7 @@ namespace Microsoft.Maui.Handlers
 			}
 
 			AView platformChildView = child.ToPlatform(MauiContext!);
-			var currentIndex = IndexOf(PlatformView, platformChildView);
+			var currentIndex = PlatformView.IndexOfChild(platformChildView);
 
 			if (currentIndex == -1)
 			{
@@ -133,19 +133,6 @@ namespace Microsoft.Maui.Handlers
 				PlatformView.RemoveViewAt(currentIndex);
 				PlatformView.AddView(platformChildView, targetIndex);
 			}
-		}
-
-		static int IndexOf(LayoutViewGroup viewGroup, AView view)
-		{
-			for (int n = 0; n < viewGroup.ChildCount; n++)
-			{
-				if (viewGroup.GetChildAt(n) == view)
-				{
-					return n;
-				}
-			}
-
-			return -1;
 		}
 
 		public static partial void MapBackground(ILayoutHandler handler, ILayout layout)


### PR DESCRIPTION
As seen in https://github.com/dotnet/maui/pull/19963 there are important performance gains that can be made by calling the specialized IndexOf() functions where possible.

- This continues with that approach and removes custom implementations of IndexOf() elsewhere in the codebase, and centralizes them under EnumerationExtensions.

- I added the same kind of check to the predicate-based IndexOf() operation, which @drasticactions showed is needed for HotReload. It would be good to see those same gains when doing HotReload.

- I also found a Xamarin.Android function `IndexOfChild` that could be substituted. It has the same behavior of returning -1 if the child is not found.