### PR TITLE
Fix for Frame PanGestureRecognizer is not working in Android 

### DIFF
--- a/src/Controls/src/Core/Compatibility/Android/Renderers/MotionEventHelper.cs
+++ b/src/Controls/src/Core/Compatibility/Android/Renderers/MotionEventHelper.cs
@@ -23,7 +23,8 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 				return false;
 			}
 
-			return true;
+           // We should consider the InputTransparent for the VisualElement and decides to pass touch to the event
+			return ShouldPassThroughElement();
 		}
 
 		public void UpdateElement(VisualElement element)

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue16978.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue16978.xaml
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Maui.Controls.Sample.Issues.Issue16978"
+             AutomationId="FrameGesturePage">
+    <ContentPage.Content>
+    <Grid BackgroundColor="Red" Margin="5">
+      <Grid.GestureRecognizers>
+        <PanGestureRecognizer PanUpdated="PanGestureRecognizer_PanUpdated" />
+      </Grid.GestureRecognizers>
+      <Frame x:Name="getStartedFrame"
+               Margin="0"
+               Padding="0"
+               Background="#10556C"
+               BorderColor="Transparent"
+               CornerRadius="10"
+               HorizontalOptions="FillAndExpand"
+               Opacity="0.7"
+               VerticalOptions="FillAndExpand"
+               HasShadow="False" />
+    </Grid>
+
+  </ContentPage.Content>
+</ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue16978.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue16978.xaml
@@ -17,7 +17,9 @@
                HorizontalOptions="FillAndExpand"
                Opacity="0.7"
                VerticalOptions="FillAndExpand"
-               HasShadow="False" />
+               HasShadow="False" >
+        <Label x:Name="FrameLabel" AutomationId="FrameLabelTest" Text="Gesture is not detected" VerticalOptions="Start" HeightRequest="50"/>
+      </Frame>
     </Grid>
 
   </ContentPage.Content>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue16978.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue16978.xaml
@@ -6,7 +6,7 @@
     <ContentPage.Content>
     <Grid BackgroundColor="Red" Margin="5">
       <Grid.GestureRecognizers>
-        <PanGestureRecognizer PanUpdated="PanGestureRecognizer_PanUpdated" />
+        <TapGestureRecognizer Tapped="TapGestureRecognizer_Tapped" />
       </Grid.GestureRecognizers>
       <Frame x:Name="getStartedFrame"
                Margin="0"

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue16978.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue16978.xaml.cs
@@ -6,6 +6,9 @@ using System.Threading.Tasks;
 
 namespace Maui.Controls.Sample.Issues
 {
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	[Issue(IssueTracker.Github, 16978, "[Android]PanGestureRecognizer is not updated for Frame",
+	PlatformAffected.Android)]
 	public partial class Issue16978 : ContentPage
 	{
 		public Issue16978()

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue16978.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue16978.xaml.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Maui.Controls.Sample.Issues
+{
+	public partial class Issue16978 : ContentPage
+	{
+		public Issue16978()
+		{
+			InitializeComponent();
+		}
+		private void PanGestureRecognizer_PanUpdated(object sender, PanUpdatedEventArgs e)
+		{
+			(sender as Grid).BackgroundColor = Colors.GreenYellow;
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue16978.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue16978.xaml.cs
@@ -17,7 +17,7 @@ namespace Maui.Controls.Sample.Issues
 		}
 		private void PanGestureRecognizer_PanUpdated(object sender, PanUpdatedEventArgs e)
 		{
-			(sender as Grid).BackgroundColor = Colors.GreenYellow;
+			FrameLabel.Text = "Pan Gesture Recognized";
 		}
 	}
 }

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue16978.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue16978.xaml.cs
@@ -15,9 +15,10 @@ namespace Maui.Controls.Sample.Issues
 		{
 			InitializeComponent();
 		}
-		private void PanGestureRecognizer_PanUpdated(object sender, PanUpdatedEventArgs e)
+
+		private void TapGestureRecognizer_Tapped(object sender, TappedEventArgs e)
 		{
-			FrameLabel.Text = "Pan Gesture Recognized";
+			FrameLabel.Text = "Tap Gesture Recognized";
 		}
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue16978.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue16978.cs
@@ -1,5 +1,4 @@
-﻿#if !WINDOWS
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
 
@@ -19,12 +18,10 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		public void GestureNotRecogonizedForFrame()
 		{
 			// Is a Android issue; see https://github.com/dotnet/maui/issues/16978
-			App.WaitForElement("FrameGesturePage");
-			App.DragCoordinates(100, 100, 200, 200);
+			App.WaitForElement("FrameLabelTest");
+			App.Tap("FrameLabelTest");
 		    var result = App.WaitForElement("FrameLabelTest").GetText();
-			Assert.That(result, Is.EqualTo("Pan Gesture Recognized"));
+			Assert.That(result, Is.EqualTo("Tap Gesture Recognized"));
 		}
 	}
 }
