### PR TITLE
[tests] fix F5 for Windows device tests

### DIFF
--- a/src/Core/tests/DeviceTests.Shared/Core.DeviceTests.Shared.csproj
+++ b/src/Core/tests/DeviceTests.Shared/Core.DeviceTests.Shared.csproj
@@ -8,6 +8,7 @@
     <!--<Nullable>enable</Nullable>-->
     <NoWarn>$(NoWarn),CA1416</NoWarn>
     <ExcludeMicrosoftNetTestSdk>true</ExcludeMicrosoftNetTestSdk>
+    <DisableArcadeTestFramework>true</DisableArcadeTestFramework>
   </PropertyGroup>
 
   <Import Project="$(MauiSrcDirectory)MultiTargeting.targets" />

--- a/src/Microsoft.Maui.TestUtils.DeviceTests.Runners.targets
+++ b/src/Microsoft.Maui.TestUtils.DeviceTests.Runners.targets
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+  <PropertyGroup>
+    <DisableArcadeTestFramework>true</DisableArcadeTestFramework>
+  </PropertyGroup>
+
   <ItemGroup>
     <CompilerVisibleProperty Include="RootNamespace" />
     <CompilerVisibleProperty Include="ApplicationId" />

--- a/src/TestUtils/src/DeviceTests.Runners/TestUtils.DeviceTests.Runners.csproj
+++ b/src/TestUtils/src/DeviceTests.Runners/TestUtils.DeviceTests.Runners.csproj
@@ -9,6 +9,7 @@
     <NoWarn>$(NoWarn);CA1416</NoWarn>
     <WarningsNotAsErrors>$(WarningsNotAsErrors);XC0022;XC0023</WarningsNotAsErrors>
     <ExcludeMicrosoftNetTestSdk>true</ExcludeMicrosoftNetTestSdk>
+    <DisableArcadeTestFramework>true</DisableArcadeTestFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/TestUtils/src/DeviceTests/TestUtils.DeviceTests.csproj
+++ b/src/TestUtils/src/DeviceTests/TestUtils.DeviceTests.csproj
@@ -8,6 +8,7 @@
     <AssemblyName>Microsoft.Maui.TestUtils.DeviceTests</AssemblyName>
     <Nullable>enable</Nullable>
     <ExcludeMicrosoftNetTestSdk>true</ExcludeMicrosoftNetTestSdk>
+    <DisableArcadeTestFramework>true</DisableArcadeTestFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
If you try to F5 the Windows device tests, you'll get an error:

    Error (active) APPX1101 Payload contains two or more files with the same destination path 'xunit.runner.utility.netcoreapp10.dll'. Source files:
    ...\Microsoft.Maui.Cache\NuGet\packages\xunit.runner.visualstudio\2.8.0\build\net6.0\xunit.runner.utility.netcoreapp10.dll
    ...\Microsoft.Maui.Cache\NuGet\packages\xunit.runner.utility\2.6.6\lib\netcoreapp1.0\xunit.runner.utility.netcoreapp10.dll	Controls.DeviceTests (net8.0-windows10.0.19041.0)
    ...\Microsoft.Maui.Cache\NuGet\packages\microsoft.windowsappsdk\1.5.240311000\buildTransitive\Microsoft.Build.Msix.Packaging.targets

This is due to dotnet/arcade using:

https://github.com/dotnet/arcade/blob/2c08708d18855f2e2779ac5d0623a5978751c4f3/src/Microsoft.DotNet.Arcade.Sdk/tools/XUnit/XUnit.targets#L13

For now, let's set `$(DisableArcadeTestFramework)` and it won't import `XUnit.targets` from arcade.

After these changes, I can F5 again.