### PR TITLE
[XamlC] Fix error XDataTypeSyntax message format

### DIFF
--- a/loc/cs/src/Controls/src/Build.Tasks/ErrorMessages.resx.lcl
+++ b/loc/cs/src/Controls/src/Build.Tasks/ErrorMessages.resx.lcl
@@ -260,7 +260,7 @@
       </Item>
       <Item ItemId=";XDataTypeSyntax" ItemType="0;.resx" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[x:DataType expects a string literal, an {{x:Type}} markup or {{x:Nul}l}.]]></Val>
+          <Val><![CDATA[x:DataType expects a string literal, an {{x:Type}} markup or {{x:Null}}.]]></Val>
         </Str>
         <Disp Icon="Str" />
       </Item>

--- a/loc/de/src/Controls/src/Build.Tasks/ErrorMessages.resx.lcl
+++ b/loc/de/src/Controls/src/Build.Tasks/ErrorMessages.resx.lcl
@@ -260,7 +260,7 @@
       </Item>
       <Item ItemId=";XDataTypeSyntax" ItemType="0;.resx" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[x:DataType expects a string literal, an {{x:Type}} markup or {{x:Nul}l}.]]></Val>
+          <Val><![CDATA[x:DataType expects a string literal, an {{x:Type}} markup or {{x:Null}}.]]></Val>
         </Str>
         <Disp Icon="Str" />
       </Item>

--- a/loc/es/src/Controls/src/Build.Tasks/ErrorMessages.resx.lcl
+++ b/loc/es/src/Controls/src/Build.Tasks/ErrorMessages.resx.lcl
@@ -260,7 +260,7 @@
       </Item>
       <Item ItemId=";XDataTypeSyntax" ItemType="0;.resx" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[x:DataType expects a string literal, an {{x:Type}} markup or {{x:Nul}l}.]]></Val>
+          <Val><![CDATA[x:DataType expects a string literal, an {{x:Type}} markup or {{x:Null}}.]]></Val>
         </Str>
         <Disp Icon="Str" />
       </Item>

--- a/loc/fr/src/Controls/src/Build.Tasks/ErrorMessages.resx.lcl
+++ b/loc/fr/src/Controls/src/Build.Tasks/ErrorMessages.resx.lcl
@@ -260,7 +260,7 @@
       </Item>
       <Item ItemId=";XDataTypeSyntax" ItemType="0;.resx" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[x:DataType expects a string literal, an {{x:Type}} markup or {{x:Nul}l}.]]></Val>
+          <Val><![CDATA[x:DataType expects a string literal, an {{x:Type}} markup or {{x:Null}}.]]></Val>
         </Str>
         <Disp Icon="Str" />
       </Item>

--- a/loc/it/src/Controls/src/Build.Tasks/ErrorMessages.resx.lcl
+++ b/loc/it/src/Controls/src/Build.Tasks/ErrorMessages.resx.lcl
@@ -260,7 +260,7 @@
       </Item>
       <Item ItemId=";XDataTypeSyntax" ItemType="0;.resx" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[x:DataType expects a string literal, an {{x:Type}} markup or {{x:Nul}l}.]]></Val>
+          <Val><![CDATA[x:DataType expects a string literal, an {{x:Type}} markup or {{x:Null}}.]]></Val>
         </Str>
         <Disp Icon="Str" />
       </Item>

--- a/loc/ja/src/Controls/src/Build.Tasks/ErrorMessages.resx.lcl
+++ b/loc/ja/src/Controls/src/Build.Tasks/ErrorMessages.resx.lcl
@@ -260,7 +260,7 @@
       </Item>
       <Item ItemId=";XDataTypeSyntax" ItemType="0;.resx" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[x:DataType expects a string literal, an {{x:Type}} markup or {{x:Nul}l}.]]></Val>
+          <Val><![CDATA[x:DataType expects a string literal, an {{x:Type}} markup or {{x:Null}}.]]></Val>
         </Str>
         <Disp Icon="Str" />
       </Item>

