### PR TITLE
[iOS] Remove a nullability error when using 17.2.8104

### DIFF
--- a/src/Core/src/Fonts/EmbeddedFontLoader.iOS.cs
+++ b/src/Core/src/Fonts/EmbeddedFontLoader.iOS.cs
@@ -49,7 +49,8 @@ namespace Microsoft.Maui
 				if (uiFont != null)
 					return name;
 
-				throw new NSErrorException(error);
+				// we know error is not null, the NotNullWhen attr is missing in the iOS bindings, ref: https://github.com/xamarin/xamarin-macios/pull/20050
+				throw new NSErrorException(error!);
 			}
 			catch (Exception ex)
 			{


### PR DESCRIPTION
### Description of Change

Add ! operator to remove an error regarding nullability for iOS 17.2.8104.  Ref in the iOS SDK: https://github.com/xamarin/xamarin-macios/pull/20050

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
