### PR TITLE
iOS Entry & Editor Placeholder font follows FontFamily property

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Editor/EditorTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Editor/EditorTests.iOS.cs
@@ -1,7 +1,11 @@
-﻿using System.Threading.Tasks;
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
 using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Hosting;
 using Microsoft.Maui.Platform;
 using Xunit;
+using static Microsoft.Maui.DeviceTests.AssertHelpers;
 
 namespace Microsoft.Maui.DeviceTests
 {
@@ -37,6 +41,49 @@ namespace Microsoft.Maui.DeviceTests
 				return (int)nativeEditor.GetOffsetFromPosition(nativeEditor.SelectedTextRange.Start, nativeEditor.SelectedTextRange.End);
 
 			return -1;
+		}
+
+		[Category(TestCategory.Editor)]
+		public class PlaceholderTests : ControlsHandlerTestBase
+		{
+			[Fact]
+			public async Task PlaceholderFontFamily()
+			{
+				EnsureHandlerCreated(builder =>
+				{
+					builder.ConfigureMauiHandlers(handlers =>
+					{
+						handlers.AddHandler(typeof(Editor), typeof(EditorHandler));
+					});
+				});
+
+				var expectedFontFamily = "Times New Roman";
+
+				var editor = new Editor
+				{
+					FontFamily = expectedFontFamily,
+					Placeholder = "This is a placeholder"
+				};
+
+				ContentPage contentPage = new ContentPage()
+				{
+					Content = new VerticalStackLayout()
+					{
+						editor
+					}
+				};
+
+				await CreateHandlerAndAddToWindow(contentPage, async () =>
+				{
+					await AssertEventually(() => editor.IsVisible);
+					var handler = CreateHandler<EditorHandler>(editor);
+					var platformControl = GetPlatformControl(handler);
+
+					var placeholderLabel = handler.PlatformView.Subviews.OfType<UIKit.UILabel>().FirstOrDefault();
+
+					Assert.Equal(expectedFontFamily, placeholderLabel?.Font?.FamilyName);
+				});
+			}
 		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.iOS.cs
@@ -271,5 +271,48 @@ namespace Microsoft.Maui.DeviceTests
 				Assert.True(isFocused, $"{page} failed to focus the second entry DANG");
 			}
 		}
+
+		[Category(TestCategory.Entry)]
+		public class PlaceholderTests : ControlsHandlerTestBase
+		{
+			[Fact]
+			public async Task PlaceholderFontFamily()
+			{
+				EnsureHandlerCreated(builder =>
+				{
+					builder.ConfigureMauiHandlers(handlers =>
+					{
+						handlers.AddHandler(typeof(Entry), typeof(EntryHandler));
+					});
+				});
+
+				var expectedFontFamily = "Times New Roman";
+
+				var entry = new Entry
+				{
+					FontFamily = expectedFontFamily,
+					Placeholder = "This is a placeholder"
+				};
+
+				ContentPage contentPage = new ContentPage()
+				{
+					Content = new VerticalStackLayout()
+					{
+						entry
+					}
+				};
+
+				await CreateHandlerAndAddToWindow(contentPage, async () =>
+				{
+					await AssertEventually(() => entry.IsVisible);
+					var handler = CreateHandler<EntryHandler>(entry);
+					var platformControl = GetPlatformControl(handler);
+
+					var placeholderLabel = handler.PlatformView.Subviews.OfType<UIKit.UILabel>().FirstOrDefault();
+
+					Assert.Equal(expectedFontFamily, placeholderLabel?.Font?.FamilyName);
+				});
+			}
+		}
 	}
 }

--- a/src/Core/src/Platform/iOS/MauiTextView.cs
+++ b/src/Core/src/Platform/iOS/MauiTextView.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Maui.Platform
 			set
 			{
 				base.Font = value;
-				UpdatePlaceholderFontSize(value);
+				UpdatePlaceholderFont(value);
 
 			}
 		}
@@ -175,10 +175,10 @@ namespace Microsoft.Maui.Platform
 			};
 		}
 
-		void UpdatePlaceholderFontSize(UIFont? value)
+		void UpdatePlaceholderFont(UIFont? value)
 		{
 			_defaultPlaceholderSize ??= _placeholderLabel.Font.PointSize;
-			_placeholderLabel.Font = _placeholderLabel.Font.WithSize(
+			_placeholderLabel.Font = value ?? _placeholderLabel.Font.WithSize(
 				value?.PointSize ?? _defaultPlaceholderSize.Value);
 		}
 


### PR DESCRIPTION
### Description of Change

We were only setting the placeholder font size and character spacing, not the font for iOS. This change fixes that for `Editor` and `Entry`. Also adds device tests to verify this behavior.

### Issues Fixed

Fixes #20839