### PR TITLE
[iOS] Fix setting the CurrentItem on CarouselView load 

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/CarouselViewHandler.iOS.cs
+++ b/src/Controls/src/Core/Handlers/Items/CarouselViewHandler.iOS.cs
@@ -58,7 +58,12 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		public static void MapPosition(CarouselViewHandler handler, CarouselView carouselView)
 		{
-			(handler.Controller as CarouselViewController)?.UpdateFromPosition();
+			// If the initial position hasn't been set, we have a UpdateInitialPosition call on CarouselViewController
+			// that will handle this so we want to skip this mapper call. We need to wait for the CollectionView to be ready
+			if(handler.Controller is CarouselViewController  carouselViewController && carouselViewController.InitialPositionSet)
+			{
+				carouselViewController.UpdateFromPosition();
+			}
 		}
 
 		public static void MapLoop(CarouselViewHandler handler, CarouselView carouselView)

--- a/src/Controls/src/Core/Handlers/Items/iOS/CarouselViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/CarouselViewController.cs
@@ -73,9 +73,18 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		public override nint GetItemsCount(UICollectionView collectionView, nint section) => LoopItemsSource.LoopCount;
 
+		void InitializeCarouselViewLoopManager()
+		{
+			if (_carouselViewLoopManager is null)
+			{
+				_carouselViewLoopManager = new CarouselViewLoopManager(Layout as UICollectionViewFlowLayout);
+				_carouselViewLoopManager.SetItemsSource(LoopItemsSource);
+			}
+		}
+
 		public override void ViewDidLoad()
 		{
-			_carouselViewLoopManager = new CarouselViewLoopManager(Layout as UICollectionViewFlowLayout);
+			InitializeCarouselViewLoopManager();
 			base.ViewDidLoad();
 		}
 
@@ -214,11 +223,14 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			
 			_carouselViewLoopManager?.Dispose();
 			_carouselViewLoopManager = null;
+			InitialPositionSet = false;
 
 		}
 
 		void Setup(CarouselView carouselView)
 		{
+			InitializeCarouselViewLoopManager();
+						
 			_oldViews = new List<View>();
 			
 			carouselView.Scrolled += CarouselViewScrolled;

--- a/src/Controls/src/Core/Handlers/Items/iOS/CarouselViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/CarouselViewController.cs
@@ -5,32 +5,35 @@ using System.Collections.Specialized;
 using System.Diagnostics.CodeAnalysis;
 using CoreGraphics;
 using Foundation;
+using Microsoft.Maui.Devices;
 using ObjCRuntime;
 using UIKit;
 
 namespace Microsoft.Maui.Controls.Handlers.Items
 {
-	public class CarouselViewController : ItemsViewController<CarouselView>
+	public class CarouselViewController : ItemsViewController<CarouselView>, MauiCollectionView.ICustomMauiCollectionViewDelegate
 	{
 		[Obsolete("Use ItemsView property instead")]
 		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = "Unused")]
 		protected readonly CarouselView Carousel;
 
 		CarouselViewLoopManager _carouselViewLoopManager;
-		bool _initialPositionSet;
-		bool _updatingScrollOffset;
+		bool _isCenteringItem;
+
+		// We need to keep track of the old views to update the visual states
+		// if this is null we are not attached to the window
 		List<View> _oldViews;
 		int _gotoPosition = -1;
 		CGSize _size;
 		ILoopItemsViewSource LoopItemsSource => ItemsSource as ILoopItemsViewSource;
 		bool _isDragging;
 
+		bool _isRotating;
+
 		public CarouselViewController(CarouselView itemsView, ItemsViewLayout layout) : base(itemsView, layout)
 		{
 			CollectionView.AllowsSelection = false;
 			CollectionView.AllowsMultipleSelection = false;
-			itemsView.Scrolled += CarouselViewScrolled;
-			_oldViews = new List<View>();
 		}
 
 		public override UICollectionViewCell GetCell(UICollectionView collectionView, NSIndexPath indexPath)
@@ -44,10 +47,14 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				var correctedIndexPath = NSIndexPath.FromRowSection(cellAndCorrectedIndex.correctedIndex, 0);
 
 				if (cell is DefaultCell defaultCell)
+				{
 					UpdateDefaultCell(defaultCell, correctedIndexPath);
+				}
 
 				if (cell is TemplatedCell templatedCell)
+				{
 					UpdateTemplatedCell(templatedCell, correctedIndexPath);
+				}
 			}
 			else
 			{
@@ -57,7 +64,9 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			var element = (cell as TemplatedCell)?.PlatformHandler?.VirtualView as VisualElement;
 
 			if (element != null)
+			{
 				VisualStateManager.GoToState(element, CarouselView.DefaultItemVisualState);
+			}
 
 			return cell;
 		}
