### PR TITLE
Support changing Window coordinates while changing those coordinates

### DIFF
--- a/src/Controls/src/Core/Window/Window.cs
+++ b/src/Controls/src/Core/Window/Window.cs
@@ -204,15 +204,18 @@ namespace Microsoft.Maui.Controls
 		void IWindow.FrameChanged(Rect frame)
 		{
 			if (new Rect(X, Y, Width, Height) == frame)
+			{
 				return;
+			}
 
 			_batchFrameUpdate++;
-			bool shouldTriggerSizeChanged = (Width != frame.Width) || (Height != frame.Height);
 
-			X = frame.X;
-			Y = frame.Y;
-			Width = frame.Width;
-			Height = frame.Height;
+			var shouldTriggerSizeChanged = (Width != frame.Width) || (Height != frame.Height);
+
+			SetValue(XProperty, frame.X, SetterSpecificity.FromHandler);
+			SetValue(YProperty, frame.Y, SetterSpecificity.FromHandler);
+			SetValue(WidthProperty, frame.Width, SetterSpecificity.FromHandler);
+			SetValue(HeightProperty, frame.Height, SetterSpecificity.FromHandler);
 
 			_batchFrameUpdate--;
 			if (_batchFrameUpdate < 0)
@@ -221,25 +224,6 @@ namespace Microsoft.Maui.Controls
 			if (_batchFrameUpdate == 0 && shouldTriggerSizeChanged)
 			{
 				SizeChanged?.Invoke(this, EventArgs.Empty);
-			}
-
-
-			// If for some reason during the PropertyChanged event on X,Y,Width,Height
-			// the user has changed these values. Then we need to propagate them back to the handler
-			UpdateHandler(X != frame.X, nameof(X));
-			UpdateHandler(Y != frame.Y, nameof(Y));
-			UpdateHandler(Width != frame.Width, nameof(Width));
-			UpdateHandler(Height != frame.Height, nameof(Height));
-
-
-			void UpdateHandler(bool condition, string property)
-			{
-				if (Handler is null || !condition)
-				{
-					return;
-				}
-
-				Handler.UpdateValue(property);
 			}
 		}
 
@@ -252,7 +236,6 @@ namespace Microsoft.Maui.Controls
 
 			base.UpdateHandlerValue(property);
 		}
-
 
 		public event EventHandler<ModalPoppedEventArgs>? ModalPopped;
 		public event EventHandler<ModalPoppingEventArgs>? ModalPopping;

--- a/src/Core/tests/DeviceTests/Core.DeviceTests.csproj
+++ b/src/Core/tests/DeviceTests/Core.DeviceTests.csproj
@@ -13,6 +13,10 @@
     <ExcludeMicrosoftNetTestSdk>true</ExcludeMicrosoftNetTestSdk>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(CI)' == 'true' or '$(TF_BUILD)' == 'true' ">
+    <DefineConstants>$(DefineConstants);CI</DefineConstants>
+  </PropertyGroup>
+
   <PropertyGroup>
     <ApplicationTitle>Core Tests</ApplicationTitle>
     <ApplicationId>com.microsoft.maui.core.devicetests</ApplicationId>

--- a/src/Core/tests/DeviceTests/Handlers/Window/WindowHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Window/WindowHandlerTests.cs
@@ -34,7 +34,11 @@ namespace Microsoft.Maui.DeviceTests
 
 #if MACCATALYST || WINDOWS
 
