### PR TITLE
NativeAOT: Update NativeAOT integration tests to run with 9.0.1xx-preview1

### DIFF
--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/TemplateTests.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/TemplateTests.cs
@@ -195,6 +195,7 @@ namespace Microsoft.Maui.IntegrationTests
 			var extendedBuildProps = BuildProps;
 			extendedBuildProps.Add("PublishAot=true");
 			extendedBuildProps.Add("PublishAotUsingRuntimePack=true");  // TODO: This parameter will become obsolete https://github.com/dotnet/runtime/issues/87060
+			extendedBuildProps.Add("IlcTreatWarningsAsErrors=false");
 
 			Assert.IsTrue(DotnetInternal.Publish(projectFile, "Release", framework: framework, properties: extendedBuildProps, runtimeIdentifier: runtimeIdentifier),
 				$"Project {Path.GetFileName(projectFile)} failed to build. Check test output/attachments for errors.");
@@ -216,6 +217,7 @@ namespace Microsoft.Maui.IntegrationTests
 			var extendedBuildProps = BuildProps;
 			extendedBuildProps.Add("PublishAot=true");
 			extendedBuildProps.Add("PublishAotUsingRuntimePack=true");  // TODO: This parameter will become obsolete https://github.com/dotnet/runtime/issues/87060
+			extendedBuildProps.Add("IlcTreatWarningsAsErrors=false");
 			extendedBuildProps.Add("TrimmerSingleWarn=false");
 
 			string binLogFilePath = $"publish-{DateTime.UtcNow.ToFileTimeUtc()}.binlog";

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/BuildWarningsUtilities.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/BuildWarningsUtilities.cs
@@ -125,21 +125,6 @@ namespace Microsoft.Maui.IntegrationTests
 		{
 			new WarningsPerFile
 			{
-				File = "ILC",
-				WarningsPerCode = new List<WarningsPerCode>
-				{
-					new WarningsPerCode
-					{
-						Code = "IL3050",
-						Messages = new List<string>
-						{
-							"<Module>..cctor(): Using member 'System.Enum.GetValues(Type)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling. It might not be possible to create an array of the enum type at runtime. Use the GetValues<TEnum> overload or the GetValuesAsUnderlyingType method instead.",
-						}
-					},
-				}
-			},
-			new WarningsPerFile
-			{
 				File = "src/Controls/src/Xaml/XamlParser.cs",
 				WarningsPerCode = new List<WarningsPerCode>
 				{


### PR DESCRIPTION
## Description 

There were two issues around NativeAOT integration tests:

### `TreatWarningsAsErrors=true`

With .NET9-p1 NativeAOT integration tests started failing due to https://github.com/dotnet/runtime/pull/96567
This change enabled ILC (NativeAOT compiler) to take `TreatWarningsAsErrors` into account during compilation.
Since this flag is set to `true` in integration testing, it caused CI failures.

As we are in the process of reducing the number of warnings to 0, until we reach that point we need to run these tests by escaping `TreatWarningsAsErrors=true` setting. This can be achieved by setting `IlcTreatWarningsAsErrors=false`.

### `<Module>..cctor(): Using member 'System.Enum.GetValues(Type)'` warning
- https://github.com/dotnet/maui/commit/90de1998e3dcdd5b5aad949c93b3e2ca1c50b684 properly removed the fixed warning
- however, https://github.com/dotnet/maui/commit/a36ceaebdf9367236731ca30a626707bb41fd379 seemed to add it back, which did not uncover the problem as it was merged against ios workload that did not have the fix in place

---

This PR fixes both of these issues.

/cc: @simonrozsival 