### PR TITLE
Fix SafeArea adjustments

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue24246.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue24246.xaml
@@ -1,0 +1,10 @@
+﻿<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Maui.Controls.Sample.Issues.Issue24246"
+             Title="Issue24246"
+             xmlns:ios="clr-namespace:Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific;assembly=Microsoft.Maui.Controls"
+             ios:Page.UseSafeArea="false">
+      <VerticalStackLayout x:Name="layout" Background="Purple" IgnoreSafeArea="False" VerticalOptions="Start" IsClippedToBounds="True" >
+        <Entry x:Name="label" Background="Green" Text="Hello there"></Entry>
+    </VerticalStackLayout>
+</ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue24246.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue24246.xaml.cs
@@ -1,0 +1,11 @@
+namespace Maui.Controls.Sample.Issues;
+
+
+[Issue(IssueTracker.Github, 24246, "SafeArea arrange insets are currently insetting based on an incorrect Bounds", PlatformAffected.iOS)]
+public partial class Issue24246 : ContentPage
+{
+	public Issue24246()
+	{
+		InitializeComponent();
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue24246.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue24246.cs
@@ -1,0 +1,26 @@
+﻿using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue24246 : _IssuesUITest
+	{
+		public Issue24246(TestDevice testDevice) : base(testDevice)
+		{
+		}
+
+		public override string Issue => "SafeArea arrange insets are currently insetting based on an incorrect Bounds";
+
+		[Test]
+		[Category(UITestCategories.Layout)]
+		public void TapThenDoubleTap()
+		{
+			App.WaitForElement("entry");
+			App.EnterText("entry", "Hello, World!");
+
+			var result = App.WaitForElement("entry").GetText();
+			Assert.That(result, Is.EqualTo("Hello, World!"));
+		}
+	}
+}

--- a/src/Core/src/Platform/iOS/MauiScrollView.cs
+++ b/src/Core/src/Platform/iOS/MauiScrollView.cs
@@ -9,6 +9,8 @@ namespace Microsoft.Maui.Platform
 	{
 		public MauiScrollView()
 		{
+			// By setting this to 'Never', we take full control of the content layout and manage the insets manually in our code, avoiding any automatic adjustments by the system.
+			ContentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentBehavior.Never;
 		}
 
 		// overriding this method so it does not automatically scroll large UITextFields


### PR DESCRIPTION
### Description of Change

Added `ContentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentBehavior.Never;` to changes in this PR: https://github.com/dotnet/maui/pull/23729

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/25266
Fixes https://github.com/dotnet/maui/issues/24246

|Before|After|
|--|--|
|<video src="https://github.com/user-attachments/assets/31be7a24-df96-4657-abb4-5f1b8481fc3c" width="300px"/>|<video src="https://github.com/user-attachments/assets/dfffbe98-19c1-4f10-a164-4e96e1892b7f" width="300px"/>|
