### PR TITLE
[X] allow namescope resolution before parenting

### DIFF
--- a/src/Controls/src/Build.Tasks/SetNamescopesAndRegisterNamesVisitor.cs
+++ b/src/Controls/src/Build.Tasks/SetNamescopesAndRegisterNamesVisitor.cs
@@ -59,6 +59,18 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 			}
 			if (setNameScope && Context.Variables[node].VariableType.InheritsFromOrImplements(Context.Cache, Context.Body.Method.Module.ImportReference(Context.Cache, ("Microsoft.Maui.Controls", "Microsoft.Maui.Controls", "BindableObject"))))
 				SetNameScope(node, namescopeVarDef);
+			//workaround when VSM tries to apply state before parenting
+			else if (Context.Variables[node].VariableType.InheritsFromOrImplements(Context.Cache, Context.Body.Method.Module.ImportReference(Context.Cache, ("Microsoft.Maui.Controls", "Microsoft.Maui.Controls", "Element"))))
+			{
+				var module = Context.Body.Method.Module;
+				var parameterTypes = new[] {
+					("Microsoft.Maui.Controls", "Microsoft.Maui.Controls", "Element"),
+					("Microsoft.Maui.Controls", "Microsoft.Maui.Controls.Internals", "INameScope"),
+				};
+				Context.IL.Append(Context.Variables[node].LoadAs(Context.Cache, module.GetTypeDefinition(Context.Cache, parameterTypes[0]), module));
+				Context.IL.Append(namescopeVarDef.LoadAs(Context.Cache, module.GetTypeDefinition(Context.Cache, parameterTypes[1]), module));
+				Context.IL.Emit(OpCodes.Stfld, module.ImportFieldReference(Context.Cache, parameterTypes[0], nameof(Element.transientNamescope)));
+			}
 			Context.Scopes[node] = new Tuple<VariableDefinition, IList<string>>(namescopeVarDef, namesInNamescope);
 		}
 

--- a/src/Controls/src/Core/Element/Element.cs
+++ b/src/Controls/src/Core/Element/Element.cs
@@ -502,13 +502,15 @@ namespace Microsoft.Maui.Controls
 			return false;
 		}
 
+		internal INameScope transientNamescope;
+
 		/// <summary>Returns the element that has the specified name.</summary>
 		/// <param name="name">The name of the element to be found.</param>
 		/// <returns>The element that has the specified name.</returns>
 		/// <exception cref="InvalidOperationException">Thrown if the element's namescope couldn't be found.</exception>
 		public object FindByName(string name)
 		{
-			var namescope = GetNameScope();
+			var namescope = GetNameScope() ?? transientNamescope;
 			if (namescope == null)
 				throw new InvalidOperationException("this element is not in a namescope");
 			return namescope.FindByName(name);

--- a/src/Controls/src/Core/Element/Element.cs
+++ b/src/Controls/src/Core/Element/Element.cs
@@ -502,7 +502,11 @@ namespace Microsoft.Maui.Controls
 			return false;
 		}
 
-		internal INameScope transientNamescope;
+		//this is only used by XAMLC, not added to public API
+		[EditorBrowsable(EditorBrowsableState.Never)]
+#pragma warning disable RS0016 // Add public types and members to the declared API
+		public INameScope transientNamescope;
+#pragma warning restore RS0016 // Add public types and members to the declared API
 
 		/// <summary>Returns the element that has the specified name.</summary>
 		/// <param name="name">The name of the element to be found.</param>

--- a/src/Controls/src/Xaml/CreateValuesVisitor.cs
+++ b/src/Controls/src/Xaml/CreateValuesVisitor.cs
@@ -152,6 +152,11 @@ namespace Microsoft.Maui.Controls.Xaml
 			if (value is BindableObject bindableValue && node.NameScopeRef != (parentNode as IElementNode)?.NameScopeRef)
 				NameScope.SetNameScope(bindableValue, node.NameScopeRef.NameScope);
 
