### PR TITLE
[Android Connectivity] Set app package on Intent used to invoke context receiver for network callback

### DIFF
--- a/src/Essentials/src/Battery/Battery.android.cs
+++ b/src/Essentials/src/Battery/Battery.android.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Maui.Devices
 		void StartEnergySaverListeners()
 		{
 			powerReceiver = new EnergySaverBroadcastReceiver(OnEnergySaverChanged);
-			PlatformUtils.RegisterBroadcastReceiver(powerReceiver, new IntentFilter(PowerManager.ActionPowerSaveModeChanged), false);
+			PlatformUtils.RegisterBroadcastReceiver(powerReceiver, new IntentFilter(PowerManager.ActionPowerSaveModeChanged));
 		}
 
 		void StopEnergySaverListeners()
@@ -52,7 +52,7 @@ namespace Microsoft.Maui.Devices
 			Permissions.EnsureDeclared<Permissions.Battery>();
 
 			batteryReceiver = new BatteryBroadcastReceiver(OnBatteryInfoChanged);
-			PlatformUtils.RegisterBroadcastReceiver(batteryReceiver, new IntentFilter(Intent.ActionBatteryChanged), false);
+			PlatformUtils.RegisterBroadcastReceiver(batteryReceiver, new IntentFilter(Intent.ActionBatteryChanged));
 		}
 
 		void StopBatteryListeners()
@@ -76,7 +76,7 @@ namespace Microsoft.Maui.Devices
 				Permissions.EnsureDeclared<Permissions.Battery>();
 
 				using (var filter = new IntentFilter(Intent.ActionBatteryChanged))
