### PR TITLE
[housekeeping] Update & Consolidate Appium + driver versions

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -128,6 +128,14 @@
     <CoverletCollectorPackageVersion>6.0.0</CoverletCollectorPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
+    <!-- Appium -->
+    <AppiumVersion>2.11.4</AppiumVersion>
+    <AppiumWindowsDriverVersion>2.12.32</AppiumWindowsDriverVersion>
+    <AppiumXCUITestDriverVersion>7.26.4</AppiumXCUITestDriverVersion>
+    <AppiumMac2DriverVersion>1.19.1</AppiumMac2DriverVersion>
+    <AppiumUIAutomator2DriverVersion>3.8.0</AppiumUIAutomator2DriverVersion>
+  </PropertyGroup>
+  <PropertyGroup>
     <!-- arcade -->
     <!-- xunit -->
     <XUnitVersion>$(XunitPackageVersion)</XUnitVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -129,9 +129,9 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Appium -->
-    <AppiumVersion>2.11.4</AppiumVersion>
+    <AppiumVersion>2.11.5</AppiumVersion>
     <AppiumWindowsDriverVersion>2.12.32</AppiumWindowsDriverVersion>
-    <AppiumXCUITestDriverVersion>7.26.4</AppiumXCUITestDriverVersion>
+    <AppiumXCUITestDriverVersion>7.27.0</AppiumXCUITestDriverVersion>
     <AppiumMac2DriverVersion>1.19.1</AppiumMac2DriverVersion>
     <AppiumUIAutomator2DriverVersion>3.8.0</AppiumUIAutomator2DriverVersion>
   </PropertyGroup>

--- a/eng/scripts/appium-install.ps1
+++ b/eng/scripts/appium-install.ps1
@@ -49,7 +49,8 @@ param
 )
 
 # By default, versions should be read from /eng/Versions.props
