### PR TITLE
Fix border lagging and unwanted animations on iOS

### DIFF
--- a/src/Compatibility/Core/src/MacOS/Extensions/BrushExtensions.cs
+++ b/src/Compatibility/Core/src/MacOS/Extensions/BrushExtensions.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.MacOS
 				var p1 = linearGradientBrush.StartPoint;
 				var p2 = linearGradientBrush.EndPoint;
 
-				var linearGradientLayer = new CAGradientLayer
+				var linearGradientLayer = new StaticCAGradientLayer
 				{
 					Name = BackgroundLayer,
 					AutoresizingMask = CAAutoresizingMask.HeightSizable | CAAutoresizingMask.WidthSizable,
@@ -86,7 +86,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.MacOS
 				var center = radialGradientBrush.Center;
 				var radius = radialGradientBrush.Radius;
 
-				var radialGradientLayer = new CAGradientLayer
+				var radialGradientLayer = new StaticCAGradientLayer
 				{
 					Name = BackgroundLayer,
 					Frame = control.Bounds,

--- a/src/Compatibility/Core/src/iOS/VisualElementTracker.cs
+++ b/src/Compatibility/Core/src/iOS/VisualElementTracker.cs
@@ -416,7 +416,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.MacOS
 			var formsGeometry = element.Clip;
 			var nativeGeometry = formsGeometry.ToCGPath();
 
-			var maskLayer = new CAShapeLayer
+			var maskLayer = new StaticCAShapeLayer
 			{
 				Name = ClipShapeLayer,
 				Path = nativeGeometry.Data,

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellFlyoutLayoutManager.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellFlyoutLayoutManager.cs
@@ -293,7 +293,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				if (_context.Shell.FlyoutHeaderBehavior == FlyoutHeaderBehavior.Scroll && HeaderViewTopVerticalOffset > 0 && _headerOffset < 0)
 				{
 					var headerHeight = Math.Max(HeaderMinimumHeight, ArrangedHeaderViewHeightWithMargin + _headerOffset);
-					CAShapeLayer shapeLayer = new CAShapeLayer();
+					CAShapeLayer shapeLayer = new StaticCAShapeLayer();
 					CGRect rect = new CGRect(0, _headerOffset * -1, parentFrame.Width, headerHeight);
 					var path = CGPath.FromRect(rect);
 					shapeLayer.Path = path;

--- a/src/Controls/src/Core/Platform/iOS/Extensions/BrushExtensions.cs
+++ b/src/Controls/src/Core/Platform/iOS/Extensions/BrushExtensions.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 			if (brush is SolidColorBrush solidColorBrush)
 			{
-				var linearGradientLayer = new CALayer
+				var linearGradientLayer = new StaticCALayer
 				{
 					Name = BackgroundLayer,
 					ContentsGravity = CALayer.GravityResizeAspectFill,
@@ -60,7 +60,7 @@ namespace Microsoft.Maui.Controls.Platform
 				var p1 = linearGradientBrush.StartPoint;
 				var p2 = linearGradientBrush.EndPoint;
 
-				var linearGradientLayer = new CAGradientLayer
+				var linearGradientLayer = new StaticCAGradientLayer
 				{
 					Name = BackgroundLayer,
 					ContentsGravity = CALayer.GravityResizeAspectFill,
@@ -85,7 +85,7 @@ namespace Microsoft.Maui.Controls.Platform
 				var center = radialGradientBrush.Center;
 				var radius = radialGradientBrush.Radius;
 
-				var radialGradientLayer = new CAGradientLayer
+				var radialGradientLayer = new StaticCAGradientLayer
 				{
 					Name = BackgroundLayer,
 					ContentsGravity = CALayer.GravityResizeAspectFill,
@@ -176,30 +176,8 @@ namespace Microsoft.Maui.Controls.Platform
 			}
 		}
 
-		public static void UpdateBackgroundLayer(this UIView view)
-		{
-			if (view == null || view.Frame.IsEmpty)
-				return;
-
-			var layer = view.Layer;
-
-			UpdateBackgroundLayer(layer, view.Bounds);
-		}
-
-		static void UpdateBackgroundLayer(this CALayer layer, CGRect bounds)
-		{
-			var sublayers = layer?.Sublayers;
-			if (sublayers is not null)
-			{
-				foreach (var sublayer in sublayers)
-				{
-					UpdateBackgroundLayer(sublayer, bounds);
-
-					if (sublayer.Name == BackgroundLayer && sublayer.Frame != bounds)
-						sublayer.Frame = bounds;
-				}
-			}
-		}
+		public static void UpdateBackgroundLayer(this UIView view) =>
+			view.UpdateBackgroundLayerFrame(BackgroundLayer);
 
 		static CGPoint GetRadialGradientBrushEndPoint(Point startPoint, double radius)
 		{

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue18204.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue18204.xaml
@@ -3,7 +3,12 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="Maui.Controls.Sample.Issues.Issue18204"
              Title="Issue18204">
-
+    <ContentPage.Resources>
+      <Color x:Key="TealFadeStart">#1B836D</Color>
+      <Color x:Key="TealFadeEnd">#015b66</Color>
+      <Color x:Key="TealFadeStartHover">#2aab88</Color>
+      <Color x:Key="TealFadeEndHover">#026875</Color>
+    </ContentPage.Resources>
     <VerticalStackLayout Padding="24">
       <Border
         HorizontalOptions="Center"
@@ -12,6 +17,34 @@
         Shadow="{Shadow Brush=Black, Offset='0,2', Radius=2, Opacity=0.20}"
         StrokeShape="{RoundRectangle CornerRadius=20}">
         <Button x:Name="TheButton" Clicked="ButtonClicked" BackgroundColor="LightGreen" WidthRequest="200" HeightRequest="500" />
+      </Border>
+      <Border x:Name="TheOtherButton"
+              BackgroundColor="Transparent"
+              StrokeShape="{RoundRectangle CornerRadius=20}"
+              StrokeThickness="0"
+              IsVisible="False"
+              Stroke="Transparent">
+        <Border.Background>
+          <LinearGradientBrush StartPoint="0,0" EndPoint="1,0">
+            <GradientStop Offset="0.1" Color="{DynamicResource TealFadeEnd}" />
+            <GradientStop Offset="1.0" Color="{DynamicResource TealFadeStart}" />
+          </LinearGradientBrush>
+        </Border.Background>
+        <Border.Content>
+          <Grid ColumnDefinitions="auto,*,auto"
+                Padding="16,8">
+              <Label Grid.Column="0"
+                     FontSize="24"
+                     Text="Hello" />
+              <Label Grid.Column="1"
+                     FontSize="24"
+                     Text="awesome"
+                     HorizontalTextAlignment="Center"/>
+              <Label Grid.Column="2"
+                     FontSize="24"
+                     Text="World!" />
+          </Grid>
+        </Border.Content>
       </Border>
     </VerticalStackLayout>
 </ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue18204.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue18204.xaml
@@ -9,19 +9,29 @@
       <Color x:Key="TealFadeStartHover">#2aab88</Color>
       <Color x:Key="TealFadeEndHover">#026875</Color>
     </ContentPage.Resources>
-    <VerticalStackLayout Padding="24">
+    <VerticalStackLayout Padding="24" Spacing="30">
+      <Button AutomationId="ChangeSize"
+              Clicked="ChangeSizeClicked"
+              Text="Change Size"
+              BackgroundColor="WhiteSmoke"
+              WidthRequest="200" />
+      <Button AutomationId="ShowHide"
+              Clicked="ShowHideClicked"
+              Text="Show/Hide"
+              BackgroundColor="WhiteSmoke"
+              WidthRequest="200" />
       <Border
         HorizontalOptions="Center"
-        x:Name="TheBorder"
         BackgroundColor="LightBlue"
-        Shadow="{Shadow Brush=Black, Offset='0,2', Radius=2, Opacity=0.20}"
+        Shadow="{Shadow Brush=Black, Offset='0,2', Radius=24, Opacity=0.2}"
         StrokeShape="{RoundRectangle CornerRadius=20}">
-        <Button x:Name="TheButton" Clicked="ButtonClicked" BackgroundColor="LightGreen" WidthRequest="200" HeightRequest="500" />
+        <Button x:Name="TheButton" BackgroundColor="LightGreen" WidthRequest="200" HeightRequest="400" />
       </Border>
       <Border x:Name="TheOtherButton"
               BackgroundColor="Transparent"
               StrokeShape="{RoundRectangle CornerRadius=20}"
               StrokeThickness="0"
+              Shadow="{Shadow Brush=Black, Offset='0,2', Radius=24, Opacity=0.5}"
               IsVisible="False"
               Stroke="Transparent">
         <Border.Background>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue18204.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue18204.xaml.cs
@@ -13,6 +13,10 @@ public partial class Issue18204 : ContentPage
 	public Issue18204()
 	{
 		InitializeComponent();
+		Dispatcher.DispatchDelayed(TimeSpan.FromSeconds(3), () =>
+		{
+			TheOtherButton.IsVisible = true;
+		});
 	}
 
 	private void ButtonClicked(object sender, EventArgs e)

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue18204.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue18204.xaml.cs
@@ -13,17 +13,19 @@ public partial class Issue18204 : ContentPage
 	public Issue18204()
 	{
 		InitializeComponent();
-		Dispatcher.DispatchDelayed(TimeSpan.FromSeconds(3), () =>
-		{
-			TheOtherButton.IsVisible = true;
-		});
 	}
 
-	private void ButtonClicked(object sender, EventArgs e)
+	private void ChangeSizeClicked(object sender, EventArgs e)
 	{
-		var button = (Button)sender;
+		var button = TheButton;
 		button.CancelAnimations();
-		var targetHeight = button.HeightRequest == 200.0 ? 500.0 : 200.0;
+		var targetHeight = button.HeightRequest == 200.0 ? 400.0 : 200.0;
 		button.Animate("Height", new Animation(v => button.HeightRequest = v, button.Height, targetHeight, Easing.Linear));
+	}
+	
+	private void ShowHideClicked(object sender, EventArgs e)
+	{
+		var button = TheOtherButton;
+		button.IsVisible = !button.IsVisible;
 	}
 }

--- a/src/Core/src/Graphics/PaintExtensions.iOS.cs
+++ b/src/Core/src/Graphics/PaintExtensions.iOS.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Maui.Graphics
 
 		public static CALayer? CreateCALayer(this SolidPaint solidPaint, CGRect frame = default)
 		{
-			var solidColorLayer = new CALayer
+			var solidColorLayer = new StaticCALayer
 			{
 				ContentsGravity = CALayer.GravityResizeAspectFill,
 				Frame = frame,
@@ -57,7 +57,7 @@ namespace Microsoft.Maui.Graphics
 			var p1 = linearGradientPaint.StartPoint;
 			var p2 = linearGradientPaint.EndPoint;
 
-			var linearGradientLayer = new CAGradientLayer
+			var linearGradientLayer = new StaticCAGradientLayer
 			{
 				ContentsGravity = CALayer.GravityResizeAspectFill,
 				Frame = frame,
@@ -81,7 +81,7 @@ namespace Microsoft.Maui.Graphics
 			var center = radialGradientPaint.Center;
 			var radius = radialGradientPaint.Radius;
 
-			var radialGradientLayer = new CAGradientLayer
+			var radialGradientLayer = new StaticCAGradientLayer
 			{
 				ContentsGravity = CALayer.GravityResizeAspectFill,
 				Frame = frame,

--- a/src/Core/src/Handlers/Border/BorderHandler.iOS.cs
+++ b/src/Core/src/Handlers/Border/BorderHandler.iOS.cs
@@ -20,11 +20,6 @@ namespace Microsoft.Maui.Handlers
 			};
 		}
 
-		protected override void ConnectHandler(ContentView platformView)
-		{
-			base.ConnectHandler(platformView);
-		}
-
 		protected override void DisconnectHandler(ContentView platformView)
 		{
 			base.DisconnectHandler(platformView);

--- a/src/Core/src/Platform/iOS/ContentView.cs
+++ b/src/Core/src/Platform/iOS/ContentView.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Maui.Platform
 				return;
 			}
 
-			_contentMask ??= new CAShapeLayer();
+			_contentMask ??= new MauiCAClipLayer();
 
 			var bounds = Bounds;
 
@@ -93,12 +93,6 @@ namespace Microsoft.Maui.Platform
 			var clipBounds = new RectF(0, 0, clipWidth, clipHeight);
 			_contentMask.Path = GetClipPath(clipBounds, strokeThickness);
 
-			// Set the mask on the content, if it isn't already
-			if (content.Layer.Mask != _contentMask)
-			{
-				content.Layer.Mask = _contentMask;
-			}
-
 			// Since the mask is on the content's CALayer, it's anchored to the content. But we need it to be
 			// relative to _this_ container. So we need to compute an adjusted position for it.
 
@@ -112,16 +106,14 @@ namespace Microsoft.Maui.Platform
 
 			CGPoint adjustedMaskPosition = new(clipCenterX - contentOffsetX, clipCenterY - contentOffsetY);
 
-			// Relocating/resizing a layer is animated by default; the mask will slide around as we do things like
-			// resize the content that's being masked. To prevent his, we need to set the animation duration 
-			// to zero during the operation. We'll do that in its own transaction so as not to change the default
-			// animation durations for everything else.
-
-			CATransaction.Begin();
-			CATransaction.AnimationDuration = 0;
 			_contentMask.Bounds = clipBounds;
 			_contentMask.Position = adjustedMaskPosition;
-			CATransaction.Commit();
+
+			// Set the mask on the content, if it isn't already
+			if (content.Layer.Mask != _contentMask)
+			{
+				content.Layer.Mask = _contentMask;
+			}
 		}
 
 		CGPath? GetClipPath(RectF bounds, float strokeThickness)

--- a/src/Core/src/Platform/iOS/ContentView.cs
+++ b/src/Core/src/Platform/iOS/ContentView.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Maui.Platform
 			base.LayoutSubviews();
 
 			UpdateClip();
-			this.UpdateMauiCALayer();
+			this.UpdateBackgroundLayerFrame();
 		}
 
 		internal IBorderStroke? Clip
@@ -78,7 +78,7 @@ namespace Microsoft.Maui.Platform
 				return;
 			}
 
-			_contentMask ??= new MauiCAClipLayer();
+			_contentMask ??= new StaticCAShapeLayer();
 
 			var bounds = Bounds;
 

--- a/src/Core/src/Platform/iOS/MauiCAClipLayer.cs
+++ b/src/Core/src/Platform/iOS/MauiCAClipLayer.cs
@@ -1,0 +1,11 @@
+using CoreAnimation;
+
+namespace Microsoft.Maui.Platform;
+
+class MauiCAClipLayer : CAShapeLayer
+{
+	public override void AddAnimation(CAAnimation animation, string? key)
+	{
+		// Do nothing, we don't want animations here
+	}
+}

--- a/src/Core/src/Platform/iOS/MauiCALayer.cs
+++ b/src/Core/src/Platform/iOS/MauiCALayer.cs
@@ -5,7 +5,6 @@ using CoreAnimation;
 using CoreGraphics;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Graphics.Platform;
-using ObjCRuntime;
 using UIKit;
 
 namespace Microsoft.Maui.Platform
@@ -36,6 +35,11 @@ namespace Microsoft.Maui.Platform
 			_bounds = new CGRect();
 
 			ContentsScale = UIScreen.MainScreen.Scale;
+		}
+
+		public override void AddAnimation(CAAnimation animation, string? key)
+		{
+			// Do nothing, we don't want animations here
 		}
 
 		public override void LayoutSublayers()

--- a/src/Core/src/Platform/iOS/StaticCAGradientLayer.cs
+++ b/src/Core/src/Platform/iOS/StaticCAGradientLayer.cs
@@ -1,0 +1,11 @@
+using CoreAnimation;
+
+namespace Microsoft.Maui.Platform;
+
+class StaticCAGradientLayer : CAGradientLayer
+{
+	public override void AddAnimation(CAAnimation animation, string? key)
+	{
+		// Do nothing, we don't want animations here
+	}
+}

--- a/src/Core/src/Platform/iOS/StaticCALayer.cs
+++ b/src/Core/src/Platform/iOS/StaticCALayer.cs
@@ -1,0 +1,11 @@
+using CoreAnimation;
+
+namespace Microsoft.Maui.Platform;
+
+class StaticCALayer : CALayer
+{
+	public override void AddAnimation(CAAnimation animation, string? key)
+	{
+		// Do nothing, we don't want animations here
+	}
+}

--- a/src/Core/src/Platform/iOS/StaticCAShapeLayer.cs
+++ b/src/Core/src/Platform/iOS/StaticCAShapeLayer.cs
@@ -2,7 +2,7 @@ using CoreAnimation;
 
 namespace Microsoft.Maui.Platform;
 
-class MauiCAClipLayer : CAShapeLayer
+class StaticCAShapeLayer : CAShapeLayer
 {
 	public override void AddAnimation(CAAnimation animation, string? key)
 	{

--- a/src/Core/src/Platform/iOS/StrokeExtensions.cs
+++ b/src/Core/src/Platform/iOS/StrokeExtensions.cs
@@ -101,7 +101,6 @@ namespace Microsoft.Maui.Platform
 
 			platformView.UpdateMauiCALayer(border);
 		}
-		
 		internal static void UpdateMauiCALayer(this UIView platformView, IBorderStroke? border)
 		{
 			CALayer? backgroundLayer = platformView.Layer as MauiCALayer;

--- a/src/Core/src/Platform/iOS/StrokeExtensions.cs
+++ b/src/Core/src/Platform/iOS/StrokeExtensions.cs
@@ -157,44 +157,5 @@ namespace Microsoft.Maui.Platform
 				contentView.Clip = border;
 			}
 		}
-
-		internal static void UpdateMauiCALayer(this UIView view)
-		{
-			if (view.Frame.IsEmpty)
-			{
-				return;
-			}
-
-			var layer = view.Layer;
-			if (layer?.Sublayers is { Length: > 0 } sublayers)
-			{
-				var bounds = view.Bounds;
-				var backgroundLayers = GetBackgroundLayersNeedingUpdate(sublayers, bounds);
-
-				foreach (CALayer backgroundLayer in backgroundLayers)
-				{
-					backgroundLayer.Frame = bounds;
-				}
-			}
-		}
-
-		static IEnumerable<CALayer> GetBackgroundLayersNeedingUpdate(this CALayer[] layers, CGRect bounds)
-		{
-			foreach (var layer in layers)
-			{
-				if (layer.Sublayers is { Length: > 0 } sublayers)
-				{
-					foreach (var sublayer in GetBackgroundLayersNeedingUpdate(sublayers, bounds))
-					{
-						yield return sublayer;
-					}
-				}
-
-				if (layer.Name == ViewExtensions.BackgroundLayerName && layer.Frame != bounds)
-				{
-					yield return layer;
-				}
-			}
-		}
 	}
 }

--- a/src/Core/src/Platform/iOS/StrokeExtensions.cs
+++ b/src/Core/src/Platform/iOS/StrokeExtensions.cs
@@ -101,7 +101,7 @@ namespace Microsoft.Maui.Platform
 
 			platformView.UpdateMauiCALayer(border);
 		}
-
+		
 		internal static void UpdateMauiCALayer(this UIView platformView, IBorderStroke? border)
 		{
 			CALayer? backgroundLayer = platformView.Layer as MauiCALayer;
@@ -134,8 +134,6 @@ namespace Microsoft.Maui.Platform
 
 			if (backgroundLayer is MauiCALayer mauiCALayer)
 			{
-				backgroundLayer.Frame = platformView.Bounds;
-
 				if (border is IView view)
 					mauiCALayer.SetBackground(view.Background);
 				else
@@ -156,7 +154,9 @@ namespace Microsoft.Maui.Platform
 			}
 
 			if (platformView is ContentView contentView)
+			{
 				contentView.Clip = border;
+			}
 		}
 
 		internal static void UpdateMauiCALayer(this UIView view)
@@ -171,7 +171,11 @@ namespace Microsoft.Maui.Platform
 			{
 				var bounds = view.Bounds;
 				var backgroundLayers = GetBackgroundLayersNeedingUpdate(sublayers, bounds);
-				backgroundLayers.UpdateBackgroundLayers(bounds);
+
+				foreach (CALayer backgroundLayer in backgroundLayers)
+				{
+					backgroundLayer.Frame = bounds;
+				}
 			}
 		}
 
