### PR TITLE
[Trimming] Remove unnecessary regular expressions

### DIFF
--- a/src/Controls/src/Core/Routing.cs
+++ b/src/Controls/src/Core/Routing.cs
@@ -3,7 +3,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using System.Text.RegularExpressions;
 
 namespace Microsoft.Maui.Controls
 {

--- a/src/Controls/src/Xaml/XamlLoader.cs
+++ b/src/Controls/src/Xaml/XamlLoader.cs
@@ -32,7 +32,6 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Text.RegularExpressions;
 using System.Xml;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Controls.Xaml.Diagnostics;
@@ -353,12 +352,85 @@ namespace Microsoft.Maui.Controls.Xaml
 
 				var xaml = reader.ReadToEnd();
 
-				var pattern = $"x:Class *= *\"{type.FullName}\"";
-				var regex = new Regex(pattern, RegexOptions.ECMAScript);
-				if (regex.IsMatch(xaml) || xaml.IndexOf($"x:Class=\"{type.FullName}\"") != -1)
+				if (ContainsXClass(xaml, type.FullName))
+				{
 					return xaml;
+				}
 			}
 			return null;
+
+			// Equivalent to regex $"x:Class *= *\"{fullName}\""
+			static bool ContainsXClass(string xaml, string fullName)
+			{
+				int index = 0;
+				while (index >= 0 && index < xaml.Length)
+				{
+					if (FindNextXClass()
+						&& SkipWhitespaces()
+						&& NextCharacter('=')
+						&& SkipWhitespaces()
+						&& NextCharacter('"')
+						&& NextFullName()
+						&& NextCharacter('"'))
+					{
+						return true;
+					}
+				}
+
+				return false;
+
+				bool FindNextXClass()
+				{
+					const string xClass = "x:Class";
+
+					index = xaml.IndexOf(xClass, startIndex: index);
+					if (index < 0)
+					{
+						return false;
+					}
+
+					index += xClass.Length;
+					return true;
+				}
+				
+				bool SkipWhitespaces()
+				{
+					while (index < xaml.Length && xaml[index] == ' ')
+					{
+						index++;
+					}
+
+					return true;
+				}
+				
+				bool NextCharacter(char character)
+				{
+					if (index < xaml.Length && xaml[index] != character)
+					{
+						return false;
+					}
+
+					index++;
+					return true;
+				}
+
+				bool NextFullName()
+				{
+					if (index >= xaml.Length - fullName.Length)
+					{
+						return false;
+					}
+
+					var slice = xaml.AsSpan().Slice(index, fullName.Length);
+					if (!MemoryExtensions.Equals(slice, fullName.AsSpan(), StringComparison.Ordinal))
+					{
+						return false;
+					}
+
+					index += fullName.Length;
+					return true;
+				}
+			}
 		}
 	}
 }

--- a/src/Core/src/Platform/iOS/KeyboardAutoManagerScroll.cs
+++ b/src/Core/src/Platform/iOS/KeyboardAutoManagerScroll.cs
@@ -6,7 +6,7 @@
  */
 
 using System;
-using System.Text.RegularExpressions;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using CoreGraphics;
@@ -254,8 +254,7 @@ public static class KeyboardAutoManagerScroll
 		if (description is null)
 			return null;
 
-		// remove everything except for numbers and commas
-		var temp = Regex.Replace(description, @"[^0-9,]", "");
+		var temp = RemoveEverythingExceptForNumbersAndCommas(description);
 		var dimensions = temp.Split(',');
 
 		if (dimensions.Length == 4
@@ -268,6 +267,19 @@ public static class KeyboardAutoManagerScroll
 		}
 
 		return null;
+
+		static string RemoveEverythingExceptForNumbersAndCommas(string input)
+		{
+			var sb = new StringBuilder(input.Length);
+			foreach (var character in input)
+			{
+				if (char.IsDigit(character) || character == ',')
+				{
+					sb.Append(character);
+				}
+			}
+			return sb.ToString();
+		}
 	}
 
 	// Used to debounce calls from different oberservers so we can be sure

--- a/src/Graphics/src/Graphics/PathBuilder.cs
+++ b/src/Graphics/src/Graphics/PathBuilder.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
-using System.Text.RegularExpressions;
 
 namespace Microsoft.Maui.Graphics
 {
@@ -117,7 +116,7 @@ namespace Microsoft.Maui.Graphics
 #else
 				pathAsString = pathAsString.Replace("Infinity", "0", StringComparison.Ordinal);
 #endif
-				pathAsString = Regex.Replace(pathAsString, "([a-zA-Z])", " $1 ");
+				pathAsString = SeparateLetterCharsWithSpaces(pathAsString);
 #if NETSTANDARD2_0
 				pathAsString = pathAsString.Replace("-", " -");
 				pathAsString = pathAsString.Replace(" E  -", "E-");
@@ -212,6 +211,25 @@ namespace Microsoft.Maui.Graphics
 #if DEBUG
 				throw;
 #endif
+			}
+
+			static string SeparateLetterCharsWithSpaces(string input)
+			{
+				var sb = new StringBuilder(input.Length, maxCapacity: 3 * input.Length);
+				foreach (var character in input)
+				{
+					if (char.IsLetter(character))
+					{
+						sb.Append(' ');
+						sb.Append(character);
+						sb.Append(' ');
+					}
+					else
+					{
+						sb.Append(character);
+					}
+				}
+				return sb.ToString();
 			}
 
 			return _path;


### PR DESCRIPTION
### Description of Change

There are a few places where we use regular expressions, but we can achieve the same result fairly easily. By refactoring these few methods, we can remove the dependency on System.Text.RegularExpressions.dll completely and shaving off some dead weight. Consider the difference in .ipa size of `dotnet new maui` built with NativeAOT for iOS:

| Before | After | Diff |
| ---------: | --------: | -------: |
| 5,224,205 B | 5,081,799 B | 142,406 B (2.7%) |

There are still a few places where we use regular expressions (BlazorWebView, WebView, Windows-specific code) that we could investigate.

### Issues Fixed

Contributes to #18658 