### PR TITLE
[Windows] Optimize `WrapperView`

### DIFF
--- a/src/Core/src/Platform/Windows/WrapperView.cs
+++ b/src/Core/src/Platform/Windows/WrapperView.cs
@@ -149,9 +149,13 @@ namespace Microsoft.Maui.Platform
 		partial void ShadowChanged()
 		{
 			if (HasShadow)
+			{
 				UpdateShadowAsync().FireAndForget(IPlatformApplication.Current?.Services?.CreateLogger(nameof(WrapperView)));
+			}
 			else
+			{
 				CreateShadowAsync().FireAndForget(IPlatformApplication.Current?.Services?.CreateLogger(nameof(WrapperView)));
+			}
 		}
 
 		void OnChildSizeChanged(object sender, SizeChangedEventArgs e)
@@ -181,10 +185,14 @@ namespace Microsoft.Maui.Platform
 			}
 
 			if (_shadowHost is not null)
+			{
 				ElementCompositionPreview.SetElementChildVisual(_shadowHost, null);
+			}
 
 			if (_shadowCanvas.Children.Count > 0)
+			{
 				_shadowCanvas.Children.RemoveAt(0);
+			}
 
 			if (_shadowVisual != null)
 			{
@@ -254,7 +262,9 @@ namespace Microsoft.Maui.Platform
 		async Task UpdateShadowAsync()
 		{
 			if (_dropShadow != null)
+			{
 				await SetShadowPropertiesAsync(_dropShadow, Shadow);
+			}
 
 			UpdateShadowSize();
 		}
@@ -266,12 +276,16 @@ namespace Microsoft.Maui.Platform
 				float width = (float)_shadowHostSize.Width;
 
 				if (width <= 0)
+				{
 					width = (float)frameworkElement.ActualWidth;
+				}
 
 				float height = (float)_shadowHostSize.Height;
 
 				if (height <= 0)
+				{
 					height = (float)frameworkElement.ActualHeight;
+				}
 
 				if (_shadowVisual is not null)
 				{
@@ -308,7 +322,9 @@ namespace Microsoft.Maui.Platform
 			dropShadow.Opacity = opacity;
 
 			if (shadowColor != null)
+			{
 				dropShadow.Color = shadowColor.ToWindowsColor();
+			}
 
 			dropShadow.Offset = new Vector3((float)offset.X, (float)offset.Y, 0);
 			dropShadow.Mask = await Child.GetAlphaMaskAsync();

--- a/src/Core/src/Platform/Windows/WrapperView.cs
+++ b/src/Core/src/Platform/Windows/WrapperView.cs
@@ -131,7 +131,9 @@ namespace Microsoft.Maui.Platform
 			if (_borderPath is null)
 			{
 				_borderPath = new();
-				Children.Add(_borderPath);
+
+				int index = _shadowCanvas is not null ? 1 : 0;
+				Children.Insert(index, _borderPath);
 			}
 
 			IShape? borderShape = Border.Shape;

--- a/src/Core/src/Platform/Windows/WrapperView.cs
+++ b/src/Core/src/Platform/Windows/WrapperView.cs
@@ -227,7 +227,9 @@ namespace Microsoft.Maui.Platform
 			if (_shadowCanvas is null)
 			{
 				_shadowCanvas = new();
-				Children.Add(_shadowCanvas);
+
+				// Shadow canvas must be the first child. The order of children (i.e. shadow canvas and border path) matters.
+				Children.Insert(0, _shadowCanvas);
 			}
 
 			var ttv = Child.TransformToVisual(_shadowCanvas);

--- a/src/Core/src/Platform/Windows/WrapperView.cs
+++ b/src/Core/src/Platform/Windows/WrapperView.cs
@@ -65,8 +65,6 @@ namespace Microsoft.Maui.Platform
 			DisposeClip();
 			DisposeShadow();
 			DisposeBorder();
-
-			GC.SuppressFinalize(this);
 		}
 
 		partial void ClipChanged() => UpdateClip();


### PR DESCRIPTION
### Description of Change

This PR attempts to optimize `WrapperView` class on Windows. Not every `WrapperView` has a border or a shadow set, so it can be set up when it's really needed.

### Performance impact

* MAIN: [1723819781..speedscope.MAIN.json](https://github.com/user-attachments/files/16638537/1723819781.speedscope.MAIN.json)
* PR: [1723819902..speedscope.PR.json](https://github.com/user-attachments/files/16638552/1723819902.speedscope.PR.json)

![image](https://github.com/user-attachments/assets/255c323e-deea-4824-ae4f-283303a1b018)

-> 93% improvement for the execution of the constructor.

### Issues Fixed

- fixes #24281
Contributes to #21787 (when `<Label>`s have set a background color and thus there is a container for those labels).