### PR TITLE
[Windows] Add `WindowsBatchPropertyMapper` to save unnecessary work when initializing views

### DIFF
--- a/src/Core/src/Handlers/View/ViewHandler.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.cs
@@ -27,6 +27,9 @@ namespace Microsoft.Maui.Handlers
 #if ANDROID
 			// Use a custom mapper for Android which knows how to batch the initial property sets
 			new AndroidBatchPropertyMapper<IView, IViewHandler>(ElementMapper)
+#elif WINDOWS
+			// Use a custom mapper for Windows which knows how to batch the initial property sets
+			new WindowsBatchPropertyMapper<IView, IViewHandler>(ElementMapper)
 #else
 			new PropertyMapper<IView, IViewHandler>(ElementHandler.ElementMapper)
 #endif

--- a/src/Core/src/Handlers/View/WindowsBatchPropertyMapper.cs
+++ b/src/Core/src/Handlers/View/WindowsBatchPropertyMapper.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Maui.Handlers;
+
+#if WINDOWS
+class WindowsBatchPropertyMapper<TVirtualView, TViewHandler> : PropertyMapper<TVirtualView, TViewHandler>
+	where TVirtualView : IElement
+	where TViewHandler : IElementHandler
+{
+	// During mass property updates, this list of properties will be skipped
+	public static HashSet<string> SkipList = new(StringComparer.Ordinal)
+	{ 
+		// TranslationX does the work that is necessary to make other properties work.
+		nameof(IView.TranslationY),
+		nameof(IView.Scale),
+		nameof(IView.ScaleX),
+		nameof(IView.ScaleY),
+		nameof(IView.Rotation),
+		nameof(IView.RotationX),
+		nameof(IView.RotationY),
+		nameof(IView.AnchorX),
+		nameof(IView.AnchorY),
+	};
+
+	public WindowsBatchPropertyMapper(params IPropertyMapper[] chained) : base(chained) { }
+
+	public override IEnumerable<string> GetKeys()
+	{
+		foreach (var key in _mapper.Keys)
+		{
+			// When reporting the key list for mass updates up the chain, ignore properties in SkipList.
+			// These will be handled by ViewHandler.SetVirtualView() instead.
+			if (SkipList.Contains(key))
+			{
+				continue;
+			}
+
+			yield return key;
+		}
+
+		if (Chained is not null)
+		{
+			foreach (var chain in Chained)
+				foreach (var key in chain.GetKeys())
+					yield return key;
+		}
+	}
+}
+#endif


### PR DESCRIPTION
### Description of Change

This PR is based on the idea that for each view, [many `MapTranslation*`  methods](https://github.com/dotnet/maui/blob/c1566589d1794e5adcbcf2e93bd77fc85f859253/src/Core/src/Handlers/View/ViewHandler.Windows.cs#L38-L86) are called but the they are called for no good reason because the operation is always the same. So in effect, there are many unnecessary interop calls which are costly. 

The implementation is based on https://github.com/dotnet/maui/blob/c1566589d1794e5adcbcf2e93bd77fc85f859253/src/Core/src/Handlers/View/AndroidBatchPropertyMapper.cs (basically a copy).

### Performance impact

* MAIN [1724527142..speedscope.MAIN.json](https://github.com/user-attachments/files/16737798/1724527142.speedscope.MAIN.json)
* PR [1724526920..speedscope.PR.json](https://github.com/user-attachments/files/16737797/1724526920.speedscope.PR.json)

![image](https://github.com/user-attachments/assets/d3ccb523-de7e-4f46-aca1-8b872faa930b)

### Issues Fixed

Contributes to #21787
Replaces #21818