### PR TITLE
[Android] - Fixed Flickering Issue When Toggling WebView Visibility

### DIFF
--- a/src/Core/src/Handlers/WebView/WebViewHandler.Android.cs
+++ b/src/Core/src/Handlers/WebView/WebViewHandler.Android.cs
@@ -20,34 +20,18 @@ namespace Microsoft.Maui.Handlers
 
 		protected internal string? UrlCanceled { get; set; }
 
-		private MauiWebView? platformView;
 		protected override AWebView CreatePlatformView()
 		{
-			platformView = new MauiWebView(this, Context!);
+			var platformView = new MauiWebView(this, Context!)
+			{
+				LayoutParameters = new LayoutParams(LayoutParams.MatchParent, LayoutParams.MatchParent)
+			};
+
 			platformView.Settings.JavaScriptEnabled = true;
 			platformView.Settings.DomStorageEnabled = true;
 			platformView.Settings.SetSupportMultipleWindows(true);
 
 			return platformView;
-		}
-
-		public override Size GetDesiredSize(double widthConstraint, double heightConstraint)
-		{
-			if (heightConstraint <= 0 || double.IsInfinity(heightConstraint))
-			{
-				var measuredHeight = PlatformView?.ContentHeight ?? 0;
-				return base.GetDesiredSize(widthConstraint, measuredHeight);
-			}
-
-			if (platformView != null && platformView?.LayoutParameters is LayoutParams layoutParams)
-			{
-				if (layoutParams.Width != LayoutParams.MatchParent && layoutParams.Height != LayoutParams.MatchParent)
-				{
-					platformView.LayoutParameters = new LayoutParams(LayoutParams.MatchParent, LayoutParams.MatchParent);
-				}
-			}
-
-			return base.GetDesiredSize(widthConstraint, heightConstraint);
 		}
 
 		internal WebNavigationEvent CurrentNavigationEvent

--- a/src/Core/src/Handlers/WebView/WebViewHandler.Android.cs
+++ b/src/Core/src/Handlers/WebView/WebViewHandler.Android.cs
@@ -2,8 +2,6 @@
 using System.Collections.Generic;
 using System.Net;
 using Android.Webkit;
-using Microsoft.Maui.Graphics;
-using System.Diagnostics;
 using static Android.Views.ViewGroup;
 using AWebView = Android.Webkit.WebView;
 

--- a/src/Core/src/Handlers/WebView/WebViewHandler.Android.cs
+++ b/src/Core/src/Handlers/WebView/WebViewHandler.Android.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Net;
 using Android.Webkit;
+using Microsoft.Maui.Graphics;
 using static Android.Views.ViewGroup;
 using AWebView = Android.Webkit.WebView;
 
@@ -30,6 +31,25 @@ namespace Microsoft.Maui.Handlers
 			platformView.Settings.SetSupportMultipleWindows(true);
 
 			return platformView;
+		}
+
+		public override Size GetDesiredSize(double widthConstraint, double heightConstraint)
+		{
+			if (heightConstraint <= 0 || double.IsInfinity(heightConstraint))
+			{
+				var measuredHeight = PlatformView?.ContentHeight ?? 0;
+				return base.GetDesiredSize(widthConstraint, measuredHeight);
+			}
+
+			if(PlatformView?.LayoutParameters is LayoutParams layoutParams)
+			{
+				if(layoutParams.Width != LayoutParams.MatchParent && layoutParams.Height != LayoutParams.MatchParent)
+				{
+					PlatformView.LayoutParameters = new LayoutParams(LayoutParams.MatchParent, LayoutParams.MatchParent);
+				}
+			}
+
+			return base.GetDesiredSize(widthConstraint, heightConstraint);
 		}
 
 		internal WebNavigationEvent CurrentNavigationEvent

--- a/src/Core/src/Handlers/WebView/WebViewHandler.Android.cs
+++ b/src/Core/src/Handlers/WebView/WebViewHandler.Android.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using System.Net;
 using Android.Webkit;
+using Microsoft.Maui.Graphics;
+using System.Diagnostics;
 using static Android.Views.ViewGroup;
 using AWebView = Android.Webkit.WebView;
 
@@ -18,18 +20,34 @@ namespace Microsoft.Maui.Handlers
 
 		protected internal string? UrlCanceled { get; set; }
 
