### PR TITLE
[X] Ignore Parent DataType on collection

### DIFF
--- a/src/Controls/src/Xaml/XamlServiceProvider.cs
+++ b/src/Controls/src/Xaml/XamlServiceProvider.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Reflection;
 using System.Xml;
 using Microsoft.Maui.Controls.Internals;
@@ -29,7 +31,7 @@ namespace Microsoft.Maui.Controls.Xaml.Internals
 			IValueConverterProvider = new ValueConverterProvider();
 
 			if (node is IElementNode elementNode)
-				Add(typeof(IXamlDataTypeProvider), new XamlDataTypeProvider(elementNode));
+				Add(typeof(IXamlDataTypeProvider), new XamlDataTypeProvider(elementNode, context));
 		}
 
 		public XamlServiceProvider() => IValueConverterProvider = new ValueConverterProvider();
@@ -268,8 +270,12 @@ namespace Microsoft.Maui.Controls.Xaml.Internals
 
 	class XamlDataTypeProvider : IXamlDataTypeProvider
 	{
-		public XamlDataTypeProvider(IElementNode node)
+		[UnconditionalSuppressMessage("AOT", "IL3050:Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling.", Justification = "<Pending>")]
+		public XamlDataTypeProvider(IElementNode node, HydrationContext context)
 		{
+			Context = context;
+			
+
 			static IElementNode GetParent(IElementNode node)
 			{
 				return node switch
@@ -289,6 +295,22 @@ namespace Microsoft.Maui.Controls.Xaml.Internals
 				return false;
 			}
 
+			[UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code", Justification = "<Pending>")]
+			static bool IsBindingBaseProperty(IElementNode node, HydrationContext context)
+			{
+				if (   ApplyPropertiesVisitor.TryGetPropertyName(node, node.Parent, out XmlName name)
+					&& node.Parent is IElementNode parent
+					&& XamlParser.GetElementType(parent.XmlType, 
+												 new XmlLineInfo(((IXmlLineInfo)node).LineNumber, ((IXmlLineInfo)node).LinePosition), 
+												 context.RootElement.GetType().Assembly, out var xpe) is Type parentType
+					&& parentType.GetRuntimeProperties().FirstOrDefault(p => p.Name == name.LocalName) is PropertyInfo propertyInfo
+					&& propertyInfo.PropertyType == typeof(BindingBase))
+				{								
+						return true;
+				}
+				return false;
+			}
+
 			INode dataTypeNode = null;
 			IElementNode n = node as IElementNode;
 
@@ -305,17 +327,21 @@ namespace Microsoft.Maui.Controls.Xaml.Internals
 
 			while (n != null)
 			{
+				
 				if (n != skipNode && n.Properties.TryGetValue(XmlName.xDataType, out dataTypeNode))
 				{
 					break;
 				}
-
+				if (IsBindingBaseProperty(n, context))
+				{					
+					break;
+				}
 				n = GetParent(n);
 			}
 			if (dataTypeNode is ValueNode valueNode)
 				BindingDataType = valueNode.Value as string;
-
 		}
 		public string BindingDataType { get; }
+		public HydrationContext Context { get; }
 	}
 }

