### PR TITLE
[Testing] moved FlyoutHeaderAdaptsToMinimumHeight to appium

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellFlyoutTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellFlyoutTests.cs
@@ -92,34 +92,7 @@ namespace Microsoft.Maui.DeviceTests
 				Assert.Contains(shellSectionGrid, (shellSection as IVisualTreeElement).GetVisualChildren());
 				Assert.Contains(shellContentGrid, (shellContent as IVisualTreeElement).GetVisualChildren());
 			});
-		}
-
-		[Fact]
-		public async Task FlyoutHeaderAdaptsToMinimumHeight()
-		{
-			await RunShellTest(shell =>
-			{
-				var layout = new VerticalStackLayout()
-				{
-					new Label() { Text = "Flyout Header" }
-				};
-
-				layout.MinimumHeightRequest = 30;
-
-				shell.FlyoutHeader = layout;
-				shell.FlyoutHeaderBehavior = FlyoutHeaderBehavior.CollapseOnScroll;
-			},
-			async (shell, handler) =>
-			{
-				await OpenFlyout(handler);
-				var flyoutFrame = GetFrameRelativeToFlyout(handler, shell.FlyoutHeader as IView);
-
-				await AssertionExtensions.AssertEventually(() =>
-				{
-					return Math.Abs(30 - flyoutFrame.Height) < 0.2;
-				}, message: $"Expected: {30}. Actual: {flyoutFrame.Height}. Diff: {Math.Abs(30 - flyoutFrame.Height)}");
-			});
-		}
+		}	
 
 #if !WINDOWS
 		[Theory]

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue24284.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue24284.xaml
@@ -5,7 +5,9 @@
        xmlns:ns="clr-namespace:Maui.Controls.Sample.Issues">
     <ShellContent Title="Page 1">
         <ContentPage>
-            <Border AutomationId="Border" HeightRequest="30"/>
+            <Border BackgroundColor="Red" AutomationId="Border" HeightRequest="30">
+                <Label Text="Hello, World!"/>
+            </Border>
         </ContentPage>
     </ShellContent>
      <ShellContent Title="Page 2">

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue24284.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue24284.xaml
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Shell xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+       xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+       x:Class="Maui.Controls.Sample.Issues.Issue24284"
+       xmlns:ns="clr-namespace:Maui.Controls.Sample.Issues">
+    <ShellContent Title="Page 1">
+        <ContentPage>
+            <Border AutomationId="Border" HeightRequest="30"/>
+        </ContentPage>
+    </ShellContent>
+     <ShellContent Title="Page 2">
+        <ContentPage/>
+    </ShellContent>
+</Shell>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue24284.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue24284.xaml
@@ -5,9 +5,7 @@
        xmlns:ns="clr-namespace:Maui.Controls.Sample.Issues">
     <ShellContent Title="Page 1">
         <ContentPage>
-            <Border BackgroundColor="Red" AutomationId="Border" HeightRequest="30">
-                <Label Text="Hello, World!"/>
-            </Border>
+            <Label HeightRequest="30" AutomationId="HeightReferenceLabel" Text="Hello, World!"/>
         </ContentPage>
     </ShellContent>
      <ShellContent Title="Page 2">

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue24284.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue24284.xaml.cs
@@ -7,16 +7,15 @@ public partial class Issue24284 : Shell
 	public Issue24284()
 	{
 		InitializeComponent();
-		var layout = new VerticalStackLayout()
-		{
-			AutomationId = "FlyoutHeader",
-			BackgroundColor = Colors.Red,
-			Children = {
-				new Label() { Text = "Flyout Header" }
-			},
-			MinimumHeightRequest = 30
+
+		var label = new Label() 
+		{ 
+			AutomationId = "HeaderLabel",
+			Text = "Flyout Header",
+			MinimumHeightRequest = 30,
 		};
-		FlyoutHeader = layout;
+
+		FlyoutHeader = label;
 		FlyoutHeaderBehavior = FlyoutHeaderBehavior.CollapseOnScroll;
 		FlyoutIsPresented = true;
 	}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue24284.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue24284.xaml.cs
@@ -1,0 +1,23 @@
+﻿namespace Maui.Controls.Sample.Issues;
+
+[XamlCompilation(XamlCompilationOptions.Compile)]
+[Issue(IssueTracker.Github, 24284, "FlyoutHeaderAdaptsToMinimumHeight", PlatformAffected.All)]
+public partial class Issue24284 : Shell
+{
+	public Issue24284()
+	{
+		InitializeComponent();
+		var layout = new VerticalStackLayout()
+		{
+			AutomationId = "FlyoutHeader",
+			BackgroundColor = Colors.Red,
+			Children = {
+				new Label() { Text = "Flyout Header" }
+			},
+			MinimumHeightRequest = 30
+		};
+		FlyoutHeader = layout;
+		FlyoutHeaderBehavior = FlyoutHeaderBehavior.CollapseOnScroll;
+		FlyoutIsPresented = true;
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue24284.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue24284.cs
@@ -15,10 +15,10 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		[Category(UITestCategories.Shell)]
 		public void FlyoutHeaderAdaptsToMinimumHeight()
 		{
-			var layout = App.WaitForElement("FlyoutHeader").GetRect();
-			var border = App.WaitForElement("Border").GetRect();
+			var heightReferenceLabel = App.WaitForElement("HeightReferenceLabel").GetRect();
+			var headerLabel = App.WaitForElement("HeaderLabel").GetRect();
 
-			ClassicAssert.True(Math.Abs(border.Height - layout.Height) < 0.2);
+			ClassicAssert.True(Math.Abs(headerLabel.Height - heightReferenceLabel.Height) < 0.2);
 		}
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue24284.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue24284.cs
@@ -1,0 +1,24 @@
+﻿using NUnit.Framework;
+using NUnit.Framework.Legacy;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue24284 : _IssuesUITest
+	{
+		public Issue24284(TestDevice testDevice) : base(testDevice){ }
+
+		public override string Issue => "FlyoutHeaderAdaptsToMinimumHeight";
+
+		[Test]
+		[Category(UITestCategories.Shell)]
+		public void FlyoutHeaderAdaptsToMinimumHeight()
+		{
+			var layout = App.WaitForElement("FlyoutHeader").GetRect();
+			var border = App.WaitForElement("Border").GetRect();
+
+			ClassicAssert.True(Math.Abs(border.Height - layout.Height) < 0.2);
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change

FlyoutHeaderAdaptsToMinimumHeight

is failing a good amount. This is a shell based test so let's just move it to Appium where those tend to run a bit more reliably

https://dev.azure.com/xamarin/public/_test/analytics?definitionId=62&contextType=build

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/24284