-		[Fact]
+		[Fact(
+#if CI && MACCATALYST
+			Skip = "Causes Catalyst test run to hang"
+#endif
+		)]
 		public async Task InitialPositionsAreTakenIntoAccount()
 		{
 			var window = new Window(new NavigationPage(new ContentPage()))
@@ -63,7 +67,11 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
-		[Fact]
+		[Fact(
+#if CI && MACCATALYST
+			Skip = "Causes Catalyst test run to hang"
+#endif
+		)]
 		public async Task UpdatedPositionsAreTakenIntoAccount()
 		{
 			var window = new Window(new NavigationPage(new ContentPage()));
@@ -92,7 +100,11 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
-		[Fact]
+		[Fact(
+#if CI && MACCATALYST
+			Skip = "Causes Catalyst test run to hang"
+#endif
+		)]
 		public async Task ChangingTitleWhileChangingTitle()
 		{
 			var window = new Window(new NavigationPage(new ContentPage()))
@@ -116,7 +128,11 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
-		[Fact]
+		[Fact(
+#if CI && MACCATALYST
+			Skip = "Causes Catalyst test run to hang"
+#endif
+		)]
 		public async Task ChangingSizeWhileChangingSize()
 		{
 			var window = new Window(new NavigationPage(new ContentPage()))
@@ -156,7 +172,11 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
-		[Fact]
+		[Fact(
+#if CI && MACCATALYST
+			Skip = "Causes Catalyst test run to hang"
+#endif
+		)]
 		public async Task WindowSupportsEmptyPage()
 		{
 			var window = new Window(new ContentPage());
@@ -167,7 +187,11 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
-		[Theory]
+		[Theory(
+#if CI && MACCATALYST
+			Skip = "Causes Catalyst test run to hang"
+#endif
+		)]
 		[InlineData(150, 300)]
 		[InlineData(200, 300)]
 		[InlineData(500, 500)]
@@ -195,7 +219,11 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
-		[Theory]
+		[Theory(
+#if CI && MACCATALYST
+			Skip = "Causes Catalyst test run to hang"
+#endif
+		)]
 		[InlineData(150, 300)]
 		[InlineData(200, 300)]
 		[InlineData(500, 500)]
@@ -223,7 +251,11 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
-		[Theory]
+		[Theory(
+#if CI && MACCATALYST
+			Skip = "Causes Catalyst test run to hang"
+#endif
+		)]
 		[InlineData(150, 150)]
 		[InlineData(200, 200)]
 		[InlineData(500, 300)]
@@ -251,7 +283,11 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
-		[Theory]
+		[Theory(
+#if CI && MACCATALYST
+			Skip = "Causes Catalyst test run to hang"
+#endif
+		)]
 		[InlineData(150, 150)]
 		[InlineData(200, 200)]
 		[InlineData(500, 300)]

--- a/src/Core/tests/DeviceTests/Handlers/Window/WindowHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Window/WindowHandlerTests.cs
@@ -34,12 +34,7 @@ namespace Microsoft.Maui.DeviceTests
 
 #if MACCATALYST || WINDOWS
 
-		[Fact(
-#if MACCATALYST
-			Skip = "Setting Location on MacCatalyst is currently not supported"
-#endif
-			)]
-
+		[Fact]
 		public async Task InitialPositionsAreTakenIntoAccount()
 		{
 			var window = new Window(new NavigationPage(new ContentPage()))
@@ -50,22 +45,118 @@ namespace Microsoft.Maui.DeviceTests
 				Y = 500
 			};
 
-			await RunWindowTest(window, async handler =>
+			await RunWindowTest(window, handler =>
 			{
-				// Just let things settle for good measure
-				await Task.Delay(100);
+#if MACCATALYST
+				// these are updated by the OS
+				Assert.True(window.Width > 0, $"Expected Width to be >= 0, but was {window.Width}");
+				Assert.True(window.Height > 0, $"Expected Height to be >= 0, but was {window.Height}");
+				// these are not available from the OS...
+				Assert.True(window.X == 0, $"Expected X to be == 0, but was {window.X}");
+				Assert.True(window.Y == 0, $"Expected Y to be == 0, but was {window.Y}");
+#elif WINDOWS
 				Assert.Equal(200, window.Width);
 				Assert.Equal(500, window.Height);
 				Assert.Equal(0, window.X);
 				Assert.Equal(500, window.Y);
+#endif
 			});
 		}
 
-		[Fact(
+		[Fact]
+		public async Task UpdatedPositionsAreTakenIntoAccount()
+		{
+			var window = new Window(new NavigationPage(new ContentPage()));
+
+			await RunWindowTest(window, async handler =>
+			{
+				var currentFrame = new Rect(window.X, window.Y, window.Width, window.Height);
+
+				window.Width = 200;
+				window.Height = 500;
+				window.X = 0;
+				window.Y = 0;
+
+				// Just let things settle as some platforms require a few UI cycles to update bounds
+				await Task.Delay(100);
+
 #if MACCATALYST
-		Skip = "Causes Catalyst test run to hang"
+				// Mac Catalyst does not support this operation, so it should never change
+				Assert.Equal(currentFrame, new Rect(window.X, window.Y, window.Width, window.Height));
+#elif WINDOWS
+				Assert.Equal(200, window.Width);
+				Assert.Equal(500, window.Height);
+				Assert.Equal(0, window.X);
+				Assert.Equal(0, window.Y);
 #endif
-		)]
+			});
+		}
+
+		[Fact]
+		public async Task ChangingTitleWhileChangingTitle()
+		{
+			var window = new Window(new NavigationPage(new ContentPage()))
+			{
+				Title = "Initial"
+			};
+
+			window.PropertyChanged += (s, e) =>
+			{
+				if (e.PropertyName == nameof(Window.Title) && window.Title == "Changed")
+				{
+					window.Title = "Final";
+				}
+			};
+
+			await RunWindowTest(window, handler =>
+			{
+				window.Title = "Changed";
+
+				Assert.Equal("Final", window.Title);
+			});
+		}
+
+		[Fact]
+		public async Task ChangingSizeWhileChangingSize()
+		{
+			var window = new Window(new NavigationPage(new ContentPage()))
+			{
+				Width = 300,
+				Height = 500,
+				X = 0,
+				Y = 500
+			};
+
+			window.PropertyChanged += (s, e) =>
+			{
+				if (e.PropertyName == nameof(Window.Width) && window.Width == 400)
+				{
+					window.Width = 250;
+				}
+			};
+
+			await RunWindowTest(window, async handler =>
+			{
+				var currentFrame = new Rect(window.X, window.Y, window.Width, window.Height);
+
+				window.Width = 400;
+
+				// Just let things settle as some platforms require a few UI cycles to update bounds
+				await Task.Delay(100);
+
+#if MACCATALYST
+				// Mac Catalyst does not support this operation, so it should never change
+				Assert.Equal(currentFrame, new Rect(window.X, window.Y, window.Width, window.Height));
+#elif WINDOWS
+				Assert.Equal(250, window.Width);
+				Assert.Equal(500, window.Height);
+				Assert.Equal(0, window.X);
+				Assert.Equal(500, window.Y);
+#endif
+			});
+		}
+
+		[Fact]
 		public async Task WindowSupportsEmptyPage()
 		{
 			var window = new Window(new ContentPage());
@@ -76,11 +167,7 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
-		[Theory(
-#if MACCATALYST
-		Skip = "Causes Catalyst test run to hang"
-#endif
-		)]
+		[Theory]
 		[InlineData(150, 300)]
 		[InlineData(200, 300)]
 		[InlineData(500, 500)]
@@ -101,17 +188,14 @@ namespace Microsoft.Maui.DeviceTests
 
 				window.MinimumWidth = min;
 
-				await Task.Delay(100); // mac catalyst seems to have delays
+				// Just let things settle as some platforms require a few UI cycles to update bounds
+				await Task.Delay(100);
 
 				Assert.Equal(expected, window.Width);
 			});
 		}
 
-		[Theory(
-#if MACCATALYST
-		Skip = "Causes Catalyst test run to hang"
-#endif
-		)]
+		[Theory]
 		[InlineData(150, 300)]
 		[InlineData(200, 300)]
 		[InlineData(500, 500)]
@@ -132,17 +216,14 @@ namespace Microsoft.Maui.DeviceTests
 
 				window.MinimumHeight = min;
 
-				await Task.Delay(100); // mac catalyst seems to have delays
+				// Just let things settle as some platforms require a few UI cycles to update bounds
+				await Task.Delay(100);
 
 				Assert.Equal(expected, window.Height);
 			});
 		}
 
