### PR TITLE
Fix HostIdentifier bindings for item templates

### DIFF
--- a/src/Templates/src/templates/maui-contentpage-csharp/.template.config/template.json
+++ b/src/Templates/src/templates/maui-contentpage-csharp/.template.config/template.json
@@ -38,6 +38,10 @@
         "description": "Namespace for the generated code.",
         "replaces": "MauiApp1",
         "type": "parameter"
+      },
+      "HostIdentifier": {
+          "type": "bind",
+          "binding": "HostIdentifier"
       }
     }
   }

--- a/src/Templates/src/templates/maui-contentpage-xaml/.template.config/template.json
+++ b/src/Templates/src/templates/maui-contentpage-xaml/.template.config/template.json
@@ -42,6 +42,10 @@
         "description": "namespace for the generated code",
         "replaces": "MauiApp1",
         "type": "parameter"
+      },
+      "HostIdentifier": {
+          "type": "bind",
+          "binding": "HostIdentifier"
       }
     }
   }

--- a/src/Templates/src/templates/maui-contentview-csharp/.template.config/template.json
+++ b/src/Templates/src/templates/maui-contentview-csharp/.template.config/template.json
@@ -38,6 +38,10 @@
         "description": "Namespace for the generated code.",
         "replaces": "MauiApp1",
         "type": "parameter"
+      },
+      "HostIdentifier": {
+          "type": "bind",
+          "binding": "HostIdentifier"
       }
     }
   }

--- a/src/Templates/src/templates/maui-contentview-xaml/.template.config/template.json
+++ b/src/Templates/src/templates/maui-contentview-xaml/.template.config/template.json
@@ -42,6 +42,10 @@
             "description": "Namespace for the generated code.",
             "replaces": "MauiApp1",
             "type": "parameter"
+        },
+        "HostIdentifier": {
+            "type": "bind",
+            "binding": "HostIdentifier"
         }
     }
 }

--- a/src/Templates/src/templates/maui-resourcedictionary-xaml/.template.config/template.json
+++ b/src/Templates/src/templates/maui-resourcedictionary-xaml/.template.config/template.json
@@ -42,6 +42,10 @@
             "description": "Namespace for the generated code.",
             "replaces": "MauiApp1",
             "type": "parameter"
+        },
+        "HostIdentifier": {
+            "type": "bind",
+            "binding": "HostIdentifier"
         }
     }
 }


### PR DESCRIPTION
### Description of Change

Noticed some weird cli output when trying to create item templates. 

> Processing post-creation actions ...
> The post action 84c0da21-51c8-4541-9940-6ca19af04ee6 is not supported.
> Description: Opens NewPagel.xaml in the editor.

![image](https://github.com/user-attachments/assets/1a1c647e-3625-4775-8907-0b534acdb243)

This is caused because the `HostIdentifier` variable is not bound for these templates. This change fixes that.

The templates currently work fine, they just give this weird warning.

### Issues Fixed

Related similar earlier PR: #13903