### PR TITLE
[Trimming] Use type converters instead of implicit cast operators (part 2/2)

### DIFF
--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue8647.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue8647.cs
@@ -64,11 +64,29 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 			}
 		}
 
+		[TypeConverter(typeof(ItemTypeConverter))]
 		class Item
 		{
 			public string Value { get; set; }
 
 			public static implicit operator Item(string value) => new Item { Value = value };
+
+			private sealed class ItemTypeConverter : TypeConverter
+			{
+				public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+					=> sourceType == typeof(string);
+				public override object ConvertFromInvariantString(string value)
+					=> new Item { Value = value };
+				public override object ConvertFrom(ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value)
+					=> value switch
+					{
+						string str => (Item)str,
+						_ => throw new NotSupportedException(),
+					};
+
+				public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType) => false;
+				public override object ConvertTo(ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value, Type destinationType) => throw new NotSupportedException();
+			}
 		}
 	}
 }

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue8647.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue8647.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.ComponentModel;
 using System.Collections.Generic;
 using Microsoft.Maui.Controls.CustomAttributes;
 using Microsoft.Maui.Controls.Internals;
@@ -65,26 +64,26 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 			}
 		}
 
-		[TypeConverter(typeof(ItemTypeConverter))]
+		[System.ComponentModel.TypeConverter(typeof(ItemTypeConverter))]
 		class Item
 		{
 			public string Value { get; set; }
 
 			public static implicit operator Item(string value) => new Item { Value = value };
 
-			private sealed class ItemTypeConverter : TypeConverter
+			private sealed class ItemTypeConverter : System.ComponentModel.TypeConverter
 			{
-				public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+				public override bool CanConvertFrom(System.ComponentModel.ITypeDescriptorContext context, Type sourceType)
 					=> sourceType == typeof(string);
-				public override object ConvertFrom(ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value)
+				public override object ConvertFrom(System.ComponentModel.ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value)
 					=> value switch
 					{
 						string str => (Item)str,
 						_ => throw new NotSupportedException(),
 					};
 
-				public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType) => false;
-				public override object ConvertTo(ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value, Type destinationType) => throw new NotSupportedException();
+				public override bool CanConvertTo(System.ComponentModel.ITypeDescriptorContext context, Type destinationType) => false;
+				public override object ConvertTo(System.ComponentModel.ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value, Type destinationType) => throw new NotSupportedException();
 			}
 		}
 	}

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue8647.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue8647.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using System.Collections.Generic;
 using Microsoft.Maui.Controls.CustomAttributes;
 using Microsoft.Maui.Controls.Internals;
