### PR TITLE
[iOS] PullToRefresh activity indicator improvements - fix

### DIFF
--- a/src/Core/src/Platform/iOS/MauiRefreshView.cs
+++ b/src/Core/src/Platform/iOS/MauiRefreshView.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
+using CoreFoundation;
 using CoreGraphics;
 using Microsoft.Maui.Graphics;
 using ObjCRuntime;
@@ -73,13 +74,16 @@ namespace Microsoft.Maui.Platform
 		{
 			if (view is UIScrollView scrollView)
 			{
-				if (scrollView.ContentOffset.Y < 0)
-					return true;
-
 				if (refreshing)
 					scrollView.SetContentOffset(new CoreGraphics.CGPoint(0, _originalY - _refreshControlHeight), true);
 				else
-					scrollView.SetContentOffset(new CoreGraphics.CGPoint(0, _originalY), true);
+				{
+					// Restore the scroll position after a slight delay to ensure layout has stabilized
+					DispatchQueue.MainQueue.DispatchAfter(new DispatchTime(DispatchTime.Now, TimeSpan.FromMilliseconds(100)), () =>
+					{
+						scrollView.SetContentOffset(new CoreGraphics.CGPoint(0, _originalY), true);
+					});
+				}
 
 				return true;
 			}
@@ -140,6 +144,13 @@ namespace Microsoft.Maui.Platform
 					scrollView.RefreshControl = _refreshControl;
 				else
 					scrollView.InsertSubview(_refreshControl, index);
+
+				//Setting the bounds so that the refresh control renders above the potential header
+				_refreshControl.Bounds = new CGRect(
+					_refreshControl.Bounds.X,
+					-scrollView.ContentOffset.Y,
+					_refreshControl.Bounds.Width,
+					_refreshControl.Bounds.Height);
 
 				scrollView.AlwaysBounceVertical = true;
 

--- a/src/Core/src/Platform/iOS/MauiRefreshView.cs
+++ b/src/Core/src/Platform/iOS/MauiRefreshView.cs
@@ -75,15 +75,9 @@ namespace Microsoft.Maui.Platform
 			if (view is UIScrollView scrollView)
 			{
 				if (refreshing)
-					scrollView.SetContentOffset(new CoreGraphics.CGPoint(0, _originalY - _refreshControlHeight), true);
+					scrollView.SetContentOffset(new CGPoint(0, _originalY - _refreshControlHeight), true);
 				else
-				{
-					// Restore the scroll position after a slight delay to ensure layout has stabilized
-					DispatchQueue.MainQueue.DispatchAfter(new DispatchTime(DispatchTime.Now, TimeSpan.FromMilliseconds(100)), () =>
-					{
-						scrollView.SetContentOffset(new CoreGraphics.CGPoint(0, _originalY), true);
-					});
-				}
+					scrollView.ContentOffset = new CGPoint(0, _originalY);
 
 				return true;
 			}


### PR DESCRIPTION
### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/20723
Fixes https://github.com/dotnet/maui/issues/24960

|Before|After|
|--|--|
|<video src="https://github.com/dotnet/maui/assets/42434498/8d22c195-66fd-4be9-aace-53fe05006526" width="300px"/>|<video src="https://github.com/dotnet/maui/assets/42434498/a2217bd2-a5b5-410f-9479-4ac61c6b80e4" width="300px"/>|
|<video src="https://github.com/user-attachments/assets/88dcbf6b-479c-4e92-85fb-feaf01c63695" width="300px"/>|<video src="https://github.com/user-attachments/assets/c4cf916c-090e-4b4c-8caf-1ecb3a926e64" width="300px"/>|

The same issue happens with CV2
https://github.com/dotnet/maui/pull/20824#issuecomment-2707891709

```xaml
<Grid RowDefinitions="*">
    <RefreshView IsRefreshing="False">
        <CollectionView>
            <CollectionView.Header>
                <ContentView HeightRequest="200"
                                BackgroundColor="Green"/>
            </CollectionView.Header>
            <CollectionView.ItemsSource>
                <x:Array Type="{x:Type x:String}">
                    <x:String>Item 1</x:String>
                    <x:String>Item 2</x:String>
                    <x:String>Item 3</x:String>
                </x:Array>
            </CollectionView.ItemsSource>
        </CollectionView>
    </RefreshView>
</Grid>
```





