### PR TITLE
[Housekeeping] Enabling ignored tests

### DIFF
--- a/src/Core/tests/DeviceTests.Shared/HandlerTests/HandlerTestBaseOfT.Tests.cs
+++ b/src/Core/tests/DeviceTests.Shared/HandlerTests/HandlerTestBaseOfT.Tests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Maui.DeviceTests
 	public abstract partial class HandlerTestBase<THandler, TStub>
 	{
 		[Fact]
-		public async Task DisconnectHandlerDoesntCrash()
+		public virtual async Task DisconnectHandlerDoesntCrash()
 		{
 			var handler = await CreateHandlerAsync(new TStub()) as IPlatformViewHandler;
 			await InvokeOnMainThreadAsync(() =>

--- a/src/Core/tests/DeviceTests.Shared/HandlerTests/TextInput/TextInputHandlerTests.cs
+++ b/src/Core/tests/DeviceTests.Shared/HandlerTests/TextInput/TextInputHandlerTests.cs
@@ -55,11 +55,7 @@ namespace Microsoft.Maui.DeviceTests
 				Assert.Equal(0, eventFiredCount);
 		}
 
-		[Fact
-#if WINDOWS
-			(Skip = "Failing on Windows")
-#endif
-			]
+		[Fact]
 		public async Task CursorPositionDoesntResetWhenNativeTextValueChanges()
 		{
 			var textInput = new TStub()
@@ -67,11 +63,10 @@ namespace Microsoft.Maui.DeviceTests
 				Text = "Hello"
 			};
 
-
 			int cursorPosition = 0;
-			await InvokeOnMainThreadAsync(() =>
+
+			await AttachAndRun(textInput, handler =>
 			{
-				var handler = CreateHandler<THandler>(textInput);
 				UpdateCursorStartPosition(handler, 5);
 				handler.UpdateValue(nameof(ITextInput.Text));
 				cursorPosition = GetCursorStartPosition(handler);

--- a/src/Core/tests/DeviceTests/Handlers/ActivityIndicator/ActivityIndicatorHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/ActivityIndicator/ActivityIndicatorHandlerTests.cs
@@ -1,7 +1,5 @@
 ﻿using System.Threading.Tasks;
 using Microsoft.Maui.DeviceTests.Stubs;
-using Microsoft.Maui.Graphics;
-using Microsoft.Maui.Handlers;
 using Xunit;
 
 namespace Microsoft.Maui.DeviceTests
@@ -22,19 +20,21 @@ namespace Microsoft.Maui.DeviceTests
 			await ValidatePropertyInitValue(activityIndicator, () => activityIndicator.IsRunning, GetNativeIsRunning, activityIndicator.IsRunning);
 		}
 
-		[Fact(DisplayName = "Background Updates Correctly"
-#if WINDOWS
-			, Skip = "Failing on Windows"
-#endif
-			)]
-		public async Task BackgroundUpdatesCorrectly()
+		[Theory(DisplayName = "Background Updates Correctly")]
+		[InlineData(0xFFFF0000)]
+		[InlineData(0xFF00FF00)]
+		[InlineData(0xFF0000FF)]
+		public async Task BackgroundUpdatesCorrectly(uint color)
 		{
+			var expected = Color.FromUint(color);
+
 			var activityIndicator = new ActivityIndicatorStub()
 			{
+				Background = new SolidPaintStub(Color.FromUint(0xFF888888)),
 				IsRunning = true
 			};
 
-			await ValidateHasColor(activityIndicator, Colors.Yellow, () => activityIndicator.Background = new SolidPaintStub(Colors.Yellow), nameof(activityIndicator.Background));
+			await ValidateHasColor(activityIndicator, expected, () => activityIndicator.Background = new SolidPaintStub(expected), nameof(activityIndicator.Background));
 		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/Border/BorderHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Border/BorderHandlerTests.cs
@@ -77,6 +77,7 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		[Theory(DisplayName = "StrokeShape Initializes Correctly")]
+		[InlineData("Ellipse")]
 		[InlineData("Rectangle")]
 		[InlineData("RoundRectangle")]
 		public async Task StrokeShapeInitializesCorrectly(string shape)
@@ -90,6 +91,11 @@ namespace Microsoft.Maui.DeviceTests
 				Height = 100,
 				Width = 300
 			};
+
+			if (shape == "Ellipse")
+			{
+				border.Shape = new EllipseShapeStub();
+			}
 
 			if (shape == "Rectangle")
 			{

--- a/src/Core/tests/DeviceTests/Handlers/DatePicker/DatePickerHandlerTests.Windows.cs
+++ b/src/Core/tests/DeviceTests/Handlers/DatePicker/DatePickerHandlerTests.Windows.cs
@@ -9,6 +9,20 @@ namespace Microsoft.Maui.DeviceTests
 {
 	public partial class DatePickerHandlerTests
 	{
+		[Fact]
+		public override async Task DisconnectHandlerDoesntCrash()
+		{
+			var datePicker = new DatePickerStub
+			{
+				MinimumDate = DateTime.Today.AddDays(-1),
+				MaximumDate = DateTime.Today.AddDays(1),
+				Date = DateTime.Today
+			};
+
+			var handler = await CreateHandlerAsync(datePicker) as IPlatformViewHandler;
+			await InvokeOnMainThreadAsync(handler.DisconnectHandler);
+		}
+
 		[Theory(DisplayName = "Format Initializes Correctly")]
 		[InlineData("dd/MM/yyyy", "{day.integer(2)}/{month.integer(2)}/{year.full}")]
 		[InlineData("d/M/yy", "{day.integer}/{month.integer(1)}/{year.abbreviated}")]

--- a/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Maui.DeviceTests
 	[Category(TestCategory.SearchBar)]
 	public partial class SearchBarHandlerTests : CoreHandlerTestBase<SearchBarHandler, SearchBarStub>
 	{
-		[Theory(DisplayName = "Background Initializes Correctly"]
+		[Theory(DisplayName = "Background Initializes Correctly")]
 		[InlineData(0xFFFF0000)]
 		[InlineData(0xFF00FF00)]
 		[InlineData(0xFF0000FF)]
@@ -257,11 +257,7 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.Equal(expectedText, platformText);
 		}
 
-		[Fact(DisplayName = "CancelButtonColor Initialize Correctly"
-#if WINDOWS
-		, Skip = "Fails on Windows"
-#endif
-		)]
+		[Fact(DisplayName = "CancelButtonColor Initialize Correctly")]
 		public async Task CancelButtonColorInitializeCorrectly()
 		{
 			var searchBar = new SearchBarStub()

--- a/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.cs
@@ -267,7 +267,17 @@ namespace Microsoft.Maui.DeviceTests
 				CancelButtonColor = Colors.Yellow,
 			};
 
+#if WINDOWS
+			// The cancel button won't exist in the SearchBar until the SearchBar is loaded (and OnApplyTemplate is called)
+			// so we need to attach the SearchBar to the running app before we can check the color
+
+			await AttachAndRun(searchBar, async (searchBarHandler) =>
+			{
+				await ValidatePropertyInitValue(searchBar, () => searchBar.CancelButtonColor, GetNativeCancelButtonColor, Colors.Yellow);
+			});
+#else
 			await ValidateHasColor(searchBar, Colors.Yellow);
+#endif
 		}
 
 		[Fact(DisplayName = "Null Cancel Button Color Doesn't Crash")]

--- a/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.cs
@@ -1,7 +1,5 @@
 ﻿using System.Threading.Tasks;
 using Microsoft.Maui.DeviceTests.Stubs;
-using Microsoft.Maui.Graphics;
-using Microsoft.Maui.Handlers;
 using Xunit;
 using static Microsoft.Maui.DeviceTests.AssertHelpers;
 
@@ -10,11 +8,7 @@ namespace Microsoft.Maui.DeviceTests
 	[Category(TestCategory.SearchBar)]
 	public partial class SearchBarHandlerTests : CoreHandlerTestBase<SearchBarHandler, SearchBarStub>
 	{
-		[Theory(DisplayName = "Background Initializes Correctly"
-#if IOS || MACCATALYST
-			, Skip = "This test is currently invalid on iOS https://github.com/dotnet/maui/issues/13693"
-#endif
-			)]
+		[Theory(DisplayName = "Background Initializes Correctly"]
 		[InlineData(0xFFFF0000)]
 		[InlineData(0xFF00FF00)]
 		[InlineData(0xFF0000FF)]
@@ -28,8 +22,16 @@ namespace Microsoft.Maui.DeviceTests
 				Text = "Background",
 			};
 
+#if IOS || MACCATALYST
+			await ValidatePropertyInitValue(searchBar, () => 
+				(searchBar.Background as SolidPaint).Color, 
+				GetNativeBackgroundColor, 
+				(searchBar.Background as SolidPaint).Color);
+#else
 			await ValidateHasColor(searchBar, expected);
+#endif
 		}
+
 
 		[Fact(DisplayName = "Text Initializes Correctly")]
 		public async Task TextInitializesCorrectly()

--- a/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.iOS.cs
@@ -140,6 +140,9 @@ namespace Microsoft.Maui.DeviceTests
 		static UISearchBar GetNativeSearchBar(SearchBarHandler searchBarHandler) =>
 			(UISearchBar)searchBarHandler.PlatformView;
 
+		Color GetNativeBackgroundColor(SearchBarHandler searchBarHandler) =>
+			GetNativeSearchBar(searchBarHandler).BarTintColor.ToColor();
+
 		string GetNativeText(SearchBarHandler searchBarHandler) =>
 			GetNativeSearchBar(searchBarHandler).Text;
 

--- a/src/Core/tests/DeviceTests/Handlers/Slider/SliderHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Slider/SliderHandlerTests.Android.cs
@@ -10,6 +10,17 @@ namespace Microsoft.Maui.DeviceTests
 {
 	public partial class SliderHandlerTests
 	{
+		[Fact(DisplayName = "Thumb Color Initializes Correctly")]
+		public async Task ThumbColorInitializesCorrectly()
+		{
+			var slider = new SliderStub()
+			{
+				ThumbColor = Colors.Purple
+			};
+
+			await ValidateNativeThumbColor(slider, Colors.Purple);
+		}
+
 		[Fact(DisplayName = "ThumbImageSource Initializes Correctly", Skip = "There seems to be an issue, so disable for now: https://github.com/dotnet/maui/issues/1275")]
 		public async Task ThumbImageSourceInitializesCorrectly()
 		{

--- a/src/Core/tests/DeviceTests/Handlers/Slider/SliderHandlerTests.Windows.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Slider/SliderHandlerTests.Windows.cs
@@ -1,6 +1,5 @@
 ﻿using System.Threading.Tasks;
 using Microsoft.Maui.DeviceTests.Stubs;
-using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using Xunit;
 using static Microsoft.Maui.DeviceTests.AssertHelpers;
@@ -9,6 +8,28 @@ namespace Microsoft.Maui.DeviceTests
 {
 	public partial class SliderHandlerTests
 	{
+		[Fact(DisplayName = "Thumb Color Initializes Correctly")]
+		public async Task ThumbColorInitializesCorrectly()
+		{
+			var slider = new SliderStub()
+			{
+				ThumbColor = Colors.Purple
+			};
+
+			await InvokeOnMainThreadAsync(async () =>
+			{
+				var handler = CreateHandler(slider);
+
+				await handler.PlatformView.AttachAndRun(async () =>
+				{
+					await AssertEventually(() => handler.PlatformView.IsLoaded());
+
+					await ValidateNativeThumbColor(slider, Colors.Purple);
+				}, MauiContext);
+			});
+
+		}
+
 		// https://github.com/dotnet/maui/issues/12405
 		[Theory(DisplayName = "Platform Slider SmallChange Initializes Correctly")]
 		[InlineData(0, 1, 0)]
@@ -97,7 +118,7 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
-		Slider GetNativeSlider(SliderHandler sliderHandler) =>
+        UI.Xaml.Controls.Slider GetNativeSlider(SliderHandler sliderHandler) =>
 			sliderHandler.PlatformView;
 
 		double GetNativeProgress(SliderHandler sliderHandler) =>
@@ -127,6 +148,26 @@ namespace Microsoft.Maui.DeviceTests
 		bool ImageSourceLoaded(SliderHandler sliderHandler)
 		{
 			return (sliderHandler.PlatformView as MauiSlider)?.ThumbImageSource != null;
+		}
+
+		async Task ValidateNativeThumbColor(ISlider slider, Color color)
+		{
+			var expected = await GetValueAsync(slider, handler =>
+			{
+				var nativeSlider = GetNativeSlider(handler);
+
+				if (nativeSlider.GetFirstDescendant<Thumb>() is Thumb thumb)
+				{
+					if (thumb.Background is UI.Xaml.Media.SolidColorBrush solidThumb)
+					{
+						return solidThumb.Color.ToColor();
+					}
+				}
+				
+				return null;
+			});
+
+			Assert.Equal(expected, color);
 		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/Slider/SliderHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Slider/SliderHandlerTests.cs
@@ -51,19 +51,6 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.Equal(expectedPercent, nativePercent, 5);
 		}
 
-#if !WINDOWS
-		[Fact(DisplayName = "Thumb Color Initializes Correctly", Skip = "There seems to be an issue, so disable for now: https://github.com/dotnet/maui/issues/1275")]
-		public async Task ThumbColorInitializesCorrectly()
-		{
-			var slider = new SliderStub()
-			{
-				ThumbColor = Colors.Purple
-			};
-
-			await ValidateNativeThumbColor(slider, Colors.Purple);
-		}
-#endif
-
 		[Fact(DisplayName = "Null Thumb Color Doesn't Crash")]
 		public async Task NullThumbColorDoesntCrash()
 		{

--- a/src/Core/tests/DeviceTests/Handlers/Slider/SliderHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Slider/SliderHandlerTests.iOS.cs
@@ -7,6 +7,17 @@ namespace Microsoft.Maui.DeviceTests
 {
 	public partial class SliderHandlerTests
 	{
+		[Fact(DisplayName = "Thumb Color Initializes Correctly")]
+		public async Task ThumbColorInitializesCorrectly()
+		{
+			var slider = new SliderStub()
+			{
+				ThumbColor = Colors.Purple
+			};
+
+			await ValidateNativeThumbColor(slider, Colors.Purple);
+		}
+
 		[Fact(DisplayName = "ThumbImageSource Initializes Correctly")]
 		public async Task ThumbImageSourceInitializesCorrectly()
 		{


### PR DESCRIPTION
### Description of Change

Enabling ignored tests:
- Dashed Stroke Initializes Correctly (all variations)
- Background Initializes Correctly (all variations)
- Stroke Initializes Correctly (all variations)
- CancelButtonColorInitializeCorrectly
- StrokeShape Initializes Correctly (all variations)
- BackgroundUpdatesCorrectly
- DisconnectHandlerDoesntCrash
- CursorPositionDoesntResetWhenNativeTextValueChanges

### Issues Fixed

Related with #15530