### PR TITLE
[net9.0] Enable back the failing Shell tests

### DIFF
--- a/src/Controls/tests/Core.UnitTests/NavigationPageLifecycleTests.cs
+++ b/src/Controls/tests/Core.UnitTests/NavigationPageLifecycleTests.cs
@@ -126,33 +126,33 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.Equal(1, pushedPage.DisappearingCount);
 		}
 
-		// [Theory]
-		// [InlineData(false)]
-		// [InlineData(true)]
-		// public async Task RemoveInnerPage(bool useMaui)
-		// {
-		// 	ContentPage initialPage = new ContentPage();
-		// 	ContentPage pushedPage = new ContentPage();
+		[Theory]
+		[InlineData(false)]
+		[InlineData(true)]
+		public async Task RemoveInnerPage(bool useMaui)
+		{
+			ContentPage initialPage = new ContentPage();
+			ContentPage pushedPage = new ContentPage();
 
-		// 	ContentPage initialPageAppearing = null;
-		// 	ContentPage pageDisappeared = null;
+			ContentPage initialPageAppearing = null;
+			ContentPage pageDisappeared = null;
 
-		// 	NavigationPage nav = new TestNavigationPage(useMaui, initialPage);
-		// 	_ = new Window(nav);
-		// 	nav.SendAppearing();
+			NavigationPage nav = new TestNavigationPage(useMaui, initialPage);
+			_ = new Window(nav);
+			nav.SendAppearing();
 
-		// 	var pageToRemove = new ContentPage();
-		// 	await nav.PushAsync(pageToRemove);
-		// 	await nav.PushAsync(pushedPage);
+			var pageToRemove = new ContentPage();
+			await nav.PushAsync(pageToRemove);
+			await nav.PushAsync(pushedPage);
 
 
-		// 	initialPage.Appearing += (__, _)
-		// 		=> throw new XunitException("Appearing Fired Incorrectly");
+			initialPage.Appearing += (__, _)
+				=> throw new XunitException("Appearing Fired Incorrectly");
 
-		// 	pushedPage.Disappearing += (__, _)
-		// 		=> throw new XunitException("Appearing Fired Incorrectly");
+			pushedPage.Disappearing += (__, _)
+				=> throw new XunitException("Appearing Fired Incorrectly");
 
-		// 	nav.Navigation.RemovePage(pageToRemove);
-		// }
+			nav.Navigation.RemovePage(pageToRemove);
+		}
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/ShellLifeCycleTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellLifeCycleTests.cs
@@ -164,35 +164,35 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.True(page.Appearing);
 		}
 
-		// [Fact]
-		// public async Task EnsureOnAppearingFiresForLastPageOnlyAbsoluteRoute()
-		// {
-		// 	Shell shell = new TestShell();
-		// 	LifeCyclePage shellContentPage = new LifeCyclePage();
-		// 	shell.Items.Add(CreateShellItem());
-		// 	shell.Items.Add(CreateShellItem(page: shellContentPage, shellItemRoute: "ShellItemRoute"));
-		// 	await shell.GoToAsync("///ShellItemRoute/LifeCyclePage/LifeCyclePage");
+		[Fact]
+		public async Task EnsureOnAppearingFiresForLastPageOnlyAbsoluteRoute()
+		{
+			Shell shell = new TestShell();
+			LifeCyclePage shellContentPage = new LifeCyclePage();
+			shell.Items.Add(CreateShellItem());
+			shell.Items.Add(CreateShellItem(page: shellContentPage, shellItemRoute: "ShellItemRoute"));
+			await shell.GoToAsync("///ShellItemRoute/LifeCyclePage/LifeCyclePage");
 
-		// 	var page = (LifeCyclePage)shell.GetVisiblePage();
-		// 	var nonVisiblePage = (LifeCyclePage)shell.Navigation.NavigationStack[1];
+			var page = (LifeCyclePage)shell.GetVisiblePage();
+			var nonVisiblePage = (LifeCyclePage)shell.Navigation.NavigationStack[1];
 
-		// 	Assert.False(shellContentPage.Appearing);
-		// 	Assert.False(nonVisiblePage.Appearing);
-		// 	await page.AppearingTask.ConfigureAwait(false);
-		// 	Assert.True(page.Appearing);
-		// }
+			Assert.False(shellContentPage.Appearing);
+			Assert.False(nonVisiblePage.Appearing);
+			await page.AppearingTask.ConfigureAwait(false);
+			Assert.True(page.Appearing);
+		}
 
 
-		// [Fact]
-		// public async Task EnsureOnAppearingFiresForPushedPage()
-		// {
-		// 	Shell shell = new TestShell();
-		// 	shell.Items.Add(CreateShellItem());
-		// 	await shell.Navigation.PushAsync(new LifeCyclePage());
-		// 	var page = (LifeCyclePage)shell.GetVisiblePage();
-		// 	Assert.True(page.Appearing);
-		// 	Assert.True(page.ParentSet);
-		// }
+		[Fact]
+		public async Task EnsureOnAppearingFiresForPushedPage()
+		{
+			Shell shell = new TestShell();
+			shell.Items.Add(CreateShellItem());
+			await shell.Navigation.PushAsync(new LifeCyclePage());
+			var page = (LifeCyclePage)shell.GetVisiblePage();
+			Assert.True(page.Appearing);
+			Assert.True(page.ParentSet);
+		}
 
 		[Fact]
 		public async Task NavigatedFiresAfterContentIsCreatedWhenUsingTemplate()

