### PR TITLE
Make sure the view is still alive after posting

### DIFF
--- a/src/Core/src/Platform/Android/ImageButtonExtensions.cs
+++ b/src/Core/src/Platform/Android/ImageButtonExtensions.cs
@@ -36,6 +36,9 @@ namespace Microsoft.Maui.Platform
 			// https://github.com/material-components/material-components-android/issues/2063
 			await Task.Yield();
 
+			if (!platformButton.IsAlive())
+				return;
+
 			// We must re-set all the paddings because the first time was not hard enough.
 			platformButton.SetContentPadding((int)padding.Left, (int)padding.Top, (int)padding.Right, (int)padding.Bottom);
 			platformButton.SetPadding(0, 0, 0, 0);


### PR DESCRIPTION



### Description of Change

I saw in some of my local testing the shape view may actually be disposed if you write code or when you run the device tests.

When we come back after the UI loop, make sure the platform view is still alive.

This should not happen if the view is attached to the UI since it is still being used, but if you happen to navigate or close some popup it may occur.