### PR TITLE
FlyoutItemIsVisible property in Shell Items is always true

### DIFF
--- a/src/Controls/src/Core/Shell/ShellItem.cs
+++ b/src/Controls/src/Core/Shell/ShellItem.cs
@@ -221,6 +221,9 @@ namespace Microsoft.Maui.Controls
 
 			result.Route = Routing.GenerateImplicitRoute(shellSection.Route);
 
+			// Fix for FlyoutItemIsVisible property in Shell Items is always true, we need to set FlyoutItemIsVisible
+			result.FlyoutItemIsVisible = Shell.GetFlyoutItemIsVisible(shellSection.CurrentItem);
+
 			result.Items.Add(shellSection);
 			result.SetBinding(TitleProperty, new Binding(nameof(Title), BindingMode.OneWay, source: shellSection));
 			result.SetBinding(IconProperty, new Binding(nameof(Icon), BindingMode.OneWay, source: shellSection));

--- a/src/Controls/src/Core/Shell/ShellSection.cs
+++ b/src/Controls/src/Core/Shell/ShellSection.cs
@@ -289,6 +289,9 @@ namespace Microsoft.Maui.Controls
 
 			shellSection.Route = Routing.GenerateImplicitRoute(contentRoute);
 
+			// Fix for FlyoutItemIsVisible property in Shell Items is always true, we need to set FlyoutItemIsVisible
+			shellSection.FlyoutItemIsVisible = Shell.GetFlyoutItemIsVisible(shellContent);
+
 			shellSection.Items.Add(shellContent);
 
 			shellSection.SetBinding(TitleProperty, new Binding(nameof(Title), BindingMode.OneWay, source: shellContent));

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
@@ -345,6 +345,53 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
+		[Fact(DisplayName = "FlyoutItemIsVisible is always true")]
+		public async Task FlyoutItemVisibilityWithoutTabBar()
+		{
+			SetupBuilder();
+			// Set up Shell and content pages
+			var mainTabPage = new ContentPage() {Title = "MainTabPage" };
+			var secondTabPage = new ContentPage() { Title = "SecondTabPage" };
+			var thirdTabPage = new ContentPage() { Title = "ThirdTabPage" };
+
+			Shell shell = new Shell();
+
+			// Adding ShellContent directly to Shell
+			shell.Items.Add(new ShellContent()
+			{
+				Title = "Home",
+				FlyoutItemIsVisible = false, // Set to false to hide from Flyout
+				ContentTemplate = new DataTemplate(() => mainTabPage),
+				Route = "MainPage"
+			});
+
+			shell.Items.Add(new ShellContent()
+			{
+				Title = "SecondTabPage",
+				FlyoutItemIsVisible = false, // Set to false to hide from Flyout
+				ContentTemplate = new DataTemplate(() => secondTabPage),
+				Route = "SecondTabPage"
+			});
+
+			shell.Items.Add(new ShellContent()
+			{
+				Title = "ThirdTabPage",
+				FlyoutItemIsVisible = false, // Set to false to hide from Flyout
+				ContentTemplate = new DataTemplate(() => thirdTabPage),
+				Route = "ThirdTabPage"
+			});
+
+			// Get visible flyout items
+			var visibleFlyoutItems = shell.Items.Where(item => item.FlyoutItemIsVisible).ToList();
+
+			await CreateHandlerAndAddToWindow<ShellHandler>(shell, async (handler) =>
+			{
+				// TODO MAUI Fix this 
+				await Task.Delay(100);
+				Assert.Empty(visibleFlyoutItems);
+			});
+		}
+
 		[Fact(DisplayName = "FlyoutContent Renderers When FlyoutBehavior Starts As Locked")]
 		public async Task FlyoutContentRenderersWhenFlyoutBehaviorStartsAsLocked()
 		{

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
@@ -346,13 +346,12 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		[Fact(DisplayName = "FlyoutItemIsVisible is always true")]
-		public async Task FlyoutItemVisibilityWithoutTabBar()
+		public async Task FlyoutItemIsVisiblePropertyTest()
 		{
 			SetupBuilder();
 			// Set up Shell and content pages
 			var mainTabPage = new ContentPage() {Title = "MainTabPage" };
 			var secondTabPage = new ContentPage() { Title = "SecondTabPage" };
-			var thirdTabPage = new ContentPage() { Title = "ThirdTabPage" };
 
 			Shell shell = new Shell();
 
@@ -368,26 +367,16 @@ namespace Microsoft.Maui.DeviceTests
 			shell.Items.Add(new ShellContent()
 			{
 				Title = "SecondTabPage",
-				FlyoutItemIsVisible = false, // Set to false to hide from Flyout
+				FlyoutItemIsVisible = false,
 				ContentTemplate = new DataTemplate(() => secondTabPage),
 				Route = "SecondTabPage"
-			});
-
-			shell.Items.Add(new ShellContent()
-			{
-				Title = "ThirdTabPage",
-				FlyoutItemIsVisible = false, // Set to false to hide from Flyout
-				ContentTemplate = new DataTemplate(() => thirdTabPage),
-				Route = "ThirdTabPage"
 			});
 
 			// Get visible flyout items
 			var visibleFlyoutItems = shell.Items.Where(item => item.FlyoutItemIsVisible).ToList();
 
-			await CreateHandlerAndAddToWindow<ShellHandler>(shell, async (handler) =>
+			await CreateHandlerAndAddToWindow<ShellHandler>(shell,(handler) =>
 			{
-				// TODO MAUI Fix this 
-				await Task.Delay(100);
 				Assert.Empty(visibleFlyoutItems);
 			});
 		}


### PR DESCRIPTION
### RootCause 
The FlyoutItemIsVisible property has a default value of true, the bindable property in Shell handles the data updates.  However, updates to the FlyoutItemIsVisible property are not reflected in the public API.

### Description of Change

Updated the FlyoutItemIsVisible while creating a shellcontent to update the public API properly 

### Validated the behaviour in the following platforms
 
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

### Issues Fixed
Fixes #24797 