### PR TITLE
Migrate xml docs directly into code for ExtensionPoints

### DIFF
--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration/Android.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration/Android.xml
@@ -16,12 +16,6 @@
       <InterfaceName>Microsoft.Maui.Controls.IConfigPlatform</InterfaceName>
     </Interface>
   </Interfaces>
-  <Docs>
-    <summary>Marker class that identifies the Android platform.</summary>
-    <remarks>
-      <para>Developers specify the type name of this marker class to the <see cref="M:Microsoft.Maui.Controls.IElementConfiguration`1.On``1" /> method to specify the underlying Android control on which to run a platform-specific effect.</para>
-    </remarks>
-  </Docs>
   <Members>
     <Member MemberName=".ctor">
       <MemberSignature Language="C#" Value="public Android ();" />

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration/Tizen.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration/Tizen.xml
@@ -16,12 +16,6 @@
       <InterfaceName>Microsoft.Maui.Controls.IConfigPlatform</InterfaceName>
     </Interface>
   </Interfaces>
-  <Docs>
-    <summary>Marker class that identifies the Tizen platform.</summary>
-    <remarks>
-      <para>Developers specify the type name of this marker class to the <see cref="M:Microsoft.Maui.Controls.IElementConfiguration`1.On``1" /> method to specify the underlying Tizen control on which to run a platform-specific effect.</para>
-    </remarks>
-  </Docs>
   <Members>
     <Member MemberName=".ctor">
       <MemberSignature Language="C#" Value="public Tizen ();" />

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration/Windows.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration/Windows.xml
@@ -16,12 +16,6 @@
       <InterfaceName>Microsoft.Maui.Controls.IConfigPlatform</InterfaceName>
     </Interface>
   </Interfaces>
-  <Docs>
-    <summary>Marker class that identifies the Windows platform.</summary>
-    <remarks>
-      <para>Developers specify the type name of this marker class to the <see cref="M:Microsoft.Maui.Controls.IElementConfiguration`1.On``1" /> method to specify the underlying Windows control on which to run a platform-specific effect.</para>
-    </remarks>
-  </Docs>
   <Members>
     <Member MemberName=".ctor">
       <MemberSignature Language="C#" Value="public Windows ();" />

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration/iOS.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration/iOS.xml
@@ -16,12 +16,6 @@
       <InterfaceName>Microsoft.Maui.Controls.IConfigPlatform</InterfaceName>
     </Interface>
   </Interfaces>
-  <Docs>
-    <summary>Marker class that identifies the iOS platform.</summary>
-    <remarks>
-      <para>Developers specify the type name of this marker class to the <see cref="M:Microsoft.Maui.Controls.IElementConfiguration`1.On``1" /> method to specify the underlying iOS control on which to run a platform-specific effect.</para>
-    </remarks>
-  </Docs>
   <Members>
     <Member MemberName=".ctor">
       <MemberSignature Language="C#" Value="public iOS ();" />

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration/macOS.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration/macOS.xml
@@ -16,10 +16,6 @@
       <InterfaceName>Microsoft.Maui.Controls.IConfigPlatform</InterfaceName>
     </Interface>
   </Interfaces>
-  <Docs>
-    <summary>Marker class that identifies the macOS platform.</summary>
-    <remarks>Developers specify the type name of this marker class to the <see cref="M:Microsoft.Maui.Controls.IElementConfiguration`1.On``1" /> method to specify the underlying iOS control on which to run a platform-specific effect.</remarks>
-  </Docs>
   <Members>
     <Member MemberName=".ctor">
       <MemberSignature Language="C#" Value="public macOS ();" />

