### PR TITLE
[iOS] Span's TapGestureRecognizer not working if text is truncated - UITest

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue21837.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue21837.xaml
@@ -1,0 +1,93 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Maui.Controls.Sample.Issues.Issue21837"
+             Title="Issue21837">
+
+    <VerticalStackLayout HorizontalOptions="Start" Spacing="10">
+        <Label AutomationId="resultLabel"  Text="{Binding TapCount, StringFormat='Number of recognized taps: {0}'}" FontSize="30" FontAttributes="Bold" />
+        
+        <Label Text="Single line, progressively limited width:" FontSize="20" FontAttributes="Bold" />
+
+        <Label AutomationId="label1"  HorizontalOptions="Start" MaxLines="1" BackgroundColor="LightCyan" WidthRequest="600">
+            <Label.FormattedText>
+                <FormattedString>
+                    <Span Text="Only our WidthRequests differ. Otherwise we're the same. Please tap us!">
+                        <Span.GestureRecognizers>
+                            <TapGestureRecognizer Command="{Binding TapCommand}" />
+                        </Span.GestureRecognizers>
+                    </Span>
+                </FormattedString>
+            </Label.FormattedText>
+        </Label>
+        <Label AutomationId="label2" HorizontalOptions="Start" MaxLines="1" BackgroundColor="LightCyan" WidthRequest="500">
+            <Label.FormattedText>
+                <FormattedString>
+                    <Span Text="Only our WidthRequests differ. Otherwise we're the same. Please tap us!">
+                        <Span.GestureRecognizers>
+                            <TapGestureRecognizer Command="{Binding TapCommand}" />
+                        </Span.GestureRecognizers>
+                    </Span>
+                </FormattedString>
+            </Label.FormattedText>
+        </Label>
+        <Label AutomationId="label3" HorizontalOptions="Start" MaxLines="1" LineBreakMode="TailTruncation" BackgroundColor="LightCyan" >
+            <Label.FormattedText>
+                <FormattedString>
+                    <Span Text="Only our WidthRequests differ. Otherwise we're the same. Please tap us!">
+                        <Span.GestureRecognizers>
+                            <TapGestureRecognizer Command="{Binding TapCommand}" />
+                        </Span.GestureRecognizers>
+                    </Span>
+                </FormattedString>
+            </Label.FormattedText>
+        </Label>
+        <Label AutomationId="label4" HorizontalOptions="Start" MaxLines="1" BackgroundColor="LightCyan" WidthRequest="300">
+            <Label.FormattedText>
+                <FormattedString>
+                    <Span Text="Only our WidthRequests differ. Otherwise we're the same. Please tap us!">
+                        <Span.GestureRecognizers>
+                            <TapGestureRecognizer Command="{Binding TapCommand}" />
+                        </Span.GestureRecognizers>
+                    </Span>
+                </FormattedString>
+            </Label.FormattedText>
+        </Label>
+
+        <Label Text="Limited width, progressively limited lines:" FontSize="20" FontAttributes="Bold" />
+
+        <Label AutomationId="label5" HorizontalOptions="Start" MaxLines="7" BackgroundColor="LightGoldenrodYellow" WidthRequest="100">
+            <Label.FormattedText>
+                <FormattedString>
+                    <Span Text="Only our MaxLines differ. Otherwise we're the same. Please tap us!">
+                        <Span.GestureRecognizers>
+                            <TapGestureRecognizer Command="{Binding TapCommand}" />
+                        </Span.GestureRecognizers>
+                    </Span>
+                </FormattedString>
+            </Label.FormattedText>
+        </Label>
+        <Label AutomationId="label6" HorizontalOptions="Start" MaxLines="6" BackgroundColor="LightGoldenrodYellow" WidthRequest="100">
+            <Label.FormattedText>
+                <FormattedString>
+                    <Span Text="Only our MaxLines differ. Otherwise we're the same. Please tap us!">
+                        <Span.GestureRecognizers>
+                            <TapGestureRecognizer Command="{Binding TapCommand}" />
+                        </Span.GestureRecognizers>
+                    </Span>
+                </FormattedString>
+            </Label.FormattedText>
+        </Label>
+        <Label AutomationId="label7" HorizontalOptions="Start" MaxLines="5" BackgroundColor="LightGoldenrodYellow" WidthRequest="100">
+            <Label.FormattedText>
+                <FormattedString>
+                    <Span Text="Only our MaxLines differ. Otherwise we're the same. Please tap us!">
+                        <Span.GestureRecognizers>
+                            <TapGestureRecognizer Command="{Binding TapCommand}" />
+                        </Span.GestureRecognizers>
+                    </Span>
+                </FormattedString>
+            </Label.FormattedText>
+        </Label>
+    </VerticalStackLayout>
+</ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue21837.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue21837.xaml.cs
@@ -1,0 +1,28 @@
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 21837, "Span's TapGestureRecognizer not working if text is truncated", PlatformAffected.All)]
+
+public partial class Issue21837 : ContentPage
+{
+	private int _tapCount;
+	public int TapCount
+	{
+		get => _tapCount;
+		set
+		{
+			_tapCount = value;
+			OnPropertyChanged();
+		}
+	}
+
+	public Command TapCommand { get; set; }
+
+	public Issue21837()
+	{
+		InitializeComponent();
+		TapCommand = new Command(() => ++TapCount);
+		BindingContext = this;
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue21837.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue21837.cs
@@ -1,0 +1,29 @@
+﻿using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue21837 : _IssuesUITest
+{
+	public Issue21837(TestDevice device) : base(device)
+	{
+	}
+
+	public override string Issue => "Span's TapGestureRecognizer not working if text is truncated";
+
+	[Test]
+	[Category(UITestCategories.Label)]
+	public void TapsShouldBeCorrectlyRecognized()
+	{
+		int numberOfTappableLabels = 7;
+
+		_ = App.WaitForElement("label1");
+
+		for (int i = 0; i < numberOfTappableLabels; i++)
+			App.Click($"label{i + 1}");
+
+		var resultText = App.FindElement("resultLabel").GetText();
+		Assert.That(resultText, Is.EqualTo($"Number of recognized taps: {numberOfTappableLabels}"));
+	}
+}


### PR DESCRIPTION
### Issues Fixed

Windows is not working either, but I have no machine to work on it
Fixes https://github.com/dotnet/maui/issues/21837

|Before|After|
|--|--|
|<video src="https://github.com/dotnet/maui/assets/42434498/68196bda-9dca-472a-8f44-7ef5acd42cc7" width="300px"/>|<video src="https://github.com/dotnet/maui/assets/42434498/7a3be163-81b3-4cf7-a641-1cb9f05651fe" width="300px"/>|
