### PR TITLE
[Android] Flyout Page - support for a custom flyout icon

### DIFF
--- a/src/Controls/src/Core/FlyoutPage/FlyoutPage.cs
+++ b/src/Controls/src/Core/FlyoutPage/FlyoutPage.cs
@@ -352,6 +352,7 @@ namespace Microsoft.Maui.Controls
 
 		IView IFlyoutView.Flyout => this.Flyout;
 		IView IFlyoutView.Detail => this.Detail;
+		IImageSource IFlyoutView.FlyoutIcon => this.Flyout.IconImageSource;
 
 		Maui.FlyoutBehavior IFlyoutView.FlyoutBehavior
 		{

--- a/src/Controls/src/Core/Shell/Shell.cs
+++ b/src/Controls/src/Core/Shell/Shell.cs
@@ -1983,6 +1983,7 @@ namespace Microsoft.Maui.Controls
 
 		IView IFlyoutView.Flyout => this.FlyoutContentView;
 		IView IFlyoutView.Detail => null;
+		IImageSource IFlyoutView.FlyoutIcon => IconImageSource;
 
 		bool IFlyoutView.IsPresented { get => FlyoutIsPresented; set => FlyoutIsPresented = value; }
 

--- a/src/Core/src/Core/IFlyoutView.cs
+++ b/src/Core/src/Core/IFlyoutView.cs
@@ -12,6 +12,11 @@
 		IView Flyout { get; }
 
 		/// <summary>
+		///  Gets the flyout custom icon.
+		/// </summary>
+		IImageSource FlyoutIcon { get; }
+
+		/// <summary>
 		/// Gets the detail view.
 		/// </summary>
 		IView Detail { get; }

--- a/src/Core/src/Handlers/FlyoutView/FlyoutViewHandler.Android.cs
+++ b/src/Core/src/Handlers/FlyoutView/FlyoutViewHandler.Android.cs
@@ -364,6 +364,7 @@ namespace Microsoft.Maui.Handlers
 				te.Toolbar?.Handler is ToolbarHandler th)
 			{
 				th.SetupWithDrawerLayout(platformHandler.DrawerLayout);
+				th.UpdateToolbarIcon(view.FlyoutIcon);
 			}
 		}
 

--- a/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -23,6 +23,7 @@ Microsoft.Maui.HybridWebViewRawMessage.HybridWebViewRawMessage() -> void
 Microsoft.Maui.HybridWebViewRawMessage.Message.get -> string?
 Microsoft.Maui.HybridWebViewRawMessage.Message.set -> void
 Microsoft.Maui.IApplication.ActivateWindow(Microsoft.Maui.IWindow! window) -> void
+Microsoft.Maui.IFlyoutView.FlyoutIcon.get -> Microsoft.Maui.IImageSource!
 Microsoft.Maui.IHybridWebView
 Microsoft.Maui.IHybridWebView.DefaultFile.get -> string?
 Microsoft.Maui.IHybridWebView.EvaluateJavaScriptAsync(string! script) -> System.Threading.Tasks.Task<string?>!

--- a/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -23,6 +23,7 @@ Microsoft.Maui.HybridWebViewRawMessage.HybridWebViewRawMessage() -> void
 Microsoft.Maui.HybridWebViewRawMessage.Message.get -> string?
 Microsoft.Maui.HybridWebViewRawMessage.Message.set -> void
 Microsoft.Maui.IApplication.ActivateWindow(Microsoft.Maui.IWindow! window) -> void
+Microsoft.Maui.IFlyoutView.FlyoutIcon.get -> Microsoft.Maui.IImageSource!
 Microsoft.Maui.IHybridWebView
 Microsoft.Maui.IHybridWebView.DefaultFile.get -> string?
 Microsoft.Maui.IHybridWebView.EvaluateJavaScriptAsync(string! script) -> System.Threading.Tasks.Task<string?>!

--- a/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -23,6 +23,7 @@ Microsoft.Maui.HybridWebViewRawMessage.HybridWebViewRawMessage() -> void
 Microsoft.Maui.HybridWebViewRawMessage.Message.get -> string?
 Microsoft.Maui.HybridWebViewRawMessage.Message.set -> void
 Microsoft.Maui.IApplication.ActivateWindow(Microsoft.Maui.IWindow! window) -> void
+Microsoft.Maui.IFlyoutView.FlyoutIcon.get -> Microsoft.Maui.IImageSource!
 Microsoft.Maui.IHybridWebView
 Microsoft.Maui.IHybridWebView.DefaultFile.get -> string?
 Microsoft.Maui.IHybridWebView.EvaluateJavaScriptAsync(string! script) -> System.Threading.Tasks.Task<string?>!

--- a/src/Core/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -23,6 +23,7 @@ Microsoft.Maui.HybridWebViewRawMessage.HybridWebViewRawMessage() -> void
 Microsoft.Maui.HybridWebViewRawMessage.Message.get -> string?
 Microsoft.Maui.HybridWebViewRawMessage.Message.set -> void
 Microsoft.Maui.IApplication.ActivateWindow(Microsoft.Maui.IWindow! window) -> void
