### PR TITLE
[Windows] Skip initial assignments in property mapper (take 3)

### DIFF
--- a/src/Controls/src/Core/Platform/Windows/Extensions/AccessibilityExtensions.cs
+++ b/src/Controls/src/Core/Platform/Windows/Extensions/AccessibilityExtensions.cs
@@ -46,16 +46,28 @@ namespace Microsoft.Maui.Controls.Platform
 				return _defaultAutomationPropertiesAccessibilityView;
 			}
 
+			bool isInitializing = (Element.Handler as ElementHandler)?._isInitializing ?? false;
+
 			AccessibilityView? currentValue = null;
 
-			if (!_defaultAutomationPropertiesAccessibilityView.HasValue)
+			if (isInitializing)
 			{
-				_defaultAutomationPropertiesAccessibilityView = currentValue = (AccessibilityView)Control.GetValue(NativeAutomationProperties.AccessibilityViewProperty);
+				currentValue = AccessibilityView.Content;
+				_defaultAutomationPropertiesAccessibilityView ??= AccessibilityView.Content;
+			} 
+			else 
+			{
+				if (!_defaultAutomationPropertiesAccessibilityView.HasValue)
+				{
+					_defaultAutomationPropertiesAccessibilityView = currentValue = (AccessibilityView)Control.GetValue(NativeAutomationProperties.AccessibilityViewProperty);
+				}
 			}
 
 			var newValue = _defaultAutomationPropertiesAccessibilityView;
 
-			var elemValue = (bool?)Element.GetValue(AutomationProperties.IsInAccessibleTreeProperty);
+			var elemValue = isInitializing 
+				? null
+				: (bool?)Element.GetValue(AutomationProperties.IsInAccessibleTreeProperty);
 
 			if (elemValue == true)
 			{

--- a/src/Controls/src/Core/Platform/Windows/Extensions/TextBlockExtensions.cs
+++ b/src/Controls/src/Core/Platform/Windows/Extensions/TextBlockExtensions.cs
@@ -24,6 +24,8 @@ namespace Microsoft.Maui.Controls.Platform
 
 		public static void UpdateText(this TextBlock platformControl, Label label)
 		{
+			bool isFirstAssignment = (label.Handler as ElementHandler)?._isInitializing ?? false;
+
 			switch (label.TextType)
 			{
 				case TextType.Html:
@@ -32,13 +34,16 @@ namespace Microsoft.Maui.Controls.Platform
 
 				default:
 					if (label.FormattedText != null)
+					{
 						platformControl.UpdateInlines(label);
+					}
 					else
 					{
-						if (platformControl.TextHighlighters.Count > 0)
+						if (!isFirstAssignment && platformControl.TextHighlighters.Count > 0)
 						{
 							platformControl.TextHighlighters.Clear();
 						}
+
 						platformControl.Text = TextTransformUtilites.GetTransformedText(label.Text, label.TextTransform);
 					}
 					break;
@@ -67,7 +72,9 @@ namespace Microsoft.Maui.Controls.Platform
 		public static void UpdateDetectReadingOrderFromContent(this TextBlock platformControl, Label label)
 		{
 			if (label.IsSet(Specifics.DetectReadingOrderFromContentProperty))
+			{
 				platformControl.SetTextReadingOrder(label.OnThisPlatform().GetDetectReadingOrderFromContent());
+			}
 		}
 
 		internal static void SetLineBreakMode(this TextBlock textBlock, LineBreakMode lineBreakMode, int? maxLines = null)

--- a/src/Core/src/Handlers/Element/ElementHandler.cs
+++ b/src/Core/src/Handlers/Element/ElementHandler.cs
@@ -32,6 +32,9 @@ namespace Microsoft.Maui.Handlers
 
 		public IElement? VirtualView { get; private protected set; }
 
+		/// <summary><see langword="true"/> when view's properties are being set through its mapper for the first time, <see langword="false"/> otherwise.</summary>
+		internal bool _isInitializing;
+
 		public virtual void SetMauiContext(IMauiContext mauiContext) =>
 			MauiContext = mauiContext;
 
@@ -47,10 +50,21 @@ namespace Microsoft.Maui.Handlers
 			bool setupPlatformView = oldVirtualView == null;
 
 			VirtualView = view;
-			PlatformView ??= CreatePlatformElement();
+
+			bool isNew = false;
+
+			if (PlatformView is null)
+			{
+				PlatformView = CreatePlatformElement();
+				isNew = true;
+			}
+
+			_isInitializing = isNew;
 
 			if (VirtualView.Handler != this)
+			{
 				VirtualView.Handler = this;
+			}
 
 			// We set the previous virtual view to null after setting it on the incoming virtual view.
 			// This makes it easier for the incoming virtual view to have influence
@@ -77,6 +91,8 @@ namespace Microsoft.Maui.Handlers
 			}
 
 			_mapper.UpdateProperties(this, VirtualView);
+
+			_isInitializing = false;
 		}
 
 		public virtual void UpdateValue(string property)

--- a/src/Core/src/Handlers/View/ViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.Windows.cs
@@ -134,7 +134,11 @@ namespace Microsoft.Maui.Handlers
 				}
 				else
 				{
-					uiElement.ClearValue(UIElement.ContextFlyoutProperty);
+					bool? skipInitialization = (handler as ElementHandler)?._isInitializing ?? false;
+					if (skipInitialization != true)
+					{
+						uiElement.ClearValue(UIElement.ContextFlyoutProperty);
+					}
 				}
 			}
 		}

