### PR TITLE
[iOS] Using long-press navigation on back button with shell pages - fix

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellSectionRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellSectionRenderer.cs
@@ -70,6 +70,8 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 		ShellSection _shellSection;
 		bool _ignorePopCall;
 
+		bool _popRequested;
+
 		// When setting base.ViewControllers iOS doesn't modify the property right away. 
 		// if you set base.ViewControllers to a new array and then retrieve base.ViewControllers
 		// iOS will return the previous array until the new array has been processed
@@ -107,7 +109,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 		[Export("navigationBar:didPopItem:")]
 		[Internals.Preserve(Conditional = true)]
 		bool DidPopItem(UINavigationBar _, UINavigationItem __)
-			=> true;
+			=> _popRequested || SendPop();
 
 		internal bool SendPop()
 		{
@@ -392,6 +394,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 		protected virtual async void OnPopRequested(NavigationRequestedEventArgs e)
 		{
+			_popRequested = true;
 			var page = e.Page;
 			var animated = e.Animated;
 
@@ -432,6 +435,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 		protected virtual async void OnPopToRootRequested(NavigationRequestedEventArgs e)
 		{
+			_popRequested = true;
 			var animated = e.Animated;
 			var task = new TaskCompletionSource<bool>();
 			var pages = _shellSection.Stack.ToList();
@@ -593,6 +597,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 		public override void PushViewController(UIViewController viewController, bool animated)
 		{
 			_pendingViewControllers = null;
+			_popRequested = false;
 			if (IsInMoreTab && ParentViewController is UITabBarController tabBarController)
 			{
 				tabBarController.MoreNavigationController.PushViewController(viewController, animated);
@@ -600,7 +605,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			else
 			{
 				base.PushViewController(viewController, animated);
-			}
+			}			
 		}
 
 		public override UIViewController PopViewController(bool animated)

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellSectionRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellSectionRenderer.cs
@@ -101,8 +101,13 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 		[Export("navigationBar:shouldPopItem:")]
 		[Internals.Preserve(Conditional = true)]
-		public bool ShouldPopItem(UINavigationBar _, UINavigationItem __) =>
-			SendPop();
+		public bool ShouldPopItem(UINavigationBar _, UINavigationItem __)
+			=> SendPop();
+
+		[Export("navigationBar:didPopItem:")]
+		[Internals.Preserve(Conditional = true)]
+		bool DidPopItem(UINavigationBar _, UINavigationItem __)
+			=> true;
 
 		internal bool SendPop()
 		{

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue23892.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue23892.cs
@@ -1,0 +1,53 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 23892, "Using long-press navigation on back button using shell does not update the shell's current page", PlatformAffected.iOS)]
+
+public class Issue23892 : TestShell
+{
+    protected override void Init()
+    {
+        var page = CreateContentPage("Test page");
+        int onAppearingCount = 0;
+
+        Label label = new Label
+        {
+            AutomationId = "label",
+            Text = "This is a test page"
+        };
+        page.Content = new StackLayout()
+        {
+            label,
+            new Button
+            {
+                AutomationId = "button",
+                Text = "Click to navigate to detail page",
+                Command = new Command(()=> Shell.Current.Navigation.PushAsync(new Issue23892Detail()))
+            }
+        };
+
+        page.Appearing += (s, e) =>
+        {
+            label.Text = $"OnAppearing count: {++onAppearingCount}";
+        };
+        Routing.RegisterRoute(nameof(Issue23892Detail), typeof(Issue23892Detail));
+    }
+
+    class Issue23892Detail : ContentPage
+    {
+        public Issue23892Detail()
+        {
+            SetBackButtonBehavior(this, new BackButtonBehavior
+            {
+                TextOverride = "Back",
+            });
+
+            Content = new StackLayout
+            {
+                Children =
+                {
+                    new Label { Text = "This is a detail page" }
+                }
+            };
+        }
+    }
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue23892.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue23892.cs
@@ -1,0 +1,29 @@
+﻿#if IOS
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue23892 : _IssuesUITest
+	{
+		public Issue23892(TestDevice testDevice) : base(testDevice)
+		{
+		}
+
+		public override string Issue => "Using long-press navigation on back button using shell does not update the shell's current page";
+
+		[Test]
+		[Category(UITestCategories.Shell)]
+		public void ShellBackButtonShouldWorkOnLongPress()
+		{
+			App.WaitForElement("button");
+			App.Click("button");
+			App.LongPress("Back");
+			var text = App.FindElement("label").GetText();
+
+			Assert.That(text, Is.EqualTo("OnAppearing count: 2"));
+		}
+	}
+}
+#endif


### PR DESCRIPTION
### Description of Change

The `[Export("navigationBar:shouldPopItem:")]` is not being triggered when navigating back with the iOS's callout menu

Fixes https://github.com/dotnet/maui/issues/23892

|Before|After|
|--|--|
|<video src="https://github.com/user-attachments/assets/e77dcaa1-dcc8-40d3-a6f7-10434bc09886" width="300px"/>|<video src="https://github.com/user-attachments/assets/f687eb90-8779-4a67-9991-5c789f3d666f" width="300px"/>|


