### PR TITLE
Trigger InvalidateMeasure event on CollectionView when content size changes (iOS)

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
@@ -250,17 +250,17 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				{
 					invalidate = true;
 				}
-
-				if (heightChanged && (contentSize.Value.Height < screenHeight || _previousContentSize.Height < screenHeight))
+				else if (heightChanged && (contentSize.Value.Height < screenHeight || _previousContentSize.Height < screenHeight))
 				{
 					invalidate = true;
 				}
 
 				if (invalidate)
 				{
-					(ItemsView as IView)?.InvalidateMeasure();
+					ItemsView.InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
 				}
 			}
+
 			_previousContentSize = contentSize.Value;
 		}
 		


### PR DESCRIPTION
### Description of Change

Problem reported in #21141 has been fixed by #23052 , except for one use case: nested collection view.
The nested `CollectionView` should trigger `MeasureInvalidated` but it's not: it is just triggering `SetNeedsLayout` on the native view.

This PR adds the event triggering so that the parent `TemplatedCell` can react to it.

### Issues Fixed

Fixes #21141
