### PR TITLE
[iOS] NullReferenceException for Span GridItemsLayout fix

### DIFF
--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issue19803.xaml
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issue19803.xaml
@@ -1,0 +1,33 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Maui.Controls.Sample.Issues.Issue19803"
+             x:Name="Page"
+             xmlns:ns="clr-namespace:Maui.Controls.Sample.Issues">
+    <Grid RowDefinitions="*, 48">
+        <CollectionView>
+            <CollectionView.ItemsLayout>
+                <GridItemsLayout Span="{Binding ColumnCount, Source={x:Reference Page}}" Orientation="Horizontal"/>
+            </CollectionView.ItemsLayout>
+            <CollectionView.ItemTemplate>
+                <DataTemplate>
+                    <Label Text="{Binding }"/>
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+            <CollectionView.ItemsSource>
+                <x:Array Type="{x:Type x:String}">
+                    <x:String>Item 1</x:String>
+                    <x:String>Item 2</x:String>
+                    <x:String>Item 3</x:String>
+                    <x:String>Item 4</x:String>
+                    <x:String>Item 5</x:String>
+                    <x:String>Item 6</x:String>
+                    <x:String>Item 7</x:String>
+                    <x:String>Item 8</x:String>
+                    <x:String>Item 9</x:String>
+                </x:Array>
+            </CollectionView.ItemsSource>
+        </CollectionView>
+        <Button AutomationId="button" Grid.Row="1" Clicked="UpdateColumnCount" Text="UpdateColumns"/>
+    </Grid>
+</ContentPage>

--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issue19803.xaml.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issue19803.xaml.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+
+namespace Maui.Controls.Sample.Issues
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	[Issue(IssueTracker.Github, 19803, "[iOS] Setting Binding on Span GridItemsLayout results in NullReferenceException", PlatformAffected.iOS)]
+	public partial class Issue19803 : ContentPage
+	{
+		public Issue19803()
+		{
+			InitializeComponent();
+			BindingContext = this;
+		}
+
+		public int ColumnCount { get; set; } = 3;
+
+		private void UpdateColumnCount(object sender, EventArgs e)
+		{
+			ColumnCount++;
+			Dispatcher.Dispatch(() =>
+			{
+				OnPropertyChanged(nameof(ColumnCount));
+			});
+		}
+	}
+}

--- a/src/Controls/src/Core/Handlers/Items/iOS/GridViewLayout.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/GridViewLayout.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		protected override void HandlePropertyChanged(PropertyChangedEventArgs propertyChanged)
 		{
-			if (propertyChanged.IsOneOf(GridItemsLayout.SpanProperty, GridItemsLayout.HorizontalItemSpacingProperty,
+			if (CollectionView != null && propertyChanged.IsOneOf(GridItemsLayout.SpanProperty, GridItemsLayout.HorizontalItemSpacingProperty,
 				GridItemsLayout.VerticalItemSpacingProperty))
 			{
 				// Update the constraints; ConstrainTo will pick up the new span

--- a/src/Controls/tests/UITests/Tests/Issues/Issue19803.cs
+++ b/src/Controls/tests/UITests/Tests/Issues/Issue19803.cs
@@ -1,0 +1,27 @@
+﻿using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.AppiumTests.Issues
+{
+	public class Issue19803 : _IssuesUITest
+	{
+		public Issue19803(TestDevice device) : base(device)
+		{
+		}
+
+		public override string Issue => "[iOS] Setting Binding on Span GridItemsLayout results in NullReferenceException";
+
+		[Test]
+		public void NoNREWhenChangingGridItemsLayout()
+		{
+			this.IgnoreIfPlatforms(new TestDevice[] { TestDevice.Android, TestDevice.Mac, TestDevice.Windows });
+
+			_ = App.WaitForElement("button");
+
+			//The test passes if no NullReferenceException is thrown
+			App.Click("button");
+
+		}
+	}
+}

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Bz18828.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Bz18828.xaml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+			 xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests"
+             x:Name="Page"
+			 x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Bz18828">
+    <StackLayout>
+        <Frame WidthRequest="320" x:Name="frame"/>
+        <CollectionView x:Name="collectionView">
+            <CollectionView.ItemsLayout>
+                <GridItemsLayout Orientation="Vertical"
+                                 Span="{Binding Source={x:Reference frame}, Path=WidthRequest, Converter={local:Bz18828Converter}}" />
+            </CollectionView.ItemsLayout>
+        </CollectionView>
+    </StackLayout>
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Bz18828.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Bz18828.xaml.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Globalization;
+using NUnit.Framework;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests
+{
+	public class Bz18828Converter : IValueConverter
+	{
+		public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+		{
+			if (value is double width)
+			{
+				int result = (int)Math.Floor(width / 160d);
+				return Math.Max(1, result);
+			}
+			else
+			{
+				return 1;
+			}
+		}
+
+		public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+		{
+			throw new NotImplementedException();
+		}
+	}
+
+	public partial class Bz18828 : ContentPage
+	{
+		public Bz18828()
+		{
+			InitializeComponent();
+		}
+
+		public Bz18828(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		class Tests
+		{
+			[TestCase(true)]
+			[TestCase(false)]
+			public void GridItemsLayoutWithConverter(bool useCompiledXaml)
+			{
+				var layout = new Bz18828(useCompiledXaml);
+				Assert.True(((GridItemsLayout)layout.collectionView.ItemsLayout).Span == 2);
+			}
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change

Added a null check

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/19803
Fixes https://github.com/dotnet/maui/issues/18828

|Demo|
|---|
|<video src="https://github.com/dotnet/maui/assets/42434498/2de8c8e3-803b-42e4-8bb0-8d8f7242b69d"/>|

