### PR TITLE
[XC] Fallback to reflection-based bindings for bindings with "invalid" path

### DIFF
--- a/src/Controls/tests/Xaml.UnitTests/BindingsCompiler.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/BindingsCompiler.xaml
@@ -5,8 +5,10 @@
 		xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests"
 		xmlns:sys="clr-namespace:System;assembly=mscorlib"
         xmlns:cmp="clr-namespace:Microsoft.Maui.Controls.Compatibility;assembly=Microsoft.Maui.Controls"
-		x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.BindingsCompiler" >
-	<cmp:StackLayout>
+		x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.BindingsCompiler"
+        x:Name="page"
+        x:DataType="local:GlobalViewModel">
+	<cmp:StackLayout x:Name="stack" x:DataType="{x:Null}">
         <cmp:StackLayout x:DataType="local:MockViewModel">
 			<Label Text="{Binding Text}" x:Name="label0" />
 			<Label Text="{Binding Path=Text}" x:Name="label1" />
@@ -23,6 +25,7 @@
 			<Label Text="{Binding StructModel.Model.Text, Mode=TwoWay}" x:Name="label10" />
             <Label Text="Text for label12" x:Name="label11" />
             <Label Text="{Binding Text, x:DataType=Label, Source={x:Reference label11}}" x:Name="label12" />
+            <Label Text="{Binding BindingContext.GlobalText, Source={x:Reference page}, x:DataType=ContentPage}" x:Name="label13" />
 
 			<Picker
 				ItemsSource="{Binding Items}"

--- a/src/Controls/tests/Xaml.UnitTests/BindingsCompiler.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/BindingsCompiler.xaml.cs
@@ -56,8 +56,9 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 
 				var layout = new BindingsCompiler(useCompiledXaml)
 				{
-					BindingContext = vm
+					BindingContext = new GlobalViewModel(),
 				};
+				layout.stack.BindingContext = vm;
 				layout.label6.BindingContext = new MockStructViewModel
 				{
 					Model = new MockViewModel
@@ -121,11 +122,14 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 				}
 
 				//testing invalid bindingcontext type
-				layout.BindingContext = new object();
+				layout.stack.BindingContext = new object();
 				Assert.AreEqual(null, layout.label0.Text);
 
 				//testing source
 				Assert.That(layout.label12.Text, Is.EqualTo("Text for label12"));
+
+				//testing binding with path that cannot be statically compiled (we don't support casts in the Path)
+				Assert.That(layout.label13.Text, Is.EqualTo("Global Text"));
 			}
 			
 			[Test] 
@@ -146,6 +150,11 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		}
 		public int I { get; set; }
 		public MockViewModel Model { get; set; }
+	}
+
+	class GlobalViewModel
+	{
+		public string GlobalText { get; set; } = "Global Text";
 	}
 
 	class MockViewModel : INotifyPropertyChanged

--- a/src/Controls/tests/Xaml.UnitTests/Controls.Xaml.UnitTests.csproj
+++ b/src/Controls/tests/Xaml.UnitTests/Controls.Xaml.UnitTests.csproj
@@ -6,7 +6,7 @@
     <AssemblyName>Microsoft.Maui.Controls.Xaml.UnitTests</AssemblyName>
     <WarningLevel>4</WarningLevel>
     <NoWarn>$(NoWarn);0672;0219;0414;CS0436;CS0618</NoWarn>
-    <WarningsNotAsErrors>$(WarningsNotAsErrors);XC0618;XC0022,XC0023</WarningsNotAsErrors>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);XC0618;XC0022,XC0023;XC0045</WarningsNotAsErrors>
     <IsPackable>false</IsPackable>
     <DisableMSBuildAssemblyCopyCheck>true</DisableMSBuildAssemblyCopyCheck>
   </PropertyGroup>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Gh2517.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Gh2517.xaml
@@ -3,5 +3,5 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Gh2517"
              x:DataType="Label">
-    <Label Text="{Binding MissingProperty}" />
+    <Label Text="{Binding MissingProperty}" x:Name="Label" />
 </ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Gh2517.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Gh2517.xaml.cs
