### PR TITLE
Fix menus to only create casting list once

### DIFF
--- a/src/Controls/src/Core/Menu/MenuBarItem.cs
+++ b/src/Controls/src/Core/Menu/MenuBarItem.cs
@@ -16,8 +16,11 @@ namespace Microsoft.Maui.Controls
 		public static readonly BindableProperty IsEnabledProperty = BindableProperty.Create(nameof(IsEnabled), typeof(bool),
 			typeof(MenuBarItem), true);
 
-
 		static readonly BindableProperty PriorityProperty = BindableProperty.Create(nameof(Priority), typeof(int), typeof(ToolbarItem), 0);
+		public MenuBarItem()
+		{
+			LogicalChildrenInternalBackingStore = new CastingList<Element, IMenuElement>(_menus);
+		}
 
 		public int Priority
 		{
@@ -39,8 +42,7 @@ namespace Microsoft.Maui.Controls
 
 		readonly List<IMenuElement> _menus = new List<IMenuElement>();
 
-		private protected override IList<Element> LogicalChildrenInternalBackingStore
-			=> new CastingList<Element, IMenuElement>(_menus);
+		private protected override IList<Element> LogicalChildrenInternalBackingStore {get; }
 
 		public IMenuElement this[int index]
 		{

--- a/src/Controls/src/Core/Menu/MenuFlyout.cs
+++ b/src/Controls/src/Core/Menu/MenuFlyout.cs
@@ -10,9 +10,15 @@ namespace Microsoft.Maui.Controls
 	public class MenuFlyout : FlyoutBase, IMenuFlyout // Same pattern as MenuBarItem
 	{
 		readonly List<IMenuElement> _menus = new List<IMenuElement>();
+		public MenuFlyout()
+		{
+			LogicalChildrenInternalBackingStore = new CastingList<Element, IMenuElement>(_menus);
+		}
 
 		private protected override IList<Element> LogicalChildrenInternalBackingStore
-			=> new CastingList<Element, IMenuElement>(_menus);
+		{
+			get;
+		}
 
 		public IMenuElement this[int index]
 		{

--- a/src/Controls/src/Core/Menu/MenuFlyoutSubItem.cs
+++ b/src/Controls/src/Core/Menu/MenuFlyoutSubItem.cs
@@ -14,8 +14,12 @@ namespace Microsoft.Maui.Controls
 	{
 		readonly List<IMenuElement> _menus = new List<IMenuElement>();
 
-		private protected override IList<Element> LogicalChildrenInternalBackingStore
-			=> new CastingList<Element, IMenuElement>(_menus);
+		public MenuFlyoutSubItem()
+		{
+			LogicalChildrenInternalBackingStore = new CastingList<Element, IMenuElement>(_menus);
+		}
+
+		private protected override IList<Element> LogicalChildrenInternalBackingStore {get; }
 
 		public IMenuElement this[int index]
 		{


### PR DESCRIPTION
### Description of Change

The `LogicalChildrenInternalBackingStore` currently instantiates a new `CastingList` every time it's accessed. This fixes the code, so it's only created once during construction.
