### PR TITLE
[Android] Pickers' reopening in collections

### DIFF
--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issue19739.xaml
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issue19739.xaml
@@ -1,0 +1,25 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Maui.Controls.Sample.Issues.Issue19739">
+    <ListView ItemsSource="{Binding AutomationIds}" AutomationId="listView" HasUnevenRows="True">
+        <ListView.ItemTemplate>
+            <DataTemplate>
+                <ViewCell>
+                    <VerticalStackLayout Margin="0,5">
+                        <Label Text="{Binding .}"/> 
+                        <Picker AutomationId="{Binding .}" Title="Select item">
+                            <Picker.ItemsSource>
+                                <x:Array Type="{x:Type x:String}">
+                                    <x:String>Item 1</x:String>
+                                    <x:String>Item 2</x:String>
+                                    <x:String>Item 3</x:String>
+                                </x:Array>
+                            </Picker.ItemsSource>
+                        </Picker>
+                    </VerticalStackLayout>
+                </ViewCell>
+            </DataTemplate>
+        </ListView.ItemTemplate>
+    </ListView>
+</ContentPage>

--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issue19739.xaml.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issue19739.xaml.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+
+namespace Maui.Controls.Sample.Issues
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	[Issue(IssueTracker.Github, 19739, "[Android] Pickers reopen when selecting items", PlatformAffected.Android)]
+	public partial class Issue19739 : ContentPage
+	{
+		public List<string> AutomationIds
+			=> new() { "picker1", "picker2", "picker3" };
+
+		public Issue19739()
+		{
+			InitializeComponent();
+			BindingContext = this;
+		}
+	}
+}

--- a/src/Controls/tests/UITests/Tests/Issues/Issue19739.cs
+++ b/src/Controls/tests/UITests/Tests/Issues/Issue19739.cs
@@ -1,0 +1,39 @@
+﻿using NUnit.Framework;
+using OpenQA.Selenium.Appium;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.AppiumTests.Issues
+{
+	public class Issue19739 : _IssuesUITest
+	{
+		public Issue19739(TestDevice device) : base(device)
+		{
+		}
+
+		public override string Issue => "[Android] Pickers reopen when selecting items";
+
+		[Test]
+		public void PickersDialogsShouldAlwaysCloseWhenSelectingItem()
+		{
+			this.IgnoreIfPlatforms(new[]
+			{
+				TestDevice.iOS,
+				TestDevice.Mac,
+				TestDevice.Windows
+			});
+
+			_ = App.WaitForElement("listView");
+
+
+			for (int i=1;i<=3;i++)
+			{
+				App.Click($"picker{i}");
+				((AppiumApp)App).Driver.FindElements(MobileBy.XPath("//android.widget.TextView[@text=\"Item 1\"]")).First().Click();
+			}
+			
+			// Passes when pickers open dialogs and close them after selecting any item
+			VerifyScreenshot();
+		}
+	}
+}

--- a/src/Core/src/Handlers/Picker/PickerHandler.Android.cs
+++ b/src/Core/src/Handlers/Picker/PickerHandler.Android.cs
@@ -91,14 +91,7 @@ namespace Microsoft.Maui.Handlers
 			if (PlatformView == null)
 				return;
 
-			if (e.HasFocus)
-			{
-				if (PlatformView.Clickable)
-					PlatformView.CallOnClick();
-				else
-					OnClick(PlatformView, EventArgs.Empty);
-			}
-			else if (_dialog != null)
+			if (_dialog != null)
 			{
 				_dialog.Hide();
 				_dialog = null;

--- a/src/Core/src/Platform/Android/MauiPicker.cs
+++ b/src/Core/src/Platform/Android/MauiPicker.cs
@@ -25,7 +25,6 @@ namespace Microsoft.Maui.Platform
 		protected override void OnFocusChanged(bool gainFocus, [GeneratedEnum] FocusSearchDirection direction, ARect? previouslyFocusedRect)
 		{
 			base.OnFocusChanged(gainFocus, direction, previouslyFocusedRect);
-			PickerManager.OnFocusChanged(gainFocus, this);
 		}
 
 		protected override void Dispose(bool disposing)

--- a/src/Core/src/Platform/Android/PickerManager.cs
+++ b/src/Core/src/Platform/Android/PickerManager.cs
@@ -34,8 +34,7 @@ namespace Microsoft.Maui.Platform
 
 		public static void OnFocusChanged(bool gainFocus, EditText sender)
 		{
-			if (gainFocus)
-				sender.CallOnClick();
+
 		}
 
 		static void OnKeyPress(object? sender, AView.KeyEventArgs e)


### PR DESCRIPTION
### Description of Change

I removed the possibility of opening pickers when the focus changes.
This fixes the incorrect behavior of pickers nested inside collections.
I might be wrong, but why are the pickers opened when the focus changes?
Shouldn't they be triggered to show the dialog only when a user clicks
the text field?

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/19739

|Before|After|
|---|---|
|<video src="https://github.com/dotnet/maui/assets/42434498/5217961b-6fb3-4363-83f6-22b768fa0a9b"/>|<video src="https://github.com/dotnet/maui/assets/42434498/849819e0-01a9-4014-b21f-5410687ddf2f"/>







