### PR TITLE
dismiss the modal when IsAnimated is set to false

### DIFF
--- a/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Android.cs
+++ b/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Android.cs
@@ -140,6 +140,7 @@ namespace Microsoft.Maui.Controls.Platform
 			}
 			else
 			{
+				dialogFragment.Dismiss();
 				source.TrySetResult(modal);
 			}
 

--- a/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.cs
@@ -532,6 +532,29 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.Empty(rootPage.GetCurrentPage().Navigation.ModalStack);
 		}
 
+		[Fact]
+		public async Task DismissModalIfNotAnimated()
+		{
+			SetupBuilder();
+			var page = new ContentPage();
+
+			var modalPage = new ContentPage()
+			{
+				Content = new Label() { Text = "Page with no animation" }
+			};
+
+			var window = new Window(page);
+
+			await CreateHandlerAndAddToWindow(window, async () =>
+			{
+				await page.Navigation.PushModalAsync(modalPage, false);
+				await OnLoadedAsync(modalPage);
+				await modalPage.Navigation.PopModalAsync(false);
+				await OnUnloadedAsync(modalPage);
+
+			});
+		}
+
 		class PageTypes : IEnumerable<object[]>
 		{
 			public IEnumerator<object[]> GetEnumerator()


### PR DESCRIPTION
This is just a follow up to my previous PR (#22869), where I forgot to dismiss the ModalPage if the `IsAnimated` is set to false.