### PR TITLE
[Trimming] Enable analyzers in Controls.Core on Tizen

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/Tizen/CellContentFactory.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/Tizen/CellContentFactory.cs
@@ -1,5 +1,6 @@
 #nullable disable
 using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Controls.Internals;
 
 namespace Microsoft.Maui.Controls.Handlers.Compatibility
 {
@@ -73,8 +74,8 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 #pragma warning restore CS0612 // Type or member is obsolete
 			};
 
-			text.SetBinding(Label.TextProperty, new Binding("Text", source: sectionCell));
-			text.SetBinding(Label.TextColorProperty, new Binding("TextColor", source: sectionCell));
+			text.SetBinding(Label.TextProperty, TypedBinding.ForSingleNestingLevel("Text", static (SectionCell cell) => cell.Text, source: sectionCell));
+			text.SetBinding(Label.TextColorProperty, TypedBinding.ForSingleNestingLevel("TextColor", static (SectionCell cell) => cell.TextColor, source: sectionCell));
 
 			var layout = new Controls.StackLayout
 			{
@@ -92,15 +93,15 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		static View CreateContent(TextCell textcell)
 		{
 			var text = new Label();
-			text.SetBinding(Label.TextProperty, new Binding("Text", source: textcell));
-			text.SetBinding(Label.TextColorProperty, new Binding("TextColor", source: textcell));
+			text.SetBinding(Label.TextProperty, TypedBinding.ForSingleNestingLevel("Text", static (TextCell cell) => cell.Text, source: textcell));
+			text.SetBinding(Label.TextColorProperty, TypedBinding.ForSingleNestingLevel("TextColor", static (TextCell cell) => cell.TextColor, source: textcell));
 #pragma warning disable CS0612 // Type or member is obsolete
 			text.FontSize = Device.GetNamedSize(NamedSize.Default, typeof(Label));
 #pragma warning restore CS0612 // Type or member is obsolete
 
 			var detail = new Label();
-			detail.SetBinding(Label.TextProperty, new Binding("Detail", source: textcell));
-			detail.SetBinding(Label.TextColorProperty, new Binding("DetailColor", source: textcell));
+			detail.SetBinding(Label.TextProperty, TypedBinding.ForSingleNestingLevel("Detail", static (TextCell cell) => cell.Detail, source: textcell));
+			detail.SetBinding(Label.TextColorProperty, TypedBinding.ForSingleNestingLevel("DetailColor", static (TextCell cell) => cell.DetailColor, source: textcell));
 #pragma warning disable CS0612 // Type or member is obsolete
 			detail.FontSize = Device.GetNamedSize(NamedSize.Micro, typeof(Label));
 #pragma warning restore CS0612 // Type or member is obsolete
@@ -138,7 +139,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			{
 				Aspect = Aspect.AspectFit,
 			};
-			img.SetBinding(Image.SourceProperty, new Binding("ImageSource", source: imageCell));
+			img.SetBinding(Image.SourceProperty, TypedBinding.ForSingleNestingLevel("ImageSource", static (ImageCell cell) => cell.ImageSource, source: imageCell));
 			layout.Add(img, 0, 0);
 			layout.Add(textcell, 1, 0);
 			return layout;
@@ -147,15 +148,20 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		static View CreateContent(EntryCell entryCell)
 		{
 			var entry = new Entry();
-			entry.SetBinding(Entry.TextProperty, new Binding("Text", BindingMode.TwoWay, source: entryCell));
-			entry.SetBinding(Entry.PlaceholderProperty, new Binding("Placeholder", source: entryCell));
-			entry.SetBinding(InputView.KeyboardProperty, new Binding("Keyboard", source: entryCell));
-			entry.SetBinding(Entry.HorizontalTextAlignmentProperty, new Binding("HorizontalTextAlignment", source: entryCell));
-			entry.SetBinding(Entry.VerticalTextAlignmentProperty, new Binding("VerticalTextAlignment", source: entryCell));
+			entry.SetBinding(Entry.TextProperty,
+				TypedBinding.ForSingleNestingLevel("Text",
+					static (EntryCell cell) => cell.Text,
+					static (cell, value) => cell.Text = value,
+					mode: BindingMode.TwoWay,
+					source: entryCell));
+			entry.SetBinding(Entry.PlaceholderProperty, TypedBinding.ForSingleNestingLevel("Placeholder", static (EntryCell cell) => cell.Placeholder, source: entryCell));
+			entry.SetBinding(InputView.KeyboardProperty, TypedBinding.ForSingleNestingLevel("Keyboard", static (EntryCell cell) => cell.Keyboard, source: entryCell));
+			entry.SetBinding(Entry.HorizontalTextAlignmentProperty, TypedBinding.ForSingleNestingLevel("HorizontalTextAlignment", static (EntryCell cell) => cell.HorizontalTextAlignment, source: entryCell));
+			entry.SetBinding(Entry.VerticalTextAlignmentProperty, TypedBinding.ForSingleNestingLevel("VerticalTextAlignment", static (EntryCell cell) => cell.VerticalTextAlignment, source: entryCell));
 
 			var label = new Label();
-			label.SetBinding(Label.TextProperty, new Binding("Label", source: entryCell));
-			label.SetBinding(Label.TextColorProperty, new Binding("LabelColor", source: entryCell));
+			label.SetBinding(Label.TextProperty, TypedBinding.ForSingleNestingLevel("Label", static (EntryCell cell) => cell.Label, source: entryCell));
+			label.SetBinding(Label.TextColorProperty, TypedBinding.ForSingleNestingLevel("LabelColor", static (EntryCell cell) => cell.LabelColor, source: entryCell));
 #pragma warning disable CS0612 // Type or member is obsolete
 			label.FontSize = Device.GetNamedSize(NamedSize.Micro, typeof(Label));
 #pragma warning restore CS0612 // Type or member is obsolete
@@ -182,14 +188,19 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				HorizontalOptions = LayoutOptions.StartAndExpand,
 			};
 #pragma warning restore CS0618
-			text.SetBinding(Label.TextProperty, new Binding("Text", source: switchCell));
+			text.SetBinding(Label.TextProperty, TypedBinding.ForSingleNestingLevel("Text", static (SwitchCell cell) => cell.Text, source: switchCell));
 
 			var sw = new Switch
 			{
 				HorizontalOptions = LayoutOptions.End
 			};
-			sw.SetBinding(Switch.IsToggledProperty, new Binding("On", BindingMode.TwoWay, source: switchCell));
-			sw.SetBinding(Switch.OnColorProperty, new Binding("OnColor", source: switchCell));
+			sw.SetBinding(Switch.IsToggledProperty,
+				TypedBinding.ForSingleNestingLevel("On",
+				static (SwitchCell cell) => cell.On,
+				static (cell, value) => cell.On = value,
+				mode: BindingMode.TwoWay,
+				source: switchCell));
+			sw.SetBinding(Switch.OnColorProperty, TypedBinding.ForSingleNestingLevel("OnColor", static (SwitchCell cell) => cell.OnColor, source: switchCell));
 
 			var layout = new Controls.StackLayout
 			{

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/Tizen/ListViewRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/Tizen/ListViewRenderer.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel;
 using System.Linq;
 using Microsoft.Maui.Controls.Handlers.Items;
+using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Controls.Platform;
 using Tizen.NUI;
 using Tizen.UIExtensions.NUI;
@@ -97,7 +98,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 					template = new CellWrapperTemplate(new DataTemplate(() =>
 					{
 						var label = new TextCell();
-						label.SetBinding(TextCell.TextProperty, new Binding("."));
+						label.SetBinding(TextCell.TextProperty, TypedBinding.ForSingleNestingLevel(string.Empty, static (object source) => source));
 						return label;
 					}), Element);
 				}

--- a/src/Controls/src/Core/Controls.Core.csproj
+++ b/src/Controls/src/Core/Controls.Core.csproj
@@ -21,7 +21,7 @@
     <Description>.NET Multi-platform App UI (.NET MAUI) is a cross-platform framework for creating native mobile and desktop apps with C# and XAML. This package only contains the core C# and XAML objects used by .NET MAUI. Please install the Microsoft.Maui.Controls package to start using .NET MAUI.</Description>
   </PropertyGroup>
 
-  <PropertyGroup Condition="!$(TargetFramework.StartsWith('netstandard')) and $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) != 'tizen'">
+  <PropertyGroup Condition="!$(TargetFramework.StartsWith('netstandard'))">
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
     <EnableAotAnalyzer>true</EnableAotAnalyzer>
     <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>

--- a/src/Controls/src/Core/Handlers/Items/Tizen/ItemTemplateAdaptor.cs
+++ b/src/Controls/src/Core/Handlers/Items/Tizen/ItemTemplateAdaptor.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
+using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Graphics;
 using Tizen.UIExtensions.NUI;
 using NView = Tizen.NUI.BaseComponents.View;
@@ -435,7 +436,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			{
 				TextColor = Colors.Black,
 			};
-			label.SetBinding(XLabel.TextProperty, new Binding(".", converter: new ToTextConverter()));
+			label.SetBinding(XLabel.TextProperty, TypedBinding.ForSingleNestingLevel(string.Empty, static (object source) => source, converter: new ToTextConverter()));
 
 			return new Controls.StackLayout
 			{

--- a/src/Controls/src/Core/Handlers/Shell/Tizen/ShellContentItemAdaptor.cs
+++ b/src/Controls/src/Core/Handlers/Shell/Tizen/ShellContentItemAdaptor.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using Microsoft.Maui.Controls.Handlers.Items;
+using Microsoft.Maui.Controls.Internals;
 using GColor = Microsoft.Maui.Graphics.Color;
 using NView = Tizen.NUI.BaseComponents.View;
 
@@ -28,9 +29,9 @@ namespace Microsoft.Maui.Controls.Platform
 			var nativeView = base.CreateNativeView(index);
 
 			var view = GetTemplatedView(nativeView);
-			view?.SetBinding(ShellContentItemView.SelectedTextColorProperty, new Binding("TitleColor", source: _itemAppearance));
-			view?.SetBinding(ShellContentItemView.SelectedBarColorProperty, new Binding("ForegroundColor", source: _itemAppearance));
-			view?.SetBinding(ShellContentItemView.UnselectedColorProperty, new Binding("UnselectedColor", source: _itemAppearance));
+			view?.SetBinding(ShellContentItemView.SelectedTextColorProperty, TypedBinding.ForSingleNestingLevel("TitleColor", static (ItemAppearance appearance) => appearance.TitleColor, source: _itemAppearance));
+			view?.SetBinding(ShellContentItemView.SelectedBarColorProperty, TypedBinding.ForSingleNestingLevel("ForegroundColor", static (ItemAppearance appearance) => appearance.ForegroundColor, source: _itemAppearance));
+			view?.SetBinding(ShellContentItemView.UnselectedColorProperty, TypedBinding.ForSingleNestingLevel("UnselectedColor", static (ItemAppearance appearance) => appearance.UnselectedColor, source: _itemAppearance));
 
 			return nativeView;
 		}

--- a/src/Controls/src/Core/Handlers/Shell/Tizen/ShellContentItemView.cs
+++ b/src/Controls/src/Core/Handlers/Shell/Tizen/ShellContentItemView.cs
@@ -1,3 +1,4 @@
+using Microsoft.Maui.Controls.Internals;
 using GColor = Microsoft.Maui.Graphics.Color;
 using GColors = Microsoft.Maui.Graphics.Colors;
 
@@ -60,7 +61,7 @@ namespace Microsoft.Maui.Controls.Platform
 				HorizontalTextAlignment = TextAlignment.Center,
 				VerticalTextAlignment = TextAlignment.Center,
 			};
-			_label.SetBinding(Label.TextProperty, new Binding("Title"));
+			_label.SetBinding(Label.TextProperty, TypedBinding.ForSingleNestingLevel("Title", static (BaseShellItem item) => item.Title));
 
 			_bar = new BoxView
 			{

--- a/src/Controls/src/Core/Handlers/Shell/Tizen/ShellFlyoutItemView.cs
+++ b/src/Controls/src/Core/Handlers/Shell/Tizen/ShellFlyoutItemView.cs
@@ -1,3 +1,4 @@
+using Microsoft.Maui.Controls.Internals;
 using GColors = Microsoft.Maui.Graphics.Colors;
 
 namespace Microsoft.Maui.Controls.Platform
@@ -33,7 +34,7 @@ namespace Microsoft.Maui.Controls.Platform
 				HorizontalOptions = LayoutOptions.Center,
 				VerticalOptions = LayoutOptions.Center,
 			};
-			icon.SetBinding(Image.SourceProperty, new Binding("Icon"));
+			icon.SetBinding(Image.SourceProperty, TypedBinding.ForSingleNestingLevel("Icon", static (BaseShellItem item) => item.Icon));
 
 			var label = new Label
 			{
@@ -41,7 +42,7 @@ namespace Microsoft.Maui.Controls.Platform
 				FontSize = 16,
 				VerticalTextAlignment = TextAlignment.Center,
 			};
-			label.SetBinding(Label.TextProperty, new Binding("Title"));
+			label.SetBinding(Label.TextProperty, TypedBinding.ForSingleNestingLevel("Title", static (BaseShellItem item) => item.Title));
 
 			_grid = new Grid
 			{

--- a/src/Controls/src/Core/Handlers/Shell/Tizen/ShellItemView.cs
+++ b/src/Controls/src/Core/Handlers/Shell/Tizen/ShellItemView.cs
@@ -254,7 +254,7 @@ namespace Microsoft.Maui.Controls.Platform
 				Remove(_bottomTabBar);
 		}
 
-		class MoreItem
+		internal class MoreItem
 		{
 			const string PathMoreVert = "M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z";
 

--- a/src/Controls/src/Core/Handlers/Shell/Tizen/ShellSearchItemAdaptor.cs
+++ b/src/Controls/src/Core/Handlers/Shell/Tizen/ShellSearchItemAdaptor.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using Microsoft.Maui.Controls.Handlers.Items;
+using Microsoft.Maui.Controls.Internals;
 using GColor = Microsoft.Maui.Graphics.Color;
 using GColors = Microsoft.Maui.Graphics.Colors;
 
@@ -24,7 +25,7 @@ namespace Microsoft.Maui.Controls.Platform
 			{
 				TextColor = GColors.Black,
 			};
-			label.SetBinding(Label.TextProperty, new Binding("."));
+			label.SetBinding(Label.TextProperty, TypedBinding.ForSingleNestingLevel(string.Empty, static (object source) => source));
 
 			return new Controls.StackLayout
 			{

--- a/src/Controls/src/Core/Handlers/Shell/Tizen/ShellSectionItemAdaptor.cs
+++ b/src/Controls/src/Core/Handlers/Shell/Tizen/ShellSectionItemAdaptor.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using Microsoft.Maui.Controls.Handlers.Items;
+using Microsoft.Maui.Controls.Internals;
 using GColor = Microsoft.Maui.Graphics.Color;
 using NView = Tizen.NUI.BaseComponents.View;
 
@@ -27,8 +28,8 @@ namespace Microsoft.Maui.Controls.Platform
 			var nativeView = base.CreateNativeView(index);
 
 			var view = GetTemplatedView(nativeView);
-			view?.SetBinding(ShellSectionItemView.SelectedColorProperty, new Binding("TitleColor", source: _itemAppearance));
-			view?.SetBinding(ShellSectionItemView.UnselectedColorProperty, new Binding("UnselectedColor", source: _itemAppearance));
+			view?.SetBinding(ShellSectionItemView.SelectedColorProperty, TypedBinding.ForSingleNestingLevel("TitleColor", static (ItemAppearance appearance) => appearance.TitleColor, source: _itemAppearance));
+			view?.SetBinding(ShellSectionItemView.UnselectedColorProperty, TypedBinding.ForSingleNestingLevel("UnselectedColor", static (ItemAppearance appearance) => appearance.UnselectedColor, source: _itemAppearance));
 
 			return nativeView;
 		}

--- a/src/Controls/src/Core/Handlers/Shell/Tizen/ShellSectionItemView.cs
+++ b/src/Controls/src/Core/Handlers/Shell/Tizen/ShellSectionItemView.cs
@@ -1,3 +1,4 @@
+using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Controls.Shapes;
 using GColor = Microsoft.Maui.Graphics.Color;
 using GColors = Microsoft.Maui.Graphics.Colors;
@@ -119,7 +120,7 @@ namespace Microsoft.Maui.Controls.Platform
 					VerticalOptions = LayoutOptions.Center,
 				};
 
-				_icon.SetBinding(Path.DataProperty, new Binding("IconPath", converter: new IconConverter()));
+				_icon.SetBinding(Path.DataProperty, TypedBinding.ForSingleNestingLevel("IconPath", static (ShellItemView.MoreItem item) => item.IconPath, converter: new IconConverter()));
 				return _icon;
 			}
 			else
