### PR TITLE
[iOS] TapGestureRecognizer should not fire when view is not enabled

### DIFF
--- a/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
@@ -608,6 +608,11 @@ namespace Microsoft.Maui.Controls.Platform
 			if (view == null)
 				return;
 
+			if (!view.IsEnabled)
+			{
+				return;
+			}
+
 			var tapPosition = e.GetPositionRelativeToPlatformElement(Control);
 
 			if (tapPosition == null)

--- a/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.iOS.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.iOS.cs
@@ -757,6 +757,11 @@ namespace Microsoft.Maui.Controls.Platform
 					return false;
 				}
 
+				if (!virtualView.IsEnabled)
+				{
+					return false;
+				}
+
 				if (touch.View == platformView)
 				{
 					return true;

--- a/src/Controls/tests/Core.UnitTests/Gestures/TapGestureRecognizerTests.cs
+++ b/src/Controls/tests/Core.UnitTests/Gestures/TapGestureRecognizerTests.cs
@@ -29,5 +29,21 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			tap.SendTapped(view);
 			Assert.Equal(result, tap.CommandParameter);
 		}
+
+		[Fact]
+		public void NoCallbackWhenViewIsDisabled()
+		{
+			var view = new View
+			{
+				IsEnabled = false
+			};
+
+			var tap = new TapGestureRecognizer();
+			object result = null;
+			tap.Command = new Command(o => result = o);
+
+			tap.SendTapped(view);
+			Assert.Null(result);
+		}
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/Gestures/TapGestureRecognizerTests.cs
+++ b/src/Controls/tests/Core.UnitTests/Gestures/TapGestureRecognizerTests.cs
@@ -29,21 +29,5 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			tap.SendTapped(view);
 			Assert.Equal(result, tap.CommandParameter);
 		}
-
-		[Fact]
-		public void NoCallbackWhenViewIsDisabled()
-		{
-			var view = new View
-			{
-				IsEnabled = false
-			};
-
-			var tap = new TapGestureRecognizer();
-			object result = null;
-			tap.Command = new Command(o => result = o);
-
-			tap.SendTapped(view);
-			Assert.Null(result);
-		}
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/GestureRecognizerUITests.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/GestureRecognizerUITests.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Maui.TestCases.Tests
 			App.Tap("DisabledTapSurface");
 
 			var result = App.FindElement("DisabledTapGestureResults").GetText();
-			ClassicAssert.AreNotEqual("Success", result);
+			ClassicAssert.AreNotEqual("Failed", result);
 		}
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/GestureRecognizerUITests.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/GestureRecognizerUITests.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Maui.TestCases.Tests
 			App.WaitForElement("SingleTapSurface");
 			App.Tap("SingleTapSurface");
 
-			var result = App.FindElement("SingleTapResults").GetText();
+			var result = App.FindElement("SingleTapGestureResults").GetText();
 			ClassicAssert.AreEqual("Success", result);
 		}
 		
@@ -79,7 +79,7 @@ namespace Microsoft.Maui.TestCases.Tests
 			App.WaitForElement("DisabledTapSurface");
 			App.Tap("DisabledTapSurface");
 
-			var result = App.FindElement("DisabledTapResults").GetText();
+			var result = App.FindElement("DisabledTapGestureResults").GetText();
 			ClassicAssert.AreNotEqual("Success", result);
 		}
 	}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/GestureRecognizerUITests.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/GestureRecognizerUITests.cs
@@ -52,5 +52,35 @@ namespace Microsoft.Maui.TestCases.Tests
 			var result = App.FindElement("DoubleTapResults").GetText();
 			ClassicAssert.AreEqual("Success", result);
 		}
+		
+		[Test]
+		[Category(UITestCategories.Gestures)]
+		public void SingleTap()
+		{
+			App.WaitForElement("TargetView");
+			App.EnterText("TargetView", "SingleTapGallery");
+			App.Tap("GoButton");
+
+			App.WaitForElement("SingleTapSurface");
+			App.Tap("SingleTapSurface");
+
+			var result = App.FindElement("SingleTapResults").GetText();
+			ClassicAssert.AreEqual("Success", result);
+		}
+		
+		[Test]
+		[Category(UITestCategories.Gestures)]
+		public void DisabledSingleTap()
+		{
+			App.WaitForElement("TargetView");
+			App.EnterText("TargetView", "SingleTapGallery");
+			App.Tap("GoButton");
+
+			App.WaitForElement("DisabledTapSurface");
+			App.Tap("DisabledTapSurface");
+
+			var result = App.FindElement("DisabledTapResults").GetText();
+			ClassicAssert.AreNotEqual("Success", result);
+		}
 	}
 }

