### PR TITLE
[Android] MediaPicker: Use New Photo Picker

### DIFF
--- a/src/Essentials/src/Essentials.csproj
+++ b/src/Essentials/src/Essentials.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.1;netstandard2.0;$(_MauiDotNetTfm);$(MauiPlatforms)</TargetFrameworks>
     <TargetFrameworks Condition="'$(IncludePreviousTfmsEssentials)' == 'true'">$(TargetFrameworks);$(_MauiPreviousDotNetTfm);$(MauiPreviousPlatforms)</TargetFrameworks>
@@ -43,7 +43,9 @@
     <Compile Include="**\*.android.cs" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
     <Compile Include="**\*.android.*.cs" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
     <AndroidResource Include="Resources\xml\*.xml" />
+    <PackageReference Include="Xamarin.AndroidX.Activity" Version="1.8.2.1" />
     <PackageReference Include="Xamarin.AndroidX.Browser" Version="1.8.0.8" />
+    <PackageReference Include="Xamarin.AndroidX.Collection.Ktx" Version="1.4.0.1" />
     <PackageReference Include="Xamarin.AndroidX.Security.SecurityCrypto" Version="1.1.0.2-alpha06" />
     <PackageReference Include="Xamarin.Google.Crypto.Tink.Android" Version="1.16.0.1" />
   </ItemGroup>

--- a/src/Essentials/src/Essentials.csproj
+++ b/src/Essentials/src/Essentials.csproj
@@ -43,9 +43,8 @@
     <Compile Include="**\*.android.cs" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
     <Compile Include="**\*.android.*.cs" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
     <AndroidResource Include="Resources\xml\*.xml" />
-    <PackageReference Include="Xamarin.AndroidX.Activity" Version="1.8.2.1" />
+    <PackageReference Include="Xamarin.AndroidX.Activity" Version="1.9.3.2" />
     <PackageReference Include="Xamarin.AndroidX.Browser" Version="1.8.0.8" />
-    <PackageReference Include="Xamarin.AndroidX.Collection.Ktx" Version="1.4.0.1" />
     <PackageReference Include="Xamarin.AndroidX.Security.SecurityCrypto" Version="1.1.0.2-alpha06" />
     <PackageReference Include="Xamarin.Google.Crypto.Tink.Android" Version="1.16.0.1" />
   </ItemGroup>

--- a/src/Essentials/src/Platform/ActivityForResultRequest.android.cs
+++ b/src/Essentials/src/Platform/ActivityForResultRequest.android.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Threading.Tasks;
+using AndroidX.Activity;
+using AndroidX.Activity.Result;
+using AndroidX.Activity.Result.Contract;
+using JavaObject = Java.Lang.Object;
+
+namespace Microsoft.Maui.ApplicationModel;
+
+/// <summary>
+/// Represents a request for an activity result.
+/// Provides a type-safe mechanism for registering and launching 
+/// activity result requests using the specified contract and callback.
+/// </summary>
+/// <typeparam name="TContract">The type of the activity result contract.</typeparam>
+/// <typeparam name="TResult">The type of the result returned by the activity.</typeparam>
+/// <remarks>
+/// <para>
+/// <see href="https://developer.android.com/training/basics/intents/result">Google docs</see>
+/// </para>
+/// This must be unconditionally registered every time our activity is created.
+/// </remarks>
+internal abstract class ActivityForResultRequest<TContract, TResult>
+	where TContract : ActivityResultContract, new()
+	where TResult : JavaObject
+{
+	protected ActivityResultLauncher launcher;
+	protected TaskCompletionSource<TResult> tcs = null;
+
+	/// <summary>
+	/// Gets a value indicating whether the request is registered.
+	/// </summary>
+	protected bool IsRegistered => launcher is not null;
+
+	/// <summary>
+	/// Registers this request to start an activity for a result.
+	/// </summary>
+	/// <param name="componentActivity">The component activity to register the request with.</param>
+	public void Register(ComponentActivity componentActivity)
+	{
+		var contract = new TContract();
+		var callback = new ActivityResultCallback<TResult>(result => tcs?.SetResult(result));
+
+		launcher = componentActivity.RegisterForActivityResult(contract, callback);
+	}
+
+	/// <summary>
+	/// Launches the activity result request with the specified input.
+	/// </summary>
+	/// <typeparam name="T">The type of the input parameter.</typeparam>
+	/// <param name="input">The input parameter to launch the request with.</param>
+	/// <returns>
+	/// A task that represents the asynchronous operation, containing the result of the activity.
+	/// </returns>
+	public Task<TResult> Launch<T>(T input)
+		where T : JavaObject
+	{
+		tcs = new TaskCompletionSource<TResult>();
+
+		if (!IsRegistered)
+		{
+			tcs.SetCanceled();
+			return tcs.Task;
+		}
+
+		try
+		{
+			launcher.Launch(input);
+		}
+		catch (Exception ex)
+		{
+			tcs.SetException(ex);
+		}
+
+		return tcs.Task;
+	}
+}

