### PR TITLE
[net8.0] Update net8.0 to Sonoma and iOS

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -28,21 +28,21 @@
       <Uri>https://github.com/xamarin/xamarin-android</Uri>
       <Sha>183b7f7688f6b3283256555f50eec38fc35ef6f6</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.MacCatalyst.Sdk" Version="17.2.8079">
+    <Dependency Name="Microsoft.MacCatalyst.Sdk" Version="17.5.8001">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>c56bd8c55918e84587e5712c197c2e98f26731be</Sha>
+      <Sha>64731f8c40752601abebe8eeaf334837344d679b</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.macOS.Sdk" Version="14.2.8079">
+    <Dependency Name="Microsoft.macOS.Sdk" Version="14.5.8001">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>c56bd8c55918e84587e5712c197c2e98f26731be</Sha>
+      <Sha>64731f8c40752601abebe8eeaf334837344d679b</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.iOS.Sdk" Version="17.2.8079">
+    <Dependency Name="Microsoft.iOS.Sdk" Version="17.5.8001">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>c56bd8c55918e84587e5712c197c2e98f26731be</Sha>
+      <Sha>64731f8c40752601abebe8eeaf334837344d679b</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.tvOS.Sdk" Version="17.2.8079">
+    <Dependency Name="Microsoft.tvOS.Sdk" Version="17.5.8001">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>c56bd8c55918e84587e5712c197c2e98f26731be</Sha>
+      <Sha>64731f8c40752601abebe8eeaf334837344d679b</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.Workload.Emscripten.Current.Manifest-8.0.100" Version="8.0.3" CoherentParentDependency="Microsoft.NETCore.App.Ref">
       <Uri>https://github.com/dotnet/emsdk</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -28,21 +28,21 @@
       <Uri>https://github.com/xamarin/xamarin-android</Uri>
       <Sha>183b7f7688f6b3283256555f50eec38fc35ef6f6</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.MacCatalyst.Sdk" Version="17.5.8013">
+    <Dependency Name="Microsoft.MacCatalyst.Sdk" Version="17.5.8015">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>33099a60e30e4ef2d41be2c90a58da5e41e527d8</Sha>
+      <Sha>4916a01ad615a8ca892ca93442ef0ff547ae3ce9</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.macOS.Sdk" Version="14.5.8013">
+    <Dependency Name="Microsoft.macOS.Sdk" Version="14.5.8015">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>33099a60e30e4ef2d41be2c90a58da5e41e527d8</Sha>
+      <Sha>4916a01ad615a8ca892ca93442ef0ff547ae3ce9</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.iOS.Sdk" Version="17.5.8013">
+    <Dependency Name="Microsoft.iOS.Sdk" Version="17.5.8015">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>33099a60e30e4ef2d41be2c90a58da5e41e527d8</Sha>
+      <Sha>4916a01ad615a8ca892ca93442ef0ff547ae3ce9</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.tvOS.Sdk" Version="17.5.8013">
+    <Dependency Name="Microsoft.tvOS.Sdk" Version="17.5.8015">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>33099a60e30e4ef2d41be2c90a58da5e41e527d8</Sha>
+      <Sha>4916a01ad615a8ca892ca93442ef0ff547ae3ce9</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.Workload.Emscripten.Current.Manifest-8.0.100" Version="8.0.3" CoherentParentDependency="Microsoft.NETCore.App.Ref">
       <Uri>https://github.com/dotnet/emsdk</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -28,21 +28,21 @@
       <Uri>https://github.com/xamarin/xamarin-android</Uri>
       <Sha>183b7f7688f6b3283256555f50eec38fc35ef6f6</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.MacCatalyst.Sdk" Version="17.5.8007">
+    <Dependency Name="Microsoft.MacCatalyst.Sdk" Version="17.5.8013">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>500f632a392b152af9e54fb8b53800322d060260</Sha>
+      <Sha>33099a60e30e4ef2d41be2c90a58da5e41e527d8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.macOS.Sdk" Version="14.5.8007">
+    <Dependency Name="Microsoft.macOS.Sdk" Version="14.5.8013">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>500f632a392b152af9e54fb8b53800322d060260</Sha>
+      <Sha>33099a60e30e4ef2d41be2c90a58da5e41e527d8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.iOS.Sdk" Version="17.5.8007">
+    <Dependency Name="Microsoft.iOS.Sdk" Version="17.5.8013">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>500f632a392b152af9e54fb8b53800322d060260</Sha>
+      <Sha>33099a60e30e4ef2d41be2c90a58da5e41e527d8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.tvOS.Sdk" Version="17.5.8007">
+    <Dependency Name="Microsoft.tvOS.Sdk" Version="17.5.8013">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>500f632a392b152af9e54fb8b53800322d060260</Sha>
+      <Sha>33099a60e30e4ef2d41be2c90a58da5e41e527d8</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.Workload.Emscripten.Current.Manifest-8.0.100" Version="8.0.3" CoherentParentDependency="Microsoft.NETCore.App.Ref">
       <Uri>https://github.com/dotnet/emsdk</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -28,21 +28,21 @@
       <Uri>https://github.com/xamarin/xamarin-android</Uri>
       <Sha>183b7f7688f6b3283256555f50eec38fc35ef6f6</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.MacCatalyst.Sdk" Version="17.5.8016">
