### PR TITLE
Fix Android FlyoutPage crash when changing orientation of tablet

### DIFF
--- a/src/Core/src/Handlers/FlyoutView/FlyoutViewHandler.Android.cs
+++ b/src/Core/src/Handlers/FlyoutView/FlyoutViewHandler.Android.cs
@@ -150,11 +150,13 @@ namespace Microsoft.Maui.Handlers
 			LayoutViews();
 		}
 
-		void LayoutViews()
+		async void LayoutViews()
 		{
 			if (_flyoutView == null)
 				return;
-
+			if (DrawerLayout.Parent != null)
+				await Task.Delay(100);
+		
 			if (VirtualView.FlyoutBehavior == FlyoutBehavior.Locked)
 				LayoutSideBySide();
 			else

--- a/src/Core/src/Handlers/FlyoutView/FlyoutViewHandler.Android.cs
+++ b/src/Core/src/Handlers/FlyoutView/FlyoutViewHandler.Android.cs
@@ -155,10 +155,17 @@ namespace Microsoft.Maui.Handlers
 			if (_flyoutView == null)
 				return;
 			if (DrawerLayout.Parent != null)
-				await Task.Delay(100);
+				await Task.Delay(500);
 		
 			if (VirtualView.FlyoutBehavior == FlyoutBehavior.Locked)
-				LayoutSideBySide();
+			{
+			    if ((DrawerLayout.Parent != null) && DrawerLayout.IsOpen)
+			    {
+			        DrawerLayout.Close();
+			        await Task.Delay(500);
+			    }
+			    LayoutSideBySide();
+			}
 			else
 				LayoutAsFlyout();
 		}


### PR DESCRIPTION
On an Android tablet, switching from landscape to portrait, and from portrait to landscape repeatedly produces this error: androidx.appcompat.widget.LinearLayoutCompat$LayoutParams cannot be cast to androidx.drawerlayout.widget.DrawerLayout$LayoutParams

This error can be easily reproduced on a physical tablet by quickly changing orientation.



The change of orientation triggers method UpdateFlyoutBehavior of src/Core/src/Handlers/FlyoutView/FlyoutViewHandler.Android.cs, that calls method LayoutViews to determine if the views are to be created in “side by side” mode or “as flyout”. The problem is after the rotation, DrawerLayout.GetPlatformViewBounds() called (for investigation) in this method shows that the Android view still has the height/width before the rotation. The MAUI code is ahead of the android reality. Waiting 100ms is enough to let Android adapt its interface.

A similar issue had been addressed by Xamarin developers: the comment on line 324 of https://github.com/xamarin/Xamarin.Forms/blob/5.0.0/Xamarin.Forms.Platform.Android/AppCompat/FlyoutPageRenderer.cs is  //hack : when the orientation changes and we try to close the Flyout on Android		 //sometimes Android picks the width of the screen previous to the rotation


### Description of Change

<!-- Enter description of the fix in this section -->

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #18161
Fixes #24779

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
