### PR TITLE
[ci] Update azdo BuildNumber

### DIFF
--- a/eng/Versions.targets
+++ b/eng/Versions.targets
@@ -99,7 +99,7 @@
     </ItemGroup>
 
     <Message Condition="$(CI) and '$(BUILD_REASON)' == 'Schedule'" Importance="high" Text="##vso[build.addbuildtag]$(NightlyTag)"/>
-    <Message Condition="$(CI)" Importance="high" Text="##vso[build.updatebuildnumber]$(PackageVersion)"/>
+    <Message Condition="$(CI) and '$(Build.BuildNumber)' != '$(PackageVersion)'" Importance="high" Text="##vso[build.updatebuildnumber]$(PackageVersion)"/>
   </Target>
 
   <Target Name="VersionInfoReport" DependsOnTargets="SetVersions">

--- a/eng/Versions.targets
+++ b/eng/Versions.targets
@@ -99,7 +99,7 @@
     </ItemGroup>
 
     <Message Condition="$(CI) and '$(BUILD_REASON)' == 'Schedule'" Importance="high" Text="##vso[build.addbuildtag]$(NightlyTag)"/>
-    <Message Condition="$(CI) and '$(Build.BuildNumber)' != '$(PackageVersion)'" Importance="high" Text="##vso[build.updatebuildnumber]$(PackageVersion)"/>
+    <Message Condition="$(CI) and '$(BUILD_BUILDNUMBER)' != '$(PackageVersion)'" Importance="high" Text="##vso[build.updatebuildnumber]$(PackageVersion)"/>
   </Target>
 
   <Target Name="VersionInfoReport" DependsOnTargets="SetVersions">


### PR DESCRIPTION
### Description of Change
This pull request includes a modification in the `eng/Versions.targets` file. The change refines the condition for updating the build number in the Continuous Integration (CI) environment. Now, the build number will only be updated if the current build number is not equal to the package version.

Fixes: 

Sometimes we get this failure on our build pipelines:

```
TF209010: The build number format 9.0.0-ci.net9.28848+pr.20714-sha.27ef680658-azdo.109346 (TaskId:363) contains invalid character(s), is too long, or ends with '.'. The maximum length of a build number is 255 characters. Characters which are not allowed include '"', '/', ':', '<', '>', '\', '|', '?', '@', and '*'.
```