### PR TITLE
[XC] Fix passing message arguments to BuildException when logging warning as error

### DIFF
--- a/src/Controls/src/Build.Tasks/BuildException.cs
+++ b/src/Controls/src/Build.Tasks/BuildException.cs
@@ -30,7 +30,12 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 
 		static string FormatMessage(BuildExceptionCode code, IXmlLineInfo xmlinfo, object[] args)
 		{
-			var message = string.Format(ErrorMessages.ResourceManager.GetString(code.ErrorMessageKey), args);
+			var message = ErrorMessages.ResourceManager.GetString(code.ErrorMessageKey);
+			if (args is not null)
+			{
+				message = string.Format(message, args);
+			}
+
 			var ecode = code.Code;
 			var position = xmlinfo == null || !xmlinfo.HasLineInfo() ? "" : $"({xmlinfo.LineNumber},{xmlinfo.LinePosition})";
 

--- a/src/Controls/src/Build.Tasks/XamlCTask.cs
+++ b/src/Controls/src/Build.Tasks/XamlCTask.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 			{
 				loggingHelper.LogError("XamlC", $"{code.CodePrefix}{code.CodeCode:0000}", code.HelpLink, xamlFilePath, lineNumber, linePosition, endLineNumber, endLinePosition, ErrorMessages.ResourceManager.GetString(code.ErrorMessageKey), messageArgs);
 				LoggedErrors ??= new();
-				LoggedErrors.Add(new BuildException(code, new XmlLineInfo(lineNumber, linePosition), innerException: null));
+				LoggedErrors.Add(new BuildException(code, new XmlLineInfo(lineNumber, linePosition), innerException: null, messageArgs));
 			}
 			else
 			{


### PR DESCRIPTION
### Description of Change

We weren't passing `messageArgs` to the constructor of `BuildException`. In the case of warnings such as XC0045 the error message could not be correctly formatted because it expected multiple arguments and none were available.

/cc @StephaneDelcroix 