### PR TITLE
[XC] Add feature switch to enable compiling bindings with source

### DIFF
--- a/docs/design/FeatureSwitches.md
+++ b/docs/design/FeatureSwitches.md
@@ -11,6 +11,7 @@ The following switches are toggled for applications running on Mono for `TrimMod
 | MauiQueryPropertyAttributeSupport | Microsoft.Maui.RuntimeFeature.IsQueryPropertyAttributeSupported | When disabled, the `[QueryProperty(...)]` attributes won't be used to set values to properties when navigating. |
 | MauiImplicitCastOperatorsUsageViaReflectionSupport | Microsoft.Maui.RuntimeFeature.IsImplicitCastOperatorsUsageViaReflectionSupported | When disabled, MAUI won't look for implicit cast operators when converting values from one type to another. This feature is not trim-compatible. |
 | _MauiBindingInterceptorsSupport | Microsoft.Maui.RuntimeFeature.AreBindingInterceptorsSupported | When disabled, MAUI won't intercept any calls to `SetBinding` methods and try to compile them. Enabled by default. |
+| MauiEnableXamlCBindingWithSourceCompilation | Microsoft.Maui.RuntimeFeature.XamlCBindingWithSourceCompilationEnabled | When enabled, MAUI will compile all bindings, including those where the `Source` property is used. |
 
 ## MauiEnableIVisualAssemblyScanning
 
@@ -61,3 +62,12 @@ Compiled binding in XAML:
 ```xml
 <Label Text="{Binding Customer.Name}" x:DataType="local:PageViewModel" />
 ```
+
+## MauiEnableXamlCBindingWithSourceCompilation
+
+XamlC skipped compilation of bindings with the `Source` property set to any value in previous releases. Some bindings might start producing build errors or start failing at runtime after this feature is enabled. After enabling this feature, make sure all bindings have the right `x:DataType` so they are compiled correctly. For bindings which should not be compiled, clear the data type like this:
+```
+{Binding MyProperty, Source={x:Reference MyTarget}, x:DataType={x:Null}}
+```
+
+This feature is disabled by default, unless `TrimMode=true` or `PublishAot=true`. For fully trimmed and NativeAOT apps, the feature is enabled.

--- a/src/Compatibility/ControlGallery/src/Core/Compatibility.ControlGallery.Core.csproj
+++ b/src/Compatibility/ControlGallery/src/Core/Compatibility.ControlGallery.Core.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <XFDisableTargetsValidation>True</XFDisableTargetsValidation>
+    <MauiEnableXamlCBindingWithSourceCompilation>true</MauiEnableXamlCBindingWithSourceCompilation>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DefineConstants>TRACE;DEBUG;PERF;APP</DefineConstants>

--- a/src/Controls/samples/Controls.Sample/Maui.Controls.Sample.csproj
+++ b/src/Controls/samples/Controls.Sample/Maui.Controls.Sample.csproj
@@ -23,6 +23,7 @@
     <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
     <ApplicationVersion>1</ApplicationVersion>
     <_FastDeploymentDiagnosticLogging>True</_FastDeploymentDiagnosticLogging>
+    <MauiEnableXamlCBindingWithSourceCompilation>true</MauiEnableXamlCBindingWithSourceCompilation>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Controls/samples/Directory.Build.props
+++ b/src/Controls/samples/Directory.Build.props
@@ -4,6 +4,7 @@
     <UseMaui Condition=" '$(UseWorkload)' == 'true' ">true</UseMaui>
     <DefaultXamlRuntime Condition=" '$(UseWorkload)' != 'true' ">Maui</DefaultXamlRuntime>
     <WarningsNotAsErrors>$(WarningsNotAsErrors);XC0022;XC0023</WarningsNotAsErrors>
+    <MauiEnableXamlCBindingWithSourceCompilation>true</MauiEnableXamlCBindingWithSourceCompilation>
   </PropertyGroup>
   <Import Project="../../../Directory.Build.props" />
 </Project>

--- a/src/Controls/src/Build.Tasks/BuildException.cs
+++ b/src/Controls/src/Build.Tasks/BuildException.cs
@@ -58,6 +58,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 		public static BuildExceptionCode BindingWithoutDataType = new BuildExceptionCode("XC", 0022, nameof(BindingWithoutDataType), "https://learn.microsoft.com/dotnet/maui/fundamentals/data-binding/compiled-bindings"); //warning
 		public static BuildExceptionCode BindingWithNullDataType = new BuildExceptionCode("XC", 0023, nameof(BindingWithNullDataType), "https://learn.microsoft.com/dotnet/maui/fundamentals/data-binding/compiled-bindings"); //warning
 		public static BuildExceptionCode BindingWithXDataTypeFromOuterScope = new BuildExceptionCode("XC", 0024, nameof(BindingWithXDataTypeFromOuterScope), "https://learn.microsoft.com/dotnet/maui/fundamentals/data-binding/compiled-bindings"); //warning
+		public static BuildExceptionCode BindingWithSourceCompilationSkipped = new BuildExceptionCode("XC", 0025, nameof(BindingWithSourceCompilationSkipped), "https://learn.microsoft.com/dotnet/maui/fundamentals/data-binding/compiled-bindings"); //warning
 
 		//Bindings, conversions
 		public static BuildExceptionCode Conversion = new BuildExceptionCode("XC", 0040, nameof(Conversion), "");

--- a/src/Controls/src/Build.Tasks/ErrorMessages.resx
+++ b/src/Controls/src/Build.Tasks/ErrorMessages.resx
@@ -144,6 +144,9 @@
   <data name="BindingWithXDataTypeFromOuterScope" xml:space="preserve">
     <value>Binding might be compiled incorrectly since the x:DataType annotation comes from an outer scope. Make sure you annotate all DataTemplate XAML elements with the correct x:DataType. See https://learn.microsoft.com/dotnet/maui/fundamentals/data-binding/compiled-bindings for more information.</value>
   </data>
+  <data name="BindingWithSourceCompilationSkipped" xml:space="preserve">
+    <value>Binding was not compiled because it has an explicitly set Source property and compilation of bindings with Source is not enabled. Consider enabling this optimization by setting the &lt;MauiEnableXamlCBindingWithSourceCompilation&gt;true&lt;/MauiEnableXamlCBindingWithSourceCompilation&gt; in your project file and make sure the correct x:DataType is specified for this binding. See https://learn.microsoft.com/dotnet/maui/fundamentals/data-binding/compiled-bindings for more information.</value>
+  </data>
   <data name="BindingPropertyNotFound" xml:space="preserve">
     <value>Binding: Property "{0}" not found on "{1}".</value>
     <comment>0 is property name, 1 is type name</comment>

--- a/src/Controls/src/Build.Tasks/ILContext.cs
+++ b/src/Controls/src/Build.Tasks/ILContext.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 			ParentContextValues = parentContextValues;
 			Module = module;
 			Cache = cache;
+			CompileBindingsWithSource = false;
 		}
 
 		public XamlCache Cache { get; private set; }
@@ -46,5 +47,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 		public TaskLoggingHelper LoggingHelper { get; internal set; }
 
 		public bool ValidateOnly { get; set; }
+
+		public bool CompileBindingsWithSource { get; set; }
 	}
 }

--- a/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
+++ b/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
@@ -1770,6 +1770,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 				XamlFilePath = parentContext.XamlFilePath,
 				LoggingHelper = parentContext.LoggingHelper,
 				ValidateOnly = parentContext.ValidateOnly,
+				CompileBindingsWithSource = parentContext.CompileBindingsWithSource,
 			};
 
 			//Instanciate nested class

--- a/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
+++ b/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
@@ -300,10 +300,21 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 
 				if (bindingExtensionType.HasValue)
 				{
-					if (TryCompileBindingPath(node, context, vardefref.VariableDefinition, bindingExtensionType.Value, isStandaloneBinding: bpRef is null, out var instructions))
+					// for backwards compatibility, it is possible to disable compilation of bindings with the `Source` property via a feature switch
+					// this feature switch is enabled by default only for NativeAOT and full trimming mode
+					bool hasSource = node.Properties.ContainsKey(new XmlName("", "Source"));
+					bool skipBindingCompilation = hasSource && !context.CompileBindingsWithSource;
+					if (!skipBindingCompilation)
 					{
-						foreach (var instruction in instructions)
-							yield return instruction;
+						if (TryCompileBindingPath(node, context, vardefref.VariableDefinition, bindingExtensionType.Value, isStandaloneBinding: bpRef is null, out var instructions))
+						{
+							foreach (var instruction in instructions)
+								yield return instruction;
+						}
+					}
+					else
+					{
+						context.LoggingHelper.LogWarningOrError(BuildExceptionCode.BindingWithSourceCompilationSkipped, context.XamlFilePath, node.LineNumber, node.LinePosition, 0, 0, null);
 					}
 				}
 

--- a/src/Controls/src/Build.Tasks/XamlCTask.cs
+++ b/src/Controls/src/Build.Tasks/XamlCTask.cs
@@ -128,6 +128,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 		public bool OptimizeIL { get; set; } = true;
 		public bool DefaultCompile { get; set; }
 		public bool ForceCompile { get; set; }
+		public bool CompileBindingsWithSource { get; set; }
 		public string TargetFramework { get; set; }
 
 		public int WarningLevel { get; set; } = 4; //unused so far
@@ -415,6 +416,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 					XamlFilePath = xamlFilePath,
 					LoggingHelper = loggingHelper,
 					ValidateOnly = ValidateOnly,
+					CompileBindingsWithSource = CompileBindingsWithSource,
 				};
 
 

--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
@@ -175,6 +175,7 @@
 			DebugSymbols = "$(DebugSymbols)"
 			DebugType = "$(DebugType)"
 			DefaultCompile = "true"
+      CompileBindingsWithSource = "$(MauiEnableXamlCBindingWithSourceCompilation)"
 			ValidateOnly = "$(_MauiXamlCValidateOnly)"
 			TargetFramework = "$(TargetFramework)"
 			KeepXamlResources = "$(MauiKeepXamlResources)"
@@ -225,7 +226,7 @@
            Text="The %24(TargetFrameworkVersion) for $(ProjectName) ($(TargetFrameworkVersion)) is less than the minimum required %24(TargetFrameworkVersion) for Microsoft.Maui ($(MinTargetFrameworkVersionForMaui)). You need to increase the %24(TargetFrameworkVersion) for $(ProjectName)."   />
   </Target>
 
-  <Target Name="_MauiPrepareForILLink" BeforeTargets="PrepareForILLink;_GenerateRuntimeConfigurationFilesInputCache">
+  <Target Name="_MauiPrepareForILLink" BeforeTargets="PrepareForILLink;_GenerateRuntimeConfigurationFilesInputCache;XamlC">
     <PropertyGroup>
       <MauiEnableIVisualAssemblyScanning Condition="'$(MauiEnableIVisualAssemblyScanning)' == ''">false</MauiEnableIVisualAssemblyScanning>
     </PropertyGroup>
@@ -233,6 +234,7 @@
       <MauiShellSearchResultsRendererDisplayMemberNameSupported Condition="'$(MauiShellSearchResultsRendererDisplayMemberNameSupported)' == ''">false</MauiShellSearchResultsRendererDisplayMemberNameSupported>
       <MauiQueryPropertyAttributeSupport Condition="'$(MauiQueryPropertyAttributeSupport)' == ''">false</MauiQueryPropertyAttributeSupport>
       <MauiImplicitCastOperatorsUsageViaReflectionSupport Condition="'$(MauiImplicitCastOperatorsUsageViaReflectionSupport)' == ''">false</MauiImplicitCastOperatorsUsageViaReflectionSupport>
+      <MauiEnableXamlCBindingWithSourceCompilation Condition="'$(MauiEnableXamlCBindingWithSourceCompilation)' == ''">true</MauiEnableXamlCBindingWithSourceCompilation>
     </PropertyGroup>
     <ItemGroup>
       <RuntimeHostConfigurationOption Include="Microsoft.Maui.RuntimeFeature.IsIVisualAssemblyScanningEnabled"
@@ -255,6 +257,10 @@
                                       Condition="'$(_MauiBindingInterceptorsSupport)' != ''"
                                       Value="$(_MauiBindingInterceptorsSupport)"
                                       Trim="true" />
+      <RuntimeHostConfigurationOption Include="Microsoft.Maui.RuntimeFeature.Microsoft.Maui.RuntimeFeature.IsXamlCBindingWithSourceCompilationEnabled"
+                                      Condition="'$(MauiEnableXamlCBindingWithSourceCompilation)' != ''"
+                                      Value="$(MauiEnableXamlCBindingWithSourceCompilation)"
+                                      Trim="false" />
     </ItemGroup>
   </Target>
 

--- a/src/Controls/src/Core/Binding.cs
+++ b/src/Controls/src/Core/Binding.cs
@@ -131,7 +131,7 @@ namespace Microsoft.Maui.Controls
 			{
 				if (DataType != null && bindingContext != null && !DataType.IsAssignableFrom(bindingContext.GetType()))
 				{
-					BindingDiagnostics.SendBindingFailure(this, "Binding", "Mismatch between the specified x:DataType and the current binding context");
+					BindingDiagnostics.SendBindingFailure(this, "Binding", $"Mismatch between the specified x:DataType ({DataType}) and the current binding context ({bindingContext.GetType()}).");
 					bindingContext = null;
 				}
 			}

--- a/src/Controls/src/Core/Binding.cs
+++ b/src/Controls/src/Core/Binding.cs
@@ -124,10 +124,16 @@ namespace Microsoft.Maui.Controls
 			var isApplied = IsApplied;
 
 			var bindingContext = src ?? Context ?? context;
-			if (DataType != null && bindingContext != null && !DataType.IsAssignableFrom(bindingContext.GetType()))
+
+			// Do not check type mismatch if this is a binding with Source and compilation of bindings with Source is disabled
+			bool skipTypeMismatchCheck = Source is not null && !RuntimeFeature.IsXamlCBindingWithSourceCompilationEnabled;
+			if (!skipTypeMismatchCheck)
 			{
-				BindingDiagnostics.SendBindingFailure(this, "Binding", "Mismatch between the specified x:DataType and the current binding context");
-				bindingContext = null;
+				if (DataType != null && bindingContext != null && !DataType.IsAssignableFrom(bindingContext.GetType()))
+				{
+					BindingDiagnostics.SendBindingFailure(this, "Binding", "Mismatch between the specified x:DataType and the current binding context");
+					bindingContext = null;
+				}
 			}
 
 			base.Apply(bindingContext, bindObj, targetProperty, fromBindingContextChanged, specificity);

--- a/src/Controls/src/Core/TypedBinding.cs
+++ b/src/Controls/src/Core/TypedBinding.cs
@@ -288,6 +288,11 @@ namespace Microsoft.Maui.Controls.Internals
 		internal void ApplyCore(object sourceObject, BindableObject target, BindableProperty property, bool fromTarget, SetterSpecificity specificity)
 		{
 			var isTSource = sourceObject is TSource;
+			if (!isTSource && sourceObject is not null)
+			{
+				BindingDiagnostics.SendBindingFailure(this, "Binding", $"Mismatch between the specified x:DataType ({typeof(TSource)}) and the current binding context ({sourceObject.GetType()})");
+			}
+
 			var mode = this.GetRealizedMode(property);
 			if ((mode == BindingMode.OneWay || mode == BindingMode.OneTime) && fromTarget)
 				return;

--- a/src/Controls/src/Xaml/MarkupExtensions/BindingExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/BindingExtension.cs
@@ -38,8 +38,8 @@ namespace Microsoft.Maui.Controls.Xaml
 			return TypedBinding;
 
 			[UnconditionalSuppressMessage("TrimAnalysis", "IL2026",
-				Justification = "This code is only reachable in XamlC compiled code when there is a missing x:DataType and the binding could not be compiled. " +
-					"In that case, we produce a warning that the binding could not be compiled.")]
+				Justification = "If this method is invoked, we have already produced warnings in XamlC " +
+					"when the compilation of this binding failed or was skipped.")]
 			BindingBase CreateBinding()
 			{
 				Type bindingXDataType = null;

--- a/src/Controls/tests/SourceGen.UnitTests/SourceGen.UnitTests.csproj
+++ b/src/Controls/tests/SourceGen.UnitTests/SourceGen.UnitTests.csproj
@@ -10,6 +10,7 @@
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
     <DisableMSBuildAssemblyCopyCheck>true</DisableMSBuildAssemblyCopyCheck>
+    <MauiEnableXamlCBindingWithSourceCompilation>true</MauiEnableXamlCBindingWithSourceCompilation>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/src/Controls/tests/TestCases.HostApp/Controls.TestCases.HostApp.csproj
+++ b/src/Controls/tests/TestCases.HostApp/Controls.TestCases.HostApp.csproj
@@ -11,6 +11,7 @@
     <RuntimeIdentifier Condition="$(TargetFramework.Contains('-maccatalyst'))">maccatalyst-x64</RuntimeIdentifier>
     <RuntimeIdentifier Condition="$(TargetFramework.Contains('-maccatalyst')) and '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'arm64'">maccatalyst-arm64</RuntimeIdentifier>
     <ExcludeMicrosoftNetTestSdk>true</ExcludeMicrosoftNetTestSdk>
+    <MauiEnableXamlCBindingWithSourceCompilation>true</MauiEnableXamlCBindingWithSourceCompilation>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Controls/tests/TestCases.HostApp/Directory.Build.props
+++ b/src/Controls/tests/TestCases.HostApp/Directory.Build.props
@@ -4,6 +4,7 @@
     <UseMaui Condition=" '$(UseWorkload)' == 'true' ">true</UseMaui>
     <DefaultXamlRuntime Condition=" '$(UseWorkload)' != 'true' ">Maui</DefaultXamlRuntime>
     <WarningsNotAsErrors>$(WarningsNotAsErrors);XC0022;XC0023</WarningsNotAsErrors>
+    <MauiEnableXamlCBindingWithSourceCompilation>true</MauiEnableXamlCBindingWithSourceCompilation>
   </PropertyGroup>
   <Import Project="../../../../Directory.Build.props" />
 </Project>

--- a/src/Controls/tests/Xaml.UnitTests/Controls.Xaml.UnitTests.csproj
+++ b/src/Controls/tests/Xaml.UnitTests/Controls.Xaml.UnitTests.csproj
@@ -9,8 +9,6 @@
     <WarningsNotAsErrors>$(WarningsNotAsErrors);XC0618;XC0022;XC0023;XC0025;XC0045</WarningsNotAsErrors>
     <IsPackable>false</IsPackable>
     <DisableMSBuildAssemblyCopyCheck>true</DisableMSBuildAssemblyCopyCheck>
-
-    <!-- enable compilation of bindings with Source -->
     <MauiEnableXamlCBindingWithSourceCompilation>true</MauiEnableXamlCBindingWithSourceCompilation>
   </PropertyGroup>
 

--- a/src/Controls/tests/Xaml.UnitTests/Controls.Xaml.UnitTests.csproj
+++ b/src/Controls/tests/Xaml.UnitTests/Controls.Xaml.UnitTests.csproj
@@ -6,9 +6,12 @@
     <AssemblyName>Microsoft.Maui.Controls.Xaml.UnitTests</AssemblyName>
     <WarningLevel>4</WarningLevel>
     <NoWarn>$(NoWarn);0672;0219;0414;CS0436;CS0618</NoWarn>
-    <WarningsNotAsErrors>$(WarningsNotAsErrors);XC0618;XC0022;XC0023;XC0045</WarningsNotAsErrors>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);XC0618;XC0022;XC0023;XC0025;XC0045</WarningsNotAsErrors>
     <IsPackable>false</IsPackable>
     <DisableMSBuildAssemblyCopyCheck>true</DisableMSBuildAssemblyCopyCheck>
+
+    <!-- enable compilation of bindings with Source -->
+    <MauiEnableXamlCBindingWithSourceCompilation>true</MauiEnableXamlCBindingWithSourceCompilation>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui23711.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui23711.xaml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests"
+             x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui23711"
+             x:DataType="local:DeclaredModel"
+             x:Name="root">
+    <Label x:Name="label" Text="{Binding Value, Source={x:Reference root}}" />
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui23711.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui23711.xaml.cs
@@ -1,0 +1,66 @@
+using System.Linq;
+using Microsoft.Maui.ApplicationModel;
+using Microsoft.Maui.Controls.Core.UnitTests;
+using Microsoft.Maui.Devices;
+using Microsoft.Maui.Dispatching;
+
+using Microsoft.Maui.UnitTests;
+using NUnit.Framework;
+
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+[XamlCompilation(XamlCompilationOptions.Skip)]
+public partial class Maui23711 : ContentPage
+{
+    public Maui23711()
+    {
+        InitializeComponent();
+    }
+
+    public Maui23711(bool useCompiledXaml)
+    {
+        //this stub will be replaced at compile time
+    }
+
+    [TestFixture]
+    class Test
+    {
+        MockDeviceInfo mockDeviceInfo;
+
+        [SetUp]
+        public void Setup()
+        {
+            Application.SetCurrentApplication(new MockApplication());
+            DeviceInfo.SetCurrent(mockDeviceInfo = new MockDeviceInfo());
+            DispatcherProvider.SetCurrent(new DispatcherProviderStub());
+        }
+
+
+        [TearDown] public void TearDown()
+        {
+            AppInfo.SetCurrent(null);
+            DeviceInfo.SetCurrent(null);
+        }
+
+        [Test]
+        public void UsesReflectionBasedBindingsWhenCompilationOfBindingsWithSourceIsDisabled([Values(false, true)] bool compileBindingsWithSource)
+        {
+            MockCompiler.Compile(typeof(Maui23711), out MethodDefinition methodDefinition, compileBindingsWithSource: compileBindingsWithSource);
+            Assert.AreEqual(compileBindingsWithSource, ContainsTypedBindingInstantiation(methodDefinition));
+        }
+
+        static bool ContainsTypedBindingInstantiation(MethodDefinition methodDef)
+            => methodDef.Body.Instructions.Any(instruction =>
+                instruction.OpCode == OpCodes.Newobj
+                && instruction.Operand is MethodReference methodRef
+                && methodRef.DeclaringType.Name == "TypedBinding`2");
+    }
+}
+
+public class DeclaredModel
+{
+    public string Value { get; set; }
+}

