### PR TITLE
[CI] Fix template to get it back to work with the megapipeline.

### DIFF
--- a/eng/pipelines/common/maui-templates.yml
+++ b/eng/pipelines/common/maui-templates.yml
@@ -104,6 +104,7 @@ jobs:
 
   - pwsh: ./build.ps1 --target=dotnet-integration-build --verbosity=diagnostic
     displayName: Build Microsoft.Maui.IntegrationTests
+    workingDirectory: ${{ parameters.checkoutDirectory }}
 
   - pwsh: ./build.ps1 --target=dotnet-integration-test --filter="FullyQualifiedName=Microsoft.Maui.IntegrationTests.TemplateTests" --resultsfilename="integration-tests" --verbosity=diagnostic
     displayName: Run $(PLATFORM_NAME) templates build tests

--- a/eng/pipelines/common/maui-templates.yml
+++ b/eng/pipelines/common/maui-templates.yml
@@ -108,6 +108,7 @@ jobs:
 
   - pwsh: ./build.ps1 --target=dotnet-integration-test --filter="FullyQualifiedName=Microsoft.Maui.IntegrationTests.TemplateTests" --resultsfilename="integration-tests" --verbosity=diagnostic
     displayName: Run $(PLATFORM_NAME) templates build tests
+    workingDirectory: ${{ parameters.checkoutDirectory }}
 
   - task: PublishTestResults@2
     displayName: Publish the $(PLATFORM_NAME) templates build tests


### PR DESCRIPTION
The template has a parameter that allows to know the checkout location, that allow use to reuse it in the megapiepline. The new step was added ignoring that fact.


Sample failure due to the new step:  https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=9075626&view=logs&j=62ecfeaa-0bce-5196-414b-0bff00ed26b7&t=26d5aeb6-6bdb-5c57-8c74-4cf8c1fa3546 