### PR TITLE
[Catalyst] Add default FilePickerFileTypes

### DIFF
--- a/src/Essentials/src/FilePicker/FilePicker.ios.cs
+++ b/src/Essentials/src/FilePicker/FilePicker.ios.cs
@@ -89,31 +89,36 @@ namespace Microsoft.Maui.Storage
 		static FilePickerFileType PlatformImageFileType() =>
 			new FilePickerFileType(new Dictionary<DevicePlatform, IEnumerable<string>>
 			{
-				{ DevicePlatform.iOS, new[] { (string)UTType.Image } }
+				{ DevicePlatform.iOS, new[] { (string)UTType.Image } },
+				{ DevicePlatform.MacCatalyst, new[] { (string)UTType.Image } }
 			});
 
 		static FilePickerFileType PlatformPngFileType() =>
 			new FilePickerFileType(new Dictionary<DevicePlatform, IEnumerable<string>>
 			{
-				{ DevicePlatform.iOS, new[] { (string)UTType.PNG } }
+				{ DevicePlatform.iOS, new[] { (string)UTType.PNG } },
+				{ DevicePlatform.MacCatalyst, new[] { (string)UTType.PNG } }
 			});
 
 		static FilePickerFileType PlatformJpegFileType() =>
 			new FilePickerFileType(new Dictionary<DevicePlatform, IEnumerable<string>>
 			{
-				{ DevicePlatform.iOS, new[] { (string)UTType.JPEG } }
+				{ DevicePlatform.iOS, new[] { (string)UTType.JPEG } },
+				{ DevicePlatform.MacCatalyst, new[] { (string)UTType.JPEG } }
 			});
 
 		static FilePickerFileType PlatformVideoFileType() =>
 			new FilePickerFileType(new Dictionary<DevicePlatform, IEnumerable<string>>
 			{
-				{ DevicePlatform.iOS, new string[] { UTType.MPEG4, UTType.Video, UTType.AVIMovie, UTType.AppleProtectedMPEG4Video, "mp4", "m4v", "mpg", "mpeg", "mp2", "mov", "avi", "mkv", "flv", "gifv", "qt" } }
+				{ DevicePlatform.iOS, new string[] { UTType.MPEG4, UTType.Video, UTType.AVIMovie, UTType.AppleProtectedMPEG4Video, "mp4", "m4v", "mpg", "mpeg", "mp2", "mov", "avi", "mkv", "flv", "gifv", "qt" } },
+				{ DevicePlatform.MacCatalyst, new string[] { UTType.MPEG4, UTType.Video, UTType.AVIMovie, UTType.AppleProtectedMPEG4Video, "mp4", "m4v", "mpg", "mpeg", "mp2", "mov", "avi", "mkv", "flv", "gifv", "qt" } }
 			});
 
 		static FilePickerFileType PlatformPdfFileType() =>
 			new FilePickerFileType(new Dictionary<DevicePlatform, IEnumerable<string>>
 			{
-				{ DevicePlatform.iOS, new[] { (string)UTType.PDF } }
+				{ DevicePlatform.iOS, new[] { (string)UTType.PDF } },
+				{ DevicePlatform.MacCatalyst, new[] { (string)UTType.PDF } }
 			});
 #pragma warning restore CA1422 // Validate platform compatibility
 #pragma warning restore CA1416


### PR DESCRIPTION
### Description of Change

When we are trying the samples of the maui repo, if you try the FilePickerPage and select one of the options to select a particular file type it would throw NSE. These types from iOS seem to work fine on Catalyst. 

To test use the Essentials sample and the FilePicker for image or pdf. 

I m trying to figure why sometimes it still return null when you pick a file, we applied a fix but doesn-t seem to be working everything , so this could be related with some time of race condition. 

### Issues Fixed

Work related with  #15126 

