### PR TITLE
[XC] Fix x:DataType resolution for BindingContext

### DIFF
--- a/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
+++ b/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
@@ -382,14 +382,26 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 
 			INode dataTypeNode = null;
 			IElementNode n = node;
+
+			// Special handling for BindingContext={Binding ...}
+			// The order of checks is:
+			// - x:DataType on the binding itself
+			// - SKIP looking for x:DataType on the parent
+			// - continue looking for x:DataType on the parent's parent...
+			IElementNode skipNode = null;
+			if (IsBindingContextBinding(node))
+			{
+				skipNode = GetParent(node);
+			}
+
 			while (n != null)
 			{
-				if (n.Properties.TryGetValue(XmlName.xDataType, out dataTypeNode))
+				if (n != skipNode && n.Properties.TryGetValue(XmlName.xDataType, out dataTypeNode))
+				{
 					break;
-				if (n.Parent is ListNode listNode)
-					n = listNode.Parent as IElementNode;
-				else
-					n = n.Parent as IElementNode;
+				}
+
+				n = GetParent(n);
 			}
 
 			if (dataTypeNode is null)
@@ -486,6 +498,25 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 				yield return Create(Ldnull);
 			yield return Create(Newobj, module.ImportReference(ctorinforef));
 			yield return Create(Callvirt, module.ImportPropertySetterReference(context.Cache, bindingExtensionType, propertyName: "TypedBinding"));
+
+			static IElementNode GetParent(IElementNode node)
+			{
+				return node switch
+				{
+					{ Parent: ListNode { Parent: IElementNode parentNode } } => parentNode,
+					{ Parent: IElementNode parentNode } => parentNode,
+					_ => null,
+				};
+			}
+
+			static bool IsBindingContextBinding(ElementNode node)
+			{
+				// looking for BindingContext="{Binding ...}"
+				return GetParent(node) is IElementNode parentNode
+					&& ApplyPropertiesVisitor.TryGetPropertyName(node, parentNode, out var propertyName)
+					&& propertyName.NamespaceURI == ""
+					&& propertyName.LocalName == nameof(BindableObject.BindingContext);
+			}
 		}
 
 		static IList<(PropertyDefinition property, TypeReference propDeclTypeRef, string indexArg)> ParsePath(ILContext context, string path, TypeReference tSourceRef, IXmlLineInfo lineInfo, ModuleDefinition module)

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui21434.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui21434.cs
@@ -1,0 +1,54 @@
+using System;
+using Microsoft.Maui.ApplicationModel;
+using Microsoft.Maui.Controls.Core.UnitTests;
+using Microsoft.Maui.Dispatching;
+
+using Microsoft.Maui.UnitTests;
+using NUnit.Framework;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public partial class Maui21434
+{
+    public Maui21434()
+    {
+        InitializeComponent();
+    }
+
+    public Maui21434(bool useCompiledXaml)
+    {
+        //this stub will be replaced at compile time
+    }
+
+    [TestFixture]
+    class Test
+    {
+        [SetUp]
+        public void Setup()
+        {
+            Application.SetCurrentApplication(new MockApplication());
+            DispatcherProvider.SetCurrent(new DispatcherProviderStub());
+        }
+
+        [TearDown] public void TearDown() => AppInfo.SetCurrent(null);
+
+        [Test]
+        public void BindingsDoNotResolveStaticProperties([Values(false, true)] bool useCompiledXaml)
+        {
+            var page = new Maui21434(useCompiledXaml);
+            Assert.That(page.ParentTextLabel?.Text, Is.EqualTo("ParentText"));
+            Assert.That(page.ChildTextLabel?.Text, Is.EqualTo("ChildText"));
+        }
+    }
+}
+
+public class ParentViewModel21434
+{
+    public string Text => "ParentText";
+    public ChildViewModel21434 Child { get; } = new();
+}
+
+public class ChildViewModel21434
+{
+    public string Text => "ChildText";
+}

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui21434.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui21434.xaml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                    xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests"
+                    x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui21434"
+                    x:DataType="local:ParentViewModel21434">
+    <ContentPage.BindingContext>
+        <local:ParentViewModel21434 />
+    </ContentPage.BindingContext>
+
+    <VerticalStackLayout>
+        <Label Text="{Binding Text}" x:Name="ParentTextLabel" />
+        <Label BindingContext="{Binding Child}" Text="{Binding Text}" x:DataType="local:ChildViewModel21434" x:Name="ChildTextLabel" />
+    </VerticalStackLayout>
+</ContentPage>


### PR DESCRIPTION
### Description of Change

There is a difference between how dynamic bindings are applied and how XamlC compiles bindings when it comes to the `BindingContext` property. While the dynamic bindings use the inherited context for the `BindingContext` property, XamlC doesn't. This PR aligns the behaviors.

### Issues Fixed

Fixes #21434

/cc @StephaneDelcroix 