### PR TITLE
[gh actions] use "inclusive heat sensor" v0.1.1

### DIFF
--- a/.github/workflows/inclusive-heat-sensor.yml
+++ b/.github/workflows/inclusive-heat-sensor.yml
@@ -4,8 +4,6 @@ on:
     types: [opened, reopened]
   issue_comment:
     types: [created, edited]
-  pull_request:
-    types: [reopened]
   pull_request_review_comment:
     types: [created, edited]
 
@@ -16,5 +14,5 @@ permissions:
 
 jobs:
   detect-heat:
-    uses: jonathanpeppers/inclusive-heat-sensor/.github/workflows/comments.yml@v0.1
+    uses: jonathanpeppers/inclusive-heat-sensor/.github/workflows/comments.yml@v0.1.1
     secrets: inherit


### PR DESCRIPTION
Context: https://github.com/dotnet/maui/pull/25389
Context: https://github.com/jonathanpeppers/inclusive-heat-sensor/releases/tag/v0.1.1

The version of the action in #25389 had an issue where a non-zero exit code could make the step fail. This would trigger a GitHub notification for the commenter.

So, to avoid that, the v0.1.1 release:

* Uses `continue-on-error: true` in the step that runs the action.

* Explicitly `exit 0` in powershell, this was the true cause of the non-zero exit code.

Note that we're still testing out this idea, our goal is to run this silently to decide how useful this will be.

I also made this no longer run on `pull_request` reopen, as this event doesn't make sense.