### PR TITLE
[Windows] Fix CollectionView DisconnectHandler SelectionMode Crash

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/SelectableItemsViewHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Items/SelectableItemsViewHandler.Windows.cs
@@ -49,8 +49,8 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 			if (oldListViewBase != null)
 			{
-				oldListViewBase.ClearValue(ListViewBase.SelectionModeProperty);
 				oldListViewBase.SelectionChanged -= PlatformSelectionChanged;
+				oldListViewBase.ClearValue(ListViewBase.SelectionModeProperty);
 			}
 
 			if (ItemsView != null)

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.Windows.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.ObjectModel;
+﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
@@ -48,6 +49,51 @@ namespace Microsoft.Maui.DeviceTests
 
 			await CreateHandlerAndAddToWindow<LayoutHandler>(layout, (handler) =>
 			{
+				// Validate that no exceptions are thrown
+				var collectionViewHandler = (IElementHandler)collectionView.Handler;
+				collectionViewHandler.DisconnectHandler();
+
+				((IElementHandler)handler).DisconnectHandler();
+
+				return Task.CompletedTask;
+			});
+		}
+
+		[Fact(DisplayName = "CollectionView Disconnects Correctly with MultiSelection")]
+		public async Task CollectionViewHandlerDisconnectsWithMultiSelect()
+		{
+			SetupBuilder();
+
+			ObservableCollection<string> data = new ObservableCollection<string>()
+			{
+				"Item 1",
+				"Item 2",
+				"Item 3"
+			};
+
+			var collectionView = new CollectionView()
+			{
+				ItemTemplate = new Controls.DataTemplate(() =>
+				{
+					return new VerticalStackLayout()
+					{
+						new Label()
+					};
+				}),
+				SelectionMode = SelectionMode.Multiple,
+				ItemsSource = data
+			};
+
+			var layout = new VerticalStackLayout()
+			{
+				collectionView
+			};
+
+			await CreateHandlerAndAddToWindow<LayoutHandler>(layout, (handler) =>
+			{
+				collectionView.SelectedItems.Add(data[0]);
+				collectionView.SelectedItems.Add(data[2]);
+
 				// Validate that no exceptions are thrown
 				var collectionViewHandler = (IElementHandler)collectionView.Handler;
 				collectionViewHandler.DisconnectHandler();


### PR DESCRIPTION
### Description of Change

Fix a crash when the `DisconnectHandler` is invoked on a `CollectionView` when multiple items are selected by reordering the unsubscription of `SelectionChanged` and clearing the `SelectionModeProperty`. 

The issue was caused because `oldListViewBase.ClearValue(ListViewBase.SelectionModeProperty)` fires an `SelectionChanged` event, which runs code that shouldn't be run in a handler disconnect (the handler will be null). 

### Issues Fixed

Fixes #23649
