### PR TITLE
Add newer cmd linetools paths to cake

### DIFF
--- a/eng/devices/android.cake
+++ b/eng/devices/android.cake
@@ -376,7 +376,17 @@ void PerformCleanupIfNeeded(bool cleanupEnabled)
 void SetAndroidEnvironmentVariables(string sdkRoot)
 {
 	// Set up Android SDK environment variables and paths
-	string[] paths = { $"{sdkRoot}/tools/bin", $"{sdkRoot}/cmdline-tools/latest/bin", $"{sdkRoot}/cmdline-tools/5.0/bin", $"{sdkRoot}/cmdline-tools/7.0/bin", $"{sdkRoot}/platform-tools", $"{sdkRoot}/emulator" };
+	string[] paths = { 
+		$"{sdkRoot}/tools/bin", 
+		$"{sdkRoot}/cmdline-tools/latest/bin", 
+		$"{sdkRoot}/cmdline-tools/5.0/bin", 
+		$"{sdkRoot}/cmdline-tools/7.0/bin", 
+		$"{sdkRoot}/cmdline-tools/11.0/bin", 
+		$"{sdkRoot}/cmdline-tools/12.0/bin",
+		$"{sdkRoot}/cmdline-tools/13.0/bin",
+		$"{sdkRoot}/platform-tools", 
+		$"{sdkRoot}/emulator" };
+		
 	foreach (var path in paths)
 	{
 		SetEnvironmentVariable("PATH", path, prepend: true);


### PR DESCRIPTION
### Description of Change

The newer versions of VS only install version 11.0. We need to make sure that's part of the path.

We have some work planned to convert these commands to not be as dependent on cake but for now this will fix scenarios that are just installing 11+