### PR TITLE
Fix the tests in VS

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -119,8 +119,9 @@
     <MicrosoftNETTestSdkPackageVersion>17.6.0</MicrosoftNETTestSdkPackageVersion>
     <XunitPackageVersion>2.6.6</XunitPackageVersion>
     <XunitRunnerVisualStudioPackageVersion>2.8.0</XunitRunnerVisualStudioPackageVersion>
+    <XunitExtensibilityExecutionPackageVersion>2.6.6</XunitExtensibilityExecutionPackageVersion>
     <XunitAssertPackageVersion>2.6.6</XunitAssertPackageVersion>
-    <XUnitAnalyzersPackageVersion>1.10.0</XUnitAnalyzersPackageVersion>
+    <XUnitAnalyzersPackageVersion>1.13.0</XUnitAnalyzersPackageVersion>
     <XunitAbstractionsPackageVersion>2.0.3</XunitAbstractionsPackageVersion>
     <NSubstitutePackageVersion>5.1.0</NSubstitutePackageVersion>
     <CoverletCollectorPackageVersion>6.0.0</CoverletCollectorPackageVersion>

--- a/src/Microsoft.Maui.TestUtils.DeviceTests.Runners.targets
+++ b/src/Microsoft.Maui.TestUtils.DeviceTests.Runners.targets
@@ -9,4 +9,8 @@
     <AdditionalFiles Include="@(MauiSplashScreen)" IsMauiSplashScreen="True" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitRunnerVisualStudioPackageVersion)" ExcludeAssets="all" />
+  </ItemGroup>
+
 </Project>

--- a/src/TestUtils/src/DeviceTests/TestUtils.DeviceTests.csproj
+++ b/src/TestUtils/src/DeviceTests/TestUtils.DeviceTests.csproj
@@ -12,7 +12,9 @@
 
   <ItemGroup>
     <PackageReference Include="xunit" Version="$(XunitPackageVersion)" />
+    <PackageReference Include="xunit.assert" Version="$(XunitAssertPackageVersion)" />
     <PackageReference Include="xunit.runner.utility" Version="$(XunitPackageVersion)" />
+    <PackageReference Include="xunit.extensibility.execution" Version="$(XunitExtensibilityExecutionPackageVersion)" />
     <PackageReference Include="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="1.0.0-prerelease.21558.2" />
   </ItemGroup>
 


### PR DESCRIPTION
### Description of Change

Arcade is setting things but they do not apply to app-based tests. The VS runner should not be included and we need to make sure the dependencies propagate to the test apps.