### PR TITLE
[net9.0] Fix API23 Core device tests

### DIFF
--- a/eng/devices/android.cake
+++ b/eng/devices/android.cake
@@ -234,6 +234,11 @@ void ExecuteTests(string project, string device, string appPath, string appPacka
 	}
 	finally
 	{
+		if (testsFailed)
+		{
+			// uncomment if you want to copy the test app to the results directory for any reason
+			// CopyFile(testApp, new DirectoryPath(resultsDir).CombineWithFilePath(new FilePath(testApp).GetFilename()));
+		}
 
 		HandleTestResults(resultsDir, testsFailed, false);
 	}

--- a/eng/pipelines/common/device-tests-steps.yml
+++ b/eng/pipelines/common/device-tests-steps.yml
@@ -4,7 +4,7 @@ parameters:
   device: '' # the xharness device to use
   apiversion: '' # the iOS device api version to use
   cakeArgs: '' # additional cake args
-  androidConfiguration: 'debug' # Indicates the configuration to use for Android. We're slowly enabling this for all projects
+  androidConfiguration: '' # Indicates the configuration to use for Android. We're slowly enabling this for all projects
   provisionatorChannel: 'latest'
   agentPoolAccessToken: ''
   artifactName: 'nuget'

--- a/eng/pipelines/common/device-tests-steps.yml
+++ b/eng/pipelines/common/device-tests-steps.yml
@@ -4,7 +4,7 @@ parameters:
   device: '' # the xharness device to use
   apiversion: '' # the iOS device api version to use
   cakeArgs: '' # additional cake args
-  androidConfiguration: '' # Indicates the configuration to use for Android. We're slowly enabling this for all projects
+  androidConfiguration: 'debug' # Indicates the configuration to use for Android. We're slowly enabling this for all projects
   provisionatorChannel: 'latest'
   agentPoolAccessToken: ''
   artifactName: 'nuget'

--- a/eng/pipelines/common/device-tests-steps.yml
+++ b/eng/pipelines/common/device-tests-steps.yml
@@ -88,20 +88,41 @@ steps:
       continueOnError: true
       timeoutInMinutes: 5
 
-  - pwsh: |
-      ./build.ps1 -Script eng/devices/${{ parameters.platform }}.cake --project="${{ parameters.path }}" --device=${{ parameters.device }} --apiversion=${{ parameters.apiversion }} --packageid=${{ parameters.windowsPackageId }} --results="$(TestResultsDirectory)" --binlog="$(LogDirectory)" ${{ parameters.cakeArgs }}
-    displayName: $(Agent.JobName)
-    workingDirectory: ${{ parameters.checkoutDirectory }}
-    condition: and(succeeded(), ne(variables['Platform.Name'], 'Mac'))
-    retryCountOnTaskFailure: 1
+  # Everything should be release but doing android for now to work around an xharness issue
+  - ${{ if eq(parameters.platform, 'android')}}:
+    - pwsh: |
+        ./build.ps1 -Script eng/devices/${{ parameters.platform }}.cake --project="${{ parameters.path }}" --device=${{ parameters.device }} --apiversion=${{ parameters.apiversion }} --packageid=${{ parameters.windowsPackageId }} --results="$(TestResultsDirectory)" --binlog="$(LogDirectory)" ${{ parameters.cakeArgs }} --configuration=${{ parameters.androidConfiguration }}
+      displayName: $(Agent.JobName)
+      workingDirectory: ${{ parameters.checkoutDirectory }}
+      condition: and(succeeded(), ne(variables['Platform.Name'], 'Mac'))
+      retryCountOnTaskFailure: 1
 
