### PR TITLE
Correct "can not" to "cannot" in messages, comments, etc.

### DIFF
--- a/loc/cs/src/Controls/src/Build.Tasks/ErrorMessages.resx.lcl
+++ b/loc/cs/src/Controls/src/Build.Tasks/ErrorMessages.resx.lcl
@@ -239,7 +239,7 @@
       </Item>
       <Item ItemId=";StyleSheetSourceOrContent" ItemType="0;.resx" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[StyleSheet can not have both a Source and a content.]]></Val>
+          <Val><![CDATA[StyleSheet cannot have both a Source and a content.]]></Val>
         </Str>
         <Disp Icon="Str" />
       </Item>

--- a/loc/de/src/Controls/src/Build.Tasks/ErrorMessages.resx.lcl
+++ b/loc/de/src/Controls/src/Build.Tasks/ErrorMessages.resx.lcl
@@ -239,7 +239,7 @@
       </Item>
       <Item ItemId=";StyleSheetSourceOrContent" ItemType="0;.resx" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[StyleSheet can not have both a Source and a content.]]></Val>
+          <Val><![CDATA[StyleSheet cannot have both a Source and a content.]]></Val>
         </Str>
         <Disp Icon="Str" />
       </Item>

--- a/loc/es/src/Controls/src/Build.Tasks/ErrorMessages.resx.lcl
+++ b/loc/es/src/Controls/src/Build.Tasks/ErrorMessages.resx.lcl
@@ -239,7 +239,7 @@
       </Item>
       <Item ItemId=";StyleSheetSourceOrContent" ItemType="0;.resx" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[StyleSheet can not have both a Source and a content.]]></Val>
+          <Val><![CDATA[StyleSheet cannot have both a Source and a content.]]></Val>
         </Str>
         <Disp Icon="Str" />
       </Item>

--- a/loc/fr/src/Controls/src/Build.Tasks/ErrorMessages.resx.lcl
+++ b/loc/fr/src/Controls/src/Build.Tasks/ErrorMessages.resx.lcl
@@ -239,7 +239,7 @@
       </Item>
       <Item ItemId=";StyleSheetSourceOrContent" ItemType="0;.resx" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[StyleSheet can not have both a Source and a content.]]></Val>
+          <Val><![CDATA[StyleSheet cannot have both a Source and a content.]]></Val>
         </Str>
         <Disp Icon="Str" />
       </Item>

--- a/loc/it/src/Controls/src/Build.Tasks/ErrorMessages.resx.lcl
+++ b/loc/it/src/Controls/src/Build.Tasks/ErrorMessages.resx.lcl
@@ -239,7 +239,7 @@
       </Item>
       <Item ItemId=";StyleSheetSourceOrContent" ItemType="0;.resx" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[StyleSheet can not have both a Source and a content.]]></Val>
+          <Val><![CDATA[StyleSheet cannot have both a Source and a content.]]></Val>
         </Str>
         <Disp Icon="Str" />
       </Item>

--- a/loc/ja/src/Controls/src/Build.Tasks/ErrorMessages.resx.lcl
+++ b/loc/ja/src/Controls/src/Build.Tasks/ErrorMessages.resx.lcl
@@ -239,7 +239,7 @@
       </Item>
       <Item ItemId=";StyleSheetSourceOrContent" ItemType="0;.resx" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[StyleSheet can not have both a Source and a content.]]></Val>
+          <Val><![CDATA[StyleSheet cannot have both a Source and a content.]]></Val>
         </Str>
         <Disp Icon="Str" />
       </Item>

--- a/loc/ko/src/Controls/src/Build.Tasks/ErrorMessages.resx.lcl
+++ b/loc/ko/src/Controls/src/Build.Tasks/ErrorMessages.resx.lcl
@@ -239,7 +239,7 @@
       </Item>
       <Item ItemId=";StyleSheetSourceOrContent" ItemType="0;.resx" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[StyleSheet can not have both a Source and a content.]]></Val>
+          <Val><![CDATA[StyleSheet cannot have both a Source and a content.]]></Val>
         </Str>
         <Disp Icon="Str" />
       </Item>

