### PR TITLE
[iOS] Fix KeyboardScrolling for controls inside the NavBar

### DIFF
--- a/src/Core/src/Platform/iOS/KeyboardAutoManagerScroll.cs
+++ b/src/Core/src/Platform/iOS/KeyboardAutoManagerScroll.cs
@@ -319,6 +319,12 @@ public static class KeyboardAutoManagerScroll
 
 		if (View.FindResponder<UINavigationController>() is UINavigationController navigationController)
 		{
+			if (View.IsDescendantOfView(navigationController.NavigationBar))
+			{
+				IsKeyboardAutoScrollHandling = false;
+				return;
+			}
+
 			navigationBarAreaHeight = navigationController.NavigationBar.Frame.GetMaxY();
 		}
 		else


### PR DESCRIPTION
### Description of Change

<!-- Enter description of the fix in this section -->
Small fix to tell the iOS KeyboardAutoManagerScroll that there is no need to scroll if the view in question is inside the Navigation Bar.


https://github.com/dotnet/maui/assets/50846373/d4e135e9-e9b6-4611-a6af-6fe007d74af1

As for testing, I don't think the UITests can have a shell instance yet.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #21630

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
