### PR TITLE
[Android] fix TapGestureRecognizer.Tapped called multiple times on Android

### DIFF
--- a/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Android.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Android.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
+using System.Linq;
 using Android.Content;
 using Android.Views;
 using AndroidX.Core.View;

--- a/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Android.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Android.cs
@@ -269,8 +269,25 @@ namespace Microsoft.Maui.Controls.Platform
 			SetupGestures();
 		}
 
+		void ClearPlatformViewEventHandlers()
+		{
+			if (View == null)
+				return;
+
+			var platformView = Control;
+
+			if (platformView == null)
+				return;
+
+			if (View.GestureRecognizers.Any(gestureRecognizer => gestureRecognizer is not PointerGestureRecognizer))
+			{
+				platformView.Touch -= OnPlatformViewTouched;
+			}
+		}
+
 		void GestureCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
 		{
+			ClearPlatformViewEventHandlers();
 			UpdateDragAndDrop();
 			UpdatePointer();
 			SetupGestures();


### PR DESCRIPTION
Fixes: https://github.com/dotnet/maui/issues/23177

### Description of Change

On an Android device, when a new GestureRecognizer is added to a view, the previous GestureRecognizers' Tapped event is raised multiple times by a single tap. I added a method named ClearPlatformViewEventHandlers to remove OnPlatformViewTouched from the Touch event when the GestureCollectionChanged method is called.

Added method:
```
void ClearPlatformViewEventHandlers()
{
	if (View == null)
		return;

	var platformView = Control;

	if (platformView == null)
		return;

	if (View.GestureRecognizers.Any(gestureRecognizer => gestureRecognizer is not PointerGestureRecognizer))
	{
		platformView.Touch -= OnPlatformViewTouched;
	}
}
```

Called in GestureCollectionChanged method:
```
void GestureCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
{
	ClearPlatformViewEventHandlers();
	UpdateDragAndDrop();
	UpdatePointer();
	SetupGestures();

	if (_tapAndPanAndSwipeDetector.IsValueCreated)
		_tapAndPanAndSwipeDetector.Value.UpdateLongPressSettings();

	View?.AddOrRemoveControlsAccessibilityDelegate();
}
```
