### PR TITLE
[Android] Input transparent for a content page

### DIFF
--- a/src/Controls/src/Core/ContentPage/ContentPage.Mapper.cs
+++ b/src/Controls/src/Core/ContentPage/ContentPage.Mapper.cs
@@ -12,7 +12,9 @@ namespace Microsoft.Maui.Controls
 		internal new static void RemapForControls()
 		{
 			PageHandler.Mapper.ReplaceMapping<ContentPage, IPageHandler>(nameof(ContentPage.HideSoftInputOnTapped), MapHideSoftInputOnTapped);
-#if IOS
+#if ANDROID
+			PageHandler.Mapper.ReplaceMapping<ContentPage, IPageHandler>(nameof(ContentPage.InputTransparent), MapInputTransparent);
+#elif IOS
 			PageHandler.Mapper.ReplaceMapping<ContentPage, IPageHandler>(PlatformConfiguration.iOSSpecific.Page.PrefersHomeIndicatorAutoHiddenProperty.PropertyName, MapPrefersHomeIndicatorAutoHidden);
 			PageHandler.Mapper.ReplaceMapping<ContentPage, IPageHandler>(PlatformConfiguration.iOSSpecific.Page.PrefersStatusBarHiddenProperty.PropertyName, MapPrefersStatusBarHidden);
 #endif
@@ -27,6 +29,16 @@ namespace Microsoft.Maui.Controls
 		static void MapPrefersStatusBarHidden(IPageHandler handler, ContentPage page)
 		{
 			handler?.UpdateValue(nameof(IiOSPageSpecifics.PrefersStatusBarHiddenMode));
+		}
+#endif
+
+#if ANDROID
+		static void MapInputTransparent(IPageHandler handler, ContentPage page)
+		{
+			if (handler.PlatformView is ContentViewGroup layout)
+			{
+				layout.InputTransparent = page.InputTransparent;
+			}
 		}
 #endif
 

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue25007.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue25007.xaml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Maui.Controls.Sample.Issues.Issue25007">
+    <VerticalStackLayout>
+        <Button AutomationId="EnableInputTransparentButton"
+                Text="Enable input transparent for this content page"
+                Clicked="ButtonClicked"/>
+        <Button AutomationId="ActionButton"
+                x:Name="ActionButton"
+                Clicked="UpdateCountClicked"
+                Text="Count: 0"/>
+    </VerticalStackLayout>
+</ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue25007.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue25007.xaml.cs
@@ -1,0 +1,22 @@
+﻿namespace Maui.Controls.Sample.Issues
+{
+	[Issue(IssueTracker.Github, 25007, "ContentPage Property InputTransparent = true, causes blank page", PlatformAffected.Android)]
+	public partial class Issue25007 : ContentPage
+	{
+		int _clicksCount;
+		public Issue25007()
+		{
+			InitializeComponent();
+		}
+
+		private void ButtonClicked(object sender, EventArgs e)
+		{
+			this.InputTransparent = true;
+		}
+
+		private void UpdateCountClicked(object sender, EventArgs e)
+		{
+			ActionButton.Text = $"Count: {++_clicksCount}";
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25007.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25007.cs
@@ -1,0 +1,29 @@
+﻿using NUnit.Framework;
+using NUnit.Framework.Legacy;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue25007 : _IssuesUITest
+	{
+		public Issue25007(TestDevice testDevice) : base(testDevice)
+		{
+		}
+
+		public override string Issue => "ContentPage Property InputTransparent = true, causes blank page";
+
+		[Test]
+		[Category(UITestCategories.InputTransparent)]
+		public void InputTransparentShouldWorkOnContentPage()
+		{
+			App.WaitForElement("ActionButton");
+			App.Click("ActionButton");
+			App.Click("EnableInputTransparentButton");
+			App.Click("ActionButton");
+			
+			var countNumberText = App.FindElement("ActionButton").GetText();
+			Assert.That(countNumberText,Is.EqualTo("Count: 1"));
+		}
+	}
+}

--- a/src/Core/src/Platform/Android/ContentViewGroup.cs
+++ b/src/Core/src/Platform/Android/ContentViewGroup.cs
@@ -14,6 +14,8 @@ namespace Microsoft.Maui.Platform
 		IBorderStroke? _clip;
 		readonly Context _context;
 
+		internal bool InputTransparent { get; set; }
+
 		public ContentViewGroup(Context context) : base(context)
 		{
 			_context = context;
@@ -54,6 +56,16 @@ namespace Microsoft.Maui.Platform
 		Graphics.Size CrossPlatformArrange(Graphics.Rect bounds)
 		{
 			return CrossPlatformLayout?.CrossPlatformArrange(bounds) ?? Graphics.Size.Zero;
+		}
+
+		public override bool DispatchTouchEvent(MotionEvent? e)
+		{
+			if (InputTransparent)
+			{
+				return false;
+			}
+
+			return base.DispatchTouchEvent(e);
 		}
 
 		protected override void OnMeasure(int widthMeasureSpec, int heightMeasureSpec)

--- a/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -90,3 +90,4 @@ override Microsoft.Maui.PlatformWrapperView.OnLayout(bool changed, int left, int
 virtual Microsoft.Maui.PlatformWrapperView.DrawShadow(Android.Graphics.Canvas! canvas, int viewWidth, int viewHeight) -> void
 *REMOVED*~override Microsoft.Maui.Platform.WrapperView.DrawShadow(Android.Graphics.Canvas canvas, int viewWidth, int viewHeight) -> void
 *REMOVED*abstract Microsoft.Maui.PlatformWrapperView.DrawShadow(Android.Graphics.Canvas! p0, int p1, int p2) -> void
+override Microsoft.Maui.Platform.ContentViewGroup.DispatchTouchEvent(Android.Views.MotionEvent? e) -> bool


### PR DESCRIPTION
### Description of Change

When setting input transparent to true for content page it has been put into a wrapper view which causes weird behavior and sometimes crashes the app

<img width="1054" alt="Screenshot 2024-10-05 at 16 00 12" src="https://github.com/user-attachments/assets/189d3851-f876-45fa-8c89-d9a2634e28fc">

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/25007

https://github.com/user-attachments/assets/df202e19-bc7f-41d0-b9de-26a42872e2e4