### PR TITLE
[X] Fix TargetType simplification bug

### DIFF
--- a/src/Controls/src/Build.Tasks/XamlCTask.cs
+++ b/src/Controls/src/Build.Tasks/XamlCTask.cs
@@ -364,8 +364,8 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 				rootnode.Accept(new CreateObjectVisitor(visitorContext), null);
 				rootnode.Accept(new SetNamescopesAndRegisterNamesVisitor(visitorContext), null);
 				rootnode.Accept(new SetFieldVisitor(visitorContext), null);
-				rootnode.Accept(new SetResourcesVisitor(visitorContext), null);
 				rootnode.Accept(new SimplifyTypeExtensionVisitor(), null);
+				rootnode.Accept(new SetResourcesVisitor(visitorContext), null);
 				rootnode.Accept(new SetPropertiesVisitor(visitorContext, true), null);
 
 				il.Emit(Ret);

--- a/src/Controls/src/Xaml/XamlLoader.cs
+++ b/src/Controls/src/Xaml/XamlLoader.cs
@@ -187,8 +187,8 @@ namespace Microsoft.Maui.Controls.Xaml
 					resources.Accept(new NamescopingVisitor(visitorContext), null); //set namescopes for {x:Reference}
 					resources.Accept(new CreateValuesVisitor(visitorContext), null);
 					resources.Accept(new RegisterXNamesVisitor(visitorContext), null);
-					resources.Accept(new FillResourceDictionariesVisitor(visitorContext), null);
 					resources.Accept(new SimplifyTypeExtensionVisitor(), null);
+					resources.Accept(new FillResourceDictionariesVisitor(visitorContext), null);
 					resources.Accept(new ApplyPropertiesVisitor(visitorContext, true), null);
 
 					return visitorContext.Values[resources] as IResourceDictionary;
@@ -207,8 +207,8 @@ namespace Microsoft.Maui.Controls.Xaml
 			rootnode.Accept(new NamescopingVisitor(visitorContext), null); //set namescopes for {x:Reference}
 			rootnode.Accept(new CreateValuesVisitor(visitorContext), null);
 			rootnode.Accept(new RegisterXNamesVisitor(visitorContext), null);
-			rootnode.Accept(new FillResourceDictionariesVisitor(visitorContext), null);
 			rootnode.Accept(new SimplifyTypeExtensionVisitor(), null);
+			rootnode.Accept(new FillResourceDictionariesVisitor(visitorContext), null);
 			rootnode.Accept(new ApplyPropertiesVisitor(visitorContext, true), null);
 		}
 

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui21757.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui21757.xaml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ResourceDictionary xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                    x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui21757">
+    <Color x:Key="Gray-200">#C8C8C8</Color>
+    <Style x:Key="A" TargetType="BoxView">
+        <Setter Property="Color" Value="{StaticResource Gray-200}" />
+    </Style>
+    <Style x:Key="B" TargetType="{x:Type BoxView}">
+        <Setter Property="Color" Value="{StaticResource Gray-200}" />
+    </Style>
+</ResourceDictionary>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui21757.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui21757.xaml.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+using Microsoft.Maui.ApplicationModel;
+using Microsoft.Maui.Controls.Core.UnitTests;
+using Microsoft.Maui.Controls.Shapes;
+using Microsoft.Maui.Devices;
+using Microsoft.Maui.Dispatching;
+
+using Microsoft.Maui.Graphics;
+using Microsoft.Maui.UnitTests;
+using NUnit.Framework;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public partial class Maui21757
+{
+    public Maui21757()
+    {
+        InitializeComponent();
+    }
+
+    public Maui21757(bool useCompiledXaml)
+    {
+        //this stub will be replaced at compile time
+    }
+
+    [TestFixture]
+    class Test
+    {
+        [SetUp]
+        public void Setup()
+        {
+            Application.SetCurrentApplication(new MockApplication());
+            DispatcherProvider.SetCurrent(new DispatcherProviderStub());
+        }
+
+        [TearDown] public void TearDown() => AppInfo.SetCurrent(null);
+
+        [Test]
+        public void TypeLiteralAndXTypeCanBeUsedInterchangeably([Values(false, true)] bool useCompiledXaml)
+        {
+            var resourceDictionary = new Maui21757(useCompiledXaml);
+
+            var styleA = resourceDictionary["A"] as Style;
+            Assert.NotNull(styleA);
+            Assert.That(styleA.TargetType, Is.EqualTo(typeof(BoxView)));
+            Assert.That(styleA.Setters[0].Property, Is.EqualTo(BoxView.ColorProperty));
+            Assert.That(styleA.Setters[0].Value, Is.EqualTo(Color.FromArgb("#C8C8C8")));
+
+            var styleB = resourceDictionary["B"] as Style;
+            Assert.NotNull(styleB);
+            Assert.That(styleB.TargetType, Is.EqualTo(typeof(BoxView)));
+            Assert.That(styleB.Setters[0].Property, Is.EqualTo(BoxView.ColorProperty));
+            Assert.That(styleB.Setters[0].Value, Is.EqualTo(Color.FromArgb("#C8C8C8")));
+        }
+    }
+}


### PR DESCRIPTION
### Description of Change

When `TargetType="{x:Type ...}"` appeared in a `<ResourceDictionary>`, it wasn't simplified because of the order in which the visitors were applied.

### Issues Fixed

Fixes #21757
Fixes #21848

/cc @StephaneDelcroix 