### PR TITLE
[iOS] Only invalidate ancestors upon MeasureInvalidated

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/iOS/FrameRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/iOS/FrameRenderer.cs
@@ -205,33 +205,6 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			}
 		}
 
-		bool _pendingSuperViewSetNeedsLayout;
-
-		public override void SetNeedsLayout()
-		{
-			base.SetNeedsLayout();
-
-			if (Window is not null)
-			{
-				_pendingSuperViewSetNeedsLayout = false;
-				this.Superview?.SetNeedsLayout();
-			}
-			else{
-				_pendingSuperViewSetNeedsLayout = true;
-			}
-		}
-
-		public override void MovedToWindow()
-		{
-			base.MovedToWindow();
-			if (_pendingSuperViewSetNeedsLayout)
-			{
-				this.Superview?.SetNeedsLayout();
-			}
-
-			_pendingSuperViewSetNeedsLayout = false;
-		}
-
 		[Microsoft.Maui.Controls.Internals.Preserve(Conditional = true)]
 		class FrameView : Microsoft.Maui.Platform.ContentView
 		{

--- a/src/Controls/src/Core/Compatibility/Handlers/iOS/VisualElementRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/iOS/VisualElementRenderer.cs
@@ -1,14 +1,14 @@
 ﻿using System;
 using System.ComponentModel;
 using Microsoft.Maui.Controls.Platform;
-using Microsoft.Maui.Graphics;
 using UIKit;
 
 namespace Microsoft.Maui.Controls.Handlers.Compatibility
 {
-	public abstract partial class VisualElementRenderer<TElement> : UIView, IPlatformViewHandler, IElementHandler
+	public abstract partial class VisualElementRenderer<TElement> : UIView, IPlatformViewHandler, IElementHandler, IMauiPlatformView
 		where TElement : Element, IView
 	{
+		bool _invalidateParentWhenMovedToWindow;
 		object? IElementHandler.PlatformView => Subviews.Length > 0 ? Subviews[0] : this;
 
 		public virtual UIViewController? ViewController => null;
@@ -92,6 +92,21 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		void OnSizeChanged(object? sender, EventArgs e)
 		{
 			UpdateNativeWidget();
+		}
+
+		void IMauiPlatformView.InvalidateAncestorsMeasuresWhenMovedToWindow()
+		{
+			_invalidateParentWhenMovedToWindow = true;
+		}
+
+		public override void MovedToWindow()
+		{
+			base.MovedToWindow();
+			if (_invalidateParentWhenMovedToWindow)
+			{
+				_invalidateParentWhenMovedToWindow = false;
+				this.InvalidateAncestorsMeasures();
+			}
 		}
 	}
 }

--- a/src/Controls/src/Core/Handlers/Items/iOS/MauiCollectionView.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/MauiCollectionView.cs
@@ -5,8 +5,10 @@ using UIKit;
 
 namespace Microsoft.Maui.Controls.Handlers.Items;
 
-internal class MauiCollectionView : UICollectionView, IUIViewLifeCycleEvents
+internal class MauiCollectionView : UICollectionView, IUIViewLifeCycleEvents, IMauiPlatformView
 {
+	bool _invalidateParentWhenMovedToWindow;
+
 	WeakReference<ICustomMauiCollectionViewDelegate>? _customDelegate;
 	public MauiCollectionView(CGRect frame, UICollectionViewLayout layout) : base(frame, layout)
 	{
@@ -18,8 +20,14 @@ internal class MauiCollectionView : UICollectionView, IUIViewLifeCycleEvents
 			base.ScrollRectToVisible(rect, animated);
 	}
 
+	void IMauiPlatformView.InvalidateAncestorsMeasuresWhenMovedToWindow()
+	{
+		_invalidateParentWhenMovedToWindow = true;
+	}
+
 	[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = IUIViewLifeCycleEvents.UnconditionalSuppressMessage)]
 	EventHandler? _movedToWindow;
+
 	event EventHandler? IUIViewLifeCycleEvents.MovedToWindow
 	{
 		add => _movedToWindow += value;
@@ -34,6 +42,12 @@ internal class MauiCollectionView : UICollectionView, IUIViewLifeCycleEvents
 		if(_customDelegate?.TryGetTarget(out var target) == true)
 		{
 			target.MovedToWindow(this);
+		}
+
+		if (_invalidateParentWhenMovedToWindow)
+		{
+			_invalidateParentWhenMovedToWindow = false;
+			this.InvalidateAncestorsMeasures();
 		}
 	}
 

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -339,4 +339,5 @@ virtual Microsoft.Maui.Controls.Handlers.Items2.ItemsViewController2<TItemsView>
 virtual Microsoft.Maui.Controls.Handlers.Items2.ItemsViewController2<TItemsView>.UpdateVisibility() -> void
 virtual Microsoft.Maui.Controls.Handlers.Items2.ItemsViewDelegator2<TItemsView, TViewController>.GetVisibleItemsIndex() -> (bool VisibleItems, int First, int Center, int Last)
 virtual Microsoft.Maui.Controls.Handlers.Items2.ItemsViewHandler2<TItemsView>.UpdateLayout() -> void
-override Microsoft.Maui.Controls.Handlers.Compatibility.FrameRenderer.MovedToWindow() -> void
+override Microsoft.Maui.Controls.Handlers.Compatibility.VisualElementRenderer<TElement>.MovedToWindow() -> void
+*REMOVED*override Microsoft.Maui.Controls.Handlers.Compatibility.FrameRenderer.SetNeedsLayout() -> void

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -339,4 +339,5 @@ virtual Microsoft.Maui.Controls.Handlers.Items2.ItemsViewController2<TItemsView>
 virtual Microsoft.Maui.Controls.Handlers.Items2.ItemsViewController2<TItemsView>.UpdateVisibility() -> void
 virtual Microsoft.Maui.Controls.Handlers.Items2.ItemsViewDelegator2<TItemsView, TViewController>.GetVisibleItemsIndex() -> (bool VisibleItems, int First, int Center, int Last)
 virtual Microsoft.Maui.Controls.Handlers.Items2.ItemsViewHandler2<TItemsView>.UpdateLayout() -> void
-override Microsoft.Maui.Controls.Handlers.Compatibility.FrameRenderer.MovedToWindow() -> void
+override Microsoft.Maui.Controls.Handlers.Compatibility.VisualElementRenderer<TElement>.MovedToWindow() -> void
+*REMOVED*override Microsoft.Maui.Controls.Handlers.Compatibility.FrameRenderer.SetNeedsLayout() -> void

--- a/src/Controls/tests/DeviceTests/Elements/CarouselView/CarouselViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CarouselView/CarouselViewTests.cs
@@ -147,7 +147,10 @@ namespace Microsoft.Maui.DeviceTests
 				Assert.False(data.IsCollectionChangedEventEmpty);
 			});
 
