### PR TITLE
[XC] split warnings on ',' and ';'

### DIFF
--- a/src/Controls/src/Build.Tasks/XamlCTask.cs
+++ b/src/Controls/src/Build.Tasks/XamlCTask.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 			Context.WarningLevel = warningLevel;
 			Context.TreatWarningsAsErrors = treatWarningsAsErrors;
 
-			Context.NoWarn = noWarn?.Split([';'], StringSplitOptions.RemoveEmptyEntries).Select(s =>
+			Context.NoWarn = noWarn?.Split([';', ','], StringSplitOptions.RemoveEmptyEntries).Select(s =>
 			{
 				if (int.TryParse(s, out var i))
 					return i;
@@ -50,7 +50,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 				return -1;
 			}).Where(i => i != -1).ToList();
 
-			Context.WarningsAsErrors = warningsAsErrors?.Split([';'], StringSplitOptions.RemoveEmptyEntries).Select(s =>
+			Context.WarningsAsErrors = warningsAsErrors?.Split([';', ','], StringSplitOptions.RemoveEmptyEntries).Select(s =>
 			{
 				if (int.TryParse(s, out var i))
 					return i;
@@ -63,7 +63,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 				return -1;
 			}).Where(i => i != -1).ToList();
 
-			Context.WarningsNotAsErrors = warningsNotAsErrors?.Split([';'], StringSplitOptions.RemoveEmptyEntries).Select(s =>
+			Context.WarningsNotAsErrors = warningsNotAsErrors?.Split([';', ','], StringSplitOptions.RemoveEmptyEntries).Select(s =>
 			{
 				if (int.TryParse(s, out var i))
 					return i;

--- a/src/Controls/tests/Xaml.UnitTests/Controls.Xaml.UnitTests.csproj
+++ b/src/Controls/tests/Xaml.UnitTests/Controls.Xaml.UnitTests.csproj
@@ -6,7 +6,7 @@
     <AssemblyName>Microsoft.Maui.Controls.Xaml.UnitTests</AssemblyName>
     <WarningLevel>4</WarningLevel>
     <NoWarn>$(NoWarn);0672;0219;0414;CS0436;CS0618</NoWarn>
-    <WarningsNotAsErrors>$(WarningsNotAsErrors);XC0618;XC0022;XC0023</WarningsNotAsErrors>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);XC0618;XC0022,XC0023</WarningsNotAsErrors>
     <IsPackable>false</IsPackable>
     <DisableMSBuildAssemblyCopyCheck>true</DisableMSBuildAssemblyCopyCheck>
   </PropertyGroup>


### PR DESCRIPTION
### Description of Change

[XC] split warnings on ',' and ';'

### Issues Fixed

- fixes #20568


<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
