### PR TITLE
[iOS] Adjust Keyboard Scrolling for Sticky Headers and Fix Bottom Content Inset

### DIFF
--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issue19956.xaml
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issue19956.xaml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Maui.Controls.Sample.Issues.Issue19956"
+             Title="Issue19956">
+
+    <Grid RowDefinitions="Auto,*">
+        <VerticalStackLayout
+            Grid.Row="0"
+            BackgroundColor="DarkOrange">
+            <Label
+                Margin="30"
+                HorizontalOptions="Center"
+                HorizontalTextAlignment="Center"
+                Text="Sticky header panel"
+                VerticalOptions="Center"
+                AutomationId="StickyHeader" />
+        </VerticalStackLayout>
+        <ScrollView Grid.Row="1">
+            <VerticalStackLayout
+                Padding="30,0"
+                Spacing="25">
+                <Label
+                    Text="1" />
+                <Entry ReturnType="Next" BackgroundColor="WhiteSmoke" AutomationId="Entry1" />
+                <Label
+                    Text="2" />
+                <Entry BackgroundColor="WhiteSmoke" AutomationId="Entry2" />
+                <Label
+                    Text="3" />
+                <Entry BackgroundColor="WhiteSmoke" AutomationId="Entry3"/>
+                <Label
+                    Text="4" />
+                <Entry BackgroundColor="WhiteSmoke" AutomationId="Entry4"/>
+                <Label
+                    Text="5" />
+                <Entry BackgroundColor="WhiteSmoke" AutomationId="Entry5"/>
+                <Label
+                    Text="6" />
+                <Entry BackgroundColor="WhiteSmoke" AutomationId="Entry6"/>
+                <Label
+                    Text="7" />
+                <Entry BackgroundColor="WhiteSmoke" AutomationId="Entry7"/>
+                <Label
+                    Text="8" />
+                <Entry BackgroundColor="WhiteSmoke" AutomationId="Entry8"/>
+                <Label
+                    Text="9" />
+                <Entry BackgroundColor="WhiteSmoke" AutomationId="Entry9"/>
+                <Label
+                    Text="10" />
+                <Entry ReturnType="Next" BackgroundColor="WhiteSmoke" AutomationId="Entry10"/>
+                <Label
+                    Text="11" />
+                <Entry BackgroundColor="WhiteSmoke" AutomationId="Entry11"/>
+                <Label
+                    Text="12" />
+                <Entry ReturnType="Next" BackgroundColor="WhiteSmoke" AutomationId="Entry12"/>
+            </VerticalStackLayout>
+        </ScrollView>
+    </Grid>
+</ContentPage>

--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issue19956.xaml.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issue19956.xaml.cs
@@ -1,0 +1,17 @@
+using System;
+using System.ComponentModel;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+
+namespace Maui.Controls.Sample.Issues
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	[Issue(IssueTracker.Github, 19956, "Sticky headers and bottom content insets", PlatformAffected.iOS)]
+	public partial class Issue19956 : ContentPage
+	{
+		public Issue19956()
+		{
+			InitializeComponent();
+		}
+	}
+}

