### PR TITLE
[CI] Bump xcode 15.4.0

### DIFF
--- a/eng/pipelines/common/device-tests-steps.yml
+++ b/eng/pipelines/common/device-tests-steps.yml
@@ -11,9 +11,10 @@ parameters:
   checkoutDirectory: $(System.DefaultWorkingDirectory)
   useArtifacts: false
   rebootAgent: true
+  poolName: 'Azure Pipelines'
 
 steps:
-  - ${{ if eq(parameters.platform, 'ios')}}:
+  - ${{ if and(eq(parameters.platform, 'ios'), ne(parameters.poolName, 'Azure Pipelines')) }}:
     - bash: |
         chmod +x $(System.DefaultWorkingDirectory)/eng/scripts/clean-bot.sh
         chmod +x $(System.DefaultWorkingDirectory)/eng/scripts/clean-simulator-runtime.sh
@@ -29,9 +30,8 @@ steps:
         platform: macos
       skipXcode: ${{ or(eq(parameters.platform, 'android'), eq(parameters.platform, 'windows')) }}
       skipProvisioning: ${{ eq(parameters.platform, 'windows') }}
-      ${{ if eq(parameters.platform, 'ios')}}:
-        skipAndroidSdks: false
-        skipAndroidImages: true
+      skipAndroidImages : ${{ eq(parameters.platform, 'ios') }}
+      skipAndroidSdks: ${{ eq(parameters.platform, 'ios') }}
       provisionatorChannel: ${{ parameters.provisionatorChannel }}
 
   - pwsh: ./build.ps1 --target=dotnet --configuration="Release" --verbosity=diagnostic
@@ -120,15 +120,6 @@ steps:
       condition: always()
       continueOnError: true
 
-
-  - ${{ if eq(parameters.platform, 'ios')}}:
-    - bash: |
-        zip -9r "$(LogDirectory)/CoreSimulatorLog.zip" "$HOME/Library/Logs/CoreSimulator/"
-        zip -9r "$(LogDirectory)/DiagnosticReports.zip" "$HOME/Library/Logs/DiagnosticReports/"
-      displayName: Zip Simulator Logs
-      condition: always()
-      continueOnError: true
-
   - task: PublishTestResults@2
     displayName: Publish the $(Agent.JobName) test results
     condition: always()
@@ -143,7 +134,7 @@ steps:
     inputs:
       artifactName: '$(Agent.JobName) (attempt $(System.JobAttempt))'
 
-  - ${{ if eq(parameters.rebootAgent, true) }}:
+  - ${{ if and(eq(parameters.platform, 'ios'), ne(parameters.poolName, 'Azure Pipelines')) }}:
     # This must always be placed as the last step in the job
     - template: agent-rebooter/mac.v1.yml@yaml-templates
       parameters:

--- a/eng/pipelines/common/device-tests.yml
+++ b/eng/pipelines/common/device-tests.yml
@@ -61,6 +61,7 @@ stages:
             artifactItemPattern: ${{ parameters.artifactItemPattern }}
             checkoutDirectory: ${{ parameters.checkoutDirectory }}
             useArtifacts: ${{ parameters.useArtifacts }}
+            poolName: ${{ parameters.androidPool.name }}
 
   - stage: ios_device_tests
     displayName: iOS Device Tests
@@ -102,6 +103,7 @@ stages:
             artifactItemPattern: ${{ parameters.artifactItemPattern }}
             checkoutDirectory: ${{ parameters.checkoutDirectory }}
             useArtifacts: ${{ parameters.useArtifacts }}
+            poolName: 'Azure Pipelines'
 
   - stage: catalyst_device_tests
     displayName: macOS Device Tests
@@ -141,6 +143,8 @@ stages:
             artifactItemPattern: ${{ parameters.artifactItemPattern }}
             checkoutDirectory: ${{ parameters.checkoutDirectory }}
             useArtifacts: ${{ parameters.useArtifacts }}
