### PR TITLE
[Windows] Fixed TextCell Command executes only once

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/Windows/CellControl.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/Windows/CellControl.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			// 🚀 unsubscribe from propertychanged
 			Cell.PropertyChanged -= _propertyChangedHandler;
 			// Allows the Cell to unsubscribe from Parent.PropertyChanged
-			if(Cell.Parent is ListView)
+			if (Cell.Parent is ListView)
 				Cell.Parent = null;
 		}
 

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/Windows/CellControl.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/Windows/CellControl.cs
@@ -70,7 +70,8 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			// 🚀 unsubscribe from propertychanged
 			Cell.PropertyChanged -= _propertyChangedHandler;
 			// Allows the Cell to unsubscribe from Parent.PropertyChanged
-			Cell.Parent = null;
+			if(Cell.Parent is ListView)
+				Cell.Parent = null;
 		}
 
 

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue21112.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue21112.cs
@@ -70,6 +70,12 @@ namespace Maui.Controls.Sample.Issues
 				Text = "Click"
 			};
 
+			var label = new Label
+			{
+				AutomationId = "NavigatedPageLabel",
+				Text = "Navigated Page"
+			};
+
 			button.Clicked += (sender, e) =>
 			{
 				Navigation.PopAsync();
@@ -79,7 +85,8 @@ namespace Maui.Controls.Sample.Issues
 			{
 				Children =
 				{
-					button
+					button,
+					label
 				}
 			};
 		}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue21112.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue21112.cs
@@ -73,7 +73,7 @@ namespace Maui.Controls.Sample.Issues
 			var label = new Label
 			{
 				AutomationId = "NavigatedPageLabel",
-				Text = "Navigated Page"
+				Text = "Main Page"
 			};
 
 			button.Clicked += (sender, e) =>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue21112.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue21112.cs
@@ -17,7 +17,7 @@ namespace Maui.Controls.Sample.Issues
 		public MainPage()
 		{
 			var stackLayout = new StackLayout();
-			BindingContext = new MainViewModel();
+			BindingContext = new Issue21112ViewModel();
 
 			var headerTextCell = new TextCell
 			{
@@ -92,11 +92,11 @@ namespace Maui.Controls.Sample.Issues
 		}
 	}
 
