### PR TITLE
[XC] compile StaticResource w/ generics

### DIFF
--- a/src/Controls/src/Build.Tasks/CreateObjectVisitor.cs
+++ b/src/Controls/src/Build.Tasks/CreateObjectVisitor.cs
@@ -124,17 +124,6 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 				return;
 			}
 
-			if (IsXaml2009LanguagePrimitive(node))
-			{
-				var vardef = new VariableDefinition(typeref);
-				Context.Variables[node] = vardef;
-				Context.Body.Variables.Add(vardef);
-
-				Context.IL.Append(PushValueFromLanguagePrimitive(typedef, node));
-				Context.IL.Emit(Stloc, vardef);
-				return;
-			}
-
 			MethodDefinition factoryCtorInfo = null;
 			MethodDefinition factoryMethodInfo = null;
 			MethodDefinition parameterizedCtorInfo = null;
@@ -214,7 +203,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 					(vardef.VariableType.IsValueType || isColor))
 				{
 					//<Color>Purple</Color>
-					Context.IL.Append(vnode.PushConvertedValue(Context, typeref, new ICustomAttributeProvider[] { typedef },
+					Context.IL.Append(vnode.PushConvertedValue(Context, typeref, [typedef],
 						(requiredServices) => node.PushServiceProvider(Context, requiredServices),
 						false, true));
 					Context.IL.Emit(OpCodes.Stloc, vardef);
@@ -324,7 +313,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 				{
 					foreach (var instruction in vnode.PushConvertedValue(Context,
 						parameter.ParameterType,
-						new ICustomAttributeProvider[] { parameter, parameter.ParameterType.ResolveCached(Context.Cache) },
+						[parameter, parameter.ParameterType.ResolveCached(Context.Cache)],
 						(requiredServices) => enode.PushServiceProvider(Context, requiredServices),
 						false, true))
 						yield return instruction;
@@ -362,7 +351,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 				{
 					foreach (var instruction in vnode.PushConvertedValue(Context,
 						parameter.ParameterType,
-						new ICustomAttributeProvider[] { parameter, parameter.ParameterType.ResolveCached(Context.Cache) },
+						[parameter, parameter.ParameterType.ResolveCached(Context.Cache)],
 						(requiredServices) => enode.PushServiceProvider(Context, requiredServices),
 						false, true))
 						yield return instruction;

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui25309.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui25309.xaml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests"
+    xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
+    x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui25309">
+    <ContentPage.Resources>
+        <ResourceDictionary>
+            <Color x:Key="LightGray">#B1B3B3</Color>
+            <Color x:Key="myBlue">#140F4B</Color>
+
+            <local:Maui25309BoolToObjectConverter x:Key="IsValidConverter"
+                                           TrueObject="{StaticResource myBlue}"
+                                           FalseObject="{StaticResource LightGray}"/>
+        </ResourceDictionary>
+    </ContentPage.Resources>
+    <Label
+        x:Name="label"
+        Text="Hello, world!"
+        BackgroundColor="{Binding IsValid, Converter={StaticResource IsValidConverter}}" />
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui25309.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui25309.xaml.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using Microsoft.Maui.ApplicationModel;
+using Microsoft.Maui.Controls.Core.UnitTests;
+using Microsoft.Maui.Dispatching;
+using Microsoft.Maui.Graphics;
+using Microsoft.Maui.UnitTests;
+using NUnit.Framework;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+public partial class Maui25309 : ContentPage
+{
+    public Maui25309()
+    {
+        InitializeComponent();
+    }
+
+	public Maui25309(bool useCompiledXaml)
+	{
+		//this stub will be replaced at compile time
+	}
+
+    [TestFixture]
+    class Test
+    {
+        [SetUp]
+        public void Setup()
+        {
+            Application.SetCurrentApplication(new MockApplication());
+            DispatcherProvider.SetCurrent(new DispatcherProviderStub());
+        }
+
+        [TearDown] public void TearDown()
+        {
+            AppInfo.SetCurrent(null);
+        }
+
+        [Test]
+        public void GenericConvertersDoesNotThrowNRE([Values(true, false)] bool useCompiledXaml)
+        {
+			if (useCompiledXaml)			
+				Assert.DoesNotThrow(()=>MockCompiler.Compile(typeof(Maui25309)));
+			
+			var page = new Maui25309(useCompiledXaml) {BindingContext = new { IsValid = true }};
+            var converter = page.Resources["IsValidConverter"] as Maui25309BoolToObjectConverter;
+            Assert.IsNotNull(converter);
+            Assert.That(page.label.BackgroundColor, Is.EqualTo(Color.Parse("#140F4B")));
+        }
+    }
+}
+
+#nullable enable
+class Maui25309BoolToObjectConverter : Maui25309BoolToObjectConverter<object>
+{
+}
+
+public class Maui25309BoolToObjectConverter<TObject> : IValueConverter
+{
+    public TObject? TrueObject { get; set; }
+
+    public TObject? FalseObject { get; set; }
+
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture) {
+        bool boolValue = false;
+        if (value is bool bv)
+            boolValue = bv;
+
+        return boolValue ? TrueObject : FalseObject;
+    } 
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        throw new NotImplementedException();
+    }
+}


### PR DESCRIPTION
### Description of Change

{StaticResource} are now compiled when possible, there was an issue, throwing NRE, when the target property of the resource is of generic type.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

- fixes #25309


