### PR TITLE
[Android] Removing TapGestureRecognizer with at least 2 taps causes Exception - fix

### DIFF
--- a/src/Controls/src/Core/Platform/Android/InnerGestureListener.cs
+++ b/src/Controls/src/Core/Platform/Android/InnerGestureListener.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 		bool HasAnyGestures()
 		{
-			return _panGestureHandler.HasAnyGestures() || _tapGestureHandler.HasAnyGestures() || _swipeGestureHandler.HasAnyGestures();
+			return (_panGestureHandler?.HasAnyGestures() ?? false) || (_tapGestureHandler?.HasAnyGestures() ?? false) || (_swipeGestureHandler?.HasAnyGestures() ?? false);
 		}
 
 		// This is needed because GestureRecognizer callbacks can be delayed several hundred milliseconds

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue21437.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue21437.xaml
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Maui.Controls.Sample.Issues.Issue21437"
+             xmlns:issues="clr-namespace:Maui.Controls.Sample.Issues"
+             Title="Issue21437">
+   <VerticalStackLayout BindableLayout.ItemsSource="{Binding Items}" HorizontalOptions="Start">
+        <BindableLayout.ItemTemplate>
+            <DataTemplate>
+                <Label Text="{Binding .}" AutomationId="{Binding .}" HorizontalOptions="Start">
+                    <Label.GestureRecognizers>
+                        <TapGestureRecognizer
+                            NumberOfTapsRequired="2"
+                            Command="{Binding TapCommand, Source={RelativeSource AncestorType={x:Type issues:Issue21437}}}"
+                            CommandParameter="{Binding .}" />
+                    </Label.GestureRecognizers>
+                </Label>
+            </DataTemplate>
+        </BindableLayout.ItemTemplate>
+    </VerticalStackLayout>
+</ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue21437.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue21437.xaml.cs
@@ -1,0 +1,24 @@
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+using System.Collections.ObjectModel;
+
+namespace Maui.Controls.Sample.Issues;
+
+[XamlCompilation(XamlCompilationOptions.Compile)]
+[Issue(IssueTracker.Github, 21437, "Removing TapGestureRecognizer with at least 2 taps causes Exception", PlatformAffected.Android)]
+
+public partial class Issue21437 : ContentPage
+{
+	public ObservableCollection<string> Items { get; } = new() { "Item1", "Item2", "Item3" };
+
+	public Command TapCommand => new Command<string>(obj =>
+	{
+		Items.Remove(obj);
+	});
+
+	public Issue21437()
+	{
+		InitializeComponent();
+		BindingContext = this;
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue21437.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue21437.xaml.cs
@@ -1,10 +1,7 @@
-using Microsoft.Maui.Controls;
-using Microsoft.Maui.Controls.Xaml;
 using System.Collections.ObjectModel;
 
 namespace Maui.Controls.Sample.Issues;
 
-[XamlCompilation(XamlCompilationOptions.Compile)]
 [Issue(IssueTracker.Github, 21437, "Removing TapGestureRecognizer with at least 2 taps causes Exception", PlatformAffected.Android)]
 
 public partial class Issue21437 : ContentPage

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue21437.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue21437.cs
@@ -14,6 +14,7 @@ public class Issue21437 : _IssuesUITest
 	{ }
 
     [Test]
+	[Category(UITestCategories.Gestures)]
 	public void ExceptionShouldNotBeThrown()
 	{
 		_ = App.WaitForElement("Item2");

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue21437.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue21437.cs
@@ -1,0 +1,23 @@
+﻿using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.AppiumTests.Issues;
+
+public class Issue21437 : _IssuesUITest
+{
+	public override string Issue => "Removing TapGestureRecognizer with at least 2 taps causes Exception";
+
+	public Issue21437(TestDevice device)
+		: base(device)
+	{ }
+
+    [Test]
+	public void ExceptionShouldNotBeThrown()
+	{
+		_ = App.WaitForElement("Item2");
+		App.DoubleClick("Item2");
+
+        //The test passes if no exception is thrown
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue21437.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue21437.cs
@@ -2,7 +2,7 @@
 using UITest.Appium;
 using UITest.Core;
 
-namespace Microsoft.Maui.AppiumTests.Issues;
+namespace Microsoft.Maui.TestCases.Tests.Issues;
 
 public class Issue21437 : _IssuesUITest
 {

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue21437.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue21437.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿#if ANDROID
+using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
 
@@ -21,3 +22,4 @@ public class Issue21437 : _IssuesUITest
         //The test passes if no exception is thrown
 	}
 }
+#endif


### PR DESCRIPTION
### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/21437

|Before|After|
|--|--|
|<video src="https://github.com/dotnet/maui/assets/42434498/4b1574cc-0059-4789-b504-4f71a1baeb74" width="300px"/>|<video src="https://github.com/dotnet/maui/assets/42434498/c1740d6e-d7ac-470c-91cf-7cede4634f3e" width="300px"/>|


