### PR TITLE
Eilon/net8 blazor androidhang

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -120,6 +120,7 @@
     <XunitRunnerVisualStudioPackageVersion>2.8.0</XunitRunnerVisualStudioPackageVersion>
     <XunitAssertPackageVersion>2.8.0</XunitAssertPackageVersion>
     <XUnitAnalyzersPackageVersion>1.13.0</XUnitAnalyzersPackageVersion>
+    <XunitAbstractionsPackageVersion>2.0.3</XunitAbstractionsPackageVersion>
     <NSubstitutePackageVersion>5.1.0</NSubstitutePackageVersion>
     <CoverletCollectorPackageVersion>6.0.0</CoverletCollectorPackageVersion>
   </PropertyGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -116,10 +116,10 @@
   </PropertyGroup>
   <PropertyGroup>
     <MicrosoftNETTestSdkPackageVersion>17.6.0</MicrosoftNETTestSdkPackageVersion>
-    <XunitPackageVersion>2.5.1</XunitPackageVersion>
-    <XunitRunnerVisualStudioPackageVersion>2.5.1</XunitRunnerVisualStudioPackageVersion>
-    <XunitAssertPackageVersion>2.5.1</XunitAssertPackageVersion>
-    <XUnitAnalyzersPackageVersion>1.3.0</XUnitAnalyzersPackageVersion>
+    <XunitPackageVersion>2.8.0</XunitPackageVersion>
+    <XunitRunnerVisualStudioPackageVersion>2.8.0</XunitRunnerVisualStudioPackageVersion>
+    <XunitAssertPackageVersion>2.8.0</XunitAssertPackageVersion>
+    <XUnitAnalyzersPackageVersion>1.13.0</XUnitAnalyzersPackageVersion>
     <NSubstitutePackageVersion>5.1.0</NSubstitutePackageVersion>
     <CoverletCollectorPackageVersion>6.0.0</CoverletCollectorPackageVersion>
   </PropertyGroup>

--- a/src/BlazorWebView/src/Maui/Android/BlazorWebViewHandler.Android.cs
+++ b/src/BlazorWebView/src/Maui/Android/BlazorWebViewHandler.Android.cs
@@ -59,6 +59,11 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 			return blazorAndroidWebView;
 		}
 
