### PR TITLE
Simplify `NavigationRootManager.Connect` on the Windows platform.

### DIFF
--- a/src/Core/src/Platform/Windows/NavigationRootManager.cs
+++ b/src/Core/src/Platform/Windows/NavigationRootManager.cs
@@ -89,24 +89,15 @@ namespace Microsoft.Maui.Platform
 				_rootView.Content = null;
 			}
 
-			NavigationView rootNavigationView;
-			if (platformView is NavigationView nv)
+			if (platformView is NavigationView)
 			{
-				rootNavigationView = nv;
 				_rootView.Content = platformView;
 			}
 			else
 			{
-				if (_rootView.Content is RootNavigationView navView)
-				{
-					rootNavigationView = navView;
-				}
-				else
-				{
-					rootNavigationView = new RootNavigationView();
-				}
-
-				rootNavigationView.Content = platformView;
+				var rootNavigationView = new RootNavigationView() {
+					Content = platformView
+				};
 				_rootView.Content = rootNavigationView;
 			}
 

--- a/src/Core/src/Platform/Windows/NavigationRootManager.cs
+++ b/src/Core/src/Platform/Windows/NavigationRootManager.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Maui.Platform
 				// It might have code in the handler that retrieves this class.
 				_rootView.Content = null;
 			}
-			
+
 			_rootView.Content = platformView is NavigationView ? platformView : new RootNavigationView()
 			{
 				Content = platformView

--- a/src/Core/src/Platform/Windows/NavigationRootManager.cs
+++ b/src/Core/src/Platform/Windows/NavigationRootManager.cs
@@ -88,18 +88,11 @@ namespace Microsoft.Maui.Platform
 				// It might have code in the handler that retrieves this class.
 				_rootView.Content = null;
 			}
-
-			if (platformView is NavigationView)
+			
+			_rootView.Content = platformView is NavigationView ? platformView : new RootNavigationView()
 			{
-				_rootView.Content = platformView;
-			}
-			else
-			{
-				var rootNavigationView = new RootNavigationView() {
-					Content = platformView
-				};
-				_rootView.Content = rootNavigationView;
-			}
+				Content = platformView
+			};
 
 			if (_disconnected)
 			{

--- a/src/Core/src/Platform/Windows/NavigationRootManager.cs
+++ b/src/Core/src/Platform/Windows/NavigationRootManager.cs
@@ -97,9 +97,9 @@ namespace Microsoft.Maui.Platform
 			if (_disconnected)
 			{
 				_platformWindow.Activated += OnWindowActivated;
+				_disconnected = false;
 			}
 
-			_disconnected = false;
 			_rootView.OnWindowTitleBarContentSizeChanged += WindowRootViewOnWindowTitleBarContentSizeChanged;
 		}
 


### PR DESCRIPTION
### Description of Change
I have found redundant codes in `NavigationRootManager.Connect` and this PR resolves it.

I think this is redundant because:
* If `_rootView.Content` is not null when this method is called, it will be cleared to null in the first process. So, `_rootView.Content is RootNavigationView navView` is always null.
* The variable `rootNavigationView` is set to the same reference as `_rootView.Content` but this variable is not used after codes.
* I moved `_disconnected = false;` to the `if (_disconnected)` block because you do not need to set `_disconnected` as false when it is already false.

However, I am not familiar with this code. So, if my change is missing points, feel free to close this PR.
