### PR TITLE
Still measure children if size is known on CV

### DIFF
--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issue7562.xaml
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issue7562.xaml
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage 
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Maui.Controls.Sample.Issues.Issue7562">
+    <Grid>
+        <CollectionView ItemsSource="{Binding Issues}" ItemSizingStrategy="MeasureFirstItem">
+            <CollectionView.ItemTemplate>
+                <DataTemplate>
+                    <Grid>
+                        <Label Text="{Binding Title, Mode=OneWay}"
+                        TextColor="Red"
+                        IsVisible="{Binding IsRed}"
+                            />
+
+                        <Label Text="{Binding Title, Mode=OneWay}"
+                        TextColor="Green" AutomationId="{Binding Title}"
+                        IsVisible="{Binding IsGreen}" />
+                    </Grid>
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+        </CollectionView>
+    </Grid>
+</ContentPage>

--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issue7562.xaml.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issue7562.xaml.cs
@@ -1,0 +1,53 @@
+﻿using System.Collections.ObjectModel;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Maui;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Platform;
+
+namespace Maui.Controls.Sample.Issues
+{
+	[Issue(IssueTracker.Github, 7562, "MeasureFirstItem makes items disappear on Android", PlatformAffected.Android)]
+	public partial class Issue7562 : ContentPage
+	{
+		public ObservableCollection<Issue> Issues { get; } = new ObservableCollection<Issue>();
+
+		public Issue7562()
+		{
+			InitializeComponent();
+			BindingContext = this;
+			this.Loaded += OnLoaded;
+		}
+
+		async void OnLoaded(object sender, System.EventArgs e)
+		{
+			await Task.Yield();
+			Issues[0].MakeGreen();
+			Issues[1].MakeGreen();
+			this.Loaded -= OnLoaded;
+		}
+
+		public class Issue : BindableObject
+		{
+			public string Title { get; set; }
+			public bool IsRed { get; set; } = true;
+			public bool IsGreen => !IsRed;
+
+			public void MakeGreen()
+			{
+				IsRed = false;
+				OnPropertyChanged(nameof(IsGreen));
+				OnPropertyChanged(nameof(IsRed));
+			}
+		}
+
+		protected override void OnAppearing()
+		{
+			base.OnAppearing();
+
+			Issues.Add(new Issue { Title = "Issue1" });
+			Issues.Add(new Issue { Title = "Issue2" });
+			Issues.Add(new Issue { Title = "Issue3" });
+		}
+	}
+}

--- a/src/Controls/src/Core/Handlers/Items/Android/ItemContentView.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/ItemContentView.cs
@@ -83,26 +83,39 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				return;
 			}
 
-			if (_size != null)
+			// If we're using ItemSizingStrategy.MeasureFirstItem and now we have a set size, use that
+			// Even though we already know the size we still need to pass the measure through to the children.
+			if (_size is not null)
 			{
-				// If we're using ItemSizingStrategy.MeasureFirstItem and now we have a set size, use that
-				SetMeasuredDimension((int)_size.Value.Width, (int)_size.Value.Height);
+				var w = (int)_size.Value.Width;
+				var h = (int)_size.Value.Height;
+
+				// If the platform childs measure has been invalidated, it's going to still want to
+				// participate in the measure lifecycle in order to update its internal
+				// book keeping.
+				_ = View.Measure
+					(
+						MeasureSpec.MakeMeasureSpec(w, MeasureSpecMode.Exactly),
+						MeasureSpec.MakeMeasureSpec(h, MeasureSpecMode.Exactly)
+					);
+
+				SetMeasuredDimension(w, h);
 				return;
 			}
 
 			int pixelWidth = MeasureSpec.GetSize(widthMeasureSpec);
 			int pixelHeight = MeasureSpec.GetSize(heightMeasureSpec);
 
-			var width = MeasureSpec.GetMode(widthMeasureSpec) == MeasureSpecMode.Unspecified
+			var widthSpec = MeasureSpec.GetMode(widthMeasureSpec) == MeasureSpecMode.Unspecified
 				? double.PositiveInfinity
 				: this.FromPixels(pixelWidth);
 
-			var height = MeasureSpec.GetMode(heightMeasureSpec) == MeasureSpecMode.Unspecified
+			var heightSpec = MeasureSpec.GetMode(heightMeasureSpec) == MeasureSpecMode.Unspecified
 				? double.PositiveInfinity
 				: this.FromPixels(pixelHeight);
 
 
-			var measure = View.Measure(width, height);
+			var measure = View.Measure(widthSpec, heightSpec);
 
 			if (pixelWidth == 0)
 			{

--- a/src/Controls/tests/UITests/Tests/Issues/Issue7562.cs
+++ b/src/Controls/tests/UITests/Tests/Issues/Issue7562.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.AppiumTests.Issues
+{
+	public class Issue7562 : _IssuesUITest
+	{
+		public override string Issue => "MeasureFirstItem makes items disappear on Android";
+		public Issue7562(TestDevice device) : base(device)
+		{
+		}
+
+		[Test]
+		[Category(UITestCategories.CollectionView)]
+		public void MeasureFirstItemMakesItemsDisappearOnAndroid()
+		{
+			App.WaitForElement("Issue2");
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change

On Android, even you if you already know the size your children, you still need to call "measure" so it can update its internal bookkeeping. If the layout cycle was caused by the measure on the child being invalidated, then it's going to expect its `OnMeasure` call to happen. This is also important if for some reason the "Firstitem" size gets updated and reused cells need to be remeasured. Android requires you to call "measure" so it can update its MeasuredWidth and MeasuredHeight values to use during arrange. 

### Issues Fixed

Fixes #7562
