### PR TITLE
[iOS] CharacterEncoding should be used instead of NSStringEncoding.

### DIFF
--- a/src/Core/src/Platform/iOS/LabelExtensions.cs
+++ b/src/Core/src/Platform/iOS/LabelExtensions.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Maui.Platform
 			var attr = new NSAttributedStringDocumentAttributes
 			{
 				DocumentType = NSDocumentType.HTML,
-				StringEncoding = NSStringEncoding.UTF8
+				CharacterEncoding = NSStringEncoding.UTF8
 			};
 
 			NSError nsError = new();


### PR DESCRIPTION
The property will be obsoleted in iOS 17.2.8104. This was caught by a scouting queue in the megapipeline. I am not sure how we want to approach this, I am targeting main but AFAIK the new property CharacterEncoding won't be present there. 