### PR TITLE
[ci] Use drop service for SDK insertion artifacts

### DIFF
--- a/eng/pipelines/common/sdk-insertion.yml
+++ b/eng/pipelines/common/sdk-insertion.yml
@@ -5,10 +5,11 @@ parameters:
   pushMauiPackagesToMaestro: false
   nugetArtifactName: nuget-signed
   nugetArtifactPath: $(Build.StagingDirectory)\nuget-signed
+  dropRetentionDays: 90
 
 jobs:
 - job: create_artifact_statuses
-  displayName: Create GitHub Artifact Status and Push to Maestro
+  displayName: Publish symbols and Push to Maestro
   timeoutInMinutes: 60
   pool:
     name: ${{ parameters.poolName }}
@@ -16,55 +17,48 @@ jobs:
     os: ${{ parameters.os }}
   variables:
   - group: Publish-Build-Assets
+  templateContext:
+    outputs:
+    - output: artifactsDrop
+      dropServiceURI: https://devdiv.artifacts.visualstudio.com/DefaultCollection
+      buildNumber: $(ReleaseDropPrefix)/symbols
+      dropMetadataContainerName: DropMetadata-$(Build.BuildId)-symbols-$(System.JobAttempt)
+      sourcePath: $(Build.StagingDirectory)\symbols
+      retentionDays: ${{ parameters.dropRetentionDays }}
+      toLowerCase: false
   steps:
   - checkout: self
+
+  # Download symbols to be published to the symbols artifact drop declared above
   - task: DownloadPipelineArtifact@2
     inputs:
       artifactName: ${{ parameters.nugetArtifactName }}
-      downloadPath: ${{ parameters.nugetArtifactPath }}
+      downloadPath: $(Build.StagingDirectory)\symbols
       patterns: |
-        *.nupkg
         **/*.snupkg
         **/additional-assets.zip
+    displayName: Download symbols
+
   - task: DownloadPipelineArtifact@2
     inputs:
-      artifactName: vs-msi-nugets
-      downloadPath: ${{ parameters.nugetArtifactPath }}
-  - template: templates\common\upload-vs-insertion-artifacts.yml@sdk-insertions
-    parameters:
-      githubToken: $(github--pat--vs-mobiletools-engineering-service2)
-      githubContext: $(NupkgCommitStatusName)
-      blobName: $(NupkgCommitStatusName)
-      packagePrefix: maui
-      artifactsPath: ${{ parameters.nugetArtifactPath }}
-      yamlResourceName: yaml-templates
-  - template: templates\common\upload-vs-insertion-artifacts.yml@sdk-insertions
-    parameters:
-      githubToken: $(github--pat--vs-mobiletools-engineering-service2)
-      githubContext: $(VSDropCommitStatusName)
-      blobName: $(VSDropCommitStatusName)
-      packagePrefix: maui
-      artifactsPath: $(Build.StagingDirectory)/$(VSDropCommitStatusName)
-      yamlResourceName: yaml-templates
-      downloadSteps:
-      - task: DownloadPipelineArtifact@2
-        inputs:
-          artifactName: vsdrop-signed
-          downloadPath: $(Build.StagingDirectory)/$(VSDropCommitStatusName)
-  - template: templates\common\upload-vs-insertion-artifacts.yml@sdk-insertions
-    parameters:
-      githubToken: $(github--pat--vs-mobiletools-engineering-service2)
-      githubContext: $(MultiTargetVSDropCommitStatusName)
-      blobName: $(MultiTargetVSDropCommitStatusName)
-      packagePrefix: maui
-      artifactsPath: $(Build.StagingDirectory)/$(MultiTargetVSDropCommitStatusName)
-      yamlResourceName: yaml-templates
-      downloadSteps:
-      - task: DownloadPipelineArtifact@2
-        inputs:
-          artifactName: vsdrop-multitarget-signed
-          downloadPath: $(Build.StagingDirectory)/$(MultiTargetVSDropCommitStatusName)
-  
+      artifactName: DropMetadata-$(Build.BuildId)-nugets-$(System.JobAttempt)
+      downloadPath: $(Build.StagingDirectory)\metadata
+    displayName: Download nugets drop metadata
+
+  - powershell: |
+      $jsonContent = Get-Content -Path "$(Build.StagingDirectory)\metadata\VSTSDrop.json" -Raw | ConvertFrom-Json
+      $dropPrefix = $jsonContent.VstsDropBuildArtifact.VstsDropUrl -replace 'https://devdiv.artifacts.visualstudio.com/DefaultCollection/_apis/drop/drops/' -replace '/nugets'
+      Write-Host "##vso[task.setvariable variable=ReleaseDropPrefix]$dropPrefix"
+    displayName: Set variable ReleaseDropPrefix
+
+  # Download nugets drop created by nuget-msi-convert/job/v4.yml and publish to maestro
+  - task: ms-vscs-artifact.build-tasks.artifactDropDownloadTask-1.artifactDropDownloadTask@1
+    displayName: Download $(ReleaseDropPrefix)/nugets
+    inputs:
+      dropServiceURI: https://devdiv.artifacts.visualstudio.com/DefaultCollection
+      buildNumber: $(ReleaseDropPrefix)/nugets
+      destinationPath: ${{ parameters.nugetArtifactPath }}
+
   - task: UseDotNet@2                 # https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/tool/dotnet-core-tool-installer?view=azure-devops
     displayName: 'Use .NET SDK $(DOTNET_VERSION)'
     inputs:
