### PR TITLE
Fix for the Nested Entry View In A Frame Causes Crash 

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Android/FrameRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Android/FrameRenderer.cs
@@ -131,7 +131,6 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				{
 					var child = GetChildAt(0);
 					child?.RemoveFromParent();
-					child?.Dispose();
 				}
 
 				Element?.Handler?.DisconnectHandler();

--- a/src/Controls/src/Core/Compatibility/Handlers/Android/FrameRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Android/FrameRenderer.cs
@@ -131,7 +131,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				{
 					var child = GetChildAt(0);
 					child?.RemoveFromParent();
-					child = null;
+					child?.Dispose();
 				}
 
 				Element?.Handler?.DisconnectHandler();

--- a/src/Controls/src/Core/Compatibility/Handlers/Android/FrameRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Android/FrameRenderer.cs
@@ -131,7 +131,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				{
 					var child = GetChildAt(0);
 					child?.RemoveFromParent();
-					child?.Dispose();
+					child = null;
 				}
 
 				Element?.Handler?.DisconnectHandler();

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue15196.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue15196.xaml
@@ -7,7 +7,7 @@
     <Frame x:Name="frame" HeightRequest="200">
       <Entry x:Name="entry" Text="This is entry inside the frame"/>
     </Frame>
-    <Button Text="Remove the frame" AutomationId="RemoveButton" Clicked="Button_Clicked"/>
+    <Button Text="Remove the frame" AutomationId="RemoveButton" Clicked="OnButtonClicked"/>
   </StackLayout>
 
 </ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue15196.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue15196.xaml
@@ -7,9 +7,7 @@
     <Frame x:Name="frame" HeightRequest="200">
       <Entry x:Name="entry" Text="This is entry inside the frame"/>
     </Frame>
-
     <Button Text="Remove the frame" AutomationId="RemoveButton" Clicked="Button_Clicked"/>
-
   </StackLayout>
 
 </ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue15196.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue15196.xaml
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+              x:Class="Maui.Controls.Sample.Issues.Issue15196">
+
+  <StackLayout x:Name="stackLayout">
+    <Frame x:Name="frame" AutomationId="FrameWithEntry" HeightRequest="200">
+      <Entry x:Name="entry" Text="This is entry inside the frame"/>
+    </Frame>
+
+    <Button Text="Remove the frame" AutomationId="RemoveButton" Clicked="Button_Clicked"/>
+
+  </StackLayout>
+
+</ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue15196.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue15196.xaml
@@ -4,7 +4,7 @@
               x:Class="Maui.Controls.Sample.Issues.Issue15196">
 
   <StackLayout x:Name="stackLayout">
-    <Frame x:Name="frame" AutomationId="FrameWithEntry" HeightRequest="200">
+    <Frame x:Name="frame" HeightRequest="200">
       <Entry x:Name="entry" Text="This is entry inside the frame"/>
     </Frame>
 

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue15196.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue15196.xaml.cs
@@ -16,11 +16,10 @@ namespace Maui.Controls.Sample.Issues
 			InitializeComponent();
 		}
 
-		private void Button_Clicked(object sender, EventArgs e)
+		private void OnButtonClicked(object sender, EventArgs e)
 		{
 			if (stackLayout.Children.Contains(frame))
 			{
-				// Remove the frame from the stackLayout
 				stackLayout.Children.Remove(frame);
 			}
 			

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue15196.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue15196.xaml.cs
@@ -24,10 +24,9 @@ namespace Maui.Controls.Sample.Issues
 				stackLayout.Children.Remove(frame);
 			}
 
-#if ANDROID
 		frame?.Handler?.DisconnectHandler();
 		entry?.Handler?.DisconnectHandler();
-#endif
+
 		}
 	}
 }

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue15196.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue15196.xaml.cs
@@ -23,10 +23,9 @@ namespace Maui.Controls.Sample.Issues
 				// Remove the frame from the stackLayout
 				stackLayout.Children.Remove(frame);
 			}
-
+			
 		frame?.Handler?.DisconnectHandler();
 		entry?.Handler?.DisconnectHandler();
