### PR TITLE
Wire RefreshView up to our xplat layout workflow

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/RefreshView/RefreshViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/RefreshView/RefreshViewTests.cs
@@ -8,6 +8,7 @@ using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Handlers.Items;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Hosting;
+using Microsoft.Maui.Platform;
 using Xunit;
 
 namespace Microsoft.Maui.DeviceTests
@@ -22,167 +23,29 @@ namespace Microsoft.Maui.DeviceTests
 				builder.ConfigureMauiHandlers(handlers =>
 				{
 					handlers.AddHandler<RefreshView, RefreshViewHandler>();
+					handlers.AddHandler<Label, LabelHandler>();
+					handlers.AddHandler<Entry, EntryHandler>();
 				});
 			});
 		}
+		[Fact(DisplayName = "Setting the content of RefreshView removes previous platform view from visual tree")]
+		public async Task ChangingRefreshViewContentRemovesPreviousContentsPlatformViewFromVisualTree()
+		{
+			SetupBuilder();
 
+			var refreshView = new RefreshView();
+			var initialContent = new Label();
+			refreshView.Content = initialContent;
 
-		// 		[Fact(DisplayName = "IsRefreshing binding works")]
-		// 		public async Task IsRefreshingBindingWorks()
-		// 		{
-		// 			SetupBuilder();
-
-		// 			var vm = new RefreshPageViewModel();
-		// 			var refreshView = new RefreshView() { BindingContext = vm };
-
-		// 			refreshView.SetBinding(RefreshView.IsRefreshingProperty, nameof(vm.IsRefreshing), BindingMode.TwoWay);
-
-		// 			await CreateHandlerAndAddToWindow<RefreshViewHandler>(refreshView, async handler =>
-		// 			{
-		// 				var platformControl = handler.PlatformView;
-		// 				Assert.NotNull(platformControl);
-		// 				bool? platformIsRefreshing = null;
-		// #if WINDOWS
-		// 				Deferral refreshCompletionDeferral = null;
-		// 				platformControl.RefreshRequested += (s, e) =>
-		// 				{
-		// 					refreshCompletionDeferral = e.GetDeferral();
-		// 					platformIsRefreshing = true;
-		// 				};
-		// #endif
-		// 				vm.IsRefreshing = true;
-		// #if ANDROID
-		// 				platformIsRefreshing = platformControl.Refreshing;
-		// #elif IOS
-		// 				platformIsRefreshing = platformControl.IsRefreshing;
-		// #elif WINDOWS
-
-		// #endif
-		// 				Assert.NotNull(platformIsRefreshing);
-		// 				Assert.Equal(vm.IsRefreshing, platformIsRefreshing);
-		// 				await Task.Delay(300);
-		// 				vm.IsRefreshing = false;
-		// #if ANDROID
-		// 				platformIsRefreshing = platformControl.Refreshing;
-		// #elif IOS
-		// 				platformIsRefreshing = platformControl.IsRefreshing;
-		// #elif WINDOWS
-		// 				if(refreshCompletionDeferral != null)
-		// 				{
-		// 					refreshCompletionDeferral.Complete();
-		// 					refreshCompletionDeferral = null;
-		// 					platformIsRefreshing = false;
-		// 				}
-		// #endif
-		// 				Assert.Equal(vm.IsRefreshing, platformIsRefreshing);
-		// 				await Task.Delay(1000);
-		// 			});
-		// 		}
-
-		// 		[Fact(DisplayName = "IsRefreshing binding works when started on platform")]
-		// 		public async Task IsRefreshingBindingWorksFromPlatform()
-		// 		{
-		// 			SetupBuilder();
-
-		// 			var vm = new RefreshPageViewModel();
-		// 			var refreshView = new RefreshView() { BindingContext = vm };
-
-		// 			refreshView.SetBinding(RefreshView.IsRefreshingProperty, nameof(vm.IsRefreshing), BindingMode.TwoWay);
-
-		// 			await CreateHandlerAndAddToWindow<RefreshViewHandler>(refreshView, async handler =>
-		// 			{
-		// 				var platformControl = handler.PlatformView;
-		// 				Assert.NotNull(platformControl);
-		// 				bool? platformIsRefreshing = null;
-		// #if WINDOWS
-		// 				Deferral refreshCompletionDeferral = null;
-		// 				platformControl.RefreshRequested += (s, e) =>
-		// 				{
-		// 					refreshCompletionDeferral = e.GetDeferral();
-		// 					platformIsRefreshing = true;
-		// 				};
-		// 				platformControl.RequestRefresh();
-		// #endif
-
-		// #if ANDROID
-		// 				platformIsRefreshing = platformControl.Refreshing = true;
-		// #elif IOS
-		// 				platformIsRefreshing = platformControl.IsRefreshing = true;
-		// #elif WINDOWS
-
-		// #endif
-		// 				Assert.NotNull(platformIsRefreshing);
-		// 				Assert.Equal(platformIsRefreshing, vm.IsRefreshing);
-		// 				await Task.Delay(300);
-		// 				vm.IsRefreshing = false;
-		// #if ANDROID
-		// 				platformIsRefreshing = platformControl.Refreshing;
-		// #elif IOS
-		// 				platformIsRefreshing = platformControl.IsRefreshing;
-		// #elif WINDOWS
-		// 				if (refreshCompletionDeferral != null)
-		// 				{
-		// 					refreshCompletionDeferral.Complete();
-		// 					refreshCompletionDeferral = null;
-		// 					platformIsRefreshing = false;
-		// 				}
-		// #endif
-		// 				Assert.Equal(vm.IsRefreshing, platformIsRefreshing);
-		// 				await Task.Delay(1000);
-		// 			});
-		// 		}
-
-		// 		class RefreshPageViewModel : BaseViewModel
-		// 		{
-		// 			public RefreshPageViewModel()
-		// 			{
-		// 				Data = new ObservableCollection<string>()
-		// 				{
-		// 					"Item 1",
-		// 					"Item 2",
-		// 					"Item 3"
-		// 				};
-		// 			}
-		// 			bool _isRefreshing;
-		// 			ObservableCollection<string> _data;
-
-		// 			public bool IsRefreshing
-		// 			{
-		// 				get => _isRefreshing;
-		// 				set => SetProperty(ref _isRefreshing, value);
-		// 			}
-
-		// 			public ObservableCollection<string> Data
-		// 			{
-		// 				get => _data;
-		// 				set => SetProperty(ref _data, value);
-		// 			}
-		// 		}
-
-		// 		public abstract class BaseViewModel : INotifyPropertyChanged
-		// 		{
-		// 			protected bool SetProperty<T>(ref T backingStore, T value,
-		// 			[CallerMemberName] string propertyName = "",
-		// 			Action onChanged = null)
-		// 			{
-		// 				if (EqualityComparer<T>.Default.Equals(backingStore, value))
-		// 					return false;
-
-		// 				backingStore = value;
-		// 				onChanged?.Invoke();
-		// 				OnPropertyChanged(propertyName);
-		// 				return true;
-		// 			}
-
-		// 			#region INotifyPropertyChanged
-
-		// 			public event PropertyChangedEventHandler PropertyChanged;
-		// 			protected void OnPropertyChanged([CallerMemberName] string propertyName = "")
-		// 			{
-		// 				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-		// 			}
-
-		// 			#endregion
-		// 		}
+			await AttachAndRun(refreshView, async (handler) =>
+			{
+				var newContent = new Entry();
+				Assert.NotNull(((initialContent as IView).Handler as IPlatformViewHandler).PlatformView.GetParent());
+				refreshView.Content = newContent;
+				Assert.Null(((initialContent as IView).Handler as IPlatformViewHandler).PlatformView.GetParent());
+				await Task.Yield();
+				Assert.NotNull(((newContent as IView).Handler as IPlatformViewHandler).PlatformView.GetParent());
+			});
+		}
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue23029.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue23029.cs
@@ -1,0 +1,22 @@
+﻿using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue23029 : _IssuesUITest
+	{
+		public override string Issue => "RefreshView doesn't use correct layout mechanisms";
+
+		public Issue23029(TestDevice device) : base(device)
+		{
+		}
+
+		[Test]
+		[Category(UITestCategories.RefreshView)]
+		public void ValidateRefreshViewContentGetsFrameSet()
+		{
+			App.WaitForElement("SizeChangedLabel");
+		}
+	}
+}

