### PR TITLE
[XamlC] Fix typed binding static property

### DIFF
--- a/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
+++ b/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
@@ -530,7 +530,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 
 				if (p.Length > 0)
 				{
-					var property = previousPartTypeRef.GetProperty(context.Cache, pd => pd.Name == p && pd.GetMethod != null && pd.GetMethod.IsPublic, out var propDeclTypeRef)
+					var property = previousPartTypeRef.GetProperty(context.Cache, pd => pd.Name == p && pd.GetMethod != null && pd.GetMethod.IsPublic && !pd.GetMethod.IsStatic, out var propDeclTypeRef)
 						?? throw new BuildException(BuildExceptionCode.BindingPropertyNotFound, lineInfo, null, p, previousPartTypeRef);
 					properties.Add((property, propDeclTypeRef, null));
 					previousPartTypeRef = property.PropertyType.ResolveGenericParameters(propDeclTypeRef);

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui20768.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui20768.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+using Microsoft.Maui.ApplicationModel;
+using Microsoft.Maui.Controls.Core.UnitTests;
+using Microsoft.Maui.Controls.Shapes;
+using Microsoft.Maui.Devices;
+using Microsoft.Maui.Dispatching;
+
+using Microsoft.Maui.Graphics;
+using Microsoft.Maui.UnitTests;
+using NUnit.Framework;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+[XamlCompilation(XamlCompilationOptions.Skip)]
+public partial class Maui20768
+{
+    public Maui20768()
+    {
+        InitializeComponent();
+    }
+
+    public Maui20768(bool useCompiledXaml)
+    {
+        //this stub will be replaced at compile time
+    }
+
+    [TestFixture]
+    class Test
+    {
+        [SetUp]
+        public void Setup()
+        {
+            Application.SetCurrentApplication(new MockApplication());
+            DispatcherProvider.SetCurrent(new DispatcherProviderStub());
+        }
+
+        [TearDown] public void TearDown() => AppInfo.SetCurrent(null);
+
+        [Test]
+        public void BindingsDoNotResolveStaticProperties([Values(false, true)] bool useCompiledXaml)
+        {
+            if (useCompiledXaml)
+            {
+                Assert.Throws(new BuildExceptionConstraint(6, 32), () => MockCompiler.Compile(typeof(Maui20768)));
+            }
+            else
+            {
+                var page = new Maui20768(useCompiledXaml);
+                page.TitleLabel.BindingContext = new ViewModel20768();
+                Assert.Null(page.TitleLabel.Text);
+            }
+        }
+    }
+}
+
+public class ViewModel20768
+{
+    public static string Title => "Title from static property";
+}

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui20768.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui20768.xaml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                    xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests"
+                    x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui20768">
+    <Label x:Name="TitleLabel" Text="{Binding Title, x:DataType=local:ViewModel20768}" />
+</ContentPage>


### PR DESCRIPTION
### Description of Change

This PR will report an error whenever there's a compiled binding which references a property which does exist, but it is static.

### Issues Fixed

Fixes #20768
