### PR TITLE
Minor optimization for `MergedStyle.SetStyle`

### DIFF
--- a/src/Controls/src/Core/MergedStyle.cs
+++ b/src/Controls/src/Core/MergedStyle.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Maui.Controls
 
 		IList<BindableProperty> _classStyleProperties;
 
-		readonly List<BindableProperty> _implicitStyles = new List<BindableProperty>();
+		readonly List<BindableProperty> _implicitStyles = new();
 
 		IList<Style> _classStyles;
 
@@ -105,13 +105,18 @@ namespace Microsoft.Maui.Controls
 		void Apply(BindableObject bindable)
 		{
 			//NOTE specificity could be more fine grained (using distance)
-			ImplicitStyle?.Apply(bindable, new SetterSpecificity(SetterSpecificity.StyleImplicit, 0, 0, 0));
+			ImplicitStyle?.Apply(bindable, SetterSpecificity.ImplicitSetter);
 			if (ClassStyles != null)
+			{
 				foreach (var classStyle in ClassStyles)
+				{
 					//NOTE specificity could be more fine grained (using distance)
-					((IStyle)classStyle)?.Apply(bindable, new SetterSpecificity(SetterSpecificity.StyleLocal, 0, 1, 0));
+					((IStyle)classStyle)?.Apply(bindable, SetterSpecificity.LocalClassSetter);
+				}
+			}
+
 			//NOTE specificity could be more fine grained (using distance)
-			Style?.Apply(bindable, new SetterSpecificity(SetterSpecificity.StyleLocal, 0, 0, 0));
+			Style?.Apply(bindable, SetterSpecificity.LocalSetter);
 		}
 
 		public Type TargetType { get; }
@@ -191,12 +196,22 @@ namespace Microsoft.Maui.Controls
 			bool shouldReApplyImplicitStyle = implicitStyle != ImplicitStyle;
 
 			if (shouldReApplyStyle)
+			{
 				Style?.UnApply(Target);
+			}
+
 			if (shouldReApplyClassStyle && ClassStyles != null)
+			{
 				foreach (var classStyle in ClassStyles)
+				{
 					((IStyle)classStyle)?.UnApply(Target);
+				}
+			}
+
 			if (shouldReApplyImplicitStyle)
+			{
 				ImplicitStyle?.UnApply(Target);
+			}
 
 			_implicitStyle = implicitStyle;
 			_classStyles = classStyles;
@@ -204,15 +219,24 @@ namespace Microsoft.Maui.Controls
 
 			//FIXME compute specificity
 			if (shouldReApplyImplicitStyle)
-				ImplicitStyle?.Apply(Target, new SetterSpecificity(SetterSpecificity.StyleImplicit, 0, 0, 0));
+			{
+				ImplicitStyle?.Apply(Target, SetterSpecificity.ImplicitSetter);
+			}
 
 			if (shouldReApplyClassStyle && ClassStyles != null)
+			{
 				foreach (var classStyle in ClassStyles)
+				{
 					//FIXME compute specificity
-					((IStyle)classStyle)?.Apply(Target, new SetterSpecificity(SetterSpecificity.StyleLocal, 0, 1, 0));
+					((IStyle)classStyle)?.Apply(Target, SetterSpecificity.LocalClassSetter);
+				}
+			}
+
 			if (shouldReApplyStyle)
+			{
 				//FIXME compute specificity
-				Style?.Apply(Target, new SetterSpecificity(SetterSpecificity.StyleLocal, 0, 0, 0));
+				Style?.Apply(Target, SetterSpecificity.LocalSetter);
+			}
 		}
 	}
 }

--- a/src/Controls/src/Core/SetterSpecificity.cs
+++ b/src/Controls/src/Core/SetterSpecificity.cs
@@ -35,6 +35,10 @@ namespace Microsoft.Maui.Controls
 
 		public static readonly SetterSpecificity DynamicResourceSetter = new SetterSpecificity(0, 0, 1, 0, 0, 0, 0, 0);
 
