### PR TITLE
Account for margins on sizes returned from Editor

### DIFF
--- a/src/Controls/src/Core/Editor/Editor.cs
+++ b/src/Controls/src/Core/Editor/Editor.cs
@@ -1,6 +1,7 @@
 #nullable disable
 using System;
 using System.ComponentModel;
+using System.Runtime.CompilerServices;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Graphics;
 
@@ -139,12 +140,12 @@ namespace Microsoft.Maui.Controls
 				if (TheSame(_previousHeightConstraint, heightConstraint) &&
 					TheSame(_previousWidthConstraint, widthConstraint))
 				{
-					return new Size(Width, Height);
+					return new Size(Width + Margin.HorizontalThickness, Height + Margin.VerticalThickness);
 				}
 				else if (TheSame(_previousHeightConstraint, _previousBounds.Height) &&
 					TheSame(_previousWidthConstraint, _previousBounds.Width))
 				{
-					return new Size(Width, Height);
+					return new Size(Width + Margin.HorizontalThickness, Height + Margin.VerticalThickness);
 				}
 			}
 

--- a/src/Controls/src/Core/Editor/Editor.cs
+++ b/src/Controls/src/Core/Editor/Editor.cs
@@ -89,7 +89,6 @@ namespace Microsoft.Maui.Controls
 		double _previousHeightConstraint;
 		double _previousWidthRequest;
 		double _previousHeightRequest;
-		Thickness _previousMargin;
 
 		Rect _previousBounds;
 
@@ -147,25 +146,26 @@ namespace Microsoft.Maui.Controls
 				Width > 0 &&
 				Height > 0 &&
 				// If the user has changed the Margin/Width/Height then we need to re-measure
-				_previousMargin == Margin &&
 				_previousWidthRequest == WidthRequest &&
 				_previousHeightRequest == HeightRequest)
 			{
 				if (TheSame(_previousHeightConstraint, heightConstraint) &&
 					TheSame(_previousWidthConstraint, widthConstraint))
 				{
-					// If the constraints are the same as the last time we measured, then we can return the last desired size
 					var desiredSize = new Size(Width + Margin.HorizontalThickness, Height + Margin.VerticalThickness);
 					
+					// If these values are different it means we've called measure multiple times with this same measure pass
+					// so we need to return the new desired size until the measure pass is over
 					if (desiredSize == DesiredSize)
 						return desiredSize;
 				}
 				else if (TheSame(_previousHeightConstraint, _previousBounds.Height) &&
 					TheSame(_previousWidthConstraint, _previousBounds.Width))
 				{
-					// If the constraints are the same as the last time we measured, then we can return the last desired size
 					var desiredSize =  new Size(Width + Margin.HorizontalThickness, Height + Margin.VerticalThickness);
 
+					// If these values are different it means we've called measure multiple times with this same measure pass
+					// so we need to return the new desired size until the measure pass is over
 					if (desiredSize == DesiredSize)
 						return desiredSize;
 				}
@@ -173,7 +173,6 @@ namespace Microsoft.Maui.Controls
 
 			_previousWidthRequest = WidthRequest;
 			_previousHeightRequest = HeightRequest;
-			_previousMargin = Margin;
 			_previousWidthConstraint = widthConstraint;
 			_previousHeightConstraint = heightConstraint;
 			

--- a/src/Controls/src/Core/Editor/Editor.cs
+++ b/src/Controls/src/Core/Editor/Editor.cs
@@ -127,12 +127,6 @@ namespace Microsoft.Maui.Controls
 		{
 			(this as IEditorController).SendCompleted();
 		}
-
-		Size IView.Measure(double widthConstraint, double heightConstraint)
-		{
-			DesiredSize = MeasureOverride(widthConstraint, heightConstraint);
-			return DesiredSize;
-		}
 		
 		protected override Size ArrangeOverride(Rect bounds)
 		{

--- a/src/Controls/tests/DeviceTests/Elements/Editor/EditorTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Editor/EditorTests.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Maui.DeviceTests
 				}
 			};
 
