### PR TITLE
Navigation memory leak: Appearing event not being unsubscribed properly

### DIFF
--- a/src/Controls/src/Core/Element/Element.cs
+++ b/src/Controls/src/Core/Element/Element.cs
@@ -280,6 +280,7 @@ namespace Microsoft.Maui.Controls
 
 		internal bool Owned { get; set; }
 
+		Element _strongParentOverrideReference;
 		internal Element ParentOverride
 		{
 			get 
@@ -320,9 +321,17 @@ namespace Microsoft.Maui.Controls
 				}
 
 				if (value == null)
+				{
 					_parentOverride = null;
+					_strongParentOverrideReference = null;
+				}
 				else
+				{
 					_parentOverride = new WeakReference<Element>(value);
+					
+					// Maintain a strong reference to prevent unwanted garbage collections (#24507)
+					_strongParentOverrideReference = value;
+				}
 
 				if (emitChange)
 				{
@@ -333,6 +342,7 @@ namespace Microsoft.Maui.Controls
 		}
 
 		WeakReference<Element> _realParent;
+		Element _strongRealParentReference;
 		/// <summary>For internal use by .NET MAUI.</summary>
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public Element RealParent 
@@ -360,9 +370,17 @@ namespace Microsoft.Maui.Controls
 			private set
 			{
 				if (value is null)
+				{
 					_realParent = null;
+					_strongRealParentReference = null;
+				}
 				else
+				{
 					_realParent = new WeakReference<Element>(value);
+					
+					// Maintain a strong reference to prevent unwanted garbage collections (#24507)
+					_strongRealParentReference = value;
+				}
 			}
 		}
 

--- a/src/Controls/src/Core/Page/Page.cs
+++ b/src/Controls/src/Core/Page/Page.cs
@@ -606,20 +606,21 @@ namespace Microsoft.Maui.Controls
 			InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
 		}
 
+		EventHandler _onAppearingEventHandler;
 		internal void OnAppearing(Action action)
 		{
 			if (_hasAppeared)
 				action();
 			else
 			{
-				EventHandler eventHandler = null;
-				eventHandler = (_, __) =>
+				_onAppearingEventHandler = null;
+				_onAppearingEventHandler = (_, __) =>
 				{
-					this.Appearing -= eventHandler;
+					this.Appearing -= _onAppearingEventHandler;
 					action();
 				};
 
-				this.Appearing += eventHandler;
+				this.Appearing += _onAppearingEventHandler;
 			}
 		}
 
@@ -671,6 +672,11 @@ namespace Microsoft.Maui.Controls
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public void SendDisappearing()
 		{
+			// Unsubscribe the Appearing event handler here
+			// its only subscribed to when OnAppearing(Action) is called and _hasAppeared is false
+			// meaning we can get in here and _hasAppeared is still false but there's now an event attached to this.Appearing
+			this.Appearing -= _onAppearingEventHandler;
+			
 			if (!_hasAppeared)
 				return;
 

--- a/src/Controls/src/Core/Page/Page.cs
+++ b/src/Controls/src/Core/Page/Page.cs
@@ -613,10 +613,10 @@ namespace Microsoft.Maui.Controls
 				action();
 			else
 			{
-				_onAppearingEventHandler = null;
 				_onAppearingEventHandler = (_, __) =>
 				{
 					this.Appearing -= _onAppearingEventHandler;
+					_onAppearingEventHandler = null;
 					action();
 				};
 

--- a/src/Controls/src/Core/Page/Page.cs
+++ b/src/Controls/src/Core/Page/Page.cs
@@ -676,6 +676,7 @@ namespace Microsoft.Maui.Controls
 			// its only subscribed to when OnAppearing(Action) is called and _hasAppeared is false
 			// meaning we can get in here and _hasAppeared is still false but there's now an event attached to this.Appearing
 			this.Appearing -= _onAppearingEventHandler;
+			_onAppearingEventHandler = null;
 			
 			if (!_hasAppeared)
 				return;

--- a/src/Controls/tests/Core.UnitTests/PageTests.cs
+++ b/src/Controls/tests/Core.UnitTests/PageTests.cs
@@ -579,5 +579,27 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.Contains(customControl, page.LogicalChildrenInternal);
 			Assert.Contains(customControl, ((IVisualTreeElement)page).GetVisualChildren());
 		}
+
+		[Fact]
+		public void SendDisappearingUnsubscribesAppearingEvent()
+		{
+			var page = new ContentPage();
+			var navPage = new NavigationPage(page);
+			_ = new TestWindow(navPage);
+			
+			// This subscribes the event if the page has not appeared already
+			int invokeCounter = 0;
+			navPage.OnAppearing(() => { invokeCounter++; });
+			((IPageController)navPage).SendAppearing();
+			Assert.Equal(1, invokeCounter);
+			
+			// Navigate away
+			((IPageController)navPage).SendDisappearing();
+			
+			// This should not increment the counter when navigating back
+			navPage.OnAppearing(() => { invokeCounter++; });
+			((IPageController)navPage).SendAppearing();
+			Assert.Equal(1, invokeCounter);
+		}
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/ShellTestBase.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellTestBase.cs
@@ -330,9 +330,10 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 				return returnValue;
 			}
 