+Microsoft.Maui.IFlyoutView.FlyoutIcon.get -> Microsoft.Maui.IImageSource!
 Microsoft.Maui.IHybridWebView
 Microsoft.Maui.IHybridWebView.DefaultFile.get -> string?
 Microsoft.Maui.IHybridWebView.EvaluateJavaScriptAsync(string! script) -> System.Threading.Tasks.Task<string?>!

--- a/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -23,6 +23,7 @@ Microsoft.Maui.HybridWebViewRawMessage.HybridWebViewRawMessage() -> void
 Microsoft.Maui.HybridWebViewRawMessage.Message.get -> string?
 Microsoft.Maui.HybridWebViewRawMessage.Message.set -> void
 Microsoft.Maui.IApplication.ActivateWindow(Microsoft.Maui.IWindow! window) -> void
+Microsoft.Maui.IFlyoutView.FlyoutIcon.get -> Microsoft.Maui.IImageSource!
 Microsoft.Maui.IHybridWebView
 Microsoft.Maui.IHybridWebView.DefaultFile.get -> string?
 Microsoft.Maui.IHybridWebView.EvaluateJavaScriptAsync(string! script) -> System.Threading.Tasks.Task<string?>!

--- a/src/Core/src/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -23,6 +23,7 @@ Microsoft.Maui.HybridWebViewRawMessage.HybridWebViewRawMessage() -> void
 Microsoft.Maui.HybridWebViewRawMessage.Message.get -> string?
 Microsoft.Maui.HybridWebViewRawMessage.Message.set -> void
 Microsoft.Maui.IApplication.ActivateWindow(Microsoft.Maui.IWindow! window) -> void
+Microsoft.Maui.IFlyoutView.FlyoutIcon.get -> Microsoft.Maui.IImageSource!
 Microsoft.Maui.IHybridWebView
 Microsoft.Maui.IHybridWebView.DefaultFile.get -> string?
 Microsoft.Maui.IHybridWebView.EvaluateJavaScriptAsync(string! script) -> System.Threading.Tasks.Task<string?>!

--- a/src/Core/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -23,6 +23,7 @@ Microsoft.Maui.HybridWebViewRawMessage.HybridWebViewRawMessage() -> void
 Microsoft.Maui.HybridWebViewRawMessage.Message.get -> string?
 Microsoft.Maui.HybridWebViewRawMessage.Message.set -> void
 Microsoft.Maui.IApplication.ActivateWindow(Microsoft.Maui.IWindow! window) -> void
+Microsoft.Maui.IFlyoutView.FlyoutIcon.get -> Microsoft.Maui.IImageSource!
 Microsoft.Maui.IHybridWebView
 Microsoft.Maui.IHybridWebView.DefaultFile.get -> string?
 Microsoft.Maui.IHybridWebView.EvaluateJavaScriptAsync(string! script) -> System.Threading.Tasks.Task<string?>!

--- a/src/Core/src/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -23,6 +23,7 @@ Microsoft.Maui.HybridWebViewRawMessage.HybridWebViewRawMessage() -> void
 Microsoft.Maui.HybridWebViewRawMessage.Message.get -> string?
 Microsoft.Maui.HybridWebViewRawMessage.Message.set -> void
 Microsoft.Maui.IApplication.ActivateWindow(Microsoft.Maui.IWindow! window) -> void
+Microsoft.Maui.IFlyoutView.FlyoutIcon.get -> Microsoft.Maui.IImageSource!
 Microsoft.Maui.IHybridWebView
 Microsoft.Maui.IHybridWebView.DefaultFile.get -> string?
 Microsoft.Maui.IHybridWebView.EvaluateJavaScriptAsync(string! script) -> System.Threading.Tasks.Task<string?>!


### PR DESCRIPTION
### Description of Change

When the IconImageSource property was set on the Flyout page in the mobile application, there is an inconsistency between the Android and iOS platforms. While iOS correctly displays the specified icon, Android shows a default hamburger icon instead.

Fixes https://github.com/dotnet/maui/issues/15211

```
<FlyoutPage
    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
    x:Class="Maui.Controls.Sample.MainPage"
    x:Name="Self"
    xmlns:local="clr-namespace:Maui.Controls.Sample">
    <FlyoutPage.Flyout>
        <ContentPage Title="Flyout" IconImageSource="groceries.png"/>
    </FlyoutPage.Flyout>
    <FlyoutPage.Detail>
        <NavigationPage>
            <x:Arguments>
                <local:DetailPage />
            </x:Arguments>
        </NavigationPage>
    </FlyoutPage.Detail>
</FlyoutPage>
```

|Before|After|
|--|--|
|<video src="https://github.com/dotnet/maui/assets/42434498/fe5c56d2-affb-4a53-ad6e-7230db5710e8" width="300px"/>|<video src="https://github.com/dotnet/maui/assets/42434498/7ae86018-a6c7-4470-9415-ebacfca7596f" width="300px"/>|