### PR TITLE
Bump editorconfig csharp_prefer_braces down to suggestion

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -106,7 +106,7 @@ dotnet_naming_style.camel_case_underscore_style.capitalization = camel_case
 dotnet_sort_system_directives_first = true
 csharp_preserve_single_line_blocks = true
 csharp_preserve_single_line_statements = false
-csharp_prefer_braces = true:error
+csharp_prefer_braces = true:suggestion
 
 # Expression-level preferences
 dotnet_style_object_initializer = true:suggestion


### PR DESCRIPTION
### Description of Change

Bumps the `.editorconfig` `csharp_prefer_braces` setting down from error to suggestion. So our dotnet format run will not try to fix all the braces over night. This way we will still see suggestions in VS as I still think this is a good coding style to use.

### Issues Fixed

Related #21028