--- a/src/Controls/src/Xaml/XamlServiceProvider.cs
+++ b/src/Controls/src/Xaml/XamlServiceProvider.cs
@@ -270,7 +270,10 @@ namespace Microsoft.Maui.Controls.Xaml.Internals
 
 	class XamlDataTypeProvider : IXamlDataTypeProvider
 	{
-		[UnconditionalSuppressMessage("AOT", "IL3050:Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling.", Justification = "<Pending>")]
+		[RequiresUnreferencedCode("XamlDataTypeProvider is not trim and AOT-compatible.")]
+#if !NETSTANDARD
+		[RequiresDynamicCode("XamlDataTypeProvider is not trim and AOT-compatible.")]
+#endif
 		public XamlDataTypeProvider(IElementNode node, HydrationContext context)
 		{
 			Context = context;
@@ -295,7 +298,6 @@ namespace Microsoft.Maui.Controls.Xaml.Internals
 				return false;
 			}
 
-			[UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code", Justification = "<Pending>")]
 			static bool IsBindingBaseProperty(IElementNode node, HydrationContext context)
 			{
 				if (   ApplyPropertiesVisitor.TryGetPropertyName(node, node.Parent, out XmlName name)

--- a/src/Controls/tests/Xaml.UnitTests/Controls.Xaml.UnitTests.csproj
+++ b/src/Controls/tests/Xaml.UnitTests/Controls.Xaml.UnitTests.csproj
@@ -6,7 +6,7 @@
     <AssemblyName>Microsoft.Maui.Controls.Xaml.UnitTests</AssemblyName>
     <WarningLevel>4</WarningLevel>
     <NoWarn>$(NoWarn);0672;0219;0414;CS0436;CS0618</NoWarn>
-    <WarningsNotAsErrors>$(WarningsNotAsErrors);XC0618;XC0022,XC0023</WarningsNotAsErrors>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);XC0618;XC0022;XC0023</WarningsNotAsErrors>
     <IsPackable>false</IsPackable>
     <DisableMSBuildAssemblyCopyCheck>true</DisableMSBuildAssemblyCopyCheck>
   </PropertyGroup>

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/BuildWarningsUtilities.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/BuildWarningsUtilities.cs
@@ -472,7 +472,7 @@ namespace Microsoft.Maui.IntegrationTests
 						Code = "IL3050",
 						Messages = new List<string>
 						{
-							"Microsoft.Maui.Controls.Xaml.Internals.XamlServiceProvider.XamlServiceProvider(INode,HydrationContext): Using member 'System.Type.MakeGenericType(Type[])' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling. The native code for this instantiation might not be available at runtime.",
+							"Microsoft.Maui.Controls.Xaml.Internals.XamlServiceProvider.XamlServiceProvider(INode,HydrationContext): Using member 'Microsoft.Maui.Controls.Xaml.Internals.XamlDataTypeProvider.XamlDataTypeProvider(IElementNode,HydrationContext)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling. XamlDataTypeProvider is not trim and AOT-compatible.",
 						}
 					},
 					

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/BuildWarningsUtilities.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/BuildWarningsUtilities.cs
@@ -454,6 +454,30 @@ namespace Microsoft.Maui.IntegrationTests
 					},
 				}
 			},
+			new WarningsPerFile
+			{
+				File = "src/Controls/src/Xaml/XamlServiceProvider.cs",
+				WarningsPerCode = new List<WarningsPerCode>
+				{
+					new WarningsPerCode
+					{
+						Code = "IL2026",
+						Messages = new List<string>
+						{
+							"Microsoft.Maui.Controls.Xaml.Internals.XamlServiceProvider.XamlServiceProvider(INode,HydrationContext): Using member 'Microsoft.Maui.Controls.Xaml.Internals.XamlDataTypeProvider.XamlDataTypeProvider(IElementNode,HydrationContext)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. XamlDataTypeProvider is not trim and AOT-compatible.",
+						}
+					},
+					new WarningsPerCode
+					{
+						Code = "IL3050",
+						Messages = new List<string>
+						{
+							"Microsoft.Maui.Controls.Xaml.Internals.XamlServiceProvider.XamlServiceProvider(INode,HydrationContext): Using member 'System.Type.MakeGenericType(Type[])' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling. The native code for this instantiation might not be available at runtime.",
+						}
+					},
+					
+				}
+			},
 		};
 
 		#region Utility methods for generating the list of expected warnings


### PR DESCRIPTION
Picker.ItemDisplayBinding for example shouldn't inherit parent DataType

- fixes #23989


### Description of Change

<!-- Enter description of the fix in this section -->

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
