### PR TITLE
[android] improve performance of `ImageHandler.PlatformArrange()`

### DIFF
--- a/eng/BannedSymbols.txt
+++ b/eng/BannedSymbols.txt
@@ -1,5 +1,6 @@
 M:Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddSingleton`2(Microsoft.Extensions.DependencyInjection.IServiceCollection);Use a Factory method to create the service instead
 M:Android.Content.Res.ColorStateList.#ctor(System.Int32[][],System.Int32[]);Use Microsoft.Maui.PlatformInterop.Get*ColorStateList() Java methods instead
+M:Android.Widget.ImageView.GetScaleType();Use PlatformInterop.IsImageViewCenterCrop instead (or add a new method)
 P:Microsoft.Maui.MauiWinUIApplication.Services;Use the IPlatformApplication.Current.Services instead
 P:Microsoft.Maui.MauiWinUIApplication.Application;Use the IPlatformApplication.Current.Application instead
 P:Microsoft.UI.Xaml.Window.AppWindow;This API doesn't have null safety. Use GetAppWindow() and make sure to account for the possibility that GetAppWindow() might be null.

--- a/src/Compatibility/Core/src/Android/FastRenderers/ImageElementManager.cs
+++ b/src/Compatibility/Core/src/Android/FastRenderers/ImageElementManager.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.FastRenderers
 		{
 			if (sender is IVisualElementRenderer renderer && renderer.View is ImageView imageView)
 #pragma warning disable CS0618 // Obsolete
-				AViewCompat.SetClipBounds(imageView, imageView.GetScaleType() == AScaleType.CenterCrop ? new ARect(0, 0, e.Right - e.Left, e.Bottom - e.Top) : null);
+				AViewCompat.SetClipBounds(imageView, PlatformInterop.IsImageViewCenterCrop(imageView) ? new ARect(0, 0, e.Right - e.Left, e.Bottom - e.Top) : null);
 #pragma warning restore CS0618 // Obsolete
 
 		}

--- a/src/Controls/tests/DeviceTests/Controls.DeviceTests.csproj
+++ b/src/Controls/tests/DeviceTests/Controls.DeviceTests.csproj
@@ -7,6 +7,7 @@
     <RootNamespace>Microsoft.Maui.DeviceTests</RootNamespace>
     <AssemblyName>Microsoft.Maui.Controls.DeviceTests</AssemblyName>
     <NoWarn>$(NoWarn),CA1416</NoWarn>
+    <IsTestProject>true</IsTestProject>
     <!-- Disable multi-RID builds to workaround a parallel build issue -->
     <RuntimeIdentifier Condition="$(TargetFramework.Contains('-maccatalyst'))">maccatalyst-x64</RuntimeIdentifier>
     <RuntimeIdentifier Condition="$(TargetFramework.Contains('-maccatalyst')) and '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'arm64'">maccatalyst-arm64</RuntimeIdentifier>

--- a/src/Core/AndroidNative/maui/src/main/java/com/microsoft/maui/PlatformInterop.java
+++ b/src/Core/AndroidNative/maui/src/main/java/com/microsoft/maui/PlatformInterop.java
@@ -689,4 +689,19 @@ public class PlatformInterop {
         }
         return null;
     }
+
+    /*
+     * Checks if the ScaleType of the ImageView is CENTER_CROP.
+     * Avoids returning an object to C#.
+     */
+    public static boolean isImageViewCenterCrop(@NonNull ImageView imageView) {
+        return imageView.getScaleType() == ImageView.ScaleType.CENTER_CROP;
+    }
+
+    /*
+     * Sets View.ClipBounds without creating a Rect object in C#
+     */
+    public static void setClipBounds(@NonNull View view, int left, int top, int right, int bottom) {
+        view.setClipBounds(new Rect(left, top, right, bottom));
+    }
 }

--- a/src/Core/src/Handlers/Image/ImageHandler.Android.cs
+++ b/src/Core/src/Handlers/Image/ImageHandler.Android.cs
@@ -76,14 +76,13 @@ namespace Microsoft.Maui.Handlers
 
 		public override void PlatformArrange(Graphics.Rect frame)
 		{
-			if (PlatformView.GetScaleType() == ImageView.ScaleType.CenterCrop)
+			if (PlatformInterop.IsImageViewCenterCrop(PlatformView))
 			{
 				// If the image is center cropped (AspectFill), then the size of the image likely exceeds
 				// the view size in some dimension. So we need to clip to the view's bounds.
 
-				var (left, top, right, bottom) = PlatformView.Context!.ToPixels(frame);
-				var clipRect = new Android.Graphics.Rect(0, 0, right - left, bottom - top);
-				PlatformView.ClipBounds = clipRect;
+				var (left, top, right, bottom) = PlatformView.ToPixels(frame);
+				PlatformInterop.SetClipBounds(PlatformView, 0, 0, right - left, bottom - top);
 			}
 			else
 			{

--- a/src/Core/src/Platform/Android/ContextExtensions.cs
+++ b/src/Core/src/Platform/Android/ContextExtensions.cs
@@ -122,6 +122,17 @@ namespace Microsoft.Maui.Platform
 			return (float)Math.Ceiling((dp * s_displayDensity) - GeometryUtil.Epsilon);
 		}
 
+		internal static (int left, int top, int right, int bottom) ToPixels(this View view, Graphics.Rect rectangle)
+		{
+			return
+			(
+				(int)view.ToPixels(rectangle.Left),
+				(int)view.ToPixels(rectangle.Top),
+				(int)view.ToPixels(rectangle.Right),
+				(int)view.ToPixels(rectangle.Bottom)
+			);
+		}
+
 		public static (int left, int top, int right, int bottom) ToPixels(this Context context, Graphics.Rect rectangle)
 		{
 			return

--- a/src/Core/tests/DeviceTests/Core.DeviceTests.csproj
+++ b/src/Core/tests/DeviceTests/Core.DeviceTests.csproj
@@ -7,6 +7,7 @@
     <RootNamespace>Microsoft.Maui.DeviceTests</RootNamespace>
     <AssemblyName>Microsoft.Maui.Core.DeviceTests</AssemblyName>
     <NoWarn>$(NoWarn),CA1416</NoWarn>
+    <IsTestProject>true</IsTestProject>
     <!-- Disable multi-RID builds to workaround a parallel build issue -->
     <RuntimeIdentifier Condition="$(TargetFramework.Contains('-maccatalyst'))">maccatalyst-x64</RuntimeIdentifier>
     <RuntimeIdentifier Condition="$(TargetFramework.Contains('-maccatalyst')) and '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'arm64'">maccatalyst-arm64</RuntimeIdentifier>


### PR DESCRIPTION
Context: https://github.com/davidortinau/AllTheLists

Profiling @davidortinau's app, I noticed the "Check-ins" sample felt the slowest on Android.

One thing I noticed while scrolling:

    98.75ms (0.90%) Microsoft.Maui!Microsoft.Maui.Handlers.ImageHandler.PlatformArrange(Microsoft.Maui.Graphics.Rect)
    67.11ms (0.61%) Mono.Android!Android.Widget.ImageView.ScaleType.get_CenterCrop()

In this case, `PlatformArrange()` is called a lot for every `<Image/>`:

    if (PlatformView.GetScaleType() == ImageView.ScaleType.CenterCrop)
    {
        var (left, top, right, bottom) = PlatformView.Context!.ToPixels(frame);
        var clipRect = new Android.Graphics.Rect(0, 0, right - left, bottom - top);
        PlatformView.ClipBounds = clipRect;
    }

`ImageView.ScaleType` is a class, and so and some bookkeeping is done to lookup *the same* C# instance for a Java object. We can make this a bit better by writing a new Java method:

    public static boolean isImageViewCenterCrop(@NonNull ImageView imageView) {
        return imageView.getScaleType() == ImageView.ScaleType.CENTER_CROP;
    }

Next, let's make a `PlatformView.ToPixels()` extension method that can avoid calling `View.Context` for the same reason.

Lastly, we can make a `PlatformInterop.SetClipBounds()` method to avoid creating a `Android.Graphics.Rect` object in C#.

With these changes, I can only see the topmost `PlatformArrange()` method now:

    2.93ms (0.03%) Microsoft.Maui!Microsoft.Maui.Handlers.ImageHandler.PlatformArrange(Microsoft.Maui.Graphics.Rect)

This should improve the layout performance of all .NET MAUI `<Image/>` on Android. I also "banned" `GetScaleType()` in `eng/BannedSymbols.txt`.