### PR TITLE
[ios/catalyst] fix more cycles in `NavigationPage`

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		public void SetElement(VisualElement element)
 		{
 			(this as IElementHandler).SetVirtualView(element);
-			_element = new(element);
+			_element = element is null ? null : new(element);
 		}
 
 		public UIViewController ViewController

--- a/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
@@ -48,7 +48,8 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		public static CommandMapper<NavigationPage, NavigationRenderer> CommandMapper = new CommandMapper<NavigationPage, NavigationRenderer>(ViewHandler.ViewCommandMapper);
 		ViewHandlerDelegator<NavigationPage> _viewHandlerWrapper;
 		bool _navigating = false;
-		VisualElement _element;
+		WeakReference<VisualElement> _element;
+		WeakReference<Page> _current;
 		bool _uiRequestedPop; // User tapped the back button or swiped to navigate back
 		MauiNavigationDelegate NavigationDelegate => Delegate as MauiNavigationDelegate;
 
@@ -60,14 +61,18 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			Delegate = new MauiNavigationDelegate(this);
 		}
 
-		Page Current { get; set; }
+		Page Current
+		{
+			get => _current?.GetTargetOrDefault();
+			set => _current = value is null ? null : new(value);
+		}
 
 		IPageController PageController => Element as IPageController;
 
 		NavigationPage NavPage => Element as NavigationPage;
 		INavigationPageController NavPageController => NavPage;
 
-		public VisualElement Element { get => _viewHandlerWrapper.Element ?? _element; }
+		public VisualElement Element { get => _viewHandlerWrapper.Element ?? _element?.GetTargetOrDefault(); }
 
 		public event EventHandler<VisualElementChangedEventArgs> ElementChanged;
 
@@ -85,7 +90,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		public void SetElement(VisualElement element)
 		{
 			(this as IElementHandler).SetVirtualView(element);
-			_element = element;
+			_element = new(element);
 		}
 
 		public UIViewController ViewController
@@ -171,7 +176,8 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		public override void ViewWillLayoutSubviews()
 		{
 			base.ViewWillLayoutSubviews();
-			if (Current == null)
+
+			if (Current is not Page current)
 				return;
 
 			UpdateToolBarVisible();
@@ -180,7 +186,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			var toolbar = _secondaryToolbar;
 
 			//save the state of the Current page we are calculating, this will fire before Current is updated
-			_hasNavigationBar = NavigationPage.GetHasNavigationBar(Current);
+			_hasNavigationBar = NavigationPage.GetHasNavigationBar(current);
 
 			// Use 0 if the NavBar is hidden or will be hidden
 			var toolbarY = NavigationBarHidden || NavigationBar.Translucent || !_hasNavigationBar ? 0 : navBarFrameBottom;
@@ -475,8 +481,8 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			}
 			else if (e.PropertyName == NavigationPage.CurrentPageProperty.PropertyName)
 			{
-				Current = NavPage?.CurrentPage;
-				ValidateNavbarExists(Current);
+				var current = Current = NavPage?.CurrentPage;
+				ValidateNavbarExists(current);
 			}
 			else if (e.PropertyName == IsNavigationBarTranslucentProperty.PropertyName)
 			{
@@ -806,7 +812,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			}
 
 			// set Tint color (i. e. Back Button arrow and Text)
-			var iconColor = Current != null ? NavigationPage.GetIconColor(Current) : null;
+			var iconColor = Current is Page current ? NavigationPage.GetIconColor(current) : null;
 			if (iconColor == null)
 				iconColor = barTextColor;
 