--- a/src/Controls/src/Core/PlatformConfiguration/ExtensionPoints.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/ExtensionPoints.cs
@@ -1,4 +1,3 @@
-
 namespace Microsoft.Maui.Controls.PlatformConfiguration
 {
 	/// <summary>
@@ -8,14 +7,36 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration
 	/// Developers specifiy the type name of this marker class to the <see cref="M:Microsoft.Maui.Controls.IElementConfiguration`1.On``1" /> method to specify the underlying Android control on which to run a platform-specific effect.
 	/// </remarks>
 	public sealed class Android : IConfigPlatform { }
-	/// <include file="../../../docs/Microsoft.Maui.Controls.PlatformConfiguration/iOS.xml" path="Type[@FullName='Microsoft.Maui.Controls.PlatformConfiguration.iOS']/Docs/*" />
+
+	/// <summary>
+	/// Marker class that identifies the iOS platform.
+	/// </summary>
+	/// <remarks>
+	/// Developers specify the type name of this marker class to the <see cref = "M:Microsoft.Maui.Controls.IElementConfiguration`1.On``1" /> method to specify the underlying iOS control on which to run a platform-specific effect.
+	/// </remarks>
 	public sealed class iOS : IConfigPlatform { }
-	/// <include file="../../../docs/Microsoft.Maui.Controls.PlatformConfiguration/Windows.xml" path="Type[@FullName='Microsoft.Maui.Controls.PlatformConfiguration.Windows']/Docs/*" />
+
+	/// <summary>
+	/// Marker class that identifies the Windows platform.
+	/// </summary>
+	/// <remarks>
+	/// Developers specify the type name of this marker class to the <see cref = "M:Microsoft.Maui.Controls.IElementConfiguration`1.On``1" /> method to specify the underlying Windows control on which to run a platform-specific effect.
+	/// </remarks>
 	public sealed class Windows : IConfigPlatform { }
-	/// <include file="../../../docs/Microsoft.Maui.Controls.PlatformConfiguration/Tizen.xml" path="Type[@FullName='Microsoft.Maui.Controls.PlatformConfiguration.Tizen']/Docs/*" />
+
+	/// <summary>
+	/// Marker class that identifies the Tizen platform.
+	/// </summary>
+	/// <remarks>
+	/// Developers specify the type name of this marker class to the <see cref = "M:Microsoft.Maui.Controls.IElementConfiguration`1.On``1" /> method to specify the underlying Tizen control on which to run a platform-specific effect.
+	/// </remarks>
 	public sealed class Tizen : IConfigPlatform { }
-	/// <include file="../../../docs/Microsoft.Maui.Controls.PlatformConfiguration/macOS.xml" path="Type[@FullName='Microsoft.Maui.Controls.PlatformConfiguration.macOS']/Docs/*" />
+	/// <summary>Marker class that identifies the macOS platform.</summary>
+	/// <remarks>
+	/// Developers specify the type name of this marker class to the <see cref = "M:Microsoft.Maui.Controls.IElementConfiguration`1.On``1" /> method to specify the underlying iOS control on which to run a platform-specific effect.
+	/// </remarks>
 	public sealed class macOS : IConfigPlatform { }
+
 	/// <include file="../../../docs/Microsoft.Maui.Controls.PlatformConfiguration/GTK.xml" path="Type[@FullName='Microsoft.Maui.Controls.PlatformConfiguration.GTK']/Docs/*" />
 	public sealed class GTK : IConfigPlatform { }
 }

