### PR TITLE
25421- ListViewRenderer Crash in HostApp and BindingError was occured in windows platforms 

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/Windows/ListViewRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/Windows/ListViewRenderer.cs
@@ -802,10 +802,8 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		void OnControlSelectionChanged(object sender, WSelectionChangedEventArgs e)
 		{
-			if(Element is null)
-			{
-			  return;
-			}
+			if (Element is null)
+				return;
 
 			bool areEqual = false;
 

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/Windows/ListViewRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/Windows/ListViewRenderer.cs
@@ -802,6 +802,11 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		void OnControlSelectionChanged(object sender, WSelectionChangedEventArgs e)
 		{
+			if(Element is null)
+			{
+			  return;
+			}
+
 			bool areEqual = false;
 
 			if (Element.SelectedItem != null && Element.SelectedItem.GetType().IsValueType)

--- a/src/Controls/tests/TestCases.HostApp/CoreViews/CorePageView.cs
+++ b/src/Controls/tests/TestCases.HostApp/CoreViews/CorePageView.cs
@@ -111,8 +111,6 @@ namespace Maui.Controls.Sample
 			template.SetBinding(TextCell.TextProperty, "Title");
 			template.SetBinding(TextCell.AutomationIdProperty, "TitleAutomationId");
 
-			//Since the ListView already has _pages as its ItemsSource, there is no need to set the BindingContext.
-			//BindingContext = _pages;
 			ItemTemplate = template;
 			ItemsSource = _pages;
 

--- a/src/Controls/tests/TestCases.HostApp/CoreViews/CorePageView.cs
+++ b/src/Controls/tests/TestCases.HostApp/CoreViews/CorePageView.cs
@@ -111,7 +111,8 @@ namespace Maui.Controls.Sample
 			template.SetBinding(TextCell.TextProperty, "Title");
 			template.SetBinding(TextCell.AutomationIdProperty, "TitleAutomationId");
 
-			BindingContext = _pages;
+			//Since the ListView already has _pages as its ItemsSource, there is no need to set the BindingContext.
+			//BindingContext = _pages;
 			ItemTemplate = template;
 			ItemsSource = _pages;
 


### PR DESCRIPTION
## RootCause 

### ListViewRenderer Crash on HostApp 

As the HostApp uses a ListView to display a list of items, selecting a page navigates to the corresponding test cases and sets the sample page as the current main page. This action disposes the HostApp's main page, which contains the ListView. As a result, the previous list is also disposed, leading to a crash in the ListViewRenderer during the `OnControlSelectionChanged` event.

### BindingErrors occurs on windows platform 

In the HostApp, the pages private field of the ListView is set as the BindingContext of the ListView, which is causing the issue. The pages field is directly assigned to the `ItemsSource`, so there's no need to set the `BindingContext`. The problem arises because the same collection is being used for both the `BindingContext` and the `ItemsSource`, which is the root cause of the issue.

## Description of Change

### ListViewRenderer Crash on HostApp 

Ensuring that Element is not null before updating the selection will resolve the issue

### BindingErrors occurs on windows platform 

There is no need to define the BindingContext.

### Issues Fixed
Fixes #25421
