### PR TITLE
HybridWebView: Invoke JS methods from .NET

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Controls/HybridWebViewPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/HybridWebViewPage.xaml
@@ -8,22 +8,39 @@
 
     <Grid ColumnDefinitions="2*,1*" RowDefinitions="Auto,1*">
 
-        <Label
+      <Editor
           Grid.Row="0"
           Grid.Column="0"
           Text="HybridWebView here"
-          x:Name="statusLabel" />
+          IsReadOnly="True"
+          MinimumHeightRequest="200"
+          x:Name="statusText" />
+
+      <VerticalStackLayout
+          Grid.Row="0"
+          Grid.Column="1">
 
         <Button
-          Grid.Row="0"
-          Grid.Column="1"
+          Margin="10"
           Text="Send message to JS"
           Clicked="SendMessageButton_Clicked" />
 
-        <HybridWebView
+        <Button
+          Margin="10"
+          Text="Invoke JS"
+          Clicked="InvokeJSMethodButton_Clicked" />
+
+        <Button
+          Margin="10"
+          Text="Invoke Async JS"
+          Clicked="InvokeAsyncJSMethodButton_Clicked" />
+
+      </VerticalStackLayout>
+
+      <HybridWebView
           x:Name="hwv"
           Grid.Row="1"
-          Grid.ColumnSpan="2"
+          Grid.ColumnSpan="3"
           HybridRoot="HybridSamplePage"
           RawMessageReceived="hwv_RawMessageReceived"/>
 

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/HybridWebViewPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/HybridWebViewPage.xaml.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json.Serialization;
 using Microsoft.Maui.Controls;
 
 namespace Maui.Controls.Sample.Pages
@@ -10,14 +13,76 @@ namespace Maui.Controls.Sample.Pages
 			InitializeComponent();
 		}
 
+		int count;
 		private void SendMessageButton_Clicked(object sender, EventArgs e)
 		{
-			hwv.SendRawMessage("Hello from C#!");
+			hwv.SendRawMessage($"Hello from C#! #{count++}");
+		}
+
+		private async void InvokeJSMethodButton_Clicked(object sender, EventArgs e)
+		{
+			var statusResult = "";
+
+			var x = 123d;
+			var y = 321d;
+			var result = await hwv.InvokeJavaScriptAsync<ComputationResult>(
+				"AddNumbers",
+				SampleInvokeJsContext.Default.ComputationResult,
+				new object?[] { x, null, y, null },
+				new[] { SampleInvokeJsContext.Default.Double, null, SampleInvokeJsContext.Default.Double, null });
+
+			if (result is null)
+			{
+				statusResult += Environment.NewLine + $"Got no result for operation with {x} and {y} 😮";
+			}
+			else
+			{
+				statusResult += Environment.NewLine + $"Used operation {result.operationName} with numbers {x} and {y} to get {result.result}";
+			}
+
+			Dispatcher.Dispatch(() => statusText.Text += statusResult);
+		}
+
+		private async void InvokeAsyncJSMethodButton_Clicked(object sender, EventArgs e)
+		{
+			var statusResult = "";
+
+			var asyncFuncResult = await hwv.InvokeJavaScriptAsync<Dictionary<string,string>>(
+				"EvaluateMeWithParamsAndAsyncReturn",
+				SampleInvokeJsContext.Default.DictionaryStringString,
+				new object?[] { "new_key", "new_value" },
+				new[] { SampleInvokeJsContext.Default.String, SampleInvokeJsContext.Default.String });
+
+			if (asyncFuncResult == null)
+			{
+				statusResult += Environment.NewLine + $"Got no result from EvaluateMeWithParamsAndAsyncReturn 😮";
+			}
+			else
+			{
+				statusResult += Environment.NewLine + $"Got result from EvaluateMeWithParamsAndAsyncReturn: {string.Join(",", asyncFuncResult)}";
+			}
+
+			Dispatcher.Dispatch(() => statusText.Text += statusResult);
 		}
 
 		private void hwv_RawMessageReceived(object sender, HybridWebViewRawMessageReceivedEventArgs e)
 		{
-			Dispatcher.Dispatch(() => statusLabel.Text += e.Message);
+			Dispatcher.Dispatch(() => statusText.Text += Environment.NewLine + e.Message);
+		}
+
+		public class ComputationResult
+		{
+			public double result { get; set; }
+			public string? operationName { get; set; }
+		}
+
+		[JsonSourceGenerationOptions(WriteIndented = true)]
+		[JsonSerializable(typeof(ComputationResult))]
+		[JsonSerializable(typeof(double))]
+		[JsonSerializable(typeof(string))]
+		[JsonSerializable(typeof(Dictionary<string, string>))]
+		internal partial class SampleInvokeJsContext : JsonSerializerContext
+		{
 		}
 	}
 }

--- a/src/Controls/samples/Controls.Sample/Resources/Raw/HybridSamplePage/asyncdata.txt
+++ b/src/Controls/samples/Controls.Sample/Resources/Raw/HybridSamplePage/asyncdata.txt
@@ -1,0 +1,4 @@
+﻿{
+    "key1": "value1",
+    "key2": "value2"
+}

--- a/src/Controls/samples/Controls.Sample/Resources/Raw/HybridSamplePage/index.html
+++ b/src/Controls/samples/Controls.Sample/Resources/Raw/HybridSamplePage/index.html
@@ -4,6 +4,7 @@
 <head>
     <meta charset="utf-8" />
     <title></title>
+    <link rel="icon" href="data:,">
     <link rel="stylesheet" href="styles/app.css">
     <script src="scripts/HybridWebView.js"></script>
     <script>
@@ -13,6 +14,31 @@
                 var messageFromCSharp = document.getElementById("messageFromCSharp");
                 messageFromCSharp.value += '\r\n' + e.detail.message;
             });
+
+        function AddNumbers(a, x, b, y) {
+            var result = {
+                "result": a + b,
+                "operationName": "Addition"
+            };
+            return result;
+        }
+
+        var count = 0;
+
+        async function EvaluateMeWithParamsAndAsyncReturn(s1, s2) {
+            const response = await fetch("/asyncdata.txt");
+            if (!response.ok) {
+                    throw new Error(`HTTP error: ${response.status}`);
+            }
+            var jsonData = await response.json();
+
+            jsonData[s1] = s2;
+
+            const msg = 'JSON data is available: ' + JSON.stringify(jsonData);
+            window.HybridWebView.SendRawMessage(msg)
+
+            return jsonData;
+        }
     </script>
 </head>
 <body>
@@ -20,7 +46,7 @@
         Hybrid sample!
     </div>
     <div>
-        <button onclick="window.HybridWebView.SendRawMessage('Message from JS!')">Send message to C#</button>
+        <button onclick="window.HybridWebView.SendRawMessage('Message from JS! ' + (count++))">Send message to C#</button>
     </div>
     <div>
         Message from C#: <textarea readonly id="messageFromCSharp" style="width: 80%; height: 10em;"></textarea>

