### PR TITLE
[Testing] Added UITests method overrides allowing the use queries

### DIFF
--- a/src/TestUtils/src/UITest.Appium/HelperExtensions.cs
+++ b/src/TestUtils/src/UITest.Appium/HelperExtensions.cs
@@ -364,7 +364,7 @@ namespace UITest.Appium
 			app.TouchAndHold(elementToTouchAndHold);
 		}
 
-		public static void TouchAndHold(this IApp app, IUIElement? element)
+		internal static void TouchAndHold(this IApp app, IUIElement? element)
 		{
 			if (element is not null)
 			{

--- a/src/TestUtils/src/UITest.Appium/HelperExtensions.cs
+++ b/src/TestUtils/src/UITest.Appium/HelperExtensions.cs
@@ -113,8 +113,8 @@ namespace UITest.Appium
 		public static void EnterText(this IApp app, string element, string text)
 		{
 			var appElement = app.FindElement(element);
-			appElement.SendKeys(text);
-			app.DismissKeyboard();
+
+			app.EnterText(appElement, text);
 		}
 
 		/// <summary>
@@ -126,10 +126,18 @@ namespace UITest.Appium
 		public static void EnterText(this IApp app, IQuery query, string text)
 		{
 			var appElement = app.FindElement(query);
-			appElement.SendKeys(text);
-			app.DismissKeyboard();
+
+			app.EnterText(appElement, text);
 		}
 
+		internal static void EnterText(this IApp app, IUIElement? element, string text)
+		{
+			if (element is not null)
+			{
+				element.SendKeys(text);
+				app.DismissKeyboard();
+			}
+		}
 
 		/// <summary>
 		/// Hides soft keyboard if present.
@@ -276,10 +284,31 @@ namespace UITest.Appium
 		public static void DoubleTap(this IApp app, string element)
 		{
 			var elementToDoubleTap = app.FindElement(element);
-			app.CommandExecutor.Execute("doubleTap", new Dictionary<string, object>
+		
+			app.DoubleTap(elementToDoubleTap);
+		}
+
+		/// <summary>
+		/// Performs two quick tap / touch gestures on the matched element by 'query'.
+		/// </summary>
+		/// <param name="app">Represents the main gateway to interact with an app.</param>
+		/// <param name="query"></param>
+		public static void DoubleTap(this IApp app, IQuery query)
+		{
+			var elementToDoubleTap = app.FindElement(query);
+
+			app.DoubleTap(elementToDoubleTap);
+		}
+
+		internal static void DoubleTap(this IApp app, IUIElement? element)
+		{
+			if (element is not null)
 			{
-				{ "element", elementToDoubleTap },
-			});
+				app.CommandExecutor.Execute("doubleTap", new Dictionary<string, object>
+				{
+					{ "element", element },
+				});
+			}
 		}
 
 		/// <summary>
@@ -319,10 +348,31 @@ namespace UITest.Appium
 		public static void TouchAndHold(this IApp app, string element)
 		{
 			var elementToTouchAndHold = app.FindElement(element);
-			app.CommandExecutor.Execute("touchAndHold", new Dictionary<string, object>
+		
+			app.TouchAndHold(elementToTouchAndHold);
+		}
+
+		/// <summary>
+		/// Performs a continuous touch gesture on an element matched by 'query'.
+		/// </summary>
+		/// <param name="app">Represents the main gateway to interact with an app.</param>
+		/// <param name="query">Represents the query that identify an element by parameters such as type, text it contains or identifier.</param>
+		public static void TouchAndHold(this IApp app, IQuery query)
+		{
+			var elementToTouchAndHold = app.FindElement(query);
+
+			app.TouchAndHold(elementToTouchAndHold);
+		}
+
+		public static void TouchAndHold(this IApp app, IUIElement? element)
+		{
+			if (element is not null)
 			{
-				{ "element", elementToTouchAndHold },
-			});
+				app.CommandExecutor.Execute("touchAndHold", new Dictionary<string, object>
+				{
+					{ "element", element },
+				});
+			}
 		}
 
 		/// <summary>
