### PR TITLE
[WinUI] Cache gesture event subscriptions

### DIFF
--- a/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
@@ -23,6 +23,13 @@ namespace Microsoft.Maui.Controls.Platform
 		FrameworkElement? _control;
 		VisualElement? _element;
 
+		bool _areContainerDragEventsSubscribed;
+		bool _areContainerDropEventsSubscribed;
+		bool _areContainerPgrPointerEventsSubscribed;
+		bool _areContainerManipulationAndPointerEventsSubscribed;
+		bool _areContainerTapAndRightTabEventSubscribed;
+		bool _isContainerDoubleTapEventSubscribed;
+
 		bool _isDisposed;
 		bool _isPanning;
 		bool _isSwiping;
@@ -310,24 +317,61 @@ namespace Microsoft.Maui.Controls.Platform
 		{
 			if (_container != null)
 			{
-				_container.DragStarting -= HandleDragStarting;
-				_container.DropCompleted -= HandleDropCompleted;
-				_container.DragOver -= HandleDragOver;
-				_container.Drop -= HandleDrop;
-				_container.Tapped -= OnTap;
-				_container.DoubleTapped -= OnTap;
-				_container.ManipulationDelta -= OnManipulationDelta;
-				_container.ManipulationStarted -= OnManipulationStarted;
-				_container.ManipulationCompleted -= OnManipulationCompleted;
-				_container.PointerPressed -= OnPointerPressed;
-				_container.PointerExited -= OnPointerExited;
-				_container.PointerReleased -= OnPointerReleased;
-				_container.PointerCanceled -= OnPointerCanceled;
-				_container.PointerEntered -= OnPgrPointerEntered;
-				_container.PointerExited -= OnPgrPointerExited;
-				_container.PointerMoved -= OnPgrPointerMoved;
-				_container.PointerPressed -= OnPgrPointerPressed;
-				_container.PointerReleased -= OnPgrPointerReleased;
+				if (_areContainerDragEventsSubscribed)
+				{
+					_areContainerDragEventsSubscribed = false;
+
+					_container.DragStarting -= HandleDragStarting;
+					_container.DropCompleted -= HandleDropCompleted;
+				}
+
+				if (_areContainerDropEventsSubscribed)
+				{
+					_areContainerDropEventsSubscribed = false;
+
+					_container.DragOver -= HandleDragOver;
+					_container.Drop -= HandleDrop;
+					_container.DragLeave -= HandleDragLeave;
+				}
+
+				if (_areContainerTapAndRightTabEventSubscribed)
+				{
+					_areContainerTapAndRightTabEventSubscribed = false;
+
+					_container.Tapped -= OnTap;
+					_container.RightTapped -= OnTap;
+				}
+
+				if (_isContainerDoubleTapEventSubscribed)
+				{
+					_isContainerDoubleTapEventSubscribed = false;
+
+					_container.DoubleTapped -= OnTap;
+				}
+
+				if (_areContainerPgrPointerEventsSubscribed)
+				{
+					_areContainerPgrPointerEventsSubscribed = false;
+
+					_container.PointerEntered -= OnPgrPointerEntered;
+					_container.PointerExited -= OnPgrPointerExited;
+					_container.PointerMoved -= OnPgrPointerMoved;
+					_container.PointerPressed -= OnPgrPointerPressed;
+					_container.PointerReleased -= OnPgrPointerReleased;
+				}
+
+				if (_areContainerManipulationAndPointerEventsSubscribed)
+				{
+					_areContainerManipulationAndPointerEventsSubscribed = false;
+
+					_container.ManipulationDelta -= OnManipulationDelta;
+					_container.ManipulationStarted -= OnManipulationStarted;
+					_container.ManipulationCompleted -= OnManipulationCompleted;
+					_container.PointerPressed -= OnPointerPressed;
+					_container.PointerExited -= OnPointerExited;
+					_container.PointerReleased -= OnPointerReleased;
+					_container.PointerCanceled -= OnPointerCanceled;
+				}
 			}
 		}
 
@@ -688,12 +732,16 @@ namespace Microsoft.Maui.Controls.Platform
 
 			if (canDrag)
 			{
+				_areContainerDragEventsSubscribed = true;
+
 				_container.DragStarting += HandleDragStarting;
 				_container.DropCompleted += HandleDropCompleted;
 			}
 
 			if (allowDrop)
 			{
+				_areContainerDropEventsSubscribed = true;
+				
 				_container.DragOver += HandleDragOver;
 				_container.Drop += HandleDrop;
 				_container.DragLeave += HandleDragLeave;
@@ -718,6 +766,8 @@ namespace Microsoft.Maui.Controls.Platform
 			if (gestures.HasAnyGesturesFor<TapGestureRecognizer>(g => g.NumberOfTapsRequired == 1)
 				|| children?.GetChildGesturesFor<TapGestureRecognizer>(g => g.NumberOfTapsRequired == 1).Any() == true)
 			{
+				_areContainerTapAndRightTabEventSubscribed = true;
+				
 				_container.Tapped += OnTap;
 				_container.RightTapped += OnTap;
 			}
@@ -732,6 +782,8 @@ namespace Microsoft.Maui.Controls.Platform
 			if (gestures.HasAnyGesturesFor<TapGestureRecognizer>(g => g.NumberOfTapsRequired == 1 || g.NumberOfTapsRequired == 2)
 				|| children?.GetChildGesturesFor<TapGestureRecognizer>(g => g.NumberOfTapsRequired == 1 || g.NumberOfTapsRequired == 2).Any() == true)
 			{
+				_isContainerDoubleTapEventSubscribed = true;
+
 				_container.DoubleTapped += OnTap;
 			}
 			else
@@ -742,6 +794,7 @@ namespace Microsoft.Maui.Controls.Platform
 				}
 			}
 
