### PR TITLE
[Windows] `LabelHandler` - remove extra (?) line 

### DIFF
--- a/src/Core/src/Handlers/Label/LabelHandler.Windows.cs
+++ b/src/Core/src/Handlers/Label/LabelHandler.Windows.cs
@@ -36,8 +36,6 @@ namespace Microsoft.Maui.Handlers
 
 		public static void MapBackground(ILabelHandler handler, ILabel label)
 		{
-			handler.UpdateValue(nameof(IViewHandler.ContainerView));
-
 			handler.ToPlatform().UpdateBackground(label);
 		}
 


### PR DESCRIPTION
### Description of Change

I noticed that this line does not seem to be necessary. It also causes significant performance slowdown.

![image](https://github.com/dotnet/maui/assets/203266/25e11762-336f-40f6-8405-03a743085eea)

Speedscopes:

* main: [1719596822.MAIN.speedscope.json](https://github.com/user-attachments/files/16034261/1719596822.MAIN.speedscope.json)
* PR: [1719596550.speedscope.PR.json](https://github.com/user-attachments/files/16034263/1719596550.speedscope.PR.json)

-> ~%95 improvement

**However, I'm not sure if the change is correct or not. I would expect that `MapContainerView` from `ViewHandler.cs` makes sure that a container is mapped properly. But perhaps mapper chaining works differently than I think.**

### Issues Fixed

Contributes to #21787