### PR TITLE
Remove code from iOS that short circuits propagation

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/iOS/FrameRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/iOS/FrameRenderer.cs
@@ -207,7 +207,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		public override void SetNeedsLayout()
 		{
 			base.SetNeedsLayout();
-			this.GetSuperViewIfWindowSet()?.SetNeedsLayout();
+			this.Superview?.SetNeedsLayout();
 		}
 
 		[Microsoft.Maui.Controls.Internals.Preserve(Conditional = true)]

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue24434.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue24434.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.Maui.Controls.Internals;
+
+namespace Maui.Controls.Sample.Issues
+{
+	[Issue(IssueTracker.Github, 24434, "Modifying a layout while view isn't part of the Window fails to update the layout visually",
+		PlatformAffected.iOS)]
+	public class Issue24434 : ContentPage
+	{
+		public Issue24434()
+		{
+			VerticalStackLayout vsl = new VerticalStackLayout();
+
+			vsl.Add(new Button()
+			{
+				Text = "Click me and you should see a label appear beneath me",
+				LineBreakMode = LineBreakMode.WordWrap,
+				AutomationId = "ClickMe",
+				Command = new Command(async () =>
+				{
+					TaskCompletionSource taskCompletionSource = new TaskCompletionSource();
+					vsl.Unloaded += (_,_) =>
+					{
+						vsl.Add(new Label { Text = "Hello, World!", AutomationId = "Success" });
+						taskCompletionSource.TrySetResult();
+					};
+
+					await Navigation.PushAsync(new ContentPage(){ Content = new Label() { Text = "I should just disappear"}});
+					await Navigation.PushModalAsync(new ContentPage(){ Content = new Label() { Text = "I should just disappear"}});
+					
+					await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5));
+					await Navigation.PopAsync();
+					await Navigation.PopModalAsync();
+				})
+			});
+
+			Content = vsl;
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue24434.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue24434.cs
@@ -4,36 +4,44 @@ namespace Maui.Controls.Sample.Issues
 {
 	[Issue(IssueTracker.Github, 24434, "Modifying a layout while view isn't part of the Window fails to update the layout visually",
 		PlatformAffected.iOS)]
-	public class Issue24434 : ContentPage
+	public class Issue24434 : NavigationPage
 	{
-		public Issue24434()
+		public Issue24434() : base(new TestPage())
 		{
-			VerticalStackLayout vsl = new VerticalStackLayout();
 
-			vsl.Add(new Button()
+		}
+
+		public class TestPage : ContentPage
+		{
+			public TestPage()
 			{
-				Text = "Click me and you should see a label appear beneath me",
-				LineBreakMode = LineBreakMode.WordWrap,
-				AutomationId = "ClickMe",
-				Command = new Command(async () =>
+				VerticalStackLayout vsl = new VerticalStackLayout();
+
+				vsl.Add(new Button()
 				{
-					TaskCompletionSource taskCompletionSource = new TaskCompletionSource();
-					vsl.Unloaded += (_,_) =>
+					Text = "Click me and you should see a label appear beneath me",
+					LineBreakMode = LineBreakMode.WordWrap,
+					AutomationId = "ClickMe",
+					Command = new Command(async () =>
 					{
-						vsl.Add(new Label { Text = "Hello, World!", AutomationId = "Success" });
-						taskCompletionSource.TrySetResult();
-					};
+						TaskCompletionSource taskCompletionSource = new TaskCompletionSource();
+						vsl.Unloaded += (_, _) =>
+						{
+							vsl.Add(new Label { Text = "Hello, World!", AutomationId = "Success" });
+							taskCompletionSource.TrySetResult();
+						};
 
-					await Navigation.PushAsync(new ContentPage(){ Content = new Label() { Text = "I should just disappear"}});
-					await Navigation.PushModalAsync(new ContentPage(){ Content = new Label() { Text = "I should just disappear"}});
-					
-					await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5));
-					await Navigation.PopAsync();
-					await Navigation.PopModalAsync();
-				})
-			});
+						await Navigation.PushAsync(new ContentPage() { Content = new Label() { Text = "I should just disappear" } });
+						await Navigation.PushModalAsync(new ContentPage() { Content = new Label() { Text = "I should just disappear" } });
 
-			Content = vsl;
+						await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5));
+						await Navigation.PopModalAsync();
+						await Navigation.PopAsync();
+					})
+				});
+
+				Content = vsl;
+			}
 		}
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue24434.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue24434.cs
@@ -1,0 +1,24 @@
+﻿using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue24434 : _IssuesUITest
+	{
+		public Issue24434(TestDevice testDevice) : base(testDevice)
+		{
+		}
+
+		public override string Issue => "Modifying a layout while view isn't part of the Window fails to update the layout visually";
+
+		[Test]
+		[Category(UITestCategories.Layout)]
+		public void TapThenDoubleTap()
+		{
+			App.WaitForElement("ClickMe");
+			App.Tap("ClickMe");
+			App.WaitForElement("Success");
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue24434.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue24434.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 
 		[Test]
 		[Category(UITestCategories.Layout)]
-		public void TapThenDoubleTap()
+		public void ModifyingANonVisibleLayoutWorks()
 		{
 			App.WaitForElement("ClickMe");
 			App.Tap("ClickMe");

--- a/src/Core/src/Platform/iOS/LayoutView.cs
+++ b/src/Core/src/Platform/iOS/LayoutView.cs
@@ -11,14 +11,14 @@ namespace Microsoft.Maui.Platform
 		{
 			InvalidateConstraintsCache();
 			base.SubviewAdded(uiview);
-			this.GetSuperViewIfWindowSet()?.SetNeedsLayout();
+			this.Superview?.SetNeedsLayout();
 		}
 
 		public override void WillRemoveSubview(UIView uiview)
 		{
 			InvalidateConstraintsCache();
 			base.WillRemoveSubview(uiview);
-			this.GetSuperViewIfWindowSet()?.SetNeedsLayout();
+			this.Superview?.SetNeedsLayout();
 		}
 
 		public override UIView? HitTest(CGPoint point, UIEvent? uievent)

--- a/src/Core/src/Platform/iOS/MauiView.cs
+++ b/src/Core/src/Platform/iOS/MauiView.cs
@@ -140,7 +140,7 @@ namespace Microsoft.Maui.Platform
 		{
 			InvalidateConstraintsCache();
 			base.SetNeedsLayout();
-			this.GetSuperViewIfWindowSet()?.SetNeedsLayout();
+			this.Superview?.SetNeedsLayout();
 		}
 
 		IVisualTreeElement? IVisualTreeElementProvidable.GetElement()

--- a/src/Core/src/Platform/iOS/ViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/ViewExtensions.cs
@@ -264,18 +264,10 @@ namespace Microsoft.Maui.Platform
 			}
 		}
 
-		internal static UIView? GetSuperViewIfWindowSet(this UIView? view)
-		{
-			if (view?.Window is null)
-				return null;
-
-			return view.Superview;
-		}
-
 		public static void InvalidateMeasure(this UIView platformView, IView view)
 		{
 			platformView.SetNeedsLayout();
-			platformView.GetSuperViewIfWindowSet()?.SetNeedsLayout();
+			platformView.Superview?.SetNeedsLayout();
 		}
 
 		public static void UpdateWidth(this UIView platformView, IView view)

--- a/src/Core/src/Platform/iOS/WrapperView.cs
+++ b/src/Core/src/Platform/iOS/WrapperView.cs
@@ -240,7 +240,7 @@ namespace Microsoft.Maui.Platform
 		{
 			base.SetNeedsLayout();
 
-			this.GetSuperViewIfWindowSet()?.SetNeedsLayout();
+			this.Superview?.SetNeedsLayout();
 		}
 
 		partial void ClipChanged()


### PR DESCRIPTION
### Description of Change

https://github.com/dotnet/maui/pull/24217 added some code that guessed at a few paths that might be taken to cause https://github.com/dotnet/maui/issues/24032 since we've been unable to reproduce this locally.

I'm hoping that the fixes on 24217 related to not disposing the view on the `UINavigationController` covers everyones cases and we can just leave this propagation code in place for now. 

If users still report the crash then we'll need to figure out how to more surgically propagate invalidations on iOS. 


### Issues Fixed

Fixes #24434 
