### PR TITLE
[release/9.0.1xx] [Blazor Hybrid] Fire and forget `BlazorWebView` disposal by default

### DIFF
--- a/src/BlazorWebView/src/Maui/BlazorWebViewHandler.cs
+++ b/src/BlazorWebView/src/Maui/BlazorWebViewHandler.cs
@@ -13,6 +13,11 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 #endif
 	public partial class BlazorWebViewHandler
 	{
+		private const string UseBlockingDisposalSwitch = "BlazorWebView.UseBlockingDisposal";
+
+		private static bool IsBlockingDisposalEnabled =>
+			AppContext.TryGetSwitch(UseBlockingDisposalSwitch, out var enabled) && enabled;
+
 		/// <summary>
 		/// This field is part of MAUI infrastructure and is not intended for use by application code.
 		/// </summary>

--- a/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
+++ b/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Maui;
 using Microsoft.Maui.Dispatching;
 using Microsoft.Maui.Handlers;
 using UIKit;
@@ -127,13 +128,24 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 
 			if (_webviewManager != null)
 			{
-				// Dispose this component's contents and block on completion so that user-written disposal logic and
-				// Blazor disposal logic will complete.
-				_webviewManager?
+				// Start the disposal...
+				var disposalTask = _webviewManager?
 					.DisposeAsync()
-					.AsTask()
-					.GetAwaiter()
-					.GetResult();
+					.AsTask()!;
+
+				if (IsBlockingDisposalEnabled)
+				{
+					// If the app is configured to block on dispose via an AppContext switch,
+					// we'll synchronously wait for the disposal to complete. This can cause a deadlock.
+					disposalTask
+						.GetAwaiter()
+						.GetResult();
+				}
+				else
+				{
+					// Otherwise, by default, we'll fire-and-forget the disposal task.
+					disposalTask.FireAndForget(_logger);
+				}
 
 				_webviewManager = null;
 			}


### PR DESCRIPTION
Changes the default behavior of `BlazorWebViewHandler` to fire-and-forget the disposal of the underlying `WebViewManager` by default.

Fixes #24407
Fixes #24250