### PR TITLE
[Testing] Implement WaitForFirstElement method to UITest extension methods

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Bugzilla/Bugzilla51825.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Bugzilla/Bugzilla51825.cs
@@ -1,9 +1,11 @@
 ﻿using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using UITest.Appium;
 using UITest.Core;
 
 namespace Microsoft.Maui.TestCases.Tests.Issues;
 
+[Category(UITestCategories.SearchBar)]
 public class Bugzilla51825 : _IssuesUITest
 {
 	public Bugzilla51825(TestDevice testDevice) : base(testDevice)
@@ -12,25 +14,25 @@ public class Bugzilla51825 : _IssuesUITest
 
 	public override string Issue => "[iOS] Korean input in SearchBar doesn't work";
 
-// 	[Test]
-// 	[FailsOnIOS]
-// 	public void Bugzilla51825Test()
-// 	{
-// 		RunningApp.WaitForElement(q => q.Marked("Bugzilla51825SearchBar"));
-// 		RunningApp.EnterText("Bugzilla51825SearchBar", "Hello");
-// 		var label = RunningApp.WaitForFirstElement("Bugzilla51825Label");
+	[Test]
+	[FailsOnIOS]
+	public void Bugzilla51825Test()
+	{
+		App.WaitForElement("Bugzilla51825SearchBar");
+		App.EnterText("Bugzilla51825SearchBar", "Hello");
+		var label = App.WaitForFirstElement("Bugzilla51825Label");
 
-// 		Assert.IsNotEmpty(label.ReadText());
+		ClassicAssert.IsNotEmpty(label.ReadText());
 
-// 		// Windows App Driver and the Search Bar are a bit buggy
-// 		// It randomly doesn't enter the first letter
-// #if !WINDOWS
-// 		Assert.AreEqual("Hello", label.ReadText());
-// #endif
+		// Windows App Driver and the Search Bar are a bit buggy
+		// It randomly doesn't enter the first letter
+#if !WINDOWS
+		ClassicAssert.AreEqual("Hello", label.ReadText());
+#endif
 
-// 		RunningApp.Tap("Bugzilla51825Button");
+		App.Tap("Bugzilla51825Button");
 
-// 		var labelChange2 = RunningApp.WaitForFirstElement("Bugzilla51825Label");
-// 		Assert.AreEqual("Test", labelChange2.ReadText());
-// 	}
+		var labelChange2 = App.WaitForFirstElement("Bugzilla51825Label");
+		ClassicAssert.AreEqual("Test", labelChange2.ReadText());
+	}
 }

--- a/src/TestUtils/src/UITest.Appium/HelperExtensions.cs
+++ b/src/TestUtils/src/UITest.Appium/HelperExtensions.cs
@@ -53,6 +53,9 @@ namespace UITest.Appium
 			return (string?)response.Value;
 		}
 
+		public static string? ReadText(this IUIElement element)
+			=> element.GetText();
+
 		public static T? GetAttribute<T>(this IUIElement element, string attributeName)
 		{
 			var response = element.Command.Execute("getAttribute", new Dictionary<string, object>()
@@ -399,6 +402,22 @@ namespace UITest.Appium
 			TimeSpan? retryFrequency = null)
 		{
 			Wait(query, i => i is null, timeoutMessage, timeout, retryFrequency);
+		}
+
+		public static IUIElement WaitForFirstElement(this IApp app, string marked, string timeoutMessage = "Timed out waiting for element...", TimeSpan? timeout = null, TimeSpan? retryFrequency = null, TimeSpan? postTimeout = null)
+		{
+			IReadOnlyCollection<IUIElement> elements = app.FindElements(marked);
+
+			if(elements is not null && elements.Count > 0)
+			{
+				IUIElement firstElement() => elements.First();
+				
+				var result = Wait(firstElement, i => i != null, timeoutMessage, timeout, retryFrequency);
+
+				return result;
+			}
+
+			return WaitForElement(app, marked, timeoutMessage, timeout, retryFrequency, postTimeout);
 		}
 
 		public static bool WaitForTextToBePresentInElement(this IApp app, string automationId, string text, TimeSpan? timeout = null)


### PR DESCRIPTION
### Description of Change

Implement WaitForFirstElement method to UITest extension methods.

Example:

`var element = App.WaitForFirstElement("ElementAutomationId");`