### PR TITLE
Fix deprecated API usage for embedded fonts on iOS/Catalyst 18.0+

### DIFF
--- a/src/Core/src/Fonts/EmbeddedFontLoader.iOS.cs
+++ b/src/Core/src/Fonts/EmbeddedFontLoader.iOS.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Maui
 				var provider = GetCGDataProviderFromEmbeddedFont(font);
 				CGFont? cgFont = CGFont.CreateFromProvider(provider);
 				
-				if (cgFont == null)
+				if (cgFont is null)
 					throw new InvalidOperationException("Unable to load font from the stream.");
 
 				var name = cgFont.PostScriptName;
@@ -34,7 +34,7 @@ namespace Microsoft.Maui
 						return null;
 					var fontUrl = NSUrl.FromFilename(fontFilePath);
 					var nsError = CTFontManager.RegisterFontsForUrl(fontUrl, CTFontManagerScope.Process);
-					if (nsError != null)
+					if (nsError is not null)
 						throw new NSErrorException(nsError);
 					return name;
 				}
@@ -43,7 +43,7 @@ namespace Microsoft.Maui
 					return name;
 
 				var uiFont = UIFont.FromName(name, 10);
-				if (uiFont != null)
+				if (uiFont is not null)
 					return name;
 
 				// we know error is not null, the NotNullWhen attr is missing in the iOS bindings, ref: https://github.com/xamarin/xamarin-macios/pull/20050
@@ -57,9 +57,9 @@ namespace Microsoft.Maui
 			return null;
 		}
 
