### PR TITLE
Update script to generate Public API filess

### DIFF
--- a/eng/PublicAPI.empty.txt
+++ b/eng/PublicAPI.empty.txt
@@ -1,1 +1,0 @@
-#nullable enable

--- a/eng/scripts/mark-shipped.ps1
+++ b/eng/scripts/mark-shipped.ps1
@@ -1,22 +1,31 @@
-# Copied from ASP.NET:
-# https://github.com/dotnet/aspnetcore/blob/a24dd9e870bf713487e5cca46075ff3ee2c3ddc8/eng/scripts/mark-shipped.ps1
-[CmdletBinding(PositionalBinding=$false)]
-param ()
+# USAGE:
+#  - To mark all APIs as shipped:
+#    .\eng\scripts\mark-shipped.ps1
+#  - To mark APIs as shipped/unshipped based on changes between two branches:
+#    .\eng\scripts\mark-shipped.ps1 -BaselineBranch <branch>
+
+[CmdletBinding(PositionalBinding = $false)]
+param (
+    [string]$BaselineBranch
+)
 
 Set-StrictMode -version 2.0
 $ErrorActionPreference = "Stop"
 
-function MarkShipped([string]$dir) {
-    Write-Host "Processing $dir"
+$removedPrefix = "*REMOVED*";
 
-    $removedPrefix = "*REMOVED*";
+function Read-ApiFiles([string]$dir) {
     $shipped = @()
     $removed = @()
+    $added = @()
 
     $shippedFilePath = Join-Path $dir "PublicAPI.Shipped.txt"
     $shippedContents = Get-Content $shippedFilePath
     foreach ($item in $shippedContents) {
-        $shipped += $item.Trim()
+        $item = $item.Trim()
+        if ($item.Length -gt 0) {
+            $shipped += $item
+        }
     }
 
     $unshippedFilePath = Join-Path $dir "PublicAPI.Unshipped.txt"
@@ -29,28 +38,138 @@ function MarkShipped([string]$dir) {
                 $removed += $item
             }
             else {
-                $shipped += $item
+                $added += $item
             }
         }
     }
 
-    Remove-Item $shippedFilePath -Force
-    $shipped |
-        Sort-Object -Unique |
-        Where-Object { -not $removed.Contains($_) } |
-        Out-File $shippedFilePath -Encoding Ascii
+    $filtered = ($shipped + $added) | Where-Object { -not $removed.Contains($_) } | Sort-Object -Unique
 
