### PR TITLE
[Windows] Improve performance of `ContentPanel.EnsureBorderPath`

### DIFF
--- a/src/Core/src/Platform/Windows/ContentPanel.cs
+++ b/src/Core/src/Platform/Windows/ContentPanel.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using System;
+﻿using System;
 using System.Numerics;
 using Microsoft.Graphics.Canvas;
 using Microsoft.Maui.Graphics;
@@ -8,7 +7,6 @@ using Microsoft.Maui.Graphics.Win2D;
 using Microsoft.UI.Composition;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Hosting;
-using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Shapes;
 
 namespace Microsoft.Maui.Platform
@@ -55,16 +53,20 @@ namespace Microsoft.Maui.Platform
 			SizeChanged += ContentPanelSizeChanged;
 		}
 
-		void ContentPanelSizeChanged(object sender, UI.Xaml.SizeChangedEventArgs e)
+		void ContentPanelSizeChanged(object sender, SizeChangedEventArgs e)
 		{
 			if (_borderPath is null)
+			{
 				return;
+			}
 
 			var width = e.NewSize.Width;
 			var height = e.NewSize.Height;
 
 			if (width <= 0 || height <= 0)
+			{
 				return;
+			}
 
 			_borderPath.UpdatePath(_borderStroke?.Shape, width, height);
 			UpdateClip(_borderStroke?.Shape, width, height);
@@ -81,7 +83,9 @@ namespace Microsoft.Maui.Platform
 		public void UpdateBackground(Paint? background)
 		{
 			if (_borderPath == null)
+			{
 				return;
+			}
 
 			_borderPath.UpdateBackground(background);
 		}
@@ -95,12 +99,16 @@ namespace Microsoft.Maui.Platform
 		internal void UpdateBorderStroke(IBorderStroke borderStroke)
 		{
 			if (borderStroke is null)
+			{
 				return;
+			}
 
 			_borderStroke = borderStroke;
 
 			if (_borderStroke is null)
+			{
 				return;
+			}
 
 			UpdateBorder(_borderStroke.Shape);
 		}
@@ -108,7 +116,9 @@ namespace Microsoft.Maui.Platform
 		void UpdateBorder(IShape? strokeShape)
 		{
 			if (strokeShape is null || _borderPath is null)
+			{
 				return;
+			}
 
 			_borderPath.UpdateBorderShape(strokeShape, ActualWidth, ActualHeight);
 
@@ -116,7 +126,9 @@ namespace Microsoft.Maui.Platform
 			var height = ActualHeight;
 
 			if (width <= 0 || height <= 0)
+			{
 				return;
+			}
 
 			UpdateClip(strokeShape, width, height);
 		}
@@ -124,7 +136,9 @@ namespace Microsoft.Maui.Platform
 		void AddContent(FrameworkElement? content)
 		{
 			if (content == null)
+			{
 				return;
+			}
 
 			if (!Children.Contains(_content))
 				Children.Add(_content);
@@ -133,15 +147,21 @@ namespace Microsoft.Maui.Platform
 		void UpdateClip(IShape? borderShape, double width, double height)
 		{
 			if (Content is null)
+			{
 				return;
+			}
 
 			if (height <= 0 && width <= 0)
+			{
 				return;
+			}
 
 			var clipGeometry = borderShape;
 
 			if (clipGeometry is null)
+			{
 				return;
+			}
 
 			var visual = ElementCompositionPreview.GetElementVisual(Content);
 			var compositor = visual.Compositor;
@@ -149,7 +169,7 @@ namespace Microsoft.Maui.Platform
 			PathF? clipPath;
 			float strokeThickness = (float)(_borderPath?.StrokeThickness ?? 0);
 			// The path size should consider the space taken by the border (top and bottom, left and right)
-			var pathSize = new Graphics.Rect(0, 0, width - strokeThickness * 2, height - strokeThickness * 2);
+			var pathSize = new Rect(0, 0, width - strokeThickness * 2, height - strokeThickness * 2);
 
 			if (clipGeometry is IRoundRectangle roundedRectangle)
 			{

--- a/src/Core/src/Platform/Windows/ContentPanel.cs
+++ b/src/Core/src/Platform/Windows/ContentPanel.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Maui.Platform
 		public ContentPanel()
 		{
 			_borderPath = new Path();
-			EnsureBorderPath();
+			EnsureBorderPath(containsCheck: false);
 
 			SizeChanged += ContentPanelSizeChanged;
 		}
@@ -72,9 +72,18 @@ namespace Microsoft.Maui.Platform
 			UpdateClip(_borderStroke?.Shape, width, height);
 		}
 
-		internal void EnsureBorderPath()
+		internal void EnsureBorderPath(bool containsCheck = true)
 		{
-			if (!Children.Contains(_borderPath))
+			if (containsCheck)
+			{
+				var children = Children;
+
+				if (!children.Contains(_borderPath))
+				{
+					children.Add(_borderPath);
+				}
+			}
+			else
 			{
 				Children.Add(_borderPath);
 			}
@@ -140,8 +149,12 @@ namespace Microsoft.Maui.Platform
 				return;
 			}
 
-			if (!Children.Contains(_content))
-				Children.Add(_content);
+			var children = Children;
+
+			if (!children.Contains(_content))
+			{
+				children.Add(_content);
+			}
 		}
 
 		void UpdateClip(IShape? borderShape, double width, double height)

--- a/src/Core/src/Platform/Windows/ContentPanel.cs
+++ b/src/Core/src/Platform/Windows/ContentPanel.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Maui.Platform
 
 		public void UpdateBackground(Paint? background)
 		{
-			if (_borderPath == null)
+			if (_borderPath is null)
 			{
 				return;
 			}
@@ -135,7 +135,7 @@ namespace Microsoft.Maui.Platform
 
 		void AddContent(FrameworkElement? content)
 		{
-			if (content == null)
+			if (content is null)
 			{
 				return;
 			}


### PR DESCRIPTION
### Description of Change

This PR is a simple performance improvement for `ContentPanel` on Windows.

The main change is in the 3rd commit (50567205e9d18a4281ad8890106d11fa4594fdb9), previous commits fix code style.

## Performance comparison

[Speedscope](https://www.speedscope.app/) comparing main and this PR using testing code ([main](https://github.com/MartyIX/maui/tree/feature/2024-05-11-perf-ContentPanel-BASELINE), [PR](https://github.com/MartyIX/maui/tree/feature/2024-05-11-perf-ContentPanel)):

![image](https://github.com/dotnet/maui/assets/203266/a613d26d-2bb6-47f6-a920-67bbf78f27f8)

How to repeat: 

```powershell
cd src/Controls/samples/Controls.Sample.Sandbox
dotnet publish -f net8.0-windows10.0.19041.0 -c Release -p:PublishReadyToRun=false -p:WindowsPackageType=None
dotnet trace collect --format speedscope -- .\bin\Release\net8.0-windows10.0.19041.0\win10-x64\publish\Maui.Controls.Sample.Sandbox.exe
```

and click `Batch Add Borders` button FIVE times.

### Issues Fixed

Contributes to #21087