### PR TITLE
[Testing] Add UITest Stepper actions

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Elements/StepperCoreGalleryPage.cs
+++ b/src/Controls/tests/TestCases.HostApp/Elements/StepperCoreGalleryPage.cs
@@ -1,18 +1,31 @@
-using Microsoft.Maui.Controls;
-
 namespace Maui.Controls.Sample;
 
-internal class StepperCoreGalleryPage : CoreGalleryPage<Stepper>
+internal class StepperCoreGalleryPage : ContentPage
 {
-	protected override bool SupportsFocus => false;
-	protected override bool SupportsTapGestureRecognizer => false;
-
-	protected override void InitializeElement(Stepper element)
+	public StepperCoreGalleryPage()
 	{
-	}
+		var layout = new StackLayout
+		{
+			Padding = new Thickness(12)
+		};
 
-	protected override void Build()
-	{
-		base.Build();
+		// Default
+		var defaultLabel = new Label { Text = "Default" };
+		var defaultStepper = new Stepper { AutomationId = "DefaultStepper" };
+		var defaultLabelValue = new Label
+		{
+			AutomationId = "DefaultLabelValue",
+			Text = defaultStepper.Value.ToString()
+		};
+		layout.Add(defaultLabel);
+		layout.Add(defaultStepper);
+		layout.Add(defaultLabelValue);
+
+		defaultStepper.ValueChanged += (s, e) =>
+		{
+			defaultLabelValue.Text = e.NewValue.ToString();
+		};
+
+		Content = layout;
 	}
 }

--- a/src/Controls/tests/TestCases.HostApp/Elements/StepperCoreGalleryPage.cs
+++ b/src/Controls/tests/TestCases.HostApp/Elements/StepperCoreGalleryPage.cs
@@ -10,7 +10,7 @@ internal class StepperCoreGalleryPage : ContentPage
 		};
 
 		// Default
-		var defaultLabel = new Label { Text = "Default" };
+		var defaultLabel = new Label { AutomationId = "DefaultLabel", Text = "Default" };
 		var defaultStepper = new Stepper { AutomationId = "DefaultStepper" };
 		var defaultLabelValue = new Label
 		{

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/StepperUITests.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/StepperUITests.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿#if ANDROID || IOS
+using NUnit.Framework;
 using NUnit.Framework.Legacy;
 using UITest.Appium;
 using UITest.Core;
@@ -76,3 +77,4 @@ namespace Microsoft.Maui.TestCases.Tests
 		}
 	}
 }
