### PR TITLE
Fix crash if users only sets selected color on android bottom tabs

### DIFF
--- a/src/Controls/src/Core/Platform/Android/TabbedPageManager.cs
+++ b/src/Controls/src/Core/Platform/Android/TabbedPageManager.cs
@@ -666,9 +666,7 @@ namespace Microsoft.Maui.Controls.Handlers
 					var defaultColors =  styledAttributes.GetColorStateList(Resource.Styleable.NavigationBarView_itemIconTint);
 					if (defaultColors is not null)
 					{
-						defaultColor = defaultColors.DefaultColor;
-						var light = (int)new Color(0, 0, 0, 0.6f).ToPlatform();
-						var dark = (int)new Color(1, 1, 1, 0.6f).ToPlatform();				
+						defaultColor = defaultColors.DefaultColor;		
 					}
 					else
 					{

--- a/src/Controls/src/Core/Platform/Android/TabbedPageManager.cs
+++ b/src/Controls/src/Core/Platform/Android/TabbedPageManager.cs
@@ -8,6 +8,7 @@ using Android.Content.Res;
 using Android.Graphics;
 using Android.Graphics.Drawables;
 using Android.Views;
+using AndroidX.AppCompat.Widget;
 using AndroidX.CoordinatorLayout.Widget;
 using AndroidX.Fragment.App;
 using AndroidX.ViewPager2.Widget;
@@ -629,12 +630,27 @@ namespace Microsoft.Maui.Controls.Handlers
 		{
 			if (IsBottomTabPlacement)
 			{
-				if (_orignalTabIconColors == null)
+				if (_orignalTabIconColors is null)
 					_orignalTabIconColors = _bottomNavigationView.ItemIconTintList;
 			}
 			// this ensures that existing behavior doesn't change
 			else if (!IsBottomTabPlacement && BarSelectedItemColor != null && BarItemColor == null)
 				return null;
+
+
+			var boop = Resource.Styleable.NavigationBarView_itemIconTint;
+
+				// context, null, R.styleable.Toolbar, Resource.Attribute.toolbarStyle, 0
+			var styledAttributes = 
+				TintTypedArray.ObtainStyledAttributes(_context.Context, null, Resource.Styleable.NavigationBarView, Resource.Attribute.bottomNavigationStyle, 0);
+			try
+			{
+				var defaultColors =  styledAttributes.GetColorStateList(boop);
+			}
+			finally
+			{
+				styledAttributes.Recycle();
+			}
 
 			Color barItemColor = BarItemColor;
 			Color barSelectedItemColor = BarSelectedItemColor;

--- a/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.Android.cs
@@ -42,6 +42,36 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		[Fact]
+		public async Task SettingJustSelectedATabColorOnBottomTabsDoesntCrash()
+		{
+			SetupBuilder();
+			var tabbedPage = new TabbedPage
+            {
+                Children =
+                {
+                    new ContentPage() { Title = "Page1"}
+                    ,new ContentPage() { Title = "Page2"}
+                    ,new ContentPage() { Title = "Page3"}
+                
+                },
+				SelectedTabColor = Colors.Red,
+            };
+
+			Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.TabbedPage
+				.SetToolbarPlacement(tabbedPage, Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.ToolbarPlacement.Bottom);
+				
+			tabbedPage.SelectedTabColor = Colors.Red;
+
+			bool success = false;
+			await CreateHandlerAndAddToWindow<TabbedViewHandler>(tabbedPage, handler =>
+			{
+				success = true;
+			});
+
+			Assert.True(success);
+		}
+
+		[Fact]
 		public async Task ChangingBottomTabAttributesDoesntRecreateBottomTabs()
 		{
 			SetupBuilder();


### PR DESCRIPTION
### Description of Change

When setting just the selected color we weren't account for the user not setting the default color. This PR extracts the default color from the styles and then uses that for the default color

### Issues Fixed

Fixes #19299

