### PR TITLE
Fix null reference exception in KeyboardAutoManagerScroll when UIWindow is null

### DIFF
--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issue21726.xaml
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issue21726.xaml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Maui.Controls.Sample.Issues.Issue21726"
+             Title="Issue21726">
+    <VerticalStackLayout>
+        <Button Text="AddVC" AutomationId="AddVC" Clicked="AddVC"/>
+        <Label Background="Green" HeightRequest="100" WidthRequest="100" Text="SUCCESS" x:Name="successLabel" AutomationId="SuccessLabel" IsVisible="false"/>
+    </VerticalStackLayout>
+</ContentPage>

--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issue21726.xaml
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issue21726.xaml
@@ -5,6 +5,5 @@
              Title="Issue21726">
     <VerticalStackLayout>
         <Button Text="AddVC" AutomationId="AddVC" Clicked="AddVC"/>
-        <Label Background="Green" HeightRequest="100" WidthRequest="100" Text="SUCCESS" x:Name="successLabel" AutomationId="SuccessLabel" IsVisible="false"/>
     </VerticalStackLayout>
 </ContentPage>

--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issue21726.xaml.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issue21726.xaml.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Linq;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+using System.Threading.Tasks;
+
+namespace Maui.Controls.Sample.Issues;
+
+[XamlCompilation(XamlCompilationOptions.Compile)]
+[Issue(IssueTracker.Github, 21726, "Modal with a bottom sheet should not crash iOS Keyboard Scroll", PlatformAffected.iOS)]
+public partial class Issue21726 : ContentPage
+{
+	public static bool Success = false;
+	public Issue21726()
+	{
+		InitializeComponent();
+	}
+
+	protected override void OnAppearing()
+	{
+		base.OnAppearing();
+		if (Success)
+			successLabel.IsVisible = true;
+	}
+
+	protected override void OnDisappearing()
+	{
+		base.OnDisappearing();
+		Success = false;
+	}
+
+	void AddVC (object sender, EventArgs e)
+	{
+#if IOS
+		var window = UIKit.UIApplication.SharedApplication
+        .ConnectedScenes
+        .OfType<UIKit.UIWindowScene>()
+        .SelectMany(s => s.Windows)
+        .FirstOrDefault(w => w.IsKeyWindow);
+
+		var rootVC = window?.RootViewController;
+		while (rootVC?.PresentedViewController != null)
+		{
+			rootVC = rootVC.PresentedViewController;
+		}
+
+		if (rootVC is not null) {
+			var testVC = new TestViewController();
+
+			var testNC = new UIKit.UINavigationController(testVC);
+
+			testNC.ModalPresentationStyle = UIKit.UIModalPresentationStyle.FullScreen;
+
+			rootVC.PresentViewController(testNC, true, null);
+		}
+#endif
+	}
+
+#if IOS
+	public class TestViewController: UIKit.UIViewController {
+
+		UIKit.UITextField TextField1;
+		UIKit.UIButton Button1;
+
+		public override void ViewDidLoad() {
+			base.ViewDidLoad();
+
+			View.BackgroundColor = UIKit.UIColor.White;
+
+			TextField1 = new UIKit.UITextField(new CoreGraphics.CGRect(20, 120, 200, 20));
+			TextField1.Placeholder = "TextField1";
+			TextField1.BorderStyle = UIKit.UITextBorderStyle.RoundedRect;
+
+			Button1 = new UIKit.UIButton(new CoreGraphics.CGRect(20, 320, 200, 40));
+			Button1.SetTitle("Dismiss", UIKit.UIControlState.Normal);
+			Button1.BackgroundColor = UIKit.UIColor.SystemBlue;
+			Button1.TouchUpInside += (sender, e) => {
+				DismissViewController(true, null);
+			};
+
+			View.AddSubview(TextField1);
+			View.AddSubview(Button1);
+		}
+
+		public override async void ViewDidAppear(bool animated) {
+			try
+			{
+				base.ViewDidAppear(animated);
+				TextField1.BecomeFirstResponder();
+				await Task.Delay(1000);
+				TextField1.ResignFirstResponder();
+				await Task.Delay(1000);
+				Button1.SendActionForControlEvents(UIKit.UIControlEvent.TouchUpInside);
+				Issue21726.Success = true;
+			}
+			catch
+			{
+				Issue21726.Success = false;
+			}
+		}
+	}
+#endif
+}

