### PR TITLE
Fixed all remaining CA1416 errors

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/iOS/ListViewRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/iOS/ListViewRenderer.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Linq;
+using System.Runtime.Versioning;
 using Foundation;
 using Microsoft.Maui.Controls.Compatibility;
 using Microsoft.Maui.Controls.Internals;
@@ -306,8 +307,15 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			base.TraitCollectionDidChange(previousTraitCollection);
 #pragma warning restore CA1422 // Validate platform compatibility
 			// Make sure the cells adhere to changes UI theme
-			if (OperatingSystem.IsIOSVersionAtLeast(13) && previousTraitCollection?.UserInterfaceStyle != TraitCollection.UserInterfaceStyle)
+			if (OperatingSystem.IsIOSVersionAtLeast(13) && !UIStyleMatches(previousTraitCollection))
 				ReloadData();
+		}
+
+		[SupportedOSPlatform("ios13.0")]
+		[SupportedOSPlatform("maccatalyst13.1")]
+		bool UIStyleMatches (UITraitCollection target)
+		{
+			return target.UserInterfaceStyle == TraitCollection.UserInterfaceStyle;
 		}
 
 		NSIndexPath[] GetPaths(int section, int index, int count)

--- a/src/Controls/src/Core/Compatibility/Handlers/TableView/iOS/TableViewRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/TableView/iOS/TableViewRenderer.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Runtime.Versioning;
 using Microsoft.Maui.Controls.Platform;
 using Microsoft.Maui.Graphics;
 using UIKit;
@@ -126,8 +127,15 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			base.TraitCollectionDidChange(previousTraitCollection);
 #pragma warning restore CA1422 // Validate platform compatibility
 			// Make sure the cells adhere to changes UI theme
-			if (OperatingSystem.IsIOSVersionAtLeast(13) && previousTraitCollection?.UserInterfaceStyle != TraitCollection.UserInterfaceStyle)
+			if (OperatingSystem.IsIOSVersionAtLeast(13) && !UIStyleMatches(previousTraitCollection))
 				Control.ReloadData();
+		}
+
+		[SupportedOSPlatform("ios13.0")]
+		[SupportedOSPlatform("maccatalyst13.1")]
+		bool UIStyleMatches (UITraitCollection target)
+		{
+			return target.UserInterfaceStyle == TraitCollection.UserInterfaceStyle;
 		}
 
 		void SetSource()

--- a/src/Controls/src/Core/Compatibility/Handlers/iOS/FrameRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/iOS/FrameRenderer.cs
@@ -1,6 +1,7 @@
 ﻿#nullable disable
 using System;
 using System.ComponentModel;
+using System.Runtime.Versioning;
 using CoreGraphics;
 using Microsoft.Maui.Controls.Platform;
 using UIKit;
@@ -77,8 +78,15 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			base.TraitCollectionDidChange(previousTraitCollection);
 #pragma warning restore CA1422 // Validate platform compatibility
 			// Make sure the control adheres to changes in UI theme
-			if (OperatingSystem.IsIOSVersionAtLeast(13) && previousTraitCollection?.UserInterfaceStyle != TraitCollection.UserInterfaceStyle)
+			if ((OperatingSystem.IsIOSVersionAtLeast(13) || OperatingSystem.IsMacCatalystVersionAtLeast(13, 1)) && !UIStyleMatches(previousTraitCollection))
 				SetupLayer();
+		}
+
+		[SupportedOSPlatform("ios13.0")]
+		[SupportedOSPlatform("maccatalyst13.1")]
+		bool UIStyleMatches (UITraitCollection target)
+		{
+			return target.UserInterfaceStyle == TraitCollection.UserInterfaceStyle;
 		}
 
 		public virtual void SetupLayer()

--- a/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.iOS.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.iOS.cs
@@ -503,15 +503,27 @@ namespace Microsoft.Maui.Controls.Platform
 				UIEventButtonMask uIEventButtonMask = (UIEventButtonMask)0;
 
 				if ((tapGesture.Buttons & ButtonsMask.Primary) == ButtonsMask.Primary)
-					uIEventButtonMask |= UIEventButtonMask.Primary;
+					uIEventButtonMask |= Primary;
 
 				if ((tapGesture.Buttons & ButtonsMask.Secondary) == ButtonsMask.Secondary)
-					uIEventButtonMask |= UIEventButtonMask.Secondary;
+					uIEventButtonMask |= Secondary;
 
-				result.ButtonMaskRequired = uIEventButtonMask;
+				SetButtonMask(result, uIEventButtonMask);
 			}
 
 			return result;
+		}
+
+		[SupportedOSPlatform("ios13.4")]
+		static UIEventButtonMask Primary => UIEventButtonMask.Primary;
+
+		[SupportedOSPlatform("ios13.4")]
+		static UIEventButtonMask Secondary => UIEventButtonMask.Secondary;
+
+		[SupportedOSPlatform("ios13.4")]
+		void SetButtonMask(UITapGestureRecognizer recognizer, UIEventButtonMask buttonMask)
+		{
+			recognizer.ButtonMaskRequired = buttonMask;
 		}
 
 		static bool ShouldRecognizeTapsTogether(UIGestureRecognizer gesture, UIGestureRecognizer other)
@@ -598,8 +610,7 @@ namespace Microsoft.Maui.Controls.Platform
 #endif
 					)
 				{
-					_defaultAccessibilityRespondsToUserInteraction = PlatformView.AccessibilityRespondsToUserInteraction;
-					PlatformView.AccessibilityRespondsToUserInteraction = true;
+					SetAccessibilityRespondsToUserInteraction();
 				}
 			}
 
@@ -727,6 +738,19 @@ namespace Microsoft.Maui.Controls.Platform
 			}
 		}
 
