### PR TITLE
Make ampersands work *more* in net9-only blazor-solution template

### DIFF
--- a/src/Templates/src/templates/maui-blazor-solution/.template.config/template.json
+++ b/src/Templates/src/templates/maui-blazor-solution/.template.config/template.json
@@ -201,6 +201,12 @@
           ]
         }
       },
+      "XmlEncodedAppNameParam": {
+        "type": "derived",
+        "valueSource": "name",
+        "valueTransform": "encode",
+        "replaces": "XmlEncodedAppName"
+      },
       "defaultAppId":{
       "type": "generated",
       "generator": "join",
@@ -448,5 +454,10 @@
         "description": "Whether to generate an explicit Program class and Main method instead of top-level statements."
       }
     },
-  "defaultName": "MauiApp1"
+    "forms": {
+        "encode": {
+          "identifier": "xmlEncode"
+        }
+    },
+    "defaultName": "MauiApp1"
 }

--- a/src/Templates/src/templates/maui-blazor-solution/MauiApp.1.Web.Client/MauiApp.1.Web.Client.csproj
+++ b/src/Templates/src/templates/maui-blazor-solution/MauiApp.1.Web.Client/MauiApp.1.Web.Client.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\MauiApp.1.Shared\MauiApp.1.Shared.csproj" />
+    <ProjectReference Include="..\XmlEncodedAppName.Shared\XmlEncodedAppName.Shared.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Templates/src/templates/maui-blazor-solution/MauiApp.1.Web/MauiApp.1.Web.csproj
+++ b/src/Templates/src/templates/maui-blazor-solution/MauiApp.1.Web/MauiApp.1.Web.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>${DefaultNetCoreTargetFramework}</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <UserSecretsId Condition="'$(IndividualLocalAuth)' == 'True'">aspnet-MauiApp.1-53bc9b9d-9d6a-45d4-8429-2a2761773502</UserSecretsId>
+    <UserSecretsId Condition="'$(IndividualLocalAuth)' == 'True'">aspnet-XmlEncodedAppName-53bc9b9d-9d6a-45d4-8429-2a2761773502</UserSecretsId>
     <NoDefaultLaunchSettingsFile Condition="'$(ExcludeLaunchSettings)' == 'True'">True</NoDefaultLaunchSettingsFile>
   </PropertyGroup>
 
@@ -16,8 +16,8 @@
   <!--#endif -->
   <!--#if (UseWebAssembly || IndividualLocalAuth) -->
   <ItemGroup>
-    <ProjectReference Include="..\MauiApp.1.Web.Client\MauiApp.1.Web.Client.csproj" Condition="'$(UseWebAssembly)' == 'True'" />
-    <ProjectReference Include="..\MauiApp.1.Shared\MauiApp.1.Shared.csproj" Condition="'$(UseWebAssembly)' != 'True'" />
+    <ProjectReference Include="..\XmlEncodedAppName.Web.Client\XmlEncodedAppName.Web.Client.csproj" Condition="'$(UseWebAssembly)' == 'True'" />
+    <ProjectReference Include="..\XmlEncodedAppName.Shared\XmlEncodedAppName.Shared.csproj" Condition="'$(UseWebAssembly)' != 'True'" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="MS_COMPONENTS_WEBASSEMBLY_SERVER_VERSION" Condition="'$(UseWebAssembly)' == 'True'" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="${MicrosoftAspNetCoreDiagnosticsEntityFrameworkCoreVersion}" Condition="'$(IndividualLocalAuth)' == 'True'" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="${MicrosoftAspNetCoreIdentityEntityFrameworkCoreVersion}" Condition="'$(IndividualLocalAuth)' == 'True'" />
@@ -27,7 +27,7 @@
   </ItemGroup>
   <!--#else -->
   <ItemGroup>
-    <ProjectReference Include="..\MauiApp.1.Shared\MauiApp.1.Shared.csproj" />
+    <ProjectReference Include="..\XmlEncodedAppName.Shared\XmlEncodedAppName.Shared.csproj" />
   </ItemGroup>
   <!--#endif -->
 

