### PR TITLE
[ios] fix leak in ListView *Cells

### DIFF
--- a/src/Controls/src/Core/Cells/Cell.cs
+++ b/src/Controls/src/Core/Cells/Cell.cs
@@ -307,8 +307,14 @@ namespace Microsoft.Maui.Controls
 		internal Android.Views.View ConvertView { get; set; }
 #elif IOS
 		internal UIKit.UITableViewCell ReusableCell { get; set; }
-		internal UIKit.UITableView TableView { get; set; }
 
+		WeakReference<UIKit.UITableView> _tableView;
+
+		internal UIKit.UITableView TableView
+		{
+			get => _tableView?.GetTargetOrDefault();
+			set => _tableView = value is null ? null : new(value);
+		}
 #endif
 
 

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/iOS/CellRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/iOS/CellRenderer.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		public static CommandMapper<Cell, CellRenderer> CommandMapper =
 			new CommandMapper<Cell, CellRenderer>(ElementHandler.ElementCommandMapper);
-		UITableView? _tableView;
+		WeakReference<UITableView>? _tableView;
 
 		private protected event PropertyChangedEventHandler? CellPropertyChanged;
 
@@ -37,7 +37,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		public virtual UITableViewCell GetCell(Cell item, UITableViewCell reusableCell, UITableView tv)
 		{
-			_tableView = tv;
+			_tableView = new(tv);
 			Performance.Start(out string reference);
 
 			var tvc = reusableCell as CellTableViewCell ?? new CellTableViewCell(UITableViewCellStyle.Default, item.GetType().FullName);
@@ -173,15 +173,17 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 			if (command == "ForceUpdateSizeRequested" && 
 				VirtualView is BindableObject bindableObject &&
-				GetRealCell(bindableObject) is UITableViewCell ctv)
+				GetRealCell(bindableObject) is UITableViewCell ctv &&
+				_tableView is not null &&
+				_tableView.TryGetTarget(out var tableView))
 			{
-				var index = _tableView?.IndexPathForCell(ctv);
+				var index = tableView.IndexPathForCell(ctv);
 				if (index == null && VirtualView is Cell c)
 				{
 					index = Controls.Compatibility.Platform.iOS.CellExtensions.GetIndexPath(c);
 				}
 				if (index != null)
-					_tableView?.ReloadRows(new[] { index }, UITableViewRowAnimation.None);
+					tableView.ReloadRows(new[] { index }, UITableViewRowAnimation.None);
 			}
 		}
 	}

--- a/src/Controls/tests/DeviceTests/Elements/ListView/ListViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/ListView/ListViewTests.cs
@@ -23,11 +23,13 @@ namespace Microsoft.Maui.DeviceTests
 				builder.ConfigureMauiHandlers(handlers =>
 				{
 					handlers.AddHandler<EntryCell, EntryCellRenderer>();
-					handlers.AddHandler<ViewCell, ViewCellRenderer>();
-					handlers.AddHandler<TextCell, TextCellRenderer>();
-					handlers.AddHandler<ListView, ListViewRenderer>();
-					handlers.AddHandler<VerticalStackLayout, LayoutHandler>();
+					handlers.AddHandler<ImageCell, ImageCellRenderer>();
 					handlers.AddHandler<Label, LabelHandler>();
+					handlers.AddHandler<ListView, ListViewRenderer>();
+					handlers.AddHandler<SwitchCell, SwitchCellRenderer>();
+					handlers.AddHandler<TextCell, TextCellRenderer>();
+					handlers.AddHandler<VerticalStackLayout, LayoutHandler>();
+					handlers.AddHandler<ViewCell, ViewCellRenderer>();
 				});
 			});
 		}

--- a/src/Controls/tests/DeviceTests/Elements/ListView/ListViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/ListView/ListViewTests.cs
@@ -320,10 +320,6 @@ namespace Microsoft.Maui.DeviceTests
 						references.Add(new(cell.Handler));
 						Assert.NotNull(cell.Handler.PlatformView);
 						references.Add(new(cell.Handler.PlatformView));
-						#if IOS
-						Assert.NotNull(cell.TableView);
-						references.Add(new(cell.TableView));
-						#endif
 					}
 				}
 

--- a/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
+++ b/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
@@ -282,7 +282,7 @@ public class MemoryTests : ControlsHandlerTestBase
 			});
 
 			Assert.NotEmpty(references);
-			foreach (var reference in references)
+			foreach (var reference in references.ToArray())
 			{
 				if (reference.Target is Cell cell)
 				{


### PR DESCRIPTION
Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2064274

After fixing #22867 for `CollectionView`, there was still a problem with `ListView`. The following types were leaking in the sample app:

* `UIKit.UITableView`
* `Microsoft.Maui.Controls.Handlers.Compatibility.ViewCellRenderer.ViewTableCell`
* `Microsoft.Maui.Platform.MauiLabel`
* `Microsoft.Maui.Platform.MauiImageView`
* `Microsoft.Maui.Platform.WrapperView`

After a lot of debugging, we found that `Cell` was holding a reference to the `UITableView`. This pointed *up* in the hierarchy, creating a cycle.

I updated an existing device test to ensure the problem is solved.