### PR TITLE
[xaml] fix potential NRE in `{Binding}`

### DIFF
--- a/src/Controls/src/Xaml/MarkupExtensions/BindingExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/BindingExtension.cs
@@ -43,7 +43,8 @@ namespace Microsoft.Maui.Controls.Xaml
 			BindingBase CreateBinding()
 			{
 				Type bindingXDataType = null;
-				if ((serviceProvider.GetService(typeof(IXamlTypeResolver)) is IXamlTypeResolver typeResolver)
+				if (serviceProvider is not null &&
+					(serviceProvider.GetService(typeof(IXamlTypeResolver)) is IXamlTypeResolver typeResolver)
 					&& (serviceProvider.GetService(typeof(IXamlDataTypeProvider)) is IXamlDataTypeProvider dataTypeProvider)
 					&& dataTypeProvider.BindingDataType != null)
 				{

--- a/src/Controls/tests/Xaml.UnitTests/BindingExtensionTests.cs
+++ b/src/Controls/tests/Xaml.UnitTests/BindingExtensionTests.cs
@@ -1,0 +1,14 @@
+﻿using NUnit.Framework;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+[TestFixture]
+public class BindingExtensionTests
+{
+	[Test]
+	public void ProvideValue_Null()
+	{
+		IMarkupExtension<BindingBase> binding = new BindingExtension { Path = "Foo" };
+		binding.ProvideValue(null); // This should not throw
+	}
+}


### PR DESCRIPTION
Fixes: https://github.com/dotnet/maui/issues/24740
Context: https://github.com/dotnet/maui/commit/cb0a332557641bf01de5d10d08ce188b5f3a5989#diff-4f7a4722cd9e9622fcdb5c9c2a596997f8c6b7b9af8b51c5469e8ea59a3d9a48

Using this in a project:

    <PackageReference Include="akgul.Maui.DataGrid" Version="4.0.4" />

Then, in a XAML file:

    xmlns:dg="clr-namespace:Maui.DataGrid;assembly=Maui.DataGrid"
    ...
    <dg:DataGrid />

Would crash with:

    [0:] [13:46:57 FTL] Inner Exception:
    System.NullReferenceException: Object reference not set to an instance of an object.
    at Microsoft.Maui.Controls.Xaml.BindingExtension.<Microsoft.Maui.Controls.Xaml.IMarkupExtension<Microsoft.Maui.Controls.BindingBase>.ProvideValue>g__CreateBinding|40_0(<>c__DisplayClass40_0& ) in /_/src/Controls/src/Xaml/MarkupExtensions/BindingExtension.cs:line 46
    at Microsoft.Maui.Controls.Xaml.BindingExtension.Microsoft.Maui.Controls.Xaml.IMarkupExtension<Microsoft.Maui.Controls.BindingBase>.ProvideValue(IServiceProvider serviceProvider) in /_/src/Controls/src/Xaml/MarkupExtensions/BindingExtension.cs:line 27
    at Maui.DataGrid.DataGrid.InitializeComponent() in D:\Maui.DataGrid\Maui.DataGrid\Microsoft.Maui.Controls.SourceGen\Microsoft.Maui.Controls.SourceGen.CodeBehindGenerator\DataGrid.xaml.sg.cs:line 53
    at Maui.DataGrid.DataGrid..ctor() in D:\Maui.DataGrid\Maui.DataGrid\DataGrid.xaml.cs:line 46
    at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Constructor(Object obj, IntPtr* args)
    at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)

Inspecting the IL, I see:

    BindingBase val115 = ((IMarkupExtension<BindingBase>)(object)val31).ProvideValue((IServiceProvider)null);

So, it is indeed passed a `null` `IServiceProvider`.

Introduce a unit test and check for `null` as a fix.