### PR TITLE
Add DotNetPurple as a named color

### DIFF
--- a/src/Graphics/src/Graphics/Colors.cs
+++ b/src/Graphics/src/Graphics/Colors.cs
@@ -299,6 +299,8 @@ namespace Microsoft.Maui.Graphics
 		public static readonly Color White = Color.FromUint(0xFFFFFFFF);
 		/// <summary>Gets the system-defined color that has an ARGB value of <c>#FFF5F5F5</c>.</summary>
 		public static readonly Color WhiteSmoke = Color.FromUint(0xFFF5F5F5);
+		/// <summary>Gets the system-defined color that has an ARGB value of <c>#FF5596D8</c>.</summary>
+		public static readonly Color XamarinBlue2011 = Color.FromUint(0xFF5596D8);
 		/// <summary>Gets the system-defined color that has an ARGB value of <c>#FFFFFF00</c>.</summary>
 		public static readonly Color Yellow = Color.FromUint(0xFFFFFF00);
 		/// <summary>Gets the system-defined color that has an ARGB value of <c>#FF9ACD32</c>.</summary>

--- a/src/Graphics/src/Graphics/Colors.cs
+++ b/src/Graphics/src/Graphics/Colors.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Maui.Graphics
 		/// <summary>Gets the system-defined color that has an ARGB value of <c>#FF1E90FF</c>.</summary>
 		public static readonly Color DodgerBlue = Color.FromUint(0xFF1E90FF);
 		/// <summary>Gets the system-defined color that has an ARGB value of <c>#0xFF512BD4</c>.</summary>
-		public static readonly Color DotNetPurple = Color.FromUint(0xFF512BD4);
+		public static readonly Color DotNetPurple2024 = Color.FromUint(0xFF512BD4);
 		/// <summary>Gets the system-defined color that has an ARGB value of <c>#FFB22222</c>.</summary>
 		public static readonly Color Firebrick = Color.FromUint(0xFFB22222);
 		/// <summary>Gets the system-defined color that has an ARGB value of <c>#FFFFFAF0</c>.</summary>

--- a/src/Graphics/src/Graphics/Colors.cs
+++ b/src/Graphics/src/Graphics/Colors.cs
@@ -95,6 +95,8 @@ namespace Microsoft.Maui.Graphics
 		public static readonly Color DimGrey = DimGray;
 		/// <summary>Gets the system-defined color that has an ARGB value of <c>#FF1E90FF</c>.</summary>
 		public static readonly Color DodgerBlue = Color.FromUint(0xFF1E90FF);
+		/// <summary>Gets the system-defined color that has an ARGB value of <c>#0xFF512BD4</c>.</summary>
+		public static readonly Color DotNetPurple = Color.FromUint(0xFF512BD4);
 		/// <summary>Gets the system-defined color that has an ARGB value of <c>#FFB22222</c>.</summary>
 		public static readonly Color Firebrick = Color.FromUint(0xFFB22222);
 		/// <summary>Gets the system-defined color that has an ARGB value of <c>#FFFFFAF0</c>.</summary>

--- a/src/Graphics/src/Graphics/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Graphics/src/Graphics/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -1500,6 +1500,7 @@ virtual Microsoft.Maui.Graphics.Paint.IsTransparent.get -> bool
 ~static readonly Microsoft.Maui.Graphics.Colors.DimGray -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Colors.DimGrey -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Colors.DodgerBlue -> Microsoft.Maui.Graphics.Color
+~static readonly Microsoft.Maui.Graphics.Colors.DotNetPurple2024 -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Colors.Firebrick -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Colors.FloralWhite -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Colors.ForestGreen -> Microsoft.Maui.Graphics.Color
@@ -1601,6 +1602,7 @@ virtual Microsoft.Maui.Graphics.Paint.IsTransparent.get -> bool
 ~static readonly Microsoft.Maui.Graphics.Colors.Wheat -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Colors.White -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Colors.WhiteSmoke -> Microsoft.Maui.Graphics.Color
+~static readonly Microsoft.Maui.Graphics.Colors.XamarinBlue2011 -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Colors.Yellow -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Colors.YellowGreen -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Text.AttributedTextRunComparer.Instance -> Microsoft.Maui.Graphics.Text.AttributedTextRunComparer

--- a/src/Graphics/src/Graphics/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Graphics/src/Graphics/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -1517,6 +1517,7 @@ virtual Microsoft.Maui.Graphics.Platform.PlatformGraphicsView.PatternPhase.get -
 ~static readonly Microsoft.Maui.Graphics.Colors.DimGray -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Colors.DimGrey -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Colors.DodgerBlue -> Microsoft.Maui.Graphics.Color
