### PR TITLE
[Trimming] Enable analyzers in Controls.Xaml

### DIFF
--- a/docs/design/FeatureSwitches.md
+++ b/docs/design/FeatureSwitches.md
@@ -9,6 +9,7 @@ Certain features of MAUI can be enabled or disabled using feature switches. The 
 | MauiShellSearchResultsRendererDisplayMemberNameSupported | Microsoft.Maui.RuntimeFeature.IsShellSearchResultsRendererDisplayMemberNameSupported | When disabled, it is necessary to always set `ItemTemplate` of any `SearchHandler`. Displaying search results through `DisplayMemberName` will not work. |
 | MauiQueryPropertyAttributeSupport | Microsoft.Maui.RuntimeFeature.IsQueryPropertyAttributeSupported | When disabled, the `[QueryProperty(...)]` attributes won't be used to set values to properties when navigating. |
 | MauiImplicitCastOperatorsUsageViaReflectionSupport | Microsoft.Maui.RuntimeFeature.IsImplicitCastOperatorsUsageViaReflectionSupported | When disabled, MAUI won't look for implicit cast operators when converting values from one type to another. This feature is not trim-compatible. |
+| MauiNonCompiledBindingsInXamlSupport | Microsoft.Maui.RuntimeFeature.AreNonCompiledBindingsInXamlSupported | When disabled, it is not possible to use string-based bindings in XAML. All bindings are required to be annotated with x:DataType so they can be compiled. |
 
 ## MauiXamlRuntimeParsingSupport
 
@@ -37,3 +38,8 @@ When disabled, MAUI won't look for implicit cast operators when converting value
 If your library or your app defines an implicit operator on a type that can be used in one of the previous scenarios, you should define a custom `TypeConverter` for your type and attach it to the type using the `[TypeConverter(typeof(MyTypeConverter))]` attribute.
 
 _Note: Prefer using the `TypeConverterAttribute` as it can help the trimmer achieve better binary size in certain scenarios._
+
+## MauiNonCompiledBindingsInXamlSupport
+
+When disabled, XAML compiler will require that all bindings are compiled. All bindings that cannot be compiled due to missing x:DataType annotations will throw runtime exceptions.
+

--- a/docs/design/FeatureSwitches.md
+++ b/docs/design/FeatureSwitches.md
@@ -9,7 +9,6 @@ Certain features of MAUI can be enabled or disabled using feature switches. The 
 | MauiShellSearchResultsRendererDisplayMemberNameSupported | Microsoft.Maui.RuntimeFeature.IsShellSearchResultsRendererDisplayMemberNameSupported | When disabled, it is necessary to always set `ItemTemplate` of any `SearchHandler`. Displaying search results through `DisplayMemberName` will not work. |
 | MauiQueryPropertyAttributeSupport | Microsoft.Maui.RuntimeFeature.IsQueryPropertyAttributeSupported | When disabled, the `[QueryProperty(...)]` attributes won't be used to set values to properties when navigating. |
 | MauiImplicitCastOperatorsUsageViaReflectionSupport | Microsoft.Maui.RuntimeFeature.IsImplicitCastOperatorsUsageViaReflectionSupported | When disabled, MAUI won't look for implicit cast operators when converting values from one type to another. This feature is not trim-compatible. |
-| MauiNonCompiledBindingsInXamlSupport | Microsoft.Maui.RuntimeFeature.AreNonCompiledBindingsInXamlSupported | When disabled, it is not possible to use string-based bindings in XAML. All bindings are required to be annotated with x:DataType so they can be compiled. |
 
 ## MauiXamlRuntimeParsingSupport
 
@@ -38,8 +37,3 @@ When disabled, MAUI won't look for implicit cast operators when converting value
 If your library or your app defines an implicit operator on a type that can be used in one of the previous scenarios, you should define a custom `TypeConverter` for your type and attach it to the type using the `[TypeConverter(typeof(MyTypeConverter))]` attribute.
 
 _Note: Prefer using the `TypeConverterAttribute` as it can help the trimmer achieve better binary size in certain scenarios._
-
-## MauiNonCompiledBindingsInXamlSupport
-
-When disabled, XAML compiler will require that all bindings are compiled. All bindings that cannot be compiled due to missing x:DataType annotations will throw runtime exceptions.
-

--- a/src/Controls/samples/Controls.Sample.UITests/Controls.Sample.UITests.csproj
+++ b/src/Controls/samples/Controls.Sample.UITests/Controls.Sample.UITests.csproj
@@ -23,6 +23,7 @@
     <PublishAot>true</PublishAot>
     <_IsPublishing>true</_IsPublishing>
     <IlcTreatWarningsAsErrors>false</IlcTreatWarningsAsErrors>
+    <WarningsNotAsErrors>IL3050;XC0022</WarningsNotAsErrors>
     <DefineConstants>$(DefineConstants);NATIVE_AOT</DefineConstants>
   </PropertyGroup>
 

--- a/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
+++ b/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
@@ -517,7 +517,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 			{
 				// looking for BindingContext="{Binding ...}"
 				return GetParent(node) is IElementNode parentNode
-					&& ApplyPropertiesVisitor.TryGetPropertyName(node, parentNode, out var propertyName)
+					&& node.TryGetPropertyName(parentNode, out var propertyName)
 					&& propertyName.NamespaceURI == ""
 					&& propertyName.LocalName == nameof(BindableObject.BindingContext);
 			}

