### PR TITLE
Remove .NET 7 from bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -42,7 +42,7 @@ body:
     id: version-with-bug
     attributes:
       label: Version with bug
-      description: In what (currently supported) version do you see this issue? Run `dotnet workload list` to find your version.
+      description: In what version do you see this issue? Run `dotnet workload list` to find your version.
       options:
         - 
         - 9.0.0-preview.3.10457

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -42,7 +42,7 @@ body:
     id: version-with-bug
     attributes:
       label: Version with bug
-      description: In what version do you see this issue? Run `dotnet workload list` to find your version.
+      description: In what (currently supported) version do you see this issue? Run `dotnet workload list` to find your version.
       options:
         - 
         - 9.0.0-preview.3.10457

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -56,16 +56,6 @@ body:
         - 8.0.7 SR2
         - 8.0.6 SR1
         - 8.0.3 GA
-        - 7.0.101
-        - 7.0.100
-        - 7.0.96
-        - 7.0.92
-        - 7.0.86
-        - 7.0.81
-        - 7.0.59
-        - 7.0.58
-        - 7.0.52
-        - 7.0.49
         - Nightly / CI build (Please specify exact version)
         - Unknown/Other
     validations:


### PR DESCRIPTION
### Description of Change

.NET 7 is out of support as per the [.NET MAUI Support Policy](https://dotnet.microsoft.com/platform/support/policy/maui), removing this from the bug template.

