### PR TITLE
Fix TemplateTests.PublishNativeAOTRootAllMauiAssemblies

### DIFF
--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/TemplateTests.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/TemplateTests.cs
@@ -346,7 +346,6 @@ namespace Microsoft.Maui.IntegrationTests
 					<ItemGroup>
 						<TrimmerRootAssembly Include="Microsoft.Maui" />
 						<TrimmerRootAssembly Include="Microsoft.Maui.Controls" />
-						<TrimmerRootAssembly Include="Microsoft.Maui.Controls.Compatibility" />
 						<TrimmerRootAssembly Include="Microsoft.Maui.Controls.Foldable" />
 						<TrimmerRootAssembly Include="Microsoft.Maui.Controls.Maps" />
 						<TrimmerRootAssembly Include="Microsoft.Maui.Controls.Xaml" />


### PR DESCRIPTION
### Description of Change

Since the Compatibility project is not referenced by the app template anymore (#22203), the TemplateTests.PublishNativeAOTRootAllMauiAssemblies test is failing because it can't find the Compatibility assembly.
