### PR TITLE
25421- ListViewRenderer Crash in HostApp and BindingError was occured in windows platforms

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/Windows/ListViewRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/Windows/ListViewRenderer.cs
@@ -319,47 +319,51 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 			if (disposing)
 			{
-				if (List != null)
-				{
-					foreach (ViewToHandlerConverter.WrapperControl wrapperControl in FindDescendants<ViewToHandlerConverter.WrapperControl>(List))
-					{
-						wrapperControl.CleanUp();
-					}
-
-					if (_subscribedToTapped)
-					{
-						_subscribedToTapped = false;
-						List.Tapped -= ListOnTapped;
-					}
-					if (_subscribedToItemClick)
-					{
-						_subscribedToItemClick = false;
-						List.ItemClick -= OnListItemClicked;
-					}
-
-					List.SelectionChanged -= OnControlSelectionChanged;
-					if (_collectionViewSource != null)
-						_collectionViewSource.Source = null;
-
-					List.DataContext = null;
-
-					// Leaving this here as a warning because setting this to null causes
-					// an AccessViolationException if you run Issue1975
-					// List.ItemsSource = null;
-
-					List = null;
-				}
-
-				if (_zoom != null)
-				{
-					_zoom.ViewChangeCompleted -= OnViewChangeCompleted;
-					_zoom = null;
-				}
+				CleanUpResources();
 			}
 
 			base.Dispose(disposing);
 		}
 
+		void CleanUpResources()
+		{
+			if (List != null)
+			{
+				foreach (ViewToHandlerConverter.WrapperControl wrapperControl in FindDescendants<ViewToHandlerConverter.WrapperControl>(List))
+				{
+					wrapperControl.CleanUp();
+				}
+
+				if (_subscribedToTapped)
+				{
+					_subscribedToTapped = false;
+					List.Tapped -= ListOnTapped;
+				}
+				if (_subscribedToItemClick)
+				{
+					_subscribedToItemClick = false;
+					List.ItemClick -= OnListItemClicked;
+				}
+
+				List.SelectionChanged -= OnControlSelectionChanged;
+				if (_collectionViewSource != null)
+					_collectionViewSource.Source = null;
+
+				List.DataContext = null;
+
+				// Leaving this here as a warning because setting this to null causes
+				// an AccessViolationException if you run Issue1975
+				// List.ItemsSource = null;
+
+				List = null;
+			}
+
+			if (_zoom != null)
+			{
+				_zoom.ViewChangeCompleted -= OnViewChangeCompleted;
+				_zoom = null;
+			}
+		}
 		static IEnumerable<T> FindDescendants<T>(DependencyObject dobj) where T : DependencyObject
 		{
 			int count = VisualTreeHelper.GetChildrenCount(dobj);
@@ -798,6 +802,12 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 				OnListItemClicked(selectedItemIndex);
 			}
+		}
+
+		private protected override void DisconnectHandlerCore()
+		{
+			CleanUpResources();
+			base.DisconnectHandlerCore();
 		}
 
 		void OnControlSelectionChanged(object sender, WSelectionChangedEventArgs e)

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/Windows/ListViewRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/Windows/ListViewRenderer.cs
@@ -802,6 +802,8 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		void OnControlSelectionChanged(object sender, WSelectionChangedEventArgs e)
 		{
+			if (Element is null)
+				return;
 			bool areEqual = false;
 
 			if (Element.SelectedItem != null && Element.SelectedItem.GetType().IsValueType)

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/Windows/ListViewRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/Windows/ListViewRenderer.cs
@@ -812,8 +812,6 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		void OnControlSelectionChanged(object sender, WSelectionChangedEventArgs e)
 		{
-			if (Element is null)
-				return;
 			bool areEqual = false;
 
 			if (Element.SelectedItem != null && Element.SelectedItem.GetType().IsValueType)

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/iOS/ListViewRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/iOS/ListViewRenderer.cs
@@ -126,6 +126,12 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			}
 		}
 
