### PR TITLE
[Windows] Make sure that `FileSystem.Current.AppDataDirectory` folder exists in unpackaged

### DIFF
--- a/src/Essentials/src/FileSystem/FileSystem.uwp.cs
+++ b/src/Essentials/src/FileSystem/FileSystem.uwp.cs
@@ -9,6 +9,25 @@ namespace Microsoft.Maui.Storage
 {
 	partial class FileSystemImplementation : IFileSystem
 	{
+		private readonly string _platformAppDataDirectory;
+
+		public FileSystemImplementation()
+		{
+			if (AppInfoUtils.IsPackagedApp)
+			{
+				_platformAppDataDirectory = ApplicationData.Current.LocalFolder.Path;
+			}
+			else
+			{
+				_platformAppDataDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), AppSpecificPath, "Data");
+
+				if (!File.Exists(_platformAppDataDirectory))
+				{
+					Directory.CreateDirectory(_platformAppDataDirectory);
+				}
+			}
+		}
+
 		static string CleanPath(string path) =>
 			string.Join("_", path.Split(Path.GetInvalidFileNameChars()));
 
@@ -20,10 +39,7 @@ namespace Microsoft.Maui.Storage
 				? ApplicationData.Current.LocalCacheFolder.Path
 				: Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), AppSpecificPath, "Cache");
 
-		string PlatformAppDataDirectory
-			=> AppInfoUtils.IsPackagedApp
-				? ApplicationData.Current.LocalFolder.Path
-				: Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), AppSpecificPath, "Data");
+		string PlatformAppDataDirectory => _platformAppDataDirectory;
 
 		Task<Stream> PlatformOpenAppPackageFileAsync(string filename)
 		{

--- a/src/Essentials/src/FileSystem/FileSystem.uwp.cs
+++ b/src/Essentials/src/FileSystem/FileSystem.uwp.cs
@@ -9,25 +9,6 @@ namespace Microsoft.Maui.Storage
 {
 	partial class FileSystemImplementation : IFileSystem
 	{
-		private readonly string _platformAppDataDirectory;
-
-		public FileSystemImplementation()
-		{
-			if (AppInfoUtils.IsPackagedApp)
-			{
-				_platformAppDataDirectory = ApplicationData.Current.LocalFolder.Path;
-			}
-			else
-			{
-				_platformAppDataDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), AppSpecificPath, "Data");
-
-				if (!File.Exists(_platformAppDataDirectory))
-				{
-					Directory.CreateDirectory(_platformAppDataDirectory);
-				}
-			}
-		}
-
 		static string CleanPath(string path) =>
 			string.Join("_", path.Split(Path.GetInvalidFileNameChars()));
 
@@ -39,7 +20,10 @@ namespace Microsoft.Maui.Storage
 				? ApplicationData.Current.LocalCacheFolder.Path
 				: Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), AppSpecificPath, "Cache");
 
-		string PlatformAppDataDirectory => _platformAppDataDirectory;
+		string PlatformAppDataDirectory
+			=> AppInfoUtils.IsPackagedApp
+				? ApplicationData.Current.LocalFolder.Path
+				: Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), AppSpecificPath, "Data");
 
 		Task<Stream> PlatformOpenAppPackageFileAsync(string filename)
 		{

--- a/src/Essentials/test/DeviceTests/Tests/FileSystem_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/FileSystem_Tests.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 	[Category("FileSystem")]
 	public class FileSystem_Tests
 	{
-		const string bundleFileContents = "This file was in the app bundle.";
+		const string BundleFileContents = "This file was in the app bundle.";
 
 		[Fact]
 		public void CacheDirectory_Is_Valid()
@@ -23,23 +23,19 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 		}
 
 		[Theory]
-		[InlineData("AppBundleFile.txt", bundleFileContents)]
-		[InlineData("AppBundleFile_NoExtension", bundleFileContents)]
-		[InlineData("Folder/AppBundleFile_Nested.txt", bundleFileContents)]
-		[InlineData("Folder\\AppBundleFile_Nested.txt", bundleFileContents)]
+		[InlineData("AppBundleFile.txt", BundleFileContents)]
+		[InlineData("AppBundleFile_NoExtension", BundleFileContents)]
+		[InlineData("Folder/AppBundleFile_Nested.txt", BundleFileContents)]
+		[InlineData("Folder\\AppBundleFile_Nested.txt", BundleFileContents)]
 		public async Task OpenAppPackageFileAsync_Can_Load_File(string filename, string contents)
 		{
-			using (var stream = await FileSystem.OpenAppPackageFileAsync(filename))
-			{
-				Assert.NotNull(stream);
+			using var stream = await FileSystem.OpenAppPackageFileAsync(filename);
+			Assert.NotNull(stream);
 
-				using (var reader = new StreamReader(stream))
-				{
-					var text = await reader.ReadToEndAsync();
+			using var reader = new StreamReader(stream);
+			var text = await reader.ReadToEndAsync();
 
-					Assert.Equal(contents, text);
-				}
-			}
+			Assert.Equal(contents, text);
 		}
 
 		[Fact]


### PR DESCRIPTION
### Description of Change

I'm not too sure if the PR is correct or not as I haven't figured out how to run Windows tests locally.

Anyway, #22231 mentions `C:\Users\davidortinau\AppData\Roaming\User Name\com.simplyprofound.sentencestudio\Data\` and that `Data` folder comes from this [place](https://github.com/dotnet/maui/pull/23265/files#diff-68e97c448bfa67ad3c292a6e146185895b0c2c6437fe5f361d6044327b56dc84L26).

### Issues Fixed

Fixes #22231