### PR TITLE
[Windows] Handle non-seekable streams in `PlatformImage.FromStream` (take 2)

### DIFF
--- a/eng/NuGetVersions.targets
+++ b/eng/NuGetVersions.targets
@@ -129,6 +129,10 @@
         Version="$(MicrosoftExtensionsPrimitivesVersion)"
     />
     <PackageReference
+        Update="Microsoft.IO.RecyclableMemoryStream"
+        Version="$(MicrosoftIoRecyclableMemoryStreamVersion)"
+    />
+    <PackageReference
         Update="Microsoft.WindowsAppSDK"
         Version="$(MicrosoftWindowsAppSDKPackageVersion)"
         NoWarn="NU1605"

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -79,6 +79,7 @@
     <MicrosoftCodeAnalysisNetAnalyzersVersion>8.0.0</MicrosoftCodeAnalysisNetAnalyzersVersion>
     <MicrosoftCodeAnalysisPublicApiAnalyzersVersion>3.3.4</MicrosoftCodeAnalysisPublicApiAnalyzersVersion>
     <MicrosoftCodeAnalysisBannedApiAnalyzersVersion>3.3.4</MicrosoftCodeAnalysisBannedApiAnalyzersVersion>
+    <MicrosoftIoRecyclableMemoryStreamVersion>3.0.1</MicrosoftIoRecyclableMemoryStreamVersion>
     <SystemNumericsVectorsVersion>4.5.0</SystemNumericsVectorsVersion>
     <SystemMemoryPackageVersion>4.5.5</SystemMemoryPackageVersion>
     <SystemBuffersPackageVersion>4.5.1</SystemBuffersPackageVersion>

--- a/src/Graphics/src/Graphics.Win2D/Graphics.Win2D.csproj
+++ b/src/Graphics/src/Graphics.Win2D/Graphics.Win2D.csproj
@@ -20,6 +20,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.WindowsAppSDK" />
     <PackageReference Include="Microsoft.Graphics.Win2D" />
+    <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Graphics/src/Graphics.Win2D/Graphics.Win2D.csproj
+++ b/src/Graphics/src/Graphics.Win2D/Graphics.Win2D.csproj
@@ -20,7 +20,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.WindowsAppSDK" />
     <PackageReference Include="Microsoft.Graphics.Win2D" />
-    <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Graphics/src/Graphics/Graphics.csproj
+++ b/src/Graphics/src/Graphics/Graphics.csproj
@@ -31,6 +31,7 @@
   <ItemGroup Condition="$(TargetFramework.Contains('-windows'))">
     <PackageReference Include="Microsoft.WindowsAppSDK" />
     <PackageReference Include="Microsoft.Graphics.Win2D" />
+    <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
   </ItemGroup>
 
   <Import Project="$(MauiSrcDirectory)Workload\Shared\LibraryPacks.targets" />

--- a/src/Graphics/src/Graphics/Graphics.csproj
+++ b/src/Graphics/src/Graphics/Graphics.csproj
@@ -31,7 +31,7 @@
   <ItemGroup Condition="$(TargetFramework.Contains('-windows'))">
     <PackageReference Include="Microsoft.WindowsAppSDK" />
     <PackageReference Include="Microsoft.Graphics.Win2D" />
-    <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
+    <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" />
   </ItemGroup>
 
   <Import Project="$(MauiSrcDirectory)Workload\Shared\LibraryPacks.targets" />

--- a/src/Graphics/src/Graphics/Platforms/Windows/PlatformImage.cs
+++ b/src/Graphics/src/Graphics/Platforms/Windows/PlatformImage.cs
@@ -156,7 +156,20 @@ namespace Microsoft.Maui.Graphics.Platform
 			if (creator == null)
 				throw new Exception("No resource creator has been registered globally or for this thread.");
 
-			var bitmap = AsyncPump.Run(async () => await CanvasBitmap.LoadAsync(creator, stream.AsRandomAccessStream()));
+			var bitmap = AsyncPump.Run(async () =>
+			{
+				if (stream.CanSeek)
+				{
+					return await CanvasBitmap.LoadAsync(creator, stream.AsRandomAccessStream());
+				}
+				else
+				{
+					using MemoryStream memoryStream = new();
+					stream.CopyTo(memoryStream);
+
+					return await CanvasBitmap.LoadAsync(creator, memoryStream.AsRandomAccessStream());
+				}
+			});
 			return new PlatformImage(creator, bitmap);
 		}
 	}

