### PR TITLE
[Windows] Allow setting `PlatformCanvas.Antialias`

### DIFF
--- a/src/Graphics/src/Graphics/Platforms/Windows/PlatformCanvas.cs
+++ b/src/Graphics/src/Graphics/Platforms/Windows/PlatformCanvas.cs
@@ -132,7 +132,7 @@ namespace Microsoft.Maui.Graphics.Platform
 
 		public override bool Antialias
 		{
-			set { }
+			set => _session.Antialiasing = value ? CanvasAntialiasing.Antialiased : CanvasAntialiasing.Aliased;
 		}
 
 		public override BlendMode BlendMode


### PR DESCRIPTION
### Description of Change

The documentation seems to be here: https://microsoft.github.io/Win2D/WinUI3/html/P_Microsoft_Graphics_Canvas_CanvasDrawingSession_Antialiasing.htm

Observations: Antialising seems to be on by default.

### Tests

My testing code

```cs
public void Draw(ICanvas canvas, RectF dirtyRect)
{
#if WINDOWS
    var platformCanvas = (Microsoft.Maui.Graphics.Win2D.W2DCanvas)canvas;
    platformCanvas.Session.Antialiasing = Microsoft.Graphics.Canvas.CanvasAntialiasing.Aliased; // EITHER THIS
    // platformCanvas.Session.Antialiasing = Microsoft.Graphics.Canvas.CanvasAntialiasing.Antialiased; // ... OR THIS
#endif

    // Left border line.
    canvas.StrokeColor = this.BorderColorLeft;
    canvas.StrokeSize = (float)this.BorderWidth.Left;
    canvas.DrawLine(0, 0, 0, dirtyRect.Height);

    // Top border line.
    canvas.StrokeColor = this.BorderColorTop;
    canvas.StrokeSize = (float)this.BorderWidth.Top;
    canvas.DrawLine(0, 0, dirtyRect.Width, 0);

    // Right border line.
    canvas.StrokeColor = this.BorderColorRight;
    canvas.StrokeSize = (float)this.BorderWidth.Right;
    canvas.DrawLine(dirtyRect.Width, 0, dirtyRect.Width, dirtyRect.Height);

    // Bottom border line.
    canvas.StrokeColor = this.BorderColorBottom;
    canvas.StrokeSize = (float)this.BorderWidth.Bottom;
    canvas.DrawLine(0, dirtyRect.Height, dirtyRect.Width, dirtyRect.Height);
}
```

Results:

* With antialising ON (`CanvasAntialiasing.Antialiased`):
  ![image](https://github.com/user-attachments/assets/80541d6d-5da1-483d-86dd-df8d0837a5fe)

* With antialising OFF (`CanvasAntialiasing.Aliased`):
  ![image](https://github.com/user-attachments/assets/dd4530d2-8ac3-4b60-9050-b9210293f605)

So it appears the PR works.