### PR TITLE
[windows] Fix Updating the initial position

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/CarouselViewHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Items/CarouselViewHandler.Windows.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections;
 using System.Collections.Specialized;
+using System.Linq;
 using Microsoft.Maui.Controls.Platform;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -187,7 +188,13 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		public static void MapPosition(CarouselViewHandler handler, CarouselView carouselView)
 		{
-			handler.UpdatePosition();
+			// If the initial position hasn't been set, we have a UpdateInitialPosition call on CarouselViewHandler
+			// that will handle this so we want to skip this mapper call. We need to wait for the LIstView to be ready
+			if (handler.InitialPositionSet)
+			{
+				handler.UpdatePosition();
+			}
+			
 		}
 
 		public static void MapIsBounceEnabled(CarouselViewHandler handler, CarouselView carouselView)
@@ -209,6 +216,9 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		{
 			handler.UpdateLoop();
 		}
+
+		internal bool InitialPositionSet { get; private set; }
+
 
 		void UpdateIsBounceEnabled()
 		{
@@ -337,7 +347,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			return -1;
 		}
 
-		void UpdateCarouselViewInitialPosition()
+		void UpdateInitialPosition()
 		{
 			if (ListViewBase == null)
 			{
@@ -348,7 +358,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			{
 				if (Element.Loop)
 				{
-					var item = ListViewBase.Items[0];
+					var item = ItemsView.CurrentItem ?? ListViewBase.Items.FirstOrDefault();
 					_loopableCollectionView.CenterMode = true;
 					ListViewBase.ScrollIntoView(item);
 					_loopableCollectionView.CenterMode = false;
@@ -358,6 +368,8 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 					UpdateCurrentItem();
 				else
 					UpdatePosition();
+
+				InitialPositionSet = true;
 			}
 		}
 
@@ -563,7 +575,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			UpdateItemsSource();
 			UpdateSnapPointsType();
 			UpdateSnapPointsAlignment();
-			UpdateCarouselViewInitialPosition();
+			UpdateInitialPosition();
 		}
 
 		void InvalidateItemSize()


### PR DESCRIPTION
### Description of Change

Fixes a problem when the mapper for the position was overriding the CurrentItem the user was setting