### PR TITLE
Ensure border stroke only updates when needed

### DIFF
--- a/src/Controls/src/Core/Border/Border.cs
+++ b/src/Controls/src/Core/Border/Border.cs
@@ -65,7 +65,14 @@ namespace Microsoft.Maui.Controls
 			if (strokeShape is VisualElement visualElement)
 			{
 				AddLogicalChild(visualElement);
-				_strokeShapeChanged ??= (sender, e) => OnPropertyChanged(nameof(StrokeShape));
+				_strokeShapeChanged ??= (sender, e) =>
+				{
+					if (e.PropertyName != nameof(Window) &&
+						e.PropertyName != nameof(Parent))
+					{
+						OnPropertyChanged(nameof(StrokeShape));
+					}
+				};
 				_strokeShapeProxy ??= new();
 				_strokeShapeProxy.Subscribe(visualElement, _strokeShapeChanged);
 			}


### PR DESCRIPTION
Ensure border stroke does not regenerate on Parent or Window property changes.

### Description of Change

Don't raise a property changed event for `StrokeShape` in the `Border` object when the `StrokeShape.Window` or `StrokeShape.Parent` property change. These properties are modified when the `Border` is added/removed from the visual tree and can cause significant performance issues for lists when they're unloaded.

Using the sample on the linked issue:
![image](https://github.com/user-attachments/assets/3ddf5463-1249-4dae-ad19-1928fe2a860b)

### Issues Fixed

Fixes #24123 
Fixes #23992