### PR TITLE
[ci] Upload build asset data to darc/maestro

### DIFF
--- a/eng/README.md
+++ b/eng/README.md
@@ -49,9 +49,32 @@ release branch is created, someone with `darc` installed locally will need to
 run the `add-subscription` command to configure updates against that new branch.
 
 
+#### Build Asset Manifest Promotion
+
+Builds from main and release branches will push NuGet package metadata to the
+darc/maestro Build Asset Registry.  This build information will also be promoted
+to a default darc/maestro channel if one is configured.  Default channels are
+manually managed at this time.  To configure a new default repo+branch <-> channel
+association, run the [`darc add-default-channel`][6] command:
+```
+darc add-default-channel --channel ".NET 9.0.1xx SDK" --branch "net9.0" --repo https://github.com/dotnet/maui
+```
+
+When a new release branch is created, this command should look something like this:
+```
+darc add-default-channel --channel ".NET 9.0.1xx SDK Preview 1" --branch "release/9.0.1xx-preview1" --repo https://github.com/dotnet/maui
+```
+
+Other products/tools can consume our package version info in the following way:
+```
+darc add-dependency -n Microsoft.Maui.Sdk -t product -r https://github.com/dotnet/maui -v 1.2.3
+```
+
+
 [0]: https://github.com/dotnet/arcade/blob/ea609b8e036359934332480de9336d98fcbb3f91/Documentation/Darc.md
 [1]: https://github.com/dotnet/arcade/blob/ea609b8e036359934332480de9336d98fcbb3f91/Documentation/Darc.md#setting-up-your-darc-client
 [2]: https://github.com/dotnet/arcade/blob/ea609b8e036359934332480de9336d98fcbb3f91/Documentation/Darc.md#authenticate
 [3]: https://github.com/dotnet/arcade/blob/ea609b8e036359934332480de9336d98fcbb3f91/Documentation/Darc.md#add-dependency
 [4]: https://github.com/dotnet/arcade/blob/ea609b8e036359934332480de9336d98fcbb3f91/Documentation/Darc.md#update-dependencies
 [5]: https://github.com/dotnet/arcade/blob/ea609b8e036359934332480de9336d98fcbb3f91/Documentation/Darc.md#add-subscription
+[6]: https://github.com/dotnet/arcade/blob/ea609b8e036359934332480de9336d98fcbb3f91/Documentation/Darc.md#add-default-channel

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -13,4 +13,10 @@
       <Sha>11ae3663fe3de366ea3566d7ae9b4731adee2ca3</Sha>
     </Dependency>
   </ProductDependencies>
+  <ToolsetDependencies>
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="8.0.0-beta.24113.2">
+      <Uri>https://github.com/dotnet/arcade</Uri>
+      <Sha>da98edc4c3ea539f109ea320672136ceb32591a7</Sha>
+    </Dependency>
+  </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -84,6 +84,7 @@
     <TizenUIExtensionsVersion>0.9.2</TizenUIExtensionsVersion>
     <SvgSkiaPackageVersion>0.5.13</SvgSkiaPackageVersion>
     <FizzlerPackageVersion>1.2.0</FizzlerPackageVersion>
+    <MicrosoftDotNetBuildTasksFeedVersion>8.0.0-beta.24113.2</MicrosoftDotNetBuildTasksFeedVersion>
   </PropertyGroup>
   <PropertyGroup>
     <MicrosoftNETTestSdkPackageVersion>17.6.0</MicrosoftNETTestSdkPackageVersion>

--- a/eng/pipelines/common/insertion.yml
+++ b/eng/pipelines/common/insertion.yml
@@ -1,6 +1,7 @@
 parameters:
-  poolName: Azure Pipelines
-  vmImage: windows-latest 
+  poolName: VSEngSS-MicroBuild2022-1ES
+  vmImage: ''
+  pushMauiPackagesToMaestro: false
 
 stages:
   - stage: sdk_insertion
@@ -12,6 +13,7 @@ stages:
       parameters:
         poolName: ${{ parameters.poolName }}
         vmImage: ${{ parameters.vmImage }}
