### PR TITLE
Revert "[X] do not apply Bindings if DataType doesnt match (#22056)"

### DIFF
--- a/src/Controls/src/Core/Binding.cs
+++ b/src/Controls/src/Core/Binding.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;
 using System.Reflection;
-using Microsoft.Maui.Controls.Xaml.Diagnostics;
 
 namespace Microsoft.Maui.Controls
 {
@@ -106,8 +105,6 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		internal Type DataType { get; set; }
-
 		internal override void Apply(bool fromTarget)
 		{
 			base.Apply(fromTarget);
@@ -123,14 +120,7 @@ namespace Microsoft.Maui.Controls
 			object src = _source;
 			var isApplied = IsApplied;
 
-			var bindingContext = src ?? Context ?? context;
-			if (DataType != null && bindingContext != null && !DataType.IsAssignableFrom(bindingContext.GetType()))
-			{
-				BindingDiagnostics.SendBindingFailure(this, "Binding", "Mismatch between the specified x:DataType and the current binding context");
-				bindingContext = null;
-			}
-
-			base.Apply(bindingContext, bindObj, targetProperty, fromBindingContextChanged, specificity);
+			base.Apply(src ?? context, bindObj, targetProperty, fromBindingContextChanged, specificity);
 
 			if (src != null && isApplied && fromBindingContextChanged)
 				return;
@@ -141,6 +131,7 @@ namespace Microsoft.Maui.Controls
 			}
 			else
 			{
+				object bindingContext = src ?? Context ?? context;
 				if (_expression == null)
 					_expression = new BindingExpression(this, SelfPath);
 				_expression.Apply(bindingContext, bindObj, targetProperty, specificity);

--- a/src/Controls/src/Core/IXamlDataTypeProvider.cs
+++ b/src/Controls/src/Core/IXamlDataTypeProvider.cs
@@ -1,5 +1,0 @@
-namespace Microsoft.Maui.Controls.Xaml;
-interface IXamlDataTypeProvider
-{
-	string BindingDataType { get; }
-}

--- a/src/Controls/src/Xaml/MarkupExtensions/BindingExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/BindingExtension.cs
@@ -1,11 +1,11 @@
 using System;
 using System.ComponentModel;
-using System.Linq.Expressions;
 using Microsoft.Maui.Controls.Internals;
 
 namespace Microsoft.Maui.Controls.Xaml
 {
 	[ContentProperty(nameof(Path))]
+	[AcceptEmptyServiceProvider]
 	public sealed class BindingExtension : IMarkupExtension<BindingBase>
 	{
 		public string Path { get; set; } = Binding.SelfPath;
@@ -21,22 +21,13 @@ namespace Microsoft.Maui.Controls.Xaml
 
 		BindingBase IMarkupExtension<BindingBase>.ProvideValue(IServiceProvider serviceProvider)
 		{
-			if (TypedBinding is null) {
-				Type bindingXDataType = null;
-				if ((serviceProvider.GetService(typeof(IXamlTypeResolver)) is IXamlTypeResolver typeResolver)
-					&& (serviceProvider.GetService(typeof(IXamlDataTypeProvider)) is IXamlDataTypeProvider dataTypeProvider)
-					&& dataTypeProvider.BindingDataType != null)
-				{
-					typeResolver.TryResolve(dataTypeProvider.BindingDataType, out bindingXDataType);
-				}
+			if (TypedBinding == null)
 				return new Binding(Path, Mode, Converter, ConverterParameter, StringFormat, Source)
 				{
 					UpdateSourceEventName = UpdateSourceEventName,
 					FallbackValue = FallbackValue,
 					TargetNullValue = TargetNullValue,
-					DataType = bindingXDataType,
 				};
-			}
 
 			TypedBinding.Mode = Mode;
 			TypedBinding.Converter = Converter;

--- a/src/Controls/src/Xaml/XamlServiceProvider.cs
+++ b/src/Controls/src/Xaml/XamlServiceProvider.cs
@@ -27,9 +27,6 @@ namespace Microsoft.Maui.Controls.Xaml.Internals
 				IXmlLineInfoProvider = new XmlLineInfoProvider(xmlLineInfo);
 
 			IValueConverterProvider = new ValueConverterProvider();
-
-			if (node is IElementNode elementNode)
-				Add(typeof(IXamlDataTypeProvider), new XamlDataTypeProvider(elementNode));
 		}
 
 		public XamlServiceProvider() => IValueConverterProvider = new ValueConverterProvider();
@@ -264,58 +261,5 @@ namespace Microsoft.Maui.Controls.Xaml.Internals
 
 		public string LookupPrefix(string namespaceName) => throw new NotImplementedException();
 		public void Add(string prefix, string ns) => namespaces.Add(prefix, ns);
-	}
-
-	class XamlDataTypeProvider : IXamlDataTypeProvider
-	{
-		public XamlDataTypeProvider(IElementNode node)
-		{
-			static IElementNode GetParent(IElementNode node)
-			{
-				return node switch
-				{
-					{ Parent: ListNode { Parent: IElementNode parentNode } } => parentNode,
-					{ Parent: IElementNode parentNode } => parentNode,
-					_ => null,
-				};
-			}
-
-			static bool IsBindingContextBinding(IElementNode node)
-			{
-				if (   ApplyPropertiesVisitor.TryGetPropertyName(node, node.Parent, out XmlName name)
-					&& name.NamespaceURI == ""
-					&& name.LocalName == nameof(BindableObject.BindingContext))
-					return true;
-				return false;
-			}
-
-			INode dataTypeNode = null;
-			IElementNode n = node as IElementNode;
-
-			// Special handling for BindingContext={Binding ...}
-			// The order of checks is:
-			// - x:DataType on the binding itself
-			// - SKIP looking for x:DataType on the parent
-			// - continue looking for x:DataType on the parent's parent...
-			IElementNode skipNode = null;
-			if (IsBindingContextBinding(node))
-			{
-				skipNode = GetParent(node);
-			}
-
-			while (n != null)
-			{
-				if (n != skipNode && n.Properties.TryGetValue(XmlName.xDataType, out dataTypeNode))
-				{
-					break;
-				}
-
-				n = GetParent(n);
-			}
-			if (dataTypeNode is ValueNode valueNode)
-				BindingDataType = valueNode.Value as string;
-
-		}
-		public string BindingDataType { get; }
 	}
 }

--- a/src/Controls/tests/Xaml.UnitTests/BindingsCompiler.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/BindingsCompiler.xaml.cs
@@ -28,9 +28,10 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		{
 			[SetUp] public void Setup() => DispatcherProvider.SetCurrent(new DispatcherProviderStub());
 			[TearDown] public void TearDown() => DispatcherProvider.SetCurrent(null);
-			
-			[Test] 
-			public void TestCompiledBindings([Values(false, true)]bool useCompiledXaml)
+
+			[TestCase(false)]
+			[TestCase(true)]
+			public void Test(bool useCompiledXaml)
 			{
 				if (useCompiledXaml)
 					MockCompiler.Compile(typeof(BindingsCompiler));
@@ -115,13 +116,6 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 				//testing invalid bindingcontext type
 				layout.BindingContext = new object();
 				Assert.AreEqual(null, layout.label0.Text);
-			}
-			
-			[Test] 
-			public void BindingsNotAppliedWithWrongContext([Values(false, true)]bool useCompiledXaml)
-			{
-				var page = new BindingsCompiler(useCompiledXaml) { BindingContext = new {Text="Foo"} };
-				Assert.AreEqual(null, page.label0.Text);
 			}
 		}
 	}


### PR DESCRIPTION
### Description of Change

This reverts commit cb0a332557641bf01de5d10d08ce188b5f3a5989.

Unfortunately, we haven't been able to get the fix for this one merged before needing to release SR9
https://github.com/dotnet/maui/issues/23989

We're going to leave this fix out of NET8 and this will only apply for NET9