### PR TITLE
Backport maestro and artifact drop infra improvements from net9.0

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -14,9 +14,9 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="8.0.0-beta.24310.5">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="9.0.0-beta.24408.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>9f6799fdc16ae19b3e9478c55b997a6aab839d09</Sha>
+      <Sha>60ae233c3d77f11c5fdb53e570b64d503b13ba59</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="8.0.0-beta.24310.5">
       <Uri>https://github.com/dotnet/arcade</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -114,7 +114,7 @@
     <TizenUIExtensionsVersion>0.9.0</TizenUIExtensionsVersion>
     <ExCSSPackageVersion>4.2.3</ExCSSPackageVersion>
     <SystemDrawingCommonPackageVersion>8.0.3</SystemDrawingCommonPackageVersion>
-    <MicrosoftDotNetBuildTasksFeedVersion>8.0.0-beta.24310.5</MicrosoftDotNetBuildTasksFeedVersion>
+    <MicrosoftDotNetBuildTasksFeedVersion>9.0.0-beta.24408.2</MicrosoftDotNetBuildTasksFeedVersion>
   </PropertyGroup>
   <PropertyGroup>
     <MicrosoftNETTestSdkPackageVersion>17.6.0</MicrosoftNETTestSdkPackageVersion>

--- a/eng/pipelines/common/sdk-insertion.yml
+++ b/eng/pipelines/common/sdk-insertion.yml
@@ -70,6 +70,7 @@ jobs:
       projects: $(Build.SourcesDirectory)\src\Workload\Microsoft.Maui.Sdk\Microsoft.Maui.Sdk.csproj
       arguments: >-
         -t:PushManifestToBuildAssetRegistry
+        -p:OfficialBuildId=$(_BuildOfficalId)
         -p:BuildAssetRegistryToken=$(MaestroAccessToken)
         -p:OutputPath=$(Build.StagingDirectory)\nuget-signed\
         -v:n -bl:$(Build.StagingDirectory)\binlogs\push-bar-manifest.binlog

--- a/eng/pipelines/common/sdk-insertion.yml
+++ b/eng/pipelines/common/sdk-insertion.yml
@@ -5,10 +5,11 @@ parameters:
   pushMauiPackagesToMaestro: false
   nugetArtifactName: nuget-signed
   nugetArtifactPath: $(Build.StagingDirectory)\nuget-signed
+  dropRetentionDays: 120
 
 jobs:
 - job: create_artifact_statuses
-  displayName: Create GitHub Artifact Status and Push to Maestro
+  displayName: Publish symbols and Push to Maestro
   timeoutInMinutes: 60
   pool:
     name: ${{ parameters.poolName }}
@@ -16,54 +17,55 @@ jobs:
     os: ${{ parameters.os }}
   variables:
   - group: Publish-Build-Assets
+  templateContext:
+    outputs:
+    - output: artifactsDrop
+      dropServiceURI: https://devdiv.artifacts.visualstudio.com/DefaultCollection
+      buildNumber: $(ReleaseDropPrefix)/symbols
+      dropMetadataContainerName: DropMetadata-$(Build.BuildId)-symbols-$(System.JobAttempt)
+      sourcePath: $(Build.StagingDirectory)\symbols
+      retentionDays: ${{ parameters.dropRetentionDays }}
+      toLowerCase: false
   steps:
   - checkout: self
+
+  # Download symbols to be published to the symbols artifact drop declared above
   - task: DownloadPipelineArtifact@2
     inputs:
-      artifactName: ${{ parameters.nugetArtifactName }}
-      downloadPath: ${{ parameters.nugetArtifactPath }}
+      artifactName: nuget
+      downloadPath: $(Build.StagingDirectory)\symbols
       patterns: |
-        *.nupkg
         **/*.snupkg
         **/additional-assets.zip
+    displayName: Download symbols
+
   - task: DownloadPipelineArtifact@2
     inputs:
