### PR TITLE
[Essentials] Add DateTimeOffset overload in Preferences

### DIFF
--- a/src/Essentials/src/Preferences/Preferences.android.cs
+++ b/src/Essentials/src/Preferences/Preferences.android.cs
@@ -84,6 +84,9 @@ namespace Microsoft.Maui.Storage
 							case DateTime dt:
 								editor.PutLong(key, dt.ToBinary());
 								break;
+							case DateTimeOffset dt:
+								editor.PutString(key, dt.ToString("O"));
+								break;
 						}
 					}
 					editor.Apply();
@@ -142,6 +145,13 @@ namespace Microsoft.Maui.Storage
 							case DateTime dt:
 								var encodedValue = sharedPreferences.GetLong(key, dt.ToBinary());
 								value = DateTime.FromBinary(encodedValue);
+								break;
+							case DateTimeOffset dt:
+								var savedDateTimeOffset = sharedPreferences.GetString(key, dt.ToString("O"));
+								if (DateTimeOffset.TryParse(savedDateTimeOffset, out var dateTimeOffset))
+								{
+									value = dateTimeOffset;
+								}
 								break;
 						}
 					}

--- a/src/Essentials/src/Preferences/Preferences.ios.tvos.watchos.macos.cs
+++ b/src/Essentials/src/Preferences/Preferences.ios.tvos.watchos.macos.cs
@@ -85,6 +85,9 @@ namespace Microsoft.Maui.Storage
 							var encodedDateTime = Convert.ToString(dt.ToBinary(), CultureInfo.InvariantCulture);
 							userDefaults.SetString(encodedDateTime, key);
 							break;
+						case DateTimeOffset dt:
+							userDefaults.SetString(dt.ToString("O"), key);
+							break;
 					}
 				}
 			}
@@ -123,6 +126,13 @@ namespace Microsoft.Maui.Storage
 							var savedDateTime = userDefaults.StringForKey(key);
 							var encodedDateTime = Convert.ToInt64(savedDateTime, CultureInfo.InvariantCulture);
 							value = DateTime.FromBinary(encodedDateTime);
+							break;
+						case DateTimeOffset dt:
+							var savedDateTimeOffset = userDefaults.StringForKey(key);
+							if (DateTimeOffset.TryParse(savedDateTimeOffset, out var dateTimeOffset))
+							{
+								value = dateTimeOffset;
+							}
 							break;
 						case string s:
 							// the case when the string is not null

--- a/src/Essentials/src/Preferences/Preferences.shared.cs
+++ b/src/Essentials/src/Preferences/Preferences.shared.cs
@@ -229,6 +229,14 @@ namespace Microsoft.Maui.Storage
 		/// <inheritdoc cref="Set(string, string?)"/>
 		public static void Set(string key, DateTime value) =>
 			Set(key, value, null);
+		
+		/// <inheritdoc cref="Get(string, string?)"/>
+		public static DateTimeOffset Get(string key, DateTimeOffset defaultValue) =>
+			Get(key, defaultValue, null);
+
+		/// <inheritdoc cref="Set(string, string?)"/>
+		public static void Set(string key, DateTimeOffset value) =>
+			Set(key, value, null);
 
 		/// <inheritdoc cref="IPreferences.Get{T}(string, T, string?)"/>
 		public static DateTime Get(string key, DateTime defaultValue, string? sharedName) =>

--- a/src/Essentials/src/Preferences/Preferences.shared.cs
+++ b/src/Essentials/src/Preferences/Preferences.shared.cs
@@ -238,6 +238,14 @@ namespace Microsoft.Maui.Storage
 		public static void Set(string key, DateTime value, string? sharedName) =>
 			Current.Set<DateTime>(key, value, sharedName);
 
+		/// <inheritdoc cref="IPreferences.Get{T}(string, T, string?)"/>
+		public static DateTimeOffset Get(string key, DateTimeOffset defaultValue, string? sharedName) =>
+			Current.Get<DateTimeOffset>(key, defaultValue, sharedName);
+
+		/// <inheritdoc cref="IPreferences.Set{T}(string, T, string?)"/>
+		public static void Set(string key, DateTimeOffset value, string? sharedName) =>
+			Current.Set<DateTimeOffset>(key, value, sharedName);
+
 		static IPreferences Current => Storage.Preferences.Default;
 
 		internal static string GetPrivatePreferencesSharedName(string feature) =>
