### PR TITLE
[Controls] Enforce CA1507 - use nameof() where possible

### DIFF
--- a/src/Controls/src/Core/.editorconfig
+++ b/src/Controls/src/Core/.editorconfig
@@ -1,0 +1,2 @@
+[*.cs]
+dotnet_diagnostic.CA1507.severity = error

--- a/src/Controls/src/Core/ActivityIndicator/ActivityIndicator.cs
+++ b/src/Controls/src/Core/ActivityIndicator/ActivityIndicator.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Maui.Controls
 	public partial class ActivityIndicator : View, IColorElement, IElementConfiguration<ActivityIndicator>, IActivityIndicator
 	{
 		/// <summary>Bindable property for <see cref="IsRunning"/>.</summary>
-		public static readonly BindableProperty IsRunningProperty = BindableProperty.Create("IsRunning", typeof(bool), typeof(ActivityIndicator), default(bool));
+		public static readonly BindableProperty IsRunningProperty = BindableProperty.Create(nameof(IsRunning), typeof(bool), typeof(ActivityIndicator), default(bool));
 
 		/// <summary>Bindable property for <see cref="Color"/>.</summary>
 		public static readonly BindableProperty ColorProperty = ColorElement.ColorProperty;

--- a/src/Controls/src/Core/Animation.cs
+++ b/src/Controls/src/Core/Animation.cs
@@ -45,10 +45,10 @@ namespace Microsoft.Maui.Controls
 		public void Add(double beginAt, double finishAt, Animation animation)
 		{
 			if (beginAt < 0 || beginAt > 1)
-				throw new ArgumentOutOfRangeException("beginAt");
+				throw new ArgumentOutOfRangeException(nameof(beginAt));
 
 			if (finishAt < 0 || finishAt > 1)
-				throw new ArgumentOutOfRangeException("finishAt");
+				throw new ArgumentOutOfRangeException(nameof(finishAt));
 
 			if (finishAt <= beginAt)
 				throw new ArgumentException("finishAt must be greater than beginAt");

--- a/src/Controls/src/Core/Cells/Cell.cs
+++ b/src/Controls/src/Core/Cells/Cell.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Maui.Controls
 		/// <include file="../../../docs/Microsoft.Maui.Controls/Cell.xml" path="//Member[@MemberName='DefaultCellHeight']/Docs/*" />
 		public const int DefaultCellHeight = 40;
 		/// <summary>Bindable property for <see cref="IsEnabled"/>.</summary>
-		public static readonly BindableProperty IsEnabledProperty = BindableProperty.Create("IsEnabled", typeof(bool), typeof(Cell), true, propertyChanged: OnIsEnabledPropertyChanged);
+		public static readonly BindableProperty IsEnabledProperty = BindableProperty.Create(nameof(IsEnabled), typeof(bool), typeof(Cell), true, propertyChanged: OnIsEnabledPropertyChanged);
 
 		ObservableCollection<MenuItem> _contextActions;
 		List<MenuItem> _currentContextActions;
@@ -116,11 +116,11 @@ namespace Microsoft.Maui.Controls
 				if (_height == value)
 					return;
 
-				OnPropertyChanging("Height");
-				OnPropertyChanging("RenderHeight");
+				OnPropertyChanging(nameof(Height));
+				OnPropertyChanging(nameof(RenderHeight));
 				_height = value;
-				OnPropertyChanged("Height");
-				OnPropertyChanged("RenderHeight");
+				OnPropertyChanged(nameof(Height));
+				OnPropertyChanged(nameof(RenderHeight));
 			}
 		}
 
@@ -265,7 +265,7 @@ namespace Microsoft.Maui.Controls
 
 			_currentContextActions = new List<MenuItem>(_contextActions);
 
-			OnPropertyChanged("HasContextActions");
+			OnPropertyChanged(nameof(HasContextActions));
 		}
 
 		async void OnForceUpdateSizeRequested()
@@ -279,7 +279,7 @@ namespace Microsoft.Maui.Controls
 
 		static void OnIsEnabledPropertyChanged(BindableObject bindable, object oldvalue, object newvalue)
 		{
-			(bindable as Cell).OnPropertyChanged("HasContextActions");
+			(bindable as Cell).OnPropertyChanged(nameof(HasContextActions));
 		}
 
 		void OnParentPropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -287,7 +287,7 @@ namespace Microsoft.Maui.Controls
 			// Technically we might be raising this even if it didn't change, but I'm taking the bet that
 			// its uncommon enough that we don't want to take the penalty of N GetValue calls to verify.
 			if (e.PropertyName == "RowHeight")
-				OnPropertyChanged("RenderHeight");
+				OnPropertyChanged(nameof(RenderHeight));
 			else if (e.PropertyName == VisualElement.FlowDirectionProperty.PropertyName ||
 					 e.PropertyName == VisualElement.VisualProperty.PropertyName)
 				PropertyPropagationController.PropagatePropertyChanged(e.PropertyName);
@@ -296,7 +296,7 @@ namespace Microsoft.Maui.Controls
 		void OnParentPropertyChanging(object sender, PropertyChangingEventArgs e)
 		{
 			if (e.PropertyName == "RowHeight")
-				OnPropertyChanging("RenderHeight");
+				OnPropertyChanging(nameof(RenderHeight));
 		}
 
 #if ANDROID

