### PR TITLE
[Windows] Subscribe pointer events only when needed

### DIFF
--- a/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
@@ -808,7 +808,6 @@ namespace Microsoft.Maui.Controls.Platform
 
 			if (hasPointerGesture)
 			{
-				_subscriptionFlags |= SubscriptionFlags.ContainerPgrPointerEventsSubscribed;
 				SubscribePointerEvents(_container);
 			}
 
@@ -834,9 +833,9 @@ namespace Microsoft.Maui.Controls.Platform
 				return;
 			}
 
+			// Pan, pinch, and swipe gestures need pointer events if not subscribed yet.
 			if (!hasPointerGesture)
 			{
-				_subscriptionFlags |= SubscriptionFlags.ContainerPgrPointerEventsSubscribed;
 				SubscribePointerEvents(_container);
 			}
 
@@ -850,6 +849,8 @@ namespace Microsoft.Maui.Controls.Platform
 
 		void SubscribePointerEvents(FrameworkElement container)
 		{
+			_subscriptionFlags |= SubscriptionFlags.ContainerPgrPointerEventsSubscribed;
+
 			container.PointerEntered += OnPgrPointerEntered;
 			container.PointerExited += OnPgrPointerExited;
 			container.PointerMoved += OnPgrPointerMoved;

--- a/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
@@ -730,15 +730,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 		void UpdateDragAndDropGestureRecognizers()
 		{
-			if (_container is null)
-			{
-				return;
-			}
-
-			var view = Element as View;
-			IList<IGestureRecognizer>? gestures = view?.GestureRecognizers;
-
-			if (gestures is null)
+			if (_container is null || Element is not View view || view.GestureRecognizers is not IList<IGestureRecognizer> gestures)
 			{
 				return;
 			}
@@ -812,16 +804,18 @@ namespace Microsoft.Maui.Controls.Platform
 				}
 			}
 
-			_subscriptionFlags |= SubscriptionFlags.ContainerPgrPointerEventsSubscribed;
-			_container.PointerEntered += OnPgrPointerEntered;
-			_container.PointerExited += OnPgrPointerExited;
-			_container.PointerMoved += OnPgrPointerMoved;
-			_container.PointerPressed += OnPgrPointerPressed;
-			_container.PointerReleased += OnPgrPointerReleased;
+			bool hasPointerGesture = ElementGestureRecognizers.HasAnyGesturesFor<PointerGestureRecognizer>();
+
+			if (hasPointerGesture)
+			{
+				_subscriptionFlags |= SubscriptionFlags.ContainerPgrPointerEventsSubscribed;
+				SubscribePointerEvents(_container);
+			}
 
 			bool hasSwipeGesture = gestures.HasAnyGesturesFor<SwipeGestureRecognizer>();
 			bool hasPinchGesture = gestures.HasAnyGesturesFor<PinchGestureRecognizer>();
 			bool hasPanGesture = gestures.HasAnyGesturesFor<PanGestureRecognizer>();
+
 			if (!hasSwipeGesture && !hasPinchGesture && !hasPanGesture)
 			{
 				return;
@@ -840,12 +834,27 @@ namespace Microsoft.Maui.Controls.Platform
 				return;
 			}
 
+			if (!hasPointerGesture)
+			{
+				_subscriptionFlags |= SubscriptionFlags.ContainerPgrPointerEventsSubscribed;
+				SubscribePointerEvents(_container);
+			}
+
 			_subscriptionFlags |= SubscriptionFlags.ContainerManipulationAndPointerEventsSubscribed;
 			_container.ManipulationMode = ManipulationModes.Scale | ManipulationModes.TranslateX | ManipulationModes.TranslateY;
 			_container.ManipulationDelta += OnManipulationDelta;
 			_container.ManipulationStarted += OnManipulationStarted;
 			_container.ManipulationCompleted += OnManipulationCompleted;
 			_container.PointerCanceled += OnPointerCanceled;
+		}
+
+		void SubscribePointerEvents(FrameworkElement container)
+		{
+			container.PointerEntered += OnPgrPointerEntered;
+			container.PointerExited += OnPgrPointerExited;
+			container.PointerMoved += OnPgrPointerMoved;
+			container.PointerPressed += OnPgrPointerPressed;
+			container.PointerReleased += OnPgrPointerReleased;
 		}
 
 		void HandleTapped(object sender, TappedRoutedEventArgs tappedRoutedEventArgs)


### PR DESCRIPTION
### Description of Change

The idea of the PR is that subscriptions

```
container.PointerEntered += OnPgrPointerEntered;
container.PointerExited += OnPgrPointerExited;
container.PointerMoved += OnPgrPointerMoved;
container.PointerPressed += OnPgrPointerPressed;
container.PointerReleased += OnPgrPointerReleased;
```

are only necessary if 

1. the associated element has [some](https://github.com/dotnet/maui/blob/f323832c7bf7b762ccac48438ec25ce7a6cd17e7/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs#L588-L592) `PointerGestureRecognizer`, or
2. [these events](https://github.com/dotnet/maui/blob/f323832c7bf7b762ccac48438ec25ce7a6cd17e7/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs#L843-L848) are subscribed.

This arguments should suffice to claim that this PR is a refactoring after an element is initialization.

Now it is necessary to prove that the PR works even if 

1. Pointer gesture events change -> should be safe because of [this](https://github.com/dotnet/maui/blob/f323832c7bf7b762ccac48438ec25ce7a6cd17e7/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs#L463-L466)
2. Element's container change -> should be safe because of [this](https://github.com/dotnet/maui/blob/f323832c7bf7b762ccac48438ec25ce7a6cd17e7/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs#L55-L69)

### Performance impact

* MAIN: [1720557197.MAIN.speedscope.MAIN.json](https://github.com/user-attachments/files/16150422/1720557197.MAIN.speedscope.MAIN.json)
* PR: [1720556818.PR.speedscope.PR.json](https://github.com/user-attachments/files/16150424/1720556818.PR.speedscope.PR.json)

![image](https://github.com/dotnet/maui/assets/203266/aad0e380-a83e-47d6-a92c-634c643a280b)

-> 98% improvement[^1].

### Issues Fixed

Contributes to #21787

[^1]: Note that this improvement is for view where there are no PointerGestureRecognizers assigned to elements as in [my use case](https://github.com/dotnet/maui/issues/21787#issue-2238579681).