### PR TITLE
Avoid recomputing bindings multiple times and bind BindingContext first

### DIFF
--- a/src/Controls/src/Core/BindableObject.cs
+++ b/src/Controls/src/Core/BindableObject.cs
@@ -341,7 +341,7 @@ namespace Microsoft.Maui.Controls
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static void SetInheritedBindingContext(BindableObject bindable, object value)
 		{
-			//I wonder if we coulnd't treat bindingcoutext with specificities
+			// I wonder if we couldn't treat BindingContext with specificities
 			BindablePropertyContext bpContext = bindable.GetContext(BindingContextProperty);
 			if (bpContext != null && bpContext.Values.GetSpecificityAndValue().Key.CompareTo(SetterSpecificity.ManualValueSetter) >= 0)
 				return;
@@ -355,20 +355,33 @@ namespace Microsoft.Maui.Controls
 			{
 				binding.Context = value;
 				bindable._inheritedContext = null;
+				// OnBindingContextChanged fires from within BindingContextProperty propertyChanged callback
+				bindable.ApplyBinding(bpContext, fromBindingContextChanged: true);
 			}
 			else
 			{
 				bindable._inheritedContext = new WeakReference(value);
+				bindable.ApplyBindings(fromBindingContextChanged: true);
+				bindable.OnBindingContextChanged();
 			}
-
-			bindable.ApplyBindings(skipBindingContext: false, fromBindingContextChanged: true);
-			bindable.OnBindingContextChanged();
 		}
 
 		/// <summary>
 		/// Applies all the current bindings to <see cref="BindingContext" />.
 		/// </summary>
-		protected void ApplyBindings() => ApplyBindings(skipBindingContext: false, fromBindingContextChanged: false);
+		protected void ApplyBindings()
+		{
+			BindablePropertyContext bpContext = GetContext(BindingContextProperty);
+			var binding = bpContext?.Bindings.Values.LastOrDefault();
+			if (binding != null)
+			{
+				ApplyBinding(bpContext, fromBindingContextChanged: false);
+			}
+			else
+			{
+				ApplyBindings(fromBindingContextChanged: false);
+			}
+		}
 
 		/// <summary>
 		/// Raises the <see cref="BindingContextChanged"/> event.
@@ -645,25 +658,43 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		internal void ApplyBindings(bool skipBindingContext, bool fromBindingContextChanged)
+		void ApplyBindings(bool fromBindingContextChanged)
 		{
 			var prop = _properties.Values.ToArray();
+
 			for (int i = 0, propLength = prop.Length; i < propLength; i++)
 			{
 				BindablePropertyContext context = prop[i];
-				var kvp = context.Bindings.LastOrDefault();
-				var specificity = kvp.Key;
-				var binding = kvp.Value;
-
-				if (binding == null)
+				if (ReferenceEquals(context.Property, BindingContextProperty))
+				{
+					// BindingContextProperty Binding is handled separately within SetInheritedBindingContext
 					continue;
+				}
 
-				if (skipBindingContext && ReferenceEquals(context.Property, BindingContextProperty))
-					continue;
-
-				binding.Unapply(fromBindingContextChanged: fromBindingContextChanged);
-				binding.Apply(BindingContext, this, context.Property, fromBindingContextChanged, specificity);
+				ApplyBinding(context, fromBindingContextChanged);
 			}
+		}
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		void ApplyBinding(BindablePropertyContext context, bool fromBindingContextChanged)
+		{
+			var bindings = context.Bindings;
+			if (bindings.Count == 0)
+			{
+				return;
+			}
+
+			var kvp = bindings.LastOrDefault();
+			var binding = kvp.Value;
+
+			if (binding == null)
+			{
+				return;
+			}
+
+			var specificity = kvp.Key;
+			binding.Unapply(fromBindingContextChanged);
+			binding.Apply(BindingContext, this, context.Property, fromBindingContextChanged, specificity);
 		}
 
 		static void BindingContextPropertyBindingChanging(BindableObject bindable, BindingBase oldBindingBase, BindingBase newBindingBase)
@@ -681,7 +712,7 @@ namespace Microsoft.Maui.Controls
 		static void BindingContextPropertyChanged(BindableObject bindable, object oldvalue, object newvalue)
 		{
 			bindable._inheritedContext = null;
-			bindable.ApplyBindings(skipBindingContext: true, fromBindingContextChanged: true);
+			bindable.ApplyBindings(fromBindingContextChanged: true);
 			bindable.OnBindingContextChanged();
 		}
 

