### PR TITLE
[android] fix memory leak in `TabbedPage`

### DIFF
--- a/src/Controls/src/Core/Platform/Android/TabbedPageManager.cs
+++ b/src/Controls/src/Core/Platform/Android/TabbedPageManager.cs
@@ -123,6 +123,7 @@ namespace Microsoft.Maui.Controls.Handlers
 				Element.Disappearing -= OnTabbedPageDisappearing;
 				RemoveTabs();
 				_viewPager.LayoutChange -= OnLayoutChanged;
+				_viewPager.Adapter = null;
 			}
 
 			Element = tabbedPage;

--- a/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.cs
@@ -426,6 +426,33 @@ namespace Microsoft.Maui.DeviceTests
 			}
 		}
 
+		[Fact(DisplayName = "Does Not Leak")]
+		public async Task DoesNotLeak()
+		{
+			SetupBuilder();
+			WeakReference pageReference = null;
+			var navPage = new NavigationPage(new ContentPage { Title = "Page 1" });
+
+			await CreateHandlerAndAddToWindow<WindowHandlerStub>(new Window(navPage), async (handler) =>
+			{
+				var page = new TabbedPage
+				{
+					Children =
+					{
+						new ContentPage
+						{
+							Content = new VerticalStackLayout { new Label() },
+						}
+					}
+				};
+				pageReference = new WeakReference(page);
+				await navPage.Navigation.PushAsync(page);
+				await navPage.Navigation.PopAsync();
+			});
+
+			await AssertionExtensions.WaitForGC(pageReference);
+		}
+
 
 		TabbedPage CreateBasicTabbedPage(bool bottomTabs = false, bool isSmoothScrollEnabled = true, IEnumerable<Page> pages = null)
 		{

--- a/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.cs
@@ -427,6 +427,11 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		[Fact(DisplayName = "Does Not Leak")]
+		[Fact(DisplayName = "Does Not Leak"
+#if WINDOWS
+			, Skip = "FIXME: fails on Windows"
+#endif
+		)]
 		public async Task DoesNotLeak()
 		{
 			SetupBuilder();

--- a/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.cs
@@ -426,7 +426,6 @@ namespace Microsoft.Maui.DeviceTests
 			}
 		}
 
-		[Fact(DisplayName = "Does Not Leak")]
 		[Fact(DisplayName = "Does Not Leak"
 #if WINDOWS
 			, Skip = "FIXME: fails on Windows"


### PR DESCRIPTION
Fixes: https://github.com/dotnet/maui/issues/17959
Context: https://github.com/VoznichkaSviatoslav1/TabbedPageMemoryLeak

In the sample app, I added some `GC.Collect()` calls to force the GC to run, but the following log message never prints:

    public partial class MyTabbedPage : TabbedPage
    {
        public MyTabbedPage()
        {
            InitializeComponent();

            Console.WriteLine("Constructor was called");
        }

        // Doesn't print!!!
        ~MyTabbedPage() => Console.WriteLine("Destructor was called");

I took a memory snapshot with `dotnet-gcdump` and found a tree like:

    SampleApp.MyTabbedPage ->
        Microsoft.Maui.Controls.Platform.MultiPageFragmentStateAdapter<Microsoft.Maui.Controls.Page> ->
            Action<Microsoft.Maui.Controls.Platform.AdapterItemKey>

I didn't find an explanation of what was holding
`MultiPageFragmentStateAdapter`. I tried eliminating the `Action<T>`, but that didn't solve the underlying issue; it just made the object tree shorter:

    SampleApp.MyTabbedPage ->
        Microsoft.Maui.Controls.Platform.MultiPageFragmentStateAdapter<Microsoft.Maui.Controls.Page>

I could also reproduce the problem in a new device test.

Reviewing the code, I found we were doing:

    _viewPager.Adapter = new MultiPageFragmentStateAdapter<Page>(tabbedPage, FragmentManager, _context) { CountOverride = tabbedPage.Children.Count };

But then in the cleanup code, we never set `Adapter` to `null`:

    _viewPager.Adapter = null;

After this change, the memory is released as expected. I am not exactly sure *why* this leaked, but the change does seem appropriate and fixes the problem.

Now the new device test passes & the sample app prints:

    03-14 15:06:32.394  6055  6055 I DOTNET  : Constructor was called
    03-14 15:06:37.008  6055  6089 I DOTNET  : Destructor was called