-      artifactName: vs-msi-nugets
-      downloadPath: ${{ parameters.nugetArtifactPath }}
-  - template: templates\common\upload-vs-insertion-artifacts.yml@sdk-insertions
-    parameters:
-      githubToken: $(github--pat--vs-mobiletools-engineering-service2)
-      githubContext: $(NupkgCommitStatusName)
-      blobName: $(NupkgCommitStatusName)
-      packagePrefix: maui
-      artifactsPath: ${{ parameters.nugetArtifactPath }}
-      yamlResourceName: yaml-templates
-  - template: templates\common\upload-vs-insertion-artifacts.yml@sdk-insertions
-    parameters:
-      githubToken: $(github--pat--vs-mobiletools-engineering-service2)
-      githubContext: $(VSDropCommitStatusName)
-      blobName: $(VSDropCommitStatusName)
-      packagePrefix: maui
-      artifactsPath: $(Build.StagingDirectory)/$(VSDropCommitStatusName)
-      yamlResourceName: yaml-templates
-      downloadSteps:
-      - task: DownloadPipelineArtifact@2
-        inputs:
-          artifactName: vsdrop-signed
-          downloadPath: $(Build.StagingDirectory)/$(VSDropCommitStatusName)
-  - template: templates\common\upload-vs-insertion-artifacts.yml@sdk-insertions
-    parameters:
-      githubToken: $(github--pat--vs-mobiletools-engineering-service2)
-      githubContext: $(MultiTargetVSDropCommitStatusName)
-      blobName: $(MultiTargetVSDropCommitStatusName)
-      packagePrefix: maui
-      artifactsPath: $(Build.StagingDirectory)/$(MultiTargetVSDropCommitStatusName)
-      yamlResourceName: yaml-templates
-      downloadSteps:
-      - task: DownloadPipelineArtifact@2
-        inputs:
-          artifactName: vsdrop-multitarget-signed
-          downloadPath: $(Build.StagingDirectory)/$(MultiTargetVSDropCommitStatusName)
+      artifactName: DropMetadata-$(Build.BuildId)-nugets-$(System.JobAttempt)
+      downloadPath: $(Build.StagingDirectory)\metadata
+    displayName: Download nugets drop metadata
+
+  - powershell: |
+      $jsonContent = Get-Content -Path "$(Build.StagingDirectory)\metadata\VSTSDrop.json" -Raw | ConvertFrom-Json
+      $dropPrefix = $jsonContent.VstsDropBuildArtifact.VstsDropUrl -replace 'https://devdiv.artifacts.visualstudio.com/DefaultCollection/_apis/drop/drops/' -replace '/nugets'
+      Write-Host "##vso[task.setvariable variable=ReleaseDropPrefix]$dropPrefix"
+    displayName: Set variable ReleaseDropPrefix
+
+  # Download nugets drop created by nuget-msi-convert/job/v4.yml and publish to maestro
+  - task: ms-vscs-artifact.build-tasks.artifactDropDownloadTask-1.artifactDropDownloadTask@1
+    displayName: Download $(ReleaseDropPrefix)/nugets
+    inputs:
+      dropServiceURI: https://devdiv.artifacts.visualstudio.com/DefaultCollection
+      buildNumber: $(ReleaseDropPrefix)/nugets
+      destinationPath: ${{ parameters.nugetArtifactPath }}
+
+  - task: UseDotNet@2                 # https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/tool/dotnet-core-tool-installer?view=azure-devops
+    displayName: 'Use .NET SDK $(DOTNET_VERSION)'
+    inputs:
+      packageType: sdk
+      version: $(DOTNET_VERSION)
+      includePreviewVersions: true
+
   - task: DotNetCoreCLI@2
     displayName: Generate and publish BAR manifest
     inputs:
@@ -72,9 +74,10 @@ jobs:
         -t:PushManifestToBuildAssetRegistry
         -p:OfficialBuildId=$(_BuildOfficalId)
         -p:BuildAssetRegistryToken=$(MaestroAccessToken)
-        -p:OutputPath=$(Build.StagingDirectory)\nuget-signed\
+        -p:OutputPath=${{ parameters.nugetArtifactPath }}
         -v:n -bl:$(Build.StagingDirectory)\binlogs\push-bar-manifest.binlog
     condition: and(succeeded(), eq('${{ parameters.pushMauiPackagesToMaestro }}', 'true'))