-				using (var battery = PlatformUtils.RegisterBroadcastReceiver(null, filter, false))
+				using (var battery = PlatformUtils.RegisterBroadcastReceiver(null, filter))
 				{
 					if (battery is null)
 						return -1; // Unknown
@@ -99,7 +99,7 @@ namespace Microsoft.Maui.Devices
 				Permissions.EnsureDeclared<Permissions.Battery>();
 
 				using (var filter = new IntentFilter(Intent.ActionBatteryChanged))
-				using (var battery = PlatformUtils.RegisterBroadcastReceiver(null, filter, false))
+				using (var battery = PlatformUtils.RegisterBroadcastReceiver(null, filter))
 				{
 					if (battery is null)
 						return BatteryState.Unknown;
@@ -129,7 +129,7 @@ namespace Microsoft.Maui.Devices
 				Permissions.EnsureDeclared<Permissions.Battery>();
 
 				using (var filter = new IntentFilter(Intent.ActionBatteryChanged))
-				using (var battery = PlatformUtils.RegisterBroadcastReceiver(null, filter, false))
+				using (var battery = PlatformUtils.RegisterBroadcastReceiver(null, filter))
 				{
 					if (battery is null)
 						return BatteryPowerSource.Unknown;

--- a/src/Essentials/src/Connectivity/Connectivity.android.cs
+++ b/src/Essentials/src/Connectivity/Connectivity.android.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Maui.Networking
 
 			conectivityReceiver = new ConnectivityBroadcastReceiver(OnConnectivityChanged);
 
-			PlatformUtils.RegisterBroadcastReceiver(conectivityReceiver, filter, true);
+			PlatformUtils.RegisterBroadcastReceiver(conectivityReceiver, filter);
 		}
 
 		void StopListeners()

--- a/src/Essentials/src/Connectivity/Connectivity.android.cs
+++ b/src/Essentials/src/Connectivity/Connectivity.android.cs
@@ -15,8 +15,7 @@ namespace Microsoft.Maui.Networking
 		/// Unique identifier for the connectivity changed action on Android.
 		/// </summary>
 		public const string ConnectivityChangedAction = "com.maui.essentials.ESSENTIALS_CONNECTIVITY_CHANGED";
-		static Intent connectivityIntent = new Intent(ConnectivityChangedAction);
-
+		
 		static ConnectivityManager connectivityManager;
 
 		static ConnectivityManager ConnectivityManager =>
@@ -51,7 +50,9 @@ namespace Microsoft.Maui.Networking
 		void StopListeners()
 		{
 			if (conectivityReceiver == null)
+			{
 				return;
+			}
 
 			try
 			{
@@ -77,11 +78,15 @@ namespace Microsoft.Maui.Networking
 		void RegisterNetworkCallback()
 		{
 			if (!OperatingSystem.IsAndroidVersionAtLeast(24))
+			{
 				return;
+			}
 
 			var manager = ConnectivityManager;
 			if (manager == null)
+			{
 				return;
+			}
 
 			var request = new NetworkRequest.Builder().Build();
 			networkCallback = new EssentialsNetworkCallback();
@@ -91,11 +96,15 @@ namespace Microsoft.Maui.Networking
 		void UnregisterNetworkCallback()
 		{
 			if (!OperatingSystem.IsAndroidVersionAtLeast(24))
+			{
 				return;
+			}
 
 			var manager = ConnectivityManager;
 			if (manager == null || networkCallback == null)
+			{
 				return;
+			}
 
 			manager.UnregisterNetworkCallback(networkCallback);
 
@@ -104,6 +113,14 @@ namespace Microsoft.Maui.Networking
 
 		class EssentialsNetworkCallback : ConnectivityManager.NetworkCallback
 		{
+			readonly Intent connectivityIntent;
+
+			public EssentialsNetworkCallback()
+			{
+				connectivityIntent = new Intent(ConnectivityChangedAction);
+				connectivityIntent.SetPackage(Application.Context.PackageName);
+			}
+
 			public override void OnAvailable(Network network) =>
 				Application.Context.SendBroadcast(connectivityIntent);
 
@@ -159,7 +176,9 @@ namespace Microsoft.Maui.Networking
 							var capabilities = manager.GetNetworkCapabilities(network);
 
 							if (capabilities == null)
+							{
 								continue;
+							}
 
 #pragma warning disable CS0618 // Type or member is obsolete
 #pragma warning disable CA1416 // Validate platform compatibility
@@ -167,7 +186,9 @@ namespace Microsoft.Maui.Networking
 							var info = manager.GetNetworkInfo(network);
 
 							if (info == null || !info.IsAvailable)
+							{
 								continue;
+							}
 #pragma warning restore CS0618 // Type or member is obsolete
 
 							// Check to see if it has the internet capability
@@ -200,12 +221,18 @@ namespace Microsoft.Maui.Networking
 					void ProcessNetworkInfo(NetworkInfo info)
 					{
 						if (info == null || !info.IsAvailable)
+						{
 							return;
+						}
 
 						if (info.IsConnected)
+						{
 							currentAccess = IsBetterAccess(currentAccess, NetworkAccess.Internet);
+						}
 						else if (info.IsConnectedOrConnecting)
+						{
 							currentAccess = IsBetterAccess(currentAccess, NetworkAccess.ConstrainedInternet);
+						}
 #pragma warning restore CA1422 // Validate platform compatibility
 #pragma warning restore CA1416 // Validate platform compatibility
 #pragma warning restore CS0618 // Type or member is obsolete
@@ -250,7 +277,9 @@ namespace Microsoft.Maui.Networking
 
 					var p = ProcessNetworkInfo(info);
 					if (p.HasValue)
+					{
 						yield return p.Value;
+					}
 				}
 
 #pragma warning disable CS0618 // Type or member is obsolete
@@ -258,7 +287,9 @@ namespace Microsoft.Maui.Networking
 				{
 
 					if (info == null || !info.IsAvailable || !info.IsConnectedOrConnecting)
+					{
 						return null;
+					}
 
 
 					return GetConnectionType(info.Type, info.TypeName);
@@ -289,22 +320,34 @@ namespace Microsoft.Maui.Networking
 					return ConnectionProfile.Unknown;
 				default:
 					if (string.IsNullOrWhiteSpace(typeName))
+					{
 						return ConnectionProfile.Unknown;
+					}
 
 					if (typeName.Contains("mobile", StringComparison.OrdinalIgnoreCase))
+					{
 						return ConnectionProfile.Cellular;
+					}
 
 					if (typeName.Contains("wimax", StringComparison.OrdinalIgnoreCase))
+					{
 						return ConnectionProfile.Cellular;
+					}
 
 					if (typeName.Contains("wifi", StringComparison.OrdinalIgnoreCase))
+					{
 						return ConnectionProfile.WiFi;
+					}
 
 					if (typeName.Contains("ethernet", StringComparison.OrdinalIgnoreCase))
+					{
 						return ConnectionProfile.Ethernet;
+					}
 
 					if (typeName.Contains("bluetooth", StringComparison.OrdinalIgnoreCase))
+					{
 						return ConnectionProfile.Bluetooth;
+					}
 
 					return ConnectionProfile.Unknown;
 			}
@@ -335,7 +378,9 @@ namespace Microsoft.Maui.Networking
 #pragma warning disable CS0618 // Type or member is obsolete
 			if (intent.Action != ConnectivityManager.ConnectivityAction && intent.Action != ConnectivityImplementation.ConnectivityChangedAction)
 #pragma warning restore CS0618 // Type or member is obsolete
+			{
 				return;
+			}
 
 			// await 1500ms to ensure that the the connection manager updates
 			await Task.Delay(1500);

--- a/src/Essentials/src/Platform/PlatformUtils.android.cs
+++ b/src/Essentials/src/Platform/PlatformUtils.android.cs
@@ -26,13 +26,12 @@ namespace Microsoft.Maui.ApplicationModel
 			return requestCode;
 		}
 
-		internal static Intent? RegisterBroadcastReceiver(BroadcastReceiver? receiver, IntentFilter filter, bool exported)
+		internal static Intent? RegisterBroadcastReceiver(BroadcastReceiver? receiver, IntentFilter filter)
 		{
 #if ANDROID34_0_OR_GREATER
 			if (OperatingSystem.IsAndroidVersionAtLeast(34))
 			{
-				var flags = exported ? ReceiverFlags.Exported : ReceiverFlags.NotExported;
-				return Application.Context.RegisterReceiver(receiver, filter, flags);
+				return Application.Context.RegisterReceiver(receiver, filter, ReceiverFlags.NotExported);
 			}
 #endif
 			return Application.Context.RegisterReceiver(receiver, filter);


### PR DESCRIPTION
### Description of Change

Android 14.0 brings in more changes for scoping invocations of broadcast receivers.  This changes to no longer export the 'internal' broadcast receiver we use for Essentials Connectivity API's (since we're the only ones expected to send broadcasts to it) and instead sets the package name of intent we broadcast to comply with OS changes and make this broadcast continue to work.

### Issues Fixed

Better fix for #17861