@@ -191,29 +195,6 @@ namespace Microsoft.Maui.Platform
 				{
 					yield return layer;
 				}
-			}
-		}
-		
-		static void UpdateBackgroundLayers(this IEnumerable<CALayer> backgroundLayers, CGRect bounds)
-		{
-			using var backgroundLayerEnumerator = backgroundLayers.GetEnumerator();
-
-			if (backgroundLayerEnumerator.MoveNext())
-			{
-				// iOS by default adds animations to certain actions such as layer resizing (setting the Frame property).
-				// This can result in the background layer not keeping up with animations controlled by MAUI.
-				// To prevent this undesired effect, native animations will be turned off for the duration of the operation.
-				CATransaction.Begin();
-				CATransaction.AnimationDuration = 0;
-				
-				do
-				{
-					var backgroundLayer = backgroundLayerEnumerator.Current;
-					backgroundLayer.Frame = bounds;
-				}
-				while (backgroundLayerEnumerator.MoveNext());
-				
-				CATransaction.Commit();
 			}
 		}
 	}

--- a/src/Core/src/Platform/iOS/ViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/ViewExtensions.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Numerics;
 using System.Threading.Tasks;
+using CoreAnimation;
 using CoreGraphics;
 using Foundation;
 using Microsoft.Maui.Graphics;
