### PR TITLE
Use correct interface type in FrameRenderer

### DIFF
--- a/global.json
+++ b/global.json
@@ -6,5 +6,8 @@
     "MSBuild.Sdk.Extras": "3.0.44",
     "Microsoft.Build.NoTargets": "3.7.0",
     "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.24310.5"
+  },
+  "sdk": {
+    "allowPrerelease": false
   }
 }

--- a/src/Controls/src/Core/Compatibility/Handlers/Android/FrameRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Android/FrameRenderer.cs
@@ -176,7 +176,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 
 			if (Element.Handler is IPlatformViewHandler pvh &&
-				Element is IContentView cv)
+				Element is ICrossPlatformLayout cv)
 			{
 				pvh.LayoutVirtualView(l, t, r, b, cv.CrossPlatformArrange);
 			}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue18526.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue18526.cs
@@ -1,0 +1,26 @@
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue18526 : _IssuesUITest
+{
+	public override string Issue => "Border not rendering inside a frame";
+
+	public Issue18526(TestDevice device)
+		: base(device)
+	{ }
+
+    [Test]
+    [Category(UITestCategories.Frame)]
+	public void BorderShouldRender()
+	{
+		var label = App.WaitForElement("label");
+        var size = label.GetRect();
+        Assert.That(label.GetText(), Is.EqualTo(".NET MAUI"));
+        Assert.That(size.Width, Is.GreaterThan(0));
+        Assert.That(size.Height, Is.GreaterThan(0));
+	}
+} 

--- a/src/Controls/tests/TestCases/Issues/Issue18526.xaml
+++ b/src/Controls/tests/TestCases/Issues/Issue18526.xaml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Maui.Controls.Sample.Issues.Issue18526">
+
+         <Frame Padding="30" Margin="30"
+                HorizontalOptions="Center"
+                VerticalOptions="Start" >
+            <Border Stroke="#C49B33"
+                    StrokeThickness="4"
+                    StrokeShape="RoundRectangle 40,0,0,40"
+                    Background="#2B0B98"
+                    Padding="16,8"
+                    HorizontalOptions="Center" Grid.Row="0">
+                <Label Text=".NET MAUI"
+                    AutomationId="label"
+                    TextColor="White"
+                    FontSize="18"
+                    FontAttributes="Bold" />
+            </Border>
+         </Frame>
+</ContentPage>

--- a/src/Controls/tests/TestCases/Issues/Issue18526.xaml.cs
+++ b/src/Controls/tests/TestCases/Issues/Issue18526.xaml.cs
@@ -1,0 +1,14 @@
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 18526, "Border not rendering inside a frame", PlatformAffected.All)]
+
+public partial class Issue18526 : ContentPage
+{
+	public Issue18526()
+	{
+		InitializeComponent();
+	}
+}


### PR DESCRIPTION
### Description of Change

We're using the wrong interface type on the arrange call of `FrameRenderer`. Measure was already updated to use `ICrossPlatformLayout`

### Issues Fixed


Fixes https://github.com/dotnet/maui/issues/18526
Fixes https://github.com/dotnet/maui/issues/18755
Fixes https://github.com/dotnet/maui/issues/20944
Fixes #23036