@@ -68,6 +77,28 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		{
 			_carouselViewLoopManager = new CarouselViewLoopManager(Layout as UICollectionViewFlowLayout);
 			base.ViewDidLoad();
+
+			if(CollectionView is MauiCollectionView mauiCollectionView)
+			{
+				mauiCollectionView.SetCustomDelegate(this);
+			}
+		}
+
+		void MauiCollectionView.ICustomMauiCollectionViewDelegate.MovedToWindow(UIView view)
+		{
+			if (view?.Window is not null)
+			{
+				DeviceDisplay.MainDisplayInfoChanged += OnDisplayInfoChanged;
+			}
+			else
+			{
+				DeviceDisplay.MainDisplayInfoChanged -= OnDisplayInfoChanged;
+			}
+		}
+
+		void OnDisplayInfoChanged(object sender, DisplayInfoChangedEventArgs e)
+		{
+			_isRotating = true;
 		}
 
 		public override void ViewWillLayoutSubviews()
@@ -82,9 +113,9 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 			if (ItemsView?.Loop == true && _carouselViewLoopManager != null)
 			{
-				_updatingScrollOffset = true;
+				_isCenteringItem = true;
 				_carouselViewLoopManager.CenterIfNeeded(CollectionView, IsHorizontal);
-				_updatingScrollOffset = false;
+				_isCenteringItem = false;
 			}
 
 			if (CollectionView.Bounds.Size != _size)
@@ -96,6 +127,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			{
 				UpdateInitialPosition();
 			}
+			_isRotating = false;
 		}
 
 		void BoundsSizeChanged()
@@ -126,14 +158,11 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			//we don't need to Subscribe because base calls CreateItemsViewSource
 			_carouselViewLoopManager?.SetItemsSource(LoopItemsSource);
 
-			if (_initialPositionSet && ItemsView is CarouselView carousel)
+			if (InitialPositionSet && ItemsView is CarouselView carousel)
 			{
 				carousel.SetValueFromRenderer(CarouselView.CurrentItemProperty, null);
 				carousel.SetValueFromRenderer(CarouselView.PositionProperty, 0);
 			}
-
-			_initialPositionSet = false;
-			UpdateInitialPosition();
 		}
 
 		protected override bool IsHorizontal => ItemsView?.ItemsLayout?.Orientation == ItemsLayoutOrientation.Horizontal;
@@ -144,7 +173,9 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		protected override string DetermineCellReuseId()
 		{
 			if (ItemsView?.ItemTemplate != null)
+			{
 				return CarouselTemplatedCell.ReuseId;
+			}
 
 			return base.DetermineCellReuseId();
 		}
@@ -175,25 +206,56 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			base.CacheCellAttributes(NSIndexPath.FromItemSection(itemIndex, 0), size);
 		}
 
-		internal void TearDown()
+		private protected override void AttachingToWindow()
 		{
-			if (ItemsView is CarouselView carousel)
-				carousel.Scrolled -= CarouselViewScrolled;
+			base.AttachingToWindow();
+			Setup(ItemsView);
+		}
+
+		private protected override void DetachingFromWindow()
+		{
+			base.DetachingFromWindow();
+			TearDown(ItemsView);
+		}
+
+		internal bool InitialPositionSet { get; private set; }
+
+		void TearDown(CarouselView carouselView)
+		{
+			_oldViews = null;
+
+			carouselView.Scrolled -= CarouselViewScrolled;
+
 			UnsubscribeCollectionItemsSourceChanged(ItemsSource);
+			
 			_carouselViewLoopManager?.Dispose();
 			_carouselViewLoopManager = null;
+
+		}
+
+		void Setup(CarouselView carouselView)
+		{
+			_oldViews = new List<View>();
+			
+			carouselView.Scrolled += CarouselViewScrolled;
+
+			SubscribeCollectionItemsSourceChanged(ItemsSource);
 		}
 
 		internal void UpdateIsScrolling(bool isScrolling)
 		{
 			if (ItemsView is CarouselView carousel)
+			{
 				carousel.IsScrolling = isScrolling;
+			}
 		}
 
 		internal NSIndexPath GetScrollToIndexPath(int position)
 		{
 			if (ItemsView?.Loop == true && _carouselViewLoopManager != null)
+			{
 				return _carouselViewLoopManager.GetGoToIndex(CollectionView, position);
+			}
 
 			return NSIndexPath.FromItemSection(position, 0);
 		}
