### PR TITLE
[Windows] Handle non-seekable streams in `PlatformImage.FromStream`

### DIFF
--- a/src/Graphics/src/Graphics/Platforms/Windows/PlatformImage.cs
+++ b/src/Graphics/src/Graphics/Platforms/Windows/PlatformImage.cs
@@ -156,7 +156,20 @@ namespace Microsoft.Maui.Graphics.Platform
 			if (creator == null)
 				throw new Exception("No resource creator has been registered globally or for this thread.");
 
-			var bitmap = AsyncPump.Run(async () => await CanvasBitmap.LoadAsync(creator, stream.AsRandomAccessStream()));
+			var bitmap = AsyncPump.Run(async () =>
+			{
+				if (stream.CanSeek)
+				{
+					return await CanvasBitmap.LoadAsync(creator, stream.AsRandomAccessStream());
+				}
+				else
+				{
+					using MemoryStream memoryStream = new();
+					stream.CopyTo(memoryStream);
+
+					return await CanvasBitmap.LoadAsync(creator, memoryStream.AsRandomAccessStream());
+				}
+			});
 			return new PlatformImage(creator, bitmap);
 		}
 	}

--- a/src/Graphics/src/Graphics/Platforms/Windows/PlatformImage.cs
+++ b/src/Graphics/src/Graphics/Platforms/Windows/PlatformImage.cs
@@ -170,6 +170,7 @@ namespace Microsoft.Maui.Graphics.Platform
 			{
 				using MemoryStream memoryStream = new();
 				stream.CopyTo(memoryStream);
+				memoryStream.Seek(0, SeekOrigin.Begin);
 
 				global::Windows.Foundation.IAsyncOperation<CanvasBitmap> bitmapAsync = CanvasBitmap.LoadAsync(creator, memoryStream.AsRandomAccessStream());
 				bitmap = bitmapAsync.AsTask().GetAwaiter().GetResult();


### PR DESCRIPTION
### Description of Change

`AsRandomAccessStream` throws `NotSupportedException` when the stream is not seekable. This PR is a simple workaround for it.

The second commit adds an optimization. The idea is to remove `AsyncPump` (introduced in https://github.com/dotnet/Microsoft.Maui.Graphics/commit/45979232d6deb180c3988158cf8d98a5ecdd8f7f and merged to MAUI in https://github.com/dotnet/maui/pull/8739) which does not seem to be necessary at all. I have tested the change with parallel loading of images and it did not break for me. But then again I don't really know why `AsyncPump` was introduced in the first place. This commit is an alternative to #23624 approach and the improvement should be the same as in that PR: https://github.com/dotnet/maui/pull/23624#issue-2410733071 (9 seconds -> 1.3 seconds for a batch of images containing ~100 images).

### Test

Tested with provided sample code:

```cs
using Microsoft.Maui.Graphics.Platform;

namespace Maui.Controls.Sample;

public partial class MainPage : ContentPage
{
	public MainPage()
	{
		InitializeComponent();
	}

	private async void OnCounterClicked(object sender, EventArgs e)
	{
		try
		{
			var imageUrl = "https://cdn-dynmedia-1.microsoft.com/is/image/microsoftcorp/Highlight-Surface-Laptop-AI-7Ed-Sapphire-MC001-3000x1682:VP5-1920x600";
			var stream = await new HttpClient().GetStreamAsync(imageUrl);
			var img = PlatformImage.FromStream(stream);
		}
		catch (Exception ex)
		{
			Console.WriteLine(ex);
		}

	}
}
```

### Issues Fixed

Fixes #18954