### PR TITLE
[IOS ]Fix border has an unexpected background animation

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue21643.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue21643.xaml
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Maui.Controls.Sample.Issues.Issue18204"
+             Title="Issue18204">
+
+  <AbsoluteLayout>
+    <Border AbsoluteLayout.LayoutBounds="10, 10, 200, 200"
+            x:Name="TheBorder"
+            AutomationId="border"
+            StrokeShape="Rectangle"
+            StrokeThickness="0"
+            BackgroundColor="Red" />
+
+    <Button AbsoluteLayout.LayoutBounds="230, 20, 70, 180"
+            AutomationId="button"
+            Text="Border"
+            Clicked="OnBorderChanged"
+            BackgroundColor="SkyBlue" />
+  </AbsoluteLayout>
+</ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue21643.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue21643.xaml
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="Maui.Controls.Sample.Issues.Issue18204"
-             Title="Issue18204">
+             x:Class="Maui.Controls.Sample.Issues.Issue21643"
+             Title="Issue21643">
 
   <AbsoluteLayout>
     <Border AbsoluteLayout.LayoutBounds="10, 10, 200, 200"

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue21643.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue21643.xaml.cs
@@ -1,0 +1,36 @@
+using System;
+using Microsoft.Maui;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+
+namespace Maui.Controls.Sample.Issues;
+
+[XamlCompilation(XamlCompilationOptions.Compile)]
+[Issue(IssueTracker.Github, 21643, "[iOS] Border has an unexpected background animation", PlatformAffected.iOS)]
+
+public partial class Issue21643 : ContentPage
+{
+	private bool isBorderOn = false;
+
+	public Issue21643()
+	{
+		InitializeComponent();
+	}
+
+	private void ButtonClicked(object sender, EventArgs e)
+	{
+		if (this.isBorderOn)
+		{
+			this.TheBorder.BackgroundColor = Colors.Red;
+			this.TheBorder.StrokeShape = new Rectangle();
+
+		}
+		else
+		{
+			this.TheBorder.BackgroundColor = Colors.Green;
+			this.TheBorder.StrokeShape = new RoundRectangle { CornerRadius = new(100.0) };
+		}
+
+		this.isBorderOn = !this.isBorderOn;
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue21643.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue21643.xaml.cs
@@ -1,12 +1,9 @@
-using System;
-using Microsoft.Maui;
-using Microsoft.Maui.Controls;
-using Microsoft.Maui.Controls.Xaml;
+using Microsoft.Maui.Controls.Shapes;
 
 namespace Maui.Controls.Sample.Issues;
 
 [XamlCompilation(XamlCompilationOptions.Compile)]
-[Issue(IssueTracker.Github, 21643, "[iOS] Border has an unexpected background animation", PlatformAffected.iOS)]
+[Issue(IssueTracker.Github, 21643, "Border has an unexpected background animation", PlatformAffected.iOS)]
 
 public partial class Issue21643 : ContentPage
 {
@@ -17,7 +14,7 @@ public partial class Issue21643 : ContentPage
 		InitializeComponent();
 	}
 
-	private void ButtonClicked(object sender, EventArgs e)
+	private void OnBorderChanged(object sender, EventArgs e)
 	{
 		if (this.isBorderOn)
 		{

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue21643.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue21643.cs
@@ -10,11 +10,11 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		{
 		}
 
-		public override string Issue => "[iOS] Border has an unexpected background animation";
+		public override string Issue => "Border has an unexpected background animation";
 
 		[Test]
 		[Category(UITestCategories.Border)]
-		public void Issue18242Test()
+		public void Issue21643Test()
 		{
 			App.WaitForElement("border");
 			App.Tap("button");

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue21643.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue21643.cs
@@ -1,0 +1,24 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue21643 : _IssuesUITest
+	{
+		public Issue21643(TestDevice device) : base(device)
+		{
+		}
+
+		public override string Issue => "[iOS] Border has an unexpected background animation";
+
+		[Test]
+		[Category(UITestCategories.Border)]
+		public void Issue18242Test()
+		{
+			App.WaitForElement("border");
+			App.Tap("button");
+			VerifyScreenshot();
+		}
+	}
+}

--- a/src/Core/src/Platform/iOS/StrokeExtensions.cs
+++ b/src/Core/src/Platform/iOS/StrokeExtensions.cs
@@ -134,6 +134,8 @@ namespace Microsoft.Maui.Platform
 
 			if (backgroundLayer is MauiCALayer mauiCALayer)
 			{
+				CATransaction.Begin();
+				CATransaction.AnimationDuration = 0;
 				backgroundLayer.Frame = platformView.Bounds;
 
 				if (border is IView view)
@@ -153,6 +155,7 @@ namespace Microsoft.Maui.Platform
 				}
 
 				mauiCALayer.SetBorderShape(border?.Shape);
+				CATransaction.Commit();
 			}
 
 			if (platformView is ContentView contentView)


### PR DESCRIPTION
### Root cause
iOS adds default animations to certain actions, which can cause unexpected background animations on borders when the BackgroundColor or CornerRadius of a border is changed.

### Description of changes

The fix involves disabling native animations temporarily while updating background layers. This is done using a CATransaction block with AnimationDuration set to 0.

### Reference
Referred code changes from StrokeExtensions
https://github.com/dotnet/maui/blob/400e6db3cd8fb40b7bb8b3e6d7104e1f0927236c/src/Core/src/Platform/iOS/StrokeExtensions.cs#L137

### Issues Fixed
Fixes #21643

### Output
**Before**




https://github.com/user-attachments/assets/9a2a5916-6876-4d28-afea-1d300bd1fff7


**After**

https://github.com/user-attachments/assets/a236025a-e752-4eac-adc0-432b80664fe0





