### PR TITLE
Fix Shell.NavBarIsVisible property

### DIFF
--- a/src/Controls/src/Core/Internals/PropertyPropagationExtensions.cs
+++ b/src/Controls/src/Core/Internals/PropertyPropagationExtensions.cs
@@ -22,6 +22,9 @@ namespace Microsoft.Maui.Controls.Internals
 
 			if (propertyName == null || propertyName == Shell.TabBarIsVisibleProperty.PropertyName)
 				BaseShellItem.PropagateFromParent(Shell.TabBarIsVisibleProperty, element);
+			
+			if (propertyName == null || propertyName == Shell.NavBarIsVisibleProperty.PropertyName)
+				BaseShellItem.PropagateFromParent(Shell.NavBarIsVisibleProperty, element);
 
 			foreach (var child in children)
 			{

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Issue18948.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Issue18948.xaml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Shell 
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui" 	
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" 
+    x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Issue18948"
+    xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests"
+    Shell.NavBarIsVisible="False">
+    <ShellContent
+        Title="One"
+        ContentTemplate="{DataTemplate local:Maui11204}"
+        Route="One" />
+    <ShellContent
+        Title="Two"
+        ContentTemplate="{DataTemplate local:Maui11204}"
+        Route="Two" />
+</Shell>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Issue18948.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Issue18948.xaml.cs
@@ -1,0 +1,30 @@
+using NUnit.Framework;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests
+{
+	public partial class Issue18948 : Shell
+	{
+		public Issue18948()
+		{
+			InitializeComponent();
+		}
+		public Issue18948(bool useCompiledXaml)
+		{
+			// This stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		public class Tests
+		{
+			[TestCase(false)]
+			[TestCase(true)]
+			public void NavBarIsVisiblePropertyPropagates(bool useCompiledXaml)
+			{
+				var shell = new Issue18948(useCompiledXaml);
+				var navBarIsVisible = Shell.GetNavBarIsVisible(shell.CurrentContent);
+				Assert.False(navBarIsVisible);
+			}
+		}
+	}
+}
+


### PR DESCRIPTION
### Description of Change

Fix `Shell.NavBarIsVisible` property.

### Issues Fixed

Fixes #18948
