### PR TITLE
Application Crash Due to Incorrect Use of <ReorderableItemsView> Instead of <CollectionView> for Reordering Items - fix

### DIFF
--- a/src/Controls/src/Core/Hosting/AppHostBuilderExtensions.cs
+++ b/src/Controls/src/Core/Hosting/AppHostBuilderExtensions.cs
@@ -62,6 +62,7 @@ public static partial class AppHostBuilderExtensions
 	internal static IMauiHandlersCollection AddControlsHandlers(this IMauiHandlersCollection handlersCollection)
 	{
 		handlersCollection.AddHandler<CollectionView, CollectionViewHandler>();
+		handlersCollection.AddHandler<ReorderableItemsView, ReorderableItemsViewHandler<ReorderableItemsView>>();
 		handlersCollection.AddHandler<CarouselView, CarouselViewHandler>();
 		handlersCollection.AddHandler<Application, ApplicationHandler>();
 		handlersCollection.AddHandler<ActivityIndicator, ActivityIndicatorHandler>();


### PR DESCRIPTION
### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/23220
