### PR TITLE
(Re)enable Mail API for Mac Catalyst

### DIFF
--- a/src/Essentials/samples/Samples/View/EmailPage.xaml
+++ b/src/Essentials/samples/Samples/View/EmailPage.xaml
@@ -13,7 +13,8 @@
     </views:BasePage.ToolbarItems>
 
     <Grid RowDefinitions="Auto,*">
-        <Label Text="Easily send email messages." FontAttributes="Bold" Margin="12" />
+        <Label Text="{Binding IsComposeSupported, StringFormat='Easily send email messages. Supported on this device: {0}'}"
+            FontAttributes="Bold" Margin="12" />
 
         <ScrollView Grid.Row="1">
             <StackLayout Padding="12,0,12,12" Spacing="6">

--- a/src/Essentials/samples/Samples/ViewModel/EmailViewModel.cs
+++ b/src/Essentials/samples/Samples/ViewModel/EmailViewModel.cs
@@ -27,6 +27,8 @@ namespace Samples.ViewModel
 			SendEmailCommand = new Command(OnSendEmail);
 		}
 
+		public bool IsComposeSupported => Email.Default.IsComposeSupported;
+
 		public ICommand SendEmailCommand { get; }
 
 		public string Subject

--- a/src/Essentials/src/Email/Email.ios.cs
+++ b/src/Essentials/src/Email/Email.ios.cs
@@ -2,7 +2,7 @@ using System.IO;
 using System.Threading.Tasks;
 using Foundation;
 using UIKit;
-#if !(MACCATALYST || MACOS)
+#if !(MACOS)
 using MessageUI;
 #endif
 
@@ -11,7 +11,7 @@ namespace Microsoft.Maui.ApplicationModel.Communication
 	partial class EmailImplementation : IEmail
 	{
 		public bool IsComposeSupported =>
-#if !(MACCATALYST || MACOS)
+#if !(MACOS)
 			MFMailComposeViewController.CanSendMail ||
 			MainThread.InvokeOnMainThread(() => UIApplication.SharedApplication.CanOpenUrl(NSUrl.FromString("mailto:")));
 #else
@@ -20,7 +20,7 @@ namespace Microsoft.Maui.ApplicationModel.Communication
 
 		Task PlatformComposeAsync(EmailMessage message)
 		{
-#if !(MACCATALYST || MACOS)
+#if !(MACOS)
 			if (MFMailComposeViewController.CanSendMail)
 				return ComposeWithMailCompose(message);
 			else
@@ -32,7 +32,7 @@ namespace Microsoft.Maui.ApplicationModel.Communication
 
 		Task ComposeWithMailCompose(EmailMessage message)
 		{
-#if !(MACCATALYST || MACOS)
+#if !(MACOS)
 			// do this first so we can throw as early as possible
 			var parentController = WindowStateManager.Default.GetCurrentUIViewController(true);
 


### PR DESCRIPTION
### Description of Change

For some reason the Essentials Mail APIs were disabled for Mac Catalyst. This PR re-enables the Mail API for Mac Catalyst by updating the conditional compilation directives in the `Email.ios.cs` file.

Manual testing indicates that its working fine.

### Issues Fixed

Fixes #24991