### PR TITLE
[net9.0] [testing] Enable Windows UITests back (#20727) and make sure Android works too

### DIFF
--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -213,7 +213,6 @@ Task("dotnet-legacy-controlgallery-android")
     .Does(() =>
     {
         var properties = new Dictionary<string, string>();
-        properties.Add("EmbedAssembliesIntoApk", "true");
         RunMSBuildWithDotNet("./src/Compatibility/ControlGallery/src/Android/Compatibility.ControlGallery.Android.csproj", properties, binlogPrefix: "controlgallery-android-");
     });
 

--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -753,7 +753,7 @@ void RunTestWithLocalDotNet(string csproj, string config, string pathDotnet = nu
     var name = System.IO.Path.GetFileNameWithoutExtension(csproj);
     var logDirectory = GetLogDirectory();
 
-    if (localDotnet)
+    if (!string.IsNullOrWhiteSpace(pathDotnet) && localDotnet)
     {
         // Make sure the path doesn't refer to the dotnet executable and make path absolute
         var localDotnetRoot = MakeAbsolute(Directory(System.IO.Path.GetDirectoryName(pathDotnet)));

--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -213,6 +213,7 @@ Task("dotnet-legacy-controlgallery-android")
     .Does(() =>
     {
         var properties = new Dictionary<string, string>();
+        properties.Add("EmbedAssembliesIntoApk", "true");
         RunMSBuildWithDotNet("./src/Compatibility/ControlGallery/src/Android/Compatibility.ControlGallery.Android.csproj", properties, binlogPrefix: "controlgallery-android-");
     });
 

--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -753,8 +753,14 @@ void RunTestWithLocalDotNet(string csproj, string config, string pathDotnet = nu
     var name = System.IO.Path.GetFileNameWithoutExtension(csproj);
     var logDirectory = GetLogDirectory();
 
-    if(localDotnet)
-        SetDotNetEnvironmentVariables();
+    if (localDotnet)
+    {
+        // Make sure the path doesn't refer to the dotnet executable and make path absolute
+        var localDotnetRoot = MakeAbsolute(Directory(System.IO.Path.GetDirectoryName(pathDotnet)));
+    	Information("new dotnet root: {0}", localDotnetRoot);
+
+        SetDotNetEnvironmentVariables(localDotnetRoot.FullPath);
+    }
 
     if (string.IsNullOrWhiteSpace(resultsFileNameWithoutExtension))
     {

--- a/eng/devices/android.cake
+++ b/eng/devices/android.cake
@@ -388,6 +388,10 @@ Task("cg-uitest")
 	//set env var for the app path for Xamarin.UITest setup
 	SetEnvironmentVariable("APP_APK", $"{TEST_APP}");
 
+	// Copy the actual tested app to the artifacts for manual inspection if needed
+	CreateDirectory($"{TEST_RESULTS}/android/tested_bin");
+	CopyFile(TEST_APP, $"{TEST_RESULTS}/android/tested_bin/{TEST_APP_PACKAGE_NAME}.apk");
+
 	// build the test library
 	var binDir = PROJECT.GetDirectory().Combine("bin").Combine(CONFIGURATION + "/" + TEST_FRAMEWORK).FullPath;
 	Information("BinDir: {0}", binDir);

--- a/eng/devices/devices-shared.cake
+++ b/eng/devices/devices-shared.cake
@@ -26,9 +26,27 @@ void FailRunOnOnlyInconclusiveTests(string testResultsFile)
     // When all tests are inconclusive the run does not fail, check if this is the case and fail the pipeline so we get notified
 	var totalTestCount = XmlPeek(testResultsFile, "/test-run/@total");
 	var inconclusiveTestCount = XmlPeek(testResultsFile, "/test-run/@inconclusive");
-	
+	var errorMessage = string.Empty;
+
+	// Try to get out error message from test results file, there is usually an error in there when tests are inconclusive
+	try
+	{
+		errorMessage = XmlPeek(testResultsFile, "(//test-suite[@result='Inconclusive']/reason/message)[1]");
+	}
+	catch
+	{
+		// Intentionally left blank
+	}
+
 	if (totalTestCount.Equals(inconclusiveTestCount))
-    {
-		throw new Exception("All tests are marked inconclusive, no tests ran. There is probably something wrong with running the tests.");
+	{
+		var exceptionMessage = "All tests are marked inconclusive, no tests ran. There is probably something wrong with running the tests.";
+
+		if (!string.IsNullOrWhiteSpace(errorMessage))
+		{
+			exceptionMessage = $"{exceptionMessage} Error message extracted from {testResultsFile}, check this file for more details: {errorMessage}";
+		}
+
+		throw new Exception(exceptionMessage);
 	}
 }

--- a/eng/devices/windows.cake
+++ b/eng/devices/windows.cake
@@ -443,26 +443,34 @@ Task("uitest")
 	Information("old dotnet root: {0}", DOTNET_ROOT);
 	Information("old dotnet path: {0}", DOTNET_PATH);
 
-	var localDotnetRoot = MakeAbsolute(Directory("../../bin/dotnet/"));
-	Information("new dotnet root: {0}", localDotnetRoot);
-
-	DOTNET_ROOT = localDotnetRoot.ToString();
-
-	var localToolPath = $"{localDotnetRoot}/dotnet.exe";
-
-	Information("new dotnet toolPath: {0}", localToolPath);
-
-	SetDotNetEnvironmentVariables(DOTNET_ROOT);
-
-	DotNetBuild(PROJECT.FullPath, new DotNetBuildSettings {
+	var buildSettings = new DotNetBuildSettings {
 			Configuration = CONFIGURATION,
-			ToolPath = localToolPath,
 			ArgumentCustomization = args => args
 				.Append("/p:ExtraDefineConstants=WINTEST")
 				.Append("/bl:" + binlog)
 				.Append("/maxcpucount:1")
 				//.Append("/tl")
-	});
+	};
+
+	string? localToolPath = null;
+
+	if (localDotnet)
+	{
+		var localDotnetRoot = MakeAbsolute(Directory("../../bin/dotnet/"));
+		Information("new dotnet root: {0}", localDotnetRoot);
+
+		DOTNET_ROOT = localDotnetRoot.ToString();
+
+		localToolPath = $"{localDotnetRoot}/dotnet.exe";
+
+		Information("new dotnet toolPath: {0}", localToolPath);
+
+		SetDotNetEnvironmentVariables(DOTNET_ROOT);
+
+		buildSettings.ToolPath = localToolPath;
+	}
+
+	DotNetBuild(PROJECT.FullPath, buildSettings);
 
 	SetEnvironmentVariable("WINDOWS_APP_PATH", TEST_APP);
 	SetEnvironmentVariable("APPIUM_LOG_FILE", $"{BINLOG_DIR}/appium_windows.log");

--- a/eng/pipelines/common/ui-tests.yml
+++ b/eng/pipelines/common/ui-tests.yml
@@ -123,28 +123,28 @@ stages:
                       agentPoolAccessToken: ${{ parameters.agentPoolAccessToken }}
                       runtimeVariant : "NativeAOT"
 
-  # - stage: winui_ui_tests
-  #   displayName: WinUI UITests
-  #   dependsOn: []
-  #   jobs:
-  #     - ${{ each project in parameters.projects }}:
-  #       - ${{ if ne(project.winui, '') }}:
-  #             - job: winui_ui_tests_${{ project.name }}
-  #               timeoutInMinutes: 240 # how long to run the job before automatically cancelling
-  #               workspace:
-  #                 clean: all
-  #               displayName: ${{ coalesce(project.desc, project.name) }}
-  #               pool: ${{ parameters.windowsPool }}
-  #               steps:
-  #                 - template: ui-tests-steps.yml
-  #                   parameters:
-  #                     platform: windows
-  #                     version: "10.0.19041"
-  #                     device: windows10
-  #                     path: ${{ project.winui }}
-  #                     app: ${{ project.app }}
-  #                     provisionatorChannel: ${{ parameters.provisionatorChannel }}
-  #                     agentPoolAccessToken: ${{ parameters.agentPoolAccessToken }}
+  - stage: winui_ui_tests
+    displayName: WinUI UITests
+    dependsOn: []
+    jobs:
+      - ${{ each project in parameters.projects }}:
+        - ${{ if ne(project.winui, '') }}:
+              - job: winui_ui_tests_${{ project.name }}
+                timeoutInMinutes: 240 # how long to run the job before automatically cancelling
+                workspace:
+                  clean: all
+                displayName: ${{ coalesce(project.desc, project.name) }}
+                pool: ${{ parameters.windowsPool }}
+                steps:
+                  - template: ui-tests-steps.yml
+                    parameters:
+                      platform: windows
+                      version: "10.0.19041"
+                      device: windows10
+                      path: ${{ project.winui }}
+                      app: ${{ project.app }}
+                      provisionatorChannel: ${{ parameters.provisionatorChannel }}
+                      agentPoolAccessToken: ${{ parameters.agentPoolAccessToken }}
 
   - stage: mac_ui_tests
     displayName: macOS UITests

--- a/src/Compatibility/ControlGallery/src/Android/Compatibility.ControlGallery.Android.csproj
+++ b/src/Compatibility/ControlGallery/src/Android/Compatibility.ControlGallery.Android.csproj
@@ -28,9 +28,6 @@
     <AndroidSigningStorePass>android</AndroidSigningStorePass>
     <AndroidSigningKeyAlias>androiddebugkey</AndroidSigningKeyAlias>
     <AndroidSigningKeyPass>android</AndroidSigningKeyPass>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <EmbedAssembliesIntoApk>True</EmbedAssembliesIntoApk>
   </PropertyGroup>
 

--- a/src/Compatibility/ControlGallery/src/Android/Compatibility.ControlGallery.Android.csproj
+++ b/src/Compatibility/ControlGallery/src/Android/Compatibility.ControlGallery.Android.csproj
@@ -32,6 +32,7 @@
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <EmbedAssembliesIntoApk>True</EmbedAssembliesIntoApk>
+    <_FastDeploymentDiagnosticLogging>True</_FastDeploymentDiagnosticLogging>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Compatibility/ControlGallery/src/Android/Compatibility.ControlGallery.Android.csproj
+++ b/src/Compatibility/ControlGallery/src/Android/Compatibility.ControlGallery.Android.csproj
@@ -32,7 +32,6 @@
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <EmbedAssembliesIntoApk>True</EmbedAssembliesIntoApk>
-    <_FastDeploymentDiagnosticLogging>True</_FastDeploymentDiagnosticLogging>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Compatibility/ControlGallery/src/Android/Compatibility.ControlGallery.Android.csproj
+++ b/src/Compatibility/ControlGallery/src/Android/Compatibility.ControlGallery.Android.csproj
@@ -28,6 +28,9 @@
     <AndroidSigningStorePass>android</AndroidSigningStorePass>
     <AndroidSigningKeyAlias>androiddebugkey</AndroidSigningKeyAlias>
     <AndroidSigningKeyPass>android</AndroidSigningKeyPass>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <EmbedAssembliesIntoApk>True</EmbedAssembliesIntoApk>
   </PropertyGroup>
 


### PR DESCRIPTION
Reverts dotnet/maui#21560

Revert of the revert.

This also adds additional functionality to the `FailRunOnOnlyInconclusiveTests` method which fails the pipeline when all tests are inconclusive. When this happens, this will now try to extract the error message from the test results file so you have to do less digging into the logs manually.

The Android Control Gallery failures were not caused by this PR, but this PR does include a fix for that as well. That was also the reason the above error handling was implemented.

Fixes #21617