### PR TITLE
[testing] Ignore TopTabsDontScrollBackToStartWhenSelected

### DIFF
--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue10134.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue10134.cs
@@ -44,6 +44,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST && __SHELL__
 		[Test]
+		[Compatibility.UITests.FailsOnMauiIOS]
 		public void TopTabsDontScrollBackToStartWhenSelected() 
 		{
 			var element1 = RunningApp.WaitForElement("Tab 1", "Shell hasn't loaded")[0].Rect;


### PR DESCRIPTION
### Description of Change

This legacy test for Issue 10134 of Xamarin.Forms is failing on Xamarin.UITests and is going to be moved to Appium.

https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=9148609&view=ms.vss-test-web.build-test-results-tab&runId=95439677&resultId=100396&paneView=debug