### PR TITLE
Remove allocation from Color.TryParse

### DIFF
--- a/src/Graphics/src/Graphics/Color.cs
+++ b/src/Graphics/src/Graphics/Color.cs
@@ -756,9 +756,7 @@ namespace Microsoft.Maui.Graphics
 			int charsWritten = value.ToLowerInvariant(loweredValue);
 			Debug.Assert(charsWritten == value.Length);
 
-			// this should use the C# feature https://github.com/dotnet/csharplang/issues/1881, when it is available
-			// for now, we need to allocate the lowered string
-			return loweredValue.ToString() switch
+			return loweredValue switch
 			{
 				"default" => default,
 				"aliceblue" => Colors.AliceBlue,


### PR DESCRIPTION
C# now allows for switching over a ReadOnlySpan<char>. Updating the code to no longer allocate a new string when trying to find the named color.