--- a/src/Controls/tests/Xaml.UnitTests/MockCompiler.cs
+++ b/src/Controls/tests/Xaml.UnitTests/MockCompiler.cs
@@ -9,12 +9,21 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 {
 	public static class MockCompiler
 	{
-		public static void Compile(Type type, string targetFramework = null, bool treatWarningsAsErrors = false)
+		public static void Compile(
+			Type type,
+			string targetFramework = null,
+			bool treatWarningsAsErrors = false,
+			bool compileBindingsWithSource = true)
 		{
-			Compile(type, out _, targetFramework, treatWarningsAsErrors);
+			Compile(type, out _, targetFramework, treatWarningsAsErrors, compileBindingsWithSource);
 		}
 
-		public static void Compile(Type type, out MethodDefinition methodDefinition, string targetFramework = null, bool treatWarningsAsErrors = false)
+		public static void Compile(
+			Type type,
+			out MethodDefinition methodDefinition,
+			string targetFramework = null,
+			bool treatWarningsAsErrors = false,
+			bool compileBindingsWithSource = true)
 		{
 			methodDefinition = null;
 			var assembly = type.Assembly.Location;
@@ -33,6 +42,7 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 				Type = type.FullName,
 				TargetFramework = targetFramework,
 				TreatWarningsAsErrors = treatWarningsAsErrors,
+				CompileBindingsWithSource = compileBindingsWithSource,
 				BuildEngine = new MSBuild.UnitTests.DummyBuildEngine()
 			};
 

--- a/src/Core/src/RuntimeFeature.cs
+++ b/src/Core/src/RuntimeFeature.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Maui
 		private const bool IsQueryPropertyAttributeSupportedByDefault = true;
 		private const bool IsImplicitCastOperatorsUsageViaReflectionSupportedByDefault = true;
 		private const bool AreBindingInterceptorsSupportedByDefault = true;
+		private const bool IsXamlCBindingWithSourceCompilationEnabledByDefault = false;
 
 #pragma warning disable IL4000 // Return value does not match FeatureGuardAttribute 'System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute'. 
 #if NET9_0_OR_GREATER
@@ -57,10 +58,21 @@ namespace Microsoft.Maui
 				? isSupported
 				: IsImplicitCastOperatorsUsageViaReflectionSupportedByDefault;
 
+#if NET9_0_OR_GREATER
+		[FeatureSwitchDefinition("Microsoft.Maui.RuntimeFeature.Microsoft.Maui.RuntimeFeature.AreBindingInterceptorsSupported")]
+#endif
 		internal static bool AreBindingInterceptorsSupported =>
 			AppContext.TryGetSwitch("Microsoft.Maui.RuntimeFeature.AreBindingInterceptorsSupported", out bool areSupported)
 				? areSupported
 				: AreBindingInterceptorsSupportedByDefault;
+
+#if NET9_0_OR_GREATER
+		[FeatureSwitchDefinition("Microsoft.Maui.RuntimeFeature.IsXamlCBindingWithSourceCompilationEnabled")]
+#endif
+		internal static bool IsXamlCBindingWithSourceCompilationEnabled =>
+			AppContext.TryGetSwitch("Microsoft.Maui.RuntimeFeature.IsXamlCBindingWithSourceCompilationEnabled", out bool areSupported)
+				? areSupported
+				: IsXamlCBindingWithSourceCompilationEnabledByDefault;
 #pragma warning restore IL4000
 	}
 }

