### PR TITLE
Update maui-blazor template default name

### DIFF
--- a/src/Templates/src/templates/maui-blazor/.template.config/template.json
+++ b/src/Templates/src/templates/maui-blazor/.template.config/template.json
@@ -125,5 +125,5 @@
         "replaces": "com.companyname.mauiapp"
       }
     },
-    "defaultName": "MauiApp1"
+    "defaultName": "MauiBlazorApp1"
   }


### PR DESCRIPTION
### Description of Change

Updated the maui-blazor template defaultName from "MauiApp1" to "MauiBlazorApp1"

### Issues Fixed

Fixes [Azure DevOps Bug 2016668](https://dev.azure.com/devdiv/DevDiv/_workitems/edit/2016668)