### PR TITLE
[Android] Allow custom handler with key listener

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue21109.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue21109.cs
@@ -14,22 +14,19 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 
 		[Test]
 		[Category(UITestCategories.Entry)]
-		public void CustomEntryListenerWorks()
+		public void EntryReturnTypeWorks()
 		{
 			App.WaitForElement("WaitForStubControl");
 
-			// 1. Verify that ReturnType works as expected.
+			// Verify that ReturnType works as expected.
+			if (App.IsKeyboardShown())
+				App.DismissKeyboard();
+
 			var returnType1 = App.FindElement("ReturnTypeResult").GetText();
+			App.Tap("ReturnTypeEntry");
 			App.EnterText("ReturnTypeEntry", "a");
 			var returnType2 = App.FindElement("ReturnTypeResult").GetText();
 			ClassicAssert.AreNotEqual(returnType1, returnType2);
-
-			// 2. Use a custom Entry with a NumberKeyListener.
-			App.Tap("CustomDecimalEntry");
-			App.EnterText("CustomDecimalEntry", "1");
-
-			// 3. If appear an alert, the test passed.
-			VerifyScreenshot();
 		}
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue21109.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue21109.cs
@@ -1,0 +1,36 @@
+﻿#if ANDROID
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue21109 : _IssuesUITest
+	{
+		public Issue21109(TestDevice device) : base(device) { }
+
+		public override string Issue => "[Android] MAUI 8.0.3 -> 8.0.6 regression: custom handler with key listener no longer works";
+
+		[Test]
+		[Category(UITestCategories.Entry)]
+		public void CustomEntryListenerWorks()
+		{
+			App.WaitForElement("WaitForStubControl");
+
+			// 1. Verify that ReturnType works as expected.
+			var returnType1 = App.FindElement("ReturnTypeResult").GetText();
+			App.EnterText("ReturnTypeEntry", "a");
+			var returnType2 = App.FindElement("ReturnTypeResult").GetText();
+			ClassicAssert.AreNotEqual(returnType1, returnType2);
+
+			// 2. Use a custom Entry with a NumberKeyListener.
+			App.Tap("CustomDecimalEntry");
+			App.EnterText("CustomDecimalEntry", "1");
+
+			// 3. If appear an alert, the test passed.
+			VerifyScreenshot();
+		}
+	}
+}
+#endif

--- a/src/Controls/tests/TestCases/Issues/Issue21109.xaml
+++ b/src/Controls/tests/TestCases/Issues/Issue21109.xaml
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Maui.Controls.Sample.Issues.Issue21109"
+             xmlns:controls="clr-namespace:Maui.Controls.Sample.Issues">
+  <VerticalStackLayout
+     Padding="30,0"
+     Spacing="25">
+    <Label
+      AutomationId="WaitForStubControl"
+      Text="ReturnType (Search)" />
+    <Entry
+      AutomationId="SearchEntry"
+      ReturnType="Search" />
+    <Label
+      Text="Update the ReturnType just typing" />
+    <Entry 
+      x:Name="ReturnTypeEntry"
+      AutomationId="ReturnTypeEntry"
+      TextChanged="OnReturnTypeEntryTextChanged"/>
+    <Label
+      x:Name="ReturnTypeResult"
+      AutomationId="ReturnTypeResult"/>
+    <Label    
+      Text="Custom DecimalEntry" />
+    <controls:DecimalEntry 
+      AutomationId="CustomDecimalEntry"/>
+  </VerticalStackLayout>
+</ContentPage>

--- a/src/Controls/tests/TestCases/Issues/Issue21109.xaml
+++ b/src/Controls/tests/TestCases/Issues/Issue21109.xaml
@@ -23,7 +23,7 @@
       AutomationId="ReturnTypeResult"/>
     <Label    
       Text="Custom DecimalEntry" />
-    <controls:DecimalEntry 
+    <controls:Issue21109DecimalEntry 
       AutomationId="CustomDecimalEntry"/>
   </VerticalStackLayout>
 </ContentPage>

