### PR TITLE
[iOS] Fix setting the CurrentItem on CarouselView load 

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/CarouselViewHandler.iOS.cs
+++ b/src/Controls/src/Core/Handlers/Items/CarouselViewHandler.iOS.cs
@@ -58,7 +58,12 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		public static void MapPosition(CarouselViewHandler handler, CarouselView carouselView)
 		{
-			(handler.Controller as CarouselViewController)?.UpdateFromPosition();
+			// If the initial position hasn't been set, we have a UpdateInitialPosition call on CarouselViewController
+			// that will handle this so we want to skip this mapper call. We need to wait for the CollectionView to be ready
+			if(handler.Controller is CarouselViewController  carouselViewController && carouselViewController.InitialPositionSet)
+			{
+				carouselViewController.UpdateFromPosition();
+			}
 		}
 
 		public static void MapLoop(CarouselViewHandler handler, CarouselView carouselView)

--- a/src/Controls/src/Core/Handlers/Items/CarouselViewHandler.iOS.cs
+++ b/src/Controls/src/Core/Handlers/Items/CarouselViewHandler.iOS.cs
@@ -101,6 +101,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		public override Size GetDesiredSize(double widthConstraint, double heightConstraint) =>
 			this.GetDesiredSizeFromHandler(widthConstraint, heightConstraint);
 
-		protected virtual double AnimationDuration => 0.5;
+		private protected virtual double AnimationDuration => 0.5;
 	}
 }

--- a/src/Controls/src/Core/Handlers/Items/iOS/CarouselViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/CarouselViewController.cs
@@ -430,7 +430,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			//If _gotoPosition is != -1 we are scrolling to that possition
 			if (_gotoPosition == -1 && carousel.Position != position)
 			{
-				Debug.WriteLine($"CarouselView: SetValueFromRenderer position to {position}");
 				carousel.SetValueFromRenderer(CarouselView.PositionProperty, position);
 			}
 		}

--- a/src/Controls/src/Core/Handlers/Items/iOS/CarouselViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/CarouselViewController.cs
@@ -624,7 +624,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			_oldViews = newViews;
 		}
 
-		private protected override void UpdateVisibility()
+		internal protected override void UpdateVisibility()
 		{
 			if (ItemsView.IsVisible)
 			{

--- a/src/Controls/src/Core/Handlers/Items/iOS/CarouselViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/CarouselViewController.cs
@@ -17,7 +17,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		protected readonly CarouselView Carousel;
 
 		CarouselViewLoopManager _carouselViewLoopManager;
-		internal bool InitialPositionSet;
 		bool _updatingScrollOffset;
 		List<View> _oldViews;
 		int _gotoPosition = -1;
@@ -171,6 +170,8 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			var itemIndex = GetIndexFromIndexPath(indexPath);
 			base.CacheCellAttributes(NSIndexPath.FromItemSection(itemIndex, 0), size);
 		}
+
+		internal bool InitialPositionSet { get; private set; }
 
 		internal void TearDown()
 		{

--- a/src/Controls/src/Core/Handlers/Items/iOS/CarouselViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/CarouselViewController.cs
@@ -418,15 +418,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				}
 				else
 				{
-					UIView.Animate(0.25, () => {
-						UpdateIsScrolling(true);
-						var currentItemPosition = ItemsSource.GetIndexForItem(carousel.CurrentItem);
-						CollectionView.ScrollToItem(currentItemPosition, UICollectionViewScrollPosition.CenteredHorizontally, false);				
-					},
-				 	() => { 
-						UpdateIsScrolling(false);
-						SetPosition(goToPosition);
-					});
+					carousel.ScrollTo(goToPosition, -1, position: Microsoft.Maui.Controls.ScrollToPosition.Center, true);
 				}
 			}
 		}

--- a/src/Controls/src/Core/Handlers/Items/iOS/CarouselViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/CarouselViewController.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		protected readonly CarouselView Carousel;
 
 		CarouselViewLoopManager _carouselViewLoopManager;
-		bool _initialPositionSet;
+		internal bool InitialPositionSet;
 		bool _updatingScrollOffset;
 		List<View> _oldViews;
 		int _gotoPosition = -1;
@@ -126,14 +126,11 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			//we don't need to Subscribe because base calls CreateItemsViewSource
 			_carouselViewLoopManager?.SetItemsSource(LoopItemsSource);
 
-			if (_initialPositionSet && ItemsView is CarouselView carousel)
+			if (InitialPositionSet && ItemsView is CarouselView carousel)
 			{
 				carousel.SetValueFromRenderer(CarouselView.CurrentItemProperty, null);
 				carousel.SetValueFromRenderer(CarouselView.PositionProperty, 0);
 			}
-
-			_initialPositionSet = false;
-			UpdateInitialPosition();
 		}
 
 		protected override bool IsHorizontal => ItemsView?.ItemsLayout?.Orientation == ItemsLayoutOrientation.Horizontal;
@@ -417,13 +414,12 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			if (itemsCount == 0)
 				return;
 
