### PR TITLE
[Android] Add test for scroll without group

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.cs
@@ -168,7 +168,11 @@ namespace Microsoft.Maui.DeviceTests
 			await AssertionExtensions.WaitForGC([.. weakReferences]);
 		}
 
-		[Fact]
+		[Fact(
+#if IOS || MACCATALYST
+Skip = "Fails on iOS/macOS: https://github.com/dotnet/maui/issues/17664"
+#endif
+)]
 		public async Task CollectionScrollToUngroupedWorks()
 		{
 			SetupBuilder();

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.cs
@@ -168,6 +168,61 @@ namespace Microsoft.Maui.DeviceTests
 			await AssertionExtensions.WaitForGC([.. weakReferences]);
 		}
 
+		[Fact]
+		public async Task CollectionScrollToUngroupedWorks()
+		{
+			SetupBuilder();
+
+			var dataList = new List<TestData>();
+			string letters = "abcdefghijklmnopqrstuvwxyz";
+			for (int i = 0; i < letters.Length; i++)
+			{
+				dataList.Add(new TestData
+				{
+					Name = $"{letters[i]}"
+				});
+			}
+
+			var collectionView = new CollectionView
+			{
+				IsGrouped = false,
+				ItemsSource = dataList,
+				ItemTemplate = new DataTemplate(() =>
+				{
+					var name = new Label()
+					{
+						TextColor = Colors.Grey,
+						HeightRequest = 64
+					};
+					name.SetBinding(Label.TextProperty, "Name");
+					return name;
+				})
+			};
+
+			await CreateHandlerAndAddToWindow<CollectionViewHandler>(collectionView, async handler =>
+			{
+				collectionView.ScrollTo(index: 24, animate: false); // Item "x"
+
+				int retryCount = 3;
+				bool foundItem = false;
+				while (retryCount > 0 && !foundItem)
+				{
+					retryCount--;
+					await Task.Delay(500);
+					for (int i = 0; i < collectionView.LogicalChildrenInternal.Count; i++)
+					{
+						var item = collectionView.LogicalChildrenInternal[i];
+						if (item is Label label && label.Text.Equals("x", StringComparison.OrdinalIgnoreCase))
+						{
+							foundItem = true;
+							break;
+						}
+					}
+				}
+				Assert.True(foundItem);
+			});
+		}
+
 		[Fact(
 #if IOS || MACCATALYST
 Skip = "Fails on iOS/macOS: https://github.com/dotnet/maui/issues/17664"


### PR DESCRIPTION
### Description of Change

When looking up the item index, using the interface `IGroupableItemsViewSource` to determine if the list is grouped or not will not work as ungrouped lists also implement that interface. This PR adjusts the logic to check if the list is ungrouped via `UngroupedItemsSource`, then returns the index.

### Issues Fixed

Fixes #24272