### PR TITLE
[iOS] Shell/NavigationPage TitleView

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
@@ -12,6 +12,7 @@ using Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific;
 using Microsoft.Maui.Devices;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Platform;
+using Microsoft.Maui.Layouts;
 using ObjCRuntime;
 using UIKit;
 using static Microsoft.Maui.Controls.Compatibility.Platform.iOS.AccessibilityExtensions;
@@ -1909,6 +1910,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			IPlatformViewHandler _child;
 			UIImageView _icon;
 			bool _disposed;
+			const int SystemMargin = 16;
 
 			public Container(View view, UINavigationBar bar) : base(bar.Bounds)
 			{
@@ -1938,6 +1940,44 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				}
 
 				ClipsToBounds = true;
+			}
+
+			// A solution based on this code https://github.dev/devxoul/UINavigationItem-Margin
+			// responsible for removing the system margin inside the navigation bar
+			UIEdgeInsets CalculateUIEdgeInsets()
+			{
+				var type = UIBarButtonSystemItem.FixedSpace;
+				var spacer = new UIBarButtonItem(type, (_, _) => { });
+
+				if (UIDevice.CurrentDevice.CheckSystemVersion(11, 0))
+				{
+					spacer.Width = SystemMargin + 8;
+				}
+				else
+				{
+					spacer.Width = SystemMargin - 16;
+				}
+
+				nfloat screenWidth = UIScreen.MainScreen.Bounds.Size.Width;
+
+				// A margin of private class `UINavigationButton` is different from custom view
+				if (!UIDevice.CurrentDevice.CheckSystemVersion(11, 0) && screenWidth < 375)
+				{
+					// 3.5 and 4 inch
+					spacer.Width += 8;
+				}
+				else if (screenWidth >= 414)
+				{
+					// 5.5 inch
+					spacer.Width -= 4;
+				}
+
+				return new UIEdgeInsets(0, spacer.Width, 0, spacer.Width);
+			}
+
+			public override UIEdgeInsets AlignmentRectInsets
+			{
+				get => CalculateUIEdgeInsets();
 			}
 
 			void OnTitleViewParentSet(object sender, EventArgs e)
@@ -2036,10 +2076,16 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				if (_icon != null)
 					_icon.Frame = new RectangleF(0, 0, IconWidth, Math.Min(toolbarHeight, IconHeight));
 
-				if (_child?.VirtualView != null)
+				if (_child?.VirtualView is IView view)
 				{
 					Rect layoutBounds = new Rect(IconWidth, 0, Bounds.Width - IconWidth, height);
 
+					if (view.HorizontalLayoutAlignment != Primitives.LayoutAlignment.Fill ||
+						view.VerticalLayoutAlignment != Primitives.LayoutAlignment.Fill)
+					{
+						view.Measure(Bounds.Width, Bounds.Height);
+						layoutBounds = view.ComputeFrame(new Rect(0, 0, Bounds.Width, Bounds.Height));
+					}
 					_child.PlatformArrangeHandler(layoutBounds);
 				}
 				else if (_icon != null && Superview != null)

--- a/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
@@ -1910,6 +1910,8 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			IPlatformViewHandler _child;
 			UIImageView _icon;
 			bool _disposed;
+
+			//https://developer.apple.com/documentation/uikit/uiview/2865930-directionallayoutmargins
 			const int SystemMargin = 16;
 
 			public Container(View view, UINavigationBar bar) : base(bar.Bounds)

--- a/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
@@ -1944,26 +1944,15 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				ClipsToBounds = true;
 			}
 
