### PR TITLE
Fix XAML intellisense and hot reload in Visual Studio 2022

### DIFF
--- a/src/Compatibility/ControlGallery/src/Directory.Build.props
+++ b/src/Compatibility/ControlGallery/src/Directory.Build.props
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <SampleProject>true</SampleProject>
     <UseMaui Condition=" '$(UseWorkload)' == 'true' ">true</UseMaui>
+    <DefaultXamlRuntime Condition=" '$(UseWorkload)' != 'true' ">Maui</DefaultXamlRuntime>
   </PropertyGroup>
   <Import Project="../../../../Directory.Build.props" />
 </Project>

--- a/src/Controls/samples/Directory.Build.props
+++ b/src/Controls/samples/Directory.Build.props
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <SampleProject>true</SampleProject>
     <UseMaui Condition=" '$(UseWorkload)' == 'true' ">true</UseMaui>
+    <DefaultXamlRuntime Condition=" '$(UseWorkload)' != 'true' ">Maui</DefaultXamlRuntime>
     <WarningsNotAsErrors>$(WarningsNotAsErrors);XC0022;XC0023</WarningsNotAsErrors>
   </PropertyGroup>
   <Import Project="../../../Directory.Build.props" />

--- a/src/Essentials/samples/Directory.Build.props
+++ b/src/Essentials/samples/Directory.Build.props
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <SampleProject>true</SampleProject>
     <UseMaui Condition=" '$(UseWorkload)' == 'true' ">true</UseMaui>
+    <DefaultXamlRuntime Condition=" '$(UseWorkload)' != 'true' ">Maui</DefaultXamlRuntime>
     <WarningsNotAsErrors>$(WarningsNotAsErrors);XC0022;XC0023</WarningsNotAsErrors>
   </PropertyGroup>
   <Import Project="../../../Directory.Build.props" />


### PR DESCRIPTION
This fix is for MAUI devs that edit and debug sample projects in Visual Studio (like `Maui.Controls.Sample.Sandbox`).

![image](https://github.com/dotnet/maui/assets/2523431/cfa16f54-056a-4dfd-89ee-ba3a4f0d9894)

Those sample projects normally don't set `UseMaui=true` since control library projects are referenced directly in the solution. We need to instead set `DefaultXamlRuntime=Maui` in order for Visual Studio intellisense and XAML hot reload to work. VS uses either `UseMaui` or `DefaultXamlRuntime` to determine the XAML runtime.
