### PR TITLE
[iOS] Add UITest for #21806 

### DIFF
--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issue21630.xaml
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issue21630.xaml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Maui.Controls.Sample.Issues.Issue21630"
+             Title="Issue21630">
+
+    <NavigationPage.TitleView>
+        <HorizontalStackLayout Spacing="40">
+            <Entry BackgroundColor="Yellow" Text="Input Entry" AutomationId="NavBarEntry"/>
+        </HorizontalStackLayout>
+    </NavigationPage.TitleView>
+
+    <CollectionView
+        SelectionMode="None"
+        BackgroundColor="white"
+        Margin="10.0">
+
+        <CollectionView.ItemsSource>
+            <x:Array Type="{x:Type x:String}">
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+            </x:Array>
+        </CollectionView.ItemsSource>
+
+        <CollectionView.ItemsLayout>
+            <LinearItemsLayout
+                Orientation="Vertical"
+                ItemSpacing="15"/>
+        </CollectionView.ItemsLayout>
+
+        <CollectionView.Header>
+            <VerticalStackLayout Spacing="20" Padding="10,20">
+                <Entry BackgroundColor="Yellow" Text="Input Entry" AutomationId="HeaderEntry"/>
+            </VerticalStackLayout>
+        </CollectionView.Header>
+
+        <CollectionView.Footer>
+            <ContentView HeightRequest="100"></ContentView>
+        </CollectionView.Footer>
+
+        <CollectionView.ItemTemplate>
+            <DataTemplate x:DataType="x:String">
+                <Border
+                    StrokeThickness="0.6">
+                    <Label
+                        Text="{Binding}"
+                        FontSize="20"/>
+                </Border>
+            </DataTemplate>
+        </CollectionView.ItemTemplate>
+
+    </CollectionView>
+</ContentPage>

--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issue21630.xaml
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issue21630.xaml
@@ -6,7 +6,7 @@
 
     <NavigationPage.TitleView>
         <HorizontalStackLayout Spacing="40">
-            <Entry BackgroundColor="Yellow" Text="Input Entry" AutomationId="NavBarEntry"/>
+            <Entry BackgroundColor="Yellow" Text="Input Entry" AutomationId="NavBarEntry" x:Name="NavBarEntry"/>
         </HorizontalStackLayout>
     </NavigationPage.TitleView>
 
@@ -58,6 +58,7 @@
         <CollectionView.Header>
             <VerticalStackLayout Spacing="20" Padding="10,20">
                 <Entry BackgroundColor="Yellow" Text="Input Entry" AutomationId="HeaderEntry"/>
+                <Button Text="Focus NavBarEntry" Clicked="FocusNavBarEntry" AutomationId="FocusButton"/>
             </VerticalStackLayout>
         </CollectionView.Header>
 

--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issue21630.xaml
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issue21630.xaml
@@ -4,78 +4,9 @@
              x:Class="Maui.Controls.Sample.Issues.Issue21630"
              Title="Issue21630">
 
-    <NavigationPage.TitleView>
-        <HorizontalStackLayout Spacing="40">
-            <Entry BackgroundColor="Yellow" Text="Input Entry" AutomationId="NavBarEntry" x:Name="NavBarEntry"/>
-        </HorizontalStackLayout>
-    </NavigationPage.TitleView>
+    <VerticalStackLayout>
+        <Button Text="Swap Main Page for NavigationPage" AutomationId="SwapNavigationPage" Clicked="SwapMainPageNav"/>
+        <Button Text="Swap Main Page for Shell Page" AutomationId="SwapShellPage" Clicked="SwapMainPageShell"/>
+    </VerticalStackLayout>
 