+        pushMauiPackagesToMaestro: ${{ parameters.pushMauiPackagesToMaestro }}
 
   - stage: sbom
     displayName: 'Software Bill of Materials'

--- a/eng/pipelines/common/sdk-insertion.yml
+++ b/eng/pipelines/common/sdk-insertion.yml
@@ -5,7 +5,7 @@ parameters:
 
 jobs:
 - job: create_artifact_statuses
-  displayName: Create GitHub Artifact Status And Push to Maestro
+  displayName: Create GitHub Artifact Status and Push to Maestro
   timeoutInMinutes: 60
   pool:
     name: ${{ parameters.poolName }}

--- a/eng/pipelines/common/sdk-insertion.yml
+++ b/eng/pipelines/common/sdk-insertion.yml
@@ -1,14 +1,18 @@
 parameters:
-  poolName: Azure Pipelines
-  vmImage: windows-latest 
+  poolName: VSEngSS-MicroBuild2022-1ES
+  vmImage: ''
+  pushMauiPackagesToMaestro: false
 
 jobs:
 - job: create_artifact_statuses
-  displayName: Create GitHub Artifact Status
+  displayName: Create GitHub Artifact Status And Push to Maestro
   timeoutInMinutes: 60
   pool:
     name: ${{ parameters.poolName }}
     vmImage: ${{ parameters.vmImage }}
+  variables:
+  - ${{ if eq('${{ parameters.pushMauiPackagesToMaestro }}', 'true') }}:
+    - group: Publish-Build-Assets
   steps:
   - checkout: self
   - task: DownloadPipelineArtifact@2
@@ -57,3 +61,21 @@ jobs:
         inputs:
           artifactName: vsdrop-multitarget-signed
           downloadPath: $(Build.StagingDirectory)/$(MultiTargetVSDropCommitStatusName)
+  - task: DotNetCoreCLI@2
+    displayName: Generate and publish BAR manifest
+    inputs:
+      projects: $(Build.SourcesDirectory)\src\Workload\Microsoft.Maui.Sdk\Microsoft.Maui.Sdk.csproj
+      arguments: >-
+      -t:PushManifestToBuildAssetRegistry
+      -p:BuildAssetRegistryToken=$(MaestroAccessToken)
+      -p:OutputPath=$(Build.StagingDirectory)\nuget\
+      -v:n -bl:$(Build.StagingDirectory)\binlogs\push-bar-manifest.binlog
+    condition: and(succeeded(), eq('${{ parameters.pushMauiPackagesToMaestro }}', 'true'))
+  - powershell: |
+      $versionEndpoint = 'https://maestro-prod.westus2.cloudapp.azure.com/api/assets/darc-version?api-version=2019-01-16'
+      $darcVersion = $(Invoke-WebRequest -Uri $versionEndpoint -UseBasicParsing).Content
+      $arcadeServicesSource = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json'
+      & dotnet tool update microsoft.dotnet.darc --version "$darcVersion" --add-source "$arcadeServicesSource" --tool-path $(Agent.ToolsDirectory)\darc -v n
+      & $(Agent.ToolsDirectory)\darc\darc add-build-to-channel --default-channels --id $(BARBuildId) --publishing-infra-version 3 --skip-assets-publishing --password $(MaestroAccessToken) --azdev-pat $(publishing-dnceng-devdiv-code-r-build-re)
+    displayName: Add build to default darc channel
+    condition: and(succeeded(), eq('${{ parameters.pushMauiPackagesToMaestro }}', 'true'))

--- a/eng/pipelines/common/sdk-insertion.yml
+++ b/eng/pipelines/common/sdk-insertion.yml
@@ -11,8 +11,7 @@ jobs:
     name: ${{ parameters.poolName }}
     vmImage: ${{ parameters.vmImage }}
   variables:
-  - ${{ if eq('${{ parameters.pushMauiPackagesToMaestro }}', 'true') }}:
-    - group: Publish-Build-Assets
+  - group: Publish-Build-Assets
   steps:
   - checkout: self
   - task: DownloadPipelineArtifact@2