--- a/src/Graphics/src/Graphics/Platforms/Windows/PlatformImage.cs
+++ b/src/Graphics/src/Graphics/Platforms/Windows/PlatformImage.cs
@@ -170,6 +170,7 @@ namespace Microsoft.Maui.Graphics.Platform
 			{
 				using MemoryStream memoryStream = new();
 				stream.CopyTo(memoryStream);
+				memoryStream.Seek(0, SeekOrigin.Begin);
 
 				global::Windows.Foundation.IAsyncOperation<CanvasBitmap> bitmapAsync = CanvasBitmap.LoadAsync(creator, memoryStream.AsRandomAccessStream());
 				bitmap = bitmapAsync.AsTask().GetAwaiter().GetResult();

--- a/src/Graphics/src/Graphics/Platforms/Windows/PlatformImage.cs
+++ b/src/Graphics/src/Graphics/Platforms/Windows/PlatformImage.cs
@@ -167,7 +167,7 @@ namespace Microsoft.Maui.Graphics.Platform
 
 			if (stream.CanSeek)
 			{
-				global::Windows.Foundation.IAsyncOperation<CanvasBitmap> bitmapAsync = CanvasBitmap.LoadAsync(creator, stream.AsRandomAccessStream());
+				var bitmapAsync = CanvasBitmap.LoadAsync(creator, stream.AsRandomAccessStream());
 				bitmap = bitmapAsync.AsTask().GetAwaiter().GetResult();
 			}
 			else
@@ -176,7 +176,7 @@ namespace Microsoft.Maui.Graphics.Platform
 				stream.CopyTo(memoryStream);
 				memoryStream.Seek(0, SeekOrigin.Begin);
 
-				global::Windows.Foundation.IAsyncOperation<CanvasBitmap> bitmapAsync = CanvasBitmap.LoadAsync(creator, memoryStream.AsRandomAccessStream());
+				var bitmapAsync = CanvasBitmap.LoadAsync(creator, memoryStream.AsRandomAccessStream());
 				bitmap = bitmapAsync.AsTask().GetAwaiter().GetResult();
 			}
 

--- a/src/Graphics/tests/Graphics.Tests/PlatformImageTests.cs
+++ b/src/Graphics/tests/Graphics.Tests/PlatformImageTests.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.IO;
+using Xunit;
+
+namespace Microsoft.Maui.Graphics.Tests;
+
+public class PlatformImageTests
+{
+	[Theory]
+	[InlineData(true)]
+	[InlineData(false)]
+	public void PlatformImageFromStreamTest(bool seekable)
+	{
+		byte[] orange1x1pxPngBytes = Convert.FromBase64String("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIW2P4v5ThPwAG7wKklwQ/bwAAAABJRU5ErkJggg==");
+		using MemoryStream memoryStream = new(orange1x1pxPngBytes);
+		Stream stream = seekable ? memoryStream : new NonSeekableReadOnlyStream(memoryStream);
+
+		var image = Microsoft.Maui.Graphics.Platform.PlatformImage.FromStream(stream);
+
+		Assert.NotNull(image);
+	}
+
+	    private class NonSeekableReadOnlyStream(Stream stream) : Stream
+	{
+		public override bool CanRead => stream.CanRead;
+
+		public override bool CanSeek => false;
+
+		public override bool CanWrite => false;
+
+		public override long Length => throw new NotSupportedException();
+
+		public override long Position
+		{
+			get { return stream.Position; }
+			set { throw new NotSupportedException(); }
+		}
+
+		public override void Flush() => throw new NotSupportedException();
+
+		public override int Read(byte[] buffer, int offset, int count)
+		{
+			return stream.Read(buffer, offset, count);
+		}
+
+		public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+		public override void SetLength(long value) => throw new NotSupportedException();
+
+		public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+	}
+}


### PR DESCRIPTION
Alternative to #23626. This PR uses the `RecyclableMemoryStreamManager` to decrease allocations.

### Description of Change

`AsRandomAccessStream` throws `NotSupportedException` when the stream is not seekable. This PR is a simple workaround for it.

The second commit adds an optimization. The idea is to remove `AsyncPump` (introduced in https://github.com/dotnet/Microsoft.Maui.Graphics/commit/45979232d6deb180c3988158cf8d98a5ecdd8f7f and merged to MAUI in https://github.com/dotnet/maui/pull/8739) which does not seem to be necessary at all. I have tested the change with parallel loading of images and it did not break for me. But then again I don't really know why `AsyncPump` was introduced in the first place. This commit is an alternative to #23624 approach and the improvement should be the same as in that PR: https://github.com/dotnet/maui/pull/23624#issue-2410733071 (9 seconds -> 1.3 seconds for a batch of images containing ~100 images).

### Test

Tested with provided sample code that reads images in parallel to make sure it works: https://gist.github.com/MartyIX/2513b1853ad8537a4d31b62c251115ad

![animation](https://github.com/user-attachments/assets/75865680-686b-42ec-a248-19ea326959e5)


### Issues Fixed

Fixes #18954