### PR TITLE
[XC] Compile "standalone" bindings

### DIFF
--- a/src/Controls/tests/Xaml.UnitTests/BindingsCompiler.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/BindingsCompiler.xaml
@@ -23,6 +23,11 @@
 			<Label Text="{Binding StructModel.Model.Text, Mode=TwoWay}" x:Name="label10" />
             <Label Text="Text for label12" x:Name="label11" />
             <Label Text="{Binding Text, x:DataType=Label, Source={x:Reference label11}}" x:Name="label12" />
+
+			<Picker
+				ItemsSource="{Binding Items}"
+				ItemDisplayBinding="{Binding Title, x:DataType=local:MockItemViewModel}"
+				x:Name="picker0" />
 		</cmp:StackLayout>
 		<Label Text="{Binding Text}" x:Name="labelWithUncompiledBinding" />
 	</cmp:StackLayout>

--- a/src/Controls/tests/Xaml.UnitTests/BindingsCompiler.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/BindingsCompiler.xaml.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Core.UnitTests;
+using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Dispatching;
 using Microsoft.Maui.UnitTests;
 using NUnit.Framework;
@@ -109,6 +110,13 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 				vm.Model = null;
 				layout.entry1.BindingContext = null;
 
+				//testing standalone bindings
+				if (useCompiledXaml)
+				{
+					var binding = layout.picker0.ItemDisplayBinding;
+					Assert.That(binding, Is.TypeOf<TypedBinding<MockItemViewModel, string>>());
+				}
+
 				//testing invalid bindingcontext type
 				layout.BindingContext = new object();
 				Assert.AreEqual(null, layout.label0.Text);
@@ -203,6 +211,38 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 
 				values[v] = value;
 				OnPropertyChanged("Indexer[" + v + "]");
+			}
+		}
+
+		MockItemViewModel[] _items;
+		public MockItemViewModel[] Items
+		{
+			get { return _items; }
+			set
+			{
+				_items = value;
+				OnPropertyChanged();
+			}
+		}
+
+		protected void OnPropertyChanged([CallerMemberName] string propertyName = null)
+		{
+			PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+		}
+	}
+
+	class MockItemViewModel : INotifyPropertyChanged
+	{
+		public event PropertyChangedEventHandler PropertyChanged;
+
+		private string _title { get; set; }
+		public string Title
+		{
+			get => _title;
+			set
+			{
+				_title = value;
+				OnPropertyChanged();
 			}
 		}
 


### PR DESCRIPTION
### Description of Change

Bindings that aren't applied to a bindable property (such as in the case of the `Picker` component and the `ItemDisplayBinding`) aren't currently compiled. This means that `Picker` and other similar components wouldn't work with NativeAOT.

/cc @StephaneDelcroix please have a look

### Issues Fixed

Contributes to #18658 