### PR TITLE
[WinUI] Perf when creating non-trivial grids (and other visual controls) (take 2)

### DIFF
--- a/src/Controls/samples/Controls.Sample.Sandbox/MainPage.xaml
+++ b/src/Controls/samples/Controls.Sample.Sandbox/MainPage.xaml
@@ -1,7 +1,18 @@
 ﻿<ContentPage
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:local="clr-namespace:Maui.Controls.Sample"
     x:Class="Maui.Controls.Sample.MainPage"
-    xmlns:local="clr-namespace:Maui.Controls.Sample">
+    x:DataType="local:MainPage">
+    <VerticalStackLayout x:Name="myLayout">
+        <Label x:Name="info" Text="Click a button" VerticalOptions="Center"/>
+        <Button Text="Clear Grid" Clicked="ClearGrid_Clicked"/>
+        <Button Text="Generate Grid" Clicked="Button_Clicked"/>
+        <Entry x:Name="BatchSize" Text="15"/>
+        <Button Text="Batch Generate Grid" Clicked="BatchGenerate_ClickedAsync"/>
 
+        <HorizontalStackLayout x:Name="myGridWrapper">
+            <Grid x:Name="contentGrid"/>
+        </HorizontalStackLayout>
+    </VerticalStackLayout>
 </ContentPage>

--- a/src/Controls/samples/Controls.Sample.Sandbox/MainPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample.Sandbox/MainPage.xaml.cs
@@ -30,14 +30,36 @@ public partial class MainPage : ContentPage
 		Stopwatch sw = Stopwatch.StartNew();
 		contentGrid.Clear();
 
+		for (int n = 0; n < rowCount; n++)
+		{
+			contentGrid.RowDefinitions.Add(new RowDefinition());
+		}
+
+		for (int n = 0; n < columnCount; n++)
+		{
+			contentGrid.ColumnDefinitions.Add(new ColumnDefinition());
+		}
+
 		for (int rowIndex = 0; rowIndex < rowCount; rowIndex++)
 		{
+			Label[] views = new Label[columnCount];
+
 			for (int columnIndex = 0; columnIndex < columnCount; columnIndex++)
 			{
-				Label control = new Label() { Text = $"[{columnIndex}x{rowIndex}]" };
-				// Button control = new() { Text = $"[{columnIndex}x{rowIndex}]" };
-				contentGrid.Add(control, column: columnIndex, row: rowIndex);
+				Label view = new Label() { Text = $"[{columnIndex}x{rowIndex}]" };
+				// Button view = new() { Text = $"[{columnIndex}x{rowIndex}]" };
+				// contentGrid.Add(view, column: columnIndex, row: rowIndex);
+
+				views[columnIndex] = view;
+
+				contentGrid.SetRow(view, rowIndex);
+				contentGrid.SetRowSpan(view, 1);
+
+				contentGrid.SetColumn(view, columnIndex);
+				contentGrid.SetColumnSpan(view, 1);
 			}
+
+			contentGrid.AddBulk(views);
 		}
 
 		sw.Stop();
@@ -62,9 +84,9 @@ public partial class MainPage : ContentPage
 			{
 				for (int columnIndex = 0; columnIndex < columnCount; columnIndex++)
 				{
-					 Label control = new() { Text = $"[{columnIndex}x{rowIndex}]" };
-					//Button control = new() { Text = $"[{columnIndex}x{rowIndex}]" };
-					contentGrid.Add(control, column: columnIndex, row: rowIndex);
+					 Label view = new() { Text = $"[{columnIndex}x{rowIndex}]" };
+					//Button view = new() { Text = $"[{columnIndex}x{rowIndex}]" };
+					contentGrid.Add(view, column: columnIndex, row: rowIndex);
 				}
 			}
 

--- a/src/Controls/samples/Controls.Sample.Sandbox/MainPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample.Sandbox/MainPage.xaml.cs
@@ -1,9 +1,80 @@
-﻿namespace Maui.Controls.Sample;
+﻿using System;
+using System.Diagnostics;
+using Microsoft.Maui.Controls;
+
+namespace Maui.Controls.Sample;
 
 public partial class MainPage : ContentPage
 {
+	const int rowCount = 30;
+	const int columnCount = 30;
+
 	public MainPage()
 	{
 		InitializeComponent();
 	}
+
+	private void ClearGrid_Clicked(object sender, EventArgs e)
+	{
+		Stopwatch sw = Stopwatch.StartNew();
+
+		contentGrid.Clear();
+
+		sw.Stop();
+
+		info.Text = $"Clearing grid took: {sw.ElapsedMilliseconds} ms";
+	}
+
+	private void Button_Clicked(object sender, EventArgs e)
+	{
+		Stopwatch sw = Stopwatch.StartNew();
+		contentGrid.Clear();
+
+		for (int rowIndex = 0; rowIndex < rowCount; rowIndex++)
+		{
+			for (int columnIndex = 0; columnIndex < columnCount; columnIndex++)
+			{
+				Label label = new Label() { Text = $"[{columnIndex}x{rowIndex}]" };
+				contentGrid.Add(label, column: columnIndex, row: rowIndex);
+			}
+		}
+
+		sw.Stop();
+		info.Text = $"Clearing grid took: {sw.ElapsedMilliseconds} ms";
+	}
+
+	private async void BatchGenerate_ClickedAsync(object sender, EventArgs e)
+	{
+		Stopwatch sw = Stopwatch.StartNew();
+
+		long sumMs = 0;
+		int batchSize = int.Parse(BatchSize.Text);
+
+		for (int i = 0; i < batchSize; i++)
+		{
+			sw.Reset();
+			sw.Start();
+
+			contentGrid.Clear();
+
+			for (int rowIndex = 0; rowIndex < rowCount; rowIndex++)
+			{
+				for (int columnIndex = 0; columnIndex < columnCount; columnIndex++)
+				{
+					Label label = new Label() { Text = $"[{columnIndex}x{rowIndex}]" };
+					contentGrid.Add(label, column: columnIndex, row: rowIndex);
+				}
+			}
+
+			sw.Stop();
+			sumMs += sw.ElapsedMilliseconds;
+
+			int runs = i + 1;
+
+			info.Text = $"Grid was created {runs} times and it took {sumMs} ms in total. Avg run took {Math.Round(sumMs / (double)runs, 2)} ms";
+
+			await Task.Delay(1000).ConfigureAwait(true);
+		}
+	}
+
 }

