### PR TITLE
Blazor Hybrid Template Remove reference to removed styling

### DIFF
--- a/src/Templates/src/templates/maui-blazor/MainPage.xaml
+++ b/src/Templates/src/templates/maui-blazor/MainPage.xaml
@@ -2,8 +2,7 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:local="clr-namespace:MauiApp._1"
-             x:Class="MauiApp._1.MainPage"
-             BackgroundColor="{DynamicResource PageBackgroundColor}">
+             x:Class="MauiApp._1.MainPage">
 
     <BlazorWebView x:Name="blazorWebView" HostPage="wwwroot/index.html">
         <BlazorWebView.RootComponents>


### PR DESCRIPTION
### Description of Change

Follow up from #24135, forgot to remove a reference to the styling in the `MainPage.xaml`