### PR TITLE
[Android] SemanticProperties.HeadingLevel not working in ListView #21830

### DIFF
--- a/src/Core/src/Platform/Android/SemanticExtensions.cs
+++ b/src/Core/src/Platform/Android/SemanticExtensions.cs
@@ -20,6 +20,8 @@ namespace Microsoft.Maui.Platform
 			string? newText = null;
 			string? newContentDescription = null;
 
+			info.Focusable = semantics?.IsHeading ?? false;
+
 			if (!string.IsNullOrEmpty(desc))
 			{
 				// Edit Text fields won't read anything for the content description


### PR DESCRIPTION
### Description of Change

Added Focusable on android Semantic Extension

### Issues Fixed

Heading is now voiced by the installation in the controls

Fixes #
#3117 
#21830 
Branch: main
