### PR TITLE
Add comments to internal methods for XAML Hot Reload usage

### DIFF
--- a/src/Controls/src/Core/IProvideParentValues.cs
+++ b/src/Controls/src/Core/IProvideParentValues.cs
@@ -7,7 +7,6 @@ namespace Microsoft.Maui.Controls.Xaml
 	// Consult XET if updating!
 	internal interface IProvideParentValues : IProvideValueTarget
 	{
-		
 		IEnumerable<object> ParentObjects { get; }
 	}
 }

--- a/src/Controls/src/Core/IProvideParentValues.cs
+++ b/src/Controls/src/Core/IProvideParentValues.cs
@@ -3,8 +3,11 @@ using System.Collections.Generic;
 
 namespace Microsoft.Maui.Controls.Xaml
 {
+	// Used by MAUI XAML Hot Reload.
+	// Consult XET if updating!
 	internal interface IProvideParentValues : IProvideValueTarget
 	{
+		
 		IEnumerable<object> ParentObjects { get; }
 	}
 }

--- a/src/Controls/src/Core/IValueConverterProvider.cs
+++ b/src/Controls/src/Core/IValueConverterProvider.cs
@@ -4,6 +4,8 @@ using System.Reflection;
 
 namespace Microsoft.Maui.Controls.Xaml
 {
+	// Used by MAUI XAML Hot Reload.
+	// Consult XET if updating!
 	interface IValueConverterProvider
 	{
 		object Convert(object value, Type toType, Func<MemberInfo> minfoRetriever, IServiceProvider serviceProvider);

--- a/src/Core/src/Platform/Standard/ViewExtensions.cs
+++ b/src/Core/src/Platform/Standard/ViewExtensions.cs
@@ -69,6 +69,8 @@ namespace Microsoft.Maui.Platform
 
 		internal static System.Numerics.Matrix4x4 GetViewTransform(this IView view) => new System.Numerics.Matrix4x4();
 
+		// Used by MAUI XAML Hot Reload.
+		// Consult XET if updating!
 		internal static Graphics.Rect GetBoundingBox(this IView view) => view.Frame;
 
 		internal static object? GetParent(this object? view)


### PR DESCRIPTION
### Description of Change

To try and prevent accidental breaking changes from affecting MAUI XAML Hot Reload, I have added comments for the current internal methods being used by it. If any changes happen to these methods, it will break shipping versions of XAML Hot Reload in Visual Studio.

If there are better ways to mark them, please let me know and I'll change it. We can also talk about the viability of making these public or coming up with better ways of protecting use of internal APIs used by partner libraries, like XAML Hot Reload. 