### PR TITLE
[iOS] Fix UI loop when setting ContentInset

### DIFF
--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issue20294.xaml
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issue20294.xaml
@@ -9,7 +9,7 @@
 
         <CollectionView.ItemsSource>
             <x:Array Type="{x:Type x:String}">
-                <x:String>asdf</x:String>
+                <x:String>ONE</x:String>
                 <x:String>asdf</x:String>
                 <x:String>asdf</x:String>
                 <x:String>asdf</x:String>
@@ -48,12 +48,12 @@
         </CollectionView.ItemsLayout>
 
         <CollectionView.Footer>
-            <Label HeightRequest="45" Text="FOOOTER"></Label>
+            <Label HeightRequest="45" Text="FOOTER" AutomationId="FOOTER"></Label>
         </CollectionView.Footer>
         
         <CollectionView.ItemTemplate>
             <DataTemplate x:DataType="x:String">
-                <Border
+                <Border AutomationId="{Binding}"
                     StrokeThickness="0.2">
                     <Label
                         Text="{Binding}"

--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issue20294.xaml
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issue20294.xaml
@@ -3,10 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              Title="Issue 20294"
              x:Class="Maui.Controls.Sample.Issues.Issue20294">
-     <CollectionView
-        SelectionMode="Single"
-        Margin="10.0">
-
+     <CollectionView SelectionMode="Single" Margin="10.0" AutomationId="theCollectionView">
         <CollectionView.ItemsSource>
             <x:Array Type="{x:Type x:String}">
                 <x:String>ONE</x:String>
@@ -37,30 +34,23 @@
                 <x:String>asdf</x:String>
                 <x:String>asdf</x:String>
                 <x:String>asdf</x:String>
-                <x:String>asdf</x:String>
+                <x:String>LAST</x:String>
             </x:Array>
         </CollectionView.ItemsSource>
-
         <CollectionView.ItemsLayout>
             <LinearItemsLayout 
                 Orientation="Vertical"
                 ItemSpacing="15"/>
         </CollectionView.ItemsLayout>
-
         <CollectionView.Footer>
-            <Label HeightRequest="45" Text="FOOTER" AutomationId="FOOTER"></Label>
-        </CollectionView.Footer>
-        
+            <Label HeightRequest="45" Text="FOOTER" AutomationId="FOOTER"/>
+        </CollectionView.Footer> 
         <CollectionView.ItemTemplate>
             <DataTemplate x:DataType="x:String">
-                <Border AutomationId="{Binding}"
-                    StrokeThickness="0.2">
-                    <Label
-                        Text="{Binding}"
-                        FontSize="20"/>
+                <Border AutomationId="{Binding}" StrokeThickness="0.2">
+                    <Label Text="{Binding}" FontSize="20"/>
                 </Border>
             </DataTemplate>
         </CollectionView.ItemTemplate>
-
     </CollectionView>
 </ContentPage>

--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issue20294.xaml
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issue20294.xaml
@@ -1,0 +1,66 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             Title="Issue 20294"
+             x:Class="Maui.Controls.Sample.Issues.Issue20294">
+     <CollectionView
+        SelectionMode="Single"
+        Margin="10.0">
+
+        <CollectionView.ItemsSource>
+            <x:Array Type="{x:Type x:String}">
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+            </x:Array>
+        </CollectionView.ItemsSource>
+
+        <CollectionView.ItemsLayout>
+            <LinearItemsLayout 
+                Orientation="Vertical"
+                ItemSpacing="15"/>
+        </CollectionView.ItemsLayout>
+
+        <CollectionView.Footer>
+            <Label HeightRequest="45" Text="FOOOTER"></Label>
+        </CollectionView.Footer>
+        
+        <CollectionView.ItemTemplate>
+            <DataTemplate x:DataType="x:String">
+                <Border
+                    StrokeThickness="0.2">
+                    <Label
+                        Text="{Binding}"
+                        FontSize="20"/>
+                </Border>
+            </DataTemplate>
+        </CollectionView.ItemTemplate>
+
+    </CollectionView>
+</ContentPage>

--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issue20294.xaml.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issue20294.xaml.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+
+namespace Maui.Controls.Sample.Issues
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	[Issue(IssueTracker.Github, 20294, "CollectionView containing a Footer and a Border with StrokeThickness set to decimal value crashes on scroll", PlatformAffected.iOS)]
+	public partial class Issue20294 : ContentPage
+	{
+		public Issue20294()
+		{
+			InitializeComponent();
+		}
+	}
+}

--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issue20294.xaml.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issue20294.xaml.cs
@@ -7,7 +7,7 @@ namespace Maui.Controls.Sample.Issues
 	[Issue(IssueTracker.Github, 20294, "CollectionView containing a Footer and a Border with StrokeThickness set to decimal value crashes on scroll", PlatformAffected.iOS)]
 	public partial class Issue20294 : ContentPage
 	{
-		public Issue20294()
+		public Issue20294()	
 		{
 			InitializeComponent();
 		}

--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewLayout.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewLayout.cs
@@ -104,11 +104,11 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			}
 		}
 
