### PR TITLE
[android] fix design-time build on project creation

### DIFF
--- a/src/Workload/Microsoft.Maui.Sdk/Sdk/Microsoft.Maui.Sdk.After.targets
+++ b/src/Workload/Microsoft.Maui.Sdk/Sdk/Microsoft.Maui.Sdk.After.targets
@@ -25,4 +25,9 @@
     <ProjectCapability Include="SingleTargetBuildForStartupProjects" Condition=" '$(EnableSingleTargetBuildForStartupProjects)' != 'false' " />
   </ItemGroup>
 
+  <!-- Fix Android design-time builds prior to NuGet restore -->
+  <PropertyGroup Condition=" '$(SingleProject)' == 'true' and '$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'android' and !Exists('$(AndroidManifest)') ">
+    <AndroidManifest Condition=" Exists('Platforms\Android\AndroidManifest.xml') ">Platforms\Android\AndroidManifest.xml</AndroidManifest>
+  </PropertyGroup>
+
 </Project>


### PR DESCRIPTION
Fixes: https://github.com/dotnet/maui/issues/21777#issuecomment-2052542298

When creating a new .NET MAUI project, the first design-time build can randomly fail with:

    C:\Program Files\dotnet\packs\Microsoft.Android.Sdk.Windows\34.0.95\tools\Xamarin.Android.Common.targets(613,3):
    error XA1018: Specified AndroidManifest file does not exist: D:\source\MauiApp3\MauiApp3\AndroidManifest.xml.

This can happen because:

1. NuGet restore isn't complete

2. `Microsoft.Maui.Controls.SingleProject.targets` is not imported

3. `$(AndroidManifest)` has not been moved to `Platforms/Android/AndroidManifest.xml`

This means the Android workload would just look for `AndroidManifest.xml` in the root of the project, which doesn't exist.

To fix this, let's check for the non-existence of `$(AndroidManifest)` in the MAUI workload and set it.

After testing this change in:

* `C:\Program Files\dotnet\packs\Microsoft.Maui.Sdk\8.0.21\Sdk\Microsoft.Maui.Sdk.After.targets`

I don't get a design-time build failure anymore.

/cc @BethMassi 