### PR TITLE
[Binding SG] Add warning when referencing results of other source generators

### DIFF
--- a/src/Controls/src/BindingSourceGen/BindingSourceGenerator.cs
+++ b/src/Controls/src/BindingSourceGen/BindingSourceGenerator.cs
@@ -119,10 +119,22 @@ public class BindingSourceGenerator : IIncrementalGenerator
 			return Result<BindingInvocationDescription>.Failure(pathParseResult.Diagnostics);
 		}
 
+		var lambdaParamType = lambdaSymbolResult.Value.Parameters[0].Type;
+		if (lambdaParamType is IErrorTypeSymbol)
+		{
+			return Result<BindingInvocationDescription>.Failure(DiagnosticsFactory.LambdaParameterCannotBeResolved(lambdaBodyResult.Value.GetLocation()));
+		}
+
+		var lambdaResultType = lambdaTypeInfo.Type;
+		if (lambdaResultType is IErrorTypeSymbol)
+		{
+			return Result<BindingInvocationDescription>.Failure(DiagnosticsFactory.LambdaResultCannotBeResolved(lambdaBodyResult.Value.GetLocation()));
+		}
+
 		var binding = new BindingInvocationDescription(
 			Location: sourceCodeLocation.ToInterceptorLocation(),
-			SourceType: BindingGenerationUtilities.CreateTypeDescription(lambdaSymbolResult.Value.Parameters[0].Type, enabledNullable),
-			PropertyType: BindingGenerationUtilities.CreateTypeDescription(lambdaTypeInfo.Type, enabledNullable),
+			SourceType: BindingGenerationUtilities.CreateTypeDescription(lambdaParamType, enabledNullable),
+			PropertyType: BindingGenerationUtilities.CreateTypeDescription(lambdaResultType, enabledNullable),
 			Path: new EquatableArray<IPathPart>([.. pathParseResult.Value]),
 			SetterOptions: DeriveSetterOptions(lambdaBodyResult.Value, context.SemanticModel, enabledNullable),
 			NullableContextEnabled: enabledNullable,

--- a/src/Controls/src/BindingSourceGen/DiagnosticsFactory.cs
+++ b/src/Controls/src/BindingSourceGen/DiagnosticsFactory.cs
@@ -17,7 +17,7 @@ public sealed record DiagnosticInfo
 internal static class DiagnosticsFactory
 {
 	public static DiagnosticInfo UnableToResolvePath(Location location)
-		=> new(
+		=> new DiagnosticInfo(
 			new DiagnosticDescriptor(
 				id: "BSG0001",
 				title: "Invalid getter method",
@@ -28,7 +28,7 @@ internal static class DiagnosticsFactory
 			location);
 
 	public static DiagnosticInfo GetterIsNotLambda(Location location)
-		=> new(
+		=> new DiagnosticInfo(
 			new DiagnosticDescriptor(
 				id: "BSG0002",
 				title: "Getter method is not a lambda",
@@ -39,7 +39,7 @@ internal static class DiagnosticsFactory
 			location);
 
 	public static DiagnosticInfo GetterLambdaBodyIsNotExpression(Location location)
-		=> new(
+		=> new DiagnosticInfo(
 			new DiagnosticDescriptor(
 				id: "BSG0003",
 				title: "Getter method body is not an expression",
@@ -50,7 +50,7 @@ internal static class DiagnosticsFactory
 			location);
 
 	public static DiagnosticInfo SuboptimalSetBindingOverload(Location location)
-		=> new(
+		=> new DiagnosticInfo(
 			new DiagnosticDescriptor(
 				id: "BSG0004",
 				title: "Using SetBinding with a string path",
@@ -58,5 +58,27 @@ internal static class DiagnosticsFactory
 				category: "Usage",
 				defaultSeverity: DiagnosticSeverity.Hidden,
 				isEnabledByDefault: false),
+			location);
+
+	public static DiagnosticInfo LambdaParameterCannotBeResolved(Location location)
+		=> new DiagnosticInfo(
+			new DiagnosticDescriptor(
+				id: "BSG0005",
+				title: "Lambda parameter cannot be resolved",
+				messageFormat: "The lambda parameter cannot be resolved. Make sure that it is not source generated.",
+				category: "Usage",
+				defaultSeverity: DiagnosticSeverity.Error,
+				isEnabledByDefault: true),
+			location);
+
+	public static DiagnosticInfo LambdaResultCannotBeResolved(Location location)
+		=> new DiagnosticInfo(
+			new DiagnosticDescriptor(
+				id: "BSG0006",
+				title: "Lambda result type cannot be resolved",
+				messageFormat: "The lambda result type cannot be resolved. Make sure that soruce generated fields / properties are not used in the path.",
+				category: "Usage",
+				defaultSeverity: DiagnosticSeverity.Error,
+				isEnabledByDefault: true),
 			location);
 }

--- a/src/Controls/tests/BindingSourceGen.UnitTests/AssertExtensions.cs
+++ b/src/Controls/tests/BindingSourceGen.UnitTests/AssertExtensions.cs
@@ -42,7 +42,7 @@ internal static class AssertExtensions
         AssertNoDiagnostics(codeGeneratorResult.GeneratedCodeCompilationDiagnostics, "Generated code compilation");
     }
 
-    private static void AssertNoDiagnostics(ImmutableArray<Diagnostic> diagnostics, string name)
+    internal static void AssertNoDiagnostics(ImmutableArray<Diagnostic> diagnostics, string name)
     {
         if (diagnostics.Any())
         {

--- a/src/Controls/tests/BindingSourceGen.UnitTests/IncrementalGenerationTests.cs
+++ b/src/Controls/tests/BindingSourceGen.UnitTests/IncrementalGenerationTests.cs
@@ -18,11 +18,11 @@ public class IncrementalGenerationTests
         """;
 
         var inputCompilation1 = SourceGenHelpers.CreateCompilation(source);
-        var driver1 = SourceGenHelpers.CreateDriver();
+        var driver1 = SourceGenHelpers.CreateDriver([new BindingSourceGenerator().AsSourceGenerator()]);
         var result1 = driver1.RunGenerators(inputCompilation1).GetRunResult().Results.Single();
 
         var inputCompilation2 = SourceGenHelpers.CreateCompilation(source);
-        var driver2 = SourceGenHelpers.CreateDriver();
+        var driver2 = SourceGenHelpers.CreateDriver([new BindingSourceGenerator().AsSourceGenerator()]);
         var result2 = driver2.RunGenerators(inputCompilation2).GetRunResult().Results.Single();
 
         Assert.Equal(result1.TrackedSteps.Count, result2.TrackedSteps.Count);
@@ -65,10 +65,10 @@ public class IncrementalGenerationTests
             new Dictionary<string, string> { { nameof(source), source } },
             new Dictionary<string, string> { { nameof(source), newSource } });
 
-		AssertStepRunReasonEquals(IncrementalStepRunReason.Modified, results[nameof(source)], TrackingNames.BindingsWithDiagnostics);
-		AssertStepRunReasonEquals(IncrementalStepRunReason.Modified, results[nameof(source)], TrackingNames.Bindings);
-		AssertStepRunReasonEquals(IncrementalStepRunReason.Unchanged, results[nameof(source)], "SourceOutput");
-		AssertStepRunReasonEquals(IncrementalStepRunReason.Modified, results[nameof(source)], "ImplementationSourceOutput");
+        AssertStepRunReasonEquals(IncrementalStepRunReason.Modified, results[nameof(source)], TrackingNames.BindingsWithDiagnostics);
+        AssertStepRunReasonEquals(IncrementalStepRunReason.Modified, results[nameof(source)], TrackingNames.Bindings);
+        AssertStepRunReasonEquals(IncrementalStepRunReason.Unchanged, results[nameof(source)], "SourceOutput");
+        AssertStepRunReasonEquals(IncrementalStepRunReason.Modified, results[nameof(source)], "ImplementationSourceOutput");
     }
 
     [Fact]
@@ -91,16 +91,16 @@ public class IncrementalGenerationTests
             new Dictionary<string, string> { { nameof(source), source } },
             new Dictionary<string, string> { { nameof(source), newSource } });
 
-		AssertStepRunReasonEquals(IncrementalStepRunReason.Modified, results[nameof(source)], TrackingNames.BindingsWithDiagnostics);
-		AssertStepRunReasonEquals(IncrementalStepRunReason.Modified, results[nameof(source)], TrackingNames.Bindings);
-		AssertStepRunReasonEquals(IncrementalStepRunReason.Unchanged, results[nameof(source)], "SourceOutput");
-		AssertStepRunReasonEquals(IncrementalStepRunReason.Modified, results[nameof(source)], "ImplementationSourceOutput");
+        AssertStepRunReasonEquals(IncrementalStepRunReason.Modified, results[nameof(source)], TrackingNames.BindingsWithDiagnostics);
+        AssertStepRunReasonEquals(IncrementalStepRunReason.Modified, results[nameof(source)], TrackingNames.Bindings);
+        AssertStepRunReasonEquals(IncrementalStepRunReason.Unchanged, results[nameof(source)], "SourceOutput");
+        AssertStepRunReasonEquals(IncrementalStepRunReason.Modified, results[nameof(source)], "ImplementationSourceOutput");
     }
 
-	private static void AssertStepRunReasonEquals(IncrementalStepRunReason expectedReason, IncrementalGeneratorRunStep[] steps, string stepName)
-	{
-		Assert.Equal(expectedReason, steps.Single(r => r.Name == stepName).Outputs.Single().Reason);
-	}
+    private static void AssertStepRunReasonEquals(IncrementalStepRunReason expectedReason, IncrementalGeneratorRunStep[] steps, string stepName)
+    {
+        Assert.Equal(expectedReason, steps.Single(r => r.Name == stepName).Outputs.Single().Reason);
+    }
 
     [Fact]
     public void DoesNotRegenerateCodeWhenNewCodeInsertedBelow()
@@ -152,15 +152,15 @@ public class IncrementalGenerationTests
             new Dictionary<string, string> { { nameof(fileASource), fileASource }, { nameof(fileBSource), fileBSource } },
             new Dictionary<string, string> { { nameof(fileASource), fileASource }, { nameof(fileBSource), fileBModified } });
 
-		AssertStepRunReasonEquals(IncrementalStepRunReason.Unchanged, results[nameof(fileASource)], TrackingNames.BindingsWithDiagnostics);
-		AssertStepRunReasonEquals(IncrementalStepRunReason.Cached, results[nameof(fileASource)], TrackingNames.Bindings);
-		AssertStepRunReasonEquals(IncrementalStepRunReason.Cached, results[nameof(fileASource)], "SourceOutput");
-		AssertStepRunReasonEquals(IncrementalStepRunReason.Cached, results[nameof(fileASource)], "ImplementationSourceOutput");
+        AssertStepRunReasonEquals(IncrementalStepRunReason.Unchanged, results[nameof(fileASource)], TrackingNames.BindingsWithDiagnostics);
+        AssertStepRunReasonEquals(IncrementalStepRunReason.Cached, results[nameof(fileASource)], TrackingNames.Bindings);
+        AssertStepRunReasonEquals(IncrementalStepRunReason.Cached, results[nameof(fileASource)], "SourceOutput");
+        AssertStepRunReasonEquals(IncrementalStepRunReason.Cached, results[nameof(fileASource)], "ImplementationSourceOutput");
 
-		AssertStepRunReasonEquals(IncrementalStepRunReason.Modified, results[nameof(fileBSource)], TrackingNames.BindingsWithDiagnostics);
-		AssertStepRunReasonEquals(IncrementalStepRunReason.Modified, results[nameof(fileBSource)], TrackingNames.Bindings);
-		AssertStepRunReasonEquals(IncrementalStepRunReason.Unchanged, results[nameof(fileBSource)], "SourceOutput");
-		AssertStepRunReasonEquals(IncrementalStepRunReason.Modified, results[nameof(fileBSource)], "ImplementationSourceOutput");
+        AssertStepRunReasonEquals(IncrementalStepRunReason.Modified, results[nameof(fileBSource)], TrackingNames.BindingsWithDiagnostics);
+        AssertStepRunReasonEquals(IncrementalStepRunReason.Modified, results[nameof(fileBSource)], TrackingNames.Bindings);
+        AssertStepRunReasonEquals(IncrementalStepRunReason.Unchanged, results[nameof(fileBSource)], "SourceOutput");
+        AssertStepRunReasonEquals(IncrementalStepRunReason.Modified, results[nameof(fileBSource)], "ImplementationSourceOutput");
     }
 
     private static Dictionary<string, IncrementalGeneratorRunStep[]> RunGeneratorOnMultipleSourcesAndReturnSteps(
@@ -169,7 +169,7 @@ public class IncrementalGenerationTests
     {
         var inputCompilation = SourceGenHelpers.CreateCompilation(initialSources);
         var cloneCompilation = inputCompilation.Clone();
-        var driver = SourceGenHelpers.CreateDriver();
+        var driver = SourceGenHelpers.CreateDriver([new BindingSourceGenerator().AsSourceGenerator()]);
 
         var driverWithCachedInfo = driver.RunGenerators(inputCompilation);
 

--- a/src/Controls/tests/BindingSourceGen.UnitTests/SourceGenHelpers.cs
+++ b/src/Controls/tests/BindingSourceGen.UnitTests/SourceGenHelpers.cs
@@ -4,6 +4,7 @@ using System.Runtime.Loader;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.Maui.Controls.BindingSourceGen;
+using Xunit;
 
 
 internal record CodeGeneratorResult(
@@ -20,28 +21,32 @@ internal static class SourceGenHelpers
 
     internal static List<string> StepsForComparison = [TrackingNames.Bindings, TrackingNames.BindingsWithDiagnostics];
 
-    internal static CSharpGeneratorDriver CreateDriver()
+    internal static CSharpGeneratorDriver CreateDriver(IEnumerable<ISourceGenerator> generators)
     {
-        var generator = new BindingSourceGenerator();
-        var sourceGenerator = generator.AsSourceGenerator();
         return CSharpGeneratorDriver.Create(
-            [sourceGenerator],
+            generators: generators,
             driverOptions: new GeneratorDriverOptions(disabledOutputs: IncrementalGeneratorOutputKind.None, trackIncrementalGeneratorSteps: true),
             parseOptions: ParseOptions);
     }
 
     internal static CodeGeneratorResult Run(string source)
     {
+        return Run(source, new[] { new BindingSourceGenerator() });
+    }
+
+    internal static CodeGeneratorResult Run(string source, IEnumerable<IIncrementalGenerator> generators)
+    {
+        // Function assumes the first generator in a list is BindingSourceGenerator
+        Assert.NotEmpty(generators);
+        Assert.IsType<BindingSourceGenerator>(generators.First());
+
         var inputCompilation = CreateCompilation(source);
-        var driver = CreateDriver();
+        var driver = CreateDriver(generators.Select(g => g.AsSourceGenerator()));
 
-        var result = driver.RunGeneratorsAndUpdateCompilation(inputCompilation, out Compilation compilation, out _).GetRunResult().Results.Single();
-
-        var generatedCodeDiagnostic = compilation.GetDiagnostics();
-        var generatedCode = result.GeneratedSources.Length == 1 ? result.GeneratedSources.Single().SourceText.ToString() : "";
+        var result = driver.RunGeneratorsAndUpdateCompilation(inputCompilation, out Compilation compilation, out _).GetRunResult().Results.FirstOrDefault();
+        var generatedCode = result.GeneratedSources.FirstOrDefault().SourceText.ToString();
 
         var trackedSteps = result.TrackedSteps;
-
         var resultBinding = trackedSteps.TryGetValue("Bindings", out ImmutableArray<IncrementalGeneratorRunStep> value)
             ? (BindingInvocationDescription)value[0].Outputs[0].Value
             : null;
@@ -50,7 +55,7 @@ internal static class SourceGenHelpers
             GeneratedFiles: result.GeneratedSources.ToDictionary(source => source.HintName, source => source.SourceText.ToString()),
             SourceCompilationDiagnostics: inputCompilation.GetDiagnostics(),
             SourceGeneratorDiagnostics: result.Diagnostics,
-            GeneratedCodeCompilationDiagnostics: generatedCodeDiagnostic,
+            GeneratedCodeCompilationDiagnostics: compilation.GetDiagnostics(),
             Binding: resultBinding);
     }
 
@@ -73,7 +78,7 @@ internal static class SourceGenHelpers
 
     internal static Compilation CreateCompilation(Dictionary<string, string> sources)
     {
-        var syntaxTrees = sources.Select(s => CSharpSyntaxTree.ParseText(s.Value, ParseOptions, path: s.Key)).ToList(); 
+        var syntaxTrees = sources.Select(s => CSharpSyntaxTree.ParseText(s.Value, ParseOptions, path: s.Key)).ToList();
         return CreateCompilationFromSyntaxTrees(syntaxTrees);
     }
 }


### PR DESCRIPTION
### Description of Change

Source generators operate independently by design, meaning they cannot utilize each other's outputs. In the case of the Binding Source Generator (SG), this implies that it cannot use the results of XamlG. This change adds a warning when lambda parameters or the lambda body contain elements that cannot be resolved during source generation.

### Issues Fixed

Fixes #23531 
