### PR TITLE
Add support for `TextAlignment.Justify` - fix

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Controls/LabelPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/LabelPage.xaml
@@ -70,6 +70,13 @@
                 BackgroundColor="LightGray"
                 HorizontalTextAlignment="End"
                 Text="This should be at the end of the line" />
+            <Label
+                BackgroundColor="Silver"
+                HorizontalTextAlignment="Justify">
+                <Label.Text>
+                    This text should be justified. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+                </Label.Text>
+            </Label>
 
             <!-- Vertical Text Alignment -->
             <Label

--- a/src/Core/src/Platform/Android/TextAlignmentExtensions.cs
+++ b/src/Core/src/Platform/Android/TextAlignmentExtensions.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Android.Widget;
+﻿using Android.Widget;
 using AGravityFlags = Android.Views.GravityFlags;
 
 namespace Microsoft.Maui.Platform
@@ -30,6 +29,7 @@ namespace Microsoft.Maui.Platform
 			view.Gravity = (view.Gravity & ~VerticalGravityMask) | alignment.ToVerticalGravityFlags() | orMask;
 		}
 
+		[Obssolete("Use UpdateHorizontalAlignment and/or UpdateVerticalAlignment instead")] // Nothing currently calls this method in our code
 		public static void UpdateTextAlignment(this EditText view, TextAlignment horizontal, TextAlignment vertical)
 		{
 			if (view.Context != null && !Rtl.IsSupported)
@@ -40,13 +40,6 @@ namespace Microsoft.Maui.Platform
 			{
 				view.TextAlignment = horizontal.ToTextAlignment();
 				view.Gravity = vertical.ToVerticalGravityFlags();
-			}
-
-			if (OperatingSystem.IsAndroidVersionAtLeast(26))
-			{
-				view.JustificationMode = horizontal == TextAlignment.Justify
-					? Android.Text.JustificationMode.InterWord
-					: Android.Text.JustificationMode.None;
 			}
 		}
 	}

--- a/src/Core/src/Platform/Android/TextAlignmentExtensions.cs
+++ b/src/Core/src/Platform/Android/TextAlignmentExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Android.Widget;
+﻿using System;
+using Android.Widget;
 using AGravityFlags = Android.Views.GravityFlags;
 
 namespace Microsoft.Maui.Platform
@@ -39,6 +40,13 @@ namespace Microsoft.Maui.Platform
 			{
 				view.TextAlignment = horizontal.ToTextAlignment();
 				view.Gravity = vertical.ToVerticalGravityFlags();
+			}
+
+			if (OperatingSystem.IsAndroidVersionAtLeast(26))
+			{
+				view.JustificationMode = horizontal == TextAlignment.Justify
+					? Android.Text.JustificationMode.InterWord
+					: Android.Text.JustificationMode.None;
 			}
 		}
 	}

--- a/src/Core/src/Platform/Android/TextAlignmentExtensions.cs
+++ b/src/Core/src/Platform/Android/TextAlignmentExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Android.Widget;
+﻿using System;
+using Android.Widget;
 using AGravityFlags = Android.Views.GravityFlags;
 
 namespace Microsoft.Maui.Platform
@@ -29,7 +30,7 @@ namespace Microsoft.Maui.Platform
 			view.Gravity = (view.Gravity & ~VerticalGravityMask) | alignment.ToVerticalGravityFlags() | orMask;
 		}
 
-		[Obssolete("Use UpdateHorizontalAlignment and/or UpdateVerticalAlignment instead")] // Nothing currently calls this method in our code
+		[Obsolete("Use UpdateHorizontalAlignment and/or UpdateVerticalAlignment instead")] // Nothing currently calls this method in our code
 		public static void UpdateTextAlignment(this EditText view, TextAlignment horizontal, TextAlignment vertical)
 		{
 			if (view.Context != null && !Rtl.IsSupported)

--- a/src/Core/src/Platform/Android/TextViewExtensions.cs
+++ b/src/Core/src/Platform/Android/TextViewExtensions.cs
@@ -65,6 +65,13 @@ namespace Microsoft.Maui.Platform
 				// to gravity, because Android will simply ignore text alignment
 				textView.Gravity = Android.Views.GravityFlags.Top | text.HorizontalTextAlignment.ToHorizontalGravityFlags();
 			}
