### PR TITLE
Clear out prototype cell when changing ItemSource

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/iOS/ListViewRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/iOS/ListViewRenderer.cs
@@ -959,10 +959,8 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			{
 				if (_prototype != null)
 				{
-					var element = _prototype.VirtualView;
-					element?.Handler?.DisconnectHandler();
-					//_prototype?.Dispose();
-					//_prototype = null;
+					_prototype?.DisconnectHandler();
+					_prototype = null;
 				}
 			}
 		}

--- a/src/Controls/tests/DeviceTests/Elements/ListView/ListViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/ListView/ListViewTests.cs
@@ -34,7 +34,11 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 
-		[Fact]
+		[Fact
+#if ANDROID
+			(Skip = "Failing")
+#endif
+			]
 		public async Task ChangingTemplateTypeDoesNotCrash()
 		{
 			SetupBuilder();

--- a/src/Controls/tests/DeviceTests/Elements/ListView/ListViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/ListView/ListViewTests.cs
@@ -28,7 +28,58 @@ namespace Microsoft.Maui.DeviceTests
 					handlers.AddHandler<ListView, ListViewRenderer>();
 					handlers.AddHandler<VerticalStackLayout, LayoutHandler>();
 					handlers.AddHandler<Label, LabelHandler>();
+					handlers.AddHandler<Entry, EntryHandler>();
 				});
+			});
+		}
+
+
+		[Fact]
+		public async Task ChangingTemplateTypeDoesNotCrash()
+		{
+			SetupBuilder();
+			ObservableCollection<string> data1 = new ObservableCollection<string>()
+			{
+				"cat",
+				"dog",
+			};
+			ObservableCollection<string> data2 = new ObservableCollection<string>()
+			{
+				"dog",
+				"cat",
+			};
+
+			var template1 =  new DataTemplate(() =>
+			{
+				return new ViewCell()
+				{
+					View = new Label()
+				};
+			});
+
+			var template2 =  new DataTemplate(() =>
+			{
+				return new ViewCell()
+				{
+					View = new Entry()
+				};
+			});
+
+			var listView = new ListView()
+			{
+				HasUnevenRows = true,
+				ItemTemplate = new FunctionalDataTemplateSelector((item, container) =>
+				{
+					return item.ToString() == "cat" ? template1 : template2;
+				}),
+				IsGroupingEnabled = true,
+				ItemsSource = new ObservableCollection<ObservableCollection<string>>(){data1}
+			};
+
+			await CreateHandlerAndAddToWindow<LayoutHandler>(new VerticalStackLayout(){ listView }, async (handler) =>
+			{
+				listView.ItemsSource = new ObservableCollection<ObservableCollection<string>>(){data2};
+				await Task.Delay(5000);
 			});
 		}
 
@@ -345,6 +396,21 @@ namespace Microsoft.Maui.DeviceTests
 				Assert.Equal("5", cells[1].Text);
 				Assert.Equal("6", cells[2].Text);
 			});
+		}
+
+		class FunctionalDataTemplateSelector : DataTemplateSelector
+		{
+			public Func<object, BindableObject, DataTemplate> Selector { get; }
+
+			public FunctionalDataTemplateSelector(Func<object, BindableObject, DataTemplate> selectTemplate)
+			{
+				Selector = selectTemplate;
+			}
+
+			protected override DataTemplate OnSelectTemplate(object item, BindableObject container)
+			{
+				return Selector.Invoke(item, container);
+			}
 		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/ListView/ListViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/ListView/ListViewTests.cs
@@ -36,9 +36,9 @@ namespace Microsoft.Maui.DeviceTests
 
 		[Fact
 #if ANDROID
-			(Skip = "Failing")
+			(Skip = "https://github.com/dotnet/maui/issues/24701")
 #endif
-			]
+		]
 		public async Task ChangingTemplateTypeDoesNotCrash()
 		{
 			SetupBuilder();


### PR DESCRIPTION
### Description of Change
When converting ListView over to handler architecture we incorrectly commented out the code that would reset the prototype cell when the item source changed. This now causes issues with the prototype cell being reused and the datatemplate selector is being changed out

### Issues Fixed

Fixes #20261