-#endif
-

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue16978.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue16978.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿#if !WINDOWS
+using NUnit.Framework;
 using NUnit.Framework.Legacy;
 using UITest.Appium;
 using UITest.Core;
@@ -21,8 +22,9 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 			// Is a Android issue; see https://github.com/dotnet/maui/issues/16978
 			App.WaitForElement("FrameGesturePage");
 			App.DragCoordinates(100, 100, 200, 200);
-			VerifyScreenshot();
+			ClassicAssert.AreEqual("Triggered", App.FindElement("FrameLabelTest").GetText());
 		}
 	}
 }
+#endif
 

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue16978.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue16978.cs
@@ -1,0 +1,28 @@
+﻿using NUnit.Framework;
+using NUnit.Framework.Legacy;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	internal class Issue16978 : _IssuesUITest
+	{
+		public override string Issue => "[Android]Editor controls don't raise Completed event consistently";
+
+		public Issue16978(TestDevice device) : base(device)
+		{
+		}
+
+		[Test]
+		[Category(UITestCategories.Frame)]
+		[Category(UITestCategories.Gestures)]
+		public void GestureNotRecogonizedForFrame()
+		{
+			// Is a Android issue; see https://github.com/dotnet/maui/issues/16978
+			App.WaitForElement("FrameGesturePage");
+			App.DragCoordinates(100, 100, 200, 200);
+			VerifyScreenshot();
+		}
+	}
+}
+

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue16978.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue16978.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 {
 	internal class Issue16978 : _IssuesUITest
 	{
-		public override string Issue => "[Android]Editor controls don't raise Completed event consistently";
+		public override string Issue => "[Android]PanGestureRecognizer is not updated for Frame";
 
 		public Issue16978(TestDevice device) : base(device)
 		{

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue16978.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue16978.cs
@@ -1,6 +1,5 @@
 ﻿#if !WINDOWS
 using NUnit.Framework;
-using NUnit.Framework.Legacy;
 using UITest.Appium;
 using UITest.Core;
 
@@ -22,7 +21,8 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 			// Is a Android issue; see https://github.com/dotnet/maui/issues/16978
 			App.WaitForElement("FrameGesturePage");
 			App.DragCoordinates(100, 100, 200, 200);
-			ClassicAssert.AreEqual("Triggered", App.FindElement("FrameLabelTest").GetText());
+		    var result = App.WaitForElement("FrameLabelTest").GetText();
+			Assert.That(result, Is.EqualTo("Pan Gesture Recognized"));
 		}
 	}
 }


### PR DESCRIPTION
### Root Cause

The touch events in the Frame control on the Android platform are not handled correctly. Specifically, in the FrameRenderer, the touch event handler consistently returns true, which suppresses the default behavior and prevents the expected response to touch interactions.

### Description of Change 
The MotionEventHelper class contains a method called ShouldPassThroughElement(), which is designed to evaluate whether a touch event should be passed through an element. Utilizing this method will ensure correct touch handling, thereby resolving the issue

### Issues Fixed
Fixes #16978

### Output Video
Before Issue Fix | After Issue Fix |
|----------|----------|
|<video width="300" height="600" alt="Before Fix video" src="https://github.com/user-attachments/assets/070c3e5e-3a25-4c82-a884-e6cfa3cf0307">|<video width="300" height="600" alt="After Fix video" src="https://github.com/user-attachments/assets/bb2a788d-239a-43c9-8925-185fbf5ea787">|