### PR TITLE
2174059 MAUI hit testing ignores pages loaded by PushModalAsync

### DIFF
--- a/src/Core/src/Core/Extensions/VisualTreeElementExtensions.cs
+++ b/src/Core/src/Core/Extensions/VisualTreeElementExtensions.cs
@@ -136,7 +136,12 @@ namespace Microsoft.Maui
 			var visualElements = new List<IVisualTreeElement>();
 			if (visualElement is IWindow window)
 			{
-				uiElement = window.Content?.ToPlatform();
+				// Get the MauiWinUiWindow so we catch everything in the app window rather than the frame which doesn't include modal content
+				var platformView = window.Handler?.PlatformView;
+				if (platformView is MauiWinUIWindow winUiWindow)
+				{
+					uiElement = winUiWindow.Content;
+				}
 			}
 			else if (visualElement is IView view)
 			{

--- a/src/Core/src/Core/Extensions/VisualTreeElementExtensions.cs
+++ b/src/Core/src/Core/Extensions/VisualTreeElementExtensions.cs
@@ -136,9 +136,9 @@ namespace Microsoft.Maui
 			var visualElements = new List<IVisualTreeElement>();
 			if (visualElement is IWindow window)
 			{
-				// Get the MauiWinUiWindow so we catch everything in the app window rather than the frame which doesn't include modal content
+				// Get the UI.Xaml.Window so we catch everything in the app window rather than the frame which doesn't include modal content
 				var platformView = window.Handler?.PlatformView;
-				if (platformView is MauiWinUIWindow winUiWindow)
+				if (platformView is UI.Xaml.Window winUiWindow)
 				{
 					uiElement = winUiWindow.Content;
 				}


### PR DESCRIPTION
### Description of Change
Updated VisualTreeElementExtension to get the MauiWinUiWindow Element, as its content member gets modal content in addition to underlying content

Tested in Maui Windows and Android with a test project from the linked work item. Verified in the Maui Sandbox with fix and without.

Also verified the initial bug didn't repro on android.

### Issues Fixed
[Bug# 2174059](https://dev.azure.com/devdiv/DevDiv/_workitems/edit/2174059)