@@ -245,21 +246,36 @@ namespace Microsoft.Maui.Platform
 		public static T? FindDescendantView<T>(this UIView view) where T : UIView =>
 			FindDescendantView<T>(view, (_) => true);
 
-		public static void UpdateBackgroundLayerFrame(this UIView view)
+		public static void UpdateBackgroundLayerFrame(this UIView view) =>
+			view.UpdateBackgroundLayerFrame(BackgroundLayerName);
+
+		internal static void UpdateBackgroundLayerFrame(this UIView view, string layerName)
 		{
-			if (view == null || view.Frame.IsEmpty)
-				return;
-
-			var sublayers = view.Layer?.Sublayers;
-			if (sublayers is null || sublayers.Length == 0)
-				return;
-
-			foreach (var sublayer in sublayers)
+			if (view.Frame.IsEmpty)
 			{
-				if (sublayer.Name == BackgroundLayerName && sublayer.Frame != view.Bounds)
+				return;
+			}
+
+			var layer = view.Layer;
+			if (layer?.Sublayers is { Length: > 0 } sublayers)
+			{
+				var bounds = view.Bounds;
+				UpdateBackgroundLayers(sublayers, layerName, bounds);
+			}
+		}
+
+		static void UpdateBackgroundLayers(this CALayer[] layers, string layerName, CGRect bounds)
+		{
+			foreach (var layer in layers)
+			{
+				if (layer.Sublayers is { Length: > 0 } sublayers)
 				{
-					sublayer.Frame = view.Bounds;
-					break;
+					UpdateBackgroundLayers(sublayers, layerName, bounds);
+				}
+
+				if (layer.Name == layerName && layer.Frame != bounds)
+				{
+					layer.Frame = bounds;
 				}
 			}
 		}