-    <CollectionView
-        SelectionMode="None"
-        BackgroundColor="white"
-        Margin="10.0">
-
-        <CollectionView.ItemsSource>
-            <x:Array Type="{x:Type x:String}">
-                <x:String>asdf</x:String>
-                <x:String>asdf</x:String>
-                <x:String>asdf</x:String>
-                <x:String>asdf</x:String>
-                <x:String>asdf</x:String>
-                <x:String>asdf</x:String>
-                <x:String>asdf</x:String>
-                <x:String>asdf</x:String>
-                <x:String>asdf</x:String>
-                <x:String>asdf</x:String>
-                <x:String>asdf</x:String>
-                <x:String>asdf</x:String>
-                <x:String>asdf</x:String>
-                <x:String>asdf</x:String>
-                <x:String>asdf</x:String>
-                <x:String>asdf</x:String>
-                <x:String>asdf</x:String>
-                <x:String>asdf</x:String>
-                <x:String>asdf</x:String>
-                <x:String>asdf</x:String>
-                <x:String>asdf</x:String>
-                <x:String>asdf</x:String>
-                <x:String>asdf</x:String>
-                <x:String>asdf</x:String>
-                <x:String>asdf</x:String>
-                <x:String>asdf</x:String>
-                <x:String>asdf</x:String>
-                <x:String>asdf</x:String>
-                <x:String>asdf</x:String>
-            </x:Array>
-        </CollectionView.ItemsSource>
-
-        <CollectionView.ItemsLayout>
-            <LinearItemsLayout
-                Orientation="Vertical"
-                ItemSpacing="15"/>
-        </CollectionView.ItemsLayout>
-
-        <CollectionView.Header>
-            <VerticalStackLayout Spacing="20" Padding="10,20">
-                <Entry BackgroundColor="Yellow" Text="Input Entry" AutomationId="HeaderEntry"/>
-                <Button Text="Focus NavBarEntry" Clicked="FocusNavBarEntry" AutomationId="FocusButton"/>
-            </VerticalStackLayout>
-        </CollectionView.Header>
-
-        <CollectionView.Footer>
-            <ContentView HeightRequest="100"></ContentView>
-        </CollectionView.Footer>
-
-        <CollectionView.ItemTemplate>
-            <DataTemplate x:DataType="x:String">
-                <Border
-                    StrokeThickness="0.6">
-                    <Label
-                        Text="{Binding}"
-                        FontSize="20"/>
-                </Border>
-            </DataTemplate>
-        </CollectionView.ItemTemplate>
-
-    </CollectionView>
 </ContentPage>

--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issue21630.xaml.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issue21630.xaml.cs
@@ -1,0 +1,14 @@
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+
+namespace Maui.Controls.Sample.Issues;
+
+[XamlCompilation(XamlCompilationOptions.Compile)]
+[Issue(IssueTracker.Github, 21630, "Entries in NavBar don't trigger keyboard scroll", PlatformAffected.iOS)]
+public partial class Issue21630 : ContentPage
+{
+	public Issue21630()
+	{
+		InitializeComponent();
+	}
+}

--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issue21630.xaml.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issue21630.xaml.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Xaml;
 
@@ -10,5 +11,10 @@ public partial class Issue21630 : ContentPage
 	public Issue21630()
 	{
 		InitializeComponent();
+	}
+
+	void FocusNavBarEntry (object sender, EventArgs e)
+	{
+		NavBarEntry.Focus();
 	}
 }

--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issue21630.xaml.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issue21630.xaml.cs
@@ -16,6 +16,11 @@ public partial class Issue21630 : ContentPage
 	public Issue21630()
 	{
 		InitializeComponent();
+		Loaded += OnLoaded;
+	}
+
+	private void OnLoaded(object sender, EventArgs e)
+	{
 		_page = Application.Current.MainPage;
 		_modalStack = Navigation.ModalStack.ToList();
 	}
@@ -27,6 +32,6 @@ public partial class Issue21630 : ContentPage
 
 	void SwapMainPageShell (object sender, EventArgs e)
 	{
-		Application.Current.MainPage = new Issue21630_shellPage(_page);
+		Application.Current.MainPage = new Issue21630_shellPage(_page, _modalStack);
 	}
 }

--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issue21630.xaml.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issue21630.xaml.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Xaml;
 
@@ -8,13 +10,23 @@ namespace Maui.Controls.Sample.Issues;
 [Issue(IssueTracker.Github, 21630, "Entries in NavBar don't trigger keyboard scroll", PlatformAffected.iOS)]
 public partial class Issue21630 : ContentPage
 {
+	Page _page;
+	List<Page> _modalStack;
+
 	public Issue21630()
 	{
 		InitializeComponent();
+		_page = Application.Current.MainPage;
+		_modalStack = Navigation.ModalStack.ToList();
 	}
 
-	void FocusNavBarEntry (object sender, EventArgs e)
+	void SwapMainPageNav (object sender, EventArgs e)
 	{
-		NavBarEntry.Focus();
+		Application.Current.MainPage = new NavigationPage(new Issue21630_navPage(_page, _modalStack));
+	}
+
+	void SwapMainPageShell (object sender, EventArgs e)
+	{
+		Application.Current.MainPage = new Issue21630_shellPage(_page);
 	}
 }

