### PR TITLE
Add a hard limit on the size of an Image which can be loaded

### DIFF
--- a/src/Core/AndroidNative/maui/src/main/java/com/microsoft/maui/ClampBoundsToDisplayMetricsTransformation.java
+++ b/src/Core/AndroidNative/maui/src/main/java/com/microsoft/maui/ClampBoundsToDisplayMetricsTransformation.java
@@ -10,50 +10,55 @@ import java.nio.ByteBuffer;
 import java.security.MessageDigest;
 
 class ClampBoundsToDisplayMetricsTransformation extends BitmapTransformation {
-    private static final String ID = "com.microsoft.maui.ClampBoundsToDisplayMetricsTransformation";
-    private DisplayMetrics displayMetrics;
-    private String DisplayMetricsID;
+  private static final String ID = "com.microsoft.maui.ClampBoundsToDisplayMetricsTransformation";
 
-    public ClampBoundsToDisplayMetricsTransformation(DisplayMetrics display) {
-        this.displayMetrics = display;
-        DisplayMetricsID = displayMetrics.widthPixels + "x" + displayMetrics.heightPixels;
+  private DisplayMetrics displayMetrics;
+  private String displayMetricsID;
+
+  public ClampBoundsToDisplayMetricsTransformation(DisplayMetrics display) {
+    displayMetrics = display;
+    displayMetricsID = displayMetrics.widthPixels + "x" + displayMetrics.heightPixels;
+  }
+
+  @Override
+  protected Bitmap transform(BitmapPool pool, Bitmap toTransform, int outWidth, int outHeight) {
+    int width = toTransform.getWidth();
+    int height = toTransform.getHeight();
+
+    if (width <= displayMetrics.widthPixels && height <= displayMetrics.heightPixels) {
+      return toTransform;
     }
 
-    @Override
-    protected Bitmap transform(BitmapPool pool, Bitmap toTransform, int outWidth, int outHeight) {
-        int width = toTransform.getWidth();
-        int height = toTransform.getHeight();
+    float aspectRatio = (float) width / (float) height;
 
-        if (width <= displayMetrics.widthPixels && height <= displayMetrics.heightPixels) {
-            return toTransform;
-        }
-
-        float aspectRatio = (float) width / (float) height;
-
-        if (width > height) {
-            outWidth = displayMetrics.widthPixels;
-            outHeight = Math.round(displayMetrics.widthPixels / aspectRatio);
-        } else {
-            outHeight = displayMetrics.heightPixels;
-            outWidth = Math.round(displayMetrics.heightPixels * aspectRatio);
-        }
-
-        return Bitmap.createScaledBitmap(toTransform, outWidth, outHeight, false);
+    if (width > height) {
+      outWidth = displayMetrics.widthPixels;
+      outHeight = Math.round(displayMetrics.widthPixels / aspectRatio);
+    } else {
+      outHeight = displayMetrics.heightPixels;
+      outWidth = Math.round(displayMetrics.heightPixels * aspectRatio);
     }
 
-    @Override
-     public boolean equals(Object o) {
-       return o instanceof ClampBoundsToDisplayMetricsTransformation;
-     }
+    return Bitmap.createScaledBitmap(toTransform, outWidth, outHeight, false);
+  }
 
-      @Override
-     public int hashCode() {
-       return ID.hashCode();
-     }
+  @Override
+  public boolean equals(Object o) {
+    if (o instanceof ClampBoundsToDisplayMetricsTransformation) {
+      ClampBoundsToDisplayMetricsTransformation transform = (ClampBoundsToDisplayMetricsTransformation) o;
+      return displayMetricsID.equals(transform.displayMetricsID);
+    }
+    return false;
+  }
 
-      @Override
-     public void updateDiskCacheKey(MessageDigest messageDigest) {
-       byte[] bytes = (ID + DisplayMetricsID).getBytes(Key.CHARSET);
-       messageDigest.update(bytes);
-     }
+  @Override
+  public int hashCode() {
+    return ID.hashCode();
+  }
+
+  @Override
+  public void updateDiskCacheKey(MessageDigest messageDigest) {
+    byte[] bytes = (ID + displayMetricsID).getBytes(Key.CHARSET);
+    messageDigest.update(bytes);
+  }
 }

--- a/src/Core/AndroidNative/maui/src/main/java/com/microsoft/maui/ClampBoundsToDisplayMetricsTransformation.java
+++ b/src/Core/AndroidNative/maui/src/main/java/com/microsoft/maui/ClampBoundsToDisplayMetricsTransformation.java
@@ -1,0 +1,59 @@
+package com.microsoft.maui;
+
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.util.DisplayMetrics;
+import com.bumptech.glide.load.engine.bitmap_recycle.BitmapPool;
+import com.bumptech.glide.load.resource.bitmap.BitmapTransformation;
+import com.bumptech.glide.load.Key;
+import java.nio.ByteBuffer;
+import java.security.MessageDigest;
+
+class ClampBoundsToDisplayMetricsTransformation extends BitmapTransformation {
+    private static final String ID = "com.microsoft.maui.ClampBoundsToDisplayMetricsTransformation";
+    private DisplayMetrics displayMetrics;
+    private String DisplayMetricsID;
+
+    public ClampBoundsToDisplayMetricsTransformation(DisplayMetrics display) {
+        this.displayMetrics = display;
+        DisplayMetricsID = displayMetrics.widthPixels + "x" + displayMetrics.heightPixels;
+    }
+
+    @Override
+    protected Bitmap transform(BitmapPool pool, Bitmap toTransform, int outWidth, int outHeight) {
+        int width = toTransform.getWidth();
+        int height = toTransform.getHeight();
+
+        if (width <= displayMetrics.widthPixels && height <= displayMetrics.heightPixels) {
+            return toTransform;
+        }
+
+        float aspectRatio = (float) width / (float) height;
+
+        if (width > height) {
+            outWidth = displayMetrics.widthPixels;
+            outHeight = Math.round(displayMetrics.widthPixels / aspectRatio);
+        } else {
+            outHeight = displayMetrics.heightPixels;
+            outWidth = Math.round(displayMetrics.heightPixels * aspectRatio);
+        }
+
+        return Bitmap.createScaledBitmap(toTransform, outWidth, outHeight, false);
+    }
+
+    @Override
+     public boolean equals(Object o) {
+       return o instanceof ClampBoundsToDisplayMetricsTransformation;
+     }
+
+      @Override
+     public int hashCode() {
+       return ID.hashCode();
+     }
+
+      @Override
+     public void updateDiskCacheKey(MessageDigest messageDigest) {
+       byte[] bytes = (ID + DisplayMetricsID).getBytes(Key.CHARSET);
+       messageDigest.update(bytes);
+     }
+}

--- a/src/Core/AndroidNative/maui/src/main/java/com/microsoft/maui/PlatformInterop.java
+++ b/src/Core/AndroidNative/maui/src/main/java/com/microsoft/maui/PlatformInterop.java
@@ -296,7 +296,7 @@ public class PlatformInterop {
         }
     }
 
-    private static void prepare(RequestBuilder<Drawable> builder, MauiTarget target, boolean cachingEnabled, ImageLoaderCallback callback) {
+    private static void prepare(RequestBuilder<Drawable> builder, MauiTarget target, boolean cachingEnabled, DisplayMetrics display, ImageLoaderCallback callback) {
         // A special value to work around https://github.com/dotnet/maui/issues/6783 where targets
         // are actually re-used if all the variables are the same.
         // Adding this "error image" that will always load a null image makes each request unique,
@@ -310,6 +310,9 @@ public class PlatformInterop {
                 .skipMemoryCache(true);
         }
 
+        builder = builder
+            .transform(new ClampBoundsToDisplayMetricsTransformation(display));
+
         target.load(builder);
     }
 
@@ -319,12 +322,14 @@ public class PlatformInterop {
 
     private static void loadInto(RequestBuilder<Drawable> builder, ImageView imageView, boolean cachingEnabled, ImageLoaderCallback callback, Object model) {
         MauiCustomViewTarget target = new MauiCustomViewTarget(imageView, callback, model);
-        prepare(builder, target, cachingEnabled, callback);
+        DisplayMetrics display = imageView.getContext().getResources().getDisplayMetrics ();
+        prepare(builder, target, cachingEnabled, display, callback);
     }
 
     private static void load(RequestBuilder<Drawable> builder, Context context, boolean cachingEnabled, ImageLoaderCallback callback, Object model) {
         MauiCustomTarget target = new MauiCustomTarget(context, callback, model);
-        prepare(builder, target, cachingEnabled, callback);
+        DisplayMetrics display = context.getResources().getDisplayMetrics ();
+        prepare(builder, target, cachingEnabled, display, callback);
     }
 
     public static void loadImageFromFile(ImageView imageView, String file, ImageLoaderCallback callback) {


### PR DESCRIPTION
### Description of Change

Android has a hard limit on the size of image you can display. It cannot be larger than the size of the screen. If you try you will get the following issue

```
Java.Lang.RuntimeException: Canvas  trying to draw to large (xxx) bitmap.
```

The problem is catching this particular error, it seems to cause a hard crash. 
Once solution is to cap the size of images being loaded. 

So the problem here is the image is just too big to be handled by the hardware on the device. 

The image is 6960 x 4640 pixels. As a png that is 1.5 meg. The problem is that it is NOT 1.5 meg once loaded. 
It is an RGBA image so 6960 x 4640 x 4 (one byte for each rgba channel). So unpacked the image is `129177600` bytes. 
129 meg! 

A quote from the google engineer  https://issuetracker.google.com/issues/244854452#comment3

```
The crash itself is working as intended, so closing the bug as such. 
As for why you're hitting this, the platform guarantees that you can 
always draw a bitmap up to the same size as the display resolution, 
but not necessarily larger. 
```

So if the screen resolution is 1920x1080 we get 1920*1080*4 = 8294400 bytes. 
So this will always crash if you try to render an image that is larger than the screen resolution. 

### Issues Fixed

Fixes #23828

