### PR TITLE
Fix navigation stuck on iOS when pushing on hidden tab section in TabBar

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellSectionRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellSectionRenderer.cs
@@ -621,15 +621,21 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			var renderer = (IPlatformViewHandler)page.ToHandler(_shellSection.FindMauiContext());
 
 			var tracker = _context.CreatePageRendererTracker();
-			tracker.ViewController = renderer.ViewController;
+			var pageViewController = renderer.ViewController!;
+			tracker.ViewController = pageViewController;
 			tracker.Page = page;
 
 			_trackers[page] = tracker;
 
-			if (completionSource != null)
-				_completionTasks[renderer.ViewController] = completionSource;
+			var parentTabBar = ParentViewController as UITabBarController;
+			var showsPresentation = parentTabBar == null || ReferenceEquals(parentTabBar.SelectedViewController, this);
+			if (completionSource != null && showsPresentation)
+				_completionTasks[pageViewController] = completionSource;
 
-			PushViewController(renderer.ViewController, animated);
+			PushViewController(pageViewController, animated);
+			
+			if (completionSource != null && !showsPresentation)
+				completionSource.TrySetResult(true);
 		}
 
 		async void SendPoppedOnCompletion(Task popTask)

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue22570.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue22570.xaml
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Shell xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+       xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+       x:Class="Maui.Controls.Sample.Issues.Issue22570">
+  <TabBar Route="main"
+          Title="Tabs">
+    <ShellContent
+      Title="Home"
+      Route="Home">
+      <ContentPage>
+        <VerticalStackLayout>
+          <Button Text="Navigate to a subpage"
+                  AutomationId="button"
+                  Clicked="Button_Clicked"/>
+        </VerticalStackLayout>
+      </ContentPage>
+    </ShellContent>
+    <ShellContent Title="Foo" Route="Foo">
+      <ContentPage/>
+    </ShellContent>
+  </TabBar>
+</Shell>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue22570.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue22570.xaml.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+
+namespace Maui.Controls.Sample.Issues
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	[Issue(IssueTracker.Github, 22570, "[iOS] Cross TabBar navigation broken", PlatformAffected.iOS)]
+	public partial class Issue22570 : Shell
+	{
+		public Issue22570()
+		{
+			InitializeComponent();
+			Routing.RegisterRoute("Bar22570", typeof(Issue22570Page));
+		}
+
+		void Button_Clicked(object sender, System.EventArgs e)
+		{
+			_ = GoToAsync("//main/Foo/Bar22570");
+		}
+
+		public class Issue22570Page : ContentPage
+		{
+			public Issue22570Page()
+			{
+				Content = new VerticalStackLayout()
+				{
+					new Label()
+					{
+						Text = "Hello, World!",
+						AutomationId = "label"
+					}
+				};
+			}
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue22570.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue22570.cs
@@ -1,0 +1,24 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue22570 : _IssuesUITest
+	{
+		public Issue22570(TestDevice device)
+			: base(device)
+		{ }
+
+		public override string Issue => "[iOS] Cross TabBar navigation broken";
+
+		[Test]
+		[Category(UITestCategories.Shell)]
+		public void Issue22570Test()
+		{
+			App.WaitForElement("button");
+			App.Click("button");
+			App.WaitForElement("label");
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change

On iOS, the view controller `DidShowViewController` will not be triggered until the `Tab` inside `TabBar` becomes visible.
The code is waiting on that before switching to the new `Tab`, this causes a race condition.
So in this specific case, we have to complete the task immediately instead of waiting for `DidShowViewController`.

### Issues Fixed

Contributes to #16568 by fixing the scenario when the number of tabs is <= 5 (a.k.a. no "More" tab).
See my comment below regarding "More" tab.
