### PR TITLE
[C] Propagate resources when reparenting

### DIFF
--- a/src/Controls/src/Core/Application/Application.cs
+++ b/src/Controls/src/Core/Application/Application.cs
@@ -109,7 +109,6 @@ namespace Microsoft.Maui.Controls
 				if (value is not null)
 				{
 					value.OnResourcesChanged(this.GetMergedResources());
-					value.OnResourcesChanged([new KeyValuePair<string, object>(AppThemeBinding.AppThemeResource, _lastAppTheme)]);
 					((IElementDefinition)this).AddResourcesChangedListener(value.OnParentResourcesChanged);
 				}
 

--- a/src/Controls/src/Core/Application/Application.cs
+++ b/src/Controls/src/Core/Application/Application.cs
@@ -108,8 +108,8 @@ namespace Microsoft.Maui.Controls
 
 				if (value is not null)
 				{
-					OnParentResourcesChanged(this.GetMergedResources());
-					OnParentResourcesChanged([new KeyValuePair<string, object>(AppThemeBinding.AppThemeResource, _lastAppTheme)]);
+					value.OnResourcesChanged(this.GetMergedResources());
+					value.OnResourcesChanged([new KeyValuePair<string, object>(AppThemeBinding.AppThemeResource, _lastAppTheme)]);
 					((IElementDefinition)this).AddResourcesChangedListener(value.OnParentResourcesChanged);
 				}
 

--- a/src/Controls/src/Core/Element/Element.cs
+++ b/src/Controls/src/Core/Element/Element.cs
@@ -354,9 +354,6 @@ namespace Microsoft.Maui.Controls
 			if (RealParent != null)
 			{
 				OnParentResourcesChanged(RealParent.GetMergedResources());
-				if (Application.Current?.RequestedTheme != ApplicationModel.AppTheme.Unspecified)
-					OnParentResourcesChanged([new KeyValuePair<string, object>(AppThemeBinding.AppThemeResource, Application.Current.RequestedTheme)]);
-
 				((IElementDefinition)RealParent).AddResourcesChangedListener(OnParentResourcesChanged);
 			}
 

--- a/src/Controls/src/Core/Element/Element.cs
+++ b/src/Controls/src/Core/Element/Element.cs
@@ -319,7 +319,7 @@ namespace Microsoft.Maui.Controls
 		/// <inheritdoc/>
 		void IElementDefinition.AddResourcesChangedListener(Action<object, ResourcesChangedEventArgs> onchanged)
 		{
-			_changeHandlers = _changeHandlers ?? new List<Action<object, ResourcesChangedEventArgs>>(2);
+			_changeHandlers ??= new List<Action<object, ResourcesChangedEventArgs>>(2);
 			_changeHandlers.Add(onchanged);
 		}
 
@@ -354,6 +354,9 @@ namespace Microsoft.Maui.Controls
 			if (RealParent != null)
 			{
 				OnParentResourcesChanged(RealParent.GetMergedResources());
+				if (Application.Current?.RequestedTheme != ApplicationModel.AppTheme.Unspecified)
+					OnParentResourcesChanged([new KeyValuePair<string, object>(AppThemeBinding.AppThemeResource, Application.Current.RequestedTheme)]);
+
 				((IElementDefinition)RealParent).AddResourcesChangedListener(OnParentResourcesChanged);
 			}
 

--- a/src/Controls/src/Core/ResourcesExtensions.cs
+++ b/src/Controls/src/Core/ResourcesExtensions.cs
@@ -44,6 +44,12 @@ namespace Microsoft.Maui.Controls
 							resources[res.Key] = mergedClassStyles;
 						}
 				}
+				if (app != null)
+				{
+					resources = resources ?? new(StringComparer.Ordinal);
+					resources[AppThemeBinding.AppThemeResource] = app.RequestedTheme;
+				}
+
 				element = element.Parent;
 			}
 			return resources;

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui21774.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui21774.xaml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                    x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui21774">
+	<StackLayout>
+		<Label x:Name="label0" TextColor="{DynamicResource labelColor}"/>
+		<Label x:Name="label1" TextColor="{AppThemeBinding Light=LimeGreen, Dark=HotPink}"/>
+	</StackLayout>
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui21774.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui21774.xaml.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Maui.ApplicationModel;
+using Microsoft.Maui.Controls.Core.UnitTests;
+using Microsoft.Maui.Controls.Shapes;
+using Microsoft.Maui.Devices;
+using Microsoft.Maui.Dispatching;
+
+using Microsoft.Maui.Graphics;
+using Microsoft.Maui.UnitTests;
+using NUnit.Framework;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public partial class Maui21774
+{
+    public Maui21774()
+    {
+        InitializeComponent();
+    }
+
+    public Maui21774(bool useCompiledXaml)
+    {
+        //this stub will be replaced at compile time
+    }
+
+    [TestFixture]
+    class Test
+    {
+        [SetUp]
+        public void Setup()
+        {
+            Application.SetCurrentApplication(new MockApplication());
+            DispatcherProvider.SetCurrent(new DispatcherProviderStub());
+        }
+
+        [TearDown] public void TearDown() => AppInfo.SetCurrent(null);
+
+        [Test]
+        public void AppThemeChangeOnUnparentedPage([Values(false, true)] bool useCompiledXaml)
+        {
+            Application.Current.Resources.Add("labelColor", Colors.LimeGreen);
+			Application.Current.UserAppTheme = AppTheme.Light;
+			var page = new Maui21774(useCompiledXaml);
+			Application.Current.MainPage = page;
+
+			Assert.That(page.label0.TextColor, Is.EqualTo(Colors.LimeGreen));
+			Assert.That(page.label1.TextColor, Is.EqualTo(Colors.LimeGreen));
+
+			//unparent the page, change the resource and the theme
+			Application.Current.MainPage = null;
+			Application.Current.Resources["labelColor"] = Colors.HotPink;
+			Application.Current.UserAppTheme = AppTheme.Dark;
+			//labels should not change
+			Assert.That(page.label0.TextColor, Is.EqualTo(Colors.LimeGreen));
+			Assert.That(page.label1.TextColor, Is.EqualTo(Colors.LimeGreen));
+
+			//reparent the page
+			Application.Current.MainPage = page;
+			//labels should change
+			Assert.That(page.label0.TextColor, Is.EqualTo(Colors.HotPink));
+			Assert.That(page.label1.TextColor, Is.EqualTo(Colors.HotPink));			
+        }
+    }
+}


### PR DESCRIPTION
### Description of Change

fixes a bug when the theme is changed while the control/page isn't parented. Should fix @LeDahu22 reported issue of #21744

### Issues Fixed