### PR TITLE
Align `OnDoubleTap` behavior on Windows and Android

### DIFF
--- a/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
@@ -797,12 +797,30 @@ namespace Microsoft.Maui.Controls.Platform
 					return handled;
 				}
 
+				bool onlyDoubleTaps = false;
+
+				if (e is DoubleTappedRoutedEventArgs)
+				{
+					// Is there a recognizer that has exactly two taps?
+					foreach (var recognizer in tapGestures)
+					{
+						if (recognizer.NumberOfTapsRequired == 2)
+						{
+							onlyDoubleTaps = true;
+							break;
+						}
+					}
+				}
+
 				foreach (var recognizer in tapGestures)
 				{
-					recognizer.SendTapped(view, (relativeTo) => GetPosition(relativeTo, e));
+					if (!onlyDoubleTaps || recognizer.NumberOfTapsRequired == 2)
+					{
+						recognizer.SendTapped(view, (relativeTo) => GetPosition(relativeTo, e));
 
-					e.SetHandled(true);
-					handled = true;
+						e.SetHandled(true);
+						handled = true;
+					}
 				}
 
 				return handled;
@@ -827,7 +845,9 @@ namespace Microsoft.Maui.Controls.Platform
 					return false;
 
 				if (e is DoubleTappedRoutedEventArgs)
+				{
 					return g.NumberOfTapsRequired == 1 || g.NumberOfTapsRequired == 2;
+				}
 
 				return g.NumberOfTapsRequired == 1;
 			}

--- a/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.iOS.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.iOS.cs
@@ -665,14 +665,7 @@ namespace Microsoft.Maui.Controls.Platform
 						_proxy ??= new ShouldReceiveTouchProxy(this);
 						nativeRecognizer.ShouldReceiveTouch = _proxy.ShouldReceiveTouch;
 
-						// When handler uses a container (e.g., ButtonHandler) the actual interactive
-						// control is the first subview (UIButton). Attach there so the gesture fires.
-						if (PlatformView.Subviews?.Length > 0
-							&& PlatformView.Subviews[0] is PlatformView inner
-							&& inner is UIButton)
-							inner.AddGestureRecognizer(nativeRecognizer);
-						else
-							PlatformView.AddGestureRecognizer(nativeRecognizer);
+						PlatformView.AddGestureRecognizer(nativeRecognizer);
 
 					}
 				}

--- a/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.iOS.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.iOS.cs
@@ -664,7 +664,15 @@ namespace Microsoft.Maui.Controls.Platform
 					{
 						_proxy ??= new ShouldReceiveTouchProxy(this);
 						nativeRecognizer.ShouldReceiveTouch = _proxy.ShouldReceiveTouch;
-						PlatformView.AddGestureRecognizer(nativeRecognizer);
+
+						// When handler uses a container (e.g., ButtonHandler) the actual interactive
+						// control is the first subview (UIButton). Attach there so the gesture fires.
+						if (PlatformView.Subviews?.Length > 0
+							&& PlatformView.Subviews[0] is PlatformView inner
+							&& inner is UIButton)
+							inner.AddGestureRecognizer(nativeRecognizer);
+						else
+							PlatformView.AddGestureRecognizer(nativeRecognizer);
 
 					}
 				}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue20870.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue20870.xaml
@@ -10,35 +10,35 @@
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
 
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="*"/>
-        </Grid.ColumnDefinitions>
-
-        <FlexLayout Grid.Row="0" Direction="Row" Wrap="Wrap" JustifyContent="SpaceAround" AlignItems="Center" Margin="10">
-            <Button x:Name="ButtonSingleTap" AutomationId="ButtonSingleTap" Text="SingleTap" FontSize="16" TextColor="Red" Margin="5" MinimumWidthRequest="140" HeightRequest="50">
-                <Button.GestureRecognizers>
+    <FlexLayout Grid.Row="0" Direction="Row" Wrap="Wrap" JustifyContent="SpaceAround" AlignItems="Center" Margin="10" MinimumHeightRequest="80">
+            <!-- Using Labels instead of Buttons for gesture tests to avoid platform-specific container wrapping (iOS/macOS) affecting double-tap routing. -->
+            <Label x:Name="ButtonSingleTap" AutomationId="ButtonSingleTap" Text="SingleTap" FontSize="20" TextColor="Red" VerticalOptions="Center">
+                <Label.GestureRecognizers>
                     <TapGestureRecognizer Tapped="OnTap"/>
