### PR TITLE
Fix Android multi-window error message notation

### DIFF
--- a/src/Core/src/Platform/Android/ApplicationExtensions.cs
+++ b/src/Core/src/Platform/Android/ApplicationExtensions.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Maui.Platform
 				throw new InvalidOperationException(
 					$"This window is already associated with an active Activity ({oldActivity.GetType()}). " + 
 					$"Please override CreateWindow on {application.GetType()} "  + 
-					$"to add support for multiple activities https://aka.ms/maui-docs-create-window"  + 
+					$"to add support for multiple activities https://aka.ms/maui-docs-create-window "  + 
 					$"or set the LaunchMode to SingleTop on {activity.GetType()}.");
 			}
 


### PR DESCRIPTION
### Description of Change

I would like to suggest an additional fix for #21492.
There is no space between the link and the following word, so the console does not recognize it as a valid link.

![スクリーンショット 2024-05-12 18 54 45](https://github.com/dotnet/maui/assets/29789286/6308945c-1b0a-43d0-bf30-f4066a15be56)
