### PR TITLE
Add support for relative binding sources to TypedBinding

### DIFF
--- a/src/Controls/src/Core/Binding.cs
+++ b/src/Controls/src/Core/Binding.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Reflection;
 
@@ -125,9 +126,9 @@ namespace Microsoft.Maui.Controls
 			if (src != null && isApplied && fromBindingContextChanged)
 				return;
 
-			if (Source is RelativeBindingSource)
+			if (Source is RelativeBindingSource relativeBindingSource)
 			{
-				ApplyRelativeSourceBinding(bindObj, targetProperty, specificity);
+				ApplyRelativeSourceBinding(relativeBindingSource, bindObj, targetProperty, specificity);
 			}
 			else
 			{
@@ -139,148 +140,14 @@ namespace Microsoft.Maui.Controls
 		}
 
 #pragma warning disable RECS0165 // Asynchronous methods should return a Task instead of void
-		async void ApplyRelativeSourceBinding(
-			BindableObject targetObject,
-			BindableProperty targetProperty, SetterSpecificity specificity)
+		async void ApplyRelativeSourceBinding(RelativeBindingSource relativeSource, BindableObject targetObject, BindableProperty targetProperty, SetterSpecificity specificity)
 #pragma warning restore RECS0165 // Asynchronous methods should return a Task instead of void
 		{
-			if (!(Source is RelativeBindingSource relativeSource))
-				return;
-
 			var relativeSourceTarget = RelativeSourceTargetOverride ?? targetObject as Element;
 			if (!(relativeSourceTarget is Element))
 				throw new InvalidOperationException();
 
-			object resolvedSource = null;
-			switch (relativeSource.Mode)
-			{
-				case RelativeBindingSourceMode.Self:
-					resolvedSource = relativeSourceTarget;
-					break;
-
-				case RelativeBindingSourceMode.TemplatedParent:
-					resolvedSource = await TemplateUtilities.FindTemplatedParentAsync(relativeSourceTarget);
-					break;
-
-				case RelativeBindingSourceMode.FindAncestor:
-				case RelativeBindingSourceMode.FindAncestorBindingContext:
-					ApplyAncestorTypeBinding(targetObject, relativeSourceTarget, targetProperty, specificity);
-					return;
-
-				default:
-					throw new InvalidOperationException();
-			}
-
-			_expression.Apply(resolvedSource, targetObject, targetProperty, specificity);
-		}
-
-		void ApplyAncestorTypeBinding(
-			BindableObject actualTarget,
-			Element relativeSourceTarget,
-			BindableProperty targetProperty,
-			SetterSpecificity specificity,
-			Element currentElement = null,
-			int currentLevel = 0,
-			List<Element> chain = null,
-			object lastMatchingBctx = null)
-		{
-			currentElement = currentElement ?? relativeSourceTarget;
-			chain = chain ?? new List<Element> { relativeSourceTarget };
-
-			if (!(Source is RelativeBindingSource relativeSource))
-				return;
-
-			if (currentElement.RealParent is Application ||
-				currentElement.RealParent == null)
-			{
-				// Couldn't find the desired ancestor type in the chain, but it may be added later, 
-				// so apply with a null source for now.
-				_expression.Apply(null, actualTarget, targetProperty, specificity);
-				_expression.SubscribeToAncestryChanges(
-					chain,
-					relativeSource.Mode == RelativeBindingSourceMode.FindAncestorBindingContext,
-					rootIsSource: false);
-			}
-			else if (currentElement.RealParent != null)
-			{
-				chain.Add(currentElement.RealParent);
-				if (ElementFitsAncestorTypeAndLevel(currentElement.RealParent, ref currentLevel, ref lastMatchingBctx))
-				{
-					object resolvedSource;
-					if (relativeSource.Mode == RelativeBindingSourceMode.FindAncestor)
-						resolvedSource = currentElement.RealParent;
-					else
-						resolvedSource = currentElement.RealParent?.BindingContext;
-					_expression.Apply(resolvedSource, actualTarget, targetProperty, specificity);
-					_expression.SubscribeToAncestryChanges(
-						chain,
-						relativeSource.Mode == RelativeBindingSourceMode.FindAncestorBindingContext,
-						rootIsSource: true);
-				}
-				else
-				{
-					ApplyAncestorTypeBinding(
-						actualTarget,
-						relativeSourceTarget,
-						targetProperty,
-						specificity,
-						currentElement.RealParent,
-						currentLevel,
-						chain,
-						lastMatchingBctx);
-				}
-			}
-			else
-			{
-				EventHandler onElementParentSet = null;
-				onElementParentSet = (sender, e) =>
-				{
-					currentElement.ParentSet -= onElementParentSet;
-					ApplyAncestorTypeBinding(
-						actualTarget,
-						relativeSourceTarget,
-						targetProperty,
-						specificity,
-						currentElement,
-						currentLevel,
-						chain,
-						lastMatchingBctx);
-				};
-				currentElement.ParentSet += onElementParentSet;
-			}
-		}
-
-		bool ElementFitsAncestorTypeAndLevel(Element element, ref int level, ref object lastPotentialBctx)
-		{
-			if (!(Source is RelativeBindingSource relativeSource))
-				return false;
-
-			bool fitsElementType =
-				relativeSource.Mode == RelativeBindingSourceMode.FindAncestor &&
-				relativeSource.AncestorType.IsAssignableFrom(element.GetType());
-
-			bool fitsBindingContextType =
-				element.BindingContext != null &&
-				relativeSource.Mode == RelativeBindingSourceMode.FindAncestorBindingContext &&
-				relativeSource.AncestorType.IsAssignableFrom(element.BindingContext.GetType());
-
-			if (!fitsElementType && !fitsBindingContextType)
-				return false;
-
-			if (fitsBindingContextType)
-			{
-				if (!object.ReferenceEquals(lastPotentialBctx, element.BindingContext))
-				{
-					lastPotentialBctx = element.BindingContext;
-					level++;
-				}
-			}
-			else
-			{
-				level++;
-			}
-
-			return level >= relativeSource.AncestorLevel;
+			await relativeSource.Apply(_expression, relativeSourceTarget, targetObject, targetProperty, specificity);
 		}
 
 		internal override BindingBase Clone()

