### PR TITLE
When swapping out ShellItems clear services

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFlyoutTemplatedContentRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFlyoutTemplatedContentRenderer.cs
@@ -127,6 +127,14 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 				void InitialLoad(GenericGlobalLayoutListener listener, AView view)
 				{
+					// This means the handler was disconnected before the flyout was loaded
+					if (_shellContext?.Shell is null)
+					{
+						listener.Invalidate();
+						sfl.LayoutChanging -= OnFlyoutViewLayoutChanging;
+						return;
+					}
+
 					OnFlyoutViewLayoutChanging();
 
 					if (_flyoutContentView == null || ggll == null)

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -347,6 +347,7 @@ static Microsoft.Maui.Controls.Binding.Create<TSource, TProperty>(System.Func<TS
 *REMOVED*~static Microsoft.Maui.Controls.WebView.ControlsWebViewMapper -> Microsoft.Maui.IPropertyMapper<Microsoft.Maui.IWebView, Microsoft.Maui.Handlers.WebViewHandler>
 *REMOVED*static Microsoft.Maui.Controls.FlyoutPage.ControlsFlyoutPageMapper -> Microsoft.Maui.IPropertyMapper<Microsoft.Maui.IFlyoutView!, Microsoft.Maui.Handlers.FlyoutViewHandler!>!
 *REMOVED*static Microsoft.Maui.Controls.Toolbar.ControlsToolbarMapper -> Microsoft.Maui.IPropertyMapper<Microsoft.Maui.Controls.Toolbar!, Microsoft.Maui.Handlers.ToolbarHandler!>!
+~override Microsoft.Maui.Controls.ShellContent.OnPropertyChanged(string propertyName = null) -> void
 Microsoft.Maui.Controls.Embedding.EmbeddingExtensions
 static Microsoft.Maui.Controls.Embedding.EmbeddingExtensions.CreateEmbeddedWindowContext(this Microsoft.Maui.Hosting.MauiApp! mauiApp, Android.App.Activity! platformWindow) -> Microsoft.Maui.IMauiContext!
 static Microsoft.Maui.Controls.Embedding.EmbeddingExtensions.ToPlatformEmbedded(this Microsoft.Maui.IElement! element, Microsoft.Maui.IMauiContext! context) -> Android.Views.View!

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -240,6 +240,7 @@ override Microsoft.Maui.Controls.SearchBar.IsEnabledCore.get -> bool
 ~Microsoft.Maui.Controls.WebView.UserAgent.set -> void
 ~override Microsoft.Maui.Controls.Region.Equals(object obj) -> bool
 ~override Microsoft.Maui.Controls.Shapes.Matrix.Equals(object obj) -> bool
+~override Microsoft.Maui.Controls.ShellContent.OnPropertyChanged(string propertyName = null) -> void
 ~static Microsoft.Maui.Controls.Region.FromRectangles(System.Collections.Generic.IEnumerable<Microsoft.Maui.Graphics.Rect> rectangles) -> Microsoft.Maui.Controls.Region
 ~static readonly Microsoft.Maui.Controls.InputView.CursorPositionProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.InputView.FontAttributesProperty -> Microsoft.Maui.Controls.BindableProperty

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -370,6 +370,7 @@ static Microsoft.Maui.Controls.Binding.Create<TSource, TProperty>(System.Func<TS
 *REMOVED*~static Microsoft.Maui.Controls.WebView.ControlsWebViewMapper -> Microsoft.Maui.IPropertyMapper<Microsoft.Maui.IWebView, Microsoft.Maui.Handlers.WebViewHandler>
 *REMOVED*static Microsoft.Maui.Controls.FlyoutPage.ControlsFlyoutPageMapper -> Microsoft.Maui.IPropertyMapper<Microsoft.Maui.IFlyoutView!, Microsoft.Maui.Handlers.FlyoutViewHandler!>!
 *REMOVED*static Microsoft.Maui.Controls.Toolbar.ControlsToolbarMapper -> Microsoft.Maui.IPropertyMapper<Microsoft.Maui.Controls.Toolbar!, Microsoft.Maui.Handlers.ToolbarHandler!>!
+~override Microsoft.Maui.Controls.ShellContent.OnPropertyChanged(string propertyName = null) -> void
 Microsoft.Maui.Controls.Embedding.EmbeddingExtensions
 static Microsoft.Maui.Controls.Embedding.EmbeddingExtensions.CreateEmbeddedWindowContext(this Microsoft.Maui.Hosting.MauiApp! mauiApp, UIKit.UIWindow! platformWindow) -> Microsoft.Maui.IMauiContext!
 static Microsoft.Maui.Controls.Embedding.EmbeddingExtensions.ToPlatformEmbedded(this Microsoft.Maui.IElement! element, Microsoft.Maui.IMauiContext! context) -> UIKit.UIView!

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -318,3 +318,4 @@ Microsoft.Maui.Controls.WebViewProcessTerminatedEventArgs
 Microsoft.Maui.Controls.WebViewProcessTerminatedEventArgs.WebViewProcessTerminatedEventArgs() -> void
 Microsoft.Maui.Controls.PlatformWebViewProcessTerminatedEventArgs
 Microsoft.Maui.Controls.PlatformWebViewProcessTerminatedEventArgs.PlatformWebViewProcessTerminatedEventArgs() -> void
+~override Microsoft.Maui.Controls.ShellContent.OnPropertyChanged(string propertyName = null) -> void

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -357,6 +357,7 @@ static Microsoft.Maui.Controls.Binding.Create<TSource, TProperty>(System.Func<TS
 *REMOVED*~static Microsoft.Maui.Controls.WebView.ControlsWebViewMapper -> Microsoft.Maui.IPropertyMapper<Microsoft.Maui.IWebView, Microsoft.Maui.Handlers.WebViewHandler>
 *REMOVED*static Microsoft.Maui.Controls.FlyoutPage.ControlsFlyoutPageMapper -> Microsoft.Maui.IPropertyMapper<Microsoft.Maui.IFlyoutView!, Microsoft.Maui.Handlers.FlyoutViewHandler!>!
 *REMOVED*static Microsoft.Maui.Controls.Toolbar.ControlsToolbarMapper -> Microsoft.Maui.IPropertyMapper<Microsoft.Maui.Controls.Toolbar!, Microsoft.Maui.Handlers.ToolbarHandler!>!
+~override Microsoft.Maui.Controls.ShellContent.OnPropertyChanged(string propertyName = null) -> void
 Microsoft.Maui.Controls.Embedding.EmbeddingExtensions
 static Microsoft.Maui.Controls.Embedding.EmbeddingExtensions.CreateEmbeddedWindowContext(this Microsoft.Maui.Hosting.MauiApp! mauiApp, Microsoft.UI.Xaml.Window! platformWindow) -> Microsoft.Maui.IMauiContext!
 static Microsoft.Maui.Controls.Embedding.EmbeddingExtensions.ToPlatformEmbedded(this Microsoft.Maui.IElement! element, Microsoft.Maui.IMauiContext! context) -> Microsoft.UI.Xaml.FrameworkElement!

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -315,3 +315,4 @@ static Microsoft.Maui.Controls.Binding.Create<TSource, TProperty>(System.Func<TS
 *REMOVED*~static Microsoft.Maui.Controls.WebView.ControlsWebViewMapper -> Microsoft.Maui.IPropertyMapper<Microsoft.Maui.IWebView, Microsoft.Maui.Handlers.WebViewHandler>
 *REMOVED*static Microsoft.Maui.Controls.FlyoutPage.ControlsFlyoutPageMapper -> Microsoft.Maui.IPropertyMapper<Microsoft.Maui.IFlyoutView!, Microsoft.Maui.Handlers.FlyoutViewHandler!>!
 *REMOVED*static Microsoft.Maui.Controls.Toolbar.ControlsToolbarMapper -> Microsoft.Maui.IPropertyMapper<Microsoft.Maui.Controls.Toolbar!, Microsoft.Maui.Handlers.ToolbarHandler!>!
+~override Microsoft.Maui.Controls.ShellContent.OnPropertyChanged(string propertyName = null) -> void

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -315,3 +315,4 @@ static Microsoft.Maui.Controls.Binding.Create<TSource, TProperty>(System.Func<TS
 *REMOVED*~static Microsoft.Maui.Controls.WebView.ControlsWebViewMapper -> Microsoft.Maui.IPropertyMapper<Microsoft.Maui.IWebView, Microsoft.Maui.Handlers.WebViewHandler>
 *REMOVED*static Microsoft.Maui.Controls.FlyoutPage.ControlsFlyoutPageMapper -> Microsoft.Maui.IPropertyMapper<Microsoft.Maui.IFlyoutView!, Microsoft.Maui.Handlers.FlyoutViewHandler!>!
 *REMOVED*static Microsoft.Maui.Controls.Toolbar.ControlsToolbarMapper -> Microsoft.Maui.IPropertyMapper<Microsoft.Maui.Controls.Toolbar!, Microsoft.Maui.Handlers.ToolbarHandler!>!
+~override Microsoft.Maui.Controls.ShellContent.OnPropertyChanged(string propertyName = null) -> void

--- a/src/Controls/src/Core/Shell/Shell.cs
+++ b/src/Controls/src/Core/Shell/Shell.cs
@@ -1634,7 +1634,17 @@ namespace Microsoft.Maui.Controls
 		static void OnCurrentItemChanged(BindableObject bindable, object oldValue, object newValue)
 		{
 			if (oldValue is ShellItem oldShellItem)
+			{
 				oldShellItem.SendDisappearing();
+
+				foreach(var section in oldShellItem.Items)
+				{
+					foreach(var content in section.Items)
+					{
+						content.EvaluateDisconnect();
+					}
+				}
+			}
 
 			if (newValue == null)
 				return;

--- a/src/Controls/src/Core/Shell/ShellContent.cs
+++ b/src/Controls/src/Core/Shell/ShellContent.cs
@@ -249,8 +249,8 @@ namespace Microsoft.Maui.Controls
 
 			if (_contentCache is not null)
 			{
-				RemoveLogicalChild(_contentCache);
 				_contentCache.Unloaded -= OnPageUnloaded;
+				RemoveLogicalChild(_contentCache);
 			}
 
 			_contentCache = null;

--- a/src/Controls/src/Core/Shell/ShellContent.cs
+++ b/src/Controls/src/Core/Shell/ShellContent.cs
@@ -255,9 +255,7 @@ namespace Microsoft.Maui.Controls
 			_contentCache = null;
 		}
 
-#pragma warning disable RS0016 // Add public types and members to the declared API
 		protected override void OnPropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
-#pragma warning restore RS0016 // Add public types and members to the declared API
 		{
 			base.OnPropertyChanged(propertyName);
 

--- a/src/Controls/src/Core/Shell/ShellContent.cs
+++ b/src/Controls/src/Core/Shell/ShellContent.cs
@@ -5,7 +5,6 @@ using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Reflection;
-using System.Security.Cryptography;
 using Microsoft.Maui.Controls.Internals;
 
 namespace Microsoft.Maui.Controls

--- a/src/Controls/tests/TestCases.HostApp/Issues/Shell/ShellTransientTests.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Shell/ShellTransientTests.cs
@@ -4,13 +4,60 @@ using Microsoft.Maui.Controls;
 
 namespace Maui.Controls.Sample.Issues
 {
-	[Issue(IssueTracker.None, 0, "Navigating Between Transient Shell States Recreates Pages")]
+	[Issue(IssueTracker.None, 0, "Validate Basic Service Lifetime Behavior On Shell")]
 	public class ShellTransientTests : Shell
 	{
-        List<ContentPage> _contentPages = new List<ContentPage>();
+        static List<ContentPage> _contentPages = new List<ContentPage>();
 		protected override void OnNavigated(ShellNavigatedEventArgs args)
 		{
 			base.OnNavigated(args);
+            LoadCurrentPage();
+		}
+
+        void LoadCurrentPage()
+        {
+            var navigatetoTransientPage = new Button 
+            { 
+                Text = "Navigate to transient page", 
+                AutomationId = "NavigateToTransientPage",
+                Command = new Command(() => 
+                {
+                    ((ContentPage)this.CurrentPage).Content = new Label(){ Text = "Navigating. If you tried to navigate to the same page type, you'll be stuck here."};
+                    this.CurrentItem = Items[0];
+                })
+            };
+
+            var navigateToNotRegisteredPage = new Button 
+            { 
+                Text = "Navigate to Unregistered page", 
+                AutomationId = "NavigateToUnregisteredPage",
+                Command = new Command(() => 
+                {
+                    ((ContentPage)this.CurrentPage).Content = new Label(){ Text = "Navigating. If you tried to navigate to the same page type, you'll be stuck here."};
+                    this.CurrentItem = Items[1];
+                })
+            };
+
+            var navigateToScopedPage = new Button 
+            { 
+                Text = "Navigate to scoped page", 
+                AutomationId = "NavigateToScopedPage",
+                Command = new Command(() => 
+                {
+                    ((ContentPage)this.CurrentPage).Content = new Label(){ Text = "Navigating. If you tried to navigate to the same page type, you'll be stuck here."};
+                    this.CurrentItem = Items[2];
+                })
+            };
+
+            var navigateToNewShell = new Button 
+            { 
+                Text = "Navigate to New Shell", 
+                AutomationId = "NavigateToNewShell",
+                Command = new Command(() => 
+                {
+                    this.Window.Page = new ShellTransientTests();
+                })
+            };
 
             if (_contentPages.Contains(this.CurrentPage))
             {
@@ -18,7 +65,11 @@ namespace Maui.Controls.Sample.Issues
                 {
                     Children =
                     {
-                        new Label { Text = "Test Failed I am not a new page", AutomationId = "Failure" }
+                        navigatetoTransientPage,
+                        navigateToNotRegisteredPage,
+                        navigateToScopedPage,
+                        navigateToNewShell,
+                        new Label { Text = "I am not a new page", AutomationId = "OldPage" }
                     }
                 };
             }
@@ -28,13 +79,17 @@ namespace Maui.Controls.Sample.Issues
                 {
                     Children =
                     {
-                        new Label { Text = "I am a new page", AutomationId = "Success" }
+                        navigatetoTransientPage,
+                        navigateToNotRegisteredPage,
+                        navigateToScopedPage,
+                        navigateToNewShell,
+                        new Label { Text = "I am a new page", AutomationId = "NewPage" }
                     }
                 };
             }
 
             _contentPages.Add((ContentPage)this.CurrentPage);
-		}
+        }
 
 		public ShellTransientTests()
         {
@@ -43,20 +98,19 @@ namespace Maui.Controls.Sample.Issues
                 ContentTemplate = new DataTemplate(typeof(TransientPage))
             };
 
-
             var shellContent2 = new ShellContent()
-            {
-                ContentTemplate = new DataTemplate(typeof(TransientPage))
-            };
-
-            var shellContent3 = new ShellContent()
             {
                 ContentTemplate = new DataTemplate(typeof(ContentPage))
             };
 
+            var shellContent3 = new ShellContent()
+            {
+                ContentTemplate = new DataTemplate(typeof(ScopedPage))
+            };
+
             Items.Add(new FlyoutItem()
             {
-                Title = "Flyout Item 1",
+                Title = "Transient Page",
                 Items =
                 {
                     shellContent1
@@ -65,17 +119,16 @@ namespace Maui.Controls.Sample.Issues
 
             Items.Add(new FlyoutItem()
             {
-                Title = "Flyout Item 2",
+                Title = "Not Registered Page",
                 Items =
                 {
                     shellContent2
                 }
             });
 
-
             Items.Add(new FlyoutItem()
             {
-                Title = "Flyout Item 3",
+                Title = "Scoped Page",
                 Items =
                 {
                     shellContent3

--- a/src/Controls/tests/TestCases.HostApp/Issues/Shell/ShellTransientTests.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Shell/ShellTransientTests.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Diagnostics;
+using Microsoft.Maui.Controls;
+
+namespace Maui.Controls.Sample.Issues
+{
+	[Issue(IssueTracker.None, 0, "Navigating Between Transient Shell States Recreates Pages")]
+	public class ShellTransientTests : Shell
+	{
+        List<ContentPage> _contentPages = new List<ContentPage>();
+		protected override void OnNavigated(ShellNavigatedEventArgs args)
+		{
+			base.OnNavigated(args);
+
+            if (_contentPages.Contains(this.CurrentPage))
+            {
+                (CurrentPage as ContentPage).Content = new VerticalStackLayout()
+                {
+                    Children =
+                    {
+                        new Label { Text = "Test Failed I am not a new page", AutomationId = "Failure" }
+                    }
+                };
+            }
+            else
+            {
+                (CurrentPage as ContentPage).Content = new VerticalStackLayout()
+                {
+                    Children =
+                    {
+                        new Label { Text = "I am a new page", AutomationId = "Success" }
+                    }
+                };
+            }
+
+            _contentPages.Add((ContentPage)this.CurrentPage);
+		}
+
+		public ShellTransientTests()
+        {
+            var shellContent1 = new ShellContent()
+            {
+                ContentTemplate = new DataTemplate(typeof(TransientPage))
+            };
+
+
+            var shellContent2 = new ShellContent()
+            {
+                ContentTemplate = new DataTemplate(typeof(TransientPage))
+            };
+
+            var shellContent3 = new ShellContent()
+            {
+                ContentTemplate = new DataTemplate(typeof(ContentPage))
+            };
+
+            Items.Add(new FlyoutItem()
+            {
+                Title = "Flyout Item 1",
+                Items =
+                {
+                    shellContent1
+                }
+            });
+
+            Items.Add(new FlyoutItem()
+            {
+                Title = "Flyout Item 2",
+                Items =
+                {
+                    shellContent2
+                }
+            });
+
+
+            Items.Add(new FlyoutItem()
+            {
+                Title = "Flyout Item 3",
+                Items =
+                {
+                    shellContent3
+                }
+            });
+        }
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/MauiProgram.cs
+++ b/src/Controls/tests/TestCases.HostApp/MauiProgram.cs
@@ -25,6 +25,8 @@ namespace Maui.Controls.Sample
 				})
 				.Issue21109AddMappers();
 
+			appBuilder.Services.AddTransient<TransientPage>();
+			appBuilder.Services.AddScoped<ScopedPage>();
 			return appBuilder.Build();
 		}
 	}

--- a/src/Controls/tests/TestCases.HostApp/ScopedPage.cs
+++ b/src/Controls/tests/TestCases.HostApp/ScopedPage.cs
@@ -1,0 +1,15 @@
+
+namespace Maui.Controls.Sample;
+
+public class ScopedPage : ContentPage
+{
+    static int i = 0;
+    public ScopedPage()
+    {
+        Index = i;
+        Content = new Label { Text = $"I'm a scoped page: {Index}" };
+        i++;
+    }
+
+    public int Index {get; private set;}
+}

--- a/src/Controls/tests/TestCases.HostApp/TransientPage.cs
+++ b/src/Controls/tests/TestCases.HostApp/TransientPage.cs
@@ -1,0 +1,15 @@
+
+namespace Maui.Controls.Sample;
+
+public class TransientPage : ContentPage
+{
+    static int i = 0;
+    public TransientPage()
+    {
+        Index = i;
+        Content = new Label { Text = $"I'm a transient page: {Index}" };
+        i++;
+    }
+
+    public int Index {get; private set;}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Shell/ShellTransientTests.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Shell/ShellTransientTests.cs
@@ -1,0 +1,70 @@
+﻿using Microsoft.Maui.TestCases.Tests;
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public partial class ShellTransientTests : _IssuesUITest
+	{
+		public ShellTransientTests(TestDevice device) : base(device) { }
+
+		public override string Issue => "Validate Basic Service Lifetime Behavior On Shell";
+
+		protected override bool ResetAfterEachTest => true;
+
+		[Test]
+		[Category(UITestCategories.Shell)]
+		public void ValidateBasicServiceLifetimePageBehavior()
+		{			
+			// Navigate to Transient Page for the First time
+			App.WaitForElement("NewPage");
+
+			// Navigate to Unregistered Page
+			App.WaitForElement("NavigateToUnregisteredPage");
+			App.Tap("NavigateToUnregisteredPage");
+			App.WaitForElement("NewPage", "New Page Not Created For Initial Navigation to Unregistered Page");
+
+			// Navigate to Scoped Page for the First time
+			App.WaitForElement("NavigateToScopedPage");
+			App.Tap("NavigateToScopedPage");
+			App.WaitForElement("NewPage", "New Page Not Created For Initial Navigation to Scoped Page");
+
+			// Navigate to Transient Page for the Second time
+			App.WaitForElement("NavigateToTransientPage");
+			App.Tap("NavigateToTransientPage");
+			App.WaitForElement("NewPage", "New Page Not Created For Second Navigation To Transient Page");
+
+			// Navigate to Transient Page for the Second time
+			App.WaitForElement("NavigateToScopedPage");
+			App.Tap("NavigateToScopedPage");
+			App.WaitForElement("OldPage", "New Page Incorrectly Created For Scoped Page");
+
+			// Navigate to Unregistered Page
+			App.WaitForElement("NavigateToUnregisteredPage");
+			App.Tap("NavigateToUnregisteredPage");
+			App.WaitForElement("OldPage", "New Page Incorrectly Created For Unregistered Page");
+		}
+
+		[Test]
+		[Category(UITestCategories.Shell)]
+		public void SwappingShellInstancesRecreatesPages()
+		{
+			// Navigate to Scoped Page so we can test that it's resued in Swapped Shell
+			App.WaitForElement("NavigateToScopedPage");
+			App.Tap("NavigateToScopedPage");
+			App.WaitForElement("NewPage", "New Page Not Created For Initial Navigation to Scoped Page");
+
+			// Verify New Page Created for Transient Page
+			App.WaitForElement("NewPage");
+			App.Tap("NavigateToNewShell");
+			App.WaitForElement("NewPage");
+
+			// Navigate to Scoped Page on Second Shell
+			App.WaitForElement("NavigateToScopedPage");
+			App.Tap("NavigateToScopedPage");
+			App.WaitForElement("OldPage", "New Page Incorrectly Created For Scoped Page");
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/ScrollViewUITests.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/ScrollViewUITests.cs
@@ -20,8 +20,12 @@ namespace Microsoft.Maui.TestCases.Tests
 			App.NavigateToGallery(LayoutGallery);
 		}
 
+#if ANDROID
 		[Test]
 		[Description("Scroll element to the start")]
+		[FailsOnIOS("This test is failing, likely due to product issue")]
+		[FailsOnMac("This test is failing, likely due to product issue")]
+		[FailsOnWindows("This test is failing, likely due to product issue")]
 		public void ScrollToElement1Start()
 		{
 			if (Device == TestDevice.Android)
@@ -43,6 +47,9 @@ namespace Microsoft.Maui.TestCases.Tests
 
 		[Test]
 		[Description("Scroll element to the center")]
+		[FailsOnIOS("This test is failing, likely due to product issue")]
+		[FailsOnMac("This test is failing, likely due to product issue")]
+		[FailsOnWindows("This test is failing, likely due to product issue")]
 		public void ScrollToElement2Center()
 		{
 			if (Device == TestDevice.Android)
@@ -67,6 +74,9 @@ namespace Microsoft.Maui.TestCases.Tests
 
 		[Test]
 		[Description("Scroll element to the end")]
+		[FailsOnIOS("This test is failing, likely due to product issue")]
+		[FailsOnMac("This test is failing, likely due to product issue")]
+		[FailsOnWindows("This test is failing, likely due to product issue")]
 		public void ScrollToElement3End()
 		{
 			if (Device == TestDevice.Android)
@@ -88,6 +98,9 @@ namespace Microsoft.Maui.TestCases.Tests
 
 		[Test]
 		[Description("ScrollTo Y = 100")]
+		[FailsOnIOS("This test is failing, likely due to product issue")]
+		[FailsOnMac("This test is failing, likely due to product issue")]
+		[FailsOnWindows("This test is failing, likely due to product issue")]
 		public void ScrollToY()
 		{
 			if (Device == TestDevice.Android)
@@ -106,6 +119,9 @@ namespace Microsoft.Maui.TestCases.Tests
 		// ScrollToYTwice (src\Compatibility\ControlGallery\src\UITests.Shared\Tests\ScrollViewUITests.cs)
 		[Test]
 		[Description("ScrollTo Y = 100")]
+		[FailsOnIOS("This test is failing, likely due to product issue")]
+		[FailsOnMac("This test is failing, likely due to product issue")]
+		[FailsOnWindows("This test is failing, likely due to product issue")]
 		public void ScrollToYTwice()
 		{
 			if (Device == TestDevice.Android)
@@ -125,9 +141,13 @@ namespace Microsoft.Maui.TestCases.Tests
 				Assert.Ignore("This test is failing, likely due to product issue");
 			}
 		}
+#endif
+
 #if ANDROID || IOS
 		[Test]
 		[Description("Scroll down the ScrollView using a gesture")]
+		[FailsOnMac("This test is failing, likely due to product issue")]
+		[FailsOnWindows("This test is failing, likely due to product issue")]
 		public void ScrollUpAndDownWithGestures()
 		{
 			App.ScrollDown("thescroller", ScrollStrategy.Gesture, 0.75);


### PR DESCRIPTION
### Description

When the user is switching to a new context on shell and they've loaded the ShellContent via the services out. This will clear out the ContentCache so the service will get retrieved again. This allows the users to specify if they want pages to be transient vs persistent. 

#### Rules for clearing out the cache
- If the window changes for a shell  (this will happen when the user is swapping out the shell)
- If the user switches to a new ShellItem (new TabBar, new FlyoutItem)
  -  The cache will not clear out when switch tabs. It only clears the cache when the app switches to a new "ShellItem" level context
- If the user sets the `ShellItem => ShellSection => ShellContent` to not be visible then we'll clear out the cache because the user has indicated that this Page should not longer be part of the active structure

#### Scenarios where the cache isn't cleared
- Navigating through bottom tabs
- Navigation through top tabs
- if the user hasn't registered the Page itself against the services then we don't clear out the cache. This means for anyone not registering shell services, the behavior won't change. 