### PR TITLE
[nuget-msi-convert] Do not use new VS component IDs

### DIFF
--- a/eng/automation/vs-workload.template.props
+++ b/eng/automation/vs-workload.template.props
@@ -4,7 +4,7 @@
     <TargetName>Microsoft.NET.Sdk.Maui.Workload.@VSMAN_VERSION@</TargetName>
     <ManifestBuildVersion>@VS_COMPONENT_VERSION@</ManifestBuildVersion>
     <EnableSideBySideManifests>true</EnableSideBySideManifests>
-    <UseVisualStudioComponentPrefix>true</UseVisualStudioComponentPrefix>
+    <UseVisualStudioComponentPrefix>false</UseVisualStudioComponentPrefix>
   </PropertyGroup>
   <ItemGroup>
     <!-- Shorten package names to avoid long path caching issues in Visual Studio -->


### PR DESCRIPTION
Context: https://github.com/dotnet/maui/commit/ce01c154f737bfbbf09c4fce2044de246ba199a7

We've decided hold off on this change until .NET 10.