### PR TITLE
[iOS] Fix NRE in Shell SearchHandlerAppearanceTracker

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/SearchHandlerAppearanceTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/SearchHandlerAppearanceTracker.cs
@@ -262,7 +262,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 
 			SetSearchBarIconColor(uiButton, targetColor, _defaultPlaceholderTintColor);
-			uiButton.TintColor = targetColor.ToPlatform() ?? _defaultPlaceholderTintColor;
+			uiButton.TintColor = targetColor?.ToPlatform() ?? _defaultPlaceholderTintColor;
 		}
 
 		void UpdateClearIconColor(Color targetColor)
@@ -373,7 +373,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			button.SetImage(newIcon, UIControlState.Normal);
 			button.SetImage(newIcon, UIControlState.Selected);
 			button.SetImage(newIcon, UIControlState.Highlighted);
-			button.TintColor = button.ImageView.TintColor = targetColor != null ? targetColor.ToPlatform() : defaultTintColor;
+			button.TintColor = button.ImageView.TintColor = targetColor?.ToPlatform() ?? defaultTintColor;
 		}
 
 		protected virtual void Dispose(bool disposing)


### PR DESCRIPTION
### Description of Change

Fix crash on iOS involving Shell SearchHandler.
Fallback to `_defaultPlaceholderTintColor` if `targetColor` is null in `UpdateClearPlaceholderIconColor`.

### Issues Fixed

Fixes #19504 
A previous PR fixed an identical problem #11927 

### Steps to Reproduce

Create a shell with two shell content. Add a SearchHandler to one ShellContent ContentPage.
Start application. Click on the SearchHandler. Navigate to the other page. Navigate back. NullReferenceException crash.

