### PR TITLE
Add Apple Privacy Manifest to new project template

### DIFF
--- a/src/Templates/src/templates/maui-blazor/Platforms/iOS/Resources/PrivacyInfo.xcprivacy
+++ b/src/Templates/src/templates/maui-blazor/Platforms/iOS/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+This is the minimum required version of the Apple Privacy Manifest for .NET MAUI apps.
+The contents below are needed because of APIs that are used in the .NET framework and .NET MAUI SDK.
+
+You are responsible for adding extra entries as needed for your application.
+
+More information: https://aka.ms/maui-privacy-manifest
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>NSPrivacyAccessedAPITypes</key>
+    <array>
+        <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>C617.1</string>
+            </array>
+        </dict>
+        <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategorySystemBootTime</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>35F9.1</string>
+            </array>
+        </dict>
+        <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryDiskSpace</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>E174.1</string>
+            </array>
+        </dict>
+        <!--
+            The entry below is only needed when you're using the Preferences API in your app.
+        <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>CA92.1</string>
+            </array>
+        </dict> -->
+    </array>
+</dict>
+</plist>

--- a/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
+++ b/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
@@ -61,5 +61,5 @@
 		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="MS_EXT_LOG_DEBUG_VERSION" />
 	</ItemGroup>
-	
+
 </Project>

--- a/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
+++ b/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
@@ -61,5 +61,5 @@
 		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="MS_EXT_LOG_DEBUG_VERSION" />
 	</ItemGroup>
-
+	
 </Project>

--- a/src/Templates/src/templates/maui-mobile/Platforms/iOS/Resources/PrivacyInfo.xcprivacy
+++ b/src/Templates/src/templates/maui-mobile/Platforms/iOS/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+This is the minimum required version of the Apple Privacy Manifest for .NET MAUI apps.
+The contents below are needed because of APIs that are used in the .NET framework and .NET MAUI SDK.
+
+You are responsible for adding extra entries as needed for your application.
+
+More information: https://aka.ms/maui-privacy-manifest
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>NSPrivacyAccessedAPITypes</key>
+    <array>
+        <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>C617.1</string>
+            </array>
+        </dict>
+        <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategorySystemBootTime</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>35F9.1</string>
+            </array>
+        </dict>
+        <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryDiskSpace</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>E174.1</string>
+            </array>
+        </dict>
+        <!--
+            The entry below is only needed when you're using the Preferences API in your app.
+        <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>CA92.1</string>
+            </array>
+        </dict> -->
+    </array>
+</dict>
+</plist>

--- a/src/Templates/src/templates/maui-multiproject/MauiApp.1.iOS/Resources/PrivacyInfo.xcprivacy
+++ b/src/Templates/src/templates/maui-multiproject/MauiApp.1.iOS/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+This is the minimum required version of the Apple Privacy Manifest for .NET MAUI apps.
+The contents below are needed because of APIs that are used in the .NET framework and .NET MAUI SDK.
+
+You are responsible for adding extra entries as needed for your application.
+
+More information: https://aka.ms/maui-privacy-manifest
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>NSPrivacyAccessedAPITypes</key>
+    <array>
+        <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>C617.1</string>
+            </array>
+        </dict>
+        <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategorySystemBootTime</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>35F9.1</string>
+            </array>
+        </dict>
+        <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryDiskSpace</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>E174.1</string>
+            </array>
+        </dict>
+        <!--
+            The entry below is only needed when you're using the Preferences API in your app.
+        <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>CA92.1</string>
+            </array>
+        </dict> -->
+    </array>
+</dict>
+</plist>


### PR DESCRIPTION
### Description of Change

This adds the Apple Privacy Manifest, minimal version needed for a .NET MAUI app, to the default templates so that people don't have to add this manually.

One of the entries is commented out by default, when not explicitly using the Preferences APIs this is not needed as it will be trimmed when you publish your app. If you do use the Preferences APIs, uncomment the entry.

More information: https://aka.ms/maui-privacy-manifest

If you find this and are wondering how to deal with this in your already existing project: you should be able to take the contents from the `PrivacyInfo.xcprivacy` file and put that in your project. Then make sure that that file ends up in the root of your app bundle, this PR also shows you what changes to make for that in your csproj.