### PR TITLE
Fixes Android FontModel Glide In-Memory Caching

### DIFF
--- a/src/Core/AndroidNative/maui/src/main/java/com/microsoft/maui/glide/font/FontModel.java
+++ b/src/Core/AndroidNative/maui/src/main/java/com/microsoft/maui/glide/font/FontModel.java
@@ -4,6 +4,8 @@ import android.graphics.Typeface;
 
 import androidx.annotation.ColorInt;
 
+import java.util.Objects;
+
 import com.bumptech.glide.signature.ObjectKey;
 
 public class FontModel {
@@ -18,6 +20,22 @@ public class FontModel {
         this.glyph = glyph;
         this.textSize = textSize;
         this.typeface = typeface;
+    }
+    
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        FontModel other = (FontModel) o;
+        return color == other.color &&
+            Objects.equals(glyph, other.glyph) &&
+            textSize == other.textSize &&
+            typeface == other.typeface;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(color, glyph, textSize, typeface);
     }
 
     public int getColor() {


### PR DESCRIPTION
### Description of Change

Thanks to additional logging I've discovered `FontModel`-related images are not being cached in memory.

https://bumptech.github.io/glide/tut/custom-modelloader.html#implementing-buildloaddata

> A [Key](https://bumptech.github.io/glide/javadocs/440/com/bumptech/glide/load/Key.html) that will be used as part of our disk cache keys (**the model’s equals() and hashCode() methods are used for the in memory cache key**).

Without this fix we're filling up the memory cache with identical `FontModel`s.
This brings a very good improvement with applications using `FontIconSource`.

### Issues Fixed

Slightly improves #6625 on `FontIconSource` by fixing the non-working in-memory cache (which has synchronous loading).