--- a/loc/ko/src/Controls/src/Build.Tasks/ErrorMessages.resx.lcl
+++ b/loc/ko/src/Controls/src/Build.Tasks/ErrorMessages.resx.lcl
@@ -260,7 +260,7 @@
       </Item>
       <Item ItemId=";XDataTypeSyntax" ItemType="0;.resx" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[x:DataType expects a string literal, an {{x:Type}} markup or {{x:Nul}l}.]]></Val>
+          <Val><![CDATA[x:DataType expects a string literal, an {{x:Type}} markup or {{x:Null}}.]]></Val>
         </Str>
         <Disp Icon="Str" />
       </Item>

--- a/loc/pl/src/Controls/src/Build.Tasks/ErrorMessages.resx.lcl
+++ b/loc/pl/src/Controls/src/Build.Tasks/ErrorMessages.resx.lcl
@@ -260,7 +260,7 @@
       </Item>
       <Item ItemId=";XDataTypeSyntax" ItemType="0;.resx" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[x:DataType expects a string literal, an {{x:Type}} markup or {{x:Nul}l}.]]></Val>
+          <Val><![CDATA[x:DataType expects a string literal, an {{x:Type}} markup or {{x:Null}}.]]></Val>
         </Str>
         <Disp Icon="Str" />
       </Item>

--- a/loc/pt-BR/src/Controls/src/Build.Tasks/ErrorMessages.resx.lcl
+++ b/loc/pt-BR/src/Controls/src/Build.Tasks/ErrorMessages.resx.lcl
@@ -260,7 +260,7 @@
       </Item>
       <Item ItemId=";XDataTypeSyntax" ItemType="0;.resx" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[x:DataType expects a string literal, an {{x:Type}} markup or {{x:Nul}l}.]]></Val>
+          <Val><![CDATA[x:DataType expects a string literal, an {{x:Type}} markup or {{x:Null}}.]]></Val>
         </Str>
         <Disp Icon="Str" />
       </Item>

--- a/loc/ru/src/Controls/src/Build.Tasks/ErrorMessages.resx.lcl
+++ b/loc/ru/src/Controls/src/Build.Tasks/ErrorMessages.resx.lcl
@@ -260,7 +260,7 @@
       </Item>
       <Item ItemId=";XDataTypeSyntax" ItemType="0;.resx" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[x:DataType expects a string literal, an {{x:Type}} markup or {{x:Nul}l}.]]></Val>
+          <Val><![CDATA[x:DataType expects a string literal, an {{x:Type}} markup or {{x:Null}}.]]></Val>
         </Str>
         <Disp Icon="Str" />
       </Item>

--- a/loc/tr/src/Controls/src/Build.Tasks/ErrorMessages.resx.lcl
+++ b/loc/tr/src/Controls/src/Build.Tasks/ErrorMessages.resx.lcl
@@ -260,7 +260,7 @@
       </Item>
       <Item ItemId=";XDataTypeSyntax" ItemType="0;.resx" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[x:DataType expects a string literal, an {{x:Type}} markup or {{x:Nul}l}.]]></Val>
+          <Val><![CDATA[x:DataType expects a string literal, an {{x:Type}} markup or {{x:Null}}.]]></Val>
         </Str>
         <Disp Icon="Str" />
       </Item>

--- a/loc/zh-Hans/src/Controls/src/Build.Tasks/ErrorMessages.resx.lcl
+++ b/loc/zh-Hans/src/Controls/src/Build.Tasks/ErrorMessages.resx.lcl
@@ -260,7 +260,7 @@
       </Item>
       <Item ItemId=";XDataTypeSyntax" ItemType="0;.resx" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[x:DataType expects a string literal, an {{x:Type}} markup or {{x:Nul}l}.]]></Val>
+          <Val><![CDATA[x:DataType expects a string literal, an {{x:Type}} markup or {{x:Null}}.]]></Val>
         </Str>
         <Disp Icon="Str" />
       </Item>

--- a/loc/zh-Hant/src/Controls/src/Build.Tasks/ErrorMessages.resx.lcl
+++ b/loc/zh-Hant/src/Controls/src/Build.Tasks/ErrorMessages.resx.lcl
@@ -260,7 +260,7 @@
       </Item>
       <Item ItemId=";XDataTypeSyntax" ItemType="0;.resx" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[x:DataType expects a string literal, an {{x:Type}} markup or {{x:Nul}l}.]]></Val>
