### PR TITLE
Disable Warnings for RegisterGraphicsFont

### DIFF
--- a/src/Core/src/Fonts/EmbeddedFontLoader.iOS.cs
+++ b/src/Core/src/Fonts/EmbeddedFontLoader.iOS.cs
@@ -42,8 +42,12 @@ namespace Microsoft.Maui
 
 				var name = cgFont.PostScriptName;
 
+#pragma warning disable CA1416  // TODO:  'RegisterGraphicsFont' is obsolete on: 'ios' 15.0 and later
+#pragma warning disable CA1422
 				if (CTFontManager.RegisterGraphicsFont(cgFont, out var error))
 					return name;
+#pragma warning restore CA1422 
+#pragma warning restore CA1416
 
 				var uiFont = UIFont.FromName(name, 10);
 				if (uiFont != null)


### PR DESCRIPTION
### Description of Change

We have a PR to update this code to use the latest APIs [here](https://github.com/dotnet/maui/pull/25055) but it's currently not passing our device tests. For now, we're going to suppress these warnings so that folks who have updated to XCode 16 are able to compile our main branch locally. 

We are already suppressing these warnings on the net9.0 branch so we aren't really adding anything extra here