### PR TITLE
[Windows] Ensure consistent background colors for UI test cases

### DIFF
--- a/src/Controls/samples/Controls.Sample.UITests/CoreViews/CoreGalleryBasePage.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/CoreViews/CoreGalleryBasePage.cs
@@ -44,8 +44,6 @@ namespace Maui.Controls.Sample
 
 			Root = new StackLayout
 			{
-				// Make sure background color is consistant so that the Mica material doesn't cause issues on Windows
-				BackgroundColor = Application.Current.RequestedTheme == AppTheme.Dark ? Colors.Black : Colors.White,
 				Padding = new Thickness(20),
 				Children =
 				{

--- a/src/Controls/samples/Controls.Sample.UITests/CoreViews/CoreGalleryBasePage.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/CoreViews/CoreGalleryBasePage.cs
@@ -2,9 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Maui;
-using Microsoft.Maui.ApplicationModel;
 using Microsoft.Maui.Controls;
-using Microsoft.Maui.Graphics;
 
 namespace Maui.Controls.Sample
 {

--- a/src/Controls/samples/Controls.Sample.UITests/CoreViews/CoreGalleryBasePage.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/CoreViews/CoreGalleryBasePage.cs
@@ -2,7 +2,9 @@
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Maui;
+using Microsoft.Maui.ApplicationModel;
 using Microsoft.Maui.Controls;
+using Microsoft.Maui.Graphics;
 
 namespace Maui.Controls.Sample
 {
@@ -42,6 +44,8 @@ namespace Maui.Controls.Sample
 
 			Root = new StackLayout
 			{
+				// Make sure background color is consistant so that the Mica material doesn't cause issues on Windows
+				BackgroundColor = Application.Current.RequestedTheme == AppTheme.Dark ? Colors.Black : Colors.White,
 				Padding = new Thickness(20),
 				Children =
 				{

--- a/src/Controls/samples/Controls.Sample.UITests/CoreViews/CoreNavigationPage.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/CoreViews/CoreNavigationPage.cs
@@ -25,7 +25,7 @@ namespace Maui.Controls.Sample
 
 		private void UpdateThemeColor(object _, AppThemeChangedEventArgs args)
 		{
-			// Make sure background color is consistant so that the Mica material doesn't cause issues on Windows
+			// Make sure background color is consistent so that the Mica material doesn't cause issues on Windows
 			BackgroundColor =
 					Application.Current.RequestedTheme == Microsoft.Maui.ApplicationModel.AppTheme.Dark ? Colors.Black : Colors.White;
 		}

--- a/src/Controls/samples/Controls.Sample.UITests/CoreViews/CoreNavigationPage.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/CoreViews/CoreNavigationPage.cs
@@ -1,7 +1,9 @@
-﻿using Microsoft.Maui.Controls.Internals;
+﻿using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Controls.PlatformConfiguration;
 using Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific;
 using Microsoft.Maui.Graphics;
+using Application = Microsoft.Maui.Controls.Application;
 
 namespace Maui.Controls.Sample
 {
@@ -17,12 +19,23 @@ namespace Maui.Controls.Sample
 			On<iOS>().SetPrefersLargeTitles(true);
 
 			Navigation.PushAsync(new CoreRootPage(this));
+
+			Application.Current.RequestedThemeChanged += UpdateThemeColor;
+		}
+
+		private void UpdateThemeColor(object _, AppThemeChangedEventArgs args)
+		{
+			// Make sure background color is consistant so that the Mica material doesn't cause issues on Windows
+			BackgroundColor =
+					Application.Current.RequestedTheme == Microsoft.Maui.ApplicationModel.AppTheme.Dark ? Colors.Black : Colors.White;
 		}
 
 		public static void InitNavigationPageStyling(Microsoft.Maui.Controls.NavigationPage navigationPage)
 		{
 			navigationPage.BarBackgroundColor = Colors.Maroon;
 			navigationPage.BarTextColor = Colors.Yellow;
+			navigationPage.BackgroundColor =
+					Application.Current.RequestedTheme == Microsoft.Maui.ApplicationModel.AppTheme.Dark ? Colors.Black : Colors.White;
 		}
 	}
 }

--- a/src/Controls/samples/Controls.Sample.UITests/TestCases.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/TestCases.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
-using Microsoft.Maui.Graphics;
 
 namespace Maui.Controls.Sample
 {
@@ -101,7 +100,6 @@ namespace Maui.Controls.Sample
 				{
 					throw new InvalidCastException("Issue must be of type Page");
 				}
-
 				return page;
 			}
 

--- a/src/Controls/samples/Controls.Sample.UITests/TestCases.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/TestCases.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
+using Microsoft.Maui.Graphics;
 
 namespace Maui.Controls.Sample
 {
@@ -62,9 +63,7 @@ namespace Maui.Controls.Sample
 						TrackOnInsights(page);
 						if (page is ContentPage /*|| page is CarouselPage*/)
 						{
-
 							await Navigation.PushAsync(page);
-
 						}
 						else if (page is Shell)
 						{
@@ -102,6 +101,11 @@ namespace Maui.Controls.Sample
 				{
 					throw new InvalidCastException("Issue must be of type Page");
 				}
+
+				// Make sure background color is consistant so that the Mica material doesn't cause issues on Windows
+				page.BackgroundColor = Application.Current.RequestedTheme == 
+					Microsoft.Maui.ApplicationModel.AppTheme.Dark ? Colors.Black : Colors.White;
+
 				return page;
 			}
 

--- a/src/Controls/samples/Controls.Sample.UITests/TestCases.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/TestCases.cs
@@ -102,10 +102,6 @@ namespace Maui.Controls.Sample
 					throw new InvalidCastException("Issue must be of type Page");
 				}
 
-				// Make sure background color is consistant so that the Mica material doesn't cause issues on Windows
-				page.BackgroundColor = Application.Current.RequestedTheme == 
-					Microsoft.Maui.ApplicationModel.AppTheme.Dark ? Colors.Black : Colors.White;
-
 				return page;
 			}
 


### PR DESCRIPTION
### Description of Change

Make sure all background colors for test cases are black or white depending on the theme. This prevents issues w/ the Mica material when creating new screenshot based tests

### Issues Fixed

Fixes #21021
