### PR TITLE
Go back to ignoring ExpectingPageNotToBreak

### DIFF
--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue7534.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue7534.cs
@@ -49,6 +49,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 
 #if UITEST && __ANDROID__
 		[Test]
+		[Compatibility.UITests.FailsOnMauiAndroid]
 		public void ExpectingPageNotToBreak()
 		{
 			RunningApp.Screenshot("Test passed, label is showing as it should!");


### PR DESCRIPTION
### Description of Change

This test was added back into the pool as part of this PR 
https://github.com/dotnet/maui/pull/20531

But it was still crashing at that point. Xamarin.UITest just wasn't reporting the crash as a failure unfortunately 