--- a/src/Controls/tests/TestCases/Issues/Issue21109.xaml.cs
+++ b/src/Controls/tests/TestCases/Issues/Issue21109.xaml.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using Microsoft.Maui;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+
+namespace Maui.Controls.Sample.Issues
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	[Issue(IssueTracker.Github, 21109, "[Android] MAUI 8.0.3 -> 8.0.6 regression: custom handler with key listener no longer works", PlatformAffected.All)]
+	public partial class Issue21109 : ContentPage
+	{
+		public Issue21109()
+		{
+			InitializeComponent();
+
+			ReturnTypeResult.Text = $"ReturnType: {ReturnTypeEntry.ReturnType}";
+		}
+
+		void OnReturnTypeEntryTextChanged(object sender, TextChangedEventArgs e)
+		{
+			Random rnd = new Random();
+			var returnTypeCount = Enum.GetNames(typeof(ReturnType)).Length;
+
+			ReturnType returnType = ReturnType.Default;
+
+			do
+			{
+				returnType = (ReturnType)rnd.Next(0, returnTypeCount);
+			} while (returnType == ReturnTypeEntry.ReturnType);
+
+			ReturnTypeEntry.ReturnType = returnType;
+			ReturnTypeResult.Text = $"ReturnType: {returnType}";
+		}
+	}
+
+	public class DecimalEntry : Entry
+	{
+		public DecimalEntry()
+		{
+			Keyboard = Keyboard.Numeric;
+		}
+	}
+}

--- a/src/Controls/tests/TestCases/Issues/Issue21109.xaml.cs
+++ b/src/Controls/tests/TestCases/Issues/Issue21109.xaml.cs
@@ -2,6 +2,7 @@
 using Microsoft.Maui;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Xaml;
+using Microsoft.Maui.Hosting;
 
 namespace Maui.Controls.Sample.Issues
 {
@@ -33,11 +34,32 @@ namespace Maui.Controls.Sample.Issues
 		}
 	}
 
-	public class DecimalEntry : Entry
+	public class Issue21109DecimalEntry : Entry
 	{
-		public DecimalEntry()
+		public Issue21109DecimalEntry()
 		{
 			Keyboard = Keyboard.Numeric;
+		}
+	}
+
+	public static class Issue21109Extensions
+	{
+		public static MauiAppBuilder Issue21109AddMappers(this MauiAppBuilder builder)
+		{
+			builder.ConfigureMauiHandlers(handlers => 
+			{
+				Microsoft.Maui.Handlers.EntryHandler.Mapper.AppendToMapping(nameof(Issue21109DecimalEntry), (handler, view) =>
+				{
+					if (view is Issue21109DecimalEntry)
+					{
+#if ANDROID
+						handler.PlatformView.KeyListener = new Platform.Issue21109NumericKeyListener(handler.PlatformView.InputType);
+#endif
+					}
+				});
+			});
+
+			return builder;
 		}
 	}
 }

--- a/src/Controls/tests/TestCases/MauiProgram.cs
+++ b/src/Controls/tests/TestCases/MauiProgram.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Maui.Controls.Sample.Issues;
 using Microsoft.Maui;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Hosting;
@@ -8,18 +9,31 @@ namespace Maui.Controls.Sample
 {
 	public static class MauiProgram
 	{
-		public static MauiApp CreateMauiApp() =>
-			MauiApp
-				.CreateBuilder()
-	#if IOS || ANDROID
-				.UseMauiMaps()
-	#endif
-				.UseMauiApp<App>()
+		public static MauiApp CreateMauiApp()
+		{
+			var appBuilder = MauiApp.CreateBuilder();
+
+#if IOS || ANDROID
+			appBuilder.UseMauiMaps();
+#endif
+			appBuilder.UseMauiApp<App>()
 				.ConfigureFonts(fonts =>
 				{
 					fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
-				})
-				.Build();
+				});
+
+			Microsoft.Maui.Handlers.EntryHandler.Mapper.AppendToMapping(nameof(DecimalEntry), (handler, view) =>
+			{
+				if (view is DecimalEntry)
+				{
+#if ANDROID
+					handler.PlatformView.KeyListener = new Platform.NumericKeyListener(handler.PlatformView.InputType);
+#endif
+				}
+			});
+
+			return appBuilder.Build();
+		}
 	}
 
 	class App : Application

--- a/src/Controls/tests/TestCases/MauiProgram.cs
+++ b/src/Controls/tests/TestCases/MauiProgram.cs
@@ -20,17 +20,8 @@ namespace Maui.Controls.Sample
 				.ConfigureFonts(fonts =>
 				{
 					fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
-				});
-
-			Microsoft.Maui.Handlers.EntryHandler.Mapper.AppendToMapping(nameof(DecimalEntry), (handler, view) =>
-			{
-				if (view is DecimalEntry)
-				{
-#if ANDROID
-					handler.PlatformView.KeyListener = new Platform.NumericKeyListener(handler.PlatformView.InputType);
-#endif
-				}
-			});
+				})
+				.Issue21109AddMappers();
 
 			return appBuilder.Build();
 		}

