### PR TITLE
Add s/triaged label for issues opened by core team

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -579,5 +579,15 @@ configuration:
       - removeLabel:
           label: s/try-latest-version
       description: Remove 's/try-latest-version' when new reply from author comes in
+    - if:
+      - payloadType: Issues
+      - activitySenderHasPermission:
+          permission: Write
+      - isAction:
+          action: Opened
+      then:
+      - addLabel:
+          label: s/triaged
+      description: Add 's/triaged' label to issues opened by the core team, we assume these issues do not need triaging
 onFailure: 
 onSuccess: 


### PR DESCRIPTION
### Description of Change

Adds a rule to the bot that adds the s/triaged label to an issue which is opened by the core team (someone with write permissions on the repo). A lot of times these issues are tasks and/or very cryptic to the triage team. This way, the triage team will skip these issues and we assume the issues are valid ones and/or not issues that need triage.

~@mkArtakMSFT adding you for review to see if this is valid yaml? Is there another way to check this is not breaking our whole automation other than having your review? 😄~

Oh I see there is a status check that validates the YAML, awesome!