### PR TITLE
[Windows] Clamp images inside buttons to button width/height

### DIFF
--- a/src/Core/src/Platform/Windows/MauiButton.cs
+++ b/src/Core/src/Platform/Windows/MauiButton.cs
@@ -2,19 +2,36 @@
 using Microsoft.UI.Xaml.Automation.Peers;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
-using Windows.Security.Credentials.UI;
 using WThickness = Microsoft.UI.Xaml.Thickness;
 
 namespace Microsoft.Maui.Platform
 {
 	public class MauiButton : Button
 	{
+		DefaultMauiButtonContent _defaultButtonContent;
+
 		public MauiButton()
 		{
-			Content = new DefaultMauiButtonContent();
+			Content = _defaultButtonContent = new DefaultMauiButtonContent();
 
 			VerticalAlignment = VerticalAlignment.Stretch;
 			HorizontalAlignment = HorizontalAlignment.Stretch;
+
+			SizeChanged += MauiButton_SizeChanged;
+		}
+
+		private void MauiButton_SizeChanged(object sender, SizeChangedEventArgs e)
+		{
+			if (!double.IsInfinity(Width))
+			{
+				_defaultButtonContent.LimitImageWidth(
+					ActualWidth - (Padding.Left + Padding.Right));
+			}
+			else if (!double.IsInfinity(Height))
+			{
+				_defaultButtonContent.LimitImageHeight(
+					ActualHeight - (Padding.Top + Padding.Bottom));
+			}
 		}
 
 		protected override AutomationPeer OnCreateAutomationPeer()
@@ -61,6 +78,16 @@ namespace Microsoft.Maui.Platform
 			Children.Add(_textBlock);
 
 			LayoutImageLeft(0);
+		}
+
+		internal void LimitImageWidth(double width)
+		{
+			_image.MaxWidth = width - ColumnSpacing;
+		}
+
+		internal void LimitImageHeight(double height)
+		{
+			_image.MaxHeight = height - RowSpacing;
 		}
 
 		public void LayoutImageLeft(double spacing)
@@ -133,7 +160,6 @@ namespace Microsoft.Maui.Platform
 			Grid.SetRow(_textBlock, 0);
 			Grid.SetRowSpan(_textBlock, 2);
 			Grid.SetColumnSpan(_textBlock, 1);
-
 		}
 
 		void SetupVerticalLayout(double spacing)

--- a/src/Core/src/Platform/Windows/MauiButton.cs
+++ b/src/Core/src/Platform/Windows/MauiButton.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.UI.Xaml;
+﻿using System;
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Automation.Peers;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
@@ -8,11 +9,9 @@ namespace Microsoft.Maui.Platform
 {
 	public class MauiButton : Button
 	{
-		DefaultMauiButtonContent _defaultButtonContent;
-
 		public MauiButton()
 		{
-			Content = _defaultButtonContent = new DefaultMauiButtonContent();
+			Content = new DefaultMauiButtonContent();
 
 			VerticalAlignment = VerticalAlignment.Stretch;
 			HorizontalAlignment = HorizontalAlignment.Stretch;
@@ -22,15 +21,27 @@ namespace Microsoft.Maui.Platform
 
 		private void MauiButton_SizeChanged(object sender, SizeChangedEventArgs e)
 		{
-			if (!double.IsInfinity(Width))
+			if (Content is DefaultMauiButtonContent defaultButtonContent)
 			{
-				_defaultButtonContent.LimitImageWidth(
-					ActualWidth - (Padding.Left + Padding.Right));
-			}
-			else if (!double.IsInfinity(Height))
-			{
-				_defaultButtonContent.LimitImageHeight(
-					ActualHeight - (Padding.Top + Padding.Bottom));
+				if (!double.IsNaN(Width))
+				{
+					var maxWidth = Math.Max(0, ActualWidth - (Padding.Left + Padding.Right) - defaultButtonContent.ColumnSpacing);
+					defaultButtonContent.LimitImageWidth(maxWidth);
+				}
+				else
+				{
+					defaultButtonContent.LimitImageWidth(double.PositiveInfinity);
+				}
+
+				if (!double.IsNaN(Height))
+				{
+					var maxHeight = Math.Max(0, ActualHeight - (Padding.Top + Padding.Bottom) - defaultButtonContent.RowSpacing);
+					defaultButtonContent.LimitImageHeight(maxHeight);
+				}
+				else
+				{
+					defaultButtonContent.LimitImageHeight(double.PositiveInfinity);
+				}
 			}
 		}
 
@@ -82,12 +93,12 @@ namespace Microsoft.Maui.Platform
 
 		internal void LimitImageWidth(double width)
 		{
-			_image.MaxWidth = width - ColumnSpacing;
+			_image.MaxWidth = width;
 		}
 
 		internal void LimitImageHeight(double height)
 		{
-			_image.MaxHeight = height - RowSpacing;
+			_image.MaxHeight = height;
 		}
 
 		public void LayoutImageLeft(double spacing)


### PR DESCRIPTION
### Description of Change

This PR forces images inside buttons to always fit inside the available space, rather than expand be clipped

### Issues Fixed

Fixes #21683