### PR TITLE
Check if CV Item Handler has been created

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/iOS/TemplatedCell.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/TemplatedCell.cs
@@ -303,7 +303,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		void UpdateSelectionColor()
 		{
-			if (PlatformHandler.VirtualView is not View view)
+			if (PlatformHandler?.VirtualView is not View view)
 			{
 				return;
 			}
@@ -313,6 +313,11 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		void UpdateSelectionColor(View view)
 		{
+			if (SelectedBackgroundView is null)
+			{
+				return;
+			}
+			
 			// Prevents the use of default color when there are VisualStateManager with Selected state setting the background color
 			// First we check whether the cell has the default selected background color; if it does, then we should check
 			// to see if the cell content is the VSM to set a selected color

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.cs
@@ -460,5 +460,53 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		record MyRecord(string Name);
+
+
+		[Fact]
+		public async Task SettingSelectedItemAfterModifyingCollectionDoesntCrash()
+		{
+			SetupBuilder();
+
+			var Items = new ObservableCollection<string>();
+			var collectionView = new CollectionView
+			{
+				ItemTemplate = new DataTemplate(() =>
+				{
+					var label = new Label()
+					{
+						Text = "Margin Test",
+						Margin = new Thickness(10, 10, 10, 10),
+						HeightRequest = 50,
+					};
+
+					label.SetBinding(Label.TextProperty, new Binding("."));
+					return label;
+				}),
+				ItemsSource = Items,
+				SelectionMode = SelectionMode.Single
+			};
+
+			var vsl = new VerticalStackLayout()
+			{
+				collectionView				
+			};
+
+			vsl.HeightRequest = 500;
+			vsl.WidthRequest = 500;
+
+			var frame = collectionView.Frame;
+
+			await vsl.AttachAndRun<LayoutHandler>(async (handler) =>
+			{
+				await WaitForUIUpdate(frame, collectionView);
+				frame = collectionView.Frame;
+				await Task.Yield();
+				Items.Add("Item 1");
+				Items.Add("Item 2");
+				Items.Add("Item 3");
+				collectionView.SelectedItem = Items.FirstOrDefault(x => x == "Item 3");
+				await WaitForUIUpdate(frame, collectionView);
+			}, MauiContext, (view) => CreateHandlerAsync<LayoutHandler>(view));
+		}
 	}
 }


### PR DESCRIPTION
### Description of Change

When a CV is nested inside a VerticalStackLayout it will get measured and have its `CollectionView.SelectItem` set before the content of the `TemplatedCells` has been created, as the `TemplatedCells` are created during the `Dequeue` process, iOS well set the `Selected` property to true before we realize the handlers. So, we need to not react off of selected being changed until the handler has been bound to the `TemplatedCell`

### Issues Fixed
Fixes #20606
