### PR TITLE
Initialize ResourceDictionaryHelpers.SetAndLoadSource when XAML Hot Reload is enabled

### DIFF
--- a/src/Controls/src/Xaml/ResourceDictionaryHelpers.cs
+++ b/src/Controls/src/Xaml/ResourceDictionaryHelpers.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Maui.Controls.Xaml
 		internal static void Init()
 		{
 			// This code will be trimmed in production builds
-			if (HotReload.MauiHotReloadHelper.IsSupported)
+			if (VisualDiagnostics.IsEnabled)
 			{
 #pragma warning disable IL2026, IL3050
 				ResourceDictionary.s_setAndLoadSource = ResourceDictionaryHelpers.SetAndLoadSource;


### PR DESCRIPTION
NOTE: This change is for the net9.0 branch and the bug linked below won't repro for .NET 8.

MAUI Full Page Hot Reload was broken for `ResourceDictionary` on Android because the method `ResourceDictionaryHotReloadHelper.Init()` did not initialize `ResourceDictionaryHelpers.SetAndLoadSource`.

Fixes bug:
* https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2276173

The code was added in this PR by @simonrozsival:
* https://github.com/dotnet/maui/pull/23683

On Android, the call to `HotReload.MauiHotReloadHelper.IsSupported` returns false. So, either `IsSupported`'s result is wrong, or the check needs to be replaced. I think checking for `VisualDiagnostics.IsEnabled` is better because that will be true any time XAML Hot Reload could be enabled.

I have no idea how this could affect code trimming, so that might affect the fix.

The bug shows that when ResourceDictionary is edited for Android, this error appears in Visual Studio or VSCode when they try to hot reload the XAML:
![image](https://github.com/user-attachments/assets/1ec18229-f4af-4c8d-bb60-c68f3700bfd4)
