### PR TITLE
[Android] RequestLayout when visibility changes (#20264)

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue20264.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue20264.xaml
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="Maui.Controls.Sample.Issues.Issue20264"
+    xmlns:ns="clr-namespace:Maui.Controls.Sample.Issues">
+    <VerticalStackLayout>
+        <Label
+            Text="Hello, Maui!"
+            AutomationId="label"
+            x:Name="label"
+            IsVisible="False">
+            <Label.Shadow>
+                <Shadow Opacity="1.0" Radius="0.5" Offset="0,0" Brush="Red"/>
+            </Label.Shadow>
+        </Label>
+        <Button Text="Click"
+            HeightRequest="100"
+            AutomationId="button"
+            Clicked="OnButtonClicked"/>
+    </VerticalStackLayout>
+</ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue20264.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue20264.xaml.cs
@@ -1,0 +1,17 @@
+﻿namespace Maui.Controls.Sample.Issues
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	[Issue(IssueTracker.Github, 20264, "Android does not update visibility of a visual element if it has a Shadow", PlatformAffected.Android)]
+	public partial class Issue20264 : ContentPage
+	{
+		public Issue20264()
+		{
+			InitializeComponent();
+		}
+
+		private void OnButtonClicked(object sender, EventArgs e)
+		{
+			label.IsVisible = true;
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue20264.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue20264.cs
@@ -1,0 +1,24 @@
+﻿#if !MACCATALYST
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue20264 : _IssuesUITest
+	{
+		public Issue20264(TestDevice device) : base(device)
+		{ }
+
+		public override string Issue => "Android does not update visibility of a visual element if it has a Shadow";
+
+		[Test]
+		public void Issue20264Test()
+		{
+			App.WaitForElement("button");
+			App.Click("button");
+			App.WaitForElement("label");
+		}
+	}
+}
+#endif

--- a/src/Core/src/Platform/Android/WrapperView.cs
+++ b/src/Core/src/Platform/Android/WrapperView.cs
@@ -273,6 +273,8 @@ namespace Microsoft.Maui.Platform
 					var child = GetChildAt(n);
 					child.Visibility = ViewStates.Visible;
 				}
+				
+				RequestLayout();
 			}
 		}
 


### PR DESCRIPTION
### Description of Change

The visibility on a visual element didn't initially update when an element was a wrapper view and we want to change the visibility from false to true. Only after the second call, the view became visible

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/20264
Fixes https://github.com/dotnet/maui/issues/23344
