### PR TITLE
[ios/catalyst] fix memory leak in gestures

### DIFF
--- a/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.iOS.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.iOS.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Maui.Controls.Platform
 		bool? _defaultAccessibilityRespondsToUserInteraction;
 
 		double _previousScale = 1.0;
-		UITouchEventArgs? _shouldReceiveTouch;
+		ShouldReceiveTouchProxy? _proxy;
 		DragAndDropDelegate? _dragAndDropDelegate;
 
 		public GesturePlatformManager(IViewHandler handler)
@@ -340,19 +340,19 @@ namespace Microsoft.Maui.Controls.Platform
 						switch (r.State)
 						{
 							case UIGestureRecognizerState.Began:
-								if (r.NumberOfTouches != panRecognizer.TouchPoints)
+								if (r.NumberOfTouches != ((PanGestureRecognizer)panGestureRecognizer).TouchPoints)
 									return;
 								panGestureRecognizer.SendPanStarted(view, PanGestureRecognizer.CurrentId.Value);
 								break;
 							case UIGestureRecognizerState.Changed:
-								if (r.NumberOfTouches != panRecognizer.TouchPoints)
+								if (r.NumberOfTouches != ((PanGestureRecognizer)panGestureRecognizer).TouchPoints)
 								{
 									r.State = UIGestureRecognizerState.Ended;
 									panGestureRecognizer.SendPanCompleted(view, PanGestureRecognizer.CurrentId.Value);
 									PanGestureRecognizer.CurrentId.Increment();
 									return;
 								}
-								var translationInView = r.TranslationInView(PlatformView);
+								var translationInView = r.TranslationInView(eventTracker?.PlatformView);
 								panGestureRecognizer.SendPan(view, translationInView.X, translationInView.Y, PanGestureRecognizer.CurrentId.Value);
 								break;
 							case UIGestureRecognizerState.Cancelled:
@@ -361,7 +361,7 @@ namespace Microsoft.Maui.Controls.Platform
 								PanGestureRecognizer.CurrentId.Increment();
 								break;
 							case UIGestureRecognizerState.Ended:
-								if (r.NumberOfTouches != panRecognizer.TouchPoints)
+								if (r.NumberOfTouches != ((PanGestureRecognizer)panGestureRecognizer).TouchPoints)
 								{
 									panGestureRecognizer.SendPanCompleted(view, PanGestureRecognizer.CurrentId.Value);
 									PanGestureRecognizer.CurrentId.Increment();
@@ -564,12 +564,6 @@ namespace Microsoft.Maui.Controls.Platform
 			if (ElementGestureRecognizers == null)
 				return;
 
-			if (_shouldReceiveTouch == null)
-			{
-				// Cache this so we don't create a new UITouchEventArgs instance for every recognizer
-				_shouldReceiveTouch = ShouldReceiveTouch;
-			}
-
 			UIDragInteraction? uIDragInteraction = null;
 			UIDropInteraction? uIDropInteraction = null;
 
@@ -669,7 +663,8 @@ namespace Microsoft.Maui.Controls.Platform
 				{
 					if (nativeRecognizer != null && PlatformView != null)
 					{
-						nativeRecognizer.ShouldReceiveTouch = _shouldReceiveTouch;
+						_proxy ??= new ShouldReceiveTouchProxy(this);
+						nativeRecognizer.ShouldReceiveTouch = _proxy.ShouldReceiveTouch;
 						PlatformView.AddGestureRecognizer(nativeRecognizer);
 
 					}
@@ -738,37 +733,47 @@ namespace Microsoft.Maui.Controls.Platform
 				LoadRecognizers();
 		}
 
-		bool ShouldReceiveTouch(UIGestureRecognizer recognizer, UITouch touch)
+		class ShouldReceiveTouchProxy
 		{
-			var platformView = PlatformView;
-			var virtualView = _handler?.VirtualView;
+			readonly WeakReference<GesturePlatformManager> _manager;
 
-			if (virtualView == null || platformView == null)
+			public ShouldReceiveTouchProxy(GesturePlatformManager manager) => _manager = new(manager);
+
+			public bool ShouldReceiveTouch(UIGestureRecognizer recognizer, UITouch touch)
 			{
+				if (!_manager.TryGetTarget(out var manager))
+					return false;
+
+				var platformView = manager.PlatformView;
+				var virtualView = manager._handler?.VirtualView;
+
+				if (virtualView == null || platformView == null)
+				{
+					return false;
+				}
+
+				if (virtualView.InputTransparent)
+				{
+					return false;
+				}
+
+				if (touch.View == platformView)
+				{
+					return true;
+				}
+
+				// If the touch is coming from the UIView our handler is wrapping (e.g., if it's  
+				// wrapping a UIView which already has a gesture recognizer), then we should let it through
+				// (This goes for children of that control as well)
+
+				if (touch.View.IsDescendantOfView(platformView) &&
+					(touch.View.GestureRecognizers?.Length > 0 || platformView.GestureRecognizers?.Length > 0))
+				{
+					return true;
+				}
+
 				return false;
 			}
-
-			if (virtualView.InputTransparent)
-			{
-				return false;
-			}
-
-			if (touch.View == platformView)
-			{
-				return true;
-			}
-
-			// If the touch is coming from the UIView our handler is wrapping (e.g., if it's  
-			// wrapping a UIView which already has a gesture recognizer), then we should let it through
-			// (This goes for children of that control as well)
-
-			if (touch.View.IsDescendantOfView(platformView) &&
-				(touch.View.GestureRecognizers?.Length > 0 || platformView.GestureRecognizers?.Length > 0))
-			{
-				return true;
-			}
-
-			return false;
 		}
 
 		void GestureRecognizersOnCollectionChanged(object? sender, NotifyCollectionChangedEventArgs notifyCollectionChangedEventArgs)

--- a/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
+++ b/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
@@ -5,6 +5,7 @@ using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Handlers;
 using Microsoft.Maui.Controls.Handlers.Compatibility;
 using Microsoft.Maui.Controls.Handlers.Items;
+using Microsoft.Maui.Controls.Platform;
 using Microsoft.Maui.Controls.Shapes;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Hosting;
@@ -51,6 +52,11 @@ public class MemoryTests : ControlsHandlerTestBase
 				handlers.AddHandler<TableView, TableViewRenderer>();
 				handlers.AddHandler<TimePicker, TimePickerHandler>();
 				handlers.AddHandler<WebView, WebViewHandler>();
+#if IOS || MACCATALYST
+				handlers.AddHandler(typeof(NavigationPage), typeof(NavigationRenderer));
+#else
+				handlers.AddHandler(typeof(NavigationPage), typeof(NavigationViewHandler));
+#endif
 			});
 		});
 	}
