### PR TITLE
Trigger remeasure when constraints on CV changes

### DIFF
--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issue21967.xaml
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issue21967.xaml
@@ -36,8 +36,8 @@
                 <DataTemplate>
                     <Grid BackgroundColor="LightGray">
                         <Label
-                            Text="{Binding .}"
-                            AutomationId="{Binding .}"
+                            Text="{Binding Text}"
+                            AutomationId="{Binding AutomationId}"
                             HorizontalOptions="Fill"
                             VerticalOptions="Fill"/>
                     </Grid>

--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issue21967.xaml
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issue21967.xaml
@@ -4,7 +4,7 @@
              x:Class="Maui.Controls.Sample.Issues.Issue21967"
              Title="Issue21967">
      <Grid
-        RowDefinitions="Auto,Auto,*"
+        RowDefinitions="Auto,Auto,Auto,*"
         RowSpacing="8"
         Margin="8">
  
@@ -13,6 +13,14 @@
  
         <Button
             Grid.Row="1"
+            Text="Set to Full Size"
+            AutomationId="FullSize"
+            x:Name="buttonFullSize"
+            HorizontalOptions="Center"
+            VerticalOptions="Center"/>
+ 
+        <Button
+            Grid.Row="2"
             Text="Resize"
             AutomationId="Resize"
             x:Name="button"
@@ -20,7 +28,7 @@
             VerticalOptions="Center"/>
  
         <CollectionView
-            Grid.Row="2"
+            Grid.Row="3"
             x:Name="cv"
             ItemSizingStrategy="MeasureFirstItem">
  

--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issue21967.xaml
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issue21967.xaml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Maui.Controls.Sample.Issues.Issue21967"
+             Title="Issue21967">
+     <Grid
+        RowDefinitions="Auto,Auto,*"
+        RowSpacing="8"
+        Margin="8">
+ 
+        <Label Grid.Row="0" Text="Click the resize button and elements in the CV should resize.">
+        </Label>
+ 
+        <Button
+            Grid.Row="1"
+            Text="Resize"
+            AutomationId="Resize"
+            x:Name="button"
+            HorizontalOptions="Center"
+            VerticalOptions="Center"/>
+ 
+        <CollectionView
+            Grid.Row="2"
+            x:Name="cv"
+            ItemSizingStrategy="MeasureFirstItem">
+ 
+            <CollectionView.ItemsLayout>
+                <GridItemsLayout
+                    Orientation="Vertical"
+                    HorizontalItemSpacing="8"
+                    VerticalItemSpacing="8"
+                    Span="2"/>
+            </CollectionView.ItemsLayout>
+ 
+            <CollectionView.ItemTemplate>
+                <DataTemplate>
+                    <Grid BackgroundColor="LightGray">
+                        <Label
+                            Text="{Binding .}"
+                            AutomationId="{Binding .}"
+                            HorizontalOptions="Fill"
+                            VerticalOptions="Fill"/>
+                    </Grid>
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+            
+        </CollectionView>
+ 
+    </Grid>
+</ContentPage>

--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issue21967.xaml.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issue21967.xaml.cs
@@ -1,0 +1,27 @@
+using System;
+using Microsoft.Maui;
+using Microsoft.Maui.Controls;
+using System.Collections.Generic;
+ 
+namespace Maui.Controls.Sample.Issues;
+ 
+[Issue(IssueTracker.Github, 21967, "CollectionView causes invalid measurements on resize", PlatformAffected.Android)]
+public partial class Issue21967 : ContentPage
+{
+    public Issue21967()
+    {
+        InitializeComponent();
+        cv.ItemsSource = new List<string> { "Item1", "Item2", "Item3", "Item4", "Item5" };
+        button.Clicked += (_, _) =>
+        {
+            if (cv.WidthRequest == 200)
+            {
+                cv.WidthRequest = 100;
+            }
+            else
+            {
+                cv.WidthRequest = 200;
+            }
+        };
+    }
+}

--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issue21967.xaml.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issue21967.xaml.cs
@@ -40,5 +40,10 @@ public partial class Issue21967 : ContentPage
                 cv.WidthRequest = 200;
             }
         };