@@ -7,7 +7,7 @@ using NUnit.Framework;
 
 namespace Microsoft.Maui.Controls.Xaml.UnitTests
 {
-	[XamlCompilation(XamlCompilationOptions.Skip)]
+	// related to https://github.com/dotnet/maui/issues/23711
 	public partial class Gh2517 : ContentPage
 	{
 		public Gh2517()
@@ -24,10 +24,15 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		class Tests
 		{
 			[TestCase(true)]
-			public void ErrorOnMissingBindingTarget(bool useCompiledXaml)
+			public void BindingWithInvalidPathIsNotCompiled(bool useCompiledXaml)
 			{
 				if (useCompiledXaml)
-					Assert.Throws<BuildException>(() => MockCompiler.Compile(typeof(Gh2517)));
+					MockCompiler.Compile(typeof(Gh2517));
+
+				var view = new Gh2517(useCompiledXaml);
+
+				var binding = view.Label.GetContext(Label.TextProperty).Bindings.GetValue();
+				Assert.That(binding, Is.TypeOf<Binding>());
 			}
 		}
 	}

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Gh3606.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Gh3606.xaml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui" xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Gh3606" x:Name="page">
 	<StackLayout x:DataType="x:String">
-        <Label Text="{Binding Content, Source={x:Reference page}}" />
+        <Label Text="{Binding Content, Source={x:Reference page}}" x:Name="Label" />
     </StackLayout>
 </ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Gh3606.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Gh3606.xaml.cs
@@ -8,7 +8,7 @@ using NUnit.Framework;
 
 namespace Microsoft.Maui.Controls.Xaml.UnitTests
 {
-	[XamlCompilation(XamlCompilationOptions.Skip)]
+	// related to https://github.com/dotnet/maui/issues/23711
 	public partial class Gh3606 : ContentPage
 	{
 		public Gh3606()
@@ -30,17 +30,15 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 
 			[TestCase(true)]
 			[TestCase(false)]
-			public void BindingsWithSourceAreCompiled(bool useCompiledXaml)
+			public void BindingsWithSourceAndInvalidPathAreNotCompiled(bool useCompiledXaml)
 			{
 				if (useCompiledXaml)
-				{
-					// The XAML file contains a mismatch between the source the x:DataType attribute so the compilation of the binding will fail
-					Assert.Throws(new BuildExceptionConstraint(4, 16), () => MockCompiler.Compile(typeof(Gh3606)));
-				}
-				else
-				{
-					Assert.DoesNotThrow(() => new Gh3606(useCompiledXaml: false));
-				}
+					MockCompiler.Compile(typeof(Gh3606));
+
+				var view = new Gh3606(useCompiledXaml);
+
+				var binding = view.Label.GetContext(Label.TextProperty).Bindings.GetValue();
+				Assert.That(binding, Is.TypeOf<Binding>());
 			}
 		}
 	}

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui20768.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui20768.cs
@@ -15,7 +15,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Maui.Controls.Xaml.UnitTests;
 
-[XamlCompilation(XamlCompilationOptions.Skip)]
 public partial class Maui20768
 {
     public Maui20768()
@@ -43,16 +42,12 @@ public partial class Maui20768
         [Test]
         public void BindingsDoNotResolveStaticProperties([Values(false, true)] bool useCompiledXaml)
         {
-            if (useCompiledXaml)
-            {
-                Assert.Throws(new BuildExceptionConstraint(6, 32), () => MockCompiler.Compile(typeof(Maui20768)));
-            }
-            else
-            {
-                var page = new Maui20768(useCompiledXaml);
-                page.TitleLabel.BindingContext = new ViewModel20768();
-                Assert.Null(page.TitleLabel.Text);
-            }
+			if (useCompiledXaml)
+				MockCompiler.Compile(typeof(Maui20768));
+
+			var page = new Maui20768(useCompiledXaml);
+			page.TitleLabel.BindingContext = new ViewModel20768();
+			Assert.Null(page.TitleLabel.Text);
         }
     }
 }


### PR DESCRIPTION
### Description of Change

We've improved binding optimizations in .NET 9 and it is now possible to compile all sorts of bindings that weren't supported in .NET 8 and earlier. This change can break existing code though:
- In the cases when there is a binding with a `Source` but it inherits the `x:DataType` from the parent, there can often be a mismatch between the `x:DataType` and the type of the `Source`
- Sometimes customers want to reference another element and access its BindingContext (`{Binding BindingContext.Title Source={x:Reference ...}}`). Since we don't support casting in the path, XamlC won't be able to correctly resolve and build the property chain (in the example `BindingContext` is of type `object` and it doesn't have any property `Title`).

While there are workarounds to these issues, it might be better to just fallback to a reflection-based binding that will resolve the actual properties at runtime in these cases to keep the apps working and produce a warning so that the developer can either choose to ignore it or address it. Feedback is very welcome.

I recommend hiding whitespace changes when looking at the code diff.

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/23711