### PR TITLE
Always return Granted for Read-Write Storage permissions on Android

### DIFF
--- a/src/Essentials/src/Permissions/Permissions.android.cs
+++ b/src/Essentials/src/Permissions/Permissions.android.cs
@@ -521,14 +521,75 @@ namespace Microsoft.Maui.ApplicationModel
 
 		public partial class StorageRead : BasePlatformPermission
 		{
-			public override (string androidPermission, bool isRuntime)[] RequiredPermissions =>
-				new (string, bool)[] { (Manifest.Permission.ReadExternalStorage, true) };
+			public override (string androidPermission, bool isRuntime)[] RequiredPermissions
+			{
+				get
+				{
+					if (!OperatingSystem.IsAndroidVersionAtLeast(33))
+					{
+						return [];
+					}
+					
+					return new (string, bool)[] { (Manifest.Permission.ReadExternalStorage, true) };
+				}
+			}
+
+			public override Task<PermissionStatus> RequestAsync()
+			{
+				if (OperatingSystem.IsAndroidVersionAtLeast(33))
+				{
+					return Task.FromResult(PermissionStatus.Granted);
+				}
+
+				return base.RequestAsync();
+			}
+
+			public override Task<PermissionStatus> CheckStatusAsync()
+			{
+				if (OperatingSystem.IsAndroidVersionAtLeast(33))
+				{
+					return Task.FromResult(PermissionStatus.Granted);
+				}
+				
+				return base.CheckStatusAsync();
+			}
 		}
 
 		public partial class StorageWrite : BasePlatformPermission
 		{
-			public override (string androidPermission, bool isRuntime)[] RequiredPermissions =>
-				new (string, bool)[] { (Manifest.Permission.WriteExternalStorage, true) };
+			public override (string androidPermission, bool isRuntime)[] RequiredPermissions
+			{
+
+				get 
+				{
+					if (!OperatingSystem.IsAndroidVersionAtLeast(33))
+					{
+						return [];
+					}
+					
+					return new (string, bool)[] { (Manifest.Permission.WriteExternalStorage, true) };
+				}
+			}
+				
+			public override Task<PermissionStatus> RequestAsync()
+			{
+				if (OperatingSystem.IsAndroidVersionAtLeast(33))
+				{
+					return Task.FromResult(PermissionStatus.Granted);
+				}
+
+				return base.RequestAsync();
+			}
+
+			public override Task<PermissionStatus> CheckStatusAsync()
+			{
+				if (OperatingSystem.IsAndroidVersionAtLeast(33))
+				{
+					return Task.FromResult(PermissionStatus.Granted);
+				}
+
+				return base.CheckStatusAsync();
+			}
 		}
 
 		public partial class Vibrate : BasePlatformPermission

--- a/src/Essentials/src/Permissions/Permissions.android.cs
+++ b/src/Essentials/src/Permissions/Permissions.android.cs
@@ -525,7 +525,7 @@ namespace Microsoft.Maui.ApplicationModel
 			{
 				get
 				{
-					if (!OperatingSystem.IsAndroidVersionAtLeast(33))
+					if (OperatingSystem.IsAndroidVersionAtLeast(33))
 					{
 						return [];
 					}
@@ -562,7 +562,7 @@ namespace Microsoft.Maui.ApplicationModel
 
 				get 
 				{
-					if (!OperatingSystem.IsAndroidVersionAtLeast(33))
+					if (OperatingSystem.IsAndroidVersionAtLeast(33))
 					{
 						return [];
 					}

--- a/src/Essentials/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -56,3 +56,7 @@ static Microsoft.Maui.Devices.Sensors.Geolocation.StopListeningForeground() -> v
 *REMOVED*Microsoft.Maui.Media.IMediaPicker.CaptureVideoAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<Microsoft.Maui.Storage.FileResult!>!
 *REMOVED*Microsoft.Maui.Media.IMediaPicker.PickPhotoAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<Microsoft.Maui.Storage.FileResult!>!
 *REMOVED*Microsoft.Maui.Media.IMediaPicker.PickVideoAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<Microsoft.Maui.Storage.FileResult!>!
+~override Microsoft.Maui.ApplicationModel.Permissions.StorageRead.CheckStatusAsync() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>
+~override Microsoft.Maui.ApplicationModel.Permissions.StorageRead.RequestAsync() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>
+~override Microsoft.Maui.ApplicationModel.Permissions.StorageWrite.CheckStatusAsync() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>
+~override Microsoft.Maui.ApplicationModel.Permissions.StorageWrite.RequestAsync() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>

--- a/src/Essentials/test/DeviceTests/Tests/Permissions_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/Permissions_Tests.cs
@@ -79,7 +79,11 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 			});
 		}
 
