### PR TITLE
Added condition in WindowStateManager for selecting proper scene used

### DIFF
--- a/src/Essentials/src/Platform/WindowStateManager.ios.cs
+++ b/src/Essentials/src/Platform/WindowStateManager.ios.cs
@@ -140,7 +140,8 @@ namespace Microsoft.Maui.ApplicationModel
 				try
 				{
 					using var scenes = UIApplication.SharedApplication.ConnectedScenes;
-					var windowScene = scenes.ToArray<UIWindowScene>().FirstOrDefault();
+					var windowScene = scenes.ToArray().OfType<UIWindowScene>().FirstOrDefault(scene => 
+						scene.Session.Role == UIWindowSceneSessionRole.Application);
 					return windowScene?.Windows.FirstOrDefault();
 				}
 				catch (InvalidCastException)
@@ -163,7 +164,8 @@ namespace Microsoft.Maui.ApplicationModel
 				try
 				{
 					using var scenes = UIApplication.SharedApplication.ConnectedScenes;
-					var windowScene = scenes.ToArray<UIWindowScene>().FirstOrDefault();
+					var windowScene = scenes.ToArray().OfType<UIWindowScene>().FirstOrDefault(scene => 
+						scene.Session.Role == UIWindowSceneSessionRole.Application);
 					return windowScene?.Windows;
 				}
 				catch (InvalidCastException)


### PR DESCRIPTION
### Description of Change

Existing implementation causes issues in project where CarPlay application is supported because in some cases, Window from `CarPlay` app was. 
It might be worth to check for multi window scenarios. 

### Issues Fixed

https://github.com/dotnet/maui/issues/23910

