### PR TITLE
Do not include Maui.InTree.targets for an AspNet.Core project

### DIFF
--- a/src/Essentials/samples/Directory.Build.targets
+++ b/src/Essentials/samples/Directory.Build.targets
@@ -1,4 +1,3 @@
 <Project>
-  <Import Project="$(MauiSrcDirectory)Maui.InTree.targets" Condition=" '$(UseMaui)' != 'true' " />
   <Import Project="$(MauiRootDirectory)Directory.Build.targets" />
 </Project>

--- a/src/Essentials/samples/Samples/Directory.Build.targets
+++ b/src/Essentials/samples/Samples/Directory.Build.targets
@@ -1,0 +1,4 @@
+<Project>
+  <Import Project="$(MauiSrcDirectory)Maui.InTree.targets" Condition=" '$(UseMaui)' != 'true' " />
+  <Import Project="../Directory.Build.targets" />
+</Project>


### PR DESCRIPTION
### Description of Change

After we introduced the Binding Source Generator, it started generating code also in the `Essentials.Sample.Server.WebAuthenticator.csproj` which is an ASP.NET Core server and shouldn't include the analzyer:
```
D:\a\_work\1\s\artifacts\obj\Essentials.Sample.Server.WebAuthenticator\Release\net9.0\Microsoft.Maui.Controls.BindingSourceGen\Microsoft.Maui.Controls.BindingSourceGen.BindingSourceGenerator\GeneratedBindingInterceptorsCommon.g.cs(40,39): error CS0246: The type or namespace name 'BindingMode' could not be found (are you missing a using directive or an assembly reference?) [D:\a\_work\1\s\src\Essentials\samples\Sample.Server.WebAuthenticator\Essentials.Sample.Server.WebAuthenticator.csproj]
D:\a\_work\1\s\artifacts\obj\Essentials.Sample.Server.WebAuthenticator\Release\net9.0\Microsoft.Maui.Controls.BindingSourceGen\Microsoft.Maui.Controls.BindingSourceGen.BindingSourceGenerator\GeneratedBindingInterceptorsCommon.g.cs(40,57): error CS0246: The type or namespace name 'BindableProperty' could not be found (are you missing a using directive or an assembly reference?) [D:\a\_work\1\s\src\Essentials\samples\Sample.Server.WebAuthenticator\Essentials.Sample.Server.WebAuthenticator.csproj]
D:\a\_work\1\s\artifacts\obj\Essentials.Sample.Server.WebAuthenticator\Release\net9.0\Microsoft.Maui.Controls.BindingSourceGen\Microsoft.Maui.Controls.BindingSourceGen.BindingSourceGenerator\GeneratedBindingInterceptorsCommon.g.cs(47,39): error CS0246: The type or namespace name 'BindingMode' could not be found (are you missing a using directive or an assembly reference?) [D:\a\_work\1\s\src\Essentials\samples\Sample.Server.WebAuthenticator\Essentials.Sample.Server.WebAuthenticator.csproj]
```

It seems that the problem is that we're including `Maui.InTree.targets` for non-MAUI projects in src/Essentials/samples/Directory.Build.targets (see [history of that file](https://github.com/simonrozsival/maui/commits/05720981ba70b4412f22abc2a0b8311b286a33d7/src/Essentials/samples/Directory.Build.targets)). I don't understand why we needed to import that targets file, it doesn't seem to be necessary to build the ASP.NET Core project.

/cc @jonathanpeppers @PureWeen @mattleibow @StephaneDelcroix 