--- a/src/Controls/tests/Core.UnitTests/ShellNavigatedArgsTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellNavigatedArgsTests.cs
@@ -167,21 +167,21 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 
-		// [Fact]
-		// public async Task RemovePageFromNavigationSetsCorrectNavigationSource()
-		// {
-		// 	Routing.RegisterRoute("pagemiddle", typeof(ContentPage));
-		// 	Routing.RegisterRoute("page", typeof(ContentPage));
-		// 	var shell = new TestShell(
-		// 		CreateShellItem(shellItemRoute: "item")
-		// 	);
+		[Fact]
+		public async Task RemovePageFromNavigationSetsCorrectNavigationSource()
+		{
+			Routing.RegisterRoute("pagemiddle", typeof(ContentPage));
+			Routing.RegisterRoute("page", typeof(ContentPage));
+			var shell = new TestShell(
+				CreateShellItem(shellItemRoute: "item")
+			);
 
-		// 	await shell.GoToAsync("//item/pagemiddle/page");
-		// 	shell.Navigation.RemovePage(shell.Navigation.NavigationStack[1]);
+			await shell.GoToAsync("//item/pagemiddle/page");
+			shell.Navigation.RemovePage(shell.Navigation.NavigationStack[1]);
 
-		// 	await shell.TestNavigationArgs(ShellNavigationSource.Remove,
-		// 		"//item/pagemiddle/page", "//item/page");
-		// }
+			await shell.TestNavigationArgs(ShellNavigationSource.Remove,
+				"//item/pagemiddle/page", "//item/page");
+		}
 
 		[Fact]
 		public async Task RemovePageSetsCorrectNavigationSource()

--- a/src/Controls/tests/Core.UnitTests/ShellNavigatedArgsTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellNavigatedArgsTests.cs
@@ -148,23 +148,23 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 
-		// [Fact]
-		// public async Task InsertPageFromNavigationSetsCorrectNavigationSource()
-		// {
-		// 	Routing.RegisterRoute("pagemiddle", typeof(ContentPage));
-		// 	Routing.RegisterRoute("page", typeof(ContentPage));
-		// 	var shell = new TestShell(
-		// 		CreateShellItem(shellItemRoute: "item")
-		// 	);
+		[Fact]
+		public async Task InsertPageFromNavigationSetsCorrectNavigationSource()
+		{
+			Routing.RegisterRoute("pagemiddle", typeof(ContentPage));
+			Routing.RegisterRoute("page", typeof(ContentPage));
+			var shell = new TestShell(
+				CreateShellItem(shellItemRoute: "item")
+			);
 
-		// 	await shell.GoToAsync("//item/page");
-		// 	ContentPage contentPage = new ContentPage();
-		// 	Routing.SetRoute(contentPage, "pagemiddle");
-		// 	shell.Navigation.InsertPageBefore(contentPage, shell.Navigation.NavigationStack.Last());
+			await shell.GoToAsync("//item/page");
+			ContentPage contentPage = new ContentPage();
+			Routing.SetRoute(contentPage, "pagemiddle");
+			shell.Navigation.InsertPageBefore(contentPage, shell.Navigation.NavigationStack.Last());
 
-		// 	await shell.TestNavigationArgs(ShellNavigationSource.Insert,
-		// 		"//item/page", "//item/pagemiddle/page");
-		// }
+			await shell.TestNavigationArgs(ShellNavigationSource.Insert,
+				"//item/page", "//item/pagemiddle/page");
+		}
 
 
 		// [Fact]

--- a/src/Controls/tests/Core.UnitTests/ShellNavigatedArgsTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellNavigatedArgsTests.cs
@@ -183,22 +183,22 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		// 		"//item/pagemiddle/page", "//item/page");
 		// }
 
