### PR TITLE
Fixed creation of the CustomTabsActivityManager

### DIFF
--- a/src/Essentials/src/WebAuthenticator/WebAuthenticator.android.cs
+++ b/src/Essentials/src/WebAuthenticator/WebAuthenticator.android.cs
@@ -93,7 +93,7 @@ namespace Microsoft.Maui.Authentication
 			var success = false;
 			var parentActivity = ActivityStateManager.Default.GetCurrentActivity(true);
 
-			var customTabsActivityManager = CustomTabsActivityManager.From(parentActivity);
+			var customTabsActivityManager = new CustomTabsActivityManager(parentActivity);
 			try
 			{
 				if (await BindServiceAsync(customTabsActivityManager))


### PR DESCRIPTION
### Description of Change

Fix to avoid using the `From` method to get the CustomTabsActivityManager manager. This method would store a reference to the activity from a static field, and this will be kept after activity is destroyed. As no extra logic is inside this method, I've changed it to direct new instance creation each time.

### Issues Fixed

Fixes #22017 