+          <Val><![CDATA[x:DataType expects a string literal, an {{x:Type}} markup or {{x:Null}}.]]></Val>
         </Str>
         <Disp Icon="Str" />
       </Item>

--- a/src/Controls/src/Build.Tasks/ErrorMessages.Designer.cs
+++ b/src/Controls/src/Build.Tasks/ErrorMessages.Designer.cs
@@ -340,7 +340,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to x:DataType expects a string literal, an {{x:Type}} markup or {{x:Nul}l}..
+        ///   Looks up a localized string similar to x:DataType expects a string literal, an {{x:Type}} markup or {{x:Null}}..
         /// </summary>
         internal static string XDataTypeSyntax {
             get {

--- a/src/Controls/src/Build.Tasks/ErrorMessages.resx
+++ b/src/Controls/src/Build.Tasks/ErrorMessages.resx
@@ -241,7 +241,7 @@
     <comment>0 is a type name</comment>
   </data>
   <data name="XDataTypeSyntax" xml:space="preserve">
-    <value>x:DataType expects a string literal, an {{x:Type}} markup or {{x:Nul}l}.</value>
+    <value>x:DataType expects a string literal, an {{x:Type}} markup or {{x:Null}}.</value>
   </data>
   <data name="UnattributedMarkupType" xml:space="preserve">
     <value>Consider attributing the markup extension "{0}" with [RequireService] or [AcceptEmptyServiceProvider] if it doesn't require any.</value>

--- a/src/Controls/src/Build.Tasks/xlf/ErrorMessages.cs.resx
+++ b/src/Controls/src/Build.Tasks/xlf/ErrorMessages.cs.resx
@@ -232,7 +232,7 @@
     <comment>0 is a type name</comment>
   </data>
   <data name="XDataTypeSyntax" xml:space="preserve">
-    <value>x:DataType očekává řetězcový literál, značku {{x:Type}} nebo {{x:Nul}l}.</value>
+    <value>x:DataType očekává řetězcový literál, značku {{x:Type}} nebo {{x:Null}}.</value>
   </data>
   <data name="XmlnsUndeclared" xml:space="preserve">
     <value>Nedeklarovaná předpona xmlns: {0}</value>

--- a/src/Controls/src/Build.Tasks/xlf/ErrorMessages.cs.xlf
+++ b/src/Controls/src/Build.Tasks/xlf/ErrorMessages.cs.xlf
@@ -158,8 +158,8 @@
         <note>0 is a type name</note>
       </trans-unit>
       <trans-unit id="XDataTypeSyntax">
-        <source>x:DataType expects a string literal, an {{x:Type}} markup or {{x:Nul}l}.</source>
-        <target state="translated">x:DataType očekává řetězcový literál, značku {{x:Type}} nebo {{x:Nul}l}.</target>
+        <source>x:DataType expects a string literal, an {{x:Type}} markup or {{x:Null}}.</source>
+        <target state="translated">x:DataType očekává řetězcový literál, značku {{x:Type}} nebo {{x:Null}}.</target>
         <note />
       </trans-unit>
       <trans-unit id="XKeyNotLiteral">

--- a/src/Controls/src/Build.Tasks/xlf/ErrorMessages.de.resx
+++ b/src/Controls/src/Build.Tasks/xlf/ErrorMessages.de.resx
@@ -232,7 +232,7 @@
     <comment>0 is a type name</comment>
   </data>
   <data name="XDataTypeSyntax" xml:space="preserve">
-    <value>x:DataType erwartet ein Zeichenfolgenliteral, ein {{x:Type}}-Markup oder {{x:Nul}l}.</value>
+    <value>x:DataType erwartet ein Zeichenfolgenliteral, ein {{x:Type}}-Markup oder {{x:Null}}.</value>
   </data>
   <data name="XmlnsUndeclared" xml:space="preserve">
     <value>Nicht deklariertes xmlns-Präfix "{0}".</value>

--- a/src/Controls/src/Build.Tasks/xlf/ErrorMessages.de.xlf
+++ b/src/Controls/src/Build.Tasks/xlf/ErrorMessages.de.xlf
@@ -158,8 +158,8 @@
         <note>0 is a type name</note>
       </trans-unit>
       <trans-unit id="XDataTypeSyntax">
-        <source>x:DataType expects a string literal, an {{x:Type}} markup or {{x:Nul}l}.</source>
-        <target state="translated">x:DataType erwartet ein Zeichenfolgenliteral, ein {{x:Type}}-Markup oder {{x:Nul}l}.</target>
+        <source>x:DataType expects a string literal, an {{x:Type}} markup or {{x:Null}}.</source>
+        <target state="translated">x:DataType erwartet ein Zeichenfolgenliteral, ein {{x:Type}}-Markup oder {{x:Null}}.</target>
         <note />
       </trans-unit>
       <trans-unit id="XKeyNotLiteral">

--- a/src/Controls/src/Build.Tasks/xlf/ErrorMessages.es.resx
+++ b/src/Controls/src/Build.Tasks/xlf/ErrorMessages.es.resx
@@ -232,7 +232,7 @@
     <comment>0 is a type name</comment>
   </data>
   <data name="XDataTypeSyntax" xml:space="preserve">
-    <value>x:DataType espera un literal de cadena, una marca {{x:Type}} o {{x:Nul}l}.</value>
+    <value>x:DataType espera un literal de cadena, una marca {{x:Type}} o {{x:Null}}.</value>
   </data>
   <data name="XmlnsUndeclared" xml:space="preserve">
     <value>Prefijo xmlns no declarado "{0}".</value>

--- a/src/Controls/src/Build.Tasks/xlf/ErrorMessages.es.xlf
+++ b/src/Controls/src/Build.Tasks/xlf/ErrorMessages.es.xlf
@@ -158,8 +158,8 @@
         <note>0 is a type name</note>
       </trans-unit>
       <trans-unit id="XDataTypeSyntax">
-        <source>x:DataType expects a string literal, an {{x:Type}} markup or {{x:Nul}l}.</source>
-        <target state="translated">x:DataType espera un literal de cadena, una marca {{x:Type}} o {{x:Nul}l}.</target>
+        <source>x:DataType expects a string literal, an {{x:Type}} markup or {{x:Null}}.</source>
+        <target state="translated">x:DataType espera un literal de cadena, una marca {{x:Type}} o {{x:Null}}.</target>
         <note />
       </trans-unit>
       <trans-unit id="XKeyNotLiteral">

--- a/src/Controls/src/Build.Tasks/xlf/ErrorMessages.fr.resx
+++ b/src/Controls/src/Build.Tasks/xlf/ErrorMessages.fr.resx
@@ -232,7 +232,7 @@
     <comment>0 is a type name</comment>
   </data>
   <data name="XDataTypeSyntax" xml:space="preserve">
-    <value>x:DataType attend un littéral de chaîne, une balise {{x:Type}} ou {{x:Nul}l}.</value>
+    <value>x:DataType attend un littéral de chaîne, une balise {{x:Type}} ou {{x:Null}}.</value>
   </data>
   <data name="XmlnsUndeclared" xml:space="preserve">
     <value>Préfixe xmlns non déclaré "{0}".</value>

--- a/src/Controls/src/Build.Tasks/xlf/ErrorMessages.fr.xlf
+++ b/src/Controls/src/Build.Tasks/xlf/ErrorMessages.fr.xlf
@@ -158,8 +158,8 @@
         <note>0 is a type name</note>
       </trans-unit>
       <trans-unit id="XDataTypeSyntax">
-        <source>x:DataType expects a string literal, an {{x:Type}} markup or {{x:Nul}l}.</source>
-        <target state="translated">x:DataType attend un littéral de chaîne, une balise {{x:Type}} ou {{x:Nul}l}.</target>
+        <source>x:DataType expects a string literal, an {{x:Type}} markup or {{x:Null}}.</source>
+        <target state="translated">x:DataType attend un littéral de chaîne, une balise {{x:Type}} ou {{x:Null}}.</target>
         <note />
       </trans-unit>
       <trans-unit id="XKeyNotLiteral">

--- a/src/Controls/src/Build.Tasks/xlf/ErrorMessages.it.resx
+++ b/src/Controls/src/Build.Tasks/xlf/ErrorMessages.it.resx
@@ -232,7 +232,7 @@
     <comment>0 is a type name</comment>
   </data>
   <data name="XDataTypeSyntax" xml:space="preserve">
-    <value>Con x:DataType è previsto un valore letterale stringa, un markup {{x:Type}} oppure {{x:Nul}l}.</value>
+    <value>Con x:DataType è previsto un valore letterale stringa, un markup {{x:Type}} oppure {{x:Null}}.</value>
   </data>
   <data name="XmlnsUndeclared" xml:space="preserve">
     <value>Il prefisso xmlns "{0}" non è dichiarato.</value>

--- a/src/Controls/src/Build.Tasks/xlf/ErrorMessages.it.xlf
+++ b/src/Controls/src/Build.Tasks/xlf/ErrorMessages.it.xlf
@@ -158,8 +158,8 @@
         <note>0 is a type name</note>
       </trans-unit>
       <trans-unit id="XDataTypeSyntax">
-        <source>x:DataType expects a string literal, an {{x:Type}} markup or {{x:Nul}l}.</source>
-        <target state="translated">Con x:DataType è previsto un valore letterale stringa, un markup {{x:Type}} oppure {{x:Nul}l}.</target>
+        <source>x:DataType expects a string literal, an {{x:Type}} markup or {{x:Null}}.</source>
+        <target state="translated">Con x:DataType è previsto un valore letterale stringa, un markup {{x:Type}} oppure {{x:Null}}.</target>
         <note />
       </trans-unit>
       <trans-unit id="XKeyNotLiteral">

--- a/src/Controls/src/Build.Tasks/xlf/ErrorMessages.ja.resx
+++ b/src/Controls/src/Build.Tasks/xlf/ErrorMessages.ja.resx
@@ -232,7 +232,7 @@
     <comment>0 is a type name</comment>
   </data>
   <data name="XDataTypeSyntax" xml:space="preserve">
-    <value>x:DataType には、文字列リテラル、{{x:Type}} マークアップ、または {{x:Nul}l} を指定する必要があります。</value>
+    <value>x:DataType には、文字列リテラル、{{x:Type}} マークアップ、または {{x:Null}} を指定する必要があります。</value>
   </data>
   <data name="XmlnsUndeclared" xml:space="preserve">
     <value>宣言されていない xmlns プレフィックス "{0}" です。</value>

--- a/src/Controls/src/Build.Tasks/xlf/ErrorMessages.ja.xlf
+++ b/src/Controls/src/Build.Tasks/xlf/ErrorMessages.ja.xlf
@@ -158,8 +158,8 @@
         <note>0 is a type name</note>
       </trans-unit>
       <trans-unit id="XDataTypeSyntax">
-        <source>x:DataType expects a string literal, an {{x:Type}} markup or {{x:Nul}l}.</source>
-        <target state="translated">x:DataType には、文字列リテラル、{{x:Type}} マークアップ、または {{x:Nul}l} を指定する必要があります。</target>
+        <source>x:DataType expects a string literal, an {{x:Type}} markup or {{x:Null}}.</source>
+        <target state="translated">x:DataType には、文字列リテラル、{{x:Type}} マークアップ、または {{x:Null}} を指定する必要があります。</target>
         <note />
       </trans-unit>
       <trans-unit id="XKeyNotLiteral">

--- a/src/Controls/src/Build.Tasks/xlf/ErrorMessages.ko.resx
+++ b/src/Controls/src/Build.Tasks/xlf/ErrorMessages.ko.resx
@@ -232,7 +232,7 @@
     <comment>0 is a type name</comment>
   </data>
   <data name="XDataTypeSyntax" xml:space="preserve">
-    <value>x:DataType에는 {{x:Type}} 태그 또는 {{x:Nul}l} 문자열 리터럴이 필요합니다.</value>
+    <value>x:DataType에는 {{x:Type}} 태그 또는 {{x:Null}} 문자열 리터럴이 필요합니다.</value>
   </data>
   <data name="XmlnsUndeclared" xml:space="preserve">
     <value>선언되지 않은 xmlns 접두사 "{0}"입니다.</value>

--- a/src/Controls/src/Build.Tasks/xlf/ErrorMessages.ko.xlf
+++ b/src/Controls/src/Build.Tasks/xlf/ErrorMessages.ko.xlf
@@ -158,8 +158,8 @@
         <note>0 is a type name</note>
       </trans-unit>
       <trans-unit id="XDataTypeSyntax">
-        <source>x:DataType expects a string literal, an {{x:Type}} markup or {{x:Nul}l}.</source>
-        <target state="translated">x:DataType에는 {{x:Type}} 태그 또는 {{x:Nul}l} 문자열 리터럴이 필요합니다.</target>
+        <source>x:DataType expects a string literal, an {{x:Type}} markup or {{x:Null}}.</source>
+        <target state="translated">x:DataType에는 {{x:Type}} 태그 또는 {{x:Null}} 문자열 리터럴이 필요합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="XKeyNotLiteral">

--- a/src/Controls/src/Build.Tasks/xlf/ErrorMessages.pl.resx
+++ b/src/Controls/src/Build.Tasks/xlf/ErrorMessages.pl.resx
@@ -232,7 +232,7 @@
     <comment>0 is a type name</comment>
   </data>
   <data name="XDataTypeSyntax" xml:space="preserve">
-    <value>Argument x:DataType oczekuje literału ciągu, znacznika {{x:Type}} lub {{x:Nul}l}.</value>
+    <value>Argument x:DataType oczekuje literału ciągu, znacznika {{x:Type}} lub {{x:Null}}.</value>
   </data>
   <data name="XmlnsUndeclared" xml:space="preserve">
     <value>Niezadeklarowany prefiks xmlns „{0}”.</value>

--- a/src/Controls/src/Build.Tasks/xlf/ErrorMessages.pl.xlf
+++ b/src/Controls/src/Build.Tasks/xlf/ErrorMessages.pl.xlf
@@ -158,8 +158,8 @@
         <note>0 is a type name</note>
       </trans-unit>
       <trans-unit id="XDataTypeSyntax">
-        <source>x:DataType expects a string literal, an {{x:Type}} markup or {{x:Nul}l}.</source>
-        <target state="translated">Argument x:DataType oczekuje literału ciągu, znacznika {{x:Type}} lub {{x:Nul}l}.</target>
+        <source>x:DataType expects a string literal, an {{x:Type}} markup or {{x:Null}}.</source>
+        <target state="translated">Argument x:DataType oczekuje literału ciągu, znacznika {{x:Type}} lub {{x:Null}}.</target>
         <note />
       </trans-unit>
       <trans-unit id="XKeyNotLiteral">

--- a/src/Controls/src/Build.Tasks/xlf/ErrorMessages.pt-BR.resx
+++ b/src/Controls/src/Build.Tasks/xlf/ErrorMessages.pt-BR.resx
@@ -232,7 +232,7 @@
     <comment>0 is a type name</comment>
   </data>
   <data name="XDataTypeSyntax" xml:space="preserve">
-    <value>O x:DataType espera um literal de cadeia de caracteres, uma marcação {{x:Type}} ou um {{x:Nul}l}.</value>
+    <value>O x:DataType espera um literal de cadeia de caracteres, uma marcação {{x:Type}} ou um {{x:Null}}.</value>
   </data>
   <data name="XmlnsUndeclared" xml:space="preserve">
     <value>Prefixo xmlns não declarado "{0}".</value>

--- a/src/Controls/src/Build.Tasks/xlf/ErrorMessages.pt-BR.xlf
+++ b/src/Controls/src/Build.Tasks/xlf/ErrorMessages.pt-BR.xlf
@@ -158,8 +158,8 @@
         <note>0 is a type name</note>
       </trans-unit>
       <trans-unit id="XDataTypeSyntax">
-        <source>x:DataType expects a string literal, an {{x:Type}} markup or {{x:Nul}l}.</source>
-        <target state="translated">O x:DataType espera um literal de cadeia de caracteres, uma marcação {{x:Type}} ou um {{x:Nul}l}.</target>
+        <source>x:DataType expects a string literal, an {{x:Type}} markup or {{x:Null}}.</source>
+        <target state="translated">O x:DataType espera um literal de cadeia de caracteres, uma marcação {{x:Type}} ou um {{x:Null}}.</target>
         <note />
       </trans-unit>
       <trans-unit id="XKeyNotLiteral">

--- a/src/Controls/src/Build.Tasks/xlf/ErrorMessages.ru.resx
+++ b/src/Controls/src/Build.Tasks/xlf/ErrorMessages.ru.resx
@@ -232,7 +232,7 @@
     <comment>0 is a type name</comment>
   </data>
   <data name="XDataTypeSyntax" xml:space="preserve">
-    <value>x:DataType ожидает строковый литерал, разметку {{x:Type}} или {{x:Nul}l}.</value>
+    <value>x:DataType ожидает строковый литерал, разметку {{x:Type}} или {{x:Null}}.</value>
   </data>
   <data name="XmlnsUndeclared" xml:space="preserve">
     <value>Необъявленный префикс xmlns "{0}".</value>

--- a/src/Controls/src/Build.Tasks/xlf/ErrorMessages.ru.xlf
+++ b/src/Controls/src/Build.Tasks/xlf/ErrorMessages.ru.xlf
@@ -158,8 +158,8 @@
         <note>0 is a type name</note>
       </trans-unit>
       <trans-unit id="XDataTypeSyntax">
-        <source>x:DataType expects a string literal, an {{x:Type}} markup or {{x:Nul}l}.</source>
-        <target state="translated">x:DataType ожидает строковый литерал, разметку {{x:Type}} или {{x:Nul}l}.</target>
+        <source>x:DataType expects a string literal, an {{x:Type}} markup or {{x:Null}}.</source>
+        <target state="translated">x:DataType ожидает строковый литерал, разметку {{x:Type}} или {{x:Null}}.</target>
         <note />
       </trans-unit>
       <trans-unit id="XKeyNotLiteral">

--- a/src/Controls/src/Build.Tasks/xlf/ErrorMessages.tr.resx
+++ b/src/Controls/src/Build.Tasks/xlf/ErrorMessages.tr.resx
@@ -232,7 +232,7 @@
     <comment>0 is a type name</comment>
   </data>
   <data name="XDataTypeSyntax" xml:space="preserve">
-    <value>x:DataType için bir dize sabit değeri, {{x:Type}} işaretlemesi veya {{x:Nul}l} bekleniyor.</value>
+    <value>x:DataType için bir dize sabit değeri, {{x:Type}} işaretlemesi veya {{x:Null}} bekleniyor.</value>
   </data>
   <data name="XmlnsUndeclared" xml:space="preserve">
     <value>"{0}" xmlns ön eki bildirilmedi.</value>

--- a/src/Controls/src/Build.Tasks/xlf/ErrorMessages.tr.xlf
+++ b/src/Controls/src/Build.Tasks/xlf/ErrorMessages.tr.xlf
@@ -158,8 +158,8 @@
         <note>0 is a type name</note>
       </trans-unit>
       <trans-unit id="XDataTypeSyntax">
-        <source>x:DataType expects a string literal, an {{x:Type}} markup or {{x:Nul}l}.</source>
-        <target state="translated">x:DataType için bir dize sabit değeri, {{x:Type}} işaretlemesi veya {{x:Nul}l} bekleniyor.</target>
+        <source>x:DataType expects a string literal, an {{x:Type}} markup or {{x:Null}}.</source>
+        <target state="translated">x:DataType için bir dize sabit değeri, {{x:Type}} işaretlemesi veya {{x:Null}} bekleniyor.</target>
         <note />
       </trans-unit>
       <trans-unit id="XKeyNotLiteral">

--- a/src/Controls/src/Build.Tasks/xlf/ErrorMessages.zh-Hans.resx
+++ b/src/Controls/src/Build.Tasks/xlf/ErrorMessages.zh-Hans.resx
@@ -232,7 +232,7 @@
     <comment>0 is a type name</comment>
   </data>
   <data name="XDataTypeSyntax" xml:space="preserve">
-    <value>x:DataType 需要字符串文本、{{x:Type}} 标记或 {{x:Nul}l}。</value>
+    <value>x:DataType 需要字符串文本、{{x:Type}} 标记或 {{x:Null}}。</value>
   </data>
   <data name="XmlnsUndeclared" xml:space="preserve">
     <value>xmlns 前缀“{0}”未经过声明。</value>

--- a/src/Controls/src/Build.Tasks/xlf/ErrorMessages.zh-Hans.xlf
+++ b/src/Controls/src/Build.Tasks/xlf/ErrorMessages.zh-Hans.xlf
@@ -158,8 +158,8 @@
         <note>0 is a type name</note>
       </trans-unit>
       <trans-unit id="XDataTypeSyntax">
-        <source>x:DataType expects a string literal, an {{x:Type}} markup or {{x:Nul}l}.</source>
-        <target state="translated">x:DataType 需要字符串文本、{{x:Type}} 标记或 {{x:Nul}l}。</target>
+        <source>x:DataType expects a string literal, an {{x:Type}} markup or {{x:Null}}.</source>
+        <target state="translated">x:DataType 需要字符串文本、{{x:Type}} 标记或 {{x:Null}}。</target>
         <note />
       </trans-unit>
       <trans-unit id="XKeyNotLiteral">

--- a/src/Controls/src/Build.Tasks/xlf/ErrorMessages.zh-Hant.resx
+++ b/src/Controls/src/Build.Tasks/xlf/ErrorMessages.zh-Hant.resx
@@ -232,7 +232,7 @@
     <comment>0 is a type name</comment>
   </data>
   <data name="XDataTypeSyntax" xml:space="preserve">
-    <value>x:DataType 需要字串常值、{{x:Type}} 標記或 {{x:Nul}l}。</value>
+    <value>x:DataType 需要字串常值、{{x:Type}} 標記或 {{x:Null}}。</value>
   </data>
   <data name="XmlnsUndeclared" xml:space="preserve">
     <value>未宣告的 xmlns 前置詞 "{0}"。</value>

--- a/src/Controls/src/Build.Tasks/xlf/ErrorMessages.zh-Hant.xlf
+++ b/src/Controls/src/Build.Tasks/xlf/ErrorMessages.zh-Hant.xlf
@@ -158,8 +158,8 @@
         <note>0 is a type name</note>
       </trans-unit>
       <trans-unit id="XDataTypeSyntax">
-        <source>x:DataType expects a string literal, an {{x:Type}} markup or {{x:Nul}l}.</source>
-        <target state="translated">x:DataType 需要字串常值、{{x:Type}} 標記或 {{x:Nul}l}。</target>
+        <source>x:DataType expects a string literal, an {{x:Type}} markup or {{x:Null}}.</source>
+        <target state="translated">x:DataType 需要字串常值、{{x:Type}} 標記或 {{x:Null}}。</target>
         <note />
       </trans-unit>
       <trans-unit id="XKeyNotLiteral">


### PR DESCRIPTION
### Description of Change

Invalid syntax in `x:DataType` reported a weird error message:
```
MainPage.xaml : XamlC error : Input string was not in a correct format. Failure to parse near offset 69. Unexpected closing brace without a corresponding opening brace. [MyMauiApp/MyMauiApp.csproj::TargetFramework=net9.0-maccatalyst]
```
With the fix in the error message, this is printed instead:
```
MainPage.xaml(11,33): XamlC error XFC0102: x:DataType expects a string literal, an {{x:Type}} markup or {{x:Null}}. [MyMauiApp/MyMauiApp.csproj::TargetFramework=net9.0-maccatalyst]
```

## Questions

- Should this be fixed in `main` or just in `net9.0`?
- Are the double curly brackets what we actually want? Is it necessary to prevent string interpolation in some context?