--- a/src/Essentials/src/Platform/ActivityResultCallback.android.cs
+++ b/src/Essentials/src/Platform/ActivityResultCallback.android.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using AndroidX.Activity.Result;
+using JavaObject = Java.Lang.Object;
+
+namespace Microsoft.Maui.ApplicationModel
+{
+	class ActivityResultCallback<T> : JavaObject, IActivityResultCallback
+	{
+		readonly Action<T> _callback;
+
+		public ActivityResultCallback(Action<T> callback) => _callback = callback;
+
+		public void OnActivityResult(JavaObject result)
+		{
+			if (result is T obj)
+			{
+				_callback(obj);
+			}
+		}
+	}
+}

--- a/src/Essentials/src/Platform/ActivityResultCallback.android.cs
+++ b/src/Essentials/src/Platform/ActivityResultCallback.android.cs
@@ -2,20 +2,15 @@
 using AndroidX.Activity.Result;
 using JavaObject = Java.Lang.Object;
 
-namespace Microsoft.Maui.ApplicationModel
+namespace Microsoft.Maui.ApplicationModel;
+
+class ActivityResultCallback<T>(Action<T> onActivityResult) : JavaObject, IActivityResultCallback
+	where T : JavaObject
 {
-	class ActivityResultCallback<T> : JavaObject, IActivityResultCallback
+	readonly Action<T> _onActivityResult = onActivityResult;
+
+	public void OnActivityResult(JavaObject result)
 	{
-		readonly Action<T> _callback;
-
-		public ActivityResultCallback(Action<T> callback) => _callback = callback;
-
-		public void OnActivityResult(JavaObject result)
-		{
-			if (result is T obj)
-			{
-				_callback(obj);
-			}
-		}
+		_onActivityResult.Invoke(result as T);
 	}
 }

--- a/src/Essentials/src/Platform/ActivityStateManager.android.cs
+++ b/src/Essentials/src/Platform/ActivityStateManager.android.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Android.App;
 using Android.Content;
 using Android.OS;
