### PR TITLE
[Android] Fix app crash caused by dynamic template switching in ListView

### DIFF
--- a/src/Controls/src/Core/Application/Application.cs
+++ b/src/Controls/src/Core/Application/Application.cs
@@ -220,7 +220,7 @@ namespace Microsoft.Maui.Controls
 
 			return null;
 #elif ANDROID
-			var context = Current?.Windows?.Count > 0 && Current.Windows[0].MauiContext is not null ? Current.Windows[0].MauiContext.Context : Current?.FindMauiContext()?.Context;
+			var context = (Current?.Windows?.Count > 0 && Current.Windows[0].MauiContext is not null) ? Current.Windows[0].MauiContext.Context : Current?.FindMauiContext()?.Context;
 			if (context is not null)
 				return context?.GetAccentColor();
 

--- a/src/Controls/src/Core/Application/Application.cs
+++ b/src/Controls/src/Core/Application/Application.cs
@@ -220,7 +220,7 @@ namespace Microsoft.Maui.Controls
 
 			return null;
 #elif ANDROID
-			var context = Current?.Windows?.Count > 0 ? Current.Windows[0].MauiContext.Context : Current?.FindMauiContext()?.Context;
+			var context = Current?.Windows?.Count > 0 && Current.Windows[0].MauiContext is not null ? Current.Windows[0].MauiContext.Context : Current?.FindMauiContext()?.Context;
 			if (context is not null)
 				return context?.GetAccentColor();
 

--- a/src/Controls/src/Core/Application/Application.cs
+++ b/src/Controls/src/Core/Application/Application.cs
@@ -220,8 +220,9 @@ namespace Microsoft.Maui.Controls
 
 			return null;
 #elif ANDROID
-			if (Current?.Windows?.Count > 0)
-				return Current.Windows[0].MauiContext.Context?.GetAccentColor();
+			var context = Current?.Windows?.Count > 0 ? Current.Windows[0].MauiContext.Context : Current?.FindMauiContext()?.Context;
+			if (context is not null)
+				return context?.GetAccentColor();
 
 			return null;
 #elif IOS

--- a/src/Controls/src/Core/Application/Application.cs
+++ b/src/Controls/src/Core/Application/Application.cs
@@ -220,10 +220,9 @@ namespace Microsoft.Maui.Controls
 
 			return null;
 #elif ANDROID
-			if (Current?.Windows?.Count > 0)
-				return Current.Windows[0].MauiContext.Context?.GetAccentColor();
-
-			return null;
+			return Current?.Windows?.Count > 0
+			? Current.Windows[0].MauiContext.Context?.GetAccentColor()
+			: Color.FromRgba(50, 79, 133, 255);
 #elif IOS
 			return ColorExtensions.AccentColor.ToColor();
 #else

--- a/src/Controls/src/Core/Application/Application.cs
+++ b/src/Controls/src/Core/Application/Application.cs
@@ -220,9 +220,10 @@ namespace Microsoft.Maui.Controls
 
 			return null;
 #elif ANDROID
-			return Current?.Windows?.Count > 0
-			? Current.Windows[0].MauiContext.Context?.GetAccentColor()
-			: Color.FromRgba(50, 79, 133, 255);
+			if (Current?.Windows?.Count > 0)
+				return Current.Windows[0].MauiContext.Context?.GetAccentColor();
+
+			return null;
 #elif IOS
 			return ColorExtensions.AccentColor.ToColor();
 #else

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/ViewCellRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/ViewCellRenderer.cs
@@ -244,6 +244,12 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 				var platformView = _viewCell.View.ToPlatform(Element.FindMauiContext());
 				_viewHandler = (IPlatformViewHandler)_viewCell.View.Handler;
+
+				if (platformView.Parent != null && platformView.Parent is ViewGroup parentViewGroup)
+				{
+					parentViewGroup.RemoveView(platformView);
+				}
+
 				AddView(platformView);
 
 				UpdateIsEnabled();

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/ViewCellRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/ViewCellRenderer.cs
@@ -245,9 +245,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				var platformView = _viewCell.View.ToPlatform(Element.FindMauiContext());
 				_viewHandler = (IPlatformViewHandler)_viewCell.View.Handler;
 
-				if (platformView.Parent != null && platformView.Parent is ViewGroup parentViewGroup)
+				if (platformView?.Parent is ViewGroup)
 				{
-					parentViewGroup.RemoveView(platformView);
+					platformView.RemoveFromParent();
 				}
 
 				AddView(platformView);

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/ViewCellRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/ViewCellRenderer.cs
@@ -244,12 +244,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 				var platformView = _viewCell.View.ToPlatform(Element.FindMauiContext());
 				_viewHandler = (IPlatformViewHandler)_viewCell.View.Handler;