-			// A solution based on this code https://github.dev/devxoul/UINavigationItem-Margin
-			// responsible for removing the system margin inside the navigation bar
 			UIEdgeInsets CalculateUIEdgeInsets()
 			{
 				var type = UIBarButtonSystemItem.FixedSpace;
 				var spacer = new UIBarButtonItem(type, (_, _) => { });
-
-				if (UIDevice.CurrentDevice.CheckSystemVersion(11, 0))
-				{
-					spacer.Width = SystemMargin + 8;
-				}
-				else
-				{
-					spacer.Width = SystemMargin - 16;
-				}
+				spacer.Width = SystemMargin + (OperatingSystem.IsIOSVersionAtLeast(11) ? 8 : -16);
 
 				nfloat screenWidth = UIScreen.MainScreen.Bounds.Size.Width;
 
-				// A margin of private class `UINavigationButton` is different from custom view
-				if (!UIDevice.CurrentDevice.CheckSystemVersion(11, 0) && screenWidth < 375)
+				if (!OperatingSystem.IsIOSVersionAtLeast(11) && screenWidth < 375)
 				{
 					// 3.5 and 4 inch
 					spacer.Width += 8;


### PR DESCRIPTION
Fixes https://github.com/dotnet/maui/issues/9333
Fixes https://github.com/dotnet/maui/issues/19231
Fixes https://github.com/dotnet/maui/issues/5063

## Current behavior
 Layout options have no effect on the title view. The content inside the `titleView` behaves as it has both `HorizontalOptions` and `VerticalOptions` set to `Fill`. Also, notice that there's a horizontal margin that cannot be removed even with setting the negative values to margin eg. `Margin="-20,0"` (https://github.com/dotnet/maui/issues/19231)

### Currently
<img width="385" alt="Screenshot 2024-03-02 at 14 58 41" src="https://github.com/dotnet/maui/assets/42434498/d2948732-783a-4e12-81cb-32b8d02bea22">

## Proposed behavior https://github.com/dotnet/maui/issues/5063
Utilizes our current LayoutOptions to indicate how you want a TitleView to layout on the screen and removes the default horizontal margin so that we can customize it.

```
<NavigationPage.TitleView>
    <HorizontalStackLayout BackgroundColor="red">
        <Label VerticalOptions="Center" Text="Navigation page's title"/>
        <Image Source="dotnet_bot.png" Scale="0.8"/>
    </HorizontalStackLayout>
</NavigationPage.TitleView>
```

### `Default` - (horizontal and vertical options set to fill implicitly)

<img width="385" alt="Screenshot 2024-03-02 at 15 00 41" src="https://github.com/dotnet/maui/assets/42434498/03949fdc-7467-48c7-a308-083e01509a6b">

### `HorizontalOptions="Start"`
<img width="385" alt="Screenshot 2024-03-02 at 15 02 14" src="https://github.com/dotnet/maui/assets/42434498/7d874679-047e-414f-a4a3-2c0ca909da92">

### `HorizontalOptions="Center"`
<img width="385" alt="Screenshot 2024-03-02 at 15 04 44" src="https://github.com/dotnet/maui/assets/42434498/b8c892b8-87fb-49df-8b01-2bd183e21a96">

### `HorizontalOptions="End"`
<img width="385" alt="Screenshot 2024-03-02 at 15 05 47" src="https://github.com/dotnet/maui/assets/42434498/46ffd14e-56e4-4420-b1dd-b777989efd7d">

### `VerticalOptions="Start"`
<img width="385" alt="Screenshot 2024-03-02 at 15 09 49" src="https://github.com/dotnet/maui/assets/42434498/b01a4b8b-704c-42b7-837c-c5225dae62fb">

### `VerticalOptions="Center"`
<img width="385" alt="Screenshot 2024-03-02 at 15 07 58" src="https://github.com/dotnet/maui/assets/42434498/3db14960-ffc0-43e2-b477-a7f762f59871">

### `VerticalOptions="End"`
<img width="385" alt="Screenshot 2024-03-02 at 15 06 56" src="https://github.com/dotnet/maui/assets/42434498/93167311-5b23-4f73-8832-7438a1c9d42b">

### `VerticalOptions="Start"` `HorizontalOptions="Start"`
<img width="385" alt="Screenshot 2024-03-02 at 15 15 30" src="https://github.com/dotnet/maui/assets/42434498/a462142e-2a6d-4edc-91e5-46a03318708b">

### `VerticalOptions="Center"` `HorizontalOptions="Center"`
<img width="385" alt="Screenshot 2024-03-02 at 15 14 42" src="https://github.com/dotnet/maui/assets/42434498/5c460b0c-1c24-48c8-ac84-29210903ac6b">

### `VerticalOptions="End"` `HorizontalOptions="End"`
<img width="385" alt="Screenshot 2024-03-02 at 15 15 07" src="https://github.com/dotnet/maui/assets/42434498/a2e28892-5865-4f62-8ba0-9d2a632cdbfc">

## Remarks
I didn't implement anything that changes the behavior when additional toolbar items are added. For example, if there's a back button the title view places itself to the right of this button. It is because I'm not sure what is the desired behavior. On one hand, it looks weird that when we want to center the title it is moved to the right, but on the other, it is the default iOS's behavior and I believe a future discussion should be made https://github.com/xamarin/Xamarin.Forms/issues/4848
<img width="385" alt="Screenshot 2024-03-02 at 16 10 55" src="https://github.com/dotnet/maui/assets/42434498/2eee7174-d379-49cc-9e44-c7b4b4556298">


