### PR TITLE
[X] do not look for parent DataType on collections

### DIFF
--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
@@ -161,8 +161,8 @@
 			<_MauiXamlCValidateOnly Condition="'$(BuildingForLiveUnitTesting)' == 'True' ">True</_MauiXamlCValidateOnly>
 
 			<MauiStrictXamlCompilation Condition="'$(MauiStrictXamlCompilation)' == '' and ('$(PublishAot)' == 'true' or '$(TrimMode)' == 'full')">true</MauiStrictXamlCompilation>
-			<_MauiXamlCNoWarn>$(NoWarn)</_MauiXamlCNoWarn>
-			<_MauiXamlCNoWarn Condition="'$(MauiStrictXamlCompilation)' != 'true'">$(_MauiXamlCNoWarn);XC0022;XC0023</_MauiXamlCNoWarn>
+			<_MauiXamlCWarningsNotAsErrors>$(WarningsNotAsErrors)</_MauiXamlCWarningsNotAsErrors>
+			<_MauiXamlCWarningsNotAsErrors Condition="'$(MauiStrictXamlCompilation)' != 'true'">$(_MauiXamlCWarningsNotAsErrors);XC0022;XC0023</_MauiXamlCWarningsNotAsErrors>
 
       <_MauiXamlCGenerateFullPaths Condition="'$(_MauiXamlCGenerateFullPaths)' == '' and '$(GenerateFullPaths)' == 'true'">true</_MauiXamlCGenerateFullPaths>
       <_MauiXamlCGenerateFullPaths Condition="'$(_MauiXamlCGenerateFullPaths)' == ''">false</_MauiXamlCGenerateFullPaths>
@@ -181,9 +181,9 @@
 
       WarningLevel = "$(WarningLevel)"
       TreatWarningsAsErrors = "$(TreatWarningsAsErrors)"
-      NoWarn = "$(_MauiXamlCNoWarn)"
+      NoWarn = "$(NoWarn)"
       WarningsAsErrors = "$(WarningsAsErrors)"
-      WarningsNotAsErrors = "$(WarningsNotAsErrors)"
+      WarningsNotAsErrors = "$(_MauiXamlCWarningsNotAsErrors)"
       GenerateFullPaths = "$(_MauiXamlCGenerateFullPaths)"
       FullPathPrefix = "$(_MauiXamlCFullPathPrefix)" />
       

