### PR TITLE
iOS UIImpactFeedbackGenerator should be used on iOS 17.5 and up

### DIFF
--- a/src/Essentials/src/HapticFeedback/HapticFeedback.ios.cs
+++ b/src/Essentials/src/HapticFeedback/HapticFeedback.ios.cs
@@ -23,8 +23,8 @@ namespace Microsoft.Maui.Devices
 		void Click()
 		{
 			UIImpactFeedbackGenerator impact;
-#if IOS17_4_OR_GREATER || MACCATALYST17_4_OR_GREATER
-			if (OperatingSystem.IsIOSVersionAtLeast(17, 4) || OperatingSystem.IsMacCatalystVersionAtLeast(17, 4))
+#if IOS17_5_OR_GREATER || MACCATALYST17_5_OR_GREATER
+			if (OperatingSystem.IsIOSVersionAtLeast(17, 5) || OperatingSystem.IsMacCatalystVersionAtLeast(17, 5))
 			{
 				impact = UIImpactFeedbackGenerator.GetFeedbackGenerator(UIImpactFeedbackStyle.Light, new UIView());
 			}
@@ -41,8 +41,8 @@ namespace Microsoft.Maui.Devices
 		void LongPress()
 		{
 			UIImpactFeedbackGenerator impact;
-#if IOS17_4_OR_GREATER || MACCATALYST17_4_OR_GREATER
-			if (OperatingSystem.IsIOSVersionAtLeast(17, 4) || OperatingSystem.IsMacCatalystVersionAtLeast(17, 4))
+#if IOS17_5_OR_GREATER || MACCATALYST17_5_OR_GREATER
+			if (OperatingSystem.IsIOSVersionAtLeast(17, 5) || OperatingSystem.IsMacCatalystVersionAtLeast(17, 5))
 			{
 				impact = UIImpactFeedbackGenerator.GetFeedbackGenerator(UIImpactFeedbackStyle.Medium, new UIView());
 			}


### PR DESCRIPTION
### Description of Change

In https://github.com/dotnet/maui/pull/24605 we used some newer iOS APIs, however the gate for the haptic feedback API was too low of a version. It should be iOS 17.5 and up as opposed to 17.4 and up as it was specified now. Causing this API to crash on 17.4.

See https://developer.apple.com/documentation/uikit/uiimpactfeedbackgenerator/4403142-feedbackgeneratorwithstyle

### Issues Fixed

Fixes #25560
