### PR TITLE
[net9.0] Fix apiscan version for net9

### DIFF
--- a/eng/pipelines/maui-release.yml
+++ b/eng/pipelines/maui-release.yml
@@ -162,5 +162,6 @@ extends:
             vmImage: ${{ parameters.VM_IMAGE_HOST.image }}
             os: ${{ parameters.VM_IMAGE_HOST.os }}     
             scanArtifacts: ['${{ parameters.PackPlatform.binariesArtifact }}']
+            softwareVersion: 9.0
 
         


### PR DESCRIPTION
### Description of Change

Since new API can be used, is better to pass the correct version for this branch. 