### PR TITLE
[Accessibility] Add accessibility label to the menu button

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellPageRendererTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellPageRendererTracker.cs
@@ -359,7 +359,10 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 					if (String.IsNullOrWhiteSpace(image?.AutomationId))
 					{
 						if (IsRootPage)
+						{
 							NavigationItem.LeftBarButtonItem.AccessibilityIdentifier = "OK";
+							NavigationItem.LeftBarButtonItem.AccessibilityLabel = "Menu";
+						}
 						else
 							NavigationItem.LeftBarButtonItem.AccessibilityIdentifier = "Back";
 					}


### PR DESCRIPTION
### Description of Change

<!-- Enter description of the fix in this section -->
The flyout menu button on Catalyst does not have a label on the Accessibility Inspector. This small change allows the accessibility inspector to show the hamburger button is a menu button.


https://github.com/user-attachments/assets/23b29e66-20f9-440f-87ba-ec3c28b5ace4

See that the flyout menu label changes to "Menu" when we are on the root page.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes:
* https://github.com/dotnet/maui/issues/22904

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
