### PR TITLE
[testing] Ignore flacky tests on iOS17

### DIFF
--- a/src/Controls/tests/UITests/Tests/Issues/Issue17022.cs
+++ b/src/Controls/tests/UITests/Tests/Issues/Issue17022.cs
@@ -52,9 +52,13 @@ namespace Microsoft.Maui.AppiumTests.Issues
                 else
                 {
                     if (isTopOfScreen)
+                    {
                         Assert.AreEqual(rect.Y, 0);
+                    }
                     else
+                    {
                         Assert.AreNotEqual(rect.Y, 0);
+                    }
                 }
             }
             catch 

--- a/src/Controls/tests/UITests/Tests/Issues/Issue18751.cs
+++ b/src/Controls/tests/UITests/Tests/Issues/Issue18751.cs
@@ -12,19 +12,19 @@ namespace Microsoft.Maui.AppiumTests.Issues
 
 		public override string Issue => "Can scroll CollectionView inside RefreshView";
 
-		[Test]
-		public async Task Issue18751Test()
-		{
-			this.IgnoreIfPlatforms(new TestDevice[] { TestDevice.Windows },
-				"Currently fails on Windows; see https://github.com/dotnet/maui/issues/15994");
+		// [Test]
+		// public async Task Issue18751Test()
+		// {
+		// 	this.IgnoreIfPlatforms(new TestDevice[] { TestDevice.Windows },
+		// 		"Currently fails on Windows; see https://github.com/dotnet/maui/issues/15994");
 
-			App.WaitForElement("WaitForStubControl");
+		// 	App.WaitForElement("WaitForStubControl");
 
-			// Load images.
-			await Task.Delay(1000);
+		// 	// Load images.
+		// 	await Task.Delay(1000);
 
-			// The test passes if you are able to see the image, name, and location of each monkey.
-			VerifyScreenshot();
-		}
+		// 	// The test passes if you are able to see the image, name, and location of each monkey.
+		// 	VerifyScreenshot();
+		// }
 	}
 }

--- a/src/Controls/tests/UITests/Tests/Issues/Issue18751.cs
+++ b/src/Controls/tests/UITests/Tests/Issues/Issue18751.cs
@@ -12,19 +12,20 @@ namespace Microsoft.Maui.AppiumTests.Issues
 
 		public override string Issue => "Can scroll CollectionView inside RefreshView";
 
-		// [Test]
-		// public async Task Issue18751Test()
-		// {
-		// 	this.IgnoreIfPlatforms(new TestDevice[] { TestDevice.Windows },
-		// 		"Currently fails on Windows; see https://github.com/dotnet/maui/issues/15994");
+		[Test]
+		[Ignore("This test is failing on iOS17, https://github.com/dotnet/maui/issues/20582")]
+		public async Task Issue18751Test()
+		{
+			this.IgnoreIfPlatforms(new TestDevice[] { TestDevice.Windows },
+				"Currently fails on Windows; see https://github.com/dotnet/maui/issues/15994");
 
-		// 	App.WaitForElement("WaitForStubControl");
+			App.WaitForElement("WaitForStubControl");
 
-		// 	// Load images.
-		// 	await Task.Delay(1000);
+			// Load images.
+			await Task.Delay(1000);
 
-		// 	// The test passes if you are able to see the image, name, and location of each monkey.
-		// 	VerifyScreenshot();
-		// }
+			// The test passes if you are able to see the image, name, and location of each monkey.
+			VerifyScreenshot();
+		}
 	}
 }

--- a/src/Controls/tests/UITests/Tests/KeyboardScrollingNonScrollingPageSmallTitlesTests.cs
+++ b/src/Controls/tests/UITests/Tests/KeyboardScrollingNonScrollingPageSmallTitlesTests.cs
@@ -24,25 +24,25 @@ namespace Microsoft.Maui.AppiumTests
 			this.Back();
 		}
 
