### PR TITLE
Fix the batch file for running local dotnet on windows

### DIFF
--- a/dotnet-local.cmd
+++ b/dotnet-local.cmd
@@ -1,8 +1,9 @@
 @echo off
+setlocal enabledelayedexpansion
 SET ROOT=%~dp0
 IF EXIST "%ROOT%\bin\dotnet\dotnet.exe" (
-    SET DOTNET_ROOT=%ROOT%\bin\dotnet
-    SET PATH=%DOTNET_ROOT%;%PATH%
+    SET "DOTNET_ROOT=%ROOT%\bin\dotnet"
+    SET "PATH=!DOTNET_ROOT!;%PATH%"
     call "%ROOT%\bin\dotnet\dotnet.exe" %*
 ) ELSE (
     echo "You must build MAUI first. Please see '.github/DEVELOPMENT.md' for details."


### PR DESCRIPTION
The problem was that the body of the IF statement is considered one "line" and all environment variables are replaced before that "line" is executed. So set commands don't have an effect on the rest of the code in that IF. Changed this to use `enabledelayedexpansion` and the `!!` syntax which makes it work the way would expect.

One additional fix, enclose the set commands in quotation marks. This fixes a bug where if the `PATH` contains a parenthesis, the script would just plain fail (which can happen if one has x86 programs in their PATH).