### PR TITLE
[ios/catalyst] fix leak in NavigationPage

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.cs
@@ -303,8 +303,32 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
-		[Fact(DisplayName = "NavigationPage Does Not Leak")]
+		[Fact(DisplayName = "Does Not Leak")]
 		public async Task DoesNotLeak()
+		{
+			SetupBuilder();
+			WeakReference pageReference = null;
+			WeakReference handlerReference = null;
+
+			{
+				var navPage = new NavigationPage(new ContentPage());
+				var window = new Window(navPage);
+
+				await CreateHandlerAndAddToWindow<WindowHandlerStub>(window, (handler) =>
+				{
+					pageReference = new WeakReference(navPage);
+					handlerReference = new WeakReference(handler);
+
+					// Just replace the page with a new one
+					window.Page = new ContentPage();
+				});
+			}
+
+			await AssertionExtensions.WaitForGC(pageReference, handlerReference);
+		}
+
+		[Fact(DisplayName = "Child Pages Do Not Leak")]
+		public async Task ChildPagesDoNotLeak()
 		{
 
 #if ANDROID

--- a/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.cs
@@ -303,7 +303,11 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
-		[Fact(DisplayName = "Does Not Leak")]
+		[Fact(DisplayName = "Does Not Leak"
+#if WINDOWS
+			, Skip = "Failing"
+#endif
+		)]
 		public async Task DoesNotLeak()
 		{
 			SetupBuilder();


### PR DESCRIPTION
Fixes: https://github.com/dotnet/maui/issues/20119

PR #13833 fixed a leak in child pages of a `NavigationPage`, but it appears there are several cycles that would prevent the `NavigationPage` itself from going away.

So, if you did something like this:

    // The original NavigationPage & children leak
    Application.Current.MainPage = new NavigationPage(new Page1());
    Application.Current.MainPage = new Page2();

I could reproduce the same problem in a new device test.

The cycles (and solutions) are:

1. `NavigationPage` -> `NavigationRenderer` -> `ParentingViewController` -> `NavigationPage`

    * Solution: make `_child` a `WeakReference`

2. `NavigationPage` -> `MenuItemTracker` -> `NavigationPage`

    * Solution: make `_target` a `WeakReference`, and `_additionalTargets` a `List<WeakReference>`

3. `NavigationPage` -> `MenuItemTracker.CollectionChanged` -> `NavigationPage`

    * Solution: subscribe/unsubscribe in `WillMoveToParentViewController`

After these changes the sample app works, and the new device test passes.
