### PR TITLE
For XAML Hot Reload: Add public method to clear ResourceDictionary cache

### DIFF
--- a/src/Controls/src/Core/Internals/ResourceLoader.cs
+++ b/src/Controls/src/Core/Internals/ResourceLoader.cs
@@ -21,6 +21,15 @@ namespace Microsoft.Maui.Controls.Internals
 			}
 		}
 
+		/// <summary>
+		/// Typed ResourceDictionaries are cached when first loaded.
+		/// For hot reload to be able to modify and reload them, the cache must be able to be cleared.
+		/// </summary>
+		public static void ClearResourceCache()
+		{
+			ResourceDictionary.ClearCache();
+		}
+
 		public class ResourceLoadingQuery
 		{
 			public AssemblyName AssemblyName { get; set; }

--- a/src/Controls/src/Core/ResourceDictionary.cs
+++ b/src/Controls/src/Core/ResourceDictionary.cs
@@ -366,7 +366,7 @@ namespace Microsoft.Maui.Controls
 
 		event EventHandler<ResourcesChangedEventArgs> ValuesChanged;
 
-		//only used for unit testing
+		// Only used for unit testing and hot reload
 		internal static void ClearCache() => s_instances = new ConditionalWeakTable<Type, ResourceDictionary>();
 
 		[Xaml.ProvideCompiled("Microsoft.Maui.Controls.XamlC.RDSourceTypeConverter")]

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Gh13209.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Gh13209.xaml.cs
@@ -1,7 +1,5 @@
-using System;
 using System.Collections.Generic;
-using Microsoft.Maui.Controls;
-using Microsoft.Maui.Controls.Core.UnitTests;
+using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Graphics;
 using NUnit.Framework;
 
@@ -18,7 +16,7 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[TestFixture]
 		class Tests
 		{
-			[TearDown] public void TearDown() => ResourceDictionary.ClearCache();
+			[TearDown] public void TearDown() => ResourceLoader.ClearResourceCache();
 
 			[TestCase(true), TestCase(false)]
 			public void RdWithSource(bool useCompiledXaml)


### PR DESCRIPTION
### Description of Change

This change allows Visual Studio tooling for XAML hot reload to be able to access a method without using reflection.

When someone is debugging their MAUI app and triggers a Full Page Hot Reload, that feature needs to be able to reload a `ResourceDictionary` from its XAML source and not the cache. The method `ResourceDictionary.ClearCache` does the job, but it's an internal method. I'm exposing that method through `Microsoft.Maui.Controls.Internals.ResourceLoader` since that's where the other full page hot reload helper code is located.

Eventually Visual Studio can use the public static method instead of hacky reflection.