+			_areContainerPgrPointerEventsSubscribed = true;
 			_container.PointerEntered += OnPgrPointerEntered;
 			_container.PointerExited += OnPgrPointerExited;
 			_container.PointerMoved += OnPgrPointerMoved;
@@ -769,6 +822,7 @@ namespace Microsoft.Maui.Controls.Platform
 				return;
 			}
 
+			_areContainerManipulationAndPointerEventsSubscribed = true;
 			_container.ManipulationMode = ManipulationModes.Scale | ManipulationModes.TranslateX | ManipulationModes.TranslateY;
 			_container.ManipulationDelta += OnManipulationDelta;
 			_container.ManipulationStarted += OnManipulationStarted;

--- a/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using Microsoft.Extensions.Logging;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Graphics;
-using Microsoft.UI.Input;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media.Imaging;

--- a/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
@@ -311,7 +311,7 @@ namespace Microsoft.Maui.Controls.Platform
 		{
 			if (_container != null)
 			{
-				if (_subscriptionFlags.HasFlag(SubscriptionFlags.ContainerDragEventsSubscribed))
+				if ((_subscriptionFlags & SubscriptionFlags.ContainerDragEventsSubscribed) != 0)
 				{
 					_subscriptionFlags &= ~SubscriptionFlags.ContainerDragEventsSubscribed;
 
@@ -319,7 +319,7 @@ namespace Microsoft.Maui.Controls.Platform
 					_container.DropCompleted -= HandleDropCompleted;
 				}
 
-				if (_subscriptionFlags.HasFlag(SubscriptionFlags.ContainerDropEventsSubscribed))
+				if ((_subscriptionFlags & SubscriptionFlags.ContainerDropEventsSubscribed) != 0)
 				{
 					_subscriptionFlags &= ~SubscriptionFlags.ContainerDropEventsSubscribed;
 
@@ -328,7 +328,7 @@ namespace Microsoft.Maui.Controls.Platform
 					_container.DragLeave -= HandleDragLeave;
 				}
 
-				if (_subscriptionFlags.HasFlag(SubscriptionFlags.ContainerTapAndRightTabEventSubscribed))
+				if ((_subscriptionFlags & SubscriptionFlags.ContainerTapAndRightTabEventSubscribed) != 0)
 				{
 					_subscriptionFlags &= ~SubscriptionFlags.ContainerTapAndRightTabEventSubscribed;
 
@@ -336,14 +336,14 @@ namespace Microsoft.Maui.Controls.Platform
 					_container.RightTapped -= OnTap;
 				}
 
-				if (_subscriptionFlags.HasFlag(SubscriptionFlags.ContainerDoubleTapEventSubscribed))
+				if ((_subscriptionFlags & SubscriptionFlags.ContainerDoubleTapEventSubscribed) != 0)
 				{
 					_subscriptionFlags &= ~SubscriptionFlags.ContainerDoubleTapEventSubscribed;
 
 					_container.DoubleTapped -= OnTap;
 				}
 
-				if (_subscriptionFlags.HasFlag(SubscriptionFlags.ContainerPgrPointerEventsSubscribed))
+				if ((_subscriptionFlags & SubscriptionFlags.ContainerPgrPointerEventsSubscribed) != 0)
 				{
 					_subscriptionFlags &= ~SubscriptionFlags.ContainerPgrPointerEventsSubscribed;
 
@@ -354,7 +354,7 @@ namespace Microsoft.Maui.Controls.Platform
 					_container.PointerReleased -= OnPgrPointerReleased;
 				}
 
-				if (_subscriptionFlags.HasFlag(SubscriptionFlags.ContainerManipulationAndPointerEventsSubscribed))
+				if ((_subscriptionFlags & SubscriptionFlags.ContainerManipulationAndPointerEventsSubscribed) != 0)
 				{
 					_subscriptionFlags &= ~SubscriptionFlags.ContainerManipulationAndPointerEventsSubscribed;
 


### PR DESCRIPTION
### Description of Change

Interops operations on Windows are costly. This PR avoids unsubscribing events that were not subscribed in the first place and thus improving performance.

#### Speedscope

* [Maui.Controls.Sample.Sandbox.exe_20240420_185714.speedscope.json](https://github.com/dotnet/maui/files/15049142/Maui.Controls.Sample.Sandbox.exe_20240420_185714.speedscope.json) - main
* [Maui.Controls.Sample.Sandbox.exe_20240420_185847.speedscope.json](https://github.com/dotnet/maui/files/15049143/Maui.Controls.Sample.Sandbox.exe_20240420_185847.speedscope.json) - PR

![image](https://github.com/dotnet/maui/assets/203266/c50336db-0f88-467a-b524-f5192a4f8e98)

-> 70% improvement for that particular method.

I test with my complex grid [sample](https://github.com/dotnet/maui/issues/21787#issuecomment-2051710728) basically.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Contributes to #21787

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