-			carouselView.Handler?.DisconnectHandler();
+			await InvokeOnMainThreadAsync(() =>
+			{
+				carouselView.Handler?.DisconnectHandler();
+			});
 
 			Assert.True(data.IsCollectionChangedEventEmpty);
 		}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue24996.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue24996.xaml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:issues="clr-namespace:Maui.Controls.Sample.Issues"
+             x:Class="Maui.Controls.Sample.Issues.Issue24996"
+             Title="Issue24996"
+             x:Reference="Self">
+  <issues:ObservedLayout24996 x:Name="Root" BackgroundColor="DarkSlateBlue">
+    <issues:ObservedLayout24996.GestureRecognizers>
+      <TapGestureRecognizer Tapped="OnTapped" />
+    </issues:ObservedLayout24996.GestureRecognizers>
+    <issues:ObservedLayout24996 x:Name="Lvl1" BackgroundColor="BlueViolet">
+      <issues:ObservedLayout24996 x:Name="Lvl2" BackgroundColor="AliceBlue">
+        <issues:ObservedLayout24996 x:Name="Lvl3"
+                                    BackgroundColor="Aqua"
+                                    HeightRequest="200"
+                                    WidthRequest="200">
+          <Border BackgroundColor="GreenYellow" HeightRequest="100" WidthRequest="100" />
+        </issues:ObservedLayout24996>
+        </issues:ObservedLayout24996>
+      </issues:ObservedLayout24996>
+    <Label x:Name="Stats" 
+           AutomationId="Stats"
+           HeightRequest="80"
+           WidthRequest="{Binding Width, Source={x:Reference Root}}"
+           AbsoluteLayout.LayoutFlags="PositionProportional"
+           AbsoluteLayout.LayoutBounds="0,1,-1,-1"
+           BackgroundColor="#222222"
+           TextColor="White"/>
+  </issues:ObservedLayout24996>
+</ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue24996.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue24996.xaml
@@ -4,28 +4,36 @@
              xmlns:issues="clr-namespace:Maui.Controls.Sample.Issues"
              x:Class="Maui.Controls.Sample.Issues.Issue24996"
              Title="Issue24996"
