### PR TITLE
[XC] Fix SimplifyTypeExtensionVisitor

### DIFF
--- a/src/Controls/src/Xaml/SimplifyTypeExtensionVisitor.cs
+++ b/src/Controls/src/Xaml/SimplifyTypeExtensionVisitor.cs
@@ -55,16 +55,22 @@ namespace Microsoft.Maui.Controls.Xaml
 
 			static bool IsTypeExtension(ElementNode node, out ValueNode typeNameValueNode)
 			{
-				XmlName typeNameXmlName = new("", "TypeName");
-
-				if (node.XmlType.Name == nameof(TypeExtension)
-					&& node.XmlType.NamespaceUri == XamlParser.X2009Uri
-					&& node.Properties.ContainsKey(typeNameXmlName)
-					&& node.Properties[typeNameXmlName] is ValueNode valueNode
-					&& valueNode.Value is string)
+				if (node.XmlType.Name == nameof(TypeExtension) && node.XmlType.NamespaceUri == XamlParser.X2009Uri)
 				{
-					typeNameValueNode = valueNode;
-					return true;
+					XmlName typeNameXmlName = new("", "TypeName");
+					if (node.Properties.ContainsKey(typeNameXmlName)
+						&& node.Properties[typeNameXmlName] is ValueNode { Value: string } propertyValueNode)
+					{
+						typeNameValueNode = propertyValueNode;
+						return true;
+					}
+
+					if (node.CollectionItems.Count == 1
+						&& node.CollectionItems[0] is ValueNode { Value: string } collectionValueNode)
+					{
+						typeNameValueNode = collectionValueNode;
+						return true;
+					}
 				}
 
 				typeNameValueNode = null;

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui21757_2.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui21757_2.xaml
@@ -1,0 +1,20 @@
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests"
+             x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui21757_2" x:DataType="local:ViewModelMainPage21757_2">
+
+    <StackLayout Orientation="Vertical" BindableLayout.ItemsSource="{Binding TestList}" Spacing="5">
+        <BindableLayout.ItemTemplate>
+            <DataTemplate x:DataType="{x:Type local:ViewModelTest21757_2}">
+                <Grid BackgroundColor="Blue" HeightRequest="30">
+                    <Grid.Triggers>
+                        <DataTrigger TargetType="{x:Type Grid}" Binding="{Binding TestValue}" Value="0">
+                            <Setter Property="BackgroundColor" Value="Red" />
+                        </DataTrigger>
+                    </Grid.Triggers>
+                </Grid>
+            </DataTemplate>
+        </BindableLayout.ItemTemplate>
+    </StackLayout>
+
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui21757_2.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui21757_2.xaml.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+using Microsoft.Maui.ApplicationModel;
+using Microsoft.Maui.Controls.Core.UnitTests;
+using Microsoft.Maui.Controls.Shapes;
+using Microsoft.Maui.Devices;
+using Microsoft.Maui.Dispatching;
+
+using Microsoft.Maui.Graphics;
+using Microsoft.Maui.UnitTests;
+using NUnit.Framework;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+[XamlCompilation(XamlCompilationOptions.Skip)]
+public partial class Maui21757_2
+{
+    public Maui21757_2()
+    {
+        InitializeComponent();
+    }
+
+    public Maui21757_2(bool useCompiledXaml)
+    {
+        //this stub will be replaced at compile time
+    }
+
+    [TestFixture]
+    class Test
+    {
+        [SetUp]
+        public void Setup()
+        {
+            Application.SetCurrentApplication(new MockApplication());
+            DispatcherProvider.SetCurrent(new DispatcherProviderStub());
+        }
+
+        [TearDown] public void TearDown() => AppInfo.SetCurrent(null);
+
+        [Test]
+        public void TypeLiteralAndXTypeCanBeUsedInterchangeably()
+        {
+            Assert.DoesNotThrow(() => MockCompiler.Compile(typeof(Maui21757_2)));
+        }
+    }
+}
+
+public class ViewModelMainPage21757_2
+{
+	public List<ViewModelTest21757_2> TestList { get; set; }
+
+	public ViewModelMainPage21757_2()
+	{
+		TestList = new List<ViewModelTest21757_2>()
+		{
+			new ViewModelTest21757_2() { TestValue = 0 },
+			new ViewModelTest21757_2() { TestValue = 1 },
+			new ViewModelTest21757_2() { TestValue = 2 },
+			new ViewModelTest21757_2() { TestValue = 3 }
+		};
+	}
+}
+
+public class ViewModelTest21757_2
+{
+	public int TestValue { get; set; }
+}


### PR DESCRIPTION
### Description of Change

In some cases the `{x:Type Abc}` ends up being transformed into a an `ElementNode` with a single collection item node instead of being stored under the default `TypeName` content property. The visitor wasn't able to correctly identify the collection item case.

### Issues Fixed

Fixes #21757 (again)