+
+        buttonFullSize.Clicked += (_, _) =>
+        {
+            cv.WidthRequest = Microsoft.Maui.Primitives.Dimension.Unset;
+        };
     }
 }

--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issue21967.xaml.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issue21967.xaml.cs
@@ -2,16 +2,33 @@ using System;
 using Microsoft.Maui;
 using Microsoft.Maui.Controls;
 using System.Collections.Generic;
- 
+using System.Linq;
+
 namespace Maui.Controls.Sample.Issues;
  
 [Issue(IssueTracker.Github, 21967, "CollectionView causes invalid measurements on resize", PlatformAffected.Android)]
 public partial class Issue21967 : ContentPage
 {
+	public readonly record struct Data(string Text, string AutomationId);
     public Issue21967()
     {
         InitializeComponent();
-        cv.ItemsSource = new List<string> { "Item1", "Item2", "Item3", "Item4", "Item5" };
+        cv.ItemsSource = 
+			new List<string> { "Item1", "Item2", "Item3", "Item4", "Item5" }
+			.Select((x, i) => 
+			{
+				string text = x;
+
+				if (i == 1)
+				{
+					// Generate long text that would measure really big to ensure everything stays measured the
+					text = Enumerable.Range(0,1000).Select(x => x.ToString()).Aggregate((x, y) => x + " " + y);
+				}
+				return new Data(text, x);
+			})
+			.ToList();
+
+		
         button.Clicked += (_, _) =>
         {
             if (cv.WidthRequest == 200)

--- a/src/Controls/src/Core/Handlers/Items/Android/Adapters/StructuredItemsViewAdapter.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/Adapters/StructuredItemsViewAdapter.cs
@@ -17,11 +17,14 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		// I'm storing this here because in the children I'm using a weakreference and
 		// I don't want this action to get GC'd
 		Action<Size> _reportMeasure;
+		Func<Size?> _retrieveStaticSize;
 
 		protected internal StructuredItemsViewAdapter(TItemsView itemsView,
 			Func<View, Context, ItemContentView> createItemContentView = null) : base(itemsView, createItemContentView)
 		{
 			_reportMeasure = SetStaticSize;
+			_retrieveStaticSize = () => _size ?? null;
+
 			UpdateHasHeader();
 			UpdateHasFooter();
 		}
@@ -104,6 +107,11 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			if (ItemsView.ItemSizingStrategy == ItemSizingStrategy.MeasureFirstItem)
 			{
 				templatedItemViewHolder.Bind(context, ItemsView, _reportMeasure, _size);
+
+				if (templatedItemViewHolder.ItemView is ItemContentView itemContentView)
+				{
+					itemContentView.RetrieveStaticSize = _retrieveStaticSize;
+				}
 			}
 			else
 			{

--- a/src/Controls/src/Core/Handlers/Items/Android/Adapters/StructuredItemsViewAdapter.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/Adapters/StructuredItemsViewAdapter.cs
@@ -14,9 +14,14 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 	{
 		Size? _size;
 
+		// I'm storing this here because in the children I'm using a weakreference and
+		// I don't want this action to get GC'd
+		Action<Size> _reportMeasure;
+
 		protected internal StructuredItemsViewAdapter(TItemsView itemsView,
 			Func<View, Context, ItemContentView> createItemContentView = null) : base(itemsView, createItemContentView)
 		{
+			_reportMeasure = SetStaticSize;
 			UpdateHasHeader();
 			UpdateHasFooter();
 		}
@@ -98,7 +103,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		{
 			if (ItemsView.ItemSizingStrategy == ItemSizingStrategy.MeasureFirstItem)
 			{
-				templatedItemViewHolder.Bind(context, ItemsView, SetStaticSize, _size);
+				templatedItemViewHolder.Bind(context, ItemsView, _reportMeasure, _size);
 			}
 			else
 			{

--- a/src/Controls/src/Core/Handlers/Items/Android/ItemContentView.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/ItemContentView.cs
@@ -109,34 +109,55 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			// The problem is that HandleItemSizingStrategy(Action<Size> reportMeasure, Size? size) 
 			// is called during "Bind" and then measure is called on all visible cells after that
 			// the result of this is that every single cell does an individual measure opposed to just using
-			// the first cell to set the size.			
-			_pixelSize = _pixelSize ?? RetrieveStaticSize?.Invoke();
+			// the first cell to set the size.
 
-			// If the measure changes significantly, we need to invalidate the pixel size
-			// This will happen if the user rotates the device or even just changes the height/width
-			// on the CollectionView itself. 
-			if (pixelWidth != 0 && _previousPixelWidth != pixelWidth)
+			var possibleNewSize = RetrieveStaticSize?.Invoke();
+
+			// This means a different cell has already set our new size
+			// so let's just use that instead of perform our own speculative measure
+			if (possibleNewSize is not null && 
+				_pixelSize is not null &&
+				!_pixelSize.Equals(possibleNewSize))
 			{
-				// We only need to worry about clearing pixel size if we've
-				// already made a first pass
-				if (_previousPixelWidth != -1)
+				_pixelSize = possibleNewSize;
+			}
+			else
+			{
+				_pixelSize = _pixelSize ?? possibleNewSize;
+
+				// If the measure changes significantly, we need to invalidate the pixel size
+				// This will happen if the user rotates the device or even just changes the height/width
+				// on the CollectionView itself. 
+				if (pixelWidth != 0 && _previousPixelWidth != pixelWidth)
 				{
-					_pixelSize = null;
+					// We only need to worry about clearing pixel size if we've
+					// already made a first pass
+					if (_previousPixelWidth != -1)
+					{
+						_pixelSize = null;
+					}
 				}
 
+				if (pixelHeight != 0 && _previousPixelHeight != pixelHeight)
+				{
+					// We only need to worry about clearing pixel size if we've
+					// already made a first pass
+					if (_previousPixelHeight != -1)
+					{
+						_pixelSize = null;
+					}
+
+					_pixelSize = null;
+				}
+			}
+
+			if (pixelWidth != 0)
+			{
 				_previousPixelWidth = pixelWidth;
 			}
 
-			if (pixelHeight != 0 && _previousPixelHeight != pixelHeight)
+			if (pixelHeight != 0)
 			{
-				// We only need to worry about clearing pixel size if we've
-				// already made a first pass
-				if (_previousPixelHeight != -1)
-				{
-					_pixelSize = null;
-				}
-
-				_pixelSize = null;
 				_previousPixelHeight = pixelHeight;
 			}
 

--- a/src/Controls/src/Core/Handlers/Items/Android/ItemContentView.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/ItemContentView.cs
@@ -128,7 +128,11 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				// If the measure changes significantly, we need to invalidate the pixel size
 				// This will happen if the user rotates the device or even just changes the height/width
 				// on the CollectionView itself. 
-				if (pixelWidth != 0 && _previousPixelWidth != pixelWidth)
+				// The Abs comparison I think is currently just a workaround for this
+				// https://github.com/dotnet/maui/issues/22271
+				// Once we fix 22271 I don't think we need this
+				// I'm also curious if we would still need this https://github.com/dotnet/maui/pull/21140
+				if (pixelWidth != 0 && Math.Abs(_previousPixelWidth - pixelWidth) > 1)
 				{
 					// We only need to worry about clearing pixel size if we've
 					// already made a first pass
@@ -138,7 +142,8 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 					}
 				}
 
-				if (pixelHeight != 0 && _previousPixelHeight != pixelHeight)
+
+				if (pixelHeight != 0 && Math.Abs(_previousPixelHeight - pixelHeight) > 1)
 				{
 					// We only need to worry about clearing pixel size if we've
 					// already made a first pass

--- a/src/Controls/src/Core/Handlers/Items/Android/ItemContentView.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/ItemContentView.cs
@@ -9,8 +9,15 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 {
 	public class ItemContentView : ViewGroup
 	{
-		Size? _size;
-		Action<Size> _reportMeasure;
+		Size? _pixelSize;
+		WeakReference _reportMeasure;
+		int _previousPixelWidth;
+		int _previousPixelHeight;
+
+		Action<Size> ReportMeasure
+		{
+			get => _reportMeasure?.Target as Action<Size>;
+		}
 
 		protected IPlatformViewHandler Content;
 		internal IView View => Content?.VirtualView;
@@ -53,13 +60,13 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			}
 
 			Content = null;
-			_size = null;
+			_pixelSize = null;
 		}
 
 		internal void HandleItemSizingStrategy(Action<Size> reportMeasure, Size? size)
 		{
-			_reportMeasure = reportMeasure;
-			_size = size;
+			_reportMeasure = new WeakReference(reportMeasure);
+			_pixelSize = size;
 		}
 
 		protected override void OnLayout(bool changed, int l, int t, int r, int b)
@@ -83,39 +90,54 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				return;
 			}
 
+			int pixelWidth = MeasureSpec.GetSize(widthMeasureSpec);
+			int pixelHeight = MeasureSpec.GetSize(heightMeasureSpec);
+			var widthMode = MeasureSpec.GetMode(widthMeasureSpec);
+			var heightMode = MeasureSpec.GetMode(heightMeasureSpec);
+
+			// If the measure changes significantly, we need to invalidate the pixel size
+			// This will happen if the user rotates the device or even just changes the height/width
+			// on the CollectionView itself. 
+			if (pixelWidth != 0 && _previousPixelWidth != pixelWidth)
+			{
+				_pixelSize = null;
+				_previousPixelWidth = pixelWidth;
+			}
+
+			if (pixelHeight != 0 && _previousPixelHeight != pixelHeight)
+			{
+				_pixelSize = null;
+				_previousPixelHeight = pixelHeight;
+			}
+
 			// If we're using ItemSizingStrategy.MeasureFirstItem and now we have a set size, use that
 			// Even though we already know the size we still need to pass the measure through to the children.
-			if (_size is not null)
+			if (_pixelSize is not null)
 			{
-				var w = (int)_size.Value.Width;
-				var h = (int)_size.Value.Height;
+				var w = (int)this.FromPixels(_pixelSize.Value.Width);
+				var h = (int)this.FromPixels(_pixelSize.Value.Height);
 
 				// If the platform childs measure has been invalidated, it's going to still want to
 				// participate in the measure lifecycle in order to update its internal
 				// book keeping.
-				_ = View.Measure
-					(
+				_ = (View.Handler as IPlatformViewHandler)?.MeasureVirtualView(
 						MeasureSpec.MakeMeasureSpec(w, MeasureSpecMode.Exactly),
 						MeasureSpec.MakeMeasureSpec(h, MeasureSpecMode.Exactly)
 					);
 
-				SetMeasuredDimension(w, h);
+				SetMeasuredDimension((int)_pixelSize.Value.Width, (int)_pixelSize.Value.Height);
 				return;
 			}
 
-			int pixelWidth = MeasureSpec.GetSize(widthMeasureSpec);
-			int pixelHeight = MeasureSpec.GetSize(heightMeasureSpec);
-
-			var widthSpec = MeasureSpec.GetMode(widthMeasureSpec) == MeasureSpecMode.Unspecified
+			var width = widthMode == MeasureSpecMode.Unspecified
 				? double.PositiveInfinity
 				: this.FromPixels(pixelWidth);
 
-			var heightSpec = MeasureSpec.GetMode(heightMeasureSpec) == MeasureSpecMode.Unspecified
+			var height = heightMode == MeasureSpecMode.Unspecified
 				? double.PositiveInfinity
 				: this.FromPixels(pixelHeight);
 
-
-			var measure = View.Measure(widthSpec, heightSpec);
+			var measure = View.Measure(width, height);
 
 			if (pixelWidth == 0)
 			{
@@ -127,8 +149,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				pixelHeight = (int)this.ToPixels(measure.Height);
 			}
 
-			_reportMeasure?.Invoke(new Size(pixelWidth, pixelHeight));
-			_reportMeasure = null; // Make sure we only report back the measure once
+			ReportMeasure?.Invoke(new Size(pixelWidth, pixelHeight));
 
 			SetMeasuredDimension(pixelWidth, pixelHeight);
 		}

--- a/src/Controls/tests/UITests/Tests/Issues/Issue21967.cs
+++ b/src/Controls/tests/UITests/Tests/Issues/Issue21967.cs
@@ -25,5 +25,14 @@ namespace Microsoft.Maui.AppiumTests.Issues
             Assert.Greater(largestSize.Width, mediumSize.Width);
             Assert.Greater(mediumSize.Width, smallSize.Width);
 		}
+
+        
+		[Test]
+		[Category(UITestCategories.CollectionView)]
+		public void CollectionViewFirstItemCorrectlySetsTheMeasure()
+		{
+			var itemSize = App.WaitForElement("Item1").GetRect();
+            Assert.Greater(200, itemSize.Height);
+		}
 	}
 }

--- a/src/Controls/tests/UITests/Tests/Issues/Issue21967.cs
+++ b/src/Controls/tests/UITests/Tests/Issues/Issue21967.cs
@@ -1,4 +1,5 @@
 ﻿using NUnit.Framework;
+using OpenQA.Selenium;
 using UITest.Appium;
 using UITest.Core;
 
@@ -25,7 +26,6 @@ namespace Microsoft.Maui.AppiumTests.Issues
             Assert.Greater(largestSize.Width, mediumSize.Width);
             Assert.Greater(mediumSize.Width, smallSize.Width);
 		}
-
         
 		[Test]
 		[Category(UITestCategories.CollectionView)]
@@ -33,6 +33,32 @@ namespace Microsoft.Maui.AppiumTests.Issues
 		{
 			var itemSize = App.WaitForElement("Item1").GetRect();
             Assert.Greater(200, itemSize.Height);
+		}
+        
+		[Test]
+		[Category(UITestCategories.CollectionView)]
+		public void CollectionViewWorksWhenRotatingDevice()
+		{
+			this.IgnoreIfPlatforms(new TestDevice[] { TestDevice.Mac, TestDevice.Windows });
+
+			try
+			{
+				App.WaitForElement("FullSize");
+				App.Tap("FullSize");
+				App.SetOrientationPortrait();
+				var itemSizePortrait = App.WaitForElement("Item1").GetRect();
+				App.SetOrientationLandscape();
+				var itemSizeLandscape = App.WaitForElement("Item1").GetRect();
+				App.SetOrientationPortrait();
+				var itemSizePortrait2 = App.WaitForElement("Item1").GetRect();
+
+				Assert.Greater(itemSizeLandscape.Width, itemSizePortrait.Width);
+				Assert.AreEqual(itemSizePortrait2.Width, itemSizePortrait.Width);
+			}
+			finally
+			{
+				App.SetOrientationPortrait();
+			}
 		}
 	}
 }