-  - bash: |
-      # Execute the powershell script from a bash shell on Mac to avoid interference between powershell processes that lead to this error: The STDIO streams did not close within 10 seconds of the exit event from process '/usr/local/bin/pwsh'. This may indicate a child process inherited the STDIO streams and has not yet exited.
-      pwsh ./build.ps1 -Script eng/devices/${{ parameters.platform }}.cake --project="${{ parameters.path }}" --device=${{ parameters.device }} --apiversion=${{ parameters.apiversion }} --packageid=${{ parameters.windowsPackageId }} --results="$(TestResultsDirectory)" --binlog="$(LogDirectory)" ${{ parameters.cakeArgs }}
-    displayName: $(Agent.JobName)
-    workingDirectory: ${{ parameters.checkoutDirectory }}
-    condition: and(succeeded(), eq(variables['Platform.Name'], 'Mac'))
-    retryCountOnTaskFailure: 1
+  - ${{ if eq(parameters.platform, 'android')}}:
+    - bash: |
+        # Execute the powershell script from a bash shell on Mac to avoid interference between powershell processes that lead to this error: The STDIO streams did not close within 10 seconds of the exit event from process '/usr/local/bin/pwsh'. This may indicate a child process inherited the STDIO streams and has not yet exited.
+        pwsh ./build.ps1 -Script eng/devices/${{ parameters.platform }}.cake --project="${{ parameters.path }}" --device=${{ parameters.device }} --apiversion=${{ parameters.apiversion }} --packageid=${{ parameters.windowsPackageId }} --results="$(TestResultsDirectory)" --binlog="$(LogDirectory)" ${{ parameters.cakeArgs }} --configuration=${{ parameters.androidConfiguration }}
+      displayName: $(Agent.JobName)
+      workingDirectory: ${{ parameters.checkoutDirectory }}
+      condition: and(succeeded(), eq(variables['Platform.Name'], 'Mac'))
+      retryCountOnTaskFailure: 1
+
+  - ${{ if ne(parameters.platform, 'android')}}:
+    - pwsh: |
+        ./build.ps1 -Script eng/devices/${{ parameters.platform }}.cake --project="${{ parameters.path }}" --device=${{ parameters.device }} --apiversion=${{ parameters.apiversion }} --packageid=${{ parameters.windowsPackageId }} --results="$(TestResultsDirectory)" --binlog="$(LogDirectory)" ${{ parameters.cakeArgs }}
+      displayName: $(Agent.JobName)
+      workingDirectory: ${{ parameters.checkoutDirectory }}
+      condition: and(succeeded(), ne(variables['Platform.Name'], 'Mac'))
+      retryCountOnTaskFailure: 1
+
+  - ${{ if ne(parameters.platform, 'android')}}:
+    - bash: |
+        # Execute the powershell script from a bash shell on Mac to avoid interference between powershell processes that lead to this error: The STDIO streams did not close within 10 seconds of the exit event from process '/usr/local/bin/pwsh'. This may indicate a child process inherited the STDIO streams and has not yet exited.
+        pwsh ./build.ps1 -Script eng/devices/${{ parameters.platform }}.cake --project="${{ parameters.path }}" --device=${{ parameters.device }} --apiversion=${{ parameters.apiversion }} --packageid=${{ parameters.windowsPackageId }} --results="$(TestResultsDirectory)" --binlog="$(LogDirectory)" ${{ parameters.cakeArgs }}
+      displayName: $(Agent.JobName)
+      workingDirectory: ${{ parameters.checkoutDirectory }}
+      condition: and(succeeded(), eq(variables['Platform.Name'], 'Mac'))
+      retryCountOnTaskFailure: 1
+  # Everything should be release but doing android for now to work around an xharness issue
 
   - ${{ if eq(parameters.platform, 'ios')}}:
     - bash: |

--- a/eng/pipelines/common/device-tests-steps.yml
+++ b/eng/pipelines/common/device-tests-steps.yml
@@ -4,6 +4,7 @@ parameters:
   device: '' # the xharness device to use
   apiversion: '' # the iOS device api version to use
   cakeArgs: '' # additional cake args
+  androidConfiguration: '' # Indicates the configuration to use for Android. We're slowly enabling this for all projects
   provisionatorChannel: 'latest'
   agentPoolAccessToken: ''
   artifactName: 'nuget'

