### PR TITLE
[Windows]  FilePicker picking multiple files is very slow because of `FutureAccessList` use

### DIFF
--- a/src/Essentials/src/FilePicker/FilePicker.uwp.cs
+++ b/src/Essentials/src/FilePicker/FilePicker.uwp.cs
@@ -40,12 +40,6 @@ namespace Microsoft.Maui.Storage
 					resultList.Add(file);
 			}
 
-			if (AppInfoUtils.IsPackagedApp)
-			{
-				foreach (var file in resultList)
-					StorageApplicationPermissions.FutureAccessList.Add(file);
-			}
-
 			return resultList.Select(storageFile => new FileResult(storageFile));
 		}
 


### PR DESCRIPTION
### Description of Change

Please read first this comment https://github.com/dotnet/maui/issues/19868#issuecomment-2166485653.

This PR removes adding data to future access list ... because it appears it's unnecessary. I think so because of dates of the two following changes:

* https://github.com/dotnet/maui/commit/de3def1b7efa1ad4dcc12c9386a0b7193cba35c8 - FilePicker picking multiple files (Mar 4, 2020)
* https://github.com/xamarin/Xamarin.Forms/pull/13584 (Jan 29, 2021)

The main reason why no future access list is necessary is IMHO because MAUI on Windows has [always](https://github.com/dotnet/maui/blob/b01e16389d30a6b894e2dc964320b7d7350b5d7b/src/Templates/src/templates/maui-mobile/Platforms/Windows/Package.appxmanifest#L43) `runFullTrust` capability. 

I'm not really sure if I got it right. Feel free to correct me. I asked here https://github.com/microsoft/microsoft-ui-xaml/discussions/9731 to get some clarity. To check if the app is running in AppContainer, one can probably use [this](https://github.com/dotnet/runtime/blob/9df96f9ffe9accd08bcd1d195c8ee118ffea1652/src/libraries/System.Diagnostics.PerformanceCounter/src/misc/EnvironmentHelpers.cs#L38-L52).

### How to test?

Run the essentials sample project and pick multiple files from any folder you like.

### Issues Fixed

Fixes #19868
