### PR TITLE
Batch iOS SetNeedsLayout

### DIFF
--- a/src/Core/src/Handlers/Layout/LayoutHandler.iOS.cs
+++ b/src/Core/src/Handlers/Layout/LayoutHandler.iOS.cs
@@ -38,6 +38,8 @@ namespace Microsoft.Maui.Handlers
 			{
 				PlatformView.AddSubview(child.ToPlatform(MauiContext));
 			}
+
+			PlatformView.SetNeedsLayout();
 		}
 
 		public void Add(IView child)
@@ -54,6 +56,8 @@ namespace Microsoft.Maui.Handlers
 			{
 				childPlatformView.UpdateFlowDirection(child);
 			}
+
+			PlatformView.SetNeedsLayout();
 		}
 
 		public void Remove(IView child)
@@ -64,12 +68,14 @@ namespace Microsoft.Maui.Handlers
 			if (child?.ToPlatform() is PlatformView childView)
 			{
 				childView.RemoveFromSuperview();
+				PlatformView.SetNeedsLayout();
 			}
 		}
 
 		public void Clear()
 		{
 			PlatformView.ClearSubviews();
+			PlatformView.SetNeedsLayout();
 		}
 
 		public void Insert(int index, IView child)
@@ -86,6 +92,8 @@ namespace Microsoft.Maui.Handlers
 			{
 				childPlatformView.UpdateFlowDirection(child);
 			}
+
+			PlatformView.SetNeedsLayout();
 		}
 
 		public void Update(int index, IView child)
@@ -137,6 +145,7 @@ namespace Microsoft.Maui.Handlers
 			{
 				PlatformView.Subviews.RemoveAt(currentIndex);
 				PlatformView.InsertSubview(nativeChildView, targetIndex);
+				PlatformView.SetNeedsLayout();
 			}
 		}
 

--- a/src/Core/src/Platform/iOS/LayoutView.cs
+++ b/src/Core/src/Platform/iOS/LayoutView.cs
@@ -7,20 +7,6 @@ namespace Microsoft.Maui.Platform
 	{
 		bool _userInteractionEnabled;
 
-		public override void SubviewAdded(UIView uiview)
-		{
-			InvalidateConstraintsCache();
-			base.SubviewAdded(uiview);
-			TryToInvalidateSuperView(false);
-		}
-
-		public override void WillRemoveSubview(UIView uiview)
-		{
-			InvalidateConstraintsCache();
-			base.WillRemoveSubview(uiview);
-			TryToInvalidateSuperView(false);
-		}
-
 		public override UIView? HitTest(CGPoint point, UIEvent? uievent)
 		{
 			var result = base.HitTest(point, uievent);

--- a/src/Core/src/Platform/iOS/ViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/ViewExtensions.cs
@@ -296,6 +296,35 @@ namespace Microsoft.Maui.Platform
 			UpdateFrame(platformView, view);
 		}
 
+		const nint DefaultTag = 0;
+		const nint LayoutPassTag = -1;
+
+		internal static bool IsInLayoutPass(this UIView view)
+		{
+			if (view.Window is { } window)
+			{
+				return window.Tag == LayoutPassTag;
+			}
+
+			return false;
+		}
+
+		internal static void BeginLayoutPass(this UIView view)
+		{
+			if (view.Window is { } window)
+			{
+				window.Tag = LayoutPassTag;
+			}
+		}
+
+		internal static void EndLayoutPass(this UIView view)
+		{
+			if (view.Window is { } window)
+			{
+				window.Tag = DefaultTag;
+			}
+		}
+
 		public static void UpdateHeight(this UIView platformView, IView view)
 		{
 			UpdateFrame(platformView, view);

--- a/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -1,3 +1,5 @@
 #nullable enable
 override Microsoft.Maui.Platform.MauiCALayer.AddAnimation(CoreAnimation.CAAnimation! animation, string? key) -> void
 *REMOVED*override Microsoft.Maui.Handlers.BorderHandler.ConnectHandler(Microsoft.Maui.Platform.ContentView! platformView) -> void
+*REMOVED*override Microsoft.Maui.Platform.LayoutView.SubviewAdded(UIKit.UIView! uiview) -> void
+*REMOVED*override Microsoft.Maui.Platform.LayoutView.WillRemoveSubview(UIKit.UIView! uiview) -> void

--- a/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,3 +1,5 @@
 #nullable enable
 override Microsoft.Maui.Platform.MauiCALayer.AddAnimation(CoreAnimation.CAAnimation! animation, string? key) -> void
 *REMOVED*override Microsoft.Maui.Handlers.BorderHandler.ConnectHandler(Microsoft.Maui.Platform.ContentView! platformView) -> void
+*REMOVED*override Microsoft.Maui.Platform.LayoutView.SubviewAdded(UIKit.UIView! uiview) -> void
+*REMOVED*override Microsoft.Maui.Platform.LayoutView.WillRemoveSubview(UIKit.UIView! uiview) -> void


### PR DESCRIPTION
### Description of Change

This PR avoids the repetitive native layout traversal to invalidate ancestors.
This also removes overrides on iOS layout methods (add / remove) and brings invalidation to the handler.

**Before**
![image](https://github.com/user-attachments/assets/7ba5b6d7-b4c9-4520-bb91-dd7d935c532c)

**After**
![image](https://github.com/user-attachments/assets/264e4edd-5332-44f9-a175-ce2a72db8112)