### PR TITLE
[tests] Use public pool for iOS device and uitests

### DIFF
--- a/eng/pipelines/device-tests.yml
+++ b/eng/pipelines/device-tests.yml
@@ -69,12 +69,8 @@ parameters:
   - name: iosPool
     type: object
     default:
-      name: $(iosTestsVmPool)
-      vmImage: $(iosTestsVmImage)
-      demands:
-        - macOS.Name -equals Ventura
-        - macOS.Architecture -equals x64
-        - Agent.OSVersion -equals 13.5
+      name: $(macosTestsVmPool)
+      vmImage: $(macosTestsVmImage)
 
   - name: catalystPool
     type: object

--- a/eng/pipelines/ui-tests.yml
+++ b/eng/pipelines/ui-tests.yml
@@ -73,12 +73,8 @@ parameters:
   - name: iosPool
     type: object
     default:
-      name: $(androidTestsVmPool)
-      vmImage: $(androidTestsVmImage)
-      demands:
-        - macOS.Name -equals Ventura
-        - macOS.Architecture -equals x64
-        - Agent.OSVersion -equals 13.5
+      name: $(macosTestsVmPool)
+      vmImage: $(macosTestsVmImage)
   
   - name: windowsPool
     type: object


### PR DESCRIPTION
### Description of Change

Try to workaround issues we see on our own bots running device and uitests . 
Try use Azure Pipelines  macOS-13