### PR TITLE
[iOS] Add a Container around ImageButton

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue23897.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue23897.cs
@@ -68,7 +68,7 @@ namespace Maui.Controls.Sample.Issues
                         LineBreakMode = LineBreakMode.WordWrap,
 						Command = new Command(async () =>
 						{
-							await Navigation.PushAsync(new ContentPage(), true);
+							await Navigation.PushAsync(new ContentPage(), false);
                             await Task.Yield();
                             await Navigation.PopAsync(true);
 						})

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue23897.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue23897.cs
@@ -1,0 +1,80 @@
+namespace Maui.Controls.Sample.Issues
+{
+	[Issue(IssueTracker.Github, 23897, "Add a permanent wrapper around ImageButton so it works better with loading and unloading", PlatformAffected.iOS)]
+	public class Issue23897 : NavigationPage
+	{
+		
+		public Issue23897() : base(new TestPage())
+		{
+		}
+		
+		public class TestPage : ContentPage
+		{
+            Label _labelLoadedCount;
+            Label _labelUnloadedCount;
+            ImageButton _imageButton;
+			private int _loadedCount;
+			private int _unloadedCount;
+
+			public TestPage()
+			{
+                _imageButton  = new ImageButton()
+                {
+                    Source = "coffee.png",
+                    AutomationId = "ImageButton",
+                    HeightRequest = 100,
+                    WidthRequest = 100
+                };
+
+                _imageButton.Loaded += (s, e) =>
+                {
+                    _labelLoadedCount.Text = $"{++_loadedCount}";
+                };
+
+                _imageButton.Unloaded += (s, e) =>
+                {
+                    _labelUnloadedCount.Text = $"{++_unloadedCount}";
+                };
+
+                _labelUnloadedCount = new Label()
+                {
+                    AutomationId = "UnloadedCount",
+                    Text = "0"
+                };
+
+                _labelLoadedCount = new Label()
+                {
+                    AutomationId = "LoadedCount",
+                    Text = "0"
+                };
+                
+				Content = new VerticalStackLayout()
+				{
+                    new Label() 
+                    {
+                        Text = "ImageButton Loaded Count:",
+                    },
+                    _labelLoadedCount,
+                    new Label() 
+                    {
+                        Text = "ImageButton Unloaded Count:",
+                    },
+                    _labelUnloadedCount,
+                    _imageButton,
+					new Button()
+					{
+						Text = "Push And Pop Page to Validate ImageButton Loading/Unloaded",
+						AutomationId = "PushAndPopPage",
+                        LineBreakMode = LineBreakMode.WordWrap,
+						Command = new Command(async () =>
+						{
+							await Navigation.PushAsync(new ContentPage(), true);
+                            await Task.Yield();
+                            await Navigation.PopAsync(true);
+						})
+					}
+				};
+			}
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue23897.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue23897.cs
@@ -1,0 +1,26 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue23897(TestDevice device) : _IssuesUITest(device)
+	{
+		public override string Issue => "Add a permanent wrapper around ImageButton so it works better with loading and unloading"; 
+
+		[Test]
+		[Category(UITestCategories.ImageButton)]
+		public void LoadingAndUnloadingWorksForImageButton()
+		{
+			for (int i = 0; i < 3; i++)
+			{
+				var loadedCount = App.WaitForElement("LoadedCount").GetText();
+				var unLoadedCount = App.WaitForElement("UnloadedCount").GetText();
+				Assert.That(loadedCount, Is.EqualTo($"{i + 1}"));
+				Assert.That(unLoadedCount, Is.EqualTo($"{i}"));
+
+				App.Tap("PushAndPopPage");
+			}
+		}
+	}
+}

--- a/src/Core/src/Handlers/ImageButton/ImageButtonHandler.iOS.cs
+++ b/src/Core/src/Handlers/ImageButton/ImageButtonHandler.iOS.cs
@@ -5,6 +5,10 @@ namespace Microsoft.Maui.Handlers
 {
 	public partial class ImageButtonHandler : ViewHandler<IImageButton, UIButton>
 	{
+		// Because we can't inherit from Button we use the container to handle
+		// Life cycle events and things like monitoring focus changed
+		public override bool NeedsContainer => true;
+		
 		readonly ImageButtonProxy _proxy = new();
 
 		protected override UIButton CreatePlatformView()

--- a/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -50,6 +50,7 @@ Microsoft.Maui.Platform.MauiScrollView.MauiScrollView() -> void
 Microsoft.Maui.SoftInputExtensions
 override Microsoft.Maui.Handlers.ButtonHandler.NeedsContainer.get -> bool
 override Microsoft.Maui.Handlers.ContentViewHandler.DisconnectHandler(Microsoft.Maui.Platform.ContentView! platformView) -> void
+override Microsoft.Maui.Handlers.ImageButtonHandler.NeedsContainer.get -> bool
 override Microsoft.Maui.Handlers.RefreshViewHandler.SetVirtualView(Microsoft.Maui.IView! view) -> void
 override Microsoft.Maui.Handlers.ScrollViewHandler.NeedsContainer.get -> bool
 override Microsoft.Maui.Handlers.SwipeItemButton.Frame.get -> CoreGraphics.CGRect

--- a/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -53,6 +53,7 @@ Microsoft.Maui.SoftInputExtensions
 *REMOVED*override Microsoft.Maui.Handlers.BorderHandler.PlatformArrange(Microsoft.Maui.Graphics.Rect rect) -> void
 override Microsoft.Maui.Handlers.ButtonHandler.NeedsContainer.get -> bool
 override Microsoft.Maui.Handlers.ContentViewHandler.DisconnectHandler(Microsoft.Maui.Platform.ContentView! platformView) -> void
+override Microsoft.Maui.Handlers.ImageButtonHandler.NeedsContainer.get -> bool
 override Microsoft.Maui.Handlers.RefreshViewHandler.SetVirtualView(Microsoft.Maui.IView! view) -> void
 override Microsoft.Maui.Handlers.ScrollViewHandler.NeedsContainer.get -> bool
 override Microsoft.Maui.Handlers.SwipeItemButton.Frame.get -> CoreGraphics.CGRect
@@ -159,4 +160,5 @@ virtual Microsoft.Maui.MauiUIApplicationDelegate.PerformFetch(UIKit.UIApplicatio
 *REMOVED*override Microsoft.Maui.Platform.ContentView.SetNeedsLayout() -> void
 Microsoft.Maui.Platform.UIEdgeInsetsExtensions
 static Microsoft.Maui.Platform.UIEdgeInsetsExtensions.ToThickness(this UIKit.UIEdgeInsets insets) -> Microsoft.Maui.Thickness
+*REMOVED*override Microsoft.Maui.Platform.MauiLabel.InvalidateIntrinsicContentSize() -> void
 *REMOVED*override Microsoft.Maui.Platform.MauiLabel.InvalidateIntrinsicContentSize() -> void

--- a/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -161,4 +161,3 @@ virtual Microsoft.Maui.MauiUIApplicationDelegate.PerformFetch(UIKit.UIApplicatio
 Microsoft.Maui.Platform.UIEdgeInsetsExtensions
 static Microsoft.Maui.Platform.UIEdgeInsetsExtensions.ToThickness(this UIKit.UIEdgeInsets insets) -> Microsoft.Maui.Thickness
 *REMOVED*override Microsoft.Maui.Platform.MauiLabel.InvalidateIntrinsicContentSize() -> void
-*REMOVED*override Microsoft.Maui.Platform.MauiLabel.InvalidateIntrinsicContentSize() -> void


### PR DESCRIPTION
### Description of Change

With this https://github.com/dotnet/maui/pull/16868 we set ButtonHandler to always have a wrapper view in order to facilitate loading behaviors. We should have set ImageButton to always have a container as well.

Because of how iOS works we can't inherit from UIButton so we have to come at it from different angles.

This should resolve issues where ImageButton isn't reliably firing Loaded events

### Issues Fixed

Fixes #23897 