--- a/src/Controls/tests/TestCases/Issues/Issue23029.xaml
+++ b/src/Controls/tests/TestCases/Issues/Issue23029.xaml
@@ -1,0 +1,45 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Maui.Controls.Sample.Issues.Issue23029">
+    <!-- 
+         Remove RefreshView or comment it out, and you will notice SizeChanged is fired 
+         and if you add RefreshView the SizeChanged will not fire. 
+    -->
+    <Grid RowDefinitions="Auto,*" x:Name="grid">
+        <RefreshView Grid.Row="1">
+            <CollectionView x:Name="CView">
+
+                <CollectionView.ItemsLayout>
+                    <GridItemsLayout Orientation="Vertical" Span="1" />
+                </CollectionView.ItemsLayout>
+
+                <CollectionView.ItemTemplate>
+                    <DataTemplate>
+                        <Grid Padding="0, 0, 10, 10">
+                            <Border Padding="20" Stroke="CornflowerBlue" StrokeThickness="1.5" Background="Transparent">
+                                <Border.StrokeShape>
+                                    <RoundRectangle CornerRadius="20"/>
+                                </Border.StrokeShape>
+
+                                <VerticalStackLayout Spacing="10">
+
+                                    <Label Text="{Binding ProgramName}" />
+
+                                    <Label Text="{Binding CourseName}" />
+
+                                    <Label Text="{Binding DueDate}" />
+
+                                    <HorizontalStackLayout Spacing="5">
+                                        <Button Text="Download" />
+                                        <Button Text="Upload" />
+                                    </HorizontalStackLayout>
+                                </VerticalStackLayout>
+                            </Border>
+                        </Grid>
+                    </DataTemplate>
+                </CollectionView.ItemTemplate>
+            </CollectionView>
+        </RefreshView>
+    </Grid>
+</ContentPage>

