### PR TITLE
Remove the 'Resources' prefix from BundleResource

### DIFF
--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.SingleProject.targets
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.SingleProject.targets
@@ -61,6 +61,63 @@
 
   </Target>
 
+  <!--
+    Workaround for the issue where the resource starts with the Resources/ prefix,
+    either in the Identity or Link metadata. The fix is to assume that was not intended
+    since that is how it worked in 8.0.60 and earlier.
+    However, if there is a LogicalName metadata, we will skip processing as that is what
+    was explicitly set (even though the build will fail).
+  -->
+  <PropertyGroup>
+    <CollectBundleResourcesDependsOn>
+      _MauiRemoveResourcesPrefixFromBundleResource;
+      $(CollectBundleResourcesDependsOn);
+    </CollectBundleResourcesDependsOn>
+  </PropertyGroup>
+  <Target Name="_MauiRemoveResourcesPrefixFromBundleResource">
+    <!-- Collect the items into 2 categories: Link or no Link -->
+    <ItemGroup>
+      <_MauiBundleResourceWithLogicalName
+        Include="@(BundleResource->HasMetadata('LogicalName'))" />
+      <_MauiBundleResourceWithLink
+        Include="@(BundleResource->HasMetadata('Link'))"
+        Exclude="@(_MauiBundleResourceWithLogicalName)" />
+      <_MauiBundleResourceWithoutLink
+        Include="@(BundleResource)"
+        Exclude="@(_MauiBundleResourceWithLink);@(_MauiBundleResourceWithLogicalName)" />
+    </ItemGroup>
+    <!-- Set the LogicalName to be a path relative to Resources -->
+    <ItemGroup>
+      <_MauiBundleResourceWithRelativeLogicalName
+        Include="@(_MauiBundleResourceWithLink)"
+        LogicalName="$([MSBuild]::MakeRelative('$(MSBuildProjectDirectory)/Resources/', '$(MSBuildProjectDirectory)/%(Link)'))" />
+      <_MauiBundleResourceWithRelativeLogicalName
+        Include="@(_MauiBundleResourceWithoutLink)"
+        LogicalName="$([MSBuild]::MakeRelative('$(MSBuildProjectDirectory)/Resources/', '%(FullPath)'))" />
+    </ItemGroup>
+    <!-- Remove all items that are not below the Resources directory -->
+    <ItemGroup>
+      <_MauiBundleResourceWithCorrectLogicalName
+        Include="@(_MauiBundleResourceWithRelativeLogicalName)"
+        Condition="!$([System.String]::new('%(_MauiBundleResourceWithRelativeLogicalName.LogicalName)').StartsWith('..'))" />
+    </ItemGroup>
+    <!-- Replace the items in @(BundleResource) with the ones with a correct LogicalName -->
+    <ItemGroup>
+      <BundleResource Remove="@(_MauiBundleResourceWithCorrectLogicalName)" />
+      <BundleResource Include="@(_MauiBundleResourceWithCorrectLogicalName)" />
+    </ItemGroup>
+    <!-- Clean up items -->
+    <ItemGroup>
+      <_MauiBundleResourceResult Include="@(BundleResource)" />
+      <_MauiBundleResourceWithLogicalName Remove="@(_MauiBundleResourceWithLogicalName)" />
+      <_MauiBundleResourceWithLink Remove="@(_MauiBundleResourceWithLink)" />
+      <_MauiBundleResourceWithoutLink Remove="@(_MauiBundleResourceWithoutLink)" />
+      <_MauiBundleResourceWithRelativeLogicalName Remove="@(_MauiBundleResourceWithRelativeLogicalName)" />
+      <_MauiBundleResourceWithCorrectLogicalName Remove="@(_MauiBundleResourceWithCorrectLogicalName)" />
+      <_MauiBundleResourceResult Remove="@(_MauiBundleResourceResult)" />
+    </ItemGroup>
+  </Target>
+
   <!-- Import Maui Single Project property pages -->
   <PropertyGroup Condition="'$(MauiDesignTimeTargetsPath)' == ''">
     <MauiDesignTimeTargetsPath>$(MSBuildExtensionsPath)\Microsoft\VisualStudio\Maui\Maui.DesignTime.targets</MauiDesignTimeTargetsPath>

--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.SingleProject.targets
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.SingleProject.targets
@@ -62,62 +62,21 @@
   </Target>
 
   <!--
