### PR TITLE
Fixes endless loop of HorizontalScroll

### DIFF
--- a/src/Core/src/Platform/Android/MauiScrollView.cs
+++ b/src/Core/src/Platform/Android/MauiScrollView.cs
@@ -214,7 +214,7 @@ namespace Microsoft.Maui.Platform
 		{
 			base.OnLayout(changed, left, top, right, bottom);
 
-			if (_hScrollView?.Parent == this && _content is not null)
+			if (changed && _hScrollView?.Parent == this && _content is not null)
 			{
 				var scrollViewContentHeight = _content.Height;
 				var hScrollViewHeight = bottom - top;


### PR DESCRIPTION
### Description of Change

<!-- Enter description of the fix in this section -->
I know PR #22347 has fixed #20684. But,I am still searching for the root cause of the problem.
I printed the log and saw that the height was constantly being changed to completely different values.
I think MauiScrollView.OnLayout is where the modifications should be made.

Change \src\Core\src\Platform\Android\MauiScrollView.cs

Log:
https://github.com/dotnet/maui/pull/22566#issuecomment-2128358252

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #20684

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
