### PR TITLE
[ci] Fix maestro publishing for stable packages

### DIFF
--- a/src/Workload/Shared/Maestro.targets
+++ b/src/Workload/Shared/Maestro.targets
@@ -40,6 +40,7 @@
 
     <PushToBuildStorage
         ItemsToPush="@(ItemsToPush)"
+        IsStableBuild="$(StabilizePackageVersion)"
         ManifestBuildData="@(ManifestBuildData)"
         ManifestRepoUri="$(BUILD_REPOSITORY_NAME)"
         ManifestBranch="$(BUILD_SOURCEBRANCH)"


### PR DESCRIPTION
We've seen the build promotion pipeline fail when trying to publish
stable package versions:

    error : Package 'Microsoft.AspNetCore.Components.WebView.Maui' has stable version '8.0.60' but is targeted at a non-isolated feed 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json'

This is because we were not declaring these packages as stable when
building the build asset registry manifest.

Fix this by passing the `$(StabilizePackageVersion)` [property][0] to the
build asset manifest creation task. This property needs to be updated
manually when switching to stable package versioning (see b956220bff).

When `$(StabilizePackageVersion)` is set to true, packages will be
pushed to an isolated feed during publishing, such as:

    Package Microsoft.Android.Ref.34@34.0.125 (Shipping) should go to https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-android-b8317b6f/nuget/v3/index.json (Isolated, Public)

[0]: https://github.com/dotnet/maui/blob/eb9b5513920b054189a4d7b04943a1fa27963249/eng/Versions.props#L14