### PR TITLE
Fix SafeArea adjustments

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Controls.TestCases.HostApp.csproj
+++ b/src/Controls/tests/TestCases.HostApp/Controls.TestCases.HostApp.csproj
@@ -10,6 +10,7 @@
     <RuntimeIdentifier Condition="$(TargetFramework.Contains('-maccatalyst'))">maccatalyst-x64</RuntimeIdentifier>
     <RuntimeIdentifier Condition="$(TargetFramework.Contains('-maccatalyst')) and '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'arm64'">maccatalyst-arm64</RuntimeIdentifier>
     <ExcludeMicrosoftNetTestSdk>true</ExcludeMicrosoftNetTestSdk>
+    <RootNamespace>Maui.Controls.Sample</RootNamespace>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue24246.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue24246.xaml
@@ -1,0 +1,11 @@
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Maui.Controls.Sample.Issues.Issue24246"
+             Title="Issue24246"
+            xmlns:ios="clr-namespace:Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific;assembly=Microsoft.Maui.Controls"
+            ios:Page.UseSafeArea="false">
+     <VerticalStackLayout Background="Purple" IgnoreSafeArea="False" VerticalOptions="Start" IsClippedToBounds="True" >
+        <Entry AutomationId="entry" Background="Green"></Entry>
+        <Label AutomationId="label" Text="If you can't interact with the above entry field, the test has failed" LineBreakMode="CharacterWrap"></Label>
+    </VerticalStackLayout>
+</ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue24246.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue24246.xaml.cs
@@ -1,0 +1,11 @@
+namespace Maui.Controls.Sample.Issues;
+
+
+[Issue(IssueTracker.Github, 24246, "SafeArea arrange insets are currently insetting based on an incorrect Bounds", PlatformAffected.iOS)]
+public partial class Issue24246 : ContentPage
+{
+	public Issue24246()
+	{
+		InitializeComponent();
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue24246.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue24246.cs
@@ -1,0 +1,26 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue24246 : _IssuesUITest
+	{
+		public Issue24246(TestDevice testDevice) : base(testDevice)
+		{
+		}
+
+		public override string Issue => "SafeArea arrange insets are currently insetting based on an incorrect Bounds";
+
+		[Test]
+		[Category(UITestCategories.Layout)]
+		public void TapThenDoubleTap()
+		{
+			App.WaitForElement("entry");
+            App.EnterText("entry", "Hello, World!");
+
+            var result = App.WaitForElement("entry").GetText();
+            Assert.That(result, Is.EqualTo("Hello, World!"));
+		}
+	}
+}

--- a/src/Core/src/Platform/iOS/MauiView.cs
+++ b/src/Core/src/Platform/iOS/MauiView.cs
@@ -25,9 +25,16 @@ namespace Microsoft.Maui.Platform
 
 		bool RespondsToSafeArea()
 		{
+			if (View is not ISafeAreaView sav || sav.IgnoreSafeArea)
+			{
+				return false;
+			}
+
 			if (_respondsToSafeArea.HasValue)
 				return _respondsToSafeArea.Value;
+
 			return (bool)(_respondsToSafeArea = RespondsToSelector(new Selector("safeAreaInsets")));
+
 		}
 
 		protected CGRect AdjustForSafeArea(CGRect bounds)
@@ -35,7 +42,7 @@ namespace Microsoft.Maui.Platform
 			if (KeyboardAutoManagerScroll.ShouldIgnoreSafeAreaAdjustment)
 				KeyboardAutoManagerScroll.ShouldScrollAgain = true;
 
-			if (View is not ISafeAreaView sav || sav.IgnoreSafeArea || !RespondsToSafeArea())
+			if (!RespondsToSafeArea())
 			{
 				return bounds;
 			}
@@ -88,6 +95,12 @@ namespace Microsoft.Maui.Platform
 			return CrossPlatformLayout?.CrossPlatformArrange(bounds) ?? Size.Zero;
 		}
 
