### PR TITLE
[Trimming] Disable assembly scanning for types implementing IVisual

### DIFF
--- a/docs/design/FeatureSwitches.md
+++ b/docs/design/FeatureSwitches.md
@@ -5,9 +5,14 @@ Certain features of MAUI can be enabled or disabled using feature switches. The 
 | MSBuild Property Name | AppContext Setting | Description |
 |-|-|-|
 | MauiXamlRuntimeParsingSupport | Microsoft.Maui.RuntimeFeature.IsXamlRuntimeParsingSupported | When disabled, all XAML loading at runtime will throw an exception. This will affect usage of APIs such as the `LoadFromXaml` extension method. This feature can be safely turned off when all XAML resources are compiled using XamlC (see [XAML compilation](https://learn.microsoft.com/en-us/dotnet/maui/xaml/xamlc)). This feature is enabled by default for all configurations except for NativeAOT. |
+| MauiEnableIVisualAssemblyScanning | Microsoft.Maui.RuntimeFeature.IsIVisualAssemblyScanningEnabled | When enabled, MAUI will scan assemblies for types implementing `IVisual` and for `[assembly: Visual(...)]` attributes and register these types. |
 
 ## MauiXamlRuntimeParsingSupport
 
 When this feature is disabled, the following APIs are affected:
 - [`LoadFromXaml` extension methods](https://learn.microsoft.com/en-us/dotnet/maui/xaml/runtime-load) will throw runtime exceptions.
 - [Disabling XAML compilation](https://learn.microsoft.com/en-us/dotnet/maui/xaml/xamlc#disable-xaml-compilation) using `[XamlCompilation(XamlCompilationOptions.Skip)]` on pages and controls or whole assemblies will cause runtime exceptions.
+
+## MauiEnableIVisualAssemblyScanning
+
+When this feature is not enabled, custom and third party `IVisual` types will not be automatically discovered and registerd.

--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
@@ -209,11 +209,16 @@
   <Target Name="_MauiPrepareForILLink" BeforeTargets="PrepareForILLink">
     <PropertyGroup>
       <MauiXamlRuntimeParsingSupport Condition="'$(MauiXamlRuntimeParsingSupport)' == '' and '$(PublishAot)' == 'true'">false</MauiXamlRuntimeParsingSupport>
+      <MauiEnableIVisualAssemblyScanning Condition="'$(MauiEnableIVisualAssemblyScanning)' == ''">false</MauiEnableIVisualAssemblyScanning>
     </PropertyGroup>
     <ItemGroup>
       <RuntimeHostConfigurationOption Include="Microsoft.Maui.RuntimeFeature.IsXamlRuntimeParsingSupported"
                                       Condition="'$(MauiXamlRuntimeParsingSupport)' != ''"
                                       Value="$(MauiXamlRuntimeParsingSupport)"
+                                      Trim="true" />
+      <RuntimeHostConfigurationOption Include="Microsoft.Maui.RuntimeFeature.IsIVisualAssemblyScanningEnabled"
+                                      Condition="'$(MauiEnableIVisualAssemblyScanning)' != ''"
+                                      Value="$(MauiEnableIVisualAssemblyScanning)"
                                       Trim="true" />
     </ItemGroup>
   </Target>

--- a/src/Core/src/ILLink.Substitutions.xml
+++ b/src/Core/src/ILLink.Substitutions.xml
@@ -3,6 +3,8 @@
     <type fullname="Microsoft.Maui.RuntimeFeature">
       <method signature="System.Boolean get_IsXamlRuntimeParsingSupported()" body="stub" feature="Microsoft.Maui.RuntimeFeature.IsXamlRuntimeParsingSupported" value="false" featurevalue="false" />
       <method signature="System.Boolean get_IsXamlRuntimeParsingSupported()" body="stub" feature="Microsoft.Maui.RuntimeFeature.IsXamlRuntimeParsingSupported" value="true" featurevalue="true" />
+      <method signature="System.Boolean get_IsIVisualAssemblyScanningEnabled()" body="stub" feature="Microsoft.Maui.RuntimeFeature.IsIVisualAssemblyScanningEnabled" value="false" featurevalue="false" />
+      <method signature="System.Boolean get_IsIVisualAssemblyScanningEnabled()" body="stub" feature="Microsoft.Maui.RuntimeFeature.IsIVisualAssemblyScanningEnabled" value="true" featurevalue="true" />
     </type>
   </assembly>
 </linker>

--- a/src/Core/src/RuntimeFeature.cs
+++ b/src/Core/src/RuntimeFeature.cs
@@ -15,10 +15,16 @@ namespace Microsoft.Maui
 	internal static class RuntimeFeature
 	{
 		private const bool IsXamlRuntimeParsingSupportedByDefault = true;
+		private const bool IsIVisualAssemblyScanningEnabledByDefault = false;
 
 		internal static bool IsXamlRuntimeParsingSupported
 			=> AppContext.TryGetSwitch("Microsoft.Maui.RuntimeFeature.IsXamlRuntimeParsingSupported", out bool isEnabled)
 				? isEnabled
 				: IsXamlRuntimeParsingSupportedByDefault;
+
+		internal static bool IsIVisualAssemblyScanningEnabled =>
+			AppContext.TryGetSwitch("Microsoft.Maui.RuntimeFeature.IsIVisualAssemblyScanningEnabled", out bool isEnabled)
+				? isEnabled
+				: IsIVisualAssemblyScanningEnabledByDefault;
 	}
 }

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/AppleTemplateTests.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/AppleTemplateTests.cs
@@ -49,6 +49,7 @@ namespace Microsoft.Maui.IntegrationTests
 				buildProps.Add("PublishAotUsingRuntimePack=true"); // TODO: This parameter will become obsolete https://github.com/dotnet/runtime/issues/87060
 				buildProps.Add("_IsPublishing=true"); // using dotnet build with -p:_IsPublishing=true enables targeting simulators
 				buildProps.Add($"RuntimeIdentifier={runtimeIdentifier}");
+				buildProps.Add("IlcTreatWarningsAsErrors=false"); // TODO: Remove this once all warnings are fixed https://github.com/dotnet/maui/issues/19397
 			}
 
 			Assert.IsTrue(DotnetInternal.Build(projectFile, config, framework: $"{framework}-ios", properties: buildProps),

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/BuildWarningsUtilities.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/BuildWarningsUtilities.cs
@@ -168,6 +168,38 @@ namespace Microsoft.Maui.IntegrationTests
 							"Microsoft.Maui.Controls.Xaml.TypeConversionExtensions.GetImplicitConversionOperator(Type,Type,Type): 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicMethods' in call to 'System.Type.GetMethods(BindingFlags)'. The parameter '#0' of method 'Microsoft.Maui.Controls.Xaml.TypeConversionExtensions.GetImplicitConversionOperator(Type,Type,Type)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.",
 						}
 					},
+					new WarningsPerCode
+					{
+						Code = "IL2072",
+						Messages = new List<string>
+						{
+							"Microsoft.Maui.Controls.Xaml.TypeConversionExtensions.<>c__DisplayClass2_0.<ConvertTo>b__0(): 'type' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicParameterlessConstructor' in call to 'System.Activator.CreateInstance(Type)'. The return value of method 'Microsoft.Maui.Controls.Xaml.TypeConversionExtensions.GetTypeConverterType(IEnumerable`1<CustomAttributeData>)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.",
+							"Microsoft.Maui.Controls.Xaml.TypeConversionExtensions.<>c__DisplayClass2_0.<ConvertTo>b__0(): 'type' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicParameterlessConstructor' in call to 'System.Activator.CreateInstance(Type)'. The return value of method 'Microsoft.Maui.Controls.Xaml.TypeConversionExtensions.GetTypeConverterType(IEnumerable`1<CustomAttributeData>)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.",
+						}
+					},
+					new WarningsPerCode
+					{
+						Code = "IL2057",
+						Messages = new List<string>
+						{
+							"Microsoft.Maui.Controls.Xaml.TypeConversionExtensions.GetTypeConverterType(IEnumerable`1<CustomAttributeData>): Unrecognized value passed to the parameter 'typeName' of method 'System.Type.GetType(String)'. It's not possible to guarantee the availability of the target type.",
+						}
+					},
+				}
+			},
+			new WarningsPerFile
+			{
+				File = "src/Controls/src/Core/Routing.cs",
+				WarningsPerCode = new List<WarningsPerCode>
+				{
+					new WarningsPerCode
+					{
+						Code = "IL2111",
+						Messages = new List<string>
+						{
+							"Microsoft.Maui.Controls.Routing..cctor(): Method 'Microsoft.Maui.Controls.Routing.RegisterRoute(String,Type)' with parameters or return value with `DynamicallyAccessedMembersAttribute` is accessed via reflection. Trimmer can't guarantee availability of the requirements of the method.",
+						}
+					},
 				}
 			},
 			new WarningsPerFile

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/BuildWarningsUtilities.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/BuildWarningsUtilities.cs
@@ -168,38 +168,6 @@ namespace Microsoft.Maui.IntegrationTests
 							"Microsoft.Maui.Controls.Xaml.TypeConversionExtensions.GetImplicitConversionOperator(Type,Type,Type): 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicMethods' in call to 'System.Type.GetMethods(BindingFlags)'. The parameter '#0' of method 'Microsoft.Maui.Controls.Xaml.TypeConversionExtensions.GetImplicitConversionOperator(Type,Type,Type)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.",
 						}
 					},