--- a/src/Controls/tests/TestCases/Issues/Issue23029.xaml.cs
+++ b/src/Controls/tests/TestCases/Issues/Issue23029.xaml.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.ObjectModel;
+using System;
+using System.Collections.ObjectModel;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Xaml;
 

--- a/src/Controls/tests/TestCases/Issues/Issue23029.xaml.cs
+++ b/src/Controls/tests/TestCases/Issues/Issue23029.xaml.cs
@@ -1,0 +1,53 @@
+﻿using System.Collections.ObjectModel;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+
+namespace Maui.Controls.Sample.Issues
+{
+	[Issue(IssueTracker.Github, 23029, "RefreshView doesn't use correct layout mechanisms", PlatformAffected.All)]
+    public partial class Issue23029 : ContentPage
+    {
+        public Issue23029()
+        {
+            InitializeComponent();
+            ObservableCollection<AssessmentModel> list = [];
+            for (int i = 0; i < 100; i++)
+            {
+                list.Add(new AssessmentModel()
+                {
+                    ProgramName = "International Assessment " + i.ToString(),
+                    CourseName = "English " + i.ToString(),
+                    DueDate = DateTime.Now.ToShortDateString()
+                });
+            }
+            CView.ItemsSource = list;
+
+            CView.SizeChanged += OnSizeChanged;
+        }
+
+        private void OnSizeChanged(object sender, EventArgs e)
+        {
+            if (CView.Frame.Height > 0 && CView.Width > 0 && grid.Children.Count == 1)
+            {
+                // Works around a bug with modifying the grid while it's being measured
+                this.Dispatcher.Dispatch(() =>
+                {
+                    grid.Children.Insert(0, new Label() { Text = "Size Changed", AutomationId = "SizeChangedLabel" });
+                });
+            }
+
+            if (sender is CollectionView collectionView && collectionView.ItemsLayout is GridItemsLayout gridItemsLayout)
+            {
+                double maxWidthPerItem = 300;
+                gridItemsLayout.Span = Math.Max(1, (int)(collectionView.Width / maxWidthPerItem));
+            }
+        }
+
+        public class AssessmentModel
+        {
+            public string ProgramName { get; set; } = string.Empty;
+            public string CourseName { get; set; } = string.Empty;
+            public string DueDate { get; set; } = string.Empty;
+        }
+    }
+}

