### PR TITLE
Making sure FindMauiContext fallbacks to default for the title icon i…

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
@@ -1453,7 +1453,6 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				}
 				else
 				{
-					titleIcon.LoadImage(titleIcon.FindMauiContext(true), result =>
 					titleIcon.LoadImage(_mauiContext, result =>
 					{
 						var image = result?.Value;

--- a/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
@@ -22,6 +22,7 @@ using PointF = CoreGraphics.CGPoint;
 using RectangleF = CoreGraphics.CGRect;
 using SizeF = CoreGraphics.CGSize;
 using Microsoft.Maui.Platform;
+using Accelerate;
 
 namespace Microsoft.Maui.Controls.Handlers.Compatibility
 {
@@ -1451,7 +1452,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				}
 				else
 				{
-					if (!_navigation.TryGetTarget(out NavigationRenderer n) && n.MauiContext is not null)
+					if (!_navigation.TryGetTarget(out NavigationRenderer n) || n.MauiContext is null)
 						return;
 
 					titleIcon.LoadImage(n.MauiContext, result =>

--- a/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
@@ -361,7 +361,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 			// must pack into container so padding can work
 			// otherwise the view controller is forced to 0,0
-			var pack = new ParentingViewController(this) { Child = page };
+			var pack = new ParentingViewController(this, MauiContext) { Child = page };
 
 			pack.UpdateTitleArea(page);
 
@@ -1092,14 +1092,16 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			Page _child;
 			bool _disposed;
 			ToolbarTracker _tracker = new ToolbarTracker();
+			IMauiContext _mauiContext;
 
-			public ParentingViewController(NavigationRenderer navigation)
+			public ParentingViewController(NavigationRenderer navigation, IMauiContext mauiContext)
 			{
 #pragma warning disable CA1416, CA1422 // TODO: 'UIViewController.AutomaticallyAdjustsScrollViewInsets' is unsupported on: 'ios' 11.0 and later
 				AutomaticallyAdjustsScrollViewInsets = false;
 #pragma warning restore CA1416, CA1422
 
 				_navigation = new WeakReference<NavigationRenderer>(navigation);
+				_mauiContext = mauiContext;
 			}
 
 			public Page Child
@@ -1452,6 +1454,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				else
 				{
 					titleIcon.LoadImage(titleIcon.FindMauiContext(true), result =>
+					titleIcon.LoadImage(_mauiContext, result =>
 					{
 						var image = result?.Value;
 						try

--- a/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
@@ -1,4 +1,4 @@
-﻿#nullable disable
+#nullable disable
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -22,6 +22,7 @@ using PointF = CoreGraphics.CGPoint;
 using RectangleF = CoreGraphics.CGRect;
 using SizeF = CoreGraphics.CGSize;
 using Microsoft.Maui.Platform;
+using Accelerate;
 
 namespace Microsoft.Maui.Controls.Handlers.Compatibility
 {
@@ -361,7 +362,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 			// must pack into container so padding can work
 			// otherwise the view controller is forced to 0,0
-			var pack = new ParentingViewController(this, MauiContext) { Child = page };
+			var pack = new ParentingViewController(this) { Child = page };
 
 			pack.UpdateTitleArea(page);
 
@@ -1092,16 +1093,14 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			Page _child;
 			bool _disposed;
 			ToolbarTracker _tracker = new ToolbarTracker();
-			IMauiContext _mauiContext;
 
-			public ParentingViewController(NavigationRenderer navigation, IMauiContext mauiContext)
+			public ParentingViewController(NavigationRenderer navigation)
 			{
 #pragma warning disable CA1416, CA1422 // TODO: 'UIViewController.AutomaticallyAdjustsScrollViewInsets' is unsupported on: 'ios' 11.0 and later
 				AutomaticallyAdjustsScrollViewInsets = false;
 #pragma warning restore CA1416, CA1422
 
 				_navigation = new WeakReference<NavigationRenderer>(navigation);
-				_mauiContext = mauiContext;
 			}
 
 			public Page Child
@@ -1453,7 +1452,10 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				}
 				else
 				{
-					titleIcon.LoadImage(_mauiContext, result =>
+					if (!_navigation.TryGetTarget(out NavigationRenderer n) && n.MauiContext is not null)
+						return;
+
+					titleIcon.LoadImage(n.MauiContext, result =>
 					{
 						var image = result?.Value;
 						try

--- a/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
@@ -1451,7 +1451,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				}
 				else
 				{
-					titleIcon.LoadImage(titleIcon.FindMauiContext(), result =>
+					titleIcon.LoadImage(titleIcon.FindMauiContext(true), result =>
 					{
 						var image = result?.Value;
 						try

--- a/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
@@ -22,7 +22,6 @@ using PointF = CoreGraphics.CGPoint;
 using RectangleF = CoreGraphics.CGRect;
 using SizeF = CoreGraphics.CGSize;
 using Microsoft.Maui.Platform;
-using Accelerate;
 
 namespace Microsoft.Maui.Controls.Handlers.Compatibility
 {

--- a/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
@@ -22,7 +22,6 @@ using PointF = CoreGraphics.CGPoint;
 using RectangleF = CoreGraphics.CGRect;
 using SizeF = CoreGraphics.CGSize;
 using Microsoft.Maui.Platform;
-using Accelerate;
 
 namespace Microsoft.Maui.Controls.Handlers.Compatibility
 {
@@ -1452,21 +1451,21 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				}
 				else
 				{
-					if (!_navigation.TryGetTarget(out NavigationRenderer n) || n.MauiContext is null)
-						return;
-
-					titleIcon.LoadImage(n.MauiContext, result =>
+					if (_navigation.TryGetTarget(out NavigationRenderer n) && n.MauiContext is IMauiContext mc)
 					{
-						var image = result?.Value;
-						try
+						titleIcon.LoadImage(mc, result =>
 						{
-							titleViewContainer.Icon = new UIImageView(image);
-						}
-						catch
-						{
-							//UIImage ctor throws on file not found if MonoTouch.ObjCRuntime.Class.ThrowOnInitFailure is true;
-						}
-					});
+							var image = result?.Value;
+							try
+							{
+								titleViewContainer.Icon = new UIImageView(image);
+							}
+							catch
+							{
+								//UIImage ctor throws on file not found if MonoTouch.ObjCRuntime.Class.ThrowOnInitFailure is true;
+							}
+						});
+					}
 				}
 			}
 

--- a/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.cs
@@ -362,5 +362,19 @@ namespace Microsoft.Maui.DeviceTests
 				await OnLoadedAsync(reusedPage.Content);
 			});
 		}
+
+		[Fact]
+		public async Task SettingTitleIconImageSourceDoesntCrash()
+		{
+			SetupBuilder();
+			var navPage = new NavigationPage(new ContentPage()) { Title = "App Page" };
+
+			await CreateHandlerAndAddToWindow<WindowHandlerStub>(new Window(navPage), async (handler) =>
+			{
+				var page = new ContentPage() { Content = new Frame(), Title = "Detail" };
+				await navPage.PushAsync(new NavigationPage(page));
+				NavigationPage.SetTitleIconImageSource(page, "red.png");
+			});
+		}
 	}
 }


### PR DESCRIPTION
### Description of Change

Passing a true value to FindMauiContext to make sure context is not null for Title Icon on iOS.
The ImageSource does not have a handler or a parent, so the method will return a null value and causes a crash.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #21518


<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
