### PR TITLE
Don't worry about the size of the text

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Layout/LayoutTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Layout/LayoutTests.Android.cs
@@ -1,12 +1,3 @@
-using System;
-using System.Threading.Tasks;
-using Android.Graphics.Drawables;
-using AndroidX.AppCompat.Widget;
-using AndroidX.Core.Widget;
-using Microsoft.Maui.Controls;
-using Microsoft.Maui.DeviceTests.Stubs;
-using Microsoft.Maui.Handlers;
-using Microsoft.Maui.Hosting;
 using Microsoft.Maui.Platform;
 using Xunit;
 
@@ -14,60 +5,6 @@ namespace Microsoft.Maui.DeviceTests
 {
 	public partial class LayoutTests
 	{
-		[Theory(DisplayName = "Button Icon has Correct Position"), Category(TestCategory.Layout)]
-		[InlineData(Button.ButtonContentLayout.ImagePosition.Left)]
-		[InlineData(Button.ButtonContentLayout.ImagePosition.Top)]
-		[InlineData(Button.ButtonContentLayout.ImagePosition.Right)]
-		[InlineData(Button.ButtonContentLayout.ImagePosition.Bottom)]
-		public async Task NestedButtonHasExpectedIconPosition(Button.ButtonContentLayout.ImagePosition imagePosition)
-		{
-			EnsureHandlerCreated(builder =>
-			{
-				builder.ConfigureMauiHandlers(handlers =>
-				{
-					handlers.AddHandler<Page, PageHandler>();
-					handlers.AddHandler<Window, WindowHandlerStub>();
-					handlers.AddHandler<Layout, LayoutHandler>();
-					handlers.AddHandler<Button, ButtonHandler>();
-				});
-			});
-
-			var button = new Button()
-			{
-				Text = "Hello",
-				ImageSource = "red.png",
-				ContentLayout = new Button.ButtonContentLayout(imagePosition, 8)
-			};
-
-			var page = new ContentPage()
-			{
-				Content = new HorizontalStackLayout()
-				{
-					button
-				}
-			};
-
-			await CreateHandlerAndAddToWindow(page, () =>
-			{
-				var handler = CreateHandler<ButtonHandler>(button);
-
-				var platformButton = (AppCompatButton)handler.PlatformView;
-
-				int matchingDrawableIndex = imagePosition switch
-				{
-					Button.ButtonContentLayout.ImagePosition.Left => 0,
-					Button.ButtonContentLayout.ImagePosition.Top => 1,
-					Button.ButtonContentLayout.ImagePosition.Right => 2,
-					Button.ButtonContentLayout.ImagePosition.Bottom => 3,
-					_ => throw new InvalidOperationException(),
-				};
-
-				// Assert that the image is in the expected position
-				Drawable[] drawables = TextViewCompat.GetCompoundDrawablesRelative(platformButton);
-				Assert.NotNull(drawables[matchingDrawableIndex]);
-			});
-		}
-
 		void ValidateInputTransparentOnPlatformView(IView view)
 		{
 			var handler = view.ToHandler(MauiContext);

--- a/src/Core/src/Handlers/Button/ButtonHandler.Android.cs
+++ b/src/Core/src/Handlers/Button/ButtonHandler.Android.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using Android.Content.Res;
 using Android.Graphics.Drawables;
@@ -189,7 +190,7 @@ namespace Microsoft.Maui.Handlers
 
 				button.Icon = platformImage is null
 					? null
-					: new MauiMaterialButton.MauiResizableDrawable(platformImage);
+					: (OperatingSystem.IsAndroidVersionAtLeast(23)) ? new MauiMaterialButton.MauiResizableDrawable(platformImage) : platformImage;
 			}
 		}
 	}

--- a/src/Core/src/Handlers/ElementHandlerExtensions.cs
+++ b/src/Core/src/Handlers/ElementHandlerExtensions.cs
@@ -95,5 +95,9 @@ namespace Microsoft.Maui
 #endif
 			return true;
 		}
+
+		internal static bool IsConnected(this IElementHandler handler) =>
+			handler.PlatformView is not null;
+
 	}
 }

