### PR TITLE
Entry Height gets updated when loaded inside the RoundRectangle Shape

### DIFF
--- a/src/Controls/src/Core/Shapes/RoundRectangle.cs
+++ b/src/Controls/src/Core/Shapes/RoundRectangle.cs
@@ -101,7 +101,7 @@ namespace Microsoft.Maui.Controls.Shapes
 			return path;
 		}
 
-		PathF IRoundRectangle.RoundRectangleInnerPath()
+		PathF IRoundRectangle.InnerPath()
 		{
 			return GetInnerPath((float)StrokeThickness);		 
 		}

--- a/src/Controls/src/Core/Shapes/RoundRectangle.cs
+++ b/src/Controls/src/Core/Shapes/RoundRectangle.cs
@@ -101,11 +101,9 @@ namespace Microsoft.Maui.Controls.Shapes
 			return path;
 		}
 
-		PathF IRoundRectangle.RounRectangleInnerPath()
+		PathF IRoundRectangle.RoundRectangleInnerPath()
 		{
-			var stroke = (float)StrokeThickness;
-			var path = GetInnerPath(stroke);
-			return path;
+			return GetInnerPath((float)StrokeThickness);		 
 		}
 
 		PathF IRoundRectangle.InnerPathForBounds(Rect viewBounds, float strokeThickness)

--- a/src/Controls/src/Core/Shapes/RoundRectangle.cs
+++ b/src/Controls/src/Core/Shapes/RoundRectangle.cs
@@ -101,6 +101,13 @@ namespace Microsoft.Maui.Controls.Shapes
 			return path;
 		}
 
+		PathF IRoundRectangle.RounRectangleInnerPath()
+		{
+			var stroke = (float)StrokeThickness;
+			var path = GetInnerPath(stroke);
+			return path;
+		}
+
 		PathF IRoundRectangle.InnerPathForBounds(Rect viewBounds, float strokeThickness)
 		{
 			_fallbackHeight = viewBounds.Height;

--- a/src/Controls/src/Core/Shapes/Shape.cs
+++ b/src/Controls/src/Core/Shapes/Shape.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Maui.Controls.Shapes
 
 		double _fallbackWidth;
 		double _fallbackHeight;
-		private static bool IsStrokeUpdated;
+		bool _isStrokeUpdated;
 
 		/// <summary>Bindable property for <see cref="Fill"/>.</summary>
 		public static readonly BindableProperty FillProperty =
@@ -263,9 +263,9 @@ namespace Microsoft.Maui.Controls.Shapes
 
 		private static void OnStrokePropertyChanged(BindableObject bindable, object oldValue, object newValue)
 		{
-			if (bindable is RoundRectangle rect && IsStrokeUpdated)
+			if (bindable is RoundRectangle rect && rect._isStrokeUpdated)
 			{
-					IsStrokeUpdated = false;
+				rect._isStrokeUpdated = false;
 			}
 		}
 
@@ -446,11 +446,11 @@ namespace Microsoft.Maui.Controls.Shapes
 					break;
 			}
 
-			if(!IsStrokeUpdated)
+			if (!_isStrokeUpdated)
 			{
 				result.Height += StrokeThickness;
 				result.Width += StrokeThickness;
-				IsStrokeUpdated = true;
+				_isStrokeUpdated = true;
 			}
 
 			return result;

