### PR TITLE
[ios/catalyst] avoid duplicating `UIView.Subviews` arrays

### DIFF
--- a/src/Core/src/Platform/iOS/WrapperView.cs
+++ b/src/Core/src/Platform/iOS/WrapperView.cs
@@ -77,13 +77,14 @@ namespace Microsoft.Maui.Platform
 		{
 			base.LayoutSubviews();
 
-			if (Subviews.Length == 0)
+			var subviews = Subviews;
+			if (subviews.Length == 0)
 				return;
 
 			if (_borderView is not null)
 				BringSubviewToFront(_borderView);
 
-			var child = Subviews[0];
+			var child = subviews[0];
 
 			child.Frame = Bounds;
 
@@ -115,10 +116,11 @@ namespace Microsoft.Maui.Platform
 
 		public override CGSize SizeThatFits(CGSize size)
 		{
-			if (Subviews.Length == 0)
+			var subviews = Subviews;
+			if (subviews.Length == 0)
 				return base.SizeThatFits(size);
 
-			var child = Subviews[0];
+			var child = subviews[0];
 
 			// Calling SizeThatFits on an ImageView always returns the image's dimensions, so we need to call the extension method
 			// This also affects ImageButtons
@@ -136,10 +138,11 @@ namespace Microsoft.Maui.Platform
 
 		internal CGSize SizeThatFitsWrapper(CGSize originalSpec, double virtualViewWidth, double virtualViewHeight)
 		{
-			if (Subviews.Length == 0)
+			var subviews = Subviews;
+			if (subviews.Length == 0)
 				return base.SizeThatFits(originalSpec);
 
-			var child = Subviews[0];
+			var child = subviews[0];
 
 			if (child is UIImageView || (child is UIButton imageButton && imageButton.ImageView?.Image is not null && imageButton.CurrentTitle is null))
 			{


### PR DESCRIPTION
Context: https://github.com/dotnet/maui/issues/21580
Similar to: https://github.com/dotnet/maui/pull/21308

Recording this app in `dotnet-trace`, I saw:

    (0.81%)	Microsoft.MacCatalyst!UIKit.UIView.get_Subviews()

Where this time is spent in:

* `Microsoft.Maui!Microsoft.Maui.Platform.WrapperView`

Reviewing the code, it calls `this.Subviews` twice, which would marshal and create two arrays. It then calls `Subviews[0]`.

Storing in a local instead will avoid creating the array twice:

    var subviews = Subviews;
    if (subviews.Length == 0)
        return;
    //...
    var child = subviews[0];

This improves things a small amount, but is probably worth it:

    (0.72%)	Microsoft.MacCatalyst!UIKit.UIView.get_Subviews()

I'll think about making an analyzer for this, but  I didn't find any similar cases that appear in `dotnet-trace` at the moment.

This doesn't fully solve #21580, but it's a small improvement.
