### PR TITLE
Use the path for determining the extension

### DIFF
--- a/src/Core/src/ImageSources/UriImageSourceService/UriImageSourceService.iOS.cs
+++ b/src/Core/src/ImageSources/UriImageSourceService/UriImageSourceService.iOS.cs
@@ -47,9 +47,7 @@ namespace Microsoft.Maui
 		{
 			// TODO: use a real caching library with the URI
 
-			var hash = Crc64.ComputeHashString(imageSource.Uri.OriginalString);
-			var ext = Path.GetExtension(imageSource.Uri.OriginalString);
-			var filename = $"{hash}{ext}";
+			var filename = GetCachedFileName(imageSource);
 			var pathToImageCache = Path.Combine(CacheDirectory, filename);
 
 			NSData? imageData;
@@ -116,6 +114,14 @@ namespace Microsoft.Maui
 				throw new InvalidOperationException($"Unable to load image stream data from '{path}'.");
 
 			return imageData;
+		}
+
+		internal string GetCachedFileName(IUriImageSource imageSource)
+		{
+			var hash = Crc64.ComputeHashString(imageSource.Uri.OriginalString);
+			var ext = Path.GetExtension(imageSource.Uri.AbsolutePath);
+			var filename = $"{hash}{ext}";
+			return filename;
 		}
 #pragma warning restore CA1822 // Mark members as static
 	}

--- a/src/Core/tests/DeviceTests/Services/ImageSource/UriImageSourceServiceTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Services/ImageSource/UriImageSourceServiceTests.iOS.cs
@@ -19,5 +19,31 @@ namespace Microsoft.Maui.DeviceTests
 
 			await Assert.ThrowsAsync<InvalidCastException>(() => service.GetImageAsync(imageSource));
 		}
+
+		[Theory]
+		[InlineData("https://test.com/file", "{hash}")]
+		[InlineData("https://test.com/file#test", "{hash}")]
+		[InlineData("https://test.com/file#test=123", "{hash}")]
+		[InlineData("https://test.com/file?test", "{hash}")]
+		[InlineData("https://test.com/file?test=123", "{hash}")]
+		[InlineData("https://test.com/file.png", "{hash}.png")]
+		[InlineData("https://test.com/file.jpg", "{hash}.jpg")]
+		[InlineData("https://test.com/file.gif", "{hash}.gif")]
+		[InlineData("https://test.com/file.jpg?ids", "{hash}.jpg")]
+		[InlineData("https://test.com/file.jpg?id=123", "{hash}.jpg")]
+		[InlineData("https://test.com/file.gif#id=123", "{hash}.gif")]
+		[InlineData("https://test.com/file.gif#ids", "{hash}.gif")]
+		public void CachedFilenameIsCorrectAndValid(string uri, string expected)
+		{
+			using var algorithm = new Crc64HashAlgorithm();
+			var hashed = algorithm.ComputeHashString(uri);
+			expected = expected.Replace("{hash}", hashed, StringComparison.OrdinalIgnoreCase);
+
+			var service = new UriImageSourceService();
+
+			var filename = service.GetCachedFileName(new UriImageSourceStub { Uri = new Uri(uri) });
+
+			Assert.Equal(expected, filename);
+		}
 	}
 }


### PR DESCRIPTION
### Description of Change

It appears I did not account for queries or other parts of the URI when calculating the cached filename: https://github.com/dotnet/maui/commit/e15cf82cf6ca18292fe90d9bde1f3e7d23e69cd2#diff-5b4c12343494c46071fc9079950656933700a4d80490aed3a136c4ca581ff533L28

This PR makes sure to only use the URI path and not any of the additional components.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #21748

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
