### PR TITLE
Fix Stepper doesn't change increment value when being bound to double in MVVM context (Windows)

### DIFF
--- a/src/Controls/src/Core/Stepper/Stepper.cs
+++ b/src/Controls/src/Core/Stepper/Stepper.cs
@@ -105,7 +105,5 @@ namespace Microsoft.Maui.Controls
 
 		/// <inheritdoc/>
 		public IPlatformElementConfiguration<T, Stepper> On<T>() where T : IConfigPlatform => _platformConfigurationRegistry.Value.On<T>();
-
-		double IStepper.Interval => Increment;
 	}
 }

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue20706.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue20706.xaml
@@ -1,0 +1,88 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Maui.Controls.Sample.Issues.Issue20706"
+             xmlns:local="clr-namespace:Maui.Controls.Sample.Issues">
+  <ContentPage.BindingContext>
+    <local:ViewModelClass/>
+  </ContentPage.BindingContext>
+  <ContentPage.Content>
+    <VerticalStackLayout>
+      <Stepper AutomationId="stepper" x:Name="stepperValue"
+               Maximum="1000"
+	            Increment="{Binding Increment}" />
+      <Entry AutomationId="entry" 
+	          Text="{Binding Value,Source={x:Reference stepperValue}} "/>
+      <HorizontalStackLayout>
+        <Border x:Name="lbl01"
+	               StrokeShape="RoundRectangle 5,5,5,5"
+	               StrokeThickness="{Binding Stroke01}"
+	            BackgroundColor="Blue"
+	               Padding="5,0,5,0">
+          <Label Text="0,1" AutomationId="label0.1"
+	                  WidthRequest="30"
+	                  HeightRequest="30"
+	                  HorizontalTextAlignment="Center"
+	                  VerticalTextAlignment="Center">
+            <Label.GestureRecognizers>
+              <TapGestureRecognizer Command="{Binding ChangeDecimalExponentCommand}"
+	                                         CommandParameter="0,1" />
+            </Label.GestureRecognizers>
+          </Label>
+        </Border >
+        <Border x:Name="Border"
+	               StrokeShape="RoundRectangle 5,5,5,5"
+	               StrokeThickness="{Binding Stroke1}"
+	       BackgroundColor="Blue"
+	               Padding="5,0,5,0">
+          <Label Text="1"  AutomationId="label1"
+	                              WidthRequest="30"
+	                              HeightRequest="30"
+	                              HorizontalTextAlignment="Center"
+	                              VerticalTextAlignment="Center">
+            <Label.GestureRecognizers>
+              <TapGestureRecognizer Command="{Binding ChangeDecimalExponentCommand}"
+	                                         CommandParameter="1" />
+            </Label.GestureRecognizers>
+          </Label>
+        </Border >
+        <Border x:Name="border1"
+	               StrokeShape="RoundRectangle 5,5,5,5"
+	               StrokeThickness="{Binding Stroke10}"
+	             BackgroundColor="Blue"
+	               Padding="5,0,5,0">
+          <Label Text="10" AutomationId="label10"
+	                              WidthRequest="30"
+	                              HeightRequest="30"
+	                              HorizontalTextAlignment="Center"
+	                              VerticalTextAlignment="Center">
+            <Label.GestureRecognizers>
+              <TapGestureRecognizer Command="{Binding ChangeDecimalExponentCommand}"
+	                                         CommandParameter="10" />
+            </Label.GestureRecognizers>
+          </Label>
+        </Border >
+        <Border x:Name="lbl100"
+	               StrokeShape="RoundRectangle 5,5,5,5"
+	               StrokeThickness="{Binding Stroke100}"
+	           BackgroundColor="Blue"
+	               Padding="5,0,5,0">
+          <Label Text="100" AutomationId="label100"
+	                              WidthRequest="30"
+	                              HeightRequest="30"
+	                              HorizontalTextAlignment="Center"
+	                              VerticalTextAlignment="Center">
+            <Label.GestureRecognizers>
+              <TapGestureRecognizer Command="{Binding ChangeDecimalExponentCommand}"
+	                                         CommandParameter="100" />
+            </Label.GestureRecognizers>
+          </Label>
+        </Border >
+      </HorizontalStackLayout>
+      <HorizontalStackLayout Spacing="5">
+        <Label Text="The choosen increment value is:" />
+        <Label Text="{Binding Source={x:Reference stepperValue}, Path=Increment}"/>
+      </HorizontalStackLayout>
+    </VerticalStackLayout>
+  </ContentPage.Content>
+</ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue20706.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue20706.xaml.cs
@@ -1,0 +1,117 @@
+﻿#nullable enable
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace Maui.Controls.Sample.Issues
+{
+    [Issue(IssueTracker.Github, 20706, "Stepper doesn't change increment value when being bound to a double in MVVM context (Windows)")]
+    public partial class Issue20706 : ContentPage
+    {
+        public Issue20706()
+        {
+            InitializeComponent();
+        }
+    }
+
+    public class ViewModelBase : INotifyPropertyChanged
+    {
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        public virtual void RaisePropertyChanged([CallerMemberName] string? property = null)
+           => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(property));
+        public bool SetProperty<T>(ref T storage, T value, [CallerMemberName] string? property = null)
+        {
+            if (object.Equals(storage, value))
+                return false;
+
+            storage = value;
+            RaisePropertyChanged(property);
+            return true;
+        }
+    }
+    internal class ViewModelClass : ViewModelBase
+    {
+        private double _increment;
+        private double _stroke01 = 0;
+        private double _stroke1 = 0;
+        private double _stroke10 = 0;
+        private double _stroke100 = 0;
+
+        public double Increment
+        {
+            set => SetProperty(ref _increment, value);
+            get => _increment;
+        }
+
+        public double Stroke01
+        {
+            set => SetProperty<double>(ref _stroke01, value);
+            get => _stroke01;
+        }
+        public double Stroke1
+        {
+            set => SetProperty<double>(ref _stroke1, value);
+            get => _stroke1;
+        }
+        public double Stroke10
+        {
+            set => SetProperty<double>(ref _stroke10, value);
+            get => _stroke10;
+        }
+        public double Stroke100
+        {
+            set => SetProperty<double>(ref _stroke100, value);
+            get => _stroke100;
+        }
+
+        public ViewModelClass()
+        {
+            Increment = 11;
+            Stroke1 = 5;
+        }
+
+        public Command ChangeDecimalExponentCommand
+           => new Command<string>((exponent) =>
+           {
+               switch (exponent)
+               {
+                   case "0,1":
+                       Increment = 0.1;
+                       Stroke01 = 5;
+                       Stroke1 = 0;
+                       Stroke10 = 0;
+                       Stroke100 = 0;
+                       break;
+                   case "1":
+                       Increment = 1;
+                       Stroke01 = 0;
+                       Stroke1 = 5;
+                       Stroke10 = 0;
+                       Stroke100 = 0;
+                       break;
+                   case "10":
+                       Increment = 10;
+                       Stroke01 = 0;
+                       Stroke1 = 0;
+                       Stroke10 = 5;
+                       Stroke100 = 0;
+                       break;
+                   case "100":
+                       Increment = 100;
+                       Stroke01 = 0;
+                       Stroke1 = 0;
+                       Stroke10 = 0;
+                       Stroke100 = 5;
+                       break;
+                   default:
+                       Increment = 1;
+                       Stroke01 = 0;
+                       Stroke1 = 0;
+                       Stroke10 = 0;
+                       Stroke100 = 0;
+                       break;
+               };
+           });
+    }
+}
+

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue20706.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue20706.cs
@@ -1,0 +1,30 @@
+﻿#if WINDOWS
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+    public class Issue20706 : _IssuesUITest
+	{
+		public override string Issue => "Stepper doesn't change increment value when being bound to a double in MVVM context (Windows)";
+		public Issue20706(TestDevice device) : base(device)
+		{
+		}
+
+		[Test]
+		[Category(UITestCategories.Stepper)]
+		public void ChangeIncrementValue()
+		{
+			App.WaitForElement("stepper");
+			App.Tap("label1");
+			App.TapCoordinates(34, 20);
+			App.WaitForElement("entry");
+			VerifyScreenshot();
+			App.Tap("label10");
+			App.WaitForElement("entry");
+			VerifyScreenshot();
+		}
+	}
+}
+#endif