--- a/src/Core/src/Handlers/RefreshView/RefreshViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/RefreshView/RefreshViewHandler.Windows.cs
@@ -16,7 +16,8 @@ namespace Microsoft.Maui.Handlers
 		{
 			return new RefreshContainer
 			{
-				PullDirection = RefreshPullDirection.TopToBottom
+				PullDirection = RefreshPullDirection.TopToBottom,
+				Content = new ContentPanel()
 			};
 		}
 
@@ -34,6 +35,12 @@ namespace Microsoft.Maui.Handlers
 			nativeView.RefreshRequested -= OnRefresh;
 
 			CompleteRefresh();
+
+			if (nativeView.Content is ContentPanel contentPanel)
+			{
+				contentPanel.Content = null;
+				contentPanel.CrossPlatformLayout = null;
+			}
 
 			base.DisconnectHandler(nativeView);
 		}
@@ -63,8 +70,27 @@ namespace Microsoft.Maui.Handlers
 
 		static void UpdateContent(IRefreshViewHandler handler)
 		{
-			handler.PlatformView.Content =
-				handler.VirtualView.Content?.ToPlatform(handler.MauiContext!);
+			IView content;
+
+			if (handler.VirtualView is IContentView cv && cv.PresentedContent is IView view)
+			{
+				content = view;
+			}
+			else
+			{
+				content = handler.VirtualView.Content;
+			}
+
+			var platformContent = content.ToPlatform(handler.MauiContext!);
+			if (handler.PlatformView.Content is ContentPanel contentPanel)
+			{
+				contentPanel.Content = platformContent;
+				contentPanel.CrossPlatformLayout = (handler.VirtualView as ICrossPlatformLayout);
+			}
+			else
+			{
+				handler.PlatformView.Content = platformContent;
+			}
 		}
 
 		static void UpdateRefreshColor(IRefreshViewHandler handler)

--- a/src/Core/src/Handlers/RefreshView/RefreshViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/RefreshView/RefreshViewHandler.Windows.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Maui.Handlers
 
 		static void UpdateContent(IRefreshViewHandler handler)
 		{
-			IView content;
+			IView? content;
 
 			if (handler.VirtualView is IContentView cv && cv.PresentedContent is IView view)
 			{
@@ -81,7 +81,7 @@ namespace Microsoft.Maui.Handlers
 				content = handler.VirtualView.Content;
 			}
 
-			var platformContent = content.ToPlatform(handler.MauiContext!);
+			var platformContent = content?.ToPlatform(handler.MauiContext!);
 			if (handler.PlatformView.Content is ContentPanel contentPanel)
 			{
 				contentPanel.Content = platformContent;

--- a/src/Core/src/Platform/Windows/ContentPanel.cs
+++ b/src/Core/src/Platform/Windows/ContentPanel.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Maui.Platform
 				var children = Children;
 
 				// Remove the previous content if it exists
-				if (_content is not null && children.Contains(_content))
+				if (_content is not null && children.Contains(_content) && value != _content)
 				{
 					children.Remove(_content);
 				}

--- a/src/Core/src/Platform/Windows/ContentPanel.cs
+++ b/src/Core/src/Platform/Windows/ContentPanel.cs
@@ -24,8 +24,25 @@ namespace Microsoft.Maui.Platform
 			get => _content;
 			set
 			{
+				var children = Children;
+
+				// Remove the previous content if it exists
+				if (_content is not null && children.Contains(_content))
+				{
+					children.Remove(_content);
+				}
+
 				_content = value;
-				AddContent(_content);
+
+				if (_content is null)
+				{
+					return;
+				}
+
+				if (!children.Contains(_content))
+				{
+					children.Add(_content);
+				}
 			}
 		}
 
@@ -140,21 +157,6 @@ namespace Microsoft.Maui.Platform
 			}
 
 			UpdateClip(strokeShape, width, height);