--- a/src/Controls/tests/UITests/Tests/Issues/Issue19956.cs
+++ b/src/Controls/tests/UITests/Tests/Issues/Issue19956.cs
@@ -1,0 +1,93 @@
+﻿using System.Drawing;
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+using Microsoft.Maui.AppiumTests;
+using OpenQA.Selenium.Appium.MultiTouch;
+
+namespace Microsoft.Maui.AppiumTests.Issues;
+public class Issue19956: _IssuesUITest
+{
+    public Issue19956(TestDevice device) : base(device) { }
+
+    public override string Issue => "Sticky headers and bottom content insets";
+
+    [Test]
+    public void ContentAccountsForStickyHeaders()
+    {
+        this.IgnoreIfPlatforms(new TestDevice[] { TestDevice.Android, TestDevice.Mac, TestDevice.Windows },
+            "This is an iOS Keyboard Scrolling issue.");
+
+        var app = App as AppiumApp;
+        if (app is null)
+            return;
+
+        var stickyHeader = App.WaitForElement("StickyHeader");
+        var stickyHeaderRect = stickyHeader.GetRect();
+
+        // Scroll to the bottom of the page
+        var actions = new TouchAction(app.Driver);
+        actions.LongPress(null, 5, 650).MoveTo(null, 5, 100).Release().Perform();
+
+        app.Click("Entry12");
+        ValidateEntryPosition("Entry12", app, stickyHeaderRect);
+        ValidateEntryPosition("Entry1", app, stickyHeaderRect);
+        ValidateEntryPosition("Entry2", app, stickyHeaderRect);
+    }
+
+    void ValidateEntryPosition (string entryName, AppiumApp app, Rectangle stickyHeaderRect)
+    {
+        var entryRect = App.WaitForElement(entryName).GetRect();
+        var keyboardPos = KeyboardScrolling.FindiOSKeyboardLocation(app.Driver);
+
+        Assert.AreEqual(App.WaitForElement("StickyHeader").GetRect(), stickyHeaderRect);
+        Assert.Less(stickyHeaderRect.Bottom, entryRect.Top);
+        Assert.NotNull(keyboardPos);
+        Assert.Less(entryRect.Bottom, keyboardPos!.Value.Y);
+
+        KeyboardScrolling.NextiOSKeyboardPress(app.Driver);
+    }
+
+    [Test]
+    public void BottomInsetsSetCorrectly()
+    {
+        this.IgnoreIfPlatforms(new TestDevice[] { TestDevice.Android, TestDevice.Mac, TestDevice.Windows },
+            "This is an iOS Keyboard Scrolling issue.");
+
+        var app = App as AppiumApp;
+        if (app is null)
+            return;
+
+        app.Click("Entry5");
+        ScrollToBottom(app);
+        CheckForBottomEntry(app);
+        KeyboardScrolling.NextiOSKeyboardPress(app.Driver);
+
+        app.Click("Entry10");
+        ScrollToBottom(app);
+        CheckForBottomEntry(app);
+        KeyboardScrolling.NextiOSKeyboardPress(app.Driver);
+
+        ScrollToBottom(app);
+        CheckForBottomEntry(app);
+    }
+
+    static void ScrollToBottom(AppiumApp app)
+    {
+        var actions = new TouchAction(app.Driver);
+        // scroll up once to trigger resetting content insets
+        actions.LongPress(null, 5, 300).MoveTo(null, 5, 450).Release().Perform();
+        actions.LongPress(null, 5, 400).MoveTo(null, 5, 100).Release().Perform();
+
+        actions.LongPress(null, 5, 400).MoveTo(null, 5, 100).Release().Perform();
+        actions.LongPress(null, 5, 400).MoveTo(null, 5, 100).Release().Perform();
+    }
+
+    void CheckForBottomEntry (AppiumApp app)
+    {
+        var bottomEntryRect = App.WaitForElement("Entry12").GetRect();
+        var keyboardPosition = KeyboardScrolling.FindiOSKeyboardLocation(app.Driver);
+        Assert.NotNull(keyboardPosition);
+        Assert.Less(bottomEntryRect.Bottom, keyboardPosition!.Value.Y);
+    }
+}