-			if (!_initialPositionSet)
+			if (!InitialPositionSet)
 			{
 				if (ItemsView is not CarouselView carousel)
 					return;
 
-				System.Diagnostics.Debug.WriteLine($"UpdateInitialPosition");
-				_initialPositionSet = true;
+				InitialPositionSet = true;
 
 				int position = carousel.Position;
 				var currentItem = carousel.CurrentItem;

--- a/src/Controls/src/Core/Handlers/Items/iOS/CarouselViewDelegator.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/CarouselViewDelegator.cs
@@ -11,12 +11,9 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			: base(itemsViewLayout, itemsViewController)
 		{
 		}
-
 		public override void Scrolled(UIScrollView scrollView)
-		{
+		{		
 			base.Scrolled(scrollView);
-
-			ViewController?.UpdateIsScrolling(true);
 		}
 
 		public override void ScrollAnimationEnded(UIScrollView scrollView)
@@ -27,6 +24,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		public override void DecelerationEnded(UIScrollView scrollView)
 		{
 			ViewController?.UpdateIsScrolling(false);
+			base.DecelerationEnded(scrollView);
 		}
 
 		public override void DraggingStarted(UIScrollView scrollView)

--- a/src/Controls/src/Core/Handlers/Items/iOS/CarouselViewDelegator.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/CarouselViewDelegator.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		public override void Scrolled(UIScrollView scrollView)
 		{		
 			base.Scrolled(scrollView);
+			ViewController?.UpdateIsScrolling(true);
 		}
 
 		public override void ScrollAnimationEnded(UIScrollView scrollView)

--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
@@ -185,18 +185,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			(collectionView as IUIViewLifeCycleEvents).MovedToWindow += CollectionViewMovedToWindow;	
 		}
 
-		void CollectionViewMovedToWindow(object sender, EventArgs e)
-		{
-			if (CollectionView?.Window != null)
-			{
-				AttachingToWindow();
-			}
-			else
-			{
-				DettachingFromWindow();
-			}
-		}
-
 		public override void ViewWillAppear(bool animated)
 		{
 			base.ViewWillAppear(animated);
@@ -209,6 +197,18 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			base.ViewWillLayoutSubviews();
 			InvalidateMeasureIfContentSizeChanged();
 			LayoutEmptyView();
+		}
+
+		void CollectionViewMovedToWindow(object sender, EventArgs e)
+		{
+			if (CollectionView?.Window != null)
+			{
+				AttachingToWindow();
+			}
+			else
+			{
+				DetachingFromWindow();
+			}
 		}
 
 		void InvalidateMeasureIfContentSizeChanged()
@@ -261,16 +261,8 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			}
 			_previousContentSize = contentSize.Value;
 		}
+		
 
-		internal virtual void AttachingToWindow()
-		{
-
-		}
-
-		internal virtual void DettachingFromWindow()
-		{
-
-		}
 		internal Size? GetSize()
 		{
 			if (_emptyViewDisplayed)
@@ -779,7 +771,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			return ItemsViewLayout.EstimatedItemSize;
 		}
 
-		internal protected virtual void UpdateVisibility()
+		private protected virtual void UpdateVisibility()
 		{
 			if (ItemsView.IsVisible)
 			{
@@ -795,6 +787,16 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			{
 				CollectionView.Hidden = true;
 			}
+		}
+
+		private protected virtual void AttachingToWindow()
+		{
+
+		}
+
+		private protected virtual void DetachingFromWindow()
+		{
+
 		}
 	}
 }

--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
@@ -179,9 +179,22 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		public override void LoadView()
 		{
-			base.LoadView(); 
+			base.LoadView();
+			var collectionView = new MauiCollectionView(CGRect.Empty, ItemsViewLayout);
+			CollectionView = collectionView;
+			(collectionView as IUIViewLifeCycleEvents).MovedToWindow += CollectionViewMovedToWindow;	
+		}
 
-			CollectionView = new MauiCollectionView(CGRect.Empty, ItemsViewLayout);
+		void CollectionViewMovedToWindow(object sender, EventArgs e)
+		{
+			if (CollectionView?.Window != null)
+			{
+				AttachingToWindow();
+			}
+			else
+			{
+				DettachingFromWindow();
+			}
 		}
 
 		public override void ViewWillAppear(bool animated)
@@ -249,6 +262,15 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			_previousContentSize = contentSize.Value;
 		}
 
+		internal virtual void AttachingToWindow()
+		{
+
+		}
+
+		internal virtual void DettachingFromWindow()
+		{
+
+		}
 		internal Size? GetSize()
 		{
 			if (_emptyViewDisplayed)

--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
@@ -771,7 +771,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			return ItemsViewLayout.EstimatedItemSize;
 		}
 
