### PR TITLE
[nuget-msi-convert] Support improved VS component IDs

### DIFF
--- a/eng/automation/vs-workload.template.props
+++ b/eng/automation/vs-workload.template.props
@@ -4,6 +4,7 @@
     <TargetName>Microsoft.NET.Sdk.Maui.Workload.@VSMAN_VERSION@</TargetName>
     <ManifestBuildVersion>@VS_COMPONENT_VERSION@</ManifestBuildVersion>
     <EnableSideBySideManifests>true</EnableSideBySideManifests>
+    <UseVisualStudioComponentPrefix>true</UseVisualStudioComponentPrefix>
   </PropertyGroup>
   <ItemGroup>
     <!-- Shorten package names to avoid long path caching issues in Visual Studio -->

--- a/eng/pipelines/maui-release.yml
+++ b/eng/pipelines/maui-release.yml
@@ -67,7 +67,7 @@ resources:
       type: github
       name: xamarin/yaml-templates
       endpoint: xamarin
-      ref: refs/heads/main
+      ref: refs/heads/dev/pjc/msi-arcade-05c72bb
     - repository: sdk-insertions
       type: github
       name: xamarin/sdk-insertions

--- a/eng/pipelines/maui-release.yml
+++ b/eng/pipelines/maui-release.yml
@@ -67,7 +67,7 @@ resources:
       type: github
       name: xamarin/yaml-templates
       endpoint: xamarin
-      ref: refs/heads/dev/pjc/msi-arcade-05c72bb
+      ref: refs/heads/main
     - repository: sdk-insertions
       type: github
       name: xamarin/sdk-insertions


### PR DESCRIPTION
Context: https://github.com/dotnet/arcade/commit/b2d3a3a35526b529490e8f7e410b3777b3f20bd6
Context: https://github.com/xamarin/yaml-templates/pull/339

The VS insertion manifest generation has been updated to use new VS
component IDs required for .NET 9+.