### PR TITLE
[X] Match behavior of compiled bindings with indexers to their non-compiled counterparts

### DIFF
--- a/src/Controls/tests/Xaml.UnitTests/BindingsCompiler.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/BindingsCompiler.xaml.cs
@@ -98,6 +98,10 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 				vm.Model[3] = "TextIndex2";
 				Assert.AreEqual("TextIndex2", layout.label3.Text);
 
+				//https://github.com/dotnet/maui/issues/23621
+				vm.Model.SetIndexerValueAndCallOnPropertyChangedWithoutIndex(3, "TextIndex3");
+				Assert.AreEqual("TextIndex3", layout.label3.Text);
+
 				//testing 2way
 				Assert.AreEqual("Text2", layout.entry0.Text);
 				((IElementController)layout.entry0).SetValueFromRenderer(Entry.TextProperty, "Text3");
@@ -201,6 +205,15 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 				values[v] = value;
 				OnPropertyChanged("Indexer[" + v + "]");
 			}
+		}
+
+		public void SetIndexerValueAndCallOnPropertyChangedWithoutIndex(int v, string value)
+		{
+			if (values[v] == value)
+				return;
+
+			values[v] = value;
+			OnPropertyChanged("Indexer");
 		}
 
 		protected void OnPropertyChanged([CallerMemberName] string propertyName = null)


### PR DESCRIPTION
### Description of Change

Non-compiled bindings with indexers are reaplied when the PropertyChanged event is raised for both `"Item"` and `"Item[idx]"` property names. Compiled bindings only react to changes to the `"Item[idx]"` variant.

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/23621

/cc @StephaneDelcroix