### PR TITLE
Run UI tests per groups of categories in CI

### DIFF
--- a/eng/devices/android.cake
+++ b/eng/devices/android.cake
@@ -18,9 +18,6 @@ var testAppInstrumentation = Argument("instrumentation", EnvironmentVariable("AN
 var testResultsPath = Argument("results", EnvironmentVariable("ANDROID_TEST_RESULTS") ?? GetTestResultsDirectory()?.FullPath);
 var deviceCleanupEnabled = Argument("cleanup", true);
 
-// Test where clause
-string testWhere = Argument("where", EnvironmentVariable("NUNIT_TEST_WHERE") ?? "");
-
 // Device details
 var deviceSkin = Argument("skin", EnvironmentVariable("ANDROID_TEST_SKIN") ?? "Nexus 5X");
 var androidAvd = "DEVICE_TESTS_EMULATOR";
@@ -96,7 +93,6 @@ Task("uitest-build")
 
 	});
 Task("uitest")
-	.IsDependentOn("uitest-build")
 	.Does(() =>
 	{
 		ExecuteUITests(projectPath, testAppProjectPath, testAppPackageName, testDevice, testResultsPath, binlogDirectory, configuration, targetFramework, "", androidVersion, dotnetToolPath, testAppInstrumentation);
@@ -305,7 +301,12 @@ void ExecuteUITests(string project, string app, string appPackageName, string de
 	var name = System.IO.Path.GetFileNameWithoutExtension(project);
 	var binlog = $"{binDir}/{name}-{config}-{platform}.binlog";
 	var appiumLog = $"{binDir}/appium_{platform}.log";
-	var resultsFileName = $"{name}-{config}-{platform}";
+	var resultsFileName = $"{name}-{config}-{platform}-{testFilter.Replace("|", "_").Replace("TestCategory=", "")}";
+
+	if (resultsFileName.Contains("!~'.+'"))
+	{
+		resultsFileName = $"{name}-{config}-{platform}-notcategorized";
+	}
 
 	DotNetBuild(project, new DotNetBuildSettings
 	{

--- a/eng/devices/android.cake
+++ b/eng/devices/android.cake
@@ -301,12 +301,7 @@ void ExecuteUITests(string project, string app, string appPackageName, string de
 	var name = System.IO.Path.GetFileNameWithoutExtension(project);
 	var binlog = $"{binDir}/{name}-{config}-{platform}.binlog";
 	var appiumLog = $"{binDir}/appium_{platform}.log";
-	var resultsFileName = $"{name}-{config}-{platform}-{testFilter.Replace("|", "_").Replace("TestCategory=", "")}";
-
-	if (resultsFileName.Contains("!~'.+'"))
-	{
-		resultsFileName = $"{name}-{config}-{platform}-notcategorized";
-	}
+	var resultsFileName = SanitizeTestResultsFilename($"{name}-{config}-{platform}-{testFilter}");
 
 	DotNetBuild(project, new DotNetBuildSettings
 	{

--- a/eng/devices/catalyst.cake
+++ b/eng/devices/catalyst.cake
@@ -143,12 +143,7 @@ void ExecuteUITests(string project, string app, string device, string resultsDir
 	var name = System.IO.Path.GetFileNameWithoutExtension(project);
 	var binlog = $"{binDir}/{name}-{config}-mac.binlog";
 	var appiumLog = $"{binDir}/appium_mac.log";
-	var resultsFileName = $"{name}-{config}-catalyst-{testFilter.Replace("|", "_").Replace("TestCategory=", "")}";
-
-	if (resultsFileName.Contains("!~'.+'"))
-	{
-		resultsFileName = $"{name}-{config}-catalyst-notcategorized";
-	}
+	var resultsFileName = SanitizeTestResultsFilename($"{name}-{config}-catalyst-{testFilter}");
 
 	DotNetBuild(project, new DotNetBuildSettings
 	{

--- a/eng/devices/devices-shared.cake
+++ b/eng/devices/devices-shared.cake
@@ -222,3 +222,10 @@ void ExecuteWithRetries(Func<int> action, int retries)
         System.Threading.Thread.Sleep(1000);
     }
 }
+
+string SanitizeTestResultsFilename(string input)
+{
+    string resultFilename = input.Replace("|", "_").Replace("TestCategory=", "");
+
+    return resultFilename;
+}

--- a/eng/devices/devices-shared.cake
+++ b/eng/devices/devices-shared.cake
@@ -45,7 +45,7 @@ IEnumerable<string> GetTestApplications(string project, string device, string co
     const string artifactsDir = "../../artifacts/bin/";
     bool isAndroid = tfm.Contains("android");
 
-    var binDir = new DirectoryPath(project).Combine($"{binDirBase}/{config}/{tfm}/{rid}");
+    var binDir = new DirectoryPath(project).Combine($"{config}/{tfm}/{rid}");
     IEnumerable<string> applications;
 
     if (isAndroid)

--- a/eng/devices/ios.cake
+++ b/eng/devices/ios.cake
@@ -208,12 +208,7 @@ void ExecuteUITests(string project, string app, string device, string resultsDir
 	var name = System.IO.Path.GetFileNameWithoutExtension(project);
 	var binlog = $"{binDir}/{name}-{config}-ios.binlog";
 	var appiumLog = $"{binDir}/appium_ios.log";
-	var resultsFileName = $"{name}-{config}-ios-{testFilter.Replace("|", "_").Replace("TestCategory=", "")}";
-
-	if (resultsFileName.Contains("!~'.+'"))
-	{
-		resultsFileName = $"{name}-{config}-ios-notcategorized";
-	}
+	var resultsFileName = SanitizeTestResultsFilename($"{name}-{config}-ios-{testFilter)}");
 
 	DotNetBuild(project, new DotNetBuildSettings
 	{

--- a/eng/devices/ios.cake
+++ b/eng/devices/ios.cake
@@ -208,7 +208,7 @@ void ExecuteUITests(string project, string app, string device, string resultsDir
 	var name = System.IO.Path.GetFileNameWithoutExtension(project);
 	var binlog = $"{binDir}/{name}-{config}-ios.binlog";
 	var appiumLog = $"{binDir}/appium_ios.log";
-	var resultsFileName = SanitizeTestResultsFilename($"{name}-{config}-ios-{testFilter)}");
+	var resultsFileName = SanitizeTestResultsFilename($"{name}-{config}-ios-{testFilter}");
 
 	DotNetBuild(project, new DotNetBuildSettings
 	{

--- a/eng/devices/ios.cake
+++ b/eng/devices/ios.cake
@@ -18,9 +18,6 @@ var platform = testDevice.ToLower().Contains("simulator") ? "iPhoneSimulator" : 
 var runtimeIdentifier = Argument("rid", EnvironmentVariable("IOS_RUNTIME_IDENTIFIER") ?? GetDefaultRuntimeIdentifier(testDevice));
 var deviceCleanupEnabled = Argument("cleanup", true);
 
-// Test where clause
-string testWhere = Argument("where", EnvironmentVariable("NUNIT_TEST_WHERE") ?? "");
-
 // Device details
 var udid = Argument("udid", EnvironmentVariable("IOS_SIMULATOR_UDID") ?? "");
 var iosVersion = Argument("apiversion", EnvironmentVariable("IOS_PLATFORM_VERSION") ?? DefaultVersion);
@@ -87,7 +84,6 @@ Task("uitest-build")
 	});
 
 Task("uitest")
-	.IsDependentOn("uitest-build")
 	.Does(() =>
 	{
 		ExecuteUITests(projectPath, testAppProjectPath, testDevice, testResultsPath, binlogDirectory, configuration, targetFramework, runtimeIdentifier, iosVersion, dotnetToolPath);
@@ -212,7 +208,12 @@ void ExecuteUITests(string project, string app, string device, string resultsDir
 	var name = System.IO.Path.GetFileNameWithoutExtension(project);
 	var binlog = $"{binDir}/{name}-{config}-ios.binlog";
 	var appiumLog = $"{binDir}/appium_ios.log";
-	var resultsFileName = $"{name}-{config}-ios";
+	var resultsFileName = $"{name}-{config}-ios-{testFilter.Replace("|", "_").Replace("TestCategory=", "")}";
+
+	if (resultsFileName.Contains("!~'.+'"))
+	{
+		resultsFileName = $"{name}-{config}-ios-notcategorized";
+	}
 
 	DotNetBuild(project, new DotNetBuildSettings
 	{

--- a/eng/devices/windows.cake
+++ b/eng/devices/windows.cake
@@ -216,12 +216,7 @@ Task("Test")
 
 	if (!string.IsNullOrWhiteSpace(testFilter))
 	{
-		testResultsFile += $"-{testFilter.Replace("|", "_").Replace("TestCategory=", "")}";
-	}
-
-	if (testResultsFile.Contains("!~'.+'"))
-	{
-		testResultsFile = $"\\TestResults-{PACKAGEID.Replace(".", "_")}-notcategorized";
+		testResultsFile += SanitizeTestResultsFilename($"-{testFilter}");
 	}
 
 	testResultsFile += ".xml";

--- a/eng/devices/windows.cake
+++ b/eng/devices/windows.cake
@@ -212,7 +212,20 @@ Task("Test")
 	Information("Cleaned directories");
 
 	var testResultsPath = MakeAbsolute((DirectoryPath)TEST_RESULTS).FullPath.Replace("/", "\\");
-	var testResultsFile = testResultsPath + $"\\TestResults-{PACKAGEID.Replace(".", "_")}.xml";
+	var testResultsFile = testResultsPath + $"\\TestResults-{PACKAGEID.Replace(".", "_")}";
+
+	if (!string.IsNullOrWhiteSpace(testFilter))
+	{
+		testResultsFile += $"-{testFilter.Replace("|", "_").Replace("TestCategory=", "")}";
+	}
+
+	if (testResultsFile.Contains("!~'.+'"))
+	{
+		testResultsFile = $"\\TestResults-{PACKAGEID.Replace(".", "_")}-notcategorized";
+	}
+
+	testResultsFile += ".xml";
+
 	var testsToRunFile = MakeAbsolute((DirectoryPath)TEST_RESULTS).FullPath.Replace("/", "\\") + $"\\devicetestcategories.txt";
 
 	Information($"Test Results File: {testResultsFile}");
@@ -432,7 +445,7 @@ Task("SetupTestPaths")
 		}
 
 		var winVersion = $"{dotnetVersion}-windows{windowsVersion}";
-		var binDir = TEST_APP_PROJECT.GetDirectory().Combine("bin").Combine(CONFIGURATION + "/" + winVersion).Combine(DOTNET_PLATFORM);
+		var binDir = TEST_APP_PROJECT.GetDirectory().Combine("Controls.TestCases.HostApp").Combine(CONFIGURATION + "/" + winVersion).Combine(DOTNET_PLATFORM);
 		Information("BinDir: {0}", binDir);
 		var apps = GetFiles(binDir + "/*.exe").Where(c => !c.FullPath.EndsWith("createdump.exe"));
 		if (apps.Count() == 0) 
@@ -464,7 +477,7 @@ Task("SetupTestPaths")
 				binDir = MakeAbsolute(new DirectoryPath(arcadeBin + "/Essentials.DeviceTests/" + CONFIGURATION + "/" + winVersion).Combine(DOTNET_PLATFORM));
 			}
 
-			Information("Looking for .app in arcade binDir {0}", binDir);
+			Information("Looking for .exe in arcade binDir {0}", binDir);
 			apps = GetFiles(binDir + "/*.exe").Where(c => !c.FullPath.EndsWith("createdump.exe"));
 			if(apps.Count() == 0 )
 			{

--- a/eng/pipelines/common/ui-tests-build-sample.yml
+++ b/eng/pipelines/common/ui-tests-build-sample.yml
@@ -1,0 +1,69 @@
+parameters:
+  platform: '' # [ android, ios, windows, catalyst ]
+  path: '' # path to csproj
+  device: '' # the xharness device to use
+  cakeArgs: '' # additional cake args
+  app: '' #path to app to test
+  version: '' #the iOS version'
+  provisionatorChannel: 'latest'
+  agentPoolAccessToken: ''
+  configuration : "Release"
+  testFilter: ''
+
+steps:
+  - ${{ if eq(parameters.platform, 'ios')}}:
+    - bash: |
+        chmod +x $(System.DefaultWorkingDirectory)/eng/scripts/clean-bot.sh
+        $(System.DefaultWorkingDirectory)/eng/scripts/clean-bot.sh
+      displayName: 'Clean bot'
+      continueOnError: true
+      timeoutInMinutes: 60
+
+  - template: provision.yml
+    parameters:
+      skipProvisioning:  ${{ eq(parameters.platform, 'windows') }}
+      skipAndroidSdks: ${{ ne(parameters.platform, 'android') }}
+      skipXcode: ${{ or(eq(parameters.platform, 'android'), eq(parameters.platform, 'windows')) }}
+      provisionatorChannel: ${{ parameters.provisionatorChannel }}
+      
+  - task: PowerShell@2
+    condition: ne('${{ parameters.platform }}' , 'windows')
+    inputs:
+      targetType: 'inline'
+      script: |
+        defaults write -g NSAutomaticCapitalizationEnabled -bool false
+        defaults write -g NSAutomaticTextCompletionEnabled -bool false
+        defaults write -g NSAutomaticSpellingCorrectionEnabled -bool false
+    displayName: "Modify defaults"
+    continueOnError: true
+
+  - pwsh: ./build.ps1 --target=dotnet --configuration="${{ parameters.configuration }}" --verbosity=diagnostic
+    displayName: 'Install .NET'
+    retryCountOnTaskFailure: 2
+    env:
+      DOTNET_TOKEN: $(dotnetbuilds-internal-container-read-token)
+      PRIVATE_BUILD: $(PrivateBuild)
+
+  - pwsh: echo "##vso[task.prependpath]$(DotNet.Dir)"
+    displayName: 'Add .NET to PATH'
+
+  - pwsh: ./build.ps1 --target=dotnet-buildtasks --configuration="${{ parameters.configuration }}"
+    displayName: 'Build the MSBuild Tasks'
+
+  - pwsh: ./build.ps1 --target=dotnet-samples --configuration="${{ parameters.configuration }}" --${{ parameters.platform }} --verbosity=diagnostic --usenuget=false
+    displayName: 'Build the samples'
+
+  - bash: |
+      if [ -f "$HOME/Library/Logs/CoreSimulator/*" ]; then rm -r $HOME/Library/Logs/CoreSimulator/*; fi
+      if [ -f "$HOME/Library/Logs/DiagnosticReports/*" ]; then rm -r $HOME/Library/Logs/DiagnosticReports/*; fi
+    displayName: Delete Old Simulator Logs
+    condition: ${{ eq(parameters.platform, 'ios') }}
+    continueOnError: true
+
+  - publish: $(System.DefaultWorkingDirectory)/artifacts/bin
+    condition: ne('${{ parameters.platform }}' , 'windows')
+    artifact: ui-tests-samples
+
+  - publish: $(System.DefaultWorkingDirectory)/artifacts/bin
+    condition: eq('${{ parameters.platform }}' , 'windows')
+    artifact: ui-tests-samples-windows

--- a/eng/pipelines/common/ui-tests-compatibility-steps.yml
+++ b/eng/pipelines/common/ui-tests-compatibility-steps.yml
@@ -8,9 +8,9 @@ parameters:
   provisionatorChannel: 'latest'
   agentPoolAccessToken: ''
   configuration : "Release"
-  where : "cat==Issues"
   targetSample: "dotnet-legacy-controlgallery"
   provisionPlatform: "windows"
+  testFilter: ''
 
 steps:
   - bash: |
@@ -56,7 +56,19 @@ steps:
     condition: ${{ eq(parameters.platform, 'ios') }}
     continueOnError: true
 
-  - pwsh: ./build.ps1 -Script eng/devices/${{ parameters.platform }}.cake --target=cg-uitest --project="${{ parameters.path }}" --appproject="${{ parameters.app }}" --device="${{ parameters.device }}" --apiversion="${{ parameters.version }}" --configuration="${{ parameters.configuration }}" --results="$(TestResultsDirectory)" --binlog="$(LogDirectory)" ${{ parameters.cakeArgs }} --verbosity=diagnostic --where="${{ parameters.where }}"
+  - pwsh: |
+      $command = "./build.ps1 -Script eng/devices/${{ parameters.platform }}.cake --target=cg-uitest --project=""${{ parameters.path }}"""
+      $command += " --appproject=""${{ parameters.app }}"" --device=""${{ parameters.device }}"" --apiversion=""${{ parameters.version }}"" --configuration=""${{ parameters.configuration }}"""
+      $command += " --results=""$(TestResultsDirectory)"" --binlog=""$(LogDirectory)"" ${{ parameters.cakeArgs }} --verbosity=diagnostic"
+      
+      $testFilter = "${{ parameters.testFilter }}"
+
+      # Cake does not allow empty parameters, so check if our filter is empty before adding it
+      if ($testFilter) {
+        $command += " --test-filter ""${{ parameters.testFilter }}"""
+      }
+
+      Invoke-Expression $command
     displayName: $(Agent.JobName)
     # retryCountOnTaskFailure: 2
 

--- a/eng/pipelines/common/ui-tests-compatibility-steps.yml
+++ b/eng/pipelines/common/ui-tests-compatibility-steps.yml
@@ -56,7 +56,7 @@ steps:
     condition: ${{ eq(parameters.platform, 'ios') }}
     continueOnError: true
 
-  - pwsh: ./build.ps1 -Script eng/devices/${{ parameters.platform }}.cake --target=cg-uitest --project="${{ parameters.path }}" --appproject="${{ parameters.app }}" --device="${{ parameters.device }}" --apiversion="${{ parameters.version }}" --configuration="${{ parameters.configuration }}" --results="$(TestResultsDirectory)" --binlog="$(LogDirectory)" ${{ parameters.cakeArgs }} --verbosity=diagnostic --where="${{ parameters.where }}"
+  - pwsh: ./build.ps1 -Script eng/devices/${{ parameters.platform }}.cake --target=cg-uitest --project="${{ parameters.path }}" --appproject="${{ parameters.app }}" --device="${{ parameters.device }}" --apiversion="${{ parameters.version }}" --configuration="${{ parameters.configuration }}" --results="$(TestResultsDirectory)" --binlog="$(LogDirectory)" ${{ parameters.cakeArgs }} --verbosity=diagnostic
     displayName: $(Agent.JobName)
     # retryCountOnTaskFailure: 2
 

--- a/eng/pipelines/common/ui-tests-compatibility-steps.yml
+++ b/eng/pipelines/common/ui-tests-compatibility-steps.yml
@@ -61,13 +61,17 @@ steps:
       $command += " --appproject=""${{ parameters.app }}"" --device=""${{ parameters.device }}"" --apiversion=""${{ parameters.version }}"" --configuration=""${{ parameters.configuration }}"""
       $command += " --results=""$(TestResultsDirectory)"" --binlog=""$(LogDirectory)"" ${{ parameters.cakeArgs }} --verbosity=diagnostic"
       
+      $testFilter = ""
+
       "${{ parameters.testFilter }}".Split(",") | ForEach {
         $testFilter += "TestCategory=" + $_ + "|"
       }
 
+      $testFilter = $testFilter.TrimEnd("|")
+
       # Cake does not allow empty parameters, so check if our filter is empty before adding it
       if ($testFilter) {
-        $command += " --test-filter ""${{ parameters.testFilter }}"""
+        $command += " --test-filter ""$testFilter"""
       }
 
       Invoke-Expression $command

--- a/eng/pipelines/common/ui-tests-compatibility-steps.yml
+++ b/eng/pipelines/common/ui-tests-compatibility-steps.yml
@@ -56,25 +56,7 @@ steps:
     condition: ${{ eq(parameters.platform, 'ios') }}
     continueOnError: true
 
-  - pwsh: |
-      $command = "./build.ps1 -Script eng/devices/${{ parameters.platform }}.cake --target=cg-uitest --project=""${{ parameters.path }}"""
-      $command += " --appproject=""${{ parameters.app }}"" --device=""${{ parameters.device }}"" --apiversion=""${{ parameters.version }}"" --configuration=""${{ parameters.configuration }}"""
-      $command += " --results=""$(TestResultsDirectory)"" --binlog=""$(LogDirectory)"" ${{ parameters.cakeArgs }} --verbosity=diagnostic"
-      
-      $testFilter = ""
-
-      "${{ parameters.testFilter }}".Split(",") | ForEach {
-        $testFilter += "TestCategory=" + $_ + "|"
-      }
-
-      $testFilter = $testFilter.TrimEnd("|")
-
-      # Cake does not allow empty parameters, so check if our filter is empty before adding it
-      if ($testFilter) {
-        $command += " --test-filter ""$testFilter"""
-      }
-
-      Invoke-Expression $command
+  - pwsh: ./build.ps1 -Script eng/devices/${{ parameters.platform }}.cake --target=cg-uitest --project="${{ parameters.path }}" --appproject="${{ parameters.app }}" --device="${{ parameters.device }}" --apiversion="${{ parameters.version }}" --configuration="${{ parameters.configuration }}" --results="$(TestResultsDirectory)" --binlog="$(LogDirectory)" ${{ parameters.cakeArgs }} --verbosity=diagnostic --where="${{ parameters.where }}"
     displayName: $(Agent.JobName)
     # retryCountOnTaskFailure: 2
 

--- a/eng/pipelines/common/ui-tests-compatibility-steps.yml
+++ b/eng/pipelines/common/ui-tests-compatibility-steps.yml
@@ -61,7 +61,9 @@ steps:
       $command += " --appproject=""${{ parameters.app }}"" --device=""${{ parameters.device }}"" --apiversion=""${{ parameters.version }}"" --configuration=""${{ parameters.configuration }}"""
       $command += " --results=""$(TestResultsDirectory)"" --binlog=""$(LogDirectory)"" ${{ parameters.cakeArgs }} --verbosity=diagnostic"
       
-      $testFilter = "${{ parameters.testFilter }}"
+      "${{ parameters.testFilter }}".Split(",") | ForEach {
+        $testFilter += "TestCategory=" + $_ + "|"
+      }
 
       # Cake does not allow empty parameters, so check if our filter is empty before adding it
       if ($testFilter) {

--- a/eng/pipelines/common/ui-tests-steps.yml
+++ b/eng/pipelines/common/ui-tests-steps.yml
@@ -62,18 +62,11 @@ steps:
       
       $testFilter = ""
 
-      if ("${{ parameters.testFilter }}" -eq "zzEmptyCategoryzz")
-      {
-        $testFilter = "TestCategory\!~'.+'"
+      "${{ parameters.testFilter }}".Split(",") | ForEach {
+        $testFilter += "TestCategory=" + $_ + "|"
       }
-      else
-      {
-        "${{ parameters.testFilter }}".Split(",") | ForEach {
-          $testFilter += "TestCategory=" + $_ + "|"
-        }
 
-        $testFilter = $testFilter.TrimEnd("|")
-      }
+      $testFilter = $testFilter.TrimEnd("|")
 
       # Cake does not allow empty parameters, so check if our filter is empty before adding it
       if ($testFilter) {

--- a/eng/pipelines/common/ui-tests-steps.yml
+++ b/eng/pipelines/common/ui-tests-steps.yml
@@ -8,33 +8,28 @@ parameters:
   provisionatorChannel: 'latest'
   agentPoolAccessToken: ''
   configuration : "Release"
+  testFilter: ''
 
 steps:
-  - ${{ if eq(parameters.platform, 'ios')}}:
-    - bash: |
-        chmod +x $(System.DefaultWorkingDirectory)/eng/scripts/clean-bot.sh
-        $(System.DefaultWorkingDirectory)/eng/scripts/clean-bot.sh
-      displayName: 'Clean bot'
-      continueOnError: true
-      timeoutInMinutes: 60
-
-  - template: provision.yml
-    parameters:
-      skipProvisioning:  ${{ eq(parameters.platform, 'windows') }}
-      skipAndroidSdks: ${{ ne(parameters.platform, 'android') }}
-      skipXcode: ${{ or(eq(parameters.platform, 'android'), eq(parameters.platform, 'windows')) }}
-      provisionatorChannel: ${{ parameters.provisionatorChannel }}
-
-  - task: PowerShell@2
+  - task: DownloadPipelineArtifact@2
     condition: ne('${{ parameters.platform }}' , 'windows')
     inputs:
-      targetType: 'inline'
-      script: |
-        defaults write -g NSAutomaticCapitalizationEnabled -bool false
-        defaults write -g NSAutomaticTextCompletionEnabled -bool false
-        defaults write -g NSAutomaticSpellingCorrectionEnabled -bool false
-    displayName: "Modify defaults"
-    continueOnError: true
+      artifact: ui-tests-samples
+
+  - task: DownloadPipelineArtifact@2
+    condition: eq('${{ parameters.platform }}' , 'windows')
+    inputs:
+      artifact: ui-tests-samples-windows
+  
+  - pwsh: ./build.ps1 --target=dotnet --configuration="${{ parameters.configuration }}" --verbosity=diagnostic
+    displayName: 'Install .NET'
+    retryCountOnTaskFailure: 2
+    env:
+      DOTNET_TOKEN: $(dotnetbuilds-internal-container-read-token)
+      PRIVATE_BUILD: $(PrivateBuild)
+
+  - pwsh: echo "##vso[task.prependpath]$(DotNet.Dir)"
+    displayName: 'Add .NET to PATH'
 
   # AzDO hosted agents default to 1024x768; set something bigger for Windows UI tests
   - task: ScreenResolutionUtility@1
@@ -60,30 +55,32 @@ steps:
     env:
       APPIUM_HOME: $(APPIUM_HOME)
 
-  - pwsh: ./build.ps1 --target=dotnet --configuration="${{ parameters.configuration }}" --verbosity=diagnostic
-    displayName: 'Install .NET'
-    retryCountOnTaskFailure: 2
-    env:
-      DOTNET_TOKEN: $(dotnetbuilds-internal-container-read-token)
-      PRIVATE_BUILD: $(PrivateBuild)
+  - pwsh: |
+      $command = "./build.ps1 -Script eng/devices/${{ parameters.platform }}.cake --target=uitest --project=""${{ parameters.path }}"""
+      $command += " --appproject=""${{ parameters.app }}"" --device=""${{ parameters.device }}"" --apiversion=""${{ parameters.version }}"" --configuration=""${{ parameters.configuration }}"""
+      $command += " --results=""$(TestResultsDirectory)"" --binlog=""$(LogDirectory)"" ${{ parameters.cakeArgs }} --verbosity=diagnostic"
+      
+      $testFilter = ""
 
-  - pwsh: echo "##vso[task.prependpath]$(DotNet.Dir)"
-    displayName: 'Add .NET to PATH'
+      if ("${{ parameters.testFilter }}" -eq "zzEmptyCategoryzz")
+      {
+        $testFilter = "TestCategory\!~'.+'"
+      }
+      else
+      {
+        "${{ parameters.testFilter }}".Split(",") | ForEach {
+          $testFilter += "TestCategory=" + $_ + "|"
+        }
 
-  - pwsh: ./build.ps1 --target=dotnet-buildtasks --configuration="${{ parameters.configuration }}"
-    displayName: 'Build the MSBuild Tasks'
+        $testFilter = $testFilter.TrimEnd("|")
+      }
 
-  - pwsh: ./build.ps1 --target=dotnet-samples --configuration="${{ parameters.configuration }}" --${{ parameters.platform }} --verbosity=diagnostic --usenuget=false
-    displayName: 'Build the samples'
+      # Cake does not allow empty parameters, so check if our filter is empty before adding it
+      if ($testFilter) {
+        $command += " --test-filter ""$testFilter"""
+      }
 
-  - bash: |
-      if [ -f "$HOME/Library/Logs/CoreSimulator/*" ]; then rm -r $HOME/Library/Logs/CoreSimulator/*; fi
-      if [ -f "$HOME/Library/Logs/DiagnosticReports/*" ]; then rm -r $HOME/Library/Logs/DiagnosticReports/*; fi
-    displayName: Delete Old Simulator Logs
-    condition: ${{ eq(parameters.platform, 'ios') }}
-    continueOnError: true
-
-  - pwsh: ./build.ps1 -Script eng/devices/${{ parameters.platform }}.cake --target=uitest --project="${{ parameters.path }}" --appproject="${{ parameters.app }}" --device="${{ parameters.device }}" --apiversion="${{ parameters.version }}" --configuration="${{ parameters.configuration }}" --results="$(TestResultsDirectory)" --binlog="$(LogDirectory)" ${{ parameters.cakeArgs }} --verbosity=diagnostic
+      Invoke-Expression $command
     displayName: $(Agent.JobName)
     ${{ if ne(parameters.platform, 'android')}}:
       retryCountOnTaskFailure: 1

--- a/eng/pipelines/common/ui-tests.yml
+++ b/eng/pipelines/common/ui-tests.yml
@@ -10,6 +10,24 @@ parameters:
   provisionatorChannel: 'latest'
   agentPoolAccessToken: ''
   runCompatibilityTests: false
+  categoryGroupsToTest:
+    # Make sure that this list is always up-to-date with src/Controls/tests/TestCases.Shared.Tests/UITestCategories.cs
+    # we might want to improve this somehow depending on how much the categories change over time
+    - 'Accessibility,ActionSheet,ActivityIndicator,Animation,AppLinks'
+    - 'Border,BoxView,Brush,Button'
+    - 'CarouselView,Cells,CheckBox,CollectionView,ContextActions,CustomRenderers'
+    - 'DatePicker,Dispatcher,DisplayAlert,DisplayPrompt,DragAndDrop'
+    - 'Editor,Effects,Entry,FlyoutPage,Focus,Frame,Gestures'
+    - 'Image,ImageButton,IndicatorView,InputTransparent,IsEnabled,IsVisible'
+    - 'Label,Layout,Lifecycle,ListView'
+    - 'ManualReview,Maps,Navigation'
+    - 'Page,Performance,Picker,ProgressBar'
+    - 'RadioButton,RefreshView'
+    - 'ScrollView,SearchBar,Shape,Shell,Slider,SoftInput,Stepper,Switch,SwipeView'
+    - 'TabbedPage,TableView,TimePicker,TitleView,ToolbarItem'
+    - 'ViewBaseTests,Visual,WebView,Window'
+    #- 'zzEmptyCategoryzz' # reserved keyword to make sure we run tests with no category specified
+
   projects:
     - name: name
       desc: Human Description
@@ -24,16 +42,48 @@ parameters:
       compatibilityiOSApp: /optional/path/to/app.csproj
 
 stages:
+  - stage: build_ui_tests
+    displayName: Build UITests Sample App
+    dependsOn: []
+    jobs:
+      - job: build_ui_tests
+        displayName: Build Sample App
+        pool: ${{ parameters.androidPool }}
+        variables:
+          REQUIRED_XCODE: $(DEVICETESTS_REQUIRED_XCODE)
+          APPIUM_HOME: $(System.DefaultWorkingDirectory)/.appium/
+        steps:
+          - template: ui-tests-build-sample.yml
+
+  - stage: build_ui_tests_windows
+    displayName: Build UITests Windows Sample App
+    dependsOn: []
+    jobs:
+      - job: build_ui_tests
+        displayName: Build Sample App (Windows)
+        pool: ${{ parameters.windowsPool }}
+        variables:
+          REQUIRED_XCODE: $(DEVICETESTS_REQUIRED_XCODE)
+          APPIUM_HOME: $(System.DefaultWorkingDirectory)/.appium/
+        steps:
+          - template: ui-tests-build-sample.yml
+            parameters:
+                platform: windows
 
   - stage: android_ui_tests
     displayName: Android UITests
-    dependsOn: []
+    dependsOn: build_ui_tests
     jobs:
       - ${{ each project in parameters.projects }}:
         - ${{ if ne(project.android, '') }}:
           - ${{ each api in parameters.androidApiLevels }}:
             - ${{ if not(containsValue(project.androidApiLevelsExclude, api)) }}:
               - job: android_ui_tests_${{ project.name }}_${{ api }}
+                strategy:
+                  matrix:
+                    ${{ each categoryGroup in parameters.categoryGroupsToTest }}:
+                      ${{ categoryGroup }}:
+                        CATEGORYGROUP: ${{ categoryGroup }}
                 timeoutInMinutes: 240 # how long to run the job before automatically cancelling
                 workspace:
                   clean: all
@@ -55,16 +105,22 @@ stages:
                         device: android-emulator-64_${{ api }}
                       provisionatorChannel: ${{ parameters.provisionatorChannel }}
                       agentPoolAccessToken: ${{ parameters.agentPoolAccessToken }}
+                      testFilter: $(CATEGORYGROUP)
 
   - stage: ios_ui_tests
     displayName: iOS UITests
-    dependsOn: []
+    dependsOn: build_ui_tests
     jobs:
       - ${{ each project in parameters.projects }}:
         - ${{ if ne(project.ios, '') }}:
           - ${{ each version in parameters.iosVersions }}:
             - ${{ if not(containsValue(project.iosVersionsExclude, version)) }}:
               - job: ios_ui_tests_${{ project.name }}_${{ replace(version, '.', '_') }}
+                strategy:
+                  matrix:
+                    ${{ each categoryGroup in parameters.categoryGroupsToTest }}:
+                      ${{ categoryGroup }}:
+                        CATEGORYGROUP: ${{ categoryGroup }}
                 timeoutInMinutes: 240 # how long to run the job before automatically cancelling
                 workspace:
                   clean: all
@@ -89,14 +145,20 @@ stages:
                         device: ios-simulator-64_${{ version }}
                       provisionatorChannel: ${{ parameters.provisionatorChannel }}
                       agentPoolAccessToken: ${{ parameters.agentPoolAccessToken }}
+                      testFilter: $(CATEGORYGROUP)
 
   - stage: winui_ui_tests
     displayName: WinUI UITests
-    dependsOn: []
+    dependsOn: build_ui_tests_windows
     jobs:
       - ${{ each project in parameters.projects }}:
         - ${{ if ne(project.winui, '') }}:
               - job: winui_ui_tests_${{ project.name }}
+                strategy:
+                  matrix:
+                    ${{ each categoryGroup in parameters.categoryGroupsToTest }}:
+                      ${{ categoryGroup }}:
+                        CATEGORYGROUP: ${{ categoryGroup }}
                 timeoutInMinutes: 240 # how long to run the job before automatically cancelling
                 workspace:
                   clean: all
@@ -114,14 +176,20 @@ stages:
                       app: ${{ project.app }}
                       provisionatorChannel: ${{ parameters.provisionatorChannel }}
                       agentPoolAccessToken: ${{ parameters.agentPoolAccessToken }}
+                      testFilter: $(CATEGORYGROUP)
 
   - stage: mac_ui_tests
     displayName: macOS UITests
-    dependsOn: []
+    dependsOn: build_ui_tests
     jobs:
       - ${{ each project in parameters.projects }}:
         - ${{ if ne(project.mac, '') }}:
               - job: mac_ui_tests_${{ project.name }}
+                strategy:
+                  matrix:
+                    ${{ each categoryGroup in parameters.categoryGroupsToTest }}:
+                      ${{ categoryGroup }}:
+                        CATEGORYGROUP: ${{ categoryGroup }}
                 timeoutInMinutes: 240 # how long to run the job before automatically cancelling
                 workspace:
                   clean: all
@@ -140,6 +208,7 @@ stages:
                       app: ${{ project.app }}
                       provisionatorChannel: ${{ parameters.provisionatorChannel }}
                       agentPoolAccessToken: ${{ parameters.agentPoolAccessToken }}
+                      testFilter: $(CATEGORYGROUP)
 
   - ${{ if eq(parameters.runCompatibilityTests, true) }}:  
     - stage: android_compatibility_ui_tests
@@ -151,6 +220,11 @@ stages:
             - ${{ each api in parameters.androidApiLevels }}:
               - ${{ if not(containsValue(project.androidApiLevelsExclude, api)) }}:
                 - job: android_compatibility_ui_tests_${{ project.name }}_${{ api }}
+                  strategy:
+                    matrix:
+                      ${{ each categoryGroup in parameters.categoryGroupsToTest }}:
+                        ${{ categoryGroup }}:
+                          CATEGORYGROUP: ${{ categoryGroup }}
                   timeoutInMinutes: 240
                   workspace:
                     clean: all
@@ -174,6 +248,7 @@ stages:
                           DEVICE: android-emulator-64_${{ api }}
                         provisionatorChannel: ${{ parameters.provisionatorChannel }}
                         agentPoolAccessToken: ${{ parameters.agentPoolAccessToken }}
+                        testFilter: $(CATEGORYGROUP)
 
     - stage: ios_compatibility_ui_tests
       displayName: iOS Compatibility UITests
@@ -184,6 +259,11 @@ stages:
             - ${{ each version in parameters.iosVersions }}:
               - ${{ if not(containsValue(project.iosVersionsExclude, version)) }}:
                 - job: ios_compatibility_ui_tests_${{ project.name }}_${{ replace(version, '.', '_') }}
+                  strategy:
+                    matrix:
+                      ${{ each categoryGroup in parameters.categoryGroupsToTest }}:
+                        ${{ categoryGroup }}:
+                          CATEGORYGROUP: ${{ categoryGroup }}
                   timeoutInMinutes: 240
                   workspace:
                     clean: all
@@ -210,3 +290,4 @@ stages:
                           device: ios-simulator-64_${{ version }}
                         provisionatorChannel: ${{ parameters.provisionatorChannel }}
                         agentPoolAccessToken: ${{ parameters.agentPoolAccessToken }}
+                        testFilter: $(CATEGORYGROUP)

--- a/eng/pipelines/common/ui-tests.yml
+++ b/eng/pipelines/common/ui-tests.yml
@@ -26,7 +26,6 @@ parameters:
     - 'ScrollView,SearchBar,Shape,Shell,Slider,SoftInput,Stepper,Switch,SwipeView'
     - 'TabbedPage,TableView,TimePicker,TitleView,ToolbarItem'
     - 'ViewBaseTests,Visual,WebView,Window'
-    #- 'zzEmptyCategoryzz' # reserved keyword to make sure we run tests with no category specified
 
   projects:
     - name: name

--- a/eng/pipelines/common/ui-tests.yml
+++ b/eng/pipelines/common/ui-tests.yml
@@ -219,11 +219,6 @@ stages:
             - ${{ each api in parameters.androidApiLevels }}:
               - ${{ if not(containsValue(project.androidApiLevelsExclude, api)) }}:
                 - job: android_compatibility_ui_tests_${{ project.name }}_${{ api }}
-                  strategy:
-                    matrix:
-                      ${{ each categoryGroup in parameters.categoryGroupsToTest }}:
-                        ${{ categoryGroup }}:
-                          CATEGORYGROUP: ${{ categoryGroup }}
                   timeoutInMinutes: 240
                   workspace:
                     clean: all
@@ -247,7 +242,6 @@ stages:
                           DEVICE: android-emulator-64_${{ api }}
                         provisionatorChannel: ${{ parameters.provisionatorChannel }}
                         agentPoolAccessToken: ${{ parameters.agentPoolAccessToken }}
-                        testFilter: $(CATEGORYGROUP)
 
     - stage: ios_compatibility_ui_tests
       displayName: iOS Compatibility UITests
@@ -258,11 +252,6 @@ stages:
             - ${{ each version in parameters.iosVersions }}:
               - ${{ if not(containsValue(project.iosVersionsExclude, version)) }}:
                 - job: ios_compatibility_ui_tests_${{ project.name }}_${{ replace(version, '.', '_') }}
-                  strategy:
-                    matrix:
-                      ${{ each categoryGroup in parameters.categoryGroupsToTest }}:
-                        ${{ categoryGroup }}:
-                          CATEGORYGROUP: ${{ categoryGroup }}
                   timeoutInMinutes: 240
                   workspace:
                     clean: all
@@ -289,4 +278,3 @@ stages:
                           device: ios-simulator-64_${{ version }}
                         provisionatorChannel: ${{ parameters.provisionatorChannel }}
                         agentPoolAccessToken: ${{ parameters.agentPoolAccessToken }}
-                        testFilter: $(CATEGORYGROUP)

--- a/eng/pipelines/ui-tests.yml
+++ b/eng/pipelines/ui-tests.yml
@@ -143,7 +143,7 @@ stages:
           desc: Controls
           androidApiLevelsExclude: [25] # Ignore for now API25 since the runs's are not stable
           android: $(System.DefaultWorkingDirectory)/src/Controls/tests/TestCases.Android.Tests/Controls.TestCases.Android.Tests.csproj
-          app: $(System.DefaultWorkingDirectory)/src/Controls/tests/TestCases.HostApp/Controls.TestCases.HostApp.csproj
+          app: $(Pipeline.Workspace)/Controls.TestCases.HostApp/
           iosVersionsExclude: [ '12.4'] # Ignore iOS 12.4 while we can't make it work on CI
           ios: $(System.DefaultWorkingDirectory)/src/Controls/tests/TestCases.iOS.Tests/Controls.TestCases.iOS.Tests.csproj
           winui: $(System.DefaultWorkingDirectory)/src/Controls/tests/TestCases.WinUI.Tests/Controls.TestCases.WinUI.Tests.csproj

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/ScrollViewUITests.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/ScrollViewUITests.cs
@@ -21,7 +21,6 @@ namespace Microsoft.Maui.TestCases.Tests
 		}
 
 		[Test]
-		[Category(UITestCategories.ScrollView)]
 		[Description("Scroll element to the start")]
 		public void ScrollToElement1Start()
 		{
@@ -43,7 +42,6 @@ namespace Microsoft.Maui.TestCases.Tests
 		}
 
 		[Test]
-		[Category(UITestCategories.ScrollView)]
 		[Description("Scroll element to the center")]
 		public void ScrollToElement2Center()
 		{
@@ -68,7 +66,6 @@ namespace Microsoft.Maui.TestCases.Tests
 		}
 
 		[Test]
-		[Category(UITestCategories.ScrollView)]
 		[Description("Scroll element to the end")]
 		public void ScrollToElement3End()
 		{
@@ -130,7 +127,6 @@ namespace Microsoft.Maui.TestCases.Tests
 		}
 #if ANDROID || IOS
 		[Test]
-		[Category(UITestCategories.ScrollView)]
 		[Description("Scroll down the ScrollView using a gesture")]
 		public void ScrollUpAndDownWithGestures()
 		{

--- a/src/Controls/tests/TestCases.Shared.Tests/UITestCategories.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/UITestCategories.cs
@@ -1,5 +1,7 @@
 namespace Microsoft.Maui.TestCases.Tests
 {
+	// Make sure that this list is always up-to-date with eng/pipelines/common/ui-tests.yml
+	// we might want to improve this somehow depending on how much the categories change over time
 	internal static class UITestCategories
 	{
 		public const string ViewBaseTests = "ViewBaseTests";


### PR DESCRIPTION
### Description of Change

This change runs the UI tests in our CI per groups of categories. Right now I have configured them to be all 5-ish categories for each group. This way we gain mostly two things:

1. By keeping the runs shorter, tests are less likely to fail
2. If something does fail, we can only retry that group which takes 10-15 minutes instead of 60-90 minutes or more

Additional advantage is that we can easier locate flaky tests in a category.

Disadvantage is that we need to keep the categories in code and YAML the same. Added a commend to both the cs file with the categories as well as the YAML to hopefully let us think of this. The analyzer from #23287 should make sure that no tests are added without a category.

### Issues Fixed

Fixes #21241

Related #23287 