--- a/src/Controls/src/Core/Element/Element.cs
+++ b/src/Controls/src/Core/Element/Element.cs
@@ -587,8 +587,6 @@ namespace Microsoft.Maui.Controls
 		{
 			child.SetParent(this);
 
-			child.ApplyBindings(skipBindingContext: false, fromBindingContextChanged: true);
-
 			ChildAdded?.Invoke(this, new ElementEventArgs(child));
 
 			VisualDiagnostics.OnChildAdded(this, child);

--- a/src/Core/tests/Benchmarks/Benchmarks/ElementBenchmarker.cs
+++ b/src/Core/tests/Benchmarks/Benchmarks/ElementBenchmarker.cs
@@ -19,7 +19,89 @@ namespace Microsoft.Maui.Handlers.Benchmarks
 				brush.Color = Colors.Black;
 				brush.Color = Colors.Green;
 			}
+
 			return brush.Color == Colors.Green;
+		}
+
+		class MockElement : Element
+		{
+			public static readonly BindableProperty TextProperty = BindableProperty.Create(
+				nameof(Text),
+				typeof(string),
+				typeof(MockElement));
+
+			public string Text
+			{
+				get => (string)GetValue(TextProperty);
+				set => SetValue(TextProperty, value);
+			}
+		}
+
+		[Benchmark]
+		public void ApplyPropertyViaBindingContextInheritance()
+		{
+			const int iterations = 100;
+
+			for (int i = 0; i < iterations; i++)
+			{
+				var bindingContext = "a binding context";
+
+				var root = new MockElement();
+				var bindableProperty = MockElement.TextProperty;
+
+				var level1 = new MockElement();
+				level1.SetBinding(
+					bindableProperty,
+					new Binding(".", BindingMode.OneWay));
+
+				var level2 = new MockElement();
+				level2.SetBinding(
+					bindableProperty,
+					new Binding(".", BindingMode.OneWay));
+
+				root.AddLogicalChild(level1);
+				level1.AddLogicalChild(level2);
+
+				root.BindingContext = bindingContext;
+			}
+		}
+		
+		[Benchmark]
+		public void ApplyBindingContextViaBindingContextInheritance()
+		{
+			const int iterations = 100;
+
+			var bindingContext = new
+			{
+				Level1 = new
+				{
+					Level2 = new
+					{
+						Text = "a binding context"
+					}
+				}
+			};
+
+			for (int i = 0; i < iterations; i++)
+			{
+				var root = new MockElement();
+
+				var level1 = new MockElement();
+				level1.SetBinding(
+					BindableObject.BindingContextProperty,
+					new Binding("Level1", BindingMode.OneWay));
+
+				var level2 = new MockElement();
+				level2.SetBinding(MockElement.TextProperty, new Binding("Text", BindingMode.OneWay));
+				level2.SetBinding(
+					BindableObject.BindingContextProperty,
+					new Binding("Level2", BindingMode.OneWay));
+
+				root.AddLogicalChild(level1);
+				level1.AddLogicalChild(level2);
+
+				root.BindingContext = bindingContext;
+			}
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change

The two unit tests shows the expectation we all have about bindings:
- eventual `BindingContext` binding should apply before any property binding
- `Binding` should happen only once upon binding context inheritance

### Benchmarks

#### Before

| Method                                          | Mean     | Error   | StdDev  | Gen0     | Gen1    | Gen2    | Allocated |
|------------------------------------------------ |---------:|--------:|--------:|---------:|--------:|--------:|----------:|
| SetProperty                                     | 892.2 us | 7.64 us | 6.77 us |        - |       - |       - |     873 B |
| ApplyProperty ViaBindingContextInheritance       | 379.7 us | 3.94 us | 3.49 us |  76.6602 | 38.0859 |  3.9063 |  644003 B |
| ApplyBindingContext ViaBindingContextInheritance | 775.7 us | 8.05 us | 7.13 us | 109.3750 | 54.6875 | 11.7188 |  919289 B |

#### After

| Method                                          | Mean     | Error   | StdDev  | Gen0    | Gen1    | Allocated |
|------------------------------------------------ |---------:|--------:|--------:|--------:|--------:|----------:|
| SetProperty                                     | 868.0 us | 1.00 us | 0.83 us |       - |       - |     873 B |
| ApplyProperty ViaBindingContextInheritance       | 309.0 us | 0.54 us | 0.50 us | 72.7539 | 36.1328 |  612000 B |
| ApplyBindingContext ViaBindingContextInheritance | 497.6 us | 1.23 us | 1.15 us | 93.7500 | 46.8750 |  784881 B |

### Issues Fixed

Fixes #10806
