### PR TITLE
[Android] Tabs briefly display wrong background color when navigating…

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellItemRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellItemRenderer.cs
@@ -85,7 +85,15 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 			HookEvents(ShellItem);
 			SetupMenu();
-
+			var appearance = (ShellContext.Shell).GetAppearanceForPivot(ShellItem);
+			if (_bottomView.Background is ColorDrawable background)
+			{
+				var appearanceElement = appearance as IShellAppearanceElement;
+				if (appearanceElement != null)
+				{
+					background.Color = appearanceElement.EffectiveTabBarBackgroundColor.ToPlatform();
+				}
+			}
 			_appearanceTracker = ShellContext.CreateBottomNavViewAppearanceTracker(ShellItem);
 			_bottomNavigationTracker = new BottomNavigationViewTracker();
 			((IShellController)ShellContext.Shell).AddAppearanceObserver(this, ShellItem);

--- a/src/Controls/src/Core/Shell/Shell.cs
+++ b/src/Controls/src/Core/Shell/Shell.cs
@@ -1754,7 +1754,7 @@ namespace Microsoft.Maui.Controls
 			return defaultValue();
 		}
 
-		ShellAppearance GetAppearanceForPivot(Element pivot)
+		internal ShellAppearance GetAppearanceForPivot(Element pivot)
 		{
 			// this algorithm is pretty simple
 			// 1) Get the "CurrentPage" by walking down from the pivot


### PR DESCRIPTION
 ### Root Cause:
 
- On Android, the BottomNavigationView initially has a ColorDrawable with a white background, which is the default color during its creation. Later, the BottomNavigationView background is changed to a ColorChangeRevealDrawable with an animation, transitioning to the color specified by IShellAppearanceElement.EffectiveTabBarBackgroundColor. Since the previous background color (white) differs from the current color (black), the animation displays a transition from white to black when switching pages.

### Description of Change:
 
- To resolve this issue, the IShellAppearanceElement.EffectiveTabBarBackgroundColor is applied to the background of the BottomNavigationView immediately after its creation. This ensures that no animation is triggered later, as the previous background color (black) and the current color (black) remain the same.
 
**Tested the behaviour in the following platforms.**
- [x] Android
- [] Windows
- [] iOS
- [] Mac
 
### Reference
 
N/A
 
### Issues Fixed
 
Fixes #16522
 
### Screenshots
 
| After Issue Fix |
[screen-capture.webm](https://github.com/user-attachments/assets/68031f8d-7420-4112-b647-989bc8dba9ab)