@@ -334,7 +384,7 @@ namespace UITest.Appium
 		public static void TouchAndHoldCoordinates(this IApp app, float x, float y)
 		{
 			app.CommandExecutor.Execute("touchAndHoldCoordinates", new Dictionary<string, object>
-			{		
+			{
 				{ "x", x },
 				{ "y", y }
 			});
@@ -351,11 +401,33 @@ namespace UITest.Appium
 			var dragSourceElement = app.FindElement(dragSource);
 			var targetSourceElement = app.FindElement(dragTarget);
 
-			app.CommandExecutor.Execute("dragAndDrop", new Dictionary<string, object>
+			app.DragAndDrop(dragSourceElement, targetSourceElement);
+		}
+
+		/// <summary>
+		/// Performs a long touch on an item, followed by dragging the item to a second item and dropping it.
+		/// </summary>
+		/// <param name="app">Represents the main gateway to interact with an app.</param>
+		/// <param name="dragSource">Represents the query that identify a source element by parameters such as type, text it contains or identifier.</param>
+		/// <param name="dragTarget">Represents the query that identify a target element by parameters such as type, text it contains or identifier.</param>
+		public static void DragAndDrop(this IApp app, IQuery dragSource, IQuery dragTarget)
+		{
+			var dragSourceElement = app.FindElement(dragSource);
+			var targetSourceElement = app.FindElement(dragTarget);
+
+			app.DragAndDrop(dragSourceElement, targetSourceElement);
+		}
+
+		internal static void DragAndDrop(this IApp app, IUIElement? dragSourceElement, IUIElement? targetSourceElement)
+		{
+			if (dragSourceElement is not null && targetSourceElement is not null)
 			{
-				{ "sourceElement", dragSourceElement },
-				{ "destinationElement", targetSourceElement }
-			});
+				app.CommandExecutor.Execute("dragAndDrop", new Dictionary<string, object>
+				{
+					{ "sourceElement", dragSourceElement },
+					{ "destinationElement", targetSourceElement }
+				});
+			}
 		}
 
 		/// <summary>
@@ -542,10 +614,10 @@ namespace UITest.Appium
 		{
 			IReadOnlyCollection<IUIElement> elements = app.FindElements(marked);
 
-			if(elements is not null && elements.Count > 0)
+			if (elements is not null && elements.Count > 0)
 			{
 				IUIElement firstElement() => elements.First();
-				
+
 				var result = Wait(firstElement, i => i != null, timeoutMessage, timeout, retryFrequency);
 
 				return result;
@@ -694,13 +766,36 @@ namespace UITest.Appium
 		{
 			var elementToSwipe = app.FindElement(marked);
 
-			app.CommandExecutor.Execute("swipeLeftToRight", new Dictionary<string, object>
+			app.SwipeLeftToRight(elementToSwipe, swipePercentage, swipeSpeed, withInertia);
+		}
+
+		/// <summary>
+		/// Performs a left to right swipe gesture on an element matched by 'query'.
+		/// </summary>
+		/// <param name="app">Represents the main gateway to interact with an app.</param>
+		/// <param name="query">Represents the query that identify an element by parameters such as type, text it contains or identifier.</param>
+		/// <param name="swipePercentage">How far across the element to swipe (from 0.0 to 1.0).</param>
+		/// <param name="swipeSpeed">The speed of the gesture.</param>
+		/// <param name="withInertia">Whether swipes should cause inertia.</param>
+		public static void SwipeLeftToRight(this IApp app, IQuery query, double swipePercentage = 0.67, int swipeSpeed = 500, bool withInertia = true)
+		{
+			var elementToSwipe = app.FindElement(query);
+
+			app.SwipeLeftToRight(elementToSwipe, swipePercentage, swipeSpeed, withInertia);
+		}
+
+		internal static void SwipeLeftToRight(this IApp app, IUIElement? element, double swipePercentage = 0.67, int swipeSpeed = 500, bool withInertia = true)
+		{
+			if (element is not null)
 			{
-				{ "element", elementToSwipe},
-				{ "swipePercentage", swipePercentage },
-				{ "swipeSpeed", swipeSpeed },
-				{ "withInertia", withInertia }
-			});
+				app.CommandExecutor.Execute("swipeLeftToRight", new Dictionary<string, object>
+				{
+					{ "element", element },
+					{ "swipePercentage", swipePercentage },
+					{ "swipeSpeed", swipeSpeed },
+					{ "withInertia", withInertia }
+				});
+			}
 		}
 
 		/// <summary>
@@ -733,13 +828,36 @@ namespace UITest.Appium
 		{
 			var elementToSwipe = app.FindElement(marked);
 
-			app.CommandExecutor.Execute("swipeRightToLeft", new Dictionary<string, object>
+			app.SwipeRightToLeft(elementToSwipe, swipePercentage, swipeSpeed, withInertia);
+		}
+
+		/// <summary>
+		/// Performs a right to left swipe gesture on an element matched by 'query'.
+		/// </summary>
+		/// <param name="app">Represents the main gateway to interact with an app.</param>
+		/// <param name="query">Represents the query that identify an element by parameters such as type, text it contains or identifier.</param>
+		/// <param name="swipePercentage">How far across the element to swipe (from 0.0 to 1.0).</param>
+		/// <param name="swipeSpeed">The speed of the gesture.</param>
+		/// <param name="withInertia">Whether swipes should cause inertia.</param>
+		public static void SwipeRightToLeft(this IApp app, IQuery query, double swipePercentage = 0.67, int swipeSpeed = 500, bool withInertia = true)
+		{
+			var elementToSwipe = app.FindElement(query);
+
+			app.SwipeRightToLeft(elementToSwipe, swipePercentage, swipeSpeed, withInertia);
+		}
+
+		internal static void SwipeRightToLeft(this IApp app, IUIElement? element, double swipePercentage = 0.67, int swipeSpeed = 500, bool withInertia = true)
+		{
+			if (element is not null)
 			{
-				{ "element", elementToSwipe},
-				{ "swipePercentage", swipePercentage },
-				{ "swipeSpeed", swipeSpeed },
-				{ "withInertia", withInertia }
-			});
+				app.CommandExecutor.Execute("swipeRightToLeft", new Dictionary<string, object>
+				{
+					{ "element", element },
+					{ "swipePercentage", swipePercentage },
+					{ "swipeSpeed", swipeSpeed },
+					{ "withInertia", withInertia }
+				});
+			}
 		}
 
 		/// <summary>
