### PR TITLE
[Android] Failed to inflate ColorStateList  - error fix for CheckBox

### DIFF
--- a/src/Core/src/Platform/Android/Resources/values/styles.xml
+++ b/src/Core/src/Platform/Android/Resources/values/styles.xml
@@ -65,6 +65,8 @@
       <!-- remove all the min sizes as MAUI manages it -->
       <item name="android:minWidth">0dp</item>
       <item name="android:minHeight">0dp</item>
+      <!-- remove the button tint as MAUI manages it -->
+      <item name="buttonTint">?attr/colorPrimary</item>
     </style>
 
     <style name="MauiAlertDialogTheme" parent="ThemeOverlay.MaterialComponents.MaterialAlertDialog">


### PR DESCRIPTION
### Description

In the styles.xml file, I noticed that `Widget.Material3.CompoundButton.CheckBox` is set as the parent for `MauiCheckBox`. However, Maui.MainTheme has `Theme.MaterialComponents.DayNight` as its parent.

After changing the parent of `Maui.MainTheme` to `Theme.Material3.DayNight.NoActionBar`, the error disappeared, but I had some reservations about whether that was the right solution.

So I dug deeper and found in `src/Core/AndroidNative/maui/build/intermediates/incremental/release/mergeReleaseResources/merger.xml` the following code

```
<style name="Base.Widget.Material3.CompoundButton.CheckBox" parent="Widget.MaterialComponents.CompoundButton.CheckBox">
    
    <item name="android:textAppearance">?attr/textAppearanceBodyMedium</item>
    <item name="errorAccessibilityLabel">@string/error_a11y_label</item>
    <item name="buttonTint">@color/m3_checkbox_button_tint</item>
    <item name="buttonIconTint">@color/m3_checkbox_button_icon_tint</item>
    <item name="buttonIcon">@null</item>
</style>
```

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/18897
Fixes https://github.com/dotnet/maui/issues/24602

|Before|After|
|--|--|
|<img src="https://github.com/user-attachments/assets/1dee07ba-c063-41d5-a971-89b550daf247" width="300px"/>|<img src="https://github.com/user-attachments/assets/1f2cab9d-890b-4f31-ba1c-9684fcec4cc9" width="300px"/>|
