### PR TITLE
Don't propagate VE.Frame changes back down to the Handler

### DIFF
--- a/src/Controls/src/Core/Element/Element.cs
+++ b/src/Controls/src/Core/Element/Element.cs
@@ -571,7 +571,7 @@ namespace Microsoft.Maui.Controls
 		{
 			base.OnPropertyChanged(propertyName);
 
-			Handler?.UpdateValue(propertyName);
+			UpdateHandlerValue(propertyName);
 
 			if (_effects?.Count > 0)
 			{
@@ -582,6 +582,9 @@ namespace Microsoft.Maui.Controls
 				}
 			}
 		}
+
+		private protected virtual void UpdateHandlerValue(string property) =>
+			Handler?.UpdateValue(property);
 
 		internal IEnumerable<Element> Descendants() =>
 			Descendants<Element>();

--- a/src/Controls/src/Core/VisualElement/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement/VisualElement.cs
@@ -1944,11 +1944,11 @@ namespace Microsoft.Maui.Controls
 
 		private protected override void UpdateHandlerValue(string property)
 		{
-			// The Height and Width properties aren't really meant to propagate back down to the handler.
-			// These properties are only set when the platform code updates the VisualElement.Frame property
-			// during an arrange pass, indicating what the actual width and height of the platform element are.
-			// WidthRequest and HeightRequest are the properties that we use to propagate changes down to the handler.
-			// These will still propagate down to the handler via the `OnRequestChanged` method.
+			// The HeightProperty and WidthProperty are not designed to propagate back to the handler.
+			// Instead, we use WidthRequestProperty and HeightRequestProperty to propagate changes to the handler.
+			// HeightProperty and WidthProperty are readonly and only update when the VisualElement.Frame property is set
+			// during an arrange pass, which indicates the actual width and height of the platform element.
+			// Changes to WidthRequestProperty and HeightRequestProperty will propagate to the handler via the `OnRequestChanged` method.
 			if (this.Batched && (property == HeightProperty.PropertyName || property == WidthProperty.PropertyName))
 				return;
 

--- a/src/Controls/src/Core/VisualElement/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement/VisualElement.cs
@@ -1944,10 +1944,11 @@ namespace Microsoft.Maui.Controls
 
 		private protected override void UpdateHandlerValue(string property)
 		{
-			// The Height and Width Property aren't really meant to propagate back down to the handler
-			// These properties are only set with the platform code updates the VisualElement.Frame property
-			// indicating what the actual width and height are.
-			// WidthRequest and HeightRequest are the properties that we use to propagate changes down to the Handler.
+			// The Height and Width properties aren't really meant to propagate back down to the handler.
+			// These properties are only set when the platform code updates the VisualElement.Frame property
+			// during an arrange pass, indicating what the actual width and height of the platform element are.
+			// WidthRequest and HeightRequest are the properties that we use to propagate changes down to the handler.
+			// These will still propagate down to the handler via the `OnRequestChanged` method.
 			if (this.Batched && (property == HeightProperty.PropertyName || property == WidthProperty.PropertyName))
 				return;
 

--- a/src/Controls/src/Core/VisualElement/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement/VisualElement.cs
@@ -1942,6 +1942,18 @@ namespace Microsoft.Maui.Controls
 			return value;
 		}
 
+		private protected override void UpdateHandlerValue(string property)
+		{
+			// The Height and Width Property aren't really meant to propagate back down to the handler
+			// These properties are only set with the platform code updates the VisualElement.Frame property
+			// indicating what the actual width and height are.
+			// WidthRequest and HeightRequest are the properties that we use to propagate changes down to the Handler.
+			if (this.Batched && (property == HeightProperty.PropertyName || property == WidthProperty.PropertyName))
+				return;
+
+			base.UpdateHandlerValue(property);
+		}
+
 		/// <inheritdoc/>
 		double IView.Width
 		{

--- a/src/Controls/tests/Core.UnitTests/TestClasses/BasicVisualElement.cs
+++ b/src/Controls/tests/Core.UnitTests/TestClasses/BasicVisualElement.cs
@@ -1,0 +1,23 @@
+using System.Threading.Tasks;
+using Microsoft.Maui.Animations;
+
+using Microsoft.Maui.Handlers;
+
+namespace Microsoft.Maui.Controls.Core.UnitTests
+{
+    public class BasicVisualElement : VisualElement
+    {
+    }
+
+    public class BasicVisualElementHandler : ViewHandler<BasicVisualElement, object>
+    {
+        public BasicVisualElementHandler(IPropertyMapper mapper, CommandMapper commandMapper = null) : base(mapper, commandMapper)
+        {
+        }
+
+        protected override object CreatePlatformView()
+        {
+            return new object();
+        }
+    }
+}

--- a/src/Controls/tests/Core.UnitTests/VisualElementTests.cs
+++ b/src/Controls/tests/Core.UnitTests/VisualElementTests.cs
@@ -296,12 +296,13 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		[Fact]
 		public void WidthAndHeightRequestPropagateToHandler()
 		{
-			bool mapperCalled = false;
+			int heightMapperCalled = 0;
+			int widthMapperCalled = 0;
 
 			var mapper = new PropertyMapper<IView, ViewHandler>(ViewHandler.ViewMapper)
 			{
-				[nameof(IView.Height)] = (_,_) => mapperCalled = true,
-				[nameof(IView.Width)] = (_,_) => mapperCalled = true,
+				[nameof(IView.Height)] = (_,_) => heightMapperCalled++,
+				[nameof(IView.Width)] = (_,_) => widthMapperCalled++,
 			};
 
 			var mauiApp1 = MauiApp.CreateBuilder()
@@ -312,13 +313,15 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			var element = new BasicVisualElement();
 			var platformView = element.ToPlatform(new MauiContext(mauiApp1.Services));
 
-			mapperCalled = false;
+			heightMapperCalled = 0;
+			widthMapperCalled = 0;
 			element.WidthRequest = 99;
-			Assert.True(mapperCalled);
+			Assert.Equal(1, heightMapperCalled);
+			Assert.Equal(1, widthMapperCalled);
 
-			mapperCalled = false;
 			element.HeightRequest = 99;
-			Assert.True(mapperCalled);
+			Assert.Equal(2, heightMapperCalled);
+			Assert.Equal(2, widthMapperCalled);
 		}
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/VisualElementTests.cs
+++ b/src/Controls/tests/Core.UnitTests/VisualElementTests.cs
@@ -292,5 +292,33 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			Assert.True(mapperCalled);
 		}
+
+		[Fact]
+		public void WidthAndHeightRequestPropagateToHandler()
+		{
+			bool mapperCalled = false;
+
+			var mapper = new PropertyMapper<IView, ViewHandler>(ViewHandler.ViewMapper)
+			{
+				[nameof(IView.Height)] = (_,_) => mapperCalled = true,
+				[nameof(IView.Width)] = (_,_) => mapperCalled = true,
+			};
+
+			var mauiApp1 = MauiApp.CreateBuilder()
+				.UseMauiApp<ApplicationStub>()
+				.ConfigureMauiHandlers(handlers => handlers.AddHandler<BasicVisualElement>((services) => new BasicVisualElementHandler(mapper)))
+				.Build();
+
+			var element = new BasicVisualElement();
+			var platformView = element.ToPlatform(new MauiContext(mauiApp1.Services));
+
+			mapperCalled = false;
+			element.WidthRequest = 99;
+			Assert.True(mapperCalled);
+
+			mapperCalled = false;
+			element.HeightRequest = 99;
+			Assert.True(mapperCalled);
+		}
 	}
 }


### PR DESCRIPTION
### Description of Change

The Height and Width Property aren't really meant to propagate back down to the handler. These properties are only set when the platform code updates the VisualElement.Frame property, indicating what the actual width and height of the platform element are. WidthRequest and HeightRequest are the properties that we use to propagate changes down to the Handler and those will still propagate down via the `OnRequestChange` calls

### Issues Fixed

Fixes #22271

