### PR TITLE
[net9.0] [testing] Enable Windows UITests back

### DIFF
--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -753,8 +753,14 @@ void RunTestWithLocalDotNet(string csproj, string config, string pathDotnet = nu
     var name = System.IO.Path.GetFileNameWithoutExtension(csproj);
     var logDirectory = GetLogDirectory();
 
-    if(localDotnet)
-        SetDotNetEnvironmentVariables(System.IO.Path.GetDirectoryName(pathDotnet));
+    if (localDotnet)
+    {
+        // Make sure the path doesn't refer to the dotnet executable and make path absolute
+        var localDotnetRoot = MakeAbsolute(Directory(System.IO.Path.GetDirectoryName(pathDotnet)));
+    	Information("new dotnet root: {0}", localDotnetRoot);
+
+        SetDotNetEnvironmentVariables();
+    }
 
     if (string.IsNullOrWhiteSpace(resultsFileNameWithoutExtension))
     {

--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -759,7 +759,7 @@ void RunTestWithLocalDotNet(string csproj, string config, string pathDotnet = nu
         var localDotnetRoot = MakeAbsolute(Directory(System.IO.Path.GetDirectoryName(pathDotnet)));
     	Information("new dotnet root: {0}", localDotnetRoot);
 
-        SetDotNetEnvironmentVariables();
+        SetDotNetEnvironmentVariables(localDotnetRoot);
     }
 
     if (string.IsNullOrWhiteSpace(resultsFileNameWithoutExtension))

--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -754,7 +754,7 @@ void RunTestWithLocalDotNet(string csproj, string config, string pathDotnet = nu
     var logDirectory = GetLogDirectory();
 
     if(localDotnet)
-        SetDotNetEnvironmentVariables(pathDotnet);
+        SetDotNetEnvironmentVariables(System.IO.Path.GetDirectoryName(pathDotnet));
 
     if (string.IsNullOrWhiteSpace(resultsFileNameWithoutExtension))
     {

--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -759,7 +759,7 @@ void RunTestWithLocalDotNet(string csproj, string config, string pathDotnet = nu
         var localDotnetRoot = MakeAbsolute(Directory(System.IO.Path.GetDirectoryName(pathDotnet)));
     	Information("new dotnet root: {0}", localDotnetRoot);
 
-        SetDotNetEnvironmentVariables(localDotnetRoot);
+        SetDotNetEnvironmentVariables(localDotnetRoot.FullPath);
     }
 
     if (string.IsNullOrWhiteSpace(resultsFileNameWithoutExtension))

--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -754,7 +754,7 @@ void RunTestWithLocalDotNet(string csproj, string config, string pathDotnet = nu
     var logDirectory = GetLogDirectory();
 
     if(localDotnet)
-        SetDotNetEnvironmentVariables();
+        SetDotNetEnvironmentVariables(pathDotnet);
 
     if (string.IsNullOrWhiteSpace(resultsFileNameWithoutExtension))
     {

--- a/eng/devices/windows.cake
+++ b/eng/devices/windows.cake
@@ -443,26 +443,34 @@ Task("uitest")
 	Information("old dotnet root: {0}", DOTNET_ROOT);
 	Information("old dotnet path: {0}", DOTNET_PATH);
 
-	var localDotnetRoot = MakeAbsolute(Directory("../../bin/dotnet/"));
-	Information("new dotnet root: {0}", localDotnetRoot);
-
-	DOTNET_ROOT = localDotnetRoot.ToString();
-
-	var localToolPath = $"{localDotnetRoot}/dotnet.exe";
-
-	Information("new dotnet toolPath: {0}", localToolPath);
-
-	SetDotNetEnvironmentVariables(DOTNET_ROOT);
-
-	DotNetBuild(PROJECT.FullPath, new DotNetBuildSettings {
+	var buildSettings = new DotNetBuildSettings {
 			Configuration = CONFIGURATION,
-			ToolPath = localToolPath,
 			ArgumentCustomization = args => args
 				.Append("/p:ExtraDefineConstants=WINTEST")
 				.Append("/bl:" + binlog)
 				.Append("/maxcpucount:1")
 				//.Append("/tl")
-	});
+	};
+
+	string? localToolPath = null;
+
+	if (localDotnet)
+	{
+		var localDotnetRoot = MakeAbsolute(Directory("../../bin/dotnet/"));
+		Information("new dotnet root: {0}", localDotnetRoot);
+
+		DOTNET_ROOT = localDotnetRoot.ToString();
+
+		localToolPath = $"{localDotnetRoot}/dotnet.exe";
+
+		Information("new dotnet toolPath: {0}", localToolPath);
+
+		SetDotNetEnvironmentVariables(DOTNET_ROOT);
+
+		buildSettings.ToolPath = localToolPath;
+	}
+
+	DotNetBuild(PROJECT.FullPath, buildSettings);
 
 	SetEnvironmentVariable("WINDOWS_APP_PATH", TEST_APP);
 	SetEnvironmentVariable("APPIUM_LOG_FILE", $"{BINLOG_DIR}/appium_windows.log");

--- a/eng/pipelines/common/ui-tests.yml
+++ b/eng/pipelines/common/ui-tests.yml
@@ -123,28 +123,28 @@ stages:
                       agentPoolAccessToken: ${{ parameters.agentPoolAccessToken }}
                       runtimeVariant : "NativeAOT"
 
-  # - stage: winui_ui_tests
-  #   displayName: WinUI UITests
-  #   dependsOn: []
-  #   jobs:
-  #     - ${{ each project in parameters.projects }}:
-  #       - ${{ if ne(project.winui, '') }}:
-  #             - job: winui_ui_tests_${{ project.name }}
-  #               timeoutInMinutes: 240 # how long to run the job before automatically cancelling
-  #               workspace:
-  #                 clean: all
-  #               displayName: ${{ coalesce(project.desc, project.name) }}
-  #               pool: ${{ parameters.windowsPool }}
-  #               steps:
-  #                 - template: ui-tests-steps.yml
-  #                   parameters:
-  #                     platform: windows
-  #                     version: "10.0.19041"
-  #                     device: windows10
-  #                     path: ${{ project.winui }}
-  #                     app: ${{ project.app }}
-  #                     provisionatorChannel: ${{ parameters.provisionatorChannel }}
-  #                     agentPoolAccessToken: ${{ parameters.agentPoolAccessToken }}
+  - stage: winui_ui_tests
+    displayName: WinUI UITests
+    dependsOn: []
+    jobs:
+      - ${{ each project in parameters.projects }}:
+        - ${{ if ne(project.winui, '') }}:
+              - job: winui_ui_tests_${{ project.name }}
+                timeoutInMinutes: 240 # how long to run the job before automatically cancelling
+                workspace:
+                  clean: all
+                displayName: ${{ coalesce(project.desc, project.name) }}
+                pool: ${{ parameters.windowsPool }}
+                steps:
+                  - template: ui-tests-steps.yml
+                    parameters:
+                      platform: windows
+                      version: "10.0.19041"
+                      device: windows10
+                      path: ${{ project.winui }}
+                      app: ${{ project.app }}
+                      provisionatorChannel: ${{ parameters.provisionatorChannel }}
+                      agentPoolAccessToken: ${{ parameters.agentPoolAccessToken }}
 
   - stage: mac_ui_tests
     displayName: macOS UITests


### PR DESCRIPTION
### Description of Change

We have disable the UITests with net9 because it was failing to launch the app. This reverts that back. 

I think to fix this we fix this https://github.com/dotnet/maui/issues/20692