### PR TITLE
[Catalyst,Windows] Allow drag item from outside the app

### DIFF
--- a/src/Controls/samples/Controls.Sample.Sandbox/MauiProgram.cs
+++ b/src/Controls/samples/Controls.Sample.Sandbox/MauiProgram.cs
@@ -10,7 +10,9 @@ namespace Maui.Controls.Sample
 		public static MauiApp CreateMauiApp() =>
 			MauiApp
 				.CreateBuilder()
+#if __ANDROID__ || __IOS__
 				.UseMauiMaps()
+#endif
 				.UseMauiApp<App>()
 				.Build();
 	}

--- a/src/Controls/samples/Controls.Sample/Pages/Core/DropFileToMauiApp.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/DropFileToMauiApp.xaml
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<views:BasePage 
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="Maui.Controls.Sample.Pages.DropFileToMauiApp"
+    xmlns:views="clr-namespace:Maui.Controls.Sample.Pages.Base">
+    <views:BasePage.Resources>
+    </views:BasePage.Resources>
+    <Grid x:Name="myLayout">
+        <Grid.GestureRecognizers>
+            <DropGestureRecognizer DragOver="DropGestureDragOver" Drop="DropGestureDrop" DragLeave="DropGestureDragLeave"/>
+        </Grid.GestureRecognizers>
+        <Label x:Name="lblPath" HorizontalOptions="Center" VerticalOptions="Center" Text="Drag a file here like a .txt" />
+    </Grid>
+</views:BasePage>

--- a/src/Controls/samples/Controls.Sample/Pages/Core/DropFileToMauiApp.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/DropFileToMauiApp.xaml
@@ -8,7 +8,7 @@
     </views:BasePage.Resources>
     <Grid x:Name="myLayout">
         <Grid.GestureRecognizers>
-            <DropGestureRecognizer DragOver="DropGestureDragOver" Drop="DropGestureDrop" DragLeave="DropGestureDragLeave"/>
+            <DropGestureRecognizer AllowDrop="True" DragOver="DropGestureDragOver" Drop="DropGestureDrop" DragLeave="DropGestureDragLeave"/>
         </Grid.GestureRecognizers>
         <Label x:Name="lblPath" HorizontalOptions="Center" VerticalOptions="Center" Text="Drag a file here like a .txt" />
     </Grid>

--- a/src/Controls/samples/Controls.Sample/Pages/Core/DropFileToMauiApp.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/DropFileToMauiApp.xaml.cs
@@ -28,26 +28,6 @@ namespace Maui.Controls.Sample.Pages
 		public DropFileToMauiApp()
 		{
 			InitializeComponent();
-
-			var dragGesture = new DragGestureRecognizer();
-			dragGesture.DragStarting += DragGestureDragStarting;
-			myLayout.GestureRecognizers.Add(dragGesture);
-		}
-
-		void DragGestureDragStarting(object? sender, DragStartingEventArgs e)
-		{
-#if IOS || MACCATALYST
-			Func<UIKit.UIDragPreview> action = () =>
-			{
-				var image = UIKit.UIImage.FromFile("dotnet_bot.png");
-				UIKit.UIImageView imageView = new UIKit.UIImageView(image);
-				imageView.ContentMode = UIKit.UIViewContentMode.Center;
-				imageView.Frame = new CoreGraphics.CGRect(0, 0, 250, 250);
-				return new UIKit.UIDragPreview(imageView);
-			};
-
-			e.PlatformArgs?.SetPreviewProvider(action);
-#endif
 		}
 
 		void DropGestureDragLeave(object? sender, DragEventArgs e)
