### PR TITLE
Improve performance of rendering `DatePicker`

### DIFF
--- a/src/Controls/src/Core/DatePicker/DatePicker.cs
+++ b/src/Controls/src/Core/DatePicker/DatePicker.cs
@@ -1,6 +1,5 @@
 #nullable disable
 using System;
-using System.Threading.Tasks;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Graphics;
 
@@ -16,7 +15,7 @@ namespace Microsoft.Maui.Controls
 		public static readonly BindableProperty DateProperty = BindableProperty.Create(nameof(Date), typeof(DateTime), typeof(DatePicker), default(DateTime), BindingMode.TwoWay,
 			coerceValue: CoerceDate,
 			propertyChanged: DatePropertyChanged,
-			defaultValueCreator: (bindable) => DateTime.Today);
+			defaultValueCreator: (bindable) => GetDefaultDate());
 
 		/// <summary>Bindable property for <see cref="MinimumDate"/>.</summary>
 		public static readonly BindableProperty MinimumDateProperty = BindableProperty.Create(nameof(MinimumDate), typeof(DateTime), typeof(DatePicker), new DateTime(1900, 1, 1),
@@ -50,19 +49,6 @@ namespace Microsoft.Maui.Controls
 		public DatePicker()
 		{
 			_platformConfigurationRegistry = new Lazy<PlatformConfigurationRegistry<DatePicker>>(() => new PlatformConfigurationRegistry<DatePicker>(this));
-		}
-
-		/// <summary>
-		/// Initialize <see cref="DateTime"/> on startup since first call without initializing beforehand takes too much time
-		/// See: https://github.com/dotnet/maui/issues/24929
-		/// </summary>
-		static DatePicker()
-		{
-			Task.Run(() =>
-			{
-				DateTime dateNow = DateTime.Now;
-				string dateString = dateNow.ToString();
-			});
 		}
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/DatePicker.xml" path="//Member[@MemberName='Date']/Docs/*" />
@@ -164,6 +150,11 @@ namespace Microsoft.Maui.Controls
 
 		void ITextElement.OnTextTransformChanged(TextTransform oldValue, TextTransform newValue)
 		{
+		}
+
+		static DateTime GetDefaultDate()
+		{
+			return DateTimeOffset.Now.DateTime;
 		}
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/DatePicker.xml" path="//Member[@MemberName='UpdateFormsText']/Docs/*" />

--- a/src/Controls/src/Core/DatePicker/DatePicker.cs
+++ b/src/Controls/src/Core/DatePicker/DatePicker.cs
@@ -154,7 +154,7 @@ namespace Microsoft.Maui.Controls
 
 		static DateTime GetDefaultDate()
 		{
-			return DateTimeOffset.Now.DateTime;
+			return DateTimeOffset.Now.DateTime.Date;
 		}
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/DatePicker.xml" path="//Member[@MemberName='UpdateFormsText']/Docs/*" />

--- a/src/Controls/src/Core/DatePicker/DatePicker.cs
+++ b/src/Controls/src/Core/DatePicker/DatePicker.cs
@@ -1,5 +1,6 @@
 #nullable disable
 using System;
+using System.Threading.Tasks;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Graphics;
 
@@ -49,6 +50,19 @@ namespace Microsoft.Maui.Controls
 		public DatePicker()
 		{
 			_platformConfigurationRegistry = new Lazy<PlatformConfigurationRegistry<DatePicker>>(() => new PlatformConfigurationRegistry<DatePicker>(this));
+		}
+
+		/// <summary>
+		/// Initialize <see cref="DateTime"/> on startup since first call without initializing beforehand takes too much time
+		/// See: https://github.com/dotnet/maui/issues/24929
+		/// </summary>
+		static DatePicker()
+		{
+			Task.Run(() =>
+			{
+				DateTime dateNow = DateTime.Now;
+				string dateString = dateNow.ToString();
+			});
 		}
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/DatePicker.xml" path="//Member[@MemberName='Date']/Docs/*" />

--- a/src/Core/src/Platform/Android/DatePickerExtensions.cs
+++ b/src/Core/src/Platform/Android/DatePickerExtensions.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Maui.Platform
 		{
 			if (datePickerDialog != null)
 			{
-				datePickerDialog.DatePicker.MinDate = (long)datePicker.MinimumDate.Subtract(DateTime.MinValue.AddYears(1969)).TotalMilliseconds;
+				datePickerDialog.DatePicker.MinDate = (long)datePicker.MinimumDate.ToUniversalTimeNative().Subtract(DateTime.MinValue.AddYears(1969)).TotalMilliseconds;
 			}
 		}
 
@@ -49,8 +49,22 @@ namespace Microsoft.Maui.Platform
 		{
 			if (datePickerDialog != null)
 			{
-				datePickerDialog.DatePicker.MaxDate = (long)datePicker.MaximumDate.Subtract(DateTime.MinValue.AddYears(1969)).TotalMilliseconds;
+				datePickerDialog.DatePicker.MaxDate = (long)datePicker.MaximumDate.ToUniversalTimeNative().Subtract(DateTime.MinValue.AddYears(1969)).TotalMilliseconds;
 			}
+		}
+
+		internal static DateTime ToUniversalTimeNative(this DateTime date)
+		{
+			if (date.Kind == DateTimeKind.Utc)
+			{
+				return date;
+			}
+			var timeZone = Java.Util.TimeZone.Default;
+			if (timeZone != null && date != DateTime.MaxValue && date != DateTime.MinValue)
+			{
+				return date.AddHours(-1 * (double)timeZone.RawOffset / 1000 / 60 / 60);
+			}
+			return date.ToUniversalTime();
 		}
 
 		internal static void SetText(this MauiDatePicker platformDatePicker, IDatePicker datePicker)

--- a/src/Core/src/Platform/Android/DatePickerExtensions.cs
+++ b/src/Core/src/Platform/Android/DatePickerExtensions.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Maui.Platform
 		{
 			if (datePickerDialog != null)
 			{
-				datePickerDialog.DatePicker.MinDate = (long)datePicker.MinimumDate.ToUniversalTime().Subtract(DateTime.MinValue.AddYears(1969)).TotalMilliseconds;
+				datePickerDialog.DatePicker.MinDate = (long)datePicker.MinimumDate.Subtract(DateTime.MinValue.AddYears(1969)).TotalMilliseconds;
 			}
 		}
 
@@ -49,7 +49,7 @@ namespace Microsoft.Maui.Platform
 		{
 			if (datePickerDialog != null)
 			{
-				datePickerDialog.DatePicker.MaxDate = (long)datePicker.MaximumDate.ToUniversalTime().Subtract(DateTime.MinValue.AddYears(1969)).TotalMilliseconds;
+				datePickerDialog.DatePicker.MaxDate = (long)datePicker.MaximumDate.Subtract(DateTime.MinValue.AddYears(1969)).TotalMilliseconds;
 			}
 		}
 


### PR DESCRIPTION
### Description of Change

1. Instead of `DateTime.Now` I'm using the `DateTimeOffset.Now.DateTime.Date`. 

|Before|After|
|-|-|
| ![image](https://github.com/user-attachments/assets/4fe66453-b883-4fbd-a28d-168a466c0ae9) | ![image](https://github.com/user-attachments/assets/55153ef7-7d22-4323-a686-6f49525b9d66)  |

2. I've replaced the `.ToUniversalTime()` from `UpdateMinimumDate()` and `UpdateMaximumDate()` with `.ToUniversalTimeNative()` which uses TimeZone info from Java skipping loading the TZ database through .NET

|Before|After|
|-|-|
| ![image](https://github.com/user-attachments/assets/925251da-79f1-4763-bcfd-8cf188a02866) | ![image](https://github.com/user-attachments/assets/6b24e14e-8f73-4161-bf91-28b6021cfa3d) |

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #24929
This issue also includes `TimePicker` but I haven't looked into it yet.

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->

### Performance change

Recorded in release configuration on physical android device - Samsung Galaxy A50.
|Before|After|
|-----|------|
| <video src="https://github.com/user-attachments/assets/33f32296-bddd-45b4-befa-22f7745e1a8b"/> | <video src="https://github.com/user-attachments/assets/212ad99d-9111-476d-9ffc-dfee2a837d54"><video/> |