### PR TITLE
[iOS] Use non-overridden traits in AppInfoImplementation.RequestTheme

### DIFF
--- a/src/Essentials/src/AppInfo/AppInfo.ios.tvos.watchos.macos.cs
+++ b/src/Essentials/src/AppInfo/AppInfo.ios.tvos.watchos.macos.cs
@@ -54,10 +54,9 @@ namespace Microsoft.Maui.ApplicationModel
 				if ((OperatingSystem.IsIOS() && !OperatingSystem.IsIOSVersionAtLeast(13, 0)) || (OperatingSystem.IsTvOS() && !OperatingSystem.IsTvOSVersionAtLeast(13, 0)))
 					return AppTheme.Unspecified;
 
-				var traits =
-					MainThread.InvokeOnMainThread(() => WindowStateManager.Default.GetCurrentUIViewController()?.TraitCollection) ??
-					UITraitCollection.CurrentTraitCollection;
-
+				// This always returns the non-overridden trais which allows restoring the
+				// application back to the system theme.
+				var traits = UIScreen.MainScreen.TraitCollection;
 				var uiStyle = traits.UserInterfaceStyle;
 
 				return uiStyle switch


### PR DESCRIPTION
### Description of Change

Fixes getting the system theme after an overridden dark/light theme was applied to the app.

### Issues Fixed

Fixes #23411

