### PR TITLE
If the current thread dispatcher is null return the app level dispatcher

### DIFF
--- a/src/Compatibility/ControlGallery/src/Issues.Shared/IsInvokeRequiredRaceCondition.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/IsInvokeRequiredRaceCondition.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST
 		[Test]
-		[Microsoft.Maui.Controls.Compatibility.UITests.FailsOnMauiIOS]
+		[Microsoft.Maui.Controls.Compatibility.UITests.MovedToAppium]
 		public void ShouldNotCrash()
 		{
 			RunningApp.Tap(q => q.Marked("crashButton"));

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/TestPages/TestPages.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/TestPages/TestPages.cs
@@ -958,6 +958,9 @@ namespace Microsoft.Maui.Controls.ControlGallery
 				if (serviceType == typeof(IDispatcher))
 					return _dispatcher;
 
+				if (serviceType == typeof(ApplicationDispatcher))
+					return new ApplicationDispatcher(_dispatcher);
+
 				throw new NotImplementedException();
 			}
 

--- a/src/Controls/samples/Controls.Sample.UITests/Issues/IsInvokeRequiredRaceCondition.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/IsInvokeRequiredRaceCondition.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Maui;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Graphics;
+
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.None, 1, "Application.Current.Dispatcher.IsDispatchRequired race condition causes crash")]
+public class IsInvokeRequiredRaceCondition : TestContentPage
+{
+	protected override void Init()
+	{
+		var button = new Button
+		{
+			AutomationId = "crashButton",
+			Text = "Start Test"
+		};
+
+		var success = new Label { Text = "Success", IsVisible = false, AutomationId = "successLabel" };
+
+		var instructions = new Label { Text = "Click the Start Test button. " };
+
+		Content = new StackLayout
+		{
+			HorizontalOptions = LayoutOptions.Fill,
+			VerticalOptions = LayoutOptions.Fill,
+			Children = { instructions, success, button }
+		};
+
+		button.Clicked += async (sender, args) =>
+		{
+			await Task.WhenAll(GenerateTasks());
+			success.IsVisible = true;
+		};
+	}
+
+	List<Task> GenerateTasks()
+	{
+		var result = new List<Task>();
+
+		for (int n = 0; n < 1000; n++)
+		{
+			result.Add(Task.Run(() => { var t = Application.Current.Dispatcher.IsDispatchRequired; }));
+		}
+
+		return result;
+	}
+
+}

--- a/src/Controls/src/Core/DispatcherExtensions.cs
+++ b/src/Controls/src/Core/DispatcherExtensions.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Maui.Controls
 			if (bindableObject is Application app &&
 				app.FindMauiContext() is IMauiContext appMauiContext)
 			{
-				if (appMauiContext.Services.GetService<ApplicationDispatcher>()?.Dispatcher is IDispatcher appDispatcherServiceDispatcher)
+				if (appMauiContext.Services.GetOptionalApplicationDispatcher() is IDispatcher appDispatcherServiceDispatcher)
 					return appDispatcherServiceDispatcher;
 
 				// If BO is of type Application then check for its Dispatcher

--- a/src/Controls/src/Core/DispatcherExtensions.cs
+++ b/src/Controls/src/Core/DispatcherExtensions.cs
@@ -22,11 +22,17 @@ namespace Microsoft.Maui.Controls
 			if (Dispatcher.GetForCurrentThread() is IDispatcher globalDispatcher)
 				return globalDispatcher;
 
-			// If BO is of type Application then check for its Dispatcher
+			// If BO is of type Application then return the Dispatcher from ApplicationDispatcher
 			if (bindableObject is Application app &&
-				app.FindMauiContext() is IMauiContext appMauiContext &&
-				appMauiContext.Services.GetService<IDispatcher>() is IDispatcher appHandlerDispatcher)
-				return appHandlerDispatcher;
+				app.FindMauiContext() is IMauiContext appMauiContext)
+			{
+				if (appMauiContext.Services.GetService<ApplicationDispatcher>()?.Dispatcher is IDispatcher appDispatcherServiceDispatcher)
+					return appDispatcherServiceDispatcher;
+
+				// If BO is of type Application then check for its Dispatcher
+				if (appMauiContext.Services.GetService<IDispatcher>() is IDispatcher appHandlerDispatcher)
+					return appHandlerDispatcher;
+			}
 
 			// try looking on the static app
 			// We don't include Application because Application.Dispatcher will call

--- a/src/Controls/src/Core/DispatcherExtensions.cs
+++ b/src/Controls/src/Core/DispatcherExtensions.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui.Dispatching;
+using Microsoft.Maui.Hosting;
 
 namespace Microsoft.Maui.Controls
 {

--- a/src/Controls/tests/UITests/Tests/Issues/IsInvokeRequiredRaceCondition.cs
+++ b/src/Controls/tests/UITests/Tests/Issues/IsInvokeRequiredRaceCondition.cs
@@ -1,0 +1,22 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.AppiumTests.Issues;
+
+	public class IsInvokeRequiredRaceCondition : _IssuesUITest
+	{
+		public IsInvokeRequiredRaceCondition(TestDevice device) : base(device)
+		{
+		}
+
+		public override string Issue => "Application.Current.Dispatcher.IsDispatchRequired race condition causes crash";
+		
+		[Test]
+		public void ApplicationDispatcherIsInvokeRequiredRaceConditionCausesCrash()
+		{
+			App.WaitForElement("crashButton");
+			App.Click("crashButton");
+			App.WaitForElement("successLabel");
+		}
+	}

--- a/src/Core/src/Hosting/Dispatching/AppHostBuilderExtensions.cs
+++ b/src/Core/src/Hosting/Dispatching/AppHostBuilderExtensions.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Maui.Hosting
 				services.CreateLogger<Dispatcher>()?.LogWarning("Replaced an existing DispatcherProvider with one from the service provider.");
 			}
 