@@ -138,6 +144,56 @@ public class MemoryTests : ControlsHandlerTestBase
 		});
 
 		await AssertionExtensions.WaitForGC(viewReference, handlerReference, platformViewReference);
+	}
+
+	[Theory("Gesture Does Not Leak")]
+	[InlineData(typeof(DragGestureRecognizer))]
+	[InlineData(typeof(DropGestureRecognizer))]
+	[InlineData(typeof(PanGestureRecognizer))]
+	[InlineData(typeof(PinchGestureRecognizer))]
+	[InlineData(typeof(PointerGestureRecognizer))]
+	[InlineData(typeof(SwipeGestureRecognizer))]
+	[InlineData(typeof(TapGestureRecognizer))]
+	public async Task GestureDoesNotLeak(Type type)
+	{
+		SetupBuilder();
+
+		WeakReference viewReference = null;
+		WeakReference handlerReference = null;
+
+		var observable = new ObservableCollection<int> { 1 };
+		var navPage = new NavigationPage(new ContentPage { Title = "Page 1" });
+
+		await CreateHandlerAndAddToWindow(new Window(navPage), async () =>
+		{
+			await navPage.Navigation.PushAsync(new ContentPage
+			{
+				Content = new CollectionView
+				{
+					ItemTemplate = new DataTemplate(() =>
+					{
+						var view = new Label
+						{
+							GestureRecognizers =
+							{
+								(GestureRecognizer)Activator.CreateInstance(type)
+							}
+						};
+						view.SetBinding(Label.TextProperty, ".");
+
+						viewReference = new WeakReference(view);
+						handlerReference = new WeakReference(view.Handler);
+
+						return view;
+					}),
+					ItemsSource = observable
+				}
+			});
+
+			await navPage.Navigation.PopAsync();
+		});
+
+		await AssertionExtensions.WaitForGC(viewReference, handlerReference);
 	}
 
 #if IOS

--- a/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
+++ b/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
@@ -51,11 +51,12 @@ public class MemoryTests : ControlsHandlerTestBase
 				handlers.AddHandler<Switch, SwitchHandler>();
 				handlers.AddHandler<TableView, TableViewRenderer>();
 				handlers.AddHandler<TimePicker, TimePickerHandler>();
+				handlers.AddHandler<Toolbar, ToolbarHandler>();
 				handlers.AddHandler<WebView, WebViewHandler>();
 #if IOS || MACCATALYST
-				handlers.AddHandler(typeof(NavigationPage), typeof(NavigationRenderer));
+				handlers.AddHandler<NavigationPage, NavigationRenderer>();
 #else
-				handlers.AddHandler(typeof(NavigationPage), typeof(NavigationViewHandler));
+				handlers.AddHandler<NavigationPage, NavigationViewHandler>();
 #endif
 			});
 		});


### PR DESCRIPTION
Related: https://github.com/dotnet/maui/pull/21089
Context: https://github.com/jonathanpeppers/iOSMauiCollectionView/commit/547b7fa6774af4cefddcccab66b7111b67cec07e

Doing something like this and running on iOS or Catalyst:

    <CollectionView.ItemTemplate>
        <DataTemplate>
            <Label Text="{Binding Name}">
                <Label.GestureRecognizers>
                    <TapGestureRecognizer Command="{Binding BindingContext.Command}" />
                </Label.GestureRecognizers>
            </Label>
        </DataTemplate>
    </CollectionView.ItemTemplate>

Causes a memory leak.

I could reproduce this in a test that is a bit more elaborate than #21089, showing issues for different types of gestures:

* Usage of `ShouldReceiveTouch` creates a cycle:

  * `GesturePlatformManager` -> `UIGestureRecognizer.ShouldReceiveTouch` -> `GesturePlatformManager`

  * We can move `ShouldReceiveTouch` to a "proxy" class, and avoid the cycle.

* `PanGestureRecognizer` has closures that cause the same cycle:

  * `this.PlatformView` -> `eventTracker?.PlatformView`

  * `panRecognizer` -> `((PanGestureRecognizer)panGestureRecognizer)`

  * These already had a `WeakReference` to use instead, but we could just make use of them.

There *may* be a general problem with `CollectionView` in how it doesn't tear down `GesturePlatformManager` in the same way for children. But in either case, the problems above are cycles that should be broken.