--- a/eng/pipelines/common/sdk-insertion.yml
+++ b/eng/pipelines/common/sdk-insertion.yml
@@ -66,10 +66,10 @@ jobs:
     inputs:
       projects: $(Build.SourcesDirectory)\src\Workload\Microsoft.Maui.Sdk\Microsoft.Maui.Sdk.csproj
       arguments: >-
-      -t:PushManifestToBuildAssetRegistry
-      -p:BuildAssetRegistryToken=$(MaestroAccessToken)
-      -p:OutputPath=$(Build.StagingDirectory)\nuget\
-      -v:n -bl:$(Build.StagingDirectory)\binlogs\push-bar-manifest.binlog
+        -t:PushManifestToBuildAssetRegistry
+        -p:BuildAssetRegistryToken=$(MaestroAccessToken)
+        -p:OutputPath=$(Build.StagingDirectory)\nuget\
+        -v:n -bl:$(Build.StagingDirectory)\binlogs\push-bar-manifest.binlog
     condition: and(succeeded(), eq('${{ parameters.pushMauiPackagesToMaestro }}', 'true'))
   - powershell: |
       $versionEndpoint = 'https://maestro-prod.westus2.cloudapp.azure.com/api/assets/darc-version?api-version=2019-01-16'

--- a/eng/pipelines/maui-release.yml
+++ b/eng/pipelines/maui-release.yml
@@ -26,6 +26,9 @@ variables:
   - template: templates/common/vs-release-vars.yml@sdk-insertions
 
 parameters:
+  - name: pushMauiPackagesToMaestro
+    default: true
+
   - name: provisionatorChannel
     displayName: 'Provisionator channel'
     type: string
@@ -83,5 +86,4 @@ stages:
     - template: common/sign.yml                                     # Sign only using the private server
     - template: common/insertion.yml                                # Insert on VS and SDK
       parameters:
-        poolName: $(windowsNet6VmPool)
-        vmImage: $(windowsNet6VmImage)
+        pushMauiPackagesToMaestro: ${{ parameters.pushMauiPackagesToMaestro }}

--- a/src/Workload/Microsoft.Maui.Sdk/Microsoft.Maui.Sdk.csproj
+++ b/src/Workload/Microsoft.Maui.Sdk/Microsoft.Maui.Sdk.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.Build.NoTargets">
 
   <Import Project="../Shared/Common.targets" />
+  <Import Project="../Shared/Maestro.targets" />
 
   <PropertyGroup>
     <OutputPath>$(DotNetPacksDirectory)$(PackageId)/$(PackageVersion)/</OutputPath>

--- a/src/Workload/Shared/Maestro.targets
+++ b/src/Workload/Shared/Maestro.targets
@@ -36,12 +36,12 @@
     <MSBuild
         Targets="Restore"
         Projects="$(PkgMicrosoft_DotNet_Arcade_Sdk)\tools\SdkTasks\PublishBuildAssets.proj"
-        Properties="Configuration=$(Configuration);RepoRoot=$(MauiRootDirectory);VersionPrefix=$(PackageReferenceVersion)"
+        Properties="Configuration=$(Configuration);RepoRoot=$(MauiRootDirectory);VersionPrefix=$(_MauiDotNetVersion)"
     />
 
     <MSBuild
         Projects="$(PkgMicrosoft_DotNet_Arcade_Sdk)\tools\SdkTasks\PublishBuildAssets.proj"
-        Properties="Configuration=$(Configuration);RepoRoot=$(MauiRootDirectory);VersionPrefix=$(PackageReferenceVersion);ManifestsPath=$(OutputPath)bar-manifests;MaestroApiEndpoint=https://maestro-prod.westus2.cloudapp.azure.com"
+        Properties="Configuration=$(Configuration);RepoRoot=$(MauiRootDirectory);VersionPrefix=$(_MauiDotNetVersion);ManifestsPath=$(OutputPath)bar-manifests;MaestroApiEndpoint=https://maestro-prod.westus2.cloudapp.azure.com"
     />
   </Target>
 

--- a/src/Workload/Shared/Maestro.targets
+++ b/src/Workload/Shared/Maestro.targets
@@ -13,16 +13,6 @@
 
     <Error Condition="'@(BuildArtifacts)' == ''" Text="No packages to create manifest from." />
 
