### PR TITLE
[ci] Try skip install android stuff on handlers build

### DIFF
--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -167,6 +167,9 @@ stages:
                 parameters:
                   poolName: ${{ BuildPlatform.poolName }}
                   gitHubToken: $(github--pat--vs-mobiletools-engineering-service2)
+                  skipAndroidSdks: true
+                  skipAndroidImages: true
+                  installDefaultAndroidApi: true
               - pwsh: ./build.ps1 --target=dotnet --configuration="${{ BuildConfiguration }}" --verbosity=diagnostic
                 displayName: 'Install .NET'
                 retryCountOnTaskFailure: 3
@@ -234,7 +237,9 @@ stages:
                       checkoutDirectory: '$(System.DefaultWorkingDirectory)'
                       provisionatorChannel: ${{ parameters.provisionatorChannel }}
                       gitHubToken: $(github--pat--vs-mobiletools-engineering-service2)
+                      skipAndroidSdks: true
                       skipAndroidImages: true
+                      installDefaultAndroidApi: true
 
   - stage: samples_net
     displayName: Test .NET MAUI Samples
@@ -256,6 +261,9 @@ stages:
             - template: common/provision.yml
               parameters:
                 poolName: ${{ BuildPlatform.poolName }}
+                skipAndroidSdks: true
+                skipAndroidImages: true
+                installDefaultAndroidApi: true
 
             - task: DownloadBuildArtifacts@0
               displayName: 'Download Packages'


### PR DESCRIPTION
### Description of Change

We don t need to always install the android images for every normal build