+~static readonly Microsoft.Maui.Graphics.Colors.DotNetPurple2024 -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Colors.Firebrick -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Colors.FloralWhite -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Colors.ForestGreen -> Microsoft.Maui.Graphics.Color
@@ -1618,6 +1619,7 @@ virtual Microsoft.Maui.Graphics.Platform.PlatformGraphicsView.PatternPhase.get -
 ~static readonly Microsoft.Maui.Graphics.Colors.Wheat -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Colors.White -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Colors.WhiteSmoke -> Microsoft.Maui.Graphics.Color
+~static readonly Microsoft.Maui.Graphics.Colors.XamarinBlue2011 -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Colors.Yellow -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Colors.YellowGreen -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Text.AttributedTextRunComparer.Instance -> Microsoft.Maui.Graphics.Text.AttributedTextRunComparer

--- a/src/Graphics/src/Graphics/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Graphics/src/Graphics/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -1517,6 +1517,7 @@ virtual Microsoft.Maui.Graphics.Platform.PlatformGraphicsView.PatternPhase.get -
 ~static readonly Microsoft.Maui.Graphics.Colors.DimGray -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Colors.DimGrey -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Colors.DodgerBlue -> Microsoft.Maui.Graphics.Color
+~static readonly Microsoft.Maui.Graphics.Colors.DotNetPurple2024 -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Colors.Firebrick -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Colors.FloralWhite -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Colors.ForestGreen -> Microsoft.Maui.Graphics.Color
@@ -1618,6 +1619,7 @@ virtual Microsoft.Maui.Graphics.Platform.PlatformGraphicsView.PatternPhase.get -
 ~static readonly Microsoft.Maui.Graphics.Colors.Wheat -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Colors.White -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Colors.WhiteSmoke -> Microsoft.Maui.Graphics.Color
+~static readonly Microsoft.Maui.Graphics.Colors.XamarinBlue2011 -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Colors.Yellow -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Colors.YellowGreen -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Text.AttributedTextRunComparer.Instance -> Microsoft.Maui.Graphics.Text.AttributedTextRunComparer

--- a/src/Graphics/src/Graphics/PublicAPI/net-macos/PublicAPI.Unshipped.txt
+++ b/src/Graphics/src/Graphics/PublicAPI/net-macos/PublicAPI.Unshipped.txt
@@ -1525,6 +1525,7 @@ virtual Microsoft.Maui.Graphics.Platform.PlatformGraphicsView.PatternPhase.get -
 ~static readonly Microsoft.Maui.Graphics.Colors.DimGray -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Colors.DimGrey -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Colors.DodgerBlue -> Microsoft.Maui.Graphics.Color
+~static readonly Microsoft.Maui.Graphics.Colors.DotNetPurple2024 -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Colors.Firebrick -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Colors.FloralWhite -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Colors.ForestGreen -> Microsoft.Maui.Graphics.Color
@@ -1626,6 +1627,7 @@ virtual Microsoft.Maui.Graphics.Platform.PlatformGraphicsView.PatternPhase.get -
 ~static readonly Microsoft.Maui.Graphics.Colors.Wheat -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Colors.White -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Colors.WhiteSmoke -> Microsoft.Maui.Graphics.Color
+~static readonly Microsoft.Maui.Graphics.Colors.XamarinBlue2011 -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Colors.Yellow -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Colors.YellowGreen -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Text.AttributedTextRunComparer.Instance -> Microsoft.Maui.Graphics.Text.AttributedTextRunComparer

--- a/src/Graphics/src/Graphics/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Graphics/src/Graphics/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -1340,6 +1340,7 @@ virtual Microsoft.Maui.Graphics.Paint.IsTransparent.get -> bool
 ~static readonly Microsoft.Maui.Graphics.Colors.DimGray -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Colors.DimGrey -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Colors.DodgerBlue -> Microsoft.Maui.Graphics.Color
+~static readonly Microsoft.Maui.Graphics.Colors.DotNetPurple2024 -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Colors.Firebrick -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Colors.FloralWhite -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Colors.ForestGreen -> Microsoft.Maui.Graphics.Color
@@ -1441,6 +1442,7 @@ virtual Microsoft.Maui.Graphics.Paint.IsTransparent.get -> bool
 ~static readonly Microsoft.Maui.Graphics.Colors.Wheat -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Colors.White -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Colors.WhiteSmoke -> Microsoft.Maui.Graphics.Color
