### PR TITLE
fix: fix 23131 can't reuse BottomItem's tabEnabled

### DIFF
--- a/src/Controls/src/Core/Platform/Android/BottomNavigationViewUtils.cs
+++ b/src/Controls/src/Core/Platform/Android/BottomNavigationViewUtils.cs
@@ -102,6 +102,7 @@ namespace Microsoft.Maui.Controls.Platform
 					else
 					{
 						SetMenuItemTitle(menuItem, item.title);
+						UpdateEnabled(item.tabEnabled, menuItem);
 						loadTasks.Add(SetMenuItemIcon(menuItem, item.icon, mauiContext));
 					}
 				}


### PR DESCRIPTION
### Description of Change

<!-- Enter description of the fix in this section -->

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #23131

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