+    <Dependency Name="Microsoft.MacCatalyst.Sdk" Version="17.5.8018">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>e1cb86ebae0b6a071e5c4849a0955928a9bf5efe</Sha>
+      <Sha>271132311b14527ebda3026626d1f58abf26634e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.macOS.Sdk" Version="14.5.8016">
+    <Dependency Name="Microsoft.macOS.Sdk" Version="14.5.8018">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>e1cb86ebae0b6a071e5c4849a0955928a9bf5efe</Sha>
+      <Sha>271132311b14527ebda3026626d1f58abf26634e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.iOS.Sdk" Version="17.5.8016">
+    <Dependency Name="Microsoft.iOS.Sdk" Version="17.5.8018">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>e1cb86ebae0b6a071e5c4849a0955928a9bf5efe</Sha>
+      <Sha>271132311b14527ebda3026626d1f58abf26634e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.tvOS.Sdk" Version="17.5.8016">
+    <Dependency Name="Microsoft.tvOS.Sdk" Version="17.5.8018">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>e1cb86ebae0b6a071e5c4849a0955928a9bf5efe</Sha>
+      <Sha>271132311b14527ebda3026626d1f58abf26634e</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.Workload.Emscripten.Current.Manifest-8.0.100" Version="8.0.3" CoherentParentDependency="Microsoft.NETCore.App.Ref">
       <Uri>https://github.com/dotnet/emsdk</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -28,21 +28,21 @@
       <Uri>https://github.com/xamarin/xamarin-android</Uri>
       <Sha>183b7f7688f6b3283256555f50eec38fc35ef6f6</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.MacCatalyst.Sdk" Version="17.5.8001">
+    <Dependency Name="Microsoft.MacCatalyst.Sdk" Version="17.5.8007">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>64731f8c40752601abebe8eeaf334837344d679b</Sha>
+      <Sha>500f632a392b152af9e54fb8b53800322d060260</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.macOS.Sdk" Version="14.5.8001">
+    <Dependency Name="Microsoft.macOS.Sdk" Version="14.5.8007">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>64731f8c40752601abebe8eeaf334837344d679b</Sha>
+      <Sha>500f632a392b152af9e54fb8b53800322d060260</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.iOS.Sdk" Version="17.5.8001">
+    <Dependency Name="Microsoft.iOS.Sdk" Version="17.5.8007">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>64731f8c40752601abebe8eeaf334837344d679b</Sha>
+      <Sha>500f632a392b152af9e54fb8b53800322d060260</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.tvOS.Sdk" Version="17.5.8001">
+    <Dependency Name="Microsoft.tvOS.Sdk" Version="17.5.8007">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>64731f8c40752601abebe8eeaf334837344d679b</Sha>
+      <Sha>500f632a392b152af9e54fb8b53800322d060260</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.Workload.Emscripten.Current.Manifest-8.0.100" Version="8.0.3" CoherentParentDependency="Microsoft.NETCore.App.Ref">
       <Uri>https://github.com/dotnet/emsdk</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -28,21 +28,21 @@
       <Uri>https://github.com/xamarin/xamarin-android</Uri>
       <Sha>183b7f7688f6b3283256555f50eec38fc35ef6f6</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.MacCatalyst.Sdk" Version="17.5.8015">
+    <Dependency Name="Microsoft.MacCatalyst.Sdk" Version="17.5.8016">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>4916a01ad615a8ca892ca93442ef0ff547ae3ce9</Sha>
+      <Sha>e1cb86ebae0b6a071e5c4849a0955928a9bf5efe</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.macOS.Sdk" Version="14.5.8015">
+    <Dependency Name="Microsoft.macOS.Sdk" Version="14.5.8016">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>4916a01ad615a8ca892ca93442ef0ff547ae3ce9</Sha>
+      <Sha>e1cb86ebae0b6a071e5c4849a0955928a9bf5efe</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.iOS.Sdk" Version="17.5.8015">
+    <Dependency Name="Microsoft.iOS.Sdk" Version="17.5.8016">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>4916a01ad615a8ca892ca93442ef0ff547ae3ce9</Sha>
+      <Sha>e1cb86ebae0b6a071e5c4849a0955928a9bf5efe</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.tvOS.Sdk" Version="17.5.8015">
+    <Dependency Name="Microsoft.tvOS.Sdk" Version="17.5.8016">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>4916a01ad615a8ca892ca93442ef0ff547ae3ce9</Sha>
+      <Sha>e1cb86ebae0b6a071e5c4849a0955928a9bf5efe</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.Workload.Emscripten.Current.Manifest-8.0.100" Version="8.0.3" CoherentParentDependency="Microsoft.NETCore.App.Ref">
       <Uri>https://github.com/dotnet/emsdk</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -51,10 +51,10 @@
     <!-- xamarin/xamarin-android -->
     <MicrosoftAndroidSdkWindowsPackageVersion>34.0.113</MicrosoftAndroidSdkWindowsPackageVersion>
     <!-- xamarin/xamarin-macios -->