--- a/src/Core/src/Core/IStepper.cs
+++ b/src/Core/src/Core/IStepper.cs
@@ -9,6 +9,6 @@
 		/// <summary>
 		/// Gets the amount by which Value is increased or decreased.
 		/// </summary>
-		double Interval { get; }
+		double Increment { get; }
 	}
 }

--- a/src/Core/src/Handlers/Stepper/StepperHandler.Windows.cs
+++ b/src/Core/src/Handlers/Stepper/StepperHandler.Windows.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Maui.Handlers
 
 		public static void MapIncrement(IStepperHandler handler, IStepper stepper)
 		{
-			handler.PlatformView?.UpdateInterval(stepper);
+			handler.PlatformView?.UpdateIncrement(stepper);
 		}
 
 		public static void MapValue(IStepperHandler handler, IStepper stepper)

--- a/src/Core/src/Handlers/Stepper/StepperHandler.cs
+++ b/src/Core/src/Handlers/Stepper/StepperHandler.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Maui.Handlers
 	{
 		public static IPropertyMapper<IStepper, IStepperHandler> Mapper = new PropertyMapper<IStepper, StepperHandler>(ViewHandler.ViewMapper)
 		{
-			[nameof(IStepper.Interval)] = MapIncrement,
+			[nameof(IStepper.Increment)] = MapIncrement,
 			[nameof(IStepper.Maximum)] = MapMaximum,
 			[nameof(IStepper.Minimum)] = MapMinimum,
 			[nameof(IStepper.Value)] = MapValue,

--- a/src/Core/src/Platform/Android/StepperHandlerManager.cs
+++ b/src/Core/src/Platform/Android/StepperHandlerManager.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Maui.Platform
 				if (!(HandlerHolder.StepperHandler?.VirtualView is IStepper stepper))
 					return;
 
-				var increment = stepper.Interval;
+				var increment = stepper.Increment;
 
 				if (view == HandlerHolder.StepperHandler.DownButton)
 					increment = -increment;

--- a/src/Core/src/Platform/Tizen/MauiStepper.cs
+++ b/src/Core/src/Platform/Tizen/MauiStepper.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Maui.Platform
 
 		public void UpdateIncrement(IStepper stepper)
 		{
-			Increment = stepper.Interval;
+			Increment = stepper.Increment;
 		}
 
 		public void UpdateValue(IStepper stepper)

--- a/src/Core/src/Platform/Windows/StepperExtensions.cs
+++ b/src/Core/src/Platform/Windows/StepperExtensions.cs
@@ -14,9 +14,9 @@ namespace Microsoft.Maui.Platform
 			platformStepper.Maximum = stepper.Maximum;
 		}
 
-		public static void UpdateInterval(this MauiStepper platformStepper, IStepper stepper)
+		public static void UpdateIncrement(this MauiStepper platformStepper, IStepper stepper)
 		{
-			platformStepper.Increment = stepper.Interval;
+			platformStepper.Increment = stepper.Increment;
 		}
 
 		public static void UpdateValue(this MauiStepper platformStepper, IStepper stepper)

--- a/src/Core/src/Platform/iOS/StepperExtensions.cs
+++ b/src/Core/src/Platform/iOS/StepperExtensions.cs
@@ -17,10 +17,10 @@ namespace Microsoft.Maui.Platform
 
 		public static void UpdateIncrement(this UIStepper platformStepper, IStepper stepper)
 		{
-			var increment = stepper.Interval;
+			var increment = stepper.Increment;
 
 			if (increment > 0)
-				platformStepper.StepValue = stepper.Interval;
+				platformStepper.StepValue = stepper.Increment;
 		}
 
 		public static void UpdateValue(this UIStepper platformStepper, IStepper stepper)

--- a/src/Core/src/PublicAPI/net-android/PublicAPI.Shipped.txt
+++ b/src/Core/src/PublicAPI/net-android/PublicAPI.Shipped.txt
@@ -1148,7 +1148,6 @@ Microsoft.Maui.IStackNavigation.NavigationFinished(System.Collections.Generic.IR
 Microsoft.Maui.IStackNavigation.RequestNavigation(Microsoft.Maui.NavigationRequest! eventArgs) -> void
 Microsoft.Maui.IStackNavigationView
 Microsoft.Maui.IStepper
-Microsoft.Maui.IStepper.Interval.get -> double
 Microsoft.Maui.IStreamImageSource
 Microsoft.Maui.IStreamImageSource.GetStreamAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.IO.Stream!>!
 Microsoft.Maui.IStroke

--- a/src/Core/src/PublicAPI/net-ios/PublicAPI.Shipped.txt
+++ b/src/Core/src/PublicAPI/net-ios/PublicAPI.Shipped.txt
@@ -1112,7 +1112,6 @@ Microsoft.Maui.IStackNavigation.NavigationFinished(System.Collections.Generic.IR
 Microsoft.Maui.IStackNavigation.RequestNavigation(Microsoft.Maui.NavigationRequest! eventArgs) -> void
 Microsoft.Maui.IStackNavigationView
 Microsoft.Maui.IStepper
-Microsoft.Maui.IStepper.Interval.get -> double
 Microsoft.Maui.IStreamImageSource
 Microsoft.Maui.IStreamImageSource.GetStreamAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.IO.Stream!>!
 Microsoft.Maui.IStroke

--- a/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Shipped.txt
+++ b/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Shipped.txt
@@ -1112,7 +1112,6 @@ Microsoft.Maui.IStackNavigation.NavigationFinished(System.Collections.Generic.IR
 Microsoft.Maui.IStackNavigation.RequestNavigation(Microsoft.Maui.NavigationRequest! eventArgs) -> void
 Microsoft.Maui.IStackNavigationView
 Microsoft.Maui.IStepper
-Microsoft.Maui.IStepper.Interval.get -> double
 Microsoft.Maui.IStreamImageSource
 Microsoft.Maui.IStreamImageSource.GetStreamAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.IO.Stream!>!
 Microsoft.Maui.IStroke

--- a/src/Core/src/PublicAPI/net-tizen/PublicAPI.Shipped.txt
+++ b/src/Core/src/PublicAPI/net-tizen/PublicAPI.Shipped.txt
@@ -1107,7 +1107,6 @@ Microsoft.Maui.IStackNavigation.NavigationFinished(System.Collections.Generic.IR
 Microsoft.Maui.IStackNavigation.RequestNavigation(Microsoft.Maui.NavigationRequest! eventArgs) -> void
 Microsoft.Maui.IStackNavigationView
 Microsoft.Maui.IStepper
-Microsoft.Maui.IStepper.Interval.get -> double
 Microsoft.Maui.IStreamImageSource
 Microsoft.Maui.IStreamImageSource.GetStreamAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.IO.Stream!>!
 Microsoft.Maui.IStroke

--- a/src/Core/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -82,3 +82,4 @@ virtual Microsoft.Maui.Handlers.ImageHandler.SourceLoader.get -> Microsoft.Maui.
 virtual Microsoft.Maui.Handlers.SwipeItemMenuItemHandler.SourceLoader.get -> Microsoft.Maui.Platform.ImageSourcePartLoader!
 virtual Microsoft.Maui.Animations.Ticker.OnSystemEnabledChanged() -> void
 virtual Microsoft.Maui.Animations.Ticker.SystemEnabled.set -> void
+Microsoft.Maui.IStepper.Increment.get -> double

--- a/src/Core/src/PublicAPI/net-windows/PublicAPI.Shipped.txt
+++ b/src/Core/src/PublicAPI/net-windows/PublicAPI.Shipped.txt
@@ -1127,7 +1127,6 @@ Microsoft.Maui.IStackNavigation.NavigationFinished(System.Collections.Generic.IR
 Microsoft.Maui.IStackNavigation.RequestNavigation(Microsoft.Maui.NavigationRequest! eventArgs) -> void
 Microsoft.Maui.IStackNavigationView
 Microsoft.Maui.IStepper
-Microsoft.Maui.IStepper.Interval.get -> double
 Microsoft.Maui.IStreamImageSource
 Microsoft.Maui.IStreamImageSource.GetStreamAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.IO.Stream!>!
 Microsoft.Maui.IStroke
@@ -2776,7 +2775,6 @@ static Microsoft.Maui.Platform.SliderExtensions.UpdateMinimumTrackColor(this Mic
 static Microsoft.Maui.Platform.SliderExtensions.UpdateThumbColor(this Microsoft.UI.Xaml.Controls.Slider! platformSlider, Microsoft.Maui.ISlider! slider) -> void
 static Microsoft.Maui.Platform.SliderExtensions.UpdateValue(this Microsoft.UI.Xaml.Controls.Slider! nativeSlider, Microsoft.Maui.ISlider! slider) -> void
 static Microsoft.Maui.Platform.StepperExtensions.UpdateBackground(this Microsoft.Maui.Platform.MauiStepper! platformStepper, Microsoft.Maui.IStepper! stepper) -> void
-static Microsoft.Maui.Platform.StepperExtensions.UpdateInterval(this Microsoft.Maui.Platform.MauiStepper! platformStepper, Microsoft.Maui.IStepper! stepper) -> void
 static Microsoft.Maui.Platform.StepperExtensions.UpdateMaximum(this Microsoft.Maui.Platform.MauiStepper! platformStepper, Microsoft.Maui.IStepper! stepper) -> void
 static Microsoft.Maui.Platform.StepperExtensions.UpdateMinimum(this Microsoft.Maui.Platform.MauiStepper! platformStepper, Microsoft.Maui.IStepper! stepper) -> void
 static Microsoft.Maui.Platform.StepperExtensions.UpdateValue(this Microsoft.Maui.Platform.MauiStepper! platformStepper, Microsoft.Maui.IStepper! stepper) -> void

--- a/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -114,3 +114,5 @@ virtual Microsoft.Maui.Handlers.ButtonHandler.ImageSourceLoader.get -> Microsoft
 virtual Microsoft.Maui.Handlers.ImageButtonHandler.SourceLoader.get -> Microsoft.Maui.Platform.ImageSourcePartLoader!
 virtual Microsoft.Maui.Handlers.ImageHandler.SourceLoader.get -> Microsoft.Maui.Platform.ImageSourcePartLoader!
 virtual Microsoft.Maui.Handlers.SwipeItemMenuItemHandler.SourceLoader.get -> Microsoft.Maui.Platform.ImageSourcePartLoader!
+Microsoft.Maui.IStepper.Increment.get -> double
+static Microsoft.Maui.Platform.StepperExtensions.UpdateIncrement(this Microsoft.Maui.Platform.MauiStepper! platformStepper, Microsoft.Maui.IStepper! stepper) -> void

--- a/src/Core/src/PublicAPI/net/PublicAPI.Shipped.txt
+++ b/src/Core/src/PublicAPI/net/PublicAPI.Shipped.txt
@@ -1086,7 +1086,6 @@ Microsoft.Maui.IStackNavigation.NavigationFinished(System.Collections.Generic.IR
 Microsoft.Maui.IStackNavigation.RequestNavigation(Microsoft.Maui.NavigationRequest! eventArgs) -> void
 Microsoft.Maui.IStackNavigationView
 Microsoft.Maui.IStepper
-Microsoft.Maui.IStepper.Interval.get -> double
 Microsoft.Maui.IStreamImageSource
 Microsoft.Maui.IStreamImageSource.GetStreamAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.IO.Stream!>!
 Microsoft.Maui.IStroke

--- a/src/Core/src/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -82,3 +82,4 @@ virtual Microsoft.Maui.Handlers.ButtonHandler.ImageSourceLoader.get -> Microsoft
 virtual Microsoft.Maui.Handlers.ImageButtonHandler.SourceLoader.get -> Microsoft.Maui.Platform.ImageSourcePartLoader!
 virtual Microsoft.Maui.Handlers.ImageHandler.SourceLoader.get -> Microsoft.Maui.Platform.ImageSourcePartLoader!
 virtual Microsoft.Maui.Handlers.SwipeItemMenuItemHandler.SourceLoader.get -> Microsoft.Maui.Platform.ImageSourcePartLoader!
+Microsoft.Maui.IStepper.Increment.get -> double

--- a/src/Core/src/PublicAPI/netstandard/PublicAPI.Shipped.txt
+++ b/src/Core/src/PublicAPI/netstandard/PublicAPI.Shipped.txt
@@ -1086,7 +1086,6 @@ Microsoft.Maui.IStackNavigation.NavigationFinished(System.Collections.Generic.IR
 Microsoft.Maui.IStackNavigation.RequestNavigation(Microsoft.Maui.NavigationRequest! eventArgs) -> void
 Microsoft.Maui.IStackNavigationView
 Microsoft.Maui.IStepper
-Microsoft.Maui.IStepper.Interval.get -> double
 Microsoft.Maui.IStreamImageSource
 Microsoft.Maui.IStreamImageSource.GetStreamAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.IO.Stream!>!
 Microsoft.Maui.IStroke

--- a/src/Core/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -82,3 +82,4 @@ virtual Microsoft.Maui.Handlers.ImageButtonHandler.SourceLoader.get -> Microsoft
 virtual Microsoft.Maui.Handlers.ImageHandler.SourceLoader.get -> Microsoft.Maui.Platform.ImageSourcePartLoader!
 *REMOVED*Microsoft.Maui.Handlers.SwipeItemMenuItemHandler.SourceLoader.get -> Microsoft.Maui.Platform.ImageSourcePartLoader!
 virtual Microsoft.Maui.Handlers.SwipeItemMenuItemHandler.SourceLoader.get -> Microsoft.Maui.Platform.ImageSourcePartLoader!
+Microsoft.Maui.IStepper.Increment.get -> double

--- a/src/Core/src/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
+++ b/src/Core/src/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
@@ -1084,7 +1084,6 @@ Microsoft.Maui.IStackNavigation.NavigationFinished(System.Collections.Generic.IR
 Microsoft.Maui.IStackNavigation.RequestNavigation(Microsoft.Maui.NavigationRequest! eventArgs) -> void
 Microsoft.Maui.IStackNavigationView
 Microsoft.Maui.IStepper
-Microsoft.Maui.IStepper.Interval.get -> double
 Microsoft.Maui.IStreamImageSource
 Microsoft.Maui.IStreamImageSource.GetStreamAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.IO.Stream!>!
 Microsoft.Maui.IStroke

--- a/src/Core/src/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -82,3 +82,4 @@ virtual Microsoft.Maui.Handlers.ImageButtonHandler.SourceLoader.get -> Microsoft
 virtual Microsoft.Maui.Handlers.ImageHandler.SourceLoader.get -> Microsoft.Maui.Platform.ImageSourcePartLoader!
 *REMOVED*Microsoft.Maui.Handlers.SwipeItemMenuItemHandler.SourceLoader.get -> Microsoft.Maui.Platform.ImageSourcePartLoader!
 virtual Microsoft.Maui.Handlers.SwipeItemMenuItemHandler.SourceLoader.get -> Microsoft.Maui.Platform.ImageSourcePartLoader!
+Microsoft.Maui.IStepper.Increment.get -> double


### PR DESCRIPTION
### Root Cause
 
Stepper has increment property and when updating the increment value from XAML, Interval is not referenced properly and Increment change is not notified to PlatformView as IStepper.Interval property is mapped to MapIncrement method. 

### Description of Change
So, renamed interface Interval to Increment and mapped to mapIncrement method. Also renamed all the interval reference with Increment.
### API changes
Renamed IStepper.Interval to IStepper.Increment

### Issues Fixed
Fixes #20706 

### Output video 
### Before Changes

https://github.com/user-attachments/assets/668993ec-532d-43b4-8b1a-47b98c8ec077

### After Changes


https://github.com/user-attachments/assets/be60183c-883c-4f72-a49c-06c9f3d6b489