--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issue21726.xaml.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issue21726.xaml.cs
@@ -10,23 +10,9 @@ namespace Maui.Controls.Sample.Issues;
 [Issue(IssueTracker.Github, 21726, "Modal with a bottom sheet should not crash iOS Keyboard Scroll", PlatformAffected.iOS)]
 public partial class Issue21726 : ContentPage
 {
-	public static bool Success = false;
 	public Issue21726()
 	{
 		InitializeComponent();
-	}
-
-	protected override void OnAppearing()
-	{
-		base.OnAppearing();
-		if (Success)
-			successLabel.IsVisible = true;
-	}
-
-	protected override void OnDisappearing()
-	{
-		base.OnDisappearing();
-		Success = false;
 	}
 
 	void AddVC (object sender, EventArgs e)
@@ -47,9 +33,10 @@ public partial class Issue21726 : ContentPage
 		if (rootVC is not null) {
 			var testVC = new TestViewController();
 
-			var testNC = new UIKit.UINavigationController(testVC);
-
-			testNC.ModalPresentationStyle = UIKit.UIModalPresentationStyle.FullScreen;
+			var testNC = new UIKit.UINavigationController(testVC)
+			{
+				ModalPresentationStyle = UIKit.UIModalPresentationStyle.FullScreen
+			};
 
 			rootVC.PresentViewController(testNC, true, null);
 		}
@@ -67,36 +54,23 @@ public partial class Issue21726 : ContentPage
 
 			View.BackgroundColor = UIKit.UIColor.White;
 
-			TextField1 = new UIKit.UITextField(new CoreGraphics.CGRect(20, 120, 200, 20));
-			TextField1.Placeholder = "TextField1";
-			TextField1.BorderStyle = UIKit.UITextBorderStyle.RoundedRect;
+			TextField1 = new UIKit.UITextField(new CoreGraphics.CGRect(20, 120, 200, 20))
+			{
+				Placeholder = "TextField1",
+				BorderStyle = UIKit.UITextBorderStyle.RoundedRect,
+				AccessibilityIdentifier = "TextField1"
+			};
 
 			Button1 = new UIKit.UIButton(new CoreGraphics.CGRect(20, 320, 200, 40));
 			Button1.SetTitle("Dismiss", UIKit.UIControlState.Normal);
 			Button1.BackgroundColor = UIKit.UIColor.SystemBlue;
+			Button1.AccessibilityIdentifier = "Button1";
 			Button1.TouchUpInside += (sender, e) => {
 				DismissViewController(true, null);
 			};
 
 			View.AddSubview(TextField1);
 			View.AddSubview(Button1);
-		}
-
-		public override async void ViewDidAppear(bool animated) {
-			try
-			{
-				base.ViewDidAppear(animated);
-				TextField1.BecomeFirstResponder();
-				await Task.Delay(1000);
-				TextField1.ResignFirstResponder();
-				await Task.Delay(1000);
-				Button1.SendActionForControlEvents(UIKit.UIControlEvent.TouchUpInside);
-				Issue21726.Success = true;
-			}
-			catch
-			{
-				Issue21726.Success = false;
-			}
 		}
 	}
 #endif