--- a/src/Controls/src/Core/RelativeBindingSource.cs
+++ b/src/Controls/src/Core/RelativeBindingSource.cs
@@ -1,5 +1,8 @@
 #nullable disable
 using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls.Internals;
 
 namespace Microsoft.Maui.Controls
 {
@@ -64,6 +67,167 @@ namespace Microsoft.Maui.Controls
 			{
 				return _templatedParent ?? (_templatedParent = new RelativeBindingSource(RelativeBindingSourceMode.TemplatedParent));
 			}
+		}
+
+#nullable enable
+
+		internal async Task Apply(BindingExpression expression, Element relativeSourceTarget, BindableObject targetObject, BindableProperty targetProperty, SetterSpecificity specificity)
+		{
+			var bindingAdapter = new BindingExpressionAdapter(expression, targetObject, targetProperty, specificity);
+			await Apply(bindingAdapter, relativeSourceTarget);
+		}
+
+		internal async Task Apply(TypedBindingBase binding, Element relativeSourceTarget, BindableObject targetObject, BindableProperty targetProperty, SetterSpecificity specificity)
+		{
+			var bindingAdapter = new TypedBindingAdapter(binding, targetObject, targetProperty, specificity);
+			await Apply(bindingAdapter, relativeSourceTarget);
+		}
+
+		private async Task Apply(IBindingAdapter bindingAdapter, Element relativeSourceTarget)
+		{	
+			object? resolvedSource = null;
+			switch (Mode)
+			{
+				case RelativeBindingSourceMode.Self:
+					resolvedSource = relativeSourceTarget;
+					break;
+
+				case RelativeBindingSourceMode.TemplatedParent:
+					resolvedSource = await TemplateUtilities.FindTemplatedParentAsync(relativeSourceTarget);
+					break;
+
+				case RelativeBindingSourceMode.FindAncestor:
+				case RelativeBindingSourceMode.FindAncestorBindingContext:
+					ApplyAncestorTypeBinding(
+						bindingAdapter,
+						relativeSourceTarget,
+						chain: new List<Element> { relativeSourceTarget },
+						currentLevel: 0);
+					return;
+
+				default:
+					throw new InvalidOperationException();
+			}
+
+			bindingAdapter.Apply(resolvedSource);
+		}
+
+		private void ApplyAncestorTypeBinding(
+			IBindingAdapter bindingAdapter,
+			Element currentElement,
+			int currentLevel,
+			List<Element> chain,
+			object? lastMatchingBctx = null)
+		{
+			if (currentElement.RealParent is Application ||
+				currentElement.RealParent == null)
+			{
+				// Couldn't find the desired ancestor type in the chain, but it may be added later, 
+				// so apply with a null source for now.
+				bindingAdapter.Apply(null);
+				bindingAdapter.SubscribeToAncestryChanges(
+					chain, includeBindingContext: Mode == RelativeBindingSourceMode.FindAncestorBindingContext, rootIsSource: false);
+			}
+			else if (currentElement.RealParent != null)
+			{
+				chain.Add(currentElement.RealParent);
+				if (ElementFitsAncestorTypeAndLevel(currentElement.RealParent, ref currentLevel, ref lastMatchingBctx))
+				{
+					object? resolvedSource;
+					if (Mode == RelativeBindingSourceMode.FindAncestor)
+						resolvedSource = currentElement.RealParent;
+					else
+						resolvedSource = currentElement.RealParent?.BindingContext;
+					bindingAdapter.Apply(resolvedSource);
+					bindingAdapter.SubscribeToAncestryChanges(
+						chain, includeBindingContext: Mode == RelativeBindingSourceMode.FindAncestorBindingContext, rootIsSource: true);
+				}
+				else
+				{
+					ApplyAncestorTypeBinding(bindingAdapter, currentElement.RealParent, currentLevel, chain, lastMatchingBctx);
+				}
+			}
+			else
+			{
+				EventHandler? onElementParentSet = null;
+				onElementParentSet = (sender, e) =>
+				{
+					currentElement.ParentSet -= onElementParentSet;
+					ApplyAncestorTypeBinding(bindingAdapter, currentElement, currentLevel, chain, lastMatchingBctx);
+				};
+				currentElement.ParentSet += onElementParentSet;
+			}
+		}
+
+		private bool ElementFitsAncestorTypeAndLevel(Element element, ref int level, ref object? lastPotentialBctx)
+		{
+			bool fitsElementType =
+				Mode == RelativeBindingSourceMode.FindAncestor &&
+				AncestorType!.IsAssignableFrom(element.GetType());
+
+			bool fitsBindingContextType =
+				element.BindingContext != null &&
+				Mode == RelativeBindingSourceMode.FindAncestorBindingContext &&
+				AncestorType!.IsAssignableFrom(element.BindingContext.GetType());
+
+			if (!fitsElementType && !fitsBindingContextType)
+				return false;
+
+			if (fitsBindingContextType)
+			{
+				if (!object.ReferenceEquals(lastPotentialBctx, element.BindingContext))
+				{
+					lastPotentialBctx = element.BindingContext;
+					level++;
+				}
+			}
+			else
+			{
+				level++;
+			}
+
+			return level >= AncestorLevel;
+		}
+
+		private interface IBindingAdapter
+		{
+			void Apply(object? resolvedSource);
+			void Unapply();
+			void SubscribeToAncestryChanges(List<Element> chain, bool includeBindingContext, bool rootIsSource);
+		}
+
+		private struct BindingExpressionAdapter(
+			BindingExpression expression,
+			BindableObject target,
+			BindableProperty property,
+			SetterSpecificity specificity)
+			: IBindingAdapter
+		{	
+			public void Apply(object? resolvedSource)
+				=> expression.Apply(resolvedSource, target, property, specificity);
+
+			public void Unapply()
+				=> expression.Unapply();
+
+			public void SubscribeToAncestryChanges(List<Element> chain, bool includeBindingContext, bool rootIsSource)
+				=> expression.SubscribeToAncestryChanges(chain, includeBindingContext, rootIsSource);
+		}
+
+		private struct TypedBindingAdapter(
+			TypedBindingBase binding,
+			BindableObject target,
+			BindableProperty property,
+			SetterSpecificity specificity)
+			: IBindingAdapter
+		{
+			public void Apply(object? resolvedSource)
+				=> binding.ApplyToResolvedSource(resolvedSource, target, property, false, specificity);
+
+			public void Unapply()
+				=> binding.Unapply();
+
+			public void SubscribeToAncestryChanges(List<Element> chain, bool includeBindingContext, bool rootIsSource)
+				=> binding.SubscribeToAncestryChanges(chain, includeBindingContext, rootIsSource);
 		}
 	}
 }

--- a/src/Controls/src/Core/TypedBinding.cs
+++ b/src/Controls/src/Core/TypedBinding.cs
@@ -71,6 +71,51 @@ namespace Microsoft.Maui.Controls.Internals
 		internal abstract void SubscribeToAncestryChanges(List<Element> chain, bool includeBindingContext, bool rootIsSource);
 	}
 
