### PR TITLE
[Windows] Upgrade Windows App SDK from 1.5.4 to 1.5.5

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -60,7 +60,7 @@
     <!-- emsdk -->
     <MicrosoftNETWorkloadEmscriptenPackageVersion>8.0.0</MicrosoftNETWorkloadEmscriptenPackageVersion>
     <!-- wasdk -->
-    <MicrosoftWindowsAppSDKPackageVersion>1.5.240607001</MicrosoftWindowsAppSDKPackageVersion>
+    <MicrosoftWindowsAppSDKPackageVersion>1.5.240627000</MicrosoftWindowsAppSDKPackageVersion>
     <MicrosoftWindowsSDKBuildToolsPackageVersion>10.0.22621.756</MicrosoftWindowsSDKBuildToolsPackageVersion>
     <MicrosoftGraphicsWin2DPackageVersion>1.2.0</MicrosoftGraphicsWin2DPackageVersion>
     <!-- Everything else -->


### PR DESCRIPTION
### Description of Change

This PR upgrades Windows App SDK from [1.5.4](https://learn.microsoft.com/en-gb/windows/apps/windows-app-sdk/stable-channel#version-154-15240607001) to [1.5.5](https://learn.microsoft.com/en-gb/windows/apps/windows-app-sdk/stable-channel#version-155-15240627000). It contains some bugfixes and fixes for a few crashes.

Note: Yes, these updates [do not come](https://github.com/dotnet/maui/pull/23209#issuecomment-2188332064) automatically as they used to.