--- a/src/Controls/samples/Controls.Sample.Sandbox/MainPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample.Sandbox/MainPage.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using Microsoft.Maui.Controls;
 

--- a/src/Controls/samples/Controls.Sample.Sandbox/MainPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample.Sandbox/MainPage.xaml.cs
@@ -40,7 +40,7 @@ public partial class MainPage : ContentPage
 		}
 
 		sw.Stop();
-		info.Text = $"Clearing grid took: {sw.ElapsedMilliseconds} ms";
+		info.Text = $"Grid was created in: {sw.ElapsedMilliseconds} ms";
 	}
 
 	private async void BatchGenerate_ClickedAsync(object sender, EventArgs e)

--- a/src/Controls/samples/Controls.Sample.Sandbox/MainPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample.Sandbox/MainPage.xaml.cs
@@ -40,9 +40,11 @@ public partial class MainPage : ContentPage
 			contentGrid.ColumnDefinitions.Add(new ColumnDefinition());
 		}
 
+		int i = 0;
+		Label[] views = new Label[rowCount * columnCount];
+
 		for (int rowIndex = 0; rowIndex < rowCount; rowIndex++)
 		{
-			Label[] views = new Label[columnCount];
 
 			for (int columnIndex = 0; columnIndex < columnCount; columnIndex++)
 			{
@@ -50,7 +52,8 @@ public partial class MainPage : ContentPage
 				// Button view = new() { Text = $"[{columnIndex}x{rowIndex}]" };
 				// contentGrid.Add(view, column: columnIndex, row: rowIndex);
 
-				views[columnIndex] = view;
+				views[i] = view;
+				i++;
 
 				contentGrid.SetRow(view, rowIndex);
 				contentGrid.SetRowSpan(view, 1);
@@ -58,9 +61,9 @@ public partial class MainPage : ContentPage
 				contentGrid.SetColumn(view, columnIndex);
 				contentGrid.SetColumnSpan(view, 1);
 			}
-
-			contentGrid.AddBulk(views);
 		}
+
+		contentGrid.AddBulk(views);
 
 		sw.Stop();
 		info.Text = $"Grid was created in: {sw.ElapsedMilliseconds} ms";

--- a/src/Controls/samples/Controls.Sample.Sandbox/MainPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample.Sandbox/MainPage.xaml.cs
@@ -34,8 +34,9 @@ public partial class MainPage : ContentPage
 		{
 			for (int columnIndex = 0; columnIndex < columnCount; columnIndex++)
 			{
-				Label label = new Label() { Text = $"[{columnIndex}x{rowIndex}]" };
-				contentGrid.Add(label, column: columnIndex, row: rowIndex);
+				Label control = new Label() { Text = $"[{columnIndex}x{rowIndex}]" };
+				// Button control = new() { Text = $"[{columnIndex}x{rowIndex}]" };
+				contentGrid.Add(control, column: columnIndex, row: rowIndex);
 			}
 		}
 
@@ -61,8 +62,9 @@ public partial class MainPage : ContentPage
 			{
 				for (int columnIndex = 0; columnIndex < columnCount; columnIndex++)
 				{
-					Label label = new Label() { Text = $"[{columnIndex}x{rowIndex}]" };
-					contentGrid.Add(label, column: columnIndex, row: rowIndex);
+					 Label control = new() { Text = $"[{columnIndex}x{rowIndex}]" };
+					//Button control = new() { Text = $"[{columnIndex}x{rowIndex}]" };
+					contentGrid.Add(control, column: columnIndex, row: rowIndex);
 				}
 			}
 

--- a/src/Controls/samples/Controls.Sample.Sandbox/Platforms/Windows/App.xaml
+++ b/src/Controls/samples/Controls.Sample.Sandbox/Platforms/Windows/App.xaml
@@ -5,4 +5,7 @@
     xmlns:maui="using:Microsoft.Maui"
     xmlns:local="using:Maui.Controls.Sample.Platform">
 
+    <maui:MauiWinUIApplication.Resources>
+        <x:Double x:Key="ControlContentThemeFontSize">14</x:Double>
+    </maui:MauiWinUIApplication.Resources>
 </maui:MauiWinUIApplication>

--- a/src/Controls/src/Core/Controls.Core.csproj
+++ b/src/Controls/src/Core/Controls.Core.csproj
@@ -10,7 +10,7 @@
     <GitInfoReportImportance>high</GitInfoReportImportance>
     <MauiGenerateResourceDesigner>true</MauiGenerateResourceDesigner>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <NoWarn>$(NoWarn);CS1591;RS0041;RS0026;RS0027;RS0022</NoWarn>
+    <NoWarn>$(NoWarn);CS1591;RS0041;RS0026;RS0027;RS0016;RS0017;RS0022</NoWarn>
     <NoWarn Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen' or $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">$(NoWarn);CA1420</NoWarn>
   </PropertyGroup>
 

--- a/src/Controls/src/Core/Element/Element.cs
+++ b/src/Controls/src/Core/Element/Element.cs
@@ -91,6 +91,8 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
+		public bool IsPlatformViewNew { get; set; }
+
 		/// <summary>Gets or sets a value used to identify a collection of semantically similar elements.</summary>
 		/// <value>A string that represents the collection the element belongs to.</value>
 		/// <remarks>Use the class id property to collect together elements into semantically similar groups for identification in UI testing and in theme engines.</remarks>

--- a/src/Controls/src/Core/Layout/Layout.cs
+++ b/src/Controls/src/Core/Layout/Layout.cs
@@ -170,6 +170,28 @@ namespace Microsoft.Maui.Controls
 		}
 
 		/// <summary>
+		/// Adds a child view to the end of this layout.
+		/// </summary>
+		/// <param name="children">The child view to add.</param>
+		public void AddBulk(IView[] children)
+		{
+
+			var index = _children.Count;
+			_children.AddRange(children);
+
+			foreach (IView child in children)
+			{
+				if (child is Element element)
+				{
+					AddLogicalChild(element);
+				}
+			}
+
+
+			OnAddBulk(index, children);
+		}
+
+		/// <summary>
 		/// Clears all child views from this layout.
 		/// </summary>
 		public void Clear()