@@ -58,7 +38,6 @@ namespace Maui.Controls.Sample.Pages
 		async void DropGestureDrop(object? sender, DropEventArgs e)
 		{
 			var filePaths = new List<string>();
-			await Task.Delay(1);
 
 #if WINDOWS
 			if (e.PlatformArgs is not null && e.PlatformArgs.DragEventArgs.DataView.Contains(StandardDataFormats.StorageItems))
@@ -125,16 +104,6 @@ namespace Maui.Controls.Sample.Pages
 
 		void DropGestureDragOver(object? sender, DragEventArgs e)
 		{
-#if IOS || MACCATALYST
-			Func<UIKit.UIDragPreview> action = () =>
-			{
-				var image = UIKit.UIImage.FromFile("dotnet_bot.png");
-				UIKit.UIImageView imageView = new UIKit.UIImageView(image);
-				imageView.ContentMode = UIKit.UIViewContentMode.Center;
-				imageView.Frame = new CoreGraphics.CGRect(0, 0, 250, 250);
-				return new UIKit.UIDragPreview(imageView);
-			};
-#endif
 			Debug.WriteLine($"Dragging {e.Data?.Text}, {e.Data?.Image}");
 		}
 

--- a/src/Controls/samples/Controls.Sample/Pages/Core/DropFileToMauiApp.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/DropFileToMauiApp.xaml.cs
@@ -55,10 +55,7 @@ namespace Maui.Controls.Sample.Pages
 
 				}
 			}
-#endif
-
-
-#if MACCATALYST
+#elif MACCATALYST
 
 			var session = e.PlatformArgs?.DropSession;
 			if (session == null)
@@ -96,7 +93,8 @@ namespace Maui.Controls.Sample.Pages
 
 				return await LoadItemAsync(itemProvider, typeIdentifiers);
 			}
-
+#else
+			await Task.CompletedTask;
 #endif
 
 			lblPath.Text = filePaths.FirstOrDefault();

--- a/src/Controls/samples/Controls.Sample/Pages/Core/DropFileToMauiApp.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/DropFileToMauiApp.xaml.cs
@@ -1,0 +1,142 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Maui;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Graphics;
+
+#if WINDOWS
+using Windows.ApplicationModel.DataTransfer;
+using Windows.Storage;
+#endif
+
+#if IOS || MACCATALYST
+using UIKit;
+using Foundation;
+#endif
+
+namespace Maui.Controls.Sample.Pages
+{
+	public partial class DropFileToMauiApp
+	{
+
+		public DropFileToMauiApp()
+		{
+			InitializeComponent();
+
+			var dragGesture = new DragGestureRecognizer();
+			dragGesture.DragStarting += DragGestureDragStarting;
+			myLayout.GestureRecognizers.Add(dragGesture);
+		}
+
+		void DragGestureDragStarting(object? sender, DragStartingEventArgs e)
+		{
+#if IOS || MACCATALYST
+			Func<UIKit.UIDragPreview> action = () =>
+			{
+				var image = UIKit.UIImage.FromFile("dotnet_bot.png");
+				UIKit.UIImageView imageView = new UIKit.UIImageView(image);
+				imageView.ContentMode = UIKit.UIViewContentMode.Center;
+				imageView.Frame = new CoreGraphics.CGRect(0, 0, 250, 250);
+				return new UIKit.UIDragPreview(imageView);
+			};
+
+			e.PlatformArgs?.SetPreviewProvider(action);
+#endif
+		}
+
+		void DropGestureDragLeave(object? sender, DragEventArgs e)
+		{
+
+		}
+
+		async void DropGestureDrop(object? sender, DropEventArgs e)
+		{
+			var filePaths = new List<string>();
+			await Task.Delay(1);
+
+#if WINDOWS
+			if (e.PlatformArgs is not null && e.PlatformArgs.DragEventArgs.DataView.Contains(StandardDataFormats.StorageItems))
+			{
+				var items = await e.PlatformArgs.DragEventArgs.DataView.GetStorageItemsAsync();
+				if (items.Any())
+				{
+					foreach (var item in items)
+					{
+						if (item is StorageFile file)
+						{
+							filePaths.Add(item.Path);
+						}
+					}
+
+				}
+			}
+#endif
+
+
+#if MACCATALYST
+
+			var session = e.PlatformArgs?.DropSession;
+			if (session == null)
+			{
+				return;
+			}
+			foreach (UIDragItem item in session.Items)
+			{
+				var result = await LoadItemAsync(item.ItemProvider, item.ItemProvider.RegisteredTypeIdentifiers.ToList());
+				if (result is not null)
+				{
+					filePaths.Add(result.FileUrl?.Path!);
+				}
+			}
+			foreach (var item in filePaths)
+			{
+				Debug.WriteLine($"Path: {item}");
+			}
+
+			static async Task<LoadInPlaceResult?> LoadItemAsync(NSItemProvider itemProvider, List<string> typeIdentifiers)
+			{
+				if (typeIdentifiers is null || typeIdentifiers.Count == 0)
+				{
+					return null;
+				}
+
+				var typeIdent = typeIdentifiers.First();
+
+				if (itemProvider.HasItemConformingTo(typeIdent))
+				{
+					return await itemProvider.LoadInPlaceFileRepresentationAsync(typeIdent);
+				}
+
+				typeIdentifiers.Remove(typeIdent);
+
+				return await LoadItemAsync(itemProvider, typeIdentifiers);
+			}
+
+#endif
+
+			lblPath.Text = filePaths.FirstOrDefault();
+		}
+
+		void DropGestureDragOver(object? sender, DragEventArgs e)
+		{
+#if IOS || MACCATALYST
+			Func<UIKit.UIDragPreview> action = () =>
+			{
+				var image = UIKit.UIImage.FromFile("dotnet_bot.png");
+				UIKit.UIImageView imageView = new UIKit.UIImageView(image);
+				imageView.ContentMode = UIKit.UIViewContentMode.Center;
+				imageView.Frame = new CoreGraphics.CGRect(0, 0, 250, 250);
+				return new UIKit.UIDragPreview(imageView);
+			};
+#endif
+			Debug.WriteLine($"Dragging {e.Data?.Text}, {e.Data?.Image}");
+		}
+
+	}
+}