--- a/src/Templates/src/templates/maui-blazor-solution/MauiApp.1/MainPage.xaml
+++ b/src/Templates/src/templates/maui-blazor-solution/MauiApp.1/MainPage.xaml
@@ -2,7 +2,7 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:local="clr-namespace:MauiApp._1"
-             xmlns:shared="clr-namespace:MauiApp._1.Shared;assembly=MauiApp.1.Shared"
+             xmlns:shared="clr-namespace:MauiApp._1.Shared;assembly=XmlEncodedAppName.Shared"
              x:Class="MauiApp._1.MainPage"
              BackgroundColor="{DynamicResource PageBackgroundColor}">
 

--- a/src/Templates/src/templates/maui-blazor-solution/MauiApp.1/MauiApp.1.csproj
+++ b/src/Templates/src/templates/maui-blazor-solution/MauiApp.1/MauiApp.1.csproj
@@ -22,7 +22,7 @@
     <Nullable>enable</Nullable>
 
     <!-- Display name -->
-    <ApplicationTitle>MauiApp.1</ApplicationTitle>
+    <ApplicationTitle>XmlEncodedAppName</ApplicationTitle>
 
     <!-- App Identifier -->
     <ApplicationId>com.companyname.mauiapp</ApplicationId>
@@ -64,7 +64,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\MauiApp.1.Shared\MauiApp.1.Shared.csproj" />
+    <ProjectReference Include="..\XmlEncodedAppName.Shared\XmlEncodedAppName.Shared.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Templates/src/templates/maui-blazor-solution/MauiApp.1/Platforms/Tizen/tizen-manifest.xml
+++ b/src/Templates/src/templates/maui-blazor-solution/MauiApp.1/Platforms/Tizen/tizen-manifest.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest package="maui-application-id-placeholder" version="0.0.0" api-version="8" xmlns="http://tizen.org/ns/packages">
   <profile name="common" />
-  <ui-application appid="maui-application-id-placeholder" exec="MauiApp.1.dll" multiple="false" nodisplay="false" taskmanage="true" type="dotnet" launch_mode="single">
+  <ui-application appid="maui-application-id-placeholder" exec="XmlEncodedAppName.dll" multiple="false" nodisplay="false" taskmanage="true" type="dotnet" launch_mode="single">
     <label>maui-application-title-placeholder</label>
     <icon>maui-appicon-placeholder</icon>
     <metadata key="http://tizen.org/metadata/prefer_dotnet_aot" value="true" />