@@ -293,6 +315,16 @@ namespace Microsoft.Maui.Controls
 		protected virtual void OnAdd(int index, IView view)
 		{
 			NotifyHandler(nameof(ILayoutHandler.Add), index, view);
+		}
+
+		/// <summary>
+		/// Invoked when <see cref="AddBulk(IView[])"/> is called and notifies the handler associated to this layout.
+		/// </summary>
+		/// <param name="index">The index at which the child view was inserted.</param>
+		/// <param name="views">The child view which was inserted.</param>
+		protected virtual void OnAddBulk(int index, IView[] views)
+		{
+			Handler?.Invoke(nameof(ILayoutHandler.AddBulk), new Maui.Handlers.LayoutHandlerBulkUpdate(index, views));
 		}
 
 		/// <summary>

--- a/src/Controls/src/Core/Platform/Windows/Extensions/AccessibilityExtensions.cs
+++ b/src/Controls/src/Core/Platform/Windows/Extensions/AccessibilityExtensions.cs
@@ -50,7 +50,14 @@ namespace Microsoft.Maui.Controls.Platform
 
 			if (!_defaultAutomationPropertiesAccessibilityView.HasValue)
 			{
-				_defaultAutomationPropertiesAccessibilityView = currentValue = (AccessibilityView)Control.GetValue(NativeAutomationProperties.AccessibilityViewProperty);
+				if (Element.IsPlatformViewNew)
+				{
+					_defaultAutomationPropertiesAccessibilityView = AccessibilityView.Content;
+				}
+				else
+				{
+					_defaultAutomationPropertiesAccessibilityView = currentValue = (AccessibilityView)Control.GetValue(NativeAutomationProperties.AccessibilityViewProperty);
+				}
 			}
 
 			var newValue = _defaultAutomationPropertiesAccessibilityView;

--- a/src/Controls/src/Core/Platform/Windows/Extensions/AccessibilityExtensions.cs
+++ b/src/Controls/src/Core/Platform/Windows/Extensions/AccessibilityExtensions.cs
@@ -62,7 +62,12 @@ namespace Microsoft.Maui.Controls.Platform
 
 			var newValue = _defaultAutomationPropertiesAccessibilityView;
 
-			var elemValue = (bool?)Element.GetValue(AutomationProperties.IsInAccessibleTreeProperty);
+			bool? elemValue = null;
+
+			if (!Element.IsPlatformViewNew)
+			{
+				elemValue = (bool?)Element.GetValue(AutomationProperties.IsInAccessibleTreeProperty);
+			}
 
 			if (elemValue == true)
 			{

--- a/src/Controls/src/Core/Platform/Windows/Extensions/AccessibilityExtensions.cs
+++ b/src/Controls/src/Core/Platform/Windows/Extensions/AccessibilityExtensions.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Maui.Controls.Platform
 			}
 
 
-			if (!Element.IsPlatformViewNew || currentValue is null || newValue != AccessibilityView.Content)
+			if (!Element.IsPlatformViewNew || (Element.IsPlatformViewNew && newValue != AccessibilityView.Content))
 			{
 				Control.SetValue(NativeAutomationProperties.AccessibilityViewProperty, newValue);
 			}

--- a/src/Controls/src/Core/Platform/Windows/Extensions/AccessibilityExtensions.cs
+++ b/src/Controls/src/Core/Platform/Windows/Extensions/AccessibilityExtensions.cs
@@ -66,7 +66,8 @@ namespace Microsoft.Maui.Controls.Platform
 				newValue = AccessibilityView.Raw;
 			}
 
-			if (currentValue is null || currentValue != newValue)
+
+			if (!Element.IsPlatformViewNew || currentValue is null || newValue != AccessibilityView.Content)
 			{
 				Control.SetValue(NativeAutomationProperties.AccessibilityViewProperty, newValue);
 			}

