### PR TITLE
Use newer default backup rules for android

### DIFF
--- a/src/BlazorWebView/tests/MauiDeviceTests/Platforms/Android/AndroidManifest.xml
+++ b/src/BlazorWebView/tests/MauiDeviceTests/Platforms/Android/AndroidManifest.xml
@@ -1,6 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-	<application android:allowBackup="true" android:icon="@mipmap/appicon" android:roundIcon="@mipmap/appicon_round" android:supportsRtl="true"></application>
+	<application
+		android:allowBackup="true"
+		android:dataExtractionRules="@xml/microsoft_maui_essentials_dataextractionrules_defaults"
+		android:fullBackupContent="@xml/microsoft_maui_essentials_fullbackupcontent_defaults"
+		android:icon="@mipmap/appicon"
+		android:roundIcon="@mipmap/appicon_round"
+		android:supportsRtl="true">
+	</application>
 	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 	<uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />

--- a/src/Controls/samples/Controls.Sample.Profiling/Platforms/Android/AndroidManifest.xml
+++ b/src/Controls/samples/Controls.Sample.Profiling/Platforms/Android/AndroidManifest.xml
@@ -1,5 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-	<application android:allowBackup="true" android:icon="@mipmap/appicon" android:roundIcon="@mipmap/appicon_round" android:supportsRtl="true"></application>
+	<application
+		android:allowBackup="true"
+		android:dataExtractionRules="@xml/microsoft_maui_essentials_dataextractionrules_defaults"
+		android:fullBackupContent="@xml/microsoft_maui_essentials_fullbackupcontent_defaults"
+		android:icon="@mipmap/appicon"
+		android:roundIcon="@mipmap/appicon_round"
+		android:supportsRtl="true">
+	</application>
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 </manifest>

--- a/src/Controls/samples/Controls.Sample.Sandbox/Platforms/Android/AndroidManifest.xml
+++ b/src/Controls/samples/Controls.Sample.Sandbox/Platforms/Android/AndroidManifest.xml
@@ -1,6 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:installLocation="auto">
-  <application android:allowBackup="true" android:icon="@mipmap/appicon" android:roundIcon="@mipmap/appicon_round" android:supportsRtl="true">
+  <application
+    android:allowBackup="true"
+    android:dataExtractionRules="@xml/microsoft_maui_essentials_dataextractionrules_defaults"
+    android:fullBackupContent="@xml/microsoft_maui_essentials_fullbackupcontent_defaults"
+    android:icon="@mipmap/appicon"
+    android:roundIcon="@mipmap/appicon_round"
+    android:supportsRtl="true">
     <meta-data android:name="com.google.android.geo.API_KEY" android:value="" />
 
     <meta-data android:name="com.google.android.gms.version" android:value="@integer/google_play_services_version" />

--- a/src/Controls/samples/Controls.Sample/Platforms/Android/AndroidManifest.xml
+++ b/src/Controls/samples/Controls.Sample/Platforms/Android/AndroidManifest.xml
@@ -1,6 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:installLocation="auto">
-  <application android:allowBackup="true" android:icon="@mipmap/appicon" android:roundIcon="@mipmap/appicon_round" android:supportsRtl="true">
+  <application
+    android:allowBackup="true"
+    android:dataExtractionRules="@xml/microsoft_maui_essentials_dataextractionrules_defaults"
+    android:fullBackupContent="@xml/microsoft_maui_essentials_fullbackupcontent_defaults"
+    android:icon="@mipmap/appicon"
+    android:roundIcon="@mipmap/appicon_round"
+    android:supportsRtl="true">
     <meta-data android:name="com.google.android.maps.v2.API_KEY" android:value="YOUR_API_KEY" />
 
     <meta-data android:name="com.google.android.gms.version" android:value="@integer/google_play_services_version" />