--- a/src/Controls/samples/Controls.Sample/Resources/Raw/HybridSamplePage/scripts/HybridWebView.js
+++ b/src/Controls/samples/Controls.Sample/Resources/Raw/HybridSamplePage/scripts/HybridWebView.js
@@ -1,48 +1,78 @@
-﻿function HybridWebViewInit() {
-
-    function DispatchHybridWebViewMessage(message) {
-        const event = new CustomEvent("HybridWebViewMessageReceived", { detail: { message: message } });
-        window.dispatchEvent(event);
-    }
-
-    if (window.chrome && window.chrome.webview) {
-        // Windows WebView2
-        window.chrome.webview.addEventListener('message', arg => {
-            DispatchHybridWebViewMessage(arg.data);
-        });
-    }
-    else if (window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.webwindowinterop) {
-        // iOS and MacCatalyst WKWebView
-        window.external = {
-            "receiveMessage": message => {
-                DispatchHybridWebViewMessage(message);
-            }
-        };
-    }
-    else {
-        // Android WebView
-        window.addEventListener('message', arg => {
-            DispatchHybridWebViewMessage(arg.data);
-        });
-    }
-}
-
-window.HybridWebView = {
-    "SendRawMessage": function (message) {
+﻿window.HybridWebView = {
+    "Init": function () {
+        function DispatchHybridWebViewMessage(message) {
+            const event = new CustomEvent("HybridWebViewMessageReceived", { detail: { message: message } });
+            window.dispatchEvent(event);
+        }
 
         if (window.chrome && window.chrome.webview) {
             // Windows WebView2
-            window.chrome.webview.postMessage(message);
+            window.chrome.webview.addEventListener('message', arg => {
+                DispatchHybridWebViewMessage(arg.data);
+            });
         }
         else if (window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.webwindowinterop) {
             // iOS and MacCatalyst WKWebView
-            window.webkit.messageHandlers.webwindowinterop.postMessage(message);
+            window.external = {
+                "receiveMessage": message => {
+                    DispatchHybridWebViewMessage(message);
+                }
+            };
         }
         else {
             // Android WebView
-            hybridWebViewHost.sendRawMessage(message);
+            window.addEventListener('message', arg => {
+                DispatchHybridWebViewMessage(arg.data);
+            });
         }
+    },
+
+    "SendRawMessage": function (message) {
+        window.HybridWebView.__SendMessageInternal('RawMessage', message);
+    },
+
+    "__SendMessageInternal": function (type, message) {
+
+        const messageToSend = type + '|' + message;
+
+        if (window.chrome && window.chrome.webview) {
+            // Windows WebView2
+            window.chrome.webview.postMessage(messageToSend);
+        }
+        else if (window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.webwindowinterop) {
+            // iOS and MacCatalyst WKWebView
+            window.webkit.messageHandlers.webwindowinterop.postMessage(messageToSend);
+        }
+        else {
+            // Android WebView
+            hybridWebViewHost.sendMessage(messageToSend);
+        }
+    },
+
+    "InvokeMethod": function (taskId, methodName, args) {
+        if (methodName[Symbol.toStringTag] === 'AsyncFunction') {
+            // For async methods, we need to call the method and then trigger the callback when it's done
+            const asyncPromise = methodName(...args);
+            asyncPromise
+                .then(asyncResult => {
+                    window.HybridWebView.__TriggerAsyncCallback(taskId, asyncResult);
+                })
+                .catch(error => console.error(error));
+        } else {
+            // For sync methods, we can call the method and trigger the callback immediately
+            const syncResult = methodName(...args);
+            window.HybridWebView.__TriggerAsyncCallback(taskId, syncResult);
+        }
+    },
+
+    "__TriggerAsyncCallback": function (taskId, result) {
+        // Make sure the result is a string
+        if (result && typeof (result) !== 'string') {
+            result = JSON.stringify(result);
+        }
+
+        window.HybridWebView.__SendMessageInternal('InvokeMethodCompleted', taskId + '|' + result);
     }
 }
 
-HybridWebViewInit();
+window.HybridWebView.Init();

--- a/src/Controls/src/Core/HybridWebView/HybridWebView.cs
+++ b/src/Controls/src/Core/HybridWebView/HybridWebView.cs
@@ -1,9 +1,19 @@
 ﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Maui.Devices;
+using System.Collections.Generic;
+
+#if WINDOWS || ANDROID || IOS || MACCATALYST
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+#endif
 
 namespace Microsoft.Maui.Controls
 {
 	/// <summary>
-	/// A <see cref="View"/> that presents local HTML content in a web view and allows JavaScript and C# code to interop using messages.
+	/// A <see cref="View"/> that presents local HTML content in a web view and allows JavaScript and C# code to
+	/// communicate by using messages and by invoking methods.
 	/// </summary>
 	public class HybridWebView : View, IHybridWebView
 	{
@@ -15,30 +25,51 @@ namespace Microsoft.Maui.Controls
 			BindableProperty.Create(nameof(HybridRoot), typeof(string), typeof(HybridWebView), defaultValue: "wwwroot");
 
 
-		/// <summary>
-		/// Specifies the file within the <see cref="HybridRoot"/> that should be served as the default file. The
-		/// default value is <c>index.html</c>.
-		/// </summary>
+		/// <inheritdoc/>
 		public string? DefaultFile
 		{
 			get { return (string)GetValue(DefaultFileProperty); }
 			set { SetValue(DefaultFileProperty, value); }
 		}
 
-		/// <summary>
-		///  The path within the app's "Raw" asset resources that contain the web app's contents. For example, if the
-		///  files are located in <c>[ProjectFolder]/Resources/Raw/hybrid_root</c>, then set this property to "hybrid_root".
-		///  The default value is <c>wwwroot</c>, which maps to <c>[ProjectFolder]/Resources/Raw/wwwroot</c>.
-		/// </summary>
+		/// <inheritdoc/>
 		public string? HybridRoot
 		{
 			get { return (string)GetValue(HybridRootProperty); }
 			set { SetValue(HybridRootProperty, value); }
 		}
 
-		void IHybridWebView.RawMessageReceived(string rawMessage)
+		void IHybridWebView.MessageReceived(string rawMessage)
 		{
-			RawMessageReceived?.Invoke(this, new HybridWebViewRawMessageReceivedEventArgs(rawMessage));
+			if (string.IsNullOrEmpty(rawMessage))
+			{
+				throw new ArgumentException($"The raw message cannot be null or empty.", nameof(rawMessage));
+			}
+			var indexOfPipe = rawMessage.IndexOf("|", StringComparison.Ordinal);
+			if (indexOfPipe == -1)
+			{
+				throw new ArgumentException($"The raw message must contain a pipe character ('|').", nameof(rawMessage));
+			}
+
+			var messageType = rawMessage.Substring(0, indexOfPipe);
+			var messageContent = rawMessage.Substring(indexOfPipe + 1);
+
+			switch (messageType)
+			{
+				case "InvokeMethodCompleted":
+					{
+						var sections = messageContent.Split('|');
+						var taskId = sections[0];
+						var result = sections[1];
+						AsyncTaskCompleted(taskId, result);
+					}
+					break;
+				case "RawMessage":
+					RawMessageReceived?.Invoke(this, new HybridWebViewRawMessageReceivedEventArgs(messageContent));
+					break;
+				default:
+					throw new ArgumentException($"The message type '{messageType}' is not recognized.", nameof(rawMessage));
+			}
 		}
 
 		/// <summary>
@@ -46,9 +77,163 @@ namespace Microsoft.Maui.Controls
 		/// </summary>
 		public event EventHandler<HybridWebViewRawMessageReceivedEventArgs>? RawMessageReceived;
 
+		/// <summary>
+		/// Sends a raw message to the code running in the web view. Raw messages have no additional processing.
+		/// </summary>
+		/// <param name="rawMessage"></param>
 		public void SendRawMessage(string rawMessage)
 		{
-			Handler?.Invoke(nameof(IHybridWebView.SendRawMessage), rawMessage);
+			Handler?.Invoke(
+				nameof(IHybridWebView.SendRawMessage),
+				new HybridWebViewRawMessage
+				{
+					Message = rawMessage,
+				});
+		}
+
+		private int _invokeTaskId;
+		private Dictionary<string, TaskCompletionSource<string>> asyncTaskCallbacks = new Dictionary<string, TaskCompletionSource<string>>();
+
+		/// <summary>
+		/// Handler for when the an Async JavaScript task has completed and needs to notify .NET.
+		/// </summary>
+		private void AsyncTaskCompleted(string taskId, string result)
+		{
+			//Look for the callback in the list of pending callbacks.
+			if (!string.IsNullOrEmpty(taskId) && asyncTaskCallbacks.ContainsKey(taskId))
+			{
+				//Get the callback and remove it from the list.
+				var callback = asyncTaskCallbacks[taskId];
+				callback.SetResult(result);
+
+				//Remove the callback.
+				asyncTaskCallbacks.Remove(taskId);
+			}
+		}
+
+		/// <summary>
+		/// Invokes a JavaScript method named <paramref name="methodName"/> and optionally passes in the parameter values
+		/// specified by <paramref name="paramValues"/>.
+		/// </summary>
+		/// <param name="methodName">The name of the JavaScript method to invoke.</param>
+		/// <param name="paramValues">Optional array of objects to be passed to the JavaScript method.</param>
+		/// <param name="paramJsonTypeInfos">Optional array of metadata about serializing the types of the parameters specified by <paramref name="paramValues"/>.</param>
+		/// <returns>A string containing the return value of the called method.</returns>
+#if WINDOWS || ANDROID || IOS || MACCATALYST
+		public async Task<string?> InvokeJavaScriptAsync(string methodName, object?[]? paramValues, JsonTypeInfo?[]? paramJsonTypeInfos = null)
+		{
+			if (string.IsNullOrEmpty(methodName))
+			{
+				throw new ArgumentException($"The method name cannot be null or empty.", nameof(methodName));
+			}
+			if (paramValues != null && paramJsonTypeInfos == null)
+			{
+				throw new ArgumentException($"The parameter values were provided, but the parameter JSON type infos were not.", nameof(paramJsonTypeInfos));
+			}
+			if (paramValues == null && paramJsonTypeInfos != null)
+			{
+				throw new ArgumentException($"The parameter JSON type infos were provided, but the parameter values were not.", nameof(paramValues));
+			}
+			if (paramValues != null && paramValues.Length != paramJsonTypeInfos!.Length)
+			{
+				throw new ArgumentException($"The number of parameter values does not match the number of parameter JSON type infos.", nameof(paramValues));
+			}
+
+			// Create a callback for async JavaScript methods to invoke when they are done
+			var callback = new TaskCompletionSource<string>();
+			var currentInvokeTaskId = $"{_invokeTaskId++}";
+			asyncTaskCallbacks.Add(currentInvokeTaskId, callback);
+
+			var paramsValuesStringArray =
+				paramValues == null
+				? string.Empty
+				: string.Join(
+					", ",
+					paramValues.Select((v, i) => (v == null ? "null" : JsonSerializer.Serialize(v, paramJsonTypeInfos![i]!))));
+
+			await EvaluateJavaScriptAsync($"window.HybridWebView.InvokeMethod({currentInvokeTaskId}, {methodName}, [{paramsValuesStringArray}])");
+
+			return await callback.Task;
+		}
+#else
+		public Task<string?> InvokeJavaScriptAsync(string methodName, object?[]? paramValues = null, object?[]? paramJsonTypeInfos = null)
+		{
+			_invokeTaskId++; // This is to avoid the compiler warning about the field not being used
+			throw new NotImplementedException();
+		}
+#endif
+
+		/// <summary>
+		/// Invokes a JavaScript method named <paramref name="methodName"/> and optionally passes in the parameter values specified
+		/// by <paramref name="paramValues"/> by JSON-encoding each one.
+		/// </summary>
+		/// <typeparam name="TReturnType">The type of the return value to deserialize from JSON.</typeparam>
+		/// <param name="methodName">The name of the JavaScript method to invoke.</param>
+		/// <param name="returnTypeJsonTypeInfo">Metadata about deserializing the type of the return value specified by <typeparamref name="TReturnType"/>.</param>
+		/// <param name="paramValues">Optional array of objects to be passed to the JavaScript method by JSON-encoding each one.</param>
+		/// <param name="paramJsonTypeInfos">Optional array of metadata about serializing the types of the parameters specified by <paramref name="paramValues"/>.</param>
+		/// <returns>An object of type <typeparamref name="TReturnType"/> containing the return value of the called method.</returns>
+#if WINDOWS || ANDROID || IOS || MACCATALYST
+		public async Task<TReturnType?> InvokeJavaScriptAsync<TReturnType>(string methodName, JsonTypeInfo<TReturnType?> returnTypeJsonTypeInfo, object?[]? paramValues = null, JsonTypeInfo?[]? paramJsonTypeInfos = null)
+		{
+			var stringResult = await InvokeJavaScriptAsync(methodName, paramValues, paramJsonTypeInfos);
+
+			if (stringResult is null)
+			{
+				return default;
+			}
+			return JsonSerializer.Deserialize<TReturnType?>(stringResult, returnTypeJsonTypeInfo);
+	}
+#else
+		public Task<TReturnType?> InvokeJavaScriptAsync<TReturnType>(string methodName, object returnTypeJsonTypeInfo, object?[]? paramValues, object?[]? paramJsonTypeInfos)
+		{
+			throw new NotImplementedException();
+		}
+#endif
+
+		/// <inheritdoc/>
+		public async Task<string?> EvaluateJavaScriptAsync(string script)
+		{
+			if (script == null)
+			{
+				return null;
+			}
+
+			// Make all the platforms mimic Android's implementation, which is by far the most complete.
+			if (DeviceInfo.Platform != DevicePlatform.Android)
+			{
+				script = WebView.EscapeJsString(script);
+
+				if (DeviceInfo.Platform != DevicePlatform.WinUI)
+				{
+					// Use JSON.stringify() method to converts a JavaScript value to a JSON string
+					script = "try{JSON.stringify(eval('" + script + "'))}catch(e){'null'};";
+				}
+				else
+				{
+					script = "try{eval('" + script + "')}catch(e){'null'};";
+				}
+			}
+
+			string? result;
+
+			// Use the handler command to evaluate the JS
+			result = await Handler!.InvokeAsync(nameof(IHybridWebView.EvaluateJavaScriptAsync),
+				new EvaluateJavaScriptAsyncRequest(script));
+
+			//if the js function errored or returned null/undefined treat it as null
+			if (result == "null")
+			{
+				result = null;
+			}
+			//JSON.stringify wraps the result in literal quotes, we just want the actual returned result
+			//note that if the js function returns the string "null" we will get here and not above
+			else if (result != null)
+			{
+				result = result.Trim('"');
+			}
+
+			return result;
 		}
 	}
 }

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -3,9 +3,12 @@ Microsoft.Maui.Controls.HandlerProperties
 Microsoft.Maui.Controls.HybridWebView
 Microsoft.Maui.Controls.HybridWebView.DefaultFile.get -> string?
 Microsoft.Maui.Controls.HybridWebView.DefaultFile.set -> void
+Microsoft.Maui.Controls.HybridWebView.EvaluateJavaScriptAsync(string! script) -> System.Threading.Tasks.Task<string?>!
 Microsoft.Maui.Controls.HybridWebView.HybridRoot.get -> string?
 Microsoft.Maui.Controls.HybridWebView.HybridRoot.set -> void
 Microsoft.Maui.Controls.HybridWebView.HybridWebView() -> void
+Microsoft.Maui.Controls.HybridWebView.InvokeJavaScriptAsync(string! methodName, object?[]? paramValues, System.Text.Json.Serialization.Metadata.JsonTypeInfo?[]? paramJsonTypeInfos = null) -> System.Threading.Tasks.Task<string?>!
+Microsoft.Maui.Controls.HybridWebView.InvokeJavaScriptAsync<TReturnType>(string! methodName, System.Text.Json.Serialization.Metadata.JsonTypeInfo<TReturnType?>! returnTypeJsonTypeInfo, object?[]? paramValues = null, System.Text.Json.Serialization.Metadata.JsonTypeInfo?[]? paramJsonTypeInfos = null) -> System.Threading.Tasks.Task<TReturnType?>!
 Microsoft.Maui.Controls.HybridWebView.RawMessageReceived -> System.EventHandler<Microsoft.Maui.Controls.HybridWebViewRawMessageReceivedEventArgs!>?
 Microsoft.Maui.Controls.HybridWebView.SendRawMessage(string! rawMessage) -> void
 Microsoft.Maui.Controls.HybridWebViewRawMessageReceivedEventArgs

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -34,9 +34,12 @@ Microsoft.Maui.Controls.Handlers.Items2.TemplatedCell2.TemplatedCell2(CoreGraphi
 Microsoft.Maui.Controls.HybridWebView
 Microsoft.Maui.Controls.HybridWebView.DefaultFile.get -> string?
 Microsoft.Maui.Controls.HybridWebView.DefaultFile.set -> void
+Microsoft.Maui.Controls.HybridWebView.EvaluateJavaScriptAsync(string! script) -> System.Threading.Tasks.Task<string?>!
 Microsoft.Maui.Controls.HybridWebView.HybridRoot.get -> string?
 Microsoft.Maui.Controls.HybridWebView.HybridRoot.set -> void
 Microsoft.Maui.Controls.HybridWebView.HybridWebView() -> void
+Microsoft.Maui.Controls.HybridWebView.InvokeJavaScriptAsync(string! methodName, object?[]? paramValues, System.Text.Json.Serialization.Metadata.JsonTypeInfo?[]? paramJsonTypeInfos = null) -> System.Threading.Tasks.Task<string?>!
+Microsoft.Maui.Controls.HybridWebView.InvokeJavaScriptAsync<TReturnType>(string! methodName, System.Text.Json.Serialization.Metadata.JsonTypeInfo<TReturnType?>! returnTypeJsonTypeInfo, object?[]? paramValues = null, System.Text.Json.Serialization.Metadata.JsonTypeInfo?[]? paramJsonTypeInfos = null) -> System.Threading.Tasks.Task<TReturnType?>!
 Microsoft.Maui.Controls.HybridWebView.RawMessageReceived -> System.EventHandler<Microsoft.Maui.Controls.HybridWebViewRawMessageReceivedEventArgs!>?
 Microsoft.Maui.Controls.HybridWebView.SendRawMessage(string! rawMessage) -> void
 Microsoft.Maui.Controls.HybridWebViewRawMessageReceivedEventArgs

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -34,9 +34,12 @@ Microsoft.Maui.Controls.Handlers.Items2.TemplatedCell2.TemplatedCell2(CoreGraphi
 Microsoft.Maui.Controls.HybridWebView
 Microsoft.Maui.Controls.HybridWebView.DefaultFile.get -> string?
 Microsoft.Maui.Controls.HybridWebView.DefaultFile.set -> void
+Microsoft.Maui.Controls.HybridWebView.EvaluateJavaScriptAsync(string! script) -> System.Threading.Tasks.Task<string?>!
 Microsoft.Maui.Controls.HybridWebView.HybridRoot.get -> string?
 Microsoft.Maui.Controls.HybridWebView.HybridRoot.set -> void
 Microsoft.Maui.Controls.HybridWebView.HybridWebView() -> void
+Microsoft.Maui.Controls.HybridWebView.InvokeJavaScriptAsync(string! methodName, object?[]? paramValues, System.Text.Json.Serialization.Metadata.JsonTypeInfo?[]? paramJsonTypeInfos = null) -> System.Threading.Tasks.Task<string?>!
+Microsoft.Maui.Controls.HybridWebView.InvokeJavaScriptAsync<TReturnType>(string! methodName, System.Text.Json.Serialization.Metadata.JsonTypeInfo<TReturnType?>! returnTypeJsonTypeInfo, object?[]? paramValues = null, System.Text.Json.Serialization.Metadata.JsonTypeInfo?[]? paramJsonTypeInfos = null) -> System.Threading.Tasks.Task<TReturnType?>!
 Microsoft.Maui.Controls.HybridWebView.RawMessageReceived -> System.EventHandler<Microsoft.Maui.Controls.HybridWebViewRawMessageReceivedEventArgs!>?
 Microsoft.Maui.Controls.HybridWebView.SendRawMessage(string! rawMessage) -> void
 Microsoft.Maui.Controls.HybridWebViewRawMessageReceivedEventArgs

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -3,9 +3,12 @@ Microsoft.Maui.Controls.HandlerProperties
 Microsoft.Maui.Controls.HybridWebView
 Microsoft.Maui.Controls.HybridWebView.DefaultFile.get -> string?
 Microsoft.Maui.Controls.HybridWebView.DefaultFile.set -> void
+Microsoft.Maui.Controls.HybridWebView.EvaluateJavaScriptAsync(string! script) -> System.Threading.Tasks.Task<string?>!
 Microsoft.Maui.Controls.HybridWebView.HybridRoot.get -> string?
 Microsoft.Maui.Controls.HybridWebView.HybridRoot.set -> void
 Microsoft.Maui.Controls.HybridWebView.HybridWebView() -> void
+Microsoft.Maui.Controls.HybridWebView.InvokeJavaScriptAsync(string! methodName, object?[]? paramValues = null, object?[]? paramJsonTypeInfos = null) -> System.Threading.Tasks.Task<string?>!
+Microsoft.Maui.Controls.HybridWebView.InvokeJavaScriptAsync<TReturnType>(string! methodName, object! returnTypeJsonTypeInfo, object?[]? paramValues, object?[]? paramJsonTypeInfos) -> System.Threading.Tasks.Task<TReturnType?>!
 Microsoft.Maui.Controls.HybridWebView.RawMessageReceived -> System.EventHandler<Microsoft.Maui.Controls.HybridWebViewRawMessageReceivedEventArgs!>?
 Microsoft.Maui.Controls.HybridWebView.SendRawMessage(string! rawMessage) -> void
 Microsoft.Maui.Controls.HybridWebViewRawMessageReceivedEventArgs

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -25,9 +25,12 @@ Microsoft.Maui.Controls.Handlers.Items.CarouselViewHandler.~CarouselViewHandler(
 Microsoft.Maui.Controls.HybridWebView
 Microsoft.Maui.Controls.HybridWebView.DefaultFile.get -> string?
 Microsoft.Maui.Controls.HybridWebView.DefaultFile.set -> void
+Microsoft.Maui.Controls.HybridWebView.EvaluateJavaScriptAsync(string! script) -> System.Threading.Tasks.Task<string?>!
 Microsoft.Maui.Controls.HybridWebView.HybridRoot.get -> string?
 Microsoft.Maui.Controls.HybridWebView.HybridRoot.set -> void
 Microsoft.Maui.Controls.HybridWebView.HybridWebView() -> void
+Microsoft.Maui.Controls.HybridWebView.InvokeJavaScriptAsync(string! methodName, object?[]? paramValues, System.Text.Json.Serialization.Metadata.JsonTypeInfo?[]? paramJsonTypeInfos = null) -> System.Threading.Tasks.Task<string?>!
+Microsoft.Maui.Controls.HybridWebView.InvokeJavaScriptAsync<TReturnType>(string! methodName, System.Text.Json.Serialization.Metadata.JsonTypeInfo<TReturnType?>! returnTypeJsonTypeInfo, object?[]? paramValues = null, System.Text.Json.Serialization.Metadata.JsonTypeInfo?[]? paramJsonTypeInfos = null) -> System.Threading.Tasks.Task<TReturnType?>!
 Microsoft.Maui.Controls.HybridWebView.RawMessageReceived -> System.EventHandler<Microsoft.Maui.Controls.HybridWebViewRawMessageReceivedEventArgs!>?
 Microsoft.Maui.Controls.HybridWebView.SendRawMessage(string! rawMessage) -> void
 Microsoft.Maui.Controls.HybridWebViewRawMessageReceivedEventArgs

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -3,9 +3,12 @@ Microsoft.Maui.Controls.HandlerProperties
 Microsoft.Maui.Controls.HybridWebView
 Microsoft.Maui.Controls.HybridWebView.DefaultFile.get -> string?
 Microsoft.Maui.Controls.HybridWebView.DefaultFile.set -> void
+Microsoft.Maui.Controls.HybridWebView.EvaluateJavaScriptAsync(string! script) -> System.Threading.Tasks.Task<string?>!
 Microsoft.Maui.Controls.HybridWebView.HybridRoot.get -> string?
 Microsoft.Maui.Controls.HybridWebView.HybridRoot.set -> void
 Microsoft.Maui.Controls.HybridWebView.HybridWebView() -> void
+Microsoft.Maui.Controls.HybridWebView.InvokeJavaScriptAsync(string! methodName, object?[]? paramValues = null, object?[]? paramJsonTypeInfos = null) -> System.Threading.Tasks.Task<string?>!
+Microsoft.Maui.Controls.HybridWebView.InvokeJavaScriptAsync<TReturnType>(string! methodName, object! returnTypeJsonTypeInfo, object?[]? paramValues, object?[]? paramJsonTypeInfos) -> System.Threading.Tasks.Task<TReturnType?>!
 Microsoft.Maui.Controls.HybridWebView.RawMessageReceived -> System.EventHandler<Microsoft.Maui.Controls.HybridWebViewRawMessageReceivedEventArgs!>?
 Microsoft.Maui.Controls.HybridWebView.SendRawMessage(string! rawMessage) -> void
 Microsoft.Maui.Controls.HybridWebViewRawMessageReceivedEventArgs

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -25,9 +25,12 @@ Microsoft.Maui.Controls.HandlerProperties
 Microsoft.Maui.Controls.HybridWebView
 Microsoft.Maui.Controls.HybridWebView.DefaultFile.get -> string?
 Microsoft.Maui.Controls.HybridWebView.DefaultFile.set -> void
+Microsoft.Maui.Controls.HybridWebView.EvaluateJavaScriptAsync(string! script) -> System.Threading.Tasks.Task<string?>!
 Microsoft.Maui.Controls.HybridWebView.HybridRoot.get -> string?
 Microsoft.Maui.Controls.HybridWebView.HybridRoot.set -> void
 Microsoft.Maui.Controls.HybridWebView.HybridWebView() -> void
+Microsoft.Maui.Controls.HybridWebView.InvokeJavaScriptAsync(string! methodName, object?[]? paramValues = null, object?[]? paramJsonTypeInfos = null) -> System.Threading.Tasks.Task<string?>!
+Microsoft.Maui.Controls.HybridWebView.InvokeJavaScriptAsync<TReturnType>(string! methodName, object! returnTypeJsonTypeInfo, object?[]? paramValues, object?[]? paramJsonTypeInfos) -> System.Threading.Tasks.Task<TReturnType?>!
 Microsoft.Maui.Controls.HybridWebView.RawMessageReceived -> System.EventHandler<Microsoft.Maui.Controls.HybridWebViewRawMessageReceivedEventArgs!>?
 Microsoft.Maui.Controls.HybridWebView.SendRawMessage(string! rawMessage) -> void
 Microsoft.Maui.Controls.HybridWebViewRawMessageReceivedEventArgs

--- a/src/Controls/src/Core/WebView/WebView.cs
+++ b/src/Controls/src/Core/WebView/WebView.cs
@@ -287,7 +287,7 @@ namespace Microsoft.Maui.Controls
 			return _platformConfigurationRegistry.Value.On<T>();
 		}
 
-		static string EscapeJsString(string js)
+		internal static string EscapeJsString(string js)
 		{
 			if (js == null)
 				return null;

--- a/src/Controls/tests/DeviceTests/Elements/HybridWebView/HybridWebViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/HybridWebView/HybridWebViewTests.cs
@@ -1,4 +1,7 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Hosting;
@@ -7,7 +10,7 @@ using Xunit;
 namespace Microsoft.Maui.DeviceTests
 {
 	[Category(TestCategory.HybridWebView)]
-	public class HybridWebViewTests : ControlsHandlerTestBase
+	public partial class HybridWebViewTests : ControlsHandlerTestBase
 	{
 		void SetupBuilder()
 		{
@@ -54,10 +57,10 @@ namespace Microsoft.Maui.DeviceTests
 
 				var platformView = handler.PlatformView;
 
-				// Setup the view to be displayed/parented and run our tests on it
+				// Set up the view to be displayed/parented and run our tests on it
 				await AttachAndRun(hybridWebView, async (handler) =>
 				{
-					await Task.Delay(5000);
+					await WaitForHybridWebViewLoaded(hybridWebView);
 
 					const string TestRawMessage = "Hybrid\"\"'' {Test} with chars!";
 					hybridWebView.SendRawMessage(TestRawMessage);
@@ -78,6 +81,276 @@ namespace Microsoft.Maui.DeviceTests
 					Assert.True(passed, $"Waited for raw message response but it never arrived or didn't match (last message: {lastRawMessage})");
 				});
 			});
+		}
+
+		[Fact]
+		public async Task InvokeJavaScriptMethodWithParametersAndNullsAndComplexResult()
+		{
+#if ANDROID
+			// NOTE: skip this test on older Android devices because it is not currently supported on these versions
+			if (!System.OperatingSystem.IsAndroidVersionAtLeast(24))
+			{
+				return;
+			}
+#endif
+
+			SetupBuilder();
+
+			await InvokeOnMainThreadAsync(async () =>
+			{
+				var hybridWebView = new HybridWebView()
+				{
+					WidthRequest = 100,
+					HeightRequest = 100,
+
+					HybridRoot = "HybridTestRoot",
+				};
+
+				var handler = CreateHandler(hybridWebView);
+
+				var platformView = handler.PlatformView;
+
+				// Set up the view to be displayed/parented and run our tests on it
+				await AttachAndRun(hybridWebView, async (handler) =>
+				{
+					await WaitForHybridWebViewLoaded(hybridWebView);
+
+					var x = 123.456m;
+					var y = 654.321m;
+
+					var result = await hybridWebView.InvokeJavaScriptAsync<ComputationResult>(
+						"AddNumbersWithNulls",
+						HybridWebViewTestContext.Default.ComputationResult,
+						new object[] { x, null, y, null },
+						new[] { HybridWebViewTestContext.Default.Decimal, null, HybridWebViewTestContext.Default.Decimal, null });
+
+					Assert.NotNull(result);
+					Assert.Equal(777.777m, result.result);
+					Assert.Equal("AdditionWithNulls", result.operationName);
+				});
+			});
+		}
+
+		[Fact]
+		public async Task InvokeJavaScriptMethodWithParametersAndResult()
+		{
+#if ANDROID
+			// NOTE: skip this test on older Android devices because it is not currently supported on these versions
+			if (!System.OperatingSystem.IsAndroidVersionAtLeast(24))
+			{
+				return;
+			}
+#endif
+
+			SetupBuilder();
+
+			await InvokeOnMainThreadAsync(async () =>
+			{
+				var hybridWebView = new HybridWebView()
+				{
+					WidthRequest = 100,
+					HeightRequest = 100,
+
+					HybridRoot = "HybridTestRoot",
+				};
+
+				var handler = CreateHandler(hybridWebView);
+
+				var platformView = handler.PlatformView;
+
+				// Set up the view to be displayed/parented and run our tests on it
+				await AttachAndRun(hybridWebView, async (handler) =>
+				{
+					await WaitForHybridWebViewLoaded(hybridWebView);
+
+					var x = 123.456m;
+					var y = 654.321m;
+
+					var result = await hybridWebView.InvokeJavaScriptAsync<decimal>(
+						"EvaluateMeWithParamsAndReturn",
+						HybridWebViewTestContext.Default.Decimal,
+						new object[] { x, y },
+						new[] { HybridWebViewTestContext.Default.Decimal, HybridWebViewTestContext.Default.Decimal });
+
+					Assert.Equal(777.777m, result);
+				});
+			});
+		}
+
+		[Fact]
+		public async Task InvokeJavaScriptMethodWithParametersAndComplexResult()
+		{
+#if ANDROID
+			// NOTE: skip this test on older Android devices because it is not currently supported on these versions
+			if (!System.OperatingSystem.IsAndroidVersionAtLeast(24))
+			{
+				return;
+			}
+#endif
+
+			SetupBuilder();
+
+			await InvokeOnMainThreadAsync(async () =>
+			{
+				var hybridWebView = new HybridWebView()
+				{
+					WidthRequest = 100,
+					HeightRequest = 100,
+
+					HybridRoot = "HybridTestRoot",
+				};
+
+				var handler = CreateHandler(hybridWebView);
+
+				var platformView = handler.PlatformView;
+
+				// Set up the view to be displayed/parented and run our tests on it
+				await AttachAndRun(hybridWebView, async (handler) =>
+				{
+					await WaitForHybridWebViewLoaded(hybridWebView);
+
+					var x = 123.456m;
+					var y = 654.321m;
+
+					var result = await hybridWebView.InvokeJavaScriptAsync<ComputationResult>(
+						"AddNumbers",
+						HybridWebViewTestContext.Default.ComputationResult,
+						new object[] { x, y },
+						new[] { HybridWebViewTestContext.Default.Decimal, HybridWebViewTestContext.Default.Decimal });
+
+					Assert.NotNull(result);
+					Assert.Equal(777.777m, result.result);
+					Assert.Equal("Addition", result.operationName);
+				});
+			});
+		}
+
+		[Fact]
+		public async Task InvokeAsyncJavaScriptMethodWithParametersAndComplexResult()
+		{
+#if ANDROID
+			// NOTE: skip this test on older Android devices because it is not currently supported on these versions
+			if (!System.OperatingSystem.IsAndroidVersionAtLeast(24))
+			{
+				return;
+			}
+#endif
+
+			SetupBuilder();
+
+			await InvokeOnMainThreadAsync(async () =>
+			{
+				var hybridWebView = new HybridWebView()
+				{
+					WidthRequest = 100,
+					HeightRequest = 100,
+
+					HybridRoot = "HybridTestRoot",
+				};
+
+				var handler = CreateHandler(hybridWebView);
+
+				var platformView = handler.PlatformView;
+
+				// Set up the view to be displayed/parented and run our tests on it
+				await AttachAndRun(hybridWebView, async (handler) =>
+				{
+					await WaitForHybridWebViewLoaded(hybridWebView);
+
+					var s1 = "new_key";
+					var s2 = "new_value";
+
+					var result = await hybridWebView.InvokeJavaScriptAsync<Dictionary<string, string>>(
+						"EvaluateMeWithParamsAndAsyncReturn",
+						HybridWebViewTestContext.Default.DictionaryStringString,
+						new object[] { s1, s2 },
+						new[] { HybridWebViewTestContext.Default.String, HybridWebViewTestContext.Default.String });
+
+					Assert.NotNull(result);
+					Assert.Equal(3, result.Count);
+					Assert.Equal("value1", result["key1"]);
+					Assert.Equal("value2", result["key2"]);
+					Assert.Equal(s2, result[s1]);
+				});
+			});
+		}
+
+		[Fact]
+		public async Task EvaluateJavaScriptAndGetResult()
+		{
+#if ANDROID
+			// NOTE: skip this test on older Android devices because it is not currently supported on these versions
+			if (!System.OperatingSystem.IsAndroidVersionAtLeast(24))
+			{
+				return;
+			}
+#endif
+
+			SetupBuilder();
+
+			await InvokeOnMainThreadAsync(async () =>
+			{
+				var hybridWebView = new HybridWebView()
+				{
+					WidthRequest = 100,
+					HeightRequest = 100,
+
+					HybridRoot = "HybridTestRoot",
+				};
+
+				var handler = CreateHandler(hybridWebView);
+
+				var platformView = handler.PlatformView;
+
+				// Set up the view to be displayed/parented and run our tests on it
+				await AttachAndRun(hybridWebView, async (handler) =>
+				{
+					await WaitForHybridWebViewLoaded(hybridWebView);
+
+					// Run some JavaScript to call a method and get result
+					var result1 = await hybridWebView.EvaluateJavaScriptAsync("EvaluateMeWithParamsAndReturn('abc', 'def')");
+					Assert.Equal("abcdef", result1);
+
+					// Run some JavaScript to get an arbitrary result by running JavaScript
+					var result2 = await hybridWebView.EvaluateJavaScriptAsync("window.TestKey");
+					Assert.Equal("test_value", result2);
+				});
+			});
+		}
+
+		public class ComputationResult
+		{
+			public decimal result { get; set; }
+			public string operationName { get; set; }
+		}
+
+		[JsonSourceGenerationOptions(WriteIndented = true)]
+		[JsonSerializable(typeof(ComputationResult))]
+		[JsonSerializable(typeof(decimal))]
+		[JsonSerializable(typeof(string))]
+		[JsonSerializable(typeof(Dictionary<string, string>))]
+		internal partial class HybridWebViewTestContext : JsonSerializerContext
+		{
+		}
+
+		private async Task WaitForHybridWebViewLoaded(HybridWebView hybridWebView)
+		{
+			const int NumRetries = 10;
+			const int RetryDelay = 500;
+			for (var i = 0; i < NumRetries; i++)
+			{
+				// 1. Check that the window.HybridWebView object exists (as set by HybridWebView.js)
+				// 2. Check that the test page's HTML is loaded by checking for the HTML element defined in the Resources\Raw\HybridTestRoot\index.html test page
+				var loaded = await hybridWebView.EvaluateJavaScriptAsync("Object.hasOwn(window, 'HybridWebView') && (document.getElementById('htmlLoaded') !== null)");
+				if (loaded == "true")
+				{
+					return;
+				}
+
+				await Task.Delay(RetryDelay);
+			}
+
+			Assert.Fail($"Waited {NumRetries * RetryDelay:N0}ms for the HybridWebView test page to be ready, but it wasn't.");
 		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Resources/Raw/HybridTestRoot/asyncdata.txt
+++ b/src/Controls/tests/DeviceTests/Resources/Raw/HybridTestRoot/asyncdata.txt
@@ -1,0 +1,4 @@
+﻿{
+    "key1": "value1",
+    "key2": "value2"
+}

--- a/src/Controls/tests/DeviceTests/Resources/Raw/HybridTestRoot/index.html
+++ b/src/Controls/tests/DeviceTests/Resources/Raw/HybridTestRoot/index.html
@@ -4,6 +4,7 @@
 <head>
     <meta charset="utf-8" />
     <title></title>
+    <link rel="icon" href="data:,">
     <script src="scripts/HybridWebView.js"></script>
     <script>
         window.addEventListener(
@@ -13,11 +14,51 @@
 
                 window.HybridWebView.SendRawMessage('You said: ' + msg)
             });
+
+        // test method invoke with simple parameters and simple return value
+        // test evaluate javascript to invoke
+        function EvaluateMeWithParamsAndReturn(s1, s2) {
+            return s1 + s2;
+        }
+
+        // test method invoke with parameters, and returning complex type
+        function AddNumbers(a, b) {
+            var result = {
+                "result": a + b,
+                "operationName": "Addition"
+            };
+            return result;
+        }
+
+        // test method invoke with parameters and nulls, and returning complex type
+        function AddNumbersWithNulls(a, null1, b, null2) {
+            var result = {
+                "result": a + b,
+                "operationName": "AdditionWithNulls"
+            };
+            return result;
+        }
+
+        // test async method invoke with parameters, and returning complex type
+        async function EvaluateMeWithParamsAndAsyncReturn(s1, s2) {
+            const response = await fetch("/asyncdata.txt");
+            if (!response.ok) {
+                    throw new Error(`HTTP error: ${response.status}`);
+            }
+            var jsonData = await response.json();
+            jsonData[s1] = s2;
+            return jsonData;
+        }
+
+        // test evaluate arbitrary javascript
+        window.TestKey = 'test_value';
+
     </script>
 </head>
 <body>
     <div>
         Hybrid test!
     </div>
+    <div id="htmlLoaded"></div>
 </body>
 </html>

--- a/src/Controls/tests/DeviceTests/Resources/Raw/HybridTestRoot/scripts/HybridWebView.js
+++ b/src/Controls/tests/DeviceTests/Resources/Raw/HybridTestRoot/scripts/HybridWebView.js
@@ -1,48 +1,78 @@
-﻿function HybridWebViewInit() {
-
-    function DispatchHybridWebViewMessage(message) {
-        const event = new CustomEvent("HybridWebViewMessageReceived", { detail: { message: message } });
-        window.dispatchEvent(event);
-    }
-
-    if (window.chrome && window.chrome.webview) {
-        // Windows WebView2
-        window.chrome.webview.addEventListener('message', arg => {
-            DispatchHybridWebViewMessage(arg.data);
-        });
-    }
-    else if (window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.webwindowinterop) {
-        // iOS and MacCatalyst WKWebView
-        window.external = {
-            "receiveMessage": message => {
-                DispatchHybridWebViewMessage(message);
-            }
-        };
-    }
-    else {
-        // Android WebView
-        window.addEventListener('message', arg => {
-            DispatchHybridWebViewMessage(arg.data);
-        });
-    }
-}
-
-window.HybridWebView = {
-    "SendRawMessage": function (message) {
+﻿window.HybridWebView = {
+    "Init": function () {
+        function DispatchHybridWebViewMessage(message) {
+            const event = new CustomEvent("HybridWebViewMessageReceived", { detail: { message: message } });
+            window.dispatchEvent(event);
+        }
 
         if (window.chrome && window.chrome.webview) {
             // Windows WebView2
-            window.chrome.webview.postMessage(message);
+            window.chrome.webview.addEventListener('message', arg => {
+                DispatchHybridWebViewMessage(arg.data);
+            });
         }
         else if (window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.webwindowinterop) {
             // iOS and MacCatalyst WKWebView
-            window.webkit.messageHandlers.webwindowinterop.postMessage(message);
+            window.external = {
+                "receiveMessage": message => {
+                    DispatchHybridWebViewMessage(message);
+                }
+            };
         }
         else {
             // Android WebView
-            hybridWebViewHost.sendRawMessage(message);
+            window.addEventListener('message', arg => {
+                DispatchHybridWebViewMessage(arg.data);
+            });
         }
+    },
+
+    "SendRawMessage": function (message) {
+        window.HybridWebView.__SendMessageInternal('RawMessage', message);
+    },
+
+    "__SendMessageInternal": function (type, message) {
+
+        const messageToSend = type + '|' + message;
+
+        if (window.chrome && window.chrome.webview) {
+            // Windows WebView2
+            window.chrome.webview.postMessage(messageToSend);
+        }
+        else if (window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.webwindowinterop) {
+            // iOS and MacCatalyst WKWebView
+            window.webkit.messageHandlers.webwindowinterop.postMessage(messageToSend);
+        }
+        else {
+            // Android WebView
+            hybridWebViewHost.sendMessage(messageToSend);
+        }
+    },
+
+    "InvokeMethod": function (taskId, methodName, args) {
+        if (methodName[Symbol.toStringTag] === 'AsyncFunction') {
+            // For async methods, we need to call the method and then trigger the callback when it's done
+            const asyncPromise = methodName(...args);
+            asyncPromise
+                .then(asyncResult => {
+                    window.HybridWebView.__TriggerAsyncCallback(taskId, asyncResult);
+                })
+                .catch(error => console.error(error));
+        } else {
+            // For sync methods, we can call the method and trigger the callback immediately
+            const syncResult = methodName(...args);
+            window.HybridWebView.__TriggerAsyncCallback(taskId, syncResult);
+        }
+    },
+
+    "__TriggerAsyncCallback": function (taskId, result) {
+        // Make sure the result is a string
+        if (result && typeof (result) !== 'string') {
+            result = JSON.stringify(result);
+        }
+
+        window.HybridWebView.__SendMessageInternal('InvokeMethodCompleted', taskId + '|' + result);
     }
 }
 
-HybridWebViewInit();
+window.HybridWebView.Init();

--- a/src/Core/src/Core/IHybridWebView.cs
+++ b/src/Core/src/Core/IHybridWebView.cs
@@ -1,18 +1,31 @@
-﻿namespace Microsoft.Maui
+﻿using System.Threading.Tasks;
+
+namespace Microsoft.Maui
 {
 	public interface IHybridWebView : IView
 	{
+		/// <summary>
+		/// Specifies the file within the <see cref="HybridRoot"/> that should be served as the default file. The
+		/// default value is <c>index.html</c>.
+		/// </summary>
 		string? DefaultFile { get; }
 
 		/// <summary>
 		///  The path within the app's "Raw" asset resources that contain the web app's contents. For example, if the
 		///  files are located in <c>[ProjectFolder]/Resources/Raw/hybrid_root</c>, then set this property to "hybrid_root".
-		///  The default value is <c>HybridRoot</c>, which maps to <c>[ProjectFolder]/Resources/Raw/HybridRoot</c>.
+		///  The default value is <c>wwwroot</c>, which maps to <c>[ProjectFolder]/Resources/Raw/wwwroot</c>.
 		/// </summary>
 		string? HybridRoot { get; }
 
-		void RawMessageReceived(string rawMessage);
+		void MessageReceived(string rawMessage);
 
 		void SendRawMessage(string rawMessage);
+
+		/// <summary>
+		/// Runs the JavaScript code provided in the <paramref name="script"/> parameter and returns the result as a string.
+		/// </summary>
+		/// <param name="script">The JavaScript code to run.</param>
+		/// <returns>The return value (if any) of running the script.</returns>
+		Task<string?> EvaluateJavaScriptAsync(string script);
 	}
 }

--- a/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.Android.cs
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.Android.cs
@@ -1,9 +1,6 @@
 ﻿using System;
 using Android.Webkit;
 using Java.Interop;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
 using static Android.Views.ViewGroup;
 using AWebView = Android.Webkit.WebView;
 
@@ -50,10 +47,10 @@ namespace Microsoft.Maui.Handlers
 			private HybridWebViewHandler? Handler => _hybridWebViewHandler is not null && _hybridWebViewHandler.TryGetTarget(out var h) ? h : null;
 
 			[JavascriptInterface]
-			[Export("sendRawMessage")]
-			public void SendRawMessage(string message)
+			[Export("sendMessage")]
+			public void SendMessage(string message)
 			{
-				Handler?.VirtualView?.RawMessageReceived(message);
+				Handler?.VirtualView?.MessageReceived(message);
 			}
 		}
 
@@ -90,14 +87,22 @@ namespace Microsoft.Maui.Handlers
 			base.DisconnectHandler(platformView);
 		}
 
+		public static void MapEvaluateJavaScriptAsync(IHybridWebViewHandler handler, IHybridWebView hybridWebView, object? arg)
+		{
+			if (arg is EvaluateJavaScriptAsyncRequest request)
+			{
+				handler.PlatformView.EvaluateJavaScript(request);
+			}
+		}
+
 		public static void MapSendRawMessage(IHybridWebViewHandler handler, IHybridWebView hybridWebView, object? arg)
 		{
-			if (arg is not string rawMessage || handler.PlatformView is not IHybridPlatformWebView hybridPlatformWebView)
+			if (arg is not HybridWebViewRawMessage hybridWebViewRawMessage || handler.PlatformView is not IHybridPlatformWebView hybridPlatformWebView)
 			{
 				return;
 			}
 
-			hybridPlatformWebView.SendRawMessage(rawMessage);
+			hybridPlatformWebView.SendRawMessage(hybridWebViewRawMessage.Message ?? "");
 		}
 	}
 }

--- a/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.Standard.cs
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.Standard.cs
@@ -6,6 +6,8 @@ namespace Microsoft.Maui.Handlers
 	{
 		protected override object CreatePlatformView() => throw new NotImplementedException();
 
+		public static void MapEvaluateJavaScriptAsync(IHybridWebViewHandler handler, IHybridWebView hybridWebView, object? arg) { }
+
 		public static void MapSendRawMessage(IHybridWebViewHandler handler, IHybridWebView hybridWebView, object? arg) { }
 	}
 }

--- a/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.Tizen.cs
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.Tizen.cs
@@ -6,6 +6,8 @@ namespace Microsoft.Maui.Handlers
 	{
 		protected override Tizen.NUI.BaseComponents.View CreatePlatformView() => throw new NotImplementedException();
 
+		public static void MapEvaluateJavaScriptAsync(IHybridWebViewHandler handler, IHybridWebView hybridWebView, object? arg) { }
+
 		public static void MapSendRawMessage(IHybridWebViewHandler handler, IHybridWebView hybridWebView, object? arg) { }
 	}
 }

--- a/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.cs
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.cs
@@ -49,7 +49,8 @@ namespace Microsoft.Maui.Handlers
 
         public static CommandMapper<IHybridWebView, IHybridWebViewHandler> CommandMapper = new(ViewCommandMapper)
         {
-            [nameof(IHybridWebView.SendRawMessage)] = MapSendRawMessage,
+			[nameof(IHybridWebView.EvaluateJavaScriptAsync)] = MapEvaluateJavaScriptAsync,
+			[nameof(IHybridWebView.SendRawMessage)] = MapSendRawMessage,
         };
 
         public HybridWebViewHandler() : base(Mapper, CommandMapper)

--- a/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.iOS.cs
@@ -1,15 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
-using System.Net;
 using System.Runtime.Versioning;
-using System.Text;
 using System.Threading.Tasks;
 using Foundation;
-using Microsoft.Extensions.Logging;
-using Microsoft.Maui.Graphics;
 using UIKit;
 using WebKit;
 using RectangleF = CoreGraphics.CGRect;
@@ -65,19 +59,33 @@ namespace Microsoft.Maui.Handlers
 			return new MauiHybridWebView(this, RectangleF.Empty, config);
 		}
 
