### PR TITLE
[Windows] Ensure titlebar button foreground colors use app theme

### DIFF
--- a/src/Core/src/Platform/Windows/MauiWinUIWindow.cs
+++ b/src/Core/src/Platform/Windows/MauiWinUIWindow.cs
@@ -215,7 +215,8 @@ namespace Microsoft.Maui
 
 				titleBar.ButtonBackgroundColor = Colors.Transparent;
 				titleBar.ButtonInactiveBackgroundColor = Colors.Transparent;
-				titleBar.ButtonForegroundColor = _viewSettings.GetColorValue(ViewManagement.UIColorType.Foreground);
+				titleBar.ButtonForegroundColor = UI.Xaml.Application.Current.RequestedTheme == UI.Xaml.ApplicationTheme.Dark ?
+					Colors.White : Colors.Black;
 			}
 		}
 


### PR DESCRIPTION
### Description of Change

Ensure titlebar button foreground colors use app theme vs Windows theme

### Issues Fixed

Fixes #23057