### PR TITLE
[XC] Respects GenerateFullPaths

### DIFF
--- a/src/Controls/src/Build.Tasks/XamlCTask.cs
+++ b/src/Controls/src/Build.Tasks/XamlCTask.cs
@@ -27,16 +27,25 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 			public IList<int> WarningsNotAsErrors { get; set; }
 			public IList<int> NoWarn { get; set; }
 			public bool HasLoggedError { get; set; }
+			public string PathPrefix { get; set; }
 		}
 
 		static LoggingHelperContext Context { get; set; }
 
-		public static void SetContext(this TaskLoggingHelper loggingHelper, int warningLevel, bool treatWarningsAsErrors, string noWarn, string warningsAsErrors, string warningsNotAsErrors)
+		public static void SetContext(
+			this TaskLoggingHelper loggingHelper,
+			int warningLevel,
+			bool treatWarningsAsErrors,
+			string noWarn,
+			string warningsAsErrors,
+			string warningsNotAsErrors,
+			string pathPrefix)
 		{
 			if (Context == null)
 				Context = new LoggingHelperContext();
 			Context.WarningLevel = warningLevel;
 			Context.TreatWarningsAsErrors = treatWarningsAsErrors;
+			Context.PathPrefix = pathPrefix?.TrimEnd('/');
 
 			Context.NoWarn = noWarn?.Split([';', ','], StringSplitOptions.RemoveEmptyEntries).Select(s =>
 			{
@@ -84,6 +93,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 				Context = new LoggingHelperContext();
 			if (Context.NoWarn != null && Context.NoWarn.Contains(code.CodeCode))
 				return;
+			xamlFilePath = loggingHelper.GetXamlFilePath(xamlFilePath);
 			if ((Context.TreatWarningsAsErrors && (Context.WarningsNotAsErrors == null || !Context.WarningsNotAsErrors.Contains(code.CodeCode)))
 				|| (Context.WarningsAsErrors != null && Context.WarningsAsErrors.Contains(code.CodeCode)))
 			{
@@ -94,6 +104,18 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 			{
 				loggingHelper.LogWarning("XamlC", $"{code.CodePrefix}{code.CodeCode:0000}", code.HelpLink, xamlFilePath, lineNumber, linePosition, endLineNumber, endLinePosition, ErrorMessages.ResourceManager.GetString(code.ErrorMessageKey), messageArgs);
 			}
+		}
+
+		public static string GetXamlFilePath(this TaskLoggingHelper loggingHelper, string xamlFilePath)
+		{
+			Context ??= new LoggingHelperContext();
+
+			if (Context.PathPrefix is string prefix)
+			{
+				xamlFilePath = $"{prefix}/{xamlFilePath}";
+			}
+
+			return xamlFilePath;
 		}
 	}
 
@@ -113,6 +135,8 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 		public string WarningsNotAsErrors { get; set; }
 		public string NoWarn { get; set; }
 
+		public bool GenerateFullPaths { get; set; }
+		public string FullPathPrefix { get; set; }
 
 		public IAssemblyResolver DefaultAssemblyResolver { get; set; }
 
@@ -128,7 +152,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 		public override bool Execute(out IList<Exception> thrownExceptions)
 		{
 			thrownExceptions = null;
-			LoggingHelper.SetContext(WarningLevel, TreatWarningsAsErrors, NoWarn, WarningsAsErrors, WarningsNotAsErrors);
+			LoggingHelper.SetContext(WarningLevel, TreatWarningsAsErrors, NoWarn, WarningsAsErrors, WarningsNotAsErrors, GenerateFullPaths ? FullPathPrefix : null);
 			LoggingHelper.LogMessage(Normal, $"{new string(' ', 0)}Compiling Xaml, assembly: {Assembly}");
 			var skipassembly = !DefaultCompile;
 			bool success = true;
@@ -137,6 +161,11 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 			{
 				LoggingHelper.LogMessage(Normal, $"{new string(' ', 2)}Assembly file not found. Skipping XamlC.");
 				return true;
+			}
+
+			if (GenerateFullPaths && string.IsNullOrEmpty(FullPathPrefix))
+			{
+				LoggingHelper.LogMessage(Low, "  GenerateFullPaths is enabled but FullPathPrefix is missing or empty.");
 			}
 
 			using (var fallbackResolver = DefaultAssemblyResolver == null ? new XamlCAssemblyResolver() : null)
@@ -266,6 +295,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 								success = false;
 								LoggingHelper.LogMessage(Low, $"{new string(' ', 8)}failed.");
 								(thrownExceptions = thrownExceptions ?? new List<Exception>()).Add(e);
+								xamlFilePath = LoggingHelper.GetXamlFilePath(xamlFilePath);
 								if (e is BuildException be)
 									LoggingHelper.LogError("XamlC", be.Code.Code, be.HelpLink, xamlFilePath, be.XmlInfo?.LineNumber ?? 0, be.XmlInfo?.LinePosition ?? 0, 0, 0, ErrorMessages.ResourceManager.GetString(be.Code.ErrorMessageKey), be.MessageArgs);
 								else if (e is XamlParseException xpe) //shouldn't happen anymore

--- a/src/Controls/src/Build.Tasks/XamlCTask.cs
+++ b/src/Controls/src/Build.Tasks/XamlCTask.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 				Context = new LoggingHelperContext();
 			Context.WarningLevel = warningLevel;
 			Context.TreatWarningsAsErrors = treatWarningsAsErrors;
-			Context.PathPrefix = pathPrefix?.TrimEnd('/');
+			Context.PathPrefix = pathPrefix;
 
 			Context.NoWarn = noWarn?.Split([';', ','], StringSplitOptions.RemoveEmptyEntries).Select(s =>
 			{
@@ -112,7 +112,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 
 			if (Context.PathPrefix is string prefix)
 			{
-				xamlFilePath = $"{prefix}/{xamlFilePath}";
+				xamlFilePath = IOPath.Combine(prefix, xamlFilePath);
 			}
 
 			return xamlFilePath;

--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
@@ -154,6 +154,10 @@
 			<MauiStrictXamlCompilation Condition="'$(MauiStrictXamlCompilation)' == '' and ('$(PublishAot)' == 'true' or '$(TrimMode)' == 'full')">true</MauiStrictXamlCompilation>
 			<_MauiXamlCNoWarn>$(NoWarn)</_MauiXamlCNoWarn>
 			<_MauiXamlCNoWarn Condition="'$(MauiStrictXamlCompilation)' != 'true'">$(_MauiXamlCNoWarn);XC0022;XC0023</_MauiXamlCNoWarn>
+
+      <_MauiXamlCGenerateFullPaths Condition="'$(_MauiXamlCGenerateFullPaths)' == '' and '$(GenerateFullPaths)' == 'true'">true</_MauiXamlCGenerateFullPaths>
+      <_MauiXamlCGenerateFullPaths Condition="'$(_MauiXamlCGenerateFullPaths)' == ''">false</_MauiXamlCGenerateFullPaths>
+      <_MauiXamlCFullPathPrefix Condition="'$(_MauiXamlCFullPathPrefix)' == '' and '$(_MauiXamlCGenerateFullPaths)' == 'true'">$(MSBuildProjectDirectory)</_MauiXamlCFullPathPrefix>
 		</PropertyGroup>
 		<XamlCTask
 			Assembly = "$(IntermediateOutputPath)$(TargetFileName)"
@@ -170,7 +174,9 @@
       TreatWarningsAsErrors = "$(TreatWarningsAsErrors)"
       NoWarn = "$(_MauiXamlCNoWarn)"
       WarningsAsErrors = "$(WarningsAsErrors)"
-      WarningsNotAsErrors = "$(WarningsNotAsErrors)" />
+      WarningsNotAsErrors = "$(WarningsNotAsErrors)"
+      GenerateFullPaths = "$(_MauiXamlCGenerateFullPaths)"
+      FullPathPrefix = "$(_MauiXamlCFullPathPrefix)" />
       
 		<Touch Files="$(IntermediateOutputPath)XamlC.stamp" AlwaysCreate="True" />
 		<ItemGroup>


### PR DESCRIPTION
### Description of Change

XamlC always generates relative paths to the files it produces. This doesn't seem to work well together with the VSCode's "$msCompile" problem matcher which expects file paths in the logs to be absolute. This change should help us get correct error and warning messages shown in the VS Code's "Problems" list.

/cc @StephaneDelcroix