+		public static void MapEvaluateJavaScriptAsync(IHybridWebViewHandler handler, IHybridWebView hybridWebView, object? arg)
+		{
+			if (arg is EvaluateJavaScriptAsyncRequest request)
+			{
+				if (handler.PlatformView is null)
+				{
+					request.SetCanceled();
+					return;
+				}
+
+				handler.PlatformView.EvaluateJavaScript(request);
+			}
+		}
+
 		public static void MapSendRawMessage(IHybridWebViewHandler handler, IHybridWebView hybridWebView, object? arg)
 		{
-			if (arg is not string rawMessage || handler.PlatformView is not IHybridPlatformWebView hybridPlatformWebView)
+			if (arg is not HybridWebViewRawMessage hybridWebViewRawMessage || handler.PlatformView is not IHybridPlatformWebView hybridPlatformWebView)
 			{
 				return;
 			}
 
-			hybridPlatformWebView.SendRawMessage(rawMessage);
+			hybridPlatformWebView.SendRawMessage(hybridWebViewRawMessage.Message ?? "");
 		}
 
 		private void MessageReceived(Uri uri, string message)
 		{
-			VirtualView?.RawMessageReceived(message);
+			VirtualView?.MessageReceived(message);
 		}
 
 		protected override void ConnectHandler(WKWebView platformView)

