### PR TITLE
[Windows] Upgrade Windows App SDK from 1.5.1 to 1.5.4

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -60,7 +60,7 @@
     <!-- emsdk -->
     <MicrosoftNETWorkloadEmscriptenPackageVersion>8.0.0</MicrosoftNETWorkloadEmscriptenPackageVersion>
     <!-- wasdk -->
-    <MicrosoftWindowsAppSDKPackageVersion>1.5.240311000</MicrosoftWindowsAppSDKPackageVersion>
+    <MicrosoftWindowsAppSDKPackageVersion>1.5.240607001</MicrosoftWindowsAppSDKPackageVersion>
     <MicrosoftWindowsSDKBuildToolsPackageVersion>10.0.22621.756</MicrosoftWindowsSDKBuildToolsPackageVersion>
     <MicrosoftGraphicsWin2DPackageVersion>1.2.0</MicrosoftGraphicsWin2DPackageVersion>
     <!-- Everything else -->


### PR DESCRIPTION
### Description of Change

This PR upgrades Windows App SDK from [1.5.1](https://learn.microsoft.com/en-gb/windows/apps/windows-app-sdk/stable-channel#version-151-15240311000) to [1.5.4](https://learn.microsoft.com/en-gb/windows/apps/windows-app-sdk/stable-channel#version-154-15240607001). It contains some bugfixes and fixes for a few crashes.