### PR TITLE
Observes the `PrefersEphemeralWebBrowserSession` by setting the custom tab to run in incognito mode

### DIFF
--- a/src/Essentials/src/WebAuthenticator/WebAuthenticator.android.cs
+++ b/src/Essentials/src/WebAuthenticator/WebAuthenticator.android.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Maui.Authentication
 			currentRedirectUri = callbackUrl;
 
 			// Try to start with custom tabs if the system supports it and we resolve it
-			AuthenticatingWithCustomTabs = await StartCustomTabsActivity(url);
+			AuthenticatingWithCustomTabs = await StartCustomTabsActivity(url, webAuthenticatorOptions.PrefersEphemeralWebBrowserSession);
 
 			// Fall back to using the system browser if necessary
 			if (!AuthenticatingWithCustomTabs)
@@ -87,7 +87,7 @@ namespace Microsoft.Maui.Authentication
 			return await tcsResponse.Task;
 		}
 
-		static async Task<bool> StartCustomTabsActivity(Uri url)
+		static async Task<bool> StartCustomTabsActivity(Uri url, bool incognito)
 		{
 			// Is only set to true if BindServiceAsync succeeds and no exceptions are thrown
 			var success = false;
@@ -103,6 +103,9 @@ namespace Microsoft.Maui.Authentication
 						.Build();
 
 					customTabsIntent.Intent.SetData(global::Android.Net.Uri.Parse(url.OriginalString));
+
+					if (incognito)
+						customTabsIntent.Intent.PutExtra("com.google.android.apps.chrome.EXTRA_OPEN_NEW_INCOGNITO_TAB", true);
 
 					if (customTabsIntent.Intent.ResolveActivity(parentActivity.PackageManager) != null)
 					{

--- a/src/Essentials/src/WebAuthenticator/WebAuthenticator.shared.cs
+++ b/src/Essentials/src/WebAuthenticator/WebAuthenticator.shared.cs
@@ -178,7 +178,7 @@ namespace Microsoft.Maui.Authentication
 		/// Gets or sets whether the browser used for the authentication flow is short-lived.
 		/// This means it will not share session nor cookies with the regular browser on this device if set the <see langword="true"/>. 
 		/// </summary>
-		/// <remarks>This setting only has effect on iOS.</remarks>
+		/// <remarks>This setting only has effect on iOS and Android.</remarks>
 		public bool PrefersEphemeralWebBrowserSession { get; set; }
 
 		/// <summary>


### PR DESCRIPTION
### Description of Change

This sets the webauth intent to use the incognito mode if the system browser supports it and user sets `WebAuthenticatorOptions.PrefersEphemeralWebBrowserSession = true`.

See also 
- https://groups.google.com/a/chromium.org/g/chromium-reviews/c/d1901HSe8nc
- https://stackoverflow.com/questions/66443545/how-can-i-start-chrome-custom-tabs-in-incognito-mode/72540492#72540492

### Issues Fixed

Fixes #20835

