### PR TITLE
Add MauiUIApplicationDelegate remote notification methods

### DIFF
--- a/src/Controls/samples/Controls.Sample/MauiProgram.cs
+++ b/src/Controls/samples/Controls.Sample/MauiProgram.cs
@@ -242,7 +242,9 @@ namespace Maui.Controls.Sample
 						.PerformActionForShortcutItem((a, b, c) => LogEvent(nameof(iOSLifecycle.PerformActionForShortcutItem)))
 						.WillEnterForeground((a) => LogEvent(nameof(iOSLifecycle.WillEnterForeground)))
 						.ApplicationSignificantTimeChange((a) => LogEvent(nameof(iOSLifecycle.ApplicationSignificantTimeChange)))
-						.WillTerminate((a) => LogEvent(nameof(iOSLifecycle.WillTerminate))));
+						.WillTerminate((a) => LogEvent(nameof(iOSLifecycle.WillTerminate)))
+						.RegisteredForRemoteNotifications((a, b) => LogEvent(nameof(iOSLifecycle.RegisteredForRemoteNotifications)))
+						.ReceivedRemoteNotification((a,b) => LogEvent(nameof(iOSLifecycle.ReceivedRemoteNotification))));
 #elif WINDOWS
 					// Log everything in this one
 					events.AddWindows(windows => windows

--- a/src/Core/src/LifecycleEvents/iOS/iOSLifecycle.cs
+++ b/src/Core/src/LifecycleEvents/iOS/iOSLifecycle.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Foundation;
-using ObjCRuntime;
 using UIKit;
 
 namespace Microsoft.Maui.LifecycleEvents
@@ -19,6 +18,8 @@ namespace Microsoft.Maui.LifecycleEvents
 		public delegate void WillTerminate(UIApplication application);
 		public delegate void ApplicationSignificantTimeChange(UIApplication application);
 		public delegate void PerformFetch(UIApplication application, Action<UIBackgroundFetchResult> completionHandler);
+		public delegate void RegisteredForRemoteNotifications(UIApplication application, NSData deviceToken);
+		public delegate void ReceivedRemoteNotification(UIApplication application, NSDictionary userInfo);
 
 		// Scene
 		public delegate void SceneWillConnect(UIScene scene, UISceneSession session, UISceneConnectionOptions connectionOptions);

--- a/src/Core/src/LifecycleEvents/iOS/iOSLifecycleBuilderExtensions.cs
+++ b/src/Core/src/LifecycleEvents/iOS/iOSLifecycleBuilderExtensions.cs
@@ -16,7 +16,8 @@ namespace Microsoft.Maui.LifecycleEvents
 		public static IiOSLifecycleBuilder WillEnterForeground(this IiOSLifecycleBuilder lifecycle, iOSLifecycle.WillEnterForeground del) => lifecycle.OnEvent(del);
 		public static IiOSLifecycleBuilder WillTerminate(this IiOSLifecycleBuilder lifecycle, iOSLifecycle.WillTerminate del) => lifecycle.OnEvent(del);
 		public static IiOSLifecycleBuilder ApplicationSignificantTimeChange(this IiOSLifecycleBuilder lifecycle, iOSLifecycle.ApplicationSignificantTimeChange del) => lifecycle.OnEvent(del);
-
+		public static IiOSLifecycleBuilder RegisteredForRemoteNotifications(this IiOSLifecycleBuilder lifecycle, iOSLifecycle.RegisteredForRemoteNotifications del) => lifecycle.OnEvent(del);
+		public static IiOSLifecycleBuilder ReceivedRemoteNotification(this IiOSLifecycleBuilder lifecycle, iOSLifecycle.ReceivedRemoteNotification del) => lifecycle.OnEvent(del);
 
 		[System.Runtime.Versioning.SupportedOSPlatform("ios13.0")]
 		[System.Runtime.Versioning.SupportedOSPlatform("tvos13.0")]

--- a/src/Core/src/Platform/iOS/MauiUIApplicationDelegate.cs
+++ b/src/Core/src/Platform/iOS/MauiUIApplicationDelegate.cs
@@ -165,6 +165,18 @@ namespace Microsoft.Maui
 			_services?.InvokeLifecycleEvents<iOSLifecycle.PerformFetch>(del => del(application, completionHandler));
 		}
 
+		[Export("application:didRegisterForRemoteNotificationsWithDeviceToken:")]
+		public virtual void RegisteredForRemoteNotifications(UIApplication application, NSData deviceToken)
+		{
+			_services?.InvokeLifecycleEvents<iOSLifecycle.RegisteredForRemoteNotifications>(del => del(application, deviceToken));
+		}
+
+		[Export("application:didReceiveRemoteNotification:")]
+		public virtual void ReceivedRemoteNotification(UIApplication application, NSDictionary userInfo)
+		{
+			_services?.InvokeLifecycleEvents<iOSLifecycle.ReceivedRemoteNotification>(del => del(application, userInfo));
+		}
+
 		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = "There can only be one MauiUIApplicationDelegate.")]
 		public static MauiUIApplicationDelegate Current { get; private set; } = null!;
 

