### PR TITLE
warnings ignored on compatability

### DIFF
--- a/src/Compatibility/Core/src/Compatibility.csproj
+++ b/src/Compatibility/Core/src/Compatibility.csproj
@@ -19,6 +19,9 @@
     <NoWarn>$(NoWarn);CA1416;CS8305</NoWarn>
     <DefineConstants>$(DefineConstants);WINDOWS</DefineConstants>
   </PropertyGroup>
+  <PropertyGroup Condition="$(TargetFramework.Contains('iOS')) == true ">
+    <NoWarn>$(NoWarn);CA1416</NoWarn>
+  </PropertyGroup>
 
   <PropertyGroup>
     <!-- NuGet package information -->


### PR DESCRIPTION
Was told that the compatibility assembly can have the warning ignored.