### PR TITLE
[ios] fix memory leak in RadioButton

### DIFF
--- a/src/Controls/src/Core/Border/Border.cs
+++ b/src/Controls/src/Core/Border/Border.cs
@@ -68,6 +68,9 @@ namespace Microsoft.Maui.Controls
 				_strokeShapeChanged ??= (sender, e) => OnPropertyChanged(nameof(StrokeShape));
 				_strokeShapeProxy ??= new();
 				_strokeShapeProxy.Subscribe(visualElement, _strokeShapeChanged);
+
+				OnParentResourcesChanged(this.GetMergedResources());
+				((IElementDefinition)this).AddResourcesChangedListener(visualElement.OnParentResourcesChanged);
 			}
 		}
 
@@ -77,6 +80,8 @@ namespace Microsoft.Maui.Controls
 
 			if (strokeShape is VisualElement visualElement)
 			{
+				((IElementDefinition)this).RemoveResourcesChangedListener(visualElement.OnParentResourcesChanged);
+
 				SetInheritedBindingContext(visualElement, null);
 				_strokeShapeProxy?.Unsubscribe();
 			}

--- a/src/Controls/src/Core/Border/Border.cs
+++ b/src/Controls/src/Core/Border/Border.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Maui.Controls
 
 			if (strokeShape is VisualElement visualElement)
 			{
-				AddLogicalChild(visualElement);
+				SetInheritedBindingContext(visualElement, BindingContext);
 				_strokeShapeChanged ??= (sender, e) => OnPropertyChanged(nameof(StrokeShape));
 				_strokeShapeProxy ??= new();
 				_strokeShapeProxy.Subscribe(visualElement, _strokeShapeChanged);
@@ -77,7 +77,7 @@ namespace Microsoft.Maui.Controls
 
 			if (strokeShape is VisualElement visualElement)
 			{
-				RemoveLogicalChild(visualElement);
+				SetInheritedBindingContext(visualElement, null);
 				_strokeShapeProxy?.Unsubscribe();
 			}
 		}

--- a/src/Controls/src/Core/Border/Border.cs
+++ b/src/Controls/src/Core/Border/Border.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Maui.Controls
 			BindableProperty.Create(nameof(StrokeShape), typeof(IShape), typeof(Border), new Rectangle(),
 				propertyChanging: (bindable, oldvalue, newvalue) =>
 				{
-					if (newvalue is not null)
+					if (oldvalue is not null)
 						(bindable as Border)?.StopNotifyingStrokeShapeChanges();
 				},
 				propertyChanged: (bindable, oldvalue, newvalue) =>
@@ -92,7 +92,7 @@ namespace Microsoft.Maui.Controls
 			BindableProperty.Create(nameof(Stroke), typeof(Brush), typeof(Border), null,
 				propertyChanging: (bindable, oldvalue, newvalue) =>
 				{
-					if (newvalue is not null)
+					if (oldvalue is not null)
 						(bindable as Border)?.StopNotifyingStrokeChanges();
 				},
 				propertyChanged: (bindable, oldvalue, newvalue) =>

--- a/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.cs
@@ -4,8 +4,10 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Handlers;
 using Microsoft.Maui.Controls.Handlers.Compatibility;
 using Microsoft.Maui.Controls.Handlers.Items;
+using Microsoft.Maui.Controls.Shapes;
 using Microsoft.Maui.DeviceTests.Stubs;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Hosting;
@@ -33,15 +35,19 @@ namespace Microsoft.Maui.DeviceTests
 					handlers.AddHandler(typeof(TabbedPage), typeof(TabbedViewHandler));
 #endif
 					handlers.AddHandler(typeof(FlyoutPage), typeof(FlyoutViewHandler));
-					handlers.AddHandler<Page, PageHandler>();
-					handlers.AddHandler<Window, WindowHandlerStub>();
-					handlers.AddHandler<Frame, FrameRenderer>();
-					handlers.AddHandler<Label, LabelHandler>();
+					handlers.AddHandler(typeof(ScrollView), typeof(ScrollViewHandler));
+					handlers.AddHandler<Border, BorderHandler>();
 					handlers.AddHandler<Button, ButtonHandler>();
 					handlers.AddHandler<CarouselView, CarouselViewHandler>();
 					handlers.AddHandler<CollectionView, CollectionViewHandler>();
-					handlers.AddHandler(typeof(Controls.ContentView), typeof(ContentViewHandler));
-					handlers.AddHandler(typeof(ScrollView), typeof(ScrollViewHandler));
+					handlers.AddHandler<Frame, FrameRenderer>();
+					handlers.AddHandler<IContentView, ContentViewHandler>();
+					handlers.AddHandler<Label, LabelHandler>();
+					handlers.AddHandler<Layout, LayoutHandler>();
+					handlers.AddHandler<Page, PageHandler>();
+					handlers.AddHandler<RadioButton, RadioButtonHandler>();
+					handlers.AddHandler<Shape, ShapeViewHandler>();
+					handlers.AddHandler<Window, WindowHandlerStub>();
 				});
 			});
 		}
@@ -323,6 +329,7 @@ namespace Microsoft.Maui.DeviceTests
 						new ContentView(),
 						new Label(),
 						new ScrollView(),
+						new RadioButton(),
 					}
 				};
 				pageReference = new WeakReference(page);


### PR DESCRIPTION
Context: https://github.com/heyThorsten/GCTest
Fixes: https://github.com/dotnet/maui/issues/20023

In testing the above sample, a page with a `RadioButton` has a memory leak due to the usage of `Border.StrokeShape`.

There was also a slight "rabbit" hole, where we thought there was also an issue with `GestureRecognizers`. But this was not the case in a real app (just unit tests):

* https://github.com/dotnet/maui/pull/21089

It turns out that when `GestureRecognizers` are used in `MemoryTests`, they will leak if there is no `Window` involved.

Instead of using `MemoryTests` like I would traditionally, we should instead use `NavigationPageTests.DoesNotLeak()`. I can reproduce the problem with `RadioButton` *and* a `Window` exists in the test.

## Underlying issue ##

It appears that `Border.StrokeShape` does not use the same pattern as other properties like `Border.Stroke`:

* On set: `SetInheritedBindingContext(visualElement, BindingContext);`
* On unset: `SetInheritedBindingContext(visualElement, null);`

It instead used:

* On set: `AddLogicalChild(visualElement);`
* On unset: `RemoveLogicalChild(visualElement);`

6136a8ad that introduced these does not mention why one was used over another. I am unsure if this will cause a problem, but it fixes the leak.