--- a/src/Controls/src/Xaml/XamlServiceProvider.cs
+++ b/src/Controls/src/Xaml/XamlServiceProvider.cs
@@ -296,7 +296,10 @@ namespace Microsoft.Maui.Controls.Xaml.Internals
 
 	class XamlDataTypeProvider : IXamlDataTypeProvider
 	{
-		[UnconditionalSuppressMessage("AOT", "IL3050:Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling.", Justification = "<Pending>")]
+		[RequiresUnreferencedCode(TrimmerConstants.XamlRuntimeParsingNotSupportedWarning)]
+#if !NETSTANDARD
+		[RequiresDynamicCode(TrimmerConstants.XamlRuntimeParsingNotSupportedWarning)]
+#endif
 		public XamlDataTypeProvider(IElementNode node, HydrationContext context)
 		{
 			Context = context;
@@ -321,7 +324,6 @@ namespace Microsoft.Maui.Controls.Xaml.Internals
 				return false;
 			}
 
-			[UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code", Justification = "<Pending>")]
 			static bool IsBindingBaseProperty(IElementNode node, HydrationContext context)
 			{
 				if (   node.TryGetPropertyName(node.Parent, out XmlName name)

--- a/src/Controls/src/Xaml/XamlServiceProvider.cs
+++ b/src/Controls/src/Xaml/XamlServiceProvider.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Reflection;
 using System.Xml;
 using Microsoft.Maui.Controls.Internals;
@@ -36,7 +37,7 @@ namespace Microsoft.Maui.Controls.Xaml.Internals
 			IValueConverterProvider = defaultValueConverterProvider;
 
 			if (node is IElementNode elementNode)
-				Add(typeof(IXamlDataTypeProvider), new XamlDataTypeProvider(elementNode));
+				Add(typeof(IXamlDataTypeProvider), new XamlDataTypeProvider(elementNode, context));
 		}
 
 		public XamlServiceProvider() => IValueConverterProvider = defaultValueConverterProvider;
@@ -295,8 +296,12 @@ namespace Microsoft.Maui.Controls.Xaml.Internals
 
 	class XamlDataTypeProvider : IXamlDataTypeProvider
 	{
-		public XamlDataTypeProvider(IElementNode node)
+		[UnconditionalSuppressMessage("AOT", "IL3050:Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling.", Justification = "<Pending>")]
+		public XamlDataTypeProvider(IElementNode node, HydrationContext context)
 		{
+			Context = context;
+			
+
 			static IElementNode GetParent(IElementNode node)
 			{
 				return node switch
@@ -316,6 +321,22 @@ namespace Microsoft.Maui.Controls.Xaml.Internals
 				return false;
 			}
 
+			[UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code", Justification = "<Pending>")]
+			static bool IsBindingBaseProperty(IElementNode node, HydrationContext context)
+			{
+				if (   node.TryGetPropertyName(node.Parent, out XmlName name)
+					&& node.Parent is IElementNode parent
+					&& XamlParser.GetElementType(parent.XmlType, 
+												 new XmlLineInfo(((IXmlLineInfo)node).LineNumber, ((IXmlLineInfo)node).LinePosition), 
+												 context.RootElement.GetType().Assembly, out var xpe) is Type parentType
+					&& parentType.GetRuntimeProperties().FirstOrDefault(p => p.Name == name.LocalName) is PropertyInfo propertyInfo
+					&& propertyInfo.PropertyType == typeof(BindingBase))
+				{								
+						return true;
+				}
+				return false;
+			}
+
 			INode dataTypeNode = null;
 			IElementNode n = node as IElementNode;
 
@@ -332,17 +353,21 @@ namespace Microsoft.Maui.Controls.Xaml.Internals
 
 			while (n != null)
 			{
+				
 				if (n != skipNode && n.Properties.TryGetValue(XmlName.xDataType, out dataTypeNode))
 				{
 					break;
 				}
-
+				if (IsBindingBaseProperty(n, context))
+				{					
+					break;
+				}
 				n = GetParent(n);
 			}
 			if (dataTypeNode is ValueNode valueNode)
 				BindingDataType = valueNode.Value as string;
-
 		}
 		public string BindingDataType { get; }
+		public HydrationContext Context { get; }
 	}
 }

--- a/src/Controls/tests/Xaml.UnitTests/Controls.Xaml.UnitTests.csproj
+++ b/src/Controls/tests/Xaml.UnitTests/Controls.Xaml.UnitTests.csproj
@@ -6,7 +6,7 @@
     <AssemblyName>Microsoft.Maui.Controls.Xaml.UnitTests</AssemblyName>
     <WarningLevel>4</WarningLevel>
     <NoWarn>$(NoWarn);0672;0219;0414;CS0436;CS0618</NoWarn>
-    <WarningsNotAsErrors>$(WarningsNotAsErrors);XC0618;XC0022,XC0023;XC0045</WarningsNotAsErrors>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);XC0618;XC0022;XC0023;XC0045</WarningsNotAsErrors>
     <IsPackable>false</IsPackable>
     <DisableMSBuildAssemblyCopyCheck>true</DisableMSBuildAssemblyCopyCheck>
   </PropertyGroup>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui23989.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui23989.xaml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage
+		xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+		xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+		xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests"
+		xmlns:sys="clr-namespace:System;assembly=mscorlib"
+        xmlns:cmp="clr-namespace:Microsoft.Maui.Controls.Compatibility;assembly=Microsoft.Maui.Controls"
+		x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui23989" >
+    <cmp:StackLayout x:DataType="local:MockViewModel">
+        <Picker
+            ItemsSource="{Binding Items}"
+            ItemDisplayBinding="{Binding Title}"
+            x:Name="picker0" />
+        <Picker
+            ItemsSource="{Binding Items}"
+            ItemDisplayBinding="{Binding Title, x:DataType=local:MockItemViewModel}"
+            x:Name="picker1" />
+    </cmp:StackLayout>
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui23989.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui23989.xaml.cs
@@ -1,0 +1,64 @@
+using Microsoft.Maui.ApplicationModel;
+using Microsoft.Maui.Dispatching;
+
+using Microsoft.Maui.Controls.Core.UnitTests;
+using Microsoft.Maui.UnitTests;
+using NUnit.Framework;
+using Microsoft.Maui.Controls.Internals;
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public partial class Maui23989
+{
+    public Maui23989()
+    {
+        InitializeComponent();
+    }
+
+    public Maui23989(bool useCompiledXaml)
+    {
+        //this stub will be replaced at compile time
+    }
+
+    [TestFixture]
+    public class Test
+    {
+        [SetUp]
+        public void Setup()
+        {
+            Application.SetCurrentApplication(new MockApplication());
+            DispatcherProvider.SetCurrent(new DispatcherProviderStub());
+        }
+
+        [TearDown] public void TearDown() => AppInfo.SetCurrent(null);
+
+        [Test]
+        public void ItemDisplayBindingWithoutDataTypeFails([Values(false, true)] bool useCompiledXaml)
+        {
+            if (useCompiledXaml)
+                Assert.Throws(new BuildExceptionConstraint(12, 13, s => s.Contains("0022", StringComparison.Ordinal)), ()=> MockCompiler.Compile(typeof(Maui23989), null, true));
+
+            var layout = new Maui23989(useCompiledXaml);
+            //without x:DataType, bindings aren't compiled
+            Assert.That(layout.picker0.ItemDisplayBinding, Is.TypeOf<Binding>());
+            if (useCompiledXaml)
+                Assert.That(layout.picker1.ItemDisplayBinding, Is.TypeOf<TypedBinding<MockItemViewModel, string>>());
+            else
+                Assert.That(layout.picker1.ItemDisplayBinding, Is.TypeOf<Binding>());
+
+            layout.BindingContext = new MockViewModel{
+                Items = new List<MockItemViewModel> { 
+                    new MockItemViewModel { Title = "item1" },
+                    new MockItemViewModel { Title = "item2" },
+                    new MockItemViewModel { Title = "item3" },
+                }.ToArray()
+            };
+
+            Assert.That(layout.picker0.Items[0], Is.EqualTo("item1"));
+            Assert.That(layout.picker1.Items[0], Is.EqualTo("item1"));
+            
+        }
+    }
+}


### PR DESCRIPTION
### Description of Change

- re-enable XC0022 and XC0023 as WarningsNotAsErrors
- do not assume that x:DataType is inherited on Picker items

### Issues Fixed

- fixes #23989
