### PR TITLE
[DRAFT] Update the macios dependencies to new package names.

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -28,21 +28,21 @@
       <Uri>https://github.com/xamarin/xamarin-android</Uri>
       <Sha>e222c43a4a44ccfc04e08c65fc4cddde147fd306</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.MacCatalyst.Sdk" Version="17.2.8047">
+    <Dependency Name="Microsoft.MacCatalyst.Sdk.net8.0_17.2" Version="17.2.8257-ci.main">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>8097226bdb411d4b613157ff5559ef26191cbf6f</Sha>
+      <Sha>90a4288eb39b99fc92df24becb30236e01e63ead</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.macOS.Sdk" Version="14.2.8047">
+    <Dependency Name="Microsoft.macOS.Sdk.net8.0_14.2" Version="14.2.8257-ci.main">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>8097226bdb411d4b613157ff5559ef26191cbf6f</Sha>
+      <Sha>90a4288eb39b99fc92df24becb30236e01e63ead</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.iOS.Sdk" Version="17.2.8047">
+    <Dependency Name="Microsoft.iOS.Sdk.net8.0_17.2" Version="17.2.8257-ci.main">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>8097226bdb411d4b613157ff5559ef26191cbf6f</Sha>
+      <Sha>90a4288eb39b99fc92df24becb30236e01e63ead</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.tvOS.Sdk" Version="17.2.8047">
+    <Dependency Name="Microsoft.tvOS.Sdk.net8.0_17.2" Version="17.2.8257-ci.main">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>8097226bdb411d4b613157ff5559ef26191cbf6f</Sha>
+      <Sha>90a4288eb39b99fc92df24becb30236e01e63ead</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.Workload.Emscripten.Current.Manifest-8.0.100" Version="8.0.3" CoherentParentDependency="Microsoft.NETCore.App.Ref">
       <Uri>https://github.com/dotnet/emsdk</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -30,7 +30,7 @@
     <MicrosoftiOSSdkPackageVersion>17.2.8047</MicrosoftiOSSdkPackageVersion>
     <MicrosofttvOSSdkPackageVersion>17.2.8047</MicrosofttvOSSdkPackageVersion>
     <MicrosoftMacCatalystSdknet80_172PackageVersion>17.2.8257-ci.main</MicrosoftMacCatalystSdknet80_172PackageVersion>
-    <MicrosoftmacOSSdknet80_142PackageVersion>17.2.8257-ci.main</MicrosoftmacOSSdknet80_142PackageVersion>
+    <MicrosoftmacOSSdknet80_142PackageVersion>14.2.8257-ci.main</MicrosoftmacOSSdknet80_142PackageVersion>
     <MicrosoftiOSSdknet80_172PackageVersion>17.2.8257-ci.main</MicrosoftiOSSdknet80_172PackageVersion>
     <MicrosofttvOSSdknet80_172PackageVersion>17.2.8257-ci.main</MicrosofttvOSSdknet80_172PackageVersion>
     <!-- Samsung/Tizen.NET -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -29,6 +29,10 @@
     <MicrosoftmacOSSdkPackageVersion>14.2.8047</MicrosoftmacOSSdkPackageVersion>
     <MicrosoftiOSSdkPackageVersion>17.2.8047</MicrosoftiOSSdkPackageVersion>
     <MicrosofttvOSSdkPackageVersion>17.2.8047</MicrosofttvOSSdkPackageVersion>
+    <MicrosoftMacCatalystSdknet80_172PackageVersion>17.2.8257-ci.main</MicrosoftMacCatalystSdknet80_172PackageVersion>
+    <MicrosoftmacOSSdknet80_142PackageVersion>17.2.8257-ci.main</MicrosoftmacOSSdknet80_142PackageVersion>
+    <MicrosoftiOSSdknet80_172PackageVersion>17.2.8257-ci.main</MicrosoftiOSSdknet80_172PackageVersion>
+    <MicrosofttvOSSdknet80_172PackageVersion>17.2.8257-ci.main</MicrosofttvOSSdknet80_172PackageVersion>
     <!-- Samsung/Tizen.NET -->
     <SamsungTizenSdkPackageVersion>8.0.130</SamsungTizenSdkPackageVersion>
     <!-- emsdk -->
@@ -103,5 +107,9 @@
     <DotNetAndroidManifestVersionBand>$(DotNetVersionBand)</DotNetAndroidManifestVersionBand>
     <DotNetMaciOSManifestVersionBand>$(DotNetVersionBand)</DotNetMaciOSManifestVersionBand>
     <DotNetTizenManifestVersionBand>$(DotNetVersionBand)</DotNetTizenManifestVersionBand>
+    <MicrosoftMacCatalystSdkPackageVersion>$(MicrosoftMacCatalystSdknet80_172PackageVersion)</MicrosoftMacCatalystSdkPackageVersion>
+    <MicrosoftmacOSSdkPackageVersion>$(MicrosoftmacOSSdknet80_142PackageVersion)</MicrosoftmacOSSdkPackageVersion>
+    <MicrosoftiOSSdkPackageVersion>$(MicrosoftiOSSdknet80_172PackageVersion)</MicrosoftiOSSdkPackageVersion>
+    <MicrosofttvOSSdkPackageVersion>$(MicrosofttvOSSdknet80_172PackageVersion)</MicrosofttvOSSdkPackageVersion>
   </PropertyGroup>
 </Project>

--- a/src/Core/src/Platform/iOS/LabelExtensions.cs
+++ b/src/Core/src/Platform/iOS/LabelExtensions.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Maui.Platform
 			var attr = new NSAttributedStringDocumentAttributes
 			{
 				DocumentType = NSDocumentType.HTML,
-				StringEncoding = NSStringEncoding.UTF8
+				CharacterEncoding = NSStringEncoding.UTF8
 			};
 
 			NSError nsError = new();


### PR DESCRIPTION
### Description of Change

Update the macios dependencies to new package names now that multi-targeting
has been implemented for Xcode 15.3.

⚠️ This is a PR only to validate multi-targeting, *do not merge* ⚠️