### PR TITLE
Use corrected index for CellDisplayingEnded

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/iOS/CarouselViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/CarouselViewController.cs
@@ -36,6 +36,11 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			CollectionView.AllowsMultipleSelection = false;
 		}
 
+		private protected override NSIndexPath GetAdjustedIndexPathForItemSource(NSIndexPath indexPath)
+		{
+			return NSIndexPath.FromItemSection(GetIndexFromIndexPath(indexPath), 0);
+		}
+
 		public override UICollectionViewCell GetCell(UICollectionView collectionView, NSIndexPath indexPath)
 		{
 			UICollectionViewCell cell;

--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
@@ -798,7 +798,32 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		private protected virtual void DetachingFromWindow()
 		{
+		}
 
+		private protected virtual NSIndexPath GetAdjustedIndexPathForItemSource(NSIndexPath indexPath)
+		{
+			return indexPath;
+		}
+
+		internal virtual void CellDisplayingEndedFromDelegate(UICollectionViewCell cell, NSIndexPath indexPath)
+		{
+			if (cell is TemplatedCell templatedCell &&
+				(templatedCell.PlatformHandler?.VirtualView as View)?.BindingContext is object bindingContext)
+			{
+				// We want to unbind a cell that is no longer present in the items source. Unfortunately
+				// it's too expensive to check directly, so let's check that the current binding context
+				// matches the item at a given position.
+
+				indexPath = GetAdjustedIndexPathForItemSource(indexPath);
+
+				var itemsSource = ItemsSource;
+				if (itemsSource is null ||
+					!itemsSource.IsIndexPathValid(indexPath) ||
+					!Equals(itemsSource[indexPath], bindingContext))
+				{
+					templatedCell.Unbind();
+				}
+			}
 		}
 	}
 }

--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewDelegator.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewDelegator.cs
@@ -105,24 +105,10 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 			return ItemsViewLayout.GetMinimumLineSpacingForSection(collectionView, layout, section);
 		}
-
+		
 		public override void CellDisplayingEnded(UICollectionView collectionView, UICollectionViewCell cell, NSIndexPath indexPath)
 		{
-			if (cell is TemplatedCell templatedCell &&
-				(templatedCell.PlatformHandler?.VirtualView as View)?.BindingContext is object bindingContext)
-			{
-				// We want to unbind a cell that is no longer present in the items source. Unfortunately
-				// it's too expensive to check directly, so let's check that the current binding context
-				// matches the item at a given position.
-
-				var itemsSource = ViewController?.ItemsSource;
-				if (itemsSource is null ||
-					!itemsSource.IsIndexPathValid(indexPath) ||
-					!Equals(itemsSource[indexPath], bindingContext))
-				{
-					templatedCell.Unbind();
-				}
-			}
+			ViewController?.CellDisplayingEndedFromDelegate(cell, indexPath);
 		}
 
 		protected virtual (bool VisibleItems, NSIndexPath First, NSIndexPath Center, NSIndexPath Last) GetVisibleItemsIndexPath()

--- a/src/Controls/src/Core/Handlers/Items/iOS/TemplatedCell.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/TemplatedCell.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		protected nfloat ConstrainedDimension;
 