+		public static readonly SetterSpecificity ImplicitSetter = new(StyleImplicit, 0, 0, 0);
+		public static readonly SetterSpecificity LocalSetter = new(StyleLocal, 0, 0, 0);
+		public static readonly SetterSpecificity LocalClassSetter = new(StyleLocal, 0, 1, 0);
+
 		// handler always apply, but are removed when anything else comes in. see SetValueActual
 		public static readonly SetterSpecificity FromHandler = new SetterSpecificity(0xFF, 0, 0, 0, 0, 0, 0, 0);
 

--- a/src/Controls/src/Core/StyleSheets/Style.cs
+++ b/src/Controls/src/Core/StyleSheets/Style.cs
@@ -71,7 +71,9 @@ namespace Microsoft.Maui.Controls.StyleSheets
 				if (property == null)
 					continue;
 				if (string.Equals(decl.Value, "initial", StringComparison.OrdinalIgnoreCase))
+				{
 					styleable.SetValue(property, property.DefaultValue, new SetterSpecificity(SetterSpecificity.StyleImplicit, (byte)selectorSpecificity.Id, (byte)selectorSpecificity.Class, (byte)selectorSpecificity.Type));
+				}
 				else
 				{
 					object value;

--- a/src/Controls/tests/Core.UnitTests/BindableObjectUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/BindableObjectUnitTests.cs
@@ -1023,7 +1023,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		public void StyleValueIsOverridenByValue()
 		{
 			var label = new Label();
-			label.SetValue(Label.TextProperty, "Foo", new SetterSpecificity(SetterSpecificity.StyleImplicit, 0, 0, 0));
+			label.SetValue(Label.TextProperty, "Foo", SetterSpecificity.ImplicitSetter);
 			Assert.Equal("Foo", label.Text);
 
 			label.SetValue(Label.TextProperty, "Bar");
@@ -1061,7 +1061,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		{
 			var label = new Label();
 			label.BindingContext = new { foo = "Foo", bar = "Bar" };
-			label.SetValue(Label.TextProperty, "Foo", new SetterSpecificity(SetterSpecificity.StyleImplicit, 0, 0, 0));
+			label.SetValue(Label.TextProperty, "Foo", SetterSpecificity.ImplicitSetter);
 			Assert.Equal("Foo", label.Text);
 
 			label.SetBinding(Label.TextProperty, "bar");
@@ -1105,7 +1105,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 					{"bar", "Bar"}
 				}
 			};
-			label.SetValue(Label.TextProperty, "Foo", new SetterSpecificity(SetterSpecificity.StyleImplicit, 0, 0, 0));
+			label.SetValue(Label.TextProperty, "Foo", SetterSpecificity.ImplicitSetter);
 			Assert.Equal("Foo", label.Text);
 
 			label.SetDynamicResource(Label.TextProperty, "bar");
@@ -1152,7 +1152,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			label.SetValue(Label.TextProperty, "Foo");
 			Assert.Equal("Foo", label.Text);
 
-			label.SetValue(Label.TextProperty, "Bar", new SetterSpecificity(SetterSpecificity.StyleImplicit, 0, 0, 0));
+			label.SetValue(Label.TextProperty, "Bar", SetterSpecificity.ImplicitSetter);
 			Assert.Equal("Foo", label.Text);
 		}
 		[Fact]
@@ -1163,7 +1163,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			label.BindingContext = new { foo = "Foo" };
 			Assert.Equal("Foo", label.Text);
 
-			label.SetValue(Label.TextProperty, "Bar", new SetterSpecificity(SetterSpecificity.StyleImplicit, 0, 0, 0));
+			label.SetValue(Label.TextProperty, "Bar", SetterSpecificity.ImplicitSetter);
 			Assert.Equal("Foo", label.Text);
 		}
 		[Fact]
@@ -1176,7 +1176,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			};
 			Assert.Equal("Foo", label.Text);
 
