### PR TITLE
[Windows][GestureManager] Unsubscribe control tap events only if they were subscribed

### DIFF
--- a/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
@@ -391,9 +391,9 @@ namespace Microsoft.Maui.Controls.Platform
 
 			ClearContainerEventHandlers();
 
-			if (_element is View && ElementGestureRecognizers is not null)
+			if (_element is View && ElementGestureRecognizers is {} gestureRecognizers)
 			{
-				ElementGestureRecognizers.CollectionChanged -= _collectionChangedHandler;
+				gestureRecognizers.CollectionChanged -= _collectionChangedHandler;
 			}
 
 			if (_control is not null)

--- a/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
@@ -103,10 +103,17 @@ namespace Microsoft.Maui.Controls.Platform
 				if (_control == value)
 					return;
 
-				if (_control != null)
+				if (_control is not null)
 				{
-					_control.Tapped -= HandleTapped;
-					_control.DoubleTapped -= HandleDoubleTapped;
+					if ((_subscriptionFlags & SubscriptionFlags.ControlTapEventSubscribed) != 0)
+					{
+						_control.Tapped -= HandleTapped;
+					}
+
+					if ((_subscriptionFlags & SubscriptionFlags.ControlDoubleTapEventSubscribed) != 0)
+					{
+						_control.DoubleTapped -= HandleDoubleTapped;
+					}
 				}
 
 				_control = value;
@@ -371,30 +378,35 @@ namespace Microsoft.Maui.Controls.Platform
 		protected virtual void Dispose(bool disposing)
 		{
 			if (_isDisposed)
+			{
 				return;
+			}
 
 			_isDisposed = true;
 
 			if (!disposing)
+			{
 				return;
+			}
 
 			ClearContainerEventHandlers();
 
-			if (_element != null)
+			if (_element is View && ElementGestureRecognizers is not null)
 			{
-
-				var view = _element as View;
-				if (view != null)
-				{
-					if (ElementGestureRecognizers != null)
-						ElementGestureRecognizers.CollectionChanged -= _collectionChangedHandler;
-				}
+				ElementGestureRecognizers.CollectionChanged -= _collectionChangedHandler;
 			}
 
-			if (_control != null)
+			if (_control is not null)
 			{
-				_control.Tapped -= HandleTapped;
-				_control.DoubleTapped -= HandleDoubleTapped;
+				if ((_subscriptionFlags & SubscriptionFlags.ControlTapEventSubscribed) != 0)
+				{
+					_control.Tapped -= HandleTapped;
+				}
+
+				if ((_subscriptionFlags & SubscriptionFlags.ControlDoubleTapEventSubscribed) != 0)
+				{
+					_control.DoubleTapped -= HandleDoubleTapped;
+				}
 			}
 
 			Control = null;
@@ -783,8 +795,9 @@ namespace Microsoft.Maui.Controls.Platform
 			}
 			else
 			{
-				if (_control != null && PreventGestureBubbling)
+				if (_control is not null && PreventGestureBubbling)
 				{
+					_subscriptionFlags |= SubscriptionFlags.ControlTapEventSubscribed;
 					_control.Tapped += HandleTapped;
 				}
 			}
@@ -798,8 +811,9 @@ namespace Microsoft.Maui.Controls.Platform
 			}
 			else
 			{
-				if (_control != null && PreventGestureBubbling)
+				if (_control is not null && PreventGestureBubbling)
 				{
+					_subscriptionFlags |= SubscriptionFlags.ControlDoubleTapEventSubscribed;
 					_control.DoubleTapped += HandleDoubleTapped;
 				}
 			}
@@ -885,7 +899,9 @@ namespace Microsoft.Maui.Controls.Platform
 			ContainerPgrPointerEventsSubscribed = 1 << 2,
 			ContainerManipulationAndPointerEventsSubscribed = 1 << 3,
 			ContainerTapAndRightTabEventSubscribed = 1 << 4,
-			ContainerDoubleTapEventSubscribed = 1 << 5
+			ContainerDoubleTapEventSubscribed = 1 << 5,
+			ControlTapEventSubscribed = 1 << 6,
+			ControlDoubleTapEventSubscribed = 1 << 7
 		}
 	}
 }

--- a/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
@@ -284,16 +284,16 @@ namespace Microsoft.Maui.Controls.Platform
 				if (_element == value)
 					return;
 
-				if (_element is View && ElementGestureRecognizers is {} gestureRecognizers)
+				if (_element is View && ElementGestureRecognizers is {} gestureRecognizersBefore)
 				{
-					gestureRecognizers.CollectionChanged -= _collectionChangedHandler;
+					gestureRecognizersBefore.CollectionChanged -= _collectionChangedHandler;
 				}
 
 				_element = value;
 
-				if (_element is View && ElementGestureRecognizers is {} gestureRecognizers)
+				if (_element is View && ElementGestureRecognizers is {} gestureRecognizersAfter)
 				{
-					gestureRecognizers.CollectionChanged += _collectionChangedHandler;
+					gestureRecognizersAfter.CollectionChanged += _collectionChangedHandler;
 				}
 			}
 		}

--- a/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
@@ -284,26 +284,16 @@ namespace Microsoft.Maui.Controls.Platform
 				if (_element == value)
 					return;
 
-				if (_element != null)
+				if (_element is View && ElementGestureRecognizers is {} gestureRecognizers)
 				{
-					var view = _element as View;
-					if (view != null)
-					{
-						if (ElementGestureRecognizers != null)
-							ElementGestureRecognizers.CollectionChanged -= _collectionChangedHandler;
-					}
+					gestureRecognizers.CollectionChanged -= _collectionChangedHandler;
 				}
 
 				_element = value;
 
-				if (_element != null)
+				if (_element is View && ElementGestureRecognizers is {} gestureRecognizers)
 				{
-					var view = _element as View;
-					if (view != null)
-					{
-						if (ElementGestureRecognizers != null)
-							ElementGestureRecognizers.CollectionChanged += _collectionChangedHandler;
-					}
+					gestureRecognizers.CollectionChanged += _collectionChangedHandler;
 				}
 			}
 		}


### PR DESCRIPTION
### Description of Change

The idea of the PR is that subscriptions of 

* `_control.Tapped` 
* `_control.DoubleTapped` 

make sense to unsubscribe only if they were subscribed.

### Performance impact

* MAIN: [1722594597..speedscope.MAIN.json](https://github.com/user-attachments/files/16469303/1722594597.speedscope.MAIN.json)
* PR: [1722594442..speedscope.PR.json](https://github.com/user-attachments/files/16469300/1722594442.speedscope.PR.json)

![image](https://github.com/user-attachments/assets/044ac45d-ee20-403d-94b2-5b3b1b84b6b9)

-> 86% for execution of `GestureManager.SetupGestureManager` 

### Issues Fixed

Contributes to #21787

Easier to review with [whitespace off](https://github.com/dotnet/maui/pull/23976/files?diff=split&w=1).