### PR TITLE
Fix `dotnet new maui` trim warnings when publish with trimMode full

### DIFF
--- a/src/Core/src/HotReload/HotReloadHelper.cs
+++ b/src/Core/src/HotReload/HotReloadHelper.cs
@@ -34,21 +34,36 @@ namespace Microsoft.Maui.HotReload
 
 		public static void Register(IHotReloadableView view, params object[] parameters)
 		{
-			if (!IsSupported || !IsEnabled)
+			// Check separately to avoid trim warnings
+			if (!IsSupported)
 				return;
+
+			if (!IsEnabled)
+				return;
+
 			currentViews[view] = parameters;
 		}
 
 		public static void UnRegister(IHotReloadableView view)
 		{
-			if (!IsSupported || !IsEnabled)
+			// Check separately to avoid trim warnings
+			if (!IsSupported)
 				return;
+
+			if (!IsEnabled)
+				return;
+
 			currentViews.Remove(view);
 		}
 		public static bool IsReplacedView(IHotReloadableView view, IView newView)
 		{
-			if (!IsSupported || !IsEnabled)
+			// Check separately to avoid trim warnings
+			if (!IsSupported)
 				return false;
+
+			if (!IsEnabled)
+				return false;
+
 			if (view == null || newView == null)
 				return false;
 
@@ -58,7 +73,11 @@ namespace Microsoft.Maui.HotReload
 		}
 		public static IView GetReplacedView(IHotReloadableView view)
 		{
-			if (!IsSupported || !IsEnabled)
+			// Check separately to avoid trim warnings
+			if (!IsSupported)
+				return view;
+
+			if (!IsEnabled)
 				return view;
 
 			var viewType = view.GetType();
@@ -105,7 +124,11 @@ namespace Microsoft.Maui.HotReload
 #endif
 		public static void RegisterReplacedView(string oldViewType, Type newViewType)
 		{
-			if (!IsSupported || !IsEnabled)
+			// Check separately to avoid trim warnings
+			if (!IsSupported)
+				return;
+
+			if (!IsEnabled)
 				return;
 
 			Action<MethodInfo> executeStaticMethod = (method) =>


### PR DESCRIPTION
### Description of Change

ILLink may experience problems understanding complex conditional checks https://github.com/dotnet/runtime/blob/main/docs/design/tools/illink/feature-checks.md#boolean-andor

This PR breaks down complex if checks so that they can be understood by ILLInk. 


~~Previously hot reload has been disabled on NativeAOT via `System.Reflection.Metadata.MetadataUpdater.IsSupported` check. This however didn't work when publishing with `TrimMode=full`. This PR replaces the previous check with a custom feature switch which is set to false when publishing with `TrimMode=full`.~~

### Issues Fixed
Fixes #24062 