### PR TITLE
Add better exception if user opens second activity

### DIFF
--- a/src/Core/src/Platform/Android/ApplicationExtensions.cs
+++ b/src/Core/src/Platform/Android/ApplicationExtensions.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Maui.Platform
 					$"This window is already associated with an active Activity ({oldActivity.GetType()}). " + 
 					$"Please override CreateWindow on {application.GetType()} "  + 
 					$"to add support for multiple activities https://learn.microsoft.com/en-us/dotnet/maui/fundamentals/windows?view=net-maui-8.0#create-a-window "  + 
-					$"or set the LaunchMode to SingleTask on {activity.GetType()}.");
+					$"or set the LaunchMode to SingleTop on {activity.GetType()}.");
 			}
 
 			activity.SetWindowHandler(window, mauiContext);

--- a/src/Core/src/Platform/Android/ApplicationExtensions.cs
+++ b/src/Core/src/Platform/Android/ApplicationExtensions.cs
@@ -45,6 +45,17 @@ namespace Microsoft.Maui.Platform
 
 			var window = application.CreateWindow(activationState);
 
+			if (window.Handler?.PlatformView is Activity oldActivity && 
+				oldActivity != activity &&
+				!oldActivity.IsDestroyed)
+			{
+				throw new InvalidOperationException(
+					$"This window is already associated with an active Activity ({oldActivity.GetType()}). " + 
+					$"Please override CreateWindow on {application.GetType()} "  + 
+					$"to add support for multiple activities https://learn.microsoft.com/en-us/dotnet/maui/fundamentals/windows?view=net-maui-8.0#create-a-window "  + 
+					$"or set the LaunchMode to SingleTask on {activity.GetType()}.");
+			}
+
 			activity.SetWindowHandler(window, mauiContext);
 		}
 

--- a/src/Core/src/Platform/Android/ApplicationExtensions.cs
+++ b/src/Core/src/Platform/Android/ApplicationExtensions.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Maui.Platform
 				throw new InvalidOperationException(
 					$"This window is already associated with an active Activity ({oldActivity.GetType()}). " + 
 					$"Please override CreateWindow on {application.GetType()} "  + 
-					$"to add support for multiple activities https://learn.microsoft.com/en-us/dotnet/maui/fundamentals/windows?view=net-maui-8.0#create-a-window "  + 
+					$"to add support for multiple activities https://aka.ms/maui-docs-create-window"  + 
 					$"or set the LaunchMode to SingleTop on {activity.GetType()}.");
 			}
 

