### PR TITLE
[Trimming] Fix ILLink warnings in source generated code

### DIFF
--- a/src/Controls/src/SourceGen/CodeBehindGenerator.cs
+++ b/src/Controls/src/SourceGen/CodeBehindGenerator.cs
@@ -358,14 +358,9 @@ public class CodeBehindGenerator : IIncrementalGenerator
 
 		sb.AppendLine("\t\tprivate void InitializeComponent()");
 		sb.AppendLine("\t\t{");
-		sb.AppendLine("\t\t\t[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage(\"TrimAnalysis\", \"IL2026:RequiresUnreferencedCode\",");
-		sb.AppendLine("\t\t\t\tJustification = \"By default, Xaml compilation replaces the body of InitializeComponent, so LoadFromXaml will never be called in production builds.\")]");
-		sb.AppendLine("\t\t\tvoid LoadFromXaml()");
-		sb.AppendLine("\t\t\t{");
-		sb.AppendLine($"\t\t\t\tglobal::Microsoft.Maui.Controls.Xaml.Extensions.LoadFromXaml(this, typeof({rootType}));");
-		sb.AppendLine("\t\t\t}");
-		sb.AppendLine();
-		sb.AppendLine($"\t\t\tLoadFromXaml();");
+		sb.AppendLine("#pragma warning disable IL2026 // The body of InitializeComponent will be replaced by XamlC so LoadFromXaml will never be called in production builds");
+		sb.AppendLine($"\t\t\tglobal::Microsoft.Maui.Controls.Xaml.Extensions.LoadFromXaml(this, typeof({rootType}));");
+		sb.AppendLine("#pragma warning restore IL2026");
 
 		if (namedFields != null)
 		{

--- a/src/Controls/src/SourceGen/CodeBehindGenerator.cs
+++ b/src/Controls/src/SourceGen/CodeBehindGenerator.cs
@@ -358,7 +358,15 @@ public class CodeBehindGenerator : IIncrementalGenerator
 
 		sb.AppendLine("\t\tprivate void InitializeComponent()");
 		sb.AppendLine("\t\t{");
-		sb.AppendLine($"\t\t\tglobal::Microsoft.Maui.Controls.Xaml.Extensions.LoadFromXaml(this, typeof({rootType}));");
+		sb.AppendLine("\t\t\t[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage(\"TrimAnalysis\", \"IL2026:RequiresUnreferencedCode\",");
+		sb.AppendLine("\t\t\t\tJustification = \"The body of InitializeComponent will be replaced by XamlC so LoadFromXaml will never be called in production builds.\")]");
+		sb.AppendLine("\t\t\tvoid LoadFromXaml()");
+		sb.AppendLine("\t\t\t{");
+		sb.AppendLine($"\t\t\t\tglobal::Microsoft.Maui.Controls.Xaml.Extensions.LoadFromXaml(this, typeof({rootType}));");
+		sb.AppendLine("\t\t\t}");
+		sb.AppendLine();
+		sb.AppendLine($"\t\t\tLoadFromXaml();");
+
 		if (namedFields != null)
 		{
 			foreach ((var fname, var ftype, var faccess) in namedFields)

--- a/src/Controls/src/SourceGen/CodeBehindGenerator.cs
+++ b/src/Controls/src/SourceGen/CodeBehindGenerator.cs
@@ -359,7 +359,7 @@ public class CodeBehindGenerator : IIncrementalGenerator
 		sb.AppendLine("\t\tprivate void InitializeComponent()");
 		sb.AppendLine("\t\t{");
 		sb.AppendLine("\t\t\t[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage(\"TrimAnalysis\", \"IL2026:RequiresUnreferencedCode\",");
-		sb.AppendLine("\t\t\t\tJustification = \"The body of InitializeComponent will be replaced by XamlC so LoadFromXaml will never be called in production builds.\")]");
+		sb.AppendLine("\t\t\t\tJustification = \"By default, Xaml compilation replaces the body of InitializeComponent, so LoadFromXaml will never be called in production builds.\")]");
 		sb.AppendLine("\t\t\tvoid LoadFromXaml()");
 		sb.AppendLine("\t\t\t{");
 		sb.AppendLine($"\t\t\t\tglobal::Microsoft.Maui.Controls.Xaml.Extensions.LoadFromXaml(this, typeof({rootType}));");


### PR DESCRIPTION
### Description of Change

~ILLink~ _Trim analyzer_ is reporting the following warnings:

```
/.../MyMauiApp/obj/Release/net9.0-maccatalyst/maccatalyst-arm64/Microsoft.Maui.Controls.SourceGen/Microsoft.Maui.Controls.SourceGen.CodeBehindGenerator/Resources_Styles_Colors.xaml.sg.cs(30,4): warning IL2026: Using member 'Microsoft.Maui.Controls.Xaml.Extensions.LoadFromXaml<TXaml>(TXaml, Type)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. Loading XAML at runtime might require types and members that cannot be statically analyzed. Make sure all of the required types and members are preserved. [/.../MyMauiApp/MyMauiApp.csproj::TargetFramework=net9.0-maccatalyst]
```

It is safe to suppress the warnings in the `InitializeComponent` method because its method body will be replaced with `XamlC` in Release builds.

### Issues Fixed

Contributes to #19397 

/cc @jonathanpeppers @vitek-karas @StephaneDelcroix 