### PR TITLE
Fix BindingAdapterPosition Exception

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/Android/Adapters/SelectableItemsViewAdapter.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/Adapters/SelectableItemsViewAdapter.cs
@@ -123,7 +123,10 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		void SelectableClicked(object sender, int adapterPosition)
 		{
-			UpdateMauiSelection(adapterPosition);
+			if (adapterPosition >= 0 && adapterPosition < ItemsSource?.Count)
+			{
+				UpdateMauiSelection(adapterPosition);
+			}
 		}
 
 		void UpdateMauiSelection(int adapterPosition)

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue22674.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue22674.xaml
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Maui.Controls.Sample.Issues.Issue22674">
+  <CollectionView 
+    AutomationId="TestCollectionView"
+    SelectionMode="Single"
+		ItemsSource="{Binding ItemList}"
+		SelectionChanged="OnCollectionViewSelectionChanged">
+    <CollectionView.ItemTemplate>
+      <DataTemplate>
+        <Label
+          Text="{Binding .}" 
+          HorizontalTextAlignment="Center" />
+      </DataTemplate>
+    </CollectionView.ItemTemplate>
+  </CollectionView>
+</ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue22674.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue22674.xaml.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections.ObjectModel;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+
+namespace Maui.Controls.Sample.Issues
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	[Issue(IssueTracker.Github, 22674, "Crash when quickly clicking to delete item", PlatformAffected.iOS)]
+	public partial class Issue22674 : ContentPage
+	{
+		public Issue22674()
+		{
+			InitializeComponent();
+
+			BindingContext = this;
+		}
+
+		public ObservableCollection<string> ItemList { get; } = ["A", "B", "C", "D", "E", "F", "G", "H", "I",];
+		
+		void OnCollectionViewSelectionChanged(object sender, SelectionChangedEventArgs e)
+		{
+			if (sender is CollectionView view && view.SelectedItem is string item)
+			{
+				ItemList.Remove(item);
+			}
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue22674.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue22674.cs
@@ -1,0 +1,27 @@
+﻿#if iOS
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue22674 : _IssuesUITest
+{
+	public Issue22674(TestDevice device) : base(device) { }
+
+	public override string Issue => "Crash when quickly clicking to delete item";
+
+	[Test]
+	public void RemoveItemWhenSelectionChanged()
+	{
+		App.WaitForElement("TestCollectionView");
+
+		for (int i = 0; i < 5; i++)
+		{
+			App.TapCoordinates(24, 24);
+		}
+
+		// Without crashes, the test has passed.
+	}
+}
+#endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue22674.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue22674.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿#if ANDROID
+using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
 
@@ -23,3 +24,4 @@ public class Issue22674 : _IssuesUITest
 		// Without crashes, the test has passed.
 	}
 }
+#endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue22674.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue22674.cs
@@ -12,6 +12,7 @@ public class Issue22674 : _IssuesUITest
 	public override string Issue => "Crash when quickly clicking to delete item";
 
 	[Test]
+	[Category(UITestCategories.CollectionView)]
 	public void RemoveItemWhenSelectionChanged()
 	{
 		App.WaitForElement("TestCollectionView");

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue22674.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue22674.cs
@@ -1,5 +1,4 @@
-﻿#if iOS
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
 
@@ -24,4 +23,3 @@ public class Issue22674 : _IssuesUITest
 		// Without crashes, the test has passed.
 	}
 }
-#endif


### PR DESCRIPTION
### Description of Change

<!-- Enter description of the fix in this section -->
When BindingAdapterPosition is -1, an exception will be thrown.
The correct handling should be to determine this value.
### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #22674
Fixes #20764

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
