### PR TITLE
Make sure the main branch is using .NET 8 SDK

### DIFF
--- a/global.json
+++ b/global.json
@@ -6,5 +6,9 @@
     "MSBuild.Sdk.Extras": "3.0.44",
     "Microsoft.Build.NoTargets": "3.7.0",
     "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.24310.5"
+  },
+  "sdk": {
+    "version": "8.0.100",
+    "rollForward": "latestMinor"
   }
 }

--- a/global.json
+++ b/global.json
@@ -8,7 +8,6 @@
     "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.24310.5"
   },
   "sdk": {
-    "version": "8.0.100",
-    "rollForward": "latestMinor"
+    "allowPrerelease": false
   }
 }


### PR DESCRIPTION



### Description of Change

The main branch needs to use the .NET 8 SDK because we are building the .NET 7 TFMs as well. The .NET 9 SDK does not support .NET 7 TFMs anymore.