### PR TITLE
[Mac] Remove newly added RefreshView test

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue16910.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue16910.cs
@@ -17,7 +17,9 @@ public class Issue16910 : _IssuesUITest
 
 	}
 
+#if !MACCATALYST
 	[Test]
+	[FailsOnMac("When the refreshview appears on catalyst. Appium starts to have a really hard time finding elements")]
 	public void BindingUpdatesFromProgrammaticRefresh()
 	{
 		_ = App.WaitForElement("StartRefreshing");
@@ -26,6 +28,7 @@ public class Issue16910 : _IssuesUITest
 		App.Click("StopRefreshing");
 		App.WaitForElement("IsNotRefreshing");
 	}
+#endif
 
 // Windows only works with touch inputs which we don't have running on the test server
 #if !WINDOWS && !MACCATALYST


### PR DESCRIPTION
### Description of Change
I recently re-enabled these tests https://github.com/dotnet/maui/pull/23181, but, it seems like Appium currently doesn't play well with the refreshview on Catalyst. I tried to workaround the issue a bit but it seems like this is now causing frequent enough crashing on main that we should just ignore this test on Catalyst