+		[SupportedOSPlatform("ios13.0")]
+		[SupportedOSPlatform("maccatalyst13.0")]
+#if TVOS
+		[SupportedOSPlatform("tvos11.0")]
+#endif
+		void SetAccessibilityRespondsToUserInteraction()
+		{
+			if (PlatformView is not null) {
+				_defaultAccessibilityRespondsToUserInteraction = PlatformView.AccessibilityRespondsToUserInteraction;
+				PlatformView.AccessibilityRespondsToUserInteraction = true;		
+			}
+		}
+
 		void OnTapGestureRecognizerPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
 		{
 			if (e.Is(TapGestureRecognizer.ButtonsProperty))
@@ -782,16 +806,22 @@ namespace Microsoft.Maui.Controls.Platform
 			{
 				PlatformView.AccessibilityTraits &= ~_addedFlags;
 
-				if (OperatingSystem.IsIOSVersionAtLeast(13) || OperatingSystem.IsMacCatalystVersionAtLeast(13))
+				if (OperatingSystem.IsIOSVersionAtLeast(15) || OperatingSystem.IsMacCatalystVersionAtLeast(15))
 				{
 					if (_defaultAccessibilityRespondsToUserInteraction != null)
-						PlatformView.AccessibilityRespondsToUserInteraction = _defaultAccessibilityRespondsToUserInteraction.Value;
+						SetAccessibilityResponse(PlatformView, _defaultAccessibilityRespondsToUserInteraction.Value);
 				}
 			}
 
 			_addedFlags = UIAccessibilityTrait.None;
 			_defaultAccessibilityRespondsToUserInteraction = null;
 			LoadRecognizers();
+		}
+
+		[SupportedOSPlatform("ios15.0")]
+	void SetAccessibilityResponse(PlatformView view, bool newValue)
+		{
+			view.AccessibilityRespondsToUserInteraction = newValue;
 		}
 
 		void OnElementChanged(object sender, VisualElementChangedEventArgs e)

--- a/src/Controls/src/Core/Platform/iOS/Extensions/BrushExtensions.cs
+++ b/src/Controls/src/Core/Platform/iOS/Extensions/BrushExtensions.cs
@@ -121,16 +121,27 @@ namespace Microsoft.Maui.Controls.Platform
 			if (backgroundLayer == null)
 				return null;
 
-			UIGraphics.BeginImageContextWithOptions(backgroundLayer.Bounds.Size, false, UIScreen.MainScreen.Scale);
+			if (OperatingSystem.IsMacCatalystVersionAtLeast(13, 1) || OperatingSystem.IsIOSVersionAtLeast(11))
+			{
+				var size = new CGSize(backgroundLayer.Bounds.Size.Width * UIScreen.MainScreen.Scale, backgroundLayer.Bounds.Size.Height * UIScreen.MainScreen.Scale);
+				var renderer = new UIGraphicsImageRenderer(size);
+				var gradientImage = renderer.CreateImage((UIGraphicsImageRendererContext ctx) => {
+					backgroundLayer.RenderInContext(ctx.CGContext);
+				});
+				return gradientImage;
+			} else {
+				UIGraphics.BeginImageContextWithOptions(backgroundLayer.Bounds.Size, false, UIScreen.MainScreen.Scale);
 
-			if (UIGraphics.GetCurrentContext() == null)
-				return null;
+				if (UIGraphics.GetCurrentContext() == null)
+					return null;
 
-			backgroundLayer.RenderInContext(UIGraphics.GetCurrentContext());
-			UIImage gradientImage = UIGraphics.GetImageFromCurrentImageContext();
-			UIGraphics.EndImageContext();
+				backgroundLayer.RenderInContext(UIGraphics.GetCurrentContext());
+				UIImage gradientImage = UIGraphics.GetImageFromCurrentImageContext();
+				UIGraphics.EndImageContext();
 
-			return gradientImage;
+				return gradientImage;
+			}
+
 		}
 
 		public static void InsertBackgroundLayer(this UIView view, CALayer backgroundLayer, int index = -1)

--- a/src/Controls/tests/TestCases/Issues/Issue21726.xaml.cs
+++ b/src/Controls/tests/TestCases/Issues/Issue21726.xaml.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Runtime.Versioning;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Xaml;
 using System.Threading.Tasks;
@@ -18,6 +19,15 @@ public partial class Issue21726 : ContentPage
 	void AddVC (object sender, EventArgs e)
 	{
 #if IOS
+		if (OperatingSystem.IsIOSVersionAtLeast(13))
+			AddVCImpl(sender, e);
+#endif
+	}
+
+#if IOS
+	[SupportedOSPlatform("ios13.0")]
+	void AddVCImpl(object sender, EventArgs e)
+	{
 		var window = UIKit.UIApplication.SharedApplication
         .ConnectedScenes
         .OfType<UIKit.UIWindowScene>()
@@ -40,10 +50,9 @@ public partial class Issue21726 : ContentPage
 
 			rootVC.PresentViewController(testNC, true, null);
 		}
-#endif
 	}
 