-    <PropertyGroup>
-      <BUILD_BUILDID>test-buildid</BUILD_BUILDID>
-      <SYSTEM_DEFINITIONID>test-defid</SYSTEM_DEFINITIONID>
-      <SYSTEM_TEAMPROJECT>test-teamproject</SYSTEM_TEAMPROJECT>
-      <BUILD_BUILDNUMBER>test-buildnum</BUILD_BUILDNUMBER>
-      <BUILD_REPOSITORY_URI>test-repouri</BUILD_REPOSITORY_URI>
-      <BUILD_SOURCEBRANCH>test-sourcebranch</BUILD_SOURCEBRANCH>
-      <BUILD_SOURCEVERSION>test-sourcevers</BUILD_SOURCEVERSION>
-    </PropertyGroup>
-
     <ItemGroup>
       <ManifestBuildData Include="InitialAssetsLocation=https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json" />
       <ManifestBuildData Include="AzureDevOpsBuildId=$(BUILD_BUILDID)" />

--- a/src/Workload/Shared/Maestro.targets
+++ b/src/Workload/Shared/Maestro.targets
@@ -1,4 +1,8 @@
 <Project>
+  <PropertyGroup>
+    <RootManifestOutputPath>$([MSBuild]::EnsureTrailingSlash($(OutputPath)))</RootManifestOutputPath>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.DotNet.Arcade.Sdk" Version="$(MicrosoftDotNetBuildTasksFeedVersion)" PrivateAssets="all" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.DotNet.Build.Tasks.Feed" Version="$(MicrosoftDotNetBuildTasksFeedVersion)" PrivateAssets="all" />
@@ -8,7 +12,7 @@
 
   <Target Name="PushManifestToBuildAssetRegistry" >
     <ItemGroup>
-      <BuildArtifacts Include="$(OutputPath)\**\*.nupkg" />
+      <BuildArtifacts Include="$(RootManifestOutputPath)**\*.nupkg" />
     </ItemGroup>
 
     <Error Condition="'@(BuildArtifacts)' == ''" Text="No packages to create manifest from." />
@@ -25,7 +29,7 @@
 
     <GenerateBuildManifest
         Artifacts="@(BuildArtifacts)"
-        OutputPath="$(OutputPath)\bar-manifests\AssetManifest.xml"
+        OutputPath="$(RootManifestOutputPath)bar-manifests\AssetManifest.xml"
         BuildId="$(BUILD_BUILDNUMBER)"
         BuildData="@(ManifestBuildData)"
         RepoUri="$(BUILD_REPOSITORY_URI)"
@@ -41,7 +45,7 @@
 
     <MSBuild
         Projects="$(PkgMicrosoft_DotNet_Arcade_Sdk)\tools\SdkTasks\PublishBuildAssets.proj"
-        Properties="Configuration=$(Configuration);RepoRoot=$(MauiRootDirectory);VersionPrefix=$(_MauiDotNetVersion);ManifestsPath=$(OutputPath)bar-manifests;MaestroApiEndpoint=https://maestro-prod.westus2.cloudapp.azure.com"
+        Properties="Configuration=$(Configuration);RepoRoot=$(MauiRootDirectory);VersionPrefix=$(_MauiDotNetVersion);ManifestsPath=$(RootManifestOutputPath)bar-manifests;MaestroApiEndpoint=https://maestro-prod.westus2.cloudapp.azure.com"
     />
   </Target>
 

