### PR TITLE
Update NavigatedFromEventArgs.cs

### DIFF
--- a/src/Controls/src/Core/Page/NavigatedFromEventArgs.cs
+++ b/src/Controls/src/Core/Page/NavigatedFromEventArgs.cs
@@ -10,6 +10,6 @@ namespace Microsoft.Maui.Controls
 			DestinationPage = destinationPage;
 		}
 
-		internal Page DestinationPage { get; }
+		public Page DestinationPage { get; }
 	}
 }


### PR DESCRIPTION
A public class that does not expose any properties is not acceptable especially if when you override the event and its argument it does not give you the information you need


### Description of Change

    protected override void OnNavigatedFrom(NavigatedFromEventArgs args)
    {
        Page? page = args.GetType().GetProperty("DestinationPage", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)?.GetValue(args) as Page;
        if (page is MainPage)
        {
            Model.Reset();
        }
        base.OnNavigatedFrom(args);
    }

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
