### PR TITLE
[Windows] Improve AOT compatibility on Windows

### DIFF
--- a/src/Compatibility/Core/src/Compatibility.csproj
+++ b/src/Compatibility/Core/src/Compatibility.csproj
@@ -9,7 +9,7 @@
     <iOSRoot>iOS\</iOSRoot>
     <WindowsRoot>Windows\</WindowsRoot>
     <TizenRoot>Tizen\</TizenRoot>
-    <IsAotCompatible Condition="!$(TargetFramework.StartsWith('netstandard')) and $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) != 'windows'">true</IsAotCompatible>
+    <IsAotCompatible Condition="!$(TargetFramework.StartsWith('netstandard'))">true</IsAotCompatible>
     <MauiGenerateResourceDesigner>true</MauiGenerateResourceDesigner>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);CS1591;CS0672;CS0618</NoWarn>
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="$(TargetFramework.Contains('-windows')) == true ">
-    <NoWarn>$(NoWarn);CA1416;CS8305;IL2059</NoWarn>
+    <NoWarn>$(NoWarn);CA1416;CS8305</NoWarn>
     <DefineConstants>$(DefineConstants);WINDOWS</DefineConstants>
   </PropertyGroup>
 
@@ -52,8 +52,6 @@
   </ItemGroup>
   <PropertyGroup>
     <InterceptorsPreviewNamespaces>$(InterceptorsPreviewNamespaces);Microsoft.Maui.Controls.Generated</InterceptorsPreviewNamespaces>
-    <!-- https://github.com/dotnet/msbuild/issues/9785 -->
-    <CompilerResponseFile Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">$(CompilerResponseFile);WorkaroundXamlPreCompilePreviewFeatures.rsp</CompilerResponseFile>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference

--- a/src/Compatibility/Core/src/Compatibility.csproj
+++ b/src/Compatibility/Core/src/Compatibility.csproj
@@ -19,6 +19,7 @@
   <PropertyGroup Condition="$(TargetFramework.Contains('-windows')) == true ">
     <NoWarn>$(NoWarn);CA1416;CS8305</NoWarn>
     <DefineConstants>$(DefineConstants);WINDOWS</DefineConstants>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Compatibility/Core/src/Windows/ActivityIndicatorRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/ActivityIndicatorRenderer.cs
@@ -6,7 +6,7 @@ using Microsoft.UI.Xaml;
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
 	[System.Obsolete(Compatibility.Hosting.MauiAppBuilderExtensions.UseMapperInstead)]
