### PR TITLE
[XamlC] Prioritize compiled markup extensions over primitive types

### DIFF
--- a/src/Controls/src/Build.Tasks/CreateObjectVisitor.cs
+++ b/src/Controls/src/Build.Tasks/CreateObjectVisitor.cs
@@ -51,17 +51,6 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 			var typeref = Module.ImportReference(node.XmlType.GetTypeReference(Context.Cache, Module, node));
 			TypeDefinition typedef = typeref.ResolveCached(Context.Cache);
 
-			if (IsXaml2009LanguagePrimitive(node))
-			{
-				var vardef = new VariableDefinition(typeref);
-				Context.Variables[node] = vardef;
-				Context.Body.Variables.Add(vardef);
-
-				Context.IL.Append(PushValueFromLanguagePrimitive(typedef, node));
-				Context.IL.Emit(Stloc, vardef);
-				return;
-			}
-
 			//if this is a MarkupExtension that can be compiled directly, compile and returns the value
 			var compiledMarkupExtensionName = typeref
 				.GetCustomAttribute(Context.Cache, Module, ("Microsoft.Maui.Controls", "Microsoft.Maui.Controls.Xaml", "ProvideCompiledAttribute"))
@@ -89,6 +78,17 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 						node.SkipProperties.Add(prop.Key);
 				node.CollectionItems.Clear();
 
+				return;
+			}
+
+			if (IsXaml2009LanguagePrimitive(node))
+			{
+				var vardef = new VariableDefinition(typeref);
+				Context.Variables[node] = vardef;
+				Context.Body.Variables.Add(vardef);
+
+				Context.IL.Append(PushValueFromLanguagePrimitive(typedef, node));
+				Context.IL.Emit(Stloc, vardef);
 				return;
 			}
 


### PR DESCRIPTION
### Description of Change

Fixes the following build error:
```
Issues\Maui20616.xaml(7,10): XamlC XC0103 error : Consider attributing the markup extension "Microsoft.Maui.Controls.Xaml.TypeExtension" with [RequireService] or [AcceptEmptyServiceProvider] if it doesn't require any. [D:\a\_work\1\s\src\Controls\tests\Xaml.UnitTests\Controls.Xaml.UnitTests.csproj]
```

The `x:Type` markup extension wasn't compiled because it was recognized as `IsXaml2009LanguagePrimitive`. With this change, XamlC will first check if the markup extension provides a compiled variant.

Compare the output for this sample XAML:

```xml
<ContentPage.Resources>
    <x:Type x:Key="mainPage">local:MainPage</x:Type>
</ContentPage.Resources>
```

```diff
// decompiled IL
-TypeExtension typeExtension = new TypeExtension();
-typeExtension.TypeName = "local:MainPage";
-XamlServiceProvider xamlServiceProvider = new XamlServiceProvider();
-Type typeFromHandle = typeof(IProvideValueTarget);
-object[] array = new object[0 + 1];
-array[0] = mainPage;
-object obj;
-xamlServiceProvider.Add(typeFromHandle, obj = new SimpleValueTargetProvider(array, typeof(VisualElement).GetRuntimeProperty("Resources"), new NameScope[2] { nameScope, nameScope }, false));
-xamlServiceProvider.Add(typeof(IReferenceProvider), obj);
-Type typeFromHandle2 = typeof(IXamlTypeResolver);
-XmlNamespaceResolver xmlNamespaceResolver = new XmlNamespaceResolver();
-xmlNamespaceResolver.Add("", "http://schemas.microsoft.com/dotnet/2021/maui");
-xmlNamespaceResolver.Add("x", "http://schemas.microsoft.com/winfx/2009/xaml");
-xmlNamespaceResolver.Add("local", "clr-namespace:MyMauiApp;Assembly=MyMauiApp");
-xamlServiceProvider.Add(typeFromHandle2, new XamlTypeResolver(xmlNamespaceResolver, typeof(MainPage).Assembly));
-xamlServiceProvider.Add(typeof(IXmlLineInfoProvider), new XmlLineInfoProvider(new XmlLineInfo(7, 10)));
-Type type = ((IMarkupExtension<Type>)typeExtension).ProvideValue((IServiceProvider)xamlServiceProvider);
+Type type = typeof(MainPage);
 mainPage.Resources.Add("mainPage", type);
```

/cc @StephaneDelcroix @rmarinho 