### PR TITLE
For Android, respect Minimum/Maximum size requests even when size is set

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/Android/SizedItemContentView.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/SizedItemContentView.cs
@@ -38,10 +38,10 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			{
 				var widthSpec = Context.CreateMeasureSpec(targetWidth,
 					double.IsInfinity(targetWidth) ? double.NaN : targetWidth
-					, targetWidth);
+					, minimumSize: double.NaN, maximumSize: targetWidth);
 
 				var heightSpec = Context.CreateMeasureSpec(targetHeight, double.IsInfinity(targetHeight) ? double.NaN : targetHeight
-					, targetHeight);
+					, minimumSize: double.NaN, maximumSize: targetHeight);
 
 				var size = pvh.MeasureVirtualView(widthSpec, heightSpec);
 

--- a/src/Controls/tests/DeviceTests/Elements/Layout/LayoutTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Layout/LayoutTests.cs
@@ -535,5 +535,44 @@ namespace Microsoft.Maui.DeviceTests
 				});
 			});
 		}
+
+		[Fact]
+		public async Task SizeRequestIsClampedToMinimumAndMaximum()
+		{
+			EnsureHandlerCreated((builder) =>
+			{
+				builder.ConfigureMauiHandlers(handler =>
+				{
+					handler.AddHandler(typeof(Button), typeof(ButtonHandler));
+					handler.AddHandler(typeof(Layout), typeof(LayoutHandler));
+				});
+			});
+
+			var button = new Button()
+			{
+				WidthRequest = 20, // request smaller than the minimum
+				MinimumWidthRequest = 200,
+				MaximumWidthRequest = 300,
+
+				HeightRequest = 400, // request larger than the maximum
+				MinimumHeightRequest = 200,
+				MaximumHeightRequest = 300,
+
+				HorizontalOptions = LayoutOptions.Start,
+				VerticalOptions = LayoutOptions.Start,
+			};
+
+			var grid = new Grid { button };
+
+			await InvokeOnMainThreadAsync(async () =>
+			{
+				await AttachAndRun(grid, _ =>
+				{
+					// The size should be the minimum requested size, since that will easily hold the "X" text
+					Assert.Equal(button.MinimumWidthRequest, button.Width, 0.5);
+					Assert.Equal(button.MaximumHeightRequest, button.Height, 0.5);
+				});
+			});
+		}
 	}
 }

--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Android.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Android.cs
@@ -47,8 +47,8 @@ namespace Microsoft.Maui.Handlers
 			}
 
 			// Create a spec to handle the native measure
-			var widthSpec = Context.CreateMeasureSpec(widthConstraint, virtualView.Width, virtualView.MaximumWidth);
-			var heightSpec = Context.CreateMeasureSpec(heightConstraint, virtualView.Height, virtualView.MaximumHeight);
+			var widthSpec = Context.CreateMeasureSpec(widthConstraint, virtualView.Width, virtualView.MinimumWidth, virtualView.MaximumWidth);
+			var heightSpec = Context.CreateMeasureSpec(heightConstraint, virtualView.Height, virtualView.MinimumHeight, virtualView.MaximumHeight);
 
 			if (platformView.FillViewport)
 			{

--- a/src/Core/src/Handlers/ViewHandlerExtensions.Android.cs
+++ b/src/Core/src/Handlers/ViewHandlerExtensions.Android.cs
@@ -87,8 +87,8 @@ namespace Microsoft.Maui
 			}
 
 			// Create a spec to handle the native measure
-			var widthSpec = Context.CreateMeasureSpec(widthConstraint, virtualView.Width, virtualView.MaximumWidth);
-			var heightSpec = Context.CreateMeasureSpec(heightConstraint, virtualView.Height, virtualView.MaximumHeight);
+			var widthSpec = Context.CreateMeasureSpec(widthConstraint, virtualView.Width, virtualView.MinimumWidth, virtualView.MaximumWidth);
+			var heightSpec = Context.CreateMeasureSpec(heightConstraint, virtualView.Height, virtualView.MinimumHeight, virtualView.MaximumHeight);
 
 			var packed = PlatformInterop.MeasureAndGetWidthAndHeight(platformView, widthSpec, heightSpec);
 			var measuredWidth = (int)(packed >> 32);

--- a/src/Core/src/Platform/Android/ContextExtensions.cs
+++ b/src/Core/src/Platform/Android/ContextExtensions.cs
@@ -2,7 +2,6 @@ using System;
 using System.IO;
 using Android.Content;
 using Android.Content.Res;
-using Android.OS;
 using Android.Util;
 using Android.Views;
 using Android.Views.InputMethods;
@@ -378,7 +377,7 @@ namespace Microsoft.Maui.Platform
 			return _navigationBarHeight ?? 0;
 		}
 
-		internal static int CreateMeasureSpec(this Context context, double constraint, double explicitSize, double maximumSize)
+		internal static int CreateMeasureSpec(this Context context, double constraint, double explicitSize, double minimumSize, double maximumSize)
 		{
 			var mode = MeasureSpecMode.AtMost;
 
@@ -386,7 +385,14 @@ namespace Microsoft.Maui.Platform
 			{
 				// We have a set value (i.e., a Width or Height)
 				mode = MeasureSpecMode.Exactly;
-				constraint = explicitSize;
+
+				// Since the mode is "Exactly", we have to return the exact final value clamped to the minimum/maximum.
+				constraint = Math.Max(explicitSize, ResolveMinimum(minimumSize));
+
+				if (IsMaximumSet(maximumSize))
+				{
+					constraint = Math.Min(constraint, maximumSize);
+				}
 			}
 			else if (IsMaximumSet(maximumSize) && maximumSize < constraint)
 			{


### PR DESCRIPTION
### Description of Change

This change is for Android layout only: Clamp the final width/height within the minimum/maximum sizes. Since the layout mode is being set to `MeasureSpecMode.Exactly`, we need to give Android the exact final measurement, it will not take minimum/maximum size requests into account.

See the bug for full info.

### Issues Fixed

Fixes:
* https://github.com/dotnet/maui/issues/25163
