### PR TITLE
[testing] Cleaning up TemplateTests iOS simulator issues

### DIFF
--- a/eng/pipelines/common/maui-templates.yml
+++ b/eng/pipelines/common/maui-templates.yml
@@ -138,6 +138,15 @@ jobs:
       - ${{ each pair in step }}:
           ${{ pair.key }}: ${{ pair.value }}
 
+    - ${{ if eq(RunPlatform.testName, 'RunOniOS') }}:
+      - bash: |
+          chmod +x $(System.DefaultWorkingDirectory)/eng/scripts/clean-bot.sh
+          chmod +x $(System.DefaultWorkingDirectory)/eng/scripts/clean-simulator-runtime.sh
+          $(System.DefaultWorkingDirectory)/eng/scripts/clean-bot.sh
+        displayName: 'Clean bot'
+        continueOnError: true
+        timeoutInMinutes: 60
+
     - template: provision.yml
       parameters:
         skipXcode: ${{ eq(RunPlatform.testName, 'RunOnAndroid') }}
@@ -161,8 +170,23 @@ jobs:
         DOTNET_TOKEN: $(dotnetbuilds-internal-container-read-token)
         PRIVATE_BUILD: $(PrivateBuild)
 
+    - ${{ if eq(RunPlatform.testName, 'RunOniOS') }}:
+      - bash: |
+          if [ -f "$HOME/Library/Logs/CoreSimulator/*" ]; then rm -r $HOME/Library/Logs/CoreSimulator/*; fi
+          if [ -f "$HOME/Library/Logs/DiagnosticReports/*" ]; then rm -r $HOME/Library/Logs/DiagnosticReports/*; fi
+        displayName: Delete Old Simulator Logs
+        condition: always()
+        continueOnError: true
+
     # - script: dotnet tool update Microsoft.DotNet.XHarness.CLI --add-source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json --version "9.0.0-prerelease*" -g
     #   displayName: install xharness
+
+    - ${{ if eq(RunPlatform.testName, 'RunOniOS') }}:
+      - pwsh: ./build.ps1 -Script eng/devices/ios.cake --target=Cleanup --verbosity=diagnostic
+        displayName: Reset iOS simulators
+        # TODO: pass properly device type/version from top-level yml
+        env:
+          IOS_TEST_DEVICE: ios-simulator-64_17.2
 
     - pwsh: ./build.ps1 --target=dotnet-integration-build --verbosity=diagnostic
       displayName: Build Microsoft.Maui.IntegrationTests
@@ -170,6 +194,19 @@ jobs:
     - pwsh: ./build.ps1 --target=dotnet-integration-test --filter="Name=${{ RunPlatform.testName }}" --resultsfilename="integration-run-${{ RunPlatform.testName }}" --verbosity=diagnostic
       displayName: Run $(PLATFORM_NAME) templates run tests
       continueOnError: true
+      # TODO: pass properly device type/version from top-level yml
+      ${{ if eq(RunPlatform.testName, 'RunOniOS') }}:
+        env:
+            IOS_TEST_DEVICE: ios-simulator-64_17.2
+
+    - ${{ if eq(RunPlatform.testName, 'RunOniOS') }}:
+      - bash: |
+          suffix=$(date +%Y%m%d%H%M%S)
+          zip -9r "$(LogDirectory)/CoreSimulatorLog_${suffix}.zip" "$HOME/Library/Logs/CoreSimulator/"
+          zip -9r "$(LogDirectory)/DiagnosticReports_${suffix}.zip" "$HOME/Library/Logs/DiagnosticReports/"
+        displayName: Zip Simulator Logs
+        condition: always()
+        continueOnError: true
 
     - task: PublishTestResults@2
       displayName: Publish the $(PLATFORM_NAME) templates run tests

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Apple/Simulator.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Apple/Simulator.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Maui.IntegrationTests.Apple
 	{
 		readonly string XCRunTool = "xcrun";
 
-		public string XHarnessID { get; set; } = "ios-simulator-64";
+		public string XHarnessID { get; set; } = System.Environment.GetEnvironmentVariable("IOS_TEST_DEVICE") ?? "ios-simulator-64";
 
 		string _udid = "";
 		public string GetUDID()


### PR DESCRIPTION
## Description

This PR tries to fix failures reported in: https://github.com/dotnet/maui/issues/21077 

The issues seem to be caused by the following:
- we are querying `xharness` to find the device's UDID based on `ios-simulator-64` in:
https://github.com/dotnet/maui/blob/7639a2cf24ac3e5a17a08fc1eb0103883659d57d/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Apple/Simulator.cs#L8
- since we are only passing the device name: `ios-simulator-64`, xharness returns the first device that matches the pattern. However, there can be more device with the same name but different version which can lead to unwanted behaviour

## Problem scenario

There are two devices:
    - `ios-simulator-64_17.0` (e.g., UDID: `491595A5-EBC3-4605-9069-7D2E57E826B0`, State: `Shutdown`)
    - `ios-simulator-64_17.2` (eg., UDID: `A3DB0329-7EE0-4C6C-A69A-2B6CF76F870E`, State: `Booted`)

When querying for device's UDID based on `ios-simulator-64` only, xharness will return: `491595A5-EBC3-4605-9069-7D2E57E826B0` which is a device already in 'Shutdown' state. 

This can be a problem, as the sequence in the test SetUp code in `TemplateTests`:
https://github.com/dotnet/maui/blob/7639a2cf24ac3e5a17a08fc1eb0103883659d57d/src/TestUtils/src/Microsoft.Maui.IntegrationTests/AppleTemplateTests.cs#L16-L18
can further cause the simulator to be in a corrupted state:
```
   [ToolRunner] Running: xcrun simctl shutdown 491595A5-EBC3-4605-9069-7D2E57E826B0
   [ToolRunner] Process 'xcrun' exited with code: 149
   [ToolRunner] Running: xcrun simctl boot 491595A5-EBC3-4605-9069-7D2E57E826B0
   [ToolRunner] Process 'xcrun' exited with code: 0
```
Which finally makes the test execution fail:
```
error VSTEST1: Microsoft.Maui.IntegrationTests.AppleTemplateTests.AppleTemplateSetup()   Failed to boot simulator with UDID '491595A5-EBC3-4605-9069-7D2E57E826B0'
```

## Solution

This PR tries to fix the problem by:
- utilizing the same logic for preparing and reseting iOS simulators prior to test run (like we do for device and UI tests)  and 
- explicitly querying the exact device name and version
which should bring us always to a clean state, before executing TemplateTests

---
Contributes to: 
- https://github.com/dotnet/maui/issues/21077
- https://github.com/dotnet/maui/issues/20623