### PR TITLE
[windows] fix memory leak in WebView

### DIFF
--- a/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
+++ b/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
@@ -242,6 +242,42 @@ public class MemoryTests : ControlsHandlerTestBase
 		await AssertionExtensions.WaitForGC(viewReference, handlerReference, platformViewReference);
 	}
 
+	[Fact("WebView Does Not Leak")]
+	public async Task WebViewDoesNotLeak()
+	{
+		SetupBuilder();
+
+		var references = new List<WeakReference>();
+		var navPage = new NavigationPage(new ContentPage { Title = "Page 1" });
+
+		await CreateHandlerAndAddToWindow(new Window(navPage), async () =>
+		{
+			{
+				var webView = new WebView
+				{
+					HeightRequest = 500, // NOTE: non-zero size required for Windows
+					Source = new HtmlWebViewSource { Html = "<p>hi</p>" },
+				};
+				var page = new ContentPage
+				{
+					Content = new VerticalStackLayout { webView }
+				};
+				await navPage.Navigation.PushAsync(page);
+				await OnLoadedAsync(page);
+				await Task.Delay(1000); // give the WebView time to load
+
+				references.Add(new(webView));
+				references.Add(new(webView.Handler));
+				references.Add(new(webView.Handler.PlatformView));
+
+				await navPage.Navigation.PopAsync();
+			}
+
+			// Assert *before* the Window is closed
+			await AssertionExtensions.WaitForGC(references.ToArray());
+		});
+	}
+
 	[Theory("Gesture Does Not Leak")]
 	[InlineData(typeof(DragGestureRecognizer))]
 	[InlineData(typeof(DropGestureRecognizer))]


### PR DESCRIPTION
Fixes: https://github.com/dotnet/maui/issues/20283
Fixes: https://github.com/dotnet/maui/issues/22972
Context: https://github.com/davide-cavallini/webview-winUI-maui-leak

The above sample on Windows was leaking because it does the following:

1. Your app has a single `Window`

2. Navigate to a page with a `WebView`

3. Navigate away

Because the `Window` remains alive, `WebViewHandler` subscribes to `Window.Closed` which keeps a reference to the `WebView` and keeps it alive indefinitely.

I was able to reproduce this in a test, that keeps the `Window` alive before calling `AssertionExtensions.WaitForGC()`.

The solution was to move the `Window.Closed` subscription to the `WebView2Proxy` nested class. This makes sure that the `WebView`, its handler, etc. can be collected *before* the `Window` is closed.

I also found a secondary issue while debugging, if you call:

    webView.Close(); // MauiWebView or WebView2

If `CoreWebView2` is not initialized, it will throw a C++ exception.

We can instead do:

    if (webView.CoreWebView2 is not null)
    {
        webView.Close();
    }
