### PR TITLE
[msbuild] Fix BundleResource defaults for iOS and MacCatalyst

### DIFF
--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.Globs.props
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.Globs.props
@@ -66,6 +66,7 @@
     <BundleResource
         Include="$(iOSProjectFolder)Resources\**"
         Exclude="$(_SingleProjectiOSExcludes)"
+        Link="$([MSBuild]::MakeRelative ('$(MSBuildProjectDirectory)', '%(FullPath)'))"
         IsDefaultItem="true"
     />
     <ImageAsset
@@ -101,6 +102,7 @@
     <BundleResource
         Include="$(MacCatalystProjectFolder)Resources\**"
         Exclude="$(_SingleProjectMacCatalystExcludes)"
+        Link="$([MSBuild]::MakeRelative ('$(MSBuildProjectDirectory)', '%(FullPath)'))"
         IsDefaultItem="true"
     />
     <ImageAsset


### PR DESCRIPTION
Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2172694
Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2172757

This PR https://github.com/dotnet/maui/pull/21350 added the new `PrivacyInfo.xcprivacy` to our default templates (new requirement from Apple) when building from Windows we try to bundle this resource and unfortunately we are missing the required Link metadata when this is done from single project triggering a condition where the path is incorrectly calculated when zipped in windows and once the zip archive is transfered to the mac host it is unable to unarchive the file. To fix this we simply unify the logic with what the macios SDK currently does https://github.com/xamarin/xamarin-macios/blob/main/dotnet/targets/Microsoft.Sdk.DefaultItems.template.props#L77 
this ensures the right bundling happens.