### PR TITLE
Fix BindingAdapterPosition Exception

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/Android/SelectableViewHolder.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/SelectableViewHolder.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		public void OnClick(global::Android.Views.View view)
 		{
-			if (_isSelectionEnabled)
+			if (_isSelectionEnabled && BindingAdapterPosition >= 0)
 			{
 				OnViewHolderClicked(BindingAdapterPosition);
 			}


### PR DESCRIPTION
### Description of Change

<!-- Enter description of the fix in this section -->
When BindingAdapterPosition is -1, an exception will be thrown.
The correct handling should be to determine this value.

some log:
D SelectableViewHolder.OnClick: BindingAdapterPosition: 1
D SelectableViewHolder.OnClick: BindingAdapterPosition: -1
D SelectableViewHolder.OnClick: BindingAdapterPosition: -1
E InputDispatcher: channel '90d113e 程序异常! (server)' ~ Channel is unrecoverably broken and will be disposed!

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