--- a/loc/pl/src/Controls/src/Build.Tasks/ErrorMessages.resx.lcl
+++ b/loc/pl/src/Controls/src/Build.Tasks/ErrorMessages.resx.lcl
@@ -239,7 +239,7 @@
       </Item>
       <Item ItemId=";StyleSheetSourceOrContent" ItemType="0;.resx" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[StyleSheet can not have both a Source and a content.]]></Val>
+          <Val><![CDATA[StyleSheet cannot have both a Source and a content.]]></Val>
         </Str>
         <Disp Icon="Str" />
       </Item>

--- a/loc/pt-BR/src/Controls/src/Build.Tasks/ErrorMessages.resx.lcl
+++ b/loc/pt-BR/src/Controls/src/Build.Tasks/ErrorMessages.resx.lcl
@@ -239,7 +239,7 @@
       </Item>
       <Item ItemId=";StyleSheetSourceOrContent" ItemType="0;.resx" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[StyleSheet can not have both a Source and a content.]]></Val>
+          <Val><![CDATA[StyleSheet cannot have both a Source and a content.]]></Val>
         </Str>
         <Disp Icon="Str" />
       </Item>

--- a/loc/ru/src/Controls/src/Build.Tasks/ErrorMessages.resx.lcl
+++ b/loc/ru/src/Controls/src/Build.Tasks/ErrorMessages.resx.lcl
@@ -239,7 +239,7 @@
       </Item>
       <Item ItemId=";StyleSheetSourceOrContent" ItemType="0;.resx" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[StyleSheet can not have both a Source and a content.]]></Val>
+          <Val><![CDATA[StyleSheet cannot have both a Source and a content.]]></Val>
         </Str>
         <Disp Icon="Str" />
       </Item>

--- a/loc/tr/src/Controls/src/Build.Tasks/ErrorMessages.resx.lcl
+++ b/loc/tr/src/Controls/src/Build.Tasks/ErrorMessages.resx.lcl
@@ -239,7 +239,7 @@
       </Item>
       <Item ItemId=";StyleSheetSourceOrContent" ItemType="0;.resx" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[StyleSheet can not have both a Source and a content.]]></Val>
+          <Val><![CDATA[StyleSheet cannot have both a Source and a content.]]></Val>
         </Str>
         <Disp Icon="Str" />
       </Item>

--- a/loc/zh-Hans/src/Controls/src/Build.Tasks/ErrorMessages.resx.lcl
+++ b/loc/zh-Hans/src/Controls/src/Build.Tasks/ErrorMessages.resx.lcl
@@ -239,7 +239,7 @@
       </Item>
       <Item ItemId=";StyleSheetSourceOrContent" ItemType="0;.resx" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[StyleSheet can not have both a Source and a content.]]></Val>
+          <Val><![CDATA[StyleSheet cannot have both a Source and a content.]]></Val>
         </Str>
         <Disp Icon="Str" />
       </Item>

--- a/loc/zh-Hant/src/Controls/src/Build.Tasks/ErrorMessages.resx.lcl
+++ b/loc/zh-Hant/src/Controls/src/Build.Tasks/ErrorMessages.resx.lcl
@@ -239,7 +239,7 @@
       </Item>
       <Item ItemId=";StyleSheetSourceOrContent" ItemType="0;.resx" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[StyleSheet can not have both a Source and a content.]]></Val>
+          <Val><![CDATA[StyleSheet cannot have both a Source and a content.]]></Val>
         </Str>
         <Disp Icon="Str" />
       </Item>

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue6929.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue6929.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Maui.Controls.ControlGallery.Issues
 			var stack = new StackLayout
 			{
 				Padding = 100,
-				Children = { new Label { Text = "Turn on the Screen Reader. Click the button. Another label should appear. If you can not swipe to access and hear the text of the new label, this test has failed." }, label2, button },
+				Children = { new Label { Text = "Turn on the Screen Reader. Click the button. Another label should appear. If you cannot swipe to access and hear the text of the new label, this test has failed." }, label2, button },
 			};
 
 			Content = stack;