-    <MicrosoftMacCatalystSdkPackageVersion>17.2.8079</MicrosoftMacCatalystSdkPackageVersion>
-    <MicrosoftmacOSSdkPackageVersion>14.2.8079</MicrosoftmacOSSdkPackageVersion>
-    <MicrosoftiOSSdkPackageVersion>17.2.8079</MicrosoftiOSSdkPackageVersion>
-    <MicrosofttvOSSdkPackageVersion>17.2.8079</MicrosofttvOSSdkPackageVersion>
+    <MicrosoftMacCatalystSdkPackageVersion>17.5.8001</MicrosoftMacCatalystSdkPackageVersion>
+    <MicrosoftmacOSSdkPackageVersion>14.5.8001</MicrosoftmacOSSdkPackageVersion>
+    <MicrosoftiOSSdkPackageVersion>17.5.8001</MicrosoftiOSSdkPackageVersion>
+    <MicrosofttvOSSdkPackageVersion>17.5.8001</MicrosofttvOSSdkPackageVersion>
     <!-- Samsung/Tizen.NET -->
     <SamsungTizenSdkPackageVersion>8.0.130</SamsungTizenSdkPackageVersion>
     <!-- emsdk -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -51,10 +51,10 @@
     <!-- xamarin/xamarin-android -->
     <MicrosoftAndroidSdkWindowsPackageVersion>34.0.113</MicrosoftAndroidSdkWindowsPackageVersion>
     <!-- xamarin/xamarin-macios -->
-    <MicrosoftMacCatalystSdkPackageVersion>17.5.8007</MicrosoftMacCatalystSdkPackageVersion>
-    <MicrosoftmacOSSdkPackageVersion>14.5.8007</MicrosoftmacOSSdkPackageVersion>
-    <MicrosoftiOSSdkPackageVersion>17.5.8007</MicrosoftiOSSdkPackageVersion>
-    <MicrosofttvOSSdkPackageVersion>17.5.8007</MicrosofttvOSSdkPackageVersion>
+    <MicrosoftMacCatalystSdkPackageVersion>17.5.8013</MicrosoftMacCatalystSdkPackageVersion>
+    <MicrosoftmacOSSdkPackageVersion>14.5.8013</MicrosoftmacOSSdkPackageVersion>
+    <MicrosoftiOSSdkPackageVersion>17.5.8013</MicrosoftiOSSdkPackageVersion>
+    <MicrosofttvOSSdkPackageVersion>17.5.8013</MicrosofttvOSSdkPackageVersion>
     <!-- Samsung/Tizen.NET -->
     <SamsungTizenSdkPackageVersion>8.0.130</SamsungTizenSdkPackageVersion>
     <!-- emsdk -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -51,10 +51,10 @@
     <!-- xamarin/xamarin-android -->
     <MicrosoftAndroidSdkWindowsPackageVersion>34.0.113</MicrosoftAndroidSdkWindowsPackageVersion>
     <!-- xamarin/xamarin-macios -->
-    <MicrosoftMacCatalystSdkPackageVersion>17.5.8013</MicrosoftMacCatalystSdkPackageVersion>
-    <MicrosoftmacOSSdkPackageVersion>14.5.8013</MicrosoftmacOSSdkPackageVersion>
-    <MicrosoftiOSSdkPackageVersion>17.5.8013</MicrosoftiOSSdkPackageVersion>
-    <MicrosofttvOSSdkPackageVersion>17.5.8013</MicrosofttvOSSdkPackageVersion>
+    <MicrosoftMacCatalystSdkPackageVersion>17.5.8015</MicrosoftMacCatalystSdkPackageVersion>
+    <MicrosoftmacOSSdkPackageVersion>14.5.8015</MicrosoftmacOSSdkPackageVersion>
+    <MicrosoftiOSSdkPackageVersion>17.5.8015</MicrosoftiOSSdkPackageVersion>
+    <MicrosofttvOSSdkPackageVersion>17.5.8015</MicrosofttvOSSdkPackageVersion>
     <!-- Samsung/Tizen.NET -->
     <SamsungTizenSdkPackageVersion>8.0.130</SamsungTizenSdkPackageVersion>
     <!-- emsdk -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -51,10 +51,10 @@
     <!-- xamarin/xamarin-android -->
     <MicrosoftAndroidSdkWindowsPackageVersion>34.0.113</MicrosoftAndroidSdkWindowsPackageVersion>
     <!-- xamarin/xamarin-macios -->
-    <MicrosoftMacCatalystSdkPackageVersion>17.5.8015</MicrosoftMacCatalystSdkPackageVersion>
-    <MicrosoftmacOSSdkPackageVersion>14.5.8015</MicrosoftmacOSSdkPackageVersion>
-    <MicrosoftiOSSdkPackageVersion>17.5.8015</MicrosoftiOSSdkPackageVersion>
-    <MicrosofttvOSSdkPackageVersion>17.5.8015</MicrosofttvOSSdkPackageVersion>
+    <MicrosoftMacCatalystSdkPackageVersion>17.5.8016</MicrosoftMacCatalystSdkPackageVersion>
+    <MicrosoftmacOSSdkPackageVersion>14.5.8016</MicrosoftmacOSSdkPackageVersion>
+    <MicrosoftiOSSdkPackageVersion>17.5.8016</MicrosoftiOSSdkPackageVersion>
+    <MicrosofttvOSSdkPackageVersion>17.5.8016</MicrosofttvOSSdkPackageVersion>
     <!-- Samsung/Tizen.NET -->
     <SamsungTizenSdkPackageVersion>8.0.130</SamsungTizenSdkPackageVersion>
     <!-- emsdk -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -51,10 +51,10 @@
     <!-- xamarin/xamarin-android -->
     <MicrosoftAndroidSdkWindowsPackageVersion>34.0.113</MicrosoftAndroidSdkWindowsPackageVersion>
     <!-- xamarin/xamarin-macios -->