--- a/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -35,6 +35,8 @@ Microsoft.Maui.KeyboardAcceleratorModifiers.Shift = 1 -> Microsoft.Maui.Keyboard
 Microsoft.Maui.KeyboardAcceleratorModifiers.Windows = 16 -> Microsoft.Maui.KeyboardAcceleratorModifiers
 Microsoft.Maui.Layouts.FlexBasis.Equals(Microsoft.Maui.Layouts.FlexBasis other) -> bool
 Microsoft.Maui.LifecycleEvents.iOSLifecycle.PerformFetch
+Microsoft.Maui.LifecycleEvents.iOSLifecycle.RegisteredForRemoteNotifications
+Microsoft.Maui.LifecycleEvents.iOSLifecycle.ReceivedRemoteNotification
 Microsoft.Maui.Platform.IImageSourcePartSetter
 Microsoft.Maui.Platform.IImageSourcePartSetter.Handler.get -> Microsoft.Maui.IElementHandler?
 Microsoft.Maui.Platform.IImageSourcePartSetter.ImageSourcePart.get -> Microsoft.Maui.IImageSourcePart?
@@ -107,6 +109,8 @@ static Microsoft.Maui.Hosting.MauiHandlersCollectionExtensions.TryAddHandler<TTy
 static Microsoft.Maui.Layouts.FlexBasis.operator !=(Microsoft.Maui.Layouts.FlexBasis left, Microsoft.Maui.Layouts.FlexBasis right) -> bool
 static Microsoft.Maui.Layouts.FlexBasis.operator ==(Microsoft.Maui.Layouts.FlexBasis left, Microsoft.Maui.Layouts.FlexBasis right) -> bool
 static Microsoft.Maui.Layouts.LayoutExtensions.ArrangeContentUnbounded(this Microsoft.Maui.IContentView! contentView, Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
+static Microsoft.Maui.LifecycleEvents.iOSLifecycleBuilderExtensions.RegisteredForRemoteNotifications(this Microsoft.Maui.LifecycleEvents.IiOSLifecycleBuilder! lifecycle, Microsoft.Maui.LifecycleEvents.iOSLifecycle.RegisteredForRemoteNotifications! del) -> Microsoft.Maui.LifecycleEvents.IiOSLifecycleBuilder!
+static Microsoft.Maui.LifecycleEvents.iOSLifecycleBuilderExtensions.ReceivedRemoteNotification(this Microsoft.Maui.LifecycleEvents.IiOSLifecycleBuilder! lifecycle, Microsoft.Maui.LifecycleEvents.iOSLifecycle.ReceivedRemoteNotification! del) -> Microsoft.Maui.LifecycleEvents.IiOSLifecycleBuilder!
 static Microsoft.Maui.Handlers.SearchBarHandler.MapKeyboard(Microsoft.Maui.Handlers.ISearchBarHandler! handler, Microsoft.Maui.ISearchBar! searchBar) -> void
 static Microsoft.Maui.Platform.KeyboardAutoManagerScroll.Connect() -> void
 static Microsoft.Maui.Platform.KeyboardAutoManagerScroll.Disconnect() -> void
@@ -146,6 +150,8 @@ virtual Microsoft.Maui.Handlers.ImageButtonHandler.SourceLoader.get -> Microsoft
 virtual Microsoft.Maui.Handlers.ImageHandler.SourceLoader.get -> Microsoft.Maui.Platform.ImageSourcePartLoader!
 virtual Microsoft.Maui.Handlers.SwipeItemMenuItemHandler.SourceLoader.get -> Microsoft.Maui.Platform.ImageSourcePartLoader!
 virtual Microsoft.Maui.MauiUIApplicationDelegate.PerformFetch(UIKit.UIApplication! application, System.Action<UIKit.UIBackgroundFetchResult>! completionHandler) -> void
+virtual Microsoft.Maui.MauiUIApplicationDelegate.RegisteredForRemoteNotifications(UIKit.UIApplication! application, Foundation.NSData! deviceToken) -> void
+virtual Microsoft.Maui.MauiUIApplicationDelegate.ReceivedRemoteNotification(UIKit.UIApplication! application, Foundation.NSDictionary! userInfo) -> void
 Microsoft.Maui.Platform.MauiView.CacheMeasureConstraints(double widthConstraint, double heightConstraint) -> void
 Microsoft.Maui.Platform.MauiView.InvalidateConstraintsCache() -> void
 Microsoft.Maui.Platform.MauiView.IsMeasureValid(double widthConstraint, double heightConstraint) -> bool

--- a/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -34,6 +34,8 @@ Microsoft.Maui.KeyboardAcceleratorModifiers.None = 0 -> Microsoft.Maui.KeyboardA
 Microsoft.Maui.KeyboardAcceleratorModifiers.Shift = 1 -> Microsoft.Maui.KeyboardAcceleratorModifiers
 Microsoft.Maui.KeyboardAcceleratorModifiers.Windows = 16 -> Microsoft.Maui.KeyboardAcceleratorModifiers
 Microsoft.Maui.Layouts.FlexBasis.Equals(Microsoft.Maui.Layouts.FlexBasis other) -> bool
+Microsoft.Maui.LifecycleEvents.iOSLifecycle.ReceivedRemoteNotification
+Microsoft.Maui.LifecycleEvents.iOSLifecycle.RegisteredForRemoteNotifications
 Microsoft.Maui.Platform.IImageSourcePartSetter
 Microsoft.Maui.Platform.IImageSourcePartSetter.Handler.get -> Microsoft.Maui.IElementHandler?
 Microsoft.Maui.Platform.IImageSourcePartSetter.ImageSourcePart.get -> Microsoft.Maui.IImageSourcePart?
@@ -110,6 +112,8 @@ static Microsoft.Maui.Hosting.MauiHandlersCollectionExtensions.TryAddHandler<TTy
 static Microsoft.Maui.Layouts.FlexBasis.operator !=(Microsoft.Maui.Layouts.FlexBasis left, Microsoft.Maui.Layouts.FlexBasis right) -> bool
 static Microsoft.Maui.Layouts.FlexBasis.operator ==(Microsoft.Maui.Layouts.FlexBasis left, Microsoft.Maui.Layouts.FlexBasis right) -> bool
 static Microsoft.Maui.Layouts.LayoutExtensions.ArrangeContentUnbounded(this Microsoft.Maui.IContentView! contentView, Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
+static Microsoft.Maui.LifecycleEvents.iOSLifecycleBuilderExtensions.RegisteredForRemoteNotifications(this Microsoft.Maui.LifecycleEvents.IiOSLifecycleBuilder! lifecycle, Microsoft.Maui.LifecycleEvents.iOSLifecycle.RegisteredForRemoteNotifications! del) -> Microsoft.Maui.LifecycleEvents.IiOSLifecycleBuilder!
+static Microsoft.Maui.LifecycleEvents.iOSLifecycleBuilderExtensions.ReceivedRemoteNotification(this Microsoft.Maui.LifecycleEvents.IiOSLifecycleBuilder! lifecycle, Microsoft.Maui.LifecycleEvents.iOSLifecycle.ReceivedRemoteNotification! del) -> Microsoft.Maui.LifecycleEvents.IiOSLifecycleBuilder!
 static Microsoft.Maui.Handlers.SearchBarHandler.MapKeyboard(Microsoft.Maui.Handlers.ISearchBarHandler! handler, Microsoft.Maui.ISearchBar! searchBar) -> void
 static Microsoft.Maui.Platform.SearchBarExtensions.UpdateIsSpellCheckEnabled(this UIKit.UISearchBar! uiSearchBar, Microsoft.Maui.ISearchBar! searchBar, UIKit.UITextField? textField = null) -> void
 static Microsoft.Maui.Platform.SearchBarExtensions.UpdateIsTextPredictionEnabled(this UIKit.UISearchBar! uiSearchBar, Microsoft.Maui.ISearchBar! searchBar, UIKit.UITextField? textField = null) -> void
@@ -143,6 +147,8 @@ static Microsoft.Maui.SoftInputExtensions.ShowSoftInputAsync(this Microsoft.Maui
 *REMOVED*Microsoft.Maui.Handlers.ImageButtonHandler.SourceLoader.get -> Microsoft.Maui.Platform.ImageSourcePartLoader!
 *REMOVED*Microsoft.Maui.Handlers.ImageHandler.SourceLoader.get -> Microsoft.Maui.Platform.ImageSourcePartLoader!
 *REMOVED*Microsoft.Maui.Handlers.SwipeItemMenuItemHandler.SourceLoader.get -> Microsoft.Maui.Platform.ImageSourcePartLoader!
+virtual Microsoft.Maui.MauiUIApplicationDelegate.RegisteredForRemoteNotifications(UIKit.UIApplication! application, Foundation.NSData! deviceToken) -> void
+virtual Microsoft.Maui.MauiUIApplicationDelegate.ReceivedRemoteNotification(UIKit.UIApplication! application, Foundation.NSDictionary! userInfo) -> void
 virtual Microsoft.Maui.Animations.Ticker.OnSystemEnabledChanged() -> void
 virtual Microsoft.Maui.Animations.Ticker.SystemEnabled.set -> void
 virtual Microsoft.Maui.Handlers.ButtonHandler.ImageSourceLoader.get -> Microsoft.Maui.Platform.ImageSourcePartLoader!


### PR DESCRIPTION
### Description of Change

Add ```RegisteredForRemoteNotifications``` and ```ReceivedRemoteNotification``` to ```MauiUIApplicationDelegate``` as virtual methods to allow override. Add corresponding lifecycle events.

### Issues Fixed

Fixes [#23451](https://github.com/dotnet/maui/issues/23451)