### PR TITLE
Fix layout when MinimumWidth/HeightRequest is removed on Windows

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Layout/LayoutTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Layout/LayoutTests.cs
@@ -495,5 +495,49 @@ namespace Microsoft.Maui.DeviceTests
 				await expectation.AssertEventually(timeout: 2000, message: $"Button did not have expected Width of {expectedWidth}");
 			});
 		}
+
+		[Fact]
+		public async Task MinimumSizeRequestsCanBeCleared()
+		{
+			EnsureHandlerCreated((builder) =>
+			{
+				builder.ConfigureMauiHandlers(handler =>
+				{
+					handler.AddHandler(typeof(Button), typeof(ButtonHandler));
+					handler.AddHandler(typeof(Layout), typeof(LayoutHandler));
+				});
+			});
+
+			var button = new Button()
+			{
+				Text = "X",
+				MinimumWidthRequest = 400,
+				MinimumHeightRequest = 500,
+				HorizontalOptions = LayoutOptions.Start,
+				VerticalOptions = LayoutOptions.Start,
+			};
+
+			var grid = new Grid { button };
+
+			await InvokeOnMainThreadAsync(async () =>
+			{
+				await AttachAndRun(grid, _ =>
+				{
+					// The size should be the minimum requested size, since that will easily hold the "X" text
+					Assert.Equal(400, button.Width, 0.5);
+					Assert.Equal(500, button.Height, 0.5);
+
+					button.ClearValue(VisualElement.MinimumWidthRequestProperty);
+					button.ClearValue(VisualElement.MinimumHeightRequestProperty);
+				});
+
+				await AttachAndRun(grid, _ =>
+				{
+					// The new size should just be enough to hold the "X" text
+					Assert.True(button.Width < 100);
+					Assert.True(button.Height < 100);
+				});
+			});
+		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Layout/LayoutTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Layout/LayoutTests.cs
@@ -511,8 +511,8 @@ namespace Microsoft.Maui.DeviceTests
 			var button = new Button()
 			{
 				Text = "X",
-				MinimumWidthRequest = 400,
-				MinimumHeightRequest = 500,
+				MinimumWidthRequest = 300,
+				MinimumHeightRequest = 200,
 				HorizontalOptions = LayoutOptions.Start,
 				VerticalOptions = LayoutOptions.Start,
 			};
@@ -524,8 +524,8 @@ namespace Microsoft.Maui.DeviceTests
 				await AttachAndRun(grid, _ =>
 				{
 					// The size should be the minimum requested size, since that will easily hold the "X" text
-					Assert.Equal(400, button.Width, 0.5);
-					Assert.Equal(500, button.Height, 0.5);
+					Assert.Equal(300, button.Width, 0.5);
+					Assert.Equal(200, button.Height, 0.5);
 
 					button.ClearValue(VisualElement.MinimumWidthRequestProperty);
 					button.ClearValue(VisualElement.MinimumHeightRequestProperty);

--- a/src/Controls/tests/DeviceTests/Elements/Layout/LayoutTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Layout/LayoutTests.cs
@@ -521,7 +521,7 @@ namespace Microsoft.Maui.DeviceTests
 
 			await InvokeOnMainThreadAsync(async () =>
 			{
-				await AttachAndRun(grid, _ =>
+				await AttachAndRun(grid, async _ =>
 				{
 					// The size should be the minimum requested size, since that will easily hold the "X" text
 					Assert.Equal(300, button.Width, 0.5);
@@ -529,13 +529,9 @@ namespace Microsoft.Maui.DeviceTests
 
 					button.ClearValue(VisualElement.MinimumWidthRequestProperty);
 					button.ClearValue(VisualElement.MinimumHeightRequestProperty);
-				});
 
-				await AttachAndRun(grid, _ =>
-				{
 					// The new size should just be enough to hold the "X" text
-					Assert.True(button.Width < 100);
-					Assert.True(button.Height < 100);
+					await AssertionExtensions.AssertEventually(() => button.Width < 100 && button.Height < 100);
 				});
 			});
 		}

--- a/src/Core/src/Platform/Windows/ViewExtensions.cs
+++ b/src/Core/src/Platform/Windows/ViewExtensions.cs
@@ -195,9 +195,13 @@ namespace Microsoft.Maui.Platform
 
 			if (Dimension.IsMinimumSet(minHeight))
 			{
-				// We only use the minimum value if it's been explicitly set; otherwise, leave it alone
-				// because the platform/theme may have a minimum height for this control
+				// We only use the minimum value if it's been explicitly set; otherwise, clear the local
+				// value so that the platform/theme can use the default minimum height for this control
 				platformView.MinHeight = minHeight;
+			}
+			else
+			{
+				platformView.ClearValue(FrameworkElement.MinHeightProperty);
 			}
 		}
 
@@ -207,9 +211,13 @@ namespace Microsoft.Maui.Platform
 
 			if (Dimension.IsMinimumSet(minWidth))
 			{
-				// We only use the minimum value if it's been explicitly set; otherwise, leave it alone
-				// because the platform/theme may have a minimum width for this control
+				// We only use the minimum value if it's been explicitly set; otherwise, clear the local
+				// value so that the platform/theme can use the default minimum width for this control
 				platformView.MinWidth = minWidth;
+			}
+			else
+			{
+				platformView.ClearValue(FrameworkElement.MinWidthProperty);
 			}
 		}
 


### PR DESCRIPTION
### Description of Change

`ViewExtensions.UpdateMinimumHeight|Width` for WinUI is supposed to update `FrameworkElement.MinHeight|Width` based on the MAUI property `MinimumHeightRequest/MinimumWidthRequest`. But it would completely skip the update when the value was removed, so the previously set value would stay in effect. That locks in the old `FrameworkElement.MinHeight|Width`, and layout doesn't change.

The fix is to remove `FrameworkElement.MinHeight|Width` when `MinimumHeightRequest/MinimumWidthRequest` is removed.

### Issues Fixed

Fixes #24638
