### PR TITLE
Permissions (BT & WiFi): don't add AccessFineLocation to required permissions if NeverForLocation flag is present

### DIFF
--- a/src/Essentials/src/Permissions/Permissions.android.cs
+++ b/src/Essentials/src/Permissions/Permissions.android.cs
@@ -24,6 +24,24 @@ namespace Microsoft.Maui.ApplicationModel
 			return requestedPermissions?.Any(r => r.Equals(permission, StringComparison.OrdinalIgnoreCase)) ?? false;
 		}
 
+		private static bool HasFlagInManifest(string permission, RequestedPermission flag)
+		{
+			var context = Application.Context;
+#pragma warning disable CS0618, CA1416, CA1422 // Deprecated in API 33: https://developer.android.com/reference/android/content/pm/PackageManager#getPackageInfo(java.lang.String,%20int)
+			var packageInfo = context.PackageManager.GetPackageInfo(context.PackageName, PackageInfoFlags.Permissions);
+#pragma warning restore CS0618, CA1416, CA1422
+			var requestedPermissions = packageInfo?.RequestedPermissions;
+			var requestedPermissionsFlags = packageInfo?.RequestedPermissionsFlags;
+
+			for (int i=0; i<requestedPermissions.Count; i++)
+			{
+				if (requestedPermissions[i].Equals(permission, StringComparison.OrdinalIgnoreCase))
+					return (requestedPermissionsFlags[i] & (int)flag) != 0;
+			}
+
+			return false;
+		}
+
 		internal static void OnRequestPermissionsResult(int requestCode, string[] permissions, Permission[] grantResults)
 			=> BasePlatformPermission.OnRequestPermissionsResult(requestCode, permissions, grantResults);
 
@@ -204,8 +222,7 @@ namespace Microsoft.Maui.ApplicationModel
 					var permissions = new List<(string, bool)>();
 
 					// When targeting Android 11 or lower, AccessFineLocation is required for Bluetooth.
-					// For Android 12 and above, it is optional.
-					if (Application.Context.ApplicationInfo.TargetSdkVersion <= BuildVersionCodes.R || IsDeclaredInManifest(Manifest.Permission.AccessFineLocation))
+					if (Application.Context.ApplicationInfo.TargetSdkVersion <= BuildVersionCodes.R)
 						permissions.Add((Manifest.Permission.AccessFineLocation, true));
 
 #if __ANDROID_31__
@@ -218,6 +235,9 @@ namespace Microsoft.Maui.ApplicationModel
 							permissions.Add((Manifest.Permission.BluetoothConnect, true));
 						if (IsDeclaredInManifest(Manifest.Permission.BluetoothAdvertise))
 							permissions.Add((Manifest.Permission.BluetoothAdvertise, true));
+						// for Android 12 and above, AccessFineLocation is optional
+						if (IsDeclaredInManifest(Manifest.Permission.AccessFineLocation) && !HasFlagInManifest(Manifest.Permission.BluetoothScan, RequestedPermission.NeverForLocation))
+							permissions.Add((Manifest.Permission.AccessFineLocation, true));
 					}
 #endif
 
@@ -365,8 +385,7 @@ namespace Microsoft.Maui.ApplicationModel
 				{
 					var permissions = new List<(string, bool)>();
 					// When targeting Android 12 or lower, AccessFineLocation is required for several WiFi APIs.
-					// For Android 13 and above, it is optional.
-					if (Application.Context.ApplicationInfo.TargetSdkVersion < BuildVersionCodes.Tiramisu || IsDeclaredInManifest(Manifest.Permission.AccessFineLocation))
+					if (Application.Context.ApplicationInfo.TargetSdkVersion < BuildVersionCodes.Tiramisu)
 						permissions.Add((Manifest.Permission.AccessFineLocation, true));
 
 #if __ANDROID_33__
@@ -375,6 +394,9 @@ namespace Microsoft.Maui.ApplicationModel
 						// new runtime permission on Android 13
 						if (IsDeclaredInManifest(Manifest.Permission.NearbyWifiDevices))
 							permissions.Add((Manifest.Permission.NearbyWifiDevices, true));
+						// for Android 13 and above, AccessFineLocation is optional
+						if (IsDeclaredInManifest(Manifest.Permission.AccessFineLocation) && !HasFlagInManifest(Manifest.Permission.NearbyWifiDevices, RequestedPermission.NeverForLocation))
+							permissions.Add((Manifest.Permission.AccessFineLocation, true));
 					}
 #endif
 


### PR DESCRIPTION
### Description of Change

This fixes #20871, by making sure that `AccessFineLocation` is not added to the required permissions for `Permissions.Bluetooth` or `Permissions.NearbyWifiDevices` if they are declared with the `NeverForLocation` flag.
Otherwise the permission status will be `PermissionStatus.Denied`, if `AccessFineLocation` is in the manifest but denied at runtime (even if it is not strictly required).

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #20871

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