--- a/src/Controls/tests/UITests/Tests/Issues/Issue21726.cs
+++ b/src/Controls/tests/UITests/Tests/Issues/Issue21726.cs
@@ -1,0 +1,37 @@
+﻿using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.AppiumTests.Issues
+{
+    public class Issue21726 : _IssuesUITest
+    {
+        public Issue21726(TestDevice device) : base(device)
+        {
+        }
+
+        public override string Issue => "Modal with a bottom sheet should not crash iOS Keyboard Scroll";
+
+        [Test]
+        public void PushViewControllerWithNullWindow()
+        {
+            App.WaitForElement("AddVC");
+
+            App.Click("AddVC");
+
+            App.WaitForElement("AddVC");
+
+            try
+            {
+                var didSucceed = App.WaitForElement("SuccessLabel");
+            }
+            catch
+            {
+                // Just in case these tests leave the app in an unreliable state
+                App.ResetApp();
+                FixtureSetup();
+                throw;
+            }
+        }
+    }
+}

--- a/src/Controls/tests/UITests/Tests/Issues/Issue21726.cs
+++ b/src/Controls/tests/UITests/Tests/Issues/Issue21726.cs
@@ -15,15 +15,14 @@ namespace Microsoft.Maui.AppiumTests.Issues
         [Test]
         public void PushViewControllerWithNullWindow()
         {
-            App.WaitForElement("AddVC");
-
-            App.Click("AddVC");
-
-            App.WaitForElement("AddVC");
-
             try
             {
-                var didSucceed = App.WaitForElement("SuccessLabel");
+                App.WaitForElement("AddVC");
+                App.Click("AddVC");
+                App.WaitForElement("TextField1").Click();
+                App.WaitForElement("Button1").Click();
+                var mainPageElement = App.WaitForElement("AddVC");
+                Assert.NotNull(mainPageElement);
             }
             catch
             {

--- a/src/Controls/tests/UITests/Tests/Issues/Issue21726.cs
+++ b/src/Controls/tests/UITests/Tests/Issues/Issue21726.cs
@@ -15,22 +15,14 @@ namespace Microsoft.Maui.AppiumTests.Issues
         [Test]
         public void PushViewControllerWithNullWindow()
         {
-            try
-            {
-                App.WaitForElement("AddVC");
-                App.Click("AddVC");
-                App.WaitForElement("TextField1").Click();
-                App.WaitForElement("Button1").Click();
-                var mainPageElement = App.WaitForElement("AddVC");
-                Assert.NotNull(mainPageElement);
-            }
-            catch
-            {
-                // Just in case these tests leave the app in an unreliable state
-                App.ResetApp();
-                FixtureSetup();
-                throw;
-            }
+            this.IgnoreIfPlatforms([TestDevice.Android, TestDevice.Mac, TestDevice.Windows]);
+
+            App.WaitForElement("AddVC");
+            App.Click("AddVC");
+            App.WaitForElement("TextField1").Click();
+            App.WaitForElement("Button1").Click();
+            var mainPageElement = App.WaitForElement("AddVC");
+            Assert.NotNull(mainPageElement);
         }
     }
 }

--- a/src/Core/src/Platform/iOS/KeyboardAutoManagerScroll.cs
+++ b/src/Core/src/Platform/iOS/KeyboardAutoManagerScroll.cs
@@ -299,7 +299,8 @@ public static class KeyboardAutoManagerScroll
 	internal static void AdjustPosition()
 	{
 		if (ContainerView is null
-			|| (View is not UITextField && View is not UITextView))
+			|| (View is not UITextField && View is not UITextView)
+			|| !View.IsDescendantOfView(ContainerView))
 		{
 			IsKeyboardAutoScrollHandling = false;
 			return;

--- a/src/Core/src/Platform/iOS/KeyboardAutoManagerScroll.cs
+++ b/src/Core/src/Platform/iOS/KeyboardAutoManagerScroll.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * This class is adapted from IQKeyboardManager which is an open-source
  * library implemented for iOS to handle Keyboard interactions with
  * UITextFields/UITextViews. Link to their MIT License can be found here:
@@ -310,6 +310,11 @@ public static class KeyboardAutoManagerScroll
 
 		var rootViewOrigin = new CGPoint(ContainerView.Frame.GetMinX(), ContainerView.Frame.GetMinY());
 		var window = ContainerView.Window;
+
+		if (window is null)
+		{
+			return;
+		}
 
 		var intersectRect = CGRect.Intersect(KeyboardFrame, window.Frame);
 		var kbSize = intersectRect == CGRect.Empty ? new CGSize(KeyboardFrame.Width, 0) : intersectRect.Size;

--- a/src/Core/src/Platform/iOS/KeyboardAutoManagerScroll.cs
+++ b/src/Core/src/Platform/iOS/KeyboardAutoManagerScroll.cs
@@ -414,9 +414,7 @@ public static class KeyboardAutoManagerScroll
 		}
 
 		else if (cursorRect.Y >= topBoundary && cursorRect.Y < bottomBoundary)