-    <MicrosoftMacCatalystSdkPackageVersion>17.5.8016</MicrosoftMacCatalystSdkPackageVersion>
-    <MicrosoftmacOSSdkPackageVersion>14.5.8016</MicrosoftmacOSSdkPackageVersion>
-    <MicrosoftiOSSdkPackageVersion>17.5.8016</MicrosoftiOSSdkPackageVersion>
-    <MicrosofttvOSSdkPackageVersion>17.5.8016</MicrosofttvOSSdkPackageVersion>
+    <MicrosoftMacCatalystSdkPackageVersion>17.5.8018</MicrosoftMacCatalystSdkPackageVersion>
+    <MicrosoftmacOSSdkPackageVersion>14.5.8018</MicrosoftmacOSSdkPackageVersion>
+    <MicrosoftiOSSdkPackageVersion>17.5.8018</MicrosoftiOSSdkPackageVersion>
+    <MicrosofttvOSSdkPackageVersion>17.5.8018</MicrosofttvOSSdkPackageVersion>
     <!-- Samsung/Tizen.NET -->
     <SamsungTizenSdkPackageVersion>8.0.130</SamsungTizenSdkPackageVersion>
     <!-- emsdk -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -51,10 +51,10 @@
     <!-- xamarin/xamarin-android -->
     <MicrosoftAndroidSdkWindowsPackageVersion>34.0.113</MicrosoftAndroidSdkWindowsPackageVersion>
     <!-- xamarin/xamarin-macios -->
-    <MicrosoftMacCatalystSdkPackageVersion>17.5.8001</MicrosoftMacCatalystSdkPackageVersion>
-    <MicrosoftmacOSSdkPackageVersion>14.5.8001</MicrosoftmacOSSdkPackageVersion>
-    <MicrosoftiOSSdkPackageVersion>17.5.8001</MicrosoftiOSSdkPackageVersion>
-    <MicrosofttvOSSdkPackageVersion>17.5.8001</MicrosofttvOSSdkPackageVersion>
+    <MicrosoftMacCatalystSdkPackageVersion>17.5.8007</MicrosoftMacCatalystSdkPackageVersion>
+    <MicrosoftmacOSSdkPackageVersion>14.5.8007</MicrosoftmacOSSdkPackageVersion>
+    <MicrosoftiOSSdkPackageVersion>17.5.8007</MicrosoftiOSSdkPackageVersion>
+    <MicrosofttvOSSdkPackageVersion>17.5.8007</MicrosofttvOSSdkPackageVersion>
     <!-- Samsung/Tizen.NET -->
     <SamsungTizenSdkPackageVersion>8.0.130</SamsungTizenSdkPackageVersion>
     <!-- emsdk -->

--- a/eng/pipelines/common/device-tests-steps.yml
+++ b/eng/pipelines/common/device-tests-steps.yml
@@ -11,9 +11,10 @@ parameters:
   checkoutDirectory: $(System.DefaultWorkingDirectory)
   useArtifacts: false
   rebootAgent: true
+  poolName: 'Azure Pipelines'
 
 steps:
-  - ${{ if eq(parameters.platform, 'ios')}}:
+  - ${{ if and(eq(parameters.platform, 'ios'), ne(parameters.poolName, 'Azure Pipelines')) }}:
     - bash: |
         chmod +x $(System.DefaultWorkingDirectory)/eng/scripts/clean-bot.sh
         chmod +x $(System.DefaultWorkingDirectory)/eng/scripts/clean-simulator-runtime.sh
@@ -29,9 +30,8 @@ steps:
         platform: macos
       skipXcode: ${{ or(eq(parameters.platform, 'android'), eq(parameters.platform, 'windows')) }}
       skipProvisioning: ${{ eq(parameters.platform, 'windows') }}
-      ${{ if eq(parameters.platform, 'ios')}}:
-        skipAndroidSdks: false
-        skipAndroidImages: true
+      skipAndroidImages : ${{ eq(parameters.platform, 'ios') }}
+      skipAndroidSdks: ${{ eq(parameters.platform, 'ios') }}
       provisionatorChannel: ${{ parameters.provisionatorChannel }}
 
   - pwsh: ./build.ps1 --target=dotnet --configuration="Release" --verbosity=diagnostic
@@ -120,15 +120,6 @@ steps:
       condition: always()
       continueOnError: true
 
-
-  - ${{ if eq(parameters.platform, 'ios')}}:
-    - bash: |
-        zip -9r "$(LogDirectory)/CoreSimulatorLog.zip" "$HOME/Library/Logs/CoreSimulator/"
-        zip -9r "$(LogDirectory)/DiagnosticReports.zip" "$HOME/Library/Logs/DiagnosticReports/"
-      displayName: Zip Simulator Logs
-      condition: always()
-      continueOnError: true
-
   - task: PublishTestResults@2
     displayName: Publish the $(Agent.JobName) test results
     condition: always()