--- a/src/Compatibility/Core/src/Tizen/Renderers/VisualElementRenderer.cs
+++ b/src/Compatibility/Core/src/Tizen/Renderers/VisualElementRenderer.cs
@@ -260,7 +260,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Tizen
 			{
 				// This is the reason why I call SendDisappearing() here.
 				// When OnChildRemove is called first like how it is called in Navigation.PopToRootAsync(),
-				// you can not controll using SendDisappearing() on the lower class.
+				// you cannot control using SendDisappearing() on the lower class.
 				(Element as IPageController)?.SendDisappearing();
 
 				if (Element != null)

--- a/src/Compatibility/Core/src/WPF/Microsoft.Windows.Shell/Standard/Verify.cs
+++ b/src/Compatibility/Core/src/WPF/Microsoft.Windows.Shell/Standard/Verify.cs
@@ -55,7 +55,7 @@ namespace Standard
 			Assert.IsNeitherNullNorEmpty(name);
 
 			// Notice that ArgumentNullException and ArgumentException take the parameters in opposite order :P
-			const string errorMessage = "The parameter can not be either null or empty.";
+			const string errorMessage = "The parameter cannot be either null or empty.";
 			if (null == value)
 			{
 				Assert.Fail();
@@ -82,7 +82,7 @@ namespace Standard
 			Assert.IsNeitherNullNorEmpty(name);
 
 			// Notice that ArgumentNullException and ArgumentException take the parameters in opposite order :P
-			const string errorMessage = "The parameter can not be either null or empty or consist only of white space characters.";
+			const string errorMessage = "The parameter cannot be either null or empty or consist only of white space characters.";
 			if (null == value)
 			{
 				Assert.Fail();

--- a/src/Compatibility/Core/src/Windows/NativeEventWrapper.cs
+++ b/src/Compatibility/Core/src/Windows/NativeEventWrapper.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 			}
 			catch (Exception)
 			{
-				Application.Current?.FindMauiContext()?.CreateLogger<NativeEventWrapper>()?.LogWarning("Can not attach NativeEventWrapper.");
+				Application.Current?.FindMauiContext()?.CreateLogger<NativeEventWrapper>()?.LogWarning("Cannot attach NativeEventWrapper.");
 			}
 		}
 

--- a/src/Compatibility/Core/src/iOS/Renderers/SwipeViewRenderer.cs
+++ b/src/Compatibility/Core/src/iOS/Renderers/SwipeViewRenderer.cs
@@ -706,7 +706,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 				catch (Exception)
 				{
 					// UIImage ctor throws on file not found if MonoTouch.ObjCRuntime.Class.ThrowOnInitFailure is true;
-					Forms.MauiContext?.CreateLogger<SwipeViewRenderer>()?.LogWarning("Can not load SwipeItem Icon");
+					Forms.MauiContext?.CreateLogger<SwipeViewRenderer>()?.LogWarning("Cannot load SwipeItem Icon");
 				}
 			}
 		}

