### PR TITLE
Add some defensive code around layout propagation

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,16 +1,16 @@
 <Project>
   <PropertyGroup>
     <!-- The .NET product branding version -->
-    <ProductVersion>8.0.80</ProductVersion>
+    <ProductVersion>8.0.81</ProductVersion>
     <MajorVersion>8</MajorVersion>
     <MinorVersion>0</MinorVersion>
-    <PatchVersion>80</PatchVersion>
+    <PatchVersion>81</PatchVersion>
     <SdkBandVersion>8.0.100</SdkBandVersion>
-    <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>
+    <PreReleaseVersionLabel>ci.net8</PreReleaseVersionLabel>
     <!-- Servicing builds have different characteristics for the way dependencies, baselines, and versions are handled. -->
     <IsServicingBuild Condition=" '$(PreReleaseVersionLabel)' == 'servicing' ">true</IsServicingBuild>
     <!-- Enable to remove prerelease label and produce stable package versions. -->
-    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">true</StabilizePackageVersion>
+    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
     <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>
     <WorkloadVersionSuffix Condition="'$(DotNetFinalVersionKind)' != 'release' and '$(PreReleaseVersionIteration)' == ''">-$(PreReleaseVersionLabel)</WorkloadVersionSuffix>
     <WorkloadVersionSuffix Condition="'$(WorkloadVersionSuffix)' == '' and '$(DotNetFinalVersionKind)' != 'release'">-$(PreReleaseVersionLabel).$(PreReleaseVersionIteration)</WorkloadVersionSuffix>

--- a/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
@@ -1145,7 +1145,14 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 						return;
 
 					if (child is not null)
+					{
 						child.PropertyChanged -= HandleChildPropertyChanged;
+
+						if(child.Handler is IPlatformViewHandler handler)
+						{
+							handler.ViewController?.View?.RemoveFromSuperview();
+						}
+					}
 
 					if (value is not null)
 					{

--- a/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
@@ -1147,11 +1147,6 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 					if (child is not null)
 					{
 						child.PropertyChanged -= HandleChildPropertyChanged;
-
-						if(child.Handler is IPlatformViewHandler handler)
-						{
-							handler.ViewController?.View?.RemoveFromSuperview();
-						}
 					}
 
 					if (value is not null)
@@ -1317,6 +1312,20 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 					for (var i = 0; i < ToolbarItems.Length; i++)
 						ToolbarItems[i].Dispose();
 				}
+
+				for (int i = View.Subviews.Length - 1; i >= 0; i--)
+				{
+					View.Subviews[i].RemoveFromSuperview();
+				}
+
+
+				for (int i = ChildViewControllers.Length - 1; i >= 0; i--)
+				{
+					var childViewController = ChildViewControllers[i];
+					childViewController.View.RemoveFromSuperview();
+					childViewController.RemoveFromParentViewController();
+				}
+
 			}
 
 			protected override void Dispose(bool disposing)
@@ -1991,7 +2000,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 					if (_child != null)
 					{
-						_child.PlatformView.RemoveFromSuperview();
+						(_child.ContainerView ?? _child.PlatformView).RemoveFromSuperview();
 						_child.DisconnectHandler();
 						_child = null;
 					}

--- a/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
@@ -328,7 +328,10 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			var actuallyRemoved = poppedViewController == null ? true : !await task;
 			_ignorePopCall = false;
 
-			poppedViewController?.Dispose();
+			if (poppedViewController is ParentingViewController pvc)
+				pvc.Disconnect(false);
+			else
+				poppedViewController?.Dispose();
 
 			UpdateToolBarVisible();
 			return actuallyRemoved;
@@ -1272,6 +1275,43 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				}
 			}
 
