### PR TITLE
[Android] Create `DatePickerDialog` on demand

### DIFF
--- a/src/Core/src/Handlers/DatePicker/DatePickerHandler.Android.cs
+++ b/src/Core/src/Handlers/DatePicker/DatePickerHandler.Android.cs
@@ -17,15 +17,10 @@ namespace Microsoft.Maui.Handlers
 				HidePicker = HidePickerDialog
 			};
 
-			var date = VirtualView?.Date;
-
-			if (date != null)
-				_dialog = CreateDatePickerDialog(date.Value.Year, date.Value.Month, date.Value.Day);
-
 			return mauiDatePicker;
 		}
 
-		internal DatePickerDialog? DatePickerDialog { get { return _dialog; } }
+		internal DatePickerDialog? DatePickerDialog { get { return _dialog ??= CreateDefaultDatePickerDialog(); } }
 
 		protected override void ConnectHandler(MauiDatePicker platformView)
 		{
@@ -64,6 +59,16 @@ namespace Microsoft.Maui.Handlers
 			base.DisconnectHandler(platformView);
 		}
 
+		DatePickerDialog? CreateDefaultDatePickerDialog()
+		{
+			var date = VirtualView?.Date;
+			if (date != null)
+			{
+				return CreateDatePickerDialog(date.Value.Year, date.Value.Month, date.Value.Day);
+			}
+			return null;
+		}
+
 		protected virtual DatePickerDialog CreateDatePickerDialog(int year, int month, int day)
 		{
 			var dialog = new DatePickerDialog(Context!, (o, e) =>
@@ -73,7 +78,11 @@ namespace Microsoft.Maui.Handlers
 					VirtualView.Date = e.Date;
 				}
 			}, year, month, day);
-
+			if (VirtualView != null)
+			{
+				dialog.DatePicker.MaxDate = (long)VirtualView.MaximumDate.ToUniversalTimeNative().Subtract(DateTime.MinValue.AddYears(1969)).TotalMilliseconds;
+				dialog.DatePicker.MinDate = (long)VirtualView.MinimumDate.ToUniversalTimeNative().Subtract(DateTime.MinValue.AddYears(1969)).TotalMilliseconds;
+			}
 			return dialog;
 		}
 

--- a/src/Core/src/Platform/Android/DatePickerExtensions.cs
+++ b/src/Core/src/Platform/Android/DatePickerExtensions.cs
@@ -53,6 +53,20 @@ namespace Microsoft.Maui.Platform
 			}
 		}
 
+		internal static DateTime ToUniversalTimeNative(this DateTime date)
+		{
+			if (date.Kind == DateTimeKind.Utc)
+			{
+				return date;
+			}
+			var timeZone = Java.Util.TimeZone.Default;
+			if (timeZone != null && date != DateTime.MaxValue && date != DateTime.MinValue)
+			{
+				return date.AddHours(-1 * (double)timeZone.RawOffset / 1000 / 60 / 60);
+			}
+			return date.ToUniversalTime();
+		}
+
 		internal static void SetText(this MauiDatePicker platformDatePicker, IDatePicker datePicker)
 		{
 			platformDatePicker.Text = datePicker.Date.ToString(datePicker.Format);


### PR DESCRIPTION
### Description of Change

This PR is an addition to https://github.com/dotnet/maui/pull/24948 and it further improves performance of first render of `DatePicker` by creating `DatePickerDialog` on demand instead of on control render.

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/24929

### Blockers

This PR should be merged after https://github.com/dotnet/maui/pull/20547 is merged since it might break workarounds like this one https://github.com/dotnet/maui/issues/12899#issuecomment-1403661769 