### PR TITLE
[X] Dont SetBinding for values returned by OnIdiom

### DIFF
--- a/src/Controls/src/Xaml/ApplyPropertiesVisitor.cs
+++ b/src/Controls/src/Xaml/ApplyPropertiesVisitor.cs
@@ -613,7 +613,7 @@ namespace Microsoft.Maui.Controls.Xaml
 			else
 				minforetriever = () => property.DeclaringType.GetRuntimeProperties().FirstOrDefault(pi => pi.Name == property.PropertyName);
 			var convertedValue = value.ConvertTo(property.ReturnType, minforetriever, serviceProvider, out exception);
-			if (property.ReturnType == typeof(string) && convertedValue is not string)
+			if (property.ReturnType == typeof(string) && convertedValue != null && convertedValue is not string)
 				convertedValue = convertedValue.ToString();
 			if (exception != null)
 				return false;

--- a/src/Controls/src/Xaml/HydrationContext.cs
+++ b/src/Controls/src/Xaml/HydrationContext.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
 
@@ -18,5 +19,6 @@ namespace Microsoft.Maui.Controls.Xaml
 		public Action<Exception> ExceptionHandler { get; set; }
 		public object RootElement { get; set; }
 		public Assembly RootAssembly { get; internal set; }
+		public static List<object> PreventSetBinding { get; internal set; } = new ();
 	}
 }

--- a/src/Controls/src/Xaml/XamlNode.cs
+++ b/src/Controls/src/Xaml/XamlNode.cs
@@ -171,6 +171,7 @@ namespace Microsoft.Maui.Controls.Xaml
 		public XmlType XmlType { get; }
 		public string NamespaceURI { get; }
 		public NameScopeRef NameScopeRef { get; set; }
+		public bool PreventSetBinding { get; internal set; }
 
 		public override void Accept(IXamlNodeVisitor visitor, INode parentNode)
 		{


### PR DESCRIPTION
### Description of Change

align debug behavior with compiled one. OnIdiom doesn't tell the compiler the type returned, so it can't Setbinding




### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

- fixes #18697
- fixes #22877

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