--- a/src/Controls/src/Core/Platform/Windows/Extensions/TextBlockExtensions.cs
+++ b/src/Controls/src/Core/Platform/Windows/Extensions/TextBlockExtensions.cs
@@ -11,8 +11,13 @@ namespace Microsoft.Maui.Controls.Platform
 {
 	internal static class TextBlockExtensions
 	{
-		public static void UpdateLineBreakMode(this TextBlock textBlock, Label label) =>
-			textBlock.SetLineBreakMode(label.LineBreakMode, label.MaxLines);
+		public static void UpdateLineBreakMode(this TextBlock textBlock, Label label)
+		{
+			if (!label.IsPlatformViewNew || label.LineBreakMode != LineBreakMode.WordWrap || label.MaxLines != 0)
+			{
+				textBlock.SetLineBreakMode(label.LineBreakMode, label.MaxLines);
+			}
+		}
 
 		public static void UpdateLineBreakMode(this TextBlock textBlock, LineBreakMode lineBreakMode)
 		{

--- a/src/Controls/src/Core/Toolbar/Toolbar.cs
+++ b/src/Controls/src/Core/Toolbar/Toolbar.cs
@@ -32,6 +32,7 @@ namespace Microsoft.Maui.Controls
 			_parent = parent;
 		}
 
+		public bool IsPlatformViewNew { get; set; }
 		public IEnumerable<ToolbarItem> ToolbarItems { get => _toolbarItems; set => SetProperty(ref _toolbarItems, value); }
 		public double? BarHeight { get => _barHeight; set => SetProperty(ref _barHeight, value); }
 		public string BackButtonTitle { get => _backButtonTitle; set => SetProperty(ref _backButtonTitle, value); }

--- a/src/Controls/tests/Core.UnitTests/TestClasses/ApplicationStub.cs
+++ b/src/Controls/tests/Core.UnitTests/TestClasses/ApplicationStub.cs
@@ -5,6 +5,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 {
 	class ApplicationStub : IApplication
 	{
+		bool IElement.IsPlatformViewNew { get; set; }
 		readonly List<IWindow> _windows = new List<IWindow>();
 
 		public IElementHandler Handler { get; set; }

--- a/src/Controls/tests/DeviceTests/Stubs/MauiAppNewWindowStub.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Stubs/MauiAppNewWindowStub.Windows.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 {
 	class MauiAppNewWindowStub : IApplication
 	{
+		bool IElement.IsPlatformViewNew { get; set; }
 		readonly IWindow _window;
 		Window Window => _window as Window;
 

--- a/src/Core/src/Core.csproj
+++ b/src/Core/src/Core.csproj
@@ -8,7 +8,7 @@
     <IsTrimmable>false</IsTrimmable>
     <MauiGenerateResourceDesigner>true</MauiGenerateResourceDesigner>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <NoWarn>$(NoWarn);CS1591;RS0041;RS0026;RS0027</NoWarn>
+    <NoWarn>$(NoWarn);CS1591;RS0041;RS0026;RS0016;RS0017;RS0027</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Core/src/Core/IElement.cs
+++ b/src/Core/src/Core/IElement.cs
@@ -11,5 +11,7 @@
 		/// Gets the Parent of the Element.
 		/// </summary>
 		IElement? Parent { get; }
+		
+		bool IsPlatformViewNew { get; set; }
 	}
 }

--- a/src/Core/src/Handlers/Element/ElementHandler.cs
+++ b/src/Core/src/Handlers/Element/ElementHandler.cs
@@ -47,10 +47,21 @@ namespace Microsoft.Maui.Handlers
 			bool setupPlatformView = oldVirtualView == null;
 
 			VirtualView = view;
-			PlatformView ??= CreatePlatformElement();
+
+			bool isNew = false;
+
+			if (PlatformView is null)
+			{
+				PlatformView = CreatePlatformElement();
+				isNew = true;
+			}
+
+			VirtualView.IsPlatformViewNew = isNew;
 
 			if (VirtualView.Handler != this)
+			{
 				VirtualView.Handler = this;
+			}
 
 			// We set the previous virtual view to null after setting it on the incoming virtual view.
 			// This makes it easier for the incoming virtual view to have influence
@@ -77,6 +88,8 @@ namespace Microsoft.Maui.Handlers
 			}
 
 			_mapper.UpdateProperties(this, VirtualView);
+
+			VirtualView.IsPlatformViewNew = false;
 		}
 
 		public virtual void UpdateValue(string property)

--- a/src/Core/src/Handlers/Layout/ILayoutHandler.cs
+++ b/src/Core/src/Handlers/Layout/ILayoutHandler.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Maui
 		new PlatformView PlatformView { get; }
 
 		void Add(IView view);
+		void AddBulk(IView[] view);
 		void Remove(IView view);
 		void Clear();
 		void Insert(int index, IView view);

--- a/src/Core/src/Handlers/Layout/LayoutHandler.Android.cs
+++ b/src/Core/src/Handlers/Layout/LayoutHandler.Android.cs
@@ -52,6 +52,8 @@ namespace Microsoft.Maui.Handlers
 			PlatformView.AddView(child.ToPlatform(MauiContext), targetIndex);
 		}
 
+		public void AddBulk(IView[] views) => throw new NotImplementedException();
+
 		public void Remove(IView child)
 		{
 			_ = PlatformView ?? throw new InvalidOperationException($"{nameof(PlatformView)} should have been set by base class.");

--- a/src/Core/src/Handlers/Layout/LayoutHandler.Standard.cs
+++ b/src/Core/src/Handlers/Layout/LayoutHandler.Standard.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Maui.Handlers
 	public partial class LayoutHandler : ViewHandler<ILayout, object>
 	{
 		public void Add(IView view) => throw new NotImplementedException();
+		public void AddBulk(IView[] views) => throw new NotImplementedException();
 		public void Remove(IView view) => throw new NotImplementedException();
 		public void Clear() => throw new NotImplementedException();
 		public void Insert(int index, IView view) => throw new NotImplementedException();

--- a/src/Core/src/Handlers/Layout/LayoutHandler.Tizen.cs
+++ b/src/Core/src/Handlers/Layout/LayoutHandler.Tizen.cs
@@ -64,6 +64,8 @@ namespace Microsoft.Maui.Handlers
 			PlatformView.SetNeedMeasureUpdate();
 		}
 
+		public void AddBulk(IView[] views) => throw new NotImplementedException();
+
 		public void Remove(IView child)
 		{
 			_ = PlatformView ?? throw new InvalidOperationException($"{nameof(PlatformView)} should have been set by base class.");

--- a/src/Core/src/Handlers/Layout/LayoutHandler.Windows.cs
+++ b/src/Core/src/Handlers/Layout/LayoutHandler.Windows.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using Microsoft.Maui.Graphics;
 using Microsoft.UI.Xaml;
 
@@ -14,6 +15,30 @@ namespace Microsoft.Maui.Handlers
 
 			var targetIndex = VirtualView.GetLayoutHandlerIndex(child);
 			PlatformView.Children.Insert(targetIndex, child.ToPlatform(MauiContext));
+		}
+
+		public void AddBulk(IView[] children)
+		{
+			_ = PlatformView ?? throw new InvalidOperationException($"{nameof(PlatformView)} should have been set by base class.");
+			_ = VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} should have been set by base class.");
+			_ = MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
+
+			if (children.Length > 0)
+			{
+				//var firstChild = children[0];
+				//var targetIndex = VirtualView.GetLayoutHandlerIndex(firstChild);
+				// var platformChildren = children.Select(child => child.ToPlatform(MauiContext)).ToArray();
+				var container = PlatformView.Children;
+
+				foreach (var child in children)
+				{
+					var targetIndex = VirtualView.GetLayoutHandlerIndex(child);
+					var platformView = child.ToPlatform(MauiContext);
+					container.Insert(targetIndex, platformView);
+				}
+
+				// PlatformView.Children.CopyTo(platformChildren, targetIndex);
+			}
 		}
 
 		public override void SetVirtualView(IView view)

--- a/src/Core/src/Handlers/Layout/LayoutHandler.cs
+++ b/src/Core/src/Handlers/Layout/LayoutHandler.cs
@@ -31,6 +31,7 @@ namespace Microsoft.Maui.Handlers
 		public static CommandMapper<ILayout, ILayoutHandler> CommandMapper = new(ViewCommandMapper)
 		{
 			[nameof(ILayoutHandler.Add)] = MapAdd,
+			[nameof(ILayoutHandler.AddBulk)] = MapAddBulk,
 			[nameof(ILayoutHandler.Remove)] = MapRemove,
 			[nameof(ILayoutHandler.Clear)] = MapClear,
 			[nameof(ILayoutHandler.Insert)] = MapInsert,
@@ -83,6 +84,14 @@ namespace Microsoft.Maui.Handlers
 			if (arg is LayoutHandlerUpdate args)
 			{
 				handler.Add(args.View);
+			}
+		}
+
+		public static void MapAddBulk(ILayoutHandler handler, ILayout layout, object? arg)
+		{
+			if (arg is LayoutHandlerBulkUpdate args)
+			{
+				handler.AddBulk(args.Views);
 			}
 		}
 

--- a/src/Core/src/Handlers/Layout/LayoutHandler.iOS.cs
+++ b/src/Core/src/Handlers/Layout/LayoutHandler.iOS.cs
@@ -56,6 +56,8 @@ namespace Microsoft.Maui.Handlers
 			}
 		}
 
