### PR TITLE
Added Google Cloud Map Styles support for Android.

### DIFF
--- a/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
+++ b/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
@@ -71,7 +71,13 @@ namespace Microsoft.Maui.Maps.Handlers
 
 		protected override MapView CreatePlatformView()
 		{
-			MapView mapView = new MapView(Context);
+			GoogleMapOptions options = new GoogleMapOptions();
+			
+			string? mapId = GetMapId();
+			if (mapId != null)
+				options.InvokeMapId(mapId);
+  
+			MapView mapView = new MapView(Context, options);
 			mapView.OnCreate(s_bundle);
 			mapView.OnResume();
 			return mapView;
@@ -405,6 +411,13 @@ namespace Microsoft.Maui.Maps.Handlers
 
 		void OnMapClick(object? sender, GoogleMap.MapClickEventArgs e) =>
 			VirtualView.Clicked(new Devices.Sensors.Location(e.Point.Latitude, e.Point.Longitude));
+
+		string? GetMapId()
+		{
+			int resourceId = Context.Resources?.GetIdentifier("map_id", "string", Context.PackageName) ?? 0;
+			
+			return resourceId != 0 ? Context.GetString(resourceId) : null;
+		}
 
 		void AddPins(IList pins)
 		{


### PR DESCRIPTION
### Description of Change

Added support for Google Cloud Map Styles for Android.
To assign a Map ID on Android, you need to add `<string name="map_id">YOUR_MAP_ID</string>` to Resources/values/strings.xml.

Before:
<img width="343" alt="image" src="https://github.com/user-attachments/assets/f2276a37-ca4b-4fa0-b9ad-5e22a8b88513">

After:
<img width="345" alt="image" src="https://github.com/user-attachments/assets/c2f55656-d41a-4653-8d5f-85cabfa834a4">

