### PR TITLE
Change HybridWebView default address to 0.0.0.1

### DIFF
--- a/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.cs
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Maui.Handlers
 		// Using an IP address means that the web view doesn't wait for any DNS resolution,
 		// making it substantially faster. Note that this isn't real HTTP traffic, since
 		// we intercept all the requests within this origin.
-		private static readonly string AppHostAddress = "0.0.0.0";
+		private static readonly string AppHostAddress = "0.0.0.1";
 
 		private static readonly string AppHostScheme =
 #if IOS || MACCATALYST
@@ -43,8 +43,8 @@ namespace Microsoft.Maui.Handlers
 #endif
 
 		/// <summary>
-		/// Gets the application's base URI. Defaults to <c>https://0.0.0.0/</c> on Windows and Android,
-		/// and <c>app://0.0.0.0/</c> on iOS and MacCatalyst (because <c>https</c> is reserved).
+		/// Gets the application's base URI. Defaults to <c>https://0.0.0.1/</c> on Windows and Android,
+		/// and <c>app://0.0.0.1/</c> on iOS and MacCatalyst (because <c>https</c> is reserved).
 		/// </summary>
 		internal static readonly string AppOrigin = $"{AppHostScheme}://{AppHostAddress}/";
 


### PR DESCRIPTION
The 0.0.0.0 address stopped working in iOS 18/MacCat, and is possibly going to stop working in other platforms/webviews, so it's being changed to 0.0.0.1, which has been verified to work.

Fixes #24364
