### PR TITLE
Stepper doesn't change increment value when being bound to a double in MVVM context (Windows)

### DIFF
--- a/src/Controls/src/Core/Stepper/Stepper.cs
+++ b/src/Controls/src/Core/Stepper/Stepper.cs
@@ -105,7 +105,5 @@ namespace Microsoft.Maui.Controls
 
 		/// <inheritdoc/>
 		public IPlatformElementConfiguration<T, Stepper> On<T>() where T : IConfigPlatform => _platformConfigurationRegistry.Value.On<T>();
-
-		double IStepper.Interval => Increment;
 	}
 }

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue20706.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue20706.xaml
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Maui.Controls.Sample.Issues.Issue20706"
+             xmlns:local="clr-namespace:Maui.Controls.Sample.Issues">
+  <ContentPage.BindingContext>
+    <local:ViewModelClass/>
+  </ContentPage.BindingContext>
+  <ContentPage.Content>
+    <VerticalStackLayout>
+      <Stepper AutomationId="stepper" x:Name="stepperValue"
+               Maximum="1000"
+	            Increment="{Binding Increment}" />
+      <Entry AutomationId="entry" 
+	          Text="{Binding Value,Source={x:Reference stepperValue}} "/>
+      <Button AutomationId="incrementButton" Text="Change Increment Value" x:Name="button" Clicked="button_Clicked"/>
+
+    </VerticalStackLayout>
+  </ContentPage.Content>
+</ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue20706.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue20706.xaml.cs
@@ -1,0 +1,52 @@
+﻿#nullable enable
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace Maui.Controls.Sample.Issues
+{
+    [Issue(IssueTracker.Github, 20706, "Stepper doesn't change increment value when being bound to a double in MVVM context (Windows)")]
+    public partial class Issue20706 : ContentPage
+    {
+        public Issue20706()
+        {
+            InitializeComponent();
+        }
+
+		private void button_Clicked(object sender, EventArgs e)
+		{
+			stepperValue.Increment = 10;
+        }
+    }
+    internal class ViewModelClass : INotifyPropertyChanged
+    {
+        private double _increment;
+
+        public double Increment
+        {
+			get 
+			{
+				return _increment; 
+			}
+			
+			set
+			{  _increment = value;
+				OnPropertyChanged("Increment");
+			}
+        }
+
+		public ViewModelClass()
+		{
+			Increment = 2;
+		}
+		private void OnPropertyChanged(string v)
+		{
+			if (PropertyChanged != null)
+			{
+				PropertyChanged(this, new PropertyChangedEventArgs(v));
+			}
+		}
+
+		public event PropertyChangedEventHandler? PropertyChanged;
+	}
+}
+

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue20706.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue20706.cs
@@ -1,0 +1,27 @@
+﻿#if WINDOWS
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+    public class Issue20706 : _IssuesUITest
+	{
+		public override string Issue => "Stepper doesn't change increment value when being bound to a double in MVVM context (Windows)";
+		public Issue20706(TestDevice device) : base(device)
+		{
+		}
+
+		[Test]
+		[Category(UITestCategories.Stepper)]
+		public void ChangeIncrementValue()
+		{
+			App.WaitForElement("incrementButton");
+			App.Click("incrementButton");
+			App.WaitForElement("stepper");
+			App.Tap("+");
+			VerifyScreenshot();
+		}
+	}
+}
+#endif

--- a/src/Core/src/Core/IStepper.cs
+++ b/src/Core/src/Core/IStepper.cs
@@ -9,6 +9,6 @@
 		/// <summary>
 		/// Gets the amount by which Value is increased or decreased.
 		/// </summary>
-		double Interval { get; }
+		double Increment { get; }
 	}
 }

--- a/src/Core/src/Handlers/Stepper/StepperHandler.Windows.cs
+++ b/src/Core/src/Handlers/Stepper/StepperHandler.Windows.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Maui.Handlers
 
 		public static void MapIncrement(IStepperHandler handler, IStepper stepper)
 		{
-			handler.PlatformView?.UpdateInterval(stepper);
+			handler.PlatformView?.UpdateIncrement(stepper);
 		}
 
 		public static void MapValue(IStepperHandler handler, IStepper stepper)

