### PR TITLE
[Windows] Use correct build version check

### DIFF
--- a/src/Essentials/src/Connectivity/Connectivity.uwp.cs
+++ b/src/Essentials/src/Connectivity/Connectivity.uwp.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Maui.Networking
 		{
 			get
 			{
-				if (OperatingSystem.IsWindowsVersionAtLeast(11))
+				if (OperatingSystem.IsWindowsVersionAtLeast(10, 0, 21996, 0))
 				{
 					var profile = NetworkInformation.GetInternetConnectionProfile();
 					if (profile == null)

--- a/src/Essentials/src/Connectivity/Connectivity.uwp.cs
+++ b/src/Essentials/src/Connectivity/Connectivity.uwp.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Maui.Networking
 		{
 			get
 			{
-				if (OperatingSystem.IsWindowsVersionAtLeast(10, 0, 21996, 0))
+				if (OperatingSystem.IsWindowsVersionAtLeast(10, 0, 22000, 0))
 				{
 					var profile = NetworkInformation.GetInternetConnectionProfile();
 					if (profile == null)


### PR DESCRIPTION
### Description of Change

Windows 11 version isn't actually 11.*, it's 10.0.21996

### Issues Fixed

Fixes #21990