+using AndroidX.Activity;
 
 namespace Microsoft.Maui.ApplicationModel
 {
@@ -79,6 +80,9 @@ namespace Microsoft.Maui.ApplicationModel
 		{
 			if (activity.Application is not Application application)
 				throw new InvalidOperationException("Activity was not attached to an application.");
+
+			if (activity is ComponentActivity componentActivity)
+				PickVisualMediaForResult.Register(componentActivity);
 
 			Init(application);
 			lifecycleListener!.Activity = activity;

--- a/src/Essentials/src/Platform/ActivityStateManager.android.cs
+++ b/src/Essentials/src/Platform/ActivityStateManager.android.cs
@@ -6,6 +6,7 @@ using Android.App;
 using Android.Content;
 using Android.OS;
 using AndroidX.Activity;
+using Microsoft.Maui.Media;
 
 namespace Microsoft.Maui.ApplicationModel
 {
@@ -81,8 +82,8 @@ namespace Microsoft.Maui.ApplicationModel
 			if (activity.Application is not Application application)
 				throw new InvalidOperationException("Activity was not attached to an application.");
 
-			if (activity is ComponentActivity componentActivity)
-				PickVisualMediaForResult.Register(componentActivity);
+			if (activity is ComponentActivity componentActivity && MediaPickerImplementation.IsPhotoPickerAvailable)
+				PickVisualMediaForResult.Instance.Register(componentActivity);
 
 			Init(application);
 			lifecycleListener!.Activity = activity;

--- a/src/Essentials/src/Platform/PickVisualMediaForResult.android.cs
+++ b/src/Essentials/src/Platform/PickVisualMediaForResult.android.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Threading.Tasks;
+using AndroidX.Activity;
+using AndroidX.Activity.Result;
+using AndroidX.Activity.Result.Contract;
+using AndroidUri = Android.Net.Uri;
+
+namespace Microsoft.Maui.ApplicationModel
+{
+	static class PickVisualMediaForResult
+	{
+		static ActivityResultLauncher launcher;
+		static TaskCompletionSource<AndroidUri> tcs = null;
+
+		public static void Register(ComponentActivity componentActivity)
+		{
+			var contract = new ActivityResultContracts.PickVisualMedia();
+			var callback = new ActivityResultCallback<AndroidUri>(uri => tcs?.SetResult(uri));
+			launcher = componentActivity.RegisterForActivityResult(contract, callback);
+		}
+
+		public static Task<AndroidUri> Launch(PickVisualMediaRequest request)
+		{
+			tcs = new TaskCompletionSource<AndroidUri>();
+
+			if (launcher is null)
+			{
+				tcs.SetCanceled();
+				return tcs.Task;
+			}
+
+			try
+			{
+				launcher.Launch(request);
+			}
+			catch (Exception ex)
+			{
+				tcs.SetException(ex);
+			}
+
+			return tcs.Task;
+		}
+	}
+}

--- a/src/Essentials/src/Platform/PickVisualMediaForResult.android.cs
+++ b/src/Essentials/src/Platform/PickVisualMediaForResult.android.cs
@@ -1,44 +1,12 @@
 ﻿using System;
-using System.Threading.Tasks;
-using AndroidX.Activity;
-using AndroidX.Activity.Result;
-using AndroidX.Activity.Result.Contract;
+using static AndroidX.Activity.Result.Contract.ActivityResultContracts;
 using AndroidUri = Android.Net.Uri;
 
-namespace Microsoft.Maui.ApplicationModel
+namespace Microsoft.Maui.ApplicationModel;
+
+internal class PickVisualMediaForResult : ActivityForResultRequest<PickVisualMedia, AndroidUri>
 {
-	static class PickVisualMediaForResult
-	{
-		static ActivityResultLauncher launcher;
-		static TaskCompletionSource<AndroidUri> tcs = null;
+    static readonly Lazy<PickVisualMediaForResult> LazyInstance = new(new PickVisualMediaForResult());
 
-		public static void Register(ComponentActivity componentActivity)
-		{
-			var contract = new ActivityResultContracts.PickVisualMedia();
-			var callback = new ActivityResultCallback<AndroidUri>(uri => tcs?.SetResult(uri));
-			launcher = componentActivity.RegisterForActivityResult(contract, callback);
-		}
-
-		public static Task<AndroidUri> Launch(PickVisualMediaRequest request)
-		{
-			tcs = new TaskCompletionSource<AndroidUri>();
-
-			if (launcher is null)
-			{
-				tcs.SetCanceled();
-				return tcs.Task;
-			}
-
-			try
-			{
-				launcher.Launch(request);
-			}
-			catch (Exception ex)
-			{
-				tcs.SetException(ex);
-			}
-
-			return tcs.Task;
-		}
-	}
+    public static PickVisualMediaForResult Instance => LazyInstance.Value;
 }

--- a/src/Essentials/src/Platform/PlatformUtils.android.cs
+++ b/src/Essentials/src/Platform/PlatformUtils.android.cs
@@ -10,7 +10,6 @@ namespace Microsoft.Maui.ApplicationModel
 	static class PlatformUtils
 	{
 		internal const int requestCodeFilePicker = 11001;
-		internal const int requestCodeMediaPicker = 11002;
 		internal const int requestCodeMediaCapture = 11003;
 		internal const int requestCodePickContact = 11004;
 

--- a/src/Essentials/src/Platform/PlatformUtils.android.cs
+++ b/src/Essentials/src/Platform/PlatformUtils.android.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Maui.ApplicationModel
 	static class PlatformUtils
 	{
 		internal const int requestCodeFilePicker = 11001;
+		internal const int requestCodeMediaPicker = 11002;
 		internal const int requestCodeMediaCapture = 11003;
 		internal const int requestCodePickContact = 11004;
 


### PR DESCRIPTION
### Description of Change

Use the modern [Photo picker](https://developer.android.com/training/data-storage/shared/photopicker) via the [Activity Result API](https://developer.android.com/training/basics/intents/result)'s for selecting a photo or video. 

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes [#9615](https://github.com/dotnet/maui/issues/9615)
Fixes #29076

### Demo
**Samsung Galaxy S21 (API 34):**
| As-is | To-be |
| --- | --- |
| ![9615_api34_asis](https://github.com/user-attachments/assets/b4256f4b-88b4-448a-b884-34ca3a2074a8) | ![9615_api34_tobe](https://github.com/user-attachments/assets/5b16caf7-fe60-4b31-a672-d8a59199fa87) |

**Zebra TC75 (API 25):**
| As-is | To-be |
| --- | --- |
| ![9615_api25_asis](https://github.com/user-attachments/assets/f5bcdd99-187b-4704-91e4-8501aff53a0c) | ![9615_api25_tobe](https://github.com/user-attachments/assets/fa41d89e-c558-4f38-8a58-be59b553ff5b) |
