### PR TITLE
Add embedding sample and code

### DIFF
--- a/src/Controls/samples/Controls.Sample.Embedding/Platforms/Android/FirstFragment.cs
+++ b/src/Controls/samples/Controls.Sample.Embedding/Platforms/Android/FirstFragment.cs
@@ -11,6 +11,10 @@ namespace Maui.Controls.Sample.Droid;
 [Register("com.microsoft.maui.sample.emdedding." + nameof(FirstFragment))]
 public class FirstFragment : Fragment
 {
+	EmbeddingScenarios.IScenario? _scenario;
+	MyMauiContent? _mauiView;
+	Android.Views.View? _nativeView;
+
 	public override View? OnCreateView(LayoutInflater inflater, ViewGroup? container, Bundle? savedInstanceState) =>
 		inflater.Inflate(Resource.Layout.fragment_first, container, false);
 
@@ -26,14 +30,43 @@ public class FirstFragment : Fragment
 
 		var button3 = view.FindViewById<Button>(Resource.Id.button3)!;
 		button3.Click += OnMagicClicked;
+
+		// Uncomment the scenario to test:
+		//_scenario = new EmbeddingScenarios.Scenario1_Basic();
+		//_scenario = new EmbeddingScenarios.Scenario2_Scoped();
+		_scenario = new EmbeddingScenarios.Scenario3_Correct();
+
+		// Create the view and (maybe) the window
+		(_mauiView, _nativeView) = _scenario!.Embed(Activity!);
+
+		// Add the new view to the UI
+		var rootLayout = view.FindViewById<LinearLayout>(Resource.Id.layout_first)!;
+		rootLayout.AddView(_nativeView, 1, new LinearLayout.LayoutParams(MatchParent, WrapContent));
 	}
 
 	public override void OnDestroyView()
 	{
 		base.OnDestroyView();
+
+		// Remove the view from the UI
+		var rootLayout = View!.FindViewById<LinearLayout>(Resource.Id.layout_first)!;
+		rootLayout.RemoveView(_nativeView);
+
+		// If we used a window, then clean that up
+		if (_mauiView?.Window is IWindow window)
+			window.Destroying();
+
+		base.OnStop();
 	}
 
-	private void OnMagicClicked(object? sender, EventArgs e)
+	private async void OnMagicClicked(object? sender, EventArgs e)
 	{
+		if (_mauiView?.DotNetBot is not Image bot)
+			return;
+
+		await bot.RotateTo(360, 1000);
+		bot.Rotation = 0;
+
+		bot.HeightRequest = 90;
 	}
 }

--- a/src/Controls/samples/Controls.Sample.Embedding/Platforms/Android/SettingsFragment.cs
+++ b/src/Controls/samples/Controls.Sample.Embedding/Platforms/Android/SettingsFragment.cs
@@ -11,6 +11,10 @@ namespace Maui.Controls.Sample.Droid;
 [Register("com.microsoft.maui.sample.emdedding." + nameof(SettingsFragment))]
 public class SettingsFragment : Fragment
 {
+	EmbeddingScenarios.IScenario? _scenario;
+	MyMauiContent? _mauiView;
+	Android.Views.View? _nativeView;
+
 	public override View? OnCreateView(LayoutInflater inflater, ViewGroup? container, Bundle? savedInstanceState) =>
 		inflater.Inflate(Resource.Layout.fragment_settings, container, false);
 
@@ -26,14 +30,43 @@ public class SettingsFragment : Fragment
 
 		var button3 = view.FindViewById<Button>(Resource.Id.button3)!;
 		button3.Click += OnMagicClicked;
+
+		// Uncomment the scenario to test:
+		//_scenario = new EmbeddingScenarios.Scenario1_Basic();
+		//_scenario = new EmbeddingScenarios.Scenario2_Scoped();
+		_scenario = new EmbeddingScenarios.Scenario3_Correct();
+
+		// Create the view and (maybe) the window
+		(_mauiView, _nativeView) = _scenario!.Embed(Activity!);
+
+		// Add the new view to the UI
+		var rootLayout = view.FindViewById<LinearLayout>(Resource.Id.layout_settings)!;
+		rootLayout.AddView(_nativeView, 1, new LinearLayout.LayoutParams(MatchParent, WrapContent));
 	}
 
 	public override void OnDestroyView()
 	{
 		base.OnDestroyView();
+
+		// Remove the view from the UI
+		var rootLayout = View!.FindViewById<LinearLayout>(Resource.Id.layout_settings)!;
+		rootLayout.RemoveView(_nativeView);
+
+		// If we used a window, then clean that up
+		if (_mauiView?.Window is IWindow window)
+			window.Destroying();
+
+		base.OnStop();
 	}
 
-	private void OnMagicClicked(object? sender, EventArgs e)
+	private async void OnMagicClicked(object? sender, EventArgs e)
 	{
+		if (_mauiView?.DotNetBot is not Image bot)
+			return;
+
+		await bot.RotateTo(360, 1000);
+		bot.Rotation = 0;
+
+		bot.HeightRequest = 90;
 	}
 }

--- a/src/Controls/samples/Controls.Sample.Embedding/Platforms/MacCatalyst/MainViewController.cs
+++ b/src/Controls/samples/Controls.Sample.Embedding/Platforms/MacCatalyst/MainViewController.cs
@@ -2,6 +2,10 @@
 
 public class MainViewController : UIViewController
 {
+	EmbeddingScenarios.IScenario? _scenario;
+	MyMauiContent? _mauiView;
+	UIView? _nativeView;
+
 	public override void ViewDidLoad()
 	{
 		base.ViewDidLoad();
@@ -34,7 +38,16 @@ public class MainViewController : UIViewController
 		firstButton.SetTitle("UIKit Button Above MAUI", UIControlState.Normal);
 		stackView.AddArrangedSubview(firstButton);
 
-		// TODO: The MAUI content will go here.
+		// Uncomment the scenario to test:
+		//_scenario = new EmbeddingScenarios.Scenario1_Basic();
+		//_scenario = new EmbeddingScenarios.Scenario2_Scoped();
+		_scenario = new EmbeddingScenarios.Scenario3_Correct();
+
+		// create the view and (maybe) the window
+		(_mauiView, _nativeView) = _scenario.Embed(ParentViewController!.View!.Window);
+
+		// add the new view to the UI
+		stackView.AddArrangedSubview(new ContainerView(_nativeView));
 
 		// Create UIKit button
 		var secondButton = new UIButton(UIButtonType.System);
@@ -44,9 +57,21 @@ public class MainViewController : UIViewController
 		// Create UIKit button
 		var thirdButton = new UIButton(UIButtonType.System);
 		thirdButton.SetTitle("UIKit Button Magic", UIControlState.Normal);
+		thirdButton.TouchUpInside += OnMagicClicked;
 		stackView.AddArrangedSubview(thirdButton);
 
 		AddNavBarButtons();
+	}
+
+	private async void OnMagicClicked(object? sender, EventArgs e)
+	{
+		if (_mauiView?.DotNetBot is not Image bot)
+			return;
+
+		await bot.RotateTo(360, 1000);
+		bot.Rotation = 0;
+
+		bot.HeightRequest = 90;
 	}
 
 	private void AddNavBarButtons()
@@ -86,5 +111,34 @@ public class MainViewController : UIViewController
 				Console.WriteLine(new NSErrorException(error));
 			});
 		}
+	}
+
+	// UIStackView uses IntrinsicContentSize instead of SizeThatFits
+	// so we need to create a container view to wrap the Maui view and
+	// redirect the IntrinsicContentSize to the Maui view's SizeThatFits.
+	class ContainerView : UIView
+	{
+		public ContainerView(UIView view)
+		{
+			AddSubview(view);
+		}
+
+		public override CGSize IntrinsicContentSize =>
+			SizeThatFits(new CGSize(nfloat.MaxValue, nfloat.MaxValue));
+
+		public override void LayoutSubviews()
+		{
+			if (Subviews?.FirstOrDefault() is {} view)
+				view.Frame = Bounds;
+		}
+
+		public override void SetNeedsLayout()
+		{
+			base.SetNeedsLayout();
+			InvalidateIntrinsicContentSize();
+		}
+
+		public override CGSize SizeThatFits(CGSize size) =>
+			Subviews?.FirstOrDefault()?.SizeThatFits(size) ?? CGSize.Empty;
 	}
 }

