### PR TITLE
`IWindow.Content` can be null in Core

### DIFF
--- a/src/Core/src/Core/Extensions/VisualTreeElementExtensions.cs
+++ b/src/Core/src/Core/Extensions/VisualTreeElementExtensions.cs
@@ -136,7 +136,7 @@ namespace Microsoft.Maui
 			var visualElements = new List<IVisualTreeElement>();
 			if (visualElement is IWindow window)
 			{
-				uiElement = window.Content.ToPlatform();
+				uiElement = window.Content?.ToPlatform();
 			}
 			else if (visualElement is IView view)
 			{

--- a/src/Core/src/Platform/iOS/ElementExtensions.cs
+++ b/src/Core/src/Platform/iOS/ElementExtensions.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Maui.Platform
 
 		public static UIViewController ToUIViewController(this IElement view, IMauiContext context)
 		{
-			var platformView = view.ToPlatform(context);
+			var platformView = view?.ToPlatform(context);
 			if (view?.Handler is IPlatformViewHandler nvh && nvh.ViewController != null)
 				return nvh.ViewController;
 

--- a/src/Core/src/Platform/iOS/ElementExtensions.cs
+++ b/src/Core/src/Platform/iOS/ElementExtensions.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Maui.Platform
 
 		public static UIViewController ToUIViewController(this IElement view, IMauiContext context)
 		{
-			var platformView = view?.ToPlatform(context);
+			var _ = view?.ToPlatform(context);
 			if (view?.Handler is IPlatformViewHandler nvh && nvh.ViewController != null)
 				return nvh.ViewController;
 

--- a/src/Core/src/Platform/iOS/ElementExtensions.cs
+++ b/src/Core/src/Platform/iOS/ElementExtensions.cs
@@ -11,6 +11,8 @@ namespace Microsoft.Maui.Platform
 
 		public static UIViewController ToUIViewController(this IElement view, IMauiContext context)
 		{
+			// The returned value is not used here, but this method is used to set 
+			// up the platform view and handler. So, do not delete!
 			var _ = view?.ToPlatform(context);
 			if (view?.Handler is IPlatformViewHandler nvh && nvh.ViewController != null)
 				return nvh.ViewController;


### PR DESCRIPTION
### Description of Change

In some cases, like embedding, there is no real MAUI window but instead we have a proxy window.

This PR just adds null checking, and in net9.0 we can make the property nullable in Core.