### PR TITLE
[Windows] Handle focus events using `FocusManager`

### DIFF
--- a/src/Core/src/Handlers/View/ViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.Windows.cs
@@ -1,6 +1,7 @@
 ﻿#nullable enable
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Input;
@@ -10,7 +11,7 @@ namespace Microsoft.Maui.Handlers
 {
 	public partial class ViewHandler
 	{
-		static Dictionary<PlatformView, ViewHandler>? FocusManagerMapping;
+		static ConditionalWeakTable<PlatformView, ViewHandler>? FocusManagerMapping;
 
 		partial void ConnectingHandler(PlatformView? platformView)
 		{

--- a/src/Core/src/Platform/Windows/ViewExtensions.cs
+++ b/src/Core/src/Platform/Windows/ViewExtensions.cs
@@ -19,6 +19,21 @@ namespace Microsoft.Maui.Platform
 {
 	public static partial class ViewExtensions
 	{
+		internal static readonly DependencyProperty MauiHandlerProperty = DependencyProperty.RegisterAttached("MauiHandler",
+			typeof(WeakReference<ViewHandler>), typeof(FrameworkElement), new PropertyMetadata(null));
+
+		internal static void SetMauiHandler(this FrameworkElement element, ViewHandler? handler)
+		{
+			var weakRef = handler != null ? new WeakReference<ViewHandler>(handler) : null;
+			element.SetValue(MauiHandlerProperty, weakRef);
+		}
+
+		internal static ViewHandler? GetMauiHandler(this FrameworkElement element)
+		{
+			var weakRef = (WeakReference<ViewHandler>?)element.GetValue(MauiHandlerProperty);
+			return weakRef?.TryGetTarget(out var viewHandler) == true ? viewHandler : null;
+		}
+		
 		public static void TryMoveFocus(this FrameworkElement platformView, FocusNavigationDirection direction)
 		{
 			if (platformView?.XamlRoot?.Content is UIElement elem)
@@ -36,7 +51,9 @@ namespace Microsoft.Maui.Platform
 		public static void Unfocus(this FrameworkElement platformView, IView view)
 		{
 			if (platformView is Control control)
+			{
 				UnfocusControl(control);
+			}
 		}
 
 		public static void UpdateVisibility(this FrameworkElement platformView, IView view)
@@ -378,8 +395,10 @@ namespace Microsoft.Maui.Platform
 
 		internal static void UnfocusControl(Control control)
 		{
-			if (control == null || !control.IsEnabled)
+			if (!control.IsEnabled)
+			{
 				return;
+			}
 
 			var isTabStop = control.IsTabStop;
 			control.IsTabStop = false;

--- a/src/Core/tests/DeviceTests.Shared/HandlerTests/Focus/FocusHandlerTests.cs
+++ b/src/Core/tests/DeviceTests.Shared/HandlerTests/Focus/FocusHandlerTests.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Maui.DeviceTests
 				Assert.True(inputControl1.IsFocused);
 				Assert.False(inputControl2.IsFocused);
 
-				// UNfocus the first control (revert the focus)
+				// Unfocus the first control (revert the focus)
 				inputControl1.Handler.Invoke(nameof(IView.Unfocus));
 
 				// assert

--- a/src/TestUtils/src/DeviceTests/AssertionExtensions.Windows.cs
+++ b/src/TestUtils/src/DeviceTests/AssertionExtensions.Windows.cs
@@ -13,6 +13,7 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media.Imaging;
 using Windows.Graphics.DirectX;
 using Windows.Storage.Streams;
+using Microsoft.UI.Xaml.Input;
 using Xunit;
 using Xunit.Sdk;
 using WColor = Windows.UI.Color;
@@ -49,7 +50,8 @@ namespace Microsoft.Maui.DeviceTests
 		public static async Task WaitForFocused(this FrameworkElement view, int timeout = 1000)
 		{
 			TaskCompletionSource focusSource = new TaskCompletionSource();
-			view.GotFocus += OnFocused;
+
+			FocusManager.GotFocus += OnFocused;
 
 			try
 			{
@@ -57,20 +59,24 @@ namespace Microsoft.Maui.DeviceTests
 			}
 			finally
 			{
-				view.GotFocus -= OnFocused;
+				FocusManager.GotFocus -= OnFocused;
 			}
 
-			void OnFocused(object? sender, RoutedEventArgs e)
+			void OnFocused(object? sender, FocusManagerGotFocusEventArgs e)
 			{
-				view.GotFocus -= OnFocused;
-				focusSource.SetResult();
+				if (e.NewFocusedElement == view)
+				{
+					FocusManager.GotFocus -= OnFocused;
+					focusSource.SetResult();
+				}
 			}
 		}
 
 		public static async Task WaitForUnFocused(this FrameworkElement view, int timeout = 1000)
 		{
 			TaskCompletionSource focusSource = new TaskCompletionSource();
-			view.LostFocus += OnUnFocused;
+
+			FocusManager.LostFocus += OnUnFocused;
 
 			try
 			{
@@ -78,13 +84,16 @@ namespace Microsoft.Maui.DeviceTests
 			}
 			finally
 			{
-				view.LostFocus -= OnUnFocused;
+				FocusManager.LostFocus -= OnUnFocused;
 			}
 
-			void OnUnFocused(object? sender, RoutedEventArgs e)
+			void OnUnFocused(object? sender, FocusManagerLostFocusEventArgs e)
 			{
-				view.LostFocus -= OnUnFocused;
-				focusSource.SetResult();
+				if (e.OldFocusedElement == view)
+				{
+					FocusManager.LostFocus -= OnUnFocused;
+					focusSource.SetResult();
+				}
 			}
 		}
 


### PR DESCRIPTION
Alternative to #23885

### Description of Change

[Subscribing](https://github.com/dotnet/maui/blob/af2b66835f5fa99732c120b6358dd2b6e2e3581b/src/Core/src/Handlers/View/ViewHandler.Windows.cs#L18-L19) and [unsubscribing](https://github.com/dotnet/maui/blob/af2b66835f5fa99732c120b6358dd2b6e2e3581b/src/Core/src/Handlers/View/ViewHandler.Windows.cs#L27-L28) focus events for each MAUI view is costly. 

This PR attempts to use `FocusManager` [events](https://learn.microsoft.com/en-us/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.input.focusmanager?view=windows-app-sdk-1.5#events) to achieve the same result.

### Performance impact

* [1725976162..speedscope.main.json](https://github.com/user-attachments/files/16945922/1725976162.speedscope.main.json)
* [1725976022..speedscope.PR.json](https://github.com/user-attachments/files/16945921/1725976022.speedscope.PR.json)

![image](https://github.com/user-attachments/assets/345e86c1-28a0-4b88-857e-04e19c88e8ee)

-> 64% improvement

### Issues Fixed

Contributes to #21787