### PR TITLE
Improve performance and stability of `BindableLayout`

### DIFF
--- a/src/Controls/src/Core/BindableLayout/BindableLayout.cs
+++ b/src/Controls/src/Core/BindableLayout/BindableLayout.cs
@@ -1,9 +1,9 @@
 #nullable disable
 using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.Collections.Specialized;
 using Microsoft.Maui.Controls.Internals;
+using Microsoft.Maui.Dispatching;
 
 namespace Microsoft.Maui.Controls
 {
@@ -148,6 +148,18 @@ namespace Microsoft.Maui.Controls
 				_ = layout.Children.Add(item);
 			}
 		}
+		
+		internal static void Replace(this IBindableLayout layout, object item, int index)
+		{
+			if (layout is Maui.ILayout mauiLayout && item is IView view)
+			{
+				mauiLayout[index] = view;
+			}
+			else
+			{
+				layout.Children[index] = item;
+			}
+		}
 
 		internal static void Insert(this IBindableLayout layout, object item, int index)
 		{
@@ -200,9 +212,35 @@ namespace Microsoft.Maui.Controls
 
 	class BindableLayoutController
 	{
+		static readonly BindableProperty BindableLayoutTemplateProperty = BindableProperty.CreateAttached("BindableLayoutTemplate", typeof(DataTemplate), typeof(BindableLayoutController), default(DataTemplate));
+		
+		/// <summary>
+		/// Gets the template reference used to generate a view in the <see cref="BindableLayout"/>.
+		/// </summary>
+		static DataTemplate GetBindableLayoutTemplate(BindableObject b)
+		{
+			return (DataTemplate)b.GetValue(BindableLayoutTemplateProperty);
+		}
+		
+		/// <summary>
+		/// Sets the template reference used to generate a view in the <see cref="BindableLayout"/>.
+		/// </summary>
+		static void SetBindableLayoutTemplate(BindableObject b, DataTemplate value)
+		{
+			b.SetValue(BindableLayoutTemplateProperty, value);
+		}
+
+		static readonly DataTemplate DefaultItemTemplate = new DataTemplate(() =>
+		{
+			var label = new Label { HorizontalTextAlignment = TextAlignment.Center };
+			label.SetBinding(Label.TextProperty, ".");
+			return label;
+		});
+
 		readonly WeakReference<IBindableLayout> _layoutWeakReference;
 		readonly WeakNotifyCollectionChangedProxy _collectionChangedProxy = new();
 		readonly NotifyCollectionChangedEventHandler _collectionChangedEventHandler;
+		readonly IDispatcher _dispatcher;
 		IEnumerable _itemsSource;
 		DataTemplate _itemTemplate;
 		DataTemplateSelector _itemTemplateSelector;
@@ -220,6 +258,7 @@ namespace Microsoft.Maui.Controls
 
 		public BindableLayoutController(IBindableLayout layout)
 		{
+			_dispatcher = (layout as BindableObject)?.Dispatcher;
 			_layoutWeakReference = new WeakReference<IBindableLayout>(layout);
 			_collectionChangedEventHandler = ItemsSourceCollectionChanged;
 		}
@@ -290,7 +329,7 @@ namespace Microsoft.Maui.Controls
 
 			if (!_isBatchUpdate)
 			{
-				CreateChildren();
+				UpdateEmptyView();
 			}
 		}
 
@@ -302,8 +341,18 @@ namespace Microsoft.Maui.Controls
 
 			if (!_isBatchUpdate)
 			{
-				CreateChildren();
+				UpdateEmptyView();
 			}
+		}
+
+		void UpdateEmptyView()
+		{
+			if (!_layoutWeakReference.TryGetTarget(out IBindableLayout layout))
+			{
+				return;
+			}
+
+			TryAddEmptyView(layout, out _);
 		}
 
 		void CreateChildren()
@@ -313,17 +362,95 @@ namespace Microsoft.Maui.Controls
 				return;
 			}
 
-			ClearChildren(layout);
-
-			UpdateEmptyView(layout);
-
-			if (_itemsSource == null)
-				return;
-
-			foreach (object item in _itemsSource)
+			if (TryAddEmptyView(layout, out IEnumerator enumerator))
 			{
-				layout.Add(CreateItemView(item, layout));
+				return;
 			}
