### PR TITLE
iOS Next Entry to skip hidden parents

### DIFF
--- a/src/Core/src/Platform/iOS/ViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/ViewExtensions.cs
@@ -826,7 +826,7 @@ namespace Microsoft.Maui.Platform
 			{
 				var sibling = siblings[i];
 
-				if (sibling.Subviews is not null && sibling.Subviews.Length > 0)
+				if (!sibling.Hidden && sibling.Subviews?.Length > 0)
 				{
 					var childVal = sibling.Subviews[0].FindNextView(0, isValidType);
 					if (childVal is not null)

--- a/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.iOS.cs
@@ -449,6 +449,100 @@ namespace Microsoft.Maui.DeviceTests
 			}, entry1, editor, entry2, entry3);
 		}
 
+		[Fact]
+		public async Task NextMovesSkipsHiddenSibling()
+		{
+			var entry1 = new EntryStub
+			{
+				ReturnType = ReturnType.Next,
+			};
+
+			var entry2 = new EntryStub
+			{
+				Visibility = Visibility.Hidden,
+				ReturnType = ReturnType.Next,
+			};
+
+			var entry3 = new EntryStub
+			{
+				ReturnType = ReturnType.Next
+			};
+
+			await NextMovesHelper(() =>
+			{
+				KeyboardAutoManager.GoToNextResponderOrResign(entry1.ToPlatform(), customSuperView: entry1.ToPlatform().Superview);
+				Assert.True(entry3.IsFocused);
+			}, entry1, entry2, entry3);
+		}
+
+		[Fact]
+		public async Task NextMovesSkipsHiddenParent()
+		{
+			var entry1 = new EntryStub
+			{
+				ReturnType = ReturnType.Next,
+			};
+
+			var entry2 = new EntryStub
+			{
+				ReturnType = ReturnType.Next,
+			};
+
+			var entry3 = new EntryStub
+			{
+				ReturnType = ReturnType.Next
+			};
+
+			var vsl1 = new VerticalStackLayoutStub();
+			vsl1.Add(entry1);
+			var vsl2 = new VerticalStackLayoutStub { Visibility = Visibility.Hidden };
+			vsl2.Add(entry2);
+			var vsl3 = new VerticalStackLayoutStub();
+			vsl3.Add(entry3);
+
+			await NextMovesHelper(() =>
+			{
+				KeyboardAutoManager.GoToNextResponderOrResign(entry1.ToPlatform(), customSuperView: vsl1.ToPlatform().Superview);
+				Assert.True(entry3.IsFocused);
+			}, vsl1, vsl2, vsl3);
+		}
+
+		[Fact]
+		public async Task NextMovesSkipsHiddenAncestor()
+		{
+			var entry1 = new EntryStub
+			{
+				ReturnType = ReturnType.Next,
+			};
+
+			var entry2 = new EntryStub
+			{
+				ReturnType = ReturnType.Next,
+			};
+
+			var entry3 = new EntryStub
+			{
+				ReturnType = ReturnType.Next
+			};
+
+			var vsl1 = new VerticalStackLayoutStub();
+			vsl1.Add(entry1);
+			var vsl2 = new VerticalStackLayoutStub { Visibility = Visibility.Hidden };
+			var vsl2_1 = new VerticalStackLayoutStub();
+			var vsl2_2 = new VerticalStackLayoutStub();
+			vsl2.Add(vsl2_1);
+			vsl2_1.Add(vsl2_2);
+			vsl2_2.Add(entry2);
+			var vsl3 = new VerticalStackLayoutStub();
+			vsl3.Add(entry3);
+
+			await NextMovesHelper(() =>
+			{
+				KeyboardAutoManager.GoToNextResponderOrResign(entry1.ToPlatform(), customSuperView: vsl1.ToPlatform().Superview);
+				Assert.True(entry3.IsFocused);
+			}, vsl1, vsl2, vsl3);
+		}
+
 		async Task NextMovesHelper(Action action = null, params StubBase[] views)
 		{
 			EnsureHandlerCreated(builder =>


### PR DESCRIPTION
### Description of Change

<!-- Enter description of the fix in this section -->
We have a bug in iOS when using an Entry's Next ReturnType. If the next 'available' entry/editor is not visible, we skip it and go on to the next available entry/editor. However, if the parent of the next 'available' entry/editor is not visible and the 'available' entry/editor is not marked as not visible, we will still go into it.

In the search for the next entry/editor, we go through the current controls siblings, then go up a level to the parent's siblings and look into their children. Because of this, we can simply check if the parent is visible and go onto the next parent if so.

| Before | After |
| -- | -- |
| <video width="300" src="https://github.com/dotnet/maui/assets/50846373/905115b9-cdf0-416c-a2a3-8be85d136d12"> | <video width="300" src="https://github.com/dotnet/maui/assets/50846373/f85c0c1f-35d1-4576-86f4-2661439a79a3"> |

<details> 
<summary> 

#### Code Snippet from original issue (click me!) 

</summary>

```xaml
<?xml version="1.0" encoding="utf-8" ?>
<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
             x:Class="MauiApp1.MainPage">
    <ScrollView>
        <VerticalStackLayout Padding="30,0" Spacing="25">
            <Entry Placeholder="entry1" ReturnType="Next"/>

            <Grid IsVisible="False">
                <Entry x:Name="hiddenEntry2" Placeholder="hiddenEntry2" ReturnType="Next" Focused="HiddenEntry2Focused"/>
            </Grid>

            <Entry Placeholder="entry3" ReturnType="Next" Focused="Entry3Focused"/>
        </VerticalStackLayout>
    </ScrollView>
</ContentPage>
```

```cs
namespace MauiApp1
{
    public partial class MainPage : ContentPage
    {
        public MainPage()
        {
            InitializeComponent();
        }

        private void HiddenEntry2Focused(object sender, FocusEventArgs e)
        {
            Console.WriteLine("Hidden entry: IsVisible: " + hiddenEntry2.IsVisible);
        }

        private void Entry3Focused(object sender, FocusEventArgs e)
        {
            Console.WriteLine("Hidden entry: IsVisible: " + hiddenEntry2.IsVisible);
        }
    }
}
```

</details> 

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #19139

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
