### PR TITLE
Restore iOS/macOS SecureStorage.DefaultAccessible default value

### DIFF
--- a/src/Essentials/src/SecureStorage/SecureStorage.ios.tvos.watchos.macos.cs
+++ b/src/Essentials/src/SecureStorage/SecureStorage.ios.tvos.watchos.macos.cs
@@ -8,7 +8,8 @@ namespace Microsoft.Maui.Storage
 {
 	partial class SecureStorageImplementation : ISecureStorage, IPlatformSecureStorage
 	{
-		public SecAccessible DefaultAccessible { get; set; }
+		public SecAccessible DefaultAccessible { get; set; } =
+			SecAccessible.AfterFirstUnlock;
 
 		public Task SetAsync(string key, string value, SecAccessible accessible)
 		{


### PR DESCRIPTION
### Description of Change

Restores the default value of `SecureStorage.DefaultAccessible` for iOS & macOS. In #4668 this default value was dropped, but I don't see indication this was intentional. To make migration from Xamarin.Forms easier this should still be the same(?) although at this point this might be a breaking change for .NET MAUI 🤷‍♂️ 

So if we decide to not do this change we need to update the documentation.

### Issues Fixed

Fixes #17582
