### PR TITLE
[Localization] Change OneLoc branch to 'lego'

### DIFF
--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -22,7 +22,7 @@ variables:
 - name: isTargetMainBranch
   value: $[eq(variables['System.PullRequest.TargetBranch'], 'refs/heads/main')]
 - name: isLocPRBranch
-  value: $[startsWith(variables['System.PullRequest.SourceBranch'], 'loc-hb')]
+  value: $[startsWith(variables['System.PullRequest.SourceBranch'], 'lego')]
 - name: isPullRequest
   value: $[eq(variables['Build.Reason'], 'PullRequest')]
 - name: isLocHandoffBranch


### PR DESCRIPTION
In our automation for localization, we have the first step in the localization process coming to us from a branch called 'loc-hb' but it now starts with 'lego' as you can see in this example: https://github.com/dotnet/maui/pull/24935. This change will help our automated flow.