### PR TITLE
[draft][XAML] `OnPlatform` doesn't work with `AppThemeBinding` in Release mode

### DIFF
--- a/src/Controls/tests/Xaml.UnitTests/OnPlatform.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/OnPlatform.xaml
@@ -60,8 +60,9 @@
 				</OnPlatform>
 			</Label.HeightRequest>
 		</Label>
-        <Button x:Name="button0" Style="{StaticResource ButtonStyle0}" Text="Button label" />
-        <Button x:Name="button1" Style="{StaticResource ButtonStyle1}" Text="Button label" />
-        <Button x:Name="button2" FontSize="{OnPlatform iOS=36}" Text="Button label" />
+		<Button x:Name="button0" Style="{StaticResource ButtonStyle0}" Text="Button label" />
+		<Button x:Name="button1" Style="{StaticResource ButtonStyle1}" Text="Button label" />
+		<Button x:Name="button2" FontSize="{OnPlatform iOS=36}" Text="Button label" />
+		<Button x:Name="button3" FontSize="{OnPlatform iOS={AppThemeBinding Light=10, Dark=12, Default=14}, WinUI={AppThemeBinding Light=16, Dark=18, Default=20}, Default=22}" Text="Button label" />
 	</StackLayout>
 </ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/OnPlatform.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/OnPlatform.xaml.cs
@@ -184,6 +184,23 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 				layout = new OnPlatform(useCompiledXaml);
 				Assert.AreEqual(0.0, layout.button2.FontSize);
 			}
+
+			[TestCase(false)]
+			[TestCase(true)]
+			public void OnPlatformInlineWithAppThemeBinding(bool useCompiledXaml)
+			{
+				mockDeviceInfo.Platform = DevicePlatform.iOS;
+				var layout = new OnPlatform(useCompiledXaml);
+				Assert.AreEqual(10, layout.button3.FontSize);
+
+				mockDeviceInfo.Platform = DevicePlatform.MacCatalyst;
+				layout = new OnPlatform(useCompiledXaml);
+				Assert.AreEqual(22, layout.button3.FontSize);
+
+				mockDeviceInfo.Platform = DevicePlatform.WinUI;
+				layout = new OnPlatform(useCompiledXaml);
+				Assert.AreEqual(16, layout.button3.FontSize);
+			}
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change

This PR adds a unit test to show that the issue is really in the release mode. The test passed in the debug configuration.

