### PR TITLE
Revoke #19349. Fixes #20684

### DIFF
--- a/src/Core/AndroidNative/maui/src/main/java/com/microsoft/maui/PlatformInterop.java
+++ b/src/Core/AndroidNative/maui/src/main/java/com/microsoft/maui/PlatformInterop.java
@@ -64,33 +64,10 @@ import java.util.List;
 
 public class PlatformInterop {
      public static void requestLayoutIfNeeded(View view) {
-        
-        // If the view isn't currently in the layout process, then we simply request
-        // that layout happen next time around
         if (!view.isInLayout())	{
             view.requestLayout();
 			return;
 		}
-		
-        /* 
-            Something is requesting layout while the view is already in the middle of a layout pass. This is most 
-            likely because a layout-affecting property has been data bound to another layout-affecting property, e.g. 
-            binding the width of a child control to the ActualWidth of its parent.
-            
-            If we simply call `requestLayout()` again right now, it will set a flag which will be cleared at the end 
-            of the current layout pass, and the view will not be laid out with the updated values.
-
-            Instead, we post the layout request to the UI thread's queue, ensuring that it will happen after the current
-            layout pass has finished. Layout will happen again with the updated values.
-        */
-
-		Runnable runnable = () -> { 
-			if (!view.isInLayout())	{
-				view.requestLayout();
-			}
-		};
-		
-		view.post(runnable);
     }
 
     public static void removeFromParent(View view) {


### PR DESCRIPTION
This change comes from #19349, which simply and crudely piles up a large number of threads before loading the interface,Causing a significant decrease in performance. I don't have a better way, so I have to delete it


### Description of Change

Revoke src\Core\AndroidNative\maui\src\main\java\com\microsoft\maui\PlatformInterop.java changed in #19349

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #20684

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
