### PR TITLE
[release/8.0.1xx-sr8] Update the mac/iOS workloads

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -51,10 +51,10 @@
     <!-- xamarin/xamarin-android -->
     <MicrosoftAndroidSdkWindowsPackageVersion>34.0.113</MicrosoftAndroidSdkWindowsPackageVersion>
     <!-- xamarin/xamarin-macios -->
-    <MicrosoftMacCatalystSdkPackageVersion>17.2.8022</MicrosoftMacCatalystSdkPackageVersion>
-    <MicrosoftmacOSSdkPackageVersion>14.2.8022</MicrosoftmacOSSdkPackageVersion>
-    <MicrosoftiOSSdkPackageVersion>17.2.8022</MicrosoftiOSSdkPackageVersion>
-    <MicrosofttvOSSdkPackageVersion>17.2.8022</MicrosofttvOSSdkPackageVersion>
+    <MicrosoftMacCatalystSdkPackageVersion>17.5.8020</MicrosoftMacCatalystSdkPackageVersion>
+    <MicrosoftmacOSSdkPackageVersion>14.5.8020</MicrosoftmacOSSdkPackageVersion>
+    <MicrosoftiOSSdkPackageVersion>17.5.8020</MicrosoftiOSSdkPackageVersion>
+    <MicrosofttvOSSdkPackageVersion>17.5.8020</MicrosofttvOSSdkPackageVersion>
     <!-- Samsung/Tizen.NET -->
     <SamsungTizenSdkPackageVersion>8.0.130</SamsungTizenSdkPackageVersion>
     <!-- emsdk -->

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/BuildWarningsUtilities.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/BuildWarningsUtilities.cs
@@ -125,21 +125,6 @@ namespace Microsoft.Maui.IntegrationTests
 		{
 			new WarningsPerFile
 			{
-				File = "ILC",
-				WarningsPerCode = new List<WarningsPerCode>
-				{
-					new WarningsPerCode
-					{
-						Code = "IL3050",
-						Messages = new List<string>
-						{
-							"<Module>..cctor(): Using member 'System.Enum.GetValues(Type)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling. It might not be possible to create an array of the enum type at runtime. Use the GetValues<TEnum> overload or the GetValuesAsUnderlyingType method instead.",
-						}
-					},
-				}
-			},
-			new WarningsPerFile
-			{
 				File = "src/Controls/src/Xaml/XamlParser.cs",
 				WarningsPerCode = new List<WarningsPerCode>
 				{


### PR DESCRIPTION
### Description of Change

We are "multitargeting" to 17.0, but this was only really supported in the latest iOS workloads.

Right now, the 17.0 TFM version will always be 17.2.

Maui 8.0.80 with TFM 17.0 is actually 
```
// Microsoft.iOS, Version=17.2.0.0, Culture=neutral, PublicKeyToken=84e04ff9cfb79065
```

When I use the latest SDKs and workloads and try multitarget SkiaSharp to 17.0 because I want to support everyone, I get this error:

> CSC : error CS1705: Assembly 'Microsoft.Maui' with identity 'Microsoft.Maui, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null' uses 'Microsoft.MacCatalyst, Version=17.2.0.0, Culture=neutral, PublicKeyToken=84e04ff9cfb79065' which has a higher version than referenced assembly 'Microsoft.MacCatalyst' with identity 'Microsoft.MacCatalyst, Version=17.0.0.0, Culture=neutral, PublicKeyToken=84e04ff9cfb79065' [D:\GitHub\SkiaSharp\source\SkiaSharp.Views.Maui\SkiaSharp.Views.Maui.Core\SkiaSharp.Views.Maui.Core.csproj::TargetFramework=net8.0-maccatalyst17.0]

I can't use 17.2 in SkiaSharp with the new SDK as the only TFM versions that are supported are 17.0 and 17.5

On Main https://github.com/dotnet/maui/pull/24263