@@ -80,9 +74,10 @@ jobs:
         -t:PushManifestToBuildAssetRegistry
         -p:OfficialBuildId=$(_BuildOfficalId)
         -p:BuildAssetRegistryToken=$(MaestroAccessToken)
-        -p:OutputPath=$(Build.StagingDirectory)\nuget-signed\
+        -p:OutputPath=${{ parameters.nugetArtifactPath }}
         -v:n -bl:$(Build.StagingDirectory)\binlogs\push-bar-manifest.binlog
     condition: and(succeeded(), eq('${{ parameters.pushMauiPackagesToMaestro }}', 'true'))
+
   - powershell: |
       $versionEndpoint = 'https://maestro.dot.net/api/assets/darc-version?api-version=2019-01-16'
       $darcVersion = $(Invoke-WebRequest -Uri $versionEndpoint -UseBasicParsing).Content

--- a/eng/pipelines/common/sdk-insertion.yml
+++ b/eng/pipelines/common/sdk-insertion.yml
@@ -5,7 +5,7 @@ parameters:
   pushMauiPackagesToMaestro: false
   nugetArtifactName: nuget-signed
   nugetArtifactPath: $(Build.StagingDirectory)\nuget-signed
-  dropRetentionDays: 90
+  dropRetentionDays: 120
 
 jobs:
 - job: create_artifact_statuses

--- a/eng/pipelines/common/sdk-insertion.yml
+++ b/eng/pipelines/common/sdk-insertion.yml
@@ -32,7 +32,7 @@ jobs:
   # Download symbols to be published to the symbols artifact drop declared above
   - task: DownloadPipelineArtifact@2
     inputs:
-      artifactName: ${{ parameters.nugetArtifactName }}
+      artifactName: nuget
       downloadPath: $(Build.StagingDirectory)\symbols
       patterns: |
         **/*.snupkg

--- a/eng/pipelines/common/sign.yml
+++ b/eng/pipelines/common/sign.yml
@@ -22,7 +22,7 @@ stages:
           use1ESTemplate: true
           usePipelineArtifactTasks: true
         
-      - template: nuget-msi-convert/job/v3.yml@yaml-templates
+      - template: nuget-msi-convert/job/v4.yml@yaml-templates
         parameters:
           yamlResourceName: yaml-templates
           artifactName: nuget-signed

--- a/eng/pipelines/common/sign.yml
+++ b/eng/pipelines/common/sign.yml
@@ -42,7 +42,7 @@ stages:
             inputs:
               TargetFolders: |
                 $(Build.ArtifactStagingDirectory)\bin\manifests
-                $(Build.ArtifactStagingDirectory)\bin\manifests-multitarget
+                $(Build.ArtifactStagingDirectory)\bin\manifests-packs
                 $(Build.ArtifactStagingDirectory)\bin\msi-nupkgs
               ExcludeSNVerify: true
               ApprovalListPathForCerts: $(Build.ArtifactStagingDirectory)\sign-verify\SignVerifyIgnore.txt

--- a/eng/pipelines/maui-release.yml
+++ b/eng/pipelines/maui-release.yml
@@ -60,7 +60,7 @@ resources:
       type: github
       name: xamarin/yaml-templates
       endpoint: xamarin
-      ref: refs/heads/main
+      ref: refs/heads/dev/pjc/v4drop-metadata
     - repository: sdk-insertions
       type: github
       name: xamarin/sdk-insertions

--- a/eng/pipelines/maui-release.yml
+++ b/eng/pipelines/maui-release.yml
@@ -60,7 +60,7 @@ resources:
       type: github
       name: xamarin/yaml-templates
       endpoint: xamarin
-      ref: refs/heads/dev/pjc/v4drop-metadata
+      ref: refs/heads/main
     - repository: sdk-insertions
       type: github
       name: xamarin/sdk-insertions


### PR DESCRIPTION
Context: xamarin/yaml-templates@8759ec9

Steps to upload release artifacts to custom blob storage have been
replaced with azure-artifacts-drop (aka.ms/drop).

A new version of nuget-msi-convert has been added that will create a set
of artifact drops for the following shipping artifacts:
  * nugets
  * vs-components
  * vs-packs

The nugets drop contains all shipping packages that should be pushed to
various feeds or NuGet.org.

The components and packs drops are used for VS insertions.