### PR TITLE
[C] use ResourcesChanged to propagate Theme

### DIFF
--- a/Microsoft.Maui-dev.sln
+++ b/Microsoft.Maui-dev.sln
@@ -241,7 +241,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UITest.Appium", "src\TestUt
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UITest.NUnit", "src\TestUtils\src\UITest.NUnit\UITest.NUnit.csproj", "{A307B624-48D4-494E-A70D-5B3CDF6620CF}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Controls.SourceGen.UnitTests", "src\Controls\tests\SourceGen.UnitTests\Conrtrols.SourceGen.UnitTests\Controls.SourceGen.UnitTests.csproj", "{06747B55-91DB-47F5-B7A2-56526C28A0D3}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Controls.SourceGen.UnitTests", "src\Controls\tests\SourceGen.UnitTests\Controls.SourceGen.UnitTests\Controls.SourceGen.UnitTests.csproj", "{06747B55-91DB-47F5-B7A2-56526C28A0D3}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SourceGen.UnitTests", "src\Controls\tests\SourceGen.UnitTests\SourceGen.UnitTests.csproj", "{BC7F7C82-694F-4B97-86FC-273FB3FACA25}"
 EndProject

--- a/src/Controls/src/Core/AppThemeBinding.cs
+++ b/src/Controls/src/Core/AppThemeBinding.cs
@@ -8,10 +8,37 @@ namespace Microsoft.Maui.Controls
 {
 	class AppThemeBinding : BindingBase
 	{
+		class AppThemeProxy : Element
+		{
+			public AppThemeProxy(Element parent, AppThemeBinding binding)
+			{
+				_parent = parent;
+				Binding = binding;
+				this.SetDynamicResource(AppThemeProperty, "__ApplicationTheme__");
+				((IElementDefinition)parent).AddResourcesChangedListener(OnParentResourcesChanged);
+			}
+
+			public static BindableProperty AppThemeProperty = BindableProperty.Create("AppTheme", typeof(AppTheme), typeof(AppThemeBinding), AppTheme.Unspecified,
+				propertyChanged: (bindable, oldValue, newValue) => ((AppThemeProxy)bindable).OnAppThemeChanged());
+			readonly Element _parent;
+
+			public void OnAppThemeChanged()
+			{
+				Binding.Apply(false);
+			}
+
+			public AppThemeBinding Binding { get; }
+
+			public void Unsubscribe()
+			{
+				((IElementDefinition)_parent).RemoveResourcesChangedListener(OnParentResourcesChanged);
+			}
+		}
+
 		WeakReference<BindableObject> _weakTarget;
 		BindableProperty _targetProperty;
-		bool _attached;
 		SetterSpecificity specificity;
+		AppThemeProxy _appThemeProxy;
 
 		internal override BindingBase Clone()
 		{
@@ -34,7 +61,6 @@ namespace Microsoft.Maui.Controls
 		{
 			base.Apply(fromTarget);
 			ApplyCore();
-			SetAttached(true);
 		}
 
 		internal override void Apply(object context, BindableObject bindObj, BindableProperty targetProperty, bool fromBindingContextChanged, SetterSpecificity specificity)
@@ -44,12 +70,15 @@ namespace Microsoft.Maui.Controls
 			base.Apply(context, bindObj, targetProperty, fromBindingContextChanged, specificity);
 			this.specificity = specificity;
 			ApplyCore(false);
-			SetAttached(true);
+			_appThemeProxy = new AppThemeProxy(bindObj as Element, this);
+
 		}
 
 		internal override void Unapply(bool fromBindingContextChanged = false)
 		{
-			SetAttached(false);
+			_appThemeProxy?.Unsubscribe();
+			_appThemeProxy = null;
+
 			base.Unapply(fromBindingContextChanged);
 			_weakTarget = null;
 			_targetProperty = null;
@@ -62,7 +91,6 @@ namespace Microsoft.Maui.Controls
 		{
 			if (_weakTarget == null || !_weakTarget.TryGetTarget(out var target))
 			{
-				SetAttached(false);
 				return;
 			}
 
@@ -146,25 +174,6 @@ namespace Microsoft.Maui.Controls
 				AppTheme.Dark => _isDarkSet ? Dark : Default,
 				_ => _isLightSet ? Light : Default,
 			};
-		}
-
-		void SetAttached(bool value)
-		{
-			var app = Application.Current;
-			if (app != null && _attached != value)
-			{
-				if (value)
-				{
-					// Going from false -> true
-					app.RequestedThemeChanged += OnRequestedThemeChanged;
-				}
-				else
-				{
-					// Going from true -> false
-					app.RequestedThemeChanged -= OnRequestedThemeChanged;
-				}
-				_attached = value;
-			}
 		}
 	}
 }