-#if IOS
+
 	public class TestViewController: UIKit.UIViewController {
 
 		UIKit.UITextField TextField1;

--- a/src/Core/src/Handlers/ActivityIndicator/ActivityIndicatorHandler.iOS.cs
+++ b/src/Core/src/Handlers/ActivityIndicator/ActivityIndicatorHandler.iOS.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.Versioning;
 using CoreGraphics;
 using ObjCRuntime;
 using UIKit;
@@ -11,13 +12,20 @@ namespace Microsoft.Maui.Handlers
 		{
 			MauiActivityIndicator platformView;
 
-			if (OperatingSystem.IsIOSVersionAtLeast(13))
-				platformView = new MauiActivityIndicator(CGRect.Empty, VirtualView) { ActivityIndicatorViewStyle = UIActivityIndicatorViewStyle.Medium };
+			UIActivityIndicatorViewStyle style;
+			if (OperatingSystem.IsIOSVersionAtLeast(13) || OperatingSystem.IsMacCatalystVersionAtLeast(13, 1))
+				style = MediumStyle;
 			else
-				platformView = new MauiActivityIndicator(CGRect.Empty, VirtualView) { ActivityIndicatorViewStyle = UIActivityIndicatorViewStyle.Gray };
+				style = UIActivityIndicatorViewStyle.Gray;
+			platformView = new MauiActivityIndicator(CGRect.Empty, VirtualView) { ActivityIndicatorViewStyle = style };
 
 			return platformView;
 		}
+
+		[SupportedOSPlatform("ios13.0")]
+		[SupportedOSPlatform("maccatalyst13.1")]
+		static UIActivityIndicatorViewStyle MediumStyle => UIActivityIndicatorViewStyle.Medium;
+
 
 		public static partial void MapIsRunning(IActivityIndicatorHandler handler, IActivityIndicator activityIndicator)
 		{

--- a/src/Core/src/Handlers/MenuFlyoutItem/MenuFlyoutItemHandler.iOS.cs
+++ b/src/Core/src/Handlers/MenuFlyoutItem/MenuFlyoutItemHandler.iOS.cs
@@ -1,11 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Runtime.Versioning;
 using Foundation;
 using UIKit;
 
 namespace Microsoft.Maui.Handlers
 {
-	[System.Runtime.Versioning.SupportedOSPlatform("ios13.0")]
+	[SupportedOSPlatform("ios13.0")]
 	public partial class MenuFlyoutItemHandler
 	{
 		internal static Dictionary<int, IMenuElement> menus = new Dictionary<int, IMenuElement>();

--- a/src/Core/src/Handlers/Window/WindowHandler.iOS.cs
+++ b/src/Core/src/Handlers/Window/WindowHandler.iOS.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.Versioning;
 using ObjCRuntime;
 using UIKit;
 
@@ -53,30 +54,36 @@ namespace Microsoft.Maui.Handlers
 
 		public static void MapMenuBar(IWindowHandler handler, IWindow view)
 		{
-			if (!(OperatingSystem.IsIOSVersionAtLeast(13) || OperatingSystem.IsMacCatalystVersionAtLeast(13)))
-				return;
-
-			if (MauiUIApplicationDelegate.Current != null &&
-				view is IMenuBarElement mb)
-			{
-				if (MauiUIApplicationDelegate.Current.MenuBuilder == null)
-				{
-					UIMenuSystem
-						.MainSystem
-						.SetNeedsRebuild();
-				}
-				else
-				{
-					// The handlers that are part of MenuBar
-					// are only relevant while the menu is being built
-					// because you can only build a menu while the
-					// `AppDelegate.BuildMenu` override is running
-					mb.MenuBar?.Handler?.DisconnectHandler();
-					mb.MenuBar?
-						.ToHandler(handler.MauiContext!)?
-						.DisconnectHandler();
-				}
+			if (OperatingSystem.IsIOSVersionAtLeast(13) || OperatingSystem.IsMacCatalystVersionAtLeast(13, 1)) {
+				MapMenuBarImpl(handler, view);
 			}
+		}
+
+		[SupportedOSPlatform("ios13.0")]
+		[SupportedOSPlatform("maccatalyst13.1")]
+		static void MapMenuBarImpl(IWindowHandler handler, IWindow view)
+		{
+				if (MauiUIApplicationDelegate.Current != null &&
+					view is IMenuBarElement mb)
+				{
+					if (MauiUIApplicationDelegate.Current.MenuBuilder == null)
+					{
+						UIMenuSystem
+							.MainSystem
+							.SetNeedsRebuild();
+					}
+					else
+					{
+						// The handlers that are part of MenuBar
+						// are only relevant while the menu is being built
+						// because you can only build a menu while the
+						// `AppDelegate.BuildMenu` override is running
+						mb.MenuBar?.Handler?.DisconnectHandler();
+						mb.MenuBar?
+							.ToHandler(handler.MauiContext!)?
+							.DisconnectHandler();
+					}
+				}
 		}
 
 		public static void MapRequestDisplayDensity(IWindowHandler handler, IWindow window, object? args)

--- a/src/Core/src/Hosting/LifecycleEvents/AppHostBuilderExtensions.iOS.cs
+++ b/src/Core/src/Hosting/LifecycleEvents/AppHostBuilderExtensions.iOS.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.Versioning;
 using Microsoft.Maui.Hosting;
 using Microsoft.Maui.LifecycleEvents;
 using UIKit;
@@ -58,46 +59,33 @@ namespace Microsoft.Maui.LifecycleEvents
 			iOS
 				.SceneWillEnterForeground(scene =>
 				{
-					if (!OperatingSystem.IsIOSVersionAtLeast(13))
-						return;
-
-					if (scene.Delegate is IUIWindowSceneDelegate windowScene &&
-						scene.ActivationState != UISceneActivationState.Unattached)
-					{
-						windowScene.GetWindow().GetWindow()?.Resumed();
+					if (OperatingSystem.IsIOSVersionAtLeast(13) || OperatingSystem.IsMacCatalystVersionAtLeast(13, 1)) {
+						WindowSceneResumed(scene);
 					}
 				})
 				.SceneOnActivated(scene =>
 				{
-					if (!OperatingSystem.IsIOSVersionAtLeast(13))
-						return;
-
-					if (scene.Delegate is IUIWindowSceneDelegate sd)
-						sd.GetWindow().GetWindow()?.Activated();
+					if (OperatingSystem.IsIOSVersionAtLeast(13) || OperatingSystem.IsMacCatalystVersionAtLeast(13, 1)) {
+						WindowSceneActivated(scene);
+					}
 				})
 				.SceneOnResignActivation(scene =>
 				{
-					if (!OperatingSystem.IsIOSVersionAtLeast(13))
-						return;
-
-					if (scene.Delegate is IUIWindowSceneDelegate sd)
-						sd.GetWindow().GetWindow()?.Deactivated();
+					if (OperatingSystem.IsIOSVersionAtLeast(13) || OperatingSystem.IsMacCatalystVersionAtLeast(13, 1)) {
+						WindowSceneDeactivated(scene);
+					}
 				})
 				.SceneDidEnterBackground(scene =>
 				{
-					if (!OperatingSystem.IsIOSVersionAtLeast(13))
-						return;
-
-					if (scene.Delegate is IUIWindowSceneDelegate sd)
-						sd.GetWindow().GetWindow()?.Stopped();
+					if (OperatingSystem.IsIOSVersionAtLeast(13) || OperatingSystem.IsMacCatalystVersionAtLeast(13, 1)) {
+						WindowSceneStopped(scene);
+					}
 				})
 				.SceneDidDisconnect(scene =>
 				{
-					if (!OperatingSystem.IsIOSVersionAtLeast(13))
-						return;
-
-					if (scene.Delegate is IUIWindowSceneDelegate sd)
-						sd.GetWindow().GetWindow()?.Destroying();
+					if (OperatingSystem.IsIOSVersionAtLeast(13) || OperatingSystem.IsMacCatalystVersionAtLeast(13, 1)) {
+						WindowSceneDestroying(scene);
+					}
 				});
 		}
 
@@ -110,19 +98,68 @@ namespace Microsoft.Maui.LifecycleEvents
 			iOS = iOS
 				.WindowSceneDidUpdateCoordinateSpace((windowScene, _, _, _) =>
 				{
-					if (!OperatingSystem.IsIOSVersionAtLeast(13))
-						return;
-
-					if (windowScene.Delegate is not IUIWindowSceneDelegate wsd ||
-						wsd.GetWindow() is not UIWindow platformWindow)
-						return;
-
-					var window = platformWindow.GetWindow();
-					if (window is null)
-						return;
-
-					window.FrameChanged(platformWindow.Frame.ToRectangle());
+					if (OperatingSystem.IsIOSVersionAtLeast(13) || OperatingSystem.IsMacCatalystVersionAtLeast(13, 1)) {
+						OnConfigureWindowImpl(windowScene);
+					}
 				});
+		}
+		
+		[SupportedOSPlatform("ios13.0")]
+		[SupportedOSPlatform("maccatalyst13.1")]
+		static void OnConfigureWindowImpl(UIWindowScene windowScene)
+		{
+			if (windowScene.Delegate is not IUIWindowSceneDelegate wsd ||
+				wsd.GetWindow() is not UIWindow platformWindow)
+				return;
+
+			var window = platformWindow.GetWindow();
+			if (window is null)
+				return;
+
+			window.FrameChanged(platformWindow.Frame.ToRectangle());		
+		}
+
+		[SupportedOSPlatform("ios13.0")]
+		[SupportedOSPlatform("maccatalyst13.1")]
+		static void WindowSceneActivated(UIScene scene)
+		{
+			if (scene.Delegate is IUIWindowSceneDelegate sd)
+				sd.GetWindow().GetWindow()?.Activated();
+		}
+
+		[SupportedOSPlatform("ios13.0")]
+		[SupportedOSPlatform("maccatalyst13.1")]
+		static void WindowSceneDeactivated(UIScene scene)
+		{
+			if (scene.Delegate is IUIWindowSceneDelegate sd)
+				sd.GetWindow().GetWindow()?.Deactivated();
+		}
+
+		[SupportedOSPlatform("ios13.0")]
+		[SupportedOSPlatform("maccatalyst13.1")]
+		static void WindowSceneResumed(UIScene scene)
+		{
+			if (scene.Delegate is IUIWindowSceneDelegate windowScene &&
+				scene.ActivationState != UISceneActivationState.Unattached)
+			{
+				windowScene.GetWindow().GetWindow()?.Resumed();
+			}
+		}
+
+		[SupportedOSPlatform("ios13.0")]
+		[SupportedOSPlatform("maccatalyst13.1")]
+		static void WindowSceneStopped(UIScene scene)
+		{
+			if (scene.Delegate is IUIWindowSceneDelegate sd)
+				sd.GetWindow().GetWindow()?.Stopped();
+		}
+
+		[SupportedOSPlatform("ios13.0")]
+		[SupportedOSPlatform("maccatalyst13.1")]
+		static void WindowSceneDestroying(UIScene scene)
+		{
+			if (scene.Delegate is IUIWindowSceneDelegate sd)
+				sd.GetWindow().GetWindow()?.Destroying();
 		}
 	}
 }

--- a/src/Core/src/Platform/iOS/ApplicationExtensions.cs
+++ b/src/Core/src/Platform/iOS/ApplicationExtensions.cs
@@ -147,7 +147,13 @@ namespace Microsoft.Maui.Platform
 
 			if (application is null)
 				return;
+			SetViewControllerUIStyle(application);
+		}
 
+		[SupportedOSPlatform("ios13.0")]
+		[SupportedOSPlatform("maccatalyst13.1")]
+		static void SetViewControllerUIStyle(IApplication application)
+		{
 			var currentViewController = WindowStateManager.Default.GetCurrentUIViewController(false);
 
 			if (currentViewController is null)
@@ -156,15 +162,28 @@ namespace Microsoft.Maui.Platform
 			switch (application.UserAppTheme)
 			{
 				case AppTheme.Light:
-					currentViewController.OverrideUserInterfaceStyle = UIUserInterfaceStyle.Light;
+					currentViewController.OverrideUserInterfaceStyle = Light;
 					break;
 				case AppTheme.Dark:
-					currentViewController.OverrideUserInterfaceStyle = UIUserInterfaceStyle.Dark;
+					currentViewController.OverrideUserInterfaceStyle = Dark;
 					break;
 				default:
-					currentViewController.OverrideUserInterfaceStyle = UIUserInterfaceStyle.Unspecified;
+					currentViewController.OverrideUserInterfaceStyle = Unspecified;
 					break;
 			}
 		}
+		
+		[SupportedOSPlatform("ios13.0")]
+		[SupportedOSPlatform("maccatalyst13.1")]
+		static UIUserInterfaceStyle Light = UIUserInterfaceStyle.Light;
+
+		[SupportedOSPlatform("ios13.0")]
+		[SupportedOSPlatform("maccatalyst13.1")]
+		static UIUserInterfaceStyle Dark = UIUserInterfaceStyle.Dark;
+
+		[SupportedOSPlatform("ios13.0")]
+		[SupportedOSPlatform("maccatalyst13.1")]
+		static UIUserInterfaceStyle Unspecified = UIUserInterfaceStyle.Unspecified;
+
 	}
 }