-		private WeakReference<DataTemplate> _currentTemplate;
+		WeakReference<DataTemplate> _currentTemplate;
 
 		public DataTemplate CurrentTemplate
 		{

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/CarouselViewUITests.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/CarouselViewUITests.cs
@@ -15,126 +15,85 @@ namespace Microsoft.Maui.TestCases.Tests
 		{
 		}
 
+		protected override bool ResetAfterEachTest => true;
+
+		public override void TestSetup()
+		{
+			base.TestSetup();
+			App.NavigateToGallery(CarouselViewGallery);
+		}
+
 		[Test]
 		[Category(UITestCategories.CarouselView)]
 		public async Task CarouselViewSetPosition()
 		{
-			App.NavigateToGallery(CarouselViewGallery);
 			await Task.Delay(2000);
-			try
-			{
-				App.WaitForElement("lblPosition");
-				await Task.Delay(3000);
-				CheckLabelValue("lblPosition", "3");
-			}
-			catch
-			{
-				App.Screenshot("Failed to Start on the correct position ");
-			}
-			finally
-			{
-				Reset();
-			}
+			App.WaitForElement("lblPosition");
+			await Task.Delay(3000);
+			CheckLabelValue("lblPosition", "3");
 		}
 
 		[Test]
 		[Category(UITestCategories.CarouselView)]
 		public void CarouselViewGoToNextCurrentItem()
 		{
-			App.NavigateToGallery(CarouselViewGallery);
-			try
-			{
-				int indexToTest = 3;
-				var index = indexToTest.ToString();
-				var nextIndex = (indexToTest + 1).ToString();
+			int indexToTest = 3;
+			var index = indexToTest.ToString();
+			var nextIndex = (indexToTest + 1).ToString();
 
-				CheckLabelValue("lblPosition", index);
-				CheckLabelValue("lblCurrentItem", index);
-				App.WaitForElement($"CarouselItem{index}");
+			CheckLabelValue("lblPosition", index);
+			CheckLabelValue("lblCurrentItem", index);
+			App.WaitForElement($"CarouselItem{index}");
 
-				App.Tap("btnNext");
-				CheckLabelValue("lblPosition", nextIndex);
-				CheckLabelValue("lblCurrentItem", nextIndex);
-				CheckLabelValue("lblSelected", nextIndex);
-				App.Tap("btnPrev");
-			}
-			catch
-			{
-				App.Screenshot("Failed to tap on btnNext");
-			}
-			finally
-			{
-				Reset();
-			}
+			App.Tap("btnNext");
+			CheckLabelValue("lblPosition", nextIndex);
+			CheckLabelValue("lblCurrentItem", nextIndex);
+			CheckLabelValue("lblSelected", nextIndex);
+			App.Tap("btnPrev");
 		}
 
 		[Test]
 		[Category(UITestCategories.CarouselView)]
 		public void CarouselViewGoToPreviousCurrentItem()
 		{
-			App.NavigateToGallery(CarouselViewGallery);
-			try
-			{
-				int indexToTest = 3;
-				var index = indexToTest.ToString();
-				var previousIndex = (indexToTest - 1).ToString();
+			int indexToTest = 3;
+			var index = indexToTest.ToString();
+			var previousIndex = (indexToTest - 1).ToString();
 
-				CheckLabelValue("lblPosition", index);
-				CheckLabelValue("lblCurrentItem", index);
-				App.WaitForElement($"CarouselItem{index}");
+			CheckLabelValue("lblPosition", index);
+			CheckLabelValue("lblCurrentItem", index);
+			App.WaitForElement($"CarouselItem{index}");
 
-				App.Tap("btnPrev");
-				CheckLabelValue("lblPosition", previousIndex);
-				CheckLabelValue("lblCurrentItem", previousIndex);
-				CheckLabelValue("lblSelected", previousIndex);
-			}
-			catch
-			{
-				App.Screenshot("Failed to tap on btnPrev");
-			}
-			finally
-			{
-				Reset();
-			}
+			App.Tap("btnPrev");
+			CheckLabelValue("lblPosition", previousIndex);
+			CheckLabelValue("lblCurrentItem", previousIndex);
+			CheckLabelValue("lblSelected", previousIndex);
 		}
 
 		[Test]
 		[Category(UITestCategories.CarouselView)]
 		public async Task CarouselViewKeepPositionChangingOrientation()
 		{
-			App.NavigateToGallery(CarouselViewGallery);
-			try
-			{
-				int indexToTest = 3;
-					var index = indexToTest.ToString();
+			int indexToTest = 3;
+			var index = indexToTest.ToString();
 
-					CheckLabelValue("lblPosition", index);
-					CheckLabelValue("lblCurrentItem", index);
-					App.WaitForElement($"CarouselItem{index}");
+			CheckLabelValue("lblPosition", index);
+			CheckLabelValue("lblCurrentItem", index);
+			App.WaitForElement($"CarouselItem{index}");
 
-					App.SetOrientationLandscape();
-					App.SetOrientationPortrait();
+			App.SetOrientationLandscape();
+			App.SetOrientationPortrait();
 
-					await Task.Delay(3000);
+			await Task.Delay(3000);
 
-					CheckLabelValue("lblPosition", index);
-					CheckLabelValue("lblCurrentItem", index);
-			}
-			catch
-			{
-				App.Screenshot("Failed to tap on btnSetPosition");
-			}
-			finally
-			{
-				Reset();
-			}
+			CheckLabelValue("lblPosition", index);
+			CheckLabelValue("lblCurrentItem", index);
 		}
 
 		[Test]
 		[Category(UITestCategories.CarouselView)]
 		public void NavigateBackWhenLooped()
 		{
-			App.NavigateToGallery(CarouselViewGallery);
             int index = 3;
 
             for (int i = 0; i < 10; i++)
@@ -154,7 +113,6 @@ namespace Microsoft.Maui.TestCases.Tests
 		[Category(UITestCategories.CarouselView)]
 		public void NavigateForwardWhenLooped()
 		{
-			App.NavigateToGallery(CarouselViewGallery);
             int index = 3;
 
             for (int i = 0; i < 10; i++)

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/CarouselViewUITests.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/CarouselViewUITests.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿#if !WINDOWS
+using NUnit.Framework;
 using NUnit.Framework.Legacy;
 using UITest.Appium;
 using UITest.Core;
@@ -14,12 +15,6 @@ namespace Microsoft.Maui.TestCases.Tests
 		{
 		}
 
-		protected override void FixtureSetup()
-		{
-			base.FixtureSetup();
-			//App.NavigateToGallery(CarouselViewGallery);
-		}
-
 		[Test]
 		[Category(UITestCategories.CarouselView)]
 		public async Task CarouselViewSetPosition()
@@ -28,16 +23,9 @@ namespace Microsoft.Maui.TestCases.Tests
 			await Task.Delay(2000);
 			try
 			{
-				if (Device == TestDevice.Windows)
-				{
-					Assert.Ignore("For now not running on windows");
-				}
-				else
-				{
-					App.WaitForElement("lblPosition");
-					await Task.Delay(3000);
-					CheckLabelValue("lblPosition", "3");
-				}
+				App.WaitForElement("lblPosition");
+				await Task.Delay(3000);
+				CheckLabelValue("lblPosition", "3");
 			}
 			catch
 			{
@@ -56,26 +44,19 @@ namespace Microsoft.Maui.TestCases.Tests
 			App.NavigateToGallery(CarouselViewGallery);
 			try
 			{
-				if (Device == TestDevice.Windows)
-				{
-					Assert.Ignore("For now not running on windows");
-				}
-				else
-				{
-					int indexToTest = 3;
-					var index = indexToTest.ToString();
-					var nextIndex = (indexToTest + 1).ToString();
+				int indexToTest = 3;
+				var index = indexToTest.ToString();
+				var nextIndex = (indexToTest + 1).ToString();
 
-					CheckLabelValue("lblPosition", index);
-					CheckLabelValue("lblCurrentItem", index);
-					App.WaitForElement($"CarouselItem{index}");
+				CheckLabelValue("lblPosition", index);
+				CheckLabelValue("lblCurrentItem", index);
+				App.WaitForElement($"CarouselItem{index}");
 
-					App.Tap("btnNext");
-					CheckLabelValue("lblPosition", nextIndex);
-					CheckLabelValue("lblCurrentItem", nextIndex);
-					CheckLabelValue("lblSelected", nextIndex);
-					App.Tap("btnPrev");
-				}
+				App.Tap("btnNext");
+				CheckLabelValue("lblPosition", nextIndex);
+				CheckLabelValue("lblCurrentItem", nextIndex);
+				CheckLabelValue("lblSelected", nextIndex);
+				App.Tap("btnPrev");
 			}
 			catch
 			{
@@ -94,25 +75,18 @@ namespace Microsoft.Maui.TestCases.Tests
 			App.NavigateToGallery(CarouselViewGallery);
 			try
 			{
-				if (Device == TestDevice.Windows)
-				{
-					Assert.Ignore("For now not running on windows");
-				}
-				else
-				{
-					int indexToTest = 3;
-					var index = indexToTest.ToString();
-					var previousIndex = (indexToTest - 1).ToString();
+				int indexToTest = 3;
+				var index = indexToTest.ToString();
+				var previousIndex = (indexToTest - 1).ToString();
 
-					CheckLabelValue("lblPosition", index);
-					CheckLabelValue("lblCurrentItem", index);
-					App.WaitForElement($"CarouselItem{index}");
+				CheckLabelValue("lblPosition", index);
+				CheckLabelValue("lblCurrentItem", index);
+				App.WaitForElement($"CarouselItem{index}");
 
-					App.Tap("btnPrev");
-					CheckLabelValue("lblPosition", previousIndex);
-					CheckLabelValue("lblCurrentItem", previousIndex);
-					CheckLabelValue("lblSelected", previousIndex);
-				}
+				App.Tap("btnPrev");
+				CheckLabelValue("lblPosition", previousIndex);
+				CheckLabelValue("lblCurrentItem", previousIndex);
+				CheckLabelValue("lblSelected", previousIndex);
 			}
 			catch
 			{
@@ -131,13 +105,7 @@ namespace Microsoft.Maui.TestCases.Tests
 			App.NavigateToGallery(CarouselViewGallery);
 			try
 			{
-				if (Device == TestDevice.Mac || Device == TestDevice.Windows)
-				{
-					Assert.Ignore("For now not running on Desktop");
-				}
-				else
-				{
-					int indexToTest = 3;
+				int indexToTest = 3;
 					var index = indexToTest.ToString();
 
 					CheckLabelValue("lblPosition", index);
@@ -151,7 +119,6 @@ namespace Microsoft.Maui.TestCases.Tests
 
 					CheckLabelValue("lblPosition", index);
 					CheckLabelValue("lblCurrentItem", index);
-				}
 			}
 			catch
 			{
@@ -210,3 +177,4 @@ namespace Microsoft.Maui.TestCases.Tests
 		}
 	}
 }
+#endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/CarouselViewUITests.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/CarouselViewUITests.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Maui.TestCases.Tests
 			CheckLabelValue("lblPosition", index);
 			CheckLabelValue("lblCurrentItem", index);
 		}
-
+#if !ANDROID
 		[Test]
 		[Category(UITestCategories.CarouselView)]
 		public void NavigateBackWhenLooped()
@@ -127,6 +127,7 @@ namespace Microsoft.Maui.TestCases.Tests
                 index++;
             }
 		}
+#endif
 
 		void CheckLabelValue(string labelAutomationId, string value)
 		{

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/CarouselViewUITests.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/CarouselViewUITests.cs
@@ -68,6 +68,7 @@ namespace Microsoft.Maui.TestCases.Tests
 
 					CheckLabelValue("lblPosition", index);
 					CheckLabelValue("lblCurrentItem", index);
+					App.WaitForElement($"CarouselItem{index}");
 
 					App.Tap("btnNext");
 					CheckLabelValue("lblPosition", nextIndex);
@@ -105,6 +106,7 @@ namespace Microsoft.Maui.TestCases.Tests
 
 					CheckLabelValue("lblPosition", index);
 					CheckLabelValue("lblCurrentItem", index);
+					App.WaitForElement($"CarouselItem{index}");
 
 					App.Tap("btnPrev");
 					CheckLabelValue("lblPosition", previousIndex);
@@ -140,6 +142,7 @@ namespace Microsoft.Maui.TestCases.Tests
 
 					CheckLabelValue("lblPosition", index);
 					CheckLabelValue("lblCurrentItem", index);
+					App.WaitForElement($"CarouselItem{index}");
 
 					App.SetOrientationLandscape();
 					App.SetOrientationPortrait();
@@ -158,6 +161,46 @@ namespace Microsoft.Maui.TestCases.Tests
 			{
 				Reset();
 			}
+		}
+
+		[Test]
+		[Category(UITestCategories.CarouselView)]
+		public void NavigateBackWhenLooped()
+		{
+			App.NavigateToGallery(CarouselViewGallery);
+            int index = 3;
+
+            for (int i = 0; i < 10; i++)
+            {
+                if (index < 0)
+                {
+                    index = 4;
+                }
+                
+                App.WaitForElement($"CarouselItem{index}");
+                App.ScrollLeft("TheCarouselView");
+                index--;
+            }
+		}
+
+		[Test]
+		[Category(UITestCategories.CarouselView)]
+		public void NavigateForwardWhenLooped()
+		{
+			App.NavigateToGallery(CarouselViewGallery);
+            int index = 3;
+
+            for (int i = 0; i < 10; i++)
+            {
+                if (index > 4)
+                {
+                    index = 0;
+                }
+                
+                App.WaitForElement($"CarouselItem{index}");
+                App.ScrollRight("TheCarouselView");
+                index++;
+            }
 		}
 
 		void CheckLabelValue(string labelAutomationId, string value)

--- a/src/Controls/tests/TestCases.Shared.Tests/UITest.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/UITest.cs
@@ -212,9 +212,9 @@ namespace Microsoft.Maui.TestCases.Tests
 			}
 		}
 