--- a/src/Controls/samples/Controls.Sample/ViewModels/GesturesViewModel.cs
+++ b/src/Controls/samples/Controls.Sample/ViewModels/GesturesViewModel.cs
@@ -11,6 +11,8 @@ namespace Maui.Controls.Sample.ViewModels
 		{
 			new SectionModel(typeof(DragAndDropBetweenLayouts), "Drag And Drop",
 				"Drag and Drop Views."),
+			new SectionModel(typeof(DropFileToMauiApp), "Drag and Drop file from OS",
+				"Drop File to App"),
 			new SectionModel(typeof(PanGestureGallery), "Pan Gesture",
 				"Pan Gesture."),
 			new SectionModel(typeof(PinchGestureTestPage), "Pinch Gesture",

--- a/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
@@ -202,10 +202,7 @@ namespace Microsoft.Maui.Controls.Platform
 				element = ve;
 			}
 
-			if (datapackage is null)
-				return;
-
-			var args = new DropEventArgs(datapackage.View, (relativeTo) => GetPosition(relativeTo, e), new PlatformDropEventArgs(sender as UIElement, e));
+			var args = new DropEventArgs(datapackage?.View, (relativeTo) => GetPosition(relativeTo, e), new PlatformDropEventArgs(sender as UIElement, e));
 			SendEventArgs<DropGestureRecognizer>(async rec =>
 			{
 				if (!rec.AllowDrop)

--- a/src/Controls/src/Core/Platform/iOS/DragAndDropDelegate.cs
+++ b/src/Controls/src/Core/Platform/iOS/DragAndDropDelegate.cs
@@ -90,15 +90,14 @@ namespace Microsoft.Maui.Controls.Platform
 		{
 			UIDropOperation operation = UIDropOperation.Cancel;
 
-			if (session.LocalDragSession == null)
-				return new UIDropProposal(operation);
-
 			DataPackage package = null;
-
-			if (session.LocalDragSession.Items.Length > 0 &&
-				session.LocalDragSession.Items[0].LocalObject is CustomLocalStateData cdi)
+			if (session.LocalDragSession != null)
 			{
-				package = cdi.DataPackage;
+				if (session.LocalDragSession.Items.Length > 0 &&
+					session.LocalDragSession.Items[0].LocalObject is CustomLocalStateData cdi)
+				{
+					package = cdi.DataPackage;
+				}
 			}
 
 			var platformArgs = new PlatformDragEventArgs(_viewHandler.PlatformView, interaction, session);


### PR DESCRIPTION
### Description of Change

Seems we can allow the DropGestureRecognizer to work with an item being dragged from outside of our application, like drop a file into the .NET MAUI app and process it. 
This does make the experience perfect but unblocks ours users to use the Drop gesture.

Not sure how we test this, I added a sample page that allows to show the path of the file dragged. we can add more logic to this . 

I used some sample code from @drasticactions for the native parte.. 


### Issues Fixed

Fixes #6080 
