### PR TITLE
[iOS] Set WindowOverlay's GraphicsView to transparent input

### DIFF
--- a/src/Core/src/WindowOverlay/WindowOverlay.iOS.cs
+++ b/src/Core/src/WindowOverlay/WindowOverlay.iOS.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Maui
 	{
 		PassthroughView? _passthroughView;
 		IDisposable? _frameObserver;
-		PlatformGraphicsView? _graphicsView;
+		OverlayGraphicsView? _graphicsView;
 
 		public virtual bool Initialize()
 		{
@@ -29,7 +29,7 @@ namespace Microsoft.Maui
 			_passthroughView = new PassthroughView(this, platformWindow.RootViewController.View.Frame);
 			_passthroughView.AutoresizingMask = UIViewAutoresizing.All;
 
-			_graphicsView = new PlatformGraphicsView(_passthroughView.Frame, this, new DirectRenderer());
+			_graphicsView = new OverlayGraphicsView(_passthroughView.Frame, this, new DirectRenderer());
 			_graphicsView.AutoresizingMask = UIViewAutoresizing.All;
 
 			_passthroughView.AddSubview(_graphicsView);
@@ -78,6 +78,17 @@ namespace Microsoft.Maui
 		{
 			HandleUIChange();
 			Invalidate();
+		}
+
+		class OverlayGraphicsView : PlatformGraphicsView
+		{
+			public OverlayGraphicsView(CGRect frame, IDrawable drawable, IGraphicsRenderer renderer)
+			: base(frame, drawable, renderer)
+			{
+
+			}
+
+			public override bool IsTransparentFocusItem => true;
 		}
 
 		class PassthroughView : UIView


### PR DESCRIPTION
### Description of Change

<!-- Enter description of the fix in this section -->

The PlatformGraphicsView is a UIView that can be focused by keyboard input. As the WindowOverlay implements one for its graphics layer, if any item is under it in the UI layer, it would handle the tab events and not pass them to the underlying UI Elements. 

By setting the view to be transparent, it will ignore keyboard presses but still allow the passthrough view to work to handle UI taps. Since I didn't want to break existing APIs, I subclassed PlatformGraphicsView inside the overlay to set `IsTransparentFocusItem` specifically for that view.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes https://github.com/dotnet/maui/issues/20135

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
