### PR TITLE
Inheriting Visual States

### DIFF
--- a/.github/agent-pr-session/pr-20467.md
+++ b/.github/agent-pr-session/pr-20467.md
@@ -9,8 +9,8 @@
 | Pre-Flight | ✅ COMPLETE |
 | 🧪 Tests | ✅ COMPLETE |
 | 🚦 Gate | ✅ PASSED |
-| 🔧 Fix | ▶️ IN PROGRESS |
-| 📋 Report | ⏳ PENDING |
+| 🔧 Fix | ✅ COMPLETE |
+| 📋 Report | ▶️ IN PROGRESS |
 
 ---
 

--- a/.github/agent-pr-session/pr-20467.md
+++ b/.github/agent-pr-session/pr-20467.md
@@ -1,8 +1,27 @@
 # PR Review: #20467 - Inheriting Visual States
 
+## ✅ Final Recommendation: APPROVE
+
+**Rationale:**
+1. **Fix is correct** - Gate verification confirms the fix resolves the issue (tests FAIL without fix, PASS with fix)
+2. **Clean implementation** - PR's approach (merge in Setter.Apply) is cleaner than alternatives (explored Style.ApplyCore approach - works but more complex)
+3. **Well-isolated** - New `MergeWithParent()` extension method is reusable and testable
+4. **Comprehensive testing** - Added unit test validates both visual states work correctly
+5. **No breaking changes** - Only adds functionality, doesn't change existing behavior
+
+**Improvements Made:**
+- ✅ Added unit test `VisualStatesInheritFromParentStyle` to validate the fix
+- ✅ Verified test correctly catches the bug (FAILS without fix)
+- ✅ Explored alternative approaches (Style.ApplyCore) - confirmed PR's approach is superior
+
+**Suggested PR Description Update:**
+Add the required NOTE block at the top and "Issues Fixed" section with test information.
+
+---
+
 **Date:** 2026-01-10 | **Issue:** None (community PR) | **PR:** [#20467](https://github.com/dotnet/maui/pull/20467)
 
-## ⏳ Status: IN PROGRESS
+## ✅ Status: COMPLETE
 
 | Phase | Status |
 |-------|--------|
@@ -10,7 +29,7 @@
 | 🧪 Tests | ✅ COMPLETE |
 | 🚦 Gate | ✅ PASSED |
 | 🔧 Fix | ✅ COMPLETE |
-| 📋 Report | ▶️ IN PROGRESS |
+| 📋 Report | ✅ COMPLETE |
 
 ---
 

--- a/.github/agent-pr-session/pr-20467.md
+++ b/.github/agent-pr-session/pr-20467.md
@@ -1,0 +1,144 @@
+# PR Review: #20467 - Inheriting Visual States
+
+**Date:** 2026-01-10 | **Issue:** None (community PR) | **PR:** [#20467](https://github.com/dotnet/maui/pull/20467)
+
+## ⏳ Status: IN PROGRESS
+
+| Phase | Status |
+|-------|--------|
+| Pre-Flight | ✅ COMPLETE |
+| 🧪 Tests | ✅ COMPLETE |
+| 🚦 Gate | ✅ PASSED |
+| 🔧 Fix | ▶️ IN PROGRESS |
+| 📋 Report | ⏳ PENDING |
+
+---
+
+<details>
+<summary><strong>📋 Issue Summary</strong></summary>
+
+**Problem:** Visual states from parent styles aren't being applied to derived styles.
+
+**Scenario:**
+When a derived style (with `BasedOn` referencing a parent style) defines visual states in the same `VisualStateGroup` as the parent, only the derived style's visual states work. The parent style's visual states in that group are ignored.
+
+**Example:**
+- Parent style defines `Custom` visual state
+- Derived style (BasedOn parent) defines `Normal` visual state in same `CommonStates` group
+- Result: `Custom` state is ignored (doesn't apply colors)
+
+**Steps to Reproduce:**
+1. Define parent style with visual state (e.g., `Custom`)
+2. Create derived style with `BasedOn` parent
+3. Add different visual state to same group (e.g., `Normal`)
+4. Try to switch to parent's visual state via `VisualStateManager.GoToState()`
+
+**Expected:** Both parent and derived visual states should work
+**Actual:** Only derived style's visual states work
+
+**Platforms Affected:**
+- [x] iOS
+- [x] Android
+- [x] Windows
+- [x] MacCatalyst
+(All platforms - this is XAML/Style logic)
+
+**Related Work:**
+- PR #19812 mentioned in comments (PointerOver priority) - closed, unrelated to inheritance
+- Missing before/after images in PR description
+
+</details>
+
+<details>
+<summary><strong>📁 Files Changed</strong></summary>
+
+| File | Type | Changes |
+|------|------|---------|
+| `src/Controls/src/Core/Setter.cs` | Fix | +7 lines |
+| `src/Controls/src/Core/VisualStateManager.cs` | Fix | +19 lines |
+
+**No test files included.**
+
+</details>
+
+<details>
+<summary><strong>💬 PR Discussion Summary</strong></summary>
+
+**Key Comments:**
+- @MartyIX: Asked about relationship to PR #19812 (Feb 10, 2024) - author hasn't responded
+- @MartyIX: Noted before/after images are missing from PR description (Mar 8, 2025)
+- @jsuarezruiz: Triggered Azure Pipelines (May 13, 2024)
+- Bot: Community contribution
+
+**Reviewer Feedback:**
+- No formal reviews submitted
+- No inline code comments
+
+**Disagreements to Investigate:**
+None
+
+**Author Uncertainty:**
+- No response to question about relationship to PR #19812
+- Missing visual comparison (images broken in PR description)
+
+</details>
+
+<details>
+<summary><strong>🧪 Tests</strong></summary>
+
+**Status**: ⏳ PENDING
+
+
+- [x] Unit test created: `VisualStatesInheritFromParentStyle`
+- [x] Tests reproduce the issue
+- [x] Tests follow xUnit pattern
+
+**Test Files:**
+- Unit Test: `src/Controls/tests/Core.UnitTests/VisualStateManagerTests.cs`
+
+**Test Verification:**
+- ❌ WITHOUT fix: Test FAILS (Expected 2 states, found 1: Normal)
+- ✅ WITH fix: Test PASSES (Both Normal and Custom states present)
+
+
+</details>
+
+<details>
+<summary><strong>🚦 Gate - Test Verification</strong></summary>
+
+**Status**: ⏳ PENDING
+
+- [ ] Tests FAIL without fix (bug reproduced)
+- [ ] Tests PASS with fix (bug resolved)
+
+**Result:** PASSED ✅
+
+**Verification Details:**
+- Test: `VisualStatesInheritFromParentStyle`
+- WITHOUT fix: `Expected at least 2 states (Normal + Custom), but found 1: Normal`
+- WITH fix: Both states present, switching between them works correctly
+
+</details>
+
+<details>
+<summary><strong>🔧 Fix Candidates</strong></summary>
+
+**Status**: ⏳ PENDING
+
+| # | Source | Approach | Test Result | Files Changed | Notes |
+|---|--------|----------|-------------|---------------|-------|
+| PR | PR #20467 | Merge parent visual states into derived style during `Setter.Apply()` | ✅ PASS (Gate) | `Setter.cs` (+7), `VisualStateManager.cs` (+19) | Original PR - validated by Gate |
+
+**PR's Approach:**
+1. In `Setter.Apply()`: When applying visual state groups, check if target already has visual states
+2. If yes: Call new `MergeWithParent()` extension method
+3. `MergeWithParent()`: For matching VisualStateGroup names, add parent's visual states that don't exist in derived style
+
+**Exhausted:** No
+**Selected Fix:** PENDING
+
+</details>
+
+---
+
+**Next Step:** Create tests, then proceed to Gate verification.

--- a/.github/agent-pr-session/pr-20467.md
+++ b/.github/agent-pr-session/pr-20467.md
@@ -134,11 +134,30 @@ None
 2. If yes: Call new `MergeWithParent()` extension method
 3. `MergeWithParent()`: For matching VisualStateGroup names, add parent's visual states that don't exist in derived style
 
-**Exhausted:** No
-**Selected Fix:** PENDING
+
+| 1 | try-fix | Merge visual states at Style.ApplyCore() level before applying setters | ✅ PASS | `Style.cs` (+36) | Works! Alternative approach - merges at style application time instead of setter application time |
+
+**Exhausted:** Yes (explored both viable approaches)
+**Selected Fix:** PR's fix
+
+**Comparison:**
+Both fixes work correctly. Here's the trade-off analysis:
+
+| Criterion | PR's Fix (Setter.Apply) | try-fix #1 (Style.ApplyCore) |
+|-----------|-------------------------|------------------------------|
+| **Files changed** | 2 files (+26 lines) | 1 file (+36 lines) |
+| **Complexity** | Lower - isolated extension method | Higher - Style.cs logic more complex |
+| **Scope** | Narrow - only affects visual state setters | Broader - affects all style applications |
+| **Reusability** | MergeWithParent() is reusable | Merge logic embedded in ApplyCore |
+| **Maintainability** | Better - extension method is testable in isolation | Harder - mixed with style application logic |
+| **Performance** | Merges only when setter applied | Pre-merges before application (slightly earlier) |
+
+**Verdict:** PR's fix is superior because:
+1. **Better separation of concerns** - Visual state merging logic lives with VisualStateManager
+2. **More reusable** - Extension method could be used elsewhere if needed
+3. **Easier to maintain** - Isolated logic is easier to test and modify
+4. **Cleaner** - Doesn't complicate Style.ApplyCore with domain-specific logic
+
+Both approaches validate that merging parent visual states is the correct solution. The PR author chose the cleaner implementation point.
 
 </details>
-
----
-
-**Next Step:** Create tests, then proceed to Gate verification.

--- a/src/Controls/src/Core/Setter.cs
+++ b/src/Controls/src/Core/Setter.cs
@@ -85,7 +85,14 @@ namespace Microsoft.Maui.Controls
 			else if (Value is DynamicResource dynamicResource)
 				targetObject.SetDynamicResource(Property, dynamicResource.Key, specificity);
 			else if (Value is IList<VisualStateGroup> visualStateGroupCollection)
+			{
+				//Check if the target has already any visual states
+				if (targetObject.GetValue(Property) is VisualStateGroupList parentVisualStateGroups)
+				{
+					visualStateGroupCollection.MergeWithParent(parentVisualStateGroups);
+				}
 				targetObject.SetValue(Property, visualStateGroupCollection.Clone(), specificity);
+			}
 			else
 				targetObject.SetValue(Property, Value, specificity: specificity);
 		}

--- a/src/Controls/src/Core/VisualStateManager.cs
+++ b/src/Controls/src/Core/VisualStateManager.cs
@@ -779,6 +779,25 @@ namespace Microsoft.Maui.Controls
 
 			return false;
 		}
+
+		internal static void MergeWithParent(this IList<VisualStateGroup> groups, VisualStateGroupList parentVisualStateGroups)
+		{
+			// Find these VisualStateGroup that are the same for the parent and the child VisualStateGroupList
+			foreach (var parentVisualStateGroup in parentVisualStateGroups)
+			{
+				if (groups.FirstOrDefault(x => x.Name == parentVisualStateGroup.Name) is { } visualStateGroup)
+				{
+					// Find the visual states that were defined in the parent visualStateGroup, but are not defined in the new visualStateGroup
+					foreach (var parentVisualState in parentVisualStateGroup.States)
+					{
+						if (!visualStateGroup.States.Any(x => x.Name == parentVisualState.Name))
+						{
+							visualStateGroup.States.Add(parentVisualState);
+						}
+					}
+				}
+			}
+		}
 	}
 
 	internal class WatchAddList<T> : IList<T>


