### PR TITLE
[Trimming] Use type converters instead of implicit cast operators (part 1/2)

### DIFF
--- a/docs/design/FeatureSwitches.md
+++ b/docs/design/FeatureSwitches.md
@@ -8,6 +8,7 @@ Certain features of MAUI can be enabled or disabled using feature switches. The 
 | MauiEnableIVisualAssemblyScanning | Microsoft.Maui.RuntimeFeature.IsIVisualAssemblyScanningEnabled | When enabled, MAUI will scan assemblies for types implementing `IVisual` and for `[assembly: Visual(...)]` attributes and register these types. |
 | MauiShellSearchResultsRendererDisplayMemberNameSupported | Microsoft.Maui.RuntimeFeature.IsShellSearchResultsRendererDisplayMemberNameSupported | When disabled, it is necessary to always set `ItemTemplate` of any `SearchHandler`. Displaying search results through `DisplayMemberName` will not work. |
 | MauiQueryPropertyAttributeSupport | Microsoft.Maui.RuntimeFeature.IsQueryPropertyAttributeSupported | When disabled, the `[QueryProperty(...)]` attributes won't be used to set values to properties when navigating. |
+| MauiImplicitCastOperatorsUsageViaReflectionSupport | Microsoft.Maui.RuntimeFeature.IsImplicitCastOperatorsUsageViaReflectionSupported | When disabled, MAUI won't look for implicit cast operators when converting values from one type to another. This feature is not trim-compatible. |
 
 ## MauiXamlRuntimeParsingSupport
 