-             x:Reference="Self">
-  <issues:ObservedLayout24996 x:Name="Root" BackgroundColor="DarkSlateBlue">
-    <issues:ObservedLayout24996.GestureRecognizers>
+             x:Name="Self">
+  <AbsoluteLayout BackgroundColor="DarkSlateBlue">
+    <AbsoluteLayout.GestureRecognizers>
       <TapGestureRecognizer Tapped="OnTapped" />
-    </issues:ObservedLayout24996.GestureRecognizers>
-    <issues:ObservedLayout24996 x:Name="Lvl1" BackgroundColor="BlueViolet">
-      <issues:ObservedLayout24996 x:Name="Lvl2" BackgroundColor="AliceBlue">
-        <issues:ObservedLayout24996 x:Name="Lvl3"
-                                    BackgroundColor="Aqua"
-                                    HeightRequest="200"
-                                    WidthRequest="200">
-          <Border BackgroundColor="GreenYellow" HeightRequest="100" WidthRequest="100" />
-        </issues:ObservedLayout24996>
+    </AbsoluteLayout.GestureRecognizers>
+    <Grid RowDefinitions="*" ColumnDefinitions="*">
+      <issues:ObservedLayout24996 x:Name="Lvl1" BackgroundColor="BlueViolet">
+        <issues:ObservedLayout24996 x:Name="Lvl2" BackgroundColor="AliceBlue">
+          <issues:ObservedLayout24996 x:Name="Lvl3"
+                                      BackgroundColor="Aqua"
+                                      HeightRequest="200"
+                                      WidthRequest="200">
+            <Border BackgroundColor="GreenYellow" HeightRequest="100" WidthRequest="100" />
+          </issues:ObservedLayout24996>
         </issues:ObservedLayout24996>
       </issues:ObservedLayout24996>
-    <Label x:Name="Stats" 
-           AutomationId="Stats"
-           HeightRequest="80"
-           WidthRequest="{Binding Width, Source={x:Reference Root}}"
-           AbsoluteLayout.LayoutFlags="PositionProportional"
-           AbsoluteLayout.LayoutBounds="0,1,-1,-1"
-           BackgroundColor="#222222"
-           TextColor="White"/>
-  </issues:ObservedLayout24996>
+    </Grid>
+    <VerticalStackLayout AbsoluteLayout.LayoutFlags="PositionProportional"
+                         AbsoluteLayout.LayoutBounds="0,1,-1,-1"
+                         BackgroundColor="#222222">
+      <Label x:Name="Coords"
+             HeightRequest="40"
+             WidthRequest="{Binding Width, Source={x:Reference Self}}"
+             AutomationId="Coords"
+             TextColor="White"/>
+      <Label x:Name="Stats"
+             HeightRequest="40"
+             WidthRequest="{Binding Width, Source={x:Reference Self}}"
+             AutomationId="Stats"
+             TextColor="White"/>
+    </VerticalStackLayout>
+  </AbsoluteLayout>
 </ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue24996.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue24996.xaml.cs
