### PR TITLE
Use fixed version for apiscan

### DIFF
--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -304,4 +304,4 @@ stages:
           enableCodeInspector: true
           apiScanEnabled: true
           apiScanSoftwareName: 'MAUI'
-          apiScanSoftwareVersionNum: $(Build.BuildNumber)
+          apiScanSoftwareVersionNum: 8.0


### PR DESCRIPTION
### Description of Change

See if this helps with apiscan failing with 

```
 ERROR: Microsoft.Tools.ApiScan.ApiScanLib.Exceptions.BadArgumentException: 'MAUI' has not been enabled for release runs
 ```
