### PR TITLE
Add xUnit types to avoid first-chance exceptions in tests

### DIFF
--- a/src/TestUtils/src/DeviceTests/TestUtils.DeviceTests.csproj
+++ b/src/TestUtils/src/DeviceTests/TestUtils.DeviceTests.csproj
@@ -12,6 +12,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\TestShared\xUnitSharedAttributes.cs" Link="xUnitSharedAttributes.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="xunit" Version="$(XunitPackageVersion)" />
     <PackageReference Include="xunit.assert" Version="$(XunitAssertPackageVersion)" />
     <PackageReference Include="xunit.runner.utility" Version="$(XunitPackageVersion)" />

--- a/src/TestUtils/src/DeviceTests/xUnitCustomizations.cs
+++ b/src/TestUtils/src/DeviceTests/xUnitCustomizations.cs
@@ -1,146 +1,22 @@
 ﻿#nullable enable
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
-using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
-using Xunit;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
 namespace Microsoft.Maui
 {
-	public class InlineDataDiscoverer : Xunit.Sdk.InlineDataDiscoverer
-	{
-		public InlineDataDiscoverer(IMessageSink diagnosticMessageSink)
-		{
-		}
-	}
-
 	/// <summary>
-	/// Provides a data source for a data theory, with the data coming from inline values.
+	/// This type provides the assembly name for the xUnit attributes specified in
+	/// the linked TestShared\xUnitSharedAttributes.cs file.
 	/// </summary>
-	[DataDiscoverer("Microsoft.Maui.InlineDataDiscoverer", "Microsoft.Maui.TestUtils.DeviceTests")]
-	[AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
-	public sealed class InlineDataAttribute : DataAttribute
+	internal static class XUnitTypeData
 	{
-		readonly object[] data;
-
-		/// <summary>
-		/// Initializes a new instance of the <see cref="InlineDataAttribute"/> class.
-		/// </summary>
-		/// <param name="data">The data values to pass to the theory.</param>
-		public InlineDataAttribute(params object[] data)
-		{
-			this.data = data;
-		}
-
-		/// <inheritdoc/>
-		public override IEnumerable<object[]> GetData(MethodInfo testMethod)
-		{
-			// This is called by the WPA81 version as it does not have access to attribute ctor params
-			return new[] { data };
-		}
-	}
-
-	public class ClassDataDiscoverer : DataDiscoverer
-	{
-		public ClassDataDiscoverer(IMessageSink diagnosticMessageSink)
-		{
-		}
-	}
-
-	/// <summary>
-	/// Provides a data source for a data theory, with the data coming from a class
-	/// which must implement IEnumerable&lt;object[]&gt;.
-	/// Caution: the property is completely enumerated by .ToList() before any test is run. Hence it should return independent object sets.
-	/// </summary>
-	[AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
-	[DataDiscoverer("Microsoft.Maui.ClassDataDiscoverer", "Microsoft.Maui.TestUtils.DeviceTests")]
-	public class ClassDataAttribute : DataAttribute
-	{
-		/// <summary>
-		/// Initializes a new instance of the <see cref="ClassDataAttribute"/> class.
-		/// </summary>
-		/// <param name="class">The class that provides the data.</param>
-		public ClassDataAttribute(Type @class)
-		{
-			Class = @class;
-		}
-
-		/// <summary>
-		/// Gets the type of the class that provides the data.
-		/// </summary>
-		public Type Class { get; private set; }
-
-		/// <inheritdoc/>
-		public override IEnumerable<object[]> GetData(MethodInfo testMethod)
-		{
-			IEnumerable<object[]>? data = Activator.CreateInstance(Class) as IEnumerable<object[]>;
-			if (data == null)
-				throw new ArgumentException(
-					string.Format(
-						CultureInfo.CurrentCulture,
-						"{0} must implement IEnumerable<object[]> to be used as ClassData for the test method named '{1}' on {2}",
-						Class.FullName,
-						testMethod.Name,
-						testMethod.DeclaringType!.FullName
-					)
-				);
-
-			return data;
-		}
-	}
-
-	public class MemberDataDiscoverer : DataDiscoverer
-	{
-		public MemberDataDiscoverer(IMessageSink diagnosticMessageSink)
-		{
-		}
-	}
-
-	/// <summary>
-	/// Provides a data source for a data theory, with the data coming from one of the following sources:
-	/// 1. A static property
-	/// 2. A static field
-	/// 3. A static method (with parameters)
-	/// The member must return something compatible with IEnumerable&lt;object[]&gt; with the test data.
-	/// Caution: the property is completely enumerated by .ToList() before any test is run. Hence it should return independent object sets.
-	/// </summary>
-	[DataDiscoverer("Microsoft.Maui.MemberDataDiscoverer", "Microsoft.Maui.TestUtils.DeviceTests")]
-	[AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
-	public sealed class MemberDataAttribute : MemberDataAttributeBase
-	{
-		/// <summary>
-		/// Initializes a new instance of the <see cref="MemberDataAttribute"/> class.
-		/// </summary>
-		/// <param name="memberName">The name of the public static member on the test class that will provide the test data</param>
-		/// <param name="parameters">The parameters for the member (only supported for methods; ignored for everything else)</param>
-		public MemberDataAttribute(string memberName, params object[] parameters)
-			: base(memberName, parameters) { }
-
-		/// <inheritdoc/>
-		protected override object[] ConvertDataItem(MethodInfo testMethod, object item)
-		{
-			if (item == null)
-				return null!;
-
-			var array = item as object[];
-			if (array == null)
-				throw new ArgumentException(
-					string.Format(
-						CultureInfo.CurrentCulture,
-						"Property {0} on {1} yielded an item that is not an object[]",
-						MemberName,
-						MemberType ?? testMethod.DeclaringType
-					)
-				);
-
-			return array;
-		}
+		internal const string XUnitAttributeAssembly = "Microsoft.Maui.TestUtils.DeviceTests";
 	}
 
 	/// <summary>
@@ -211,7 +87,7 @@ namespace Microsoft.Maui
 	}
 
 	/// <summary>
-	/// Conveninence attribute for setting a Category trait on a test or test class
+	/// Convenience attribute for setting a Category trait on a test or test class
 	/// </summary>
 	[TraitDiscoverer("Microsoft.Maui.CategoryDiscoverer", "Microsoft.Maui.TestUtils.DeviceTests")]
 	[AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = true)]

--- a/src/TestUtils/src/DeviceTests/xUnitCustomizations.cs
+++ b/src/TestUtils/src/DeviceTests/xUnitCustomizations.cs
@@ -1,21 +1,158 @@
 ﻿#nullable enable
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
+using Xunit;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
 namespace Microsoft.Maui
 {
+	public class InlineDataDiscoverer : Xunit.Sdk.InlineDataDiscoverer
+	{
+		public InlineDataDiscoverer(IMessageSink diagnosticMessageSink)
+		{
+		}
+	}
+
+	/// <summary>
+	/// Provides a data source for a data theory, with the data coming from inline values.
+	/// </summary>
+	[DataDiscoverer("Microsoft.Maui.InlineDataDiscoverer", "Microsoft.Maui.TestUtils.DeviceTests")]
+	[AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+	public sealed class InlineDataAttribute : DataAttribute
+	{
+		readonly object[] data;
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="InlineDataAttribute"/> class.
+		/// </summary>
+		/// <param name="data">The data values to pass to the theory.</param>
+		public InlineDataAttribute(params object[] data)
+		{
+			this.data = data;
+		}
+
+		/// <inheritdoc/>
+		public override IEnumerable<object[]> GetData(MethodInfo testMethod)
+		{
+			// This is called by the WPA81 version as it does not have access to attribute ctor params
+			return new[] { data };
+		}
+	}
+
+	public class ClassDataDiscoverer : DataDiscoverer
+	{
+		public ClassDataDiscoverer(IMessageSink diagnosticMessageSink)
+		{
+		}
+	}
+
+	/// <summary>
+	/// Provides a data source for a data theory, with the data coming from a class
+	/// which must implement IEnumerable&lt;object[]&gt;.
+	/// Caution: the property is completely enumerated by .ToList() before any test is run. Hence it should return independent object sets.
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
+	[DataDiscoverer("Microsoft.Maui.ClassDataDiscoverer", "Microsoft.Maui.TestUtils.DeviceTests")]
+	public class ClassDataAttribute : DataAttribute
+	{
+		/// <summary>
+		/// Initializes a new instance of the <see cref="ClassDataAttribute"/> class.
+		/// </summary>
+		/// <param name="class">The class that provides the data.</param>
+		public ClassDataAttribute(Type @class)
+		{
+			Class = @class;
+		}
+
+		/// <summary>
+		/// Gets the type of the class that provides the data.
+		/// </summary>
+		public Type Class { get; private set; }
+
+		/// <inheritdoc/>
+		public override IEnumerable<object[]> GetData(MethodInfo testMethod)
+		{
+			IEnumerable<object[]>? data = Activator.CreateInstance(Class) as IEnumerable<object[]>;
+			if (data == null)
+				throw new ArgumentException(
+					string.Format(
+						CultureInfo.CurrentCulture,
+						"{0} must implement IEnumerable<object[]> to be used as ClassData for the test method named '{1}' on {2}",
+						Class.FullName,
+						testMethod.Name,
+						testMethod.DeclaringType!.FullName
+					)
+				);
+
+			return data;
+		}
+	}
+
+	public class MemberDataDiscoverer : DataDiscoverer
+	{
+		public MemberDataDiscoverer(IMessageSink diagnosticMessageSink)
+		{
+		}
+	}
+
+	/// <summary>
+	/// Provides a data source for a data theory, with the data coming from one of the following sources:
+	/// 1. A static property
+	/// 2. A static field
+	/// 3. A static method (with parameters)
+	/// The member must return something compatible with IEnumerable&lt;object[]&gt; with the test data.
+	/// Caution: the property is completely enumerated by .ToList() before any test is run. Hence it should return independent object sets.
+	/// </summary>
+	[DataDiscoverer("Microsoft.Maui.MemberDataDiscoverer", "Microsoft.Maui.TestUtils.DeviceTests")]
+	[AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
+	public sealed class MemberDataAttribute : MemberDataAttributeBase
+	{
+		/// <summary>
+		/// Initializes a new instance of the <see cref="MemberDataAttribute"/> class.
+		/// </summary>
+		/// <param name="memberName">The name of the public static member on the test class that will provide the test data</param>
+		/// <param name="parameters">The parameters for the member (only supported for methods; ignored for everything else)</param>
+		public MemberDataAttribute(string memberName, params object[] parameters)
+			: base(memberName, parameters) { }
+
+		/// <inheritdoc/>
+		protected override object[] ConvertDataItem(MethodInfo testMethod, object item)
+		{
+			if (item == null)
+				return null!;
+
+			var array = item as object[];
+			if (array == null)
+				throw new ArgumentException(
+					string.Format(
+						CultureInfo.CurrentCulture,
+						"Property {0} on {1} yielded an item that is not an object[]",
+						MemberName,
+						MemberType ?? testMethod.DeclaringType
+					)
+				);
+
+			return array;
+		}
+	}
+
 	/// <summary>
 	/// Custom trait discoverer which adds a Category trait for filtering, etc.
 	/// </summary>
 	public class CategoryDiscoverer : ITraitDiscoverer
 	{
 		public const string Category = "Category";
+
+		public CategoryDiscoverer(IMessageSink diagnosticMessageSink)
+		{
+		}
 
 		public IEnumerable<KeyValuePair<string, string>> GetTraits(IAttributeInfo traitAttribute)
 		{

--- a/src/TestUtils/src/TestShared/xUnitSharedAttributes.cs
+++ b/src/TestUtils/src/TestShared/xUnitSharedAttributes.cs
@@ -1,0 +1,150 @@
+﻿#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Reflection;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+// This file contains xUnit test attributes used in the TestUtils and TestUtils.DeviceTests projects.
+// They are copies of the built-in xUnit attributes, but contain extra code to avoid first-chance
+// exceptions that would otherwise occur when the tests begin. The exception they prevent is a Reflection
+// exception due to the built-in xUnit attributes not having a constructor that takes an IMessageSink.
+
+// Because all the tests in .NET MAUI are in sub-namespaces of Microsoft.Maui, these custom xUnit attributes
+// are picked up instead of the built-in xUnit attributes that have the same name.
+
+namespace Microsoft.Maui
+{
+	/// <inheritdoc/>
+	public class InlineDataDiscoverer : Xunit.Sdk.InlineDataDiscoverer
+	{
+		public InlineDataDiscoverer(IMessageSink diagnosticMessageSink)
+		{
+		}
+	}
+
+	/// <summary>
+	/// Provides a data source for a data theory, with the data coming from inline values.
+	/// </summary>
+	[DataDiscoverer("Microsoft.Maui.InlineDataDiscoverer", XUnitTypeData.XUnitAttributeAssembly)]
+	[AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+	public sealed class InlineDataAttribute : DataAttribute
+	{
+		readonly object[] data;
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="InlineDataAttribute"/> class.
+		/// </summary>
+		/// <param name="data">The data values to pass to the theory.</param>
+		public InlineDataAttribute(params object[] data)
+		{
+			this.data = data;
+		}
+
+		/// <inheritdoc/>
+		public override IEnumerable<object[]> GetData(MethodInfo testMethod)
+		{
+			// This is called by the WPA81 version as it does not have access to attribute ctor params
+			return new[] { data };
+		}
+	}
+
+	public class ClassDataDiscoverer : DataDiscoverer
+	{
+		public ClassDataDiscoverer(IMessageSink diagnosticMessageSink)
+		{
+		}
+	}
+
+	/// <summary>
+	/// Provides a data source for a data theory, with the data coming from a class
+	/// which must implement IEnumerable&lt;object[]&gt;.
+	/// Caution: the property is completely enumerated by .ToList() before any test is run. Hence it should return independent object sets.
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
+	[DataDiscoverer("Microsoft.Maui.ClassDataDiscoverer", XUnitTypeData.XUnitAttributeAssembly)]
+	public class ClassDataAttribute : DataAttribute
+	{
+		/// <summary>
+		/// Initializes a new instance of the <see cref="ClassDataAttribute"/> class.
+		/// </summary>
+		/// <param name="class">The class that provides the data.</param>
+		public ClassDataAttribute(Type @class)
+		{
+			Class = @class;
+		}
+
+		/// <summary>
+		/// Gets the type of the class that provides the data.
+		/// </summary>
+		public Type Class { get; private set; }
+
+		/// <inheritdoc/>
+		public override IEnumerable<object[]> GetData(MethodInfo testMethod)
+		{
+			IEnumerable<object[]>? data = Activator.CreateInstance(Class) as IEnumerable<object[]>;
+			if (data == null)
+				throw new ArgumentException(
+					string.Format(
+						CultureInfo.CurrentCulture,
+						"{0} must implement IEnumerable<object[]> to be used as ClassData for the test method named '{1}' on {2}",
+						Class.FullName,
+						testMethod.Name,
+						testMethod.DeclaringType!.FullName
+					)
+				);
+
+			return data;
+		}
+	}
+
+	public class MemberDataDiscoverer : DataDiscoverer
+	{
+		public MemberDataDiscoverer(IMessageSink diagnosticMessageSink)
+		{
+		}
+	}
+
+	/// <summary>
+	/// Provides a data source for a data theory, with the data coming from one of the following sources:
+	/// 1. A static property
+	/// 2. A static field
+	/// 3. A static method (with parameters)
+	/// The member must return something compatible with IEnumerable&lt;object[]&gt; with the test data.
+	/// Caution: the property is completely enumerated by .ToList() before any test is run. Hence it should return independent object sets.
+	/// </summary>
+	[DataDiscoverer("Microsoft.Maui.MemberDataDiscoverer", XUnitTypeData.XUnitAttributeAssembly)]
+	[AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
+	public sealed class MemberDataAttribute : MemberDataAttributeBase
+	{
+		/// <summary>
+		/// Initializes a new instance of the <see cref="MemberDataAttribute"/> class.
+		/// </summary>
+		/// <param name="memberName">The name of the public static member on the test class that will provide the test data</param>
+		/// <param name="parameters">The parameters for the member (only supported for methods; ignored for everything else)</param>
+		public MemberDataAttribute(string memberName, params object[] parameters)
+			: base(memberName, parameters) { }
+
+		/// <inheritdoc/>
+		protected override object[] ConvertDataItem(MethodInfo testMethod, object item)
+		{
+			if (item == null)
+				return null!;
+
+			var array = item as object[];
+			if (array == null)
+				throw new ArgumentException(
+					string.Format(
+						CultureInfo.CurrentCulture,
+						"Property {0} on {1} yielded an item that is not an object[]",
+						MemberName,
+						MemberType ?? testMethod.DeclaringType
+					)
+				);
+
+			return array;
+		}
+	}
+}

--- a/src/TestUtils/src/TestUtils/TestUtils.csproj
+++ b/src/TestUtils/src/TestUtils/TestUtils.csproj
@@ -11,7 +11,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit" Version="$(XunitPackageVersion)"/>
+    <Compile Include="..\TestShared\xUnitSharedAttributes.cs" Link="xUnitSharedAttributes.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="xunit" Version="$(XunitPackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/TestUtils/src/TestUtils/xUnitCustomizations.cs
+++ b/src/TestUtils/src/TestUtils/xUnitCustomizations.cs
@@ -1,143 +1,19 @@
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
-using System.Reflection;
 using System.Runtime.CompilerServices;
-using Xunit;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
 namespace Microsoft.Maui
 {
-	public class InlineDataDiscoverer : Xunit.Sdk.InlineDataDiscoverer
-	{
-		public InlineDataDiscoverer(IMessageSink diagnosticMessageSink)
-		{
-		}
-	}
-
 	/// <summary>
-	/// Provides a data source for a data theory, with the data coming from inline values.
+	/// This type provides the assembly name for the xUnit attributes specified in
+	/// the linked TestShared\xUnitSharedAttributes.cs file.
 	/// </summary>
-	[DataDiscoverer("Microsoft.Maui.InlineDataDiscoverer", "Microsoft.Maui.TestUtils")]
-	[AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
-	public sealed class InlineDataAttribute : DataAttribute
+	internal static class XUnitTypeData
 	{
-		readonly object[] data;
-
-		/// <summary>
-		/// Initializes a new instance of the <see cref="InlineDataAttribute"/> class.
-		/// </summary>
-		/// <param name="data">The data values to pass to the theory.</param>
-		public InlineDataAttribute(params object[] data)
-		{
-			this.data = data;
-		}
-
-		/// <inheritdoc/>
-		public override IEnumerable<object[]> GetData(MethodInfo testMethod)
-		{
-			// This is called by the WPA81 version as it does not have access to attribute ctor params
-			return new[] { data };
-		}
-	}
-
-	public class ClassDataDiscoverer : DataDiscoverer
-	{
-		public ClassDataDiscoverer(IMessageSink diagnosticMessageSink)
-		{
-		}
-	}
-
-	/// <summary>
-	/// Provides a data source for a data theory, with the data coming from a class
-	/// which must implement IEnumerable&lt;object[]&gt;.
-	/// Caution: the property is completely enumerated by .ToList() before any test is run. Hence it should return independent object sets.
-	/// </summary>
-	[AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
-	[DataDiscoverer("Microsoft.Maui.ClassDataDiscoverer", "Microsoft.Maui.TestUtils")]
-	public class ClassDataAttribute : DataAttribute
-	{
-		/// <summary>
-		/// Initializes a new instance of the <see cref="ClassDataAttribute"/> class.
-		/// </summary>
-		/// <param name="class">The class that provides the data.</param>
-		public ClassDataAttribute(Type @class)
-		{
-			Class = @class;
-		}
-
-		/// <summary>
-		/// Gets the type of the class that provides the data.
-		/// </summary>
-		public Type Class { get; private set; }
-
-		/// <inheritdoc/>
-		public override IEnumerable<object[]> GetData(MethodInfo testMethod)
-		{
-			IEnumerable<object[]> data = Activator.CreateInstance(Class) as IEnumerable<object[]>;
-			if (data == null)
-				throw new ArgumentException(
-					string.Format(
-						CultureInfo.CurrentCulture,
-						"{0} must implement IEnumerable<object[]> to be used as ClassData for the test method named '{1}' on {2}",
-						Class.FullName,
-						testMethod.Name,
-						testMethod.DeclaringType!.FullName
-					)
-				);
-
-			return data;
-		}
-	}
-
-	public class MemberDataDiscoverer : DataDiscoverer
-	{
-		public MemberDataDiscoverer(IMessageSink diagnosticMessageSink)
-		{
-		}
-	}
-
-	/// <summary>
-	/// Provides a data source for a data theory, with the data coming from one of the following sources:
-	/// 1. A static property
-	/// 2. A static field
-	/// 3. A static method (with parameters)
-	/// The member must return something compatible with IEnumerable&lt;object[]&gt; with the test data.
-	/// Caution: the property is completely enumerated by .ToList() before any test is run. Hence it should return independent object sets.
-	/// </summary>
-	[DataDiscoverer("Microsoft.Maui.MemberDataDiscoverer", "Microsoft.Maui.TestUtils")]
-	[AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
-	public sealed class MemberDataAttribute : MemberDataAttributeBase
-	{
-		/// <summary>
-		/// Initializes a new instance of the <see cref="MemberDataAttribute"/> class.
-		/// </summary>
-		/// <param name="memberName">The name of the public static member on the test class that will provide the test data</param>
-		/// <param name="parameters">The parameters for the member (only supported for methods; ignored for everything else)</param>
-		public MemberDataAttribute(string memberName, params object[] parameters)
-			: base(memberName, parameters) { }
-
-		/// <inheritdoc/>
-		protected override object[] ConvertDataItem(MethodInfo testMethod, object item)
-		{
-			if (item == null)
-				return null!;
-
-			var array = item as object[];
-			if (array == null)
-				throw new ArgumentException(
-					string.Format(
-						CultureInfo.CurrentCulture,
-						"Property {0} on {1} yielded an item that is not an object[]",
-						MemberName,
-						MemberType ?? testMethod.DeclaringType
-					)
-				);
-
-			return array;
-		}
+		internal const string XUnitAttributeAssembly = "Microsoft.Maui.TestUtils";
 	}
 
 	public class CategoryDiscoverer : ITraitDiscoverer
@@ -161,7 +37,7 @@ namespace Microsoft.Maui
 	}
 
 	/// <summary>
-	/// Conveninence attribute for setting a Category trait on a test or test class
+	/// Convenience attribute for setting a Category trait on a test or test class
 	/// </summary>
 	[TraitDiscoverer("Microsoft.Maui.CategoryDiscoverer", "Microsoft.Maui.TestUtils")]
 	[AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = true)]

--- a/src/TestUtils/src/TestUtils/xUnitCustomizations.cs
+++ b/src/TestUtils/src/TestUtils/xUnitCustomizations.cs
@@ -1,14 +1,151 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
+using System.Reflection;
 using System.Runtime.CompilerServices;
+using Xunit;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
 namespace Microsoft.Maui
 {
+	public class InlineDataDiscoverer : Xunit.Sdk.InlineDataDiscoverer
+	{
+		public InlineDataDiscoverer(IMessageSink diagnosticMessageSink)
+		{
+		}
+	}
+
+	/// <summary>
+	/// Provides a data source for a data theory, with the data coming from inline values.
+	/// </summary>
+	[DataDiscoverer("Microsoft.Maui.InlineDataDiscoverer", "Microsoft.Maui.TestUtils.DeviceTests")]
+	[AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+	public sealed class InlineDataAttribute : DataAttribute
+	{
+		readonly object[] data;
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="InlineDataAttribute"/> class.
+		/// </summary>
+		/// <param name="data">The data values to pass to the theory.</param>
+		public InlineDataAttribute(params object[] data)
+		{
+			this.data = data;
+		}
+
+		/// <inheritdoc/>
+		public override IEnumerable<object[]> GetData(MethodInfo testMethod)
+		{
+			// This is called by the WPA81 version as it does not have access to attribute ctor params
+			return new[] { data };
+		}
+	}
+
+	public class ClassDataDiscoverer : DataDiscoverer
+	{
+		public ClassDataDiscoverer(IMessageSink diagnosticMessageSink)
+		{
+		}
+	}
+
+	/// <summary>
+	/// Provides a data source for a data theory, with the data coming from a class
+	/// which must implement IEnumerable&lt;object[]&gt;.
+	/// Caution: the property is completely enumerated by .ToList() before any test is run. Hence it should return independent object sets.
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
+	[DataDiscoverer("Microsoft.Maui.ClassDataDiscoverer", "Microsoft.Maui.TestUtils.DeviceTests")]
+	public class ClassDataAttribute : DataAttribute
+	{
+		/// <summary>
+		/// Initializes a new instance of the <see cref="ClassDataAttribute"/> class.
+		/// </summary>
+		/// <param name="class">The class that provides the data.</param>
+		public ClassDataAttribute(Type @class)
+		{
+			Class = @class;
+		}
+
+		/// <summary>
+		/// Gets the type of the class that provides the data.
+		/// </summary>
+		public Type Class { get; private set; }
+
+		/// <inheritdoc/>
+		public override IEnumerable<object[]> GetData(MethodInfo testMethod)
+		{
+			IEnumerable<object[]> data = Activator.CreateInstance(Class) as IEnumerable<object[]>;
+			if (data == null)
+				throw new ArgumentException(
+					string.Format(
+						CultureInfo.CurrentCulture,
+						"{0} must implement IEnumerable<object[]> to be used as ClassData for the test method named '{1}' on {2}",
+						Class.FullName,
+						testMethod.Name,
+						testMethod.DeclaringType!.FullName
+					)
+				);
+
+			return data;
+		}
+	}
+
+	public class MemberDataDiscoverer : DataDiscoverer
+	{
+		public MemberDataDiscoverer(IMessageSink diagnosticMessageSink)
+		{
+		}
+	}
+
+	/// <summary>
+	/// Provides a data source for a data theory, with the data coming from one of the following sources:
+	/// 1. A static property
+	/// 2. A static field
+	/// 3. A static method (with parameters)
+	/// The member must return something compatible with IEnumerable&lt;object[]&gt; with the test data.
+	/// Caution: the property is completely enumerated by .ToList() before any test is run. Hence it should return independent object sets.
+	/// </summary>
+	[DataDiscoverer("Microsoft.Maui.MemberDataDiscoverer", "Microsoft.Maui.TestUtils.DeviceTests")]
+	[AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
+	public sealed class MemberDataAttribute : MemberDataAttributeBase
+	{
+		/// <summary>
+		/// Initializes a new instance of the <see cref="MemberDataAttribute"/> class.
+		/// </summary>
+		/// <param name="memberName">The name of the public static member on the test class that will provide the test data</param>
+		/// <param name="parameters">The parameters for the member (only supported for methods; ignored for everything else)</param>
+		public MemberDataAttribute(string memberName, params object[] parameters)
+			: base(memberName, parameters) { }
+
+		/// <inheritdoc/>
+		protected override object[] ConvertDataItem(MethodInfo testMethod, object item)
+		{
+			if (item == null)
+				return null!;
+
+			var array = item as object[];
+			if (array == null)
+				throw new ArgumentException(
+					string.Format(
+						CultureInfo.CurrentCulture,
+						"Property {0} on {1} yielded an item that is not an object[]",
+						MemberName,
+						MemberType ?? testMethod.DeclaringType
+					)
+				);
+
+			return array;
+		}
+	}
+
 	public class CategoryDiscoverer : ITraitDiscoverer
 	{
+		public CategoryDiscoverer(IMessageSink diagnosticMessageSink)
+		{
+		}
+
 		public IEnumerable<KeyValuePair<string, string>> GetTraits(IAttributeInfo traitAttribute)
 		{
 			var args = traitAttribute.GetConstructorArguments().ToList();

--- a/src/TestUtils/src/TestUtils/xUnitCustomizations.cs
+++ b/src/TestUtils/src/TestUtils/xUnitCustomizations.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Maui
 	/// <summary>
 	/// Provides a data source for a data theory, with the data coming from inline values.
 	/// </summary>
-	[DataDiscoverer("Microsoft.Maui.InlineDataDiscoverer", "Microsoft.Maui.TestUtils.DeviceTests")]
+	[DataDiscoverer("Microsoft.Maui.InlineDataDiscoverer", "Microsoft.Maui.TestUtils")]
 	[AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
 	public sealed class InlineDataAttribute : DataAttribute
 	{
@@ -56,7 +56,7 @@ namespace Microsoft.Maui
 	/// Caution: the property is completely enumerated by .ToList() before any test is run. Hence it should return independent object sets.
 	/// </summary>
 	[AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
-	[DataDiscoverer("Microsoft.Maui.ClassDataDiscoverer", "Microsoft.Maui.TestUtils.DeviceTests")]
+	[DataDiscoverer("Microsoft.Maui.ClassDataDiscoverer", "Microsoft.Maui.TestUtils")]
 	public class ClassDataAttribute : DataAttribute
 	{
 		/// <summary>
@@ -107,7 +107,7 @@ namespace Microsoft.Maui
 	/// The member must return something compatible with IEnumerable&lt;object[]&gt; with the test data.
 	/// Caution: the property is completely enumerated by .ToList() before any test is run. Hence it should return independent object sets.
 	/// </summary>
-	[DataDiscoverer("Microsoft.Maui.MemberDataDiscoverer", "Microsoft.Maui.TestUtils.DeviceTests")]
+	[DataDiscoverer("Microsoft.Maui.MemberDataDiscoverer", "Microsoft.Maui.TestUtils")]
 	[AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
 	public sealed class MemberDataAttribute : MemberDataAttributeBase
 	{


### PR DESCRIPTION
While debugging various test projects in this repo, if you have the debugger set to catch *all* exceptions, you'll see a bunch of first-chance exceptions for various xUnit types, such as:

```
System.MissingMethodException: 'Constructor on type 'Xunit.Sdk.InlineDataDiscoverer' not found.'
```

While they're harmless from a functional perspective, several of these happen when you start debugging tests, which I've found rather annoying while debugging tests. There are usually 3 - 4 of the exceptions.

The issue was originall reported several years ago to xUnit: https://github.com/xunit/xunit/issues/819 ... but it was closed without a fix.

This change re-implements the affected xUnit types as well as a custom MAUI test type to avoid the exception.

The effect of this PR is that all the tests use new custom implemented `[InlineData]`, `[ClassData]`, and other attributes. Because the new types have the same name as the originals, no test code had to be updated - it automatically resolves to the new types.

The new types avoid the exception by having a constructor for the xUnit Message Sink (though they don't actually use it for anything).