### PR TITLE
Remove Switch On/Off content

### DIFF
--- a/src/Core/src/Handlers/Switch/SwitchHandler.Windows.cs
+++ b/src/Core/src/Handlers/Switch/SwitchHandler.Windows.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Maui.Handlers
 {
 	public partial class SwitchHandler : ViewHandler<ISwitch, ToggleSwitch>
 	{
-		protected override ToggleSwitch CreatePlatformView() => new ToggleSwitch();
+		protected override ToggleSwitch CreatePlatformView() => new ToggleSwitch() { OffContent = null, OnContent = null };
 
 		public static void MapIsOn(ISwitchHandler handler, ISwitch view)
 		{

--- a/src/Core/tests/DeviceTests/Handlers/Switch/SwitchHandlerTests.Windows.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Switch/SwitchHandlerTests.Windows.cs
@@ -1,12 +1,30 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.Maui.DeviceTests.Stubs;
+using Xunit;
 using Color = Microsoft.Maui.Graphics.Color;
 
 namespace Microsoft.Maui.DeviceTests
 {
 	public partial class SwitchHandlerTests
 	{
+		[Fact(DisplayName = "On and Off Content is null")]
+		public async Task OnOffNullContent()
+		{
+			var switchStub = new SwitchStub()
+			{
+				IsOn = true
+			};
+			await AttachAndRun(switchStub, (handler) =>
+			{
+				var toggleSwitch = handler.PlatformView;
+				Assert.NotNull(toggleSwitch);
+				Assert.Null(toggleSwitch.OffContent);
+				Assert.Null(toggleSwitch.OnContent);
+			});
+		}
+
 		void SetIsOn(SwitchHandler switchHandler, bool value) =>
 			GetNativeSwitch(switchHandler).IsOn = value;
 


### PR DESCRIPTION
### Description of Change

Removes the default On/Off text on the Windows ToggleSwitch. This brings consistency with iOS and Android, and avoids issues with not being able to style the text.

### Issues Fixed

Fixes #20486

I've validated the fix with the Sandbox app. I'd love to add some unit tests too, but need a little guidance wrt where to put that, and how to verify that it no longer renders the text.