![image](https://github.com/user-attachments/assets/67e0fdf1-72dd-47ac-819b-a10b3fd3d036)


Complete `OnPlatform.cs` 

<details><summary>Details</summary>

```cs
using System;
using System.CodeDom.Compiler;
using System.Collections.Generic;
using System.Diagnostics.CodeAnalysis;
using System.Reflection;
using Microsoft.Maui.Controls.Core.UnitTests;
using Microsoft.Maui.Controls.Internals;
using Microsoft.Maui.Controls.Xaml.Internals;
using Microsoft.Maui.Devices;
using NUnit.Framework;

namespace Microsoft.Maui.Controls.Xaml.UnitTests;

[XamlFilePath("OnPlatform.xaml")]
public class OnPlatform : ContentPage
{
	[TestFixture]
	public class Tests
	{
		private MockDeviceInfo mockDeviceInfo;

		[SetUp]
		public void Setup()
		{
			DeviceInfo.SetCurrent(mockDeviceInfo = new MockDeviceInfo());
		}

		[TearDown]
		public void TearDown()
		{
			DeviceInfo.SetCurrent(null);
		}

		[TestCase(false)]
		[TestCase(true)]
		public void BoolToVisibility(bool useCompiledXaml)
		{
			mockDeviceInfo.Platform = DevicePlatform.iOS;
			OnPlatform layout = new OnPlatform(useCompiledXaml);
			Assert.AreEqual(true, layout.label0.IsVisible);
			mockDeviceInfo.Platform = DevicePlatform.Android;
			layout = new OnPlatform(useCompiledXaml);
			Assert.AreEqual(false, layout.label0.IsVisible);
		}

		[TestCase(false)]
		[TestCase(true)]
		public void DoubleToWidth(bool useCompiledXaml)
		{
			mockDeviceInfo.Platform = DevicePlatform.iOS;
			OnPlatform layout = new OnPlatform(useCompiledXaml);
			Assert.AreEqual(20, layout.label0.WidthRequest);
			mockDeviceInfo.Platform = DevicePlatform.Android;
			layout = new OnPlatform(useCompiledXaml);
			Assert.AreEqual(30, layout.label0.WidthRequest);
			mockDeviceInfo.Platform = DevicePlatform.MacCatalyst;
			layout = new OnPlatform(useCompiledXaml);
			Assert.AreEqual(0.0, layout.label0.WidthRequest);
		}

		[TestCase(false)]
		[TestCase(true)]
		public void StringToText(bool useCompiledXaml)
		{
			mockDeviceInfo.Platform = DevicePlatform.iOS;
			OnPlatform layout = new OnPlatform(useCompiledXaml);
			Assert.AreEqual("Foo", layout.label0.Text);
			mockDeviceInfo.Platform = DevicePlatform.Android;
			layout = new OnPlatform(useCompiledXaml);
			Assert.AreEqual("Bar", layout.label0.Text);
			mockDeviceInfo.Platform = DevicePlatform.MacCatalyst;
			layout = new OnPlatform(useCompiledXaml);
			Assert.AreEqual(null, layout.label0.Text);
		}

		[TestCase(false)]
		[TestCase(true)]
		public void OnPlatformAsResource(bool useCompiledXaml)
		{
			OnPlatform layout = new OnPlatform(useCompiledXaml);
			OnPlatform<FontAttributes> onplat = layout.Resources["fontAttributes"] as OnPlatform<FontAttributes>;
			Assert.NotNull(onplat);
			mockDeviceInfo.Platform = DevicePlatform.iOS;
			Assert.AreEqual(FontAttributes.Bold, (FontAttributes)onplat);
			mockDeviceInfo.Platform = DevicePlatform.Android;
			Assert.AreEqual(FontAttributes.Italic, (FontAttributes)onplat);
			mockDeviceInfo.Platform = DevicePlatform.MacCatalyst;
			Assert.AreEqual(FontAttributes.None, (FontAttributes)onplat);
		}

		[TestCase(false)]
		[TestCase(true)]
		public void OnPlatformAsResourceAreApplied(bool useCompiledXaml)
		{
			mockDeviceInfo.Platform = DevicePlatform.iOS;
			OnPlatform layout = new OnPlatform(useCompiledXaml);
			OnIdiom<double> onidiom = layout.Resources["fontSize"] as OnIdiom<double>;
			Assert.NotNull(onidiom);
			Assert.That(onidiom.Phone, Is.TypeOf<double>());
			Assert.AreEqual(20, onidiom.Phone);
			Assert.AreEqual(FontAttributes.Bold, layout.label0.FontAttributes);
			mockDeviceInfo.Platform = DevicePlatform.Android;
			layout = new OnPlatform(useCompiledXaml);
			Assert.AreEqual(FontAttributes.Italic, layout.label0.FontAttributes);
		}

		[TestCase(false)]
		[TestCase(true)]
		public void OnPlatform2Syntax(bool useCompiledXaml)
		{
			mockDeviceInfo.Platform = DevicePlatform.Android;
			OnPlatform layout = new OnPlatform(useCompiledXaml);
			Assert.AreEqual(42, layout.label0.HeightRequest);
			mockDeviceInfo.Platform = DevicePlatform.iOS;
			layout = new OnPlatform(useCompiledXaml);
			Assert.AreEqual(21, layout.label0.HeightRequest);
			mockDeviceInfo.Platform = DevicePlatform.MacCatalyst;
			layout = new OnPlatform(useCompiledXaml);
			Assert.AreEqual(63.0, layout.label0.HeightRequest);
			mockDeviceInfo.Platform = DevicePlatform.Create("FooBar");
			layout = new OnPlatform(useCompiledXaml);
			Assert.AreEqual(42, layout.label0.HeightRequest);
		}

		[TestCase(false)]
		[TestCase(true)]
		public void OnPlatformDefault(bool useCompiledXaml)
		{
			mockDeviceInfo.Platform = DevicePlatform.Create("\ud83d\ude80");
			OnPlatform layout = new OnPlatform(useCompiledXaml);
			Assert.AreEqual(63, layout.label0.HeightRequest);
		}

		[TestCase(false)]
		[TestCase(true)]
		public void OnPlatformInStyle0(bool useCompiledXaml)
		{
			mockDeviceInfo.Platform = DevicePlatform.iOS;
			OnPlatform layout = new OnPlatform(useCompiledXaml);
			Assert.AreEqual(36, layout.button0.FontSize);
			mockDeviceInfo.Platform = DevicePlatform.MacCatalyst;
			layout = new OnPlatform(useCompiledXaml);
			Assert.AreEqual(0.0, layout.button0.FontSize);
		}

		[TestCase(false)]
		[TestCase(true)]
		public void OnPlatformInStyle1(bool useCompiledXaml)
		{
			mockDeviceInfo.Platform = DevicePlatform.iOS;
			OnPlatform layout = new OnPlatform(useCompiledXaml);
			Assert.AreEqual(36, layout.button1.FontSize);
			mockDeviceInfo.Platform = DevicePlatform.MacCatalyst;
			layout = new OnPlatform(useCompiledXaml);
			Assert.AreEqual(0.0, layout.button1.FontSize);
		}

		[TestCase(false)]
		[TestCase(true)]
		public void OnPlatformInline(bool useCompiledXaml)
		{
			mockDeviceInfo.Platform = DevicePlatform.iOS;
			OnPlatform layout = new OnPlatform(useCompiledXaml);
			Assert.AreEqual(36, layout.button2.FontSize);
			mockDeviceInfo.Platform = DevicePlatform.MacCatalyst;
			layout = new OnPlatform(useCompiledXaml);
			Assert.AreEqual(0.0, layout.button2.FontSize);
		}

		[TestCase(false)]
		[TestCase(true)]
		public void OnPlatformInlineWithAppThemeBinding(bool useCompiledXaml)
		{
			mockDeviceInfo.Platform = DevicePlatform.WinUI;
			OnPlatform layout = new OnPlatform(useCompiledXaml);
			Assert.AreEqual(10, layout.button3.FontSize);
			mockDeviceInfo.Platform = DevicePlatform.MacCatalyst;
			layout = new OnPlatform(useCompiledXaml);
			Assert.AreEqual(16, layout.button3.FontSize);
		}
	}

	[GeneratedCode("Microsoft.Maui.Controls.SourceGen", "1.0.0.0")]
	private Label label0;

	[GeneratedCode("Microsoft.Maui.Controls.SourceGen", "1.0.0.0")]
	private Button button0;

	[GeneratedCode("Microsoft.Maui.Controls.SourceGen", "1.0.0.0")]
	private Button button1;

	[GeneratedCode("Microsoft.Maui.Controls.SourceGen", "1.0.0.0")]
	private Button button2;

	[GeneratedCode("Microsoft.Maui.Controls.SourceGen", "1.0.0.0")]
	private Button button3;

	public OnPlatform()
	{
		InitializeComponent();
	}

	public OnPlatform(bool useCompiledXaml)
	{
		if (useCompiledXaml)
		{
			InitializeComponent();
		}
		else
		{
			__InitComponentRuntime();
		}
	}

	[GeneratedCode("Microsoft.Maui.Controls.SourceGen", "1.0.0.0")]
	[MemberNotNull("label0")]
	[MemberNotNull("button0")]
	[MemberNotNull("button1")]
	[MemberNotNull("button2")]
	[MemberNotNull("button3")]
	private void InitializeComponent()
	{
		On on = new On();
		On on2 = new On();
		OnPlatform<FontAttributes> onPlatform = new OnPlatform<FontAttributes>();
		On on3 = new On();
		On on4 = new On();
		On on5 = new On();
		OnPlatform<double> onPlatform2 = new OnPlatform<double>();
		On on6 = new On();
		On on7 = new On();
		On on8 = new On();
		OnPlatform<double> onPlatform3 = new OnPlatform<double>();
		StaticResourceExtension staticResourceExtension = new StaticResourceExtension();
		StaticResourceExtension staticResourceExtension2 = new StaticResourceExtension();
		OnIdiom<double> onIdiom = new OnIdiom<double>();
		OnPlatformExtension onPlatformExtension = new OnPlatformExtension();
		Setter setter = new Setter();
		Style style = new Style(typeof(Button));
		On on9 = new On();
		OnPlatform<double> onPlatform4 = new OnPlatform<double>();
		Setter setter2 = new Setter();
		Style style2 = new Style(typeof(Button));
		ResourceDictionary resourceDictionary = new ResourceDictionary();
		StaticResourceExtension staticResourceExtension3 = new StaticResourceExtension();
		StaticResourceExtension staticResourceExtension4 = new StaticResourceExtension();
		On on10 = new On();
		On on11 = new On();
		OnPlatform<bool> onPlatform5 = new OnPlatform<bool>();
		On on12 = new On();
		On on13 = new On();
		OnPlatform<double> onPlatform6 = new OnPlatform<double>();
		On on14 = new On();
		On on15 = new On();
		OnPlatform<string> onPlatform7 = new OnPlatform<string>();
		On on16 = new On();
		On on17 = new On();
		OnPlatform<double> onPlatform8 = new OnPlatform<double>();
		Label label = new Label();
		StaticResourceExtension staticResourceExtension5 = new StaticResourceExtension();
		Button button = new Button();
		StaticResourceExtension staticResourceExtension6 = new StaticResourceExtension();
		Button button2 = new Button();
		OnPlatformExtension onPlatformExtension2 = new OnPlatformExtension();
		Button button3 = new Button();
		AppThemeBindingExtension appThemeBindingExtension = new AppThemeBindingExtension();
		OnPlatformExtension onPlatformExtension3 = new OnPlatformExtension();
		Button button4 = new Button();
		StackLayout stackLayout = new StackLayout();
		OnPlatform onPlatform9;
		NameScope nameScope = (NameScope)(NameScope.GetNameScope(onPlatform9 = this) ?? new NameScope());
		NameScope.SetNameScope(onPlatform9, nameScope);
		NameScope nameScope2 = new NameScope();
		NameScope nameScope3 = new NameScope();
		((INameScope)nameScope).RegisterName("label0", (object)label);
		if (label.StyleId == null)
		{
			label.StyleId = "label0";
		}
		((INameScope)nameScope).RegisterName("button0", (object)button);
		if (button.StyleId == null)
		{
			button.StyleId = "button0";
		}
		((INameScope)nameScope).RegisterName("button1", (object)button2);
		if (button2.StyleId == null)
		{
			button2.StyleId = "button1";
		}
		((INameScope)nameScope).RegisterName("button2", (object)button3);
		if (button3.StyleId == null)
		{
			button3.StyleId = "button2";
		}
		((INameScope)nameScope).RegisterName("button3", (object)button4);
		if (button4.StyleId == null)
		{
			button4.StyleId = "button3";
		}
		label0 = label;
		button0 = button;
		button1 = button2;
		this.button2 = button3;
		this.button3 = button4;
		onPlatform9.Resources = resourceDictionary;
		on.Platform = new List<string>(1) { "iOS" };
		on.Value = "Bold";
		onPlatform.Platforms.Add(on);
		on2.Platform = new List<string>(1) { "Android" };
		on2.Value = "Italic";
		onPlatform.Platforms.Add(on2);
		resourceDictionary.Add("fontAttributes", onPlatform);
		on3.Platform = new List<string>(1) { "iOS" };
		on3.Value = "20";
		onPlatform2.Platforms.Add(on3);
		on4.Platform = new List<string>(1) { "Android" };
		on4.Value = "20";
		onPlatform2.Platforms.Add(on4);
		on5.Platform = new List<string>(1) { "UWP" };
		on5.Value = "30";
		onPlatform2.Platforms.Add(on5);
		resourceDictionary.Add("phone", onPlatform2);
		on6.Platform = new List<string>(1) { "iOS" };
		on6.Value = "40";
		onPlatform3.Platforms.Add(on6);
		on7.Platform = new List<string>(1) { "Android" };
		on7.Value = "40";
		onPlatform3.Platforms.Add(on7);
		on8.Platform = new List<string>(1) { "UWP" };
		on8.Value = "60";
		onPlatform3.Platforms.Add(on8);
		resourceDictionary.Add("tablet", onPlatform3);
		staticResourceExtension.Key = "phone";
		XamlServiceProvider xamlServiceProvider = new XamlServiceProvider();
		Type? typeFromHandle = typeof(IProvideValueTarget);
		object[] array;
		int num;
		object[] array2 = (array = new object[(num = 0) + 3]);
		array2[0] = onIdiom;
		array2[1] = resourceDictionary;
		array2[2] = onPlatform9;
		object service;
		xamlServiceProvider.Add(typeFromHandle, service = new SimpleValueTargetProvider(array2, typeof(OnIdiom<double>).GetRuntimeProperty("Phone"), new NameScope[4] { nameScope, nameScope, nameScope, nameScope }, notused: false));
		xamlServiceProvider.Add(typeof(IReferenceProvider), service);
		Type? typeFromHandle2 = typeof(IXamlTypeResolver);
		XmlNamespaceResolver xmlNamespaceResolver = new XmlNamespaceResolver();
		xmlNamespaceResolver.Add("", "http://schemas.microsoft.com/dotnet/2021/maui");
		xmlNamespaceResolver.Add("x", "http://schemas.microsoft.com/winfx/2009/xaml");
		xamlServiceProvider.Add(typeFromHandle2, new XamlTypeResolver(xmlNamespaceResolver, typeof(OnPlatform).Assembly));
		xamlServiceProvider.Add(typeof(IXmlLineInfoProvider), new XmlLineInfoProvider(new XmlLineInfo(22, 5)));
		object obj = ((IMarkupExtension)staticResourceExtension).ProvideValue((IServiceProvider)xamlServiceProvider);
		onIdiom.Phone = (double)obj;
		staticResourceExtension2.Key = "tablet";
		XamlServiceProvider xamlServiceProvider2 = new XamlServiceProvider();
		Type? typeFromHandle3 = typeof(IProvideValueTarget);
		object[] array3;
		int num2;
		object[] array4 = (array3 = new object[(num2 = 0) + 3]);
		array4[0] = onIdiom;
		array4[1] = resourceDictionary;
		array4[2] = onPlatform9;
		object service2;
		xamlServiceProvider2.Add(typeFromHandle3, service2 = new SimpleValueTargetProvider(array4, typeof(OnIdiom<double>).GetRuntimeProperty("Tablet"), new NameScope[4] { nameScope, nameScope, nameScope, nameScope }, notused: false));
		xamlServiceProvider2.Add(typeof(IReferenceProvider), service2);
		Type? typeFromHandle4 = typeof(IXamlTypeResolver);
		XmlNamespaceResolver xmlNamespaceResolver2 = new XmlNamespaceResolver();
		xmlNamespaceResolver2.Add("", "http://schemas.microsoft.com/dotnet/2021/maui");
		xmlNamespaceResolver2.Add("x", "http://schemas.microsoft.com/winfx/2009/xaml");
		xamlServiceProvider2.Add(typeFromHandle4, new XamlTypeResolver(xmlNamespaceResolver2, typeof(OnPlatform).Assembly));
		xamlServiceProvider2.Add(typeof(IXmlLineInfoProvider), new XmlLineInfoProvider(new XmlLineInfo(23, 5)));
		object obj2 = ((IMarkupExtension)staticResourceExtension2).ProvideValue((IServiceProvider)xamlServiceProvider2);
		onIdiom.Tablet = (double)obj2;
		resourceDictionary.Add("fontSize", onIdiom);
		setter.Property = Button.FontSizeProperty;
		onPlatformExtension.iOS = "36";
		XamlServiceProvider xamlServiceProvider3 = new XamlServiceProvider();
		Type? typeFromHandle5 = typeof(IProvideValueTarget);
		object[] array5;
		int num3;
		object[] array6 = (array5 = new object[(num3 = 0) + 4]);
		array6[0] = setter;
		array6[1] = style;
		array6[2] = resourceDictionary;
		array6[3] = onPlatform9;
		object service3;
		xamlServiceProvider3.Add(typeFromHandle5, service3 = new SimpleValueTargetProvider(array6, typeof(Setter).GetRuntimeProperty("Value"), new NameScope[5] { nameScope2, nameScope2, nameScope, nameScope, nameScope }, notused: false));
		xamlServiceProvider3.Add(typeof(IReferenceProvider), service3);
		Type? typeFromHandle6 = typeof(IXamlTypeResolver);
		XmlNamespaceResolver xmlNamespaceResolver3 = new XmlNamespaceResolver();
		xmlNamespaceResolver3.Add("", "http://schemas.microsoft.com/dotnet/2021/maui");
		xmlNamespaceResolver3.Add("x", "http://schemas.microsoft.com/winfx/2009/xaml");
		xamlServiceProvider3.Add(typeFromHandle6, new XamlTypeResolver(xmlNamespaceResolver3, typeof(OnPlatform).Assembly));
		xamlServiceProvider3.Add(typeof(IXmlLineInfoProvider), new XmlLineInfoProvider(new XmlLineInfo(25, 45)));
		object value = ((IMarkupExtension)onPlatformExtension).ProvideValue((IServiceProvider)xamlServiceProvider3);
		setter.Value = value;
		style.Setters.Add(setter);
		resourceDictionary.Add("ButtonStyle0", style);
		setter2.Property = Button.FontSizeProperty;
		on9.Platform = new List<string>(1) { "iOS" };
		on9.Value = "36";
		onPlatform4.Platforms.Add(on9);
		setter2.Value = onPlatform4;
		style2.Setters.Add(setter2);
		resourceDictionary.Add("ButtonStyle1", style2);
		onPlatform9.Resources = resourceDictionary;
		staticResourceExtension3.Key = "fontAttributes";
		XamlServiceProvider xamlServiceProvider4 = new XamlServiceProvider();
		Type? typeFromHandle7 = typeof(IProvideValueTarget);
		object[] array7;
		int num4;
		object[] array8 = (array7 = new object[(num4 = 0) + 3]);
		array8[0] = label;
		array8[1] = stackLayout;
		array8[2] = onPlatform9;
		object service4;
		xamlServiceProvider4.Add(typeFromHandle7, service4 = new SimpleValueTargetProvider(array8, Label.FontAttributesProperty, new NameScope[4] { nameScope, nameScope, nameScope, nameScope }, notused: false));
		xamlServiceProvider4.Add(typeof(IReferenceProvider), service4);
		Type? typeFromHandle8 = typeof(IXamlTypeResolver);
		XmlNamespaceResolver xmlNamespaceResolver4 = new XmlNamespaceResolver();
		xmlNamespaceResolver4.Add("", "http://schemas.microsoft.com/dotnet/2021/maui");
		xmlNamespaceResolver4.Add("x", "http://schemas.microsoft.com/winfx/2009/xaml");
		xamlServiceProvider4.Add(typeFromHandle8, new XamlTypeResolver(xmlNamespaceResolver4, typeof(OnPlatform).Assembly));
		xamlServiceProvider4.Add(typeof(IXmlLineInfoProvider), new XmlLineInfoProvider(new XmlLineInfo(37, 26)));
		object obj3 = ((IMarkupExtension)staticResourceExtension3).ProvideValue((IServiceProvider)xamlServiceProvider4);
		label.FontAttributes = (FontAttributes)obj3;
		staticResourceExtension4.Key = "fontSize";
		XamlServiceProvider xamlServiceProvider5 = new XamlServiceProvider();
		Type? typeFromHandle9 = typeof(IProvideValueTarget);
		object[] array9;
		int num5;
		object[] array10 = (array9 = new object[(num5 = 0) + 3]);
		array10[0] = label;
		array10[1] = stackLayout;
		array10[2] = onPlatform9;
		object service5;
		xamlServiceProvider5.Add(typeFromHandle9, service5 = new SimpleValueTargetProvider(array10, Label.FontSizeProperty, new NameScope[4] { nameScope, nameScope, nameScope, nameScope }, notused: false));
		xamlServiceProvider5.Add(typeof(IReferenceProvider), service5);
		Type? typeFromHandle10 = typeof(IXamlTypeResolver);
		XmlNamespaceResolver xmlNamespaceResolver5 = new XmlNamespaceResolver();
		xmlNamespaceResolver5.Add("", "http://schemas.microsoft.com/dotnet/2021/maui");
		xmlNamespaceResolver5.Add("x", "http://schemas.microsoft.com/winfx/2009/xaml");
		xamlServiceProvider5.Add(typeFromHandle10, new XamlTypeResolver(xmlNamespaceResolver5, typeof(OnPlatform).Assembly));
		xamlServiceProvider5.Add(typeof(IXmlLineInfoProvider), new XmlLineInfoProvider(new XmlLineInfo(37, 75)));
		object obj4 = ((IMarkupExtension)staticResourceExtension4).ProvideValue((IServiceProvider)xamlServiceProvider5);
		label.FontSize = (double)obj4;
		on10.Platform = new List<string>(1) { "iOS" };
		on10.Value = "true";
		onPlatform5.Platforms.Add(on10);
		on11.Platform = new List<string>(1) { "Android" };
		on11.Value = "false";
		onPlatform5.Platforms.Add(on11);
		label.SetValue(VisualElement.IsVisibleProperty, (bool)onPlatform5);
		on12.Platform = new List<string>(1) { "iOS" };
		on12.Value = "20";
		onPlatform6.Platforms.Add(on12);
		on13.Platform = new List<string>(1) { "Android" };
		on13.Value = "30";
		onPlatform6.Platforms.Add(on13);
		label.SetValue(VisualElement.WidthRequestProperty, (double)onPlatform6);
		on14.Platform = new List<string>(1) { "iOS" };
		on14.Value = "Foo";
		onPlatform7.Platforms.Add(on14);
		on15.Platform = new List<string>(1) { "Android" };
		on15.Value = "Bar";
		onPlatform7.Platforms.Add(on15);
		label.SetValue(Label.TextProperty, (string)onPlatform7);
		onPlatform8.Default = 63.0;
		on16.Platform = new List<string>(1) { "iOS" };
		on16.Value = "21";
		onPlatform8.Platforms.Add(on16);
		on17.Platform = new List<string>(2) { "Android", "FooBar" };
		on17.Value = "42";
		onPlatform8.Platforms.Add(on17);
		label.SetValue(VisualElement.HeightRequestProperty, (double)onPlatform8);
		stackLayout.Children.Add(label);
		staticResourceExtension5.Key = "ButtonStyle0";
		XamlServiceProvider xamlServiceProvider6 = new XamlServiceProvider();
		Type? typeFromHandle11 = typeof(IProvideValueTarget);
		object[] array11;
		int num6;
		object[] array12 = (array11 = new object[(num6 = 0) + 3]);
		array12[0] = button;
		array12[1] = stackLayout;
		array12[2] = onPlatform9;
		object service6;
		xamlServiceProvider6.Add(typeFromHandle11, service6 = new SimpleValueTargetProvider(array12, VisualElement.StyleProperty, new NameScope[4] { nameScope, nameScope, nameScope, nameScope }, notused: false));
		xamlServiceProvider6.Add(typeof(IReferenceProvider), service6);
		Type? typeFromHandle12 = typeof(IXamlTypeResolver);
		XmlNamespaceResolver xmlNamespaceResolver6 = new XmlNamespaceResolver();
		xmlNamespaceResolver6.Add("", "http://schemas.microsoft.com/dotnet/2021/maui");
		xmlNamespaceResolver6.Add("x", "http://schemas.microsoft.com/winfx/2009/xaml");
		xamlServiceProvider6.Add(typeFromHandle12, new XamlTypeResolver(xmlNamespaceResolver6, typeof(OnPlatform).Assembly));
		xamlServiceProvider6.Add(typeof(IXmlLineInfoProvider), new XmlLineInfoProvider(new XmlLineInfo(63, 28)));
		object style3 = ((IMarkupExtension)staticResourceExtension5).ProvideValue((IServiceProvider)xamlServiceProvider6);
		button.Style = (Style)style3;
		button.SetValue(Button.TextProperty, "Button label");
		stackLayout.Children.Add(button);
		staticResourceExtension6.Key = "ButtonStyle1";
		XamlServiceProvider xamlServiceProvider7 = new XamlServiceProvider();
		Type? typeFromHandle13 = typeof(IProvideValueTarget);
		object[] array13;
		int num7;
		object[] array14 = (array13 = new object[(num7 = 0) + 3]);
		array14[0] = button2;
		array14[1] = stackLayout;
		array14[2] = onPlatform9;
		object service7;
		xamlServiceProvider7.Add(typeFromHandle13, service7 = new SimpleValueTargetProvider(array14, VisualElement.StyleProperty, new NameScope[4] { nameScope, nameScope, nameScope, nameScope }, notused: false));
		xamlServiceProvider7.Add(typeof(IReferenceProvider), service7);
		Type? typeFromHandle14 = typeof(IXamlTypeResolver);
		XmlNamespaceResolver xmlNamespaceResolver7 = new XmlNamespaceResolver();
		xmlNamespaceResolver7.Add("", "http://schemas.microsoft.com/dotnet/2021/maui");
		xmlNamespaceResolver7.Add("x", "http://schemas.microsoft.com/winfx/2009/xaml");
		xamlServiceProvider7.Add(typeFromHandle14, new XamlTypeResolver(xmlNamespaceResolver7, typeof(OnPlatform).Assembly));
		xamlServiceProvider7.Add(typeof(IXmlLineInfoProvider), new XmlLineInfoProvider(new XmlLineInfo(64, 28)));
		object style4 = ((IMarkupExtension)staticResourceExtension6).ProvideValue((IServiceProvider)xamlServiceProvider7);
		button2.Style = (Style)style4;
		button2.SetValue(Button.TextProperty, "Button label");
		stackLayout.Children.Add(button2);
		onPlatformExtension2.iOS = "36";
		XamlServiceProvider xamlServiceProvider8 = new XamlServiceProvider();
		Type? typeFromHandle15 = typeof(IProvideValueTarget);
		object[] array15;
		int num8;
		object[] array16 = (array15 = new object[(num8 = 0) + 3]);
		array16[0] = button3;
		array16[1] = stackLayout;
		array16[2] = onPlatform9;
		object service8;
		xamlServiceProvider8.Add(typeFromHandle15, service8 = new SimpleValueTargetProvider(array16, Button.FontSizeProperty, new NameScope[4] { nameScope, nameScope, nameScope, nameScope }, notused: false));
		xamlServiceProvider8.Add(typeof(IReferenceProvider), service8);
		Type? typeFromHandle16 = typeof(IXamlTypeResolver);
		XmlNamespaceResolver xmlNamespaceResolver8 = new XmlNamespaceResolver();
		xmlNamespaceResolver8.Add("", "http://schemas.microsoft.com/dotnet/2021/maui");
		xmlNamespaceResolver8.Add("x", "http://schemas.microsoft.com/winfx/2009/xaml");
		xamlServiceProvider8.Add(typeFromHandle16, new XamlTypeResolver(xmlNamespaceResolver8, typeof(OnPlatform).Assembly));
		xamlServiceProvider8.Add(typeof(IXmlLineInfoProvider), new XmlLineInfoProvider(new XmlLineInfo(65, 28)));
		object obj5 = ((IMarkupExtension)onPlatformExtension2).ProvideValue((IServiceProvider)xamlServiceProvider8);
		button3.FontSize = (double)obj5;
		button3.SetValue(Button.TextProperty, "Button label");
		stackLayout.Children.Add(button3);
		appThemeBindingExtension.Light = "10";
		appThemeBindingExtension.Dark = "12";
		appThemeBindingExtension.Default = "14";
		XamlServiceProvider xamlServiceProvider9 = new XamlServiceProvider();
		Type? typeFromHandle17 = typeof(IProvideValueTarget);
		object[] array17;
		int num9;
		object[] array18 = (array17 = new object[(num9 = 0) + 4]);
		array18[0] = onPlatformExtension3;
		array18[1] = button4;
		array18[2] = stackLayout;
		array18[3] = onPlatform9;
		object service9;
		xamlServiceProvider9.Add(typeFromHandle17, service9 = new SimpleValueTargetProvider(array18, typeof(OnPlatformExtension).GetRuntimeProperty("WinUI"), new NameScope[5] { nameScope, nameScope, nameScope, nameScope, nameScope }, notused: false));
		xamlServiceProvider9.Add(typeof(IReferenceProvider), service9);
		Type? typeFromHandle18 = typeof(IXamlTypeResolver);
		XmlNamespaceResolver xmlNamespaceResolver9 = new XmlNamespaceResolver();
		xmlNamespaceResolver9.Add("", "http://schemas.microsoft.com/dotnet/2021/maui");
		xmlNamespaceResolver9.Add("x", "http://schemas.microsoft.com/winfx/2009/xaml");
		xamlServiceProvider9.Add(typeFromHandle18, new XamlTypeResolver(xmlNamespaceResolver9, typeof(OnPlatform).Assembly));
		xamlServiceProvider9.Add(typeof(IXmlLineInfoProvider), new XmlLineInfoProvider(new XmlLineInfo(66, 30)));
		BindingBase winUI = ((IMarkupExtension<BindingBase>)appThemeBindingExtension).ProvideValue((IServiceProvider)xamlServiceProvider9);
		onPlatformExtension3.WinUI = winUI;
		onPlatformExtension3.Default = "16";
		XamlServiceProvider xamlServiceProvider10 = new XamlServiceProvider();
		Type? typeFromHandle19 = typeof(IProvideValueTarget);
		object[] array19;
		int num10;
		object[] array20 = (array19 = new object[(num10 = 0) + 3]);
		array20[0] = button4;
		array20[1] = stackLayout;
		array20[2] = onPlatform9;
		object service10;
		xamlServiceProvider10.Add(typeFromHandle19, service10 = new SimpleValueTargetProvider(array20, Button.FontSizeProperty, new NameScope[4] { nameScope, nameScope, nameScope, nameScope }, notused: false));
		xamlServiceProvider10.Add(typeof(IReferenceProvider), service10);
		Type? typeFromHandle20 = typeof(IXamlTypeResolver);
		XmlNamespaceResolver xmlNamespaceResolver10 = new XmlNamespaceResolver();
		xmlNamespaceResolver10.Add("", "http://schemas.microsoft.com/dotnet/2021/maui");
		xmlNamespaceResolver10.Add("x", "http://schemas.microsoft.com/winfx/2009/xaml");
		xamlServiceProvider10.Add(typeFromHandle20, new XamlTypeResolver(xmlNamespaceResolver10, typeof(OnPlatform).Assembly));
		xamlServiceProvider10.Add(typeof(IXmlLineInfoProvider), new XmlLineInfoProvider(new XmlLineInfo(66, 30)));
		object obj6 = ((IMarkupExtension)onPlatformExtension3).ProvideValue((IServiceProvider)xamlServiceProvider10);
		button4.FontSize = (double)obj6;
		button4.SetValue(Button.TextProperty, "Button label");
		stackLayout.Children.Add(button4);
		onPlatform9.SetValue(ContentPage.ContentProperty, stackLayout);
	}

	private void __InitComponentRuntime()
	{
		this.LoadFromXaml(typeof(OnPlatform));
		label0 = this.FindByName<Label>("label0");
		button0 = this.FindByName<Button>("button0");
		button1 = this.FindByName<Button>("button1");
		button2 = this.FindByName<Button>("button2");
		button3 = this.FindByName<Button>("button3");
	}
}
```

</details> 

I think the issue is that something like

```cs
object obj6 = ((IMarkupExtension)onPlatformExtension3).ProvideValue((IServiceProvider)xamlServiceProvider10);
button4.FontSize = (double)obj6;
```

returns `AppThemeBinding` object instead of "resolving it further".

Files worth checking:

* https://github.com/dotnet/maui/blob/d5eab865092d76e798683b5dfbbaa1ec4b624d32/src/Controls/src/Xaml/MarkupExtensions/OnPlatformExtension.cs
* https://github.com/dotnet/maui/blob/d5eab865092d76e798683b5dfbbaa1ec4b624d32/src/Controls/src/Xaml/MarkupExtensions/AppThemeBindingExtension.cs#L44


### Issues Fixed

Fixes #19388