### PR TITLE
[net9.0] [ci] Remove ForceNet8Current

### DIFF
--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -579,7 +579,6 @@ void SetDotNetEnvironmentVariables(string dotnetDir = null)
     SetEnvironmentVariable("DOTNET_MSBUILD_SDK_RESOLVER_CLI_DIR", dotnet);
     SetEnvironmentVariable("DOTNET_MULTILEVEL_LOOKUP", "0");
     SetEnvironmentVariable("MSBuildEnableWorkloadResolver", "true");
-    SetEnvironmentVariable("ForceNet8Current", "true");
     SetEnvironmentVariable("PATH", dotnet, prepend: true);
 
     // Get "full" .binlog in Project System Tools

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/DotnetInternal.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/DotnetInternal.cs
@@ -108,7 +108,6 @@ namespace Microsoft.Maui.IntegrationTests
 			var pinfo = new ProcessStartInfo(DotnetTool, $"{command} {args}");
 			pinfo.EnvironmentVariables["DOTNET_MULTILEVEL_LOOKUP"] = "0";
 			pinfo.EnvironmentVariables["DOTNET_ROOT"] = DotnetRoot;
-			pinfo.EnvironmentVariables["ForceNet8Current"] = "true";
 
 			return ToolRunner.Run(pinfo, out exitCode, timeoutInSeconds: timeoutInSeconds);
 		}


### PR DESCRIPTION
### Description of Change

We have enable `ForceNet8Current` to workaround a bug on preview1 that should be fixed with preview2 when building the net8 templates with the net9.0 sdk.