### PR TITLE
Fixed Switch Thumb and On Colors

### DIFF
--- a/src/Controls/src/Core/Switch/Switch.cs
+++ b/src/Controls/src/Core/Switch/Switch.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Maui.Controls
 			((Switch)bindable).Toggled?.Invoke(bindable, new ToggledEventArgs((bool)newValue));
 			((Switch)bindable).ChangeVisualState();
 			((IView)bindable)?.Handler?.UpdateValue(nameof(ISwitch.TrackColor));
-
+			((IView)bindable)?.Handler?.UpdateValue(nameof(ISwitch.ThumbColor));
 		}, defaultBindingMode: BindingMode.TwoWay);
 
 		/// <summary>Bindable property for <see cref="OnColor"/>.</summary>
@@ -32,7 +32,11 @@ namespace Microsoft.Maui.Controls
 			});
 
 		/// <summary>Bindable property for <see cref="ThumbColor"/>.</summary>
-		public static readonly BindableProperty ThumbColorProperty = BindableProperty.Create(nameof(ThumbColor), typeof(Color), typeof(Switch), null);
+		public static readonly BindableProperty ThumbColorProperty = BindableProperty.Create(nameof(ThumbColor), typeof(Color), typeof(Switch), null, 
+			propertyChanged: (bindable, oldValue, newValue) =>
+			{
+				((IView)bindable)?.Handler?.UpdateValue(nameof(ISwitch.ThumbColor));
+			});
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/Switch.xml" path="//Member[@MemberName='OnColor']/Docs/*" />
 		public Color OnColor

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Issue19380.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Issue19380.cs
@@ -1,0 +1,39 @@
+using Microsoft.Maui.Graphics;
+using NUnit.Framework;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests
+{
+	public partial class Issue19380 : ContentPage
+	{
+		public Issue19380()
+		{
+			InitializeComponent();
+		}
+
+		public Issue19380(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		class Tests
+		{
+			[TestCase(true)]
+			[TestCase(false)]
+			public void ShouldOverrideThumbAndOnColorsFromResources(bool useCompiledXaml)
+			{
+				var layout = new Issue19380(useCompiledXaml);
+
+				var switch1 = layout.Switch1;
+
+				Assert.True(switch1.OnColor == Colors.Red);
+				Assert.True(switch1.ThumbColor == Colors.Blue);
+
+				switch1.IsToggled = true;
+
+				Assert.True(switch1.OnColor == Colors.Red);
+				Assert.True(switch1.ThumbColor == Colors.Blue);
+			}
+		}
+	}
+}

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Issue19380.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Issue19380.xaml
@@ -1,0 +1,38 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+			 x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Issue19380">
+
+    <ContentPage.Resources>
+        <Style TargetType="Switch">
+            <Setter Property="VisualStateManager.VisualStateGroups">
+                <VisualStateGroupList>
+                    <VisualStateGroup x:Name="CommonStates">
+                        <VisualState x:Name="Normal" />
+                        <VisualState x:Name="Disabled">
+                            <VisualState.Setters>
+                                <Setter Property="OnColor" Value="Black" />
+                                <Setter Property="ThumbColor" Value="Black" />
+                            </VisualState.Setters>
+                        </VisualState>
+                        <VisualState x:Name="On">
+                            <VisualState.Setters>
+                                <Setter Property="OnColor" Value="Green" />
+                                <Setter Property="ThumbColor" Value="Green" />
+                            </VisualState.Setters>
+                        </VisualState>
+                        <VisualState x:Name="Off">
+                            <VisualState.Setters>
+                                <Setter Property="ThumbColor" Value="White" />
+                            </VisualState.Setters>
+                        </VisualState>
+                    </VisualStateGroup>
+                </VisualStateGroupList>
+            </Setter>
+        </Style>
+    </ContentPage.Resources>
+
+    <StackLayout>
+	    <Switch x:Name="Switch1" OnColor="Red" ThumbColor="Blue"/>
+    </StackLayout>
+</ContentPage>


### PR DESCRIPTION
### Description of Change

The initial respect for the ThumbColor and OnColor properties was
overridden by values set within visual states each time the switcher changed
its state. I recommend verifying whether these values have been overwritten,
and if so, exclusively utilizing the new properties.

### Issues Fixed
Fixes https://github.com/dotnet/maui/issues/19883

Fixes https://github.com/dotnet/maui/issues/19380

|Before|
|---|
|<video src="https://github.com/dotnet/maui/assets/42434498/1bf06f72-6da2-4959-b667-7a9baf40f936"/>
|After|
|<video src="https://github.com/dotnet/maui/assets/42434498/2f55b919-4f66-4301-8cc7-8c7d24c3024e"/>|





