### PR TITLE
[ios] avoid duplicating `CALayer.Sublayer` arrays

### DIFF
--- a/src/Compatibility/Core/src/MacOS/Extensions/BrushExtensions.cs
+++ b/src/Compatibility/Core/src/MacOS/Extensions/BrushExtensions.cs
@@ -156,10 +156,11 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.MacOS
 				if (layer.Name == BackgroundLayer)
 					layer?.RemoveFromSuperLayer();
 
-				if (layer.Sublayers == null || layer.Sublayers.Count() == 0)
+				var sublayers = layer.Sublayers;
+				if (sublayers is null || sublayers.Length == 0)
 					return;
 
-				foreach (var subLayer in layer.Sublayers)
+				foreach (var subLayer in sublayers)
 				{
 					if (subLayer.Name == BackgroundLayer)
 						subLayer?.RemoveFromSuperLayer();

--- a/src/Controls/src/Core/Platform/iOS/Extensions/BrushExtensions.cs
+++ b/src/Controls/src/Core/Platform/iOS/Extensions/BrushExtensions.cs
@@ -164,10 +164,11 @@ namespace Microsoft.Maui.Controls.Platform
 				if (layer.Name == BackgroundLayer)
 					layer?.RemoveFromSuperLayer();
 
-				if (layer.Sublayers == null || layer.Sublayers.Count() == 0)
+				var sublayers = layer.Sublayers;
+				if (sublayers is null || sublayers.Length == 0)
 					return;
 
-				foreach (var subLayer in layer.Sublayers)
+				foreach (var subLayer in sublayers)
 				{
 					if (subLayer.Name == BackgroundLayer)
 						subLayer?.RemoveFromSuperLayer();
@@ -187,9 +188,10 @@ namespace Microsoft.Maui.Controls.Platform
 
 		static void UpdateBackgroundLayer(this CALayer layer, CGRect bounds)
 		{
-			if (layer != null && layer.Sublayers != null)
+			var sublayers = layer?.Sublayers;
+			if (sublayers is not null)
 			{
-				foreach (var sublayer in layer.Sublayers)
+				foreach (var sublayer in sublayers)
 				{
 					UpdateBackgroundLayer(sublayer, bounds);
 

--- a/src/Core/src/Platform/iOS/LayerExtensions.cs
+++ b/src/Core/src/Platform/iOS/LayerExtensions.cs
@@ -34,10 +34,11 @@ namespace Microsoft.Maui.Platform
 				return;
 			}
 
-			if (layer.Sublayers == null || layer.Sublayers.Length == 0)
+			var sublayers = layer.Sublayers;
+			if (sublayers is null || sublayers.Length == 0)
 				return;
 
-			foreach (var subLayer in layer.Sublayers)
+			foreach (var subLayer in sublayers)
 			{
 				if (subLayer.Name == ViewExtensions.BackgroundLayerName)
 				{

--- a/src/Core/src/Platform/iOS/StrokeExtensions.cs
+++ b/src/Core/src/Platform/iOS/StrokeExtensions.cs
@@ -161,9 +161,10 @@ namespace Microsoft.Maui.Platform
 
 		static void UpdateBackgroundLayer(this CALayer layer, CGRect bounds)
 		{
-			if (layer != null && layer.Sublayers != null)
+			var sublayers = layer?.Sublayers;
+			if (sublayers is not null)
 			{
-				foreach (var sublayer in layer.Sublayers)
+				foreach (var sublayer in sublayers)
 				{
 					UpdateBackgroundLayer(sublayer, bounds);
 

--- a/src/Core/src/Platform/iOS/ViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/ViewExtensions.cs
@@ -250,12 +250,11 @@ namespace Microsoft.Maui.Platform
 			if (view == null || view.Frame.IsEmpty)
 				return;
 
-			var layer = view.Layer;
-
-			if (layer == null || layer.Sublayers == null || layer.Sublayers.Length == 0)
+			var sublayers = view.Layer?.Sublayers;
+			if (sublayers is null || sublayers.Length == 0)
 				return;
 
-			foreach (var sublayer in layer.Sublayers)
+			foreach (var sublayer in sublayers)
 			{
 				if (sublayer.Name == BackgroundLayerName && sublayer.Frame != view.Bounds)
 				{

--- a/src/Core/src/Platform/iOS/WrapperView.cs
+++ b/src/Core/src/Platform/iOS/WrapperView.cs
@@ -255,10 +255,11 @@ namespace Microsoft.Maui.Platform
 
 		CALayer? GetLayer()
 		{
-			if (Layer is null || Layer.Sublayers is null)
+			var sublayers = Layer?.Sublayers;
+			if (sublayers is null)
 				return null;
 
-			foreach (var subLayer in Layer.Sublayers)
+			foreach (var subLayer in sublayers)
 				if (subLayer.Delegate is not null)
 					return subLayer;
 
@@ -267,10 +268,11 @@ namespace Microsoft.Maui.Platform
 
 		CALayer? GetBackgroundLayer()
 		{
-			if (Layer is null || Layer.Sublayers is null)
+			var sublayers = Layer?.Sublayers;
+			if (sublayers is null)
 				return null;
 
-			foreach (var subLayer in Layer.Sublayers)
+			foreach (var subLayer in sublayers)
 				if (subLayer.Name == ViewExtensions.BackgroundLayerName)
 					return subLayer;
 

--- a/src/Essentials/src/Screenshot/Screenshot.ios.cs
+++ b/src/Essentials/src/Screenshot/Screenshot.ios.cs
@@ -137,10 +137,11 @@ namespace Microsoft.Maui.Media
 
 		static void HideSublayers(CALayer layer, Dictionary<CALayer, bool> visibilitySnapshot)
 		{
-			if (layer.Sublayers == null)
+			var sublayers = layer?.Sublayers;
+			if (sublayers is null)
 				return;
 
-			foreach (var sublayer in layer.Sublayers)
+			foreach (var sublayer in sublayers)
 			{
 				HideSublayers(sublayer, visibilitySnapshot);
 


### PR DESCRIPTION
Context: https://discord.com/channels/732297728826277939/732297808148824115/1219383992067821608

In a customer's application, they saw in Xcode's Instruments:

    4.4% Microsoft_Maui_Platform_StokeExtensions_UpdateBackgroundLayer_CoreAnimation_CALayer_CoreGraphics_CGRect
    >   2.7% CoreAnimation_CALayer_get_Sublayers

Reviewing the code, there is a performance problem:

    if (layer != null && layer.Sublayers != null)
    {
        foreach (var sublayer in layer.Sublayers)
        {
            //...
        }
    }

This accesses `CALayer.Sublayers` twice:

1. null check

2. `foreach`

When C# calls into Objective-C here, the returned array is marshaled and copied to a C# array that can be consumed in managed code. We are doing this work twice!

I audited all calls to `CALayer.Sublayers` and found that we can avoid this in places that are called frequently.

This should improve the performance of all views on iOS or Catalyst. However, I don't have access to the customer's application to test the difference. We can have them try a nightly MAUI build after this is merged.