--- a/src/Controls/src/Core/PlatformConfiguration/ExtensionPoints.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/ExtensionPoints.cs
@@ -1,7 +1,12 @@
 
 namespace Microsoft.Maui.Controls.PlatformConfiguration
 {
-	/// <include file="../../../docs/Microsoft.Maui.Controls.PlatformConfiguration/Android.xml" path="Type[@FullName='Microsoft.Maui.Controls.PlatformConfiguration.Android']/Docs/*" />
+	/// <summary>
+	/// Marker class that identifies the Android platform.
+	/// </summary>
+	/// <remarks>
+	/// Developers specifiy the type name of this marker class to the <see cref="M:Microsoft.Maui.Controls.IElementConfiguration`1.On``1" /> method to specify the underlying Android control on which to run a platform-specific effect.
+	/// </remarks>
 	public sealed class Android : IConfigPlatform { }
 	/// <include file="../../../docs/Microsoft.Maui.Controls.PlatformConfiguration/iOS.xml" path="Type[@FullName='Microsoft.Maui.Controls.PlatformConfiguration.iOS']/Docs/*" />
 	public sealed class iOS : IConfigPlatform { }

--- a/src/Controls/src/Core/PlatformConfiguration/ExtensionPoints.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/ExtensionPoints.cs
@@ -4,7 +4,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration
 	/// Marker class that identifies the Android platform.
 	/// </summary>
 	/// <remarks>
-	/// Developers specifiy the type name of this marker class to the <see cref="M:Microsoft.Maui.Controls.IElementConfiguration`1.On``1" /> method to specify the underlying Android control on which to run a platform-specific effect.
+	/// Developers specifiy the type name of this marker class to the <see cref="IElementConfiguration{TElement}.On{T}" /> method to specify the underlying Android control on which to run a platform-specific effect.
 	/// </remarks>
 	public sealed class Android : IConfigPlatform { }
 
@@ -12,7 +12,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration
 	/// Marker class that identifies the iOS platform.
 	/// </summary>
 	/// <remarks>
-	/// Developers specify the type name of this marker class to the <see cref = "M:Microsoft.Maui.Controls.IElementConfiguration`1.On``1" /> method to specify the underlying iOS control on which to run a platform-specific effect.
+	/// Developers specify the type name of this marker class to the <see cref = "IElementConfiguration{TElement}.On{T}" /> method to specify the underlying iOS control on which to run a platform-specific effect.
 	/// </remarks>
 	public sealed class iOS : IConfigPlatform { }
 
@@ -20,7 +20,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration
 	/// Marker class that identifies the Windows platform.
 	/// </summary>
 	/// <remarks>
-	/// Developers specify the type name of this marker class to the <see cref = "M:Microsoft.Maui.Controls.IElementConfiguration`1.On``1" /> method to specify the underlying Windows control on which to run a platform-specific effect.
+	/// Developers specify the type name of this marker class to the <see cref = "IElementConfiguration{TElement}.On{T}" /> method to specify the underlying Windows control on which to run a platform-specific effect.
 	/// </remarks>
 	public sealed class Windows : IConfigPlatform { }
 
@@ -28,15 +28,23 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration
 	/// Marker class that identifies the Tizen platform.
 	/// </summary>
 	/// <remarks>
-	/// Developers specify the type name of this marker class to the <see cref = "M:Microsoft.Maui.Controls.IElementConfiguration`1.On``1" /> method to specify the underlying Tizen control on which to run a platform-specific effect.
+	/// Developers specify the type name of this marker class to the <see cref = "IElementConfiguration{TElement}.On{T}" /> method to specify the underlying Tizen control on which to run a platform-specific effect.
 	/// </remarks>
 	public sealed class Tizen : IConfigPlatform { }
-	/// <summary>Marker class that identifies the macOS platform.</summary>
+	
+	/// <summary>
+	/// Marker class that identifies the macOS platform.
+	/// </summary>
 	/// <remarks>
-	/// Developers specify the type name of this marker class to the <see cref = "M:Microsoft.Maui.Controls.IElementConfiguration`1.On``1" /> method to specify the underlying iOS control on which to run a platform-specific effect.
+	/// Developers specify the type name of this marker class to the <see cref = "IElementConfiguration{TElement}.On{T}" /> method to specify the underlying macOS control on which to run a platform-specific effect.
 	/// </remarks>
 	public sealed class macOS : IConfigPlatform { }
 
-	/// <include file="../../../docs/Microsoft.Maui.Controls.PlatformConfiguration/GTK.xml" path="Type[@FullName='Microsoft.Maui.Controls.PlatformConfiguration.GTK']/Docs/*" />
+	/// <summary>
+	/// Marker class that identifies the Linux platform.
+	/// </summary>
+	/// /// <remarks>
+	/// Developers specify the type name of this marker class to the <see cref = "IElementConfiguration{TElement}.On{T}" /> method to specify the underlying GTK control on which to run a platform-specific effect.
+	/// </remarks>
 	public sealed class GTK : IConfigPlatform { }
 }


### PR DESCRIPTION
### Description of Change

Move code from external xml files directly into the code files. In this case, we are porting platform config docs directly into the ExtensionPoints.cs file.