--- a/src/Controls/tests/TestCases/Platforms/Android/Issue21109NumericKeyListener.cs
+++ b/src/Controls/tests/TestCases/Platforms/Android/Issue21109NumericKeyListener.cs
@@ -6,13 +6,13 @@ using AView = Android.Views.View;
 
 namespace Maui.Controls.Sample.Platform;
 
-public class NumericKeyListener : NumberKeyListener
+public class Issue21109NumericKeyListener : NumberKeyListener
 {
     public override InputTypes InputType { get; }
 
     protected override char[] GetAcceptedChars() => "0123456789-,.".ToCharArray();
 
-    public NumericKeyListener(InputTypes inputType)
+    public Issue21109NumericKeyListener(InputTypes inputType)
     {
         InputType = inputType;
     }

--- a/src/Controls/tests/TestCases/Platforms/Android/NumericKeyListener.cs
+++ b/src/Controls/tests/TestCases/Platforms/Android/NumericKeyListener.cs
@@ -1,0 +1,25 @@
+using Android.Text;
+using Android.Text.Method;
+using Android.Views;
+using Microsoft.Maui.Controls;
+using AView = Android.Views.View;
+
+namespace Maui.Controls.Sample.Platform;
+
+public class NumericKeyListener : NumberKeyListener
+{
+    public override InputTypes InputType { get; }
+
+    protected override char[] GetAcceptedChars() => "0123456789-,.".ToCharArray();
+
+    public NumericKeyListener(InputTypes inputType)
+    {
+        InputType = inputType;
+    }
+
+    public override bool OnKeyDown(AView view, IEditable content, Keycode keyCode, KeyEvent e)
+    {
+        Application.Current.MainPage.DisplayAlert("OnKeyDown", string.Empty, "Ok");
+        return base.OnKeyDown(view, content, keyCode, e);
+    }
+}

--- a/src/Core/src/Handlers/Entry/EntryHandler.Android.cs
+++ b/src/Core/src/Handlers/Entry/EntryHandler.Android.cs
@@ -42,7 +42,6 @@ namespace Microsoft.Maui.Handlers
 		// TODO: NET8 issoto - Change the return type to MauiAppCompatEditText
 		protected override void ConnectHandler(AppCompatEditText platformView)
 		{
-			platformView.ViewAttachedToWindow += OnViewAttachedToWindow;
 			platformView.TextChanged += OnTextChanged;
 			platformView.FocusChange += OnFocusedChange;
 			platformView.Touch += OnTouch;
@@ -54,7 +53,6 @@ namespace Microsoft.Maui.Handlers
 		{
 			_clearButtonDrawable = null;
 
-			platformView.ViewAttachedToWindow -= OnViewAttachedToWindow;
 			platformView.TextChanged -= OnTextChanged;
 			platformView.FocusChange -= OnFocusedChange;
 			platformView.Touch -= OnTouch;
@@ -146,14 +144,6 @@ namespace Microsoft.Maui.Handlers
 		{
 			if (args is FocusRequest request)
 				handler.PlatformView.Focus(request);
-		}
-
-		void OnViewAttachedToWindow(object? sender, ViewAttachedToWindowEventArgs e)
-		{
-			if (PlatformView is null || VirtualView is null)
-				return;
-
-			PlatformView.UpdateReturnType(VirtualView);
 		}
 
 		void OnTextChanged(object? sender, TextChangedEventArgs e)

--- a/src/Core/src/Platform/Android/EditTextExtensions.cs
+++ b/src/Core/src/Platform/Android/EditTextExtensions.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
+using Android.Content;
 using Android.Content.Res;
 using Android.Graphics.Drawables;
 using Android.Text;
@@ -203,6 +203,10 @@ namespace Microsoft.Maui.Platform
 		{
 			editText.SetInputType(entry);
 			editText.ImeOptions = entry.ReturnType.ToPlatform();
+			
+			// Restart the input on the current focused EditText
+			InputMethodManager? imm = (InputMethodManager?)editText.Context?.GetSystemService(Context.InputMethodService);
+			imm?.RestartInput(editText);
 		}
 
 		// TODO: NET8 issoto - Revisit this, marking this method as `internal` to avoid breaking public API changes


### PR DESCRIPTION
### Description of Change

Allow custom handler with key listener.
![fix-21109](https://github.com/dotnet/maui/assets/6755973/74a7cc8d-0d54-4e93-ac6c-8ee5585595dc)
Verified that the `ReturnType` property keeps working correctly.

### Issues Fixed

Fixes #21109
