### PR TITLE
Add MSBuild glob for Windows Assets

### DIFF
--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.Globs.props
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.Globs.props
@@ -150,6 +150,10 @@
       <Generator>MSBuild:Compile</Generator>
       <XamlRuntime>$(DefaultXamlRuntime)</XamlRuntime>
     </Page>
+    <Content
+      Include="$(WindowsProjectFolder)\Assets\Images\**"
+      Exclude="$(_SingleProjectWindowsExcludes)"
+      TargetPath="%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
 
   <!-- Tizen -->


### PR DESCRIPTION
### Description of Change

Similar to #23269 but specific to Windows Assets.

This adds a glob that will take any asset under `Platforms\Windows\Assets\**` and put that in the app bundle root.

Potentially breaking change for people as one workaround was to just reference the file by specifying the whole path, for example: `<Image Source="{OnPlatform flag.png, WinUI=Platforms/Windows/Assets/Images/flag.png}" />`

### Issues Fixed

Fixes #16755