@@ -130,7 +131,7 @@ namespace Microsoft.Maui.Controls.Platform
 					VerticalOptions = LayoutOptions.Center,
 				};
 
-				_icon.SetBinding(Image.SourceProperty, new Binding("Icon"));
+				_icon.SetBinding(Image.SourceProperty, TypedBinding.ForSingleNestingLevel("Icon", static (BaseShellItem item) => item.Icon));
 				return _icon;
 			}
 		}
@@ -144,7 +145,16 @@ namespace Microsoft.Maui.Controls.Platform
 				HorizontalTextAlignment = TextAlignment.Center,
 				VerticalTextAlignment = TextAlignment.Center,
 			};
-			_label.SetBinding(Label.TextProperty, new Binding("Title"));
+
+			if (_isMoreItem)
+			{
+				_label.SetBinding(Label.TextProperty, TypedBinding.ForSingleNestingLevel("Title", static (ShellItemView.MoreItem item) => item.Title));
+			}
+			else
+			{
+				_label.SetBinding(Label.TextProperty, TypedBinding.ForSingleNestingLevel("Title", static (BaseShellItem item) => item.Title));
+			}
+
 			return _label;
 		}
 

--- a/src/Controls/src/Core/TabbedPage/TabbedPage.Tizen.cs
+++ b/src/Controls/src/Core/TabbedPage/TabbedPage.Tizen.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using Microsoft.Maui.Controls.Handlers.Items;
+using Microsoft.Maui.Controls.Internals;
 using Tizen.NUI;
 using Tizen.UIExtensions.NUI;
 using GColor = Microsoft.Maui.Graphics.Color;