+			internal void Disconnect(bool dispose)
+			{
+				if (Child is Page child)
+				{
+					child.SendDisappearing();
+					child.PropertyChanged -= HandleChildPropertyChanged;
+					Child = null;
+				}
+
+				if (_tracker is not null)
+				{
+					_tracker.Target = null;
+					_tracker.CollectionChanged -= TrackerOnCollectionChanged;
+					_tracker = null;
+				}
+
+				if (NavigationItem.TitleView is not null)
+				{
+					if (dispose)
+						NavigationItem.TitleView.Dispose();
+						
+					NavigationItem.TitleView = null;
+				}
+
+				if (NavigationItem.RightBarButtonItems is not null && dispose)
+				{
+					for (var i = 0; i < NavigationItem.RightBarButtonItems.Length; i++)
+						NavigationItem.RightBarButtonItems[i].Dispose();
+				}
+
+				if (ToolbarItems is not null && dispose)
+				{
+					for (var i = 0; i < ToolbarItems.Length; i++)
+						ToolbarItems[i].Dispose();
+				}
+			}
+
 			protected override void Dispose(bool disposing)
 			{
 				if (_disposed)
@@ -1283,34 +1323,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 				if (disposing)
 				{
-					if (Child is Page child)
-					{
-						child.SendDisappearing();
-						child.PropertyChanged -= HandleChildPropertyChanged;
-						Child = null;
-					}
-
-					_tracker.Target = null;
-					_tracker.CollectionChanged -= TrackerOnCollectionChanged;
-					_tracker = null;
-
-					if (NavigationItem.TitleView != null)
-					{
-						NavigationItem.TitleView.Dispose();
-						NavigationItem.TitleView = null;
-					}
-
-					if (NavigationItem.RightBarButtonItems != null)
-					{
-						for (var i = 0; i < NavigationItem.RightBarButtonItems.Length; i++)
-							NavigationItem.RightBarButtonItems[i].Dispose();
-					}
-
-					if (ToolbarItems != null)
-					{
-						for (var i = 0; i < ToolbarItems.Length; i++)
-							ToolbarItems[i].Dispose();
-					}
+					Disconnect(true);
 				}
 
 				base.Dispose(disposing);

--- a/src/Controls/src/Core/Compatibility/Handlers/iOS/FrameRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/iOS/FrameRenderer.cs
@@ -207,7 +207,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		public override void SetNeedsLayout()
 		{
 			base.SetNeedsLayout();
-			Superview?.SetNeedsLayout();
+			this.GetSuperViewIfWindowSet()?.SetNeedsLayout();
 		}
 
 		[Microsoft.Maui.Controls.Internals.Preserve(Conditional = true)]

--- a/src/Controls/src/Core/NavigationPage/NavigationPage.cs
+++ b/src/Controls/src/Core/NavigationPage/NavigationPage.cs
@@ -402,6 +402,8 @@ namespace Microsoft.Maui.Controls
 		void RemoveFromInnerChildren(Element page)
 		{
 			InternalChildren.Remove(page);
+
+			// TODO For NET9 we should remove this because the DisconnectHandlers will take care of it
 			page.Handler = null;
 		}
 

--- a/src/Controls/src/Core/Platform/iOS/Extensions/ButtonExtensions.cs
+++ b/src/Controls/src/Core/Platform/iOS/Extensions/ButtonExtensions.cs
@@ -188,7 +188,7 @@ namespace Microsoft.Maui.Controls.Platform
 			{
 				platformButton.ImageEdgeInsets = imageInsets;
 				platformButton.TitleEdgeInsets = titleInsets;
-				platformButton.Superview?.SetNeedsLayout();
+				platformButton.GetSuperViewIfWindowSet()?.SetNeedsLayout();
 			}
 #pragma warning restore CA1416, CA1422
 		}

--- a/src/Core/src/Handlers/View/ViewHandlerOfT.iOS.cs
+++ b/src/Core/src/Handlers/View/ViewHandlerOfT.iOS.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Maui.Handlers
 				if (containerView is WrapperView wrapperView)
 				{
 					wrapperView.RemoveFromSuperview();
-					wrapperView.Dispose();
+					wrapperView.Disconnect();
 				}
 			}
 		}

--- a/src/Core/src/Platform/iOS/LayoutView.cs
+++ b/src/Core/src/Platform/iOS/LayoutView.cs
@@ -11,14 +11,14 @@ namespace Microsoft.Maui.Platform
 		{
 			InvalidateConstraintsCache();
 			base.SubviewAdded(uiview);
-			Superview?.SetNeedsLayout();
+			this.GetSuperViewIfWindowSet()?.SetNeedsLayout();
 		}
 
 		public override void WillRemoveSubview(UIView uiview)
 		{
 			InvalidateConstraintsCache();
 			base.WillRemoveSubview(uiview);
-			Superview?.SetNeedsLayout();
+			this.GetSuperViewIfWindowSet()?.SetNeedsLayout();
 		}
 
 		public override UIView? HitTest(CGPoint point, UIEvent? uievent)