-		}
-
-		void AddContent(FrameworkElement? content)
-		{
-			if (content is null)
-			{
-				return;
-			}
-
-			var children = Children;
-
-			if (!children.Contains(_content))
-			{
-				children.Add(_content);
-			}
 		}
 
 		void UpdateClip(IShape? borderShape, double width, double height)

--- a/src/Core/src/Platform/iOS/MauiRefreshView.cs
+++ b/src/Core/src/Platform/iOS/MauiRefreshView.cs
@@ -10,7 +10,7 @@ using WebKit;
 
 namespace Microsoft.Maui.Platform
 {
-	public class MauiRefreshView : UIView, IUIViewLifeCycleEvents
+	public class MauiRefreshView : MauiView
 	{
 		bool _isRefreshing;
 		nfloat _originalY;
@@ -54,12 +54,14 @@ namespace Microsoft.Maui.Platform
 
 		public void UpdateContent(IView? content, IMauiContext? mauiContext)
 		{
-			if (_refreshControlParent != null)
+			if (_refreshControlParent is not null)
+			{
 				TryRemoveRefresh(_refreshControlParent);
+			}
 
 			_contentView?.RemoveFromSuperview();
 
-			if (content != null && mauiContext != null)
+			if (content is not null && mauiContext is not null)
 			{
 				_contentView = content.ToPlatform(mauiContext);
 				AddSubview(_contentView);
@@ -166,17 +168,6 @@ namespace Microsoft.Maui.Platform
 			return false;
 		}
 
-		public override CGRect Bounds
-		{
-			get => base.Bounds;
-			set
-			{
-				base.Bounds = value;
-				if (_contentView != null)
-					_contentView.Frame = value;
-			}
-		}
-
 		public void UpdateIsEnabled(bool isRefreshViewEnabled)
 		{
 			_refreshControl.Enabled = isRefreshViewEnabled;
@@ -198,19 +189,5 @@ namespace Microsoft.Maui.Platform
 		bool CanUseRefreshControlProperty() =>
 			this.GetNavigationController()?.NavigationBar?.PrefersLargeTitles ?? true;
 #pragma warning restore CA1416
-
-		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = IUIViewLifeCycleEvents.UnconditionalSuppressMessage)]
-		EventHandler? _movedToWindow;
-		event EventHandler IUIViewLifeCycleEvents.MovedToWindow
-		{
-			add => _movedToWindow += value;
-			remove => _movedToWindow -= value;
-		}
-
-		public override void MovedToWindow()
-		{
-			base.MovedToWindow();
-			_movedToWindow?.Invoke(this, EventArgs.Empty);
-		}
 	}
 }

--- a/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -50,6 +50,7 @@ Microsoft.Maui.Platform.MauiScrollView.MauiScrollView() -> void
 Microsoft.Maui.SoftInputExtensions
 override Microsoft.Maui.Handlers.ButtonHandler.NeedsContainer.get -> bool
 override Microsoft.Maui.Handlers.ContentViewHandler.DisconnectHandler(Microsoft.Maui.Platform.ContentView! platformView) -> void
