### PR TITLE
Add Frame observer for UIWindow frame changes

### DIFF
--- a/src/Core/src/Handlers/Window/WindowHandler.iOS.cs
+++ b/src/Core/src/Handlers/Window/WindowHandler.iOS.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using CoreGraphics;
+using Foundation;
 using ObjCRuntime;
 using UIKit;
 
@@ -6,10 +8,13 @@ namespace Microsoft.Maui.Handlers
 {
 	public partial class WindowHandler : ElementHandler<IWindow, UIWindow>
 	{
+		IDisposable? _frameObserver;
+		
 		protected override void ConnectHandler(UIWindow platformView)
 		{
 			base.ConnectHandler(platformView);
-
+			// For Size Change Events on the given window.
+			_frameObserver = platformView.AddObserver("frame", Foundation.NSKeyValueObservingOptions.New, FrameAction);
 			UpdateVirtualViewFrame(platformView);
 		}
 		public static void MapTitle(IWindowHandler handler, IWindow window) =>
@@ -88,6 +93,14 @@ namespace Microsoft.Maui.Handlers
 		void UpdateVirtualViewFrame(UIWindow window)
 		{
 			VirtualView.FrameChanged(window.Bounds.ToRectangle());
+		}
+
+		void FrameAction(Foundation.NSObservedChange obj)
+		{
+			if (obj.NewValue is NSValue value)
+			{
+				VirtualView.FrameChanged(value.CGRectValue.ToRectangle());
+			}
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change

As far as I can see, there are no SizeChange events fired for iOS and Mac, as beyond its initial creation there's no events wired in to handle it. Normally, I believe, you would override `viewWillTransitionToSize` on the UIView, but since I don't think MAUI subclasses UIWindow, we can steal what the WindowOverlay does and subscribe to `frame` changes. Those should fire when the underlying UIWindow Frame updates.

I'm not 100% sure if the numbers are correct for the parameters being passed in, but since SizeChange itself doesn't send that info, it should be safe enough as an underlying SizeChange event.

The two underlying issues I have with this are:

- I don't know where to dispose the FrameObserver from the handler.
- I'm not sure how to write a test for this.

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/20198


https://github.com/dotnet/maui/assets/898335/15016bb8-23f3-4828-9736-bc6fb6ea0d67


<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