--- a/src/Core/tests/DeviceTests.Shared/Stubs/CoreApplicationStub.cs
+++ b/src/Core/tests/DeviceTests.Shared/Stubs/CoreApplicationStub.cs
@@ -5,6 +5,8 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 {
 	public class CoreApplicationStub : IApplication
 	{
+		IWindow _singleWindow;
+
 		readonly List<IWindow> _windows = new List<IWindow>();
 
 		public IElementHandler Handler { get; set; }
@@ -17,9 +19,11 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 
 		public IWindow CreateWindow(IActivationState state)
 		{
+			if (_singleWindow is not null)
+				return _singleWindow;
+				
 			_windows.Add(new WindowStub());
-
-			return _windows[0];
+			return _windows.Last();
 		}
 
 		public void OpenWindow(IWindow window)
@@ -33,5 +37,10 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 		}
 
 		public void ThemeChanged() { }
+
+		public void SetSingleWindow(IWindow window)
+		{
+			_singleWindow = window;
+		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/Window/WindowHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Window/WindowHandlerTests.Android.cs
@@ -1,12 +1,41 @@
 ﻿using System.Threading.Tasks;
 using AndroidX.AppCompat.App;
 using Microsoft.Maui.Controls;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
+using Microsoft.Maui.DeviceTests.Stubs;
+using Android.App;
+using System;
 
 namespace Microsoft.Maui.DeviceTests
 {
 	public partial class WindowHandlerTests : CoreHandlerTestBase
 	{
+
+		[Fact]
+		public async Task UsingTheSameWindowThrowsInvalidOperationException()
+		{
+			await InvokeOnMainThreadAsync(() =>
+			{
+				var app = (CoreApplicationStub)MauiContext.Services.GetRequiredService<IApplication>();
+
+				var activity1 = new MauiAppCompatActivity();
+				var activity2 = new MauiAppCompatActivity();
+				
+				activity1.CreatePlatformWindow(app, null);
+
+				var window = app.Windows[0];
+				app.SetSingleWindow(window);
+
+				Assert.Throws<InvalidOperationException>(() =>
+				{
+					activity2.CreatePlatformWindow(app, null);
+				});
+
+			});
+		}
+
+
 		[Fact]
 		public async Task TitleSetsOnWindow()
 		{

--- a/src/Core/tests/DeviceTests/Handlers/Window/WindowHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Window/WindowHandlerTests.Android.cs
@@ -6,6 +6,7 @@ using Xunit;
 using Microsoft.Maui.DeviceTests.Stubs;
 using Android.App;
 using System;
+using Microsoft.Maui.Hosting;
 
 namespace Microsoft.Maui.DeviceTests
 {
@@ -15,9 +16,20 @@ namespace Microsoft.Maui.DeviceTests
 		[Fact]
 		public async Task UsingTheSameWindowThrowsInvalidOperationException()
 		{
+			EnsureHandlerCreated(builder =>
+			{
+				builder.ConfigureMauiHandlers(handlers =>
+				{
+					handlers.AddHandler<WindowStub, WindowHandlerProxyStub>();
+				});
+			});
+
 			await InvokeOnMainThreadAsync(() =>
 			{
 				var app = (CoreApplicationStub)MauiContext.Services.GetRequiredService<IApplication>();
+				var handler = new ApplicationHandler();
+				app.Handler = handler;
+				handler.SetMauiContext(MauiContext);
 
 				var activity1 = new MauiAppCompatActivity();
 				var activity2 = new MauiAppCompatActivity();

--- a/src/Core/tests/DeviceTests/Stubs/WindowHandlerProxyStub.cs
+++ b/src/Core/tests/DeviceTests/Stubs/WindowHandlerProxyStub.cs
@@ -14,6 +14,11 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 {
 	public class WindowHandlerProxyStub : ElementHandler<IWindow, PlatformView>, IWindowHandler
 	{
+		public WindowHandlerProxyStub() : this(new PropertyMapper<IWindow, IWindowHandler>(), new CommandMapper<IWindow, IWindowHandler>())
+		{
+
+		}
+
 		public WindowHandlerProxyStub(IPropertyMapper<IWindow, IWindowHandler> mapper = null, CommandMapper<IWindow, IWindowHandler> commandMapper = null)
 			: base(mapper ?? new PropertyMapper<IWindow, IWindowHandler>(), commandMapper ?? new CommandMapper<IWindow, IWindowHandler>())
 		{

--- a/src/Templates/src/templates/maui-mobile/Platforms/Android/MainActivity.cs
+++ b/src/Templates/src/templates/maui-mobile/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace MauiApp._1;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTask, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/src/Templates/src/templates/maui-mobile/Platforms/Android/MainActivity.cs
+++ b/src/Templates/src/templates/maui-mobile/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace MauiApp._1;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTask, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/src/Templates/src/templates/maui-multiproject/MauiApp.1.Droid/MainActivity.cs
+++ b/src/Templates/src/templates/maui-multiproject/MauiApp.1.Droid/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace MauiApp._1.Droid;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTask, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }

--- a/src/Templates/src/templates/maui-multiproject/MauiApp.1.Droid/MainActivity.cs
+++ b/src/Templates/src/templates/maui-multiproject/MauiApp.1.Droid/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace MauiApp._1.Droid;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTask, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }


### PR DESCRIPTION
### Description of Change

- Add better exception when users hit the scenario where they unknowingly launch a new activity but are reusing a window from a previous activity that hasn't been destroyed
- Modify the templates to set LaunchMode to singleTask because they aren't overriding `CreateWindow` which means they are only compatibile with singleTop launchMode
  

### Concern

A few people have worked around this issue by overriding `OnPostCreate` and ignoring the exception. This PR will break those people but realistically those users should fix the solution correctly opposed to just swallowing the exception.

### Issues Fixed


Fixes #18692
