### PR TITLE
[Android] Fix incorrect height of CollectionView when ItemsSource is empty.

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/Android/MauiRecyclerView.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/MauiRecyclerView.cs
@@ -473,12 +473,16 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 			if (_itemDecoration is SpacingItemDecoration spacingDecoration)
 			{
-				// SpacingItemDecoration applies spacing to all items & all 4 sides of the items.
-				// We need to adjust the padding on the RecyclerView so this spacing isn't visible around the outer edge of our control.
-				// Horizontal & vertical spacing should only exist between items. 
-				var horizontalPadding = -spacingDecoration.HorizontalOffset;
-				var verticalPadding = -spacingDecoration.VerticalOffset;
-				SetPadding(horizontalPadding, verticalPadding, horizontalPadding, verticalPadding);
+				var layoutManager = GetLayoutManager();
+				if (layoutManager != null && layoutManager.ItemCount > 0)
+				{
+					// SpacingItemDecoration applies spacing to all items & all 4 sides of the items.
+					// We need to adjust the padding on the RecyclerView so this spacing isn't visible around the outer edge of our control.
+					// Horizontal & vertical spacing should only exist between items. 
+					var horizontalPadding = -spacingDecoration.HorizontalOffset;
+					var verticalPadding = -spacingDecoration.VerticalOffset;
+					SetPadding(horizontalPadding, verticalPadding, horizontalPadding, verticalPadding);
+				}
 			}
 		}
 

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue23148.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue23148.xaml
@@ -5,7 +5,7 @@
 
   <ContentPage.Content>
 
-    <VerticalStackLayout Padding="30,0" Spacing="25">
+    <VerticalStackLayout AutomationId="StackLayout" Padding="30,0" Spacing="25">
 
       <Button
 			x:Name="CounterBtn"

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue23148.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue23148.xaml
@@ -1,0 +1,33 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+ xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+ x:Class="Maui.Controls.Sample.Issues.Issue23148">
+
+  <ContentPage.Content>
+
+    <VerticalStackLayout Padding="30,0" Spacing="25">
+
+      <Button
+			x:Name="CounterBtn"
+			Text="Click me" 
+			Command="{Binding AddCommand}"
+			HorizontalOptions="Fill" />
+
+      <CollectionView ItemsSource="{Binding Items}" Background="Green">
+        <CollectionView.ItemsLayout>
+          <LinearItemsLayout Orientation="Vertical" ItemSpacing="8"/>
+        </CollectionView.ItemsLayout>
+        <CollectionView.ItemTemplate>
+          <DataTemplate>
+            <Label Text="{Binding .}"/>
+          </DataTemplate>
+        </CollectionView.ItemTemplate>
+      </CollectionView>
+
+      <Label Text="Bottom text"/>
+
+    </VerticalStackLayout>
+
+  </ContentPage.Content>
+
+</ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue23148.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue23148.xaml.cs
@@ -1,0 +1,23 @@
+﻿using System.Collections.ObjectModel;
+using System.Windows.Input;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+
+namespace Controls.TestCases.HostApp
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	[Issue(IssueTracker.Github, 23148, "Incorrect height of CollectionView when ItemsSource is empty", PlatformAffected.Android)]
+
+	public partial class Issue23148 : ContentPage
+	{
+		public ObservableCollection<string> Items { get; set; } = [];
+
+		public ICommand AddCommand => new Command(() => Items.Add("Item"));
+
+		public Issue23148()
+		{
+			InitializeComponent();
+			BindingContext = this;
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue23148.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue23148.xaml.cs
@@ -3,7 +3,7 @@ using System.Windows.Input;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Xaml;
 
-namespace Controls.TestCases.HostApp
+namespace Maui.Controls.Sample.Issues
 {
 	[XamlCompilation(XamlCompilationOptions.Compile)]
 	[Issue(IssueTracker.Github, 23148, "Incorrect height of CollectionView when ItemsSource is empty", PlatformAffected.Android)]

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue23148.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue23148.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Tests.Issues
+{
+	public class Issue23148 : _IssuesUITest
+	{
+		public override string Issue => "Incorrect height of CollectionView when ItemsSource is empty";
+
+		public Issue23148(TestDevice device) : base(device)
+		{
+		}
+
+		[Test]
+		[Category(UITestCategories.CollectionView)]
+
+		public async void CollectionViewNullItemsHeight()
+		{
+			// Is a Android issue; see https://github.com/dotnet/maui/issues/23148
+
+			await Task.Delay(500);
+			VerifyScreenshot();
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue23148.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue23148.cs
@@ -7,7 +7,7 @@ using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
 
-namespace Microsoft.Maui.TestCases.Tests.Tests.Issues
+namespace Microsoft.Maui.TestCases.Tests.Issues
 {
 	public class Issue23148 : _IssuesUITest
 	{

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue23148.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue23148.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using NUnit.Framework;
+using UITest.Appium;
 using UITest.Core;
 
 namespace Microsoft.Maui.TestCases.Tests.Tests.Issues
@@ -19,11 +20,11 @@ namespace Microsoft.Maui.TestCases.Tests.Tests.Issues
 		[Test]
 		[Category(UITestCategories.CollectionView)]
 
-		public async void CollectionViewEmptyItemsHeight()
+		public void CollectionViewEmptyItemsHeight()
 		{
 			// Is a Android issue; see https://github.com/dotnet/maui/issues/23148
 
-			await Task.Delay(500);
+			App.WaitForElement("StackLayout");
 			VerifyScreenshot();
 		}
 	}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue23148.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue23148.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Maui.TestCases.Tests.Tests.Issues
 		[Test]
 		[Category(UITestCategories.CollectionView)]
 
-		public async void CollectionViewNullItemsHeight()
+		public async void CollectionViewEmptyItemsHeight()
 		{
 			// Is a Android issue; see https://github.com/dotnet/maui/issues/23148
 


### PR DESCRIPTION
### Root Cause: 

- The `ItemSpacing` was set in the `MauiRecyclerView` even when the `ItemsSource` was `null`. As a result, the default padding occupied space in the `MauiRecyclerView`.
 
### Description of Change: 

- The `ItemSpacing` (padding) should only be applied if the `ItemsCount` is greater than zero. Otherwise, padding should not be applied.


### Issues Fixed

Fixes #23148

| Before Issue Fix | After Issue Fix |
|----------|----------|
| <img src="https://github.com/user-attachments/assets/84fb77b2-4576-477b-abd4-4f51d78609ef" > | <img src="https://github.com/user-attachments/assets/916f4451-8f86-4131-9e7a-01dcd68afe9b" > |




