### PR TITLE
Adding tests (disabled) from Control Gallery to Appium

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Bugzilla33578.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Bugzilla33578.cs
@@ -1,0 +1,71 @@
+using System;
+using Microsoft.Maui.Controls.CustomAttributes;
+using Microsoft.Maui.Controls.Internals;
+
+namespace Maui.Controls.Sample.Issues;
+
+[Preserve(AllMembers = true)]
+[Issue(IssueTracker.Bugzilla, 33578, "TableView EntryCell shows DefaultKeyboard, but after scrolling down and back a NumericKeyboard (")]
+public class Bugzilla33578 : TestContentPage
+{
+	protected override void Init()
+	{
+		Content = new TableView
+		{
+			AutomationId = "table",
+			Root = new TableRoot {
+				new TableSection {
+					new EntryCell {
+						Placeholder = "Enter text here 1",
+						AutomationId = "entryNormal"
+					},
+					new EntryCell {
+						Placeholder = "Enter text here 2"
+					},
+					new EntryCell {
+						Placeholder = "Enter text here"
+					},
+					new EntryCell {
+						Placeholder = "Enter text here"
+					},
+					new EntryCell {
+						Placeholder = "Enter text here"
+					},
+					new EntryCell {
+						Placeholder = "Enter text here"
+					},
+					new EntryCell {
+						Placeholder = "Enter text here"
+					},
+					new EntryCell {
+						Placeholder = "Enter text here"
+					},
+					new EntryCell {
+						Placeholder = "Enter text here"
+					},
+					new EntryCell {
+						Placeholder = "Enter text here"
+					},
+					new EntryCell {
+						Placeholder = "Enter text here"
+					},
+					new EntryCell {
+						Placeholder = "Enter text here"
+					},
+					new EntryCell {
+						Placeholder = "Enter text here"
+					},
+					new EntryCell {
+						Placeholder = "Enter text here",
+						AutomationId = "entryPreviousNumeric"
+					},
+					new EntryCell {
+						Keyboard = Keyboard.Numeric,
+						Placeholder = "0",
+						AutomationId = "entryNumeric"
+					}
+				}
+			}
+		};
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Bugzilla33612.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Bugzilla33612.cs
@@ -1,0 +1,132 @@
+using System;
+using System.Linq;
+using Microsoft.Maui.Controls.CustomAttributes;
+using Microsoft.Maui.Controls.Internals;
+
+namespace Maui.Controls.Sample.Issues;
+
+
+[Preserve(AllMembers = true)]
+[Issue(IssueTracker.Bugzilla, 33612,
+	"(A) Removing a page from the navigation stack causes an 'Object reference' exception in Android only",
+	PlatformAffected.Android)]
+public class Bugzilla33612 : TestNavigationPage
+{
+	class Page1 : ContentPage
+	{
+		public Page1()
+		{
+			var button = new Button { Text = "Go To Page 2" };
+			button.Clicked += (sender, args) => Navigation.PushAsync(new Page2());
+
+			Content = new StackLayout()
+			{
+				Children = {
+					new Label { Text = "This is Page 1 - the root page" },
+					button
+				}
+			};
+		}
+	}
+
+	class FakePage : ContentPage
+	{
+		public FakePage()
+		{
+			Content = new StackLayout()
+			{
+				Children = {
+					new Label { Text = "This is a fake page. It will never show up." }
+				}
+			};
+		}
+	}
+
+	class Page2 : ContentPage
+	{
+		public Page2()
+		{
+			var button = new Button { Text = "Go to Page 3" };
+			button.Clicked += async (sender, args) =>
+			{
+				int numPagesToRemove = Navigation.NavigationStack.Count;
+
+				Page3 page3 = new Page3();
+				await Navigation.PushAsync(page3);
+
+				var fake = new FakePage();
+				Navigation.InsertPageBefore(fake, page3);
+
+				// Remove all the previous pages on the stack (i.e., Page 1)
+				// This should work fine
+				for (int i = 0; i < numPagesToRemove; i++)
+				{
+					Page p = Navigation.NavigationStack.ElementAt(0);
+					Navigation.RemovePage(p);
+				}
+			};
+
+			Content = new StackLayout()
+			{
+				Children = {
+					new Label { Text = "This is Page 2" },
+					button
+				}
+			};
+		}
+	}
+
+	class SuccessPage : ContentPage
+	{
+		public SuccessPage()
+		{
+			Content = new StackLayout()
+			{
+				Children = {
+					new Label { Text = "If you're seeing this, nothing crashed. Yay!" }
+				}
+			};
+		}
+	}
+
+	class Page3 : ContentPage
+	{
+		public Page3()
+		{
+			var button = new Button { AutomationId = "btn", Text = "Return To Page 2" };
+			button.Clicked += (sender, args) =>
+			{
+				int numPagesToRemove = Navigation.NavigationStack.Count;
+
+				// Remove all the previous pages on the stack 
+				// Originally this would fail (and crash the app), because FakePage 
+				// was never actually run through SwitchContentAsync
+				// which means that it never had its renderer set.
+				// But now it should work just fine
+				for (int i = 0; i < numPagesToRemove - 1; i++)
+				{
+					Page p = Navigation.NavigationStack.ElementAt(0);
+					Navigation.RemovePage(p);
+				}
+
+				var success = new SuccessPage();
+				Navigation.PushAsync(success);
+			};
+
+			Content = new StackLayout()
+			{
+				Children = {
+					new Label { Text = "This is Page 3" },
+					button
+				}
+			};
+		}
+	}
+
+	protected override void Init()
+	{
+		var page1 = new Page1();
+
+		PushAsync(page1);
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Bugzilla33870.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Bugzilla33870.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using Microsoft.Maui.Controls.CustomAttributes;
+using Microsoft.Maui.Controls.Internals;
+
+namespace Maui.Controls.Sample.Issues;
+
+[Preserve(AllMembers = true)]
+[Issue(IssueTracker.Bugzilla, 33870, "[W] Crash when the ListView Selection is set to null", PlatformAffected.WinRT)]
+
+public class Bugzilla33870 : TestContentPage
+{
+	const string PageContentAutomatedId = nameof(PageContentAutomatedId);
+	const string ListViewAutomatedId = nameof(ListViewAutomatedId);
+	const string SelectionClearedText = "Cleared";
+	const string ClearSelectionItem = "CLEAR SELECTION";
+
+	protected override void Init()
+	{
+		var source = new ObservableCollection<Section>
+		{
+			new Section("SECTION 1")
+			{
+				new MenuItem("ITEM 1"),
+				new MenuItem("ITEM 2"),
+			},
+			new Section("SECTION 2")
+			{
+				new MenuItem("ITEM 3"),
+				new MenuItem(ClearSelectionItem),
+			}
+		};
+
+		var label = new Label
+		{
+			Text = "Tap CLEAR SELECTION. If the app does not crash and no item is selected, the test has passed."
+		};
+
+		var listView = new ListView
+		{
+			AutomationId = ListViewAutomatedId,
+			ItemsSource = source,
+			IsGroupingEnabled = true,
+			GroupDisplayBinding = new Binding(nameof(Section.Title)),
+			ItemTemplate = new DataTemplate(() =>
+			{
+				var viewCell = new ViewCell();
+				var itemTemplateLabel = new Label();
+				itemTemplateLabel.SetBinding(Label.TextProperty, nameof(MenuItem.Name));
+				viewCell.View = itemTemplateLabel;
+				return viewCell;
+			})
+		};
+
+		listView.ItemSelected += (sender, args) =>
+		{
+			var selectedMenuItem = args.SelectedItem as MenuItem;
+			if (selectedMenuItem == null)
+			{
+				return;
+			}
+
+			label.Text = selectedMenuItem.Name;
+			if (selectedMenuItem.Name == ClearSelectionItem)
+			{
+				((ListView)sender).SelectedItem = null;
+
+				label.Text = SelectionClearedText;
+			}
+		};
+
+		var stack = new StackLayout
+		{
+			AutomationId = PageContentAutomatedId,
+			Children =
+			{
+				label,
+				listView
+			}
+		};
+
+		Content = stack;
+	}
+
+	class Section : ObservableCollection<MenuItem>
+	{
+		public Section(string title)
+			: this(new List<MenuItem>())
+		{
+			Title = title;
+		}
+
+		Section(IEnumerable<MenuItem> items)
+			: base(items)
+		{ }
+
+		public string Title { get; }
+	}
+
+	class MenuItem
+	{
+
+		public MenuItem(string name)
+		{
+			Name = name;
+		}
+
+		public string Name { get; }
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Bugzilla34632.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Bugzilla34632.cs
@@ -1,0 +1,66 @@
+using System;
+using Microsoft.Maui.Controls.CustomAttributes;
+using Microsoft.Maui.Controls.Internals;
+using Microsoft.Maui.Devices;
+
+namespace Maui.Controls.Sample.Issues;
+
+[Preserve(AllMembers = true)]
+[Issue(IssueTracker.Bugzilla, 34632, "Can't change IsPresented when setting SplitOnLandscape ")]
+public class Bugzilla34632 : TestFlyoutPage
+{
+	protected override void Init()
+	{
+#pragma warning disable CS0618 // Type or member is obsolete
+		if (DeviceInfo.Platform == DevicePlatform.UWP)
+			FlyoutLayoutBehavior = FlyoutLayoutBehavior.Split;
+		else
+			FlyoutLayoutBehavior = FlyoutLayoutBehavior.SplitOnLandscape;
+#pragma warning restore CS0618 // Type or member is obsolete
+
+		Flyout = new ContentPage
+		{
+			Title = "Main Page",
+			Content = new Button
+			{
+				Text = "Flyout",
+				AutomationId = "btnFlyout",
+				Command = new Command(() =>
+				{
+					//If we're in potrait toggle hide the menu on click
+					if (Width < Height || DeviceInfo.Idiom == DeviceIdiom.Phone)
+					{
+						IsPresented = false;
+					}
+				})
+			}
+		};
+
+		Detail = new NavigationPage(new ModalRotationIssue());
+		NavigationPage.SetHasBackButton(Detail, false);
+	}
+
+	[Preserve(AllMembers = true)]
+	public class ModalRotationIssue : ContentPage
+	{
+		public ModalRotationIssue()
+		{
+			var btn = new Button { Text = "Open Modal", AutomationId = "btnModal" };
+			btn.Clicked += OnButtonClicked;
+			Content = btn;
+		}
+
+		async void OnButtonClicked(object sender, EventArgs e)
+		{
+			var testButton = new Button { Text = "Rotate Before Clicking", AutomationId = "btnDismissModal" };
+			testButton.Clicked += (async (snd, args) => await Navigation.PopModalAsync());
+
+			var testModal = new ContentPage()
+			{
+				Content = testButton
+			};
+
+			await Navigation.PushModalAsync(testModal);
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Bugzilla34912.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Bugzilla34912.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Collections.ObjectModel;
+using System.Linq;
+using Microsoft.Maui.Controls.CustomAttributes;
+using Microsoft.Maui.Controls.Internals;
+
+namespace Maui.Controls.Sample.Issues;
+
+// Note: Fails on UWP due to https://bugzilla.xamarin.com/show_bug.cgi?id=60521
+[Preserve(AllMembers = true)]
+[Issue(IssueTracker.Bugzilla, 34912, "ListView.IsEnabled has no effect on iOS")]
+public class Bugzilla34912 : TestContentPage
+{
+	protected override void Init()
+	{
+		Padding = new Thickness(0, 20, 0, 0);
+
+		var source = SetupList();
+
+		var list = new ListView
+		{
+			ItemTemplate = new DataTemplate(typeof(TextCell))
+			{
+				Bindings = {
+					{ TextCell.TextProperty, new Binding ("Name") }
+				}
+			},
+
+			GroupDisplayBinding = new Binding("LongTitle"),
+			GroupShortNameBinding = new Binding("Title"),
+			Header = "HEADER",
+			Footer = "FOOTER",
+			IsGroupingEnabled = true,
+			ItemsSource = SetupList(),
+		};
+
+		list.ItemTapped += (sender, e) =>
+		{
+			var listItem = (Issue2777.ListItemValue)e.Item;
+			DisplayAlert(listItem.Name, "You tapped " + listItem.Name, "OK", "Cancel");
+		};
+
+		var btnDisable = new Button()
+		{
+			Text = "Disable ListView",
+			AutomationId = "btnDisable"
+		};
+		btnDisable.Clicked += (object sender, EventArgs e) =>
+		{
+			if (list.IsEnabled == true)
+			{
+				list.IsEnabled = false;
+				btnDisable.Text = "Enable ListView";
+			}
+			else
+			{
+				list.IsEnabled = true;
+				btnDisable.Text = "Disable ListView";
+			}
+		};
+
+#pragma warning disable CS0618 // Type or member is obsolete
+		Content = new StackLayout
+		{
+			VerticalOptions = LayoutOptions.FillAndExpand,
+			Children = { btnDisable, list }
+		};
+#pragma warning restore CS0618 // Type or member is obsolete
+	}
+
+	ObservableCollection<Issue2777.ListItemCollection> SetupList()
+	{
+		var allListItemGroups = new ObservableCollection<Issue2777.ListItemCollection>();
+
+		foreach (var item in Issue2777.ListItemCollection.GetSortedData())
+		{
+			// Attempt to find any existing groups where theg group title matches the first char of our ListItem's name.
+			var listItemGroup = allListItemGroups.FirstOrDefault(g => g.Title == item.Label);
+
+			// If the list group does not exist, we create it.
+			if (listItemGroup == null)
+			{
+				listItemGroup = new Issue2777.ListItemCollection(item.Label);
+				listItemGroup.Add(item);
+				allListItemGroups.Add(listItemGroup);
+			}
+			else
+			{ // If the group does exist, we simply add the demo to the existing group.
+				listItemGroup.Add(item);
+			}
+		}
+		return allListItemGroups;
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Bugzilla36955.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Bugzilla36955.cs
@@ -1,0 +1,36 @@
+using System;
+using Microsoft.Maui.Controls.CustomAttributes;
+using Microsoft.Maui.Controls.Internals;
+
+namespace Maui.Controls.Sample.Issues;
+
+[Preserve(AllMembers = true)]
+[Issue(IssueTracker.Bugzilla, 36955, "[iOS] ViewCellRenderer.UpdateIsEnabled referencing null object", PlatformAffected.iOS)]
+public class Bugzilla36955 : TestContentPage
+{
+	protected override void Init()
+	{
+		var ts = new TableSection();
+		var tr = new TableRoot { ts };
+		var tv = new TableView(tr);
+
+		var sc = new SwitchCell
+		{
+			Text = "Toggle switch; nothing should crash"
+		};
+
+		var button = new Button();
+		button.SetBinding(Button.TextProperty, new Binding("On", source: sc));
+
+		var vc = new ViewCell
+		{
+			View = button
+		};
+		vc.SetBinding(Cell.IsEnabledProperty, new Binding("On", source: sc));
+
+		ts.Add(sc);
+		ts.Add(vc);
+
+		Content = tv;
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Bugzilla37462.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Bugzilla37462.cs
@@ -1,0 +1,60 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Maui.Controls.CustomAttributes;
+using Microsoft.Maui.Controls.Internals;
+
+namespace Maui.Controls.Sample.Issues;
+
+[Preserve(AllMembers = true)]
+[Issue(IssueTracker.Bugzilla, 37462, "Using App Compat/App Compat theme breaks Navigation.RemovePage on Android ", PlatformAffected.Android)]
+public class Bugzilla37462 : TestNavigationPage
+{
+	protected override void Init()
+	{
+		var page1 = new ContentPage { Title = "Page 1" };
+		var button1 = new Button { Text = "Go To 2", AutomationId = "Go To 2" };
+		var label1 = new Label { Text = "This is a label on page 1", AutomationId = "This is a label on page 1" };
+		page1.Content = new StackLayout { Children = { button1, label1 } };
+		page1.Appearing += (sender, args) =>
+		{
+			((IVisualElementController)page1).InvalidateMeasure(InvalidationTrigger.MeasureChanged);
+		};
+
+		var page2 = new ContentPage { Title = "Page 2" };
+		var button2 = new Button { Text = "Go To 3", AutomationId = "Go To 3" };
+		var label2 = new Label { Text = "This is a label on page 2" };
+		page2.Content = new StackLayout { Children = { button2, label2 } };
+
+		var page3 = new ContentPage { Title = "Page 3" };
+		var button3 = new Button { Text = "Go To 4", AutomationId = "Go To 4" };
+		var label3 = new Label { Text = "This is a label on page 3" };
+		page3.Content = new StackLayout { Children = { button3, label3 } };
+
+		var page4 = new ContentPage { Title = "Page 4" };
+		var button4 = new Button { Text = "Back to 1", AutomationId = "Back to 1" };
+		var label4 = new Label { Text = "This is a label on page 4" };
+		page4.Content = new StackLayout { Children = { button4, label4 } };
+
+		button1.Clicked += async (sender, args) => { await Navigation.PushAsync(page2); };
+		button2.Clicked += async (sender, args) => { await Navigation.PushAsync(page3); };
+		button3.Clicked += async (sender, args) => { await Navigation.PushAsync(page4); };
+
+		button4.Clicked += async (sender, args) =>
+		{
+			List<Page> existingPages = Navigation.NavigationStack.ToList();
+
+			// Clear all pages except current and home
+			foreach (Page page in existingPages)
+			{
+				if (page.Title != "Page 1" && page.Title != "Page 4")
+				{
+					Navigation.RemovePage(page);
+				}
+			}
+
+			await Navigation.PopAsync();
+		};
+
+		Navigation.PushAsync(page1);
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Bugzilla37841.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Bugzilla37841.cs
@@ -1,0 +1,131 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using Microsoft.Maui.Controls.CustomAttributes;
+using Microsoft.Maui.Controls.Internals;
+
+namespace Maui.Controls.Sample.Issues;
+
+[Preserve(AllMembers = true)]
+[Issue(IssueTracker.Bugzilla, 37841, "TableView EntryCells and TextCells cease to update after focus change", PlatformAffected.Android)]
+public class Bugzilla37841 : TestContentPage
+{
+	_37841ViewModel _viewModel;
+
+	protected override void Init()
+	{
+		_viewModel = new _37841ViewModel();
+
+		var instructions = new Label { FontSize = 16, Text = @"Click on the Generate button. 
+The EntryCell should display '12345' and the TextCell should display '6789'. 
+Click on the Generate button a second time. 
+The EntryCell should display '112358' and the TextCell should display '48151623'." };
+
+		var button = new Button { Text = "Generate", AutomationId = "Generate" };
+		button.SetBinding(Button.CommandProperty, nameof(_37841ViewModel.GetNextNumbersCommand));
+
+		var random1 = new EntryCell { IsEnabled = false, Label = "Entry Cell", AutomationId = "entrycell" };
+		random1.SetBinding(EntryCell.TextProperty, nameof(_37841ViewModel.Value1));
+
+		var textCell = new TextCell { IsEnabled = false, Detail = "TextCell", AutomationId = "textcell" };
+		textCell.SetBinding(TextCell.TextProperty, nameof(_37841ViewModel.Value2));
+
+		var buttonViewCell = new ViewCell { View = button };
+
+		var section = new TableSection("") {
+			random1,
+			textCell,
+			buttonViewCell
+		};
+
+		var root = new TableRoot { section };
+		var tv = new TableView { Root = root };
+
+		Content = new StackLayout
+		{
+			Children = { instructions, tv }
+		};
+
+		BindingContext = _viewModel;
+	}
+
+	[Preserve(AllMembers = true)]
+	public class _37841ViewModel : INotifyPropertyChanged
+	{
+		public int Value1
+		{
+			get { return _value1; }
+			set
+			{
+				if (value != _value1)
+				{
+					_value1 = value;
+					RaisePropertyChanged();
+				}
+			}
+		}
+
+		public int Value2
+		{
+			get { return _value2; }
+			set
+			{
+				if (value != _value2)
+				{
+					_value2 = value;
+					RaisePropertyChanged();
+				}
+			}
+		}
+
+		public Command GetNextNumbersCommand
+			=> _getNextNumbersCommand ?? (_getNextNumbersCommand = new Command(ExecuteGenerateRandomCommand));
+
+		class SomeNumbers : IEnumerable<int>
+		{
+			public IEnumerator<int> GetEnumerator()
+			{
+				while (true)
+				{
+					yield return 12345;
+					yield return 6789;
+					yield return 112358;
+					yield return 48151623;
+				}
+			}
+
+			IEnumerator IEnumerable.GetEnumerator()
+			{
+				return GetEnumerator();
+			}
+		}
+
+		readonly IEnumerator<int> _numberList = new SomeNumbers().GetEnumerator();
+
+		void ExecuteGenerateRandomCommand()
+		{
+			_numberList.MoveNext();
+			Value1 = _numberList.Current;
+			_numberList.MoveNext();
+			Value2 = _numberList.Current;
+		}
+
+		void RaisePropertyChanged([CallerMemberName] string propertyName = null)
+		{
+			PropertyChangedEventHandler handler = PropertyChanged;
+
+			handler?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+		}
+
+		#region INotifyPropertyChanged implementation
+
+		public event PropertyChangedEventHandler PropertyChanged;
+
+		#endregion
+
+		Command _getNextNumbersCommand;
+		int _value1;
+		int _value2;
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Bugzilla38112.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Bugzilla38112.cs
@@ -1,0 +1,92 @@
+using System;
+using Microsoft.Maui.Controls.CustomAttributes;
+using Microsoft.Maui.Controls.Internals;
+
+namespace Maui.Controls.Sample.Issues;
+
+[Preserve(AllMembers = true)]
+[Issue(IssueTracker.Bugzilla, 38112, "Switch becomes reenabled when previous ViewCell is removed from TableView", PlatformAffected.Android)]
+public class Bugzilla38112 : TestContentPage
+{
+	bool _removed;
+	protected override void Init()
+	{
+		var layout = new StackLayout();
+		var button = new Button { Text = "Click", AutomationId = "Click" };
+		var tablesection = new TableSection { Title = "Switches" };
+		var tableview = new TableView { Intent = TableIntent.Form, Root = new TableRoot { tablesection } };
+#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
+		var viewcell1 = new ViewCell
+		{
+			View = new StackLayout
+			{
+				HorizontalOptions = LayoutOptions.FillAndExpand,
+				Orientation = StackOrientation.Horizontal,
+				Children = {
+					new Label { Text = "Switch 1", HorizontalOptions = LayoutOptions.StartAndExpand },
+					new Switch { AutomationId = "switch1", HorizontalOptions = LayoutOptions.End, IsToggled = true }
+				}
+			}
+		};
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
+		var viewcell2 = new ViewCell
+		{
+			View = new StackLayout
+			{
+				HorizontalOptions = LayoutOptions.FillAndExpand,
+				Orientation = StackOrientation.Horizontal,
+				Children = {
+					new Label { Text = "Switch 2", HorizontalOptions = LayoutOptions.StartAndExpand },
+					new Switch { AutomationId = "switch2", HorizontalOptions = LayoutOptions.End, IsToggled = true }
+				}
+			}
+		};
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
+		Label label = new Label { Text = "Switch 3", HorizontalOptions = LayoutOptions.StartAndExpand, AutomationId = "resultlabel" };
+#pragma warning restore CS0618 // Type or member is obsolete
+		Switch switchie = new Switch { AutomationId = "switch3", HorizontalOptions = LayoutOptions.End, IsToggled = true, IsEnabled = false };
+		switchie.Toggled += (sender, e) =>
+		{
+			label.Text = "FAIL";
+		};
+#pragma warning disable CS0618 // Type or member is obsolete
+		var viewcell3 = new ViewCell
+		{
+			View = new StackLayout
+			{
+				HorizontalOptions = LayoutOptions.FillAndExpand,
+				Orientation = StackOrientation.Horizontal,
+				Children = {
+					label,
+					switchie,
+				}
+			}
+		};
+#pragma warning restore CS0618 // Type or member is obsolete
+
+		tablesection.Add(viewcell1);
+		tablesection.Add(viewcell2);
+		tablesection.Add(viewcell3);
+
+		button.Clicked += (sender, e) =>
+		{
+			if (_removed)
+				tablesection.Insert(1, viewcell2);
+			else
+				tablesection.Remove(viewcell2);
+
+			_removed = !_removed;
+		};
+
+		layout.Children.Add(button);
+		layout.Children.Add(tableview);
+
+		Content = layout;
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Bugzilla38731.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Bugzilla38731.cs
@@ -1,0 +1,104 @@
+using System;
+using Microsoft.Maui.Controls.CustomAttributes;
+using Microsoft.Maui.Controls.Internals;
+
+namespace Maui.Controls.Sample.Issues;
+
+[Preserve(AllMembers = true)]
+[Issue(IssueTracker.Bugzilla, 38731, "iOS.NavigationRenderer.GetAppearedOrDisappearedTask NullReferenceExceptionObject", PlatformAffected.iOS)]
+public class Bugzilla38731 : TestContentPage
+{
+	protected override void Init()
+	{
+		var label = new Label();
+		label.Text = "Page one...";
+		label.HorizontalTextAlignment = TextAlignment.Center;
+
+		var button = new Button();
+		button.AutomationId = "btn1";
+		button.Text = "Navigate to page two";
+		button.Clicked += Button_Clicked;
+
+		var content = new StackLayout();
+		content.Children.Add(label);
+		content.Children.Add(button);
+
+		Title = "Page one";
+		Content = content;
+	}
+
+	void Button_Clicked(object sender, EventArgs e)
+	{
+		Navigation.PushAsync(new PageTwo());
+	}
+
+	public class PageTwo : ContentPage
+	{
+		public PageTwo()
+		{
+			var label = new Label();
+			label.Text = "Page two...";
+			label.HorizontalTextAlignment = TextAlignment.Center;
+
+			var button = new Button();
+			button.AutomationId = "btn2";
+			button.Text = "Navigate to page three";
+			button.Clicked += Button_Clicked;
+
+			var content = new StackLayout();
+			content.Children.Add(label);
+			content.Children.Add(button);
+
+			Title = "Page two";
+			Content = content;
+		}
+
+		void Button_Clicked(object sender, EventArgs e)
+		{
+			Navigation.PushAsync(new PageThree());
+		}
+	}
+
+	public class PageThree : ContentPage
+	{
+		public PageThree()
+		{
+			var label = new Label();
+			label.Text = "Page three...";
+			label.HorizontalTextAlignment = TextAlignment.Center;
+
+			var button = new Button();
+			button.AutomationId = "btn3";
+			button.Text = "Navigate to page four";
+			button.Clicked += Button_Clicked;
+
+			var content = new StackLayout();
+			content.Children.Add(label);
+			content.Children.Add(button);
+
+			Title = "Page three";
+			Content = content;
+		}
+
+		void Button_Clicked(object sender, EventArgs e)
+		{
+			Navigation.PushAsync(new PageFour());
+		}
+	}
+
+	public class PageFour : ContentPage
+	{
+		public PageFour()
+		{
+			var label = new Label();
+			label.Text = "Last page... Tap back very quick";
+			label.HorizontalTextAlignment = TextAlignment.Center;
+
+			var content = new StackLayout();
+			content.Children.Add(label);
+
+			Title = "Page four";
+			Content = content;
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Bugzilla33578.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Bugzilla33578.cs
@@ -1,0 +1,38 @@
+﻿// #if IOS
+// using NUnit.Framework;
+// using UITest.Appium;
+// using UITest.Core;
+
+// namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+// public class Bugzilla33578 : _IssuesUITest
+// {
+// 	public Bugzilla33578(TestDevice testDevice) : base(testDevice)
+// 	{
+// 	}
+
+// 	public override string Issue => "TableView EntryCell shows DefaultKeyboard, but after scrolling down and back a NumericKeyboard (";
+
+// 	// TODO: Migration from Xamarin.UITest
+// 	// Find out how to do this advanced stuff with Appium
+// 	[Test]
+// 	[Category(UITestCategories.TableView)]
+// 	[FailsOnIOS]
+// 	public void TableViewEntryCellShowsDefaultKeyboardThenNumericKeyboardAfterScrolling()
+// 	{
+// 		App.ScrollDown("table");
+// 		App.ScrollDown("table");
+// 		App.Tap("entryNumeric");
+// 		var e = App.Query(c => c.Marked("0").Parent("UITextField").Index(0).Invoke("keyboardType"))[0];
+// 		//8 DecimalPad
+// 		Assert.AreEqual(8, e);
+// 		App.DismissKeyboard();
+// 		App.Tap(x => x.Marked("Enter text here").Index(0).Parent());
+// 		App.ScrollUp();
+// 		App.Tap(x => x.Marked("Enter text here 1"));
+// 		App.Tap(x => x.Marked("Enter text here 2").Index(0).Parent());
+// 		var e1 = App.Query(c => c.Marked("Enter text here 2").Parent("UITextField").Index(0).Invoke("keyboardType"))[0];
+// 		Assert.AreEqual(0, e1);
+// 	}
+// }
+// #endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Bugzilla33612.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Bugzilla33612.cs
@@ -1,0 +1,35 @@
+﻿// using NUnit.Framework;
+// using UITest.Appium;
+// using UITest.Core;
+
+// namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+// public class Bugzilla33612 : _IssuesUITest
+// {
+// 	public Bugzilla33612(TestDevice testDevice) : base(testDevice)
+// 	{
+// 	}
+
+// 	public override string Issue => "(A) Removing a page from the navigation stack causes an 'Object reference' exception in Android only";
+
+// 	[Test]
+// 	[Category(UITestCategories.Navigation)]
+// 	public void Issue33612RemovePagesWithoutRenderers()
+// 	{
+// 		App.WaitForElement("Go To Page 2");
+// 		App.Tap("Go To Page 2");
+
+// 		App.WaitForElement("This is Page 2");
+// 		App.Screenshot("At Page 2");
+// 		App.Tap("Go to Page 3");
+
+// 		App.WaitForElement("This is Page 3");
+// 		App.WaitForElement("Return To Page 2",
+// 			timeout: TimeSpan.FromSeconds(15));
+// 		App.Screenshot("At Page 3");
+// 		App.Tap("Return To Page 2");
+
+// 		App.WaitForElement("If you're seeing this, nothing crashed. Yay!");
+// 		App.Screenshot("Success Page");
+// 	}
+// }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Bugzilla33870.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Bugzilla33870.cs
@@ -1,0 +1,26 @@
+﻿// using NUnit.Framework;
+// using UITest.Appium;
+// using UITest.Core;
+
+// namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+// public class Bugzilla33870 : _IssuesUITest
+// {
+// 	public Bugzilla33870(TestDevice testDevice) : base(testDevice)
+// 	{
+// 	}
+
+// 	public override string Issue => "[W] Crash when the ListView Selection is set to null";
+
+// 	[Test]
+// 	[Category(UITestCategories.ListView)]
+// 	[FailsOnIOS]
+// 	public void Bugzilla33870Test()
+// 	{
+// 		App.WaitForElement("PageContentAutomatedId");
+// 		App.WaitForElement("ListViewAutomatedId");
+// 		App.Tap("CLEAR SELECTION");
+
+// 		App.WaitForElement("Cleared");
+// 	}
+// }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Bugzilla34632.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Bugzilla34632.cs
@@ -1,0 +1,47 @@
+﻿// #if !IOS && !WINDOWS // Setting orientation is not supported on Windows
+// using NUnit.Framework;
+// using UITest.Appium;
+// using UITest.Core;
+
+// namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+// public class Bugzilla34632 : _IssuesUITest
+// {
+// 	public Bugzilla34632(TestDevice testDevice) : base(testDevice)
+// 	{
+// 	}
+
+// 	public override string Issue => "Can't change IsPresented when setting SplitOnLandscape ";
+
+// 	[Test]
+// 	[Category(UITestCategories.FlyoutPage)]
+// 	public void Bugzilla34632Test()
+// 	{
+// 		if (Devices.DeviceInfo.Idiom == Devices.DeviceIdiom.Tablet)
+// 		{
+// 			App.SetOrientationPortrait();
+// 			App.Tap("btnModal");
+// 			App.SetOrientationLandscape();
+// 			App.Tap("btnDismissModal");
+// 			App.Tap("btnModal");
+// 			App.SetOrientationPortrait();
+// 			App.Tap("btnDismissModal");
+// 			App.Tap("Main Page");
+// 			App.Tap("btnFlyout");
+// 			App.WaitForNoElement("btnFlyout");
+// 		}
+// 		else
+// 		{
+// 			// Wait for the test to finish loading before exiting otherwise
+// 			// the next UI test might start running while this is still loading
+// 			App.WaitForElement("btnModal");
+// 		}
+// 	}
+
+// 	[TearDown]
+// 	public void TearDown()
+// 	{
+// 		App.SetOrientationPortrait();
+// 	}
+// }
+// #endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Bugzilla34912.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Bugzilla34912.cs
@@ -1,0 +1,27 @@
+﻿// using NUnit.Framework;
+// using UITest.Appium;
+// using UITest.Core;
+
+// namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+// public class Bugzilla34912 : _IssuesUITest
+// {
+// 	public Bugzilla34912(TestDevice testDevice) : base(testDevice)
+// 	{
+// 	}
+
+// 	public override string Issue => "Can't change IsPresented when setting SplitOnLandscape ";
+
+// 	[Test]
+// 	[Category(UITestCategories.ListView)]
+// 	[FailsOnIOS]
+// 	public void Bugzilla34912Test()
+// 	{
+// 		App.Tap("Allen");
+// 		App.WaitForElement("You tapped Allen");
+// 		App.Tap("OK");
+// 		App.Tap("btnDisable");
+// 		App.Tap("Allen");
+// 		App.WaitForNoElement("You tapped Allen");
+// 	}
+// }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Bugzilla36955.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Bugzilla36955.cs
@@ -1,0 +1,28 @@
+﻿// using NUnit.Framework;
+// using UITest.Appium;
+// using UITest.Core;
+
+// namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+// public class Bugzilla36955 : _IssuesUITest
+// {
+// 	public Bugzilla36955(TestDevice testDevice) : base(testDevice)
+// 	{
+// 	}
+
+// 	public override string Issue => "[iOS] ViewCellRenderer.UpdateIsEnabled referencing null object";
+
+// 	// TODO from Xamarin.UITest Migration, seems to be ignored already
+// 	// Also uses some specific XamUITest APIs that we need to find counterparts for
+// 	[Ignore("Test failing due to unrelated issue, disable for moment")]
+// 	[Category(UITestCategories.TableView)]
+// 	[Test]
+// 	public void Bugzilla36955Test()
+// 	{
+// 		AppResult[] buttonFalse = RunningApp.Query(q => q.Button().Text("False"));
+// 		Assert.AreEqual(buttonFalse.Length == 1, true);
+// 		RunningApp.Tap(q => q.Class("Switch"));
+// 		AppResult[] buttonTrue = RunningApp.Query(q => q.Button().Text("True"));
+// 		Assert.AreEqual(buttonTrue.Length == 1, true);
+// 	}
+// }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Bugzilla37462.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Bugzilla37462.cs
@@ -1,0 +1,38 @@
+﻿// using NUnit.Framework;
+// using UITest.Appium;
+// using UITest.Core;
+
+// namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+// public class Bugzilla37462 : _IssuesUITest
+// {
+// 	public Bugzilla37462(TestDevice testDevice) : base(testDevice)
+// 	{
+// 	}
+
+// 	public override string Issue => "Using App Compat/App Compat theme breaks Navigation.RemovePage on Android ";
+
+// 	[Test]
+// 	[Category(UITestCategories.Navigation)]
+// 	public void CanRemoveIntermediatePagesAndPopToFirstPage ()
+// 	{
+// 		// Start at page 1
+// 		App.WaitForElement ("Go To 2");
+// 		App.WaitForElement ("This is a label on page 1");
+// 		App.Tap ("Go To 2");
+
+// 		App.WaitForElement ("Go To 3");
+// 		App.Tap ("Go To 3");
+
+// 		App.WaitForElement ("Go To 4");
+// 		App.Tap ("Go To 4");
+
+// 		App.WaitForElement ("Back to 1");
+// 		App.Tap ("Back to 1");
+
+// 		// Clicking "Back to 1" should remove pages 2 and 3 from the stack
+// 		// Then call PopAsync, which should return to page 1
+// 		App.WaitForElement ("Go To 2");
+// 		App.WaitForElement ("This is a label on page 1");
+// 	}
+// }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Bugzilla37841.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Bugzilla37841.cs
@@ -1,0 +1,34 @@
+﻿// using NUnit.Framework;
+// using UITest.Appium;
+// using UITest.Core;
+
+// namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+// public class Bugzilla37841 : _IssuesUITest
+// {
+// 	public Bugzilla37841(TestDevice testDevice) : base(testDevice)
+// 	{
+// 	}
+
+// 	public override string Issue => "TableView EntryCells and TextCells cease to update after focus change";
+
+// 	[Test]
+// 	[Category(UITestCategories.TableView)]
+// 	[FailsOnIOS]
+// 	public void TextAndEntryCellsDataBindInTableView()
+// 	{
+// 		App.WaitForElement("Generate");
+// 		App.Tap("Generate");
+
+// 		App.Screenshot("First Generate Tap");
+
+// 		App.WaitForTextToBePresentInElement("entrycell", "12345");
+// 		App.WaitForTextToBePresentInElement("textcell", "6789");
+// 		App.Tap("Generate");
+
+// 		App.Screenshot("Second Generate Tap");
+
+// 		App.WaitForTextToBePresentInElement("entrycell", "112358");
+// 		App.WaitForTextToBePresentInElement("textcell", "48151623");
+// 	}
+// }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Bugzilla38112.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Bugzilla38112.cs
@@ -1,0 +1,38 @@
+﻿// using NUnit.Framework;
+// using UITest.Appium;
+// using UITest.Core;
+
+// namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+// [Category(UITestCategories.TableView)]
+// public class Bugzilla38112 : _IssuesUITest
+// {
+// 	public Bugzilla38112(TestDevice testDevice) : base(testDevice)
+// 	{
+// 	}
+
+// 	public override string Issue => "Switch becomes reenabled when previous ViewCell is removed from TableView";
+
+// 	// TODO from Xamarin.UITest migration, test fails, look into it later
+// 	[Test]
+// 	[FailsOnIOS]
+// 	public void Bugzilla38112_SwitchIsStillOnScreen ()
+// 	{
+// 		App.WaitForElement("Click");
+// 		App.Tap("Click");
+// 		App.WaitForElement("switch3");
+// 	}
+
+// 	[Test]
+// 	[FailsOnIOS]
+// 	public void Bugzilla38112_SwitchIsStillDisabled ()
+// 	{
+// 		App.WaitForElement("Click");
+// 		App.Tap("Click");
+// 		App.WaitForElement("switch3");
+// 		App.Tap("switch3");
+// 		App.WaitForNoElement("FAIL");
+// 		Assert.That(App.FindElement("resultlabel").GetText()?.Equals("FAIL",
+// 			StringComparison.OrdinalIgnoreCase), Is.False);
+// 	}
+// }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Bugzilla38731.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Bugzilla38731.cs
@@ -1,0 +1,36 @@
+﻿// #if IOS
+// using NUnit.Framework;
+// using UITest.Appium;
+// using UITest.Core;
+
+// namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+// public class Bugzilla38731 : _IssuesUITest
+// {
+// 	public Bugzilla38731(TestDevice testDevice) : base(testDevice)
+// 	{
+// 	}
+
+// 	public override string Issue => "iOS.NavigationRenderer.GetAppearedOrDisappearedTask NullReferenceExceptionObject";
+
+// 	[Test]
+// 	[Category(UITestCategories.Navigation)]
+// 	[FailsOnIOS]
+// 	public void Bugzilla38731Test ()
+// 	{
+// 		App.WaitForElement("btn1");
+// 		App.Tap("btn1");
+
+// 		App.WaitForElement("btn2");
+// 		App.Tap("btn2");
+
+// 		App.WaitForElement("btn3");
+// 		App.Tap("btn3");
+		
+// 		App.Back();
+// 		App.Back();
+// 		App.Back();
+// 		App.Back();
+// 	}
+// }
+// #endif


### PR DESCRIPTION
Third PR moving remaining tests from the control gallery into the right place for more modern test running with Appium.

Tests are moved as disabled and we will run through these again to reenable them as we go.

Related to https://github.com/dotnet/maui/pull/24153