+            poolName: 'Azure Pipelines'
+
 
   - stage: windows_device_tests
     displayName: Windows Device Tests

--- a/eng/pipelines/common/maui-templates.yml
+++ b/eng/pipelines/common/maui-templates.yml
@@ -36,14 +36,14 @@ parameters:
     - name: $(androidTestsVmPool)
       vmImage: $(androidTestsVmImage)
       demands:
-        - macOS.Name -equals Ventura
+        - macOS.Name -equals Sonoma
         - macOS.Architecture -equals x64
       testName: RunOnAndroid
       artifact: templates-run-android
     - name: $(iosTestsVmPool)
       vmImage: $(iosTestsVmImage)
       demands:
-        - macOS.Name -equals Ventura
+        - macOS.Name -equals Sonoma
         - macOS.Architecture -equals x64
       testName: RunOniOS
       artifact: templates-run-ios
@@ -71,7 +71,7 @@ jobs:
     name: $(POOL_NAME)
     vmImage: $(POOL_VIMAGE)
     demands:
-      - macOS.Name -equals Ventura
+      - macOS.Name -equals Sonoma
       - macOS.Architecture -equals x64
   steps:
 

--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -15,14 +15,15 @@ parameters:
 
 steps:
   # Prepare macOS
-  - template: agent-cleanser/v1.yml@yaml-templates
-    parameters:
-      condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
-      UninstallMono: false
-      UninstallXamarinMac: false
-      CleanseAgentToolsDotNet: true           # Cleanse all .NET versions under the agent tools directory and use only those provisioned by the pipeline
-      SelfHealPowerShell: false
-      AUTH_TOKEN_GITHUB_COM: $(github--pat--vs-mobiletools-engineering-service2)
+  - ${{ if ne(parameters.poolName, 'Azure Pipelines') }}:
+    - template: agent-cleanser/v1.yml@yaml-templates
+      parameters:
+        condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
+        UninstallMono: false
+        UninstallXamarinMac: false
+        CleanseAgentToolsDotNet: true           # Cleanse all .NET versions under the agent tools directory and use only those provisioned by the pipeline
+        SelfHealPowerShell: false
+        AUTH_TOKEN_GITHUB_COM: $(github--pat--vs-mobiletools-engineering-service2)
   # Provision Xcode
   - ${{ if ne(parameters.skipXcode, 'true') }}:
     - task: xamops.azdevex.provisionator-task.provisionator@2
@@ -148,15 +149,3 @@ steps:
         arguments: -ConfigFile $(System.DefaultWorkingDirectory)/NuGet.config -Password $Env:Token
       env:
         Token: $(dn-bot-dnceng-artifact-feeds-rw) 
-  # Prepare for Reunion packages
-  # - ${{ if eq(variables['System.TeamProject'], 'devdiv') }}:
-  #   - task: NuGetAuthenticate@0
-  #     displayName: 'Authenticate Reunion NuGet sources'
-  #     inputs:
-  #       nuGetServiceConnections: Project.Reunion.nuget.internal
-  #   - pwsh: |
-  #       $path = '$(Build.SourcesDirectory)\NuGet.config'
-  #       [xml]$xml = Get-Content $path
-  #       $xml.configuration.RemoveChild($xml.configuration.disabledPackageSources)
-  #       $xml.Save($path)
-  #     displayName: 'Add "wasdk-internal" to NuGet.config'

--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -8,9 +8,9 @@ variables:
 - name: DOTNET_VERSION
   value: 8.0.300
 - name: REQUIRED_XCODE
-  value: 15.3.0
+  value: 15.4.0
 - name: DEVICETESTS_REQUIRED_XCODE
-  value: 15.3.0
+  value: 15.4.0
 - name: LocBranchPrefix
   value: 'loc-hb'
 - name: isMainBranch

--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -8,9 +8,9 @@ variables:
 - name: DOTNET_VERSION
   value: 8.0.300
 - name: REQUIRED_XCODE
