### PR TITLE
[Android] Fix item fading when moving between groups in Grouped CollectionView

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/Android/ItemsSources/ObservableItemsSource.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/ItemsSources/ObservableItemsSource.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 			if (disposing)
 			{
-				((INotifyCollectionChanged)_itemsSource).CollectionChanged -= CollectionChanged;
+				_proxy.Unsubscribe();
 			}
 		}
 


### PR DESCRIPTION
### Root Cause
In the ObservableItemsSource class, the CollectionChanged event was directly removed in the Dispose method instead of using the WeakNotifyCollectionChangedProxy.Unsubscribe(). This caused incorrect event handling, leading to a visual glitch where both the selected and the next item temporarily faded in a grouped CollectionView on Android.
 
### Description of Change
The fix involved correctly unsubscribing from the CollectionChanged event using WeakNotifyCollectionChangedProxy.Unsubscribe() in the Dispose method. This change ensures proper event handling, preventing unintended visual effects during item movements in a grouped CollectionView.

### Reference

https://github.com/dotnet/maui/blob/main/src/Controls/src/Core/Handlers/Items/CarouselViewHandler.Windows.cs#L56

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/23152
Fixes https://github.com/dotnet/maui/issues/21698 
Fixes https://github.com/dotnet/maui/issues/23138

### Output

#### Before

![GroupedCollectionViewBeforeFix](https://github.com/user-attachments/assets/1f3c300f-df15-4681-ae03-f9864703a8c2)

#### After:

![GroupedCollectionViewAfterFix](https://github.com/user-attachments/assets/a14ed46d-dc0e-46df-b667-d5603f510f10)
