### PR TITLE
Use older JS API for HybridWebView test code and wait longer for web view to be ready

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/HybridWebView/HybridWebViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/HybridWebView/HybridWebViewTests.cs
@@ -335,13 +335,14 @@ namespace Microsoft.Maui.DeviceTests
 
 		private async Task WaitForHybridWebViewLoaded(HybridWebView hybridWebView)
 		{
-			const int NumRetries = 10;
+			const int NumRetries = 40;
 			const int RetryDelay = 500;
 			for (var i = 0; i < NumRetries; i++)
 			{
 				// 1. Check that the window.HybridWebView object exists (as set by HybridWebView.js)
 				// 2. Check that the test page's HTML is loaded by checking for the HTML element defined in the Resources\Raw\HybridTestRoot\index.html test page
-				var loaded = await hybridWebView.EvaluateJavaScriptAsync("Object.hasOwn(window, 'HybridWebView') && (document.getElementById('htmlLoaded') !== null)");
+
+				var loaded = await hybridWebView.EvaluateJavaScriptAsync("('HybridWebView' in window && Object.prototype.hasOwnProperty.call(window, 'HybridWebView')) && (document.getElementById('htmlLoaded') !== null)");
 				if (loaded == "true")
 				{
 					return;


### PR DESCRIPTION
### Description of Change

Apparently the test code was using JavaScript APIs that were not available on older Android emulators with older WebViews. I changed that code to use APIs that did exist.

Also increased total timeout from 5sec to 20sec in case emulators are slow.

Report of all HybridWebView tests failing on Android emulators: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=10075610&view=ms.vss-test-web.build-test-results-tab&runId=108410690&resultId=100057&paneView=debug

They all failed with `Waited 5,000ms for the HybridWebView test page to be ready, but it wasn't.`.