--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issue21630_navPage.xaml
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issue21630_navPage.xaml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Maui.Controls.Sample.Issues.Issue21630_navPage"
+             Title="Issue21630_navPage"
+             Shell.BackgroundColor="Green">
+
+    <NavigationPage.TitleView>
+        <HorizontalStackLayout Spacing="40">
+            <Entry BackgroundColor="Yellow" Text="Input Entry" AutomationId="NavBarEntryNavigationPage" x:Name="NavBarEntryNav"/>
+        </HorizontalStackLayout>
+    </NavigationPage.TitleView>
+
+    <Shell.TitleView>
+        <HorizontalStackLayout Spacing="40">
+            <Entry BackgroundColor="Yellow" Text="Input Entry" AutomationId="NavBarEntryShellPage" x:Name="NavBarEntryShell"/>
+        </HorizontalStackLayout>
+    </Shell.TitleView>
+
+    <CollectionView
+        SelectionMode="None"
+        BackgroundColor="white"
+        Margin="10.0">
+
+        <CollectionView.ItemsSource>
+            <x:Array Type="{x:Type x:String}">
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+                <x:String>asdf</x:String>
+            </x:Array>
+        </CollectionView.ItemsSource>
+
+        <CollectionView.ItemsLayout>
+            <LinearItemsLayout
+                Orientation="Vertical"
+                ItemSpacing="15"/>
+        </CollectionView.ItemsLayout>
+
+        <CollectionView.Header>
+            <VerticalStackLayout Spacing="20" Padding="10,20">
+                <Entry BackgroundColor="Yellow" Text="Input Entry" AutomationId="HeaderEntry"/>
+                <Button Text="Focus NavBarEntryNav" Clicked="FocusNavBarEntryNav" AutomationId="FocusButtonNavigationPage"/>
+                <Button Text="Focus NavBarEntryShell" Clicked="FocusNavBarEntryShell" AutomationId="FocusButtonShellPage"/>
+                <Button Text="Restore MainPage" Clicked="RestoreMainPage" AutomationId="RestoreMainPageButton"/>
+            </VerticalStackLayout>
+        </CollectionView.Header>
+
+        <CollectionView.Footer>
+            <ContentView HeightRequest="100"></ContentView>
+        </CollectionView.Footer>
+
+        <CollectionView.ItemTemplate>
+            <DataTemplate x:DataType="x:String">
+                <Border
+                    StrokeThickness="0.6">
+                    <Label
+                        Text="{Binding}"
+                        FontSize="20"/>
+                </Border>
+            </DataTemplate>
+        </CollectionView.ItemTemplate>
+
+    </CollectionView>
+</ContentPage>

--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issue21630_navPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issue21630_navPage.xaml.cs
@@ -13,7 +13,9 @@ public partial class Issue21630_navPage : ContentPage
 	public Issue21630_navPage()
 	{
 		InitializeComponent();
-		_page = Shell.Current.BindingContext as Page;
+		var bc = (ValueTuple<Page, List<Page>>)Shell.Current.BindingContext;
+		_page = bc.Item1;
+		_modalStack = bc.Item2;
 	}
 
 	public Issue21630_navPage(Page page, List<Page> modalStack)

--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issue21630_navPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issue21630_navPage.xaml.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+
+namespace Maui.Controls.Sample.Issues;
+
+public partial class Issue21630_navPage : ContentPage
+{
+	Page _page;
+	List<Page> _modalStack;
+
+	public Issue21630_navPage()
+	{
+		InitializeComponent();
+		_page = Shell.Current.BindingContext as Page;
+	}
+
+	public Issue21630_navPage(Page page, List<Page> modalStack)
+	{
+		InitializeComponent();
+		_page = page;
+		_modalStack = modalStack;
+	}
+
+	void FocusNavBarEntryNav (object sender, EventArgs e)
+	{
+		NavBarEntryNav.Focus();
+	}
+
+	void FocusNavBarEntryShell (object sender, EventArgs e)
+	{
+		NavBarEntryShell.Focus();
+	}
+
+	async void RestoreMainPage (object sender, EventArgs e)
+	{
+		Application.Current.MainPage = _page;
+		await Task.Yield();
+
+		foreach(var page in _modalStack)
+		{
+			await _page.Navigation.PushModalAsync(page);
+		}
+	}
+}