-		[SetUp]
-		public void TestSetup()
+		public override void TestSetup()
 		{
+			base.TestSetup();
 			var device = App.GetTestDevice();
 			if(device == TestDevice.Android || device == TestDevice.iOS)
 			{

--- a/src/Controls/tests/TestCases/Elements/CarouselViewCoreGalleryPage.xaml
+++ b/src/Controls/tests/TestCases/Elements/CarouselViewCoreGalleryPage.xaml
@@ -94,6 +94,7 @@
                                 <Image 
                                     Source="{Binding Image}"
                                     InputTransparent="true"
+                                    AutomationId="{Binding Title}"
                                     Aspect="AspectFit" />
                                 <Label 
                                     Text="{Binding Index}"  Grid.Row="1"

--- a/src/TestUtils/src/UITest.NUnit/UITestBase.cs
+++ b/src/TestUtils/src/UITest.NUnit/UITestBase.cs
@@ -8,19 +8,37 @@ namespace UITest.Appium.NUnit
 {
 	public abstract class UITestBase : UITestContextBase
 	{
+		protected virtual bool ResetAfterEachTest => false;
+
 		public UITestBase(TestDevice testDevice)
 			: base(testDevice)
 		{
 		}
 
-		[SetUp]
 		public void RecordTestSetup()
 		{
 			var name = TestContext.CurrentContext.Test.MethodName ?? TestContext.CurrentContext.Test.Name;
 			TestContext.Progress.WriteLine($">>>>> {DateTime.Now} {name} Start");
 		}
 
+		[SetUp]
+		public virtual void TestSetup()
+		{
+			RecordTestSetup();
+		}
+
 		[TearDown]
+		public virtual void TestTearDown()
+		{
+			RecordTestTeardown();
+			UITestBaseTearDown();
+			if (ResetAfterEachTest)
+			{
+				Reset();
+				FixtureSetup();
+			}
+		}
+
 		public void RecordTestTeardown()
 		{
 			var name = TestContext.CurrentContext.Test.MethodName ?? TestContext.CurrentContext.Test.Name;
@@ -37,7 +55,8 @@ namespace UITest.Appium.NUnit
 		{
 			try
 			{
-				Reset();
+				if (!ResetAfterEachTest)
+					Reset();
 			}
 			catch (Exception e)
 			{
@@ -46,7 +65,6 @@ namespace UITest.Appium.NUnit
 			}
 		}
 
-		[TearDown]
 		public void UITestBaseTearDown()
 		{
 			try
@@ -55,8 +73,11 @@ namespace UITest.Appium.NUnit
 				{
 					SaveDeviceDiagnosticInfo();
 
-					Reset();
-					FixtureSetup();
+					if (!ResetAfterEachTest)
+					{
+						Reset();
+						FixtureSetup();
+					}
 
 					// Assert.Fail will immediately exit the test which is desirable as the app is not
 					// running anymore so we can't capture any UI structures or any screenshots


### PR DESCRIPTION
### Description of Change

`CellDisplayingEnded` currently doesn't use the adjusted carouselview indexes when accessing the itemsource to see if it should unbind the items.

### Issues Fixed

Fixes #22015

