### PR TITLE
[net9.0] Obsolete the old mechanism for registrations

### DIFF
--- a/src/Controls/src/Core/Application/Application.cs
+++ b/src/Controls/src/Core/Application/Application.cs
@@ -40,12 +40,14 @@ namespace Microsoft.Maui.Controls
 				SetCurrentApplication(this);
 
 #pragma warning disable CS0612 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 			_systemResources = new Lazy<IResourceDictionary>(() =>
 			{
 				var systemResources = DependencyService.Get<ISystemResourcesProvider>().GetSystemResources();
 				systemResources.ValuesChanged += OnParentResourcesChanged;
 				return systemResources;
 			});
+#pragma warning restore CS0618 // Type or member is obsolete
 #pragma warning restore CS0612 // Type or member is obsolete
 
 			_platformConfigurationRegistry = new Lazy<PlatformConfigurationRegistry<Application>>(() => new PlatformConfigurationRegistry<Application>(this));

--- a/src/Controls/src/Core/Compatibility/Android/FontNamedSizeService.cs
+++ b/src/Controls/src/Core/Compatibility/Android/FontNamedSizeService.cs
@@ -7,7 +7,9 @@ using Microsoft.Maui.Controls.Internals;
 using AndroidResource = Android.Resource;
 
 #pragma warning disable CS0612 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 [assembly: Microsoft.Maui.Controls.Dependency(typeof(Microsoft.Maui.Controls.Compatibility.Platform.Android.FontNamedSizeService))]
+#pragma warning restore CS0618 // Type or member is obsolete
 #pragma warning restore CS0612 // Type or member is obsolete
 
 namespace Microsoft.Maui.Controls.Compatibility.Platform.Android

--- a/src/Controls/src/Core/Compatibility/Android/PlatformSizeService.cs
+++ b/src/Controls/src/Core/Compatibility/Android/PlatformSizeService.cs
@@ -1,7 +1,9 @@
 #nullable disable
 using Microsoft.Maui.Controls.Internals;
 
+#pragma warning disable CS0618 // Type or member is obsolete
 [assembly: Microsoft.Maui.Controls.Dependency(typeof(Microsoft.Maui.Controls.Compatibility.Platform.Android.PlatformSizeService))]
