### PR TITLE
[net9.0] Android RC 1 build, with feeds

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -26,6 +26,8 @@
     <!-- Added manually for dotnet/runtime 8.0.8 -->
     <add key="darc-pub-dotnet-emsdk-e92f92e" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-emsdk-e92f92ef/nuget/v3/index.json" />
     <add key="darc-pub-dotnet-runtime-2d5c0b7" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-2d5c0b72/nuget/v3/index.json" />
+    <!-- Added manually for .NET 8 Android -->
+    <add key="darc-pub-dotnet-android-b0fd011" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-android-b0fd0113/nuget/v3/index.json" />
   </packageSources>
   <activePackageSource>
     <add key="All" value="(Aggregate source)" />

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -8,9 +8,9 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>c4a79875fcb2c76b2e92ff50940d4ea9264e2eeb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Android.Sdk.Windows" Version="35.0.0-rc.1.69">
+    <Dependency Name="Microsoft.Android.Sdk.Windows" Version="35.0.0-rc.1.78">
       <Uri>https://github.com/dotnet/android</Uri>
-      <Sha>e70ae00cbef38de282f16701045eec6578c5062f</Sha>
+      <Sha>033928361fdfe7a1e1674564ef6eba1120d712e9</Sha>
     </Dependency>
     <Dependency Name="Microsoft.MacCatalyst.Sdk.net9.0_17.5" Version="17.5.9260-net9-rc1">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -50,7 +50,7 @@
     <MicrosoftExtensionsLoggingDebugVersion>9.0.0-rc.1.24421.1</MicrosoftExtensionsLoggingDebugVersion>
     <MicrosoftExtensionsPrimitivesVersion>9.0.0-rc.1.24421.1</MicrosoftExtensionsPrimitivesVersion>
     <!-- xamarin/xamarin-android -->
-    <MicrosoftAndroidSdkWindowsPackageVersion>35.0.0-rc.1.69</MicrosoftAndroidSdkWindowsPackageVersion>
+    <MicrosoftAndroidSdkWindowsPackageVersion>35.0.0-rc.1.78</MicrosoftAndroidSdkWindowsPackageVersion>
     <!-- xamarin/xamarin-macios -->
     <MicrosoftMacCatalystSdknet90_175PackageVersion>17.5.9260-net9-rc1</MicrosoftMacCatalystSdknet90_175PackageVersion>
     <MicrosoftmacOSSdknet90_145PackageVersion>14.5.9260-net9-rc1</MicrosoftmacOSSdknet90_145PackageVersion>


### PR DESCRIPTION
Changes: https://github.com/dotnet/android/compare/e70ae00c...03392836
Context: https://github.com/dotnet/android/commit/bc56b3a8

.NET Android is now using Maestro to push stable-branded builds, and so a new feed is required for now.

At some point, we can setup a `Microsoft.Android.NET9` and `Microsoft.Android.NET8` pack that would make it possible to track *both* .NET 8 & 9 and Maestro could manage the feeds.