### PR TITLE
[Localization] Remove check not allowing translations to run on net9.0

### DIFF
--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -291,7 +291,6 @@ stages:
         RunPlatforms: ${{ parameters.RunTemplatePlatforms }}
         BuildPlatforms: ${{ parameters.BuilTemplatePlatforms }}
 
-  - ${{ if eq(variables['System.TeamProject'], 'devdiv') }}:
-    - template: common/localization-handoff.yml                     # Process outgoing strings [Localization Handoff]
-    - template: common/localization-handback.yml                    # Process incoming translations and Create PR to main [Localization Handback]
-    - template: common/merge-translations-update.yml                # Validating incoming translations strings and merge PR [Localization Handback]
+  - template: common/localization-handoff.yml                     # Process outgoing strings [Localization Handoff]
+  - template: common/localization-handback.yml                    # Process incoming translations and Create PR to main [Localization Handback]
+  - template: common/merge-translations-update.yml                # Validating incoming translations strings and merge PR [Localization Handback]


### PR DESCRIPTION
### Description of Change

<!-- Enter description of the fix in this section -->
In the net9.0 branch, the translations section is not being applied. `- ${{ if eq(variables['System.TeamProject'], 'devdiv') }}:` being false caused the localization templates not to be run. I'm not sure if we need to replace this with something else but I think it should work as this PR has it since that templates all have their own checks on whether to run.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