--- a/src/Core/tests/DeviceTests/Core.DeviceTests.csproj
+++ b/src/Core/tests/DeviceTests/Core.DeviceTests.csproj
@@ -33,6 +33,11 @@
     <!-- <WindowsPackageType>None</WindowsPackageType> -->
   </PropertyGroup>
 
+  <PropertyGroup>
+    <!-- enable compilation of bindings with Source -->
+    <MauiEnableXamlCBindingWithSourceCompilation>true</MauiEnableXamlCBindingWithSourceCompilation>
+  </PropertyGroup>
+
   <ItemGroup>
     <MauiIcon Include="Resources\appicon.svg" ForegroundFile="Resources\appiconfg.svg" Color="#512BD4" />
     <MauiSplashScreen Include="Resources\appiconfg.svg" Color="#512BD4" BaseSize="128,128" />

--- a/src/Essentials/samples/Directory.Build.props
+++ b/src/Essentials/samples/Directory.Build.props
@@ -4,6 +4,7 @@
     <UseMaui Condition=" '$(UseWorkload)' == 'true' ">true</UseMaui>
     <DefaultXamlRuntime Condition=" '$(UseWorkload)' != 'true' ">Maui</DefaultXamlRuntime>
     <WarningsNotAsErrors>$(WarningsNotAsErrors);XC0022;XC0023</WarningsNotAsErrors>
