### PR TITLE
Remove implicit reference to Maui Compatibility and template references

### DIFF
--- a/src/Templates/src/templates/maui-blazor-solution/MauiApp.1/MauiApp.1.csproj
+++ b/src/Templates/src/templates/maui-blazor-solution/MauiApp.1/MauiApp.1.csproj
@@ -59,7 +59,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
-    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="$(MauiVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="MS_EXT_LOG_DEBUG_VERSION" />
   </ItemGroup>

--- a/src/Templates/src/templates/maui-blazor/MauiApp.1.csproj
+++ b/src/Templates/src/templates/maui-blazor/MauiApp.1.csproj
@@ -59,7 +59,6 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
-        <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
         <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="$(MauiVersion)" />
         <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="MS_EXT_LOG_DEBUG_VERSION" />
     </ItemGroup>

--- a/src/Templates/src/templates/maui-lib/MauiLib1.csproj
+++ b/src/Templates/src/templates/maui-lib/MauiLib1.csproj
@@ -21,7 +21,6 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
-		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
 	</ItemGroup>
 
 </Project>

--- a/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
+++ b/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
@@ -58,7 +58,6 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
-		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="MS_EXT_LOG_DEBUG_VERSION" />
 	</ItemGroup>
 

--- a/src/Templates/src/templates/maui-multiproject/MauiApp.1.Droid/MauiApp.1.Droid.csproj
+++ b/src/Templates/src/templates/maui-multiproject/MauiApp.1.Droid/MauiApp.1.Droid.csproj
@@ -11,7 +11,6 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
-		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="MS_EXT_LOG_DEBUG_VERSION" />
 	</ItemGroup>
 

--- a/src/Templates/src/templates/maui-multiproject/MauiApp.1.Mac/MauiApp.1.Mac.csproj
+++ b/src/Templates/src/templates/maui-multiproject/MauiApp.1.Mac/MauiApp.1.Mac.csproj
@@ -11,7 +11,6 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
-		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="MS_EXT_LOG_DEBUG_VERSION" />
 	</ItemGroup>
 

--- a/src/Templates/src/templates/maui-multiproject/MauiApp.1.WinUI/MauiApp.1.WinUI.csproj
+++ b/src/Templates/src/templates/maui-multiproject/MauiApp.1.WinUI/MauiApp.1.WinUI.csproj
@@ -20,7 +20,6 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
-		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="MS_EXT_LOG_DEBUG_VERSION" />
 	</ItemGroup>
 

--- a/src/Templates/src/templates/maui-multiproject/MauiApp.1.iOS/MauiApp.1.iOS.csproj
+++ b/src/Templates/src/templates/maui-multiproject/MauiApp.1.iOS/MauiApp.1.iOS.csproj
@@ -11,7 +11,6 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
-		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="MS_EXT_LOG_DEBUG_VERSION" />
 	</ItemGroup>
 

--- a/src/Templates/src/templates/maui-multiproject/MauiApp.1/MauiApp.1.csproj
+++ b/src/Templates/src/templates/maui-multiproject/MauiApp.1/MauiApp.1.csproj
@@ -22,7 +22,6 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
-		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="MS_EXT_LOG_DEBUG_VERSION" />
 	</ItemGroup>
 

--- a/src/Workload/Microsoft.Maui.Sdk/Sdk/BundledVersions.in.targets
+++ b/src/Workload/Microsoft.Maui.Sdk/Sdk/BundledVersions.in.targets
@@ -11,7 +11,7 @@
       referenced.  This will eventually switch to false by default and become opt, in,
       however Visual Studio currently depends on this assembly being loaded for Live Visual Tree.
     -->
-    <UseMauiCompat Condition=" '$(UseMauiCompat)' == '' and '$(UseMaui)' == 'true' ">true</UseMauiCompat>
+    <UseMauiCompat Condition=" '$(UseMauiCompat)' == '' and '$(UseMaui)' == 'true' ">false</UseMauiCompat>
 
     <!--
       If opted into NuGet Central Package Management, $(DisableMauiImplicitPackageReferences) defaults to true


### PR DESCRIPTION
### Description of Change

For new users it's not advantageous (and can be confusing) to have the Maui Compatibility package referenced. Nothing from this package should be used by new projects. 

### TODO
What updates need to be made to the migration tool? Does it already set UseMauiCompat to true? 