+#endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/StepperUITests.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/StepperUITests.cs
@@ -1,4 +1,4 @@
-﻿#if ANDROID || IOS
+﻿#if ANDROID || IOS || WINDOWS
 using NUnit.Framework;
 using NUnit.Framework.Legacy;
 using UITest.Appium;

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/StepperUITests.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/StepperUITests.cs
@@ -1,0 +1,78 @@
+﻿using NUnit.Framework;
+using NUnit.Framework.Legacy;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests
+{
+	[Category(UITestCategories.Stepper)]
+	public class StepperUITests : UITest
+	{
+		public const string StepperGallery = "Stepper Gallery";
+
+		public StepperUITests(TestDevice device)
+			: base(device)
+		{
+		}
+
+		protected override void FixtureSetup()
+		{
+			base.FixtureSetup();
+			App.NavigateToGallery(StepperGallery);
+		}
+
+		[Test]
+		[Category(UITestCategories.Stepper)]
+		[Description("Increase the Stepper value")]
+		public void IncreaseStepper()
+		{
+			const string stepperAutomationId = "DefaultStepper";
+			const string valueAutomationId = "DefaultLabelValue";
+
+			App.WaitForElement(stepperAutomationId);
+
+			// 1. Check the current value.
+			var step1Value = App.FindElement(valueAutomationId).GetText();
+			ClassicAssert.AreEqual("0", step1Value);
+
+			// 2. Increase the value.
+			App.IncreaseStepper(stepperAutomationId);
+			App.Screenshot("Increase the Stepper value");
+
+			// 3. Verify that the value has increased.
+			var step3Value = App.FindElement(valueAutomationId).GetText();
+			ClassicAssert.AreEqual("1", step3Value);
+		}
+
+		[Test]
+		[Category(UITestCategories.Stepper)]
+		[Description("Decrease the Stepper value")]
+		public void DecreaseStepper()
+		{
+			const string stepperAutomationId = "DefaultStepper";
+			const string valueAutomationId = "DefaultLabelValue";
+
+			App.WaitForElement(stepperAutomationId);
+
+			// 1. Check the current value.
+			var step1Value = App.FindElement(valueAutomationId).GetText();
+			ClassicAssert.AreEqual("0", step1Value);
+
+			// 2. Increase the value.
+			App.IncreaseStepper(stepperAutomationId);
+			App.Screenshot("Increase the Stepper value");
+
+			// 3. Verify that the value has increased.
+			var step3Value = App.FindElement(valueAutomationId).GetText();
+			ClassicAssert.AreEqual("1", step3Value);
+
+			// 4. Decrease the value.
+			App.DecreaseStepper(stepperAutomationId);
+			App.Screenshot("Decrease the Stepper value");
+
+			// 5. Verify that the value has decreased.
+			var step5Value = App.FindElement(valueAutomationId).GetText();
+			ClassicAssert.AreEqual("0", step5Value);
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/StepperUITests.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/StepperUITests.cs
@@ -27,10 +27,11 @@ namespace Microsoft.Maui.TestCases.Tests
 		[Description("Increase the Stepper value")]
 		public void IncreaseStepper()
 		{
+			const string titleAutomationId = "DefaultLabel";
 			const string stepperAutomationId = "DefaultStepper";
 			const string valueAutomationId = "DefaultLabelValue";
 
-			App.WaitForElement(stepperAutomationId);
+			App.WaitForElement(titleAutomationId);
 
 			// 1. Check the current value.
 			var step1Value = App.FindElement(valueAutomationId).GetText();
@@ -50,10 +51,11 @@ namespace Microsoft.Maui.TestCases.Tests
 		[Description("Decrease the Stepper value")]
 		public void DecreaseStepper()
 		{
+			const string titleAutomationId = "DefaultLabel";
 			const string stepperAutomationId = "DefaultStepper";
 			const string valueAutomationId = "DefaultLabelValue";
 
-			App.WaitForElement(stepperAutomationId);
+			App.WaitForElement(titleAutomationId);
 
 			// 1. Check the current value.
 			var step1Value = App.FindElement(valueAutomationId).GetText();

--- a/src/Core/src/Platform/Windows/MauiStepper.cs
+++ b/src/Core/src/Platform/Windows/MauiStepper.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Maui.Graphics;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
 using WBrush = Microsoft.UI.Xaml.Media.Brush;
@@ -98,14 +99,21 @@ namespace Microsoft.Maui.Platform
 		{
 			base.OnApplyTemplate();
 
+			var mauiStepperAutomationId = AutomationProperties.GetAutomationId(this);
+
 			_plus = GetTemplateChild("Plus") as Button;
 			if (_plus != null)
+			{
+				AutomationProperties.SetAutomationId(_plus, mauiStepperAutomationId + "Plus");
 				_plus.Click += OnPlusClicked;
+			}
 
 			_minus = GetTemplateChild("Minus") as Button;
 			if (_minus != null)
+			{
+				AutomationProperties.SetAutomationId(_minus, mauiStepperAutomationId + "Minus");
 				_minus.Click += OnMinusClicked;
-
+			}
 			UpdateEnabled(Value);
 			UpdateButtonBackground();
 		}

--- a/src/Core/src/Platform/Windows/Styles/MauiStepperStyle.xaml
+++ b/src/Core/src/Platform/Windows/Styles/MauiStepperStyle.xaml
@@ -12,8 +12,8 @@
                             <ColumnDefinition Width="*" />
                             <ColumnDefinition Width="*" />
                         </Grid.ColumnDefinitions>
-                        <Button Name="Minus" AutomationProperties.AutomationId="DecreaseStepper" Grid.Column="0" Content="-" />
-                        <Button Name="Plus" AutomationProperties.AutomationId="IncreaseStepper" Grid.Column="1" Content="+" />
+                        <Button Name="Minus" Grid.Column="0" Content="-" />
+                        <Button Name="Plus" Grid.Column="1" Content="+" />
                     </Grid>
                 </ControlTemplate>
             </Setter.Value>

--- a/src/Core/src/Platform/Windows/Styles/MauiStepperStyle.xaml
+++ b/src/Core/src/Platform/Windows/Styles/MauiStepperStyle.xaml
@@ -12,8 +12,8 @@
                             <ColumnDefinition Width="*" />
                             <ColumnDefinition Width="*" />
                         </Grid.ColumnDefinitions>
-                        <Button Name="Minus" Grid.Column="0" Content="-" />
-                        <Button Name="Plus" Grid.Column="1" Content="+" />
+                        <Button Name="Minus" AutomationProperties.AutomationId="DecreaseStepper" Grid.Column="0" Content="-" />
+                        <Button Name="Plus" AutomationProperties.AutomationId="IncreaseStepper" Grid.Column="1" Content="+" />
                     </Grid>
                 </ControlTemplate>
             </Setter.Value>

--- a/src/TestUtils/src/UITest.Appium/Actions/AppiumAndroidStepperActions.cs
+++ b/src/TestUtils/src/UITest.Appium/Actions/AppiumAndroidStepperActions.cs
@@ -37,7 +37,13 @@ public class AppiumAndroidStepperActions : ICommandExecutionGroup
 
 	CommandResponse Increase(IDictionary<string, object> parameters)
 	{
-		var stepper = GetAppiumElement(parameters["element"]);
+		string? elementId = parameters["elementId"].ToString();
+
+		if (elementId is null)
+			return CommandResponse.FailedEmptyResponse;
+
+		var element = _appiumApp.FindElement(elementId);
+		var stepper = GetAppiumElement(elementId);
 		
 		if (stepper is null)
 			return CommandResponse.FailedEmptyResponse;
@@ -55,7 +61,13 @@ public class AppiumAndroidStepperActions : ICommandExecutionGroup
 
 	CommandResponse Decrease(IDictionary<string, object> parameters)
 	{
-		var stepper = GetAppiumElement(parameters["element"]);
+		string? elementId = parameters["elementId"].ToString();
+
+		if (elementId is null)
+			return CommandResponse.FailedEmptyResponse;
+
+		var element = _appiumApp.FindElement(elementId);
+		var stepper = GetAppiumElement(elementId);
 
 		if (stepper is null)
 			return CommandResponse.FailedEmptyResponse;

--- a/src/TestUtils/src/UITest.Appium/Actions/AppiumAndroidStepperActions.cs
+++ b/src/TestUtils/src/UITest.Appium/Actions/AppiumAndroidStepperActions.cs
@@ -1,0 +1,82 @@
+﻿using OpenQA.Selenium.Appium;
+using UITest.Core;
+
+namespace UITest.Appium;
+
+public class AppiumAndroidStepperActions : ICommandExecutionGroup
+{
+	const string IncreaseCommand = "increaseStepper";
+	const string DecreaseCommand = "decreaseStepper";
+
+	readonly List<string> _commands = new()
+	{
+		IncreaseCommand,
+		DecreaseCommand
+	};
+	readonly AppiumApp _appiumApp;
+
+	public AppiumAndroidStepperActions(AppiumApp appiumApp)
+	{
+		_appiumApp = appiumApp;
+	}
+
+	public bool IsCommandSupported(string commandName)
+	{
+		return _commands.Contains(commandName, StringComparer.OrdinalIgnoreCase);
+	}
+
+	public CommandResponse Execute(string commandName, IDictionary<string, object> parameters)
+	{
+		return commandName switch
+		{
+			IncreaseCommand => Increase(parameters),
+			DecreaseCommand => Decrease(parameters),
+			_ => CommandResponse.FailedEmptyResponse,
+		};
+	}
+
+	CommandResponse Increase(IDictionary<string, object> parameters)
+	{
+		var stepper = GetAppiumElement(parameters["element"]);
+		
+		if (stepper is null)
+			return CommandResponse.FailedEmptyResponse;
+
+		var buttons = AppiumQuery.ByClass("android.widget.Button").FindElements(stepper, _appiumApp);
+
+		if(buttons is not null && buttons.Count > 1)
+		{
+			var increaseButton = buttons.LastOrDefault();
+			increaseButton?.Tap();
+		}
+
+		return CommandResponse.SuccessEmptyResponse;
+	}
+
+	CommandResponse Decrease(IDictionary<string, object> parameters)
+	{
+		var stepper = GetAppiumElement(parameters["element"]);
+
+		if (stepper is null)
+			return CommandResponse.FailedEmptyResponse;
+
+		var buttons = AppiumQuery.ByClass("android.widget.Button").FindElements(stepper, _appiumApp);
+
+		if (buttons is not null && buttons.Count > 1)
+		{
+			var decreaseButton = buttons.FirstOrDefault();
+			decreaseButton?.Tap();
+		}
+
+		return CommandResponse.SuccessEmptyResponse;
+	}
+
+	static AppiumElement? GetAppiumElement(object element) =>
+		element switch
+		{
+			AppiumElement appiumElement => appiumElement,
+			AppiumDriverElement driverElement => driverElement.AppiumElement,
+			_ => null
+		};
+}
+

--- a/src/TestUtils/src/UITest.Appium/Actions/AppiumAndroidStepperActions.cs
+++ b/src/TestUtils/src/UITest.Appium/Actions/AppiumAndroidStepperActions.cs
@@ -43,7 +43,7 @@ public class AppiumAndroidStepperActions : ICommandExecutionGroup
 			return CommandResponse.FailedEmptyResponse;
 
 		var element = _appiumApp.FindElement(elementId);
-		var stepper = GetAppiumElement(elementId);
+		var stepper = GetAppiumElement(element);
 		
 		if (stepper is null)
 			return CommandResponse.FailedEmptyResponse;
@@ -67,7 +67,7 @@ public class AppiumAndroidStepperActions : ICommandExecutionGroup
 			return CommandResponse.FailedEmptyResponse;
 
 		var element = _appiumApp.FindElement(elementId);
-		var stepper = GetAppiumElement(elementId);
+		var stepper = GetAppiumElement(element);
 
 		if (stepper is null)
 			return CommandResponse.FailedEmptyResponse;

--- a/src/TestUtils/src/UITest.Appium/Actions/AppiumIOSStepperActions.cs
+++ b/src/TestUtils/src/UITest.Appium/Actions/AppiumIOSStepperActions.cs
@@ -44,7 +44,7 @@ class AppiumIOSStepperActions : ICommandExecutionGroup
 			return CommandResponse.FailedEmptyResponse;
 
 		var element = _appiumApp.FindElement(elementId);
-		var stepper = GetAppiumElement(elementId);
+		var stepper = GetAppiumElement(element);
 
 		if (stepper is null)
 			return CommandResponse.FailedEmptyResponse;
@@ -68,7 +68,7 @@ class AppiumIOSStepperActions : ICommandExecutionGroup
 			return CommandResponse.FailedEmptyResponse;
 
 		var element = _appiumApp.FindElement(elementId);
-		var stepper = GetAppiumElement(elementId);
+		var stepper = GetAppiumElement(element);
 
 		if (stepper is null)
 			return CommandResponse.FailedEmptyResponse;

--- a/src/TestUtils/src/UITest.Appium/Actions/AppiumIOSStepperActions.cs
+++ b/src/TestUtils/src/UITest.Appium/Actions/AppiumIOSStepperActions.cs
@@ -3,7 +3,7 @@ using UITest.Core;
 
 namespace UITest.Appium;
 
-class AppiumAppleStepperActions : ICommandExecutionGroup
+class AppiumIOSStepperActions : ICommandExecutionGroup
 {
 	const string IncreaseCommand = "increaseStepper";
 	const string DecreaseCommand = "decreaseStepper";
@@ -16,7 +16,7 @@ class AppiumAppleStepperActions : ICommandExecutionGroup
 
 	readonly AppiumApp _appiumApp;
 
-	public AppiumAppleStepperActions(AppiumApp appiumApp)
+	public AppiumIOSStepperActions(AppiumApp appiumApp)
 	{
 		_appiumApp = appiumApp;
 	}

--- a/src/TestUtils/src/UITest.Appium/Actions/AppiumIOSStepperActions.cs
+++ b/src/TestUtils/src/UITest.Appium/Actions/AppiumIOSStepperActions.cs
@@ -1,0 +1,82 @@
+﻿using OpenQA.Selenium.Appium;
+using UITest.Core;
+
+namespace UITest.Appium;
+
+class AppiumAppleStepperActions : ICommandExecutionGroup
+{
+	const string IncreaseCommand = "increaseStepper";
+	const string DecreaseCommand = "decreaseStepper";
+
+	readonly List<string> _commands = new()
+	{
+		IncreaseCommand,
+		DecreaseCommand
+	};
+
+	readonly AppiumApp _appiumApp;
+
+	public AppiumAppleStepperActions(AppiumApp appiumApp)
+	{
+		_appiumApp = appiumApp;
+	}
+
+	public bool IsCommandSupported(string commandName)
+	{
+		return _commands.Contains(commandName, StringComparer.OrdinalIgnoreCase);
+	}
+
+	public CommandResponse Execute(string commandName, IDictionary<string, object> parameters)
+	{
+		return commandName switch
+		{
+			IncreaseCommand => Increase(parameters),
+			DecreaseCommand => Decrease(parameters),
+			_ => CommandResponse.FailedEmptyResponse,
+		};
+	}
+
+	CommandResponse Increase(IDictionary<string, object> parameters)
+	{
+		var stepper = GetAppiumElement(parameters["element"]);
+
+		if (stepper is null)
+			return CommandResponse.FailedEmptyResponse;
+
+		var buttons = AppiumQuery.ByClass("XCUIElementTypeButton").FindElements(stepper, _appiumApp);
+
+		if (buttons is not null && buttons.Count > 1)
+		{
+			var increaseButton = buttons.LastOrDefault();
+			increaseButton?.Tap();
+		}
+
+		return CommandResponse.SuccessEmptyResponse;
+	}
+
+	CommandResponse Decrease(IDictionary<string, object> parameters)
+	{
+		var stepper = GetAppiumElement(parameters["element"]);
+
+		if (stepper is null)
+			return CommandResponse.FailedEmptyResponse;
+
+		var buttons = AppiumQuery.ByClass("XCUIElementTypeButton").FindElements(stepper, _appiumApp);
+
+		if (buttons is not null && buttons.Count > 1)
+		{
+			var decreaseButton = buttons.FirstOrDefault();
+			decreaseButton?.Tap();
+		}
+
+		return CommandResponse.SuccessEmptyResponse;
+	}
+
+	static AppiumElement? GetAppiumElement(object element) =>
+		element switch
+		{
+			AppiumElement appiumElement => appiumElement,
+			AppiumDriverElement driverElement => driverElement.AppiumElement,
+			_ => null
+		};
+	

--- a/src/TestUtils/src/UITest.Appium/Actions/AppiumIOSStepperActions.cs
+++ b/src/TestUtils/src/UITest.Appium/Actions/AppiumIOSStepperActions.cs
@@ -79,4 +79,4 @@ class AppiumAppleStepperActions : ICommandExecutionGroup
 			AppiumDriverElement driverElement => driverElement.AppiumElement,
 			_ => null
 		};
-	
+}

--- a/src/TestUtils/src/UITest.Appium/Actions/AppiumIOSStepperActions.cs
+++ b/src/TestUtils/src/UITest.Appium/Actions/AppiumIOSStepperActions.cs
@@ -38,7 +38,13 @@ class AppiumIOSStepperActions : ICommandExecutionGroup
 
 	CommandResponse Increase(IDictionary<string, object> parameters)
 	{
-		var stepper = GetAppiumElement(parameters["element"]);
+		string? elementId = parameters["elementId"].ToString();
+
+		if (elementId is null)
+			return CommandResponse.FailedEmptyResponse;
+
+		var element = _appiumApp.FindElement(elementId);
+		var stepper = GetAppiumElement(elementId);
 
 		if (stepper is null)
 			return CommandResponse.FailedEmptyResponse;
@@ -56,7 +62,13 @@ class AppiumIOSStepperActions : ICommandExecutionGroup
 
 	CommandResponse Decrease(IDictionary<string, object> parameters)
 	{
-		var stepper = GetAppiumElement(parameters["element"]);
+		string? elementId = parameters["elementId"].ToString();
+
+		if (elementId is null)
+			return CommandResponse.FailedEmptyResponse;
+
+		var element = _appiumApp.FindElement(elementId);
+		var stepper = GetAppiumElement(elementId);
 
 		if (stepper is null)
 			return CommandResponse.FailedEmptyResponse;

--- a/src/TestUtils/src/UITest.Appium/Actions/AppiumWindowsStepperActions.cs
+++ b/src/TestUtils/src/UITest.Appium/Actions/AppiumWindowsStepperActions.cs
@@ -37,25 +37,24 @@ public class AppiumWindowsStepperActions : ICommandExecutionGroup
 
 	CommandResponse Increase(IDictionary<string, object> parameters)
 	{
-		var stepper = GetAppiumElement(parameters["element"]);
+		string? elementId = parameters["elementId"].ToString();
 
-		if (stepper is null)
+		if (elementId is null)
 			return CommandResponse.FailedEmptyResponse;
 
-		var increaseButton = stepper.FindElement(OpenQA.Selenium.By.Id("IncreaseStepper"));
+		var increaseButton = _appiumApp.FindElement(elementId + "Plus");
 		increaseButton?.Click();
-
 		return CommandResponse.SuccessEmptyResponse;
 	}
 
 	CommandResponse Decrease(IDictionary<string, object> parameters)
 	{
-		var stepper = GetAppiumElement(parameters["element"]);
+		string? elementId = parameters["elementId"].ToString();
 
-		if (stepper is null)
+		if (elementId is null)
 			return CommandResponse.FailedEmptyResponse;
 
-		var decreaseButton = stepper.FindElement(OpenQA.Selenium.By.Id("DecreaseStepper"));
+		var decreaseButton = _appiumApp.FindElement(elementId + "Minus");
 		decreaseButton?.Click();
 
 		return CommandResponse.SuccessEmptyResponse;

--- a/src/TestUtils/src/UITest.Appium/Actions/AppiumWindowsStepperActions.cs
+++ b/src/TestUtils/src/UITest.Appium/Actions/AppiumWindowsStepperActions.cs
@@ -42,13 +42,8 @@ public class AppiumWindowsStepperActions : ICommandExecutionGroup
 		if (stepper is null)
 			return CommandResponse.FailedEmptyResponse;
 
-		var buttons = AppiumQuery.ByXPath("//Button").FindElements(stepper, _appiumApp);
-
-		var increaseButton = AppiumQuery.ByXPath("//*[@text='\" + \"+\" + \"']\"")
-			.FindElements(stepper, _appiumApp)
-			.FirstOrDefault();
-
-		increaseButton?.Tap();
+		var increaseButton = stepper.FindElement(OpenQA.Selenium.By.Id("IncreaseStepper"));
+		increaseButton?.Click();
 
 		return CommandResponse.SuccessEmptyResponse;
 	}
@@ -60,11 +55,8 @@ public class AppiumWindowsStepperActions : ICommandExecutionGroup
 		if (stepper is null)
 			return CommandResponse.FailedEmptyResponse;
 
-		var decreaseButton = AppiumQuery.ByXPath("//*[@text='\" + \"-\" + \"']\"")
-			.FindElements(stepper, _appiumApp)
-			.FirstOrDefault();
-
-		decreaseButton?.Tap();
+		var decreaseButton = stepper.FindElement(OpenQA.Selenium.By.Id("DecreaseStepper"));
+		decreaseButton?.Click();
 
 		return CommandResponse.SuccessEmptyResponse;
 	}

--- a/src/TestUtils/src/UITest.Appium/Actions/AppiumWindowsStepperActions.cs
+++ b/src/TestUtils/src/UITest.Appium/Actions/AppiumWindowsStepperActions.cs
@@ -42,7 +42,7 @@ public class AppiumWindowsStepperActions : ICommandExecutionGroup
 		if (stepper is null)
 			return CommandResponse.FailedEmptyResponse;
 
-		var buttons = AppiumQuery.ByClass("//Button").FindElements(stepper, _appiumApp);
+		var buttons = AppiumQuery.ByXPath("//Button").FindElements(stepper, _appiumApp);
 
 		if (buttons is not null && buttons.Count > 1)
 		{
@@ -60,7 +60,7 @@ public class AppiumWindowsStepperActions : ICommandExecutionGroup
 		if (stepper is null)
 			return CommandResponse.FailedEmptyResponse;
 
-		var buttons = AppiumQuery.ByClass("//Button").FindElements(stepper, _appiumApp);
+		var buttons = AppiumQuery.ByXPath("//Button").FindElements(stepper, _appiumApp);
 
 		if (buttons is not null && buttons.Count > 1)
 		{

--- a/src/TestUtils/src/UITest.Appium/Actions/AppiumWindowsStepperActions.cs
+++ b/src/TestUtils/src/UITest.Appium/Actions/AppiumWindowsStepperActions.cs
@@ -44,11 +44,11 @@ public class AppiumWindowsStepperActions : ICommandExecutionGroup
 
 		var buttons = AppiumQuery.ByXPath("//Button").FindElements(stepper, _appiumApp);
 
-		if (buttons is not null && buttons.Count > 1)
-		{
-			var increaseButton = buttons.LastOrDefault();
-			increaseButton?.Tap();
-		}
+		var increaseButton = AppiumQuery.ByXPath("//*[@text='\" + \"+\" + \"']\"")
+			.FindElements(stepper, _appiumApp)
+			.FirstOrDefault();
+
+		increaseButton?.Tap();
 
 		return CommandResponse.SuccessEmptyResponse;
 	}
@@ -60,13 +60,11 @@ public class AppiumWindowsStepperActions : ICommandExecutionGroup
 		if (stepper is null)
 			return CommandResponse.FailedEmptyResponse;
 
-		var buttons = AppiumQuery.ByXPath("//Button").FindElements(stepper, _appiumApp);
+		var decreaseButton = AppiumQuery.ByXPath("//*[@text='\" + \"-\" + \"']\"")
+			.FindElements(stepper, _appiumApp)
+			.FirstOrDefault();
 
-		if (buttons is not null && buttons.Count > 1)
-		{
-			var decreaseButton = buttons.FirstOrDefault();
-			decreaseButton?.Tap();
-		}
+		decreaseButton?.Tap();
 
 		return CommandResponse.SuccessEmptyResponse;
 	}
@@ -79,4 +77,3 @@ public class AppiumWindowsStepperActions : ICommandExecutionGroup
 			_ => null
 		};
 }
-

--- a/src/TestUtils/src/UITest.Appium/Actions/AppiumWindowsStepperActions.cs
+++ b/src/TestUtils/src/UITest.Appium/Actions/AppiumWindowsStepperActions.cs
@@ -1,0 +1,82 @@
+﻿using OpenQA.Selenium.Appium;
+using UITest.Core;
+
+namespace UITest.Appium;
+
+public class AppiumWindowsStepperActions : ICommandExecutionGroup
+{
+	const string IncreaseCommand = "increaseStepper";
+	const string DecreaseCommand = "decreaseStepper";
+
+	readonly List<string> _commands = new()
+	{
+		IncreaseCommand,
+		DecreaseCommand
+	};
+	readonly AppiumApp _appiumApp;
+
+	public AppiumWindowsStepperActions(AppiumApp appiumApp)
+	{
+		_appiumApp = appiumApp;
+	}
+
+	public bool IsCommandSupported(string commandName)
+	{
+		return _commands.Contains(commandName, StringComparer.OrdinalIgnoreCase);
+	}
+
+	public CommandResponse Execute(string commandName, IDictionary<string, object> parameters)
+	{
+		return commandName switch
+		{
+			IncreaseCommand => Increase(parameters),
+			DecreaseCommand => Decrease(parameters),
+			_ => CommandResponse.FailedEmptyResponse,
+		};
+	}
+
+	CommandResponse Increase(IDictionary<string, object> parameters)
+	{
+		var stepper = GetAppiumElement(parameters["element"]);
+
+		if (stepper is null)
+			return CommandResponse.FailedEmptyResponse;
+
+		var buttons = AppiumQuery.ByClass("//Button").FindElements(stepper, _appiumApp);
+
+		if (buttons is not null && buttons.Count > 1)
+		{
+			var increaseButton = buttons.LastOrDefault();
+			increaseButton?.Tap();
+		}
+
+		return CommandResponse.SuccessEmptyResponse;
+	}
+
+	CommandResponse Decrease(IDictionary<string, object> parameters)
+	{
+		var stepper = GetAppiumElement(parameters["element"]);
+
+		if (stepper is null)
+			return CommandResponse.FailedEmptyResponse;
+
+		var buttons = AppiumQuery.ByClass("//Button").FindElements(stepper, _appiumApp);
+
+		if (buttons is not null && buttons.Count > 1)
+		{
+			var decreaseButton = buttons.FirstOrDefault();
+			decreaseButton?.Tap();
+		}
+
+		return CommandResponse.SuccessEmptyResponse;
+	}
+
+	static AppiumElement? GetAppiumElement(object element) =>
+		element switch
+		{
+			AppiumElement appiumElement => appiumElement,
+			AppiumDriverElement driverElement => driverElement.AppiumElement,
+			_ => null
+		};
+}
+

--- a/src/TestUtils/src/UITest.Appium/Actions/AppiumWindowsStepperActions.cs
+++ b/src/TestUtils/src/UITest.Appium/Actions/AppiumWindowsStepperActions.cs
@@ -1,5 +1,4 @@
-﻿using OpenQA.Selenium.Appium;
-using UITest.Core;
+﻿using UITest.Core;
 
 namespace UITest.Appium;
 
@@ -59,12 +58,4 @@ public class AppiumWindowsStepperActions : ICommandExecutionGroup
 
 		return CommandResponse.SuccessEmptyResponse;
 	}
-
-	static AppiumElement? GetAppiumElement(object element) =>
-		element switch
-		{
-			AppiumElement appiumElement => appiumElement,
-			AppiumDriverElement driverElement => driverElement.AppiumElement,
-			_ => null
-		};
 }

--- a/src/TestUtils/src/UITest.Appium/AppiumAndroidApp.cs
+++ b/src/TestUtils/src/UITest.Appium/AppiumAndroidApp.cs
@@ -14,6 +14,7 @@ namespace UITest.Appium
 			_commandExecutor.AddCommandGroup(new AppiumAndroidSpecificActions(this));
 			_commandExecutor.AddCommandGroup(new AppiumAndroidVirtualKeyboardActions(this));
 			_commandExecutor.AddCommandGroup(new AppiumAndroidAlertActions(this));
+			_commandExecutor.AddCommandGroup(new AppiumAndroidStepperActions(this));
 		}
 
 		public static AppiumAndroidApp CreateAndroidApp(Uri remoteAddress, IConfig config)

--- a/src/TestUtils/src/UITest.Appium/AppiumIOSApp.cs
+++ b/src/TestUtils/src/UITest.Appium/AppiumIOSApp.cs
@@ -18,6 +18,7 @@ namespace UITest.Appium
 			_commandExecutor.AddCommandGroup(new AppiumIOSThemeChangeAction(this));
 			_commandExecutor.AddCommandGroup(new AppiumIOSAlertActions(this));
 			_commandExecutor.AddCommandGroup(new AppiumIOSThemeChangeAction(this));
+			_commandExecutor.AddCommandGroup(new AppiumIOSStepperActions(this));
 		}
 
 		public override ApplicationState AppState

--- a/src/TestUtils/src/UITest.Appium/AppiumWindowsApp.cs
+++ b/src/TestUtils/src/UITest.Appium/AppiumWindowsApp.cs
@@ -10,7 +10,7 @@ namespace UITest.Appium
 		public AppiumWindowsApp(Uri remoteAddress, IConfig config)
 			: base(new WindowsDriver(remoteAddress, GetOptions(config)), config)
 		{
-
+			_commandExecutor.AddCommandGroup(new AppiumWindowsStepperActions(this));
 		}
 
 		public override ApplicationState AppState

--- a/src/TestUtils/src/UITest.Appium/HelperExtensions.cs
+++ b/src/TestUtils/src/UITest.Appium/HelperExtensions.cs
@@ -788,7 +788,7 @@ namespace UITest.Appium
 		{
 			app.CommandExecutor.Execute("decreaseStepper", new Dictionary<string, object>
 			{
-				["element"] = marked
+				["elementId"] = marked
 			});
 		}
 

--- a/src/TestUtils/src/UITest.Appium/HelperExtensions.cs
+++ b/src/TestUtils/src/UITest.Appium/HelperExtensions.cs
@@ -773,11 +773,9 @@ namespace UITest.Appium
 		/// <param name="marked">Marked selector of the Stepper element to increase.</param>
 		public static void IncreaseStepper(this IApp app, string marked)
 		{
-			var element = app.FindElement(marked);
-
 			app.CommandExecutor.Execute("increaseStepper", new Dictionary<string, object>
 			{
-				["element"] = element
+				["elementId"] = marked
 			});
 		}
 
@@ -788,11 +786,9 @@ namespace UITest.Appium
 		/// <param name="marked">Marked selector of the Stepper element to decrease.</param>
 		public static void DecreaseStepper(this IApp app, string marked)
 		{
-			var element = app.FindElement(marked);
-
 			app.CommandExecutor.Execute("decreaseStepper", new Dictionary<string, object>
 			{
-				["element"] = element
+				["element"] = marked
 			});
 		}
 

--- a/src/TestUtils/src/UITest.Appium/HelperExtensions.cs
+++ b/src/TestUtils/src/UITest.Appium/HelperExtensions.cs
@@ -767,6 +767,36 @@ namespace UITest.Appium
 		}
 
 		/// <summary>
+		/// Increases the value of a Stepper control.
+		/// </summary>
+		/// <param name="app">Represents the main gateway to interact with an app.</param>
+		/// <param name="marked">Marked selector of the Stepper element to increase.</param>
+		public static void IncreaseStepper(this IApp app, string marked)
+		{
+			var element = app.FindElement(marked);
+
+			app.CommandExecutor.Execute("increaseStepper", new Dictionary<string, object>
+			{
+				["element"] = element
+			});
+		}
+
+		/// <summary>
+		/// Decreases the value of a Stepper control.
+		/// </summary>
+		/// <param name="app">Represents the main gateway to interact with an app.</param>
+		/// <param name="marked">Marked selector of the Stepper element to decrease.</param>
+		public static void DecreaseStepper(this IApp app, string marked)
+		{
+			var element = app.FindElement(marked);
+
+			app.CommandExecutor.Execute("decreaseStepper", new Dictionary<string, object>
+			{
+				["element"] = element
+			});
+		}
+
+		/// <summary>
 		/// Performs a continuous drag gesture between 2 points.
 		/// </summary>
 		/// <param name="app">Represents the main gateway to interact with an app.</param>


### PR DESCRIPTION
### Description of Change

The `Stepper` control on all platforms is a composition of two buttons. With UITests using Appium and queries we can access each button although it requires more lines and some changes per platform.

This PR adds the **IncreaseStepper** and **DecreaseStepper** extension methods to easily increase and decrease the Stepper value in UI tests.

`App.IncreaseStepper(stepperAutomationId);`