### PR TITLE
[Testing] Extend NativeAOT Templates tests to cover all supported platforms

### DIFF
--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/TemplateTests.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/TemplateTests.cs
@@ -203,6 +203,10 @@ namespace Microsoft.Maui.IntegrationTests
 
 		[Test]
 		[TestCase("maui", $"{DotNetCurrent}-ios", "ios-arm64")]
+		[TestCase("maui", $"{DotNetCurrent}-ios", "iossimulator-arm64")]
+		[TestCase("maui", $"{DotNetCurrent}-ios", "iossimulator-x64")]
+		[TestCase("maui", $"{DotNetCurrent}-maccatalyst", "maccatalyst-arm64")]
+		[TestCase("maui", $"{DotNetCurrent}-maccatalyst", "maccatalyst-x64")]
 		public void PublishNativeAOT(string id, string framework, string runtimeIdentifier)
 		{
 			if (!TestEnvironment.IsMacOS)
@@ -216,40 +220,17 @@ namespace Microsoft.Maui.IntegrationTests
 
 			var extendedBuildProps = BuildProps;
 			extendedBuildProps.Add("PublishAot=true");
-			extendedBuildProps.Add("PublishAotUsingRuntimePack=true");  // TODO: This parameter will become obsolete https://github.com/dotnet/runtime/issues/87060
-			extendedBuildProps.Add("IlcTreatWarningsAsErrors=false");
-
-			Assert.IsTrue(DotnetInternal.Publish(projectFile, "Release", framework: framework, properties: extendedBuildProps, runtimeIdentifier: runtimeIdentifier),
-				$"Project {Path.GetFileName(projectFile)} failed to build. Check test output/attachments for errors.");
-		}
-
-		[Test]
-		[TestCase("maui", $"{DotNetCurrent}-ios", "ios-arm64")]
-		public void PublishNativeAOTCheckWarnings(string id, string framework, string runtimeIdentifier)
-		{
-			if (!TestEnvironment.IsMacOS)
-				Assert.Ignore("Publishing a MAUI iOS app with NativeAOT is only supported on a host MacOS system.");
-
-			var projectDir = TestDirectory;
-			var projectFile = Path.Combine(projectDir, $"{Path.GetFileName(projectDir)}.csproj");
-
-			Assert.IsTrue(DotnetInternal.New(id, projectDir, DotNetCurrent),
-				$"Unable to create template {id}. Check test output for errors.");
-
-			var extendedBuildProps = BuildProps;
-			extendedBuildProps.Add("PublishAot=true");
-			extendedBuildProps.Add("PublishAotUsingRuntimePack=true");  // TODO: This parameter will become obsolete https://github.com/dotnet/runtime/issues/87060
+			extendedBuildProps.Add("PublishAotUsingRuntimePack=true");  // TODO: This parameter will become obsolete https://github.com/dotnet/runtime/issues/87060 in net9
+			extendedBuildProps.Add("_IsPublishing=true"); // This makes 'dotnet build -r iossimulator-x64' equivalent to 'dotnet publish -r iossimulator-x64'
 			extendedBuildProps.Add("IlcTreatWarningsAsErrors=false");
 			extendedBuildProps.Add("TrimmerSingleWarn=false");
 
 			string binLogFilePath = $"publish-{DateTime.UtcNow.ToFileTimeUtc()}.binlog";
-			Assert.IsTrue(DotnetInternal.Publish(projectFile, "Release", framework: framework, properties: extendedBuildProps, runtimeIdentifier: runtimeIdentifier, binlogPath: binLogFilePath),
+			Assert.IsTrue(DotnetInternal.Build(projectFile, "Release", framework: framework, properties: extendedBuildProps, runtimeIdentifier: runtimeIdentifier, binlogPath: binLogFilePath),
 				$"Project {Path.GetFileName(projectFile)} failed to build. Check test output/attachments for errors.");
 
-			var expectedWarnings = BuildWarningsUtilities.ExpectedNativeAOTWarnings;
 			var actualWarnings = BuildWarningsUtilities.ReadNativeAOTWarningsFromBinLog(binLogFilePath);
-
-			actualWarnings.AssertWarnings(expectedWarnings);
+			actualWarnings.AssertNoWarnings();
 		}
 
 		[Test]

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/BuildWarningsUtilities.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/BuildWarningsUtilities.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Maui.IntegrationTests
 	{
 		public string File { get; set; } = string.Empty;
 		public List<WarningsPerCode> WarningsPerCode { get; set; } = new List<WarningsPerCode>();
+		public override string ToString() => string.Join("\n", WarningsPerCode.SelectMany(warningPerCode => warningPerCode.Messages.Select(message => $"{File}: {warningPerCode.Code}: {message}")).ToList());
 	}
 
 	public class WarningsPerCode
@@ -80,6 +81,11 @@ namespace Microsoft.Maui.IntegrationTests
 					warningsPerCode.Messages.Add(message);
 				}
 			}
+		}
+
+		public static void AssertNoWarnings(this List<WarningsPerFile> actualWarnings)
+		{
+			Assert.AreEqual(0, actualWarnings.Count, $"No warnings expected, but got {actualWarnings.Count} warnings:\n{string.Join("\n", actualWarnings.Select(actualWarning => actualWarning.ToString()))}");
 		}
 
 		public static void AssertWarnings(this List<WarningsPerFile> actualWarnings, List<WarningsPerFile> expectedWarnings)

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/DotnetInternal.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/DotnetInternal.cs
@@ -46,9 +46,9 @@ namespace Microsoft.Maui.IntegrationTests
 			return buildArgs;
 		}
 
-		public static bool Build(string projectFile, string config, string target = "", string framework = "", IEnumerable<string>? properties = null, string binlogPath = "", bool msbuildWarningsAsErrors = false)
+		public static bool Build(string projectFile, string config, string target = "", string framework = "", IEnumerable<string>? properties = null, string binlogPath = "", bool msbuildWarningsAsErrors = false, string runtimeIdentifier = "")
 		{
-			var buildArgs = ConstructBuildArgs(projectFile, config, target, framework, properties, binlogPath);
+			var buildArgs = ConstructBuildArgs(projectFile, config, target, framework, properties, binlogPath, runtimeIdentifier, false);
 
 			if (msbuildWarningsAsErrors)
 			{


### PR DESCRIPTION
### Description of Change

This PR improves MAUI with NativeAOT test coverage by extending the `Templates` tests with cases for all supported platforms.

Additionally, as we reached 0 warnings for the template MAUI app and NativeAOT (via: https://github.com/dotnet/maui/pull/21050), I simplified the test cases.

NOTE: I did not remove the logic in `src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/BuildWarningsUtilities.cs` intentionally, as we might want to use it for testing builds of apps which still have trim/AOT warnings.