+
+			if (OperatingSystem.IsAndroidVersionAtLeast(26))
+			{
+				textView.JustificationMode = text.HorizontalTextAlignment == TextAlignment.Justify
+					? Android.Text.JustificationMode.InterWord
+					: Android.Text.JustificationMode.None;
+			}
 		}
 
 		public static void UpdateVerticalTextAlignment(this TextView textView, ITextAlignment textAlignment)

--- a/src/Core/src/Platform/Windows/AlignmentExtensions.cs
+++ b/src/Core/src/Platform/Windows/AlignmentExtensions.cs
@@ -6,47 +6,34 @@ namespace Microsoft.Maui.Platform
 	{
 		public static HorizontalAlignment ToPlatformHorizontalAlignment(this TextAlignment alignment)
 		{
-			switch (alignment)
+			return alignment switch
 			{
-				case TextAlignment.Center:
-					return HorizontalAlignment.Center;
-				case TextAlignment.End:
-					return HorizontalAlignment.Right;
-				default:
-					return HorizontalAlignment.Left;
-			}
+				TextAlignment.Center => HorizontalAlignment.Center,
+				TextAlignment.End => HorizontalAlignment.Right,
+				TextAlignment.Justify => HorizontalAlignment.Stretch,
+				_ => HorizontalAlignment.Left,
+			};
 		}
 
 		public static VerticalAlignment ToPlatformVerticalAlignment(this TextAlignment alignment)
 		{
-			switch (alignment)
+			return alignment switch
 			{
-				case TextAlignment.Center:
-					return VerticalAlignment.Center;
-				case TextAlignment.End:
-					return VerticalAlignment.Bottom;
-				default:
-					return VerticalAlignment.Top;
-			}
+				TextAlignment.Center => VerticalAlignment.Center,
+				TextAlignment.End => VerticalAlignment.Bottom,
+				_ => VerticalAlignment.Top,
+			};
 		}
 
 		public static UI.Xaml.TextAlignment ToPlatform(this TextAlignment alignment, bool isLtr = true)
 		{
-			switch (alignment)
+			return alignment switch
 			{
-				case TextAlignment.Center:
-					return UI.Xaml.TextAlignment.Center;
-				case TextAlignment.End:
-					if (isLtr)
-						return UI.Xaml.TextAlignment.Right;
-					else
-						return UI.Xaml.TextAlignment.Left;
-				default:
-					if (isLtr)
-						return UI.Xaml.TextAlignment.Left;
-					else
-						return UI.Xaml.TextAlignment.Right;
-			}
+				TextAlignment.Center => UI.Xaml.TextAlignment.Center,
+				TextAlignment.Justify => UI.Xaml.TextAlignment.Justify,
+				TextAlignment.End => isLtr ? UI.Xaml.TextAlignment.Right : UI.Xaml.TextAlignment.Left,
+				_ => isLtr ? UI.Xaml.TextAlignment.Left : UI.Xaml.TextAlignment.Right,
+			};
 		}
 	}
 }