-    Workaround for the issue where the resource starts with the Resources/ prefix,
+    TEMPORARY workaround for the issue where the resource starts with the Resources/ prefix,
     either in the Identity or Link metadata. The fix is to assume that was not intended
     since that is how it worked in 8.0.60 and earlier.
-    However, if there is a LogicalName metadata, we will skip processing as that is what
-    was explicitly set (even though the build will fail).
+    See: https://github.com/xamarin/xamarin-macios/issues/20968
   -->
-  <PropertyGroup>
-    <CollectBundleResourcesDependsOn Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' or $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
-      _MauiRemoveResourcesPrefixFromBundleResource;
-      $(CollectBundleResourcesDependsOn);
-    </CollectBundleResourcesDependsOn>
-  </PropertyGroup>
-  <Target Name="_MauiRemoveResourcesPrefixFromBundleResource">
-    <!-- Collect the items into 2 categories: Link or no Link -->
-    <ItemGroup>
-      <_MauiBundleResourceWithLogicalName
-        Include="@(BundleResource->HasMetadata('LogicalName'))" />
-      <_MauiBundleResourceWithLink
-        Include="@(BundleResource->HasMetadata('Link'))"
-        Exclude="@(_MauiBundleResourceWithLogicalName)" />
-      <_MauiBundleResourceWithoutLink
-        Include="@(BundleResource)"
-        Exclude="@(_MauiBundleResourceWithLink);@(_MauiBundleResourceWithLogicalName)" />
-    </ItemGroup>
-    <!-- Set the LogicalName to be a path relative to Resources -->
-    <ItemGroup>
-      <_MauiBundleResourceWithRelativeLogicalName
-        Include="@(_MauiBundleResourceWithLink)"
-        Condition="@(_MauiBundleResourceWithLink->Count()) > 0"
-        LogicalName="$([MSBuild]::MakeRelative('$(MSBuildProjectDirectory)/Resources/', '$(MSBuildProjectDirectory)/%(Link)'))" />
-      <_MauiBundleResourceWithRelativeLogicalName
-        Include="@(_MauiBundleResourceWithoutLink)"
-        Condition="@(_MauiBundleResourceWithoutLink->Count()) > 0"
-        LogicalName="$([MSBuild]::MakeRelative('$(MSBuildProjectDirectory)/Resources/', '%(FullPath)'))" />
-    </ItemGroup>
-    <!-- Remove all items that are not below the Resources directory -->
-    <ItemGroup>
-      <_MauiBundleResourceWithCorrectLogicalName
-        Include="@(_MauiBundleResourceWithRelativeLogicalName)"
-        Condition="!$([System.String]::new('%(_MauiBundleResourceWithRelativeLogicalName.LogicalName)').StartsWith('..'))" />
-    </ItemGroup>
-    <!-- Replace the items in @(BundleResource) with the ones with a correct LogicalName -->
-    <ItemGroup>
-      <BundleResource Remove="@(_MauiBundleResourceWithCorrectLogicalName)" />
-      <BundleResource Include="@(_MauiBundleResourceWithCorrectLogicalName)" />
-    </ItemGroup>
-    <!-- Clean up items -->
-    <ItemGroup>
-      <_MauiBundleResourceResult Include="@(BundleResource)" />
-      <_MauiBundleResourceWithLogicalName Remove="@(_MauiBundleResourceWithLogicalName)" />
-      <_MauiBundleResourceWithLink Remove="@(_MauiBundleResourceWithLink)" />
-      <_MauiBundleResourceWithoutLink Remove="@(_MauiBundleResourceWithoutLink)" />
-      <_MauiBundleResourceWithRelativeLogicalName Remove="@(_MauiBundleResourceWithRelativeLogicalName)" />
-      <_MauiBundleResourceWithCorrectLogicalName Remove="@(_MauiBundleResourceWithCorrectLogicalName)" />
-      <_MauiBundleResourceResult Remove="@(_MauiBundleResourceResult)" />
-    </ItemGroup>
+  <Target Name="_MauiBefore_CollectBundleResources" BeforeTargets="_CollectBundleResources">
+    <PropertyGroup>
+      <_MauiOld_ResourcePrefix>$(_ResourcePrefix)</_MauiOld_ResourcePrefix>
+      <_ResourcePrefix>Resources;$(_ResourcePrefix)</_ResourcePrefix>
+    </PropertyGroup>
+  </Target>
+  <Target Name="_MauiAfter_CollectBundleResources" AfterTargets="_CollectBundleResources">
+    <PropertyGroup>
+      <_ResourcePrefix>$(_MauiOld_ResourcePrefix)</_ResourcePrefix>
+    </PropertyGroup>
   </Target>
 
   <!-- Import Maui Single Project property pages -->

