### PR TITLE
Add .NET MAUI into the launch settings

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,22 +1,28 @@
 {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
-    "version": "0.2.0",
-    "configurations": [
-        {
-            "name": "Attach to Process",
-            "type": "coreclr",
-            "request": "attach",
-            "processId": "${input:processid}"
-          }
-    ],
-    "inputs": [
-        {
-          "id": "processid",
-          "type": "promptString",
-          "default": "0",
-          "description": "Enter dotnet build process id reported when setting the env var MSBUILDDEBUGONSTART=2",
-        }
-    ]
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": ".NET MAUI",
+      "type": "maui",
+      "request": "launch",
+      "preLaunchTask": "maui: Build"
+    },
+    {
+      "name": "Attach to Process",
+      "type": "coreclr",
+      "request": "attach",
+      "processId": "${input:processid}"
+    }
+  ],
+  "inputs": [
+    {
+      "id": "processid",
+      "type": "promptString",
+      "default": "0",
+      "description": "Enter dotnet build process id reported when setting the env var MSBUILDDEBUGONSTART=2",
+    }
+  ]
 }


### PR DESCRIPTION



### Description of Change
After this PR: https://github.com/dotnet/maui/pull/20695

We now need to add MAUI back in there. It was not needed before because if it was blank it was assumed maui. Now it is more than just MAUI.