### PR TITLE
[testing] Try xunit 2.6.6 with 2.8.0 vs runner

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -116,10 +116,10 @@
   </PropertyGroup>
   <PropertyGroup>
     <MicrosoftNETTestSdkPackageVersion>17.6.0</MicrosoftNETTestSdkPackageVersion>
-    <XunitPackageVersion>2.8.0</XunitPackageVersion>
+    <XunitPackageVersion>2.6.6</XunitPackageVersion>
     <XunitRunnerVisualStudioPackageVersion>2.8.0</XunitRunnerVisualStudioPackageVersion>
-    <XunitAssertPackageVersion>2.8.0</XunitAssertPackageVersion>
-    <XUnitAnalyzersPackageVersion>1.13.0</XUnitAnalyzersPackageVersion>
+    <XunitAssertPackageVersion>2.6.6</XunitAssertPackageVersion>
+    <XUnitAnalyzersPackageVersion>1.10.0</XUnitAnalyzersPackageVersion>
     <XunitAbstractionsPackageVersion>2.0.3</XunitAbstractionsPackageVersion>
     <NSubstitutePackageVersion>5.1.0</NSubstitutePackageVersion>
     <CoverletCollectorPackageVersion>6.0.0</CoverletCollectorPackageVersion>


### PR DESCRIPTION
Trying a still newer version but not fully new of xunit, related to #22582

Thought here is we can try and incrementally bump to newer xunit until we see the version that starts failing with mem leaks.