### PR TITLE
[Android] RemainingItemsThresholdReachedCommand of CarouselView is not triggered

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/Android/RecyclerViewScrollListener.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/RecyclerViewScrollListener.cs
@@ -65,11 +65,11 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				case -1:
 					return;
 				case 0:
-					if (Last == ItemsViewAdapter.ItemCount - 1)
+					if (Last == ItemsViewAdapter.ItemsSource.Count - 1)
 						_itemsView.SendRemainingItemsThresholdReached();
 					break;
 				default:
-					if (ItemsViewAdapter.ItemCount - 1 - Last <= _itemsView.RemainingItemsThreshold)
+					if (ItemsViewAdapter.ItemsSource.Count - 1 - Last <= _itemsView.RemainingItemsThreshold)
 						_itemsView.SendRemainingItemsThresholdReached();
 					break;
 			}


### PR DESCRIPTION
### Description of Change

The RemainingItemsThresholdReachedCommand is never triggered on Android when carousel view has the `loop` property set to `true` (a default value)

The cause of it is this overriden ItemCount property

<img width="650" alt="Screenshot 2024-10-29 at 14 52 29" src="https://github.com/user-attachments/assets/3eb8adab-a441-4f2a-9392-9be630ce49c4">


<img width="741" alt="Screenshot 2024-10-29 at 14 50 29" src="https://github.com/user-attachments/assets/f0872aeb-94f7-4076-8a86-4368059657c1">

I'm not sure if it is a desired behaviour or not, but on iOS and Windows this is not the case

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/24571
