### PR TITLE
Creating .NET MAUI Project sometimes causes error *.png is being used  by another process

### DIFF
--- a/src/SingleProject/Resizetizer/src/SkiaSharpTools.cs
+++ b/src/SingleProject/Resizetizer/src/SkiaSharpTools.cs
@@ -201,6 +201,7 @@ namespace Microsoft.Maui.Resizetizer
 				{
 					using var stream = File.Create(destination);
 					tempBitmap.Encode(stream, SKEncodedImageFormat.Png, 100);
+					return;
 				}
 				catch (Exception ex)
 				{

--- a/src/SingleProject/Resizetizer/src/SkiaSharpTools.cs
+++ b/src/SingleProject/Resizetizer/src/SkiaSharpTools.cs
@@ -1,12 +1,54 @@
 ﻿using System;
 using System.Diagnostics;
 using System.IO;
+using System.Threading;
+using System.Runtime.InteropServices;
 using SkiaSharp;
 
 namespace Microsoft.Maui.Resizetizer
 {
 	internal abstract class SkiaSharpTools
 	{
+		const int ERROR_ACCESS_DENIED = -2147024891;
+		const int ERROR_SHARING_VIOLATION = -2147024864;
+		const int DEFAULT_FILE_WRITE_RETRY_ATTEMPTS = 10;
+		const int DEFAULT_FILE_WRITE_RETRY_DELAY_MS = 1000;
+
+		static int fileWriteRetry = -1;
+		static int fileWriteRetryDelay = -1;
+
+		/// <summary>
+		/// Checks for the environment variable DOTNET_ANDROID_FILE_WRITE_RETRY_ATTEMPTS to
+		/// see if a custom value for the number of times to retry writing a file has been 
+		/// set.
+		/// </summary>
+		/// <returns>The value of DOTNET_ANDROID_FILE_WRITE_RETRY_ATTEMPTS or the default of DEFAULT_FILE_WRITE_RETRY_ATTEMPTS</returns>
+		public static int GetFileWriteRetryAttempts ()
+		{
+			if (fileWriteRetry == -1) {
+				var retryVariable = Environment.GetEnvironmentVariable ("DOTNET_ANDROID_FILE_WRITE_RETRY_ATTEMPTS");
+				if (string.IsNullOrEmpty (retryVariable) || !int.TryParse (retryVariable, out fileWriteRetry))
+					fileWriteRetry = DEFAULT_FILE_WRITE_RETRY_ATTEMPTS;
+			}
+			return fileWriteRetry;
+		}
+
+		/// <summary>
+		/// Checks for the environment variable DOTNET_ANDROID_FILE_WRITE_RETRY_DELAY_MS to
+		/// see if a custom value for the delay between trying to write a file has been 
+		/// set.
+		/// </summary>
+		/// <returns>The value of DOTNET_ANDROID_FILE_WRITE_RETRY_DELAY_MS or the default of DEFAULT_FILE_WRITE_RETRY_DELAY_MS</returns>
+		public static int GetFileWriteRetryDelay ()
+		{
+			if (fileWriteRetryDelay == -1) {
+				var delayVariable = Environment.GetEnvironmentVariable ("DOTNET_ANDROID_FILE_WRITE_RETRY_DELAY_MS");
+				if (string.IsNullOrEmpty (delayVariable) || !int.TryParse (delayVariable, out fileWriteRetryDelay))
+					fileWriteRetryDelay = DEFAULT_FILE_WRITE_RETRY_DELAY_MS;
+			}
+			return fileWriteRetryDelay;
+		} 
+
 		static SkiaSharpTools()
 		{
 			// DO NOT DELETE!
@@ -150,8 +192,35 @@ namespace Microsoft.Maui.Resizetizer
 
 		void Save(string destination, SKBitmap tempBitmap)
 		{
-			using var stream = File.Create(destination);
-			tempBitmap.Encode(stream, SKEncodedImageFormat.Png, 100);
+			int attempt = 0;
+			int attempts = GetFileWriteRetryAttempts ();
+			int delay = GetFileWriteRetryDelay ();
+			while (attempt <= attempts)
+			{
+				try
+				{
+					using var stream = File.Create(destination);
+					tempBitmap.Encode(stream, SKEncodedImageFormat.Png, 100);
+				}
+				catch (Exception ex)
+				{
+					switch (ex)
+					{
+						case UnauthorizedAccessException:
+						case IOException:
+							var code = Marshal.GetHRForException(ex);
+							if ((code != ERROR_ACCESS_DENIED && code  != ERROR_SHARING_VIOLATION) || attempt == attempts)
+							{
+								throw;
+							}
+							break;
+						default:
+							throw;
+					}
+					attempt++;
+					Thread.Sleep(delay);
+				}
+			}
 		}
 
 		public abstract SKSize GetOriginalSize();

--- a/src/SingleProject/Resizetizer/src/SkiaSharpTools.cs
+++ b/src/SingleProject/Resizetizer/src/SkiaSharpTools.cs
@@ -209,7 +209,7 @@ namespace Microsoft.Maui.Resizetizer
 						case UnauthorizedAccessException:
 						case IOException:
 							var code = Marshal.GetHRForException(ex);
-							if ((code != ERROR_ACCESS_DENIED && code  != ERROR_SHARING_VIOLATION) || attempt == attempts)
+							if ((code != ERROR_ACCESS_DENIED && code  != ERROR_SHARING_VIOLATION) || attempt >= attempts)
 							{
 								throw;
 							}

--- a/src/SingleProject/Resizetizer/src/nuget/buildTransitive/Microsoft.Maui.Resizetizer.After.targets
+++ b/src/SingleProject/Resizetizer/src/nuget/buildTransitive/Microsoft.Maui.Resizetizer.After.targets
@@ -59,21 +59,6 @@
             _CleanResizetizer;
         </CleanDependsOn>
 
-        <_ResizetizerInputsFile>$(IntermediateOutputPath)mauiimage.inputs</_ResizetizerInputsFile>
-        <_ResizetizerOutputsFile>$(IntermediateOutputPath)mauiimage.outputs</_ResizetizerOutputsFile>
-        <_ResizetizerStampFile>$(IntermediateOutputPath)mauiimage.stamp</_ResizetizerStampFile>
-        <_MauiFontInputsFile>$(IntermediateOutputPath)mauifont.inputs</_MauiFontInputsFile>
-        <_MauiFontStampFile>$(IntermediateOutputPath)mauifont.stamp</_MauiFontStampFile>
-        <_MauiSplashInputsFile>$(IntermediateOutputPath)mauisplash.inputs</_MauiSplashInputsFile>
-        <_MauiSplashStampFile>$(IntermediateOutputPath)mauisplash.stamp</_MauiSplashStampFile>
-        <_MauiManifestStampFile>$(IntermediateOutputPath)mauimanifest.stamp</_MauiManifestStampFile>
-
-        <_ResizetizerIntermediateOutputRoot>$(IntermediateOutputPath)resizetizer\</_ResizetizerIntermediateOutputRoot>
-        <_MauiIntermediateImages>$(_ResizetizerIntermediateOutputRoot)r\</_MauiIntermediateImages>
-        <_MauiIntermediateFonts>$(_ResizetizerIntermediateOutputRoot)f\</_MauiIntermediateFonts>
-        <_MauiIntermediateSplashScreen>$(_ResizetizerIntermediateOutputRoot)sp\</_MauiIntermediateSplashScreen>
-        <_MauiIntermediateManifest>$(_ResizetizerIntermediateOutputRoot)m\</_MauiIntermediateManifest>
-
         <_ResizetizerPlatformIdentifier>$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)'))</_ResizetizerPlatformIdentifier>
         <_ResizetizerNoTargetPlatform Condition="'$(_ResizetizerPlatformIdentifier)' == ''">True</_ResizetizerNoTargetPlatform>
         <_ResizetizerPlatformIsAndroid Condition="'$(_ResizetizerPlatformIdentifier)' == 'android'">True</_ResizetizerPlatformIsAndroid>
@@ -83,6 +68,24 @@
         <_ResizetizerPlatformIstvOS Condition="'$(_ResizetizerPlatformIdentifier)' == 'tvos'">True</_ResizetizerPlatformIstvOS>
         <_ResizetizerPlatformIsWindows Condition="$(_ResizetizerPlatformIdentifier.Contains('windows')) == 'True'">True</_ResizetizerPlatformIsWindows>
         <_ResizetizerPlatformIsTizen Condition="'$(_ResizetizerPlatformIdentifier)' == 'tizen'">True</_ResizetizerPlatformIsTizen>
+
+        <_ResizetizerIntermediateOutputPath Condition=" '$(_ResizetizerIntermediateOutputPath)' == '' And '$(_ResizetizerPlatformIsAndroid)' == 'True' And '$(DesignTimeBuild)' == 'True' ">$(IntermediateOutputPath)designtime</_ResizetizerIntermediateOutputPath>
+        <_ResizetizerIntermediateOutputPath Condition=" '$(_ResizetizerIntermediateOutputPath)' == '' " >$(IntermediateOutputPath)</_ResizetizerIntermediateOutputPath>
+
+        <_ResizetizerInputsFile>$(_ResizetizerIntermediateOutputPath)mauiimage.inputs</_ResizetizerInputsFile>
+        <_ResizetizerOutputsFile>$(_ResizetizerIntermediateOutputPath)mauiimage.outputs</_ResizetizerOutputsFile>
+        <_ResizetizerStampFile>$(_ResizetizerIntermediateOutputPath)mauiimage.stamp</_ResizetizerStampFile>
+        <_MauiFontInputsFile>$(_ResizetizerIntermediateOutputPath)mauifont.inputs</_MauiFontInputsFile>
+        <_MauiFontStampFile>$(_ResizetizerIntermediateOutputPath)mauifont.stamp</_MauiFontStampFile>
+        <_MauiSplashInputsFile>$(_ResizetizerIntermediateOutputPath)mauisplash.inputs</_MauiSplashInputsFile>
+        <_MauiSplashStampFile>$(_ResizetizerIntermediateOutputPath)mauisplash.stamp</_MauiSplashStampFile>
+        <_MauiManifestStampFile>$(_ResizetizerIntermediateOutputPath)mauimanifest.stamp</_MauiManifestStampFile>
+
+        <_ResizetizerIntermediateOutputRoot>$(_ResizetizerIntermediateOutputPath)resizetizer\</_ResizetizerIntermediateOutputRoot>
+        <_MauiIntermediateImages>$(_ResizetizerIntermediateOutputRoot)r\</_MauiIntermediateImages>
+        <_MauiIntermediateFonts>$(_ResizetizerIntermediateOutputRoot)f\</_MauiIntermediateFonts>
+        <_MauiIntermediateSplashScreen>$(_ResizetizerIntermediateOutputRoot)sp\</_MauiIntermediateSplashScreen>
+        <_MauiIntermediateManifest>$(_ResizetizerIntermediateOutputRoot)m\</_MauiIntermediateManifest>
 
         <ResizetizerIncludeSelfProject Condition="'$(ResizetizerIncludeSelfProject)' == ''">False</ResizetizerIncludeSelfProject>
 
@@ -504,7 +507,7 @@
         </ItemGroup>
 
         <!-- Stamp file for Outputs -->
-        <MakeDir Directories="$(IntermediateOutputPath)"/>
+        <MakeDir Directories="$(_ResizetizerIntermediateOutputPath)"/>
         <Touch Files="$(_MauiSplashStampFile)" AlwaysCreate="True" />
 
         <ItemGroup>

--- a/src/SingleProject/Resizetizer/src/nuget/buildTransitive/Microsoft.Maui.Resizetizer.After.targets
+++ b/src/SingleProject/Resizetizer/src/nuget/buildTransitive/Microsoft.Maui.Resizetizer.After.targets
@@ -69,7 +69,6 @@
         <_ResizetizerPlatformIsWindows Condition="$(_ResizetizerPlatformIdentifier.Contains('windows')) == 'True'">True</_ResizetizerPlatformIsWindows>
         <_ResizetizerPlatformIsTizen Condition="'$(_ResizetizerPlatformIdentifier)' == 'tizen'">True</_ResizetizerPlatformIsTizen>
 
-        <_ResizetizerIntermediateOutputPath Condition=" '$(_ResizetizerIntermediateOutputPath)' == '' And '$(_ResizetizerPlatformIsAndroid)' == 'True' And '$(DesignTimeBuild)' == 'True' ">$(IntermediateOutputPath)designtime</_ResizetizerIntermediateOutputPath>
         <_ResizetizerIntermediateOutputPath Condition=" '$(_ResizetizerIntermediateOutputPath)' == '' " >$(IntermediateOutputPath)</_ResizetizerIntermediateOutputPath>
 
         <_ResizetizerInputsFile>$(_ResizetizerIntermediateOutputPath)mauiimage.inputs</_ResizetizerInputsFile>


### PR DESCRIPTION
Fixes https://github.com/dotnet/maui/issues/25207
Context
https://github.com/dotnet/android-tools/pull/245
https://github.com/dotnet/android/pull/9409

So there is a problem where the design time builds (DTB) of android sometimes lock files. This can happen when two processes try to write to the same file. This is not a great experience for our users as it just fails the build.

So lets add some retry code to the `SkiaSharpTools.Save` method. This will catch `UnauthorizedAccessException` exceptions as well as specific `IOException` types (Access Denied and Sharing Violation). This will allow us to catch when this happens and retry the write. There is a small delay before attempting to write the file again.

Note these code uses the Identical code as we are going to use in Android. We have introduced two new environment variables which can be used to control the new behavior.

1. `DOTNET_ANDROID_FILE_WRITE_RETRY_ATTEMPTS`. Integer, controls the number of times we try to write the file. The default is 10.
2. `DOTNET_ANDROID_FILE_WRITE_RETRY_DELAY_MS`. Integer, controls the delay in milliseconds between retry attempts.  Default is 1000ms (or 1 second).

