### PR TITLE
Fix TapGestureRecognizer disregards parent's IsEnabled status

### DIFF
--- a/src/Core/src/Platform/iOS/ViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/ViewExtensions.cs
@@ -16,6 +16,15 @@ namespace Microsoft.Maui.Platform
 
 		public static void UpdateIsEnabled(this UIView platformView, IView view)
 		{
+			if (platformView is UIResponder &&
+				platformView.GestureRecognizers != null)
+			{
+				foreach (var gesture in platformView.GestureRecognizers)
+				{
+					gesture.Enabled = view.IsEnabled;
+				}
+			}
+
 			if (platformView is not UIControl uiControl)
 				return;
 


### PR DESCRIPTION
### Description of Change

When calling the IsEnabled property, the container parent is checked because it is not equal to what is in other controls. 
For example. The parent of the Grid is the UIResponder, and the parent of the Button is the UIControl. 
Previously, for this reason, the IsEnabled property was not changed for any container.

### Issues Fixed

TapGestureRecognizer disregards parent's IsEnabled status on iOS and Catalyst. 

Fixed for: layouts except frame on iOS and Catalyst.

Fixes #

#18995 

Branch: main