--- a/src/Core/src/Platform/Windows/TextAlignmentToHorizontalAlignmentConverter.cs
+++ b/src/Core/src/Platform/Windows/TextAlignmentToHorizontalAlignmentConverter.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Maui.Platform
 			{
 				case Microsoft.UI.Xaml.TextAlignment.Center:
 					return HorizontalAlignment.Center;
+				case Microsoft.UI.Xaml.TextAlignment.Justify:
+					return HorizontalAlignment.Stretch;
 				case Microsoft.UI.Xaml.TextAlignment.Left:
 					return HorizontalAlignment.Left;
 				case Microsoft.UI.Xaml.TextAlignment.Right:
@@ -32,6 +34,8 @@ namespace Microsoft.Maui.Platform
 					return Microsoft.UI.Xaml.TextAlignment.Left;
 				case HorizontalAlignment.Center:
 					return Microsoft.UI.Xaml.TextAlignment.Center;
+				case HorizontalAlignment.Stretch:
+					return Microsoft.UI.Xaml.TextAlignment.Justify;
 				case HorizontalAlignment.Right:
 					return Microsoft.UI.Xaml.TextAlignment.Right;
 				default:

--- a/src/Core/src/Platform/iOS/TextAlignmentExtensions.cs
+++ b/src/Core/src/Platform/iOS/TextAlignmentExtensions.cs
@@ -31,6 +31,7 @@ namespace Microsoft.Maui.Platform
 			return alignment switch
 			{
 				TextAlignment.Center => UITextAlignment.Center,
+				TextAlignment.Justify => UITextAlignment.Justified,
 				TextAlignment.End => UITextAlignment.Right,
 				TextAlignment.Start => UITextAlignment.Left,
 				_ => UITextAlignment.Left,

--- a/src/Core/src/Primitives/TextAlignment.cs
+++ b/src/Core/src/Primitives/TextAlignment.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Maui
 		/// <include file="../../docs/Microsoft.Maui/TextAlignment.xml" path="//Member[@MemberName='Center']/Docs/*" />
 		Center,
 		/// <include file="../../docs/Microsoft.Maui/TextAlignment.xml" path="//Member[@MemberName='End']/Docs/*" />
-		End
+		End,
+		Justify
 	}
 }

--- a/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -210,3 +210,4 @@ Microsoft.Maui.IApplication.ActivateWindow(Microsoft.Maui.IWindow! window) -> vo
 static Microsoft.Maui.Handlers.ApplicationHandler.MapActivateWindow(Microsoft.Maui.Handlers.ApplicationHandler! handler, Microsoft.Maui.IApplication! application, object? args) -> void
 *REMOVED*Microsoft.Maui.IWindow.Content.get -> Microsoft.Maui.IView!
 Microsoft.Maui.IWindow.Content.get -> Microsoft.Maui.IView?
+Microsoft.Maui.TextAlignment.Justify = 3 -> Microsoft.Maui.TextAlignment