--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issue21630_shellPage.xaml
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issue21630_shellPage.xaml
@@ -1,0 +1,12 @@
+<Shell
+    x:Class="Maui.Controls.Sample.Issues.Issue21630_shellPage"
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:local="clr-namespace:Maui.Controls.Sample.Issues"
+    Shell.FlyoutBehavior="Disabled">
+
+    <ShellContent
+        Title="Home"
+        ContentTemplate="{DataTemplate local:Issue21630_navPage}"
+        Route="Issue21630_navPage" />
+</Shell>

--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issue21630_shellPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issue21630_shellPage.xaml.cs
@@ -1,0 +1,13 @@
+using Microsoft.Maui.Controls;
+
+namespace Maui.Controls.Sample.Issues
+{
+	public partial class Issue21630_shellPage : Shell
+	{
+		public Issue21630_shellPage(Page page)
+		{
+			InitializeComponent();
+			BindingContext = page;
+		}
+	}
+}

--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issue21630_shellPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issue21630_shellPage.xaml.cs
@@ -1,13 +1,14 @@
 using Microsoft.Maui.Controls;
+using System.Collections.Generic;
 
 namespace Maui.Controls.Sample.Issues
 {
 	public partial class Issue21630_shellPage : Shell
 	{
-		public Issue21630_shellPage(Page page)
+		public Issue21630_shellPage(Page page, List<Page> modalStack)
 		{
 			InitializeComponent();
-			BindingContext = page;
+			BindingContext = (page, modalStack);
 		}
 	}
 }

--- a/src/Controls/tests/UITests/Tests/Issues/Issue21630.cs
+++ b/src/Controls/tests/UITests/Tests/Issues/Issue21630.cs
@@ -15,24 +15,44 @@ public class Issue21630 : _IssuesUITest
     string NavBarEntry => "NavBarEntry";
     string HeaderEntry => "HeaderEntry";
     string FocusButton => "FocusButton";
+    string RestoreButton => "RestoreMainPageButton";
 
-    [Test]
-	public void NavBarEntryDoesNotTriggerKeyboardScroll()
+	[TestCase("SwapNavigationPage")]
+	[TestCase("SwapShellPage")]
+	public void NavBarEntryDoesNotTriggerKeyboardScroll(string scenario)
 	{
-        var navBarEntry = App.WaitForElement(NavBarEntry);
-		var navBarLocation = navBarEntry.GetRect();
-		var headerEntry = App.WaitForElement(HeaderEntry);
-		var headerLocation = headerEntry.GetRect();
+		try
+		{
+			var scenarioSuffix = scenario == "SwapNavigationPage" ? "NavigationPage" : "ShellPage";
 
-        App.Click(FocusButton);
+			App.WaitForElement(scenario);
+			App.Click(scenario);
 
-        var newNavBarEntry = App.WaitForElement(NavBarEntry);
-		var newNavBarEntryLocation = newNavBarEntry.GetRect();
-        Assert.AreEqual(navBarLocation, newNavBarEntryLocation);
+			var navBarEntry = App.WaitForElement(NavBarEntry + scenarioSuffix);
+			var navBarLocation = navBarEntry.GetRect();
+			var headerEntry = App.WaitForElement(HeaderEntry);
+			var headerLocation = headerEntry.GetRect();
 
-        var newHeaderEntry = App.WaitForElement(HeaderEntry);
-		var newHeaderLocation = newHeaderEntry.GetRect();
+			App.Click(FocusButton + scenarioSuffix);
 
-        Assert.AreEqual(headerLocation, newHeaderLocation);
+			var newNavBarEntry = App.WaitForElement(NavBarEntry + scenarioSuffix);
+			var newNavBarEntryLocation = newNavBarEntry.GetRect();
+			Assert.AreEqual(navBarLocation, newNavBarEntryLocation);
+
+			var newHeaderEntry = App.WaitForElement(HeaderEntry);
+			var newHeaderLocation = newHeaderEntry.GetRect();
+
+			Assert.AreEqual(headerLocation, newHeaderLocation);
+
+			App.WaitForElement(RestoreButton);
+			App.Click(RestoreButton);
+		}
+		catch
+		{
+			// Just in case these tests leave the app in an unreliable state
+			App.ResetApp();
+			FixtureSetup();
+			throw;
+		}
 	}
 }

