### PR TITLE
[Trimming] Disable query property assignment via reflection on NativeAOT

### DIFF
--- a/docs/design/FeatureSwitches.md
+++ b/docs/design/FeatureSwitches.md
@@ -6,6 +6,7 @@ Certain features of MAUI can be enabled or disabled using feature switches. The 
 |-|-|-|
 | MauiXamlRuntimeParsingSupport | Microsoft.Maui.RuntimeFeature.IsXamlRuntimeParsingSupported | When disabled, all XAML loading at runtime will throw an exception. This will affect usage of APIs such as the `LoadFromXaml` extension method. This feature can be safely turned off when all XAML resources are compiled using XamlC (see [XAML compilation](https://learn.microsoft.com/en-us/dotnet/maui/xaml/xamlc)). This feature is enabled by default for all configurations except for NativeAOT. |
 | MauiEnableIVisualAssemblyScanning | Microsoft.Maui.RuntimeFeature.IsIVisualAssemblyScanningEnabled | When enabled, MAUI will scan assemblies for types implementing `IVisual` and for `[assembly: Visual(...)]` attributes and register these types. |
+| MauiQueryPropertyAttributeSupport | Microsoft.Maui.RuntimeFeature.IsQueryPropertyAttributeSupported | When disabled, the `[QueryProperty(...)]` attributes won't be used to set values to properties when navigating. |
 
 ## MauiXamlRuntimeParsingSupport
 
@@ -16,3 +17,7 @@ When this feature is disabled, the following APIs are affected:
 ## MauiEnableIVisualAssemblyScanning
 
 When this feature is not enabled, custom and third party `IVisual` types will not be automatically discovered and registerd.
+
+## MauiQueryPropertyAttributeSupport
+
+When disabled, the `[QueryProperty(...)]` attributes won't be used to set values to properties when navigating. Instead, implement the [`IQueryAttributable`](https://learn.microsoft.com/en-us/dotnet/maui/fundamentals/shell/navigation#process-navigation-data-using-a-single-method) interface whenever you need to accept query parameters.

--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
@@ -210,6 +210,7 @@
     <PropertyGroup>
       <MauiXamlRuntimeParsingSupport Condition="'$(MauiXamlRuntimeParsingSupport)' == '' and '$(PublishAot)' == 'true'">false</MauiXamlRuntimeParsingSupport>
       <MauiEnableIVisualAssemblyScanning Condition="'$(MauiEnableIVisualAssemblyScanning)' == ''">false</MauiEnableIVisualAssemblyScanning>
+      <MauiQueryPropertyAttributeSupport Condition="'$(MauiQueryPropertyAttributeSupport)' == ''">false</MauiQueryPropertyAttributeSupport>
     </PropertyGroup>
     <ItemGroup>
       <RuntimeHostConfigurationOption Include="Microsoft.Maui.RuntimeFeature.IsXamlRuntimeParsingSupported"
@@ -219,6 +220,10 @@
       <RuntimeHostConfigurationOption Include="Microsoft.Maui.RuntimeFeature.IsIVisualAssemblyScanningEnabled"
                                       Condition="'$(MauiEnableIVisualAssemblyScanning)' != ''"
                                       Value="$(MauiEnableIVisualAssemblyScanning)"
+                                      Trim="true" />
+      <RuntimeHostConfigurationOption Include="Microsoft.Maui.RuntimeFeature.IsQueryPropertyAttributeSupported"
+                                      Condition="'$(MauiQueryPropertyAttributeSupport)' != ''"
+                                      Value="$(MauiQueryPropertyAttributeSupport)"
                                       Trim="true" />
     </ItemGroup>
   </Target>

--- a/src/Controls/src/Core/Shell/QueryPropertyAttribute.cs
+++ b/src/Controls/src/Core/Shell/QueryPropertyAttribute.cs
@@ -1,10 +1,12 @@
 #nullable disable
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../../docs/Microsoft.Maui.Controls/QueryPropertyAttribute.xml" path="Type[@FullName='Microsoft.Maui.Controls.QueryPropertyAttribute']/Docs/*" />
 	[AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+	[RequiresUnreferencedCode(TrimmerConstants.QueryPropertyAttributeWarning, Url = TrimmerConstants.QueryPropertyDocsUrl)]
 	public class QueryPropertyAttribute : Attribute
 	{
 		/// <include file="../../../docs/Microsoft.Maui.Controls/QueryPropertyAttribute.xml" path="//Member[@MemberName='Name']/Docs/*" />

--- a/src/Controls/src/Core/Shell/ShellContent.cs
+++ b/src/Controls/src/Core/Shell/ShellContent.cs
@@ -295,42 +295,45 @@ namespace Microsoft.Maui.Controls
 			if (content is BindableObject bindable && bindable.BindingContext != null && content != bindable.BindingContext)
 				ApplyQueryAttributes(bindable.BindingContext, query, oldQuery);
 
-			var type = content.GetType();
-			var queryPropertyAttributes = type.GetCustomAttributes(typeof(QueryPropertyAttribute), true);
-			if (queryPropertyAttributes.Length == 0)
+			if (RuntimeFeature.IsQueryPropertyAttributeSupported)
 			{
-				ClearQueryIfAppliedToPage(query, content);
-				return;
-			}
-
-			foreach (QueryPropertyAttribute attrib in queryPropertyAttributes)
-			{
-				if (query.TryGetValue(attrib.QueryId, out var value))
+				var type = content.GetType();
+				var queryPropertyAttributes = type.GetCustomAttributes(typeof(QueryPropertyAttribute), true);
+				if (queryPropertyAttributes.Length == 0)
 				{
-					PropertyInfo prop = type.GetRuntimeProperty(attrib.Name);
+					ClearQueryIfAppliedToPage(query, content);
+					return;
+				}
 
-					if (prop != null && prop.CanWrite && prop.SetMethod.IsPublic)
+				foreach (QueryPropertyAttribute attrib in queryPropertyAttributes)
+				{
+					if (query.TryGetValue(attrib.QueryId, out var value))
 					{
-						if (prop.PropertyType == typeof(string))
-						{
-							if (value != null)
-								value = global::System.Net.WebUtility.UrlDecode((string)value);
+						PropertyInfo prop = type.GetRuntimeProperty(attrib.Name);
 
-							prop.SetValue(content, value);
-						}
-						else
+						if (prop != null && prop.CanWrite && prop.SetMethod.IsPublic)
 						{
-							var castValue = Convert.ChangeType(value, prop.PropertyType);
-							prop.SetValue(content, castValue);
+							if (prop.PropertyType == typeof(string))
+							{
+								if (value != null)
+									value = global::System.Net.WebUtility.UrlDecode((string)value);
+
+								prop.SetValue(content, value);
+							}
+							else
+							{
+								var castValue = Convert.ChangeType(value, prop.PropertyType);
+								prop.SetValue(content, castValue);
+							}
 						}
 					}
-				}
-				else if (oldQuery.TryGetValue(attrib.QueryId, out var oldValue))
-				{
-					PropertyInfo prop = type.GetRuntimeProperty(attrib.Name);
+					else if (oldQuery.TryGetValue(attrib.QueryId, out var oldValue))
+					{
+						PropertyInfo prop = type.GetRuntimeProperty(attrib.Name);
 
-					if (prop != null && prop.CanWrite && prop.SetMethod.IsPublic)
-						prop.SetValue(content, null);
+						if (prop != null && prop.CanWrite && prop.SetMethod.IsPublic)
+							prop.SetValue(content, null);
+					}
 				}
 			}
 

--- a/src/Controls/src/Core/TrimmerConstants.cs
+++ b/src/Controls/src/Core/TrimmerConstants.cs
@@ -10,5 +10,5 @@ class TrimmerConstants
 	internal const string XamlRuntimeParsingNotSupportedWarning = "Loading XAML at runtime might require types and members that cannot be statically analyzed. Make sure all of the required types and members are preserved.";
 
 	internal const string QueryPropertyAttributeWarning = "Using QueryPropertyAttribute is not trimming friendly and might not work correctly. Implement the IQueryAttributable interface instead.";
-	internal const string QueryPropertyDocsUrl = "https://learn.microsoft.com/en-us/dotnet/maui/fundamentals/shell/navigation#process-navigation-data-using-a-single-method";
+	internal const string QueryPropertyDocsUrl = "https://learn.microsoft.com/dotnet/maui/fundamentals/shell/navigation#process-navigation-data-using-a-single-method";
 }

--- a/src/Controls/src/Core/TrimmerConstants.cs
+++ b/src/Controls/src/Core/TrimmerConstants.cs
@@ -8,4 +8,7 @@ class TrimmerConstants
 	internal const string NativeBindingService = "This method properly handles missing properties, and there is not a way to preserve them from this method.";
 
 	internal const string XamlRuntimeParsingNotSupportedWarning = "Loading XAML at runtime might require types and members that cannot be statically analyzed. Make sure all of the required types and members are preserved.";
+
+	internal const string QueryPropertyAttributeWarning = "Using QueryPropertyAttribute is not trimming friendly and might not work correctly. Implement the IQueryAttributable interface instead.";
+	internal const string QueryPropertyDocsUrl = "https://learn.microsoft.com/en-us/dotnet/maui/fundamentals/shell/navigation#process-navigation-data-using-a-single-method";
 }

--- a/src/Core/src/ILLink.Substitutions.xml
+++ b/src/Core/src/ILLink.Substitutions.xml
@@ -5,6 +5,8 @@
       <method signature="System.Boolean get_IsXamlRuntimeParsingSupported()" body="stub" feature="Microsoft.Maui.RuntimeFeature.IsXamlRuntimeParsingSupported" value="true" featurevalue="true" />
       <method signature="System.Boolean get_IsIVisualAssemblyScanningEnabled()" body="stub" feature="Microsoft.Maui.RuntimeFeature.IsIVisualAssemblyScanningEnabled" value="false" featurevalue="false" />
       <method signature="System.Boolean get_IsIVisualAssemblyScanningEnabled()" body="stub" feature="Microsoft.Maui.RuntimeFeature.IsIVisualAssemblyScanningEnabled" value="true" featurevalue="true" />
+      <method signature="System.Boolean get_IsQueryPropertyAttributeSupported()" body="stub" feature="Microsoft.Maui.RuntimeFeature.IsQueryPropertyAttributeSupported" value="false" featurevalue="false" />
+      <method signature="System.Boolean get_IsQueryPropertyAttributeSupported()" body="stub" feature="Microsoft.Maui.RuntimeFeature.IsQueryPropertyAttributeSupported" value="true" featurevalue="true" />
     </type>
   </assembly>
 </linker>

--- a/src/Core/src/RuntimeFeature.cs
+++ b/src/Core/src/RuntimeFeature.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Maui
 	{
 		private const bool IsXamlRuntimeParsingSupportedByDefault = true;
 		private const bool IsIVisualAssemblyScanningEnabledByDefault = false;
+		private const bool IsQueryPropertyAttributeSupportedByDefault = true;
 
 		internal static bool IsXamlRuntimeParsingSupported
 			=> AppContext.TryGetSwitch("Microsoft.Maui.RuntimeFeature.IsXamlRuntimeParsingSupported", out bool isEnabled)
@@ -31,5 +32,10 @@ namespace Microsoft.Maui
 			AppContext.TryGetSwitch("Microsoft.Maui.RuntimeFeature.IsIVisualAssemblyScanningEnabled", out bool isEnabled)
 				? isEnabled
 				: IsIVisualAssemblyScanningEnabledByDefault;
+
+		internal static bool IsQueryPropertyAttributeSupported =>
+			AppContext.TryGetSwitch("Microsoft.Maui.RuntimeFeature.IsQueryPropertyAttributeSupported", out bool isSupported)
+				? isSupported
+				: IsQueryPropertyAttributeSupportedByDefault;
 	}
 }

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/BuildWarningsUtilities.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/BuildWarningsUtilities.cs
@@ -141,22 +141,6 @@ namespace Microsoft.Maui.IntegrationTests
 			},
 			new WarningsPerFile
 			{
-				File = "src/Controls/src/Core/Shell/ShellContent.cs",
-				WarningsPerCode = new List<WarningsPerCode>
-				{
-					new WarningsPerCode
-					{
-						Code = "IL2072",
-						Messages = new List<string>
-						{
-							"Microsoft.Maui.Controls.ShellContent.ApplyQueryAttributes(Object,ShellRouteParameters,ShellRouteParameters): 'name' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicProperties' in call to 'System.Reflection.RuntimeReflectionExtensions.GetRuntimeProperty(Type,String)'. The return value of method 'System.Object.GetType()' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.",
-							"Microsoft.Maui.Controls.ShellContent.ApplyQueryAttributes(Object,ShellRouteParameters,ShellRouteParameters): 'name' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicProperties' in call to 'System.Reflection.RuntimeReflectionExtensions.GetRuntimeProperty(Type,String)'. The return value of method 'System.Object.GetType()' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.",
-						}
-					},
-				}
-			},
-			new WarningsPerFile
-			{
 				File = "src/Controls/src/Core/BindingExpression.cs",
 				WarningsPerCode = new List<WarningsPerCode>
 				{


### PR DESCRIPTION
### Description of Change

This PR fixes 2 trimming warnings in `dotnet new maui` app.

This PR introduces a feature switch that will disable the part of shell navigation that propagates the query parameters to properties based on `[QueryProperty("PropertyName", "queryId")]` attributes. The developer can still consume query parameters by implementing the `IQueryAttributable` interface manually. The feature will enabled by default for all Mono apps and it will be disabled by default only when building with NativeAOT.

### Issues Fixed

Contributes to #19397 
We could reintroduce this feature for NativeAOT apps if #20466 is approved and implemented.

/cc @PureWeen @mattleibow @jonathanpeppers 