### PR TITLE
[CI] Move to a pool dedicate just for APIScan.

### DIFF
--- a/eng/pipelines/common/apiscan.yml
+++ b/eng/pipelines/common/apiscan.yml
@@ -1,5 +1,5 @@
 parameters:
-  poolName: VSEngSS-MicroBuild2022-1ES
+  poolName: MAUI-1ESPT-Windows2022
   vmImage: ''
   os: windows
   softwareName: 'MAUI'


### PR DESCRIPTION
Move to a pool that was only created for APIScan so that we do not overuse the signing pool.