### PR TITLE
[Windows] Set `CanDrag` and `AllowDrop` only if needed

### DIFF
--- a/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
@@ -315,6 +315,7 @@ namespace Microsoft.Maui.Controls.Platform
 				{
 					_subscriptionFlags &= ~SubscriptionFlags.ContainerDragEventsSubscribed;
 
+					_container.CanDrag = false;
 					_container.DragStarting -= HandleDragStarting;
 					_container.DropCompleted -= HandleDropCompleted;
 				}
@@ -323,6 +324,7 @@ namespace Microsoft.Maui.Controls.Platform
 				{
 					_subscriptionFlags &= ~SubscriptionFlags.ContainerDropEventsSubscribed;
 
+					_container.AllowDrop = false;
 					_container.DragOver -= HandleDragOver;
 					_container.Drop -= HandleDrop;
 					_container.DragLeave -= HandleDragLeave;
@@ -719,15 +721,13 @@ namespace Microsoft.Maui.Controls.Platform
 			}
 
 			bool canDrag = gestures.FirstGestureOrDefault<DragGestureRecognizer>()?.CanDrag ?? false;
-			_container.CanDrag = canDrag;
-
 			bool allowDrop = gestures.FirstGestureOrDefault<DropGestureRecognizer>()?.AllowDrop ?? false;
-			_container.AllowDrop = allowDrop;
 
 			if (canDrag)
 			{
 				_subscriptionFlags |= SubscriptionFlags.ContainerDragEventsSubscribed;
 
+				_container.CanDrag = true;
 				_container.DragStarting += HandleDragStarting;
 				_container.DropCompleted += HandleDropCompleted;
 			}
@@ -736,6 +736,7 @@ namespace Microsoft.Maui.Controls.Platform
 			{
 				_subscriptionFlags |= SubscriptionFlags.ContainerDropEventsSubscribed;
 				
+				_container.AllowDrop = true;
 				_container.DragOver += HandleDragOver;
 				_container.Drop += HandleDrop;
 				_container.DragLeave += HandleDragLeave;


### PR DESCRIPTION
### Description of Change

This PR makes it so that `_container.CanDrag` and `_container.AllowDrop` are not set unnecessarily. The PR assumes that most of UI elements are not draggable and droppable by default.

#### Speedscope

* main: [Maui.Controls.Sample.Sandbox.exe_20240524_132632.speedscope.MAIN1.json](https://github.com/dotnet/maui/files/15433589/Maui.Controls.Sample.Sandbox.exe_20240524_132632.speedscope.MAIN1.json)
* PR: [Maui.Controls.Sample.Sandbox.exe_20240524_130213.speedscope.PR1.json](https://github.com/dotnet/maui/files/15433592/Maui.Controls.Sample.Sandbox.exe_20240524_130213.speedscope.PR1.json)

![image](https://github.com/dotnet/maui/assets/203266/b1f82651-b462-4844-a70c-4403312eb85b)


-> ~9% improvement

### Issues Fixed

Contributes to #21787