--- a/src/Core/src/Platform/iOS/KeyboardAutoManagerScroll.cs
+++ b/src/Core/src/Platform/iOS/KeyboardAutoManagerScroll.cs
@@ -580,7 +580,7 @@ public static class KeyboardAutoManagerScroll
 			// ContentInset logic
 			if (ScrolledView is not null)
 			{
-				var bottomInset = ScrolledView.Bounds.Height + ScrolledView.ContentOffset.Y - ScrolledView.ContentSize.Height;
+				var bottomInset = kbSize.Height;
 				var bottomScrollIndicatorInset = bottomInset - TextViewDistanceFromBottom;
 
 				bottomInset = nfloat.Max(StartingContentInsets.Bottom, bottomInset);

--- a/src/Core/src/Platform/iOS/KeyboardAutoManagerScroll.cs
+++ b/src/Core/src/Platform/iOS/KeyboardAutoManagerScroll.cs
@@ -317,7 +317,7 @@ public static class KeyboardAutoManagerScroll
 		nfloat statusBarHeight;
 		nfloat navigationBarAreaHeight;
 
-		if (ContainerView.GetNavigationController() is UINavigationController navigationController)
+		if (ContainerView.FindResponder<UINavigationController>() is UINavigationController navigationController)
 		{
 			navigationBarAreaHeight = navigationController.NavigationBar.Frame.GetMaxY();
 		}
@@ -513,7 +513,7 @@ public static class KeyboardAutoManagerScroll
 
 					// if PrefersLargeTitles is true, we may need additional logic to
 					// handle the collapsable navbar
-					var navController = View?.GetNavigationController();
+					var navController = View?.FindResponder<UINavigationController>();
 					var prefersLargeTitles = navController?.NavigationBar.PrefersLargeTitles ?? false;
 
 					if (prefersLargeTitles)

--- a/src/Core/src/Platform/iOS/KeyboardAutoManagerScroll.cs
+++ b/src/Core/src/Platform/iOS/KeyboardAutoManagerScroll.cs
@@ -530,9 +530,6 @@ public static class KeyboardAutoManagerScroll
 
 					if ((!superScrollView.ContentOffset.Equals(newContentOffset) || innerScrollValue != 0) && superScrollViewRect is not null)
 					{
-						// if we can scroll the superScrollView and still not be above keyboard, pass scrolling to the parent
-						// superScrollViewRect = superScrollView.ConvertRectToView(superScrollView.Bounds, window);
-
 						if (nextScrollView is null && superScrollViewRect.Value.Y < bottomBoundary)
 						{
 							UIView.Animate(AnimationDuration, 0, UIViewAnimationOptions.CurveEaseOut, () =>

--- a/src/Core/src/Platform/iOS/KeyboardAutoManagerScroll.cs
+++ b/src/Core/src/Platform/iOS/KeyboardAutoManagerScroll.cs
@@ -32,7 +32,8 @@ public static class KeyboardAutoManagerScroll
 	static CGRect? CursorRect;
 	static CGRect? StartingContainerViewFrame;
 	internal static bool IsKeyboardShowing;
-	static int TextViewTopDistance = 20;
+	static int TextViewDistanceFromBottom = 20;
+	static int TextViewDistanceFromTop = 5;
 	static int DebounceCount;
 	static NSObject? WillShowToken;
 	static NSObject? WillHideToken;
@@ -330,7 +331,7 @@ public static class KeyboardAutoManagerScroll
 			navigationBarAreaHeight = statusBarHeight;
 		}
 
-		var topLayoutGuide = Math.Max(navigationBarAreaHeight, ContainerView.LayoutMargins.Top) + 5;
+		var topLayoutGuide = Math.Max(navigationBarAreaHeight, ContainerView.LayoutMargins.Top) + TextViewDistanceFromTop;
 
 		// calculate the cursor rect
 		var localCursor = FindLocalCursorPosition();
@@ -347,9 +348,9 @@ public static class KeyboardAutoManagerScroll
 
 		// give a small offset of 20 plus the cursor.Height for the distance
 		// between the selected text and the keyboard
-		TextViewTopDistance = ((int?)localCursor?.Height ?? 0) + 20;
+		TextViewDistanceFromBottom = ((int?)localCursor?.Height ?? 0) + 20;
 
-		var keyboardYPosition = window.Frame.Height - kbSize.Height - TextViewTopDistance;
+		var keyboardYPosition = window.Frame.Height - kbSize.Height - TextViewDistanceFromBottom;
 
 		// readjust contentInset when the textView height is too large for the screen
 		var rootSuperViewFrameInWindow = window.Frame;
@@ -363,12 +364,26 @@ public static class KeyboardAutoManagerScroll
 		bool cursorTooHigh = false;
 		bool cursorTooLow = false;
 
+		// Find the next parent ScrollView that is scrollable
+		var superView = View.FindResponder<UIScrollView>();
+		var superScrollView = FindParentScroll(superView);
+
+		CGRect? superScrollViewRect = null;
+		var topBoundary = topLayoutGuide;
+		var bottomBoundary = (double)keyboardYPosition;
+
+		if (superScrollView is not null){
+			superScrollViewRect = superScrollView.ConvertRectToView(superScrollView.Bounds, window);
+			topBoundary = Math.Max(topBoundary, superScrollViewRect.Value.Top + TextViewDistanceFromTop);
+			bottomBoundary = Math.Min(bottomBoundary, superScrollViewRect.Value.Bottom - TextViewDistanceFromBottom);
+		}
+
 		// scenario where we go into an editor with the "Next" keyboard button,
 		// but the cursor location on the editor is scrolled below the visible section
 		if (View is UITextView && cursorRect.Y >= viewRectInWindow.GetMaxY())
 		{
 			cursorNotInViewScroll = viewRectInWindow.GetMaxY() - cursorRect.GetMaxY();
-			move = cursorRect.Y - keyboardYPosition + cursorNotInViewScroll;
+			move = cursorRect.Y - (nfloat)bottomBoundary + cursorNotInViewScroll;
 			cursorTooLow = true;
 		}
 
@@ -377,7 +392,7 @@ public static class KeyboardAutoManagerScroll
 		else if (View is UITextView && cursorRect.Y < viewRectInWindow.GetMinY())
 		{
 			cursorNotInViewScroll = viewRectInWindow.GetMinY() - cursorRect.Y;
-			move = cursorRect.Y - keyboardYPosition + cursorNotInViewScroll;
+			move = cursorRect.Y - (nfloat)bottomBoundary + cursorNotInViewScroll;
 			cursorTooHigh = true;
 
 			// no need to move the screen down if we can already see the view
@@ -385,18 +400,14 @@ public static class KeyboardAutoManagerScroll
 				move = 0;
 		}
 
-		else if (cursorRect.Y >= topLayoutGuide && cursorRect.Y < keyboardYPosition)
+		else if (cursorRect.Y >= topBoundary && cursorRect.Y < bottomBoundary)
 			return;
 
-		else if (cursorRect.Y > keyboardYPosition)
-			move = cursorRect.Y - keyboardYPosition;
+		else if (cursorRect.Y > bottomBoundary)
+			move = cursorRect.Y - (nfloat)bottomBoundary;
 
-		else if (cursorRect.Y <= topLayoutGuide)
-			move = cursorRect.Y - (nfloat)topLayoutGuide;
-
-		// Find the next parent ScrollView that is scrollable
-		var superView = View.FindResponder<UIScrollView>();
-		var superScrollView = FindParentScroll(superView);
+		else if (cursorRect.Y <= topBoundary)
+			move = cursorRect.Y - (nfloat)topBoundary;
 
 		// This is the case when the keyboard is already showing and we click another editor/entry
 		if (LastScrollView is not null)
@@ -458,7 +469,7 @@ public static class KeyboardAutoManagerScroll
 						if (!previousCellRect.IsEmpty)
 						{
 							var previousCellRectInRootSuperview = tableView.ConvertRectToView(previousCellRect, ContainerView.Superview);
-							move = (nfloat)Math.Min(0, previousCellRectInRootSuperview.GetMaxY() - topLayoutGuide);
+							move = (nfloat)Math.Min(0, previousCellRectInRootSuperview.GetMaxY() - topBoundary);
 						}
 					}
 				}
@@ -477,7 +488,7 @@ public static class KeyboardAutoManagerScroll
 						if (!previousCellRect.IsEmpty)
 						{
 							var previousCellRectInRootSuperview = collectionView.ConvertRectToView(previousCellRect, ContainerView.Superview);
-							move = (nfloat)Math.Min(0, previousCellRectInRootSuperview.GetMaxY() - topLayoutGuide);
+							move = (nfloat)Math.Min(0, previousCellRectInRootSuperview.GetMaxY() - topBoundary);
 						}
 					}
 				}