+
   - powershell: |
       $versionEndpoint = 'https://maestro.dot.net/api/assets/darc-version?api-version=2019-01-16'
       $darcVersion = $(Invoke-WebRequest -Uri $versionEndpoint -UseBasicParsing).Content

--- a/eng/pipelines/common/sdk-insertion.yml
+++ b/eng/pipelines/common/sdk-insertion.yml
@@ -22,7 +22,7 @@ jobs:
     - output: artifactsDrop
       dropServiceURI: https://devdiv.artifacts.visualstudio.com/DefaultCollection
       buildNumber: $(ReleaseDropPrefix)/symbols
-      dropMetadataContainerName: DropMetadata-$(Build.BuildId)-symbols-$(System.JobAttempt)
+      dropMetadataContainerName: DropMetadata-shipping-symbols
       sourcePath: $(Build.StagingDirectory)\symbols
       retentionDays: ${{ parameters.dropRetentionDays }}
       toLowerCase: false
@@ -41,7 +41,7 @@ jobs:
 
   - task: DownloadPipelineArtifact@2
     inputs:
-      artifactName: DropMetadata-$(Build.BuildId)-nugets-$(System.JobAttempt)
+      artifactName: DropMetadata-shipping-nugets
       downloadPath: $(Build.StagingDirectory)\metadata
     displayName: Download nugets drop metadata
 

--- a/eng/pipelines/common/sdk-insertion.yml
+++ b/eng/pipelines/common/sdk-insertion.yml
@@ -15,8 +15,6 @@ jobs:
     name: ${{ parameters.poolName }}
     image: ${{ parameters.vmImage }}
     os: ${{ parameters.os }}
-  variables:
-  - group: Publish-Build-Assets
   templateContext:
     outputs:
     - output: artifactsDrop
@@ -59,30 +57,36 @@ jobs:
       buildNumber: $(ReleaseDropPrefix)/nugets
       destinationPath: ${{ parameters.nugetArtifactPath }}
 
-  - task: UseDotNet@2                 # https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/tool/dotnet-core-tool-installer?view=azure-devops
-    displayName: 'Use .NET SDK $(DOTNET_VERSION)'
+  - task: UseDotNet@2
+    displayName: Install .NET 9.x
     inputs:
-      packageType: sdk
-      version: $(DOTNET_VERSION)
+      version: 9.x
       includePreviewVersions: true
 
-  - task: DotNetCoreCLI@2
+  - task: AzureCLI@2
     displayName: Generate and publish BAR manifest
     inputs:
-      projects: $(Build.SourcesDirectory)\src\Workload\Microsoft.Maui.Sdk\Microsoft.Maui.Sdk.csproj
-      arguments: >-
+      azureSubscription: "Darc: Maestro Production"
+      scriptType: ps
+      scriptLocation: inlineScript
+      inlineScript: >-
+        dotnet build $(Build.SourcesDirectory)\src\Workload\Microsoft.Maui.Sdk\Microsoft.Maui.Sdk.csproj
         -t:PushManifestToBuildAssetRegistry
         -p:OfficialBuildId=$(_BuildOfficalId)
-        -p:BuildAssetRegistryToken=$(MaestroAccessToken)
         -p:OutputPath=${{ parameters.nugetArtifactPath }}
         -v:n -bl:$(Build.StagingDirectory)\binlogs\push-bar-manifest.binlog
     condition: and(succeeded(), eq('${{ parameters.pushMauiPackagesToMaestro }}', 'true'))
 