-					new WarningsPerCode
-					{
-						Code = "IL2072",
-						Messages = new List<string>
-						{
-							"Microsoft.Maui.Controls.Xaml.TypeConversionExtensions.<>c__DisplayClass2_0.<ConvertTo>b__0(): 'type' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicParameterlessConstructor' in call to 'System.Activator.CreateInstance(Type)'. The return value of method 'Microsoft.Maui.Controls.Xaml.TypeConversionExtensions.GetTypeConverterType(IEnumerable`1<CustomAttributeData>)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.",
-							"Microsoft.Maui.Controls.Xaml.TypeConversionExtensions.<>c__DisplayClass2_0.<ConvertTo>b__0(): 'type' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicParameterlessConstructor' in call to 'System.Activator.CreateInstance(Type)'. The return value of method 'Microsoft.Maui.Controls.Xaml.TypeConversionExtensions.GetTypeConverterType(IEnumerable`1<CustomAttributeData>)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.",
-						}
-					},
-					new WarningsPerCode
-					{
-						Code = "IL2057",
-						Messages = new List<string>
-						{
-							"Microsoft.Maui.Controls.Xaml.TypeConversionExtensions.GetTypeConverterType(IEnumerable`1<CustomAttributeData>): Unrecognized value passed to the parameter 'typeName' of method 'System.Type.GetType(String)'. It's not possible to guarantee the availability of the target type.",
-						}
-					},
-				}
-			},
-			new WarningsPerFile
-			{
-				File = "src/Controls/src/Core/Routing.cs",
-				WarningsPerCode = new List<WarningsPerCode>
-				{
-					new WarningsPerCode
-					{
-						Code = "IL2111",
-						Messages = new List<string>
-						{
-							"Microsoft.Maui.Controls.Routing..cctor(): Method 'Microsoft.Maui.Controls.Routing.RegisterRoute(String,Type)' with parameters or return value with `DynamicallyAccessedMembersAttribute` is accessed via reflection. Trimmer can't guarantee availability of the requirements of the method.",
-						}
-					},
 				}
 			},
 			new WarningsPerFile