@@ -26,3 +27,26 @@ When this feature is disabled, any value set to [`SearchHandler.DisplayMemberNam
 ## MauiQueryPropertyAttributeSupport
 
 When disabled, the `[QueryProperty(...)]` attributes won't be used to set values to properties when navigating. Instead, implement the [`IQueryAttributable`](https://learn.microsoft.com/en-us/dotnet/maui/fundamentals/shell/navigation#process-navigation-data-using-a-single-method) interface whenever you need to accept query parameters.
+
+## MauiImplicitCastOperatorsUsageViaReflectionSupport
+
+When disabled, MAUI won't look for implicit cast operators when converting values from one type to another. This can affact the following scenarios:
+- bindings between properties with different types,
+- setting a property value of a bindable object with a value of different type.
+
+If your library or your app defines an implicit operator on a type that can be used in one of the previous scenarios, you should define a custom `TypeConverter` for your type and attach it to the type using the `[TypeConverter(typeof(MyTypeConverter))]` attribute.
+
+If you need to define a type converter for a type that you don't own, you can use `MauiAppBuilder.ConfigureTypeConversions`:
+
+```c#
+var builder = MauiApp.CreateBuilder();
+builder
+    .UseMauiApp<App>()
+    .ConfigureTypeConversions(config =>
+    {
+        config.AddTypeConverter<MyTypeA, MyTypeAConverter>();
+        config.AddTypeConverter<MyTypeB>(() => new MyTypeBConverter(myFlag: false));
+    });
+```
+
+_Note: Prefer using the `TypeConverterAttribute` as it can help the trimmer achieve better binary size in certain scenarios._

--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
@@ -231,7 +231,7 @@
                                       Condition="'$(MauiQueryPropertyAttributeSupport)' != ''"
                                       Value="$(MauiQueryPropertyAttributeSupport)"
                                       Trim="true" />
-      <RuntimeHostConfigurationOption Include="Microsoft.Maui.RuntimeFeature.IsImplicitCastOperatorsUsageViaReflectionSupport"
+      <RuntimeHostConfigurationOption Include="Microsoft.Maui.RuntimeFeature.IsImplicitCastOperatorsUsageViaReflectionSupported"
                                       Condition="'$(MauiImplicitCastOperatorsUsageViaReflectionSupport)' != ''"
                                       Value="$(MauiImplicitCastOperatorsUsageViaReflectionSupport)"
                                       Trim="true" />

--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
@@ -211,7 +211,8 @@
       <MauiXamlRuntimeParsingSupport Condition="'$(MauiXamlRuntimeParsingSupport)' == '' and '$(PublishAot)' == 'true'">false</MauiXamlRuntimeParsingSupport>
       <MauiEnableIVisualAssemblyScanning Condition="'$(MauiEnableIVisualAssemblyScanning)' == ''">false</MauiEnableIVisualAssemblyScanning>
       <MauiShellSearchResultsRendererDisplayMemberNameSupported Condition="'$(MauiShellSearchResultsRendererDisplayMemberNameSupported)' == '' and '$(PublishAot)' == 'true'">false</MauiShellSearchResultsRendererDisplayMemberNameSupported>
-      <MauiQueryPropertyAttributeSupport Condition="'$(MauiQueryPropertyAttributeSupport)' == ''">false</MauiQueryPropertyAttributeSupport>
+      <MauiQueryPropertyAttributeSupport Condition="'$(MauiQueryPropertyAttributeSupport)' == '' and '$(PublishAot)' == 'true'">false</MauiQueryPropertyAttributeSupport>
+      <MauiImplicitCastOperatorsUsageViaReflectionSupport Condition="'$(MauiImplicitCastOperatorsUsageViaReflectionSupport)' == '' and '$(PublishAot)' == 'true'">false</MauiImplicitCastOperatorsUsageViaReflectionSupport>
     </PropertyGroup>
     <ItemGroup>
       <RuntimeHostConfigurationOption Include="Microsoft.Maui.RuntimeFeature.IsXamlRuntimeParsingSupported"
@@ -229,6 +230,10 @@
       <RuntimeHostConfigurationOption Include="Microsoft.Maui.RuntimeFeature.IsQueryPropertyAttributeSupported"
                                       Condition="'$(MauiQueryPropertyAttributeSupport)' != ''"
                                       Value="$(MauiQueryPropertyAttributeSupport)"
+                                      Trim="true" />
+      <RuntimeHostConfigurationOption Include="Microsoft.Maui.RuntimeFeature.IsImplicitCastOperatorsUsageViaReflectionSupport"
+                                      Condition="'$(MauiImplicitCastOperatorsUsageViaReflectionSupport)' != ''"
+                                      Value="$(MauiImplicitCastOperatorsUsageViaReflectionSupport)"
                                       Trim="true" />
     </ItemGroup>
   </Target>

--- a/src/Controls/src/Core/BindableProperty.cs
+++ b/src/Controls/src/Core/BindableProperty.cs
@@ -229,10 +229,9 @@ namespace Microsoft.Maui.Controls
 			if (returnType.IsAssignableFrom(valueType))
 				return true;
 
-			var cast = returnType.GetImplicitConversionOperator(fromType: valueType, toType: returnType) ?? valueType.GetImplicitConversionOperator(fromType: valueType, toType: returnType);
-			if (cast != null)
+			if (TypeConversionHelper.TryConvert(value, returnType, out var convertedValue))
 			{
-				value = cast.Invoke(null, new[] { value });
+				value = convertedValue;
 				return true;
 			}
 			if (KnownIValueConverters.TryGetValue(returnType, out IValueConverter valueConverter))

--- a/src/Controls/src/Core/IWrappedValue.cs
+++ b/src/Controls/src/Core/IWrappedValue.cs
@@ -1,0 +1,11 @@
+#nullable enable
+using System;
+
+namespace Microsoft.Maui.Controls
+{
+	internal interface IWrappedValue
+	{
+		object? Value { get; }
+		Type ValueType { get; }
+	}
+}

--- a/src/Controls/src/Core/OnIdiom.cs
+++ b/src/Controls/src/Core/OnIdiom.cs
@@ -3,7 +3,7 @@ using Microsoft.Maui.Devices;
 
 namespace Microsoft.Maui.Controls
 {
-	public class OnIdiom<T>
+	public class OnIdiom<T> : IWrappedValue
 	{
 		T _phone;
 		T _tablet;
@@ -87,5 +87,8 @@ namespace Microsoft.Maui.Controls
 			else
 				return onIdiom._isPhoneSet ? onIdiom.Phone : (onIdiom._isDefaultSet ? onIdiom.Default : default(T));
 		}
+
+		object IWrappedValue.Value => (T)this;
+		System.Type IWrappedValue.ValueType => typeof(T);
 	}
 }

--- a/src/Controls/src/Core/OnPlatform.cs
+++ b/src/Controls/src/Core/OnPlatform.cs
@@ -6,7 +6,7 @@ using Microsoft.Maui.Devices;
 namespace Microsoft.Maui.Controls
 {
 	[ContentProperty("Platforms")]
-	public class OnPlatform<T>
+	public class OnPlatform<T> : IWrappedValue
 	{
 		public OnPlatform()
 		{
@@ -54,6 +54,9 @@ namespace Microsoft.Maui.Controls
 
 			return onPlatform.hasDefault ? onPlatform.@default : default(T);
 		}
+
+		object IWrappedValue.Value => (T)this;
+		System.Type IWrappedValue.ValueType => typeof(T);
 	}
 
 	/// <include file="../../docs/Microsoft.Maui.Controls/On.xml" path="Type[@FullName='Microsoft.Maui.Controls.On']/Docs/*" />

--- a/src/Controls/src/Core/TypeConversionHelper.cs
+++ b/src/Controls/src/Core/TypeConversionHelper.cs
@@ -35,18 +35,6 @@ namespace Microsoft.Maui.Controls
 				valueType = wrappedType;
 			}
 
-			if (TryGetTypeConverter(valueType, out var converter) && converter is not null && converter.CanConvertTo(targetType))
-			{
-				convertedValue = converter.ConvertTo(value, targetType) ?? throw new InvalidOperationException($"The {converter.GetType()} returned null when converting {valueType} to {targetType}");
-				return true;
-			}
-
-			if (TryGetTypeConverter(targetType, out converter) && converter is not null && converter.CanConvertFrom(valueType))
-			{
-				convertedValue = converter.ConvertFrom(value) ?? throw new InvalidOperationException($"The {converter.GetType()} returned null when converting from {valueType}");
-				return true;
-			}
-
 			if (RuntimeFeature.IsImplicitCastOperatorsUsageViaReflectionSupported)
 			{
 				if (TryConvertUsingImplicitCastOperator(value, targetType, out convertedValue))
@@ -56,6 +44,18 @@ namespace Microsoft.Maui.Controls
 			}
 			else
 			{
+				if (TryGetTypeConverter(valueType, out var converter) && converter is not null && converter.CanConvertTo(targetType))
+				{
+					convertedValue = converter.ConvertTo(value, targetType) ?? throw new InvalidOperationException($"The {converter.GetType()} returned null when converting {valueType} to {targetType}");
+					return true;
+				}
+
+				if (TryGetTypeConverter(targetType, out converter) && converter is not null && converter.CanConvertFrom(valueType))
+				{
+					convertedValue = converter.ConvertFrom(value) ?? throw new InvalidOperationException($"The {converter.GetType()} returned null when converting from {valueType}");
+					return true;
+				}
+
 				WarnIfImplicitOperatorIsAvailable(value, targetType);
 			}
 

--- a/src/Controls/src/Core/TypeConversionHelper.cs
+++ b/src/Controls/src/Core/TypeConversionHelper.cs
@@ -69,8 +69,7 @@ namespace Microsoft.Maui.Controls
 
 		[RequiresUnreferencedCode("The method uses reflection to find implicit conversion operators. " +
 			"It is not possible to guarantee that trimming does not remove some of the implicit operators. " +
-			"Consider preserving op_Implicit methods through DynamicDependency or DynamicallyAccessedMembers attributes.",
-			Url = "https://learn.microsoft.com/dotnet/core/deploying/trimming/prepare-libraries-for-trimming")]
+			"Consider adding a custom TypeConverter that can perform the conversion instead.")]
 		private static bool TryConvertUsingImplicitCastOperator(object value, Type targetType, [NotNullWhen(true)] out object? result)
 		{
 			Type valueType = value.GetType();
@@ -87,8 +86,8 @@ namespace Microsoft.Maui.Controls
 			result = null;
 			return false;
 
-			[UnconditionalSuppressMessage("ReflectionAnalysis", "IL2070:RequiresUnreferencedCode",
-				Justification = "We add our own RequiresUnreferencedCode attribute to the parent method.")]
+			[RequiresUnreferencedCode("The method looks for op_Implicit methods using reflection. " +
+				"We cannot guarantee that the method is preserved when the code is trimmed.")]
 			static MethodInfo? GetImplicitConversionOperator(Type onType, Type fromType, Type toType)
 			{
 				const BindingFlags bindingAttr = BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy;

--- a/src/Controls/src/Core/TypeConversionHelper.cs
+++ b/src/Controls/src/Core/TypeConversionHelper.cs
@@ -1,0 +1,172 @@
+#nullable enable
+
+using System;
+using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Maui.Controls.Xaml;
+using Microsoft.Maui.Hosting;
+
+namespace Microsoft.Maui.Controls
+{
+	internal static class TypeConversionHelper
+	{
+		internal static bool TryConvert(object value, Type targetType, out object? convertedValue)
+		{
+			Type valueType = value.GetType();
+
+			if (value is IWrappedValue { Value: var wrappedValue, ValueType: var wrappedType })
+			{
+				if (wrappedValue is null)
+				{
+					convertedValue = null;
+					return !targetType.IsValueType || targetType.IsGenericType && targetType.GetGenericTypeDefinition() == typeof(Nullable<>);
+				}
+
+				// It might be enough just to unwrap the value
+				if (targetType.IsAssignableFrom(wrappedType))
+				{
+					convertedValue = wrappedValue;
+					return true;
+				}
+
+				value = wrappedValue;
+				valueType = wrappedType;
+			}
+
+			if (TryGetTypeConverter(valueType, out var converter) && converter is not null && converter.CanConvertTo(targetType))
+			{
+				convertedValue = converter.ConvertTo(value, targetType) ?? throw new InvalidOperationException($"The {converter.GetType()} returned null when converting {valueType} to {targetType}");
+				return true;
+			}
+
+			if (TryGetTypeConverter(targetType, out converter) && converter is not null && converter.CanConvertFrom(valueType))
+			{
+				convertedValue = converter.ConvertFrom(value) ?? throw new InvalidOperationException($"The {converter.GetType()} returned null when converting from {valueType}");
+				return true;
+			}
+
+			if (RuntimeFeature.IsImplicitCastOperatorsUsageViaReflectionSupported)
+			{
+				if (TryConvertUsingImplicitCastOperator(value, targetType, out convertedValue))
+				{
+					return true;
+				}
+			}
+			else
+			{
+				WarnIfImplicitOperatorIsAvailable(value, targetType);
+			}
+
+			convertedValue = null;
+			return false;
+		}
+
+		private static bool TryGetTypeConverter(Type type, [NotNullWhen(true)] out TypeConverter? converter)
+			=> TypeConversionAppBuilderExtensions.TryGetTypeConverter(type, out converter)
+				|| type.TryGetTypeConverter(out converter);
+
+		[RequiresUnreferencedCode("The method uses reflection to find implicit conversion operators. " +
+			"It is not possible to guarantee that trimming does not remove some of the implicit operators. " +
+			"Consider preserving op_Implicit methods through DynamicDependency or DynamicallyAccessedMembers attributes.",
+			Url = "https://learn.microsoft.com/dotnet/core/deploying/trimming/prepare-libraries-for-trimming")]
+		private static bool TryConvertUsingImplicitCastOperator(object value, Type targetType, [NotNullWhen(true)] out object? result)
+		{
+			Type valueType = value.GetType();
+			MethodInfo? opImplicit = GetImplicitConversionOperator(valueType, fromType: valueType, toType: targetType)
+										?? GetImplicitConversionOperator(targetType, fromType: valueType, toType: targetType);
+
+			object? convertedValue = opImplicit?.Invoke(null, new[] { value });
+			if (convertedValue is not null)
+			{
+				result = convertedValue;
+				return true;
+			}
+
+			result = null;
+			return false;
+
+			[UnconditionalSuppressMessage("ReflectionAnalysis", "IL2070:RequiresUnreferencedCode",
+				Justification = "We add our own RequiresUnreferencedCode attribute to the parent method.")]
+			static MethodInfo? GetImplicitConversionOperator(Type onType, Type fromType, Type toType)
+			{
+				const BindingFlags bindingAttr = BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy;
+
+				try
+				{
+					var method = onType.GetMethod("op_Implicit", bindingAttr, null, new[] { fromType }, null);
+					if (method is not null
+						&& IsImplicitOperator(method)
+						&& HasSuitableReturnType(method, toType))
+					{
+						return method;
+					}
+				}
+				catch (AmbiguousMatchException)
+				{
+					// Ignore the exception and fall back to custom filtering of all methods.
+					// This happens when there are multiple implicit operators with the same parameter type,
+					// but with different return types.
+				}
+
+				foreach (var method in onType.GetMethods(bindingAttr))
+				{
+					if (IsImplicitOperator(method)
+						&& HasSuitableParameterType(method, fromType)
+						&& HasSuitableReturnType(method, toType))
+					{
+						return method;
+					}
+				}
+
+				return null;
+			}
+
+			static bool IsImplicitOperator(MethodInfo method)
+				=> method.IsSpecialName
+					&& method.IsPublic
+					&& method.IsStatic
+					&& method.Name == "op_Implicit";
+
+			// Note: our custom type compatiblity checks are much less permissie than what .NET does internally.
+			// The `IsAssignableFrom` method will for example return `false` when asking if `int` can be assigned
+			// to `long`. This will filter out some valid matches and can lead to unexpected behavior.
+			// The converison method has behaved this way for many years so we should probably keep it this way,
+			// especially since we're trying to replace these implicit operators with type converters.
+
+			static bool HasSuitableParameterType(MethodInfo method, Type fromType)
+				=> method.GetParameters() is ParameterInfo[] parameters
+					&& parameters.Length == 1
+					&& parameters[0].ParameterType.IsAssignableFrom(fromType);
+
+			static bool HasSuitableReturnType(MethodInfo method, Type toType)
+				=> toType.IsAssignableFrom(method.ReturnType);
+		}
+
+		private static void WarnIfImplicitOperatorIsAvailable(object value, Type targetType)
+		{
+			[UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
+				Justification = "The method tries finding implicit cast operators reflection to help developers " +
+					"catch the cases where they are missing type converters during development mostly in debug builds. " +
+					"The method is expected not to find anything when the app code is trimmed.")]
+			bool HasImplicitOperatorConversion()
+			{
+				return TryConvertUsingImplicitCastOperator(value, targetType, out _);
+			}
+
+			if (HasImplicitOperatorConversion())
+			{
+				// If we reach this point, it means that the implicit cast operator exists, but we are not allowed to use it. This can happen for example in debug builds
+				// when the app is not trimmed. This is the best effort to help developers catch the cases where they are missing type converters during development.
+				// Unforutnately, we cannot just add a build warning at this moment.
+				Application.Current?.FindMauiContext()?.CreateLogger(nameof(TypeConversionHelper))?.LogWarning(
+					$"It is not possible to convert value of type {value.GetType()} to {targetType} via an implicit cast " +
+					"because this feature is disabled. You should add a type converter that will implement this conversion and attach it to either of " +
+					"these types using the [TypeConverter] attribute or using the ConfigureTypeConversions method on MauiAppBuilder. Alternatively, you " +
+					"can enable this feature by setting the MauiImplicitCastOperatorsUsageViaReflectionSupport MSBuild property to true in your project file. " +
+					"Note: this feature is not compatible with trimming and with NativeAOT.");
+			}
+		}
+	}
+}

--- a/src/Controls/src/Xaml/CreateValuesVisitor.cs
+++ b/src/Controls/src/Xaml/CreateValuesVisitor.cs
@@ -248,12 +248,13 @@ namespace Microsoft.Maui.Controls.Xaml
 				{
 					if ((p[i].ParameterType.IsAssignableFrom(types[i])))
 						continue;
-					var op_impl = p[i].ParameterType.GetImplicitConversionOperator(fromType: types[i], toType: p[i].ParameterType)
-								?? types[i].GetImplicitConversionOperator(fromType: types[i], toType: p[i].ParameterType);
 
-					if (op_impl == null)
+					if (!TypeConversionHelper.TryConvert(arguments[i], p[i].ParameterType, out var convertedValue))
+					{
 						return false;
-					arguments[i] = op_impl.Invoke(null, new[] { arguments[i] });
+					}
+
+					arguments[i] = convertedValue;
 				}
 				return true;
 			}

--- a/src/Controls/src/Xaml/MarkupExtensions/StaticResourceExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/StaticResourceExtension.cs
@@ -43,21 +43,10 @@ namespace Microsoft.Maui.Controls.Xaml
 			if (propertyType is null || propertyType.IsAssignableFrom(valueType))
 				return value;
 
-			MethodInfo implicit_op;
-
-			//OnPlatform might need double cast
-			if (valueType.IsGenericType && valueType.Name == "OnPlatform`1")
+			if (TypeConversionHelper.TryConvert(value, propertyType, out var convertedValue))
 			{
-				var onPlatType = valueType.GetGenericArguments()[0];
-				implicit_op = valueType.GetImplicitConversionOperator(fromType: valueType, toType: onPlatType);
-				value = implicit_op.Invoke(value, new[] { value });
-				valueType = value.GetType();
+				return convertedValue;
 			}
-
-			implicit_op = valueType.GetImplicitConversionOperator(fromType: valueType, toType: propertyType)
-							?? propertyType.GetImplicitConversionOperator(fromType: valueType, toType: propertyType);
-			if (implicit_op != null)
-				return implicit_op.Invoke(value, new[] { value });
 
 			return value;
 		}

