### PR TITLE
Add Flaky UI Test category

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/UITestCategories.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/UITestCategories.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Maui.TestCases.Tests
 		public const string Layout = "Layout";
 		public const string ListView = "ListView";
 		public const string LifeCycle = "Lifecycle";
+		public const string Flaky = "Flaky";
 		public const string FlyoutPage = "FlyoutPage";
 		public const string Picker = "Picker";
 		public const string ProgressBar = "ProgressBar";


### PR DESCRIPTION
### Description of Change

Adds a `Flaky` UI test category to the categories. With this we can better identify and track flaky UI tests going forward and retry those easier as a group. Also see #22609 
