### PR TITLE
Improve MauiFactory performance by avoiding reflection to get base classes

### DIFF
--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/BuildWarningsUtilities.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/BuildWarningsUtilities.cs
@@ -380,6 +380,14 @@ namespace Microsoft.Maui.IntegrationTests
 							"Microsoft.Maui.Hosting.Internal.MauiFactory.GetServiceBaseTypes(Type): 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.Interfaces' in call to 'System.Type.GetInterfaces()'. The parameter '#0' of method 'Microsoft.Maui.Hosting.Internal.MauiFactory.GetServiceBaseTypes(Type)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.",
 						}
 					},
+					new WarningsPerCode
+					{
+						Code = "IL2070",
+						Messages = new List<string>
+						{
+							"Microsoft.Maui.Hosting.Internal.MauiFactory.ServiceBaseTypesFactory(Type): 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.Interfaces' in call to 'System.Type.GetInterfaces()'. The parameter '#0' of method 'Microsoft.Maui.Hosting.Internal.MauiFactory.ServiceBaseTypesFactory(Type)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.",
+						}
+					},
 				}
 			},
 			new WarningsPerFile


### PR DESCRIPTION
### Description of Change

A minor improvement to a piece of code executed on every `ToHandler` or `ToPlatform`.

**Speedscope Before**
<img width="1291" alt="image" src="https://github.com/user-attachments/assets/3e5c1feb-e510-4d2c-ae78-0bfc4d488deb">

**Speedscope After**
<img width="1288" alt="image" src="https://github.com/user-attachments/assets/81db1be4-b161-48ca-842c-16abe1080175">

**Extra note**
I had some code ready to cache the entire `Type` => `ServiceDescriptor(s)` and make this even faster, but it breaks a unit test which honestly I don't understand the purpose of:
https://github.com/dotnet/maui/blob/3de5be94b043d2d8cafdb2fedbae1bb363ec5f2e/src/Core/tests/UnitTests/Hosting/HostBuilderHandlerTests.cs#L86-L99