### PR TITLE
[android] use cached value for `GetDisplayDensity()`

### DIFF
--- a/src/Core/src/Platform/Android/ContextExtensions.cs
+++ b/src/Core/src/Platform/Android/ContextExtensions.cs
@@ -406,8 +406,12 @@ namespace Microsoft.Maui.Platform
 			return mode.MakeMeasureSpec(deviceConstraint);
 		}
 
-		public static float GetDisplayDensity(this Context? context) =>
-			context?.Resources?.DisplayMetrics?.Density ?? 1.0f;
+		public static float GetDisplayDensity(this Context? context)
+		{
+			EnsureMetrics(context);
+
+			return s_displayDensity;
+		}
 
 		public static Rect ToCrossPlatformRectInReferenceFrame(this Context context, int left, int top, int right, int bottom)
 		{


### PR DESCRIPTION
Context: https://github.com/davidortinau/AllTheLists

Profiling @davidortinau's app, I noticed the "Check-ins" sample felt the slowest on Android.

One thing I noticed while scrolling:

    44.37ms (0.48%) Microsoft.Maui!Microsoft.Maui.Platform.StrokeExtensions.UpdateMauiDrawable(Android.Views.View,Microsoft.Maui.IBorderStr
    40.59ms (0.44%) Microsoft.Maui!Microsoft.Maui.Graphics.MauiDrawable..ctor(Android.Content.Context)

Where a lot of the time is actually just spent in:

    54.48ms (0.59%) Microsoft.Maui!Microsoft.Maui.Platform.ContextExtensions.GetDisplayDensity(Android.Content.Context)

The `GetDisplayDensity()` method is called a lot, and it's not using the cached value we already have!

Reading the history in 6babd4ec, there does not appear to be a reason we *didn't* use the cached value.

With this change in place, I see instead:

    7.81ms (0.12%) Microsoft.Maui!Microsoft.Maui.Platform.StrokeExtensions.UpdateMauiDrawable(Android.Views.View,Microsoft.Maui.IBorderStr

And I don't see *any* time spent in `MauiDrawable..ctor()` anymore.

This change should improve the performance of any `<Border/>` on Android.