### PR TITLE
[Windows] Subscribe less pointer events in `UpdatingGestureRecognizers`

### DIFF
--- a/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
@@ -361,9 +361,6 @@ namespace Microsoft.Maui.Controls.Platform
 					_container.ManipulationDelta -= OnManipulationDelta;
 					_container.ManipulationStarted -= OnManipulationStarted;
 					_container.ManipulationCompleted -= OnManipulationCompleted;
-					_container.PointerPressed -= OnPointerPressed;
-					_container.PointerExited -= OnPointerExited;
-					_container.PointerReleased -= OnPointerReleased;
 					_container.PointerCanceled -= OnPointerCanceled;
 				}
 			}
@@ -544,6 +541,11 @@ namespace Microsoft.Maui.Controls.Platform
 			HandlePgrPointerEvent(e, (view, recognizer)
 						=> recognizer.SendPointerExited(view, (relativeTo)
 							=> GetPosition(relativeTo, e), _control is null ? null : new PlatformPointerEventArgs(_control, e)));
+
+			if ((_subscriptionFlags & SubscriptionFlags.ContainerManipulationAndPointerEventsSubscribed) != 0)
+			{
+				OnPointerExited(sender, e);
+			}
 		}
 
 		void OnPgrPointerMoved(object sender, PointerRoutedEventArgs e)
@@ -556,6 +558,11 @@ namespace Microsoft.Maui.Controls.Platform
 			HandlePgrPointerEvent(e, (view, recognizer)
 						=> recognizer.SendPointerPressed(view, (relativeTo)
 							=> GetPosition(relativeTo, e), _control is null ? null : new PlatformPointerEventArgs(_control, e)));
+
+			if ((_subscriptionFlags & SubscriptionFlags.ContainerManipulationAndPointerEventsSubscribed) != 0)
+			{
+				OnPointerPressed(sender, e);
+			}
 		}
 
 		void OnPgrPointerReleased(object sender, PointerRoutedEventArgs e)
@@ -563,6 +570,11 @@ namespace Microsoft.Maui.Controls.Platform
 			HandlePgrPointerEvent(e, (view, recognizer)
 						=> recognizer.SendPointerReleased(view, (relativeTo)
 							=> GetPosition(relativeTo, e), _control is null ? null : new PlatformPointerEventArgs(_control, e)));
+
+			if ((_subscriptionFlags & SubscriptionFlags.ContainerManipulationAndPointerEventsSubscribed) != 0)
+			{
+				OnPointerReleased(sender, e);
+			}
 		}
 
 		private void HandlePgrPointerEvent(PointerRoutedEventArgs e, Action<View, PointerGestureRecognizer> SendPointerEvent)
@@ -827,9 +839,6 @@ namespace Microsoft.Maui.Controls.Platform
 			_container.ManipulationDelta += OnManipulationDelta;
 			_container.ManipulationStarted += OnManipulationStarted;
 			_container.ManipulationCompleted += OnManipulationCompleted;
-			_container.PointerPressed += OnPointerPressed;
-			_container.PointerExited += OnPointerExited;
-			_container.PointerReleased += OnPointerReleased;
 			_container.PointerCanceled += OnPointerCanceled;
 		}
 

--- a/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
@@ -540,9 +540,11 @@ namespace Microsoft.Maui.Controls.Platform
 					=> GetPosition(relativeTo, e), _control is null ? null : new PlatformPointerEventArgs(_control, e)));
 
 		void OnPgrPointerExited(object sender, PointerRoutedEventArgs e)
-			=> HandlePgrPointerEvent(e, (view, recognizer)
-				=> recognizer.SendPointerExited(view, (relativeTo)
-					=> GetPosition(relativeTo, e), _control is null ? null : new PlatformPointerEventArgs(_control, e)));
+		{
+			HandlePgrPointerEvent(e, (view, recognizer)
+						=> recognizer.SendPointerExited(view, (relativeTo)
+							=> GetPosition(relativeTo, e), _control is null ? null : new PlatformPointerEventArgs(_control, e)));
+		}
 
 		void OnPgrPointerMoved(object sender, PointerRoutedEventArgs e)
 			=> HandlePgrPointerEvent(e, (view, recognizer)
@@ -550,14 +552,18 @@ namespace Microsoft.Maui.Controls.Platform
 					=> GetPosition(relativeTo, e), _control is null ? null : new PlatformPointerEventArgs(_control, e)));
 
 		void OnPgrPointerPressed(object sender, PointerRoutedEventArgs e)
-			=> HandlePgrPointerEvent(e, (view, recognizer)
-				=> recognizer.SendPointerPressed(view, (relativeTo)
-					=> GetPosition(relativeTo, e), _control is null ? null : new PlatformPointerEventArgs(_control, e)));
+		{
+			HandlePgrPointerEvent(e, (view, recognizer)
+						=> recognizer.SendPointerPressed(view, (relativeTo)
+							=> GetPosition(relativeTo, e), _control is null ? null : new PlatformPointerEventArgs(_control, e)));
+		}
 
 		void OnPgrPointerReleased(object sender, PointerRoutedEventArgs e)
-			=> HandlePgrPointerEvent(e, (view, recognizer)
-				=> recognizer.SendPointerReleased(view, (relativeTo)
-					=> GetPosition(relativeTo, e), _control is null ? null : new PlatformPointerEventArgs(_control, e)));
+		{
+			HandlePgrPointerEvent(e, (view, recognizer)
+						=> recognizer.SendPointerReleased(view, (relativeTo)
+							=> GetPosition(relativeTo, e), _control is null ? null : new PlatformPointerEventArgs(_control, e)));
+		}
 
 		private void HandlePgrPointerEvent(PointerRoutedEventArgs e, Action<View, PointerGestureRecognizer> SendPointerEvent)
 		{


### PR DESCRIPTION
### Description of Change

The idea of the PR is simple. There two sets of pointer event subscriptions:

https://github.com/dotnet/maui/blob/fcabff1fe3e551e22558cba74dd3a86e00323b69/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs#L792-L796

and

https://github.com/dotnet/maui/blob/fcabff1fe3e551e22558cba74dd3a86e00323b69/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs#L824-L827

Consequently, `_container.PointerPressed`, `_container.PointerExited`, and `_container.PointerReleased` are subscribed twice. And this PR removes these subscriptions.

 

### Performance impact

* MAIN: [Maui.Controls.Sample.Sandbox.exe_20240601_222830.speedscope.MAIN.json](https://github.com/user-attachments/files/15523262/Maui.Controls.Sample.Sandbox.exe_20240601_222830.speedscope.MAIN.json)
* PR: [Maui.Controls.Sample.Sandbox.exe_20240601_223130.speedscope.PR.json](https://github.com/user-attachments/files/15523263/Maui.Controls.Sample.Sandbox.exe_20240601_223130.speedscope.PR.json)

![image](https://github.com/dotnet/maui/assets/203266/fd77fd77-9c62-414f-b7a6-d9ceec6b3621)

-> ~25% improvement

### Issues Fixed

Contributes to #21787