### PR TITLE
Revert "Add some defensive code around layout propagation (#24217)"

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,10 +1,10 @@
 <Project>
   <PropertyGroup>
     <!-- The .NET product branding version -->
-    <ProductVersion>8.0.81</ProductVersion>
+    <ProductVersion>8.0.82</ProductVersion>
     <MajorVersion>8</MajorVersion>
     <MinorVersion>0</MinorVersion>
-    <PatchVersion>81</PatchVersion>
+    <PatchVersion>82</PatchVersion>
     <SdkBandVersion>8.0.100</SdkBandVersion>
     <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>
     <!-- Servicing builds have different characteristics for the way dependencies, baselines, and versions are handled. -->

--- a/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
@@ -328,10 +328,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			var actuallyRemoved = poppedViewController == null ? true : !await task;
 			_ignorePopCall = false;
 
-			if (poppedViewController is ParentingViewController pvc)
-				pvc.Disconnect(false);
-			else
-				poppedViewController?.Dispose();
+			poppedViewController?.Dispose();
 
 			UpdateToolBarVisible();
 			return actuallyRemoved;
@@ -1145,9 +1142,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 						return;
 
 					if (child is not null)
-					{
 						child.PropertyChanged -= HandleChildPropertyChanged;
-					}
 
 					if (value is not null)
 					{
@@ -1277,57 +1272,6 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				}
 			}
 
-			internal void Disconnect(bool dispose)
-			{
-				if (Child is Page child)
-				{
-					child.SendDisappearing();
-					child.PropertyChanged -= HandleChildPropertyChanged;
-					Child = null;
-				}
-
-				if (_tracker is not null)
-				{
-					_tracker.Target = null;
-					_tracker.CollectionChanged -= TrackerOnCollectionChanged;
-					_tracker = null;
-				}
-
-				if (NavigationItem.TitleView is not null)
-				{
-					if (dispose)
-						NavigationItem.TitleView.Dispose();
-						
-					NavigationItem.TitleView = null;
-				}
-
-				if (NavigationItem.RightBarButtonItems is not null && dispose)
-				{
-					for (var i = 0; i < NavigationItem.RightBarButtonItems.Length; i++)
-						NavigationItem.RightBarButtonItems[i].Dispose();
-				}
-
-				if (ToolbarItems is not null && dispose)
-				{
-					for (var i = 0; i < ToolbarItems.Length; i++)
-						ToolbarItems[i].Dispose();
-				}
-
-				for (int i = View.Subviews.Length - 1; i >= 0; i--)
-				{
-					View.Subviews[i].RemoveFromSuperview();
-				}
-
-
-				for (int i = ChildViewControllers.Length - 1; i >= 0; i--)
-				{
-					var childViewController = ChildViewControllers[i];
-					childViewController.View.RemoveFromSuperview();
-					childViewController.RemoveFromParentViewController();
-				}
-
-			}
-
 			protected override void Dispose(bool disposing)
 			{
 				if (_disposed)
@@ -1339,7 +1283,34 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 				if (disposing)
 				{
-					Disconnect(true);
+					if (Child is Page child)
+					{
+						child.SendDisappearing();
+						child.PropertyChanged -= HandleChildPropertyChanged;
+						Child = null;
+					}
+
+					_tracker.Target = null;
+					_tracker.CollectionChanged -= TrackerOnCollectionChanged;
+					_tracker = null;
+
+					if (NavigationItem.TitleView != null)
+					{
+						NavigationItem.TitleView.Dispose();
+						NavigationItem.TitleView = null;
+					}
+
+					if (NavigationItem.RightBarButtonItems != null)
+					{
+						for (var i = 0; i < NavigationItem.RightBarButtonItems.Length; i++)
+							NavigationItem.RightBarButtonItems[i].Dispose();
+					}
+
+					if (ToolbarItems != null)
+					{
+						for (var i = 0; i < ToolbarItems.Length; i++)
+							ToolbarItems[i].Dispose();
+					}
 				}
 
 				base.Dispose(disposing);
@@ -2000,7 +1971,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 					if (_child != null)
 					{
-						(_child.ContainerView ?? _child.PlatformView).RemoveFromSuperview();
+						_child.PlatformView.RemoveFromSuperview();
 						_child.DisconnectHandler();
 						_child = null;
 					}

--- a/src/Controls/src/Core/Compatibility/Handlers/iOS/FrameRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/iOS/FrameRenderer.cs
@@ -207,7 +207,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		public override void SetNeedsLayout()
 		{
 			base.SetNeedsLayout();
-			this.GetSuperViewIfWindowSet()?.SetNeedsLayout();
+			Superview?.SetNeedsLayout();
 		}
 
 		[Microsoft.Maui.Controls.Internals.Preserve(Conditional = true)]

--- a/src/Controls/src/Core/NavigationPage/NavigationPage.cs
+++ b/src/Controls/src/Core/NavigationPage/NavigationPage.cs
@@ -402,8 +402,6 @@ namespace Microsoft.Maui.Controls
 		void RemoveFromInnerChildren(Element page)
 		{
 			InternalChildren.Remove(page);
-
-			// TODO For NET9 we should remove this because the DisconnectHandlers will take care of it
 			page.Handler = null;
 		}
 

--- a/src/Controls/src/Core/Platform/iOS/Extensions/ButtonExtensions.cs
+++ b/src/Controls/src/Core/Platform/iOS/Extensions/ButtonExtensions.cs
@@ -188,7 +188,7 @@ namespace Microsoft.Maui.Controls.Platform
 			{
 				platformButton.ImageEdgeInsets = imageInsets;
 				platformButton.TitleEdgeInsets = titleInsets;
-				platformButton.GetSuperViewIfWindowSet()?.SetNeedsLayout();
+				platformButton.Superview?.SetNeedsLayout();
 			}
 #pragma warning restore CA1416, CA1422
 		}

