### PR TITLE
Bump GitInfo to 3.3.3

### DIFF
--- a/eng/Git.Build.targets
+++ b/eng/Git.Build.targets
@@ -1,6 +1,6 @@
 <Project>
   <ItemGroup>
-    <PackageReference Include="GitInfo" Version="2.2.0" PrivateAssets="All" />
+    <PackageReference Include="GitInfo" Version="3.3.3" PrivateAssets="All" />
     <PackageReference Include="MSBuilder.GenerateAssemblyInfo" Version="0.2.2" PrivateAssets="All" />
 	</ItemGroup>
  </Project>


### PR DESCRIPTION
### Description of Change

In an attempt to overcome #19185 let's first try to update the dependency for it. This version has no SponsorLink or something like that, so should be safe to use.

### Issues Fixed

Related #19185 

Let's close this issue once we verify this actually does something. Because this doesn't always happen, let's check for a while before we actually assume it's fixed after merging this.
