### PR TITLE
[WinUI] Optimize `TransformationExtensions`

### DIFF
--- a/src/Core/src/Platform/Windows/TransformationExtensions.cs
+++ b/src/Core/src/Platform/Windows/TransformationExtensions.cs
@@ -8,8 +8,6 @@ namespace Microsoft.Maui.Platform
 	{
 		public static void UpdateTransformation(this FrameworkElement frameworkElement, IView view)
 		{
-			double anchorX = view.AnchorX;
-			double anchorY = view.AnchorY;
 			double rotationX = view.RotationX;
 			double rotationY = view.RotationY;
 			double rotation = view.Rotation;
@@ -17,9 +15,6 @@ namespace Microsoft.Maui.Platform
 			double translationY = view.TranslationY;
 			double scaleX = view.Scale * view.ScaleX;
 			double scaleY = view.Scale * view.ScaleY;
-
-			frameworkElement.RenderTransformOrigin = new global::Windows.Foundation.Point(anchorX, anchorY);
-			frameworkElement.RenderTransform = new ScaleTransform { ScaleX = scaleX, ScaleY = scaleY };
 
 			if (rotationX % 360 == 0 && rotationY % 360 == 0 && rotation % 360 == 0 &&
 				translationX == 0 && translationY == 0 && scaleX == 1 && scaleY == 1)
@@ -29,6 +24,12 @@ namespace Microsoft.Maui.Platform
 			}
 			else
 			{
+				double anchorX = view.AnchorX;
+				double anchorY = view.AnchorY;
+
+				frameworkElement.RenderTransformOrigin = new global::Windows.Foundation.Point(anchorX, anchorY);
+				frameworkElement.RenderTransform = new ScaleTransform { ScaleX = scaleX, ScaleY = scaleY };
+
 				// PlaneProjection removes touch and scrollwheel functionality on scrollable views such
 				// as ScrollView, ListView, and TableView. If neither RotationX or RotationY are set
 				// (i.e. their absolute value is 0), a CompositeTransform is instead used to allow for


### PR DESCRIPTION
### Description of Change

This PR makes it so that `RenderTransform` property is not set *unnecessarily* just to be unset immediately after. Setting `RenderTransform` seems very costly. 

All UI elements that do not need `RenderTransform` will benefit from this change. For example, creating biggish grids or more complex apps where inefficiencies add up.

#### Speedscope

##### 1st measurement

* main: [Maui.Controls.Sample.Sandbox.exe_20240517_115325.speedscope.MAIN.json](https://github.com/dotnet/maui/files/15347173/Maui.Controls.Sample.Sandbox.exe_20240517_115325.speedscope.MAIN.json)
* PR: [Maui.Controls.Sample.Sandbox.exe_20240517_115005.speedscope.PR.json](https://github.com/dotnet/maui/files/15347170/Maui.Controls.Sample.Sandbox.exe_20240517_115005.speedscope.PR.json)

![image](https://github.com/dotnet/maui/assets/203266/beb56ca8-91dd-4977-9524-4b74169cd7ce)

-> 75% improvement

I need to double check the results because it seems "too much".

##### 2nd measurement

* main: [Maui.Controls.Sample.Sandbox.exe_20240517_125520.speedscope.json](https://github.com/dotnet/maui/files/15348015/Maui.Controls.Sample.Sandbox.exe_20240517_125520.speedscope.json)
* PR: [Maui.Controls.Sample.Sandbox.exe_20240517_124307.speedscope.json](https://github.com/dotnet/maui/files/15347905/Maui.Controls.Sample.Sandbox.exe_20240517_124307.speedscope.json)

![image](https://github.com/dotnet/maui/assets/203266/613794a7-7162-4eea-b385-fc0c751f72f3)

-> 87% improvement

### Issues Fixed

Contributes to #21787