--- a/src/Core/src/Platform/iOS/MauiView.cs
+++ b/src/Core/src/Platform/iOS/MauiView.cs
@@ -140,7 +140,7 @@ namespace Microsoft.Maui.Platform
 		{
 			InvalidateConstraintsCache();
 			base.SetNeedsLayout();
-			Superview?.SetNeedsLayout();
+			this.GetSuperViewIfWindowSet()?.SetNeedsLayout();
 		}
 
 		IVisualTreeElement? IVisualTreeElementProvidable.GetElement()

--- a/src/Core/src/Platform/iOS/ViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/ViewExtensions.cs
@@ -264,10 +264,18 @@ namespace Microsoft.Maui.Platform
 			}
 		}
 
+		internal static UIView? GetSuperViewIfWindowSet(this UIView? view)
+		{
+			if (view?.Window is null)
+				return null;
+
+			return view.Superview;
+		}
+
 		public static void InvalidateMeasure(this UIView platformView, IView view)
 		{
 			platformView.SetNeedsLayout();
-			platformView.Superview?.SetNeedsLayout();
+			platformView.GetSuperViewIfWindowSet()?.SetNeedsLayout();
 		}
 
 		public static void UpdateWidth(this UIView platformView, IView view)

--- a/src/Core/src/Platform/iOS/WrapperView.cs
+++ b/src/Core/src/Platform/iOS/WrapperView.cs
@@ -105,12 +105,19 @@ namespace Microsoft.Maui.Platform
 			SetBorder();
 		}
 
+		internal void Disconnect()
+		{
+			MaskLayer = null;
+			BackgroundMaskLayer = null;
+			ShadowLayer = null;
+			_borderView?.RemoveFromSuperview();
+		}
+
+
+		// TODO obsolete or delete this for NET9
 		public new void Dispose()
 		{
-			DisposeClip();
-			DisposeShadow();
-			DisposeBorder();
-
+			Disconnect();
 			base.Dispose();
 		}
 
@@ -158,7 +165,7 @@ namespace Microsoft.Maui.Platform
 		{
 			base.SetNeedsLayout();
 
-			Superview?.SetNeedsLayout();
+			this.GetSuperViewIfWindowSet()?.SetNeedsLayout();
 		}
 
 		partial void ClipChanged()
@@ -200,12 +207,6 @@ namespace Microsoft.Maui.Platform
 			backgroundMask.Path = nativePath;
 		}
 
-		void DisposeClip()
-		{
-			MaskLayer = null;
-			BackgroundMaskLayer = null;
-		}
-
 		void SetShadow()
 		{
 			var shadowLayer = ShadowLayer;
@@ -230,11 +231,6 @@ namespace Microsoft.Maui.Platform
 				shadowLayer.SetShadow(Shadow);
 		}
 
-		void DisposeShadow()
-		{
-			ShadowLayer = null;
-		}
-
 		void SetBorder()
 		{
 			if (Border == null)
@@ -249,11 +245,6 @@ namespace Microsoft.Maui.Platform
 			}
 
 			_borderView.UpdateMauiCALayer(Border);
-		}
-
-		void DisposeBorder()
-		{
-			_borderView?.RemoveFromSuperview();
 		}
 
 		CALayer? GetLayer()


### PR DESCRIPTION
### Description of Change

We still haven't been able to reproduce this issue ourselves, but based on users stack traces we have identified certain areas that might cause these exceptions. 

All of the changes in this PR are good changes to make. None of these changes are purely a guess that doesn't have some other functional benefit. 

My guess is that the fix to `NavigationRenderer` and `WrapperView` are probably what's resolving the crash most directly. In .NET MAUI we try to never actually dispose of anything because it can lead to the exceptions that users are seeing. 

The fixes around `LayoutIfNeeded` are somewhat of a guess and do run the risk of just pushing this bug down the road. 

That being said, not calling `LayoutIfNeeded` when we aren't part of the visual tree is a valid change to make and this change will at least make this path not crash. 

### Issues Fixed

Fixes #24032

