### PR TITLE
[Tests] Update to Appium 5.0.0

### DIFF
--- a/src/Controls/tests/TestCases.Android.Tests/Controls.TestCases.Android.Tests.csproj
+++ b/src/Controls/tests/TestCases.Android.Tests/Controls.TestCases.Android.Tests.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Appium.WebDriver" Version="5.0.0-rc.7" />
+    <PackageReference Include="Appium.WebDriver" Version="5.0.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
   </ItemGroup>

--- a/src/Controls/tests/TestCases.Mac.Tests/Controls.TestCases.Mac.Tests.csproj
+++ b/src/Controls/tests/TestCases.Mac.Tests/Controls.TestCases.Mac.Tests.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Appium.WebDriver" Version="5.0.0-rc.7" />
+    <PackageReference Include="Appium.WebDriver" Version="5.0.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
   </ItemGroup>

--- a/src/Controls/tests/TestCases.WinUI.Tests/Controls.TestCases.WinUI.Tests.csproj
+++ b/src/Controls/tests/TestCases.WinUI.Tests/Controls.TestCases.WinUI.Tests.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Appium.WebDriver" Version="5.0.0-rc.7" />
+    <PackageReference Include="Appium.WebDriver" Version="5.0.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
   </ItemGroup>

--- a/src/Controls/tests/TestCases.iOS.Tests/Controls.TestCases.iOS.Tests.csproj
+++ b/src/Controls/tests/TestCases.iOS.Tests/Controls.TestCases.iOS.Tests.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Appium.WebDriver" Version="5.0.0-rc.7" />
+    <PackageReference Include="Appium.WebDriver" Version="5.0.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
   </ItemGroup>

--- a/src/TestUtils/src/UITest.Appium/Actions/AppiumLifecycleActions.cs
+++ b/src/TestUtils/src/UITest.Appium/Actions/AppiumLifecycleActions.cs
@@ -61,12 +61,6 @@ namespace UITest.Appium
 					{ "bundleId", _app.GetAppId() },
 				});
 			}
-			else if (_app.GetTestDevice() == TestDevice.Windows)
-			{
-#pragma warning disable CS0618 // Type or member is obsolete
-				_app.Driver.LaunchApp();
-#pragma warning restore CS0618 // Type or member is obsolete
-			}
 			else 
 			{
 				_app.Driver.ActivateApp(_app.GetAppId());
@@ -142,12 +136,6 @@ namespace UITest.Appium
 					{
 						{ "bundleId", _app.GetAppId() },
 					});
-				}
-				else if (_app.GetTestDevice() == TestDevice.Windows)
-				{
-	#pragma warning disable CS0618 // Type or member is obsolete
-					_app.Driver.CloseApp();
-	#pragma warning restore CS0618 // Type or member is obsolete
 				}
 				else
 				{

--- a/src/TestUtils/src/UITest.Appium/Actions/AppiumLifecycleActions.cs
+++ b/src/TestUtils/src/UITest.Appium/Actions/AppiumLifecycleActions.cs
@@ -55,13 +55,21 @@ namespace UITest.Appium
 				return CommandResponse.FailedEmptyResponse;
 
 			if (_app.GetTestDevice() == TestDevice.Mac)
-			{	
+			{
 				_app.Driver.ExecuteScript("macos: activateApp", new Dictionary<string, object>
 				{
 					{ "bundleId", _app.GetAppId() },
 				});
 			}
-			else 
+			else if (_app.Driver is WindowsDriver windowsDriver)
+			{
+				// Appium driver removed the LaunchApp method in 5.0.0, so we need to use the executeScript method instead
+				// Currently the appium-windows-driver reports the following commands as compatible:
+				//   startRecordingScreen,stopRecordingScreen,launchApp,closeApp,deleteFile,deleteFolder,
+				//   click,scroll,clickAndDrag,hover,keys,setClipboard,getClipboard
+				windowsDriver.ExecuteScript("windows: launchApp", [_app.GetAppId()]);
+			}
+			else
 			{
 				_app.Driver.ActivateApp(_app.GetAppId());
 			}
@@ -121,7 +129,7 @@ namespace UITest.Appium
 			}
 			catch (Exception)
 			{
-				// TODO Pass in logger so we can log these exceptions
+				// TODO: Pass in logger so we can log these exceptions
 				
 				// Occasionally the app seems to get so locked up it can't 
 				// even report back the appstate. In that case, we'll just
@@ -136,6 +144,13 @@ namespace UITest.Appium
 					{
 						{ "bundleId", _app.GetAppId() },
 					});
+				}
+				else if (_app.Driver is WindowsDriver windowsDriver)
+				{
+					// This is still here for now, but it looks like it will get removed just like
+					// LaunchApp was in 5.0.0, in which case we may need to use:
+					// windowsDriver.ExecuteScript("windows: closeApp", [_app.GetAppId()]);
+					windowsDriver.CloseApp();
 				}
 				else
 				{

--- a/src/TestUtils/src/UITest.Appium/UITest.Appium.csproj
+++ b/src/TestUtils/src/UITest.Appium/UITest.Appium.csproj
@@ -7,8 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Appium.WebDriver" Version="5.0.0-rc.7" />
-    <PackageReference Include="System.Drawing.Common" Version="8.0.3" />
+    <PackageReference Include="Appium.WebDriver" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
There was a previous PR that ran into issues with a later prerelease: #22117 Now that 5.0.0 is out, trying to update again.

- `WindowsDriver` still implements `CloseApp` which was [moved](https://github.com/appium/dotnet-client/pull/773) from the appium driver, so we can use it by casting still.
- `LaunchApp` is now [removed](https://github.com/appium/dotnet-client/pull/766) completely and `ActivateApp` throws not implemented, so we can't use it on windows and instead are using `driver.ExecuteScript("windows: launchApp", ["my-app-id"]);`

I've opened an issue on the dotnet appium driver repo for reference: https://github.com/appium/dotnet-client/issues/793

I also removed an extra explicit ref to `System.Drawing.Common` since it comes in transitively from `Appium.Webdriver` package (and the version was causing issues since the newer appium.webdriver uses a newer version).

