### PR TITLE
[XC] Allow generic types in x:DataType and x:Type

### DIFF
--- a/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
+++ b/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
@@ -419,12 +419,17 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 			if (dataType is null)
 				throw new BuildException(XDataTypeSyntax, dataTypeNode as IXmlLineInfo, null);
 
-			var prefix = dataType.Contains(":") ? dataType.Substring(0, dataType.IndexOf(":", StringComparison.Ordinal)) : "";
-			var namespaceuri = node.NamespaceResolver.LookupNamespace(prefix) ?? "";
-			if (!string.IsNullOrEmpty(prefix) && string.IsNullOrEmpty(namespaceuri))
+			XmlType dtXType = null;
+			try
+			{
+				dtXType = TypeArgumentsParser.ParseSingle(dataType, node.NamespaceResolver, dataTypeNode as IXmlLineInfo)
+					?? throw new BuildException(XDataTypeSyntax, dataTypeNode as IXmlLineInfo, null);
+			}
+			catch (XamlParseException)
+			{
+				var prefix = dataType.Contains(":") ? dataType.Substring(0, dataType.IndexOf(":", StringComparison.Ordinal)) : "";
 				throw new BuildException(XmlnsUndeclared, dataTypeNode as IXmlLineInfo, null, prefix);
-
-			var dtXType = new XmlType(namespaceuri, dataType, null);
+			}
 
 			var tSourceRef = dtXType.GetTypeReference(context.Cache, module, (IXmlLineInfo)node);
 			if (tSourceRef == null)

--- a/src/Controls/src/Build.Tasks/XmlTypeExtensions.cs
+++ b/src/Controls/src/Build.Tasks/XmlTypeExtensions.cs
@@ -50,25 +50,17 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 			return xmlnsDefinitions;
 		}
 
-		public static TypeReference GetTypeReference(XamlCache cache, string xmlType, ModuleDefinition module, BaseNode node)
+		public static TypeReference GetTypeReference(XamlCache cache, string typeName, ModuleDefinition module, BaseNode node)
 		{
-			var split = xmlType.Split(':');
-			if (split.Length > 2)
-				throw new BuildException(BuildExceptionCode.InvalidXaml, node as IXmlLineInfo, null, xmlType);
-
-			string prefix, name;
-			if (split.Length == 2)
+			try
 			{
-				prefix = split[0];
-				name = split[1];
+				XmlType xmlType = TypeArgumentsParser.ParseSingle(typeName, node.NamespaceResolver, (IXmlLineInfo)node);
+				return GetTypeReference(xmlType, cache, module, node as IXmlLineInfo);
 			}
-			else
+			catch (XamlParseException)
 			{
-				prefix = "";
-				name = split[0];
+				throw new BuildException(BuildExceptionCode.InvalidXaml, node as IXmlLineInfo, null, typeName);
 			}
-			var namespaceuri = node.NamespaceResolver.LookupNamespace(prefix) ?? "";
-			return GetTypeReference(new XmlType(namespaceuri, name, null), cache, module, node as IXmlLineInfo);
 		}
 
 		public static TypeReference GetTypeReference(XamlCache cache, string namespaceURI, string typename, ModuleDefinition module, IXmlLineInfo xmlInfo)

--- a/src/Controls/src/Xaml/TypeArgumentsParser.cs
+++ b/src/Controls/src/Xaml/TypeArgumentsParser.cs
@@ -18,6 +18,18 @@ namespace Microsoft.Maui.Controls.Xaml
 			return typeList;
 		}
 
