### PR TITLE
[Accessibility] Make flyout titles on iOS read as buttons

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/UIContainerCell.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/UIContainerCell.cs
@@ -28,7 +28,10 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				_renderer = (IPlatformViewHandler)view.ToHandler(view.FindMauiContext() ?? shell.FindMauiContext());
 			}
 
-			ContentView.AddSubview(_renderer.PlatformView);
+			var platformView = view.ToPlatform();
+			ContentView.AddSubview(platformView);
+			platformView.AccessibilityTraits |= UIAccessibilityTrait.Button;
+
 			_renderer.PlatformView.ClipsToBounds = true;
 			ContentView.ClipsToBounds = true;
 


### PR DESCRIPTION
### Description of Change

<!-- Enter description of the fix in this section -->
The linked issue below states that the flyout titles are not properly characterized and will not make sense to customers using screen reader. This PR allows the titles to be stated as buttons.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Related to:
* https://github.com/dotnet/maui/issues/23000

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