--- a/src/Core/src/Platform/Windows/MauiHybridWebView.cs
+++ b/src/Core/src/Platform/Windows/MauiHybridWebView.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.Web.WebView2.Core;
 
@@ -7,6 +8,7 @@ namespace Microsoft.Maui.Platform
 	public class MauiHybridWebView : WebView2, IHybridPlatformWebView
 	{
 		private readonly WeakReference<HybridWebViewHandler> _handler;
+		internal Task<bool>? WebViewReadyTask { get; set; }
 
 		public MauiHybridWebView(HybridWebViewHandler handler)
 		{
@@ -17,6 +19,16 @@ namespace Microsoft.Maui.Platform
 		public void SendRawMessage(string rawMessage)
 		{
 			CoreWebView2.PostWebMessageAsString(rawMessage);
+		}
+
+		public async void RunAfterInitialize(Action action)
+		{
+			var isWebViewInitialized = await WebViewReadyTask!;
+
+			if (isWebViewInitialized)
+			{
+				action();
+			}
 		}
 	}
 }

--- a/src/Core/src/Primitives/HybridWebViewRawMessage.cs
+++ b/src/Core/src/Primitives/HybridWebViewRawMessage.cs
@@ -1,0 +1,13 @@
+﻿namespace Microsoft.Maui
+{
+	/// <summary>
+	/// Represents a raw message received used the HybridWebView.
+	/// </summary>
+	public class HybridWebViewRawMessage
+	{
+		/// <summary>
+		/// The content of the message.
+		/// </summary>
+		public string? Message { get; set; }
+	}
+}