--- a/src/Controls/docs/Microsoft.Maui.Controls/BindingBase.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/BindingBase.xml
@@ -227,7 +227,7 @@ label.AddBinding (new Binding (Label.TextProperty, "Price") {
       <Docs>
         <summary>Throws an <see cref="T:System.InvalidOperationException" /> if the binding has been applied.</summary>
         <remarks>
-          <para>Use this method in property setters as bindings can not be changed once applied.</para>
+          <para>Use this method in property setters as bindings cannot be changed once applied.</para>
         </remarks>
       </Docs>
     </Member>

--- a/src/Controls/src/Build.Tasks/ErrorMessages.Designer.cs
+++ b/src/Controls/src/Build.Tasks/ErrorMessages.Designer.cs
@@ -313,7 +313,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to StyleSheet can not have both a Source and a content..
+        ///   Looks up a localized string similar to StyleSheet cannot have both a Source and a content..
         /// </summary>
         internal static string StyleSheetSourceOrContent {
             get {

--- a/src/Controls/src/Build.Tasks/ErrorMessages.resx
+++ b/src/Controls/src/Build.Tasks/ErrorMessages.resx
@@ -234,7 +234,7 @@
     <value>Source property is not a string literal.</value>
   </data>
   <data name="StyleSheetSourceOrContent" xml:space="preserve">
-    <value>StyleSheet can not have both a Source and a content.</value>
+    <value>StyleSheet cannot have both a Source and a content.</value>
   </data>
   <data name="StyleSheetStyleNotALiteral" xml:space="preserve">
     <value>Style property or Content is not a string literal.</value>

--- a/src/Controls/src/Build.Tasks/xlf/ErrorMessages.cs.xlf
+++ b/src/Controls/src/Build.Tasks/xlf/ErrorMessages.cs.xlf
@@ -143,7 +143,7 @@
         <note />
       </trans-unit>
       <trans-unit id="StyleSheetSourceOrContent">
-        <source>StyleSheet can not have both a Source and a content.</source>
+        <source>StyleSheet cannot have both a Source and a content.</source>
         <target state="translated">Šablona stylů nemůže obsahovat jak zdroj, tak obsah.</target>
         <note />
       </trans-unit>

--- a/src/Controls/src/Build.Tasks/xlf/ErrorMessages.de.xlf
+++ b/src/Controls/src/Build.Tasks/xlf/ErrorMessages.de.xlf
@@ -143,7 +143,7 @@
         <note />
       </trans-unit>
       <trans-unit id="StyleSheetSourceOrContent">
-        <source>StyleSheet can not have both a Source and a content.</source>
+        <source>StyleSheet cannot have both a Source and a content.</source>
         <target state="translated">Das StyleSheet kann nicht gleichzeitig eine Source-Eigenschaft und einen Inhalt aufweisen.</target>
         <note />
       </trans-unit>

--- a/src/Controls/src/Build.Tasks/xlf/ErrorMessages.es.xlf
+++ b/src/Controls/src/Build.Tasks/xlf/ErrorMessages.es.xlf
@@ -143,7 +143,7 @@
         <note />
       </trans-unit>
       <trans-unit id="StyleSheetSourceOrContent">
-        <source>StyleSheet can not have both a Source and a content.</source>
+        <source>StyleSheet cannot have both a Source and a content.</source>
         <target state="translated">StyleSheet no puede tener un origen y un contenido.</target>
         <note />
       </trans-unit>

--- a/src/Controls/src/Build.Tasks/xlf/ErrorMessages.fr.xlf
+++ b/src/Controls/src/Build.Tasks/xlf/ErrorMessages.fr.xlf
@@ -143,7 +143,7 @@
         <note />
       </trans-unit>
       <trans-unit id="StyleSheetSourceOrContent">
-        <source>StyleSheet can not have both a Source and a content.</source>
+        <source>StyleSheet cannot have both a Source and a content.</source>
         <target state="translated">StyleSheet ne peut pas avoir à la fois Source et un contenu.</target>
         <note />
       </trans-unit>

--- a/src/Controls/src/Build.Tasks/xlf/ErrorMessages.it.xlf
+++ b/src/Controls/src/Build.Tasks/xlf/ErrorMessages.it.xlf
@@ -143,7 +143,7 @@
         <note />
       </trans-unit>
       <trans-unit id="StyleSheetSourceOrContent">
-        <source>StyleSheet can not have both a Source and a content.</source>
+        <source>StyleSheet cannot have both a Source and a content.</source>
         <target state="translated">Un elemento StyleSheet non può includere sia un elemento Source che contenuto.</target>
         <note />
       </trans-unit>

--- a/src/Controls/src/Build.Tasks/xlf/ErrorMessages.ja.xlf
+++ b/src/Controls/src/Build.Tasks/xlf/ErrorMessages.ja.xlf
@@ -143,7 +143,7 @@
         <note />
       </trans-unit>
       <trans-unit id="StyleSheetSourceOrContent">
-        <source>StyleSheet can not have both a Source and a content.</source>
+        <source>StyleSheet cannot have both a Source and a content.</source>
         <target state="translated">スタイルシートにソースとコンテンツの両方を含めることはできません。</target>
         <note />
       </trans-unit>

--- a/src/Controls/src/Build.Tasks/xlf/ErrorMessages.ko.xlf
+++ b/src/Controls/src/Build.Tasks/xlf/ErrorMessages.ko.xlf
@@ -143,7 +143,7 @@
         <note />
       </trans-unit>
       <trans-unit id="StyleSheetSourceOrContent">
-        <source>StyleSheet can not have both a Source and a content.</source>
+        <source>StyleSheet cannot have both a Source and a content.</source>
         <target state="translated">스타일 시트는 소스와 콘텐츠 중 하나만 포함할 수 있습니다.</target>
         <note />
       </trans-unit>

--- a/src/Controls/src/Build.Tasks/xlf/ErrorMessages.pl.xlf
+++ b/src/Controls/src/Build.Tasks/xlf/ErrorMessages.pl.xlf
@@ -143,7 +143,7 @@
         <note />
       </trans-unit>
       <trans-unit id="StyleSheetSourceOrContent">
-        <source>StyleSheet can not have both a Source and a content.</source>
+        <source>StyleSheet cannot have both a Source and a content.</source>
         <target state="translated">Arkusz stylów nie może mieć zarówno źródła, jak i zawartości.</target>
         <note />
       </trans-unit>

--- a/src/Controls/src/Build.Tasks/xlf/ErrorMessages.pt-BR.xlf
+++ b/src/Controls/src/Build.Tasks/xlf/ErrorMessages.pt-BR.xlf
@@ -143,7 +143,7 @@
         <note />
       </trans-unit>
       <trans-unit id="StyleSheetSourceOrContent">
-        <source>StyleSheet can not have both a Source and a content.</source>
+        <source>StyleSheet cannot have both a Source and a content.</source>
         <target state="translated">A StyleSheet não pode ter uma Origem e também um conteúdo.</target>
         <note />
       </trans-unit>

--- a/src/Controls/src/Build.Tasks/xlf/ErrorMessages.ru.xlf
+++ b/src/Controls/src/Build.Tasks/xlf/ErrorMessages.ru.xlf
@@ -143,7 +143,7 @@
         <note />
       </trans-unit>
       <trans-unit id="StyleSheetSourceOrContent">
-        <source>StyleSheet can not have both a Source and a content.</source>
+        <source>StyleSheet cannot have both a Source and a content.</source>
         <target state="translated">Таблица стилей (StyleSheet) не может одновременно содержать источник (Source) и содержимое.</target>
         <note />
       </trans-unit>

--- a/src/Controls/src/Build.Tasks/xlf/ErrorMessages.tr.xlf
+++ b/src/Controls/src/Build.Tasks/xlf/ErrorMessages.tr.xlf
@@ -143,7 +143,7 @@
         <note />
       </trans-unit>
       <trans-unit id="StyleSheetSourceOrContent">
-        <source>StyleSheet can not have both a Source and a content.</source>
+        <source>StyleSheet cannot have both a Source and a content.</source>
         <target state="translated">StyleSheet, hem Source hem de içerik bulunduramaz.</target>
         <note />
       </trans-unit>

--- a/src/Controls/src/Build.Tasks/xlf/ErrorMessages.zh-Hans.xlf
+++ b/src/Controls/src/Build.Tasks/xlf/ErrorMessages.zh-Hans.xlf
@@ -143,7 +143,7 @@
         <note />
       </trans-unit>
       <trans-unit id="StyleSheetSourceOrContent">
-        <source>StyleSheet can not have both a Source and a content.</source>
+        <source>StyleSheet cannot have both a Source and a content.</source>
         <target state="translated">样式表不能同时具有源和内容。</target>
         <note />
       </trans-unit>

--- a/src/Controls/src/Build.Tasks/xlf/ErrorMessages.zh-Hant.xlf
+++ b/src/Controls/src/Build.Tasks/xlf/ErrorMessages.zh-Hant.xlf
@@ -143,7 +143,7 @@
         <note />
       </trans-unit>
       <trans-unit id="StyleSheetSourceOrContent">
-        <source>StyleSheet can not have both a Source and a content.</source>
+        <source>StyleSheet cannot have both a Source and a content.</source>
         <target state="translated">樣式表不能同時有來源和內容。</target>
         <note />
       </trans-unit>

--- a/src/Controls/src/Xaml/ApplyPropertiesVisitor.cs
+++ b/src/Controls/src/Xaml/ApplyPropertiesVisitor.cs
@@ -181,7 +181,7 @@ namespace Microsoft.Maui.Controls.Xaml
 					return;
 				}
 
-				xpe = xpe ?? new XamlParseException($"Can not set the content of {((IElementNode)parentNode).XmlType.Name} as it doesn't have a ContentPropertyAttribute", node);
+				xpe = xpe ?? new XamlParseException($"Cannot set the content of {((IElementNode)parentNode).XmlType.Name} as it doesn't have a ContentPropertyAttribute", node);
 				if (Context.ExceptionHandler != null)
 					Context.ExceptionHandler(xpe);
 				else

--- a/src/Controls/src/Xaml/MarkupExtensions/ReferenceExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/ReferenceExtension.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Maui.Controls.Xaml
 					return value;
 			}
 
-			throw new XamlParseException($"Can not find the object referenced by `{Name}`", serviceProvider);
+			throw new XamlParseException($"Cannot find the object referenced by `{Name}`", serviceProvider);
 		}
 	}
 }

