### PR TITLE
Fix arcade warnings and update versions

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -120,6 +120,7 @@
     <XunitRunnerVisualStudioPackageVersion>2.8.0</XunitRunnerVisualStudioPackageVersion>
     <XunitAssertPackageVersion>2.8.0</XunitAssertPackageVersion>
     <XUnitAnalyzersPackageVersion>1.13.0</XUnitAnalyzersPackageVersion>
+    <XunitAbstractionsPackageVersion>2.0.3</XunitAbstractionsPackageVersion>
     <NSubstitutePackageVersion>5.1.0</NSubstitutePackageVersion>
     <CoverletCollectorPackageVersion>6.0.0</CoverletCollectorPackageVersion>
   </PropertyGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -116,10 +116,10 @@
   </PropertyGroup>
   <PropertyGroup>
     <MicrosoftNETTestSdkPackageVersion>17.6.0</MicrosoftNETTestSdkPackageVersion>
-    <XunitPackageVersion>2.5.1</XunitPackageVersion>
-    <XunitRunnerVisualStudioPackageVersion>2.5.1</XunitRunnerVisualStudioPackageVersion>
-    <XunitAssertPackageVersion>2.5.1</XunitAssertPackageVersion>
-    <XUnitAnalyzersPackageVersion>1.3.0</XUnitAnalyzersPackageVersion>
+    <XunitPackageVersion>2.8.0</XunitPackageVersion>
+    <XunitRunnerVisualStudioPackageVersion>2.8.0</XunitRunnerVisualStudioPackageVersion>
+    <XunitAssertPackageVersion>2.8.0</XunitAssertPackageVersion>
+    <XUnitAnalyzersPackageVersion>1.13.0</XUnitAnalyzersPackageVersion>
     <NSubstitutePackageVersion>5.1.0</NSubstitutePackageVersion>
     <CoverletCollectorPackageVersion>6.0.0</CoverletCollectorPackageVersion>
   </PropertyGroup>

--- a/src/Controls/tests/DeviceTests/Controls.DeviceTests.csproj
+++ b/src/Controls/tests/DeviceTests/Controls.DeviceTests.csproj
@@ -7,6 +7,7 @@
     <RootNamespace>Microsoft.Maui.DeviceTests</RootNamespace>
     <AssemblyName>Microsoft.Maui.Controls.DeviceTests</AssemblyName>
     <NoWarn>$(NoWarn),CA1416</NoWarn>
+    <ExcludeMicrosoftNetTestSdk>false</ExcludeMicrosoftNetTestSdk>
     <!-- Disable multi-RID builds to workaround a parallel build issue -->
     <RuntimeIdentifier Condition="$(TargetFramework.Contains('-maccatalyst'))">maccatalyst-x64</RuntimeIdentifier>
     <RuntimeIdentifier Condition="$(TargetFramework.Contains('-maccatalyst')) and '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'arm64'">maccatalyst-arm64</RuntimeIdentifier>

--- a/src/Core/tests/DeviceTests.Shared/Core.DeviceTests.Shared.csproj
+++ b/src/Core/tests/DeviceTests.Shared/Core.DeviceTests.Shared.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="xunit" Version="$(XunitPackageVersion)"/>
     <PackageReference Include="xunit.runner.utility" Version="$(XunitPackageVersion)"/>
-    <PackageReference Include="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="$(MicrosoftDotNetXHarnessTestRunnersXunitVersion)" />
+    <PackageReference Include="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="1.0.0-prerelease.21558.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Core/tests/DeviceTests.Shared/Core.DeviceTests.Shared.csproj
+++ b/src/Core/tests/DeviceTests.Shared/Core.DeviceTests.Shared.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="xunit" Version="$(XunitPackageVersion)"/>
     <PackageReference Include="xunit.runner.utility" Version="$(XunitPackageVersion)"/>