+		private const string FireAndForgetAsyncSwitch = "BlazorWebView.FireAndForgetAsync";
+
+		private static bool IsFireAndForgetAsyncEnabled =>
+			AppContext.TryGetSwitch(FireAndForgetAsyncSwitch, out var enabled) && enabled;
+
 		protected override void DisconnectHandler(AWebView platformView)
 		{
 			platformView.StopLoading();
@@ -67,11 +72,22 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 			{
 				// Dispose this component's contents and block on completion so that user-written disposal logic and
 				// Blazor disposal logic will complete.
-				_webviewManager?
+
+				// Fire and forget...
+				var disposalTask = _webviewManager?
 					.DisposeAsync()
-					.AsTask()
-					.GetAwaiter()
-					.GetResult();
+					.AsTask()!;
+
+				if (IsFireAndForgetAsyncEnabled)
+				{
+					disposalTask.FireAndForget();
+				}
+				else
+				{
+					disposalTask
+						.GetAwaiter()
+						.GetResult();
+				}
 
 				_webviewManager = null;
 			}

--- a/src/Core/tests/DeviceTests.Shared/Core.DeviceTests.Shared.csproj
+++ b/src/Core/tests/DeviceTests.Shared/Core.DeviceTests.Shared.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="xunit" Version="$(XunitPackageVersion)"/>
     <PackageReference Include="xunit.runner.utility" Version="$(XunitPackageVersion)"/>
-    <PackageReference Include="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="1.0.0-prerelease.21558.2" />
+    <PackageReference Include="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="$(MicrosoftDotNetXHarnessTestRunnersXunitVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Graphics/tests/Graphics.Tests/Graphics.Tests.csproj
+++ b/src/Graphics/tests/Graphics.Tests/Graphics.Tests.csproj
@@ -11,7 +11,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="xunit" Version="$(XunitPackageVersion)"/>
-		<PackageReference Include="coverlet.collector" Version="6.0.0">
+		<PackageReference Include="coverlet.collector" Version="$(CoverletCollectorPackageVersion)" >
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>

--- a/src/SingleProject/Resizetizer/test/UnitTests/Resizetizer.UnitTests.csproj
+++ b/src/SingleProject/Resizetizer/test/UnitTests/Resizetizer.UnitTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>$(_MauiDotNetTfm)</TargetFramework>
@@ -13,7 +13,7 @@
     <PackageReference Include="SkiaSharp" />
     <PackageReference Include="SkiaSharp.Extended" />
     <PackageReference Include="xunit" Version="$(XunitPackageVersion)"/>
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="coverlet.collector" Version="$(CoverletCollectorPackageVersion)" />
     <PackageReference Include="Svg.Skia" />
   </ItemGroup>
 

--- a/src/TestUtils/src/DeviceTests.Runners/TestUtils.DeviceTests.Runners.csproj
+++ b/src/TestUtils/src/DeviceTests.Runners/TestUtils.DeviceTests.Runners.csproj
@@ -17,7 +17,7 @@
   <ItemGroup>
     <PackageReference Include="xunit"  Version="$(XunitPackageVersion)"/>
     <PackageReference Include="xunit.runner.utility"  Version="$(XunitPackageVersion)"/>
-    <PackageReference Include="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="1.0.0-prerelease.21558.2"/>
+    <PackageReference Include="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="$(MicrosoftDotNetXHarnessTestRunnersXunitVersion)"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/TestUtils/src/DeviceTests.Runners/TestUtils.DeviceTests.Runners.csproj
+++ b/src/TestUtils/src/DeviceTests.Runners/TestUtils.DeviceTests.Runners.csproj
@@ -15,9 +15,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit"  Version="$(XunitPackageVersion)"/>
-    <PackageReference Include="xunit.runner.utility"  Version="$(XunitPackageVersion)"/>
-    <PackageReference Include="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="$(MicrosoftDotNetXHarnessTestRunnersXunitVersion)"/>
+    <PackageReference Include="xunit" Version="$(XunitPackageVersion)" />
+    <PackageReference Include="xunit.runner.utility" Version="$(XunitPackageVersion)" />
+    <PackageReference Include="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="$(MicrosoftDotNetXHarnessTestRunnersXunitVersion)" />
+    <PackageReference Include="xunit.abstractions" Version="$(XunitAbstractionsPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/TestUtils/src/DeviceTests.Runners/VisualRunner/DeviceRunner.cs
+++ b/src/TestUtils/src/DeviceTests.Runners/VisualRunner/DeviceRunner.cs
@@ -286,9 +286,17 @@ namespace Microsoft.Maui.TestUtils.DeviceTests.Runners.VisualRunner
 
 			var deviceExecSink = new DeviceExecutionSink(xunitTestCases, this, context);
 
-			IExecutionSink resultsSink = new DelegatingExecutionSummarySink(deviceExecSink, () => cancelled);
+			IExecutionSink resultsSink = new ExecutionSink(deviceExecSink, new ExecutionSinkOptions
+			{
+				CancelThunk = () => cancelled
+			});
 			if (longRunningSeconds > 0)
-				resultsSink = new DelegatingLongRunningTestDetectionSink(resultsSink, TimeSpan.FromSeconds(longRunningSeconds), diagSink);
+				resultsSink = new ExecutionSink(resultsSink, new ExecutionSinkOptions
+				{	
+					CancelThunk = () => cancelled,
+					DiagnosticMessageSink = diagSink,
+					LongRunningTestTime = TimeSpan.FromSeconds(longRunningSeconds)
+				});
 
 			var assm = new XunitProjectAssembly() { AssemblyFilename = runInfo.AssemblyFileName };
 			deviceExecSink.OnMessage(new TestAssemblyExecutionStarting(assm, executionOptions));

--- a/src/TestUtils/src/DeviceTests.Runners/VisualRunner/Sinks/DiagnosticMessageSink.cs
+++ b/src/TestUtils/src/DeviceTests.Runners/VisualRunner/Sinks/DiagnosticMessageSink.cs
@@ -1,17 +1,29 @@
 ﻿#nullable enable
 using System;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.Maui.TestUtils.DeviceTests.Runners.VisualRunner
 {
-	class DiagnosticMessageSink : DiagnosticEventSink
+	class DiagnosticMessageSink : LongLivedMarshalByRefObject, Xunit.Abstractions.IMessageSink
 	{
+		string _assemblyDisplayName;
+		Action<string> _logger;
+		bool _show;
 		public DiagnosticMessageSink(Action<string> logger, string assemblyDisplayName, bool showDiagnostics)
 		{
-			if (showDiagnostics && logger != null)
+			_logger = logger;
+			_assemblyDisplayName = assemblyDisplayName;
+			_show = showDiagnostics;
+		}
+
+		public bool OnMessage(IMessageSinkMessage message)
+		{
+			if (_show && _logger is not null)
 			{
-				DiagnosticMessageEvent += args => logger($"{assemblyDisplayName}: {args.Message.Message}");
+				_logger($"{_assemblyDisplayName}: {(message as DiagnosticMessage)?.Message}");
 			}
+			return true;
 		}
 	}
 }

--- a/src/TestUtils/src/DeviceTests/TestUtils.DeviceTests.csproj
+++ b/src/TestUtils/src/DeviceTests/TestUtils.DeviceTests.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="xunit" Version="$(XunitPackageVersion)" />
     <PackageReference Include="xunit.runner.utility" Version="$(XunitPackageVersion)" />
-    <PackageReference Include="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="1.0.0-prerelease.21558.2" />
+    <PackageReference Include="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="$(MicrosoftDotNetXHarnessTestRunnersXunitVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/TestUtils/src/TestUtils/TestUtils.csproj
+++ b/src/TestUtils/src/TestUtils/TestUtils.csproj
@@ -6,6 +6,7 @@
     <AssemblyName>Microsoft.Maui.TestUtils</AssemblyName>
 
     <IsPackable>false</IsPackable>
+    <NoWarn>$(NoWarn);NU1701</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Description of Change

Add an opt-in switch to enable the BlazorWebView to 'fire and forget' the async disposal that occurs in BlazorWebView. By default, the BlazorWebView does async-over-sync for disposal, meaning that it blocks the thread until the async disposal is complete. Unfortunately, this can cause deadlocks if the disposal itself needs to run code on the same thread (because that thread is blocked while waiting). The control has had this logic for a long time, but it seems that on Android the luck has changed, and hangs are now quite common during disposal.

By default there is no behavior change.

If you are encountering hangs in Android with BlazorWebView, you can enable this [AppContext Switch](https://learn.microsoft.com/dotnet/api/system.appcontext.trygetswitch?view=net-8.0) with one line of code in your app's `MauiProgram.cs`:

```c#
AppContext.SetSwitch("BlazorWebView.FireAndForgetAsync", isEnabled: true);
```

This issue has been reported in several different issues, but we think they all have this same root cause, and enabling this new switch should fix your app.

Example reports:

* DisposeAsync() on IJSObjectReference causes hanging when called on Android 11 and lower on app suspension #13529
* [regression/8.0.0-rc.1.9171] APP crashes when "minimized" at android #17477
* Application freezes when phone font size (or anything affecting UI) changes while app is running. #18284
* Applink makes app hang after using back button in Android with MAUI 8 #20267
* Problems with .NET Maui Hybrid Blazor Foreground Service #20303
* .NET MAUI Stuck on splash screen when reopen the app after start a foreground service #20678
* Hybrid app with Android foreground service locks up when reopening the app with the service running #20812
* Freezing App when Navigating Between Tabs with BlazorWebView in Maui Blazor App #22344

## Caveats

Because enabling this new switch means that disposal can return before all objects are disposed, this can cause behavioral changes in an app. The items that are disposed are partially Blazor's own internal types, but also app-defined types such as scoped services used within the BlazorWebView portion of the app.

### Issues Fixed

Fixes #13529
