### PR TITLE
Enable RefreshView Tests

### DIFF
--- a/src/Controls/tests/Core.UnitTests/NavigationPageLifecycleTests.cs
+++ b/src/Controls/tests/Core.UnitTests/NavigationPageLifecycleTests.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			_ = new TestWindow(nav);
 
-			await waitForFirstAppearing.Task;
+			await waitForFirstAppearing.Task.WaitAsync(TimeSpan.FromSeconds(2));
 			initialPage.Appearing += (sender, _) =>
 			{
 				Assert.True(appearingShouldFireOnInitialPage);
@@ -92,12 +92,12 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			pushedPage.Disappearing += (sender, _)
 				=> pageDisappeared = (ContentPage)sender;
 
-			await nav.PushAsync(pushedPage);
+			await nav.PushAsync(pushedPage).WaitAsync(TimeSpan.FromSeconds(2));
 			Assert.Null(rootPageFiresAppearingAfterPop);
 			appearingShouldFireOnInitialPage = true;
 			Assert.Null(pageDisappeared);
 
-			await nav.PopAsync();
+			await nav.PopAsync().WaitAsync(TimeSpan.FromSeconds(2));
 
 			Assert.Equal(initialPage, rootPageFiresAppearingAfterPop);
 			Assert.Equal(pushedPage, pageDisappeared);

--- a/src/Controls/tests/Core.UnitTests/TestClasses/TestNavigationPage.cs
+++ b/src/Controls/tests/Core.UnitTests/TestClasses/TestNavigationPage.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 		TaskCompletionSource _navigationSource;
 
-		public Task NavigatingTask => (_navigationSource?.Task ?? Task.CompletedTask);
+		public Task NavigatingTask => _navigationSource?.Task ?? Task.CompletedTask;
 
 		public async void CompleteCurrentNavigation()
 		{

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue16910.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue16910.xaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="Maui.Controls.Sample.Issues.Issue16910">
     <ContentPage.Content>
-        <Grid RowDefinitions="Auto,100,*,Auto" x:Name="grid">
+        <Grid RowDefinitions="Auto,100,*,50,50" x:Name="grid">
             <Label Grid.Row="1" Text="Interact with the RefreshView and make sure the IsRefreshing Label correctly Represents current state." />
             <RefreshView x:Name="refreshView" Grid.Row="2" IsRefreshing="{Binding IsRefreshing, Mode=TwoWay}">
                 <CollectionView ItemsSource="{Binding ItemSource}" AutomationId="CollectionView">
@@ -15,7 +15,7 @@
                 </CollectionView>
             </RefreshView>
             <Button x:Name="StopRefreshing" AutomationId="StopRefreshing" Grid.Row="3" Text="Stop Refresh" Clicked="OnStopRefreshClicked" />
-            <Button x:Name="StartRefreshing" AutomationId="StartRefreshing" Grid.Row="3" Text="Refresh" Clicked="OnRefreshClicked" />
+            <Button x:Name="StartRefreshing" AutomationId="StartRefreshing" Grid.Row="4" Text="Refresh" Clicked="OnRefreshClicked" />
         </Grid>
     </ContentPage.Content>
 </ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue16910.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue16910.xaml
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Maui.Controls.Sample.Issues.Issue16910">
+    <ContentPage.Content>
+        <Grid RowDefinitions="Auto,100,*,Auto" x:Name="grid">
+            <Label Grid.Row="1" Text="Interact with the RefreshView and make sure the IsRefreshing Label correctly Represents current state." />
+            <RefreshView x:Name="refreshView" Grid.Row="2" IsRefreshing="{Binding IsRefreshing, Mode=TwoWay}">
+                <CollectionView ItemsSource="{Binding ItemSource}" AutomationId="CollectionView">
+                    <CollectionView.ItemTemplate>
+                        <DataTemplate>
+                            <Label Text="{Binding Text}" AutomationId="{Binding AutomationId}" />
+                        </DataTemplate>
+                    </CollectionView.ItemTemplate>
+                </CollectionView>
+            </RefreshView>
+            <Button x:Name="StopRefreshing" AutomationId="StopRefreshing" Grid.Row="3" Text="Stop Refresh" Clicked="OnStopRefreshClicked" />
+            <Button x:Name="StartRefreshing" AutomationId="StartRefreshing" Grid.Row="3" Text="Refresh" Clicked="OnRefreshClicked" />
+        </Grid>
+    </ContentPage.Content>
+</ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue16910.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue16910.xaml.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections;
+using System.Linq;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+using Microsoft.Maui.Platform;
+
+namespace Maui.Controls.Sample.Issues
+{
+	[Issue(IssueTracker.Github, 16910, "IsRefreshing binding works", PlatformAffected.All)]
+	public partial class Issue16910 : ContentPage
+	{
+		Label _isRefreshingLabel = new Label(){Text = "Is Refreshing", AutomationId = "IsRefreshing"};
+		Label _isNotRefreshingLabel = new Label(){Text = "Is Not Refreshing", AutomationId = "IsNotRefreshing"};
+
+		bool _isRefreshing;
+
+		public IEnumerable ItemSource {get; set;}
+
+		public bool IsRefreshing
+		{
+			get => _isRefreshing;
+			set
+			{
+				_isRefreshing = value;
+				OnPropertyChanged(nameof(IsRefreshing));
+				UpdateRefreshingLabels();
+			}
+		}
+
+		void UpdateRefreshingLabels()
+		{
+			if (IsRefreshing)
+			{
+				grid.Remove(_isNotRefreshingLabel);
+				grid.Insert(0, _isRefreshingLabel);
+				StartRefreshing.IsVisible = false;
+				StopRefreshing.IsVisible = true;
+			}
+			else
+			{
+				grid.Remove(_isRefreshingLabel);
+				grid.Insert(0, _isNotRefreshingLabel);
+				StartRefreshing.IsVisible = true;
+				StopRefreshing.IsVisible = false;
+			}
+		}
+
+		public Issue16910()
+		{
+			InitializeComponent();
+			UpdateRefreshingLabels();
+			ItemSource = 
+				Enumerable.Range(0,100)
+					.Select(x => new { Text = $"Item {x}", AutomationId = $"Item{x}"  })
+					.ToList();		
+					
+			this.BindingContext = this;
+		}
+
+
+		void OnStopRefreshClicked(object sender, EventArgs e)
+		{
+			refreshView.IsRefreshing = false;
+		}		
+		
+		void OnRefreshClicked(object sender, EventArgs e)
+		{
+			refreshView.IsRefreshing = true;
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue16910.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue16910.cs
@@ -1,6 +1,7 @@
 ﻿using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
+using System.Threading.Tasks;
 
 namespace Microsoft.Maui.TestCases.Tests.Issues;
 
@@ -21,8 +22,8 @@ public class Issue16910 : _IssuesUITest
 		_ = App.WaitForElement("StartRefreshing");
 		App.Tap("StartRefreshing");
 		App.WaitForElement("IsRefreshing");
-		App.WaitForElement("StopRefreshing");
-		App.Tap("StopRefreshing");
+		App.Click("StopRefreshing");
+		App.WaitForElement("IsNotRefreshing");
 	}
 
 // Windows only works with touch inputs which we don't have running on the test server
@@ -35,6 +36,7 @@ public class Issue16910 : _IssuesUITest
 		App.ScrollUp("CollectionView");
 		App.WaitForElement("IsRefreshing");
 		App.Tap("StopRefreshing");
+		App.WaitForElement("IsNotRefreshing");
 	}
 #endif
 

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue16910.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue16910.cs
@@ -27,6 +27,7 @@ public class Issue16910 : _IssuesUITest
 // Windows only works with touch inputs which we don't have running on the test server
 #if !WINDOWS && !MACCATALYST
     [Test]
+	[Category(UITestCategories.RefreshView)]
 	public void BindingUpdatesFromInteractiveRefresh()
 	{
 		_ = App.WaitForElement("CollectionView");

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue16910.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue16910.cs
@@ -25,7 +25,7 @@ public class Issue16910 : _IssuesUITest
 	}
 
 // Windows only works with touch inputs which we don't have running on the test server
-#if !WINDOWS
+#if !WINDOWS && !MACCATALYST
     [Test]
 	public void BindingUpdatesFromInteractiveRefresh()
 	{

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue16910.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue16910.cs
@@ -21,6 +21,7 @@ public class Issue16910 : _IssuesUITest
 		_ = App.WaitForElement("StartRefreshing");
 		App.Tap("StartRefreshing");
 		App.WaitForElement("IsRefreshing");
+		App.WaitForElement("StopRefreshing");
 		App.Tap("StopRefreshing");
 	}
 

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue16910.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue16910.cs
@@ -1,0 +1,39 @@
+﻿using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue16910 : _IssuesUITest
+{
+	public override string Issue => "IsRefreshing binding works";
+
+	protected override bool ResetAfterEachTest => true;
+	public Issue16910(TestDevice device)
+		: base(device)
+	{ 
+
+	}
+
+    [Test]
+	public void BindingUpdatesFromProgrammaticRefresh()
+	{
+		_ = App.WaitForElement("StartRefreshing");
+		App.Tap("StartRefreshing");
+		App.WaitForElement("IsRefreshing");
+		App.Tap("StopRefreshing");
+	}
+
+// Windows only works with touch inputs which we don't have running on the test server
+#if !WINDOWS
+    [Test]
+	public void BindingUpdatesFromInteractiveRefresh()
+	{
+		_ = App.WaitForElement("CollectionView");
+		App.ScrollUp("CollectionView");
+		App.WaitForElement("IsRefreshing");
+		App.Tap("StopRefreshing");
+	}
+#endif
+
+}

--- a/src/TestUtils/src/UITest.Appium/Actions/AppiumMouseActions.cs
+++ b/src/TestUtils/src/UITest.Appium/Actions/AppiumMouseActions.cs
@@ -3,6 +3,7 @@ using OpenQA.Selenium;
 using OpenQA.Selenium.Appium;
 using OpenQA.Selenium.Appium.Interactions;
 using OpenQA.Selenium.Interactions;
+using OpenQA.Selenium.Support.UI;
 using UITest.Core;
 
 namespace UITest.Appium
@@ -93,22 +94,35 @@ namespace UITest.Appium
 
 		CommandResponse ClickElement(AppiumElement element)
 		{
+			var tagName = element.TagName;
 			try
 			{
 				element.Click();
 				return CommandResponse.SuccessEmptyResponse;
 			}
-			catch (InvalidOperationException)
+			catch (InvalidOperationException ioe)
 			{
+				Console.WriteLine($"WebDriverException: {ioe}");
 				return ProcessException();
 			}
-			catch (WebDriverException)
+			catch (WebDriverException we)
 			{
+				Console.WriteLine($"WebDriverException: {we}");
 				return ProcessException();
 			}
 
 			CommandResponse ProcessException()
 			{
+				// Appium elements will sometimes become stale
+				// Which appears to happen if click fails, so, we retrieve it here
+				if(!String.IsNullOrWhiteSpace(tagName))
+					element = (AppiumElement)_appiumApp.FindElement(tagName);
+
+				if (element is null)
+				{
+					return CommandResponse.FailedEmptyResponse;
+				}
+
 				// Some elements aren't "clickable" from an automation perspective (e.g., Frame renders as a Border
 				// with content in it; if the content is just a TextBlock, we'll end up here)
 

--- a/src/TestUtils/src/UITest.Appium/Actions/AppiumMouseActions.cs
+++ b/src/TestUtils/src/UITest.Appium/Actions/AppiumMouseActions.cs
@@ -2,6 +2,7 @@
 using OpenQA.Selenium;
 using OpenQA.Selenium.Appium;
 using OpenQA.Selenium.Appium.Interactions;
+using OpenQA.Selenium.Appium.Mac;
 using OpenQA.Selenium.Interactions;
 using OpenQA.Selenium.Support.UI;
 using UITest.Core;
@@ -94,7 +95,12 @@ namespace UITest.Appium
 
 		CommandResponse ClickElement(AppiumElement element)
 		{
-			var tagName = element.TagName;
+			string tagName = string.Empty;
+			
+			// If the click fails on catalyst we need to retrieve the element again
+			if (_appiumApp.Driver is MacDriver)
+				tagName = element.TagName;
+
 			try
 			{
 				element.Click();


### PR DESCRIPTION
### Description of Change

Move disabled device tests to appium. These tests require UI interactions which we can't really recreate from the device tests.

I tested removing the changes made in https://github.com/dotnet/maui/pull/17062/files#diff-2d87a80df0a7988d1f249910b23fc95a072e4df4bd0c92c18ec6f03517cf35b7R153-R158 to validate that the Appium tests I added are doing something useful and they are :-)  If you comment out the code in #17062 the android app just crashes. 

### Issues Fixed

Fixes #17114