-
 		}
 	}
 }

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue15196.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue15196.xaml.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Internals;
+using Microsoft.Maui.Controls.Xaml;
+using Microsoft.Maui.Graphics;
+
+namespace Maui.Controls.Sample.Issues
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	[Issue(IssueTracker.Github, 15196, "Nested Entry View In A Frame Causes Crash", PlatformAffected.Android)]
+	public partial class Issue15196 : ContentPage
+	{
+		public Issue15196()
+		{
+			InitializeComponent();
+		}
+
+		private void Button_Clicked(object sender, EventArgs e)
+		{
+			if (stackLayout.Children.Contains(frame))
+			{
+				// Remove the frame from the stackLayout
+				stackLayout.Children.Remove(frame);
+			}
+
+#if ANDROID
+		frame?.Handler?.DisconnectHandler();
+		entry?.Handler?.DisconnectHandler();
+#endif
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue15196.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue15196.cs
@@ -15,7 +15,6 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		[Category(UITestCategories.Entry)]
 		public void NestedEntryViewInFrameShouldNotCrash()
 		{
-			//Validate the crash is fixed
 			App.WaitForElement("RemoveButton");
 			App.Click("RemoveButton");
 		}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue15196.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue15196.cs
@@ -13,8 +13,7 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 
 		[Test]
 		[Category(UITestCategories.Entry)]
-		[Category(UITestCategories.Frame)]
-		public void CrashShouldNotOccur()
+		public void NestedEntryViewInFrameShouldNotCrash()
 		{
 			//Validate the crash is fixed
 			App.WaitForElement("RemoveButton");

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue15196.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue15196.cs
@@ -1,0 +1,25 @@
+﻿#if !MACCATALYST
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+    internal class Issue15196 : _IssuesUITest
+	{
+		public override string Issue => "Nested Entry View In A Frame Causes Crash";
+
+		public Issue15196(TestDevice testDevice) : base(testDevice) { }
+
+		[Test]
+		[Category(UITestCategories.Entry)]
+		[Category(UITestCategories.Frame)]
+		public void CrashShouldNotOccur()
+		{
+			//Validate the crash is fixed
+			App.WaitForElement("RemoveButton");
+			App.Click("RemoveButton");
+		}
+	}
+}
+#endif

--- a/src/Core/src/Handlers/Entry/EntryHandler.Android.cs
+++ b/src/Core/src/Handlers/Entry/EntryHandler.Android.cs
@@ -52,9 +52,6 @@ namespace Microsoft.Maui.Handlers
 		// TODO: NET8 issoto - Change the return type to MauiAppCompatEditText
 		protected override void DisconnectHandler(AppCompatEditText platformView)
 		{
-			if (platformView is null || platformView.Handle == IntPtr.Zero)
-				return;
-
 			_clearButtonDrawable = null;
 			platformView.ViewAttachedToWindow -= OnPlatformViewAttachedToWindow;
 			platformView.TextChanged -= OnTextChanged;

--- a/src/Core/src/Handlers/Entry/EntryHandler.Android.cs
+++ b/src/Core/src/Handlers/Entry/EntryHandler.Android.cs
@@ -52,6 +52,9 @@ namespace Microsoft.Maui.Handlers
 		// TODO: NET8 issoto - Change the return type to MauiAppCompatEditText
 		protected override void DisconnectHandler(AppCompatEditText platformView)
 		{
+			if (platformView is null || platformView.Handle == IntPtr.Zero)
+				return;
+
 			_clearButtonDrawable = null;
 			platformView.ViewAttachedToWindow -= OnPlatformViewAttachedToWindow;
 			platformView.TextChanged -= OnTextChanged;


### PR DESCRIPTION
### Root cause

<!-- Enter description of the fix in this section -->

In the FrameRenderer class, the Dispose() method is called from the disconnect handler, where the child is disposed of. After that, the disconnect handler of EntryHandler.Android is called. Disposing of the child in the FrameRenderer class causes the child object to be inaccessible in the disconnect handler of EntryHandler.Android.

### Description of Issue Fix

Removed the child dispose method from the FrameRenderer to prevent the ObjectDisposedException from occurring in the child disconnect handler

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #15196
Fixes #22372 
<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->

### Screenshots

| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video width="270" height="600"  src="https://github.com/user-attachments/assets/4fa659d6-b27e-49c5-9eae-d6901cdaab4b"> | <video width="270" height="600"  src="https://github.com/user-attachments/assets/3e5599b9-3000-4baa-831a-bd4fe2aceae4"> |