--- a/src/Controls/tests/DeviceTests/Platforms/Android/AndroidManifest.xml
+++ b/src/Controls/tests/DeviceTests/Platforms/Android/AndroidManifest.xml
@@ -1,6 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-	<application android:allowBackup="true" android:icon="@mipmap/appicon" android:roundIcon="@mipmap/appicon_round" android:supportsRtl="true"></application>
+	<application
+		android:allowBackup="true"
+		android:dataExtractionRules="@xml/microsoft_maui_essentials_dataextractionrules_defaults"
+		android:fullBackupContent="@xml/microsoft_maui_essentials_fullbackupcontent_defaults"
+		android:icon="@mipmap/appicon"
+		android:roundIcon="@mipmap/appicon_round"
+		android:supportsRtl="true">
+	</application>
 	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 	<uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />

--- a/src/Controls/tests/TestCases.HostApp/Platforms/Android/AndroidManifest.xml
+++ b/src/Controls/tests/TestCases.HostApp/Platforms/Android/AndroidManifest.xml
@@ -1,6 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:installLocation="auto">
-  <application android:allowBackup="true" android:icon="@mipmap/appicon" android:roundIcon="@mipmap/appicon_round" android:supportsRtl="true">
+  <application
+    android:allowBackup="true"
+    android:dataExtractionRules="@xml/microsoft_maui_essentials_dataextractionrules_defaults"
+    android:fullBackupContent="@xml/microsoft_maui_essentials_fullbackupcontent_defaults"
+    android:icon="@mipmap/appicon"
+    android:roundIcon="@mipmap/appicon_round"
+    android:supportsRtl="true">
     <meta-data android:name="com.google.android.geo.API_KEY" android:value="" />
 
     <meta-data android:name="com.google.android.gms.version" android:value="@integer/google_play_services_version" />

--- a/src/Core/tests/Benchmarks.Droid/AndroidManifest.xml
+++ b/src/Core/tests/Benchmarks.Droid/AndroidManifest.xml
@@ -1,5 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-  <application android:allowBackup="true" android:icon="@mipmap/ic_launcher" android:label="@string/app_name" android:roundIcon="@mipmap/ic_launcher_round" android:supportsRtl="true">
+  <application
+    android:allowBackup="true"
+    android:dataExtractionRules="@xml/microsoft_maui_essentials_dataextractionrules_defaults"
+    android:fullBackupContent="@xml/microsoft_maui_essentials_fullbackupcontent_defaults"
+    android:icon="@mipmap/ic_launcher"
+    android:label="@string/app_name"
+    android:roundIcon="@mipmap/ic_launcher_round"
+    android:supportsRtl="true">
   </application>
 </manifest>

--- a/src/Core/tests/DeviceTests/Platforms/Android/AndroidManifest.xml
+++ b/src/Core/tests/DeviceTests/Platforms/Android/AndroidManifest.xml
@@ -1,6 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-	<application android:allowBackup="true" android:icon="@mipmap/appicon" android:roundIcon="@mipmap/appicon_round" android:supportsRtl="true"></application>
+	<application
+		android:allowBackup="true"
+		android:dataExtractionRules="@xml/microsoft_maui_essentials_dataextractionrules_defaults"
+		android:fullBackupContent="@xml/microsoft_maui_essentials_fullbackupcontent_defaults"
+		android:icon="@mipmap/appicon"
+		android:roundIcon="@mipmap/appicon_round"
+		android:supportsRtl="true">
+	</application>
 	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 	<uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />

--- a/src/Essentials/samples/Samples/Platforms/Android/AndroidManifest.xml
+++ b/src/Essentials/samples/Samples/Platforms/Android/AndroidManifest.xml
@@ -50,5 +50,12 @@
 	<uses-feature android:name="android.hardware.location" android:required="false" />
 	<uses-feature android:name="android.hardware.location.gps" android:required="false" />
 	<uses-feature android:name="android.hardware.location.network" android:required="false" />
