### PR TITLE
Fix OnNavigatedTo not called when navigating back to a specific page

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
@@ -1720,7 +1720,6 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 					NavigationRenderer navRenderer;
 					if (_navigation.TryGetTarget(out navRenderer))
 						await navRenderer.UpdateFormsInnerNavigation(Child);
-
 				}
 				base.DidMoveToParentViewController(parent);
 			}

--- a/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
@@ -1719,9 +1719,8 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				{
 					NavigationRenderer navRenderer;
 					if (_navigation.TryGetTarget(out navRenderer))
-					{
 						await navRenderer.UpdateFormsInnerNavigation(Child);
-					}
+
 				}
 				base.DidMoveToParentViewController(parent);
 			}

--- a/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
@@ -1720,8 +1720,6 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 					NavigationRenderer navRenderer;
 					if (_navigation.TryGetTarget(out navRenderer))
 					{
-						if (!navRenderer._uiRequestedPop)
-							navRenderer._uiRequestedPop = true;
 						await navRenderer.UpdateFormsInnerNavigation(Child);
 					}
 				}

--- a/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
@@ -1719,7 +1719,11 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				{
 					NavigationRenderer navRenderer;
 					if (_navigation.TryGetTarget(out navRenderer))
+					{
+						if (!navRenderer._uiRequestedPop)
+							navRenderer._uiRequestedPop = true;
 						await navRenderer.UpdateFormsInnerNavigation(Child);
+					}
 				}
 				base.DidMoveToParentViewController(parent);
 			}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue25371.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue25371.cs
@@ -7,20 +7,20 @@ namespace Maui.Controls.Sample.Issues
 	[Issue(IssueTracker.Github, 25371, "OnNavigatedTo not called when navigating back to a specific page", PlatformAffected.iOS | PlatformAffected.macOS)]
 	public class Issue25371 : NavigationPage
 	{
-		public Issue25371() : base(new MainPage())
+		public Issue25371() : base(new FirstPage25371())
 		{
 		}
 	}
