### PR TITLE
Fix Android flyout button (burger) visibility not reevaluated when orientation changes

### DIFF
--- a/src/Controls/src/Core/NavigationPage/NavigationPageToolbar.cs
+++ b/src/Controls/src/Core/NavigationPage/NavigationPageToolbar.cs
@@ -42,8 +42,20 @@ namespace Microsoft.Maui.Controls
 			ToolbarItems = _toolbarTracker.ToolbarItems;
 		}
 
+#if ANDROID
+		Devices.DisplayOrientation lastOrientation = Devices.DisplayOrientation.Unknown;
+#endif
+
 		void OnPagePropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
 		{
+#if ANDROID
+			if ((e.PropertyName == "Height") && (Parent is FlyoutPage) && (lastOrientation != Devices.DeviceDisplay.MainDisplayInfo.Orientation))
+			{
+				if (lastOrientation != Devices.DisplayOrientation.Unknown)
+					UpdateBackButton();
+				lastOrientation = Devices.DeviceDisplay.MainDisplayInfo.Orientation;
+			}
+#endif
 			if (e.IsOneOf(NavigationPage.HasNavigationBarProperty,
 				NavigationPage.HasBackButtonProperty,
 				NavigationPage.TitleIconImageSourceProperty,


### PR DESCRIPTION
The condition to show the flyout button (burger) or not is set in method ShouldShowToolbarButton of the FlyoutPage. In Android, this method is not hit when orientation changes. This method is only called once during initialization.

This modification triggers the update of this button when orientation changes.

https://github.com/dotnet/maui/issues/24468