@@ -485,13 +496,13 @@ public static class KeyboardAutoManagerScroll
 				else
 				{
 					shouldContinue = !(innerScrollValue == 0
-						&& cursorRect.Y + cursorNotInViewScroll >= topLayoutGuide
-						&& cursorRect.Y + cursorNotInViewScroll <= keyboardYPosition);
+						&& cursorRect.Y + cursorNotInViewScroll >= topBoundary
+						&& cursorRect.Y + cursorNotInViewScroll <= bottomBoundary);
 
-					if (cursorRect.Y - innerScrollValue < topLayoutGuide && !cursorTooHigh)
-						move = cursorRect.Y - innerScrollValue - (nfloat)topLayoutGuide;
-					else if (cursorRect.Y - innerScrollValue > keyboardYPosition && !cursorTooLow)
-						move = cursorRect.Y - innerScrollValue - keyboardYPosition;
+					if (cursorRect.Y - innerScrollValue < topBoundary && !cursorTooHigh)
+						move = cursorRect.Y - innerScrollValue - (nfloat)topBoundary;
+					else if (cursorRect.Y - innerScrollValue > bottomBoundary && !cursorTooLow)
+						move = cursorRect.Y - innerScrollValue - (nfloat)bottomBoundary;
 				}
 
 				// Go up the hierarchy and look for other scrollViews until we reach the UIWindow
