### PR TITLE
Move PopLifeCycle to device tests

### DIFF
--- a/src/Controls/tests/Core.UnitTests/NavigationPageLifecycleTests.cs
+++ b/src/Controls/tests/Core.UnitTests/NavigationPageLifecycleTests.cs
@@ -57,7 +57,6 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 		[Theory]
 		[InlineData(false)]
-		[InlineData(true)]
 		public async Task PopLifeCycle(bool useMaui)
 		{
 			bool appearingShouldFireOnInitialPage = false;


### PR DESCRIPTION
### Description of Change

This test has been fairly flakey inside our unit tests. This moves it to DeviceTests so it'll just run on the device, which will be more accurate anyway. 