--- a/src/Controls/samples/Controls.Sample.Embedding/Platforms/Windows/MainWindow.xaml.cs
+++ b/src/Controls/samples/Controls.Sample.Embedding/Platforms/Windows/MainWindow.xaml.cs
@@ -4,21 +4,54 @@ namespace Maui.Controls.Sample.WinUI;
 
 public sealed partial class MainWindow : Microsoft.UI.Xaml.Window
 {
+	EmbeddingScenarios.IScenario? _scenario;
+	MyMauiContent? _mauiView;
+	FrameworkElement? _nativeView;
+
 	public MainWindow()
 	{
 		InitializeComponent();
 	}
 
-	private void OnRootLayoutLoaded(object? sender, RoutedEventArgs e)
+	private async void OnRootLayoutLoaded(object? sender, RoutedEventArgs e)
 	{
+		// Sometimes Loaded fires twice...
+		if (_nativeView is not null)
+			return;
+
+		await Task.Yield();
+
+		// Uncomment the scenario to test:
+		//_scenario = new EmbeddingScenarios.Scenario1_Basic();
+		//_scenario = new EmbeddingScenarios.Scenario2_Scoped();
+		_scenario = new EmbeddingScenarios.Scenario3_Correct();
+
+		// create the view and (maybe) the window
+		(_mauiView, _nativeView) = _scenario.Embed(this);
+
+		// add the new view to the UI
+		RootLayout.Children.Insert(1, _nativeView);
 	}
 
 	private void OnWindowClosed(object? sender, WindowEventArgs args)
 	{
+		// Remove the view from the UI
+		RootLayout.Children.Remove(_nativeView);
+
+		// If we used a window, then clean that up
+		if (_mauiView?.Window is IWindow window)
+			window.Destroying();
 	}
 
-	private void OnMagicClicked(object? sender, RoutedEventArgs e)
+	private async void OnMagicClicked(object? sender, RoutedEventArgs e)
 	{
+		if (_mauiView?.DotNetBot is not Image bot)
+			return;
+
+		await bot.RotateTo(360, 1000);
+		bot.Rotation = 0;
+
+		bot.HeightRequest = 90;
 	}
 
 	private void OnNewWindowClicked(object? sender, RoutedEventArgs e)

--- a/src/Controls/samples/Controls.Sample.Embedding/Shared/EmbeddingReflection.cs
+++ b/src/Controls/samples/Controls.Sample.Embedding/Shared/EmbeddingReflection.cs
@@ -1,0 +1,53 @@
+#if ANDROID
+using PlatformView = Android.Views.View;
+using PlatformWindow = Android.App.Activity;
+#elif IOS || MACCATALYST
+using PlatformView = UIKit.UIView;
+using PlatformWindow = UIKit.UIWindow;
+#elif WINDOWS
+using PlatformView = Microsoft.UI.Xaml.FrameworkElement;
+using PlatformWindow = Microsoft.UI.Xaml.Window;
+#endif
+
+namespace Microsoft.Maui.Controls.Embedding;
+
+/// <summary>
+/// This class is just here to serve as a reflection-based bridge to the EmbeddingExtensions class.
+/// </summary>
+static class EmbeddingReflection
+{
+	public static MauiAppBuilder UseMauiEmbeddedApp<TApp>(this MauiAppBuilder builder)
+		where TApp : class, IApplication
+	{
+		typeof(DynamicResourceExtension).Assembly // Controls.Xaml
+			.GetType("Microsoft.Maui.Controls.Embedding.EmbeddingExtensions")!
+			.GetMethod("UseMauiEmbeddedApp", 1, [ typeof(MauiAppBuilder) ])!
+			.MakeGenericMethod(typeof(TApp))
+			.Invoke(null, [ builder ]);
+		return builder;
+	}
+
+	public static IMauiContext CreateEmbeddedWindowContext(this MauiApp mauiApp, PlatformWindow platformWindow)
+	{
+		return (IMauiContext)typeof(Application).Assembly // Controls.Core
+			.GetType("Microsoft.Maui.Controls.Embedding.EmbeddingExtensions")!
+			.GetMethod("CreateEmbeddedWindowContext", [ typeof(MauiApp), typeof(PlatformWindow) ])!
+			.Invoke(null, [ mauiApp, platformWindow ])!;
+	}
+
+	public static PlatformView ToPlatformEmbedded(this IElement element, IMauiContext context)
+	{
+		return (PlatformView)typeof(Application).Assembly // Controls.Core
+			.GetType("Microsoft.Maui.Controls.Embedding.EmbeddingExtensions")!
+			.GetMethod("ToPlatformEmbedded", [ typeof(IElement), typeof(IMauiContext) ])!
+			.Invoke(null, [ element, context ])!;
+	}
+
+	public static PlatformView ToPlatformEmbedded(this IElement element, MauiApp mauiApp, PlatformWindow platformWindow)
+	{
+		return (PlatformView)typeof(Application).Assembly // Controls.Core
+			.GetType("Microsoft.Maui.Controls.Embedding.EmbeddingExtensions")!
+			.GetMethod("ToPlatformEmbedded", [ typeof(IElement), typeof(MauiApp), typeof(PlatformWindow) ])!
+			.Invoke(null, [ element, mauiApp, platformWindow ])!;
+	}
+}

--- a/src/Controls/samples/Controls.Sample.Embedding/Shared/EmbeddingScenarios.cs
+++ b/src/Controls/samples/Controls.Sample.Embedding/Shared/EmbeddingScenarios.cs
@@ -1,0 +1,76 @@
+﻿using Microsoft.Maui.Platform;
+using Microsoft.Maui.Controls.Embedding;
+
+#if ANDROID
+using PlatformView = Android.Views.View;
+using PlatformWindow = Android.App.Activity;
+#elif IOS || MACCATALYST
+using PlatformView = UIKit.UIView;
+using PlatformWindow = UIKit.UIWindow;
+#elif WINDOWS
+using PlatformView = Microsoft.UI.Xaml.FrameworkElement;
+using PlatformWindow = Microsoft.UI.Xaml.Window;
+#endif
+
+namespace Maui.Controls.Sample;
+
+class EmbeddingScenarios
+{
+	public interface IScenario
+	{
+		(MyMauiContent, PlatformView) Embed(PlatformWindow window);
+	}
+
+	public class Scenario1_Basic : IScenario
+	{
+		public (MyMauiContent, PlatformView) Embed(PlatformWindow window)
+		{
+			var mauiApp = MauiProgram.CreateMauiApp();
+#if ANDROID
+			var mauiContext = new MauiContext(mauiApp.Services, window);
+#else
+			var mauiContext = new MauiContext(mauiApp.Services);
+#endif
+			var mauiView = new MyMauiContent();
+			var nativeView = mauiView.ToPlatform(mauiContext);
+			return (mauiView, nativeView);
+		}
+	}
+
+	public class Scenario2_Scoped : IScenario
+	{
+		public (MyMauiContent, PlatformView) Embed(PlatformWindow window)
+		{
+			var mauiApp = MauiProgram.CreateMauiApp();
+			var mauiView = new MyMauiContent();
+			var nativeView = mauiView.ToPlatformEmbedded(mauiApp, window);
+			return (mauiView, nativeView);
+		}
+	}
+
+	public class Scenario3_Correct : IScenario
+	{
+		public static class MyEmbeddedMauiApp
+		{
+			static MauiApp? _shared;
+
+			public static MauiApp Shared => _shared ??= MauiProgram.CreateMauiApp();
+		}
+
+		PlatformWindow? _window;
+		IMauiContext? _windowContext;
+
+		public IMauiContext WindowContext =>
+			_windowContext ??= MyEmbeddedMauiApp.Shared.CreateEmbeddedWindowContext(_window ?? throw new InvalidOperationException());
+
+		public (MyMauiContent, PlatformView) Embed(PlatformWindow window)
+		{
+			_window ??= window;
+
+			var context = WindowContext;
+			var mauiView = new MyMauiContent();
+			var nativeView = mauiView.ToPlatformEmbedded(context);
+			return (mauiView, nativeView);
+		}
+	}
+}

--- a/src/Controls/samples/Controls.Sample.Embedding/Shared/MauiProgram.cs
+++ b/src/Controls/samples/Controls.Sample.Embedding/Shared/MauiProgram.cs
@@ -10,8 +10,7 @@ public static class MauiProgram
 		var builder = MauiApp.CreateBuilder();
 
 		builder
-			.UseMauiApp<App>()
-			.UseMauiEmbedding()
+			.UseMauiEmbeddedApp<App>()
 			.ConfigureFonts(fonts =>
 			{
 				fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");

--- a/src/Controls/samples/Controls.Sample.Embedding/Shared/MauiProgram.cs
+++ b/src/Controls/samples/Controls.Sample.Embedding/Shared/MauiProgram.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.Logging;
+using Microsoft.Maui.Controls.Embedding;
 
 namespace Maui.Controls.Sample;
 
@@ -10,6 +11,7 @@ public static class MauiProgram
 
 		builder
 			.UseMauiApp<App>()
+			.UseMauiEmbedding()
 			.ConfigureFonts(fonts =>
 			{
 				fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");

--- a/src/Controls/samples/Controls.Sample.Embedding/Shared/MyMauiContent.xaml
+++ b/src/Controls/samples/Controls.Sample.Embedding/Shared/MyMauiContent.xaml
@@ -1,0 +1,67 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentView
+  xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+  xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+  x:Class="Maui.Controls.Sample.MyMauiContent">
+
+  <VerticalStackLayout
+    Padding="30,0"
+    Spacing="25">
+
+    <Image
+      x:Name="image"
+      Source="dotnet_bot.png"
+      HeightRequest="185"
+      Aspect="AspectFit"
+      SemanticProperties.Description="dot net bot in a race car number eight">
+      <Image.GestureRecognizers>
+        <TapGestureRecognizer Tapped="OnCounterClicked" />
+      </Image.GestureRecognizers>
+    </Image>
+
+    <Label
+      Text="Hello, World!"
+      Style="{StaticResource Headline}"
+      SemanticProperties.HeadingLevel="Level1">
+
+      <VisualStateManager.VisualStateGroups>
+        <VisualStateGroupList>
+          <VisualStateGroup>
+            <VisualState x:Name="Narrow">
+              <VisualState.StateTriggers>
+                <AdaptiveTrigger MinWindowWidth="0" />
+              </VisualState.StateTriggers>
+              <VisualState.Setters>
+                <Setter Property="Text" Value="Hello, Nrw World!" />
+              </VisualState.Setters>
+            </VisualState>
+            <VisualState x:Name="Wide">
+              <VisualState.StateTriggers>
+                <AdaptiveTrigger MinWindowWidth="800" />
+              </VisualState.StateTriggers>
+              <VisualState.Setters>
+                <Setter Property="Text" Value="Hello, W i d e World!" />
+              </VisualState.Setters>
+            </VisualState>
+          </VisualStateGroup>
+        </VisualStateGroupList>
+      </VisualStateManager.VisualStateGroups>
+
+    </Label>
+
+    <Label
+      Text="Welcome to &#10;.NET Multi-platform App UI"
+      Style="{StaticResource SubHeadline}"
+      SemanticProperties.HeadingLevel="Level2"
+      SemanticProperties.Description="Welcome to dot net Multi platform App U I" />
+
+    <Button
+      x:Name="CounterBtn"
+      Text="Click me"
+      SemanticProperties.Hint="Counts the number of times you click"
+      Clicked="OnCounterClicked"
+      HorizontalOptions="Fill" />
+
+  </VerticalStackLayout>
+
+</ContentView>

--- a/src/Controls/samples/Controls.Sample.Embedding/Shared/MyMauiContent.xaml.cs
+++ b/src/Controls/samples/Controls.Sample.Embedding/Shared/MyMauiContent.xaml.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.Maui.Controls.Embedding;
+using Microsoft.Maui.Platform;
+
+namespace Maui.Controls.Sample;
+
+public partial class MyMauiContent
+{
+	int count = 0;
+
+	public MyMauiContent()
+	{
+		InitializeComponent();
+	}
+
+	public Image DotNetBot => image;
+
+	private async void OnCounterClicked(object sender, EventArgs e)
+	{
+		count++;
+
+		if (count == 1)
+			CounterBtn.Text = $"Clicked {count} time";
+		else
+			CounterBtn.Text = $"Clicked {count} times";
+
+		SemanticScreenReader.Announce(CounterBtn.Text);
+
+		await image.ScaleTo(1.2, 60);
+		await image.ScaleTo(1, 60);
+	}
+}

--- a/src/Controls/src/Core/Application/Application.cs
+++ b/src/Controls/src/Core/Application/Application.cs
@@ -524,7 +524,7 @@ namespace Microsoft.Maui.Controls
 			throw new NotImplementedException($"Either set {nameof(MainPage)} or override {nameof(Application.CreateWindow)}.");
 		}
 
-		void AddWindow(Window window)
+		internal void AddWindow(Window window)
 		{
 			_windows.Add(window);
 

--- a/src/Controls/src/Core/Embedding/EmbeddedWindow.cs
+++ b/src/Controls/src/Core/Embedding/EmbeddedWindow.cs
@@ -1,0 +1,17 @@
+﻿#if ANDROID || IOS || MACCATALYST || WINDOWS
+
+namespace Microsoft.Maui.Controls.Embedding;
+
+/// <summary>
+/// An embedded window that is never used directly, but instead forms a connection between
+/// the MAUI app and the embedded MAUI content.
+/// </summary>
+class EmbeddedWindow : Window, IWindow
+{
+	/// <summary>
+	/// Always returns null because this window will never have any direct content.
+	/// </summary>
+	IView IWindow.Content => null!;
+}
+
+#endif

--- a/src/Controls/src/Core/Embedding/EmbeddingExtensions.cs
+++ b/src/Controls/src/Core/Embedding/EmbeddingExtensions.cs
@@ -1,0 +1,120 @@
+﻿#if ANDROID || IOS || MACCATALYST || WINDOWS
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Maui.Embedding;
+using Microsoft.Maui.Hosting;
+
+#if ANDROID
+using PlatformView = Android.Views.View;
+using PlatformWindow = Android.App.Activity;
+#elif IOS || MACCATALYST
+using PlatformView = UIKit.UIView;
+using PlatformWindow = UIKit.UIWindow;
+#elif WINDOWS
+using PlatformView = Microsoft.UI.Xaml.FrameworkElement;
+using PlatformWindow = Microsoft.UI.Xaml.Window;
+#endif
+
+namespace Microsoft.Maui.Controls.Embedding;
+
+#pragma warning disable RS0016 // Add public types and members to the declared API
+
+/// <summary>
+/// A set of extension methods that allow for embedding a MAUI view within a native application.
+/// </summary>
+public static class EmbeddingExtensions
+{
+	/// <summary>
+	/// Enables MAUI to be embedded in native platform application by injecting embedded handlers into the service collection.
+	/// </summary>
+	/// <param name="builder">The <see cref="MauiAppBuilder"/> instance.</param>
+	/// <returns>The <see cref="MauiAppBuilder"/> instance.</returns>
+	public static MauiAppBuilder UseMauiEmbedding(this MauiAppBuilder builder)
+	{
+#if ANDROID
+		var platformApplication = (Android.App.Application)Android.App.Application.Context;
+#elif IOS || MACCATALYST
+		var platformApplication = UIKit.UIApplication.SharedApplication.Delegate;
+#elif WINDOWS
+		var platformApplication = Microsoft.UI.Xaml.Application.Current;
+#endif
+
+		// Enable Core embedded features.
+		builder.UseMauiEmbedding(platformApplication);
+
+		// Register the embedded window handler.
+		builder.ConfigureMauiHandlers(handlers =>
+		{
+			handlers.AddHandler<EmbeddedWindow, EmbeddedWindowHandler>();
+		});
+
+		return builder;
+	}
+
+	/// <summary>
+	/// Creates a window-scoped <see cref="IMauiContext"/> for the provided native platform window.
+	/// </summary>
+	/// <param name="mauiApp">The <see cref="MauiApp"/> instance.</param>
+	/// <param name="platformWindow">The native platform window instance to create the context for.</param>
+	/// <returns>The window-scoped <see cref="IMauiContext"/> instance.</returns>
+	/// <remarks>
+	/// In addition to the context being created, a new Window instance is created and attached to the app.
+	/// </remarks>
+	public static IMauiContext CreateEmbeddedWindowContext(this MauiApp mauiApp, PlatformWindow platformWindow)
+	{
+		var window = new EmbeddedWindow();
+
+		// Create the Core embedded window scope.
+		var windowContext = mauiApp.CreateEmbeddedWindowContext(platformWindow, window);
+
+		// If the app is an embedded app then we need to add the window to the app.
+		var embeddedApp = mauiApp.Services.GetRequiredService<EmbeddedPlatformApplication>();
+		if (embeddedApp.Application is Application app && !app.Windows.Contains(window))
+		{
+			app.AddWindow(window);
+		}
+
+		return windowContext;
+	}
+
+	/// <summary>
+	/// Similar to <see cref="ElementExtensions.ToPlatform(IElement, IMauiContext)"/>, but also adds the element as
+	/// a logical child to the embedded window.
+	/// </summary>
+	/// <param name="element">The element to use when creating the native platform view.</param>
+	/// <param name="context">The context to use when creating the native platform view.</param>
+	/// <returns>The native platform view that represents the element.</returns>
+	/// <remarks>
+	/// Only if the window is an embedded window and the element is a <see cref="VisualElement"/> will the element
+	/// be added as a logical child of that window.
+	/// </remarks>
+	public static PlatformView ToPlatformEmbedded(this IElement element, IMauiContext context)
+	{
+		// If the window is an embedded window, then we need to add the element as a logical child.
+		var wndProvider = context.Services.GetService<EmbeddedWindowProvider>();
+		if (wndProvider is not null && wndProvider.Window is EmbeddedWindow wnd && element is VisualElement visual)
+			wnd.AddLogicalChild(visual);
+
+		return element.ToPlatform(context);
+	}
+
+	/// <summary>
+	/// Similar to <see cref="ElementExtensions.ToPlatform(IElement, IMauiContext)"/>, but also adds the element as
+	/// a logical child to a new embedded window.
+	/// </summary>
+	/// <param name="element">The element to use when creating the native platform view.</param>
+	/// <param name="mauiApp">The <see cref="MauiApp"/> instance.</param>
+	/// <param name="platformWindow">The native platform window that will host this element.</param>
+	/// <returns>The native platform view that represents the element.</returns>
+	/// <remarks>
+	/// Only if the window is an embedded window and the element is a <see cref="VisualElement"/> will the element
+	/// be added as a logical child of that window.
+	/// </remarks>
+	public static PlatformView ToPlatformEmbedded(this IElement element, MauiApp mauiApp, PlatformWindow platformWindow)
+	{
+		var windowContext = mauiApp.CreateEmbeddedWindowContext(platformWindow);
+		return element.ToPlatformEmbedded(windowContext);
+	}
+}
+
+#endif

--- a/src/Controls/src/Core/Embedding/EmbeddingExtensions.cs
+++ b/src/Controls/src/Core/Embedding/EmbeddingExtensions.cs
@@ -1,6 +1,10 @@
 ﻿#if ANDROID || IOS || MACCATALYST || WINDOWS
+using System;
 using System.Linq;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Maui.Controls.Hosting;
 using Microsoft.Maui.Embedding;
 using Microsoft.Maui.Hosting;
 
@@ -17,19 +21,17 @@ using PlatformWindow = Microsoft.UI.Xaml.Window;
 
 namespace Microsoft.Maui.Controls.Embedding;
 
-#pragma warning disable RS0016 // Add public types and members to the declared API
-
 /// <summary>
 /// A set of extension methods that allow for embedding a MAUI view within a native application.
 /// </summary>
-public static class EmbeddingExtensions
+internal static class EmbeddingExtensions
 {
 	/// <summary>
 	/// Enables MAUI to be embedded in native platform application by injecting embedded handlers into the service collection.
 	/// </summary>
 	/// <param name="builder">The <see cref="MauiAppBuilder"/> instance.</param>
 	/// <returns>The <see cref="MauiAppBuilder"/> instance.</returns>
-	public static MauiAppBuilder UseMauiEmbedding(this MauiAppBuilder builder)
+	internal static MauiAppBuilder UseMauiEmbedding(this MauiAppBuilder builder)
 	{
 #if ANDROID
 		var platformApplication = (Android.App.Application)Android.App.Application.Context;

--- a/src/Controls/src/Core/Hosting/AppHostBuilderExtensions.cs
+++ b/src/Controls/src/Core/Hosting/AppHostBuilderExtensions.cs
@@ -1,0 +1,257 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Maui.Controls.Handlers;
+using Microsoft.Maui.Controls.Handlers.Items;
+using Microsoft.Maui.Controls.Shapes;
+using Microsoft.Maui.Dispatching;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Hosting;
+using Microsoft.Maui.Platform;
+
+#if ANDROID
+using Microsoft.Maui.Controls.Handlers.Compatibility;
+using Microsoft.Maui.Controls.Compatibility.Platform.Android;
+#elif WINDOWS
+using ResourcesProvider = Microsoft.Maui.Controls.Compatibility.Platform.UWP.WindowsResourcesProvider;
+using Microsoft.Maui.Controls.Compatibility.Platform.UWP;
+#elif IOS || MACCATALYST
+using Microsoft.Maui.Controls.Compatibility.Platform.iOS;
+using Microsoft.Maui.Controls.Handlers.Compatibility;
+#elif TIZEN
+using Microsoft.Maui.Controls.Handlers.Compatibility;
+using Microsoft.Maui.Controls.Compatibility.Platform.Tizen;
+#endif
+
+namespace Microsoft.Maui.Controls.Hosting;
+
+public static partial class AppHostBuilderExtensions
+{
+	/// <summary>
+	/// Configures the <see cref="MauiAppBuilder"/> to use the specified <typeparamref name="TApp"/> as the main application type.
+	/// </summary>
+	/// <typeparam name="TApp">The type to use as the application.</typeparam>
+	/// <param name="builder">The <see cref="MauiAppBuilder"/> to configure.</param>
+	/// <returns>The configured <see cref="MauiAppBuilder"/>.</returns>
+	internal static MauiAppBuilder UseMauiPrimaryApp<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TApp>(this MauiAppBuilder builder)
+		where TApp : class, IApplication
+	{
+#pragma warning disable RS0030 // Do not used banned APIs - don't want to use a factory method here
+		builder.Services.TryAddSingleton<IApplication, TApp>();
+#pragma warning restore RS0030
+		builder.SetupDefaults();
+		return builder;
+	}
+
+	/// <summary>
+	/// Configures the <see cref="MauiAppBuilder"/> to use the specified <typeparamref name="TApp"/> as the main application type.
+	/// </summary>
+	/// <typeparam name="TApp">The type to use as the application.</typeparam>
+	/// <param name="builder">The <see cref="MauiAppBuilder"/> to configure.</param>
+	/// <param name="implementationFactory">A factory to create the specified <typeparamref name="TApp"/> using the services provided in a <see cref="IServiceProvider"/>.</param>
+	/// <returns>The configured <see cref="MauiAppBuilder"/>.</returns>
+	internal static MauiAppBuilder UseMauiPrimaryApp<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TApp>(this MauiAppBuilder builder, Func<IServiceProvider, TApp> implementationFactory)
+		where TApp : class, IApplication
+	{
+		builder.Services.TryAddSingleton<IApplication>(implementationFactory);
+		builder.SetupDefaults();
+		return builder;
+	}
+
+	internal static IMauiHandlersCollection AddControlsHandlers(this IMauiHandlersCollection handlersCollection)
+	{
+		handlersCollection.AddHandler<CollectionView, CollectionViewHandler>();
+		handlersCollection.AddHandler<CarouselView, CarouselViewHandler>();
+		handlersCollection.AddHandler<Application, ApplicationHandler>();
+		handlersCollection.AddHandler<ActivityIndicator, ActivityIndicatorHandler>();
+		handlersCollection.AddHandler<BoxView, BoxViewHandler>();
+		handlersCollection.AddHandler<Button, ButtonHandler>();
+		handlersCollection.AddHandler<CheckBox, CheckBoxHandler>();
+		handlersCollection.AddHandler<DatePicker, DatePickerHandler>();
+		handlersCollection.AddHandler<Editor, EditorHandler>();
+		handlersCollection.AddHandler<Entry, EntryHandler>();
+		handlersCollection.AddHandler<GraphicsView, GraphicsViewHandler>();
+		handlersCollection.AddHandler<Image, ImageHandler>();
+		handlersCollection.AddHandler<Label, LabelHandler>();
+		handlersCollection.AddHandler<Layout, LayoutHandler>();
+		handlersCollection.AddHandler<Picker, PickerHandler>();
+		handlersCollection.AddHandler<ProgressBar, ProgressBarHandler>();
+		handlersCollection.AddHandler<ScrollView, ScrollViewHandler>();
+		handlersCollection.AddHandler<SearchBar, SearchBarHandler>();
+		handlersCollection.AddHandler<Slider, SliderHandler>();
+		handlersCollection.AddHandler<Stepper, StepperHandler>();
+		handlersCollection.AddHandler<Switch, SwitchHandler>();
+		handlersCollection.AddHandler<TimePicker, TimePickerHandler>();
+		handlersCollection.AddHandler<Page, PageHandler>();
+		handlersCollection.AddHandler<WebView, WebViewHandler>();
+		handlersCollection.AddHandler<Border, BorderHandler>();
+		handlersCollection.AddHandler<IContentView, ContentViewHandler>();
+		handlersCollection.AddHandler<Shapes.Ellipse, ShapeViewHandler>();
+		handlersCollection.AddHandler<Shapes.Line, LineHandler>();
+		handlersCollection.AddHandler<Shapes.Path, PathHandler>();
+		handlersCollection.AddHandler<Shapes.Polygon, PolygonHandler>();
+		handlersCollection.AddHandler<Shapes.Polyline, PolylineHandler>();
+		handlersCollection.AddHandler<Shapes.Rectangle, RectangleHandler>();
+		handlersCollection.AddHandler<Shapes.RoundRectangle, RoundRectangleHandler>();
+		handlersCollection.AddHandler<Window, WindowHandler>();
+		handlersCollection.AddHandler<ImageButton, ImageButtonHandler>();
+		handlersCollection.AddHandler<IndicatorView, IndicatorViewHandler>();
+		handlersCollection.AddHandler<RadioButton, RadioButtonHandler>();
+		handlersCollection.AddHandler<RefreshView, RefreshViewHandler>();
+		handlersCollection.AddHandler<SwipeItem, SwipeItemMenuItemHandler>();
+		handlersCollection.AddHandler<SwipeView, SwipeViewHandler>();
+
+#pragma warning disable CA1416 //  'MenuBarHandler', MenuFlyoutSubItemHandler, MenuFlyoutSubItemHandler, MenuBarItemHandler is only supported on: 'ios' 13.0 and later
+		handlersCollection.AddHandler<MenuBar, MenuBarHandler>();
+		handlersCollection.AddHandler<MenuFlyoutSubItem, MenuFlyoutSubItemHandler>();
+		handlersCollection.AddHandler<MenuFlyoutSeparator, MenuFlyoutSeparatorHandler>();
+		handlersCollection.AddHandler<MenuFlyoutItem, MenuFlyoutItemHandler>();
+		handlersCollection.AddHandler<MenuBarItem, MenuBarItemHandler>();
+#pragma warning restore CA1416
+
+#if WINDOWS || ANDROID || IOS || MACCATALYST || TIZEN
+		handlersCollection.AddHandler(typeof(ListView), typeof(Handlers.Compatibility.ListViewRenderer));
+#if !TIZEN
+		handlersCollection.AddHandler(typeof(Cell), typeof(Handlers.Compatibility.CellRenderer));
+		handlersCollection.AddHandler(typeof(ImageCell), typeof(Handlers.Compatibility.ImageCellRenderer));
+		handlersCollection.AddHandler(typeof(EntryCell), typeof(Handlers.Compatibility.EntryCellRenderer));
+		handlersCollection.AddHandler(typeof(TextCell), typeof(Handlers.Compatibility.TextCellRenderer));
+		handlersCollection.AddHandler(typeof(ViewCell), typeof(Handlers.Compatibility.ViewCellRenderer));
+		handlersCollection.AddHandler(typeof(SwitchCell), typeof(Handlers.Compatibility.SwitchCellRenderer));
+#endif
+		handlersCollection.AddHandler(typeof(TableView), typeof(Handlers.Compatibility.TableViewRenderer));
+		handlersCollection.AddHandler(typeof(Frame), typeof(Handlers.Compatibility.FrameRenderer));
+#endif
+
+#if WINDOWS || MACCATALYST
+		handlersCollection.AddHandler(typeof(MenuFlyout), typeof(MenuFlyoutHandler));
+#endif
+
+#if IOS || MACCATALYST
+		handlersCollection.AddHandler(typeof(NavigationPage), typeof(Handlers.Compatibility.NavigationRenderer));
+		handlersCollection.AddHandler(typeof(TabbedPage), typeof(Handlers.Compatibility.TabbedRenderer));
+		handlersCollection.AddHandler(typeof(FlyoutPage), typeof(Handlers.Compatibility.PhoneFlyoutPageRenderer));
+#endif
+
+#if ANDROID || IOS || MACCATALYST || TIZEN
+		handlersCollection.AddHandler<SwipeItemView, SwipeItemViewHandler>();
+#endif
+
+#if ANDROID || IOS || MACCATALYST
+		handlersCollection.AddHandler<Shell, ShellRenderer>();
+#elif WINDOWS
+		handlersCollection.AddHandler<Shell, ShellHandler>();
+		handlersCollection.AddHandler<ShellItem, ShellItemHandler>();
+		handlersCollection.AddHandler<ShellSection, ShellSectionHandler>();
+		handlersCollection.AddHandler<ShellContent, ShellContentHandler>();
+#elif TIZEN
+		handlersCollection.AddHandler<Shell, ShellHandler>();
+		handlersCollection.AddHandler<ShellItem, ShellItemHandler>();
+		handlersCollection.AddHandler<ShellSection, ShellSectionHandler>();
+#endif
+
+#if WINDOWS || ANDROID || TIZEN
+		handlersCollection.AddHandler<NavigationPage, NavigationViewHandler>();
+		handlersCollection.AddHandler<Toolbar, ToolbarHandler>();
+		handlersCollection.AddHandler<FlyoutPage, FlyoutViewHandler>();
+		handlersCollection.AddHandler<TabbedPage, TabbedViewHandler>();
+#endif
+
+		return handlersCollection;
+	}
+
+	static MauiAppBuilder SetupDefaults(this MauiAppBuilder builder)
+	{
+#if WINDOWS || ANDROID || IOS || MACCATALYST || TIZEN
+		// initialize compatibility DependencyService
+		DependencyService.SetToInitialized();
+		DependencyService.Register<PlatformSizeService>();
+
+#pragma warning disable CS0612, CA1416 // Type or member is obsolete, 'ResourcesProvider' is unsupported on: 'iOS' 14.0 and later
+		DependencyService.Register<ResourcesProvider>();
+		DependencyService.Register<FontNamedSizeService>();
+#pragma warning restore CS0612, CA1416 // Type or member is obsolete
+#endif
+		builder.Services.AddScoped(_ => new HideSoftInputOnTappedChangedManager());
+
+		builder.ConfigureImageSourceHandlers();
+
+		builder.ConfigureMauiHandlers(handlers =>
+		{
+			handlers.AddControlsHandlers();
+		});
+
+#if WINDOWS
+		builder.Services.TryAddEnumerable(ServiceDescriptor.Transient<IMauiInitializeService, MauiControlsInitializer>());
+#endif
+
+		builder.RemapForControls();
+
+		return builder;
+	}
+
+	class MauiControlsInitializer : IMauiInitializeService
+	{
+		public void Initialize(IServiceProvider services)
+		{
+#if WINDOWS
+			var dispatcher = services.GetRequiredApplicationDispatcher();
+
+			dispatcher
+				.DispatchIfRequired(() =>
+				{
+					var dictionaries = UI.Xaml.Application.Current?.Resources?.MergedDictionaries;
+					if (dictionaries != null)
+					{
+						// Microsoft.Maui.Controls
+						UI.Xaml.Application.Current?.Resources?.AddLibraryResources("MicrosoftMauiControlsIncluded", "ms-appx:///Microsoft.Maui.Controls/Platform/Windows/Styles/Resources.xbf");
+					}
+				});
+#endif
+		}
+	}
+
+	static MauiAppBuilder ConfigureImageSourceHandlers(this MauiAppBuilder builder)
+	{
+		builder.ConfigureImageSources(services =>
+		{
+			services.AddService<FileImageSource>(svcs => new FileImageSourceService(svcs.CreateLogger<FileImageSourceService>()));
+			services.AddService<FontImageSource>(svcs => new FontImageSourceService(svcs.GetRequiredService<IFontManager>(), svcs.CreateLogger<FontImageSourceService>()));
+			services.AddService<StreamImageSource>(svcs => new StreamImageSourceService(svcs.CreateLogger<StreamImageSourceService>()));
+			services.AddService<UriImageSource>(svcs => new UriImageSourceService(svcs.CreateLogger<UriImageSourceService>()));
+		});
+
+		return builder;
+	}
+
+	static MauiAppBuilder RemapForControls(this MauiAppBuilder builder)
+	{
+		// Update the mappings for IView/View to work specifically for Controls
+		Element.RemapForControls();
+		Application.RemapForControls();
+		VisualElement.RemapForControls();
+		Label.RemapForControls();
+		Button.RemapForControls();
+		CheckBox.RemapForControls();
+		DatePicker.RemapForControls();
+		RadioButton.RemapForControls();
+		FlyoutPage.RemapForControls();
+		Toolbar.RemapForControls();
+		Window.RemapForControls();
+		Editor.RemapForControls();
+		Entry.RemapForControls();
+		SwipeView.RemapForControls();
+		Picker.RemapForControls();
+		SearchBar.RemapForControls();
+		TabbedPage.RemapForControls();
+		TimePicker.RemapForControls();
+		Layout.RemapForControls();
+		ScrollView.RemapForControls();
+		RefreshView.RemapForControls();
+		Shape.RemapForControls();
+		WebView.RemapForControls();
+		ContentPage.RemapForControls();
+		return builder;
+	}
+}

--- a/src/Controls/src/Core/Hosting/AppHostBuilderExtensions.cs
+++ b/src/Controls/src/Core/Hosting/AppHostBuilderExtensions.cs
@@ -225,7 +225,7 @@ public static partial class AppHostBuilderExtensions
 		return builder;
 	}
 
-	static MauiAppBuilder RemapForControls(this MauiAppBuilder builder)
+	internal static MauiAppBuilder RemapForControls(this MauiAppBuilder builder)
 	{
 		// Update the mappings for IView/View to work specifically for Controls
 		Element.RemapForControls();

--- a/src/Controls/src/Core/Properties/AssemblyInfo.cs
+++ b/src/Controls/src/Core/Properties/AssemblyInfo.cs
@@ -49,6 +49,7 @@ using Compatibility = Microsoft.Maui.Controls.Compatibility;
 
 [assembly: InternalsVisibleTo("CommunityToolkit.Maui")]
 [assembly: InternalsVisibleTo("CommunityToolkit.Maui.Core")]
+[assembly: InternalsVisibleTo("CommunityToolkit.Maui.Embedding")]
 [assembly: InternalsVisibleTo("CommunityToolkit.Maui.UnitTests")]
 [assembly: InternalsVisibleTo("CommunityToolkit.Maui.Markup")]
 [assembly: InternalsVisibleTo("CommunityToolkit.Maui.Markup.UnitTests")]

--- a/src/Controls/src/Xaml/Embedding/EmbeddingExtensions.cs
+++ b/src/Controls/src/Xaml/Embedding/EmbeddingExtensions.cs
@@ -20,7 +20,9 @@ internal static class EmbeddingExtensions
 		where TApp : class, IApplication
 	{
 		builder.UseMauiApp<TApp>();
+#if ANDROID || IOS || MACCATALYST || WINDOWS
 		builder.UseMauiEmbedding();
+#endif
 		return builder;
 	}
 
@@ -35,7 +37,9 @@ internal static class EmbeddingExtensions
 		where TApp : class, IApplication
 	{
 		builder.UseMauiApp<TApp>(implementationFactory);
+#if ANDROID || IOS || MACCATALYST || WINDOWS
 		builder.UseMauiEmbedding();
+#endif
 		return builder;
 	}
 }

--- a/src/Controls/src/Xaml/Embedding/EmbeddingExtensions.cs
+++ b/src/Controls/src/Xaml/Embedding/EmbeddingExtensions.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Maui.Controls.Hosting;
+using Microsoft.Maui.Hosting;
+
+namespace Microsoft.Maui.Controls.Embedding;
+
+/// <summary>
+/// A set of extension methods that allow for embedding a MAUI view within a native application.
+/// </summary>
+internal static class EmbeddingExtensions
+{
+	/// <summary>
+	/// Configures the <see cref="MauiAppBuilder"/> to use the specified <typeparamref name="TApp"/> as the embedded application type.
+	/// </summary>
+	/// <typeparam name="TApp">The type to use as the embedded application.</typeparam>
+	/// <param name="builder">The <see cref="MauiAppBuilder"/> to configure.</param>
+	/// <returns>The configured <see cref="MauiAppBuilder"/>.</returns>
+	public static MauiAppBuilder UseMauiEmbeddedApp<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TApp>(this MauiAppBuilder builder)
+		where TApp : class, IApplication
+	{
+		builder.UseMauiApp<TApp>();
+		builder.UseMauiEmbedding();
+		return builder;
+	}
+
+	/// <summary>
+	/// Configures the <see cref="MauiAppBuilder"/> to use the specified <typeparamref name="TApp"/> as the embedded application type.
+	/// </summary>
+	/// <typeparam name="TApp">The type to use as the embedded application.</typeparam>
+	/// <param name="builder">The <see cref="MauiAppBuilder"/> to configure.</param>
+	/// <param name="implementationFactory">A factory to create the specified <typeparamref name="TApp"/> using the services provided in a <see cref="IServiceProvider"/>.</param>
+	/// <returns>The configured <see cref="MauiAppBuilder"/>.</returns>
+	public static MauiAppBuilder UseMauiEmbeddedApp<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TApp>(this MauiAppBuilder builder, Func<IServiceProvider, TApp> implementationFactory)
+		where TApp : class, IApplication
+	{
+		builder.UseMauiApp<TApp>(implementationFactory);
+		builder.UseMauiEmbedding();
+		return builder;
+	}
+}

--- a/src/Controls/src/Xaml/Hosting/AppHostBuilderExtensions.cs
+++ b/src/Controls/src/Xaml/Hosting/AppHostBuilderExtensions.cs
@@ -1,260 +1,49 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
-using Microsoft.Maui.Controls.Handlers;
-using Microsoft.Maui.Controls.Handlers.Items;
-using Microsoft.Maui.Controls.Shapes;
-using Microsoft.Maui.Dispatching;
-using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Hosting;
-using Microsoft.Maui.Platform;
 
+namespace Microsoft.Maui.Controls.Hosting;
 
-#if ANDROID
-using Microsoft.Maui.Controls.Handlers.Compatibility;
-using Microsoft.Maui.Controls.Compatibility.Platform.Android;
-#elif WINDOWS
-using ResourcesProvider = Microsoft.Maui.Controls.Compatibility.Platform.UWP.WindowsResourcesProvider;
-using Microsoft.Maui.Controls.Compatibility.Platform.UWP;
-#elif IOS || MACCATALYST
-using Microsoft.Maui.Controls.Compatibility.Platform.iOS;
-using Microsoft.Maui.Controls.Handlers.Compatibility;
-#elif TIZEN
-using Microsoft.Maui.Controls.Handlers.Compatibility;
-using Microsoft.Maui.Controls.Compatibility.Platform.Tizen;
-#endif
-
-namespace Microsoft.Maui.Controls.Hosting
+public static partial class AppHostBuilderExtensions
 {
-	public static partial class AppHostBuilderExtensions
+	/// <summary>
+	/// Configures the <see cref="MauiAppBuilder"/> to use the specified <typeparamref name="TApp"/> as the main application type.
+	/// </summary>
+	/// <typeparam name="TApp">The type to use as the application.</typeparam>
+	/// <param name="builder">The <see cref="MauiAppBuilder"/> to configure.</param>
+	/// <returns>The configured <see cref="MauiAppBuilder"/>.</returns>
+	public static MauiAppBuilder UseMauiApp<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TApp>(this MauiAppBuilder builder)
+		where TApp : class, IApplication
 	{
-		/// <summary>
-		/// Configures the <see cref="MauiAppBuilder"/> to use the specified <typeparamref name="TApp"/> as the main application type.
-		/// </summary>
-		/// <typeparam name="TApp">The type to use as the application.</typeparam>
-		/// <param name="builder">The <see cref="MauiAppBuilder"/> to configure.</param>
-		/// <returns>The configured <see cref="MauiAppBuilder"/>.</returns>
-		public static MauiAppBuilder UseMauiApp<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TApp>(this MauiAppBuilder builder)
-			where TApp : class, IApplication
-		{
-#pragma warning disable RS0030 // Do not used banned APIs - don't want to use a factory method here
-			builder.Services.TryAddSingleton<IApplication, TApp>();
-#pragma warning restore RS0030
-			builder.SetupDefaults();
-			return builder;
-		}
+		builder.UseMauiPrimaryApp<TApp>();
+		builder.SetupXamlDefaults();
+		return builder;
+	}
 
-		/// <summary>
-		/// Configures the <see cref="MauiAppBuilder"/> to use the specified <typeparamref name="TApp"/> as the main application type.
-		/// </summary>
-		/// <typeparam name="TApp">The type to use as the application.</typeparam>
-		/// <param name="builder">The <see cref="MauiAppBuilder"/> to configure.</param>
-		/// <param name="implementationFactory">A factory to create the specified <typeparamref name="TApp"/> using the services provided in a <see cref="IServiceProvider"/>.</param>
-		/// <returns>The configured <see cref="MauiAppBuilder"/>.</returns>
-		public static MauiAppBuilder UseMauiApp<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TApp>(this MauiAppBuilder builder, Func<IServiceProvider, TApp> implementationFactory)
-			where TApp : class, IApplication
-		{
-			builder.Services.TryAddSingleton<IApplication>(implementationFactory);
-			builder.SetupDefaults();
-			return builder;
-		}
+	/// <summary>
+	/// Configures the <see cref="MauiAppBuilder"/> to use the specified <typeparamref name="TApp"/> as the main application type.
+	/// </summary>
+	/// <typeparam name="TApp">The type to use as the application.</typeparam>
+	/// <param name="builder">The <see cref="MauiAppBuilder"/> to configure.</param>
+	/// <param name="implementationFactory">A factory to create the specified <typeparamref name="TApp"/> using the services provided in a <see cref="IServiceProvider"/>.</param>
+	/// <returns>The configured <see cref="MauiAppBuilder"/>.</returns>
+	public static MauiAppBuilder UseMauiApp<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TApp>(this MauiAppBuilder builder, Func<IServiceProvider, TApp> implementationFactory)
+		where TApp : class, IApplication
+	{
+		builder.UseMauiPrimaryApp<TApp>(implementationFactory);
+		builder.SetupXamlDefaults();
+		return builder;
+	}
 
-		public static IMauiHandlersCollection AddMauiControlsHandlers(this IMauiHandlersCollection handlersCollection)
-		{
-			handlersCollection.AddHandler<CollectionView, CollectionViewHandler>();
-			handlersCollection.AddHandler<CarouselView, CarouselViewHandler>();
-			handlersCollection.AddHandler<Application, ApplicationHandler>();
-			handlersCollection.AddHandler<ActivityIndicator, ActivityIndicatorHandler>();
-			handlersCollection.AddHandler<BoxView, BoxViewHandler>();
-			handlersCollection.AddHandler<Button, ButtonHandler>();
-			handlersCollection.AddHandler<CheckBox, CheckBoxHandler>();
-			handlersCollection.AddHandler<DatePicker, DatePickerHandler>();
-			handlersCollection.AddHandler<Editor, EditorHandler>();
-			handlersCollection.AddHandler<Entry, EntryHandler>();
-			handlersCollection.AddHandler<GraphicsView, GraphicsViewHandler>();
-			handlersCollection.AddHandler<Image, ImageHandler>();
-			handlersCollection.AddHandler<Label, LabelHandler>();
-			handlersCollection.AddHandler<Layout, LayoutHandler>();
-			handlersCollection.AddHandler<Picker, PickerHandler>();
-			handlersCollection.AddHandler<ProgressBar, ProgressBarHandler>();
-			handlersCollection.AddHandler<ScrollView, ScrollViewHandler>();
-			handlersCollection.AddHandler<SearchBar, SearchBarHandler>();
-			handlersCollection.AddHandler<Slider, SliderHandler>();
-			handlersCollection.AddHandler<Stepper, StepperHandler>();
-			handlersCollection.AddHandler<Switch, SwitchHandler>();
-			handlersCollection.AddHandler<TimePicker, TimePickerHandler>();
-			handlersCollection.AddHandler<Page, PageHandler>();
-			handlersCollection.AddHandler<WebView, WebViewHandler>();
-			handlersCollection.AddHandler<Border, BorderHandler>();
-			handlersCollection.AddHandler<IContentView, ContentViewHandler>();
-			handlersCollection.AddHandler<Shapes.Ellipse, ShapeViewHandler>();
-			handlersCollection.AddHandler<Shapes.Line, LineHandler>();
-			handlersCollection.AddHandler<Shapes.Path, PathHandler>();
-			handlersCollection.AddHandler<Shapes.Polygon, PolygonHandler>();
-			handlersCollection.AddHandler<Shapes.Polyline, PolylineHandler>();
-			handlersCollection.AddHandler<Shapes.Rectangle, RectangleHandler>();
-			handlersCollection.AddHandler<Shapes.RoundRectangle, RoundRectangleHandler>();
-			handlersCollection.AddHandler<Window, WindowHandler>();
-			handlersCollection.AddHandler<ImageButton, ImageButtonHandler>();
-			handlersCollection.AddHandler<IndicatorView, IndicatorViewHandler>();
-			handlersCollection.AddHandler<RadioButton, RadioButtonHandler>();
-			handlersCollection.AddHandler<RefreshView, RefreshViewHandler>();
-			handlersCollection.AddHandler<SwipeItem, SwipeItemMenuItemHandler>();
-			handlersCollection.AddHandler<SwipeView, SwipeViewHandler>();
+	public static IMauiHandlersCollection AddMauiControlsHandlers(this IMauiHandlersCollection handlersCollection) =>
+		handlersCollection.AddControlsHandlers();
 
-#pragma warning disable CA1416 //  'MenuBarHandler', MenuFlyoutSubItemHandler, MenuFlyoutSubItemHandler, MenuBarItemHandler is only supported on: 'ios' 13.0 and later
-			handlersCollection.AddHandler<MenuBar, MenuBarHandler>();
-			handlersCollection.AddHandler<MenuFlyoutSubItem, MenuFlyoutSubItemHandler>();
-			handlersCollection.AddHandler<MenuFlyoutSeparator, MenuFlyoutSeparatorHandler>();
-			handlersCollection.AddHandler<MenuFlyoutItem, MenuFlyoutItemHandler>();
-			handlersCollection.AddHandler<MenuBarItem, MenuBarItemHandler>();
-#pragma warning restore CA1416
-
+	static MauiAppBuilder SetupXamlDefaults(this MauiAppBuilder builder)
+	{
 #if WINDOWS || ANDROID || IOS || MACCATALYST || TIZEN
-			handlersCollection.AddHandler(typeof(ListView), typeof(Handlers.Compatibility.ListViewRenderer));
-#if !TIZEN
-			handlersCollection.AddHandler(typeof(Cell), typeof(Handlers.Compatibility.CellRenderer));
-			handlersCollection.AddHandler(typeof(ImageCell), typeof(Handlers.Compatibility.ImageCellRenderer));
-			handlersCollection.AddHandler(typeof(EntryCell), typeof(Handlers.Compatibility.EntryCellRenderer));
-			handlersCollection.AddHandler(typeof(TextCell), typeof(Handlers.Compatibility.TextCellRenderer));
-			handlersCollection.AddHandler(typeof(ViewCell), typeof(Handlers.Compatibility.ViewCellRenderer));
-			handlersCollection.AddHandler(typeof(SwitchCell), typeof(Handlers.Compatibility.SwitchCellRenderer));
+		DependencyService.Register<Xaml.ResourcesLoader>();
+		DependencyService.Register<Xaml.ValueConverterProvider>();
 #endif
-			handlersCollection.AddHandler(typeof(TableView), typeof(Handlers.Compatibility.TableViewRenderer));
-			handlersCollection.AddHandler(typeof(Frame), typeof(Handlers.Compatibility.FrameRenderer));
-#endif
-
-#if WINDOWS || MACCATALYST
-			handlersCollection.AddHandler(typeof(MenuFlyout), typeof(MenuFlyoutHandler));
-#endif
-
-#if IOS || MACCATALYST
-			handlersCollection.AddHandler(typeof(NavigationPage), typeof(Handlers.Compatibility.NavigationRenderer));
-			handlersCollection.AddHandler(typeof(TabbedPage), typeof(Handlers.Compatibility.TabbedRenderer));
-			handlersCollection.AddHandler(typeof(FlyoutPage), typeof(Handlers.Compatibility.PhoneFlyoutPageRenderer));
-#endif
-
-#if ANDROID || IOS || MACCATALYST || TIZEN
-			handlersCollection.AddHandler<SwipeItemView, SwipeItemViewHandler>();
-#if ANDROID || IOS || MACCATALYST
-			handlersCollection.AddHandler<Shell, ShellRenderer>();
-#else
-			handlersCollection.AddHandler<Shell, ShellHandler>();
-			handlersCollection.AddHandler<ShellItem, ShellItemHandler>();
-			handlersCollection.AddHandler<ShellSection, ShellSectionHandler>();
-#endif
-#endif
-#if WINDOWS || ANDROID || TIZEN
-			handlersCollection.AddHandler<NavigationPage, NavigationViewHandler>();
-			handlersCollection.AddHandler<Toolbar, ToolbarHandler>();
-			handlersCollection.AddHandler<FlyoutPage, FlyoutViewHandler>();
-			handlersCollection.AddHandler<TabbedPage, TabbedViewHandler>();
-#endif
-
-#if WINDOWS
-			handlersCollection.AddHandler<ShellItem, ShellItemHandler>();
-			handlersCollection.AddHandler<ShellSection, ShellSectionHandler>();
-			handlersCollection.AddHandler<ShellContent, ShellContentHandler>();
-			handlersCollection.AddHandler<Shell, ShellHandler>();
-#endif
-			return handlersCollection;
-		}
-
-		static MauiAppBuilder SetupDefaults(this MauiAppBuilder builder)
-		{
-#if WINDOWS || ANDROID || IOS || MACCATALYST || TIZEN
-			// initialize compatibility DependencyService
-			DependencyService.SetToInitialized();
-			DependencyService.Register<Xaml.ResourcesLoader>();
-			DependencyService.Register<Xaml.ValueConverterProvider>();
-			DependencyService.Register<PlatformSizeService>();
-
-#pragma warning disable CS0612, CA1416 // Type or member is obsolete, 'ResourcesProvider' is unsupported on: 'iOS' 14.0 and later
-			DependencyService.Register<ResourcesProvider>();
-			DependencyService.Register<FontNamedSizeService>();
-#pragma warning restore CS0612, CA1416 // Type or member is obsolete
-#endif
-			builder.Services.AddScoped(_ => new HideSoftInputOnTappedChangedManager());
-			builder.ConfigureImageSourceHandlers();
-			builder
-				.ConfigureMauiHandlers(handlers =>
-				{
-					handlers.AddMauiControlsHandlers();
-				});
-
-#if WINDOWS
-			builder.Services.TryAddEnumerable(ServiceDescriptor.Transient<IMauiInitializeService, MauiControlsInitializer>());
-#endif
-			builder.RemapForControls();
-
-			return builder;
-		}
-
-		class MauiControlsInitializer : IMauiInitializeService
-		{
-			public void Initialize(IServiceProvider services)
-			{
-#if WINDOWS
-				var dispatcher = services.GetRequiredApplicationDispatcher();
-
-				dispatcher
-					.DispatchIfRequired(() =>
-					{
-						var dictionaries = UI.Xaml.Application.Current?.Resources?.MergedDictionaries;
-						if (dictionaries != null)
-						{
-							// Microsoft.Maui.Controls
-							UI.Xaml.Application.Current?.Resources?.AddLibraryResources("MicrosoftMauiControlsIncluded", "ms-appx:///Microsoft.Maui.Controls/Platform/Windows/Styles/Resources.xbf");
-						}
-					});
-#endif
-			}
-		}
-
-
-		internal static MauiAppBuilder ConfigureImageSourceHandlers(this MauiAppBuilder builder)
-		{
-			builder.ConfigureImageSources(services =>
-			{
-				services.AddService<FileImageSource>(svcs => new FileImageSourceService(svcs.CreateLogger<FileImageSourceService>()));
-				services.AddService<FontImageSource>(svcs => new FontImageSourceService(svcs.GetRequiredService<IFontManager>(), svcs.CreateLogger<FontImageSourceService>()));
-				services.AddService<StreamImageSource>(svcs => new StreamImageSourceService(svcs.CreateLogger<StreamImageSourceService>()));
-				services.AddService<UriImageSource>(svcs => new UriImageSourceService(svcs.CreateLogger<UriImageSourceService>()));
-			});
-
-			return builder;
-		}
-
-		internal static MauiAppBuilder RemapForControls(this MauiAppBuilder builder)
-		{
-			// Update the mappings for IView/View to work specifically for Controls
-			Element.RemapForControls();
-			Application.RemapForControls();
-			VisualElement.RemapForControls();
-			Label.RemapForControls();
-			Button.RemapForControls();
-			CheckBox.RemapForControls();
-			DatePicker.RemapForControls();
-			RadioButton.RemapForControls();
-			FlyoutPage.RemapForControls();
-			Toolbar.RemapForControls();
-			Window.RemapForControls();
-			Editor.RemapForControls();
-			Entry.RemapForControls();
-			SwipeView.RemapForControls();
-			Picker.RemapForControls();
-			SearchBar.RemapForControls();
-			TabbedPage.RemapForControls();
-			TimePicker.RemapForControls();
-			Layout.RemapForControls();
-			ScrollView.RemapForControls();
-			RefreshView.RemapForControls();
-			Shape.RemapForControls();
-			WebView.RemapForControls();
-			ContentPage.RemapForControls();
-
-			return builder;
-		}
+		return builder;
 	}
 }

--- a/src/Controls/src/Xaml/Properties/AssemblyInfo.cs
+++ b/src/Controls/src/Xaml/Properties/AssemblyInfo.cs
@@ -13,6 +13,7 @@ using Microsoft.Maui.Controls.Internals;
 [assembly: InternalsVisibleTo("Microsoft.Maui.Controls.Compatibility")]
 [assembly: InternalsVisibleTo("CommunityToolkit.Maui")]
 [assembly: InternalsVisibleTo("CommunityToolkit.Maui.Core")]
+[assembly: InternalsVisibleTo("CommunityToolkit.Maui.Embedding")]
 [assembly: InternalsVisibleTo("CommunityToolkit.Maui.UnitTests")]
 [assembly: InternalsVisibleTo("CommunityToolkit.Maui.Markup")]
 [assembly: InternalsVisibleTo("CommunityToolkit.Maui.Markup.UnitTests")]

--- a/src/Core/src/Core/Extensions/VisualTreeElementExtensions.cs
+++ b/src/Core/src/Core/Extensions/VisualTreeElementExtensions.cs
@@ -136,7 +136,7 @@ namespace Microsoft.Maui
 			var visualElements = new List<IVisualTreeElement>();
 			if (visualElement is IWindow window)
 			{
-				uiElement = window.Content.ToPlatform();
+				uiElement = window.Content?.ToPlatform();
 			}
 			else if (visualElement is IView view)
 			{

--- a/src/Core/src/Embedding/EmbeddedPlatformApplication.cs
+++ b/src/Core/src/Embedding/EmbeddedPlatformApplication.cs
@@ -1,0 +1,60 @@
+﻿#if ANDROID || IOS || MACCATALYST || WINDOWS
+using System;
+using Microsoft.Extensions.DependencyInjection;
+
+#if ANDROID
+using PlatformApplication = Android.App.Application;
+#elif IOS || MACCATALYST
+using PlatformApplication = UIKit.IUIApplicationDelegate;
+#elif WINDOWS
+using PlatformApplication = Microsoft.UI.Xaml.Application;
+#endif
+
+namespace Microsoft.Maui.Embedding;
+
+/// <summary>
+/// A <see cref="IPlatformApplication"/> that is used in embedding scenarios where the native platform application
+/// instance is either unknown at the time, or not controlled by MAUI.
+/// </summary>
+internal class EmbeddedPlatformApplication : IPlatformApplication
+{
+	private readonly MauiContext _rootContext;
+
+	public EmbeddedPlatformApplication(IServiceProvider services)
+	{
+		IPlatformApplication.Current = this;
+
+		PlatformApplication = services.GetRequiredService<PlatformApplication>();
+
+#if ANDROID
+		_rootContext = new MauiContext(services, PlatformApplication);
+#else
+		_rootContext = new MauiContext(services);
+#endif
+
+		Context = _rootContext.MakeApplicationScope(PlatformApplication);
+
+		Services = Context.Services;
+
+		Application = Services.GetRequiredService<IApplication>();
+
+		PlatformApplication.SetApplicationHandler(Application, Context);
+	}
+
+	/// <summary>
+	/// Gets the native platform application instance that is hosting this MAUI app.
+	/// </summary>
+	public PlatformApplication PlatformApplication { get; }
+
+	/// <summary>
+	/// Gets the application-scoped <see cref="IMauiContext"/>.
+	/// </summary>
+	public IMauiContext Context { get; }
+
+	/// Gets the application-scoped services.
+	public IServiceProvider Services { get; }
+
+	/// Gets the current MAUI application instance.
+	public IApplication Application { get; }
+}
+#endif

--- a/src/Core/src/Embedding/EmbeddedWindowHandler.Android.cs
+++ b/src/Core/src/Embedding/EmbeddedWindowHandler.Android.cs
@@ -1,0 +1,24 @@
+﻿using Android.App;
+
+namespace Microsoft.Maui.Embedding;
+
+internal partial class EmbeddedWindowHandler
+{
+	protected override void ConnectHandler(Activity platformView)
+	{
+		base.ConnectHandler(platformView);
+
+		UpdateVirtualViewFrame(platformView);
+	}
+
+	protected override void DisconnectHandler(Activity platformView)
+	{
+		base.DisconnectHandler(platformView);
+	}
+
+	void UpdateVirtualViewFrame(Activity activity)
+	{
+		var frame = activity.GetWindowFrame();
+		VirtualView.FrameChanged(frame);
+	}
+}

--- a/src/Core/src/Embedding/EmbeddedWindowHandler.Windows.cs
+++ b/src/Core/src/Embedding/EmbeddedWindowHandler.Windows.cs
@@ -1,0 +1,53 @@
+﻿using Microsoft.Maui.Graphics;
+using Microsoft.UI.Windowing;
+
+using PlatformWindow = Microsoft.UI.Xaml.Window;
+
+namespace Microsoft.Maui.Embedding;
+
+internal partial class EmbeddedWindowHandler
+{
+	protected override void ConnectHandler(PlatformWindow platformView)
+	{
+		base.ConnectHandler(platformView);
+
+		var appWindow = platformView.GetAppWindow();
+		if (appWindow is not null)
+		{
+			// then pass the actual size back to the user
+			UpdateVirtualViewFrame(appWindow);
+
+			// THEN attach the event to reduce churn
+			appWindow.Changed += OnWindowChanged;
+		}
+	}
+
+	protected override void DisconnectHandler(PlatformWindow platformView)
+	{
+		var appWindow = platformView.GetAppWindow();
+		if (appWindow is not null)
+			appWindow.Changed -= OnWindowChanged;
+
+		base.DisconnectHandler(platformView);
+	}
+
+	void OnWindowChanged(AppWindow sender, AppWindowChangedEventArgs args)
+	{
+		if (!args.DidSizeChange && !args.DidPositionChange)
+			return;
+
+		UpdateVirtualViewFrame(sender);
+	}
+
+	void UpdateVirtualViewFrame(AppWindow appWindow)
+	{
+		var size = appWindow.Size;
+		var pos = appWindow.Position;
+
+		var density = PlatformView.GetDisplayDensity();
+
+		VirtualView.FrameChanged(new Rect(
+			pos.X / density, pos.Y / density,
+			size.Width / density, size.Height / density));
+	}
+}

--- a/src/Core/src/Embedding/EmbeddedWindowHandler.cs
+++ b/src/Core/src/Embedding/EmbeddedWindowHandler.cs
@@ -1,0 +1,56 @@
+﻿#if ANDROID || IOS || MACCATALYST || WINDOWS
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Platform;
+
+#if ANDROID
+using PlatformWindow = Android.App.Activity;
+#elif IOS || MACCATALYST
+using PlatformWindow = UIKit.UIWindow;
+#elif WINDOWS
+using PlatformWindow = Microsoft.UI.Xaml.Window;
+#endif
+
+namespace Microsoft.Maui.Embedding;
+
+/// <summary>
+/// A reduced functionality <see cref="WindowHandler"/> for embedded scenarios.
+/// </summary>
+/// <remarks>
+/// The main purpose is to avoid adding mappers that affect the platform window since it is not meant to be
+/// modified arbitrarily from embedded MAUI views.
+/// </remarks>
+internal partial class EmbeddedWindowHandler : ElementHandler<IWindow, PlatformWindow>, IWindowHandler
+{
+	public static IPropertyMapper<IWindow, IWindowHandler> Mapper =
+		new PropertyMapper<IWindow, IWindowHandler>(ElementHandler.ElementMapper)
+		{
+		};
+
+	public static CommandMapper<IWindow, IWindowHandler> CommandMapper =
+		new(ElementCommandMapper)
+		{
+			[nameof(IWindow.RequestDisplayDensity)] = WindowHandler.MapRequestDisplayDensity,
+		};
+
+	public EmbeddedWindowHandler()
+		: base(Mapper, CommandMapper)
+	{
+	}
+
+	public EmbeddedWindowHandler(IPropertyMapper? mapper)
+		: base(mapper ?? Mapper, CommandMapper)
+	{
+	}
+
+	public EmbeddedWindowHandler(IPropertyMapper? mapper, CommandMapper? commandMapper)
+		: base(mapper ?? Mapper, commandMapper ?? CommandMapper)
+	{
+	}
+
+	protected override PlatformWindow CreatePlatformElement() =>
+		MauiContext!.Services.GetRequiredService<PlatformWindow>() ??
+		throw new InvalidOperationException("EmbeddedWindowHandler could not locate a platform window.");
+}
+#endif

--- a/src/Core/src/Embedding/EmbeddedWindowHandler.iOS.cs
+++ b/src/Core/src/Embedding/EmbeddedWindowHandler.iOS.cs
@@ -1,7 +1,8 @@
-﻿using Microsoft.Maui.Graphics;
-using Microsoft.UI.Windowing;
+﻿using System;
+using ObjCRuntime;
+using UIKit;
 
-using PlatformWindow = Microsoft.UI.Xaml.Window;
+using PlatformWindow = UIKit.UIWindow;
 
 namespace Microsoft.Maui.Embedding;
 

--- a/src/Core/src/Embedding/EmbeddedWindowHandler.iOS.cs
+++ b/src/Core/src/Embedding/EmbeddedWindowHandler.iOS.cs
@@ -1,21 +1,19 @@
-﻿//using Microsoft.Maui.Graphics;
-//using Microsoft.UI.Windowing;
+﻿using Microsoft.Maui.Graphics;
+using Microsoft.UI.Windowing;
 
-//using PlatformWindow = Microsoft.UI.Xaml.Window;
+using PlatformWindow = Microsoft.UI.Xaml.Window;
 
-//namespace Microsoft.Maui.Embedding;
+namespace Microsoft.Maui.Embedding;
 
-//internal partial class EmbeddedWindowHandler
-//{
-//	protected override void ConnectHandler(PlatformWindow platformView)
-//	{
-//		base.ConnectHandler(platformView);
+internal partial class EmbeddedWindowHandler
+{
+	protected override void ConnectHandler(PlatformWindow platformView)
+	{
+		base.ConnectHandler(platformView);
+	}
 
-//	}
-
-//	protected override void DisconnectHandler(PlatformWindow platformView)
-//	{
-
-//		base.DisconnectHandler(platformView);
-//	}
-//}
+	protected override void DisconnectHandler(PlatformWindow platformView)
+	{
+		base.DisconnectHandler(platformView);
+	}
+}

--- a/src/Core/src/Embedding/EmbeddedWindowHandler.iOS.cs
+++ b/src/Core/src/Embedding/EmbeddedWindowHandler.iOS.cs
@@ -1,0 +1,21 @@
+﻿//using Microsoft.Maui.Graphics;
+//using Microsoft.UI.Windowing;
+
+//using PlatformWindow = Microsoft.UI.Xaml.Window;
+
+//namespace Microsoft.Maui.Embedding;
+
+//internal partial class EmbeddedWindowHandler
+//{
+//	protected override void ConnectHandler(PlatformWindow platformView)
+//	{
+//		base.ConnectHandler(platformView);
+
+//	}
+
+//	protected override void DisconnectHandler(PlatformWindow platformView)
+//	{
+
+//		base.DisconnectHandler(platformView);
+//	}
+//}

--- a/src/Core/src/Embedding/EmbeddedWindowProvider.cs
+++ b/src/Core/src/Embedding/EmbeddedWindowProvider.cs
@@ -1,0 +1,36 @@
+﻿#if ANDROID || IOS || MACCATALYST || WINDOWS
+using System;
+
+#if ANDROID
+using PlatformWindow = Android.App.Activity;
+#elif IOS || MACCATALYST
+using PlatformWindow = UIKit.UIWindow;
+#elif WINDOWS
+using PlatformWindow = Microsoft.UI.Xaml.Window;
+#endif
+
+namespace Microsoft.Maui.Embedding;
+
+/// <summary>
+/// A proxy service that provides access to the embedded window and its associated platform window.
+/// </summary>
+/// <remarks>
+/// This is used when embedding but also serves to allow the platform window to be added to the service collection
+/// before it is actually known or instantiated.
+/// </remarks>
+internal class EmbeddedWindowProvider
+{
+	WeakReference<PlatformWindow>? _platformWindow;
+	WeakReference<IWindow>? _window;
+
+	public void SetWindow(PlatformWindow? platformWindow, IWindow? window)
+	{
+		_platformWindow = platformWindow is null ? null : new WeakReference<PlatformWindow>(platformWindow);
+		_window = window is null ? null : new WeakReference<IWindow>(window);
+	}
+
+	public PlatformWindow? PlatformWindow => _platformWindow?.GetTargetOrDefault();
+
+	public IWindow? Window => _window?.GetTargetOrDefault();
+}
+#endif

--- a/src/Core/src/Embedding/EmbeddingExtensions.cs
+++ b/src/Core/src/Embedding/EmbeddingExtensions.cs
@@ -28,7 +28,7 @@ internal static class EmbeddingExtensions
 	/// <param name="builder">The <see cref="MauiAppBuilder"/> instance.</param>
 	/// <param name="platformApplication">The native application instance.</param>
 	/// <returns>The <see cref="MauiAppBuilder"/> instance.</returns>
-	public static MauiAppBuilder UseMauiEmbedding(this MauiAppBuilder builder, PlatformApplication? platformApplication = null)
+	internal static MauiAppBuilder UseMauiEmbedding(this MauiAppBuilder builder, PlatformApplication? platformApplication = null)
 	{
 #if ANDROID
 		platformApplication ??= (Android.App.Application)Android.App.Application.Context;
@@ -70,7 +70,7 @@ internal static class EmbeddingExtensions
 	/// <param name="platformWindow">The native window instance to create the context for.</param>
 	/// <param name="window">The MAUI window instance to connect to the platform window.</param>
 	/// <returns>The window-scoped <see cref="IMauiContext"/> instance.</returns>
-	public static IMauiContext CreateEmbeddedWindowContext(this MauiApp mauiApp, PlatformWindow platformWindow, IWindow window)
+	internal static IMauiContext CreateEmbeddedWindowContext(this MauiApp mauiApp, PlatformWindow platformWindow, IWindow window)
 	{
 		// Get the embedded application instance.
 		var embeddedApp = mauiApp.Services.GetRequiredService<EmbeddedPlatformApplication>();

--- a/src/Core/src/Embedding/EmbeddingExtensions.cs
+++ b/src/Core/src/Embedding/EmbeddingExtensions.cs
@@ -1,0 +1,100 @@
+﻿#if ANDROID || IOS || MACCATALYST || WINDOWS
+using System;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Maui.Hosting;
+
+#if ANDROID
+using PlatformWindow = Android.App.Activity;
+using PlatformApplication = Android.App.Application;
+#elif IOS || MACCATALYST
+using PlatformWindow = UIKit.UIWindow;
+using PlatformApplication = UIKit.IUIApplicationDelegate;
+#elif WINDOWS
+using PlatformWindow = Microsoft.UI.Xaml.Window;
+using PlatformApplication = Microsoft.UI.Xaml.Application;
+#endif
+
+namespace Microsoft.Maui.Embedding;
+
+/// <summary>
+/// A set of extension methods that allow for embedding a MAUI view within a native application.
+/// </summary>
+internal static class EmbeddingExtensions
+{
+	/// <summary>
+	/// Enables MAUI to be embedded in native application by injecting embedded handlers into the service collection.
+	/// </summary>
+	/// <param name="builder">The <see cref="MauiAppBuilder"/> instance.</param>
+	/// <param name="platformApplication">The native application instance.</param>
+	/// <returns>The <see cref="MauiAppBuilder"/> instance.</returns>
+	public static MauiAppBuilder UseMauiEmbedding(this MauiAppBuilder builder, PlatformApplication? platformApplication = null)
+	{
+#if ANDROID
+		platformApplication ??= (Android.App.Application)Android.App.Application.Context;
+#elif IOS || MACCATALYST
+		platformApplication ??= UIKit.UIApplication.SharedApplication.Delegate;
+#elif WINDOWS
+		platformApplication ??= Microsoft.UI.Xaml.Application.Current;
+#endif
+
+		if (platformApplication is null)
+		{
+			throw new InvalidOperationException("Platform application instance is required and was not able to be detected.");
+		}
+
+		// Register the current native application that is currently running.
+		builder.Services.AddSingleton(platformApplication);
+
+		// Register the IPlatformApplication for the embedded application.
+		builder.Services.AddSingleton<EmbeddedPlatformApplication>(svc => new EmbeddedPlatformApplication(svc));
+
+		builder.Services.AddScoped<EmbeddedWindowProvider>(svc => new EmbeddedWindowProvider());
+
+		// Returning null is acceptable here as the platform window is optional.
+		// However, we do not know for sure until we resolve it.
+		builder.Services.AddScoped<PlatformWindow>(svc => svc.GetRequiredService<EmbeddedWindowProvider>().PlatformWindow!);
+
+		// Register an initializer as we need a platform application to be
+		// instantiated as soon as possible. In a typical app, this would be
+		// done by the platform-specific bootstrapper.
+		builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IMauiInitializeService, EmbeddedInitializeService>(svc => new EmbeddedInitializeService()));
+
+		return builder;
+	}
+
+	/// <summary>
+	/// Creates a window-scoped <see cref="IMauiContext"/> for the provided platform window.
+	/// </summary>
+	/// <param name="mauiApp">The <see cref="MauiApp"/> instance.</param>
+	/// <param name="platformWindow">The native window instance to create the context for.</param>
+	/// <param name="window">The MAUI window instance to connect to the platform window.</param>
+	/// <returns>The window-scoped <see cref="IMauiContext"/> instance.</returns>
+	public static IMauiContext CreateEmbeddedWindowContext(this MauiApp mauiApp, PlatformWindow platformWindow, IWindow window)
+	{
+		// Get the embedded application instance.
+		var embeddedApp = mauiApp.Services.GetRequiredService<EmbeddedPlatformApplication>();
+
+		// Create a window context for the platform window that was provided.
+		var windowContext = embeddedApp.Context.MakeWindowScope(platformWindow, out var windowScope);
+
+		// Add the platform window to the service provider.
+		var wndProvider = windowContext.Services.GetRequiredService<EmbeddedWindowProvider>();
+		wndProvider.SetWindow(platformWindow, window);
+
+		// Connect the platform window to the MAUI window in order for lifecycle events to work.
+		window.ToHandler(windowContext);
+
+		return windowContext;
+	}
+
+	/// <summary>
+	/// An initializer to make sure the <see cref="IPlatformApplication.Current"/> is populated.
+	/// </summary>
+	private class EmbeddedInitializeService : IMauiInitializeService
+	{
+		public void Initialize(IServiceProvider services) =>
+			services.GetRequiredService<EmbeddedPlatformApplication>();
+	}
+}
+#endif


### PR DESCRIPTION
### Description of Change

This PR adds some overloads for MAUI to embed MAUI views in a platform app.

There are a few ways to embed things after this PR, each with increasing levels of steps, but also increasing levels of developer enjoyment.

With each case here, the `MauiProgram` is the same as before, except that `UseMauiApp` is replaced with  `UseMauiEmbeddedApp` to enable the embedding infrastructure. This is needed because unlike a traditional MAUI app, the platform application (eg: `UIApplication`) and `IPlatformApplication` needs to be registered in the service provider for the rest of MAUI to be rooted. There may be cases where this is not needed, but this will probably break tooling and other things because everything expects there to be a current and running MAUI application. In a typical MAUI app, this is done in the platform application setup code. But, in an embedded scenario, the platform application is not controlled by MAUI and is instead a user instance.

```cs
public static class MauiProgram
{
    public static MauiApp CreateMauiApp() =>
        MauiApp
            .CreateBuilder()
            .UseMauiEmbeddedApp<App>()
            .Build();
}
```

#### Simplest

For the very simplest of cases, embedding can be done without any additional code besides the construction of the app and then creating a context to get the native view:

```cs
// 1. Ensure app is built before creating MAUI views (should be a shared static)
var mauiApp = MauiProgram.CreateMauiApp();
// 2. Create MAUI embedded window context
var mauiContext = new MauiContext(mauiApp.Services);
// 3. Create MAUI views
var mauiView = new MyMauiContent();
// 4. Create platform view
var nativeView = mauiView.ToPlatform(mauiContext);
// 5. Add to the UI
RootLayout.Children.Add(nativeView);
```

This will work because many situations may not care if it is attached to anything in the MAUI world. This is effectively a floating view in the MAUI universe that just has access to app-specific things. Some things, such as Hot Reload or MAUI features may not work because the view has no idea how to handle a world in which it is detached from the app.

In addition to the potentially missing features, we are also creating a brand new app each time we want to embed a control. This is fine for a single case and maybe if none of the components are using `Application.Current`. However, this is fairly common in apps and libraries, so the better way to do this is to create a shared, static instance of the MAUI app:

```cs
// 1. The MauiApp instance should be static for the entire app to use.
static MauiApp? _sharedMauiApp;
static MauiApp SharedMauiApp => _sharedMauiApp ??= MauiProgram.CreateMauiApp();
```

This will also allow you to instantiate the `MauiApp` early in your app lifecycle and not have a small delay when instantiating the actual MAUI views.

#### Window Scopes

.NET MAUI uses scoped services to manage the services and instances that are needed for each window. In some cases, a window may have a different dispatcher than the app or other windows. There may also be a case where a control needs to have access to a Window to do things. For example, adaptive triggers require access to a view's window, and if there is no window, it cannot work. 

In order to wrap the view in a window, there is a `ToPlatformEmbedded` extension method that will do the same thing as the existing `ToPlatform`, but also make sure that it attaches to the application correctly. This means that it creates an embedded window that is attached to the application, and then the control is attached to that. This results in the window-related APIs working as well as tooling (Hot Reload) now starting to function.

```cs
// 1. Ensure app is built before creating MAUI views (should be a shared static)
var mauiApp = MauiProgram.CreateMauiApp();
// 2. Create MAUI views
var mauiView = new MyMauiContent();
// 3. Create platform view
var nativeView = mauiView.ToPlatformEmbedded(mauiApp, this);
// 4. Add to the UI
RootLayout.Children.Add(nativeView);
```

#### Correct Window Scopes

One downside of using the `ToPlatformEmbedded` extension method that accepts a platform window is that it will create a new embedded window for each invocation. This means, if you have 3 embedded views, you will also have 3 embedded windows attached to the app.

To correctly relate a single native window with a single MAUI window, we can use the `CreateEmbeddedWindowContext` to first create a window context and then use that (instead of the app context) to attach windows:

```cs
// 1. Ensure app is built before creating MAUI views (should be a shared static)
var mauiApp = MauiProgram.CreateMauiApp();
// 2. Create MAUI embedded window context
var windowContext = mauiApp.CreateEmbeddedWindowContext(this);
// 3. Create MAUI views
var mauiView = new MyMauiContent();
// 4. Create platform view
var nativeView = mauiView.ToPlatformEmbedded(windowContext);
// 5. Add to the UI
RootLayout.Children.Add(nativeView);
```

#### Final

If we put all this together, we can have a single, shared instance of our MAUI app, a single MAUI window for each native window, and all the tooling works correctly. For example, if we want to embed two different MAUI views on to a single WinUI window:

```cs
// 1. Create a shared/static/reusable instance of the MauiApp that will form the root of the MAUI component.
//
// A separate class just to provide shared access to the MAUI app from anywhere.
// This property could be anywhere because it is static, most likely on some native application type.
// But for platforms like Android, applications are not as common so a new type to host the property is also fine.
// If you have a single window app, then this static property could also just reside in the window class.
public static class MyEmbeddedMauiApp
{
    private static MauiApp? _shared;
    public static MauiApp Shared =>
        _shared ??= MauiProgram.CreateMauiApp();
}

// The type "MainWindow" is a native WinUI window that is not controlled by MAUI.
// For other platforms, this may not be a "window" type, but some component of it.
public sealed partial class MainWindow : Microsoft.UI.Xaml.Window
{
    // 2. A window-scoped IMauiContext that represents the native window.
    private IMauiContext? windowContext;
    private IMauiContext WindowContext =>
        windowContext ??= MyEmbeddedMauiApp.Shared.CreateEmbeddedWindowContext(this);

    // This method can be called multiple times to embed multiple MAUI views.
    private void EmbedMauiView()
    {
        // 2. Make sure the MAUI app and window context is ready because this example uses lazy loading.
        // If the implementation is not lazy, then this will be the actual call to CreateEmbeddedWindowContext.
        var context = WindowContext;

        // 3. Create the MAUI views to be embedded. There could be multiple in a single window.
        var mauiView = new MyMauiContent();

        // 4. Create the platform view from the MAUI view using the window context.
        // Access to the platform view from the MAUI view is via the mauiView.Handler.PlatformView property.
        var nativeView = mauiView.ToPlatformEmbedded(context);

        // 5. Add the new native view to the UI.
        RootLayout.Children.Add(nativeView);
    }
}
```

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