-			label.SetValue(Label.TextProperty, "Bar", new SetterSpecificity(SetterSpecificity.StyleImplicit, 0, 0, 0));
+			label.SetValue(Label.TextProperty, "Bar", SetterSpecificity.ImplicitSetter);
 			Assert.Equal("Foo", label.Text);
 		}
 
@@ -1271,10 +1271,10 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		public void StyleValueIsOverridenByStyleValue()
 		{
 			var label = new Label();
-			label.SetValue(Label.TextProperty, "Foo", new SetterSpecificity(SetterSpecificity.StyleImplicit, 0, 0, 0));
+			label.SetValue(Label.TextProperty, "Foo", SetterSpecificity.ImplicitSetter);
 			Assert.Equal("Foo", label.Text);
 
-			label.SetValue(Label.TextProperty, "Bar", new SetterSpecificity(SetterSpecificity.StyleImplicit, 0, 0, 0));
+			label.SetValue(Label.TextProperty, "Bar", SetterSpecificity.ImplicitSetter);
 			Assert.Equal("Bar", label.Text);
 		}
 
@@ -1311,7 +1311,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		{
 			var label = new Label();
 			label.BindingContext = new { foo = "Foo", bar = "Bar" };
-			label.SetValue(Label.TextProperty, "Foo", new SetterSpecificity(SetterSpecificity.StyleImplicit, 0, 0, 0));
+			label.SetValue(Label.TextProperty, "Foo", SetterSpecificity.ImplicitSetter);
 			Assert.Equal("Foo", label.Text);
 
 			label.SetBinding(Label.TextProperty, new Binding("bar"), new SetterSpecificity(0, 0, 0, 1, SetterSpecificity.StyleLocal, 0, 0, 0));
@@ -1354,7 +1354,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 				{"bar", "Bar"}
 			};
 			label.BindingContext = new { foo = "Foo", bar = "Bar" };
-			label.SetValue(Label.TextProperty, "Foo", new SetterSpecificity(SetterSpecificity.StyleImplicit, 0, 0, 0));
+			label.SetValue(Label.TextProperty, "Foo", SetterSpecificity.ImplicitSetter);
 			Assert.Equal("Foo", label.Text);
 
 			label.SetDynamicResource(Label.TextProperty, "bar", new SetterSpecificity(0, 0, 1, 0, SetterSpecificity.StyleLocal, 0, 0, 0));

--- a/src/Controls/tests/Core.UnitTests/LabelTests.cs
+++ b/src/Controls/tests/Core.UnitTests/LabelTests.cs
@@ -117,7 +117,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			Assert.Equal(label.GetDefaultFontSize(), label.FontSize);
 
-			label.SetValue(Label.FontSizeProperty, 1.0, new SetterSpecificity(SetterSpecificity.StyleImplicit, 0, 0, 0));
+			label.SetValue(Label.FontSizeProperty, 1.0, SetterSpecificity.ImplicitSetter);
 			Assert.Equal(1.0, label.FontSize);
 		}
 
@@ -130,7 +130,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			label.SetValue(Label.FontSizeProperty, 2.0);
 			Assert.Equal(2.0, label.FontSize);
 
-			label.SetValue(Label.FontSizeProperty, 1.0, new SetterSpecificity(SetterSpecificity.StyleImplicit, 0, 0, 0));
+			label.SetValue(Label.FontSizeProperty, 1.0, SetterSpecificity.ImplicitSetter);
 			Assert.Equal(2.0, label.FontSize);
 		}
 

