### PR TITLE
Fix Button Regression with null image source

### DIFF
--- a/src/Controls/src/Core/Button/Button.iOS.cs
+++ b/src/Controls/src/Core/Button/Button.iOS.cs
@@ -80,19 +80,10 @@ namespace Microsoft.Maui.Controls
 			}
 			platformButton.UpdateContentEdgeInsets(button, contentEdgeInsets);
 
-			_originalImageRef.TryGetTarget(out var _originalImage);
-
 			if (image is not null)
 			{
-				// Save the original image for later image resizing
-				if (_originalImage is null || image != _originalImage)
-				{
-					_originalImage = image;
-					_originalImageRef = new WeakReference<UIImage>(_originalImage);
-				}
-
 				// Resize the image if necessary and then update the image variable
-				if (ResizeImageIfNecessary(platformButton, button, image, padding, spacing, borderWidth, widthConstraint, heightConstraint, _originalImage))
+				if (ResizeImageIfNecessary(platformButton, button, image, padding, spacing, borderWidth, widthConstraint, heightConstraint))
 				{
 					image = platformButton.CurrentImage;
 				}
@@ -340,10 +331,18 @@ namespace Microsoft.Maui.Controls
 		/// <param name="borderWidth"></param>
 		/// <param name="widthConstraint"></param>
 		/// <param name="heightConstraint"></param>
-		/// <param name="originalImage"></param>
 		/// <returns></returns>
-		static bool ResizeImageIfNecessary(UIButton platformButton, Button button, UIImage image, Thickness padding, double spacing, double borderWidth, double widthConstraint, double heightConstraint, UIImage originalImage)
+		bool ResizeImageIfNecessary(UIButton platformButton, Button button, UIImage image, Thickness padding, double spacing, double borderWidth, double widthConstraint, double heightConstraint)
 		{
+			_originalImageRef.TryGetTarget(out var _originalImage);
+
+			// Save the original image for later image resizing
+			if (_originalImage is null || image != _originalImage)
+			{
+				_originalImage = image;
+				_originalImageRef = new WeakReference<UIImage>(_originalImage);
+			}
+
 			var currentImageWidth = image.Size.Width;
 			var currentImageHeight = image.Size.Height;
 

--- a/src/Controls/src/Core/Button/Button.iOS.cs
+++ b/src/Controls/src/Core/Button/Button.iOS.cs
@@ -100,7 +100,6 @@ namespace Microsoft.Maui.Controls
 
 			else
 			{
-				_originalImage = null;
 				_originalImageRef = new WeakReference<UIImage>(null);
 			}
 

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue25409.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue25409.xaml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Maui.Controls.Sample.Issues.Issue25409"
+             Title="Issue25409">
+    <Button
+        x:Name="button1"
+        AutomationId="button1"
+        Text="Click me"
+        Clicked="OnCounterClicked" />
+</ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue25409.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue25409.xaml.cs
@@ -1,0 +1,52 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 25409, "UIButton CurrentImage can be set without crashing", PlatformAffected.iOS)]
+public partial class Issue25409 : ContentPage
+{
+	public Issue25409()
+	{
+		InitializeComponent();
+	}
+
+	int count = 0;
+
+	private void OnCounterClicked(object sender, EventArgs e)
+	{
+#if IOS
+		((Action)(async () =>
+		{
+			if (count % 2 == 0)
+			{
+				var imageSource = new FileImageSource() { File = "shopping_cart.png" };
+
+				if (button1.Handler?.MauiContext is not null && (button1.Handler.PlatformView is UIKit.UIButton platformButton))
+				{
+					var imageResult = await imageSource.GetPlatformImageAsync(button1.Handler.MauiContext);
+					if (imageResult is not null)
+					{
+						platformButton.SetImage(imageResult.Value, UIKit.UIControlState.Normal);
+					}
+				}
+
+				// since changing the UIButton.CurrentImage with SetImage does not trigger a layout pass,
+				// we can change something else to force a layout pass
+				button1.Text = string.Empty;
+			}
+
+			else
+			{
+				if (button1.Handler?.PlatformView is UIKit.UIButton platformButton)
+				{
+					platformButton.SetImage(null, UIKit.UIControlState.Normal);
+				}
+
+				// since changing the UIButton.CurrentImage with SetImage does not trigger a layout pass,
+				// we can change something else to force a layout pass
+				button1.Text = "Trigger Layout!";
+			}
+
+			count++;
+		}))();
+#endif
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue25409.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue25409.xaml.cs
@@ -8,7 +8,9 @@ public partial class Issue25409 : ContentPage
 		InitializeComponent();
 	}
 
+#if IOS
 	int count = 0;
+#endif
 
 	private void OnCounterClicked(object sender, EventArgs e)
 	{

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25409.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25409.cs
@@ -1,0 +1,28 @@
+#if IOS
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue25409 : _IssuesUITest
+{
+	public Issue25409(TestDevice testDevice) : base(testDevice)
+	{
+	}
+
+	public override string Issue => "UIButton CurrentImage can be set without crashing";
+
+	[Test]
+	[Category(UITestCategories.Button)]
+	public void CurrentImageSet()
+	{
+		App.WaitForElement("button1");
+		App.Tap("button1");
+		App.WaitForElement("button1");
+		App.Tap("button1");
+		App.WaitForElement("button1");
+		App.Tap("button1");
+	}
+}
+#endif


### PR DESCRIPTION
This PR fixes an null reference issue that occurs when an button has its image set by UIButton.SetImage. Instead of using the Button.ImageSource.ToString() to see if the image has changed without needing to hold a reference to the image, the code now uses the UIButton.CurrentImage hash to determine if the image has changed. This helps us know if the image was changed in those situations where the Button.ImageSource is null but the UIButton.CurrentImage is still set.

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

<!-- Enter description of the fix in this section -->

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #25409

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
