### PR TITLE
Re-enable GetServiceOrCreateInstance with Shell

### DIFF
--- a/src/Controls/src/Core/ControlTemplate.cs
+++ b/src/Controls/src/Core/ControlTemplate.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Maui.Controls
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/ControlTemplate.xml" path="//Member[@MemberName='.ctor'][3]/Docs/*" />
 		public ControlTemplate(
-			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type type)
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type)
 			: base(type)
 		{
 		}

--- a/src/Controls/src/Core/DataTemplate.cs
+++ b/src/Controls/src/Core/DataTemplate.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Maui.Controls
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/DataTemplate.xml" path="//Member[@MemberName='.ctor'][3]/Docs/*" />
 		public DataTemplate(
-			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type type)
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type)
 			: base(type)
 		{
 			_id = Interlocked.Increment(ref idCounter);

--- a/src/Controls/src/Core/ElementTemplate.cs
+++ b/src/Controls/src/Core/ElementTemplate.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Maui.Controls
 		Element _parent;
 		bool _canRecycle; // aka IsDeclarative
 
-		[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+		[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
 		readonly Type _type;
 
 		internal ElementTemplate()
@@ -21,7 +21,7 @@ namespace Microsoft.Maui.Controls
 		}
 
 		internal ElementTemplate(
-			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type type)
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type)
 			: this()
 		{
 			if (type == null)
@@ -44,7 +44,8 @@ namespace Microsoft.Maui.Controls
 		}
 
 		internal bool CanRecycle => _canRecycle;
-		[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+
+		[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
 		internal Type Type => _type;
 
 		Element IElementDefinition.Parent

--- a/src/Controls/src/Core/Routing.cs
+++ b/src/Controls/src/Core/Routing.cs
@@ -224,7 +224,7 @@ namespace Microsoft.Maui.Controls
 		/// <include file="../../docs/Microsoft.Maui.Controls/Routing.xml" path="//Member[@MemberName='RegisterRoute'][1]/Docs/*" />
 		public static void RegisterRoute(
 			string route,
-			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type type)
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type)
 		{
 			RegisterRoute(route, new TypeRouteFactory(type));
 		}
@@ -258,11 +258,11 @@ namespace Microsoft.Maui.Controls
 
 		class TypeRouteFactory : RouteFactory
 		{
-			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
 			readonly Type _type;
 
 			public TypeRouteFactory(
-				[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type type)
+				[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type)
 			{
 				_type = type;
 			}
@@ -276,7 +276,7 @@ namespace Microsoft.Maui.Controls
 			{
 				if (services != null)
 				{
-					return (Element)(services.GetService(_type) ?? Activator.CreateInstance(_type));
+					return (Element)Extensions.DependencyInjection.ActivatorUtilities.GetServiceOrCreateInstance(services, _type);
 				}
 
 				return (Element)Activator.CreateInstance(_type);

--- a/src/Controls/src/Core/Shell/ShellContent.cs
+++ b/src/Controls/src/Core/Shell/ShellContent.cs
@@ -60,21 +60,21 @@ namespace Microsoft.Maui.Controls
 			var content = Content;
 
 			Page result = null;
-			if (template == null)
+			if (template is null)
 			{
 				if (content is Page page)
 					result = page;
 			}
 			else
 			{
-				if (template.Type != null)
+				if (template.Type is not null)
 				{
 					template.LoadTemplate = () =>
 					{
 						var services = Parent?.FindMauiContext()?.Services;
-						if (services != null)
+						if (services is not null)
 						{
-							return services.GetService(template.Type) ?? Activator.CreateInstance(template.Type);
+							return Extensions.DependencyInjection.ActivatorUtilities.GetServiceOrCreateInstance(services, template.Type);
 						}
 						return Activator.CreateInstance(template.Type);
 					};
@@ -83,7 +83,7 @@ namespace Microsoft.Maui.Controls
 				ContentCache = result;
 			}
 
-			if (result == null)
+			if (result is null)
 				throw new InvalidOperationException($"No Content found for {nameof(ShellContent)}, Title:{Title}, Route {Route}");
 
 			if (result is TabbedPage)

--- a/src/Controls/tests/Core.UnitTests/ShellNavigatingTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellNavigatingTests.cs
@@ -629,8 +629,6 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		{
 			var serviceCollection = new ServiceCollection();
 			serviceCollection.AddTransient<Dependency>();
-			serviceCollection.AddTransient<PageWithDependency>();
-			serviceCollection.AddTransient<PageWithDependencyAndMultipleConstructors>();
 			IServiceProvider services = serviceCollection.BuildServiceProvider();
 			var fakeMauiContext = Substitute.For<IMauiContext>();
 			var fakeHandler = Substitute.For<IElementHandler>();


### PR DESCRIPTION
### Description of Change
This PR reverts https://github.com/dotnet/maui/pull/4281

We initially had to revert this change for net7.0 because of the following runtime issue https://github.com/dotnet/runtime/issues/46132

That was fixed in net8.0, so we're giving it another go for net9.0

With this change, users will no longer be required to register all of their pages unless users want to influence the lifetime of a page.