--- a/src/Controls/tests/UITests/Tests/Issues/Issue21630.cs
+++ b/src/Controls/tests/UITests/Tests/Issues/Issue21630.cs
@@ -14,6 +14,7 @@ public class Issue21630 : _IssuesUITest
 
     string NavBarEntry => "NavBarEntry";
     string HeaderEntry => "HeaderEntry";
+    string FocusButton => "FocusButton";
 
     [Test]
 	public void NavBarEntryDoesNotTriggerKeyboardScroll()
@@ -23,7 +24,7 @@ public class Issue21630 : _IssuesUITest
 		var headerEntry = App.WaitForElement(HeaderEntry);
 		var headerLocation = headerEntry.GetRect();
 
-        App.Click(NavBarEntry);
+        App.Click(FocusButton);
 
         var newNavBarEntry = App.WaitForElement(NavBarEntry);
 		var newNavBarEntryLocation = newNavBarEntry.GetRect();

--- a/src/Controls/tests/UITests/Tests/Issues/Issue21630.cs
+++ b/src/Controls/tests/UITests/Tests/Issues/Issue21630.cs
@@ -1,0 +1,37 @@
+﻿using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.AppiumTests.Issues;
+
+public class Issue21630 : _IssuesUITest
+{
+	public override string Issue => "Entries in NavBar don't trigger keyboard scroll";
+
+	public Issue21630(TestDevice device)
+		: base(device)
+	{ }
+
+    string NavBarEntry => "NavBarEntry";
+    string HeaderEntry => "HeaderEntry";
+
+    [Test]
+	public void NavBarEntryDoesNotTriggerKeyboardScroll()
+	{
+        var navBarEntry = App.WaitForElement(NavBarEntry);
+		var navBarLocation = navBarEntry.GetRect();
+		var headerEntry = App.WaitForElement(HeaderEntry);
+		var headerLocation = headerEntry.GetRect();
+
+        App.Click(NavBarEntry);
+
+        var newNavBarEntry = App.WaitForElement(NavBarEntry);
+		var newNavBarEntryLocation = newNavBarEntry.GetRect();
+        Assert.AreEqual(navBarLocation, newNavBarEntryLocation);
+
+        var newHeaderEntry = App.WaitForElement(HeaderEntry);
+		var newHeaderLocation = newHeaderEntry.GetRect();
+
+        Assert.AreEqual(headerLocation, newHeaderLocation);
+	}
+}

--- a/src/Core/src/Platform/iOS/KeyboardAutoManagerScroll.cs
+++ b/src/Core/src/Platform/iOS/KeyboardAutoManagerScroll.cs
@@ -299,7 +299,8 @@ public static class KeyboardAutoManagerScroll
 	internal static void AdjustPosition()
 	{
 		if (ContainerView is null
-			|| (View is not UITextField && View is not UITextView))
+			|| (View is not UITextField && View is not UITextView)
+			|| !View.IsDescendantOfView(ContainerView))
 		{
 			IsKeyboardAutoScrollHandling = false;
 			return;

--- a/src/Core/src/Platform/iOS/KeyboardAutoManagerScroll.cs
+++ b/src/Core/src/Platform/iOS/KeyboardAutoManagerScroll.cs
@@ -299,8 +299,7 @@ public static class KeyboardAutoManagerScroll
 	internal static void AdjustPosition()
 	{
 		if (ContainerView is null
-			|| (View is not UITextField && View is not UITextView)
-			|| !View.IsDescendantOfView(ContainerView))
+			|| (View is not UITextField && View is not UITextView))
 		{
 			IsKeyboardAutoScrollHandling = false;
 			return;


### PR DESCRIPTION
### Description of Change

<!-- Enter description of the fix in this section -->
This PR adds a UITest for the fix in https://github.com/dotnet/maui/pull/21806 where the entry in a NavigationBar was triggering the Keyboard Scrolling on iOS.

Side note: the change of `!View.IsDescendantOfView(ContainerView)` is also in this PR: https://github.com/dotnet/maui/pull/21753 but needed for the UITest. Sorry for any confusion!

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
