### PR TITLE
[Core] Enforce CA1507 - use nameof() where possible

### DIFF
--- a/src/Core/src/.editorconfig
+++ b/src/Core/src/.editorconfig
@@ -7,6 +7,7 @@ dotnet_analyzer_diagnostic.category-Performance.severity = warning
 
 [*.cs]
 dotnet_diagnostic.CA1307.severity = error
+dotnet_diagnostic.CA1507.severity = error
 dotnet_diagnostic.CA1805.severity = error
 dotnet_diagnostic.CA1806.severity = error
 dotnet_diagnostic.CA1822.severity = error

--- a/src/Core/src/Platform/Android/MauiWebChromeClient.cs
+++ b/src/Core/src/Platform/Android/MauiWebChromeClient.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Maui.Platform
 
 		public MauiWebChromeClient(IWebViewHandler handler)
 		{
-			_ = handler ?? throw new ArgumentNullException("handler");
+			_ = handler ?? throw new ArgumentNullException(nameof(handler));
 
 			SetContext(handler);
 		}

--- a/src/Core/src/Platform/Android/MauiWebView.cs
+++ b/src/Core/src/Platform/Android/MauiWebView.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Maui.Platform
 
 		public MauiWebView(WebViewHandler handler, Context context) : base(context)
 		{
-			_handler = handler ?? throw new ArgumentNullException("handler");
+			_handler = handler ?? throw new ArgumentNullException(nameof(handler));
 		}
 
 		void IWebViewDelegate.LoadHtml(string? html, string? baseUrl)

--- a/src/Core/src/Platform/Windows/KeyboardExtensions.cs
+++ b/src/Core/src/Platform/Windows/KeyboardExtensions.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Maui.Platform
 		public static InputScope ToInputScope(this Keyboard self)
 		{
 			if (self == null)
-				throw new ArgumentNullException("self");
+				throw new ArgumentNullException(nameof(self));
 
 			var result = new InputScope();
 			var name = new InputScopeName();

--- a/src/Core/src/Platform/iOS/MauiWKWebView.cs
+++ b/src/Core/src/Platform/iOS/MauiWKWebView.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Maui.Platform
 		public MauiWKWebView(CGRect frame, WebViewHandler handler, WKWebViewConfiguration configuration)
 			: base(frame, configuration)
 		{
-			_ = handler ?? throw new ArgumentNullException("handler");
+			_ = handler ?? throw new ArgumentNullException(nameof(handler));
 			_handler = new WeakReference<WebViewHandler>(handler);
 
 			BackgroundColor = UIColor.Clear;

--- a/src/Core/src/Platform/iOS/MauiWebViewNavigationDelegate.cs
+++ b/src/Core/src/Platform/iOS/MauiWebViewNavigationDelegate.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Maui.Platform
 
 		public MauiWebViewNavigationDelegate(IWebViewHandler handler)
 		{
-			_ = handler ?? throw new ArgumentNullException("handler");
+			_ = handler ?? throw new ArgumentNullException(nameof(handler));
 			_handler = new WeakReference<IWebViewHandler>(handler);
 		}
 

--- a/src/Core/src/Platform/iOS/MauiWebViewUIDelegate.cs
+++ b/src/Core/src/Platform/iOS/MauiWebViewUIDelegate.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Maui.Platform
 
 		public MauiWebViewUIDelegate(IWebViewHandler handler)
 		{
-			_ = handler ?? throw new ArgumentNullException("handler");
+			_ = handler ?? throw new ArgumentNullException(nameof(handler));
 			_handler = new WeakReference<IWebViewHandler>(handler);
 		}
 

--- a/src/Core/src/Primitives/GridLength.cs
+++ b/src/Core/src/Primitives/GridLength.cs
@@ -47,9 +47,9 @@ namespace Microsoft.Maui
 		public GridLength(double value, GridUnitType type)
 		{
 			if (value < 0 || double.IsNaN(value))
-				throw new ArgumentException("value is less than 0 or is not a number", "value");
+				throw new ArgumentException("value is less than 0 or is not a number", nameof(value));
 			if ((int)type < (int)GridUnitType.Absolute || (int)type > (int)GridUnitType.Auto)
-				throw new ArgumentException("type is not a valid GridUnitType", "type");
+				throw new ArgumentException("type is not a valid GridUnitType", nameof(type));
 
 			Value = value;
 			GridUnitType = type;


### PR DESCRIPTION
Enforces [CA1507](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1507)

This will allow potential future bugs to be discovered at compile-time, rather than at runtime.

I used a roslyn refactoring to accomplish this, but I sanity checked all of the individual changes.