### PR TITLE
Update dependabot.yml to fix slash vs. dash

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -61,4 +61,4 @@ updates:
   labels:
       - "nuget"
       - "dependencies"
-      - "area/infrastructure"
+      - "area-infrastructure"


### PR DESCRIPTION
Oops. I used the old label name.