### PR TITLE
Crash on iOS when initializing a TabbedPage without children - fix

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/FlyoutPage/iOS/PhoneFlyoutPageRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/FlyoutPage/iOS/PhoneFlyoutPageRenderer.cs
@@ -581,8 +581,8 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		void UpdatePageSpecifics()
 		{
-			ChildViewControllerForHomeIndicatorAutoHidden.SetNeedsUpdateOfHomeIndicatorAutoHidden();
-			ChildViewControllerForStatusBarHidden().SetNeedsStatusBarAppearanceUpdate();
+			ChildViewControllerForHomeIndicatorAutoHidden?.SetNeedsUpdateOfHomeIndicatorAutoHidden();
+			ChildViewControllerForStatusBarHidden()?.SetNeedsStatusBarAppearanceUpdate();
 		}
 
 		public override UIViewController ChildViewControllerForStatusBarHidden()

--- a/src/Controls/src/Core/Compatibility/Handlers/TabbedPage/iOS/TabbedRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/TabbedPage/iOS/TabbedRenderer.cs
@@ -270,8 +270,8 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		void UpdatePageSpecifics()
 		{
-			ChildViewControllerForHomeIndicatorAutoHidden.SetNeedsUpdateOfHomeIndicatorAutoHidden();
-			ChildViewControllerForStatusBarHidden().SetNeedsStatusBarAppearanceUpdate();
+			ChildViewControllerForHomeIndicatorAutoHidden?.SetNeedsUpdateOfHomeIndicatorAutoHidden();
+			ChildViewControllerForStatusBarHidden()?.SetNeedsStatusBarAppearanceUpdate();
 		}
 
 		void Reset()

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue22633.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue22633.cs
@@ -1,0 +1,21 @@
+﻿using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue22633 : _IssuesUITest
+	{
+		public Issue22633(TestDevice device) : base(device)
+		{
+		}
+
+		public override string Issue => "[iOS] Crash on when initializing a TabbedPage without children";
+
+		[Test]
+		public void ExceptionShouldNotBeThrown()
+		{
+			App.WaitForElement("label");
+		}
+	}
+}

--- a/src/Controls/tests/TestCases/Issues/Issue22633.xaml
+++ b/src/Controls/tests/TestCases/Issues/Issue22633.xaml
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<TabbedPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Maui.Controls.Sample.Issues.Issue22633"
+             Title="Issue22633">
+</TabbedPage>

--- a/src/Controls/tests/TestCases/Issues/Issue22633.xaml.cs
+++ b/src/Controls/tests/TestCases/Issues/Issue22633.xaml.cs
@@ -1,0 +1,38 @@
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+using System.Threading.Tasks;
+
+namespace Maui.Controls.Sample.Issues;
+
+[XamlCompilation(XamlCompilationOptions.Compile)]
+[Issue(IssueTracker.Github, 22633, "[iOS] Crash on when initializing a TabbedPage without children", PlatformAffected.iOS)]
+public partial class Issue22633 : TabbedPage
+{
+	public Issue22633()
+	{
+		InitializeComponent();
+	}
+
+	protected override void OnAppearing()
+	{
+		base.OnAppearing();
+		_ = SimulateNavigationServiceAsync();
+	}
+
+	async Task SimulateNavigationServiceAsync()
+	{
+		// add a delay to simulate the navigation service
+		await Task.Delay(100);
+
+		Children.Add(new ContentPage
+		{
+			Title = "Page1",
+			Content = new VerticalStackLayout()
+			{
+				new Label() { AutomationId = "label", Text = "Hello, World!" }
+			}
+		});
+
+		Children.Add(new ContentPage { Title = "Page2" });
+	}
+}


### PR DESCRIPTION
### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/22633

Caused by this PR: https://github.com/dotnet/maui/pull/20069