### PR TITLE
[Windows] Round item size in GridView

### DIFF
--- a/src/Controls/src/Core/Platform/Windows/CollectionView/FormsGridView.cs
+++ b/src/Controls/src/Core/Platform/Windows/CollectionView/FormsGridView.cs
@@ -1,4 +1,5 @@
 #nullable disable
+using System;
 using Microsoft.Maui.Graphics;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -113,11 +114,11 @@ namespace Microsoft.Maui.Controls.Platform
 
 			if (_orientation == Orientation.Horizontal)
 			{
-				_wrapGrid.ItemHeight = _wrapGrid.ActualHeight / Span;
+				_wrapGrid.ItemHeight = Math.Floor(_wrapGrid.ActualHeight / Span);
 			}
 			else
 			{
-				_wrapGrid.ItemWidth = _wrapGrid.ActualWidth / Span;
+				_wrapGrid.ItemWidth = Math.Floor(_wrapGrid.ActualWidth / Span);
 			}
 		}
 


### PR DESCRIPTION
### Description of Change

Round item size in GridView to prevent flickering of items on high-DPI displays in WinAppSDK 1.5

### Issues Fixed

Fixes #21001
