### PR TITLE
[X] inherit DataType based on attribute

### DIFF
--- a/src/Controls/src/Core/ListView/ListView.cs
+++ b/src/Controls/src/Core/ListView/ListView.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Windows.Input;
 using Microsoft.Extensions.Logging;
 using Microsoft.Maui.Controls.Internals;
+using Microsoft.Maui.Controls.Xaml;
 using Microsoft.Maui.Controls.Xaml.Diagnostics;
 using Microsoft.Maui.Devices;
 using Microsoft.Maui.Graphics;
@@ -151,6 +152,7 @@ namespace Microsoft.Maui.Controls
 		}
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/ListView.xml" path="//Member[@MemberName='GroupDisplayBinding']/Docs/*" />
+		[DoesNotInheritDataType]
 		public BindingBase GroupDisplayBinding
 		{
 			get { return _groupDisplayBinding; }
@@ -176,6 +178,7 @@ namespace Microsoft.Maui.Controls
 		}
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/ListView.xml" path="//Member[@MemberName='GroupShortNameBinding']/Docs/*" />
+		[DoesNotInheritDataType]
 		public BindingBase GroupShortNameBinding
 		{
 			get { return _groupShortNameBinding; }

--- a/src/Controls/src/Core/Picker/Picker.cs
+++ b/src/Controls/src/Core/Picker/Picker.cs
@@ -7,6 +7,7 @@ using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using Microsoft.Maui.Controls.Internals;
+using Microsoft.Maui.Controls.Xaml;
 using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Controls
@@ -199,6 +200,7 @@ namespace Microsoft.Maui.Controls
 
 		BindingBase _itemDisplayBinding;
 		/// <include file="../../docs/Microsoft.Maui.Controls/Picker.xml" path="//Member[@MemberName='ItemDisplayBinding']/Docs/*" />
+		[DoesNotInheritDataType]
 		public BindingBase ItemDisplayBinding
 		{
 			get { return _itemDisplayBinding; }

--- a/src/Controls/src/Core/TemplatedItemsList.cs
+++ b/src/Controls/src/Core/TemplatedItemsList.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Cadenza.Collections;
 using Microsoft.Maui.Controls.Internals;
+using Microsoft.Maui.Controls.Xaml;
 using Microsoft.Maui.Devices;
 
 namespace Microsoft.Maui.Controls.Internals
@@ -100,6 +101,7 @@ namespace Microsoft.Maui.Controls.Internals
 			remove { PropertyChanged -= value; }
 		}
 
+		[DoesNotInheritDataType]
 		public BindingBase GroupDisplayBinding
 		{
 			get { return _groupDisplayBinding; }
@@ -133,6 +135,7 @@ namespace Microsoft.Maui.Controls.Internals
 
 		public BindableProperty GroupHeaderTemplateProperty { get; set; }
 
+		[DoesNotInheritDataType]
 		public BindingBase GroupShortNameBinding
 		{
 			get { return _groupShortNameBinding; }

--- a/src/Controls/src/Core/Xaml/DoesNotInheritDataTypeAttribute.cs
+++ b/src/Controls/src/Core/Xaml/DoesNotInheritDataTypeAttribute.cs
@@ -1,0 +1,9 @@
+#nullable disable
+using System;
+
+namespace Microsoft.Maui.Controls.Xaml
+{
+	internal class DoesNotInheritDataTypeAttribute : Attribute
+	{
+	}
+}

--- a/src/Controls/src/Xaml/XamlServiceProvider.cs
+++ b/src/Controls/src/Xaml/XamlServiceProvider.cs
@@ -324,7 +324,7 @@ namespace Microsoft.Maui.Controls.Xaml.Internals
 				return false;
 			}
 
-			static bool IsBindingBaseProperty(IElementNode node, HydrationContext context)
+			static bool DoesNotInheritDataType(IElementNode node, HydrationContext context)
 			{
 				if (   node.TryGetPropertyName(node.Parent, out XmlName name)
 					&& node.Parent is IElementNode parent
@@ -332,9 +332,9 @@ namespace Microsoft.Maui.Controls.Xaml.Internals
 												 new XmlLineInfo(((IXmlLineInfo)node).LineNumber, ((IXmlLineInfo)node).LinePosition), 
 												 context.RootElement.GetType().Assembly, out var xpe) is Type parentType
 					&& parentType.GetRuntimeProperties().FirstOrDefault(p => p.Name == name.LocalName) is PropertyInfo propertyInfo
-					&& propertyInfo.PropertyType == typeof(BindingBase))
+					&& propertyInfo.CustomAttributes.Any(ca => ca.AttributeType == typeof(DoesNotInheritDataTypeAttribute)))
 				{								
-						return true;
+					return true;
 				}
 				return false;
 			}
@@ -360,7 +360,7 @@ namespace Microsoft.Maui.Controls.Xaml.Internals
 				{
 					break;
 				}
-				if (IsBindingBaseProperty(n, context))
+				if (DoesNotInheritDataType(n, context))
 				{					
 					break;
 				}


### PR DESCRIPTION
### Description of Change

Changes the heuristic for deciding if we need ot ignore parent DataType, as DataTrigger.Binding shoud inherit it, and
Picker.ItemDisplayNameBinding should not

### Issues Fixed

this is an alternate fix for #23989, partially replaces #24513, and will help fixing #25141 together with #25152

