### PR TITLE
Fix <ApplicationTitle> encoding in maui templates

### DIFF
--- a/src/Templates/README.md
+++ b/src/Templates/README.md
@@ -10,10 +10,13 @@ Add the local artifacts to the NuGet.config:
 ```
 
 ```dotnetcli
+# uninstall, build, and install the templates
+dotnet new uninstall Microsoft.Maui.Templates.net8
 dotnet pack Microsoft.Maui.sln
-dotnet new -i artifacts\Microsoft.Maui.Templates.*.nupkg
+dotnet new install artifacts\Microsoft.Maui.Templates.*.nupkg
+
 # then just in the maui folder, so you get a NuGet.config
-mkdir foo
-cd foo
+mkdir myproject
+cd myproject
 dotnet new maui
 ```

--- a/src/Templates/README.md
+++ b/src/Templates/README.md
@@ -13,7 +13,7 @@ Add the local artifacts to the NuGet.config:
 # uninstall, build, and install the templates
 dotnet new uninstall Microsoft.Maui.Templates.net8
 dotnet pack Microsoft.Maui.sln
-dotnet new install artifacts\Microsoft.Maui.Templates.*.nupkg
+dotnet new install artifacts\packages\Release\Shipping\Microsoft.Maui.Templates.*.nupkg
 
 # then just in the maui folder, so you get a NuGet.config
 mkdir myproject

--- a/src/Templates/src/templates/maui-blazor/.template.config/template.json
+++ b/src/Templates/src/templates/maui-blazor/.template.config/template.json
@@ -102,11 +102,11 @@
           ]
         }
       },
-      "nameToApplicationTitle": {
+      "XmlEncodedAppName": {
         "type": "derived",
         "valueSource": "name",
         "valueTransform": "encode",
-        "replaces": "MauiAppApplicationTitle"
+        "replaces": "XmlEncodedAppName"
       },
       "defaultAppId":{
         "type": "generated",

--- a/src/Templates/src/templates/maui-blazor/.template.config/template.json
+++ b/src/Templates/src/templates/maui-blazor/.template.config/template.json
@@ -102,7 +102,7 @@
           ]
         }
       },
-      "XmlEncodedAppName": {
+      "XmlEncodedAppNameParam": {
         "type": "derived",
         "valueSource": "name",
         "valueTransform": "encode",

--- a/src/Templates/src/templates/maui-blazor/.template.config/template.json
+++ b/src/Templates/src/templates/maui-blazor/.template.config/template.json
@@ -102,6 +102,12 @@
           ]
         }
       },
+      "nameToApplicationTitle": {
+        "type": "derived",
+        "valueSource": "name",
+        "valueTransform": "encode",
+        "replaces": "MauiAppApplicationTitle"
+      },
       "defaultAppId":{
         "type": "generated",
         "generator": "join",
@@ -127,6 +133,11 @@
         },
         "replaces": "com.companyname.mauiapp"
       }
+    },
+    "forms": {
+        "encode": {
+          "identifier": "xmlEncode"
+        }
     },
     "defaultName": "MauiApp1"
   }

--- a/src/Templates/src/templates/maui-blazor/MauiApp.1.csproj
+++ b/src/Templates/src/templates/maui-blazor/MauiApp.1.csproj
@@ -22,7 +22,7 @@
         <Nullable>enable</Nullable>
 
         <!-- Display name -->
-        <ApplicationTitle>MauiAppApplicationTitle</ApplicationTitle>
+        <ApplicationTitle>XmlEncodedAppName</ApplicationTitle>
 
         <!-- App Identifier -->
         <ApplicationId>com.companyname.mauiapp</ApplicationId>

--- a/src/Templates/src/templates/maui-blazor/MauiApp.1.csproj
+++ b/src/Templates/src/templates/maui-blazor/MauiApp.1.csproj
@@ -22,7 +22,7 @@
         <Nullable>enable</Nullable>
 
         <!-- Display name -->
-        <ApplicationTitle>MauiApp.1</ApplicationTitle>
+        <ApplicationTitle>MauiAppApplicationTitle</ApplicationTitle>
 
         <!-- App Identifier -->
         <ApplicationId>com.companyname.mauiapp</ApplicationId>

--- a/src/Templates/src/templates/maui-blazor/Platforms/Tizen/tizen-manifest.xml
+++ b/src/Templates/src/templates/maui-blazor/Platforms/Tizen/tizen-manifest.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest package="maui-application-id-placeholder" version="0.0.0" api-version="8" xmlns="http://tizen.org/ns/packages">
   <profile name="common" />
-  <ui-application appid="maui-application-id-placeholder" exec="MauiApp.1.dll" multiple="false" nodisplay="false" taskmanage="true" type="dotnet" launch_mode="single">
+  <ui-application appid="maui-application-id-placeholder" exec="XmlEncodedAppName.dll" multiple="false" nodisplay="false" taskmanage="true" type="dotnet" launch_mode="single">
     <label>maui-application-title-placeholder</label>
     <icon>maui-appicon-placeholder</icon>
     <metadata key="http://tizen.org/metadata/prefer_dotnet_aot" value="true" />

--- a/src/Templates/src/templates/maui-mobile/.template.config/template.json
+++ b/src/Templates/src/templates/maui-mobile/.template.config/template.json
@@ -106,11 +106,11 @@
           ]
         }
       },
-      "nameToApplicationTitle": {
+      "XmlEncodedAppName": {
         "type": "derived",
         "valueSource": "name",
         "valueTransform": "encode",
-        "replaces": "MauiAppApplicationTitle"
+        "replaces": "XmlEncodedAppName"
       },
       "defaultAppId":{
         "type": "generated",

--- a/src/Templates/src/templates/maui-mobile/.template.config/template.json
+++ b/src/Templates/src/templates/maui-mobile/.template.config/template.json
@@ -106,6 +106,12 @@
           ]
         }
       },
+      "nameToApplicationTitle": {
+        "type": "derived",
+        "valueSource": "name",
+        "valueTransform": "encode",
+        "replaces": "MauiAppApplicationTitle"
+      },
       "defaultAppId":{
         "type": "generated",
         "generator": "join",
@@ -130,6 +136,11 @@
           "fallbackVariableName": "defaultAppId"
         },
         "replaces": "com.companyname.mauiapp"
+      }
+    },
+    "forms": {
+      "encode": {
+        "identifier": "xmlEncode"
       }
     },
     "defaultName": "MauiApp1"

--- a/src/Templates/src/templates/maui-mobile/.template.config/template.json
+++ b/src/Templates/src/templates/maui-mobile/.template.config/template.json
@@ -106,7 +106,7 @@
           ]
         }
       },
-      "XmlEncodedAppName": {
+      "XmlEncodedAppNameParam": {
         "type": "derived",
         "valueSource": "name",
         "valueTransform": "encode",

--- a/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
+++ b/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
@@ -21,7 +21,7 @@
 		<Nullable>enable</Nullable>
 
 		<!-- Display name -->
-		<ApplicationTitle>MauiApp.1</ApplicationTitle>
+		<ApplicationTitle>MauiAppApplicationTitle</ApplicationTitle>
 
 		<!-- App Identifier -->
 		<ApplicationId>com.companyname.mauiapp</ApplicationId>

--- a/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
+++ b/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
@@ -21,7 +21,7 @@
 		<Nullable>enable</Nullable>
 
 		<!-- Display name -->
-		<ApplicationTitle>MauiAppApplicationTitle</ApplicationTitle>
+		<ApplicationTitle>XmlEncodedAppName</ApplicationTitle>
 
 		<!-- App Identifier -->
 		<ApplicationId>com.companyname.mauiapp</ApplicationId>

--- a/src/Templates/src/templates/maui-mobile/Platforms/Tizen/tizen-manifest.xml
+++ b/src/Templates/src/templates/maui-mobile/Platforms/Tizen/tizen-manifest.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest package="maui-application-id-placeholder" version="0.0.0" api-version="8" xmlns="http://tizen.org/ns/packages">
   <profile name="common" />
-  <ui-application appid="maui-application-id-placeholder" exec="MauiApp.1.dll" multiple="false" nodisplay="false" taskmanage="true" type="dotnet" launch_mode="single">
+  <ui-application appid="maui-application-id-placeholder" exec="XmlEncodedAppName.dll" multiple="false" nodisplay="false" taskmanage="true" type="dotnet" launch_mode="single">
     <label>maui-application-title-placeholder</label>
     <icon>maui-appicon-placeholder</icon>
     <metadata key="http://tizen.org/metadata/prefer_dotnet_aot" value="true" />

--- a/src/Templates/src/templates/maui-multiproject/.template.config/template.json
+++ b/src/Templates/src/templates/maui-multiproject/.template.config/template.json
@@ -191,7 +191,7 @@
           ]
         }
       },
-      "XmlEncodedAppName": {
+      "XmlEncodedAppNameParam": {
         "type": "derived",
         "valueSource": "name",
         "valueTransform": "encode",

--- a/src/Templates/src/templates/maui-multiproject/.template.config/template.json
+++ b/src/Templates/src/templates/maui-multiproject/.template.config/template.json
@@ -191,6 +191,12 @@
           ]
         }
       },
+      "XmlEncodedAppName": {
+        "type": "derived",
+        "valueSource": "name",
+        "valueTransform": "encode",
+        "replaces": "XmlEncodedAppName"
+      },
       "defaultAppId":{
       "type": "generated",
       "generator": "join",
@@ -216,6 +222,11 @@
       },
       "replaces": "com.companyname.mauiapp"
     }
+  },
+  "forms": {
+      "encode": {
+        "identifier": "xmlEncode"
+      }
   },
   "defaultName": "MauiApp1"
 }

--- a/src/Templates/src/templates/maui-multiproject/MauiApp.1.Droid/MauiApp.1.Droid.csproj
+++ b/src/Templates/src/templates/maui-multiproject/MauiApp.1.Droid/MauiApp.1.Droid.csproj
@@ -4,6 +4,7 @@
 		<TargetFramework>DOTNET_TFM-android</TargetFramework>
 		<SupportedOSPlatformVersion>21.0</SupportedOSPlatformVersion>
 		<OutputType>Exe</OutputType>
+		<RootNamespace>MauiApp._1</RootNamespace>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UseMaui>true</UseMaui>
@@ -16,7 +17,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<ProjectReference Include="..\MauiApp.1\MauiApp.1.csproj" />
+		<ProjectReference Include="..\XmlEncodedAppName\XmlEncodedAppName.csproj" />
 	</ItemGroup>
 
 </Project>

--- a/src/Templates/src/templates/maui-multiproject/MauiApp.1.Droid/Resources/values/strings.xml
+++ b/src/Templates/src/templates/maui-multiproject/MauiApp.1.Droid/Resources/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">MauiApp.1</string>
+    <string name="app_name">XmlEncodedAppName</string>
 </resources>

--- a/src/Templates/src/templates/maui-multiproject/MauiApp.1.Mac/MauiApp.1.Mac.csproj
+++ b/src/Templates/src/templates/maui-multiproject/MauiApp.1.Mac/MauiApp.1.Mac.csproj
@@ -4,6 +4,7 @@
 		<TargetFramework>DOTNET_TFM-maccatalyst</TargetFramework>
 		<SupportedOSPlatformVersion>13.1</SupportedOSPlatformVersion>
 		<OutputType>Exe</OutputType>
+		<RootNamespace>MauiApp._1</RootNamespace>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UseMaui>true</UseMaui>
@@ -16,7 +17,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<ProjectReference Include="..\MauiApp.1\MauiApp.1.csproj" />
+		<ProjectReference Include="..\XmlEncodedAppName\XmlEncodedAppName.csproj" />
 	</ItemGroup>
 
 </Project>

--- a/src/Templates/src/templates/maui-multiproject/MauiApp.1.WinUI/MauiApp.1.WinUI.csproj
+++ b/src/Templates/src/templates/maui-multiproject/MauiApp.1.WinUI/MauiApp.1.WinUI.csproj
@@ -4,7 +4,7 @@
 		<OutputType>WinExe</OutputType>
 		<TargetFramework>DOTNET_TFM-windows10.0.19041.0</TargetFramework>
 		<TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
-		<RootNamespace>MauiApp.1.WinUI</RootNamespace>
+		<RootNamespace>MauiApp._1.WinUI</RootNamespace>
 		<ApplicationManifest>app.manifest</ApplicationManifest>
 		<Platforms>x86;x64;ARM64</Platforms>
 		<RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
@@ -25,7 +25,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<ProjectReference Include="..\MauiApp.1\MauiApp.1.csproj" />
+		<ProjectReference Include="..\XmlEncodedAppName\XmlEncodedAppName.csproj" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Templates/src/templates/maui-multiproject/MauiApp.1.iOS/MauiApp.1.iOS.csproj
+++ b/src/Templates/src/templates/maui-multiproject/MauiApp.1.iOS/MauiApp.1.iOS.csproj
@@ -4,6 +4,7 @@
 		<TargetFramework>DOTNET_TFM-ios</TargetFramework>
 		<SupportedOSPlatformVersion>11.0</SupportedOSPlatformVersion>
 		<OutputType>Exe</OutputType>
+		<RootNamespace>MauiApp._1</RootNamespace>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UseMaui>true</UseMaui>
@@ -16,7 +17,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<ProjectReference Include="..\MauiApp.1\MauiApp.1.csproj" />
+		<ProjectReference Include="..\XmlEncodedAppName\XmlEncodedAppName.csproj" />
 	</ItemGroup>
 
 </Project>

--- a/src/Templates/src/templates/maui-multiproject/MauiApp.1/MauiApp.1.csproj
+++ b/src/Templates/src/templates/maui-multiproject/MauiApp.1/MauiApp.1.csproj
@@ -4,6 +4,7 @@
 		<TargetFramework>DOTNET_TFM</TargetFramework>
 		<SingleProject>true</SingleProject>
 		<ImplicitUsings>enable</ImplicitUsings>
+		<RootNamespace>MauiApp._1</RootNamespace>
 		<UseMaui>true</UseMaui>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/TemplateTests.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/TemplateTests.cs
@@ -134,7 +134,7 @@ namespace Microsoft.Maui.IntegrationTests
 					.Elements("ApplicationTitle")
 					.Single()
 					.Value;
-				Assert.AreEqual($"com.companyname.{projectName}", appTitle);
+				Assert.AreEqual(projectName, appTitle);
 			}
 
 			Assert.IsTrue(DotnetInternal.Build(projectFile, "Debug", properties: BuildProps, msbuildWarningsAsErrors: true),

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/TemplateTests.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/TemplateTests.cs
@@ -14,20 +14,20 @@ namespace Microsoft.Maui.IntegrationTests
 				Path.Combine(TestDirectory, "Directory.Build.targets"), true);
 		}
 
-		[Test]
-		// Parameters: short name, target framework, build config, use pack target
-		[TestCase("maui", DotNetPrevious, "Debug", false)]
-		[TestCase("maui", DotNetPrevious, "Release", false)]
-		[TestCase("maui", DotNetCurrent, "Debug", false)]
-		[TestCase("maui", DotNetCurrent, "Release", false)]
-		[TestCase("maui-blazor", DotNetPrevious, "Debug", false)]
-		[TestCase("maui-blazor", DotNetPrevious, "Release", false)]
-		[TestCase("maui-blazor", DotNetCurrent, "Debug", false)]
-		[TestCase("maui-blazor", DotNetCurrent, "Release", false)]
-		[TestCase("mauilib", DotNetPrevious, "Debug", true)]
-		[TestCase("mauilib", DotNetPrevious, "Release", true)]
-		[TestCase("mauilib", DotNetCurrent, "Debug", true)]
-		[TestCase("mauilib", DotNetCurrent, "Release", true)]
+		// [Test]
+		// // Parameters: short name, target framework, build config, use pack target
+		// [TestCase("maui", DotNetPrevious, "Debug", false)]
+		// [TestCase("maui", DotNetPrevious, "Release", false)]
+		// [TestCase("maui", DotNetCurrent, "Debug", false)]
+		// [TestCase("maui", DotNetCurrent, "Release", false)]
+		// [TestCase("maui-blazor", DotNetPrevious, "Debug", false)]
+		// [TestCase("maui-blazor", DotNetPrevious, "Release", false)]
+		// [TestCase("maui-blazor", DotNetCurrent, "Debug", false)]
+		// [TestCase("maui-blazor", DotNetCurrent, "Release", false)]
+		// [TestCase("mauilib", DotNetPrevious, "Debug", true)]
+		// [TestCase("mauilib", DotNetPrevious, "Release", true)]
+		// [TestCase("mauilib", DotNetCurrent, "Debug", true)]
+		// [TestCase("mauilib", DotNetCurrent, "Release", true)]
 		public void Build(string id, string framework, string config, bool shouldPack)
 		{
 			var projectDir = TestDirectory;
@@ -48,11 +48,11 @@ namespace Microsoft.Maui.IntegrationTests
 				$"Project {Path.GetFileName(projectFile)} failed to build. Check test output/attachments for errors.");
 		}
 
-		[Test]
-		[TestCase("Debug", "simplemulti")]
-		[TestCase("Release", "simplemulti")]
-		[TestCase("Debug", "MultiProject@Symbol & More")]
-		[TestCase("Release", "MultiProject@Symbol & More")]
+		// [Test]
+		// [TestCase("Debug", "simplemulti")]
+		// [TestCase("Release", "simplemulti")]
+		// [TestCase("Debug", "MultiProject@Symbol & More")]
+		// [TestCase("Release", "MultiProject@Symbol & More")]
 		public void BuildMultiProject(string config, string projectName)
 		{
 			var projectDir = Path.Combine(TestDirectory, projectName);
@@ -72,11 +72,11 @@ namespace Microsoft.Maui.IntegrationTests
 				$"Solution {name} failed to build. Check test output/attachments for errors.");
 		}
 
-		[Test]
-		[TestCase("Debug", "--android")]
-		[TestCase("Debug", "--ios")]
-		[TestCase("Debug", "--windows")]
-		[TestCase("Debug", "--macos")]
+		// [Test]
+		// [TestCase("Debug", "--android")]
+		// [TestCase("Debug", "--ios")]
+		// [TestCase("Debug", "--windows")]
+		// [TestCase("Debug", "--macos")]
 		public void BuildMultiProjectSinglePlatform(string config, string platformArg)
 		{
 			var projectDir = TestDirectory;
@@ -113,6 +113,12 @@ namespace Microsoft.Maui.IntegrationTests
 			Assert.IsTrue(DotnetInternal.New(id, projectDir, DotNetCurrent),
 				$"Unable to create template {id}. Check test output for errors.");
 
+			var proj = System.IO.File.ReadAllText(projectFile);
+			TestContext.WriteLine($"-------- Project file start --------");
+			TestContext.WriteLine(proj);
+			TestContext.WriteLine($"-------- Project file start --------");
+
+
 			EnableTizen(projectFile);
 
 			// libraries do not have application IDs
@@ -141,20 +147,20 @@ namespace Microsoft.Maui.IntegrationTests
 				$"Project {Path.GetFileName(projectFile)} failed to build. Check test output/attachments for errors.");
 		}
 
-		[Test]
-		// Parameters: short name, target framework, build config, use pack target
-		[TestCase("maui", DotNetPrevious, "Debug", false)]
-		[TestCase("maui", DotNetPrevious, "Release", false)]
-		[TestCase("maui", DotNetCurrent, "Debug", false)]
-		[TestCase("maui", DotNetCurrent, "Release", false)]
-		[TestCase("maui-blazor", DotNetPrevious, "Debug", false)]
-		[TestCase("maui-blazor", DotNetPrevious, "Release", false)]
-		[TestCase("maui-blazor", DotNetCurrent, "Debug", false)]
-		[TestCase("maui-blazor", DotNetCurrent, "Release", false)]
-		[TestCase("mauilib", DotNetPrevious, "Debug", true)]
-		[TestCase("mauilib", DotNetPrevious, "Release", true)]
-		[TestCase("mauilib", DotNetCurrent, "Debug", true)]
-		[TestCase("mauilib", DotNetCurrent, "Release", true)]
+		// [Test]
+		// // Parameters: short name, target framework, build config, use pack target
+		// [TestCase("maui", DotNetPrevious, "Debug", false)]
+		// [TestCase("maui", DotNetPrevious, "Release", false)]
+		// [TestCase("maui", DotNetCurrent, "Debug", false)]
+		// [TestCase("maui", DotNetCurrent, "Release", false)]
+		// [TestCase("maui-blazor", DotNetPrevious, "Debug", false)]
+		// [TestCase("maui-blazor", DotNetPrevious, "Release", false)]
+		// [TestCase("maui-blazor", DotNetCurrent, "Debug", false)]
+		// [TestCase("maui-blazor", DotNetCurrent, "Release", false)]
+		// [TestCase("mauilib", DotNetPrevious, "Debug", true)]
+		// [TestCase("mauilib", DotNetPrevious, "Release", true)]
+		// [TestCase("mauilib", DotNetCurrent, "Debug", true)]
+		// [TestCase("mauilib", DotNetCurrent, "Release", true)]
 		public void BuildWithMauiVersion(string id, string framework, string config, bool shouldPack)
 		{
 			var projectDir = TestDirectory;
@@ -181,15 +187,15 @@ namespace Microsoft.Maui.IntegrationTests
 				$"Project {Path.GetFileName(projectFile)} failed to build. Check test output/attachments for errors.");
 		}
 
-		[Test]
-		[TestCase("maui", DotNetPrevious, "Debug")]
-		[TestCase("maui", DotNetPrevious, "Release")]
-		[TestCase("maui", DotNetCurrent, "Debug")]
-		[TestCase("maui", DotNetCurrent, "Release")]
-		[TestCase("maui-blazor", DotNetPrevious, "Debug")]
-		[TestCase("maui-blazor", DotNetPrevious, "Release")]
-		[TestCase("maui-blazor", DotNetCurrent, "Debug")]
-		[TestCase("maui-blazor", DotNetCurrent, "Release")]
+		// [Test]
+		// [TestCase("maui", DotNetPrevious, "Debug")]
+		// [TestCase("maui", DotNetPrevious, "Release")]
+		// [TestCase("maui", DotNetCurrent, "Debug")]
+		// [TestCase("maui", DotNetCurrent, "Release")]
+		// [TestCase("maui-blazor", DotNetPrevious, "Debug")]
+		// [TestCase("maui-blazor", DotNetPrevious, "Release")]
+		// [TestCase("maui-blazor", DotNetCurrent, "Debug")]
+		// [TestCase("maui-blazor", DotNetCurrent, "Release")]
 		public void BuildUnpackaged(string id, string framework, string config)
 		{
 			var projectDir = TestDirectory;
@@ -207,10 +213,10 @@ namespace Microsoft.Maui.IntegrationTests
 				$"Project {Path.GetFileName(projectFile)} failed to build. Check test output/attachments for errors.");
 		}
 
-		[Test]
-		[TestCase("maui", true, true)]
-		[TestCase("maui", true, false)]
-		[TestCase("maui", false, true)]
+		// [Test]
+		// [TestCase("maui", true, true)]
+		// [TestCase("maui", true, false)]
+		// [TestCase("maui", false, true)]
 		public void BuildWindowsAppSDKSelfContained(string id, bool wasdkself, bool netself)
 		{
 			if (TestEnvironment.IsMacOS)
@@ -237,8 +243,8 @@ namespace Microsoft.Maui.IntegrationTests
 				$"Project {Path.GetFileName(projectFile)} failed to build. Check test output/attachments for errors.");
 		}
 
-		[Test]
-		[TestCase("maui", $"{DotNetCurrent}-ios", "ios-arm64")]
+		// [Test]
+		// [TestCase("maui", $"{DotNetCurrent}-ios", "ios-arm64")]
 		public void PublishNativeAOT(string id, string framework, string runtimeIdentifier)
 		{
 			if (!TestEnvironment.IsMacOS)
@@ -259,8 +265,8 @@ namespace Microsoft.Maui.IntegrationTests
 				$"Project {Path.GetFileName(projectFile)} failed to build. Check test output/attachments for errors.");
 		}
 
-		[Test]
-		[TestCase("maui", $"{DotNetCurrent}-ios", "ios-arm64")]
+		//[Test]
+		//[TestCase("maui", $"{DotNetCurrent}-ios", "ios-arm64")]
 		public void PublishNativeAOTCheckWarnings(string id, string framework, string runtimeIdentifier)
 		{
 			if (!TestEnvironment.IsMacOS)
@@ -288,8 +294,8 @@ namespace Microsoft.Maui.IntegrationTests
 			actualWarnings.AssertWarnings(expectedWarnings);
 		}
 
-		[Test]
-		[TestCase("maui", DotNetCurrent, "Release")]
+		//[Test]
+		//[TestCase("maui", DotNetCurrent, "Release")]
 		public void PublishUnpackaged(string id, string framework, string config)
 		{
 			if (!TestEnvironment.IsWindows)
@@ -325,11 +331,11 @@ namespace Microsoft.Maui.IntegrationTests
 		/// <summary>
 		/// Tests the scenario where a .NET MAUI Library specifically uses UseMauiCore instead of UseMaui.
 		/// </summary>
-		[Test]
-		[TestCase("mauilib", DotNetPrevious, "Debug")]
-		[TestCase("mauilib", DotNetPrevious, "Release")]
-		[TestCase("mauilib", DotNetCurrent, "Debug")]
-		[TestCase("mauilib", DotNetCurrent, "Release")]
+		//[Test]
+		//[TestCase("mauilib", DotNetPrevious, "Debug")]
+		//[TestCase("mauilib", DotNetPrevious, "Release")]
+		//[TestCase("mauilib", DotNetCurrent, "Debug")]
+		//[TestCase("mauilib", DotNetCurrent, "Release")]
 		public void PackCoreLib(string id, string framework, string config)
 		{
 			var projectDir = TestDirectory;
@@ -359,10 +365,10 @@ namespace Microsoft.Maui.IntegrationTests
 				$"Project {Path.GetFileName(projectFile)} failed to build. Check test output/attachments for errors.");
 		}
 
-		[Test]
-		[TestCase("maui", DotNetCurrent, "Debug")]
-		[TestCase("mauilib", DotNetCurrent, "Debug")]
-		[TestCase("maui-blazor", DotNetCurrent, "Debug")]
+		//[Test]
+		//[TestCase("maui", DotNetCurrent, "Debug")]
+		//[TestCase("mauilib", DotNetCurrent, "Debug")]
+		//[TestCase("maui-blazor", DotNetCurrent, "Debug")]
 		public void BuildWithoutPackageReference(string id, string framework, string config)
 		{
 			var projectDir = TestDirectory;
@@ -383,13 +389,13 @@ namespace Microsoft.Maui.IntegrationTests
 				$"Project {Path.GetFileName(projectFile)} failed to build. Check test output/attachments for errors.");
 		}
 
-		[Test]
-		[TestCase("maui", "Debug", "2.0", "2")]
-		[TestCase("maui", "Release", "2.0", "2")]
-		[TestCase("maui", "Release", "0.3", "3")]
-		[TestCase("maui-blazor", "Debug", "2.0", "2")]
-		[TestCase("maui-blazor", "Release", "2.0", "2")]
-		[TestCase("maui-blazor", "Release", "0.3", "3")]
+		//[Test]
+		//[TestCase("maui", "Debug", "2.0", "2")]
+		//[TestCase("maui", "Release", "2.0", "2")]
+		//[TestCase("maui", "Release", "0.3", "3")]
+		//[TestCase("maui-blazor", "Debug", "2.0", "2")]
+		//[TestCase("maui-blazor", "Release", "2.0", "2")]
+		//[TestCase("maui-blazor", "Release", "0.3", "3")]
 		public void BuildWithDifferentVersionNumber(string id, string config, string display, string version)
 		{
 			var projectDir = TestDirectory;
@@ -410,9 +416,9 @@ namespace Microsoft.Maui.IntegrationTests
 				$"Project {Path.GetFileName(projectFile)} failed to build. Check test output/attachments for errors.");
 		}
 
-		[Test]
-		[TestCase("maui-blazor", "Debug", DotNetCurrent)]
-		[TestCase("maui-blazor", "Release", DotNetCurrent)]
+		//[Test]
+		//[TestCase("maui-blazor", "Debug", DotNetCurrent)]
+		//[TestCase("maui-blazor", "Release", DotNetCurrent)]
 		public void CheckEntitlementsForMauiBlazorOnMacCatalyst(string id, string config, string framework)
 		{
 			if (TestEnvironment.IsWindows)
@@ -442,7 +448,7 @@ namespace Microsoft.Maui.IntegrationTests
 			CollectionAssert.AreEqual(expectedEntitlements, foundEntitlements, "Entitlements missing from executable.");
 		}
 
-		[Test]
+		//[Test]
 		public void BuildHandlesBadFilesInImages()
 		{
 			var projectDir = TestDirectory;

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/TemplateTests.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/TemplateTests.cs
@@ -113,13 +113,25 @@ namespace Microsoft.Maui.IntegrationTests
 			Assert.IsTrue(DotnetInternal.New(id, projectDir, DotNetCurrent),
 				$"Unable to create template {id}. Check test output for errors.");
 
+			EnableTizen(projectFile);
+
+
+
 			var proj = System.IO.File.ReadAllText(projectFile);
 			TestContext.WriteLine($"-------- Project file start --------");
 			TestContext.WriteLine(proj);
-			TestContext.WriteLine($"-------- Project file start --------");
+			TestContext.WriteLine($"-------- Project file end --------");
+			TestContext.WriteLine("");
+			TestContext.WriteLine("");
+
+			var tm = System.IO.File.ReadAllText(Path.Combine(projectDir, "Platforms", "Tizen", "tizen-manifest.xml"));
+			TestContext.WriteLine($"-------- Tizen file start --------");
+			TestContext.WriteLine(tm);
+			TestContext.WriteLine($"-------- Tizen file end --------");
+			TestContext.WriteLine("");
+			TestContext.WriteLine("");
 
 
-			EnableTizen(projectFile);
 
 			// libraries do not have application IDs
 			if (id != "mauilib")

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/TemplateTests.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/TemplateTests.cs
@@ -49,11 +49,13 @@ namespace Microsoft.Maui.IntegrationTests
 		}
 
 		[Test]
-		[TestCase("Debug")]
-		[TestCase("Release")]
-		public void BuildMultiProject(string config)
+		[TestCase("Debug", "simplemulti")]
+		[TestCase("Release", "simplemulti")]
+		[TestCase("Debug", "MultiProject@Symbol & More")]
+		[TestCase("Release", "MultiProject@Symbol & More")]
+		public void BuildMultiProject(string config, string projectName)
 		{
-			var projectDir = TestDirectory;
+			var projectDir = Path.Combine(TestDirectory, projectName);
 			var name = Path.GetFileName(projectDir);
 			var solutionFile = Path.Combine(projectDir, $"{name}.sln");
 
@@ -132,7 +134,7 @@ namespace Microsoft.Maui.IntegrationTests
 					.Elements("ApplicationTitle")
 					.Single()
 					.Value;
-				Assert.AreEqual($"com.companyname.{projectName}", appId);
+				Assert.AreEqual($"com.companyname.{projectName}", appTitle);
 			}
 
 			Assert.IsTrue(DotnetInternal.Build(projectFile, "Debug", properties: BuildProps, msbuildWarningsAsErrors: true),

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/TemplateTests.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/TemplateTests.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Maui.IntegrationTests
 
 			if (!TestEnvironment.IsWindows)
 			{
-				Assert.IsTrue(DotnetInternal.Run("sln", $"{solutionFile} remove {projectDir}/{name}.WinUI/{name}.WinUI.csproj"),
+				Assert.IsTrue(DotnetInternal.Run("sln", $"\"{solutionFile}\" remove \"{projectDir}/{name}.WinUI/{name}.WinUI.csproj\""),
 					$"Unable to remove WinUI project from solution. Check test output for errors.");
 			}
 

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/TemplateTests.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/TemplateTests.cs
@@ -14,20 +14,20 @@ namespace Microsoft.Maui.IntegrationTests
 				Path.Combine(TestDirectory, "Directory.Build.targets"), true);
 		}
 
-		// [Test]
-		// // Parameters: short name, target framework, build config, use pack target
-		// [TestCase("maui", DotNetPrevious, "Debug", false)]
-		// [TestCase("maui", DotNetPrevious, "Release", false)]
-		// [TestCase("maui", DotNetCurrent, "Debug", false)]
-		// [TestCase("maui", DotNetCurrent, "Release", false)]
-		// [TestCase("maui-blazor", DotNetPrevious, "Debug", false)]
-		// [TestCase("maui-blazor", DotNetPrevious, "Release", false)]
-		// [TestCase("maui-blazor", DotNetCurrent, "Debug", false)]
-		// [TestCase("maui-blazor", DotNetCurrent, "Release", false)]
-		// [TestCase("mauilib", DotNetPrevious, "Debug", true)]
-		// [TestCase("mauilib", DotNetPrevious, "Release", true)]
-		// [TestCase("mauilib", DotNetCurrent, "Debug", true)]
-		// [TestCase("mauilib", DotNetCurrent, "Release", true)]
+		[Test]
+		// Parameters: short name, target framework, build config, use pack target
+		[TestCase("maui", DotNetPrevious, "Debug", false)]
+		[TestCase("maui", DotNetPrevious, "Release", false)]
+		[TestCase("maui", DotNetCurrent, "Debug", false)]
+		[TestCase("maui", DotNetCurrent, "Release", false)]
+		[TestCase("maui-blazor", DotNetPrevious, "Debug", false)]
+		[TestCase("maui-blazor", DotNetPrevious, "Release", false)]
+		[TestCase("maui-blazor", DotNetCurrent, "Debug", false)]
+		[TestCase("maui-blazor", DotNetCurrent, "Release", false)]
+		[TestCase("mauilib", DotNetPrevious, "Debug", true)]
+		[TestCase("mauilib", DotNetPrevious, "Release", true)]
+		[TestCase("mauilib", DotNetCurrent, "Debug", true)]
+		[TestCase("mauilib", DotNetCurrent, "Release", true)]
 		public void Build(string id, string framework, string config, bool shouldPack)
 		{
 			var projectDir = TestDirectory;
@@ -48,11 +48,11 @@ namespace Microsoft.Maui.IntegrationTests
 				$"Project {Path.GetFileName(projectFile)} failed to build. Check test output/attachments for errors.");
 		}
 
-		// [Test]
-		// [TestCase("Debug", "simplemulti")]
-		// [TestCase("Release", "simplemulti")]
-		// [TestCase("Debug", "MultiProject@Symbol & More")]
-		// [TestCase("Release", "MultiProject@Symbol & More")]
+		[Test]
+		[TestCase("Debug", "simplemulti")]
+		[TestCase("Release", "simplemulti")]
+		[TestCase("Debug", "MultiProject@Symbol & More")]
+		[TestCase("Release", "MultiProject@Symbol & More")]
 		public void BuildMultiProject(string config, string projectName)
 		{
 			var projectDir = Path.Combine(TestDirectory, projectName);
@@ -72,11 +72,11 @@ namespace Microsoft.Maui.IntegrationTests
 				$"Solution {name} failed to build. Check test output/attachments for errors.");
 		}
 
-		// [Test]
-		// [TestCase("Debug", "--android")]
-		// [TestCase("Debug", "--ios")]
-		// [TestCase("Debug", "--windows")]
-		// [TestCase("Debug", "--macos")]
+		[Test]
+		[TestCase("Debug", "--android")]
+		[TestCase("Debug", "--ios")]
+		[TestCase("Debug", "--windows")]
+		[TestCase("Debug", "--macos")]
 		public void BuildMultiProjectSinglePlatform(string config, string platformArg)
 		{
 			var projectDir = TestDirectory;
@@ -115,24 +115,6 @@ namespace Microsoft.Maui.IntegrationTests
 
 			EnableTizen(projectFile);
 
-
-
-			var proj = System.IO.File.ReadAllText(projectFile);
-			TestContext.WriteLine($"-------- Project file start --------");
-			TestContext.WriteLine(proj);
-			TestContext.WriteLine($"-------- Project file end --------");
-			TestContext.WriteLine("");
-			TestContext.WriteLine("");
-
-			var tm = System.IO.File.ReadAllText(Path.Combine(projectDir, "Platforms", "Tizen", "tizen-manifest.xml"));
-			TestContext.WriteLine($"-------- Tizen file start --------");
-			TestContext.WriteLine(tm);
-			TestContext.WriteLine($"-------- Tizen file end --------");
-			TestContext.WriteLine("");
-			TestContext.WriteLine("");
-
-
-
 			// libraries do not have application IDs
 			if (id != "mauilib")
 			{
@@ -159,20 +141,20 @@ namespace Microsoft.Maui.IntegrationTests
 				$"Project {Path.GetFileName(projectFile)} failed to build. Check test output/attachments for errors.");
 		}
 
-		// [Test]
-		// // Parameters: short name, target framework, build config, use pack target
-		// [TestCase("maui", DotNetPrevious, "Debug", false)]
-		// [TestCase("maui", DotNetPrevious, "Release", false)]
-		// [TestCase("maui", DotNetCurrent, "Debug", false)]
-		// [TestCase("maui", DotNetCurrent, "Release", false)]
-		// [TestCase("maui-blazor", DotNetPrevious, "Debug", false)]
-		// [TestCase("maui-blazor", DotNetPrevious, "Release", false)]
-		// [TestCase("maui-blazor", DotNetCurrent, "Debug", false)]
-		// [TestCase("maui-blazor", DotNetCurrent, "Release", false)]
-		// [TestCase("mauilib", DotNetPrevious, "Debug", true)]
-		// [TestCase("mauilib", DotNetPrevious, "Release", true)]
-		// [TestCase("mauilib", DotNetCurrent, "Debug", true)]
-		// [TestCase("mauilib", DotNetCurrent, "Release", true)]
+		[Test]
+		// Parameters: short name, target framework, build config, use pack target
+		[TestCase("maui", DotNetPrevious, "Debug", false)]
+		[TestCase("maui", DotNetPrevious, "Release", false)]
+		[TestCase("maui", DotNetCurrent, "Debug", false)]
+		[TestCase("maui", DotNetCurrent, "Release", false)]
+		[TestCase("maui-blazor", DotNetPrevious, "Debug", false)]
+		[TestCase("maui-blazor", DotNetPrevious, "Release", false)]
+		[TestCase("maui-blazor", DotNetCurrent, "Debug", false)]
+		[TestCase("maui-blazor", DotNetCurrent, "Release", false)]
+		[TestCase("mauilib", DotNetPrevious, "Debug", true)]
+		[TestCase("mauilib", DotNetPrevious, "Release", true)]
+		[TestCase("mauilib", DotNetCurrent, "Debug", true)]
+		[TestCase("mauilib", DotNetCurrent, "Release", true)]
 		public void BuildWithMauiVersion(string id, string framework, string config, bool shouldPack)
 		{
 			var projectDir = TestDirectory;
@@ -199,15 +181,15 @@ namespace Microsoft.Maui.IntegrationTests
 				$"Project {Path.GetFileName(projectFile)} failed to build. Check test output/attachments for errors.");
 		}
 
-		// [Test]
-		// [TestCase("maui", DotNetPrevious, "Debug")]
-		// [TestCase("maui", DotNetPrevious, "Release")]
-		// [TestCase("maui", DotNetCurrent, "Debug")]
-		// [TestCase("maui", DotNetCurrent, "Release")]
-		// [TestCase("maui-blazor", DotNetPrevious, "Debug")]
-		// [TestCase("maui-blazor", DotNetPrevious, "Release")]
-		// [TestCase("maui-blazor", DotNetCurrent, "Debug")]
-		// [TestCase("maui-blazor", DotNetCurrent, "Release")]
+		[Test]
+		[TestCase("maui", DotNetPrevious, "Debug")]
+		[TestCase("maui", DotNetPrevious, "Release")]
+		[TestCase("maui", DotNetCurrent, "Debug")]
+		[TestCase("maui", DotNetCurrent, "Release")]
+		[TestCase("maui-blazor", DotNetPrevious, "Debug")]
+		[TestCase("maui-blazor", DotNetPrevious, "Release")]
+		[TestCase("maui-blazor", DotNetCurrent, "Debug")]
+		[TestCase("maui-blazor", DotNetCurrent, "Release")]
 		public void BuildUnpackaged(string id, string framework, string config)
 		{
 			var projectDir = TestDirectory;
@@ -225,10 +207,10 @@ namespace Microsoft.Maui.IntegrationTests
 				$"Project {Path.GetFileName(projectFile)} failed to build. Check test output/attachments for errors.");
 		}
 
-		// [Test]
-		// [TestCase("maui", true, true)]
-		// [TestCase("maui", true, false)]
-		// [TestCase("maui", false, true)]
+		[Test]
+		[TestCase("maui", true, true)]
+		[TestCase("maui", true, false)]
+		[TestCase("maui", false, true)]
 		public void BuildWindowsAppSDKSelfContained(string id, bool wasdkself, bool netself)
 		{
 			if (TestEnvironment.IsMacOS)
@@ -255,8 +237,8 @@ namespace Microsoft.Maui.IntegrationTests
 				$"Project {Path.GetFileName(projectFile)} failed to build. Check test output/attachments for errors.");
 		}
 
-		// [Test]
-		// [TestCase("maui", $"{DotNetCurrent}-ios", "ios-arm64")]
+		[Test]
+		[TestCase("maui", $"{DotNetCurrent}-ios", "ios-arm64")]
 		public void PublishNativeAOT(string id, string framework, string runtimeIdentifier)
 		{
 			if (!TestEnvironment.IsMacOS)
@@ -277,8 +259,8 @@ namespace Microsoft.Maui.IntegrationTests
 				$"Project {Path.GetFileName(projectFile)} failed to build. Check test output/attachments for errors.");
 		}
 
-		//[Test]
-		//[TestCase("maui", $"{DotNetCurrent}-ios", "ios-arm64")]
+		[Test]
+		[TestCase("maui", $"{DotNetCurrent}-ios", "ios-arm64")]
 		public void PublishNativeAOTCheckWarnings(string id, string framework, string runtimeIdentifier)
 		{
 			if (!TestEnvironment.IsMacOS)
@@ -306,8 +288,8 @@ namespace Microsoft.Maui.IntegrationTests
 			actualWarnings.AssertWarnings(expectedWarnings);
 		}
 
-		//[Test]
-		//[TestCase("maui", DotNetCurrent, "Release")]
+		[Test]
+		[TestCase("maui", DotNetCurrent, "Release")]
 		public void PublishUnpackaged(string id, string framework, string config)
 		{
 			if (!TestEnvironment.IsWindows)
@@ -343,11 +325,11 @@ namespace Microsoft.Maui.IntegrationTests
 		/// <summary>
 		/// Tests the scenario where a .NET MAUI Library specifically uses UseMauiCore instead of UseMaui.
 		/// </summary>
-		//[Test]
-		//[TestCase("mauilib", DotNetPrevious, "Debug")]
-		//[TestCase("mauilib", DotNetPrevious, "Release")]
-		//[TestCase("mauilib", DotNetCurrent, "Debug")]
-		//[TestCase("mauilib", DotNetCurrent, "Release")]
+		[Test]
+		[TestCase("mauilib", DotNetPrevious, "Debug")]
+		[TestCase("mauilib", DotNetPrevious, "Release")]
+		[TestCase("mauilib", DotNetCurrent, "Debug")]
+		[TestCase("mauilib", DotNetCurrent, "Release")]
 		public void PackCoreLib(string id, string framework, string config)
 		{
 			var projectDir = TestDirectory;
@@ -377,10 +359,10 @@ namespace Microsoft.Maui.IntegrationTests
 				$"Project {Path.GetFileName(projectFile)} failed to build. Check test output/attachments for errors.");
 		}
 
-		//[Test]
-		//[TestCase("maui", DotNetCurrent, "Debug")]
-		//[TestCase("mauilib", DotNetCurrent, "Debug")]
-		//[TestCase("maui-blazor", DotNetCurrent, "Debug")]
+		[Test]
+		[TestCase("maui", DotNetCurrent, "Debug")]
+		[TestCase("mauilib", DotNetCurrent, "Debug")]
+		[TestCase("maui-blazor", DotNetCurrent, "Debug")]
 		public void BuildWithoutPackageReference(string id, string framework, string config)
 		{
 			var projectDir = TestDirectory;
@@ -401,13 +383,13 @@ namespace Microsoft.Maui.IntegrationTests
 				$"Project {Path.GetFileName(projectFile)} failed to build. Check test output/attachments for errors.");
 		}
 
-		//[Test]
-		//[TestCase("maui", "Debug", "2.0", "2")]
-		//[TestCase("maui", "Release", "2.0", "2")]
-		//[TestCase("maui", "Release", "0.3", "3")]
-		//[TestCase("maui-blazor", "Debug", "2.0", "2")]
-		//[TestCase("maui-blazor", "Release", "2.0", "2")]
-		//[TestCase("maui-blazor", "Release", "0.3", "3")]
+		[Test]
+		[TestCase("maui", "Debug", "2.0", "2")]
+		[TestCase("maui", "Release", "2.0", "2")]
+		[TestCase("maui", "Release", "0.3", "3")]
+		[TestCase("maui-blazor", "Debug", "2.0", "2")]
+		[TestCase("maui-blazor", "Release", "2.0", "2")]
+		[TestCase("maui-blazor", "Release", "0.3", "3")]
 		public void BuildWithDifferentVersionNumber(string id, string config, string display, string version)
 		{
 			var projectDir = TestDirectory;
@@ -428,9 +410,9 @@ namespace Microsoft.Maui.IntegrationTests
 				$"Project {Path.GetFileName(projectFile)} failed to build. Check test output/attachments for errors.");
 		}
 
-		//[Test]
-		//[TestCase("maui-blazor", "Debug", DotNetCurrent)]
-		//[TestCase("maui-blazor", "Release", DotNetCurrent)]
+		[Test]
+		[TestCase("maui-blazor", "Debug", DotNetCurrent)]
+		[TestCase("maui-blazor", "Release", DotNetCurrent)]
 		public void CheckEntitlementsForMauiBlazorOnMacCatalyst(string id, string config, string framework)
 		{
 			if (TestEnvironment.IsWindows)
@@ -460,7 +442,7 @@ namespace Microsoft.Maui.IntegrationTests
 			CollectionAssert.AreEqual(expectedEntitlements, foundEntitlements, "Entitlements missing from executable.");
 		}
 
-		//[Test]
+		[Test]
 		public void BuildHandlesBadFilesInImages()
 		{
 			var projectDir = TestDirectory;


### PR DESCRIPTION
### Summary
There is a bug where certain characters (in this case `&`) which are not valid in MSBuild/XML are being used as the `<ApplicationTitle>` in the `maui-mobile` template. To fix this, I made `<ApplicationTitle>` use a custom symbol instead of the default name parameter. This symbol uses **xmlEncode** to allow it to work properly in the .csproj file.

### Issues Fixed
Fixes [AB#2045293](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/2045293)

### Before/After
#### Before (using the project name `Cats&Dogs`):
![image](https://github.com/dotnet/maui/assets/17788297/a94abf66-a773-402b-a72b-175d7e7bcd76)

#### After (using the project name `Cats&Dogs2`):
![image](https://github.com/dotnet/maui/assets/17788297/d43900eb-418d-42a3-9751-ab8267920cad)


Fixes #21090