### PR TITLE
[ci] Set OfficialBuildId when building asset manifests

### DIFF
--- a/eng/pipelines/common/sdk-insertion.yml
+++ b/eng/pipelines/common/sdk-insertion.yml
@@ -78,6 +78,7 @@ jobs:
       projects: $(Build.SourcesDirectory)\src\Workload\Microsoft.Maui.Sdk\Microsoft.Maui.Sdk.csproj
       arguments: >-
         -t:PushManifestToBuildAssetRegistry
+        -p:OfficialBuildId=$(_BuildOfficalId)
         -p:BuildAssetRegistryToken=$(MaestroAccessToken)
         -p:OutputPath=$(Build.StagingDirectory)\nuget-signed\
         -v:n -bl:$(Build.StagingDirectory)\binlogs\push-bar-manifest.binlog

--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -1,6 +1,8 @@
 variables:
 - name: BuildVersion
   value: $[counter('buildversion-counter', 5000)]
+- name: _BuildOfficalId
+  value: $[ format('{0}.{1}', format('{0:yyyyMMdd}', pipeline.startTime), counter(format('{0:yyyyMMdd}', pipeline.startTime), 1) )]
 - name: NUGET_VERSION
   value: 6.4.0
 - name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE

--- a/eng/pipelines/maui-release.yml
+++ b/eng/pipelines/maui-release.yml
@@ -137,9 +137,7 @@ extends:
                 value: $(Build.SourcesDirectory)/build.cmd -ci
               - name: _BuildConfig
                 value: Release
-              - name: _BuildOfficalId
-                value: $[ format('{0}.{1}', format('{0:yyyyMMdd}', pipeline.startTime), counter(format('{0:yyyyMMdd}', pipeline.startTime), 1) )]
-            
+
             steps:
               - template: /eng/pipelines/common/pack.yml@self
                 parameters:

--- a/src/Workload/Shared/Maestro.targets
+++ b/src/Workload/Shared/Maestro.targets
@@ -48,15 +48,17 @@
         AssetManifestPath="$(AssetManifestPath)"
         PublishingVersion="3" />
 
+    <Message Text="BAR manifest version: $(PackageReferenceVersion)" />
+
     <MSBuild
         Targets="Restore"
         Projects="$(PkgMicrosoft_DotNet_Arcade_Sdk)\tools\SdkTasks\PublishBuildAssets.proj"
-        Properties="Configuration=$(Configuration);RepoRoot=$(MauiRootDirectory);VersionPrefix=$(Version)"
+        Properties="Configuration=$(Configuration);RepoRoot=$(MauiRootDirectory);VersionPrefix=$(PackageReferenceVersion)"
     />
 
     <MSBuild
         Projects="$(PkgMicrosoft_DotNet_Arcade_Sdk)\tools\SdkTasks\PublishBuildAssets.proj"
-        Properties="Configuration=$(Configuration);RepoRoot=$(MauiRootDirectory);VersionPrefix=$(Version);ManifestsPath=$(ArtifactsLogDir)AssetManifest;MaestroApiEndpoint=https://maestro.dot.net"
+        Properties="Configuration=$(Configuration);RepoRoot=$(MauiRootDirectory);VersionPrefix=$(PackageReferenceVersion);ManifestsPath=$(ArtifactsLogDir)AssetManifest;MaestroApiEndpoint=https://maestro.dot.net"
     />
   </Target>
 


### PR DESCRIPTION
Context: https://github.com/dotnet/maui/commit/812807c5cbe2cebc2e6cc49eff0dbde0f4e3a460

The maestro build promotion step has been failing with:

    PublishArtifactsInManifest.proj(130,5): error : Asset 'D:\a\_work\1\a\3fecf55a-18fb-414d-b980-84c0f56a3856\MergedManifest.xml' already exists with different contents at 'https://dotnetbuilds.blob.core.windows.net/public/assets/manifests/dotnet-maui/9.0.0-ci-dev/MergedManifest.xml'

The manifest version information passed to the `PublishBuildAssets.proj`
build does not contain revision information, causing asset publishing
to fail as it will not overwrite existing assets with the same version.

We should be able to fix this by setting the `OfficialBuildId` property
when building the asset manifests, similar to what is currently being
done when [packing the NuGets][0].

[0]: https://github.com/dotnet/maui/blob/5d3e788f297098417f6c603e5187fb24a37dda63/eng/cake/dotnet.cake#L285