### PR TITLE
Add missing UI Test category to fix main build

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue22289.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue22289.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		}
 
 		[Test]
+		[Category(UITestCategories.InputTransparent)]
 		public void ButtonsShouldBeVisible()
 		{
 			App.WaitForElement("changeVisibilityButton");


### PR DESCRIPTION
### Description of Change

#23287 adds an analyzer for missing `[Category]` attributes but #22345 just missed that one, this fixes  the build

cc: @kubaflo make sure to add categories to UI tests now, also for existing PRs!