### PR TITLE
Fix PopoverPresentationController for action sheet

### DIFF
--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issues16321.xaml
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issues16321.xaml
@@ -6,6 +6,8 @@
     <VerticalStackLayout>
       <Label Text="After clicking each button you should see an alert"></Label>
       <Button Text="Open Alert With Modals" AutomationId="OpenAlertWithModals" Clicked="OpenAlertWithModals"></Button>
+      <Button Text="Open Action Sheet With Modals" AutomationId="OpenActionSheetWithModals" Clicked="OpenActionSheetWithModals"></Button>
       <Button Text="Open Alert With New UIWindow" AutomationId="OpenAlertWithNewUIWindow" Clicked="OpenAlertWithNewUIWindow"></Button>
+      <Button Text="Open Action Sheet With New UIWindow" AutomationId="OpenActionSheetWithNewUIWindow" Clicked="OpenActionSheetWithNewUIWindow"></Button>
     </VerticalStackLayout>
   </ContentPage>

--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issues16321.xaml.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issues16321.xaml.cs
@@ -106,7 +106,7 @@ namespace Maui.Controls.Sample.Issues
 #else
 		async void OpenActionSheetWithNewUIWindow(System.Object sender, System.EventArgs e)
 		{
-			await page.DisplayActionSheet("hello", "message", "Cancel", "Option 1", "Option 2");
+			await this.DisplayActionSheet("hello", "message", "Cancel", "Option 1", "Option 2");
 		}
 
 		async void OpenAlertWithNewUIWindow(System.Object sender, System.EventArgs e)

--- a/src/Controls/samples/Controls.Sample.UITests/Issues/Issues16321.xaml.cs
+++ b/src/Controls/samples/Controls.Sample.UITests/Issues/Issues16321.xaml.cs
@@ -4,6 +4,8 @@ using Microsoft.Maui.Platform;
 using Microsoft.Maui;
 using System.Linq;
 using System;
+using System.Threading.Tasks;
+
 
 #if IOS
 using UIKit;
@@ -38,8 +40,18 @@ namespace Maui.Controls.Sample.Issues
 			await Navigation.PopModalAsync();
 		}
 
+		async void OpenActionSheetWithModals(System.Object sender, System.EventArgs e)
+		{
+			await Navigation.PushModalAsync(new ContentPage());
+			await Navigation.PushModalAsync(new ContentPage());
+			await this.DisplayActionSheet("hello", "message", "Cancel", "Option 1", "Option 2");
+			await Navigation.PopModalAsync();
+			await Navigation.PopModalAsync();
+		}
+
 #if IOS
-		async void OpenAlertWithNewUIWindow(System.Object sender, System.EventArgs e)
+
+		async void OpenPrompt(System.Object sender, System.EventArgs e, Func<Page, Task> promptAction)
 		{
 			var uIWindow = new UIWindow();
 			var keyWindow = (this.Window.Handler.PlatformView as UIWindow);
@@ -59,7 +71,7 @@ namespace Maui.Controls.Sample.Issues
 			popupVC.ModalTransitionStyle = UIModalTransitionStyle.CoverVertical;
 			await uIWindow.RootViewController.PresentViewControllerAsync(popupVC, false);
 
-			await page.DisplayAlert("hello", "message", "Cancel");
+			await promptAction.Invoke(page);
 
 			var rvc = uIWindow.RootViewController;
 
@@ -74,11 +86,33 @@ namespace Maui.Controls.Sample.Issues
 			keyWindow.WindowLevel = UIWindowLevel.Normal;
 			this.RemoveLogicalChild(page);
 		}
-#else
-			async void OpenAlertWithNewUIWindow(System.Object sender, System.EventArgs e)
+
+		void OpenAlertWithNewUIWindow(System.Object sender, System.EventArgs e)
+		{
+			OpenPrompt(sender, e, (page) =>
 			{
-				await this.DisplayAlert("hello", "message", "Cancel");
-			}
+				return page.DisplayAlert("hello", "message", "Cancel");
+			});
+		}
+
+
+		void OpenActionSheetWithNewUIWindow(System.Object sender, System.EventArgs e)
+		{
+			OpenPrompt(sender, e, (page) =>
+			{
+				return page.DisplayActionSheet("hello", "message", "Cancel", "Option 1", "Option 2");
+			});
+		}
+#else
+		async void OpenActionSheetWithNewUIWindow(System.Object sender, System.EventArgs e)
+		{
+			await page.DisplayActionSheet("hello", "message", "Cancel", "Option 1", "Option 2");
+		}
+
+		async void OpenAlertWithNewUIWindow(System.Object sender, System.EventArgs e)
+		{
+			await this.DisplayAlert("hello", "message", "Cancel");
+		}
 #endif
 	}
 }

--- a/src/Controls/tests/UITests/Tests/Issues/Issue16321.cs
+++ b/src/Controls/tests/UITests/Tests/Issues/Issue16321.cs
@@ -11,29 +11,20 @@ namespace Microsoft.Maui.AppiumTests.Issues
 		public override string Issue => "Alerts Open on top of current presented view";
 
 		[Test]
+		[TestCase("OpenAlertWithModals")]
+		[TestCase("OpenAlertWithNewUIWindow")]
+		[TestCase("OpenActionSheetWithNewUIWindow")]
+		[TestCase("OpenActionSheetWithModals")]
 		[Category(UITestCategories.DisplayAlert)]
-		public void OpenAlertWithModals()
+		public void OpenAlertWithModals(string testCase)
 		{
 			this.IgnoreIfPlatforms(new[]
 			{
 				TestDevice.Mac, TestDevice.Windows, TestDevice.Android
 			});
 
-			App.WaitForElement("OpenAlertWithModals").Click();
-			App.WaitForElement("Cancel").Click();
-		}
-
-		[Test]
-		[Category(UITestCategories.DisplayAlert)]
-		public void OpenAlertWithNewUIWindow()
-		{
-			this.IgnoreIfPlatforms(new[]
-			{
-				TestDevice.Mac, TestDevice.Windows, TestDevice.Android
-			});
-
-			App.WaitForElement("OpenAlertWithNewUIWindow").Click();
-			App.WaitForElement("Cancel").Click();
+			App.WaitForElement(testCase).Tap();
+			App.WaitForElement("Cancel").Tap();
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change

Use the topmost UIViewController when presenting an action sheet. This was already accomplished for DisplayAlert and using ActionSheets on iPhones but it also needed to be applied to iPads

### Issues Fixed


Fixes #21934

