### PR TITLE
Remove the huge xcsync for now

### DIFF
--- a/eng/pipelines/common/device-tests-steps.yml
+++ b/eng/pipelines/common/device-tests-steps.yml
@@ -44,6 +44,9 @@ steps:
   - pwsh: echo "##vso[task.prependpath]$(DotNet.Dir)"
     displayName: 'Add .NET to PATH'
 
+  - pwsh: Get-ChildItem "$(DotNet.Dir)/packs/Microsoft.*.Sdk.*/*/tools/lib/xcsync" | Remove-Item -Recurse
+    displayName: 'Remove xcsync as this is not used and will be fixed later'
+
   - ${{ if eq(parameters.useArtifacts, true) }}:
 
     - task: DownloadBuildArtifacts@0


### PR DESCRIPTION
### Description of Change

The new xcsync tool is vary large 600MB and duplicated 4 times for each SDK. The size and the rest are going to be fixed for RC1, but we do not even need it for CI. 

Removing it for now.