@@ -755,14 +873,38 @@ namespace UITest.Appium
 		{
 			var elementToSwipe = app.FindElement(marked);
 
-			app.CommandExecutor.Execute("scrollLeft", new Dictionary<string, object>
+			app.ScrollLeft(elementToSwipe, strategy, swipePercentage, swipeSpeed, withInertia);
+		}
+
+		/// <summary>
+		/// Scrolls left on the first element matching query.
+		/// </summary>
+		/// <param name="app">Represents the main gateway to interact with an app.</param>
+		/// <param name="query">Represents the query that identify an element by parameters such as type, text it contains or identifier.</param>
+		/// <param name="strategy">Strategy for scrolling element.</param>
+		/// <param name="swipePercentage">How far across the element to swipe (from 0.0 to 1.0).</param>
+		/// <param name="swipeSpeed">The speed of the gesture.</param>
+		/// <param name="withInertia">Whether swipes should cause inertia.</param>
+		public static void ScrollLeft(this IApp app, IQuery query, ScrollStrategy strategy = ScrollStrategy.Auto, double swipePercentage = 0.67, int swipeSpeed = 500, bool withInertia = true)
+		{
+			var elementToSwipe = app.FindElement(query);
+
+			app.ScrollLeft(elementToSwipe, strategy, swipePercentage, swipeSpeed, withInertia);
+		}
+
+		internal static void ScrollLeft(this IApp app, IUIElement? element, ScrollStrategy strategy = ScrollStrategy.Auto, double swipePercentage = 0.67, int swipeSpeed = 500, bool withInertia = true)
+		{
+			if (element is not null)
 			{
-				{ "element", elementToSwipe},
-				{ "strategy", strategy },
-				{ "swipePercentage", swipePercentage },
-				{ "swipeSpeed", swipeSpeed },
-				{ "withInertia", withInertia }
-			});
+				app.CommandExecutor.Execute("scrollLeft", new Dictionary<string, object>
+				{
+					{ "element", element },
+					{ "strategy", strategy },
+					{ "swipePercentage", swipePercentage },
+					{ "swipeSpeed", swipeSpeed },
+					{ "withInertia", withInertia }
+				});
+			}
 		}
 
 		/// <summary>
