### PR TITLE
Remove excessive StackLayout API docs

### DIFF
--- a/src/Controls/docs/Microsoft.Maui.Controls/StackLayout.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/StackLayout.xml
@@ -29,88 +29,7 @@
   <Docs>
     <summary>A <see cref="T:Microsoft.Maui.Controls.Layout" /> that positions child elements in a single line which can be oriented vertically or horizontally.</summary>
     <remarks>
-      <para>Because <see cref="T:Microsoft.Maui.Controls.StackLayout" /> layouts override the bounds on their child elements, application developers should not set bounds on them.</para>
-      <example>
-        <para>The following example code shows how to create a new <see cref="T:Microsoft.Maui.Controls.StackLayout" /> with children that explore many of the layout behaviors of <see cref="T:Microsoft.Maui.Controls.StackLayout" />:</para>
-        <code lang="csharp lang-csharp"><![CDATA[
-StackLayout stackLayout = new StackLayout
-{
-    Spacing = 0,
-    VerticalOptions = LayoutOptions.FillAndExpand,
-    Children = 
-    {
-        new Label
-        {
-            Text = "StackLayout",
-            HorizontalOptions = LayoutOptions.Start
-        },
-        new Label
-        {
-            Text = "stacks its children",
-            HorizontalOptions = LayoutOptions.Center
-        },
-        new Label
-        {
-            Text = "vertically",
-            HorizontalOptions = LayoutOptions.End
-        },
-        new Label
-        {
-            Text = "by default,",
-            HorizontalOptions = LayoutOptions.Center
-        },
-        new Label
-        {
-            Text = "but horizontal placement",
-            HorizontalOptions = LayoutOptions.Start
-        },
-        new Label
-        {
-            Text = "can be controlled with",
-            HorizontalOptions = LayoutOptions.Center
-        },
-        new Label
-        {
-            Text = "the HorizontalOptions property.",
-            HorizontalOptions = LayoutOptions.End
-        },
-        new Label
-        {
-            Text = "An Expand option allows one or more children " +
-                   "to occupy the an area within the remaining " +
-                   "space of the StackLayout after it's been sized " +
-                   "to the height of its parent.",
-            VerticalOptions = LayoutOptions.CenterAndExpand,
-            HorizontalOptions = LayoutOptions.End
-        },
-        new StackLayout
-        {
-            Spacing = 0,
-            Orientation = StackOrientation.Horizontal,
-            Children = 
-            {
-                new Label
-                {
-                    Text = "Stacking",
-                },
-                new Label
-                {
-                    Text = "can also be",
-                    HorizontalOptions = LayoutOptions.CenterAndExpand
-                },
-                new Label
-                {
-                    Text = "horizontal.",
-                },
-            }
-        }
-    }
-};
-]]></code>
-      </example>
-      <para>
-        <img href="~/xml/Microsoft.Maui.Controls/_images/StackLayout.TripleScreenShot.png" />
-      </para>
+      
     </remarks>
   </Docs>
   <Members>
@@ -134,23 +53,6 @@ StackLayout stackLayout = new StackLayout
       <Parameters />
       <Docs>
         <summary>Initializes a new instance of the StackLayout class.</summary>
-        <remarks>
-          <para>
-              The following example shows the initialization of a new StackLayout and setting its orientation and children.
-              </para>
-          <example>
-            <code lang="csharp lang-csharp"><![CDATA[
-var stackLayout = new StackLayout {
-  Orientation = StackOrientation.Horizontal,
-  Children = {
-    firstChild,
-    secondChild,
-    thirdChild
-  }
-};
-              ]]></code>
-          </example>
-        </remarks>
       </Docs>
     </Member>
     <Member MemberName="LayoutChildren">

--- a/src/Controls/src/Core/Layout/StackLayout.cs
+++ b/src/Controls/src/Core/Layout/StackLayout.cs
@@ -4,14 +4,22 @@ using Microsoft.Maui.Layouts;
 
 namespace Microsoft.Maui.Controls
 {
-	/// <include file="../../../docs/Microsoft.Maui.Controls/StackLayout.xml" path="Type[@FullName='Microsoft.Maui.Controls.StackLayout']/Docs/*" />
+	/// <summary>
+	/// A <see cref="Layout" /> that positions child elements in a single line which can be oriented vertically or horizontally.
+	/// </summary>
+	/// <remarks>
+	/// For better performance look at the specialized <see cref="VerticalStackLayout" /> and <see cref="HorizontalStackLayout" />.
+	/// </remarks>
 	public class StackLayout : StackBase, IStackLayout
 	{
 		/// <summary>Bindable property for <see cref="Orientation"/>.</summary>
 		public static readonly BindableProperty OrientationProperty = BindableProperty.Create(nameof(Orientation), typeof(StackOrientation), typeof(StackLayout), StackOrientation.Vertical,
 			propertyChanged: OrientationChanged);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/StackLayout.xml" path="//Member[@MemberName='Orientation']/Docs/*" />
+		/// <summary>
+		/// Gets or sets the value which indicates the direction which child elements are positioned. Default value is <see cref="StackOrientation.Vertical"/>.
+		/// This is a bindable property.
+		/// </summary>
 		public StackOrientation Orientation
 		{
 			get { return (StackOrientation)GetValue(OrientationProperty); }

--- a/src/Controls/src/Core/Layout/StackLayout.cs
+++ b/src/Controls/src/Core/Layout/StackLayout.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Maui.Controls
 	/// A <see cref="Layout" /> that positions child elements in a single line which can be oriented vertically or horizontally.
 	/// </summary>
 	/// <remarks>
-	/// For better performance look at the specialized <see cref="VerticalStackLayout" /> and <see cref="HorizontalStackLayout" />.
+	/// Also see the specialized <see cref="VerticalStackLayout" /> and <see cref="HorizontalStackLayout" />, which might be more suitable if you do not need to change the orientation at runtime.
 	/// </remarks>
 	public class StackLayout : StackBase, IStackLayout
 	{


### PR DESCRIPTION
### Description of Change

Removes the very verbose example in the `StackLayout` API docs. This also moves some of the docs back into the code.

Also see #24037 
