### PR TITLE
Fix loaded so it fires on second subscription

### DIFF
--- a/src/Controls/src/Core/VisualElement/VisualElement.Standard.cs
+++ b/src/Controls/src/Core/VisualElement/VisualElement.Standard.cs
@@ -8,13 +8,13 @@ namespace Microsoft.Maui.Controls
 	{
 		partial void HandlePlatformUnloadedLoaded()
 		{
-			if (Window != null)
+			if (this.IsLoaded)
 			{
-				SendLoaded();
+				SendLoaded(false);
 			}
 			else
 			{
-				SendUnloaded();
+				SendUnloaded(false);
 			}
 		}
 	}

--- a/src/Controls/src/Core/VisualElement/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement/VisualElement.cs
@@ -2146,19 +2146,19 @@ namespace Microsoft.Maui.Controls
 		{
 			add
 			{
-				bool watchingLoaded = _watchingPlatformLoaded;
+				bool loadedAlreadyFired = _isLoadedFired;
+
 				_loaded += value;
 				UpdatePlatformUnloadedLoadedWiring(Window);
 
-				// The point of this code, is to fire loaded if the element is already loaded.
-				//
-				// If this is the first time the user is subscribing to Loaded,
-				// UpdatePlatformUnloadedLoadedWiring will take care of firing Loaded.
-				// If we are already wired up to watch loaded, then we'll fire it off if we know this
-				// view is in a state where it's been determined that it's accurate to fire
-				// _isLoadedFired.
-				if (_isLoadedFired && watchingLoaded)
+				// The first time UpdatePlatformUnloadedLoadedWiring is called it will handle
+				// invoking _loaded
+				// This is only to make sure that new subscribers get invoked when the element is already loaded
+				// and a previous subscriber has already invoked the UpdatePlatformUnloadedLoadedWiring path
+				if (loadedAlreadyFired)
+				{
 					value?.Invoke(this, EventArgs.Empty);
+				}
 
 			}
 			remove
@@ -2212,7 +2212,9 @@ namespace Microsoft.Maui.Controls
 			// unloaded is still correctly being watched for.
 
 			if (updateWiring)
+			{
 				UpdatePlatformUnloadedLoadedWiring(Window);
+			}
 		}
 
 		void SendUnloaded() => SendUnloaded(true);

--- a/src/Controls/src/Core/VisualElement/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement/VisualElement.cs
@@ -2155,7 +2155,7 @@ namespace Microsoft.Maui.Controls
 				// invoking _loaded
 				// This is only to make sure that new subscribers get invoked when the element is already loaded
 				// and a previous subscriber has already invoked the UpdatePlatformUnloadedLoadedWiring path
-				if (loadedAlreadyFired)
+				if (loadedAlreadyFired && _isLoadedFired)
 				{
 					value?.Invoke(this, EventArgs.Empty);
 				}

--- a/src/Controls/tests/Core.UnitTests/PageLifeCycleTests.cs
+++ b/src/Controls/tests/Core.UnitTests/PageLifeCycleTests.cs
@@ -288,6 +288,31 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact]
+		public async Task LoadedFiresOnSecondSubscription()
+		{
+			var previousPage = new LCPage();
+			var lcPage = new LCPage();
+			var navigationPage =
+				new TestNavigationPage(true, previousPage)
+					.AddToTestWindow();
+
+			await navigationPage.PushAsync(lcPage);
+
+			int loadedCnt = 0;
+			lcPage.Loaded += OnLoaded;
+			Assert.Equal(1, loadedCnt);
+
+			lcPage.Loaded -= OnLoaded;
+			lcPage.Loaded += OnLoaded;		
+			Assert.Equal(2, loadedCnt);
+
+			void OnLoaded(object sender, System.EventArgs e)
+			{
+				loadedCnt++;
+			}
+		}
+
+		[Fact]
 		public async Task LoadedFiresOnInitialSubscription()
 		{
 			var previousPage = new LCPage();
@@ -299,6 +324,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			await navigationPage.PushAsync(lcPage);
 
 			int loadedCnt = 0;
+			int secondLoadedSubscriberCnt = 0;
 			int unLoadedCnt = 0;
 
 			Assert.True(lcPage.IsLoaded);
@@ -309,21 +335,25 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 				loadedCnt++;
 			};
 
-			// Subscribing to loaded should fire the loaded
-			// event if the page is already loaded
+			Assert.Equal(1, loadedCnt);
+
+			// Subscribing to loaded a second time
+			// Should fire the event on the new subsciber;
 			lcPage.Loaded += (_, _) => 
 			{
-				loadedCnt++;
+				secondLoadedSubscriberCnt++;
 			};
 
 			lcPage.Unloaded += (_, _) => unLoadedCnt++;
 
-			Assert.Equal(2, loadedCnt);
+			Assert.Equal(1, loadedCnt);
+			Assert.Equal(1, secondLoadedSubscriberCnt);
 			Assert.Equal(0, unLoadedCnt);
 			
 			await navigationPage.PopAsync();
 
-			Assert.Equal(2, loadedCnt);
+			Assert.Equal(1, loadedCnt);
+			Assert.Equal(1, secondLoadedSubscriberCnt);
 			Assert.Equal(1, unLoadedCnt);
 		}
 


### PR DESCRIPTION
### Description of Change

The fix here should have just been to watch if "Loaded" had already been fired on entry to the subscriber. We just kept kind of building up conditionals instead of correcting the initial misstep. 

### Issues Fixed


Fixes #23058
Fixes #23080

