### PR TITLE
Fix BlazorWebView Failing To Load Iframes With Parent

### DIFF
--- a/src/BlazorWebView/src/Maui/BlazorWebView.cs
+++ b/src/BlazorWebView/src/Maui/BlazorWebView.cs
@@ -11,7 +11,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 	/// </summary>
 	public partial class BlazorWebView : View, IBlazorWebView
 	{
-		internal const string AppHostAddress = "localhost";
+		internal const string AppHostAddress = "127.0.0.1";
 
 		private readonly JSComponentConfigurationStore _jSComponents = new();
 

--- a/src/BlazorWebView/src/Maui/BlazorWebView.cs
+++ b/src/BlazorWebView/src/Maui/BlazorWebView.cs
@@ -11,7 +11,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 	/// </summary>
 	public partial class BlazorWebView : View, IBlazorWebView
 	{
-		internal const string AppHostAddress = "0.0.0.0";
+		internal const string AppHostAddress = "localhost";
 
 		private readonly JSComponentConfigurationStore _jSComponents = new();
 

--- a/src/BlazorWebView/src/SharedSource/WebView2WebViewManager.cs
+++ b/src/BlazorWebView/src/SharedSource/WebView2WebViewManager.cs
@@ -49,7 +49,7 @@ namespace Microsoft.AspNetCore.Components.WebView.WebView2
 		// Using an IP address means that WebView2 doesn't wait for any DNS resolution,
 		// making it substantially faster. Note that this isn't real HTTP traffic, since
 		// we intercept all the requests within this origin.
-		internal static readonly string AppHostAddress = "localhost";
+		internal static readonly string AppHostAddress = "127.0.0.1";
 
 		/// <summary>
 		/// Gets the application's base URI. Defaults to <c>https://0.0.0.0/</c>

--- a/src/BlazorWebView/src/SharedSource/WebView2WebViewManager.cs
+++ b/src/BlazorWebView/src/SharedSource/WebView2WebViewManager.cs
@@ -49,7 +49,7 @@ namespace Microsoft.AspNetCore.Components.WebView.WebView2
 		// Using an IP address means that WebView2 doesn't wait for any DNS resolution,
 		// making it substantially faster. Note that this isn't real HTTP traffic, since
 		// we intercept all the requests within this origin.
-		internal static readonly string AppHostAddress = "0.0.0.0";
+		internal static readonly string AppHostAddress = "localhost";
 
 		/// <summary>
 		/// Gets the application's base URI. Defaults to <c>https://0.0.0.0/</c>


### PR DESCRIPTION
### Description of Change
The following will work in a Blazor Web App but does not work in a MAUI Blazor Hybrid app:

```
<iframe src="https://player.twitch.tv/?channel=jaaski&parent=localhost"
        height="400px"
        width="400px"
        allowfullscreen>
</iframe>
```

After digging into this and testing the changes locally with my app (copied the DLLs manually after building) I suspect the host address being 0.0.0.0 is causing the issue here.

Using `127.0.0.1` instead of `0.0.0.0` allows the iframe to successfully embed on the page via:

```
<iframe src="https://player.twitch.tv/?channel=jaaski&parent=127.0.0.1"
        height="400px"
        width="400px"
        allowfullscreen>
</iframe>
```

While this does work, I think it might be better to allow this to be configurable? Maybe there are other use cases where changing it is valuable.

I am also not sure of other consequences of this change, maybe this doesn't work in practice for other reasons but just wanted to give it a shot 😅 

### Issues Fixed
Fixes #20091

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