-
-				if (platformView?.Parent is ViewGroup)
-				{
-					platformView.RemoveFromParent();
-				}
-
+				platformView.RemoveFromParent();
 				AddView(platformView);
 
 				UpdateIsEnabled();

--- a/src/Controls/tests/DeviceTests/Elements/ListView/ListViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/ListView/ListViewTests.cs
@@ -34,11 +34,7 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 
-		[Fact
-#if ANDROID
-			(Skip = "https://github.com/dotnet/maui/issues/24701")
-#endif
-		]
+		[Fact]
 		public async Task ChangingTemplateTypeDoesNotCrash()
 		{
 			SetupBuilder();

--- a/src/Core/src/Platform/Android/ColorExtensions.cs
+++ b/src/Core/src/Platform/Android/ColorExtensions.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Maui.Platform
 			=> self?.ToPlatform() ?? new AColor(ContextCompat.GetColor(context, defaultColorResourceId));
 
 		public static AColor ToPlatform(this Color? self, Color defaultColor)
-			=> (self ?? defaultColor ?? Color.FromArgb("#ff33b5e5")).ToPlatform();
+			=> self?.ToPlatform() ?? defaultColor.ToPlatform();
 
 		public static Color ToColor(this uint color)
 		{

--- a/src/Core/src/Platform/Android/ColorExtensions.cs
+++ b/src/Core/src/Platform/Android/ColorExtensions.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Maui.Platform
 			=> self?.ToPlatform() ?? new AColor(ContextCompat.GetColor(context, defaultColorResourceId));
 
 		public static AColor ToPlatform(this Color? self, Color defaultColor)
-			=> self?.ToPlatform() ?? defaultColor.ToPlatform();
+			=> (self ?? defaultColor ?? Color.FromArgb("#ff33b5e5")).ToPlatform();
 
 		public static Color ToColor(this uint color)
 		{


### PR DESCRIPTION
### Exception I – Object reference not set to an instance of an object at GraphicsExtensions.AsColor :
During the execution of the device test case - `ChangingTemplateTypeDoesNotCrash`, a fatal exception was thrown, causing a crash.

### Root Cause

The root cause of the `NullReferenceException` was identified as a failure to check for a valid context or color before calling the AsColor method. Specifically, the line of code responsible for this was:
```
var color = Current?.Windows?.Count > 0 
            ? Current.Windows[0].MauiContext.Context?.GetAccentColor() 
            : null;
```

In the `UpdateSeparatorColor` method, when returning null for `Application.AccentColor `, the method requests:
`bline.SetBackgroundColor(separatorColor.ToPlatform(Application.AccentColor));
`Since no default separator color was set, this led to the issue. The failure was particularly observed in our test case that enabled grouping, which is why only the `ChangingTemplateTypeDoesNotCrash` test case was failing.

### Description of Change

To resolve this issue, the following modifications were implemented in the relevant code segment:

Default Color Implementation: A fallback mechanism was implemented to provide a default color (e.g., `Color.FromRgba(50, 79, 133, 255)) `when the `window.count` resource is unavailable. This approach prevents the application from crashing and ensures that the UI continues to function smoothly even in command line device test cases.

### Exception II – The specified child already has a parent. you must call `removeView()` on the child’s parent first at `ViewGroup.addViewInner`.

### Root cause

In the ViewCellRenderer class, the platform view was being recreated for each cell without properly removing the existing parent view (i.e., the ViewCellContainer ) before attempting to add the new view. This caused an exception:'The specified child already has a parent. You must call removeView() on the child's parent first. 'The issue arose due to improper handling of the platform view's parent when switching between different DataTemplates in a ListView using the RetainElement caching strategy in .NET MAUI.

### Description of Issue Fix

The fix involved checking if the platformView already had a parent (i.e., ViewGroup) and ensuring that the parent was removed before adding the platformView to the new container. By introducing this conditional check, the system prevents the platform view from being associated with multiple parents, which caused the "The specified child already has a parent" exception. This change ensures that dynamic template changes in the ListView are handled correctly, improving view recycling and maintaining stable rendering without conflicts.

Tested the behavior in the following platforms.
 
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac


### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #24701

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->

### Output



Before fix:

![ListView_BeforeFix](https://github.com/user-attachments/assets/24594261-edfd-48b4-866d-de74ff218215)


After fix:

![ListView_AfterFix](https://github.com/user-attachments/assets/9c595494-b760-46c3-9e42-66074c01db87)

### Testcase:

The Testcase is already available for this fix. Please refer to the PR link below for reference.


[Clear out prototype cell when changing ItemSource by PureWeen · Pull Request #24700 · dotnet/maui (github.com)](https://github.com/dotnet/maui/pull/24700)

