### PR TITLE
[WinUI] Fix gif animation initial state

### DIFF
--- a/src/Core/src/Handlers/Image/ImageHandler.Windows.cs
+++ b/src/Core/src/Handlers/Image/ImageHandler.Windows.cs
@@ -6,12 +6,21 @@ using WImage = Microsoft.UI.Xaml.Controls.Image;
 
 namespace Microsoft.Maui.Handlers
 {
-	public partial class ImageHandler : ViewHandler<IImage, Image>
+	public partial class ImageHandler : ViewHandler<IImage, WImage>
 	{
-		protected override Image CreatePlatformView() => new Image();
+		protected override WImage CreatePlatformView() => new WImage();
 
-		protected override void DisconnectHandler(Image platformView)
+		protected override void ConnectHandler(WImage platformView)
 		{
+			platformView.ImageOpened += OnImageOpened;
+
+			base.ConnectHandler(platformView);
+		}
+
+		protected override void DisconnectHandler(WImage platformView)
+		{
+			platformView.ImageOpened -= OnImageOpened;
+
 			base.DisconnectHandler(platformView);
 			SourceLoader.Reset();
 		}
@@ -37,6 +46,11 @@ namespace Microsoft.Maui.Handlers
 
 		public static Task MapSourceAsync(IImageHandler handler, IImage image) =>
 			handler.SourceLoader.UpdateImageSourceAsync();
+
+		void OnImageOpened(object sender, RoutedEventArgs e)
+		{
+			UpdateValue(nameof(IImage.IsAnimationPlaying));
+		}
 
 		partial class ImageImageSourcePartSetter
 		{

--- a/src/Core/src/Platform/Windows/ImageSourcePartExtensions.cs
+++ b/src/Core/src/Platform/Windows/ImageSourcePartExtensions.cs
@@ -42,8 +42,6 @@ namespace Microsoft.Maui.Platform
 				if (applied)
 				{
 					setImage(uiImage);
-					if (destinationContext is WImage imageView)
-						imageView.UpdateIsAnimationPlaying(image);
 				}
 
 				events?.LoadingCompleted(applied);

--- a/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -44,6 +44,7 @@ Microsoft.Maui.Platform.MauiWebView.MauiWebView(Microsoft.Maui.Handlers.WebViewH
 Microsoft.Maui.SizeRequest.Equals(Microsoft.Maui.SizeRequest other) -> bool
 Microsoft.Maui.SoftInputExtensions
 override Microsoft.Maui.Handlers.ContentViewHandler.DisconnectHandler(Microsoft.Maui.Platform.ContentPanel! platformView) -> void
+override Microsoft.Maui.Handlers.ImageHandler.ConnectHandler(Microsoft.UI.Xaml.Controls.Image! platformView) -> void
 override Microsoft.Maui.Handlers.MenuFlyoutHandler.DisconnectHandler(Microsoft.UI.Xaml.Controls.MenuFlyout! platformView) -> void
 override Microsoft.Maui.Layouts.FlexBasis.Equals(object? obj) -> bool
 override Microsoft.Maui.Layouts.FlexBasis.GetHashCode() -> int

--- a/src/Core/tests/DeviceTests/Handlers/Image/ImageHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Image/ImageHandlerTests.cs
@@ -121,9 +121,7 @@ namespace Microsoft.Maui.DeviceTests
 #endif
 		)]
 		[InlineData("animated_heart.gif", true)]
-#if !WINDOWS
 		[InlineData("animated_heart.gif", false)]
-#endif
 		public async virtual Task AnimatedSourceInitializesCorrectly(string filename, bool isAnimating)
 		{
 			var image = new TStub
@@ -138,8 +136,10 @@ namespace Microsoft.Maui.DeviceTests
 
 				await image.WaitUntilLoaded();
 
-				await AttachAndRun(GetPlatformImageView(handler), () =>
+				await AttachAndRun(GetPlatformImageView(handler), async () =>
 				{
+					await image.WaitUntilDecoded();
+
 					Assert.Equal(isAnimating, GetNativeIsAnimationPlaying(handler));
 				});
 			});


### PR DESCRIPTION
### Description of Change

Animated GIF on WinUI are not correctly respecting the IsAnimationPlaying because the actual image is animated, not the view. However, the image has to actually be loaded and on-screen before we can start/stop playing.

This PR waits for the image to be fully loaded and presented before handling the animation.

This PR needs:
 - https://github.com/dotnet/maui/pull/20167

Based on the work in:

 - https://github.com/dotnet/maui/pull/14295