### PR TITLE
[C] fix specificity comparison

### DIFF
--- a/src/Controls/src/Core/Element/Element.cs
+++ b/src/Controls/src/Core/Element/Element.cs
@@ -747,7 +747,7 @@ namespace Microsoft.Maui.Controls
 		internal override void OnSetDynamicResource(BindableProperty property, string key, SetterSpecificity specificity)
 		{
 			base.OnSetDynamicResource(property, key, specificity);
-			if (!DynamicResources.TryGetValue(property, out var existing) || existing.Item2.CompareTo(specificity) < 0)
+			if (!DynamicResources.TryGetValue(property, out var existing) || existing.Item2.CompareTo(specificity) <= 0)
 				DynamicResources[property] = (key, specificity);
 			if (this.TryGetResource(key, out var value))
 				OnResourceChanged(property, value, specificity);

--- a/src/Controls/tests/Xaml.UnitTests/AppResources/Style24849.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/AppResources/Style24849.xaml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ResourceDictionary xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" 
+             x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Style24849">
+    <Color x:Key="PrimaryButtonBackgroundColor">#D65397</Color>
+    <Color x:Key="PrimaryButtonTextColor">White</Color>
+    <Color x:Key="PrimaryButtonDisabledBackgroundColor">#EBE9EB</Color>
+    <Color x:Key="PrimaryButtonDisabledTextColor">#3c3c3b</Color>
+    <Style TargetType="Button">                
+        <Setter Property="TextColor" Value="{DynamicResource PrimaryButtonTextColor}" />
+        <Setter Property="Background" Value="{DynamicResource PrimaryButtonBackgroundColor}" />
+        <Setter Property="VisualStateManager.VisualStateGroups">
+
+            <!--  below is working version  -->
+            <!--<VisualStateGroupList>
+                <VisualStateGroup x:Name="CommonStates">
+                    <VisualState x:Name="Normal" />
+                    <VisualState x:Name="Disabled">
+                        <VisualState.Setters>
+                            <Setter Property="TextColor" Value="{DynamicResource PrimaryButtonDisabledTextColor}" />
+                            <Setter Property="Background" Value="{DynamicResource PrimaryButtonDisabledBackgroundColor}" />
+                        </VisualState.Setters>
+                    </VisualState>
+                    <VisualState x:Name="PointerOver" />
+                </VisualStateGroup>
+            </VisualStateGroupList>-->
+
+            <!--  below is not working  -->
+            <VisualStateGroupList>
+                <VisualStateGroup x:Name="CommonStates">
+                    <VisualState x:Name="Normal">
+                        <VisualState.Setters>
+                            <Setter Property="Background" Value="{DynamicResource PrimaryButtonBackgroundColor}" />
+                            <Setter Property="TextColor" Value="{DynamicResource PrimaryButtonTextColor}" />
+                        </VisualState.Setters>
+                    </VisualState>
+                    <VisualState x:Name="Disabled">
+                        <VisualState.Setters>
+                            <Setter Property="TextColor" Value="{DynamicResource PrimaryButtonDisabledTextColor}" />
+                            <Setter Property="Background" Value="{DynamicResource PrimaryButtonDisabledBackgroundColor}" />
+                        </VisualState.Setters>
+                    </VisualState>
+                </VisualStateGroup>
+            </VisualStateGroupList>
+        </Setter>
+    </Style>
+</ResourceDictionary>

--- a/src/Controls/tests/Xaml.UnitTests/AppResources/Style24849.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/AppResources/Style24849.xaml
@@ -2,42 +2,21 @@
 <ResourceDictionary xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" 
              x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Style24849">
-    <Color x:Key="PrimaryButtonBackgroundColor">#D65397</Color>
     <Color x:Key="PrimaryButtonTextColor">White</Color>
-    <Color x:Key="PrimaryButtonDisabledBackgroundColor">#EBE9EB</Color>
     <Color x:Key="PrimaryButtonDisabledTextColor">#3c3c3b</Color>
     <Style TargetType="Button">                
         <Setter Property="TextColor" Value="{DynamicResource PrimaryButtonTextColor}" />
-        <Setter Property="Background" Value="{DynamicResource PrimaryButtonBackgroundColor}" />
         <Setter Property="VisualStateManager.VisualStateGroups">
-
-            <!--  below is working version  -->
-            <!--<VisualStateGroupList>
-                <VisualStateGroup x:Name="CommonStates">
-                    <VisualState x:Name="Normal" />
-                    <VisualState x:Name="Disabled">
-                        <VisualState.Setters>
-                            <Setter Property="TextColor" Value="{DynamicResource PrimaryButtonDisabledTextColor}" />
-                            <Setter Property="Background" Value="{DynamicResource PrimaryButtonDisabledBackgroundColor}" />
-                        </VisualState.Setters>
-                    </VisualState>
-                    <VisualState x:Name="PointerOver" />
-                </VisualStateGroup>
-            </VisualStateGroupList>-->
-
-            <!--  below is not working  -->
             <VisualStateGroupList>
                 <VisualStateGroup x:Name="CommonStates">
                     <VisualState x:Name="Normal">
                         <VisualState.Setters>
-                            <Setter Property="Background" Value="{DynamicResource PrimaryButtonBackgroundColor}" />
                             <Setter Property="TextColor" Value="{DynamicResource PrimaryButtonTextColor}" />
                         </VisualState.Setters>
                     </VisualState>
                     <VisualState x:Name="Disabled">
                         <VisualState.Setters>
                             <Setter Property="TextColor" Value="{DynamicResource PrimaryButtonDisabledTextColor}" />
-                            <Setter Property="Background" Value="{DynamicResource PrimaryButtonDisabledBackgroundColor}" />
                         </VisualState.Setters>
                     </VisualState>
                 </VisualStateGroup>

--- a/src/Controls/tests/Xaml.UnitTests/AppResources/Style24849.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/AppResources/Style24849.xaml.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Core.UnitTests;
+using NUnit.Framework;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests
+{
+	public partial class Style24849 : ResourceDictionary
+	{
+		public Style24849()
+		{
+			InitializeComponent();
+		}
+	}
+}

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui24849.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui24849.xaml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests"
+             x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui24849">
+    <ContentPage.Resources>
+        <Color x:Key="PrimaryButtonBackgroundColor">#D65397</Color>
+        <Color x:Key="PrimaryButtonTextColor">White</Color>
+        <Color x:Key="PrimaryButtonDisabledBackgroundColor">#EBE9EB</Color>
+        <Color x:Key="PrimaryButtonDisabledTextColor">#3c3c3b</Color>
+        <Style TargetType="Button">                
+            <Setter Property="TextColor" Value="{DynamicResource PrimaryButtonTextColor}" />
+            <Setter Property="Background" Value="{DynamicResource PrimaryButtonBackgroundColor}" />
+            <Setter Property="VisualStateManager.VisualStateGroups">
+
+                <!--  below is working version  -->
+                <!--<VisualStateGroupList>
+                    <VisualStateGroup x:Name="CommonStates">
+                        <VisualState x:Name="Normal" />
+                        <VisualState x:Name="Disabled">
+                            <VisualState.Setters>
+                                <Setter Property="TextColor" Value="{DynamicResource PrimaryButtonDisabledTextColor}" />
+                                <Setter Property="Background" Value="{DynamicResource PrimaryButtonDisabledBackgroundColor}" />
+                            </VisualState.Setters>
+                        </VisualState>
+                        <VisualState x:Name="PointerOver" />
+                    </VisualStateGroup>
+                </VisualStateGroupList>-->
+
+                <!--  below is not working  -->
+                <VisualStateGroupList>
+                    <VisualStateGroup x:Name="CommonStates">
+                        <VisualState x:Name="Normal">
+                            <VisualState.Setters>
+                                <Setter Property="Background" Value="{DynamicResource PrimaryButtonBackgroundColor}" />
+                                <Setter Property="TextColor" Value="{DynamicResource PrimaryButtonTextColor}" />
+                            </VisualState.Setters>
+                        </VisualState>
+                        <VisualState x:Name="Disabled">
+                            <VisualState.Setters>
+                                <Setter Property="TextColor" Value="{DynamicResource PrimaryButtonDisabledTextColor}" />
+                                <Setter Property="Background" Value="{DynamicResource PrimaryButtonDisabledBackgroundColor}" />
+                            </VisualState.Setters>
+                        </VisualState>
+                    </VisualStateGroup>
+                </VisualStateGroupList>
+            </Setter>
+        </Style>
+    </ContentPage.Resources>
+    <Button x:Name="button"  IsEnabled="False" />
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui24849.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui24849.xaml
@@ -3,49 +3,5 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests"
              x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui24849">
-    <ContentPage.Resources>
-        <Color x:Key="PrimaryButtonBackgroundColor">#D65397</Color>
-        <Color x:Key="PrimaryButtonTextColor">White</Color>
-        <Color x:Key="PrimaryButtonDisabledBackgroundColor">#EBE9EB</Color>
-        <Color x:Key="PrimaryButtonDisabledTextColor">#3c3c3b</Color>
-        <Style TargetType="Button">                
-            <Setter Property="TextColor" Value="{DynamicResource PrimaryButtonTextColor}" />
-            <Setter Property="Background" Value="{DynamicResource PrimaryButtonBackgroundColor}" />
-            <Setter Property="VisualStateManager.VisualStateGroups">
-
-                <!--  below is working version  -->
-                <!--<VisualStateGroupList>
-                    <VisualStateGroup x:Name="CommonStates">
-                        <VisualState x:Name="Normal" />
-                        <VisualState x:Name="Disabled">
-                            <VisualState.Setters>
-                                <Setter Property="TextColor" Value="{DynamicResource PrimaryButtonDisabledTextColor}" />
-                                <Setter Property="Background" Value="{DynamicResource PrimaryButtonDisabledBackgroundColor}" />
-                            </VisualState.Setters>
-                        </VisualState>
-                        <VisualState x:Name="PointerOver" />
-                    </VisualStateGroup>
-                </VisualStateGroupList>-->
-
-                <!--  below is not working  -->
-                <VisualStateGroupList>
-                    <VisualStateGroup x:Name="CommonStates">
-                        <VisualState x:Name="Normal">
-                            <VisualState.Setters>
-                                <Setter Property="Background" Value="{DynamicResource PrimaryButtonBackgroundColor}" />
-                                <Setter Property="TextColor" Value="{DynamicResource PrimaryButtonTextColor}" />
-                            </VisualState.Setters>
-                        </VisualState>
-                        <VisualState x:Name="Disabled">
-                            <VisualState.Setters>
-                                <Setter Property="TextColor" Value="{DynamicResource PrimaryButtonDisabledTextColor}" />
-                                <Setter Property="Background" Value="{DynamicResource PrimaryButtonDisabledBackgroundColor}" />
-                            </VisualState.Setters>
-                        </VisualState>
-                    </VisualStateGroup>
-                </VisualStateGroupList>
-            </Setter>
-        </Style>
-    </ContentPage.Resources>
     <Button x:Name="button"  IsEnabled="False" />
 </ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui24849.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui24849.xaml.cs
@@ -49,8 +49,12 @@ public partial class Maui24849 : ContentPage
 
         [Test]
         public void VSGReturnsToNormal([Values(false, true)] bool useCompiledXaml)
-        {
-            var page = new Maui24849(useCompiledXaml);
+        {            
+            var app = new MockApplication();
+            app.Resources.Add(new Style24849());
+            
+            var page = new Maui24849(useCompiledXaml);        
+            app.MainPage = page;
 
             Assert.That(page.button.IsEnabled, Is.False);
             Assert.That((page.button.Background as SolidColorBrush).Color , Is.EqualTo(Color.FromHex("#EBE9EB")));
@@ -65,7 +69,6 @@ public partial class Maui24849 : ContentPage
             Assert.That(page.button.IsEnabled, Is.False);
             Assert.That((page.button.Background as SolidColorBrush).Color , Is.EqualTo(Color.FromHex("#EBE9EB")));
             Assert.That(page.button.TextColor, Is.EqualTo(Color.FromHex("#3c3c3b")));
-
         }
     }
 }

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui24849.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui24849.xaml.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+using Microsoft.Maui.ApplicationModel;
+using Microsoft.Maui.Controls.Core.UnitTests;
+using Microsoft.Maui.Controls.Shapes;
+using Microsoft.Maui.Devices;
+using Microsoft.Maui.Dispatching;
+
+using Microsoft.Maui.Graphics;
+using Microsoft.Maui.UnitTests;
+using NUnit.Framework;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public partial class Maui24849 : ContentPage
+{
+    public Maui24849()
+    {
+        InitializeComponent();
+    }
+
+    public Maui24849(bool useCompiledXaml)
+    {
+        //this stub will be replaced at compile time
+    }
+
+    [TestFixture]
+    class Test
+    {
+        MockDeviceInfo mockDeviceInfo;
+
+        [SetUp]
+        public void Setup()
+        {
+            Application.SetCurrentApplication(new MockApplication());
+            DeviceInfo.SetCurrent(mockDeviceInfo = new MockDeviceInfo());
+            DispatcherProvider.SetCurrent(new DispatcherProviderStub());
+        }
+
+
+        [TearDown] public void TearDown()
+        {
+            AppInfo.SetCurrent(null);
+            DeviceInfo.SetCurrent(null);
+        }
+
+        [Test]
+        public void VSGReturnsToNormal([Values(false, true)] bool useCompiledXaml)
+        {
+            var page = new Maui24849(useCompiledXaml);
+
+            Assert.That(page.button.IsEnabled, Is.False);
+            Assert.That((page.button.Background as SolidColorBrush).Color , Is.EqualTo(Color.FromHex("#EBE9EB")));
+            Assert.That(page.button.TextColor, Is.EqualTo(Color.FromHex("#3c3c3b")));
+
+            page.button.IsEnabled = true;
+            Assert.That(page.button.IsEnabled, Is.True);
+            Assert.That((page.button.Background as SolidColorBrush).Color, Is.EqualTo(Color.FromHex("#D65397")));
+            Assert.That(page.button.TextColor, Is.EqualTo(Colors.White));
+
+            page.button.IsEnabled = false;
+            Assert.That(page.button.IsEnabled, Is.False);
+            Assert.That((page.button.Background as SolidColorBrush).Color , Is.EqualTo(Color.FromHex("#EBE9EB")));
+            Assert.That(page.button.TextColor, Is.EqualTo(Color.FromHex("#3c3c3b")));
+
+        }
+    }
+}

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui24849.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui24849.xaml.cs
@@ -52,22 +52,19 @@ public partial class Maui24849 : ContentPage
         {            
             var app = new MockApplication();
             app.Resources.Add(new Style24849());
-            
-            var page = new Maui24849(useCompiledXaml);        
+            var page = new Maui24849(useCompiledXaml);       
+                         
             app.MainPage = page;
 
             Assert.That(page.button.IsEnabled, Is.False);
-            Assert.That((page.button.Background as SolidColorBrush).Color , Is.EqualTo(Color.FromHex("#EBE9EB")));
             Assert.That(page.button.TextColor, Is.EqualTo(Color.FromHex("#3c3c3b")));
 
             page.button.IsEnabled = true;
             Assert.That(page.button.IsEnabled, Is.True);
-            Assert.That((page.button.Background as SolidColorBrush).Color, Is.EqualTo(Color.FromHex("#D65397")));
             Assert.That(page.button.TextColor, Is.EqualTo(Colors.White));
 
             page.button.IsEnabled = false;
             Assert.That(page.button.IsEnabled, Is.False);
-            Assert.That((page.button.Background as SolidColorBrush).Color , Is.EqualTo(Color.FromHex("#EBE9EB")));
             Assert.That(page.button.TextColor, Is.EqualTo(Color.FromHex("#3c3c3b")));
         }
     }


### PR DESCRIPTION
When a dynresource replaces another one with the same specificity, keep the last value

- fixes #24849 