-		[Fact]
+		[Fact
+#if !__ANDROID__
+		(Skip = "Test only applies to Android")
+#endif
+		]
 		public async Task StorageAndroid13AlwaysGranted()
 		{
 			if (DeviceInfo.Platform == DevicePlatform.Android && OperatingSystem.IsAndroidVersionAtLeast(33))

--- a/src/Essentials/test/DeviceTests/Tests/Permissions_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/Permissions_Tests.cs
@@ -2,7 +2,9 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.Maui.ApplicationModel;
 using Microsoft.Maui.Devices;
+using Microsoft.Maui.Dispatching;
 using Xunit;
+using Xunit.Sdk;
 
 namespace Microsoft.Maui.Essentials.DeviceTests
 {
@@ -87,6 +89,14 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 
 				status = await Permissions.CheckStatusAsync<Permissions.StorageWrite>();
 				Assert.Equal(PermissionStatus.Granted, status);
+			}
+			else // Android < API 33, we didn't request these, so status denied
+			{
+				var status = await Permissions.CheckStatusAsync<Permissions.StorageRead>();
+				Assert.Equal(PermissionStatus.Denied, status);
+
+				status = await Permissions.CheckStatusAsync<Permissions.StorageWrite>();
+				Assert.Equal(PermissionStatus.Denied, status);
 			}
 		}
 	}

--- a/src/Essentials/test/DeviceTests/Tests/Permissions_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/Permissions_Tests.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Threading.Tasks;
 using Microsoft.Maui.ApplicationModel;
+using Microsoft.Maui.Devices;
 using Xunit;
 
 namespace Microsoft.Maui.Essentials.DeviceTests
@@ -73,6 +75,19 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 			{
 				await Assert.ThrowsAsync<PermissionException>(async () => await Permissions.RequestAsync<Permissions.LocationWhenInUse>());
 			});
+		}
+
+		[Fact]
+		public async Task StorageAndroid13AlwaysGranted()
+		{
+			if (DeviceInfo.Platform == DevicePlatform.Android && OperatingSystem.IsAndroidVersionAtLeast(33))
+			{
+				var status = await Permissions.CheckStatusAsync<Permissions.StorageRead>();
+				Assert.Equal(PermissionStatus.Granted, status);
+
+				status = await Permissions.CheckStatusAsync<Permissions.StorageWrite>();
+				Assert.Equal(PermissionStatus.Granted, status);
+			}
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change

The `android.permission.READ_EXTERNAL_STORAGE` and `android.permission.WRITE_EXTERNAL_STORAGE` permissions are no longer available on Android 13 (API 33) and up. This PR changes the current .NET MAUI implementation to not change anything for < API 33, and always returns granted for API 33+.

If you want to access specific media files, you now need to [request specific permissions](https://developer.android.com/about/versions/13/behavior-changes-13#granular-media-permissions) for that. This PR don't implement those yet. For the time being you can implement those manually if you need them, following this documentation here: https://learn.microsoft.com/dotnet/maui/platform-integration/appmodel/permissions?tabs=android#extending-permissions.

### Issues Fixed

Fixes #14729
