### PR TITLE
Fixed Size not calculated properly when invoking UseMauiCompatibility method in MauiProgram

### DIFF
--- a/src/Controls/src/Core/Hosting/AppHostBuilderExtensions.cs
+++ b/src/Controls/src/Core/Hosting/AppHostBuilderExtensions.cs
@@ -88,6 +88,7 @@ public static partial class AppHostBuilderExtensions
 		handlersCollection.AddHandler<HybridWebView, HybridWebViewHandler>();
 		handlersCollection.AddHandler<Border, BorderHandler>();
 		handlersCollection.AddHandler<IContentView, ContentViewHandler>();
+		handlersCollection.AddHandler<ContentView, ContentViewHandler>();
 		handlersCollection.AddHandler<Shapes.Ellipse, ShapeViewHandler>();
 		handlersCollection.AddHandler<Shapes.Line, LineHandler>();
 		handlersCollection.AddHandler<Shapes.Path, PathHandler>();


### PR DESCRIPTION
### Root Cause
When using UseMauiCompatibility, the ContentView handler is set to RenderToHandlerShim instead of ContentViewHandler. As a result, the measuring logic is managed by VisualElementRender, leading to a size of 0 being returned.
 
### Description of Change
Registering the ContentView handler with the control as ContentView instead of IContentView will resolve the issue.

 
Validated the behaviour in the following platforms
 
- [x] Android
- [x] Windows
- [ ] iOS
- [ ] Mac
 
 
### Issues Fixed
  
Fixes #10238

### Output 

#### Windows
**Before**
![Before](https://github.com/user-attachments/assets/ae34173a-22f6-4d0b-a52f-28a382e06bd3)

**After**
![After](https://github.com/user-attachments/assets/c68ae326-2bc6-43da-8033-765975d376e2)
