### PR TITLE
Adding items to windows ObservableItemTemplateCollection 

### DIFF
--- a/src/Controls/src/Core/Platform/Windows/CollectionView/ObservableItemTemplateCollection.cs
+++ b/src/Controls/src/Core/Platform/Windows/CollectionView/ObservableItemTemplateCollection.cs
@@ -160,13 +160,14 @@ namespace Microsoft.Maui.Controls.Platform
 
 		void Add(NotifyCollectionChangedEventArgs args)
 		{
-			var startIndex = args.NewStartingIndex > -1 ? args.NewStartingIndex : _itemsSource.IndexOf(args.NewItems[0]);
+			var index = args.NewStartingIndex > -1 ? args.NewStartingIndex : _itemsSource.IndexOf(args.NewItems[0]);
 
 			var count = args.NewItems.Count;
 
 			for (int n = 0; n < count; n++)
 			{
-				Insert(startIndex, new ItemTemplateContext(_itemTemplate, args.NewItems[n], _container, _itemHeight, _itemWidth, _itemSpacing, _mauiContext));
+				Insert(index, new ItemTemplateContext(_itemTemplate, args.NewItems[n], _container, _itemHeight, _itemWidth, _itemSpacing, _mauiContext));
+				index++;
 			}
 		}
 


### PR DESCRIPTION
### Description of Change

Inserting more than one item to ObservableItemTemplateCollection under windows needs updating the inserting index

### Issues Fixed

After inserting multiple items to the collection without updating the inserting index inverts the order of the inserted items

