### PR TITLE
[ios/catalyst] fix memory leak in modal pages

### DIFF
--- a/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
+++ b/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
@@ -63,6 +63,33 @@ public class MemoryTests : ControlsHandlerTestBase
 		});
 	}
 
+	[Fact("Page Does Not Leak")]
+	public async Task PageDoesNotLeak()
+	{
+		SetupBuilder();
+
+		WeakReference viewReference = null;
+		WeakReference handlerReference = null;
+		WeakReference platformViewReference = null;
+
+		var navPage = new NavigationPage(new ContentPage { Title = "Page 1" });
+
+		await CreateHandlerAndAddToWindow(new Window(navPage), async () =>
+		{
+			var page = new ContentPage { Content = new Label() };
+			
+			await navPage.Navigation.PushModalAsync(page);
+
+			viewReference = new WeakReference(page);
+			handlerReference = new WeakReference(page.Handler);
+			platformViewReference = new WeakReference(page.Handler.PlatformView);
+
+			await navPage.Navigation.PopModalAsync();
+		});
+
+		await AssertionExtensions.WaitForGC(viewReference, handlerReference, platformViewReference);
+	}
+
 	[Theory("Handler Does Not Leak")]
 	[InlineData(typeof(ActivityIndicator))]
 	[InlineData(typeof(Border))]

--- a/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
+++ b/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
@@ -84,6 +84,8 @@ public class MemoryTests : ControlsHandlerTestBase
 			handlerReference = new WeakReference(page.Handler);
 			platformViewReference = new WeakReference(page.Handler.PlatformView);
 
+			// Windows requires Loaded event to fire before unloading
+			await Task.Delay(500);
 			await navPage.Navigation.PopModalAsync();
 		});
 

--- a/src/Core/src/Platform/iOS/ContainerViewController.cs
+++ b/src/Core/src/Platform/iOS/ContainerViewController.cs
@@ -8,8 +8,7 @@ namespace Microsoft.Maui.Platform
 {
 	public class ContainerViewController : UIViewController, IReloadHandler
 	{
-		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = "Proven safe in test: NavigationPageTests.DoesNotLeak")]
-		IElement? _view;
+		WeakReference<IElement>? _view;
 		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = "Proven safe in test: NavigationPageTests.DoesNotLeak")]
 		UIView? currentPlatformView;
 
@@ -21,7 +20,7 @@ namespace Microsoft.Maui.Platform
 
 		public IElement? CurrentView
 		{
-			get => _view;
+			get => _view?.GetTargetOrDefault();
 			set => SetView(value);
 		}
 
@@ -33,15 +32,15 @@ namespace Microsoft.Maui.Platform
 
 		void SetView(IElement? view, bool forceRefresh = false)
 		{
-			if (view == _view && !forceRefresh)
+			if (_view?.GetTargetOrDefault() is IElement existingView && view == existingView && !forceRefresh)
 				return;
 
-			_view = view;
+			_view = view is null ? null : new(view);
 
 			if (view is ITitledElement page)
 				Title = page.Title;
 
-			if (_view is IHotReloadableView ihr)
+			if (view is IHotReloadableView ihr)
 			{
 				ihr.ReloadHandler = this;
 				MauiHotReloadHelper.AddActiveView(ihr);
@@ -50,8 +49,8 @@ namespace Microsoft.Maui.Platform
 			currentPlatformView?.RemoveFromSuperview();
 			currentPlatformView = null;
 
-			if (IsViewLoaded && _view != null)
-				LoadPlatformView(_view);
+			if (IsViewLoaded && view is not null)
+				LoadPlatformView(view);
 		}
 
 		internal UIView LoadFirstView(IElement view)
@@ -63,8 +62,8 @@ namespace Microsoft.Maui.Platform
 		public override void LoadView()
 		{
 			base.LoadView();
-			if (_view != null && Context != null)
-				LoadPlatformView(_view);
+			if (CurrentView is IElement view && Context != null)
+				LoadPlatformView(view);
 		}
 
 		void LoadPlatformView(IElement view)
@@ -83,7 +82,7 @@ namespace Microsoft.Maui.Platform
 			_ = Context ?? throw new ArgumentNullException(nameof(Context));
 			_ = _view ?? throw new ArgumentNullException(nameof(view));
 
-			return _view.ToPlatform(Context);
+			return view.ToPlatform(Context);
 		}
 
 		public override void ViewDidLayoutSubviews()

--- a/src/Core/src/Platform/iOS/ContainerViewController.cs
+++ b/src/Core/src/Platform/iOS/ContainerViewController.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Maui.Platform
 
 		void SetView(IElement? view, bool forceRefresh = false)
 		{
-			if (_view?.GetTargetOrDefault() is IElement existingView && view == existingView && !forceRefresh)
+			if (CurrentView is IElement existingView && view == existingView && !forceRefresh)
 				return;
 
 			_view = view is null ? null : new(view);


### PR DESCRIPTION
Fixes: https://github.com/dotnet/maui/issues/20094
Context: https://github.com/AdamEssenmacher/iOSModalLeak.Maui

In the above sample, you can see that modal `Page`'s on iOS or Catalyst live forever after they are dismissed. I was able to reproduce this issue in a device test.

After some investigation, the `ContainerViewController` appears to have a cycle:

* `ContainerViewController` -> `IElement? _view;` -> `PageHandler` -> `ContainerViewController`

After 7d0af63c was merged, this works fine when using `NavigationPage`, but not when using modals.

It appears after solving the cycle, the `ContainerViewController` goes away as well as the `PageHandler` and the `Page`.