### PR TITLE
[ci] Add scheduled push to nightly feed job

### DIFF
--- a/eng/pipelines/maui-release.yml
+++ b/eng/pipelines/maui-release.yml
@@ -228,7 +228,7 @@ extends:
                     # https://learn.microsoft.com/en-us/azure/devops/pipelines/scripts/logging-commands?view=azure-devops&tabs=bash#setendpoint-modify-a-service-connection-field
                     Write-Host "##vso[task.setendpoint id=$(MauiNightlyFeedServiceConnectionId);field=authParameter;key=apitoken]${accessToken}"
 
-              - task: NuGetAuthenticate@0
+              - task: NuGetAuthenticate@1
                 displayName: NuGet Authenticate using managed identity token
                 inputs:
                   nuGetServiceConnections: maui-nightly-feed

--- a/eng/pipelines/maui-release.yml
+++ b/eng/pipelines/maui-release.yml
@@ -196,7 +196,7 @@ extends:
             os: ${{ parameters.VM_IMAGE_HOST.os }}     
             scanArtifacts: ['${{ parameters.PackPlatform.binariesArtifact }}']
 
-        - ${{ if eq(variables['Build.Reason'], 'Schedule') }}:
+        - ${{ if eq(variables['Build.Reason'], 'Manual') }}:
           - stage: nightly
             displayName: Nightly
             dependsOn: ['sdk_insertion']
@@ -239,7 +239,7 @@ extends:
                   downloadPath: $(Build.StagingDirectory)\nuget-signed
                 displayName: Download nuget-signed
 
-             - task: DownloadPipelineArtifact@2
+              - task: DownloadPipelineArtifact@2
                 inputs:
                   artifactName: vs-msi-nugets
                   downloadPath: $(Build.StagingDirectory)\nuget-signed

--- a/eng/pipelines/maui-release.yml
+++ b/eng/pipelines/maui-release.yml
@@ -235,22 +235,15 @@ extends:
 
               - task: DownloadPipelineArtifact@2
                 inputs:
-                  artifactName: DropMetadata-$(Build.BuildId)-nugets-$(System.JobAttempt)
-                  downloadPath: $(Build.StagingDirectory)\metadata
-                displayName: Download nugets drop metadata
+                  artifactName: nuget-signed
+                  downloadPath: $(Build.StagingDirectory)\nuget-signed
+                displayName: Download nuget-signed
 
-              - powershell: |
-                  $jsonContent = Get-Content -Path "$(Build.StagingDirectory)\metadata\VSTSDrop.json" -Raw | ConvertFrom-Json
-                  $dropPrefix = $jsonContent.VstsDropBuildArtifact.VstsDropUrl -replace 'https://devdiv.artifacts.visualstudio.com/DefaultCollection/_apis/drop/drops/' -replace '/nugets'
-                  Write-Host "##vso[task.setvariable variable=ReleaseDropPrefix]$dropPrefix"
-                displayName: Set variable ReleaseDropPrefix
-
-              - task: ms-vscs-artifact.build-tasks.artifactDropDownloadTask-1.artifactDropDownloadTask@1
-                displayName: Download $(ReleaseDropPrefix)/nugets
+             - task: DownloadPipelineArtifact@2
                 inputs:
-                  dropServiceURI: https://devdiv.artifacts.visualstudio.com/DefaultCollection
-                  buildNumber: $(ReleaseDropPrefix)/nugets
-                  destinationPath: $(Build.StagingDirectory)\nuget-signed
+                  artifactName: vs-msi-nugets
+                  downloadPath: $(Build.StagingDirectory)\nuget-signed
+                displayName: Download vs-msi-nugets
 
               - powershell: |
                   $feed = "$env:NUGET_FEED_MAUI_NIGHTLY"

--- a/eng/pipelines/maui-release.yml
+++ b/eng/pipelines/maui-release.yml
@@ -196,7 +196,7 @@ extends:
             os: ${{ parameters.VM_IMAGE_HOST.os }}     
             scanArtifacts: ['${{ parameters.PackPlatform.binariesArtifact }}']
 
-        - ${{ if eq(variables['Build.Reason'], 'Schedule')) }}:
+        - ${{ if eq(variables['Build.Reason'], 'Schedule') }}:
           - stage: nightly
             displayName: Nightly
             dependsOn: ['sdk_insertion']

--- a/eng/pipelines/maui-release.yml
+++ b/eng/pipelines/maui-release.yml
@@ -20,6 +20,12 @@ trigger:
     - SECURITY.md
     - THIRD-PARTY-NOTICES.TXT
 
+schedules:
+- cron: "0 5 * * *"
+  displayName: Run daily at 5:00 UTC
+  branches:
+    include:
+    - main
 
 variables:
   - template: /eng/pipelines/common/variables.yml@self
