### PR TITLE
 Refactor: Path.GetTempFileName() is considered insecure in certain scenarios

### DIFF
--- a/src/Graphics/src/Graphics/Platforms/iOS/PlatformPdfExportContext.cs
+++ b/src/Graphics/src/Graphics/Platforms/iOS/PlatformPdfExportContext.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Maui.Graphics.Platform
 
 			if (_tempFilePath == null)
 			{
-				_tempFilePath = Path.GetTempFileName();
+				_tempFilePath = Path.GetRandomFileName();
 				UIGraphics.BeginPDFContext(_tempFilePath, CGRect.Empty, _documentInfo);
 			}
 


### PR DESCRIPTION
### Description of Change

Replaced `Path.GetTempFileName()` with `Path.GetRandomFileName()` to prevent insecure temporary file creation, mitigating race condition issues and enhancing security. 

Use `Path.GetRandomFileName()` and manually create the file securely, ensuring atomic creation with non-predictable names. This mitigates the risk of race conditions and unauthorized access.

### Issues Fixed

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
