### PR TITLE
Improve Android device type check and improve UI Test cake scripts

### DIFF
--- a/eng/devices/android.cake
+++ b/eng/devices/android.cake
@@ -91,7 +91,14 @@ Task("uitest-build")
 		ExecuteBuildUITestApp(testAppProjectPath, testDevice, binlogDirectory, configuration, targetFramework, "", dotnetToolPath);
 	});
 
+Task("uitest-prepare")
+	.Does(() =>
+	{
+		ExecutePrepareUITests(projectPath, testAppProjectPath, testAppPackageName, testDevice, testResultsPath, binlogDirectory, configuration, targetFramework, "", androidVersion, dotnetToolPath, testAppInstrumentation);
+	});
+
 Task("uitest")
+	.IsDependentOn("uitest-prepare")
 	.Does(() =>
 	{
 		ExecuteUITests(projectPath, testAppProjectPath, testAppPackageName, testDevice, testResultsPath, binlogDirectory, configuration, targetFramework, "", androidVersion, dotnetToolPath, testAppInstrumentation);
@@ -265,10 +272,11 @@ void ExecuteBuildUITestApp(string appProject, string device, string binDir, stri
 	Information("UI Test app build completed.");
 }
 
-void ExecuteUITests(string project, string app, string appPackageName, string device, string resultsDir, string binDir, string config, string tfm, string rid, string ver, string toolPath, string instrumentation)
+void ExecutePrepareUITests(string project, string app, string appPackageName, string device, string resultsDir, string binDir, string config, string tfm, string rid, string ver, string toolPath, string instrumentation)
 {
 	string platform = "android";
-	Information("Starting UI Tests...");
+	Information("Preparing UI Tests...");
+
 	var testApp = GetTestApplications(app, device, config, tfm, "").FirstOrDefault();
 
 	if (string.IsNullOrEmpty(testApp))
@@ -295,7 +303,11 @@ void ExecuteUITests(string project, string app, string appPackageName, string de
 	Information($"Results Directory: {resultsDir}");
 
 	InstallApk(testApp, appPackageName, resultsDir, deviceSkin);
+}
 
+void ExecuteUITests(string project, string app, string appPackageName, string device, string resultsDir, string binDir, string config, string tfm, string rid, string ver, string toolPath, string instrumentation)
+{
+	string platform = "android";
 	Information("Build UITests project {0}", project);
 
 	var name = System.IO.Path.GetFileNameWithoutExtension(project);

--- a/eng/devices/android.cake
+++ b/eng/devices/android.cake
@@ -6,6 +6,11 @@ const int DefaultApiLevel = 30;
 
 Information("Local Dotnet: {0}", localDotnet);
 
+if (EnvironmentVariable("JAVA_HOME") == null)
+{
+	throw new Exception("JAVA_HOME environment variable isn't set. Set it to your JDK installation (e.g. \"C:\\Program Files (x86)\\Android\\openjdk\\jdk-17.0.8.101-hotspot\\bin\").");
+}
+
 string DEFAULT_ANDROID_PROJECT = "../../src/Controls/tests/TestCases.Android.Tests/Controls.TestCases.Android.Tests.csproj";
 var projectPath = Argument("project", EnvironmentVariable("ANDROID_TEST_PROJECT") ?? DEFAULT_ANDROID_PROJECT);
 var testDevice = Argument("device", EnvironmentVariable("ANDROID_TEST_DEVICE") ?? $"android-emulator-64_{DefaultApiLevel}");
@@ -65,7 +70,12 @@ Setup(context =>
 
 Teardown(context =>
 {
-	CleanUpVirtualDevice(emulatorProcess, avdSettings);
+	// For the uitest-prepare target, just leave the virtual device running
+	if (! string.Equals(TARGET, "uitest-prepare", StringComparison.OrdinalIgnoreCase))
+	{
+		CleanUpVirtualDevice(emulatorProcess, avdSettings);
+	}
+
 });
 
 Task("boot");
@@ -454,7 +464,7 @@ void HandleVirtualDevice(AndroidEmulatorToolSettings emuSettings, AndroidAvdMana
 		catch { }
 
 		// create the new AVD
-		Information("Creating AVD: {0}...", avdName);
+		Information("Creating AVD: {0} ({1})...", avdName, avdImage);
 		AndroidAvdCreate(avdName, avdImage, avdSkin, force: true, settings: avdSettings);
 
 		// start the emulator

--- a/eng/devices/devices-shared.cake
+++ b/eng/devices/devices-shared.cake
@@ -21,13 +21,9 @@ string TARGET = Argument("target", "Test");
 string DEFAULT_PROJECT = "";
 string DEFAULT_APP_PROJECT = "";
 
-if (string.Equals(TARGET, "uitest", StringComparison.OrdinalIgnoreCase))
-{
-    DEFAULT_PROJECT = "../../src/Controls/tests/TestCases.Shared.Tests/Controls.TestCases.Shared.Tests.csproj";
-    DEFAULT_APP_PROJECT = "../../src/Controls/tests/TestCases.HostApp/Controls.TestCases.HostApp.csproj";
-}
 
-if (string.Equals(TARGET, "uitest-build", StringComparison.OrdinalIgnoreCase))
+// "uitest", "uitest-build", and "uitest-prepare" all trigger this case
+if (TARGET.StartsWith("uitest", StringComparison.OrdinalIgnoreCase))
 {
     DEFAULT_PROJECT = "../../src/Controls/tests/TestCases.Shared.Tests/Controls.TestCases.Shared.Tests.csproj";
     DEFAULT_APP_PROJECT = "../../src/Controls/tests/TestCases.HostApp/Controls.TestCases.HostApp.csproj";

--- a/eng/devices/ios.cake
+++ b/eng/devices/ios.cake
@@ -65,7 +65,7 @@ Setup(context =>
 
 Teardown(context => 
 {
-	if (!deviceBoot || targetBoot)
+	if (!deviceBoot || targetBoot || string.Equals(TARGET, "uitest-prepare", StringComparison.OrdinalIgnoreCase))
 	{
 		return;
 	}
@@ -99,11 +99,17 @@ Task("uitest-build")
 		ExecuteBuildUITestApp(testAppProjectPath, testDevice, binlogDirectory, configuration, targetFramework, runtimeIdentifier, dotnetToolPath);
 	});
 
+Task("uitest-prepare")
+	.Does(() =>
+	{
+		ExecutePrepareUITests(projectPath, testAppProjectPath, testDevice, testResultsPath, binlogDirectory, configuration, targetFramework, runtimeIdentifier, iosVersion, dotnetToolPath);
+	});
+
 Task("uitest")
+	.IsDependentOn("uitest-prepare")
 	.Does(() =>
 	{
 		ExecuteUITests(projectPath, testAppProjectPath, testDevice, testResultsPath, binlogDirectory, configuration, targetFramework, runtimeIdentifier, iosVersion, dotnetToolPath);
-
 	});
 
 Task("cg-uitest")
@@ -203,15 +209,14 @@ void ExecuteTests(string project, string device, string resultsDir, string confi
 	Information("Testing completed.");
 }
 
-void ExecuteUITests(string project, string app, string device, string resultsDir, string binDir, string config, string tfm, string rid, string ver, string toolPath)
+void ExecutePrepareUITests(string project, string app, string device, string resultsDir, string binDir, string config, string tfm, string rid, string ver, string toolPath)
 {
-	Information("Starting UI Tests...");
+	Information("Preparing UI Tests...");
 	var testApp = GetTestApplications(app, device, config, tfm, rid).FirstOrDefault();
 
 	Information($"Testing Device: {device}");
 	Information($"Testing App Project: {app}");
 	Information($"Testing App: {testApp}");
-	Information($"Results Directory: {resultsDir}");
 
 	if (string.IsNullOrEmpty(testApp))
 	{
@@ -219,6 +224,11 @@ void ExecuteUITests(string project, string app, string device, string resultsDir
 	}
 
 	InstallIpa(testApp, "", device, resultsDir, ver, toolPath);
+}
+
+void ExecuteUITests(string project, string app, string device, string resultsDir, string binDir, string config, string tfm, string rid, string ver, string toolPath)
+{
+	Information($"Results Directory: {resultsDir}");
 
 	Information("Build UITests project {0}", project);
 

--- a/src/Controls/tests/TestCases.Shared.Tests/UITest.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/UITest.cs
@@ -128,10 +128,17 @@ namespace Microsoft.Maui.TestCases.Tests
 				{
 					case TestDevice.Android:
 						environmentName = "android";
+						var deviceApiLevel = (long)((AppiumApp)App).Driver.Capabilities.GetCapability("deviceApiLevel");
+						var deviceScreenSize = (string)((AppiumApp)App).Driver.Capabilities.GetCapability("deviceScreenSize");
+						var deviceScreenDensity = (long)((AppiumApp)App).Driver.Capabilities.GetCapability("deviceScreenDensity");
+
+						if (! (deviceApiLevel == 30 && deviceScreenSize == "1080x1920" && deviceScreenDensity == 420))
+						{
+							Assert.Fail($"Android visual tests should be run on an API30 emulator image with 1080x1920 420dpi screen, but the current device is API {deviceApiLevel} with a {deviceScreenSize} {deviceScreenDensity}dpi screen. Follow the steps on the MAUI UI testing wiki to launch the Android emulator with the right image.");
+						}
 						break;
 
 					case TestDevice.iOS:
-
 						var platformVersion = (string)((AppiumApp)App).Driver.Capabilities.GetCapability("platformVersion");
 						var device = (string)((AppiumApp)App).Driver.Capabilities.GetCapability("deviceName");
 
@@ -201,11 +208,6 @@ namespace Microsoft.Maui.TestCases.Tests
 				{
 					IImageEditor imageEditor = _imageEditorFactory.CreateImageEditor(actualImage);
 					(int width, int height) = imageEditor.GetSize();
-
-					if (width != 1080 || height != 2400)
-					{
-						Assert.Fail($"Android visual tests should be run on an Nexus 5X (API 30) emulator image (1080x2400 screen), but the current device has the wrong screen size ({width}x{height}). Follow the steps on the MAUI UI testing wiki to launch the android emulator with the right image, running the script there.");
-					}
 
 					imageEditor.Crop(0, cropFromTop, width, height - cropFromTop - cropFromBottom);
 

--- a/src/Controls/tests/TestCases.Shared.Tests/UITest.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/UITest.cs
@@ -127,14 +127,7 @@ namespace Microsoft.Maui.TestCases.Tests
 				switch (_testDevice)
 				{
 					case TestDevice.Android:
-						if (deviceName == "Nexus 5X")
-						{
-							environmentName = "android";
-						}
-						else
-						{
-							Assert.Fail($"Android visual tests should be run on an Nexus 5X (API 30) emulator image, but the current device is '{deviceName}'. Follow the steps on the MAUI UI testing wiki.");
-						}
+						environmentName = "android";
 						break;
 
 					case TestDevice.iOS:
@@ -152,7 +145,6 @@ namespace Microsoft.Maui.TestCases.Tests
 						}
 						else
 						{
-
 							Assert.Fail($"iOS visual tests should be run on iPhone Xs (iOS 17.2) or iPhone X (iOS 16.4) simulator images, but the current device is '{deviceName}'. Follow the steps on the MAUI UI testing wiki.");
 						}
 						break;
@@ -209,6 +201,11 @@ namespace Microsoft.Maui.TestCases.Tests
 				{
 					IImageEditor imageEditor = _imageEditorFactory.CreateImageEditor(actualImage);
 					(int width, int height) = imageEditor.GetSize();
+
+					if (width != 1080 || height != 2400)
+					{
+						Assert.Fail($"Android visual tests should be run on an Nexus 5X (API 30) emulator image (1080x2400 screen), but the current device has the wrong screen size ({width}x{height}). Follow the steps on the MAUI UI testing wiki to launch the android emulator with the right image, running the script there.");
+					}
 
 					imageEditor.Crop(0, cropFromTop, width, height - cropFromTop - cropFromBottom);
 


### PR DESCRIPTION
### Description of Change

For Android visual tests, they should be run with the right device image. However, there's no easy way to check the device type for Appium. The check that was there before works on CI since the DEVICE_SKIN environment variable is set there (set by the android.cake script). And it can work locally if folks run android.cake then launch VS from that console session to get the env variable - but it doesn't work if VS is run separately (normal case). So update this with a different check, matching on the API level / screen size / screen density capabilities. Also update the failure message to give good instructions.

Also update the android.cake and ios.cake scripts to:
- Have a new `uitest-prepare` target, which creates the image, launches the emulator/simulator, installs the apps, but doesn't run any tests nor does it stop the device when existing, just leaving things running. You can use this script to launch and then run individual tests in VS Test Explorer
- Validate that JAVA_HOME is set for android.cake


### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
