### PR TITLE
Obsolete IBorder

### DIFF
--- a/src/Core/src/Core/IBorder.cs
+++ b/src/Core/src/Core/IBorder.cs
@@ -3,7 +3,7 @@
 /// <summary>
 /// Provides functionality to provide a border.
 /// </summary>
-[Obsolete("IBorder is not used and will be removed in a future release. Use IBorderView or IBorderStroke instead.")]
+[System.Obsolete("IBorder is not used and will be removed in a future release. Use IBorderView or IBorderStroke instead.")]
 public interface IBorder
 {
 	/// <summary>

--- a/src/Core/src/Core/IBorder.cs
+++ b/src/Core/src/Core/IBorder.cs
@@ -1,9 +1,13 @@
-﻿namespace Microsoft.Maui;
+﻿using System;
+using System.ComponentModel;
+
+namespace Microsoft.Maui;
 
 /// <summary>
 /// Provides functionality to provide a border.
 /// </summary>
-[System.Obsolete("IBorder is not used and will be removed in a future release. Use IBorderView or IBorderStroke instead.")]
+[EditorBrowsable(EditorBrowsableState.Never)]
+[Obsolete("IBorder is not used and will be removed in a future release. Use IBorderView or IBorderStroke instead.")]
 public interface IBorder
 {
 	/// <summary>

--- a/src/Core/src/Core/IBorder.cs
+++ b/src/Core/src/Core/IBorder.cs
@@ -3,6 +3,7 @@
 /// <summary>
 /// Provides functionality to provide a border.
 /// </summary>
+[Obsolete("IBorder is not used and will be removed in a future release. Use IBorderView or IBorderStroke instead.")]
 public interface IBorder
 {
 	/// <summary>

--- a/src/Core/src/Handlers/View/ViewHandler.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.cs
@@ -57,7 +57,9 @@ namespace Microsoft.Maui.Handlers
 				[nameof(IView.AnchorX)] = MapAnchorX,
 				[nameof(IView.AnchorY)] = MapAnchorY,
 				[nameof(IViewHandler.ContainerView)] = MapContainerView,
+#pragma warning disable CS0618 // Type or member is obsolete
 				[nameof(IBorder.Border)] = MapBorderView,
+#pragma warning restore CS0618 // Type or member is obsolete
 #if ANDROID || WINDOWS || TIZEN
 				[nameof(IToolbarElement.Toolbar)] = MapToolbar,
 #endif
@@ -419,6 +421,7 @@ namespace Microsoft.Maui.Handlers
 				handler.HasContainer = view.NeedsContainer();
 		}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		/// <summary>
 		/// Maps the abstract <see cref="IBorder.Border"/> property to the platform-specific implementations.
 		/// </summary>
@@ -430,6 +433,7 @@ namespace Microsoft.Maui.Handlers
 
 			((PlatformView?)handler.ContainerView)?.UpdateBorder(view);
 		}
+#pragma warning restore CS0618 // Type or member is obsolete
 
 		static partial void MappingFrame(IViewHandler handler, IView view);
 

--- a/src/Core/src/Platform/Android/ViewExtensions.cs
+++ b/src/Core/src/Platform/Android/ViewExtensions.cs
@@ -118,6 +118,8 @@ namespace Microsoft.Maui.Platform
 			if (platformView is WrapperView wrapper)
 				wrapper.Shadow = view.Shadow;
 		}
+
+		[Obsolete("IBorder is not used and will be removed in a future release.")]
 		public static void UpdateBorder(this AView platformView, IView view)
 		{
 			if (platformView is WrapperView wrapper)

--- a/src/Core/src/Platform/Tizen/ViewExtensions.cs
+++ b/src/Core/src/Platform/Tizen/ViewExtensions.cs
@@ -128,6 +128,7 @@ namespace Microsoft.Maui.Platform
 			}
 		}
 
+		[Obsolete("IBorder is not used and will be removed in a future release.")]
 		public static void UpdateBorder(this NView platformView, IView view)
 		{
 			if (view is IBorder border && platformView is WrapperView wrapperView)

--- a/src/Core/src/Platform/Windows/ViewExtensions.cs
+++ b/src/Core/src/Platform/Windows/ViewExtensions.cs
@@ -83,6 +83,7 @@ namespace Microsoft.Maui.Platform
 			}
 		}
 
+		[Obsolete("IBorder is not used and will be removed in a future release.")]
 		public static void UpdateBorder(this FrameworkElement platformView, IView view)
 		{
 			var border = (view as IBorder)?.Border;

--- a/src/Core/src/Platform/WrapperView.cs
+++ b/src/Core/src/Platform/WrapperView.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Maui.Platform
 		IShape? _clip;
 		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = "IShadow is a non-NSObject in MAUI.")]
 		IShadow? _shadow;
-		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = "IBorder is a non-NSObject in MAUI.")]
+		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = "IBorderStroke is a non-NSObject in MAUI.")]
 		IBorderStroke? _border;
 
 #if WINDOWS

--- a/src/Core/src/Platform/iOS/ViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/ViewExtensions.cs
@@ -227,6 +227,8 @@ namespace Microsoft.Maui.Platform
 					wrapperView.Shadow = view.Shadow;
 			}
 		}
+
+		[Obsolete("IBorder is not used and will be removed in a future release.")]
 		public static void UpdateBorder(this UIView platformView, IView view)
 		{
 			var border = (view as IBorder)?.Border;

--- a/src/Core/src/ViewExtensions.cs
+++ b/src/Core/src/ViewExtensions.cs
@@ -60,8 +60,10 @@ namespace Microsoft.Maui
 #endif
 
 #if ANDROID || IOS
+#pragma warning disable CS0618 // Type or member is obsolete
 			if (view is IBorder border && border.Border != null)
 				return true;
+#pragma warning retore CS0618 // Type or member is obsolete
 #elif WINDOWS
 			if (view is IBorderView border)
 				return border?.Shape != null || border?.Stroke != null;

--- a/src/Core/src/ViewExtensions.cs
+++ b/src/Core/src/ViewExtensions.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Maui
 #pragma warning disable CS0618 // Type or member is obsolete
 			if (view is IBorder border && border.Border != null)
 				return true;
-#pragma warning retore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
 #elif WINDOWS
 			if (view is IBorderView border)
 				return border?.Shape != null || border?.Stroke != null;


### PR DESCRIPTION
### Description of Change

This was used for something before, but instead we ended up with something else.

Currently we have `IBorderStroke` which is an interface that adds "border properties" to a view, and then `IBorderView` which is a view that has those "border properties" already added.

The `IBorder` view was meant to be part of a view that had a `Border` property and all views would have that. But, after many discussions and investigation, this because unfeasible due to the fact that some controls have a native "border" already - such as a `Button`. If a button only has simple support for border properties, either we would have to re-implement  button or we would have to ignore properties.

As a result, for the current feature, we opted for a `Border` control that can be used to wrap any view instead of us doing it automatically when you were not expecting that to happen.