### PR TITLE
Add properties for device tests to configure release/debug 

### DIFF
--- a/eng/pipelines/common/device-tests-steps.yml
+++ b/eng/pipelines/common/device-tests-steps.yml
@@ -4,7 +4,7 @@ parameters:
   device: '' # the xharness device to use
   apiversion: '' # the iOS device api version to use
   cakeArgs: '' # additional cake args
-  androidConfiguration: '' # Indicates the configuration to use for Android. We're slowly enabling this for all projects
+  deviceTestConfiguration: '' # Indicates the configuration to use for Android. We're slowly enabling this for all projects
   provisionatorChannel: 'latest'
   agentPoolAccessToken: ''
   artifactName: 'nuget'
@@ -95,41 +95,18 @@ steps:
       continueOnError: true
       timeoutInMinutes: 5
 
-  # Everything should be release but doing android for now to work around an xharness issue
-  - ${{ if eq(parameters.platform, 'android')}}:
-    - pwsh: |
-        ./build.ps1 -Script eng/devices/${{ parameters.platform }}.cake --project="${{ parameters.path }}" --device=${{ parameters.device }} --apiversion=${{ parameters.apiversion }} --packageid=${{ parameters.windowsPackageId }} --results="$(TestResultsDirectory)" --binlog="$(LogDirectory)" ${{ parameters.cakeArgs }} --configuration=${{ parameters.androidConfiguration }}
-      displayName: $(Agent.JobName)
-      workingDirectory: ${{ parameters.checkoutDirectory }}
-      condition: and(succeeded(), ne(variables['Platform.Name'], 'Mac'))
-      retryCountOnTaskFailure: 1
+  - pwsh: |
+      ./build.ps1 -Script eng/devices/${{ parameters.platform }}.cake --project="${{ parameters.path }}" --device=${{ parameters.device }} --apiversion=${{ parameters.apiversion }} --packageid=${{ parameters.windowsPackageId }} --results="$(TestResultsDirectory)" --binlog="$(LogDirectory)" ${{ parameters.cakeArgs }} --configuration=${{ parameters.deviceTestConfiguration }}
+    displayName: $(Agent.JobName)
+    workingDirectory: ${{ parameters.checkoutDirectory }}
+    condition: and(succeeded(), ne(variables['Platform.Name'], 'Mac'))
 
