### PR TITLE
[ci] Add missing demands

### DIFF
--- a/eng/pipelines/common/maui-templates.yml
+++ b/eng/pipelines/common/maui-templates.yml
@@ -42,6 +42,9 @@ parameters:
       artifact: templates-run-android
     - name: $(iosTestsVmPool)
       vmImage: $(iosTestsVmImage)
+      demands:
+        - macOS.Name -equals Ventura
+        - macOS.Architecture -equals x64
       testName: RunOniOS
       artifact: templates-run-ios
 


### PR DESCRIPTION
### Description of Change

When testing megapipeline we saw that we were missing some demands for running iOS device tests