-		[Theory(
-#if MACCATALYST
-		Skip = "Causes Catalyst test run to hang"
-#endif
-		)]
+		[Theory]
 		[InlineData(150, 150)]
 		[InlineData(200, 200)]
 		[InlineData(500, 300)]
@@ -163,17 +244,14 @@ namespace Microsoft.Maui.DeviceTests
 
 				window.MaximumWidth = max;
 
-				await Task.Delay(100); // mac catalyst seems to have delays
+				// Just let things settle as some platforms require a few UI cycles to update bounds
+				await Task.Delay(100);
 
 				Assert.Equal(expected, window.Width);
 			});
 		}
 
-		[Theory(
-#if MACCATALYST
-		Skip = "Causes Catalyst test run to hang"
-#endif
-		)]
+		[Theory]
 		[InlineData(150, 150)]
 		[InlineData(200, 200)]
 		[InlineData(500, 300)]
@@ -194,7 +272,8 @@ namespace Microsoft.Maui.DeviceTests
 
 				window.MaximumHeight = max;
 
-				await Task.Delay(100); // mac catalyst seems to have delays
+				// Just let things settle as some platforms require a few UI cycles to update bounds
+				await Task.Delay(100);
 
 				Assert.Equal(expected, window.Height);
 			});
@@ -232,6 +311,10 @@ namespace Microsoft.Maui.DeviceTests
 				// If we don't wait for the content to load then the CloseWindow call crashes
 				await ((IPlatformViewHandler)window.Page.Handler).PlatformView.OnLoadedAsync();
 #endif
