### PR TITLE
Support the unpackaged format for font loading

### DIFF
--- a/src/Core/src/ImageSources/FontImageSourceService/FontImageSourceService.Windows.cs
+++ b/src/Core/src/ImageSources/FontImageSourceService/FontImageSourceService.Windows.cs
@@ -6,8 +6,10 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Graphics.Canvas;
 using Microsoft.Graphics.Canvas.Text;
 using Microsoft.Graphics.Canvas.UI.Xaml;
+using Microsoft.Maui.ApplicationModel;
 using Microsoft.Maui.Devices;
 using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Storage;
 using WImageSource = Microsoft.UI.Xaml.Media.ImageSource;
 
 namespace Microsoft.Maui
@@ -119,6 +121,18 @@ namespace Microsoft.Maui
 						fontSource = family;
 						break;
 					}
+				}
+			}
+
+			// unpackaged apps can't load files using packaged schemes
+			if (!AppInfoUtils.IsPackagedApp)
+			{
+				var fontUri = new Uri(fontSource, UriKind.RelativeOrAbsolute);
+			
+				var path = fontUri.AbsolutePath.TrimStart('/');
+				if (FileSystemUtils.TryGetAppPackageFileUri(path, out var uri))
+				{
+					fontSource = uri + fontUri.Fragment;
 				}
 			}
 


### PR DESCRIPTION
### Description of Change

This PR adds some logic similar to what was added to loading the font family name using Win2D. It has to convert the MSIX URI format to the file:// URI format.

This does not fix fix the issue as we also need a Win2D update that actually has the other half of the fix.

I need to add tests still, but we could potentially merge this for now and add tests in the https://github.com/dotnet/maui/blob/main/src/Controls/samples/Controls.Sample.UITests/Concepts/ImageLoadingGalleryPage.cs and https://github.com/dotnet/maui/blob/main/src/Controls/tests/UITests/Tests/Concepts/ImageLoadingGalleryTests.cs files. I currently just added the tests for the file-based images, not the generated ones.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Almost fixes #15802

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
