### PR TITLE
[Android] Fixed customising alert buttons' colors

### DIFF
--- a/src/Core/src/Platform/Android/Resources/values/styles.xml
+++ b/src/Core/src/Platform/Android/Resources/values/styles.xml
@@ -68,7 +68,7 @@
     </style>
 
     <style name="MauiAlertDialogTheme" parent="ThemeOverlay.MaterialComponents.MaterialAlertDialog">
-      <item name="colorPrimary">?attr/colorOnSurface</item>
+      <item name="colorPrimary">@color/colorPrimary</item>
     </style>
 
   <!-- 


### PR DESCRIPTION
### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/20108


#### Platforms\Android\Resources\values\colors.xml
```
<?xml version="1.0" encoding="utf-8"?>
<resources>
    <color name="colorPrimary">#f00</color>
    <color name="colorPrimaryDark">#2B0B98</color>
    <color name="colorAccent">#2B0B98</color>
</resources>
```

|Before|After|
|--|--|
|<img src="https://github.com/dotnet/maui/assets/42434498/be5de617-c2cf-476c-b04a-dedb0678b403" width="300px"/>|<img src="https://github.com/dotnet/maui/assets/42434498/ec34402b-f9d2-42e5-b6c6-f225f90cc727" width="300px"/>|