@@ -1,0 +1,63 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 24996, "Translation causes multiple layout passes", PlatformAffected.All)]
+public partial class Issue24996 : ContentPage
+{
+	public Issue24996()
+	{
+		InitializeComponent();
+		UpdateText();
+
+		SizeChanged += delegate {
+			if (Width > 0) {
+				// For some reason, constraining this layout to a fixed size causes a `SetNeedsLayout` to be called
+				// when translating the Lvl2 view outside the bottom boundary.
+				// This causes a layout pass to be called on the Root, Lvl1, Lvl2, and Lvl3.
+				Lvl1.WidthRequest = Width;
+				Lvl1.HeightRequest = Height;
+			}
+		};
+	}
+
+	protected override async void OnAppearing()
+	{
+		base.OnAppearing();
+		await Task.Delay(250);
+		Root.MeasurePasses = Root.ArrangePasses = 0;
+		Lvl1.MeasurePasses = Lvl1.ArrangePasses = 0;
+		Lvl2.MeasurePasses = Lvl2.ArrangePasses = 0;
+		Lvl3.MeasurePasses = Lvl3.ArrangePasses = 0;
+		UpdateText();
+	}
+
+	public async void OnTapped(object sender, EventArgs e)
+	{
+		Lvl2.TranslationY = Random.Shared.Next(0, (int)Height);
+		Lvl2.TranslationX = Random.Shared.Next(0, (int)Width);
+		await Task.Delay(500);
+		UpdateText();
+	}
+
+	void UpdateText()
+	{
+		Stats.Text = $"Root[{Root.MeasurePasses}/{Root.ArrangePasses}] - Lvl1[{Lvl1.MeasurePasses}/{Lvl1.ArrangePasses}] - Lvl2[{Lvl2.MeasurePasses}/{Lvl2.ArrangePasses}] - Lvl3[{Lvl3.MeasurePasses}/{Lvl3.ArrangePasses}]";
+	}
+}
+
+public class ObservedLayout24996 : AbsoluteLayout
+{
+	public int MeasurePasses { get; set; }
+	public int ArrangePasses { get; set; }
+
+	protected override Size MeasureOverride(double widthConstraint, double heightConstraint)
+	{
+		MeasurePasses++;
+		return base.MeasureOverride(widthConstraint, heightConstraint);
+	}
+
+	protected override Size ArrangeOverride(Rect bounds)
+	{
+		ArrangePasses++;
+		return base.ArrangeOverride(bounds);
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue24996.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue24996.xaml.cs
@@ -1,8 +1,17 @@
 namespace Maui.Controls.Sample.Issues;
 
-[Issue(IssueTracker.Github, 24996, "Translation causes multiple layout passes", PlatformAffected.All)]
+[Issue(IssueTracker.Github, 24996, "Changing Translation of an element causes Maui in iOS to constantly run Measure & ArrangeChildren", PlatformAffected.All)]
 public partial class Issue24996 : ContentPage
 {
+	Point[] _translations = [
+		new(40, 80),
+		new(1000, 20),
+		new(20, 1000),
+		new(1000, 1000),
+	];
+
+	int _index = -1;
+
 	public Issue24996()
 	{
 		InitializeComponent();
@@ -23,7 +32,6 @@ public partial class Issue24996 : ContentPage
 	{
 		base.OnAppearing();
 		await Task.Delay(250);
-		Root.MeasurePasses = Root.ArrangePasses = 0;
 		Lvl1.MeasurePasses = Lvl1.ArrangePasses = 0;
 		Lvl2.MeasurePasses = Lvl2.ArrangePasses = 0;
 		Lvl3.MeasurePasses = Lvl3.ArrangePasses = 0;
@@ -32,15 +40,17 @@ public partial class Issue24996 : ContentPage
 
 	public async void OnTapped(object sender, EventArgs e)
 	{
-		Lvl2.TranslationY = Random.Shared.Next(0, (int)Height);
-		Lvl2.TranslationX = Random.Shared.Next(0, (int)Width);
-		await Task.Delay(500);
+		var testPoint = _translations[++_index % _translations.Length];
+		Coords.Text = $"X: {testPoint.X}, Y: {testPoint.Y}";
+		Lvl2.TranslationX = testPoint.X;
+		Lvl2.TranslationY = testPoint.Y;
+		await Task.Delay(100);
 		UpdateText();
 	}
 
 	void UpdateText()
 	{
-		Stats.Text = $"Root[{Root.MeasurePasses}/{Root.ArrangePasses}] - Lvl1[{Lvl1.MeasurePasses}/{Lvl1.ArrangePasses}] - Lvl2[{Lvl2.MeasurePasses}/{Lvl2.ArrangePasses}] - Lvl3[{Lvl3.MeasurePasses}/{Lvl3.ArrangePasses}]";
+		Stats.Text = $"Lvl1[{Lvl1.MeasurePasses}/{Lvl1.ArrangePasses}] - Lvl2[{Lvl2.MeasurePasses}/{Lvl2.ArrangePasses}] - Lvl3[{Lvl3.MeasurePasses}/{Lvl3.ArrangePasses}]";
 	}
 }
 

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue24996.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue24996.cs
@@ -1,0 +1,30 @@
+﻿using NUnit.Framework;
+using NUnit.Framework.Legacy;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue24996 : _IssuesUITest
+	{
+		public Issue24996(TestDevice testDevice) : base(testDevice)
+		{
+		}
+
+		public override string Issue => "Changing Translation of an element causes Maui in iOS to constantly run Measure & ArrangeChildren";
+
+		[Test]
+		[Category(UITestCategories.Layout)]
+		public async Task ChangingTranslationShouldNotCauseLayoutPassOnAncestors()
+		{
+			var element = App.WaitForElement("Stats");
+			// Tries to translate the element in different positions, on-screen and off-screen.
+			for (int i = 0; i < 4; i++)
+			{
+				element.Tap();
+				await Task.Delay(150);
+				ClassicAssert.True(element.GetText()!.StartsWith("Lvl1[0/0]"));
+			}
+		}
+	}
+}

--- a/src/Core/src/Handlers/Layout/LayoutHandler.iOS.cs
+++ b/src/Core/src/Handlers/Layout/LayoutHandler.iOS.cs
@@ -38,6 +38,8 @@ namespace Microsoft.Maui.Handlers
 			{
 				PlatformView.AddSubview(child.ToPlatform(MauiContext));
 			}
+
+			PlatformView.InvalidateAncestorsMeasures();
 		}
 
 		public void Add(IView child)
@@ -54,6 +56,8 @@ namespace Microsoft.Maui.Handlers
 			{
 				childPlatformView.UpdateFlowDirection(child);
 			}
+
+			PlatformView.InvalidateAncestorsMeasures();
 		}
 
 		public void Remove(IView child)
@@ -65,11 +69,14 @@ namespace Microsoft.Maui.Handlers
 			{
 				childView.RemoveFromSuperview();
 			}
+
+			PlatformView.InvalidateAncestorsMeasures();
 		}
 
 		public void Clear()
 		{
 			PlatformView.ClearSubviews();
+			PlatformView.InvalidateAncestorsMeasures();
 		}
 
 		public void Insert(int index, IView child)