@@ -263,6 +271,7 @@ namespace Microsoft.Maui.Storage
 			typeof(double),
 			typeof(float),
 			typeof(DateTime),
+			typeof(DateTimeOffset)
 		};
 
 		internal static void CheckIsSupportedType<T>()

--- a/src/Essentials/src/Preferences/Preferences.tizen.cs
+++ b/src/Essentials/src/Preferences/Preferences.tizen.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Maui.Storage
 							var encodedValue = Preference.Get<long>(fullKey);
 							value = (T)(object)DateTime.FromBinary(encodedValue);
 							break;
-						case DateTimOffset dt:
+						case DateTimeOffset dt:
 							var savedDateTimeOffset = Preference.Get<string>(fullKey);
 							if (DateTimeOffset.TryParse(savedDateTimeOffset, out var dateTimeOffset))
 							{

--- a/src/Essentials/src/Preferences/Preferences.tizen.cs
+++ b/src/Essentials/src/Preferences/Preferences.tizen.cs
@@ -58,6 +58,10 @@ namespace Microsoft.Maui.Storage
 				{
 					Preference.Set(fullKey, dt.ToBinary());
 				}
+				else if (value is DateTimeOffset dt)
+				{
+					Preference.Set(fullKey, dt.ToString("O"));
+				}
 				else
 					Preference.Set(fullKey, value);
 			}
@@ -84,6 +88,13 @@ namespace Microsoft.Maui.Storage
 						case DateTime dt:
 							var encodedValue = Preference.Get<long>(fullKey);
 							value = (T)(object)DateTime.FromBinary(encodedValue);
+							break;
+						case DateTimOffset dt:
+							var savedDateTimeOffset = Preference.Get<string>(fullKey);
+							if (DateTimeOffset.TryParse(savedDateTimeOffset, out var dateTimeOffset))
+							{
+								value = (T)(object)dateTimeOffset;
+							}
 							break;
 						default:
 							// the case when the string is null

--- a/src/Essentials/src/Preferences/Preferences.tizen.cs
+++ b/src/Essentials/src/Preferences/Preferences.tizen.cs
@@ -58,9 +58,9 @@ namespace Microsoft.Maui.Storage
 				{
 					Preference.Set(fullKey, dt.ToBinary());
 				}
-				else if (value is DateTimeOffset dt)
+				else if (value is DateTimeOffset dto)
 				{
-					Preference.Set(fullKey, dt.ToString("O"));
+					Preference.Set(fullKey, dto.ToString("O"));
 				}
 				else
 					Preference.Set(fullKey, value);

--- a/src/Essentials/src/Preferences/Preferences.uwp.cs
+++ b/src/Essentials/src/Preferences/Preferences.uwp.cs
@@ -193,6 +193,10 @@ namespace Microsoft.Maui.Storage
 
 			if (value is null)
 				prefs.TryRemove(key, out _);
+			else if (value is DateTime dt)
+				prefs[key] = string.Format(CultureInfo.InvariantCulture, "{0}", dt.ToBinary());
+			else if (value is DateTimeOffset dto)
+				prefs[key] = dto.ToString("O");
 			else
 				prefs[key] = string.Format(CultureInfo.InvariantCulture, "{0}", value);
 
