### PR TITLE
Add switch to BlazorWebView to configure 'fire and forget' for Android Disposal

### DIFF
--- a/src/BlazorWebView/src/Maui/Android/BlazorWebViewHandler.Android.cs
+++ b/src/BlazorWebView/src/Maui/Android/BlazorWebViewHandler.Android.cs
@@ -70,20 +70,22 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 
 			if (_webviewManager != null)
 			{
-				// Dispose this component's contents and block on completion so that user-written disposal logic and
-				// Blazor disposal logic will complete.
+				// Dispose this component's contents so that user-written disposal logic and Blazor disposal logic will complete.
 
-				// Fire and forget...
+				// Start the disposal...
 				var disposalTask = _webviewManager?
 					.DisposeAsync()
 					.AsTask()!;
 
 				if (IsAndroidFireAndForgetAsyncEnabled)
 				{
+					// If the app is configured to fire-and-forget via an AppContext Switch, we'll do that.
 					disposalTask.FireAndForget();
 				}
 				else
 				{
+					// Otherwise by default, we'll synchronously wait for the disposal to complete. This can cause
+					// a deadlock, but is the original behavior.
 					disposalTask
 						.GetAwaiter()
 						.GetResult();


### PR DESCRIPTION
### Description of Change

Add an opt-in switch to enable the BlazorWebView to 'fire and forget' the async disposal that occurs in BlazorWebView. By default, the BlazorWebView does async-over-sync for disposal, meaning that it blocks the thread until the async disposal is complete. Unfortunately, this can cause deadlocks if the disposal itself needs to run code on the same thread (because that thread is blocked while waiting). The control has had this logic for a long time, but it seems that on Android the luck has changed, and hangs are now quite common during disposal.

By default there is no behavior change.

If you are encountering hangs in Android with BlazorWebView, you can enable this [AppContext Switch](https://learn.microsoft.com/dotnet/api/system.appcontext.trygetswitch?view=net-8.0) with one line of code in your app's `MauiProgram.cs`:

```c#
AppContext.SetSwitch("BlazorWebView.AndroidFireAndForgetAsync", isEnabled: true);
```

This issue has been reported in several different issues, but we think they all have this same root cause, and enabling this new switch should fix your app.

**Confirmed fixed by this PR**:
* DisposeAsync() on IJSObjectReference causes hanging when called on Android 11 and lower on app suspension #13529 
* [regression/8.0.0-rc.1.9171] APP crashes when "minimized" at android #17477
* Application freezes when phone font size (or anything affecting UI) changes while app is running. #18284
* Freezing App when Navigating Between Tabs with BlazorWebView in Maui Blazor App #22344

**Hard to test, but seem to be exactly the same issue**:
* Applink makes app hang after using back button in Android with MAUI 8 #20267
* Problems with .NET Maui Hybrid Blazor Foreground Service #20303
* .NET MAUI Stuck on splash screen when reopen the app after start a foreground service #20678
* Hybrid app with Android foreground service locks up when reopening the app with the service running #20812

## Caveats

Because enabling this new switch means that disposal can return before all objects are disposed, this can cause behavioral changes in an app. The items that are disposed are partially Blazor's own internal types, but also app-defined types such as scoped services used within the BlazorWebView portion of the app.

### Issues Fixed

Fixes #13529
