### PR TITLE
Detect MauiCALayer being rendered offscreen

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue23070.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue23070.xaml
@@ -1,0 +1,68 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Maui.Controls.Sample.Issues.Issue23070"
+             Title="Issue23070">
+    <ContentPage.Resources>
+      <Color x:Key="Primary">#512BD4</Color>
+      <Color x:Key="PrimaryDark">#ac99ea</Color>
+      <Color x:Key="Secondary">#DFD8F7</Color>
+      <SolidColorBrush x:Key="PrimaryBrush" Color="{StaticResource Primary}"/>
+      
+      <DataTemplate x:Key="T0">
+        <Border
+          StrokeShape="{RoundRectangle CornerRadius=20}">
+          <Border.Background>
+            <LinearGradientBrush>
+              <GradientStop Offset="0" Color="{StaticResource PrimaryDark}" />
+              <GradientStop Offset="1.0" Color="{StaticResource Secondary}" />
+            </LinearGradientBrush>
+          </Border.Background>
+          <Label
+            FontAttributes="Bold"
+            FontSize="20"
+            HorizontalOptions="Center"
+            Text="Hello"
+            VerticalOptions="Center" />
+          <Border.Shadow>
+            <Shadow
+              Brush="{StaticResource PrimaryBrush}"
+              Opacity="0.3"
+              Radius="6"
+              Offset="0, 3" />
+          </Border.Shadow>
+        </Border>
+      </DataTemplate>
+      <DataTemplate x:Key="T1">
+        <Border
+          StrokeShape="{RoundRectangle CornerRadius=20}">
+          <Border.Background>
+            <LinearGradientBrush>
+              <GradientStop Offset="0" Color="{StaticResource Primary}" />
+              <GradientStop Offset="1.0" Color="{StaticResource Secondary}" />
+            </LinearGradientBrush>
+          </Border.Background>
+          <Border.Shadow>
+            <Shadow
+              Brush="{StaticResource PrimaryBrush}"
+              Opacity="0.3"
+              Radius="6"
+              Offset="0, 3" />
+          </Border.Shadow>
+          <Label
+            FontAttributes="Bold"
+            FontSize="20"
+            HorizontalOptions="Center"
+            Text="Hello"
+            TextColor="White"
+            VerticalOptions="Center" />
+        </Border>
+      </DataTemplate>
+    </ContentPage.Resources>
+  
+    <Grid x:Name="TheGrid" Padding="24" RowDefinitions="*,40">
+      <Button x:Name="TheButton" Clicked="ButtonClicked" Text="Tap Me" BackgroundColor="LightGreen"  />
+      
+      
+    </Grid>
+</ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue23070.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue23070.xaml.cs
@@ -1,0 +1,41 @@
+using System;
+using Microsoft.Maui;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+
+namespace Maui.Controls.Sample.Issues;
+
+[XamlCompilation(XamlCompilationOptions.Compile)]
+[Issue(IssueTracker.Github, 23070, "[iOS] Border redraws with 1 frame lag", PlatformAffected.iOS)]
+
+public partial class Issue23070 : ContentPage
+{
+	int t = 0;
+	
+	public Issue23070()
+	{
+		InitializeComponent();
+		var template = (DataTemplate)Resources[$"T0"];
+		TheGrid.Add((View)template.CreateContent(), 0, 1);
+	}
+
+	private async void ButtonClicked(object sender, EventArgs e)
+	{
+		TheButton.IsEnabled = false;
+		
+		TheGrid.RemoveAt(1);
+		t = (t + 1) % 2;
+		var template = (DataTemplate)Resources[$"T{t}"];
+		var content = (View)template.CreateContent();
+		content.IsVisible = false;
+		TheGrid.Add(content, 0, 1);
+		await Task.Delay(1000);
+		content.IsVisible = true;
+		await Task.Delay(1000);
+		content.IsVisible = false;
+		await Task.Delay(1000);
+		content.IsVisible = true;
+
+		TheButton.IsEnabled = true;
+	}
+}

--- a/src/Core/src/Platform/iOS/MauiCALayer.cs
+++ b/src/Core/src/Platform/iOS/MauiCALayer.cs
@@ -42,10 +42,17 @@ namespace Microsoft.Maui.Platform
 		{
 			base.LayoutSublayers();
 
-			if (Bounds.Equals(_bounds))
-				return;
+			// If the super layer's frame is zero, indicating an off-screen rendering scenario, 
+			// the bounds are intentionally kept at zero to avoid incorrect initial drawing 
+			// caused by bounds matching the screen size.
+			var bounds = SuperLayer?.Frame == CGRect.Empty ? CGRect.Empty : Bounds;
 
-			_bounds = new CGRect(Bounds.Location, Bounds.Size);
+			if (bounds.Equals(_bounds))
+			{
+				return;
+			}
+
+			_bounds = new CGRect(bounds.Location, bounds.Size);
 		}
 
 		public override void DrawInContext(CGContext ctx)


### PR DESCRIPTION
### Description of Change

If the super layer's frame is zero, indicating an off-screen rendering scenario, the bounds are intentionally kept at zero to avoid incorrect initial drawing caused by bounds matching the screen size.

**Before fix**
![Simulator Screen Recording - iPhone 15 Pro Max - 2024-07-17 at 12 15 44](https://github.com/user-attachments/assets/b4eae16f-7c78-4d77-83d7-d895eeaaabf4)


**After fix**

![Simulator Screen Recording - iPhone 15 Pro Max - 2024-07-17 at 11 53 37](https://github.com/user-attachments/assets/b53c3a55-717a-46dc-a483-bf795be6dba1)


### Issues Fixed

Fixes #23070