--- a/src/Core/src/Platform/iOS/WrapperView.cs
+++ b/src/Core/src/Platform/iOS/WrapperView.cs
@@ -268,7 +268,7 @@ namespace Microsoft.Maui.Platform
 			var path = _clip?.PathForBounds(bounds);
 			var nativePath = path?.AsCGPath();
 
-			mask ??= MaskLayer = new CAShapeLayer();
+			mask ??= MaskLayer = new StaticCAShapeLayer();
 			mask.Path = nativePath;
 
 			var backgroundLayer = GetBackgroundLayer();
@@ -278,7 +278,7 @@ namespace Microsoft.Maui.Platform
 			if (backgroundLayer is null)
 				return;
 
-			backgroundMask ??= BackgroundMaskLayer = new CAShapeLayer();
+			backgroundMask ??= BackgroundMaskLayer = new StaticCAShapeLayer();
 			backgroundMask.Path = nativePath;
 		}
 
@@ -289,7 +289,7 @@ namespace Microsoft.Maui.Platform
 			if (shadowLayer == null && Shadow == null)
 				return;
 
-			shadowLayer ??= ShadowLayer = new CAShapeLayer();
+			shadowLayer ??= ShadowLayer = new StaticCAShapeLayer();
 
 			var frame = Frame;
 			var bounds = new RectF(0, 0, (float)frame.Width, (float)frame.Height);