-		internal virtual void UpdateConstraints(CGSize size)
+		internal virtual bool UpdateConstraints(CGSize size)
 		{
 			if (size.IsCloseTo(_currentSize))
 			{
-				return;
+				return false;
 			}
 
 			ClearCellSizeCache();
@@ -119,6 +119,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			ConstrainTo(newSize);
 
 			UpdateCellConstraints();
+			return true;
 		}
 
 		internal void SetInitialConstraints(CGSize size)
@@ -573,14 +574,12 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		public override bool ShouldInvalidateLayoutForBoundsChange(CGRect newBounds)
 		{
-			if (newBounds.Size == _currentSize)
+			if (newBounds.Size.IsCloseTo(_currentSize))
 			{
 				return base.ShouldInvalidateLayoutForBoundsChange(newBounds);
 			}
 
-			UpdateConstraints(CollectionView.AdjustedContentInset.InsetRect(newBounds).Size);
-
-			return true;
+			return UpdateConstraints(CollectionView.AdjustedContentInset.InsetRect(newBounds).Size);
 		}
 
 		internal bool TryGetCachedCellSize(object item, out CGSize size)

--- a/src/Controls/src/Core/Handlers/Items/iOS/StructuredItemsViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/StructuredItemsViewController.cs
@@ -133,16 +133,18 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			}
 
 			if (formsElement != null)
+			{
 				ItemsView.AddLogicalChild(formsElement);
+			}
 
 			if (formsElement != null)
 			{
 				RemeasureLayout(formsElement);
 				formsElement.MeasureInvalidated += OnFormsElementMeasureInvalidated;
 			}
-			else if (uiView != null)
+			else
 			{
-				uiView.SizeToFit();
+				uiView?.SizeToFit();
 			}
 		}
 
@@ -159,7 +161,9 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				nfloat emptyWidth = emptyView?.Frame.Width ?? 0f;
 
 				if (_headerUIView != null && _headerUIView.Frame.X != headerWidth)
+				{
 					_headerUIView.Frame = new CoreGraphics.CGRect(-headerWidth, 0, headerWidth, CollectionView.Frame.Height);
+				}
 
 				if (_footerUIView != null && (_footerUIView.Frame.X != ItemsViewLayout.CollectionViewContentSize.Width || emptyWidth > 0))
 					_footerUIView.Frame = new CoreGraphics.CGRect(ItemsViewLayout.CollectionViewContentSize.Width + emptyWidth, 0, footerWidth, CollectionView.Frame.Height);

--- a/src/Controls/tests/UITests/Tests/Issues/Issue20294.cs
+++ b/src/Controls/tests/UITests/Tests/Issues/Issue20294.cs
@@ -14,6 +14,8 @@ public class Issue20294 : _IssuesUITest
 	[Test]
 	public void ScrollToEndDoesntCrash()
 	{
+		this.IgnoreIfPlatforms(new TestDevice[] { TestDevice.Android, TestDevice.Mac, TestDevice.Windows });
+		
 		App.ScrollTo("FOOTER");
 		App.ScrollUp("theCollectionView", ScrollStrategy.Gesture, 0.5);
 		App.ScrollDown("theCollectionView", ScrollStrategy.Gesture, 0.5);

--- a/src/Controls/tests/UITests/Tests/Issues/Issue20294.cs
+++ b/src/Controls/tests/UITests/Tests/Issues/Issue20294.cs
@@ -14,7 +14,11 @@ public class Issue20294 : _IssuesUITest
 	[Test]
 	public void ScrollToEndDoesntCrash()
 	{
- 		App.ScrollDown("FOOTER");
-		App.ScrollUp("ONE");
+		App.ScrollTo("FOOTER");
+		App.ScrollUp("theCollectionView", ScrollStrategy.Gesture, 0.5);
+		App.ScrollDown("theCollectionView", ScrollStrategy.Gesture, 0.5);
+		App.ScrollDown("theCollectionView", ScrollStrategy.Gesture, 0.5);
+		App.ScrollUp("theCollectionView", ScrollStrategy.Gesture, 0.5);
+		App.ScrollDown("theCollectionView", ScrollStrategy.Gesture, 0.5);
 	}
 }

--- a/src/Controls/tests/UITests/Tests/Issues/Issue20294.cs
+++ b/src/Controls/tests/UITests/Tests/Issues/Issue20294.cs
@@ -1,0 +1,20 @@
+﻿using System.Drawing;
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.AppiumTests.Issues;
+
+public class Issue20294 : _IssuesUITest
+{
+	public Issue20294(TestDevice device) : base(device) { }
+
+	public override string Issue => "CollectionView containing a Footer and a Border with StrokeThickness set to decimal value crashes on scroll";
+
+	[Test]
+	public void ScrollToEndDoesntCrash()
+	{
+ 		App.ScrollDown("FOOTER");
+		App.ScrollUp("ONE");
+	}
+}


### PR DESCRIPTION
### Description of Change

Seems that we are always firing the bonds change even If they don't change, for example when the Bounds are similar when using CloseTo we should treat as the Bounds didn't change, but the code was always returning true there.

This issue also happens because when we use a footer we also set insets to the CollectionView that cause the Bounds event to change 

Fixes #20294 
Fixes #20320