-		private static CGDataProvider GetCGDataProviderFromEmbeddedFont(EmbeddedFont font)
+		static CGDataProvider GetCGDataProviderFromEmbeddedFont(EmbeddedFont font)
 		{
-			if (font.ResourceStream == null)
+			if (font.ResourceStream is null)
 			{
 				if (!System.IO.File.Exists(font.FontName))
 					throw new InvalidOperationException("ResourceStream was null.");
@@ -69,20 +69,20 @@ namespace Microsoft.Maui
 			else
 			{
 				var data = NSData.FromStream(font.ResourceStream);
-				if (data == null)
+				if (data is null)
 					throw new InvalidOperationException("Unable to load font stream data.");
 				return new CGDataProvider(data);
 			}
 		}
 
-		private static string? SaveCGFontToFile(CGDataProvider dataProvider, string? fontName)
+		static string? SaveCGFontToFile(CGDataProvider dataProvider, string? fontName)
 		{
 			if (string.IsNullOrEmpty(fontName))
 				return null;
 
 			using (var fontData = dataProvider.CopyData())
 			{
-				if (fontData == null)
+				if (fontData is null)
 					return null;
 
 				// Gets the temporary directory path for the current application.

--- a/src/Core/src/Fonts/EmbeddedFontLoader.iOS.cs
+++ b/src/Core/src/Fonts/EmbeddedFontLoader.iOS.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System;
+using System.IO;
 using CoreGraphics;
 using CoreText;
 using Foundation;
@@ -18,29 +19,25 @@ namespace Microsoft.Maui
 		{
 			try
 			{
-				CGFont? cgFont;
-
-				if (font.ResourceStream == null)
-				{
-					if (!System.IO.File.Exists(font.FontName))
-						throw new InvalidOperationException("ResourceStream was null.");
-
-					var provider = new CGDataProvider(font.FontName);
-					cgFont = CGFont.CreateFromProvider(provider);
-				}
-				else
-				{
-					var data = NSData.FromStream(font.ResourceStream);
-					if (data == null)
-						throw new InvalidOperationException("Unable to load font stream data.");
-					var provider = new CGDataProvider(data);
-					cgFont = CGFont.CreateFromProvider(provider);
-				}
-
+				var provider = GetCGDataProviderFromEmbeddedFont(font);
+				CGFont? cgFont = CGFont.CreateFromProvider(provider);
+				
 				if (cgFont == null)
 					throw new InvalidOperationException("Unable to load font from the stream.");
 
 				var name = cgFont.PostScriptName;
+
+				if (OperatingSystem.IsIOSVersionAtLeast(18, 0) || OperatingSystem.IsMacCatalystVersionAtLeast(18, 0))
+				{
+					var fontFilePath = SaveCGFontToFile(provider, name);
+					if (string.IsNullOrEmpty(fontFilePath))
+						return null;
+					var fontUrl = NSUrl.FromFilename(fontFilePath);
+					var nsError = CTFontManager.RegisterFontsForUrl(fontUrl, CTFontManagerScope.Process);
+					if (nsError != null)
+						throw new NSErrorException(nsError);
+					return name;
+				}
 
 				if (CTFontManager.RegisterGraphicsFont(cgFont, out var error))
 					return name;
@@ -58,6 +55,45 @@ namespace Microsoft.Maui
 			}
 
 			return null;
+		}
+
+		private static CGDataProvider GetCGDataProviderFromEmbeddedFont(EmbeddedFont font)
+		{
+			if (font.ResourceStream == null)
+			{
+				if (!System.IO.File.Exists(font.FontName))
+					throw new InvalidOperationException("ResourceStream was null.");
+
+				return new CGDataProvider(font.FontName);
+			}
+			else
+			{
+				var data = NSData.FromStream(font.ResourceStream);
+				if (data == null)
+					throw new InvalidOperationException("Unable to load font stream data.");
+				return new CGDataProvider(data);
+			}
+		}
+
+		private static string? SaveCGFontToFile(CGDataProvider dataProvider, string? fontName)
+		{
+			if (string.IsNullOrEmpty(fontName))
+				return null;
+
+			using (var fontData = dataProvider.CopyData())
+			{
+				if (fontData == null)
+					return null;
+
+				var tempFolderPath = NSFileManager.DefaultManager.GetTemporaryDirectory().Path;
+				if (string.IsNullOrEmpty(tempFolderPath))
+					return null;
+
+				var fontFilePath = System.IO.Path.Combine(tempFolderPath, $"{fontName}.ttf");
+
+				System.IO.File.WriteAllBytes(fontFilePath, fontData.ToArray());
+				return fontFilePath;
+			}
 		}
 	}
 }

--- a/src/Core/src/Fonts/EmbeddedFontLoader.iOS.cs
+++ b/src/Core/src/Fonts/EmbeddedFontLoader.iOS.cs
@@ -85,6 +85,7 @@ namespace Microsoft.Maui
 				if (fontData == null)
 					return null;
 
+				// Gets the temporary directory path for the current application.
 				var tempFolderPath = NSFileManager.DefaultManager.GetTemporaryDirectory().Path;
 				if (string.IsNullOrEmpty(tempFolderPath))
 					return null;

--- a/src/Core/tests/DeviceTests/Services/FontManagerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Services/FontManagerTests.iOS.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using UIKit;
 using Xunit;
 
@@ -22,6 +23,24 @@ public partial class FontManagerTests : TestBase
 			manager.GetFont(Font.OfSize(fontName, manager.DefaultFontSize)));
 
 		Assert.Equal(expectedFamilyName, font.FamilyName);
+	}
+
+	[Fact]
+	public async Task CanLoadEmbeddedFont()
+	{
+		await InvokeOnMainThreadAsync(() =>
+		{
+			var fontName = "FooBarFont";
+			var fontWeight = FontWeight.Regular;
+
+			var registrar = new FontRegistrar(new EmbeddedFontLoader());
+			registrar.Register("dokdo_regular.ttf", fontName, GetType().Assembly);
+			var manager = new FontManager(registrar);
+			var actual = manager.GetFont(Font.OfSize(fontName, 12, fontWeight));
+
+			Assert.Equal("Dokdo", actual.FamilyName);
+			Assert.Equal("Dokdo-Regular", actual.Name);
+		});
 	}
 
 }


### PR DESCRIPTION
### Description of Change

`CTFontManager.RegisterGraphicsFont` throws a [deprecation warning](https://developer.apple.com/documentation/coretext/1499499-ctfontmanagerregistergraphicsfon) for iOS 18+. This was breaking my build.

https://github.com/xamarin/xamarin-macios/blob/main/src/CoreText/CTFontManager.cs#L445-L462

This PR attempts to change it to a supported API for these platforms, using `CTFontManager.RegisterFontsForUrl`. To do this, I believe, we need to write the font to a file on disk (in this case, in temp storage in the users application cache) and then register it.