### PR TITLE
[Catalyst] Fix Selectors for Menus

### DIFF
--- a/src/Core/src/Platform/iOS/MauiUIApplicationDelegate.Menu.cs
+++ b/src/Core/src/Platform/iOS/MauiUIApplicationDelegate.Menu.cs
@@ -84,7 +84,9 @@ namespace Microsoft.Maui
 
 		[SupportedOSPlatform("ios13.0")]
 		[Export(KeyboardAcceleratorExtensions.MenuItemSelectedSelector)]
-		static internal void MenuItemSelected(UICommand uiCommand)
+		#pragma warning disable CA1822 // Selectors can't be static, or else it won't be found
+		internal void MenuItemSelected(UICommand uiCommand)
+		#pragma warning restore CA1822
 		{
 			uiCommand.SendClicked();
 		}


### PR DESCRIPTION
### Description of Change

Setting `Static` on a ObjC selector breaks it, so we accidentally broke all Menu flyout options for Mac Catalyst, including those bound with Commands and Clicks.

Removing Static fixes it. 

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes https://github.com/dotnet/maui/issues/20685

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
