### PR TITLE
Fix BlazorWebView on iOS/MacCatalyst 18

### DIFF
--- a/src/BlazorWebView/src/Maui/Android/AndroidWebKitWebViewManager.cs
+++ b/src/BlazorWebView/src/Maui/Android/AndroidWebKitWebViewManager.cs
@@ -22,9 +22,9 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		// Using an IP address means that WebView doesn't wait for any DNS resolution,
 		// making it substantially faster. Note that this isn't real HTTP traffic, since
 		// we intercept all the requests within this origin.
-		private static readonly string AppOrigin = $"https://{BlazorWebView.AppHostAddress}/";
-		private static readonly Uri AppOriginUri = new(AppOrigin);
-		private static readonly AUri AndroidAppOriginUri = AUri.Parse(AppOrigin)!;
+		private static string AppOrigin { get; } = $"https://{BlazorWebView.AppHostAddress}/";
+		private static Uri AppOriginUri { get; } = new(AppOrigin);
+		private static AUri AndroidAppOriginUri { get; } = AUri.Parse(AppOrigin)!;
 		private readonly ILogger _logger;
 		private readonly AWebView _webview;
 		private readonly string _contentRootRelativeToAppRoot;

--- a/src/BlazorWebView/src/Maui/BlazorWebView.cs
+++ b/src/BlazorWebView/src/Maui/BlazorWebView.cs
@@ -27,7 +27,16 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 			else
 			{
 #if IOS || MACCATALYST
-				return "localhost";
+				// NOTE: skip this test on older Android devices because it is not currently supported on these versions
+				if (System.OperatingSystem.IsIOSVersionAtLeast(18) ||
+					System.OperatingSystem.IsMacCatalystVersionAtLeast(18))
+				{
+					return "localhost";
+				}
+				else
+				{
+					return "0.0.0.0";
+				}
 #else
 				return "0.0.0.0";
 #endif

--- a/src/BlazorWebView/src/Maui/BlazorWebView.cs
+++ b/src/BlazorWebView/src/Maui/BlazorWebView.cs
@@ -11,7 +11,28 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 	/// </summary>
 	public partial class BlazorWebView : View, IBlazorWebView
 	{
-		internal const string AppHostAddress = "0.0.0.0";
+		internal static string AppHostAddress { get; } = GetAppHostAddress();
+
+		private const string AppHostAddressAlways0000Switch = "BlazorWebView.AppHostAddressAlways0000";
+
+		private static bool IsAppHostAddressAlways0000Enabled =>
+			AppContext.TryGetSwitch(AppHostAddressAlways0000Switch, out var enabled) && enabled;
+
+		private static string GetAppHostAddress()
+		{
+			if (IsAppHostAddressAlways0000Enabled)
+			{
+				return "0.0.0.0";
+			}
+			else
+			{
+#if IOS || MACCATALYST
+				return "localhost";
+#else
+				return "0.0.0.0";
+#endif
+			}
+		}
 
 		private readonly JSComponentConfigurationStore _jSComponents = new();
 

--- a/src/BlazorWebView/src/Maui/BlazorWebView.cs
+++ b/src/BlazorWebView/src/Maui/BlazorWebView.cs
@@ -30,8 +30,13 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 				// On iOS/MacCatalyst 18 and higher the 0.0.0.0 address does not work, so we use localhost instead.
 				// This preserves behavior on older versions of those systems, while defaulting to new behavior on
 				// the new system.
-				if (System.OperatingSystem.IsIOSVersionAtLeast(18) ||
-					System.OperatingSystem.IsMacCatalystVersionAtLeast(18))
+
+				// Note that pre-release versions of iOS/MacCatalyst have the expected Major/Minor values,
+				// but the Build, MajorRevision, MinorRevision, and Revision values are all -1, so we need
+				// to pass in int.MinValue for those values.
+
+				if (System.OperatingSystem.IsIOSVersionAtLeast(major: 18, minor: int.MinValue, build: int.MinValue) ||
+					System.OperatingSystem.IsMacCatalystVersionAtLeast(major: 18, minor: int.MinValue, build: int.MinValue))
 				{
 					return "localhost";
 				}

--- a/src/BlazorWebView/src/Maui/BlazorWebView.cs
+++ b/src/BlazorWebView/src/Maui/BlazorWebView.cs
@@ -27,7 +27,9 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 			else
 			{
 #if IOS || MACCATALYST
-				// NOTE: skip this test on older Android devices because it is not currently supported on these versions
+				// On iOS/MacCatalyst 18 and higher the 0.0.0.0 address does not work, so we use localhost instead.
+				// This preserves behavior on older versions of those systems, while defaulting to new behavior on
+				// the new system.
 				if (System.OperatingSystem.IsIOSVersionAtLeast(18) ||
 					System.OperatingSystem.IsMacCatalystVersionAtLeast(18))
 				{

--- a/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
+++ b/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
@@ -23,8 +23,8 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 	{
 		private IOSWebViewManager? _webviewManager;
 
-		internal const string AppOrigin = "app://" + BlazorWebView.AppHostAddress + "/";
-		internal static readonly Uri AppOriginUri = new(AppOrigin);
+		internal static string AppOrigin { get; } = "app://" + BlazorWebView.AppHostAddress + "/";
+		internal static Uri AppOriginUri { get; } = new(AppOrigin);
 		private const string BlazorInitScript = @"
 			window.__receiveMessageCallbacks = [];
 			window.__dispatchMessageCallback = function(message) {


### PR DESCRIPTION
### Description of Change

Starting wtih iOS/MacCatalyst 18 the internal `0.0.0.0` address used to host the BlazorWebView's content no longer works and causes the BlazorWebView to not load and render as an empty rectangle. It turns out that using `localhost` as the base address does work (credit to @veler for discovering and sharing this!). This change changes the default behavior to be `localhost` on iOS/MacCatalyst 18 and newer. No other platforms are changed at all.

I've added a back-compat switch to always use `0.0.0.0` in case the new behavior causes any problem, which can be activated using this switch at the start of `MauiProgram.cs` in an app:

```c#
// Set this switch to use the LEGACY behavior of always using 0.0.0.0 to host BlazorWebView
AppContext.SetSwitch("BlazorWebView.AppHostAddressAlways0000", true);
```

I've started testing this and it looks good, but I have some more testing to do.

### Issues Fixed

Fixes #23390