@@ -143,7 +134,7 @@ steps:
     inputs:
       artifactName: '$(Agent.JobName) (attempt $(System.JobAttempt))'
 
-  - ${{ if eq(parameters.rebootAgent, true) }}:
+  - ${{ if and(eq(parameters.platform, 'ios'), ne(parameters.poolName, 'Azure Pipelines')) }}:
     # This must always be placed as the last step in the job
     - template: agent-rebooter/mac.v1.yml@yaml-templates
       parameters:

--- a/eng/pipelines/common/device-tests.yml
+++ b/eng/pipelines/common/device-tests.yml
@@ -61,6 +61,7 @@ stages:
             artifactItemPattern: ${{ parameters.artifactItemPattern }}
             checkoutDirectory: ${{ parameters.checkoutDirectory }}
             useArtifacts: ${{ parameters.useArtifacts }}
+            poolName: ${{ parameters.androidPool.name }}
 
   - stage: ios_device_tests
     displayName: iOS Device Tests
@@ -102,6 +103,7 @@ stages:
             artifactItemPattern: ${{ parameters.artifactItemPattern }}
             checkoutDirectory: ${{ parameters.checkoutDirectory }}
             useArtifacts: ${{ parameters.useArtifacts }}
+            poolName: 'Azure Pipelines'
 
   - stage: catalyst_device_tests
     displayName: macOS Device Tests
@@ -141,6 +143,8 @@ stages:
             artifactItemPattern: ${{ parameters.artifactItemPattern }}
             checkoutDirectory: ${{ parameters.checkoutDirectory }}
             useArtifacts: ${{ parameters.useArtifacts }}
+            poolName: 'Azure Pipelines'
+
 
   - stage: windows_device_tests
     displayName: Windows Device Tests

--- a/eng/pipelines/common/maui-templates.yml
+++ b/eng/pipelines/common/maui-templates.yml
@@ -36,14 +36,14 @@ parameters:
     - name: $(androidTestsVmPool)
       vmImage: $(androidTestsVmImage)
       demands:
-        - macOS.Name -equals Ventura
+        - macOS.Name -equals Sonoma
         - macOS.Architecture -equals x64
       testName: RunOnAndroid
       artifact: templates-run-android
     - name: $(iosTestsVmPool)
       vmImage: $(iosTestsVmImage)
       demands:
-        - macOS.Name -equals Ventura
+        - macOS.Name -equals Sonoma
         - macOS.Architecture -equals x64
       testName: RunOniOS
       artifact: templates-run-ios
@@ -71,7 +71,7 @@ jobs:
     name: $(POOL_NAME)
     vmImage: $(POOL_VIMAGE)
     demands:
-      - macOS.Name -equals Ventura
+      - macOS.Name -equals Sonoma
       - macOS.Architecture -equals x64
   steps:
 

--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -15,14 +15,15 @@ parameters:
 
 steps:
   # Prepare macOS
-  - template: agent-cleanser/v1.yml@yaml-templates
-    parameters:
-      condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
-      UninstallMono: false
-      UninstallXamarinMac: false
-      CleanseAgentToolsDotNet: true           # Cleanse all .NET versions under the agent tools directory and use only those provisioned by the pipeline
-      SelfHealPowerShell: false
-      AUTH_TOKEN_GITHUB_COM: $(github--pat--vs-mobiletools-engineering-service2)
+  - ${{ if ne(parameters.poolName, 'Azure Pipelines') }}:
+    - template: agent-cleanser/v1.yml@yaml-templates
+      parameters:
+        condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
+        UninstallMono: false
+        UninstallXamarinMac: false
+        CleanseAgentToolsDotNet: true           # Cleanse all .NET versions under the agent tools directory and use only those provisioned by the pipeline
+        SelfHealPowerShell: false
+        AUTH_TOKEN_GITHUB_COM: $(github--pat--vs-mobiletools-engineering-service2)
   # Provision Xcode
   - ${{ if ne(parameters.skipXcode, 'true') }}:
     - task: xamops.azdevex.provisionator-task.provisionator@2
@@ -148,15 +149,3 @@ steps:
         arguments: -ConfigFile $(System.DefaultWorkingDirectory)/NuGet.config -Password $Env:Token
       env:
         Token: $(dn-bot-dnceng-artifact-feeds-rw) 
-  # Prepare for Reunion packages
-  # - ${{ if eq(variables['System.TeamProject'], 'devdiv') }}:
-  #   - task: NuGetAuthenticate@0
-  #     displayName: 'Authenticate Reunion NuGet sources'
-  #     inputs:
-  #       nuGetServiceConnections: Project.Reunion.nuget.internal
-  #   - pwsh: |
-  #       $path = '$(Build.SourcesDirectory)\NuGet.config'
-  #       [xml]$xml = Get-Content $path
-  #       $xml.configuration.RemoveChild($xml.configuration.disabledPackageSources)
-  #       $xml.Save($path)
-  #     displayName: 'Add "wasdk-internal" to NuGet.config'

