### PR TITLE
Match behavior of compiled bindings with indexers to their counterparts

### DIFF
--- a/src/Controls/src/BindingSourceGen/BindingCodeWriter.cs
+++ b/src/Controls/src/BindingSourceGen/BindingCodeWriter.cs
@@ -342,6 +342,16 @@ public static class BindingCodeWriter
 				nextExpression = AccessExpressionBuilder.ExtendExpression(previousExpression, MaybeWrapInConditionalAccess(part, forceConditonalAccessToNextPart));
 				forceConditonalAccessToNextPart = part is Cast;
 
+				// Make binding react for PropertyChanged events on indexer itself
+				if (part is IndexAccess indexAccess)
+				{
+					AppendLine($"new(static source => {previousExpression}, \"{indexAccess.DefaultMemberName}\"),");
+				}
+				else if (part is ConditionalAccess conditionalAccess && conditionalAccess.Part is IndexAccess innerIndexAccess)
+				{
+					AppendLine($"new(static source => {previousExpression}, \"{innerIndexAccess.DefaultMemberName}\"),");
+				}
+
 				// Some parts don't have a property name, so we can't generate a handler for them (for example casts)
 				if (part.PropertyName is string propertyName)
 				{

--- a/src/Controls/tests/BindingSourceGen.UnitTests/BindingCodeWriterTests.cs
+++ b/src/Controls/tests/BindingSourceGen.UnitTests/BindingCodeWriterTests.cs
@@ -420,8 +420,11 @@ public class BindingCodeWriterTests
                     setter,
                     handlers: new Tuple<Func<global::MyNamespace.MySourceClass, object?>, string>[]
                     {
+                        new(static source => source, "Item"),
                         new(static source => source, "Item[12]"),
+                        new(static source => source[12], "Indexer"),
                         new(static source => source[12], "Indexer[Abc]"),
+                        new(static source => source[12]?["Abc"], "Item"),
                         new(static source => source[12]?["Abc"], "Item[0]"),
                     })
                 {

--- a/src/Controls/tests/BindingSourceGen.UnitTests/IntegrationTests.cs
+++ b/src/Controls/tests/BindingSourceGen.UnitTests/IntegrationTests.cs
@@ -498,6 +498,7 @@ public class IntegrationTests
                             handlers: new Tuple<Func<global::MyNamespace.A?, object?>, string>[]
                             {
                                 new(static source => source, "B"),
+                                new(static source => source?.B, "Item"),
                                 new(static source => source?.B, "Item[0]"),
                                 new(static source => source?.B?[0], "C"),
                             })
@@ -1414,8 +1415,11 @@ public class IntegrationTests
                             setter,
                             handlers: new Tuple<Func<global::MyNamespace.MySourceClass, object?>, string>[]
                             {
+                                new(static source => source, "Item"),
                                 new(static source => source, "Item[12]"),
+                                new(static source => source[12], "Indexer"),
                                 new(static source => source[12], "Indexer[Abc]"),
+                                new(static source => source[12]?["Abc"], "Item"),
                                 new(static source => source[12]?["Abc"], "Item[0]"),
                             })
                         {


### PR DESCRIPTION
Adds `Item` to handlers array when dealing with indexers.

Fixes https://github.com/dotnet/maui/issues/24255