### PR TITLE
Fix for WebView Error when changing page with WebView loading a page

### DIFF
--- a/src/Core/src/Platform/iOS/MauiWebViewUIDelegate.cs
+++ b/src/Core/src/Platform/iOS/MauiWebViewUIDelegate.cs
@@ -22,18 +22,21 @@ namespace Microsoft.Maui.Platform
 			if (!OperatingSystem.IsIOSVersionAtLeast(13))
 				return;
 
+			UIContextMenuConfiguration? uIContextMenuConfiguration = null;
 			foreach (var interaction in webView.Interactions)
 			{
 				if (interaction is MauiUIContextMenuInteraction cmi)
 				{
 					var contextMenu = cmi.GetConfigurationForMenu();
 					if (contextMenu != null)
-						completionHandler(contextMenu);
+					{
+						uIContextMenuConfiguration = contextMenu;
+					}
 
 					break;
 				}
 			}
-
+			completionHandler(uIContextMenuConfiguration!);
 			return;
 		}
 


### PR DESCRIPTION
### Description of Change
Ensure that SetContextMenuConfiguration always calls the completion handler and not just when a MauiUIContextMenuInteraction's configuration is found.

### Issues Fixed
Fixes #20627 