--- a/src/Templates/src/templates/maui-blazor-solution/MauiApp.1/Platforms/Windows/app.manifest
+++ b/src/Templates/src/templates/maui-blazor-solution/MauiApp.1/Platforms/Windows/app.manifest
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="1.0.0.0" name="MauiApp.1.WinUI.app"/>
+  <assemblyIdentity version="1.0.0.0" name="XmlEncodedAppName.WinUI.app"/>
 
   <application xmlns="urn:schemas-microsoft-com:asm.v3">
     <windowsSettings>

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/TemplateTests.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/TemplateTests.cs
@@ -82,12 +82,12 @@ namespace Microsoft.Maui.IntegrationTests
 		{
 			const string templateShortName = "maui-blazor-web";
 
-			var solutionProjectDir = TestDirectory;
+			var solutionProjectDir = TestDirectory + " & More";
 
-			var webAppProjectDir = Path.Combine(TestDirectory, Path.GetFileName(solutionProjectDir) + ".Web");
+			var webAppProjectDir = Path.Combine(solutionProjectDir, Path.GetFileName(solutionProjectDir) + ".Web");
 			var webAppProjectFile = Path.Combine(webAppProjectDir, $"{Path.GetFileName(webAppProjectDir)}.csproj");
 
-			var mauiAppProjectDir = Path.Combine(TestDirectory, Path.GetFileName(solutionProjectDir));
+			var mauiAppProjectDir = Path.Combine(solutionProjectDir, Path.GetFileName(solutionProjectDir));
 			var mauiAppProjectFile = Path.Combine(mauiAppProjectDir, $"{Path.GetFileName(mauiAppProjectDir)}.csproj");
 
 			TestContext.WriteLine($"Creating project in {solutionProjectDir}");

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/TemplateTests.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/TemplateTests.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Maui.IntegrationTests
 		{
 			const string templateShortName = "maui-blazor-web";
 
-			var solutionProjectDir = TestDirectory + " & More";
+			var solutionProjectDir = TestDirectory + "&More";
 
 			var webAppProjectDir = Path.Combine(solutionProjectDir, Path.GetFileName(solutionProjectDir) + ".Web");
 			var webAppProjectFile = Path.Combine(webAppProjectDir, $"{Path.GetFileName(webAppProjectDir)}.csproj");

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/TemplateTests.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/TemplateTests.cs
@@ -52,37 +52,47 @@ namespace Microsoft.Maui.IntegrationTests
 		// Parameters:  target framework, build config, dotnet new additional parameters
 
 		// First, 4 default scenarios
-		[TestCase(DotNetCurrent, "Debug", "")]
-		[TestCase(DotNetCurrent, "Release", "")]
-		[TestCase(DotNetCurrent, "Debug", "")]
-		[TestCase(DotNetCurrent, "Release", "")]
+		[TestCase(DotNetCurrent, "Debug", "", false)]
+		[TestCase(DotNetCurrent, "Release", "", false)]
+		[TestCase(DotNetCurrent, "Debug", "", false)]
+		[TestCase(DotNetCurrent, "Release", "", false)]
 
 		// Then, scenarios with additional template parameters:
 		// - Interactivity Location: None/WASM/Server/Auto
 		// - Empty vs. With Sample Content
 		// - ProgramMain vs. TopLevel statements
 		// And alternately testing other options for a healthy mix.
-		[TestCase(DotNetCurrent, "Debug", "-I None --Empty")]
-		[TestCase(DotNetCurrent, "Release", "-I WebAssembly --Empty")]
-		[TestCase(DotNetCurrent, "Debug", "-I Server --Empty")]
-		[TestCase(DotNetCurrent, "Release", "-I Auto --Empty")]
-		[TestCase(DotNetCurrent, "Debug", "-I None")]
-		[TestCase(DotNetCurrent, "Release", "-I WebAssembly")]
-		[TestCase(DotNetCurrent, "Debug", "-I Server")]
-		[TestCase(DotNetCurrent, "Release", "-I Auto")]
-		[TestCase(DotNetCurrent, "Debug", "-I None --Empty --UseProgramMain")]
-		[TestCase(DotNetCurrent, "Release", "-I WebAssembly --Empty --UseProgramMain")]
-		[TestCase(DotNetCurrent, "Debug", "-I Server --Empty --UseProgramMain")]
-		[TestCase(DotNetCurrent, "Release", "-I Auto --Empty --UseProgramMain")]
-		[TestCase(DotNetCurrent, "Debug", "-I None --UseProgramMain")]
-		[TestCase(DotNetCurrent, "Release", "-I WebAssembly --UseProgramMain")]
-		[TestCase(DotNetCurrent, "Debug", "-I Server --UseProgramMain")]
-		[TestCase(DotNetCurrent, "Release", "-I Auto --UseProgramMain")]
-		public void BuildMauiBlazorWebSolution(string framework, string config, string additionalDotNetNewParams)
+		[TestCase(DotNetCurrent, "Debug", "-I None --Empty", false)]
+		[TestCase(DotNetCurrent, "Release", "-I WebAssembly --Empty", false)]
+		[TestCase(DotNetCurrent, "Debug", "-I Server --Empty", false)]
+		[TestCase(DotNetCurrent, "Release", "-I Auto --Empty", false)]
+		[TestCase(DotNetCurrent, "Debug", "-I None", false)]
+		[TestCase(DotNetCurrent, "Release", "-I WebAssembly", false)]
+		[TestCase(DotNetCurrent, "Debug", "-I Server", false)]
+		[TestCase(DotNetCurrent, "Release", "-I Auto", false)]
+		[TestCase(DotNetCurrent, "Debug", "-I None --Empty --UseProgramMain", false)]
+		[TestCase(DotNetCurrent, "Release", "-I WebAssembly --Empty --UseProgramMain", false)]
+		[TestCase(DotNetCurrent, "Debug", "-I Server --Empty --UseProgramMain", false)]
+		[TestCase(DotNetCurrent, "Release", "-I Auto --Empty --UseProgramMain", false)]
+		[TestCase(DotNetCurrent, "Debug", "-I None --UseProgramMain", false)]
+		[TestCase(DotNetCurrent, "Release", "-I WebAssembly --UseProgramMain", false)]
+		[TestCase(DotNetCurrent, "Debug", "-I Server --UseProgramMain", false)]
+		[TestCase(DotNetCurrent, "Release", "-I Auto --UseProgramMain", false)]
+
+		// Then, some scenarios with tricky names in Debug builds only
+		// This doesn't work on Android in Release, so we skip that for now
+		// See https://github.com/dotnet/android/issues/9107
+		[TestCase(DotNetCurrent, "Debug", "", true)]
+		[TestCase(DotNetCurrent, "Debug", "-I Server --UseProgramMain", true)]
+		public void BuildMauiBlazorWebSolution(string framework, string config, string additionalDotNetNewParams, bool useTrickyProjectName)
 		{
 			const string templateShortName = "maui-blazor-web";
 
-			var solutionProjectDir = TestDirectory + "+More";
+			var solutionProjectDir = TestDirectory;
+   			if (useTrickyProjectName)
+	  		{
+	 			solutionProjectDir += " & More";
+	 		}
 
 			var webAppProjectDir = Path.Combine(solutionProjectDir, Path.GetFileName(solutionProjectDir) + ".Web");
 			var webAppProjectFile = Path.Combine(webAppProjectDir, $"{Path.GetFileName(webAppProjectDir)}.csproj");

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/TemplateTests.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/TemplateTests.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Maui.IntegrationTests
 			var solutionProjectDir = TestDirectory;
    			if (useTrickyProjectName)
 	  		{
-	 			solutionProjectDir += " & More";
+	 			solutionProjectDir += "&More";
 	 		}
 
 			var webAppProjectDir = Path.Combine(solutionProjectDir, Path.GetFileName(solutionProjectDir) + ".Web");

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/TemplateTests.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/TemplateTests.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Maui.IntegrationTests
 		{
 			const string templateShortName = "maui-blazor-web";
 
-			var solutionProjectDir = TestDirectory + "&More";
+			var solutionProjectDir = TestDirectory + "+More";
 
 			var webAppProjectDir = Path.Combine(solutionProjectDir, Path.GetFileName(solutionProjectDir) + ".Web");
 			var webAppProjectFile = Path.Combine(webAppProjectDir, $"{Path.GetFileName(webAppProjectDir)}.csproj");


### PR DESCRIPTION
Fixes #23105

This change is effectivly applying the same change as https://github.com/dotnet/maui/pull/22084, but to the net9-only template in the net9 branch.

However, unfortunately this doesn't seem like it can be a complete fix because there seem to be issues in other parts of the product. They are tracked separately in these issues:
* https://github.com/dotnet/aspnetcore/issues/56765 (various issues with Blazor and/or static web assets)
* https://github.com/dotnet/android/issues/9107 (this bug means that Android won't work at all with `&` in the path, but the other platforms seem to work).

This fix does address some cases, though, and helps ensure that at least the code generated by the templates is valid, even if other parts of the system are incapable of processing certain characters.