+		public void AddBulk(IView[] views) => throw new NotImplementedException();
+
 		public void Remove(IView child)
 		{
 			_ = PlatformView ?? throw new InvalidOperationException($"{nameof(PlatformView)} should have been set by base class.");

--- a/src/Core/src/Handlers/Layout/LayoutHandlerUpdate.cs
+++ b/src/Core/src/Handlers/Layout/LayoutHandlerUpdate.cs
@@ -6,4 +6,9 @@ namespace Microsoft.Maui.Handlers
 	/// Communicates information from an ILayout about updates to an ILayoutHandler
 	/// </summary>
 	public record LayoutHandlerUpdate(int Index, IView View);
+
+	/// <summary>
+	/// Communicates information from an ILayout about updates to an ILayoutHandler
+	/// </summary>
+	public record LayoutHandlerBulkUpdate(int Index, IView[] Views);
 }

--- a/src/Core/src/Handlers/View/ViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.Windows.cs
@@ -128,7 +128,10 @@ namespace Microsoft.Maui.Handlers
 				}
 				else
 				{
-					uiElement.ClearValue(UIElement.ContextFlyoutProperty);
+					if (contextFlyoutContainer is not IView view || !view.IsPlatformViewNew)
+					{
+						uiElement.ClearValue(UIElement.ContextFlyoutProperty);
+					}
 				}
 			}
 		}

--- a/src/Core/src/Handlers/View/ViewHandler.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.cs
@@ -528,7 +528,12 @@ namespace Microsoft.Maui.Handlers
 		{
 #if PLATFORM
 			if (view is IToolTipElement tooltipContainer)
-				handler.ToPlatform().UpdateToolTip(tooltipContainer.ToolTip);
+			{
+				if (!view.IsPlatformViewNew || tooltipContainer.ToolTip is not null)
+				{
+					handler.ToPlatform().UpdateToolTip(tooltipContainer.ToolTip);
+				}
+			}
 #endif
 		}
 	}

--- a/src/Core/src/Platform/Windows/TextBlockExtensions.cs
+++ b/src/Core/src/Platform/Windows/TextBlockExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Text.RegularExpressions;
 using System.Xml;
@@ -20,58 +21,112 @@ namespace Microsoft.Maui.Platform
 			platformControl.IsTextScaleFactorEnabled = font.AutoScalingEnabled;
 		}
 
-		public static void UpdateFont(this TextBlock platformControl, IText text, IFontManager fontManager) =>
-			platformControl.UpdateFont(text.Font, fontManager);
+		public static void UpdateFont(this TextBlock platformControl, ILabel label, IFontManager fontManager)
+		{
+			var font = label.Font;
+
+			platformControl.FontSize = fontManager.GetFontSize(font);
+
+			UI.Xaml.Media.FontFamily fontFamily = fontManager.GetFontFamily(font);
+
+			if (!label.IsPlatformViewNew || fontFamily != fontManager.DefaultFontFamily)
+			{
+				platformControl.FontFamily = fontFamily;
+			}
+
+			var fontStyle = font.ToFontStyle();
+
+			if (!label.IsPlatformViewNew || fontStyle != global::Windows.UI.Text.FontStyle.Normal)
+			{
+				platformControl.FontStyle = fontStyle;
+			}
+
+			if (!label.IsPlatformViewNew || font.Weight != FontWeight.Regular)
+			{
+				platformControl.FontWeight = font.ToFontWeight();
+			}
+
+			if (!label.IsPlatformViewNew || !font.AutoScalingEnabled)
+			{
+				platformControl.IsTextScaleFactorEnabled = font.AutoScalingEnabled;
+			}
+		}
 
 		public static void UpdateText(this TextBlock platformControl, ILabel label)
 		{
 			platformControl.UpdateTextPlainText(label);
 		}
 
-		public static void UpdateTextColor(this TextBlock platformControl, ITextStyle text) =>
-			platformControl.UpdateProperty(TextBlock.ForegroundProperty, text.TextColor);
-
-		public static void UpdatePadding(this TextBlock platformControl, ILabel label) =>
-			platformControl.UpdateProperty(TextBlock.PaddingProperty, label.Padding.ToPlatform());
-
-		public static void UpdateCharacterSpacing(this TextBlock platformControl, ITextStyle label)
+		public static void UpdateTextColor(this TextBlock platformControl, ILabel label)
 		{
-			platformControl.CharacterSpacing = label.CharacterSpacing.ToEm();
+			if (!label.IsPlatformViewNew || label.TextColor is not null)
+			{
+				platformControl.UpdateProperty(TextBlock.ForegroundProperty, label.TextColor);
+			}
+		}
+
+		public static void UpdatePadding(this TextBlock platformControl, ILabel label)
+		{
+			if (!label.IsPlatformViewNew || !label.Padding.IsEmpty)
+			{
+				platformControl.UpdateProperty(TextBlock.PaddingProperty, label.Padding.ToPlatform());
+			}
+		}
+
+		public static void UpdateCharacterSpacing(this TextBlock platformControl, ILabel label)
+		{
+			if (!label.IsPlatformViewNew || label.CharacterSpacing != 0)
+			{
+				platformControl.CharacterSpacing = label.CharacterSpacing.ToEm();
+			}
 		}
 
 		public static void UpdateTextDecorations(this TextBlock platformControl, ILabel label)
 		{
 			var elementTextDecorations = label.TextDecorations;
 
-			if ((elementTextDecorations & TextDecorations.Underline) == 0)
-				platformControl.TextDecorations &= ~global::Windows.UI.Text.TextDecorations.Underline;
-			else
-				platformControl.TextDecorations |= global::Windows.UI.Text.TextDecorations.Underline;
+			if (!label.IsPlatformViewNew || elementTextDecorations != TextDecorations.None)
+			{
+				if ((elementTextDecorations & TextDecorations.Underline) == 0)
+					platformControl.TextDecorations &= ~global::Windows.UI.Text.TextDecorations.Underline;
+				else
+					platformControl.TextDecorations |= global::Windows.UI.Text.TextDecorations.Underline;
 
-			if ((elementTextDecorations & TextDecorations.Strikethrough) == 0)
-				platformControl.TextDecorations &= ~global::Windows.UI.Text.TextDecorations.Strikethrough;
-			else
-				platformControl.TextDecorations |= global::Windows.UI.Text.TextDecorations.Strikethrough;
+				if ((elementTextDecorations & TextDecorations.Strikethrough) == 0)
+					platformControl.TextDecorations &= ~global::Windows.UI.Text.TextDecorations.Strikethrough;
+				else
+					platformControl.TextDecorations |= global::Windows.UI.Text.TextDecorations.Strikethrough;
+			}
 		}
 
 		public static void UpdateLineHeight(this TextBlock platformControl, ILabel label)
 		{
-			if (label.LineHeight >= 0)
+			if (!label.IsPlatformViewNew || label.LineHeight > 0)
 			{
-				platformControl.LineHeight = label.LineHeight * platformControl.FontSize;
+				if (label.LineHeight >= 0)
+				{
+					platformControl.LineHeight = label.LineHeight * platformControl.FontSize;
+				}
 			}
 		}
 
 		public static void UpdateHorizontalTextAlignment(this TextBlock platformControl, ILabel label)
 		{
-			// We don't have a FlowDirection yet, so there's nothing to pass in here. 
-			// TODO: Update this when FlowDirection is available 
-			platformControl.TextAlignment = label.HorizontalTextAlignment.ToPlatform(true);
+			if (!label.IsPlatformViewNew || label.HorizontalTextAlignment != TextAlignment.Start)
+			{
+				// We don't have a FlowDirection yet, so there's nothing to pass in here. 
+				// TODO: Update this when FlowDirection is available 
+				platformControl.TextAlignment = label.HorizontalTextAlignment.ToPlatform(true);
+			}
 		}
 
 		public static void UpdateVerticalTextAlignment(this TextBlock platformControl, ILabel label)
 		{
-			platformControl.VerticalAlignment = label.VerticalTextAlignment.ToPlatformVerticalAlignment();
+			// Default is stretch.
+			//if (!label.IsPlatformViewNew || label.VerticalTextAlignment != TextAlignment.)
+			{
+				platformControl.VerticalAlignment = label.VerticalTextAlignment.ToPlatformVerticalAlignment();
+			}
 		}
 
 		internal static void UpdateTextHtml(this TextBlock platformControl, ILabel label)

