### PR TITLE
Bump $(MicrosoftMauiPreviousDotNetReleasedVersion) to 8.0.21

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <!-- Current previous .NET SDK major version's stable release of MAUI packages -->
-    <MicrosoftMauiPreviousDotNetReleasedVersion>8.0.7</MicrosoftMauiPreviousDotNetReleasedVersion>
+    <MicrosoftMauiPreviousDotNetReleasedVersion>8.0.21</MicrosoftMauiPreviousDotNetReleasedVersion>
     <!-- dotnet/installer -->
     <MicrosoftDotnetSdkInternalPackageVersion>9.0.100-preview.4.24221.5</MicrosoftDotnetSdkInternalPackageVersion>
     <!-- dotnet/runtime -->


### PR DESCRIPTION
We will need this in .NET 9 Preview 4 to ensure the .NET 8 version does not move backwards when attemping to insert into VS.
