### PR TITLE
Entry fields do not work correctly if bound to a numeric property from a ViewModel - fix

### DIFF
--- a/src/Controls/src/Core/BindingExpression.cs
+++ b/src/Controls/src/Core/BindingExpression.cs
@@ -427,6 +427,7 @@ namespace Microsoft.Maui.Controls
 		}
 
 		static readonly Type[] DecimalTypes = { typeof(float), typeof(decimal), typeof(double) };
+		static readonly Type[] NumericTypes = { typeof(float), typeof(decimal), typeof(double), typeof(int)};
 
 		internal static bool TryConvert(ref object value, BindableProperty targetProperty, Type convertTo, bool toTarget)
 		{
@@ -461,6 +462,13 @@ namespace Microsoft.Maui.Controls
 				{
 					value = original;
 					return false;
+				}
+
+				// If the input string is null, empty, or consists only of whitespace, 
+				// and the target type is a numeric type, set the value to 0 to ensure proper numeric conversion
+				if (string.IsNullOrWhiteSpace(stringValue) && NumericTypes.Contains(convertTo))
+				{
+					value = 0;
 				}
 
 				value = Convert.ChangeType(value, convertTo, CultureInfo.CurrentCulture);

--- a/src/Controls/src/Core/BindingExpression.cs
+++ b/src/Controls/src/Core/BindingExpression.cs
@@ -427,7 +427,22 @@ namespace Microsoft.Maui.Controls
 		}
 
 		static readonly Type[] DecimalTypes = { typeof(float), typeof(decimal), typeof(double) };
-		static readonly Type[] NumericTypes = { typeof(float), typeof(decimal), typeof(double), typeof(int)};
+		static readonly Type[] NumericTypes =
+		{
+			typeof(sbyte),
+			typeof(byte),
+			typeof(short),
+			typeof(ushort),
+			typeof(int),
+			typeof(uint),
+			typeof(long),
+			typeof(ulong),
+			typeof(nint),
+			typeof(nuint),
+			typeof(float),
+			typeof(double),
+			typeof(decimal),
+		};
 
 		internal static bool TryConvert(ref object value, BindableProperty targetProperty, Type convertTo, bool toTarget)
 		{

--- a/src/Controls/tests/Core.UnitTests/BindingUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/BindingUnitTests.cs
@@ -1953,6 +1953,23 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.Equal(slider.Value, Slider.ValueProperty.DefaultValue);
 		}
 
+		[Fact]
+		public void ConvertNumericToZero()
+		{
+			System.Threading.Thread.CurrentThread.CurrentCulture = System.Threading.Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
+
+			var entry = new Entry();
+			var vm = new MockViewModel { Value = 5 };
+			entry.BindingContext = vm;
+			entry.SetBinding(Entry.TextProperty, "Value", BindingMode.TwoWay);
+
+			Assert.Equal("5", entry.Text);
+
+			entry.Text = string.Empty;
+
+			Assert.Equal(0, vm.Value);
+		}
+
 		class NullViewModel : INotifyPropertyChanged
 		{
 			public event PropertyChangedEventHandler PropertyChanged;

--- a/src/Controls/tests/Core.UnitTests/MockViewModel.cs
+++ b/src/Controls/tests/Core.UnitTests/MockViewModel.cs
@@ -26,6 +26,20 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			}
 		}
 
+		int _value;
+		public virtual int Value
+		{
+			get { return _value; }
+			set
+			{
+				if (_value == value)
+					return;
+
+				_value = value;
+				OnPropertyChanged("Value");
+			}
+		}
+
 		protected void OnPropertyChanged([CallerMemberName] string propertyName = null)
 		{
 			PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));


### PR DESCRIPTION
### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/15846

|Before|After|
|--|--|
|<video src="https://github.com/dotnet/maui/assets/42434498/4fb5453e-69e5-4b44-9c50-7ec811821b82" width="300px"/>|<video src="https://github.com/dotnet/maui/assets/42434498/2d570e60-23fb-4f3c-8de9-439423750c4e" width="300px"/>|



