### PR TITLE
[iOS] Avoid crash adding items to ObservableCollection

### DIFF
--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issue21374.xaml
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issue21374.xaml
@@ -1,0 +1,47 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="Maui.Controls.Sample.Issues.Issue21374"
+    xmlns:viewModels="clr-namespace:Maui.Controls.Sample.Issues"
+    Title="Issue 21374">
+  <ContentPage.BindingContext>
+    <viewModels:Issue21374ViewModel />
+  </ContentPage.BindingContext>
+  <Grid>
+    <Grid.RowDefinitions>
+      <RowDefinition Height="Auto" />
+      <RowDefinition Height="*" />
+    </Grid.RowDefinitions>
+    <Button   
+      Grid.Row="0"
+      AutomationId="WaitForStubControl"
+      Command="{Binding PopulateItemsCommand}"
+      Text="Populate items" />
+    <Grid
+        Grid.Row="1">
+      <Grid.RowDefinitions>
+        <RowDefinition Height="*" />
+        <RowDefinition Height="Auto" />
+      </Grid.RowDefinitions>
+      <CollectionView  
+        Grid.Row="0" 
+        ItemsSource="{Binding Items}">
+        <CollectionView.ItemTemplate>
+          <DataTemplate>
+            <StackLayout              
+              Padding="8"
+              Orientation="Horizontal"
+              Spacing="16">
+              <Label 
+                Text="{Binding Text}" />
+            </StackLayout>
+          </DataTemplate>
+        </CollectionView.ItemTemplate>
+      </CollectionView>
+      <Label 
+        Grid.Row="1"
+        Text="{Binding Success}"/>
+    </Grid>
+  </Grid>
+</ContentPage>

--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issue21374.xaml
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issue21374.xaml
@@ -41,6 +41,7 @@
       </CollectionView>
       <Label 
         Grid.Row="1"
+        AutomationId="Success"
         Text="{Binding Success}"/>
     </Grid>
   </Grid>

--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issue21374.xaml.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issue21374.xaml.cs
@@ -1,0 +1,86 @@
+﻿using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Windows.Input;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+
+namespace Maui.Controls.Sample.Issues
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	[Issue(IssueTracker.Github, 21374, "Error when adding to ObservableCollection", PlatformAffected.iOS)]
+	public partial class Issue21374 : ContentPage
+	{
+		public Issue21374()
+		{
+			InitializeComponent();
+		}
+	}
+
+	public class Issue21374Model
+	{
+		public string Text { get; set; }
+	}
+
+	public class Issue21374ViewModel : INotifyPropertyChanged
+	{
+		string _success;
+		ObservableCollection<Issue21374Model> _items = new ObservableCollection<Issue21374Model>();
+
+		public ICommand PopulateItemsCommand => new Command(PopulateItems);
+
+		public string Success
+		{
+			get => _success;
+			set
+			{
+				_success = value;
+				OnPropertyChanged("Success");
+			}
+		}
+
+		public ObservableCollection<Issue21374Model> Items
+		{
+			get => _items;
+			set
+			{
+				if (_items != value)
+				{
+					_items = value;
+					OnPropertyChanged("Items");
+				}
+			}
+		}
+
+		public event PropertyChangedEventHandler PropertyChanged;
+
+		void PopulateItems()
+		{
+			try
+			{
+				for (int j = 0; j < 10; j++)
+				{
+					Items.Add(new Issue21374Model { Text = $"Item {j + 1}" });
+				}
+
+				Success = "Success";
+			}
+			catch
+			{
+				Success = "Failed";
+			}
+		}
+
+		protected void OnPropertyChanged([CallerMemberName] string propertyName = "")
+		{
+			PropertyChangedEventHandler changed = PropertyChanged;
+
+			if (changed == null)
+			{
+				return;
+			}
+
+			changed.Invoke(this, new PropertyChangedEventArgs(propertyName));
+		}
+	}
+}

--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewLayout.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewLayout.cs
@@ -392,23 +392,21 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			if (preferredAttributes.RepresentedElementKind != UICollectionElementKindSectionKey.Header
 				&& preferredAttributes.RepresentedElementKind != UICollectionElementKindSectionKey.Footer)
 			{
-				if (OperatingSystem.IsIOSVersionAtLeast(12) || OperatingSystem.IsTvOSVersionAtLeast(12))
-				{
-					return base.GetInvalidationContext(preferredAttributes, originalAttributes);
-				}
-
 				try
 				{
 					// We only have to do this on older iOS versions; sometimes when removing a cell that's right at the edge
 					// of the viewport we'll run into a race condition where the invalidation context will have the removed
 					// indexpath. And then things crash. So 
-
 					var defaultContext = base.GetInvalidationContext(preferredAttributes, originalAttributes);
 					return defaultContext;
 				}
 				catch (ObjCRuntime.ObjCException ex) when (ex.Name == "NSRangeException")
 				{
 					Application.Current?.FindMauiContext()?.CreateLogger<ItemsViewLayout>()?.LogWarning(ex, "NSRangeException");
+				}
+				catch (ObjCRuntime.ObjCException ex) when (ex.Name == "NSInvalidArgumentException")
+				{
+					Application.Current?.FindMauiContext()?.CreateLogger<ItemsViewLayout>()?.LogWarning(ex, "NSInvalidArgumentException");
 				}
 
 				UICollectionViewFlowLayoutInvalidationContext context = new UICollectionViewFlowLayoutInvalidationContext();

--- a/src/Controls/tests/UITests/Tests/Issues/Issue21374.cs
+++ b/src/Controls/tests/UITests/Tests/Issues/Issue21374.cs
@@ -1,0 +1,31 @@
+﻿using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.AppiumTests.Issues
+{
+	public class Issue21374 : _IssuesUITest
+	{
+		public Issue21374(TestDevice device) : base(device)
+		{
+		}
+
+		public override string Issue => "Error when adding to ObservableCollection";
+
+		[Test]
+		[Category(UITestCategories.CollectionView)]
+		public void AddingItemsToObservableCollectionNoCrash()
+		{
+			this.IgnoreIfPlatforms(new[]
+			{
+				TestDevice.Android,
+				TestDevice.Mac,
+				TestDevice.Windows
+			});
+
+			App.WaitForElement("WaitForStubControl");
+			App.Click("WaitForStubControl");
+			App.WaitForNoElement("Success");
+		}
+	}
+}

--- a/src/Controls/tests/UITests/Tests/Issues/Issue21374.cs
+++ b/src/Controls/tests/UITests/Tests/Issues/Issue21374.cs
@@ -25,7 +25,8 @@ namespace Microsoft.Maui.AppiumTests.Issues
 
 			App.WaitForElement("WaitForStubControl");
 			App.Click("WaitForStubControl");
-			App.WaitForNoElement("Success");
+			var result = App.WaitForElement("Success").GetText();
+			Assert.AreEqual("Success", result);
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change

Avoid crash adding items to ObservableCollection.

### Issues Fixed

Fixes #21374 