@@ -86,6 +93,8 @@ namespace Microsoft.Maui.Handlers
 			{
 				childPlatformView.UpdateFlowDirection(child);
 			}
+
+			PlatformView.InvalidateAncestorsMeasures();
 		}
 
 		public void Update(int index, IView child)
@@ -99,6 +108,7 @@ namespace Microsoft.Maui.Handlers
 			var targetIndex = VirtualView.GetLayoutHandlerIndex(child);
 			PlatformView.InsertSubview(child.ToPlatform(MauiContext), targetIndex);
 			PlatformView.SetNeedsLayout();
+			PlatformView.InvalidateAncestorsMeasures();
 		}
 
 		public void UpdateZIndex(IView child)
@@ -137,6 +147,7 @@ namespace Microsoft.Maui.Handlers
 			{
 				PlatformView.Subviews.RemoveAt(currentIndex);
 				PlatformView.InsertSubview(nativeChildView, targetIndex);
+				PlatformView.InvalidateAncestorsMeasures();
 			}
 		}
 

--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.iOS.cs
@@ -34,6 +34,16 @@ namespace Microsoft.Maui.Handlers
 			return new MauiScrollView();
 		}
 
+		public override void SetVirtualView(IView view)
+		{
+			base.SetVirtualView(view);
+
+			if (PlatformView is MauiScrollView scrollView)
+			{
+				scrollView.View = view;
+			}
+		}
+
 		protected override void ConnectHandler(UIScrollView platformView)
 		{
 			base.ConnectHandler(platformView);

--- a/src/Core/src/Platform/iOS/IMauiPlatformView.cs
+++ b/src/Core/src/Platform/iOS/IMauiPlatformView.cs
@@ -1,0 +1,6 @@
+namespace Microsoft.Maui.Platform;
+
+internal interface IMauiPlatformView
+{
+	void InvalidateAncestorsMeasuresWhenMovedToWindow();
+}

--- a/src/Core/src/Platform/iOS/LayoutView.cs
+++ b/src/Core/src/Platform/iOS/LayoutView.cs
@@ -11,14 +11,12 @@ namespace Microsoft.Maui.Platform
 		{
 			InvalidateConstraintsCache();
 			base.SubviewAdded(uiview);
-			TryToInvalidateSuperView(false);
 		}
 
 		public override void WillRemoveSubview(UIView uiview)
 		{
 			InvalidateConstraintsCache();
 			base.WillRemoveSubview(uiview);
-			TryToInvalidateSuperView(false);
 		}
 
 		public override UIView? HitTest(CGPoint point, UIEvent? uievent)

--- a/src/Core/src/Platform/iOS/MauiScrollView.cs
+++ b/src/Core/src/Platform/iOS/MauiScrollView.cs
@@ -1,14 +1,45 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using CoreGraphics;
+using Foundation;
 using UIKit;
 
 namespace Microsoft.Maui.Platform
 {
-	public class MauiScrollView : UIScrollView, IUIViewLifeCycleEvents
+	public class MauiScrollView : UIScrollView, IUIViewLifeCycleEvents, IMauiPlatformView
 	{
+#pragma warning disable MEM0002
+		// Justification: this is a self-reference so it won't cause a memory leak
+		// Having this as a field prevents the observer from being GC'd
+		IDisposable? _contentSizeObserver;
+#pragma warning restore MEM0002
+
+		bool _invalidateParentWhenMovedToWindow;
+		CGSize _lastContentSize;
+
+		WeakReference<IView>? _reference;
+
+		internal IView? View
+		{
+			get => _reference != null && _reference.TryGetTarget(out var v) ? v : null;
+			set => _reference = value == null ? null : new(value);
+		}
+
 		public MauiScrollView()
 		{
+			_contentSizeObserver = AddObserver("contentSize", NSKeyValueObservingOptions.New, ContentSizeChanged);
+		}
+
+		void ContentSizeChanged(NSObservedChange obj)
+		{
+			// This is needed in case the ScrollView is set to auto-size through `VerticalOptions` or `HorizontalOptions`.
+			// We use the same strategy in `CollectionView`.
+			var newSize = ContentSize;
+			if (newSize != _lastContentSize)
+			{
+				_lastContentSize = newSize;
+				View?.InvalidateMeasure();
+			}
 		}
 
 		// overriding this method so it does not automatically scroll large UITextFields
@@ -17,6 +48,11 @@ namespace Microsoft.Maui.Platform
 		{
 			if (!KeyboardAutoManagerScroll.IsKeyboardAutoScrollHandling)
 				base.ScrollRectToVisible(rect, animated);
+		}
+
+		void IMauiPlatformView.InvalidateAncestorsMeasuresWhenMovedToWindow()
+		{
+			_invalidateParentWhenMovedToWindow = true;
 		}
 
 		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = IUIViewLifeCycleEvents.UnconditionalSuppressMessage)]
@@ -31,6 +67,11 @@ namespace Microsoft.Maui.Platform
 		{
 			base.MovedToWindow();
 			_movedToWindow?.Invoke(this, EventArgs.Empty);
+			if (_invalidateParentWhenMovedToWindow)
+			{
+				_invalidateParentWhenMovedToWindow = false;
+				this.InvalidateAncestorsMeasures();
+			}
 		}
 	}
 }

