### PR TITLE
[Android] Fix scroll bar visibility set to Always not consistant

### DIFF
--- a/src/Core/src/Platform/Android/MauiScrollView.cs
+++ b/src/Core/src/Platform/Android/MauiScrollView.cs
@@ -62,17 +62,19 @@ namespace Microsoft.Maui.Platform
 			}
 
 			_hScrollView.HorizontalScrollBarEnabled = scrollBarVisibility == ScrollBarVisibility.Always;
+			_hScrollView.ScrollbarFadingEnabled = scrollBarVisibility != ScrollBarVisibility.Always;
 		}
 
 		public void SetVerticalScrollBarVisibility(ScrollBarVisibility scrollBarVisibility)
 		{
-			if (_defaultVerticalScrollVisibility == 0)
+		if (_defaultVerticalScrollVisibility == 0)
 				_defaultVerticalScrollVisibility = VerticalScrollBarEnabled ? ScrollBarVisibility.Always : ScrollBarVisibility.Never;
 
 			if (scrollBarVisibility == ScrollBarVisibility.Default)
 				scrollBarVisibility = _defaultVerticalScrollVisibility;
 
 			VerticalScrollBarEnabled = scrollBarVisibility == ScrollBarVisibility.Always;
+			ScrollbarFadingEnabled = scrollBarVisibility != ScrollBarVisibility.Always;
 
 			this.HandleScrollBarVisibilityChange();
 		}

--- a/src/Core/src/Platform/Android/MauiScrollView.cs
+++ b/src/Core/src/Platform/Android/MauiScrollView.cs
@@ -134,7 +134,8 @@ namespace Microsoft.Maui.Platform
 				if (_content != null && _content.Parent != this)
 				{
 					_content.RemoveFromParent();
-					_hScrollView?.RemoveFromParent();
+					if (_hScrollView != null)
+						_hScrollView.RemoveFromParent();
 					AddView(_content);
 				}
 			}

--- a/src/Core/src/Platform/Android/MauiScrollView.cs
+++ b/src/Core/src/Platform/Android/MauiScrollView.cs
@@ -60,21 +60,31 @@ namespace Microsoft.Maui.Platform
 			{
 				scrollBarVisibility = _defaultHorizontalScrollVisibility;
 			}
+			else
+			{
+				// Only disable fading when we explicitly set visibility to Always.
+				_hScrollView.ScrollbarFadingEnabled = scrollBarVisibility != ScrollBarVisibility.Always;
+			}
 
 			_hScrollView.HorizontalScrollBarEnabled = scrollBarVisibility == ScrollBarVisibility.Always;
-			_hScrollView.ScrollbarFadingEnabled = scrollBarVisibility != ScrollBarVisibility.Always;
 		}
 
 		public void SetVerticalScrollBarVisibility(ScrollBarVisibility scrollBarVisibility)
 		{
-		if (_defaultVerticalScrollVisibility == 0)
+			if (_defaultVerticalScrollVisibility == 0)
 				_defaultVerticalScrollVisibility = VerticalScrollBarEnabled ? ScrollBarVisibility.Always : ScrollBarVisibility.Never;
 
 			if (scrollBarVisibility == ScrollBarVisibility.Default)
+			{
 				scrollBarVisibility = _defaultVerticalScrollVisibility;
+			}
+			else
+			{
+				// Only disable fading when we explicitly set visibility to Always.
+				ScrollbarFadingEnabled = scrollBarVisibility != ScrollBarVisibility.Always;
+			}
 
 			VerticalScrollBarEnabled = scrollBarVisibility == ScrollBarVisibility.Always;
-			ScrollbarFadingEnabled = scrollBarVisibility != ScrollBarVisibility.Always;
 
 			this.HandleScrollBarVisibilityChange();
 		}