+		private MauiWebView? platformView;
 		protected override AWebView CreatePlatformView()
 		{
-			var platformView = new MauiWebView(this, Context!)
-			{
-				LayoutParameters = new LayoutParams(LayoutParams.MatchParent, LayoutParams.MatchParent)
-			};
-
+			platformView = new MauiWebView(this, Context!);
 			platformView.Settings.JavaScriptEnabled = true;
 			platformView.Settings.DomStorageEnabled = true;
 			platformView.Settings.SetSupportMultipleWindows(true);
 
 			return platformView;
+		}
+
+		public override Size GetDesiredSize(double widthConstraint, double heightConstraint)
+		{
+			if (heightConstraint <= 0 || double.IsInfinity(heightConstraint))
+			{
+				var measuredHeight = PlatformView?.ContentHeight ?? 0;
+				return base.GetDesiredSize(widthConstraint, measuredHeight);
+			}
+
+			if (platformView != null && platformView?.LayoutParameters is LayoutParams layoutParams)
+			{
+				if (layoutParams.Width != LayoutParams.MatchParent && layoutParams.Height != LayoutParams.MatchParent)
+				{
+					platformView.LayoutParameters = new LayoutParams(LayoutParams.MatchParent, LayoutParams.MatchParent);
+				}
+			}
+
+			return base.GetDesiredSize(widthConstraint, heightConstraint);
 		}
 
 		internal WebNavigationEvent CurrentNavigationEvent

--- a/src/Core/src/PublicAPI/net-android/PublicAPI.Shipped.txt
+++ b/src/Core/src/PublicAPI/net-android/PublicAPI.Shipped.txt
@@ -2255,6 +2255,7 @@ override Microsoft.Maui.Handlers.ViewHandler<TVirtualView, TPlatformView>.SetupC
 override Microsoft.Maui.Handlers.WebViewHandler.CreatePlatformView() -> Android.Webkit.WebView!
 override Microsoft.Maui.Handlers.WebViewHandler.DisconnectHandler(Android.Webkit.WebView! platformView) -> void
 override Microsoft.Maui.Handlers.WebViewHandler.SetVirtualView(Microsoft.Maui.IView! view) -> void
+override Microsoft.Maui.Handlers.WebViewHandler.GetDesiredSize(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Handlers.WindowHandler.ConnectHandler(Android.App.Activity! platformView) -> void
 override Microsoft.Maui.Handlers.WindowHandler.CreatePlatformElement() -> Android.App.Activity!
 override Microsoft.Maui.Layouts.AbsoluteLayoutManager.ArrangeChildren(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size

--- a/src/Core/src/PublicAPI/net-android/PublicAPI.Shipped.txt
+++ b/src/Core/src/PublicAPI/net-android/PublicAPI.Shipped.txt
@@ -2255,7 +2255,6 @@ override Microsoft.Maui.Handlers.ViewHandler<TVirtualView, TPlatformView>.SetupC
 override Microsoft.Maui.Handlers.WebViewHandler.CreatePlatformView() -> Android.Webkit.WebView!
 override Microsoft.Maui.Handlers.WebViewHandler.DisconnectHandler(Android.Webkit.WebView! platformView) -> void
 override Microsoft.Maui.Handlers.WebViewHandler.SetVirtualView(Microsoft.Maui.IView! view) -> void
-override Microsoft.Maui.Handlers.WebViewHandler.GetDesiredSize(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Handlers.WindowHandler.ConnectHandler(Android.App.Activity! platformView) -> void
 override Microsoft.Maui.Handlers.WindowHandler.CreatePlatformElement() -> Android.App.Activity!
 override Microsoft.Maui.Layouts.AbsoluteLayoutManager.ArrangeChildren(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size


### PR DESCRIPTION
### Description
* In Android when changing the visibility of a WebView within a grid, Getting an issue where the elements underneath the grid start flickering.

### Root Cause
* The flickering happened due to incorrect height handling. The use of MatchParent caused an infinite height, making the layout try to fill the entire parent height, which led to instability. 
### Resolution
* The infinite value was managed to prevent the layout from taking more space than necessary, ensuring stable behavior. 

### Issue Fixed
Fixes #24113 

### Before Changes

https://github.com/user-attachments/assets/663b7043-8425-49d1-9ae2-eaebbd44e0de



### After Changes
 

https://github.com/user-attachments/assets/20fc72a8-db20-456a-99ae-feeb8c11f287