-  - ${{ if eq(parameters.platform, 'android')}}:
-    - bash: |
-        # Execute the powershell script from a bash shell on Mac to avoid interference between powershell processes that lead to this error: The STDIO streams did not close within 10 seconds of the exit event from process '/usr/local/bin/pwsh'. This may indicate a child process inherited the STDIO streams and has not yet exited.
-        pwsh ./build.ps1 -Script eng/devices/${{ parameters.platform }}.cake --project="${{ parameters.path }}" --device=${{ parameters.device }} --apiversion=${{ parameters.apiversion }} --packageid=${{ parameters.windowsPackageId }} --results="$(TestResultsDirectory)" --binlog="$(LogDirectory)" ${{ parameters.cakeArgs }} --configuration=${{ parameters.androidConfiguration }}
-      displayName: $(Agent.JobName)
-      workingDirectory: ${{ parameters.checkoutDirectory }}
-      condition: and(succeeded(), eq(variables['Platform.Name'], 'Mac'))
-      retryCountOnTaskFailure: 1
-
-  - ${{ if ne(parameters.platform, 'android')}}:
-    - pwsh: |
-        ./build.ps1 -Script eng/devices/${{ parameters.platform }}.cake --project="${{ parameters.path }}" --device=${{ parameters.device }} --apiversion=${{ parameters.apiversion }} --packageid=${{ parameters.windowsPackageId }} --results="$(TestResultsDirectory)" --binlog="$(LogDirectory)" ${{ parameters.cakeArgs }}
-      displayName: $(Agent.JobName)
-      workingDirectory: ${{ parameters.checkoutDirectory }}
-      condition: and(succeeded(), ne(variables['Platform.Name'], 'Mac'))
-      retryCountOnTaskFailure: 1
-
-  - ${{ if ne(parameters.platform, 'android')}}:
-    - bash: |
-        # Execute the powershell script from a bash shell on Mac to avoid interference between powershell processes that lead to this error: The STDIO streams did not close within 10 seconds of the exit event from process '/usr/local/bin/pwsh'. This may indicate a child process inherited the STDIO streams and has not yet exited.
-        pwsh ./build.ps1 -Script eng/devices/${{ parameters.platform }}.cake --project="${{ parameters.path }}" --device=${{ parameters.device }} --apiversion=${{ parameters.apiversion }} --packageid=${{ parameters.windowsPackageId }} --results="$(TestResultsDirectory)" --binlog="$(LogDirectory)" ${{ parameters.cakeArgs }}
-      displayName: $(Agent.JobName)
-      workingDirectory: ${{ parameters.checkoutDirectory }}
-      condition: and(succeeded(), eq(variables['Platform.Name'], 'Mac'))
-      retryCountOnTaskFailure: 1
-  # Everything should be release but doing android for now to work around an xharness issue
+  - bash: |
+      # Execute the powershell script from a bash shell on Mac to avoid interference between powershell processes that lead to this error: The STDIO streams did not close within 10 seconds of the exit event from process '/usr/local/bin/pwsh'. This may indicate a child process inherited the STDIO streams and has not yet exited.
+      pwsh ./build.ps1 -Script eng/devices/${{ parameters.platform }}.cake --project="${{ parameters.path }}" --device=${{ parameters.device }} --apiversion=${{ parameters.apiversion }} --packageid=${{ parameters.windowsPackageId }} --results="$(TestResultsDirectory)" --binlog="$(LogDirectory)" ${{ parameters.cakeArgs }} --configuration=${{ parameters.deviceTestConfiguration }}
+    displayName: $(Agent.JobName)
+    workingDirectory: ${{ parameters.checkoutDirectory }}
+    condition: and(succeeded(), eq(variables['Platform.Name'], 'Mac'))
 
   - ${{ if eq(parameters.platform, 'ios')}}:
     - bash: |

--- a/eng/pipelines/common/device-tests-steps.yml
+++ b/eng/pipelines/common/device-tests-steps.yml
@@ -99,7 +99,8 @@ steps:
       ./build.ps1 -Script eng/devices/${{ parameters.platform }}.cake --project="${{ parameters.path }}" --device=${{ parameters.device }} --apiversion=${{ parameters.apiversion }} --packageid=${{ parameters.windowsPackageId }} --results="$(TestResultsDirectory)" --binlog="$(LogDirectory)" ${{ parameters.cakeArgs }} --configuration=${{ parameters.deviceTestConfiguration }}
     displayName: $(Agent.JobName)
     workingDirectory: ${{ parameters.checkoutDirectory }}
-    condition: and(succeeded(), ne(variables['Platform.Name'], 'Mac'))
+    condition: and(succeeded(), ne(variables['Platform.Name'], 'Mac'))      
+    retryCountOnTaskFailure: 1
 
   - bash: |
       # Execute the powershell script from a bash shell on Mac to avoid interference between powershell processes that lead to this error: The STDIO streams did not close within 10 seconds of the exit event from process '/usr/local/bin/pwsh'. This may indicate a child process inherited the STDIO streams and has not yet exited.
@@ -107,6 +108,7 @@ steps:
     displayName: $(Agent.JobName)
     workingDirectory: ${{ parameters.checkoutDirectory }}
     condition: and(succeeded(), eq(variables['Platform.Name'], 'Mac'))
+    retryCountOnTaskFailure: 1
 
   - ${{ if eq(parameters.platform, 'ios')}}:
     - bash: |