-		{
 			return;
-		}
 
 		else if (cursorRect.Y > bottomBoundary)
 			move = cursorRect.Y - (nfloat)bottomBoundary;

--- a/src/Core/src/Platform/iOS/KeyboardAutoManagerScroll.cs
+++ b/src/Core/src/Platform/iOS/KeyboardAutoManagerScroll.cs
@@ -415,7 +415,6 @@ public static class KeyboardAutoManagerScroll
 
 		else if (cursorRect.Y >= topBoundary && cursorRect.Y < bottomBoundary)
 		{
-			IsKeyboardAutoScrollHandling = false;
 			return;
 		}
 

--- a/src/Core/src/Platform/iOS/KeyboardAutoManagerScroll.cs
+++ b/src/Core/src/Platform/iOS/KeyboardAutoManagerScroll.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * This class is adapted from IQKeyboardManager which is an open-source
  * library implemented for iOS to handle Keyboard interactions with
  * UITextFields/UITextViews. Link to their MIT License can be found here:

--- a/src/Core/src/Platform/iOS/KeyboardAutoManagerScroll.cs
+++ b/src/Core/src/Platform/iOS/KeyboardAutoManagerScroll.cs
@@ -313,6 +313,7 @@ public static class KeyboardAutoManagerScroll
 
 		if (window is null)
 		{
+			IsKeyboardAutoScrollHandling = false;
 			return;
 		}
 
@@ -412,7 +413,10 @@ public static class KeyboardAutoManagerScroll
 		}
 
 		else if (cursorRect.Y >= topBoundary && cursorRect.Y < bottomBoundary)
+		{
+			IsKeyboardAutoScrollHandling = false;
 			return;
+		}
 
 		else if (cursorRect.Y > bottomBoundary)
 			move = cursorRect.Y - (nfloat)bottomBoundary;


### PR DESCRIPTION
### Description of Change

There is a `NullReferenceException` being thrown by the `KeyboardAutoManagerScroll` during specific scenarios such as using a [BottomSheet](https://github.com/the49ltd/The49.Maui.BottomSheet) and focussing an `Editor` control.

After raising the issue @Larhei noted that this crash is also happening within the `SearchHandler` so its not just external libraries that are affected.

I have added a null check to return early from `AdjustPosition` if the `UIWindow` is `null`.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #21726
Fixes #21160

### Methodology

I have verified this locally by referencing the [BottomSheet](https://github.com/the49ltd/The49.Maui.BottomSheet) library (at great pain I might add... I had to reference the source locally and remove all nugets 🤦‍♂️) and then verifying the issue happened on the `Maui.Controls.Sample` app.

I then debugged through the `KeyboardAutoManagerScroll` class to verify where the `NullReferenceException` was throwing, added a null check + return and then verified my example worked at runtime.

I have attached a video of the sample app, the `UIWindow` showing null in the debugger & the crash no longer happening on my fix branch.

https://github.com/dotnet/maui/assets/33064621/c807a490-da94-46d8-ad69-b8f7291af564