### PR TITLE
Changed order of calls to properly close MediaPicker Activity / ViewController and set the picker result

### DIFF
--- a/src/Essentials/src/MediaPicker/MediaPicker.ios.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.ios.cs
@@ -86,8 +86,8 @@ namespace Microsoft.Maui.Media
 			{
 				CompletedHandler = async info =>
 				{
-					GetFileResult(info, tcs);
 					await vc.DismissViewControllerAsync(true);
+					GetFileResult(info, tcs);
 				}
 			};
 


### PR DESCRIPTION
Fixes this issue https://github.com/Alex-Dobrynin/Xamarin.Controls.ImageCropper/issues/8

Shortly, at the moment of getting the result of mediapicker, the activity or viewcontroller remains opened. And if open another activity or viewcontroller right after the result of mediapicker you will not see any new activity/viewcontroller opened. So to fix this we need to change the order of calls: 

1. we need to close activity/viewcontroller
3. we need to set the result of mediapicker

Actual result: we need to put some Task.Delay after mediapicker result to be able open new activity/viewcontroller
Expected result: we able to open new activity/viewcontroller right after getting the picker result.

To reproduce it, you can try open new activity or viewcontroller from the topmost one (which is still mediapicker's activity/viewcontrolelr) right after the mediapicker result.

Affects only android/ios