-                </Button.GestureRecognizers>
-            </Button>
-            <Button x:Name="ButtonDoubleTap" AutomationId="ButtonDoubleTap" Text="DoubleTap" FontSize="16" TextColor="Green" Margin="5" MinimumWidthRequest="140" HeightRequest="50">
-                <Button.GestureRecognizers>
+                </Label.GestureRecognizers>
+            </Label>
+            <Label x:Name="ButtonDoubleTap" AutomationId="ButtonDoubleTap" Text="DoubleTap" FontSize="20" TextColor="Green" VerticalOptions="Center">
+                <Label.GestureRecognizers>
                     <TapGestureRecognizer Tapped="OnDoubleTap" NumberOfTapsRequired="2"/>
-                </Button.GestureRecognizers>
-            </Button>
-            <Button x:Name="ButtonSingleAndDoubleTap" AutomationId="ButtonSingleAndDoubleTap" Text="Single+Double" FontSize="16" TextColor="Blue" Margin="5" MinimumWidthRequest="140" HeightRequest="50">
-                <Button.GestureRecognizers>
+                </Label.GestureRecognizers>
+            </Label>
+            <Label x:Name="ButtonSingleAndDoubleTap" AutomationId="ButtonSingleAndDoubleTap" Text="SingleAndDoubleTap" FontSize="20" TextColor="Blue" VerticalOptions="Center">
+                <Label.GestureRecognizers>
                     <TapGestureRecognizer Tapped="OnTap"/>
                     <TapGestureRecognizer Tapped="OnDoubleTap" NumberOfTapsRequired="2"/>
-                </Button.GestureRecognizers>
-            </Button>
-            <Button x:Name="ButtonDoubleAndSingleTap" AutomationId="ButtonDoubleAndSingleTap" Text="Double+Single" FontSize="16" TextColor="Purple" Margin="5" MinimumWidthRequest="140" HeightRequest="50">
-                <Button.GestureRecognizers>
+                </Label.GestureRecognizers>
+            </Label>
+            <Label x:Name="ButtonDoubleAndSingleTap" AutomationId="ButtonDoubleAndSingleTap" Text="DoubleAndSingleTap" FontSize="20" TextColor="Purple" VerticalOptions="Center">
+                <Label.GestureRecognizers>
                     <TapGestureRecognizer Tapped="OnDoubleTap" NumberOfTapsRequired="2"/>
                     <TapGestureRecognizer Tapped="OnTap"/>
