### PR TITLE
Fixing regression in Picker behavior in 8.0.60

### DIFF
--- a/src/Controls/src/Core/Picker/Picker.cs
+++ b/src/Controls/src/Core/Picker/Picker.cs
@@ -312,8 +312,23 @@ namespace Microsoft.Maui.Controls
 
 		void RemoveItems(NotifyCollectionChangedEventArgs e)
 		{
-			int removeStart = e.OldStartingIndex < Items.Count ? e.OldStartingIndex : Items.Count - e.OldItems.Count;
-			int index = removeStart + e.OldItems.Count - 1;
+			int removeStart;
+			// Items are removed in reverse order, so index starts at the index of the last item to remove
+			int index;
+
+			if (e.OldStartingIndex < Items.Count)
+			{
+				// Remove e.OldItems.Count items starting at e.OldStartingIndex
+				removeStart = e.OldStartingIndex;
+				index = e.OldStartingIndex + e.OldItems.Count - 1;
+			}
+			else
+			{
+				// Remove e.OldItems.Count items at the end when e.OldStartingIndex is past the end of the Items collection
+				removeStart = Items.Count - e.OldItems.Count;
+				index = Items.Count - 1;
+			}
+
 			foreach (object _ in e.OldItems)
 				((LockableObservableListWrapper)Items).InternalRemoveAt(index--);
 			if (removeStart <= SelectedIndex)

--- a/src/Controls/src/Core/Picker/Picker.cs
+++ b/src/Controls/src/Core/Picker/Picker.cs
@@ -302,19 +302,21 @@ namespace Microsoft.Maui.Controls
 
 		void AddItems(NotifyCollectionChangedEventArgs e)
 		{
-			int index = e.NewStartingIndex < 0 ? Items.Count : e.NewStartingIndex;
+			int insertIndex = e.NewStartingIndex < 0 ? Items.Count : e.NewStartingIndex;
+			int index = insertIndex;
 			foreach (object newItem in e.NewItems)
 				((LockableObservableListWrapper)Items).InternalInsert(index++, GetDisplayMember(newItem));
-			if (index <= SelectedIndex)
+			if (insertIndex <= SelectedIndex)
 				UpdateSelectedItem(SelectedIndex);
 		}
 
 		void RemoveItems(NotifyCollectionChangedEventArgs e)
 		{
-			int index = e.OldStartingIndex < Items.Count ? e.OldStartingIndex : Items.Count;
+			int removeStart = e.OldStartingIndex < Items.Count ? e.OldStartingIndex : Items.Count - e.OldItems.Count;
+			int index = removeStart + e.OldItems.Count;
 			foreach (object _ in e.OldItems)
 				((LockableObservableListWrapper)Items).InternalRemoveAt(index--);
-			if (index <= SelectedIndex)
+			if (removeStart <= SelectedIndex)
 			{
 				ClampSelectedIndex();
 			}

--- a/src/Controls/src/Core/Picker/Picker.cs
+++ b/src/Controls/src/Core/Picker/Picker.cs
@@ -313,7 +313,7 @@ namespace Microsoft.Maui.Controls
 		void RemoveItems(NotifyCollectionChangedEventArgs e)
 		{
 			int removeStart = e.OldStartingIndex < Items.Count ? e.OldStartingIndex : Items.Count - e.OldItems.Count;
-			int index = removeStart + e.OldItems.Count;
+			int index = removeStart + e.OldItems.Count - 1;
 			foreach (object _ in e.OldItems)
 				((LockableObservableListWrapper)Items).InternalRemoveAt(index--);
 			if (removeStart <= SelectedIndex)

--- a/src/Controls/tests/Core.UnitTests/PickerTests.cs
+++ b/src/Controls/tests/Core.UnitTests/PickerTests.cs
@@ -338,6 +338,118 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.Equal("Ringo", picker.Items[1]);
 		}
 
+		[Theory]
+		[InlineData(0)]
+		[InlineData(1)]
+		public void TestItemsSourceCollectionChangedInsertBeforeSelected(int insertionIndex)
+		{
+			var items = new ObservableCollection<object>
+			{
+				new { Name = "John" },
+				new { Name = "Paul" },
+				new { Name = "Ringo" }
+			};
+			var picker = new Picker
+			{
+				ItemDisplayBinding = new Binding("Name"),
+				ItemsSource = items,
+				SelectedIndex = 1
+			};
+			items.Insert(insertionIndex, new { Name = "George" });
+			Assert.Equal(1, picker.SelectedIndex);
+			Assert.Equal(items[1], picker.SelectedItem);
+		}
+
+		[Theory]
+		[InlineData(2)]
+		[InlineData(3)]
+		public void TestItemsSourceCollectionChangedInsertAfterSelected(int insertionIndex)
+		{
+			var items = new ObservableCollection<object>
+			{
+				new { Name = "John" },
+				new { Name = "Paul" },
+				new { Name = "Ringo" }
+			};
+			var picker = new Picker
+			{
+				ItemDisplayBinding = new Binding("Name"),
+				ItemsSource = items,
+				SelectedIndex = 1
+			};
+			items.Insert(insertionIndex, new { Name = "George" });
+			Assert.Equal(1, picker.SelectedIndex);
+			Assert.Equal(items[1], picker.SelectedItem);
+		}
+
+		[Theory]
+		[InlineData(0)]
+		[InlineData(1)]
+		public void TestItemsSourceCollectionChangedRemoveBeforeSelected(int removeIndex)
+		{
+			var items = new ObservableCollection<object>
+			{
+				new { Name = "John" },
+				new { Name = "Paul" },
+				new { Name = "Ringo" },
+				new { Name = "George" }
+			};
+			var picker = new Picker
+			{
+				ItemDisplayBinding = new Binding("Name"),
+				ItemsSource = items,
+				SelectedIndex = 1
+			};
+			items.RemoveAt(removeIndex);
+			Assert.Equal(1, picker.SelectedIndex);
+			Assert.Equal(items[1], picker.SelectedItem);
+		}
+
+		[Fact]
+		public void TestItemsSourceCollectionChangedRemoveAtEndSelected()
+		{
+			var items = new ObservableCollection<object>
+			{
+				new { Name = "John" },
+				new { Name = "Paul" },
+				new { Name = "Ringo" },
+				new { Name = "George" }
+			};
+			var picker = new Picker
+			{
+				ItemDisplayBinding = new Binding("Name"),
+				ItemsSource = items,
+				SelectedIndex = 3
+			};
+			items.RemoveAt(3);
+			Assert.Equal(2, picker.SelectedIndex);
+			Assert.Equal(items[2], picker.SelectedItem);
+		}
+
+		[Fact]
+		public void TestItemsSourceCollectionChangedRemoveAfterSelected()
+		{
+			var items = new ObservableCollection<object>
+			{
+				new { Name = "John" },
+				new { Name = "Paul" },
+				new { Name = "Ringo" },
+				new { Name = "George" }
+			};
+			var picker = new Picker
+			{
+				ItemDisplayBinding = new Binding("Name"),
+				ItemsSource = items,
+				SelectedIndex = 1
+			};
+			items.RemoveAt(2);
+			Assert.Equal(1, picker.SelectedIndex);
+			Assert.Equal(items[1], picker.SelectedItem);
+		}
+
+
+		// TODO: Multi-item add and remove
+
 		[Fact]
 		public void TestSelectedIndexAssignedItemsSourceCollectionChangedAppend()
 		{


### PR DESCRIPTION
### Description of Change

Correcting the logic of when to update the SelectedItem when a new item is inserted into an INotifyCollectionChanged ItemsSource. The previous code did not account for index being incremented as the new items are inserted into the Items collection, which resulted in failing to reliably update the SelectedItem to account for the inserted items. Also correcting the logic for removing items when an INotifyCollectionChanged ItemsSource has items removed. Based on the documentation, I believe the OldStartingIndex refers to the index of the first removed item, not the end of the removed range like the current behavior has.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #23367

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
