### PR TITLE
[Android] Ensure disconnected ItemsViewHandler doesn't hold onto the items source

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/Android/ItemsSources/ItemsSourceFactory.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/ItemsSources/ItemsSourceFactory.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			switch (itemsSource)
 			{
 				case IList list when itemsSource is INotifyCollectionChanged:
-					return new ObservableItemsSource(new MarshalingObservableCollection(list), container, notifier);
+					return new ObservableItemsSource(new MarshalingObservableCollection(list), container, notifier, disposeItemsSource: true);
 				case IEnumerable _ when itemsSource is INotifyCollectionChanged:
 					return new ObservableItemsSource(itemsSource, container, notifier);
 				case IList list:

--- a/src/Controls/src/Core/Handlers/Items/Android/ItemsSources/ObservableItemsSource.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/ItemsSources/ObservableItemsSource.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 	internal class ObservableItemsSource : IItemsViewSource, IObservableItemsViewSource
 	{
 		readonly IEnumerable _itemsSource;
+		readonly bool _disposeItemsSource;
 		readonly BindableObject _container;
 		readonly ICollectionChangedNotifier _notifier;
 		readonly WeakNotifyCollectionChangedProxy _proxy = new();
@@ -16,9 +17,10 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		~ObservableItemsSource() => _proxy.Unsubscribe();
 
-		public ObservableItemsSource(IEnumerable itemSource, BindableObject container, ICollectionChangedNotifier notifier)
+		public ObservableItemsSource(IEnumerable itemSource, BindableObject container, ICollectionChangedNotifier notifier, bool disposeItemsSource = false)
 		{
 			_itemsSource = itemSource;
+			_disposeItemsSource = disposeItemsSource;
 			_container = container;
 			_notifier = notifier;
 			_collectionChanged = CollectionChanged;
@@ -83,6 +85,14 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			if (disposing)
 			{
 				_proxy.Unsubscribe();
+
+				if (_disposeItemsSource)
+				{
+					if (_itemsSource is MarshalingObservableCollection marshalingObservableCollection)
+						marshalingObservableCollection.Dispose();
+					else if (_itemsSource is IDisposable disposableCollection)
+						disposableCollection.Dispose();
+				}
 			}
 		}
 

--- a/src/Controls/src/Core/Items/MarshalingObservableCollection.cs
+++ b/src/Controls/src/Core/Items/MarshalingObservableCollection.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Maui.Controls
 	{
 		readonly IList _internalCollection;
 		readonly IDispatcher _dispatcher;
+		readonly WeakNotifyCollectionChangedProxy _proxy;
 
 		/// <param name="list">The list parameter.</param>
 		public MarshalingObservableCollection(IList list)
@@ -32,8 +33,7 @@ namespace Microsoft.Maui.Controls
 
 			_internalCollection = list;
 			_dispatcher = Dispatcher.GetForCurrentThread();
-
-			incc.CollectionChanged += InternalCollectionChanged;
+			_proxy = new WeakNotifyCollectionChangedProxy(incc, InternalCollectionChanged);
 
 			foreach (var item in _internalCollection)
 			{
@@ -156,6 +156,11 @@ namespace Microsoft.Maui.Controls
 			}
 
 			OnCollectionChanged(args);
+		}
+
+		internal void Dispose()
+		{
+			_proxy.Unsubscribe();
 		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/CarouselView/CarouselViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CarouselView/CarouselViewTests.cs
@@ -114,7 +114,6 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
-#if !ANDROID //https://github.com/dotnet/maui/pull/24610
 		[Fact]
 		public async void DisconnectedCarouselViewDoesNotHookCollectionViewChanged()
 		{
@@ -154,7 +153,6 @@ namespace Microsoft.Maui.DeviceTests
 
 			Assert.True(data.IsCollectionChangedEventEmpty);
 		}
-#endif
 	}
 
 	internal class CustomDataTemplateSelectorSelector : DataTemplateSelector


### PR DESCRIPTION
### Description of Change

Any control derived from `ItemsView` (`CarouselView`, `CollectionView`) never disconnected from the `ItemsSource.CollectionChanged` callback when `DisconnectHandler()` is called. If the lifetime of the item source outlives the controls it can result in the `CollectionChanged` callback keeping part of the UI tree alive in a half-zombie state. Any change then calls the callback and it may cause crashes with `NullReferenceException` as seen in #24304.

### Issues Fixed

Fixes #24304
