### PR TITLE
[Windows] Fix ListView insert not working properly

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/Windows/ListViewRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/Windows/ListViewRenderer.cs
@@ -260,8 +260,6 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				ClearSizeEstimate();
 				ReloadData();
 			}
-
-			Element.Dispatcher.DispatchIfRequired(() => List?.UpdateLayout());
 		}
 
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/src/Controls/tests/DeviceTests/Elements/ListView/ListViewTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/ListView/ListViewTests.Windows.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
+using Microsoft.Maui.Handlers;
 
 namespace Microsoft.Maui.DeviceTests
 {
@@ -13,6 +15,38 @@ namespace Microsoft.Maui.DeviceTests
 		void ValidatePlatformCells(ListView listView)
 		{
 
+		}
+
+		[Fact]
+		public async Task InsertItemWorks()
+		{
+			SetupBuilder();
+
+			var data = new ObservableCollection<string>();
+			var listView = new ListView()
+			{
+				ItemsSource = data
+			};
+
+			var layout = new VerticalStackLayout()
+			{
+				listView
+			};
+
+			await CreateHandlerAndAddToWindow<LayoutHandler>(layout, async (handler) =>
+			{
+				await Task.Delay(100);
+
+				data.Add("Item 1");
+				data.Add("Item 3");
+				data.Insert(1, "Item 2");
+
+				await Task.Delay(100);
+
+				var children = listView.GetVisualTreeDescendants();
+
+				Assert.True(children.Any());
+			});
 		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/ListView/ListViewTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/ListView/ListViewTests.Windows.cs
@@ -5,7 +5,12 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Handlers.Compatibility;
+using Microsoft.Maui.Controls.Platform;
 using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Platform;
+using Microsoft.UI.Xaml;
+using Xunit;
 
 namespace Microsoft.Maui.DeviceTests
 {
@@ -41,11 +46,12 @@ namespace Microsoft.Maui.DeviceTests
 				data.Add("Item 3");
 				data.Insert(1, "Item 2");
 
-				await Task.Delay(100);
+				await Task.Delay(1000);
 
-				var children = listView.GetVisualTreeDescendants();
+				var actualListView = listView.ToPlatform() as ListViewRenderer;
+				var textChildren = actualListView.GetChildren<UI.Xaml.Controls.TextBlock>();
 
-				Assert.True(children.Any());
+				Assert.True(textChildren.Any(x => x.Text == "Item 3"));
 			});
 		}
 	}

--- a/src/Controls/tests/DeviceTests/Elements/ListView/ListViewTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/ListView/ListViewTests.Windows.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Maui.DeviceTests
 				data.Add("Item 3");
 				data.Insert(1, "Item 2");
 
-				await Task.Delay(1000);
+				await Task.Delay(200);
 
 				var actualListView = listView.ToPlatform() as ListViewRenderer;
 				var textChildren = actualListView.GetChildren<UI.Xaml.Controls.TextBlock>();

--- a/src/Controls/tests/DeviceTests/Elements/ListView/ListViewTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/ListView/ListViewTests.Windows.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Maui.DeviceTests
 				var actualListView = listView.ToPlatform() as ListViewRenderer;
 				var textChildren = actualListView.GetChildren<UI.Xaml.Controls.TextBlock>();
 
-				Assert.True(textChildren.Any(x => x.Text == "Item 3"));
+				Assert.Contains(textChildren, (x) => x.Text == "Item 3");
 			});
 		}
 	}


### PR DESCRIPTION
### Description of Change

Remove a call that caused issues when inserting items in the ListView control. Basically, we end up calling a layout invalidate right before and after the item insert, which causes issues with data binding. We should not be forcing a layout invalidation when the collection is modified.

The callstack looks like the following:
```
Item 1 Added (ListViewRenderer.OnCollectionChanged -> add dispatcher queue of List.UpdateLayout())
Item 3 Added (ListViewRenderer.OnCollectionChanged -> add dispatcher queue of List.UpdateLayout())
...
Layout pass happens (queued List.UpdateLayout fires), which invokes:
    CellControl.DataContextChanged
        - Called w/ NewValue == null
        - Called again w/ NewValue == Test 1 (DataContext is already Test 1)
...
Item 2 Inserted (ListViewRenderer.OnCollectionChanged -> add dispatcher queue of  List.UpdateLayout())
...
Layout pass happens, which invokes:
    CellControl.DataContextChanged
        - Called w/ NewValue == null
        - Called again w/ NewValue == Test 2 (DataContext is already Test 2)
        - Called w/ NewValue == null (DataContext is null)
        - Called again w/ NewValue == Test 2 (DataContext is already Test 2)
```

### Issues Fixed

Fixes #22393
