### PR TITLE
Fix XmlType .Equals override

### DIFF
--- a/src/Controls/src/Xaml/XamlNode.cs
+++ b/src/Controls/src/Xaml/XamlNode.cs
@@ -65,7 +65,8 @@ namespace Microsoft.Maui.Controls.Xaml
 			return
 				NamespaceUri == other.NamespaceUri &&
 				Name == other.Name &&
-				(TypeArguments == null && other.TypeArguments == null || TypeArguments.SequenceEqual(other.TypeArguments));
+				(TypeArguments == null && other.TypeArguments == null ||
+				 TypeArguments != null && other.TypeArguments != null && TypeArguments.SequenceEqual(other.TypeArguments));
 		}
 
 		public override int GetHashCode()

--- a/src/Controls/tests/Xaml.UnitTests/XmlTypeTests.cs
+++ b/src/Controls/tests/Xaml.UnitTests/XmlTypeTests.cs
@@ -1,0 +1,98 @@
+using NUnit.Framework;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests
+{
+	[TestFixture]
+	public class XmlTypeTests : BaseTestFixture
+	{
+		[Test]
+		public void TestXmlTypeEquality()
+		{
+			// Arrange
+			var type1 = new XmlType("http://example.com", "Type1", typeArguments: null);
+			var type2 = new XmlType("http://example.com", "Type1", typeArguments: null);
+
+			// Act
+			var result = type1.Equals(type2);
+
+			// Assert
+			Assert.IsTrue(result);
+		}
+
+		[Test]
+		public void TestXmlTypeInequality()
+		{
+			// Arrange
+			var type1 = new XmlType("http://example.com", "Type1", typeArguments: null);
+			var type2 = new XmlType("http://example.com", "Type2", typeArguments: null);
+
+			// Act
+			var result = type1.Equals(type2);
+
+			// Assert
+			Assert.IsFalse(result);
+		}
+
+		[Test]
+		public void TestXmlTypeEqualityWithTypeArgs()
+		{
+			// Arrange
+			var typeArg = new XmlType("http://example.com", "TypeArg", typeArguments: null);
+			var type1 = new XmlType("http://example.com", "Type1", typeArguments: [typeArg]);
+			var type2 = new XmlType("http://example.com", "Type1", typeArguments: [typeArg]);
+
+			// Act
+			var result = type1.Equals(type2);
+
+			// Assert
+			Assert.IsTrue(result);
+		}
+
+		[Test]
+		public void TestXmlTypeInequalityWithSameTypeArgs()
+		{
+			// Arrange
+			var typeArg = new XmlType("http://example.com", "TypeArg", typeArguments: null);
+			var type1 = new XmlType("http://example.com", "Type1", typeArguments: [typeArg]);
+			var type2 = new XmlType("http://example.com", "Type2", typeArguments: [typeArg]);
+
+			// Act
+			var result = type1.Equals(type2);
+
+			// Assert
+			Assert.IsFalse(result);
+		}
+
+
+		[Test]
+		public void TestXmlTypeInequalityWithDifferentTypeArgs()
+		{
+			// Arrange
+			var typeArg1 = new XmlType("http://example.com", "TypeArg1", typeArguments: null);
+			var typeArg2 = new XmlType("http://example.com", "TypeArg2", typeArguments: null);
+			var type1 = new XmlType("http://example.com", "Type1", typeArguments: [typeArg1]);
+			var type2 = new XmlType("http://example.com", "Type1", typeArguments: [typeArg2]);
+
+			// Act
+			var result = type1.Equals(type2);
+
+			// Assert
+			Assert.IsFalse(result);
+		}
+
+		[Test]
+		public void TestXmlTypeInequalityWithAndWithoutTypeArgs()
+		{
+			// Arrange
+			var typeArg = new XmlType("http://example.com", "TypeArg", typeArguments: null);
+			var type1 = new XmlType("http://example.com", "Type1", typeArguments: [typeArg]);
+			var type2 = new XmlType("http://example.com", "Type1", typeArguments: null);
+
+			// Act
+			var result = type1.Equals(type2);
+
+			// Assert
+			Assert.IsFalse(result);
+		}
+	}
+}


### PR DESCRIPTION
- Make sure to only check type argument sequences if both of them are non-null
- Add XmlType equality tests for this and other equality scenarios

Fixes #21170