### PR TITLE
Android mipmap/appicon failing with "APT2260"

### DIFF
--- a/src/SingleProject/Resizetizer/src/ResizetizeImages.cs
+++ b/src/SingleProject/Resizetizer/src/ResizetizeImages.cs
@@ -118,6 +118,8 @@ namespace Microsoft.Maui.Resizetizer
 				attr.Add("_ResizetizerDpiScale", img.Dpi.Scale.ToString("0.0", CultureInfo.InvariantCulture));
 
 				copiedResources.Add(new TaskItem(itemSpec, attr));
+				// force the date time so we never update an image if its not changed.
+				File.SetLastWriteTimeUtc (itemSpec, DateTime.UtcNow);
 			}
 
 			CopiedResources = copiedResources.ToArray();

--- a/src/SingleProject/Resizetizer/src/nuget/buildTransitive/Microsoft.Maui.Resizetizer.After.targets
+++ b/src/SingleProject/Resizetizer/src/nuget/buildTransitive/Microsoft.Maui.Resizetizer.After.targets
@@ -60,6 +60,7 @@
         </CleanDependsOn>
 
         <_ResizetizerInputsFile>$(IntermediateOutputPath)mauiimage.inputs</_ResizetizerInputsFile>
+        <_ResizetizerOutputsFile>$(IntermediateOutputPath)mauiimage.outputs</_ResizetizerOutputsFile>
         <_ResizetizerStampFile>$(IntermediateOutputPath)mauiimage.stamp</_ResizetizerStampFile>
         <_MauiFontInputsFile>$(IntermediateOutputPath)mauifont.inputs</_MauiFontInputsFile>
         <_MauiFontStampFile>$(IntermediateOutputPath)mauifont.stamp</_MauiFontStampFile>
@@ -115,6 +116,7 @@
             $(ResizetizeDependsOnTargets);
             ResizetizeCollectItems;
             ProcessMauiSplashScreens;
+            _ReadResizetizeImagesOutputs;
         </ResizetizeDependsOnTargets>
         <ProcessMauiFontsDependsOnTargets>
             $(ProcessMauiFontsDependsOnTargets);
@@ -601,10 +603,16 @@
         </ItemGroup>
     </Target>
 
+    <Target Name="_ReadResizetizeImagesOutputs">
+        <ReadLinesFromFile File="$(_ResizetizerOutputsFile)" Condition="Exists ('$(_ResizetizerOutputsFile)')">
+            <Output TaskParameter="Lines" ItemName="_ResizetizerOutputs" />
+        </ReadLinesFromFile>
+    </Target>
+
     <Target Name="ResizetizeImages"
         Condition="'$(EnableMauiImageProcessing)' == 'true'"
         Inputs="$(MSBuildThisFileFullPath);$(_ResizetizerTaskAssemblyName);$(_ResizetizerInputsFile);@(MauiImage)"
-        Outputs="$(_ResizetizerStampFile)"
+        Outputs="$(_ResizetizerStampFile);@(_ResizetizerOutputs)"
         AfterTargets="$(ResizetizeAfterTargets)"
         BeforeTargets="$(ResizetizeBeforeTargets)"
         DependsOnTargets="$(ResizetizeDependsOnTargets)">
@@ -720,10 +728,17 @@
 
         <!-- Touch/create our stamp file for outputs -->
         <Touch Files="$(_ResizetizerStampFile)" AlwaysCreate="True" />
+        <WriteLinesToFile
+            File="$(_ResizetizerOutputsFile)"
+            Lines="@(_ResizetizerCollectedImages->'%(Identity)')"
+            Overwrite="true"
+            WriteOnlyWhenDifferent="true"
+        />
 
         <!-- Include our images and stamp file as filewrites so they don't get rm'd -->
         <ItemGroup>
             <FileWrites Include="$(_ResizetizerStampFile)" />
+            <FileWrites Include="$(_ResizetizerOutputsFile)" />
         </ItemGroup>
     </Target>
 


### PR DESCRIPTION
### Description of Change

Users are reporting this error quite allot. During a build it fails with the following error

```
 APT2260 resource mipmap/appicon (aka xxx:mipmap/appicon) not found.
```

Further investigation this only appears to happen during a full build of all the platforms. Specifying `-f net8.0-android` on the build this does not seem to happen at all.

The problem is the build gets into a weird situation where the `mauiimage.stamp` file is present but none of the generated images are. Considering that the stamp file gets generated AFTER the images its kinda difficult to see how this even occurs.

The work around for this is to write the list of generated image files to `mauiimage.outputs`. We can then read this list back on subsequent builds and use that list for the `Outputs` of the `ResizetizeImages` target. This means the target will run if either the stamp file or any of the expected images are not present.

### Issues Fixed
Context https://developercommunity.visualstudio.com/t/Android-mipmapappicon-failing-with-APT/10622494
