### PR TITLE
Ignore orientation CarV test for Mac

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/CarouselViewUITests.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/CarouselViewUITests.cs
@@ -70,6 +70,8 @@ namespace Microsoft.Maui.TestCases.Tests
 			CheckLabelValue("lblSelected", previousIndex);
 		}
 
+// Catalyst doesn't support orientation changes
+#if !MACCATALYST
 		[Test]
 		[Category(UITestCategories.CarouselView)]
 		public async Task CarouselViewKeepPositionChangingOrientation()
@@ -89,7 +91,9 @@ namespace Microsoft.Maui.TestCases.Tests
 			CheckLabelValue("lblPosition", index);
 			CheckLabelValue("lblCurrentItem", index);
 		}
-#if !ANDROID
+#endif
+
+#if IOS || WINDOWS
 		[Test]
 		[Category(UITestCategories.CarouselView)]
 		public void NavigateBackWhenLooped()

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/CollectionViewUITests.CollectionViewItemsUpdatingScrollMode.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/CollectionViewUITests.CollectionViewItemsUpdatingScrollMode.cs
@@ -13,38 +13,32 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 
 		public override string Issue => "CollectionView ItemsUpdatingScrollMode";
 
-		[OneTimeTearDown]
-		public void CollectionViewItemsUpdatingScrollModeOneTimeTearDown()
-		{
-			this.Back();
-		}
+		protected override bool ResetAfterEachTest => true;
 
+#if ANDROID
 		// KeepScrollOffset (src\Compatibility\ControlGallery\src\Issues.Shared\CollectionViewItemsUpdatingScrollMode.cs)
 		[Test]
 		[Category(UITestCategories.CollectionView)]
+		[FailsOnIOS("This test is failing, likely due to product issue")]
+		[FailsOnMac("This test is failing, likely due to product issue")]
+		[FailsOnWindows("This test is failing, likely due to product issue")]
 		public void KeepItemsInView()
 		{
-			if (Device == TestDevice.Android)
-			{
-				App.WaitForElement("ScrollToMiddle");
-				App.Click("ScrollToMiddle");
-				App.WaitForNoElement("Vegetables.jpg, 10");
+			App.WaitForElement("ScrollToMiddle");
+			App.Click("ScrollToMiddle");
+			App.WaitForNoElement("Vegetables.jpg, 10");
 
-				for (int n = 0; n < 25; n++)
-				{
-					App.Click("AddItemAbove");
-				}
-
-				App.WaitForNoElement("Vegetables.jpg, 10");
-			}
-			else
+			for (int n = 0; n < 25; n++)
 			{
-				Assert.Ignore("This test is failing, requires research.");
+				App.Click("AddItemAbove");
 			}
+
+			App.WaitForNoElement("Vegetables.jpg, 10");
 		}
+#endif
 
 		// KeepScrollOffset (src\Compatibility\ControlGallery\src\Issues.Shared\CollectionViewItemsUpdatingScrollMode.cs)
-		[Test]
+		//[Test]
 		[Category(UITestCategories.CollectionView)]
 		[FailsOnAllPlatforms("This test is failing, likely due to product issue")]
 		public void KeepScrollOffset()
@@ -61,7 +55,7 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		}
 
 		// KeepLastItemInView(src\Compatibility\ControlGallery\src\Issues.Shared\CollectionViewItemsUpdatingScrollMode.cs)
-		[Test]
+		//[Test]
 		[Category(UITestCategories.CollectionView)]
 		[FailsOnAllPlatforms("This test is failing, likely due to product issue")]
 		public void KeepLastItemInView()

--- a/src/TestUtils/src/UITest.Appium/Actions/AppiumLifecycleActions.cs
+++ b/src/TestUtils/src/UITest.Appium/Actions/AppiumLifecycleActions.cs
@@ -127,35 +127,40 @@ namespace UITest.Appium
 			}
 			catch (Exception)
 			{
+				// TODO Pass in logger so we can log these exceptions
+				
 				// Occasionally the app seems to get so locked up it can't 
 				// even report back the appstate. In that case, we'll just
 				// try to trigger a reset.
 			}
 
-			if (_app.GetTestDevice() == TestDevice.Mac)
+			try
 			{
-				_app.Driver.ExecuteScript("macos: terminateApp", new Dictionary<string, object>
+				if (_app.GetTestDevice() == TestDevice.Mac)
 				{
-					{ "bundleId", _app.GetAppId() },
-				});
-			}
-			else if (_app.GetTestDevice() == TestDevice.Windows)
-			{
-#pragma warning disable CS0618 // Type or member is obsolete
-				_app.Driver.CloseApp();
-#pragma warning restore CS0618 // Type or member is obsolete
-			}
-			else
-			{
-				try
+					_app.Driver.ExecuteScript("macos: terminateApp", new Dictionary<string, object>
+					{
+						{ "bundleId", _app.GetAppId() },
+					});
+				}
+				else if (_app.GetTestDevice() == TestDevice.Windows)
+				{
+	#pragma warning disable CS0618 // Type or member is obsolete
+					_app.Driver.CloseApp();
+	#pragma warning restore CS0618 // Type or member is obsolete
+				}
+				else
 				{
 					_app.Driver.TerminateApp(_app.GetAppId());
 				}
-				catch (Exception)
-				{
-					// Occasionally the app seems like it's already closed before we get here
-					// and then this throws an exception
-				}
+			}
+			catch (Exception)
+			{
+				// TODO Pass in logger so we can log these exceptions
+
+				// Occasionally the app seems like it's already closed before we get here
+				// and then this throws an exception.
+				return CommandResponse.FailedEmptyResponse;
 			}
 
 			return CommandResponse.SuccessEmptyResponse;


### PR DESCRIPTION
### Description of Changes

In cleaning up the CarV tests to make them a little bit faster and less flakey. One of the tests, that was also ignored for Catalyst, was readded to the set of catalyst tests. 

https://github.com/dotnet/maui/pull/22912