### PR TITLE
[blazorwebview] align `SupportedOSPlatform` attribute with templates

### DIFF
--- a/src/BlazorWebView/src/Maui/BlazorWebView.cs
+++ b/src/BlazorWebView/src/Maui/BlazorWebView.cs
@@ -18,11 +18,13 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 #endif
 	public partial class BlazorWebView : View, IBlazorWebView
 	{
-		// NOTE: keep these in sync with:
+		// NOTE: keep these in *reasonably* in sync with:
+		// * src\BlazorWebView\src\Maui\Microsoft.AspNetCore.Components.WebView.Maui.csproj
 		// * src\Templates\src\templates\maui-blazor\MauiApp.1.csproj
 		// * src\Templates\src\templates\maui-blazor-solution\MauiApp.1\MauiApp.1.csproj
+		// * https://learn.microsoft.com/dotnet/maui/supported-platforms
 		internal const string AndroidSupportedOSPlatformVersion = "android24.0";
-		internal const string iOSSupportedOSPlatformVersion = "ios15.0";
+		internal const string iOSSupportedOSPlatformVersion = "ios14.0";
 
 		internal static string AppHostAddress { get; } = HostAddressHelper.GetAppHostAddress();
 

--- a/src/BlazorWebView/src/Maui/BlazorWebView.cs
+++ b/src/BlazorWebView/src/Maui/BlazorWebView.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using System.Runtime.Versioning;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Maui;
@@ -10,8 +11,19 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 	/// <summary>
 	/// A <see cref="View"/> that can render Blazor content.
 	/// </summary>
+#if ANDROID
+	[SupportedOSPlatform(AndroidSupportedOSPlatformVersion)]
+#elif IOS
+	[SupportedOSPlatform(iOSSupportedOSPlatformVersion)]
+#endif
 	public partial class BlazorWebView : View, IBlazorWebView
 	{
+		// NOTE: keep these in sync with:
+		// * src\Templates\src\templates\maui-blazor\MauiApp.1.csproj
+		// * src\Templates\src\templates\maui-blazor-solution\MauiApp.1\MauiApp.1.csproj
+		internal const string AndroidSupportedOSPlatformVersion = "android24.0";
+		internal const string iOSSupportedOSPlatformVersion = "ios15.0";
+
 		internal static string AppHostAddress { get; } = HostAddressHelper.GetAppHostAddress();
 
 		private readonly JSComponentConfigurationStore _jSComponents = new();

--- a/src/BlazorWebView/src/Maui/BlazorWebView.cs
+++ b/src/BlazorWebView/src/Maui/BlazorWebView.cs
@@ -15,6 +15,8 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 	[SupportedOSPlatform(AndroidSupportedOSPlatformVersion)]
 #elif IOS
 	[SupportedOSPlatform(iOSSupportedOSPlatformVersion)]
+#elif MACCATALYST
+	[SupportedOSPlatform(MacCatalystSupportedOSPlatformVersion)]
 #endif
 	public partial class BlazorWebView : View, IBlazorWebView
 	{
@@ -24,7 +26,8 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		// * src\Templates\src\templates\maui-blazor-solution\MauiApp.1\MauiApp.1.csproj
 		// * https://learn.microsoft.com/dotnet/maui/supported-platforms
 		internal const string AndroidSupportedOSPlatformVersion = "android24.0";
-		internal const string iOSSupportedOSPlatformVersion = "ios14.0";
+		internal const string iOSSupportedOSPlatformVersion = "ios15.0";
+		internal const string MacCatalystSupportedOSPlatformVersion = "maccatalyst15.0";
 
 		internal static string AppHostAddress { get; } = HostAddressHelper.GetAppHostAddress();
 
@@ -94,9 +97,11 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 
 		/// <inheritdoc />
 #if ANDROID
-		[System.Runtime.Versioning.SupportedOSPlatform("android23.0")]
+		[System.Runtime.Versioning.SupportedOSPlatform(AndroidSupportedOSPlatformVersion)]
 #elif IOS
-		[System.Runtime.Versioning.SupportedOSPlatform("ios11.0")]
+		[System.Runtime.Versioning.SupportedOSPlatform(iOSSupportedOSPlatformVersion)]
+#elif MACCATALYST
+		[System.Runtime.Versioning.SupportedOSPlatform(MacCatalystSupportedOSPlatformVersion)]
 #endif
 		public virtual IFileProvider CreateFileProvider(string contentRootDir)
 		{
@@ -111,7 +116,11 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		/// <returns>Returns a <see cref="Task"/> representing <c>true</c> if the <paramref name="workItem"/> was called, or <c>false</c> if it was not called because Blazor is not currently running.</returns>
 		/// <exception cref="ArgumentNullException">Thrown if <paramref name="workItem"/> is <c>null</c>.</exception>
 #if ANDROID
-		[System.Runtime.Versioning.SupportedOSPlatform("android23.0")]
+		[System.Runtime.Versioning.SupportedOSPlatform(AndroidSupportedOSPlatformVersion)]
+#elif IOS
+		[System.Runtime.Versioning.SupportedOSPlatform(iOSSupportedOSPlatformVersion)]
+#elif MACCATALYST
+		[System.Runtime.Versioning.SupportedOSPlatform(MacCatalystSupportedOSPlatformVersion)]
 #endif
 		public virtual async Task<bool> TryDispatchAsync(Action<IServiceProvider> workItem)
 		{

--- a/src/BlazorWebView/src/Maui/BlazorWebViewHandler.cs
+++ b/src/BlazorWebView/src/Maui/BlazorWebViewHandler.cs
@@ -9,7 +9,9 @@ using Microsoft.Maui.Handlers;
 namespace Microsoft.AspNetCore.Components.WebView.Maui
 {
 #if ANDROID
-	[SupportedOSPlatform("android23.0")]
+	[SupportedOSPlatform(BlazorWebView.AndroidSupportedOSPlatformVersion)]
+#elif IOS
+	[SupportedOSPlatform(BlazorWebView.iOSSupportedOSPlatformVersion)]
 #endif
 	public partial class BlazorWebViewHandler
 	{

--- a/src/BlazorWebView/src/Maui/BlazorWebViewHandler.cs
+++ b/src/BlazorWebView/src/Maui/BlazorWebViewHandler.cs
@@ -12,6 +12,8 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 	[SupportedOSPlatform(BlazorWebView.AndroidSupportedOSPlatformVersion)]
 #elif IOS
 	[SupportedOSPlatform(BlazorWebView.iOSSupportedOSPlatformVersion)]
+#elif MACCATALYST
+	[SupportedOSPlatform(BlazorWebView.MacCatalystSupportedOSPlatformVersion)]
 #endif
 	public partial class BlazorWebViewHandler
 	{

--- a/src/BlazorWebView/src/Maui/Microsoft.AspNetCore.Components.WebView.Maui.csproj
+++ b/src/BlazorWebView/src/Maui/Microsoft.AspNetCore.Components.WebView.Maui.csproj
@@ -23,6 +23,9 @@
     <PackageTags>$(DefaultPackageTags);blazor;webview;aspnet</PackageTags>
     <PackageIconFullPath>$(MauiRootDirectory)Assets\aspnet-icon.png</PackageIconFullPath>
     <Description>Build .NET Multi-platform App UI (.NET MAUI) apps with Blazor web UI in the BlazorWebView control.</Description>
+    <!-- NOTE: keep in sync with BlazorWebView.cs -->
+    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">14.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">24.0</SupportedOSPlatformVersion>
   </PropertyGroup>
 
   <Import Project="$(MauiSrcDirectory)MultiTargeting.targets" />

--- a/src/BlazorWebView/src/Maui/Microsoft.AspNetCore.Components.WebView.Maui.csproj
+++ b/src/BlazorWebView/src/Maui/Microsoft.AspNetCore.Components.WebView.Maui.csproj
@@ -24,7 +24,8 @@
     <PackageIconFullPath>$(MauiRootDirectory)Assets\aspnet-icon.png</PackageIconFullPath>
     <Description>Build .NET Multi-platform App UI (.NET MAUI) apps with Blazor web UI in the BlazorWebView control.</Description>
     <!-- NOTE: keep in sync with BlazorWebView.cs -->
-    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">14.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">15.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">15.0</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">24.0</SupportedOSPlatformVersion>
   </PropertyGroup>
 

--- a/src/BlazorWebView/src/SharedSource/BlazorWebViewServiceCollectionExtensions.cs
+++ b/src/BlazorWebView/src/SharedSource/BlazorWebViewServiceCollectionExtensions.cs
@@ -30,9 +30,9 @@ namespace Microsoft.Extensions.DependencyInjection
 		public static IWpfBlazorWebViewBuilder AddWpfBlazorWebView(this IServiceCollection services)
 #elif WEBVIEW2_MAUI
 #if ANDROID
-	    [System.Runtime.Versioning.SupportedOSPlatform("android23.0")]
+	    [System.Runtime.Versioning.SupportedOSPlatform(BlazorWebView.AndroidSupportedOSPlatformVersion)]
 #elif IOS
-		[System.Runtime.Versioning.SupportedOSPlatform("ios11.0")]
+		[System.Runtime.Versioning.SupportedOSPlatform(BlazorWebView.iOSSupportedOSPlatformVersion)]
 #endif
 		public static IMauiBlazorWebViewBuilder AddMauiBlazorWebView(this IServiceCollection services)
 #else

--- a/src/BlazorWebView/src/SharedSource/BlazorWebViewServiceCollectionExtensions.cs
+++ b/src/BlazorWebView/src/SharedSource/BlazorWebViewServiceCollectionExtensions.cs
@@ -33,6 +33,8 @@ namespace Microsoft.Extensions.DependencyInjection
 	    [System.Runtime.Versioning.SupportedOSPlatform(BlazorWebView.AndroidSupportedOSPlatformVersion)]
 #elif IOS
 		[System.Runtime.Versioning.SupportedOSPlatform(BlazorWebView.iOSSupportedOSPlatformVersion)]
+#elif MACCATALYST
+		[System.Runtime.Versioning.SupportedOSPlatform(BlazorWebView.MacCatalystSupportedOSPlatformVersion)]
 #endif
 		public static IMauiBlazorWebViewBuilder AddMauiBlazorWebView(this IServiceCollection services)
 #else


### PR DESCRIPTION
Context: https://learn.microsoft.com/dotnet/maui/supported-platforms

To get the appropriate warnings from Roslyn analyzers, we should align the `SupportedOSPlatform` attribute for public-facing `BlazorWebView` APIs for iOS and Android:

* `BlazorWebView` class

* `BlazorWebViewHandler` class

* `BlazorWebViewServiceCollectionExtensions.AddMauiBlazorWebView()` which is used in `MauiProgram.cs` to register `BlazorWebView`.

I used the same numbers set in:

* `src\Templates\src\templates\maui-blazor\MauiApp.1.csproj`

* `src\Templates\src\templates\maui-blazor-solution\MauiApp.1\MauiApp.1.csproj`