### PR TITLE
[net9.0] update to .NET 9 Preview 2 builds

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,39 +1,39 @@
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.Dotnet.Sdk.Internal" Version="9.0.100-preview.1.24101.2">
+    <Dependency Name="Microsoft.Dotnet.Sdk.Internal" Version="9.0.100-preview.2.24106.6">
       <Uri>https://github.com/dotnet/installer</Uri>
-      <Sha>6bbd460f4db0a37cafeb04a1ed2d798ae56b0283</Sha>
+      <Sha>fb7b9a4b9e578fa8c9f5fb67e22daf4b0d22668e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="9.0.0-preview.1.24080.9">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="9.0.0-preview.2.24080.1" CoherentParentDependency="Microsoft.Dotnet.Sdk.Internal">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>1d1bf92fcf43aa6981804dc53c5174445069c9e4</Sha>
+      <Sha>d40c654c274fe4f4afe66328f0599130f3eb2ea6</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Android.Sdk.Windows" Version="34.99.0-preview.1.148">
+    <Dependency Name="Microsoft.Android.Sdk.Windows" Version="34.99.0-preview.2.154">
       <Uri>https://github.com/xamarin/xamarin-android</Uri>
-      <Sha>d18cbfe1e988220163513d705e37266f7c61e3ce</Sha>
+      <Sha>0c495deebd14604ebb874af3580c34986f72f201</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.MacCatalyst.Sdk" Version="17.2.9085-net9-p1">
+    <Dependency Name="Microsoft.MacCatalyst.Sdk" Version="17.2.9088-net9-p2">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>1ffdfbca2f1995ba6c65d0452fd6a27abaecc622</Sha>
+      <Sha>8abd4fcf33e51deb357e6f3ac12cd085dc81c2bf</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.macOS.Sdk" Version="14.2.9085-net9-p1">
+    <Dependency Name="Microsoft.macOS.Sdk" Version="14.2.9088-net9-p2">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>1ffdfbca2f1995ba6c65d0452fd6a27abaecc622</Sha>
+      <Sha>8abd4fcf33e51deb357e6f3ac12cd085dc81c2bf</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.iOS.Sdk" Version="17.2.9085-net9-p1">
+    <Dependency Name="Microsoft.iOS.Sdk" Version="17.2.9088-net9-p2">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>1ffdfbca2f1995ba6c65d0452fd6a27abaecc622</Sha>
+      <Sha>8abd4fcf33e51deb357e6f3ac12cd085dc81c2bf</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.tvOS.Sdk" Version="17.2.9085-net9-p1">
+    <Dependency Name="Microsoft.tvOS.Sdk" Version="17.2.9088-net9-p2">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>1ffdfbca2f1995ba6c65d0452fd6a27abaecc622</Sha>
+      <Sha>8abd4fcf33e51deb357e6f3ac12cd085dc81c2bf</Sha>
     </Dependency>
     <Dependency Name="Microsoft.WindowsAppSDK" Version="0.0.1">
       <Uri>https://dev.azure.com/microsoft/ProjectReunion/_git/ProjectReunionInternal</Uri>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Workload.Emscripten.Current.Manifest-9.0.100.Transport" Version="9.0.0-preview.1.24072.2" CoherentParentDependency="Microsoft.NETCore.App.Ref">
+    <Dependency Name="Microsoft.NET.Workload.Emscripten.Current.Manifest-9.0.100.Transport" Version="9.0.0-preview.2.24076.1" CoherentParentDependency="Microsoft.NETCore.App.Ref">
       <Uri>https://github.com/dotnet/emsdk</Uri>
-      <Sha>e8ab136db368ccb85c572d2c1541e3056883df3c</Sha>
+      <Sha>687be2a32a302aaade82380c0eaafa5af85fb4da</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.Authorization" Version="9.0.0-preview.1.24081.5">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -3,9 +3,9 @@
     <!-- Current previous .NET SDK major version's stable release of MAUI packages -->
     <MicrosoftMauiPreviousDotNetReleasedVersion>8.0.3</MicrosoftMauiPreviousDotNetReleasedVersion>
     <!-- dotnet/installer -->
