### PR TITLE
[iOS] SwipeView: Fix reenabling parent scrolling after cancelled swipe

### DIFF
--- a/src/Core/src/Platform/iOS/MauiSwipeView.cs
+++ b/src/Core/src/Platform/iOS/MauiSwipeView.cs
@@ -517,7 +517,7 @@ namespace Microsoft.Maui.Platform
 		{
 			var swipeThresholdPercent = MinimumOpenSwipeThresholdPercentage * GetSwipeThreshold();
 
-			if (Math.Abs(_swipeOffset) < swipeThresholdPercent)
+			if (!scrollEnabled && Math.Abs(_swipeOffset) < swipeThresholdPercent)
 				return;
 
 			if (scrollEnabled == _isScrollEnabled)


### PR DESCRIPTION
### Description of Change

Fixes an issue where scrolling of SwipeView's parent is disabled during swipe but not reenabled when the swipe is cancelled by manually moving the touch below the threshold.

### Issues Fixed

Fixes #23441 
Fixes #16856