--- a/src/Core/src/Handlers/View/ViewHandler.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.cs
@@ -530,7 +530,10 @@ namespace Microsoft.Maui.Handlers
 		/// <param name="view">The associated <see cref="IView"/> instance.</param>
 		public static void MapToolTip(IViewHandler handler, IView view)
 		{
-#if PLATFORM
+#if WINDOWS
+			if (view is IToolTipElement tooltipContainer)
+				handler.ToPlatform().UpdateToolTip(tooltipContainer);
+#elif PLATFORM
 			if (view is IToolTipElement tooltipContainer)
 				handler.ToPlatform().UpdateToolTip(tooltipContainer.ToolTip);
 #endif

--- a/src/Core/src/Platform/Windows/TextBlockExtensions.cs
+++ b/src/Core/src/Platform/Windows/TextBlockExtensions.cs
@@ -5,7 +5,6 @@ using System.Xml;
 using System.Xml.Linq;
 using System.Xml.Resolvers;
 using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Documents;
 
 namespace Microsoft.Maui.Platform
 {
@@ -31,8 +30,18 @@ namespace Microsoft.Maui.Platform
 		public static void UpdateTextColor(this TextBlock platformControl, ITextStyle text) =>
 			platformControl.UpdateProperty(TextBlock.ForegroundProperty, text.TextColor);
 
-		public static void UpdatePadding(this TextBlock platformControl, ILabel label) =>
-			platformControl.UpdateProperty(TextBlock.PaddingProperty, label.Padding.ToPlatform());
+        public static void UpdatePadding(this TextBlock platformControl, ILabel label)
+        {
+			var padding = label.Padding;
+
+            bool? skipInitialization = (label.Handler as ElementHandler)?._isInitializing ?? false
+                || padding != Thickness.Zero;
+
+            if (skipInitialization != true)
+            {
+                platformControl.UpdateProperty(TextBlock.PaddingProperty, padding.ToPlatform());
+            }
+        }
 
 		public static void UpdateCharacterSpacing(this TextBlock platformControl, ITextStyle label)
 		{

--- a/src/Core/src/Platform/Windows/TextBlockExtensions.cs
+++ b/src/Core/src/Platform/Windows/TextBlockExtensions.cs
@@ -45,7 +45,21 @@ namespace Microsoft.Maui.Platform
 
 		public static void UpdateCharacterSpacing(this TextBlock platformControl, ITextStyle label)
 		{
-			platformControl.CharacterSpacing = label.CharacterSpacing.ToEm();
+			var characterSpacing = label.CharacterSpacing.ToEm();
+
+			if (label is ILabel realLabel)
+			{
+				bool skipInitialization = (realLabel.Handler as ElementHandler)?._isInitializing ?? false && characterSpacing == 0;
+
+				if (!skipInitialization)
+				{
+					platformControl.CharacterSpacing = characterSpacing;
+				}
+			}
+			else
+			{
+				platformControl.CharacterSpacing = characterSpacing;
+			}
 		}
 
 		public static void UpdateTextDecorations(this TextBlock platformControl, ILabel label)

--- a/src/Core/src/Platform/Windows/TransformationExtensions.cs
+++ b/src/Core/src/Platform/Windows/TransformationExtensions.cs
@@ -19,8 +19,13 @@ namespace Microsoft.Maui.Platform
 			if (rotationX % 360 == 0 && rotationY % 360 == 0 && rotation % 360 == 0 &&
 				translationX == 0 && translationY == 0 && scaleX == 1 && scaleY == 1)
 			{
-				frameworkElement.Projection = null;
-				frameworkElement.RenderTransform = null;
+				bool? skipInitialization = (view.Handler as ElementHandler)?._isInitializing ?? false;
+
+				if (skipInitialization != true)
+				{
+					frameworkElement.Projection = null;
+					frameworkElement.RenderTransform = null;
+				}
 			}
 			else
 			{

--- a/src/Core/src/Platform/Windows/ViewExtensions.cs
+++ b/src/Core/src/Platform/Windows/ViewExtensions.cs
@@ -326,6 +326,18 @@ namespace Microsoft.Maui.Platform
 				await panel.UpdateBackgroundImageSourceAsync(imageSource, provider);
 		}
 
+		internal static void UpdateToolTip(this FrameworkElement platformView, IToolTipElement toolTipElement)
+		{
+			var content = toolTipElement.ToolTip?.Content;
+			var skipInitialization = (toolTipElement is IView view) && ((view.Handler as ElementHandler)?._isInitializing ?? false
+				|| content is not null);
+
+			if (!skipInitialization)
+			{
+				ToolTipService.SetToolTip(platformView, content);
+			}
+		}
+
 		public static void UpdateToolTip(this FrameworkElement platformView, ToolTip? tooltip)
 		{
 			ToolTipService.SetToolTip(platformView, tooltip?.Content);


### PR DESCRIPTION
### Description of Change

Alternative to #22108

### Performance implications

* MAIN: [1722625589..speedscope.json](https://github.com/user-attachments/files/16474372/1722625589.speedscope.json)
* PR: [1722625386..speedscope.PR.InitAssignments.json](https://github.com/user-attachments/files/16474371/1722625386.speedscope.PR.InitAssignments.json)


![image](https://github.com/user-attachments/assets/3150eca4-e25c-415f-840c-954c4740b600)

![image](https://github.com/user-attachments/assets/c5c01335-cc39-4740-97cc-98e09414367f)

![image](https://github.com/user-attachments/assets/c8a473f8-e0f8-4992-9956-42f026cc6a97)

![image](https://github.com/user-attachments/assets/ad684098-755a-4deb-93a3-251459d00893)

![image](https://github.com/user-attachments/assets/047fb2f1-8844-4e6f-a478-5e258f344467)

### Best time observed

![image](https://github.com/user-attachments/assets/1a3a1e79-e351-4116-aebf-58e3bb521489)

* In April, the time [was](https://github.com/dotnet/maui/issues/21787#issue-2238579681) about 900 ms.
* In May/June, then time [was](https://github.com/dotnet/maui/issues/21787#issuecomment-2136145288) about 300-400ms.
* I believe that https://github.com/dotnet/maui/pull/24695 helped us to get to ~200ms.

BTW: In vanilla WinUI, the grid scenario takes ~100 ms. So MAUI is only about 50% slower than WinUI with this PR.

### Issues Fixed

Contributes to #17303
Contributes to #21787