### PR TITLE
[Testing] Implement QueryUntilPresent method to UITest extension methods

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue6286.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue6286.cs
@@ -1,0 +1,56 @@
+﻿namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 6286, "ObjectDisposedException in Android WebView.EvaluateJavascriptAsync", PlatformAffected.Android)]
+public class Issue6286 : TestNavigationPage
+{
+	WebView _webview;
+	WebView _webview2;
+	ContentPage _page1;
+	ContentPage _page2;
+
+	protected override void Init()
+	{
+		_webview = new WebView { Source = "https://microsoft.com" };
+		_webview.Navigated += OnWebviewNavigated;
+		_page1 = new ContentPage { Content = _webview };
+
+		_webview2 = new WebView { Source = "https://google.com" };
+		_webview2.Navigated += OnWebviewNavigated;
+		_page2 = new ContentPage { Content = _webview2 };
+
+		Navigation.PushAsync(_page1);
+		RunTest();
+	}
+
+	async void RunTest()
+	{
+		try
+		{
+			int count = 0;
+			while (count < 3)
+			{
+				await Task.Delay(2000);
+				count++;
+
+				_webview.Source = "https://google.com";
+				await Navigation.PushAsync(_page2);
+
+				_webview2.Source = "https://microsoft.com";
+				await Navigation.PopAsync();
+			}
+
+			_page1.Content = new Label { Text = "success", AutomationId = "success" };
+		}
+		catch (Exception exc)
+		{
+			_page1.Content = new Label { Text = $"{exc}", AutomationId = "failure" };
+		}
+	}
+
+	async void OnWebviewNavigated(object sender, WebNavigatedEventArgs e)
+	{
+		await _webview.EvaluateJavaScriptAsync("document.write('i executed this javascript woohoo');");
+
+		await _webview2.EvaluateJavaScriptAsync("document.write('i executed this javascript woohoo');");
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue6286.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue6286.cs
@@ -1,0 +1,23 @@
+﻿#if ANDROID
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+internal class Issue6286 : _IssuesUITest
+{
+	public Issue6286(TestDevice testDevice) : base(testDevice)
+	{
+	}
+
+	public override string Issue => "ObjectDisposedException in Android WebView.EvaluateJavascriptAsync";
+
+	[Test]
+	[Category(UITestCategories.WebView)]
+	public void Issue6286_WebView_Test()
+	{
+		App.QueryUntilPresent(() => App.WaitForElement("success"));
+	}
+}
+#endif

--- a/src/TestUtils/src/UITest.Appium/HelperExtensions.cs
+++ b/src/TestUtils/src/UITest.Appium/HelperExtensions.cs
@@ -429,6 +429,62 @@ namespace UITest.Appium
 		}
 
 		/// <summary>
+		/// Repeatedly executes a query until it returns a non-empty value or the specified retry count is reached.
+		/// </summary>
+		/// <typeparam name="T">The type of the element.</typeparam>
+		/// <param name="app">Represents the main gateway to interact with an app.</param>
+		/// <param name="func">The query to execute.</param>
+		/// <param name="retryCount">The number of times to retry execution. Default is 10.</param>
+		/// <param name="delayInMs">The delay in milliseconds between retries. Default is 2000ms.</param>
+		/// <returns>An value of type T.</returns>
+		public static T QueryUntilPresent<T>(
+			this IApp app,
+			Func<T> func,
+			int retryCount = 10,
+			int delayInMs = 2000)
+		{
+			var result = func();
+
+			int counter = 0;
+			while ((result is null) && counter < retryCount)
+			{
+				Thread.Sleep(delayInMs);
+				result = func();
+				counter++;
+			}
+
+			return result;
+		}
+
+		/// <summary>
+		/// Repeatedly executes a query until it returns a null value or the specified retry count is reached.
+		/// </summary>
+		/// <typeparam name="T">The type of the element.</typeparam>
+		/// <param name="app">Represents the main gateway to interact with an app.</param>
+		/// <param name="func">The query to execute.</param>
+		/// <param name="retryCount">The number of times to retry execution. Default is 10.</param>
+		/// <param name="delayInMs">The delay in milliseconds between retries. Default is 2000ms.</param>
+		/// <returns>An value of type T.</returns>
+		public static T QueryUntilNotPresent<T>(
+			this IApp app,
+			Func<T> func,
+			int retryCount = 10,
+			int delayInMs = 2000)
+		{
+			var result = func();
+
+			int counter = 0;
+			while ((result is not null) && counter < retryCount)
+			{
+				Thread.Sleep(delayInMs);
+				result = func();
+				counter++;
+			}
+
+			return result;
+		}
+
+		/// <summary>
 		/// Presses the volume up button on the device.
 		/// </summary>
 		/// <param name="app">Represents the main gateway to interact with an app.</param>


### PR DESCRIPTION
### Description of Change

Implement **QueryUntilPresent** and QueryUntilNoPresent method to UITest extension methods.

Example:

`App.QueryUntilPresent(() => App.WaitForElement("success"));`