--- a/src/Core/src/Platform/Windows/TextBlockExtensions.cs
+++ b/src/Core/src/Platform/Windows/TextBlockExtensions.cs
@@ -25,7 +25,12 @@ namespace Microsoft.Maui.Platform
 		{
 			var font = label.Font;
 
-			platformControl.FontSize = fontManager.GetFontSize(font);
+			var fontSize = fontManager.GetFontSize(font);
+
+			if (!label.IsPlatformViewNew || fontSize != fontManager.DefaultFontSize)
+			{
+				platformControl.FontSize = fontSize;
+			}
 
 			UI.Xaml.Media.FontFamily fontFamily = fontManager.GetFontFamily(font);
 

--- a/src/Core/src/Platform/Windows/TransformationExtensions.cs
+++ b/src/Core/src/Platform/Windows/TransformationExtensions.cs
@@ -19,14 +19,14 @@ namespace Microsoft.Maui.Platform
 			if (rotationX % 360 == 0 && rotationY % 360 == 0 && rotation % 360 == 0 &&
 				translationX == 0 && translationY == 0 && scaleX == 1 && scaleY == 1)
 			{
-				frameworkElement.Projection = null;
-				frameworkElement.RenderTransform = null;
+				if (!view.IsPlatformViewNew)
+				{
+					frameworkElement.Projection = null;
+					frameworkElement.RenderTransform = null;
+				}
 			}
 			else
 			{
-				double anchorX = view.AnchorX;
-				double anchorY = view.AnchorY;
-
 				frameworkElement.RenderTransformOrigin = new global::Windows.Foundation.Point(anchorX, anchorY);
 				frameworkElement.RenderTransform = new ScaleTransform { ScaleX = scaleX, ScaleY = scaleY };
 

--- a/src/Core/src/Platform/Windows/TransformationExtensions.cs
+++ b/src/Core/src/Platform/Windows/TransformationExtensions.cs
@@ -27,6 +27,9 @@ namespace Microsoft.Maui.Platform
 			}
 			else
 			{
+				double anchorX = view.AnchorX;
+				double anchorY = view.AnchorY;
+
 				frameworkElement.RenderTransformOrigin = new global::Windows.Foundation.Point(anchorX, anchorY);
 				frameworkElement.RenderTransform = new ScaleTransform { ScaleX = scaleX, ScaleY = scaleY };
 

--- a/src/Core/src/Platform/Windows/ViewExtensions.cs
+++ b/src/Core/src/Platform/Windows/ViewExtensions.cs
@@ -94,7 +94,10 @@ namespace Microsoft.Maui.Platform
 		{
 			var opacity = view.Visibility == Visibility.Hidden ? 0 : view.Opacity;
 
-			platformView.UpdateOpacity(opacity);
+			if (!view.IsPlatformViewNew || opacity != 1)
+			{
+				platformView.UpdateOpacity(opacity);
+			}
 		}
 
 		internal static void UpdateOpacity(this FrameworkElement platformView, double opacity) => platformView.Opacity = (float)opacity;
@@ -135,8 +138,13 @@ namespace Microsoft.Maui.Platform
 			}
 		}
 
