### PR TITLE
Add additional GC.Collect for tests

### DIFF
--- a/src/Controls/tests/Core.UnitTests/BindableLayoutTests.cs
+++ b/src/Controls/tests/Core.UnitTests/BindableLayoutTests.cs
@@ -414,15 +414,11 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			}
 
 			// First GC
-			await Task.Yield();
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+			await TestHelpers.Collect();
 			Assert.False(controllerRef.IsAlive, "BindableLayoutController should not be alive!");
 
 			// Second GC
-			await Task.Yield();
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+			await TestHelpers.Collect();
 			Assert.False(proxyRef.IsAlive, "WeakCollectionChangedProxy should not be alive!");
 		}
 
@@ -436,9 +432,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			Assert.Equal(2, layout.Children.Count);
 
-			await Task.Yield();
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+			await TestHelpers.Collect();
 
 			list.Add("Baz");
 			Assert.Equal(3, layout.Children.Count);

--- a/src/Controls/tests/Core.UnitTests/BindingBaseUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/BindingBaseUnitTests.cs
@@ -735,7 +735,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact]
-		public void CollectionAndContextAreHeldWeakly()
+		public async Task CollectionAndContextAreHeldWeakly()
 		{
 			WeakReference weakCollection = null, weakContext = null;
 
@@ -760,8 +760,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			create();
 
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+			await TestHelpers.Collect();
 
 			Assert.False(weakCollection.IsAlive);
 			Assert.False(weakContext.IsAlive);

--- a/src/Controls/tests/Core.UnitTests/NavigationUnitTest.cs
+++ b/src/Controls/tests/Core.UnitTests/NavigationUnitTest.cs
@@ -718,9 +718,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			await navPage.PopAsync();
 
 			await Task.Delay(100);
-
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+			await TestHelpers.Collect();
 
 			Assert.True(isFinalized);
 		}

--- a/src/Controls/tests/Core.UnitTests/StyleTests.cs
+++ b/src/Controls/tests/Core.UnitTests/StyleTests.cs
@@ -442,9 +442,8 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			var tracker = new WeakReference(label);
 			label.Style = style;
 			label = null;
-
-			await Task.Delay(10);
-			GC.Collect();
+						
+			await TestHelpers.Collect();
 
 			Assert.False(tracker.IsAlive);
 			Assert.NotNull(style);

--- a/src/Controls/tests/Core.UnitTests/VisualElementTests.cs
+++ b/src/Controls/tests/Core.UnitTests/VisualElementTests.cs
@@ -173,9 +173,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			var geometry = (Geometry)Activator.CreateInstance(type);
 			var reference = new WeakReference(new VisualElement { Clip = geometry });
 
-			await Task.Yield();
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+			await TestHelpers.Collect();
 
 			Assert.False(reference.IsAlive, "VisualElement should not be alive!");
 		}

--- a/src/Core/tests/UnitTests/TestHelpers.cs
+++ b/src/Core/tests/UnitTests/TestHelpers.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 
-namespace Microsoft.Maui.Controls.Core.UnitTests
+namespace Microsoft.Maui.UnitTests
 {
 	internal static class TestHelpers
 	{

--- a/src/Core/tests/UnitTests/Views/BorderTests.cs
+++ b/src/Core/tests/UnitTests/Views/BorderTests.cs
@@ -63,9 +63,7 @@ namespace Microsoft.Maui.UnitTests.Views
 					fired = true;
 			};
 
-			await Task.Yield();
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+			await TestHelpers.Collect();
 			GC.KeepAlive(border);
 
 			strokeShape.CornerRadius = new CornerRadius(24);
@@ -85,10 +83,8 @@ namespace Microsoft.Maui.UnitTests.Views
 				if (e.PropertyName == nameof(Border.Stroke))
 					fired = true;
 			};
-
-			await Task.Yield();
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+			
+			await TestHelpers.Collect();
 			GC.KeepAlive(border);
 
 			stroke.Color = Colors.Green;
@@ -105,10 +101,8 @@ namespace Microsoft.Maui.UnitTests.Views
 			var reference = new WeakReference(new Border { StrokeShape = strokeShape });
 
 			strokeShape = null;
-
-			await Task.Yield();
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+						
+			await TestHelpers.Collect();
 
 			Assert.False(reference.IsAlive, "Border should not be alive!");
 		}

--- a/src/Core/tests/UnitTests/Views/ShapeTests.cs
+++ b/src/Core/tests/UnitTests/Views/ShapeTests.cs
@@ -22,10 +22,8 @@ namespace Microsoft.Maui.UnitTests.Views
 				if (e.PropertyName == nameof(Shape.Fill))
 					fired = true;
 			};
-
-			await Task.Yield();
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+			
+			await TestHelpers.Collect();
 			GC.KeepAlive(shape);
 
 			fill.Color = Colors.Green;
@@ -38,10 +36,8 @@ namespace Microsoft.Maui.UnitTests.Views
 		{
 			var fill = new SolidColorBrush(Colors.Red);
 			var reference = new WeakReference(new Rectangle { Fill = fill });
-
-			await Task.Yield();
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+			
+			await TestHelpers.Collect();
 
 			Assert.False(reference.IsAlive, "Shape should not be alive!");
 		}
@@ -58,10 +54,8 @@ namespace Microsoft.Maui.UnitTests.Views
 				if (e.PropertyName == nameof(Shape.Stroke))
 					fired = true;
 			};
-
-			await Task.Yield();
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+			
+			await TestHelpers.Collect();
 			GC.KeepAlive(shape);
 
 			stroke.Color = Colors.Green;
@@ -75,9 +69,7 @@ namespace Microsoft.Maui.UnitTests.Views
 			var stroke = new SolidColorBrush(Colors.Red);
 			var reference = new WeakReference(new Rectangle { Stroke = stroke });
 
-			await Task.Yield();
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+			await TestHelpers.Collect();
 
 			Assert.False(reference.IsAlive, "Shape should not be alive!");
 		}

--- a/src/Core/tests/UnitTests/WeakListTests.cs
+++ b/src/Core/tests/UnitTests/WeakListTests.cs
@@ -13,10 +13,8 @@ namespace Microsoft.Maui.UnitTests
 			var expected = new object();
 			var list = new WeakList<object> { expected, new object() };
 			list.CleanupThreshold = 1;
-
-			await Task.Yield();
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+			
+			await TestHelpers.Collect();
 
 			foreach (var item in list)
 			{
@@ -34,9 +32,8 @@ namespace Microsoft.Maui.UnitTests
 			var list = new WeakList<object> { expected, new object() };
 			list.CleanupThreshold = 1;
 
-			await Task.Yield();
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+			
+			await TestHelpers.Collect();
 
 			list.Remove(expected);
 
@@ -50,9 +47,8 @@ namespace Microsoft.Maui.UnitTests
 			var list = new WeakList<object> { expected, new object() };
 			list.CleanupThreshold = 1;
 
-			await Task.Yield();
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+			
+			await TestHelpers.Collect();
 
 			list.Add(new object());
 


### PR DESCRIPTION
### Description of Change

After updating to the latest xunit we're starting to get periodic failures from tests related to GC tests.  This PR adds an extra collect call which is sometimes necessary after calling WaitForPendingFinalizers