-$versionPropsPath = [IO.Path]::Combine(Get-Location(), '..', 'Version.props')
+$getLocation = Get-Location
+$versionPropsPath = [IO.Path]::Combine($getLocation, '..', 'Version.props')
 
 if (Test-Path $versionPropsPath)
 {

--- a/eng/scripts/appium-install.ps1
+++ b/eng/scripts/appium-install.ps1
@@ -40,13 +40,47 @@ Find the script for that on the DevDiv Azure DevOps instance, Engineering team, 
 
 param
 (
-    [string] $appiumVersion = '2.11.4',
-    [string] $windowsDriverVersion = '2.12.32',
-    [string] $androidDriverVersion = '3.8.0',    
-    [string] $iOSDriverVersion = '7.26.4',
-    [string] $macDriverVersion = '1.19.1',
+    [string] $appiumVersion = '',
+    [string] $windowsDriverVersion = '',
+    [string] $androidDriverVersion = '',
+    [string] $iOSDriverVersion = '',
+    [string] $macDriverVersion = '',
     [string] $logsDir = '../appium-logs'
 )
+
+# By default, versions should be read from /eng/Versions.props
+$versionPropsPath = [IO.Path]::Combine(Get-Location(), '..', 'Version.props')
+
+if (Test-Path $versionPropsPath)
+{
+    Write-Output "Reading versions from Version.props..."
+    [xml]$versionProps = Get-Content $versionPropsPath
+    
+    $versionPropsAppiumVersion = $versionProps.Project.PropertyGroup.AppiumVersion | Where-Object { $_ -ne $null } | Select-Object -Last 1
+    if ($versionPropsAppiumVersion -ne $null) {
+        $appiumVersion = $versionPropsAppiumVersion
+    }
+
+    $versionPropsWindowsDriverVersion = $versionProps.Project.PropertyGroup.AppiumWindowsDriverVersion | Where-Object { $_ -ne $null } | Select-Object -Last 1
+    if ($versionPropsWindowsDriverVersion -ne $null) {
+        $windowsDriverVersion = $versionPropsWindowsDriverVersion
+    }
+
+    $versionPropsUIAutomator2DriverVersion = $versionProps.Project.PropertyGroup.AppiumUIAutomator2DriverVersion | Where-Object { $_ -ne $null } | Select-Object -Last 1
+    if ($versionPropsUIAutomator2DriverVersion -ne $null) {
+        $androidDriverVersion = $versionPropsUIAutomator2DriverVersion
+    }
+
+    $versionPropsXCUItestDriverVersion = $versionProps.Project.PropertyGroup.AppiumXCUITestDriverVersion | Where-Object { $_ -ne $null } | Select-Object -Last 1
+    if ($versionPropsXCUItestDriverVersion -ne $null) {
+        $iOSDriverVersion = $versionPropsXCUItestDriverVersion
+    }
+
+    $versionPropsMac2DriverVersion = $versionProps.Project.PropertyGroup.AppiumMac2DriverVersion | Where-Object { $_ -ne $null } | Select-Object -Last 1
+    if ($versionPropsMac2DriverVersion -ne $null) {
+        $macDriverVersion = $versionPropsMac2DriverVersion
+    }
+}
 
 Write-Output  "Welcome to the Appium installer"
 

--- a/eng/scripts/appium-install.ps1
+++ b/eng/scripts/appium-install.ps1
@@ -40,11 +40,11 @@ Find the script for that on the DevDiv Azure DevOps instance, Engineering team, 
 
 param
 (
-    [string] $appiumVersion = '2.11.0',
-    [string] $windowsDriverVersion = '2.12.23',
-    [string] $androidDriverVersion = '3.7.0',    
-    [string] $iOSDriverVersion = '7.21.0',
-    [string] $macDriverVersion = '1.17.4',
+    [string] $appiumVersion = '2.11.4',
+    [string] $windowsDriverVersion = '2.12.32',
+    [string] $androidDriverVersion = '3.8.0',    
+    [string] $iOSDriverVersion = '7.26.4',
+    [string] $macDriverVersion = '1.19.1',
     [string] $logsDir = '../appium-logs'
 )
 

--- a/eng/scripts/appium-install.ps1
+++ b/eng/scripts/appium-install.ps1
@@ -52,6 +52,8 @@ param
 $getLocation = Get-Location
 $versionPropsPath = [IO.Path]::Combine($getLocation, '..', 'Version.props')
 
+Write-Output "Checking $versionPropsPath for versions..."
+
 if (Test-Path $versionPropsPath)
 {
     Write-Output "Reading versions from Version.props..."
@@ -122,11 +124,16 @@ if ($appiumCurrentVersion) {
     Write-Output  "No Appium version installed"
 }
 
+# Check if we found a version of appium at all
+$missingAppium = [string]::IsNullOrEmpty($appiumCurrentVersion)
+
 # If current version does not match the one we want, uninstall and install the new version
-if ($appiumCurrentVersion -ne $appiumVersion) {
-    Write-Output  "Uninstalling appium $appiumCurrentVersion"
-    npm uninstall --logs-dir=$logsDir --loglevel $npmLogLevel -g appium
-    Write-Output  "Uninstalled appium $appiumCurrentVersion"
+if ($missingAppium -or ($appiumCurrentVersion -ne $appiumVersion)) {
+    if (-not $missingAppium) {
+        Write-Output  "Uninstalling appium $appiumCurrentVersion"
+        npm uninstall --logs-dir=$logsDir --loglevel $npmLogLevel -g appium
+        Write-Output  "Uninstalled appium $appiumCurrentVersion"
+    }
 
     Write-Output  "Installing appium $appiumVersion"
     npm install --logs-dir=$logsDir --loglevel $npmLogLevel -g appium@$appiumVersion

--- a/eng/scripts/appium-install.ps1
+++ b/eng/scripts/appium-install.ps1
@@ -49,8 +49,8 @@ param
 )
 
 # By default, versions should be read from /eng/Versions.props
-$getLocation = Get-Location
-$versionPropsPath = [IO.Path]::Combine($getLocation, '..', 'Version.props')
+$getLocation = $PSScriptRoot
+$versionPropsPath = [IO.Path]::Combine($getLocation, '..', 'Versions.props')
 
 Write-Output "Checking $versionPropsPath for versions..."
 
@@ -83,6 +83,9 @@ if (Test-Path $versionPropsPath)
     if ($versionPropsMac2DriverVersion -ne $null) {
         $macDriverVersion = $versionPropsMac2DriverVersion
     }
+}
+else {
+    throw "The version.props file was not found at path: $versionPropsPath"
 }
 
 Write-Output  "Welcome to the Appium installer"


### PR DESCRIPTION
Updating to latest Appium and Appium Driver versions (except windows not just yet since they have moved away from automatically installing WAD, so we'll look at that in a different PR).

This also moves those versions to our consolidated `/eng/Versions.props` file.
