### PR TITLE
[Android] Geolocation IsListeningForeground property is always false

### DIFF
--- a/src/Essentials/src/Geolocation/Geolocation.android.cs
+++ b/src/Essentials/src/Geolocation/Geolocation.android.cs
@@ -178,7 +178,7 @@ namespace Microsoft.Maui.Devices.Sensors
 			if (listeningProviders.Count == 0)
 				listeningProviders.Add(providerInfo.Provider);
 
-			var continuousListener = new ContinuousLocationListener(LocationManager, providerInfo.Accuracy, listeningProviders);
+			continuousListener = new ContinuousLocationListener(LocationManager, providerInfo.Accuracy, listeningProviders);
 			continuousListener.LocationHandler = HandleLocation;
 			continuousListener.ErrorHandler = HandleError;
 

--- a/src/Essentials/test/DeviceTests/Tests/Geolocation_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/Geolocation_Tests.cs
@@ -88,5 +88,25 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 			Assert.True(location.Timestamp < DateTimeOffset.UtcNow);
 			Assert.True(location.Timestamp > DateTimeOffset.UtcNow.Subtract(TimeSpan.FromDays(1)));
 		}
+
+		[Fact]
+		[Trait(Traits.InteractionType, Traits.InteractionTypes.Human)]
+		public async Task Geolocation_IsListeningForeground()
+		{
+			await MainThread.InvokeOnMainThreadAsync(async () =>
+			{
+				await Permissions.RequestAsync<Permissions.LocationWhenInUse>();
+			});
+
+			var request = new GeolocationListeningRequest(GeolocationAccuracy.Best);
+			request.DesiredAccuracy = GeolocationAccuracy.Low;
+			request.MinimumTime = TimeSpan.FromSeconds(5);
+
+			bool hasServiceStarted = await Geolocation.StartListeningForegroundAsync(request);
+
+			bool isListeningForeground = Geolocation.IsListeningForeground;
+
+			Assert.Equal(hasServiceStarted, isListeningForeground);
+		}
 	}
 }


### PR DESCRIPTION
### Description of Change

Remove the var keyword so the targetted continousListener is the static one inside the class instead of a local variable

https://github.com/dotnet/maui/blob/d3335ad840007e102ce635dc13fa82b7613873d7/src/Essentials/src/Geolocation/Geolocation.android.cs#L181

continuousListener is always null, that causes the property IsListeningInForeground to be always false and making it impossible to Stop the listener

### Issues Fixed

Fixes #21439 