### PR TITLE
Update vscode extension recommendations

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,7 @@
 {
     "recommendations": [
-      "ms-dotnettools.csharp",
-      "ms-vscode.mono-debug",
-      "visualstudioexptteam.vscodeintellicode",
+      "ms-dotnettools.vscodeintellicode-csharp",
+      "ms-dotnettools.dotnet-maui",
+      "github.copilot-chat"
     ]
 }


### PR DESCRIPTION
### Description of Change

We were recommending some now less than useful extensions.  This updates the recommended extensions to be: C# Dev Kit, C# Intellicode, and GitHub CoPilot Chat, which will pull in their required dependencies as well.