--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.SingleProject.targets
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.SingleProject.targets
@@ -69,7 +69,7 @@
     was explicitly set (even though the build will fail).
   -->
   <PropertyGroup>
-    <CollectBundleResourcesDependsOn>
+    <CollectBundleResourcesDependsOn Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' or $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
       _MauiRemoveResourcesPrefixFromBundleResource;
       $(CollectBundleResourcesDependsOn);
     </CollectBundleResourcesDependsOn>
@@ -90,9 +90,11 @@
     <ItemGroup>
       <_MauiBundleResourceWithRelativeLogicalName
         Include="@(_MauiBundleResourceWithLink)"
+        Condition="@(_MauiBundleResourceWithLink->Count()) > 0"
         LogicalName="$([MSBuild]::MakeRelative('$(MSBuildProjectDirectory)/Resources/', '$(MSBuildProjectDirectory)/%(Link)'))" />
       <_MauiBundleResourceWithRelativeLogicalName
         Include="@(_MauiBundleResourceWithoutLink)"
+        Condition="@(_MauiBundleResourceWithoutLink->Count()) > 0"
         LogicalName="$([MSBuild]::MakeRelative('$(MSBuildProjectDirectory)/Resources/', '%(FullPath)'))" />
     </ItemGroup>
     <!-- Remove all items that are not below the Resources directory -->

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/TemplateTests.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/TemplateTests.cs
@@ -269,6 +269,37 @@ namespace Microsoft.Maui.IntegrationTests
 		}
 
 		[Test]
+		[TestCase("maui", "ios")]
+		[TestCase("maui", "maccatalyst")]
+		[TestCase("maui-blazor", "ios")]
+		[TestCase("maui-blazor", "maccatalyst")]
+		public void BuildWithCustomBundleResource(string id, bool framework)
+		{
+			var projectDir = TestDirectory;
+			var projectFile = Path.Combine(projectDir, $"{Path.GetFileName(projectDir)}.csproj");
+
+			Assert.IsTrue(DotnetInternal.New(id, projectDir, DotNetCurrent),
+				$"Unable to create template {id}. Check test output for errors.");
+
+			File.WriteAllText(Path.Combine(projectDir, "Resources", "testfile.txt"), "Something here :)");
+
+			FileUtilities.ReplaceInFile(projectFile,
+				"</Project>",
+				$"""
+				  <ItemGroup>
+				    <BundleResource Include="Resources\testfile.txt" />
+				  </ItemGroup>
+				</Project>
+				""");
+
+			var extendedBuildProps = BuildProps;
+			extendedBuildProps.Add($"TargetFramework={DotNetCurrent}-{framework}");
+
+			Assert.IsTrue(DotnetInternal.Build(projectFile, "Debug", properties: extendedBuildProps, msbuildWarningsAsErrors: true),
+				$"Project {Path.GetFileName(projectFile)} failed to build. Check test output/attachments for errors.");
+		}
+
+		[Test]
 		[TestCase("maui", $"{DotNetCurrent}-ios", "ios-arm64")]
 		public void PublishNativeAOT(string id, string framework, string runtimeIdentifier)
 		{

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/TemplateTests.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/TemplateTests.cs
@@ -273,7 +273,7 @@ namespace Microsoft.Maui.IntegrationTests
 		[TestCase("maui", "maccatalyst")]
 		[TestCase("maui-blazor", "ios")]
 		[TestCase("maui-blazor", "maccatalyst")]
-		public void BuildWithCustomBundleResource(string id, bool framework)
+		public void BuildWithCustomBundleResource(string id, string framework)
 		{
 			var projectDir = TestDirectory;
 			var projectFile = Path.Combine(projectDir, $"{Path.GetFileName(projectDir)}.csproj");


### PR DESCRIPTION


### Description of Change



Prior to Maui 8.0.70, there was a bug that only removed the "Resources/" prefix, and not the correct "Platforms/iOS/Resources/": https://github.com/dotnet/maui/issues/16734

The PR https://github.com/dotnet/maui/pull/23269 fixes the original issue, but now exposed the case where `@(BundleResource)` were included in the root "Resources" folder instead of the "Platforms/iOS/Resources" folder.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #23554

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