-  value: 15.2.0
+  value: 15.3.0
 - name: DEVICETESTS_REQUIRED_XCODE
-  value: 15.2.0
+  value: 15.3.0
 - name: LocBranchPrefix
   value: 'loc-hb'
 - name: isMainBranch

--- a/eng/pipelines/device-tests.yml
+++ b/eng/pipelines/device-tests.yml
@@ -69,17 +69,14 @@ parameters:
   - name: iosPool
     type: object
     default:
-      name: $(iosTestsVmPool)
-      vmImage: $(iosTestsVmImage)
-      demands:
-        - macOS.Name -equals Ventura
-        - macOS.Architecture -equals x64
+      name: $(macosTestsVmPool)
+      vmImage: macOS-14
 
   - name: catalystPool
     type: object
     default:
       name: $(macosTestsVmPool)
-      vmImage: $(macosTestsVmImage)
+      vmImage: macOS-14
 
   - name: windowsPool
     type: object

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -101,14 +101,14 @@ parameters:
     - name: $(androidTestsVmPool)
       vmImage: $(androidTestsVmImage)
       demands:
-        - macOS.Name -equals Ventura
+        - macOS.Name -equals Sonoma
         - macOS.Architecture -equals x64
       testName: RunOnAndroid
       artifact: templates-run-android
     - name: $(iosTestsVmPool)
       vmImage: $(iosTestsVmImage)
       demands:
-        - macOS.Name -equals Ventura
+        - macOS.Name -equals Sonoma
         - macOS.Architecture -equals x64
       testName: RunOniOS
       artifact: templates-run-ios
@@ -155,7 +155,7 @@ stages:
               name: ${{ BuildPlatform.poolName }}
               vmImage: ${{ BuildPlatform.vmImage }}
               demands:
-                - macOS.Name -equals Ventura
+                - macOS.Name -equals Sonoma
                 - macOS.Architecture -equals x64
             steps:
               - template: common/provision.yml
@@ -197,7 +197,7 @@ stages:
             name: ${{ PackPlatform.poolName }}
             vmImage: ${{ PackPlatform.vmImage }}
             demands:
-              - macOS.Name -equals Ventura
+              - macOS.Name -equals Sonoma
               - macOS.Architecture -equals x64
           variables:
             - name: _buildScript
@@ -245,7 +245,7 @@ stages:
             name: ${{ BuildPlatform.poolName }}
             vmImage: ${{ BuildPlatform.vmImage }}
             demands:
-              - macOS.Name -equals Ventura
+              - macOS.Name -equals Sonoma
               - macOS.Architecture -equals x64
           steps:
             - template: common/provision.yml

--- a/eng/pipelines/ui-tests.yml
+++ b/eng/pipelines/ui-tests.yml
@@ -67,7 +67,7 @@ parameters:
       name: $(androidTestsVmPool)
       vmImage: $(androidTestsVmImage)
       demands:
-        - macOS.Name -equals Ventura
+        - macOS.Name -equals Sonoma
         - macOS.Architecture -equals x64
 
   - name: iosPool
@@ -76,7 +76,7 @@ parameters:
       name: $(iosTestsVmPool)
       vmImage: $(iosTestsVmImage)
       demands:
-        - macOS.Name -equals Ventura
+        - macOS.Name -equals Sonoma
         - macOS.Architecture -equals x64
   
   - name: windowsPool
@@ -89,7 +89,7 @@ parameters:
     type: object
     default:
       name: $(macosTestsVmPool)
-      vmImage: $(macosTestsVmImage)
+      vmImage: macOS-14
 
   - name: androidCompatibilityPool
     type: object
@@ -97,7 +97,7 @@ parameters:
       name: $(androidTestsVmPool)
       vmImage: $(androidTestsVmImage)
       demands:
-        - macOS.Name -equals Ventura
+        - macOS.Name -equals Sonoma
         - macOS.Architecture -equals x64
 
   - name: iosCompatibilityPool