--- a/src/Core/src/Platform/iOS/MauiView.cs
+++ b/src/Core/src/Platform/iOS/MauiView.cs
@@ -7,9 +7,9 @@ using UIKit;
 
 namespace Microsoft.Maui.Platform
 {
-	public abstract class MauiView : UIView, ICrossPlatformLayoutBacking, IVisualTreeElementProvidable, IUIViewLifeCycleEvents
+	public abstract class MauiView : UIView, ICrossPlatformLayoutBacking, IVisualTreeElementProvidable, IUIViewLifeCycleEvents, IMauiPlatformView
 	{
-		bool _fireSetNeedsLayoutOnParentWhenWindowAttached;
+		bool _invalidateParentWhenMovedToWindow;
 		static bool? _respondsToSafeArea;
 
 		double _lastMeasureHeight = double.NaN;
@@ -144,27 +144,6 @@ namespace Microsoft.Maui.Platform
 		{
 			InvalidateConstraintsCache();
 			base.SetNeedsLayout();
-			TryToInvalidateSuperView(false);
-		}
-
-		private protected void TryToInvalidateSuperView(bool shouldOnlyInvalidateIfPending)
-		{
-			if (shouldOnlyInvalidateIfPending && !_fireSetNeedsLayoutOnParentWhenWindowAttached)
-			{
-				return;
-			}
-
-			// We check for Window to avoid scenarios where an invalidate might propagate up the tree
-			// To a SuperView that's been disposed which will cause a crash when trying to access it
-			if (Window is not null)
-			{
-				this.Superview?.SetNeedsLayout();
-				_fireSetNeedsLayoutOnParentWhenWindowAttached = false;
-			}
-			else
-			{
-				_fireSetNeedsLayoutOnParentWhenWindowAttached = true;
-			}
 		}
 
 		IVisualTreeElement? IVisualTreeElementProvidable.GetElement()
@@ -185,6 +164,11 @@ namespace Microsoft.Maui.Platform
 			return null;
 		}
 
+		void IMauiPlatformView.InvalidateAncestorsMeasuresWhenMovedToWindow()
+		{
+			_invalidateParentWhenMovedToWindow = true;
+		}
+
 		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = IUIViewLifeCycleEvents.UnconditionalSuppressMessage)]
 		EventHandler? _movedToWindow;
 		event EventHandler? IUIViewLifeCycleEvents.MovedToWindow
@@ -197,7 +181,11 @@ namespace Microsoft.Maui.Platform
 		{
 			base.MovedToWindow();
 			_movedToWindow?.Invoke(this, EventArgs.Empty);
-			TryToInvalidateSuperView(true);
+			if (_invalidateParentWhenMovedToWindow)
+			{
+				_invalidateParentWhenMovedToWindow = false;
+				this.InvalidateAncestorsMeasures();
+			}
 		}
 
 		[UnconditionalSuppressMessage("Memory", "MEM0001", Justification = IUIViewLifeCycleEvents.UnconditionalSuppressMessage)]