+			TestWindow _testWindow;
 			public TestShell()
 			{
-				_ = new TestWindow() { Page = this };
+				_testWindow = new TestWindow() { Page = this };
 				Routing.RegisterRoute(nameof(TestPage1), typeof(TestPage1));
 				Routing.RegisterRoute(nameof(TestPage2), typeof(TestPage2));
 				Routing.RegisterRoute(nameof(TestPage3), typeof(TestPage3));

--- a/src/Controls/tests/Core.UnitTests/TestClasses/TestWindow.cs
+++ b/src/Controls/tests/Core.UnitTests/TestClasses/TestWindow.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 {
 	public class TestWindow : Window
 	{
+		TestApp _testApp;
 		public TestWindow()
 		{
 
@@ -24,8 +25,8 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			if (propertyName == PageProperty.PropertyName &&
 				Parent == null)
 			{
-				var app = new TestApp(this);
-				_ = (app as IApplication).CreateWindow(null);
+				_testApp = new TestApp(this);
+				_ = (_testApp as IApplication).CreateWindow(null);
 			}
 		}
 


### PR DESCRIPTION
### Description of Change
Capture the event being subscribed to `Appearing` in `OnAppearing(Action)` into a file-scoped field, to be unsubscribed now in `SendDisappearing()`.

The `OnAppearing(Action)` call in `Page.cs` was subscribing an event to the `Appearing` EventHandler, and not unsubscribing when navigating away, leading to memory leaks. Note the `_invocationList` count in the screenshot:

![Screenshot 2024-08-28 at 10 26 23 AM](https://github.com/user-attachments/assets/c1e7b89a-4ea6-4d11-a6a6-77bb56fdf6bd)

I also have gcdump's of a File>New MAUI application with two pages that navigate to each other automatically, reproducing the issue. Source code and gcdumps here: https://github.com/mattsetaro/MauiMemoryLeak 

I was also able to reproduce the memory leak with a unit test, here is the unit test and a screenshot of the memory snapshot from dotMemory (`Object[]` from screenshot is `_invocationList` on the `Appearing` event):
![Screenshot 2024-08-28 at 10 17 20 AM](https://github.com/user-attachments/assets/bbccd05f-b4ba-4d26-9851-0dd63f901d43)

```
[Fact]
public async void MemoryLeak()
{
    Routing.RegisterRoute("page1/page2", typeof(DummyPage));
    Routing.RegisterRoute("page1/page2/page3", typeof(DumberPage));
    
    var shell = new TestShell(
    CreateShellItem(shellSectionRoute: "page1")
    );
    
    int ctr = 0;
    while (true)
    {
        await shell.GoToAsync("page1/page2/page3");
        Assert.True(shell.CurrentPage is DumberPage);
        
        await shell.GoToAsync("..");
        Assert.True(shell.CurrentPage is DummyPage);
        
        if (++ctr % 1000 == 0)
        {
	    _testOutputHelper.WriteLine("Total memory: " + GC.GetTotalMemory(false).ToString("N0"));
        }
    }
}

class DummyPage : Page
{
}

class DumberPage : Page
{
}
```


### Issues Fixed

* Fixes #24478 
* Fixes #24409