--- a/src/Controls/src/Core/Shapes/Shape.cs
+++ b/src/Controls/src/Core/Shapes/Shape.cs
@@ -387,7 +387,7 @@ namespace Microsoft.Maui.Controls.Shapes
 			// For other shapes, the GetPath() method excludes the stroke thickness"
 			if (this is IRoundRectangle roundRectangle)
 			{
-				pathBounds = roundRectangle.RoundRectangleInnerPath().GetBoundsByFlattening(1);
+				pathBounds = roundRectangle.InnerPath().GetBoundsByFlattening(1);
 			}
 			else
 			{

--- a/src/Controls/src/Core/Shapes/Shape.cs
+++ b/src/Controls/src/Core/Shapes/Shape.cs
@@ -60,7 +60,14 @@ namespace Microsoft.Maui.Controls.Shapes
 
 		/// <summary>Bindable property for <see cref="StrokeThickness"/>.</summary>
 		public static readonly BindableProperty StrokeThicknessProperty =
-			BindableProperty.Create(nameof(StrokeThickness), typeof(double), typeof(Shape), 1.0, propertyChanged: OnStrokePropertyChanged);
+			BindableProperty.Create(nameof(StrokeThickness), typeof(double), typeof(Shape), 1.0,
+				propertyChanged: (bindable, oldvalue, newvalue) =>
+				{
+					if (bindable is RoundRectangle rect && rect._isStrokeUpdated)
+					{
+						rect._isStrokeUpdated = false;
+					}
+				});
 
 		/// <summary>Bindable property for <see cref="StrokeDashArray"/>.</summary>
 		public static readonly BindableProperty StrokeDashArrayProperty =
@@ -258,14 +265,6 @@ namespace Microsoft.Maui.Controls.Shapes
 
 				SetInheritedBindingContext(stroke, null);
 				_strokeProxy?.Unsubscribe();
-			}
-		}
-
-		private static void OnStrokePropertyChanged(BindableObject bindable, object oldValue, object newValue)
-		{
-			if (bindable is RoundRectangle rect && rect._isStrokeUpdated)
-			{
-				rect._isStrokeUpdated = false;
 			}
 		}
 

--- a/src/Controls/src/Core/Shapes/Shape.cs
+++ b/src/Controls/src/Core/Shapes/Shape.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Maui.Controls.Shapes
 
 		double _fallbackWidth;
 		double _fallbackHeight;
+		private static bool IsStrokeUpdated;
 
 		/// <summary>Bindable property for <see cref="Fill"/>.</summary>
 		public static readonly BindableProperty FillProperty =
@@ -59,7 +60,7 @@ namespace Microsoft.Maui.Controls.Shapes
 
 		/// <summary>Bindable property for <see cref="StrokeThickness"/>.</summary>
 		public static readonly BindableProperty StrokeThicknessProperty =
-			BindableProperty.Create(nameof(StrokeThickness), typeof(double), typeof(Shape), 1.0);
+			BindableProperty.Create(nameof(StrokeThickness), typeof(double), typeof(Shape), 1.0, propertyChanged: OnStrokePropertyChanged);
 
 		/// <summary>Bindable property for <see cref="StrokeDashArray"/>.</summary>
 		public static readonly BindableProperty StrokeDashArrayProperty =
@@ -260,6 +261,14 @@ namespace Microsoft.Maui.Controls.Shapes
 			}
 		}
 
+		private static void OnStrokePropertyChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			if (bindable is RoundRectangle rect && IsStrokeUpdated)
+			{
+					IsStrokeUpdated = false;
+			}
+		}
+
 		PathF IShape.PathForBounds(Graphics.Rect viewBounds)
 		{
 			_fallbackHeight = viewBounds.Height;
@@ -437,8 +446,12 @@ namespace Microsoft.Maui.Controls.Shapes
 					break;
 			}
 
-			result.Height += StrokeThickness;
-			result.Width += StrokeThickness;
+			if(!IsStrokeUpdated)
+			{
+				result.Height += StrokeThickness;
+				result.Width += StrokeThickness;
+				IsStrokeUpdated = true;
+			}
 
 			return result;
 		}

--- a/src/Controls/src/Core/Shapes/Shape.cs
+++ b/src/Controls/src/Core/Shapes/Shape.cs
@@ -383,13 +383,15 @@ namespace Microsoft.Maui.Controls.Shapes
 
 			// TODO: not using this.GetPath().Bounds.Size;
 			//       since default GetBoundsByFlattening(0.001) returns incorrect results for curves