-		private protected virtual void UpdateVisibility()
+		internal protected virtual void UpdateVisibility()
 		{
 			if (ItemsView.IsVisible)
 			{

--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewDelegator.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewDelegator.cs
@@ -27,7 +27,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		public override void Scrolled(UIScrollView scrollView)
 		{
-			base.Scrolled(scrollView);
 		}
 
 		public override void DecelerationEnded(UIScrollView scrollView)

--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewDelegator.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewDelegator.cs
@@ -27,17 +27,23 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		public override void Scrolled(UIScrollView scrollView)
 		{
-			//base.Scrolled(scrollView);
+			base.Scrolled(scrollView);
 		}
 
-#pragma warning disable RS0016 // Add public types and members to the declared API
 		public override void DecelerationEnded(UIScrollView scrollView)
-#pragma warning restore RS0016 // Add public types and members to the declared API
 		{
+			var viewController = ViewController;
+			if (viewController is null)
+			{
+				return;
+			}
+
 			var (visibleItems, firstVisibleItemIndex, centerItemIndex, lastVisibleItemIndex) = GetVisibleItemsIndex();
 
 			if (!visibleItems)
+			{
 				return;
+			}
 
 			var contentInset = scrollView.ContentInset;
 			var contentOffsetX = scrollView.ContentOffset.X + contentInset.Left;
@@ -54,9 +60,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				LastVisibleItemIndex = lastVisibleItemIndex
 			};
 
-			var viewController = ViewController;
-			if (viewController is null)
-				return;
 
 			var itemsView = viewController.ItemsView;
 			var source = viewController.ItemsSource;
@@ -80,8 +83,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			}
 		}
 
-		public override UIEdgeInsets GetInsetForSection(UICollectionView collectionView, UICollectionViewLayout layout,
-			nint section)
+		public override UIEdgeInsets GetInsetForSection(UICollectionView collectionView, UICollectionViewLayout layout, nint section)
 		{
 			if (ItemsViewLayout == null)
 			{
@@ -132,11 +134,18 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			}
 		}
 
+		public override CGSize GetSizeForItem(UICollectionView collectionView, UICollectionViewLayout layout, NSIndexPath indexPath)
+		{
+			return ViewController?.GetSizeForItem(indexPath) ?? CGSize.Empty;
+		}
+
 		protected virtual (bool VisibleItems, NSIndexPath First, NSIndexPath Center, NSIndexPath Last) GetVisibleItemsIndexPath()
 		{
 			var collectionView = ViewController?.CollectionView;
 			if (collectionView is null)
+			{
 				return default;
+			}
 
 			var indexPathsForVisibleItems = collectionView.IndexPathsForVisibleItems.OrderBy(x => x.Row).ToList();
 
@@ -181,11 +190,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			var centerIndexPath = collectionView.IndexPathForItemAtPoint(centerPoint);
 			centerItemIndex = centerIndexPath ?? firstVisibleItemIndex;
 			return centerItemIndex;
-		}
-
-		public override CGSize GetSizeForItem(UICollectionView collectionView, UICollectionViewLayout layout, NSIndexPath indexPath)
-		{
-			return ViewController?.GetSizeForItem(indexPath) ?? CGSize.Empty;
 		}
 	}
 }