@@ -199,10 +200,10 @@ namespace Microsoft.Maui.Controls
 				Padding = new Thickness(0);
 				HasShadow = false;
 				BorderColor = GColors.DarkGray;
-				SetBinding(BackgroundProperty, new Binding("BarBackground", source: _page));
-				SetBinding(BackgroundColorProperty, new Binding("BarBackgroundColor", source: _page));
-				SetBinding(SelectedTabColorProperty, new Binding("SelectedTabColor", source: _page));
-				SetBinding(UnselectedTabColorProperty, new Binding("UnselectedTabColor", source: _page));
+				SetBinding(BackgroundProperty, TypedBinding.ForSingleNestingLevel("BarBackground", static (TabbedPage page) => page.BarBackground, source: _page));
+				SetBinding(BackgroundColorProperty, TypedBinding.ForSingleNestingLevel("BarBackgroundColor", static (TabbedPage page) => page.BarBackgroundColor, source: _page));
+				SetBinding(SelectedTabColorProperty, TypedBinding.ForSingleNestingLevel("SelectedTabColor", static (TabbedPage page) => page.SelectedTabColor, source: _page));
+				SetBinding(UnselectedTabColorProperty, TypedBinding.ForSingleNestingLevel("UnselectedTabColor", static (TabbedPage page) => page.UnselectedTabColor, source: _page));
 
 				var label = new XLabel
 				{
@@ -211,8 +212,8 @@ namespace Microsoft.Maui.Controls
 					HorizontalTextAlignment = TextAlignment.Center,
 					VerticalTextAlignment = TextAlignment.Center,
 				};
-				label.SetBinding(XLabel.TextProperty, new Binding("Title"));
-				label.SetBinding(XLabel.TextColorProperty, new Binding("BarTextColor", source: _page));
+				label.SetBinding(XLabel.TextProperty, TypedBinding.ForSingleNestingLevel("Title", static (TabbedPage page) => page.Title, source: _page));
+				label.SetBinding(XLabel.TextColorProperty, TypedBinding.ForSingleNestingLevel("BarTextColor", static (TabbedPage page) => page.BarTextColor, source: _page));
 
 				_bar = new BoxView
 				{


### PR DESCRIPTION
### Description of Change

This PR enables analyzers on Tizen and fixes all the warnings that were reported by these analzyers.

### Issues Fixed

Contributes to #18658