--- a/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+override Microsoft.Maui.Platform.MauiCALayer.AddAnimation(CoreAnimation.CAAnimation! animation, string? key) -> void
+*REMOVED*override Microsoft.Maui.Handlers.BorderHandler.ConnectHandler(Microsoft.Maui.Platform.ContentView! platformView) -> void

--- a/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+override Microsoft.Maui.Platform.MauiCALayer.AddAnimation(CoreAnimation.CAAnimation! animation, string? key) -> void
+*REMOVED*override Microsoft.Maui.Handlers.BorderHandler.ConnectHandler(Microsoft.Maui.Platform.ContentView! platformView) -> void


### PR DESCRIPTION
### Description of Change

Fixes border animations by simply overriding the `AddAnimation` method and make it a noop.

We can therefore get rid of the `CATransaction` code and simply relay on the fact that our layers will not animate.

I really hope this is the last time we fix this :D

#### Before

![before](https://github.com/user-attachments/assets/dceccb8e-7c80-4763-aca8-547ae0cbc77d)


#### After

https://github.com/user-attachments/assets/9bb0fb45-4999-4e37-abbc-90f12a39d3dd



### Issues Fixed

Fixes #24104 
Fixes #21643 (confirmed https://github.com/dotnet/maui/issues/21643#issuecomment-2306489929)
Fixes #23688 (confirmed https://github.com/dotnet/maui/issues/23688#issuecomment-2308421735)