### PR TITLE
Create PlatformElementFactory to ElementHandler

### DIFF
--- a/src/Core/src/Handlers/Element/ElementHandlerOfT.cs
+++ b/src/Core/src/Handlers/Element/ElementHandlerOfT.cs
@@ -32,6 +32,8 @@ namespace Microsoft.Maui.Handlers
 
 		object? IElementHandler.PlatformView => base.PlatformView;
 
+		public static Func<ElementHandler<TVirtualView, TPlatformView>, TPlatformView>? PlatformElementFactory { get; set; }
+
 		protected abstract TPlatformView CreatePlatformElement();
 
 		protected virtual void ConnectHandler(TPlatformView platformView)
@@ -43,7 +45,7 @@ namespace Microsoft.Maui.Handlers
 		}
 
 		private protected override object OnCreatePlatformElement() =>
-			CreatePlatformElement();
+			PlatformElementFactory?.Invoke(this) ?? CreatePlatformElement();
 
 		private protected override void OnConnectHandler(object platformView) =>
 			ConnectHandler((TPlatformView)platformView);

--- a/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -47,6 +47,8 @@ override Microsoft.Maui.Handlers.HybridWebViewHandler.DisconnectHandler(Android.
 override Microsoft.Maui.Platform.MauiHybridWebViewClient.Dispose(bool disposing) -> void
 override Microsoft.Maui.Platform.MauiHybridWebViewClient.ShouldInterceptRequest(Android.Webkit.WebView? view, Android.Webkit.IWebResourceRequest? request) -> Android.Webkit.WebResourceResponse?
 override Microsoft.Maui.Platform.MauiWebViewClient.OnRenderProcessGone(Android.Webkit.WebView? view, Android.Webkit.RenderProcessGoneDetail? detail) -> bool
+static Microsoft.Maui.Handlers.ElementHandler<TVirtualView, TPlatformView>.PlatformElementFactory.get -> System.Func<Microsoft.Maui.Handlers.ElementHandler<TVirtualView!, TPlatformView!>!, TPlatformView!>?
+static Microsoft.Maui.Handlers.ElementHandler<TVirtualView, TPlatformView>.PlatformElementFactory.set -> void
 static Microsoft.Maui.ElementHandlerExtensions.GetRequiredService<T>(this Microsoft.Maui.IElementHandler! handler, System.Type! type) -> T
 static Microsoft.Maui.ElementHandlerExtensions.GetRequiredService<T>(this Microsoft.Maui.IElementHandler! handler) -> T
 static Microsoft.Maui.ElementHandlerExtensions.GetService<T>(this Microsoft.Maui.IElementHandler! handler, System.Type! type) -> T?

--- a/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -42,6 +42,8 @@ Microsoft.Maui.WebProcessTerminatedEventArgs.Sender.get -> WebKit.WKWebView!
 override Microsoft.Maui.Handlers.HybridWebViewHandler.ConnectHandler(WebKit.WKWebView! platformView) -> void
 override Microsoft.Maui.Handlers.HybridWebViewHandler.CreatePlatformView() -> WebKit.WKWebView!
 override Microsoft.Maui.Handlers.HybridWebViewHandler.DisconnectHandler(WebKit.WKWebView! platformView) -> void
+static Microsoft.Maui.Handlers.ElementHandler<TVirtualView, TPlatformView>.PlatformElementFactory.get -> System.Func<Microsoft.Maui.Handlers.ElementHandler<TVirtualView!, TPlatformView!>!, TPlatformView!>?
+static Microsoft.Maui.Handlers.ElementHandler<TVirtualView, TPlatformView>.PlatformElementFactory.set -> void
 static Microsoft.Maui.ElementHandlerExtensions.GetRequiredService<T>(this Microsoft.Maui.IElementHandler! handler, System.Type! type) -> T
 static Microsoft.Maui.ElementHandlerExtensions.GetRequiredService<T>(this Microsoft.Maui.IElementHandler! handler) -> T
 static Microsoft.Maui.ElementHandlerExtensions.GetService<T>(this Microsoft.Maui.IElementHandler! handler, System.Type! type) -> T?

--- a/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -42,6 +42,8 @@ Microsoft.Maui.WebProcessTerminatedEventArgs.Sender.get -> WebKit.WKWebView!
 override Microsoft.Maui.Handlers.HybridWebViewHandler.ConnectHandler(WebKit.WKWebView! platformView) -> void
 override Microsoft.Maui.Handlers.HybridWebViewHandler.CreatePlatformView() -> WebKit.WKWebView!
 override Microsoft.Maui.Handlers.HybridWebViewHandler.DisconnectHandler(WebKit.WKWebView! platformView) -> void
+static Microsoft.Maui.Handlers.ElementHandler<TVirtualView, TPlatformView>.PlatformElementFactory.get -> System.Func<Microsoft.Maui.Handlers.ElementHandler<TVirtualView!, TPlatformView!>!, TPlatformView!>?
+static Microsoft.Maui.Handlers.ElementHandler<TVirtualView, TPlatformView>.PlatformElementFactory.set -> void
 static Microsoft.Maui.ElementHandlerExtensions.GetRequiredService<T>(this Microsoft.Maui.IElementHandler! handler, System.Type! type) -> T
 static Microsoft.Maui.ElementHandlerExtensions.GetRequiredService<T>(this Microsoft.Maui.IElementHandler! handler) -> T
 static Microsoft.Maui.ElementHandlerExtensions.GetService<T>(this Microsoft.Maui.IElementHandler! handler, System.Type! type) -> T?

--- a/src/Core/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -33,6 +33,8 @@ Microsoft.Maui.TextAlignment.Justify = 3 -> Microsoft.Maui.TextAlignment
 Microsoft.Maui.WebProcessTerminatedEventArgs
 Microsoft.Maui.WebProcessTerminatedEventArgs.WebProcessTerminatedEventArgs() -> void
 override Microsoft.Maui.Handlers.HybridWebViewHandler.CreatePlatformView() -> Tizen.NUI.BaseComponents.View!
+static Microsoft.Maui.Handlers.ElementHandler<TVirtualView, TPlatformView>.PlatformElementFactory.get -> System.Func<Microsoft.Maui.Handlers.ElementHandler<TVirtualView!, TPlatformView!>!, TPlatformView!>?
+static Microsoft.Maui.Handlers.ElementHandler<TVirtualView, TPlatformView>.PlatformElementFactory.set -> void
 static Microsoft.Maui.ElementHandlerExtensions.GetRequiredService<T>(this Microsoft.Maui.IElementHandler! handler, System.Type! type) -> T
 static Microsoft.Maui.ElementHandlerExtensions.GetRequiredService<T>(this Microsoft.Maui.IElementHandler! handler) -> T
 static Microsoft.Maui.ElementHandlerExtensions.GetService<T>(this Microsoft.Maui.IElementHandler! handler, System.Type! type) -> T?

--- a/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -41,6 +41,8 @@ Microsoft.Maui.WebProcessTerminatedEventArgs.Sender.get -> Microsoft.Web.WebView
 override Microsoft.Maui.Handlers.HybridWebViewHandler.ConnectHandler(Microsoft.UI.Xaml.Controls.WebView2! platformView) -> void
 override Microsoft.Maui.Handlers.HybridWebViewHandler.CreatePlatformView() -> Microsoft.UI.Xaml.Controls.WebView2!
 override Microsoft.Maui.Handlers.HybridWebViewHandler.DisconnectHandler(Microsoft.UI.Xaml.Controls.WebView2! platformView) -> void
+static Microsoft.Maui.Handlers.ElementHandler<TVirtualView, TPlatformView>.PlatformElementFactory.get -> System.Func<Microsoft.Maui.Handlers.ElementHandler<TVirtualView!, TPlatformView!>!, TPlatformView!>?
+static Microsoft.Maui.Handlers.ElementHandler<TVirtualView, TPlatformView>.PlatformElementFactory.set -> void
 static Microsoft.Maui.ElementHandlerExtensions.GetRequiredService<T>(this Microsoft.Maui.IElementHandler! handler, System.Type! type) -> T
 static Microsoft.Maui.ElementHandlerExtensions.GetRequiredService<T>(this Microsoft.Maui.IElementHandler! handler) -> T
 static Microsoft.Maui.ElementHandlerExtensions.GetService<T>(this Microsoft.Maui.IElementHandler! handler, System.Type! type) -> T?

--- a/src/Core/src/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -40,6 +40,8 @@ static Microsoft.Maui.ElementHandlerExtensions.GetService<T>(this Microsoft.Maui
 static Microsoft.Maui.ElementHandlerExtensions.GetServiceProvider(this Microsoft.Maui.IElementHandler! handler) -> System.IServiceProvider!
 static Microsoft.Maui.ElementHandlerExtensions.IsConnected(this Microsoft.Maui.IElementHandler! handler) -> bool
 static Microsoft.Maui.Handlers.ApplicationHandler.MapActivateWindow(Microsoft.Maui.Handlers.ApplicationHandler! handler, Microsoft.Maui.IApplication! application, object? args) -> void
+static Microsoft.Maui.Handlers.ElementHandler<TVirtualView, TPlatformView>.PlatformElementFactory.get -> System.Func<Microsoft.Maui.Handlers.ElementHandler<TVirtualView!, TPlatformView!>!, TPlatformView!>?
+static Microsoft.Maui.Handlers.ElementHandler<TVirtualView, TPlatformView>.PlatformElementFactory.set -> void
 static Microsoft.Maui.Handlers.HybridWebViewHandler.CommandMapper -> Microsoft.Maui.CommandMapper<Microsoft.Maui.IHybridWebView!, Microsoft.Maui.Handlers.IHybridWebViewHandler!>!
 static Microsoft.Maui.Handlers.HybridWebViewHandler.MapEvaluateJavaScriptAsync(Microsoft.Maui.Handlers.IHybridWebViewHandler! handler, Microsoft.Maui.IHybridWebView! hybridWebView, object? arg) -> void
 static Microsoft.Maui.Handlers.HybridWebViewHandler.Mapper -> Microsoft.Maui.IPropertyMapper<Microsoft.Maui.IHybridWebView!, Microsoft.Maui.Handlers.IHybridWebViewHandler!>!
@@ -48,3 +50,4 @@ static Microsoft.Maui.Keyboard.Date.get -> Microsoft.Maui.Keyboard!
 static Microsoft.Maui.Keyboard.Password.get -> Microsoft.Maui.Keyboard!
 static Microsoft.Maui.Keyboard.Time.get -> Microsoft.Maui.Keyboard!
 static Microsoft.Maui.ViewExtensions.DisconnectHandlers(this Microsoft.Maui.IView! view) -> void
+

--- a/src/Core/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -33,6 +33,8 @@ Microsoft.Maui.TextAlignment.Justify = 3 -> Microsoft.Maui.TextAlignment
 Microsoft.Maui.WebProcessTerminatedEventArgs
 Microsoft.Maui.WebProcessTerminatedEventArgs.WebProcessTerminatedEventArgs() -> void
 override Microsoft.Maui.Handlers.HybridWebViewHandler.CreatePlatformView() -> object!
+static Microsoft.Maui.Handlers.ElementHandler<TVirtualView, TPlatformView>.PlatformElementFactory.get -> System.Func<Microsoft.Maui.Handlers.ElementHandler<TVirtualView!, TPlatformView!>!, TPlatformView!>?
+static Microsoft.Maui.Handlers.ElementHandler<TVirtualView, TPlatformView>.PlatformElementFactory.set -> void
 static Microsoft.Maui.ElementHandlerExtensions.GetRequiredService<T>(this Microsoft.Maui.IElementHandler! handler, System.Type! type) -> T
 static Microsoft.Maui.ElementHandlerExtensions.GetRequiredService<T>(this Microsoft.Maui.IElementHandler! handler) -> T
 static Microsoft.Maui.ElementHandlerExtensions.GetService<T>(this Microsoft.Maui.IElementHandler! handler, System.Type! type) -> T?

--- a/src/Core/src/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -33,6 +33,8 @@ Microsoft.Maui.TextAlignment.Justify = 3 -> Microsoft.Maui.TextAlignment
 Microsoft.Maui.WebProcessTerminatedEventArgs
 Microsoft.Maui.WebProcessTerminatedEventArgs.WebProcessTerminatedEventArgs() -> void
 override Microsoft.Maui.Handlers.HybridWebViewHandler.CreatePlatformView() -> object!
+static Microsoft.Maui.Handlers.ElementHandler<TVirtualView, TPlatformView>.PlatformElementFactory.get -> System.Func<Microsoft.Maui.Handlers.ElementHandler<TVirtualView!, TPlatformView!>!, TPlatformView!>?
+static Microsoft.Maui.Handlers.ElementHandler<TVirtualView, TPlatformView>.PlatformElementFactory.set -> void
 static Microsoft.Maui.ElementHandlerExtensions.GetRequiredService<T>(this Microsoft.Maui.IElementHandler! handler, System.Type! type) -> T
 static Microsoft.Maui.ElementHandlerExtensions.GetRequiredService<T>(this Microsoft.Maui.IElementHandler! handler) -> T
 static Microsoft.Maui.ElementHandlerExtensions.GetService<T>(this Microsoft.Maui.IElementHandler! handler, System.Type! type) -> T?

--- a/src/Core/tests/UnitTests/ElementHandlerTests.cs
+++ b/src/Core/tests/UnitTests/ElementHandlerTests.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Core.UnitTests.TestClasses;
+using Microsoft.Maui.UnitTests;
+using Xunit;
+
+namespace Core.UnitTests
+{
+
+	[Category(TestCategory.Core)]
+	public class ElementHandlerTests
+	{
+		[Fact]
+		public void CreatePlatformElementUsingPlatformElementFactory()
+		{
+			ElementHandlerStub.PlatformElementFactory = handler => new CustomPlatformCell();
+
+			var elementStub = new ElementHandlerStub();
+			elementStub.SetVirtualView(new Microsoft.Maui.Controls.TextCell());
+
+			Assert.NotNull(elementStub.PlatformView);
+			Assert.True(elementStub.PlatformView is CustomPlatformCell);
+		}
+
+		[Fact]
+		public void FactoryCanPuntAndUseOriginalType()
+		{
+			ElementHandlerStub.PlatformElementFactory = (h) => { return null; };
+
+			var handlerStub = new ElementHandlerStub();
+			handlerStub.SetVirtualView(new Microsoft.Maui.Controls.TextCell());
+
+			Assert.NotNull(handlerStub.PlatformView);
+			Assert.False(handlerStub.PlatformView is CustomPlatformCell);
+			Assert.True(handlerStub.PlatformView is object);
+		}
+	}
+
+
+
+	class CustomPlatformCell : object
+	{
+
+	}
+
+}

--- a/src/Core/tests/UnitTests/TestClasses/ElementHandlerStub.cs
+++ b/src/Core/tests/UnitTests/TestClasses/ElementHandlerStub.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Maui;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Hosting;
+
+namespace Core.UnitTests.TestClasses
+{
+	class ElementHandlerStub : ElementHandler<Microsoft.Maui.Controls.Cell, object>
+	{
+		public ElementHandlerStub(IPropertyMapper mapper, CommandMapper commandMapper = null) : base(mapper, commandMapper)
+		{
+		}
+
+		public ElementHandlerStub() : base(new PropertyMapper<IView>())
+		{
+
+		}
+
+		protected override object CreatePlatformElement()
+		{
+			return new object();
+		}
+	}
+}


### PR DESCRIPTION
This PR adds ability to easily override the PlatformElement for ElementHandler, on ViewHandler we have the PlatformViewFactory as a way to override platform view that will be used by it. Now I'm adding this extension to ElementHandler as well.