-                </Button.GestureRecognizers>
-            </Button>
-            <Button x:Name="Clear" AutomationId="Clear" Text="Clear" FontSize="16" Clicked="Clear_Clicked" Margin="5" MinimumWidthRequest="100" HeightRequest="50"/>
-
+                </Label.GestureRecognizers>
+            </Label>
+            <Label x:Name="Clear" AutomationId="Clear" Text="Clear" FontSize="20" TextColor="Black" VerticalOptions="Center">
+                <Label.GestureRecognizers>
+                    <TapGestureRecognizer Tapped="Clear_Tapped" />
+                </Label.GestureRecognizers>
+            </Label>
         </FlexLayout>
 
         <ScrollView Grid.Row="1">

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue20870.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue20870.xaml
@@ -1,0 +1,48 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Maui.Controls.Sample.Issues.Issue20870"
+             xmlns:local="clr-namespace:Maui.Controls.Sample.Issues"
+             Title="Issue20870">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="100"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*"/>
+        </Grid.ColumnDefinitions>
+
+        <FlexLayout Grid.Row="0" JustifyContent="SpaceEvenly">
+            <Button x:Name="ButtonSingleTap" AutomationId="ButtonSingleTap" Text="SingleTap" FontSize="20" TextColor="Red">
+                <Button.GestureRecognizers>
+                    <TapGestureRecognizer Tapped="OnTap"/>
+                </Button.GestureRecognizers>
+            </Button>
+            <Button x:Name="ButtonDoubleTap" AutomationId="ButtonDoubleTap" Text="DoubleTap" FontSize="20" TextColor="Green">
+                <Button.GestureRecognizers>
+                    <TapGestureRecognizer Tapped="OnDoubleTap" NumberOfTapsRequired="2"/>
+                </Button.GestureRecognizers>
+            </Button>
+            <Button x:Name="ButtonSingleAndDoubleTap" AutomationId="ButtonSingleAndDoubleTap" Text="SingleAndDoubleTap" FontSize="20" TextColor="Blue">
+                <Button.GestureRecognizers>
+                    <TapGestureRecognizer Tapped="OnTap"/>
+                    <TapGestureRecognizer Tapped="OnDoubleTap" NumberOfTapsRequired="2"/>
+                </Button.GestureRecognizers>
+            </Button>
+            <Button x:Name="ButtonDoubleAndSingleTap" AutomationId="ButtonDoubleAndSingleTap" Text="DoubleAndSingleTap" FontSize="20" TextColor="Purple">
+                <Button.GestureRecognizers>
+                    <TapGestureRecognizer Tapped="OnDoubleTap" NumberOfTapsRequired="2"/>
+                    <TapGestureRecognizer Tapped="OnTap"/>
+                </Button.GestureRecognizers>
+            </Button>
+            <Button x:Name="Clear" AutomationId="Clear" Text="Clear" FontSize="20" Clicked="Clear_Clicked"/>
+
+        </FlexLayout>
+
+        <ScrollView Grid.Row="1">
+            <Editor x:Name="Results" AutomationId="Results" Margin="20"/>
+        </ScrollView>
+    </Grid>
+</ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue20870.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue20870.xaml
@@ -6,7 +6,7 @@
              Title="Issue20870">
     <Grid>
         <Grid.RowDefinitions>
-            <RowDefinition Height="100"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
 
@@ -14,30 +14,30 @@
             <ColumnDefinition Width="*"/>
         </Grid.ColumnDefinitions>
 
-        <FlexLayout Grid.Row="0" JustifyContent="SpaceEvenly">
-            <Button x:Name="ButtonSingleTap" AutomationId="ButtonSingleTap" Text="SingleTap" FontSize="20" TextColor="Red">
+        <FlexLayout Grid.Row="0" Direction="Row" Wrap="Wrap" JustifyContent="SpaceAround" AlignItems="Center" Margin="10">
+            <Button x:Name="ButtonSingleTap" AutomationId="ButtonSingleTap" Text="SingleTap" FontSize="16" TextColor="Red" Margin="5" MinimumWidthRequest="140" HeightRequest="50">
                 <Button.GestureRecognizers>
                     <TapGestureRecognizer Tapped="OnTap"/>
                 </Button.GestureRecognizers>
             </Button>
-            <Button x:Name="ButtonDoubleTap" AutomationId="ButtonDoubleTap" Text="DoubleTap" FontSize="20" TextColor="Green">
+            <Button x:Name="ButtonDoubleTap" AutomationId="ButtonDoubleTap" Text="DoubleTap" FontSize="16" TextColor="Green" Margin="5" MinimumWidthRequest="140" HeightRequest="50">
                 <Button.GestureRecognizers>
                     <TapGestureRecognizer Tapped="OnDoubleTap" NumberOfTapsRequired="2"/>
                 </Button.GestureRecognizers>
             </Button>
-            <Button x:Name="ButtonSingleAndDoubleTap" AutomationId="ButtonSingleAndDoubleTap" Text="SingleAndDoubleTap" FontSize="20" TextColor="Blue">
+            <Button x:Name="ButtonSingleAndDoubleTap" AutomationId="ButtonSingleAndDoubleTap" Text="Single+Double" FontSize="16" TextColor="Blue" Margin="5" MinimumWidthRequest="140" HeightRequest="50">
                 <Button.GestureRecognizers>
                     <TapGestureRecognizer Tapped="OnTap"/>
                     <TapGestureRecognizer Tapped="OnDoubleTap" NumberOfTapsRequired="2"/>
                 </Button.GestureRecognizers>
             </Button>
