### PR TITLE
Fix a few more template ampersand cases

### DIFF
--- a/src/Templates/src/templates/maui-blazor/Platforms/Windows/app.manifest
+++ b/src/Templates/src/templates/maui-blazor/Platforms/Windows/app.manifest
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="1.0.0.0" name="MauiApp.1.WinUI.app"/>
+  <assemblyIdentity version="1.0.0.0" name="XmlEncodedAppName.WinUI.app"/>
 
   <application xmlns="urn:schemas-microsoft-com:asm.v3">
     <windowsSettings>

--- a/src/Templates/src/templates/maui-mobile/Platforms/Windows/app.manifest
+++ b/src/Templates/src/templates/maui-mobile/Platforms/Windows/app.manifest
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="1.0.0.0" name="MauiApp.1.WinUI.app"/>
+  <assemblyIdentity version="1.0.0.0" name="XmlEncodedAppName.WinUI.app"/>
 
   <application xmlns="urn:schemas-microsoft-com:asm.v3">
     <windowsSettings>

--- a/src/Templates/src/templates/maui-multiproject/MauiApp.1.WinUI/app.manifest
+++ b/src/Templates/src/templates/maui-multiproject/MauiApp.1.WinUI/app.manifest
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="1.0.0.0" name="MauiApp.1.app"/>
+  <assemblyIdentity version="1.0.0.0" name="XmlEncodedAppName.app"/>
 
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>


### PR DESCRIPTION
These were missed in the original PR https://github.com/dotnet/maui/pull/22084 for net8 templates, but I found this while working on the net9 templates in PR https://github.com/dotnet/maui/pull/23589.

