### PR TITLE
VSCode no longer uses MAUI to launch

### DIFF
--- a/.vscode/.launch.json
+++ b/.vscode/.launch.json
@@ -5,12 +5,6 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": ".NET MAUI",
-      "type": "maui",
-      "request": "launch",
-      "preLaunchTask": "maui: Build"
-    },
-    {
       "name": "Attach to Process",
       "type": "coreclr",
       "request": "attach",


### PR DESCRIPTION
### Description of Change

The new VS Code extensions now just use the normal C# things. 

The new C# launch type works a bit different where each project needs to have its own configuration. Since we will be left with "attach", that will be the default/primary launch which is not what we want.

Removing the maui launch type and renaming the file to allow VS Code to use its automagical detection.