### PR TITLE
[Catalyst] Fix Image not rendering in Mac Idiom (Device family = 6) Button

### DIFF
--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issue20896.xaml
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issue20896.xaml
@@ -10,6 +10,7 @@
                 <Setter Property="ImageSource" Value="groceries.png" />
                 <Setter Property="HorizontalOptions" Value="Center" />
                 <Setter Property="TextColor" Value="Black" />
+                <Setter Property="HeightRequest" Value="36" />
             </Style>
         
         </ResourceDictionary>
@@ -18,21 +19,10 @@
         <StackLayout
             Padding="12">
             <Label 
-                Text="This is a manual test to verify the use of ContentLayout in Catalyst. Remember, edit the info.plist to a UIDeviceFamily = 6"/>
-            <Button 
-                Text="Default" /> 
+                Text="This is a manual test to verify the use of ContentLayout in Catalyst. Remember, edit the info.plist to a UIDeviceFamily = 6. If the icon is drawn, the test has passed."/>
             <Button
                 ContentLayout="Left, 24"
                 Text="Left - 24"/>   
-            <Button
-                ContentLayout="Top, 24"
-                Text="Top - 24"/>
-            <Button
-                ContentLayout="Right, 24"
-                Text="Right - 24"/>
-            <Button
-                ContentLayout="Bottom, 24"
-                Text="Bottom - 24"/>
         </StackLayout>
     </ScrollView>
 </ContentPage>

--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issue20896.xaml
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issue20896.xaml
@@ -1,0 +1,38 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage 
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="Maui.Controls.Sample.Issues.Issue20896">
+    <ContentPage.Resources>
+        <ResourceDictionary>
+
+            <Style TargetType="Button">
+                <Setter Property="ImageSource" Value="groceries.png" />
+                <Setter Property="HorizontalOptions" Value="Center" />
+                <Setter Property="TextColor" Value="Black" />
+            </Style>
+        
+        </ResourceDictionary>
+    </ContentPage.Resources>
+    <ScrollView>
+        <StackLayout
+            Padding="12">
+            <Label 
+                Text="This is a manual test to verify the use of ContentLayout in Catalyst. Remember, edit the info.plist to a UIDeviceFamily = 6"/>
+            <Button 
+                Text="Default" /> 
+            <Button
+                ContentLayout="Left, 24"
+                Text="Left - 24"/>   
+            <Button
+                ContentLayout="Top, 24"
+                Text="Top - 24"/>
+            <Button
+                ContentLayout="Right, 24"
+                Text="Right - 24"/>
+            <Button
+                ContentLayout="Bottom, 24"
+                Text="Bottom - 24"/>
+        </StackLayout>
+    </ScrollView>
+</ContentPage>

--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issue20896.xaml.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issue20896.xaml.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+using Microsoft.Maui.Platform;
+
+namespace Maui.Controls.Sample.Issues
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	[Issue(IssueTracker.Github, 20896, "Mac Idiom (Device family = 6) Button styling properties not working", PlatformAffected.macOS)]
+	public partial class Issue20896 : ContentPage
+	{
+		public Issue20896()
+		{
+			InitializeComponent();
+		}
+	}
+}

--- a/src/Controls/src/Core/Button/Button.iOS.cs
+++ b/src/Controls/src/Core/Button/Button.iOS.cs
@@ -14,6 +14,10 @@ namespace Microsoft.Maui.Controls
 		{
 			var result = base.ArrangeOverride(bounds);
 			Handler?.UpdateValue(nameof(ContentLayout));
+
+			if(ImageSource is not null)
+ 				Handler?.UpdateValue(nameof(IImage.Source));
+				
 			return result;
 		}
 

--- a/src/Controls/src/Core/Platform/iOS/Extensions/ButtonExtensions.cs
+++ b/src/Controls/src/Core/Platform/iOS/Extensions/ButtonExtensions.cs
@@ -2,6 +2,7 @@
 using System;
 using CoreGraphics;
 using Foundation;
+using Microsoft.Extensions.Logging;
 using Microsoft.Maui.Controls.Internals;
 using ObjCRuntime;
 using UIKit;