--- a/eng/pipelines/common/device-tests.yml
+++ b/eng/pipelines/common/device-tests.yml
@@ -73,7 +73,7 @@ stages:
             checkoutDirectory: ${{ parameters.checkoutDirectory }}
             useArtifacts: ${{ parameters.useArtifacts }}
             poolName: ${{ parameters.androidPool.name }}
-            androidConfiguration: $(ANDROID_CONFIGURATION)
+            deviceTestConfiguration: $(ANDROID_CONFIGURATION)
             skipProvisioning: ${{ parameters.skipProvisioning }}
 
   - stage: ios_device_tests_${{ replace(parameters.targetFrameworkVersion.tfm, '.', '') }}
@@ -100,6 +100,7 @@ stages:
                   ${{ replace(coalesce(project.desc, project.name), ' ', '_') }}_V_${{ version }}:
                     REQUIRED_XCODE: $(DEVICETESTS_REQUIRED_XCODE)
                     PROJECT_PATH: ${{ project.ios }}
+                    IOS_CONFIGURATION: ${{ project.iOSConfiguration }}
                     TARGET_FRAMEWORK_VERSION: ${{ parameters.targetFrameworkVersion.tfm }}
                     ${{ if contains(version, 'device') }}:
                       DEVICE: ios-device
@@ -123,6 +124,7 @@ stages:
             useArtifacts: ${{ parameters.useArtifacts }}
             poolName: 'Azure Pipelines'
             skipProvisioning: ${{ parameters.skipProvisioning }}
+            deviceTestConfiguration: $(IOS_CONFIGURATION)
 
   - stage: catalyst_device_tests_${{ replace(parameters.targetFrameworkVersion.tfm, '.', '') }}
     displayName: ${{ parameters.targetFrameworkVersion.tfm }} macOS Device Tests
@@ -148,6 +150,7 @@ stages:
                   ${{ replace(coalesce(project.desc, project.name), ' ', '_') }}_V_${{ version }}:
                     REQUIRED_XCODE: $(DEVICETESTS_REQUIRED_XCODE)
                     PROJECT_PATH: ${{ project.catalyst }}
+                    IOS_CONFIGURATION: ${{ project.iOSConfiguration }}
                     TARGET_FRAMEWORK_VERSION: ${{ parameters.targetFrameworkVersion.tfm }}
                     ${{ if eq(version, 'latest') }}:
                       DEVICE: maccatalyst
@@ -169,6 +172,7 @@ stages:
             useArtifacts: ${{ parameters.useArtifacts }}
             poolName: 'Azure Pipelines'
             skipProvisioning: ${{ parameters.skipProvisioning }}
+            deviceTestConfiguration: $(IOS_CONFIGURATION)
 
 
   - stage: windows_device_tests_${{ replace(parameters.targetFrameworkVersion.tfm, '.', '') }}
@@ -196,6 +200,7 @@ stages:
                   PACKAGE_ID: ${{ project.windowsPackageId }}
                   DEVICE: ${{ version }}
                   TARGET_FRAMEWORK_VERSION: ${{ parameters.targetFrameworkVersion.tfm }}
+                  WINDOWS_CONFIGURATION: ${{ project.windowsConfiguration }}
       steps:
         - template: device-tests-steps.yml
           parameters:
@@ -211,3 +216,4 @@ stages:
             checkoutDirectory: ${{ parameters.checkoutDirectory }}
             useArtifacts: ${{ parameters.useArtifacts }}
             skipProvisioning: ${{ parameters.skipProvisioning }}
+            deviceTestConfiguration: $(WINDOWS_CONFIGURATION)

--- a/eng/pipelines/device-tests.yml
+++ b/eng/pipelines/device-tests.yml
@@ -140,6 +140,8 @@ stages:
           desc: Essentials
           androidApiLevelsExclude: [25] # Ignore for now API25 since the runs's are not stable
           androidConfiguration: 'Release'
