### PR TITLE
Revert "Add (back) VSMac feedback tool mention when move-to-vs-feedback label is applied"

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -363,7 +363,7 @@ configuration:
             If you encounter a problem with Visual Studio or the .NET MAUI VS Code Extension, we want to know about it so that we can diagnose and fix it. By using the Report a Problem tool, you can collect detailed information about the problem, and send it to Microsoft with just a few button clicks.
 
 
-            1. Go to the [Visual Studio for Windows feedback tool](https://learn.microsoft.com/visualstudio/ide/how-to-report-a-problem-with-visual-studio) (for Visual Studio for Mac please use the [Visual Studio for Mac feedback tool](https://learn.microsoft.com/visualstudio/mac/report-a-problem?view=vsmac-2022)) or [.NET MAUI VS Code Extension repository](https://github.com/microsoft/vscode-dotnettools/issues) to report the issue
+            1. Go to the [Visual Studio for Windows feedback tool](https://learn.microsoft.com/visualstudio/ide/how-to-report-a-problem-with-visual-studio) or [.NET MAUI VS Code Extension repository](https://github.com/microsoft/vscode-dotnettools/issues) to report the issue
 
             2. Close this bug, and consider adding a link to the VS Feedback issue so that others can follow its activity there.
       description: Ask user to use VS Feedback for VS issues


### PR DESCRIPTION
Reverts dotnet/maui#22385

We could remove Visual Studio for Mac after all... 