--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewDelegator.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewDelegator.cs
@@ -27,6 +27,13 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		public override void Scrolled(UIScrollView scrollView)
 		{
+			//base.Scrolled(scrollView);
+		}
+
+#pragma warning disable RS0016 // Add public types and members to the declared API
+		public override void DecelerationEnded(UIScrollView scrollView)
+#pragma warning restore RS0016 // Add public types and members to the declared API
+		{
 			var (visibleItems, firstVisibleItemIndex, centerItemIndex, lastVisibleItemIndex) = GetVisibleItemsIndex();
 
 			if (!visibleItems)

--- a/src/Controls/src/Core/Handlers/Items/iOS/MauiCollectionView.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/MauiCollectionView.cs
@@ -1,9 +1,11 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
 using CoreGraphics;
 using UIKit;
 
 namespace Microsoft.Maui.Controls.Handlers.Items;
 
-internal class MauiCollectionView : UICollectionView
+internal class MauiCollectionView : UICollectionView, IUIViewLifeCycleEvents
 {
 	public MauiCollectionView(CGRect frame, UICollectionViewLayout layout) : base(frame, layout)
 	{
@@ -13,5 +15,19 @@ internal class MauiCollectionView : UICollectionView
 	{
 		if (!KeyboardAutoManagerScroll.IsKeyboardAutoScrollHandling)
 			base.ScrollRectToVisible(rect, animated);
+	}
+
+	[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = IUIViewLifeCycleEvents.UnconditionalSuppressMessage)]
+	EventHandler? _movedToWindow;
+	event EventHandler? IUIViewLifeCycleEvents.MovedToWindow
+	{
+		add => _movedToWindow += value;
+		remove => _movedToWindow -= value;
+	}
+
+	public override void MovedToWindow()
+	{
+		base.MovedToWindow();
+		_movedToWindow?.Invoke(this, EventArgs.Empty);
 	}
 }

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -146,6 +146,7 @@ Microsoft.Maui.Controls.Handlers.BoxViewHandler.BoxViewHandler() -> void
 ~Microsoft.Maui.Controls.InputView.FontFamily.get -> string
 ~Microsoft.Maui.Controls.InputView.FontFamily.set -> void
 ~override Microsoft.Maui.Controls.Handlers.Items.CarouselViewController.DetermineCellReuseId(Foundation.NSIndexPath indexPath) -> string
+~override Microsoft.Maui.Controls.Handlers.Items.ItemsViewDelegator<TItemsView, TViewController>.DecelerationEnded(UIKit.UIScrollView scrollView) -> void
 ~override Microsoft.Maui.Controls.ImageButton.OnPropertyChanged(string propertyName = null) -> void
 ~override Microsoft.Maui.Controls.Handlers.Compatibility.PhoneFlyoutPageRenderer.ViewWillTransitionToSize(CoreGraphics.CGSize toSize, UIKit.IUIViewControllerTransitionCoordinator coordinator) -> void
 ~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRootRenderer.TraitCollectionDidChange(UIKit.UITraitCollection previousTraitCollection) -> void

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -264,4 +264,3 @@ Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTapped.set -> void
 *REMOVED*Microsoft.Maui.Controls.Entry.FontSize.set -> void
 *REMOVED*Microsoft.Maui.Controls.Entry.SelectionLength.get -> int
 *REMOVED*Microsoft.Maui.Controls.Entry.SelectionLength.set -> void
-virtual Microsoft.Maui.Controls.Handlers.Items.CarouselViewHandler.AnimationDuration.get -> double

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -263,3 +263,4 @@ Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTapped.set -> void
 *REMOVED*Microsoft.Maui.Controls.Entry.FontSize.set -> void
 *REMOVED*Microsoft.Maui.Controls.Entry.SelectionLength.get -> int
 *REMOVED*Microsoft.Maui.Controls.Entry.SelectionLength.set -> void
+virtual Microsoft.Maui.Controls.Handlers.Items.CarouselViewHandler.AnimationDuration.get -> double

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -143,6 +143,7 @@ Microsoft.Maui.Controls.Handlers.BoxViewHandler.BoxViewHandler() -> void
 ~Microsoft.Maui.Controls.InputView.FontFamily.get -> string
 ~Microsoft.Maui.Controls.InputView.FontFamily.set -> void
 ~override Microsoft.Maui.Controls.Handlers.Items.CarouselViewController.DetermineCellReuseId(Foundation.NSIndexPath indexPath) -> string
+~override Microsoft.Maui.Controls.Handlers.Items.ItemsViewDelegator<TItemsView, TViewController>.DecelerationEnded(UIKit.UIScrollView scrollView) -> void
 ~override Microsoft.Maui.Controls.ImageButton.OnPropertyChanged(string propertyName = null) -> void
 ~override Microsoft.Maui.Controls.Handlers.Compatibility.PhoneFlyoutPageRenderer.ViewWillTransitionToSize(CoreGraphics.CGSize toSize, UIKit.IUIViewControllerTransitionCoordinator coordinator) -> void
 ~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRootRenderer.TraitCollectionDidChange(UIKit.UITraitCollection previousTraitCollection) -> void

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -134,7 +134,6 @@ static Microsoft.Maui.Controls.Region.operator !=(Microsoft.Maui.Controls.Region
 static Microsoft.Maui.Controls.Region.operator ==(Microsoft.Maui.Controls.Region left, Microsoft.Maui.Controls.Region right) -> bool
 static Microsoft.Maui.Controls.Shapes.Matrix.operator !=(Microsoft.Maui.Controls.Shapes.Matrix left, Microsoft.Maui.Controls.Shapes.Matrix right) -> bool
 static Microsoft.Maui.Controls.Shapes.Matrix.operator ==(Microsoft.Maui.Controls.Shapes.Matrix left, Microsoft.Maui.Controls.Shapes.Matrix right) -> bool
-virtual Microsoft.Maui.Controls.Handlers.Items.CarouselViewHandler.AnimationDuration.get -> double
 ~Microsoft.Maui.Controls.Handlers.Compatibility.FrameRenderer.FrameRenderer(Microsoft.Maui.IPropertyMapper mapper) -> void
 ~Microsoft.Maui.Controls.Handlers.Compatibility.FrameRenderer.FrameRenderer(Microsoft.Maui.IPropertyMapper mapper, Microsoft.Maui.CommandMapper commandMapper) -> void
 override Microsoft.Maui.Controls.View.ChangeVisualState() -> void

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -134,6 +134,7 @@ static Microsoft.Maui.Controls.Region.operator !=(Microsoft.Maui.Controls.Region
 static Microsoft.Maui.Controls.Region.operator ==(Microsoft.Maui.Controls.Region left, Microsoft.Maui.Controls.Region right) -> bool
 static Microsoft.Maui.Controls.Shapes.Matrix.operator !=(Microsoft.Maui.Controls.Shapes.Matrix left, Microsoft.Maui.Controls.Shapes.Matrix right) -> bool
 static Microsoft.Maui.Controls.Shapes.Matrix.operator ==(Microsoft.Maui.Controls.Shapes.Matrix left, Microsoft.Maui.Controls.Shapes.Matrix right) -> bool
+virtual Microsoft.Maui.Controls.Handlers.Items.CarouselViewHandler.AnimationDuration.get -> double
 ~Microsoft.Maui.Controls.Handlers.Compatibility.FrameRenderer.FrameRenderer(Microsoft.Maui.IPropertyMapper mapper) -> void
 ~Microsoft.Maui.Controls.Handlers.Compatibility.FrameRenderer.FrameRenderer(Microsoft.Maui.IPropertyMapper mapper, Microsoft.Maui.CommandMapper commandMapper) -> void
 override Microsoft.Maui.Controls.View.ChangeVisualState() -> void

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/CarouselViewUITests.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/CarouselViewUITests.cs
@@ -25,18 +25,28 @@ namespace Microsoft.Maui.TestCases.Tests
 		public async Task CarouselViewSetPosition()
 		{
 			App.NavigateToGallery(CarouselViewGallery);
-			if (Device == TestDevice.Windows)
+			await Task.Delay(2000);
+			try
 			{
-				Assert.Ignore("For now not running on windows");
+				if (Device == TestDevice.Windows)
+				{
+					Assert.Ignore("For now not running on windows");
+				}
+				else
+				{
+					App.WaitForElement("lblPosition");
+					await Task.Delay(3000);
+					CheckLabelValue("lblPosition", "3");
+				}
 			}
-			else
+			catch
 			{
-				App.WaitForElement("lblPosition");
-				await Task.Delay(3000);
-				CheckLabelValue("lblPosition", "3");
+				App.Screenshot("Failed to Start on the correct position ");
 			}
-
-			Reset();
+			finally
+			{
+				Reset();
+			}
 		}
 
 		[Test]
@@ -44,26 +54,36 @@ namespace Microsoft.Maui.TestCases.Tests
 		public void CarouselViewGoToNextCurrentItem()
 		{
 			App.NavigateToGallery(CarouselViewGallery);
-			if (Device == TestDevice.Windows)
+			try
 			{
-				Assert.Ignore("For now not running on windows");
+				if (Device == TestDevice.Windows)
+				{
+					Assert.Ignore("For now not running on windows");
+				}
+				else
+				{
+					int indexToTest = 3;
+					var index = indexToTest.ToString();
+					var nextIndex = (indexToTest + 1).ToString();
+
+					CheckLabelValue("lblPosition", index);
+					CheckLabelValue("lblCurrentItem", index);
+
+					App.Tap("btnNext");
+					CheckLabelValue("lblPosition", nextIndex);
+					CheckLabelValue("lblCurrentItem", nextIndex);
+					CheckLabelValue("lblSelected", nextIndex);
+					App.Tap("btnPrev");
+				}
 			}
-			else
+			catch
 			{
-				int indexToTest = 3;
-				var index = indexToTest.ToString();
-				var nextIndex = (indexToTest + 1).ToString();
-
-				CheckLabelValue("lblPosition", index);
-				CheckLabelValue("lblCurrentItem", index);
-
-				App.Tap("btnNext");
-				CheckLabelValue("lblPosition", nextIndex);
-				CheckLabelValue("lblCurrentItem", nextIndex);
-				CheckLabelValue("lblSelected", nextIndex);
-				App.Tap("btnPrev");
+				App.Screenshot("Failed to tap on btnNext");
 			}
-			Reset();
+			finally
+			{
+				Reset();
+			}
 		}
 
 		[Test]
@@ -71,26 +91,35 @@ namespace Microsoft.Maui.TestCases.Tests
 		public void CarouselViewGoToPreviousCurrentItem()
 		{
 			App.NavigateToGallery(CarouselViewGallery);
-			if (Device == TestDevice.Windows)
+			try
 			{
-				Assert.Ignore("For now not running on windows");
+				if (Device == TestDevice.Windows)
+				{
+					Assert.Ignore("For now not running on windows");
+				}
+				else
+				{
+					int indexToTest = 3;
+					var index = indexToTest.ToString();
+					var previousIndex = (indexToTest - 1).ToString();
+
+					CheckLabelValue("lblPosition", index);
+					CheckLabelValue("lblCurrentItem", index);
+
+					App.Tap("btnPrev");
+					CheckLabelValue("lblPosition", previousIndex);
+					CheckLabelValue("lblCurrentItem", previousIndex);
+					CheckLabelValue("lblSelected", previousIndex);
+				}
 			}
-			else
+			catch
 			{
-				int indexToTest = 3;
-				var index = indexToTest.ToString();
-				var previousIndex = (indexToTest + 1).ToString();
-
-				CheckLabelValue("lblPosition", index);
-				CheckLabelValue("lblCurrentItem", index);
-
-				App.Tap("btnNext");
-				CheckLabelValue("lblPosition", previousIndex);
-				CheckLabelValue("lblCurrentItem", previousIndex);
-				CheckLabelValue("lblSelected", previousIndex);
-				App.Tap("btnPrev");
+				App.Screenshot("Failed to tap on btnPrev");
 			}
-			Reset();
+			finally
+			{
+				Reset();
+			}
 		}
 
 		[Test]
@@ -98,29 +127,39 @@ namespace Microsoft.Maui.TestCases.Tests
 		public async Task CarouselViewKeepPositionChangingOrientation()
 		{
 			App.NavigateToGallery(CarouselViewGallery);
-			if (Device == TestDevice.Mac || Device == TestDevice.Windows)
+			try
 			{
-				Assert.Ignore("For now not running on Desktop");
+				if (Device == TestDevice.Mac || Device == TestDevice.Windows)
+				{
+					Assert.Ignore("For now not running on Desktop");
+				}
+				else
+				{
+					int indexToTest = 3;
+					var index = indexToTest.ToString();
+
+					CheckLabelValue("lblPosition", index);
+					CheckLabelValue("lblCurrentItem", index);
+
+					App.SetOrientationLandscape();
+					App.SetOrientationPortrait();
+
+					await Task.Delay(3000);
+
+					CheckLabelValue("lblPosition", index);
+					CheckLabelValue("lblCurrentItem", index);
+				}
 			}
-			else
+			catch
 			{
-				int indexToTest = 3;
-				var index = indexToTest.ToString();
-
-				CheckLabelValue("lblPosition", index);
-				CheckLabelValue("lblCurrentItem", index);
-
-				App.SetOrientationLandscape();
-				App.SetOrientationPortrait();
-				
-				await Task.Delay(3000);
-
-				CheckLabelValue("lblPosition", index);
-				CheckLabelValue("lblCurrentItem", index);
+				App.Screenshot("Failed to tap on btnSetPosition");
 			}
-			Reset();
+			finally
+			{
+				Reset();
+			}
 		}
-		
+
 		void CheckLabelValue(string labelAutomationId, string value)
 		{
 			var result = App.FindElement(labelAutomationId).GetText();

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/CarouselViewUITests.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/CarouselViewUITests.cs
@@ -24,9 +24,9 @@ namespace Microsoft.Maui.TestCases.Tests
 		[Category(UITestCategories.CarouselView)]
 		public async Task CarouselViewSetPosition()
 		{
-			if (Device != TestDevice.Android)
+			if (Device == TestDevice.Windows)
 			{
-				Assert.Ignore("For now, running this test only on Android.");
+				Assert.Ignore("For now not running on windows");
 			}
 			else
 			{
@@ -41,9 +41,9 @@ namespace Microsoft.Maui.TestCases.Tests
 		[Category(UITestCategories.CarouselView)]
 		public void CarouselViewGoToNextCurrentItem()
 		{
-			if (Device != TestDevice.Android)
+			if (Device == TestDevice.Windows)
 			{
-				Assert.Ignore("For now, running this test only on Android.");
+				Assert.Ignore("For now not running on windows");
 			}
 			else
 			{
@@ -58,6 +58,31 @@ namespace Microsoft.Maui.TestCases.Tests
 				CheckLabelValue("lblPosition", nextIndex);
 				CheckLabelValue("lblCurrentItem", nextIndex);
 				CheckLabelValue("lblSelected", nextIndex);
+				App.Tap("btnPrev");
+			}
+		}
+
+		[Test]
+		[Category(UITestCategories.CarouselView)]
+		public void CarouselViewGoToPreviousCurrentItem()
+		{
+			if (Device == TestDevice.Windows)
+			{
+				Assert.Ignore("For now not running on windows");
+			}
+			else
+			{
+				int indexToTest = 3;
+				var index = indexToTest.ToString();
+				var previousIndex = (indexToTest + 1).ToString();
+
+				CheckLabelValue("lblPosition", index);
+				CheckLabelValue("lblCurrentItem", index);
+
+				App.Tap("btnNext");
+				CheckLabelValue("lblPosition", previousIndex);
+				CheckLabelValue("lblCurrentItem", previousIndex);
+				CheckLabelValue("lblSelected", previousIndex);
 				App.Tap("btnPrev");
 			}
 		}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/CarouselViewUITests.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/CarouselViewUITests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Maui.TestCases.Tests
 			else
 			{
 				App.WaitForElement("lblPosition");
-				await Task.Delay(1000);
+				await Task.Delay(3000);
 				var result = App.FindElement("lblPosition").GetText();
 				ClassicAssert.AreEqual("3", result);
 			}
@@ -89,7 +89,7 @@ namespace Microsoft.Maui.TestCases.Tests
 
 		[Test]
 		[Category(UITestCategories.CarouselView)]
-		public void CarouselViewKeepPositionChangingOrientation()
+		public async Task CarouselViewKeepPositionChangingOrientation()
 		{
 			if (Device == TestDevice.Mac || Device == TestDevice.Windows)
 			{
@@ -105,6 +105,8 @@ namespace Microsoft.Maui.TestCases.Tests
 
 				App.SetOrientationLandscape();
 				App.SetOrientationPortrait();
+				
+				await Task.Delay(3000);
 
 				CheckLabelValue("lblPosition", index);
 				CheckLabelValue("lblCurrentItem", index);

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/CarouselViewUITests.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/CarouselViewUITests.cs
@@ -87,6 +87,30 @@ namespace Microsoft.Maui.TestCases.Tests
 			}
 		}
 
+		[Test]
+		[Category(UITestCategories.CarouselView)]
+		public void CarouselViewKeepPositionChangingOrientation()
+		{
+			if (Device == TestDevice.Mac || Device == TestDevice.Windows)
+			{
+				Assert.Ignore("For now not running on Desktop");
+			}
+			else
+			{
+				int indexToTest = 3;
+				var index = indexToTest.ToString();
+
+				CheckLabelValue("lblPosition", index);
+				CheckLabelValue("lblCurrentItem", index);
+
+				App.SetOrientationLandscape();
+				App.SetOrientationPortrait();
+
+				CheckLabelValue("lblPosition", index);
+				CheckLabelValue("lblCurrentItem", index);
+			}
+		}
+		
 		void CheckLabelValue(string labelAutomationId, string value)
 		{
 			var result = App.FindElement(labelAutomationId).GetText();

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/CarouselViewUITests.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/CarouselViewUITests.cs
@@ -17,13 +17,14 @@ namespace Microsoft.Maui.TestCases.Tests
 		protected override void FixtureSetup()
 		{
 			base.FixtureSetup();
-			App.NavigateToGallery(CarouselViewGallery);
+			//App.NavigateToGallery(CarouselViewGallery);
 		}
 
 		[Test]
 		[Category(UITestCategories.CarouselView)]
 		public async Task CarouselViewSetPosition()
 		{
+			App.NavigateToGallery(CarouselViewGallery);
 			if (Device == TestDevice.Windows)
 			{
 				Assert.Ignore("For now not running on windows");
@@ -32,15 +33,17 @@ namespace Microsoft.Maui.TestCases.Tests
 			{
 				App.WaitForElement("lblPosition");
 				await Task.Delay(3000);
-				var result = App.FindElement("lblPosition").GetText();
-				ClassicAssert.AreEqual("3", result);
+				CheckLabelValue("lblPosition", "3");
 			}
+
+			Reset();
 		}
 
 		[Test]
 		[Category(UITestCategories.CarouselView)]
 		public void CarouselViewGoToNextCurrentItem()
 		{
+			App.NavigateToGallery(CarouselViewGallery);
 			if (Device == TestDevice.Windows)
 			{
 				Assert.Ignore("For now not running on windows");
@@ -60,12 +63,14 @@ namespace Microsoft.Maui.TestCases.Tests
 				CheckLabelValue("lblSelected", nextIndex);
 				App.Tap("btnPrev");
 			}
+			Reset();
 		}
 
 		[Test]
 		[Category(UITestCategories.CarouselView)]
 		public void CarouselViewGoToPreviousCurrentItem()
 		{
+			App.NavigateToGallery(CarouselViewGallery);
 			if (Device == TestDevice.Windows)
 			{
 				Assert.Ignore("For now not running on windows");
@@ -85,12 +90,14 @@ namespace Microsoft.Maui.TestCases.Tests
 				CheckLabelValue("lblSelected", previousIndex);
 				App.Tap("btnPrev");
 			}
+			Reset();
 		}
 
 		[Test]
 		[Category(UITestCategories.CarouselView)]
 		public async Task CarouselViewKeepPositionChangingOrientation()
 		{
+			App.NavigateToGallery(CarouselViewGallery);
 			if (Device == TestDevice.Mac || Device == TestDevice.Windows)
 			{
 				Assert.Ignore("For now not running on Desktop");
@@ -111,6 +118,7 @@ namespace Microsoft.Maui.TestCases.Tests
 				CheckLabelValue("lblPosition", index);
 				CheckLabelValue("lblCurrentItem", index);
 			}
+			Reset();
 		}
 		
 		void CheckLabelValue(string labelAutomationId, string value)

--- a/src/Controls/tests/TestCases/Elements/CarouselViewCoreGalleryPage.xaml
+++ b/src/Controls/tests/TestCases/Elements/CarouselViewCoreGalleryPage.xaml
@@ -82,27 +82,31 @@
                 CurrentItem="{Binding Selected}">
                 <CarouselView.ItemTemplate>
                     <DataTemplate>
-                        <Frame 
+                        <Border 
                             x:Name="frame"
-                            HasShadow="True" 
-                            Padding="0" 
+                            Padding="10"
                             HeightRequest="100"
                             WidthRequest="200"
                             HorizontalOptions="Center" 
                             VerticalOptions="Center" 
                             BackgroundColor="Yellow">
-                            <Grid>
+                            <Grid RowDefinitions="*,Auto">
                                 <Image 
                                     Source="{Binding Image}"
                                     InputTransparent="true"
                                     Aspect="AspectFit" />
                                 <Label 
-                                    Text="{Binding Index}" 
+                                    Text="{Binding Index}"  Grid.Row="1"
                                     FontSize="Large"
-                                    HorizontalOptions="Center" 
+                                    HorizontalOptions="Start" 
+                                    VerticalOptions="Center" />
+                                <Label 
+                                    Text="{Binding Title}"  Grid.Row="1"
+                                    FontSize="Large"
+                                    HorizontalOptions="End" 
                                     VerticalOptions="Center" />
                             </Grid>
-                        </Frame>
+                        </Border>
                     </DataTemplate>
                 </CarouselView.ItemTemplate>
             </CarouselView>

--- a/src/Controls/tests/TestCases/Elements/CarouselViewCoreGalleryPage.xaml.cs
+++ b/src/Controls/tests/TestCases/Elements/CarouselViewCoreGalleryPage.xaml.cs
@@ -139,12 +139,14 @@ namespace Maui.Controls.Sample
 			Index = index;
 
 			if (string.IsNullOrEmpty(image))
-				Image = "https://picsum.photos/700/300/";
+				Image = "oasis.jpg";
 			else
 				Image = image;
 		}
 
 		public int Index { get; set; }
+
+		public string Title => $"CarouselItem{Index}";
 
 		public string Image { get; set; }
 	}

--- a/src/Controls/tests/TestCases/Elements/CarouselViewCoreGalleryPage.xaml.cs
+++ b/src/Controls/tests/TestCases/Elements/CarouselViewCoreGalleryPage.xaml.cs
@@ -17,6 +17,16 @@ namespace Maui.Controls.Sample
 			int startCurrentItem = 3;
 
 			BindingContext = new CarouselViewModel(useLooping, startCurrentItem: startCurrentItem);
+			carousel.PropertyChanged += (s,e) =>
+			{
+				//IsScrolling is a property of CarouselView but not a bindable property
+				System.Diagnostics.Debug.WriteLine($"IsScrolling: {carousel.IsScrolling}");
+			};
+			carousel.Scrolled += (s, e) =>
+			{
+				System.Diagnostics.Debug.WriteLine($"Scrolled: {e}");
+				System.Diagnostics.Debug.WriteLine($"IsScrolling: {carousel.IsScrolling}");
+			};
 		}
 	}
 


### PR DESCRIPTION
### Description of Change

Since the mappers run when the handler is started and in different order than forms, seems the initial position based on CurrentItem wasn't being set correctly since the mapper for the Position property runs first and overrides it.

We also fix an issue when rotating was not keeping the correct position, since the scroll event was triggered and we want to avoid updating the position till the orientation finishes. This changed the Scrolled event to be fired when the scroll animation finishes. 

Added a way to know better when we the CollectionViewController is attached or detached from the view hierarchy. So now we can proper call the `TearDown`  and `Setup`.

Fixes some warnings

### Issues Fixed

Fixes #18879

### Copilot summary

This pull request includes changes to the `CarouselViewHandler.iOS.cs` and `CarouselViewController.cs` files in the `src/Controls/src/Core/Handlers/Items/` directory. The changes primarily involve refactoring the code, adding new methods, and improving the existing logic. 

Here are the most significant changes:

Changes in `CarouselViewHandler.iOS.cs`:

* Imported `Foundation` and `UIKit` namespaces.
* Modified the `ScrollToRequested` method to include a new `NSIndexPath` instance and added a new `scrollToItemAction` method.
* Updated the `MapPosition` method to handle situations where the initial position hasn't been set.
* Added a new `AnimationDuration` property in the `MapLoop` method.

Changes in `CarouselViewController.cs`:

* Imported the `Microsoft.Maui.Devices` namespace.
* Refactored the `CarouselViewController` class to include new fields and methods, and modified the constructor.
* Updated the `GetCell` method to include new conditions for `DefaultCell` and `TemplatedCell`. [[1]](diffhunk://#diff-4a57b059c4b359650d1f54e41ea206fecf1df6e1f813bc1a3147099c9546f863R49-R57) [[2]](diffhunk://#diff-4a57b059c4b359650d1f54e41ea206fecf1df6e1f813bc1a3147099c9546f863R66-R68)
* Modified the `ViewDidLayoutSubviews` method to use `_isCenteringItem` instead of `_updatingScrollOffset`.
* Refactored the `UpdateItemsSource` method to use `InitialPositionSet` instead of `_initialPositionSet`.
* Updated the `AttachingToWindow` and `DetachingFromWindow` methods, and added new methods `InitialPositionSet`, `TearDown`, and `Setup`.
* Modified the `CarouselViewScrolled` method to include new conditions.
* Refactored the `CollectionViewUpdating` and `CollectionViewUpdated` methods to include new conditions.
* Updated the `UpdateLoop` and `UpdateFromCurrentItem` methods to include new conditions. [[1]](diffhunk://#diff-4a57b059c4b359650d1f54e41ea206fecf1df6e1f813bc1a3147099c9546f863R393-R457) [[2]](diffhunk://#diff-4a57b059c4b359650d1f54e41ea206fecf1df6e1f813bc1a3147099c9546f863R467-R474)
* Modified the `UpdateFromPosition` method to include new conditions and logic.
* Updated the `UpdateInitialPosition` and `UpdateVisualStates` methods to include new conditions and logic. [[1]](diffhunk://#diff-4a57b059c4b359650d1f54e41ea206fecf1df6e1f813bc1a3147099c9546f863R538) [[2]](diffhunk://#diff-4a57b059c4b359650d1f54e41ea206fecf1df6e1f813bc1a3147099c9546f863R547-R556)
* Refactored the `CarouselViewLoopManager` class to include new conditions. [[1]](diffhunk://#diff-4a57b059c4b359650d1f54e41ea206fecf1df6e1f813bc1a3147099c9546f863R639-R656) [[2]](diffhunk://#diff-4a57b059c4b359650d1f54e41ea206fecf1df6e1f813bc1a3147099c9546f863R693-R706) [[3]](diffhunk://#diff-4a57b059c4b359650d1f54e41ea206fecf1df6e1f813bc1a3147099c9546f863R719-R729)