+~static readonly Microsoft.Maui.Graphics.Colors.XamarinBlue2011 -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Colors.Yellow -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Colors.YellowGreen -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Text.AttributedTextRunComparer.Instance -> Microsoft.Maui.Graphics.Text.AttributedTextRunComparer

--- a/src/Graphics/src/Graphics/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Graphics/src/Graphics/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -1346,6 +1346,7 @@ virtual Microsoft.Maui.Graphics.Paint.IsTransparent.get -> bool
 ~static readonly Microsoft.Maui.Graphics.Colors.DimGray -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Colors.DimGrey -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Colors.DodgerBlue -> Microsoft.Maui.Graphics.Color
+~static readonly Microsoft.Maui.Graphics.Colors.DotNetPurple2024 -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Colors.Firebrick -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Colors.FloralWhite -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Colors.ForestGreen -> Microsoft.Maui.Graphics.Color
@@ -1447,6 +1448,7 @@ virtual Microsoft.Maui.Graphics.Paint.IsTransparent.get -> bool
 ~static readonly Microsoft.Maui.Graphics.Colors.Wheat -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Colors.White -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Colors.WhiteSmoke -> Microsoft.Maui.Graphics.Color
+~static readonly Microsoft.Maui.Graphics.Colors.XamarinBlue2011 -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Colors.Yellow -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Colors.YellowGreen -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Text.AttributedTextRunComparer.Instance -> Microsoft.Maui.Graphics.Text.AttributedTextRunComparer

--- a/src/Graphics/src/Graphics/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Graphics/src/Graphics/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -1340,6 +1340,7 @@ virtual Microsoft.Maui.Graphics.Paint.IsTransparent.get -> bool
 ~static readonly Microsoft.Maui.Graphics.Colors.DimGray -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Colors.DimGrey -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Colors.DodgerBlue -> Microsoft.Maui.Graphics.Color
+~static readonly Microsoft.Maui.Graphics.Colors.DotNetPurple2024 -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Colors.Firebrick -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Colors.FloralWhite -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Colors.ForestGreen -> Microsoft.Maui.Graphics.Color
@@ -1441,6 +1442,7 @@ virtual Microsoft.Maui.Graphics.Paint.IsTransparent.get -> bool
 ~static readonly Microsoft.Maui.Graphics.Colors.Wheat -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Colors.White -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Colors.WhiteSmoke -> Microsoft.Maui.Graphics.Color
+~static readonly Microsoft.Maui.Graphics.Colors.XamarinBlue2011 -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Colors.Yellow -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Colors.YellowGreen -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Text.AttributedTextRunComparer.Instance -> Microsoft.Maui.Graphics.Text.AttributedTextRunComparer

--- a/src/Graphics/src/Graphics/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Graphics/src/Graphics/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -1340,6 +1340,7 @@ virtual Microsoft.Maui.Graphics.Paint.IsTransparent.get -> bool
 ~static readonly Microsoft.Maui.Graphics.Colors.DimGray -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Colors.DimGrey -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Colors.DodgerBlue -> Microsoft.Maui.Graphics.Color
+~static readonly Microsoft.Maui.Graphics.Colors.DotNetPurple2024 -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Colors.Firebrick -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Colors.FloralWhite -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Colors.ForestGreen -> Microsoft.Maui.Graphics.Color
@@ -1441,6 +1442,7 @@ virtual Microsoft.Maui.Graphics.Paint.IsTransparent.get -> bool
 ~static readonly Microsoft.Maui.Graphics.Colors.Wheat -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Colors.White -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Colors.WhiteSmoke -> Microsoft.Maui.Graphics.Color
+~static readonly Microsoft.Maui.Graphics.Colors.XamarinBlue2011 -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Colors.Yellow -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Colors.YellowGreen -> Microsoft.Maui.Graphics.Color
 ~static readonly Microsoft.Maui.Graphics.Text.AttributedTextRunComparer.Instance -> Microsoft.Maui.Graphics.Text.AttributedTextRunComparer


### PR DESCRIPTION
Sorry in advance for if I wasn't supposed to use tabs lol


### Description of Change

Added the official [dotnet brand color](https://github.com/dotnet/brand?tab=readme-ov-file#logo) - #512BD4 (0xFF512BD4) to Colors.cs file in Maui.Graphics

### Issues Fixed

My feelings