--- a/src/Core/src/Platform/iOS/ColorExtensions.cs
+++ b/src/Core/src/Platform/iOS/ColorExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.Versioning;
 using CoreGraphics;
 using Microsoft.Maui.Graphics;
 using ObjCRuntime;
@@ -16,81 +17,114 @@ namespace Microsoft.Maui.Platform
 		{
 			get
 			{
-				if (OperatingSystem.IsIOSVersionAtLeast(13) || OperatingSystem.IsTvOSVersionAtLeast(13))
-					return UIColor.Label;
+				if (OperatingSystem.IsIOSVersionAtLeast(13) || OperatingSystem.IsTvOSVersionAtLeast(13) || OperatingSystem.IsMacCatalystVersionAtLeast(13, 1))
+					return Label;
 
 				return UIColor.Black;
 			}
 		}
+
+		[SupportedOSPlatform("ios13.0")]
+		[SupportedOSPlatform("maccatalyst13.1")]
+		[SupportedOSPlatform("tvos13.0")]
+		static UIColor Label => UIColor.Label;
 
 		internal static UIColor PlaceholderColor
 		{
 			get
 			{
 
-				if (OperatingSystem.IsIOSVersionAtLeast(13) || OperatingSystem.IsTvOSVersionAtLeast(13))
-					return UIColor.PlaceholderText;
+				if (OperatingSystem.IsIOSVersionAtLeast(13) || OperatingSystem.IsTvOSVersionAtLeast(13) || OperatingSystem.IsMacCatalystVersionAtLeast(13, 1))
+					return PlaceholderText;
 
 				return SeventyPercentGrey;
 			}
 		}
