### PR TITLE
[resizetizer] don't generate files during design-time builds

### DIFF
--- a/src/SingleProject/Resizetizer/src/nuget/buildTransitive/Microsoft.Maui.Resizetizer.After.targets
+++ b/src/SingleProject/Resizetizer/src/nuget/buildTransitive/Microsoft.Maui.Resizetizer.After.targets
@@ -168,11 +168,6 @@
             $(ResizetizeAfterTargets);
             ResizetizeCollectItems;
         </ResizetizeAfterTargets>
-
-        <ProcessMauiFontsAfterTargets>
-            $(ProcessMauiFontsAfterTargets);
-            ResizetizeCollectItems;
-        </ProcessMauiFontsAfterTargets>
     </PropertyGroup>
 
     <!-- Windows App SDK -->


### PR DESCRIPTION
Context: https://github.com/dotnet/maui/issues/21777

When looking at design-time build logs of new .NET MAUI projects, I was consistently seeing the error:

    D:\.nuget\packages\microsoft.maui.resizetizer\8.0.21\buildTransitive\Microsoft.Maui.Resizetizer.After.targets(419,9): error MAUI0000: System.IO.IOException: The process cannot access the file 'D:\source\MauiApp1\MauiApp1\obj\Debug\net8.0-android\resizetizer\sp\drawable-xxxhdpi\splash.png' because it is being used by another process.
    at System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)
    at System.IO.FileStream.Init(String path, FileMode mode, FileAccess access, Int32 rights, Boolean useRights, FileShare share, Int32 bufferSize, FileOptions options, SECURITY_ATTRIBUTES secAttrs, String msgPath, Boolean bFromProxy, Boolean useLongPath, Boolean checkHost)
    at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize)
    at Microsoft.Maui.Resizetizer.SkiaSharpTools.Save(String destination, SKBitmap tempBitmap) in D:\a\_work\1\s\src\SingleProject\Resizetizer\src\SkiaSharpTools.cs:line 153
    at Microsoft.Maui.Resizetizer.SkiaSharpTools.Resize(DpiPath dpi, String destination, Double additionalScale, Boolean dpiSizeIsAbsolute) in D:\a\_work\1\s\src\SingleProject\Resizetizer\src\SkiaSharpTools.cs:line 74
    at Microsoft.Maui.Resizetizer.Resizer.Resize(DpiPath dpi, String inputsFile) in D:\a\_work\1\s\src\SingleProject\Resizetizer\src\Resizer.cs:line 107
    at Microsoft.Maui.Resizetizer.GenerateSplashAndroidResources.WriteImages(Resizer resizer) in D:\a\_work\1\s\src\SingleProject\Resizetizer\src\GenerateSplashAndroidResources.cs:line 72
    at Microsoft.Maui.Resizetizer.GenerateSplashAndroidResources.Execute() in D:\a\_work\1\s\src\SingleProject\Resizetizer\src\GenerateSplashAndroidResources.cs:line 47 [D:\source\MauiApp1\MauiApp1\MauiApp1.csproj]

Design-time builds can run in parallel, but the resizetizer targets are generating images? Should these targets run during a design-time build *at all*?

Following the paths of the targets in the `.binlog` viewer, it seems like the targets are declaring:

    <ProcessMauiFontsAfterTargets>
        $(ProcessMauiFontsAfterTargets);
        ResizetizeCollectItems;
    </ProcessMauiFontsAfterTargets>

So if `ResizetizeCollectItems` runs *at all*, fonts are generated as well as splash screens and images.

But then we also declare:

    <ProcessMauiFontsDependsOnTargets>
        $(ProcessMauiFontsDependsOnTargets);
        ResizetizeCollectItems;
        ProcessMauiAssets;
        ProcessMauiSplashScreens;
    </ProcessMauiFontsDependsOnTargets>

So the `ProcessMauiFonts` MSBuild target both depends on and runs after `ResizetizeCollectItems`?

Reviewing the *original* code:

https://github.com/Redth/ResizetizerNT/blob/319fc3f085021dea4e836c0072adc754b0436d66/Resizetizer.NT/Resizetizer.NT.targets

It appears to have always been this way, so perhaps `$(ProcessMauiFontsAfterTargets)` was unintentional?

So, I think we should just remove this from the Android targets, and see if anything breaks?

With this change in place, I am not getting design-time build failures for new .NET MAUI projects anymore. I also don't see resizetizer generating any files.