+		public static XmlType ParseSingle(string expression, IXmlNamespaceResolver resolver, IXmlLineInfo lineInfo)
+		{
+			string remaining = null;
+			XmlType type = Parse(expression, ref remaining, resolver, lineInfo);
+			if (type is null || !string.IsNullOrWhiteSpace(remaining))
+			{
+				throw new XamlParseException($"Invalid type expression or more than one type declared in '{expression}'", lineInfo, null);
+			}
+
+			return type;
+		}
+
 		static XmlType Parse(string match, ref string remaining, IXmlNamespaceResolver resolver, IXmlLineInfo lineinfo)
 		{
 			remaining = null;

--- a/src/Controls/src/Xaml/XamlServiceProvider.cs
+++ b/src/Controls/src/Xaml/XamlServiceProvider.cs
@@ -199,23 +199,6 @@ namespace Microsoft.Maui.Controls.Xaml.Internals
 
 		Type Resolve(string qualifiedTypeName, IServiceProvider serviceProvider, out XamlParseException exception)
 		{
-			exception = null;
-			var split = qualifiedTypeName.Split(':');
-			if (split.Length > 2)
-				return null;
-
-			string prefix, name;
-			if (split.Length == 2)
-			{
-				prefix = split[0];
-				name = split[1];
-			}
-			else
-			{
-				prefix = "";
-				name = split[0];
-			}
-
 			IXmlLineInfo xmlLineInfo = null;
 			if (serviceProvider != null)
 			{
@@ -223,14 +206,8 @@ namespace Microsoft.Maui.Controls.Xaml.Internals
 					xmlLineInfo = lineInfoProvider.XmlLineInfo;
 			}
 
-			var namespaceuri = namespaceResolver.LookupNamespace(prefix);
-			if (namespaceuri == null)
-			{
-				exception = new XamlParseException($"No xmlns declaration for prefix \"{prefix}\"", xmlLineInfo);
-				return null;
-			}
-
-			return getTypeFromXmlName(new XmlType(namespaceuri, name, null), xmlLineInfo, currentAssembly, out exception);
+			var xmlType = TypeArgumentsParser.ParseSingle(qualifiedTypeName, namespaceResolver, xmlLineInfo);
+			return getTypeFromXmlName(xmlType, xmlLineInfo, currentAssembly, out exception);
 		}
 
 		internal delegate Type GetTypeFromXmlName(XmlType xmlType, IXmlLineInfo xmlInfo, Assembly currentAssembly, out XamlParseException exception);

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui20616.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui20616.xaml
@@ -3,6 +3,11 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests"
              x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui20616">
-    <Label Text="{Binding Value}" x:DataType="local:ViewModel20616(x:String)" />
-    <Label Text="{Binding Value}" x:DataType="{x:Type local:ViewModel20616(x:String)}" />
+    <ContentPage.Resources>
+        <x:Type x:Key="ViewModelBool" TypeName="local:ViewModel20616(x:Boolean)" />
+        <x:Type x:Key="NestedViewModel" TypeName="local:ViewModel20616(local:ViewModel20616(x:String))" />
+    </ContentPage.Resources>
+
+    <Label Text="{Binding Value}" x:DataType="local:ViewModel20616(x:String)" x:Name="LabelA" />
+    <Label Text="{Binding Value.Value}" x:DataType="{x:Type local:ViewModel20616(local:ViewModel20616(x:Boolean))}" x:Name="LabelB" />
 </ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui20616.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui20616.xaml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests"
+             x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui20616">
+    <Label Text="{Binding Value}" x:DataType="local:ViewModel20616(x:String)" />
+    <Label Text="{Binding Value}" x:DataType="{x:Type local:ViewModel20616(x:String)}" />
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui20616.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui20616.xaml.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using Microsoft.Maui.ApplicationModel;
 using Microsoft.Maui.Controls.Core.UnitTests;
 using Microsoft.Maui.Controls.Shapes;
+using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Devices;
 using Microsoft.Maui.Dispatching;
 
@@ -43,14 +44,28 @@ public partial class Maui20616
         [Test]
         public void XDataTypeCanBeGeneric([Values(false, true)] bool useCompiledXaml)
         {
+            var page = new Maui20616(useCompiledXaml);
+
+            page.LabelA.BindingContext = new ViewModel20616<string> { Value = "ABC" };
+            Assert.AreEqual("ABC", page.LabelA.Text);
+
             if (useCompiledXaml)
             {
-                MockCompiler.Compile(typeof(Maui20616));
+                var binding = page.LabelA.GetContext(Label.TextProperty).Bindings.Values.Single();
+                Assert.That(binding, Is.TypeOf<TypedBinding<ViewModel20616<string>, string>>());
             }
-            else
+
+            page.LabelB.BindingContext = new ViewModel20616<ViewModel20616<bool>> { Value = new ViewModel20616<bool> { Value = true } };
+            Assert.AreEqual("True", page.LabelB.Text);
+
+            if (useCompiledXaml)
             {
-                new Maui20616(useCompiledXaml: false);
+                var binding = page.LabelB.GetContext(Label.TextProperty).Bindings.Values.Single();
+                Assert.That(binding, Is.TypeOf<TypedBinding<ViewModel20616<ViewModel20616<bool>>, bool>>());
             }
+
+            Assert.AreEqual(typeof(ViewModel20616<bool>), page.Resources["ViewModelBool"]);
+            Assert.AreEqual(typeof(ViewModel20616<ViewModel20616<string>>), page.Resources["NestedViewModel"]);
         }
     }
 }

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui20616.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui20616.xaml.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+using Microsoft.Maui.ApplicationModel;
+using Microsoft.Maui.Controls.Core.UnitTests;
+using Microsoft.Maui.Controls.Shapes;
+using Microsoft.Maui.Devices;
+using Microsoft.Maui.Dispatching;
+
+using Microsoft.Maui.Graphics;
+using Microsoft.Maui.UnitTests;
+using NUnit.Framework;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public partial class Maui20616
+{
+    public Maui20616()
+    {
+        InitializeComponent();
+        BindingContext = new ViewModel20616<string> { Value = "Foo" };
+    }
+
+    public Maui20616(bool useCompiledXaml)
+    {
+        //this stub will be replaced at compile time
+    }
+
+    [TestFixture]
+    class Test
+    {
+        [SetUp]
+        public void Setup()
+        {
+            Application.SetCurrentApplication(new MockApplication());
+            DispatcherProvider.SetCurrent(new DispatcherProviderStub());
+        }
+
+        [TearDown] public void TearDown() => AppInfo.SetCurrent(null);
+
+        [Test]
+        public void XDataTypeCanBeGeneric([Values(false, true)] bool useCompiledXaml)
+        {
+            if (useCompiledXaml)
+            {
+                MockCompiler.Compile(typeof(Maui20616));
+            }
+            else
+            {
+                new Maui20616(useCompiledXaml: false);
+            }
+        }
+    }
+}
+
+public class ViewModel20616<T>
+{
+    public required T Value { get; init; }
+}


### PR DESCRIPTION
### Description of Change

- Adds support for generic types in `x:DataType`
- Adds support for generic types in `x:Type` (compiled and parsed at runtime)

### Issues Fixed

Fixes #20616 