+		// SizeThatFits does not take into account the constraints set on the view.
+		// For example, if the user has set a width and height on this view, those constraints
+		// will not be reflected in the value returned from this method. This method purely returns
+		// a measure based on the size that is passed in.
+		// The constraints are all applied by ViewHandlerExtensions.GetDesiredSizeFromHandler
+		// after it calls this method.
 		public override CGSize SizeThatFits(CGSize size)
 		{
 			if (_crossPlatformLayoutReference == null)
@@ -101,6 +114,23 @@ namespace Microsoft.Maui.Platform
 			var crossPlatformSize = CrossPlatformMeasure(widthConstraint, heightConstraint);
 
 			CacheMeasureConstraints(widthConstraint, heightConstraint);
+
+			if (RespondsToSafeArea())
+			{
+				// During the LayoutSubViews pass, we adjust the Bounds of this view for the safe area and then pass the adjusted result to CrossPlatformArrange.
+				// The CrossPlatformMeasure call does not include the safe area, so we need to add it here to ensure the returned size is correct.
+				//
+				// For example, if this is a layout with an Entry of height 20, CrossPlatformMeasure will return a height of 20.
+				// This means the bounds will be set to a height of 20, causing AdjustForSafeArea(Bounds) to return a negative bounds once it has
+				// subtracted the safe area insets. Therefore, we need to add the safe area insets to the CrossPlatformMeasure result to ensure correct arrangement.
+				var widthSafeAreaOffset = SafeAreaInsets.Left + SafeAreaInsets.Right;
+				var heightSafeAreaOffset = SafeAreaInsets.Top + SafeAreaInsets.Bottom;
+
+				var width = double.Clamp(crossPlatformSize.Width + widthSafeAreaOffset, 0, widthConstraint);
+				var height = double.Clamp(crossPlatformSize.Height + heightSafeAreaOffset, 0, heightConstraint);
+
+				return new CGSize(width, height);
+			}
 
 			return crossPlatformSize.ToCGSize();
 		}

--- a/src/Core/src/Platform/iOS/MauiView.cs
+++ b/src/Core/src/Platform/iOS/MauiView.cs
@@ -115,7 +115,9 @@ namespace Microsoft.Maui.Platform
 
 			CacheMeasureConstraints(widthConstraint, heightConstraint);
 
-			if (RespondsToSafeArea())
+			// If for some reason the upstream measure passes in a negative contraint
+			// Lets just bypass this code
+			if (RespondsToSafeArea() && widthConstraint >= 0 && heightConstraint >= 0)
 			{
 				// During the LayoutSubViews pass, we adjust the Bounds of this view for the safe area and then pass the adjusted result to CrossPlatformArrange.
 				// The CrossPlatformMeasure call does not include the safe area, so we need to add it here to ensure the returned size is correct.


### PR DESCRIPTION
### Description of Change

This PR relates to some issues found here https://github.com/dotnet/maui/pull/22476 when trying to layout a Button when it's inside a layout that is partly inside the safearea.

The problem we found is that the `MauiView` returns a size from `SizeThatFits` that doesn't include the `SafeAreaInsets`. The arrange pass insets its `Bounds` and passes this value to `CrossPlatformArrange` but the `Bounds` being used is the size of the children not including the `SafeAreaInsets` which means the bounds used for arranging is wrong. 

You can see from the screenshots below that the `VSL` surrounding the the entry gets arranged incorrectly


### Comparison

Given the following `XAML`

```XAML
<ContentPage
    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
    x:Class="Maui.Controls.Sample.MainPage"
    xmlns:local="clr-namespace:Maui.Controls.Sample"
    xmlns:ios="clr-namespace:Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific;assembly=Microsoft.Maui.Controls"
    ios:Page.UseSafeArea="false"
    >
    <VerticalStackLayout x:Name="layout" Background="Purple" IgnoreSafeArea="False" VerticalOptions="Start" IsClippedToBounds="True" >
        <Entry x:Name="label" Background="Green" Text="Hello there"></Entry>
    </VerticalStackLayout>
</ContentPage>
```

#### Before

![image](https://github.com/user-attachments/assets/c4fae475-3a51-434d-a8c3-e6a6a2ed95a9)


#### After

![image](https://github.com/user-attachments/assets/70aa05f5-6f4f-45d7-8b5d-1184232c8f9c)




### Issues Fixed


Fixes #24246