+
+			var layoutChildren = layout.Children;
+			var childrenCount = layoutChildren.Count;
+
+			// if we have the empty view, remove it before generating children
+			if (childrenCount == 1 && layoutChildren[0] == _currentEmptyView)
+			{
+				layout.RemoveAt(0);
+				childrenCount = 0;
+			}
+
+			// Add or replace items
+			var index = 0;
+			do
+			{
+				var item = enumerator.Current;
+				if (index < childrenCount)
+				{
+					ReplaceChild(item, layout, layoutChildren, index);
+				}
+				else
+				{
+					layout.Add(CreateItemView(item, SelectTemplate(item, layout)));
+				}
+
+				++index;
+			} while (enumerator.MoveNext());
+
+			// Remove exceeding items
+			while (index <= --childrenCount)
+			{
+				var child = (BindableObject) layoutChildren[childrenCount]!;
+				layout.RemoveAt(childrenCount);
+				// It's our responsibility to clear the BindingContext for the children
+				// Given that we've set them manually in CreateItemView
+				child.BindingContext = null;
+			}
+		}
+
+		bool TryAddEmptyView(IBindableLayout layout, out IEnumerator enumerator)
+		{
+			enumerator = _itemsSource?.GetEnumerator();
+
+			if (enumerator == null || !enumerator.MoveNext())
+			{
+				var layoutChildren = layout.Children;
+				
+				// We may have a single child that is either the old empty view or a generated item
+				if (layoutChildren.Count == 1)
+				{
+					var maybeEmptyView = (View)layoutChildren[0]!;
+					
+					// If the current empty view is already in place we have nothing to do
+					if (maybeEmptyView == _currentEmptyView)
+					{
+						return true;
+					}
+					
+					// We may have a single child that is either the old empty view or a generated item
+					// So remove it to make room for the new empty view
+					layout.RemoveAt(0);
+					
+					// If this is a generated item, we need to clear the BindingContext
+					if (maybeEmptyView.IsSet(BindableLayoutTemplateProperty))
+					{
+						maybeEmptyView.ClearValue(BindableObject.BindingContextProperty);
+					}
+				}
+				else if (layoutChildren.Count > 1)
+				{
+					// If we have more than one child it means we have generated items only
+					// So clear them all to make room for the new empty view
+					ClearChildren(layout);
+				}
+				
+				// If an empty view is set, add it
+				if (_currentEmptyView != null)
+				{
+					layout.Add(_currentEmptyView);
+				}
+
+				return true;
+			}
+
+			return false;
 		}
 
 		void ClearChildren(IBindableLayout layout)
@@ -333,47 +460,15 @@ namespace Microsoft.Maui.Controls
 			{
 				var child = (View)layout.Children[index]!;
 				layout.RemoveAt(index);
-
-				// Empty view inherits the BindingContext automatically,
-				// we don't want to mess up with automatic inheritance.
-				if (child == _currentEmptyView) continue;
 				
-				// Given that we've set BindingContext manually on children we have to clear it on removal.
-				child.BindingContext = null;
+				// It's our responsibility to clear the manually-set BindingContext for the generated children
+				child.ClearValue(BindableObject.BindingContextProperty);
 			}
 		}
 
-		void UpdateEmptyView(IBindableLayout layout)
+		DataTemplate SelectTemplate(object item, IBindableLayout layout)
 		{
-			if (_currentEmptyView == null)
-				return;
-
-			if (!_itemsSource?.GetEnumerator().MoveNext() ?? true)
-			{
-				layout.Add(_currentEmptyView);
-				return;
-			}
-
-			layout.Remove(_currentEmptyView);
-		}
-
-		View CreateItemView(object item, IBindableLayout layout)
-		{
-			return CreateItemView(item, _itemTemplate ?? _itemTemplateSelector?.SelectTemplate(item, layout as BindableObject));
-		}
-
-		View CreateItemView(object item, DataTemplate dataTemplate)
-		{
-			if (dataTemplate != null)
-			{
-				var view = (View)dataTemplate.CreateContent();
-				view.BindingContext = item;
-				return view;
-			}
-			else
-			{
-				return new Label { Text = item?.ToString(), HorizontalTextAlignment = TextAlignment.Center };
-			}
+			return _itemTemplate ?? _itemTemplateSelector?.SelectTemplate(item, layout as BindableObject) ?? DefaultItemTemplate;
 		}
 
 		View CreateEmptyView(object emptyView, DataTemplate dataTemplate)
