### PR TITLE
[X] do not apply Bindings if DataType doesnt match

### DIFF
--- a/src/Controls/src/Core/Binding.cs
+++ b/src/Controls/src/Core/Binding.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;
 using System.Reflection;
+using Microsoft.Maui.Controls.Xaml.Diagnostics;
 
 namespace Microsoft.Maui.Controls
 {
@@ -125,6 +126,7 @@ namespace Microsoft.Maui.Controls
 			var bindingContext = src ?? Context ?? context;
 			if (DataType != null && bindingContext != null && !DataType.IsAssignableFrom(bindingContext.GetType()))
 			{
+				BindingDiagnostics.SendBindingFailure(this, "Binding", "Mismatch between the specified x:DataType and the current binding context");
 				bindingContext = null;
 			}
 

--- a/src/Controls/src/Core/Binding.cs
+++ b/src/Controls/src/Core/Binding.cs
@@ -105,6 +105,8 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
+		internal Type DataType { get; set; }
+
 		internal override void Apply(bool fromTarget)
 		{
 			base.Apply(fromTarget);
@@ -120,7 +122,13 @@ namespace Microsoft.Maui.Controls
 			object src = _source;
 			var isApplied = IsApplied;
 
-			base.Apply(src ?? context, bindObj, targetProperty, fromBindingContextChanged, specificity);
+			var bindingContext = src ?? Context ?? context;
+			if (DataType != null && bindingContext != null && !DataType.IsAssignableFrom(bindingContext.GetType()))
+			{
+				bindingContext = null;
+			}
+
+			base.Apply(bindingContext, bindObj, targetProperty, fromBindingContextChanged, specificity);
 
 			if (src != null && isApplied && fromBindingContextChanged)
 				return;
@@ -131,7 +139,6 @@ namespace Microsoft.Maui.Controls
 			}
 			else
 			{
-				object bindingContext = src ?? Context ?? context;
 				if (_expression == null)
 					_expression = new BindingExpression(this, SelfPath);
 				_expression.Apply(bindingContext, bindObj, targetProperty, specificity);

--- a/src/Controls/src/Core/IXamlDataTypeProvider.cs
+++ b/src/Controls/src/Core/IXamlDataTypeProvider.cs
@@ -1,0 +1,5 @@
+namespace Microsoft.Maui.Controls.Xaml;
+interface IXamlDataTypeProvider
+{
+	string BindingDataType { get; }
+}

--- a/src/Controls/src/Xaml/MarkupExtensions/BindingExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/BindingExtension.cs
@@ -1,11 +1,11 @@
 using System;
 using System.ComponentModel;
+using System.Linq.Expressions;
 using Microsoft.Maui.Controls.Internals;
 
 namespace Microsoft.Maui.Controls.Xaml
 {
 	[ContentProperty(nameof(Path))]
-	[AcceptEmptyServiceProvider]
 	public sealed class BindingExtension : IMarkupExtension<BindingBase>
 	{
 		public string Path { get; set; } = Binding.SelfPath;
@@ -21,12 +21,21 @@ namespace Microsoft.Maui.Controls.Xaml
 
 		BindingBase IMarkupExtension<BindingBase>.ProvideValue(IServiceProvider serviceProvider)
 		{
+			Type bindingXDataType = null;
+			if ((serviceProvider.GetService(typeof(IXamlTypeResolver)) is IXamlTypeResolver typeResolver)
+				&& (serviceProvider.GetService(typeof(IXamlDataTypeProvider)) is IXamlDataTypeProvider dataTypeProvider)
+				&& dataTypeProvider.BindingDataType != null)
+			{
+				typeResolver.TryResolve(dataTypeProvider.BindingDataType, out bindingXDataType);
+			}
+
 			if (TypedBinding == null)
 				return new Binding(Path, Mode, Converter, ConverterParameter, StringFormat, Source)
 				{
 					UpdateSourceEventName = UpdateSourceEventName,
 					FallbackValue = FallbackValue,
 					TargetNullValue = TargetNullValue,
+					DataType = bindingXDataType,
 				};
 
 			TypedBinding.Mode = Mode;

--- a/src/Controls/src/Xaml/MarkupExtensions/BindingExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/BindingExtension.cs
@@ -21,15 +21,14 @@ namespace Microsoft.Maui.Controls.Xaml
 
 		BindingBase IMarkupExtension<BindingBase>.ProvideValue(IServiceProvider serviceProvider)
 		{
-			Type bindingXDataType = null;
-			if ((serviceProvider.GetService(typeof(IXamlTypeResolver)) is IXamlTypeResolver typeResolver)
-				&& (serviceProvider.GetService(typeof(IXamlDataTypeProvider)) is IXamlDataTypeProvider dataTypeProvider)
-				&& dataTypeProvider.BindingDataType != null)
-			{
-				typeResolver.TryResolve(dataTypeProvider.BindingDataType, out bindingXDataType);
-			}
-
-			if (TypedBinding == null)
+			if (TypedBinding is null) {
+				Type bindingXDataType = null;
+				if ((serviceProvider.GetService(typeof(IXamlTypeResolver)) is IXamlTypeResolver typeResolver)
+					&& (serviceProvider.GetService(typeof(IXamlDataTypeProvider)) is IXamlDataTypeProvider dataTypeProvider)
+					&& dataTypeProvider.BindingDataType != null)
+				{
+					typeResolver.TryResolve(dataTypeProvider.BindingDataType, out bindingXDataType);
+				}
 				return new Binding(Path, Mode, Converter, ConverterParameter, StringFormat, Source)
 				{
 					UpdateSourceEventName = UpdateSourceEventName,
@@ -37,6 +36,7 @@ namespace Microsoft.Maui.Controls.Xaml
 					TargetNullValue = TargetNullValue,
 					DataType = bindingXDataType,
 				};
+			}
 
 			TypedBinding.Mode = Mode;
 			TypedBinding.Converter = Converter;

--- a/src/Controls/src/Xaml/XamlServiceProvider.cs
+++ b/src/Controls/src/Xaml/XamlServiceProvider.cs
@@ -27,6 +27,9 @@ namespace Microsoft.Maui.Controls.Xaml.Internals
 				IXmlLineInfoProvider = new XmlLineInfoProvider(xmlLineInfo);
 
 			IValueConverterProvider = new ValueConverterProvider();
+
+			if (node is IElementNode elementNode)
+				Add(typeof(IXamlDataTypeProvider), new XamlDataTypeProvider(elementNode));
 		}
 
 		public XamlServiceProvider() => IValueConverterProvider = new ValueConverterProvider();
@@ -261,5 +264,58 @@ namespace Microsoft.Maui.Controls.Xaml.Internals
 
 		public string LookupPrefix(string namespaceName) => throw new NotImplementedException();
 		public void Add(string prefix, string ns) => namespaces.Add(prefix, ns);
+	}
+
+	class XamlDataTypeProvider : IXamlDataTypeProvider
+	{
+		public XamlDataTypeProvider(IElementNode node)
+		{
+			static IElementNode GetParent(IElementNode node)
+			{
+				return node switch
+				{
+					{ Parent: ListNode { Parent: IElementNode parentNode } } => parentNode,
+					{ Parent: IElementNode parentNode } => parentNode,
+					_ => null,
+				};
+			}
+
+			static bool IsBindingContextBinding(IElementNode node)
+			{
+				if (   ApplyPropertiesVisitor.TryGetPropertyName(node, node.Parent, out XmlName name)
+					&& name.NamespaceURI == ""
+					&& name.LocalName == nameof(BindableObject.BindingContext))
+					return true;
+				return false;
+			}
+
+			INode dataTypeNode = null;
+			IElementNode n = node as IElementNode;
+
+			// Special handling for BindingContext={Binding ...}
+			// The order of checks is:
+			// - x:DataType on the binding itself
+			// - SKIP looking for x:DataType on the parent
+			// - continue looking for x:DataType on the parent's parent...
+			IElementNode skipNode = null;
+			if (IsBindingContextBinding(node))
+			{
+				skipNode = GetParent(node);
+			}
+
+			while (n != null)
+			{
+				if (n != skipNode && n.Properties.TryGetValue(XmlName.xDataType, out dataTypeNode))
+				{
+					break;
+				}
+
+				n = GetParent(n);
+			}
+			if (dataTypeNode is ValueNode valueNode)
+				BindingDataType = valueNode.Value as string;
+
+		}
+		public string BindingDataType { get; }
 	}
 }

--- a/src/Controls/tests/Xaml.UnitTests/BindingsCompiler.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/BindingsCompiler.xaml.cs
@@ -28,10 +28,9 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		{
 			[SetUp] public void Setup() => DispatcherProvider.SetCurrent(new DispatcherProviderStub());
 			[TearDown] public void TearDown() => DispatcherProvider.SetCurrent(null);
-
-			[TestCase(false)]
-			[TestCase(true)]
-			public void Test(bool useCompiledXaml)
+			
+			[Test] 
+			public void TestCompiledBindings([Values(false, true)]bool useCompiledXaml)
 			{
 				if (useCompiledXaml)
 					MockCompiler.Compile(typeof(BindingsCompiler));
@@ -112,6 +111,13 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 				//testing invalid bindingcontext type
 				layout.BindingContext = new object();
 				Assert.AreEqual(null, layout.label0.Text);
+			}
+			
+			[Test] 
+			public void BindingsNotAppliedWithWrongContext([Values(false, true)]bool useCompiledXaml)
+			{
+				var page = new BindingsCompiler(useCompiledXaml) { BindingContext = new {Text="Foo"} };
+				Assert.AreEqual(null, page.label0.Text);
 			}
 		}
 	}


### PR DESCRIPTION
### Reverted for SR8

https://github.com/dotnet/maui/pull/24046

This should be part of SR9
https://github.com/dotnet/maui/issues/23989


### Description of Change

Make sure the behavior of bindings is consistent accross implementations (compiled/not compiled)

fixes a bunch of issues

### Issues Fixed

- fixes #21735 
- fixes #16414 
- fixes #11956
- fixes #16021
- fixes #19357

