### PR TITLE
[Android] Avoid double event subscribes in gesture manager

### DIFF
--- a/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Android.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Android.cs
@@ -207,11 +207,10 @@ namespace Microsoft.Maui.Controls.Platform
 				shouldAddTouchEvent = true;
 			}
 
-			if (!shouldAddTouchEvent)
-			{
-				platformView.Touch -= OnPlatformViewTouched;
-			}
-			else
+			// Always unsubscribe first to avoid duplicates
+			platformView.Touch -= OnPlatformViewTouched;
+
+			if (shouldAddTouchEvent)
 			{
 				platformView.Touch += OnPlatformViewTouched;
 			}

--- a/src/Controls/tests/TestCases.HostApp/Elements/DynamicTapGestureGallery.cs
+++ b/src/Controls/tests/TestCases.HostApp/Elements/DynamicTapGestureGallery.cs
@@ -1,0 +1,42 @@
+﻿namespace Maui.Controls.Sample
+{
+	public class DynamicTapGestureGallery : Microsoft.Maui.Controls.ContentView
+	{
+		public DynamicTapGestureGallery()
+		{
+			AutomationId = nameof(DynamicTapGestureGallery);
+
+			var layout = new VerticalStackLayout { Margin = 10, Spacing = 10 };
+
+			var singleTapResults = new Label { AutomationId = "DynamicTapGestureResults", Text = "0" };
+			var singleTapSurface = new Grid()
+			{
+				HeightRequest = 100,
+				WidthRequest = 200,
+				BackgroundColor = Microsoft.Maui.Graphics.Colors.AliceBlue,
+				Children = { new Label { Text = "DynamicTapSurface", AutomationId = "DynamicTapSurface" } }
+			};
+
+			var tapCount = 0;
+
+			var singleTapRecognizer = new TapGestureRecognizer();
+			singleTapRecognizer.Tapped += (sender, args) => {
+				tapCount++;
+				singleTapResults.Text = tapCount.ToString();
+
+				var dynamicTapRecognizer = new TapGestureRecognizer();
+				dynamicTapRecognizer.Tapped += (sender, args) =>
+				{
+					Console.WriteLine("DynamicTap"); 
+				};
+				singleTapSurface.GestureRecognizers.Add(dynamicTapRecognizer);
+			};
+			singleTapSurface.GestureRecognizers.Add(singleTapRecognizer);
+
+			layout.Add(singleTapSurface);
+			layout.Add(singleTapResults);
+
+			Content = layout;
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Elements/GestureRecognizerGallery.cs
+++ b/src/Controls/tests/TestCases.HostApp/Elements/GestureRecognizerGallery.cs
@@ -12,6 +12,7 @@ namespace Maui.Controls.Sample
 			Add(new PointerGestureRecognizerEvents());
 			Add(new DoubleTapGallery());
 			Add(new SingleTapGallery());
+			Add(new DynamicTapGestureGallery());
 		}
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/GestureRecognizerUITests.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/GestureRecognizerUITests.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Maui.TestCases.Tests
 		public void DynamicallyAddedTapGesturesDontCauseMultipleTapEvents()
 		{
 			App.WaitForElement("TargetView");
-			App.EnterText("TargetView", "DynamicTapGallery");
+			App.EnterText("TargetView", "DynamicTapGestureGallery");
 			App.Tap("GoButton");
 
 			App.WaitForElement("DynamicTapSurface");

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/GestureRecognizerUITests.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/GestureRecognizerUITests.cs
@@ -82,5 +82,30 @@ namespace Microsoft.Maui.TestCases.Tests
 			var result = App.FindElement("DisabledTapGestureResults").GetText();
 			ClassicAssert.AreNotEqual("Failed", result);
 		}
+
+		[Test]
+		[Category(UITestCategories.Gestures)]
+		public void DynamicallyAddedTapGesturesDontCauseMultipleTapEvents()
+		{
+			App.WaitForElement("TargetView");
+			App.EnterText("TargetView", "DynamicTapGallery");
+			App.Tap("GoButton");
+
+			App.WaitForElement("DynamicTapSurface");
+			App.Tap("DynamicTapSurface");
+			App.Tap("DynamicTapSurface");
+			App.Tap("DynamicTapSurface");
+
+			var result = App.FindElement("DynamicTapGestureResults").GetText();
+
+			if (int.TryParse(result, out var resultInt))
+			{
+				ClassicAssert.AreEqual(3, resultInt);
+			}
+			else
+			{
+				ClassicAssert.Fail("Failed to parse result as int");
+			}
+		}
 	}
 }


### PR DESCRIPTION
### Description of Change

Alternative to #23238 and #23183

Adding dynamic gesture recognizers to a control on android did cause us to register multiple times to the Touch event on the platform view from the Gesture Manager.  This change instead tries to always unsubscribe first when setting up the gestures (which happens every time the gesture collection changes).  Previously we only unsubscribed if we decided we did _not_ need the touch event for any of the gesture recognizers, but then would subscribe again over and over if we decided we _did_ need a touch event.

### Issues Fixed

Fixes #23177 

