### PR TITLE
[android] fix one layer of "overdraw" by default

### DIFF
--- a/src/Core/src/Platform/Android/Resources/values/styles.xml
+++ b/src/Core/src/Platform/Android/Resources/values/styles.xml
@@ -16,6 +16,7 @@
         <item name="checkboxStyle">@style/MauiCheckBox</item>
         <item name="android:textAllCaps">false</item>
         <item name="alertDialogTheme">@style/MauiAlertDialogTheme</item>
+        <item name="android:windowBackground">@null</item>
     </style>
     <style name="Maui.MainTheme" parent="Maui.MainTheme.Base">
       <!-- v35+ uses this to inject edge to edge opt out attribute value -->


### PR DESCRIPTION
Fixes: https://github.com/dotnet/maui/issues/18245
Context: https://developer.android.com/studio/debug/dev-options#hardware
Context: https://developer.android.com/topic/performance/rendering/inspect-gpu-rendering#debug_overdraw
Context: https://stackoverflow.com/q/6499004

There is `Debug GPU Overdraw` developer option in Android that can be enabled to see overdraw in the app.

* Blue: overdrawn by 1
* Green: overdrawn by 2
* Pink: overdrawn by 3
* Red: overdrawn by 4+

The .NET MAUI project template shows `Blue` by default, in a project with nothing on the screen.

![image](https://github.com/dotnet/maui/assets/840039/32e6c0da-fdfd-491d-9e25-3e66b9db2449)

A workaround is noted on #18245, but the *best* workaround would be in `Platforms\Android\MainActivity.cs`:

    protected override void OnCreate(Bundle? savedInstanceState)
    {
        base.OnCreate(savedInstanceState);
        // Clear the Window's background
        Window?.SetBackgroundDrawable(null);
    }

With this change in place, the `Blue` overdraw is gone in the .NET MAUI project template:

![image](https://github.com/dotnet/maui/assets/840039/6b06b43f-17f2-412d-ad58-6dd4085bcb4b)

The result is .NET MAUI apps on Android should inherently use less GPU (the size of the screen), which could be noticeable on low-end devices. It could be particularly noticeable in apps that are moving into the `Red` range based on the developer's XAML & layout choices.

We can make this same change in .NET MAUI's default `Maui.MainTheme` Android theme:

    <item name="android:windowBackground">@null</item>

The default project template has a XAML style that sets the background:

    <Style TargetType="Page" ApplyToDerivedTypes="True">
        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource OffBlack}}" />
    </Style>

So the only case this change would be noticed (wrong color), would be if:

* Developer is using a `Page` with no `Background` set, and no `Background` set on the top-most layout.

* Developer removed all XAML styles or is migrating a Xamarin.Forms app

In this case, a developer could do one of:

* Apply a `Background` to the `Page`

* Extend the `Maui.MainTheme` style, but with a `Background` set