### PR TITLE
[SG] Disable emitting generated sources

### DIFF
--- a/src/Controls/src/BindingSourceGen/Controls.BindingSourceGen.csproj
+++ b/src/Controls/src/BindingSourceGen/Controls.BindingSourceGen.csproj
@@ -13,7 +13,6 @@
   <PropertyGroup>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
-    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <IsRoslynComponent>true</IsRoslynComponent>
   </PropertyGroup>
 

--- a/src/Controls/src/SourceGen/Controls.SourceGen.csproj
+++ b/src/Controls/src/SourceGen/Controls.SourceGen.csproj
@@ -10,8 +10,6 @@
     <NoWarn>$(NoWarn);NU5128;</NoWarn>
   </PropertyGroup>
   <PropertyGroup>
-    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
-    <CompilerGeneratedFilesOutputPath>Generated</CompilerGeneratedFilesOutputPath>
     <IsRoslynComponent>true</IsRoslynComponent>
   </PropertyGroup>
 


### PR DESCRIPTION
### Description of Change

There is no need to store the generated sources on disk.

### Issues Fixed

Contributes to #22384 
