### PR TITLE
Reset opacity when view is being reused

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue19955.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue19955.cs
@@ -1,0 +1,25 @@
+﻿using System.Drawing;
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+using OpenQA.Selenium.Interactions;
+using NUnit.Framework.Legacy;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+public class Issue19955: _IssuesUITest
+{
+    public Issue19955(TestDevice device) : base(device) { }
+
+    public override string Issue => "Navigating Back to FlyoutPage Renders Blank Page";
+
+    [Test]
+	[Category(UITestCategories.FlyoutPage)]
+	public void NavigatingBackToFlyoutPageRendersBlankPage()
+    {
+		App.WaitForElement("NavigateToSecondPageButton");
+        App.Tap("NavigateToSecondPageButton");
+        App.WaitForElement("NavigateBackToFirstPageButton");
+        App.Tap("NavigateBackToFirstPageButton");
+		App.WaitForElement("NavigateToSecondPageButton");
+    }
+}

--- a/src/Controls/tests/TestCases/Issues/Issue19955.cs
+++ b/src/Controls/tests/TestCases/Issues/Issue19955.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Diagnostics;
+using Microsoft.Maui.Controls;
+
+namespace Maui.Controls.Sample.Issues
+{
+	[Issue(IssueTracker.Github, 19955, "Navigating Back to FlyoutPage Renders Blank Page")]
+	public class Issue19955 : NavigationPage
+	{
+		public Issue19955() : base(new MainFlyout())
+		{
+
+		}
+
+		public partial class MainFlyout : FlyoutPage
+		{
+			public MainFlyout()
+			{
+				Flyout = new MainFlyoutMenu();
+				Detail = new MarkerNavigationPage();
+			}
+
+			class MarkerNavigationPage : NavigationPage
+			{
+				public MarkerNavigationPage() : base(new FirstPage())
+				{
+				}
+			}	
+			
+			class MarkerNavigationPage2 : NavigationPage
+			{
+				public MarkerNavigationPage2() : base(new FirstPage())
+				{
+				}
+			}
+		}
+
+		public partial class MainFlyoutMenu : ContentPage
+		{
+			public MainFlyoutMenu()
+			{
+				Title = "MainFlyoutMenu";
+				Content = new VerticalStackLayout(){
+					new Label()
+					{
+						Text = "I'm the Flyout Page"
+					}
+				};
+			}
+		}
+
+		public partial class FirstPage : ContentPage
+		{
+			public FirstPage()
+			{
+				Content = new VerticalStackLayout(){
+					new Button(){
+						Text = "Navigate to Second page",
+						Command = new Command(Button_Clicked),
+						AutomationId = "NavigateToSecondPageButton"
+					},
+				};
+			}
+
+			async void Button_Clicked()
+			{
+				await Application.Current.MainPage.Navigation.PushAsync(new SecondPage());
+			}
+		}
+
+		public partial class SecondPage : ContentPage
+		{
+			public SecondPage()
+			{
+				Content = new VerticalStackLayout()
+				{
+					new Button(){
+						Text = "Navigate back to first page",
+						Command = new Command(Button_Clicked),
+						AutomationId = "NavigateBackToFirstPageButton"
+					}	
+				};
+			}
+
+			async void Button_Clicked()
+			{
+				await Application.Current.MainPage.Navigation.PopAsync();
+			}
+		}
+	}
+}

--- a/src/Core/src/Platform/Android/Navigation/NavigationViewFragment.cs
+++ b/src/Core/src/Platform/Android/Navigation/NavigationViewFragment.cs
@@ -58,6 +58,10 @@ namespace Microsoft.Maui.Platform
 					.CurrentPage
 					.ToPlatform(NavigationManager.MauiContext, RequireContext(), inflater, ChildFragmentManager);
 
+			// This shouldn't typically happen, but if a previous animation hasn't finished from a navigation that was interrupted
+			// the opacity of the view will be set to 0. This will reset it to 1.
+			NavigationManager.CurrentPage?.Handler?.UpdateValue(nameof(IView.Opacity));
+
 			_currentView.RemoveFromParent();
 
 			return _currentView;


### PR DESCRIPTION
### Description of Change

The DrawerLayout currently recreates its details view whenever it's navigated back to. In the case where you are nesting a FlyoutPage inside a NavigationPage, this causes a double animation to occur which leaves the opacity of the view set to zero. When android is processing an animation it sets the alpha of a view to zero

<img width="936" alt="image" src="https://github.com/dotnet/maui/assets/5375137/b1d0fb82-c133-4a92-8b0a-3e12c2ac5608">

And then when it's done it sets it back to 1, the problem we're hitting is that the second animation is starting before the first one finishes, so, the second animation thinks it needs to use "0" as the "initial" alpha value.

Ideally, we will fix DrawerLayout to just reuse its view opposed to creating a new one but that's going to take a bit more of an effort, so, this should get us through until that can be reworked.

### Issues Fixed

Fixes #19955

