### PR TITLE
[xamlc] return early in `NodeILExtensions` for `ValidateOnly`

### DIFF
--- a/src/Controls/src/Build.Tasks/ILContext.cs
+++ b/src/Controls/src/Build.Tasks/ILContext.cs
@@ -44,5 +44,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 		public string XamlFilePath { get; internal set; }
 
 		public TaskLoggingHelper LoggingHelper { get; internal set; }
+
+		public bool ValidateOnly { get; set; }
 	}
 }

--- a/src/Controls/src/Build.Tasks/NodeILExtensions.cs
+++ b/src/Controls/src/Build.Tasks/NodeILExtensions.cs
@@ -422,6 +422,10 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 
 		public static IEnumerable<Instruction> PushXmlLineInfo(this INode node, ILContext context)
 		{
+			if (context.ValidateOnly)
+			{
+				yield break;
+			}
 			var module = context.Body.Method.Module;
 
 			var xmlLineInfo = node as IXmlLineInfo;
@@ -447,6 +451,10 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 
 		public static IEnumerable<Instruction> PushParentObjectsArray(this INode node, ILContext context)
 		{
+			if (context.ValidateOnly)
+			{
+				yield break;
+			}
 			var module = context.Body.Method.Module;
 
 			var nodes = new List<IElementNode>();
@@ -585,6 +593,10 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 
 		public static IEnumerable<Instruction> PushServiceProvider(this INode node, ILContext context, FieldReference bpRef = null, PropertyReference propertyRef = null, TypeReference declaringTypeReference = null)
 		{
+			if (context.ValidateOnly)
+			{
+				yield break;
+			}
 			var module = context.Body.Method.Module;
 
 #if NOSERVICEPROVIDER

--- a/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
+++ b/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
@@ -1666,6 +1666,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 				Root = root,
 				XamlFilePath = parentContext.XamlFilePath,
 				LoggingHelper = parentContext.LoggingHelper,
+				ValidateOnly = parentContext.ValidateOnly,
 			};
 
 			//Instanciate nested class

--- a/src/Controls/src/Build.Tasks/XamlCTask.cs
+++ b/src/Controls/src/Build.Tasks/XamlCTask.cs
@@ -354,6 +354,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 				{
 					XamlFilePath = xamlFilePath,
 					LoggingHelper = loggingHelper,
+					ValidateOnly = ValidateOnly,
 				};
 
 


### PR DESCRIPTION
Context: https://github.com/dotnet/maui/commit/7efca8efb3b1d9f6e31aef0b7999842b4c7b119f
Context: https://github.com/xamarin/Xamarin.Forms/pull/7407

For Debug builds, .NET MAUI runs XamlC in a "ValidateOnly" mode, which avoids writing `.dll` files at the end. This way, we get faster builds, but still emit the same errors and warnings that would be emitted in `Release` mode.

Right now, the `ValidateOnly` flag is only checked at the end of the process to skip writing files. I looked for some places taking time, such as:

    36.30ms (1.1%) microsoft.maui.controls.build.tasks!Microsoft.Maui.Controls.Build.Tasks.NodeILExtensions+<PushServiceProvider>d__12.MoveNext()
    20.20ms (0.6%) microsoft.maui.controls.build.tasks!Microsoft.Maui.Controls.Build.Tasks.NodeILExtensions+<PushParentObjectsArray>d__9.MoveNext()
     1.21ms (0.0%) microsoft.maui.controls.build.tasks!Microsoft.Maui.Controls.Build.Tasks.NodeILExtensions.PushXmlLineInfo(class Microsoft.Maui.Controls.Xaml.INode,class Microsoft.Maui.Controls.Build.Tasks.ILContext)

And added checks to just return early in these methods.

With this change in-place, an incremental build of a `dotnet new maui` project template:

    Before:
    1704 ms  XamlCTask                                  4 calls
    After:
    1402 ms  XamlCTask                                  4 calls

This probably saves a little less than 100ms per call, but in this example it is running once per platform. This improvement probably will help even more for larger projects with many XAML files.