### PR TITLE
Cache SKPath to PathF.PlatformPath in Microsoft.Maui.Graphics.Skia

### DIFF
--- a/src/Graphics/src/Graphics.Skia/SkiaCanvas.cs
+++ b/src/Graphics/src/Graphics.Skia/SkiaCanvas.cs
@@ -588,29 +588,43 @@ namespace Microsoft.Maui.Graphics.Skia
 			_canvas.ClipRect(rect, SKClipOperation.Difference);
 		}
 
+		private SKPath GetPath(PathF path, SKPathFillType fillType = SKPathFillType.Winding)
+		{
+			var skPath = path.PlatformPath as SKPath;
+
+			if (skPath is null)
+			{
+				skPath = path.AsSkiaPath();
+				skPath.FillType = fillType;
+				path.PlatformPath = skPath;
+			}
+
+			return skPath;
+		}
+
 		protected override void PlatformDrawPath(
 			PathF path)
 		{
-			var platformPath = path.AsSkiaPath();
+			var platformPath = GetPath(path);
 			_canvas.DrawPath(platformPath, CurrentState.StrokePaintWithAlpha);
-			platformPath.Dispose();
 		}
 
 		public override void ClipPath(PathF path,
 			WindingMode windingMode = WindingMode.NonZero)
 		{
-			var platformPath = path.AsSkiaPath();
-			platformPath.FillType = windingMode == WindingMode.NonZero ? SKPathFillType.Winding : SKPathFillType.EvenOdd;
+			var fillType = windingMode == WindingMode.NonZero ? SKPathFillType.Winding : SKPathFillType.EvenOdd;
+			var platformPath = GetPath(path, fillType);
+
 			_canvas.ClipPath(platformPath);
 		}
 
 		public override void FillPath(PathF path,
 			WindingMode windingMode)
 		{
-			var platformPath = path.AsSkiaPath();
-			platformPath.FillType = windingMode == WindingMode.NonZero ? SKPathFillType.Winding : SKPathFillType.EvenOdd;
+			var fillType = windingMode == WindingMode.NonZero ? SKPathFillType.Winding : SKPathFillType.EvenOdd;
+			var platformPath = GetPath(path, fillType);
+
 			_canvas.DrawPath(platformPath, CurrentState.FillPaintWithAlpha);
-			platformPath.Dispose();
 		}
 
 		public override void DrawString(

--- a/src/Graphics/src/Graphics.Skia/SkiaCanvas.cs
+++ b/src/Graphics/src/Graphics.Skia/SkiaCanvas.cs
@@ -595,9 +595,10 @@ namespace Microsoft.Maui.Graphics.Skia
 			if (skPath is null)
 			{
 				skPath = path.AsSkiaPath();
-				skPath.FillType = fillType;
 				path.PlatformPath = skPath;
 			}
+
+			skPath.FillType = fillType;
 
 			return skPath;
 		}


### PR DESCRIPTION
### Description of Change

We can observe that in implementations such as Microsoft.Maui.Graphics.Win2D, methods like PlatformDrawPath and FillPath rely on the PathF.PlatformPath property as a cache when obtaining platform-specific Path or Geometry from PathF. This approach enhances the performance of repeated drawing and reduces the frequency of creating platform-specific objects.

However, in Microsoft.Maui.Graphics.Skia, a new SKPath object is created each time. This means that repeated drawing of a complex PathF will not achieve optimal performance in Microsoft.Maui.Graphics.Skia.

The purpose of this change is to allow Microsoft.Maui.Graphics.Skia to utilize the PathF.PlatformPath property as a cache, thereby improving the performance of Microsoft.Maui.Graphics.Skia when repeatedly drawing complex PathF.



// Cc: @mattleibow