--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -8,9 +8,9 @@ variables:
 - name: DOTNET_VERSION
   value: 8.0.300
 - name: REQUIRED_XCODE
-  value: 15.2.0
+  value: 15.4.0
 - name: DEVICETESTS_REQUIRED_XCODE
-  value: 15.2.0
+  value: 15.4.0
 - name: LocBranchPrefix
   value: 'loc-hb'
 - name: isMainBranch

--- a/eng/pipelines/device-tests.yml
+++ b/eng/pipelines/device-tests.yml
@@ -69,17 +69,14 @@ parameters:
   - name: iosPool
     type: object
     default:
-      name: $(iosTestsVmPool)
-      vmImage: $(iosTestsVmImage)
-      demands:
-        - macOS.Name -equals Ventura
-        - macOS.Architecture -equals x64
+      name: $(macosTestsVmPool)
+      vmImage: macOS-14
 
   - name: catalystPool
     type: object
     default:
       name: $(macosTestsVmPool)
-      vmImage: $(macosTestsVmImage)
+      vmImage: macOS-14
 
   - name: windowsPool
     type: object

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -101,14 +101,14 @@ parameters:
     - name: $(androidTestsVmPool)
       vmImage: $(androidTestsVmImage)
       demands:
-        - macOS.Name -equals Ventura
+        - macOS.Name -equals Sonoma
         - macOS.Architecture -equals x64
       testName: RunOnAndroid
       artifact: templates-run-android
     - name: $(iosTestsVmPool)
       vmImage: $(iosTestsVmImage)
       demands:
-        - macOS.Name -equals Ventura
+        - macOS.Name -equals Sonoma
         - macOS.Architecture -equals x64
       testName: RunOniOS
       artifact: templates-run-ios
@@ -155,7 +155,7 @@ stages:
               name: ${{ BuildPlatform.poolName }}
               vmImage: ${{ BuildPlatform.vmImage }}
               demands:
-                - macOS.Name -equals Ventura
+                - macOS.Name -equals Sonoma
                 - macOS.Architecture -equals x64
             steps:
               - template: common/provision.yml
@@ -197,7 +197,7 @@ stages:
             name: ${{ PackPlatform.poolName }}
             vmImage: ${{ PackPlatform.vmImage }}
             demands:
-              - macOS.Name -equals Ventura
+              - macOS.Name -equals Sonoma
               - macOS.Architecture -equals x64
           variables:
             - name: _buildScript
@@ -245,7 +245,7 @@ stages:
             name: ${{ BuildPlatform.poolName }}
             vmImage: ${{ BuildPlatform.vmImage }}
             demands:
-              - macOS.Name -equals Ventura
+              - macOS.Name -equals Sonoma
               - macOS.Architecture -equals x64
           steps:
             - template: common/provision.yml

--- a/eng/pipelines/ui-tests.yml
+++ b/eng/pipelines/ui-tests.yml
@@ -67,7 +67,7 @@ parameters:
       name: $(androidTestsVmPool)
       vmImage: $(androidTestsVmImage)
       demands:
-        - macOS.Name -equals Ventura
+        - macOS.Name -equals Sonoma
         - macOS.Architecture -equals x64
 
   - name: iosPool
@@ -76,7 +76,7 @@ parameters:
       name: $(iosTestsVmPool)
       vmImage: $(iosTestsVmImage)
       demands:
-        - macOS.Name -equals Ventura
+        - macOS.Name -equals Sonoma
         - macOS.Architecture -equals x64
   
   - name: windowsPool
@@ -89,7 +89,7 @@ parameters:
     type: object
     default:
       name: $(macosTestsVmPool)
-      vmImage: $(macosTestsVmImage)
+      vmImage: macOS-14
 
   - name: androidCompatibilityPool
     type: object
@@ -97,7 +97,7 @@ parameters:
       name: $(androidTestsVmPool)
       vmImage: $(androidTestsVmImage)
       demands:
-        - macOS.Name -equals Ventura
+        - macOS.Name -equals Sonoma
         - macOS.Architecture -equals x64
 
   - name: iosCompatibilityPool
@@ -106,7 +106,7 @@ parameters:
       name: $(androidTestsVmPool)
       vmImage: $(androidTestsVmImage)
       demands:
-        - macOS.Name -equals Ventura
+        - macOS.Name -equals Sonoma
         - macOS.Architecture -equals x64
 
 resources:

--- a/src/Core/src/Platform/iOS/LabelExtensions.cs
+++ b/src/Core/src/Platform/iOS/LabelExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using Foundation;
 using Microsoft.Maui.Graphics;
 using ObjCRuntime;
