### PR TITLE
[C] ColorTypeConverter include alpha when <1

### DIFF
--- a/src/Graphics/src/Graphics/Converters/ColorTypeConverter.cs
+++ b/src/Graphics/src/Graphics/Converters/ColorTypeConverter.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Maui.Graphics.Converters
 			if (!(value is Color color) || color == null)
 				throw new NotSupportedException();
 
-			return color.ToHex();
+			return color.ToRgbaHex();
 		}
 
 		public override StandardValuesCollection GetStandardValues(ITypeDescriptorContext context)


### PR DESCRIPTION
### Description of Change

[C] ColorTypeConverter include alpha when <1

### Issues Fixed

- fixes #20411