-            <Button x:Name="ButtonDoubleAndSingleTap" AutomationId="ButtonDoubleAndSingleTap" Text="DoubleAndSingleTap" FontSize="20" TextColor="Purple">
+            <Button x:Name="ButtonDoubleAndSingleTap" AutomationId="ButtonDoubleAndSingleTap" Text="Double+Single" FontSize="16" TextColor="Purple" Margin="5" MinimumWidthRequest="140" HeightRequest="50">
                 <Button.GestureRecognizers>
                     <TapGestureRecognizer Tapped="OnDoubleTap" NumberOfTapsRequired="2"/>
                     <TapGestureRecognizer Tapped="OnTap"/>
                 </Button.GestureRecognizers>
             </Button>
-            <Button x:Name="Clear" AutomationId="Clear" Text="Clear" FontSize="20" Clicked="Clear_Clicked"/>
+            <Button x:Name="Clear" AutomationId="Clear" Text="Clear" FontSize="16" Clicked="Clear_Clicked" Margin="5" MinimumWidthRequest="100" HeightRequest="50"/>
 
         </FlexLayout>
 

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue20870.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue20870.xaml.cs
@@ -9,19 +9,19 @@ namespace Maui.Controls.Sample.Issues;
 
 public partial class Issue20870 : ContentPage
 {
-	private readonly Button[] _buttons;
-
 	public Issue20870()
 	{
 		InitializeComponent();
 		BindingContext = this;
-
-		_buttons = [ButtonSingleTap, ButtonDoubleTap, ButtonSingleAndDoubleTap, ButtonDoubleAndSingleTap];
 	}
 
-	private void Clear_Clicked(object sender, System.EventArgs e)
+	// NOTE: Using Labels for gesture recognizer tests (instead of Buttons) to avoid
+	// platform-specific wrapper/container views on iOS/macOS that can interfere with
+	// hit testing and double-tap routing. This keeps gesture routing consistent across
+	// platforms for the purpose of these cross-platform UITests.
+	private void Clear_Tapped(object? sender, TappedEventArgs e)
 	{
-		Results.Text = "";
+		Results.Text = string.Empty;
 	}
 
 	private void OnTap(object? sender, TappedEventArgs e)

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue20870.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue20870.xaml.cs
@@ -1,0 +1,40 @@
+#nullable enable
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+
+namespace Maui.Controls.Sample.Issues;
+
+[XamlCompilation(XamlCompilationOptions.Compile)]
+[Issue(IssueTracker.Github, 20870, "Single-tap and double-tap tests", PlatformAffected.All)]
+
+public partial class Issue20870 : ContentPage
+{
+	private readonly Button[] _buttons;
+
+	public Issue20870()
+	{
+		InitializeComponent();
+		BindingContext = this;
+
+		_buttons = [ButtonSingleTap, ButtonDoubleTap, ButtonSingleAndDoubleTap, ButtonDoubleAndSingleTap];
+	}
+
+	private void Clear_Clicked(object sender, System.EventArgs e)
+	{
+		Results.Text = "";
+	}
+
+	private void OnTap(object? sender, TappedEventArgs e)
+	{
+		string text = Results.Text;
+		string delimiter = string.IsNullOrEmpty(text) ? "" : "|";
+		Results.Text = $"{text}{delimiter}OnTap called";
+	}
+
+	private void OnDoubleTap(object? sender, TappedEventArgs e)
+	{
+		string text = Results.Text;
+		string delimiter = string.IsNullOrEmpty(text) ? "" : "|";
+		Results.Text = $"{text}{delimiter}OnDoubleTap called";
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue20870.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue20870.cs
@@ -1,0 +1,61 @@
+﻿using NUnit.Framework;
+using NUnit.Framework.Legacy;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue20870 : _IssuesUITest
+{
+	public Issue20870(TestDevice device) : base(device) { }
+
+	public override string Issue => "Single-tap and double-tap tests";
+
+	[Test]
+	[Category(UITestCategories.Gestures)]
+	public async Task TapsAndDoubleTaps()
+	{
+		// Initialize.
+		App.WaitForElement("Results");
+
+		// Verify a button with a single-tap gesture recognizer.
+		App.Tap("ButtonSingleTap");
+		await Task.Delay(200); // Do not artificially simulate a double-tap.
+		App.Tap("ButtonSingleTap");
+
+		await Task.Delay(1000);
+
+		string? text = App.FindElement("Results").GetText()?.Trim();
+		ClassicAssert.AreEqual("OnTap called|OnTap called", text);
+
+		App.Tap("Clear");
+
+		// Verify a button with a double-tap gesture recognizer.
+		App.Tap("ButtonDoubleTap");
+		await Task.Delay(200); // Do not artificially simulate a triple-tap.
+		App.DoubleTap("ButtonDoubleTap");
+
+		text = App.FindElement("Results").GetText()?.Trim();
+		ClassicAssert.AreEqual("OnDoubleTap called", text);
+
+		App.Tap("Clear");
+
+		// Verify a button with single-tap and double-tap gesture recognizers. Note the order of recognizer registrations.
+		App.Tap("ButtonSingleAndDoubleTap");
+		await Task.Delay(200);
+		App.DoubleTap("ButtonSingleAndDoubleTap");
+
+		text = App.FindElement("Results").GetText()?.Trim();
+		ClassicAssert.AreEqual("OnTap called|OnTap called|OnDoubleTap called", text);
+
+		App.Tap("Clear");
+
+		// Verify a button with double-tap and single-tap gesture recognizers. Note the order of recognizer registrations.
+		App.Tap("ButtonDoubleAndSingleTap");
+		await Task.Delay(200);
+		App.DoubleTap("ButtonDoubleAndSingleTap");
+
+		text = App.FindElement("Results").GetText()?.Trim();
+		ClassicAssert.AreEqual("OnTap called|OnTap called|OnDoubleTap called", text);
+	}
+}


### PR DESCRIPTION
### Description of Change

Currently, on `main` when one defines 

```xaml
<Label Text="SingleAndDoubleTap" FontSize="32" TextColor="Blue">
    <Label.GestureRecognizers>
        <TapGestureRecognizer Tapped="OnTap"/>
        <TapGestureRecognizer Tapped="OnDoubleTap" NumberOfTapsRequired="2"/>
    </Label.GestureRecognizers>
</Label>
```

and double clicks that label, it leads to the following calls:

1. OnTap
2. OnTap
3. OnDoubleTap

This PR makes it so that a double click leads to:

1. OnTap
2. OnDoubleTap

This new behavior seems to be more in line with https://learn.microsoft.com/en-us/uwp/api/windows.ui.xaml.uielement.doubletapped?view=winrt-19041 which mentions:

> If a user interaction also fires DoubleTapped, [Tapped](https://learn.microsoft.com/en-us/uwp/api/windows.ui.xaml.uielement.tapped?view=winrt-22621#windows-ui-xaml-uielement-tapped) will fire first to represent the first tap, but the second tap won't fire an additional [Tapped](https://learn.microsoft.com/en-us/uwp/api/windows.ui.xaml.uielement.tapped?view=winrt-22621#windows-ui-xaml-uielement-tapped). If you want different logic for Tapped versus DoubleTapped, your Tapped handler may need to use app-specific variables and a timer in order to avoid running on interactions that are eventually interpreted as a DoubleTap action.

### Demo

**Main**:

![main-doubleClick](https://github.com/dotnet/maui/assets/203266/498d55db-8e38-49a9-9c50-43d8cb8c66c6)

**PR:**

![pr-doubleClick](https://github.com/dotnet/maui/assets/203266/3e30f6d0-ca27-432f-aa55-26467b37e910)


### Issues Fixed

Fixes #16235