### PR TITLE
Fix memory leak on repeated Animations

### DIFF
--- a/src/Controls/src/Core/AnimatableKey.cs
+++ b/src/Controls/src/Core/AnimatableKey.cs
@@ -28,21 +28,6 @@ namespace Microsoft.Maui.Controls
 
 		public override bool Equals(object obj)
 		{
-
-			/* Unmerged change from project 'Controls.Core(net7.0-windows10.0.20348)'
-			Before:
-						if (ReferenceEquals(null, obj))
-						{
-							return false;
-						}
-						if (ReferenceEquals(this, obj))
-						{
-							return true;
-						}
-						if (obj.GetType() != GetType())
-			After:
-						if (obj is null)
-			*/
 			if (obj is null)
 			{
 				return false;

--- a/src/Controls/src/Core/AnimationExtensions.cs
+++ b/src/Controls/src/Core/AnimationExtensions.cs
@@ -275,14 +275,22 @@ namespace Microsoft.Maui.Controls
 
 			if (self is VisualElement ve)
 			{
-				ve.Unloaded += (s, e) =>
-				{
-					s_animations.Remove(key);
-				};
+				ve.Unloaded += OnVisualElementUnloaded;
 			}
 
 			info.Callback(0.0f);
 			tweener.Start();
+
+			void OnVisualElementUnloaded(object sender, EventArgs args)
+			{
+				if (sender is not VisualElement visualElement)
+				{
+					return;
+				}
+
+				s_animations.Remove(key);
+				visualElement.Unloaded -= OnVisualElementUnloaded;
+			}
 		}
 
 		static void AnimateKineticInternal(IAnimatable self, IAnimationManager animationManager, string name, Func<double, double, bool> callback, double velocity, double drag, Action finished = null)

--- a/src/Controls/src/Core/AnimationExtensions.cs
+++ b/src/Controls/src/Core/AnimationExtensions.cs
@@ -67,6 +67,12 @@ namespace Microsoft.Maui.Controls
 			};
 			s_tweeners[id] = animation;
 			animation.Commit(animationManager);
+
+			animation.Finished += () =>
+			{
+				s_tweeners.TryRemove(id, out _);
+				animation.Finished = null;
+			};
 			return id;
 		}
 
@@ -81,6 +87,13 @@ namespace Microsoft.Maui.Controls
 			};
 			s_tweeners[id] = animation;
 			animation.Commit(animationManager);
+
+			animation.Finished += () =>
+			{
+				s_tweeners.TryRemove(id, out _);
+				animation.Finished = null;
+			};
+
 			return id;
 		}
 

--- a/src/Controls/src/Core/AnimationExtensions.cs
+++ b/src/Controls/src/Core/AnimationExtensions.cs
@@ -273,6 +273,14 @@ namespace Microsoft.Maui.Controls
 
 			s_animations[key] = info;
 
+			if (self is VisualElement ve)
+			{
+				ve.Unloaded += (s, e) =>
+				{
+					s_animations.Remove(key);
+				};
+			}
+
 			info.Callback(0.0f);
 			tweener.Start();
 		}

--- a/src/Controls/src/Core/Tweener.cs
+++ b/src/Controls/src/Core/Tweener.cs
@@ -34,6 +34,8 @@ namespace Microsoft.Maui.Controls
 	{
 		readonly Func<long, bool> _step;
 
+
+
 		public TweenerAnimation(Func<long, bool> step)
 		{
 			_step = step;
@@ -43,6 +45,9 @@ namespace Microsoft.Maui.Controls
 		{
 			var running = _step.Invoke((long)millisecondsSinceLastUpdate);
 			HasFinished = !running;
+
+			if (HasFinished)
+				Finished?.Invoke();
 		}
 
 		internal override void ForceFinish()


### PR DESCRIPTION
### Description of Change

<!-- Enter description of the fix in this section -->
Register a callback to run when animation finishes, removing it from the `s_tweeners` collection. 

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #25001

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->

How the gcdump diff looks like now
![image](https://github.com/user-attachments/assets/434af3dd-11e5-49f2-a8ff-b25583961b52)

![image](https://github.com/user-attachments/assets/9ca1befa-f4e6-4701-8ba8-7382f789b7a8)

