### PR TITLE
[workload] fix missing files during the build

### DIFF
--- a/src/Workload/Microsoft.Maui.Sdk/Microsoft.Maui.Sdk.csproj
+++ b/src/Workload/Microsoft.Maui.Sdk/Microsoft.Maui.Sdk.csproj
@@ -4,10 +4,6 @@
   <Import Project="../Shared/Maestro.targets" />
 
   <PropertyGroup>
-    <OutputPath>$(DotNetPacksDirectory)$(PackageId)/$(PackageVersion)/</OutputPath>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <!-- NuGet package information -->
     <IsPackable>true</IsPackable>
     <PackageId>Microsoft.Maui.Sdk</PackageId>
@@ -63,6 +59,18 @@
       />
       <FileWrites Include="$(IntermediateOutputPath)BundledVersions.targets" />
     </ItemGroup>
+  </Target>
+
+  <Target Name="_CopyWorkloadFiles" AfterTargets="_GenerateBundledVersions">
+    <PropertyGroup>
+      <_DestinationFolder>$(DotNetPacksDirectory)$(PackageId)/$(PackageReferenceVersion)/Sdk/</_DestinationFolder>
+    </PropertyGroup>
+    <ItemGroup>
+      <_Files Include="Sdk/*" />
+      <_Files Include="$(IntermediateOutputPath)BundledVersions.targets" />
+    </ItemGroup>
+    <MakeDir Directories="$(_DestinationFolder)" />
+    <Copy SourceFiles="@(_Files)" DestinationFolder="$(_DestinationFolder)" />
   </Target>
 
 </Project>


### PR DESCRIPTION
I used to do this to build MAUI:

* `dotnet cake`

* `./bin/dotnet/dotnet build SomeCustomerProject.csproj`

Unfortunately, the `dotnet build` command would give an error that the MAUI workload was not installed.

The `Microsoft.Maui.Sdk` project is copying its output to:

    OutputPath = artifacts/bin/Microsoft.Maui.Sdk/Debug/

When it should be:

    OutputPath = bin/dotnet/packs/Microsoft.Maui.Sdk/8.0.60-dev/

This appears to be caused by the migration to dotnet/arcade:

https://github.com/dotnet/arcade/blob/e6b3f32f9855dccbe2447471c8f729b66f17d242/src/Microsoft.DotNet.Arcade.Sdk/tools/ProjectLayout.props#L14

To fix this, I added a new target to copy files to an additional location.

After this change, I still got a warning:

    warning NU1603: hellomaui depends on Microsoft.Maui.Controls (>= 8.0.60-dev) but Microsoft.Maui.Controls 8.0.60-dev was not found. An approximate best match of Microsoft.Maui.Controls 8.0.60-dev.24303.1 was resolved.

But will troubleshoot that one later, the `.nupkg` files in `./bin/dotnet/library-packs/`, have a 8.0.60-dev.24303.1 version.