@@ -399,13 +494,36 @@ namespace Microsoft.Maui.Controls
 
 		void ItemsSourceCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
 		{
+			if (_dispatcher?.IsDispatchRequired ?? false)
+			{
+				_dispatcher.Dispatch(() => UpdateCollection(e));
+				return;
+			}
+
+			UpdateCollection(e);
+		}
+
+		void UpdateCollection(NotifyCollectionChangedEventArgs e)
+		{
 			if (!_layoutWeakReference.TryGetTarget(out IBindableLayout layout))
 			{
 				return;
 			}
 
+			if (e.Action == NotifyCollectionChangedAction.Replace)
+			{
+				var index = e.OldStartingIndex;
+				var layoutChildren = layout.Children;
+				foreach (var item in e.NewItems!)
+				{
+					ReplaceChild(item, layout, layoutChildren, index);
+					++index;
+				}
+				return;
+			}
+			
 			e.Apply(
-				insert: (item, index, _) => layout.Insert(CreateItemView(item, layout), index),
+				insert: (item, index, _) => layout.Insert(CreateItemView(item, SelectTemplate(item, layout)), index),
 				removeAt: (item, index) =>
 				{
 					var child = (View)layout.Children[index]!;
@@ -414,12 +532,40 @@ namespace Microsoft.Maui.Controls
 					// It's our responsibility to clear the BindingContext for the children
 					// Given that we've set them manually in CreateItemView
 					child.BindingContext = null;
+
+					// If we removed the last item, we need to insert the empty view
+					if (layout.Children.Count == 0 && _currentEmptyView != null)
+					{
+						layout.Add(_currentEmptyView);
+					}
 				},
 				reset: CreateChildren);
+		}
 
-			// UpdateEmptyView is called from within CreateChildren, therefor skip it for Reset
-			if (e.Action != NotifyCollectionChangedAction.Reset)
-				UpdateEmptyView(layout);
+		void ReplaceChild(object item, IBindableLayout layout, IList layoutChildren, int index)
+		{
+			var template = SelectTemplate(item, layout);
+			var child = (BindableObject) layoutChildren[index]!;
+			var currentTemplate = GetBindableLayoutTemplate(child);
+			if (currentTemplate == template)
+			{
+				child.BindingContext = item;
+			}
+			else
+			{
+				// It's our responsibility to clear the BindingContext for the children
+				// Given that we've set them manually in CreateItemView
+				child.BindingContext = null;
+				layout.Replace(CreateItemView(item, template), index);
+			}
+		}
+		
+		static View CreateItemView(object item, DataTemplate dataTemplate)
+		{
+			var view = (View)dataTemplate.CreateContent();
+			SetBindableLayoutTemplate(view, dataTemplate);
+			view.BindingContext = item;
+			return view;
 		}
 	}
 }

--- a/src/Controls/src/Core/BindableLayout/BindableLayout.cs
+++ b/src/Controls/src/Core/BindableLayout/BindableLayout.cs
@@ -3,7 +3,6 @@ using System;
 using System.Collections;
 using System.Collections.Specialized;
 using Microsoft.Maui.Controls.Internals;
-using Microsoft.Maui.Dispatching;
 
 namespace Microsoft.Maui.Controls
 {
@@ -240,7 +239,6 @@ namespace Microsoft.Maui.Controls
 		readonly WeakReference<IBindableLayout> _layoutWeakReference;
 		readonly WeakNotifyCollectionChangedProxy _collectionChangedProxy = new();
 		readonly NotifyCollectionChangedEventHandler _collectionChangedEventHandler;
-		readonly IDispatcher _dispatcher;
 		IEnumerable _itemsSource;
 		DataTemplate _itemTemplate;
 		DataTemplateSelector _itemTemplateSelector;
@@ -258,7 +256,6 @@ namespace Microsoft.Maui.Controls
 
 		public BindableLayoutController(IBindableLayout layout)
 		{
-			_dispatcher = (layout as BindableObject)?.Dispatcher;
 			_layoutWeakReference = new WeakReference<IBindableLayout>(layout);
 			_collectionChangedEventHandler = ItemsSourceCollectionChanged;
 		}
@@ -493,17 +490,6 @@ namespace Microsoft.Maui.Controls
 		}
 
 		void ItemsSourceCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
