### PR TITLE
Null terminate iOS TabbedRenderer

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/TabbedPage/iOS/TabbedRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/TabbedPage/iOS/TabbedRenderer.cs
@@ -110,14 +110,14 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		public override void ViewDidAppear(bool animated)
 		{
-			Page.SendAppearing();
+			Page?.SendAppearing();
 			base.ViewDidAppear(animated);
 		}
 
 		public override void ViewDidDisappear(bool animated)
 		{
 			base.ViewDidDisappear(animated);
-			Page.SendDisappearing();
+			Page?.SendDisappearing();
 		}
 
 		public override void ViewDidLayoutSubviews()
@@ -158,7 +158,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		UIViewController GetViewController(Page page)
 		{
-			if (page.Handler is not IPlatformViewHandler nvh)
+			if (page?.Handler is not IPlatformViewHandler nvh)
 				return null;
 
 			return nvh.ViewController;

--- a/src/TestUtils/src/DeviceTests/AssertionExtensions.Android.cs
+++ b/src/TestUtils/src/DeviceTests/AssertionExtensions.Android.cs
@@ -356,8 +356,16 @@ namespace Microsoft.Maui.DeviceTests
 				}
 				finally
 				{
-					rootView.RemoveView(layout);
-					layout.RemoveView(view);
+					if (rootView.IsAlive() && layout.IsAlive())
+					{
+						rootView.RemoveView(layout);
+					}
+
+					if (layout.IsAlive() && view.IsAlive())
+					{
+						layout.RemoveView(view);
+					}
+
 					_attachAndRunSemaphore.Release();
 				}
 			}


### PR DESCRIPTION
### Description of Change

We recently made the xplat view inside `TabbedRenderer` weak so there are scenarios where life cycle events might trigger a path that tries to retrieve a collected xplat view. I noticed this failure in our device tests when running locally. Occasionally it would be fine but occasionally it wouldn't :-) 