+		private protected override void DisconnectHandlerCore()
+		{
+			CleanUpResources();
+			base.DisconnectHandlerCore();
+		}
+
 		protected override void Dispose(bool disposing)
 		{
 			if (_disposed)
@@ -133,58 +139,64 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 			if (disposing)
 			{
-				if (Element != null)
-				{
-					var templatedItems = TemplatedItemsView.TemplatedItems;
-					templatedItems.CollectionChanged -= OnCollectionChanged;
-					templatedItems.GroupedCollectionChanged -= OnGroupedCollectionChanged;
-				}
-
-				if (_dataSource != null)
-				{
-					_dataSource.Dispose();
-					_dataSource = null;
-				}
-
-				if (_tableViewController != null)
-				{
-					_tableViewController.Dispose();
-					_tableViewController = null;
-				}
-
-				if (_headerRenderer != null)
-				{
-					_headerRenderer.VirtualView?.DisposeModalAndChildHandlers();
-					_headerRenderer = null;
-				}
-				if (_footerRenderer != null)
-				{
-					_footerRenderer.VirtualView?.DisposeModalAndChildHandlers();
-					_footerRenderer = null;
-				}
-
-				if (_backgroundUIView != null)
-				{
-					_backgroundUIView.Dispose();
-					_backgroundUIView = null;
-				}
-
-				var headerView = ListView?.HeaderElement as VisualElement;
-				if (headerView != null)
-					headerView.MeasureInvalidated -= OnHeaderMeasureInvalidated;
-				Control?.TableHeaderView?.Dispose();
-
-				var footerView = ListView?.FooterElement as VisualElement;
-				if (footerView != null)
-					footerView.MeasureInvalidated -= OnFooterMeasureInvalidated;
-				Control?.TableFooterView?.Dispose();
+				CleanUpResources();
 			}
 
 			_disposed = true;
 
 			base.Dispose(disposing);
 		}
+
 		bool _disposed = false;
+
+		void CleanUpResources()
+		{
+			if (Element != null)
+			{
+				var templatedItems = TemplatedItemsView.TemplatedItems;
+				templatedItems.CollectionChanged -= OnCollectionChanged;
+				templatedItems.GroupedCollectionChanged -= OnGroupedCollectionChanged;
+			}
+
+			if (_dataSource != null)
+			{
+				_dataSource.Dispose();
+				_dataSource = null;
+			}
+
+			if (_tableViewController != null)
+			{
+				_tableViewController.Dispose();
+				_tableViewController = null;
+			}
+
+			if (_headerRenderer != null)
+			{
+				_headerRenderer.VirtualView?.DisposeModalAndChildHandlers();
+				_headerRenderer = null;
+			}
+			if (_footerRenderer != null)
+			{
+				_footerRenderer.VirtualView?.DisposeModalAndChildHandlers();
+				_footerRenderer = null;
+			}
+
+			if (_backgroundUIView != null)
+			{
+				_backgroundUIView.Dispose();
+				_backgroundUIView = null;
+			}
+
+			var headerView = ListView?.HeaderElement as VisualElement;
+			if (headerView != null)
+				headerView.MeasureInvalidated -= OnHeaderMeasureInvalidated;
+			Control?.TableHeaderView?.Dispose();
+
+			var footerView = ListView?.FooterElement as VisualElement;
+			if (footerView != null)
+				footerView.MeasureInvalidated -= OnFooterMeasureInvalidated;
+			Control?.TableFooterView?.Dispose();
+		}
 		protected override void OnElementChanged(ElementChangedEventArgs<ListView> e)
 		{
 			_requestedScroll = null;

--- a/src/Controls/tests/TestCases.HostApp/CoreViews/CorePageView.cs
+++ b/src/Controls/tests/TestCases.HostApp/CoreViews/CorePageView.cs
@@ -119,7 +119,6 @@ namespace Maui.Controls.Sample
 			template.SetBinding(TextCell.TextProperty, "Title");
 			template.SetBinding(TextCell.AutomationIdProperty, "TitleAutomationId");
 
-			BindingContext = _pages;
 			ItemTemplate = template;
 			ItemsSource = _pages;
 


### PR DESCRIPTION
## RootCause
 
### ListViewRenderer Crash on HostApp
 
As the HostApp uses a ListView to display a list of items, selecting a page navigates to the corresponding test cases and sets the sample page as the current main page. This action disposes the HostApp's main page, which contains the ListView. As a result, the previous list is also disposed, leading to a crash in the ListViewRenderer during the `OnControlSelectionChanged` event.
 
### BindingErrors occurs on windows platform
 
In the HostApp, the pages private field of the ListView is set as the BindingContext of the ListView, which is causing the issue. The pages field is directly assigned to the `ItemsSource`, so there's no need to set the `BindingContext`. The problem arises because the same collection is being used for both the `BindingContext` and the `ItemsSource`, which is the root cause of the issue.
 
## Description of Change
 
### ListViewRenderer Crash on HostApp
 
The ListView events are unwired, and resources are cleaned up in the `DisconnectHandlerCore` method of the ListView renderer, ensuring all events are properly disconnected.
 
### BindingErrors occurs on windows platform
 
There is no need to define the BindingContext.
 
### Issues Fixed
Fixes #25421