### PR TITLE
Compressed layout is back (maybe?)

### DIFF
--- a/src/Controls/src/Core/Layout/Layout.cs
+++ b/src/Controls/src/Core/Layout/Layout.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Maui.Controls
 	/// Base class for layouts that allow you to arrange and group UI controls in your application.
 	/// </summary>
 	[ContentProperty(nameof(Children))]
-	public abstract partial class Layout : View, Maui.ILayout, IList<IView>, IBindableLayout, IPaddingElement, IVisualTreeElement, ISafeAreaView, IInputTransparentContainerElement
+	public abstract partial class Layout : View, Maui.ILayout, IList<IView>, IBindableLayout, IPaddingElement, IVisualTreeElement, ISafeAreaView, IInputTransparentContainerElement, ICompressedLayout
 	{
 		protected ILayoutManager _layoutManager;
 
@@ -79,6 +79,8 @@ namespace Microsoft.Maui.Controls
 				OnUpdate(index, value, old);
 			}
 		}
+		
+		bool ICompressedLayout.IsHeadless => CompressedLayout.GetIsHeadless(this);
 
 		/// <summary>Bindable property for <see cref="IsClippedToBounds"/>.</summary>
 		public static readonly BindableProperty IsClippedToBoundsProperty =

--- a/src/Controls/src/Core/Platform/GestureManager/GestureManager.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GestureManager.cs
@@ -76,7 +76,12 @@ namespace Microsoft.Maui.Controls.Platform
 			if (GesturePlatformManager != null)
 				return;
 
+#if PLATFORM
+			GesturePlatformManager = handler is IPlatformViewHandler ? new GesturePlatformManager(handler) : null;
+#else
 			GesturePlatformManager = new GesturePlatformManager(handler);