@@ -75,8 +76,6 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 			{
 				public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
 					=> sourceType == typeof(string);
-				public override object ConvertFromInvariantString(string value)
-					=> new Item { Value = value };
 				public override object ConvertFrom(ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value)
 					=> value switch
 					{

--- a/src/Compatibility/Core/src/Android/AppCompat/Platform.cs
+++ b/src/Compatibility/Core/src/Android/AppCompat/Platform.cs
@@ -16,6 +16,7 @@ using AView = Android.Views.View;
 namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 {
 	[Obsolete]
+	[TypeConverter(typeof(PlatformTypeConverter))]
 	public class Platform : BindableObject, IPlatformLayout, INavigation
 	{
 		readonly Context _context;
@@ -719,6 +720,20 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 		}
 
 		#endregion
+
+		private sealed class PlatformTypeConverter : TypeConverter
+		{
+			public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType) => destinationType == typeof(ViewGroup);
+			public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+				=> value switch
+				{
+					Platform platformValue when destinationType == typeof(ViewGroup) => (ViewGroup)platformValue,
+					_ => throw new NotSupportedException(),
+				};
+
+			public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType) => false;
+			public override object ConvertFrom(ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value) => throw new NotSupportedException();
+		}
 
 #pragma warning disable CS0618 // Type or member is obsolete
 		internal class DefaultRenderer : VisualElementRenderer<View>, ILayoutChanges

--- a/src/Compatibility/Core/src/Android/AppCompat/Platform.cs
+++ b/src/Compatibility/Core/src/Android/AppCompat/Platform.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using Android.Content;

--- a/src/Controls/src/Core/Brush/BrushTypeConverter.cs
+++ b/src/Controls/src/Core/Brush/BrushTypeConverter.cs
@@ -39,13 +39,13 @@ namespace Microsoft.Maui.Controls
 
 		public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
 		{
-			if (value is Color color)
+			if (value is Color colorValue)
 			{
-				return (Brush)color;
+				return (Brush)colorValue;
 			}
-			else if (value is Paint paint)
+			else if (value is Paint paintValue)
 			{
-				return (Brush)paint;
+				return (Brush)paintValue;
 			}
 
 			var strValue = value?.ToString();

--- a/src/Controls/src/Core/Brush/BrushTypeConverter.cs
+++ b/src/Controls/src/Core/Brush/BrushTypeConverter.cs
@@ -30,13 +30,24 @@ namespace Microsoft.Maui.Controls
 		readonly ColorTypeConverter _colorTypeConverter = new ColorTypeConverter();
 
 		public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
-			=> sourceType == typeof(string);
+			=> sourceType == typeof(string)
+				|| sourceType == typeof(Color)
+				|| sourceType == typeof(Paint);
 
 		public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
-			=> false;
+			=> destinationType == typeof(Paint);
 
 		public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
 		{
+			if (value is Color color)
+			{
+				return (Brush)color;
+			}
+			else if (value is Paint paint)
+			{
+				return (Brush)paint;
+			}
+
 			var strValue = value?.ToString();
 
 			if (strValue != null)
@@ -70,9 +81,15 @@ namespace Microsoft.Maui.Controls
 			return new SolidColorBrush(null);
 		}
 
-
 		public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
-			=> throw new NotSupportedException();
+		{
+			if (value is Brush brush && destinationType == typeof(Paint))
+			{
+				return (Paint)brush;
+			}
+
+			throw new NotSupportedException();
+		}
 
 		public class GradientBrushParser
 		{

--- a/src/Controls/src/Core/DoubleCollectionConverter.cs
+++ b/src/Controls/src/Core/DoubleCollectionConverter.cs
@@ -10,13 +10,24 @@ namespace Microsoft.Maui.Controls
 	public class DoubleCollectionConverter : TypeConverter
 	{
 		public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
-			=> sourceType == typeof(string);
+			=> sourceType == typeof(string)
+				|| sourceType == typeof(double[])
+				|| sourceType == typeof(float[]);
 
 		public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
 			=> destinationType == typeof(string);
 
 		public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
 		{
+			if (value is double[] doublesArray)
+			{
+				return (DoubleCollection)doublesArray;
+			}
+			else if (value is float[] floatsArray)
+			{
+				return (DoubleCollection)floatsArray;
+			}
+
 			var strValue = value?.ToString();
 
 			string[] doubles = strValue.Split(new char[] { ' ', ',' }, StringSplitOptions.RemoveEmptyEntries);

--- a/src/Controls/src/Core/FileImageSourceConverter.cs
+++ b/src/Controls/src/Core/FileImageSourceConverter.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Maui.Controls
 			=> sourceType == typeof(string);
 
 		public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
-			=> true;
+			=> destinationType == typeof(string);
 
 		public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
 		{

--- a/src/Controls/src/Core/FormattedString.cs
+++ b/src/Controls/src/Core/FormattedString.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/FormattedString.xml" path="Type[@FullName='Microsoft.Maui.Controls.FormattedString']/Docs/*" />
 	[ContentProperty("Spans")]
+	[TypeConverter(typeof(FormattedStringConverter))]
 	public class FormattedString : Element
 	{
 		readonly SpanCollection _spans = new SpanCollection();
@@ -85,6 +86,35 @@ namespace Microsoft.Maui.Controls
 				var removed = new List<Span>(this);
 				base.ClearItems();
 				base.OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, removed));
+			}
+		}
+
+		private sealed class FormattedStringConverter : TypeConverter
+		{
+			public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+				=> sourceType == typeof(string);
+
+			public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+				=> destinationType == typeof(string);
+
+			public override object ConvertFrom(ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value)
+			{
+				if (value is string strValue)
+				{
+					return (FormattedString)strValue;
+				}
+
+				throw new NotSupportedException();
+			}
+
+			public override object ConvertTo(ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value, Type destinationType)
+			{
+				if (value is FormattedString formattedStr)
+				{
+					return (string)formattedStr;
+				}
+
+				throw new NotSupportedException();
 			}
 		}
 	}

--- a/src/Controls/src/Core/ImageSourceConverter.cs
+++ b/src/Controls/src/Core/ImageSourceConverter.cs
@@ -11,13 +11,18 @@ namespace Microsoft.Maui.Controls
 	public sealed class ImageSourceConverter : TypeConverter
 	{
 		public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
-			=> sourceType == typeof(string);
+			=> sourceType == typeof(string) || sourceType == typeof(Uri);
 
 		public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
 			=> destinationType == typeof(string);
 
 		public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
 		{
+			if (value is Uri uriValue)
+			{
+				return (ImageSource)uriValue;
+			}
+
 			// IMPORTANT! Update ImageSourceDesignTypeConverter.IsValid if making changes here
 			var strValue = value?.ToString();
 			if (strValue != null)

--- a/src/Controls/src/Core/Shapes/PointCollectionConverter.cs
+++ b/src/Controls/src/Core/Shapes/PointCollectionConverter.cs
@@ -12,13 +12,18 @@ namespace Microsoft.Maui.Controls.Shapes
 	public class PointCollectionConverter : TypeConverter
 	{
 		public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
-			=> sourceType == typeof(string);
+			=> sourceType == typeof(string) || sourceType == typeof(Point[]);
 
 		public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
 			=> destinationType == typeof(string);
 
 		public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
 		{
+			if (value is Point[] pointArray)
+			{
+				return (PointCollection)pointArray;
+			}
+
 			var strValue = value?.ToString();
 			string[] points = strValue.Split(new char[] { ' ', ',' });
 			var pointCollection = new PointCollection();

--- a/src/Controls/src/Core/Shell/ShellContent.cs
+++ b/src/Controls/src/Core/Shell/ShellContent.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../../docs/Microsoft.Maui.Controls/ShellContent.xml" path="Type[@FullName='Microsoft.Maui.Controls.ShellContent']/Docs/*" />
 	[ContentProperty(nameof(Content))]
+	[TypeConverter(typeof(ShellContentConverter))]
 	public class ShellContent : BaseShellItem, IShellContentController, IVisualTreeElement
 	{
 		static readonly BindablePropertyKey MenuItemsPropertyKey =
@@ -363,6 +364,30 @@ namespace Microsoft.Maui.Controls
 				// parameters used during navigation
 				if (content is ContentPage)
 					query.ResetToQueryParameters();
+			}
+		}
+
+		private sealed class ShellContentConverter : TypeConverter
+		{
+			public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+				=> sourceType == typeof(TemplatedPage);
+
+			public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+				=> false;
+
+			public override object ConvertFrom(ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value)
+			{
+				if (value is TemplatedPage templatedPage)
+				{
+					return (ShellContent)templatedPage;
+				}
+
+				throw new NotSupportedException();
+			}
+
+			public override object ConvertTo(ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value, Type destinationType)
+			{
+				throw new NotSupportedException();
 			}
 		}
 	}

--- a/src/Controls/src/Core/Shell/ShellItem.cs
+++ b/src/Controls/src/Core/Shell/ShellItem.cs
@@ -50,6 +50,7 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../../docs/Microsoft.Maui.Controls/ShellItem.xml" path="Type[@FullName='Microsoft.Maui.Controls.ShellItem']/Docs/*" />
 	[ContentProperty(nameof(Items))]
 	[EditorBrowsable(EditorBrowsableState.Never)]
+	[TypeConverter(typeof(ShellItemConverter))]
 	public class ShellItem : ShellGroupItem, IShellItemController, IElementConfiguration<ShellItem>, IPropertyPropagationController, IVisualTreeElement
 	{
 		#region PropertyKeys
@@ -365,6 +366,31 @@ namespace Microsoft.Maui.Controls
 			base.OnParentSet();
 			if (this.IsVisibleItem && CurrentItem != null)
 				((IShellController)Parent)?.AppearanceChanged(CurrentItem, false);
+		}
+
+		private sealed class ShellItemConverter : TypeConverter
+		{
+			public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+				=> sourceType == typeof(ShellSection)
+					|| sourceType == typeof(ShellContent)
+					|| sourceType == typeof(TemplatedPage)
+					|| sourceType == typeof(MenuItem);
+			
+			public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+				=> false;
+
+			public override object ConvertFrom(ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value)
+				=> value switch
+				{
+					ShellSection shellSection => (ShellItem)shellSection,
+					ShellContent shellContent => (ShellItem)shellContent,
+					TemplatedPage page => (ShellItem)page,
+					MenuItem menuItem => (ShellItem)menuItem,
+					_ => throw new NotSupportedException(),
+				};
+
+			public override object ConvertTo(ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value, Type destinationType)
+				=> throw new NotSupportedException();
 		}
 	}
 }

--- a/src/Controls/src/Core/Shell/ShellNavigationState.cs
+++ b/src/Controls/src/Core/Shell/ShellNavigationState.cs
@@ -1,12 +1,15 @@
 #nullable disable
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
+using System.Globalization;
 using System.Diagnostics;
 
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../../docs/Microsoft.Maui.Controls/ShellNavigationState.xml" path="Type[@FullName='Microsoft.Maui.Controls.ShellNavigationState']/Docs/*" />
 	[DebuggerDisplay("Location = {Location}")]
+	[TypeConverter(typeof(ShellNavigationStateTypeConverter))]
 	public class ShellNavigationState
 	{
 		Uri _fullLocation;
@@ -96,6 +99,23 @@ namespace Microsoft.Maui.Controls
 			toKeep.Insert(0, "");
 			toKeep.Insert(0, "");
 			return new Uri(string.Join(Routing.PathSeparator, toKeep), UriKind.Relative);
+		}
+
+		private sealed class ShellNavigationStateTypeConverter : TypeConverter
+		{
+			public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType) => false;
+			public override object ConvertTo(ITypeDescriptorContext context, CultureInfo cultureInfo, object value, Type destinationType) => throw new NotSupportedException();
+
+			public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+				=> sourceType == typeof(string) || sourceType == typeof(Uri);
+
+			public override object ConvertFrom(ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value)
+				=> value switch
+				{
+					string str => (ShellNavigationState)str,
+					Uri uri => (ShellNavigationState)uri,
+					_ => throw new NotSupportedException(),
+				};
 		}
 	}
 }

--- a/src/Controls/src/Core/Shell/ShellSection.cs
+++ b/src/Controls/src/Core/Shell/ShellSection.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
+using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -20,6 +21,7 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../../docs/Microsoft.Maui.Controls/ShellSection.xml" path="Type[@FullName='Microsoft.Maui.Controls.ShellSection']/Docs/*" />
 	[ContentProperty(nameof(Items))]
 	[EditorBrowsable(EditorBrowsableState.Never)]
+	[TypeConverter(typeof(ShellSectionTypeConverter))]
 	public partial class ShellSection : ShellGroupItem, IShellSectionController, IPropertyPropagationController, IVisualTreeElement, IStackNavigation
 	{
 		#region PropertyKeys
@@ -1257,5 +1259,20 @@ namespace Microsoft.Maui.Controls
 		}
 #nullable disable
 
+		private sealed class ShellSectionTypeConverter : TypeConverter
+		{
+			public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType) => false;
+			public override object ConvertTo(ITypeDescriptorContext context, CultureInfo cultureInfo, object value, Type destinationType) => throw new NotSupportedException();
+
+			public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+				=> sourceType == typeof(ShellContent) || sourceType == typeof(TemplatedPage);
+			public override object ConvertFrom(ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value)
+				=> value switch
+				{
+					ShellContent shellContent => (ShellSection)shellContent,
+					TemplatedPage page => (ShellSection)page,
+					_ => throw new NotSupportedException(),
+				};
+		}
 	}
 }

--- a/src/Controls/src/Core/WebView/WebViewSource.cs
+++ b/src/Controls/src/Core/WebView/WebViewSource.cs
@@ -1,10 +1,12 @@
 #nullable disable
 using System;
 using System.ComponentModel;
+using System.Globalization;
 
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/WebViewSource.xml" path="Type[@FullName='Microsoft.Maui.Controls.WebViewSource']/Docs/*" />
+	[TypeConverter(typeof(WebViewSourceTypeConverter))]
 	public abstract class WebViewSource : BindableObject, IWebViewSource
 	{
 		public static implicit operator WebViewSource(Uri url)
@@ -29,5 +31,22 @@ namespace Microsoft.Maui.Controls
 		public abstract void Load(IWebViewDelegate renderer);
 
 		internal event EventHandler SourceChanged;
+
+		private sealed class WebViewSourceTypeConverter : TypeConverter
+		{
+			public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType) => false;
+			public override object ConvertTo(ITypeDescriptorContext context, CultureInfo cultureInfo, object value, Type destinationType) => throw new NotSupportedException();
+
+			public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+				=> sourceType == typeof(string) || sourceType == typeof(Uri);
+
+			public override object ConvertFrom(ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value)
+				=> value switch
+				{
+					string str => (UrlWebViewSource)str,
+					Uri uri => (UrlWebViewSource)uri,
+					_ => throw new NotSupportedException(),
+				};
+		}
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/BindableObjectUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/BindableObjectUnitTests.cs
@@ -1407,6 +1407,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.NotEqual(-42, bindable.GetValue(prop));
 		}
 
+		[TypeConverter(typeof(CastFromStringTypeConverter))]
 		class CastFromString
 		{
 			public string Result { get; private set; }
@@ -1415,6 +1416,22 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 				var o = new CastFromString();
 				o.Result = source;
 				return o;
+			}
+
+			private sealed class CastFromStringTypeConverter : TypeConverter
+			{
+				public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+					=> sourceType == typeof(string);
+
+				public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+					=> value switch
+					{
+						string s => (CastFromString)s,
+						_ => throw new NotSupportedException(),
+					};
+
+				public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType) => false;
+				public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType) => throw new NotSupportedException();
 			}
 		}
 
@@ -1430,6 +1447,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.Equal("foo", ((CastFromString)bindable.GetValue(prop)).Result);
 		}
 
+		[TypeConverter(typeof(CastToStringTypeConverter))]
 		class CastToString
 		{
 			string Result { get; set; }
@@ -1447,6 +1465,21 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			public override string ToString()
 			{
 				throw new InvalidOperationException();
+			}
+
+			private sealed class CastToStringTypeConverter : TypeConverter
+			{
+				public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType) => false;
+				public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value) => throw new NotSupportedException();
+
+				public override bool CanConvertTo(ITypeDescriptorContext context, Type sourceType)
+					=> sourceType == typeof(CastToString);
+				public override object ConvertTo(ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value, Type destinationType)
+					=> value switch
+					{
+						CastToString cts when destinationType == typeof(string) => (string)cts,
+						_ => throw new NotSupportedException(),
+					};
 			}
 		}
 

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Bz45299.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Bz45299.xaml.cs
@@ -69,16 +69,44 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 
 	public class Bz45299UILengthTypeConverter : TypeConverter
 	{
-		static readonly Type StringType = typeof(string);
 		public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+			=> sourceType == typeof(string)
+				|| sourceType == typeof(long)
+				|| sourceType == typeof(ulong)
+				|| sourceType == typeof(int)
+				|| sourceType == typeof(uint)
+				|| sourceType == typeof(double)
+				|| sourceType == typeof(float);
+
+		public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+			=> value switch
+			{
+				string str => (Bz45299UILength)str,
+				long l => (Bz45299UILength)l,
+				ulong ul => (Bz45299UILength)ul,
+				int i => (Bz45299UILength)i,
+				uint ui => (Bz45299UILength)ui,
+				double d => (Bz45299UILength)d,
+				float f => (Bz45299UILength)f,
+				_ => throw new NotSupportedException(),
+			};
+
+		public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+			=> destinationType == typeof(string)
+				|| destinationType == typeof(double);
+
+		public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
 		{
-			if (sourceType != StringType)
-				return false;
+			if (value is Bz45299UILength uiLength)
+			{
+				if (destinationType == typeof(string))
+					return (string)uiLength;
+				if (destinationType == typeof(double))
+					return (double)uiLength;
+			}
 
-			return true;
+			throw new NotSupportedException();
 		}
-
-		public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value) => Bz45299UILength.Zero;
 	}
 
 	[System.ComponentModel.TypeConverter(typeof(Bz45299UISizeTypeConverter))]
@@ -96,17 +124,31 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 
 	public class Bz45299UISizeTypeConverter : TypeConverter
 	{
-		private static readonly Type StringType = typeof(string);
-
 		public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+			=> sourceType == typeof(string)
+				|| sourceType == typeof(Size);
+
+		public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+			=> value switch
+			{
+				string str => (Bz45299UISize)str,
+				Size size => (Bz45299UISize)size,
+				_ => throw new NotSupportedException(),
+			};
+
+		public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+			=> destinationType == typeof(Size);
+
+		public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
 		{
-			if (sourceType != StringType)
-				return false;
+			if (value is Bz45299UISize uiSize)
+			{
+				if (destinationType == typeof(Size))
+					return (Size)uiSize;
+			}
 
-			return true;
+			throw new NotSupportedException();
 		}
-
-		public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value) => Bz45299UISize.Zero;
 	}
 
 	public partial class Bz45299 : ContentPage

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Gh1346.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Gh1346.xaml.cs
@@ -1,4 +1,6 @@
 using System;
+using System.ComponentModel;
+using System.Globalization;
 using Microsoft.Maui.Controls.Core.UnitTests;
 using Microsoft.Maui.Graphics;
 using NUnit.Framework;
@@ -51,6 +53,7 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		string Icon { get; }
 	}
 
+	[TypeConverter(typeof(Gh1346FontAwesomeTypeConverter))]
 	public sealed class Gh1346FontAwesome : IGh1346FontIcon
 	{
 		public string Icon { get; }
@@ -71,6 +74,21 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		}
 
 		public static readonly Gh1346FontAwesome SnowflakeO = new Gh1346FontAwesome('\uf2dc');
+
+		private sealed class Gh1346FontAwesomeTypeConverter : TypeConverter
+		{
+			public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType) => false;
+			public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value) => throw new NotSupportedException();
+
+			public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+				=> destinationType == typeof(Gh1346FontIconOptions);		
+			public override object ConvertTo(ITypeDescriptorContext context, CultureInfo cultureInfo, object value, Type destinationType)
+				=> value switch
+				{
+					Gh1346FontAwesome f => (Gh1346FontIconOptions)f,
+					_ => throw new NotSupportedException(),
+				};
+		}
 	}
 
 	public sealed class Gh1346FontIconOptions

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Gh4215.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Gh4215.xaml.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
+using System.Globalization;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Core.UnitTests;
 using Microsoft.Maui.Graphics;
@@ -7,12 +9,37 @@ using NUnit.Framework;
 
 namespace Microsoft.Maui.Controls.Xaml.UnitTests
 {
+	[TypeConverter(typeof(Gh4215VMTypeConverter))]
 	public class Gh4215VM
 	{
 		public static implicit operator DateTime(Gh4215VM value) => DateTime.UtcNow;
 		public static implicit operator string(Gh4215VM value) => "foo";
 		public static implicit operator long(Gh4215VM value) => long.MaxValue;
 		public static implicit operator Rect(Gh4215VM value) => new Rect();
+
+		private sealed class Gh4215VMTypeConverter : TypeConverter
+		{
+			public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+				=> destinationType == typeof(DateTime) || destinationType == typeof(string) || destinationType == typeof(long) || destinationType == typeof(Rect);
+			public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+			{
+				if (value is Gh4215VM vm)
+				{
+					if (destinationType == typeof(DateTime))
+						return (DateTime)vm;
+					if (destinationType == typeof(string))
+						return (string)vm;
+					if (destinationType == typeof(long))
+						return (long)vm;
+					if (destinationType == typeof(Rect))
+						return (Rect)vm;
+				}
+
+				throw new NotSupportedException();
+			}
+			public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType) => false;
+			public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value) => throw new NotSupportedException();
+		}
 	}
 
 	public partial class Gh4215 : ContentPage

--- a/src/Controls/tests/Xaml.UnitTests/SetValue.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/SetValue.xaml.cs
@@ -1,4 +1,6 @@
 using System;
+using System.ComponentModel;
+using System.Globalization;
 using System.Linq;
 using Microsoft.Maui.Controls.Core.UnitTests;
 using Microsoft.Maui.Dispatching;
@@ -11,11 +13,27 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 {
 	using AbsoluteLayout = Microsoft.Maui.Controls.Compatibility.AbsoluteLayout;
 
+	[TypeConverter(typeof(ConvertibleToViewTypeConverter))]
 	public class ConvertibleToView
 	{
 		public static implicit operator View(ConvertibleToView source)
 		{
 			return new Button();
+		}
+
+		internal sealed class ConvertibleToViewTypeConverter : TypeConverter
+		{
+			public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+				=> destinationType == typeof(View);
+			public override object ConvertTo(ITypeDescriptorContext context, CultureInfo cultureInfo, object value, Type destinationType)
+				=> value switch
+				{
+					ConvertibleToView convertibleValue when destinationType == typeof(View) => (View)convertibleValue,
+					_ => throw new NotSupportedException(),
+				};
+
+			public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType) => false;
+			public override object ConvertFrom(ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value) => throw new NotSupportedException();
 		}
 	}
 
@@ -49,6 +67,7 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		}
 	}
 
+	[TypeConverter(typeof(SV_FooTypeConveter))]
 	public class SV_Foo
 	{
 		public string Value { get; set; }
@@ -60,6 +79,33 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		public static implicit operator string(SV_Foo foo)
 		{
 			return foo.Value;
+		}
+
+		internal sealed class SV_FooTypeConveter : TypeConverter
+		{
+			public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+				=> destinationType == typeof(string);
+			public override object ConvertTo(ITypeDescriptorContext context, CultureInfo cultureInfo, object value, Type destinationType)
+			{
+				if (value is SV_Foo foo)
+				{
+					if (destinationType == typeof(string))
+					{
+						return (string)foo;
+					}
+				}
+
+				throw new NotSupportedException();
+			}
+
+			public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+				=> sourceType == typeof(string);
+			public override object ConvertFrom(ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value)
+				=> value switch
+				{
+					string str => (SV_Foo)str,
+					_ => throw new NotSupportedException(),
+				};
 		}
 	}
 

--- a/src/Core/src/Converters/CornerRadiusTypeConverter.cs
+++ b/src/Core/src/Converters/CornerRadiusTypeConverter.cs
@@ -8,13 +8,18 @@ namespace Microsoft.Maui.Converters
 	public class CornerRadiusTypeConverter : TypeConverter
 	{
 		public override bool CanConvertFrom(ITypeDescriptorContext? context, Type sourceType)
-			=> sourceType == typeof(string);
+			=> sourceType == typeof(string) || PrimitiveTypeConversions.IsImplicitlyConvertibleToDouble(sourceType);
 
 		public override bool CanConvertTo(ITypeDescriptorContext? context, Type? destinationType)
 			=> destinationType == typeof(string);
 
 		public override object ConvertFrom(ITypeDescriptorContext? context, CultureInfo? culture, object? value)
 		{
+			if (PrimitiveTypeConversions.TryGetDouble(value, out double d))
+			{
+				return (CornerRadius)d;
+			}
+
 			// IMPORTANT! Update CornerRadiusDesignTypeConverter.IsValid if making changes here
 			var strValue = value?.ToString();
 

--- a/src/Core/src/Converters/EasingTypeConverter.cs
+++ b/src/Core/src/Converters/EasingTypeConverter.cs
@@ -13,13 +13,18 @@ namespace Microsoft.Maui.Converters
 	public class EasingTypeConverter : TypeConverter
 	{
 		public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
-			=> sourceType == typeof(string);
+			=> sourceType == typeof(string) || sourceType == typeof(Func<double, double>);
 
 		public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
 			=> destinationType == typeof(string);
 
 		public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
 		{
+			if (value is Func<double, double> fn)
+			{
+				return (Easing)fn;
+			}
+
 			var strValue = value?.ToString();
 
 			if (string.IsNullOrWhiteSpace(strValue))

--- a/src/Core/src/Converters/FlexEnumsConverters.cs
+++ b/src/Core/src/Converters/FlexEnumsConverters.cs
@@ -226,13 +226,18 @@ namespace Microsoft.Maui.Converters
 	public class FlexBasisTypeConverter : TypeConverter
 	{
 		public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
-			=> sourceType == typeof(string);
+			=> sourceType == typeof(string) || sourceType == typeof(float);
 
 		public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
-			=> true;
+			=> destinationType == typeof(string);
 
 		public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
 		{
+			if (value is float floatValue)
+			{
+				return (FlexBasis)floatValue;
+			}
+
 			var strValue = value?.ToString();
 
 			if (strValue != null)

--- a/src/Core/src/Converters/PrimitiveTypeConversions.cs
+++ b/src/Core/src/Converters/PrimitiveTypeConversions.cs
@@ -1,0 +1,35 @@
+#nullable enable
+
+using System;
+using System.Globalization;
+
+namespace Microsoft.Maui
+{
+	internal static class PrimitiveTypeConversions
+	{
+		internal static bool IsImplicitlyConvertibleToDouble(Type type)
+			=> type == typeof(double)
+				|| type == typeof(float)
+				|| type == typeof(int)
+				|| type == typeof(uint)
+				|| type == typeof(long)
+				|| type == typeof(ulong)
+				|| type == typeof(short)
+				|| type == typeof(ushort)
+				|| type == typeof(byte)
+				|| type == typeof(sbyte)
+				|| type == typeof(char);
+
+		internal static bool TryGetDouble(object? value, out double result)
+		{
+			if (value is not null && IsImplicitlyConvertibleToDouble(value.GetType()))
+			{
+				result = Convert.ToDouble(value, CultureInfo.InvariantCulture);
+				return true;
+			}
+
+			result = 0;
+			return false;
+		}
+	}
+}

--- a/src/Core/src/Converters/ThicknessTypeConverter.cs
+++ b/src/Core/src/Converters/ThicknessTypeConverter.cs
@@ -1,6 +1,7 @@
 using System;
 using System.ComponentModel;
 using System.Globalization;
+using Microsoft.Maui.Graphics;
 
 #nullable disable
 
@@ -10,13 +11,24 @@ namespace Microsoft.Maui.Converters
 	public class ThicknessTypeConverter : TypeConverter
 	{
 		public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
-			=> sourceType == typeof(string);
+			=> sourceType == typeof(string)
+				|| sourceType == typeof(Size)
+				|| PrimitiveTypeConversions.IsImplicitlyConvertibleToDouble(sourceType);
 
 		public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
 			=> destinationType == typeof(string);
 
 		public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
 		{
+			if (PrimitiveTypeConversions.TryGetDouble(value, out double d))
+			{
+				return (Thickness)d;
+			}
+			else if (value is Size s)
+			{
+				return (Thickness)s;
+			}
+
 			// IMPORTANT! Update ThicknessTypeDesignConverter.IsValid if making changes here
 			var strValue = value?.ToString();
 

--- a/src/Core/src/Primitives/GridLength.cs
+++ b/src/Core/src/Primitives/GridLength.cs
@@ -1,11 +1,14 @@
 #nullable enable
 using System;
+using System.ComponentModel;
 using System.Diagnostics;
+using System.Globalization;
 
 namespace Microsoft.Maui
 {
 	/// <include file="../../docs/Microsoft.Maui/GridLength.xml" path="Type[@FullName='Microsoft.Maui.GridLength']/Docs/*" />
 	[DebuggerDisplay("{Value}.{GridUnitType}")]
+	[TypeConverter(typeof(GridLengthTypeConverter))]
 	public readonly struct GridLength
 	{
 		/// <include file="../../docs/Microsoft.Maui/GridLength.xml" path="//Member[@MemberName='Auto']/Docs/*" />
@@ -86,5 +89,21 @@ namespace Microsoft.Maui
 		public static bool operator ==(GridLength left, GridLength right) => left.Equals(right);
 
 		public static bool operator !=(GridLength left, GridLength right) => !(left == right);
+
+		private sealed class GridLengthTypeConverter : TypeConverter
+		{
+			public override bool CanConvertFrom(ITypeDescriptorContext? context, Type? sourceType)
+				=> sourceType == typeof(double);
+
+			public override object ConvertFrom(ITypeDescriptorContext? context, CultureInfo? culture, object? value)
+				=> value switch
+				{
+					double d => (GridLength)d,
+					_ => throw new NotSupportedException(),
+				};
+
+			public override bool CanConvertTo(ITypeDescriptorContext? context, Type? destinationType) => false;
+			public override object ConvertTo(ITypeDescriptorContext? context, CultureInfo? culture, object? value, Type? destinationType) => throw new NotSupportedException();
+		}
 	}
 }

--- a/src/Core/src/Primitives/SizeRequest.cs
+++ b/src/Core/src/Primitives/SizeRequest.cs
@@ -1,11 +1,14 @@
 using System;
+using System.ComponentModel;
 using System.Diagnostics;
+using System.Globalization;
 using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui
 {
 	/// <include file="../../docs/Microsoft.Maui/SizeRequest.xml" path="Type[@FullName='Microsoft.Maui.SizeRequest']/Docs/*" />
 	[DebuggerDisplay("Request={Request.Width}x{Request.Height}, Minimum={Minimum.Width}x{Minimum.Height}")]
+	[TypeConverter(typeof(SizeRequestTypeConverter))]
 	public struct SizeRequest : IEquatable<SizeRequest>
 	{
 		/// <include file="../../docs/Microsoft.Maui/SizeRequest.xml" path="//Member[@MemberName='Request']/Docs/*" />
@@ -47,5 +50,30 @@ namespace Microsoft.Maui
 		public static bool operator ==(SizeRequest left, SizeRequest right) => left.Equals(right);
 
 		public static bool operator !=(SizeRequest left, SizeRequest right) => !(left == right);
+
+		private sealed class SizeRequestTypeConverter : TypeConverter
+		{
+			public override bool CanConvertFrom(ITypeDescriptorContext? context, Type? sourceType)
+				=> sourceType == typeof(Size);
+			public override object ConvertFrom(ITypeDescriptorContext? context, CultureInfo? culture, object? value)
+				=> value switch
+				{
+					Size size => (SizeRequest)size,
+					_ => throw new NotSupportedException(),
+				};
+
+			public override bool CanConvertTo(ITypeDescriptorContext? context, Type? destinationType)
+				=> destinationType == typeof(Size);
+			public override object ConvertTo(ITypeDescriptorContext? context, CultureInfo? culture, object? value, Type? destinationType)
+			{
+				if (value is SizeRequest sizeRequest)
+				{
+					if (destinationType == typeof(Size))
+						return (Size)sizeRequest;
+				}
+
+				throw new NotSupportedException();
+			}
+		}
 	}
 }

--- a/src/Graphics/src/Graphics/Converters/ColorTypeConverter.cs
+++ b/src/Graphics/src/Graphics/Converters/ColorTypeConverter.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel;
 using System.Globalization;
 using System.Linq;
+using System.Numerics;
 
 namespace Microsoft.Maui.Graphics.Converters
 {
@@ -9,6 +10,11 @@ namespace Microsoft.Maui.Graphics.Converters
 	{
 		public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object fromValue)
 		{
+			if (fromValue is Vector4 vec)
+			{
+				return (Color)vec;
+			}
+
 			return Color.Parse(fromValue?.ToString());
 		}
 
@@ -180,7 +186,7 @@ namespace Microsoft.Maui.Graphics.Converters
 			=> true;
 
 		public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
-			=> sourceType == typeof(string);
+			=> sourceType == typeof(string) || sourceType == typeof(Vector4);
 
 		public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
 			=> destinationType == typeof(string);

--- a/src/Graphics/src/Graphics/Converters/PointFTypeConverter.cs
+++ b/src/Graphics/src/Graphics/Converters/PointFTypeConverter.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.ComponentModel;
 using System.Globalization;
+using System.Numerics;
 using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Graphics.Converters
@@ -8,13 +9,25 @@ namespace Microsoft.Maui.Graphics.Converters
 	public class PointFTypeConverter : TypeConverter
 	{
 		public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
-			=> sourceType == typeof(string);
+			=> sourceType == typeof(string) || sourceType == typeof(Vector2);
 
 		public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
-			=> destinationType == typeof(string);
+			=> destinationType == typeof(string)
+				|| destinationType == typeof(PointF)
+#if ANDROID
+				|| destinationType == typeof(global::Android.Graphics.Point)
+				|| destinationType == typeof(global::Android.Graphics.PointF)
+#elif IOS || MACCATALYST
+				|| destinationType == typeof(CoreGraphics.CGSize)
+				|| destinationType == typeof(CoreGraphics.CGPoint)
+#endif
+				;
 
 		public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
 		{
+			if (value is Vector2 vec)
+				return (PointF)vec;
+
 			if (PointF.TryParse(value?.ToString(), out var p))
 				return p;
 
@@ -25,6 +38,21 @@ namespace Microsoft.Maui.Graphics.Converters
 		{
 			if (!(value is PointF p))
 				throw new NotSupportedException();
+
+			if (destinationType == typeof(PointF))
+				return (PointF)p;
+#if ANDROID
+			if (destinationType == typeof(global::Android.Graphics.Point))
+				return (global::Android.Graphics.Point)p;
+			if (destinationType == typeof(global::Android.Graphics.PointF))
+				return (global::Android.Graphics.PointF)p;
+#elif IOS || MACCATALYST
+			if (destinationType == typeof(CoreGraphics.CGSize))
+				return (CoreGraphics.CGSize)p;
+			if (destinationType == typeof(CoreGraphics.CGPoint))
+				return (CoreGraphics.CGPoint)p;
+#endif
+
 			return $"{p.X.ToString(CultureInfo.InvariantCulture)}, {p.Y.ToString(CultureInfo.InvariantCulture)}";
 		}
 	}

--- a/src/Graphics/src/Graphics/Converters/PointTypeConverter.cs
+++ b/src/Graphics/src/Graphics/Converters/PointTypeConverter.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.ComponentModel;
 using System.Globalization;
+using System.Numerics;
 using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Graphics.Converters
@@ -8,13 +9,25 @@ namespace Microsoft.Maui.Graphics.Converters
 	public class PointTypeConverter : TypeConverter
 	{
 		public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
-			=> sourceType == typeof(string);
+			=> sourceType == typeof(string) || sourceType == typeof(Vector2);
 
 		public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
-			=> destinationType == typeof(string);
+			=> destinationType == typeof(string)
+				|| destinationType == typeof(PointF)
+#if ANDROID
+				|| destinationType == typeof(global::Android.Graphics.Point)
+				|| destinationType == typeof(global::Android.Graphics.PointF)
+#elif IOS || MACCATALYST
+				|| destinationType == typeof(CoreGraphics.CGSize)
+				|| destinationType == typeof(CoreGraphics.CGPoint)
+#endif
+				;
 
 		public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
 		{
+			if (value is Vector2 vec)
+				return (Point)vec;
+
 			if (Point.TryParse(value?.ToString(), out var p))
 				return p;
 
@@ -25,6 +38,20 @@ namespace Microsoft.Maui.Graphics.Converters
 		{
 			if (!(value is Point p))
 				throw new NotSupportedException();
+
+			if (destinationType == typeof(PointF))
+				return (PointF)p;
+#if ANDROID
+			if (destinationType == typeof(global::Android.Graphics.Point))
+				return (global::Android.Graphics.Point)p;
+			if (destinationType == typeof(global::Android.Graphics.PointF))
+				return (global::Android.Graphics.PointF)p;
+#elif IOS || MACCATALYST
+			if (destinationType == typeof(CoreGraphics.CGSize))
+				return (CoreGraphics.CGSize)p;
+			if (destinationType == typeof(CoreGraphics.CGPoint))
+				return (CoreGraphics.CGPoint)p;
+#endif
 			return $"{p.X.ToString(CultureInfo.InvariantCulture)}, {p.Y.ToString(CultureInfo.InvariantCulture)}";
 		}
 	}

--- a/src/Graphics/src/Graphics/Converters/RectFTypeConverter.cs
+++ b/src/Graphics/src/Graphics/Converters/RectFTypeConverter.cs
@@ -11,7 +11,14 @@ namespace Microsoft.Maui.Graphics.Converters
 			=> sourceType == typeof(string);
 
 		public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
-			=> destinationType == typeof(string);
+			=> destinationType == typeof(string)
+#if ANDROID
+				|| destinationType == typeof(global::Android.Graphics.Rect)
+				|| destinationType == typeof(global::Android.Graphics.RectF)
+#elif IOS || MACCATALYST
+				|| destinationType == typeof(CoreGraphics.CGRect)
+#endif
+			;
 
 		public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
 		{
@@ -25,6 +32,17 @@ namespace Microsoft.Maui.Graphics.Converters
 		{
 			if (!(value is RectF r))
 				throw new NotSupportedException();
+
+#if ANDROID
+			if (destinationType == typeof(global::Android.Graphics.Rect))
+				return (global::Android.Graphics.Rect)r;
+			if (destinationType == typeof(global::Android.Graphics.RectF))
+				return (global::Android.Graphics.RectF)r;
+#elif IOS || MACCATALYST
+			if (destinationType == typeof(CoreGraphics.CGRect))
+				return (CoreGraphics.CGRect)r;
+#endif
+
 			return $"{r.X.ToString(CultureInfo.InvariantCulture)}, {r.Y.ToString(CultureInfo.InvariantCulture)}, {r.Width.ToString(CultureInfo.InvariantCulture)}, {r.Height.ToString(CultureInfo.InvariantCulture)}";
 		}
 	}

--- a/src/Graphics/src/Graphics/Converters/RectTypeConverter.cs
+++ b/src/Graphics/src/Graphics/Converters/RectTypeConverter.cs
@@ -11,7 +11,15 @@ namespace Microsoft.Maui.Graphics.Converters
 			=> sourceType == typeof(string);
 
 		public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
-			=> destinationType == typeof(string);
+			=> destinationType == typeof(string)
+				|| destinationType == typeof(RectF)
+#if ANDROID
+				|| destinationType == typeof(global::Android.Graphics.Rect)
+				|| destinationType == typeof(global::Android.Graphics.RectF)
+#elif IOS || MACCATALYST
+				|| destinationType == typeof(CoreGraphics.CGRect)
+#endif
+				;
 
 		public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
 		{
@@ -25,6 +33,18 @@ namespace Microsoft.Maui.Graphics.Converters
 		{
 			if (!(value is Rect r))
 				throw new NotSupportedException();
+
+			if (destinationType == typeof(RectF))
+				return (RectF)r;
+#if ANDROID
+			if (destinationType == typeof(global::Android.Graphics.Rect))
+				return (global::Android.Graphics.Rect)r;
+			if (destinationType == typeof(global::Android.Graphics.RectF))
+				return (global::Android.Graphics.RectF)r;
+#elif IOS || MACCATALYST
+			if (destinationType == typeof(CoreGraphics.CGRect))
+				return (CoreGraphics.CGRect)r;
+#endif
 			return $"{r.X.ToString(CultureInfo.InvariantCulture)}, {r.Y.ToString(CultureInfo.InvariantCulture)}, {r.Width.ToString(CultureInfo.InvariantCulture)}, {r.Height.ToString(CultureInfo.InvariantCulture)}";
 		}
 	}

--- a/src/Graphics/src/Graphics/Converters/SizeFTypeConverter.cs
+++ b/src/Graphics/src/Graphics/Converters/SizeFTypeConverter.cs
@@ -11,7 +11,13 @@ namespace Microsoft.Maui.Graphics.Converters
 			=> sourceType == typeof(string);
 
 		public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
-			=> destinationType == typeof(string);
+			=> destinationType == typeof(string)
+				|| destinationType == typeof(Size)
+#if IOS || MACCATALYST
+				|| destinationType == typeof(CoreGraphics.CGSize)
+				|| destinationType == typeof(CoreGraphics.CGPoint)
+#endif
+				;
 
 		public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
 		{
@@ -25,6 +31,15 @@ namespace Microsoft.Maui.Graphics.Converters
 		{
 			if (!(value is SizeF size))
 				throw new NotSupportedException();
+
+			if (destinationType == typeof(Size))
+				return (Size)size;
+#if IOS || MACCATALYST
+			if (destinationType == typeof(CoreGraphics.CGSize))
+				return (CoreGraphics.CGSize)size;
+			if (destinationType == typeof(CoreGraphics.CGPoint))
+				return (CoreGraphics.CGPoint)size;
+#endif
 			return $"{size.Width.ToString(CultureInfo.InvariantCulture)}, {size.Height.ToString(CultureInfo.InvariantCulture)}";
 		}
 	}

--- a/src/Graphics/src/Graphics/Converters/SizeTypeConverter.cs
+++ b/src/Graphics/src/Graphics/Converters/SizeTypeConverter.cs
@@ -11,7 +11,13 @@ namespace Microsoft.Maui.Graphics.Converters
 			=> sourceType == typeof(string);
 
 		public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
-			=> destinationType == typeof(string);
+			=> destinationType == typeof(string)
+				|| destinationType == typeof(SizeF)
+#if IOS || MACCATALYST
+				|| destinationType == typeof(CoreGraphics.CGSize)
+				|| destinationType == typeof(CoreGraphics.CGPoint)
+#endif
+				;
 
 		public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
 		{
@@ -25,6 +31,15 @@ namespace Microsoft.Maui.Graphics.Converters
 		{
 			if (!(value is Size size))
 				throw new NotSupportedException();
+
+			if (destinationType == typeof(SizeF))
+				return (SizeF)size;
+#if IOS || MACCATALYST
+			if (destinationType == typeof(CoreGraphics.CGSize))
+				return (CoreGraphics.CGSize)size;
+			if (destinationType == typeof(CoreGraphics.CGPoint))
+				return (CoreGraphics.CGPoint)size;
+#endif
 			return $"{size.Width.ToString(CultureInfo.InvariantCulture)}, {size.Height.ToString(CultureInfo.InvariantCulture)}";
 		}
 	}


### PR DESCRIPTION
### Description of Change

This is a follow-up PR to #21050. It adds type converters for all types that have implicit operators.

#21050 should be merged first and this PR should be rebased so that we can run tests of the two PRs in CI together.