--- a/eng/pipelines/common/device-tests.yml
+++ b/eng/pipelines/common/device-tests.yml
@@ -12,6 +12,7 @@ parameters:
   artifactName: 'nuget'
   artifactItemPattern: '**/*.nupkg'
   checkoutDirectory: $(System.DefaultWorkingDirectory)
+  androidConfiguration: 'debug' # Indicates the configuration to use for Android. We're slowly enabling this for all projects
   useArtifacts: false
   targetFrameworkVersion:
     - tfm: ''

--- a/eng/pipelines/common/device-tests.yml
+++ b/eng/pipelines/common/device-tests.yml
@@ -49,6 +49,7 @@ stages:
                   ${{ replace(coalesce(project.desc, project.name), ' ', '_') }}_API_${{ api }}:
                     REQUIRED_XCODE: $(DEVICETESTS_REQUIRED_XCODE)
                     PROJECT_PATH: ${{ project.android }}
+                    ANDROID_CONFIGURATION: ${{ project.androidConfiguration }}
                     TARGET_FRAMEWORK_VERSION: ${{ parameters.targetFrameworkVersion.tfm }}
                     ${{ if eq(api, 27) }}:
                       DEVICE: android-emulator-32_${{ api }}
@@ -71,7 +72,7 @@ stages:
             checkoutDirectory: ${{ parameters.checkoutDirectory }}
             useArtifacts: ${{ parameters.useArtifacts }}
             poolName: ${{ parameters.androidPool.name }}
-            androidConfiguration: ${{ parameters.androidConfiguration }}
+            androidConfiguration: $(ANDROID_CONFIGURATION)
 
   - stage: ios_device_tests_${{ replace(parameters.targetFrameworkVersion.tfm, '.', '') }}
     displayName: ${{ parameters.targetFrameworkVersion.tfm }} iOS Device Tests

--- a/eng/pipelines/common/device-tests.yml
+++ b/eng/pipelines/common/device-tests.yml
@@ -70,6 +70,7 @@ stages:
             checkoutDirectory: ${{ parameters.checkoutDirectory }}
             useArtifacts: ${{ parameters.useArtifacts }}
             poolName: ${{ parameters.androidPool.name }}
+            androidConfiguration: ${{ parameters.androidConfiguration }}
 
   - stage: ios_device_tests_${{ replace(parameters.targetFrameworkVersion.tfm, '.', '') }}
     displayName: ${{ parameters.targetFrameworkVersion.tfm }} iOS Device Tests

--- a/eng/pipelines/device-tests.yml
+++ b/eng/pipelines/device-tests.yml
@@ -117,7 +117,7 @@ stages:
         windowsVersions: ['packaged', 'unpackaged']
         provisionatorChannel: ${{ parameters.provisionatorChannel }}
       ${{ else }}:
-        androidApiLevels: [ 33 ]
+        androidApiLevels: [ 33, 23 ]
         iosVersions: [ 'simulator-17.2' ]
         catalystVersions: [ 'latest' ]
         windowsVersions: ['packaged', 'unpackaged']
@@ -126,6 +126,7 @@ stages:
         - name: essentials
           desc: Essentials
           androidApiLevelsExclude: [25] # Ignore for now API25 since the runs's are not stable
+          androidConfiguration: 'Release'
           windowsPackageId: 'com.microsoft.maui.essentials.devicetests'
           android: $(System.DefaultWorkingDirectory)/src/Essentials/test/DeviceTests/Essentials.DeviceTests.csproj
           ios: $(System.DefaultWorkingDirectory)/src/Essentials/test/DeviceTests/Essentials.DeviceTests.csproj
@@ -134,6 +135,7 @@ stages:
         - name: graphics
           desc: Graphics
           androidApiLevelsExclude: [25] # Ignore for now API25 since the runs's are not stable
+          androidConfiguration: 'Release'
           windowsPackageId: 'com.microsoft.maui.graphics.devicetests'
           android: $(System.DefaultWorkingDirectory)/src/Graphics/tests/DeviceTests/Graphics.DeviceTests.csproj
           ios: $(System.DefaultWorkingDirectory)/src/Graphics/tests/DeviceTests/Graphics.DeviceTests.csproj
