### PR TITLE
[Trimming] Remove feature switch which is not necessary anymore

### DIFF
--- a/docs/design/FeatureSwitches.md
+++ b/docs/design/FeatureSwitches.md
@@ -6,17 +6,10 @@ The following switches are toggled for applications running on Mono for `TrimMod
 
 | MSBuild Property Name | AppContext Setting | Description |
 |-|-|-|
-| MauiXamlRuntimeParsingSupport | Microsoft.Maui.RuntimeFeature.IsXamlRuntimeParsingSupported | When disabled, all XAML loading at runtime will throw an exception. This will affect usage of APIs such as the `LoadFromXaml` extension method. This feature can be safely turned off when all XAML resources are compiled using XamlC (see [XAML compilation](https://learn.microsoft.com/dotnet/maui/xaml/xamlc)). This feature is enabled by default for all configurations except for NativeAOT. |
 | MauiEnableIVisualAssemblyScanning | Microsoft.Maui.RuntimeFeature.IsIVisualAssemblyScanningEnabled | When enabled, MAUI will scan assemblies for types implementing `IVisual` and for `[assembly: Visual(...)]` attributes and register these types. |
 | MauiShellSearchResultsRendererDisplayMemberNameSupported | Microsoft.Maui.RuntimeFeature.IsShellSearchResultsRendererDisplayMemberNameSupported | When disabled, it is necessary to always set `ItemTemplate` of any `SearchHandler`. Displaying search results through `DisplayMemberName` will not work. |
 | MauiQueryPropertyAttributeSupport | Microsoft.Maui.RuntimeFeature.IsQueryPropertyAttributeSupported | When disabled, the `[QueryProperty(...)]` attributes won't be used to set values to properties when navigating. |
 | MauiImplicitCastOperatorsUsageViaReflectionSupport | Microsoft.Maui.RuntimeFeature.IsImplicitCastOperatorsUsageViaReflectionSupported | When disabled, MAUI won't look for implicit cast operators when converting values from one type to another. This feature is not trim-compatible. |
-
-## MauiXamlRuntimeParsingSupport
-
-When this feature is disabled, the following APIs are affected:
-- [`LoadFromXaml` extension methods](https://learn.microsoft.com/dotnet/maui/xaml/runtime-load) will throw runtime exceptions.
-- [Disabling XAML compilation](https://learn.microsoft.com/dotnet/maui/xaml/xamlc#disable-xaml-compilation) using `[XamlCompilation(XamlCompilationOptions.Skip)]` on pages and controls or whole assemblies will cause runtime exceptions.
 
 ## MauiEnableIVisualAssemblyScanning
 

--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
@@ -215,16 +215,11 @@
       <MauiEnableIVisualAssemblyScanning Condition="'$(MauiEnableIVisualAssemblyScanning)' == ''">false</MauiEnableIVisualAssemblyScanning>
     </PropertyGroup>
     <PropertyGroup Condition="'$(PublishAot)' == 'true' or '$(TrimMode)' == 'full'">
-      <MauiXamlRuntimeParsingSupport Condition="'$(MauiXamlRuntimeParsingSupport)' == '' ">false</MauiXamlRuntimeParsingSupport>
       <MauiShellSearchResultsRendererDisplayMemberNameSupported Condition="'$(MauiShellSearchResultsRendererDisplayMemberNameSupported)' == ''">false</MauiShellSearchResultsRendererDisplayMemberNameSupported>
       <MauiQueryPropertyAttributeSupport Condition="'$(MauiQueryPropertyAttributeSupport)' == ''">false</MauiQueryPropertyAttributeSupport>
       <MauiImplicitCastOperatorsUsageViaReflectionSupport Condition="'$(MauiImplicitCastOperatorsUsageViaReflectionSupport)' == ''">false</MauiImplicitCastOperatorsUsageViaReflectionSupport>
     </PropertyGroup>
     <ItemGroup>
-      <RuntimeHostConfigurationOption Include="Microsoft.Maui.RuntimeFeature.IsXamlRuntimeParsingSupported"
-                                      Condition="'$(MauiXamlRuntimeParsingSupport)' != ''"
-                                      Value="$(MauiXamlRuntimeParsingSupport)"
-                                      Trim="true" />
       <RuntimeHostConfigurationOption Include="Microsoft.Maui.RuntimeFeature.IsIVisualAssemblyScanningEnabled"
                                       Condition="'$(MauiEnableIVisualAssemblyScanning)' != ''"
                                       Value="$(MauiEnableIVisualAssemblyScanning)"

--- a/src/Controls/src/Core/BindablePropertyConverter.cs
+++ b/src/Controls/src/Core/BindablePropertyConverter.cs
@@ -101,11 +101,16 @@ namespace Microsoft.Maui.Controls
 			if (bpinfo == null || bpinfo.FieldType != typeof(BindableProperty))
 				throw new XamlParseException($"Can't resolve {name} on {type.Name}", lineinfo);
 			var bp = bpinfo.GetValue(null) as BindableProperty;
-			var isObsolete = bpinfo.GetCustomAttribute<ObsoleteAttribute>() != null;
+			var isObsolete = GetObsoleteAttribute(bpinfo) != null;
 			if (bp.PropertyName != propertyName && !isObsolete)
 				throw new XamlParseException($"The PropertyName of {type.Name}.{name} is not {propertyName}", lineinfo);
 			return bp;
 		}
+
+		[UnconditionalSuppressMessage("TrimAnalysis", "IL2045:AttributeRemoval",
+			Justification = "ObsoleteAttribute instances are removed by the trimmer in production builds.")]
+		static ObsoleteAttribute GetObsoleteAttribute(FieldInfo fieldInfo)
+			=> fieldInfo.GetCustomAttribute<ObsoleteAttribute>();
 
 		[UnconditionalSuppressMessage("TrimAnalysis", "IL2057:TypeGetType",
 			Justification = "The converter is only used when parsing XAML at runtime. The developer will receive a warning " +

--- a/src/Controls/src/Core/BindablePropertyConverter.cs
+++ b/src/Controls/src/Core/BindablePropertyConverter.cs
@@ -107,7 +107,7 @@ namespace Microsoft.Maui.Controls
 			return bp;
 		}
 
-		[UnconditionalSuppressMessage("TrimAnalysis", "IL2026:RequiresUnreferencedCode",
+		[UnconditionalSuppressMessage("TrimAnalysis", "IL2057:TypeGetType",
 			Justification = "The converter is only used when parsing XAML at runtime. The developer will receive a warning " +
 				"saying that parsing XAML at runtime may not work as expected when trimming.")]
 		static Type GetControlType(string typeName)

--- a/src/Controls/src/Core/BindablePropertyConverter.cs
+++ b/src/Controls/src/Core/BindablePropertyConverter.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Reflection;
 using System.Xml;
 using Microsoft.Extensions.Logging;
-using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Controls.Xaml;
 
 namespace Microsoft.Maui.Controls
@@ -22,13 +21,11 @@ namespace Microsoft.Maui.Controls
 		public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
 			=> true;
 
+		[UnconditionalSuppressMessage("TrimAnalysis", "IL2026:RequiresUnreferencedCodeMessage",
+			Justification = "The converter is only used when parsing XAML at runtime. The developer will receive a warning " +
+				"saying that parsing XAML at runtime may not work as expected when trimming.")]
 		object IExtendedTypeConverter.ConvertFromInvariantString(string value, IServiceProvider serviceProvider)
 		{
-			if (!RuntimeFeature.IsXamlRuntimeParsingSupported)
-			{
-				throw new InvalidOperationException(RuntimeFeature.XamlRuntimeParsingNotSupportedErrorMessage);
-			}
-
 			if (string.IsNullOrWhiteSpace(value))
 				return null;
 			if (serviceProvider == null)
@@ -79,13 +76,11 @@ namespace Microsoft.Maui.Controls
 			throw new XamlParseException($"Can't resolve {value}. Syntax is [[prefix:]Type.]PropertyName.", lineinfo);
 		}
 
+		[UnconditionalSuppressMessage("TrimAnalysis", "IL2026:RequiresUnreferencedCodeMessage",
+			Justification = "The converter is only used when parsing XAML at runtime. The developer will receive a warning " +
+				"saying that parsing XAML at runtime may not work as expected when trimming.")]
 		public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
 		{
-			if (!RuntimeFeature.IsXamlRuntimeParsingSupported)
-			{
-				throw new InvalidOperationException(RuntimeFeature.XamlRuntimeParsingNotSupportedErrorMessage);
-			}
-
 			var strValue = value?.ToString();
 
 			if (string.IsNullOrWhiteSpace(strValue))

--- a/src/Controls/src/Xaml/XamlParser.cs
+++ b/src/Controls/src/Xaml/XamlParser.cs
@@ -364,21 +364,6 @@ namespace Microsoft.Maui.Controls.Xaml
 		public static Type GetElementType(XmlType xmlType, IXmlLineInfo xmlInfo, Assembly currentAssembly,
 			out XamlParseException exception)
 		{
-			if (!RuntimeFeature.IsXamlRuntimeParsingSupported)
-			{
-				throw new NotSupportedException(RuntimeFeature.XamlRuntimeParsingNotSupportedErrorMessage);
-			}
-
-			return GetElementTypeCore(xmlType, xmlInfo, currentAssembly, out exception);
-		}
-
-		[RequiresUnreferencedCode(TrimmerConstants.XamlRuntimeParsingNotSupportedWarning)]
-#if !NETSTANDARD
-		[RequiresDynamicCode(TrimmerConstants.XamlRuntimeParsingNotSupportedWarning)]
-#endif
-		private static Type GetElementTypeCore(XmlType xmlType, IXmlLineInfo xmlInfo, Assembly currentAssembly,
-			out XamlParseException exception)
-		{
 			bool hasRetriedNsSearch = false;
 
 		retry:

--- a/src/Core/src/RuntimeFeature.cs
+++ b/src/Core/src/RuntimeFeature.cs
@@ -14,28 +14,12 @@ namespace Microsoft.Maui
 	/// </remarks>
 	internal static class RuntimeFeature
 	{
-		private const bool IsXamlRuntimeParsingSupportedByDefault = true;
 		private const bool IsIVisualAssemblyScanningEnabledByDefault = false;
 		private const bool IsShellSearchResultsRendererDisplayMemberNameSupportedByDefault = true;
 		private const bool IsQueryPropertyAttributeSupportedByDefault = true;
 		private const bool IsImplicitCastOperatorsUsageViaReflectionSupportedByDefault = true;
 
 #pragma warning disable IL4000 // Return value does not match FeatureGuardAttribute 'System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute'. 
-#if !NETSTANDARD
-		[FeatureSwitchDefinition("Microsoft.Maui.RuntimeFeature.IsXamlRuntimeParsingSupported")]
-		[FeatureGuard(typeof(RequiresUnreferencedCodeAttribute))]
-		[FeatureGuard(typeof(RequiresDynamicCodeAttribute))]
-#endif
-		internal static bool IsXamlRuntimeParsingSupported
-			=> AppContext.TryGetSwitch("Microsoft.Maui.RuntimeFeature.IsXamlRuntimeParsingSupported", out bool isSupported)
-				? isSupported
-				: IsXamlRuntimeParsingSupportedByDefault;
-
-		internal const string XamlRuntimeParsingNotSupportedErrorMessage = "XAML runtime parsing is not supported. " +
-			"Ensure all XAML resources are compiled using XamlC. Alternatively, enable parsing XAML resources at runtime by setting " +
-			"the MauiXamlRuntimeParsingSupport MSBuild property to true. Note: this feature is not trimming-safe and it might not " +
-			"behave as expected when the application is trimmed.";
-
 #if !NETSTANDARD
 		[FeatureSwitchDefinition("Microsoft.Maui.RuntimeFeature.IsIVisualAssemblyScanningEnabled")]
 		[FeatureGuard(typeof(RequiresUnreferencedCodeAttribute))]


### PR DESCRIPTION
### Description of Change

In this PR, I'm removing throwing exceptions from `BindablePropertyConverter` and from `XamlParser`. These exceptions were causing problems when debugging and they aren't needed to aid trimming to remove the XAML parsing machinery. 
 When debugging and `$(MauiXamlRuntimeParsingSupport)=false` (the default when `$(PublishAot)=true` or `$(TrimMode)=full`), the app would crash on startup.

Unless the developer manually calls `LoadFromXaml` somewhere in their app, all the XAML parsing code will still be trimmed when XamlC compiles everything. Even though this PR suppresses warnings in `BindablePropertyConverter`, the developer will always see trimming warnings because they had to use `LoadFromXaml` somewhere. It isn't expected that anyone will use `BindablePropertyConverter` directly on its own (even though it is public).

#### Why did we originally need the feature switch?

The `MauiXamlRuntimeParsingSupport` was the first feature switch we added. It was necessary because we had a shared codepath in `ResourceDictionary.SetAndLoadSource(...)` which would need to behave differently when used from XamlC generated code and when used from `LoadFromXaml`. This method doesn't exist anymore, we split it into `SetAndCreateSource<T>(...)` (for XamlC use) and `ResourceDictionaryHelpers.LoadFromSource(...)` for runtime XAML parsing.

### Issues Fixed

Contributes to #18658

/cc @jonathanpeppers 