+	internal class TypedBinding
+	{
+		/// <summary>
+		/// <para>This factory method was added to simplify creating typed bindings for a property that
+		/// isn't nested which is the most common scenario.</para>
+		/// <para>This factory method must be used carefully. As the name implies, it is only applicable
+		/// when the getter and setter access a property directly on the source object. Whenever the
+		/// property is nested two or more levels deep, create the binding manually and construct the
+		/// handlers array for that usecase.</para>
+		/// </summary>
+		/// <typeparam name="TSource">The type of the source object.</typeparam>
+		/// <typeparam name="TProperty">The type of the property.</typeparam>
+		/// <param name="propertyName">The name of the property.</param>
+		/// <param name="getter">The getter function to retrieve the property value from the source object.</param>
+		/// <param name="setter">The optional setter action to set the property value on the source object.</param>
+		/// <param name="mode">The binding mode.</param>
+		/// <param name="converter">The value converter.</param>
+		/// <param name="converterParameter">The converter parameter.</param>
+		/// <param name="source">The source object.</param>
+		/// <returns>The typed binding.</returns>
+		internal static TypedBinding<TSource, TProperty> ForSingleNestingLevel<TSource, TProperty>(
+			string propertyName,
+			Func<TSource, TProperty> getter,
+			Action<TSource, TProperty> setter = null,
+			BindingMode mode = BindingMode.Default,
+			IValueConverter converter = null,
+			object converterParameter = null,
+			object source = null)
+		{
+			return new TypedBinding<TSource, TProperty>(
+				getter: source => (getter(source), true),
+				setter,
+				handlers: new Tuple<Func<TSource, object>, string>[]
+				{
+					new(static source => source, propertyName),
+				})
+			{
+				Converter = converter,
+				ConverterParameter = converterParameter,
+				Mode = mode,
+				Source = source,
+			};
+		}
+	}
+
 	[EditorBrowsable(EditorBrowsableState.Never)]
 	public sealed class TypedBinding<TSource, TProperty> : TypedBindingBase
 	{

--- a/src/Controls/src/Core/TypedBinding.cs
+++ b/src/Controls/src/Core/TypedBinding.cs
@@ -66,6 +66,9 @@ namespace Microsoft.Maui.Controls.Internals
 		internal TypedBindingBase()
 		{
 		}
+
+		internal abstract void ApplyToResolvedSource(object sourceObject, BindableObject target, BindableProperty property, bool fromTarget, SetterSpecificity specificity);
+		internal abstract void SubscribeToAncestryChanges(List<Element> chain, bool includeBindingContext, bool rootIsSource);
 	}
 
 	[EditorBrowsable(EditorBrowsableState.Never)]
@@ -96,6 +99,8 @@ namespace Microsoft.Maui.Controls.Internals
 		readonly WeakReference<BindableObject> _weakTarget = new WeakReference<BindableObject>(null);
 		SetterSpecificity _specificity;
 		BindableProperty _targetProperty;
+		List<WeakReference<Element>> _ancestryChain;
+		bool _isBindingContextRelativeSource;
 
 		// Applies the binding to a previously set source and target.
 		internal override void Apply(bool fromTarget = false)
@@ -130,19 +135,26 @@ namespace Microsoft.Maui.Controls.Internals
 
 			base.Apply(source, bindObj, targetProperty, fromBindingContextChanged, specificity);
 
-#if (!DO_NOT_CHECK_FOR_BINDING_REUSE)
-			BindableObject prevTarget;
-			if (_weakTarget.TryGetTarget(out prevTarget) && !ReferenceEquals(prevTarget, bindObj))
-				throw new InvalidOperationException("Binding instances cannot be reused");
+			if (Source is RelativeBindingSource relativeSource)
+			{
+				ApplyRelativeSourceBinding(relativeSource, bindObj, targetProperty, specificity);
+			}
+			else
+			{
+				ApplyToResolvedSource(source, bindObj, targetProperty, false, specificity);
+			}
+		}
 
-			object previousSource;
-			if (_weakSource.TryGetTarget(out previousSource) && !ReferenceEquals(previousSource, source))
-				throw new InvalidOperationException("Binding instances cannot be reused");
-#endif
-			_weakSource.SetTarget(source);
-			_weakTarget.SetTarget(bindObj);
+#pragma warning disable RECS0165 // Asynchronous methods should return a Task instead of void
+		async void ApplyRelativeSourceBinding(
+			RelativeBindingSource relativeSource, BindableObject targetObject, BindableProperty targetProperty, SetterSpecificity specificity)
+#pragma warning restore RECS0165 // Asynchronous methods should return a Task instead of void
+		{
+			var relativeSourceTarget = RelativeSourceTargetOverride ?? targetObject as Element;
+			if (!(relativeSourceTarget is Element))
+				throw new InvalidOperationException();
 
-			ApplyCore(source, bindObj, targetProperty, false, specificity);
+			await relativeSource.Apply(this, relativeSourceTarget, targetObject, targetProperty, specificity);
 		}
 
 		internal override BindingBase Clone()
@@ -166,6 +178,23 @@ namespace Microsoft.Maui.Controls.Internals
 				Source = Source,
 				UpdateSourceEventName = UpdateSourceEventName,
 			};
+		}
+
+		internal override void ApplyToResolvedSource(object source, BindableObject target, BindableProperty targetProperty, bool fromBindingContextChanged, SetterSpecificity specificity)
+		{
+#if (!DO_NOT_CHECK_FOR_BINDING_REUSE)
+			BindableObject prevTarget;
+			if (_weakTarget.TryGetTarget(out prevTarget) && !ReferenceEquals(prevTarget, target))
+				throw new InvalidOperationException("Binding instances cannot be reused");
+
+			object previousSource;
+			if (_weakSource.TryGetTarget(out previousSource) && !ReferenceEquals(previousSource, source))
+				throw new InvalidOperationException("Binding instances cannot be reused");
+#endif
+			_weakTarget.SetTarget(target);
+			_weakSource.SetTarget(source);
+
+			ApplyCore(source, target, targetProperty, fromBindingContextChanged, specificity);
 		}
 
 		internal override object GetSourceValue(object value, Type targetPropertyType)
@@ -251,6 +280,121 @@ namespace Microsoft.Maui.Controls.Internals
 					return;
 				}
 				_setter((TSource)sourceObject, (TProperty)value);
+			}
+		}
+
+		// SubscribeToAncestryChanges, ClearAncestryChangeSubscriptions, FindAncestryIndex, and
+		// OnElementParentSet are used with RelativeSource ancestor-type bindings, to detect when
+		// there has been an ancestry change requiring re-applying the binding, and to minimize
+		// re-applications especially during visual tree building.
+		internal override void SubscribeToAncestryChanges(List<Element> chain, bool includeBindingContext, bool rootIsSource)
+		{
+			ClearAncestryChangeSubscriptions();
+			if (chain == null)
+				return;
+			_isBindingContextRelativeSource = includeBindingContext;
+			_ancestryChain = new List<WeakReference<Element>>();
+			for (int i = 0; i < chain.Count; i++)
+			{
+				var elem = chain[i];
+				if (i != chain.Count - 1 || !rootIsSource)
+					// don't care about a successfully resolved source's parents
+					elem.ParentSet += OnElementParentSet;
+				if (_isBindingContextRelativeSource)
+					elem.BindingContextChanged += OnElementBindingContextChanged;
+				_ancestryChain.Add(new WeakReference<Element>(elem));
+			}
+		}
+
+		void ClearAncestryChangeSubscriptions(int beginningWith = 0)
+		{
+			if (_ancestryChain == null || _ancestryChain.Count == 0)
+				return;
+			int count = _ancestryChain.Count;
+			for (int i = beginningWith; i < count; i++)
+			{
+				Element elem;
+				var weakElement = _ancestryChain.Last();
+				if (weakElement.TryGetTarget(out elem))
+				{
+					elem.ParentSet -= OnElementParentSet;
+					if (_isBindingContextRelativeSource)
+						elem.BindingContextChanged -= OnElementBindingContextChanged;
+				}
+				_ancestryChain.RemoveAt(_ancestryChain.Count - 1);
+			}
+		}
+
+		// Returns -1 if the member is not in the chain or the
+		// chain is no longer valid.
+		int FindAncestryIndex(Element elem)
+		{
+			for (int i = 0; i < _ancestryChain.Count; i++)
+			{
+				WeakReference<Element> weak = _ancestryChain[i];
+				Element chainMember = null;
+				if (!weak.TryGetTarget(out chainMember))
+					return -1;
+				else if (object.Equals(elem, chainMember))
+					return i;
+			}
+			return -1;
+		}
+
+		void OnElementBindingContextChanged(object sender, EventArgs e)
+		{
+			if (!(sender is Element elem))
+				return;
+
+			BindableObject target = null;
+			if (_weakTarget?.TryGetTarget(out target) != true)
+				return;
+
+			object currentSource = null;
+			if (_weakSource?.TryGetTarget(out currentSource) == true)
+			{
+				// make sure that this isn't just a repeat notice
+				// from someone else in the chain about our already-resolved 
+				// binding source
+				if (object.ReferenceEquals(currentSource, elem.BindingContext))
+					return;
+			}
+
+			Unapply();
+			Apply(null, target, _targetProperty, false, SetterSpecificity.FromBinding);
+		}
+
+		void OnElementParentSet(object sender, EventArgs e)
+		{
+			if (!(sender is Element elem))
+				return;
+
+			BindableObject target = null;
+			if (_weakTarget?.TryGetTarget(out target) != true)
+				return;
+
+			if (elem.Parent == null)
+			{
+				// Remove anything further up in the chain
+				// than the element with the null parent
+				int index = FindAncestryIndex(elem);
+				if (index == -1)
+				{
+					Unapply();
+					return;
+				}
+				if (index + 1 < _ancestryChain.Count)
+					ClearAncestryChangeSubscriptions(index + 1);
+
+				// Force the binding expression to resolve to null
+				// for now, until someone in the chain gets a new
+				// non-null parent.
+				ApplyCore(null, target, _targetProperty, false, _specificity);
+			}
+			else
+			{
+				Unapply();
+				Apply(null, target, _targetProperty, false, _specificity);
 			}
 		}
 

