### PR TITLE
Update SecureStorage.android.cs

### DIFF
--- a/src/Essentials/src/SecureStorage/SecureStorage.android.cs
+++ b/src/Essentials/src/SecureStorage/SecureStorage.android.cs
@@ -69,6 +69,7 @@ namespace Microsoft.Maui.Storage
 		{
 			using var editor = PreferencesImplementation.GetSharedPreferences(Alias).Edit();
 			editor?.Clear()?.Apply();
+      		_prefs = null;
 		}
 
 		ISharedPreferences _prefs;

--- a/src/Essentials/test/DeviceTests/Tests/SecureStorage_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/SecureStorage_Tests.cs
@@ -223,5 +223,25 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 				Assert.Null(fetched);
 			});
 		}
+
+		[Theory
+#if MACCATALYST
+    			(Skip = "Need to configure entitlements.")
+#endif
+		]
+		[InlineData("test.txt", "data")]
+		public async Task Set_RemoveAll_Set_Get(string key, string data)
+		{
+			await SecureStorage.SetAsync(key, data);
+
+			// Remove all
+			SecureStorage.RemoveAll();
+
+			//Set again 
+			await SecureStorage.SetAsync(key, data);
+			var c = await SecureStorage.GetAsync(key);
+
+			Assert.Equal(data, c);
+		}
 	}
 }


### PR DESCRIPTION
### Description of Change

On PlatformRemoveAll we reset the _prefs to null. So that the encrypted_prefs_key and encrypted_prefs_value are created again on next value insert so that GetAsync can decrypt said value
Reasons: 

### Issues Fixed
Fixes #19983

Issues with Android SecureStorage.GetAsync returning null
