### PR TITLE
[Testing] CarouselView doesn't scroll to the right Position after changing the ItemSource with Loop enabled - UI Test

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue24105.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue24105.cs
@@ -1,0 +1,64 @@
+﻿using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace Maui.Controls.Sample.Issues
+{
+	[Issue(IssueTracker.Github, 24105, "CarouselView doesn't scroll to the right Position after changing the ItemSource with Loop enabled", PlatformAffected.All)]
+	public partial class Issue24105 : ContentPage
+	{
+		public Issue24105()
+		{
+			InitializeComponent();
+			BindingContext = new Issue24105ViewModel();
+		}	
+	}
+
+	public class Issue24105ViewModel : INotifyPropertyChanged
+	{
+		ObservableCollection<string> _items;
+		public ObservableCollection<string> Items
+		{
+			get=>_items;
+			set
+			{
+				_items=value;
+				OnPropertyChanged();
+			}
+		}
+
+		int _position;
+		public int Position
+		{
+			get=>_position;
+			set
+			{
+				_position=value;
+				OnPropertyChanged();
+			}
+		}
+
+		public Command ReloadItemsCommand{get;set;}
+		public Command GoToLastItemCommand{get;set;}
+
+
+		public Issue24105ViewModel()
+		{
+			Items = new ObservableCollection<string>{ "one", "two", "three", "four", "five" };
+			ReloadItemsCommand = new Command(ReloadItems);
+			GoToLastItemCommand = new Command(()=> Position = Items.Count-1);
+		}
+
+		async void ReloadItems()
+		{
+			var currentPosition = Position;
+			Position = currentPosition;
+			Items = new ObservableCollection<string>{ "one", "two", "three", "four", "five2" };
+			await Task.Delay(300);
+			Position = currentPosition;
+		}
+		public event PropertyChangedEventHandler PropertyChanged;
+		void OnPropertyChanged([CallerMemberName] string propertyName = "") =>
+			PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue24105.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue24105.xaml
@@ -1,0 +1,35 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:d="http://schemas.microsoft.com/dotnet/2021/maui/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    xmlns:local="using:Maui.Controls.Sample.Issues"
+    xmlns:issues="using:Maui.Controls.Sample.Issues"
+    x:Class="Maui.Controls.Sample.Issues.Issue24105">
+        <VerticalStackLayout Padding="30,0"
+                         Spacing="25"
+                         VerticalOptions="Center">
+        <CarouselView x:Name="CarouselView"
+                      HeightRequest="200"
+                      BackgroundColor="AliceBlue" 
+                      ItemsSource="{Binding Items}"
+                      Loop="True"
+                      Position="{Binding Position, Mode=TwoWay}">
+            <CarouselView.ItemTemplate>
+                <DataTemplate>
+                    <VerticalStackLayout HeightRequest="200" VerticalOptions="Center">
+                        <Label FontSize="32" 
+                               HorizontalTextAlignment="Center"
+                               AutomationId="{Binding .}"
+                               Text="{Binding .}"
+                               VerticalTextAlignment="Center" />
+                    </VerticalStackLayout>
+                </DataTemplate>
+            </CarouselView.ItemTemplate>
+        </CarouselView>
+        <Button AutomationId="reloadItemsButton" Command="{Binding ReloadItemsCommand}" Text="Reload Items" /> 
+        <Button AutomationId="goToLastItemButton" Command="{Binding GoToLastItemCommand}" Text="Go to last item" /> 
+    </VerticalStackLayout>
+</ContentPage>

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue24105.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue24105.cs
@@ -1,0 +1,24 @@
+﻿using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue24105 : _IssuesUITest
+	{
+		public override string Issue => "CarouselView doesn't scroll to the right Position after changing the ItemSource with Loop enabled";
+
+		public Issue24105(TestDevice testDevice) : base(testDevice) { }
+		
+		[Test]
+		[Category(UITestCategories.CarouselView)]
+		public void CarouselViewShouldScrollToRightPosition()
+		{
+			_ = App.WaitForElement("goToLastItemButton");
+			App.Click("goToLastItemButton");
+			App.WaitForElement("five");
+			App.Click("reloadItemsButton");
+			App.WaitForElement("five2");
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change

Even though it works as expected now, I'm not 100% sure if this is a correct fix, but I hope it will help you @Redth @rmarinho @PureWeen  

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/24105

|Android|iOS|
|--|--|
|<video src="https://github.com/user-attachments/assets/2ed40452-cd0c-48a4-a15a-aac46e180a9c" width="300px"/>|<video src="https://github.com/user-attachments/assets/a358358d-4374-425c-ad34-16bb3eecfab8" width="300px"/>|