--- a/src/Controls/src/Core/AppThemeBinding.cs
+++ b/src/Controls/src/Core/AppThemeBinding.cs
@@ -8,13 +8,14 @@ namespace Microsoft.Maui.Controls
 {
 	class AppThemeBinding : BindingBase
 	{
+		public const string AppThemeResource = "__MAUI_ApplicationTheme__";
 		class AppThemeProxy : Element
 		{
 			public AppThemeProxy(Element parent, AppThemeBinding binding)
 			{
 				_parent = parent;
 				Binding = binding;
-				this.SetDynamicResource(AppThemeProperty, "__ApplicationTheme__");
+				this.SetDynamicResource(AppThemeProperty, AppThemeResource);
 				((IElementDefinition)parent).AddResourcesChangedListener(OnParentResourcesChanged);
 			}
 

--- a/src/Controls/src/Core/Application/Application.cs
+++ b/src/Controls/src/Core/Application/Application.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Maui.Controls
 				if (value is not null)
 				{
 					OnParentResourcesChanged(this.GetMergedResources());
-					OnParentResourcesChanged([new KeyValuePair<string, object>("__ApplicationTheme__", _lastAppTheme)]);
+					OnParentResourcesChanged([new KeyValuePair<string, object>(AppThemeBinding.AppThemeResource, _lastAppTheme)]);
 					((IElementDefinition)this).AddResourcesChangedListener(value.OnParentResourcesChanged);
 				} else if (MainPage is not null)
 				{
@@ -252,7 +252,7 @@ namespace Microsoft.Maui.Controls
 				_themeChangedFiring = true;
 				_lastAppTheme = newTheme;
 
-				OnParentResourcesChanged([new KeyValuePair<string, object>("__ApplicationTheme__", newTheme)]);
+				OnParentResourcesChanged([new KeyValuePair<string, object>(AppThemeBinding.AppThemeResource, newTheme)]);
 				_weakEventManager.HandleEvent(this, new AppThemeChangedEventArgs(newTheme), nameof(RequestedThemeChanged));
 			}
 			finally

--- a/src/Controls/src/Core/Application/Application.cs
+++ b/src/Controls/src/Core/Application/Application.cs
@@ -101,6 +101,15 @@ namespace Microsoft.Maui.Controls
 
 				_singleWindowMainPage = value;
 
+				if (value is not null)
+				{
+					OnParentResourcesChanged(this.GetMergedResources());
+					OnParentResourcesChanged([new KeyValuePair<string, object>("__ApplicationTheme__", _lastAppTheme)]);
+					((IElementDefinition)this).AddResourcesChangedListener(value.OnParentResourcesChanged);
+				} else if (MainPage is not null)
+				{
+					((IElementDefinition)this).RemoveResourcesChangedListener(MainPage.OnParentResourcesChanged);
+				}
 				if (Windows.Count == 1)
 				{
 					Windows[0].Page = value;
@@ -243,6 +252,7 @@ namespace Microsoft.Maui.Controls
 				_themeChangedFiring = true;
 				_lastAppTheme = newTheme;
 
+				OnParentResourcesChanged([new KeyValuePair<string, object>("__ApplicationTheme__", newTheme)]);
 				_weakEventManager.HandleEvent(this, new AppThemeChangedEventArgs(newTheme), nameof(RequestedThemeChanged));
 			}
 			finally

--- a/src/Controls/src/Core/Shell/Shell.cs
+++ b/src/Controls/src/Core/Shell/Shell.cs
@@ -827,10 +827,12 @@ namespace Microsoft.Maui.Controls
 				return;
 
 			if (args.NewHandler == null)
+#pragma warning disable CS0618 // Type or member is obsolete
 				Application.Current.RequestedThemeChanged -= OnRequestedThemeChanged;
 
 			if (args.NewHandler != null && args.OldHandler == null)
 				Application.Current.RequestedThemeChanged += OnRequestedThemeChanged;
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 
 		private void OnRequestedThemeChanged(object sender, AppThemeChangedEventArgs e)

--- a/src/Controls/tests/Core.UnitTests/AppThemeTests.cs
+++ b/src/Controls/tests/Core.UnitTests/AppThemeTests.cs
@@ -34,6 +34,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			{
 				Text = "Green on Light, Red on Dark"
 			};
+			app.LoadPage(new ContentPage {Content = label});
 
 			label.SetAppThemeColor(Label.TextColorProperty, Colors.Green, Colors.Red);
 			Assert.Equal(Colors.Green, label.TextColor);
@@ -46,10 +47,13 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		[Fact]
 		public void ThemeChangeUsingSetAppTheme()
 		{
+
 			var label = new Label
 			{
 				Text = "Green on Light, Red on Dark"
 			};
+
+			app.LoadPage(new ContentPage {Content = label});
 
 			label.SetAppTheme(Label.TextColorProperty, Colors.Green, Colors.Red);
 			Assert.Equal(Colors.Green, label.TextColor);
@@ -66,6 +70,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			{
 				Text = "Green on Light, Red on Dark"
 			};
+			app.LoadPage(new ContentPage {Content = label});
 
 			label.SetBinding(Label.TextColorProperty, new AppThemeBinding { Light = Colors.Green, Dark = Colors.Red });
 			Assert.Equal(Colors.Green, label.TextColor);
@@ -82,6 +87,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			{
 				Text = "Green on Light, Red on Dark"
 			};
+			app.LoadPage(new ContentPage {Content = label});
 
 			label.SetAppThemeColor(Label.TextColorProperty, Colors.Green, Colors.Red);
 			Assert.Equal(Colors.Green, label.TextColor);
@@ -225,6 +231,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			{
 				Text = "Green on Light, Red on Dark"
 			};
+			app.LoadPage(new ContentPage {Content = label});
 
 			label.SetAppThemeColor(Label.TextColorProperty, Colors.Green, Colors.Red);
 

--- a/src/Controls/tests/Core.UnitTests/DynamicResourceTests.cs
+++ b/src/Controls/tests/Core.UnitTests/DynamicResourceTests.cs
@@ -107,8 +107,9 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			var label = new Label();
 			label.SetDynamicResource(Label.TextProperty, "foo");
 			Assert.Equal(Label.TextProperty.DefaultValue, label.Text);
-			label.Resources = new ResourceDictionary();
-			label.Resources.Add("foo", "FOO");
+			label.Resources = new ResourceDictionary {
+				{ "foo", "FOO" }
+			};
 			Assert.Equal("FOO", label.Text);
 		}
 
@@ -126,8 +127,9 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		[Fact]
 		public void ValueChangedTriggeredOnSubscribeIfKeyAlreadyExists()
 		{
-			var label = new Label();
-			label.Resources = new ResourceDictionary { { "foo", "FOO" } };
+			var label = new Label {
+				Resources = new ResourceDictionary { { "foo", "FOO" } }
+			};
 			Assert.Equal(Label.TextProperty.DefaultValue, label.Text);
 			label.SetDynamicResource(Label.TextProperty, "foo");
 			Assert.Equal("FOO", label.Text);
@@ -136,8 +138,9 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		[Fact]
 		public void RemoveDynamicResourceStopsUpdating()
 		{
-			var label = new Label();
-			label.Resources = new ResourceDictionary { { "foo", "FOO" } };
+			var label = new Label          {
+				Resources = new ResourceDictionary { { "foo", "FOO" } }
+			};
 			Assert.Equal(Label.TextProperty.DefaultValue, label.Text);
 			label.SetDynamicResource(Label.TextProperty, "foo");
 			Assert.Equal("FOO", label.Text);

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui16538.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui16538.xaml.cs
@@ -38,6 +38,7 @@ public partial class Maui16538
 
 			Application.Current.UserAppTheme = AppTheme.Dark;
 			var page = new Maui16538(useCompiledXaml);
+			Application.Current.MainPage = page;
 			Button button = page.button0;
 			Assert.That(button.BackgroundColor, Is.EqualTo(Color.FromHex("404040")));
 			button.IsEnabled = true;


### PR DESCRIPTION
### Description of Change

instead of subscribing to ThemeChanged event, use the ResourcesChanged mechanism of DynamicResource to propagate the change

### Issues Fixed

- related to #8713
- alternative to #19931
- fixes #18505
- fixes #21019