### PR DESCRIPTION
### Description of Change

Visual states from parent types aren't being applied to derived types.

I have a button that when clicked switches between a `Normal` and a `Custom` state: 
`VisualStateManager.GoToState(button, !isNormal ? "Custom" : "Normal");`

Everything works as expected when both states are defined in the same `VisualStateGroup`:

```
<Style TargetType="Button">
    <Setter Property="VisualStateManager.VisualStateGroups">
        <VisualStateGroupList>
            <VisualStateGroup x:Name="CommonStates">
                <VisualState Name="Normal">
                    <VisualState.Setters>
                        <Setter Property="TextColor" Value="White" />
                        <Setter Property="BackgroundColor" Value="Black" />
                    </VisualState.Setters>
                </VisualState>
                <VisualState Name="Custom">
                    <VisualState.Setters>
                        <Setter Property="TextColor" Value="Red" />
                        <Setter Property="BackgroundColor" Value="Green" />
                    </VisualState.Setters>
                </VisualState>
            </VisualStateGroup>
        </VisualStateGroupList>
    </Setter>
</Style>
```
The issue occurs when one of the visual states is defined in the parent Style. In that context the `Custom` style is ignored - the same happens when the visual state is defined in the global styles.
```
<Style TargetType="Button" x:Key="parentStyle">
    <Setter Property="VisualStateManager.VisualStateGroups">
        <VisualStateGroupList>
            <VisualStateGroup x:Name="CommonStates">
                <VisualState Name="Custom">
                    <VisualState.Setters>
                        <Setter Property="TextColor" Value="Red" />
                        <Setter Property="BackgroundColor" Value="Green" />
                    </VisualState.Setters>
                </VisualState>
            </VisualStateGroup>
        </VisualStateGroupList>
    </Setter>
</Style>

<Style TargetType="Button" BasedOn="{StaticResource parentStyle}">
    <Setter Property="VisualStateManager.VisualStateGroups">
        <VisualStateGroupList>
            <VisualStateGroup x:Name="CommonStates">
                <VisualState Name="Normal">
                    <VisualState.Setters>
                        <Setter Property="TextColor" Value="White" />
                        <Setter Property="BackgroundColor" Value="Black" />
                    </VisualState.Setters>
                </VisualState>
            </VisualStateGroup>
        </VisualStateGroupList>
    </Setter>
</Style>
```

This PR is supposed to fix it by adding the visual state that has not been defined in the derived style from the parent style to the derived style

|Before|After|
|---|---|
|<img src="https://github.com/dotnet/maui/assets/42434498/4076821e-7952-417c-b72b-a09b893e6bfe"/>|<img src="https://github.com/dotnet/maui/assets/42434498/d929a7ec-6dd8-489e-8dc5-218457ce8030"/>|