@@ -252,29 +220,6 @@ namespace Microsoft.Maui.IntegrationTests
 							"Microsoft.Maui.Controls.BindingExpression.GetIndexer(TypeInfo,String,String): 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicProperties', 'DynamicallyAccessedMemberTypes.NonPublicProperties' in call to 'System.Reflection.TypeInfo.DeclaredProperties.get'. The parameter '#0' of method 'Microsoft.Maui.Controls.BindingExpression.GetIndexer(TypeInfo,String,String)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.",
 							"Microsoft.Maui.Controls.BindingExpression.GetIndexer(TypeInfo,String,String): 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicProperties', 'DynamicallyAccessedMemberTypes.NonPublicProperties' in call to 'System.Reflection.TypeInfo.DeclaredProperties.get'. The parameter '#0' of method 'Microsoft.Maui.Controls.BindingExpression.GetIndexer(TypeInfo,String,String)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.",
 							"Microsoft.Maui.Controls.BindingExpression.GetIndexer(TypeInfo,String,String): 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.Interfaces' in call to 'System.Reflection.TypeInfo.ImplementedInterfaces.get'. The parameter '#0' of method 'Microsoft.Maui.Controls.BindingExpression.GetIndexer(TypeInfo,String,String)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.",
-						}
-					},
-				}
-			},
-			new WarningsPerFile
-			{
-				File = "src/Controls/src/Core/Visuals/VisualTypeConverter.cs",
-				WarningsPerCode = new List<WarningsPerCode>
-				{
-					new WarningsPerCode
-					{
-						Code = "IL2026",
-						Messages = new List<string>
-						{
-							"Microsoft.Maui.Controls.VisualTypeConverter.Register(Assembly,Dictionary`2<String,IVisual>): Using member 'System.Reflection.Assembly.GetExportedTypes()' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. Types might be removed.",
-						}
-					},
-					new WarningsPerCode
-					{
-						Code = "IL2062",
-						Messages = new List<string>
-						{
-							"Microsoft.Maui.Controls.VisualTypeConverter.Register(Assembly,Dictionary`2<String,IVisual>): Value passed to parameter '' of method 'Microsoft.Maui.Controls.VisualTypeConverter.Register(Type,Dictionary`2<String,IVisual>)' can not be statically determined and may not meet 'DynamicallyAccessedMembersAttribute' requirements.",
 						}
 					},
 				}


### PR DESCRIPTION
### Description of Change

When an app uses _visuals_, we preform assembly scanning to find all types that implement `IVisual`. This is not trimming-safe and it will likely not work with trimming/NativeAOT.

~Instead, I propose adding a new app builder API `UseVisual<TVisual>()` to register any visual which is used in the app (alongside the default visuals). This API has been suggested in #4937.~

For backwards compatibility, I added a feature switch `MauiEnableIVisualAssemblyScanning` which I propose to be disabled by default in .NET 9.

### Issues Fixed

Fixes #4937, contributes to #19397

/cc @eerhardt @PureWeen 