--- a/src/Controls/tests/Core.UnitTests/MultiBindingTests.cs
+++ b/src/Controls/tests/Core.UnitTests/MultiBindingTests.cs
@@ -119,9 +119,21 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 				{
 					Bindings = new Collection<BindingBase>
 					{
-						TypedBindingFactory.Create(static (Entry entry) => entry.FontFamily, source: RelativeBindingSource.Self),
-						TypedBindingFactory.Create(static (Entry entry) => entry.FontSize, source: RelativeBindingSource.Self),
-						TypedBindingFactory.Create(static (Entry entry) => entry.FontAttributes, source: RelativeBindingSource.Self),
+						TypedBinding.ForSingleNestingLevel(
+							nameof(Entry.FontFamily),
+							static (Entry entry) => entry.FontFamily,
+							static (entry, value) => entry.FontFamily = value,
+							source: RelativeBindingSource.Self),
+						TypedBinding.ForSingleNestingLevel(
+							nameof(Entry.FontSize),
+							static (Entry entry) => entry.FontSize,
+							static (entry, value) => entry.FontSize = value,
+							source: RelativeBindingSource.Self),
+						TypedBinding.ForSingleNestingLevel(
+							nameof(Entry.FontAttributes),
+							static (Entry entry) => entry.FontAttributes,
+							static (entry, value) => entry.FontAttributes = value,
+							source: RelativeBindingSource.Self),
 					},
 					Converter = new StringConcatenationConverter()
 				});