--- a/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -226,3 +226,4 @@ static Microsoft.Maui.Handlers.ApplicationHandler.MapActivateWindow(Microsoft.Ma
 Microsoft.Maui.IWindow.Content.get -> Microsoft.Maui.IView?
 *REMOVED*static Microsoft.Maui.Platform.ElementExtensions.ToUIViewController(this Microsoft.Maui.IElement! view, Microsoft.Maui.IMauiContext! context) -> UIKit.UIViewController!
 static Microsoft.Maui.Platform.ElementExtensions.ToUIViewController(this Microsoft.Maui.IElement? view, Microsoft.Maui.IMauiContext! context) -> UIKit.UIViewController!
+Microsoft.Maui.TextAlignment.Justify = 3 -> Microsoft.Maui.TextAlignment

--- a/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -227,3 +227,4 @@ static Microsoft.Maui.Handlers.ApplicationHandler.MapActivateWindow(Microsoft.Ma
 Microsoft.Maui.IWindow.Content.get -> Microsoft.Maui.IView?
 *REMOVED*static Microsoft.Maui.Platform.ElementExtensions.ToUIViewController(this Microsoft.Maui.IElement! view, Microsoft.Maui.IMauiContext! context) -> UIKit.UIViewController!
 static Microsoft.Maui.Platform.ElementExtensions.ToUIViewController(this Microsoft.Maui.IElement? view, Microsoft.Maui.IMauiContext! context) -> UIKit.UIViewController!
+Microsoft.Maui.TextAlignment.Justify = 3 -> Microsoft.Maui.TextAlignment

--- a/src/Core/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -132,3 +132,4 @@ static Microsoft.Maui.Platform.ElementExtensions.ToContainerView(this Microsoft.
 Microsoft.Maui.WebProcessTerminatedEventArgs
 Microsoft.Maui.WebProcessTerminatedEventArgs.WebProcessTerminatedEventArgs() -> void
 Microsoft.Maui.IWebView.ProcessTerminated(Microsoft.Maui.WebProcessTerminatedEventArgs! args) -> void
+Microsoft.Maui.TextAlignment.Justify = 3 -> Microsoft.Maui.TextAlignment

--- a/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -176,3 +176,4 @@ static Microsoft.Maui.Handlers.ApplicationHandler.MapActivateWindow(Microsoft.Ma
 Microsoft.Maui.IWindow.Content.get -> Microsoft.Maui.IView?
 *REMOVED*virtual Microsoft.Maui.Platform.NavigationRootManager.Connect(Microsoft.UI.Xaml.UIElement! platformView) -> void
 virtual Microsoft.Maui.Platform.NavigationRootManager.Connect(Microsoft.UI.Xaml.UIElement? platformView) -> void
+Microsoft.Maui.TextAlignment.Justify = 3 -> Microsoft.Maui.TextAlignment

--- a/src/Core/src/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -130,3 +130,4 @@ Microsoft.Maui.IApplication.ActivateWindow(Microsoft.Maui.IWindow! window) -> vo
 static Microsoft.Maui.Handlers.ApplicationHandler.MapActivateWindow(Microsoft.Maui.Handlers.ApplicationHandler! handler, Microsoft.Maui.IApplication! application, object? args) -> void
 *REMOVED*Microsoft.Maui.IWindow.Content.get -> Microsoft.Maui.IView!
 Microsoft.Maui.IWindow.Content.get -> Microsoft.Maui.IView?
+Microsoft.Maui.TextAlignment.Justify = 3 -> Microsoft.Maui.TextAlignment

--- a/src/Core/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -130,3 +130,4 @@ virtual Microsoft.Maui.Handlers.SwipeItemMenuItemHandler.SourceLoader.get -> Mic
 static Microsoft.Maui.ViewExtensions.DisconnectHandlers(this Microsoft.Maui.IView! view) -> void
 *REMOVED*Microsoft.Maui.IWindow.Content.get -> Microsoft.Maui.IView!
 Microsoft.Maui.IWindow.Content.get -> Microsoft.Maui.IView?
+Microsoft.Maui.TextAlignment.Justify = 3 -> Microsoft.Maui.TextAlignment

--- a/src/Core/src/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -130,3 +130,4 @@ virtual Microsoft.Maui.Handlers.ImageHandler.SourceLoader.get -> Microsoft.Maui.
 virtual Microsoft.Maui.Handlers.SwipeItemMenuItemHandler.SourceLoader.get -> Microsoft.Maui.Platform.ImageSourcePartLoader!
 *REMOVED*Microsoft.Maui.IWindow.Content.get -> Microsoft.Maui.IView!
 Microsoft.Maui.IWindow.Content.get -> Microsoft.Maui.IView?
+Microsoft.Maui.TextAlignment.Justify = 3 -> Microsoft.Maui.TextAlignment


### PR DESCRIPTION
### Description of Change

Adds support for `TextAlignment.Justify` (or should it be `Justified`?).

* [x] Android 
* [x] iOS/macOS 
* [ ] Tizen
* [x] Windows


### Demo

**Android**

![image](https://github.com/user-attachments/assets/7a356f19-1774-42d0-92fb-95a34ea25d8d)


**Windows**

![image](https://github.com/user-attachments/assets/1e2a7894-737a-412b-8e9b-c2f2e7397ea0)

**iOS**

![image](https://github.com/user-attachments/assets/0f5b0127-9c2d-41a2-b703-8fa61c2081c6)


### Issues Fixed

Fixes #24373