-  - powershell: |
-      $versionEndpoint = 'https://maestro.dot.net/api/assets/darc-version?api-version=2019-01-16'
-      $darcVersion = $(Invoke-WebRequest -Uri $versionEndpoint -UseBasicParsing).Content
-      $arcadeServicesSource = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json'
-      & dotnet tool update microsoft.dotnet.darc --version "$darcVersion" --add-source "$arcadeServicesSource" --tool-path $(Agent.ToolsDirectory)\darc -v n
-      & $(Agent.ToolsDirectory)\darc\darc add-build-to-channel --default-channels --id $(BARBuildId) --publishing-infra-version 3 --password $(MaestroAccessToken) --azdev-pat $(publishing-dnceng-devdiv-code-r-build-re)
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: "Darc: Maestro Production"
+      scriptType: ps
+      scriptLocation: inlineScript
+      inlineScript: |
+        $versionEndpoint = 'https://maestro.dot.net/api/assets/darc-version?api-version=2019-01-16'
+        $darcVersion = $(Invoke-WebRequest -Uri $versionEndpoint -UseBasicParsing).Content
+        $arcadeServicesSource = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json'
+        & dotnet tool update microsoft.dotnet.darc --version "$darcVersion" --add-source "$arcadeServicesSource" --tool-path $(Agent.ToolsDirectory)\darc -v n
+        & $(Agent.ToolsDirectory)\darc\darc add-build-to-channel --default-channels --id $(BARBuildId) --ci --publishing-infra-version 3 --azdev-pat $(System.AccessToken)
     displayName: Add build to default darc channel
     condition: and(succeeded(), eq('${{ parameters.pushMauiPackagesToMaestro }}', 'true'))

--- a/eng/pipelines/common/sdk-insertion.yml
+++ b/eng/pipelines/common/sdk-insertion.yml
@@ -90,5 +90,7 @@ jobs:
         $arcadeServicesSource = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json'
         & dotnet tool update microsoft.dotnet.darc --version "$darcVersion" --add-source "$arcadeServicesSource" --tool-path $(Agent.ToolsDirectory)\darc -v n
         & $(Agent.ToolsDirectory)\darc\darc add-build-to-channel --default-channels --id $(BARBuildId) --ci --publishing-infra-version 3 --azdev-pat $(System.AccessToken)
+    # Execute outside of the source directory to avoid any conflicting global.json file
+      workingDirectory: $(Build.SourcesDirectory)\..
     displayName: Add build to default darc channel
     condition: and(succeeded(), eq('${{ parameters.pushMauiPackagesToMaestro }}', 'true'))

--- a/eng/pipelines/common/sdk-insertion.yml
+++ b/eng/pipelines/common/sdk-insertion.yml
@@ -75,6 +75,8 @@ jobs:
         -p:OfficialBuildId=$(_BuildOfficalId)
         -p:OutputPath=${{ parameters.nugetArtifactPath }}
         -v:n -bl:$(Build.StagingDirectory)\binlogs\push-bar-manifest.binlog
+    # Execute outside of the source directory to avoid any conflicting global.json file
+      workingDirectory: $(Build.SourcesDirectory)\..
     condition: and(succeeded(), eq('${{ parameters.pushMauiPackagesToMaestro }}', 'true'))
 
   - task: AzureCLI@2

--- a/eng/pipelines/common/sdk-insertion.yml
+++ b/eng/pipelines/common/sdk-insertion.yml
@@ -70,7 +70,7 @@ jobs:
       scriptType: ps
       scriptLocation: inlineScript
       inlineScript: >-
-        dotnet build $(Build.SourcesDirectory)\src\Workload\Microsoft.Maui.Sdk\Microsoft.Maui.Sdk.csproj
+        & dotnet build $(Build.SourcesDirectory)\src\Workload\Microsoft.Maui.Sdk\Microsoft.Maui.Sdk.csproj
         -t:PushManifestToBuildAssetRegistry
         -p:OfficialBuildId=$(_BuildOfficalId)
         -p:OutputPath=${{ parameters.nugetArtifactPath }}

--- a/eng/pipelines/common/sign.yml
+++ b/eng/pipelines/common/sign.yml
@@ -22,7 +22,7 @@ stages:
           use1ESTemplate: true
           usePipelineArtifactTasks: true
         
-      - template: nuget-msi-convert/job/v3.yml@yaml-templates
+      - template: nuget-msi-convert/job/v4.yml@yaml-templates
         parameters:
           yamlResourceName: yaml-templates
           artifactName: nuget-signed
@@ -42,7 +42,7 @@ stages:
             inputs:
               TargetFolders: |
                 $(Build.ArtifactStagingDirectory)\bin\manifests
