### PR TITLE
[cake] add `SourceGen.UnitTests`

### DIFF
--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -222,6 +222,7 @@ Task("dotnet-test")
             "**/Controls.Core.UnitTests.csproj",
             "**/Controls.Core.Design.UnitTests.csproj",
             "**/Controls.Xaml.UnitTests.csproj",
+            "**/SourceGen.UnitTests.csproj",
             "**/Core.UnitTests.csproj",
             "**/Essentials.UnitTests.csproj",
             "**/Resizetizer.UnitTests.csproj",


### PR DESCRIPTION
Context: https://github.com/dotnet/maui/pull/21725

In #21725 we noticed some test projects aren't listed in `dotnet.cake`.

We don't think this affects CI, but if someone is running tests with cake locally.