### PR TITLE
Prepare the FabricBot config for migration to Policy Service

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -12,6 +12,10 @@
           "operator": "and",
           "operands": [
             {
+              "name": "isIssue",
+              "parameters": {}
+            },
+            {
               "name": "isAction",
               "parameters": {
                 "action": "created"
@@ -160,6 +164,10 @@
         "conditions": {
           "operator": "and",
           "operands": [
+            {
+              "name": "isIssue",
+              "parameters": {}
+            },
             {
               "name": "hasLabel",
               "parameters": {
@@ -2406,6 +2414,10 @@
         "conditions": {
           "operator": "and",
           "operands": [
+            {
+              "name": "isIssue",
+              "parameters": {}
+            },
             {
               "name": "hasLabel",
               "parameters": {

--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -149,8 +149,7 @@
         ],
         "eventType": "issue",
         "eventNames": [
-          "issues",
-          "project_card"
+          "issues"
         ]
       }
     },
@@ -999,8 +998,7 @@
         "eventType": "pull_request",
         "eventNames": [
           "pull_request",
-          "issues",
-          "project_card"
+          "issues"
         ],
         "taskName": "[Infrastructure PRs] Add area-infrastructure label to dependency update Pull Requests",
         "actions": [
@@ -1032,8 +1030,7 @@
         },
         "eventType": "issue",
         "eventNames": [
-          "issues",
-          "project_card"
+          "issues"
         ],
         "taskName": "Comment: Issue moved to Backlog",
         "actions": [
@@ -1066,8 +1063,7 @@
         "eventType": "pull_request",
         "eventNames": [
           "pull_request",
-          "issues",
-          "project_card"
+          "issues"
         ],
         "taskName": "Replace `s/needs-info` with `s/pr-needs-author-input` for PRs",
         "actions": [
@@ -1112,8 +1108,7 @@
         "eventType": "pull_request",
         "eventNames": [
           "pull_request",
-          "issues",
-          "project_card"
+          "issues"
         ],
         "taskName": "Remove `s/needs-repro` from PRs",
         "actions": [
@@ -1151,8 +1146,7 @@
         },
         "eventType": "issue",
         "eventNames": [
-          "issues",
-          "project_card"
+          "issues"
         ],
         "taskName": "Add comment when 's/needs-info' is applied to issue",
         "actions": [
@@ -1184,8 +1178,7 @@
         },
         "eventType": "issue",
         "eventNames": [
-          "issues",
-          "project_card"
+          "issues"
         ],
         "taskName": "Add comment when 's/needs-repro' is applied to issue",
         "actions": [
@@ -1349,8 +1342,7 @@
         },
         "eventType": "issue",
         "eventNames": [
-          "issues",
-          "project_card"
+          "issues"
         ],
         "taskName": "Add area/controls label when any 'control-X' label is applied to the issue",
         "actions": [
@@ -1515,8 +1507,7 @@
         "eventType": "pull_request",
         "eventNames": [
           "pull_request",
-          "issues",
-          "project_card"
+          "issues"
         ],
         "taskName": "Add area/controls label when any 'control-X' label is applied to the PR",
         "actions": [
@@ -1661,8 +1652,7 @@
         },
         "eventType": "issue",
         "eventNames": [
-          "issues",
-          "project_card"
+          "issues"
         ],
         "taskName": "Add 'partner' label when issue is opened by a partner",
         "actions": [
@@ -1698,8 +1688,7 @@
         },
         "eventType": "issue",
         "eventNames": [
-          "issues",
-          "project_card"
+          "issues"
         ],
         "taskName": "Ask user to use VS Feedback for VS issues",
         "actions": [
@@ -1749,8 +1738,7 @@
         },
         "eventType": "issue",
         "eventNames": [
-          "issues",
-          "project_card"
+          "issues"
         ],
         "taskName": "Add 'i/great-reporter' when issue is opened by an author we know opens high quality issues",
         "actions": [
@@ -1782,8 +1770,7 @@
         },
         "eventType": "issue",
         "eventNames": [
-          "issues",
-          "project_card"
+          "issues"
         ],
         "taskName": "Add comment when 's/try-latest-version' is applied to the issue",
         "actions": [
@@ -1935,8 +1922,7 @@
         "eventType": "pull_request",
         "eventNames": [
           "pull_request",
-          "issues",
-          "project_card"
+          "issues"
         ],
         "taskName": "Add 'community ✨' label to community contributions",
         "actions": [
@@ -2280,8 +2266,7 @@
         "eventType": "pull_request",
         "eventNames": [
           "pull_request",
-          "issues",
-          "project_card"
+          "issues"
         ],
         "taskName": "Revitalize stale PR and reopen",
         "actions": [
@@ -2324,8 +2309,7 @@
         "eventType": "pull_request",
         "eventNames": [
           "pull_request",
-          "issues",
-          "project_card"
+          "issues"
         ],
         "taskName": "Add comment when 's/pr-needs-author-input' is applied to PR",
         "actions": [
@@ -2357,8 +2341,7 @@
         },
         "eventType": "issue",
         "eventNames": [
-          "issues",
-          "project_card"
+          "issues"
         ],
         "taskName": "Tag Dave Britch when a breaking change is tagged on an issue",
         "actions": [
@@ -2391,8 +2374,7 @@
         "eventType": "pull_request",
         "eventNames": [
           "pull_request",
-          "issues",
-          "project_card"
+          "issues"
         ],
         "taskName": "Tag Dave Britch when a breaking change is tagged on an PR",
         "actions": [


### PR DESCRIPTION
Building on top of #20527, this updates the FabricBot configuration to address issues we've seen migrating other repositories to the Policy Service automation. There are no behavioral changes in this PR.

1. For issue comment events, explicitly filter to match issues and not pull requests. This was previously achieved via the `event_type` setting, but after the port, the explicit filter will be needed.
2. Remove references to project events.

/cc @mkArtakMSFT @wtgodbe 