@@ -77,12 +78,19 @@ namespace Microsoft.Maui.Platform
 		{
 			string text = label.Text ?? string.Empty;
 
+#if NET8_0
+			var attr = new NSAttributedStringDocumentAttributes
+			{
+				DocumentType = NSDocumentType.HTML,
+				CharacterEncoding = NSStringEncoding.UTF8
+			};
+#else
 			var attr = new NSAttributedStringDocumentAttributes
 			{
 				DocumentType = NSDocumentType.HTML,
 				StringEncoding = NSStringEncoding.UTF8
 			};
-
+#endif
 			NSError nsError = new();
 #pragma warning disable CS8601
 			platformLabel.AttributedText = new NSAttributedString(text, attr, ref nsError);

--- a/src/Essentials/src/Connectivity/Connectivity.ios.tvos.macos.reachability.cs
+++ b/src/Essentials/src/Connectivity/Connectivity.ios.tvos.macos.reachability.cs
@@ -142,6 +142,7 @@ namespace Microsoft.Maui.Networking
 		{
 			var ip = new IPAddress(0);
 			defaultRouteReachability = new NetworkReachability(ip);
+#pragma warning disable CA1422 // Validate platform compatibility
 			defaultRouteReachability.SetNotification(OnChange);
 			defaultRouteReachability.Schedule(CFRunLoop.Main, CFRunLoop.ModeDefault);
 
@@ -153,6 +154,7 @@ namespace Microsoft.Maui.Networking
 
 			remoteHostReachability.SetNotification(OnChange);
 			remoteHostReachability.Schedule(CFRunLoop.Main, CFRunLoop.ModeDefault);
+#pragma warning restore CA1422 // Validate platform compatibility
 
 #if !(MACCATALYST || MACOS)
 #pragma warning disable BI1234, CA1416 // Analyzer bug https://github.com/dotnet/roslyn-analyzers/issues/5938

--- a/src/Essentials/src/HapticFeedback/HapticFeedback.ios.cs
+++ b/src/Essentials/src/HapticFeedback/HapticFeedback.ios.cs
@@ -1,3 +1,4 @@
+using System;
 using UIKit;
 
 namespace Microsoft.Maui.Devices
@@ -21,7 +22,19 @@ namespace Microsoft.Maui.Devices
 
 		void Click()
 		{
-			var impact = new UIImpactFeedbackGenerator(UIImpactFeedbackStyle.Light);
+			UIImpactFeedbackGenerator impact;
+#if NET8_0
+			if (OperatingSystem.IsIOSVersionAtLeast(17, 4) || OperatingSystem.IsMacCatalystVersionAtLeast(17, 4))
+			{
+				impact = UIImpactFeedbackGenerator.GetFeedbackGenerator(UIImpactFeedbackStyle.Light, new UIView());
+			}
+			else
+			{
+				impact = new UIImpactFeedbackGenerator(UIImpactFeedbackStyle.Light);
+			}
+#else
+				impact = new UIImpactFeedbackGenerator(UIImpactFeedbackStyle.Light);
+#endif
 			impact.Prepare();
 			impact.ImpactOccurred();
 			impact.Dispose();
@@ -29,7 +42,20 @@ namespace Microsoft.Maui.Devices
 
 		void LongPress()
 		{
-			var impact = new UIImpactFeedbackGenerator(UIImpactFeedbackStyle.Medium);
+			UIImpactFeedbackGenerator impact;
+
+#if NET8_0
+			if (OperatingSystem.IsIOSVersionAtLeast(17, 4) || OperatingSystem.IsMacCatalystVersionAtLeast(17, 4))
+			{
+				impact = UIImpactFeedbackGenerator.GetFeedbackGenerator(UIImpactFeedbackStyle.Medium, new UIView());
+			}
+			else
+			{
+				impact = new UIImpactFeedbackGenerator(UIImpactFeedbackStyle.Medium);
+			}
+#else
+		impact = new UIImpactFeedbackGenerator(UIImpactFeedbackStyle.Medium);
+#endif
 			impact.Prepare();
 			impact.ImpactOccurred();
 			impact.Dispose();

--- a/src/Essentials/src/WebAuthenticator/WebAuthenticator.ios.tvos.cs
+++ b/src/Essentials/src/WebAuthenticator/WebAuthenticator.ios.tvos.cs
@@ -70,10 +70,24 @@ namespace Microsoft.Maui.Authentication
 				sf = null;
 			}
 
+
 			if (OperatingSystem.IsIOSVersionAtLeast(12))
 			{
+#if NET8_0
+				if (OperatingSystem.IsIOSVersionAtLeast(17, 4) || OperatingSystem.IsMacCatalystVersionAtLeast(17, 4))
+				{
+					// Use the new ASWebAuthenticationSession constructor with ASWebAuthenticationSessionCallback overload
+					var callback = ASWebAuthenticationSessionCallback.Create(scheme);
+					was = new ASWebAuthenticationSession(WebUtils.GetNativeUrl(url), callback, AuthSessionCallback);
+				}
+				else
+				{
+					// Fallback to the original ASWebAuthenticationSession constructor for iOS versions below 17.4
+					was = new ASWebAuthenticationSession(WebUtils.GetNativeUrl(url), scheme, AuthSessionCallback);
+				}
+#else
 				was = new ASWebAuthenticationSession(WebUtils.GetNativeUrl(url), scheme, AuthSessionCallback);
-
+#endif
 				if (OperatingSystem.IsIOSVersionAtLeast(13))
 				{
 					var ctx = new ContextProvider(WindowStateManager.Default.GetCurrentUIWindow());

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/BuildWarningsUtilities.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/BuildWarningsUtilities.cs
@@ -125,21 +125,6 @@ namespace Microsoft.Maui.IntegrationTests
 		{
 			new WarningsPerFile
 			{
-				File = "ILC",
-				WarningsPerCode = new List<WarningsPerCode>
-				{
-					new WarningsPerCode
-					{
-						Code = "IL3050",
-						Messages = new List<string>
-						{
-							"<Module>..cctor(): Using member 'System.Enum.GetValues(Type)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling. It might not be possible to create an array of the enum type at runtime. Use the GetValues<TEnum> overload or the GetValuesAsUnderlyingType method instead.",
-						}
-					},
-				}
-			},
-			new WarningsPerFile
-			{
 				File = "src/Controls/src/Xaml/XamlParser.cs",
 				WarningsPerCode = new List<WarningsPerCode>
 				{


### PR DESCRIPTION
### Description of Change

Updates the net8 branch to new iOS API for Xcode 15.4.

(replaces https://github.com/dotnet/maui/pull/23629)

This pull request introduces changes to several files to update dependencies, modify pipeline configurations, and improve compatibility with newer versions of iOS. The most significant changes include the update of the `Microsoft.MacCatalyst.Sdk`, `Microsoft.macOS.Sdk`, `Microsoft.iOS.Sdk`, and `Microsoft.tvOS.Sdk` dependencies, the addition of the `poolName` parameter in the `device-tests-steps.yml` file, and the use of the `OperatingSystem.IsIOSVersionAtLeast` method in the `HapticFeedback.ios.cs` and `WebAuthenticator.ios.tvos.cs` files to improve compatibility with iOS 17.4 and later.

Dependency updates:

* `eng/Version.Details.xml` and `eng/Versions.props`: Updated the `Microsoft.MacCatalyst.Sdk`, `Microsoft.macOS.Sdk`, `Microsoft.iOS.Sdk`, and `Microsoft.tvOS.Sdk` dependencies to version 17.5.8001.

Pipeline configuration modifications:

* [`eng/pipelines/common/device-tests-steps.yml`](diffhunk://#diff-b69b78f4a2fcf116ee0e1d0bfc8ffa31a05469eb6a3585e486af367aeddf498bR14-R17): Added the `poolName` parameter and modified several conditions and steps to use this new parameter. [[1]](diffhunk://#diff-b69b78f4a2fcf116ee0e1d0bfc8ffa31a05469eb6a3585e486af367aeddf498bR14-R17) [[2]](diffhunk://#diff-b69b78f4a2fcf116ee0e1d0bfc8ffa31a05469eb6a3585e486af367aeddf498bL32-R34) [[3]](diffhunk://#diff-b69b78f4a2fcf116ee0e1d0bfc8ffa31a05469eb6a3585e486af367aeddf498bL123-L131) [[4]](diffhunk://#diff-b69b78f4a2fcf116ee0e1d0bfc8ffa31a05469eb6a3585e486af367aeddf498bL146-R137)
* [`eng/pipelines/common/device-tests.yml`](diffhunk://#diff-7338096e4bae3a6a64beb70cc5bd2ff68bd18b5e36c49f61a58e52bdc19813c5R64): Added the `poolName` parameter to the `stages` section. [[1]](diffhunk://#diff-7338096e4bae3a6a64beb70cc5bd2ff68bd18b5e36c49f61a58e52bdc19813c5R64) [[2]](diffhunk://#diff-7338096e4bae3a6a64beb70cc5bd2ff68bd18b5e36c49f61a58e52bdc19813c5R106) [[3]](diffhunk://#diff-7338096e4bae3a6a64beb70cc5bd2ff68bd18b5e36c49f61a58e52bdc19813c5R146-R147)

Compatibility improvements:

* [`src/Core/src/Platform/iOS/LabelExtensions.cs`](diffhunk://#diff-68bac607e5744341431cc8cd0d49a6f4dcf7989de9fda9fa88edcc1287ab72deR1): Modified the `UpdateTextHtml` method to use a different `NSAttributedStringDocumentAttributes` constructor for iOS 17.4 and later. [[1]](diffhunk://#diff-68bac607e5744341431cc8cd0d49a6f4dcf7989de9fda9fa88edcc1287ab72deR1) [[2]](diffhunk://#diff-68bac607e5744341431cc8cd0d49a6f4dcf7989de9fda9fa88edcc1287ab72deR81-R93)
* [`src/Essentials/src/HapticFeedback/HapticFeedback.ios.cs`](diffhunk://#diff-1d4e89a060bb1701bd744819b6a63d518137954eabd89c5a4e28b7a3ef327b03R1): Used the `OperatingSystem.IsIOSVersionAtLeast` method to call a different `UIImpactFeedbackGenerator` constructor for iOS 17.4 and later. [[1]](diffhunk://#diff-1d4e89a060bb1701bd744819b6a63d518137954eabd89c5a4e28b7a3ef327b03R1) [[2]](diffhunk://#diff-1d4e89a060bb1701bd744819b6a63d518137954eabd89c5a4e28b7a3ef327b03L24-R58)
* [`src/Essentials/src/WebAuthenticator/WebAuthenticator.ios.tvos.cs`](diffhunk://#diff-6860adedd9d92c5f06c352e8560740a15f2e60cd2b20f77dfdfc535f16dd17d0R73-R90): Used the `OperatingSystem.IsIOSVersionAtLeast` method to call a different `ASWebAuthenticationSession` constructor for iOS 17.4 and later.