--- a/src/Controls/src/Xaml/MarkupExtensions/StyleSheetExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/StyleSheetExtension.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Maui.Controls.Xaml
 			IXmlLineInfo lineInfo;
 
 			if (!string.IsNullOrEmpty(Style) && Source != null)
-				throw new XamlParseException($"StyleSheet can not have both a Source and a content", serviceProvider);
+				throw new XamlParseException($"StyleSheet cannot have both a Source and a content", serviceProvider);
 
 			if (Source != null)
 			{

--- a/src/Controls/tests/Core.UnitTests/BindingUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/BindingUnitTests.cs
@@ -1532,7 +1532,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact, Category("[Binding] Complex paths")]
-		[Description("When part of a complex path can not be evaluated during an update, bindables should return to their default value.")]
+		[Description("When part of a complex path cannot be evaluated during an update, bindables should return to their default value.")]
 		public void NullInPathUsesDefaultValue()
 		{
 			var vm = new ComplexMockViewModel
@@ -1554,7 +1554,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact, Category("[Binding] Complex paths")]
-		[Description("When part of a complex path can not be evaluated during an update, bindables should return to their default value.")]
+		[Description("When part of a complex path cannot be evaluated during an update, bindables should return to their default value.")]
 		public void NullContextUsesDefaultValue()
 		{
 			var vm = new ComplexMockViewModel

--- a/src/Controls/tests/Core.UnitTests/TypedBindingUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/TypedBindingUnitTests.cs
@@ -1001,7 +1001,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact, Category("[Binding] Complex paths")]
-		[Description("When part of a complex path can not be evaluated during an update, bindables should return to their default value.")]
+		[Description("When part of a complex path cannot be evaluated during an update, bindables should return to their default value.")]
 		public void NullInPathUsesDefaultValue()
 		{
 			var vm = new ComplexMockViewModel
@@ -1028,7 +1028,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact, Category("[Binding] Complex paths")]
-		[Description("When part of a complex path can not be evaluated during an update, bindables should return to their default value.")]
+		[Description("When part of a complex path cannot be evaluated during an update, bindables should return to their default value.")]
 		public void NullContextUsesDefaultValue()
 		{
 			var vm = new ComplexMockViewModel
@@ -1059,7 +1059,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact, Category("[Binding] Complex paths")]
-		[Description("When part of a complex path can not be evaluated during an update, bindables should return to their default value, or TargetNullValue")]
+		[Description("When part of a complex path cannot be evaluated during an update, bindables should return to their default value, or TargetNullValue")]
 		public void NullContextUsesFallbackValue()
 		{
 			var vm = new ComplexMockViewModel

--- a/src/Core/src/Handlers/SwipeItemMenuItem/SwipeItemMenuItemHandler.iOS.cs
+++ b/src/Core/src/Handlers/SwipeItemMenuItem/SwipeItemMenuItemHandler.iOS.cs
@@ -127,7 +127,7 @@ namespace Microsoft.Maui.Handlers
 					catch (Exception)
 					{
 						// UIImage ctor throws on file not found if MonoTouch.ObjCRuntime.Class.ThrowOnInitFailure is true;
-						Handler.MauiContext?.CreateLogger<SwipeItemMenuItemHandler>()?.LogWarning("Can not load SwipeItem Icon");
+						Handler.MauiContext?.CreateLogger<SwipeItemMenuItemHandler>()?.LogWarning("Cannot load SwipeItem Icon");
 					}
 				}
 			}