+#pragma warning restore CS0618 // Type or member is obsolete
 
 namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 {

--- a/src/Controls/src/Core/Compatibility/iOS/FontNamedSizeService.cs
+++ b/src/Controls/src/Core/Compatibility/iOS/FontNamedSizeService.cs
@@ -5,7 +5,9 @@ using Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific;
 using UIKit;
 
 #pragma warning disable CS0612 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 [assembly: Microsoft.Maui.Controls.Dependency(typeof(Microsoft.Maui.Controls.Compatibility.Platform.iOS.FontNamedSizeService))]
+#pragma warning restore CS0618 // Type or member is obsolete
 #pragma warning restore CS0612 // Type or member is obsolete
 
 namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS

--- a/src/Controls/src/Core/Compatibility/iOS/PlatformSizeService.cs
+++ b/src/Controls/src/Core/Compatibility/iOS/PlatformSizeService.cs
@@ -1,7 +1,9 @@
 #nullable disable
 using Microsoft.Maui.Controls.Internals;
 
+#pragma warning disable CS0618 // Type or member is obsolete
 [assembly: Microsoft.Maui.Controls.Dependency(typeof(Microsoft.Maui.Controls.Compatibility.Platform.iOS.PlatformSizeService))]
+#pragma warning restore CS0618 // Type or member is obsolete
 
 namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 {

--- a/src/Controls/src/Core/DependencyAttribute.cs
+++ b/src/Controls/src/Core/DependencyAttribute.cs
@@ -6,6 +6,7 @@ namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/DependencyAttribute.xml" path="Type[@FullName='Microsoft.Maui.Controls.DependencyAttribute']/Docs/*" />
 	[AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+	[Obsolete("Use the service collection in the MauiAppBuilder instead. This will be removed in a future release.")]
 	public sealed class DependencyAttribute : Attribute
 	{
 		/// <include file="../../docs/Microsoft.Maui.Controls/DependencyAttribute.xml" path="//Member[@MemberName='.ctor']/Docs/*" />

--- a/src/Controls/src/Core/DependencyFetchTarget.cs
+++ b/src/Controls/src/Core/DependencyFetchTarget.cs
@@ -1,6 +1,9 @@
+using System;
+
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/DependencyFetchTarget.xml" path="Type[@FullName='Microsoft.Maui.Controls.DependencyFetchTarget']/Docs/*" />
+	[Obsolete("Use the service collection in the MauiAppBuilder instead. This will be removed in a future release.")]
 	public enum DependencyFetchTarget
 	{
 		/// <include file="../../docs/Microsoft.Maui.Controls/DependencyFetchTarget.xml" path="//Member[@MemberName='GlobalInstance']/Docs/*" />

--- a/src/Controls/src/Core/DependencyResolver.cs
+++ b/src/Controls/src/Core/DependencyResolver.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 namespace Microsoft.Maui.Controls.Internals
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls.Internals/DependencyResolver.xml" path="Type[@FullName='Microsoft.Maui.Controls.Internals.DependencyResolver']/Docs/*" />
+	[Obsolete("Use the service collection in the MauiAppBuilder instead. This will be removed in a future release.")]
 	public static class DependencyResolver
 	{
 		static Type _defaultVisualType = typeof(VisualMarker.DefaultVisual);

--- a/src/Controls/src/Core/DependencyService.cs
+++ b/src/Controls/src/Core/DependencyService.cs
@@ -9,6 +9,7 @@ using Microsoft.Maui.Controls.Internals;
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/DependencyService.xml" path="Type[@FullName='Microsoft.Maui.Controls.DependencyService']/Docs/*" />
+	[Obsolete("Use the service collection in the MauiAppBuilder instead. This will be removed in a future release.")]
 	public static class DependencyService
 	{
 		static bool s_initialized;

--- a/src/Controls/src/Core/Effect.cs
+++ b/src/Controls/src/Core/Effect.cs
@@ -34,7 +34,9 @@ namespace Microsoft.Maui.Controls
 			Effect result = null;
 			if (Internals.Registrar.Effects.TryGetValue(name, out var effectType))
 			{
+#pragma warning disable CS0618 // Type or member is obsolete
 				result = (Effect)DependencyResolver.ResolveOrCreate(effectType.Type);
+#pragma warning restore CS0618 // Type or member is obsolete
 			}
 
 			if (result == null)

--- a/src/Controls/src/Core/Hosting/Effects/AppHostBuilderExtensions.cs
+++ b/src/Controls/src/Core/Hosting/Effects/AppHostBuilderExtensions.cs
@@ -77,8 +77,10 @@ namespace Microsoft.Maui.Controls.Hosting
 		{
 			RegisteredEffects.Add(typeof(TEffect), () =>
 			{
+#pragma warning disable CS0618 // Type or member is obsolete
 				if (DependencyResolver.Resolve(typeof(TPlatformEffect)) is TPlatformEffect pe)
 					return pe;
+#pragma warning restore CS0618 // Type or member is obsolete
 
 				return new TPlatformEffect();
 			});
@@ -91,7 +93,9 @@ namespace Microsoft.Maui.Controls.Hosting
 		{
 			RegisteredEffects.Add(TEffect, () =>
 			{
+#pragma warning disable CS0618 // Type or member is obsolete
 				return (PlatformEffect)DependencyResolver.ResolveOrCreate(TPlatformEffect);
+#pragma warning restore CS0618 // Type or member is obsolete
 			});
 
 			return this;

--- a/src/Controls/src/Core/IndicatorView/IndicatorView.cs
+++ b/src/Controls/src/Core/IndicatorView/IndicatorView.cs
@@ -139,7 +139,9 @@ namespace Microsoft.Maui.Controls
 				if (Handler != null)
 					return new SizeRequest(Handler.GetDesiredSize(widthConstraint, heightConstraint));
 
+#pragma warning disable CS0618 // Type or member is obsolete
 				_platformSizeService ??= DependencyService.Get<IPlatformSizeService>();
+#pragma warning restore CS0618 // Type or member is obsolete
 				return _platformSizeService.GetPlatformSize(this, widthConstraint, heightConstraint);
 			}
 			else

--- a/src/Controls/src/Core/Interactivity/BindingCondition.cs
+++ b/src/Controls/src/Core/Interactivity/BindingCondition.cs
@@ -72,7 +72,9 @@ namespace Microsoft.Maui.Controls
 			bindable.ClearValue(_boundProperty, SetterSpecificity.FromBinding);
 		}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		static IValueConverterProvider s_valueConverter = DependencyService.Get<IValueConverterProvider>();
+#pragma warning restore CS0618 // Type or member is obsolete
 
 		bool EqualsToValue(object other)
 		{

--- a/src/Controls/src/Core/Interactivity/PropertyCondition.cs
+++ b/src/Controls/src/Core/Interactivity/PropertyCondition.cs
@@ -95,7 +95,9 @@ namespace Microsoft.Maui.Controls
 			return (bool)bindable.GetValue(_stateProperty);
 		}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		static IValueConverterProvider s_valueConverter = DependencyService.Get<IValueConverterProvider>();
+#pragma warning restore CS0618 // Type or member is obsolete
 
 		internal override void SetUp(BindableObject bindable)
 		{

--- a/src/Controls/src/Core/OnPlatform.cs
+++ b/src/Controls/src/Core/OnPlatform.cs
@@ -28,7 +28,9 @@ namespace Microsoft.Maui.Controls
 		}
 
 #pragma warning disable RECS0108 // Warns about static fields in generic types
+#pragma warning disable CS0618 // Type or member is obsolete
 		static readonly IValueConverterProvider s_valueConverter = DependencyService.Get<IValueConverterProvider>();
+#pragma warning restore CS0618 // Type or member is obsolete
 #pragma warning restore RECS0108 // Warns about static fields in generic types
 
 		public static implicit operator T(OnPlatform<T> onPlatform)

--- a/src/Controls/src/Core/RadioButton/RadioButton.cs
+++ b/src/Controls/src/Core/RadioButton/RadioButton.cs
@@ -298,7 +298,9 @@ namespace Microsoft.Maui.Controls
 				if (Handler != null)
 					return new SizeRequest(Handler.GetDesiredSize(widthConstraint, heightConstraint));
 
+#pragma warning disable CS0618 // Type or member is obsolete
 				_platformSizeService ??= DependencyService.Get<IPlatformSizeService>();
+#pragma warning restore CS0618 // Type or member is obsolete
 				return _platformSizeService.GetPlatformSize(this, widthConstraint, heightConstraint);
 			}
 

--- a/src/Controls/src/Core/Registrar.cs
+++ b/src/Controls/src/Core/Registrar.cs
@@ -109,7 +109,9 @@ namespace Microsoft.Maui.Controls.Internals
 
 			Registrar.CheckIfRendererIsCompatibilityRenderer(handlerType);
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			object handler = DependencyResolver.ResolveOrCreate(handlerType);
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			return (TRegistrable)handler;
 		}
@@ -127,7 +129,9 @@ namespace Microsoft.Maui.Controls.Internals
 				Registrar.CheckIfRendererIsCompatibilityRenderer(handlerType);
 
 				if (handlerType != null)
+#pragma warning disable CS0618 // Type or member is obsolete
 					returnValue = (TRegistrable)DependencyResolver.ResolveOrCreate(handlerType, source, visual?.GetType(), args);
+#pragma warning restore CS0618 // Type or member is obsolete
 			}
 
 			return returnValue;
@@ -507,7 +511,9 @@ namespace Microsoft.Maui.Controls.Internals
 
 			RegisterStylesheets(flags);
 			Profile.FramePartition("DependencyService.Initialize");
+#pragma warning disable CS0618 // Type or member is obsolete
 			DependencyService.Initialize(assemblies);
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			Profile.FrameEnd();
 		}

--- a/src/Controls/src/Core/VisualElement/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement/VisualElement.cs
@@ -1297,7 +1297,9 @@ namespace Microsoft.Maui.Controls
 			if (Handler != null)
 				return new SizeRequest(Handler.GetDesiredSize(widthConstraint, heightConstraint));
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			_platformSizeService ??= DependencyService.Get<IPlatformSizeService>();
+#pragma warning restore CS0618 // Type or member is obsolete
 			return _platformSizeService.GetPlatformSize(this, widthConstraint, heightConstraint);
 		}
 

--- a/src/Controls/src/Core/Xaml/TypeConversionExtensions.cs
+++ b/src/Controls/src/Core/Xaml/TypeConversionExtensions.cs
@@ -224,7 +224,9 @@ namespace Microsoft.Maui.Controls.Xaml
 				}
 			}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			var platformValueConverterService = DependencyService.Get<INativeValueConverterService>();
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			object platformValue = null;
 			if (platformValueConverterService != null && platformValueConverterService.ConvertTo(value, toType, out platformValue))

--- a/src/Controls/src/Core/Xaml/ValueConverterProvider.cs
+++ b/src/Controls/src/Core/Xaml/ValueConverterProvider.cs
@@ -5,7 +5,9 @@ using System.Reflection;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Xaml;
 
+#pragma warning disable CS0618 // Type or member is obsolete
 [assembly: Dependency(typeof(ValueConverterProvider))]
+#pragma warning restore CS0618 // Type or member is obsolete
 namespace Microsoft.Maui.Controls.Xaml
 {
 	class ValueConverterProvider : IValueConverterProvider

--- a/src/Controls/src/Xaml/ApplyPropertiesVisitor.cs
+++ b/src/Controls/src/Xaml/ApplyPropertiesVisitor.cs
@@ -548,7 +548,9 @@ namespace Microsoft.Maui.Controls.Xaml
 			if (exception != null)
 				return false;
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			var nativeBindingService = DependencyService.Get<INativeBindingService>();
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			if (binding == null)
 				return false;
@@ -576,7 +578,9 @@ namespace Microsoft.Maui.Controls.Xaml
 			exception = null;
 
 			var elementType = element.GetType();
+#pragma warning disable CS0618 // Type or member is obsolete
 			var nativeBindingService = DependencyService.Get<INativeBindingService>();
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			if (property == null)
 				return false;

--- a/src/Controls/src/Xaml/Hosting/AppHostBuilderExtensions.cs
+++ b/src/Controls/src/Xaml/Hosting/AppHostBuilderExtensions.cs
@@ -166,6 +166,7 @@ namespace Microsoft.Maui.Controls.Hosting
 
 		static MauiAppBuilder SetupDefaults(this MauiAppBuilder builder)
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 #if WINDOWS || ANDROID || IOS || MACCATALYST || TIZEN
 			// initialize compatibility DependencyService
 			DependencyService.SetToInitialized();
@@ -177,6 +178,7 @@ namespace Microsoft.Maui.Controls.Hosting
 			DependencyService.Register<FontNamedSizeService>();
 #pragma warning restore CS0612, CA1416 // Type or member is obsolete
 #endif
+#pragma warning restore CS0618 // Type or member is obsolete
 			builder.Services.AddScoped(_ => new HideSoftInputOnTappedChangedManager());
 			builder.ConfigureImageSourceHandlers();
 			builder


### PR DESCRIPTION
### Description of Change

* The DependencyService has been replaced with the service collection.

Depends on

* https://github.com/dotnet/maui/pull/23725