+override Microsoft.Maui.Handlers.RefreshViewHandler.SetVirtualView(Microsoft.Maui.IView! view) -> void
 override Microsoft.Maui.Handlers.ScrollViewHandler.NeedsContainer.get -> bool
 override Microsoft.Maui.Handlers.SwipeItemButton.Frame.get -> CoreGraphics.CGRect
 override Microsoft.Maui.Handlers.SwipeItemButton.Frame.set -> void
@@ -64,9 +65,6 @@ override Microsoft.Maui.Platform.MauiBoxView.MovedToWindow() -> void
 override Microsoft.Maui.Platform.MauiCheckBox.MovedToWindow() -> void
 override Microsoft.Maui.Platform.MauiLabel.MovedToWindow() -> void
 override Microsoft.Maui.Platform.MauiPageControl.MovedToWindow() -> void
-override Microsoft.Maui.Platform.MauiRefreshView.Bounds.get -> CoreGraphics.CGRect
-override Microsoft.Maui.Platform.MauiRefreshView.Bounds.set -> void
-override Microsoft.Maui.Platform.MauiRefreshView.MovedToWindow() -> void
 override Microsoft.Maui.Platform.MauiScrollView.MovedToWindow() -> void
 override Microsoft.Maui.Platform.MauiScrollView.ScrollRectToVisible(CoreGraphics.CGRect rect, bool animated) -> void
 override Microsoft.Maui.Platform.MauiSearchBar.MovedToWindow() -> void

--- a/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -53,6 +53,7 @@ Microsoft.Maui.SoftInputExtensions
 override Microsoft.Maui.Handlers.BorderHandler.PlatformArrange(Microsoft.Maui.Graphics.Rect rect) -> void
 override Microsoft.Maui.Handlers.ButtonHandler.NeedsContainer.get -> bool
 override Microsoft.Maui.Handlers.ContentViewHandler.DisconnectHandler(Microsoft.Maui.Platform.ContentView! platformView) -> void
+override Microsoft.Maui.Handlers.RefreshViewHandler.SetVirtualView(Microsoft.Maui.IView! view) -> void
 override Microsoft.Maui.Handlers.ScrollViewHandler.NeedsContainer.get -> bool
 override Microsoft.Maui.Handlers.SwipeItemButton.Frame.get -> CoreGraphics.CGRect
 override Microsoft.Maui.Handlers.SwipeItemButton.Frame.set -> void
@@ -67,9 +68,6 @@ override Microsoft.Maui.Platform.MauiBoxView.MovedToWindow() -> void
 override Microsoft.Maui.Platform.MauiCheckBox.MovedToWindow() -> void
 override Microsoft.Maui.Platform.MauiLabel.MovedToWindow() -> void
 override Microsoft.Maui.Platform.MauiPageControl.MovedToWindow() -> void
-override Microsoft.Maui.Platform.MauiRefreshView.Bounds.get -> CoreGraphics.CGRect
-override Microsoft.Maui.Platform.MauiRefreshView.Bounds.set -> void
-override Microsoft.Maui.Platform.MauiRefreshView.MovedToWindow() -> void
 override Microsoft.Maui.Platform.MauiScrollView.MovedToWindow() -> void
 override Microsoft.Maui.Platform.MauiScrollView.ScrollRectToVisible(CoreGraphics.CGRect rect, bool animated) -> void
 override Microsoft.Maui.Platform.MauiSearchBar.MovedToWindow() -> void


### PR DESCRIPTION
### Description of Change

`RefreshView` inherits from `ContentView` so when it measures and arranges its children it needs to use the layout flow expected by `ContentView` otherwise things like `Frame` won't get wired up during the first `Arrange` pass

### Issues Fixed

Fixes #23029 

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
