### PR TITLE
Weak Parent

### DIFF
--- a/src/Controls/src/Core/Element/Element.cs
+++ b/src/Controls/src/Core/Element/Element.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Maui.Controls
 
 		Guid? _id;
 
-		Element _parentOverride;
+		WeakReference<Element> _parentOverride;
 
 		string _styleId;
 
@@ -282,10 +282,26 @@ namespace Microsoft.Maui.Controls
 
 		internal Element ParentOverride
 		{
-			get { return _parentOverride; }
+			get 
+			{
+				if (_parentOverride is null)
+				{
+					return null;
+				}
+				if (_parentOverride.TryGetTarget(out var parent))
+				{
+					return parent;
+				}
+				else
+				{
+					// Log an error because this should never happen
+				}
+
+				return null;
+			}
 			set
 			{
-				if (_parentOverride == value)
+				if (ParentOverride == value)
 					return;
 
 				bool emitChange = Parent != value;
@@ -300,7 +316,10 @@ namespace Microsoft.Maui.Controls
 						OnParentChangingCore(Parent, RealParent);
 				}
 
-				_parentOverride = value;
+				if (value == null)
+					_parentOverride = null;
+				else
+					_parentOverride = new WeakReference<Element>(value);
 
 				if (emitChange)
 				{
@@ -310,9 +329,36 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
+		WeakReference<Element> _realParent;
 		/// <summary>For internal use by .NET MAUI.</summary>
 		[EditorBrowsable(EditorBrowsableState.Never)]
-		public Element RealParent { get; private set; }
+		public Element RealParent 
+		{ 
+			get
+			{
+				if (_realParent is null)
+				{
+					return null;
+				}
+				if (_realParent.TryGetTarget(out var parent))
+				{
+					return parent;
+				}
+				else
+				{
+					// Log an error because this should never happen
+				}
+
+				return null;
+			} 
+			private set
+			{
+				if (value is null)
+					_realParent = null;
+				else
+					_realParent = new WeakReference<Element>(value);
+			}
+		}
 
 		Dictionary<BindableProperty, (string, SetterSpecificity)> DynamicResources => _dynamicResources ?? (_dynamicResources = new Dictionary<BindableProperty, (string, SetterSpecificity)>());
 
@@ -328,7 +374,7 @@ namespace Microsoft.Maui.Controls
 		/// <remarks>Most application authors will not need to set the parent element by hand.</remarks>
 		public Element Parent
 		{
-			get { return _parentOverride ?? RealParent; }
+			get { return ParentOverride ?? RealParent; }
 			set => SetParent(value);
 		}
 

--- a/src/Controls/src/Core/Element/Element.cs
+++ b/src/Controls/src/Core/Element/Element.cs
@@ -294,7 +294,10 @@ namespace Microsoft.Maui.Controls
 				}
 				else
 				{
-					// Log an error because this should never happen
+					Application.Current?
+						.FindMauiContext()?
+						.CreateLogger<Element>()?
+						.LogWarning($"The ParentOverride on {this} has been Garbage Collected. This should never happen. Please log a bug: https://github.com/dotnet/maui");
 				}
 
 				return null;
@@ -346,7 +349,10 @@ namespace Microsoft.Maui.Controls
 				}
 				else
 				{
-					// Log an error because this should never happen
+					Application.Current?
+						.FindMauiContext()?
+						.CreateLogger<Element>()?
+						.LogWarning($"The RealParent on {this} has been Garbage Collected. This should never happen. Please log a bug: https://github.com/dotnet/maui");
 				}
 
 				return null;


### PR DESCRIPTION
### Description of Change

iOS doesn't have the ability to garbage collect if there's a circular reference of NSObjects. In order for the GC to work, it's important for platform views to only reference down the tree and never up the tree. 

This PR makes it so the `Parent` property on our xplat element is just using a WeakReference so that there isn't a strong reference from the children back up to the parents. 

This shouldn't cause any issues with the `Parent` or `Child` being collected prematurely for a couple of reasons.
1) There should really never be a scenario where a child has parent set but the parent doesn't have the child added as a logical child.
2) If for some reason one isn't true, then, the parent should have a reference to the child at the platform level. For example, if you add a button to a layout, the underlying UIView will have a reference to the UIButton which means the UIButton won't get collected.

