### PR TITLE
Call correct Arrange logic from VE.Arrange

### DIFF
--- a/src/Controls/src/Core/VisualElement/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement/VisualElement.cs
@@ -1731,6 +1731,7 @@ namespace Microsoft.Maui.Controls
 		/// <summary>
 		/// Gets or sets the frame this element resides in on screen.
 		/// </summary>
+		/// <remarks>Setting this property outside of <see cref="ArrangeOverride"/> won't do anything. If you want to influence this property you'll need to override <see cref="ArrangeOverride"/></remarks>
 		public Rect Frame
 		{
 			get => _frame;

--- a/src/Controls/src/Core/VisualElement/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement/VisualElement.cs
@@ -1836,7 +1836,10 @@ namespace Microsoft.Maui.Controls
 		/// Positions child objects and determines a size for an element.
 		/// </summary>
 		/// <param name="bounds">The final size that the parent computes for the child in layout, provided as a <see cref="Rect"/> value.</param>
-		/// <remarks>Parent objects that implement custom layout for their child elements should call this method from their layout override implementations to form a recursive layout update.</remarks>
+		/// <remarks>
+		/// Parent objects that implement custom layout for their child elements should call this method from their layout override implementations to form a recursive layout update.
+		/// Prior to .NET 9, this method simply called <see cref="Layout"/>. If you need to revert to the old behavior, just call <see cref="Layout"/>.
+		/// </remarks>
 		public void Arrange(Rect bounds)
 		{
 			ArrangeOverride(bounds);

--- a/src/Controls/src/Core/VisualElement/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement/VisualElement.cs
@@ -1852,6 +1852,7 @@ namespace Microsoft.Maui.Controls
 		/// </summary>
 		/// <param name="bounds">The new bounds of the element.</param>
 		/// <returns>The resulting size of this element's frame by the platform.</returns>
+		/// <remarks>Subclasses will stil want to call <see cref="ArrangeOverride"/> on the base class or call <see cref="IViewHandler.PlatformArrange"/> on the <see cref="Handler"/> .</remarks>
 		protected virtual Size ArrangeOverride(Rect bounds)
 		{
 			Frame = this.ComputeFrame(bounds);

--- a/src/Controls/src/Core/VisualElement/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement/VisualElement.cs
@@ -1191,11 +1191,8 @@ namespace Microsoft.Maui.Controls
 		/// <param name="flags">A value that controls whether margins are included in the returned size.</param>
 		/// <returns>The minimum size that an element needs in order to be displayed on the device.</returns>
 		/// <remarks>If the minimum size that the element needs in order to be displayed on the device is larger than can be accommodated by <paramref name="widthConstraint" /> and <paramref name="heightConstraint" />, the return value may represent a rectangle that is larger in either one or both of those parameters.</remarks>
-#pragma warning disable RS0016 // Add public types and members to the declared API
-
 		[Obsolete("Use Measure with no flags.")]
 		public virtual SizeRequest Measure(double widthConstraint, double heightConstraint, MeasureFlags flags = MeasureFlags.None)
-#pragma warning restore RS0016 // Add public types and members to the declared API
 		{
 			bool includeMargins = (flags & MeasureFlags.IncludeMargins) != 0;
 			Thickness margin = default(Thickness);
@@ -1841,7 +1838,7 @@ namespace Microsoft.Maui.Controls
 		/// <remarks>Parent objects that implement custom layout for their child elements should call this method from their layout override implementations to form a recursive layout update.</remarks>
 		public void Arrange(Rect bounds)
 		{
-			Layout(bounds);
+			ArrangeOverride(bounds);
 		}
 
 		/// <inheritdoc/>
@@ -1851,8 +1848,7 @@ namespace Microsoft.Maui.Controls
 		}
 
 		/// <summary>
-		/// Allows subclasses to override <see cref="Arrange(Rect)"/> even though
-		/// the interface has to be explicitly implemented to avoid conflict with the old <see cref="Arrange(Rect)"/> method.
+		/// Allows subclasses to implement custom Arrange logic during a controls layout pass.
 		/// </summary>
 		/// <param name="bounds">The new bounds of the element.</param>
 		/// <returns>The resulting size of this element's frame by the platform.</returns>
@@ -1898,8 +1894,7 @@ namespace Microsoft.Maui.Controls
 		}
 
 		/// <summary>
-		/// Provides a way to allow subclasses to override <see cref="Measure(double, double)"/> even though
-		/// the interface has to be explicitly implemented to avoid conflict with the old Measure method.
+		/// Allows subclasses to implement custom Measure logic during a controls measure pass.
 		/// </summary>
 		/// <param name="widthConstraint">The width constraint to request.</param>
 		/// <param name="heightConstraint">The height constraint to request.</param>


### PR DESCRIPTION
### Description of Change

Continuing along with this [trend](https://github.com/dotnet/maui/pull/23899), this PR shifts our VisualElement.Arrange to call `IView.Arrange`

The `VE.Arrange` in the MAUI code doesn't really do anything with regards to the `MAUI` layout system. Setting the Bounds/Frame directly won't really do anything. The `Bounds` and `Frame` on the `MAUI` layout system will just get set during the `Arrange` pass on the platform. If you want to influence the `bounds` or `frame` you have to subclass and override `ArrangeOverride`.

Setting the `Bounds` directly will really only cause things to happen inside the `shims`, but, that code will still continue to fire even with this change. 

### Issues Fixed
Fixes #17417 


