### PR TITLE
[XC] Propagate x:DataType from parent scope to "standalone bindings"

### DIFF
--- a/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
+++ b/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
@@ -305,7 +305,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 					bool skipBindingCompilation = hasSource && !context.CompileBindingsWithSource;
 					if (!skipBindingCompilation)
 					{
-						if (TryCompileBindingPath(node, context, vardefref.VariableDefinition, bindingExtensionType.Value, isStandaloneBinding: bpRef is null, out var instructions))
+						if (TryCompileBindingPath(node, context, vardefref.VariableDefinition, bindingExtensionType.Value, out var instructions))
 						{
 							foreach (var instruction in instructions)
 								yield return instruction;
@@ -421,7 +421,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 		}
 
 		//Once we get compiled IValueProvider, this will move to the BindingExpression
-		static bool TryCompileBindingPath(ElementNode node, ILContext context, VariableDefinition bindingExt, (string, string, string) bindingExtensionType, bool isStandaloneBinding, out IEnumerable<Instruction> instructions)
+		static bool TryCompileBindingPath(ElementNode node, ILContext context, VariableDefinition bindingExt, (string, string, string) bindingExtensionType, out IEnumerable<Instruction> instructions)
 		{
 			instructions = null;
 
@@ -454,13 +454,6 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 			{
 				if (n != skipNode && n.Properties.TryGetValue(XmlName.xDataType, out dataTypeNode))
 				{
-					break;
-				}
-				else if (isStandaloneBinding)
-				{
-					// For standalone bindings we don't allow inheriting the x:DataType from its parents.
-					// A standalone binding is a binding instance which is not immediately applied through `SetBinding(...)`
-					// but it is applied later (for example it is applied to items in a collection).
 					break;
 				}
 

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui23989.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui23989.xaml.cs
@@ -38,7 +38,7 @@ public partial class Maui23989
         public void ItemDisplayBindingWithoutDataTypeFails([Values(false, true)] bool useCompiledXaml)
         {
             if (useCompiledXaml)
-                Assert.Throws(new BuildExceptionConstraint(12, 13, s => s.Contains("0022", StringComparison.Ordinal)), ()=> MockCompiler.Compile(typeof(Maui23989), null, true));
+                Assert.Throws(new BuildExceptionConstraint(12, 13, s => s.Contains("0045", StringComparison.Ordinal)), ()=> MockCompiler.Compile(typeof(Maui23989), null, true));
 
             var layout = new Maui23989(useCompiledXaml);
             //without x:DataType, bindings aren't compiled

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui25141.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui25141.xaml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests"
+             x:DataType="local:Maui25141ViewModel"
+             x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui25141">
+    <ContentPage.Resources>
+        <MultiBinding
+            x:Key="MultiBinding"
+            Mode="TwoWay">
+            <Binding Path="Text"/>
+        </MultiBinding>
+
+        <DataTrigger
+            x:Key="DataTrigger"
+            Binding="{Binding TriggerFlag}"
+            TargetType="Label"
+            Value="True">
+            <Setter Property="Text" Value="TRIGGERED" />
+        </DataTrigger>
+    </ContentPage.Resources>
+
+    <StackLayout>
+        <Label x:Name="LabelA">
+            <Label.Text>
+                <MultiBinding Mode="TwoWay">
+                    <Binding Path="Text"/>
+                </MultiBinding>
+            </Label.Text>
+        </Label>
+
+        <Label x:Name="LabelB">
+            <Label.Triggers>
+                <DataTrigger
+                    Binding="{Binding TriggerFlag}"
+                    TargetType="Button"
+                    Value="True">
+            <Setter Property="Text" Value="TRIGGERED" />
+                </DataTrigger>
+            </Label.Triggers>
+        </Label>
+    </StackLayout>
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui25141.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui25141.xaml.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+using Microsoft.Maui.ApplicationModel;
+using Microsoft.Maui.Controls.Core.UnitTests;
+using Microsoft.Maui.Controls.Shapes;
+using Microsoft.Maui.Devices;
+using Microsoft.Maui.Dispatching;
+
+using Microsoft.Maui.Graphics;
+using Microsoft.Maui.UnitTests;
+using NUnit.Framework;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+[XamlCompilation(XamlCompilationOptions.Skip)]
+public partial class Maui25141 : ContentPage
+{
+    public Maui25141()
+    {
+        InitializeComponent();
+		BindingContext = new Maui25141ViewModel
+		{
+			Text = "Hello, Maui!",
+			TriggerFlag = true
+		};
+    }
+
+    public Maui25141(bool useCompiledXaml)
+    {
+        //this stub will be replaced at compile time
+    }
+
+    [TestFixture]
+    class Test
+    {
+        [SetUp]
+        public void Setup()
+        {
+            Application.SetCurrentApplication(new MockApplication());
+            DispatcherProvider.SetCurrent(new DispatcherProviderStub());
+        }
+
+        [TearDown] public void TearDown()
+        {
+            AppInfo.SetCurrent(null);
+            DeviceInfo.SetCurrent(null);
+        }
+
+        [Test]
+        public void BindingsInDataTriggerAndMultiBindingAreCompiledCorrectly()
+        {
+            MockCompiler.Compile(typeof(Maui25141), treatWarningsAsErrors: true);
+        }
+    }
+}
+
+public class Maui25141ViewModel : INotifyPropertyChanged
+{
+	private bool _triggerFlag;
+	public bool TriggerFlag
+	{
+		get => _triggerFlag;
+		set
+		{
+			_triggerFlag = value;
+			PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(TriggerFlag)));
+		}
+	}
+
+	private string _text;
+	public string Text
+	{
+		get => _text;
+		set
+		{
+			_text = value;
+			PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Text)));
+		}
+	}
+
+	public event PropertyChangedEventHandler PropertyChanged;
+}


### PR DESCRIPTION
### Description of Change

The `x:DataType` should always match the current `BindingContext` of the current scope. When you pass a binding to the `Picker` component, the binding context for that binding will be each individual item in the list of items to choose from and not the parent binding context. This is similar to how we have a warning when you don't set `x:DataType` on `DataTemplate` and instead the data type from the parent scope would be inherited by the template. That is likely an oversight and should be fixed.

In the cases mentioned in #25141, `DataTrigger` and `MultiBinding`, the same reasoning doesn't apply, I think. It makes sense for the binding to inherit the parent binding context type.

Looking at this design in #22023 again after some time, I don't find it intuitive and rather confusing. Especially since the warning doesn't mention that there is a special rule for "standalone" bindings. Unless we are able to distinguish the "Picker" scenario from the "Multibinding" scenario, I think we should remove the restriction. If we do that, we should also revisit https://github.com/dotnet/maui/pull/24513 to match the behavior in runtime XAML parsing.

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/25141
Fixes https://github.com/dotnet/maui/issues/5342
This restriction was introduced in https://github.com/dotnet/maui/pull/22023
This change is also related to https://github.com/dotnet/maui/pull/24513
