### PR TITLE
Setting Background to null will update rendering on Android and iOS

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Label/LabelTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Label/LabelTests.cs
@@ -335,6 +335,35 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
+		[Fact]
+		public async Task SetBackgroundToNullAffectsRendering()
+		{
+			SetupBuilder();
+
+			Label label;
+			var layout = new VerticalStackLayout
+			{
+				(label = new Label
+				{
+					WidthRequest = 200,
+					HeightRequest = 100,
+					Text = "Label",
+					TextColor = Colors.Red,
+					Background = new SolidColorBrush(Colors.Blue),
+				})
+			};
+
+			await AttachAndRun(layout, async (handler) =>
+			{
+				var platformView = handler.ToPlatform();
+				await platformView.AssertContainsColor(Colors.Blue, MauiContext);
+
+				label.Background = null;
+
+				await platformView.AssertDoesNotContainColor(Colors.Blue, MauiContext);
+			});
+		}
+
 		[Theory(
 #if WINDOWS
 		Skip = "Fails on Windows"

--- a/src/Core/src/Platform/Android/ViewExtensions.cs
+++ b/src/Core/src/Platform/Android/ViewExtensions.cs
@@ -271,36 +271,29 @@ namespace Microsoft.Maui.Platform
 		{
 			var paint = background;
 
-			if (!paint.IsNullOrEmpty())
-			{
-				// Remove previous background gradient if any
-				if (platformView.Background is MauiDrawable mauiDrawable)
-				{
-					platformView.Background = null;
-					mauiDrawable.Dispose();
-				}
+			// Remove previous background gradient if any
+			(platformView.Background as MauiDrawable)?.Dispose();
 
-				if (treatTransparentAsNull && paint.IsTransparent())
-				{
-					// For controls where android treats transparent as null it's more
-					// performant to just set the background to null instead of
-					// giving it a transparent color/drawable
-					platformView.Background = null;
-				}
-				else if (paint is SolidPaint solidPaint)
-				{
-					if (solidPaint.Color is Color backgroundColor)
-						platformView.SetBackgroundColor(backgroundColor.ToPlatform());
-				}
-				else
-				{
-					if (paint!.ToDrawable(platformView.Context) is Drawable drawable)
-						platformView.Background = drawable;
-				}
-			}
-			else if (platformView is LayoutViewGroup)
+			if (paint.IsNullOrEmpty())
 			{
 				platformView.Background = null;
+			}
+			else if (treatTransparentAsNull && paint.IsTransparent())
+			{
+				// For controls where android treats transparent as null it's more
+				// performant to just set the background to null instead of
+				// giving it a transparent color/drawable
+				platformView.Background = null;
+			}
+			else if (paint is SolidPaint solidPaint)
+			{
+				if (solidPaint.Color is Color backgroundColor)
+					platformView.SetBackgroundColor(backgroundColor.ToPlatform());
+			}
+			else
+			{
+				if (paint!.ToDrawable(platformView.Context) is Drawable drawable)
+					platformView.Background = drawable;
 			}
 		}
 

--- a/src/Core/src/Platform/iOS/ViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/ViewExtensions.cs
@@ -77,14 +77,9 @@ namespace Microsoft.Maui.Platform
 
 			if (paint.IsNullOrEmpty())
 			{
-				if (platformView is LayoutView)
-					platformView.BackgroundColor = null;
-				else
-					return;
+				platformView.BackgroundColor = null;
 			}
-
-
-			if (paint is SolidPaint solidPaint)
+			else if (paint is SolidPaint solidPaint)
 			{
 				Color backgroundColor = solidPaint.Color;
 
@@ -92,8 +87,6 @@ namespace Microsoft.Maui.Platform
 					platformView.BackgroundColor = ColorExtensions.BackgroundColor;
 				else
 					platformView.BackgroundColor = backgroundColor.ToPlatform();
-
-				return;
 			}
 			else if (paint is GradientPaint gradientPaint)
 			{


### PR DESCRIPTION
### Description of Change

When Background was set to null for some ViewElements, the Background of the platform element wasn't updated at all for Android and iOS. I just removed the "if" check that skipped setting Background to null.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #24725
Fixes #22914 

(maybe more if you look at similar bugs linked in those bugs)

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