@@ -860,8 +866,8 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 			if (currentHidden != _secondaryToolbar.Hidden)
 			{
-				if (Current?.Handler != null)
-					Current.ToPlatform().InvalidateMeasure(Current);
+				if (Current is Page current && current.Handler is not null)
+					current.ToPlatform().InvalidateMeasure(current);
 
 				if (VisibleViewController is ParentingViewController pvc)
 					pvc.UpdateFrames();
@@ -1716,7 +1722,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		void IElementHandler.SetVirtualView(Maui.IElement view)
 		{
 			_viewHandlerWrapper.SetVirtualView(view, ElementChanged, false);
-			_element = view as VisualElement;
+			_element = view is VisualElement v ? new(v) : null;
 
 			void ElementChanged(ElementChangedEventArgs<NavigationPage> e)
 			{

--- a/src/Controls/src/Core/Compatibility/Handlers/ViewHandlerDelegator.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ViewHandlerDelegator.cs
@@ -20,9 +20,14 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		internal IPropertyMapper _mapper;
 		internal readonly CommandMapper _commandMapper;
 		IPlatformViewHandler _viewHandler;
+#if IOS || MACCATALYST
 		TElement? _tempElement;
 		WeakReference<TElement>? _element;
 		public TElement? Element => _tempElement ?? _element?.GetTargetOrDefault();
+#else
+		TElement? _element;
+		public TElement? Element => _element;
+#endif
 		bool _disposed;
 
 		public ViewHandlerDelegator(
@@ -81,10 +86,14 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		{
 #if WINDOWS
 			VisualElementRenderer<TElement, TNativeElement>.SetVirtualView(view, _viewHandler, onElementChanged, ref _element, ref _mapper, _defaultMapper, autoPackage);
-#else
+#elif IOS || MACCATALYST
+			// _tempElement is used here, because the Element property is accessed before SetVirtualView() returns
 			VisualElementRenderer<TElement>.SetVirtualView(view, _viewHandler, onElementChanged, ref _tempElement, ref _mapper, _defaultMapper, autoPackage);
+			// We use _element as a WeakReference, and clear _tempElement
 			_element = _tempElement is null ? null : new(_tempElement);
 			_tempElement = null;
+#else
+			VisualElementRenderer<TElement>.SetVirtualView(view, _viewHandler, onElementChanged, ref _element, ref _mapper, _defaultMapper, autoPackage);
 #endif
 		}
 

--- a/src/Controls/src/Core/Compatibility/Handlers/ViewHandlerDelegator.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ViewHandlerDelegator.cs
@@ -20,8 +20,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		internal IPropertyMapper _mapper;
 		internal readonly CommandMapper _commandMapper;
 		IPlatformViewHandler _viewHandler;
-		TElement? _element;
-		public TElement? Element => _element;
+		TElement? _tempElement;
+		WeakReference<TElement>? _element;
+		public TElement? Element => _tempElement ?? _element?.GetTargetOrDefault();
 		bool _disposed;
 
 		public ViewHandlerDelegator(
@@ -48,11 +49,11 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		public void DisconnectHandler()
 		{
-			if (_element == null)
+			if (Element is not TElement element)
 				return;
 
-			if (_element.Handler == _viewHandler)
-				_element.Handler = null;
+			if (element.Handler == _viewHandler)
+				element.Handler = null;
 
 			_element = null;
 
@@ -81,7 +82,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 #if WINDOWS
 			VisualElementRenderer<TElement, TNativeElement>.SetVirtualView(view, _viewHandler, onElementChanged, ref _element, ref _mapper, _defaultMapper, autoPackage);
 #else
-			VisualElementRenderer<TElement>.SetVirtualView(view, _viewHandler, onElementChanged, ref _element, ref _mapper, _defaultMapper, autoPackage);
+			VisualElementRenderer<TElement>.SetVirtualView(view, _viewHandler, onElementChanged, ref _tempElement, ref _mapper, _defaultMapper, autoPackage);
+			_element = _tempElement is null ? null : new(_tempElement);
+			_tempElement = null;
 #endif
 		}
 

--- a/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.cs
@@ -311,8 +311,7 @@ namespace Microsoft.Maui.DeviceTests
 		public async Task DoesNotLeak()
 		{
 			SetupBuilder();
-			WeakReference pageReference = null;
-			WeakReference handlerReference = null;
+			var references = new List<WeakReference>();
 
 			{
 				var navPage = new NavigationPage(new ContentPage());
@@ -320,15 +319,17 @@ namespace Microsoft.Maui.DeviceTests
 
 				await CreateHandlerAndAddToWindow<WindowHandlerStub>(window, (handler) =>
 				{
-					pageReference = new WeakReference(navPage);
-					handlerReference = new WeakReference(handler);
+					references.Add(new(navPage));
+					references.Add(new(navPage.Handler));
+					references.Add(new(navPage.Handler.PlatformView));
+					references.Add(new(handler));
 
 					// Just replace the page with a new one
 					window.Page = new ContentPage();
 				});
 			}
 
-			await AssertionExtensions.WaitForGC(pageReference, handlerReference);
+			await AssertionExtensions.WaitForGC(references.ToArray());
 		}
 
 		[Fact(DisplayName = "Child Pages Do Not Leak")]

--- a/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
+++ b/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
@@ -67,8 +67,10 @@ public class MemoryTests : ControlsHandlerTestBase
 		});
 	}
 
-	[Fact("Page Does Not Leak")]
-	public async Task PageDoesNotLeak()
+	[Theory("Pages Do Not Leak")]
+	[InlineData(typeof(ContentPage))]
+	[InlineData(typeof(NavigationPage))]
+	public async Task PagesDoNotLeak(Type type)
 	{
 		SetupBuilder();
 
@@ -80,7 +82,15 @@ public class MemoryTests : ControlsHandlerTestBase
 
 		await CreateHandlerAndAddToWindow(new Window(navPage), async () =>
 		{
-			var page = new ContentPage { Content = new Label() };
+			var page = (Page)Activator.CreateInstance(type);
+			if (page is ContentPage contentPage)
+			{
+				contentPage.Content = new Label();
+			}
+			else if (page is NavigationPage navigationPage)
+			{
+				await navigationPage.PushAsync(new ContentPage { Content = new Label() });
+			}
 			
 			await navPage.Navigation.PushModalAsync(page);
 


### PR DESCRIPTION
Fixes: https://github.com/dotnet/maui/issues/21453
Context: https://github.com/dotnet/maui/pull/22810

In #22810, a leak in `NavigationPage` was fixed for the case:

    Application.Current.MainPage = new NavigationPage(new Page1());
    Application.Current.MainPage = new Page2();

However, it does *not* work for the case:

    await Navigation.PushModalAsync(new NavigationPage(new Page1()));
    await Navigation.PopModalAsync();

I could reproduce this problem in `MemoryTests.cs`.

There were still a few cycles in `NavigationRenderer`:

* `NavigationRenderer` -> `VisualElement _element` -> `NavigationRenderer`

* `NavigationRenderer` -> `Page Current` -> `NavigationRenderer`

* `NavigationRenderer` -> `ViewHandlerDelegator<NavigationPage> _viewHandlerWrapper` ->  `TElement _element` -> `NavigationRenderer`

After fixing these cycles, the test passes. The customer's sample also seems to work:

![image](https://github.com/dotnet/maui/assets/840039/51cac98c-fb33-4e88-9fd5-112d7a04817c)

`ViewHandlerDelegator` was slightly tricky, as I had to make a `_tempElement` variable and *unset* it immediately after use.