@@ -778,14 +920,38 @@ namespace UITest.Appium
 		{
 			var elementToSwipe = app.FindElement(marked);
 
-			app.CommandExecutor.Execute("scrollDown", new Dictionary<string, object>
+			app.ScrollDown(elementToSwipe, strategy, swipePercentage, swipeSpeed, withInertia);
+		}
+
+		/// <summary>
+		/// Scrolls down on the first element matching query.
+		/// </summary>
+		/// <param name="app">Represents the main gateway to interact with an app.</param>
+		/// <param name="marked">Marked selector to match.</param>
+		/// <param name="strategy">Strategy for scrolling element.</param>
+		/// <param name="swipePercentage">How far across the element to swipe (from 0.0 to 1.0).</param>
+		/// <param name="swipeSpeed">The speed of the gesture.</param>
+		/// <param name="withInertia">Whether swipes should cause inertia.</param>
+		public static void ScrollDown(this IApp app, IQuery query, ScrollStrategy strategy = ScrollStrategy.Auto, double swipePercentage = 0.67, int swipeSpeed = 500, bool withInertia = true)
+		{
+			var elementToSwipe = app.FindElement(query);
+
+			app.ScrollDown(elementToSwipe, strategy, swipePercentage, swipeSpeed, withInertia);
+		}
+
+		internal static void ScrollDown(this IApp app, IUIElement? element, ScrollStrategy strategy = ScrollStrategy.Auto, double swipePercentage = 0.67, int swipeSpeed = 500, bool withInertia = true)
+		{
+			if (element is not null)
 			{
-				{ "element", elementToSwipe},
-				{ "strategy", strategy },
-				{ "swipePercentage", swipePercentage },
-				{ "swipeSpeed", swipeSpeed },
-				{ "withInertia", withInertia }
-			});
+				app.CommandExecutor.Execute("scrollDown", new Dictionary<string, object>
+				{
+					{ "element", element },
+					{ "strategy", strategy },
+					{ "swipePercentage", swipePercentage },
+					{ "swipeSpeed", swipeSpeed },
+					{ "withInertia", withInertia }
+				});
+			}
 		}
 
 		/// <summary>
@@ -801,14 +967,38 @@ namespace UITest.Appium
 		{
 			var elementToSwipe = app.FindElement(marked);
 
-			app.CommandExecutor.Execute("scrollRight", new Dictionary<string, object>
-			{
-				{ "element", elementToSwipe},
-				{ "strategy", strategy },
-				{ "swipePercentage", swipePercentage },
-				{ "swipeSpeed", swipeSpeed },
-				{ "withInertia", withInertia }
-			});
+			app.ScrollRight(elementToSwipe, strategy, swipePercentage, swipeSpeed, withInertia);
+		}
+
+		/// <summary>
+		/// Scrolls right on the first element matching query.
+		/// </summary>
+		/// <param name="app">Represents the main gateway to interact with an app.</param>
+		/// <param name="query">Represents the query that identify an element by parameters such as type, text it contains or identifier.</param>
+		/// <param name="strategy">Strategy for scrolling element.</param>
+		/// <param name="swipePercentage">How far across the element to swipe (from 0.0 to 1.0).</param>
+		/// <param name="swipeSpeed">The speed of the gesture.</param>
+		/// <param name="withInertia">Whether swipes should cause inertia.</param>
+		public static void ScrollRight(this IApp app, IQuery query, ScrollStrategy strategy = ScrollStrategy.Auto, double swipePercentage = 0.67, int swipeSpeed = 500, bool withInertia = true)
+		{
+			var elementToSwipe = app.FindElement(query);
+
+			app.ScrollRight(elementToSwipe, strategy, swipePercentage, swipeSpeed, withInertia);
+		}
+
+		internal static void ScrollRight(this IApp app, IUIElement? element, ScrollStrategy strategy = ScrollStrategy.Auto, double swipePercentage = 0.67, int swipeSpeed = 500, bool withInertia = true)
+		{
+			if (element is not null)
+			{ 
+				app.CommandExecutor.Execute("scrollRight", new Dictionary<string, object>
+				{
+					{ "element", element },
+					{ "strategy", strategy },
+					{ "swipePercentage", swipePercentage },
+					{ "swipeSpeed", swipeSpeed },
+					{ "withInertia", withInertia }
+				});
+			}
 		}
 
 		/// <summary>