@@ -205,6 +209,19 @@ namespace Microsoft.Maui.Storage
 			{
 				if (inner.TryGetValue(key, out var value) && value is not null)
 				{
+					if (defaultValue is DateTime dt)
+					{
+						long tempValue = (long)Convert.ChangeType(value, typeof(long), CultureInfo.InvariantCulture);
+						return (T)(object)DateTime.FromBinary(tempValue);
+					}
+					else if (defaultValue is DateTimeOffset dto)
+					{
+						if (DateTimeOffset.TryParse((string)value, out var dateTimeOffset))
+						{
+							return (T)(object)dateTimeOffset;
+						}
+					}
+
 					try
 					{
 						return (T)Convert.ChangeType(value, typeof(T), CultureInfo.InvariantCulture);

--- a/src/Essentials/src/Preferences/Preferences.uwp.cs
+++ b/src/Essentials/src/Preferences/Preferences.uwp.cs
@@ -88,6 +88,10 @@ namespace Microsoft.Maui.Storage
 				{
 					appDataContainer.Values[key] = dt.ToBinary();
 				}
+				else if (value is DateTimeOffset dt)
+				{
+					appDataContainer.Values[key] = dt.ToString("O");
+				}
 				else
 				{
 					appDataContainer.Values[key] = value;
@@ -108,6 +112,13 @@ namespace Microsoft.Maui.Storage
 						if (defaultValue is DateTime dt)
 						{
 							return (T)(object)DateTime.FromBinary((long)tempValue);
+						}
+						else if (defaultValue is DateTimeOffset dt)
+						{
+							if (DateTimeOffset.TryParse((string)tempValue, out var dateTimeOffset))
+							{
+								return (T)(object)dateTimeOffset;
+							}
 						}
 						else
 						{

--- a/src/Essentials/src/Preferences/Preferences.uwp.cs
+++ b/src/Essentials/src/Preferences/Preferences.uwp.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Maui.Storage
 				}
 				else if (value is DateTimeOffset dto)
 				{
-					appDataContainer.Values[key] = dt.ToString("O");
+					appDataContainer.Values[key] = dto.ToString("O");
 				}
 				else
 				{

--- a/src/Essentials/src/Preferences/Preferences.uwp.cs
+++ b/src/Essentials/src/Preferences/Preferences.uwp.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Maui.Storage
 				{
 					appDataContainer.Values[key] = dt.ToBinary();
 				}
-				else if (value is DateTimeOffset dt)
+				else if (value is DateTimeOffset dto)
 				{
 					appDataContainer.Values[key] = dt.ToString("O");
 				}
@@ -113,7 +113,7 @@ namespace Microsoft.Maui.Storage
 						{
 							return (T)(object)DateTime.FromBinary((long)tempValue);
 						}
-						else if (defaultValue is DateTimeOffset dt)
+						else if (defaultValue is DateTimeOffset dto)
 						{
 							if (DateTimeOffset.TryParse((string)tempValue, out var dateTimeOffset))
 							{

--- a/src/Essentials/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -56,3 +56,7 @@ static Microsoft.Maui.Devices.Sensors.Geolocation.StopListeningForeground() -> v
 *REMOVED*Microsoft.Maui.Media.IMediaPicker.CaptureVideoAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<Microsoft.Maui.Storage.FileResult!>!
 *REMOVED*Microsoft.Maui.Media.IMediaPicker.PickPhotoAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<Microsoft.Maui.Storage.FileResult!>!
 *REMOVED*Microsoft.Maui.Media.IMediaPicker.PickVideoAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<Microsoft.Maui.Storage.FileResult!>!
+static Microsoft.Maui.Storage.Preferences.Get(string! key, System.DateTimeOffset defaultValue, string? sharedName) -> System.DateTimeOffset
+static Microsoft.Maui.Storage.Preferences.Get(string! key, System.DateTimeOffset defaultValue) -> System.DateTimeOffset
+static Microsoft.Maui.Storage.Preferences.Set(string! key, System.DateTimeOffset value, string? sharedName) -> void
+static Microsoft.Maui.Storage.Preferences.Set(string! key, System.DateTimeOffset value) -> void

--- a/src/Essentials/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -56,3 +56,7 @@ static Microsoft.Maui.Devices.Sensors.Geolocation.StopListeningForeground() -> v
 *REMOVED*Microsoft.Maui.Media.IMediaPicker.CaptureVideoAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<Microsoft.Maui.Storage.FileResult!>!
 *REMOVED*Microsoft.Maui.Media.IMediaPicker.PickPhotoAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<Microsoft.Maui.Storage.FileResult!>!
 *REMOVED*Microsoft.Maui.Media.IMediaPicker.PickVideoAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<Microsoft.Maui.Storage.FileResult!>!
+static Microsoft.Maui.Storage.Preferences.Get(string! key, System.DateTimeOffset defaultValue, string? sharedName) -> System.DateTimeOffset
+static Microsoft.Maui.Storage.Preferences.Get(string! key, System.DateTimeOffset defaultValue) -> System.DateTimeOffset
+static Microsoft.Maui.Storage.Preferences.Set(string! key, System.DateTimeOffset value, string? sharedName) -> void
+static Microsoft.Maui.Storage.Preferences.Set(string! key, System.DateTimeOffset value) -> void

--- a/src/Essentials/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -56,3 +56,7 @@ static Microsoft.Maui.Devices.Sensors.Geolocation.StopListeningForeground() -> v
 *REMOVED*Microsoft.Maui.Media.IMediaPicker.CaptureVideoAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<Microsoft.Maui.Storage.FileResult!>!
 *REMOVED*Microsoft.Maui.Media.IMediaPicker.PickPhotoAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<Microsoft.Maui.Storage.FileResult!>!
 *REMOVED*Microsoft.Maui.Media.IMediaPicker.PickVideoAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<Microsoft.Maui.Storage.FileResult!>!
+static Microsoft.Maui.Storage.Preferences.Get(string! key, System.DateTimeOffset defaultValue, string? sharedName) -> System.DateTimeOffset
+static Microsoft.Maui.Storage.Preferences.Get(string! key, System.DateTimeOffset defaultValue) -> System.DateTimeOffset
+static Microsoft.Maui.Storage.Preferences.Set(string! key, System.DateTimeOffset value, string? sharedName) -> void
+static Microsoft.Maui.Storage.Preferences.Set(string! key, System.DateTimeOffset value) -> void

--- a/src/Essentials/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -56,3 +56,7 @@ static Microsoft.Maui.Devices.Sensors.Geolocation.StopListeningForeground() -> v
 *REMOVED*Microsoft.Maui.Media.IMediaPicker.CaptureVideoAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<Microsoft.Maui.Storage.FileResult!>!
 *REMOVED*Microsoft.Maui.Media.IMediaPicker.PickPhotoAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<Microsoft.Maui.Storage.FileResult!>!
 *REMOVED*Microsoft.Maui.Media.IMediaPicker.PickVideoAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<Microsoft.Maui.Storage.FileResult!>!
+static Microsoft.Maui.Storage.Preferences.Get(string! key, System.DateTimeOffset defaultValue, string? sharedName) -> System.DateTimeOffset
+static Microsoft.Maui.Storage.Preferences.Get(string! key, System.DateTimeOffset defaultValue) -> System.DateTimeOffset
+static Microsoft.Maui.Storage.Preferences.Set(string! key, System.DateTimeOffset value, string? sharedName) -> void
+static Microsoft.Maui.Storage.Preferences.Set(string! key, System.DateTimeOffset value) -> void

--- a/src/Essentials/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -58,3 +58,7 @@ static Microsoft.Maui.Devices.Sensors.Geolocation.StopListeningForeground() -> v
 *REMOVED*Microsoft.Maui.Media.IMediaPicker.CaptureVideoAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<Microsoft.Maui.Storage.FileResult!>!
 *REMOVED*Microsoft.Maui.Media.IMediaPicker.PickPhotoAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<Microsoft.Maui.Storage.FileResult!>!
 *REMOVED*Microsoft.Maui.Media.IMediaPicker.PickVideoAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<Microsoft.Maui.Storage.FileResult!>!
+static Microsoft.Maui.Storage.Preferences.Get(string! key, System.DateTimeOffset defaultValue, string? sharedName) -> System.DateTimeOffset
+static Microsoft.Maui.Storage.Preferences.Get(string! key, System.DateTimeOffset defaultValue) -> System.DateTimeOffset
+static Microsoft.Maui.Storage.Preferences.Set(string! key, System.DateTimeOffset value, string? sharedName) -> void
+static Microsoft.Maui.Storage.Preferences.Set(string! key, System.DateTimeOffset value) -> void

--- a/src/Essentials/src/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -56,3 +56,7 @@ static Microsoft.Maui.Devices.Sensors.Geolocation.StopListeningForeground() -> v
 *REMOVED*Microsoft.Maui.Media.IMediaPicker.CaptureVideoAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<Microsoft.Maui.Storage.FileResult!>!
 *REMOVED*Microsoft.Maui.Media.IMediaPicker.PickPhotoAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<Microsoft.Maui.Storage.FileResult!>!
 *REMOVED*Microsoft.Maui.Media.IMediaPicker.PickVideoAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<Microsoft.Maui.Storage.FileResult!>!
+static Microsoft.Maui.Storage.Preferences.Get(string! key, System.DateTimeOffset defaultValue, string? sharedName) -> System.DateTimeOffset
+static Microsoft.Maui.Storage.Preferences.Get(string! key, System.DateTimeOffset defaultValue) -> System.DateTimeOffset
+static Microsoft.Maui.Storage.Preferences.Set(string! key, System.DateTimeOffset value, string? sharedName) -> void
+static Microsoft.Maui.Storage.Preferences.Set(string! key, System.DateTimeOffset value) -> void

--- a/src/Essentials/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -56,3 +56,7 @@ static Microsoft.Maui.Devices.Sensors.Geolocation.StopListeningForeground() -> v
 *REMOVED*Microsoft.Maui.Media.IMediaPicker.CaptureVideoAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<Microsoft.Maui.Storage.FileResult!>!
 *REMOVED*Microsoft.Maui.Media.IMediaPicker.PickPhotoAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<Microsoft.Maui.Storage.FileResult!>!
 *REMOVED*Microsoft.Maui.Media.IMediaPicker.PickVideoAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<Microsoft.Maui.Storage.FileResult!>!
+static Microsoft.Maui.Storage.Preferences.Get(string! key, System.DateTimeOffset defaultValue, string? sharedName) -> System.DateTimeOffset
+static Microsoft.Maui.Storage.Preferences.Get(string! key, System.DateTimeOffset defaultValue) -> System.DateTimeOffset
+static Microsoft.Maui.Storage.Preferences.Set(string! key, System.DateTimeOffset value, string? sharedName) -> void
+static Microsoft.Maui.Storage.Preferences.Set(string! key, System.DateTimeOffset value) -> void

--- a/src/Essentials/test/DeviceTests/Tests/Preferences_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/Preferences_Tests.cs
@@ -221,11 +221,7 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 			Assert.False(Preferences.ContainsKey("NotContainsKey1", sharedName));
 		}
 
-		[Theory(
-#if WINDOWS
-		Skip = "Fails on Windows unpackaged"
-#endif
-		)]
+		[Theory]
 		[InlineData(null, DateTimeKind.Utc)]
 		[InlineData(sharedNameTestData, DateTimeKind.Utc)]
 		[InlineData(null, DateTimeKind.Local)]
@@ -456,11 +452,7 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 			Assert.False(Preferences.Default.ContainsKey("NotContainsKey1", sharedName));
 		}
 
-		[Theory(
-#if WINDOWS
-		Skip = "Fails on Windows unpackaged"
-#endif
-		)]
+		[Theory]
 		[InlineData(null, DateTimeKind.Utc)]
 		[InlineData(sharedNameTestData, DateTimeKind.Utc)]
 		[InlineData(null, DateTimeKind.Local)]

--- a/src/Essentials/test/DeviceTests/Tests/Preferences_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/Preferences_Tests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Microsoft.Maui.Storage;
 using Xunit;
 
@@ -474,6 +475,28 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 
 			Assert.Equal(date, get);
 			Assert.Equal(kind, get.Kind);
+		}
+
+		public static IEnumerable<object[]> GetDateTimeOffsetData()
+		{
+			yield return [null, TimeSpan.Zero];
+			yield return [sharedNameTestData, TimeSpan.Zero];
+			yield return [null, TimeSpan.FromHours(1)];
+			yield return [sharedNameTestData, TimeSpan.FromHours(1)];
+		}
+
+		[Theory]
+		[MemberData(nameof(GetDateTimeOffsetData))]
+		public void DateTimeOffsetPreservesOffset_NonStatic(string sharedName, TimeSpan offset)
+		{
+			var date = new DateTime(2018, 05, 07, 8, 30, 0);
+			var dateTimeOffset = new DateTimeOffset(date, offset);
+
+			Preferences.Default.Set("datetimeoffset_offset", dateTimeOffset, sharedName);
+
+			var get = Preferences.Default.Get("datetimeoffset_offset", DateTimeOffset.MinValue, sharedName);
+
+			Assert.Equal(offset, get.Offset);
 		}
 		#endregion
 	}


### PR DESCRIPTION
### Description of Change

<!-- Enter description of the fix in this section -->

Adds overload in Preferences to store and retrieve DateTimeOffset.

There is no `ToBinary()` method on `DateTimeOffset` so I am storing it as a    ###string.

~~I have an issue with the roslyn analyzer that checks for PublicAPI, it keeps complaining no matter what I add to either file.~~ ~~

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #22786

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