-	public class MainPage : ContentPage
+	public class FirstPage25371 : ContentPage
 	{
 		Label label;
-		public MainPage()
+		public FirstPage25371()
 		{
 			var stackLayout = new StackLayout();
 		    label = new Label()
 			{
 				Text = "Welcome to Main page",
-				AutomationId ="MainPageLabel"
+				AutomationId ="FirstPageLabel"
 			};
 
 			var button = new Button() { Text = "MoveToNextPage", AutomationId="MoveToNextPage" };
@@ -39,13 +39,13 @@ namespace Maui.Controls.Sample.Issues
 
 		private void Button_Clicked(object sender, EventArgs e)
 		{
-			Navigation.PushAsync(new SecondPage());
+			Navigation.PushAsync(new SecondPage25371());
 		}
 	}
 
-	public class SecondPage : ContentPage
+	public class SecondPage25371 : ContentPage
 	{
-		public SecondPage()
+		public SecondPage25371()
 		{
 			var label = new Label()
 			{

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue25371.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue25371.cs
@@ -49,7 +49,7 @@ namespace Maui.Controls.Sample.Issues
 		{
 			var label = new Label()
 			{
-				AutomationID = "SecondPageLabel",
+				AutomationId = "SecondPageLabel",
 				Text = "Welcome to Second Page",		
 				VerticalOptions = LayoutOptions.Center,
 				HorizontalOptions = LayoutOptions.Center

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue25371.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue25371.cs
@@ -17,18 +17,18 @@ namespace Maui.Controls.Sample.Issues
 		public FirstPage25371()
 		{
 			var stackLayout = new StackLayout();
-		    label = new Label()
+			label = new Label()
 			{
 				Text = "Welcome to Main page",
-				AutomationId ="FirstPageLabel"
+				AutomationId = "FirstPageLabel"
 			};
 
-			var button = new Button() { Text = "MoveToNextPage", AutomationId="MoveToNextPage" };
+			var button = new Button() { Text = "MoveToNextPage", AutomationId = "MoveToNextPage" };
 			button.Clicked += Button_Clicked;
 			stackLayout.Children.Add(label);
 			stackLayout.Children.Add(button);
 			Content = stackLayout;
-			
+
 		}
 
 		protected override void OnNavigatedTo(NavigatedToEventArgs args)
@@ -39,6 +39,7 @@ namespace Maui.Controls.Sample.Issues
 
 		private void Button_Clicked(object sender, EventArgs e)
 		{
+			label.Text = "Welcome to Main page"; // label text should be reset to original text
 			Navigation.PushAsync(new SecondPage25371());
 		}
 	}
@@ -50,7 +51,7 @@ namespace Maui.Controls.Sample.Issues
 			var label = new Label()
 			{
 				AutomationId = "SecondPageLabel",
-				Text = "Welcome to Second Page",		
+				Text = "Welcome to Second Page",
 				VerticalOptions = LayoutOptions.Center,
 				HorizontalOptions = LayoutOptions.Center
 			};

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue25371.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue25371.cs
@@ -49,7 +49,8 @@ namespace Maui.Controls.Sample.Issues
 		{
 			var label = new Label()
 			{
-				Text = "Welcome to Second Page",
+				AutomationID = "SecondPageLabel",
+				Text = "Welcome to Second Page",		
 				VerticalOptions = LayoutOptions.Center,
 				HorizontalOptions = LayoutOptions.Center
 			};

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue25371.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue25371.cs
@@ -5,10 +5,16 @@ using Microsoft.Maui.Controls;
 namespace Maui.Controls.Sample.Issues
 {
 	[Issue(IssueTracker.Github, 25371, "OnNavigatedTo not called when navigating back to a specific page", PlatformAffected.iOS | PlatformAffected.macOS)]
-	public class Issue25371 : TestContentPage
+	public class Issue25371 : NavigationPage
+	{
+		public Issue25371() : base(new MainPage())
+		{
+		}
+	}
+	public class MainPage : ContentPage
 	{
 		Label label;
-		protected override void Init()
+		public MainPage()
 		{
 			var stackLayout = new StackLayout();
 		    label = new Label()
@@ -24,6 +30,7 @@ namespace Maui.Controls.Sample.Issues
 			Content = stackLayout;
 			
 		}
+
 		protected override void OnNavigatedTo(NavigatedToEventArgs args)
 		{
 			label.Text = "OnNavigationTo method is called";

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue25371.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue25371.cs
@@ -1,0 +1,54 @@
+using System;
+using Microsoft.Maui;
+using Microsoft.Maui.Controls;
+
+namespace Maui.Controls.Sample.Issues
+{
+	[Issue(IssueTracker.Github, 25371, "OnNavigatedTo not called when navigating back to a specific page", PlatformAffected.iOS | PlatformAffected.macOS)]
+	public class Issue25371 : TestContentPage
+	{
+		Label label;
+		protected override void Init()
+		{
+			var stackLayout = new StackLayout();
+		    label = new Label()
+			{
+				Text = "Welcome to Main page",
+				AutomationId ="MainPageLabel"
+			};
+
+			var button = new Button() { Text = "MoveToNextPage", AutomationId="MoveToNextPage" };
+			button.Clicked += Button_Clicked;
+			stackLayout.Children.Add(label);
+			stackLayout.Children.Add(button);
+			Content = stackLayout;
+			
+		}
+		protected override void OnNavigatedTo(NavigatedToEventArgs args)
+		{
+			label.Text = "OnNavigationTo method is called";
+			base.OnNavigatedTo(args);
+		}
+
+		private void Button_Clicked(object sender, EventArgs e)
+		{
+			Navigation.PushAsync(new SecondPage());
+		}
+	}
+
+	public class SecondPage : ContentPage
+	{
+		public SecondPage()
+		{
+			var label = new Label()
+			{
+				Text = "Welcome to Second Page",
+				VerticalOptions = LayoutOptions.Center,
+				HorizontalOptions = LayoutOptions.Center
+			};
+
+			Content = label;
+		}
+	}
+}
+

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25371.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25371.cs
@@ -1,3 +1,4 @@
+#if IOS
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
@@ -16,20 +17,15 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		[Category(UITestCategories.Navigation)]
 		public void ValidateOnNavigationToMethod()
 		{
-			App.WaitForElement("MainPageLabel");
+			App.WaitForElement("MoveToNextPage");
 			App.Tap("MoveToNextPage");
 			App.WaitForElement("SecondPageLabel");
 
 			App.LongPress("Back");
-			var navigationToLabel = App.FindElement("MainPageLabel").GetText();
-			if (string.IsNullOrEmpty(navigationToLabel))
-			{
-				Assert.Fail("OnNavigationTo method is not called");
-			}
-			else
-			{
-				Assert.That(navigationToLabel, Is.EqualTo("OnNavigationTo method is called"));
-			}
+
+			var navigationToLabel = App.FindElement("FirstPageLabel").GetText();
+			Assert.That(navigationToLabel, Is.EqualTo("OnNavigationTo method is called"));
 		}
 	}
 }
+#endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25371.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25371.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 			App.Tap("MoveToNextPage");
 			App.WaitForElement("SecondPageLabel");
 
-			App.LongPress(BackButtonAutomationId);
+			App.LongPress("Back");
 			var navigationToLabel = App.FindElement("MainPageLabel").GetText();
 			if (string.IsNullOrEmpty(navigationToLabel))
 			{

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25371.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25371.cs
@@ -1,0 +1,35 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue25371 : _IssuesUITest
+	{
+		public override string Issue => "OnNavigatedTo not called when navigating back to a specific page";
+
+		public Issue25371(TestDevice device) : base(device)
+		{
+		}
+
+		[Test]
+		[Category(UITestCategories.TableView)]
+		public void ValidateTableViewTitles()
+		{
+			App.WaitForElement("MainPageLabel");
+			App.Tap("MoveToNextPage");
+			App.WaitForElement("SecondPageLabel");
+
+			App.LongPress(BackButtonAutomationId);
+			var navigationToLabel = App.FindElement("MainPageLabel").GetText();
+			if (string.IsNullOrEmpty(navigationToLabel))
+			{
+				Assert.Fail("OnNavigationTo method is not called");
+			}
+			else
+			{
+				Assert.That(navigationToLabel, Is.EqualTo("OnNavigationTo method is called"));
+			}
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25371.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25371.cs
@@ -13,8 +13,8 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		}
 
 		[Test]
-		[Category(UITestCategories.TableView)]
-		public void ValidateTableViewTitles()
+		[Category(UITestCategories.Navigation)]
+		public void ValidateOnNavigationToMethod()
 		{
 			App.WaitForElement("MainPageLabel");
 			App.Tap("MoveToNextPage");


### PR DESCRIPTION
### Root Cause
When the back button is pressed and hold, and then released, the navigation pop action is not recognized as a user-initiated action.

### Description of Change

To address an issue where the navigation pop action (when the back button is pressed and held, then released) was not being recognized as initiated by the user.  Because the _uiRequestedPop field was not being set to true. The _uiRequestedPop field is used to recognize user tap actions on the back button. By setting _uiRequestedPop to true, the inner navigation actions are performed correctly,  ensuring that the navigation pop action is recognized

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #25371 

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->

### Tested the behaviour in the following platforms
 
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

### Output Screenshot

| Before  | After  |
|---------|--------|
|  <video src="https://github.com/user-attachments/assets/297013db-c2a8-492d-990a-a9ba7e899bfa" width="320" height="240" controls></video>   |   <video src="https://github.com/user-attachments/assets/778c9c95-1ddd-41ce-994f-bb1baeceb906" width="320" height="240" controls></video>   |






