### PR TITLE
Update NavigatedFromEventArgs.cs

### DIFF
--- a/src/Controls/src/Core/Page/NavigatedFromEventArgs.cs
+++ b/src/Controls/src/Core/Page/NavigatedFromEventArgs.cs
@@ -10,6 +10,6 @@ namespace Microsoft.Maui.Controls
 			DestinationPage = destinationPage;
 		}
 
-		internal Page DestinationPage { get; }
+		public Page DestinationPage { get; }
 	}
 }


### PR DESCRIPTION
### Description of Change

The class NavigatedFromEventArgs does not expose the DestinationPage property, which is needed in the event to decide what to do

### Issues Fixed

The property is not visible because it is defined as internal

Fixes #

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
