### PR TITLE
Don't throw exceptions on back-to-back window deactivations

### DIFF
--- a/src/Controls/src/Core/Window/Window.cs
+++ b/src/Controls/src/Core/Window/Window.cs
@@ -484,7 +484,7 @@ namespace Microsoft.Maui.Controls
 		void IWindow.Deactivated()
 		{
 			if (!IsActivated)
-				throw new InvalidOperationException("Window was already deactivated");
+				return;
 
 			IsActivated = false;
 			Deactivated?.Invoke(this, EventArgs.Empty);

--- a/src/Controls/src/Core/Window/Window.cs
+++ b/src/Controls/src/Core/Window/Window.cs
@@ -484,7 +484,7 @@ namespace Microsoft.Maui.Controls
 		void IWindow.Deactivated()
 		{
 			if (!IsActivated)
-				return;
+				throw new InvalidOperationException("Window was already deactivated");
 
 			IsActivated = false;
 			Deactivated?.Invoke(this, EventArgs.Empty);

--- a/src/Core/src/Platform/Windows/MauiWinUIWindow.cs
+++ b/src/Core/src/Platform/Windows/MauiWinUIWindow.cs
@@ -75,6 +75,13 @@ namespace Microsoft.Maui
 				else
 					_enableResumeEvent = true;
 			}
+			else if (args.WindowActivationState == UI.Xaml.WindowActivationState.Deactivated &&
+				!_isActivated)
+			{
+				// Don't invoke deactivated event if we're not activated. It's possible we can
+				// recieve this event twice if we start more than one process at a time
+				return;
+			}
 			else
 			{
 				_isActivated = false;

--- a/src/Core/src/Platform/Windows/MauiWinUIWindow.cs
+++ b/src/Core/src/Platform/Windows/MauiWinUIWindow.cs
@@ -79,7 +79,8 @@ namespace Microsoft.Maui
 				!_isActivated)
 			{
 				// Don't invoke deactivated event if we're not activated. It's possible we can
-				// recieve this event twice if we start more than one process at a time
+				// recieve this event multiple times if we start a new child process and that 
+				// process creates a new window
 				return;
 			}
 			else


### PR DESCRIPTION
### Description of Change

Don't throw exceptions on back-to-back window deactivations as this is valid behavior on platforms such as Windows (should we limit this change to just Windows?)

This is because it's possible to receive 2 "deactivate" window messages in a row if 2 child process windows are created rapidly. Each deactivate message has a parameter of the handle for the new window being created.

### Issues Fixed

Fixes #22406