+
+		[SupportedOSPlatform("ios13.0")]
+		[SupportedOSPlatform("maccatalyst13.1")]
+		[SupportedOSPlatform("tvos13.0")]
+		static UIColor PlaceholderText => UIColor.Label;
 
 		internal static UIColor SecondaryLabelColor
 		{
 			get
 			{
 
-				if (OperatingSystem.IsIOSVersionAtLeast(13) || OperatingSystem.IsTvOSVersionAtLeast(13))
-					return UIColor.SecondaryLabel;
+				if (OperatingSystem.IsIOSVersionAtLeast(13) || OperatingSystem.IsTvOSVersionAtLeast(13) || OperatingSystem.IsMacCatalystVersionAtLeast(13, 1))
+					return SecondaryLabel;
 
 				return new Color(.32f, .4f, .57f).ToPlatform();
 			}
 		}
 
+		[SupportedOSPlatform("ios13.0")]
+		[SupportedOSPlatform("maccatalyst13.1")]
+		[SupportedOSPlatform("tvos13.0")]
+		static UIColor SecondaryLabel => UIColor.Label;
+		
 		internal static UIColor BackgroundColor
 		{
 			get
 			{
 
-				if (OperatingSystem.IsIOSVersionAtLeast(13))
-					return UIColor.SystemBackground;
+				if (OperatingSystem.IsIOSVersionAtLeast(13) || OperatingSystem.IsMacCatalystVersionAtLeast(13, 1))
+					return SystemBackground;
 
 				return UIColor.White;
 			}
 		}
 
+		[SupportedOSPlatform("ios13.0")]
+		[SupportedOSPlatform("maccatalyst13.1")]
+		static UIColor SystemBackground => UIColor.SystemBackground;
+
 		internal static UIColor SeparatorColor
 		{
 			get
 			{
-				if (OperatingSystem.IsIOSVersionAtLeast(13) || OperatingSystem.IsTvOSVersionAtLeast(13))
-					return UIColor.Separator;
+				if (OperatingSystem.IsIOSVersionAtLeast(13) || OperatingSystem.IsTvOSVersionAtLeast(13) || OperatingSystem.IsMacCatalystVersionAtLeast(13, 1))
+					return SeparatorColorImpl;
 
 				return UIColor.Gray;
 			}
 		}
 
+		[SupportedOSPlatform("ios13.0")]
+		[SupportedOSPlatform("maccatalyst13.1")]
+		[SupportedOSPlatform("tvos13.0")]
+		static UIColor SeparatorColorImpl => UIColor.Separator;
+		
 		internal static UIColor OpaqueSeparatorColor
 		{
 			get
 			{
-				if (OperatingSystem.IsIOSVersionAtLeast(13) || OperatingSystem.IsTvOSVersionAtLeast(13))
-					return UIColor.OpaqueSeparator;
+				if (OperatingSystem.IsIOSVersionAtLeast(13) || OperatingSystem.IsTvOSVersionAtLeast(13) || OperatingSystem.IsMacCatalystVersionAtLeast(13, 1))
+					return OpaqueSeparator;
 
 				return UIColor.Black;
 			}
 		}
 
+		[SupportedOSPlatform("ios13.0")]
+		[SupportedOSPlatform("maccatalyst13.1")]
+		[SupportedOSPlatform("tvos13.0")]
+		static UIColor OpaqueSeparator => UIColor.Separator;
+
 		internal static UIColor GroupedBackground
 		{
 			get
 			{
-				if (OperatingSystem.IsIOSVersionAtLeast(13))
-					return UIColor.SystemGroupedBackground;
+				if (OperatingSystem.IsIOSVersionAtLeast(13) || OperatingSystem.IsMacCatalystVersionAtLeast(13, 1))
+					return SystemGroupedBackground;
 
 				return new UIColor(247f / 255f, 247f / 255f, 247f / 255f, 1);
 			}
 		}