@@ -242,11 +254,23 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 					Bindings = {
 						new MultiBinding {
 							Bindings = {
-								TypedBindingFactory.Create(static ( PersonViewModel vm) => vm.IsOver16),
-								TypedBindingFactory.Create(static ( PersonViewModel vm) => vm.HasPassedTest),
-								TypedBindingFactory.Create(static ( PersonViewModel vm) => vm.IsSuspended, converter: new Inverter()),
-								TypedBindingFactory.Create(
+								TypedBinding.ForSingleNestingLevel(
+									nameof(PersonViewModel.IsOver16),
+									static (PersonViewModel vm) => vm.IsOver16,
+									static (vm, value) => vm.IsOver16 = value),
+								TypedBinding.ForSingleNestingLevel(
+									nameof(PersonViewModel.HasPassedTest),
+									static (PersonViewModel vm) => vm.HasPassedTest,
+									static (vm, value) => vm.HasPassedTest = value),
+								TypedBinding.ForSingleNestingLevel(
+									nameof(PersonViewModel.IsSuspended),
+									static (PersonViewModel vm) => vm.IsSuspended,
+									static (vm, value) => vm.IsSuspended = value,
+									converter: new Inverter()),
+								TypedBinding.ForSingleNestingLevel(
+									nameof(GroupViewModel.SuspendAll),
 									static (GroupViewModel vm) => vm.SuspendAll,
+									static (vm, value) => vm.SuspendAll = value,
 									converter: new Inverter(),
 									source: new RelativeBindingSource(
 										RelativeBindingSourceMode.FindAncestorBindingContext,
@@ -254,10 +278,21 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 							},
 							Converter = new AllTrueMultiConverter()
 						},
-						TypedBindingFactory.Create(static (PersonViewModel vm) => vm.IsMonarch),
-						TypedBindingFactory.Create(
-							static (StackLayout stack) => ((GroupViewModel)stack.BindingContext).PardonAllSuspensions,
-							source: new RelativeBindingSource(RelativeBindingSourceMode.FindAncestor, typeof(StackLayout))),
+						TypedBinding.ForSingleNestingLevel(
+							nameof(PersonViewModel.IsMonarch),
+							static (PersonViewModel vm) => vm.IsMonarch,
+							static (vm, value) => vm.IsMonarch = value),
+						new TypedBinding<StackLayout, bool>(
+							static (StackLayout stack) => (((GroupViewModel)stack.BindingContext).PardonAllSuspensions, true),
+							static (stack, value) => ((GroupViewModel)stack.BindingContext).PardonAllSuspensions = value,
+							handlers: new Tuple<Func<StackLayout, object>, string>[]
+							{
+								new(static (StackLayout stack) => stack, "BindingContext"),
+								new(static (StackLayout stack) => stack.BindingContext, "PardonAllSuspensions"),
+							})
+						{
+							Source = new RelativeBindingSource(RelativeBindingSourceMode.FindAncestor, typeof(StackLayout)),
+						},
 					},
 					Converter = new AnyTrueMultiConverter(),
 					FallbackValue = "false", //use a string literal here to test xaml conversion
@@ -1018,13 +1053,24 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 				var cp = new ContentPresenter();
 				Grid.SetRow(cp, 1);
 				cp.SetBinding(ContentPresenter.ContentProperty,
-					static (ExpanderControl c) => c.Content,
-					source: RelativeBindingSource.TemplatedParent);
+					TypedBinding.ForSingleNestingLevel(
+						nameof(ExpanderControl.Content),
+						static (ExpanderControl c) => c.Content,
+						static (c, v) => c.Content = v,
+						source: RelativeBindingSource.TemplatedParent));
 				cp.SetBinding(ContentPresenter.IsVisibleProperty, new MultiBinding
 				{
 					Bindings = {
-						TypedBindingFactory.Create(static (ExpanderControl c) => c.IsEnabled, source: RelativeBindingSource.TemplatedParent),
-						TypedBindingFactory.Create(static (ExpanderControl c) => c.IsExpanded, source: RelativeBindingSource.TemplatedParent),
+						TypedBinding.ForSingleNestingLevel(
+							nameof(ExpanderControl.IsEnabled),
+							static (ExpanderControl c) => c.IsEnabled,
+							static (c, v) => c.IsEnabled = v,
+							source: RelativeBindingSource.TemplatedParent),
+						TypedBinding.ForSingleNestingLevel(
+							nameof(ExpanderControl.IsExpanded),
+							static (ExpanderControl c) => c.IsExpanded,
+							static (c, v) => c.IsExpanded = v,
+							source: RelativeBindingSource.TemplatedParent),
 					},
 					Converter = new AllTrueMultiConverter(),
 					FallbackValue = false

--- a/src/Controls/tests/Core.UnitTests/MultiBindingTests.cs
+++ b/src/Controls/tests/Core.UnitTests/MultiBindingTests.cs
@@ -8,12 +8,12 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Internals;
 using Xunit;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests
 {
 	using Grid = Microsoft.Maui.Controls.Compatibility.Grid;
-
 
 	public class MultiBindingTests : BaseTestFixture
 	{
@@ -105,6 +105,55 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact]
+		public void TestRelativeSources_TypedBinding()
+		{
+			// Self
+			var entry1 = new Entry()
+			{
+				FontFamily = "Courier New",
+				FontSize = 12,
+				FontAttributes = FontAttributes.Italic
+			};
+			entry1.SetBinding(Entry.TextProperty,
+				new MultiBinding
+				{
+					Bindings = new Collection<BindingBase>
+					{
+						TypedBindingFactory.Create(static (Entry entry) => entry.FontFamily, source: RelativeBindingSource.Self),
+						TypedBindingFactory.Create(static (Entry entry) => entry.FontSize, source: RelativeBindingSource.Self),
+						TypedBindingFactory.Create(static (Entry entry) => entry.FontAttributes, source: RelativeBindingSource.Self),
+					},
+					Converter = new StringConcatenationConverter()
+				});
+			Assert.Equal("Courier New 12 Italic", entry1.Text);
+			// Our unit test's ConvertBack should throw an exception below because the desired
+			// return types aren't all strings
+			Assert.Throws<Exception>(() => entry1.SetValueCore(Entry.TextProperty, "Arial 12 Italic", Internals.SetValueFlags.None, BindableObject.SetValuePrivateFlags.None, SetterSpecificity.ManualValueSetter));
+
+			// FindAncestor and FindAncestorBindingContext
+			// are already tested in TestNestedMultiBindings
+			TestNestedMultiBindings();
+
+			// TemplatedParent
+			var templ = new ControlTemplate(typeof(ExpanderControlTemplate_TypedBinding));
+			var expander = new ExpanderControl
+			{
+				ControlTemplate = templ,
+				Content = new Label { Text = "Content" },
+				IsEnabled = true,
+				IsExpanded = true
+			};
+			var cp = expander.Children[0].LogicalChildrenInternal[1] as ContentPresenter;
+			Assert.True(cp.IsVisible);
+			expander.IsEnabled = false;
+			Assert.False(cp.IsVisible);
+			expander.IsEnabled = true;
+			Assert.True(cp.IsVisible);
+			expander.IsExpanded = false;
+			Assert.False(cp.IsVisible);
+		}
+
+		[Fact]
 		public void TestNestedMultiBindings()
 		{
 			var group = new GroupViewModel();
@@ -136,6 +185,78 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 						new Binding(nameof(PersonViewModel.IsMonarch)),
 						new Binding(
 							$"{nameof(Element.BindingContext)}.{nameof(GroupViewModel.PardonAllSuspensions)}",
+							source: new RelativeBindingSource(RelativeBindingSourceMode.FindAncestor, typeof(StackLayout))),
+					},
+					Converter = new AnyTrueMultiConverter(),
+					FallbackValue = "false", //use a string literal here to test xaml conversion
+				});
+
+			// ^^
+			// CanDrive = (IsOver16 && HasPassedTest && !IsSuspended && !Group.SuspendAll) || IsMonarch || Group.PardonAllSuspensions
+
+			checkBox.BindingContext = group.Person5;
+			stack.Children.Add(checkBox);
+
+			// Monarch can do whatever she wants
+			Assert.True(checkBox.IsChecked);
+
+			// ... Until being deposed after a coup
+			group.Person5.IsMonarch = false;
+			Assert.False(checkBox.IsChecked);
+
+			// After passing test she can drive again
+			group.Person5.HasPassedTest = true;
+			Assert.True(checkBox.IsChecked);
+
+			// Martial law declared; no one can drive
+			group.SuspendAll = true;
+			Assert.False(checkBox.IsChecked);
+
+			// Martial law is over
+			group.SuspendAll = false;
+			Assert.True(checkBox.IsChecked);
+
+			// But she got in an accident and now can't drive again
+			group.Person5.IsSuspended = true;
+			Assert.False(checkBox.IsChecked);
+
+			// The new PM has pardoned everyone after the end of the rebellion
+			group.PardonAllSuspensions = true;
+			Assert.True(checkBox.IsChecked);
+		}
+
+		[Fact]
+		public void TestNestedMultiBindings_TypedBinding()
+		{
+			var group = new GroupViewModel();
+			var stack = new StackLayout
+			{
+				BindingContext = group
+			};
+
+			var checkBox = new CheckBox();
+			checkBox.SetBinding(
+				CheckBox.IsCheckedProperty,
+				new MultiBinding
+				{
+					Bindings = {
+						new MultiBinding {
+							Bindings = {
+								TypedBindingFactory.Create(static ( PersonViewModel vm) => vm.IsOver16),
+								TypedBindingFactory.Create(static ( PersonViewModel vm) => vm.HasPassedTest),
+								TypedBindingFactory.Create(static ( PersonViewModel vm) => vm.IsSuspended, converter: new Inverter()),
+								TypedBindingFactory.Create(
+									static (GroupViewModel vm) => vm.SuspendAll,
+									converter: new Inverter(),
+									source: new RelativeBindingSource(
+										RelativeBindingSourceMode.FindAncestorBindingContext,
+										ancestorType: typeof(GroupViewModel))),
+							},
+							Converter = new AllTrueMultiConverter()
+						},
+						TypedBindingFactory.Create(static (PersonViewModel vm) => vm.IsMonarch),
+						TypedBindingFactory.Create(
+							static (StackLayout stack) => ((GroupViewModel)stack.BindingContext).PardonAllSuspensions,
 							source: new RelativeBindingSource(RelativeBindingSourceMode.FindAncestor, typeof(StackLayout))),
 					},
 					Converter = new AnyTrueMultiConverter(),
@@ -872,6 +993,38 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 					Bindings = {
 						new Binding(nameof(ExpanderControl.IsEnabled), source: RelativeBindingSource.TemplatedParent),
 						new Binding(nameof(ExpanderControl.IsExpanded), source: RelativeBindingSource.TemplatedParent)
+					},
+					Converter = new AllTrueMultiConverter(),
+					FallbackValue = false
+				});
+				this.Children.Add(cp);
+			}
+		}
+
+		public class ExpanderControlTemplate_TypedBinding : Grid
+		{
+			public ExpanderControlTemplate_TypedBinding()
+			{
+				this.RowDefinitions = new RowDefinitionCollection
+				{
+					new RowDefinition { Height = new GridLength(0, GridUnitType.Auto)},
+					new RowDefinition { Height = new GridLength(1, GridUnitType.Star)}
+				};
+
+				var expander = new Button { Text = "^" };
+				Grid.SetRow(expander, 0);
+				this.Children.Add(expander);
+
+				var cp = new ContentPresenter();
+				Grid.SetRow(cp, 1);
+				cp.SetBinding(ContentPresenter.ContentProperty,
+					static (ExpanderControl c) => c.Content,
+					source: RelativeBindingSource.TemplatedParent);
+				cp.SetBinding(ContentPresenter.IsVisibleProperty, new MultiBinding
+				{
+					Bindings = {
+						TypedBindingFactory.Create(static (ExpanderControl c) => c.IsEnabled, source: RelativeBindingSource.TemplatedParent),
+						TypedBindingFactory.Create(static (ExpanderControl c) => c.IsExpanded, source: RelativeBindingSource.TemplatedParent),
 					},
 					Converter = new AllTrueMultiConverter(),
 					FallbackValue = false

--- a/src/Controls/tests/Core.UnitTests/RelativeSourceBindingTests.cs
+++ b/src/Controls/tests/Core.UnitTests/RelativeSourceBindingTests.cs
@@ -32,7 +32,13 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			{
 				StyleId = "label1"
 			};
-			label.SetBinding(Label.TextProperty, static (Label label) => label.StyleId, source: RelativeBindingSource.Self);
+			label.SetBinding(
+				Label.TextProperty,
+				TypedBinding.ForSingleNestingLevel(
+					nameof(StackLayout.StyleId),
+					static (Label label) => label.StyleId,
+					static (label, value) => label.StyleId = value,
+					source: RelativeBindingSource.Self));
 			Assert.Equal(label.Text, label.StyleId);
 
 			label.StyleId = "label2";
@@ -66,7 +72,13 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			var label = new Label();
 			stack.Children.Add(label);
 
-			label.SetBinding(Label.TextProperty, static (StackLayout stack) => stack.StyleId, source: new RelativeBindingSource(RelativeBindingSourceMode.FindAncestor, typeof(StackLayout), 1));
+			label.SetBinding(
+				Label.TextProperty,
+				TypedBinding.ForSingleNestingLevel(
+					nameof(StackLayout.StyleId),
+					static (StackLayout stack) => stack.StyleId,
+					static (stack, value) => stack.StyleId = value,
+					source: new RelativeBindingSource(RelativeBindingSourceMode.FindAncestor, typeof(StackLayout), 1)));
 			Assert.Equal("stack1", label.Text);
 
 			stack.StyleId = "stack2";
@@ -102,7 +114,13 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			var template = new ControlTemplate(() =>
 			{
 				label = new Label();
-				label.SetBinding(Label.TextProperty, static (Frame frame) => frame.StyleId, source: RelativeBindingSource.TemplatedParent);
+				label.SetBinding(
+					Label.TextProperty,
+					TypedBinding.ForSingleNestingLevel(
+						nameof(StackLayout.StyleId),
+						static (Frame frame) => frame.StyleId,
+						static (frame, value) => frame.StyleId = value,
+						source: RelativeBindingSource.TemplatedParent));
 				return label;
 			});
 
@@ -392,18 +410,48 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			stack1.Children.Add(stack0);
 			stack0.Children.Add(grid);
 
-			label0.SetBinding(Label.TextProperty, static (PersonViewModel vm) => vm.Name, source: new RelativeBindingSource(RelativeBindingSourceMode.FindAncestorBindingContext, typeof(PersonViewModel), 1));
-			label0.SetBinding(Label.TextColorProperty, static (StackLayout stack) => stack.BackgroundColor, source: new RelativeBindingSource(RelativeBindingSourceMode.FindAncestor, typeof(StackLayout), 1));
+			label0.SetBinding(Label.TextProperty,
+				TypedBinding.ForSingleNestingLevel(
+					nameof(PersonViewModel.Name),
+					static (PersonViewModel vm) => vm.Name,
+					static (vm, value) => vm.Name = value,
+					source: new RelativeBindingSource(RelativeBindingSourceMode.FindAncestorBindingContext, typeof(PersonViewModel), 1)));
+			label0.SetBinding(Label.TextColorProperty,
+				TypedBinding.ForSingleNestingLevel(
+					nameof(StackLayout.BackgroundColor),
+					static (StackLayout stack) => stack.BackgroundColor,
+					static (stack, value) => stack.BackgroundColor = value,
+					source: new RelativeBindingSource(RelativeBindingSourceMode.FindAncestor, typeof(StackLayout), 1)));
 			Assert.Null(label0.Text);
 			Assert.Equal(Label.TextColorProperty.DefaultValue, label0.TextColor);
 
-			label1.SetBinding(Label.TextProperty, static (PersonViewModel vm) => vm.Name, source: new RelativeBindingSource(RelativeBindingSourceMode.FindAncestorBindingContext, typeof(PersonViewModel), 2));
-			label1.SetBinding(Label.TextColorProperty, static (StackLayout stack) => stack.BackgroundColor, source: new RelativeBindingSource(RelativeBindingSourceMode.FindAncestor, typeof(StackLayout), 2));
+			label1.SetBinding(Label.TextProperty,
+				TypedBinding.ForSingleNestingLevel(
+					nameof(PersonViewModel.Name),
+					static (PersonViewModel vm) => vm.Name,
+					static (vm, value) => vm.Name = value,
+					source: new RelativeBindingSource(RelativeBindingSourceMode.FindAncestorBindingContext, typeof(PersonViewModel), 2)));
+			label1.SetBinding(Label.TextColorProperty,
+				TypedBinding.ForSingleNestingLevel(
+					nameof(StackLayout.BackgroundColor),
+					static (StackLayout stack) => stack.BackgroundColor,
+					static (stack, value) => stack.BackgroundColor = value,
+					source: new RelativeBindingSource(RelativeBindingSourceMode.FindAncestor, typeof(StackLayout), 2)));
 			Assert.Null(label1.Text);
 			Assert.Equal(Label.TextColorProperty.DefaultValue, label1.TextColor);
 
-			label2.SetBinding(Label.TextProperty, static (PersonViewModel vm) => vm.Name, source: new RelativeBindingSource(RelativeBindingSourceMode.FindAncestorBindingContext, typeof(PersonViewModel), 3));
-			label2.SetBinding(Label.TextColorProperty, static (StackLayout vm) => vm.BackgroundColor, source: new RelativeBindingSource(RelativeBindingSourceMode.FindAncestor, typeof(StackLayout), 3));
+			label2.SetBinding(Label.TextProperty,
+				TypedBinding.ForSingleNestingLevel(
+					nameof(PersonViewModel.Name),
+					static (PersonViewModel vm) => vm.Name,
+					static (vm, value) => vm.Name = value,
+					source: new RelativeBindingSource(RelativeBindingSourceMode.FindAncestorBindingContext, typeof(PersonViewModel), 3)));
+			label2.SetBinding(Label.TextColorProperty,
+				TypedBinding.ForSingleNestingLevel(
+					nameof(StackLayout.BackgroundColor),
+					static (StackLayout vm) => vm.BackgroundColor,
+					static (vm, value) => vm.BackgroundColor = value,
+					source: new RelativeBindingSource(RelativeBindingSourceMode.FindAncestor, typeof(StackLayout), 3)));
 			Assert.Null(label2.Text);
 			Assert.Equal(Label.TextColorProperty.DefaultValue, label2.TextColor);
 

--- a/src/Controls/tests/Core.UnitTests/RelativeSourceBindingTests.cs
+++ b/src/Controls/tests/Core.UnitTests/RelativeSourceBindingTests.cs
@@ -3,12 +3,12 @@ using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Graphics;
 using Xunit;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests
 {
-
 	public class RelativeSourceBindingTests : BaseTestFixture
 	{
 		[Fact]
@@ -23,6 +23,98 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 				Source = RelativeBindingSource.Self
 			});
 			Assert.Equal(label.Text, label.StyleId);
+		}
+
+		[Fact]
+		public void RelativeSourceSelfBinding_TypedBinding()
+		{
+			Label label = new Label
+			{
+				StyleId = "label1"
+			};
+			label.SetBinding(Label.TextProperty, static (Label label) => label.StyleId, source: RelativeBindingSource.Self);
+			Assert.Equal(label.Text, label.StyleId);
+
+			label.StyleId = "label2";
+			Assert.Equal("label2", label.Text);
+		}
+
+		[Fact]
+		public void RelativeSourceBinding_FindAncestor()
+		{
+			var stack = new StackLayout
+			{
+				StyleId = "stack1"
+			};
+			var label = new Label();
+			stack.Children.Add(label);
+
+			label.SetBinding(Label.TextProperty, new Binding("StyleId", source: new RelativeBindingSource(RelativeBindingSourceMode.FindAncestor, typeof(StackLayout), 1)));
+			Assert.Equal("stack1", label.Text);
+
+			stack.StyleId = "stack2";
+			Assert.Equal("stack2", label.Text);
+		}
+
+		[Fact]
+		public void RelativeSourceBinding_FindAncestor_TypedBinding()
+		{
+			var stack = new StackLayout
+			{
+				StyleId = "stack1"
+			};
+			var label = new Label();
+			stack.Children.Add(label);
+
+			label.SetBinding(Label.TextProperty, static (StackLayout stack) => stack.StyleId, source: new RelativeBindingSource(RelativeBindingSourceMode.FindAncestor, typeof(StackLayout), 1));
+			Assert.Equal("stack1", label.Text);
+
+			stack.StyleId = "stack2";
+			Assert.Equal("stack2", label.Text);
+		}
+
+		[Fact]
+		public void RelativeSourceBinding_TemplatedParent()
+		{
+			Label label = null;
+			var template = new ControlTemplate(() =>
+			{
+				label = new Label();
+				label.SetBinding(Label.TextProperty, new Binding("StyleId", source: RelativeBindingSource.TemplatedParent));
+				return label;
+			});
+
+			var frame = new Frame
+			{
+				StyleId = "frame1",
+				ControlTemplate = template
+			};
+			Assert.Equal("frame1", label?.Text);
+
+			frame.StyleId = "frame2";
+			Assert.Equal("frame2", label?.Text);
+		}
+
+		[Fact]
+		public void RelativeSourceBinding_TemplatedParent_TypedBinding()
+		{
+			Label label = null;
+			var template = new ControlTemplate(() =>
+			{
+				label = new Label();
+				label.SetBinding(Label.TextProperty, static (Frame frame) => frame.StyleId, source: RelativeBindingSource.TemplatedParent);
+				return label;
+			});
+
+			var frame = new Frame
+			{
+				StyleId = "frame1",
+				ControlTemplate = template
+			};
+			Assert.Equal("frame1", label?.Text);
+
+			frame.StyleId = "frame2";
+			Assert.Equal("frame2", label?.Text);
 		}
 
 		[Fact]
@@ -100,6 +192,218 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 				Path = nameof(StackLayout.BackgroundColor),
 				Source = new RelativeBindingSource(RelativeBindingSourceMode.FindAncestor, typeof(StackLayout), 3)
 			});
+			Assert.Null(label2.Text);
+			Assert.Equal(Label.TextColorProperty.DefaultValue, label2.TextColor);
+
+			grid.Children.Add(label0);
+			grid.Children.Add(label1);
+			grid.Children.Add(label2);
+
+			//// BindingContext changes
+
+			// stack2
+			//		stack1
+			//			stack0
+			//				grid
+			//					label0 (min level 1)	= stack0/null
+			//					label1 (min level 2)	= stack1/null
+			//					label2 (min level 3)	= stack2/null
+			Assert.Equal(label0.TextColor, stack0.BackgroundColor);
+			Assert.Equal(label1.TextColor, stack1.BackgroundColor);
+			Assert.Equal(label2.TextColor, stack2.BackgroundColor);
+			Assert.Null(label0.Text);
+			Assert.Null(label1.Text);
+			Assert.Null(label2.Text);
+
+			// stack2	(person2)
+			//		stack1 (person2*)
+			//			stack0 (person2*)
+			//				grid (person2*)
+			//					label0 (min level 1)	= stack0/person2
+			//					label1 (min level 2)	= stack1/null
+			//					label2 (min level 3)	= stack2/null
+			stack2.BindingContext = person2;
+			Assert.Equal(label0.TextColor, stack0.BackgroundColor);
+			Assert.Equal(label1.TextColor, stack1.BackgroundColor);
+			Assert.Equal(label2.TextColor, stack2.BackgroundColor);
+			Assert.Equal(label0.Text, person2.Name);
+			Assert.Null(label1.Text);
+			Assert.Null(label2.Text);
+
+			// stack2	(person2)
+			//		stack1 (person1)
+			//			stack0 (person1*)
+			//				grid (person1*)
+			//					label0 (min level 1)	= stack0/person1
+			//					label1 (min level 2)	= stack1/person2
+			//					label2 (min level 3)	= stack2/null
+			stack1.BindingContext = person1;
+			Assert.Equal(label0.TextColor, stack0.BackgroundColor);
+			Assert.Equal(label1.TextColor, stack1.BackgroundColor);
+			Assert.Equal(label2.TextColor, stack2.BackgroundColor);
+			Assert.Equal(label0.Text, person1.Name);
+			Assert.Equal(label1.Text, person2.Name);
+			Assert.Equal(Label.TextProperty.DefaultValue, label2.Text);
+
+			// stack2	(person2)
+			//		stack1 (person1)
+			//			stack0 (person0)
+			//				grid (person0*)
+			//					label0 (min level 1)	= stack0/person0
+			//					label1 (min level 2)	= stack1/person1
+			//					label2 (min level 3)	= stack2/person2
+			stack0.BindingContext = person0;
+			Assert.Equal(label0.TextColor, stack0.BackgroundColor);
+			Assert.Equal(label1.TextColor, stack1.BackgroundColor);
+			Assert.Equal(label2.TextColor, stack2.BackgroundColor);
+			Assert.Equal(label0.Text, person0.Name);
+			Assert.Equal(label1.Text, person1.Name);
+			Assert.Equal(label2.Text, person2.Name);
+
+			// stack2	
+			//		stack1 (person1)
+			//			stack0 (person0)
+			//				grid (person0*)
+			//					label0 (min level 1)	= stack0/person0
+			//					label1 (min level 2)	= stack1/person1
+			//					label2 (min level 3)	= stack2/null
+			stack2.BindingContext = null;
+			Assert.Equal(label0.TextColor, stack0.BackgroundColor);
+			Assert.Equal(label1.TextColor, stack1.BackgroundColor);
+			Assert.Equal(label2.TextColor, stack2.BackgroundColor);
+			Assert.Equal(label0.Text, person0.Name);
+			Assert.Equal(label1.Text, person1.Name);
+			Assert.Null(label2.Text);
+
+			// stack2
+			//		stack1
+			//			stack0 (person0)
+			//				grid (person0*)
+			//					label0 (min level 1)	= stack0/person0
+			//					label1 (min level 2)	= stack1/null
+			//					label2 (min level 3)	= stack2/null
+			stack1.BindingContext = null;
+			Assert.Equal(label0.TextColor, stack0.BackgroundColor);
+			Assert.Equal(label1.TextColor, stack1.BackgroundColor);
+			Assert.Equal(label2.TextColor, stack2.BackgroundColor);
+			Assert.Equal(label0.Text, person0.Name);
+			Assert.Null(label1.Text);
+			Assert.Null(label2.Text);
+
+			// stack2
+			//		stack1
+			//			stack0
+			//					label0 (min level 1)	= stack0/null
+			//					label1 (min level 2)	= stack1/null
+			//					label2 (min level 3)	= stack2/null
+			stack0.BindingContext = null;
+			Assert.Equal(label0.TextColor, stack0.BackgroundColor);
+			Assert.Equal(label1.TextColor, stack1.BackgroundColor);
+			Assert.Equal(label2.TextColor, stack2.BackgroundColor);
+			Assert.Null(label0.Text);
+			Assert.Null(label1.Text);
+			Assert.Null(label2.Text);
+
+			stack0.BindingContext = person0;
+			stack1.BindingContext = person1;
+			stack2.BindingContext = person2;
+
+			//// Parent Changes
+
+			// stack2 (person2) 
+			// stack1 (person1)
+			//		stack0 (person0)
+			//				label0 (min level 1)	= stack0/person0
+			//				label1 (min level 2)	= stack1/person1
+			//				label2 (min level 3)	= null/null
+			stack2.Children.Clear();
+			Assert.Equal(label0.TextColor, stack0.BackgroundColor);
+			Assert.Equal(label1.TextColor, stack1.BackgroundColor);
+			Assert.Equal(label2.TextColor, StackLayout.BackgroundColorProperty.DefaultValue);
+			Assert.Equal(label0.Text, person0.Name);
+			Assert.Equal(label1.Text, person1.Name);
+			Assert.Null(label2.Text);
+
+			// stack2 (person2) 
+			// stack1 (person1) 
+			// stack0 (person0)
+			//			label0 (min level 1)	= stack0/person0
+			//			label1 (min level 2)	= null/null
+			//			label2 (min level 3)	= null/null
+			stack1.Children.Clear();
+			Assert.Equal(label0.TextColor, stack0.BackgroundColor);
+			Assert.Equal(label1.TextColor, StackLayout.BackgroundColorProperty.DefaultValue);
+			Assert.Equal(label2.TextColor, StackLayout.BackgroundColorProperty.DefaultValue);
+			Assert.Equal(label0.Text, person0.Name);
+			Assert.Null(label1.Text);
+			Assert.Null(label2.Text);
+
+			// stack2 (person2) 
+			// stack1 (person1) 
+			// stack0 (person0)
+			// grid
+			//		label0 (min level 1)	= null/null
+			//		label1 (min level 2)	= null/null
+			//		label2 (min level 3)	= null/null
+			stack0.Children.Clear();
+			Assert.Equal(label0.TextColor, StackLayout.BackgroundColorProperty.DefaultValue);
+			Assert.Equal(label1.TextColor, StackLayout.BackgroundColorProperty.DefaultValue);
+			Assert.Equal(label2.TextColor, StackLayout.BackgroundColorProperty.DefaultValue);
+			Assert.Null(label0.Text);
+			Assert.Null(label1.Text);
+			Assert.Null(label2.Text);
+		}
+
+		[Fact]
+		public void RelativeSourceAncestorTypeBinding_TypedBinding()
+		{
+			Grid grid = new Grid();
+
+			StackLayout stack0 = new StackLayout
+			{
+				BackgroundColor = Colors.Red
+			};
+			StackLayout stack1 = new StackLayout
+			{
+				BackgroundColor = Colors.Green
+			};
+			StackLayout stack2 = new StackLayout
+			{
+				BackgroundColor = Colors.Blue
+			};
+
+			Label label0 = new Label();
+			Label label1 = new Label();
+			Label label2 = new Label();
+			var person0 = new PersonViewModel
+			{
+				Name = "Person 0",
+			};
+			var person1 = new PersonViewModel
+			{
+				Name = "Person 1",
+			};
+			var person2 = new PersonViewModel
+			{
+				Name = "Person 2",
+			};
+
+			stack2.Children.Add(stack1);
+			stack1.Children.Add(stack0);
+			stack0.Children.Add(grid);
+
+			label0.SetBinding(Label.TextProperty, static (PersonViewModel vm) => vm.Name, source: new RelativeBindingSource(RelativeBindingSourceMode.FindAncestorBindingContext, typeof(PersonViewModel), 1));
+			label0.SetBinding(Label.TextColorProperty, static (StackLayout stack) => stack.BackgroundColor, source: new RelativeBindingSource(RelativeBindingSourceMode.FindAncestor, typeof(StackLayout), 1));
+			Assert.Null(label0.Text);
+			Assert.Equal(Label.TextColorProperty.DefaultValue, label0.TextColor);
+
+			label1.SetBinding(Label.TextProperty, static (PersonViewModel vm) => vm.Name, source: new RelativeBindingSource(RelativeBindingSourceMode.FindAncestorBindingContext, typeof(PersonViewModel), 2));
+			label1.SetBinding(Label.TextColorProperty, static (StackLayout stack) => stack.BackgroundColor, source: new RelativeBindingSource(RelativeBindingSourceMode.FindAncestor, typeof(StackLayout), 2));
+			Assert.Null(label1.Text);
+			Assert.Equal(Label.TextColorProperty.DefaultValue, label1.TextColor);
+
+			label2.SetBinding(Label.TextProperty, static (PersonViewModel vm) => vm.Name, source: new RelativeBindingSource(RelativeBindingSourceMode.FindAncestorBindingContext, typeof(PersonViewModel), 3));
+			label2.SetBinding(Label.TextColorProperty, static (StackLayout vm) => vm.BackgroundColor, source: new RelativeBindingSource(RelativeBindingSourceMode.FindAncestor, typeof(StackLayout), 3));
 			Assert.Null(label2.Text);
 			Assert.Equal(Label.TextColorProperty.DefaultValue, label2.TextColor);
 


### PR DESCRIPTION
### Description of Change

The TypedBinding class didn't support relative binding sources. I implemented the missing functionality and there is now feature parity between classic Binding and TypedBinding. This will allow us to later compile more bindings in XAML into typed bindings using XamlC.

### Issues Fixed

Fixes #20101 

/cc @StephaneDelcroix 