--- a/src/Core/src/Handlers/Image/ImageHandler.Android.cs
+++ b/src/Core/src/Handlers/Image/ImageHandler.Android.cs
@@ -48,12 +48,17 @@ namespace Microsoft.Maui.Handlers
 		public static void MapSource(IImageHandler handler, IImage image) =>
 			MapSourceAsync(handler, image).FireAndForget(handler);
 
-		public static Task MapSourceAsync(IImageHandler handler, IImage image)
+		public static async Task MapSourceAsync(IImageHandler handler, IImage image)
 		{
-			return handler
+			await handler
 				.SourceLoader
-				.UpdateImageSourceAsync()
-				.ContinueWith((action) => handler.UpdateValue(nameof(IImage.IsAnimationPlaying)));
+				.UpdateImageSourceAsync();
+
+			handler.DisconnectHandler();
+			// Because this resolves from a task we should validate that the
+			// handler hasn't been disconnected
+			if (handler.IsConnected())
+				handler.UpdateValue(nameof(IImage.IsAnimationPlaying));
 		}
 
 		public override void PlatformArrange(Graphics.Rect frame)

--- a/src/Core/src/Handlers/Image/ImageHandler.Android.cs
+++ b/src/Core/src/Handlers/Image/ImageHandler.Android.cs
@@ -54,7 +54,6 @@ namespace Microsoft.Maui.Handlers
 				.SourceLoader
 				.UpdateImageSourceAsync();
 
-			handler.DisconnectHandler();
 			// Because this resolves from a task we should validate that the
 			// handler hasn't been disconnected
 			if (handler.IsConnected())

--- a/src/Core/src/Handlers/Image/ImageHandler.Windows.cs
+++ b/src/Core/src/Handlers/Image/ImageHandler.Windows.cs
@@ -49,7 +49,10 @@ namespace Microsoft.Maui.Handlers
 
 		void OnImageOpened(object sender, RoutedEventArgs e)
 		{
-			UpdateValue(nameof(IImage.IsAnimationPlaying));
+			// Because this resolves from a task we should validate that the
+			// handler hasn't been disconnected
+			if (this.IsConnected())
+				UpdateValue(nameof(IImage.IsAnimationPlaying));
 		}
 
 		partial class ImageImageSourcePartSetter

--- a/src/Core/src/Platform/Android/MauiMaterialButton.cs
+++ b/src/Core/src/Platform/Android/MauiMaterialButton.cs
@@ -30,9 +30,20 @@ namespace Microsoft.Maui.Platform
 			get => base.IconGravity;
 			set
 			{
+				var icon = Icon;
+				if (base.IconGravity != value)
+				{
+					Icon = null;
+				}
+
 				// Intercept the gravity value and set the flag if it's bottom.
 				ForceBottomIconGravity = value == IconGravityBottom;
 				base.IconGravity = ForceBottomIconGravity ? IconGravityTop : value;
+
+				if (Icon != icon)
+				{
+					Icon = icon;
+				}
 			}
 		}
 
@@ -40,31 +51,8 @@ namespace Microsoft.Maui.Platform
 
 		protected override void OnMeasure(int widthMeasureSpec, int heightMeasureSpec)
 		{
-			if (Icon is MauiResizableDrawable currentIcon)
-			{
-				// if there is BOTH an icon AND text, but the text layout has NOT been measured yet,
-				// we need to measure JUST the text first to get the remaining space for the icon
-				if (Layout is null && TextFormatted?.Length() > 0)
-				{
-					// remove the icon and measure JUST the text
-					Icon = null;
-					base.OnMeasure(widthMeasureSpec, heightMeasureSpec);
-
-					// restore the icon
-					Icon = currentIcon;
-				}
-
-				// determine the total client area available for BOTH the icon AND text to fit
-				var availableWidth = MeasureSpec.GetMode(widthMeasureSpec) == MeasureSpecMode.Unspecified
-					? int.MaxValue
-					: MeasureSpec.GetSize(widthMeasureSpec);
-				var availableHeight = MeasureSpec.GetMode(heightMeasureSpec) == MeasureSpecMode.Unspecified
-					? int.MaxValue
-					: MeasureSpec.GetSize(heightMeasureSpec);
-
-				// calculate the icon size based on the remaining space
-				CalculateIconSize(currentIcon, availableWidth, availableHeight);
-			}
+			// calculate the icon size based on the remaining space
+			CalculateIconSize(widthMeasureSpec, heightMeasureSpec);
 
 			// re-measure with both text and icon
 			base.OnMeasure(widthMeasureSpec, heightMeasureSpec);
@@ -86,64 +74,70 @@ namespace Microsoft.Maui.Platform
 			}
 		}
 
