### PR TITLE
[CI] Add image override to APIScan pool.

### DIFF
--- a/eng/pipelines/common/apiscan.yml
+++ b/eng/pipelines/common/apiscan.yml
@@ -1,6 +1,6 @@
 parameters:
-  poolName: MAUI-1ESPT-Windows2022
-  vmImage: ''
+  poolName: MAUI-1ESPT
+  vmImage: '1ESPT-Windows2022'
   os: windows
   softwareName: 'MAUI'
   softwareVersion: 8.0

--- a/eng/pipelines/maui-release.yml
+++ b/eng/pipelines/maui-release.yml
@@ -158,9 +158,7 @@ extends:
         - template: /eng/pipelines/common/apiscan.yml@self                                  # ApiScan
           parameters:
             dependsOn: ['pack_net']
-            poolName: ${{ parameters.VM_IMAGE_HOST.name }}
-            vmImage: ${{ parameters.VM_IMAGE_HOST.image }}
-            os: ${{ parameters.VM_IMAGE_HOST.os }}
+            os: windows
             scanArtifacts: ['${{ parameters.PackPlatform.binariesArtifact }}']
 
         


### PR DESCRIPTION
Add ImageOverride since it is needed because there are linux machines in the pool.