### PR TITLE
[Android] Fix double conversion with FromPixels

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/Android/ItemContentView.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/ItemContentView.cs
@@ -170,8 +170,8 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			// Even though we already know the size we still need to pass the measure through to the children.
 			if (_pixelSize is not null)
 			{
-				var w = (int)this.FromPixels(_pixelSize.Value.Width);
-				var h = (int)this.FromPixels(_pixelSize.Value.Height);
+				var w = (int)_pixelSize.Value.Width;
+				var h = (int)_pixelSize.Value.Height;
 
 				// If the platform childs measure has been invalidated, it's going to still want to
 				// participate in the measure lifecycle in order to update its internal


### PR DESCRIPTION
### Description of Change

`ItemContentView` on Android was calling `Convert.FromPixel` on the value passed to `MeasureVirtualView`, which then did the conversion again with `ToDouble` extension method:

https://github.com/dotnet/maui/blob/8b44525b87a790e0fe0f056839f8d575314d5467/src/Core/src/Handlers/ViewHandlerExtensions.Android.cs#L54-L55

https://github.com/dotnet/maui/blob/8b44525b87a790e0fe0f056839f8d575314d5467/src/Core/src/Platform/Android/MeasureSpecExtensions.cs#L25-L30

This in turn results in the Layout measurement called with twice downscaled values.

### Issues Fixed

