### PR TITLE
Don't invalidate SuperView if not connected to Window

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/iOS/FrameRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/iOS/FrameRenderer.cs
@@ -204,10 +204,31 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			}
 		}
 
+		bool _pendingSuperViewSetNeedsLayout;
+
 		public override void SetNeedsLayout()
 		{
 			base.SetNeedsLayout();
-			this.Superview?.SetNeedsLayout();
+
+			if (Window is not null)
+			{
+				_pendingSuperViewSetNeedsLayout = false;
+				this.Superview?.SetNeedsLayout();
+			}
+			else{
+				_pendingSuperViewSetNeedsLayout = true;
+			}
+		}
+
+		public override void MovedToWindow()
+		{
+			base.MovedToWindow();
+			if (_pendingSuperViewSetNeedsLayout)
+			{
+				this.Superview?.SetNeedsLayout();
+			}
+
+			_pendingSuperViewSetNeedsLayout = false;
 		}
 
 		[Microsoft.Maui.Controls.Internals.Preserve(Conditional = true)]

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+override Microsoft.Maui.Controls.Handlers.Compatibility.FrameRenderer.MovedToWindow() -> void

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+override Microsoft.Maui.Controls.Handlers.Compatibility.FrameRenderer.MovedToWindow() -> void

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue24434.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue24434.cs
@@ -24,24 +24,17 @@ namespace Maui.Controls.Sample.Issues
 					AutomationId = "ClickMe",
 					Command = new Command(async () =>
 					{
-						TaskCompletionSource taskCompletionSource = new TaskCompletionSource();
-
 						var secondPage = new ContentPage() { Content = new Label() { Text = "I should just disappear" } };
-						secondPage.Unloaded += (_, _) =>
-						{
-							if (taskCompletionSource.Task.IsCompleted)
-							{
-								return;
-							}
-
-							vsl.Add(new Label { Text = "Hello, World!", AutomationId = "Success" });
-							taskCompletionSource.TrySetResult();
-						};
 
 						await Navigation.PushAsync(secondPage);
 						await Navigation.PushModalAsync(new ContentPage() { Content = new Label() { Text = "I should just disappear" } });
 
-						await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5));
+						// Ensure that the VSL is unloaded otherwise the test isn't really valid
+						if (!vsl.IsLoaded)
+						{
+							vsl.Add(new Label { Text = "Hello, World!", AutomationId = "Success" });
+						}
+
 						await Navigation.PopModalAsync();
 						await Navigation.PopAsync();
 					})

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue24434.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue24434.cs
@@ -25,13 +25,20 @@ namespace Maui.Controls.Sample.Issues
 					Command = new Command(async () =>
 					{
 						TaskCompletionSource taskCompletionSource = new TaskCompletionSource();
-						vsl.Unloaded += (_, _) =>
+
+						var secondPage = new ContentPage() { Content = new Label() { Text = "I should just disappear" } };
+						secondPage.Unloaded += (_, _) =>
 						{
+							if (taskCompletionSource.Task.IsCompleted)
+							{
+								return;
+							}
+
 							vsl.Add(new Label { Text = "Hello, World!", AutomationId = "Success" });
 							taskCompletionSource.TrySetResult();
 						};
 
-						await Navigation.PushAsync(new ContentPage() { Content = new Label() { Text = "I should just disappear" } });
+						await Navigation.PushAsync(secondPage);
 						await Navigation.PushModalAsync(new ContentPage() { Content = new Label() { Text = "I should just disappear" } });
 
 						await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5));

--- a/src/Core/src/Platform/iOS/LayoutView.cs
+++ b/src/Core/src/Platform/iOS/LayoutView.cs
@@ -11,14 +11,14 @@ namespace Microsoft.Maui.Platform
 		{
 			InvalidateConstraintsCache();
 			base.SubviewAdded(uiview);
-			this.Superview?.SetNeedsLayout();
+			TryToInvalidateSuperView(false);
 		}
 
 		public override void WillRemoveSubview(UIView uiview)
 		{
 			InvalidateConstraintsCache();
 			base.WillRemoveSubview(uiview);
-			this.Superview?.SetNeedsLayout();
+			TryToInvalidateSuperView(false);
 		}
 
 		public override UIView? HitTest(CGPoint point, UIEvent? uievent)

--- a/src/Core/src/Platform/iOS/MauiView.cs
+++ b/src/Core/src/Platform/iOS/MauiView.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Maui.Platform
 {
 	public abstract class MauiView : UIView, ICrossPlatformLayoutBacking, IVisualTreeElementProvidable, IUIViewLifeCycleEvents
 	{
+		bool _fireSetNeedsLayoutOnParentWhenWindowAttached;
 		static bool? _respondsToSafeArea;
 
 		double _lastMeasureHeight = double.NaN;
@@ -140,7 +141,27 @@ namespace Microsoft.Maui.Platform
 		{
 			InvalidateConstraintsCache();
 			base.SetNeedsLayout();
-			this.Superview?.SetNeedsLayout();
+			TryToInvalidateSuperView(false);
+		}
+
+		private protected void TryToInvalidateSuperView(bool shouldOnlyInvalidateIfPending)
+		{
+			if (shouldOnlyInvalidateIfPending && !_fireSetNeedsLayoutOnParentWhenWindowAttached)
+			{
+				return;
+			}
+
+			// We check for Window to avoid scenarios where an invalidate might propagate up the tree
+			// To a SuperView that's been disposed which will cause a crash when trying to access it
+			if (Window is not null)
+			{
+				this.Superview?.SetNeedsLayout();
+				_fireSetNeedsLayoutOnParentWhenWindowAttached = false;
+			}
+			else
+			{
+				_fireSetNeedsLayoutOnParentWhenWindowAttached = true;
+			}
 		}
 
 		IVisualTreeElement? IVisualTreeElementProvidable.GetElement()
@@ -173,6 +194,7 @@ namespace Microsoft.Maui.Platform
 		{
 			base.MovedToWindow();
 			_movedToWindow?.Invoke(this, EventArgs.Empty);
+			TryToInvalidateSuperView(true);
 		}
 	}
 }

--- a/src/Core/src/Platform/iOS/ViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/ViewExtensions.cs
@@ -267,7 +267,12 @@ namespace Microsoft.Maui.Platform
 		public static void InvalidateMeasure(this UIView platformView, IView view)
 		{
 			platformView.SetNeedsLayout();
-			platformView.Superview?.SetNeedsLayout();
+
+			// MauiView/WrapperView already propagates the SetNeedsLayout to the parent
+			if (platformView is not MauiView && platformView is not WrapperView)
+			{
+				platformView.Superview?.SetNeedsLayout();
+			}
 		}
 
 		public static void UpdateWidth(this UIView platformView, IView view)


### PR DESCRIPTION
### Description of Change

I rolled back these changes on a previous PR because they caused a regression when modifying a layout that's offscreen
https://github.com/dotnet/maui/pull/24477

From testing, I found that the main part that caused a regression was the "setNeedsLayout" changes inside LayoutView. 

It's interesting because now with this [PR](https://github.com/dotnet/maui/pull/23052) the setNeedsLayout calls inside LayoutView aren't really even needed. 

A user reported that they were occasionally still seeing the exception so I've taken a different approach here and have it refire `SetNeedsLayout` on the parent if the view gets reattached to the window.  

### Issues Fixed


Fixes #24032 
