### PR TITLE
Update the Benchmarks.Droid app to use built in Android GetExternalFilesDir

### DIFF
--- a/src/Core/tests/Benchmarks.Droid/MainInstrumentation.cs
+++ b/src/Core/tests/Benchmarks.Droid/MainInstrumentation.cs
@@ -20,7 +20,7 @@ public class MainInstrumentation : Instrumentation
 
 		Instance = this;
 		ExternalDataDirectory = Context?.GetExternalFilesDir(null)?.ToString() ?? string.Empty;
-		if (ExternalDataDirectory == string.Empty)
+		if (string.IsNullOrEmpty(ExternalDataDirectory))
 		{
 			Log.Error(Tag, "ExternalDataDirectory is failed to be set");
 			return;

--- a/src/Core/tests/Benchmarks.Droid/MainInstrumentation.cs
+++ b/src/Core/tests/Benchmarks.Droid/MainInstrumentation.cs
@@ -9,6 +9,7 @@ public class MainInstrumentation : Instrumentation
 	const string Tag = "MAUI";
 
 	public static MainInstrumentation? Instance { get; private set; }
+	public static string ExternalDataDirectory { get; private set; } = string.Empty;
 
 	protected MainInstrumentation(IntPtr handle, JniHandleOwnership transfer)
 		: base(handle, transfer) { }
@@ -18,6 +19,13 @@ public class MainInstrumentation : Instrumentation
 		base.OnCreate(arguments);
 
 		Instance = this;
+		ExternalDataDirectory = Context?.GetExternalFilesDir(null)?.ToString() ?? string.Empty;
+		if (ExternalDataDirectory == string.Empty)
+		{
+			Log.Error(Tag, "ExternalDataDirectory is failed to be set");
+			return;
+		}
+		Log.Debug(Tag, $"ExternalDataDirectory: {ExternalDataDirectory}");
 
 		Start();
 	}
@@ -40,7 +48,7 @@ public class MainInstrumentation : Instrumentation
 		Environment.SetEnvironmentVariable("PERFLAB_QUEUE", "REPLACE_PERFLAB_QUEUE");
 		Environment.SetEnvironmentVariable("PERFLAB_BUILDARCH", "REPLACE_PERFLAB_BUILDARCH");
 		Environment.SetEnvironmentVariable("PERFLAB_LOCALE", "REPLACE_PERFLAB_LOCALE");
-		Directory.CreateDirectory("/storage/emulated/0/Android/data/com.microsoft.maui.benchmarks/files");
+		Directory.CreateDirectory(ExternalDataDirectory);
 #endif
 
 		var success = await Task.Factory.StartNew(Run);


### PR DESCRIPTION
### Description of Change

Update the Benchmarks.Droid app to use built in Android GetExternalFilesDir as a location to save tests to. This will fix the test runs of this done as part of dotnet/performance testing. This also needs to be backported to net9.0.

### Issues Fixed

We started hitting an issue where the hardcoded file location was not accessible due to permission errors. This switches to using the built in Android GetExternalFilesDir to get the same path which has corrected the permission error.

Fixes: https://github.com/dotnet/performance/issues/4477

FYI @jonathanpeppers 
