### PR TITLE
iOS Shell TitleView Update Height

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellPageRendererTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellPageRendererTracker.cs
@@ -535,11 +535,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 			public override void LayoutSubviews()
 			{
-				if (Height == null || Height == 0)
-				{
-					UpdateFrame(Superview);
-				}
-
+				UpdateFrame(Superview);
 				base.LayoutSubviews();
 			}
 
@@ -553,9 +549,6 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			{
 				if (newSuper is not null && newSuper.Bounds != CGRect.Empty)
 				{
-					if (!(OperatingSystem.IsIOSVersionAtLeast(11) || OperatingSystem.IsTvOSVersionAtLeast(11)))
-						Frame = new CGRect(Frame.X, newSuper.Bounds.Y, Frame.Width, newSuper.Bounds.Height);
-
 					Height = newSuper.Bounds.Height;
 				}
 			}


### PR DESCRIPTION
### Description of Change

<!-- Enter description of the fix in this section -->

If you change the constraints on iOS Shell TitleView, the height was not getting updated correctly. Currently, the LayoutSubviews is calling to update the frame only once, but since the issue in question is updating the height again, it was not getting processed.

Now on first loading the screen, the TitleView has the expected height above the tabs as such: 

<img width="633" alt="Screenshot 2024-02-22 at 4 33 15 PM" src="https://github.com/dotnet/maui/assets/50846373/0df945a7-502e-461a-8768-96cb383aa235">

### Testing
You can test this change on this branch: https://github.com/dotnet/maui/tree/dev/TJ/TitleViewHeight2-PRTesting and observe that the TitleView covers the entire height.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #18060

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
