### PR TITLE
Make `MeasureInvalidated` event work correctly

### DIFF
--- a/src/Controls/src/Core/LegacyLayouts/Layout.cs
+++ b/src/Controls/src/Core/LegacyLayouts/Layout.cs
@@ -511,7 +511,7 @@ namespace Microsoft.Maui.Controls.Compatibility
 
 			if (child is View view)
 			{
-				// we can ignore the request if we are either fully constrained or when the size request changes and we were already fully constrainted
+				// we can ignore the request if we are either fully constrained or when the size request changes and we were already fully constrained
 				if ((trigger == InvalidationTrigger.MeasureChanged && view.Constraint == LayoutConstraint.Fixed) ||
 					(trigger == InvalidationTrigger.SizeRequestChanged && view.ComputedConstraint == LayoutConstraint.Fixed))
 				{

--- a/src/Controls/src/Core/LegacyLayouts/Layout.cs
+++ b/src/Controls/src/Core/LegacyLayouts/Layout.cs
@@ -319,6 +319,12 @@ namespace Microsoft.Maui.Controls.Compatibility
 		/// It is suggested to still call the base method and modify its calculated results.</remarks>
 		protected abstract void LayoutChildren(double x, double y, double width, double height);
 
+		internal override void OnChildMeasureInvalidatedInternal(VisualElement child, InvalidationTrigger trigger)
+		{
+			// TODO: once we remove old Xamarin public signatures we can invoke `OnChildMeasureInvalidated(VisualElement, InvalidationTrigger)` directly
+			OnChildMeasureInvalidated(child, new InvalidationEventArgs(trigger));
+		}
+
 		/// <summary>
 		/// Invoked whenever a child of the layout has emitted <see cref="VisualElement.MeasureInvalidated" />.
 		/// Implement this method to add class handling for this event.
@@ -603,14 +609,10 @@ namespace Microsoft.Maui.Controls.Compatibility
 			{
 				InvalidateLayout();
 			}
-
-			view.MeasureInvalidated += OnChildMeasureInvalidated;
 		}
 
 		void OnInternalRemoved(View view, int oldIndex)
 		{
-			view.MeasureInvalidated -= OnChildMeasureInvalidated;
-
 			OnChildRemoved(view, oldIndex);
 			if (ShouldInvalidateOnChildRemoved(view))
 			{

--- a/src/Controls/src/Core/Page/Page.cs
+++ b/src/Controls/src/Core/Page/Page.cs
@@ -66,7 +66,6 @@ namespace Microsoft.Maui.Controls
 
 		readonly Lazy<PlatformConfigurationRegistry<Page>> _platformConfigurationRegistry;
 
-		bool _allocatedFlag;
 		Rect _containerArea;
 
 		bool _containerAreaSet;
@@ -543,7 +542,6 @@ namespace Microsoft.Maui.Controls
 		/// <param name="height">The height allocated to the page.</param>
 		protected override void OnSizeAllocated(double width, double height)
 		{
-			_allocatedFlag = true;
 			base.OnSizeAllocated(width, height);
 			UpdateChildrenLayout();
 		}
@@ -605,12 +603,7 @@ namespace Microsoft.Maui.Controls
 				}
 			}
 
-			_allocatedFlag = false;
 			InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
-			if (!_allocatedFlag && Width >= 0 && Height >= 0)
-			{
-				SizeAllocated(Width, Height);
-			}
 		}
 
 		internal void OnAppearing(Action action)

--- a/src/Controls/src/Core/Page/Page.cs
+++ b/src/Controls/src/Core/Page/Page.cs
@@ -497,6 +497,12 @@ namespace Microsoft.Maui.Controls
 			if (TitleView != null)
 				SetInheritedBindingContext(TitleView, BindingContext);
 		}
+		
+		internal override void OnChildMeasureInvalidatedInternal(VisualElement child, InvalidationTrigger trigger)
+		{
+			// TODO: once we remove old Xamarin public signatures we can invoke `OnChildMeasureInvalidated(VisualElement, InvalidationTrigger)` directly
+			OnChildMeasureInvalidated(child, new InvalidationEventArgs(trigger));
+		}
 
 		/// <summary>
 		/// Indicates that the preferred size of a child <see cref="Element"/> has changed.
@@ -706,9 +712,6 @@ namespace Microsoft.Maui.Controls
 				for (var i = 0; i < e.OldItems.Count; i++)
 				{
 					var item = (Element)e.OldItems[i];
-					if (item is VisualElement visual)
-						visual.MeasureInvalidated -= OnChildMeasureInvalidated;
-
 					RemoveLogicalChild(item);
 				}
 			}
@@ -721,20 +724,21 @@ namespace Microsoft.Maui.Controls
 				{
 					int insertIndex = index;
 					if (insertIndex < 0)
-						insertIndex = InternalChildren.IndexOf(item);
-
-					if (item is VisualElement visual)
 					{
-						visual.MeasureInvalidated += OnChildMeasureInvalidated;
+						insertIndex = InternalChildren.IndexOf(item);
+					}
 
-						InsertLogicalChild(insertIndex, visual);
+					InsertLogicalChild(insertIndex, item);
+					
+					if (item is VisualElement)
+					{
 						InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
 					}
-					else
-						InsertLogicalChild(insertIndex, item);
-
+					
 					if (index >= 0)
+					{
 						index++;
+					}
 				}
 			}
 		}

--- a/src/Controls/tests/TestCases.HostApp/Elements/CollectionView/CollectionViewCoreGalleryPage.cs
+++ b/src/Controls/tests/TestCases.HostApp/Elements/CollectionView/CollectionViewCoreGalleryPage.cs
@@ -47,6 +47,7 @@ namespace Maui.Controls.Sample.CollectionViewGalleries
 						// SelectionShouldUpdateBinding (src\Compatibility\ControlGallery\src\Issues.Shared\CollectionViewBoundSingleSelection.cs)
 						// ItemsFromViewModelShouldBeSelected (src\Compatibility\ControlGallery\src\Issues.Shared\CollectionViewBoundMultiSelection.cs)
 						TestBuilder.NavButton("Selection Galleries", () => new SelectionGallery(), Navigation),
+						TestBuilder.NavButton("Item Size Galleries", () => new ItemsSizeGallery(), Navigation),
 					}
 					}
 				};


### PR DESCRIPTION
### Description of Change

`MeasureInvalidated` event was working fine on Xamarin, while on MAUI we basically forgot about bubbling up the event.

This causes the issues below where the system relays on this event to do something, like resizing the cell of a collection view.

This PR brings back the `MeasureInvalidated` event trigger on parents.

I've adjusted Xamarin components like `Layout` and `Page` to leverage the new internal method I put on `VisualElement`.

I've re-enabled the collection view testing gallery regarding dynamic sizing of elements in collection view.

I don't have much time available right now, so if you need to add more tests, feel free to do it.

### Issues Fixed

Fixes #15177
Fixes #20181
Fixes #22978