### PR TITLE
Avoid throwing in async void when applying relative source bindings

### DIFF
--- a/src/Controls/src/Core/Binding.cs
+++ b/src/Controls/src/Core/Binding.cs
@@ -137,7 +137,17 @@ namespace Microsoft.Maui.Controls
 
 			if (Source is RelativeBindingSource relativeBindingSource)
 			{
-				ApplyRelativeSourceBinding(relativeBindingSource, bindObj, targetProperty, specificity);
+				var relativeSourceTarget = RelativeSourceTargetOverride ?? bindObj as Element;
+				if (relativeSourceTarget is not Element)
+				{
+					var message = bindObj is not null
+						? $"Cannot apply relative binding to {bindObj.GetType().FullName} because it is not a superclass of Element."
+						: "Cannot apply relative binding when the target object is null.";
+
+					throw new InvalidOperationException(message);
+				}
+
+				ApplyRelativeSourceBinding(relativeBindingSource, relativeSourceTarget, bindObj, targetProperty, specificity);
 			}
 			else
 			{
@@ -148,13 +158,9 @@ namespace Microsoft.Maui.Controls
 		}
 
 #pragma warning disable RECS0165 // Asynchronous methods should return a Task instead of void
-		async void ApplyRelativeSourceBinding(RelativeBindingSource relativeSource, BindableObject targetObject, BindableProperty targetProperty, SetterSpecificity specificity)
+		async void ApplyRelativeSourceBinding(RelativeBindingSource relativeSource, Element relativeSourceTarget, BindableObject targetObject, BindableProperty targetProperty, SetterSpecificity specificity)
 #pragma warning restore RECS0165 // Asynchronous methods should return a Task instead of void
 		{
-			var relativeSourceTarget = RelativeSourceTargetOverride ?? targetObject as Element;
-			if (!(relativeSourceTarget is Element))
-				throw new InvalidOperationException();
-
 			await relativeSource.Apply(_expression, relativeSourceTarget, targetObject, targetProperty, specificity);
 		}
 

--- a/src/Controls/src/Core/TypedBinding.cs
+++ b/src/Controls/src/Core/TypedBinding.cs
@@ -182,7 +182,17 @@ namespace Microsoft.Maui.Controls.Internals
 
 			if (Source is RelativeBindingSource relativeSource)
 			{
-				ApplyRelativeSourceBinding(relativeSource, bindObj, targetProperty, specificity);
+				var relativeSourceTarget = RelativeSourceTargetOverride ?? bindObj as Element;
+				if (relativeSourceTarget is not Element)
+				{
+					var message = bindObj is not null
+						? $"Cannot apply relative binding to {bindObj.GetType().FullName} because it is not a superclass of Element."
+						: "Cannot apply relative binding when the target object is null.";
+
+					throw new InvalidOperationException(message);
+				}
+
+				ApplyRelativeSourceBinding(relativeSource, relativeSourceTarget, bindObj, targetProperty, specificity);
 			}
 			else
 			{
@@ -192,13 +202,9 @@ namespace Microsoft.Maui.Controls.Internals
 
 #pragma warning disable RECS0165 // Asynchronous methods should return a Task instead of void
 		async void ApplyRelativeSourceBinding(
-			RelativeBindingSource relativeSource, BindableObject targetObject, BindableProperty targetProperty, SetterSpecificity specificity)
+			RelativeBindingSource relativeSource, Element relativeSourceTarget, BindableObject targetObject, BindableProperty targetProperty, SetterSpecificity specificity)
 #pragma warning restore RECS0165 // Asynchronous methods should return a Task instead of void
 		{
-			var relativeSourceTarget = RelativeSourceTargetOverride ?? targetObject as Element;
-			if (!(relativeSourceTarget is Element))
-				throw new InvalidOperationException();
-
 			await relativeSource.Apply(this, relativeSourceTarget, targetObject, targetProperty, specificity);
 		}
 


### PR DESCRIPTION
### Description of Change

This PR tries to improve DX when using bindings with relative sources on objects that aren't compatible (non-Elements). Previously, we would throw an exception without any explanation inside of `async void` which was hard to debug and it was unclear why the binding is failing.

### Issues Fixed

Contributes to https://github.com/dotnet/maui/issues/24313
