### PR TITLE
[net9.0] Revert: Add MauiUIApplicationDelegate remote notification methods

### DIFF
--- a/src/Controls/samples/Controls.Sample/MauiProgram.cs
+++ b/src/Controls/samples/Controls.Sample/MauiProgram.cs
@@ -246,9 +246,7 @@ namespace Maui.Controls.Sample
 						.PerformActionForShortcutItem((a, b, c) => LogEvent(nameof(iOSLifecycle.PerformActionForShortcutItem)))
 						.WillEnterForeground((a) => LogEvent(nameof(iOSLifecycle.WillEnterForeground)))
 						.ApplicationSignificantTimeChange((a) => LogEvent(nameof(iOSLifecycle.ApplicationSignificantTimeChange)))
-						.WillTerminate((a) => LogEvent(nameof(iOSLifecycle.WillTerminate)))
-						.RegisteredForRemoteNotifications((a, b) => LogEvent(nameof(iOSLifecycle.RegisteredForRemoteNotifications)))
-						.ReceivedRemoteNotification((a,b) => LogEvent(nameof(iOSLifecycle.ReceivedRemoteNotification))));
+						.WillTerminate((a) => LogEvent(nameof(iOSLifecycle.WillTerminate))));
 #elif WINDOWS
 					// Log everything in this one
 					events.AddWindows(windows => windows

--- a/src/Core/src/LifecycleEvents/iOS/iOSLifecycle.cs
+++ b/src/Core/src/LifecycleEvents/iOS/iOSLifecycle.cs
@@ -18,8 +18,6 @@ namespace Microsoft.Maui.LifecycleEvents
 		public delegate void WillTerminate(UIApplication application);
 		public delegate void ApplicationSignificantTimeChange(UIApplication application);
 		public delegate void PerformFetch(UIApplication application, Action<UIBackgroundFetchResult> completionHandler);
-		public delegate void RegisteredForRemoteNotifications(UIApplication application, NSData deviceToken);
-		public delegate void ReceivedRemoteNotification(UIApplication application, NSDictionary userInfo);
 
 		// Scene
 		public delegate void SceneWillConnect(UIScene scene, UISceneSession session, UISceneConnectionOptions connectionOptions);

--- a/src/Core/src/LifecycleEvents/iOS/iOSLifecycleBuilderExtensions.cs
+++ b/src/Core/src/LifecycleEvents/iOS/iOSLifecycleBuilderExtensions.cs
@@ -16,9 +16,7 @@ namespace Microsoft.Maui.LifecycleEvents
 		public static IiOSLifecycleBuilder WillEnterForeground(this IiOSLifecycleBuilder lifecycle, iOSLifecycle.WillEnterForeground del) => lifecycle.OnEvent(del);
 		public static IiOSLifecycleBuilder WillTerminate(this IiOSLifecycleBuilder lifecycle, iOSLifecycle.WillTerminate del) => lifecycle.OnEvent(del);
 		public static IiOSLifecycleBuilder ApplicationSignificantTimeChange(this IiOSLifecycleBuilder lifecycle, iOSLifecycle.ApplicationSignificantTimeChange del) => lifecycle.OnEvent(del);
-		public static IiOSLifecycleBuilder RegisteredForRemoteNotifications(this IiOSLifecycleBuilder lifecycle, iOSLifecycle.RegisteredForRemoteNotifications del) => lifecycle.OnEvent(del);
-		public static IiOSLifecycleBuilder ReceivedRemoteNotification(this IiOSLifecycleBuilder lifecycle, iOSLifecycle.ReceivedRemoteNotification del) => lifecycle.OnEvent(del);
-
+		
 		[System.Runtime.Versioning.SupportedOSPlatform("ios13.0")]
 		[System.Runtime.Versioning.SupportedOSPlatform("tvos13.0")]
 		public static IiOSLifecycleBuilder SceneWillConnect(this IiOSLifecycleBuilder lifecycle, iOSLifecycle.SceneWillConnect del) => lifecycle.OnEvent(del);

--- a/src/Core/src/Platform/iOS/MauiUIApplicationDelegate.cs
+++ b/src/Core/src/Platform/iOS/MauiUIApplicationDelegate.cs
@@ -165,18 +165,6 @@ namespace Microsoft.Maui
 			_services?.InvokeLifecycleEvents<iOSLifecycle.PerformFetch>(del => del(application, completionHandler));
 		}
 