@@ -824,14 +1014,29 @@ namespace UITest.Appium
 		{
 			var elementToSwipe = app.FindElement(marked);
 
-			app.CommandExecutor.Execute("scrollUp", new Dictionary<string, object>
+			app.ScrollUp(elementToSwipe, strategy, swipePercentage, swipeSpeed, withInertia);
+		}
+
+		public static void ScrollUp(this IApp app, IQuery query, ScrollStrategy strategy = ScrollStrategy.Auto, double swipePercentage = 0.67, int swipeSpeed = 500, bool withInertia = true)
+		{
+			var elementToSwipe = app.FindElement(query);
+
+			app.ScrollUp(elementToSwipe, strategy, swipePercentage, swipeSpeed, withInertia);
+		}
+
+		public static void ScrollUp(this IApp app, IUIElement? element, ScrollStrategy strategy = ScrollStrategy.Auto, double swipePercentage = 0.67, int swipeSpeed = 500, bool withInertia = true)
+		{
+			if (element is not null)
 			{
-				{ "element", elementToSwipe},
-				{ "strategy", strategy },
-				{ "swipePercentage", swipePercentage },
-				{ "swipeSpeed", swipeSpeed },
-				{ "withInertia", withInertia }
-			});
+				app.CommandExecutor.Execute("scrollUp", new Dictionary<string, object>
+				{
+					{ "element", element },
+					{ "strategy", strategy },
+					{ "swipePercentage", swipePercentage },
+					{ "swipeSpeed", swipeSpeed },
+					{ "withInertia", withInertia }
+				});
+			}
 		}
 
 		/// <summary>
@@ -966,13 +1171,36 @@ namespace UITest.Appium
 		{
 			var element = app.FindElement(marked);
 
-			app.CommandExecutor.Execute("setSliderValue", new Dictionary<string, object>
+			app.SetSliderValue(element, value, minimum, maximum);
+		}
+
+		/// <summary>
+		/// Sets the value of a slider element that matches query.
+		/// </summary>
+		/// <param name="app">Represents the main gateway to interact with an app.</param>
+		/// <param name="query">Represents the query that identify an element by parameters such as type, text it contains or identifier.</param>
+		/// <param name="value">The value to set the Slider to.</param>
+		/// <param name="minimum">Te minimum selectable value for the Slider.</param>
+		/// <param name="maximum">Te maximum selectable value for the Slider.</param>
+		public static void SetSliderValue(this IApp app, IQuery query, double value, double minimum = 0d, double maximum = 1d)
+		{
+			var element = app.FindElement(query);
+
+			app.SetSliderValue(element, value, minimum, maximum);
+		}
+
+		internal static void SetSliderValue(this IApp app, IUIElement? element, double value, double minimum = 0d, double maximum = 1d)
+		{
+			if (element is not null)
 			{
-				{ "element", element },
-				{ "value", value },
-				{ "minimum", minimum },
-				{ "maximum", maximum },
-			});
+				app.CommandExecutor.Execute("setSliderValue", new Dictionary<string, object>
+				{
+					{ "element", element },
+					{ "value", value },
+					{ "minimum", minimum },
+					{ "maximum", maximum },
+				});
+			}
 		}
 
 		/// <summary>
@@ -1259,7 +1487,7 @@ namespace UITest.Appium
 		{
 			if (app is not AppiumAndroidApp)
 			{
-				throw new InvalidOperationException($"ToggleWifi is only supported on AppiumAndroidApp");
+				throw new InvalidOperationException($"GetPerformanceData is only supported on AppiumAndroidApp");
 			}
 
 			var response = app.CommandExecutor.Execute("getPerformanceData", new Dictionary<string, object>()


### PR DESCRIPTION
### Description of Change

Added UITests method overrides allowing to use queries in addition to automation ids.

Added:
- DoubleTap (IQuery query)
- TouchAndHold (IQuery query)
- DragAndDrop (IQuery dragSource, IQuery dragTarget)
- SwipeLeftToRight (IQuery query, double swipePercentage = 0.67, int swipeSpeed = 500, bool withInertia = true)
- SwipeRightToLeft (IQuery query, double swipePercentage = 0.67, int swipeSpeed = 500, bool withInertia = true)
- ScrollLeft (IQuery query, ScrollStrategy strategy = ScrollStrategy.Auto, double swipePercentage = 0.67, int swipeSpeed = 500, bool withInertia = true)
- ScrollRight (IQuery query, ScrollStrategy strategy = ScrollStrategy.Auto, double swipePercentage = 0.67, int swipeSpeed = 500, bool withInertia = true)
- ScrollTop (IQuery query, ScrollStrategy strategy = ScrollStrategy.Auto, double swipePercentage = 0.67, int swipeSpeed = 500, bool withInertia = true)
- ScrollBottom (IQuery query, ScrollStrategy strategy = ScrollStrategy.Auto, double swipePercentage = 0.67, int swipeSpeed = 500, bool withInertia = true)