### PR TITLE
[windows] fix memory leak in `MauiWinUIWindow`

### DIFF
--- a/src/Controls/src/Core/Platform/AlertManager/AlertManager.Windows.cs
+++ b/src/Controls/src/Core/Platform/AlertManager/AlertManager.Windows.cs
@@ -26,10 +26,10 @@ namespace Microsoft.Maui.Controls.Platform
 		{
 			IMauiContext? mauiContext = window?.Handler?.MauiContext;
 			var platformWindow = mauiContext?.GetPlatformWindow();
-			if (platformWindow == null)
-				return;
 
-			var toRemove = Subscriptions.Where(s => s.PlatformView == platformWindow).ToList();
+			var toRemove = platformWindow is null ?
+				Subscriptions.Where(s => s.VirtualView == window).ToList() :
+				Subscriptions.Where(s => s.PlatformView == platformWindow).ToList();
 
 			foreach (AlertRequestHelper alertRequestHelper in toRemove)
 			{

--- a/src/Core/src/Platform/Windows/MauiWinUIWindow.cs
+++ b/src/Core/src/Platform/Windows/MauiWinUIWindow.cs
@@ -165,7 +165,7 @@ namespace Microsoft.Maui
 						var rootManager = Window?.Handler?.MauiContext?.GetNavigationRootManager();
 						if (rootManager != null)
 						{
-							rootManager?.SetTitleBarVisibility(hasTitleBar);
+							rootManager?.SetTitleBarVisibility(this, hasTitleBar);
 						}
 					}
 				}


### PR DESCRIPTION
Fixes: https://github.com/dotnet/maui/issues/22973
Context: https://github.com/danielancines/memory-leak-dotnet8-maui

After reviewing the above sample app, I found that the `MauiWinUIWindow` class was not ever going away. I could see it being held by `NavigationRootManager`:

* `Microsoft.Maui.MauiWinUIWindow` ->
  * `Microsoft.Maui.Platform.NavigationRootManager` ->
    * `Windows.Foundation.TypedEventHandler<Microsoft.UI.Xaml.Controls.NavigationView, Microsoft.UI.Xaml.Controls.NavigationViewBackRequestedEventArgs>`

After some trial and error, I found that simply changing `NavigationRootManager`'s `_platformWindow` field a `WeakReference` "untangles" things, and the sample no longer leaks `MauiWinUIWindow` instances:

![image](https://github.com/dotnet/maui/assets/840039/2562a261-cddf-43a1-879d-99add601d931)

^^ In this example, I had opened & closed five child windows, so only the currently open window is alive.

Unfortunately, I was not able to write a passing test for this issue. No matter what I tried, the platform `Window` is kept alive by a "strong handle". But taking a snapshot after the test ends, it goes away?

I still thing the test is useful, as it verifies the other objects.