--- a/src/Core/src/VisualDiagnostics/BootstrapHelper.cs
+++ b/src/Core/src/VisualDiagnostics/BootstrapHelper.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Maui
 	static class VisualDiagnosticsBootstrapHelper
 #endif
 	{
-		// Do not overload this method. ICLRRuntimeHost2::CreateDelegate can not resolve overloaded methods.
+		// Do not overload this method. ICLRRuntimeHost2::CreateDelegate cannot resolve overloaded methods.
 		[PreserveSig]
 		[RequiresUnreferencedCode("The assembly, type, or method may have been trimmed if it wasn't preserved another way.")]
 		private static int Bootstrap(

--- a/src/Essentials/src/Battery/Battery.shared.cs
+++ b/src/Essentials/src/Battery/Battery.shared.cs
@@ -207,7 +207,7 @@ namespace Microsoft.Maui.Devices
 	/// </summary>
 	public enum BatteryPowerSource
 	{
-		/// <summary>Power source can not be determined.</summary>
+		/// <summary>Power source cannot be determined.</summary>
 		Unknown = 0,
 
 		/// <summary>Power source is the battery and is currently not being charged.</summary>

--- a/src/Essentials/src/Platform/ActivityStateManager.android.cs
+++ b/src/Essentials/src/Platform/ActivityStateManager.android.cs
@@ -127,7 +127,7 @@ namespace Microsoft.Maui.ApplicationModel
 		{
 			var activity = manager.GetCurrentActivity();
 			if (throwOnNull && activity == null)
-				throw new NullReferenceException("The current Activity can not be detected. Ensure that you have called Init in your Activity or Application class.");
+				throw new NullReferenceException("The current Activity cannot be detected. Ensure that you have called Init in your Activity or Application class.");
 
 			return activity;
 		}

--- a/src/Essentials/src/Platform/WindowStateManager.ios.cs
+++ b/src/Essentials/src/Platform/WindowStateManager.ios.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Maui.ApplicationModel
 		{
 			var vc = manager.GetCurrentUIViewController();
 			if (throwOnNull && vc == null)
-				throw new NullReferenceException("The current view controller can not be detected.");
+				throw new NullReferenceException("The current view controller cannot be detected.");
 
 			return vc;
 		}
@@ -75,7 +75,7 @@ namespace Microsoft.Maui.ApplicationModel
 		{
 			var window = manager.GetCurrentUIWindow();
 			if (throwOnNull && window == null)
-				throw new NullReferenceException("The current window can not be detected.");
+				throw new NullReferenceException("The current window cannot be detected.");
 
 			return window;
 		}

--- a/src/Essentials/src/Platform/WindowStateManager.uwp.cs
+++ b/src/Essentials/src/Platform/WindowStateManager.uwp.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Maui.ApplicationModel
 		{
 			var window = manager.GetActiveWindow();
 			if (throwOnNull && window == null)
-				throw new NullReferenceException("The active Window can not be detected. Ensure that you have called Init in your Application class.");
+				throw new NullReferenceException("The active Window cannot be detected. Ensure that you have called Init in your Application class.");
 
 			return window;
 		}
@@ -81,7 +81,7 @@ namespace Microsoft.Maui.ApplicationModel
 		{
 			var window = manager.GetActiveWindow();
 			if (throwOnNull && window == null)
-				throw new NullReferenceException("The active Window can not be detected. Ensure that you have called Init in your Application class.");
+				throw new NullReferenceException("The active Window cannot be detected. Ensure that you have called Init in your Application class.");
 
 			if (window == null)
 				return IntPtr.Zero;
@@ -102,7 +102,7 @@ namespace Microsoft.Maui.ApplicationModel
 		{
 			var window = manager.GetActiveWindow();
 			if (throwOnNull && window == null)
-				throw new NullReferenceException("The active Window can not be detected. Ensure that you have called Init in your Application class.");
+				throw new NullReferenceException("The active Window cannot be detected. Ensure that you have called Init in your Application class.");
 
 			if (window == null)
 				return null;


### PR DESCRIPTION
Both are correct, but "cannot" is preferred and far more common: https://www.merriam-webster.com/grammar/cannot-vs-can-not-is-there-a-difference

In some cases it is a user-facing message, such as certain XAML errors: https://github.com/dotnet/maui/blob/4856f37f5b5f8e9701146f6b7b6fc27c336938a3/src/Controls/src/Xaml/MarkupExtensions/ReferenceExtension.cs#L36

And if you run into this type of error, you see it in Visual Studio. And it looks weird.

@spadapet , @jfversluis , @jonathanpeppers , @Redth - tagging all of you because you were participating in my discussion of this in a recent meeting. Very easy PR to review!

Notes:
* I'm submitting to net9 because this is ultimately minor.
* I left a few instances of `can not` in the repo because they are quoting other things like bug titles, so I left them as-is.