@@ -190,4 +196,85 @@ extends:
             os: ${{ parameters.VM_IMAGE_HOST.os }}     
             scanArtifacts: ['${{ parameters.PackPlatform.binariesArtifact }}']
 
-        
+        - ${{ if eq(variables['Build.Reason'], 'Schedule')) }}:
+          - stage: nightly
+            displayName: Nightly
+            dependsOn: ['sdk_insertion']
+            jobs:
+            - job: push_nightly
+              displayName: Push to nightly feed
+              pool: ${{ parameters.VM_IMAGE_HOST }}
+              workspace:
+                clean: all
+              timeoutInMinutes: 60
+              steps:
+              - checkout: none
+
+              - task: UseDotNet@2
+                displayName: Use .NET 8.x
+                inputs:
+                  version: 8.x
+
+              - task: AzureCLI@2
+                displayName: Update service connection with managed identity
+                inputs:
+                  azureSubscription: maui-nightly-feed-mi
+                  scriptType: ps
+                  scriptLocation: inlineScript
+                  inlineScript: |
+                    $accessToken = az account get-access-token --query accessToken --resource $(MauiNightlyFeedMIResourceId) -o tsv
+                    Write-Host "##vso[task.setsecret]$accessToken"
+                    Write-Host "Overwriting authorization token for the maui-nightly-feed service connection"
+                    # https://learn.microsoft.com/en-us/azure/devops/pipelines/scripts/logging-commands?view=azure-devops&tabs=bash#setendpoint-modify-a-service-connection-field
+                    Write-Host "##vso[task.setendpoint id=$(MauiNightlyFeedServiceConnectionId);field=authParameter;key=apitoken]${accessToken}"
+
+              - task: NuGetAuthenticate@0
+                displayName: NuGet Authenticate using managed identity token
+                inputs:
+                  nuGetServiceConnections: maui-nightly-feed
+
+              - task: DownloadPipelineArtifact@2
+                inputs:
+                  artifactName: DropMetadata-$(Build.BuildId)-nugets-$(System.JobAttempt)
+                  downloadPath: $(Build.StagingDirectory)\metadata
+                displayName: Download nugets drop metadata
+
+              - powershell: |
+                  $jsonContent = Get-Content -Path "$(Build.StagingDirectory)\metadata\VSTSDrop.json" -Raw | ConvertFrom-Json
+                  $dropPrefix = $jsonContent.VstsDropBuildArtifact.VstsDropUrl -replace 'https://devdiv.artifacts.visualstudio.com/DefaultCollection/_apis/drop/drops/' -replace '/nugets'
+                  Write-Host "##vso[task.setvariable variable=ReleaseDropPrefix]$dropPrefix"
+                displayName: Set variable ReleaseDropPrefix
+
+              - task: ms-vscs-artifact.build-tasks.artifactDropDownloadTask-1.artifactDropDownloadTask@1
+                displayName: Download $(ReleaseDropPrefix)/nugets
+                inputs:
+                  dropServiceURI: https://devdiv.artifacts.visualstudio.com/DefaultCollection
+                  buildNumber: $(ReleaseDropPrefix)/nugets
+                  destinationPath: $(Build.StagingDirectory)\nuget-signed
+
+              - powershell: |
+                  $feed = "$env:NUGET_FEED_MAUI_NIGHTLY"
+                  # Signed maui packages except manifest
+                  $nupkgs = (Get-ChildItem -Path "$(Build.StagingDirectory)\nuget-signed\" -Filter *.nupkg) | Where-Object { $_.BaseName -notlike 'Microsoft.NET.Sdk.Maui.Manifest-*' }
+                  $maxAttempts = 5
+                  foreach($nupkg in $nupkgs) {
+                      $nupkgFile = $nupkg.FullName
+                      $attempt = 1
+                      $waiting = $true
+                      do {
+                          try {
+                              Write-Output "dotnet push $nupkgFile"
+                              & dotnet nuget push --source $feed --api-key az --skip-duplicate $nupkgFile
+                              $waiting = $false
+                          }
+                          catch {
+                              if ($attempt -gt $maxAttempts)
+                              {
+                                throw 'Maximum attempts reached, failing!'
+                              }
+                              Write-Output "  attempt $attempt of $maxAttempts failed..."
+                              $attempt = $attempt + 1
+                          }
+                      } while ($waiting)
+                  }
+                displayName: Push nupkg to maui nightly feed


### PR DESCRIPTION
Imports the steps that push packages to the nightly feed from the
[release definition][0]. This package push will now happen as part of a
scheduled run of the MAUI-Release build pipeline.

[0]: https://dev.azure.com/devdiv/DevDiv/_release?_a=releases&view=mine&definitionId=2847