### PR TITLE
Fix item templates namespaces

### DIFF
--- a/src/Templates/src/templates/maui-contentpage-csharp/.template.config/template.json
+++ b/src/Templates/src/templates/maui-contentpage-csharp/.template.config/template.json
@@ -34,10 +34,11 @@
     "sourceName": "NewPage1",
     "defaultName": "NewPage1",
     "symbols": {
-      "namespace": {
-        "description": "Namespace for the generated code.",
+      "DefaultNamespace": {
+        "type": "bind",
+        "binding": "msbuild:RootNamespace",
         "replaces": "MauiApp1",
-        "type": "parameter"
+        "defaultValue": "MauiApp1"
       },
       "HostIdentifier": {
           "type": "bind",

--- a/src/Templates/src/templates/maui-contentpage-xaml/.template.config/template.json
+++ b/src/Templates/src/templates/maui-contentpage-xaml/.template.config/template.json
@@ -38,10 +38,11 @@
     "sourceName": "NewPage1",
     "defaultName": "NewPage1",
     "symbols": {
-      "namespace": {
-        "description": "namespace for the generated code",
+      "DefaultNamespace": {
+        "type": "bind",
+        "binding": "msbuild:RootNamespace",
         "replaces": "MauiApp1",
-        "type": "parameter"
+        "defaultValue": "MauiApp1"
       },
       "HostIdentifier": {
           "type": "bind",

--- a/src/Templates/src/templates/maui-contentview-csharp/.template.config/template.json
+++ b/src/Templates/src/templates/maui-contentview-csharp/.template.config/template.json
@@ -34,10 +34,11 @@
     "sourceName": "NewContent1",
     "defaultName": "NewContent1",
     "symbols": {
-      "namespace": {
-        "description": "Namespace for the generated code.",
+      "DefaultNamespace": {
+        "type": "bind",
+        "binding": "msbuild:RootNamespace",
         "replaces": "MauiApp1",
-        "type": "parameter"
+        "defaultValue": "MauiApp1"
       },
       "HostIdentifier": {
           "type": "bind",

--- a/src/Templates/src/templates/maui-contentview-xaml/.template.config/template.json
+++ b/src/Templates/src/templates/maui-contentview-xaml/.template.config/template.json
@@ -38,10 +38,11 @@
     "sourceName": "NewContent1",
     "defaultName": "NewContent1",
     "symbols": {
-        "namespace": {
-            "description": "Namespace for the generated code.",
-            "replaces": "MauiApp1",
-            "type": "parameter"
+        "DefaultNamespace": {
+          "type": "bind",
+          "binding": "msbuild:RootNamespace",
+          "replaces": "MauiApp1",
+          "defaultValue": "MauiApp1"
         },
         "HostIdentifier": {
             "type": "bind",

--- a/src/Templates/src/templates/maui-resourcedictionary-xaml/.template.config/template.json
+++ b/src/Templates/src/templates/maui-resourcedictionary-xaml/.template.config/template.json
@@ -38,10 +38,11 @@
     "sourceName": "Dictionary1",
     "defaultName": "Dictionary1",
     "symbols": {
-        "namespace": {
-            "description": "Namespace for the generated code.",
-            "replaces": "MauiApp1",
-            "type": "parameter"
+        "DefaultNamespace": {
+          "type": "bind",
+          "binding": "msbuild:RootNamespace",
+          "replaces": "MauiApp1",
+          "defaultValue": "MauiApp1"
         },
         "HostIdentifier": {
             "type": "bind",


### PR DESCRIPTION
### Description of Change

I noticed that our item templates did not adopt the namespace used by the project that they are added to. This PR fixes that.
