### PR TITLE
[Windows] Register focus events for controls that can receive focus

### DIFF
--- a/src/Core/src/Handlers/View/ViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.Windows.cs
@@ -13,7 +13,8 @@ namespace Microsoft.Maui.Handlers
 	{
 		partial void ConnectingHandler(PlatformView? platformView)
 		{
-			if (platformView != null)
+			// TextBlock can receive focus if TabStop is set or if text selection is allowed. No such features are available in MAUI at the moment.
+			if (platformView is not null && platformView is not TextBlock)
 			{
 				platformView.GotFocus += OnPlatformViewGotFocus;
 				platformView.LostFocus += OnPlatformViewLostFocus;
@@ -22,10 +23,13 @@ namespace Microsoft.Maui.Handlers
 
 		partial void DisconnectingHandler(PlatformView platformView)
 		{
-			UpdateIsFocused(false);
+			if (platformView is not TextBlock)
+			{
+				UpdateIsFocused(false);
 
-			platformView.GotFocus -= OnPlatformViewGotFocus;
-			platformView.LostFocus -= OnPlatformViewLostFocus;
+				platformView.GotFocus -= OnPlatformViewGotFocus;
+				platformView.LostFocus -= OnPlatformViewLostFocus;
+			}
 		}
 
 		static partial void MappingFrame(IViewHandler handler, IView view)
@@ -145,13 +149,17 @@ namespace Microsoft.Maui.Handlers
 
 		void UpdateIsFocused(bool isFocused)
 		{
-			if (VirtualView == null)
+			if (VirtualView is null)
+			{
 				return;
+			}
 
 			bool updateIsFocused = (isFocused && !VirtualView.IsFocused) || (!isFocused && VirtualView.IsFocused);
 
 			if (updateIsFocused)
+			{
 				VirtualView.IsFocused = isFocused;
+			}
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change

I noticed that MAUI [registers](https://github.com/dotnet/maui/blob/1fb670908f38d135d5a071ef1f8c9c9119e6e377/src/Core/src/Handlers/View/ViewHandler.Windows.cs#L18-L19) `GotFocus` and `LostFocus` events for all platform views on Windows.

However, for MAUI `<Label>`s, I believe it's not really necessary.

It seems that `TextBlock` (WinUI 3 type that MAUI's `Label` is mapped to) can be focusable as it contains [this method](https://github.com/microsoft/microsoft-ui-xaml/blob/66a7b0ae71c19f89c6a7d86a1986794ad1a1bf09/src/dxaml/xcp/core/inc/TextBlock.h#L155-L162):

```cpp
// Focus and selection handling related overrides and helpers.
bool IsFocusable() final
{
    return IsActive() &&
        IsVisible() &&
        IsEnabled() && (m_isTextSelectionEnabled || IsTabStop()) &&
        AreAllAncestorsVisible();
}
```

However, support for `TabStop`s was removed in #1777 (see also #1646 for reasoning) and MAUI [does not support](https://learn.microsoft.com/en-gb/dotnet/maui/user-interface/controls/label?view=net-maui-8.0) text selection for `Label`s.

### Performance impact

* MAIN [1722247190..speedscope.MAIN.json](https://github.com/user-attachments/files/16411119/1722247190.speedscope.MAIN.json)
* PR [1722247261..speedscope.PR.json](https://github.com/user-attachments/files/16411120/1722247261.speedscope.PR.json)

![image](https://github.com/user-attachments/assets/89e1cfc1-644c-4bb5-88c1-35e5a9605826)


-> ~ 96% improvement

### Issues Fixed

Contributes to #21787

### Alternative approaches

There is `FocusManager` in WinUI and it has similar events ( https://learn.microsoft.com/en-us/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.input.focusmanager?view=windows-app-sdk-1.5#events), so instead of registering events on all views one by one (and unregistering for that matter). One can probably subscribe `FocusManager` events once and just check if the platform view corresponds to one in a dictionary and do the action. 