### PR TITLE
Revert "[ios] fix memory leak in CollectionView cells (#15831)"

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/iOS/TemplatedCell.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/TemplatedCell.cs
@@ -49,13 +49,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		{
 		}
 
-		WeakReference<IPlatformViewHandler> _handler;
-
-		internal IPlatformViewHandler PlatformHandler
-		{
-			get => _handler is not null && _handler.TryGetTarget(out var h) ? h : null;
-			set => _handler = value == null ? null : new(value);
-		}
+		internal IPlatformViewHandler PlatformHandler { get; private set; }
 
 		public override void ConstrainTo(CGSize constraint)
 		{

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.iOS.cs
@@ -98,6 +98,7 @@ namespace Microsoft.Maui.DeviceTests
 
 			var labels = new List<WeakReference>();
 			VerticalCell cell = null;
+			WeakReference collectionViewReference = null;
 
 			{
 				var bindingContext = "foo";
@@ -116,12 +117,14 @@ namespace Microsoft.Maui.DeviceTests
 				});
 
 				Assert.NotNull(cell);
+				collectionViewReference = new WeakReference(collectionView);
+				collectionView = null;
 			}
 
 			// HACK: test passes running individually, but fails when running entire suite.
 			// Skip the assertion on Catalyst for now.
 #if !MACCATALYST
-			await AssertionExtensions.WaitForGC(labels.ToArray());
+			await AssertionExtensions.WaitForGC(collectionViewReference);
 #endif
 		}
 

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.iOS.cs
@@ -91,6 +91,40 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
+		[Fact("Cells Do Not Leak")]
+		public async Task CellsDoNotLeak()
+		{
+			SetupBuilder();
+
+			var labels = new List<WeakReference>();
+			VerticalCell cell = null;
+
+			{
+				var bindingContext = "foo";
+				var collectionView = new MyUserControl
+				{
+					Labels = labels
+				};
+				collectionView.ItemTemplate = new DataTemplate(collectionView.LoadDataTemplate);
+
+				var handler = await CreateHandlerAsync(collectionView);
+
+				await InvokeOnMainThreadAsync(() =>
+				{
+					cell = new VerticalCell(CGRect.Empty);
+					cell.Bind(collectionView.ItemTemplate, bindingContext, collectionView);
+				});
+
+				Assert.NotNull(cell);
+			}
+
+			// HACK: test passes running individually, but fails when running entire suite.
+			// Skip the assertion on Catalyst for now.
+#if !MACCATALYST
+			await AssertionExtensions.WaitForGC(labels.ToArray());
+#endif
+		}
+
 		/// <summary>
 		/// Simulates what a developer might do with a Page/View
 		/// </summary>

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.iOS.cs
@@ -91,40 +91,6 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
-		[Fact("Cells Do Not Leak")]
-		public async Task CellsDoNotLeak()
-		{
-			SetupBuilder();
-
-			var labels = new List<WeakReference>();
-			VerticalCell cell = null;
-
-			{
-				var bindingContext = "foo";
-				var collectionView = new MyUserControl
-				{
-					Labels = labels
-				};
-				collectionView.ItemTemplate = new DataTemplate(collectionView.LoadDataTemplate);
-
-				var handler = await CreateHandlerAsync(collectionView);
-
-				await InvokeOnMainThreadAsync(() =>
-				{
-					cell = new VerticalCell(CGRect.Empty);
-					cell.Bind(collectionView.ItemTemplate, bindingContext, collectionView);
-				});
-
-				Assert.NotNull(cell);
-			}
-
-			// HACK: test passes running individually, but fails when running entire suite.
-			// Skip the assertion on Catalyst for now.
-#if !MACCATALYST
-			await AssertionExtensions.WaitForGC(labels.ToArray());
-#endif
-		}
-
 		/// <summary>
 		/// Simulates what a developer might do with a Page/View
 		/// </summary>


### PR DESCRIPTION
Fixes #24304.

This reverts commit 05697a6b1fc8a068ad537cbf455d2407e22e7e72 and updates the test.

The test was unfortunately testing the wrong thing - that manually created `VerticalCell` doesn't hold on to the handler and platform views. What we really want to test is that `VerticalCell` created through `UICollectionView` doesn't prevent the collection view from being collected.