### PR TITLE
[WinUI] Perf when creating non-trivial grids (and other visual controls)

### DIFF
--- a/global.json
+++ b/global.json
@@ -5,5 +5,12 @@
   "msbuild-sdks": {
     "MSBuild.Sdk.Extras": "3.0.44",
     "Microsoft.Build.NoTargets": "3.3.0"
+  },
+  "sdk": {
+    "version": "8.0.0",
+    "rollForward": "latestFeature",
+    "allowPrerelease": true
   }
 }
+
+

--- a/global.json
+++ b/global.json
@@ -5,12 +5,5 @@
   "msbuild-sdks": {
     "MSBuild.Sdk.Extras": "3.0.44",
     "Microsoft.Build.NoTargets": "3.3.0"
-  },
-  "sdk": {
-    "version": "8.0.0",
-    "rollForward": "latestFeature",
-    "allowPrerelease": true
   }
 }
-
-

--- a/src/Controls/samples/Controls.Sample.Sandbox/MainPage.xaml
+++ b/src/Controls/samples/Controls.Sample.Sandbox/MainPage.xaml
@@ -8,6 +8,8 @@
         <Label x:Name="info" Text="Click a button" VerticalOptions="Center"/>
         <Button Text="Clear Grid" Clicked="ClearGrid_Clicked"/>
         <Button Text="Generate Grid" Clicked="Button_Clicked"/>
+        <Entry x:Name="BatchSize" Text="15"/>
+        <Button Text="Batch Generate Grid" Clicked="BatchGenerate_Clicked"/>
 
         <HorizontalStackLayout x:Name="myGridWrapper">
             <Grid x:Name="contentGrid"/>

--- a/src/Controls/samples/Controls.Sample.Sandbox/MainPage.xaml
+++ b/src/Controls/samples/Controls.Sample.Sandbox/MainPage.xaml
@@ -1,6 +1,16 @@
 ﻿<ContentPage
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:local="clr-namespace:Maui.Controls.Sample"
     x:Class="Maui.Controls.Sample.MainPage"
-    xmlns:local="clr-namespace:Maui.Controls.Sample">
+    x:DataType="local:MainPage">
+    <VerticalStackLayout x:Name="myLayout">
+        <Label x:Name="info" Text="Click a button" VerticalOptions="Center"/>
+        <Button Text="Clear Grid" Clicked="ClearGrid_Clicked"/>
+        <Button Text="Generate Grid" Clicked="Button_Clicked"/>
+
+        <HorizontalStackLayout x:Name="myGridWrapper">
+            <Grid x:Name="contentGrid"/>
+        </HorizontalStackLayout>
+    </VerticalStackLayout>
 </ContentPage>

--- a/src/Controls/samples/Controls.Sample.Sandbox/MainPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample.Sandbox/MainPage.xaml.cs
@@ -1,18 +1,45 @@
 ﻿using System;
-using System.Collections.ObjectModel;
 using System.Diagnostics;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Maui;
 using Microsoft.Maui.Controls;
-using Microsoft.Maui.Graphics;
 
-namespace Maui.Controls.Sample
+namespace Maui.Controls.Sample;
+
+public partial class MainPage : ContentPage
 {
-	public partial class MainPage : ContentPage
+	public MainPage()
 	{
-		public MainPage()
+		InitializeComponent();
+	}
+
+	private void ClearGrid_Clicked(object sender, EventArgs e)
+	{
+		Stopwatch sw = Stopwatch.StartNew();
+
+		contentGrid.Clear();
+
+		sw.Stop();
+
+		info.Text = $"Clearing grid took: {sw.ElapsedMilliseconds} ms";
+	}
+
+	private void Button_Clicked(object sender, EventArgs e)
+	{
+		const int rowCount = 30;
+		const int columnCount = 30;
+
+		Stopwatch sw = Stopwatch.StartNew();
+		contentGrid.Clear();
+
+		for (int rowIndex = 0; rowIndex < rowCount; rowIndex++)
 		{
-			InitializeComponent();
+			for (int columnIndex = 0; columnIndex < columnCount; columnIndex++)
+			{
+				Label label = new Label() { Text = $"[{columnIndex}x{rowIndex}]" };
+				contentGrid.Add(label, column: columnIndex, row: rowIndex);
+			}
 		}
+
+		sw.Stop();
+		info.Text = $"Clearing grid took: {sw.ElapsedMilliseconds} ms";
 	}
 }