--- a/src/Controls/src/Core/Cells/EntryCell.cs
+++ b/src/Controls/src/Core/Cells/EntryCell.cs
@@ -9,19 +9,19 @@ namespace Microsoft.Maui.Controls
 	public class EntryCell : Cell, ITextAlignmentElement, IEntryCellController, ITextAlignment
 	{
 		/// <summary>Bindable property for <see cref="Text"/>.</summary>
-		public static readonly BindableProperty TextProperty = BindableProperty.Create("Text", typeof(string), typeof(EntryCell), null, BindingMode.TwoWay);
+		public static readonly BindableProperty TextProperty = BindableProperty.Create(nameof(Text), typeof(string), typeof(EntryCell), null, BindingMode.TwoWay);
 
 		/// <summary>Bindable property for <see cref="Label"/>.</summary>
-		public static readonly BindableProperty LabelProperty = BindableProperty.Create("Label", typeof(string), typeof(EntryCell), null);
+		public static readonly BindableProperty LabelProperty = BindableProperty.Create(nameof(Label), typeof(string), typeof(EntryCell), null);
 
 		/// <summary>Bindable property for <see cref="Placeholder"/>.</summary>
-		public static readonly BindableProperty PlaceholderProperty = BindableProperty.Create("Placeholder", typeof(string), typeof(EntryCell), null);
+		public static readonly BindableProperty PlaceholderProperty = BindableProperty.Create(nameof(Placeholder), typeof(string), typeof(EntryCell), null);
 
 		/// <summary>Bindable property for <see cref="LabelColor"/>.</summary>
-		public static readonly BindableProperty LabelColorProperty = BindableProperty.Create("LabelColor", typeof(Color), typeof(EntryCell), null);
+		public static readonly BindableProperty LabelColorProperty = BindableProperty.Create(nameof(LabelColor), typeof(Color), typeof(EntryCell), null);
 
 		/// <summary>Bindable property for <see cref="Keyboard"/>.</summary>
-		public static readonly BindableProperty KeyboardProperty = BindableProperty.Create("Keyboard", typeof(Keyboard), typeof(EntryCell), Keyboard.Default);
+		public static readonly BindableProperty KeyboardProperty = BindableProperty.Create(nameof(Keyboard), typeof(Keyboard), typeof(EntryCell), Keyboard.Default);
 
 		/// <summary>Bindable property for <see cref="HorizontalTextAlignment"/>.</summary>
 		public static readonly BindableProperty HorizontalTextAlignmentProperty = TextAlignmentElement.HorizontalTextAlignmentProperty;

--- a/src/Controls/src/Core/Cells/ImageCell.cs
+++ b/src/Controls/src/Core/Cells/ImageCell.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Maui.Controls
 	public class ImageCell : TextCell
 	{
 		/// <summary>Bindable property for <see cref="ImageSource"/>.</summary>
-		public static readonly BindableProperty ImageSourceProperty = BindableProperty.Create("ImageSource", typeof(ImageSource), typeof(ImageCell), null,
+		public static readonly BindableProperty ImageSourceProperty = BindableProperty.Create(nameof(ImageSource), typeof(ImageSource), typeof(ImageCell), null,
 			propertyChanging: (bindable, oldvalue, newvalue) => ((ImageCell)bindable).OnSourcePropertyChanging((ImageSource)oldvalue, (ImageSource)newvalue),
 			propertyChanged: (bindable, oldvalue, newvalue) => ((ImageCell)bindable).OnSourcePropertyChanged((ImageSource)oldvalue, (ImageSource)newvalue));
 

--- a/src/Controls/src/Core/Cells/SwitchCell.cs
+++ b/src/Controls/src/Core/Cells/SwitchCell.cs
@@ -8,14 +8,14 @@ namespace Microsoft.Maui.Controls
 	public class SwitchCell : Cell
 	{
 		/// <summary>Bindable property for <see cref="On"/>.</summary>
-		public static readonly BindableProperty OnProperty = BindableProperty.Create("On", typeof(bool), typeof(SwitchCell), false, propertyChanged: (obj, oldValue, newValue) =>
+		public static readonly BindableProperty OnProperty = BindableProperty.Create(nameof(On), typeof(bool), typeof(SwitchCell), false, propertyChanged: (obj, oldValue, newValue) =>
 		{
 			var switchCell = (SwitchCell)obj;
 			switchCell.OnChanged?.Invoke(obj, new ToggledEventArgs((bool)newValue));
 		}, defaultBindingMode: BindingMode.TwoWay);
 
 		/// <summary>Bindable property for <see cref="Text"/>.</summary>
-		public static readonly BindableProperty TextProperty = BindableProperty.Create("Text", typeof(string), typeof(SwitchCell), default(string));
+		public static readonly BindableProperty TextProperty = BindableProperty.Create(nameof(Text), typeof(string), typeof(SwitchCell), default(string));
 
 		/// <summary>Bindable property for <see cref="OnColor"/>.</summary>
 		public static readonly BindableProperty OnColorProperty = BindableProperty.Create(nameof(OnColor), typeof(Color), typeof(SwitchCell), null);

--- a/src/Controls/src/Core/Cells/TextCell.cs
+++ b/src/Controls/src/Core/Cells/TextCell.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Maui.Controls
 	public class TextCell : Cell
 	{
 		/// <summary>Bindable property for <see cref="Command"/>.</summary>
-		public static readonly BindableProperty CommandProperty = BindableProperty.Create("Command", typeof(ICommand), typeof(TextCell), default(ICommand),
+		public static readonly BindableProperty CommandProperty = BindableProperty.Create(nameof(Command), typeof(ICommand), typeof(TextCell), default(ICommand),
 			propertyChanging: (bindable, oldvalue, newvalue) =>
 			{
 				var textCell = (TextCell)bindable;
@@ -28,7 +28,7 @@ namespace Microsoft.Maui.Controls
 			});
 
 		/// <summary>Bindable property for <see cref="CommandParameter"/>.</summary>
-		public static readonly BindableProperty CommandParameterProperty = BindableProperty.Create("CommandParameter", typeof(object), typeof(TextCell), default(object),
+		public static readonly BindableProperty CommandParameterProperty = BindableProperty.Create(nameof(CommandParameter), typeof(object), typeof(TextCell), default(object),
 			propertyChanged: (bindable, oldvalue, newvalue) =>
 			{
 				var textCell = (TextCell)bindable;
@@ -39,16 +39,16 @@ namespace Microsoft.Maui.Controls
 			});
 
 		/// <summary>Bindable property for <see cref="Text"/>.</summary>
-		public static readonly BindableProperty TextProperty = BindableProperty.Create("Text", typeof(string), typeof(TextCell), default(string));
+		public static readonly BindableProperty TextProperty = BindableProperty.Create(nameof(Text), typeof(string), typeof(TextCell), default(string));
 
 		/// <summary>Bindable property for <see cref="Detail"/>.</summary>
-		public static readonly BindableProperty DetailProperty = BindableProperty.Create("Detail", typeof(string), typeof(TextCell), default(string));
+		public static readonly BindableProperty DetailProperty = BindableProperty.Create(nameof(Detail), typeof(string), typeof(TextCell), default(string));
 
 		/// <summary>Bindable property for <see cref="TextColor"/>.</summary>
-		public static readonly BindableProperty TextColorProperty = BindableProperty.Create("TextColor", typeof(Color), typeof(TextCell), null);
+		public static readonly BindableProperty TextColorProperty = BindableProperty.Create(nameof(TextColor), typeof(Color), typeof(TextCell), null);
 
 		/// <summary>Bindable property for <see cref="DetailColor"/>.</summary>
-		public static readonly BindableProperty DetailColorProperty = BindableProperty.Create("DetailColor", typeof(Color), typeof(TextCell), null);
+		public static readonly BindableProperty DetailColorProperty = BindableProperty.Create(nameof(DetailColor), typeof(Color), typeof(TextCell), null);
 
 		/// <include file="../../../docs/Microsoft.Maui.Controls/TextCell.xml" path="//Member[@MemberName='Command']/Docs/*" />
 		public ICommand Command

--- a/src/Controls/src/Core/Compatibility/Android/FontNamedSizeService.cs
+++ b/src/Controls/src/Core/Compatibility/Android/FontNamedSizeService.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 					case NamedSize.Title:
 						return 24;
 					default:
-						throw new ArgumentOutOfRangeException("size");
+						throw new ArgumentOutOfRangeException(nameof(size));
 				}
 			}
 			switch (size)
@@ -101,7 +101,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 				case NamedSize.Title:
 					return 24;
 				default:
-					throw new ArgumentOutOfRangeException("size");
+					throw new ArgumentOutOfRangeException(nameof(size));
 			}
 		}
 

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/CellAdapter.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/CellAdapter.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		protected CellAdapter(Context context)
 		{
 			if (context == null)
-				throw new ArgumentNullException("context");
+				throw new ArgumentNullException(nameof(context));
 
 			_context = context;
 		}

--- a/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
@@ -599,9 +599,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		void InsertPageBefore(Page page, Page before)
 		{
 			if (before.Handler is not IPlatformViewHandler nvh)
-				throw new ArgumentNullException("before");
+				throw new ArgumentNullException(nameof(before));
 			if (page == null)
-				throw new ArgumentNullException("page");
+				throw new ArgumentNullException(nameof(page));
 
 			var pageContainer = CreateViewControllerForPage(page);
 			var target = nvh.ViewController.ParentViewController;
@@ -641,7 +641,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		void RemovePage(Page page)
 		{
 			if (page?.Handler is not IPlatformViewHandler nvh)
-				throw new ArgumentNullException("page");
+				throw new ArgumentNullException(nameof(page));
 			if (page == Current)
 				throw new NotSupportedException(); // should never happen as NavPage protects against this
 

--- a/src/Controls/src/Core/Compatibility/iOS/Extensions/CellExtensions.cs
+++ b/src/Controls/src/Core/Compatibility/iOS/Extensions/CellExtensions.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 		internal static NSIndexPath GetIndexPath(this Cell self)
 		{
 			if (self == null)
-				throw new ArgumentNullException("self");
+				throw new ArgumentNullException(nameof(self));
 
 			NSIndexPath path;
 

--- a/src/Controls/src/Core/Compatibility/iOS/FontNamedSizeService.cs
+++ b/src/Controls/src/Core/Compatibility/iOS/FontNamedSizeService.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 
 #endif
 				default:
-					throw new ArgumentOutOfRangeException("size");
+					throw new ArgumentOutOfRangeException(nameof(size));
 			}
 		}
 	}

--- a/src/Controls/src/Core/ElementTemplate.cs
+++ b/src/Controls/src/Core/ElementTemplate.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Maui.Controls
 			: this()
 		{
 			if (type == null)
-				throw new ArgumentNullException("type");
+				throw new ArgumentNullException(nameof(type));
 
 			_canRecycle = true;
 			_type = type;
@@ -33,7 +33,7 @@ namespace Microsoft.Maui.Controls
 			LoadTemplate = () => Activator.CreateInstance(type);
 		}
 
-		internal ElementTemplate(Func<object> loadTemplate) : this() => LoadTemplate = loadTemplate ?? throw new ArgumentNullException("loadTemplate");
+		internal ElementTemplate(Func<object> loadTemplate) : this() => LoadTemplate = loadTemplate ?? throw new ArgumentNullException(nameof(loadTemplate));
 
 		public Func<object> LoadTemplate { get; set; }
 

--- a/src/Controls/src/Core/FileImageSource.cs
+++ b/src/Controls/src/Core/FileImageSource.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Maui.Controls
 	public sealed partial class FileImageSource : ImageSource
 	{
 		/// <summary>Bindable property for <see cref="File"/>.</summary>
-		public static readonly BindableProperty FileProperty = BindableProperty.Create("File", typeof(string), typeof(FileImageSource), default(string));
+		public static readonly BindableProperty FileProperty = BindableProperty.Create(nameof(File), typeof(string), typeof(FileImageSource), default(string));
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/FileImageSource.xml" path="//Member[@MemberName='IsEmpty']/Docs/*" />
 		public override bool IsEmpty => string.IsNullOrEmpty(File);

--- a/src/Controls/src/Core/FlyoutPage/FlyoutPage.cs
+++ b/src/Controls/src/Core/FlyoutPage/FlyoutPage.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Maui.Controls
 			set
 			{
 				if (_detail != null && value == null)
-					throw new ArgumentNullException("value", "Detail cannot be set to null once a value is set.");
+					throw new ArgumentNullException(nameof(value), "Detail cannot be set to null once a value is set.");
 
 				if (_detail == value)
 					return;
@@ -92,7 +92,7 @@ namespace Microsoft.Maui.Controls
 			set
 			{
 				if (_flyout != null && value == null)
-					throw new ArgumentNullException("value", "Flyout cannot be set to null once a value is set");
+					throw new ArgumentNullException(nameof(value), "Flyout cannot be set to null once a value is set");
 
 				if (string.IsNullOrEmpty(value.Title))
 					throw new InvalidOperationException("Title property must be set on Flyout page");

--- a/src/Controls/src/Core/FocusEventArgs.cs
+++ b/src/Controls/src/Core/FocusEventArgs.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Maui.Controls
 		public FocusEventArgs(VisualElement visualElement, bool isFocused)
 		{
 			if (visualElement == null)
-				throw new ArgumentNullException("visualElement");
+				throw new ArgumentNullException(nameof(visualElement));
 
 			VisualElement = visualElement;
 			IsFocused = isFocused;

--- a/src/Controls/src/Core/FontImageSource.cs
+++ b/src/Controls/src/Core/FontImageSource.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Maui.Controls
 
 		/// <summary>Bindable property for <see cref="FontAutoScalingEnabled"/>.</summary>
 		public static readonly BindableProperty FontAutoScalingEnabledProperty =
-			BindableProperty.Create("FontAutoScalingEnabled", typeof(bool), typeof(FontImageSource), false,
+			BindableProperty.Create(nameof(FontAutoScalingEnabled), typeof(bool), typeof(FontImageSource), false,
 				propertyChanged: (b, o, n) => ((FontImageSource)b).OnSourceChanged());
 
 		public bool FontAutoScalingEnabled

--- a/src/Controls/src/Core/Frame/Frame.cs
+++ b/src/Controls/src/Core/Frame/Frame.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Maui.Controls
 		public static readonly BindableProperty BorderColorProperty = BorderElement.BorderColorProperty;
 
 		/// <summary>Bindable property for <see cref="HasShadow"/>.</summary>
-		public static readonly BindableProperty HasShadowProperty = BindableProperty.Create("HasShadow", typeof(bool), typeof(Frame), true);
+		public static readonly BindableProperty HasShadowProperty = BindableProperty.Create(nameof(HasShadow), typeof(bool), typeof(Frame), true);
 
 		/// <summary>Bindable property for <see cref="CornerRadius"/>.</summary>
 		public static readonly BindableProperty CornerRadiusProperty = BindableProperty.Create(nameof(CornerRadius), typeof(float), typeof(Frame), -1.0f,

--- a/src/Controls/src/Core/HtmlWebViewSource.cs
+++ b/src/Controls/src/Core/HtmlWebViewSource.cs
@@ -7,11 +7,11 @@ namespace Microsoft.Maui.Controls
 	public class HtmlWebViewSource : WebViewSource
 	{
 		/// <summary>Bindable property for <see cref="Html"/>.</summary>
-		public static readonly BindableProperty HtmlProperty = BindableProperty.Create("Html", typeof(string), typeof(HtmlWebViewSource), default(string),
+		public static readonly BindableProperty HtmlProperty = BindableProperty.Create(nameof(Html), typeof(string), typeof(HtmlWebViewSource), default(string),
 			propertyChanged: (bindable, oldvalue, newvalue) => ((HtmlWebViewSource)bindable).OnSourceChanged());
 
 		/// <summary>Bindable property for <see cref="BaseUrl"/>.</summary>
-		public static readonly BindableProperty BaseUrlProperty = BindableProperty.Create("BaseUrl", typeof(string), typeof(HtmlWebViewSource), default(string),
+		public static readonly BindableProperty BaseUrlProperty = BindableProperty.Create(nameof(BaseUrl), typeof(string), typeof(HtmlWebViewSource), default(string),
 			propertyChanged: (bindable, oldvalue, newvalue) => ((HtmlWebViewSource)bindable).OnSourceChanged());
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/HtmlWebViewSource.xml" path="//Member[@MemberName='BaseUrl']/Docs/*" />

--- a/src/Controls/src/Core/Interactivity/AttachedCollection.cs
+++ b/src/Controls/src/Core/Interactivity/AttachedCollection.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Maui.Controls
 		public void AttachTo(BindableObject bindable)
 		{
 			if (bindable == null)
-				throw new ArgumentNullException("bindable");
+				throw new ArgumentNullException(nameof(bindable));
 			OnAttachedTo(bindable);
 		}
 

--- a/src/Controls/src/Core/Interactivity/TriggerAction.cs
+++ b/src/Controls/src/Core/Interactivity/TriggerAction.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Maui.Controls
 		internal TriggerAction(Type associatedType)
 		{
 			if (associatedType == null)
-				throw new ArgumentNullException("associatedType");
+				throw new ArgumentNullException(nameof(associatedType));
 			AssociatedType = associatedType;
 		}
 

--- a/src/Controls/src/Core/Interactivity/TriggerBase.cs
+++ b/src/Controls/src/Core/Interactivity/TriggerBase.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Maui.Controls
 			IsSealed = true;
 
 			if (bindable == null)
-				throw new ArgumentNullException("bindable");
+				throw new ArgumentNullException(nameof(bindable));
 			if (!TargetType.IsInstanceOfType(bindable))
 				throw new InvalidOperationException("bindable not an instance of AssociatedType");
 			OnAttachedTo(bindable);
@@ -76,7 +76,7 @@ namespace Microsoft.Maui.Controls
 		void IAttachedObject.DetachFrom(BindableObject bindable)
 		{
 			if (bindable == null)
-				throw new ArgumentNullException("bindable");
+				throw new ArgumentNullException(nameof(bindable));
 			OnDetachingFrom(bindable);
 		}
 

--- a/src/Controls/src/Core/Internals/NotifyCollectionChangedEventArgsExtensions.cs
+++ b/src/Controls/src/Core/Internals/NotifyCollectionChangedEventArgsExtensions.cs
@@ -25,13 +25,13 @@ namespace Microsoft.Maui.Controls.Internals
 		public static NotifyCollectionChangedAction Apply(this NotifyCollectionChangedEventArgs self, Action<object, int, bool> insert, Action<object, int> removeAt, Action reset)
 		{
 			if (self == null)
-				throw new ArgumentNullException("self");
+				throw new ArgumentNullException(nameof(self));
 			if (reset == null)
-				throw new ArgumentNullException("reset");
+				throw new ArgumentNullException(nameof(reset));
 			if (insert == null)
-				throw new ArgumentNullException("insert");
+				throw new ArgumentNullException(nameof(insert));
 			if (removeAt == null)
-				throw new ArgumentNullException("removeAt");
+				throw new ArgumentNullException(nameof(removeAt));
 
 			switch (self.Action)
 			{

--- a/src/Controls/src/Core/Items/ReorderableItemsView.cs
+++ b/src/Controls/src/Core/Items/ReorderableItemsView.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Maui.Controls
 		public event EventHandler ReorderCompleted;
 
 		/// <summary>Bindable property for <see cref="CanMixGroups"/>.</summary>
-		public static readonly BindableProperty CanMixGroupsProperty = BindableProperty.Create("CanMixGroups", typeof(bool), typeof(ReorderableItemsView), false);
+		public static readonly BindableProperty CanMixGroupsProperty = BindableProperty.Create(nameof(CanMixGroups), typeof(bool), typeof(ReorderableItemsView), false);
 		public bool CanMixGroups
 		{
 			get { return (bool)GetValue(CanMixGroupsProperty); }
@@ -17,7 +17,7 @@ namespace Microsoft.Maui.Controls
 		}
 
 		/// <summary>Bindable property for <see cref="CanReorderItems"/>.</summary>
-		public static readonly BindableProperty CanReorderItemsProperty = BindableProperty.Create("CanReorderItems", typeof(bool), typeof(ReorderableItemsView), false);
+		public static readonly BindableProperty CanReorderItemsProperty = BindableProperty.Create(nameof(CanReorderItems), typeof(bool), typeof(ReorderableItemsView), false);
 		public bool CanReorderItems
 		{
 			get { return (bool)GetValue(CanReorderItemsProperty); }

--- a/src/Controls/src/Core/Label/Label.cs
+++ b/src/Controls/src/Core/Label/Label.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Maui.Controls
 		public static readonly BindableProperty HorizontalTextAlignmentProperty = TextAlignmentElement.HorizontalTextAlignmentProperty;
 
 		/// <summary>Bindable property for <see cref="VerticalTextAlignment"/>.</summary>
-		public static readonly BindableProperty VerticalTextAlignmentProperty = BindableProperty.Create("VerticalTextAlignment", typeof(TextAlignment), typeof(Label), TextAlignment.Start);
+		public static readonly BindableProperty VerticalTextAlignmentProperty = BindableProperty.Create(nameof(VerticalTextAlignment), typeof(TextAlignment), typeof(Label), TextAlignment.Start);
 
 		/// <summary>Bindable property for <see cref="TextColor"/>.</summary>
 		public static readonly BindableProperty TextColorProperty = TextElement.TextColorProperty;
@@ -268,7 +268,7 @@ namespace Microsoft.Maui.Controls
 
 		void OnFormattedTextChanging(object sender, PropertyChangingEventArgs e)
 		{
-			OnPropertyChanging("FormattedText");
+			OnPropertyChanging(nameof(FormattedText));
 		}
 
 		void ITextElement.OnTextTransformChanged(TextTransform oldValue, TextTransform newValue) =>
@@ -276,7 +276,7 @@ namespace Microsoft.Maui.Controls
 
 		void OnFormattedTextChanged(object sender, PropertyChangedEventArgs e)
 		{
-			OnPropertyChanged("FormattedText");
+			OnPropertyChanged(nameof(FormattedText));
 			InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
 		}
 

--- a/src/Controls/src/Core/Layout/Grid.cs
+++ b/src/Controls/src/Core/Layout/Grid.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Maui.Controls
 		readonly Dictionary<IView, GridInfo> _viewInfo = new();
 
 		/// <summary>Bindable property for <see cref="ColumnDefinitions"/>.</summary>
-		public static readonly BindableProperty ColumnDefinitionsProperty = BindableProperty.Create("ColumnDefinitions",
+		public static readonly BindableProperty ColumnDefinitionsProperty = BindableProperty.Create(nameof(ColumnDefinitions),
 			typeof(ColumnDefinitionCollection), typeof(Grid), null, validateValue: (bindable, value) => value != null,
 			propertyChanged: UpdateSizeChangedHandlers, defaultValueCreator: bindable =>
 			{
@@ -22,7 +22,7 @@ namespace Microsoft.Maui.Controls
 			});
 
 		/// <summary>Bindable property for <see cref="RowDefinitions"/>.</summary>
-		public static readonly BindableProperty RowDefinitionsProperty = BindableProperty.Create("RowDefinitions",
+		public static readonly BindableProperty RowDefinitionsProperty = BindableProperty.Create(nameof(RowDefinitions),
 			typeof(RowDefinitionCollection), typeof(Grid), null, validateValue: (bindable, value) => value != null,
 			propertyChanged: UpdateSizeChangedHandlers, defaultValueCreator: bindable =>
 			{
@@ -32,11 +32,11 @@ namespace Microsoft.Maui.Controls
 			});
 
 		/// <summary>Bindable property for <see cref="RowSpacing"/>.</summary>
-		public static readonly BindableProperty RowSpacingProperty = BindableProperty.Create("RowSpacing", typeof(double),
+		public static readonly BindableProperty RowSpacingProperty = BindableProperty.Create(nameof(RowSpacing), typeof(double),
 			typeof(Grid), 0d, propertyChanged: Invalidate);
 
 		/// <summary>Bindable property for <see cref="ColumnSpacing"/>.</summary>
-		public static readonly BindableProperty ColumnSpacingProperty = BindableProperty.Create("ColumnSpacing", typeof(double),
+		public static readonly BindableProperty ColumnSpacingProperty = BindableProperty.Create(nameof(ColumnSpacing), typeof(double),
 			typeof(Grid), 0d, propertyChanged: Invalidate);
 
 		#region Row/Column/Span Attached Properties

--- a/src/Controls/src/Core/LayoutAlignmentExtensions.cs
+++ b/src/Controls/src/Core/LayoutAlignmentExtensions.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Maui.Controls
 				case LayoutAlignment.End:
 					return 1;
 			}
-			throw new ArgumentOutOfRangeException("align");
+			throw new ArgumentOutOfRangeException(nameof(align));
 		}
 	}
 }

--- a/src/Controls/src/Core/LegacyLayouts/Grid.cs
+++ b/src/Controls/src/Core/LegacyLayouts/Grid.cs
@@ -25,15 +25,15 @@ namespace Microsoft.Maui.Controls.Compatibility
 		public static readonly BindableProperty ColumnSpanProperty = BindableProperty.CreateAttached("ColumnSpan", typeof(int), typeof(Grid), 1, validateValue: (bindable, value) => (int)value >= 1);
 
 		/// <summary>Bindable property for <see cref="RowSpacing"/>.</summary>
-		public static readonly BindableProperty RowSpacingProperty = BindableProperty.Create("RowSpacing", typeof(double), typeof(Grid), 6d,
+		public static readonly BindableProperty RowSpacingProperty = BindableProperty.Create(nameof(RowSpacing), typeof(double), typeof(Grid), 6d,
 			propertyChanged: (bindable, oldValue, newValue) => ((Grid)bindable).InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged));
 
 		/// <summary>Bindable property for <see cref="ColumnSpacing"/>.</summary>
-		public static readonly BindableProperty ColumnSpacingProperty = BindableProperty.Create("ColumnSpacing", typeof(double), typeof(Grid), 6d,
+		public static readonly BindableProperty ColumnSpacingProperty = BindableProperty.Create(nameof(ColumnSpacing), typeof(double), typeof(Grid), 6d,
 			propertyChanged: (bindable, oldValue, newValue) => ((Grid)bindable).InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged));
 
 		/// <summary>Bindable property for <see cref="ColumnDefinitions"/>.</summary>
-		public static readonly BindableProperty ColumnDefinitionsProperty = BindableProperty.Create("ColumnDefinitions", typeof(ColumnDefinitionCollection), typeof(Grid), null,
+		public static readonly BindableProperty ColumnDefinitionsProperty = BindableProperty.Create(nameof(ColumnDefinitions), typeof(ColumnDefinitionCollection), typeof(Grid), null,
 			validateValue: (bindable, value) => value != null, propertyChanged: (bindable, oldvalue, newvalue) =>
 			{
 				if (oldvalue != null)
@@ -49,7 +49,7 @@ namespace Microsoft.Maui.Controls.Compatibility
 			});
 
 		/// <summary>Bindable property for <see cref="RowDefinitions"/>.</summary>
-		public static readonly BindableProperty RowDefinitionsProperty = BindableProperty.Create("RowDefinitions", typeof(RowDefinitionCollection), typeof(Grid), null,
+		public static readonly BindableProperty RowDefinitionsProperty = BindableProperty.Create(nameof(RowDefinitions), typeof(RowDefinitionCollection), typeof(Grid), null,
 			validateValue: (bindable, value) => value != null, propertyChanged: (bindable, oldvalue, newvalue) =>
 			{
 				if (oldvalue != null)
@@ -311,24 +311,24 @@ namespace Microsoft.Maui.Controls.Compatibility
 			public void Add(View view, int left, int top)
 			{
 				if (left < 0)
-					throw new ArgumentOutOfRangeException("left");
+					throw new ArgumentOutOfRangeException(nameof(left));
 				if (top < 0)
-					throw new ArgumentOutOfRangeException("top");
+					throw new ArgumentOutOfRangeException(nameof(top));
 				Add(view, left, left + 1, top, top + 1);
 			}
 
 			public void Add(View view, int left, int right, int top, int bottom)
 			{
 				if (left < 0)
-					throw new ArgumentOutOfRangeException("left");
+					throw new ArgumentOutOfRangeException(nameof(left));
 				if (top < 0)
-					throw new ArgumentOutOfRangeException("top");
+					throw new ArgumentOutOfRangeException(nameof(top));
 				if (left >= right)
-					throw new ArgumentOutOfRangeException("right");
+					throw new ArgumentOutOfRangeException(nameof(right));
 				if (top >= bottom)
-					throw new ArgumentOutOfRangeException("bottom");
+					throw new ArgumentOutOfRangeException(nameof(bottom));
 				if (view == null)
-					throw new ArgumentNullException("view");
+					throw new ArgumentNullException(nameof(view));
 
 				SetRow(view, top);
 				SetRowSpan(view, bottom - top);
@@ -341,7 +341,7 @@ namespace Microsoft.Maui.Controls.Compatibility
 			public void AddHorizontal(IEnumerable<View> views)
 			{
 				if (views == null)
-					throw new ArgumentNullException("views");
+					throw new ArgumentNullException(nameof(views));
 
 				views.ForEach(AddHorizontal);
 			}
@@ -349,7 +349,7 @@ namespace Microsoft.Maui.Controls.Compatibility
 			public void AddHorizontal(View view)
 			{
 				if (view == null)
-					throw new ArgumentNullException("view");
+					throw new ArgumentNullException(nameof(view));
 
 				var rows = RowCount();
 				var columns = ColumnCount();
@@ -364,7 +364,7 @@ namespace Microsoft.Maui.Controls.Compatibility
 			public void AddVertical(IEnumerable<View> views)
 			{
 				if (views == null)
-					throw new ArgumentNullException("views");
+					throw new ArgumentNullException(nameof(views));
 
 				views.ForEach(AddVertical);
 			}
@@ -372,7 +372,7 @@ namespace Microsoft.Maui.Controls.Compatibility
 			public void AddVertical(View view)
 			{
 				if (view == null)
-					throw new ArgumentNullException("view");
+					throw new ArgumentNullException(nameof(view));
 
 				var rows = RowCount();
 				var columns = ColumnCount();

--- a/src/Controls/src/Core/ListProxy.cs
+++ b/src/Controls/src/Core/ListProxy.cs
@@ -131,7 +131,7 @@ namespace Microsoft.Maui.Controls
 			{
 				object value;
 				if (!TryGetValue(index, out value))
-					throw new ArgumentOutOfRangeException("index");
+					throw new ArgumentOutOfRangeException(nameof(index));
 
 				return value;
 			}

--- a/src/Controls/src/Core/ListView/ListView.cs
+++ b/src/Controls/src/Core/ListView/ListView.cs
@@ -24,53 +24,53 @@ namespace Microsoft.Maui.Controls
 		IReadOnlyList<IVisualTreeElement> IVisualTreeElement.GetVisualChildren() => _visualChildren;
 
 		/// <summary>Bindable property for <see cref="IsPullToRefreshEnabled"/>.</summary>
-		public static readonly BindableProperty IsPullToRefreshEnabledProperty = BindableProperty.Create("IsPullToRefreshEnabled", typeof(bool), typeof(ListView), false);
+		public static readonly BindableProperty IsPullToRefreshEnabledProperty = BindableProperty.Create(nameof(IsPullToRefreshEnabled), typeof(bool), typeof(ListView), false);
 
 		/// <summary>Bindable property for <see cref="IsRefreshing"/>.</summary>
-		public static readonly BindableProperty IsRefreshingProperty = BindableProperty.Create("IsRefreshing", typeof(bool), typeof(ListView), false, BindingMode.TwoWay);
+		public static readonly BindableProperty IsRefreshingProperty = BindableProperty.Create(nameof(IsRefreshing), typeof(bool), typeof(ListView), false, BindingMode.TwoWay);
 
 		/// <summary>Bindable property for <see cref="RefreshCommand"/>.</summary>
-		public static readonly BindableProperty RefreshCommandProperty = BindableProperty.Create("RefreshCommand", typeof(ICommand), typeof(ListView), null, propertyChanged: OnRefreshCommandChanged);
+		public static readonly BindableProperty RefreshCommandProperty = BindableProperty.Create(nameof(RefreshCommand), typeof(ICommand), typeof(ListView), null, propertyChanged: OnRefreshCommandChanged);
 
 		/// <summary>Bindable property for <see cref="Header"/>.</summary>
-		public static readonly BindableProperty HeaderProperty = BindableProperty.Create("Header", typeof(object), typeof(ListView), null, propertyChanged: OnHeaderChanged);
+		public static readonly BindableProperty HeaderProperty = BindableProperty.Create(nameof(Header), typeof(object), typeof(ListView), null, propertyChanged: OnHeaderChanged);
 
 		/// <summary>Bindable property for <see cref="HeaderTemplate"/>.</summary>
-		public static readonly BindableProperty HeaderTemplateProperty = BindableProperty.Create("HeaderTemplate", typeof(DataTemplate), typeof(ListView), null, propertyChanged: OnHeaderTemplateChanged,
+		public static readonly BindableProperty HeaderTemplateProperty = BindableProperty.Create(nameof(HeaderTemplate), typeof(DataTemplate), typeof(ListView), null, propertyChanged: OnHeaderTemplateChanged,
 			validateValue: ValidateHeaderFooterTemplate);
 
 		/// <summary>Bindable property for <see cref="Footer"/>.</summary>
-		public static readonly BindableProperty FooterProperty = BindableProperty.Create("Footer", typeof(object), typeof(ListView), null, propertyChanged: OnFooterChanged);
+		public static readonly BindableProperty FooterProperty = BindableProperty.Create(nameof(Footer), typeof(object), typeof(ListView), null, propertyChanged: OnFooterChanged);
 
 		/// <summary>Bindable property for <see cref="FooterTemplate"/>.</summary>
-		public static readonly BindableProperty FooterTemplateProperty = BindableProperty.Create("FooterTemplate", typeof(DataTemplate), typeof(ListView), null, propertyChanged: OnFooterTemplateChanged,
+		public static readonly BindableProperty FooterTemplateProperty = BindableProperty.Create(nameof(FooterTemplate), typeof(DataTemplate), typeof(ListView), null, propertyChanged: OnFooterTemplateChanged,
 			validateValue: ValidateHeaderFooterTemplate);
 
 		/// <summary>Bindable property for <see cref="SelectedItem"/>.</summary>
-		public static readonly BindableProperty SelectedItemProperty = BindableProperty.Create("SelectedItem", typeof(object), typeof(ListView), null, BindingMode.OneWayToSource,
+		public static readonly BindableProperty SelectedItemProperty = BindableProperty.Create(nameof(SelectedItem), typeof(object), typeof(ListView), null, BindingMode.OneWayToSource,
 			propertyChanged: OnSelectedItemChanged);
 
 		/// <summary>Bindable property for <see cref="SelectionMode"/>.</summary>
 		public static readonly BindableProperty SelectionModeProperty = BindableProperty.Create(nameof(SelectionMode), typeof(ListViewSelectionMode), typeof(ListView), ListViewSelectionMode.Single);
 
 		/// <summary>Bindable property for <see cref="HasUnevenRows"/>.</summary>
-		public static readonly BindableProperty HasUnevenRowsProperty = BindableProperty.Create("HasUnevenRows", typeof(bool), typeof(ListView), false);
+		public static readonly BindableProperty HasUnevenRowsProperty = BindableProperty.Create(nameof(HasUnevenRows), typeof(bool), typeof(ListView), false);
 
 		/// <summary>Bindable property for <see cref="RowHeight"/>.</summary>
-		public static readonly BindableProperty RowHeightProperty = BindableProperty.Create("RowHeight", typeof(int), typeof(ListView), -1);
+		public static readonly BindableProperty RowHeightProperty = BindableProperty.Create(nameof(RowHeight), typeof(int), typeof(ListView), -1);
 
 		/// <summary>Bindable property for <see cref="GroupHeaderTemplate"/>.</summary>
-		public static readonly BindableProperty GroupHeaderTemplateProperty = BindableProperty.Create("GroupHeaderTemplate", typeof(DataTemplate), typeof(ListView), null,
+		public static readonly BindableProperty GroupHeaderTemplateProperty = BindableProperty.Create(nameof(GroupHeaderTemplate), typeof(DataTemplate), typeof(ListView), null,
 			propertyChanged: OnGroupHeaderTemplateChanged);
 
 		/// <summary>Bindable property for <see cref="IsGroupingEnabled"/>.</summary>
-		public static readonly BindableProperty IsGroupingEnabledProperty = BindableProperty.Create("IsGroupingEnabled", typeof(bool), typeof(ListView), false);
+		public static readonly BindableProperty IsGroupingEnabledProperty = BindableProperty.Create(nameof(IsGroupingEnabled), typeof(bool), typeof(ListView), false);
 
 		/// <summary>Bindable property for <see cref="SeparatorVisibility"/>.</summary>
-		public static readonly BindableProperty SeparatorVisibilityProperty = BindableProperty.Create("SeparatorVisibility", typeof(SeparatorVisibility), typeof(ListView), SeparatorVisibility.Default);
+		public static readonly BindableProperty SeparatorVisibilityProperty = BindableProperty.Create(nameof(SeparatorVisibility), typeof(SeparatorVisibility), typeof(ListView), SeparatorVisibility.Default);
 
 		/// <summary>Bindable property for <see cref="SeparatorColor"/>.</summary>
-		public static readonly BindableProperty SeparatorColorProperty = BindableProperty.Create("SeparatorColor", typeof(Color), typeof(ListView), null);
+		public static readonly BindableProperty SeparatorColorProperty = BindableProperty.Create(nameof(SeparatorColor), typeof(Color), typeof(ListView), null);
 
 		/// <summary>Bindable property for <see cref="RefreshControlColor"/>.</summary>
 		public static readonly BindableProperty RefreshControlColorProperty = BindableProperty.Create(nameof(RefreshControlColor), typeof(Color), typeof(ListView), null);
@@ -384,7 +384,7 @@ namespace Microsoft.Maui.Controls
 		public void ScrollTo(object item, ScrollToPosition position, bool animated)
 		{
 			if (!Enum.IsDefined(typeof(ScrollToPosition), position))
-				throw new ArgumentException("position is not a valid ScrollToPosition", "position");
+				throw new ArgumentException("position is not a valid ScrollToPosition", nameof(position));
 
 			var args = new ScrollToRequestedEventArgs(item, position, animated);
 			if (IsPlatformEnabled)
@@ -399,7 +399,7 @@ namespace Microsoft.Maui.Controls
 			if (!IsGroupingEnabled)
 				throw new InvalidOperationException("Grouping is not enabled");
 			if (!Enum.IsDefined(typeof(ScrollToPosition), position))
-				throw new ArgumentException("position is not a valid ScrollToPosition", "position");
+				throw new ArgumentException("position is not a valid ScrollToPosition", nameof(position));
 
 			var args = new ScrollToRequestedEventArgs(item, group, position, animated);
 			if (IsPlatformEnabled)

--- a/src/Controls/src/Core/LockingSemaphore.cs
+++ b/src/Controls/src/Core/LockingSemaphore.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Maui.Controls
 		public LockingSemaphore(int initialCount)
 		{
 			if (initialCount < 0)
-				throw new ArgumentOutOfRangeException("initialCount");
+				throw new ArgumentOutOfRangeException(nameof(initialCount));
 			_currentCount = initialCount;
 		}
 

--- a/src/Controls/src/Core/MergedStyle.cs
+++ b/src/Controls/src/Core/MergedStyle.cs
@@ -152,7 +152,7 @@ namespace Microsoft.Maui.Controls
 			Type type = TargetType;
 			while (true)
 			{
-				BindableProperty implicitStyleProperty = BindableProperty.Create("ImplicitStyle", typeof(Style), typeof(NavigableElement), default(Style),
+				BindableProperty implicitStyleProperty = BindableProperty.Create(nameof(ImplicitStyle), typeof(Style), typeof(NavigableElement), default(Style),
 						propertyChanged: (bindable, oldvalue, newvalue) => OnImplicitStyleChanged());
 				_implicitStyles.Add(implicitStyleProperty);
 				Target.SetDynamicResource(implicitStyleProperty, type.FullName);
@@ -170,7 +170,7 @@ namespace Microsoft.Maui.Controls
 			_implicitStyles.Clear();
 
 			//Register the fallback
-			BindableProperty implicitStyleProperty = BindableProperty.Create("ImplicitStyle", typeof(Style), typeof(NavigableElement), default(Style),
+			BindableProperty implicitStyleProperty = BindableProperty.Create(nameof(ImplicitStyle), typeof(Style), typeof(NavigableElement), default(Style),
 						propertyChanged: (bindable, oldvalue, newvalue) => OnImplicitStyleChanged());
 			_implicitStyles.Add(implicitStyleProperty);
 			Target.SetDynamicResource(implicitStyleProperty, fallbackTypeName);

--- a/src/Controls/src/Core/MultiPage.cs
+++ b/src/Controls/src/Core/MultiPage.cs
@@ -16,13 +16,13 @@ namespace Microsoft.Maui.Controls
 	public abstract class MultiPage<[DynamicallyAccessedMembers(BindableProperty.DeclaringTypeMembers)] T> : Page, IViewContainer<T>, IPageContainer<T>, IItemsView<T>, IMultiPageController<T> where T : Page
 	{
 		/// <summary>Bindable property for <see cref="ItemsSource"/>.</summary>
-		public static readonly BindableProperty ItemsSourceProperty = BindableProperty.Create("ItemsSource", typeof(IEnumerable), typeof(MultiPage<>), null);
+		public static readonly BindableProperty ItemsSourceProperty = BindableProperty.Create(nameof(ItemsSource), typeof(IEnumerable), typeof(MultiPage<>), null);
 
 		/// <summary>Bindable property for <see cref="ItemTemplate"/>.</summary>
-		public static readonly BindableProperty ItemTemplateProperty = BindableProperty.Create("ItemTemplate", typeof(DataTemplate), typeof(MultiPage<>), null);
+		public static readonly BindableProperty ItemTemplateProperty = BindableProperty.Create(nameof(ItemTemplate), typeof(DataTemplate), typeof(MultiPage<>), null);
 
 		/// <summary>Bindable property for <see cref="SelectedItem"/>.</summary>
-		public static readonly BindableProperty SelectedItemProperty = BindableProperty.Create("SelectedItem", typeof(object), typeof(MultiPage<>), null, BindingMode.TwoWay);
+		public static readonly BindableProperty SelectedItemProperty = BindableProperty.Create(nameof(SelectedItem), typeof(object), typeof(MultiPage<>), null, BindingMode.TwoWay);
 
 		internal static readonly BindableProperty IndexProperty = BindableProperty.Create("Index", typeof(int), typeof(Page), -1);
 
@@ -178,7 +178,7 @@ namespace Microsoft.Maui.Controls
 		public static int GetIndex(T page)
 		{
 			if (page == null)
-				throw new ArgumentNullException("page");
+				throw new ArgumentNullException(nameof(page));
 
 			return (int)page.GetValue(IndexProperty);
 		}
@@ -198,7 +198,7 @@ namespace Microsoft.Maui.Controls
 		public static void SetIndex(Page page, int index)
 		{
 			if (page == null)
-				throw new ArgumentNullException("page");
+				throw new ArgumentNullException(nameof(page));
 
 			page.SetValue(IndexProperty, index);
 		}

--- a/src/Controls/src/Core/NavigationEventArgs.cs
+++ b/src/Controls/src/Core/NavigationEventArgs.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Maui.Controls
 		public NavigationEventArgs(Page page)
 		{
 			if (page == null)
-				throw new ArgumentNullException("page");
+				throw new ArgumentNullException(nameof(page));
 
 			Page = page;
 		}

--- a/src/Controls/src/Core/NavigationPage/NavigationPage.cs
+++ b/src/Controls/src/Core/NavigationPage/NavigationPage.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Maui.Controls
 		public static readonly BindableProperty TitleViewProperty = BindableProperty.CreateAttached("TitleView", typeof(View), typeof(NavigationPage), null,
 			propertyChanging: TitleViewPropertyChanging, propertyChanged: (bo, oldV, newV) => bo.AddRemoveLogicalChildren(oldV, newV));
 
-		static readonly BindablePropertyKey CurrentPagePropertyKey = BindableProperty.CreateReadOnly("CurrentPage", typeof(Page), typeof(NavigationPage), null, propertyChanged: OnCurrentPageChanged);
+		static readonly BindablePropertyKey CurrentPagePropertyKey = BindableProperty.CreateReadOnly(nameof(CurrentPage), typeof(Page), typeof(NavigationPage), null, propertyChanged: OnCurrentPageChanged);
 
 		/// <summary>Bindable property for <see cref="CurrentPage"/>.</summary>
 		public static readonly BindableProperty CurrentPageProperty = CurrentPagePropertyKey.BindableProperty;
@@ -171,7 +171,7 @@ namespace Microsoft.Maui.Controls
 		public static bool GetHasBackButton(Page page)
 		{
 			if (page == null)
-				throw new ArgumentNullException("page");
+				throw new ArgumentNullException(nameof(page));
 			return (bool)page.GetValue(HasBackButtonProperty);
 		}
 
@@ -332,7 +332,7 @@ namespace Microsoft.Maui.Controls
 		public static void SetHasBackButton(Page page, bool value)
 		{
 			if (page == null)
-				throw new ArgumentNullException("page");
+				throw new ArgumentNullException(nameof(page));
 			page.SetValue(HasBackButtonProperty, value);
 		}
 

--- a/src/Controls/src/Core/ObservableList.cs
+++ b/src/Controls/src/Core/ObservableList.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Maui.Controls
 		public void AddRange(IEnumerable<T> range)
 		{
 			if (range == null)
-				throw new ArgumentNullException("range");
+				throw new ArgumentNullException(nameof(range));
 
 			List<T> items = range.ToList();
 			int index = Items.Count;
@@ -28,9 +28,9 @@ namespace Microsoft.Maui.Controls
 		public void InsertRange(int index, IEnumerable<T> range)
 		{
 			if (index < 0 || index > Count)
-				throw new ArgumentOutOfRangeException("index");
+				throw new ArgumentOutOfRangeException(nameof(index));
 			if (range == null)
-				throw new ArgumentNullException("range");
+				throw new ArgumentNullException(nameof(range));
 
 			int originalIndex = index;
 
@@ -44,9 +44,9 @@ namespace Microsoft.Maui.Controls
 		public void Move(int oldIndex, int newIndex, int count)
 		{
 			if (oldIndex < 0 || oldIndex + count > Count)
-				throw new ArgumentOutOfRangeException("oldIndex");
+				throw new ArgumentOutOfRangeException(nameof(oldIndex));
 			if (newIndex < 0 || newIndex + count > Count)
-				throw new ArgumentOutOfRangeException("newIndex");
+				throw new ArgumentOutOfRangeException(nameof(newIndex));
 
 			var items = new List<T>(count);
 			for (var i = 0; i < count; i++)
@@ -69,7 +69,7 @@ namespace Microsoft.Maui.Controls
 		public void RemoveAt(int index, int count)
 		{
 			if (index < 0 || index + count > Count)
-				throw new ArgumentOutOfRangeException("index");
+				throw new ArgumentOutOfRangeException(nameof(index));
 
 			T[] items = Items.Skip(index).Take(count).ToArray();
 			for (int i = index; i < count; i++)
@@ -81,7 +81,7 @@ namespace Microsoft.Maui.Controls
 		public void RemoveRange(IEnumerable<T> range)
 		{
 			if (range == null)
-				throw new ArgumentNullException("range");
+				throw new ArgumentNullException(nameof(range));
 
 			List<T> items = range.ToList();
 			foreach (T item in items)
@@ -93,12 +93,12 @@ namespace Microsoft.Maui.Controls
 		public void ReplaceRange(int startIndex, IEnumerable<T> items)
 		{
 			if (items == null)
-				throw new ArgumentNullException("items");
+				throw new ArgumentNullException(nameof(items));
 
 			T[] ritems = items.ToArray();
 
 			if (startIndex < 0 || startIndex + ritems.Length > Count)
-				throw new ArgumentOutOfRangeException("startIndex");
+				throw new ArgumentOutOfRangeException(nameof(startIndex));
 
 			var oldItems = new T[ritems.Length];
 			for (var i = 0; i < ritems.Length; i++)

--- a/src/Controls/src/Core/ObservableWrapper.cs
+++ b/src/Controls/src/Core/ObservableWrapper.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Maui.Controls
 		public ObservableWrapper(ObservableCollection<TTrack> list)
 		{
 			if (list == null)
-				throw new ArgumentNullException("list");
+				throw new ArgumentNullException(nameof(list));
 
 			_list = list;
 
@@ -24,7 +24,7 @@ namespace Microsoft.Maui.Controls
 		public void Add(TRestrict item)
 		{
 			if (item == null)
-				throw new ArgumentNullException("item");
+				throw new ArgumentNullException(nameof(item));
 			if (IsReadOnly)
 				throw new NotSupportedException("The collection is read-only.");
 
@@ -88,7 +88,7 @@ namespace Microsoft.Maui.Controls
 		public bool Remove(TRestrict item)
 		{
 			if (item == null)
-				throw new ArgumentNullException("item");
+				throw new ArgumentNullException(nameof(item));
 			if (IsReadOnly)
 				throw new NotSupportedException("The collection is read-only.");
 
@@ -130,7 +130,7 @@ namespace Microsoft.Maui.Controls
 		public void Insert(int index, TRestrict item)
 		{
 			if (item == null)
-				throw new ArgumentNullException("item");
+				throw new ArgumentNullException(nameof(item));
 			if (IsReadOnly)
 				throw new NotSupportedException("The collection is read-only.");
 

--- a/src/Controls/src/Core/OrderedDictionary.cs
+++ b/src/Controls/src/Core/OrderedDictionary.cs
@@ -74,7 +74,7 @@ namespace Cadenza.Collections
 		public OrderedDictionary(ICollection<KeyValuePair<TKey, TValue>> dictionary, IEqualityComparer<TKey> equalityComparer) : this(dictionary != null ? dictionary.Count : 0, equalityComparer)
 		{
 			if (dictionary == null)
-				throw new ArgumentNullException("dictionary");
+				throw new ArgumentNullException(nameof(dictionary));
 
 			foreach (KeyValuePair<TKey, TValue> kvp in dictionary)
 				Add(kvp.Key, kvp.Value);
@@ -124,11 +124,11 @@ namespace Cadenza.Collections
 		void ICollection<KeyValuePair<TKey, TValue>>.CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex)
 		{
 			if (array == null)
-				throw new ArgumentNullException("array");
+				throw new ArgumentNullException(nameof(array));
 			if (Count > array.Length - arrayIndex)
 				throw new ArgumentException("Not enough space in array to copy");
 			if (arrayIndex < 0)
-				throw new ArgumentOutOfRangeException("arrayIndex");
+				throw new ArgumentOutOfRangeException(nameof(arrayIndex));
 
 			for (var i = 0; i < _keyOrder.Count; ++i)
 			{
@@ -296,7 +296,7 @@ namespace Cadenza.Collections
 		public int IndexOf(TKey key)
 		{
 			if (key == null)
-				throw new ArgumentNullException("key");
+				throw new ArgumentNullException(nameof(key));
 
 			return _keyOrder.IndexOf(key);
 		}
@@ -312,7 +312,7 @@ namespace Cadenza.Collections
 		public int IndexOf(TKey key, int startIndex)
 		{
 			if (key == null)
-				throw new ArgumentNullException("key");
+				throw new ArgumentNullException(nameof(key));
 
 			return _keyOrder.IndexOf(key, startIndex);
 		}
@@ -335,7 +335,7 @@ namespace Cadenza.Collections
 		public int IndexOf(TKey key, int startIndex, int count)
 		{
 			if (key == null)
-				throw new ArgumentNullException("key");
+				throw new ArgumentNullException(nameof(key));
 
 			return _keyOrder.IndexOf(key, startIndex, count);
 		}
@@ -391,11 +391,11 @@ namespace Cadenza.Collections
 			public void CopyTo(TValue[] array, int arrayIndex)
 			{
 				if (array == null)
-					throw new ArgumentNullException("array");
+					throw new ArgumentNullException(nameof(array));
 				if (Count > array.Length - arrayIndex)
 					throw new ArgumentException("Not enough space in array to copy");
 				if (arrayIndex < 0 || arrayIndex > array.Length)
-					throw new ArgumentOutOfRangeException("arrayIndex");
+					throw new ArgumentOutOfRangeException(nameof(arrayIndex));
 
 				for (var i = 0; i < _odict.Count; ++i)
 					array[arrayIndex++] = _odict[i];

--- a/src/Controls/src/Core/Page/Page.cs
+++ b/src/Controls/src/Core/Page/Page.cs
@@ -47,19 +47,19 @@ namespace Microsoft.Maui.Controls
 		/// <remarks>For internal use only. This API can be changed or removed without notice at any time.</remarks>
 		public const string ActionSheetSignalName = "Microsoft.Maui.Controls.ShowActionSheet";
 
-		internal static readonly BindableProperty IgnoresContainerAreaProperty = BindableProperty.Create("IgnoresContainerArea", typeof(bool), typeof(Page), false);
+		internal static readonly BindableProperty IgnoresContainerAreaProperty = BindableProperty.Create(nameof(IgnoresContainerArea), typeof(bool), typeof(Page), false);
 
 		/// <summary>Bindable property for <see cref="BackgroundImageSource"/>.</summary>
 		public static readonly BindableProperty BackgroundImageSourceProperty = BindableProperty.Create(nameof(BackgroundImageSource), typeof(ImageSource), typeof(Page), default(ImageSource));
 
 		/// <summary>Bindable property for <see cref="IsBusy"/>.</summary>
-		public static readonly BindableProperty IsBusyProperty = BindableProperty.Create("IsBusy", typeof(bool), typeof(Page), false, propertyChanged: (bo, o, n) => ((Page)bo).OnPageBusyChanged());
+		public static readonly BindableProperty IsBusyProperty = BindableProperty.Create(nameof(IsBusy), typeof(bool), typeof(Page), false, propertyChanged: (bo, o, n) => ((Page)bo).OnPageBusyChanged());
 
 		/// <summary>Bindable property for <see cref="Padding"/>.</summary>
 		public static readonly BindableProperty PaddingProperty = PaddingElement.PaddingProperty;
 
 		/// <summary>Bindable property for <see cref="Title"/>.</summary>
-		public static readonly BindableProperty TitleProperty = BindableProperty.Create("Title", typeof(string), typeof(Page), null);
+		public static readonly BindableProperty TitleProperty = BindableProperty.Create(nameof(Title), typeof(string), typeof(Page), null);
 
 		/// <summary>Bindable property for <see cref="IconImageSource"/>.</summary>
 		public static readonly BindableProperty IconImageSourceProperty = BindableProperty.Create(nameof(IconImageSource), typeof(ImageSource), typeof(Page), default(ImageSource));

--- a/src/Controls/src/Core/PanGestureRecognizer.cs
+++ b/src/Controls/src/Core/PanGestureRecognizer.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Maui.Controls
 		public static AutoId CurrentId { get; } = new();
 
 		/// <summary>Bindable property for <see cref="TouchPoints"/>.</summary>
-		public static readonly BindableProperty TouchPointsProperty = BindableProperty.Create("TouchPoints", typeof(int), typeof(PanGestureRecognizer), 1);
+		public static readonly BindableProperty TouchPointsProperty = BindableProperty.Create(nameof(TouchPoints), typeof(int), typeof(PanGestureRecognizer), 1);
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/PanGestureRecognizer.xml" path="//Member[@MemberName='TouchPoints']/Docs/*" />
 		public int TouchPoints

--- a/src/Controls/src/Core/Platform/Windows/Extensions/FrameworkElementExtensions.cs
+++ b/src/Controls/src/Core/Platform/Windows/Extensions/FrameworkElementExtensions.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Maui.Controls.Platform
 		public static WBrush GetForeground(this FrameworkElement element)
 		{
 			if (element == null)
-				throw new ArgumentNullException("element");
+				throw new ArgumentNullException(nameof(element));
 
 			return (WBrush)element.GetValue(GetForegroundProperty(element));
 		}
@@ -57,7 +57,7 @@ namespace Microsoft.Maui.Controls.Platform
 		public static void SetForeground(this FrameworkElement element, WBrush foregroundBrush)
 		{
 			if (element == null)
-				throw new ArgumentNullException("element");
+				throw new ArgumentNullException(nameof(element));
 
 			element.SetValue(GetForegroundProperty(element), foregroundBrush);
 		}
@@ -65,7 +65,7 @@ namespace Microsoft.Maui.Controls.Platform
 		public static void SetForeground(this FrameworkElement element, WBinding binding)
 		{
 			if (element == null)
-				throw new ArgumentNullException("element");
+				throw new ArgumentNullException(nameof(element));
 
 			element.SetBinding(GetForegroundProperty(element), binding);
 		}

--- a/src/Controls/src/Core/Platform/Windows/Extensions/VisualElementExtensions.cs
+++ b/src/Controls/src/Core/Platform/Windows/Extensions/VisualElementExtensions.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Maui.Controls.Platform
 		internal static void Cleanup(this Element self)
 		{
 			if (self == null)
-				throw new ArgumentNullException("self");
+				throw new ArgumentNullException(nameof(self));
 
 			foreach (Element element in self.Descendants())
 			{

--- a/src/Controls/src/Core/ScrollView/ScrollView.cs
+++ b/src/Controls/src/Core/ScrollView/ScrollView.cs
@@ -109,19 +109,19 @@ namespace Microsoft.Maui.Controls
 		#endregion IScrollViewController
 
 		/// <summary>Bindable property for <see cref="Orientation"/>.</summary>
-		public static readonly BindableProperty OrientationProperty = BindableProperty.Create("Orientation", typeof(ScrollOrientation), typeof(ScrollView), ScrollOrientation.Vertical);
+		public static readonly BindableProperty OrientationProperty = BindableProperty.Create(nameof(Orientation), typeof(ScrollOrientation), typeof(ScrollView), ScrollOrientation.Vertical);
 
-		static readonly BindablePropertyKey ScrollXPropertyKey = BindableProperty.CreateReadOnly("ScrollX", typeof(double), typeof(ScrollView), 0d);
+		static readonly BindablePropertyKey ScrollXPropertyKey = BindableProperty.CreateReadOnly(nameof(ScrollX), typeof(double), typeof(ScrollView), 0d);
 
 		/// <summary>Bindable property for <see cref="ScrollX"/>.</summary>
 		public static readonly BindableProperty ScrollXProperty = ScrollXPropertyKey.BindableProperty;
 
-		static readonly BindablePropertyKey ScrollYPropertyKey = BindableProperty.CreateReadOnly("ScrollY", typeof(double), typeof(ScrollView), 0d);
+		static readonly BindablePropertyKey ScrollYPropertyKey = BindableProperty.CreateReadOnly(nameof(ScrollY), typeof(double), typeof(ScrollView), 0d);
 
 		/// <summary>Bindable property for <see cref="ScrollY"/>.</summary>
 		public static readonly BindableProperty ScrollYProperty = ScrollYPropertyKey.BindableProperty;
 
-		static readonly BindablePropertyKey ContentSizePropertyKey = BindableProperty.CreateReadOnly("ContentSize", typeof(Size), typeof(ScrollView), default(Size));
+		static readonly BindablePropertyKey ContentSizePropertyKey = BindableProperty.CreateReadOnly(nameof(ContentSize), typeof(Size), typeof(ScrollView), default(Size));
 
 		/// <summary>Bindable property for <see cref="ContentSize"/>.</summary>
 		public static readonly BindableProperty ContentSizeProperty = ContentSizePropertyKey.BindableProperty;
@@ -256,13 +256,13 @@ namespace Microsoft.Maui.Controls
 				return Task.FromResult(false);
 
 			if (!Enum.IsDefined(typeof(ScrollToPosition), position))
-				throw new ArgumentException("position is not a valid ScrollToPosition", "position");
+				throw new ArgumentException("position is not a valid ScrollToPosition", nameof(position));
 
 			if (element == null)
-				throw new ArgumentNullException("element");
+				throw new ArgumentNullException(nameof(element));
 
 			if (!CheckElementBelongsToScrollViewer(element))
-				throw new ArgumentException("element does not belong to this ScrollView", "element");
+				throw new ArgumentException("element does not belong to this ScrollView", nameof(element));
 
 			var args = new ScrollToRequestedEventArgs(element, position, animated);
 			OnScrollToRequested(args);

--- a/src/Controls/src/Core/SearchBar/SearchBar.cs
+++ b/src/Controls/src/Core/SearchBar/SearchBar.cs
@@ -12,19 +12,19 @@ namespace Microsoft.Maui.Controls
 	{
 		/// <summary>Bindable property for <see cref="SearchCommand"/>.</summary>
 		public static readonly BindableProperty SearchCommandProperty = BindableProperty.Create(
-			"SearchCommand", typeof(ICommand), typeof(SearchBar), null,
+			nameof(SearchCommand), typeof(ICommand), typeof(SearchBar), null,
 			propertyChanging: CommandElement.OnCommandChanging, propertyChanged: CommandElement.OnCommandChanged);
 
 		/// <summary>Bindable property for <see cref="SearchCommandParameter"/>.</summary>
 		public static readonly BindableProperty SearchCommandParameterProperty = BindableProperty.Create(
-			"SearchCommandParameter", typeof(object), typeof(SearchBar), null,
+			nameof(SearchCommandParameter), typeof(object), typeof(SearchBar), null,
 			propertyChanged: CommandElement.OnCommandParameterChanged);
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/SearchBar.xml" path="//Member[@MemberName='TextProperty']/Docs/*" />
 		public new static readonly BindableProperty TextProperty = InputView.TextProperty;
 
 		/// <summary>Bindable property for <see cref="CancelButtonColor"/>.</summary>
-		public static readonly BindableProperty CancelButtonColorProperty = BindableProperty.Create("CancelButtonColor", typeof(Color), typeof(SearchBar), default(Color));
+		public static readonly BindableProperty CancelButtonColorProperty = BindableProperty.Create(nameof(CancelButtonColor), typeof(Color), typeof(SearchBar), default(Color));
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/SearchBar.xml" path="//Member[@MemberName='PlaceholderProperty']/Docs/*" />
 		public new static readonly BindableProperty PlaceholderProperty = InputView.PlaceholderProperty;

--- a/src/Controls/src/Core/SettersExtensions.cs
+++ b/src/Controls/src/Core/SettersExtensions.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Maui.Controls
 		public static void AddBinding(this IList<Setter> setters, BindableProperty property, Binding binding)
 		{
 			if (binding == null)
-				throw new ArgumentNullException("binding");
+				throw new ArgumentNullException(nameof(binding));
 
 			setters.Add(new Setter { Property = property, Value = binding });
 		}
@@ -27,7 +27,7 @@ namespace Microsoft.Maui.Controls
 		public static void AddDynamicResource(this IList<Setter> setters, BindableProperty property, string key)
 		{
 			if (string.IsNullOrEmpty(key))
-				throw new ArgumentNullException("key");
+				throw new ArgumentNullException(nameof(key));
 			setters.Add(new Setter { Property = property, Value = new DynamicResource(key) });
 		}
 	}

--- a/src/Controls/src/Core/Shell/NavigableElement.cs
+++ b/src/Controls/src/Core/Shell/NavigableElement.cs
@@ -11,14 +11,14 @@ namespace Microsoft.Maui.Controls
 	public class NavigableElement : Element, INavigationProxy, IStyleSelectable
 	{
 		static readonly BindablePropertyKey NavigationPropertyKey =
-			BindableProperty.CreateReadOnly("Navigation", typeof(INavigation), typeof(VisualElement), default(INavigation));
+			BindableProperty.CreateReadOnly(nameof(Navigation), typeof(INavigation), typeof(VisualElement), default(INavigation));
 
 		/// <summary>Bindable property for <see cref="Navigation"/>.</summary>
 		public static readonly BindableProperty NavigationProperty = NavigationPropertyKey.BindableProperty;
 
 		/// <summary>Bindable property for <see cref="Style"/>.</summary>
 		public static readonly BindableProperty StyleProperty =
-			BindableProperty.Create("Style", typeof(Style), typeof(VisualElement), default(Style),
+			BindableProperty.Create(nameof(Style), typeof(Style), typeof(VisualElement), default(Style),
 				propertyChanged: (bindable, oldvalue, newvalue) => ((NavigableElement)bindable)._mergedStyle.Style = (Style)newvalue);
 
 		internal readonly MergedStyle _mergedStyle;

--- a/src/Controls/src/Core/Shell/Shell.cs
+++ b/src/Controls/src/Core/Shell/Shell.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Maui.Controls
 
 		/// <summary>Bindable property for attached property <c>FlyoutBehavior</c>.</summary>
 		public static readonly BindableProperty FlyoutBehaviorProperty =
-			BindableProperty.CreateAttached("FlyoutBehavior", typeof(FlyoutBehavior), typeof(Shell), FlyoutBehavior.Flyout,
+			BindableProperty.CreateAttached(nameof(FlyoutBehavior), typeof(FlyoutBehavior), typeof(Shell), FlyoutBehavior.Flyout,
 				propertyChanged: OnFlyoutBehaviorChanged);
 
 		/// <summary>Bindable property for attached property <c>NavBarIsVisible</c>.</summary>
@@ -231,17 +231,17 @@ namespace Microsoft.Maui.Controls
 
 		/// <summary>Bindable property for attached property <c>FlyoutBackdrop</c>.</summary>
 		public static readonly BindableProperty FlyoutBackdropProperty =
-			BindableProperty.CreateAttached("FlyoutBackdrop", typeof(Brush), typeof(Shell), Brush.Default,
+			BindableProperty.CreateAttached(nameof(FlyoutBackdrop), typeof(Brush), typeof(Shell), Brush.Default,
 				propertyChanged: OnShellAppearanceValueChanged);
 
 		/// <summary>Bindable property for attached property <c>FlyoutWidth</c>.</summary>
 		public static readonly BindableProperty FlyoutWidthProperty =
-			BindableProperty.CreateAttached("FlyoutWidth", typeof(double), typeof(Shell), -1d,
+			BindableProperty.CreateAttached(nameof(FlyoutWidth), typeof(double), typeof(Shell), -1d,
 				propertyChanged: OnShellAppearanceValueChanged);
 
 		/// <summary>Bindable property for attached property <c>FlyoutHeight</c>.</summary>
 		public static readonly BindableProperty FlyoutHeightProperty =
-			BindableProperty.CreateAttached("FlyoutHeight", typeof(double), typeof(Shell), -1d,
+			BindableProperty.CreateAttached(nameof(FlyoutHeight), typeof(double), typeof(Shell), -1d,
 				propertyChanged: OnShellAppearanceValueChanged);
 
 		/// <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='GetBackgroundColor']/Docs/*" />

--- a/src/Controls/src/Core/StreamImageSource.cs
+++ b/src/Controls/src/Core/StreamImageSource.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Maui.Controls
 	public partial class StreamImageSource : ImageSource, IStreamImageSource
 	{
 		/// <summary>Bindable property for <see cref="Stream"/>.</summary>
-		public static readonly BindableProperty StreamProperty = BindableProperty.Create("Stream", typeof(Func<CancellationToken, Task<Stream>>), typeof(StreamImageSource),
+		public static readonly BindableProperty StreamProperty = BindableProperty.Create(nameof(Stream), typeof(Func<CancellationToken, Task<Stream>>), typeof(StreamImageSource),
 			default(Func<CancellationToken, Task<Stream>>));
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/StreamImageSource.xml" path="//Member[@MemberName='IsEmpty']/Docs/*" />

--- a/src/Controls/src/Core/StreamWrapper.cs
+++ b/src/Controls/src/Core/StreamWrapper.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Maui.Controls
 		public StreamWrapper(Stream wrapped, IDisposable additionalDisposable)
 		{
 			if (wrapped == null)
-				throw new ArgumentNullException("wrapped");
+				throw new ArgumentNullException(nameof(wrapped));
 
 			_wrapped = wrapped;
 			_additionalDisposable = additionalDisposable;

--- a/src/Controls/src/Core/SwipeGestureRecognizer.cs
+++ b/src/Controls/src/Core/SwipeGestureRecognizer.cs
@@ -16,13 +16,13 @@ namespace Microsoft.Maui.Controls
 		public static readonly BindableProperty CommandProperty = BindableProperty.Create(nameof(Command), typeof(ICommand), typeof(SwipeGestureRecognizer), null);
 
 		/// <summary>Bindable property for <see cref="CommandParameter"/>.</summary>
-		public static readonly BindableProperty CommandParameterProperty = BindableProperty.Create("CommandParameter", typeof(object), typeof(SwipeGestureRecognizer), null);
+		public static readonly BindableProperty CommandParameterProperty = BindableProperty.Create(nameof(CommandParameter), typeof(object), typeof(SwipeGestureRecognizer), null);
 
 		/// <summary>Bindable property for <see cref="Direction"/>.</summary>
-		public static readonly BindableProperty DirectionProperty = BindableProperty.Create("Direction", typeof(SwipeDirection), typeof(SwipeGestureRecognizer), default(SwipeDirection));
+		public static readonly BindableProperty DirectionProperty = BindableProperty.Create(nameof(Direction), typeof(SwipeDirection), typeof(SwipeGestureRecognizer), default(SwipeDirection));
 
 		/// <summary>Bindable property for <see cref="Threshold"/>.</summary>
-		public static readonly BindableProperty ThresholdProperty = BindableProperty.Create("Threshold", typeof(uint), typeof(SwipeGestureRecognizer), DefaultSwipeThreshold);
+		public static readonly BindableProperty ThresholdProperty = BindableProperty.Create(nameof(Threshold), typeof(uint), typeof(SwipeGestureRecognizer), DefaultSwipeThreshold);
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/SwipeGestureRecognizer.xml" path="//Member[@MemberName='Command']/Docs/*" />
 		public ICommand Command

--- a/src/Controls/src/Core/TableView/TableSectionBase.cs
+++ b/src/Controls/src/Core/TableView/TableSectionBase.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Maui.Controls
 	public abstract class TableSectionBase : BindableObject
 	{
 		/// <summary>Bindable property for <see cref="Title"/>.</summary>
-		public static readonly BindableProperty TitleProperty = BindableProperty.Create("Title", typeof(string), typeof(TableSectionBase), null);
+		public static readonly BindableProperty TitleProperty = BindableProperty.Create(nameof(Title), typeof(string), typeof(TableSectionBase), null);
 		/// <summary>Bindable property for <see cref="TextColor"/>.</summary>
 		public static readonly BindableProperty TextColorProperty = BindableProperty.Create(nameof(TextColor), typeof(Color), typeof(TableSectionBase), null);
 
@@ -25,7 +25,7 @@ namespace Microsoft.Maui.Controls
 		protected TableSectionBase(string title)
 		{
 			if (title == null)
-				throw new ArgumentNullException("title");
+				throw new ArgumentNullException(nameof(title));
 
 			Title = title;
 		}

--- a/src/Controls/src/Core/TableView/TableView.cs
+++ b/src/Controls/src/Core/TableView/TableView.cs
@@ -16,10 +16,10 @@ namespace Microsoft.Maui.Controls
 	public class TableView : View, ITableViewController, IElementConfiguration<TableView>, IVisualTreeElement
 	{
 		/// <summary>Bindable property for <see cref="RowHeight"/>.</summary>
-		public static readonly BindableProperty RowHeightProperty = BindableProperty.Create("RowHeight", typeof(int), typeof(TableView), -1);
+		public static readonly BindableProperty RowHeightProperty = BindableProperty.Create(nameof(RowHeight), typeof(int), typeof(TableView), -1);
 
 		/// <summary>Bindable property for <see cref="HasUnevenRows"/>.</summary>
-		public static readonly BindableProperty HasUnevenRowsProperty = BindableProperty.Create("HasUnevenRows", typeof(bool), typeof(TableView), false);
+		public static readonly BindableProperty HasUnevenRowsProperty = BindableProperty.Create(nameof(HasUnevenRows), typeof(bool), typeof(TableView), false);
 
 		readonly Lazy<PlatformConfigurationRegistry<TableView>> _platformConfigurationRegistry;
 
@@ -238,7 +238,7 @@ namespace Microsoft.Maui.Controls
 			internal static Tuple<int, int> GetPath(Cell item)
 			{
 				if (item == null)
-					throw new ArgumentNullException("item");
+					throw new ArgumentNullException(nameof(item));
 
 				return (Tuple<int, int>)item.GetValue(PathProperty);
 			}

--- a/src/Controls/src/Core/TapGestureRecognizer.cs
+++ b/src/Controls/src/Core/TapGestureRecognizer.cs
@@ -8,13 +8,13 @@ namespace Microsoft.Maui.Controls
 	public sealed class TapGestureRecognizer : GestureRecognizer
 	{
 		/// <summary>Bindable property for <see cref="Command"/>.</summary>
-		public static readonly BindableProperty CommandProperty = BindableProperty.Create("Command", typeof(ICommand), typeof(TapGestureRecognizer), null);
+		public static readonly BindableProperty CommandProperty = BindableProperty.Create(nameof(Command), typeof(ICommand), typeof(TapGestureRecognizer), null);
 
 		/// <summary>Bindable property for <see cref="CommandParameter"/>.</summary>
 		public static readonly BindableProperty CommandParameterProperty = BindableProperty.Create(nameof(CommandParameter), typeof(object), typeof(TapGestureRecognizer), null);
 
 		/// <summary>Bindable property for <see cref="NumberOfTapsRequired"/>.</summary>
-		public static readonly BindableProperty NumberOfTapsRequiredProperty = BindableProperty.Create("NumberOfTapsRequired", typeof(int), typeof(TapGestureRecognizer), 1);
+		public static readonly BindableProperty NumberOfTapsRequiredProperty = BindableProperty.Create(nameof(NumberOfTapsRequired), typeof(int), typeof(TapGestureRecognizer), 1);
 
 		/// <summary>Bindable property for <see cref="Buttons"/>.</summary>
 		public static readonly BindableProperty ButtonsProperty = BindableProperty.Create(nameof(Buttons), typeof(ButtonsMask), typeof(TapGestureRecognizer), ButtonsMask.Primary);

--- a/src/Controls/src/Core/TemplateBinding.cs
+++ b/src/Controls/src/Core/TemplateBinding.cs
@@ -24,9 +24,9 @@ namespace Microsoft.Maui.Controls
 		public TemplateBinding(string path, BindingMode mode = BindingMode.Default, IValueConverter converter = null, object converterParameter = null, string stringFormat = null)
 		{
 			if (path == null)
-				throw new ArgumentNullException("path");
+				throw new ArgumentNullException(nameof(path));
 			if (string.IsNullOrWhiteSpace(path))
-				throw new ArgumentException("path cannot be an empty string", "path");
+				throw new ArgumentException("path cannot be an empty string", nameof(path));
 
 			AllowChaining = true;
 			Path = path;

--- a/src/Controls/src/Core/TemplateExtensions.cs
+++ b/src/Controls/src/Core/TemplateExtensions.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Maui.Controls
 		public static void SetBinding(this DataTemplate self, BindableProperty targetProperty, string path)
 		{
 			if (self == null)
-				throw new ArgumentNullException("self");
+				throw new ArgumentNullException(nameof(self));
 
 			self.SetBinding(targetProperty, new Binding(path));
 		}

--- a/src/Controls/src/Core/TemplatedItemsList.cs
+++ b/src/Controls/src/Core/TemplatedItemsList.cs
@@ -20,14 +20,14 @@ namespace Microsoft.Maui.Controls.Internals
 												where TItem : BindableObject
 	{
 		/// <summary>Bindable property for <see cref="Name"/>.</summary>
-		public static readonly BindableProperty NameProperty = BindableProperty.Create("Name", typeof(string), typeof(TemplatedItemsList<TView, TItem>), null);
+		public static readonly BindableProperty NameProperty = BindableProperty.Create(nameof(Name), typeof(string), typeof(TemplatedItemsList<TView, TItem>), null);
 
 		/// <summary>Bindable property for <see cref="ShortName"/>.</summary>
-		public static readonly BindableProperty ShortNameProperty = BindableProperty.Create("ShortName", typeof(string), typeof(TemplatedItemsList<TView, TItem>), null);
+		public static readonly BindableProperty ShortNameProperty = BindableProperty.Create(nameof(ShortName), typeof(string), typeof(TemplatedItemsList<TView, TItem>), null);
 
-		static readonly BindablePropertyKey HeaderContentPropertyKey = BindableProperty.CreateReadOnly("HeaderContent", typeof(TItem), typeof(TemplatedItemsList<TView, TItem>), null);
+		static readonly BindablePropertyKey HeaderContentPropertyKey = BindableProperty.CreateReadOnly(nameof(HeaderContent), typeof(TItem), typeof(TemplatedItemsList<TView, TItem>), null);
 
-		internal static readonly BindablePropertyKey ListProxyPropertyKey = BindableProperty.CreateReadOnly("ListProxy", typeof(ListProxy), typeof(TemplatedItemsList<TView, TItem>), null,
+		internal static readonly BindablePropertyKey ListProxyPropertyKey = BindableProperty.CreateReadOnly(nameof(ListProxy), typeof(ListProxy), typeof(TemplatedItemsList<TView, TItem>), null,
 			propertyChanged: OnListProxyChanged);
 
 		static readonly BindableProperty GroupProperty = BindableProperty.Create("Group", typeof(TemplatedItemsList<TView, TItem>), typeof(TItem), null);
@@ -53,11 +53,11 @@ namespace Microsoft.Maui.Controls.Internals
 		internal TemplatedItemsList(TView itemsView, BindableProperty itemSourceProperty, BindableProperty itemTemplateProperty)
 		{
 			if (itemsView == null)
-				throw new ArgumentNullException("itemsView");
+				throw new ArgumentNullException(nameof(itemsView));
 			if (itemSourceProperty == null)
-				throw new ArgumentNullException("itemSourceProperty");
+				throw new ArgumentNullException(nameof(itemSourceProperty));
 			if (itemTemplateProperty == null)
-				throw new ArgumentNullException("itemTemplateProperty");
+				throw new ArgumentNullException(nameof(itemTemplateProperty));
 
 			_itemsView = itemsView;
 			_itemsView.PropertyChanged += BindableOnPropertyChanged;
@@ -75,9 +75,9 @@ namespace Microsoft.Maui.Controls.Internals
 		internal TemplatedItemsList(TemplatedItemsList<TView, TItem> parent, IEnumerable itemSource, TView itemsView, BindableProperty itemTemplateProperty, int windowSize = int.MaxValue)
 		{
 			if (itemsView == null)
-				throw new ArgumentNullException("itemsView");
+				throw new ArgumentNullException(nameof(itemsView));
 			if (itemTemplateProperty == null)
-				throw new ArgumentNullException("itemTemplateProperty");
+				throw new ArgumentNullException(nameof(itemTemplateProperty));
 
 			Parent = parent;
 
@@ -360,7 +360,7 @@ namespace Microsoft.Maui.Controls.Internals
 		public int GetGlobalIndexForGroup(ITemplatedItemsList<TItem> group)
 		{
 			if (group == null)
-				throw new ArgumentNullException("group");
+				throw new ArgumentNullException(nameof(group));
 
 			int groupIndex = _groupedItems.Values.IndexOf(group);
 
@@ -584,7 +584,7 @@ namespace Microsoft.Maui.Controls.Internals
 		internal static TemplatedItemsList<TView, TItem> GetGroup(TItem item)
 		{
 			if (item == null)
-				throw new ArgumentNullException("item");
+				throw new ArgumentNullException(nameof(item));
 
 			return (TemplatedItemsList<TView, TItem>)item.GetValue(GroupProperty);
 		}
@@ -592,7 +592,7 @@ namespace Microsoft.Maui.Controls.Internals
 		internal static int GetIndex(TItem item)
 		{
 			if (item == null)
-				throw new ArgumentNullException("item");
+				throw new ArgumentNullException(nameof(item));
 
 			return (int)item.GetValue(IndexProperty);
 		}
@@ -963,7 +963,7 @@ namespace Microsoft.Maui.Controls.Internals
 		static void OnListProxyChanged(BindableObject bindable, object oldValue, object newValue)
 		{
 			var til = (TemplatedItemsList<TView, TItem>)bindable;
-			til.OnPropertyChanged("ItemsSource");
+			til.OnPropertyChanged(nameof(ItemsSource));
 		}
 
 		void OnProxyCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
@@ -1137,7 +1137,7 @@ namespace Microsoft.Maui.Controls.Internals
 		static void SetGroup(TItem item, TemplatedItemsList<TView, TItem> group)
 		{
 			if (item == null)
-				throw new ArgumentNullException("item");
+				throw new ArgumentNullException(nameof(item));
 
 			item.SetValue(GroupProperty, group);
 		}

--- a/src/Controls/src/Core/Toolbar/ToolbarItem.cs
+++ b/src/Controls/src/Core/Toolbar/ToolbarItem.cs
@@ -6,13 +6,13 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../docs/Microsoft.Maui.Controls/ToolbarItem.xml" path="Type[@FullName='Microsoft.Maui.Controls.ToolbarItem']/Docs/*" />
 	public class ToolbarItem : MenuItem
 	{
-		static readonly BindableProperty OrderProperty = BindableProperty.Create("Order", typeof(ToolbarItemOrder), typeof(ToolbarItem), ToolbarItemOrder.Default, validateValue: (bo, o) =>
+		static readonly BindableProperty OrderProperty = BindableProperty.Create(nameof(Order), typeof(ToolbarItemOrder), typeof(ToolbarItem), ToolbarItemOrder.Default, validateValue: (bo, o) =>
 		{
 			var order = (ToolbarItemOrder)o;
 			return order == ToolbarItemOrder.Default || order == ToolbarItemOrder.Primary || order == ToolbarItemOrder.Secondary;
 		});
 
-		static readonly BindableProperty PriorityProperty = BindableProperty.Create("Priority", typeof(int), typeof(ToolbarItem), 0);
+		static readonly BindableProperty PriorityProperty = BindableProperty.Create(nameof(Priority), typeof(int), typeof(ToolbarItem), 0);
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/ToolbarItem.xml" path="//Member[@MemberName='.ctor'][1]/Docs/*" />
 		public ToolbarItem()
@@ -23,7 +23,7 @@ namespace Microsoft.Maui.Controls
 		public ToolbarItem(string name, string icon, Action activated, ToolbarItemOrder order = ToolbarItemOrder.Default, int priority = 0)
 		{
 			if (activated == null)
-				throw new ArgumentNullException("activated");
+				throw new ArgumentNullException(nameof(activated));
 
 			Text = name;
 			IconImageSource = icon;

--- a/src/Controls/src/Core/UrlWebViewSource.cs
+++ b/src/Controls/src/Core/UrlWebViewSource.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Maui.Controls
 	public class UrlWebViewSource : WebViewSource
 	{
 		/// <summary>Bindable property for <see cref="Url"/>.</summary>
-		public static readonly BindableProperty UrlProperty = BindableProperty.Create("Url", typeof(string), typeof(UrlWebViewSource), default(string),
+		public static readonly BindableProperty UrlProperty = BindableProperty.Create(nameof(Url), typeof(string), typeof(UrlWebViewSource), default(string),
 			propertyChanged: (bindable, oldvalue, newvalue) => ((UrlWebViewSource)bindable).OnSourceChanged());
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/UrlWebViewSource.xml" path="//Member[@MemberName='Url']/Docs/*" />

--- a/src/Controls/src/Core/VisualElement/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement/VisualElement.cs
@@ -30,57 +30,57 @@ namespace Microsoft.Maui.Controls
 
 		/// <summary>Bindable property for <see cref="InputTransparent"/>.</summary>
 		public static readonly BindableProperty InputTransparentProperty = BindableProperty.Create(
-			"InputTransparent", typeof(bool), typeof(VisualElement), default(bool),
+			nameof(InputTransparent), typeof(bool), typeof(VisualElement), default(bool),
 			propertyChanged: OnInputTransparentPropertyChanged, coerceValue: CoerceInputTransparentProperty);
 
 		bool _isEnabledExplicit = (bool)IsEnabledProperty.DefaultValue;
 
 		/// <summary>Bindable property for <see cref="IsEnabled"/>.</summary>
-		public static readonly BindableProperty IsEnabledProperty = BindableProperty.Create("IsEnabled", typeof(bool),
+		public static readonly BindableProperty IsEnabledProperty = BindableProperty.Create(nameof(IsEnabled), typeof(bool),
 			typeof(VisualElement), true, propertyChanged: OnIsEnabledPropertyChanged, coerceValue: CoerceIsEnabledProperty);
 
-		static readonly BindablePropertyKey XPropertyKey = BindableProperty.CreateReadOnly("X", typeof(double), typeof(VisualElement), default(double));
+		static readonly BindablePropertyKey XPropertyKey = BindableProperty.CreateReadOnly(nameof(X), typeof(double), typeof(VisualElement), default(double));
 
 		/// <summary>Bindable property for <see cref="X"/>.</summary>
 		public static readonly BindableProperty XProperty = XPropertyKey.BindableProperty;
 
-		static readonly BindablePropertyKey YPropertyKey = BindableProperty.CreateReadOnly("Y", typeof(double), typeof(VisualElement), default(double));
+		static readonly BindablePropertyKey YPropertyKey = BindableProperty.CreateReadOnly(nameof(Y), typeof(double), typeof(VisualElement), default(double));
 
 		/// <summary>Bindable property for <see cref="Y"/>.</summary>
 		public static readonly BindableProperty YProperty = YPropertyKey.BindableProperty;
 
 		/// <summary>Bindable property for <see cref="AnchorX"/>.</summary>
-		public static readonly BindableProperty AnchorXProperty = BindableProperty.Create("AnchorX", typeof(double), typeof(VisualElement), .5d);
+		public static readonly BindableProperty AnchorXProperty = BindableProperty.Create(nameof(AnchorX), typeof(double), typeof(VisualElement), .5d);
 
 		/// <summary>Bindable property for <see cref="AnchorY"/>.</summary>
-		public static readonly BindableProperty AnchorYProperty = BindableProperty.Create("AnchorY", typeof(double), typeof(VisualElement), .5d);
+		public static readonly BindableProperty AnchorYProperty = BindableProperty.Create(nameof(AnchorY), typeof(double), typeof(VisualElement), .5d);
 
 		/// <summary>Bindable property for <see cref="TranslationX"/>.</summary>
-		public static readonly BindableProperty TranslationXProperty = BindableProperty.Create("TranslationX", typeof(double), typeof(VisualElement), 0d);
+		public static readonly BindableProperty TranslationXProperty = BindableProperty.Create(nameof(TranslationX), typeof(double), typeof(VisualElement), 0d);
 
 		/// <summary>Bindable property for <see cref="TranslationY"/>.</summary>
-		public static readonly BindableProperty TranslationYProperty = BindableProperty.Create("TranslationY", typeof(double), typeof(VisualElement), 0d);
+		public static readonly BindableProperty TranslationYProperty = BindableProperty.Create(nameof(TranslationY), typeof(double), typeof(VisualElement), 0d);
 
-		static readonly BindablePropertyKey WidthPropertyKey = BindableProperty.CreateReadOnly("Width", typeof(double), typeof(VisualElement), -1d,
+		static readonly BindablePropertyKey WidthPropertyKey = BindableProperty.CreateReadOnly(nameof(Width), typeof(double), typeof(VisualElement), -1d,
 			coerceValue: (bindable, value) => double.IsNaN((double)value) ? 0d : value);
 
 		/// <summary>Bindable property for <see cref="Width"/>.</summary>
 		public static readonly BindableProperty WidthProperty = WidthPropertyKey.BindableProperty;
 
-		static readonly BindablePropertyKey HeightPropertyKey = BindableProperty.CreateReadOnly("Height", typeof(double), typeof(VisualElement), -1d,
+		static readonly BindablePropertyKey HeightPropertyKey = BindableProperty.CreateReadOnly(nameof(Height), typeof(double), typeof(VisualElement), -1d,
 			coerceValue: (bindable, value) => double.IsNaN((double)value) ? 0d : value);
 
 		/// <summary>Bindable property for <see cref="Height"/>.</summary>
 		public static readonly BindableProperty HeightProperty = HeightPropertyKey.BindableProperty;
 
 		/// <summary>Bindable property for <see cref="Rotation"/>.</summary>
-		public static readonly BindableProperty RotationProperty = BindableProperty.Create("Rotation", typeof(double), typeof(VisualElement), default(double));
+		public static readonly BindableProperty RotationProperty = BindableProperty.Create(nameof(Rotation), typeof(double), typeof(VisualElement), default(double));
 
 		/// <summary>Bindable property for <see cref="RotationX"/>.</summary>
-		public static readonly BindableProperty RotationXProperty = BindableProperty.Create("RotationX", typeof(double), typeof(VisualElement), default(double));
+		public static readonly BindableProperty RotationXProperty = BindableProperty.Create(nameof(RotationX), typeof(double), typeof(VisualElement), default(double));
 
 		/// <summary>Bindable property for <see cref="RotationY"/>.</summary>
-		public static readonly BindableProperty RotationYProperty = BindableProperty.Create("RotationY", typeof(double), typeof(VisualElement), default(double));
+		public static readonly BindableProperty RotationYProperty = BindableProperty.Create(nameof(RotationY), typeof(double), typeof(VisualElement), default(double));
 
 		/// <summary>Bindable property for <see cref="Scale"/>.</summary>
 		public static readonly BindableProperty ScaleProperty = BindableProperty.Create(nameof(Scale), typeof(double), typeof(VisualElement), 1d);
@@ -266,11 +266,11 @@ namespace Microsoft.Maui.Controls
 									propertyChanged: (b, o, n) => { (((VisualElement)b).AnchorX, ((VisualElement)b).AnchorY) = (Point)n; });
 
 		/// <summary>Bindable property for <see cref="IsVisible"/>.</summary>
-		public static readonly BindableProperty IsVisibleProperty = BindableProperty.Create("IsVisible", typeof(bool), typeof(VisualElement), true,
+		public static readonly BindableProperty IsVisibleProperty = BindableProperty.Create(nameof(IsVisible), typeof(bool), typeof(VisualElement), true,
 			propertyChanged: (bindable, oldvalue, newvalue) => ((VisualElement)bindable).OnIsVisibleChanged((bool)oldvalue, (bool)newvalue));
 
 		/// <summary>Bindable property for <see cref="Opacity"/>.</summary>
-		public static readonly BindableProperty OpacityProperty = BindableProperty.Create("Opacity", typeof(double), typeof(VisualElement), 1d, coerceValue: (bindable, value) => ((double)value).Clamp(0, 1));
+		public static readonly BindableProperty OpacityProperty = BindableProperty.Create(nameof(Opacity), typeof(double), typeof(VisualElement), 1d, coerceValue: (bindable, value) => ((double)value).Clamp(0, 1));
 
 		/// <summary>Bindable property for <see cref="BackgroundColor"/>.</summary>
 		public static readonly BindableProperty BackgroundColorProperty = BindableProperty.Create(nameof(BackgroundColor), typeof(Color), typeof(VisualElement), null);
@@ -383,7 +383,7 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		internal static readonly BindablePropertyKey BehaviorsPropertyKey = BindableProperty.CreateReadOnly("Behaviors", typeof(IList<Behavior>), typeof(VisualElement), default(IList<Behavior>),
+		internal static readonly BindablePropertyKey BehaviorsPropertyKey = BindableProperty.CreateReadOnly(nameof(Behaviors), typeof(IList<Behavior>), typeof(VisualElement), default(IList<Behavior>),
 			defaultValueCreator: bindable =>
 			{
 				var collection = new AttachedCollection<Behavior>();
@@ -394,7 +394,7 @@ namespace Microsoft.Maui.Controls
 		/// <summary>Bindable property for <see cref="Behaviors"/>.</summary>
 		public static readonly BindableProperty BehaviorsProperty = BehaviorsPropertyKey.BindableProperty;
 
-		internal static readonly BindablePropertyKey TriggersPropertyKey = BindableProperty.CreateReadOnly("Triggers", typeof(IList<TriggerBase>), typeof(VisualElement), default(IList<TriggerBase>),
+		internal static readonly BindablePropertyKey TriggersPropertyKey = BindableProperty.CreateReadOnly(nameof(Triggers), typeof(IList<TriggerBase>), typeof(VisualElement), default(IList<TriggerBase>),
 			defaultValueCreator: bindable =>
 			{
 				var collection = new AttachedCollection<TriggerBase>();
@@ -428,7 +428,7 @@ namespace Microsoft.Maui.Controls
 		/// <summary>Bindable property for <see cref="IsFocused"/>.</summary>
 		/// <remarks>For internal use only. This API can be changed or removed without notice at any time.</remarks>
 		[EditorBrowsable(EditorBrowsableState.Never)]
-		public static readonly BindablePropertyKey IsFocusedPropertyKey = BindableProperty.CreateReadOnly("IsFocused",
+		public static readonly BindablePropertyKey IsFocusedPropertyKey = BindableProperty.CreateReadOnly(nameof(IsFocused),
 			typeof(bool), typeof(VisualElement), default(bool), propertyChanged: OnIsFocusedPropertyChanged);
 
 		/// <summary>Bindable property for <see cref="IsFocused"/>.</summary>

--- a/src/Controls/src/Core/WebView/WebView.cs
+++ b/src/Controls/src/Core/WebView/WebView.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Maui.Controls
 	public partial class WebView : View, IWebViewController, IElementConfiguration<WebView>, IWebView
 	{
 		/// <summary>Bindable property for <see cref="Source"/>.</summary>
-		public static readonly BindableProperty SourceProperty = BindableProperty.Create("Source", typeof(WebViewSource), typeof(WebView), default(WebViewSource),
+		public static readonly BindableProperty SourceProperty = BindableProperty.Create(nameof(Source), typeof(WebViewSource), typeof(WebView), default(WebViewSource),
 			propertyChanging: (bindable, oldvalue, newvalue) =>
 			{
 				var source = oldvalue as WebViewSource;
@@ -31,12 +31,12 @@ namespace Microsoft.Maui.Controls
 				}
 			});
 
-		static readonly BindablePropertyKey CanGoBackPropertyKey = BindableProperty.CreateReadOnly("CanGoBack", typeof(bool), typeof(WebView), false);
+		static readonly BindablePropertyKey CanGoBackPropertyKey = BindableProperty.CreateReadOnly(nameof(CanGoBack), typeof(bool), typeof(WebView), false);
 
 		/// <summary>Bindable property for <see cref="CanGoBack"/>.</summary>
 		public static readonly BindableProperty CanGoBackProperty = CanGoBackPropertyKey.BindableProperty;
 
-		static readonly BindablePropertyKey CanGoForwardPropertyKey = BindableProperty.CreateReadOnly("CanGoForward", typeof(bool), typeof(WebView), false);
+		static readonly BindablePropertyKey CanGoForwardPropertyKey = BindableProperty.CreateReadOnly(nameof(CanGoForward), typeof(bool), typeof(WebView), false);
 
 		/// <summary>Bindable property for <see cref="CanGoForward"/>.</summary>
 		public static readonly BindableProperty CanGoForwardProperty = CanGoForwardPropertyKey.BindableProperty;


### PR DESCRIPTION
Enforces [CA1507](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1507)

This should ensure that an entire class of bugs can be discovered at compile time, instead of runtime.

Related: https://github.com/dotnet/maui/pull/21962