-                $(Build.ArtifactStagingDirectory)\bin\manifests-multitarget
+                $(Build.ArtifactStagingDirectory)\bin\manifests-packs
                 $(Build.ArtifactStagingDirectory)\bin\msi-nupkgs
               ExcludeSNVerify: true
               ApprovalListPathForCerts: $(Build.ArtifactStagingDirectory)\sign-verify\SignVerifyIgnore.txt

--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -1,6 +1,8 @@
 variables:
 - name: BuildVersion
   value: $[counter('buildversion-counter', 5000)]
+- name: _BuildOfficalId
+  value: $[ format('{0}.{1}', format('{0:yyyyMMdd}', pipeline.startTime), counter(format('{0:yyyyMMdd}', pipeline.startTime), 1) )]
 - name: NUGET_VERSION
   value: 6.4.0
 - name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE

--- a/eng/pipelines/maui-release.yml
+++ b/eng/pipelines/maui-release.yml
@@ -144,9 +144,7 @@ extends:
                 value: $(Build.SourcesDirectory)/build.cmd -ci
               - name: _BuildConfig
                 value: Release
-              - name: _BuildOfficalId
-                value: $[ format('{0}.{1}', format('{0:yyyyMMdd}', pipeline.startTime), counter(format('{0:yyyyMMdd}', pipeline.startTime), 1) )]
-            
+
             steps:
               - template: /eng/pipelines/common/pack.yml@self
                 parameters:

--- a/src/Workload/Shared/Maestro.targets
+++ b/src/Workload/Shared/Maestro.targets
@@ -36,7 +36,7 @@
       <ManifestBuildData Include="AzureDevOpsBranch=$(BUILD_SOURCEBRANCH)" />
     </ItemGroup>
 
-    <PushToAzureDevOpsArtifacts
+    <PushToBuildStorage
         ItemsToPush="@(ItemsToPush)"
         IsStableBuild="$(StabilizePackageVersion)"
         ManifestBuildData="@(ManifestBuildData)"

--- a/src/Workload/Shared/Maestro.targets
+++ b/src/Workload/Shared/Maestro.targets
@@ -47,15 +47,17 @@
         AssetManifestPath="$(AssetManifestPath)"
         PublishingVersion="3" />
 
+    <Message Text="BAR manifest version: $(PackageReferenceVersion)" />
+
     <MSBuild
         Targets="Restore"
         Projects="$(PkgMicrosoft_DotNet_Arcade_Sdk)\tools\SdkTasks\PublishBuildAssets.proj"
-        Properties="Configuration=$(Configuration);RepoRoot=$(MauiRootDirectory);VersionPrefix=$(Version)"
+        Properties="Configuration=$(Configuration);RepoRoot=$(MauiRootDirectory);VersionPrefix=$(PackageReferenceVersion)"
     />
 
     <MSBuild
         Projects="$(PkgMicrosoft_DotNet_Arcade_Sdk)\tools\SdkTasks\PublishBuildAssets.proj"
-        Properties="Configuration=$(Configuration);RepoRoot=$(MauiRootDirectory);VersionPrefix=$(Version);ManifestsPath=$(ArtifactsLogDir)AssetManifest;MaestroApiEndpoint=https://maestro.dot.net"
+        Properties="Configuration=$(Configuration);RepoRoot=$(MauiRootDirectory);VersionPrefix=$(PackageReferenceVersion);ManifestsPath=$(ArtifactsLogDir)AssetManifest;MaestroApiEndpoint=https://maestro.dot.net"
     />
   </Target>
 


### PR DESCRIPTION
Backports the following maestro and artifact storage changes,
removing dependencies on bosstoragemirror and adding support
for passwordless maestro auth.

https://github.com/dotnet/maui/commit/5b6db3960a640f7d7b9b001a324130e24ed5735c
https://github.com/dotnet/maui/commit/f88260ea64cd3b378815fb1c69c3817577765ac9
https://github.com/dotnet/maui/commit/e4486e64b27832cfe85c1724fe55b686755b7245
https://github.com/dotnet/maui/commit/b9d711ad26fd450dcb75d37da5fadd9823c27b30