@@ -182,15 +183,82 @@ namespace Microsoft.Maui.Controls.Platform
 
 			platformButton.UpdatePadding(button);
 
-#pragma warning disable CA1416, CA1422 // TODO: [UnsupportedOSPlatform("ios15.0")]
-			if (platformButton.ImageEdgeInsets != imageInsets ||
-				platformButton.TitleEdgeInsets != titleInsets)
+
+			// On iOS 15+, we will resize the image and then use the UIButton.Configuration to adjust the padding
+			if (OperatingSystem.IsIOSVersionAtLeast(15) && platformButton.Configuration is not null)
 			{
-				platformButton.ImageEdgeInsets = imageInsets;
-				platformButton.TitleEdgeInsets = titleInsets;
-				platformButton.Superview?.SetNeedsLayout();
+				ResizeImage(platformButton, button, image);
+				var config = platformButton.Configuration;
+
+				config.ImagePadding = imageInsets.Right - imageInsets.Left + titleInsets.Left - titleInsets.Right;
+				platformButton.Configuration = config;
 			}
-#pragma warning restore CA1416, CA1422
+
+			else if (!OperatingSystem.IsIOSVersionAtLeast(15))
+			{
+				if (platformButton.ImageEdgeInsets != imageInsets ||
+					platformButton.TitleEdgeInsets != titleInsets)
+				{
+					platformButton.ImageEdgeInsets = imageInsets;
+					platformButton.TitleEdgeInsets = titleInsets;
+					platformButton.Superview?.SetNeedsLayout();
+				}
+			}
+		}
+
+		static void ResizeImage(UIButton platformButton, Button button, UIImage image)
+		{
+			nfloat buttonSize = 0;
+
+			if (!OperatingSystem.IsIOSVersionAtLeast(15))
+			{
+				var contentEdgeInsets = platformButton.ContentEdgeInsets;
+				if (platformButton.Bounds != CGRect.Empty)
+				{
+					if (platformButton.Bounds.Height > platformButton.Bounds.Width)
+						buttonSize = platformButton.Bounds.Width - (contentEdgeInsets.Left + contentEdgeInsets.Right);
+					else
+						buttonSize = platformButton.Bounds.Height - (contentEdgeInsets.Top + contentEdgeInsets.Bottom);
+				}
+			}
+			else
+			{
+				if (platformButton.Bounds != CGRect.Empty && platformButton.Configuration?.ContentInsets is NSDirectionalEdgeInsets contentInsets)
+				{
+					if (platformButton.Bounds.Height > platformButton.Bounds.Width)
+						buttonSize = platformButton.Bounds.Width - (contentInsets.Leading + contentInsets.Trailing);
+					else
+						buttonSize = platformButton.Bounds.Height - (contentInsets.Top + contentInsets.Bottom);
+				}
+			}
+
+			try
+			{
+				if (buttonSize != 0)
+					image = ResizeImageSource(image, buttonSize, buttonSize);
+
+				image = image?.ImageWithRenderingMode(UIImageRenderingMode.AlwaysOriginal);
+
+				platformButton.SetImage(image, UIControlState.Normal);
+			}
+			catch (Exception)
+			{
+				button.Handler.MauiContext?.CreateLogger<ButtonHandler>()?.LogWarning("Can not load Button ImageSource");
+			}
+		}
+
+		static UIImage ResizeImageSource(UIImage sourceImage, nfloat maxWidth, nfloat maxHeight)
+		{
+			if (sourceImage is null || sourceImage.CGImage is null)
+				return null;
+
+			var sourceSize = sourceImage.Size;
+			float maxResizeFactor = (float)Math.Min(maxWidth / sourceSize.Width, maxHeight / sourceSize.Height);
+
+			if (maxResizeFactor > 1)
+				return sourceImage;
+
+			return UIImage.FromImage(sourceImage.CGImage, sourceImage.CurrentScale / maxResizeFactor, sourceImage.Orientation);
 		}
 
 		public static void UpdateText(this UIButton platformButton, Button button)