-		[Export("application:didRegisterForRemoteNotificationsWithDeviceToken:")]
-		public virtual void RegisteredForRemoteNotifications(UIApplication application, NSData deviceToken)
-		{
-			_services?.InvokeLifecycleEvents<iOSLifecycle.RegisteredForRemoteNotifications>(del => del(application, deviceToken));
-		}
-
-		[Export("application:didReceiveRemoteNotification:")]
-		public virtual void ReceivedRemoteNotification(UIApplication application, NSDictionary userInfo)
-		{
-			_services?.InvokeLifecycleEvents<iOSLifecycle.ReceivedRemoteNotification>(del => del(application, userInfo));
-		}
-
 		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = "There can only be one MauiUIApplicationDelegate.")]
 		public static MauiUIApplicationDelegate Current { get; private set; } = null!;
 

--- a/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -29,8 +29,6 @@ Microsoft.Maui.ITitleBar.Title.get -> string?
 Microsoft.Maui.IWebView.ProcessTerminated(Microsoft.Maui.WebProcessTerminatedEventArgs! args) -> void
 *REMOVED*Microsoft.Maui.IWindow.Content.get -> Microsoft.Maui.IView!
 Microsoft.Maui.IWindow.Content.get -> Microsoft.Maui.IView?
-Microsoft.Maui.LifecycleEvents.iOSLifecycle.ReceivedRemoteNotification
-Microsoft.Maui.LifecycleEvents.iOSLifecycle.RegisteredForRemoteNotifications
 Microsoft.Maui.Platform.MauiHybridWebView
 Microsoft.Maui.Platform.MauiHybridWebView.MauiHybridWebView(Microsoft.Maui.Handlers.HybridWebViewHandler! handler, CoreGraphics.CGRect frame, WebKit.WKWebViewConfiguration! configuration) -> void
 Microsoft.Maui.Platform.MauiHybridWebView.SendRawMessage(string! rawMessage) -> void