--- a/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -16,10 +16,15 @@ Microsoft.Maui.Handlers.IHybridWebViewHandler
 Microsoft.Maui.Handlers.IHybridWebViewHandler.PlatformView.get -> Android.Webkit.WebView!
 Microsoft.Maui.Handlers.IHybridWebViewHandler.VirtualView.get -> Microsoft.Maui.IHybridWebView!
 Microsoft.Maui.Handlers.ISwipeItemMenuItemHandler.SourceLoader.get -> Microsoft.Maui.Platform.ImageSourcePartLoader?
+Microsoft.Maui.HybridWebViewRawMessage
+Microsoft.Maui.HybridWebViewRawMessage.HybridWebViewRawMessage() -> void
+Microsoft.Maui.HybridWebViewRawMessage.Message.get -> string?
+Microsoft.Maui.HybridWebViewRawMessage.Message.set -> void
 Microsoft.Maui.IHybridWebView
 Microsoft.Maui.IHybridWebView.DefaultFile.get -> string?
+Microsoft.Maui.IHybridWebView.EvaluateJavaScriptAsync(string! script) -> System.Threading.Tasks.Task<string?>!
 Microsoft.Maui.IHybridWebView.HybridRoot.get -> string?
-Microsoft.Maui.IHybridWebView.RawMessageReceived(string! rawMessage) -> void
+Microsoft.Maui.IHybridWebView.MessageReceived(string! rawMessage) -> void
 Microsoft.Maui.IHybridWebView.SendRawMessage(string! rawMessage) -> void
 Microsoft.Maui.IKeyboardAccelerator
 Microsoft.Maui.ElementHandlerExtensions