--- a/src/Core/src/Handlers/ImageButton/ImageButtonHandler.iOS.cs
+++ b/src/Core/src/Handlers/ImageButton/ImageButtonHandler.iOS.cs
@@ -9,10 +9,16 @@ namespace Microsoft.Maui.Handlers
 
 		protected override UIButton CreatePlatformView()
 		{
-			var platformView = new UIButton(UIButtonType.System)
+			var platformView = new UIButton(UIButtonType.System);
+
+			// Starting with iOS 15, we can use the UIButton.Configuration and assign future UIButton.Configuration.ContentInsets here instead of the deprecated UIButton.ContentEdgeInsets.
+			// It is important to note that the configuration will change any set style changes so we will do this right after creating the button.
+			if (OperatingSystem.IsIOSVersionAtLeast(15))
 			{
-				ClipsToBounds = true
-			};
+				platformView.Configuration = UIButtonConfiguration.PlainButtonConfiguration;
+			}
+
+			platformView.ClipsToBounds = true;
 
 			return platformView;
 		}

--- a/src/Core/src/Platform/iOS/ButtonExtensions.cs
+++ b/src/Core/src/Platform/iOS/ButtonExtensions.cs
@@ -54,6 +54,18 @@ namespace Microsoft.Maui.Platform
 		public static void UpdateFont(this UIButton platformButton, ITextStyle textStyle, IFontManager fontManager)
 		{
 			platformButton.TitleLabel.UpdateFont(textStyle, fontManager, UIFont.ButtonFontSize);
+
+			// If iOS 15+, update the configuration with the new font
+			if (OperatingSystem.IsIOSVersionAtLeast(15) && platformButton.Configuration is UIButtonConfiguration config)
+			{
+				config.TitleTextAttributesTransformer = (incoming) =>
+				{
+					var outgoing = incoming;
+					outgoing[UIStringAttributeKey.Font] = platformButton.TitleLabel.Font;
+					return outgoing;
+				};
+				platformButton.Configuration = config;
+			}
 		}
 
 		public static void UpdatePadding(this UIButton platformButton, IButton button, Thickness? defaultPadding = null) =>
@@ -73,15 +85,24 @@ namespace Microsoft.Maui.Platform
 			if (bottom == 0.0)
 				bottom = AlmostZero;
 
-#pragma warning disable CA1416 // TODO: 'UIButton.ContentEdgeInsets' is unsupported on: 'ios' 15.0 and later.
-#pragma warning disable CA1422 // Validate platform compatibility
-			platformButton.ContentEdgeInsets = new UIEdgeInsets(
-				(float)top,
-				(float)padding.Left,
-				(float)bottom,
-				(float)padding.Right);
-#pragma warning restore CA1422 // Validate platform compatibility
-#pragma warning restore CA1416
+			if (OperatingSystem.IsIOSVersionAtLeast(15) && platformButton.Configuration is not null)
+			{
+				var config = platformButton.Configuration;
+				config.ContentInsets = new NSDirectionalEdgeInsets(
+					(float)top,
+					(float)padding.Left,
+					(float)bottom,
+					(float)padding.Right);
+				platformButton.Configuration = config;
+			}
+			else if (!OperatingSystem.IsIOSVersionAtLeast(15))
+			{
+				platformButton.ContentEdgeInsets = new UIEdgeInsets(
+					(float)top,
+					(float)padding.Left,
+					(float)bottom,
+					(float)padding.Right);
+			}
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change

Fix Image not rendering in Mac Idiom (Device family = 6) Button.

Device family = 1, 2
<img width="784" alt="Captura de pantalla 2024-03-06 a las 13 20 11" src="https://github.com/dotnet/maui/assets/6755973/1d6ba944-2a76-4a51-a75d-4c61d376cec8">

Device family = 6
<img width="1020" alt="Captura de pantalla 2024-03-06 a las 13 21 30" src="https://github.com/dotnet/maui/assets/6755973/79075cee-1af3-4609-ab9a-0b493a5c7595">

### Issues Fixed

Fixes #20896 
