### PR TITLE
Support the new RIDs on WinUI

### DIFF
--- a/src/Core/src/nuget/buildTransitive/WinUI.targets
+++ b/src/Core/src/nuget/buildTransitive/WinUI.targets
@@ -19,14 +19,6 @@
   </Target>
 
   <!--
-    Workaround for https://github.com/microsoft/WindowsAppSDK/issues/3108
-  -->
-  <Target
-    Name="_MauiAddImplicitDefineConstantsBeforeXamlPreCompile"
-    BeforeTargets="XamlPreCompile"
-    DependsOnTargets="AddImplicitDefineConstants" />
-
-  <!--
     Workaround for https://github.com/microsoft/WindowsAppSDK/issues/2684
     This replaces the error check target entirely as it is not needed.
   -->
@@ -48,16 +40,43 @@
       <NativePlatform Condition="'$(Platform)' == 'arm'">arm</NativePlatform>
       <NativePlatform Condition="'$(Platform)' == 'arm64'">arm64</NativePlatform>
     </PropertyGroup>
-    <PropertyGroup Condition="'$(Platform)' == 'AnyCPU'">
+    <PropertyGroup Condition="'$(Platform)' == 'AnyCPU' or '$(Platform)' == 'Any CPU'">
       <NativePlatform>neutral</NativePlatform>
-      <NativePlatform Condition="'$(RuntimeIdentifier)' == 'win10-x86'">x86</NativePlatform>
-      <NativePlatform Condition="'$(RuntimeIdentifier)' == 'win10-x64'">x64</NativePlatform>
-      <NativePlatform Condition="'$(RuntimeIdentifier)' == 'win10-arm'">arm</NativePlatform>
-      <NativePlatform Condition="'$(RuntimeIdentifier)' == 'win10-arm64'">arm64</NativePlatform>
+      <NativePlatform Condition="'$(RuntimeIdentifier)' == 'win10-x86' or '$(RuntimeIdentifier)' == 'win-x86'">x86</NativePlatform>
+      <NativePlatform Condition="'$(RuntimeIdentifier)' == 'win10-x64' or '$(RuntimeIdentifier)' == 'win-x64'">x64</NativePlatform>
+      <NativePlatform Condition="'$(RuntimeIdentifier)' == 'win10-arm' or '$(RuntimeIdentifier)' == 'win-arm'">arm</NativePlatform>
+      <NativePlatform Condition="'$(RuntimeIdentifier)' == 'win10-arm64' or '$(RuntimeIdentifier)' == 'win-arm64'">arm64</NativePlatform>
     </PropertyGroup>
     <ItemGroup>
       <MicrosoftWindowsAppSDKMsix Include="$([MSBuild]::NormalizeDirectory('$(MicrosoftWindowsAppSDKPackageDir)','tools\Msix\win10-$(NativePlatform)'))Microsoft.WindowsAppRuntime.?.?.Msix"/>
       <MicrosoftWindowsAppSDKMsix Include="$([MSBuild]::NormalizeDirectory('$(MicrosoftWindowsAppSDKPackageDir)','tools\Msix\win10-$(NativePlatform)'))Microsoft.WindowsAppRuntime.?.?-*.Msix"/>
+    </ItemGroup>
+  </Target>
+
+  <!--
+    Workaround for https://github.com/microsoft/WindowsAppSDK/issues/893
+    This adjusts the items if we are still resolving to AnyCPU.
+  -->
+  <Target Name="_GetProjectArchitecture" Returns="@(ProjectArchitecture)">
+    <PropertyGroup>
+      <_ProjectArchitectureOutput>Invalid</_ProjectArchitectureOutput>
+      <_ProjectArchitectureOutput Condition="'$(Platform)' == 'x86'">x86</_ProjectArchitectureOutput>
+      <_ProjectArchitectureOutput Condition="'$(Platform)' == 'Win32'">x86</_ProjectArchitectureOutput>
+      <_ProjectArchitectureOutput Condition="'$(Platform)' == 'x64'">x64</_ProjectArchitectureOutput>
+      <_ProjectArchitectureOutput Condition="'$(Platform)' == 'arm'">arm</_ProjectArchitectureOutput>
+      <_ProjectArchitectureOutput Condition="'$(Platform)' == 'arm64'">arm64</_ProjectArchitectureOutput>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Platform)' == 'AnyCPU' or '$(Platform)' == 'Any CPU'">
+      <_ProjectArchitectureOutput>neutral</_ProjectArchitectureOutput>
+      <_ProjectArchitectureOutput Condition="'$(RuntimeIdentifier)' == 'win10-x86' or '$(RuntimeIdentifier)' == 'win-x86'">x86</_ProjectArchitectureOutput>
+      <_ProjectArchitectureOutput Condition="'$(RuntimeIdentifier)' == 'win10-x64' or '$(RuntimeIdentifier)' == 'win-x64'">x64</_ProjectArchitectureOutput>
+      <_ProjectArchitectureOutput Condition="'$(RuntimeIdentifier)' == 'win10-arm' or '$(RuntimeIdentifier)' == 'win-arm'">arm</_ProjectArchitectureOutput>
+      <_ProjectArchitectureOutput Condition="'$(RuntimeIdentifier)' == 'win10-arm64' or '$(RuntimeIdentifier)' == 'win-arm64'">arm64</_ProjectArchitectureOutput>
+    </PropertyGroup>
+    <Error Condition="'$(UseAppHost)' == 'true' and '$(_ProjectArchitectureOutput)' == 'neutral' and '$(AllowNeutralPackageWithAppHost)' != 'true'"
+      Text="Packaged .NET applications with an app host exe cannot be ProcessorArchitecture neutral. Please specify a RuntimeIdentifier or a Platform other than AnyCPU." />
+    <ItemGroup>
+      <ProjectArchitecture Include="$(_ProjectArchitectureOutput)" />
     </ItemGroup>
   </Target>
 

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/TemplateTests.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/TemplateTests.cs
@@ -238,6 +238,37 @@ namespace Microsoft.Maui.IntegrationTests
 		}
 
 		[Test]
