### PR TITLE
Add Styleable Element to simplify styling for external libraries

### DIFF
--- a/src/Controls/src/Core/Menu/BaseMenuItem.cs
+++ b/src/Controls/src/Core/Menu/BaseMenuItem.cs
@@ -1,7 +1,7 @@
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/BaseMenuItem.xml" path="Type[@FullName='Microsoft.Maui.Controls.BaseMenuItem']/Docs/*" />
-	public abstract class BaseMenuItem : Element
+	public abstract class BaseMenuItem : StyleableElement
 	{
 	}
 }

--- a/src/Controls/src/Core/Menu/MenuItem.cs
+++ b/src/Controls/src/Core/Menu/MenuItem.cs
@@ -1,7 +1,6 @@
 ﻿#nullable disable
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Windows.Input;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Controls.StyleSheets;
@@ -10,7 +9,7 @@ using Microsoft.Maui.Graphics;
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/MenuItem.xml" path="Type[@FullName='Microsoft.Maui.Controls.MenuItem']/Docs/*" />
-	public partial class MenuItem : BaseMenuItem, IMenuItemController, IStyleSelectable, ICommandElement, IMenuElement, IPropertyPropagationController
+	public partial class MenuItem : BaseMenuItem, IMenuItemController, ICommandElement, IMenuElement, IPropertyPropagationController
 	{
 		/// <summary>Bindable property for <see cref="Accelerator"/>.</summary>
 		[Obsolete("Use MenuFlyoutItem.KeyboardAcceleratorsProperty instead.")]
@@ -48,14 +47,11 @@ namespace Microsoft.Maui.Controls
 		/// <include file="../../docs/Microsoft.Maui.Controls/MenuItem.xml" path="//Member[@MemberName='SetAccelerator']/Docs/*" />
 		[Obsolete("Use MenuFlyoutItem.KeyboardAcceleratorsProperty instead.")]
 		public static void SetAccelerator(BindableObject bindable, Accelerator value) => bindable.SetValue(AcceleratorProperty, value);
-
-		internal readonly MergedStyle _mergedStyle;
 		bool _isEnabledExplicit = (bool)IsEnabledProperty.DefaultValue;
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/MenuItem.xml" path="//Member[@MemberName='.ctor']/Docs/*" />
 		public MenuItem()
 		{
-			_mergedStyle = new MergedStyle(GetType(), this);
 		}
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/MenuItem.xml" path="//Member[@MemberName='Command']/Docs/*" />
@@ -99,27 +95,6 @@ namespace Microsoft.Maui.Controls
 			get => (bool)GetValue(IsEnabledProperty);
 			set => SetValue(IsEnabledProperty, value);
 		}
-
-		/// <include file="../../docs/Microsoft.Maui.Controls/MenuItem.xml" path="//Member[@MemberName='StyleClass']/Docs/*" />
-		[System.ComponentModel.TypeConverter(typeof(ListStringTypeConverter))]
-		public IList<string> StyleClass
-		{
-			get { return @class; }
-			set { @class = value; }
-		}
-
-		/// <include file="../../docs/Microsoft.Maui.Controls/MenuItem.xml" path="//Member[@MemberName='class']/Docs/*" />
-		[System.ComponentModel.TypeConverter(typeof(ListStringTypeConverter))]
-		public IList<string> @class
-		{
-			get { return _mergedStyle.StyleClass; }
-			set
-			{
-				_mergedStyle.StyleClass = value;
-			}
-		}
-
-		IList<string> IStyleSelectable.Classes => StyleClass;
 
 		public event EventHandler Clicked;
 

--- a/src/Controls/src/Core/NavigableElement/NavigableElement.cs
+++ b/src/Controls/src/Core/NavigableElement/NavigableElement.cs
@@ -11,14 +11,14 @@ namespace Microsoft.Maui.Controls
 	public class NavigableElement : Element, INavigationProxy, IStyleSelectable
 	{
 		static readonly BindablePropertyKey NavigationPropertyKey =
-			BindableProperty.CreateReadOnly(nameof(Navigation), typeof(INavigation), typeof(VisualElement), default(INavigation));
+			BindableProperty.CreateReadOnly(nameof(Navigation), typeof(INavigation), typeof(NavigableElement), default(INavigation));
 
 		/// <summary>Bindable property for <see cref="Navigation"/>.</summary>
 		public static readonly BindableProperty NavigationProperty = NavigationPropertyKey.BindableProperty;
 
 		/// <summary>Bindable property for <see cref="Style"/>.</summary>
 		public static readonly BindableProperty StyleProperty =
-			BindableProperty.Create(nameof(Style), typeof(Style), typeof(VisualElement), default(Style),
+			BindableProperty.Create(nameof(Style), typeof(Style), typeof(NavigableElement), default(Style),
 				propertyChanged: (bindable, oldvalue, newvalue) => ((NavigableElement)bindable)._mergedStyle.Style = (Style)newvalue);
 
 		internal readonly MergedStyle _mergedStyle;

--- a/src/Controls/src/Core/NavigableElement/NavigableElement.cs
+++ b/src/Controls/src/Core/NavigableElement/NavigableElement.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Maui.Controls
 {
 	/// <summary>Represents an <see cref="Element"/> with base functionality for <see cref="Page"/> navigation. Does not necessarily render on screen.</summary>
 	/// <remarks>Not meant to be used directly. Instead, opt to use derived types, such as <see cref="View"/>.</remarks>
-	public class NavigableElement : Element, INavigationProxy, IStyleSelectable
+	public class NavigableElement : StyleableElement, INavigationProxy
 	{
 		static readonly BindablePropertyKey NavigationPropertyKey =
 			BindableProperty.CreateReadOnly(nameof(Navigation), typeof(INavigation), typeof(NavigableElement), default(INavigation));
@@ -16,17 +16,12 @@ namespace Microsoft.Maui.Controls
 		/// <summary>Bindable property for <see cref="Navigation"/>.</summary>
 		public static readonly BindableProperty NavigationProperty = NavigationPropertyKey.BindableProperty;
 
-		/// <summary>Bindable property for <see cref="Style"/>.</summary>
-		public static readonly BindableProperty StyleProperty =
-			BindableProperty.Create(nameof(Style), typeof(Style), typeof(NavigableElement), default(Style),
-				propertyChanged: (bindable, oldvalue, newvalue) => ((NavigableElement)bindable)._mergedStyle.Style = (Style)newvalue);
-
-		internal readonly MergedStyle _mergedStyle;
+		/// <inheritdoc/>
+		public static readonly new BindableProperty StyleProperty = StyleableElement.StyleProperty;
 
 		internal NavigableElement()
 		{
 			Navigation = new NavigationProxy();
-			_mergedStyle = new MergedStyle(GetType(), this);
 		}
 
 		/// <summary>Gets the object responsible for handling stack-based navigation.</summary>
@@ -36,44 +31,6 @@ namespace Microsoft.Maui.Controls
 			get { return (INavigation)GetValue(NavigationProperty); }
 			internal set { SetValue(NavigationPropertyKey, value); }
 		}
-
-		/// <summary>Gets or sets the unique <see cref="Style"/> for this element.</summary>
-		public Style Style
-		{
-			get { return (Style)GetValue(StyleProperty); }
-			set { SetValue(StyleProperty, value); }
-		}
-
-		/// <summary>Gets or sets the style classes for the element.</summary>
-		/// <remarks>
-		///		<para>Equiavalent to <see cref="@class"/>.</para>
-		///		<para>Style classes enable multiple styles to be applied to a control, without resorting to style inheritance.</para>
-		/// </remarks>
-		/// <seealso href="https://learn.microsoft.com/dotnet/maui/user-interface/styles/xaml?view=net-maui-8.0#style-classes">Conceptual documentation on style classes</seealso>
-		[System.ComponentModel.TypeConverter(typeof(ListStringTypeConverter))]
-		public IList<string> StyleClass
-		{
-			get { return @class; }
-			set { @class = value; }
-		}
-
-		/// <summary>Gets or sets the style classes for the element.</summary>
-		/// <remarks>
-		///		<para>Equiavalent to <see cref="StyleClass"/>.</para>
-		///		<para>Style classes enable multiple styles to be applied to a control, without resorting to style inheritance.</para>
-		/// </remarks>
-		/// <seealso href="https://learn.microsoft.com/dotnet/maui/user-interface/styles/xaml?view=net-maui-8.0#style-classes">Conceptual documentation on style classes</seealso>
-		[System.ComponentModel.TypeConverter(typeof(ListStringTypeConverter))]
-		public IList<string> @class
-		{
-			get { return _mergedStyle.StyleClass; }
-			set
-			{
-				_mergedStyle.StyleClass = value;
-			}
-		}
-
-		IList<string> IStyleSelectable.Classes => StyleClass;
 
 		/// <summary>Gets the cast of <see cref="Navigation"/> to a <see cref="Maui.Controls.Internals.NavigationProxy"/>.</summary>
 		/// <remarks>

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -102,6 +102,8 @@ Microsoft.Maui.Controls.PointerGestureRecognizer.PointerReleasedCommand.get -> S
 Microsoft.Maui.Controls.PointerGestureRecognizer.PointerReleasedCommand.set -> void
 Microsoft.Maui.Controls.PointerGestureRecognizer.PointerReleasedCommandParameter.get -> object!
 Microsoft.Maui.Controls.PointerGestureRecognizer.PointerReleasedCommandParameter.set -> void
+Microsoft.Maui.Controls.StyleableElement.class.get -> System.Collections.Generic.IList<string!>!
+Microsoft.Maui.Controls.StyleableElement.class.set -> void
 Microsoft.Maui.Controls.TitleBar
 Microsoft.Maui.Controls.TitleBar.Content.get -> Microsoft.Maui.IView?
 Microsoft.Maui.Controls.TitleBar.Content.set -> void
@@ -361,4 +363,10 @@ static Microsoft.Maui.Controls.Embedding.EmbeddingExtensions.CreateEmbeddedWindo
 static Microsoft.Maui.Controls.Embedding.EmbeddingExtensions.ToPlatformEmbedded(this Microsoft.Maui.IElement! element, Microsoft.Maui.IMauiContext! context) -> Android.Views.View!
 static Microsoft.Maui.Controls.Embedding.EmbeddingExtensions.ToPlatformEmbedded(this Microsoft.Maui.IElement! element, Microsoft.Maui.Hosting.MauiApp! mauiApp, Android.App.Activity! platformWindow) -> Android.Views.View!
 *REMOVED*override Microsoft.Maui.Controls.Layout.Measure(double widthConstraint, double heightConstraint, Microsoft.Maui.Controls.MeasureFlags flags = Microsoft.Maui.Controls.MeasureFlags.None) -> Microsoft.Maui.SizeRequest
-*REMOVED*override Microsoft.Maui.Controls.Layout.Measure(double widthConstraint, double heightConstraint, Microsoft.Maui.Controls.MeasureFlags flags = Microsoft.Maui.Controls.MeasureFlags.None) -> Microsoft.Maui.SizeRequest
+Microsoft.Maui.Controls.StyleableElement
+Microsoft.Maui.Controls.StyleableElement.Style.get -> Microsoft.Maui.Controls.Style!
+Microsoft.Maui.Controls.StyleableElement.Style.set -> void
+Microsoft.Maui.Controls.StyleableElement.StyleableElement() -> void
+Microsoft.Maui.Controls.StyleableElement.StyleClass.get -> System.Collections.Generic.IList<string!>!
+Microsoft.Maui.Controls.StyleableElement.StyleClass.set -> void
+static readonly Microsoft.Maui.Controls.StyleableElement.StyleProperty -> Microsoft.Maui.Controls.BindableProperty!

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -374,3 +374,9 @@ static readonly Microsoft.Maui.Controls.StyleableElement.StyleProperty -> Micros
 *REMOVED*~Microsoft.Maui.Controls.MenuItem.class.set -> void
 *REMOVED*~Microsoft.Maui.Controls.MenuItem.StyleClass.get -> System.Collections.Generic.IList<string>
 *REMOVED*~Microsoft.Maui.Controls.MenuItem.StyleClass.set -> void
+*REMOVED*~Microsoft.Maui.Controls.NavigableElement.class.get -> System.Collections.Generic.IList<string>
+*REMOVED*~Microsoft.Maui.Controls.NavigableElement.class.set -> void
+*REMOVED*~Microsoft.Maui.Controls.NavigableElement.Style.get -> Microsoft.Maui.Controls.Style
+*REMOVED*~Microsoft.Maui.Controls.NavigableElement.Style.set -> void
+*REMOVED*~Microsoft.Maui.Controls.NavigableElement.StyleClass.get -> System.Collections.Generic.IList<string>
+*REMOVED*~Microsoft.Maui.Controls.NavigableElement.StyleClass.set -> void

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -370,3 +370,7 @@ Microsoft.Maui.Controls.StyleableElement.StyleableElement() -> void
 Microsoft.Maui.Controls.StyleableElement.StyleClass.get -> System.Collections.Generic.IList<string!>!
 Microsoft.Maui.Controls.StyleableElement.StyleClass.set -> void
 static readonly Microsoft.Maui.Controls.StyleableElement.StyleProperty -> Microsoft.Maui.Controls.BindableProperty!
+*REMOVED*~Microsoft.Maui.Controls.MenuItem.class.get -> System.Collections.Generic.IList<string>
+*REMOVED*~Microsoft.Maui.Controls.MenuItem.class.set -> void
+*REMOVED*~Microsoft.Maui.Controls.MenuItem.StyleClass.get -> System.Collections.Generic.IList<string>
+*REMOVED*~Microsoft.Maui.Controls.MenuItem.StyleClass.set -> void

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -574,3 +574,12 @@ static Microsoft.Maui.Controls.Embedding.EmbeddingExtensions.ToPlatformEmbedded(
 *REMOVED*Microsoft.Maui.Controls.Handlers.Compatibility.ShellScrollViewTracker.OnLayoutSubviews() -> void
 *REMOVED*Microsoft.Maui.Controls.Handlers.Compatibility.ShellScrollViewTracker.Reset() -> bool
 *REMOVED*virtual Microsoft.Maui.Controls.Handlers.Compatibility.ShellScrollViewTracker.Dispose(bool disposing) -> void
+Microsoft.Maui.Controls.StyleableElement
+Microsoft.Maui.Controls.StyleableElement.Style.get -> Microsoft.Maui.Controls.Style!
+Microsoft.Maui.Controls.StyleableElement.Style.set -> void
+Microsoft.Maui.Controls.StyleableElement.StyleableElement() -> void
+Microsoft.Maui.Controls.StyleableElement.StyleClass.get -> System.Collections.Generic.IList<string!>!
+Microsoft.Maui.Controls.StyleableElement.StyleClass.set -> void
+static readonly Microsoft.Maui.Controls.StyleableElement.StyleProperty -> Microsoft.Maui.Controls.BindableProperty!
+Microsoft.Maui.Controls.StyleableElement.class.get -> System.Collections.Generic.IList<string!>!
+Microsoft.Maui.Controls.StyleableElement.class.set -> void

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -583,3 +583,7 @@ Microsoft.Maui.Controls.StyleableElement.StyleClass.set -> void
 static readonly Microsoft.Maui.Controls.StyleableElement.StyleProperty -> Microsoft.Maui.Controls.BindableProperty!
 Microsoft.Maui.Controls.StyleableElement.class.get -> System.Collections.Generic.IList<string!>!
 Microsoft.Maui.Controls.StyleableElement.class.set -> void
+*REMOVED*~Microsoft.Maui.Controls.MenuItem.class.get -> System.Collections.Generic.IList<string>
+*REMOVED*~Microsoft.Maui.Controls.MenuItem.class.set -> void
+*REMOVED*~Microsoft.Maui.Controls.MenuItem.StyleClass.get -> System.Collections.Generic.IList<string>
+*REMOVED*~Microsoft.Maui.Controls.MenuItem.StyleClass.set -> void

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -587,3 +587,9 @@ Microsoft.Maui.Controls.StyleableElement.class.set -> void
 *REMOVED*~Microsoft.Maui.Controls.MenuItem.class.set -> void
 *REMOVED*~Microsoft.Maui.Controls.MenuItem.StyleClass.get -> System.Collections.Generic.IList<string>
 *REMOVED*~Microsoft.Maui.Controls.MenuItem.StyleClass.set -> void
+*REMOVED*~Microsoft.Maui.Controls.NavigableElement.class.get -> System.Collections.Generic.IList<string>
+*REMOVED*~Microsoft.Maui.Controls.NavigableElement.class.set -> void
+*REMOVED*~Microsoft.Maui.Controls.NavigableElement.Style.get -> Microsoft.Maui.Controls.Style
+*REMOVED*~Microsoft.Maui.Controls.NavigableElement.Style.set -> void
+*REMOVED*~Microsoft.Maui.Controls.NavigableElement.StyleClass.get -> System.Collections.Generic.IList<string>
+*REMOVED*~Microsoft.Maui.Controls.NavigableElement.StyleClass.set -> void

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -574,3 +574,12 @@ static Microsoft.Maui.Controls.Embedding.EmbeddingExtensions.ToPlatformEmbedded(
 *REMOVED*Microsoft.Maui.Controls.Handlers.Compatibility.ShellScrollViewTracker.OnLayoutSubviews() -> void
 *REMOVED*Microsoft.Maui.Controls.Handlers.Compatibility.ShellScrollViewTracker.Reset() -> bool
 *REMOVED*virtual Microsoft.Maui.Controls.Handlers.Compatibility.ShellScrollViewTracker.Dispose(bool disposing) -> void
+Microsoft.Maui.Controls.StyleableElement
+Microsoft.Maui.Controls.StyleableElement.Style.get -> Microsoft.Maui.Controls.Style!
+Microsoft.Maui.Controls.StyleableElement.Style.set -> void
+Microsoft.Maui.Controls.StyleableElement.StyleableElement() -> void
+Microsoft.Maui.Controls.StyleableElement.StyleClass.get -> System.Collections.Generic.IList<string!>!
+Microsoft.Maui.Controls.StyleableElement.StyleClass.set -> void
+static readonly Microsoft.Maui.Controls.StyleableElement.StyleProperty -> Microsoft.Maui.Controls.BindableProperty!
+Microsoft.Maui.Controls.StyleableElement.class.get -> System.Collections.Generic.IList<string!>!
+Microsoft.Maui.Controls.StyleableElement.class.set -> void

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -583,3 +583,7 @@ Microsoft.Maui.Controls.StyleableElement.StyleClass.set -> void
 static readonly Microsoft.Maui.Controls.StyleableElement.StyleProperty -> Microsoft.Maui.Controls.BindableProperty!
 Microsoft.Maui.Controls.StyleableElement.class.get -> System.Collections.Generic.IList<string!>!
 Microsoft.Maui.Controls.StyleableElement.class.set -> void
+*REMOVED*~Microsoft.Maui.Controls.MenuItem.class.get -> System.Collections.Generic.IList<string>
+*REMOVED*~Microsoft.Maui.Controls.MenuItem.class.set -> void
+*REMOVED*~Microsoft.Maui.Controls.MenuItem.StyleClass.get -> System.Collections.Generic.IList<string>
+*REMOVED*~Microsoft.Maui.Controls.MenuItem.StyleClass.set -> void

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -587,3 +587,9 @@ Microsoft.Maui.Controls.StyleableElement.class.set -> void
 *REMOVED*~Microsoft.Maui.Controls.MenuItem.class.set -> void
 *REMOVED*~Microsoft.Maui.Controls.MenuItem.StyleClass.get -> System.Collections.Generic.IList<string>
 *REMOVED*~Microsoft.Maui.Controls.MenuItem.StyleClass.set -> void
+*REMOVED*~Microsoft.Maui.Controls.NavigableElement.class.get -> System.Collections.Generic.IList<string>
+*REMOVED*~Microsoft.Maui.Controls.NavigableElement.class.set -> void
+*REMOVED*~Microsoft.Maui.Controls.NavigableElement.Style.get -> Microsoft.Maui.Controls.Style
+*REMOVED*~Microsoft.Maui.Controls.NavigableElement.Style.set -> void
+*REMOVED*~Microsoft.Maui.Controls.NavigableElement.StyleClass.get -> System.Collections.Generic.IList<string>
+*REMOVED*~Microsoft.Maui.Controls.NavigableElement.StyleClass.set -> void

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -341,3 +341,9 @@ Microsoft.Maui.Controls.StyleableElement.class.set -> void
 *REMOVED*~Microsoft.Maui.Controls.MenuItem.class.set -> void
 *REMOVED*~Microsoft.Maui.Controls.MenuItem.StyleClass.get -> System.Collections.Generic.IList<string>
 *REMOVED*~Microsoft.Maui.Controls.MenuItem.StyleClass.set -> void
+*REMOVED*~Microsoft.Maui.Controls.NavigableElement.class.get -> System.Collections.Generic.IList<string>
+*REMOVED*~Microsoft.Maui.Controls.NavigableElement.class.set -> void
+*REMOVED*~Microsoft.Maui.Controls.NavigableElement.Style.get -> Microsoft.Maui.Controls.Style
+*REMOVED*~Microsoft.Maui.Controls.NavigableElement.Style.set -> void
+*REMOVED*~Microsoft.Maui.Controls.NavigableElement.StyleClass.get -> System.Collections.Generic.IList<string>
+*REMOVED*~Microsoft.Maui.Controls.NavigableElement.StyleClass.set -> void

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -337,3 +337,7 @@ Microsoft.Maui.Controls.StyleableElement.StyleClass.set -> void
 static readonly Microsoft.Maui.Controls.StyleableElement.StyleProperty -> Microsoft.Maui.Controls.BindableProperty!
 Microsoft.Maui.Controls.StyleableElement.class.get -> System.Collections.Generic.IList<string!>!
 Microsoft.Maui.Controls.StyleableElement.class.set -> void
+*REMOVED*~Microsoft.Maui.Controls.MenuItem.class.get -> System.Collections.Generic.IList<string>
+*REMOVED*~Microsoft.Maui.Controls.MenuItem.class.set -> void
+*REMOVED*~Microsoft.Maui.Controls.MenuItem.StyleClass.get -> System.Collections.Generic.IList<string>
+*REMOVED*~Microsoft.Maui.Controls.MenuItem.StyleClass.set -> void

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -328,3 +328,12 @@ Microsoft.Maui.Controls.PlatformWebViewProcessTerminatedEventArgs.PlatformWebVie
 Microsoft.Maui.Controls.VisualElement.Measure(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 ~override Microsoft.Maui.Controls.ShellContent.OnPropertyChanged(string propertyName = null) -> void
 *REMOVED*override Microsoft.Maui.Controls.Layout.Measure(double widthConstraint, double heightConstraint, Microsoft.Maui.Controls.MeasureFlags flags = Microsoft.Maui.Controls.MeasureFlags.None) -> Microsoft.Maui.SizeRequest
+Microsoft.Maui.Controls.StyleableElement
+Microsoft.Maui.Controls.StyleableElement.Style.get -> Microsoft.Maui.Controls.Style!
+Microsoft.Maui.Controls.StyleableElement.Style.set -> void
+Microsoft.Maui.Controls.StyleableElement.StyleableElement() -> void
+Microsoft.Maui.Controls.StyleableElement.StyleClass.get -> System.Collections.Generic.IList<string!>!
+Microsoft.Maui.Controls.StyleableElement.StyleClass.set -> void
+static readonly Microsoft.Maui.Controls.StyleableElement.StyleProperty -> Microsoft.Maui.Controls.BindableProperty!
+Microsoft.Maui.Controls.StyleableElement.class.get -> System.Collections.Generic.IList<string!>!
+Microsoft.Maui.Controls.StyleableElement.class.set -> void

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -384,3 +384,9 @@ Microsoft.Maui.Controls.StyleableElement.class.set -> void
 *REMOVED*~Microsoft.Maui.Controls.MenuItem.class.set -> void
 *REMOVED*~Microsoft.Maui.Controls.MenuItem.StyleClass.get -> System.Collections.Generic.IList<string>
 *REMOVED*~Microsoft.Maui.Controls.MenuItem.StyleClass.set -> void
+*REMOVED*~Microsoft.Maui.Controls.NavigableElement.class.get -> System.Collections.Generic.IList<string>
+*REMOVED*~Microsoft.Maui.Controls.NavigableElement.class.set -> void
+*REMOVED*~Microsoft.Maui.Controls.NavigableElement.Style.get -> Microsoft.Maui.Controls.Style
+*REMOVED*~Microsoft.Maui.Controls.NavigableElement.Style.set -> void
+*REMOVED*~Microsoft.Maui.Controls.NavigableElement.StyleClass.get -> System.Collections.Generic.IList<string>
+*REMOVED*~Microsoft.Maui.Controls.NavigableElement.StyleClass.set -> void

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -380,3 +380,7 @@ Microsoft.Maui.Controls.StyleableElement.StyleClass.set -> void
 static readonly Microsoft.Maui.Controls.StyleableElement.StyleProperty -> Microsoft.Maui.Controls.BindableProperty!
 Microsoft.Maui.Controls.StyleableElement.class.get -> System.Collections.Generic.IList<string!>!
 Microsoft.Maui.Controls.StyleableElement.class.set -> void
+*REMOVED*~Microsoft.Maui.Controls.MenuItem.class.get -> System.Collections.Generic.IList<string>
+*REMOVED*~Microsoft.Maui.Controls.MenuItem.class.set -> void
+*REMOVED*~Microsoft.Maui.Controls.MenuItem.StyleClass.get -> System.Collections.Generic.IList<string>
+*REMOVED*~Microsoft.Maui.Controls.MenuItem.StyleClass.set -> void

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -371,3 +371,12 @@ static Microsoft.Maui.Controls.Embedding.EmbeddingExtensions.CreateEmbeddedWindo
 static Microsoft.Maui.Controls.Embedding.EmbeddingExtensions.ToPlatformEmbedded(this Microsoft.Maui.IElement! element, Microsoft.Maui.IMauiContext! context) -> Microsoft.UI.Xaml.FrameworkElement!
 static Microsoft.Maui.Controls.Embedding.EmbeddingExtensions.ToPlatformEmbedded(this Microsoft.Maui.IElement! element, Microsoft.Maui.Hosting.MauiApp! mauiApp, Microsoft.UI.Xaml.Window! platformWindow) -> Microsoft.UI.Xaml.FrameworkElement!
 *REMOVED*override Microsoft.Maui.Controls.Layout.Measure(double widthConstraint, double heightConstraint, Microsoft.Maui.Controls.MeasureFlags flags = Microsoft.Maui.Controls.MeasureFlags.None) -> Microsoft.Maui.SizeRequest
+Microsoft.Maui.Controls.StyleableElement
+Microsoft.Maui.Controls.StyleableElement.Style.get -> Microsoft.Maui.Controls.Style!
+Microsoft.Maui.Controls.StyleableElement.Style.set -> void
+Microsoft.Maui.Controls.StyleableElement.StyleableElement() -> void
+Microsoft.Maui.Controls.StyleableElement.StyleClass.get -> System.Collections.Generic.IList<string!>!
+Microsoft.Maui.Controls.StyleableElement.StyleClass.set -> void
+static readonly Microsoft.Maui.Controls.StyleableElement.StyleProperty -> Microsoft.Maui.Controls.BindableProperty!
+Microsoft.Maui.Controls.StyleableElement.class.get -> System.Collections.Generic.IList<string!>!
+Microsoft.Maui.Controls.StyleableElement.class.set -> void

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -338,3 +338,9 @@ Microsoft.Maui.Controls.StyleableElement.StyleClass.set -> void
 *REMOVED*~Microsoft.Maui.Controls.MenuItem.class.set -> void
 *REMOVED*~Microsoft.Maui.Controls.MenuItem.StyleClass.get -> System.Collections.Generic.IList<string>
 *REMOVED*~Microsoft.Maui.Controls.MenuItem.StyleClass.set -> void
+*REMOVED*~Microsoft.Maui.Controls.NavigableElement.class.get -> System.Collections.Generic.IList<string>
+*REMOVED*~Microsoft.Maui.Controls.NavigableElement.class.set -> void
+*REMOVED*~Microsoft.Maui.Controls.NavigableElement.Style.get -> Microsoft.Maui.Controls.Style
+*REMOVED*~Microsoft.Maui.Controls.NavigableElement.Style.set -> void
+*REMOVED*~Microsoft.Maui.Controls.NavigableElement.StyleClass.get -> System.Collections.Generic.IList<string>
+*REMOVED*~Microsoft.Maui.Controls.NavigableElement.StyleClass.set -> void

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -334,3 +334,7 @@ Microsoft.Maui.Controls.StyleableElement.Style.set -> void
 Microsoft.Maui.Controls.StyleableElement.StyleableElement() -> void
 Microsoft.Maui.Controls.StyleableElement.StyleClass.get -> System.Collections.Generic.IList<string!>!
 Microsoft.Maui.Controls.StyleableElement.StyleClass.set -> void
+*REMOVED*~Microsoft.Maui.Controls.MenuItem.class.get -> System.Collections.Generic.IList<string>
+*REMOVED*~Microsoft.Maui.Controls.MenuItem.class.set -> void
+*REMOVED*~Microsoft.Maui.Controls.MenuItem.StyleClass.get -> System.Collections.Generic.IList<string>
+*REMOVED*~Microsoft.Maui.Controls.MenuItem.StyleClass.set -> void

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -89,6 +89,8 @@ Microsoft.Maui.Controls.PointerGestureRecognizer.PointerReleasedCommand.get -> S
 Microsoft.Maui.Controls.PointerGestureRecognizer.PointerReleasedCommand.set -> void
 Microsoft.Maui.Controls.PointerGestureRecognizer.PointerReleasedCommandParameter.get -> object!
 Microsoft.Maui.Controls.PointerGestureRecognizer.PointerReleasedCommandParameter.set -> void
+Microsoft.Maui.Controls.StyleableElement.class.get -> System.Collections.Generic.IList<string!>!
+Microsoft.Maui.Controls.StyleableElement.class.set -> void
 Microsoft.Maui.Controls.TimeChangedEventArgs
 Microsoft.Maui.Controls.TimeChangedEventArgs.NewTime.get -> System.TimeSpan
 Microsoft.Maui.Controls.TimeChangedEventArgs.OldTime.get -> System.TimeSpan
@@ -136,6 +138,7 @@ static readonly Microsoft.Maui.Controls.PointerGestureRecognizer.PointerPressedC
 static readonly Microsoft.Maui.Controls.PointerGestureRecognizer.PointerPressedCommandProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.PointerGestureRecognizer.PointerReleasedCommandParameterProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.PointerGestureRecognizer.PointerReleasedCommandProperty -> Microsoft.Maui.Controls.BindableProperty!
+static readonly Microsoft.Maui.Controls.StyleableElement.StyleProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.TitleBar.ContentProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.TitleBar.ForegroundColorProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.TitleBar.IconProperty -> Microsoft.Maui.Controls.BindableProperty!
@@ -325,3 +328,9 @@ virtual Microsoft.Maui.Controls.Application.ActivateWindow(Microsoft.Maui.Contro
 Microsoft.Maui.Controls.VisualElement.Measure(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 *REMOVED*override Microsoft.Maui.Controls.Layout.Measure(double widthConstraint, double heightConstraint, Microsoft.Maui.Controls.MeasureFlags flags = Microsoft.Maui.Controls.MeasureFlags.None) -> Microsoft.Maui.SizeRequest
 static Microsoft.Maui.Controls.ViewExtensions.InvalidateMeasure(this Microsoft.Maui.Controls.VisualElement! view) -> void
+Microsoft.Maui.Controls.StyleableElement
+Microsoft.Maui.Controls.StyleableElement.Style.get -> Microsoft.Maui.Controls.Style!
+Microsoft.Maui.Controls.StyleableElement.Style.set -> void
+Microsoft.Maui.Controls.StyleableElement.StyleableElement() -> void
+Microsoft.Maui.Controls.StyleableElement.StyleClass.get -> System.Collections.Generic.IList<string!>!
+Microsoft.Maui.Controls.StyleableElement.StyleClass.set -> void

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -87,6 +87,12 @@ Microsoft.Maui.Controls.PointerGestureRecognizer.PointerReleasedCommand.get -> S
 Microsoft.Maui.Controls.PointerGestureRecognizer.PointerReleasedCommand.set -> void
 Microsoft.Maui.Controls.PointerGestureRecognizer.PointerReleasedCommandParameter.get -> object!
 Microsoft.Maui.Controls.PointerGestureRecognizer.PointerReleasedCommandParameter.set -> void
+Microsoft.Maui.Controls.StyleableElement
+Microsoft.Maui.Controls.StyleableElement.Style.get -> Microsoft.Maui.Controls.Style!
+Microsoft.Maui.Controls.StyleableElement.Style.set -> void
+Microsoft.Maui.Controls.StyleableElement.StyleableElement() -> void
+Microsoft.Maui.Controls.StyleableElement.StyleClass.get -> System.Collections.Generic.IList<string!>!
+Microsoft.Maui.Controls.StyleableElement.StyleClass.set -> void
 Microsoft.Maui.Controls.TimeChangedEventArgs
 Microsoft.Maui.Controls.TimeChangedEventArgs.NewTime.get -> System.TimeSpan
 Microsoft.Maui.Controls.TimeChangedEventArgs.OldTime.get -> System.TimeSpan
@@ -135,6 +141,7 @@ static readonly Microsoft.Maui.Controls.PointerGestureRecognizer.PointerPressedC
 static readonly Microsoft.Maui.Controls.PointerGestureRecognizer.PointerReleasedCommandParameterProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.PointerGestureRecognizer.PointerReleasedCommandProperty -> Microsoft.Maui.Controls.BindableProperty!
 Microsoft.Maui.Controls.Element.ClearLogicalChildren() -> void
+static readonly Microsoft.Maui.Controls.StyleableElement.StyleProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.TitleBar.ContentProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.TitleBar.ForegroundColorProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.TitleBar.IconProperty -> Microsoft.Maui.Controls.BindableProperty!
@@ -325,3 +332,5 @@ static Microsoft.Maui.Controls.BindingBase.Create<TSource, TProperty>(System.Fun
 Microsoft.Maui.Controls.VisualElement.Measure(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 ~override Microsoft.Maui.Controls.ShellContent.OnPropertyChanged(string propertyName = null) -> void
 *REMOVED*override Microsoft.Maui.Controls.Layout.Measure(double widthConstraint, double heightConstraint, Microsoft.Maui.Controls.MeasureFlags flags = Microsoft.Maui.Controls.MeasureFlags.None) -> Microsoft.Maui.SizeRequest
+Microsoft.Maui.Controls.StyleableElement.class.get -> System.Collections.Generic.IList<string!>!
+Microsoft.Maui.Controls.StyleableElement.class.set -> void

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -338,3 +338,9 @@ Microsoft.Maui.Controls.StyleableElement.class.set -> void
 *REMOVED*~Microsoft.Maui.Controls.MenuItem.class.set -> void
 *REMOVED*~Microsoft.Maui.Controls.MenuItem.StyleClass.get -> System.Collections.Generic.IList<string>
 *REMOVED*~Microsoft.Maui.Controls.MenuItem.StyleClass.set -> void
+*REMOVED*~Microsoft.Maui.Controls.NavigableElement.class.get -> System.Collections.Generic.IList<string>
+*REMOVED*~Microsoft.Maui.Controls.NavigableElement.class.set -> void
+*REMOVED*~Microsoft.Maui.Controls.NavigableElement.Style.get -> Microsoft.Maui.Controls.Style
+*REMOVED*~Microsoft.Maui.Controls.NavigableElement.Style.set -> void
+*REMOVED*~Microsoft.Maui.Controls.NavigableElement.StyleClass.get -> System.Collections.Generic.IList<string>
+*REMOVED*~Microsoft.Maui.Controls.NavigableElement.StyleClass.set -> void

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -334,3 +334,7 @@ Microsoft.Maui.Controls.VisualElement.Measure(double widthConstraint, double hei
 *REMOVED*override Microsoft.Maui.Controls.Layout.Measure(double widthConstraint, double heightConstraint, Microsoft.Maui.Controls.MeasureFlags flags = Microsoft.Maui.Controls.MeasureFlags.None) -> Microsoft.Maui.SizeRequest
 Microsoft.Maui.Controls.StyleableElement.class.get -> System.Collections.Generic.IList<string!>!
 Microsoft.Maui.Controls.StyleableElement.class.set -> void
+*REMOVED*~Microsoft.Maui.Controls.MenuItem.class.get -> System.Collections.Generic.IList<string>
+*REMOVED*~Microsoft.Maui.Controls.MenuItem.class.set -> void
+*REMOVED*~Microsoft.Maui.Controls.MenuItem.StyleClass.get -> System.Collections.Generic.IList<string>
+*REMOVED*~Microsoft.Maui.Controls.MenuItem.StyleClass.set -> void

--- a/src/Controls/src/Core/StyleableElement/StyleableElement.cs
+++ b/src/Controls/src/Core/StyleableElement/StyleableElement.cs
@@ -1,0 +1,57 @@
+using System.Collections.Generic;
+using Microsoft.Maui.Controls.Internals;
+using Microsoft.Maui.Controls.StyleSheets;
+
+namespace Microsoft.Maui.Controls
+{
+	/// <summary>Represents an <see cref="Element"/> with base functionality for <see cref="Page"/> styling. Does not necessarily render on screen.</summary>
+	public class StyleableElement : Element, IStyleSelectable
+	{
+		/// <summary>Bindable property for <see cref="Style"/>.</summary>
+		public static readonly BindableProperty StyleProperty =
+			BindableProperty.Create(nameof(Style), typeof(Style), typeof(StyleableElement), default(Style),
+				propertyChanged: (bindable, oldvalue, newvalue) => ((StyleableElement)bindable)._mergedStyle.Style = (Style)newvalue);
+
+		internal readonly MergedStyle _mergedStyle;
+
+		public StyleableElement()
+		{
+			_mergedStyle = new MergedStyle(GetType(), this);
+		}
+
+		/// <summary>Gets or sets the unique <see cref="Style"/> for this element.</summary>
+		public Style Style
+		{
+			get { return (Style)GetValue(StyleProperty); }
+			set { SetValue(StyleProperty, value); }
+		}
+
+		/// <summary>Gets or sets the style classes for the element.</summary>
+		/// <remarks>
+		///		<para>Equiavalent to <see cref="@class"/>.</para>
+		///		<para>Style classes enable multiple styles to be applied to a control, without resorting to style inheritance.</para>
+		/// </remarks>
+		/// <seealso href="https://learn.microsoft.com/dotnet/maui/user-interface/styles/xaml?view=net-maui-8.0#style-classes">Conceptual documentation on style classes</seealso>
+		[System.ComponentModel.TypeConverter(typeof(ListStringTypeConverter))]
+		public IList<string> StyleClass
+		{
+			get => @class;
+			set => @class = value;
+		}
+
+		/// <summary>Gets or sets the style classes for the element.</summary>
+		/// <remarks>
+		///		<para>Equiavalent to <see cref="StyleClass"/>.</para>
+		///		<para>Style classes enable multiple styles to be applied to a control, without resorting to style inheritance.</para>
+		/// </remarks>
+		/// <seealso href="https://learn.microsoft.com/dotnet/maui/user-interface/styles/xaml?view=net-maui-8.0#style-classes">Conceptual documentation on style classes</seealso>
+		[System.ComponentModel.TypeConverter(typeof(ListStringTypeConverter))]
+		public IList<string> @class
+		{
+			get => _mergedStyle.StyleClass;
+			set => _mergedStyle.StyleClass = value;
+		}
+
+		IList<string> IStyleSelectable.Classes => StyleClass;
+	}
+}

--- a/src/Controls/src/Core/StyleableElement/StyleableElement.cs
+++ b/src/Controls/src/Core/StyleableElement/StyleableElement.cs
@@ -5,7 +5,7 @@ using Microsoft.Maui.Controls.StyleSheets;
 namespace Microsoft.Maui.Controls
 {
 	/// <summary>Represents an <see cref="Element"/> with base functionality for <see cref="Page"/> styling. Does not necessarily render on screen.</summary>
-	public class StyleableElement : Element, IStyleSelectable
+	public abstract class StyleableElement : Element, IStyleSelectable
 	{
 		/// <summary>Bindable property for <see cref="Style"/>.</summary>
 		public static readonly BindableProperty StyleProperty =

--- a/src/Controls/src/Core/StyleableElement/StyleableElement.cs
+++ b/src/Controls/src/Core/StyleableElement/StyleableElement.cs
@@ -4,7 +4,7 @@ using Microsoft.Maui.Controls.StyleSheets;
 
 namespace Microsoft.Maui.Controls
 {
-	/// <summary>Represents an <see cref="Element"/> with base functionality for <see cref="Page"/> styling. Does not necessarily render on screen.</summary>
+	/// <summary>Represents an <see cref="Element"/> with base functionality for styling. Does not necessarily render on screen.</summary>
 	public abstract class StyleableElement : Element, IStyleSelectable
 	{
 		/// <summary>Bindable property for <see cref="Style"/>.</summary>

--- a/src/Controls/src/Core/VisualElement/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement/VisualElement.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Maui.Controls
 		/// <summary>Bindable property for <see cref="NavigableElement.Navigation"/>.</summary>
 		public new static readonly BindableProperty NavigationProperty = NavigableElement.NavigationProperty;
 
-		/// <summary>Bindable property for <see cref="NavigableElement.Style"/>.</summary>
+		/// <inheritdoc/>
 		public new static readonly BindableProperty StyleProperty = NavigableElement.StyleProperty;
 
 		bool _inputTransparentExplicit = (bool)InputTransparentProperty.DefaultValue;

--- a/src/Controls/tests/Core.UnitTests/TestClasses/TestApp.cs
+++ b/src/Controls/tests/Core.UnitTests/TestClasses/TestApp.cs
@@ -9,30 +9,30 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 	public class TestApp : Application
 	{
 		Page _withPage;
-		TestWindow _window;
+		Window _window;
 
 		public TestApp() : base(false)
 		{
 
 		}
 
-		public TestApp(TestWindow window) : base(false)
+		public TestApp(Window window) : base(false)
 		{
 			_window = window;
 		}
 
-		public TestWindow CreateWindow() =>
-			(TestWindow)(this as IApplication).CreateWindow(null);
+		public Window CreateWindow() =>
+			(Window)(this as IApplication).CreateWindow(null);
 
 		protected override Window CreateWindow(IActivationState activationState)
 		{
 			return _window ?? new TestWindow(_withPage ?? new ContentPage());
 		}
 
-		public TestWindow CreateWindow(Page withPage)
+		public Window CreateWindow(Page withPage)
 		{
 			_withPage = withPage;
-			return (TestWindow)(this as IApplication).CreateWindow(null);
+			return (Window)(this as IApplication).CreateWindow(null);
 		}
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/TestClasses/TestApp.cs
+++ b/src/Controls/tests/Core.UnitTests/TestClasses/TestApp.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 		protected override Window CreateWindow(IActivationState activationState)
 		{
-			return _window ?? new TestWindow(_withPage ?? new ContentPage());
+			return _window ?? new Window(_withPage ?? new ContentPage());
 		}
 
 		public Window CreateWindow(Page withPage)

--- a/src/Controls/tests/Core.UnitTests/WindowsTests.cs
+++ b/src/Controls/tests/Core.UnitTests/WindowsTests.cs
@@ -13,6 +13,63 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 	public class WindowsTests : BaseTestFixture
 	{
 		[Fact]
+		public void WindowIsStyleable()
+		{
+			var style = new Style(typeof(Window))
+			{
+				Setters =
+				{
+					new Setter { Property = Window.TitleProperty, Value = "Style Title" }
+				},
+			};
+
+			var app = new TestApp();
+			app.Resources = new ResourceDictionary { style };
+
+			var window = app.CreateWindow();
+
+			Assert.Equal("Style Title", window.Title);
+		}
+
+		[Fact]
+		public void WindowIsStyleableWithStyleClass()
+		{
+			var style = new Style(typeof(Window))
+			{
+				Setters =
+				{
+					new Setter { Property = Window.TitleProperty, Value = "Style Title" }
+				},
+				Class = "fooClass",
+			};
+
+			var app = new TestApp();
+			app.Resources = new ResourceDictionary { style };
+
+			var window = app.CreateWindow();
+			window.StyleClass = new[] { "fooClass" };
+
+			Assert.Equal("Style Title", window.Title);
+		}
+
+		[Fact]
+		public void WindowIsStyleableWithStyle()
+		{
+			var style = new Style(typeof(Window))
+			{
+				Setters =
+				{
+					new Setter { Property = Window.TitleProperty, Value = "Style Title" }
+				},
+			};
+
+			var window = new Window();
+			window.Style = style;
+
+			Assert.Equal("Style Title", window.Title);
+		}
+
+		[Fact]
 		public void ContentPageFlowDirectionSetsOnIWindow()
 		{
 			var app = new TestApp();

--- a/src/Controls/tests/Core.UnitTests/WindowsTests.cs
+++ b/src/Controls/tests/Core.UnitTests/WindowsTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 				},
 			};
 
-			var app = new TestApp(new Window(new ContentPage()));
+			var app = new TestApp();
 			app.Resources.Add(style);
 
 			var window = app.CreateWindow();
@@ -43,7 +43,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 				Class = "fooClass",
 			};
 
-			var app = new TestApp(new Window(new ContentPage()));
+			var app = new TestApp();
 			app.Resources.Add(style);
 
 			var window = app.CreateWindow();

--- a/src/Controls/tests/Core.UnitTests/WindowsTests.cs
+++ b/src/Controls/tests/Core.UnitTests/WindowsTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 	public class WindowsTests : BaseTestFixture
 	{
 		[Fact]
-		public void WindowIsStyleable()
+		public void WindowIsStyleableWithImplicitStyle()
 		{
 			var style = new Style(typeof(Window))
 			{
@@ -23,8 +23,8 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 				},
 			};
 
-			var app = new TestApp();
-			app.Resources = new ResourceDictionary { style };
+			var app = new TestApp(new Window(new ContentPage()));
+			app.Resources.Add(style);
 
 			var window = app.CreateWindow();
 
@@ -43,8 +43,8 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 				Class = "fooClass",
 			};
 
-			var app = new TestApp();
-			app.Resources = new ResourceDictionary { style };
+			var app = new TestApp(new Window(new ContentPage()));
+			app.Resources.Add(style);
 
 			var window = app.CreateWindow();
 			window.StyleClass = new[] { "fooClass" };
@@ -53,7 +53,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact]
-		public void WindowIsStyleableWithStyle()
+		public void WindowIsStyleableWithStyleProperty()
 		{
 			var style = new Style(typeof(Window))
 			{


### PR DESCRIPTION
### Description of Change

It's currently not possible for 3rd party libraries to easily hook into our styling mechanisms because all of the necessary APIs are private/internal.

This provides a version of Element that exposes the style bits making it easier to enable Styling scenarios.

### Issues Fixed
Fixes #24257