@@ -106,7 +106,7 @@ parameters:
       name: $(androidTestsVmPool)
       vmImage: $(androidTestsVmImage)
       demands:
-        - macOS.Name -equals Ventura
+        - macOS.Name -equals Sonoma
         - macOS.Architecture -equals x64
 
 resources:


### PR DESCRIPTION
### Description of Change

Bumps to use Xcode 15.4.0 and Sonoma machines. 

Device tests  for iOS and Catalyst run on Azure Pipelines macOS-14 , these machines are recreated every time maybe making it more reliable in terms of clean infrastructure. 

This pull request primarily focuses on updating the configuration of the testing environments in the pipeline. The changes involve updating the macOS version from 'Ventura' to 'Sonoma' across several files and updating the required Xcode version from '15.2.0' to '15.4.0'. Additionally, the virtual machine image for iOS and macOS tests has been updated to 'macOS-14'. 

Key changes include:

Updates to macOS version:

* [`eng/pipelines/common/maui-templates.yml`](diffhunk://#diff-beb9b1c0fe7c80ce160eac3a028a267cd8bf6bef41239e0a4bf5829ae3ac25a7L39-R46): Updated the macOS version from 'Ventura' to 'Sonoma' in the parameters for the Android and iOS tests.
* [`eng/pipelines/device-tests.yml`](diffhunk://#diff-d2d1c388a0fb3196dbfcdab96421bc88336637a3d44480c96717f92d000facaeL66-R79): Updated the macOS version from 'Ventura' to 'Sonoma' in the parameters for the Android tests and changed the iOS test parameters to use a new VM pool and image.
* [`eng/pipelines/handlers.yml`](diffhunk://#diff-5c9b6f86c989bb9415ea86f38f9e127f8dadf3a8516e9d027c7ee6289f10c394L104-R111): Updated the macOS version from 'Ventura' to 'Sonoma' in the parameters and stages for the Android and iOS tests. [[1]](diffhunk://#diff-5c9b6f86c989bb9415ea86f38f9e127f8dadf3a8516e9d027c7ee6289f10c394L104-R111) [[2]](diffhunk://#diff-5c9b6f86c989bb9415ea86f38f9e127f8dadf3a8516e9d027c7ee6289f10c394L158-R158) [[3]](diffhunk://#diff-5c9b6f86c989bb9415ea86f38f9e127f8dadf3a8516e9d027c7ee6289f10c394L200-R200) [[4]](diffhunk://#diff-5c9b6f86c989bb9415ea86f38f9e127f8dadf3a8516e9d027c7ee6289f10c394L248-R248)
* [`eng/pipelines/ui-tests.yml`](diffhunk://#diff-01226bae9fe7277cc2f291d47499e45e220b58b560fc0735c13fa6d13e21acd4L70-R70): Updated the macOS version from 'Ventura' to 'Sonoma' in the parameters for the Android and iOS tests, and updated the VM image for macOS tests. [[1]](diffhunk://#diff-01226bae9fe7277cc2f291d47499e45e220b58b560fc0735c13fa6d13e21acd4L70-R70) [[2]](diffhunk://#diff-01226bae9fe7277cc2f291d47499e45e220b58b560fc0735c13fa6d13e21acd4L79-R79) [[3]](diffhunk://#diff-01226bae9fe7277cc2f291d47499e45e220b58b560fc0735c13fa6d13e21acd4L92-R100) [[4]](diffhunk://#diff-01226bae9fe7277cc2f291d47499e45e220b58b560fc0735c13fa6d13e21acd4L109-R109)

Updates to Xcode version:

* [`eng/pipelines/common/variables.yml`](diffhunk://#diff-257fa339ab6d36b7dd4fc3eada944bea777297cec9f90dcd20fbd6b3e6c6f57dL11-R13): Updated the required Xcode version from '15.2.0' to '15.4.0'.