### PR TITLE
Propagate any Page.Title to the window, not just for Shell

### DIFF
--- a/src/Controls/src/Core/Window/Window.cs
+++ b/src/Controls/src/Core/Window/Window.cs
@@ -107,7 +107,7 @@ namespace Microsoft.Maui.Controls
 			set => SetValue(TitleProperty, value);
 		}
 
-		string? ITitledElement.Title => Title ?? (Page as Shell)?.Title;
+		string? ITitledElement.Title => Title ?? Page?.Title;
 
 		public Page? Page
 		{


### PR DESCRIPTION
### Description of Change

Trying to fix the empty title bar in Blazor Hybrid templates by updating the `Title` property in the `Window.cs` file. I don't think there is any reason to cast it specifically to `Shell` as each `Page` could have a title.

Verified this change works! 👇 

![image](https://github.com/user-attachments/assets/dc0c0ecd-f725-430d-8777-16c60f12570c)

### Issues Fixed

Fixes #25337