-    <MicrosoftDotnetSdkInternalPackageVersion>9.0.100-preview.1.24101.2</MicrosoftDotnetSdkInternalPackageVersion>
+    <MicrosoftDotnetSdkInternalPackageVersion>9.0.100-preview.2.24106.6</MicrosoftDotnetSdkInternalPackageVersion>
     <!-- dotnet/runtime -->
-    <MicrosoftNETCoreAppRefPackageVersion>9.0.0-preview.1.24080.9</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>9.0.0-preview.2.24080.1</MicrosoftNETCoreAppRefPackageVersion>
     <SystemTextJsonPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemTextJsonPackageVersion>
     <SystemTextEncodingsWebPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemTextEncodingsWebPackageVersion>
     <MicrosoftBclAsyncInterfacesPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</MicrosoftBclAsyncInterfacesPackageVersion>
@@ -23,16 +23,16 @@
     <MicrosoftExtensionsLoggingDebugVersion>9.0.0-preview.1.24080.9</MicrosoftExtensionsLoggingDebugVersion>
     <MicrosoftExtensionsPrimitivesVersion>9.0.0-preview.1.24080.9</MicrosoftExtensionsPrimitivesVersion>
     <!-- xamarin/xamarin-android -->
-    <MicrosoftAndroidSdkWindowsPackageVersion>34.99.0-preview.1.148</MicrosoftAndroidSdkWindowsPackageVersion>
+    <MicrosoftAndroidSdkWindowsPackageVersion>34.99.0-preview.2.154</MicrosoftAndroidSdkWindowsPackageVersion>
     <!-- xamarin/xamarin-macios -->
-    <MicrosoftMacCatalystSdkPackageVersion>17.2.9085-net9-p1</MicrosoftMacCatalystSdkPackageVersion>
-    <MicrosoftmacOSSdkPackageVersion>14.2.9085-net9-p1</MicrosoftmacOSSdkPackageVersion>
-    <MicrosoftiOSSdkPackageVersion>17.2.9085-net9-p1</MicrosoftiOSSdkPackageVersion>
-    <MicrosofttvOSSdkPackageVersion>17.2.9085-net9-p1</MicrosofttvOSSdkPackageVersion>
+    <MicrosoftMacCatalystSdkPackageVersion>17.2.9088-net9-p2</MicrosoftMacCatalystSdkPackageVersion>
+    <MicrosoftmacOSSdkPackageVersion>14.2.9088-net9-p2</MicrosoftmacOSSdkPackageVersion>
+    <MicrosoftiOSSdkPackageVersion>17.2.9088-net9-p2</MicrosoftiOSSdkPackageVersion>
+    <MicrosofttvOSSdkPackageVersion>17.2.9088-net9-p2</MicrosofttvOSSdkPackageVersion>
     <!-- Samsung/Tizen.NET -->
     <SamsungTizenSdkPackageVersion>8.0.135</SamsungTizenSdkPackageVersion>
     <!-- emsdk -->
-    <MicrosoftNETWorkloadEmscriptenCurrentManifest90100TransportVersion>9.0.0-preview.1.24072.2</MicrosoftNETWorkloadEmscriptenCurrentManifest90100TransportVersion>
+    <MicrosoftNETWorkloadEmscriptenCurrentManifest90100TransportVersion>9.0.0-preview.2.24076.1</MicrosoftNETWorkloadEmscriptenCurrentManifest90100TransportVersion>
     <MicrosoftNETWorkloadEmscriptenPackageVersion>$(MicrosoftNETWorkloadEmscriptenCurrentManifest90100TransportVersion)</MicrosoftNETWorkloadEmscriptenPackageVersion>
     <!-- wasdk -->
     <MicrosoftWindowsAppSDKPackageVersion>1.3.230724000</MicrosoftWindowsAppSDKPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -30,7 +30,7 @@
     <MicrosoftiOSSdkPackageVersion>17.2.9088-net9-p2</MicrosoftiOSSdkPackageVersion>
     <MicrosofttvOSSdkPackageVersion>17.2.9088-net9-p2</MicrosofttvOSSdkPackageVersion>
     <!-- Samsung/Tizen.NET -->
