### PR TITLE
Make sure resizetized image files are writable

### DIFF
--- a/src/SingleProject/Resizetizer/src/ResizetizeImages.cs
+++ b/src/SingleProject/Resizetizer/src/ResizetizeImages.cs
@@ -116,8 +116,10 @@ namespace Microsoft.Maui.Resizetizer
 				attr.Add("_ResizetizerDpiScale", img.Dpi.Scale.ToString("0.0", CultureInfo.InvariantCulture));
 
 				copiedResources.Add(new TaskItem(itemSpec, attr));
+				// Make sure the file is not readonly
+				Utils.SetWriteable(itemSpec);
 				// force the date time so we never update an image if its not changed.
-				File.SetLastWriteTimeUtc (itemSpec, DateTime.UtcNow);
+				File.SetLastWriteTimeUtc(itemSpec, DateTime.UtcNow);
 			}
 
 			CopiedResources = copiedResources.ToArray();

--- a/src/SingleProject/Resizetizer/src/Utils.cs
+++ b/src/SingleProject/Resizetizer/src/Utils.cs
@@ -57,5 +57,15 @@ namespace Microsoft.Maui.Resizetizer
 			var modified = exists ? File.GetLastWriteTimeUtc(path) : System.DateTime.MinValue;
 			return (exists, modified);
 		}
+
+		public static void SetWriteable(string source, bool checkExists = true)
+		{
+			if (checkExists && !File.Exists(source))
+				return;
+
+			var attributes = File.GetAttributes(source);
+			if ((attributes & FileAttributes.ReadOnly) == FileAttributes.ReadOnly)
+				File.SetAttributes(source, attributes & ~FileAttributes.ReadOnly);
+		}
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/maui/issues/23397

Commit ff5f3f0 added code which "touches" a file
to make sure its LastWrite time is up to date. This was to help solve certain build issues.

However there was an oversight. Certain source control systems always check out files `readonly`. In these cases the file attributes are copied when we make a copy of a file to be resizetized. When that happens we end up with the following error.

```
Access to the path 'Debug\net8.0-android\resizetizer\r\drawable\foo.png' is denied.
```

To fix this lets make sure that the file is writable before we try to update it.

Also fix some formatting to make sure it matches.