+
+				// Just let things settle as some platforms require a few UI cycles to update bounds
+				await Task.Delay(100);
+
 				try
 				{
 					await action(windowHandler);

--- a/src/Core/tests/DeviceTests/Handlers/Window/WindowHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Window/WindowHandlerTests.iOS.cs
@@ -11,11 +11,7 @@ namespace Microsoft.Maui.DeviceTests
 	{
 #if MACCATALYST
 
-		[Fact(
-#if MACCATALYST
-		Skip = "Causes Catalyst test run to hang"
-#endif
-		)]
+		[Fact]
 		public async Task TitleSetsOnWindow()
 		{
 			var window = new Window
@@ -35,12 +31,7 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
-
-		[Fact(
-#if MACCATALYST
-		Skip = "Causes Catalyst test run to hang"
-#endif
-		)]
+		[Fact]
 		public async Task ContentIsSetInitially()
 		{
 			var window = new Window
@@ -60,17 +51,13 @@ namespace Microsoft.Maui.DeviceTests
 
 				Assert.NotNull(page.View);
 				var content = Assert.IsType<Platform.ContentView>(root.View.Subviews[0]);
-				var btn = Assert.IsType<UIButton>(content.Subviews[0]);
+				var btn = Assert.IsType<UIButton>(content.Subviews[0].Subviews[0]);
 
 				Assert.Equal("Yay!", btn.Title(UIControlState.Normal));
 			});
 		}
 
-		[Fact(
-#if MACCATALYST
-		Skip = "Causes Catalyst test run to hang"
-#endif
-		)]
+		[Fact]
 		public async Task WindowSupportsEmptyPage_Platform()
 		{
 			var window = new Window(new ContentPage());

--- a/src/Core/tests/DeviceTests/Handlers/Window/WindowHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Window/WindowHandlerTests.iOS.cs
@@ -11,7 +11,11 @@ namespace Microsoft.Maui.DeviceTests
 	{
 #if MACCATALYST
 
-		[Fact]
+		[Fact(
+#if CI
+			Skip = "Causes Catalyst test run to hang"
+#endif
+		)]
 		public async Task TitleSetsOnWindow()
 		{
 			var window = new Window
@@ -31,7 +35,11 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
-		[Fact]
+		[Fact(
+#if CI
+			Skip = "Causes Catalyst test run to hang"
+#endif
+		)]
 		public async Task ContentIsSetInitially()
 		{
 			var window = new Window
@@ -57,7 +65,11 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
-		[Fact]
+		[Fact(
+#if CI
+			Skip = "Causes Catalyst test run to hang"
+#endif
+		)]
 		public async Task WindowSupportsEmptyPage_Platform()
 		{
 			var window = new Window(new ContentPage());


### PR DESCRIPTION
### Description of Change

Currently only Windows supports setting window coordinates, the rest always reset the values to the OS numbers. This is causing a stack overflow.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #21306

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
