### PR TITLE
[Android] Fix Flickering issue when calling Navigation.PopAsync

### DIFF
--- a/src/Controls/src/Core/NavigationPage/NavigationPage.cs
+++ b/src/Controls/src/Core/NavigationPage/NavigationPage.cs
@@ -402,9 +402,6 @@ namespace Microsoft.Maui.Controls
 		void RemoveFromInnerChildren(Element page)
 		{
 			InternalChildren.Remove(page);
-
-			// TODO For NET9 we should remove this because the DisconnectHandlers will take care of it
-			page.Handler = null;
 		}
 
 		void SafePop()


### PR DESCRIPTION
### Root Cause
The flickering during navigation occurred because, when performing PopAsync, the removed page’s handlers were set to null. This caused flickering as the navigation was processed.

### Description of Change
The fix involves avoiding the removal of page handlers during PopAsync, which eliminates the flickering issue during navigation.

### Validated the behaviour in the following platforms
 
- [x] Android
- [ ] Windows
- [ ] iOS
- [ ] Mac

### Issues Fixed
Fixes #13810

### Screenshots
 
Before

https://github.com/user-attachments/assets/f0592d6d-6b89-48b0-bab8-eed46d20336c

After

https://github.com/user-attachments/assets/b47e24f4-68f0-44a0-b1bf-ed8dd24d1dcf
