### PR TITLE
[Windows] Registering new double-tap event can end up in the event being firing more times than expected

### DIFF
--- a/global.json
+++ b/global.json
@@ -5,5 +5,12 @@
   "msbuild-sdks": {
     "MSBuild.Sdk.Extras": "3.0.44",
     "Microsoft.Build.NoTargets": "3.3.0"
+  },
+  "sdk": {
+    "version": "8.0.0",
+    "rollForward": "latestFeature",
+    "allowPrerelease": true
   }
 }
+
+

--- a/global.json
+++ b/global.json
@@ -5,12 +5,5 @@
   "msbuild-sdks": {
     "MSBuild.Sdk.Extras": "3.0.44",
     "Microsoft.Build.NoTargets": "3.3.0"
-  },
-  "sdk": {
-    "version": "8.0.0",
-    "rollForward": "latestFeature",
-    "allowPrerelease": true
   }
 }
-
-

--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issue20903.xaml
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issue20903.xaml
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Maui.Controls.Sample.Issues.Issue20903">
+    <VerticalStackLayout x:Name="layout">
+        <Label Text="Click the button bellow twice and then double-tap the label 'Double Tap Me' also twice." HorizontalOptions="Center" />
+
+        <Button AutomationId="AddDoubleTapHandlerButton"
+                Text="Add double-tap handler" 
+                Clicked="addDoubleTapHandlerButton_Clicked"
+                HorizontalOptions="Center"/>
+
+        <Label x:Name="myLabel"
+               AutomationId="MyLabel"
+               Text="Double Tap Me"
+               FontSize="32"
+               BackgroundColor="gray"
+               HorizontalOptions="Center"/>
+
+        <Label x:Name="eventCountLabel"
+               AutomationId="EventCountLabel"
+               Text="0"
+               FontSize="32"
+               BackgroundColor="red"
+               HorizontalOptions="Center"/>
+    </VerticalStackLayout>
+</ContentPage>

--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issue20903.xaml.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issue20903.xaml.cs
@@ -1,0 +1,31 @@
+﻿#nullable enable
+
+using System;
+using Microsoft.Maui.Controls;
+
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 20903, "Double-tap behavior should work correctly when adding a new double-tap handler", PlatformAffected.UWP)]
+public partial class Issue20903 : ContentPage
+{
+	private int _callbackCalledCount;
+
+	public Issue20903()
+	{
+		InitializeComponent();
+	}
+
+	private void OnLabelBeingDoubleTapped(object? sender, TappedEventArgs e)
+	{
+		_callbackCalledCount++;
+		eventCountLabel.Text = _callbackCalledCount.ToString();
+	}
+
+	private void addDoubleTapHandlerButton_Clicked(object sender, EventArgs e)
+	{
+		TapGestureRecognizer doubleTapGestureRecognizer = new();
+		doubleTapGestureRecognizer.Tapped += OnLabelBeingDoubleTapped;
+		doubleTapGestureRecognizer.NumberOfTapsRequired = 2;
+		myLabel.GestureRecognizers.Add(doubleTapGestureRecognizer);
+	}
+}

--- a/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
@@ -318,6 +318,7 @@ namespace Microsoft.Maui.Controls.Platform
 				_container.DragOver -= HandleDragOver;
 				_container.Drop -= HandleDrop;
 				_container.Tapped -= OnTap;
+				_container.DoubleTapped -= OnTap;
 				_container.ManipulationDelta -= OnManipulationDelta;
 				_container.ManipulationStarted -= OnManipulationStarted;
 				_container.ManipulationCompleted -= OnManipulationCompleted;

--- a/src/Controls/tests/UITests/Tests/Issues/Issue20903.cs
+++ b/src/Controls/tests/UITests/Tests/Issues/Issue20903.cs
@@ -1,0 +1,33 @@
+﻿using System.Drawing;
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.AppiumTests.Issues;
+
+public class Issue20903 : _IssuesUITest
+{
+	public Issue20903(TestDevice device) : base(device) { }
+
+	public override string Issue => "Double-tap behavior should work correctly when adding a new double-tap handler";
+
+	[Test]
+	public async Task RegisterTwoDoubleTapHandlersAndCheckNumberOfFiredEventsAsync()
+	{
+		_ = App.WaitForElement("AddDoubleTapHandlerButton");
+
+		App.Click("AddDoubleTapHandlerButton");
+		App.Click("AddDoubleTapHandlerButton");
+
+		App.DoubleClick("MyLabel");
+		await Task.Delay(500);
+		App.DoubleClick("MyLabel");
+
+		// Wait for all event handler calls.
+		await Task.Delay(1000);
+
+		IUIElement element = App.FindElement("EventCountLabel");
+		string? count = element.GetText();
+		Assert.AreEqual("4", count);
+	}
+}


### PR DESCRIPTION
### Description of Change

`_container.DoubleTapped` event is not unregistered on Windows so double-tapping does not work properly when there are more than one double-tap event handlers.

### Issues Fixed

Fixes #20903

### Demo WITHOUT the fix

![main-doubleClick](https://github.com/dotnet/maui/assets/203266/c9305d88-1348-4f15-9f0c-50878190616e)

Expected 4 but got 8.