### PR TITLE
Fixed a crash for the samples app [User interface concepts -> styles]

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/UserInterface/StylesPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/UserInterface/StylesPage.xaml
@@ -8,7 +8,7 @@
         <ResourceDictionary>
             
             <Style x:Key="CustomStyle" TargetType="Label" BaseResourceKey="SubtitleStyle">
-                <Setter Property="Label.TextColor" Value="Color.Pink"/>
+                <Setter Property="TextColor" Value="Pink"/>
             </Style>
             
             <Style x:Key="ButtonStyle" TargetType="Button">


### PR DESCRIPTION
The app crashed when navigating to styles
<img width="1539" alt="Screenshot 2024-07-26 at 15 31 00" src="https://github.com/user-attachments/assets/70455fb1-8690-4357-9d12-b9aa18d0527f">
<img width="320px" src="https://github.com/user-attachments/assets/c3c06ce1-b30f-43f5-9b03-669183baf7dd"/>

