### PR TITLE
Add VS Code Extension to move-to-vs-feedback label

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -463,13 +463,13 @@ configuration:
       then:
       - addReply:
           reply: >-
-            Thanks for the issue report @${issueAuthor}! This issue appears to be a problem with Visual Studio, so we ask that you use the VS feedback tool to report the issue. That way it will get to the routed to the team that owns this experience in VS.
+            Thanks for the issue report @${issueAuthor}! This issue appears to be a problem with Visual Studio (Code), so we ask that you use the VS feedback tool to report the issue. That way it will get to the routed to the team that owns this experience in VS (Code).
 
 
-            If you encounter a problem with Visual Studio, we want to know about it so that we can diagnose and fix it. By using the Report a Problem tool, you can collect detailed information about the problem, and send it to Microsoft with just a few button clicks.
+            If you encounter a problem with Visual Studio or the .NET MAUI VS Code Extension, we want to know about it so that we can diagnose and fix it. By using the Report a Problem tool, you can collect detailed information about the problem, and send it to Microsoft with just a few button clicks.
 
 
-            1. Go to the [Visual Studio for Windows feedback tool](https://docs.microsoft.com/visualstudio/ide/how-to-report-a-problem-with-visual-studio?view=vs-2022) or [Visual Studio for Mac feedback tool](https://learn.microsoft.com/en-us/visualstudio/mac/report-a-problem?view=vsmac-2022) to report the issue
+            1. Go to the [Visual Studio for Windows feedback tool](https://learn.microsoft.com/visualstudio/ide/how-to-report-a-problem-with-visual-studio) or [.NET MAUI VS Code Extension repository](https://github.com/microsoft/vscode-dotnettools/issues) to report the issue
 
             2. Close this bug, and consider adding a link to the VS Feedback issue so that others can follow its activity there.
       description: Ask user to use VS Feedback for VS issues


### PR DESCRIPTION
When the `move-to-vs-feedback` label is applied a comment is added to point the author to the right places to report the issue with Visual Studio correctly.

This PR adds information for the .NET MAUI VS Code Extension.

Additionally it removes the Visual Studio for Mac information since that is not relevant anymore soon and the reported bugs today are probably not going to be fixed anymore. 