### PR TITLE
[Trimming] Fix event trigger trimming warnings

### DIFF
--- a/src/Controls/src/Core/BindableObject.cs
+++ b/src/Controls/src/Core/BindableObject.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using Microsoft.Extensions.Logging;
@@ -15,6 +16,7 @@ namespace Microsoft.Maui.Controls
 	/// Provides a mechanism to propagate data changes from one object to another. Enables validation, type coercion, and an event system.
 	/// </summary>
 	/// <remarks>The <see cref="BindableObject" /> class provides a data storage mechanism that enables the application developer to synchronize data between objects in response to changes, for example, between the View and View Model in the MVVM design pattern. All of the visual elements in the <c>Microsoft.Maui.Controls</c> namespace inherit from <see cref="BindableObject" /> class, so they can all be used to bind the data behind their user interface.</remarks>
+	[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicEvents)]
 	public abstract class BindableObject : INotifyPropertyChanged, IDynamicResourceHandler
 	{
 		IDispatcher _dispatcher;

--- a/src/Controls/src/Core/Interactivity/EventTrigger.cs
+++ b/src/Controls/src/Core/Interactivity/EventTrigger.cs
@@ -12,7 +12,6 @@ namespace Microsoft.Maui.Controls
 	[ContentProperty("Actions")]
 	public sealed class EventTrigger : TriggerBase
 	{
-		static readonly MethodInfo s_handlerinfo = typeof(EventTrigger).GetMethod(nameof(OnEventTriggered), BindingFlags.Instance | BindingFlags.NonPublic, binder: null, types: new Type[] { typeof(object), typeof(EventArgs) }, modifiers: null);
 		readonly List<BindableObject> _associatedObjects = new List<BindableObject>();
 
 		EventInfo _eventinfo;
@@ -71,7 +70,7 @@ namespace Microsoft.Maui.Controls
 			try
 			{
 				_eventinfo = bindable.GetType().GetRuntimeEvent(Event);
-				_handlerdelegate = s_handlerinfo.CreateDelegate(_eventinfo.EventHandlerType, this);
+				_handlerdelegate = ((EventHandler)OnEventTriggered).Method.CreateDelegate(_eventinfo.EventHandlerType, this);
 			}
 			catch (Exception)
 			{

--- a/src/Controls/src/Core/Interactivity/EventTrigger.cs
+++ b/src/Controls/src/Core/Interactivity/EventTrigger.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Maui.Controls
 	[ContentProperty("Actions")]
 	public sealed class EventTrigger : TriggerBase
 	{
-		static readonly MethodInfo s_handlerinfo = typeof(EventTrigger).GetRuntimeMethods().Single(mi => mi.Name == "OnEventTriggered" && mi.IsPublic == false);
+		static readonly MethodInfo s_handlerinfo = typeof(EventTrigger).GetMethod(nameof(OnEventTriggered), BindingFlags.Instance | BindingFlags.NonPublic, binder: null, types: new Type[] { typeof(object), typeof(EventArgs) }, modifiers: null);
 		readonly List<BindableObject> _associatedObjects = new List<BindableObject>();
 
 		EventInfo _eventinfo;
@@ -87,7 +87,6 @@ namespace Microsoft.Maui.Controls
 				_eventinfo.RemoveEventHandler(bindable, _handlerdelegate);
 		}
 
-		[Preserve]
 		void OnEventTriggered(object sender, EventArgs e)
 		{
 			var bindable = (BindableObject)sender;


### PR DESCRIPTION
### Description of Change

This PR fixes trimming warnings related to event triggers. Consider the following example:

```xml
<Entry Text="Hello">
    <Entry.Triggers>
        <EventTrigger Event="TextChanged">
            <local:EntryTrigger />
        </EventTrigger>
    </Entry.Triggers>
</Entry>
```

An app with this markup will produce the following trimming warning:
```
/.../maui/src/Controls/src/Core/Interactivity/EventTrigger.cs(73): Trim analysis warning IL2072: Microsoft.Maui.Controls.EventTrigger.AttachHandlerTo(BindableObject): 'name' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicEvents' in call to 'System.Reflection.RuntimeReflectionExtensions.GetRuntimeEvent(Type,String)'. The return value of method 'System.Object.GetType()' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to. [/.../MyMauiApp/MyMauiApp.csproj::TargetFramework=net9.0-maccatalyst]
```

The fix will preserve all public events on BindableObjects. This is not the optimal solution and we could consider adding a generic `EventTrigger<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicEvents)] T>` variant of `EventTrigger` to preserve events only on types used with event triggers and improve app size.