-    <PackageReference Include="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="1.0.0-prerelease.21558.2" />
+    <PackageReference Include="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="$(MicrosoftDotNetXHarnessTestRunnersXunitVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Core/tests/DeviceTests.Shared/Core.DeviceTests.Shared.csproj
+++ b/src/Core/tests/DeviceTests.Shared/Core.DeviceTests.Shared.csproj
@@ -7,6 +7,7 @@
     <AssemblyName>Microsoft.Maui.DeviceTests.Shared</AssemblyName>
     <!--<Nullable>enable</Nullable>-->
     <NoWarn>$(NoWarn),CA1416</NoWarn>
+    <ExcludeMicrosoftNetTestSdk>false</ExcludeMicrosoftNetTestSdk>
   </PropertyGroup>
 
   <Import Project="$(MauiSrcDirectory)MultiTargeting.targets" />

--- a/src/Core/tests/DeviceTests/Core.DeviceTests.csproj
+++ b/src/Core/tests/DeviceTests/Core.DeviceTests.csproj
@@ -10,6 +10,7 @@
     <!-- Disable multi-RID builds to workaround a parallel build issue -->
     <RuntimeIdentifier Condition="$(TargetFramework.Contains('-maccatalyst'))">maccatalyst-x64</RuntimeIdentifier>
     <RuntimeIdentifier Condition="$(TargetFramework.Contains('-maccatalyst')) and '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'arm64'">maccatalyst-arm64</RuntimeIdentifier>
+    <ExcludeMicrosoftNetTestSdk>false</ExcludeMicrosoftNetTestSdk>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Graphics/tests/DeviceTests/Graphics.DeviceTests.csproj
+++ b/src/Graphics/tests/DeviceTests/Graphics.DeviceTests.csproj
@@ -9,6 +9,7 @@
     <!-- Disable multi-RID builds to workaround a parallel build issue -->
     <RuntimeIdentifier Condition="$(TargetFramework.Contains('-maccatalyst'))">maccatalyst-x64</RuntimeIdentifier>
     <RuntimeIdentifier Condition="$(TargetFramework.Contains('-maccatalyst')) and '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'arm64'">maccatalyst-arm64</RuntimeIdentifier>
+    <ExcludeMicrosoftNetTestSdk>false</ExcludeMicrosoftNetTestSdk>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Graphics/tests/Graphics.Tests/Graphics.Tests.csproj
+++ b/src/Graphics/tests/Graphics.Tests/Graphics.Tests.csproj
@@ -11,7 +11,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="xunit" Version="$(XunitPackageVersion)"/>
-		<PackageReference Include="coverlet.collector" Version="6.0.0">
+		<PackageReference Include="coverlet.collector" Version="$(CoverletCollectorPackageVersion)" >
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>

--- a/src/SingleProject/Resizetizer/test/UnitTests/Resizetizer.UnitTests.csproj
+++ b/src/SingleProject/Resizetizer/test/UnitTests/Resizetizer.UnitTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>$(_MauiDotNetTfm)</TargetFramework>
@@ -13,7 +13,7 @@
     <PackageReference Include="SkiaSharp" />
     <PackageReference Include="SkiaSharp.Extended" />
     <PackageReference Include="xunit" Version="$(XunitPackageVersion)"/>
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="coverlet.collector" Version="$(CoverletCollectorPackageVersion)" />
     <PackageReference Include="Svg.Skia" />
   </ItemGroup>
 

--- a/src/TestUtils/src/DeviceTests.Runners/TestUtils.DeviceTests.Runners.csproj
+++ b/src/TestUtils/src/DeviceTests.Runners/TestUtils.DeviceTests.Runners.csproj
@@ -8,6 +8,7 @@
     <!--<Nullable>enable</Nullable>-->
     <NoWarn>$(NoWarn);CA1416</NoWarn>
     <WarningsNotAsErrors>$(WarningsNotAsErrors);XC0022;XC0023</WarningsNotAsErrors>
+    <ExcludeMicrosoftNetTestSdk>false</ExcludeMicrosoftNetTestSdk>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/TestUtils/src/DeviceTests.Runners/TestUtils.DeviceTests.Runners.csproj
+++ b/src/TestUtils/src/DeviceTests.Runners/TestUtils.DeviceTests.Runners.csproj
@@ -17,7 +17,7 @@
   <ItemGroup>
     <PackageReference Include="xunit"  Version="$(XunitPackageVersion)"/>
     <PackageReference Include="xunit.runner.utility"  Version="$(XunitPackageVersion)"/>
-    <PackageReference Include="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="1.0.0-prerelease.21558.2"/>
+    <PackageReference Include="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="$(MicrosoftDotNetXHarnessTestRunnersXunitVersion)"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/TestUtils/src/DeviceTests.Runners/TestUtils.DeviceTests.Runners.csproj
+++ b/src/TestUtils/src/DeviceTests.Runners/TestUtils.DeviceTests.Runners.csproj
@@ -17,7 +17,7 @@
   <ItemGroup>
     <PackageReference Include="xunit" Version="$(XunitPackageVersion)" />
     <PackageReference Include="xunit.runner.utility" Version="$(XunitPackageVersion)" />
-    <PackageReference Include="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="$(MicrosoftDotNetXHarnessTestRunnersXunitVersion)" />
+    <PackageReference Include="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="1.0.0-prerelease.21558.2" />
     <PackageReference Include="xunit.abstractions" Version="$(XunitAbstractionsPackageVersion)" />
   </ItemGroup>
 

--- a/src/TestUtils/src/DeviceTests.Runners/TestUtils.DeviceTests.Runners.csproj
+++ b/src/TestUtils/src/DeviceTests.Runners/TestUtils.DeviceTests.Runners.csproj
@@ -15,9 +15,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit"  Version="$(XunitPackageVersion)"/>
-    <PackageReference Include="xunit.runner.utility"  Version="$(XunitPackageVersion)"/>
-    <PackageReference Include="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="$(MicrosoftDotNetXHarnessTestRunnersXunitVersion)"/>
+    <PackageReference Include="xunit" Version="$(XunitPackageVersion)" />
+    <PackageReference Include="xunit.runner.utility" Version="$(XunitPackageVersion)" />
+    <PackageReference Include="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="$(MicrosoftDotNetXHarnessTestRunnersXunitVersion)" />
+    <PackageReference Include="xunit.abstractions" Version="$(XunitAbstractionsPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/TestUtils/src/DeviceTests.Runners/VisualRunner/DeviceRunner.cs
+++ b/src/TestUtils/src/DeviceTests.Runners/VisualRunner/DeviceRunner.cs
@@ -286,9 +286,17 @@ namespace Microsoft.Maui.TestUtils.DeviceTests.Runners.VisualRunner
 
 			var deviceExecSink = new DeviceExecutionSink(xunitTestCases, this, context);
 
-			IExecutionSink resultsSink = new DelegatingExecutionSummarySink(deviceExecSink, () => cancelled);
+			IExecutionSink resultsSink = new ExecutionSink(deviceExecSink, new ExecutionSinkOptions
+			{
+				CancelThunk = () => cancelled
+			});
 			if (longRunningSeconds > 0)
-				resultsSink = new DelegatingLongRunningTestDetectionSink(resultsSink, TimeSpan.FromSeconds(longRunningSeconds), diagSink);
+				resultsSink = new ExecutionSink(resultsSink, new ExecutionSinkOptions
+				{	
+					CancelThunk = () => cancelled,
+					DiagnosticMessageSink = diagSink,
+					LongRunningTestTime = TimeSpan.FromSeconds(longRunningSeconds)
+				});
 
 			var assm = new XunitProjectAssembly() { AssemblyFilename = runInfo.AssemblyFileName };
 			deviceExecSink.OnMessage(new TestAssemblyExecutionStarting(assm, executionOptions));

--- a/src/TestUtils/src/DeviceTests.Runners/VisualRunner/Sinks/DiagnosticMessageSink.cs
+++ b/src/TestUtils/src/DeviceTests.Runners/VisualRunner/Sinks/DiagnosticMessageSink.cs
@@ -1,17 +1,29 @@
 ﻿#nullable enable
 using System;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.Maui.TestUtils.DeviceTests.Runners.VisualRunner
 {
-	class DiagnosticMessageSink : DiagnosticEventSink
+	class DiagnosticMessageSink : LongLivedMarshalByRefObject, Xunit.Abstractions.IMessageSink
 	{
+		string _assemblyDisplayName;
+		Action<string> _logger;
+		bool _show;
 		public DiagnosticMessageSink(Action<string> logger, string assemblyDisplayName, bool showDiagnostics)
 		{
-			if (showDiagnostics && logger != null)
+			_logger = logger;
+			_assemblyDisplayName = assemblyDisplayName;
+			_show = showDiagnostics;
+		}
+
+		public bool OnMessage(IMessageSinkMessage message)
+		{
+			if (_show && _logger is not null)
 			{
-				DiagnosticMessageEvent += args => logger($"{assemblyDisplayName}: {args.Message.Message}");
+				_logger($"{_assemblyDisplayName}: {(message as DiagnosticMessage)?.Message}");
 			}
+			return true;
 		}
 	}
 }

--- a/src/TestUtils/src/DeviceTests/TestUtils.DeviceTests.csproj
+++ b/src/TestUtils/src/DeviceTests/TestUtils.DeviceTests.csproj
@@ -7,6 +7,7 @@
     <RootNamespace>Microsoft.Maui.TestUtils.DeviceTests</RootNamespace>
     <AssemblyName>Microsoft.Maui.TestUtils.DeviceTests</AssemblyName>
     <Nullable>enable</Nullable>
+    <ExcludeMicrosoftNetTestSdk>false</ExcludeMicrosoftNetTestSdk>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/TestUtils/src/DeviceTests/TestUtils.DeviceTests.csproj
+++ b/src/TestUtils/src/DeviceTests/TestUtils.DeviceTests.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="xunit" Version="$(XunitPackageVersion)" />
     <PackageReference Include="xunit.runner.utility" Version="$(XunitPackageVersion)" />
-    <PackageReference Include="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="$(MicrosoftDotNetXHarnessTestRunnersXunitVersion)" />
+    <PackageReference Include="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="1.0.0-prerelease.21558.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/TestUtils/src/DeviceTests/TestUtils.DeviceTests.csproj
+++ b/src/TestUtils/src/DeviceTests/TestUtils.DeviceTests.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="xunit" Version="$(XunitPackageVersion)" />
     <PackageReference Include="xunit.runner.utility" Version="$(XunitPackageVersion)" />
-    <PackageReference Include="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="1.0.0-prerelease.21558.2" />
+    <PackageReference Include="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="$(MicrosoftDotNetXHarnessTestRunnersXunitVersion)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Description of Change

This pull request includes changes to various project files to update the Xunit package version, add the XunitAbstractions package, and modify the test setup. The changes are primarily focused on updating package versions and modifying the test execution setup.

Updates to package versions:

* [`eng/Versions.props`](diffhunk://#diff-1ea18ff65faa2ae6fed570b83747086d0317f5e4bc325064f6c14319a9c4ff67L119-R123): Updated Xunit package versions from 2.5.1 to 2.8.0 and added XunitAbstractions package version as 2.0.3.
* `src/Graphics/tests/Graphics.Tests/Graphics.Tests.csproj` and `src/SingleProject/Resizetizer/test/UnitTests/Resizetizer.UnitTests.csproj`: Changed the version of the coverlet.collector package to use the value from the Versions.props file. [[1]](diffhunk://#diff-5f2ed9971b43c655ab8936ada5892c5451c5a92152e9e45298ba0b51bc9f25c4L14-R14) [[2]](diffhunk://#diff-1dc5a07e7bc7647faddfc43a29dc812a6461f44e17a2723c679ea05e34649fb0L16-R16)
* [`src/TestUtils/src/DeviceTests.Runners/TestUtils.DeviceTests.Runners.csproj`](diffhunk://#diff-c884a100c9e209f7edd042d101fb210a699e86fdb57e0d8ef1254c16e74eece5R22): Added a reference to the XunitAbstractions package with the version from the Versions.props file.

Changes to test setup:

* `src/Controls/tests/DeviceTests/Controls.DeviceTests.csproj`, `src/Core/tests/DeviceTests.Shared/Core.DeviceTests.Shared.csproj`, `src/Core/tests/DeviceTests/Core.DeviceTests.csproj`, `src/Graphics/tests/DeviceTests/Graphics.DeviceTests.csproj`, `src/TestUtils/src/DeviceTests.Runners/TestUtils.DeviceTests.Runners.csproj`, and `src/TestUtils/src/DeviceTests/TestUtils.DeviceTests.csproj`: Added the ExcludeMicrosoftNetTestSdk property and set its value to false. [[1]](diffhunk://#diff-8b9c404f9891037c65ea0768ec01e0d8930e03001ee9f470e3b906b6aaca8606R10) [[2]](diffhunk://#diff-41b837acb08c80747b3c05ca89b8ded991265421213f0eb71e444614c9d231e1R10) [[3]](diffhunk://#diff-3da64a09d22fe1c649c9cd1e4d489d0a3836294ec9ac739d1bc2741db0a10203R13) [[4]](diffhunk://#diff-3c572fea339cc36898d5d3fae55bd48ac24d8a3230db2dcea9af9f9ccfcd44bfR12) [[5]](diffhunk://#diff-c884a100c9e209f7edd042d101fb210a699e86fdb57e0d8ef1254c16e74eece5R11) [[6]](diffhunk://#diff-4a9e00f9528720647a053550af162fa604691ea008966b7126e74320554df69bR10)
* [`src/TestUtils/src/DeviceTests.Runners/VisualRunner/DeviceRunner.cs`](diffhunk://#diff-3ae98e75925f870f90e531b3195ce8286df4b332ff572f9427873c3ecee83f1bL289-R299): Replaced the DelegatingExecutionSummarySink and DelegatingLongRunningTestDetectionSink with the ExecutionSink and updated the options passed to the sink.
* [`src/TestUtils/src/DeviceTests.Runners/VisualRunner/Sinks/DiagnosticMessageSink.cs`](diffhunk://#diff-2ac7f59d2a3f32be6b67eb42974378b7f19d3e7bbf523923820a38e78f4bbff3R4-R26): Modified the DiagnosticMessageSink to implement IMessageSink and updated the OnMessage method.