### PR TITLE
Add the trailing .0 to all the windows things

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -89,8 +89,8 @@
     <MacCatalystTargetFrameworkVersion>13.5</MacCatalystTargetFrameworkVersion>
     <MacosTargetFrameworkVersion>10.14</MacosTargetFrameworkVersion>
     <AndroidTargetFrameworkVersion>30.0</AndroidTargetFrameworkVersion>
-    <WindowsTargetFrameworkVersion>10.0.19041</WindowsTargetFrameworkVersion>
-    <Windows2TargetFrameworkVersion>10.0.20348</Windows2TargetFrameworkVersion>
+    <WindowsTargetFrameworkVersion>10.0.19041.0</WindowsTargetFrameworkVersion>
+    <Windows2TargetFrameworkVersion>10.0.20348.0</Windows2TargetFrameworkVersion>
     <TizenTargetFrameworkVersion>6.5</TizenTargetFrameworkVersion>
   </PropertyGroup>
 

--- a/eng/devices/windows.cake
+++ b/eng/devices/windows.cake
@@ -5,7 +5,7 @@
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 
-const string defaultVersion = "10.0.19041";
+const string defaultVersion = "10.0.19041.0";
 const string dotnetVersion = "net8.0";
 
 // required

--- a/eng/pipelines/common/device-tests.yml
+++ b/eng/pipelines/common/device-tests.yml
@@ -167,7 +167,7 @@ stages:
           parameters:
             platform: windows
             path: $(PROJECT_PATH)
-            apiVersion: 10.0.19041
+            apiVersion: 10.0.19041.0
             windowsPackageId: $(PACKAGE_ID)
             device: $(DEVICE) # For Windows this switches between packaged and unpackaged
             provisionatorChannel: ${{ parameters.provisionatorChannel }}

--- a/eng/pipelines/common/ui-tests.yml
+++ b/eng/pipelines/common/ui-tests.yml
@@ -104,7 +104,7 @@ stages:
                   - template: ui-tests-steps.yml
                     parameters:
                       platform: windows
-                      version: "10.0.19041"
+                      version: "10.0.19041.0"
                       device: windows10
                       path: ${{ project.winui }}
                       app: ${{ project.app }}

--- a/src/Compatibility/ControlGallery/src/WinUI/Compatibility.ControlGallery.WinUI.csproj
+++ b/src/Compatibility/ControlGallery/src/WinUI/Compatibility.ControlGallery.WinUI.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>$(_MauiDotNetTfm)-windows10.0.19041</TargetFramework>
+    <TargetFramework>$(_MauiDotNetTfm)-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17134.0</TargetPlatformMinVersion>
     <RootNamespace>Microsoft.Maui.Controls.Compatibility.ControlGallery.WinUI</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>

--- a/src/Compatibility/Core/tests/WinUI/Compatibility.Windows.UnitTests.csproj
+++ b/src/Compatibility/Core/tests/WinUI/Compatibility.Windows.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(_MauiDotNetTfm)-windows10.0.19041</TargetFramework>
+    <TargetFramework>$(_MauiDotNetTfm)-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17134.0</TargetPlatformMinVersion>
     <RootNamespace>Microsoft.Maui.Controls.Compatibility.UAP.UnitTests</RootNamespace>
     <AssemblyName>Microsoft.Maui.Controls.Compatibility.UAP.UnitTests</AssemblyName>

--- a/src/Controls/tests/UITests/UITest.cs
+++ b/src/Controls/tests/UITests/UITest.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Maui.AppiumTests
 					var appProjectFolder = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!, "..\\..\\..\\..\\..\\samples\\Controls.Sample.UITests");
 					var appProjectPath = Path.Combine(appProjectFolder, "Controls.Sample.UITests.csproj");
 					var windowsExe = "Controls.Sample.UITests.exe";
-					var windowsExePath = Path.Combine(appProjectFolder, $"bin\\{configuration}\\{frameworkVersion}-windows10.0.20348\\win10-x64\\{windowsExe}");
+					var windowsExePath = Path.Combine(appProjectFolder, $"bin\\{configuration}\\{frameworkVersion}-windows10.0.20348.0\\win10-x64\\{windowsExe}");
 
 					var appPath = string.IsNullOrEmpty(Environment.GetEnvironmentVariable("WINDOWS_APP_PATH"))
 					   ? windowsExePath


### PR DESCRIPTION



### Description of Change

This is just to be consistent and avoid a potential issue I saw when testing the potential Win2D update. I am not sure why this is needed, but appears to sometimes be needed in net7.0 scenarios.