-		[Test]
-		public void EntriesScrollingPageTest()
-		{
-			this.IgnoreIfPlatforms(new TestDevice[] { TestDevice.Android, TestDevice.Mac, TestDevice.Windows }, KeyboardScrolling.IgnoreMessage);
-			KeyboardScrolling.EntriesScrollingTest(App, KeyboardScrollingGallery);
-		}
+		// [Test]
+		// public void EntriesScrollingPageTest()
+		// {
+		// 	this.IgnoreIfPlatforms(new TestDevice[] { TestDevice.Android, TestDevice.Mac, TestDevice.Windows }, KeyboardScrolling.IgnoreMessage);
+		// 	KeyboardScrolling.EntriesScrollingTest(App, KeyboardScrollingGallery);
+		// }
 
-		[Test]
-		public void EditorsScrollingPageTest()
-		{
-			this.IgnoreIfPlatforms(new TestDevice[] { TestDevice.Android, TestDevice.Mac, TestDevice.Windows }, KeyboardScrolling.IgnoreMessage);
-			KeyboardScrolling.EditorsScrollingTest(App, KeyboardScrollingGallery);
-		}
+		// [Test]
+		// public void EditorsScrollingPageTest()
+		// {
+		// 	this.IgnoreIfPlatforms(new TestDevice[] { TestDevice.Android, TestDevice.Mac, TestDevice.Windows }, KeyboardScrolling.IgnoreMessage);
+		// 	KeyboardScrolling.EditorsScrollingTest(App, KeyboardScrollingGallery);
+		// }
 
-		[Test]
-		public void EntryNextEditorTest()
-		{
-			this.IgnoreIfPlatforms(new TestDevice[] { TestDevice.Android, TestDevice.Mac, TestDevice.Windows }, KeyboardScrolling.IgnoreMessage);
-			KeyboardScrolling.EntryNextEditorScrollingTest(App, KeyboardScrollingGallery);
-		}
+		// [Test]
+		// public void EntryNextEditorTest()
+		// {
+		// 	this.IgnoreIfPlatforms(new TestDevice[] { TestDevice.Android, TestDevice.Mac, TestDevice.Windows }, KeyboardScrolling.IgnoreMessage);
+		// 	KeyboardScrolling.EntryNextEditorScrollingTest(App, KeyboardScrollingGallery);
+		// }
 	}
 }

--- a/src/Controls/tests/UITests/Tests/KeyboardScrollingScrollingPageLargeTitlesTests.cs
+++ b/src/Controls/tests/UITests/Tests/KeyboardScrollingScrollingPageLargeTitlesTests.cs
@@ -24,25 +24,25 @@ namespace Microsoft.Maui.AppiumTests
 			this.Back();
 		}
 
-		[Test]
-		public void EntriesScrollingPageTest()
-		{
-			this.IgnoreIfPlatforms(new TestDevice[] { TestDevice.Android, TestDevice.Mac, TestDevice.Windows }, KeyboardScrolling.IgnoreMessage);
-			KeyboardScrolling.EntriesScrollingTest(App, KeyboardScrollingGallery);
-		}
+		// [Test]
+		// public void EntriesScrollingPageTest()
+		// {
+		// 	this.IgnoreIfPlatforms(new TestDevice[] { TestDevice.Android, TestDevice.Mac, TestDevice.Windows }, KeyboardScrolling.IgnoreMessage);
+		// 	KeyboardScrolling.EntriesScrollingTest(App, KeyboardScrollingGallery);
+		// }
 
-		[Test]
-		public void EditorsScrollingPageTest()
-		{
-			this.IgnoreIfPlatforms(new TestDevice[] { TestDevice.Android, TestDevice.Mac, TestDevice.Windows }, KeyboardScrolling.IgnoreMessage);
-			KeyboardScrolling.EditorsScrollingTest(App, KeyboardScrollingGallery);
-		}
+		// [Test]
+		// public void EditorsScrollingPageTest()
+		// {
+		// 	this.IgnoreIfPlatforms(new TestDevice[] { TestDevice.Android, TestDevice.Mac, TestDevice.Windows }, KeyboardScrolling.IgnoreMessage);
+		// 	KeyboardScrolling.EditorsScrollingTest(App, KeyboardScrollingGallery);
+		// }
 
