### PR TITLE
[windows] fix VisualDiagnosticsOverlay keeping Page's alive

### DIFF
--- a/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
+++ b/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
@@ -435,7 +435,11 @@ public class MemoryTests : ControlsHandlerTestBase
 		await AssertionExtensions.WaitForGC(references.ToArray());
 	}
 
-	[Fact("VisualDiagnosticsOverlay Does Not Leak")]
+	[Fact("VisualDiagnosticsOverlay Does Not Leak"
+#if IOS || MACCATALYST
+		, Skip = "Fails with 'MauiContext should have been set on parent.'"
+#endif
+	)]
 	public async Task VisualDiagnosticsOverlayDoesNotLeak()
 	{
 		SetupBuilder();

--- a/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
+++ b/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
@@ -435,6 +435,33 @@ public class MemoryTests : ControlsHandlerTestBase
 		await AssertionExtensions.WaitForGC(references.ToArray());
 	}
 
+	[Fact("VisualDiagnosticsOverlay Does Not Leak")]
+	public async Task VisualDiagnosticsOverlayDoesNotLeak()
+	{
+		SetupBuilder();
+
+		var window = new WindowStub();
+		var overlay = new VisualDiagnosticsOverlay(window);
+		var references = new List<WeakReference>();
+
+		{
+			await InvokeOnMainThreadAsync(async () =>
+			{
+				var page = new ContentPage();
+				window.Content = page;
+				await CreateHandlerAsync(page);
+				overlay.Initialize();
+				references.Add(new(page));
+				references.Add(new(page.Handler));
+				references.Add(new(page.Handler.PlatformView));
+
+				window.Content = null;
+			});
+		}
+
+		await AssertionExtensions.WaitForGC(references.ToArray());
+	}
+
 #if IOS
 	[Fact]
 	public async Task ResignFirstResponderTouchGestureRecognizer()


### PR DESCRIPTION
Fixes: https://github.com/dotnet/maui/issues/23034
Context: https://github.com/user-attachments/files/15817814/MauiApp1.zip

In the above sample app, you can observe a memory leak on Windows by doing:

    Application.Current.MainPage = new Page1(); // This page lives forever
    Application.Current.MainPage = new Page2();

Reviewing memory snapshots, it appears that the
`VisualDiagnosticsOverlay` class is keeping the `Page1` instance alive:

    MauiApp1.Page1
    -> Microsoft.Maui.Platform.ContentPanel
        -> Microsoft.Maui.Controls.VisualDiagnostics.VisualDiagnosticsOverlay
            -> Microsoft.Maui.Controls.Window

In this case, the `Window` holds a reference to the `VisualDiagnosticsOverlay`, and the `Window` is still open. `VisualDiagnosticsOverlay`'s base class is `WindowOverlay`, which has a `_platformElement` field holding the `ContentPanel` which holds the `Page1` instance.

In this case, `_platformElement` is only used for unsubscribing events, so it feels like we can just change it to a `WeakReference` to solve the issue.

I was able to write a test for this scenario as well.