### PR TITLE
PullToRefresh & item selection when listView is not enabled [iOS]

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/iOS/ListViewRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/iOS/ListViewRenderer.cs
@@ -310,6 +310,8 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				UpdateVerticalScrollBarVisibility();
 			else if (e.PropertyName == ScrollView.HorizontalScrollBarVisibilityProperty.PropertyName)
 				UpdateHorizontalScrollBarVisibility();
+			else if(e.PropertyName == Microsoft.Maui.Controls.ListView.IsEnabledProperty.PropertyName)
+				SetIsEnabled();
 		}
 
 		public override void TraitCollectionDidChange(UITraitCollection previousTraitCollection)
@@ -539,6 +541,22 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				_tableViewController.UpdateIsRefreshing(refreshing);
 		}
 
+		protected override void SetIsEnabled()
+		{
+			base.SetIsEnabled();
+			UpdatePullToRefreshEnabled();
+			UpdateSelectionMode();
+			UpdateCellsEnabled();
+		}
+
+		void UpdateCellsEnabled()
+		{
+			foreach (var cell in TemplatedItemsView.TemplatedItems)
+			{
+				cell.IsEnabled = ListView.IsEnabled;
+			}
+		}
+
 		void UpdateItems(NotifyCollectionChangedEventArgs e, int section, bool resetWhenGrouped)
 		{
 			var exArgs = e as NotifyCollectionChangedEventArgsEx;
@@ -701,7 +719,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		{
 			if (_tableViewController != null)
 			{
-				var isPullToRequestEnabled = Element.IsPullToRefreshEnabled && ListView.RefreshAllowed;
+				var isPullToRequestEnabled = Element.IsPullToRefreshEnabled && ListView.RefreshAllowed && ListView.IsEnabled;
 				_tableViewController.UpdatePullToRefreshEnabled(isPullToRequestEnabled);
 			}
 		}
@@ -743,7 +761,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		void UpdateSelectionMode()
 		{
-			if (Element.SelectionMode == ListViewSelectionMode.None)
+			if (Element.SelectionMode == ListViewSelectionMode.None || !Element.IsEnabled)
 			{
 				Element.SelectedItem = null;
 				var selectedIndexPath = Control.IndexPathForSelectedRow;

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -11,6 +11,7 @@ override Microsoft.Maui.Controls.Handlers.Items2.ItemsViewHandler2<TItemsView>.G
 ~Microsoft.Maui.Controls.Handlers.Items2.DefaultCell2.Constraint.get -> UIKit.NSLayoutConstraint
 ~Microsoft.Maui.Controls.Handlers.Items2.DefaultCell2.Constraint.set -> void
 ~Microsoft.Maui.Controls.Handlers.Items2.DefaultCell2.Label.get -> UIKit.UILabel
+override Microsoft.Maui.Controls.Handlers.Compatibility.ListViewRenderer.SetIsEnabled() -> void
 ~Microsoft.Maui.Controls.Handlers.Items2.GroupableItemsViewController2<TItemsView>
 ~Microsoft.Maui.Controls.Handlers.Items2.GroupableItemsViewController2<TItemsView>.GroupableItemsViewController2(TItemsView groupableItemsView, UIKit.UICollectionViewLayout layout) -> void
 ~Microsoft.Maui.Controls.Handlers.Items2.GroupableItemsViewDelegator2<TItemsView, TViewController>

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -9,6 +9,7 @@ override Microsoft.Maui.Controls.Handlers.Items2.ItemsViewHandler2<TItemsView>.G
 ~Microsoft.Maui.Controls.Handlers.Items2.CarouselViewHandler2.CarouselViewHandler2(Microsoft.Maui.PropertyMapper mapper = null) -> void
 ~Microsoft.Maui.Controls.Handlers.Items2.CollectionViewHandler2.CollectionViewHandler2(Microsoft.Maui.PropertyMapper mapper = null) -> void
 ~Microsoft.Maui.Controls.Handlers.Items2.DefaultCell2.Constraint.get -> UIKit.NSLayoutConstraint
+override Microsoft.Maui.Controls.Handlers.Compatibility.ListViewRenderer.SetIsEnabled() -> void
 ~Microsoft.Maui.Controls.Handlers.Items2.DefaultCell2.Constraint.set -> void
 ~Microsoft.Maui.Controls.Handlers.Items2.DefaultCell2.Label.get -> UIKit.UILabel
 ~Microsoft.Maui.Controls.Handlers.Items2.GroupableItemsViewController2<TItemsView>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue19366.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue19366.xaml
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Maui.Controls.Sample.Issues.Issue19366">
+    <VerticalStackLayout>
+        <Button Text="Disable the ListView"
+                Clicked="Button_Clicked"
+                AutomationId="disableListButton"/>
+
+        <ListView x:Name="listView">
+            <ListView.ItemTemplate>
+                <DataTemplate>
+                    <ViewCell>
+                        <Grid ColumnDefinitions="*,Auto">
+                            <Label Grid.Column="0"
+                                   Text="{Binding Text}"
+                                   AutomationId="{Binding Index, StringFormat='label{0}'}"/>
+
+                            <Button Grid.Column="1"
+                                    Text="button"
+                                    Command="{Binding ClickedCommand}"
+                                    AutomationId="{Binding Index, StringFormat='button{0}'}"/>
+                        </Grid>
+                    </ViewCell>
+                </DataTemplate>
+            </ListView.ItemTemplate>
+        </ListView>
+    </VerticalStackLayout>
+</ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue19366.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue19366.xaml.cs
@@ -1,0 +1,69 @@
+﻿using System.Collections.Generic;
+using System.ComponentModel;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+
+namespace Maui.Controls.Sample.Issues
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	[Issue(IssueTracker.Github, 19366, "Items are enabled when ListView is not enabled", PlatformAffected.iOS)]
+	public partial class Issue19366 : ContentPage
+	{
+		public Issue19366()
+		{
+			InitializeComponent();
+			List<ItemViewModel> items = new List<ItemViewModel>();
+			for (int i = 1; i <= 5; i++)
+			{
+				items.Add(new ItemViewModel()
+				{
+					Text = $"Not clicked",
+					Index = $"{i}",
+				});
+			}
+
+			listView.ItemsSource = items;
+		}
+
+		void Button_Clicked(System.Object sender, System.EventArgs e)
+		{
+			listView.IsEnabled = !listView.IsEnabled;
+		}
+	}
+
+	public class ItemViewModel : INotifyPropertyChanged
+	{
+		private string _text;
+		public string Text
+		{
+			get => _text;
+			set
+			{
+				_text = value;
+				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Text)));
+			}
+		}
+
+		private string _isEnabled;
+		public string IsEnabled
+		{
+			get => _isEnabled;
+			set
+			{
+				_isEnabled = value;
+				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsEnabled)));
+			}
+		}
+
+		public string Index { get; set; }
+
+		public Command ClickedCommand { get; set; }
+
+		public ItemViewModel()
+		{
+			ClickedCommand = new Command(() => Text = "Clicked");
+		}
+
+		public event PropertyChangedEventHandler PropertyChanged;
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue19366.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue19366.cs
@@ -1,0 +1,36 @@
+﻿#if IOS
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue19366 : _IssuesUITest
+	{
+		public Issue19366(TestDevice device) : base(device) { }
+
+		public override string Issue => "Items are enabled when ListView is not enabled";
+
+		[Test]
+		[Category(UITestCategories.ListView)]
+		public void ListCellsItemsShouldNotBeEnabledWhenListViewIsNotEnabled()
+		{
+			App.WaitForElement("button1");
+
+			// 1. Click the button of the first cell and observe the label's text change
+			App.Click("button1");
+			var listItemOneText = App.FindElement("label1").GetText();
+			ClassicAssert.True(listItemOneText == "Clicked");
+
+			// 2. Set IsEnabled property of the list to false
+			App.Click("disableListButton");
+
+			// 3. Click the button of the second cell and observe the label's text do not change
+			App.Click("button2");
+			var listItemTwoText = App.FindElement("label2").GetText();
+			ClassicAssert.True(listItemTwoText == "Not clicked");
+		}
+	}
+}
+#endif


### PR DESCRIPTION
### Description of Change

PullToRefresh & item selection when listView is not Enabled fix [iOS]

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/19366
Fixes https://github.com/dotnet/maui/issues/19768


https://github.com/dotnet/maui/assets/42434498/55f9c913-7e1a-43fb-ae98-1939d06ebf93