-	<application android:allowBackup="true" android:icon="@mipmap/appicon" android:roundIcon="@mipmap/appicon_round" android:supportsRtl="true" android:fullBackupContent="@xml/my_backup_rules"></application>
+	<application
+		android:allowBackup="true"
+		android:dataExtractionRules="@xml/microsoft_maui_essentials_dataextractionrules_defaults"
+		android:fullBackupContent="@xml/microsoft_maui_essentials_fullbackupcontent_defaults"
+		android:icon="@mipmap/appicon"
+		android:roundIcon="@mipmap/appicon_round"
+		android:supportsRtl="true">
+	</application>
 </manifest>

--- a/src/Essentials/samples/Samples/Platforms/Android/Resources/xml/my_backup_rules.xml
+++ b/src/Essentials/samples/Samples/Platforms/Android/Resources/xml/my_backup_rules.xml
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<full-backup-content>
-    <include domain="sharedpref" path="."/>
-    <exclude domain="sharedpref" path="${applicationId}.xamarinessentials.xml"/>
-</full-backup-content>

--- a/src/Essentials/src/Resources/xml-v31/microsoft_maui_essentials_dataextractionrules_defaults.xml
+++ b/src/Essentials/src/Resources/xml-v31/microsoft_maui_essentials_dataextractionrules_defaults.xml
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<data-extraction-rules>
+  <cloud-backup disableIfNoEncryptionCapabilities="false">
+    <exclude domain="sharedpref" path="${applicationId}.microsoft.maui.essentials.preferences.xml"/>
+  </cloud-backup>
+  <device-transfer>
+    <exclude domain="sharedpref" path="${applicationId}.microsoft.maui.essentials.preferences.xml"/>
+  </device-transfer>
+</data-extraction-rules>

--- a/src/Essentials/src/Resources/xml/microsoft_maui_essentials_fullbackupcontent_defaults.xml
+++ b/src/Essentials/src/Resources/xml/microsoft_maui_essentials_fullbackupcontent_defaults.xml
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<full-backup-content>
+  <exclude domain="sharedpref" path="${applicationId}.microsoft.maui.essentials.preferences.xml"/>
+</full-backup-content>

--- a/src/Essentials/test/DeviceTests/Platforms/Android/AndroidManifest.xml
+++ b/src/Essentials/test/DeviceTests/Platforms/Android/AndroidManifest.xml
@@ -1,6 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-	<application android:allowBackup="true" android:icon="@mipmap/appicon" android:roundIcon="@mipmap/appicon_round" android:supportsRtl="true"></application>
+	<application
+		android:allowBackup="true"
+		android:dataExtractionRules="@xml/microsoft_maui_essentials_dataextractionrules_defaults"
+		android:fullBackupContent="@xml/microsoft_maui_essentials_fullbackupcontent_defaults"
+		android:icon="@mipmap/appicon"
+		android:roundIcon="@mipmap/appicon_round"
+		android:supportsRtl="true">
+	</application>
 	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 	<uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />

--- a/src/Graphics/tests/DeviceTests/Platforms/Android/AndroidManifest.xml
+++ b/src/Graphics/tests/DeviceTests/Platforms/Android/AndroidManifest.xml
@@ -1,6 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-	<application android:allowBackup="true" android:icon="@mipmap/appicon" android:roundIcon="@mipmap/appicon_round" android:supportsRtl="true"></application>
+	<application
+		android:allowBackup="true"
+		android:dataExtractionRules="@xml/microsoft_maui_essentials_dataextractionrules_defaults"
+		android:fullBackupContent="@xml/microsoft_maui_essentials_fullbackupcontent_defaults"
+		android:icon="@mipmap/appicon"
+		android:roundIcon="@mipmap/appicon_round"
+		android:supportsRtl="true">
+	</application>
 	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 	<uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />

--- a/src/Templates/src/templates/maui-blazor/Platforms/Android/AndroidManifest.xml
+++ b/src/Templates/src/templates/maui-blazor/Platforms/Android/AndroidManifest.xml
@@ -1,6 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-    <application android:allowBackup="true" android:icon="@mipmap/appicon" android:roundIcon="@mipmap/appicon_round" android:supportsRtl="true"></application>
-    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-    <uses-permission android:name="android.permission.INTERNET" />
+	<application
+		android:allowBackup="true"
+		android:dataExtractionRules="@xml/microsoft_maui_essentials_dataextractionrules_defaults"
+		android:fullBackupContent="@xml/microsoft_maui_essentials_fullbackupcontent_defaults"
+		android:icon="@mipmap/appicon"
+		android:roundIcon="@mipmap/appicon_round"
+		android:supportsRtl="true">
+	</application>
+	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+	<uses-permission android:name="android.permission.INTERNET" />
 </manifest>

--- a/src/Templates/src/templates/maui-mobile/Platforms/Android/AndroidManifest.xml
+++ b/src/Templates/src/templates/maui-mobile/Platforms/Android/AndroidManifest.xml
@@ -1,6 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-	<application android:allowBackup="true" android:icon="@mipmap/appicon" android:roundIcon="@mipmap/appicon_round" android:supportsRtl="true"></application>
+	<application
+		android:allowBackup="true"
+		android:dataExtractionRules="@xml/microsoft_maui_essentials_dataextractionrules_defaults"
+		android:fullBackupContent="@xml/microsoft_maui_essentials_fullbackupcontent_defaults"
+		android:icon="@mipmap/appicon"
+		android:roundIcon="@mipmap/appicon_round"
+		android:supportsRtl="true">
+	</application>
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 	<uses-permission android:name="android.permission.INTERNET" />
 </manifest>

--- a/src/Templates/src/templates/maui-multiproject/MauiApp.1.Droid/AndroidManifest.xml
+++ b/src/Templates/src/templates/maui-multiproject/MauiApp.1.Droid/AndroidManifest.xml
@@ -1,6 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.companyname.mauiapp" android:versionCode="1" android:versionName="1.0">
-	<application android:allowBackup="true" android:icon="@mipmap/appicon" android:roundIcon="@mipmap/appicon_round" android:label="@string/app_name" android:supportsRtl="true"></application>
+	<application
+		android:allowBackup="true"
+		android:dataExtractionRules="@xml/microsoft_maui_essentials_dataextractionrules_defaults"
+		android:fullBackupContent="@xml/microsoft_maui_essentials_fullbackupcontent_defaults"
+		android:icon="@mipmap/appicon"
+		android:roundIcon="@mipmap/appicon_round"
+		android:label="@string/app_name"
+		android:supportsRtl="true">
+	</application>
 	<uses-permission android:name="android.permission.INTERNET" />
 	<uses-permission android:name="android.permission.INTERNET" />
 </manifest>

--- a/src/TestUtils/samples/DeviceTests.Sample/Platforms/Android/AndroidManifest.xml
+++ b/src/TestUtils/samples/DeviceTests.Sample/Platforms/Android/AndroidManifest.xml
@@ -1,6 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-	<application android:allowBackup="true" android:icon="@mipmap/appicon" android:roundIcon="@mipmap/appicon_round" android:supportsRtl="true"></application>
+	<application
+		android:allowBackup="true"
+		android:dataExtractionRules="@xml/microsoft_maui_essentials_dataextractionrules_defaults"
+		android:fullBackupContent="@xml/microsoft_maui_essentials_fullbackupcontent_defaults"
+		android:icon="@mipmap/appicon"
+		android:roundIcon="@mipmap/appicon_round"
+		android:supportsRtl="true">
+	</application>
 	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 	<uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />


### PR DESCRIPTION
Essentials' secure storage api's write to files which should not be backed up (https://developer.android.com/identity/data/autobackup#include-exclude-android-12).

There are now a couple of ways to specify these rules (previously we only had the old way for < API 31).

This updates the rules, but also adds them to our template so users will get them by default in new projects.


### Issues Fixed

Docs: https://github.com/dotnet/docs-maui/issues/2167
Related: https://github.com/dotnet/maui/issues/18230

