### PR TITLE
Fix cake scripts to work locally

### DIFF
--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -163,6 +163,7 @@ Task("dotnet-build")
     });
 
 Task("dotnet-samples")
+    .IsDependentOn("dotnet-buildtasks")
     .Does(() =>
     {
         var tempDir = PrepareSeparateBuildContext("samplesTest");

--- a/eng/devices/android.cake
+++ b/eng/devices/android.cake
@@ -1,10 +1,10 @@
 #addin nuget:?package=Cake.Android.Adb&version=3.2.0
 #addin nuget:?package=Cake.Android.AvdManager&version=2.2.0
-#load "../cake/helpers.cake"
-#load "../cake/dotnet.cake"
-#load "./devices-shared.cake"
+#load "./uitests-shared.cake"
 
 const int DefaultApiLevel = 30;
+
+Information("Local Dotnet: {0}", localDotnet);
 
 string DEFAULT_ANDROID_PROJECT = "../../src/Controls/tests/TestCases.Android.Tests/Controls.TestCases.Android.Tests.csproj";
 var projectPath = Argument("project", EnvironmentVariable("ANDROID_TEST_PROJECT") ?? DEFAULT_ANDROID_PROJECT);
@@ -23,9 +23,6 @@ var deviceSkin = Argument("skin", EnvironmentVariable("ANDROID_TEST_SKIN") ?? "N
 var androidAvd = "DEVICE_TESTS_EMULATOR";
 var androidAvdImage = "";
 var deviceArch = "";
-bool deviceBoot = Argument("boot", true);
-bool deviceBootWait = Argument("wait", true);
-
 var androidVersion = Argument("apiversion", EnvironmentVariable("ANDROID_PLATFORM_VERSION") ?? DefaultApiLevel.ToString());
 
 // Directory setup
@@ -58,6 +55,7 @@ var dotnetToolPath = GetDotnetToolPath();
 Setup(context =>
 {
 	LogSetupInfo(dotnetToolPath);
+
 	PerformCleanupIfNeeded(deviceCleanupEnabled);
 
 	DetermineDeviceCharacteristics(testDevice, DefaultApiLevel);
@@ -460,7 +458,7 @@ void HandleVirtualDevice(AndroidEmulatorToolSettings emuSettings, AndroidAvdMana
 void CleanUpVirtualDevice(AndroidEmulatorProcess emulatorProcess, AndroidAvdManagerToolSettings avdSettings)
 {
 	// no virtual device was used
-	if (emulatorProcess == null || !deviceBoot || TARGET.ToLower() == "boot")
+	if (emulatorProcess == null || !deviceBoot || targetBoot)
 		return;
 
 	//stop and cleanup the emulator

--- a/eng/devices/android.cake
+++ b/eng/devices/android.cake
@@ -85,11 +85,12 @@ Task("test")
 	});
 
 Task("uitest-build")
+	.IsDependentOn("dotnet-buildtasks")
 	.Does(() =>
 	{
 		ExecuteBuildUITestApp(testAppProjectPath, testDevice, binlogDirectory, configuration, targetFramework, "", dotnetToolPath);
-
 	});
+
 Task("uitest")
 	.Does(() =>
 	{
@@ -97,6 +98,7 @@ Task("uitest")
 	});
 
 Task("cg-uitest")
+	.IsDependentOn("dotnet-buildtasks")
 	.Does(() =>
 	{
 		ExecuteCGLegacyUITests(projectPath, testAppProjectPath, testAppPackageName, testDevice, testResultsPath, configuration, targetFramework, dotnetToolPath, testAppInstrumentation);

--- a/eng/devices/catalyst.cake
+++ b/eng/devices/catalyst.cake
@@ -1,6 +1,4 @@
-#load "../cake/helpers.cake"
-#load "../cake/dotnet.cake"
-#load "./devices-shared.cake"
+#load "./uitests-shared.cake"
 
 // Argument handling
 string DEFAULT_MAC_PROJECT = "../../src/Controls/tests/TestCases.Mac.Tests/Controls.TestCases.Mac.Tests.csproj";

--- a/eng/devices/devices-shared.cake
+++ b/eng/devices/devices-shared.cake
@@ -207,7 +207,18 @@ void LogSetupInfo(string toolPath)
 string GetDotnetToolPath()
 {
     var isLocalDotnet = GetBuildVariable("workloads", "local") == "local";
-    var toolPath = isLocalDotnet ? $"{MakeAbsolute(Directory("../../bin/dotnet/")).ToString()}/dotnet" : DotnetToolPathDefault;
+    string toolPath;
+    
+    
+    if(IsRunningOnWindows())
+    {
+        toolPath = isLocalDotnet ? $"{MakeAbsolute(Directory("../../bin/dotnet/")).ToString()}/dotnet" : null;
+    }
+    else
+    {
+        toolPath = isLocalDotnet ? $"{MakeAbsolute(Directory("../../bin/dotnet/")).ToString()}/dotnet" : DotnetToolPathDefault;
+    }
+
     Information(isLocalDotnet ? "Using local dotnet" : "Using system dotnet");
     return toolPath;
 }

--- a/eng/devices/ios.cake
+++ b/eng/devices/ios.cake
@@ -478,7 +478,17 @@ string GetUDID(string testDevice, string tool)
 		SetupProcessSettings = processSettings => 
 		{
 			processSettings.RedirectStandardOutput = true;
-			processSettings.RedirectedStandardOutputHandler = line => result = $"{line}";
+			processSettings.RedirectedStandardOutputHandler = line => 
+			{
+				// The output from this command returns the UDID of the simulator
+				// and NULL so we're filtering out the NULL
+				if (!string.IsNullOrWhiteSpace(line))
+				{
+					result = line;
+				}
+				
+				return line;
+			};
 		}
 	});
 

--- a/eng/devices/ios.cake
+++ b/eng/devices/ios.cake
@@ -1,14 +1,13 @@
 #addin nuget:?package=Cake.AppleSimulator&version=0.2.0
-#load "../cake/helpers.cake"
-#load "../cake/dotnet.cake"
-#load "./devices-shared.cake"
+#load "./uitests-shared.cake"
 
 const string DefaultVersion = "17.2";
+const string DefaultTestDevice = $"ios-simulator-64_{DefaultVersion}";
 
 // Required arguments
 string DEFAULT_IOS_PROJECT = "../../src/Controls/tests/TestCases.iOS.Tests/Controls.TestCases.iOS.Tests.csproj";
 var projectPath = Argument("project", EnvironmentVariable("IOS_TEST_PROJECT") ?? DEFAULT_IOS_PROJECT);
-var testDevice = Argument("device", EnvironmentVariable("IOS_TEST_DEVICE") ?? $"ios-simulator-64_{DefaultVersion}");
+var testDevice = Argument("device", EnvironmentVariable("IOS_TEST_DEVICE") ?? DefaultTestDevice);
 var targetFramework = Argument("tfm", EnvironmentVariable("TARGET_FRAMEWORK") ?? $"{DotnetVersion}-ios");
 var binlogArg = Argument("binlog", EnvironmentVariable("IOS_TEST_BINLOG") ?? "");
 var testApp = Argument("app", EnvironmentVariable("IOS_TEST_APP") ?? "");
@@ -44,6 +43,12 @@ var dotnetToolPath = GetDotnetToolPath();
 Setup(context =>
 {
 	LogSetupInfo(dotnetToolPath);
+
+	if (!deviceBoot)
+	{
+		return;
+	}
+
 	PerformCleanupIfNeeded(deviceCleanupEnabled, false);
 
 	// Device or simulator setup
@@ -58,9 +63,20 @@ Setup(context =>
 	}
 });
 
-Teardown(context => PerformCleanupIfNeeded(deviceCleanupEnabled, true));
+Teardown(context => 
+{
+	if (!deviceBoot || targetBoot)
+	{
+		return;
+	}
+
+	PerformCleanupIfNeeded(deviceCleanupEnabled, true);
+});
 
 Task("Cleanup");
+
+// Todo this doesn't work for iOS currently
+// Task("boot");
 
 Task("Build")
 	.WithCriteria(!string.IsNullOrEmpty(projectPath))
@@ -80,7 +96,6 @@ Task("uitest-build")
 	.Does(() =>
 	{
 		ExecuteBuildUITestApp(testAppProjectPath, testDevice, binlogDirectory, configuration, targetFramework, runtimeIdentifier, dotnetToolPath);
-
 	});
 
 Task("uitest")
@@ -377,7 +392,7 @@ string GetDefaultRuntimeIdentifier(string testDeviceIdentifier)
 
 void InstallIpa(string testApp, string testAppPackageName, string testDevice, string testResultsDirectory, string version, string toolPath)
 {
-	Information("Install with xharness: {0}", testApp);
+	Information("Install with xharness: {0} testDevice:{1}", testApp, testDevice);
 	var settings = new DotNetToolSettings
 	{
 		ToolPath = toolPath,
@@ -389,6 +404,7 @@ void InstallIpa(string testApp, string testAppPackageName, string testDevice, st
 							$"--targets=\"{testDevice}\" " +
 							$"--output-directory=\"{testResultsDirectory}\" " +
 							$"--verbosity=\"Debug\" ");
+
 			if (testDevice.Contains("device"))
 			{
 				if (string.IsNullOrEmpty(DEVICE_UDID))
@@ -430,9 +446,24 @@ void InstallIpa(string testApp, string testAppPackageName, string testDevice, st
 			var simulatorName = "XHarness";
 			Information("Looking for simulator: {0} iosversion {1}", simulatorName, iosVersionToRun);
 			var sims = ListAppleSimulators();
+
 			var simXH = sims.Where(s => s.Name.Contains(simulatorName) && s.Name.Contains(iosVersionToRun)).FirstOrDefault();
 			if (simXH == null)
-				throw new Exception("No simulator was found to run tests on.");
+			{
+				// if the device is already installed on this system then xharness won't create a new one
+				// Ideally we could just pull this info from xharness but I'm not sure how to convert the 
+				// ios-simulator-64_{DefaultVersion} string to a UDID from xharness
+				// so we are just going to make some assumptions here for local runs				
+				if (DefaultTestDevice == testDevice && !IsCIBuild())
+				{
+					simXH = sims.Where(s => s.Name.Contains("iPhone Xs") && s.Runtime.Contains(DefaultVersion.Replace(".", "-"))).FirstOrDefault();
+				}
+
+				if (simXH == null)
+				{
+					throw new Exception("No simulator was found to run tests on.");
+				}
+			}
 
 			deviceToRun = simXH.UDID;
 			DEVICE_NAME = simXH.Name;

--- a/eng/devices/ios.cake
+++ b/eng/devices/ios.cake
@@ -93,6 +93,7 @@ Task("Test")
 	});
 
 Task("uitest-build")
+	.IsDependentOn("dotnet-buildtasks")
 	.Does(() =>
 	{
 		ExecuteBuildUITestApp(testAppProjectPath, testDevice, binlogDirectory, configuration, targetFramework, runtimeIdentifier, dotnetToolPath);
@@ -106,6 +107,7 @@ Task("uitest")
 	});
 
 Task("cg-uitest")
+	.IsDependentOn("dotnet-buildtasks")
 	.Does(() =>
 	{
 		ExecuteCGLegacyUITests(projectPath, testAppProjectPath, testDevice, testResultsPath, configuration, targetFramework, runtimeIdentifier, iosVersion, dotnetToolPath);

--- a/eng/devices/uitests-shared.cake
+++ b/eng/devices/uitests-shared.cake
@@ -1,0 +1,13 @@
+#load "../cake/helpers.cake"
+
+if (!IsCIBuild() && GetBuildVariable("workloads", "notset") == "notset")
+{
+	SetEnvironmentVariable("workloads", "global");
+}
+
+#load "../cake/dotnet.cake"
+#load "./devices-shared.cake"
+
+bool deviceBoot = Argument("boot", TARGET.ToLower() != "uitest-build");
+bool targetBoot = TARGET.ToLower() == "boot";
+bool deviceBootWait = Argument("wait", true);

--- a/eng/devices/windows.cake
+++ b/eng/devices/windows.cake
@@ -1,6 +1,4 @@
-#load "../cake/helpers.cake"
-#load "../cake/dotnet.cake"
-#load "./devices-shared.cake"
+#load "./uitests-shared.cake"
 
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;

--- a/eng/pipelines/common/ui-tests-build-sample.yml
+++ b/eng/pipelines/common/ui-tests-build-sample.yml
@@ -47,9 +47,6 @@ steps:
   - pwsh: echo "##vso[task.prependpath]$(DotNet.Dir)"
     displayName: 'Add .NET to PATH'
 
-  - pwsh: ./build.ps1 --target=dotnet-buildtasks --configuration="${{ parameters.configuration }}"
-    displayName: 'Build the MSBuild Tasks'
-
   - pwsh: ./build.ps1 --target=dotnet-samples --configuration="${{ parameters.configuration }}" --${{ parameters.platform }} --verbosity=diagnostic --usenuget=false
     displayName: 'Build the samples'
 

--- a/eng/pipelines/common/ui-tests-compatibility-steps.yml
+++ b/eng/pipelines/common/ui-tests-compatibility-steps.yml
@@ -43,9 +43,6 @@ steps:
   - pwsh: echo "##vso[task.prependpath]$(DotNet.Dir)"
     displayName: 'Add .NET to PATH'
 
-  - pwsh: ./build.ps1 --target=dotnet-buildtasks --configuration="${{ parameters.configuration }}"
-    displayName: 'Build the MSBuild Tasks'
-
   - pwsh: ./build.ps1 --target=${{ parameters.targetSample }} --configuration="${{ parameters.configuration }}" --${{ parameters.platform }} --verbosity=diagnostic
     displayName: 'Build the Legacy ControlGallery'
 

--- a/src/Controls/tests/TestCases.Shared.Tests/UITest.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/UITest.cs
@@ -1,5 +1,6 @@
 ﻿using System.Reflection;
 using NUnit.Framework;
+using OpenQA.Selenium.Appium.iOS;
 using UITest.Appium;
 using UITest.Appium.NUnit;
 using UITest.Core;
@@ -107,6 +108,7 @@ namespace Microsoft.Maui.TestCases.Tests
 			void Verify(string? name)
 			{
 				string deviceName = GetTestConfig().GetProperty<string>("DeviceName") ?? string.Empty;
+				
 				// Remove the XHarness suffix if present
 				deviceName = deviceName.Replace(" - created by XHarness", "", StringComparison.Ordinal);
 
@@ -136,16 +138,21 @@ namespace Microsoft.Maui.TestCases.Tests
 						break;
 
 					case TestDevice.iOS:
-						if (deviceName == "iPhone Xs (iOS 17.2)")
+
+						var platformVersion = (string)((AppiumApp)App).Driver.Capabilities.GetCapability("platformVersion");
+						var device = (string)((AppiumApp)App).Driver.Capabilities.GetCapability("deviceName");
+
+						if (deviceName == "iPhone Xs (iOS 17.2)" || (device.Contains(" Xs", StringComparison.OrdinalIgnoreCase) && platformVersion == "17.2"))
 						{
 							environmentName = "ios";
 						}
-						else if (deviceName == "iPhone X (iOS 16.4)")
+						else if (deviceName == "iPhone X (iOS 16.4)" || (device.Contains(" X", StringComparison.OrdinalIgnoreCase) && platformVersion == "16.4"))
 						{
 							environmentName = "ios-iphonex";
 						}
 						else
 						{
+
 							Assert.Fail($"iOS visual tests should be run on iPhone Xs (iOS 17.2) or iPhone X (iOS 16.4) simulator images, but the current device is '{deviceName}'. Follow the steps on the MAUI UI testing wiki.");
 						}
 						break;


### PR DESCRIPTION
### Description of Change

The UITest scripts aren't really working so well when ran locally. This PR fixes them and attempts to make it so they are overall much easier to run. 

I've made comments to the various parts of the changes with thoughts/questions

Basically, this PR gets us to the point where you can do

```CLI
dotnet cake eng/devices/android.cake --target=uitest-build
dotnet cake eng/devices/android.cake --target=uitest --test-filter="TestCategory=Border"
```

### Additional thoughts
- I'd like to flatten this out so you could just do this, but it's going to take some additional organizing and this is a good first step. 
```CLI
dotnet cake --target=uitest --android
```
- I don't currently know how to get the `VerifyScreenshot` code to detect the right device when running from `test explorer`. The `Device Name` doesn't really get passed up into Appium. A bunch of the capabilities get passed in, so, maybe we can just make sure the viewport and various other values match with what our screenshots are using
![image](https://github.com/user-attachments/assets/de5ff8ba-da3d-47fc-b8ba-5660a4ac647a)
