### PR TITLE
SwipeGestureRecognizer return actual detected directions

### DIFF
--- a/src/Controls/src/Core/SwipeGestureRecognizer.cs
+++ b/src/Controls/src/Core/SwipeGestureRecognizer.cs
@@ -65,29 +65,35 @@ namespace Microsoft.Maui.Controls
 			var detected = false;
 			var threshold = Threshold;
 
+			var detectedDirection = (SwipeDirection)(0);
+
 			if (direction.IsLeft())
 			{
 				detected |= _totalX < -threshold;
+				detectedDirection |= SwipeDirection.Left;
 			}
 
 			if (direction.IsRight())
 			{
 				detected |= _totalX > threshold;
+				detectedDirection |= SwipeDirection.Right;
 			}
 
 			if (direction.IsDown())
 			{
 				detected |= _totalY > threshold;
+				detectedDirection |= SwipeDirection.Down;
 			}
 
 			if (direction.IsUp())
 			{
 				detected |= _totalY < -threshold;
+				detectedDirection |= SwipeDirection.Up;
 			}
 
 			if (detected)
 			{
-				SendSwiped(sender, direction);
+				SendSwiped(sender, detectedDirection);
 			}
 
 			return detected;

--- a/src/Controls/src/Core/SwipeGestureRecognizer.cs
+++ b/src/Controls/src/Core/SwipeGestureRecognizer.cs
@@ -69,26 +69,38 @@ namespace Microsoft.Maui.Controls
 
 			if (direction.IsLeft())
 			{
-				detected |= _totalX < -threshold;
-				detectedDirection |= SwipeDirection.Left;
+				if (_totalX < -threshold)
+				{
+					detected = true;
+					detectedDirection |= SwipeDirection.Left;
+				}
 			}
 
 			if (direction.IsRight())
 			{
-				detected |= _totalX > threshold;
-				detectedDirection |= SwipeDirection.Right;
+				if (_totalX > threshold)
+				{
+					detected = true;
+					detectedDirection |= SwipeDirection.Right;
+				}
 			}
 
 			if (direction.IsDown())
 			{
-				detected |= _totalY > threshold;
-				detectedDirection |= SwipeDirection.Down;
+				if (_totalY > threshold)
+				{
+					detected = true;
+					detectedDirection |= SwipeDirection.Down;
+				}
 			}
 
 			if (direction.IsUp())
 			{
-				detected |= _totalY < -threshold;
-				detectedDirection |= SwipeDirection.Up;
+				if (_totalY < -threshold)
+				{
+					detected = true;
+					detectedDirection |= SwipeDirection.Up;
+				}
 			}
 
 			if (detected)

--- a/src/Controls/tests/Core.UnitTests/Gestures/SwipeGestureRecognizerTests.cs
+++ b/src/Controls/tests/Core.UnitTests/Gestures/SwipeGestureRecognizerTests.cs
@@ -83,5 +83,39 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			((ISwipeGestureController)swipe).DetectSwipe(view, SwipeDirection.Up);
 			Assert.False(detected);
 		}
+
+		[Fact]
+		public void SwipedEventDirectionMatchesTotalXTestWithFlags()
+		{
+			var view = new View();
+			var swipe = new SwipeGestureRecognizer();
+
+			SwipeDirection direction = SwipeDirection.Up;
+			swipe.Swiped += (object sender, SwipedEventArgs e) =>
+			{
+				direction = e.Direction;
+			};
+
+			((ISwipeGestureController)swipe).SendSwipe(view, totalX: -150, totalY: 10);
+			((ISwipeGestureController)swipe).DetectSwipe(view, SwipeDirection.Left | SwipeDirection.Right);
+			Assert.Equal(SwipeDirection.Left, direction);
+		}
+
+		[Fact]
+		public void SwipedEventDirectionMatchesTotalYTestWithFlags()
+		{
+			var view = new View();
+			var swipe = new SwipeGestureRecognizer();
+
+			SwipeDirection direction = SwipeDirection.Left;
+			swipe.Swiped += (object sender, SwipedEventArgs e) =>
+			{
+				direction = e.Direction;
+			};
+
+			((ISwipeGestureController)swipe).SendSwipe(view, totalX: 10, totalY: -150);
+			((ISwipeGestureController)swipe).DetectSwipe(view, SwipeDirection.Up | SwipeDirection.Down);
+			Assert.Equal(SwipeDirection.Up, direction);
+		}
 	}
 }


### PR DESCRIPTION
### Description of Change

As of the current behavior SwipeGestureRecognizer passes its `Direction` property to `SwipedEventArgs` upon detection. That works for most scenarios, but it doesn't deal with the fact that `SwipeDirection` enum is a flag enumeration.

An example where this becomes an issue. If SwipeGestureRecognizer is configured with `Direction = SwipeDirection.Up | SwipeDirection.Down` and the actual detected direction is `Up` the `SwipedEventArgs.Direction` will still be `SwipeDirection.Up | SwipeDirection.Down` and thus it's not possible to know what direction was actually detected.

This PR makes sure the actual detected direction(s) is passed to SwipedEventArgs.