+#endif
+
 			_handler = handler;
 			_containerView = handler.ContainerView;
 			_platformView = handler.PlatformView;

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue24532.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue24532.xaml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Maui.Controls.Sample.Issues.Issue24532"
+             Title="Issue24532">
+
+    <Grid Padding="24" RowDefinitions="Auto,*" RowSpacing="8">
+      <Button x:Name="StartButton" Clicked="ButtonClicked" Text="Start" AutomationId="StartButton" />
+      
+      <ScrollView Grid.Row="1">
+        <VerticalStackLayout x:Name="BindableContainer" BindableLayout.ItemsSource="{Binding Models}">
+          <BindableLayout.ItemTemplate>
+            <DataTemplate>
+              <Grid RowDefinitions="Auto,Auto,Auto" CompressedLayout.IsHeadless="True">
+                <Label Text="{Binding Header}" />
+                <Label Text="{Binding Content}" Grid.Row="1" />
+                <VerticalStackLayout Grid.Row="2" BindableLayout.ItemsSource="{Binding SubModels}" CompressedLayout.IsHeadless="True">
+                  <BindableLayout.ItemTemplate>
+                    <DataTemplate>
+                      <VerticalStackLayout CompressedLayout.IsHeadless="True">
+                        <Label Text="{Binding Header}" />
+                        <Label Text="{Binding Content}" AutomationId="{Binding AutomationId}" />
+                      </VerticalStackLayout>
+                    </DataTemplate>
+                  </BindableLayout.ItemTemplate>
+                </VerticalStackLayout>
+              </Grid>
+            </DataTemplate>
+          </BindableLayout.ItemTemplate>
+        </VerticalStackLayout>
+      </ScrollView>
+    </Grid>
+</ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue24532.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue24532.xaml.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using Microsoft.Maui;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+
+#if __IOS__ || MACCATALYST
+using PlatformView = UIKit.UIView;
+#elif __ANDROID__
+using PlatformView = Android.Views.View;
+#elif WINDOWS
+using PlatformView = Microsoft.UI.Xaml.FrameworkElement;
+#elif TIZEN
+using PlatformView = Tizen.NUI.BaseComponents.View;
+#elif (NETSTANDARD || !PLATFORM)
+using PlatformView = System.Object;
+#endif
+
+namespace Maui.Controls.Sample.Issues;
+
+[XamlCompilation(XamlCompilationOptions.Compile)]
+[Issue(IssueTracker.Github, 24532, "Rendering performance", PlatformAffected.All)]
+public partial class Issue24532 : ContentPage
+{
+	public List<Model> Models { get; set; }
+
+	public Issue24532()
+	{
+		Models = GenerateOneItem("Test0");
+		BindingContext = this;
+		InitializeComponent();
+	}
+
+	private async void ButtonClicked(object sender, EventArgs e)
+	{
+		var stopwatch = new Stopwatch();
+
+		var platformView = (PlatformView)BindableContainer.Handler!.PlatformView;
+
+		var capturedTimes = new List<long[]>();
+
+		var test1Models = GenerateItems("Test1", 70);
+		var test2Models = GenerateItems("Test2", 40);
+		var resetModel = GenerateOneItem("Test0");
+
+		for (var i = 0; i < 5; i++)
+		{
+			await Task.Delay(100);
+
+			Models = test1Models;
+			stopwatch.Restart();
+			OnPropertyChanged(nameof(Models));
+			await WaitForAutomationId(platformView, "Test1");
+			stopwatch.Stop();
+			var t1 = stopwatch.ElapsedMilliseconds;
+
+			await Task.Delay(100);
+
+			Models = test2Models;
+			stopwatch.Restart();
+			OnPropertyChanged(nameof(Models));
+			await WaitForAutomationId(platformView, "Test2");
+			stopwatch.Stop();
+			var t2 = stopwatch.ElapsedMilliseconds;
+
+			await Task.Delay(100);
+
+			stopwatch.Restart();
+			BindableContainer.Clear();
+			Models = resetModel;
+			OnPropertyChanged(nameof(Models));
+			await WaitForAutomationId(platformView, "Test0");
+			stopwatch.Stop();
+			var t3 = stopwatch.ElapsedMilliseconds;
+
+			capturedTimes.Add([t1, t2, t3]);
+		}
+
+		StartButton.Text =
+			$"{capturedTimes.Average(t => t[0])},{capturedTimes.Average(t => t[1])},{capturedTimes.Average(t => t[2])}";
+	}
+
+	async Task WaitForAutomationId(PlatformView platformView, string automationId)
+	{
+		var found = false;
+
+		while (!found)
+		{
+			await Task.Delay(20);
+#if IOS
+			int length;
+			while ((length = platformView.Subviews.Length) > 0) { platformView = platformView.Subviews[length - 1]; }
+			found = platformView.AccessibilityIdentifier == automationId;
+#elif ANDROID
+			int length;
+			while ((length = (platformView as Android.Views.ViewGroup)?.ChildCount ?? 0) > 0) { platformView = ((Android.Views.ViewGroup)platformView!).GetChildAt(length - 1); }
+			found = (platformView as Android.Widget.TextView)?.Text == automationId;
+#else
+			found = true;
+#endif
+		}
+	}
+
+	static List<Model> GenerateItems(string automationId, int count)
+	{
+		return
+		[
+			..Enumerable.Range(0, count).Select(i => new Model { Content = $"Content {i}", Header = $"Header {i}" }),
+			..GenerateOneItem(automationId)
+		];
+	}
+
+	static List<Model> GenerateOneItem(string automationId)
+	{
+		return
+		[
+			new Model
+			{
+				Content = automationId,
+				Header = automationId,
+				SubModels =
+				[
+					new SubModel { Content = automationId, Header = automationId, AutomationId = automationId }
+				]
+			}
+		];
+	}
+
+	public class Model : SubModel
+	{
+		public SubModel[] SubModels { get; set; } = Enumerable.Range(0, 10).Select(i => new SubModel
+		{
+			Content = $"SubContent {i}", Header = $"SubHeader {i}"
+		}).ToArray();
+	}
+
+	public class SubModel
+	{
+		public string Header { get; set; }
+		public string Content { get; set; }
+		public string AutomationId { get; set; }
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue99999.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue99999.xaml
@@ -1,0 +1,26 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Maui.Controls.Sample.Issues.Issue99999"
+             Title="Issue99999">
+
+  <Grid Padding="24" RowDefinitions="Auto,Auto" ColumnDefinitions="*,*,*,*,*" RowSpacing="16" ColumnSpacing="8">
+    <Entry x:Name="IndexEntry" Keyboard="Numeric" Placeholder="Index" />
+    <Button Text="Ins out" Clicked="OnInsOut" Grid.Row="0" Grid.Column="1" />
+    <Button Text="Rm out" Clicked="OnRmOut" Grid.Row="0" Grid.Column="2" />
+    <Button Text="Ins in" Clicked="OnInsIn" Grid.Row="0" Grid.Column="3" />
+    <Button Text="Rm in" Clicked="OnRmIn" Grid.Row="0" Grid.Column="4" />
+
+    <VerticalStackLayout x:Name="OuterLayout" Spacing="16" Grid.Row="1" Grid.ColumnSpan="5">
+      <Label Text="Text0" BackgroundColor="LightBlue" HeightRequest="20" />
+      <Label Text="Text1" BackgroundColor="LightBlue" HeightRequest="20" />
+      <VerticalStackLayout x:Name="InnerLayout" Padding="12" Spacing="8" CompressedLayout.IsHeadless="True">
+        <Label Text="Text2" BackgroundColor="LightGreen" HeightRequest="20" />
+        <Label Text="Text3" BackgroundColor="LightGreen" HeightRequest="20" />
+        <Label Text="Text4" BackgroundColor="LightGreen" HeightRequest="20" />
+      </VerticalStackLayout>
+      <Label Text="Text5" BackgroundColor="LightBlue" HeightRequest="20" />
+      <Label Text="Text6" BackgroundColor="LightBlue" HeightRequest="20" />
+    </VerticalStackLayout>
+  </Grid>
+</ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue99999.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue99999.xaml.cs
@@ -1,0 +1,43 @@
+using System;
+using Microsoft.Maui;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+
+namespace Maui.Controls.Sample.Issues;
+
+[XamlCompilation(XamlCompilationOptions.Compile)]
+[Issue(IssueTracker.Github, 99999, "CompressedLayout is not working", PlatformAffected.All)]
+
+public partial class Issue99999 : ContentPage
+{
+	int _count = 6;
+	
+	public Issue99999()
+	{
+		InitializeComponent();
+	}
+	
+	private void OnInsOut(object sender, EventArgs e)
+	{
+		var index = int.Parse(IndexEntry.Text);
+		OuterLayout.Insert(index, new Label { Text = $"Text{++_count}" });
+	}
+	
+	private void OnRmOut(object sender, EventArgs e)
+	{
+		var index = int.Parse(IndexEntry.Text);
+		OuterLayout.RemoveAt(index);
+	}
+	
+	private void OnInsIn(object sender, EventArgs e)
+	{
+		var index = int.Parse(IndexEntry.Text);
+		InnerLayout.Insert(index, new Label { Text = $"Text{++_count}" });
+	}
+	
+	private void OnRmIn(object sender, EventArgs e)
+	{
+		var index = int.Parse(IndexEntry.Text);
+		InnerLayout.RemoveAt(index);
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue24532.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue24532.cs
@@ -1,0 +1,41 @@
+#if ANDROID || IOS || MACCATALYST
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue24532 : _IssuesUITest
+	{
+		public Issue24532(TestDevice device) : base(device) { }
+
+		public override string Issue => "Rendering performance";
+
+		[Test]
+		[Category(UITestCategories.Performance)]
+		public async Task RenderingPerformance()
+		{
+			var button = App.WaitForElement("StartButton");
+			App.Tap("StartButton");
+
+			string? text;
+			while (true)
+			{
+				text = button.GetText();
+				if (string.IsNullOrEmpty(text) || text == "Start")
+				{
+					await Task.Delay(1000);
+					continue;
+				}
+
+				break;
+			}
+
+			var times = text.Split(',');
+			Console.WriteLine(@$"First render: {times[0]}ms");
+			Console.WriteLine(@$"Binding context changed: {times[1]}ms");
+			Console.WriteLine(@$"Clear: {times[2]}ms");
+		}
+	}
+}
+#endif

--- a/src/Core/src/Core/ICompressedLayout.cs
+++ b/src/Core/src/Core/ICompressedLayout.cs
@@ -1,0 +1,17 @@
+namespace Microsoft.Maui
+{
+	
+	/// <summary>
+	/// Provides information about whether the ILayout is compressed.
+	/// </summary>
+	/// <remarks>
+	/// A compressed layout is not included in the platform tree.
+	/// </remarks>
+	internal interface ICompressedLayout
+	{
+		/// <summary>
+		/// Specifies whether the ILayout is compressed.
+		/// </summary>
+		bool IsHeadless { get; }
+	}
+}

--- a/src/Core/src/Handlers/Layout/HeadlessLayoutHandler.Android.cs
+++ b/src/Core/src/Handlers/Layout/HeadlessLayoutHandler.Android.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Linq;
+
+namespace Microsoft.Maui.Handlers;
+
+internal partial class HeadlessLayoutHandler : IHeadlessLayoutHandler
+{
+	public void Add(IView view)
+	{
+		PlatformHandler.Add(view);
+	}
+
+	public void Remove(IView view)
+	{
+		var platformView = PlatformView;
+		if (view is { Handler: HeadlessLayoutHandler headlessLayoutHandler })
+		{
+			var subviews = CollectPlatformViews(headlessLayoutHandler.VirtualView);
+			foreach (var subview in subviews)
+			{
+				platformView.RemoveView(subview);
+			}
+			return;
+		}
+
+		platformView.RemoveView(view.ToPlatform());
+	}
+
+	public void Clear()
+	{
+		var platformView = PlatformView;
+		var subviews = CollectPlatformViews(VirtualView);
+		foreach (var subview in subviews)
+		{
+			platformView.RemoveView(subview);
+		}
+	}
+
+	public void Insert(int index, IView view)
+	{
+		PlatformHandler.Insert(/* ignored */-1, view);
+	}
+
+	public void Update(int index, IView view)
+	{
+		PlatformHandler.Update(/* ignored */-1, view);
+	}
+
+	public void CreateSubviews(ref int targetIndex)
+	{
+		var mauiContext = MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by set virtual view.");
+		var platformView = PlatformView ?? throw new InvalidOperationException($"{nameof(PlatformView)} should have been set by set virtual view.");
+		var virtualView = VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} should have been set by set virtual view.");
+
+		foreach (var child in virtualView.OrderByZIndex())
+		{
+			var childHandler = ((IElement)child).ToHandler(mauiContext);
+
+			if (childHandler is IHeadlessLayoutHandler headlessLayoutHandler)
+			{
+				headlessLayoutHandler.CreateSubviews(ref targetIndex);
+				continue;
+			}
+
+			var childPlatformView = childHandler.ToPlatform();
+			platformView.AddView(childPlatformView, targetIndex++);
+		}
+	}
+
+	public void MoveSubviews(int targetIndex)
+	{
+		var platformView = PlatformView ?? throw new InvalidOperationException($"{nameof(PlatformView)} should have been set by set virtual view.");
+		var virtualView = VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} should have been set by set virtual view.");
+
+		var subviews = CollectPlatformViews(virtualView).ToArray();
+
+		if (subviews.Length == 0 || platformView.IndexOfChild(subviews[0]) == targetIndex)
+		{
+			return;
+		}
+
+		foreach (var subview in subviews)
+		{
+			platformView.RemoveView(subview);
+		}
+		
+		foreach (var subview in subviews)
+		{
+			platformView.AddView(subview, targetIndex++);
+		}
+	}
+}

--- a/src/Core/src/Handlers/Layout/HeadlessLayoutHandler.Standard.cs
+++ b/src/Core/src/Handlers/Layout/HeadlessLayoutHandler.Standard.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Linq;
+
+namespace Microsoft.Maui.Handlers;
+
+internal partial class HeadlessLayoutHandler : IHeadlessLayoutHandler
+{
+	public void Add(IView view)
+	{
+	}
+
+	public void Remove(IView view)
+	{
+	}
+
+	public void Clear()
+	{
+	}
+
+	public void Insert(int index, IView view)
+	{
+	}
+
+	public void Update(int index, IView view)
+	{
+	}
+
+	public void CreateSubviews(ref int targetIndex)
+	{
+	}
+
+	public void MoveSubviews(int targetIndex)
+	{
+	}
+}

--- a/src/Core/src/Handlers/Layout/HeadlessLayoutHandler.Tizen.cs
+++ b/src/Core/src/Handlers/Layout/HeadlessLayoutHandler.Tizen.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Linq;
+
+namespace Microsoft.Maui.Handlers;
+
+internal partial class HeadlessLayoutHandler : IHeadlessLayoutHandler
+{
+	public void Add(IView view)
+	{
+		throw new NotImplementedException();
+	}
+
+	public void Remove(IView view)
+	{
+		throw new NotImplementedException();
+	}
+
+	public void Clear()
+	{
+		throw new NotImplementedException();
+	}
+
+	public void Insert(int index, IView view)
+	{
+		throw new NotImplementedException();
+	}
+
+	public void Update(int index, IView view)
+	{
+		throw new NotImplementedException();
+	}
+
+	public void CreateSubviews(ref int targetIndex)
+	{
+		throw new NotImplementedException();
+	}
+
+	public void MoveSubviews(int targetIndex)
+	{
+		throw new NotImplementedException();
+	}
+}

--- a/src/Core/src/Handlers/Layout/HeadlessLayoutHandler.Windows.cs
+++ b/src/Core/src/Handlers/Layout/HeadlessLayoutHandler.Windows.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Linq;
+
+namespace Microsoft.Maui.Handlers;
+
+internal partial class HeadlessLayoutHandler : IHeadlessLayoutHandler
+{
+	public void Add(IView view)
+	{
+		throw new NotImplementedException();
+	}
+
+	public void Remove(IView view)
+	{
+		throw new NotImplementedException();
+	}
+
+	public void Clear()
+	{
+		throw new NotImplementedException();
+	}
+
+	public void Insert(int index, IView view)
+	{
+		throw new NotImplementedException();
+	}
+
+	public void Update(int index, IView view)
+	{
+		throw new NotImplementedException();
+	}
+
+	public void CreateSubviews(ref int targetIndex)
+	{
+		throw new NotImplementedException();
+	}
+
+	public void MoveSubviews(int targetIndex)
+	{
+		throw new NotImplementedException();
+	}
+}

--- a/src/Core/src/Handlers/Layout/HeadlessLayoutHandler.cs
+++ b/src/Core/src/Handlers/Layout/HeadlessLayoutHandler.cs
@@ -1,0 +1,212 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Maui.Graphics;
+
+#if __IOS__ || MACCATALYST
+using PlatformView = UIKit.UIView;
+using LayoutPlatformView = Microsoft.Maui.Platform.LayoutView;
+#elif __ANDROID__
+using PlatformView = Android.Views.View;
+using LayoutPlatformView = Microsoft.Maui.Platform.LayoutViewGroup;
+#elif WINDOWS
+using PlatformView = Microsoft.UI.Xaml.FrameworkElement;
+using LayoutPlatformView = Microsoft.Maui.Platform.LayoutPanel;
+#elif TIZEN
+using PlatformView = Tizen.NUI.BaseComponents.View;
+using LayoutPlatformView = Microsoft.Maui.Platform.LayoutViewGroup;
+#elif (NETSTANDARD || !PLATFORM)
+using PlatformView = System.Object;
+using LayoutPlatformView = System.Object;
+#endif
+
+namespace Microsoft.Maui.Handlers;
+
+internal partial class HeadlessLayoutHandler : IHeadlessLayoutHandler
+{
+	public static CommandMapper<ILayout, IHeadlessLayoutHandler> CommandMapper = new()
+	{
+		[nameof(ILayoutHandler.Add)] = MapAdd,
+		[nameof(ILayoutHandler.Remove)] = MapRemove,
+		[nameof(ILayoutHandler.Clear)] = MapClear,
+		[nameof(ILayoutHandler.Insert)] = MapInsert,
+		[nameof(ILayoutHandler.Update)] = MapUpdate,
+		[nameof(ILayoutHandler.UpdateZIndex)] = MapUpdateZIndex,
+		[nameof(IView.ZIndex)] = MapZIndex,
+	};
+
+	public static void MapAdd(IHeadlessLayoutHandler handler, ILayout layout, object? arg)
+	{
+		if (arg is LayoutHandlerUpdate args)
+		{
+			handler.Add(args.View);
+		}
+	}
+
+	public static void MapRemove(IHeadlessLayoutHandler handler, ILayout layout, object? arg)
+	{
+		if (arg is LayoutHandlerUpdate args)
+		{
+			handler.Remove(args.View);
+		}
+	}
+
+	public static void MapInsert(IHeadlessLayoutHandler handler, ILayout layout, object? arg)
+	{
+		if (arg is LayoutHandlerUpdate args)
+		{
+			handler.Insert(args.Index, args.View);
+		}
+	}
+
+	public static void MapClear(IHeadlessLayoutHandler handler, ILayout layout, object? arg)
+	{
+		handler.Clear();
+	}
+
+	static void MapUpdate(IHeadlessLayoutHandler handler, ILayout layout, object? arg)
+	{
+		if (arg is LayoutHandlerUpdate args)
+		{
+			handler.Update(args.Index, args.View);
+		}
+	}
+
+	static void MapUpdateZIndex(IHeadlessLayoutHandler handler, ILayout layout, object? arg)
+	{
+		if (arg is IView view)
+		{
+			handler.UpdateZIndex(view);
+		}
+	}
+	
+	static void MapZIndex(ILayoutHandler handler, ILayout view, object? arg)
+	{
+		if (view.Parent is ILayout layout)
+		{
+			(layout.Handler as ILayoutHandler)?.UpdateZIndex(view);
+		}
+	}
+
+	ILayout? _virtualView;
+	ILayoutHandler? _platformHandler;
+	ILayoutHandler PlatformHandler => _platformHandler ?? throw new InvalidOperationException($"{nameof(PlatformHandler)} should have been set previously.");
+	IView? IViewHandler.VirtualView => _virtualView;
+	IElement? IElementHandler.VirtualView => _virtualView;
+	object IElementHandler.PlatformView => PlatformHandler.PlatformView;
+
+	public ILayout VirtualView
+	{
+		get => _virtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} should have been set.");
+	}
+	
+	public LayoutPlatformView PlatformView => PlatformHandler.PlatformView;
+	
+	public IMauiContext? MauiContext { get; private set; }
+	
+	public bool HasContainer
+	{
+		get => false;
+		set
+		{
+			if (value)
+			{
+				throw new InvalidOperationException("CompressedLayout does not support HasContainer");
+			}
+		}
+	}
+
+	public object? ContainerView => null;
+	
+	public void SetMauiContext(IMauiContext mauiContext)
+	{
+		MauiContext = mauiContext;
+	}
+
+	public void SetVirtualView(IElement view)
+	{
+		_ = view ?? throw new ArgumentNullException(nameof(view));
+		_ = MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set.");
+
+		if (ReferenceEquals(_virtualView, view))
+		{
+			return;
+		}
+
+		var oldVirtualView = _virtualView;
+
+		_virtualView = view as ILayout ?? throw new InvalidOperationException($"{nameof(view)} must be an {nameof(ILayout)}.");
+		_platformHandler = FindPlatformHandler(_virtualView) ?? throw new InvalidOperationException($"No ancestor platform {nameof(ILayoutHandler)} found for {nameof(ICompressedLayout)}.");
+
+		// We set the previous virtual view to null after setting it on the incoming virtual view.
+		// This makes it easier for the incoming virtual view to have influence
+		// on how the exchange of handlers happens.
+		// We will just set the handler to null ourselves as a last resort cleanup
+		if (oldVirtualView?.Handler != null)
+		{
+			oldVirtualView.Handler = null;
+		}
+	}
+
+	public void UpdateValue(string property)
+	{
+		
+	}
+
+	public void Invoke(string command, object? args = null)
+	{
+		if (VirtualView is { } virtualView)
+		{
+			CommandMapper.Invoke(this, virtualView, command, args);
+		}
+	}
+
+	public void DisconnectHandler()
+	{
+		
+	}
+
+	public void UpdateZIndex(IView view)
+	{
+		PlatformHandler.UpdateZIndex(view);
+	}
+
+	public Size GetDesiredSize(double widthConstraint, double heightConstraint)
+	{
+		var desiredSize = VirtualView.CrossPlatformMeasure(widthConstraint, heightConstraint);
+		return desiredSize;
+	}
+
+	public void PlatformArrange(Rect frame)
+	{
+		VirtualView.CrossPlatformArrange(frame);
+	}
+	
+	static ILayoutHandler? FindPlatformHandler(ILayout? layout)
+	{
+		while (layout is { Handler: HeadlessLayoutHandler })
+		{
+			layout = layout.Parent as ILayout;
+		}
+		
+		return layout?.Handler as ILayoutHandler;
+	}
+
+	static IEnumerable<PlatformView> CollectPlatformViews(ILayout layout)
+	{
+		foreach (var view in layout)
+		{
+			var platformViewHandler = view.Handler ?? throw new InvalidOperationException($"{nameof(view.Handler)} should have been previously set.");
+			if (platformViewHandler is IHeadlessLayoutHandler headlessLayoutHandler)
+			{
+				foreach (var platformView in CollectPlatformViews(headlessLayoutHandler.VirtualView))
+				{
+					yield return platformView;
+				}
+				
+				continue;
+			}
+			
+			yield return platformViewHandler.ToPlatform();
+		}
+	}
+}

