### PR TITLE
Fix 19647

### DIFF
--- a/src/Controls/tests/Xaml.UnitTests/BindablePropertiesAccessModifiers.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/BindablePropertiesAccessModifiers.xaml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-					 xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests"
-             x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.BindablePropertiesAccessModifiers">
+			 xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests"
+             x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.BindablePropertiesAccessModifiers"
+			 x:DataType="local:BindablePropertiesAccessModifiersVM">
 	<ContentPage.Content>
 		<local:AccessModifiersControl PublicFoo="{Binding Foo}"
 								      InternalBar="{Binding Bar}"

--- a/src/Controls/tests/Xaml.UnitTests/BindablePropertiesAccessModifiers.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/BindablePropertiesAccessModifiers.xaml.cs
@@ -28,13 +28,15 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		}
 	}
 
+	public class BindablePropertiesAccessModifiersVM
+	{
+		public string Foo => "Foo";
+		public string Bar => "Bar";
+	}
+
 	public partial class BindablePropertiesAccessModifiers : ContentPage
 	{
-		class Data
-		{
-			public string Foo => "Foo";
-			public string Bar => "Bar";
-		}
+
 
 		public BindablePropertiesAccessModifiers()
 		{
@@ -54,7 +56,7 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 			public void BindProperties(bool useCompiledXaml)
 			{
 				var page = new BindablePropertiesAccessModifiers(useCompiledXaml);
-				page.BindingContext = new Data();
+				page.BindingContext = new BindablePropertiesAccessModifiersVM();
 				Assert.AreEqual("Bar", page.AMC.GetValue(AccessModifiersControl.InternalBarProperty));
 				Assert.AreEqual("Foo", page.AMC.GetValue(AccessModifiersControl.PublicFooProperty));
 			}

--- a/src/Controls/tests/Xaml.UnitTests/ColorConverter.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/ColorConverter.xaml
@@ -2,7 +2,10 @@
 <ContentPage 
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-    x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.ColorConverter">
+    x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.ColorConverter"
+    x:DataType="local:ColorConverterVM"
+    xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests">
+
     <ContentPage.Content>
         <Button        
             x:Name="Button0"

--- a/src/Controls/tests/Xaml.UnitTests/ColorConverter.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/ColorConverter.xaml.cs
@@ -6,10 +6,7 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 {
 	public partial class ColorConverter : ContentPage
 	{
-		class Data
-		{
-			public string ButtonBackground => "#fc87ad";
-		}
+
 
 		public ColorConverter()
 		{
@@ -29,11 +26,16 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 			public void StringsAreValidAsColor(bool useCompiledXaml)
 			{
 				var page = new ColorConverter(useCompiledXaml);
-				page.BindingContext = new Data();
+				page.BindingContext = new ColorConverterVM();
 
 				var expected = Color.FromArgb("#fc87ad");
 				Assert.AreEqual(expected, page.Button0.BackgroundColor);
 			}
 		}
+	}
+
+	public class ColorConverterVM
+	{
+		public string ButtonBackground => "#fc87ad";
 	}
 }

--- a/src/Controls/tests/Xaml.UnitTests/DataTemplate.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/DataTemplate.xaml
@@ -7,7 +7,7 @@
 	<ContentPage.Resources>
 		<ResourceDictionary>
 			<DataTemplate x:Key="celltemplate">
-				<TextCell Text="{Binding}"/>
+				<TextCell Text="{Binding}" x:DataType="x:String"/>
 			</DataTemplate>
 			<local:ReverseConverter x:Key="reverseConverter"/>
 		</ResourceDictionary>
@@ -23,7 +23,7 @@
 		<ListView x:Name="textCell">
 			<ListView.ItemTemplate>
 				<DataTemplate>
-					<TextCell Text="{Binding}"/>
+					<TextCell Text="{Binding}" x:DataType="x:String"/>
 				</DataTemplate>
 			</ListView.ItemTemplate>
 		</ListView>
@@ -31,14 +31,14 @@
 		<ListView x:Name="textCellAccessResource">
 			<ListView.ItemTemplate>
 				<DataTemplate>
-					<TextCell Text="{Binding Path=., Converter={StaticResource reverseConverter}}"/>
+					<TextCell Text="{Binding Path=., Converter={StaticResource reverseConverter}}" x:DataType="x:String"/>
 				</DataTemplate>
 			</ListView.ItemTemplate>
 		</ListView>
 		<ListView x:Name="viewCellAccessResource">
 			<ListView.ItemTemplate>
 				<DataTemplate>
-					<ViewCell><Label Text="{Binding Path=., Converter={StaticResource reverseConverter}}"/></ViewCell>
+					<ViewCell><Label Text="{Binding Path=., Converter={StaticResource reverseConverter}}" x:DataType="x:String"/></ViewCell>
 				</DataTemplate>
 			</ListView.ItemTemplate>
 		</ListView>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Bz27299.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Bz27299.xaml
@@ -3,7 +3,8 @@
 			 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
 			 x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Bz27299"
 			 xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests"
-			 BindingContext="{Binding Bz27299, Source={StaticResource ViewModelLocator}}">
+			 BindingContext="{Binding Bz27299, Source={StaticResource ViewModelLocator}}"
+			 x:DataType="local:Bz27299ViewModel">
 	<ContentPage.Resources>
 		<ResourceDictionary>
 			<local:Bz27299ViewModelLocator x:Key="ViewModelLocator" />

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Bz27863.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Bz27863.xaml
@@ -10,7 +10,7 @@
 			<DataTemplate x:Key="SimpleMessageTemplate">
 				<ViewCell>
 					<cmp:StackLayout >
-						<Label Text="{Binding Converter={StaticResource reverseConverter}}" />
+						<Label Text="{Binding Converter={StaticResource reverseConverter}}" x:DataType="x:String" />
 					</cmp:StackLayout>
 				</ViewCell>
 			</DataTemplate>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Gh4516.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Gh4516.xaml
@@ -3,6 +3,7 @@
 		xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
 		xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
 		xmlns:local="using:Microsoft.Maui.Controls.Xaml.UnitTests"
-		x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Gh4516">
+		x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Gh4516"
+		x:DataType="local:Gh4516VM">
 	<Image x:Name="image" Source="{Binding Images[0], FallbackValue='foo.jpg'}" />
 </ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Gh5290.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Gh5290.xaml
@@ -3,5 +3,7 @@
 		xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
 		xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
 		x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Gh5290"
-		NullableTime="{Binding Time, Mode=TwoWay}">	
+		xmlns:local="using:Microsoft.Maui.Controls.Xaml.UnitTests"
+		NullableTime="{Binding Time, Mode=TwoWay}"
+		x:DataType="local:Gh5290VM">	
 </ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Gh5706.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Gh5706.xaml
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Shell  xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
         xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+        xmlns:local="using:Microsoft.Maui.Controls.Xaml.UnitTests"
         x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Gh5706">
     <Shell.SearchHandler>
         <SearchHandler
             x:Name="searchHandler"
             Command="{Binding FilterCommand}"
-            CommandParameter="{Binding Source={x:Reference searchHandler}, Path=Query}" />
+            CommandParameter="{Binding Source={x:Reference searchHandler}, Path=Query}" 
+            x:DataType="local:Gh5706VM" />
     </Shell.SearchHandler>
 </Shell>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Gh5706.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Gh5706.xaml
@@ -7,7 +7,6 @@
         <SearchHandler
             x:Name="searchHandler"
             Command="{Binding FilterCommand}"
-            CommandParameter="{Binding Source={x:Reference searchHandler}, Path=Query}" 
-            x:DataType="local:Gh5706VM" />
+            CommandParameter="{Binding Source={x:Reference searchHandler}, Path=Query}"  />
     </Shell.SearchHandler>
 </Shell>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Gh5706.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Gh5706.xaml.cs
@@ -10,18 +10,6 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 {
 	public partial class Gh5706 : Shell
 	{
-		class VM
-		{
-			public VM()
-			{
-				FilterCommand = new Command((p) => Param = p);
-			}
-
-			public Command FilterCommand { get; set; }
-
-			public object Param { get; set; }
-		}
-
 		public Gh5706() => InitializeComponent();
 		public Gh5706(bool useCompiledXaml)
 		{
@@ -38,12 +26,24 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 			public void ReportSyntaxError([Values(false, true)] bool useCompiledXaml)
 			{
 				var layout = new Gh5706(useCompiledXaml);
-				layout.searchHandler.BindingContext = new VM();
+				layout.searchHandler.BindingContext = new Gh5706VM();
 
 				Assert.That(layout.searchHandler.CommandParameter, Is.Null);
 				layout.searchHandler.Query = "Foo";
 				Assert.That(layout.searchHandler.CommandParameter, Is.EqualTo("Foo"));
 			}
 		}
+	}
+
+	class Gh5706VM
+	{
+		public Gh5706VM()
+		{
+			FilterCommand = new Command((p) => Param = p);
+		}
+
+		public Command FilterCommand { get; set; }
+
+		public object Param { get; set; }
 	}
 }

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Gh7097.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Gh7097.xaml
@@ -3,6 +3,7 @@
         xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
         xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
         xmlns:local="using:Microsoft.Maui.Controls.Xaml.UnitTests"
+        xmlns:swi="clr-namespace:System.Windows.Input;assembly=System.ObjectModel"
         x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Gh7097"
         Title="Foo"
         x:Name="self">
@@ -21,12 +22,12 @@
                             Text="BTN 1" 
                             HorizontalOptions="FillAndExpand" 
                             CommandParameter="{Binding}" 
-                            Command="{Binding BindingContext.Button1Command, Source={x:Reference self}}"/>
+                            Command="{Binding BindingContext.Button1Command, Source={x:Reference self}}" x:DataType="swi:ICommand"/>
                         <Button 
                             Text="BTN 2" 
                             HorizontalOptions="FillAndExpand" 
                             CommandParameter="{Binding}" 
-                            Command="{Binding BindingContext.Button2Command, Source={x:Reference self}}"/>
+                            Command="{Binding BindingContext.Button2Command, Source={x:Reference self}}" x:DataType="swi:ICommand"/>
                     </StackLayout>
                 </DataTemplate>
             </CollectionView.ItemTemplate>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Gh7097.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Gh7097.xaml
@@ -22,12 +22,12 @@
                             Text="BTN 1" 
                             HorizontalOptions="FillAndExpand" 
                             CommandParameter="{Binding}" 
-                            Command="{Binding BindingContext.Button1Command, Source={x:Reference self}}" x:DataType="swi:ICommand"/>
+                            Command="{Binding BindingContext.Button1Command, Source={x:Reference self}}" x:DataType="local:Gh7097"/>
                         <Button 
                             Text="BTN 2" 
                             HorizontalOptions="FillAndExpand" 
                             CommandParameter="{Binding}" 
-                            Command="{Binding BindingContext.Button2Command, Source={x:Reference self}}" x:DataType="swi:ICommand"/>
+                            Command="{Binding BindingContext.Button2Command, Source={x:Reference self}}" x:DataType="local:Gh7097"/>
                     </StackLayout>
                 </DataTemplate>
             </CollectionView.ItemTemplate>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Issue1415.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Issue1415.xaml
@@ -2,6 +2,7 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
 			 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
 			 x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Issue1415"
-			 xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests;assembly=Microsoft.Maui.Controls.Xaml.UnitTests">
+			 xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests;assembly=Microsoft.Maui.Controls.Xaml.UnitTests"
+			 x:DataType="x:String">
 	<Label x:Name="label" Text="{Binding Converter={x:Static local:ReverseConverter.Instance}, Mode=TwoWay}"/>
 </ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Issue1438.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Issue1438.xaml
@@ -5,6 +5,7 @@
 	<StackLayout>
 		<Label BindingContext="{x:Reference slider}"
 			   x:Name="label"
+			   x:DataType="Slider"
 			   Text="{Binding Value, StringFormat='Slider value is {0:F3}'}"
 			   FontSize="Large"
 			   HorizontalOptions="Center"

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui18123.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui18123.xaml
@@ -15,8 +15,8 @@
             x:Name="deleteBtn">
             <Button.CommandParameter>
                 <MultiBinding Converter="{StaticResource MultiValueConverter}">
-                    <Binding Source="Dummy"/>
-                    <Binding Source="Edit"/>
+                    <Binding Source="Dummy" x:DataType="{x:Null}"/>
+                    <Binding Source="Edit" x:DataType="{x:Null}"/>
                 </MultiBinding>
             </Button.CommandParameter>
             <Button.Triggers>
@@ -40,15 +40,15 @@
             x:Name="editBtn">
             <Button.CommandParameter>
                 <MultiBinding Converter="{StaticResource MultiValueConverter}">
-                    <Binding Source="Dummy"/>
-                    <Binding Source="Edit"/>
+                    <Binding Source="Dummy" x:DataType="{x:Null}"/>
+                    <Binding Source="Edit" x:DataType="{x:Null}"/>
                 </MultiBinding>
             </Button.CommandParameter>
             <Button.Triggers>
-                <DataTrigger TargetType="Button" Binding="{Binding Mode}" Value="Edit" x:DataType="local:Maui18123VM">
+                <DataTrigger TargetType="Button" Binding="{Binding Mode, x:DataType=local:Maui18123VM}" Value="Edit" >
                     <Setter Property="Text" Value="SUBMIT" />
                 </DataTrigger>
-                <DataTrigger TargetType="Button" Binding="{Binding Mode}" Value="Create" x:DataType="local:Maui18123VM">
+                <DataTrigger TargetType="Button" Binding="{Binding Mode, x:DataType=local:Maui18123VM}" Value="Create" >
                     <Setter Property="Text" Value="SUBMIT" />
                     <Setter Property="CommandParameter" Value="Edit"/>
                 </DataTrigger>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui18123.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui18123.xaml
@@ -2,7 +2,8 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests"
-             x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui18123">
+             x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui18123"
+             x:DataType="local:Maui18123VM">
     <ContentPage.Resources>
         <local:Maui18123MultiValueConverter x:Key="MultiValueConverter"/>
     </ContentPage.Resources>
@@ -44,10 +45,10 @@
                 </MultiBinding>
             </Button.CommandParameter>
             <Button.Triggers>
-                <DataTrigger TargetType="Button" Binding="{Binding Mode}" Value="Edit">
+                <DataTrigger TargetType="Button" Binding="{Binding Mode}" Value="Edit" x:DataType="local:Maui18123VM">
                     <Setter Property="Text" Value="SUBMIT" />
                 </DataTrigger>
-                <DataTrigger TargetType="Button" Binding="{Binding Mode}" Value="Create">
+                <DataTrigger TargetType="Button" Binding="{Binding Mode}" Value="Create" x:DataType="local:Maui18123VM">
                     <Setter Property="Text" Value="SUBMIT" />
                     <Setter Property="CommandParameter" Value="Edit"/>
                 </DataTrigger>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui18123.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui18123.xaml.cs
@@ -44,7 +44,6 @@ public partial class Maui18123 : ContentPage
 			DispatcherProvider.SetCurrent(new DispatcherProviderStub());
 		}
 
-
 		[TearDown] public void TearDown() => AppInfo.SetCurrent(null);
 
 		[Test]
@@ -63,34 +62,33 @@ public partial class Maui18123 : ContentPage
 			Assert.That(page.deleteBtn.Text, Is.EqualTo("Delete"));
 		}
 	}
