### PR TITLE
[windows] fix memory leak in `TabbedPage`

### DIFF
--- a/src/Core/src/Platform/Windows/NavigationViewItemViewModel.cs
+++ b/src/Core/src/Platform/Windows/NavigationViewItemViewModel.cs
@@ -89,6 +89,7 @@ namespace Microsoft.Maui.Platform
 		WBrush? _unselectedForeground;
 		ObservableCollection<NavigationViewItemViewModel>? _menuItemsSource;
 		WIconElement? _icon;
+		WeakReference<object>? _data;
 
 		public object? Content
 		{
@@ -112,7 +113,11 @@ namespace Microsoft.Maui.Platform
 			get => IsSelected ? SelectedBackground : UnselectedBackground;
 		}
 
-		public object? Data { get; set; }
+		public object? Data
+		{
+			get => _data?.GetTargetOrDefault();
+			set => _data = value is null ? null : new(value);
+		}
 
 		public ObservableCollection<NavigationViewItemViewModel>? MenuItemsSource
 		{


### PR DESCRIPTION
Context: https://github.com/dotnet/maui/pull/23166

This expands upon #23166 (iOS/Catalyst memory leaks for `TabbedPage`),
fixing the same problem on Windows. I could reproduce the problem in
`MemoryTests.cs`.

I found the `NavigationViewItemViewModel.Data` property held the
`ContentPage` that held onto the `TabbedPage`. I made the backing field
a `WeakReference` and the test in `MemoryTests.cs` now passes on Windows.