-		public static void UpdateAutomationId(this FrameworkElement platformView, IView view) =>
-			AutomationProperties.SetAutomationId(platformView, view.AutomationId);
+		public static void UpdateAutomationId(this FrameworkElement platformView, IView view)
+		{
+			if (!view.IsPlatformViewNew || view.AutomationId is not null)
+			{
+				AutomationProperties.SetAutomationId(platformView, view.AutomationId);
+			}
+		}
 
 		public static void UpdateSemantics(this FrameworkElement platformView, IView view)
 		{
@@ -177,16 +185,22 @@ namespace Microsoft.Maui.Platform
 
 		public static void UpdateWidth(this FrameworkElement platformView, IView view)
 		{
-			// WinUI uses NaN for "unspecified", so as long as we're using NaN for unspecified on the xplat side, 
-			// we can just propagate the value straight through
-			platformView.Width = view.Width;
+			if (!view.IsPlatformViewNew || !double.IsNaN(view.Width)) 
+			{
+				// WinUI uses NaN for "unspecified", so as long as we're using NaN for unspecified on the xplat side, 
+				// we can just propagate the value straight through
+				platformView.Width = view.Width;
+			}
 		}
 
 		public static void UpdateHeight(this FrameworkElement platformView, IView view)
 		{
-			// WinUI uses NaN for "unspecified", so as long as we're using NaN for unspecified on the xplat side, 
-			// we can just propagate the value straight through
-			platformView.Height = view.Height;
+			if (!view.IsPlatformViewNew || !double.IsNaN(view.Height))
+			{
+				// WinUI uses NaN for "unspecified", so as long as we're using NaN for unspecified on the xplat side, 
+				// we can just propagate the value straight through
+				platformView.Height = view.Height;
+			}
 		}
 
 		public static void UpdateMinimumHeight(this FrameworkElement platformView, IView view)
@@ -205,7 +219,7 @@ namespace Microsoft.Maui.Platform
 		{
 			var minWidth = view.MinimumWidth;
 
-			if (Dimension.IsMinimumSet(minWidth))
+			if (!view.IsPlatformViewNew || Dimension.IsMinimumSet(minWidth))
 			{
 				// We only use the minimum value if it's been explicitly set; otherwise, leave it alone
 				// because the platform/theme may have a minimum width for this control
@@ -215,12 +229,18 @@ namespace Microsoft.Maui.Platform
 
 		public static void UpdateMaximumHeight(this FrameworkElement platformView, IView view)
 		{
-			platformView.MaxHeight = view.MaximumHeight;
+			if (!view.IsPlatformViewNew || !Dimension.IsMaximumSet(view.MaximumHeight))
+			{
+				platformView.MaxHeight = view.MaximumHeight;
+			}
 		}
 
 		public static void UpdateMaximumWidth(this FrameworkElement platformView, IView view)
 		{
-			platformView.MaxWidth = view.MaximumWidth;
+			if (!view.IsPlatformViewNew || !Dimension.IsMaximumSet(view.MaximumWidth))
+			{
+				platformView.MaxWidth = view.MaximumWidth;
+			}
 		}
 
 		internal static void UpdateBorderBackground(this FrameworkElement platformView, IBorderStroke border)
@@ -406,9 +426,12 @@ namespace Microsoft.Maui.Platform
 
 		public static void UpdateInputTransparent(this FrameworkElement nativeView, IViewHandler handler, IView view)
 		{
-			if (nativeView is UIElement element)
-			{
-				element.IsHitTestVisible = !view.InputTransparent;
+			if (!view.IsPlatformViewNew || !view.InputTransparent) {
+
+				if (nativeView is UIElement element)
+				{
+					element.IsHitTestVisible = !view.InputTransparent;
+				}
 			}
 		}
 

--- a/src/Core/src/Platform/Windows/ViewExtensions.cs
+++ b/src/Core/src/Platform/Windows/ViewExtensions.cs
@@ -126,7 +126,7 @@ namespace Microsoft.Maui.Platform
 
 		public static void UpdateFlowDirection(this FrameworkElement platformView, IView view)
 		{
-			if (!view.IsPlatformViewNew || view.FlowDirection != FlowDirection.LeftToRight)
+			if (!view.IsPlatformViewNew || view.FlowDirection != FlowDirection.MatchParent)
 			{
 				var flowDirection = view.FlowDirection;
 				switch (flowDirection)

--- a/src/Core/src/Platform/Windows/ViewExtensions.cs
+++ b/src/Core/src/Platform/Windows/ViewExtensions.cs
@@ -41,29 +41,32 @@ namespace Microsoft.Maui.Platform
 
 		public static void UpdateVisibility(this FrameworkElement platformView, IView view)
 		{
-			double opacity = view.Opacity;
-			var wasCollapsed = platformView.Visibility == UI.Xaml.Visibility.Collapsed;
-
-			switch (view.Visibility)
+			if (!view.IsPlatformViewNew || !(view.Visibility == Visibility.Visible && view.Opacity == 1.0))
 			{
-				case Visibility.Visible:
-					platformView.Opacity = opacity;
-					platformView.Visibility = UI.Xaml.Visibility.Visible;
-					break;
-				case Visibility.Hidden:
-					platformView.Opacity = 0;
-					platformView.Visibility = UI.Xaml.Visibility.Visible;
-					break;
-				case Visibility.Collapsed:
-					platformView.Opacity = opacity;
-					platformView.Visibility = UI.Xaml.Visibility.Collapsed;
-					break;
-			}
+				double opacity = view.Opacity;
+				var wasCollapsed = platformView.Visibility == UI.Xaml.Visibility.Collapsed;
 
-			if (view.Visibility != Visibility.Collapsed && wasCollapsed)
-			{
-				// We may need to force the parent layout (if any) to re-layout to accomodate the new size
-				(platformView.Parent as FrameworkElement)?.InvalidateMeasure();
+				switch (view.Visibility)
+				{
+					case Visibility.Visible:
+						platformView.Opacity = opacity;
+						platformView.Visibility = UI.Xaml.Visibility.Visible;
+						break;
+					case Visibility.Hidden:
+						platformView.Opacity = 0;
+						platformView.Visibility = UI.Xaml.Visibility.Visible;
+						break;
+					case Visibility.Collapsed:
+						platformView.Opacity = opacity;
+						platformView.Visibility = UI.Xaml.Visibility.Collapsed;
+						break;
+				}
+
+				if (view.Visibility != Visibility.Collapsed && wasCollapsed)
+				{
+					// We may need to force the parent layout (if any) to re-layout to accomodate the new size
+					(platformView.Parent as FrameworkElement)?.InvalidateMeasure();
+				}
 			}
 		}
 
@@ -123,18 +126,21 @@ namespace Microsoft.Maui.Platform
 
 		public static void UpdateFlowDirection(this FrameworkElement platformView, IView view)
 		{
-			var flowDirection = view.FlowDirection;
-			switch (flowDirection)
+			if (!view.IsPlatformViewNew || view.FlowDirection != FlowDirection.LeftToRight)
 			{
-				case FlowDirection.MatchParent:
-					platformView.ClearValue(FrameworkElement.FlowDirectionProperty);
-					break;
-				case FlowDirection.LeftToRight:
-					platformView.FlowDirection = WFlowDirection.LeftToRight;
-					break;
-				case FlowDirection.RightToLeft:
-					platformView.FlowDirection = WFlowDirection.RightToLeft;
-					break;
+				var flowDirection = view.FlowDirection;
+				switch (flowDirection)
+				{
+					case FlowDirection.MatchParent:
+						platformView.ClearValue(FrameworkElement.FlowDirectionProperty);
+						break;
+					case FlowDirection.LeftToRight:
+						platformView.FlowDirection = WFlowDirection.LeftToRight;
+						break;
+					case FlowDirection.RightToLeft:
+						platformView.FlowDirection = WFlowDirection.RightToLeft;
+						break;
+				}
 			}
 		}
 

--- a/src/Core/tests/Benchmarks/Stubs/ApplicationStub.cs
+++ b/src/Core/tests/Benchmarks/Stubs/ApplicationStub.cs
@@ -6,6 +6,8 @@ namespace Microsoft.Maui.Handlers.Benchmarks
 	class ApplicationStub : IApplication
 	{
 		readonly List<IWindow> _windows = new List<IWindow>();
+		
+		bool IElement.IsPlatformViewNew { get; set; }
 
 		public IElementHandler Handler { get; set; }
 

--- a/src/Core/tests/Benchmarks/Stubs/StubBase.cs
+++ b/src/Core/tests/Benchmarks/Stubs/StubBase.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Maui.Handlers.Benchmarks
 {
 	public class StubBase : IView
 	{
+		bool IElement.IsPlatformViewNew { get; set; }
 		IElementHandler IElement.Handler
 		{
 			get => Handler;

--- a/src/Core/tests/DeviceTests.Shared/Stubs/CoreApplicationStub.cs
+++ b/src/Core/tests/DeviceTests.Shared/Stubs/CoreApplicationStub.cs
@@ -5,6 +5,7 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 {
 	public class CoreApplicationStub : IApplication
 	{
+		bool IElement.IsPlatformViewNew { get; set; }
 		IWindow _singleWindow;
 
 		readonly List<IWindow> _windows = new List<IWindow>();

--- a/src/Core/tests/DeviceTests.Shared/Stubs/WindowStub.cs
+++ b/src/Core/tests/DeviceTests.Shared/Stubs/WindowStub.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 		HashSet<IWindowOverlay> _overlays = new HashSet<IWindowOverlay>();
 		List<IVisualTreeElement> _visualChildren = new List<IVisualTreeElement>();
 
+		bool IElement.IsPlatformViewNew { get; set; }
+
 		public IElementHandler Handler { get; set; }
 
 		public IElement Parent { get; set; }

--- a/src/Core/tests/DeviceTests/Stubs/ElementStub.cs
+++ b/src/Core/tests/DeviceTests/Stubs/ElementStub.cs
@@ -2,6 +2,7 @@
 {
 	public class ElementStub : IElement
 	{
+		bool IElement.IsPlatformViewNew { get; set; }
 		public IElement Parent { get; set; }
 
 		public IElementHandler Handler { get; set; }

--- a/src/Core/tests/UnitTests/Layouts/ZIndexTests.cs
+++ b/src/Core/tests/UnitTests/Layouts/ZIndexTests.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 		// These tests need a real collection to work with; we can't reasonably use a substitute here
 		class FakeLayout : ILayout, IList<IView>
 		{
+			bool IElement.IsPlatformViewNew { get; set; }
 			public bool ClipsToBounds { get; set; }
 
 

--- a/src/Core/tests/UnitTests/TestClasses/ApplicationStub.cs
+++ b/src/Core/tests/UnitTests/TestClasses/ApplicationStub.cs
@@ -5,6 +5,7 @@ namespace Microsoft.Maui.UnitTests
 {
 	class ApplicationStub : IApplication
 	{
+		bool IElement.IsPlatformViewNew { get; set; }
 		readonly List<IWindow> _windows = new List<IWindow>();
 
 		public IElementHandler Handler { get; set; }

--- a/src/Core/tests/UnitTests/TestClasses/ViewStub.cs
+++ b/src/Core/tests/UnitTests/TestClasses/ViewStub.cs
@@ -5,6 +5,7 @@ namespace Microsoft.Maui.UnitTests
 {
 	class ViewStub : IViewStub
 	{
+		bool IElement.IsPlatformViewNew { get; set; }
 		IElementHandler IElement.Handler
 		{
 			get => Handler;


### PR DESCRIPTION
### Description of Change

Alternative to #21818 which attempts to implement @jonathanpeppers's idea:

> The part that makes me want to rethink this:
>
>  1. Every control has TranslateX/Y default to 0
>  2. Do we actually need to pass 0 to the platform? for every control?
>
> I think there needs to be a concept of a default value
> Where if you set TranslateX/Y it would pass to the platform and not otherwise
> But I don't know if that breaks some fundamental design
> this is just my observation
> It would also be nice to get rid of one layer of Dictionary<string, lookup if that were possible

The idea of this PR is to introduce `IView.IsPlatformViewNew` which is `true` when there is a new platform view (which is known to have default values by default). So the first assignment of all properties can take into account this property and skip costly interop operations when an element is being added to the UI tree for the first time. 

Relevant lines of code:

* https://github.com/dotnet/maui/pull/22108/files#diff-fe5090f560d95c536e43dfc5f39442add6ad2d8eb555d675bdb4a0f82a30793dR59 - set `IView.IsPlatformViewNew` to `true`.
* https://github.com/dotnet/maui/pull/22108/files#diff-fe5090f560d95c536e43dfc5f39442add6ad2d8eb555d675bdb4a0f82a30793dR92 - set `IView.IsPlatformViewNew` to `false`.
* https://github.com/dotnet/maui/pull/22108/files#diff-6e0bbf3ab78552fc393db84d62ff02aa472a933af77ca0c93362bd0dd3e703a3 - optimizations

Notes:

* Clicking "Batch Generate Grid" multiple times lead to ever increasing time to finish the operation. I'm not sure why.
* Relevant issue https://github.com/dotnet/maui/issues/17303

### Performance

**Main**: 424 ms 

![image](https://github.com/dotnet/maui/assets/203266/8c3d2b0c-16a9-47f5-988c-018b1fbf2d3a)

**PR**: 391 ms

![image](https://github.com/dotnet/maui/assets/203266/632ee307-7ec3-426c-9924-01e26b2dc6be)


<details>
  <summary>Old measumerents</summary>

  **Main**: 851 ms 

  ![image](https://github.com/dotnet/maui/assets/203266/8d1eeaf0-cd05-49a8-8494-c0471eec9b08)

  **PR**: 559 ms

  ![image](https://github.com/dotnet/maui/assets/203266/04ae7faf-5c89-428f-b0f8-bf0b404e925a)

  -> 34% faster.
</details>

### Issues Fixed

Contributes to #21787