--- a/src/Core/tests/Benchmarks/Benchmarks/StyleBenchmarker.cs
+++ b/src/Core/tests/Benchmarks/Benchmarks/StyleBenchmarker.cs
@@ -1,0 +1,59 @@
+﻿using BenchmarkDotNet.Attributes;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Graphics;
+
+namespace Microsoft.Maui.Benchmarks;
+
+[MemoryDiagnoser]
+public class StyleBenchmarker
+{
+	Style buttonStyle;
+	Style labelStyle;
+
+	[GlobalSetup]
+	public void Setup()
+	{
+		buttonStyle = new Style(typeof(Button))
+		{
+			Setters = {
+				new Setter { Property = Button.TextColorProperty, Value = Colors.Pink },
+			},
+			Class = "pink",
+			ApplyToDerivedTypes = true,
+		};
+		labelStyle = new Style(typeof(Label))
+		{
+			Setters = {
+				new Setter { Property = Button.BackgroundColorProperty, Value = Colors.Pink },
+			},
+			Class = "pink",
+			ApplyToDerivedTypes = false,
+		};
+	}
+
+	[Benchmark]
+	public void MergedStyle()
+	{	
+		var button = new Button
+		{
+			StyleClass = new[] { "pink" },
+		};
+		var label = new Label
+		{
+			StyleClass = new[] { "pink" },
+		};
+
+		var cv = new ContentView
+		{
+			Resources = new ResourceDictionary { buttonStyle },
+			Content = new StackLayout
+			{
+				Resources = new ResourceDictionary { labelStyle },
+					Children = {
+					button,
+					label,
+				}
+			}
+		};
+	}
+}


### PR DESCRIPTION
### Description of Change

This PR just removes a few allocations. There is no big idea. 

### Benchmark

```powershell
cd src/Core/tests/Benchmarks
dotnet build -c Release --framework net9.0 && dotnet run --framework net9.0 -c Release -- --runtimes net9.0 --filter *StyleBenchmarker*
```

MAIN

| Method      | Mean     | Error    | StdDev   | Median   | Gen0   | Gen1   | Gen2   | Allocated |
|------------ |---------:|---------:|---------:|---------:|-------:|-------:|-------:|----------:|
| MergedStyle | 66.95 us | 2.668 us | 7.867 us | 63.44 us | 4.1504 | 4.0283 | 1.3428 |  25.79 KB |

PR

| Method      | Mean     | Error    | StdDev   | Median   | Gen0   | Gen1   | Gen2   | Allocated |
|------------ |---------:|---------:|---------:|---------:|-------:|-------:|-------:|----------:|
| MergedStyle | 65.98 us | 2.538 us | 7.443 us | 63.34 us | 4.1504 | 4.0283 | 1.3428 |  25.79 KB |

<details>
  <summary>Old results</summary>

    MAIN
    
    | Method      | Mean     | Error    | StdDev   | Median   | Gen0   | Gen1   | Gen2   | Allocated |
    |------------ |---------:|---------:|---------:|---------:|-------:|-------:|-------:|----------:|
    | MergedStyle | 66.18 us | 2.060 us | 5.977 us | 63.38 us | 4.5166 | 4.3945 | 0.7324 |  28.25 KB |
    
    
    PR
    
    | Method      | Mean     | Error    | StdDev   | Median   | Gen0   | Gen1   | Gen2   | Allocated |
    |------------ |---------:|---------:|---------:|---------:|-------:|-------:|-------:|----------:|
    | MergedStyle | 64.74 us | 1.820 us | 5.367 us | 62.34 us | 4.5166 | 4.3945 | 0.7324 |  28.25 KB |
    
    The improvement is not really big but I find it better than nothing.

</details>

### Additional findings

1. It appears that [`MergedStyle.ReRegisterImplicitStyles`](https://github.com/dotnet/maui/blob/d7dac41200a932ea748569a28b6f26e7e3df69db/src/Controls/src/Core/MergedStyle.cs#L165-L181) is not in use (at least not in this repo).
2. [CA1859](https://learn.microsoft.com/en-gb/dotnet/fundamentals/code-analysis/quality-rules/ca1859) is reported on line https://github.com/dotnet/maui/blob/d7dac41200a932ea748569a28b6f26e7e3df69db/src/Controls/src/Core/MergedStyle.cs#L15 and it looks like it can be trivially changed and nothing wrong would happen.


### Issues Fixed

Fixes #21539

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