+          iOSConfiguration: 'Debug'
+          windowsConfiguration: 'Debug'
           windowsPackageId: 'com.microsoft.maui.essentials.devicetests'
           android: $(System.DefaultWorkingDirectory)/src/Essentials/test/DeviceTests/Essentials.DeviceTests.csproj
           ios: $(System.DefaultWorkingDirectory)/src/Essentials/test/DeviceTests/Essentials.DeviceTests.csproj
@@ -149,6 +151,8 @@ stages:
           desc: Graphics
           androidApiLevelsExclude: [25] # Ignore for now API25 since the runs's are not stable
           androidConfiguration: 'Release'
+          iOSConfiguration: 'Debug'
+          windowsConfiguration: 'Debug'
           windowsPackageId: 'com.microsoft.maui.graphics.devicetests'
           android: $(System.DefaultWorkingDirectory)/src/Graphics/tests/DeviceTests/Graphics.DeviceTests.csproj
           ios: $(System.DefaultWorkingDirectory)/src/Graphics/tests/DeviceTests/Graphics.DeviceTests.csproj
@@ -158,6 +162,8 @@ stages:
           desc: Core
           androidApiLevelsExclude: [25] # Ignore for now API25 since the runs's are not stable
           androidConfiguration: 'Release'
+          iOSConfiguration: 'Debug'
+          windowsConfiguration: 'Debug'
           windowsPackageId: 'com.microsoft.maui.core.devicetests'
           android: $(System.DefaultWorkingDirectory)/src/Core/tests/DeviceTests/Core.DeviceTests.csproj
           ios: $(System.DefaultWorkingDirectory)/src/Core/tests/DeviceTests/Core.DeviceTests.csproj
@@ -167,6 +173,8 @@ stages:
           desc: Controls
           androidApiLevelsExclude: [27, 25] # Ignore for now API25 since the runs's are not stable
           androidConfiguration: 'Debug'
+          iOSConfiguration: 'Release'
+          windowsConfiguration: 'Debug'
           windowsPackageId: 'com.microsoft.maui.controls.devicetests'
           android: $(System.DefaultWorkingDirectory)/src/Controls/tests/DeviceTests/Controls.DeviceTests.csproj
           ios: $(System.DefaultWorkingDirectory)/src/Controls/tests/DeviceTests/Controls.DeviceTests.csproj
@@ -176,6 +184,8 @@ stages:
           desc: BlazorWebView
           androidApiLevelsExclude: [ 30, 29, 28, 27, 26, 25, 24, 23, 22, 21 ] # BlazorWebView requires a recent version of Chrome
           androidConfiguration: 'Release'
+          iOSConfiguration: 'Debug'
+          windowsConfiguration: 'Debug'
           windowsPackageId: 'Microsoft.Maui.MauiBlazorWebView.DeviceTests'
           android: $(System.DefaultWorkingDirectory)/src/BlazorWebView/tests/MauiDeviceTests/MauiBlazorWebView.DeviceTests.csproj
           ios: $(System.DefaultWorkingDirectory)/src/BlazorWebView/tests/MauiDeviceTests/MauiBlazorWebView.DeviceTests.csproj

--- a/eng/pipelines/device-tests.yml
+++ b/eng/pipelines/device-tests.yml
@@ -173,7 +173,7 @@ stages:
           desc: Controls
           androidApiLevelsExclude: [27, 25] # Ignore for now API25 since the runs's are not stable
           androidConfiguration: 'Debug'
-          iOSConfiguration: 'Release'
+          iOSConfiguration: 'Debug'
           windowsConfiguration: 'Debug'
           windowsPackageId: 'com.microsoft.maui.controls.devicetests'
           android: $(System.DefaultWorkingDirectory)/src/Controls/tests/DeviceTests/Controls.DeviceTests.csproj


### PR DESCRIPTION
### Description of Change

This adds parameters to all our device test lanes so we can configure whether they run as release/debug

I'm not currently changing any of them, we can do that in follow up PRs
