### PR TITLE
[Windows] Fix Shell.Flyout menu disappears when pressing Alt key

### DIFF
--- a/src/Controls/src/Core/Handlers/Shell/Windows/ShellFlyoutItemView.cs
+++ b/src/Controls/src/Core/Handlers/Shell/Windows/ShellFlyoutItemView.cs
@@ -93,50 +93,6 @@ namespace Microsoft.Maui.Controls.Platform
 				UpdateVisualState();
 		}
 
-		protected override global::Windows.Foundation.Size MeasureOverride(global::Windows.Foundation.Size availableSize)
-		{
-			if (ShellView == null)
-				return base.MeasureOverride(availableSize);
-
-			if (!ShellView.IsPaneOpen)
-				return base.MeasureOverride(availableSize);
-
-			if (ShellView.OpenPaneLength < availableSize.Width)
-				return base.MeasureOverride(availableSize);
-
-			if (_content is IView view)
-			{
-				if (Parent is FrameworkElement fe)
-				{
-					if (!_content.IsVisible)
-					{
-						fe.Visibility = WVisibility.Collapsed;
-					}
-					else
-					{
-						fe.Visibility = WVisibility.Visible;
-					}
-				}
-
-				var request = view.Measure(availableSize.Width, availableSize.Height);
-				Clip = new RectangleGeometry { Rect = new WRect(0, 0, request.Width, request.Height) };
-				return request.ToPlatform();
-			}
-
-			return base.MeasureOverride(availableSize);
-		}
-
-		protected override global::Windows.Foundation.Size ArrangeOverride(global::Windows.Foundation.Size finalSize)
-		{
-			if (this.ActualWidth > 0 && _content is IView view)
-			{
-				view.Arrange(new Rect(0, 0, finalSize.Width, finalSize.Height));
-				return finalSize;
-			}
-
-			return base.ArrangeOverride(finalSize);
-		}
-
 		void UpdateVisualState()
 		{
 			if (_content?.BindingContext is BaseShellItem baseShellItem && baseShellItem != null)

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Shipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Shipped.txt
@@ -7269,8 +7269,8 @@ override Microsoft.Maui.Controls.Platform.Compatibility.CellControl.MeasureOverr
 override Microsoft.Maui.Controls.Platform.ItemContentControl.ArrangeOverride(Windows.Foundation.Size finalSize) -> Windows.Foundation.Size
 override Microsoft.Maui.Controls.Platform.ItemContentControl.MeasureOverride(Windows.Foundation.Size availableSize) -> Windows.Foundation.Size
 override Microsoft.Maui.Controls.Platform.MauiCommandBar.OnApplyTemplate() -> void
-override Microsoft.Maui.Controls.Platform.ShellFlyoutItemView.ArrangeOverride(Windows.Foundation.Size finalSize) -> Windows.Foundation.Size
-override Microsoft.Maui.Controls.Platform.ShellFlyoutItemView.MeasureOverride(Windows.Foundation.Size availableSize) -> Windows.Foundation.Size
+
+
 override Microsoft.Maui.Controls.RadialGradientBrush.IsEmpty.get -> bool
 override Microsoft.Maui.Controls.RadioButton.ChangeVisualState() -> void
 override Microsoft.Maui.Controls.RadioButton.OnApplyTemplate() -> void

--- a/src/Core/src/Platform/Windows/MauiNavigationView.cs
+++ b/src/Core/src/Platform/Windows/MauiNavigationView.cs
@@ -51,8 +51,6 @@ namespace Microsoft.Maui.Platform
 			this.RegisterPropertyChangedCallback(MenuItemsSourceProperty, (_, __) => UpdateMenuItemsContainerHeight());
 			this.RegisterPropertyChangedCallback(MenuItemsProperty, (_, __) => UpdateMenuItemsContainerHeight());
 			RegisterPropertyChangedCallback(PaneDisplayModeProperty, PaneDisplayModeChanged);
-
-			this.Loaded += (s, e) => UpdatePaneDisplayMode();
 		}
 
 		void PaneDisplayModeChanged(DependencyObject sender, DependencyProperty dp) =>
@@ -165,14 +163,6 @@ namespace Microsoft.Maui.Platform
 
 			_currentFlyoutBehavior = (int)flyoutBehavior;
 
-			if (IsLoaded || PaneCustomContent != null)
-			{
-				UpdatePaneDisplayMode();
-			}
-		}
-
-		private void UpdatePaneDisplayMode()
-		{
 			switch ((FlyoutBehavior)_currentFlyoutBehavior)
 			{
 				case FlyoutBehavior.Flyout:

--- a/src/Core/src/Platform/Windows/MauiNavigationView.cs
+++ b/src/Core/src/Platform/Windows/MauiNavigationView.cs
@@ -51,6 +51,8 @@ namespace Microsoft.Maui.Platform
 			this.RegisterPropertyChangedCallback(MenuItemsSourceProperty, (_, __) => UpdateMenuItemsContainerHeight());
 			this.RegisterPropertyChangedCallback(MenuItemsProperty, (_, __) => UpdateMenuItemsContainerHeight());
 			RegisterPropertyChangedCallback(PaneDisplayModeProperty, PaneDisplayModeChanged);
+
+			this.Loaded += (s, e) => UpdatePaneDisplayMode();
 		}
 
 		void PaneDisplayModeChanged(DependencyObject sender, DependencyProperty dp) =>
@@ -162,7 +164,16 @@ namespace Microsoft.Maui.Platform
 			}
 
 			_currentFlyoutBehavior = (int)flyoutBehavior;
-			switch (flyoutBehavior)
+
+			if (IsLoaded || PaneCustomContent != null)
+			{
+				UpdatePaneDisplayMode();
+			}
+		}
+
+		private void UpdatePaneDisplayMode()
+		{
+			switch ((FlyoutBehavior)_currentFlyoutBehavior)
 			{
 				case FlyoutBehavior.Flyout:
 					IsPaneToggleButtonVisible = true;


### PR DESCRIPTION
### Description of Change

Remove `MeasureOverride` and `ArrangeOverride` from `ShellFlyoutItemView. It's not clear why it exists, but it is the source of the issue.

The issue is caused by the logic in both of these functions not invoking `base.ArrangeOverride` and `base.MeasureOverride`.

### Issues Fixed

Fixes #23214