@@ -138,6 +143,7 @@ static Microsoft.Maui.GridLength.operator ==(Microsoft.Maui.GridLength left, Mic
 static Microsoft.Maui.Handlers.EditorHandler.MapIsSpellCheckEnabled(Microsoft.Maui.Handlers.IEditorHandler! handler, Microsoft.Maui.IEditor! editor) -> void
 static Microsoft.Maui.Handlers.EntryHandler.MapIsSpellCheckEnabled(Microsoft.Maui.Handlers.IEntryHandler! handler, Microsoft.Maui.IEntry! entry) -> void
 static Microsoft.Maui.Handlers.HybridWebViewHandler.CommandMapper -> Microsoft.Maui.CommandMapper<Microsoft.Maui.IHybridWebView!, Microsoft.Maui.Handlers.IHybridWebViewHandler!>!
+static Microsoft.Maui.Handlers.HybridWebViewHandler.MapEvaluateJavaScriptAsync(Microsoft.Maui.Handlers.IHybridWebViewHandler! handler, Microsoft.Maui.IHybridWebView! hybridWebView, object? arg) -> void
 static Microsoft.Maui.Handlers.HybridWebViewHandler.Mapper -> Microsoft.Maui.IPropertyMapper<Microsoft.Maui.IHybridWebView!, Microsoft.Maui.Handlers.IHybridWebViewHandler!>!
 static Microsoft.Maui.Handlers.HybridWebViewHandler.MapSendRawMessage(Microsoft.Maui.Handlers.IHybridWebViewHandler! handler, Microsoft.Maui.IHybridWebView! hybridWebView, object? arg) -> void
 static Microsoft.Maui.Handlers.ImageButtonHandler.MapBackground(Microsoft.Maui.Handlers.IImageButtonHandler! handler, Microsoft.Maui.IImageButton! imageButton) -> void

--- a/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -19,10 +19,15 @@ Microsoft.Maui.Handlers.ISwipeItemMenuItemHandler.SourceLoader.get -> Microsoft.
 Microsoft.Maui.Handlers.SwipeItemButton
 Microsoft.Maui.Handlers.SwipeItemButton.FrameChanged -> System.EventHandler?
 Microsoft.Maui.Handlers.SwipeItemButton.SwipeItemButton() -> void
+Microsoft.Maui.HybridWebViewRawMessage
+Microsoft.Maui.HybridWebViewRawMessage.HybridWebViewRawMessage() -> void
+Microsoft.Maui.HybridWebViewRawMessage.Message.get -> string?
+Microsoft.Maui.HybridWebViewRawMessage.Message.set -> void
 Microsoft.Maui.IHybridWebView
 Microsoft.Maui.IHybridWebView.DefaultFile.get -> string?
+Microsoft.Maui.IHybridWebView.EvaluateJavaScriptAsync(string! script) -> System.Threading.Tasks.Task<string?>!
 Microsoft.Maui.IHybridWebView.HybridRoot.get -> string?
-Microsoft.Maui.IHybridWebView.RawMessageReceived(string! rawMessage) -> void
+Microsoft.Maui.IHybridWebView.MessageReceived(string! rawMessage) -> void
 Microsoft.Maui.IHybridWebView.SendRawMessage(string! rawMessage) -> void
 Microsoft.Maui.IKeyboardAccelerator
 Microsoft.Maui.IKeyboardAccelerator.Key.get -> string?
@@ -128,6 +133,7 @@ static Microsoft.Maui.CommandMapperExtensions.ReplaceMapping<TVirtualView, TView
 static Microsoft.Maui.GridLength.operator !=(Microsoft.Maui.GridLength left, Microsoft.Maui.GridLength right) -> bool
 static Microsoft.Maui.GridLength.operator ==(Microsoft.Maui.GridLength left, Microsoft.Maui.GridLength right) -> bool
 static Microsoft.Maui.Handlers.HybridWebViewHandler.CommandMapper -> Microsoft.Maui.CommandMapper<Microsoft.Maui.IHybridWebView!, Microsoft.Maui.Handlers.IHybridWebViewHandler!>!
+static Microsoft.Maui.Handlers.HybridWebViewHandler.MapEvaluateJavaScriptAsync(Microsoft.Maui.Handlers.IHybridWebViewHandler! handler, Microsoft.Maui.IHybridWebView! hybridWebView, object? arg) -> void
 static Microsoft.Maui.Handlers.HybridWebViewHandler.Mapper -> Microsoft.Maui.IPropertyMapper<Microsoft.Maui.IHybridWebView!, Microsoft.Maui.Handlers.IHybridWebViewHandler!>!
 static Microsoft.Maui.Handlers.HybridWebViewHandler.MapSendRawMessage(Microsoft.Maui.Handlers.IHybridWebViewHandler! handler, Microsoft.Maui.IHybridWebView! hybridWebView, object? arg) -> void
 static Microsoft.Maui.Handlers.MenuBarItemHandler.MapIsEnabled(Microsoft.Maui.Handlers.IMenuBarItemHandler! handler, Microsoft.Maui.IMenuBarItem! view) -> void

--- a/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -18,10 +18,15 @@ Microsoft.Maui.Handlers.ISwipeItemMenuItemHandler.SourceLoader.get -> Microsoft.
 Microsoft.Maui.Handlers.SwipeItemButton
 Microsoft.Maui.Handlers.SwipeItemButton.FrameChanged -> System.EventHandler?
 Microsoft.Maui.Handlers.SwipeItemButton.SwipeItemButton() -> void
+Microsoft.Maui.HybridWebViewRawMessage
+Microsoft.Maui.HybridWebViewRawMessage.HybridWebViewRawMessage() -> void
+Microsoft.Maui.HybridWebViewRawMessage.Message.get -> string?
+Microsoft.Maui.HybridWebViewRawMessage.Message.set -> void
 Microsoft.Maui.IHybridWebView
 Microsoft.Maui.IHybridWebView.DefaultFile.get -> string?
+Microsoft.Maui.IHybridWebView.EvaluateJavaScriptAsync(string! script) -> System.Threading.Tasks.Task<string?>!
 Microsoft.Maui.IHybridWebView.HybridRoot.get -> string?
-Microsoft.Maui.IHybridWebView.RawMessageReceived(string! rawMessage) -> void
+Microsoft.Maui.IHybridWebView.MessageReceived(string! rawMessage) -> void
 Microsoft.Maui.IHybridWebView.SendRawMessage(string! rawMessage) -> void
 Microsoft.Maui.IKeyboardAccelerator
 Microsoft.Maui.ElementHandlerExtensions
@@ -132,6 +137,7 @@ static Microsoft.Maui.CommandMapperExtensions.ReplaceMapping<TVirtualView, TView
 static Microsoft.Maui.GridLength.operator !=(Microsoft.Maui.GridLength left, Microsoft.Maui.GridLength right) -> bool
 static Microsoft.Maui.GridLength.operator ==(Microsoft.Maui.GridLength left, Microsoft.Maui.GridLength right) -> bool
 static Microsoft.Maui.Handlers.HybridWebViewHandler.CommandMapper -> Microsoft.Maui.CommandMapper<Microsoft.Maui.IHybridWebView!, Microsoft.Maui.Handlers.IHybridWebViewHandler!>!
+static Microsoft.Maui.Handlers.HybridWebViewHandler.MapEvaluateJavaScriptAsync(Microsoft.Maui.Handlers.IHybridWebViewHandler! handler, Microsoft.Maui.IHybridWebView! hybridWebView, object? arg) -> void
 static Microsoft.Maui.Handlers.HybridWebViewHandler.Mapper -> Microsoft.Maui.IPropertyMapper<Microsoft.Maui.IHybridWebView!, Microsoft.Maui.Handlers.IHybridWebViewHandler!>!
 static Microsoft.Maui.Handlers.HybridWebViewHandler.MapSendRawMessage(Microsoft.Maui.Handlers.IHybridWebViewHandler! handler, Microsoft.Maui.IHybridWebView! hybridWebView, object? arg) -> void
 static Microsoft.Maui.Handlers.MenuBarItemHandler.MapIsEnabled(Microsoft.Maui.Handlers.IMenuBarItemHandler! handler, Microsoft.Maui.IMenuBarItem! view) -> void

--- a/src/Core/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -13,6 +13,10 @@ Microsoft.Maui.Handlers.IHybridWebViewHandler
 Microsoft.Maui.Handlers.IHybridWebViewHandler.PlatformView.get -> Tizen.NUI.BaseComponents.View!
 Microsoft.Maui.Handlers.IHybridWebViewHandler.VirtualView.get -> Microsoft.Maui.IHybridWebView!
 Microsoft.Maui.Handlers.ISwipeItemMenuItemHandler.SourceLoader.get -> Microsoft.Maui.Platform.ImageSourcePartLoader?
+Microsoft.Maui.HybridWebViewRawMessage
+Microsoft.Maui.HybridWebViewRawMessage.HybridWebViewRawMessage() -> void
+Microsoft.Maui.HybridWebViewRawMessage.Message.get -> string?
+Microsoft.Maui.HybridWebViewRawMessage.Message.set -> void
 Microsoft.Maui.IApplication.UserAppTheme.get -> Microsoft.Maui.ApplicationModel.AppTheme
 Microsoft.Maui.Hosting.MauiApp.DisposeAsync() -> System.Threading.Tasks.ValueTask
 Microsoft.Maui.ElementHandlerExtensions
@@ -31,8 +35,9 @@ Microsoft.Maui.ICrossPlatformLayoutBacking.CrossPlatformLayout.get -> Microsoft.
 Microsoft.Maui.ICrossPlatformLayoutBacking.CrossPlatformLayout.set -> void
 Microsoft.Maui.IHybridWebView
 Microsoft.Maui.IHybridWebView.DefaultFile.get -> string?
+Microsoft.Maui.IHybridWebView.EvaluateJavaScriptAsync(string! script) -> System.Threading.Tasks.Task<string?>!
 Microsoft.Maui.IHybridWebView.HybridRoot.get -> string?
-Microsoft.Maui.IHybridWebView.RawMessageReceived(string! rawMessage) -> void
+Microsoft.Maui.IHybridWebView.MessageReceived(string! rawMessage) -> void
 Microsoft.Maui.IHybridWebView.SendRawMessage(string! rawMessage) -> void
 Microsoft.Maui.Layouts.FlexBasis.Equals(Microsoft.Maui.Layouts.FlexBasis other) -> bool
 Microsoft.Maui.KeyboardAcceleratorModifiers
@@ -70,6 +75,7 @@ static Microsoft.Maui.GridLength.operator ==(Microsoft.Maui.GridLength left, Mic
 static Microsoft.Maui.Handlers.EditorHandler.MapIsSpellCheckEnabled(Microsoft.Maui.Handlers.IEditorHandler! handler, Microsoft.Maui.IEditor! editor) -> void
 static Microsoft.Maui.Handlers.EntryHandler.MapIsSpellCheckEnabled(Microsoft.Maui.Handlers.IEntryHandler! handler, Microsoft.Maui.IEntry! entry) -> void
 static Microsoft.Maui.Handlers.HybridWebViewHandler.CommandMapper -> Microsoft.Maui.CommandMapper<Microsoft.Maui.IHybridWebView!, Microsoft.Maui.Handlers.IHybridWebViewHandler!>!
+static Microsoft.Maui.Handlers.HybridWebViewHandler.MapEvaluateJavaScriptAsync(Microsoft.Maui.Handlers.IHybridWebViewHandler! handler, Microsoft.Maui.IHybridWebView! hybridWebView, object? arg) -> void
 static Microsoft.Maui.Handlers.HybridWebViewHandler.Mapper -> Microsoft.Maui.IPropertyMapper<Microsoft.Maui.IHybridWebView!, Microsoft.Maui.Handlers.IHybridWebViewHandler!>!
 static Microsoft.Maui.Handlers.HybridWebViewHandler.MapSendRawMessage(Microsoft.Maui.Handlers.IHybridWebViewHandler! handler, Microsoft.Maui.IHybridWebView! hybridWebView, object? arg) -> void
 static Microsoft.Maui.Handlers.SearchBarHandler.MapIsSpellCheckEnabled(Microsoft.Maui.Handlers.ISearchBarHandler! handler, Microsoft.Maui.ISearchBar! searchBar) -> void

--- a/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -14,10 +14,15 @@ Microsoft.Maui.Handlers.IHybridWebViewHandler.PlatformView.get -> Microsoft.UI.X
 Microsoft.Maui.Handlers.IHybridWebViewHandler.VirtualView.get -> Microsoft.Maui.IHybridWebView!
 Microsoft.Maui.Handlers.ISwipeItemMenuItemHandler.SourceLoader.get -> Microsoft.Maui.Platform.ImageSourcePartLoader?
 Microsoft.Maui.ElementHandlerExtensions
+Microsoft.Maui.HybridWebViewRawMessage
+Microsoft.Maui.HybridWebViewRawMessage.HybridWebViewRawMessage() -> void
+Microsoft.Maui.HybridWebViewRawMessage.Message.get -> string?
+Microsoft.Maui.HybridWebViewRawMessage.Message.set -> void
 Microsoft.Maui.IHybridWebView
 Microsoft.Maui.IHybridWebView.DefaultFile.get -> string?
+Microsoft.Maui.IHybridWebView.EvaluateJavaScriptAsync(string! script) -> System.Threading.Tasks.Task<string?>!
 Microsoft.Maui.IHybridWebView.HybridRoot.get -> string?
-Microsoft.Maui.IHybridWebView.RawMessageReceived(string! rawMessage) -> void
+Microsoft.Maui.IHybridWebView.MessageReceived(string! rawMessage) -> void
 Microsoft.Maui.IHybridWebView.SendRawMessage(string! rawMessage) -> void
 Microsoft.Maui.IKeyboardAccelerator
 Microsoft.Maui.IKeyboardAccelerator.Key.get -> string?
@@ -61,6 +66,7 @@ Microsoft.Maui.Platform.ImageSourcePartLoader.ImageSourcePartLoader(Microsoft.Ma
 Microsoft.Maui.Platform.KeyboardAcceleratorExtensions
 Microsoft.Maui.Platform.MauiHybridWebView
 Microsoft.Maui.Platform.MauiHybridWebView.MauiHybridWebView(Microsoft.Maui.Handlers.HybridWebViewHandler! handler) -> void
+Microsoft.Maui.Platform.MauiHybridWebView.RunAfterInitialize(System.Action! action) -> void
 Microsoft.Maui.Platform.MauiHybridWebView.SendRawMessage(string! rawMessage) -> void
 Microsoft.Maui.Platform.MauiPanel
 Microsoft.Maui.Platform.MauiPanel.CrossPlatformLayout.get -> Microsoft.Maui.ICrossPlatformLayout?
@@ -96,6 +102,7 @@ static Microsoft.Maui.GridLength.operator ==(Microsoft.Maui.GridLength left, Mic
 static Microsoft.Maui.Handlers.EditorHandler.MapIsSpellCheckEnabled(Microsoft.Maui.Handlers.IEditorHandler! handler, Microsoft.Maui.IEditor! editor) -> void
 static Microsoft.Maui.Handlers.EntryHandler.MapIsSpellCheckEnabled(Microsoft.Maui.Handlers.IEntryHandler! handler, Microsoft.Maui.IEntry! entry) -> void
 static Microsoft.Maui.Handlers.HybridWebViewHandler.CommandMapper -> Microsoft.Maui.CommandMapper<Microsoft.Maui.IHybridWebView!, Microsoft.Maui.Handlers.IHybridWebViewHandler!>!
+static Microsoft.Maui.Handlers.HybridWebViewHandler.MapEvaluateJavaScriptAsync(Microsoft.Maui.Handlers.IHybridWebViewHandler! handler, Microsoft.Maui.IHybridWebView! hybridWebView, object? arg) -> void
 static Microsoft.Maui.Handlers.HybridWebViewHandler.Mapper -> Microsoft.Maui.IPropertyMapper<Microsoft.Maui.IHybridWebView!, Microsoft.Maui.Handlers.IHybridWebViewHandler!>!
 static Microsoft.Maui.Handlers.HybridWebViewHandler.MapSendRawMessage(Microsoft.Maui.Handlers.IHybridWebViewHandler! handler, Microsoft.Maui.IHybridWebView! hybridWebView, object? arg) -> void
 static Microsoft.Maui.Handlers.LayoutHandler.MapInputTransparent(Microsoft.Maui.ILayoutHandler! handler, Microsoft.Maui.ILayout! layout) -> void

--- a/src/Core/src/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -14,10 +14,15 @@ Microsoft.Maui.Handlers.IHybridWebViewHandler
 Microsoft.Maui.Handlers.IHybridWebViewHandler.PlatformView.get -> object!
 Microsoft.Maui.Handlers.IHybridWebViewHandler.VirtualView.get -> Microsoft.Maui.IHybridWebView!
 Microsoft.Maui.Handlers.ISwipeItemMenuItemHandler.SourceLoader.get -> Microsoft.Maui.Platform.ImageSourcePartLoader?
+Microsoft.Maui.HybridWebViewRawMessage
+Microsoft.Maui.HybridWebViewRawMessage.HybridWebViewRawMessage() -> void
+Microsoft.Maui.HybridWebViewRawMessage.Message.get -> string?
+Microsoft.Maui.HybridWebViewRawMessage.Message.set -> void
 Microsoft.Maui.IHybridWebView
 Microsoft.Maui.IHybridWebView.DefaultFile.get -> string?
+Microsoft.Maui.IHybridWebView.EvaluateJavaScriptAsync(string! script) -> System.Threading.Tasks.Task<string?>!
 Microsoft.Maui.IHybridWebView.HybridRoot.get -> string?
-Microsoft.Maui.IHybridWebView.RawMessageReceived(string! rawMessage) -> void
+Microsoft.Maui.IHybridWebView.MessageReceived(string! rawMessage) -> void
 Microsoft.Maui.IHybridWebView.SendRawMessage(string! rawMessage) -> void
 Microsoft.Maui.IKeyboardAccelerator
 Microsoft.Maui.IKeyboardAccelerator.Key.get -> string?
@@ -77,6 +82,7 @@ static Microsoft.Maui.GridLength.operator ==(Microsoft.Maui.GridLength left, Mic
 static Microsoft.Maui.Handlers.EditorHandler.MapIsSpellCheckEnabled(Microsoft.Maui.Handlers.IEditorHandler! handler, Microsoft.Maui.IEditor! editor) -> void
 static Microsoft.Maui.Handlers.EntryHandler.MapIsSpellCheckEnabled(Microsoft.Maui.Handlers.IEntryHandler! handler, Microsoft.Maui.IEntry! entry) -> void
 static Microsoft.Maui.Handlers.HybridWebViewHandler.CommandMapper -> Microsoft.Maui.CommandMapper<Microsoft.Maui.IHybridWebView!, Microsoft.Maui.Handlers.IHybridWebViewHandler!>!
+static Microsoft.Maui.Handlers.HybridWebViewHandler.MapEvaluateJavaScriptAsync(Microsoft.Maui.Handlers.IHybridWebViewHandler! handler, Microsoft.Maui.IHybridWebView! hybridWebView, object? arg) -> void
 static Microsoft.Maui.Handlers.HybridWebViewHandler.Mapper -> Microsoft.Maui.IPropertyMapper<Microsoft.Maui.IHybridWebView!, Microsoft.Maui.Handlers.IHybridWebViewHandler!>!
 static Microsoft.Maui.Handlers.HybridWebViewHandler.MapSendRawMessage(Microsoft.Maui.Handlers.IHybridWebViewHandler! handler, Microsoft.Maui.IHybridWebView! hybridWebView, object? arg) -> void
 static Microsoft.Maui.Handlers.SearchBarHandler.MapIsSpellCheckEnabled(Microsoft.Maui.IViewHandler! handler, Microsoft.Maui.ISearchBar! searchBar) -> void

--- a/src/Core/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -14,6 +14,10 @@ Microsoft.Maui.Handlers.IHybridWebViewHandler.PlatformView.get -> object!
 Microsoft.Maui.Handlers.IHybridWebViewHandler.VirtualView.get -> Microsoft.Maui.IHybridWebView!
 Microsoft.Maui.Handlers.ISwipeItemMenuItemHandler.SourceLoader.get -> Microsoft.Maui.Platform.ImageSourcePartLoader?
 Microsoft.Maui.IApplication.ActivateWindow(Microsoft.Maui.IWindow! window) -> void
+Microsoft.Maui.HybridWebViewRawMessage
+Microsoft.Maui.HybridWebViewRawMessage.HybridWebViewRawMessage() -> void
+Microsoft.Maui.HybridWebViewRawMessage.Message.get -> string?
+Microsoft.Maui.HybridWebViewRawMessage.Message.set -> void
 Microsoft.Maui.IApplication.UserAppTheme.get -> Microsoft.Maui.ApplicationModel.AppTheme
 Microsoft.Maui.Hosting.MauiApp.DisposeAsync() -> System.Threading.Tasks.ValueTask
 Microsoft.Maui.ElementHandlerExtensions
@@ -25,8 +29,9 @@ Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>.Add(string! key, Syste
 Microsoft.Maui.ICommandMapper<TVirtualView, TViewHandler>.Add(string! key, System.Action<TViewHandler, TVirtualView>! action) -> void
 Microsoft.Maui.IHybridWebView
 Microsoft.Maui.IHybridWebView.DefaultFile.get -> string?
+Microsoft.Maui.IHybridWebView.EvaluateJavaScriptAsync(string! script) -> System.Threading.Tasks.Task<string?>!
 Microsoft.Maui.IHybridWebView.HybridRoot.get -> string?
-Microsoft.Maui.IHybridWebView.RawMessageReceived(string! rawMessage) -> void
+Microsoft.Maui.IHybridWebView.MessageReceived(string! rawMessage) -> void
 Microsoft.Maui.IHybridWebView.SendRawMessage(string! rawMessage) -> void
 Microsoft.Maui.ITextInput.IsSpellCheckEnabled.get -> bool
 Microsoft.Maui.ICrossPlatformLayout
@@ -77,6 +82,7 @@ static Microsoft.Maui.Handlers.ApplicationHandler.MapActivateWindow(Microsoft.Ma
 static Microsoft.Maui.Handlers.EditorHandler.MapIsSpellCheckEnabled(Microsoft.Maui.Handlers.IEditorHandler! handler, Microsoft.Maui.IEditor! editor) -> void
 static Microsoft.Maui.Handlers.EntryHandler.MapIsSpellCheckEnabled(Microsoft.Maui.Handlers.IEntryHandler! handler, Microsoft.Maui.IEntry! entry) -> void
 static Microsoft.Maui.Handlers.HybridWebViewHandler.CommandMapper -> Microsoft.Maui.CommandMapper<Microsoft.Maui.IHybridWebView!, Microsoft.Maui.Handlers.IHybridWebViewHandler!>!
+static Microsoft.Maui.Handlers.HybridWebViewHandler.MapEvaluateJavaScriptAsync(Microsoft.Maui.Handlers.IHybridWebViewHandler! handler, Microsoft.Maui.IHybridWebView! hybridWebView, object? arg) -> void
 static Microsoft.Maui.Handlers.HybridWebViewHandler.Mapper -> Microsoft.Maui.IPropertyMapper<Microsoft.Maui.IHybridWebView!, Microsoft.Maui.Handlers.IHybridWebViewHandler!>!
 static Microsoft.Maui.Handlers.HybridWebViewHandler.MapSendRawMessage(Microsoft.Maui.Handlers.IHybridWebViewHandler! handler, Microsoft.Maui.IHybridWebView! hybridWebView, object? arg) -> void
 static Microsoft.Maui.Handlers.SearchBarHandler.MapIsSpellCheckEnabled(Microsoft.Maui.IViewHandler! handler, Microsoft.Maui.ISearchBar! searchBar) -> void

--- a/src/Core/src/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -14,10 +14,15 @@ Microsoft.Maui.Handlers.IHybridWebViewHandler.PlatformView.get -> object!
 Microsoft.Maui.Handlers.IHybridWebViewHandler.VirtualView.get -> Microsoft.Maui.IHybridWebView!
 Microsoft.Maui.Handlers.ISwipeItemMenuItemHandler.SourceLoader.get -> Microsoft.Maui.Platform.ImageSourcePartLoader?
 Microsoft.Maui.IApplication.ActivateWindow(Microsoft.Maui.IWindow! window) -> void
+Microsoft.Maui.HybridWebViewRawMessage
+Microsoft.Maui.HybridWebViewRawMessage.HybridWebViewRawMessage() -> void
+Microsoft.Maui.HybridWebViewRawMessage.Message.get -> string?
+Microsoft.Maui.HybridWebViewRawMessage.Message.set -> void
 Microsoft.Maui.IHybridWebView
 Microsoft.Maui.IHybridWebView.DefaultFile.get -> string?
+Microsoft.Maui.IHybridWebView.EvaluateJavaScriptAsync(string! script) -> System.Threading.Tasks.Task<string?>!
 Microsoft.Maui.IHybridWebView.HybridRoot.get -> string?
-Microsoft.Maui.IHybridWebView.RawMessageReceived(string! rawMessage) -> void
+Microsoft.Maui.IHybridWebView.MessageReceived(string! rawMessage) -> void
 Microsoft.Maui.IHybridWebView.SendRawMessage(string! rawMessage) -> void
 Microsoft.Maui.IKeyboardAccelerator
 Microsoft.Maui.IKeyboardAccelerator.Key.get -> string?
@@ -79,6 +84,7 @@ static Microsoft.Maui.Handlers.ApplicationHandler.MapActivateWindow(Microsoft.Ma
 static Microsoft.Maui.Handlers.EditorHandler.MapIsSpellCheckEnabled(Microsoft.Maui.Handlers.IEditorHandler! handler, Microsoft.Maui.IEditor! editor) -> void
 static Microsoft.Maui.Handlers.EntryHandler.MapIsSpellCheckEnabled(Microsoft.Maui.Handlers.IEntryHandler! handler, Microsoft.Maui.IEntry! entry) -> void
 static Microsoft.Maui.Handlers.HybridWebViewHandler.CommandMapper -> Microsoft.Maui.CommandMapper<Microsoft.Maui.IHybridWebView!, Microsoft.Maui.Handlers.IHybridWebViewHandler!>!
+static Microsoft.Maui.Handlers.HybridWebViewHandler.MapEvaluateJavaScriptAsync(Microsoft.Maui.Handlers.IHybridWebViewHandler! handler, Microsoft.Maui.IHybridWebView! hybridWebView, object? arg) -> void
 static Microsoft.Maui.Handlers.HybridWebViewHandler.Mapper -> Microsoft.Maui.IPropertyMapper<Microsoft.Maui.IHybridWebView!, Microsoft.Maui.Handlers.IHybridWebViewHandler!>!
 static Microsoft.Maui.Handlers.HybridWebViewHandler.MapSendRawMessage(Microsoft.Maui.Handlers.IHybridWebViewHandler! handler, Microsoft.Maui.IHybridWebView! hybridWebView, object? arg) -> void
 static Microsoft.Maui.Handlers.SearchBarHandler.MapIsSpellCheckEnabled(Microsoft.Maui.IViewHandler! handler, Microsoft.Maui.ISearchBar! searchBar) -> void


### PR DESCRIPTION
### Description of Change

**Before we get started**: HUGE thank you to @rbrundritt for working on a key part of this for async JavaScript method support!

Enable C# code to invoke methods running in JS in the WebView. The methods can be invoked as async, have optional return values, and optional parameters. The parameters and return values are serialized using JSON.

#### Example

With some simple JavaScript code like this:

```js
function AddNumbers(x, y) {
    return x + y;
}
```

And you can invoke it from C# like this:

```c#
var x = 123m;
var y = 321m;
var sum = await hybridWebView.InvokeJavaScriptAsync<decimal>(
    "AddNumbers", // JavaScript method name
    JsInvokeContext.Default.Decimal, // JSON serialization info for return type
    new object[] { x, y }, // parameter values
    new[] { JsInvokeContext.Default.Decimal, JsInvokeContext.Default.Decimal }); // JSON serialization info for each parameter
);

// sum is now 444

[JsonSourceGenerationOptions(WriteIndented = true)]
[JsonSerializable(typeof(decimal))]
[JsonSerializable(typeof(Dictionary<string, string>))]
internal partial class JsInvokeContext : JsonSerializerContext
{
    // This type's attributes specify JSON serialization info to preserve type structure for optimized/trimmed builds
}
```

And then with a bit more complex async JavaScript code like this:

```js
        async function GetAsyncData() {
            const response = await fetch("/asyncdata.txt");
            if (!response.ok) {
                    throw new Error(`HTTP error: ${response.status}`);
            }
            return await response.json();
        }
```

You can invoke it from C# like this:

```c#
var jsonDictionaryResult = await hybridWebView.InvokeJavaScriptAsync<Dictionary<string,string>>(
    "GetAsyncData", // JavaScript method name
    JsInvokeContext.Default.DictionaryStringString, // JSON serialization info for return type
    null, // this method has no parameter values
    null); // this method doesn't JSON serialization info for each parameter
);

// result is now a dictionary containing the JSON data from the web request, such as [key1]=value1, [key2]=value2
```


### Issues Fixed

Fixes #22303