### PR TITLE
[iOS] Double dash in input field crash fix

### DIFF
--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issue20439.xaml
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issue20439.xaml
@@ -1,0 +1,25 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Shell xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Maui.Controls.Sample.Issues.Issue20439"
+             xmlns:ns="clr-namespace:Maui.Controls.Sample.Issues">
+    <ShellContent
+            Title="Home">
+            <ContentPage>
+                <StackLayout VerticalOptions="Center">
+                    <Entry AutomationId="entry" Text="Tap here"/>
+                    <Button AutomationId="button" Text="Open the input page" Clicked="Button_Clicked"/>
+                </StackLayout>
+            </ContentPage>
+        </ShellContent>
+
+        <ShellContent
+            Title="Text input page">
+            <ContentPage>
+                   <Editor VerticalOptions="Center"
+                           AutomationId="editor"
+                           HeightRequest="100"
+                           Text="Potential auto correcting words: -- :-) ... omw \n" />
+            </ContentPage>
+        </ShellContent>
+</Shell>

--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issue20439.xaml.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issue20439.xaml.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+
+namespace Maui.Controls.Sample.Issues
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	[Issue(IssueTracker.Github, 20439, "[iOS] Double dash in Entry or Editor crashes the app", PlatformAffected.iOS)]
+	public partial class Issue20439 : Shell
+	{
+		public Issue20439()
+		{
+			InitializeComponent();
+		}
+
+		void Button_Clicked(object sender, System.EventArgs e)
+		{
+			CurrentItem = Items[1];
+		}
+	}
+}

--- a/src/Controls/src/Core/Platform/iOS/Extensions/TextExtensions.cs
+++ b/src/Controls/src/Core/Platform/iOS/Extensions/TextExtensions.cs
@@ -41,6 +41,12 @@ namespace Microsoft.Maui.Controls.Platform
 			// position if needed when the text was modified by a Converter.
 			var textRange = textInput.GetTextRange(textInput.BeginningOfDocument, textInput.EndOfDocument);
 			var oldText = textInput.TextInRange(textRange) ?? string.Empty;
+
+			// We need this variable because in some cases because of the iOS's
+			// auto correction eg. eg '--' => '—' the actual text in the input might have
+			// a different length that the one that has been set in the control.
+			var newTextLength = textInput.TextInRange(textRange)?.Length ?? 0;
+
 			var newText = TextTransformUtilites.GetTransformedText(
 				inputView?.Text,
 				textInput.GetSecureTextEntry() ? TextTransform.Default : inputView.TextTransform
@@ -50,8 +56,8 @@ namespace Microsoft.Maui.Controls.Platform
 			{
 				// Re-calculate the cursor offset position if the text was modified by a Converter.
 				// but if the text is being set by code, let's just move the cursor to the end.
-				var cursorOffset = newText.Length - oldText.Length;
-				var cursorPosition = isEditing ? textInput.GetCursorPosition(cursorOffset) : newText.Length;
+				var cursorOffset = newTextLength - oldText.Length;
+				var cursorPosition = isEditing ? textInput.GetCursorPosition(cursorOffset) : newTextLength;
 
 				textInput.ReplaceText(textRange, newText);
 

--- a/src/Controls/src/Core/Platform/iOS/Extensions/TextExtensions.cs
+++ b/src/Controls/src/Core/Platform/iOS/Extensions/TextExtensions.cs
@@ -45,12 +45,15 @@ namespace Microsoft.Maui.Controls.Platform
 			// We need this variable because in some cases because of the iOS's
 			// auto correction eg. eg '--' => '—' the actual text in the input might have
 			// a different length that the one that has been set in the control.
-			var newTextLength = textInput.TextInRange(textRange)?.Length ?? 0;
+			var newTextLength = !string.IsNullOrWhiteSpace(inputView.Text) ? textInput.TextInRange(textRange)?.Length ?? 0 : 0;
 
 			var newText = TextTransformUtilites.GetTransformedText(
 				inputView?.Text,
 				textInput.GetSecureTextEntry() ? TextTransform.Default : inputView.TextTransform
 				);
+
+			if (!string.IsNullOrWhiteSpace(oldText))
+				newTextLength = newText.Length;
 
 			if (oldText != newText)
 			{

--- a/src/Controls/tests/UITests/Tests/Issues/Issue20439.cs
+++ b/src/Controls/tests/UITests/Tests/Issues/Issue20439.cs
@@ -1,0 +1,28 @@
+﻿using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.AppiumTests.Issues
+{
+	public class Issue20439 : _IssuesUITest
+	{
+		public override string Issue => "[iOS] Double dash in Entry or Editor crashes the app";
+
+		public Issue20439(TestDevice device) : base(device)
+		{
+		}
+
+		[Test]
+		public void ErrorShouldNotBeThrown()
+		{
+			this.IgnoreIfPlatforms(new TestDevice[] { TestDevice.Android, TestDevice.Mac, TestDevice.Windows });
+
+			_ = App.WaitForElement("entry");
+			App.Click("entry");
+			App.Click("button");
+
+			// The test passes if no crash is observed
+			App.FindElement("editor");
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change

Using the length of the text based on the value from the iOS's text input rather than a control. It is because of the system's autocorrection that converts some combinations of characters into other symbols.

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/20439
Fixes https://github.com/dotnet/maui/issues/19954
Fixes https://github.com/dotnet/maui/issues/15937

|Before|After|
|--|--|
|<video src="https://github.com/dotnet/maui/assets/42434498/f6f1d252-3022-4591-9b80-597a8e6ccc2b"/>|<video src="https://github.com/dotnet/maui/assets/42434498/5a3fec83-10fa-4c19-9a23-9a911211a720" />|



