### PR TITLE
[core] introduce `WeakEventHandler<T>`, internal for now

### DIFF
--- a/src/Controls/src/Core/Application/Application.cs
+++ b/src/Controls/src/Core/Application/Application.cs
@@ -17,7 +17,6 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../docs/Microsoft.Maui.Controls/Application.xml" path="Type[@FullName='Microsoft.Maui.Controls.Application']/Docs/*" />
 	public partial class Application : Element, IResourcesProvider, IApplicationController, IElementConfiguration<Application>, IVisualTreeElement, IApplication
 	{
-		readonly WeakEventManager _weakEventManager = new WeakEventManager();
 		readonly Lazy<PlatformConfigurationRegistry<Application>> _platformConfigurationRegistry;
 
 #pragma warning disable CS0612 // Type or member is obsolete
@@ -218,10 +217,12 @@ namespace Microsoft.Maui.Controls
 #endif
 		}
 
+		readonly WeakEventHandler<AppThemeChangedEventArgs> _requestedThemeChanged = new();
+
 		public event EventHandler<AppThemeChangedEventArgs> RequestedThemeChanged
 		{
-			add => _weakEventManager.AddEventHandler(value);
-			remove => _weakEventManager.RemoveEventHandler(value);
+			add => _requestedThemeChanged.AddEventHandler(value);
+			remove => _requestedThemeChanged.RemoveEventHandler(value);
 		}
 
 		bool _themeChangedFiring;
@@ -243,7 +244,7 @@ namespace Microsoft.Maui.Controls
 				_themeChangedFiring = true;
 				_lastAppTheme = newTheme;
 
-				_weakEventManager.HandleEvent(this, new AppThemeChangedEventArgs(newTheme), nameof(RequestedThemeChanged));
+				_requestedThemeChanged.HandleEvent(this, new AppThemeChangedEventArgs(newTheme));
 			}
 			finally
 			{

--- a/src/Core/src/WeakEventHandler.cs
+++ b/src/Core/src/WeakEventHandler.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Maui
+{
+	/// <summary>
+	/// An internal, performance-focused version of WeakEventManager
+	/// By restricting to one event type, it can be strongly typed.
+	/// </summary>
+	class WeakEventHandler<TEventArgs> where TEventArgs : EventArgs
+	{
+		readonly List<WeakReference<EventHandler<TEventArgs>>> _subscriptions = new();
+
+		public void AddEventHandler(EventHandler<TEventArgs> handler)
+		{
+			if (handler is null)
+			{
+				throw new ArgumentNullException(nameof(handler));
+			}
+			_subscriptions.Add(new(handler));
+		}
+
+		public void RemoveEventHandler(EventHandler<TEventArgs> handler)
+		{
+			if (handler is null)
+			{
+				throw new ArgumentNullException(nameof(handler));
+			}
+
+			// Reversed, so we can RemoveAt() as we go
+			for (int i = _subscriptions.Count - 1; i >= 0; i--)
+			{
+				var subscription = _subscriptions[i];
+				if (subscription.TryGetTarget(out var existing))
+				{
+					if (handler == existing)
+					{
+						_subscriptions.RemoveAt(i);
+						break;
+					}
+				}
+				else
+				{
+					_subscriptions.RemoveAt(i);
+				}
+			}
+		}
+
+		public void HandleEvent(object? sender, TEventArgs args)
+		{
+			// Reversed, so we can RemoveAt() as we go
+			for (int i = _subscriptions.Count - 1; i >= 0; i--)
+			{
+				var subscription = _subscriptions[i];
+				if (subscription.TryGetTarget(out var handler))
+				{
+					handler.Invoke(sender, args);
+				}
+				else
+				{
+					_subscriptions.RemoveAt(i);
+				}
+			}
+		}
+	}
+}

--- a/src/Core/tests/Benchmarks/Benchmarks/WeakEventBenchmarker.cs
+++ b/src/Core/tests/Benchmarks/Benchmarks/WeakEventBenchmarker.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using BenchmarkDotNet.Attributes;
+
+namespace Microsoft.Maui.Handlers.Benchmarks
+{
+	[MemoryDiagnoser]
+	public class WeakEventBenchmarker
+	{
+		const int Iterations = 100;
+		const string EventName = "MyEvent";
+
+		void Handler(object sender, EventArgs e) { }
+
+		[Benchmark]
+		public void WeakEventHandler()
+		{
+			var eventManager = new WeakEventHandler<EventArgs>();
+
+			for (int i = 0; i < Iterations; i++)
+			{
+				eventManager.AddEventHandler(Handler);
+				eventManager.HandleEvent(this, EventArgs.Empty);
+				eventManager.RemoveEventHandler(Handler);
+			}
+		}
+
+		[Benchmark]
+		public void WeakEventManager()
+		{
+			var eventManager = new WeakEventManager();
+
+			for (int i = 0; i < Iterations; i++)
+			{
+				eventManager.AddEventHandler(Handler, EventName);
+				eventManager.HandleEvent(this, EventArgs.Empty, EventName);
+				eventManager.RemoveEventHandler(Handler, EventName);
+			}
+		}
+	}
+}


### PR DESCRIPTION
Context: https://github.com/dotnet/maui/issues/18505
Context: https://github.com/dotnet/maui/pull/19931
Context: https://github.com/dotnet/maui/files/13251041/MauiCollectionView.zip

In the above sample, a lot of time while scrolling a `CollectionView` on Android is spent in `{AppThemeBinding}` and
`Application.RequestedThemeChanged`'s underlying `WeakEventManager`.

As the top item in a `CollectionView` scrolls offscreen, it is "recycled". This refreshes the `BindingContext` of `{AppThemeBinding}`, subscribing and unsubscribing to the `Application.RequestedThemeChanged` event.

@mattleibow has a PR that is acceptable for .NET 9, but we are wanting to see what we can do for .NET 8 servicing.

Can we make a *faster* `WeakEventManager`?

`WeakEventManager` has two performance concerns:

1. It's core data structure is a `Dictionary<string, List<Subscription>>`, requiring string lookups prior to any operations.

2. It uses `System.Reflection.MethodInfo` for invocation.

These are completely reasonable, given `WeakEventManager`'s flexibility. It can handle multiple events of different `EventHandler` types.

If we restrict ourselves to a single `EventHandler<T>` type, we can:

1. Use a plain `List<T>`.

2. Just call the `EventHandler<T>` directly. No System.Reflection.

I tested these changes by parameterizing the existing `WeakEventManagerTests` for both classes and getting them to pass.

A benchmark comparing the new `WeakEventHandler<T>` to `WeakEventManager`:

| Method           | Mean     | Error    | StdDev   | Gen0   | Allocated |
|----------------- |---------:|---------:|---------:|-------:|----------:|
| WeakEventHandler | 14.02 us | 0.329 us | 0.965 us | 1.8005 |  14.95 KB |
| WeakEventManager | 46.13 us | 0.922 us | 1.025 us | 6.4087 |  52.70 KB |

I replaced usage of `WeakEventManager` in a single place, `Application.RequestedThemeChanged`.

And then in a real-world scenario, the `MauiCollectionView` sample above, scrolling on a Pixel 5:

    (13%) Microsoft.Maui!Microsoft.Maui.WeakEventManager.RemoveEventHandler(string,object,System.Reflection.MemberInfo)
    (8.8%) Microsoft.Maui!Microsoft.Maui.WeakEventHandler<TEventArgs_REF>.RemoveEventHandler(System.EventHandler`1<TEventArgs_REF>)

A 4.2% improvement is noticeable while scrolling. I think I can *feel* the difference.

This should improve the performance of creating or scrolling any control using `{AppThemeBinding}`. Note that `Styles.xaml` in the project template makes use of `{AppThemeBinding}`, so this is likely *every* control in a lot of .NET MAUI applications.

Obviously this won't be as dramatic as the improvement in #19931, but it's *something* and seems safe and reasonable to service to .NET 8.

If this change works out, we can consider:

* Use `BannedApiAnalyzers` to "ban" `WeakEventManager` in this codebase.

* Switch all usage over to `WeakEventHandler<T>` instead.

* We can leave `WeakEventManager` in place indefinitely, as it's public. It's "fine" if it's current API is useful to MAUI developers.

The only downside is if a class has multiple events, it will require multiple `WeakEventHandler<T>` objects.
