### PR TITLE
Make ImageSource more async-friendly

### DIFF
--- a/src/Controls/src/Core/StreamImageSource.cs
+++ b/src/Controls/src/Core/StreamImageSource.cs
@@ -35,17 +35,17 @@ namespace Microsoft.Maui.Controls
 			if (IsEmpty)
 				return null;
 
-			OnLoadingStarted();
+			await OnLoadingStarted();
 			userToken.Register(CancellationTokenSource.Cancel);
 			Stream stream = null;
 			try
 			{
 				stream = await Stream(CancellationTokenSource.Token);
-				OnLoadingCompleted(false);
+				await OnLoadingCompleted(false);
 			}
 			catch (OperationCanceledException)
 			{
-				OnLoadingCompleted(true);
+				await OnLoadingCompleted(true);
 				throw;
 			}
 			return stream;

--- a/src/Controls/src/Core/UriImageSource.cs
+++ b/src/Controls/src/Core/UriImageSource.cs
@@ -56,18 +56,18 @@ namespace Microsoft.Maui.Controls
 			if (IsEmpty)
 				return null;
 
-			OnLoadingStarted();
+			await OnLoadingStarted();
 			userToken.Register(CancellationTokenSource.Cancel);
 			Stream stream;
 
 			try
 			{
 				stream = await GetStreamAsync(Uri, CancellationTokenSource.Token);
-				OnLoadingCompleted(false);
+				await OnLoadingCompleted(false);
 			}
 			catch (OperationCanceledException)
 			{
-				OnLoadingCompleted(true);
+				await OnLoadingCompleted(true);
 				throw;
 			}
 			catch (Exception ex)


### PR DESCRIPTION
If SemaphoreSlim is used instead of locks, then the stream-based derived types of ImageSource can be more async-friendly.

These derived types are downloading image data from elsewhere, and that data is likely to take some significant time. Thus, the more async-friendly approach makes sense.

This seems most likely to help when the same ImageSource is being referenced in multiple places, which is the current purpose of the locks.