-		void CalculateIconSize(MauiResizableDrawable resizable, int availableWidth, int availableHeight)
+		void CalculateIconSize(int widthMeasureSpec, int heightMeasureSpec)
 		{
-			// bail if the text layout is not available yet, this is most likely a bug
-			if (Layout is null)
-			{
+			if (Icon is null)
 				return;
+
+			Drawable actual;
+
+			if (Icon is MauiResizableDrawable resizableDrawable)
+			{
+				actual = resizableDrawable.Drawable;
+			}
+			else
+			{
+				actual = Icon;
 			}
 
-			var actual = resizable.Drawable;
+			// determine the total client area available for BOTH the icon AND text to fit
+			var availableWidth = MeasureSpec.GetMode(widthMeasureSpec) == MeasureSpecMode.Unspecified
+				? int.MaxValue
+				: MeasureSpec.GetSize(widthMeasureSpec);
+			var availableHeight = MeasureSpec.GetMode(heightMeasureSpec) == MeasureSpecMode.Unspecified
+				? int.MaxValue
+				: MeasureSpec.GetSize(heightMeasureSpec);
 
 			var remainingWidth = availableWidth - PaddingLeft - PaddingRight;
 			var remainingHeight = availableHeight - PaddingTop - PaddingBottom;
 
 			if (IsIconGravityHorizontal)
 			{
-				remainingWidth -= IconPadding + GetTextLayoutWidth();
+				remainingWidth -= IconPadding;
 			}
 			else
 			{
-				remainingHeight -= IconPadding + GetTextLayoutHeight();
+				remainingHeight -= IconPadding;
 			}
 
 			var iconWidth = Math.Min(remainingWidth, actual.IntrinsicWidth);
 			var iconHeight = Math.Min(remainingHeight, actual.IntrinsicHeight);
 
-			var ratio = Math.Min(
-				(double)iconWidth / actual.IntrinsicWidth,
-				(double)iconHeight / actual.IntrinsicHeight);
+			// We don't use IconSize because IconSize makes everything a square
+			// So if the image doesn't have equal width and height it'll distory the image
+			if (OperatingSystem.IsAndroidVersionAtLeast(23) && Icon is MauiResizableDrawable resizable)
+			{
+				var ratio = Math.Min(
+					(double)iconWidth / actual.IntrinsicWidth,
+					(double)iconHeight / actual.IntrinsicHeight);
 
-			resizable.SetPreferredSize(
-				Math.Max(0, (int)(actual.IntrinsicWidth * ratio)),
-				Math.Max(0, (int)(actual.IntrinsicHeight * ratio)));
-
-			// trigger a layout re-calculation
-			Icon = null;
-			Icon = resizable;
+				if (resizable.SetPreferredSize(
+					Math.Max(0, (int)(actual.IntrinsicWidth * ratio)),
+					Math.Max(0, (int)(actual.IntrinsicHeight * ratio))))
+				{
+					// trigger a layout re-calculation
+					Icon = null;
+					Icon = resizable;
+				}
+			}
+			else
+			{
+				IconSize = Math.Max(iconWidth, iconHeight);
+			}
 		}
 
 		bool IsIconGravityHorizontal =>
 			IconGravity is IconGravityTextStart or IconGravityTextEnd or IconGravityStart or IconGravityEnd;
-
-		int GetTextLayoutWidth()
-		{
-			float maxWidth = 0;
-			int lineCount = LineCount;
-			for (int line = 0; line < lineCount; line++)
-			{
-				maxWidth = Math.Max(maxWidth, Layout!.GetLineWidth(line));
-			}
-			return (int)Math.Ceiling(maxWidth);
-		}
-
-		int GetTextLayoutHeight()
-		{
-			var layoutHeight = Layout!.Height;
-
-			return layoutHeight;
-		}
 
 		internal class MauiResizableDrawable : LayerDrawable
 		{
@@ -151,16 +145,28 @@ namespace Microsoft.Maui.Platform
 				: base([drawable])
 			{
 				PaddingMode = (int)LayerDrawablePaddingMode.Stack;
+				if (OperatingSystem.IsAndroidVersionAtLeast(23))
+				{
+					SetLayerSize(0, drawable.IntrinsicWidth, drawable.IntrinsicHeight);
+				}
 			}
 
 			public Drawable Drawable => GetDrawable(0)!;
 
-			public void SetPreferredSize(int width, int height)
+			public bool SetPreferredSize(int width, int height)
 			{
 				if (OperatingSystem.IsAndroidVersionAtLeast(23))
 				{
+					if (NumberOfLayers > 0 && GetLayerWidth(0) == width && GetLayerHeight(0) == height)
+					{
+						return false;
+					}
+
 					SetLayerSize(0, width, height);
+					return true;
 				}
+
+				return false;
 
 				// TODO: find something that works for older versions
 			}

--- a/src/Core/src/Platform/Android/MauiMaterialButton.cs
+++ b/src/Core/src/Platform/Android/MauiMaterialButton.cs
@@ -30,19 +30,24 @@ namespace Microsoft.Maui.Platform
 			get => base.IconGravity;
 			set
 			{
-				var icon = Icon;
+				// Store Icon locally for later checks
+				// so we reduce calls back to android
+				Drawable? platformIcon = null;
+				Drawable? savedIcon = null;
 				if (base.IconGravity != value)
 				{
-					Icon = null;
+					platformIcon = Icon;
+					savedIcon = platformIcon;
+					Icon = platformIcon = null;
 				}
 
 				// Intercept the gravity value and set the flag if it's bottom.
 				ForceBottomIconGravity = value == IconGravityBottom;
 				base.IconGravity = ForceBottomIconGravity ? IconGravityTop : value;
 
-				if (Icon != icon)
+				if (savedIcon != platformIcon)
 				{
-					Icon = icon;
+					Icon = savedIcon;
 				}
 			}
 		}

--- a/src/Core/src/Platform/Android/MauiMaterialButton.cs
+++ b/src/Core/src/Platform/Android/MauiMaterialButton.cs
@@ -32,20 +32,17 @@ namespace Microsoft.Maui.Platform
 			{
 				// Store Icon locally for later checks
 				// so we reduce calls back to android
-				Drawable? platformIcon = null;
 				Drawable? savedIcon = null;
-				if (base.IconGravity != value)
+				if (base.IconGravity != value && (savedIcon = Icon) is not null)
 				{
-					platformIcon = Icon;
-					savedIcon = platformIcon;
-					Icon = platformIcon = null;
+					Icon = null;
 				}
 
 				// Intercept the gravity value and set the flag if it's bottom.
 				ForceBottomIconGravity = value == IconGravityBottom;
 				base.IconGravity = ForceBottomIconGravity ? IconGravityTop : value;
 
-				if (savedIcon != platformIcon)
+				if (savedIcon is not null)
 				{
 					Icon = savedIcon;
 				}

--- a/src/Core/src/Platform/Android/MauiMaterialButton.cs
+++ b/src/Core/src/Platform/Android/MauiMaterialButton.cs
@@ -30,8 +30,9 @@ namespace Microsoft.Maui.Platform
 			get => base.IconGravity;
 			set
 			{
-				// Store Icon locally for later checks
-				// so we reduce calls back to android
+				// For IconGravityTextEnd and IconGravityTextStart, setting the Icon twice
+				// is needed to work around the Android behavior that caused
+				// https://github.com/dotnet/maui/issues/11755
 				Drawable? savedIcon = null;
 				if (base.IconGravity != value && (savedIcon = Icon) is not null)
 				{


### PR DESCRIPTION
### Description of Change

After internal conversations and for the purposes of staying consistent with SR3 we're going to take the route of always letting the image take priority over the text for placement. There's not really a best way to determine the ratio to scale the image to when you have really long text. So, when the user hits a scenarios where the image is just too big for a constrained button it's the users responsibility to resize the physical image themselves. This is ultimately better for performance as well.