--- a/src/Core/src/Platform/iOS/PageView.cs
+++ b/src/Core/src/Platform/iOS/PageView.cs
@@ -1,0 +1,6 @@
+namespace Microsoft.Maui.Platform;
+
+internal class PageView : ContentView
+{
+	
+}

--- a/src/Core/src/Platform/iOS/PageViewController.cs
+++ b/src/Core/src/Platform/iOS/PageViewController.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.Maui.ApplicationModel;
-using UIKit;
+﻿using UIKit;
 
 namespace Microsoft.Maui.Platform
 {
@@ -15,9 +14,9 @@ namespace Microsoft.Maui.Platform
 
 		protected override UIView CreatePlatformView(IElement view)
 		{
-			return new ContentView
+			return new PageView
 			{
-				CrossPlatformLayout = ((IContentView)view)
+				CrossPlatformLayout = (IContentView)view
 			};
 		}
 

--- a/src/Core/src/Platform/iOS/ViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/ViewExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Numerics;
 using System.Threading.Tasks;
 using CoreAnimation;
@@ -284,12 +285,49 @@ namespace Microsoft.Maui.Platform
 
 		public static void InvalidateMeasure(this UIView platformView, IView view)
 		{
-			platformView.SetNeedsLayout();
-
-			// MauiView/WrapperView already propagates the SetNeedsLayout to the parent
-			if (platformView is not MauiView && platformView is not WrapperView)
+			if (platformView is MauiScrollView scrollView)
 			{
-				platformView.Superview?.SetNeedsLayout();
+				// To correctly invalidate the measure of a ScrollView, we need to include its content
+				scrollView.Subviews.FirstOrDefault(platformView)?.SetNeedsLayout();
+			}
+
+			platformView.SetNeedsLayout();
+			platformView.InvalidateAncestorsMeasures();
+		}
+
+		internal static void InvalidateAncestorsMeasures(this UIView child)
+		{
+			var childMauiPlatformLayout = child as IMauiPlatformView;
+
+			while (true)
+			{
+				// We check for Window to avoid scenarios where an invalidate might propagate up the tree
+				// To a SuperView that's been disposed which will cause a crash when trying to access it
+				if (child.Window is null)
+				{
+					childMauiPlatformLayout?.InvalidateAncestorsMeasuresWhenMovedToWindow();
+					return;
+				}
+
+				var superview = child.Superview;
+
+				// We're only interested in invalidating the parent if it's a MAUI layout or a parent of a MAUI layout
+				var superviewMauiPlatformLayout = superview as IMauiPlatformView;
+				if (childMauiPlatformLayout != null || superviewMauiPlatformLayout != null)
+				{
+					superview.SetNeedsLayout();
+				}
+
+				// Potential improvement: if the MAUI view (superview here) is constrained to a fixed size, we could stop propagating
+				// when doing this, we must pay attention to a scenario where a non-fixed-size view becomes fixed-size
+				if (superview is null or PageView or UIScrollView)
+				{
+					// We reached the root view or a scrollable area (includes collection view), stop propagating
+					return;
+				}
+
+				child = superview;
+				childMauiPlatformLayout = superviewMauiPlatformLayout;
 			}
 		}
 

--- a/src/Core/src/Platform/iOS/WrapperView.cs
+++ b/src/Core/src/Platform/iOS/WrapperView.cs
@@ -9,9 +9,9 @@ using static Microsoft.Maui.Primitives.Dimension;
 
 namespace Microsoft.Maui.Platform
 {
-	public partial class WrapperView : UIView, IDisposable, IUIViewLifeCycleEvents
+	public partial class WrapperView : UIView, IDisposable, IUIViewLifeCycleEvents, IMauiPlatformView
 	{
-		bool _fireSetNeedsLayoutOnParentWhenWindowAttached;
+		bool _invalidateParentWhenMovedToWindow;
 		WeakReference<ICrossPlatformLayout>? _crossPlatformLayoutReference;
 
 		internal ICrossPlatformLayout? CrossPlatformLayout
@@ -96,6 +96,12 @@ namespace Microsoft.Maui.Platform
 				if (_shadowLayer != null)
 					Layer.InsertSublayer(_shadowLayer, 0);
 			}
+		}
+
+		public override void SetNeedsLayout()
+		{
+			InvalidateConstraintsCache();
+			base.SetNeedsLayout();
 		}
 
 		public override void LayoutSubviews()
@@ -237,32 +243,6 @@ namespace Microsoft.Maui.Platform
 			return returnSize;
 		}
 