@@ -124,8 +134,7 @@ namespace Microsoft.Maui.Platform
 				if (_content != null && _content.Parent != this)
 				{
 					_content.RemoveFromParent();
-					if (_hScrollView != null)
-						_hScrollView.RemoveFromParent();
+					_hScrollView?.RemoveFromParent();
 					AddView(_content);
 				}
 			}

--- a/src/Core/tests/DeviceTests/Handlers/ScrollView/ScrollViewHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/ScrollView/ScrollViewHandlerTests.Android.cs
@@ -134,13 +134,13 @@ namespace Microsoft.Maui.DeviceTests
 			{
 				var scrollView = new ScrollViewStub()
 				{
-					Orientation = ScrollOrientation.Vertical,
+					Orientation = ScrollOrientation.Horizontal,
 					HorizontalScrollBarVisibility = visibility
 				};
 
 				var scrollViewHandler = CreateHandler(scrollView);
 
-				return ((MauiScrollView)scrollViewHandler.PlatformView.GetChildAt(0)).ScrollbarFadingEnabled;
+				return ((MauiHorizontalScrollView)scrollViewHandler.PlatformView.GetChildAt(0)).ScrollbarFadingEnabled;
 			});
 
 			Assert.Equal(expected, result);

--- a/src/Core/tests/DeviceTests/Handlers/ScrollView/ScrollViewHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/ScrollView/ScrollViewHandlerTests.Android.cs
@@ -102,6 +102,50 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.Equal(expected, result);
 		}
 
+		[Theory]
+		[InlineData(ScrollBarVisibility.Always, false)]
+		[InlineData(ScrollBarVisibility.Default, true)]
+		[InlineData(ScrollBarVisibility.Never, true)]
+		public async Task VerticalScrollbarFadingInitializesCorrectly(ScrollBarVisibility visibility, bool expected)
+		{
+			bool result = await InvokeOnMainThreadAsync(() =>
+			{
+				var scrollView = new ScrollViewStub()
+				{
+					Orientation = ScrollOrientation.Vertical,
+					VerticalScrollBarVisibility = visibility
+				};
+
+				var scrollViewHandler = CreateHandler(scrollView);
+
+				return ((MauiScrollView)scrollViewHandler.PlatformView).ScrollbarFadingEnabled;
+			});
+
+			Assert.Equal(expected, result);
+		}
+
+		[Theory]
+		[InlineData(ScrollBarVisibility.Always, false)]
+		[InlineData(ScrollBarVisibility.Default, true)]
+		[InlineData(ScrollBarVisibility.Never, true)]
+		public async Task HorizontalScrollbarFadingInitializesCorrectly(ScrollBarVisibility visibility, bool expected)
+		{
+			bool result = await InvokeOnMainThreadAsync(() =>
+			{
+				var scrollView = new ScrollViewStub()
+				{
+					Orientation = ScrollOrientation.Vertical,
+					HorizontalScrollBarVisibility = visibility
+				};
+
+				var scrollViewHandler = CreateHandler(scrollView);
+
+				return ((MauiScrollView)scrollViewHandler.PlatformView.GetChildAt(0)).ScrollbarFadingEnabled;
+			});
+
+			Assert.Equal(expected, result);
+		}
+
 		[Fact]
 		public async Task MauiScrollViewGetsFullHeightInHorizontalOrientation()
 		{


### PR DESCRIPTION
### Description of Change

On Android the vertical and horizontal scrollbars would fade even if visibility was set to "Always". This was due to not updating the ScrollBarFadingEnabled variable from the scrollViews. Setting this to false when visibility is set to "Always" fixes the issue and makes more sense from developer experience.

### Videos

Before fix:

https://github.com/user-attachments/assets/eec5a51c-0c36-4f9f-b7e4-fa22b2c9ab09

After fix:

https://github.com/user-attachments/assets/e350c5d9-8867-4580-ba5e-c6095efc3e39



### Issues Fixed
Fixes #24894
Fixes #12760