--- a/src/Controls/samples/Controls.Sample.Sandbox/MainPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample.Sandbox/MainPage.xaml.cs
@@ -6,6 +6,9 @@ namespace Maui.Controls.Sample;
 
 public partial class MainPage : ContentPage
 {
+	const int rowCount = 30;
+	const int columnCount = 30;
+
 	public MainPage()
 	{
 		InitializeComponent();
@@ -24,9 +27,6 @@ public partial class MainPage : ContentPage
 
 	private void Button_Clicked(object sender, EventArgs e)
 	{
-		const int rowCount = 30;
-		const int columnCount = 30;
-
 		Stopwatch sw = Stopwatch.StartNew();
 		contentGrid.Clear();
 
@@ -42,4 +42,29 @@ public partial class MainPage : ContentPage
 		sw.Stop();
 		info.Text = $"Clearing grid took: {sw.ElapsedMilliseconds} ms";
 	}
+
+	private void BatchGenerate_Clicked(object sender, EventArgs e)
+	{
+		Stopwatch sw = Stopwatch.StartNew();		
+
+		int batchSize = int.Parse(BatchSize.Text);
+
+		for (int i = 0; i < batchSize; i++)
+		{
+			contentGrid.Clear();
+
+			for (int rowIndex = 0; rowIndex < rowCount; rowIndex++)
+			{
+				for (int columnIndex = 0; columnIndex < columnCount; columnIndex++)
+				{
+					Label label = new Label() { Text = $"[{columnIndex}x{rowIndex}]" };
+					contentGrid.Add(label, column: columnIndex, row: rowIndex);
+				}
+			}
+		}
+
+		sw.Stop();
+		info.Text = $"Grid was created {batchSize} times and it took {sw.ElapsedMilliseconds} ms in total. Avg run took {Math.Round(sw.ElapsedMilliseconds / (double)batchSize, 2)} ms";
+	}
+
 }

--- a/src/Core/src/Handlers/View/ViewHandler.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.cs
@@ -27,6 +27,9 @@ namespace Microsoft.Maui.Handlers
 #if ANDROID
 			// Use a custom mapper for Android which knows how to batch the initial property sets
 			new AndroidBatchPropertyMapper<IView, IViewHandler>(ElementMapper)
+#elif WINDOWS
+			// Use a custom mapper for Windows which knows how to batch the initial property sets
+			new WindowsBatchPropertyMapper<IView, IViewHandler>(ElementMapper)
 #else
 			new PropertyMapper<IView, IViewHandler>(ElementHandler.ElementMapper)
 #endif

--- a/src/Core/src/Handlers/View/WindowsBatchPropertyMapper.cs
+++ b/src/Core/src/Handlers/View/WindowsBatchPropertyMapper.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Maui.Handlers;
+
+#if WINDOWS
+class WindowsBatchPropertyMapper<TVirtualView, TViewHandler> : PropertyMapper<TVirtualView, TViewHandler>
+	where TVirtualView : IElement
+	where TViewHandler : IElementHandler
+{
+	// During mass property updates, this list of properties will be skipped
+	public static HashSet<string> SkipList = new(StringComparer.Ordinal)
+	{ 
+		// TranslationX does the work that is necessary to make other properties work.
+		nameof(IView.TranslationY),
+		nameof(IView.Scale),
+		nameof(IView.ScaleX),
+		nameof(IView.ScaleY),
+		nameof(IView.Rotation),
+		nameof(IView.RotationX),
+		nameof(IView.RotationY),
+		nameof(IView.AnchorX),
+		nameof(IView.AnchorY),
+	};
+
+	public WindowsBatchPropertyMapper(params IPropertyMapper[] chained) : base(chained) { }
+
+	public override IEnumerable<string> GetKeys()
+	{
+		foreach (var key in _mapper.Keys)
+		{
+			// When reporting the key list for mass updates up the chain, ignore properties in SkipList.
+			// These will be handled by ViewHandler.SetVirtualView() instead.
+			if (SkipList.Contains(key))
+			{
+				continue;
+			}
+
+			yield return key;
+		}
+
+		if (Chained is not null)
+		{
+			foreach (var chain in Chained)
+				foreach (var key in chain.GetKeys())
+					yield return key;
+		}
+	}
+}
+#endif


### PR DESCRIPTION
### Description of Change

Notes:

* Clicking "Batch Generate Grid" multiple times lead to ever increasing time to finish the operation. I'm not sure why.
* Relevant issue https://github.com/dotnet/maui/issues/17303
* This PR is mostly a bait to attract the MAUI team's attention to the problem that it seems it's not that hard to improve status quo substantially. However, my discussion with @jonathanpeppers[^1] somewhat suggests that the approach of this PR is not the best (mediocre at best I guess):
    > that [this PR] would help Windows
    > but same issue on all platforms, I think
    > maybe this could be a redesign thing for future, like .NET 9
    
    me: 
   
    > https://github.com/dotnet/maui/blob/0a562dcd1de72db1d52426fdd89c29e02fb00f1b/src/Core/src/Handlers/View/ViewHandler.Android.cs#L75 - so it differs on android
    > https://github.com/dotnet/maui/blob/main/src/Core/src/Handlers/View/ViewHandler.iOS.cs  - all the same
    > https://github.com/dotnet/maui/blob/main/src/Core/src/Handlers/View/ViewHandler.Windows.cs - all the same
    > https://github.com/dotnet/maui/blob/main/src/Core/src/Handlers/View/ViewHandler.Tizen.cs - all the same
    > So it seems like Android can be an exception
    > and others would just handle one of these transform properties
    
    Jonathan:
    
    > The part that makes me want to rethink this:
    >
    >  1. Every control has TranslateX/Y default to 0
    >  2. Do we actually need to pass 0 to the platform? for every control?
    >
    > I think there needs to be a concept of a default value
    > Where if you set TranslateX/Y it would pass to the platform and not otherwise
    > But I don't know if that breaks some fundamental design
    > this is just my observation
    > It would also be nice to get rid of one layer of Dictionary<string, lookup if that were possible

#### Master

851 ms 

![image](https://github.com/dotnet/maui/assets/203266/8d1eeaf0-cd05-49a8-8494-c0471eec9b08)


PR:

676 ms 

![image](https://github.com/dotnet/maui/assets/203266/92fb6b26-0c9f-4f89-af5d-9649153c3e32)

-> 20% faster.

### Issues Fixed

Contributes to #21787

[^1]: I hope he doesn't mind me copying it here.