### PR TITLE
Fix App Theme Binding For Non Elements

### DIFF
--- a/src/Controls/src/Core/Interactivity/PlatformBehavior.cs
+++ b/src/Controls/src/Core/Interactivity/PlatformBehavior.cs
@@ -102,7 +102,7 @@ public abstract partial class PlatformBehavior<TView, TPlatformView> : Behavior<
 
 	void OnLoaded(object? sender, EventArgs e)
 	{
-		if (sender is TView view && view.Handler.PlatformView is TPlatformView platformView)
+		if (sender is TView { Handler.PlatformView: TPlatformView platformView } view)
 		{
 			OnAttachedTo(view, platformView);
 			_platformView = platformView;


### PR DESCRIPTION
We encountered [this](https://github.com/CommunityToolkit/Maui/issues/1994) bug in the community toolkit touch behavior. When an `AppThemeBinding` was set on the behavior, the correct color for the app theme would load, but when the theme was changed at runtime the colors would not update. Only destroying the element completly (ie navigating away from & destroying the page) would allow you to see the correct colors, the next time you visited the page.

I was able to reproduce this issue with a basic `PlatformBehavior` outside of the community toolkit and through debugging the `AppThemeBinding` found a point where it cast the [`BindableObject as Element`](https://github.com/dotnet/maui/blob/aa1632a285e8955ec69d4df7fb4c07ec8dae74dd/src/Controls/src/Core/AppThemeBinding.cs#L74), which in the case of `PlatformBehavior`s is not valid.


### Description of Change

Add a fallback to `AppThemeProxy` to account for when `BindableObject` is not an `Element`.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #24444

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->

### Reproduction

I have a seperate branch with the code I used to debug and test this issue. Go to my branch [fix/24444/sample](https://github.com/Axemasta/maui/tree/fix/24444/sample) and run Maui.Controls.Sample, it will take you to a page with this issue setup (now fixed)