### PR TITLE
[net9] BackButtonBehavior enhancement - Changed IsVisible & IsEnabled BindingMode to OneWay

### DIFF
--- a/src/Controls/src/Core/Shell/BackButtonBehavior.cs
+++ b/src/Controls/src/Core/Shell/BackButtonBehavior.cs
@@ -23,11 +23,11 @@ namespace Microsoft.Maui.Controls
 
 		/// <summary>Bindable property for <see cref="IsEnabled"/>.</summary>
 		public static readonly BindableProperty IsEnabledProperty =
-			BindableProperty.Create(nameof(IsEnabled), typeof(bool), typeof(BackButtonBehavior), true, BindingMode.OneTime);
+			BindableProperty.Create(nameof(IsEnabled), typeof(bool), typeof(BackButtonBehavior), true, BindingMode.OneWay);
 
 		/// <summary>Bindable property for <see cref="IsVisible"/>.</summary>
 		public static readonly BindableProperty IsVisibleProperty =
-			BindableProperty.Create(nameof(IsVisible), typeof(bool), typeof(BackButtonBehavior), true, BindingMode.OneTime);
+			BindableProperty.Create(nameof(IsVisible), typeof(bool), typeof(BackButtonBehavior), true, BindingMode.OneWay);
 
 		/// <summary>Bindable property for <see cref="TextOverride"/>.</summary>
 		public static readonly BindableProperty TextOverrideProperty =


### PR DESCRIPTION
### Description of Change

By default when the shell was made, all the bindings were set to OneTime because it's supposedly more performant, but it often confuses people. This makes sense because very few things are one-time.

Fixes https://github.com/dotnet/maui/issues/19171