--- a/src/Controls/src/SourceGen/CodeBehindGenerator.cs
+++ b/src/Controls/src/SourceGen/CodeBehindGenerator.cs
@@ -358,9 +358,9 @@ public class CodeBehindGenerator : IIncrementalGenerator
 
 		sb.AppendLine("\t\tprivate void InitializeComponent()");
 		sb.AppendLine("\t\t{");
-		sb.AppendLine("#pragma warning disable IL2026 // The body of InitializeComponent will be replaced by XamlC so LoadFromXaml will never be called in production builds");
+		sb.AppendLine("#pragma warning disable IL2026, IL3050 // The body of InitializeComponent will be replaced by XamlC so LoadFromXaml will never be called in production builds");
 		sb.AppendLine($"\t\t\tglobal::Microsoft.Maui.Controls.Xaml.Extensions.LoadFromXaml(this, typeof({rootType}));");
-		sb.AppendLine("#pragma warning restore IL2026");
+		sb.AppendLine("#pragma warning restore IL2026, IL3050");
 
 		if (namedFields != null)
 		{

--- a/src/Controls/src/Xaml/ApplyPropertiesVisitor.cs
+++ b/src/Controls/src/Xaml/ApplyPropertiesVisitor.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using System.Xml;
@@ -14,6 +15,10 @@ using static System.String;
 
 namespace Microsoft.Maui.Controls.Xaml
 {
+	[RequiresUnreferencedCode(TrimmerConstants.XamlRuntimeParsingNotSupportedWarning)]
+#if !NETSTANDARD
+	[RequiresDynamicCode(TrimmerConstants.XamlRuntimeParsingNotSupportedWarning)]
+#endif
 	class ApplyPropertiesVisitor : IXamlNodeVisitor
 	{
 		public static readonly IList<XmlName> Skips = new List<XmlName> {

--- a/src/Controls/src/Xaml/ApplyPropertiesVisitor.cs
+++ b/src/Controls/src/Xaml/ApplyPropertiesVisitor.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Maui.Controls.Xaml
 				return;
 
 
-			if (TryGetPropertyName(node, parentNode, out XmlName propertyName))
+			if (node.TryGetPropertyName(parentNode, out XmlName propertyName))
 			{
 				if (TrySetRuntimeName(propertyName, source, value, node))
 					return;
@@ -83,7 +83,7 @@ namespace Microsoft.Maui.Controls.Xaml
 
 		public void Visit(ElementNode node, INode parentNode)
 		{
-			if (TryGetPropertyName(node, parentNode, out XmlName propertyName) && propertyName == XmlName._CreateContent)
+			if (node.TryGetPropertyName(parentNode, out XmlName propertyName) && propertyName == XmlName._CreateContent)
 			{
 				var s0 = Values[parentNode];
 				if (s0 is ElementTemplate)
@@ -107,7 +107,7 @@ namespace Microsoft.Maui.Controls.Xaml
 			if (!Values.TryGetValue(node, out var value) && Context.ExceptionHandler != null)
 				return;
 
-			if (propertyName != XmlName.Empty || TryGetPropertyName(node, parentNode, out propertyName))
+			if (propertyName != XmlName.Empty || node.TryGetPropertyName(parentNode, out propertyName))
 			{
 				if (Skips.Contains(propertyName))
 					return;
@@ -227,22 +227,6 @@ namespace Microsoft.Maui.Controls.Xaml
 
 		public void Visit(ListNode node, INode parentNode)
 		{
-		}
-
-		public static bool TryGetPropertyName(INode node, INode parentNode, out XmlName name)
-		{
-			name = default(XmlName);
-			var parentElement = parentNode as IElementNode;
-			if (parentElement == null)
-				return false;
-			foreach (var kvp in parentElement.Properties)
-			{
-				if (kvp.Value != node)
-					continue;
-				name = kvp.Key;
-				return true;
-			}
-			return false;
 		}
 
 		internal static bool IsCollectionItem(INode node, INode parentNode)

--- a/src/Controls/src/Xaml/Controls.Xaml.csproj
+++ b/src/Controls/src/Xaml/Controls.Xaml.csproj
@@ -22,6 +22,12 @@
 		<Description>.NET Multi-platform App UI (.NET MAUI) is a cross-platform framework for creating native mobile and desktop apps with C# and XAML. This package only contains the XAML tooling. Please install the Microsoft.Maui.Controls package to start using .NET MAUI.</Description>
 	</PropertyGroup>
 
+	<PropertyGroup Condition="!$(TargetFramework.StartsWith('netstandard'))">
+		<EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+		<EnableAotAnalyzer>true</EnableAotAnalyzer>
+		<EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
+	</PropertyGroup>
+
 	<ItemGroup>
 		<ProjectReference Include="..\..\..\Controls\src\Core\Controls.Core.csproj" />
 		<ProjectReference Include="..\..\..\Core\src\Core.csproj" />

--- a/src/Controls/src/Xaml/CreateValuesVisitor.cs
+++ b/src/Controls/src/Xaml/CreateValuesVisitor.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
@@ -9,6 +10,10 @@ using Microsoft.Maui.Controls.Xaml.Internals;
 
 namespace Microsoft.Maui.Controls.Xaml
 {
+	[RequiresUnreferencedCode(TrimmerConstants.XamlRuntimeParsingNotSupportedWarning)]
+#if !NETSTANDARD
+	[RequiresDynamicCode(TrimmerConstants.XamlRuntimeParsingNotSupportedWarning)]
+#endif
 	class CreateValuesVisitor : IXamlNodeVisitor
 	{
 		public CreateValuesVisitor(HydrationContext context)

--- a/src/Controls/src/Xaml/CreateValuesVisitor.cs
+++ b/src/Controls/src/Xaml/CreateValuesVisitor.cs
@@ -185,7 +185,7 @@ namespace Microsoft.Maui.Controls.Xaml
 		public void Visit(ListNode node, INode parentNode)
 		{
 			//this is a gross hack to keep ListNode alive. ListNode must go in favor of Properties
-			if (ApplyPropertiesVisitor.TryGetPropertyName(node, parentNode, out XmlName name))
+			if (node.TryGetPropertyName(parentNode, out XmlName name))
 				node.XmlName = name;
 		}
 

--- a/src/Controls/src/Xaml/ExpandMarkupsVisitor.cs
+++ b/src/Controls/src/Xaml/ExpandMarkupsVisitor.cs
@@ -1,10 +1,15 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Xml;
 using Microsoft.Maui.Controls.Xaml.Internals;
 
 namespace Microsoft.Maui.Controls.Xaml
 {
+	[RequiresUnreferencedCode(TrimmerConstants.XamlRuntimeParsingNotSupportedWarning)]
+#if !NETSTANDARD
+	[RequiresDynamicCode(TrimmerConstants.XamlRuntimeParsingNotSupportedWarning)]
+#endif
 	class ExpandMarkupsVisitor : IXamlNodeVisitor
 	{
 		public ExpandMarkupsVisitor(HydrationContext context) => Context = context;

--- a/src/Controls/src/Xaml/ExpandMarkupsVisitor.cs
+++ b/src/Controls/src/Xaml/ExpandMarkupsVisitor.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Maui.Controls.Xaml
 		{
 			var parentElement = parentNode as IElementNode;
 			XmlName propertyName;
-			if (!ApplyPropertiesVisitor.TryGetPropertyName(markupnode, parentNode, out propertyName))
+			if (!markupnode.TryGetPropertyName(parentNode, out propertyName))
 				return;
 			if (Skips.Contains(propertyName))
 				return;

--- a/src/Controls/src/Xaml/ExpandMarkupsVisitor.cs
+++ b/src/Controls/src/Xaml/ExpandMarkupsVisitor.cs
@@ -111,6 +111,7 @@ namespace Microsoft.Maui.Controls.Xaml
 			return new MarkupExpansionParser { ExceptionHandler = Context.ExceptionHandler }.Parse(match, ref expression, serviceProvider);
 		}
 
+		[RequiresUnreferencedCode(TrimmerConstants.XamlRuntimeParsingNotSupportedWarning)]
 		public class MarkupExpansionParser : MarkupExpressionParser, IExpressionParser<INode>
 		{
 			IElementNode _node;

--- a/src/Controls/src/Xaml/FillResourceDictionariesVisitor.cs
+++ b/src/Controls/src/Xaml/FillResourceDictionariesVisitor.cs
@@ -1,11 +1,16 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Controls.Xaml.Internals;
 
 namespace Microsoft.Maui.Controls.Xaml
 {
+	[RequiresUnreferencedCode(TrimmerConstants.XamlRuntimeParsingNotSupportedWarning)]
+#if !NETSTANDARD
+	[RequiresDynamicCode(TrimmerConstants.XamlRuntimeParsingNotSupportedWarning)]
+#endif
 	class FillResourceDictionariesVisitor : IXamlNodeVisitor
 	{
 		public FillResourceDictionariesVisitor(HydrationContext context) => Context = context;

--- a/src/Controls/src/Xaml/FillResourceDictionariesVisitor.cs
+++ b/src/Controls/src/Xaml/FillResourceDictionariesVisitor.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Maui.Controls.Xaml
 				return;
 
 			//Set RD to VE
-			if (typeof(ResourceDictionary).IsAssignableFrom(Context.Types[node]) && ApplyPropertiesVisitor.TryGetPropertyName(node, parentNode, out XmlName propertyName))
+			if (typeof(ResourceDictionary).IsAssignableFrom(Context.Types[node]) && node.TryGetPropertyName(parentNode, out XmlName propertyName))
 			{
 				if ((propertyName.LocalName == "Resources" ||
 					 propertyName.LocalName.EndsWith(".Resources", StringComparison.Ordinal)) && value is ResourceDictionary)

--- a/src/Controls/src/Xaml/MarkupExpressionParser.cs
+++ b/src/Controls/src/Xaml/MarkupExpressionParser.cs
@@ -32,6 +32,7 @@
 //
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 
 namespace Microsoft.Maui.Controls.Xaml
@@ -46,6 +47,7 @@ namespace Microsoft.Maui.Controls.Xaml
 			public object value;
 		}
 
+		[RequiresUnreferencedCode(TrimmerConstants.XamlRuntimeParsingNotSupportedWarning)]
 		public object ParseExpression(ref string expression, IServiceProvider serviceProvider)
 		{
 			if (serviceProvider == null)
@@ -120,6 +122,7 @@ namespace Microsoft.Maui.Controls.Xaml
 			return true;
 		}
 
+		[RequiresUnreferencedCode(TrimmerConstants.XamlRuntimeParsingNotSupportedWarning)]
 		protected Property ParseProperty(IServiceProvider serviceProvider, ref string remaining)
 		{
 			object value = null;
@@ -148,6 +151,7 @@ namespace Microsoft.Maui.Controls.Xaml
 			return new Property { last = next == '}', name = name, strValue = str_value, value = value };
 		}
 
+		[RequiresUnreferencedCode(TrimmerConstants.XamlRuntimeParsingNotSupportedWarning)]
 		Property ParsePropertyExpression(string prop, IServiceProvider serviceProvider, ref string remaining)
 		{
 			bool last;

--- a/src/Controls/src/Xaml/MarkupExtensionParser.cs
+++ b/src/Controls/src/Xaml/MarkupExtensionParser.cs
@@ -1,9 +1,14 @@
 using System;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
 namespace Microsoft.Maui.Controls.Xaml
 {
+	[RequiresUnreferencedCode(TrimmerConstants.XamlRuntimeParsingNotSupportedWarning)]
+#if !NETSTANDARD
+	[RequiresDynamicCode(TrimmerConstants.XamlRuntimeParsingNotSupportedWarning)]
+#endif
 	internal sealed class MarkupExtensionParser : MarkupExpressionParser, IExpressionParser<object>
 	{
 		IMarkupExtension markupExtension;

--- a/src/Controls/src/Xaml/MarkupExtensions/ArrayExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/ArrayExtension.cs
@@ -1,11 +1,15 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Maui.Controls.Xaml
 {
 	[ContentProperty(nameof(Items))]
 	[AcceptEmptyServiceProvider]
+#if !NETSTANDARD
+	[RequiresDynamicCode("ArrayExtension is not AOT safe.")]
+#endif
 	public class ArrayExtension : IMarkupExtension<Array>
 	{
 		public ArrayExtension()

--- a/src/Controls/src/Xaml/MarkupExtensions/BindingExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/BindingExtension.cs
@@ -22,23 +22,12 @@ namespace Microsoft.Maui.Controls.Xaml
 		BindingBase IMarkupExtension<BindingBase>.ProvideValue(IServiceProvider serviceProvider)
 		{
 			if (TypedBinding == null)
-			{
-				if (RuntimeFeature.AreNonCompiledBindingsInXamlSupported)
+				return new Binding(Path, Mode, Converter, ConverterParameter, StringFormat, Source)
 				{
-					return new Binding(Path, Mode, Converter, ConverterParameter, StringFormat, Source)
-					{
-						UpdateSourceEventName = UpdateSourceEventName,
-						FallbackValue = FallbackValue,
-						TargetNullValue = TargetNullValue,
-					};
-				}
-				else
-				{
-					throw new InvalidOperationException(
-						$"It was not possible to compile binding with path '{Path}'. Bindings with string paths are not supported. " +
-						"Make sure all bindings in XAML are correctly annotated with x:DataType.");
-				}
-			}
+					UpdateSourceEventName = UpdateSourceEventName,
+					FallbackValue = FallbackValue,
+					TargetNullValue = TargetNullValue,
+				};
 
 			TypedBinding.Mode = Mode;
 			TypedBinding.Converter = Converter;

--- a/src/Controls/src/Xaml/MarkupExtensions/BindingExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/BindingExtension.cs
@@ -22,12 +22,23 @@ namespace Microsoft.Maui.Controls.Xaml
 		BindingBase IMarkupExtension<BindingBase>.ProvideValue(IServiceProvider serviceProvider)
 		{
 			if (TypedBinding == null)
-				return new Binding(Path, Mode, Converter, ConverterParameter, StringFormat, Source)
+			{
+				if (RuntimeFeature.AreNonCompiledBindingsInXamlSupported)
 				{
-					UpdateSourceEventName = UpdateSourceEventName,
-					FallbackValue = FallbackValue,
-					TargetNullValue = TargetNullValue,
-				};
+					return new Binding(Path, Mode, Converter, ConverterParameter, StringFormat, Source)
+					{
+						UpdateSourceEventName = UpdateSourceEventName,
+						FallbackValue = FallbackValue,
+						TargetNullValue = TargetNullValue,
+					};
+				}
+				else
+				{
+					throw new InvalidOperationException(
+						$"It was not possible to compile binding with path '{Path}'. Bindings with string paths are not supported. " +
+						"Make sure all bindings in XAML are correctly annotated with x:DataType.");
+				}
+			}
 
 			TypedBinding.Mode = Mode;
 			TypedBinding.Converter = Converter;

--- a/src/Controls/src/Xaml/MarkupExtensions/BindingExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/BindingExtension.cs
@@ -22,12 +22,18 @@ namespace Microsoft.Maui.Controls.Xaml
 		BindingBase IMarkupExtension<BindingBase>.ProvideValue(IServiceProvider serviceProvider)
 		{
 			if (TypedBinding == null)
+			{
+#pragma warning disable IL2026 // Using member 'Microsoft.Maui.Controls.Binding.Binding(String, BindingMode, IValueConverter, Object, String, Object)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. Using bindings with string paths is not trim safe. Use expression-based binding instead.
+				// This code is only reachable in XamlC compiled code when there is a missing x:DataType and the binding could not be compiled.
+				// In that case, we produce a warning that the binding could not be compiled.
 				return new Binding(Path, Mode, Converter, ConverterParameter, StringFormat, Source)
 				{
 					UpdateSourceEventName = UpdateSourceEventName,
 					FallbackValue = FallbackValue,
 					TargetNullValue = TargetNullValue,
 				};
+#pragma warning restore IL2026
+			}
 
 			TypedBinding.Mode = Mode;
 			TypedBinding.Converter = Converter;

--- a/src/Controls/src/Xaml/MarkupExtensions/OnIdiomExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/OnIdiomExtension.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Reflection;
 using System.Xml;
@@ -13,6 +14,7 @@ namespace Microsoft.Maui.Controls.Xaml
 		 typeof(IValueConverterProvider),
 		 typeof(IXmlLineInfoProvider),
 		 typeof(IConverterOptions)])]
+	[RequiresUnreferencedCode("The OnIdiomExtension is not trim safe. Use OnIdiom<T> instead.")]
 	public class OnIdiomExtension : IMarkupExtension
 	{
 		// See Device.Idiom

--- a/src/Controls/src/Xaml/MarkupExtensions/OnPlatformExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/OnPlatformExtension.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
@@ -12,6 +13,7 @@ namespace Microsoft.Maui.Controls.Xaml
 		 typeof(IValueConverterProvider),
 		 typeof(IXmlLineInfoProvider),
 		 typeof(IConverterOptions)])]
+	[RequiresUnreferencedCode("The OnPlatformExtension is not trim safe. Use OnPlatform<T> instead.")]
 	public class OnPlatformExtension : IMarkupExtension
 	{
 		static object s_notset = new object();

--- a/src/Controls/src/Xaml/MarkupExtensions/StaticExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/StaticExtension.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using System.Xml;
@@ -7,6 +8,7 @@ namespace Microsoft.Maui.Controls.Xaml
 {
 	[ContentProperty(nameof(Member))]
 	[ProvideCompiled("Microsoft.Maui.Controls.Build.Tasks.StaticExtension")]
+	[RequiresUnreferencedCode(TrimmerConstants.XamlRuntimeParsingNotSupportedWarning)]
 	public class StaticExtension : IMarkupExtension
 	{
 		public string Member { get; set; }

--- a/src/Controls/src/Xaml/MarkupExtensions/TemplateBindingExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/TemplateBindingExtension.cs
@@ -24,24 +24,15 @@ namespace Microsoft.Maui.Controls.Xaml
 
 		BindingBase IMarkupExtension<BindingBase>.ProvideValue(IServiceProvider serviceProvider)
 		{
-			if (RuntimeFeature.AreNonCompiledBindingsInXamlSupported)
+			return new Binding
 			{
-				return new Binding
-				{
-					Source = RelativeBindingSource.TemplatedParent,
-					Path = Path,
-					Mode = Mode,
-					Converter = Converter,
-					ConverterParameter = ConverterParameter,
-					StringFormat = StringFormat
-				};
-			}
-			else
-			{
-				throw new InvalidOperationException(
-					$"It was not possible to compile binding with path '{Path}'. Bindings with string paths are not supported. " +
-					"Use {Binding RelativeSource={RelativeSource TemplatedParent}} instead of {TemplateBinding} Make sure all bindings in XAML are correctly annotated with x:DataType.");
-			}
+				Source = RelativeBindingSource.TemplatedParent,
+				Path = Path,
+				Mode = Mode,
+				Converter = Converter,
+				ConverterParameter = ConverterParameter,
+				StringFormat = StringFormat
+			};
 		}
 
 		object IMarkupExtension.ProvideValue(IServiceProvider serviceProvider)

--- a/src/Controls/src/Xaml/MarkupExtensions/TemplateBindingExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/TemplateBindingExtension.cs
@@ -1,9 +1,11 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Maui.Controls.Xaml
 {
 	[ContentProperty(nameof(Path))]
 	[AcceptEmptyServiceProvider]
+	[RequiresUnreferencedCode(TrimmerConstants.StringPathBindingWarning, Url = TrimmerConstants.ExpressionBasedBindingsDocsUrl)]
 	public sealed class TemplateBindingExtension : IMarkupExtension<BindingBase>
 	{
 		public TemplateBindingExtension()

--- a/src/Controls/src/Xaml/MarkupExtensions/TemplateBindingExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/TemplateBindingExtension.cs
@@ -24,15 +24,24 @@ namespace Microsoft.Maui.Controls.Xaml
 
 		BindingBase IMarkupExtension<BindingBase>.ProvideValue(IServiceProvider serviceProvider)
 		{
-			return new Binding
+			if (RuntimeFeature.AreNonCompiledBindingsInXamlSupported)
 			{
-				Source = RelativeBindingSource.TemplatedParent,
-				Path = Path,
-				Mode = Mode,
-				Converter = Converter,
-				ConverterParameter = ConverterParameter,
-				StringFormat = StringFormat
-			};
+				return new Binding
+				{
+					Source = RelativeBindingSource.TemplatedParent,
+					Path = Path,
+					Mode = Mode,
+					Converter = Converter,
+					ConverterParameter = ConverterParameter,
+					StringFormat = StringFormat
+				};
+			}
+			else
+			{
+				throw new InvalidOperationException(
+					$"It was not possible to compile binding with path '{Path}'. Bindings with string paths are not supported. " +
+					"Use {Binding RelativeSource={RelativeSource TemplatedParent}} instead of {TemplateBinding} Make sure all bindings in XAML are correctly annotated with x:DataType.");
+			}
 		}
 
 		object IMarkupExtension.ProvideValue(IServiceProvider serviceProvider)

--- a/src/Controls/src/Xaml/NodeExtensions.cs
+++ b/src/Controls/src/Xaml/NodeExtensions.cs
@@ -1,0 +1,21 @@
+namespace Microsoft.Maui.Controls.Xaml
+{
+	internal static class NodeExtensions
+	{
+		public static bool TryGetPropertyName(this INode node, INode parentNode, out XmlName name)
+		{
+			name = default;
+			var parentElement = parentNode as IElementNode;
+			if (parentElement == null)
+				return false;
+			foreach (var kvp in parentElement.Properties)
+			{
+				if (kvp.Value != node)
+					continue;
+				name = kvp.Key;
+				return true;
+			}
+			return false;
+		}
+	}
+}

--- a/src/Controls/src/Xaml/NodeExtensions.cs
+++ b/src/Controls/src/Xaml/NodeExtensions.cs
@@ -1,21 +1,27 @@
-namespace Microsoft.Maui.Controls.Xaml
+namespace Microsoft.Maui.Controls.Xaml;
+
+internal static class NodeExtensions
 {
-	internal static class NodeExtensions
+	public static bool TryGetPropertyName(this INode node, INode parentNode, out XmlName name)
 	{
-		public static bool TryGetPropertyName(this INode node, INode parentNode, out XmlName name)
+		name = default;
+
+		if (parentNode is not IElementNode parentElement)
 		{
-			name = default;
-			var parentElement = parentNode as IElementNode;
-			if (parentElement == null)
-				return false;
-			foreach (var kvp in parentElement.Properties)
-			{
-				if (kvp.Value != node)
-					continue;
-				name = kvp.Key;
-				return true;
-			}
 			return false;
 		}
+
+		foreach (var kvp in parentElement.Properties)
+		{
+			if (kvp.Value != node)
+			{
+				continue;
+			}
+
+			name = kvp.Key;
+			return true;
+		}
+
+		return false;
 	}
 }

--- a/src/Controls/src/Xaml/NodeExtensions.cs
+++ b/src/Controls/src/Xaml/NodeExtensions.cs
@@ -1,21 +1,20 @@
-namespace Microsoft.Maui.Controls.Xaml
+namespace Microsoft.Maui.Controls.Xaml;
+
+internal static class NodeExtensions
 {
-	internal static class NodeExtensions
+	public static bool TryGetPropertyName(this INode node, INode parentNode, out XmlName name)
 	{
-		public static bool TryGetPropertyName(this INode node, INode parentNode, out XmlName name)
-		{
-			name = default;
-			var parentElement = parentNode as IElementNode;
-			if (parentElement == null)
-				return false;
-			foreach (var kvp in parentElement.Properties)
-			{
-				if (kvp.Value != node)
-					continue;
-				name = kvp.Key;
-				return true;
-			}
+		name = default;
+		var parentElement = parentNode as IElementNode;
+		if (parentElement == null)
 			return false;
+		foreach (var kvp in parentElement.Properties)
+		{
+			if (kvp.Value != node)
+				continue;
+			name = kvp.Key;
+			return true;
 		}
+		return false;
 	}
 }

--- a/src/Controls/src/Xaml/ResourceDictionaryHelpers.cs
+++ b/src/Controls/src/Xaml/ResourceDictionaryHelpers.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Reflection;
 using System.Xml;
@@ -7,6 +8,10 @@ namespace Microsoft.Maui.Controls.Xaml
 {
 	internal static class ResourceDictionaryHelpers
 	{
+		[RequiresUnreferencedCode(TrimmerConstants.XamlRuntimeParsingNotSupportedWarning)]
+#if !NETSTANDARD
+		[RequiresDynamicCode(TrimmerConstants.XamlRuntimeParsingNotSupportedWarning)]
+#endif
 		internal static void LoadFromSource(ResourceDictionary rd, string value, Type rootType, IXmlLineInfo lineInfo)
 		{
 			(value, var assembly) = ResourceDictionary.RDSourceTypeConverter.SplitUriAndAssembly(value, rootType.Assembly);

--- a/src/Controls/src/Xaml/SimplifyOnPlatformVisitor.cs
+++ b/src/Controls/src/Xaml/SimplifyOnPlatformVisitor.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 
 #nullable disable
@@ -52,21 +52,21 @@ namespace Microsoft.Maui.Controls.Xaml
 				if (node.Properties.TryGetValue(new XmlName("", Target), out INode targetNode)
 					|| node.Properties.TryGetValue(new XmlName("", nameof(OnPlatformExtension.Default)), out targetNode))
 				{
-					if (!ApplyPropertiesVisitor.TryGetPropertyName(node, parentNode, out XmlName name))
+					if (!node.TryGetPropertyName(parentNode, out XmlName name))
 						return;
 					if (parentNode is IElementNode parentEnode)
 						parentEnode.Properties[name] = targetNode;
 				}
 				else if (node.CollectionItems.Count > 0) // syntax like {OnPlatform foo, iOS=bar}
 				{
-					if (!ApplyPropertiesVisitor.TryGetPropertyName(node, parentNode, out XmlName name))
+					if (!node.TryGetPropertyName(parentNode, out XmlName name))
 						return;
 					if (parentNode is IElementNode parentEnode)
 						parentEnode.Properties[name] = node.CollectionItems[0];
 				}
 				else //no prop for target and no Default set
 				{
-					if (!ApplyPropertiesVisitor.TryGetPropertyName(node, parentNode, out XmlName name))
+					if (!node.TryGetPropertyName(parentNode, out XmlName name))
 						return;
 					//if there's no value for the targetPlatform, ignore the node.
 					//this is slightly different than what OnPlatform does (return default(T))
@@ -81,7 +81,7 @@ namespace Microsoft.Maui.Controls.Xaml
 			//	var onNode = GetOnNode(node, Target) ?? GetDefault(node);
 
 			//	//Property node
-			//	if (ApplyPropertiesVisitor.TryGetPropertyName(node, parentNode, out XmlName name)
+			//	if (node.TryGetPropertyName(parentNode, out XmlName name)
 			//		&& parentNode is IElementNode parentEnode)
 			//	{
 			//		if (onNode != null)

--- a/src/Controls/src/Xaml/SimplifyTypeExtensionVisitor.cs
+++ b/src/Controls/src/Xaml/SimplifyTypeExtensionVisitor.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 
 #nullable disable
@@ -36,7 +36,7 @@ namespace Microsoft.Maui.Controls.Xaml
 			}
 
 			static bool IsValueOfXDataTypeOrTargetType(ElementNode node, INode parentNode, out XmlName propertyName)
-				=> ApplyPropertiesVisitor.TryGetPropertyName(node, parentNode, out propertyName)
+				=> node.TryGetPropertyName(parentNode, out propertyName)
 					&& (IsXDataType(propertyName) || IsTargetTypePropertyOfMauiType(parentNode, propertyName));
 
 			static bool IsTargetTypePropertyOfMauiType(INode parentNode, XmlName propertyName)

--- a/src/Controls/src/Xaml/ViewExtensions.cs
+++ b/src/Controls/src/Xaml/ViewExtensions.cs
@@ -31,23 +31,24 @@ using System.Reflection;
 
 namespace Microsoft.Maui.Controls.Xaml
 {
+	[RequiresUnreferencedCode(TrimmerConstants.XamlRuntimeParsingNotSupportedWarning)]
+#if !NETSTANDARD
+	[RequiresDynamicCode(TrimmerConstants.XamlRuntimeParsingNotSupportedWarning)]
+#endif
 	public static class Extensions
 	{
-		[RequiresUnreferencedCode(TrimmerConstants.XamlRuntimeParsingNotSupportedWarning)]
 		public static TXaml LoadFromXaml<TXaml>(this TXaml view, Type callingType)
 		{
 			XamlLoader.Load(view, callingType);
 			return view;
 		}
 
-		[RequiresUnreferencedCode(TrimmerConstants.XamlRuntimeParsingNotSupportedWarning)]
 		public static TXaml LoadFromXaml<TXaml>(this TXaml view, string xaml)
 		{
 			XamlLoader.Load(view, xaml);
 			return view;
 		}
 
-		[RequiresUnreferencedCode(TrimmerConstants.XamlRuntimeParsingNotSupportedWarning)]
 		internal static TXaml LoadFromXaml<TXaml>(this TXaml view, string xaml, Assembly rootAssembly)
 		{
 			XamlLoader.Load(view, xaml, rootAssembly);

--- a/src/Controls/src/Xaml/XamlLoader.cs
+++ b/src/Controls/src/Xaml/XamlLoader.cs
@@ -29,6 +29,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -38,6 +39,10 @@ using Microsoft.Maui.Controls.Xaml.Diagnostics;
 
 namespace Microsoft.Maui.Controls.Xaml
 {
+	[RequiresUnreferencedCode(TrimmerConstants.XamlRuntimeParsingNotSupportedWarning)]
+#if !NETSTANDARD
+	[RequiresDynamicCode(TrimmerConstants.XamlRuntimeParsingNotSupportedWarning)]
+#endif
 	static partial class XamlLoader
 	{
 		public static void Load(object view, Type callingType)

--- a/src/Controls/src/Xaml/XamlParser.cs
+++ b/src/Controls/src/Xaml/XamlParser.cs
@@ -357,6 +357,10 @@ namespace Microsoft.Maui.Controls.Xaml
 			}
 		}
 
+		[RequiresUnreferencedCode(TrimmerConstants.XamlRuntimeParsingNotSupportedWarning)]
+#if !NETSTANDARD
+		[RequiresDynamicCode(TrimmerConstants.XamlRuntimeParsingNotSupportedWarning)]
+#endif
 		public static Type GetElementType(XmlType xmlType, IXmlLineInfo xmlInfo, Assembly currentAssembly,
 			out XamlParseException exception)
 		{
@@ -369,6 +373,9 @@ namespace Microsoft.Maui.Controls.Xaml
 		}
 
 		[RequiresUnreferencedCode(TrimmerConstants.XamlRuntimeParsingNotSupportedWarning)]
+#if !NETSTANDARD
+		[RequiresDynamicCode(TrimmerConstants.XamlRuntimeParsingNotSupportedWarning)]
+#endif
 		private static Type GetElementTypeCore(XmlType xmlType, IXmlLineInfo xmlInfo, Assembly currentAssembly,
 			out XamlParseException exception)
 		{

--- a/src/Controls/src/Xaml/XamlServiceProvider.cs
+++ b/src/Controls/src/Xaml/XamlServiceProvider.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Xml;
 using Microsoft.Maui.Controls.Internals;
@@ -13,6 +14,10 @@ namespace Microsoft.Maui.Controls.Xaml.Internals
 
 		static IValueConverterProvider defaultValueConverterProvider = new ValueConverterProvider();
 
+		[RequiresUnreferencedCode(TrimmerConstants.XamlRuntimeParsingNotSupportedWarning)]
+#if !NETSTANDARD
+		[RequiresDynamicCode(TrimmerConstants.XamlRuntimeParsingNotSupportedWarning)]
+#endif
 		internal XamlServiceProvider(INode node, HydrationContext context)
 		{
 			if (context != null && node != null && node.Parent != null && context.Values.TryGetValue(node.Parent, out object targetObject))
@@ -181,6 +186,10 @@ namespace Microsoft.Maui.Controls.Xaml.Internals
 		readonly GetTypeFromXmlName getTypeFromXmlName;
 		readonly IXmlNamespaceResolver namespaceResolver;
 
+		[RequiresUnreferencedCode(TrimmerConstants.XamlRuntimeParsingNotSupportedWarning)]
+#if !NETSTANDARD
+		[RequiresDynamicCode(TrimmerConstants.XamlRuntimeParsingNotSupportedWarning)]
+#endif
 		public XamlTypeResolver(IXmlNamespaceResolver namespaceResolver, Assembly currentAssembly)
 			: this(namespaceResolver, XamlParser.GetElementType, currentAssembly)
 		{

--- a/src/Core/src/RuntimeFeature.cs
+++ b/src/Core/src/RuntimeFeature.cs
@@ -19,7 +19,6 @@ namespace Microsoft.Maui
 		private const bool IsShellSearchResultsRendererDisplayMemberNameSupportedByDefault = true;
 		private const bool IsQueryPropertyAttributeSupportedByDefault = true;
 		private const bool IsImplicitCastOperatorsUsageViaReflectionSupportedByDefault = true;
-		private const bool IsStringBasedBindingSupportedByDefault = true;
 
 #pragma warning disable IL4000 // Return value does not match FeatureGuardAttribute 'System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute'. 
 #if !NETSTANDARD
@@ -72,15 +71,6 @@ namespace Microsoft.Maui
 			AppContext.TryGetSwitch("Microsoft.Maui.RuntimeFeature.IsImplicitCastOperatorsUsageViaReflectionSupported", out bool isSupported)
 				? isSupported
 				: IsImplicitCastOperatorsUsageViaReflectionSupportedByDefault;
-
-#if !NETSTANDARD
-		[FeatureSwitchDefinition("Microsoft.Maui.RuntimeFeature.AreStringBasedBindingSupported")]
-		[FeatureGuard(typeof(RequiresUnreferencedCodeAttribute))]
-#endif
-		internal static bool AreNonCompiledBindingsInXamlSupported =>
-			AppContext.TryGetSwitch("Microsoft.Maui.RuntimeFeature.AreNonCompiledBindingsInXamlSupported", out bool isSupported)
-				? isSupported
-				: IsStringBasedBindingSupportedByDefault;
 #pragma warning restore IL4000
 	}
 }

--- a/src/Core/src/RuntimeFeature.cs
+++ b/src/Core/src/RuntimeFeature.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Maui
 		private const bool IsShellSearchResultsRendererDisplayMemberNameSupportedByDefault = true;
 		private const bool IsQueryPropertyAttributeSupportedByDefault = true;
 		private const bool IsImplicitCastOperatorsUsageViaReflectionSupportedByDefault = true;
+		private const bool IsStringBasedBindingSupportedByDefault = true;
 
 #pragma warning disable IL4000 // Return value does not match FeatureGuardAttribute 'System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute'. 
 #if !NETSTANDARD
@@ -71,6 +72,15 @@ namespace Microsoft.Maui
 			AppContext.TryGetSwitch("Microsoft.Maui.RuntimeFeature.IsImplicitCastOperatorsUsageViaReflectionSupported", out bool isSupported)
 				? isSupported
 				: IsImplicitCastOperatorsUsageViaReflectionSupportedByDefault;
+
+#if !NETSTANDARD
+		[FeatureSwitchDefinition("Microsoft.Maui.RuntimeFeature.AreStringBasedBindingSupported")]
+		[FeatureGuard(typeof(RequiresUnreferencedCodeAttribute))]
+#endif
+		internal static bool AreNonCompiledBindingsInXamlSupported =>
+			AppContext.TryGetSwitch("Microsoft.Maui.RuntimeFeature.AreNonCompiledBindingsInXamlSupported", out bool isSupported)
+				? isSupported
+				: IsStringBasedBindingSupportedByDefault;
 #pragma warning restore IL4000
 	}
 }

--- a/src/Core/src/RuntimeFeature.cs
+++ b/src/Core/src/RuntimeFeature.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Maui
 #if !NETSTANDARD
 		[FeatureSwitchDefinition("Microsoft.Maui.RuntimeFeature.IsXamlRuntimeParsingSupported")]
 		[FeatureGuard(typeof(RequiresUnreferencedCodeAttribute))]
+		[FeatureGuard(typeof(RequiresDynamicCodeAttribute))]
 #endif
 		internal static bool IsXamlRuntimeParsingSupported
 			=> AppContext.TryGetSwitch("Microsoft.Maui.RuntimeFeature.IsXamlRuntimeParsingSupported", out bool isSupported)


### PR DESCRIPTION
### Description of Change

This PR enables analzyers in Controls.Xaml.csproj.

Almost all XAML runtime parsing code is marked with RUC and RDC. The `TryGetPropertyName` method was moved outside of `ApplyPropertiesVisitor` so that it can be called without producing a warning.

~I introduced a new feature switch `AreNonCompiledBindingsInXamlSupported` and I'm thinking if it is the right way to go about it. I'm not very happy that it is necessary in `BindingExtension.cs` and I'm thinking if maybe we could transform `BindingExtension` into `TypedBindingExtension` in XamlC to split those two codepaths. This is the main reason why I'm opening this PR as a Draft for now.~ - EDIT: the feature switch wasn't needed after all

/cc @StephaneDelcroix 

### Issues Fixed

Contributes to https://github.com/dotnet/maui/issues/18658