### PR TITLE
Revert "[iOS] Clear BindingContext when cell is queued for reuse (#14…

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewDelegator.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewDelegator.cs
@@ -107,21 +107,8 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		}
 
 		public override void CellDisplayingEnded(UICollectionView collectionView, UICollectionViewCell cell, NSIndexPath indexPath)
-		{
-			if (cell is TemplatedCell templatedCell &&
-				(templatedCell.PlatformHandler?.VirtualView as View)?.BindingContext is object bindingContext)
-			{
-				// We want to unbind a cell that is no longer present in the items source. Unfortunately
-				// it's too expensive to check directly, so let's check that the current binding context
-				// matches the item at a given position.
-
-				var itemsSource = ViewController?.ItemsSource;
-				if (itemsSource is null ||
-					!itemsSource.IsIndexPathValid(indexPath) ||
-					!Equals(itemsSource[indexPath], bindingContext))
-				{
-					templatedCell.Unbind();
-				}
+		{			
+			
 			}
 		}
 

--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewDelegator.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewDelegator.cs
@@ -107,9 +107,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		}
 
 		public override void CellDisplayingEnded(UICollectionView collectionView, UICollectionViewCell cell, NSIndexPath indexPath)
-		{			
-			
-			}
+		{
 		}
 
 		protected virtual (bool VisibleItems, NSIndexPath First, NSIndexPath Center, NSIndexPath Last) GetVisibleItemsIndexPath()

--- a/src/Controls/src/Core/Handlers/Items/iOS/TemplatedCell.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/TemplatedCell.cs
@@ -58,15 +58,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			ConstrainedDimension = default;
 		}
 
-		internal void Unbind()
-		{
-			if (PlatformHandler?.VirtualView is View view)
-			{
-				view.MeasureInvalidated -= MeasureInvalidated;
-				view.BindingContext = null;
-			}
-		}
-
 		public override UICollectionViewLayoutAttributes PreferredLayoutAttributesFittingAttributes(
 			UICollectionViewLayoutAttributes layoutAttributes)
 		{
@@ -125,12 +116,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			_size = rectangle.Size;
 		}
 
-		public override void PrepareForReuse()
-		{
-			Unbind();
-			base.PrepareForReuse();
-		}
-
 		public void Bind(DataTemplate template, object bindingContext, ItemsView itemsView)
 		{
 			var oldElement = PlatformHandler?.VirtualView as View;
@@ -172,10 +157,18 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				// Same template
 				if (oldElement != null)
 				{
-					oldElement.BindingContext = bindingContext;
-					oldElement.MeasureInvalidated += MeasureInvalidated;
+					if (oldElement.BindingContext == null || !(oldElement.BindingContext.Equals(bindingContext)))
+					{
+						// If the data is different, update it
 
-					UpdateCellSize();
+						// Unhook the MeasureInvalidated handler, otherwise it'll fire for every invalidation during the 
+						// BindingContext change
+						oldElement.MeasureInvalidated -= MeasureInvalidated;
+						oldElement.BindingContext = bindingContext;
+						oldElement.MeasureInvalidated += MeasureInvalidated;
+
+						UpdateCellSize();
+					}
 				}
 			}
 

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -108,7 +108,6 @@ Microsoft.Maui.Controls.Region.Equals(Microsoft.Maui.Controls.Region other) -> b
 Microsoft.Maui.Controls.Shapes.Matrix.Equals(Microsoft.Maui.Controls.Shapes.Matrix other) -> bool
 Microsoft.Maui.Controls.Shapes.Shape.~Shape() -> void
 Microsoft.Maui.Controls.VisualElement.~VisualElement() -> void