--- a/src/Core/src/Handlers/Stepper/StepperHandler.cs
+++ b/src/Core/src/Handlers/Stepper/StepperHandler.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Maui.Handlers
 	{
 		public static IPropertyMapper<IStepper, IStepperHandler> Mapper = new PropertyMapper<IStepper, StepperHandler>(ViewHandler.ViewMapper)
 		{
-			[nameof(IStepper.Interval)] = MapIncrement,
+			[nameof(IStepper.Increment)] = MapIncrement,
 			[nameof(IStepper.Maximum)] = MapMaximum,
 			[nameof(IStepper.Minimum)] = MapMinimum,
 			[nameof(IStepper.Value)] = MapValue,

--- a/src/Core/src/Platform/Android/StepperHandlerManager.cs
+++ b/src/Core/src/Platform/Android/StepperHandlerManager.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Maui.Platform
 				if (!(HandlerHolder.StepperHandler?.VirtualView is IStepper stepper))
 					return;
 
-				var increment = stepper.Interval;
+				var increment = stepper.Increment;
 
 				if (view == HandlerHolder.StepperHandler.DownButton)
 					increment = -increment;

--- a/src/Core/src/Platform/Tizen/MauiStepper.cs
+++ b/src/Core/src/Platform/Tizen/MauiStepper.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Maui.Platform
 
 		public void UpdateIncrement(IStepper stepper)
 		{
-			Increment = stepper.Interval;
+			Increment = stepper.Increment;
 		}
 
 		public void UpdateValue(IStepper stepper)

--- a/src/Core/src/Platform/Windows/StepperExtensions.cs
+++ b/src/Core/src/Platform/Windows/StepperExtensions.cs
@@ -14,9 +14,9 @@ namespace Microsoft.Maui.Platform
 			platformStepper.Maximum = stepper.Maximum;
 		}
 
-		public static void UpdateInterval(this MauiStepper platformStepper, IStepper stepper)
+		public static void UpdateIncrement(this MauiStepper platformStepper, IStepper stepper)
 		{
-			platformStepper.Increment = stepper.Interval;
+			platformStepper.Increment = stepper.Increment;
 		}
 
 		public static void UpdateValue(this MauiStepper platformStepper, IStepper stepper)

--- a/src/Core/src/Platform/iOS/StepperExtensions.cs
+++ b/src/Core/src/Platform/iOS/StepperExtensions.cs
@@ -17,10 +17,10 @@ namespace Microsoft.Maui.Platform
 
 		public static void UpdateIncrement(this UIStepper platformStepper, IStepper stepper)
 		{
-			var increment = stepper.Interval;
+			var increment = stepper.Increment;
 
 			if (increment > 0)
-				platformStepper.StepValue = stepper.Interval;
+				platformStepper.StepValue = stepper.Increment;
 		}
 
 		public static void UpdateValue(this UIStepper platformStepper, IStepper stepper)

--- a/src/Core/src/PublicAPI/net-android/PublicAPI.Shipped.txt
+++ b/src/Core/src/PublicAPI/net-android/PublicAPI.Shipped.txt
@@ -1148,7 +1148,6 @@ Microsoft.Maui.IStackNavigation.NavigationFinished(System.Collections.Generic.IR
 Microsoft.Maui.IStackNavigation.RequestNavigation(Microsoft.Maui.NavigationRequest! eventArgs) -> void
 Microsoft.Maui.IStackNavigationView
 Microsoft.Maui.IStepper
-Microsoft.Maui.IStepper.Interval.get -> double
 Microsoft.Maui.IStreamImageSource
 Microsoft.Maui.IStreamImageSource.GetStreamAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.IO.Stream!>!
 Microsoft.Maui.IStroke

--- a/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -210,3 +210,4 @@ Microsoft.Maui.IApplication.ActivateWindow(Microsoft.Maui.IWindow! window) -> vo
 static Microsoft.Maui.Handlers.ApplicationHandler.MapActivateWindow(Microsoft.Maui.Handlers.ApplicationHandler! handler, Microsoft.Maui.IApplication! application, object? args) -> void
 *REMOVED*Microsoft.Maui.IWindow.Content.get -> Microsoft.Maui.IView!
 Microsoft.Maui.IWindow.Content.get -> Microsoft.Maui.IView?
+Microsoft.Maui.IStepper.Increment.get -> double

--- a/src/Core/src/PublicAPI/net-ios/PublicAPI.Shipped.txt
+++ b/src/Core/src/PublicAPI/net-ios/PublicAPI.Shipped.txt
@@ -1112,7 +1112,6 @@ Microsoft.Maui.IStackNavigation.NavigationFinished(System.Collections.Generic.IR
 Microsoft.Maui.IStackNavigation.RequestNavigation(Microsoft.Maui.NavigationRequest! eventArgs) -> void
 Microsoft.Maui.IStackNavigationView
 Microsoft.Maui.IStepper
-Microsoft.Maui.IStepper.Interval.get -> double
 Microsoft.Maui.IStreamImageSource
 Microsoft.Maui.IStreamImageSource.GetStreamAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.IO.Stream!>!
 Microsoft.Maui.IStroke

--- a/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -226,3 +226,4 @@ static Microsoft.Maui.Handlers.ApplicationHandler.MapActivateWindow(Microsoft.Ma
 Microsoft.Maui.IWindow.Content.get -> Microsoft.Maui.IView?
 *REMOVED*static Microsoft.Maui.Platform.ElementExtensions.ToUIViewController(this Microsoft.Maui.IElement! view, Microsoft.Maui.IMauiContext! context) -> UIKit.UIViewController!
 static Microsoft.Maui.Platform.ElementExtensions.ToUIViewController(this Microsoft.Maui.IElement? view, Microsoft.Maui.IMauiContext! context) -> UIKit.UIViewController!
+Microsoft.Maui.IStepper.Increment.get -> double

--- a/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Shipped.txt
+++ b/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Shipped.txt
@@ -1112,7 +1112,6 @@ Microsoft.Maui.IStackNavigation.NavigationFinished(System.Collections.Generic.IR
 Microsoft.Maui.IStackNavigation.RequestNavigation(Microsoft.Maui.NavigationRequest! eventArgs) -> void
 Microsoft.Maui.IStackNavigationView
 Microsoft.Maui.IStepper
-Microsoft.Maui.IStepper.Interval.get -> double
 Microsoft.Maui.IStreamImageSource
 Microsoft.Maui.IStreamImageSource.GetStreamAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.IO.Stream!>!
 Microsoft.Maui.IStroke

--- a/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -227,3 +227,4 @@ static Microsoft.Maui.Handlers.ApplicationHandler.MapActivateWindow(Microsoft.Ma
 Microsoft.Maui.IWindow.Content.get -> Microsoft.Maui.IView?
 *REMOVED*static Microsoft.Maui.Platform.ElementExtensions.ToUIViewController(this Microsoft.Maui.IElement! view, Microsoft.Maui.IMauiContext! context) -> UIKit.UIViewController!
 static Microsoft.Maui.Platform.ElementExtensions.ToUIViewController(this Microsoft.Maui.IElement? view, Microsoft.Maui.IMauiContext! context) -> UIKit.UIViewController!
+Microsoft.Maui.IStepper.Increment.get -> double

--- a/src/Core/src/PublicAPI/net-tizen/PublicAPI.Shipped.txt
+++ b/src/Core/src/PublicAPI/net-tizen/PublicAPI.Shipped.txt
@@ -1107,7 +1107,6 @@ Microsoft.Maui.IStackNavigation.NavigationFinished(System.Collections.Generic.IR
 Microsoft.Maui.IStackNavigation.RequestNavigation(Microsoft.Maui.NavigationRequest! eventArgs) -> void
 Microsoft.Maui.IStackNavigationView
 Microsoft.Maui.IStepper
-Microsoft.Maui.IStepper.Interval.get -> double
 Microsoft.Maui.IStreamImageSource
 Microsoft.Maui.IStreamImageSource.GetStreamAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.IO.Stream!>!
 Microsoft.Maui.IStroke

--- a/src/Core/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -132,3 +132,4 @@ static Microsoft.Maui.Platform.ElementExtensions.ToContainerView(this Microsoft.
 Microsoft.Maui.WebProcessTerminatedEventArgs
 Microsoft.Maui.WebProcessTerminatedEventArgs.WebProcessTerminatedEventArgs() -> void
 Microsoft.Maui.IWebView.ProcessTerminated(Microsoft.Maui.WebProcessTerminatedEventArgs! args) -> void
+Microsoft.Maui.IStepper.Increment.get -> double

--- a/src/Core/src/PublicAPI/net-windows/PublicAPI.Shipped.txt
+++ b/src/Core/src/PublicAPI/net-windows/PublicAPI.Shipped.txt
@@ -1127,7 +1127,6 @@ Microsoft.Maui.IStackNavigation.NavigationFinished(System.Collections.Generic.IR
 Microsoft.Maui.IStackNavigation.RequestNavigation(Microsoft.Maui.NavigationRequest! eventArgs) -> void
 Microsoft.Maui.IStackNavigationView
 Microsoft.Maui.IStepper
-Microsoft.Maui.IStepper.Interval.get -> double
 Microsoft.Maui.IStreamImageSource
 Microsoft.Maui.IStreamImageSource.GetStreamAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.IO.Stream!>!
 Microsoft.Maui.IStroke
@@ -2776,7 +2775,6 @@ static Microsoft.Maui.Platform.SliderExtensions.UpdateMinimumTrackColor(this Mic
 static Microsoft.Maui.Platform.SliderExtensions.UpdateThumbColor(this Microsoft.UI.Xaml.Controls.Slider! platformSlider, Microsoft.Maui.ISlider! slider) -> void
 static Microsoft.Maui.Platform.SliderExtensions.UpdateValue(this Microsoft.UI.Xaml.Controls.Slider! nativeSlider, Microsoft.Maui.ISlider! slider) -> void
 static Microsoft.Maui.Platform.StepperExtensions.UpdateBackground(this Microsoft.Maui.Platform.MauiStepper! platformStepper, Microsoft.Maui.IStepper! stepper) -> void
-static Microsoft.Maui.Platform.StepperExtensions.UpdateInterval(this Microsoft.Maui.Platform.MauiStepper! platformStepper, Microsoft.Maui.IStepper! stepper) -> void
 static Microsoft.Maui.Platform.StepperExtensions.UpdateMaximum(this Microsoft.Maui.Platform.MauiStepper! platformStepper, Microsoft.Maui.IStepper! stepper) -> void
 static Microsoft.Maui.Platform.StepperExtensions.UpdateMinimum(this Microsoft.Maui.Platform.MauiStepper! platformStepper, Microsoft.Maui.IStepper! stepper) -> void
 static Microsoft.Maui.Platform.StepperExtensions.UpdateValue(this Microsoft.Maui.Platform.MauiStepper! platformStepper, Microsoft.Maui.IStepper! stepper) -> void

--- a/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -172,3 +172,5 @@ static Microsoft.Maui.Handlers.ApplicationHandler.MapActivateWindow(Microsoft.Ma
 Microsoft.Maui.IWindow.Content.get -> Microsoft.Maui.IView?
 *REMOVED*virtual Microsoft.Maui.Platform.NavigationRootManager.Connect(Microsoft.UI.Xaml.UIElement! platformView) -> void
 virtual Microsoft.Maui.Platform.NavigationRootManager.Connect(Microsoft.UI.Xaml.UIElement? platformView) -> void
+Microsoft.Maui.IStepper.Increment.get -> double
+static Microsoft.Maui.Platform.StepperExtensions.UpdateIncrement(this Microsoft.Maui.Platform.MauiStepper! platformStepper, Microsoft.Maui.IStepper! stepper) -> void

--- a/src/Core/src/PublicAPI/net/PublicAPI.Shipped.txt
+++ b/src/Core/src/PublicAPI/net/PublicAPI.Shipped.txt
@@ -1086,7 +1086,6 @@ Microsoft.Maui.IStackNavigation.NavigationFinished(System.Collections.Generic.IR
 Microsoft.Maui.IStackNavigation.RequestNavigation(Microsoft.Maui.NavigationRequest! eventArgs) -> void
 Microsoft.Maui.IStackNavigationView
 Microsoft.Maui.IStepper
-Microsoft.Maui.IStepper.Interval.get -> double
 Microsoft.Maui.IStreamImageSource
 Microsoft.Maui.IStreamImageSource.GetStreamAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.IO.Stream!>!
 Microsoft.Maui.IStroke

--- a/src/Core/src/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -130,3 +130,4 @@ Microsoft.Maui.IApplication.ActivateWindow(Microsoft.Maui.IWindow! window) -> vo
 static Microsoft.Maui.Handlers.ApplicationHandler.MapActivateWindow(Microsoft.Maui.Handlers.ApplicationHandler! handler, Microsoft.Maui.IApplication! application, object? args) -> void
 *REMOVED*Microsoft.Maui.IWindow.Content.get -> Microsoft.Maui.IView!
 Microsoft.Maui.IWindow.Content.get -> Microsoft.Maui.IView?
+Microsoft.Maui.IStepper.Increment.get -> double

--- a/src/Core/src/PublicAPI/netstandard/PublicAPI.Shipped.txt
+++ b/src/Core/src/PublicAPI/netstandard/PublicAPI.Shipped.txt
@@ -1086,7 +1086,6 @@ Microsoft.Maui.IStackNavigation.NavigationFinished(System.Collections.Generic.IR
 Microsoft.Maui.IStackNavigation.RequestNavigation(Microsoft.Maui.NavigationRequest! eventArgs) -> void
 Microsoft.Maui.IStackNavigationView
 Microsoft.Maui.IStepper
-Microsoft.Maui.IStepper.Interval.get -> double
 Microsoft.Maui.IStreamImageSource
 Microsoft.Maui.IStreamImageSource.GetStreamAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.IO.Stream!>!
 Microsoft.Maui.IStroke

--- a/src/Core/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -130,3 +130,4 @@ virtual Microsoft.Maui.Handlers.SwipeItemMenuItemHandler.SourceLoader.get -> Mic
 static Microsoft.Maui.ViewExtensions.DisconnectHandlers(this Microsoft.Maui.IView! view) -> void
 *REMOVED*Microsoft.Maui.IWindow.Content.get -> Microsoft.Maui.IView!
 Microsoft.Maui.IWindow.Content.get -> Microsoft.Maui.IView?
+Microsoft.Maui.IStepper.Increment.get -> double

--- a/src/Core/src/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
+++ b/src/Core/src/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
@@ -1084,7 +1084,6 @@ Microsoft.Maui.IStackNavigation.NavigationFinished(System.Collections.Generic.IR
 Microsoft.Maui.IStackNavigation.RequestNavigation(Microsoft.Maui.NavigationRequest! eventArgs) -> void
 Microsoft.Maui.IStackNavigationView
 Microsoft.Maui.IStepper
-Microsoft.Maui.IStepper.Interval.get -> double
 Microsoft.Maui.IStreamImageSource
 Microsoft.Maui.IStreamImageSource.GetStreamAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.IO.Stream!>!
 Microsoft.Maui.IStroke

--- a/src/Core/src/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -130,3 +130,4 @@ virtual Microsoft.Maui.Handlers.ImageHandler.SourceLoader.get -> Microsoft.Maui.
 virtual Microsoft.Maui.Handlers.SwipeItemMenuItemHandler.SourceLoader.get -> Microsoft.Maui.Platform.ImageSourcePartLoader!
 *REMOVED*Microsoft.Maui.IWindow.Content.get -> Microsoft.Maui.IView!
 Microsoft.Maui.IWindow.Content.get -> Microsoft.Maui.IView?
+Microsoft.Maui.IStepper.Increment.get -> double


### PR DESCRIPTION
### Root cause
When the stepper value is updated dynamically, the current increment value isn't properly passed to the PlatformView, which is supposed to update through the IStepper.Interval property.

### Description of Change
The interface Interval has been renamed to Increment and is now mapped to the mapIncrement method. All references to Interval have also been renamed to Increment.

 ### API changes
Renamed IStepper.Interval to IStepper.Increment

### Issues Fixed
Fixes #20706

### Output Screenshot 
### Before Changes 
https://github.com/user-attachments/assets/17b99b70-6803-42d3-943e-bcd781329377

### After Changes
https://github.com/user-attachments/assets/b053f0a5-e459-4a8e-835f-743a1a8cf7d0

