### PR TITLE
[iOS] RadioButton throws CGContextSetLineWidth - Fix

### DIFF
--- a/src/Controls/src/Core/RadioButton/RadioButton.cs
+++ b/src/Controls/src/Core/RadioButton/RadioButton.cs
@@ -459,7 +459,7 @@ namespace Microsoft.Maui.Controls
 
 			border.SetBinding(Border.StrokeProperty, static (RadioButton rb) => rb.BorderColor, source: RelativeBindingSource.TemplatedParent);
 			border.SetBinding(Border.StrokeShapeProperty, static (RadioButton rb) => rb.CornerRadius, source: RelativeBindingSource.TemplatedParent, converter: new CornerRadiusToShape());
-			border.SetBinding(Border.StrokeThicknessProperty, static (RadioButton rb) => rb.BorderWidth, source: RelativeBindingSource.TemplatedParent, converter: new NonNegativeValueConverter());
+			border.SetBinding(Border.StrokeThicknessProperty, static (RadioButton rb) => rb.BorderWidth, source: RelativeBindingSource.TemplatedParent);
 
 			var grid = new Grid
 			{
@@ -687,19 +687,6 @@ namespace Microsoft.Maui.Controls
 				{
 					CornerRadius = (int)value,
 				};
-			}
-
-			public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
-			{
-				throw new NotImplementedException();
-			}
-		}
-
-		class NonNegativeValueConverter : IValueConverter
-		{
-			public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
-			{
-				return Math.Max(0, (double)value);
 			}
 
 			public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)

--- a/src/Controls/src/Core/RadioButton/RadioButton.cs
+++ b/src/Controls/src/Core/RadioButton/RadioButton.cs
@@ -459,7 +459,7 @@ namespace Microsoft.Maui.Controls
 
 			border.SetBinding(Border.StrokeProperty, static (RadioButton rb) => rb.BorderColor, source: RelativeBindingSource.TemplatedParent);
 			border.SetBinding(Border.StrokeShapeProperty, static (RadioButton rb) => rb.CornerRadius, source: RelativeBindingSource.TemplatedParent, converter: new CornerRadiusToShape());
-			border.SetBinding(Border.StrokeThicknessProperty, static (RadioButton rb) => rb.BorderWidth, source: RelativeBindingSource.TemplatedParent);
+			border.SetBinding(Border.StrokeThicknessProperty, static (RadioButton rb) => rb.BorderWidth, source: RelativeBindingSource.TemplatedParent, converter: new NonNegativeValueConverter());
 
 			var grid = new Grid
 			{
@@ -687,6 +687,19 @@ namespace Microsoft.Maui.Controls
 				{
 					CornerRadius = (int)value,
 				};
+			}
+
+			public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+			{
+				throw new NotImplementedException();
+			}
+		}
+
+		class NonNegativeValueConverter : IValueConverter
+		{
+			public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+			{
+				return Math.Max(0, (double)value);
 			}
 
 			public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)

--- a/src/Core/src/Platform/iOS/MauiCALayer.cs
+++ b/src/Core/src/Platform/iOS/MauiCALayer.cs
@@ -317,7 +317,7 @@ namespace Microsoft.Maui.Platform
 
 		void DrawBorder(CGContext ctx)
 		{
-			if (_strokeThickness == 0)
+			if (_strokeThickness <= 0)
 				return;
 
 			if (IsBorderDashed())


### PR DESCRIPTION
### Description of Change

The error occurred because the default value for Border.StrokeThickness was set to -1. Instead of changing this default to 0, I implemented a converter that ensures Border.StrokeThickness never receives negative values.

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/25273

|Before|
|----|
|<img width="863" alt="Screenshot 2024-10-26 at 15 19 01" src="https://github.com/user-attachments/assets/eb432ef1-bd1d-4acc-9586-bded85ad2884">|