--- a/src/Core/src/Handlers/View/ViewHandlerOfT.iOS.cs
+++ b/src/Core/src/Handlers/View/ViewHandlerOfT.iOS.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Maui.Handlers
 				if (containerView is WrapperView wrapperView)
 				{
 					wrapperView.RemoveFromSuperview();
-					wrapperView.Disconnect();
+					wrapperView.Dispose();
 				}
 			}
 		}

--- a/src/Core/src/Platform/iOS/LayoutView.cs
+++ b/src/Core/src/Platform/iOS/LayoutView.cs
@@ -11,14 +11,14 @@ namespace Microsoft.Maui.Platform
 		{
 			InvalidateConstraintsCache();
 			base.SubviewAdded(uiview);
-			this.GetSuperViewIfWindowSet()?.SetNeedsLayout();
+			Superview?.SetNeedsLayout();
 		}
 
 		public override void WillRemoveSubview(UIView uiview)
 		{
 			InvalidateConstraintsCache();
 			base.WillRemoveSubview(uiview);
-			this.GetSuperViewIfWindowSet()?.SetNeedsLayout();
+			Superview?.SetNeedsLayout();
 		}
 
 		public override UIView? HitTest(CGPoint point, UIEvent? uievent)

--- a/src/Core/src/Platform/iOS/MauiView.cs
+++ b/src/Core/src/Platform/iOS/MauiView.cs
@@ -140,7 +140,7 @@ namespace Microsoft.Maui.Platform
 		{
 			InvalidateConstraintsCache();
 			base.SetNeedsLayout();
-			this.GetSuperViewIfWindowSet()?.SetNeedsLayout();
+			Superview?.SetNeedsLayout();
 		}
 
 		IVisualTreeElement? IVisualTreeElementProvidable.GetElement()

--- a/src/Core/src/Platform/iOS/ViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/ViewExtensions.cs
@@ -264,18 +264,10 @@ namespace Microsoft.Maui.Platform
 			}
 		}
 
-		internal static UIView? GetSuperViewIfWindowSet(this UIView? view)
-		{
-			if (view?.Window is null)
-				return null;
-
-			return view.Superview;
-		}
-
 		public static void InvalidateMeasure(this UIView platformView, IView view)
 		{
 			platformView.SetNeedsLayout();
-			platformView.GetSuperViewIfWindowSet()?.SetNeedsLayout();
+			platformView.Superview?.SetNeedsLayout();
 		}
 
 		public static void UpdateWidth(this UIView platformView, IView view)

--- a/src/Core/src/Platform/iOS/WrapperView.cs
+++ b/src/Core/src/Platform/iOS/WrapperView.cs
@@ -105,19 +105,12 @@ namespace Microsoft.Maui.Platform
 			SetBorder();
 		}
 
-		internal void Disconnect()
-		{
-			MaskLayer = null;
-			BackgroundMaskLayer = null;
-			ShadowLayer = null;
-			_borderView?.RemoveFromSuperview();
-		}
-
-
-		// TODO obsolete or delete this for NET9
 		public new void Dispose()
 		{
-			Disconnect();
+			DisposeClip();
+			DisposeShadow();
+			DisposeBorder();
+
 			base.Dispose();
 		}
 
@@ -165,7 +158,7 @@ namespace Microsoft.Maui.Platform
 		{
 			base.SetNeedsLayout();
 
-			this.GetSuperViewIfWindowSet()?.SetNeedsLayout();
+			Superview?.SetNeedsLayout();
 		}
 
 		partial void ClipChanged()
@@ -207,6 +200,12 @@ namespace Microsoft.Maui.Platform
 			backgroundMask.Path = nativePath;
 		}
 
+		void DisposeClip()
+		{
+			MaskLayer = null;
+			BackgroundMaskLayer = null;
+		}
+
 		void SetShadow()
 		{
 			var shadowLayer = ShadowLayer;
@@ -231,6 +230,11 @@ namespace Microsoft.Maui.Platform
 				shadowLayer.SetShadow(Shadow);
 		}
 
+		void DisposeShadow()
+		{
+			ShadowLayer = null;
+		}
+
 		void SetBorder()
 		{
 			if (Border == null)
@@ -245,6 +249,11 @@ namespace Microsoft.Maui.Platform
 			}
 
 			_borderView.UpdateMauiCALayer(Border);
+		}
+
+		void DisposeBorder()
+		{
+			_borderView?.RemoveFromSuperview();
 		}
 
 		CALayer? GetLayer()


### PR DESCRIPTION
### Description of Change

This reverts commit d85c05fca3ee456c9e36c04275fce057719dad78.

Fortunately/unfortunately internal testing found an issue with these changes
https://github.com/dotnet/maui/issues/24434

Unfortunately the changes here break the layout when returning from the modal page

![image](https://github.com/user-attachments/assets/31e27694-4aab-420a-81a9-f0540cb40d43)

Before the underlying page has been attached to the window, the BindableLayout that is associated with the list of instructions gets recreated. I was thinking that iOS would perform a new layout of subviews once the view is reattached to the window and the visual tree has changed, but that assumption was unfortunately wrong. 

We'll need to address this particular path for SR9 which is scheduled for release first couple weeks of September.