@@ -517,12 +528,12 @@ public static class KeyboardAutoManagerScroll
 
 					var newContentOffset = new CGPoint(superScrollView.ContentOffset.X, shouldOffsetY);
 
-					if (!superScrollView.ContentOffset.Equals(newContentOffset) || innerScrollValue != 0)
+					if ((!superScrollView.ContentOffset.Equals(newContentOffset) || innerScrollValue != 0) && superScrollViewRect is not null)
 					{
 						// if we can scroll the superScrollView and still not be above keyboard, pass scrolling to the parent
-						var superScrollViewRect = superScrollView.ConvertRectToView(superScrollView.Bounds, window);
+						// superScrollViewRect = superScrollView.ConvertRectToView(superScrollView.Bounds, window);
 
-						if (nextScrollView is null && superScrollViewRect.Y < keyboardYPosition)
+						if (nextScrollView is null && superScrollViewRect.Value.Y < bottomBoundary)
 						{
 							UIView.Animate(AnimationDuration, 0, UIViewAnimationOptions.CurveEaseOut, () =>
 							{
@@ -570,7 +581,7 @@ public static class KeyboardAutoManagerScroll
 			if (ScrolledView is not null)
 			{
 				var bottomInset = ScrolledView.Bounds.Height + ScrolledView.ContentOffset.Y - ScrolledView.ContentSize.Height;
-				var bottomScrollIndicatorInset = bottomInset - TextViewTopDistance;
+				var bottomScrollIndicatorInset = bottomInset - TextViewDistanceFromBottom;
 
 				bottomInset = nfloat.Max(StartingContentInsets.Bottom, bottomInset);
 				bottomScrollIndicatorInset = nfloat.Max(StartingScrollIndicatorInsets.Bottom, bottomScrollIndicatorInset);
@@ -591,7 +602,7 @@ public static class KeyboardAutoManagerScroll
 
 		if (move >= 0)
 		{
-			rootViewOrigin.Y = (nfloat)Math.Max(rootViewOrigin.Y - move, Math.Min(0, -kbSize.Height - TextViewTopDistance));
+			rootViewOrigin.Y = (nfloat)Math.Max(rootViewOrigin.Y - move, Math.Min(0, -kbSize.Height - TextViewDistanceFromBottom));
 
 			if (ContainerView.Frame.X != rootViewOrigin.X || ContainerView.Frame.Y != rootViewOrigin.Y)
 			{


### PR DESCRIPTION
### Description of Change

This PR fixes two different issues regarding the iOS Keyboard Scrolling.

1. If there is a "Sticky Header" or some other view above the scrollview, sometimes, the content would not take that in account and scroll the entry behind this header. The fix for this includes calculating the size of the scrollview and compare that to the standard boundaries of the navbar and status bar on the top, and the keyboard on the bottom.

| Before | After |
| -- | -- |
| <video width="300" src="https://github.com/dotnet/maui/assets/50846373/ce15f118-1620-493d-8cb5-dbd6e994f7e9"> | <video width="300" src="https://github.com/dotnet/maui/assets/50846373/84df1a57-ff79-496f-a707-531943ff6075"> |


2. When scrolling occurs on an entry or editor, we are not able to scroll to the bottom of the scrollview when the keyboard is still open. The fix for this one was changing the previous calculation on the content inset bottom to the size of the keyboard. Sometimes, simpler is better :)

| Before | After |
| -- | -- |
| <video width="300" src="https://github.com/dotnet/maui/assets/50846373/b3c01d0b-e03b-4f60-9be0-e7e10590f85c"> | <video width="300" src="https://github.com/dotnet/maui/assets/50846373/80ae10df-64a7-4426-a2f3-2b6b7e065fab"> |


### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #19956
Fixes #20200

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