--- a/src/Controls/tests/UITests/Tests/Issues/Issue21967.cs
+++ b/src/Controls/tests/UITests/Tests/Issues/Issue21967.cs
@@ -1,0 +1,29 @@
+﻿using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.AppiumTests.Issues
+{
+	public class Issue21967 : _IssuesUITest
+	{
+		public Issue21967(TestDevice device) : base(device)
+		{
+		}
+
+		public override string Issue => "CollectionView causes invalid measurements on resize";
+
+		[Test]
+		[Category(UITestCategories.CollectionView)]
+		public void CollectionViewItemsResizeWhenContraintsOnCollectionViewChange()
+		{
+			var largestSize = App.WaitForElement("Item1").GetRect();
+			App.Tap("Resize");
+			var mediumSize = App.WaitForElement("Item1").GetRect();
+			App.Tap("Resize");
+			var smallSize = App.WaitForElement("Item1").GetRect();
+
+            Assert.Greater(largestSize.Width, mediumSize.Width);
+            Assert.Greater(mediumSize.Width, smallSize.Width);
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change

When the constraints of a RecyclerView change, the items don't get recreated so we have to re-evaluate the cached sizes being used to measure each of the items. The way the code was setup it would only set the static size once and then reuse that no matter what the change are. 

My current overall thinking here is that `ItemSizingStrategy` is somewhat pointless on android as it relates to performance. The only reason to use it would be if you want the first item to set the measure for the rest of your cells.  Generally, if you want the best performance, and you want all the cells to be the same size, then just set a specific height/width on your cells.

For example, if you just remove all of our custom measuring code inside ItemContentView and just rely on the "LayoutParams" to size the elements it all measures naturally.   

I think there are some additional issues related to messages getting propagated to the handlers
https://github.com/dotnet/maui/issues/22271

But we'll look at that as part of SR6

### Issues Fixed

Fixes #21967

