### PR TITLE
Fix "XamlC error: key was not present in the dictionary" when `OnIdiom` is used in…

### DIFF
--- a/src/Controls/src/Build.Tasks/NodeILExtensions.cs
+++ b/src/Controls/src/Build.Tasks/NodeILExtensions.cs
@@ -650,12 +650,19 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 				yield return Create(Ldtoken, module.ImportReference(context.Cache, ("Microsoft.Maui.Controls", "Microsoft.Maui.Controls.Xaml", "IProvideValueTarget")));
 				yield return Create(Call, module.ImportMethodReference(context.Cache, ("mscorlib", "System", "Type"), methodName: "GetTypeFromHandle", parameterTypes: new[] { ("mscorlib", "System", "RuntimeTypeHandle") }, isStatic: true));
 
-				if (node.Parent is IElementNode elementNode)
-					foreach (var instruction in context.Variables[elementNode].LoadAs(context.Cache, module.TypeSystem.Object, module))
+				if (node.Parent is IElementNode elementNode &&
+					context.Variables.TryGetValue(elementNode, out VariableDefinition variableDefinition))
+				{
+					foreach (var instruction in variableDefinition.LoadAs(context.Cache, module.TypeSystem.Object, module))
+					{
 						yield return instruction;
+					}
+				}
 				else
+				{
 					yield return Create(Ldnull);
-				
+				}
+
 				foreach (var instruction in PushTargetProperty(context, bpRef, propertyRef, declaringTypeReference, module))
 					yield return instruction;
 

--- a/src/Controls/tests/Xaml.UnitTests/OnPlatform.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/OnPlatform.xaml
@@ -33,7 +33,7 @@
             </Style>
 		</ResourceDictionary>
 	</ContentPage.Resources>
-	<StackLayout>
+  <StackLayout Spacing="{OnPlatform iOS={OnIdiom Default=35, Phone=25}, WinUI=25, Android={OnIdiom Default=45, Phone=25}}">
 		<Label x:Name="label0" FontAttributes="{StaticResource fontAttributes}" FontSize="{StaticResource fontSize}">
 			<Label.IsVisible>
 				<OnPlatform x:TypeArguments="x:Boolean">


### PR DESCRIPTION
### Description of Change

Fix "XamlC error: key was not present in the dictionary" when `OnIdiom` is used in `OnPlatform`:
`Spacing="{OnPlatform iOS={OnIdiom Default=35, Phone=25}, WinUI=25, Android={OnIdiom Default=45, Phone=25}}"`

The issue seems to have been caused by https://github.com/dotnet/maui/commit/f690a5116921885f533f269114ecc4384578c16b

### Issues Fixed

Fixes #23970
