### PR TITLE
Correct path to gather API docs artifacts in CI

### DIFF
--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -23,12 +23,12 @@ if (TestTFM == "default")
 Exception pendingException = null;
 
 var NuGetOnlyPackages = new string[] {
-    "Microsoft.Maui.Controls.*.nupkg",
-    "Microsoft.Maui.Core.*.nupkg",
-    "Microsoft.Maui.Essentials.*.nupkg",
-    "Microsoft.Maui.Graphics.*.nupkg",
-    "Microsoft.Maui.Maps.*.nupkg",
-    "Microsoft.AspNetCore.Components.WebView.*.nupkg",
+    "Microsoft.Maui.Controls.*.{nupkg,snupkg}",
+    "Microsoft.Maui.Core.*.{nupkg,snupkg}",
+    "Microsoft.Maui.Essentials.*.{nupkg,snupkg}",
+    "Microsoft.Maui.Graphics.*.{nupkg,snupkg}",
+    "Microsoft.Maui.Maps.*.{nupkg,snupkg}",
+    "Microsoft.AspNetCore.Components.WebView.*.{nupkg,snupkg}",
 };
 
 ProcessTFMSwitches();
@@ -334,42 +334,26 @@ Task("dotnet-pack-docs")
         EnsureDirectoryExists(destDir);
         CleanDirectories(destDir);
 
-        // Get the docs for .NET MAUI
-        foreach (var nupkg in GetFiles("./artifacts/Microsoft.Maui.*.Ref.any.*.nupkg"))
-        {
-            var d = $"{tempDir}/{nupkg.GetFilename()}";
-
-            Unzip(nupkg, d);
-            DeleteFiles($"{d}/**/*.pri");
-            DeleteFiles($"{d}/**/*.aar");
-            DeleteFiles($"{d}/**/*.DesignTools.*");
-            CopyFiles($"{d}/ref/**/net?.?/**/*.dll", $"{destDir}");
-            CopyFiles($"{d}/ref/**/net?.?/**/*.xml", $"{destDir}");
-        }
-
-        // Get the docs for libraries separately distributed as NuGets
+        // Extract the binaries, xml & pdb files for docs purposes
         foreach (var pattern in NuGetOnlyPackages)
         {
-            foreach (var nupkg in GetFiles($"./artifacts/{pattern}"))
+            foreach (var nupkg in GetFiles($"./artifacts/**/{pattern}"))
             {
                 var filename = nupkg.GetFilename().ToString();
                 var d = $"{tempDir}/{filename}";
                 Unzip(nupkg, d);
                 DeleteFiles($"{d}/**/*.pri");
                 DeleteFiles($"{d}/**/*.aar");
-                DeleteFiles($"{d}/**/*.pdb");
 
                 if (filename.StartsWith("Microsoft.AspNetCore.Components.WebView.Wpf")
                     || filename.StartsWith("Microsoft.AspNetCore.Components.WebView.WindowsForms"))
                 {
-                    CopyFiles($"{d}/lib/**/net?.?-windows?.?/**/*.dll", $"{destDir}");
-                    CopyFiles($"{d}/lib/**/net?.?-windows?.?/**/*.xml", $"{destDir}");    
+                    CopyFiles($"{d}/lib/**/net?.?-windows?.?/**/*.{{dll,xml,pdb}}", $"{destDir}");
 
                     continue;
                 }
 
-                CopyFiles($"{d}/lib/**/{{net,netstandard}}?.?/**/*.dll", $"{destDir}");
-                CopyFiles($"{d}/lib/**/{{net,netstandard}}?.?/**/*.xml", $"{destDir}");
+                CopyFiles($"{d}/lib/**/{{net,netstandard}}?.?/**/*.{{dll,xml,pdb}}", $"{destDir}");
             }
         }
 

--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -344,6 +344,8 @@ Task("dotnet-pack-docs")
                 Unzip(nupkg, d);
                 DeleteFiles($"{d}/**/*.pri");
                 DeleteFiles($"{d}/**/*.aar");
+                DeleteFiles($"{d}/**/*.DesignTools.*");
+                DeleteFiles($"{d}/**/*.resources.dll");
 
                 if (filename.StartsWith("Microsoft.AspNetCore.Components.WebView.Wpf")
                     || filename.StartsWith("Microsoft.AspNetCore.Components.WebView.WindowsForms"))
@@ -353,7 +355,7 @@ Task("dotnet-pack-docs")
                     continue;
                 }
 
-                CopyFiles($"{d}/lib/**/{{net,netstandard}}?.?/**/*.{{dll,xml,pdb}}", $"{destDir}");
+                CopyFiles($"{d}/lib/**/net?.?/**/*.{{dll,xml,pdb}}", $"{destDir}");
             }
         }
 

--- a/src/Controls/docs/Microsoft.Maui.Controls/Application.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/Application.xml
@@ -26,9 +26,9 @@
   <Docs>
     <summary>Class that represents a cross-platform mobile application.</summary>
     <remarks>
-      <para>The <see cref="T:Microsoft.Maui.Controls.Application" /> class is the core of a Microsoft.Maui.Controls application. It sets the root page of the application, persists primitive type data across invocations of the application in the <see cref="P:Microsoft.Maui.Controls.Application.Properties" /> dictionary, and provides events to respond to pushing and popping of modal views. Visual studio creates this class for the developer in the appropriate project in a new Microsoft.Maui.Controls solution.</para>
+      <para>The <see cref="T:Microsoft.Maui.Controls.Application" /> class is the core of a .NET MAUI application. It sets the root page of the application, and provides events to respond to pushing and popping of modal views. Visual Studio creates this class for the developer in the appropriate project in a new .NET MAUI solution.</para>
       <example>
-        <para>Both Visual Studio for Mac and Visual Studio create a XAML and a code-behind file for the application when the developer creates a new Microsoft.Maui.Controls solution. The following example shows a typical <c>Application</c> class, with an entry in its resource dictionary.</para>
+        <para>Both Visual Studio creates a XAML and a code-behind file for the application when the developer creates a new .NET MAUI solution. The following example shows a typical <c>Application</c> class, with an entry in its resource dictionary.</para>
         <code lang="XAML"><![CDATA[
 <Application xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"


### PR DESCRIPTION
### Description of Change

Correctly gathers the artifacts needed to fill the xml-docs artifact that is used to populate the online API docs browser.

Additionally, this now also gathers pdb files to enable new functionality in the online API docs browser that enables links from said browser straight into our code repository.

You can verify this PR works correctly by going to the build in Azure Pipelines, inspect the artifacts and see that that has a xml-docs artifact which is filled with dll, xml and pdb files.

This PR also has some minor changes in actual docs to fix the docs build system warnings.

### Issues Fixed

Fixes #22736