--- a/src/Controls/tests/TestCases/Elements/GestureRecognizerGallery.cs
+++ b/src/Controls/tests/TestCases/Elements/GestureRecognizerGallery.cs
@@ -11,6 +11,7 @@ namespace Maui.Controls.Sample
 		{
 			Add(new PointerGestureRecognizerEvents());
 			Add(new DoubleTapGallery());
+			Add(new SingleTapGallery());
 		}
 	}
 }

--- a/src/Controls/tests/TestCases/Elements/TapGestureGallery.cs
+++ b/src/Controls/tests/TestCases/Elements/TapGestureGallery.cs
@@ -1,0 +1,52 @@
+using Microsoft.Maui.Controls;
+
+namespace Maui.Controls.Sample
+{
+	public class SingleTapGallery : Microsoft.Maui.Controls.ContentView
+	{
+		public SingleTapGallery()
+		{
+			AutomationId = nameof(SingleTapGallery);
+
+			var layout = new VerticalStackLayout { Margin = 10, Spacing = 10 };
+
+			var singleTapResults = new Label { AutomationId = "SingleTapGestureResults", Text = "Should succeed."};
+			var singleTapSurface = new Grid()
+			{
+				HeightRequest = 100,
+				WidthRequest = 200,
+				BackgroundColor = Microsoft.Maui.Graphics.Colors.AliceBlue,
+				Children = { new Label { Text = "SingleTapSurface", AutomationId = "SingleTapSurface" } }
+			};
+
+			var singleTapRecognizer = new TapGestureRecognizer();
+			singleTapRecognizer.Tapped += (sender, args) => { singleTapResults.Text = "Success"; };
+			singleTapSurface.GestureRecognizers.Add(singleTapRecognizer);
+
+			layout.Add(singleTapSurface);
+			layout.Add(singleTapResults);
+			
+			
+			// Now add a tap surface that is disabled and a results label that should not change when the surface is tapped
+			var disabledTapResults = new Label { AutomationId = "DisabledTapGestureResults", Text = "Should not succeed" };
+			var disabledTapSurface = new Grid()
+			{
+				IsEnabled = false, // Disabled
+				HeightRequest = 100,
+				WidthRequest = 200,
+				BackgroundColor = Microsoft.Maui.Graphics.Colors.Bisque,
+				Children = { new Label { Text = "DisabledTapSurface", AutomationId = "DisabledTapSurface" } }
+			};
+
+			// Wire up the tap gesture recognizer, it should never fire
+			var disabledTapRecognizer = new TapGestureRecognizer();
+			disabledTapRecognizer.Tapped += (sender, args) => { disabledTapResults.Text = "Success"; };
+			disabledTapSurface.GestureRecognizers.Add(disabledTapRecognizer);
+
+			layout.Add(disabledTapSurface);
+			layout.Add(disabledTapResults);
+
+			Content = layout;
+		}
+	}
+}

--- a/src/Controls/tests/TestCases/Elements/TapGestureGallery.cs
+++ b/src/Controls/tests/TestCases/Elements/TapGestureGallery.cs
@@ -28,7 +28,7 @@ namespace Maui.Controls.Sample
 			
 			
 			// Now add a tap surface that is disabled and a results label that should not change when the surface is tapped
-			var disabledTapResults = new Label { AutomationId = "DisabledTapGestureResults", Text = "Should not succeed" };
+			var disabledTapResults = new Label { AutomationId = "DisabledTapGestureResults", Text = "Should not change when tapped" };
 			var disabledTapSurface = new Grid()
 			{
 				IsEnabled = false, // Disabled
@@ -40,7 +40,7 @@ namespace Maui.Controls.Sample
 
 			// Wire up the tap gesture recognizer, it should never fire
 			var disabledTapRecognizer = new TapGestureRecognizer();
-			disabledTapRecognizer.Tapped += (sender, args) => { disabledTapResults.Text = "Success"; };
+			disabledTapRecognizer.Tapped += (sender, args) => { disabledTapResults.Text = "Failed"; };
 			disabledTapSurface.GestureRecognizers.Add(disabledTapRecognizer);
 
 			layout.Add(disabledTapSurface);


### PR DESCRIPTION
### Description of Change

On Android we check if the control is enabled or not for sending the touch event in the gesture manager: https://github.com/dotnet/maui/blob/79695fbb7ba6517a334c795ecf0a1d6358ef309a/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Android.cs#L66

We were not doing the same thing on iOS.  This takes a similar approach now as android does.

### Issues Fixed

Fixes #18995