-			if (this is IRoundRectangle rect)
+			// Get the inner path by subtracting the stroke thickness for a rounded rectangle, as the GetPath() method returns the path including the stroke thickness.
+			// For other shapes, the GetPath() method excludes the stroke thickness"
+			if (this is IRoundRectangle roundRectangle)
 			{
-				pathBounds = rect.RounRectangleInnerPath().GetBoundsByFlattening(1);
+				pathBounds = roundRectangle.RoundRectangleInnerPath().GetBoundsByFlattening(1);
 			}
 			else
 			{
-				pathBounds = this.GetPath().GetBoundsByFlattening(1);
+			    pathBounds = this.GetPath().GetBoundsByFlattening(1);
 			}
 
 			SizeF boundsByFlattening = pathBounds.Size;

--- a/src/Controls/src/Core/Shapes/Shape.cs
+++ b/src/Controls/src/Core/Shapes/Shape.cs
@@ -449,6 +449,11 @@ namespace Microsoft.Maui.Controls.Shapes
 			{
 				result.Height += StrokeThickness;
 				result.Width += StrokeThickness;
+
+		 		// Stroke thickness is added to the measured size during each Measure call,
+				// which could cause the height of the RoundRectangle to increase repeatedly.
+				// To prevent this, the RoundRectangle's height is updated only once during the first measure using flag.
+				// Size adjustments for other shapes, such as Rectangle and Ellipse, are handled separately in the GetPath() method of the Rectangle class.
 				if (this is RoundRectangle)
 				{
 					_isStrokeUpdated = true;

--- a/src/Controls/src/Core/Shapes/Shape.cs
+++ b/src/Controls/src/Core/Shapes/Shape.cs
@@ -449,7 +449,10 @@ namespace Microsoft.Maui.Controls.Shapes
 			{
 				result.Height += StrokeThickness;
 				result.Width += StrokeThickness;
-				_isStrokeUpdated = true;
+				if (this is RoundRectangle)
+				{
+					_isStrokeUpdated = true;
+				}
 			}
 
 			return result;

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue18092.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue18092.xaml
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+              x:Class="Maui.Controls.Sample.Issues.Issue18092">
+
+  <VerticalStackLayout VerticalOptions="Center">
+    <RoundRectangle x:Name="roundRectangle" Fill="Red" AutomationId="RoundRectangle"/>
+    <Entry  AutomationId="Entry"/>
+  </VerticalStackLayout>
+</ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue18092.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue18092.xaml
@@ -4,7 +4,7 @@
               x:Class="Maui.Controls.Sample.Issues.Issue18092">
 
   <VerticalStackLayout VerticalOptions="Center">
-    <RoundRectangle x:Name="roundRectangle" Fill="Red" AutomationId="RoundRectangle"/>
+    <RoundRectangle Fill="Red" AutomationId="RoundRectangle"/>
     <Entry  AutomationId="Entry"/>
   </VerticalStackLayout>
 </ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue18092.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue18092.xaml
@@ -4,7 +4,7 @@
               x:Class="Maui.Controls.Sample.Issues.Issue18092">
 
   <VerticalStackLayout VerticalOptions="Center">
-    <RoundRectangle x:Name="roundRectangle" Fill="Red" />
+    <RoundRectangle Fill="Red" />
     <Entry  AutomationId="Entry"/>
   </VerticalStackLayout>
 </ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue18092.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue18092.xaml
@@ -4,7 +4,7 @@
               x:Class="Maui.Controls.Sample.Issues.Issue18092">
 
   <VerticalStackLayout VerticalOptions="Center">
-    <RoundRectangle Fill="Red" AutomationId="RoundRectangle"/>
+    <RoundRectangle x:Name="roundRectangle" Fill="Red" />
     <Entry  AutomationId="Entry"/>
   </VerticalStackLayout>
 </ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue18092.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue18092.xaml.cs
@@ -1,0 +1,11 @@
+﻿namespace Maui.Controls.Sample.Issues
+{
+	[Issue(IssueTracker.Github, 18092, "Entry bug—height grows on every input event", PlatformAffected.Android)]
+	public partial class Issue18092 : ContentPage
+	{
+		public Issue18092()
+		{
+			InitializeComponent();
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue18092.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue18092.cs
@@ -1,5 +1,4 @@
-﻿#if !MACCATALYST
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
 
@@ -25,4 +24,3 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		}
 	}
 }
-#endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue18092.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue18092.cs
@@ -1,0 +1,28 @@
+﻿#if !MACCATALYST
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+    internal class Issue18092 : _IssuesUITest
+    {
+		public override string Issue => "Entry bug—height grows on every input event";
+		public Issue18092(TestDevice testDevice) : base(testDevice)
+		{
+		}
+
+		[Test]
+		[Category(UITestCategories.Entry)]
+		public void EntryHeight()
+		{
+			var entry = App.WaitForElement("Entry");
+			App.EnterText("Entry", "E");
+			var initialHeight = entry.GetRect().Height;
+			App.EnterText("Entry", "ntry Control");
+			var finalHeight = entry.GetRect().Height;
+			Assert.That(initialHeight, Is.EqualTo(finalHeight));
+		}
+	}
+}
+#endif

--- a/src/Core/src/Graphics/IShape.cs
+++ b/src/Core/src/Graphics/IShape.cs
@@ -12,6 +12,6 @@
 	internal interface IRoundRectangle : IShape
 	{
 		PathF InnerPathForBounds(Rect bounds, float strokeThickness);
-		PathF RounRectangleInnerPath();
+		PathF RoundRectangleInnerPath();
 	}
 }

