### PR TITLE
Use the IsRefreshing property directly

### DIFF
--- a/src/Controls/src/Core/RefreshView/RefreshView.cs
+++ b/src/Controls/src/Core/RefreshView/RefreshView.cs
@@ -120,7 +120,7 @@ namespace Microsoft.Maui.Controls
 		
 		void ICommandElement.CanExecuteChanged(object sender, EventArgs e)
 		{
-			if((bool)GetValue(IsRefreshingProperty))
+			if (IsRefreshing)
 				return;
 
 			RefreshIsEnabledProperty();


### PR DESCRIPTION
### Description of Change

Just a follow up from #24290 where the BP was used instead of the C# property. Just makes this a bit simpler to read.