### PR TITLE
[Compatibility] Enforce CA1507 - use nameof() where possible

### DIFF
--- a/src/Compatibility/Core/src/.editorconfig
+++ b/src/Compatibility/Core/src/.editorconfig
@@ -1,0 +1,2 @@
+[*.cs]
+dotnet_diagnostic.CA1507.severity = error

--- a/src/Compatibility/Core/src/Android/RendererPool.cs
+++ b/src/Compatibility/Core/src/Android/RendererPool.cs
@@ -17,10 +17,10 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 		public RendererPool(IVisualElementRenderer renderer, VisualElement oldElement)
 		{
 			if (renderer == null)
-				throw new ArgumentNullException("renderer");
+				throw new ArgumentNullException(nameof(renderer));
 
 			if (oldElement == null)
-				throw new ArgumentNullException("oldElement");
+				throw new ArgumentNullException(nameof(oldElement));
 
 			_oldElement = oldElement;
 			_parent = renderer;
@@ -36,7 +36,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 		public IVisualElementRenderer GetFreeRenderer(VisualElement view)
 		{
 			if (view == null)
-				throw new ArgumentNullException("view");
+				throw new ArgumentNullException(nameof(view));
 
 			Type rendererType = Internals.Registrar.Registered.GetHandlerTypeForObject(view) ?? typeof(ViewRenderer);
 

--- a/src/Compatibility/Core/src/Android/Renderers/FormsWebViewClient.cs
+++ b/src/Compatibility/Core/src/Android/Renderers/FormsWebViewClient.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 		string _lastUrlNavigatedCancel;
 
 		public FormsWebViewClient(WebViewRenderer renderer)
-			=> _renderer = renderer ?? throw new ArgumentNullException("renderer");
+			=> _renderer = renderer ?? throw new ArgumentNullException(nameof(renderer));
 
 		protected FormsWebViewClient(IntPtr javaReference, JniHandleOwnership transfer) : base(javaReference, transfer)
 		{

--- a/src/Compatibility/Core/src/Windows/BackgroundTracker.cs
+++ b/src/Compatibility/Core/src/Windows/BackgroundTracker.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 		public BackgroundTracker(DependencyProperty backgroundProperty)
 		{
 			if (backgroundProperty == null)
-				throw new ArgumentNullException("backgroundProperty");
+				throw new ArgumentNullException(nameof(backgroundProperty));
 
 			_backgroundProperty = backgroundProperty;
 		}

--- a/src/Compatibility/Core/src/Windows/FrameworkElementExtensions.cs
+++ b/src/Compatibility/Core/src/Windows/FrameworkElementExtensions.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 		public static WBrush GetForeground(this FrameworkElement element)
 		{
 			if (element == null)
-				throw new ArgumentNullException("element");
+				throw new ArgumentNullException(nameof(element));
 
 			return (WBrush)element.GetValue(GetForegroundProperty(element));
 		}
@@ -57,7 +57,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 		public static void SetForeground(this FrameworkElement element, WBrush foregroundBrush)
 		{
 			if (element == null)
-				throw new ArgumentNullException("element");
+				throw new ArgumentNullException(nameof(element));
 
 			element.SetValue(GetForegroundProperty(element), foregroundBrush);
 		}
@@ -65,7 +65,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 		public static void SetForeground(this FrameworkElement element, WBinding binding)
 		{
 			if (element == null)
-				throw new ArgumentNullException("element");
+				throw new ArgumentNullException(nameof(element));
 
 			element.SetBinding(GetForegroundProperty(element), binding);
 		}

--- a/src/Compatibility/Core/src/Windows/KeyboardExtensions.cs
+++ b/src/Compatibility/Core/src/Windows/KeyboardExtensions.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 		public static InputScope ToInputScope(this Keyboard self)
 		{
 			if (self == null)
-				throw new ArgumentNullException("self");
+				throw new ArgumentNullException(nameof(self));
 
 			var result = new InputScope();
 			var name = new InputScopeName();

--- a/src/Compatibility/Core/src/Windows/TabbedPageRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/TabbedPageRenderer.cs
@@ -154,7 +154,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 		public void SetElement(VisualElement element)
 		{
 			if (element != null && !(element is TabbedPage))
-				throw new ArgumentException("Element must be a TabbedPage", "element");
+				throw new ArgumentException("Element must be a TabbedPage", nameof(element));
 
 			TabbedPage oldElement = Element;
 			Element = (TabbedPage)element;

--- a/src/Compatibility/Core/src/Windows/VisualElementExtensions.cs
+++ b/src/Compatibility/Core/src/Windows/VisualElementExtensions.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 		public static IVisualElementRenderer GetOrCreateRenderer(this VisualElement self)
 		{
 			if (self == null)
-				throw new ArgumentNullException("self");
+				throw new ArgumentNullException(nameof(self));
 
 			IVisualElementRenderer renderer = Platform.GetRenderer(self);
 			if (renderer == null)
@@ -25,7 +25,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 		internal static void Cleanup(this VisualElement self)
 		{
 			if (self == null)
-				throw new ArgumentNullException("self");
+				throw new ArgumentNullException(nameof(self));
 
 			IVisualElementRenderer renderer = Platform.GetRenderer(self);
 

--- a/src/Compatibility/Core/src/Windows/VisualElementPackager.cs
+++ b/src/Compatibility/Core/src/Windows/VisualElementPackager.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 		public VisualElementPackager(IVisualElementRenderer renderer)
 		{
 			if (renderer == null)
-				throw new ArgumentNullException("renderer");
+				throw new ArgumentNullException(nameof(renderer));
 
 			_renderer = renderer;
 

--- a/src/Compatibility/Core/src/iOS/FormsApplicationDelegate.cs
+++ b/src/Compatibility/Core/src/iOS/FormsApplicationDelegate.cs
@@ -132,7 +132,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 		protected void LoadApplication(Application application)
 		{
 			if (application == null)
-				throw new ArgumentNullException("application");
+				throw new ArgumentNullException(nameof(application));
 
 			Application.SetCurrentApplication(application);
 			_application = application;

--- a/src/Compatibility/Core/src/iOS/RendererPool.cs
+++ b/src/Compatibility/Core/src/iOS/RendererPool.cs
@@ -21,10 +21,10 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.MacOS
 		public RendererPool(IVisualElementRenderer renderer, VisualElement oldElement)
 		{
 			if (renderer == null)
-				throw new ArgumentNullException("renderer");
+				throw new ArgumentNullException(nameof(renderer));
 
 			if (oldElement == null)
-				throw new ArgumentNullException("oldElement");
+				throw new ArgumentNullException(nameof(oldElement));
 
 			_oldElement = oldElement;
 			_parent = renderer;
@@ -33,7 +33,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.MacOS
 		public IVisualElementRenderer GetFreeRenderer(VisualElement view)
 		{
 			if (view == null)
-				throw new ArgumentNullException("view");
+				throw new ArgumentNullException(nameof(view));
 
 			var rendererType = Controls.Internals.Registrar.Registered.GetHandlerTypeForObject(view) ?? typeof(ViewRenderer);
 
@@ -49,7 +49,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.MacOS
 		public void UpdateNewElement(VisualElement newElement)
 		{
 			if (newElement == null)
-				throw new ArgumentNullException("newElement");
+				throw new ArgumentNullException(nameof(newElement));
 
 			var sameChildrenTypes = true;
 

--- a/src/Compatibility/Core/src/iOS/Renderers/NavigationRenderer.cs
+++ b/src/Compatibility/Core/src/iOS/Renderers/NavigationRenderer.cs
@@ -568,9 +568,9 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 		void InsertPageBefore(Page page, Page before)
 		{
 			if (before == null)
-				throw new ArgumentNullException("before");
+				throw new ArgumentNullException(nameof(before));
 			if (page == null)
-				throw new ArgumentNullException("page");
+				throw new ArgumentNullException(nameof(page));
 
 			var pageContainer = CreateViewControllerForPage(page);
 			var target = Platform.GetRenderer(before).ViewController.ParentViewController;
@@ -610,7 +610,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 		void RemovePage(Page page)
 		{
 			if (page == null)
-				throw new ArgumentNullException("page");
+				throw new ArgumentNullException(nameof(page));
 			if (page == Current)
 				throw new NotSupportedException(); // should never happen as NavPage protects against this
 

--- a/src/Compatibility/Core/src/iOS/Renderers/WkWebViewRenderer.cs
+++ b/src/Compatibility/Core/src/iOS/Renderers/WkWebViewRenderer.cs
@@ -703,7 +703,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 			public CustomWebViewNavigationDelegate(WkWebViewRenderer renderer)
 			{
 				if (renderer == null)
-					throw new ArgumentNullException("renderer");
+					throw new ArgumentNullException(nameof(renderer));
 				_renderer = renderer;
 			}
 

--- a/src/Compatibility/Core/src/iOS/VisualElementTracker.cs
+++ b/src/Compatibility/Core/src/iOS/VisualElementTracker.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.MacOS
 
 		public VisualElementTracker(IVisualElementRenderer renderer, bool trackFrame)
 		{
-			Renderer = renderer ?? throw new ArgumentNullException("renderer");
+			Renderer = renderer ?? throw new ArgumentNullException(nameof(renderer));
 
 			_propertyChangedHandler = HandlePropertyChanged;
 			_sizeChangedEventHandler = HandleSizeChanged;


### PR DESCRIPTION
Enforces [CA1507](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1507)

Prevents an entire class of potential bugs at compile-time, instead of stumbling on them at runtime.

Relates: #21962 #22102 