### PR TITLE
[Testing] Implement Pan method to UITest extension methods

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Bugzilla/Bugzilla39530.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Bugzilla/Bugzilla39530.cs
@@ -1,4 +1,6 @@
-﻿using NUnit.Framework;
+﻿using System.Drawing;
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using UITest.Appium;
 using UITest.Core;
 
@@ -13,46 +15,46 @@ public class Bugzilla39530 : _IssuesUITest
 
 	public override string Issue => "Frames do not handle pan or pinch gestures under AppCompat";
 
-// TODO From Xamarin.UITest migration: does some advanced XamUITest operations
-// Need to find Appium equivalents
-// 	[Test]
-// #if __MACOS__
-// 	[Ignore("UITest.Desktop doesn't return empty NSView yet so it can't find the frame")]
-// #endif
-// 	[FailsOnIOS]
-// 	public void Bugzilla39530PanTest()
-// 	{
-// 		// Got to wait for the element to be visible to the UI test framework, otherwise we get occasional 
-// 		// index out of bounds exceptions if the query for the frame and its Rect run quickly enough
-// 		App.WaitForElement(q => q.Marked("frame"));
-// 		AppRect frameBounds = App.Query (q => q.Marked ("frame"))[0].Rect;
-// 		App.Pan (new Drag (frameBounds, frameBounds.CenterX, frameBounds.Y + 10, frameBounds.X + 100, frameBounds.Y + 100, Drag.Direction.LeftToRight));
+	[Test]
+	[FailsOnIOS]
+	[FailsOnMac]
+	public void Bugzilla39530PanTest()
+	{
+		if (App is not AppiumApp app2 || app2 is null || app2.Driver is null)
+		{
+			throw new InvalidOperationException("Cannot run test. Missing driver to run quick tap actions.");
+		}
 
-// 		App.WaitForElement (q => q.Marked ("Panning: Completed"));
-// 	}
+		// Got to wait for the element to be visible to the UI test framework, otherwise we get occasional 
+		// index out of bounds exceptions if the query for the frame and its Rect run quickly enough
+		App.WaitForElement("frame");
+		Rectangle frameBounds = App.FindElement("frame").GetRect();
+		App.Pan(frameBounds.CenterX(), frameBounds.Y + 10, frameBounds.X + 100, frameBounds.Y + 100);
+		App.WaitForElement("Panning: Completed");
+		var result = app2.Driver.FindElement(OpenQA.Selenium.By.XPath("//*[@text='" + "Panning: Completed" + "']"));
+		ClassicAssert.IsNotEmpty(result.Text);
+	}
 
-// 	[Test]
-// #if __MACOS__
-// 	[Ignore("UITest.Desktop doesn't return empty NSView yet so it can't find the frame")]
-// #endif
-// 	[FailsOnIOS]
-// 	public void Bugzilla39530PinchTest()
-// 	{
-// 		App.PinchToZoomIn ("frame");
-// 		App.WaitForElement(q => q.Marked("Pinching: Completed"));
-// 	}
+	/*
+	[Test]
+	[FailsOnIOS]	
+	[FailsOnMac]
+	public void Bugzilla39530PinchTest()
+	{
+		App.PinchToZoomIn("frame");
+		App.WaitForElement(q => q.Marked("Pinching: Completed"));
+	}
 
-// 	[Test]
-// #if __MACOS__
-// 	[Ignore("UITest.Desktop doesn't return empty NSView yet so it can't find the frame")]
-// #endif
-// 	[FailsOnIOS]
-// 	public void Bugzilla39530TapTest()
-// 	{
-// 		App.WaitForElement (q => q.Marked ("frame"));
-// 		App.Tap ("frame");
-// 		App.WaitForElement (q => q.Marked ("Taps: 1"));
-// 		App.Tap ("frame");
-// 		App.WaitForElement (q => q.Marked ("Taps: 2"));
-// 	}
+	[Test]
+	[FailsOnIOS]
+	[FailsOnMac]
+	public void Bugzilla39530TapTest()
+	{
+		App.WaitForElement("frame");
+		App.Tap("frame");
+		App.WaitForElement("Taps: 1");
+		App.Tap("frame");
+		App.WaitForElement("Taps: 2");
+	}
+	*/
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Bugzilla/Bugzilla39530.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Bugzilla/Bugzilla39530.cs
@@ -18,6 +18,7 @@ public class Bugzilla39530 : _IssuesUITest
 	[Test]
 	[FailsOnIOS]
 	[FailsOnMac]
+	[FailsOnWindows("Fails finding the frame element. Investigate the cause.")]
 	public void Bugzilla39530PanTest()
 	{
 		if (App is not AppiumApp app2 || app2 is null || app2.Driver is null)

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Bugzilla/Bugzilla39530.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Bugzilla/Bugzilla39530.cs
@@ -30,7 +30,6 @@ public class Bugzilla39530 : _IssuesUITest
 		App.WaitForElement("frame");
 		Rectangle frameBounds = App.FindElement("frame").GetRect();
 		App.Pan(frameBounds.CenterX(), frameBounds.Y + 10, frameBounds.X + 100, frameBounds.Y + 100);
-		App.WaitForElement("Panning: Completed");
 		var result = app2.Driver.FindElement(OpenQA.Selenium.By.XPath("//*[@text='" + "Panning: Completed" + "']"));
 		ClassicAssert.IsNotEmpty(result.Text);
 	}

--- a/src/TestUtils/src/UITest.Appium/HelperExtensions.cs
+++ b/src/TestUtils/src/UITest.Appium/HelperExtensions.cs
@@ -812,6 +812,19 @@ namespace UITest.Appium
 		}
 
 		/// <summary>
+		/// Performs a pan gesture between 2 points.
+		/// </summary>
+		/// <param name="app">Represents the main gateway to interact with an app.</param>
+		/// <param name="fromX">The x coordinate to start panning from.</param>
+		/// <param name="fromY">The y coordinate to start panning from.</param>
+		/// <param name="toX">The x coordinate to pan to.</param>
+		/// <param name="toY">The y coordinate to pan to.</param>
+		public static void Pan(this IApp app, float fromX, float fromY, float toX, float toY)
+		{
+			app.DragCoordinates(fromX, fromY, toX, toY);
+		}
+
+		/// <summary>
 		/// Navigate back on the device.
 		/// </summary>
 		/// <param name="app">Represents the main gateway to interact with an app.</param>


### PR DESCRIPTION
### Description of Change

Implement **Pan** method to UITest extension methods.

Example:

`App.Pan(frameBounds.CenterX(), frameBounds.Y + 10, frameBounds.X + 100, frameBounds.Y + 100);`