### PR TITLE
Add Android LoadImageFromFont benchmark and enable verbose Glide logging

### DIFF
--- a/src/Core/AndroidNative/maui/src/main/java/com/microsoft/maui/glide/GlideLogging.java
+++ b/src/Core/AndroidNative/maui/src/main/java/com/microsoft/maui/glide/GlideLogging.java
@@ -1,0 +1,18 @@
+package com.microsoft.maui.glide;
+
+import android.util.Log;
+
+public class GlideLogging {
+    private static final String TAG = "Glide";
+    private static final boolean IS_VERBOSE_LOGGABLE = Log.isLoggable(TAG, Log.VERBOSE);
+
+    public static boolean isVerboseLoggable() {
+        return IS_VERBOSE_LOGGABLE;
+    }
+
+    public static void v(String message) {
+        if (IS_VERBOSE_LOGGABLE) {
+            Log.v(TAG, message);
+        }
+    }
+}

--- a/src/Core/AndroidNative/maui/src/main/java/com/microsoft/maui/glide/MauiGlideModule.java
+++ b/src/Core/AndroidNative/maui/src/main/java/com/microsoft/maui/glide/MauiGlideModule.java
@@ -2,13 +2,16 @@ package com.microsoft.maui.glide;
 
 import android.content.Context;
 import android.graphics.Bitmap;
+import android.util.Log;
 
 import com.bumptech.glide.Glide;
+import com.bumptech.glide.GlideBuilder;
 import com.bumptech.glide.Registry;
 import com.bumptech.glide.annotation.GlideModule;
 import com.bumptech.glide.module.AppGlideModule;
 
 import com.microsoft.maui.ImageLoaderCallback;
+import com.microsoft.maui.glide.GlideLogging;
 import com.microsoft.maui.glide.fallback.ImageLoaderCallbackModelLoaderFactory;
 import com.microsoft.maui.glide.font.FontModel;
 import com.microsoft.maui.glide.font.FontModelLoaderFactory;
@@ -32,5 +35,14 @@ public class MauiGlideModule extends AppGlideModule {
     @Override
     public boolean isManifestParsingEnabled() {
         return false;
+    }
+
+    @Override
+    public void applyOptions(Context context, GlideBuilder builder) {
+        // Glide is checking for the log level only on some classes, so we have to do it ourselves here.
+        // Command: adb shell setprop log.tag.Glide VERBOSE
+        if (GlideLogging.isVerboseLoggable()) {
+            builder.setLogLevel(Log.VERBOSE);
+        }
     }
 }

--- a/src/Core/src/Core.csproj
+++ b/src/Core/src/Core.csproj
@@ -36,7 +36,7 @@
     <ProjectReference Include="..\..\Graphics\src\Graphics.Win2D\Graphics.Win2D.csproj" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.Contains('-android'))">
-    <PackageReference Include="Xamarin.Android.Glide" Version="4.15.1.2" />
+    <PackageReference Include="Xamarin.Android.Glide" Version="$(_XamarinAndroidGlideVersion)" />
     <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.6.1.3" />
     <PackageReference Include="Xamarin.Google.Android.Material" Version="1.9.0.2" />
     <PackageReference Include="Xamarin.AndroidX.SwipeRefreshLayout" Version="1.1.0.14" />

--- a/src/Core/tests/Benchmarks.Droid/Benchmarks.Droid.csproj
+++ b/src/Core/tests/Benchmarks.Droid/Benchmarks.Droid.csproj
@@ -28,7 +28,7 @@
     <Using Include="BenchmarkDotNet.Order" />
     <Using Include="BenchmarkDotNet.Running" />
     <PackageReference Include="BenchmarkDotNet" Version="0.13.10" />
-    <PackageReference Include="Xamarin.Android.Glide" Version="4.14.2.1" />
+    <PackageReference Include="Xamarin.Android.Glide" Version="$(_XamarinAndroidGlideVersion)" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\Controls\src\Core\Controls.Core.csproj" />

--- a/src/Core/tests/Benchmarks.Droid/ImageBenchmarks.cs
+++ b/src/Core/tests/Benchmarks.Droid/ImageBenchmarks.cs
@@ -1,12 +1,12 @@
 ﻿using Android.Content;
+using Android.Graphics;
 using Android.Graphics.Drawables;
 using Android.OS;
 using Bumptech.Glide;
-using Bumptech.Glide.Request.Target;
-using Bumptech.Glide.Request.Transition;
 using Java.Lang;
 using Microsoft.Maui.Storage;
 using AImageView = Android.Widget.ImageView;
+using Path = System.IO.Path;
 
 namespace Benchmarks.Droid;
 
@@ -20,6 +20,7 @@ public class ImageBenchmark
 	Handler? handler;
 	Context? context;
 	string? imageFilename;
+	Typeface? defaultTypeface;
 
 	[GlobalSetup]
 	public void GlobalSetup()
@@ -29,6 +30,7 @@ public class ImageBenchmark
 		imageView = new AImageView(context);
 		glide = Glide.Get(context);
 		handler = new Handler(Looper.MainLooper!);
+		defaultTypeface = Typeface.Default;
 
 		var imageName = "dotnet_bot.png";
 		var cacheDir = FileSystem.CacheDirectory;
@@ -64,6 +66,25 @@ public class ImageBenchmark
 			Microsoft.Maui.PlatformInterop.LoadImageFromFile(
 				context!,
 				imageFilename,
+				callback);
+		});
+
+		await callback.SuccessTask;
+	}
+
+	[Benchmark]
+	public async Task ImageHelperFromFont()
+	{
+		var callback = new Callback();
+
+		handler!.Post(() =>
+		{
+			Microsoft.Maui.PlatformInterop.LoadImageFromFont(
+				context,
+				Color.Aquamarine,
+				"A",
+				defaultTypeface,
+				24,
 				callback);
 		});
 


### PR DESCRIPTION
### Description of Change

Adds a benchmark for `LoadImageFromFont` on Android platform.
Also enables `VERBOSE` logging of `Glide` if requested via `adb`.

See https://github.com/dotnet/maui/issues/22757#issuecomment-2270993905