### PR TITLE
[iOS][tests] NativeAOT: Do not treat warnings as errors in integration tests

### DIFF
--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/AppleTemplateTests.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/AppleTemplateTests.cs
@@ -49,6 +49,7 @@ namespace Microsoft.Maui.IntegrationTests
 				buildProps.Add("PublishAotUsingRuntimePack=true"); // TODO: This parameter will become obsolete https://github.com/dotnet/runtime/issues/87060
 				buildProps.Add("_IsPublishing=true"); // using dotnet build with -p:_IsPublishing=true enables targeting simulators
 				buildProps.Add($"RuntimeIdentifier={runtimeIdentifier}");
+				buildProps.Add("IlcTreatWarningsAsErrors=false"); // TODO: Remove this once all warnings are fixed https://github.com/dotnet/maui/issues/19397
 			}
 
 			Assert.IsTrue(DotnetInternal.Build(projectFile, config, framework: $"{framework}-ios", properties: buildProps),

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/TemplateTests.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/TemplateTests.cs
@@ -195,6 +195,7 @@ namespace Microsoft.Maui.IntegrationTests
 			var extendedBuildProps = BuildProps;
 			extendedBuildProps.Add("PublishAot=true");
 			extendedBuildProps.Add("PublishAotUsingRuntimePack=true");  // TODO: This parameter will become obsolete https://github.com/dotnet/runtime/issues/87060
+			extendedBuildProps.Add("IlcTreatWarningsAsErrors=false");
 
 			Assert.IsTrue(DotnetInternal.Publish(projectFile, "Release", framework: framework, properties: extendedBuildProps, runtimeIdentifier: runtimeIdentifier),
 				$"Project {Path.GetFileName(projectFile)} failed to build. Check test output/attachments for errors.");
@@ -216,6 +217,7 @@ namespace Microsoft.Maui.IntegrationTests
 			var extendedBuildProps = BuildProps;
 			extendedBuildProps.Add("PublishAot=true");
 			extendedBuildProps.Add("PublishAotUsingRuntimePack=true");  // TODO: This parameter will become obsolete https://github.com/dotnet/runtime/issues/87060
+			extendedBuildProps.Add("IlcTreatWarningsAsErrors=false");
 			extendedBuildProps.Add("TrimmerSingleWarn=false");
 
 			string binLogFilePath = $"publish-{DateTime.UtcNow.ToFileTimeUtc()}.binlog";


### PR DESCRIPTION
### Description

In .net8.0 NativeAOT compiler did not treat warnings as errors.
This got fixed in .net9.0 with: https://github.com/dotnet/runtime/pull/96567

As there is a possibility that such fix will get backported, I am adding the escape mechanism to avoid our NativeAOT testing to start failing on the maui `main` branch. Set properties should not change the behaviour of the test.

Additionally, we have encountered exactly these failures when working on maui `net9.0` branch because we started pulling in the mentioned fix: 
- https://github.com/dotnet/maui/pull/20268 
- https://github.com/dotnet/maui/pull/20417/files#r1484056859

/cc: @simonrozsival  @rmarinho 
