### PR TITLE
Update Rebase GitHub Action

### DIFF
--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -20,7 +20,7 @@ jobs:
       )
     steps:
       - name: Checkout the latest code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0 # otherwise, you will fail to push refs to dest repo


### PR DESCRIPTION
Update checkout step to use checkout at v4 which uses a newer Node version. v2 uses a Node version that might be removed at some point.
