### PR TITLE
Ignore SafeArea on templates and shell flyout item templates

### DIFF
--- a/src/Compatibility/ControlGallery/src/Issues.Shared/HeaderFooterShellFlyout.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/HeaderFooterShellFlyout.cs
@@ -151,7 +151,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 					else
 					{
 						headerLabel.HeightRequest = 60;
-						
+
 						if (footerLabel is not null)
 							footerLabel.HeightRequest = 60;
 					}
@@ -192,10 +192,13 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if __IOS__
 		[Test]
-		public void FlyoutHeaderWithZeroMarginShouldHaveNoY()
+		public async Task FlyoutHeaderWithZeroMarginShouldHaveNoY()
 		{
 			RunningApp.WaitForElement("PageLoaded");
 			this.TapInFlyout("ZeroMarginHeader", makeSureFlyoutStaysOpen: true);
+			// Adding this to just really make sure layout is finished
+			// Once we move this to appium we can remove this
+			await Task.Delay(1000);
 			var layout = RunningApp.WaitForElement("ZeroMarginLayout")[0].Rect.Y;
 			Assert.AreEqual(0, layout);
 		}

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/HeaderFooterShellFlyout.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/HeaderFooterShellFlyout.cs
@@ -137,17 +137,23 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 					var headerLabel = (VisualElement)FlyoutHeader;
 					var footerLabel = (VisualElement)FlyoutFooter;
 					headerLabel.BackgroundColor = Colors.LightBlue;
-					footerLabel.BackgroundColor = Colors.LightBlue;
+
+					if (footerLabel is not null)
+						footerLabel.BackgroundColor = Colors.LightBlue;
 
 					if (headerLabel.HeightRequest == 60)
 					{
 						headerLabel.HeightRequest = 200;
-						footerLabel.HeightRequest = 200;
+
+						if (footerLabel is not null)
+							footerLabel.HeightRequest = 200;
 					}
 					else
 					{
 						headerLabel.HeightRequest = 60;
-						footerLabel.HeightRequest = 60;
+						
+						if (footerLabel is not null)
+							footerLabel.HeightRequest = 60;
 					}
 				}),
 				AutomationId = "ResizeHeaderFooter"
@@ -167,8 +173,10 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 								Margin = 0,
 								Children =
 								{
-								new Label() { Text = "Header View" }
-								}
+									new Label() { Text = "Header View" }
+								},
+								BackgroundColor = Colors.Purple,
+								IgnoreSafeArea = true
 							};
 
 						FlyoutHeaderTemplate = null;

--- a/src/Controls/src/Core/Shell/BaseShellItem.cs
+++ b/src/Controls/src/Core/Shell/BaseShellItem.cs
@@ -343,7 +343,10 @@ namespace Microsoft.Maui.Controls
 		{
 			return new DataTemplate(() =>
 			{
-				var grid = new Grid();
+				var grid = new Grid()
+				{
+					IgnoreSafeArea = true
+				};
 
 				if (DeviceInfo.Platform == DevicePlatform.WinUI)
 					grid.ColumnSpacing = grid.RowSpacing = 0;


### PR DESCRIPTION
### Description of Change

- The layout for this test needs to have IgnoreSafeArea set to true so that it correctly shifts all the way up to the top of the device
- We need to ignore the safe area for the template used on flyout items, so when the flyout item gets shifted up into the danger zone it doesn't offset the layout being used for the FlyoutItem itself

### Issues Fixed

Fixes #20296