+			//Workaround for when a VSM is applied before parenting
+			if (value is Element iElement)
+				iElement.transientNamescope = node.NameScopeRef.NameScope;
+
+
 			var assemblyName = (Context.RootAssembly ?? Context.RootElement?.GetType().Assembly)?.GetName().Name;
 			if (assemblyName != null && value != null && !value.GetType().IsValueType && XamlFilePathAttribute.GetFilePathForObject(Context.RootElement) is string path)
 				VisualDiagnostics.RegisterSourceInfo(value, new Uri($"{path};assembly={assemblyName}", UriKind.Relative), ((IXmlLineInfo)node).LineNumber, ((IXmlLineInfo)node).LinePosition);

--- a/src/Controls/tests/Xaml.UnitTests/Controls.Xaml.UnitTests.csproj
+++ b/src/Controls/tests/Xaml.UnitTests/Controls.Xaml.UnitTests.csproj
@@ -49,6 +49,7 @@
     <Compile Include="..\Core.UnitTests\MockMauiContext.cs" />
     <Compile Include="..\Core.UnitTests\MockServiceProvider.cs" />
     <Compile Include="..\Core.UnitTests\MockFontManager.cs" />
+    <Compile Include="..\Core.UnitTests\MockDeviceDisplay.cs" />
   </ItemGroup>
 
   <Import Project="$(MauiSrcDirectory)Maui.InTree.props" Condition=" '$(UseMaui)' != 'true' " />

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui16208.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui16208.xaml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                    x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui16208">
+    <HorizontalStackLayout x:Name="ItemHorizontalStack" HorizontalOptions="Center" VerticalOptions="Center" Padding="20">
+          <Label  x:Name="ItemLabel"
+                      Text="This is the label inside"
+                      FontSize="18" />
+          <VisualStateManager.VisualStateGroups>
+              <VisualStateGroupList>
+                  <VisualStateGroup x:Name="CommonStates">
+                      <VisualState x:Name="Normal">
+                          <VisualState.Setters>
+                              <Setter Property="BackgroundColor" Value="Red" />
+                              <Setter TargetName="ItemLabel" Property="Label.BackgroundColor" Value="Green" />
+                          </VisualState.Setters>
+                      </VisualState>
+  
+                      <VisualState x:Name="PointerOver">
+                          <VisualState.Setters>
+                              <Setter Property="BackgroundColor" Value="Yellow" />
+                              <Setter TargetName="ItemLabel" Property="Label.BackgroundColor" Value="Black" />
+                          </VisualState.Setters>
+                      </VisualState>
+                  </VisualStateGroup>
+              </VisualStateGroupList>
+          </VisualStateManager.VisualStateGroups>
+    </HorizontalStackLayout>
+
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui16208.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui16208.xaml.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Maui.ApplicationModel;
+using Microsoft.Maui.Controls.Core.UnitTests;
+using Microsoft.Maui.Controls.Shapes;
+using Microsoft.Maui.Devices;
+using Microsoft.Maui.Dispatching;
+
+using Microsoft.Maui.Graphics;
+using Microsoft.Maui.UnitTests;
+using NUnit.Framework;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public partial class Maui16208
+{
+    public Maui16208()
+    {
+        InitializeComponent();
+    }
+
+    public Maui16208(bool useCompiledXaml)
+    {
+        //this stub will be replaced at compile time
+    }
+
+    [TestFixture]
+    class Test
+    {		
+		MockDeviceInfo mockDeviceInfo;
+        [SetUp]
+        public void Setup()
+        {
+            Application.SetCurrentApplication(new MockApplication());
+            DispatcherProvider.SetCurrent(new DispatcherProviderStub());
+
+			DeviceInfo.SetCurrent(mockDeviceInfo = new MockDeviceInfo());
+        }
+
+        [TearDown] public void TearDown()
+        {
+            AppInfo.SetCurrent(null);
+            mockDeviceInfo = null;
+        }
+
+        [Test]
+        public void SetterAndTargetName([Values(false, true)] bool useCompiledXaml)        
+        {
+            
+            Assert.DoesNotThrow(() => new Maui16208(useCompiledXaml));
+            var page = new Maui16208(useCompiledXaml);
+            Assert.That(page!.ItemLabel.BackgroundColor, Is.EqualTo(Colors.Green));
+        }
+    }
+}

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui22001.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui22001.xaml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                    x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui22001">
+
+    <Grid>
+    <VisualStateManager.VisualStateGroups>
+            <VisualStateGroupList>
+                <VisualStateGroup>
+                    <VisualState x:Name="Portrait">
+                        <VisualState.StateTriggers>
+                            <OrientationStateTrigger Orientation="Portrait" />
+                        </VisualState.StateTriggers>
+                        <VisualState.Setters>
+                            <Setter Property="Grid.IsVisible" TargetName="_firstGrid" Value="true"/>
+                            <Setter Property="Grid.IsVisible" TargetName="_secondGrid" Value="false"/>
+                        </VisualState.Setters>
+                    </VisualState>
+                    <VisualState x:Name="Landscape">
+                        <VisualState.StateTriggers>
+                            <OrientationStateTrigger Orientation="Landscape" />
+                        </VisualState.StateTriggers>
+                        <VisualState.Setters>
+                            <Setter Property="Grid.IsVisible" TargetName="_firstGrid" Value="false"/>
+                            <Setter Property="Grid.IsVisible" TargetName="_secondGrid" Value="true"/>
+                        </VisualState.Setters>
+                    </VisualState>
+                </VisualStateGroup>
+            </VisualStateGroupList>
+        </VisualStateManager.VisualStateGroups>
+        <Grid x:Name="_firstGrid" HeightRequest="200" BackgroundColor="Yellow" />
+        <Grid x:Name="_secondGrid" HeightRequest="200" BackgroundColor="Red"/>
+    </Grid>                 
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui22001.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui22001.xaml.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Maui.ApplicationModel;
+using Microsoft.Maui.Controls.Core.UnitTests;
+using Microsoft.Maui.Controls.Shapes;
+using Microsoft.Maui.Devices;
+using Microsoft.Maui.Dispatching;
+
+using Microsoft.Maui.Graphics;
+using Microsoft.Maui.UnitTests;
+using NUnit.Framework;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public partial class Maui22001
+{
+    public Maui22001()
+    {
+        InitializeComponent();
+    }
+
+    public Maui22001(bool useCompiledXaml)
+    {
+        //this stub will be replaced at compile time
+    }
+
+    [TestFixture]
+    class Test
+    {		
+        MockDeviceDisplay mockDeviceDisplay;
+		MockDeviceInfo mockDeviceInfo;
+        [SetUp]
+        public void Setup()
+        {
+            Application.SetCurrentApplication(new MockApplication());
+            DispatcherProvider.SetCurrent(new DispatcherProviderStub());
+            			
+            DeviceDisplay.SetCurrent(mockDeviceDisplay = new MockDeviceDisplay());
+			DeviceInfo.SetCurrent(mockDeviceInfo = new MockDeviceInfo());
+        }
+
+        [TearDown] public void TearDown()
+        {
+            AppInfo.SetCurrent(null);
+            mockDeviceDisplay = null;
+            mockDeviceInfo = null;
+        }
+
+        [Test]
+        public void StateTriggerTargetName([Values(false, true)] bool useCompiledXaml)        
+        {
+            var page = new Maui22001(useCompiledXaml);
+            
+            IWindow window = new Window
+			{
+				Page = page
+			};
+            Assert.That(page._firstGrid.IsVisible, Is.True);
+            Assert.That(page._secondGrid.IsVisible, Is.False);
+
+            mockDeviceDisplay.SetMainDisplayOrientation(DisplayOrientation.Landscape);
+            Assert.That(page._firstGrid.IsVisible, Is.False);
+            Assert.That(page._secondGrid.IsVisible, Is.True);
+        }
+    }
+}


### PR DESCRIPTION
### Description of Change

when an element doesn't override the NameScope (DataTemplate, etc...) FindName fails until the element is parented.

this PR sets a field (less expensive than a BP) used only during that time, and allow VSM to be applied.

### Issues Fixed

- fixes #16208
- fixes #22001