--- a/src/Core/src/Hosting/TypeConversionAppBuilderExtensions.cs
+++ b/src/Core/src/Hosting/TypeConversionAppBuilderExtensions.cs
@@ -6,8 +6,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Maui.Hosting
 {
-	// TODO make this public
-	internal static class TypeConversionAppBuilderExtensions
+	public static class TypeConversionAppBuilderExtensions
 	{
 		private static Dictionary<Type, TypeConverter>? s_typeConverters;
 
@@ -51,8 +50,7 @@ namespace Microsoft.Maui.Hosting
 		}
 	}
 
-	// TODO make this public
-	internal interface ITypeConversionBuilder
+	public interface ITypeConversionBuilder
 	{
 		ITypeConversionBuilder AddTypeConverter<T, TConverter>() where TConverter : TypeConverter, new();
 		ITypeConversionBuilder AddTypeConverter<T>(Func<TypeConverter> createConverter);

--- a/src/Core/src/Hosting/TypeConversionAppBuilderExtensions.cs
+++ b/src/Core/src/Hosting/TypeConversionAppBuilderExtensions.cs
@@ -1,0 +1,60 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.Maui.Hosting
+{
+	// TODO make this public
+	internal static class TypeConversionAppBuilderExtensions
+	{
+		private static Dictionary<Type, TypeConverter>? s_typeConverters;
+
+		public static MauiAppBuilder ConfigureTypeConversions(this MauiAppBuilder builder, Action<ITypeConversionBuilder> configureDelegate)
+		{
+			var typeConversionBuilder = new TypeConversionBuilder();
+
+			configureDelegate(typeConversionBuilder);
+
+			foreach (var kvp in typeConversionBuilder.Converters)
+			{
+				s_typeConverters ??= new();
+				s_typeConverters[kvp.Key] = kvp.Value;
+			}
+
+			return builder;
+		}
+
+		internal static bool TryGetTypeConverter(Type type, [NotNullWhen(true)] out TypeConverter? typeConverter)
+		{
+			typeConverter = null;
+			return s_typeConverters?.TryGetValue(type, out typeConverter) ?? false;
+		}
+
+		private class TypeConversionBuilder : ITypeConversionBuilder
+		{
+			internal Dictionary<Type, TypeConverter> Converters { get; } = new();
+
+			public ITypeConversionBuilder AddTypeConverter<T, TConverter>()
+				where TConverter : TypeConverter, new()
+			{
+				Converters[typeof(T)] = new TConverter();
+				return this;
+			}
+
+			public ITypeConversionBuilder AddTypeConverter<T>(Func<TypeConverter> createConverter)
+			{
+				Converters[typeof(T)] = createConverter();
+				return this;
+			}
+		}
+	}
+
+	// TODO make this public
+	internal interface ITypeConversionBuilder
+	{
+		ITypeConversionBuilder AddTypeConverter<T, TConverter>() where TConverter : TypeConverter, new();
+		ITypeConversionBuilder AddTypeConverter<T>(Func<TypeConverter> createConverter);
+	}
+}

--- a/src/Core/src/ILLink.Substitutions.xml
+++ b/src/Core/src/ILLink.Substitutions.xml
@@ -9,6 +9,8 @@
       <method signature="System.Boolean get_IsShellSearchResultsRendererDisplayMemberNameSupported()" body="stub" feature="Microsoft.Maui.RuntimeFeature.IsShellSearchResultsRendererDisplayMemberNameSupported" value="true" featurevalue="true" />
       <method signature="System.Boolean get_IsQueryPropertyAttributeSupported()" body="stub" feature="Microsoft.Maui.RuntimeFeature.IsQueryPropertyAttributeSupported" value="false" featurevalue="false" />
       <method signature="System.Boolean get_IsQueryPropertyAttributeSupported()" body="stub" feature="Microsoft.Maui.RuntimeFeature.IsQueryPropertyAttributeSupported" value="true" featurevalue="true" />
+      <method signature="System.Boolean get_IsImplicitCastOperatorsUsageViaReflectionSupported()" body="stub" feature="Microsoft.Maui.RuntimeFeature.IsImplicitCastOperatorsUsageViaReflectionSupported" value="false" featurevalue="false" />
+      <method signature="System.Boolean get_IsImplicitCastOperatorsUsageViaReflectionSupported()" body="stub" feature="Microsoft.Maui.RuntimeFeature.IsImplicitCastOperatorsUsageViaReflectionSupported" value="true" featurevalue="true" />
     </type>
   </assembly>
 </linker>

--- a/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -140,3 +140,8 @@ virtual Microsoft.Maui.Handlers.SwipeItemMenuItemHandler.SourceLoader.get -> Mic
 ~override Microsoft.Maui.Platform.WrapperView.DrawShadow(Android.Graphics.Canvas canvas, int viewWidth, int viewHeight) -> void
 ~override Microsoft.Maui.Platform.WrapperView.GetClipPath(int width, int height) -> Android.Graphics.Path
 *REMOVED*override Microsoft.Maui.Animations.PlatformTicker.SystemEnabled.get -> bool
+Microsoft.Maui.Hosting.TypeConversionAppBuilderExtensions
+static Microsoft.Maui.Hosting.TypeConversionAppBuilderExtensions.ConfigureTypeConversions(this Microsoft.Maui.Hosting.MauiAppBuilder! builder, System.Action<Microsoft.Maui.Hosting.ITypeConversionBuilder!>! configureDelegate) -> Microsoft.Maui.Hosting.MauiAppBuilder!
+Microsoft.Maui.Hosting.ITypeConversionBuilder
+Microsoft.Maui.Hosting.ITypeConversionBuilder.AddTypeConverter<T, TConverter>() -> Microsoft.Maui.Hosting.ITypeConversionBuilder!
+Microsoft.Maui.Hosting.ITypeConversionBuilder.AddTypeConverter<T>(System.Func<System.ComponentModel.TypeConverter!>! createConverter) -> Microsoft.Maui.Hosting.ITypeConversionBuilder!

--- a/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -161,3 +161,8 @@ Microsoft.Maui.Platform.MauiView.IsMeasureValid(double widthConstraint, double h
 Microsoft.Maui.Platform.UIEdgeInsetsExtensions
 static Microsoft.Maui.Platform.UIEdgeInsetsExtensions.ToThickness(this UIKit.UIEdgeInsets insets) -> Microsoft.Maui.Thickness
 override Microsoft.Maui.Handlers.BorderHandler.PlatformArrange(Microsoft.Maui.Graphics.Rect rect) -> void
+Microsoft.Maui.Hosting.TypeConversionAppBuilderExtensions
+static Microsoft.Maui.Hosting.TypeConversionAppBuilderExtensions.ConfigureTypeConversions(this Microsoft.Maui.Hosting.MauiAppBuilder! builder, System.Action<Microsoft.Maui.Hosting.ITypeConversionBuilder!>! configureDelegate) -> Microsoft.Maui.Hosting.MauiAppBuilder!
+Microsoft.Maui.Hosting.ITypeConversionBuilder
+Microsoft.Maui.Hosting.ITypeConversionBuilder.AddTypeConverter<T, TConverter>() -> Microsoft.Maui.Hosting.ITypeConversionBuilder!
+Microsoft.Maui.Hosting.ITypeConversionBuilder.AddTypeConverter<T>(System.Func<System.ComponentModel.TypeConverter!>! createConverter) -> Microsoft.Maui.Hosting.ITypeConversionBuilder!

--- a/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -161,3 +161,8 @@ virtual Microsoft.Maui.MauiUIApplicationDelegate.PerformFetch(UIKit.UIApplicatio
 *REMOVED*override Microsoft.Maui.Platform.ContentView.SetNeedsLayout() -> void
 Microsoft.Maui.Platform.UIEdgeInsetsExtensions
 static Microsoft.Maui.Platform.UIEdgeInsetsExtensions.ToThickness(this UIKit.UIEdgeInsets insets) -> Microsoft.Maui.Thickness
+Microsoft.Maui.Hosting.TypeConversionAppBuilderExtensions
+static Microsoft.Maui.Hosting.TypeConversionAppBuilderExtensions.ConfigureTypeConversions(this Microsoft.Maui.Hosting.MauiAppBuilder! builder, System.Action<Microsoft.Maui.Hosting.ITypeConversionBuilder!>! configureDelegate) -> Microsoft.Maui.Hosting.MauiAppBuilder!
+Microsoft.Maui.Hosting.ITypeConversionBuilder
+Microsoft.Maui.Hosting.ITypeConversionBuilder.AddTypeConverter<T, TConverter>() -> Microsoft.Maui.Hosting.ITypeConversionBuilder!
+Microsoft.Maui.Hosting.ITypeConversionBuilder.AddTypeConverter<T>(System.Func<System.ComponentModel.TypeConverter!>! createConverter) -> Microsoft.Maui.Hosting.ITypeConversionBuilder!

--- a/src/Core/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -85,3 +85,8 @@ virtual Microsoft.Maui.Animations.Ticker.SystemEnabled.set -> void
 static Microsoft.Maui.Keyboard.Date.get -> Microsoft.Maui.Keyboard!
 static Microsoft.Maui.Keyboard.Password.get -> Microsoft.Maui.Keyboard!
 static Microsoft.Maui.Keyboard.Time.get -> Microsoft.Maui.Keyboard!
+Microsoft.Maui.Hosting.TypeConversionAppBuilderExtensions
+static Microsoft.Maui.Hosting.TypeConversionAppBuilderExtensions.ConfigureTypeConversions(this Microsoft.Maui.Hosting.MauiAppBuilder! builder, System.Action<Microsoft.Maui.Hosting.ITypeConversionBuilder!>! configureDelegate) -> Microsoft.Maui.Hosting.MauiAppBuilder!
+Microsoft.Maui.Hosting.ITypeConversionBuilder
+Microsoft.Maui.Hosting.ITypeConversionBuilder.AddTypeConverter<T, TConverter>() -> Microsoft.Maui.Hosting.ITypeConversionBuilder!
+Microsoft.Maui.Hosting.ITypeConversionBuilder.AddTypeConverter<T>(System.Func<System.ComponentModel.TypeConverter!>! createConverter) -> Microsoft.Maui.Hosting.ITypeConversionBuilder!

--- a/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -117,3 +117,8 @@ virtual Microsoft.Maui.Handlers.ButtonHandler.ImageSourceLoader.get -> Microsoft
 virtual Microsoft.Maui.Handlers.ImageButtonHandler.SourceLoader.get -> Microsoft.Maui.Platform.ImageSourcePartLoader!
 virtual Microsoft.Maui.Handlers.ImageHandler.SourceLoader.get -> Microsoft.Maui.Platform.ImageSourcePartLoader!
 virtual Microsoft.Maui.Handlers.SwipeItemMenuItemHandler.SourceLoader.get -> Microsoft.Maui.Platform.ImageSourcePartLoader!
+Microsoft.Maui.Hosting.TypeConversionAppBuilderExtensions
+static Microsoft.Maui.Hosting.TypeConversionAppBuilderExtensions.ConfigureTypeConversions(this Microsoft.Maui.Hosting.MauiAppBuilder! builder, System.Action<Microsoft.Maui.Hosting.ITypeConversionBuilder!>! configureDelegate) -> Microsoft.Maui.Hosting.MauiAppBuilder!
+Microsoft.Maui.Hosting.ITypeConversionBuilder
+Microsoft.Maui.Hosting.ITypeConversionBuilder.AddTypeConverter<T, TConverter>() -> Microsoft.Maui.Hosting.ITypeConversionBuilder!
+Microsoft.Maui.Hosting.ITypeConversionBuilder.AddTypeConverter<T>(System.Func<System.ComponentModel.TypeConverter!>! createConverter) -> Microsoft.Maui.Hosting.ITypeConversionBuilder!

--- a/src/Core/src/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -85,3 +85,8 @@ virtual Microsoft.Maui.Handlers.ButtonHandler.ImageSourceLoader.get -> Microsoft
 virtual Microsoft.Maui.Handlers.ImageButtonHandler.SourceLoader.get -> Microsoft.Maui.Platform.ImageSourcePartLoader!
 virtual Microsoft.Maui.Handlers.ImageHandler.SourceLoader.get -> Microsoft.Maui.Platform.ImageSourcePartLoader!
 virtual Microsoft.Maui.Handlers.SwipeItemMenuItemHandler.SourceLoader.get -> Microsoft.Maui.Platform.ImageSourcePartLoader!
+Microsoft.Maui.Hosting.TypeConversionAppBuilderExtensions
+static Microsoft.Maui.Hosting.TypeConversionAppBuilderExtensions.ConfigureTypeConversions(this Microsoft.Maui.Hosting.MauiAppBuilder! builder, System.Action<Microsoft.Maui.Hosting.ITypeConversionBuilder!>! configureDelegate) -> Microsoft.Maui.Hosting.MauiAppBuilder!
+Microsoft.Maui.Hosting.ITypeConversionBuilder
+Microsoft.Maui.Hosting.ITypeConversionBuilder.AddTypeConverter<T, TConverter>() -> Microsoft.Maui.Hosting.ITypeConversionBuilder!
+Microsoft.Maui.Hosting.ITypeConversionBuilder.AddTypeConverter<T>(System.Func<System.ComponentModel.TypeConverter!>! createConverter) -> Microsoft.Maui.Hosting.ITypeConversionBuilder!

--- a/src/Core/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -85,3 +85,8 @@ virtual Microsoft.Maui.Handlers.ImageButtonHandler.SourceLoader.get -> Microsoft
 virtual Microsoft.Maui.Handlers.ImageHandler.SourceLoader.get -> Microsoft.Maui.Platform.ImageSourcePartLoader!
 *REMOVED*Microsoft.Maui.Handlers.SwipeItemMenuItemHandler.SourceLoader.get -> Microsoft.Maui.Platform.ImageSourcePartLoader!
 virtual Microsoft.Maui.Handlers.SwipeItemMenuItemHandler.SourceLoader.get -> Microsoft.Maui.Platform.ImageSourcePartLoader!
+Microsoft.Maui.Hosting.TypeConversionAppBuilderExtensions
+static Microsoft.Maui.Hosting.TypeConversionAppBuilderExtensions.ConfigureTypeConversions(this Microsoft.Maui.Hosting.MauiAppBuilder! builder, System.Action<Microsoft.Maui.Hosting.ITypeConversionBuilder!>! configureDelegate) -> Microsoft.Maui.Hosting.MauiAppBuilder!
+Microsoft.Maui.Hosting.ITypeConversionBuilder
+Microsoft.Maui.Hosting.ITypeConversionBuilder.AddTypeConverter<T, TConverter>() -> Microsoft.Maui.Hosting.ITypeConversionBuilder!
+Microsoft.Maui.Hosting.ITypeConversionBuilder.AddTypeConverter<T>(System.Func<System.ComponentModel.TypeConverter!>! createConverter) -> Microsoft.Maui.Hosting.ITypeConversionBuilder!

--- a/src/Core/src/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -85,3 +85,8 @@ virtual Microsoft.Maui.Handlers.ImageButtonHandler.SourceLoader.get -> Microsoft
 virtual Microsoft.Maui.Handlers.ImageHandler.SourceLoader.get -> Microsoft.Maui.Platform.ImageSourcePartLoader!
 *REMOVED*Microsoft.Maui.Handlers.SwipeItemMenuItemHandler.SourceLoader.get -> Microsoft.Maui.Platform.ImageSourcePartLoader!
 virtual Microsoft.Maui.Handlers.SwipeItemMenuItemHandler.SourceLoader.get -> Microsoft.Maui.Platform.ImageSourcePartLoader!
+Microsoft.Maui.Hosting.TypeConversionAppBuilderExtensions
+static Microsoft.Maui.Hosting.TypeConversionAppBuilderExtensions.ConfigureTypeConversions(this Microsoft.Maui.Hosting.MauiAppBuilder! builder, System.Action<Microsoft.Maui.Hosting.ITypeConversionBuilder!>! configureDelegate) -> Microsoft.Maui.Hosting.MauiAppBuilder!
+Microsoft.Maui.Hosting.ITypeConversionBuilder
+Microsoft.Maui.Hosting.ITypeConversionBuilder.AddTypeConverter<T, TConverter>() -> Microsoft.Maui.Hosting.ITypeConversionBuilder!
+Microsoft.Maui.Hosting.ITypeConversionBuilder.AddTypeConverter<T>(System.Func<System.ComponentModel.TypeConverter!>! createConverter) -> Microsoft.Maui.Hosting.ITypeConversionBuilder!

--- a/src/Core/src/RuntimeFeature.cs
+++ b/src/Core/src/RuntimeFeature.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Maui
 		private const bool IsIVisualAssemblyScanningEnabledByDefault = false;
 		private const bool IsShellSearchResultsRendererDisplayMemberNameSupportedByDefault = true;
 		private const bool IsQueryPropertyAttributeSupportedByDefault = true;
+		private const bool IsImplicitCastOperatorsUsageViaReflectionSupportedByDefault = true;
 
 		internal static bool IsXamlRuntimeParsingSupported
 			=> AppContext.TryGetSwitch("Microsoft.Maui.RuntimeFeature.IsXamlRuntimeParsingSupported", out bool isSupported)
@@ -43,5 +44,10 @@ namespace Microsoft.Maui
 			AppContext.TryGetSwitch("Microsoft.Maui.RuntimeFeature.IsQueryPropertyAttributeSupported", out bool isSupported)
 				? isSupported
 				: IsQueryPropertyAttributeSupportedByDefault;
+
+		internal static bool IsImplicitCastOperatorsUsageViaReflectionSupported =>
+			AppContext.TryGetSwitch("Microsoft.Maui.RuntimeFeature.IsImplicitCastOperatorsUsageViaReflectionSupported", out bool isSupported)
+				? isSupported
+				: IsImplicitCastOperatorsUsageViaReflectionSupportedByDefault;
 	}
 }

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/BuildWarningsUtilities.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/BuildWarningsUtilities.cs
@@ -121,25 +121,7 @@ namespace Microsoft.Maui.IntegrationTests
 		#region Expected warning messages
 
 		// IMPORTANT: Always store expected File information as a relative path to the repo ROOT
-		private static readonly List<WarningsPerFile> expectedNativeAOTWarnings = new()
-		{
-			new WarningsPerFile
-			{
-				File = "src/Controls/src/Core/Xaml/TypeConversionExtensions.cs",
-				WarningsPerCode = new List<WarningsPerCode>
-				{
-					new WarningsPerCode
-					{
-						Code = "IL2070",
-						Messages = new List<string>
-						{
-							"Microsoft.Maui.Controls.Xaml.TypeConversionExtensions.GetImplicitConversionOperator(Type,Type,Type): 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicMethods' in call to 'System.Type.GetMethod(String,BindingFlags,Binder,Type[],ParameterModifier[])'. The parameter '#0' of method 'Microsoft.Maui.Controls.Xaml.TypeConversionExtensions.GetImplicitConversionOperator(Type,Type,Type)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.",
-							"Microsoft.Maui.Controls.Xaml.TypeConversionExtensions.GetImplicitConversionOperator(Type,Type,Type): 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicMethods' in call to 'System.Type.GetMethods(BindingFlags)'. The parameter '#0' of method 'Microsoft.Maui.Controls.Xaml.TypeConversionExtensions.GetImplicitConversionOperator(Type,Type,Type)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.",
-						}
-					},
-				}
-			},
-		};
+		private static readonly List<WarningsPerFile> expectedNativeAOTWarnings = new();
 
 		#region Utility methods for generating the list of expected warnings
 


### PR DESCRIPTION
### Description of Change

This is a first of two PRs that introduce the possibility to define type conversions using TypeConverters instead of relying on finding and invoking `op_Implicit` at runtime via reflection. The main reason for this change is that the way we're working with implicit operators is not trimming-compatible.

This PR introduces the internal `TypeConversionHelper` that contains all the updated conversion logic. The second PR will add type converters for all types that have implicit operators in MAUI.

#### Will this break any existing app?

No. This is an opt-in feature. Either the app is trying to run the app with NativeAOT and this feature is necessary for the app to work, or they manually opted into the feature by setting the feature switch to `false` (see `FeatureSwitches.md`).

#### What if a library or an app doesn't introduce type converters?

When MAUI tries to convert a value and there isn't a suitable type converter, it will try to look up the implicit operator and if it finds it, it will print a runtime warning. This is to give at least some feedback to the customer while making sure the app behaves the same way in Debug mode with Mono and in Release mode with NativeAOT.

I considered throwing an exception instead, but it seems common practice in MAUI to print warnings and fall back to some default value (for example if there's a binding where the path isn't compatible with the given binding context).

#### What if a library or an app needs to add a type converter for a third-party type?

There's an escape hatch in the form of the app builder extension method to globaly register a type converter for a type. See `FeatureSwitches.md`.

#### Why TypeConverter and not IValueConverter?

I chose TypeConverters over IValueConverters because they seem to be better suited for this use case. On the other hand, IValueConverters are easier to write. Feedback is welcome.

### Issues Fixed

Fixes #19922 
Fixes #5023 
Fixes #19397 - we hit 0 trimming warnings in `dotnet new maui` on iOS! 🎉 

/cc @jonathanpeppers @vitek-karas @StephaneDelcroix 