### PR TITLE
[core] Fix tests when converting with PT Locale

### DIFF
--- a/src/Controls/src/Core/Shapes/PathFigureCollectionConverter.cs
+++ b/src/Controls/src/Core/Shapes/PathFigureCollectionConverter.cs
@@ -590,9 +590,9 @@ namespace Microsoft.Maui.Controls.Shapes
 			foreach (var pathFigure in pathFigureCollection)
 			{
 				sb.Append('M')
-				.Append(pathFigure.StartPoint.X.ToString("R"))
+				.Append(pathFigure.StartPoint.X.ToString(CultureInfo.InvariantCulture))
 				.Append(',')
-				.Append(pathFigure.StartPoint.Y.ToString("R"))
+				.Append(pathFigure.StartPoint.Y.ToString(CultureInfo.InvariantCulture))
 				.Append(' ');
 
 				foreach (var pathSegment in pathFigure.Segments)
@@ -600,37 +600,37 @@ namespace Microsoft.Maui.Controls.Shapes
 					if (pathSegment is LineSegment lineSegment)
 					{
 						sb.Append('L')
-						.Append(lineSegment.Point.X.ToString("R"))
+						.Append(lineSegment.Point.X.ToString(CultureInfo.InvariantCulture))
 						.Append(',')
-						.Append(lineSegment.Point.Y.ToString("R"))
+						.Append(lineSegment.Point.Y.ToString(CultureInfo.InvariantCulture))
 						.Append(' ');
 					}
 					else if (pathSegment is BezierSegment bezierSegment)
 					{
 						sb.Append('C')
-						.Append(bezierSegment.Point1.X.ToString("R"))
+						.Append(bezierSegment.Point1.X.ToString(CultureInfo.InvariantCulture))
 						.Append(',')
-						.Append(bezierSegment.Point1.Y.ToString("R"))
+						.Append(bezierSegment.Point1.Y.ToString(CultureInfo.InvariantCulture))
 						.Append(' ')
-						.Append(bezierSegment.Point2.X.ToString("R"))
+						.Append(bezierSegment.Point2.X.ToString(CultureInfo.InvariantCulture))
 						.Append(',')
-						.Append(bezierSegment.Point2.Y.ToString("R"))
+						.Append(bezierSegment.Point2.Y.ToString(CultureInfo.InvariantCulture))
 						.Append(' ')
-						.Append(bezierSegment.Point3.X.ToString("R"))
+						.Append(bezierSegment.Point3.X.ToString(CultureInfo.InvariantCulture))
 						.Append(',')
-						.Append(bezierSegment.Point3.Y.ToString("R"))
+						.Append(bezierSegment.Point3.Y.ToString(CultureInfo.InvariantCulture))
 						.Append(' ');
 					}
 					else if (pathSegment is QuadraticBezierSegment quadraticBezierSegment)
 					{
 						sb.Append('Q')
-						.Append(quadraticBezierSegment.Point1.X.ToString("R"))
+						.Append(quadraticBezierSegment.Point1.X.ToString(CultureInfo.InvariantCulture))
 						.Append(',')
-						.Append(quadraticBezierSegment.Point1.Y.ToString("R"))
+						.Append(quadraticBezierSegment.Point1.Y.ToString(CultureInfo.InvariantCulture))
 						.Append(' ')
-						.Append(quadraticBezierSegment.Point2.X.ToString("R"))
+						.Append(quadraticBezierSegment.Point2.X.ToString(CultureInfo.InvariantCulture))
 						.Append(',')
-						.Append(quadraticBezierSegment.Point2.Y.ToString("R"))
+						.Append(quadraticBezierSegment.Point2.Y.ToString(CultureInfo.InvariantCulture))
 						.Append(' ');
 					}
 					else if (pathSegment is ArcSegment arcSegment)
@@ -646,9 +646,9 @@ namespace Microsoft.Maui.Controls.Shapes
 						.Append(',')
 						.Append(arcSegment.SweepDirection == SweepDirection.Clockwise ? "1" : "0")
 						.Append(' ')
-						.Append(arcSegment.Point.X.ToString("R"))
+						.Append(arcSegment.Point.X.ToString(CultureInfo.InvariantCulture))
 						.Append(',')
-						.Append(arcSegment.Point.Y.ToString("R"))
+						.Append(arcSegment.Point.Y.ToString(CultureInfo.InvariantCulture))
 						.Append(' ');
 					}
 				}


### PR DESCRIPTION
### Description of Change

Make the conversion to string with InvariantCulture so tests also work in computer with different locale.

This pull request includes changes to the `ParsePathFigureCollectionToString` method in the `PathFigureCollectionConverter.cs` file. The changes involve updating the way coordinates are converted to strings, specifically switching from the `"R"` format to using `CultureInfo.InvariantCulture`.

Here are the key changes:

* [`src/Controls/src/Core/Shapes/PathFigureCollectionConverter.cs`](diffhunk://#diff-a771536e1845601a5f0b9bbb2710be9ec3420a32f5473ba908cac287a9c06a80L593-R633): Updated the string conversion of various points in the `ParsePathFigureCollectionToString` method. The `ToString` method now uses `CultureInfo.InvariantCulture` instead of the `"R"` format. This change is applied to the `StartPoint` of `pathFigure`, `Point` of `lineSegment`, `Point1`, `Point2`, and `Point3` of `bezierSegment`, `Point1` and `Point2` of `quadraticBezierSegment`, and `Point` of `arcSegment`. [[1]](diffhunk://#diff-a771536e1845601a5f0b9bbb2710be9ec3420a32f5473ba908cac287a9c06a80L593-R633) [[2]](diffhunk://#diff-a771536e1845601a5f0b9bbb2710be9ec3420a32f5473ba908cac287a9c06a80L649-R651)