-		{
-			if (_dispatcher?.IsDispatchRequired ?? false)
-			{
-				_dispatcher.Dispatch(() => UpdateCollection(e));
-				return;
-			}
-
-			UpdateCollection(e);
-		}
-
-		void UpdateCollection(NotifyCollectionChangedEventArgs e)
 		{
 			if (!_layoutWeakReference.TryGetTarget(out IBindableLayout layout))
 			{

--- a/src/Controls/src/Core/BindableLayout/BindableLayout.cs
+++ b/src/Controls/src/Core/BindableLayout/BindableLayout.cs
@@ -509,7 +509,16 @@ namespace Microsoft.Maui.Controls
 			}
 			
 			e.Apply(
-				insert: (item, index, _) => layout.Insert(CreateItemView(item, SelectTemplate(item, layout)), index),
+				insert: (item, index, _) =>
+				{
+					var layoutChildren = layout.Children;
+					if (layoutChildren.Count == 1 && layoutChildren[0] == _currentEmptyView)
+					{
+						layout.RemoveAt(0);
+					}
+
+					layout.Insert(CreateItemView(item, SelectTemplate(item, layout)), index);
+				},
 				removeAt: (item, index) =>
 				{
 					var child = (View)layout.Children[index]!;

--- a/src/Controls/tests/Core.UnitTests/BindableLayoutTests.cs
+++ b/src/Controls/tests/Core.UnitTests/BindableLayoutTests.cs
@@ -13,7 +13,6 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 {
 	using StackLayout = Microsoft.Maui.Controls.Compatibility.StackLayout;
 
-
 	public class BindableLayoutTests : BaseTestFixture
 	{
 		[Fact]
@@ -191,6 +190,109 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			Assert.True(IsLayoutWithItemsSource(itemsSource, layout));
 			Assert.Equal(itemsSource.Count, layout.Children.Cast<Frame>().Count());
+		}
+
+		[Fact]
+		public void ChangingTemplateRecreatesChildren()
+		{
+			var layout = new StackLayout
+			{
+				IsPlatformEnabled = true,
+			};
+			
+			var itemsSource = new ObservableCollection<int>(Enumerable.Range(0, 10));
+			BindableLayout.SetItemsSource(layout, itemsSource);
+			
+			BindableLayout.SetItemTemplate(layout, new DataTemplate(() => new Label()));
+			Assert.All(layout.Children, c => Assert.IsType<Label>(c));
+			
+			BindableLayout.SetItemTemplate(layout, new DataTemplate(() => new Button()));
+			Assert.All(layout.Children, c => Assert.IsType<Button>(c));
+		}
+		
+		[Fact]
+		public void ChangingItemMaintainingTemplateUpdatesBindingContextOnly()
+		{
+			var layout = new StackLayout
+			{
+				IsPlatformEnabled = true,
+			};
+			
+			var itemsSource = new ObservableCollection<int>(Enumerable.Range(0, 10));
+			BindableLayout.SetItemsSource(layout, itemsSource);
+			BindableLayout.SetItemTemplate(layout, new DataTemplate(() =>
+			{
+				var label = new Label();
+				label.SetBinding(Label.TextProperty, ".");
+				return label;
+			}));
+			
+			var firstChild = layout.Children[0] as Label;
+			Assert.NotNull(firstChild);
+			Assert.Equal("0", firstChild.Text);
+			
+			itemsSource[0] = 42;
+			var firstChildAfterChange = layout.Children[0] as Label;
+			Assert.NotNull(firstChildAfterChange);
+			Assert.Equal("42", firstChildAfterChange.Text);
+			Assert.Same(firstChild, firstChildAfterChange);
+		}
+		
+		[Fact]
+		public void ChangingItemsMaintainingTemplateUpdatesBindingContextOnly()
+		{
+			var layout = new StackLayout
+			{
+				IsPlatformEnabled = true,
+			};
+			
+			var itemsSource = new List<int>(Enumerable.Range(0, 10));
+			BindableLayout.SetItemsSource(layout, itemsSource);
+			BindableLayout.SetItemTemplate(layout, new DataTemplate(() =>
+			{
+				var label = new Label();
+				label.SetBinding(Label.TextProperty, ".");
+				return label;
+			}));
+			
+			var children = layout.Children.Cast<Label>().ToList();
+			BindableLayout.SetItemsSource(layout, new List<int>(Enumerable.Range(10, 10)));
+			
+			var childrenAfterChange = layout.Children.Cast<Label>().ToList();
+			for (var i = 0; i < children.Count; i++)
+			{
+				Assert.Same(children[i], childrenAfterChange[i]);
+				Assert.Equal((i + 10).ToString(), childrenAfterChange[i].Text);
+			}
+		}
+
+		[Fact]
+		public void ChangingItemsRemovesExceedingChildren()
+		{
+			var layout = new StackLayout
+			{
+				IsPlatformEnabled = true,
+			};
+			
+			var itemsSource = new List<int>(Enumerable.Range(0, 10));
+			BindableLayout.SetItemsSource(layout, itemsSource);
+			BindableLayout.SetItemTemplate(layout, new DataTemplate(() => new Label()));
+			
+			var children = layout.Children.ToList();
+			BindableLayout.SetItemsSource(layout, new List<int>(Enumerable.Range(0, 5)));
+			
+			var childrenAfterChange = layout.Children.ToList();
+			Assert.Equal(5, childrenAfterChange.Count);
+
+			for (int i = 0; i < 5; i++)
+			{
+				Assert.Same(children[i], childrenAfterChange[i]);
+			}
+			
+			for (int i = 5; i < 10; i++)
+			{
+				Assert.Null(children[i].BindingContext);
+			}
 		}
 
 		[Fact]

--- a/src/Controls/tests/Core.UnitTests/BindableLayoutTests.cs
+++ b/src/Controls/tests/Core.UnitTests/BindableLayoutTests.cs
@@ -445,7 +445,48 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			itemsSource.Remove(0);
 			Assert.True(IsLayoutWithItemsSource(itemsSource, layout));
 		}
+		
+		[Fact]
+		public void RemovesEmptyViewWhenAddingTheFirstItem()
+		{
+			var layout = new StackLayout
+			{
+				IsPlatformEnabled = true,
+			};
 
+			var itemsSource = new ObservableCollection<int>();
+
+			var emptyView = new Label();
+			BindableLayout.SetEmptyView(layout, emptyView);
+
+			BindableLayout.SetItemsSource(layout, itemsSource);
+			Assert.Single(layout.Children);
+			Assert.Equal(emptyView, layout[0]);
+
+			itemsSource.Add(0);
+			Assert.True(IsLayoutWithItemsSource(itemsSource, layout));
+		}
+		
+		[Fact]
+		public void AddsEmptyViewWhenRemovingRemainingItem()
+		{
+			var layout = new StackLayout
+			{
+				IsPlatformEnabled = true,
+			};
+
+			var itemsSource = new ObservableCollection<int>(Enumerable.Range(0, 1));
+
+			var emptyView = new Label();
+			BindableLayout.SetEmptyView(layout, emptyView);
+
+			BindableLayout.SetItemsSource(layout, itemsSource);
+			Assert.True(IsLayoutWithItemsSource(itemsSource, layout));
+
+			itemsSource.RemoveAt(0);
+			Assert.Single(layout.Children);
+			Assert.Equal(emptyView, layout[0]);
+		}
 
 		[Fact]
 		public void ValidateBindableProperties()

--- a/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
+++ b/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui.Controls;
@@ -355,6 +356,7 @@ public class MemoryTests : ControlsHandlerTestBase
 			new { Name = "One" },
 			new { Name = "Two" },
 			new { Name = "Three" },
+			new { Name = "Four" },
 		};
 
 		var layout = new VerticalStackLayout();
@@ -395,14 +397,14 @@ public class MemoryTests : ControlsHandlerTestBase
 			await CreateHandlerAndAddToWindow<WindowHandlerStub>(new Window(page), async _ =>
 			{
 				await OnLoadedAsync(page);
-				BindableLayout.SetItemsSource(layout, new ObservableCollection<object>(observable));
+				BindableLayout.SetItemsSource(layout, new ObservableCollection<object>(observable.Take(2)));
 				page.Content = null;
 			});
 		}
 
-		// 6 Ellipses total: first 3 should not leak, last 3 should still be in the layout & alive
-		Assert.Equal(6, references.Count);
-		await AssertionExtensions.WaitForGC(references[0], references[1], references[2]);
+		// 4 Ellipses total: last 2 should not leak, first 2 should still be in the layout & alive
+		Assert.Equal(4, references.Count);
+		await AssertionExtensions.WaitForGC(references[2], references[3]);
 	}
 
 	[Fact("Window Does Not Leak")]


### PR DESCRIPTION
### Description of Change

This PR improves the performance of `BindableLayout` in all cases where the item source changes entirely or there is a `Reset` or `Replace` event (see more on #23135).
The strategy is simple: reuse existing views when possible, and simply change the `BindingContext`.

<details>

<summary>Video - Before</summary>

![before](https://github.com/dotnet/maui/assets/1423005/4865e448-9154-4b14-97ec-45ab004804f3)

</details>

<details>

<summary>Video - After</summary>

![after](https://github.com/dotnet/maui/assets/1423005/52e0c87e-bcf4-41e2-be8a-158cc9aaffa2)

</details>

### Issues Fixed

Fixes #23135