+		[TestCase("maui", true, true)]
+		[TestCase("maui", true, false)]
+		[TestCase("maui", false, true)]
+		[TestCase("maui", false, false)]
+		public void BuildWindowsRidGraph(string id, bool useridgraph, bool unpackaged)
+		{
+			if (TestEnvironment.IsMacOS)
+				Assert.Ignore("This test is designed for testing a windows build.");
+
+			var projectDir = TestDirectory;
+			var projectFile = Path.Combine(projectDir, $"{Path.GetFileName(projectDir)}.csproj");
+
+			Assert.IsTrue(DotnetInternal.New(id, projectDir, DotNetCurrent),
+				$"Unable to create template {id}. Check test output for errors.");
+
+			FileUtilities.ReplaceInFile(projectFile,
+				"<UseMaui>true</UseMaui>",
+				$"""
+				<UseMaui>true</UseMaui>
+				<UseRidGraph>{useridgraph}</UseRidGraph>
+				<WindowsPackageType>{unpackaged}</WindowsPackageType>
+				""");
+
+			var extendedBuildProps = BuildProps;
+			extendedBuildProps.Add($"TargetFramework={DotNetCurrent}-windows10.0.19041.0");
+
+			Assert.IsTrue(DotnetInternal.Build(projectFile, "Release", properties: extendedBuildProps, msbuildWarningsAsErrors: true),
+				$"Project {Path.GetFileName(projectFile)} failed to build. Check test output/attachments for errors.");
+		}
+
+		[Test]
 		[TestCase("maui", $"{DotNetCurrent}-ios", "ios-arm64")]
 		public void PublishNativeAOT(string id, string framework, string runtimeIdentifier)
 		{

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/TemplateTests.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/TemplateTests.cs
@@ -238,11 +238,11 @@ namespace Microsoft.Maui.IntegrationTests
 		}
 
 		[Test]
-		[TestCase("maui", true, true)]
-		[TestCase("maui", true, false)]
-		[TestCase("maui", false, true)]
-		[TestCase("maui", false, false)]
-		public void BuildWindowsRidGraph(string id, bool useridgraph, bool unpackaged)
+		[TestCase("maui", true, "None")]
+		[TestCase("maui", true, "MSIX")]
+		[TestCase("maui", false, "None")]
+		[TestCase("maui", false, "MSIX")]
+		public void BuildWindowsRidGraph(string id, bool useridgraph, string packageType)
 		{
 			if (TestEnvironment.IsMacOS)
 				Assert.Ignore("This test is designed for testing a windows build.");
@@ -258,7 +258,7 @@ namespace Microsoft.Maui.IntegrationTests
 				$"""
 				<UseMaui>true</UseMaui>
 				<UseRidGraph>{useridgraph}</UseRidGraph>
-				<WindowsPackageType>{unpackaged}</WindowsPackageType>
+				<WindowsPackageType>{packageType}</WindowsPackageType>
 				""");
 
 			var extendedBuildProps = BuildProps;

--- a/src/Workload/Microsoft.Maui.Sdk/Sdk/Microsoft.Maui.Sdk.Before.targets
+++ b/src/Workload/Microsoft.Maui.Sdk/Sdk/Microsoft.Maui.Sdk.Before.targets
@@ -6,7 +6,7 @@
     <!-- Generate ReadyToRun (AOT) when building for Release -->
     <PublishReadyToRun Condition=" '$(PublishReadyToRun)' == '' and '$(Configuration)' == 'Release' and '$(OutputType)' == 'WinExe' ">true</PublishReadyToRun>
     <!-- Use full RID graph: https://github.com/dotnet/docs/issues/36527 -->
-    <UseRidGraph Condition=" '$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'windows' ">true</UseRidGraph>
+    <UseRidGraph Condition=" '$(UseRidGraph)' == '' and '$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'windows' ">true</UseRidGraph>
   </PropertyGroup>
 
   <!-- The Windows App SDK does not support AnyCPU without a RID, so make sure we pick the "best" one we can -->
@@ -17,7 +17,8 @@
   <PropertyGroup Condition=" '$(SingleProject)' == 'true' and '$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'windows' and '$(_SingleProjectRIDRequired)' == 'true' and '$(_SingleProjectRIDSpecified)' != 'true' ">
     <_SingleProjectHostArchitecture>$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)</_SingleProjectHostArchitecture>
     <_SingleProjectHostArchitecture>$(_SingleProjectHostArchitecture.ToLower())</_SingleProjectHostArchitecture>
-    <RuntimeIdentifier>win10-$(_SingleProjectHostArchitecture)</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="'$(UseRidGraph)' == 'true'">win10-$(_SingleProjectHostArchitecture)</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="'$(UseRidGraph)' != 'true'">win-$(_SingleProjectHostArchitecture)</RuntimeIdentifier>
     <_MauiUsingDefaultRuntimeIdentifier>true</_MauiUsingDefaultRuntimeIdentifier>
   </PropertyGroup>
 


### PR DESCRIPTION
### Description of Change

Because the new RID graph change came too late for the rest of the ecosystem, we could not use it in .NET 8 GA. However, since some of the dependencies have now added support for the new things, we can make it work.