-			return Dispatcher.GetForCurrentThread()!;
+			return Dispatcher.GetForCurrentThread() ?? services.GetRequiredService<ApplicationDispatcher>().Dispatcher;
 		}
 
 		class ApplicationDispatcherInitializer : IMauiInitializeService

--- a/src/Core/src/Hosting/Dispatching/AppHostBuilderExtensions.cs
+++ b/src/Core/src/Hosting/Dispatching/AppHostBuilderExtensions.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Maui.Hosting
 				services.CreateLogger<Dispatcher>()?.LogWarning("Replaced an existing DispatcherProvider with one from the service provider.");
 			}
 
-			return Dispatcher.GetForCurrentThread() ?? services.GetRequiredService<ApplicationDispatcher>().Dispatcher;
+			return Dispatcher.GetForCurrentThread() ?? services.GetOptionalApplicationDispatcher()!;
 		}
 
 		class ApplicationDispatcherInitializer : IMauiInitializeService

--- a/src/Core/src/Hosting/Dispatching/AppHostBuilderExtensions.cs
+++ b/src/Core/src/Hosting/Dispatching/AppHostBuilderExtensions.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Maui.Hosting
 				services.CreateLogger<Dispatcher>()?.LogWarning("Replaced an existing DispatcherProvider with one from the service provider.");
 			}
 
-			return Dispatcher.GetForCurrentThread() ?? services.GetOptionalApplicationDispatcher()!;
+			return Dispatcher.GetForCurrentThread() ?? services.GetRequiredService<ApplicationDispatcher>().Dispatcher;
 		}
 
 		class ApplicationDispatcherInitializer : IMauiInitializeService

--- a/src/Core/src/Properties/AssemblyInfo.cs
+++ b/src/Core/src/Properties/AssemblyInfo.cs
@@ -12,6 +12,7 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("Microsoft.Maui.Controls.Compatibility.ControlGallery.Android")]
 [assembly: InternalsVisibleTo("Microsoft.Maui.Controls.Android.UITests")]
 [assembly: InternalsVisibleTo("Microsoft.Maui.Controls.iOS.UITests")]
+[assembly: InternalsVisibleTo("WinUI.UITests")]
 [assembly: InternalsVisibleTo("Microsoft.Maui.Controls.Compatibility.ControlGallery.Tizen")]
 [assembly: InternalsVisibleTo("Microsoft.Maui.Controls.Xaml")]
 [assembly: InternalsVisibleTo("Microsoft.Maui.Controls.Xaml.UnitTests")]

--- a/src/Core/src/Properties/AssemblyInfo.cs
+++ b/src/Core/src/Properties/AssemblyInfo.cs
@@ -11,6 +11,7 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("Microsoft.Maui.Controls.Compatibility.ControlGallery")]
 [assembly: InternalsVisibleTo("Microsoft.Maui.Controls.Compatibility.ControlGallery.Android")]
 [assembly: InternalsVisibleTo("Microsoft.Maui.Controls.Android.UITests")]
+[assembly: InternalsVisibleTo("Microsoft.Maui.Controls.iOS.UITests")]
 [assembly: InternalsVisibleTo("Microsoft.Maui.Controls.Compatibility.ControlGallery.Tizen")]
 [assembly: InternalsVisibleTo("Microsoft.Maui.Controls.Xaml")]
 [assembly: InternalsVisibleTo("Microsoft.Maui.Controls.Xaml.UnitTests")]

--- a/src/Core/src/Properties/AssemblyInfo.cs
+++ b/src/Core/src/Properties/AssemblyInfo.cs
@@ -10,6 +10,7 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("Microsoft.Maui.Controls.Compatibility.Tizen")]
 [assembly: InternalsVisibleTo("Microsoft.Maui.Controls.Compatibility.ControlGallery")]
 [assembly: InternalsVisibleTo("Microsoft.Maui.Controls.Compatibility.ControlGallery.Android")]
+[assembly: InternalsVisibleTo("Microsoft.Maui.Controls.Android.UITests")]
 [assembly: InternalsVisibleTo("Microsoft.Maui.Controls.Compatibility.ControlGallery.Tizen")]
 [assembly: InternalsVisibleTo("Microsoft.Maui.Controls.Xaml")]
 [assembly: InternalsVisibleTo("Microsoft.Maui.Controls.Xaml.UnitTests")]


### PR DESCRIPTION
### Description of Change

Account for scenarios where the first call to the application level IDispatcher is from a background thread.

- We modify the logic of `FindDispatcher` to fall back to our `ApplicationDispatcher` container. This means if the user calls `Application.Current.Dispatcher` from a background thread they won't fail.
- We also added a coalesce inside the factory call for "IDispatcher". 
  - The main purpose of this is to account for users calling `IPlatformApplication.Current.Services.Get<IDispatcher>()` from a background thread. Because we're no longer initializing that path via initializers we need to account for the case where a user is trying to resolve a scoped service from the static container.
  - If users try to request the window level dispatcher from a background thread, they will still get the correct dispatcher because [now](https://github.com/dotnet/maui/pull/19932) we're initializing that dispatcher whenever a scoped service is created. In the current stable version of NET8 (8.0.6) if a users first request for the dispatcher is from a background thread it'll return null, and they'll be stuck in a bad state. 

