### PR TITLE
[testing] These Semantic tests seem to fail often on MacCatalyst 

### DIFF
--- a/src/Core/tests/DeviceTests.Shared/HandlerTests/HandlerTestBaseOfT.Tests.cs
+++ b/src/Core/tests/DeviceTests.Shared/HandlerTests/HandlerTestBaseOfT.Tests.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Maui.DeviceTests
 
 		[Fact(DisplayName = "Setting Semantic Description makes element accessible"
 #if MACCATALYST
-			, Skip = "This test fails sometimes on iOS"
+			, Skip = "This test fails sometimes on MACCATALYST"
 #endif			
 		)]
 		public async virtual Task SettingSemanticDescriptionMakesElementAccessible()
@@ -102,7 +102,7 @@ namespace Microsoft.Maui.DeviceTests
 
 		[Fact(DisplayName = "Setting Semantic Hint makes element accessible"
 #if MACCATALYST
-			, Skip = "This test fails sometimes on iOS"
+			, Skip = "This test fails sometimes on MACCATALYST"
 #endif			
 		)]
 		public async virtual Task SettingSemanticHintMakesElementAccessible()

--- a/src/Core/tests/DeviceTests.Shared/HandlerTests/HandlerTestBaseOfT.Tests.cs
+++ b/src/Core/tests/DeviceTests.Shared/HandlerTests/HandlerTestBaseOfT.Tests.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		[Fact(DisplayName = "Setting Semantic Description makes element accessible"
-#if IOS
+#if MACCATALYST
 			, Skip = "This test fails sometimes on iOS"
 #endif			
 		)]
@@ -101,7 +101,7 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		[Fact(DisplayName = "Setting Semantic Hint makes element accessible"
-#if IOS
+#if MACCATALYST
 			, Skip = "This test fails sometimes on iOS"
 #endif			
 		)]
@@ -125,8 +125,8 @@ namespace Microsoft.Maui.DeviceTests
 		[Fact(DisplayName = "Semantic Description is set correctly"
 #if ANDROID
 			, Skip = "This value can't be validated through automated tests"
-#elif IOS
-			, Skip = "This test fails sometimes on iOS"
+#elif MACCATALYST
+			, Skip = "This test fails sometimes on MACCATALYST"
 #endif
 		)]
 		public async Task SetSemanticDescription()
@@ -140,8 +140,8 @@ namespace Microsoft.Maui.DeviceTests
 		[Fact(DisplayName = "Semantic Hint is set correctly"
 #if ANDROID
 			, Skip = "This value can't be validated through automated tests"
-#elif IOS
-			, Skip = "This test fails sometimes on iOS"
+#elif MACCATALYST
+			, Skip = "This test fails sometimes on MACCATALYST"
 #endif
 		)]
 		public async Task SetSemanticHint()
@@ -153,8 +153,8 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		[Fact(DisplayName = "Semantic Heading is set correctly"
-#if IOS
-			, Skip = "This test fails sometimes on iOS"
+#if MACCATALYST
+			, Skip = "This test fails sometimes on MACCATALYST"
 #endif		
 		)]
 		public async Task SetSemanticHeading()

--- a/src/Core/tests/DeviceTests.Shared/HandlerTests/HandlerTestBaseOfT.Tests.cs
+++ b/src/Core/tests/DeviceTests.Shared/HandlerTests/HandlerTestBaseOfT.Tests.cs
@@ -78,7 +78,11 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.Equal(view.Visibility, id);
 		}
 
-		[Fact(DisplayName = "Setting Semantic Description makes element accessible")]
+		[Fact(DisplayName = "Setting Semantic Description makes element accessible"
+#if IOS
+			, Skip = "This test fails sometimes on iOS"
+#endif			
+		)]
 		public async virtual Task SettingSemanticDescriptionMakesElementAccessible()
 		{
 			var view = new TStub();
@@ -96,7 +100,11 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.True(important);
 		}
 
-		[Fact(DisplayName = "Setting Semantic Hint makes element accessible")]
+		[Fact(DisplayName = "Setting Semantic Hint makes element accessible"
+#if IOS
+			, Skip = "This test fails sometimes on iOS"
+#endif			
+		)]
 		public async virtual Task SettingSemanticHintMakesElementAccessible()
 		{
 			var view = new TStub();
@@ -117,6 +125,8 @@ namespace Microsoft.Maui.DeviceTests
 		[Fact(DisplayName = "Semantic Description is set correctly"
 #if ANDROID
 			, Skip = "This value can't be validated through automated tests"
+#elif IOS
+			, Skip = "This test fails sometimes on iOS"
 #endif
 		)]
 		public async Task SetSemanticDescription()
@@ -130,6 +140,8 @@ namespace Microsoft.Maui.DeviceTests
 		[Fact(DisplayName = "Semantic Hint is set correctly"
 #if ANDROID
 			, Skip = "This value can't be validated through automated tests"
+#elif IOS
+			, Skip = "This test fails sometimes on iOS"
 #endif
 		)]
 		public async Task SetSemanticHint()
@@ -140,7 +152,11 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.Equal(view.Semantics.Hint, id);
 		}
 
-		[Fact(DisplayName = "Semantic Heading is set correctly")]
+		[Fact(DisplayName = "Semantic Heading is set correctly"
+#if IOS
+			, Skip = "This test fails sometimes on iOS"
+#endif		
+		)]
 		public async Task SetSemanticHeading()
 		{
 			var view = new TStub();


### PR DESCRIPTION
### Description of Change

Look at analytics the tests for Semantic, SetSemanticHeading, SettingSemanticHintMakesElementAccessible, SetSemanticHeading

https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=10421392&view=ms.vss-test-web.build-test-results-tab&runId=113926822&resultId=100317&paneView=debug

https://devdiv.visualstudio.com/DevDiv/_test/analytics?definitionId=14934&contextType=build