### PR TITLE
Fixed UI Test Issue on Windows Platform in Visual Studio

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/UITest.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/UITest.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Maui.TestCases.Tests
 
 		public override IConfig GetTestConfig()
 		{
-			var frameworkVersion = "net8.0";
+			var frameworkVersion = "net9.0";
 #if DEBUG
 			var configuration = "Debug";
 #else


### PR DESCRIPTION


### Description of Change

There is an issue we encountered while running UI test cases on the Windows platform using Test Explorer in Visual Studio after the recent update to .NET 9.
Changing the framework value in UITest.cs file from net8 to net9 fixes this.