-    Copy-Item eng/PublicAPI.empty.txt $unshippedFilePath
-}
-
-try {
-    foreach ($file in Get-ChildItem -re -in "PublicApi.Shipped.txt") {
-        $dir = Split-Path -parent $file
-        MarkShipped $dir
+    return @{
+        Shipped  = $shipped
+        Added    = $added
+        Removed  = $removed
+        Filtered = $filtered
     }
 }
-catch {
-    Write-Host $_
-    Write-Host $_.Exception
-    exit 1
+
+function Move-Shipped([string]$dir) {
+    Write-Host "- Processing $dir" -NoNewline
+    
+    $results = Read-ApiFiles $dir
+    $s = $results.Shipped.Count
+    $a = $results.Added.Count
+    $r = $results.Removed.Count
+    $f = $results.Filtered.Count
+
+    Write-Host " => $s + $a - $r = $f"
+
+    $unshippedFilePath = Join-Path $dir "PublicAPI.Unshipped.txt"
+    $shippedFilePath = Join-Path $dir "PublicAPI.Shipped.txt"
+
+    $results.Filtered | Out-File $shippedFilePath -Encoding Ascii -Force
+    "#nullable enable" | Out-File $unshippedFilePath -Encoding Ascii -Force
+}
+
+function Get-ShippedApiFiles() {
+    Write-Host "Looking for PublicAPI files..."
+    $files = Get-ChildItem "src" -Recurse -Filter "PublicApi.Shipped.txt" -Exclude "artifacts"
+    Write-Host "Found $($files.Count) files."
+    return $files
+}
+
+function Read-AllApiFiles() {
+    $files = Get-ShippedApiFiles
+    $results = @{}
+    $counter = 0
+    Write-Host "Processing [$counter/$($files.Count)]..." -NoNewline
+    foreach ($file in $files) {
+        $counter += 1
+        Write-Host "`rProcessing $file [$counter/$($files.Count)]...                                                                        `r" -NoNewline
+        $results[$file.FullName] = Read-ApiFiles (Split-Path -Parent $file)
+    }
+    Write-Host "`rDone.                                                                                                                                 `r"
+    return $results
+}
+
+if ($BaselineBranch) {
+    $CurrentBranch = git rev-parse --abbrev-ref HEAD
+    Write-Host "Regenerating unshipped PublicAPI files for changes between $BaselineBranch and $CurrentBranch..."
+
+    # get the APIs for the current branch
+    Write-Host "Reading PubilicAPI files for $CurrentBranch..."
+    $currentChanges = Read-AllApiFiles
+
+    # get the APIs for the baseline branch
+    Write-Host "Reading PubilicAPI files for $BaselineBranch..."
+    git checkout $BaselineBranch
+    $baselineChanges = Read-AllApiFiles
+
+    # switch back to the current branch
+    Write-Host "Generating unshipped PublicAPI files..."
+    git checkout $CurrentBranch
+
+    # process the differences between the branches
+    foreach ($file in $currentChanges.Keys) {
+        $dir = (Split-Path -Parent $file)
+        Write-Host "- Processing $dir" -NoNewline
+    
+        # get the changes for this file for each branch
+        $currentFile = $currentChanges[$file]
+        $baselineFile = $baselineChanges[$file]
+
+        # skip any files that don't exist in both branches
+        if (-not $currentFile) {
+            Write-Host " => does not exist in the current branch"
+            continue
+        }
+        if (-not $baselineFile) {
+            Write-Host " => does not exist in the baseline branch"
+            continue
+        }
+
+        # get the APIs for the current and baseline branches
+        $current = $currentFile.Filtered
+        $baseline = $baselineFile.Filtered
+
+        # calculate the changes between the branches
+        $added = $current | Where-Object { -not $baseline.Contains($_) }
+        $removed = $baseline | Where-Object { -not $current.Contains($_) }
+        $both = $added + $removed
+
+        # generate the unshipped file contents
+        $unshipped = @()
+        $unshipped += "#nullable enable"
+        foreach ($item in $both) {
+            if ($added -contains $item) {
+                $unshipped += $item
+            }
+            else {
+                $unshipped += "$removedPrefix$item"
+            }
+        }
+
+        $unshippedFilePath = Join-Path $dir "PublicAPI.Unshipped.txt"
+        $shippedFilePath = Join-Path $dir "PublicAPI.Shipped.txt"
+
+        $baseline | Out-File $shippedFilePath -Encoding Ascii -Force
+        $unshipped | Out-File $unshippedFilePath -Encoding Ascii -Force
+
+        Write-Host " => Done"
+    }
+}
+else {
+    try {
+        $files = Get-ShippedApiFiles
+        Write-Host "Processing files..."
+        foreach ($file in $files) {
+            Move-Shipped (Split-Path -Parent $file)
+        }
+        Write-Host "Processing complete."
+    }
+    catch {
+        Write-Error $_
+        Write-Error $_.Exception
+        exit 1
+    }
 }

--- a/eng/scripts/mark-shipped.ps1
+++ b/eng/scripts/mark-shipped.ps1
@@ -135,7 +135,7 @@ if ($BaselineBranch) {
         # calculate the changes between the branches
         $added = $current | Where-Object { -not $baseline.Contains($_) }
         $removed = $baseline | Where-Object { -not $current.Contains($_) }
-        $both = $added + $removed
+        $both = $added + $removed | Sort-Object -Unique
 
         # generate the unshipped file contents
         $unshipped = @()

--- a/eng/scripts/mark-shipped.ps1
+++ b/eng/scripts/mark-shipped.ps1
@@ -135,7 +135,7 @@ if ($BaselineBranch) {
         # calculate the changes between the branches
         $added = $current | Where-Object { -not $baseline.Contains($_) }
         $removed = $baseline | Where-Object { -not $current.Contains($_) }
-        $both = $added + $removed | Sort-Object -Unique
+        $both = ($added + $removed) | Sort-Object -Unique
 
         # generate the unshipped file contents
         $unshipped = @()


### PR DESCRIPTION
### Description of Change

This PR updates the script to allow for refreshing all the Public API files based on another branch.

For example, after several API updates on two branches being developed in parallel, we may wish to refresh the Public API files so that one branch has the same shipped APIs, and all the different APIs marked as unshipped.

In most cases this should not be needed, however because overrides and removal of non-breaking APIs may cause the branches to become out of sync, we do need this option. In the current situation, `main` had several API "changes" and so did `net9.0`. As a result, many of the changes in `net9.0` were part of the last SR for `main`. This script will compare the shipped APIs of `main` and only mark the added/removed APIs in `net9.0` as unshipped - removing the duplicated change entries.