--- a/src/Workload/Shared/Maestro.targets
+++ b/src/Workload/Shared/Maestro.targets
@@ -1,0 +1,58 @@
+<Project>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.DotNet.Arcade.Sdk" Version="$(MicrosoftDotNetBuildTasksFeedVersion)" PrivateAssets="all" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.DotNet.Build.Tasks.Feed" Version="$(MicrosoftDotNetBuildTasksFeedVersion)" PrivateAssets="all" />
+  </ItemGroup>
+
+  <UsingTask TaskName="GenerateBuildManifest" AssemblyFile="$(_MicrosoftDotNetBuildTasksFeedTaskDir)Microsoft.DotNet.Build.Tasks.Feed.dll" />
+
+  <Target Name="PushManifestToBuildAssetRegistry" >
+    <ItemGroup>
+      <BuildArtifacts Include="$(OutputPath)\**\*.nupkg" />
+    </ItemGroup>
+
+    <Error Condition="'@(BuildArtifacts)' == ''" Text="No packages to create manifest from." />
+
+    <PropertyGroup>
+      <BUILD_BUILDID>test-buildid</BUILD_BUILDID>
+      <SYSTEM_DEFINITIONID>test-defid</SYSTEM_DEFINITIONID>
+      <SYSTEM_TEAMPROJECT>test-teamproject</SYSTEM_TEAMPROJECT>
+      <BUILD_BUILDNUMBER>test-buildnum</BUILD_BUILDNUMBER>
+      <BUILD_REPOSITORY_URI>test-repouri</BUILD_REPOSITORY_URI>
+      <BUILD_SOURCEBRANCH>test-sourcebranch</BUILD_SOURCEBRANCH>
+      <BUILD_SOURCEVERSION>test-sourcevers</BUILD_SOURCEVERSION>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ManifestBuildData Include="InitialAssetsLocation=https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json" />
+      <ManifestBuildData Include="AzureDevOpsBuildId=$(BUILD_BUILDID)" />
+      <ManifestBuildData Include="AzureDevOpsBuildDefinitionId=$(SYSTEM_DEFINITIONID)" />
+      <ManifestBuildData Include="AzureDevOpsProject=$(SYSTEM_TEAMPROJECT)" />
+      <ManifestBuildData Include="AzureDevOpsBuildNumber=$(BUILD_BUILDNUMBER)" />
+      <ManifestBuildData Include="AzureDevOpsRepository=$(BUILD_REPOSITORY_URI)" />
+      <ManifestBuildData Include="AzureDevOpsBranch=$(BUILD_SOURCEBRANCH)" />
+    </ItemGroup>
+
+    <GenerateBuildManifest
+        Artifacts="@(BuildArtifacts)"
+        OutputPath="$(OutputPath)\bar-manifests\AssetManifest.xml"
+        BuildId="$(BUILD_BUILDNUMBER)"
+        BuildData="@(ManifestBuildData)"
+        RepoUri="$(BUILD_REPOSITORY_URI)"
+        RepoBranch="$(BUILD_SOURCEBRANCH)"
+        RepoCommit="$(BUILD_SOURCEVERSION)"
+        PublishingVersion="3" />
+
+    <MSBuild
+        Targets="Restore"
+        Projects="$(PkgMicrosoft_DotNet_Arcade_Sdk)\tools\SdkTasks\PublishBuildAssets.proj"
+        Properties="Configuration=$(Configuration);RepoRoot=$(MauiRootDirectory);VersionPrefix=$(PackageReferenceVersion)"
+    />
+
+    <MSBuild
+        Projects="$(PkgMicrosoft_DotNet_Arcade_Sdk)\tools\SdkTasks\PublishBuildAssets.proj"
+        Properties="Configuration=$(Configuration);RepoRoot=$(MauiRootDirectory);VersionPrefix=$(PackageReferenceVersion);ManifestsPath=$(OutputPath)bar-manifests;MaestroApiEndpoint=https://maestro-prod.westus2.cloudapp.azure.com"
+    />
+  </Target>
+
+</Project>


### PR DESCRIPTION
The `maui-release` pipeline has been updated to publish information
about MAUI .NET .nupkg files to the dotnet Maestro server.

With this data being published, the `darc` tool can now be used to
manage a MAUI .NET  product dependency.

For dependency updating to work, we must configure "default channel"
associations for all MAUI branches that other products may be interested
in tracking.  The `darc` tool can be used to do this manually:

    darc add-default-channel --channel ".NET 9.0.1xx SDK" --branch "net9.0" --repo https://github.com/dotnet/maui

This default channel configuration ensures that all new builds produced
by the net9.0 branch will be associated with the .NET 9 channel.  MAUI
consumers can then update to the latest build available from net9.0 with
the `update-dependencies` command:

    darc update-dependencies --channel ".NET 9.0.1xx SDK"