### PR TITLE
Call base.OnResume if Existing NavigationFragment Early

### DIFF
--- a/src/Core/src/Platform/Android/Navigation/NavigationViewFragment.cs
+++ b/src/Core/src/Platform/Android/Navigation/NavigationViewFragment.cs
@@ -70,7 +70,10 @@ namespace Microsoft.Maui.Platform
 		public override void OnResume()
 		{
 			if (_currentView == null || !NavigationManager.HasNavHost)
+			{
+				base.OnResume();
 				return;
+			}
 
 			if (_currentView.Parent == null)
 			{


### PR DESCRIPTION
### Description of Change

I noticed after merging this PR that we aren't calling`base.OnResume` on the fragment. 
https://github.com/dotnet/maui/pull/23170

That's originally how I wrote it 3 years ago. Looking at the source code for `Fragment` https://android.googlesource.com/platform/frameworks/base/+/master/core/java/android/app/Fragment.java#1645, the onresume code does some internal bookkeeping, so, not calling the base class seems like it could lead to somewhat undefined behavior. 

copilot has this to say :-)


> Yes, when you're inheriting from a Fragment in Android (including AndroidX.Fragment.App.Fragment as seen in your code), it's important to call base.OnResume() in your overridden OnResume() method. This ensures that the base class can perform necessary operations during the lifecycle event. Not calling base.OnResume() could lead to unexpected behavior or bugs because you're skipping the execution of the Fragment's core logic that happens during the resume state.