-override Microsoft.Maui.Controls.Handlers.Items.TemplatedCell.PrepareForReuse() -> void
 override Microsoft.Maui.Controls.Handlers.Compatibility.PhoneFlyoutPageRenderer.ViewWillLayoutSubviews() -> void
 override Microsoft.Maui.Controls.LayoutOptions.GetHashCode() -> int
 override Microsoft.Maui.Controls.Platform.Compatibility.ShellPageRendererTracker.TitleViewContainer.LayoutSubviews() -> void

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -107,7 +107,6 @@ Microsoft.Maui.Controls.Region.Equals(Microsoft.Maui.Controls.Region other) -> b
 Microsoft.Maui.Controls.Shapes.Matrix.Equals(Microsoft.Maui.Controls.Shapes.Matrix other) -> bool
 Microsoft.Maui.Controls.Shapes.Shape.~Shape() -> void
 Microsoft.Maui.Controls.VisualElement.~VisualElement() -> void
-override Microsoft.Maui.Controls.Handlers.Items.TemplatedCell.PrepareForReuse() -> void
 override Microsoft.Maui.Controls.Handlers.Compatibility.PhoneFlyoutPageRenderer.ViewWillLayoutSubviews() -> void
 override Microsoft.Maui.Controls.LayoutOptions.GetHashCode() -> int
 override Microsoft.Maui.Controls.Platform.Compatibility.ShellPageRendererTracker.TitleViewContainer.LayoutSubviews() -> void

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.cs
@@ -397,71 +397,7 @@ namespace Microsoft.Maui.DeviceTests
 				timeout -= interval;
 			}
 		}
-
-		[Fact]
-		public async Task ClearingItemsSourceClearsBindingContext()
-		{
-			SetupBuilder();
-
-			IReadOnlyList<Element> logicalChildren = null;
-			var collectionView = new CollectionView
-			{
-				ItemTemplate = new DataTemplate(() => new Label() { HeightRequest = 30, WidthRequest = 200 }),
-				WidthRequest = 200,
-				HeightRequest = 200,
-			};
-
-			await CreateHandlerAndAddToWindow<CollectionViewHandler>(collectionView, async handler =>
-			{
-				var data = new ObservableCollection<MyRecord>()
-				{
-					new MyRecord("Item 1"),
-					new MyRecord("Item 2"),
-					new MyRecord("Item 3"),
-				};
-				collectionView.ItemsSource = data;
-				await Task.Delay(100);
-
-				logicalChildren = collectionView.LogicalChildrenInternal;
-				Assert.NotNull(logicalChildren);
-				Assert.True(logicalChildren.Count == 3);
-
-				// Clear collection
-				var savedItems = data.ToArray();
-				data.Clear();
-
-				await Task.Delay(100);
-
-				// Check that all logical children have no binding context
-				foreach (var logicalChild in logicalChildren)
-				{
-					Assert.Null(logicalChild.BindingContext);
-				}
-
-				// Re-add the old children
-				foreach (var savedItem in savedItems)
-				{
-					data.Add(savedItem);
-				}
-
-				await Task.Delay(100);
-
-				// Check that the right number of logical children have binding context again
-				int boundChildren = 0;
-				foreach (var logicalChild in logicalChildren)
-				{
-					if (logicalChild.BindingContext is not null)
-					{
-						boundChildren++;
-					}
-				}
-				Assert.Equal(3, boundChildren);
-			});
-		}
-
-		record MyRecord(string Name);
-
-
+		
 		[Fact]
 		public async Task SettingSelectedItemAfterModifyingCollectionDoesntCrash()
 		{


### PR DESCRIPTION
### Description of Change

Revert https://github.com/dotnet/maui/pull/14619

It looks like this change caused the following "regression" https://github.com/dotnet/maui/issues/21374.

From testing I don't think this change directly caused the regression, but I think it exposed a flaw in the prototype code that now only surfaces because of that PR.

The prototype code inside ItemsViewLayout creates a prototype cell to measure with if no cells have been measured yet. This creates a phantom `TemplatedCell` that gets added to the logical children and causes there to be two `TemplatedCells` for the same `View`

I did a quick test just returning the results of the prototype cell without creating it and it no longer crashes. So, I think we need to rework the prototype cells a bit for SR4

![image](https://github.com/dotnet/maui/assets/5375137/46ac7939-bb58-45c3-a6c5-f974bb1f94dc)