+
+		[SupportedOSPlatform("ios13.0")]
+		[SupportedOSPlatform("maccatalyst13.1")]
+		static UIColor SystemGroupedBackground => UIColor.SystemGroupedBackground;
 
 		internal static UIColor AccentColor
 		{
@@ -129,12 +163,17 @@ namespace Microsoft.Maui.Platform
 		{
 			get
 			{
-				if (OperatingSystem.IsIOSVersionAtLeast(13))
-					return UIColor.SystemGray2;
+				if (OperatingSystem.IsIOSVersionAtLeast(13) || OperatingSystem.IsMacCatalystVersionAtLeast(13, 1))
+					return SystemGray2;
 
 				return UIColor.LightGray;
 			}
 		}
+
+		[SupportedOSPlatform("ios13.0")]
+		[SupportedOSPlatform("maccatalyst13.1")]
+		static UIColor SystemGray2 => UIColor.SystemGray2;
+
 
 		public static CGColor ToCGColor(this Color color)
 		{

--- a/src/Core/src/Platform/iOS/ContentView.cs
+++ b/src/Core/src/Platform/iOS/ContentView.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.Versioning;
 using CoreAnimation;
 using CoreGraphics;
 using Microsoft.Maui.Graphics;
@@ -19,7 +20,15 @@ namespace Microsoft.Maui.Platform
 		public ContentView()
 		{
 			if (OperatingSystem.IsIOSVersionAtLeast(13) || OperatingSystem.IsMacCatalystVersionAtLeast(13, 1))
-				Layer.CornerCurve = CACornerCurve.Continuous; // Available from iOS 13. More info: https://developer.apple.com/documentation/quartzcore/calayercornercurve/3152600-continuous
+				SetCornerCurve();
+				 // Available from iOS 13. More info: https://developer.apple.com/documentation/quartzcore/calayercornercurve/3152600-continuous
+		}
+
+		[SupportedOSPlatform("ios13.0")]
+		[SupportedOSPlatform("maccatalyst13.1")]
+		void SetCornerCurve()
+		{
+			Layer.CornerCurve = CACornerCurve.Continuous;	
 		}
 
 		public override void LayoutSubviews()

--- a/src/Core/src/Platform/iOS/KeyboardAcceleratorExtensions.cs
+++ b/src/Core/src/Platform/iOS/KeyboardAcceleratorExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Foundation;
+﻿using System.Runtime.Versioning;
+using Foundation;
 using ObjCRuntime;
 using UIKit;
 
@@ -8,6 +9,7 @@ namespace Microsoft.Maui.Platform
 	{
 		internal const string MenuItemSelectedSelector = "MenuItemSelected:";
 
+		[SupportedOSPlatform("ios13.0")]
 		internal static UIMenuElement CreateMenuItem(this IMenuFlyoutItem virtualView, IMauiContext mauiContext)
 		{
 			var index = MenuFlyoutItemHandler.menus.Count;
@@ -44,6 +46,7 @@ namespace Microsoft.Maui.Platform
 			return modifierFlags;
 		}
 
+		[SupportedOSPlatform("ios13.0")]
 		static UIKeyCommand CreateMenuItemKeyCommand(this IMenuFlyoutItem virtualView, int index, UIImage? uiImage, Selector selector, UIKeyModifierFlags modifierFlags, string key)
 		{
 			var keyCommand = UIKeyCommand.Create(
@@ -59,6 +62,7 @@ namespace Microsoft.Maui.Platform
 			return keyCommand;
 		}
 
+		[SupportedOSPlatform("ios13.0")]
 		static UICommand CreateMenuItemCommand(this IMenuFlyoutItem virtualView, int index, UIImage? uiImage, Selector selector)
 		{
 			var command = UICommand.Create(

--- a/src/Core/src/Platform/iOS/MauiDatePicker.cs
+++ b/src/Core/src/Platform/iOS/MauiDatePicker.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Foundation;
 using UIKit;
+using System.Runtime.Versioning;
 
 namespace Microsoft.Maui.Platform
 {
@@ -14,9 +15,9 @@ namespace Microsoft.Maui.Platform
 			BorderStyle = UITextBorderStyle.RoundedRect;
 			var picker = new UIDatePicker { Mode = UIDatePickerMode.Date, TimeZone = new NSTimeZone("UTC") };
 
-			if (OperatingSystem.IsIOSVersionAtLeast(13, 4))
+			if (OperatingSystem.IsIOSVersionAtLeast(13, 4) || OperatingSystem.IsMacCatalystVersionAtLeast(13, 4))
 			{
-				picker.PreferredDatePickerStyle = UIDatePickerStyle.Wheels;
+				picker.PreferredDatePickerStyle = Wheels;
 			}
 
 			this.InputView = picker;
@@ -72,5 +73,9 @@ namespace Microsoft.Maui.Platform
 			BorderStyle = UITextBorderStyle.RoundedRect;
 		}
 #endif
+
+		[SupportedOSPlatform("ios13.4")]
+		[SupportedOSPlatform("maccatalyst13.4")]
+		internal static UIDatePickerStyle Wheels => UIDatePickerStyle.Wheels;
 	}
 }

--- a/src/Core/src/Platform/iOS/MauiPageControl.cs
+++ b/src/Core/src/Platform/iOS/MauiPageControl.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.Versioning;
 using CoreGraphics;
 using ObjCRuntime;
 using UIKit;
@@ -115,14 +116,22 @@ namespace Microsoft.Maui.Platform
 				{
 					if (view is UIImageView imageview)
 					{
-						if (OperatingSystem.IsIOSVersionAtLeast(13) || OperatingSystem.IsTvOSVersionAtLeast(13))
-							imageview.Image = UIImage.GetSystemImage("squareshape.fill");
+						if (OperatingSystem.IsIOSVersionAtLeast(13) || OperatingSystem.IsTvOSVersionAtLeast(13) || OperatingSystem.IsMacCatalystVersionAtLeast(13, 1))
+							imageview.Image = GetSystemImage("squareshape.fill");
 						var frame = imageview.Frame;
 						//the square shape is not the same size as the circle so we might need to correct the frame
 						imageview.Frame = new CGRect(frame.X - 6, frame.Y, frame.Width, frame.Height);
 					}
 				}
 			}
+		}
+
+		[SupportedOSPlatform("ios13.0")]
+		[SupportedOSPlatform("tvos13.0")]
+		[SupportedOSPlatform("maccatalyst13.1")]
+		static UIImage? GetSystemImage(string name)
+		{
+			return UIImage.GetSystemImage(name);
 		}
 
 		void UpdateCornerRadius()

--- a/src/Core/src/Platform/iOS/MauiTimePicker.cs
+++ b/src/Core/src/Platform/iOS/MauiTimePicker.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Maui.Platform
 
 			if (OperatingSystem.IsIOSVersionAtLeast(14))
 			{
-				_picker.PreferredDatePickerStyle = UIDatePickerStyle.Wheels;
+				_picker.PreferredDatePickerStyle = MauiDatePicker.Wheels;
 			}
 
 			InputView = _picker;

--- a/src/Core/src/Platform/iOS/MauiWebViewUIDelegate.cs
+++ b/src/Core/src/Platform/iOS/MauiWebViewUIDelegate.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.Versioning;
 using Foundation;
 using UIKit;
 using WebKit;
@@ -19,9 +20,15 @@ namespace Microsoft.Maui.Platform
 
 		public override void SetContextMenuConfiguration(WKWebView webView, WKContextMenuElementInfo elementInfo, Action<UIContextMenuConfiguration> completionHandler)
 		{
-			if (!OperatingSystem.IsIOSVersionAtLeast(13))
+			if (!(OperatingSystem.IsIOSVersionAtLeast(13) || OperatingSystem.IsMacCatalystVersionAtLeast(13, 1)))
 				return;
+			SetContextMenuConfigurationImpl(webView, elementInfo, completionHandler);
+		}
 
+		[SupportedOSPlatform("ios13.0")]
+		[SupportedOSPlatform("maccatalyst13.1")]
+		static void SetContextMenuConfigurationImpl(WKWebView webView, WKContextMenuElementInfo elementInfo, Action<UIContextMenuConfiguration> completionHandler)
+		{
 			UIContextMenuConfiguration? uIContextMenuConfiguration = null;
 			foreach (var interaction in webView.Interactions)
 			{

--- a/src/Core/src/Platform/iOS/MenuExtensions.cs
+++ b/src/Core/src/Platform/iOS/MenuExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Runtime.Versioning;
 using Foundation;
 using Microsoft.Extensions.DependencyInjection;
 using ObjCRuntime;
@@ -26,16 +27,27 @@ namespace Microsoft.Maui.Platform
 
 		internal static void UpdateMenuElementAttributes(this UIMenuElement uiMenuElement, bool isEnabled)
 		{
-			if (uiMenuElement is UIAction action)
-				action.Attributes = isEnabled.ToUIMenuElementAttributes();
+			if (OperatingSystem.IsIOSVersionAtLeast(13) || OperatingSystem.IsMacCatalystVersionAtLeast(13, 1)) {
+				if (uiMenuElement is UIAction action)
+						SetUIActionAttributes(action, isEnabled);				
 
-			if (uiMenuElement is UICommand command)
-				command.Attributes = isEnabled.ToUIMenuElementAttributes();
+				if (uiMenuElement is UICommand command)
+					SetUIMenuElementAttributes(command, isEnabled);
+			}
 		}
 
-		internal static UIMenuElementAttributes ToUIMenuElementAttributes(this bool isEnabled)
+		[SupportedOSPlatform("ios13.0")]
+		[SupportedOSPlatform("maccatalyst13.1")]
+		static void SetUIActionAttributes(UIAction action, bool isEnabled)
 		{
-			return isEnabled ? 0 : UIMenuElementAttributes.Disabled;
+			action.Attributes = isEnabled ? 0 : UIMenuElementAttributes.Disabled;
+		}
+
+		[SupportedOSPlatform("ios13.0")]
+		[SupportedOSPlatform("maccatalyst13.1")]
+		static void SetUIMenuElementAttributes(UICommand command, bool isEnabled)
+		{
+			command.Attributes = isEnabled ? 0 : UIMenuElementAttributes.Disabled;
 		}
 
 		internal static UIImage? GetPlatformMenuImage(this IImageSource? imageSource, IMauiContext mauiContext)

--- a/src/Core/src/Platform/iOS/PlatformTouchGraphicsView.cs
+++ b/src/Core/src/Platform/iOS/PlatformTouchGraphicsView.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.Versioning;
 using Foundation;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Graphics.Platform;
@@ -34,7 +35,14 @@ namespace Microsoft.Maui.Platform
 			_graphicsView = new(graphicsView);
 
 			if (OperatingSystem.IsIOSVersionAtLeast(13))
-				AddGestureRecognizer(_hoverGesture = new UIHoverGestureRecognizer(_proxy.OnHover));
+				AddGestureRecognizer(_hoverGesture = MakeRecognizer(_proxy));
+		}
+
+		[SupportedOSPlatform("ios13.0")]
+		[SupportedOSPlatform("maccatalyst13.1")]
+		static UIHoverGestureRecognizer MakeRecognizer(UIHoverGestureRecognizerProxy proxy)
+		{
+			return new UIHoverGestureRecognizer(proxy.OnHover);
 		}
 
 		public void Disconnect()

--- a/src/Core/src/Platform/iOS/SearchBarExtensions.cs
+++ b/src/Core/src/Platform/iOS/SearchBarExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.Versioning;
 using Foundation;
 using Microsoft.Maui.Graphics;
 using UIKit;
@@ -9,9 +10,9 @@ namespace Microsoft.Maui.Platform
 	{
 		internal static UITextField? GetSearchTextField(this UISearchBar searchBar)
 		{
-			if (OperatingSystem.IsIOSVersionAtLeast(13))
+			if (OperatingSystem.IsIOSVersionAtLeast(13) || OperatingSystem.IsMacCatalystVersionAtLeast(13, 1))
 			{
-				return searchBar.SearchTextField;
+				return SearchField(searchBar);
 			}
 
 			// Search Subviews up to two levels deep
@@ -30,6 +31,10 @@ namespace Microsoft.Maui.Platform
 
 			return null;
 		}
+		
+		[SupportedOSPlatform("ios13.0")]
+		[SupportedOSPlatform("maccatalyst13.1")]
+		static UISearchTextField SearchField(UISearchBar bar) => bar.SearchTextField;
 
 		internal static void UpdateBackground(this UISearchBar uiSearchBar, ISearchBar searchBar)
 		{

--- a/src/Core/src/Platform/iOS/SwitchExtensions.cs
+++ b/src/Core/src/Platform/iOS/SwitchExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.Versioning;
 using UIKit;
 
 namespace Microsoft.Maui.Platform
@@ -26,7 +27,7 @@ namespace Microsoft.Maui.Platform
 			{
 				// iOS 13+ uses the UIColor.SecondarySystemFill to support Light and Dark mode
 				// else, use the RGBA equivalent of UIColor.SecondarySystemFill in Light mode
-				uIView.BackgroundColor = OperatingSystem.IsIOSVersionAtLeast(13) ? UIColor.SecondarySystemFill : DefaultBackgroundColor;
+				uIView.BackgroundColor = OperatingSystem.IsIOSVersionAtLeast(13) ? SecondarySystemFill : DefaultBackgroundColor;
 			}
 
 			else if (view.TrackColor is not null)
@@ -35,6 +36,10 @@ namespace Microsoft.Maui.Platform
 				uIView.BackgroundColor = uiSwitch.OnTintColor;
 			}
 		}
+
+		[SupportedOSPlatform("ios13.0")]
+		[SupportedOSPlatform("maccatalyst13.1")]
+		static UIColor SecondarySystemFill => UIColor.SecondarySystemFill;
 
 		public static void UpdateThumbColor(this UISwitch uiSwitch, ISwitch view)
 		{

--- a/src/Core/src/Platform/iOS/UIApplicationExtensions.cs
+++ b/src/Core/src/Platform/iOS/UIApplicationExtensions.cs
@@ -74,12 +74,12 @@ namespace Microsoft.Maui.Platform
 				if (managedWindow is not null)
 					return managedWindow;
 			}
-#pragma warning restore CA1416
 
 			if (!OperatingSystem.IsIOSVersionAtLeast(13))
 				return null;
 			else if (windowScene.Delegate is IUIWindowSceneDelegate sd)
 				return sd.GetWindow().GetWindow();
+#pragma warning restore CA1416
 
 			return null;
 		}

--- a/src/Core/src/Platform/iOS/WindowExtensions.cs
+++ b/src/Core/src/Platform/iOS/WindowExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Runtime.Versioning;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Maui.Devices;
@@ -14,8 +15,18 @@ namespace Microsoft.Maui.Platform
 			// If you set the title to null the app will crash
 			// If you set it to an empty string the title reverts back to the 
 			// default app title.
-			if (OperatingSystem.IsIOSVersionAtLeast(13) && platformWindow.WindowScene is not null)
-				platformWindow.WindowScene.Title = window.Title ?? String.Empty;
+			if (OperatingSystem.IsIOSVersionAtLeast(13)|| OperatingSystem.IsMacCatalystVersionAtLeast(13, 1))
+				AssertWindowSceneTitle(platformWindow, window.Title ?? string.Empty);
+		}
+
+		[SupportedOSPlatform("ios13.0")]
+		[SupportedOSPlatform("maccatalyst13.1")]
+		static void AssertWindowSceneTitle(UIWindow platformWindow, string title)
+		{
+			if (platformWindow.WindowScene is not null)
+			{
+				platformWindow.WindowScene.Title = title;
+			}
 		}
 
 		internal static void UpdateX(this UIWindow platformWindow, IWindow window) =>
@@ -44,9 +55,14 @@ namespace Microsoft.Maui.Platform
 
 		internal static void UpdateMaximumSize(this UIWindow platformWindow, double width, double height)
 		{
-			if (!OperatingSystem.IsIOSVersionAtLeast(13))
-				return;
+			if (OperatingSystem.IsIOSVersionAtLeast(13)|| OperatingSystem.IsMacCatalystVersionAtLeast(13, 1))
+				UpdateMaximumSizeImpl(platformWindow, width, height);
+		}
 
+		[SupportedOSPlatform("ios13.0")]
+		[SupportedOSPlatform("maccatalyst13.1")]
+		static void UpdateMaximumSizeImpl(this UIWindow platformWindow, double width, double height)
+		{
 			var restrictions = platformWindow.WindowScene?.SizeRestrictions;
 			if (restrictions is null)
 				return;
@@ -70,9 +86,14 @@ namespace Microsoft.Maui.Platform
 
 		internal static void UpdateMinimumSize(this UIWindow platformWindow, double width, double height)
 		{
-			if (!OperatingSystem.IsIOSVersionAtLeast(13))
-				return;
+			if (OperatingSystem.IsIOSVersionAtLeast(13)|| OperatingSystem.IsMacCatalystVersionAtLeast(13, 1))
+				UpdateMinimumSizeImpl(platformWindow, width, height);
+		}
 
+		[SupportedOSPlatform("ios13.0")]
+		[SupportedOSPlatform("maccatalyst13.1")]
+		static void UpdateMinimumSizeImpl(this UIWindow platformWindow, double width, double height)
+		{
 			var restrictions = platformWindow.WindowScene?.SizeRestrictions;
 			if (restrictions is null)
 				return;


### PR DESCRIPTION
This should take care of all the remaining CA1416 errors.

Here's what I found about the analyzer for this -
* It understands when code from Xamarin/macios is reachable from maui code and will flag an error
* It never understands the pattern `if (!OperatingSystem.IsZZZZZZVersionAtLeast(major, minor)) return;` that implies that the rest of the code in the method is safe, flagging a false failure
* Compound OS tests or complex code inside the test will flag a false failure
* In the case of [this code](https://gist.github.com/stephen-hawley/716761d318fbcddd7795ed53d331cdc8), the analyzer appears to hang, although to be clear, I don't have evidence that it is the analyzer doing this

In order to work around this, the simplest way is to refactor all the OS version specific code into its own method and flag it with `[SupportedOSPlatform("xxxyy.zz")]`. In this case, the above false failures go away.

In rare cases, I was unable to do this and instead used a `#pragma` to suppress the warning around the code that triggered the false failure. I tried to avoid this at all costs since this is source of bugs waiting to happen.