@@ -56,14 +54,10 @@ static Microsoft.Maui.Handlers.HybridWebViewHandler.MapSendRawMessage(Microsoft.
 static Microsoft.Maui.Keyboard.Date.get -> Microsoft.Maui.Keyboard!
 static Microsoft.Maui.Keyboard.Password.get -> Microsoft.Maui.Keyboard!
 static Microsoft.Maui.Keyboard.Time.get -> Microsoft.Maui.Keyboard!
-static Microsoft.Maui.LifecycleEvents.iOSLifecycleBuilderExtensions.ReceivedRemoteNotification(this Microsoft.Maui.LifecycleEvents.IiOSLifecycleBuilder! lifecycle, Microsoft.Maui.LifecycleEvents.iOSLifecycle.ReceivedRemoteNotification! del) -> Microsoft.Maui.LifecycleEvents.IiOSLifecycleBuilder!
-static Microsoft.Maui.LifecycleEvents.iOSLifecycleBuilderExtensions.RegisteredForRemoteNotifications(this Microsoft.Maui.LifecycleEvents.IiOSLifecycleBuilder! lifecycle, Microsoft.Maui.LifecycleEvents.iOSLifecycle.RegisteredForRemoteNotifications! del) -> Microsoft.Maui.LifecycleEvents.IiOSLifecycleBuilder!
 *REMOVED*static Microsoft.Maui.Platform.ElementExtensions.ToUIViewController(this Microsoft.Maui.IElement! view, Microsoft.Maui.IMauiContext! context) -> UIKit.UIViewController!
 static Microsoft.Maui.Platform.ElementExtensions.ToUIViewController(this Microsoft.Maui.IElement? view, Microsoft.Maui.IMauiContext! context) -> UIKit.UIViewController!
 static Microsoft.Maui.Platform.UIWindowExtensions.GetWindow(this UIKit.UIWindow? platformWindow) -> Microsoft.Maui.IWindow?
 static Microsoft.Maui.Platform.UIWindowExtensions.GetWindow(this UIKit.UIWindowScene? windowScene) -> Microsoft.Maui.IWindow?
 static Microsoft.Maui.ViewExtensions.DisconnectHandlers(this Microsoft.Maui.IView! view) -> void
-virtual Microsoft.Maui.MauiUIApplicationDelegate.ReceivedRemoteNotification(UIKit.UIApplication! application, Foundation.NSDictionary! userInfo) -> void
-virtual Microsoft.Maui.MauiUIApplicationDelegate.RegisteredForRemoteNotifications(UIKit.UIApplication! application, Foundation.NSData! deviceToken) -> void
 override Microsoft.Maui.Platform.MauiCALayer.AddAnimation(CoreAnimation.CAAnimation! animation, string? key) -> void
 *REMOVED*override Microsoft.Maui.Handlers.BorderHandler.ConnectHandler(Microsoft.Maui.Platform.ContentView! platformView) -> void

--- a/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -29,8 +29,6 @@ Microsoft.Maui.ITitleBar.Title.get -> string?
 Microsoft.Maui.IWebView.ProcessTerminated(Microsoft.Maui.WebProcessTerminatedEventArgs! args) -> void
 *REMOVED*Microsoft.Maui.IWindow.Content.get -> Microsoft.Maui.IView!
 Microsoft.Maui.IWindow.Content.get -> Microsoft.Maui.IView?
-Microsoft.Maui.LifecycleEvents.iOSLifecycle.ReceivedRemoteNotification
-Microsoft.Maui.LifecycleEvents.iOSLifecycle.RegisteredForRemoteNotifications
 Microsoft.Maui.Platform.MauiHybridWebView
 Microsoft.Maui.Platform.MauiHybridWebView.MauiHybridWebView(Microsoft.Maui.Handlers.HybridWebViewHandler! handler, CoreGraphics.CGRect frame, WebKit.WKWebViewConfiguration! configuration) -> void
 Microsoft.Maui.Platform.MauiHybridWebView.SendRawMessage(string! rawMessage) -> void
@@ -56,14 +54,10 @@ static Microsoft.Maui.Handlers.HybridWebViewHandler.MapSendRawMessage(Microsoft.
 static Microsoft.Maui.Keyboard.Date.get -> Microsoft.Maui.Keyboard!
 static Microsoft.Maui.Keyboard.Password.get -> Microsoft.Maui.Keyboard!
 static Microsoft.Maui.Keyboard.Time.get -> Microsoft.Maui.Keyboard!
-static Microsoft.Maui.LifecycleEvents.iOSLifecycleBuilderExtensions.ReceivedRemoteNotification(this Microsoft.Maui.LifecycleEvents.IiOSLifecycleBuilder! lifecycle, Microsoft.Maui.LifecycleEvents.iOSLifecycle.ReceivedRemoteNotification! del) -> Microsoft.Maui.LifecycleEvents.IiOSLifecycleBuilder!
-static Microsoft.Maui.LifecycleEvents.iOSLifecycleBuilderExtensions.RegisteredForRemoteNotifications(this Microsoft.Maui.LifecycleEvents.IiOSLifecycleBuilder! lifecycle, Microsoft.Maui.LifecycleEvents.iOSLifecycle.RegisteredForRemoteNotifications! del) -> Microsoft.Maui.LifecycleEvents.IiOSLifecycleBuilder!
 *REMOVED*static Microsoft.Maui.Platform.ElementExtensions.ToUIViewController(this Microsoft.Maui.IElement! view, Microsoft.Maui.IMauiContext! context) -> UIKit.UIViewController!
 static Microsoft.Maui.Platform.ElementExtensions.ToUIViewController(this Microsoft.Maui.IElement? view, Microsoft.Maui.IMauiContext! context) -> UIKit.UIViewController!
 static Microsoft.Maui.Platform.UIWindowExtensions.GetWindow(this UIKit.UIWindow? platformWindow) -> Microsoft.Maui.IWindow?
 static Microsoft.Maui.Platform.UIWindowExtensions.GetWindow(this UIKit.UIWindowScene? windowScene) -> Microsoft.Maui.IWindow?
 static Microsoft.Maui.ViewExtensions.DisconnectHandlers(this Microsoft.Maui.IView! view) -> void
-virtual Microsoft.Maui.MauiUIApplicationDelegate.ReceivedRemoteNotification(UIKit.UIApplication! application, Foundation.NSDictionary! userInfo) -> void
-virtual Microsoft.Maui.MauiUIApplicationDelegate.RegisteredForRemoteNotifications(UIKit.UIApplication! application, Foundation.NSData! deviceToken) -> void
 override Microsoft.Maui.Platform.MauiCALayer.AddAnimation(CoreAnimation.CAAnimation! animation, string? key) -> void
 *REMOVED*override Microsoft.Maui.Handlers.BorderHandler.ConnectHandler(Microsoft.Maui.Platform.ContentView! platformView) -> void


### PR DESCRIPTION
Unfortunately, when these lifecycle events were added in #23452 we didn't consider the implications of having the methods implemented on the appdelegate had with Apple app store submissions.  Basically if the app delegate implements these methods, Apple assumes in their static analysis of the submitted apps that you intend to use them, and will warn about requiring the appropriate entitlements to therefore be declared.

Given there's no obvious/easy way to conditionally export these selectors at this time, we are reverting the change to maintain the no warning/no error submission behaviour.

For more information and to track future potential implementations of these lifecycle events, follow: #24237

