### PR TITLE
[Windows] Optimize getting default font size and font family values

### DIFF
--- a/src/Core/src/Fonts/FontManager.Windows.cs
+++ b/src/Core/src/Fonts/FontManager.Windows.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using System;
+﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
@@ -7,6 +6,8 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Graphics.Canvas.Text;
 using Microsoft.Maui.ApplicationModel;
 using Microsoft.Maui.Storage;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
 
 namespace Microsoft.Maui
@@ -27,6 +28,12 @@ namespace Microsoft.Maui
 		readonly IFontRegistrar _fontRegistrar;
 		readonly IServiceProvider? _serviceProvider;
 
+		/// <remarks>Value is cached to avoid the performance hit of accessing <see cref="ResourceDictionary"/> many times.</remarks>
+		FontFamily? _defaultFontFamily;
+
+		/// <remarks>Value is cached to avoid the performance hit of accessing <see cref="ResourceDictionary"/> many times.</remarks>
+		double? _defaultFontSize;
+
 		/// <summary>
 		/// Creates a new <see cref="EmbeddedFontLoader"/> instance.
 		/// </summary>
@@ -37,15 +44,42 @@ namespace Microsoft.Maui
 		{
 			_fontRegistrar = fontRegistrar;
 			_serviceProvider = serviceProvider;
+
+			Application.Current.Resources.RegisterPropertyChangedCallback(Control.FontFamilyProperty, OnPropertyChanged);
+			Application.Current.Resources.RegisterPropertyChangedCallback(Control.FontSizeProperty, OnPropertyChanged);
+		}
+
+		private void OnPropertyChanged(DependencyObject sender, DependencyProperty dp)
+		{
+			if (dp == Control.FontFamilyProperty)
+			{
+				_defaultFontFamily = (FontFamily)Application.Current.Resources[SystemFontFamily];
+			}
+			else if (dp == Control.FontSizeProperty)
+			{
+				_defaultFontSize = (double)Application.Current.Resources[SystemFontSize];
+			}
 		}
 
 		/// <inheritdoc/>
-		public FontFamily DefaultFontFamily =>
-			(FontFamily)UI.Xaml.Application.Current.Resources[SystemFontFamily];
+		public FontFamily DefaultFontFamily
+		{
+			get
+			{
+				_defaultFontFamily ??= (FontFamily)Application.Current.Resources[SystemFontFamily];
+				return _defaultFontFamily;
+			}
+		}
 
 		/// <inheritdoc/>
-		public double DefaultFontSize =>
-			(double)UI.Xaml.Application.Current.Resources[SystemFontSize];
+		public double DefaultFontSize
+		{
+			get
+			{
+				_defaultFontSize ??= (double)Application.Current.Resources[SystemFontSize];
+				return _defaultFontSize.Value;
+			}
+		}
 
 		/// <inheritdoc/>
 		public FontFamily GetFontFamily(Font font)

--- a/src/Core/src/Fonts/FontManager.Windows.cs
+++ b/src/Core/src/Fonts/FontManager.Windows.cs
@@ -7,7 +7,6 @@ using Microsoft.Graphics.Canvas.Text;
 using Microsoft.Maui.ApplicationModel;
 using Microsoft.Maui.Storage;
 using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
 
 namespace Microsoft.Maui
@@ -44,21 +43,6 @@ namespace Microsoft.Maui
 		{
 			_fontRegistrar = fontRegistrar;
 			_serviceProvider = serviceProvider;
-
-			Application.Current.Resources.RegisterPropertyChangedCallback(Control.FontFamilyProperty, OnPropertyChanged);
-			Application.Current.Resources.RegisterPropertyChangedCallback(Control.FontSizeProperty, OnPropertyChanged);
-		}
-
-		private void OnPropertyChanged(DependencyObject sender, DependencyProperty dp)
-		{
-			if (dp == Control.FontFamilyProperty)
-			{
-				_defaultFontFamily = (FontFamily)Application.Current.Resources[SystemFontFamily];
-			}
-			else if (dp == Control.FontSizeProperty)
-			{
-				_defaultFontSize = (double)Application.Current.Resources[SystemFontSize];
-			}
 		}
 
 		/// <inheritdoc/>

--- a/src/Essentials/src/AppInfo/AppInfo.shared.cs
+++ b/src/Essentials/src/AppInfo/AppInfo.shared.cs
@@ -130,7 +130,7 @@ namespace Microsoft.Maui.ApplicationModel
 		/// <summary>The app is packaged and can be distributed through an MSIX or the store.</summary>
 		Packaged,
 
-		/// <summary>The app is unpcakged and can be distributed as a collection of executable files.</summary>
+		/// <summary>The app is unpackaged and can be distributed as a collection of executable files.</summary>
 		Unpackaged,
 	}
 }

--- a/src/Essentials/src/AppInfo/AppInfo.uwp.cs
+++ b/src/Essentials/src/AppInfo/AppInfo.uwp.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Maui.ApplicationModel
 		readonly ActiveWindowTracker _activeWindowTracker;
 
 		/// <summary>
-		/// Intializes a new <see cref="AppInfoImplementation"/> object with default values.
+		/// Initializes a new <see cref="AppInfoImplementation"/> object with default values.
 		/// </summary>
 		public AppInfoImplementation()
 		{


### PR DESCRIPTION
### Description of Change

I've been profiling my "complex grid" case again (see #21787) and I noticed that [getting](https://github.com/dotnet/maui/blob/fcabff1fe3e551e22558cba74dd3a86e00323b69/src/Core/src/Fonts/FontManager.Windows.cs#L42-L48) `DefaultFontFamily` and `DefaultFontSize` is costly on Windows because it requires interop operations on every access of `FontManager.DefaultFontFamily` and `FontManager.DefaultFontSize`.

Interestingly, on Android it's just a simple [constant](https://github.com/dotnet/maui/blob/a7705a9ace36b375fcec23cabf98d28a71a08ecd/src/Core/src/Fonts/FontManager.Android.cs#L49). 

Moreover, on IOS the value is [cached](https://github.com/dotnet/maui/blob/a7705a9ace36b375fcec23cabf98d28a71a08ecd/src/Core/src/Fonts/FontManager.iOS.cs#L46-L52).

But on Windows, the values are read [over and over again](https://github.com/dotnet/maui/blob/a7705a9ace36b375fcec23cabf98d28a71a08ecd/src/Core/src/Fonts/FontManager.Windows.cs#L42-L48).

There are two paths possible for Windows here:

1) Cache the two values. This would be very easy but it might turn out to be wrong (this PR)
2) Cache `DefaultFontFamily` and `DefaultFontSize` but _listen to changes_ (it appears `ContentControlThemeFontFamily` is basically static; see https://github.com/dotnet/maui/pull/22782#discussion_r1626440353). 

### Performance impact

* `main`: [Maui.Controls.Sample.Sandbox.exe_20240602_102503.speedscope.MAIN.json](https://github.com/user-attachments/files/15524666/Maui.Controls.Sample.Sandbox.exe_20240602_102503.speedscope.MAIN.json)
* PR: [Maui.Controls.Sample.Sandbox.exe_20240602_102749.speedscope.PR.json](https://github.com/user-attachments/files/15524667/Maui.Controls.Sample.Sandbox.exe_20240602_102749.speedscope.PR.json)

![image](https://github.com/dotnet/maui/assets/203266/f77b5a49-6beb-426b-ab4f-d5b804b62544)

-> ~%79 improvement

### Issues Fixed

Contributes to #21787