-		[Test]
-		public void EntryNextEditorTest()
-		{
-			this.IgnoreIfPlatforms(new TestDevice[] { TestDevice.Android, TestDevice.Mac, TestDevice.Windows }, KeyboardScrolling.IgnoreMessage);
-			KeyboardScrolling.EntryNextEditorScrollingTest(App, KeyboardScrollingGallery);
-		}
+		// [Test]
+		// public void EntryNextEditorTest()
+		// {
+		// 	this.IgnoreIfPlatforms(new TestDevice[] { TestDevice.Android, TestDevice.Mac, TestDevice.Windows }, KeyboardScrolling.IgnoreMessage);
+		// 	KeyboardScrolling.EntryNextEditorScrollingTest(App, KeyboardScrollingGallery);
+		// }
 	}
 }

--- a/src/Controls/tests/UITests/Tests/KeyboardScrollingScrollingPageSmallTitlesTests.cs
+++ b/src/Controls/tests/UITests/Tests/KeyboardScrollingScrollingPageSmallTitlesTests.cs
@@ -24,25 +24,25 @@ namespace Microsoft.Maui.AppiumTests
 			this.Back();
 		}
 
-		[Test]
-		public void EntriesScrollingPageTest()
-		{
-			this.IgnoreIfPlatforms(new TestDevice[] { TestDevice.Android, TestDevice.Mac, TestDevice.Windows }, KeyboardScrolling.IgnoreMessage);
-			KeyboardScrolling.EntriesScrollingTest(App, KeyboardScrollingGallery);
-		}
+		// [Test]
+		// public void EntriesScrollingPageTest()
+		// {
+		// 	this.IgnoreIfPlatforms(new TestDevice[] { TestDevice.Android, TestDevice.Mac, TestDevice.Windows }, KeyboardScrolling.IgnoreMessage);
+		// 	KeyboardScrolling.EntriesScrollingTest(App, KeyboardScrollingGallery);
+		// }
 
-		[Test]
-		public void EditorsScrollingPageTest()
-		{
-			this.IgnoreIfPlatforms(new TestDevice[] { TestDevice.Android, TestDevice.Mac, TestDevice.Windows }, KeyboardScrolling.IgnoreMessage);
-			KeyboardScrolling.EditorsScrollingTest(App, KeyboardScrollingGallery);
-		}
+		// [Test]
+		// public void EditorsScrollingPageTest()
+		// {
+		// 	this.IgnoreIfPlatforms(new TestDevice[] { TestDevice.Android, TestDevice.Mac, TestDevice.Windows }, KeyboardScrolling.IgnoreMessage);
+		// 	KeyboardScrolling.EditorsScrollingTest(App, KeyboardScrollingGallery);
+		// }
 
-		[Test]
-		public void EntryNextEditorTest()
-		{
-			this.IgnoreIfPlatforms(new TestDevice[] { TestDevice.Android, TestDevice.Mac, TestDevice.Windows }, KeyboardScrolling.IgnoreMessage);
-			KeyboardScrolling.EntryNextEditorScrollingTest(App, KeyboardScrollingGallery);
-		}
+		// [Test]
+		// public void EntryNextEditorTest()
+		// {
+		// 	this.IgnoreIfPlatforms(new TestDevice[] { TestDevice.Android, TestDevice.Mac, TestDevice.Windows }, KeyboardScrolling.IgnoreMessage);
+		// 	KeyboardScrolling.EntryNextEditorScrollingTest(App, KeyboardScrollingGallery);
+		// }
 	}
 }


### PR DESCRIPTION
### Description of Change

These tests seem to fail on iOS17, we are going to disable for now and look at them better and renable. 

- Some of the keyboard were already disabled here https://github.com/dotnet/maui/issues/20496 @tj-devel709  will take a look 
- New issue for test #18751 to be reenabled . Seems the visual comparison fails because of the bottom notch has a different color, maybe we should crop the bottom @BretJohnson  ? https://github.com/dotnet/maui/issues/20582