### PR TITLE
Fallback if user doesn't specify ext on image

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Image/ImageTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Image/ImageTests.iOS.cs
@@ -122,5 +122,34 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.Equal(100, image.Height);
 			Assert.Equal(200, image.Width);
 		}
+
+		[Fact]
+		public async Task ImageLoadsIfYouDontSpecifyExtension()
+		{
+			SetupBuilder();
+
+			var layout = new Grid();
+			var image = new Image
+			{
+				Source = "big_white_horizontal",
+				Aspect = Aspect.AspectFit,
+				HeightRequest = 100
+			};
+
+			layout.Add(image);
+
+			await InvokeOnMainThreadAsync(async () =>
+			{
+				var handler = CreateHandler<LayoutHandler>(layout);
+
+				await image.WaitUntilLoaded();
+
+				await handler.ToPlatform().AssertContainsColor(Colors.White, MauiContext);
+			});
+
+			// We asked the image to have a fixed height, so it should resize accordingly even if it could grow in width
+			Assert.Equal(100, image.Height);
+			Assert.Equal(200, image.Width);
+		}
 	}
 }

--- a/src/Core/src/ImageSources/FileImageSourceService/FileImageSourceService.iOS.cs
+++ b/src/Core/src/ImageSources/FileImageSourceService/FileImageSourceService.iOS.cs
@@ -22,10 +22,16 @@ namespace Microsoft.Maui
 			try
 			{
 				using var cgImageSource = imageSource.GetPlatformImageSource(out var loadedScale);
-				if (cgImageSource is null)
-					throw new InvalidOperationException("Unable to load image file.");
 
-				var image = cgImageSource.GetPlatformImage(loadedScale);
+				// If the user doesn't specify the extention, then we fall back to just letting iOS load the file
+				// This means, if users try to load a animated gif and don't specify an extention it won't animate
+				// We could do a search with various extensions but that's a lot of excess churn for a scenario
+				// that's easily fixed by the user. Plus, the extension is required on other platforms so it's actually
+				// more consistent to not load the gif on iOS without the extension.			
+				var image = cgImageSource?.GetPlatformImage(loadedScale) ?? imageSource.GetPlatformImage();
+
+				if (image is null)
+					throw new InvalidOperationException("Unable to load image file.");
 
 				var result = new ImageSourceServiceResult(image, () => image.Dispose());
 


### PR DESCRIPTION
### Description of Change

The new gif loading code uses a slightly more manual way to load the CGImageSource so that it can activate animation features. One caveat of this code is that we need to know the extension of the incoming file. 

On iOS if you're using a PNG you don't have to actually include the extension for it to load your file, so, to maintain backwards compatibility this adds code that will fall back to the old loading mechanism for images. 

### Issues Fixed
Fixes #20782 

