### PR TITLE
Fix iOS log exports

### DIFF
--- a/eng/devices/ios.cake
+++ b/eng/devices/ios.cake
@@ -311,11 +311,43 @@ void PerformCleanupIfNeeded(bool cleanupEnabled)
 {
 	if (cleanupEnabled)
 	{
+		var logDirectory = GetLogDirectory();
 		Information("Cleaning up...");
 		Information("Deleting XHarness simulator if exists...");
 		var sims = ListAppleSimulators().Where(s => s.Name.Contains("XHarness")).ToArray();
 		foreach (var sim in sims)
 		{
+			try
+			{
+				var homeDirectory = Environment.GetEnvironmentVariable("HOME");
+                Information("Diagnostics Reports");
+				StartProcess("zip", new ProcessSettings {
+					Arguments = new ProcessArgumentBuilder()
+						.Append("-9r")
+						.AppendQuoted($"{logDirectory}/DiagnosticReports_${sim.UDID}.zip")
+						.AppendQuoted($"{homeDirectory}/Library/Logs/DiagnosticReports/"),
+					RedirectStandardOutput = false
+				});
+
+                Information("CoreSimulator");
+				StartProcess("zip", new ProcessSettings {
+					Arguments = new ProcessArgumentBuilder()
+						.Append("-9r")
+						.AppendQuoted($"{logDirectory}/CoreSimulator_${sim.UDID}.zip")
+						.AppendQuoted($"{homeDirectory}/Library/Logs/CoreSimulator/{sim.UDID}"),
+					RedirectStandardOutput = false
+				});
+
+				StartProcess("xcrun", $"simctl spawn {sim.UDID} log collect --output {logDirectory}/{sim.UDID}_log.logarchive");
+				var screenshotPath = $"{testResultsPath}/{sim.UDID}_screenshot.png";
+				StartProcess("xcrun", $"simctl io {sim.UDID} screenshot {screenshotPath}");
+			}
+			catch(Exception ex)
+			{
+				Information($"Failed to collect logs for simulator {sim.Name} ({sim.UDID}): {ex.Message}");
+				Information($"Command Executed: simctl spawn {sim.UDID} log collect --output {logDirectory}/{sim.UDID}_log.logarchive");
+			}
+
 			Information($"Deleting XHarness simulator {sim.Name} ({sim.UDID})...");
 			StartProcess("xcrun", $"simctl shutdown {sim.UDID}");
 			ExecuteWithRetries(() => StartProcess("xcrun", $"simctl delete {sim.UDID}"), 3);

--- a/eng/devices/ios.cake
+++ b/eng/devices/ios.cake
@@ -44,7 +44,7 @@ var dotnetToolPath = GetDotnetToolPath();
 Setup(context =>
 {
 	LogSetupInfo(dotnetToolPath);
-	PerformCleanupIfNeeded(deviceCleanupEnabled);
+	PerformCleanupIfNeeded(deviceCleanupEnabled, false);
 
 	// Device or simulator setup
 	if (testDevice.Contains("device"))
@@ -58,7 +58,7 @@ Setup(context =>
 	}
 });
 
-Teardown(context => PerformCleanupIfNeeded(deviceCleanupEnabled));
+Teardown(context => PerformCleanupIfNeeded(deviceCleanupEnabled, true));
 
 Task("Cleanup");
 
@@ -307,7 +307,7 @@ void ExecuteCGLegacyUITests(string project, string appProject, string device, st
 
 // Helper methods
 
-void PerformCleanupIfNeeded(bool cleanupEnabled)
+void PerformCleanupIfNeeded(bool cleanupEnabled, bool createDeviceLogs)
 {
 	if (cleanupEnabled)
 	{
@@ -317,35 +317,47 @@ void PerformCleanupIfNeeded(bool cleanupEnabled)
 		var sims = ListAppleSimulators().Where(s => s.Name.Contains("XHarness")).ToArray();
 		foreach (var sim in sims)
 		{
-			try
+			if(createDeviceLogs)
 			{
-				var homeDirectory = Environment.GetEnvironmentVariable("HOME");
-                Information("Diagnostics Reports");
-				StartProcess("zip", new ProcessSettings {
-					Arguments = new ProcessArgumentBuilder()
-						.Append("-9r")
-						.AppendQuoted($"{logDirectory}/DiagnosticReports_${sim.UDID}.zip")
-						.AppendQuoted($"{homeDirectory}/Library/Logs/DiagnosticReports/"),
-					RedirectStandardOutput = false
-				});
+				try
+				{
+					var homeDirectory = Environment.GetEnvironmentVariable("HOME");
+					Information("Diagnostics Reports");
+					StartProcess("zip", new ProcessSettings {
+						Arguments = new ProcessArgumentBuilder()
+							.Append("-9r")
+							.AppendQuoted($"{logDirectory}/DiagnosticReports_${sim.UDID}.zip")
+							.AppendQuoted($"{homeDirectory}/Library/Logs/DiagnosticReports/"),
+						RedirectStandardOutput = false
+					});
 
-                Information("CoreSimulator");
-				StartProcess("zip", new ProcessSettings {
-					Arguments = new ProcessArgumentBuilder()
-						.Append("-9r")
-						.AppendQuoted($"{logDirectory}/CoreSimulator_${sim.UDID}.zip")
-						.AppendQuoted($"{homeDirectory}/Library/Logs/CoreSimulator/{sim.UDID}"),
-					RedirectStandardOutput = false
-				});
+					Information("CoreSimulator");
+					StartProcess("zip", new ProcessSettings {
+						Arguments = new ProcessArgumentBuilder()
+							.Append("-9r")
+							.AppendQuoted($"{logDirectory}/CoreSimulator_${sim.UDID}.zip")
+							.AppendQuoted($"{homeDirectory}/Library/Logs/CoreSimulator/{sim.UDID}"),
+						RedirectStandardOutput = false
+					});
 
-				StartProcess("xcrun", $"simctl spawn {sim.UDID} log collect --output {logDirectory}/{sim.UDID}_log.logarchive");
-				var screenshotPath = $"{testResultsPath}/{sim.UDID}_screenshot.png";
-				StartProcess("xcrun", $"simctl io {sim.UDID} screenshot {screenshotPath}");
-			}
-			catch(Exception ex)
-			{
-				Information($"Failed to collect logs for simulator {sim.Name} ({sim.UDID}): {ex.Message}");
-				Information($"Command Executed: simctl spawn {sim.UDID} log collect --output {logDirectory}/{sim.UDID}_log.logarchive");
+					StartProcess("xcrun", $"simctl spawn {sim.UDID} log collect --output {homeDirectory}/{sim.UDID}_log.logarchive");
+
+					StartProcess("zip", new ProcessSettings {
+						Arguments = new ProcessArgumentBuilder()
+							.Append("-9r")
+							.AppendQuoted($"{logDirectory}/{sim.UDID}_log.logarchive.zip")
+							.AppendQuoted($"{homeDirectory}/{sim.UDID}_log.logarchive"),
+						RedirectStandardOutput = false
+					});
+
+					var screenshotPath = $"{testResultsPath}/{sim.UDID}_screenshot.png";
+					StartProcess("xcrun", $"simctl io {sim.UDID} screenshot {screenshotPath}");
+				}
+				catch(Exception ex)
+				{
+					Information($"Failed to collect logs for simulator {sim.Name} ({sim.UDID}): {ex.Message}");
+					Information($"Command Executed: simctl spawn {sim.UDID} log collect --output {logDirectory}/{sim.UDID}_log.logarchive");
+				}
 			}
 
 			Information($"Deleting XHarness simulator {sim.Name} ({sim.UDID})...");

--- a/eng/devices/ios.cake
+++ b/eng/devices/ios.cake
@@ -326,7 +326,7 @@ void PerformCleanupIfNeeded(bool cleanupEnabled, bool createDeviceLogs)
 					StartProcess("zip", new ProcessSettings {
 						Arguments = new ProcessArgumentBuilder()
 							.Append("-9r")
-							.AppendQuoted($"{logDirectory}/DiagnosticReports_${sim.UDID}.zip")
+							.AppendQuoted($"{logDirectory}/DiagnosticReports_{sim.UDID}.zip")
 							.AppendQuoted($"{homeDirectory}/Library/Logs/DiagnosticReports/"),
 						RedirectStandardOutput = false
 					});
@@ -335,7 +335,7 @@ void PerformCleanupIfNeeded(bool cleanupEnabled, bool createDeviceLogs)
 					StartProcess("zip", new ProcessSettings {
 						Arguments = new ProcessArgumentBuilder()
 							.Append("-9r")
-							.AppendQuoted($"{logDirectory}/CoreSimulator_${sim.UDID}.zip")
+							.AppendQuoted($"{logDirectory}/CoreSimulator_{sim.UDID}.zip")
 							.AppendQuoted($"{homeDirectory}/Library/Logs/CoreSimulator/{sim.UDID}"),
 						RedirectStandardOutput = false
 					});

--- a/eng/pipelines/common/device-tests-steps.yml
+++ b/eng/pipelines/common/device-tests-steps.yml
@@ -79,14 +79,6 @@ steps:
       Write-Host "##vso[task.setvariable variable=Platform.Name]${platformName}"
     displayName: 'Set Platform.Name'
 
-  - ${{ if eq(parameters.platform, 'ios')}}:
-    - bash: |
-        if [ -f "$HOME/Library/Logs/CoreSimulator/*" ]; then rm -r $HOME/Library/Logs/CoreSimulator/*; fi
-        if [ -f "$HOME/Library/Logs/DiagnosticReports/*" ]; then rm -r $HOME/Library/Logs/DiagnosticReports/*; fi
-      displayName: Delete Old Simulator Logs
-      condition: always()
-      continueOnError: true
-
   - ${{ if eq(parameters.platform, 'windows')}}:
     - pwsh: |
         $errorPath = "HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps"
@@ -113,10 +105,8 @@ steps:
 
   - ${{ if eq(parameters.platform, 'ios')}}:
     - bash: |
-        suffix=$(date +%Y%m%d%H%M%S)
-        zip -9r "$(LogDirectory)/CoreSimulatorLog_${suffix}.zip" "$HOME/Library/Logs/CoreSimulator/"
-        zip -9r "$(LogDirectory)/DiagnosticReports_${suffix}.zip" "$HOME/Library/Logs/DiagnosticReports/"
-      displayName: Zip Simulator Logs
+        pwsh ./build.ps1 --target=Cleanup -Script eng/devices/${{ parameters.platform }}.cake ---results="$(TestResultsDirectory)" ${{ parameters.cakeArgs }}
+      displayName: Cleanup and Create Simulator Logs if Test Run Failed To
       condition: always()
       continueOnError: true
 

--- a/eng/pipelines/common/device-tests.yml
+++ b/eng/pipelines/common/device-tests.yml
@@ -72,7 +72,7 @@ stages:
         clean: all
       displayName: "iOS tests"
       pool: ${{ parameters.iosPool }}
-      timeoutInMinutes: 140
+      timeoutInMinutes: 45
       strategy:
         matrix:
           # create all the variables used for the matrix

--- a/eng/pipelines/common/maui-templates.yml
+++ b/eng/pipelines/common/maui-templates.yml
@@ -170,14 +170,6 @@ jobs:
         DOTNET_TOKEN: $(dotnetbuilds-internal-container-read-token)
         PRIVATE_BUILD: $(PrivateBuild)
 
-    - ${{ if eq(RunPlatform.testName, 'RunOniOS') }}:
-      - bash: |
-          if [ -f "$HOME/Library/Logs/CoreSimulator/*" ]; then rm -r $HOME/Library/Logs/CoreSimulator/*; fi
-          if [ -f "$HOME/Library/Logs/DiagnosticReports/*" ]; then rm -r $HOME/Library/Logs/DiagnosticReports/*; fi
-        displayName: Delete Old Simulator Logs
-        condition: always()
-        continueOnError: true
-
     # - script: dotnet tool update Microsoft.DotNet.XHarness.CLI --add-source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json --version "9.0.0-prerelease*" -g
     #   displayName: install xharness
 
@@ -201,10 +193,8 @@ jobs:
 
     - ${{ if eq(RunPlatform.testName, 'RunOniOS') }}:
       - bash: |
-          suffix=$(date +%Y%m%d%H%M%S)
-          zip -9r "$(LogDirectory)/CoreSimulatorLog_${suffix}.zip" "$HOME/Library/Logs/CoreSimulator/"
-          zip -9r "$(LogDirectory)/DiagnosticReports_${suffix}.zip" "$HOME/Library/Logs/DiagnosticReports/"
-        displayName: Zip Simulator Logs
+          pwsh ./build.ps1 --target=Cleanup -Script eng/devices/${{ parameters.platform }}.cake ---results="$(TestResultsDirectory)" ${{ parameters.cakeArgs }}
+        displayName: Cleanup and Create Simulator Logs if Test Run Failed To
         condition: always()
         continueOnError: true
 

--- a/eng/pipelines/common/maui-templates.yml
+++ b/eng/pipelines/common/maui-templates.yml
@@ -192,8 +192,7 @@ jobs:
             IOS_TEST_DEVICE: ios-simulator-64_17.2
 
     - ${{ if eq(RunPlatform.testName, 'RunOniOS') }}:
-      - bash: |
-          pwsh ./build.ps1 --target=Cleanup -Script eng/devices/${{ parameters.platform }}.cake ---results="$(TestResultsDirectory)" ${{ parameters.cakeArgs }}
+      - pwsh: ./build.ps1 --target=Cleanup -Script eng/devices/${{ parameters.platform }}.cake ---results="$(TestResultsDirectory)" ${{ parameters.cakeArgs }}
         displayName: Cleanup and Create Simulator Logs if Test Run Failed To
         condition: always()
         continueOnError: true

--- a/eng/pipelines/common/maui-templates.yml
+++ b/eng/pipelines/common/maui-templates.yml
@@ -192,7 +192,7 @@ jobs:
             IOS_TEST_DEVICE: ios-simulator-64_17.2
 
     - ${{ if eq(RunPlatform.testName, 'RunOniOS') }}:
-      - pwsh: ./build.ps1 --target=Cleanup -Script eng/devices/${{ parameters.platform }}.cake ---results="$(TestResultsDirectory)" ${{ parameters.cakeArgs }}
+      - pwsh: ./build.ps1 --target=Cleanup -Script eng/devices/ios.cake ---results="$(TestResultsDirectory)" ${{ parameters.cakeArgs }}
         displayName: Cleanup and Create Simulator Logs if Test Run Failed To
         condition: always()
         continueOnError: true

--- a/eng/pipelines/common/ui-tests-steps.yml
+++ b/eng/pipelines/common/ui-tests-steps.yml
@@ -100,6 +100,8 @@ steps:
       }
 
       Invoke-Expression $command
+
+  - pwsh: ./build.ps1 -Script eng/devices/${{ parameters.platform }}.cake --target=uitest --project="${{ parameters.path }}" --appproject="${{ parameters.app }}" --device="${{ parameters.device }}" --apiversion="${{ parameters.version }}" --configuration="${{ parameters.configuration }}" --results="$(TestResultsDirectory)" --binlog="$(LogDirectory)" ${{ parameters.cakeArgs }} --verbosity=diagnostic  --runtimevariant="${{ parameters.runtimeVariant }}"
     displayName: $(Agent.JobName)
     ${{ if ne(parameters.platform, 'android')}}:
       retryCountOnTaskFailure: 1
@@ -107,10 +109,8 @@ steps:
       APPIUM_HOME: $(APPIUM_HOME)
 
   - bash: |
-      suffix=$(date +%Y%m%d%H%M%S)
-      zip -9r "$(LogDirectory)/CoreSimulatorLog_${suffix}.zip" "$HOME/Library/Logs/CoreSimulator/"
-      zip -9r "$(LogDirectory)/DiagnosticReports_${suffix}.zip" "$HOME/Library/Logs/DiagnosticReports/"
-    displayName: Zip Simulator Logs
+      pwsh ./build.ps1 --target=Cleanup -Script eng/devices/${{ parameters.platform }}.cake ---results="$(TestResultsDirectory)" ${{ parameters.cakeArgs }}
+      displayName: Cleanup and Create Simulator Logs if Test Run Failed To
     condition: ${{ eq(parameters.platform, 'ios') }}
     continueOnError: true
 

--- a/eng/pipelines/common/ui-tests-steps.yml
+++ b/eng/pipelines/common/ui-tests-steps.yml
@@ -101,13 +101,6 @@ steps:
 
       Invoke-Expression $command
 
-  - pwsh: ./build.ps1 -Script eng/devices/${{ parameters.platform }}.cake --target=uitest --project="${{ parameters.path }}" --appproject="${{ parameters.app }}" --device="${{ parameters.device }}" --apiversion="${{ parameters.version }}" --configuration="${{ parameters.configuration }}" --results="$(TestResultsDirectory)" --binlog="$(LogDirectory)" ${{ parameters.cakeArgs }} --verbosity=diagnostic  --runtimevariant="${{ parameters.runtimeVariant }}"
-    displayName: $(Agent.JobName)
-    ${{ if ne(parameters.platform, 'android')}}:
-      retryCountOnTaskFailure: 1
-    env:
-      APPIUM_HOME: $(APPIUM_HOME)
-
   - bash: |
       pwsh ./build.ps1 --target=Cleanup -Script eng/devices/${{ parameters.platform }}.cake ---results="$(TestResultsDirectory)" ${{ parameters.cakeArgs }}
       displayName: Cleanup and Create Simulator Logs if Test Run Failed To

--- a/eng/pipelines/common/ui-tests-steps.yml
+++ b/eng/pipelines/common/ui-tests-steps.yml
@@ -108,7 +108,7 @@ steps:
 
   - bash: |
       pwsh ./build.ps1 --target=Cleanup -Script eng/devices/${{ parameters.platform }}.cake ---results="$(TestResultsDirectory)" ${{ parameters.cakeArgs }}
-      displayName: Cleanup and Create Simulator Logs if Test Run Failed To
+    displayName: Cleanup and Create Simulator Logs if Test Run Failed To
     condition: ${{ eq(parameters.platform, 'ios') }}
     continueOnError: true
 

--- a/eng/pipelines/common/ui-tests-steps.yml
+++ b/eng/pipelines/common/ui-tests-steps.yml
@@ -99,7 +99,12 @@ steps:
         $command += " --test-filter ""$testFilter"""
       }
 
-      Invoke-Expression $command
+      Invoke-Expression $command  
+    displayName: $(Agent.JobName)
+    ${{ if ne(parameters.platform, 'android')}}:
+      retryCountOnTaskFailure: 1
+    env:
+      APPIUM_HOME: $(APPIUM_HOME)
 
   - bash: |
       pwsh ./build.ps1 --target=Cleanup -Script eng/devices/${{ parameters.platform }}.cake ---results="$(TestResultsDirectory)" ${{ parameters.cakeArgs }}


### PR DESCRIPTION
### Description of Change

At one point we added code to collect all the iOS console logs when running tests. AFAICT none of those added steps successfully gather the logs during test runs. Because the iOS devices are created and then destroyed within the scope of the test run, the device logs no longer exist after the run has finished. This PR should now grab only the logs we care about.