### PR TITLE
Make sure to copy and push the vs-workloads props

### DIFF
--- a/eng/pipelines/common/pack.yml
+++ b/eng/pipelines/common/pack.yml
@@ -158,7 +158,7 @@ steps:
       Contents: |
         ${{ parameters.checkoutDirectory }}/artifacts/**/*.*nupkg
         ${{ parameters.checkoutDirectory }}/artifacts/**/*.zip
-        ${{ parameters.checkoutDirectory }}/artifacts/vs-workload.props
+        ${{ parameters.checkoutDirectory }}/artifacts/**/vs-workload.props
         ${{ parameters.checkoutDirectory }}/eng/automation/SignList.xml
         ${{ parameters.checkoutDirectory }}/eng/automation/SignVerifyIgnore.txt
         !${{ parameters.checkoutDirectory}}/artifacts/docs-packs/**


### PR DESCRIPTION
### Description of Change

Seems the location for vs-workload.props is not the root of the artifacts  folder,  is now on the Shipping folder, so we need to copy from correct place. 

"C:\repos\dotnet\maui\artifacts\packages\Debug\Shipping\vs-workload.props"