-			await CreateHandlerAndAddToWindow<LayoutHandler>(layout, async (_) =>
+			await AttachAndRun<LayoutHandler>(layout, async (_) =>
 			{
 				var frame = editor.Frame;
 
@@ -60,11 +60,119 @@ namespace Microsoft.Maui.DeviceTests
 					Assert.Equal(initialHeight, editor.Height);
 			});
 		}
+		
+		[Fact]
+		public async Task EditorMeasureUpdatesWhenChangingHeight()
+		{
+			SetupBuilder();
+			var control = new Editor();
+			control.HeightRequest = 50;
+			control.WidthRequest = 50;
 
-		static async Task WaitForUIUpdate(Graphics.Rect frame, Editor collectionView, int timeout = 1000, int interval = 100)
+			IView layout = new VerticalStackLayout()
+			{
+				Children =
+				{
+					control
+				}
+			};
+
+			await AttachAndRun<LayoutHandler>(layout, async (_) =>
+			{
+				var frame = control.Frame;
+
+				layout.Arrange(new Graphics.Rect(Graphics.Point.Zero, layout.Measure(100, 100)));
+				await Task.Yield();
+				control.HeightRequest = 60;
+				layout.Arrange(new Graphics.Rect(Graphics.Point.Zero, layout.Measure(100, 100)));
+				await Task.Yield();
+
+				var frame2 = control.Frame;
+				var desiredSize = control.DesiredSize;
+				var height = control.Height;
+				var width = control.Width;
+
+				Assert.Equal(60, frame2.Bottom, 0.5d);
+				Assert.Equal(60, desiredSize.Height, 0.5d);
+			});
+		}
+		
+		[Fact]
+		public async Task EditorMeasureUpdatesWhenChangingWidth()
+		{
+			SetupBuilder();
+			var control = new Editor();
+			control.HeightRequest = 50;
+			control.WidthRequest = 50;
+
+			IView layout = new VerticalStackLayout()
+			{
+				Children =
+				{
+					control
+				}
+			};
+
+			await AttachAndRun<LayoutHandler>(layout, async (_) =>
+			{
+				var frame = control.Frame;
+
+				layout.Arrange(new Graphics.Rect(Graphics.Point.Zero, layout.Measure(100, 100)));
+				await Task.Yield();
+				control.WidthRequest = 60;
+				layout.Arrange(new Graphics.Rect(Graphics.Point.Zero, layout.Measure(100, 100)));
+				await Task.Yield();
+
+				var frame2 = control.Frame;
+				var desiredSize = control.DesiredSize;
+				var height = control.Height;
+				var width = control.Width;
+
+				Assert.Equal(60, frame2.Right, 0.5d);
+				Assert.Equal(60, desiredSize.Width, 0.5d);
+			});
+		}
+
+		[Fact]
+		public async Task EditorMeasureUpdatesWhenChangingMargin()
+		{
+			SetupBuilder();
+			var control = new Editor();
+			control.HeightRequest = 50;
+			control.WidthRequest = 50;
+
+			IView layout = new VerticalStackLayout()
+			{
+				Children =
+				{
+					control
+				}
+			};
+
+			await AttachAndRun<LayoutHandler>(layout, async (_) =>
+			{
+				var frame = control.Frame;
+
+				layout.Arrange(new Graphics.Rect(Graphics.Point.Zero, layout.Measure(100, 100)));
+				await Task.Yield();
+				control.Margin = new Thickness(5,5,5,5);
+				layout.Arrange(new Graphics.Rect(Graphics.Point.Zero, layout.Measure(100, 100)));
+				await Task.Yield();
+
+				var frame2 = control.Frame;
+				var desiredSize = control.DesiredSize;
+				var height = control.Height;
+				var width = control.Width;
+
+				Assert.Equal(55, frame2.Right, 0.5d);
+				Assert.Equal(60, desiredSize.Width, 0.5d);
+			});
+		}
+
+		static async Task WaitForUIUpdate(Graphics.Rect frame, Editor editor, int timeout = 1000, int interval = 100)
 		{
 			// Wait for layout to happen
-			while (collectionView.Frame == frame && timeout >= 0)
+			while (editor.Frame == frame && timeout >= 0)
 			{
 				await Task.Delay(interval);
 				timeout -= interval;

--- a/src/Controls/tests/DeviceTests/Elements/Editor/EditorTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Editor/EditorTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Handlers;
@@ -177,8 +178,12 @@ namespace Microsoft.Maui.DeviceTests
 				(control) =>
 				{
 					control.WidthRequest = Primitives.Dimension.Unset;
+					control.Text = String.Join(",", Enumerable.Range(0, 100).Select(x => "a").ToArray());
 				},
-				(control) => control.MaximumWidthRequest = 10,
+				(control) =>
+				{
+					control.MaximumWidthRequest = 10;
+				},
 				(control) =>
 				{
 					var frame = control.Frame;

--- a/src/Controls/tests/DeviceTests/Elements/View/ViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/View/ViewTests.cs
@@ -30,6 +30,8 @@ namespace Microsoft.Maui.DeviceTests
 			control.Margin = new Thickness(5, 5, 5, 5);
 			control.HeightRequest = 50;
 			control.WidthRequest = 50;
+			control.MinimumHeightRequest = 0;
+			control.MinimumWidthRequest = 0;
 
 			IView layout = new VerticalStackLayout()
 			{

--- a/src/Controls/tests/DeviceTests/Elements/View/ViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/View/ViewTests.cs
@@ -20,5 +20,44 @@ namespace Microsoft.Maui.DeviceTests
 	[Category(TestCategory.View)]
 	public partial class ViewTests : ControlsHandlerTestBase
 	{
+		[Theory]
+		[ClassData(typeof(TestCases.ControlsViewTypesTestCases))]
+		public async Task ViewWithMarginSetsFrameAndDesiredSizeCorrectly(Type controlType)
+		{
+			EnsureHandlerCreated(TestCases.ControlsViewTypesTestCases.Setup);
+
+			var control = Activator.CreateInstance(controlType) as View;
+			control.Margin = new Thickness(5, 5, 5, 5);
+			control.HeightRequest = 50;
+			control.WidthRequest = 50;
+
+			IView layout = new VerticalStackLayout()
+			{
+				Children =
+				{
+					control
+				}
+			};
+
+			await AttachAndRun<LayoutHandler>(layout, async (_) =>
+			{
+				layout.Arrange(new Graphics.Rect(Graphics.Point.Zero, layout.Measure(100, 100)));
+				await Task.Yield();
+				layout.Arrange(new Graphics.Rect(Graphics.Point.Zero, layout.Measure(100, 100)));
+				await Task.Yield();
+
+				var frame = control.Frame;
+				var desiredSize = control.DesiredSize;
+
+				Assert.Equal(5, frame.X, 0.5d);
+				Assert.Equal(5, frame.Y, 0.5d);
+				Assert.Equal(50, frame.Width, 0.5d);
+				Assert.Equal(50, frame.Height, 0.5d);
+				Assert.Equal(55, frame.Right, 0.5d);
+				Assert.Equal(55, frame.Bottom, 0.5d);
+				Assert.Equal(60, desiredSize.Width, 0.5d);
+				Assert.Equal(60, desiredSize.Height, 0.5d);
+			});
+		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/View/ViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/View/ViewTests.cs
@@ -27,14 +27,23 @@ namespace Microsoft.Maui.DeviceTests
 			EnsureHandlerCreated(TestCases.ControlsViewTypesTestCases.Setup);
 
 			var control = Activator.CreateInstance(controlType) as View;
+
+#if MACCATALYST || IOS
+			if (control is SearchBar sb)
+				return;
+#endif
 			control.Margin = new Thickness(5, 5, 5, 5);
 			control.HeightRequest = 50;
 			control.WidthRequest = 50;
 			control.MinimumHeightRequest = 0;
 			control.MinimumWidthRequest = 0;
+			control.HorizontalOptions = LayoutOptions.Start;
+			control.VerticalOptions = LayoutOptions.Start;
 
 			IView layout = new VerticalStackLayout()
 			{
+				HeightRequest = 100,
+				WidthRequest = 100,
 				Children =
 				{
 					control
@@ -43,9 +52,6 @@ namespace Microsoft.Maui.DeviceTests
 
 			await AttachAndRun<LayoutHandler>(layout, async (_) =>
 			{
-				layout.Arrange(new Graphics.Rect(Graphics.Point.Zero, layout.Measure(100, 100)));
-				await Task.Yield();
-				layout.Arrange(new Graphics.Rect(Graphics.Point.Zero, layout.Measure(100, 100)));
 				await Task.Yield();
 
 				var frame = control.Frame;

--- a/src/Controls/tests/DeviceTests/TestCases/ControlsViewTypesTestCases.cs
+++ b/src/Controls/tests/DeviceTests/TestCases/ControlsViewTypesTestCases.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Handlers;
+using Microsoft.Maui.Controls.Handlers.Compatibility;
+using Microsoft.Maui.Controls.Handlers.Items;
+using Microsoft.Maui.Controls.Shapes;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Hosting;
+
+#if IOS || MACCATALYST
+using FlyoutViewHandler = Microsoft.Maui.Controls.Handlers.Compatibility.PhoneFlyoutPageRenderer;
+#endif
+
+namespace Microsoft.Maui.DeviceTests.TestCases
+{
+	public class ControlsViewTypesTestCases : IEnumerable<object[]>
+	{
+		private readonly List<object[]> _data = new()
+		{
+            new object[] { typeof(ActivityIndicator) },
+            new object[] { typeof(Border) },
+            new object[] { typeof(BoxView) },
+            new object[] { typeof(Button) },
+            new object[] { typeof(CarouselView) },
+            new object[] { typeof(CheckBox) },
+            new object[] { typeof(CollectionView) },
+            new object[] { typeof(ContentView) },
+            new object[] { typeof(DatePicker) },
+            new object[] { typeof(Editor) },
+            new object[] { typeof(Ellipse) },
+            new object[] { typeof(Entry) },
+            new object[] { typeof(Frame) },
+            new object[] { typeof(GraphicsView) },
+            new object[] { typeof(Image) },
+            new object[] { typeof(ImageButton) },
+            new object[] { typeof(IndicatorView) },
+            new object[] { typeof(Label) },
+            new object[] { typeof(Line) },
+            new object[] { typeof(ListView) },
+            new object[] { typeof(Picker) },
+            new object[] { typeof(Polygon) },
+            new object[] { typeof(Polyline) },
+            new object[] { typeof(ProgressBar) },
+            new object[] { typeof(RadioButton) },
+            new object[] { typeof(Rectangle) },
+            new object[] { typeof(RefreshView) },
+            new object[] { typeof(RoundRectangle) },
+            new object[] { typeof(ScrollView) },
+            new object[] { typeof(SearchBar) },
+            new object[] { typeof(Slider) },
+            new object[] { typeof(Stepper) },
+            new object[] { typeof(SwipeView) },
+            new object[] { typeof(Switch) },
+            new object[] { typeof(TableView) },
+            new object[] { typeof(TimePicker) },
+            new object[] { typeof(WebView) },
+		};
+
+		public IEnumerator<object[]> GetEnumerator() => _data.GetEnumerator();
+
+		IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+		public static void Setup(MauiAppBuilder builder)
+		{
+			builder.ConfigureMauiHandlers(handlers =>
+			{
+				handlers.AddHandler<ActivityIndicator, ActivityIndicatorHandler>();
+                handlers.AddHandler<Border, BorderHandler>();
+                handlers.AddHandler<BoxView, BoxViewHandler>();
+                handlers.AddHandler<Button, ButtonHandler>();
+                handlers.AddHandler<CarouselView, CarouselViewHandler>();
+                handlers.AddHandler<CollectionView, CollectionViewHandler>();
+                handlers.AddHandler<ContentView, ContentViewHandler>();
+                handlers.AddHandler<CheckBox, CheckBoxHandler>();
+                handlers.AddHandler<DatePicker, DatePickerHandler>();
+                handlers.AddHandler<Entry, EntryHandler>();
+                handlers.AddHandler<Editor, EditorHandler>();
+                handlers.AddHandler<Frame, FrameRenderer>();
+                handlers.AddHandler<GraphicsView, GraphicsViewHandler>();
+                handlers.AddHandler<Label, LabelHandler>();
+                handlers.AddHandler<ListView, ListViewRenderer>();
+                handlers.AddHandler<Picker, PickerHandler>();
+                handlers.AddHandler<Polygon, PolygonHandler>();
+                handlers.AddHandler<Polyline, PolylineHandler>();
+                handlers.AddHandler<Ellipse, ShapeViewHandler>();
+                handlers.AddHandler<Line, LineHandler>();
+                handlers.AddHandler<Path, PathHandler>();
+                handlers.AddHandler<Polygon, PolygonHandler>();
+                handlers.AddHandler<Polyline, PolylineHandler>();
+                handlers.AddHandler<Rectangle, RectangleHandler>();
+                handlers.AddHandler<RoundRectangle, RoundRectangleHandler>();
+                handlers.AddHandler<ProgressBar, ProgressBarHandler>();
+                handlers.AddHandler<SearchBar, SearchBarHandler>();
+                handlers.AddHandler<IContentView, ContentViewHandler>();
+                handlers.AddHandler<Image, ImageHandler>();
+                handlers.AddHandler<ImageButton, ImageButtonHandler>();
+                handlers.AddHandler<IndicatorView, IndicatorViewHandler>();
+                handlers.AddHandler<RefreshView, RefreshViewHandler>();
+                handlers.AddHandler<IScrollView, ScrollViewHandler>();
+                handlers.AddHandler<Slider, SliderHandler>();
+                handlers.AddHandler<Stepper, StepperHandler>();
+                handlers.AddHandler<SwipeView, SwipeViewHandler>();
+                handlers.AddHandler<Switch, SwitchHandler>();
+                handlers.AddHandler<TableView, TableViewRenderer>();
+                handlers.AddHandler<TimePicker, TimePickerHandler>();
+                handlers.AddHandler<WebView, WebViewHandler>();
+			});
+		}
+	}
+}

--- a/src/Core/src/Layouts/LayoutExtensions.cs
+++ b/src/Core/src/Layouts/LayoutExtensions.cs
@@ -24,11 +24,11 @@ namespace Microsoft.Maui.Layouts
 			heightConstraint -= margin.VerticalThickness;
 
 			// Ask the handler to do the actual measuring
-			var measureWithMargins = view.Handler.GetDesiredSize(widthConstraint, heightConstraint);
+			var measureWithoutMargins = view.Handler.GetDesiredSize(widthConstraint, heightConstraint);
 
 			// Account for the margins when reporting the desired size value
-			return new Size(measureWithMargins.Width + margin.HorizontalThickness,
-				measureWithMargins.Height + margin.VerticalThickness);
+			return new Size(measureWithoutMargins.Width + margin.HorizontalThickness,
+				measureWithoutMargins.Height + margin.VerticalThickness);
 		}
 
 		public static Rect ComputeFrame(this IView view, Rect bounds)

--- a/src/TestUtils/src/DeviceTests/AssertionExtensions.iOS.cs
+++ b/src/TestUtils/src/DeviceTests/AssertionExtensions.iOS.cs
@@ -116,9 +116,15 @@ namespace Microsoft.Maui.DeviceTests
 			// so the optimization code causes the attached view to not remeasure when it actually should. 
 			// So we add a UIView in the middle to force our attached view to not optimize itself and actually
 			// remeasure when requested
-			var uiView = new UIView();
-			uiView.AddSubview(view);
-			currentView.AddSubview(uiView);
+			var attachedView = view;
+
+			if (currentView is MauiView)
+			{
+				attachedView = new UIView();
+				attachedView.AddSubview(view);				
+			}
+
+			currentView.AddSubview(attachedView);
 
 			// Give the UI time to refresh
 			await Task.Delay(100);
@@ -132,6 +138,7 @@ namespace Microsoft.Maui.DeviceTests
 			finally
 			{
 				view.RemoveFromSuperview();
+				attachedView.RemoveFromSuperview();
 
 				// Give the UI time to refresh
 				await Task.Delay(100);

--- a/src/TestUtils/src/DeviceTests/AssertionExtensions.iOS.cs
+++ b/src/TestUtils/src/DeviceTests/AssertionExtensions.iOS.cs
@@ -108,7 +108,17 @@ namespace Microsoft.Maui.DeviceTests
 		public static async Task<T> AttachAndRun<T>(this UIView view, Func<Task<T>> action)
 		{
 			var currentView = FindContentView();
-			currentView.AddSubview(view);
+
+			// MauiView has optimization code that won't fire a remeasure of the child view
+			// Check LayoutSubviews inside Mauiveiw.cs for more details. 
+			// If the parent is a MauiView, the expectation is that the parent will call
+			// measure on all the children. But this view that we're "attaching" is unknown to MauiView
+			// so the optimization code causes the attached view to not remeasure when it actually should. 
+			// So we add a UIView in the middle to force our attached view to not optimize itself and actually
+			// remeasure when requested
+			var uiView = new UIView();
+			uiView.AddSubview(view);
+			currentView.AddSubview(uiView);
 
 			// Give the UI time to refresh
 			await Task.Delay(100);

--- a/src/TestUtils/src/DeviceTests/AssertionExtensions.iOS.cs
+++ b/src/TestUtils/src/DeviceTests/AssertionExtensions.iOS.cs
@@ -116,14 +116,19 @@ namespace Microsoft.Maui.DeviceTests
 			// so the optimization code causes the attached view to not remeasure when it actually should. 
 			// So we add a UIView in the middle to force our attached view to not optimize itself and actually
 			// remeasure when requested
-			var attachedView = view;
-
-			if (currentView is MauiView)
+			// This middle view is also helpful so we can make sure the attached view isn't inside the safe area
+			// which can have some unexpected results
+			var safeAreaInsets = currentView.SafeAreaInsets;
+			var attachedView = new UIView()
 			{
-				attachedView = new UIView();
-				attachedView.AddSubview(view);				
-			}
+				Frame = new CGRect(
+					safeAreaInsets.Right,
+					safeAreaInsets.Top,
+					currentView.Frame.Width - safeAreaInsets.Right,
+					currentView.Frame.Height - safeAreaInsets.Top)
+			};
 
+			attachedView.AddSubview(view);	
 			currentView.AddSubview(attachedView);
 
 			// Give the UI time to refresh


### PR DESCRIPTION
### Description of Change

The Editor control short circuits measuring itself if the user has set EditorAutoSizeOption to Disabled. This ensures that the editor always retains the initial height it was measured with as the user types. The code that was short circuiting the measure wasn't including the margins with the returned size which was causing an infinite loop of confusion as the calling code expected the return value to have margins on it. 

### Issues Fixed

Fixes #20126

Need to verify if this fixes
https://github.com/dotnet/maui/issues/17757

