### PR TITLE
[net8.0] Update xharness

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -21,7 +21,7 @@
       ]
     },
     "microsoft.dotnet.xharness.cli": {
-      "version": "8.0.0-prerelease.23525.2",
+      "version": "9.0.0-prerelease.24112.4",
       "commands": [
         "xharness"
       ]

--- a/NuGet.config
+++ b/NuGet.config
@@ -2,6 +2,10 @@
 <configuration>
   <packageSources>
     <clear />
+    <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
+    <!--  Begin: Package sources from dotnet-aspnetcore -->
+    <add key="darc-pub-dotnet-aspnetcore-476e2aa" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-aspnetcore-476e2aa0/nuget/v3/index.json" />
+    <!--  End: Package sources from dotnet-aspnetcore -->
     <!--  Begin: Package sources from dotnet-emsdk -->
     <add key="darc-pub-dotnet-emsdk-9a29abd" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-emsdk-9a29abdd/nuget/v3/index.json" />
     <add key="darc-pub-dotnet-emsdk-9a29abd-1" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-emsdk-9a29abdd-1/nuget/v3/index.json" />

--- a/NuGet.config
+++ b/NuGet.config
@@ -4,11 +4,12 @@
     <clear />
     <!--  Begin: Package sources from dotnet-emsdk -->
     <add key="darc-pub-dotnet-emsdk-9a29abd" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-emsdk-9a29abdd/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-emsdk-9a29abd-1" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-emsdk-9a29abdd-1/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-emsdk -->
     <!--  Begin: Package sources from dotnet-runtime -->
     <add key="darc-pub-dotnet-runtime-62304a6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-62304a6d/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-runtime -->
-     <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
+    <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
     <add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
     <add key="dotnet7" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json" />
     <add key="dotnet8" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json" />
@@ -21,7 +22,11 @@
     <add key="darc-pub-dotnet-runtime-8473eeb" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-8473eeb9/nuget/v3/index.json" />
     <!-- Added manually for dotnet/runtime 6.0.26 -->
     <add key="darc-pub-dotnet-runtime-647b468" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-647b468f/nuget/v3/index.json" />
-    <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
+    <!-- Added manually for dotnet/runtime 7.0.17 -->
+    <add key="darc-pub-dotnet-emsdk-ec6dc98" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-emsdk-ec6dc98e/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-runtime-38ab85f" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-38ab85f1/nuget/v3/index.json" />
+    <!-- Added manually for dotnet/runtime 6.0.28 -->
+    <add key="darc-pub-dotnet-runtime-3e88dca" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-3e88dcaf/nuget/v3/index.json" />
     <!-- <add key="local" value="artifacts" /> -->
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" protocolVersion="3" />
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" protocolVersion="3" />

--- a/NuGet.config
+++ b/NuGet.config
@@ -2,6 +2,13 @@
 <configuration>
   <packageSources>
     <clear />
+    <!--  Begin: Package sources from dotnet-emsdk -->
+    <add key="darc-pub-dotnet-emsdk-9a29abd" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-emsdk-9a29abdd/nuget/v3/index.json" />
+    <!--  End: Package sources from dotnet-emsdk -->
+    <!--  Begin: Package sources from dotnet-runtime -->
+    <add key="darc-pub-dotnet-runtime-62304a6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-62304a6d/nuget/v3/index.json" />
+    <!--  End: Package sources from dotnet-runtime -->
+     <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
     <add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
     <add key="dotnet7" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json" />
     <add key="dotnet8" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json" />
@@ -9,12 +16,11 @@
     <add key="skiasharp" value="https://pkgs.dev.azure.com/xamarin/public/_packaging/SkiaSharp/nuget/v3/index.json" />
     <add key="wasdk-internal" value="https://pkgs.dev.azure.com/microsoft/ProjectReunion/_packaging/Project.Reunion.nuget.internal/nuget/v3/index.json" />
     <add key="benchmark-dotnet-prerelease" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/benchmark-dotnet-prerelease/nuget/v3/index.json" />
-    <!-- Added manually for dotnet/runtime 7.0.14 -->
-    <add key="darc-pub-dotnet-emsdk-942bfc8" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-emsdk-942bfc8c/nuget/v3/index.json" />
-    <add key="darc-pub-dotnet-runtime-35db500" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-35db500c/nuget/v3/index.json" />
-    <!-- Added manually for dotnet/runtime 6.0.25 -->
-    <add key="darc-pub-dotnet-emsdk-d8bc162" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-emsdk-d8bc162c/nuget/v3/index.json" />
-    <add key="darc-pub-dotnet-runtime-4a336b1" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-4a336b1c/nuget/v3/index.json" />
+    <!-- Added manually for dotnet/runtime 7.0.15 -->
+    <add key="darc-pub-dotnet-emsdk-33b038b" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-emsdk-33b038b5/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-runtime-8473eeb" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-8473eeb9/nuget/v3/index.json" />
+    <!-- Added manually for dotnet/runtime 6.0.26 -->
+    <add key="darc-pub-dotnet-runtime-647b468" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-647b468f/nuget/v3/index.json" />
     <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
     <!-- <add key="local" value="artifacts" /> -->
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" protocolVersion="3" />

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -28,9 +28,9 @@
       <Uri>https://github.com/xamarin/xamarin-android</Uri>
       <Sha>e222c43a4a44ccfc04e08c65fc4cddde147fd306</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.MacCatalyst.Sdk" Version="17.2.8041">
+    <Dependency Name="Microsoft.MacCatalyst.Sdk" Version="17.2.8031">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>f3c0259f827b51f6bc086654a112dfacda8dd549</Sha>
+      <Sha>77cf347049ce73bcfea295fc8672f70fb9c4ee35</Sha>
     </Dependency>
     <Dependency Name="Microsoft.macOS.Sdk" Version="14.2.8031">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,10 +1,26 @@
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.Dotnet.Sdk.Internal" Version="8.0.101-servicing.23614.6">
+    <Dependency Name="Microsoft.Dotnet.Sdk.Internal" Version="8.0.103-servicing.24119.1">
       <Uri>https://github.com/dotnet/installer</Uri>
-      <Sha>461c7766428ba2782725d89d95d3f4f414ff8c92</Sha>
+      <Sha>96079bf81dc2299f54c3a0673fed1cf58ca2a2a5</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NETCore.App.Ref" Version="8.0.3">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>62304a6d7085e32672ec988835eab41d89b82e25</Sha>
+    </Dependency>
+    <Dependency Name="System.Text.Json" Version="8.0.3">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>62304a6d7085e32672ec988835eab41d89b82e25</Sha>
+    </Dependency>
+    <Dependency Name="System.Text.Encodings.Web" Version="8.0.1">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>62304a6d7085e32672ec988835eab41d89b82e25</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Bcl.AsyncInterfaces" Version="8.0.1">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>62304a6d7085e32672ec988835eab41d89b82e25</Sha>
+    </Dependency>
+    <Dependency Name="System.CodeDom" Version="8.0.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>62304a6d7085e32672ec988835eab41d89b82e25</Sha>
     </Dependency>
@@ -12,9 +28,9 @@
       <Uri>https://github.com/xamarin/xamarin-android</Uri>
       <Sha>e222c43a4a44ccfc04e08c65fc4cddde147fd306</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.MacCatalyst.Sdk" Version="17.2.8031">
+    <Dependency Name="Microsoft.MacCatalyst.Sdk" Version="17.2.8041">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>77cf347049ce73bcfea295fc8672f70fb9c4ee35</Sha>
+      <Sha>f3c0259f827b51f6bc086654a112dfacda8dd549</Sha>
     </Dependency>
     <Dependency Name="Microsoft.macOS.Sdk" Version="14.2.8031">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
@@ -35,49 +51,49 @@
     <Dependency Name="Microsoft.WindowsAppSDK" Version="0.0.1">
       <Uri>https://dev.azure.com/microsoft/ProjectReunion/_git/ProjectReunionInternal</Uri>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authorization" Version="8.0.0">
+    <Dependency Name="Microsoft.AspNetCore.Authorization" Version="8.0.3">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>a2536e6a4e384182825e89ee064115b5d841e97e</Sha>
+      <Sha>476e2aa0c7cb25d6a9c774228e5c549c77620108</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.Facebook" Version="8.0.0">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.Facebook" Version="8.0.3">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>a2536e6a4e384182825e89ee064115b5d841e97e</Sha>
+      <Sha>476e2aa0c7cb25d6a9c774228e5c549c77620108</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.Google" Version="8.0.0">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.Google" Version="8.0.3">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>a2536e6a4e384182825e89ee064115b5d841e97e</Sha>
+      <Sha>476e2aa0c7cb25d6a9c774228e5c549c77620108</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="8.0.0">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="8.0.3">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>a2536e6a4e384182825e89ee064115b5d841e97e</Sha>
+      <Sha>476e2aa0c7cb25d6a9c774228e5c549c77620108</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components" Version="8.0.0">
+    <Dependency Name="Microsoft.AspNetCore.Components" Version="8.0.3">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>a2536e6a4e384182825e89ee064115b5d841e97e</Sha>
+      <Sha>476e2aa0c7cb25d6a9c774228e5c549c77620108</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Analyzers" Version="8.0.0">
+    <Dependency Name="Microsoft.AspNetCore.Components.Analyzers" Version="8.0.3">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>a2536e6a4e384182825e89ee064115b5d841e97e</Sha>
+      <Sha>476e2aa0c7cb25d6a9c774228e5c549c77620108</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Forms" Version="8.0.0">
+    <Dependency Name="Microsoft.AspNetCore.Components.Forms" Version="8.0.3">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>a2536e6a4e384182825e89ee064115b5d841e97e</Sha>
+      <Sha>476e2aa0c7cb25d6a9c774228e5c549c77620108</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebView" Version="8.0.0">
+    <Dependency Name="Microsoft.AspNetCore.Components.WebView" Version="8.0.3">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>a2536e6a4e384182825e89ee064115b5d841e97e</Sha>
+      <Sha>476e2aa0c7cb25d6a9c774228e5c549c77620108</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Web" Version="8.0.0">
+    <Dependency Name="Microsoft.AspNetCore.Components.Web" Version="8.0.3">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>a2536e6a4e384182825e89ee064115b5d841e97e</Sha>
+      <Sha>476e2aa0c7cb25d6a9c774228e5c549c77620108</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Metadata" Version="8.0.0">
+    <Dependency Name="Microsoft.AspNetCore.Metadata" Version="8.0.3">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>a2536e6a4e384182825e89ee064115b5d841e97e</Sha>
+      <Sha>476e2aa0c7cb25d6a9c774228e5c549c77620108</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.JSInterop" Version="8.0.0">
+    <Dependency Name="Microsoft.JSInterop" Version="8.0.3">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>a2536e6a4e384182825e89ee064115b5d841e97e</Sha>
+      <Sha>476e2aa0c7cb25d6a9c774228e5c549c77620108</Sha>
     </Dependency>
     <Dependency Name="Microsoft.TemplateEngine.Tasks" Version="7.0.100-preview.2.22102.8">
       <Uri>https://github.com/dotnet/templating</Uri>
@@ -99,17 +115,17 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>59edaad404d1b8e47080015ae8d0787f94c970df</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0">
+    <Dependency Name="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>59edaad404d1b8e47080015ae8d0787f94c970df</Sha>
+      <Sha>62304a6d7085e32672ec988835eab41d89b82e25</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.FileProviders.Abstractions" Version="8.0.0">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>59edaad404d1b8e47080015ae8d0787f94c970df</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0">
+    <Dependency Name="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>59edaad404d1b8e47080015ae8d0787f94c970df</Sha>
+      <Sha>62304a6d7085e32672ec988835eab41d89b82e25</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Logging" Version="8.0.0">
       <Uri>https://github.com/dotnet/runtime</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,12 +1,12 @@
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.Dotnet.Sdk.Internal" Version="8.0.100-rtm.23530.12">
+    <Dependency Name="Microsoft.Dotnet.Sdk.Internal" Version="8.0.101-servicing.23614.6">
       <Uri>https://github.com/dotnet/installer</Uri>
-      <Sha>ae28d5bc061eedfe863ef3e22d090054b69e7685</Sha>
+      <Sha>461c7766428ba2782725d89d95d3f4f414ff8c92</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="8.0.0">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="8.0.3">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>59edaad404d1b8e47080015ae8d0787f94c970df</Sha>
+      <Sha>62304a6d7085e32672ec988835eab41d89b82e25</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Android.Sdk.Windows" Version="34.0.84">
       <Uri>https://github.com/xamarin/xamarin-android</Uri>
@@ -28,9 +28,9 @@
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
       <Sha>77cf347049ce73bcfea295fc8672f70fb9c4ee35</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Workload.Emscripten.Current.Manifest-8.0.100" Version="8.0.0" CoherentParentDependency="Microsoft.NETCore.App.Ref">
+    <Dependency Name="Microsoft.NET.Workload.Emscripten.Current.Manifest-8.0.100" Version="8.0.3" CoherentParentDependency="Microsoft.NETCore.App.Ref">
       <Uri>https://github.com/dotnet/emsdk</Uri>
-      <Sha>51bf18a2e20024dfa89d63e20b0c3b695b5c1eed</Sha>
+      <Sha>9a29abdd764a4de0f253ed368871877a47725247</Sha>
     </Dependency>
     <Dependency Name="Microsoft.WindowsAppSDK" Version="0.0.1">
       <Uri>https://dev.azure.com/microsoft/ProjectReunion/_git/ProjectReunionInternal</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -127,17 +127,17 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>59edaad404d1b8e47080015ae8d0787f94c970df</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XHarness.TestRunners.Common" Version="8.0.0-prerelease.23525.2">
+    <Dependency Name="Microsoft.DotNet.XHarness.TestRunners.Common" Version="9.0.0-prerelease.24112.4">
       <Uri>https://github.com/dotnet/xharness</Uri>
-      <Sha>abaa77ecc150bc450f4865df3ae31c3f5b9c1490</Sha>
+      <Sha>11ae3663fe3de366ea3566d7ae9b4731adee2ca3</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="8.0.0-prerelease.23525.2">
+    <Dependency Name="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="9.0.0-prerelease.24112.4">
       <Uri>https://github.com/dotnet/xharness</Uri>
-      <Sha>abaa77ecc150bc450f4865df3ae31c3f5b9c1490</Sha>
+      <Sha>11ae3663fe3de366ea3566d7ae9b4731adee2ca3</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XHarness.CLI" Version="8.0.0-prerelease.23525.2">
+    <Dependency Name="Microsoft.DotNet.XHarness.CLI" Version="9.0.0-prerelease.24112.4">
       <Uri>https://github.com/dotnet/xharness</Uri>
-      <Sha>abaa77ecc150bc450f4865df3ae31c3f5b9c1490s</Sha>
+      <Sha>11ae3663fe3de366ea3566d7ae9b4731adee2ca3</Sha>
     </Dependency>
   </ProductDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -25,7 +25,7 @@
     <!-- xamarin/xamarin-android -->
     <MicrosoftAndroidSdkWindowsPackageVersion>34.0.84</MicrosoftAndroidSdkWindowsPackageVersion>
     <!-- xamarin/xamarin-macios -->
-    <MicrosoftMacCatalystSdkPackageVersion>17.2.8041</MicrosoftMacCatalystSdkPackageVersion>
+    <MicrosoftMacCatalystSdkPackageVersion>17.2.8031</MicrosoftMacCatalystSdkPackageVersion>
     <MicrosoftmacOSSdkPackageVersion>14.2.8031</MicrosoftmacOSSdkPackageVersion>
     <MicrosoftiOSSdkPackageVersion>17.2.8031</MicrosoftiOSSdkPackageVersion>
     <MicrosofttvOSSdkPackageVersion>17.2.8031</MicrosofttvOSSdkPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -3,21 +3,21 @@
     <!-- Current previous .NET SDK major version's stable release of MAUI packages -->
     <MicrosoftMauiPreviousDotNetReleasedVersion>7.0.101</MicrosoftMauiPreviousDotNetReleasedVersion>
     <!-- dotnet/installer -->
-    <MicrosoftDotnetSdkInternalPackageVersion>8.0.101-servicing.23614.6</MicrosoftDotnetSdkInternalPackageVersion>
+    <MicrosoftDotnetSdkInternalPackageVersion>8.0.103-servicing.24119.1</MicrosoftDotnetSdkInternalPackageVersion>
     <!-- dotnet/runtime -->
     <MicrosoftNETCoreAppRefPackageVersion>8.0.3</MicrosoftNETCoreAppRefPackageVersion>
-    <SystemTextJsonPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemTextJsonPackageVersion>
-    <SystemTextEncodingsWebPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemTextEncodingsWebPackageVersion>
-    <MicrosoftBclAsyncInterfacesPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</MicrosoftBclAsyncInterfacesPackageVersion>
+    <SystemTextJsonPackageVersion>8.0.3</SystemTextJsonPackageVersion>
+    <SystemTextEncodingsWebPackageVersion>8.0.0</SystemTextEncodingsWebPackageVersion>
+    <MicrosoftBclAsyncInterfacesPackageVersion>8.0.0</MicrosoftBclAsyncInterfacesPackageVersion>
     <!-- Microsoft/Extensions -->
-    <SystemCodeDomPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemCodeDomPackageVersion>
+    <SystemCodeDomPackageVersion>8.0.0</SystemCodeDomPackageVersion>
     <MicrosoftExtensionsConfigurationVersion>8.0.0</MicrosoftExtensionsConfigurationVersion>
     <MicrosoftExtensionsConfigurationAbstractionsVersion>8.0.0</MicrosoftExtensionsConfigurationAbstractionsVersion>
     <MicrosoftExtensionsConfigurationJsonVersion>8.0.0</MicrosoftExtensionsConfigurationJsonVersion>
     <MicrosoftExtensionsDependencyInjectionVersion>8.0.0</MicrosoftExtensionsDependencyInjectionVersion>
-    <MicrosoftExtensionsDependencyInjectionAbstractionsVersion>8.0.0</MicrosoftExtensionsDependencyInjectionAbstractionsVersion>
+    <MicrosoftExtensionsDependencyInjectionAbstractionsVersion>8.0.1</MicrosoftExtensionsDependencyInjectionAbstractionsVersion>
     <MicrosoftExtensionsFileProvidersAbstractionsVersion>8.0.0</MicrosoftExtensionsFileProvidersAbstractionsVersion>
-    <MicrosoftExtensionsLoggingAbstractionsVersion>8.0.0</MicrosoftExtensionsLoggingAbstractionsVersion>
+    <MicrosoftExtensionsLoggingAbstractionsVersion>8.0.1</MicrosoftExtensionsLoggingAbstractionsVersion>
     <MicrosoftExtensionsLoggingVersion>8.0.0</MicrosoftExtensionsLoggingVersion>
     <MicrosoftExtensionsLoggingConsoleVersion>8.0.0</MicrosoftExtensionsLoggingConsoleVersion>
     <MicrosoftExtensionsLoggingDebugVersion>8.0.0</MicrosoftExtensionsLoggingDebugVersion>
@@ -25,7 +25,7 @@
     <!-- xamarin/xamarin-android -->
     <MicrosoftAndroidSdkWindowsPackageVersion>34.0.84</MicrosoftAndroidSdkWindowsPackageVersion>
     <!-- xamarin/xamarin-macios -->
-    <MicrosoftMacCatalystSdkPackageVersion>17.2.8031</MicrosoftMacCatalystSdkPackageVersion>
+    <MicrosoftMacCatalystSdkPackageVersion>17.2.8041</MicrosoftMacCatalystSdkPackageVersion>
     <MicrosoftmacOSSdkPackageVersion>14.2.8031</MicrosoftmacOSSdkPackageVersion>
     <MicrosoftiOSSdkPackageVersion>17.2.8031</MicrosoftiOSSdkPackageVersion>
     <MicrosofttvOSSdkPackageVersion>17.2.8031</MicrosofttvOSSdkPackageVersion>
@@ -38,17 +38,17 @@
     <MicrosoftWindowsSDKBuildToolsPackageVersion>10.0.22621.756</MicrosoftWindowsSDKBuildToolsPackageVersion>
     <MicrosoftGraphicsWin2DPackageVersion>1.0.5.1</MicrosoftGraphicsWin2DPackageVersion>
     <!-- Everything else -->
-    <MicrosoftAspNetCoreAuthorizationPackageVersion>8.0.0</MicrosoftAspNetCoreAuthorizationPackageVersion>
-    <MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>8.0.0</MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>
-    <MicrosoftAspNetCoreAuthenticationGooglePackageVersion>8.0.0</MicrosoftAspNetCoreAuthenticationGooglePackageVersion>
-    <MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>8.0.0</MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>
-    <MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>8.0.0</MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>
-    <MicrosoftAspNetCoreComponentsFormsPackageVersion>8.0.0</MicrosoftAspNetCoreComponentsFormsPackageVersion>
-    <MicrosoftAspNetCoreComponentsPackageVersion>8.0.0</MicrosoftAspNetCoreComponentsPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebPackageVersion>8.0.0</MicrosoftAspNetCoreComponentsWebPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebViewPackageVersion>8.0.0</MicrosoftAspNetCoreComponentsWebViewPackageVersion>
-    <MicrosoftAspNetCoreMetadataPackageVersion>8.0.0</MicrosoftAspNetCoreMetadataPackageVersion>
-    <MicrosoftJSInteropPackageVersion>8.0.0</MicrosoftJSInteropPackageVersion>
+    <MicrosoftAspNetCoreAuthorizationPackageVersion>8.0.3</MicrosoftAspNetCoreAuthorizationPackageVersion>
+    <MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>8.0.3</MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>
+    <MicrosoftAspNetCoreAuthenticationGooglePackageVersion>8.0.3</MicrosoftAspNetCoreAuthenticationGooglePackageVersion>
+    <MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>8.0.3</MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>
+    <MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>8.0.3</MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>
+    <MicrosoftAspNetCoreComponentsFormsPackageVersion>8.0.3</MicrosoftAspNetCoreComponentsFormsPackageVersion>
+    <MicrosoftAspNetCoreComponentsPackageVersion>8.0.3</MicrosoftAspNetCoreComponentsPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebPackageVersion>8.0.3</MicrosoftAspNetCoreComponentsWebPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebViewPackageVersion>8.0.3</MicrosoftAspNetCoreComponentsWebViewPackageVersion>
+    <MicrosoftAspNetCoreMetadataPackageVersion>8.0.3</MicrosoftAspNetCoreMetadataPackageVersion>
+    <MicrosoftJSInteropPackageVersion>8.0.3</MicrosoftJSInteropPackageVersion>
     <!-- Other packages -->
     <MicrosoftCodeAnalysisNetAnalyzersVersion>8.0.0</MicrosoftCodeAnalysisNetAnalyzersVersion>
     <MicrosoftCodeAnalysisPublicApiAnalyzersVersion>3.3.4</MicrosoftCodeAnalysisPublicApiAnalyzersVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -78,9 +78,9 @@
     <_HarfBuzzSharpVersion>7.3.0</_HarfBuzzSharpVersion>
     <_SkiaSharpNativeAssetsVersion>0.0.0-commit.e2c5c86249621857107c779af0f79b4d06613766.655</_SkiaSharpNativeAssetsVersion>
     <MicrosoftTemplateEngineTasksVersion>7.0.114</MicrosoftTemplateEngineTasksVersion>
-    <MicrosoftDotNetXHarnessTestRunnersCommonVersion>8.0.0-prerelease.23525.2</MicrosoftDotNetXHarnessTestRunnersCommonVersion>
-    <MicrosoftDotNetXHarnessTestRunnersXunitVersion>8.0.0-prerelease.23525.2</MicrosoftDotNetXHarnessTestRunnersXunitVersion>
-    <MicrosoftDotNetXHarnessCLIVersion>8.0.0-prerelease.23525.2</MicrosoftDotNetXHarnessCLIVersion>
+    <MicrosoftDotNetXHarnessTestRunnersCommonVersion>9.0.0-prerelease.24112.4</MicrosoftDotNetXHarnessTestRunnersCommonVersion>
+    <MicrosoftDotNetXHarnessTestRunnersXunitVersion>9.0.0-prerelease.24112.4</MicrosoftDotNetXHarnessTestRunnersXunitVersion>
+    <MicrosoftDotNetXHarnessCLIVersion>9.0.0-prerelease.24112.4</MicrosoftDotNetXHarnessCLIVersion>
     <TizenUIExtensionsVersion>0.9.2</TizenUIExtensionsVersion>
     <SvgSkiaPackageVersion>0.5.13</SvgSkiaPackageVersion>
     <FizzlerPackageVersion>1.2.0</FizzlerPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -32,7 +32,7 @@
     <!-- Samsung/Tizen.NET -->
     <SamsungTizenSdkPackageVersion>8.0.130</SamsungTizenSdkPackageVersion>
     <!-- emsdk -->
-    <MicrosoftNETWorkloadEmscriptenPackageVersion>8.0.0</MicrosoftNETWorkloadEmscriptenPackageVersion>
+    <MicrosoftNETWorkloadEmscriptenPackageVersion>8.0.3</MicrosoftNETWorkloadEmscriptenPackageVersion>
     <!-- wasdk -->
     <MicrosoftWindowsAppSDKPackageVersion>1.3.230724000</MicrosoftWindowsAppSDKPackageVersion>
     <MicrosoftWindowsSDKBuildToolsPackageVersion>10.0.22621.756</MicrosoftWindowsSDKBuildToolsPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -3,9 +3,9 @@
     <!-- Current previous .NET SDK major version's stable release of MAUI packages -->
     <MicrosoftMauiPreviousDotNetReleasedVersion>7.0.101</MicrosoftMauiPreviousDotNetReleasedVersion>
     <!-- dotnet/installer -->
-    <MicrosoftDotnetSdkInternalPackageVersion>8.0.100-rtm.23530.12</MicrosoftDotnetSdkInternalPackageVersion>
+    <MicrosoftDotnetSdkInternalPackageVersion>8.0.101-servicing.23614.6</MicrosoftDotnetSdkInternalPackageVersion>
     <!-- dotnet/runtime -->
-    <MicrosoftNETCoreAppRefPackageVersion>8.0.0</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>8.0.3</MicrosoftNETCoreAppRefPackageVersion>
     <SystemTextJsonPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemTextJsonPackageVersion>
     <SystemTextEncodingsWebPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemTextEncodingsWebPackageVersion>
     <MicrosoftBclAsyncInterfacesPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</MicrosoftBclAsyncInterfacesPackageVersion>

--- a/eng/pipelines/common/maui-templates.yml
+++ b/eng/pipelines/common/maui-templates.yml
@@ -73,7 +73,6 @@ jobs:
     demands:
       - macOS.Name -equals Ventura
       - macOS.Architecture -equals x64
-      - Agent.OSVersion -equals 13.5
   steps:
 
   - ${{ each step in parameters.prepareSteps }}:

--- a/eng/pipelines/device-tests.yml
+++ b/eng/pipelines/device-tests.yml
@@ -74,7 +74,6 @@ parameters:
       demands:
         - macOS.Name -equals Ventura
         - macOS.Architecture -equals x64
-        - Agent.OSVersion -equals 13.5
 
   - name: catalystPool
     type: object

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -112,7 +112,6 @@ parameters:
       demands:
         - macOS.Name -equals Ventura
         - macOS.Architecture -equals x64
-        - Agent.OSVersion -equals 13.5
       testName: RunOnAndroid
       artifact: templates-run-android
     - name: $(iosTestsVmPool)
@@ -120,7 +119,6 @@ parameters:
       demands:
         - macOS.Name -equals Ventura
         - macOS.Architecture -equals x64
-        - Agent.OSVersion -equals 13.5
       testName: RunOniOS
       artifact: templates-run-ios
 
@@ -170,7 +168,6 @@ stages:
               demands:
                 - macOS.Name -equals Ventura
                 - macOS.Architecture -equals x64
-                - Agent.OSVersion -equals 13.5
             steps:
               - template: common/provision.yml
                 parameters:
@@ -213,7 +210,6 @@ stages:
             demands:
               - macOS.Name -equals Ventura
               - macOS.Architecture -equals x64
-              - Agent.OSVersion -equals 13.5
           steps:
             - template: common/pack.yml
               parameters:

--- a/eng/pipelines/ui-tests.yml
+++ b/eng/pipelines/ui-tests.yml
@@ -78,7 +78,6 @@ parameters:
       demands:
         - macOS.Name -equals Ventura
         - macOS.Architecture -equals x64
-        - Agent.OSVersion -equals 13.5
   
   - name: windowsPool
     type: object
@@ -109,7 +108,6 @@ parameters:
       demands:
         - macOS.Name -equals Ventura
         - macOS.Architecture -equals x64
-        - Agent.OSVersion -equals 13.5
 
 
 resources:


### PR DESCRIPTION
### Description of Change



This pull request includes changes to update various versions and dependencies in the project, as well as removing some specific agent demands in the pipeline configuration files. The most significant changes are the version updates for `Microsoft.Dotnet.Sdk.Internal`, `Microsoft.NETCore.App.Ref`, `Microsoft.NET.Workload.Emscripten`, and `Microsoft.DotNet.XHarness` in multiple files. Additionally, the agent demand `Agent.OSVersion -equals 13.5` was removed from several pipeline configuration files.

We need to use latest xharness so we can use the correct iOS17 devices, and have the correct screenshots for compare
Just updating xharness that is now on net9 is not working because of the following error. so we need to also update the runtime

Error log: 
```
default,mono_log_level=debug,mono_log_mask=all
Telemetry is: Enabled
Running /Users/builder/azdo/_work/1/s/bin/dotnet/dotnet /Users/builder/.nuget/packages/microsoft.dotnet.xharness.cli/9.0.0-prerelease.24112.4/tools/net8.0/any/Microsoft.DotNet.XHarness.CLI.dll android test --app=/Users/builder/azdo/_work/1/s/src/Essentials/test/DeviceTests/bin/Debug/net8.0-android/com.microsoft.maui.essentials.devicetests-Signed.apk --package-name=com.microsoft.maui.essentials.devicetests --instrumentation=com.microsoft.maui.essentials.devicetests.TestInstrumentation --device-arch=x86_64 --output-directory=/Users/builder/azdo/_work/1/a/test-results --verbosity=Debug
Process ID: 52620
You must install or update .NET to run this application.

App: /Users/builder/.nuget/packages/microsoft.dotnet.xharness.cli/9.0.0-prerelease.24112.4/tools/net8.0/any/Microsoft.DotNet.XHarness.CLI.dll
Architecture: x64
Framework: 'Microsoft.AspNetCore.App', version '8.0.0' (x64)
.NET location: /Users/builder/azdo/_work/1/s/bin/dotnet/

The following frameworks were found:
  8.0.0-rtm.23524.5 at [/Users/builder/azdo/_work/1/s/bin/dotnet/shared/Microsoft.AspNetCore.App]

Learn more:
https://aka.ms/dotnet/app-launch-failed

To install missing framework, download:
https://aka.ms/dotnet-core-applaunch?framework=Microsoft.AspNetCore.App&framework_version=8.0.0&arch=x64&rid=osx-x64&os=osx.13
An error occurred when executing task 'Test'.
```

Version updates:

* [`.config/dotnet-tools.json`](diffhunk://#diff-7afd3bcf0d0c06d6f87c451ef06b321beef770ece4299b3230bb280470ada2f6L24-R24): Updated the version of `microsoft.dotnet.xharness.cli` from `8.0.0-prerelease.23525.2` to `9.0.0-prerelease.24112.4`.
* [`NuGet.config`](diffhunk://#diff-9c5952957709545aad811b400e7e516eebade1e44fc4fbc23203403ffeb92c34R5-R23): Updated the package sources for `dotnet-emsdk` and `dotnet-runtime`.
* [`eng/Version.Details.xml`](diffhunk://#diff-fb62e94a1d6f29f863e3d0a22aa38269f6cd1d7f03b109dc06e2cbf2548b86d3L3-R9): Updated the versions and hashes for `Microsoft.Dotnet.Sdk.Internal`, `Microsoft.NETCore.App.Ref`, `Microsoft.NET.Workload.Emscripten.Current.Manifest-8.0.100`, and `Microsoft.DotNet.XHarness`. [[1]](diffhunk://#diff-fb62e94a1d6f29f863e3d0a22aa38269f6cd1d7f03b109dc06e2cbf2548b86d3L3-R9) [[2]](diffhunk://#diff-fb62e94a1d6f29f863e3d0a22aa38269f6cd1d7f03b109dc06e2cbf2548b86d3L31-R33) [[3]](diffhunk://#diff-fb62e94a1d6f29f863e3d0a22aa38269f6cd1d7f03b109dc06e2cbf2548b86d3L130-R140)
* [`eng/Versions.props`](diffhunk://#diff-1ea18ff65faa2ae6fed570b83747086d0317f5e4bc325064f6c14319a9c4ff67L6-R8): Updated the versions for `MicrosoftDotnetSdkInternalPackageVersion`, `MicrosoftNETCoreAppRefPackageVersion`, `MicrosoftNETWorkloadEmscriptenPackageVersion`, and `MicrosoftDotNetXHarness`. [[1]](diffhunk://#diff-1ea18ff65faa2ae6fed570b83747086d0317f5e4bc325064f6c14319a9c4ff67L6-R8) [[2]](diffhunk://#diff-1ea18ff65faa2ae6fed570b83747086d0317f5e4bc325064f6c14319a9c4ff67L35-R35) [[3]](diffhunk://#diff-1ea18ff65faa2ae6fed570b83747086d0317f5e4bc325064f6c14319a9c4ff67L81-R83)

Pipeline configuration changes:

* `eng/pipelines/common/maui-templates.yml`, `eng/pipelines/device-tests.yml`, `eng/pipelines/handlers.yml`, `eng/pipelines/ui-tests.yml`: Removed the agent demand `Agent.OSVersion -equals 13.5` from the pipeline configurations. [[1]](diffhunk://#diff-beb9b1c0fe7c80ce160eac3a028a267cd8bf6bef41239e0a4bf5829ae3ac25a7L76) [[2]](diffhunk://#diff-d2d1c388a0fb3196dbfcdab96421bc88336637a3d44480c96717f92d000facaeL77) [[3]](diffhunk://#diff-5c9b6f86c989bb9415ea86f38f9e127f8dadf3a8516e9d027c7ee6289f10c394L115-L123) [[4]](diffhunk://#diff-5c9b6f86c989bb9415ea86f38f9e127f8dadf3a8516e9d027c7ee6289f10c394L173) [[5]](diffhunk://#diff-5c9b6f86c989bb9415ea86f38f9e127f8dadf3a8516e9d027c7ee6289f10c394L216) [[6]](diffhunk://#diff-01226bae9fe7277cc2f291d47499e45e220b58b560fc0735c13fa6d13e21acd4L81) [[7]](diffhunk://#diff-01226bae9fe7277cc2f291d47499e45e220b58b560fc0735c13fa6d13e21acd4L112)
