### PR TITLE
[ios/catalyst] fix memory leaks in ListView

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/ListViewRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/ListViewRenderer.cs
@@ -1,7 +1,6 @@
 #nullable disable
 using System;
 using System.ComponentModel;
-using System.Threading.Tasks;
 using Android.Content;
 using Android.Runtime;
 using Android.Views;
@@ -477,17 +476,19 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			}
 		}
 
-		async void UpdateIsSwipeToRefreshEnabled()
+		void UpdateIsSwipeToRefreshEnabled()
 		{
 			if (_refresh != null)
 			{
 				var isEnabled = Element.IsPullToRefreshEnabled && (Element as IListViewController).RefreshAllowed;
-				await Task.Yield();
-				// NOTE: only disable while NOT refreshing, otherwise Command bindings CanExecute behavior will effectively
-				// cancel refresh animation. If not possible right now we will be called by UpdateIsRefreshing().
-				// For details see https://github.com/xamarin/Xamarin.Forms/issues/8384
-				if (isEnabled || !_refresh.Refreshing)
-					_refresh.Enabled = isEnabled;
+				_refresh.Post(() =>
+				{
+					// NOTE: only disable while NOT refreshing, otherwise Command bindings CanExecute behavior will effectively
+					// cancel refresh animation. If not possible right now we will be called by UpdateIsRefreshing().
+					// For details see https://github.com/xamarin/Xamarin.Forms/issues/8384
+					if (isEnabled || !_refresh.Refreshing)
+						_refresh.Enabled = isEnabled;
+				});
 			}
 		}
 

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/ListViewRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/ListViewRenderer.cs
@@ -1,6 +1,7 @@
 #nullable disable
 using System;
 using System.ComponentModel;
+using System.Threading.Tasks;
 using Android.Content;
 using Android.Runtime;
 using Android.Views;
@@ -476,19 +477,17 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			}
 		}
 
-		void UpdateIsSwipeToRefreshEnabled()
+		async void UpdateIsSwipeToRefreshEnabled()
 		{
 			if (_refresh != null)
 			{
 				var isEnabled = Element.IsPullToRefreshEnabled && (Element as IListViewController).RefreshAllowed;
-				_refresh.Post(() =>
-				{
-					// NOTE: only disable while NOT refreshing, otherwise Command bindings CanExecute behavior will effectively
-					// cancel refresh animation. If not possible right now we will be called by UpdateIsRefreshing().
-					// For details see https://github.com/xamarin/Xamarin.Forms/issues/8384
-					if (isEnabled || !_refresh.Refreshing)
-						_refresh.Enabled = isEnabled;
-				});
+				await Task.Yield();
+				// NOTE: only disable while NOT refreshing, otherwise Command bindings CanExecute behavior will effectively
+				// cancel refresh animation. If not possible right now we will be called by UpdateIsRefreshing().
+				// For details see https://github.com/xamarin/Xamarin.Forms/issues/8384
+				if (isEnabled || !_refresh.Refreshing)
+					_refresh.Enabled = isEnabled;
 			}
 		}
 

--- a/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
+++ b/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
@@ -99,6 +99,10 @@ public class MemoryTests : ControlsHandlerTestBase
 		SetupBuilder();
 
 #if ANDROID
+		// TODO: fixing upstream at https://github.com/xamarin/xamarin-android/pull/8900
+		if (type == typeof(ListView))
+			return;
+
 		// NOTE: skip certain controls on older Android devices
 		if (type == typeof (DatePicker) && !OperatingSystem.IsAndroidVersionAtLeast(30))
 				return;

--- a/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
+++ b/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
@@ -50,6 +50,7 @@ public class MemoryTests : ControlsHandlerTestBase
 				handlers.AddHandler<SwipeView, SwipeViewHandler>();
 				handlers.AddHandler<Switch, SwitchHandler>();
 				handlers.AddHandler<TableView, TableViewRenderer>();
+				handlers.AddHandler<TextCell, TextCellRenderer>();
 				handlers.AddHandler<TimePicker, TimePickerHandler>();
 				handlers.AddHandler<Toolbar, ToolbarHandler>();
 				handlers.AddHandler<WebView, WebViewHandler>();
@@ -78,6 +79,7 @@ public class MemoryTests : ControlsHandlerTestBase
 	[InlineData(typeof(ImageButton))]
 	[InlineData(typeof(IndicatorView))]
 	[InlineData(typeof(Label))]
+	[InlineData(typeof(ListView))]
 	[InlineData(typeof(Picker))]
 	[InlineData(typeof(Polygon))]
 	[InlineData(typeof(Polyline))]
@@ -122,6 +124,16 @@ public class MemoryTests : ControlsHandlerTestBase
 			if (view is ContentView content)
 			{
 				content.Content = new Label();
+			}
+			else if (view is ListView listView)
+			{
+				listView.ItemTemplate = new DataTemplate(() =>
+				{
+					var cell = new TextCell();
+					cell.SetBinding(TextCell.TextProperty, ".");
+					return cell;
+				});
+				listView.ItemsSource = observable;
 			}
 			else if (view is ItemsView items)
 			{


### PR DESCRIPTION
Fixes: https://github.com/dotnet/maui/issues/20025

I could reproduce the leak here, pretty easily with changes to `MemoryTests`.

`ListView` has several cycles that prevent garbage collection from happening:

* `FormsUITableViewController` has `ListView _list`
  * `FormsUITableViewController` -> `ListView` -> `ListViewRenderer` -> `FormsUITableViewController`

* `ListViewDataSource` has `UITableView _uiTableView`
  * `ListViewDataSource` -> `UITableView` -> `ListViewDataSource`

* `ListViewDataSource` has `FormsUITableViewController _uiTableViewController`
  * `ListViewDataSource` -> `FormsUITableViewController` -> `UITableView` -> `ListViewDataSource`

* `ListViewDataSource` has `protected ListView List`
  * `ListViewDataSource` -> `ListView` -> `ListViewRenderer` -> `FormsUITableViewController` -> `UITableView` -> `ListViewDataSource`

I changed the above fields to all be `WeakReference<T>` and the leaks went away.