--- a/src/Core/src/Graphics/IShape.cs
+++ b/src/Core/src/Graphics/IShape.cs
@@ -12,6 +12,6 @@
 	internal interface IRoundRectangle : IShape
 	{
 		PathF InnerPathForBounds(Rect bounds, float strokeThickness);
-		PathF RoundRectangleInnerPath();
+		PathF InnerPath();
 	}
 }

--- a/src/Core/src/Graphics/IShape.cs
+++ b/src/Core/src/Graphics/IShape.cs
@@ -12,5 +12,6 @@
 	internal interface IRoundRectangle : IShape
 	{
 		PathF InnerPathForBounds(Rect bounds, float strokeThickness);
+		PathF RounRectangleInnerPath();
 	}
 }


### PR DESCRIPTION
### RootCause

In the case of a rounded rectangle, the stroke thickness is added to the measured size during each `Measure` call. As a result, for every input in the `Entry` control, the width and height of the rounded rectangle are updated.

This issue was introduced due to the following PRs:
[Rendering Shapes without explicit bounds. by VSadov · Pull Request #5817 · dotnet/maui (github.com)](https://github.com/dotnet/maui/pull/5817)
[Fixed Android RoundRectangle border logic by jstedfast · Pull Request #17087 · dotnet/maui (github.com)](https://github.com/dotnet/maui/pull/17087)

While reverting change in above PR, current fix is fixed and issue mentioned above PR replicates.

### Description of Change

The fix ensures that RoundRectangle handles stroke thickness consistently across measure calls. Previously, GetPath() directly used the full width and height without adjusting for StrokeThickness, causing the measured size to increase with each input event.

To resolve this, GetInnerPath() has been updated to exclude StrokeThickness from the size calculation, aligning RoundRectangle behavior with Rectangle. This prevents the height from increasing on each MeasureOverride() call.

### Issues Fixed
Fixes #18092 

Tested the behaviour in the following platforms
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac
 
### Output Videos 

Before Issue Fix | After Issue Fix |
|----------|----------|
|<video width="300" height="600" alt="Before Fix video" src="https://github.com/user-attachments/assets/071fcbf0-e2be-4ba8-bb37-95efbaf845c2">|<video width="300" height="600" alt="After Fix video" src="https://github.com/user-attachments/assets/baf7f58b-941b-45a3-8100-1e1053301fd9">|