### PR TITLE
[Android] SearchHandler - added focus/unfocus support

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/SearchHandlerAppearanceTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/SearchHandlerAppearanceTracker.cs
@@ -32,6 +32,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			_control = searchView.View;
 			_searchHandler.PropertyChanged += SearchHandlerPropertyChanged;
 			_editText = (_control as ViewGroup).GetChildrenOfType<EditText>().FirstOrDefault();
+			_editText.FocusChange += EditTextFocusChange;
 			UpdateSearchBarColors();
 			UpdateFont();
 			UpdateHorizontalTextAlignment();
@@ -81,6 +82,11 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			{
 				UpdateAutomationId();
 			}
+		}
+
+		void EditTextFocusChange(object s, AView.FocusChangeEventArgs args)
+		{
+			_searchHandler.SetIsFocused(_editText.IsFocused);
 		}
 
 		void UpdateSearchBarColors()
@@ -221,6 +227,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				if (_searchHandler != null)
 				{
 					_searchHandler.PropertyChanged -= SearchHandlerPropertyChanged;
+					_editText.FocusChange -= EditTextFocusChange;
 				}
 				_searchHandler = null;
 				_control = null;

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue24670.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue24670.xaml
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Shell xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+       xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+       x:Class="Maui.Controls.Sample.Issues.Issue24670">
+    <ShellContent
+        Title="Home"
+        Route="MainPage">
+        <ContentPage>
+            <Shell.SearchHandler>
+                <SearchHandler
+                    x:Name="searchHandler"
+                    SearchBoxVisibility="Expanded"
+                    Focused="SearchHandler_Focused"
+                    Unfocused="SearchHandler_Unfocused"
+                    Placeholder="Click to focus.."/>
+            </Shell.SearchHandler>
+
+            <StackLayout>
+                <Entry AutomationId="entry"/>
+                <Label x:Name="focusedLabel"
+                       AutomationId="focusedLabel"
+                       Text="Focused: False"/>
+                <Label x:Name="unfocusedLabel"
+                       AutomationId="unfocusedLabel"
+                       Text="Unfocused: False"/>
+            </StackLayout>
+        </ContentPage>
+    </ShellContent>
+</Shell>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue24670.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue24670.xaml
@@ -9,10 +9,11 @@
             <Shell.SearchHandler>
                 <SearchHandler
                     x:Name="searchHandler"
+                    AutomationId="searchHandler"
+                    Placeholder="searchHandler"
                     SearchBoxVisibility="Expanded"
                     Focused="SearchHandler_Focused"
-                    Unfocused="SearchHandler_Unfocused"
-                    Placeholder="Click to focus.."/>
+                    Unfocused="SearchHandler_Unfocused"/>
             </Shell.SearchHandler>
 
             <StackLayout>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue24670.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue24670.xaml.cs
@@ -1,0 +1,22 @@
+﻿namespace Maui.Controls.Sample.Issues
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	[Issue(IssueTracker.Github, "24670", "SearchHandler.Focused event never fires", PlatformAffected.All)]
+	public partial class Issue24670 : Shell
+	{
+		public Issue24670()
+		{
+			InitializeComponent();
+		}
+
+		private void SearchHandler_Focused(object sender, EventArgs e)
+		{
+			focusedLabel.Text = "Focused: True";
+		}
+
+		private void SearchHandler_Unfocused(object sender, EventArgs e)
+		{
+			unfocusedLabel.Text = "Unfocused: True";
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue24670.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue24670.cs
@@ -1,0 +1,35 @@
+﻿#if ANDROID
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue24670 : _IssuesUITest
+	{
+		public override string Issue => "SearchHandler.Focused event never fires";
+
+		public Issue24670(TestDevice testDevice) : base(testDevice)
+		{
+		}
+
+		[Test]
+		[Category(UITestCategories.Shell)]
+		[Category(UITestCategories.SearchBar)]
+		public void SearchHandlerFocusAndUnfocusEventsShouldWork()
+		{
+			// Click the edit text of the search handler at the top to focus it
+			App.DoubleTapCoordinates(250, 150);
+
+			// Click the entry below to trigger the unfocused event
+			App.Click("entry");
+			
+			var focusedLabelText = App.WaitForElement("focusedLabel").GetText();
+			var unfocusedLabelText = App.WaitForElement("unfocusedLabel").GetText();
+
+			Assert.That(focusedLabelText, Is.EqualTo("Focused: True"));
+			Assert.That(unfocusedLabelText, Is.EqualTo("Unfocused: True"));
+		}
+	}
+}
+#endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue24670.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue24670.cs
@@ -18,8 +18,8 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		[Category(UITestCategories.SearchBar)]
 		public void SearchHandlerFocusAndUnfocusEventsShouldWork()
 		{
-			// Click the edit text of the search handler at the top to focus it
-			App.DoubleTapCoordinates(250, 150);
+			App.WaitForElement("searchHandler");
+			App.Click("searchHandler");
 
 			// Click the entry below to trigger the unfocused event
 			App.Click("entry");


### PR DESCRIPTION
### Description of Change

Added a missing support for focus/unfocus events. Implemented it similar to how it has been done for iOS 
(https://github.dev/kubaflo/maui/blob/8921d3bfab72dc78aba940020a6b2ea06a708408/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/SearchHandlerAppearanceTracker.cs#L32-L49)

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/24670

<video src="https://github.com/user-attachments/assets/47372cf0-4bfa-4d55-bb05-02b99157c1a6" width="300px"/>

