### PR TITLE
Temporarily Remove Tests

### DIFF
--- a/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.cs
@@ -720,7 +720,7 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
-		[Fact]
+		[Fact(Skip = "https://github.com/dotnet/maui/issues/20533")]
 		public async Task DoneClosesKeyboard()
 		{
 			EnsureHandlerCreated(builder =>

--- a/src/Core/tests/DeviceTests/Handlers/Switch/SwitchHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Switch/SwitchHandlerTests.cs
@@ -37,6 +37,8 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.Equal(0, fireCount);
 		}
 
+#if !WINDOWS
+// WINDOWS: https://github.com/dotnet/maui/issues/20535
 		[Theory(DisplayName = "Track Color Initializes Correctly")]
 		[InlineData(true)]
 		//[InlineData(false)] // Track color is not always visible when off
@@ -53,6 +55,7 @@ namespace Microsoft.Maui.DeviceTests
 				await ValidateTrackColor(switchStub, Colors.Red);
 			});
 		}
+#endif
 
 		[Fact(DisplayName = "Track Color Updates Correctly")]
 		public async Task TrackColorUpdatesCorrectly()

--- a/src/Core/tests/DeviceTests/Handlers/Switch/SwitchHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Switch/SwitchHandlerTests.cs
@@ -55,7 +55,6 @@ namespace Microsoft.Maui.DeviceTests
 				await ValidateTrackColor(switchStub, Colors.Red);
 			});
 		}
-#endif
 
 		[Fact(DisplayName = "Track Color Updates Correctly")]
 		public async Task TrackColorUpdatesCorrectly()
@@ -69,6 +68,7 @@ namespace Microsoft.Maui.DeviceTests
 				await ValidateTrackColor(switchStub, Colors.Red, () => switchStub.TrackColor = Colors.Red);
 			});
 		}
+#endif
 
 		[Fact(DisplayName = "ThumbColor Initializes Correctly", Skip = "There seems to be an issue, so disable for now: https://github.com/dotnet/maui/issues/1275")]
 		public async Task ThumbColorInitializesCorrectly()


### PR DESCRIPTION
### Description of Change

- We can move the android test to Appium
- The Windows tests is going to take some time until we can restructure how we run our tests a bit.
