### PR TITLE
[Windows] Cache full app package file path

### DIFF
--- a/src/Essentials/src/AppInfo/AppInfo.uwp.cs
+++ b/src/Essentials/src/AppInfo/AppInfo.uwp.cs
@@ -114,6 +114,18 @@ namespace Microsoft.Maui.ApplicationModel
 		/// </summary>
 		public static bool IsPackagedApp => _isPackagedAppLazy.Value;
 
+		static readonly Lazy<string> platformGetFullAppPackageFilePath = new Lazy<string>(() =>
+		{
+			return IsPackagedApp
+				? Package.Current.InstalledLocation.Path
+				: AppContext.BaseDirectory;
+		});
+
+		/// <summary>
+		/// Gets full application path.
+		/// </summary>
+		public static string PlatformGetFullAppPackageFilePath => platformGetFullAppPackageFilePath.Value;
+
 		/// <summary>
 		/// Converts a <see cref="PackageVersion"/> object to a <see cref="Version"/> object.
 		/// </summary>

--- a/src/Essentials/src/FileSystem/FileSystemUtils.uwp.cs
+++ b/src/Essentials/src/FileSystem/FileSystemUtils.uwp.cs
@@ -3,7 +3,6 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using Microsoft.Maui.ApplicationModel;
-using Package = Windows.ApplicationModel.Package;
 
 namespace Microsoft.Maui.Storage
 {
@@ -21,14 +20,7 @@ namespace Microsoft.Maui.Storage
 				throw new ArgumentNullException(nameof(filename));
 
 			filename = NormalizePath(filename);
-
-			string root;
-			if (AppInfoUtils.IsPackagedApp)
-				root = Package.Current.InstalledLocation.Path;
-			else
-				root = AppContext.BaseDirectory;
-
-			return Path.Combine(root, filename);
+			return Path.Combine(AppInfoUtils.PlatformGetFullAppPackageFilePath, filename);
 		}
 
 		public static bool TryGetAppPackageFileUri(string filename, [NotNullWhen(true)] out string? uri)


### PR DESCRIPTION
### Description of Change

I have noticed that one can cache `Package.Current.InstalledLocation.Path` to save about 4 ms (measured in Debug mode) for each call of `FileSystemUtils.PlatformGetFullAppPackageFilePath`[^1] because there is no interop call to WinRT[^2].

### Testing

https://github.com/MartyIX/maui/tree/feature/2024-03-16-app-path-optimization-testing (https://github.com/MartyIX/maui/commit/ab01bf43a21ef7be7a9fea0fd65da730d1e16dee)

### Issues Fixed

Contributes to #8594

[^1]: Called for each registered font (see #8594). 
[^2]: Please correct me if I got it wrong.