### PR TITLE
Use UIView.Window instead of the global window

### DIFF
--- a/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.iOS.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.iOS.cs
@@ -275,11 +275,11 @@ namespace Microsoft.Maui.Controls.Platform
 					if (weakRecognizer.Target is IPinchGestureController pinchGestureRecognizer &&
 						weakEventTracker.Target is GesturePlatformManager eventTracker &&
 						eventTracker._handler?.VirtualView is View view &&
-						UIApplication.SharedApplication.GetKeyWindow() is UIWindow window)
+						eventTracker.PlatformView is {} platformView)
 					{
 						var oldScale = eventTracker._previousScale;
 						var originPoint = r.LocationInView(null);
-						originPoint = window.ConvertPointToView(originPoint, eventTracker.PlatformView);
+						originPoint = platformView.Window.ConvertPointToView(originPoint, platformView);
 
 						var scaledPoint = new Point(originPoint.X / view.Width, originPoint.Y / view.Height);
 
@@ -412,8 +412,7 @@ namespace Microsoft.Maui.Controls.Platform
 			{
 				if (weakRecognizer.Target is PointerGestureRecognizer pointerGestureRecognizer &&
 					weakEventTracker.Target is GesturePlatformManager eventTracker &&
-					eventTracker._handler?.VirtualView is View view &&
-					eventTracker._handler?.MauiContext?.GetPlatformWindow() is UIWindow window)
+					eventTracker._handler?.VirtualView is View view)
 				{
 					var originPoint = pointerGesture.LocationInView(eventTracker?.PlatformView);
 					var platformPointerArgs = new PlatformPointerEventArgs(pointerGesture.View, pointerGesture);


### PR DESCRIPTION
### Description of Change

I noticed in my embedding world when I did not register the UIWindow with the service collection, this crashed. And then I see we are comparing locations with the Key Window, but not the window that the view is actually on.

Not sure if these decisions were intentional, but the first change to not use the key window just uses the platform view's window and the second is to remove the check that sems to not be used.