--- a/src/Core/src/Handlers/Layout/HeadlessLayoutHandler.iOS.cs
+++ b/src/Core/src/Handlers/Layout/HeadlessLayoutHandler.iOS.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Linq;
+using PlatformView = UIKit.UIView;
+using LayoutPlatformView = Microsoft.Maui.Platform.LayoutView;
+
+namespace Microsoft.Maui.Handlers;
+
+internal partial class HeadlessLayoutHandler : IHeadlessLayoutHandler
+{
+	public void Add(IView view)
+	{
+		PlatformHandler.Add(view);
+	}
+
+	public void Remove(IView view)
+	{
+		if (view is { Handler: HeadlessLayoutHandler headlessLayoutHandler })
+		{
+			var subviews = CollectPlatformViews(headlessLayoutHandler.VirtualView);
+			foreach (var subview in subviews)
+			{
+				subview.RemoveFromSuperview();
+			}
+			return;
+		}
+
+		view.ToPlatform().RemoveFromSuperview();
+	}
+
+	public void Clear()
+	{
+		var subviews = CollectPlatformViews(VirtualView);
+		foreach (var subview in subviews)
+		{
+			subview.RemoveFromSuperview();
+		}
+	}
+
+	public void Insert(int index, IView view)
+	{
+		PlatformHandler.Insert(/* ignored */-1, view);
+	}
+
+	public void Update(int index, IView view)
+	{
+		PlatformHandler.Update(/* ignored */-1, view);
+	}
+
+	public void CreateSubviews(ref int targetIndex)
+	{
+		var mauiContext = MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by set virtual view.");
+		var platformView = PlatformView ?? throw new InvalidOperationException($"{nameof(PlatformView)} should have been set by set virtual view.");
+		var virtualView = VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} should have been set by set virtual view.");
+
+		foreach (var child in virtualView.OrderByZIndex())
+		{
+			var childHandler = ((IElement)child).ToHandler(mauiContext);
+
+			if (childHandler is IHeadlessLayoutHandler headlessLayoutHandler)
+			{
+				headlessLayoutHandler.CreateSubviews(ref targetIndex);
+				continue;
+			}
+
+			var childPlatformView = childHandler.ToPlatform();
+			platformView.InsertSubview(childPlatformView, targetIndex++);
+			
+			if (child.FlowDirection == FlowDirection.MatchParent)
+			{
+				childPlatformView.UpdateFlowDirection(child);
+			}
+		}
+	}
+
+	public void MoveSubviews(int targetIndex)
+	{
+		var platformView = PlatformView ?? throw new InvalidOperationException($"{nameof(PlatformView)} should have been set by set virtual view.");
+		var virtualView = VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} should have been set by set virtual view.");
+
+		var subviews = CollectPlatformViews(virtualView).ToArray();
+
+		if (subviews.Length == 0 || platformView.Subviews.IndexOf(subviews[0]) == targetIndex)
+		{
+			return;
+		}
+
+		foreach (var subview in subviews)
+		{
+			subview.RemoveFromSuperview();
+		}
+		
+		foreach (var subview in subviews)
+		{
+			platformView.InsertSubview(subview, targetIndex++);
+		}
+	}
+}