-	public class ActivityIndicatorRenderer : ViewRenderer<ActivityIndicator, FormsProgressBar>
+	public partial class ActivityIndicatorRenderer : ViewRenderer<ActivityIndicator, FormsProgressBar>
 	{
 		object _foregroundDefault;
 

--- a/src/Compatibility/Core/src/Windows/AlertDialog.cs
+++ b/src/Compatibility/Core/src/Windows/AlertDialog.cs
@@ -3,7 +3,7 @@ using Microsoft.UI.Xaml.Controls;
 
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
-	public class AlertDialog : ContentDialog
+	public partial class AlertDialog : ContentDialog
 	{
 		public Microsoft.UI.Xaml.Controls.ScrollBarVisibility VerticalScrollBarVisibility { get; set; }
 

--- a/src/Compatibility/Core/src/Windows/BoolToVisibilityConverter.cs
+++ b/src/Compatibility/Core/src/Windows/BoolToVisibilityConverter.cs
@@ -3,7 +3,7 @@ using Microsoft.UI.Xaml;
 
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
-	public sealed class BoolToVisibilityConverter : Microsoft.UI.Xaml.Data.IValueConverter
+	public sealed partial class BoolToVisibilityConverter : Microsoft.UI.Xaml.Data.IValueConverter
 	{
 		public bool FalseIsVisible { get; set; }
 

--- a/src/Compatibility/Core/src/Windows/BoxViewBorderRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/BoxViewBorderRenderer.cs
@@ -9,7 +9,7 @@ using WShape = Microsoft.UI.Xaml.Shapes.Shape;
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
 	[System.Obsolete(Compatibility.Hosting.MauiAppBuilderExtensions.UseMapperInstead)]
-	public class BoxViewBorderRenderer : ViewRenderer<BoxView, WBorder>
+	public partial class BoxViewBorderRenderer : ViewRenderer<BoxView, WBorder>
 	{
 		protected override void OnElementChanged(ElementChangedEventArgs<BoxView> e)
 		{

--- a/src/Compatibility/Core/src/Windows/BrushConverter.cs
+++ b/src/Compatibility/Core/src/Windows/BrushConverter.cs
@@ -4,7 +4,7 @@ using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
-	public class BrushConverter : Microsoft.UI.Xaml.Data.IValueConverter
+	public partial class BrushConverter : Microsoft.UI.Xaml.Data.IValueConverter
 	{
 		public object Convert(object value, Type targetType, object parameter, string language)
 		{

--- a/src/Compatibility/Core/src/Windows/ButtonRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/ButtonRenderer.cs
@@ -15,7 +15,7 @@ using WThickness = Microsoft.UI.Xaml.Thickness;
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
 	[Obsolete(Compatibility.Hosting.MauiAppBuilderExtensions.UseMapperInstead)]
-	public class ButtonRenderer : ViewRenderer<Button, FormsButton>
+	public partial class ButtonRenderer : ViewRenderer<Button, FormsButton>
 	{
 		bool _fontApplied;
 		TextBlock _textBlock = null;

--- a/src/Compatibility/Core/src/Windows/CarouselPageRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/CarouselPageRenderer.cs
@@ -10,7 +10,7 @@ using WSelectionChangedEventArgs = Microsoft.UI.Xaml.Controls.SelectionChangedEv
 
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
-	internal class CarouselPageRenderer : FlipView, IVisualElementRenderer
+	internal partial class CarouselPageRenderer : FlipView, IVisualElementRenderer
 	{
 		bool _fromUpdate;
 		bool _disposed;

--- a/src/Compatibility/Core/src/Windows/CellControl.cs
+++ b/src/Compatibility/Core/src/Windows/CellControl.cs
@@ -22,7 +22,7 @@ using WSolidColorBrush = Microsoft.UI.Xaml.Media.SolidColorBrush;
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
 	[Obsolete("Use Microsoft.Maui.Controls.Platform.Compatibility.CellControl instead")]
-	public class CellControl : ContentControl
+	public partial class CellControl : ContentControl
 	{
 		public static readonly DependencyProperty CellProperty = DependencyProperty.Register("Cell", typeof(object), typeof(CellControl),
 			new PropertyMetadata(null, (o, e) => ((CellControl)o).SetSource((Cell)e.OldValue, (Cell)e.NewValue)));

--- a/src/Compatibility/Core/src/Windows/CheckBoxRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/CheckBoxRenderer.cs
@@ -7,7 +7,7 @@ using WBrush = Microsoft.UI.Xaml.Media.Brush;
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
 	[System.Obsolete(Compatibility.Hosting.MauiAppBuilderExtensions.UseMapperInstead)]
-	public class CheckBoxRenderer : ViewRenderer<CheckBox, FormsCheckBox>
+	public partial class CheckBoxRenderer : ViewRenderer<CheckBox, FormsCheckBox>
 	{
 		static WBrush _tintDefaultBrush = Colors.Blue.ToPlatform();
 		bool _disposed = false;

--- a/src/Compatibility/Core/src/Windows/CollectionView/CarouselViewRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/CollectionView/CarouselViewRenderer.cs
@@ -19,7 +19,7 @@ using WSnapPointsType = Microsoft.UI.Xaml.Controls.SnapPointsType;
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
 	[System.Obsolete(Compatibility.Hosting.MauiAppBuilderExtensions.UseMapperInstead)]
-	public class CarouselViewRenderer : ItemsViewRenderer<CarouselView>
+	public partial class CarouselViewRenderer : ItemsViewRenderer<CarouselView>
 	{
 		ScrollViewer _scrollViewer;
 		WScrollBarVisibility? _horizontalScrollBarVisibilityWithoutLoop;

--- a/src/Compatibility/Core/src/Windows/CollectionView/CollectionViewRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/CollectionView/CollectionViewRenderer.cs
@@ -14,7 +14,7 @@ using Windows.Foundation;
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
 	[System.Obsolete(Compatibility.Hosting.MauiAppBuilderExtensions.UseMapperInstead)]
-	public class CollectionViewRenderer : GroupableItemsViewRenderer<GroupableItemsView>
+	public partial class CollectionViewRenderer : GroupableItemsViewRenderer<GroupableItemsView>
 	{
 	}
 }

--- a/src/Compatibility/Core/src/Windows/CollectionView/GroupableItemsViewRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/CollectionView/GroupableItemsViewRenderer.cs
@@ -6,7 +6,7 @@ using Microsoft.UI.Xaml.Data;
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
 	[System.Obsolete(Compatibility.Hosting.MauiAppBuilderExtensions.UseMapperInstead)]
-	public class GroupableItemsViewRenderer<TItemsView> : SelectableItemsViewRenderer<TItemsView>
+	public partial class GroupableItemsViewRenderer<TItemsView> : SelectableItemsViewRenderer<TItemsView>
 		where TItemsView : GroupableItemsView
 	{
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs changedProperty)

--- a/src/Compatibility/Core/src/Windows/CollectionView/ItemContentControl.cs
+++ b/src/Compatibility/Core/src/Windows/CollectionView/ItemContentControl.cs
@@ -10,7 +10,7 @@ using WThickness = Microsoft.UI.Xaml.Thickness;
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
 	[System.Obsolete]
-	public class ItemContentControl : ContentControl
+	public partial class ItemContentControl : ContentControl
 	{
 		VisualElement _visualElement;
 		IVisualElementRenderer _renderer;

--- a/src/Compatibility/Core/src/Windows/CollectionView/SelectableItemsViewRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/CollectionView/SelectableItemsViewRenderer.cs
@@ -9,7 +9,7 @@ using UWPSelectionChangedEventArgs = Microsoft.UI.Xaml.Controls.SelectionChanged
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
 	[System.Obsolete(Compatibility.Hosting.MauiAppBuilderExtensions.UseMapperInstead)]
-	public class SelectableItemsViewRenderer<TItemsView> : StructuredItemsViewRenderer<TItemsView>
+	public partial class SelectableItemsViewRenderer<TItemsView> : StructuredItemsViewRenderer<TItemsView>
 		where TItemsView : SelectableItemsView
 	{
 		bool _ignoreNativeSelectionChange;
@@ -201,7 +201,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 			ItemsView.SelectionChanged += FormsSelectionChanged;
 		}
 
-		class SelectionModeConvert : Microsoft.UI.Xaml.Data.IValueConverter
+		partial class SelectionModeConvert : Microsoft.UI.Xaml.Data.IValueConverter
 		{
 			public object Convert(object value, Type targetType, object parameter, string language)
 			{

--- a/src/Compatibility/Core/src/Windows/CollectionView/StructuredItemsViewRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/CollectionView/StructuredItemsViewRenderer.cs
@@ -13,7 +13,7 @@ using WThickness = Microsoft.UI.Xaml.Thickness;
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
 	[System.Obsolete(Compatibility.Hosting.MauiAppBuilderExtensions.UseMapperInstead)]
-	public class StructuredItemsViewRenderer<TItemsView> : ItemsViewRenderer<TItemsView>
+	public partial class StructuredItemsViewRenderer<TItemsView> : ItemsViewRenderer<TItemsView>
 		where TItemsView : StructuredItemsView
 	{
 		View _currentHeader;

--- a/src/Compatibility/Core/src/Windows/DatePickerRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/DatePickerRenderer.cs
@@ -15,7 +15,7 @@ using WBrush = Microsoft.UI.Xaml.Media.Brush;
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
 	[System.Obsolete(Compatibility.Hosting.MauiAppBuilderExtensions.UseMapperInstead)]
-	public class DatePickerRenderer : ViewRenderer<DatePicker, Microsoft.UI.Xaml.Controls.DatePicker>
+	public partial class DatePickerRenderer : ViewRenderer<DatePicker, Microsoft.UI.Xaml.Controls.DatePicker>
 	{
 		WBrush _defaultBrush;
 		bool _fontApplied;

--- a/src/Compatibility/Core/src/Windows/DefaultRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/DefaultRenderer.cs
@@ -3,7 +3,7 @@ using Microsoft.UI.Xaml;
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
 	[System.Obsolete(Compatibility.Hosting.MauiAppBuilderExtensions.UseMapperInstead)]
-	internal sealed class DefaultRenderer : ViewRenderer<View, FrameworkElement>
+	internal sealed partial class DefaultRenderer : ViewRenderer<View, FrameworkElement>
 	{
 	}
 }

--- a/src/Compatibility/Core/src/Windows/EditorRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/EditorRenderer.cs
@@ -13,7 +13,7 @@ using WBrush = Microsoft.UI.Xaml.Media.Brush;
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
 	[System.Obsolete(Compatibility.Hosting.MauiAppBuilderExtensions.UseMapperInstead)]
-	public class EditorRenderer : ViewRenderer<Editor, FormsTextBox>
+	public partial class EditorRenderer : ViewRenderer<Editor, FormsTextBox>
 	{
 		bool _fontApplied;
 		WBrush _backgroundColorFocusedDefaultBrush;

--- a/src/Compatibility/Core/src/Windows/EntryCellTextBox.cs
+++ b/src/Compatibility/Core/src/Windows/EntryCellTextBox.cs
@@ -6,7 +6,7 @@ using Windows.System;
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
 	[Obsolete("Use Microsoft.Maui.Controls.Platform.Compatibility.EntryCellTextBox instead")]
-	public class EntryCellTextBox : TextBox
+	public partial class EntryCellTextBox : TextBox
 	{
 		protected override void OnKeyUp(KeyRoutedEventArgs e)
 		{

--- a/src/Compatibility/Core/src/Windows/EntryRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/EntryRenderer.cs
@@ -15,7 +15,7 @@ using WBrush = Microsoft.UI.Xaml.Media.Brush;
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
 	[System.Obsolete(Compatibility.Hosting.MauiAppBuilderExtensions.UseMapperInstead)]
-	public class EntryRenderer : ViewRenderer<Entry, FormsTextBox>
+	public partial class EntryRenderer : ViewRenderer<Entry, FormsTextBox>
 	{
 		bool _fontApplied;
 		WBrush _backgroundColorFocusedDefaultBrush;

--- a/src/Compatibility/Core/src/Windows/FlyoutPageControl.cs
+++ b/src/Compatibility/Core/src/Windows/FlyoutPageControl.cs
@@ -9,7 +9,7 @@ using WVisibility = Microsoft.UI.Xaml.Visibility;
 
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
-	public class FlyoutPageControl : Control, IToolbarProvider, ITitleViewRendererController
+	public partial class FlyoutPageControl : Control, IToolbarProvider, ITitleViewRendererController
 	{
 		public static readonly DependencyProperty FlyoutProperty = DependencyProperty.Register(nameof(Flyout), typeof(FrameworkElement), typeof(FlyoutPageControl),
 			new PropertyMetadata(default(FrameworkElement)));
@@ -388,7 +388,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 
 	}
 
-	public class MasterDetailControl : FlyoutPageControl
+	public partial class MasterDetailControl : FlyoutPageControl
 	{
 		public FrameworkElement Master
 		{

--- a/src/Compatibility/Core/src/Windows/FormsButton.cs
+++ b/src/Compatibility/Core/src/Windows/FormsButton.cs
@@ -9,7 +9,7 @@ using WContentPresenter = Microsoft.UI.Xaml.Controls.ContentPresenter;
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
 	[PortHandler]
-	public class FormsButton : Microsoft.UI.Xaml.Controls.Button
+	public partial class FormsButton : Microsoft.UI.Xaml.Controls.Button
 	{
 		public static readonly DependencyProperty BorderRadiusProperty = DependencyProperty.Register(nameof(BorderRadius), typeof(int), typeof(FormsButton),
 			new PropertyMetadata(default(int), OnBorderRadiusChanged));

--- a/src/Compatibility/Core/src/Windows/FormsCancelButton.cs
+++ b/src/Compatibility/Core/src/Windows/FormsCancelButton.cs
@@ -5,7 +5,7 @@ using WBrush = Microsoft.UI.Xaml.Media.Brush;
 
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
-	internal class FormsCancelButton : Microsoft.UI.Xaml.Controls.Button
+	internal partial class FormsCancelButton : Microsoft.UI.Xaml.Controls.Button
 	{
 		TextBlock _cancelButtonGlyph;
 		WBorder _cancelButtonBackground;

--- a/src/Compatibility/Core/src/Windows/FormsCheckBox.cs
+++ b/src/Compatibility/Core/src/Windows/FormsCheckBox.cs
@@ -5,7 +5,7 @@ using WindowsCheckbox = Microsoft.UI.Xaml.Controls.CheckBox;
 
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
-	public class FormsCheckBox : WindowsCheckbox
+	public partial class FormsCheckBox : WindowsCheckbox
 	{
 		public static readonly DependencyProperty TintBrushProperty =
 			DependencyProperty.Register(nameof(TintBrush), typeof(WBrush), typeof(FormsCheckBox),

--- a/src/Compatibility/Core/src/Windows/FormsComboBox.cs
+++ b/src/Compatibility/Core/src/Windows/FormsComboBox.cs
@@ -6,7 +6,7 @@ using WVisualState = Microsoft.UI.Xaml.VisualState;
 
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
-	public class FormsComboBox : ComboBox
+	public partial class FormsComboBox : ComboBox
 	{
 		public FormsComboBox()
 		{

--- a/src/Compatibility/Core/src/Windows/FormsCommandBar.cs
+++ b/src/Compatibility/Core/src/Windows/FormsCommandBar.cs
@@ -8,7 +8,7 @@ using WVisibility = Microsoft.UI.Xaml.Visibility;
 
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
-	public class FormsCommandBar : CommandBar
+	public partial class FormsCommandBar : CommandBar
 	{
 		Microsoft.UI.Xaml.Controls.Button _moreButton;
 		Microsoft.UI.Xaml.Controls.ItemsControl _primaryItemsControl;

--- a/src/Compatibility/Core/src/Windows/FormsPivot.cs
+++ b/src/Compatibility/Core/src/Windows/FormsPivot.cs
@@ -7,7 +7,7 @@ using WBrush = Microsoft.UI.Xaml.Media.Brush;
 
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
-	public class FormsPivot : Pivot, IToolbarProvider
+	public partial class FormsPivot : Pivot, IToolbarProvider
 	{
 		public static readonly DependencyProperty TitleVisibilityProperty = DependencyProperty.Register(nameof(TitleVisibility), typeof(UI.Xaml.Visibility), typeof(FormsPivot), new PropertyMetadata(UI.Xaml.Visibility.Collapsed));
 

--- a/src/Compatibility/Core/src/Windows/FormsPresenter.cs
+++ b/src/Compatibility/Core/src/Windows/FormsPresenter.cs
@@ -5,7 +5,7 @@ using Microsoft.UI.Xaml;
 
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
-	internal class FormsPresenter : Microsoft.UI.Xaml.Controls.ContentPresenter
+	internal partial class FormsPresenter : Microsoft.UI.Xaml.Controls.ContentPresenter
 	{
 		public FormsPresenter()
 		{

--- a/src/Compatibility/Core/src/Windows/FormsProgressBar.cs
+++ b/src/Compatibility/Core/src/Windows/FormsProgressBar.cs
@@ -2,7 +2,7 @@ using Microsoft.UI.Xaml;
 
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
-	public class FormsProgressBar : Microsoft.UI.Xaml.Controls.ProgressBar
+	public partial class FormsProgressBar : Microsoft.UI.Xaml.Controls.ProgressBar
 	{
 		public static readonly DependencyProperty ElementOpacityProperty = DependencyProperty.Register(
 			nameof(ElementOpacity), typeof(double), typeof(FormsProgressBar), new PropertyMetadata(default(double)));

--- a/src/Compatibility/Core/src/Windows/FormsRadioButton.cs
+++ b/src/Compatibility/Core/src/Windows/FormsRadioButton.cs
@@ -6,7 +6,7 @@ using WContentPresenter = Microsoft.UI.Xaml.Controls.ContentPresenter;
 
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
-	public class FormsRadioButton : Microsoft.UI.Xaml.Controls.RadioButton
+	public partial class FormsRadioButton : Microsoft.UI.Xaml.Controls.RadioButton
 	{
 		public static readonly DependencyProperty BorderRadiusProperty = DependencyProperty.Register(nameof(BorderRadius), typeof(int), typeof(FormsButton),
 			new PropertyMetadata(default(int), OnBorderRadiusChanged));

--- a/src/Compatibility/Core/src/Windows/FormsSlider.cs
+++ b/src/Compatibility/Core/src/Windows/FormsSlider.cs
@@ -8,7 +8,7 @@ using WVisibility = Microsoft.UI.Xaml.Visibility;
 
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
-	public class FormsSlider : Microsoft.UI.Xaml.Controls.Slider
+	public partial class FormsSlider : Microsoft.UI.Xaml.Controls.Slider
 	{
 		internal Thumb Thumb { get; set; }
 		internal Thumb ImageThumb { get; set; }

--- a/src/Compatibility/Core/src/Windows/FormsTextBox.cs
+++ b/src/Compatibility/Core/src/Windows/FormsTextBox.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 	///     An intermediate class for injecting bindings for things the default
 	///     textbox doesn't allow us to bind/modify
 	/// </summary>
-	public class FormsTextBox : TextBox
+	public partial class FormsTextBox : TextBox
 	{
 		const char ObfuscationCharacter = '●';
 

--- a/src/Compatibility/Core/src/Windows/FrameRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/FrameRenderer.cs
@@ -10,7 +10,7 @@ using WBorder = Microsoft.UI.Xaml.Controls.Border;
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
 	[Obsolete("Use Microsoft.Maui.Controls.Handlers.Compatibility.FrameRenderer instead")]
-	public class FrameRenderer : ViewRenderer<Frame, WBorder>
+	public partial class FrameRenderer : ViewRenderer<Frame, WBorder>
 	{
 		public FrameRenderer()
 		{

--- a/src/Compatibility/Core/src/Windows/ImageButtonRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/ImageButtonRenderer.cs
@@ -16,7 +16,7 @@ using WThickness = Microsoft.UI.Xaml.Thickness;
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
 	[System.Obsolete(Compatibility.Hosting.MauiAppBuilderExtensions.UseMapperInstead)]
-	public class ImageButtonRenderer : ViewRenderer<ImageButton, FormsButton>, IImageVisualElementRenderer
+	public partial class ImageButtonRenderer : ViewRenderer<ImageButton, FormsButton>, IImageVisualElementRenderer
 	{
 		bool _measured;
 		bool _disposed;

--- a/src/Compatibility/Core/src/Windows/ImageRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/ImageRenderer.cs
@@ -9,7 +9,7 @@ using Microsoft.UI.Xaml;
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
 	[System.Obsolete(Compatibility.Hosting.MauiAppBuilderExtensions.UseMapperInstead)]
-	public class ImageRenderer : ViewRenderer<Image, Microsoft.UI.Xaml.Controls.Image>, IImageVisualElementRenderer
+	public partial class ImageRenderer : ViewRenderer<Image, Microsoft.UI.Xaml.Controls.Image>, IImageVisualElementRenderer
 	{
 		bool _measured;
 		bool _disposed;

--- a/src/Compatibility/Core/src/Windows/ImageSourceIconElementConverter.cs
+++ b/src/Compatibility/Core/src/Windows/ImageSourceIconElementConverter.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
-	internal class ImageSourceIconElementConverter : Microsoft.UI.Xaml.Data.IValueConverter
+	internal partial class ImageSourceIconElementConverter : Microsoft.UI.Xaml.Data.IValueConverter
 	{
 		public object Convert(object value, Type targetType, object parameter, string language)
 		{

--- a/src/Compatibility/Core/src/Windows/IndicatorViewRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/IndicatorViewRenderer.cs
@@ -14,7 +14,7 @@ using WSolidColorBrush = Microsoft.UI.Xaml.Media.SolidColorBrush;
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
 	[System.Obsolete(Compatibility.Hosting.MauiAppBuilderExtensions.UseMapperInstead)]
-	class IndicatorViewRenderer : ViewRenderer<IndicatorView, FrameworkElement>
+	partial class IndicatorViewRenderer : ViewRenderer<IndicatorView, FrameworkElement>
 	{
 		const int DefaultPadding = 4;
 		WSolidColorBrush _selectedColor;

--- a/src/Compatibility/Core/src/Windows/InterceptVisualStateManager.cs
+++ b/src/Compatibility/Core/src/Windows/InterceptVisualStateManager.cs
@@ -4,7 +4,7 @@ using Microsoft.UI.Xaml.Controls;
 
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
-	internal class InterceptVisualStateManager : Microsoft.UI.Xaml.VisualStateManager
+	internal partial class InterceptVisualStateManager : Microsoft.UI.Xaml.VisualStateManager
 	{
 		static InterceptVisualStateManager s_instance;
 

--- a/src/Compatibility/Core/src/Windows/LabelRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/LabelRenderer.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 	}
 
 	[System.Obsolete(Compatibility.Hosting.MauiAppBuilderExtensions.UseMapperInstead)]
-	public class LabelRenderer : ViewRenderer<Label, TextBlock>
+	public partial class LabelRenderer : ViewRenderer<Label, TextBlock>
 	{
 		bool _fontApplied;
 		bool _isInitiallyDefault;

--- a/src/Compatibility/Core/src/Windows/LayoutRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/LayoutRenderer.cs
@@ -11,7 +11,7 @@ using WSolidColorBrush = Microsoft.UI.Xaml.Media.SolidColorBrush;
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
 	[System.Obsolete(Compatibility.Hosting.MauiAppBuilderExtensions.UseMapperInstead)]
-	public class LayoutRenderer : ViewRenderer<Layout, FrameworkElement>
+	public partial class LayoutRenderer : ViewRenderer<Layout, FrameworkElement>
 	{
 		protected override void OnElementChanged(ElementChangedEventArgs<Layout> e)
 		{

--- a/src/Compatibility/Core/src/Windows/ListGroupHeaderPresenter.cs
+++ b/src/Compatibility/Core/src/Windows/ListGroupHeaderPresenter.cs
@@ -7,7 +7,7 @@ using Microsoft.UI.Xaml.Media;
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
 	[Obsolete("Use Microsoft.Maui.Controls.Platform.Compatibility.ListGroupHeaderPresenter instead")]
-	public class ListGroupHeaderPresenter : Microsoft.UI.Xaml.Controls.ContentPresenter
+	public partial class ListGroupHeaderPresenter : Microsoft.UI.Xaml.Controls.ContentPresenter
 	{
 		void OnTapped(object sender, TappedRoutedEventArgs tappedRoutedEventArgs)
 		{

--- a/src/Compatibility/Core/src/Windows/ListViewGroupStyleSelector.cs
+++ b/src/Compatibility/Core/src/Windows/ListViewGroupStyleSelector.cs
@@ -4,7 +4,7 @@ using Microsoft.UI.Xaml.Controls;
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
 	[Obsolete("Use Microsoft.Maui.Controls.Platform.Compatibility.ListViewGroupStyleSelector instead")]
-	public class ListViewGroupStyleSelector : GroupStyleSelector
+	public partial class ListViewGroupStyleSelector : GroupStyleSelector
 	{
 		protected override GroupStyle SelectGroupStyleCore(object group, uint level)
 		{

--- a/src/Compatibility/Core/src/Windows/ListViewRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/ListViewRenderer.cs
@@ -29,7 +29,7 @@ using WSelectionChangedEventArgs = Microsoft.UI.Xaml.Controls.SelectionChangedEv
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
 	[Obsolete("Use Microsoft.Maui.Controls.Handlers.Compatibility.ListViewRenderer instead")]
-	public class ListViewRenderer : ViewRenderer<ListView, FrameworkElement>
+	public partial class ListViewRenderer : ViewRenderer<ListView, FrameworkElement>
 	{
 		ITemplatedItemsView<Cell> TemplatedItemsView => Element;
 		bool _collectionIsWrapped;
@@ -45,7 +45,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 
 		protected WListView List { get; private set; }
 
-		protected class ListViewTransparent : WListView
+		protected partial class ListViewTransparent : WListView
 		{
 			public ListViewTransparent() : base() { }
 

--- a/src/Compatibility/Core/src/Windows/MasterBackgroundConverter.cs
+++ b/src/Compatibility/Core/src/Windows/MasterBackgroundConverter.cs
@@ -8,7 +8,7 @@ using WSolidColorBrush = Microsoft.UI.Xaml.Media.SolidColorBrush;
 
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
-	public class MasterBackgroundConverter : Microsoft.UI.Xaml.Data.IValueConverter
+	public partial class MasterBackgroundConverter : Microsoft.UI.Xaml.Data.IValueConverter
 	{
 		// Obtained by comparing the Mail apps master section background to the detail background
 		const double Shift = 0.03;

--- a/src/Compatibility/Core/src/Windows/NativeViewWrapperRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/NativeViewWrapperRenderer.cs
@@ -5,7 +5,7 @@ using Microsoft.UI.Xaml;
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
 #pragma warning disable CS0618 // Type or member is obsolete
-	public class NativeViewWrapperRenderer : ViewRenderer<NativeViewWrapper, FrameworkElement>
+	public partial class NativeViewWrapperRenderer : ViewRenderer<NativeViewWrapper, FrameworkElement>
 #pragma warning restore CS0618 // Type or member is obsolete
 	{
 		public override SizeRequest GetDesiredSize(double widthConstraint, double heightConstraint)

--- a/src/Compatibility/Core/src/Windows/PageControl.cs
+++ b/src/Compatibility/Core/src/Windows/PageControl.cs
@@ -8,7 +8,7 @@ using WVisibility = Microsoft.UI.Xaml.Visibility;
 
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
-	public sealed class PageControl : ContentControl, IToolbarProvider, ITitleViewRendererController
+	public sealed partial class PageControl : ContentControl, IToolbarProvider, ITitleViewRendererController
 	{
 		public static readonly DependencyProperty TitleVisibilityProperty = DependencyProperty.Register(nameof(TitleVisibility), typeof(WVisibility), typeof(PageControl), new PropertyMetadata(WVisibility.Visible));
 

--- a/src/Compatibility/Core/src/Windows/PageRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/PageRenderer.cs
@@ -10,7 +10,7 @@ using Windows.UI.ViewManagement;
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
 	[System.Obsolete(Compatibility.Hosting.MauiAppBuilderExtensions.UseMapperInstead)]
-	public class PageRenderer :
+	public partial class PageRenderer :
 		//Microsoft.UI.Xaml.Controls.Grid, IVisualElementRenderer 
 		VisualElementRenderer<Page, FrameworkElement>
 	{

--- a/src/Compatibility/Core/src/Windows/PageToRenderedElementConverter.cs
+++ b/src/Compatibility/Core/src/Windows/PageToRenderedElementConverter.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
-	public class PageToRenderedElementConverter : Microsoft.UI.Xaml.Data.IValueConverter
+	public partial class PageToRenderedElementConverter : Microsoft.UI.Xaml.Data.IValueConverter
 	{
 		public object Convert(object value, Type targetType, object parameter, string language)
 		{

--- a/src/Compatibility/Core/src/Windows/PickerRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/PickerRenderer.cs
@@ -13,7 +13,7 @@ using WSelectionChangedEventArgs = Microsoft.UI.Xaml.Controls.SelectionChangedEv
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
 	[System.Obsolete(Compatibility.Hosting.MauiAppBuilderExtensions.UseMapperInstead)]
-	public class PickerRenderer : ViewRenderer<Picker, FormsComboBox>
+	public partial class PickerRenderer : ViewRenderer<Picker, FormsComboBox>
 	{
 		bool _fontApplied;
 		bool _isAnimating;

--- a/src/Compatibility/Core/src/Windows/ProgressBarRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/ProgressBarRenderer.cs
@@ -8,7 +8,7 @@ using Microsoft.UI.Xaml.Controls.Primitives;
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
 	[System.Obsolete(Compatibility.Hosting.MauiAppBuilderExtensions.UseMapperInstead)]
-	public class ProgressBarRenderer : ViewRenderer<ProgressBar, Microsoft.UI.Xaml.Controls.ProgressBar>
+	public partial class ProgressBarRenderer : ViewRenderer<ProgressBar, Microsoft.UI.Xaml.Controls.ProgressBar>
 	{
 		object _foregroundDefault;
 

--- a/src/Compatibility/Core/src/Windows/RadioButtonRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/RadioButtonRenderer.cs
@@ -10,7 +10,7 @@ using WThickness = Microsoft.UI.Xaml.Thickness;
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
 	[System.Obsolete(Compatibility.Hosting.MauiAppBuilderExtensions.UseMapperInstead)]
-	public class RadioButtonRenderer : ViewRenderer<RadioButton, FormsRadioButton>
+	public partial class RadioButtonRenderer : ViewRenderer<RadioButton, FormsRadioButton>
 	{
 		bool _fontApplied;
 

--- a/src/Compatibility/Core/src/Windows/RefreshViewRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/RefreshViewRenderer.cs
@@ -14,7 +14,7 @@ using WBrush = Microsoft.UI.Xaml.Media.Brush;
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
 	[System.Obsolete(Compatibility.Hosting.MauiAppBuilderExtensions.UseMapperInstead)]
-	public class RefreshViewRenderer : ViewRenderer<RefreshView, RefreshContainer>
+	public partial class RefreshViewRenderer : ViewRenderer<RefreshView, RefreshContainer>
 	{
 		bool _isDisposed;
 		Deferral _refreshCompletionDeferral;

--- a/src/Compatibility/Core/src/Windows/ScrollViewRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/ScrollViewRenderer.cs
@@ -11,7 +11,7 @@ using WRect = Windows.Foundation.Rect;
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
 	[System.Obsolete(Compatibility.Hosting.MauiAppBuilderExtensions.UseMapperInstead)]
-	public class ScrollViewRenderer : ViewRenderer<ScrollView, ScrollViewer>
+	public partial class ScrollViewRenderer : ViewRenderer<ScrollView, ScrollViewer>
 	{
 		VisualElement _currentView;
 		bool _checkedForRtlScroll = false;

--- a/src/Compatibility/Core/src/Windows/SearchBarRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/SearchBarRenderer.cs
@@ -12,7 +12,7 @@ using WBrush = Microsoft.UI.Xaml.Media.Brush;
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
 	[System.Obsolete(Compatibility.Hosting.MauiAppBuilderExtensions.UseMapperInstead)]
-	public class SearchBarRenderer : ViewRenderer<SearchBar, AutoSuggestBox>
+	public partial class SearchBarRenderer : ViewRenderer<SearchBar, AutoSuggestBox>
 	{
 		WBrush _defaultPlaceholderColorBrush;
 		WBrush _defaultPlaceholderColorFocusBrush;

--- a/src/Compatibility/Core/src/Windows/Shapes/EllipseRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/Shapes/EllipseRenderer.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.WPF
 #endif
 {
 	[System.Obsolete(Compatibility.Hosting.MauiAppBuilderExtensions.UseMapperInstead)]
-	public class EllipseRenderer : ShapeRenderer<Ellipse, WEllipse>
+	public partial class EllipseRenderer : ShapeRenderer<Ellipse, WEllipse>
 	{
 		protected override void OnElementChanged(ElementChangedEventArgs<Ellipse> args)
 		{

--- a/src/Compatibility/Core/src/Windows/Shapes/LineRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/Shapes/LineRenderer.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.WPF
 #endif
 {
 	[System.Obsolete(Compatibility.Hosting.MauiAppBuilderExtensions.UseMapperInstead)]
-	public class LineRenderer : ShapeRenderer<Line, WLine>
+	public partial class LineRenderer : ShapeRenderer<Line, WLine>
 	{
 		protected override void OnElementChanged(ElementChangedEventArgs<Line> args)
 		{

--- a/src/Compatibility/Core/src/Windows/Shapes/PathRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/Shapes/PathRenderer.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.WPF
 #endif
 {
 	[System.Obsolete(Compatibility.Hosting.MauiAppBuilderExtensions.UseMapperInstead)]
-	public class PathRenderer : ShapeRenderer<Path, WPath>
+	public partial class PathRenderer : ShapeRenderer<Path, WPath>
 	{
 		protected override void OnElementChanged(ElementChangedEventArgs<Path> args)
 		{

--- a/src/Compatibility/Core/src/Windows/Shapes/PolygonRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/Shapes/PolygonRenderer.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.WPF
 #endif
 {
 	[System.Obsolete(Compatibility.Hosting.MauiAppBuilderExtensions.UseMapperInstead)]
-	public class PolygonRenderer : ShapeRenderer<Polygon, WPolygon>
+	public partial class PolygonRenderer : ShapeRenderer<Polygon, WPolygon>
 	{
 		PointCollection _points;
 

--- a/src/Compatibility/Core/src/Windows/Shapes/PolylineRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/Shapes/PolylineRenderer.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.WPF
 #endif
 {
 	[System.Obsolete(Compatibility.Hosting.MauiAppBuilderExtensions.UseMapperInstead)]
-	public class PolylineRenderer : ShapeRenderer<Polyline, WPolyline>
+	public partial class PolylineRenderer : ShapeRenderer<Polyline, WPolyline>
 	{
 		PointCollection _points;
 

--- a/src/Compatibility/Core/src/Windows/Shapes/RectangleRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/Shapes/RectangleRenderer.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.WPF
 #endif
 {
 	[System.Obsolete(Compatibility.Hosting.MauiAppBuilderExtensions.UseMapperInstead)]
-	public class RectangleRenderer : ShapeRenderer<FormsRectangle, WRectangle>
+	public partial class RectangleRenderer : ShapeRenderer<FormsRectangle, WRectangle>
 	{
 		protected override void OnElementChanged(ElementChangedEventArgs<FormsRectangle> args)
 		{

--- a/src/Compatibility/Core/src/Windows/Shapes/ShapeRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/Shapes/ShapeRenderer.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.WPF
 #endif
 {
 	[System.Obsolete(Compatibility.Hosting.MauiAppBuilderExtensions.UseMapperInstead)]
-	public class ShapeRenderer<TShape, TNativeShape> : ViewRenderer<TShape, TNativeShape>
+	public partial class ShapeRenderer<TShape, TNativeShape> : ViewRenderer<TShape, TNativeShape>
 		  where TShape : Shape
 		  where TNativeShape : WShape
 	{

--- a/src/Compatibility/Core/src/Windows/SliderRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/SliderRenderer.cs
@@ -12,7 +12,7 @@ using WBrush = Microsoft.UI.Xaml.Media.Brush;
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
 	[System.Obsolete(Compatibility.Hosting.MauiAppBuilderExtensions.UseMapperInstead)]
-	public class SliderRenderer : ViewRenderer<Slider, FormsSlider>
+	public partial class SliderRenderer : ViewRenderer<Slider, FormsSlider>
 	{
 		WBrush defaultforegroundcolor;
 		WBrush defaultbackgroundcolor;

--- a/src/Compatibility/Core/src/Windows/StepperControl.cs
+++ b/src/Compatibility/Core/src/Windows/StepperControl.cs
@@ -13,7 +13,7 @@ using WVisualStateManager = Microsoft.UI.Xaml.VisualStateManager;
 
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
-	public sealed class StepperControl : Control
+	public sealed partial class StepperControl : Control
 	{
 		public static readonly DependencyProperty ValueProperty = DependencyProperty.Register("Value", typeof(double), typeof(StepperControl), new PropertyMetadata(default(double), OnValueChanged));
 

--- a/src/Compatibility/Core/src/Windows/StepperRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/StepperRenderer.cs
@@ -5,7 +5,7 @@ using Microsoft.Maui.Controls.Platform;
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
 	[System.Obsolete(Compatibility.Hosting.MauiAppBuilderExtensions.UseMapperInstead)]
-	public class StepperRenderer : ViewRenderer<Stepper, StepperControl>
+	public partial class StepperRenderer : ViewRenderer<Stepper, StepperControl>
 	{
 		bool _isDisposed;
 

--- a/src/Compatibility/Core/src/Windows/SwipeViewRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/SwipeViewRenderer.cs
@@ -14,7 +14,7 @@ using WSwipeMode = Microsoft.UI.Xaml.Controls.SwipeMode;
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
 	[System.Obsolete(Compatibility.Hosting.MauiAppBuilderExtensions.UseMapperInstead)]
-	public class SwipeViewRenderer : ViewRenderer<SwipeView, WSwipeControl>
+	public partial class SwipeViewRenderer : ViewRenderer<SwipeView, WSwipeControl>
 	{
 		bool _isDisposed;
 		Dictionary<WSwipeItem, SwipeItem> _leftItems;

--- a/src/Compatibility/Core/src/Windows/SwitchRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/SwitchRenderer.cs
@@ -16,7 +16,7 @@ using WVisualStateManager = Microsoft.UI.Xaml.VisualStateManager;
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
 	[System.Obsolete(Compatibility.Hosting.MauiAppBuilderExtensions.UseMapperInstead)]
-	public class SwitchRenderer : ViewRenderer<Switch, ToggleSwitch>
+	public partial class SwitchRenderer : ViewRenderer<Switch, ToggleSwitch>
 	{
 		const string ToggleSwitchCommonStates = "CommonStates";
 		const string ToggleSwitchPointerOver = "PointerOver";

--- a/src/Compatibility/Core/src/Windows/TableViewRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/TableViewRenderer.cs
@@ -9,7 +9,7 @@ using WSelectionChangedEventArgs = Microsoft.UI.Xaml.Controls.SelectionChangedEv
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
 	[Obsolete("Use Microsoft.Maui.Controls.Handlers.Compatibility.TableViewRenderer instead")]
-	public class TableViewRenderer : ViewRenderer<TableView, Microsoft.UI.Xaml.Controls.ListView>
+	public partial class TableViewRenderer : ViewRenderer<TableView, Microsoft.UI.Xaml.Controls.ListView>
 	{
 		bool _ignoreSelectionEvent;
 		bool _disposed;

--- a/src/Compatibility/Core/src/Windows/TextAlignmentToHorizontalAlignmentConverter.cs
+++ b/src/Compatibility/Core/src/Windows/TextAlignmentToHorizontalAlignmentConverter.cs
@@ -3,7 +3,7 @@ using Microsoft.UI.Xaml;
 
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
-	public sealed class TextAlignmentToHorizontalAlignmentConverter : Microsoft.UI.Xaml.Data.IValueConverter
+	public sealed partial class TextAlignmentToHorizontalAlignmentConverter : Microsoft.UI.Xaml.Data.IValueConverter
 	{
 		public object Convert(object value, Type targetType, object parameter, string language)
 		{

--- a/src/Compatibility/Core/src/Windows/TimePickerRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/TimePickerRenderer.cs
@@ -13,7 +13,7 @@ using WBrush = Microsoft.UI.Xaml.Media.Brush;
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
 	[System.Obsolete(Compatibility.Hosting.MauiAppBuilderExtensions.UseMapperInstead)]
-	public class TimePickerRenderer : ViewRenderer<TimePicker, Microsoft.UI.Xaml.Controls.TimePicker>
+	public partial class TimePickerRenderer : ViewRenderer<TimePicker, Microsoft.UI.Xaml.Controls.TimePicker>
 	{
 		WBrush _defaultBrush;
 		bool _fontApplied;

--- a/src/Compatibility/Core/src/Windows/ViewRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/ViewRenderer.cs
@@ -6,7 +6,7 @@ using Microsoft.UI.Xaml.Automation.Peers;
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
 	[Obsolete("Use Microsoft.Maui.Controls.Handlers.Compatibility.ViewRenderer instead")]
-	public class ViewRenderer<TElement, TNativeElement> : VisualElementRenderer<TElement, TNativeElement> where TElement : View where TNativeElement : FrameworkElement
+	public partial class ViewRenderer<TElement, TNativeElement> : VisualElementRenderer<TElement, TNativeElement> where TElement : View where TNativeElement : FrameworkElement
 	{
 		string _defaultAutomationPropertiesName;
 		AccessibilityView? _defaultAutomationPropertiesAccessibilityView;

--- a/src/Compatibility/Core/src/Windows/ViewToRendererConverter.cs
+++ b/src/Compatibility/Core/src/Windows/ViewToRendererConverter.cs
@@ -7,7 +7,7 @@ using WRect = Windows.Foundation.Rect;
 
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
-	public class ViewToRendererConverter : ViewToHandlerConverter
+	public partial class ViewToRendererConverter : ViewToHandlerConverter
 	{
 	}
 }

--- a/src/Compatibility/Core/src/Windows/VisualElementRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/VisualElementRenderer.cs
@@ -16,7 +16,7 @@ using WSolidColorBrush = Microsoft.UI.Xaml.Media.SolidColorBrush;
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
 	[Obsolete("Use Microsoft.Maui.Controls.Handlers.Compatibility.VisualElementRenderer instead")]
-	public class VisualElementRenderer<TElement, TNativeElement> : Panel, IVisualNativeElementRenderer, IDisposable, IEffectControlProvider where TElement : VisualElement
+	public partial class VisualElementRenderer<TElement, TNativeElement> : Panel, IVisualNativeElementRenderer, IDisposable, IEffectControlProvider where TElement : VisualElement
 																																	  where TNativeElement : FrameworkElement
 	{
 		string _defaultAutomationPropertiesName;

--- a/src/Compatibility/Core/src/Windows/WebViewRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/WebViewRenderer.cs
@@ -18,7 +18,7 @@ using WWebView = Microsoft.UI.Xaml.Controls.WebView2;
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
 	[System.Obsolete(Compatibility.Hosting.MauiAppBuilderExtensions.UseMapperInstead)]
-	public class WebViewRenderer : ViewRenderer<WebView, WebView2>, IWebViewDelegate
+	public partial class WebViewRenderer : ViewRenderer<WebView, WebView2>, IWebViewDelegate
 	{
 		IWebViewController WebViewController => Element;
 		WebNavigationEvent _eventState;

--- a/src/Compatibility/Core/src/WorkaroundXamlPreCompilePreviewFeatures.rsp
+++ b/src/Compatibility/Core/src/WorkaroundXamlPreCompilePreviewFeatures.rsp
@@ -1,1 +1,0 @@
-/features:"InterceptorsPreviewNamespaces=Microsoft.Maui.Controls.Generated"

--- a/src/Controls/src/Core/Controls.Core.csproj
+++ b/src/Controls/src/Core/Controls.Core.csproj
@@ -26,8 +26,6 @@
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
     <EnableAotAnalyzer>true</EnableAotAnalyzer>
     <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
-    <!-- TODO: Remove once XamlTypeInfo.g.cs generates trimming-friendly code -->
-    <NoWarn Condition="$(TargetFramework.Contains('-windows'))">$(NoWarn);IL2059</NoWarn>
   </PropertyGroup>
 
   <Import Project="$(MauiSrcDirectory)MultiTargeting.targets" />
@@ -48,8 +46,6 @@
 
   <PropertyGroup>
     <InterceptorsPreviewNamespaces>$(InterceptorsPreviewNamespaces);Microsoft.Maui.Controls.Generated</InterceptorsPreviewNamespaces>
-    <!-- https://github.com/dotnet/msbuild/issues/9785 -->
-    <CompilerResponseFile Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">$(CompilerResponseFile);WorkaroundXamlPreCompilePreviewFeatures.rsp</CompilerResponseFile>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference

--- a/src/Controls/src/Core/WorkaroundXamlPreCompilePreviewFeatures.rsp
+++ b/src/Controls/src/Core/WorkaroundXamlPreCompilePreviewFeatures.rsp
@@ -1,1 +1,0 @@
-/features:"InterceptorsPreviewNamespaces=Microsoft.Maui.Controls.Generated"

--- a/src/Core/src/Core.csproj
+++ b/src/Core/src/Core.csproj
@@ -16,8 +16,6 @@
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
     <EnableAotAnalyzer>true</EnableAotAnalyzer>
     <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
-    <!-- TODO: Remove once XamlTypeInfo.g.cs generates trimming-friendly code -->
-    <NoWarn Condition="$(TargetFramework.Contains('-windows'))">$(NoWarn);IL2059</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Essentials/src/Email/EmailHelper.uwp.cs
+++ b/src/Essentials/src/Email/EmailHelper.uwp.cs
@@ -41,10 +41,11 @@ namespace Microsoft.Maui.ApplicationModel.Communication
 		}
 
 		static IntPtr GetUnmanagedArray<TStruct>(TStruct[]? array)
+			where TStruct : struct
 		{
 			if (array?.Length > 0)
 			{
-				var size = Marshal.SizeOf(typeof(TStruct));
+				var size = Marshal.SizeOf<TStruct>();
 
 				var intptr = Marshal.AllocHGlobal(array.Length * size);
 
@@ -66,7 +67,7 @@ namespace Microsoft.Maui.ApplicationModel.Communication
 			var count = array?.Length;
 			if (count > 0)
 			{
-				var size = Marshal.SizeOf(typeof(TStruct));
+				var size = Marshal.SizeOf<TStruct>();
 
 				var ptr = intptr;
 				for (var i = 0; i < count; i++)

--- a/src/Essentials/src/Essentials.csproj
+++ b/src/Essentials/src/Essentials.csproj
@@ -7,6 +7,7 @@
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <WarningsNotAsErrors>BI1234</WarningsNotAsErrors>
     <IsAotCompatible Condition="!$(TargetFramework.StartsWith('netstandard'))">true</IsAotCompatible>
+    <AllowUnsafeBlocks Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">true</AllowUnsafeBlocks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);NU5104;RS0041;RS0026</NoWarn>
     <WarningsAsErrors>$(WarningsAsErrors);CS1591</WarningsAsErrors>

--- a/src/Essentials/src/Essentials.csproj
+++ b/src/Essentials/src/Essentials.csproj
@@ -6,8 +6,7 @@
     <RootNamespace>Microsoft.Maui.Essentials</RootNamespace>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <WarningsNotAsErrors>BI1234</WarningsNotAsErrors>
-    <IsAotCompatible Condition="!$(TargetFramework.StartsWith('netstandard')) and $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) != 'windows'">true</IsAotCompatible>
-    <IsTrimmable Condition="!$(TargetFramework.StartsWith('netstandard')) and $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">true</IsTrimmable>
+    <IsAotCompatible Condition="!$(TargetFramework.StartsWith('netstandard'))">true</IsAotCompatible>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);NU5104;RS0041;RS0026</NoWarn>
     <WarningsAsErrors>$(WarningsAsErrors);CS1591</WarningsAsErrors>

--- a/src/Essentials/src/Platform/PlatformMethods.uwp.cs
+++ b/src/Essentials/src/Platform/PlatformMethods.uwp.cs
@@ -98,7 +98,7 @@ namespace Microsoft.Maui.ApplicationModel
 
 		public static Maui.Graphics.Rect GetCaptionButtonsBound(IntPtr hWnd)
 		{
-			DwmGetWindowAttribute(hWnd, DwmWindowAttribute.DWMWA_CAPTION_BUTTON_BOUNDS, out RECT value, Marshal.SizeOf(typeof(RECT)));
+			DwmGetWindowAttribute(hWnd, DwmWindowAttribute.DWMWA_CAPTION_BUTTON_BOUNDS, out RECT value, Marshal.SizeOf<RECT>());
 			var density = GetDpiForWindow(hWnd) / 96f;
 			return new Graphics.Rect(
 				value.Left / density,

--- a/src/Essentials/src/Preferences/Preferences.uwp.cs
+++ b/src/Essentials/src/Preferences/Preferences.uwp.cs
@@ -2,6 +2,7 @@ using System;
 using System.Globalization;
 using System.IO;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Microsoft.Maui.ApplicationModel;
 using Windows.Storage;
 
@@ -245,9 +246,7 @@ namespace Microsoft.Maui.Storage
 			{
 				using var stream = File.OpenRead(AppPreferencesPath);
 
-#pragma warning disable IL2026 // Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
-				var readPreferences = JsonSerializer.Deserialize<PreferencesDictionary>(stream);
-#pragma warning restore IL2026 // Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
+				PreferencesDictionary readPreferences = JsonSerializer.Deserialize(stream, PreferencesJsonSerializerContext.Default.PreferencesDictionary);
 
 				if (readPreferences != null)
 				{
@@ -268,12 +267,15 @@ namespace Microsoft.Maui.Storage
 			Directory.CreateDirectory(dir);
 
 			using var stream = File.Create(AppPreferencesPath);
-#pragma warning disable IL2026 // Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
-			JsonSerializer.Serialize(stream, _preferences);
-#pragma warning restore IL2026 // Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
+			JsonSerializer.Serialize(stream, _preferences, PreferencesJsonSerializerContext.Default.PreferencesDictionary);
 		}
 
 		static string CleanSharedName(string sharedName) =>
 			string.IsNullOrEmpty(sharedName) ? string.Empty : sharedName;
 	}
+}
+
+[JsonSerializable(typeof(PreferencesDictionary), TypeInfoPropertyName = nameof(PreferencesDictionary))]
+internal partial class PreferencesJsonSerializerContext : JsonSerializerContext
+{
 }

--- a/src/Essentials/src/SecureStorage/SecureStorage.uwp.cs
+++ b/src/Essentials/src/SecureStorage/SecureStorage.uwp.cs
@@ -3,8 +3,10 @@ using System.IO;
 using System.Runtime.InteropServices.WindowsRuntime;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using Microsoft.Maui.ApplicationModel;
+using Microsoft.Maui.Storage;
 using Windows.Security.Cryptography.DataProtection;
 using Windows.Storage;
 using SecureStorageDictionary = System.Collections.Concurrent.ConcurrentDictionary<string, byte[]>;
@@ -125,9 +127,7 @@ namespace Microsoft.Maui.Storage
 			{
 				using var stream = File.OpenRead(AppSecureStoragePath);
 
-#pragma warning disable IL2026 // Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
-				var readPreferences = JsonSerializer.Deserialize<SecureStorageDictionary>(stream);
-#pragma warning restore IL2026 // Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
+				SecureStorageDictionary readPreferences = JsonSerializer.Deserialize(stream, SecureStorageJsonSerializerContext.Default.SecureStorageDictionary);
 
 				if (readPreferences != null)
 				{
@@ -148,9 +148,7 @@ namespace Microsoft.Maui.Storage
 			Directory.CreateDirectory(dir);
 
 			using var stream = File.Create(AppSecureStoragePath);
-#pragma warning disable IL2026 // Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
-			JsonSerializer.Serialize(stream, _secureStorage);
-#pragma warning restore IL2026 // Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
+			JsonSerializer.Serialize(stream, _secureStorage, SecureStorageJsonSerializerContext.Default.SecureStorageDictionary);
 		}
 
 		public Task<byte[]> GetAsync(string key)
@@ -182,4 +180,9 @@ namespace Microsoft.Maui.Storage
 			Save();
 		}
 	}
+}
+
+[JsonSerializable(typeof(SecureStorageDictionary), TypeInfoPropertyName = nameof(SecureStorageDictionary))]
+internal partial class SecureStorageJsonSerializerContext : JsonSerializerContext
+{
 }


### PR DESCRIPTION
### Description of Change

- We had several places where we suppressed the IL2059 on Windows. This isn't needed anymore because the generated code in XamlTypeInfo.g.cs is trim safe.
- We don't need .rsp files as a workaround anymore. The bug in the XamlPreCompile step has been fixed in WinUI.
- We were using AOT-incompatible `Marshal.SizeOf(typeof(T))`. This can be easily fixed by using the generic overload.
- We were using trim-incompatible JSON serialization. This can be easily replaced with source-generated JSON serialization.
- We need to make quite a few classes partial to make the CsWinRT com-wrappers source generator happy.
- We need to allow unsafe blocks because the CsWinRT source generator produces unsafe code.

This is a follow-up to #24266, cc @Foda