-    <SamsungTizenSdkPackageVersion>8.0.135</SamsungTizenSdkPackageVersion>
+    <SamsungTizenSdkPackageVersion>8.0.137</SamsungTizenSdkPackageVersion>
     <!-- emsdk -->
     <MicrosoftNETWorkloadEmscriptenCurrentManifest90100TransportVersion>9.0.0-preview.2.24076.1</MicrosoftNETWorkloadEmscriptenCurrentManifest90100TransportVersion>
     <MicrosoftNETWorkloadEmscriptenPackageVersion>$(MicrosoftNETWorkloadEmscriptenCurrentManifest90100TransportVersion)</MicrosoftNETWorkloadEmscriptenPackageVersion>


### PR DESCRIPTION
I ran the following commands.

Update xamarin-android:

    > darc update-dependencies --id 211420
    Looking up build with BAR id 211420
    Updating 'Microsoft.Android.Sdk.Windows': '34.99.0-preview.1.148' => '34.99.0-preview.2.154' (from build 'main-0c495deebd14604ebb874af3580c34986f72f201-1' of 'https://github.com/xamarin/xamarin-android')

Find the latest xamarin-macios builds:

    > darc get-build --repo xamarin/xamarin-macios --commit 8abd4fcf33e51deb357e6f3ac12cd085dc81c2bf

Update xamarin-macios:

    > darc update-dependencies --id 211270
    Looking up build with BAR id 211270
    Updating 'Microsoft.MacCatalyst.Sdk': '17.2.9085-net9-p1' => '17.2.9088-net9-p2' (from build '20240205.8' of 'https://github.com/xamarin/xamarin-macios')
    > darc update-dependencies --id 211269
    Looking up build with BAR id 211269
    Updating 'Microsoft.macOS.Sdk': '14.2.9085-net9-p1' => '14.2.9088-net9-p2' (from build '20240205.8' of 'https://github.com/xamarin/xamarin-macios')
    > darc update-dependencies --id 211268
    Looking up build with BAR id 211268
    Updating 'Microsoft.tvOS.Sdk': '17.2.9085-net9-p1' => '17.2.9088-net9-p2' (from build '20240205.8' of 'https://github.com/xamarin/xamarin-macios')
    > darc update-dependencies --id 211267
    Looking up build with BAR id 211267
    Updating 'Microsoft.iOS.Sdk': '17.2.9085-net9-p1' => '17.2.9088-net9-p2' (from build '20240205.8' of 'https://github.com/xamarin/xamarin-macios')

Next, I noticed that the .NET SDK and runtime weren't updated. I added `CoherentParentDependency` and ran:

    > darc update-dependencies --id 211463
    Looking up build with BAR id 211463
    Updating 'Microsoft.Dotnet.Sdk.Internal': '9.0.100-preview.2.24078.1' => '9.0.100-preview.2.24106.6' (from build '20240206.6' of 'https://github.com/dotnet/installer')
    Checking for coherency updates...
    Using 'Strict' coherency mode. If this fails, a second attempt utilizing 'Legacy' Coherency mode will be made.
    Updating 'Microsoft.NETCore.App.Ref': '9.0.0-preview.2.24076.4' => '9.0.0-preview.2.24080.1' to ensure coherency with Microsoft.Dotnet.Sdk.Internal@9.0.100-preview.2.24106.6
    Updating 'Microsoft.NET.Workload.Emscripten.Current.Manifest-9.0.100.Transport': '9.0.0-alpha.1.24072.1' => '9.0.0-preview.2.24076.1' to ensure coherency with Microsoft.NETCore.App.Ref@9.0.0-preview.2.24076.4