### PR TITLE
[Testing] Navigate directly to control tests

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/CoreViews/CoreGalleryBasePage.cs
+++ b/src/Controls/tests/TestCases.HostApp/CoreViews/CoreGalleryBasePage.cs
@@ -48,10 +48,10 @@ namespace Maui.Controls.Sample
 					new Button()
 					{
 						Text = "Dismiss Page",
-						Command = new Command(async () =>
+						Command = new Command(() =>
 						{
 							if (_picker.SelectedIndex == 0)
-								await Navigation.PopAsync();
+								Application.Current.Quit();
 							else
 								_picker.SelectedIndex--;
 						})

--- a/src/Controls/tests/TestCases.HostApp/CoreViews/CorePageView.cs
+++ b/src/Controls/tests/TestCases.HostApp/CoreViews/CorePageView.cs
@@ -123,7 +123,7 @@ namespace Maui.Controls.Sample
 			ItemTemplate = template;
 			ItemsSource = _pages;
 
-			ItemSelected += async (sender, args) =>
+			ItemSelected += (sender, args) =>
 			{
 				if (SelectedItem == null)
 				{
@@ -134,14 +134,8 @@ namespace Maui.Controls.Sample
 				if (item is GalleryPageFactory page)
 				{
 					var realize = page.Realize();
-					if (realize is Shell)
-					{
-						Application.Current.MainPage = realize;
-					}
-					else
-					{
-						await PushPage(realize);
-					}
+
+					Application.Current.MainPage = new NavigationPage(realize);
 				}
 
 				SelectedItem = null;

--- a/src/Controls/tests/TestCases.HostApp/CoreViews/CorePageView.cs
+++ b/src/Controls/tests/TestCases.HostApp/CoreViews/CorePageView.cs
@@ -135,7 +135,7 @@ namespace Maui.Controls.Sample
 				{
 					var realize = page.Realize();
 
-					Application.Current.MainPage = new NavigationPage(realize);
+					Application.Current.MainPage = realize;
 				}
 
 				SelectedItem = null;


### PR DESCRIPTION
### Description of Change

Related with https://github.com/dotnet/maui/pull/22019

We now reset the App after every single test run as well so that each test gets a fresh run of the app to work with. This PR apply changes to navigate directly to the control test scenario we want like we already did with the issues test cases.

The visual hierarchy is simplified and navigation time is reduced. It also maintains a single NavigationBar.

Before
![ios-nav-test-before](https://github.com/user-attachments/assets/c215e031-1caa-42e6-9f19-cf436d4c0f0b)

After
![ios-nav-test-after](https://github.com/user-attachments/assets/a98a272a-a345-41dc-8648-3112f95dd8ae)