-		// [Fact]
-		// public async Task RemovePageSetsCorrectNavigationSource()
-		// {
-		// 	Routing.RegisterRoute("pagemiddle", typeof(ContentPage));
-		// 	Routing.RegisterRoute("page", typeof(ContentPage));
-		// 	var shell = new TestShell(
-		// 		CreateShellItem(shellItemRoute: "item")
-		// 	);
+		[Fact]
+		public async Task RemovePageSetsCorrectNavigationSource()
+		{
+			Routing.RegisterRoute("pagemiddle", typeof(ContentPage));
+			Routing.RegisterRoute("page", typeof(ContentPage));
+			var shell = new TestShell(
+				CreateShellItem(shellItemRoute: "item")
+			);
 
-		// 	await shell.GoToAsync("//item/pagemiddle/page");
-		// 	await shell.GoToAsync("//item/page");
+			await shell.GoToAsync("//item/pagemiddle/page");
+			await shell.GoToAsync("//item/page");
 
 
-		// 	await shell.TestNavigationArgs(ShellNavigationSource.Remove,
-		// 		"//item/pagemiddle/page", "//item/page");
-		// }
+			await shell.TestNavigationArgs(ShellNavigationSource.Remove,
+				"//item/pagemiddle/page", "//item/page");
+		}
 
 		[Fact]
 		public async Task InitialNavigatingArgs()

--- a/src/Controls/tests/Core.UnitTests/ShellNavigatingTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellNavigatingTests.cs
@@ -534,25 +534,25 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.Equal("//animals/monkeys/details", shell.CurrentState.Location.ToString());
 		}
 
-		//[Theory]
-		//[InlineData(true)]
-		//[InlineData(false)]
-		//public async Task GotoSameGlobalRoutesCollapsesUriCorrectly(bool modal)
-		//{
-		//	var shell = new Shell();
-		//	var item1 = CreateShellItem<FlyoutItem>(asImplicit: true, shellItemRoute: "animals", shellContentRoute: "monkeys");
+		[Theory]
+		[InlineData(true)]
+		[InlineData(false)]
+		public async Task GotoSameGlobalRoutesCollapsesUriCorrectly(bool modal)
+		{
+			var shell = new Shell();
+			var item1 = CreateShellItem<FlyoutItem>(asImplicit: true, shellItemRoute: "animals", shellContentRoute: "monkeys");
 
-		//	if (modal)
-		//		Routing.RegisterRoute("details", typeof(ShellModalTests.ModalTestPage));
-		//	else
-		//		Routing.RegisterRoute("details", typeof(ContentPage));
+			if (modal)
+				Routing.RegisterRoute("details", typeof(ShellModalTests.ModalTestPage));
+			else
+				Routing.RegisterRoute("details", typeof(ContentPage));
 
-		//	shell.Items.Add(item1);
+			shell.Items.Add(item1);
 
-		//	await shell.GoToAsync("details");
-		//	await shell.GoToAsync("details");
-		//	Assert.Equal("//animals/monkeys/details/details", shell.CurrentState.Location.ToString());
-		//}
+			await shell.GoToAsync("details");
+			await shell.GoToAsync("details");
+			Assert.Equal("//animals/monkeys/details/details", shell.CurrentState.Location.ToString());
+		}
 
 		[Fact]
 		public async Task ShellSectionWithGlobalRouteAbsolute()

--- a/src/Controls/tests/Core.UnitTests/ShellTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellTests.cs
@@ -1240,28 +1240,27 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.NotNull(item.CurrentItem.CurrentItem);
 		}
 
-		// [Fact]
+		[Fact]
+		public async Task GetCurrentPageInShellNavigation()
+		{
+			Shell shell = new TestShell();
+			var item1 = CreateShellItem(asImplicit: true, shellContentRoute: "rootlevelcontent1");
 
-		// public async Task GetCurrentPageInShellNavigation()
-		// {
-		// 	Shell shell = new TestShell();
-		// 	var item1 = CreateShellItem(asImplicit: true, shellContentRoute: "rootlevelcontent1");
+			shell.Items.Add(item1);
+			Routing.RegisterRoute("cat", typeof(ContentPage));
 
-		// 	shell.Items.Add(item1);
-		// 	Routing.RegisterRoute("cat", typeof(ContentPage));
+			Page page = null;
 
-		// 	Page page = null;
+			shell.Navigated += (_, __) =>
+			{
+				page = shell.CurrentPage;
+			};
 
-		// 	shell.Navigated += (_, __) =>
-		// 	{
-		// 		page = shell.CurrentPage;
-		// 	};
-
-		// 	await shell.GoToAsync("cat");
-		// 	Assert.NotNull(page);
-		// 	Assert.IsType<ContentPage>(page);
-		// 	Assert.Equal(shell.Navigation.NavigationStack[1], page);
-		// }
+			await shell.GoToAsync("cat");
+			Assert.NotNull(page);
+			Assert.IsType<ContentPage>(page);
+			Assert.Equal(shell.Navigation.NavigationStack[1], page);
+		}
 
 		[Fact]
 		public async Task GetCurrentPageBetweenSections()


### PR DESCRIPTION
### Description of Change

When merging[ main to net9.0](https://github.com/dotnet/maui/pull/22712/)  we got some failures that we disabled to get the branch merged with latest changes. 

More tests comment out here https://github.com/dotnet/maui/pull/24905

This pr enables back these tests. 