-	public class MainViewModel
+	public class Issue21112ViewModel
 	{
 		public ICommand NavigateCommand { get; set; }
 
-		public MainViewModel()
+		public Issue21112ViewModel()
 		{
 			NavigateCommand = new Command<Type>(async (Type pageType) =>
 			{

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue21112.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue21112.cs
@@ -1,10 +1,10 @@
-﻿namespace Controls.TestCases.HostApp.Issues
+﻿namespace Maui.Controls.Sample.Issues
 {
 	[XamlCompilation(XamlCompilationOptions.Compile)]
 	[Issue(IssueTracker.Github, 21112, "TableView TextCell command executes only once", PlatformAffected.UWP)]
-	public class Issue21112 : ContentPage
+	public class Issue21112 : TestContentPage
 	{
-		public Issue21112()
+		protected override void Init()
 		{
 			Title = "AbsoluteLayout demos";
 

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue21112.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue21112.cs
@@ -48,7 +48,7 @@ namespace Maui.Controls.Sample.Issues
 
 			button.Clicked += (sender, e) =>
 			{
-				headerTextCell.Command?.Execute(headerTextCell.CommandParameter);
+				headerTextCell.Command.Execute(headerTextCell.CommandParameter);
 			};
 
 			stackLayout.Children.Add(tableView);

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue21112.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue21112.cs
@@ -1,0 +1,69 @@
+﻿namespace Controls.TestCases.HostApp.Issues
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	[Issue(IssueTracker.Github, 21112, "TableView TextCell command executes only once", PlatformAffected.UWP)]
+	public class Issue21112 : ContentPage
+	{
+		public Issue21112()
+		{
+			Title = "AbsoluteLayout demos";
+
+			var tableView = new TableView
+			{
+				Intent = TableIntent.Menu,
+				Root = new TableRoot
+				{
+					new TableSection("XAML")
+					{
+						new TextCell
+						{
+							Text = "Stylish header demo",
+							AutomationId = "TextCell",
+							Detail = "Absolute positioning and sizing",
+							Command = new Command<Type>(async (pageType) =>
+							{
+								var page = (Page)Activator.CreateInstance(pageType);
+								await Navigation.PushAsync(page);
+							}),
+							CommandParameter = typeof(StylishHeaderDemoPage)
+						}
+					}
+				}
+			};
+
+			Content = tableView;
+		}
+	}
+
+	public class StylishHeaderDemoPage : ContentPage
+	{
+		public StylishHeaderDemoPage()
+		{
+			Title = "Stylish header demo";
+
+			var stackLayout = new StackLayout
+			{
+				Margin = new Thickness(20)
+			};
+
+			var button = new Button
+			{
+				WidthRequest = 150,
+				AutomationId = "Button",
+				Text = "click"
+			};
+
+			button.Clicked += Button_Clicked;
+
+			stackLayout.Children.Add(button);
+
+			Content = stackLayout;
+		}
+
+		private async void Button_Clicked(object sender, EventArgs e)
+		{
+			await Navigation.PopAsync();
+		}
+
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue21112.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue21112.cs
@@ -5,8 +5,8 @@ using UITest.Core;
 
 namespace Microsoft.Maui.TestCases.Tests.Issues
 {
-    public class Issue21112 : _IssuesUITest
-    {
+	public class Issue21112 : _IssuesUITest
+	{
 		public Issue21112(TestDevice testDevice) : base(testDevice)
 		{
 		}
@@ -16,13 +16,13 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		[Category(UITestCategories.TableView)]
 		public void TableViewTextCellCommand()
 		{
-			App.WaitForElement("TextCell");
-			App.Tap("TextCell");
-			App.WaitForElement("Button");
-			App.Tap("Button");
-			App.WaitForElement("TextCell");
-			App.Tap("TextCell");
-			App.WaitForElement("Button");
+			App.WaitForElement("MainPageButton");
+			App.Tap("MainPageButton");
+			App.WaitForElement("NavigatedPageButton");
+			App.Tap("NavigatedPageButton");
+			App.WaitForElement("MainPageButton");
+			App.Tap("MainPageButton");
+			App.WaitForElement("NavigatedPageButton");
 		}
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue21112.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue21112.cs
@@ -1,5 +1,4 @@
 ﻿using NUnit.Framework;
-using NUnit.Framework.Legacy;
 using UITest.Appium;
 using UITest.Core;
 
@@ -22,9 +21,8 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 			App.Tap("NavigatedPageButton");
 			App.WaitForElement("MainPageButton");
 			App.Tap("MainPageButton");
-			App.WaitForElement("NavigatedPageLabel");
-			ClassicAssert.AreEqual("Navigated Page", App.FindElement("NavigatedPageLabel").GetText());
-
+			var label = App.WaitForElement("NavigatedPageLabel");
+			Assert.That(label.GetText(), Is.EqualTo("Main Page"));
 		}
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue21112.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue21112.cs
@@ -18,9 +18,11 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		{
 			App.WaitForElement("TextCell");
 			App.Tap("TextCell");
+			App.WaitForElement("Button");
 			App.Tap("Button");
+			App.WaitForElement("TextCell");
 			App.Tap("TextCell");
-			VerifyScreenshot();
+			App.WaitForElement("Button");
 		}
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue21112.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue21112.cs
@@ -1,5 +1,5 @@
-﻿#if !MACCATALYST
-using NUnit.Framework;
+﻿using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using UITest.Appium;
 using UITest.Core;
 
@@ -22,7 +22,9 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 			App.Tap("NavigatedPageButton");
 			App.WaitForElement("MainPageButton");
 			App.Tap("MainPageButton");
+			App.WaitForElement("NavigatedPageLabel");
+			ClassicAssert.AreEqual("Navigated Page", App.FindElement("NavigatedPageLabel").GetText());
+
 		}
 	}
 }
-#endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue21112.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue21112.cs
@@ -1,0 +1,27 @@
+﻿#if !MACCATALYST
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+    public class Issue21112 : _IssuesUITest
+    {
+		public Issue21112(TestDevice testDevice) : base(testDevice)
+		{
+		}
+		public override string Issue => "TableView TextCell command executes only once";
+
+		[Test]
+		[Category(UITestCategories.TableView)]
+		public void TableViewTextCellCommand()
+		{
+			App.WaitForElement("TextCell");
+			App.Tap("TextCell");
+			App.Tap("Button");
+			App.Tap("TextCell");
+			VerifyScreenshot();
+		}
+	}
+}
+#endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue21112.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue21112.cs
@@ -22,7 +22,6 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 			App.Tap("NavigatedPageButton");
 			App.WaitForElement("MainPageButton");
 			App.Tap("MainPageButton");
-			App.WaitForElement("NavigatedPageButton");
 		}
 	}
 }


### PR DESCRIPTION
### Root Cause
While fixing a memory leak in ListView, the Cell's parent was set to null in the Unloaded event. This caused the TextCell's parent to be set to null during initial navigation, preventing commands from executing afterward.

### Description of Change
The fix ensures that the parent is set to null only when the parent control is a ListView. This preserves the memory leak fix while also resolving the issue with command execution in TextCell.

### Tested the behaviour in the following platforms
 
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

### Issues Fixed
 
Fixes https://github.com/dotnet/maui/issues/21112

### Screenshots

| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video width="270" height="600"  src="https://github.com/user-attachments/assets/85b27388-50e9-4716-9bfc-52ca4e598527"> | <video width="300" height="600"  src="https://github.com/user-attachments/assets/a0284a84-fa04-43cc-acd8-d683f58d3362">) |