+    <MauiEnableXamlCBindingWithSourceCompilation>true</MauiEnableXamlCBindingWithSourceCompilation>
   </PropertyGroup>
   <Import Project="../../../Directory.Build.props" />
 </Project>

--- a/src/TestUtils/src/DeviceTests.Runners/TestUtils.DeviceTests.Runners.csproj
+++ b/src/TestUtils/src/DeviceTests.Runners/TestUtils.DeviceTests.Runners.csproj
@@ -10,6 +10,7 @@
     <WarningsNotAsErrors>$(WarningsNotAsErrors);XC0022;XC0023</WarningsNotAsErrors>
     <ExcludeMicrosoftNetTestSdk>true</ExcludeMicrosoftNetTestSdk>
     <DisableArcadeTestFramework>true</DisableArcadeTestFramework>
+    <MauiEnableXamlCBindingWithSourceCompilation>true</MauiEnableXamlCBindingWithSourceCompilation>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Description of Change

This PR adds a new feature switch `IsXamlCBindingWithSourceCompilationEnabled` which is disabled by default unless the app is built with `<PublishAot>true</PublishAot>` or with `<TrimMode>full</TrimMode>`.

This feature switch should make it easier to migrate existing apps to .NET 9. In some apps, bindings that previously worked would now stop working (see #23711 for customer feedback).

To make it possible to enable this feature by default in the future, I added a new warning `XC0025` that will be shown by XamlC for all bindings that are not compiled because this feature is disabled.

I also modified the error message when there is a mismatch between the declared x:DataType and the actual binding context. This is based on feedback in #24349. The error message will now contain the actual conflicting types and it should help developers identify which binding is failing more easily. I also added this warning to `TypedBinding` which also rejects inputs that don't match the expected source type. This change should make it easier to enable the new feature switch in existing apps or when migrating to NativeAOT/full trimming.

/cc @jonathanpeppers @StephaneDelcroix @PureWeen @vitek-karas 

### Issues Fixed

Fixes #23711 
Fixes #24349