### PR TITLE
[tests] Try a newer xunit

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -117,10 +117,10 @@
   </PropertyGroup>
   <PropertyGroup>
     <MicrosoftNETTestSdkPackageVersion>17.6.0</MicrosoftNETTestSdkPackageVersion>
-    <XunitPackageVersion>2.7.1</XunitPackageVersion>
+    <XunitPackageVersion>2.8.0</XunitPackageVersion>
     <XunitRunnerVisualStudioPackageVersion>2.8.0</XunitRunnerVisualStudioPackageVersion>
-    <XunitExtensibilityExecutionPackageVersion>2.7.1</XunitExtensibilityExecutionPackageVersion>
-    <XunitAssertPackageVersion>2.7.1</XunitAssertPackageVersion>
+    <XunitExtensibilityExecutionPackageVersion>2.8.0</XunitExtensibilityExecutionPackageVersion>
+    <XunitAssertPackageVersion>2.8.0</XunitAssertPackageVersion>
     <XUnitAnalyzersPackageVersion>1.13.0</XUnitAnalyzersPackageVersion>
     <XunitAbstractionsPackageVersion>2.0.3</XunitAbstractionsPackageVersion>
     <NSubstitutePackageVersion>5.1.0</NSubstitutePackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -117,10 +117,10 @@
   </PropertyGroup>
   <PropertyGroup>
     <MicrosoftNETTestSdkPackageVersion>17.6.0</MicrosoftNETTestSdkPackageVersion>
-    <XunitPackageVersion>2.6.6</XunitPackageVersion>
+    <XunitPackageVersion>2.7.1</XunitPackageVersion>
     <XunitRunnerVisualStudioPackageVersion>2.8.0</XunitRunnerVisualStudioPackageVersion>
-    <XunitExtensibilityExecutionPackageVersion>2.6.6</XunitExtensibilityExecutionPackageVersion>
-    <XunitAssertPackageVersion>2.6.6</XunitAssertPackageVersion>
+    <XunitExtensibilityExecutionPackageVersion>2.7.1</XunitExtensibilityExecutionPackageVersion>
+    <XunitAssertPackageVersion>2.7.1</XunitAssertPackageVersion>
     <XUnitAnalyzersPackageVersion>1.13.0</XUnitAnalyzersPackageVersion>
     <XunitAbstractionsPackageVersion>2.0.3</XunitAbstractionsPackageVersion>
     <NSubstitutePackageVersion>5.1.0</NSubstitutePackageVersion>


### PR DESCRIPTION
XUnit 2.8.0 seemed to have issues in CI for us around GC related tests.

We dropped down to an older 2.6.6 version which helped.  In testing newer versions (eg: 2.7.1) we hit some errors while running in the IDE which were fixed in #22835

Now trying a slightly newer version of Xunit again to see where we stand.

