### PR TITLE
[iOS] Pasting long text when the editor has a max length

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue17783.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue17783.cs
@@ -1,0 +1,45 @@
+using System.Windows.Input;
+
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 17783, "Pasting long text when the editor has a max length does nothing", PlatformAffected.All)]
+public partial class Issue17783 : ContentPage
+{
+	public Issue17783()
+	{
+		var stackLayout = new VerticalStackLayout();
+
+		var entry = new Entry
+		{
+			AutomationId = "Entry",
+			MaxLength = 5
+		};
+
+		var editor = new Editor
+		{
+			AutomationId = "Editor",
+			MaxLength = 5
+		};
+
+		var pasteToEntryButton = new Button
+		{
+			Text = "Paste to entry",
+			AutomationId = "PasteToEntryButton"
+		};
+		pasteToEntryButton.Clicked += (s, e) => entry.Text = "Hello, Maui!";
+
+		var pasteToEditorButton = new Button
+		{
+			Text = "Paste to editor",
+			AutomationId = "PasteToEditorButton"
+		};
+		pasteToEditorButton.Clicked += (s, e) => editor.Text = "Hello, Maui!";
+
+		stackLayout.Children.Add(entry);
+		stackLayout.Children.Add(editor);
+		stackLayout.Children.Add(pasteToEntryButton);
+		stackLayout.Children.Add(pasteToEditorButton);
+
+		Content = stackLayout;
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue17783.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue17783.cs
@@ -1,0 +1,30 @@
+﻿using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue17783 : _IssuesUITest
+	{
+		public Issue17783(TestDevice testDevice) : base(testDevice)
+		{
+		}
+
+		public override string Issue => "Pasting long text when the editor has a max length does nothing";
+
+		[Test]
+		[Category(UITestCategories.Editor)]
+		[Category(UITestCategories.Entry)]
+		public void TextShouldBeCut()
+		{
+			App.WaitForElement("PasteToEntryButton");
+			App.Click("PasteToEntryButton");
+			App.Click("PasteToEditorButton");
+			var entryText = App.FindElement("Entry").GetText;
+			var editorText = App.FindElement("Editor").GetText;
+
+			Assert.That(entryText, Is.EqualTo("Hello"));
+			Assert.That(editorText, Is.EqualTo("Hello"));
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue17783.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue17783.cs
@@ -20,8 +20,8 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 			App.WaitForElement("PasteToEntryButton");
 			App.Click("PasteToEntryButton");
 			App.Click("PasteToEditorButton");
-			var entryText = App.FindElement("Entry").GetText;
-			var editorText = App.FindElement("Editor").GetText;
+			var entryText = App.FindElement("Entry").GetText();
+			var editorText = App.FindElement("Editor").GetText();
 
 			Assert.That(entryText, Is.EqualTo("Hello"));
 			Assert.That(editorText, Is.EqualTo("Hello"));

--- a/src/Core/src/Core/Extensions/ITextInputExtensions.cs
+++ b/src/Core/src/Core/Extensions/ITextInputExtensions.cs
@@ -39,7 +39,13 @@ namespace Microsoft.Maui
 
 			var newLength = currLength + addLength - remLength;
 
-			return newLength <= textInput.MaxLength;
+			var shouldChange = newLength <= textInput.MaxLength;
+
+			// cut text when user is pasting a text longer that maxlength
+			if(!shouldChange && !string.IsNullOrWhiteSpace(replacementString) && replacementString!.Length >= textInput.MaxLength)
+				textInput.Text = replacementString!.Substring(0, textInput.MaxLength);
+
+			return shouldChange;
 		}
 #endif
 


### PR DESCRIPTION
### Description of Change

<!-- Enter description of the fix in this section -->

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/17783

|Android (current)|
|--|
|<video src="https://github.com/user-attachments/assets/d22139b4-e4bf-458c-8e27-f1e324fd99ca" width="300px"/>|


|iOS (current)|iOS(fixed)|
|--|--|
|<video src="https://github.com/user-attachments/assets/68d74da0-afef-4908-80ce-e5f16566209b" width="300px"/>|<video src="https://github.com/user-attachments/assets/37a4d007-e7f4-4c0e-9356-0e052aa129af" width="300px"/>|