@@ -142,6 +144,7 @@ stages:
         - name: core
           desc: Core
           androidApiLevelsExclude: [25] # Ignore for now API25 since the runs's are not stable
+          androidConfiguration: 'Release'
           windowsPackageId: 'com.microsoft.maui.core.devicetests'
           android: $(System.DefaultWorkingDirectory)/src/Core/tests/DeviceTests/Core.DeviceTests.csproj
           ios: $(System.DefaultWorkingDirectory)/src/Core/tests/DeviceTests/Core.DeviceTests.csproj
@@ -150,6 +153,7 @@ stages:
         - name: controls
           desc: Controls
           androidApiLevelsExclude: [27, 25] # Ignore for now API25 since the runs's are not stable
+          androidConfiguration: 'Debug'
           windowsPackageId: 'com.microsoft.maui.controls.devicetests'
           android: $(System.DefaultWorkingDirectory)/src/Controls/tests/DeviceTests/Controls.DeviceTests.csproj
           ios: $(System.DefaultWorkingDirectory)/src/Controls/tests/DeviceTests/Controls.DeviceTests.csproj
@@ -158,6 +162,7 @@ stages:
         - name: blazorwebview
           desc: BlazorWebView
           androidApiLevelsExclude: [ 30, 29, 28, 27, 26, 25, 24, 23, 22, 21 ] # BlazorWebView requires a recent version of Chrome
+          androidConfiguration: 'Release'
           windowsPackageId: 'Microsoft.Maui.MauiBlazorWebView.DeviceTests'
           android: $(System.DefaultWorkingDirectory)/src/BlazorWebView/tests/MauiDeviceTests/MauiBlazorWebView.DeviceTests.csproj
           ios: $(System.DefaultWorkingDirectory)/src/BlazorWebView/tests/MauiDeviceTests/MauiBlazorWebView.DeviceTests.csproj

--- a/src/Core/tests/DeviceTests/Core.DeviceTests.csproj
+++ b/src/Core/tests/DeviceTests/Core.DeviceTests.csproj
@@ -42,6 +42,11 @@
     <MauiAsset Include="Resources\Raw\**" LogicalName="%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
 
+  
+  <PropertyGroup>
+    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
+  </PropertyGroup>
+  
   <ItemGroup>
     <ProjectReference Include="..\..\..\TestUtils\src\DeviceTests\TestUtils.DeviceTests.csproj" />
     <ProjectReference Include="..\..\..\TestUtils\src\DeviceTests.Runners\TestUtils.DeviceTests.Runners.csproj" />

--- a/src/Core/tests/DeviceTests/Services/ImageSource/StreamImageSourceServiceTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Services/ImageSource/StreamImageSourceServiceTests.Android.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Maui.DeviceTests
 			await Assert.ThrowsAsync<InvalidCastException>(() => service.GetDrawableAsync(imageSource, MauiProgram.DefaultContext));
 		}
 
+#if DEBUG
 		[Theory]
 		[InlineData("#FF0000")]
 		[InlineData("#00FF00")]
@@ -44,5 +45,6 @@ namespace Microsoft.Maui.DeviceTests
 
 			bitmap.AssertColorAtCenter(expectedColor);
 		}
+#endif
 	}
 }


### PR DESCRIPTION
### Description of Change

- It looks like for some unknown reason XHarness is unable to find the Maui Instrumentation class on our Core.Devices.csproj. I worked with @jonathanpeppers on this for a little bit and we couldn't really figure out why. It looks like if we build the device tests using a release configuration vs debug then XHarness is able to find everything. We should be doing this anyway, so that's the fix I'm going for here

- I've left our `Controls.DeviceTests` as debug for now because they are locking up/freezing for some unknown reason when running.  https://github.com/dotnet/maui/issues/24337

- I've disabled some `StreamImageSource` tests when compiled for `Release` because for some reason these are failing when in release mode.  https://github.com/dotnet/maui/issues/24338