### PR TITLE
[X] Only show x:DataType warnings when using NativeAOT

### DIFF
--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
@@ -146,11 +146,15 @@
 		Inputs="$(IntermediateOutputPath)$(TargetFileName)"
 		Outputs="$(IntermediateOutputPath)XamlC.stamp"
 		Condition=" '$(DesignTimeBuild)' != 'True' AND '@(MauiXaml)' != ''">
-	    <PropertyGroup>
-		<_MauiXamlCValidateOnly>$(MauiXamlCValidateOnly)</_MauiXamlCValidateOnly>
-		<_MauiXamlCValidateOnly Condition="'$(Configuration)' == 'Debug' AND '$(_MauiForceXamlCForDebug)' != 'True'">True</_MauiXamlCValidateOnly>
-		<_MauiXamlCValidateOnly Condition="'$(BuildingForLiveUnitTesting)' == 'True' ">True</_MauiXamlCValidateOnly>
-	    </PropertyGroup>
+		<PropertyGroup>
+			<_MauiXamlCValidateOnly>$(MauiXamlCValidateOnly)</_MauiXamlCValidateOnly>
+			<_MauiXamlCValidateOnly Condition="'$(Configuration)' == 'Debug' AND '$(_MauiForceXamlCForDebug)' != 'True'">True</_MauiXamlCValidateOnly>
+			<_MauiXamlCValidateOnly Condition="'$(BuildingForLiveUnitTesting)' == 'True' ">True</_MauiXamlCValidateOnly>
+
+			<MauiStrictXamlCompilation Condition="'$(MauiStrictXamlCompilation)' == '' and '$(PublishAot)' == 'true'">true</MauiStrictXamlCompilation>
+			<_MauiXamlCNoWarn>$(NoWarn)</_MauiXamlCNoWarn>
+			<_MauiXamlCNoWarn Condition="'$(MauiStrictXamlCompilation)' != 'true'">$(_MauiXamlCNoWarn);XC0022;XC0023</_MauiXamlCNoWarn>
+		</PropertyGroup>
 		<XamlCTask
 			Assembly = "$(IntermediateOutputPath)$(TargetFileName)"
 			ReferencePath = "@(ReferencePath)"
@@ -164,7 +168,7 @@
 
       WarningLevel = "$(WarningLevel)"
       TreatWarningsAsErrors = "$(TreatWarningsAsErrors)"
-      NoWarn = "$(NoWarn)"
+      NoWarn = "$(_MauiXamlCNoWarn)"
       WarningsAsErrors = "$(WarningsAsErrors)"
       WarningsNotAsErrors = "$(WarningsNotAsErrors)" />
       


### PR DESCRIPTION
### Description of Change

This is a follow-up to #21281.

Disabling the `x:DataType` related warnings (introduced in #19360) could help reduce friction migrating from Xamarin.Forms to .NET 8. On the other hand, the warning has already been released and some customers might find it useful. For these customers, it would be possible to still enable the warnings by setting `<MauiStrictXamlCompilation>true</MauiStrictXamlCompilation>` in their project file. This "strict compilation" would remain enabled by default for NativeAOT.

### Issues Fixed

Based on feedback in https://github.com/dotnet/maui/discussions/21277

/cc @StephaneDelcroix @rmarinho @PureWeen 