### PR TITLE
Move CollectionViewItemsLayoutUpdate to appium

### DIFF
--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue5354.xaml.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue5354.xaml.cs
@@ -76,6 +76,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 #if UITEST
 		[Test]
 		[Compatibility.UITests.FailsOnMauiIOS]
+		[Compatibility.UITests.MovedToAppium]
 		public void CollectionViewItemsLayoutUpdate()
 		{
 			RunningApp.WaitForElement("CollectionView5354");

--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issue5354.xaml
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issue5354.xaml
@@ -1,0 +1,33 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="Maui.Controls.Sample.Issues.Issue5354">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition/>
+        </Grid.RowDefinitions>
+
+        <StackLayout Orientation="Vertical" Spacing="5" Grid.Row="0" VerticalOptions="Center">
+            <Label x:Name="Label" LineBreakMode="WordWrap" Text="Switch between linear and grid layouts. If layouts appear as expected with proper spacing between items, the test passes." HorizontalTextAlignment="Center" VerticalTextAlignment="Center"/>
+            <Button AutomationId="Button5354" Text="Switch to grid layout" HorizontalOptions="Center" VerticalOptions="Center" Clicked="ButtonClicked"/>
+        </StackLayout>
+
+        <CollectionView AutomationId="CollectionView5354" Grid.Row="1" ItemsSource="{Binding Items}">
+            <CollectionView.ItemsLayout>
+                <LinearItemsLayout Orientation="Vertical" ItemSpacing="5"/>
+            </CollectionView.ItemsLayout>
+            
+            <CollectionView.ItemTemplate>
+                <DataTemplate>
+                    <StackLayout Orientation="Vertical" Spacing="10" BackgroundColor="Beige" Padding="10">
+                        <Image Source="{Binding Source}" HeightRequest="100"/>
+                        <Label Text="{Binding Text}" HorizontalTextAlignment="Center" AutomationId="{Binding AutomationId}"/>
+                    </StackLayout>
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+
+        </CollectionView>
+    </Grid>
+</ContentPage>

--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issue5354.xaml.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issue5354.xaml.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using Microsoft.Maui.Controls.Internals;
+using Microsoft.Maui.Controls.Xaml;
+using Microsoft.Maui.Controls;
+
+
+namespace Maui.Controls.Sample.Issues
+{
+	[Issue(IssueTracker.None, 5354, "[CollectionView] Updating the ItemsLayout type should refresh the layout", PlatformAffected.All)]
+	public partial class Issue5354 : ContentPage
+	{
+		int count = 0;
+
+		public Issue5354()
+		{
+			InitializeComponent();
+
+			BindingContext = new ViewModel5354();
+		}
+
+		void ButtonClicked(object sender, EventArgs e)
+		{
+			var button = sender as Button;
+			var stackLayout = button.Parent as StackLayout;
+			var grid = stackLayout.Parent as Grid;
+			var collectionView = grid.Children[1] as CollectionView;
+
+			if (count % 2 == 0)
+			{
+				collectionView.ItemsLayout = new GridItemsLayout(ItemsLayoutOrientation.Vertical)
+				{
+					Span = 2,
+					HorizontalItemSpacing = 5,
+					VerticalItemSpacing = 5
+				};
+
+				button.Text = "Switch to linear layout";
+			}
+			else
+			{
+				collectionView.ItemsLayout = new LinearItemsLayout(ItemsLayoutOrientation.Vertical)
+				{
+					ItemSpacing = 5
+				};
+
+				button.Text = "Switch to grid layout";
+			}
+
+			++count;
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	public class ViewModel5354
+	{
+		public ObservableCollection<Model5354> Items { get; set; }
+
+		public ViewModel5354()
+		{
+			var collection = new ObservableCollection<Model5354>();
+			var pageSize = 50;
+
+			for (var i = 0; i < pageSize; i++)
+			{
+				collection.Add(new Model5354
+				{
+					Text = "Image" + i,
+					Source = i % 2 == 0 ?
+					"groceries.png" :
+					"dotnet_bot.png",
+					AutomationId = "Image" + i
+				});
+			}
+
+			Items = collection;
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	public class Model5354
+	{
+		public string Text { get; set; }
+
+		public string Source { get; set; }
+
+		public string AutomationId { get; set; }
+
+		public Model5354()
+		{
+
+		}
+	}
+}

--- a/src/Controls/tests/UITests/Tests/Issues/Issue5354.cs
+++ b/src/Controls/tests/UITests/Tests/Issues/Issue5354.cs
@@ -23,9 +23,7 @@ namespace Maui.Controls.Sample.Issues
 			App.WaitForElement("Button5354");
 			
 			for(int i = 0; i < 3; i++)
-			{
-				App.WaitForNoElement("NoElement", timeout: TimeSpan.FromSeconds(3));
-			
+			{			
 				var linearRect0 = App.WaitForElement("Image0").GetRect();
 				var linearRect1 = App.WaitForElement("Image1").GetRect();
 
@@ -34,7 +32,6 @@ namespace Maui.Controls.Sample.Issues
 
 				App.Click("Button5354");
 
-				App.WaitForNoElement("NoElement", timeout: TimeSpan.FromSeconds(3));
 				var gridRect0 = App.WaitForElement("Image0").GetRect();
 				var gridRect1 = App.WaitForElement("Image1").GetRect();
 

--- a/src/Controls/tests/UITests/Tests/Issues/Issue5354.cs
+++ b/src/Controls/tests/UITests/Tests/Issues/Issue5354.cs
@@ -16,6 +16,9 @@ namespace Maui.Controls.Sample.Issues
 		[Category(UITestCategories.CollectionView)]
 		public void CollectionViewItemsLayoutUpdate()
 		{
+  			this.IgnoreIfPlatforms(new TestDevice[] { TestDevice.iOS, TestDevice.Mac, TestDevice.Windows },
+				"This is a product bug.");
+	
 			App.WaitForElement("CollectionView5354");
 			App.WaitForElement("Button5354");
 			

--- a/src/Controls/tests/UITests/Tests/Issues/Issue5354.cs
+++ b/src/Controls/tests/UITests/Tests/Issues/Issue5354.cs
@@ -1,0 +1,43 @@
+﻿using Microsoft.Maui.AppiumTests;
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+
+namespace Maui.Controls.Sample.Issues
+{
+	public partial class Issue5354 : _IssuesUITest
+	{
+		public Issue5354(TestDevice device) : base(device) { }
+
+		public override string Issue => "[CollectionView] Updating the ItemsLayout type should refresh the layout";
+
+		[Test]
+		[Category(UITestCategories.CollectionView)]
+		public void CollectionViewItemsLayoutUpdate()
+		{
+			this.IgnoreIfPlatforms(new TestDevice[] { TestDevice.Windows },
+				"Copied from Xamarin.Forms. Test was not running or working on Windows.");
+
+			App.WaitForElement("CollectionView5354");
+			App.WaitForElement("Button5354");
+			var colView = App.WaitForElement("CollectionView5354");
+			App.WaitForNoElement("NoElement", timeout: TimeSpan.FromSeconds(3));
+		
+			var linearRect0 = App.WaitForElement("Image0").GetRect();
+			var linearRect1 = App.WaitForElement("Image1").GetRect();
+
+			Assert.AreEqual(linearRect0.X, linearRect1.X);
+			Assert.GreaterOrEqual(linearRect1.Y, linearRect0.Y + linearRect0.Height);
+
+			App.Click("Button5354");
+
+			App.WaitForNoElement("NoElement", timeout: TimeSpan.FromSeconds(3));
+			var gridRect0 = App.WaitForElement("Image0").GetRect();
+			var gridRect1 = App.WaitForElement("Image1").GetRect();
+
+			Assert.AreEqual(gridRect0.Y, gridRect1.Y);
+			Assert.AreEqual(gridRect0.Height, gridRect1.Height);
+		}
+	}
+}

--- a/src/Controls/tests/UITests/Tests/Issues/Issue5354.cs
+++ b/src/Controls/tests/UITests/Tests/Issues/Issue5354.cs
@@ -21,23 +21,28 @@ namespace Maui.Controls.Sample.Issues
 
 			App.WaitForElement("CollectionView5354");
 			App.WaitForElement("Button5354");
-			var colView = App.WaitForElement("CollectionView5354");
-			App.WaitForNoElement("NoElement", timeout: TimeSpan.FromSeconds(3));
-		
-			var linearRect0 = App.WaitForElement("Image0").GetRect();
-			var linearRect1 = App.WaitForElement("Image1").GetRect();
+			
+			for(int i = 0; i < 3; i++)
+			{
+				App.WaitForNoElement("NoElement", timeout: TimeSpan.FromSeconds(3));
+			
+				var linearRect0 = App.WaitForElement("Image0").GetRect();
+				var linearRect1 = App.WaitForElement("Image1").GetRect();
 
-			Assert.AreEqual(linearRect0.X, linearRect1.X);
-			Assert.GreaterOrEqual(linearRect1.Y, linearRect0.Y + linearRect0.Height);
+				Assert.AreEqual(linearRect0.X, linearRect1.X);
+				Assert.GreaterOrEqual(linearRect1.Y, linearRect0.Y + linearRect0.Height);
 
-			App.Click("Button5354");
+				App.Click("Button5354");
 
-			App.WaitForNoElement("NoElement", timeout: TimeSpan.FromSeconds(3));
-			var gridRect0 = App.WaitForElement("Image0").GetRect();
-			var gridRect1 = App.WaitForElement("Image1").GetRect();
+				App.WaitForNoElement("NoElement", timeout: TimeSpan.FromSeconds(3));
+				var gridRect0 = App.WaitForElement("Image0").GetRect();
+				var gridRect1 = App.WaitForElement("Image1").GetRect();
 
-			Assert.AreEqual(gridRect0.Y, gridRect1.Y);
-			Assert.AreEqual(gridRect0.Height, gridRect1.Height);
+				Assert.AreEqual(gridRect0.Y, gridRect1.Y);
+				Assert.AreEqual(gridRect0.Height, gridRect1.Height);
+				
+				App.Click("Button5354");
+			}
 		}
 	}
 }

--- a/src/Controls/tests/UITests/Tests/Issues/Issue5354.cs
+++ b/src/Controls/tests/UITests/Tests/Issues/Issue5354.cs
@@ -16,9 +16,6 @@ namespace Maui.Controls.Sample.Issues
 		[Category(UITestCategories.CollectionView)]
 		public void CollectionViewItemsLayoutUpdate()
 		{
-			this.IgnoreIfPlatforms(new TestDevice[] { TestDevice.Windows },
-				"Copied from Xamarin.Forms. Test was not running or working on Windows.");
-
 			App.WaitForElement("CollectionView5354");
 			App.WaitForElement("Button5354");
 			


### PR DESCRIPTION
### Description of Change

`CollectionViewItemsLayoutUpdate` has become somewhat flakey after some Android CV improvements. That test was just scrolling through looking for a specific image. 

The whole point of that test is to verify that the ItemsLayout changes during runtime so I don't quite understand the point of scrolling and searching for the image. 

https://github.com/xamarin/xamarin.forms/issues/5354

I've updated the test to just verify that the top images shift from a linear position to a grid position. 

Which seems more accurate?
