### PR TITLE
Show number of filtered tests in DeviceTests UI

### DIFF
--- a/src/TestUtils/src/DeviceTests.Runners/VisualRunner/Pages/TestAssemblyPage.xaml
+++ b/src/TestUtils/src/DeviceTests.Runners/VisualRunner/Pages/TestAssemblyPage.xaml
@@ -55,7 +55,7 @@
 
         <!-- additional controls -->
         <StackLayout Orientation="Horizontal" Grid.Row="3" HorizontalOptions="Center" Spacing="5">
-            <Button Text="Run Filtered" Command="{Binding RunFilteredTestsCommand}" />
+            <Button Text="{Binding RunFilteredText}" Command="{Binding RunFilteredTestsCommand}" />
             <Button Text="Run All" Command="{Binding RunAllTestsCommand}" />
         </StackLayout>
 


### PR DESCRIPTION
### Description of Change

The initial screen is unchanged:
![image](https://github.com/user-attachments/assets/0b9235ad-dcf5-46fb-91b0-c011d8f63009)

Then pick an assembly, and when you type to filter, it shows you how many filtered tests you will run:
![image](https://github.com/user-attachments/assets/f71c02c0-02fa-458a-a5e6-b2ee47d33c1b)

And as a minor change, it also disables the Run Filtered button if there are no matches at all:
![image](https://github.com/user-attachments/assets/922bbc47-bba7-4928-8ed1-147f9a325905)

### Issues Fixed

Fixes My Pet Annoyance
