### PR TITLE
[ios/catalyst] fix memory leak in TabbedPage

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/TabbedPage/iOS/TabbedRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/TabbedPage/iOS/TabbedRenderer.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		bool? _defaultBarTranslucent;
 		IMauiContext _mauiContext;
 		UITabBarAppearance _tabBarAppearance;
-		VisualElement _element;
+		WeakReference<VisualElement> _element;
 
 		IMauiContext MauiContext => _mauiContext;
 		public static IPropertyMapper<TabbedPage, TabbedRenderer> Mapper = new PropertyMapper<TabbedPage, TabbedRenderer>(TabbedViewHandler.ViewMapper);
@@ -57,7 +57,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			get { return (TabbedPage)Element; }
 		}
 
-		public VisualElement Element => _viewHandlerWrapper.Element ?? _element;
+		public VisualElement Element => _viewHandlerWrapper.Element ?? _element?.GetTargetOrDefault();
 
 		public event EventHandler<VisualElementChangedEventArgs> ElementChanged;
 
@@ -72,11 +72,14 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		public void SetElement(VisualElement element)
 		{
 			_viewHandlerWrapper.SetVirtualView(element, OnElementChanged, false);
-			_element = element;
+			_element = element is null ? null : new(element);
 
 			FinishedCustomizingViewControllers += HandleFinishedCustomizingViewControllers;
-			Tabbed.PropertyChanged += OnPropertyChanged;
-			Tabbed.PagesChanged += OnPagesChanged;
+			if (element is TabbedPage tabbed)
+			{
+				tabbed.PropertyChanged += OnPropertyChanged;
+				tabbed.PagesChanged += OnPagesChanged;
+			}
 
 			OnPagesChanged(null, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
 
@@ -134,8 +137,11 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 				Page?.SendDisappearing();
 
-				Tabbed.PropertyChanged -= OnPropertyChanged;
-				Tabbed.PagesChanged -= OnPagesChanged;
+				if (Tabbed is TabbedPage tabbed)
+				{
+					tabbed.PropertyChanged -= OnPropertyChanged;
+					tabbed.PagesChanged -= OnPagesChanged;
+				}
 
 				FinishedCustomizingViewControllers -= HandleFinishedCustomizingViewControllers;
 			}
@@ -188,8 +194,8 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			SetControllers();
 
 			UIViewController controller = null;
-			if (Tabbed.CurrentPage != null)
-				controller = GetViewController(Tabbed.CurrentPage);
+			if (Tabbed?.CurrentPage is Page currentPage)
+				controller = GetViewController(currentPage);
 			if (controller != null && controller != base.SelectedViewController)
 				base.SelectedViewController = controller;
 
@@ -202,7 +208,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		{
 			if (e.PropertyName == nameof(TabbedPage.CurrentPage))
 			{
-				var current = Tabbed.CurrentPage;
+				var current = Tabbed?.CurrentPage;
 				if (current == null)
 					return;
 
@@ -244,15 +250,20 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		void UpdateCurrentPagePreferredStatusBarUpdateAnimation()
 		{
-			PageUIStatusBarAnimation animation = ((Page)Element).OnThisPlatform().PreferredStatusBarUpdateAnimation();
-			Tabbed.CurrentPage.OnThisPlatform().SetPreferredStatusBarUpdateAnimation(animation);
+			if (Page is Page page)
+			{
+				PageUIStatusBarAnimation animation = page.OnThisPlatform().PreferredStatusBarUpdateAnimation();
+				Tabbed?.CurrentPage?.OnThisPlatform().SetPreferredStatusBarUpdateAnimation(animation);
+			}
 		}
 
 		void UpdatePrefersStatusBarHiddenOnPages()
 		{
+			if (Tabbed is not TabbedPage tabbed)
+				return;
 			for (var i = 0; i < ViewControllers.Length; i++)
 			{
-				Tabbed.GetPageByIndex(i).OnThisPlatform().SetPrefersStatusBarHidden(Tabbed.OnThisPlatform().PrefersStatusBarHidden());
+				tabbed.GetPageByIndex(i).OnThisPlatform().SetPrefersStatusBarHidden(tabbed.OnThisPlatform().PrefersStatusBarHidden());
 			}
 		}
 
@@ -260,7 +271,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		{
 			get
 			{
-				var current = Tabbed.CurrentPage;
+				var current = Tabbed?.CurrentPage;
 				if (current == null)
 					return null;
 
@@ -276,15 +287,19 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		void Reset()
 		{
+			if (Tabbed is not TabbedPage tabbed)
+				return;
 			var i = 0;
-			foreach (var page in Tabbed.Children)
+			foreach (var page in tabbed.Children)
 				SetupPage(page, i++);
 		}
 
 		void SetControllers()
 		{
+			if (Tabbed is not TabbedPage tabbed)
+				return;
 			var list = new List<UIViewController>();
-			var pages = Tabbed.InternalChildren;
+			var pages = tabbed.InternalChildren;
 			for (var i = 0; i < pages.Count; i++)
 			{
 				var child = pages[i];
@@ -315,10 +330,10 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		void UpdateBarBackgroundColor()
 		{
-			if (Tabbed == null || TabBar == null)
+			if (Tabbed is not TabbedPage tabbed || TabBar == null)
 				return;
 
-			var barBackgroundColor = Tabbed.BarBackgroundColor;
+			var barBackgroundColor = tabbed.BarBackgroundColor;
 			var isDefaultColor = barBackgroundColor == null;
 
 			if (isDefaultColor && !_barBackgroundColorWasSet)
@@ -342,20 +357,20 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		void UpdateBarBackground()
 		{
-			if (Tabbed == null || TabBar == null)
+			if (Tabbed is not TabbedPage tabbed || TabBar == null)
 				return;
 
-			var barBackground = Tabbed.BarBackground;
+			var barBackground = tabbed.BarBackground;
 
 			TabBar.UpdateBackground(barBackground);
 		}
 
 		void UpdateBarTextColor()
 		{
-			if (Tabbed == null || TabBar == null || TabBar.Items == null)
+			if (Tabbed is not TabbedPage tabbed || TabBar == null || TabBar.Items == null)
 				return;
 
-			var barTextColor = Tabbed.BarTextColor;
+			var barTextColor = tabbed.BarTextColor;
 			var isDefaultColor = barTextColor == null;
 
 			if (isDefaultColor && !_barTextColorWasSet)
@@ -395,11 +410,11 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		void UpdateBarTranslucent()
 		{
-			if (Tabbed == null || TabBar == null || Element == null)
+			if (Tabbed == null || TabBar == null || Element is not VisualElement element)
 				return;
 
 			_defaultBarTranslucent = _defaultBarTranslucent ?? TabBar.Translucent;
-			switch (TabbedPageConfiguration.GetTranslucencyMode(Element))
+			switch (TabbedPageConfiguration.GetTranslucencyMode(element))
 			{
 				case TranslucencyMode.Translucent:
 					TabBar.Translucent = true;
@@ -415,12 +430,14 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		void UpdateChildrenOrderIndex(UIViewController[] viewControllers)
 		{
+			if (Tabbed is not TabbedPage tabbed)
+				return;
 			for (var i = 0; i < viewControllers.Length; i++)
 			{
 				var originalIndex = -1;
 				if (int.TryParse(viewControllers[i].TabBarItem.Tag.ToString(), out originalIndex))
 				{
-					var page = (Page)Tabbed.InternalChildren[originalIndex];
+					var page = (Page)tabbed.InternalChildren[originalIndex];
 					TabbedPage.SetIndex(page, i);
 				}
 			}
@@ -428,9 +445,12 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		void UpdateCurrentPage()
 		{
-			var count = Tabbed.InternalChildren.Count;
-			var index = (int)SelectedIndex;
-			((TabbedPage)Element).CurrentPage = index >= 0 && index < count ? Tabbed.GetPageByIndex(index) : null;
+			if (Tabbed is TabbedPage tabbed)
+			{
+				var count = tabbed.InternalChildren.Count;
+				var index = (int)SelectedIndex;
+				tabbed.CurrentPage = index >= 0 && index < count ? tabbed.GetPageByIndex(index) : null;
+			}
 		}
 
 		async void SetTabBarItem(IPlatformViewHandler renderer)
@@ -442,7 +462,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			var icons = await GetIcon(page);
 			renderer.ViewController.TabBarItem = new UITabBarItem(page.Title, icons?.Item1, icons?.Item2)
 			{
-				Tag = Tabbed.Children.IndexOf(page),
+				Tag = Tabbed?.Children.IndexOf(page) ?? -1,
 				AccessibilityIdentifier = page.AutomationId
 			};
 			icons?.Item1?.Dispose();
@@ -451,12 +471,12 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		void UpdateSelectedTabColors()
 		{
-			if (Tabbed == null || TabBar == null || TabBar.Items == null)
+			if (Tabbed is not TabbedPage tabbed || TabBar == null || TabBar.Items == null)
 				return;
 
-			if (Tabbed.IsSet(TabbedPage.SelectedTabColorProperty) && Tabbed.SelectedTabColor != null)
+			if (tabbed.IsSet(TabbedPage.SelectedTabColorProperty) && tabbed.SelectedTabColor != null)
 			{
-				TabBar.TintColor = Tabbed.SelectedTabColor.ToPlatform();
+				TabBar.TintColor = tabbed.SelectedTabColor.ToPlatform();
 			}
 			else
 			{
@@ -467,8 +487,8 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				UpdateiOS15TabBarAppearance();
 			else
 			{
-				if (Tabbed.IsSet(TabbedPage.UnselectedTabColorProperty) && Tabbed.UnselectedTabColor != null)
-					TabBar.UnselectedItemTintColor = Tabbed.UnselectedTabColor.ToPlatform();
+				if (tabbed.IsSet(TabbedPage.UnselectedTabColorProperty) && tabbed.UnselectedTabColor != null)
+					TabBar.UnselectedItemTintColor = tabbed.UnselectedTabColor.ToPlatform();
 				else
 					TabBar.UnselectedItemTintColor = UITabBar.Appearance.TintColor;
 			}
@@ -501,14 +521,16 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		[System.Runtime.Versioning.SupportedOSPlatform("tvos15.0")]
 		void UpdateiOS15TabBarAppearance()
 		{
+			if (Tabbed is not TabbedPage tabbed)
+				return;
 			TabBar.UpdateiOS15TabBarAppearance(
 				ref _tabBarAppearance,
 				_defaultBarColor,
 				_defaultBarTextColor,
-				Tabbed.IsSet(TabbedPage.SelectedTabColorProperty) ? Tabbed.SelectedTabColor : null,
-				Tabbed.IsSet(TabbedPage.UnselectedTabColorProperty) ? Tabbed.UnselectedTabColor : null,
-				Tabbed.IsSet(TabbedPage.BarBackgroundColorProperty) ? Tabbed.BarBackgroundColor : null,
-				Tabbed.IsSet(TabbedPage.BarTextColorProperty) ? Tabbed.BarTextColor : null,
+				tabbed.IsSet(TabbedPage.SelectedTabColorProperty) ? tabbed.SelectedTabColor : null,
+				tabbed.IsSet(TabbedPage.UnselectedTabColorProperty) ? tabbed.UnselectedTabColor : null,
+				tabbed.IsSet(TabbedPage.BarBackgroundColorProperty) ? tabbed.BarBackgroundColor : null,
+				tabbed.IsSet(TabbedPage.BarTextColorProperty) ? tabbed.BarTextColor : null,
 				null);
 		}
 

--- a/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
+++ b/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
@@ -61,8 +61,10 @@ public class MemoryTests : ControlsHandlerTestBase
 				handlers.AddHandler<ViewCell, ViewCellRenderer>();
 #if IOS || MACCATALYST
 				handlers.AddHandler<NavigationPage, NavigationRenderer>();
+				handlers.AddHandler<TabbedPage, TabbedRenderer>();
 #else
 				handlers.AddHandler<NavigationPage, NavigationViewHandler>();
+				handlers.AddHandler<TabbedPage, TabbedViewHandler>();
 #endif
 			});
 		});
@@ -71,6 +73,7 @@ public class MemoryTests : ControlsHandlerTestBase
 	[Theory("Pages Do Not Leak")]
 	[InlineData(typeof(ContentPage))]
 	[InlineData(typeof(NavigationPage))]
+	[InlineData(typeof(TabbedPage))]
 	public async Task PagesDoNotLeak(Type type)
 	{
 		SetupBuilder();
@@ -91,6 +94,10 @@ public class MemoryTests : ControlsHandlerTestBase
 			else if (page is NavigationPage navigationPage)
 			{
 				await navigationPage.PushAsync(new ContentPage { Content = new Label() });
+			}
+			else if (page is TabbedPage tabbedPage)
+			{
+				tabbedPage.Children.Add(new ContentPage { Content = new Label() });
 			}
 			
 			await navPage.Navigation.PushModalAsync(page);


### PR DESCRIPTION
Context: https://github.com/dotnet/maui/pull/23164

Just the same way as `NavigationPage` in #23164, `TabbedPage` also has
a memory leak caused by the cycle:

* `TabbedPage` -> `TabbedRenderer` -> `VisualElement _element;` -> `TabbedPage`

I could add a new `[Theory]` in `MemoryTests.cs` to see the issue.

This PR fixes the memory leak by breaking the cycle in `TabbedRenderer`.