-		public override void SetNeedsLayout()
-		{
-			base.SetNeedsLayout();
-			TryToInvalidateSuperView(false);
-		}
-
-		private protected void TryToInvalidateSuperView(bool onlyIfPending)
-		{
-			if (onlyIfPending && !_fireSetNeedsLayoutOnParentWhenWindowAttached)
-			{
-				return;
-			}
-
-			// We check for Window to avoid scenarios where an invalidate might propagate up the tree
-			// To a SuperView that's been disposed which will cause a crash when trying to access it
-			if (Window is not null)
-			{
-				_fireSetNeedsLayoutOnParentWhenWindowAttached = false;
-				this.Superview?.SetNeedsLayout();
-			}
-			else
-			{
-				_fireSetNeedsLayoutOnParentWhenWindowAttached = true;
-			}
-		}
-
 		partial void ClipChanged()
 		{
 			SetClip();
@@ -274,6 +254,12 @@ namespace Microsoft.Maui.Platform
 		}
 
 		partial void BorderChanged() => SetBorder();
+
+		void InvalidateConstraintsCache()
+		{
+			_lastMeasureWidth = double.NaN;
+			_lastMeasureHeight = double.NaN;
+		}
 
 		void SetClip()
 		{
@@ -368,6 +354,11 @@ namespace Microsoft.Maui.Platform
 			return Layer;
 		}
 
+		void IMauiPlatformView.InvalidateAncestorsMeasuresWhenMovedToWindow()
+		{
+			_invalidateParentWhenMovedToWindow = true;
+		}
+
 		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = IUIViewLifeCycleEvents.UnconditionalSuppressMessage)]
 		EventHandler? _movedToWindow;
 		event EventHandler? IUIViewLifeCycleEvents.MovedToWindow
@@ -380,7 +371,11 @@ namespace Microsoft.Maui.Platform
 		{
 			base.MovedToWindow();
 			_movedToWindow?.Invoke(this, EventArgs.Empty);
-			TryToInvalidateSuperView(true);
+			if (_invalidateParentWhenMovedToWindow)
+			{
+				_invalidateParentWhenMovedToWindow = false;
+				this.InvalidateAncestorsMeasures();
+			}
 		}
 	}
 }

--- a/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -77,3 +77,4 @@ static Microsoft.Maui.ViewExtensions.DisconnectHandlers(this Microsoft.Maui.IVie
 override Microsoft.Maui.Platform.MauiCALayer.AddAnimation(CoreAnimation.CAAnimation! animation, string? key) -> void
 *REMOVED*override Microsoft.Maui.Handlers.BorderHandler.ConnectHandler(Microsoft.Maui.Platform.ContentView! platformView) -> void
 override Microsoft.Maui.Handlers.BorderHandler.PlatformArrange(Microsoft.Maui.Graphics.Rect rect) -> void
+override Microsoft.Maui.Handlers.ScrollViewHandler.SetVirtualView(Microsoft.Maui.IView! view) -> void

--- a/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -77,3 +77,4 @@ static Microsoft.Maui.ViewExtensions.DisconnectHandlers(this Microsoft.Maui.IVie
 override Microsoft.Maui.Platform.MauiCALayer.AddAnimation(CoreAnimation.CAAnimation! animation, string? key) -> void
 *REMOVED*override Microsoft.Maui.Handlers.BorderHandler.ConnectHandler(Microsoft.Maui.Platform.ContentView! platformView) -> void
 override Microsoft.Maui.Handlers.BorderHandler.PlatformArrange(Microsoft.Maui.Graphics.Rect rect) -> void
+override Microsoft.Maui.Handlers.ScrollViewHandler.SetVirtualView(Microsoft.Maui.IView! view) -> void


### PR DESCRIPTION
### Description of Change

iOS does NOT provide a way to invalidate the ancestors in a single command (like other platforms do): this is needed to make MAUI layout system work.

To achieve that, we've overridden `SetNeedsLayout` method on our custom `UIView`s like `MauiView`.
This unfortunately causes native-triggered `SetNeedsLayout` to bubble up.
When mapping `TranslationX`, iOS natively triggers a `SetNeedsLayout` on that view, which causes not needed propagation.

This PR moves the `SetNeedsLayout` propagation to the mapping code and fixes the issue.
Besides that, this PR stops the propagation when encountering a `UIScrollView` or the page.
This should improve the performance when using scrollable areas.

There are some situations, where scrollable area are "sized-to-content".
This was already handled by collection view handler by watching the content size, so I've done the same within `MauiScrollView` through `AddObserver`.

Follow-up PR #25664 which replaces this one.

### Issues Fixed

Fixes #24996