+}
 
-	public partial class Maui18123VM : BindableObject
+public partial class Maui18123VM : BindableObject
+{
+	string _mode = "";
+	public string Mode
 	{
-		string _mode = "";
-		public string Mode
+		get { return _mode; }
+		set
 		{
-			get { return _mode; }
-			set
-			{
-				_mode = value;
-				OnPropertyChanged();
-			}
+			_mode = value;
+			OnPropertyChanged();
 		}
+	}
 
-		Command testCommand;
-		public Command TestCommand => testCommand ??= new Command(Test);
+	Command testCommand;
+	public Command TestCommand => testCommand ??= new Command(Test);
 
-		void Test(object parameter)
-		{
-			var value = string.Empty;
+	void Test(object parameter)
+	{
+		var value = string.Empty;
 
-			if (parameter is object[] parameters)
-				value = parameters.LastOrDefault()?.ToString();
-			else
-				value = parameter.ToString();
+		if (parameter is object[] parameters)
+			value = parameters.LastOrDefault()?.ToString();
+		else
+			value = parameter.ToString();
 
-			Mode = value;
-		}
-
+		Mode = value;
 	}
 }

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui6367.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui6367.xaml.cs
@@ -22,8 +22,7 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 			[Test]
 			public void NestedTriggers([Values(false, true)] bool useCompiledXaml)
 			{
-				Maui6367 view = new Maui6367(useCompiledXaml);
-				//Assert.DoesNotThrow(() => view = new Maui6367(useCompiledXaml));
+				Maui6367 view = new Maui6367(useCompiledXaml);				
 			}
 		}
 	}


### PR DESCRIPTION
### Description of Change

Warn on XAML and Bindings that can't be compiled
Compile Bindings used as properties (Setters, Triggers, MultiBindings)

### Issues Fixed

- Fixes #19647
- Fixes #5342
