### PR TITLE
[controls] fix leak in ImageSource, caused by Task that never completes

### DIFF
--- a/src/Controls/src/Core/ImageSource.cs
+++ b/src/Controls/src/Core/ImageSource.cs
@@ -52,16 +52,14 @@ namespace Microsoft.Maui.Controls
 			if (!IsLoading)
 				return Task.FromResult(false);
 
-			var tcs = new TaskCompletionSource<bool>();
-			TaskCompletionSource<bool> original = Interlocked.CompareExchange(ref _completionSource, tcs, null);
-			if (original == null)
+			TaskCompletionSource<bool> original = Interlocked.CompareExchange(ref _completionSource, new TaskCompletionSource<bool>(), null);
+			if (original is null)
 			{
 				_cancellationTokenSource.Cancel();
+				return Task.FromResult(false);
 			}
-			else
-				tcs = original;
 
-			return tcs.Task;
+			return original.Task;
 		}
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/ImageSource.xml" path="//Member[@MemberName='FromFile']/Docs/*" />

--- a/src/Controls/tests/Core.UnitTests/ImageSourceTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ImageSourceTests.cs
@@ -156,5 +156,16 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			var image = new Image { Source = path };
 			Assert.IsType<FileImageSource>(image.Source);
 		}
+
+		[Fact]
+		public async Task CancelCompletes()
+		{
+			var imageSource = new StreamImageSource
+			{
+				Stream = _ => Task.FromResult<Stream>(new MemoryStream())
+			};
+			await ((IStreamImageSource)imageSource).GetStreamAsync();
+			await imageSource.Cancel(); // This should complete!
+		}
 	}
 }


### PR DESCRIPTION
Context: https://github.com/AdamEssenmacher/MemoryToolkit.Maui/tree/main/samples

Testing the above sample, I saw some odd results in a `.gcdump` related to `UriImageSource` inside a `CollectionView`:

![image](https://github.com/dotnet/maui/assets/840039/4ce0cefe-c0d9-4ee1-8b05-826fd395637e)

It appears that we `await` a `Task` that never completes, which is:

https://github.com/dotnet/maui/blob/8e4450cbc14932a6c74aeb8b7bfee9c94eca18b0/src/Controls/src/Core/ImageElement.cs#L129

The `Task` also holds onto the `ImageSource` and whatever memory it happened to use. That would be ok if the `Task` completed.

I could reproduce the problem in a test:

    [Fact]
    public async Task CancelCompletes()
    {
        var imageSource = new StreamImageSource
        {
            Stream = _ => Task.FromResult<Stream>(new MemoryStream())
        };
        await ((IStreamImageSource)imageSource).GetStreamAsync();
        await imageSource.Cancel(); // This should complete!
    }

This non-completing `Task` can occur when changing `Image.Source`, which would certainly be bad while scrolling a `CollectionView`!

To fix, I refactored the code slightly and had the problematic case return:

    return Task.FromResult(false);