--- a/src/Core/src/Handlers/Layout/IHeadlessLayoutHandler.cs
+++ b/src/Core/src/Handlers/Layout/IHeadlessLayoutHandler.cs
@@ -1,0 +1,7 @@
+namespace Microsoft.Maui.Handlers;
+
+internal interface IHeadlessLayoutHandler : ILayoutHandler
+{
+	void CreateSubviews(ref int targetIndex);
+	void MoveSubviews(int targetIndex);
+}


### PR DESCRIPTION
### Description of Change

In Xamarin using `CompressedLayout.IsHeadless="True"` literally changed the performance of our app from "laggy" to "snappy" on Android :)

This is just a proof-of-concept to show how compressed layout support could look like in MAUI and if adding such support would increase the performance or not.

| Test case | First render | BindingContext changes | Clear |
|----------|-------------|-------------------------|------|
| iOS `main` | 1316ms | 166.2ms | 46.4ms |
| iOS `PR` | 1225ms | 118.4ms | 123.8ms |
| Android `main` | 533ms | 55.4ms | 34.6ms |
| Android `PR` | 433ms | 50.2ms | 30.2ms |

I still don't understand the reason behind slow `Clear` on iOS, especially because that `PlatformView.ClearSubviews()` didn't change.

Also, I've not implemented the `InvalidateMeasure` part, on which I feel there would be additional considerations.

Anyway, before going further with this one, I wanted to double-check with you if this will ever be taken in consideration.

![Simulator Screen Recording - iPhone Xs - 2024-09-13 at 18 18 17](https://github.com/user-attachments/assets/6d1efa4f-ae18-4a32-a649-f2f63f690006)


