### PR TITLE
Use a different gif URL as MS News blocked us

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Controls/ImageButtonPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/ImageButtonPage.xaml.cs
@@ -37,7 +37,7 @@ namespace Maui.Controls.Sample.Pages
 		void UseOnlineSource_Clicked(object sender, EventArgs e)
 		{
 			AnimatedGifImage.Source =
-				ImageSource.FromUri(new Uri("https://news.microsoft.com/wp-content/uploads/prod/2022/07/hexagon_print.gif"));
+				ImageSource.FromUri(new Uri("https://raw.githubusercontent.com/dotnet/maui/126f47aaf9d5c01224f54fe1c6bfb1c8299cc2fe/src/Compatibility/ControlGallery/src/iOS/GifTwo.gif"));
 		}
 	}
 

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/ImagePage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/ImagePage.xaml.cs
@@ -28,7 +28,7 @@ namespace Maui.Controls.Sample.Pages
 		void UseOnlineSource_Clicked(object sender, EventArgs e)
 		{
 			AnimatedGifImage.Source =
-				ImageSource.FromUri(new Uri("https://news.microsoft.com/wp-content/uploads/prod/2022/07/hexagon_print.gif"));
+				ImageSource.FromUri(new Uri("https://raw.githubusercontent.com/dotnet/maui/126f47aaf9d5c01224f54fe1c6bfb1c8299cc2fe/src/Compatibility/ControlGallery/src/iOS/GifTwo.gif"));
 		}
 	}
 }


### PR DESCRIPTION



### Description of Change

:'(

That's right, they don't want us "borrowing" their content for our app. So we made a better one ourselves. Thanks past Xamarin.Forms contributor/developer... Bet it was Sam. She is cool and did things like this.

Anyone remember the cute god that they snuck into the source repo? Try find it!