### PR TITLE
Remove MAUI styling from Blazor Hybrid Solution template

### DIFF
--- a/src/Templates/src/templates/maui-blazor-solution/MauiApp.1/App.xaml
+++ b/src/Templates/src/templates/maui-blazor-solution/MauiApp.1/App.xaml
@@ -6,20 +6,11 @@
     <Application.Resources>
         <ResourceDictionary>
 
-            <Color x:Key="PageBackgroundColor">#512bdf</Color>
-            <Color x:Key="PrimaryTextColor">White</Color>
-
-            <Style TargetType="Label">
-                <Setter Property="TextColor" Value="{DynamicResource PrimaryTextColor}" />
-                <Setter Property="FontFamily" Value="OpenSansRegular" />
-            </Style>
-
-            <Style TargetType="Button">
-                <Setter Property="TextColor" Value="{DynamicResource PrimaryTextColor}" />
-                <Setter Property="FontFamily" Value="OpenSansRegular" />
-                <Setter Property="BackgroundColor" Value="#2b0b98" />
-                <Setter Property="Padding" Value="14,10" />
-            </Style>
+        <!--
+            For information about styling .NET MAUI pages
+            please refer to the documentation:
+            https://learn.microsoft.com/dotnet/maui/user-interface/styles/xaml
+        -->
 
         </ResourceDictionary>
     </Application.Resources>

--- a/src/Templates/src/templates/maui-blazor-solution/MauiApp.1/App.xaml
+++ b/src/Templates/src/templates/maui-blazor-solution/MauiApp.1/App.xaml
@@ -9,7 +9,7 @@
         <!--
             For information about styling .NET MAUI pages
             please refer to the documentation:
-            https://learn.microsoft.com/dotnet/maui/user-interface/styles/xaml
+            https://go.microsoft.com/fwlink/?linkid=2282329
         -->
 
         </ResourceDictionary>

--- a/src/Templates/src/templates/maui-blazor-solution/MauiApp.1/MainPage.xaml
+++ b/src/Templates/src/templates/maui-blazor-solution/MauiApp.1/MainPage.xaml
@@ -3,8 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:local="clr-namespace:MauiApp._1"
              xmlns:shared="clr-namespace:MauiApp._1.Shared;assembly=XmlEncodedAppName.Shared"
-             x:Class="MauiApp._1.MainPage"
-             BackgroundColor="{DynamicResource PageBackgroundColor}">
+             x:Class="MauiApp._1.MainPage">
 
     <BlazorWebView x:Name="blazorWebView" HostPage="wwwroot/index.html">
         <BlazorWebView.RootComponents>


### PR DESCRIPTION
### Description of Change

Same as #24135 but for the new Blazor Hybrid solution template

> The Blazor Hybrid template contains some minor .NET MAUI XAML styling which seems to serve no purpose. The only thing it does is sometimes make a purple color show up where you don't expect it and it is not light/dark theme aware.
> 
> I think it makes more sense to not have it and instead have a pointer for people to look at the docs if they start looking into it.