@@ -201,7 +263,9 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		internal int GetIndexFromIndexPath(NSIndexPath indexPath)
 		{
 			if (ItemsView?.Loop == true && _carouselViewLoopManager != null)
+			{
 				return _carouselViewLoopManager.GetCorrectedIndexFromIndexPath(indexPath);
+			}
 
 			return indexPath.Row;
 		}
@@ -209,10 +273,21 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		[UnconditionalSuppressMessage("Memory", "MEM0003", Justification = "Proven safe in test: MemoryTests.HandlerDoesNotLeak")]
 		void CarouselViewScrolled(object sender, ItemsViewScrolledEventArgs e)
 		{
-			if (_updatingScrollOffset)
+			// If we are trying to center the item when Loop is enabled we don't want to update the position
+			if (_isCenteringItem)
+			{
 				return;
+			}
 
+			// If we are dragging the carousel we don't want to update the position
+			// We will do it when the dragging ends
 			if (_isDragging)
+			{
+				return;
+			}
+
+			// If we are rotating the device we don't want to update the position
+			if (_isRotating)
 			{
 				return;
 			}
@@ -228,7 +303,9 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		void CollectionViewUpdating(object sender, NotifyCollectionChangedEventArgs e)
 		{
 			if (ItemsView is not CarouselView carousel)
+			{
 				return;
+			}
 
 			int carouselPosition = carousel.Position;
 			_positionAfterUpdate = carouselPosition;
@@ -236,13 +313,19 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			var count = ItemsSource.ItemCount;
 
 			if (e.Action == NotifyCollectionChangedAction.Remove)
+			{
 				_positionAfterUpdate = GetPositionWhenRemovingItems(e.OldStartingIndex, carouselPosition, currentItemPosition, count);
+			}
 
 			if (e.Action == NotifyCollectionChangedAction.Reset)
+			{
 				_positionAfterUpdate = GetPositionWhenResetItems();
+			}
 
 			if (e.Action == NotifyCollectionChangedAction.Add)
+			{
 				_positionAfterUpdate = GetPositionWhenAddingItems(carouselPosition, currentItemPosition);
+			}
 		}
 
 		[UnconditionalSuppressMessage("Memory", "MEM0003", Justification = "Proven safe in test: MemoryTests.HandlerDoesNotLeak")]
@@ -319,12 +402,16 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		internal void UpdateLoop()
 		{
 			if (ItemsView is not CarouselView carousel)
+			{
 				return;
+			}
 
 			var carouselPosition = carousel.Position;
 
 			if (LoopItemsSource != null)
+			{
 				LoopItemsSource.Loop = carousel.Loop;
+			}
 
 			CollectionView.ReloadData();
 
@@ -334,15 +421,21 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		void ScrollToPosition(int goToPosition, int carouselPosition, bool animate, bool forceScroll = false)
 		{
 			if (ItemsView is not CarouselView carousel)
+			{
 				return;
+			}
 
 			if (carousel.Loop)
+			{
 				carouselPosition = _carouselViewLoopManager?.GetCorrectPositionForCenterItem(CollectionView) ?? -1;
+			}
 
 			//no center item found, collection could be empty
 			//also if we are dragging we don't need to ScrollTo
 			if (carousel.IsDragging || carouselPosition == -1)
+			{
 				return;
+			}
 
 			if (_gotoPosition == -1 && (goToPosition != carouselPosition || forceScroll))
 			{
@@ -353,25 +446,30 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		void SetPosition(int position)
 		{
-			if (position == -1)
+			if (position == -1 || ItemsView is not CarouselView carousel)
+			{
 				return;
-			if (ItemsView is not CarouselView carousel)
-				return;
+			}
 
 			//we arrived center
 			if (position == _gotoPosition)
+			{
 				_gotoPosition = -1;
+			}
 
 			//If _gotoPosition is != -1 we are scrolling to that possition
 			if (_gotoPosition == -1 && carousel.Position != position)
+			{
 				carousel.SetValueFromRenderer(CarouselView.PositionProperty, position);
-
+			}
 		}
 
 		void SetCurrentItem(int carouselPosition)
 		{
 			if (ItemsSource.ItemCount == 0)
+			{
 				return;
+			}
 
 			var item = GetItemAtIndex(NSIndexPath.FromItemSection(carouselPosition, 0));
 			ItemsView?.SetValueFromRenderer(CarouselView.CurrentItemProperty, item);
@@ -381,9 +479,14 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		internal void UpdateFromCurrentItem()
 		{
 			if (ItemsView is not CarouselView carousel)
+			{
 				return;
+			}
+
 			if (carousel.CurrentItem == null || ItemsSource == null || ItemsSource.ItemCount == 0)
+			{
 				return;
+			}
 
 			var currentItemPosition = GetIndexForItem(carousel.CurrentItem).Row;
 
@@ -395,15 +498,22 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		internal void UpdateFromPosition()
 		{
 			if (ItemsView is not CarouselView carousel)
+			{
 				return;
+			}
+
 			var itemsCount = ItemsSource?.ItemCount;
 			if (itemsCount == 0)
+			{
 				return;
+			}
 
 			var currentItemPosition = GetIndexForItem(carousel.CurrentItem).Row;
 			var carouselPosition = carousel.Position;
 			if (carouselPosition == _gotoPosition)
+			{
 				_gotoPosition = -1;
+			}
 
 			ScrollToPosition(carouselPosition, currentItemPosition, carousel.AnimatePositionChanges);
 
@@ -415,15 +525,18 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			var itemsCount = ItemsSource?.ItemCount;
 
 			if (itemsCount == 0)
+			{
 				return;
+			}
 
-			if (!_initialPositionSet)
+			if (!InitialPositionSet)
 			{
 				if (ItemsView is not CarouselView carousel)
+				{
 					return;
+				}
 
-				System.Diagnostics.Debug.WriteLine($"UpdateInitialPosition");
-				_initialPositionSet = true;
+				InitialPositionSet = true;
 
 				int position = carousel.Position;
 				var currentItem = carousel.CurrentItem;
@@ -445,7 +558,16 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		void UpdateVisualStates()
 		{
 			if (ItemsView is not CarouselView carousel)
+			{
 				return;
+			}
+
+			// We aren't ready to update the visual states yet
+			if(_oldViews == null)
+			{
+				return;
+			}
+
 			var cells = CollectionView.VisibleCells;
 
 			var newViews = new List<View>();
@@ -457,7 +579,9 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			foreach (var cell in cells)
 			{
 				if (!((cell as CarouselTemplatedCell)?.PlatformHandler?.VirtualView is View itemView))
+				{
 					return;
+				}
 
 				var item = itemView.BindingContext;
 				var pos = ItemsSource.GetIndexForItem(item).Row;
@@ -502,7 +626,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			_oldViews = newViews;
 		}
 
-		protected internal override void UpdateVisibility()
+		internal protected override void UpdateVisibility()
 		{
 			if (ItemsView.IsVisible)
 			{
@@ -526,7 +650,9 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		public CarouselViewLoopManager(UICollectionViewFlowLayout layout)
 		{
 			if (layout == null)
+			{
 				throw new ArgumentNullException(nameof(layout), "LoopManager expects a UICollectionViewFlowLayout");
+			}
 
 			_layout = layout;
 		}
@@ -534,9 +660,13 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		public void CenterIfNeeded(UICollectionView collectionView, bool isHorizontal)
 		{
 			if (isHorizontal)
+			{
 				CenterHorizontalIfNeeded(collectionView);
+			}
 			else
+			{
 				CenterVerticallyIfNeeded(collectionView);
+			}
 		}
 
 		protected virtual void Dispose(bool disposing)
@@ -574,7 +704,10 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		{
 			NSIndexPath centerIndexPath = GetIndexPathForCenteredItem(collectionView);
 			if (centerIndexPath == null)
+			{
 				return -1;
+			}
+
 			return GetCorrectedIndexFromIndexPath(centerIndexPath);
 		}
 
@@ -582,7 +715,9 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		{
 			NSIndexPath centerIndexPath = GetIndexPathForCenteredItem(collectionView);
 			if (centerIndexPath == null)
+			{
 				return NSIndexPath.FromItemSection(0, 0);
+			}
 
 			var currentCarouselPosition = GetCorrectedIndexFromIndexPath(centerIndexPath);
 			var itemSourceCount = _itemsSource.ItemCount;
@@ -595,11 +730,17 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 			int goToPosition;
 			if (diffToStart < incrementAbs)
+			{
 				goToPosition = centerIndexPath.Row - diffToStart;
+			}
 			else if (diffToEnd < incrementAbs)
+			{
 				goToPosition = centerIndexPath.Row + diffToEnd;
+			}
 			else
+			{
 				goToPosition = centerIndexPath.Row - increment;
+			}
 
 			NSIndexPath goToIndexPath = NSIndexPath.FromItemSection(goToPosition, 0);
 
@@ -617,7 +758,9 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			var boundsHeight = collectionView.Bounds.Size.Height;
 
 			if (contentHeight == 0 || cellHeight == 0)
+			{
 				return;
+			}
 
 			var centerOffsetY = (LoopCount * contentHeight - boundsHeight) / 2;
 			var distFromCenter = centerOffsetY - currentOffset.Y;
@@ -650,7 +793,9 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			var boundsWidth = collectionView.Bounds.Size.Width;
 
 			if (contentWidth == 0 || cellWidth == 0)
+			{
 				return;
+			}
 
 			var centerOffsetX = (LoopCount * contentWidth - boundsWidth) / 2;
 			var distFromCentre = centerOffsetX - currentOffset.X;
@@ -686,7 +831,9 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		{
 			var itemsCount = GetItemsSourceCount();
 			if ((indexToCorrect < itemsCount && indexToCorrect >= 0) || itemsCount == 0)
+			{
 				return indexToCorrect;
+			}
 
 			var countInIndex = (double)(indexToCorrect / itemsCount);
 			var flooredValue = (int)(Math.Floor(countInIndex));

--- a/src/Controls/src/Core/Handlers/Items/iOS/CarouselViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/CarouselViewController.cs
@@ -11,7 +11,7 @@ using UIKit;
 
 namespace Microsoft.Maui.Controls.Handlers.Items
 {
-	public class CarouselViewController : ItemsViewController<CarouselView>, MauiCollectionView.ICustomMauiCollectionViewDelegate
+	public class CarouselViewController : ItemsViewController<CarouselView>
 	{
 		[Obsolete("Use ItemsView property instead")]
 		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = "Unused")]
@@ -77,23 +77,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		{
 			_carouselViewLoopManager = new CarouselViewLoopManager(Layout as UICollectionViewFlowLayout);
 			base.ViewDidLoad();
-
-			if(CollectionView is MauiCollectionView mauiCollectionView)
-			{
-				mauiCollectionView.SetCustomDelegate(this);
-			}
-		}
-
-		void MauiCollectionView.ICustomMauiCollectionViewDelegate.MovedToWindow(UIView view)
-		{
-			if (view?.Window is not null)
-			{
-				DeviceDisplay.MainDisplayInfoChanged += OnDisplayInfoChanged;
-			}
-			else
-			{
-				DeviceDisplay.MainDisplayInfoChanged -= OnDisplayInfoChanged;
-			}
 		}
 
 		void OnDisplayInfoChanged(object sender, DisplayInfoChangedEventArgs e)
@@ -225,6 +208,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			_oldViews = null;
 
 			carouselView.Scrolled -= CarouselViewScrolled;
+			DeviceDisplay.MainDisplayInfoChanged -= OnDisplayInfoChanged;
 
 			UnsubscribeCollectionItemsSourceChanged(ItemsSource);
 			
@@ -238,6 +222,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			_oldViews = new List<View>();
 			
 			carouselView.Scrolled += CarouselViewScrolled;
+			DeviceDisplay.MainDisplayInfoChanged += OnDisplayInfoChanged;
 
 			SubscribeCollectionItemsSourceChanged(ItemsSource);
 		}

--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
@@ -11,7 +11,7 @@ using UIKit;
 
 namespace Microsoft.Maui.Controls.Handlers.Items
 {
-	public abstract class ItemsViewController<TItemsView> : UICollectionViewController
+	public abstract class ItemsViewController<TItemsView> : UICollectionViewController, MauiCollectionView.ICustomMauiCollectionViewDelegate
 	where TItemsView : ItemsView
 	{
 		public const int EmptyTag = 333;
@@ -181,8 +181,8 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		{
 			base.LoadView();
 			var collectionView = new MauiCollectionView(CGRect.Empty, ItemsViewLayout);
+			collectionView.SetCustomDelegate(this);
 			CollectionView = collectionView;
-			(collectionView as IUIViewLifeCycleEvents).MovedToWindow += CollectionViewMovedToWindow;	
 		}
 
 		public override void ViewWillAppear(bool animated)
@@ -199,7 +199,9 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			LayoutEmptyView();
 		}
 
-		void CollectionViewMovedToWindow(object sender, EventArgs e)
+
+
+		void MauiCollectionView.ICustomMauiCollectionViewDelegate.MovedToWindow(UIView view)
 		{
 			if (CollectionView?.Window != null)
 			{

--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
@@ -179,9 +179,10 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		public override void LoadView()
 		{
-			base.LoadView(); 
-
-			CollectionView = new MauiCollectionView(CGRect.Empty, ItemsViewLayout);
+			base.LoadView();
+			var collectionView = new MauiCollectionView(CGRect.Empty, ItemsViewLayout);
+			CollectionView = collectionView;
+			(collectionView as IUIViewLifeCycleEvents).MovedToWindow += CollectionViewMovedToWindow;	
 		}
 
 		public override void ViewWillAppear(bool animated)
@@ -196,6 +197,18 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			base.ViewWillLayoutSubviews();
 			InvalidateMeasureIfContentSizeChanged();
 			LayoutEmptyView();
+		}
+
+		void CollectionViewMovedToWindow(object sender, EventArgs e)
+		{
+			if (CollectionView?.Window != null)
+			{
+				AttachingToWindow();
+			}
+			else
+			{
+				DetachingFromWindow();
+			}
 		}
 
 		void InvalidateMeasureIfContentSizeChanged()
@@ -248,6 +261,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			}
 			_previousContentSize = contentSize.Value;
 		}
+		
 
 		internal Size? GetSize()
 		{
@@ -773,6 +787,16 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			{
 				CollectionView.Hidden = true;
 			}
+		}
+
+		private protected virtual void AttachingToWindow()
+		{
+
+		}
+
+		private protected virtual void DetachingFromWindow()
+		{
+
 		}
 	}
 }

--- a/src/Controls/src/Core/Handlers/Items/iOS/MauiCollectionView.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/MauiCollectionView.cs
@@ -1,10 +1,13 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
 using CoreGraphics;
 using UIKit;
 
 namespace Microsoft.Maui.Controls.Handlers.Items;
 
-internal class MauiCollectionView : UICollectionView
+internal class MauiCollectionView : UICollectionView, IUIViewLifeCycleEvents
 {
+	WeakReference<ICustomMauiCollectionViewDelegate>? _customDelegate;
 	public MauiCollectionView(CGRect frame, UICollectionViewLayout layout) : base(frame, layout)
 	{
 	}
@@ -13,5 +16,35 @@ internal class MauiCollectionView : UICollectionView
 	{
 		if (!KeyboardAutoManagerScroll.IsKeyboardAutoScrollHandling)
 			base.ScrollRectToVisible(rect, animated);
+	}
+
+	[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = IUIViewLifeCycleEvents.UnconditionalSuppressMessage)]
+	EventHandler? _movedToWindow;
+	event EventHandler? IUIViewLifeCycleEvents.MovedToWindow
+	{
+		add => _movedToWindow += value;
+		remove => _movedToWindow -= value;
+	}
+
+	public override void MovedToWindow()
+	{
+		base.MovedToWindow();
+		_movedToWindow?.Invoke(this, EventArgs.Empty);
+
+		if(_customDelegate?.TryGetTarget(out var target) == true)
+		{
+			target.MovedToWindow(this);
+		}
+	}
+
+	internal void SetCustomDelegate(ICustomMauiCollectionViewDelegate customDelegate)
+	{
+		_customDelegate = new WeakReference<ICustomMauiCollectionViewDelegate>(customDelegate);
+	}
+
+
+	internal interface ICustomMauiCollectionViewDelegate
+	{
+		void MovedToWindow(UIView view);
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/CarouselViewUITests.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/CarouselViewUITests.cs
@@ -17,23 +17,35 @@ namespace Microsoft.Maui.TestCases.Tests
 		protected override void FixtureSetup()
 		{
 			base.FixtureSetup();
-			App.NavigateToGallery(CarouselViewGallery);
+			//App.NavigateToGallery(CarouselViewGallery);
 		}
 
 		[Test]
 		[Category(UITestCategories.CarouselView)]
 		public async Task CarouselViewSetPosition()
 		{
-			if (Device != TestDevice.Android)
+			App.NavigateToGallery(CarouselViewGallery);
+			await Task.Delay(2000);
+			try
 			{
-				Assert.Ignore("For now, running this test only on Android.");
+				if (Device == TestDevice.Windows)
+				{
+					Assert.Ignore("For now not running on windows");
+				}
+				else
+				{
+					App.WaitForElement("lblPosition");
+					await Task.Delay(3000);
+					CheckLabelValue("lblPosition", "3");
+				}
 			}
-			else
+			catch
 			{
-				App.WaitForElement("lblPosition");
-				await Task.Delay(1000);
-				var result = App.FindElement("lblPosition").GetText();
-				ClassicAssert.AreEqual("3", result);
+				App.Screenshot("Failed to Start on the correct position ");
+			}
+			finally
+			{
+				Reset();
 			}
 		}
 
@@ -41,24 +53,110 @@ namespace Microsoft.Maui.TestCases.Tests
 		[Category(UITestCategories.CarouselView)]
 		public void CarouselViewGoToNextCurrentItem()
 		{
-			if (Device != TestDevice.Android)
+			App.NavigateToGallery(CarouselViewGallery);
+			try
 			{
-				Assert.Ignore("For now, running this test only on Android.");
+				if (Device == TestDevice.Windows)
+				{
+					Assert.Ignore("For now not running on windows");
+				}
+				else
+				{
+					int indexToTest = 3;
+					var index = indexToTest.ToString();
+					var nextIndex = (indexToTest + 1).ToString();
+
+					CheckLabelValue("lblPosition", index);
+					CheckLabelValue("lblCurrentItem", index);
+
+					App.Tap("btnNext");
+					CheckLabelValue("lblPosition", nextIndex);
+					CheckLabelValue("lblCurrentItem", nextIndex);
+					CheckLabelValue("lblSelected", nextIndex);
+					App.Tap("btnPrev");
+				}
 			}
-			else
+			catch
 			{
-				int indexToTest = 3;
-				var index = indexToTest.ToString();
-				var nextIndex = (indexToTest + 1).ToString();
+				App.Screenshot("Failed to tap on btnNext");
+			}
+			finally
+			{
+				Reset();
+			}
+		}
 
-				CheckLabelValue("lblPosition", index);
-				CheckLabelValue("lblCurrentItem", index);
+		[Test]
+		[Category(UITestCategories.CarouselView)]
+		public void CarouselViewGoToPreviousCurrentItem()
+		{
+			App.NavigateToGallery(CarouselViewGallery);
+			try
+			{
+				if (Device == TestDevice.Windows)
+				{
+					Assert.Ignore("For now not running on windows");
+				}
+				else
+				{
+					int indexToTest = 3;
+					var index = indexToTest.ToString();
+					var previousIndex = (indexToTest - 1).ToString();
 
-				App.Tap("btnNext");
-				CheckLabelValue("lblPosition", nextIndex);
-				CheckLabelValue("lblCurrentItem", nextIndex);
-				CheckLabelValue("lblSelected", nextIndex);
-				App.Tap("btnPrev");
+					CheckLabelValue("lblPosition", index);
+					CheckLabelValue("lblCurrentItem", index);
+
+					App.Tap("btnPrev");
+					CheckLabelValue("lblPosition", previousIndex);
+					CheckLabelValue("lblCurrentItem", previousIndex);
+					CheckLabelValue("lblSelected", previousIndex);
+				}
+			}
+			catch
+			{
+				App.Screenshot("Failed to tap on btnPrev");
+			}
+			finally
+			{
+				Reset();
+			}
+		}
+
+		[Test]
+		[Category(UITestCategories.CarouselView)]
+		public async Task CarouselViewKeepPositionChangingOrientation()
+		{
+			App.NavigateToGallery(CarouselViewGallery);
+			try
+			{
+				if (Device == TestDevice.Mac || Device == TestDevice.Windows)
+				{
+					Assert.Ignore("For now not running on Desktop");
+				}
+				else
+				{
+					int indexToTest = 3;
+					var index = indexToTest.ToString();
+
+					CheckLabelValue("lblPosition", index);
+					CheckLabelValue("lblCurrentItem", index);
+
+					App.SetOrientationLandscape();
+					App.SetOrientationPortrait();
+
+					await Task.Delay(3000);
+
+					CheckLabelValue("lblPosition", index);
+					CheckLabelValue("lblCurrentItem", index);
+				}
+			}
+			catch
+			{
+				App.Screenshot("Failed to tap on btnSetPosition");
+			}
+			finally
+			{
+				Reset();
 			}
 		}
 

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue10234.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue10234.cs
@@ -17,26 +17,17 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		[Category(UITestCategories.CarouselView)]
 		public void ScrollCarouselViewAfterDispose()
 		{
-			try
-			{
-				_ = App.WaitForElement("GoToTest");
-				App.Tap("GoToTest");
-				App.WaitForElement("goToShow");
-				App.Tap("goToShow");
-				App.WaitForElement("goToBack");
-				ScrollNextItem();
-				App.Tap("goToBack");
-				App.WaitForElement("goToShow");
-				App.Tap("goToShow");
-				ScrollNextItem();
-				App.WaitForElement("goToBack");
-				App.Tap("goToBack");
-				App.WaitForElement("goToShow");
-			}
-			finally
-			{
-				Reset();
-			}
+			App.WaitForElement("goToShow");
+			App.Tap("goToShow");
+			App.WaitForElement("goToBack");
+			ScrollNextItem();
+			App.Tap("goToBack");
+			App.WaitForElement("goToShow");
+			App.Tap("goToShow");
+			ScrollNextItem();
+			App.WaitForElement("goToBack");
+			App.Tap("goToBack");
+			App.WaitForElement("goToShow");
 		}
 
 		void ScrollNextItem()

--- a/src/Controls/tests/TestCases/Elements/CarouselViewCoreGalleryPage.xaml
+++ b/src/Controls/tests/TestCases/Elements/CarouselViewCoreGalleryPage.xaml
@@ -82,27 +82,31 @@
                 CurrentItem="{Binding Selected}">
                 <CarouselView.ItemTemplate>
                     <DataTemplate>
-                        <Frame 
+                        <Border 
                             x:Name="frame"
-                            HasShadow="True" 
-                            Padding="0" 
+                            Padding="10"
                             HeightRequest="100"
                             WidthRequest="200"
                             HorizontalOptions="Center" 
                             VerticalOptions="Center" 
                             BackgroundColor="Yellow">
-                            <Grid>
+                            <Grid RowDefinitions="*,Auto">
                                 <Image 
                                     Source="{Binding Image}"
                                     InputTransparent="true"
                                     Aspect="AspectFit" />
                                 <Label 
-                                    Text="{Binding Index}" 
+                                    Text="{Binding Index}"  Grid.Row="1"
                                     FontSize="Large"
-                                    HorizontalOptions="Center" 
+                                    HorizontalOptions="Start" 
+                                    VerticalOptions="Center" />
+                                <Label 
+                                    Text="{Binding Title}"  Grid.Row="1"
+                                    FontSize="Large"
+                                    HorizontalOptions="End" 
                                     VerticalOptions="Center" />
                             </Grid>
-                        </Frame>
+                        </Border>
                     </DataTemplate>
                 </CarouselView.ItemTemplate>
             </CarouselView>

--- a/src/Controls/tests/TestCases/Elements/CarouselViewCoreGalleryPage.xaml.cs
+++ b/src/Controls/tests/TestCases/Elements/CarouselViewCoreGalleryPage.xaml.cs
@@ -139,12 +139,14 @@ namespace Maui.Controls.Sample
 			Index = index;
 
 			if (string.IsNullOrEmpty(image))
-				Image = "https://picsum.photos/700/300/";
+				Image = "oasis.jpg";
 			else
 				Image = image;
 		}
 
 		public int Index { get; set; }
+
+		public string Title => $"CarouselItem{Index}";
 
 		public string Image { get; set; }
 	}

--- a/src/Controls/tests/TestCases/Issues/Issue10234.cs
+++ b/src/Controls/tests/TestCases/Issues/Issue10234.cs
@@ -9,25 +9,6 @@ using Microsoft.Maui.Controls;
 namespace Maui.Controls.Sample.Issues
 {
 	[Issue(IssueTracker.None, 10234, "CarouselView disposed on iOS when navigating back in Shell", PlatformAffected.iOS)]
-	public class Issue10234Test : ContentPage
-	{
-		public Issue10234Test()
-		{
-			Content = new VerticalStackLayout()
-			{
-				Children = 
-				{
-					new Button() 
-					{ 
-						Text = "Go To Test", 
-						AutomationId = "GoToTest", 
-						Command = new Command(() => Application.Current.MainPage = new Issue10234()) 
-					}
-				}
-			};			
-		}
-	}
-
 	public class Issue10234 : Shell
 	{
 		public Issue10234()


### PR DESCRIPTION
### Description of Change

Since the mappers run when the handler is started and in different order than forms, seems the initial position based on CurrentItem wasn't being set correctly since the mapper for the Position property runs first and overrides it.

We also fix an issue when rotating was not keeping the correct position, since the scroll event was triggered and we want to avoid updating the position till the orientation finishes. This changed the Scrolled event to be fired when the scroll animation finishes. 

Added a way to know better when we the CollectionViewController is attached or detached from the view hierarchy. So now we can proper call the `TearDown`  and `Setup`.

Fixes some warnings

### Issues Fixed

Fixes #18879
This pull request includes substantial changes to the CarouselViewHandler and CarouselViewController classes in the `src/Controls/src/Core/Handlers/Items/` directory. The changes primarily focus on improving the code readability, maintainability, and robustness by adding necessary condition checks and refactoring the code. 
