### PR TITLE
Revert "[ios] fix memory leak in RadioButton

### DIFF
--- a/src/Controls/src/Core/Border/Border.cs
+++ b/src/Controls/src/Core/Border/Border.cs
@@ -64,13 +64,10 @@ namespace Microsoft.Maui.Controls
 
 			if (strokeShape is VisualElement visualElement)
 			{
-				SetInheritedBindingContext(visualElement, BindingContext);
+				AddLogicalChild(visualElement);
 				_strokeShapeChanged ??= (sender, e) => OnPropertyChanged(nameof(StrokeShape));
 				_strokeShapeProxy ??= new();
 				_strokeShapeProxy.Subscribe(visualElement, _strokeShapeChanged);
-
-				OnParentResourcesChanged(this.GetMergedResources());
-				((IElementDefinition)this).AddResourcesChangedListener(visualElement.OnParentResourcesChanged);
 			}
 		}
 
@@ -80,9 +77,7 @@ namespace Microsoft.Maui.Controls
 
 			if (strokeShape is VisualElement visualElement)
 			{
-				((IElementDefinition)this).RemoveResourcesChangedListener(visualElement.OnParentResourcesChanged);
-
-				SetInheritedBindingContext(visualElement, null);
+				RemoveLogicalChild(visualElement);
 				_strokeShapeProxy?.Unsubscribe();
 			}
 		}


### PR DESCRIPTION
### Description of Change

Now that we are setting the parent to weak https://github.com/dotnet/maui/pull/22561 we can rely on that for breaking the cycle. 

I realize this somewhat brings back the issue with having a shared resource, but, that's not a new problem whereas the regression caused is a new problem. 

Ideally we'll have the concept of shared in net9

### Issues Fixed
Fixes #21747
