### PR TITLE
Fix Appium install PowerShell script

### DIFF
--- a/eng/scripts/appium-install.ps1
+++ b/eng/scripts/appium-install.ps1
@@ -67,9 +67,11 @@ if (!(Test-Path $logsDir -PathType Container)) {
 $AppiumHome = $env:APPIUM_HOME
 Write-Output "APPIUM_HOME: $AppiumHome"
 
-if (Test-Path $AppiumHome) {
-    Write-Output  "Removing existing APPIUM_HOME Cache..."
-    Remove-Item -Path $AppiumHome -Recurse -Force
+if ($AppiumHome) {
+    if (Test-Path $AppiumHome) {
+        Write-Output  "Removing existing APPIUM_HOME Cache..."
+        Remove-Item -Path $AppiumHome -Recurse -Force
+    }
 }
 
 # Create the directory for appium home


### PR DESCRIPTION
### Description of Change

The PowerShell script would check if APPIUM_HOME is set, but when its not and returns null, the subsequent `Test-Path` would throw a null reference exception.