### PR TITLE
Remove all To be added. from API docs

### DIFF
--- a/src/Controls/docs/Microsoft.Maui.Controls.Internals/ActionSheetArguments.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Internals/ActionSheetArguments.xml
@@ -19,7 +19,6 @@
   </Attributes>
   <Docs>
     <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -45,7 +44,6 @@
         <param name="destruction">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="buttons">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Buttons">
@@ -65,7 +63,6 @@
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <value>For internal use by the Microsoft.Maui.Controls platform.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Cancel">
@@ -85,7 +82,6 @@
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <value>For internal use by the Microsoft.Maui.Controls platform.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Destruction">
@@ -105,7 +101,6 @@
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <value>For internal use by the Microsoft.Maui.Controls platform.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Result">
@@ -125,7 +120,6 @@
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <value>For internal use by the Microsoft.Maui.Controls platform.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetResult">
@@ -148,7 +142,6 @@
       <Docs>
         <param name="result">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Title">
@@ -168,7 +161,6 @@
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <value>For internal use by the Microsoft.Maui.Controls platform.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Internals/AlertArguments.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Internals/AlertArguments.xml
@@ -19,7 +19,6 @@
   </Attributes>
   <Docs>
     <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -45,7 +44,6 @@
         <param name="accept">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="cancel">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Accept">
@@ -65,7 +63,6 @@
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <value>For internal use by the Microsoft.Maui.Controls platform.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Cancel">
@@ -85,7 +82,6 @@
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <value>For internal use by the Microsoft.Maui.Controls platform.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Message">
@@ -105,7 +101,6 @@
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <value>For internal use by the Microsoft.Maui.Controls platform.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Result">
@@ -125,7 +120,6 @@
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <value>For internal use by the Microsoft.Maui.Controls platform.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetResult">
@@ -148,7 +142,6 @@
       <Docs>
         <param name="result">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Title">
@@ -168,7 +161,6 @@
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <value>For internal use by the Microsoft.Maui.Controls platform.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Internals/AsyncValueExtensions.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Internals/AsyncValueExtensions.xml
@@ -18,7 +18,6 @@
   </Attributes>
   <Docs>
     <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="AsAsyncValue&lt;T&gt;">
@@ -47,7 +46,6 @@
         <param name="defaultValue">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <returns>For internal use by the Microsoft.Maui.Controls platform.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Internals/CellExtensions.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Internals/CellExtensions.xml
@@ -19,7 +19,6 @@
   </Attributes>
   <Docs>
     <summary>For internal use by platform renderers.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="GetGroup&lt;TView,TItem&gt;">
@@ -58,7 +57,6 @@
         <param name="cell">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by platform renderers.</summary>
         <returns>For internal use by the Microsoft.Maui.Controls platform.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetGroupHeaderContent&lt;TView,TItem&gt;">
@@ -97,7 +95,6 @@
         <param name="cell">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by platform renderers.</summary>
         <returns>For internal use by the Microsoft.Maui.Controls platform.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetIndex&lt;TView,TItem&gt;">
@@ -136,7 +133,6 @@
         <param name="cell">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by platform renderers.</summary>
         <returns>For internal use by the Microsoft.Maui.Controls platform.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetIsGroupHeader&lt;TView,TItem&gt;">
@@ -175,7 +171,6 @@
         <param name="cell">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by platform renderers.</summary>
         <returns>For internal use by the Microsoft.Maui.Controls platform.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetPath">
@@ -199,7 +194,6 @@
         <param name="cell">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by platform renderers.</summary>
         <returns>For internal use by the Microsoft.Maui.Controls platform.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetIsGroupHeader&lt;TView,TItem&gt;">
@@ -239,7 +233,6 @@
         <param name="cell">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="value">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by platform renderers.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Internals/ContentPageEx.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Internals/ContentPageEx.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Data">
@@ -30,8 +28,6 @@
         <ReturnType>System.Collections.Generic.List&lt;Microsoft.Maui.Controls.Internals.ProfileDatum&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="LoadProfile">
@@ -52,8 +48,6 @@
       </Parameters>
       <Docs>
         <param name="page">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Internals/DataTemplateExtensions.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Internals/DataTemplateExtensions.xml
@@ -19,7 +19,6 @@
   </Attributes>
   <Docs>
     <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="CreateContent">
@@ -47,7 +46,6 @@
         <param name="container">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <returns>For internal use by the Microsoft.Maui.Controls platform.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SelectDataTemplate">
@@ -75,7 +73,6 @@
         <param name="container">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <returns>For internal use by the Microsoft.Maui.Controls platform.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Internals/DependencyResolver.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Internals/DependencyResolver.xml
@@ -14,7 +14,6 @@
   <Interfaces />
   <Docs>
     <summary>Contains static methods that add functions to use for resolving dependencies.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="ResolveUsing">

--- a/src/Controls/docs/Microsoft.Maui.Controls.Internals/DeviceOrientationExtensions.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Internals/DeviceOrientationExtensions.xml
@@ -19,7 +19,6 @@
   </Attributes>
   <Docs>
     <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="IsLandscape">
@@ -43,7 +42,6 @@
         <param name="orientation">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <returns>For internal use by the Microsoft.Maui.Controls platform.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsPortrait">
@@ -67,7 +65,6 @@
         <param name="orientation">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <returns>For internal use by the Microsoft.Maui.Controls platform.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Internals/DynamicResource.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Internals/DynamicResource.xml
@@ -20,7 +20,6 @@
   </Attributes>
   <Docs>
     <summary>For internal use by platform renderers.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -41,7 +40,6 @@
       <Docs>
         <param name="key">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by platform renderers.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Key">
@@ -62,7 +60,6 @@
       <Docs>
         <summary>For internal use by platform renderers.</summary>
         <value>For internal use by the Microsoft.Maui.Controls platform.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Internals/EffectUtilities.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Internals/EffectUtilities.xml
@@ -19,7 +19,6 @@
   </Attributes>
   <Docs>
     <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="RegisterEffectControlProvider">
@@ -46,7 +45,6 @@
         <param name="oldElement">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="newElement">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="UnregisterEffectControlProvider">
@@ -70,7 +68,6 @@
         <param name="self">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="element">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Internals/EnumerableExtensions.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Internals/EnumerableExtensions.xml
@@ -19,7 +19,6 @@
   </Attributes>
   <Docs>
     <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="ForEach&lt;T&gt;">
@@ -48,7 +47,6 @@
         <param name="enumeration">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="action">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetChildGesturesFor&lt;T&gt;">
@@ -87,7 +85,6 @@
         <param name="predicate">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <returns>For internal use by the Microsoft.Maui.Controls platform.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetGesturesFor&lt;T&gt;">
@@ -126,7 +123,6 @@
         <param name="predicate">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <returns>For internal use by the Microsoft.Maui.Controls platform.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GroupToDictionary&lt;TSource,TKey&gt;">
@@ -157,7 +153,6 @@
         <param name="func">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <returns>For internal use by the Microsoft.Maui.Controls platform.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IndexOf&lt;T&gt;">
@@ -187,7 +182,6 @@
         <param name="predicate">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <returns>For internal use by the Microsoft.Maui.Controls platform.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IndexOf&lt;T&gt;">
@@ -217,7 +211,6 @@
         <param name="item">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <returns>For internal use by the Microsoft.Maui.Controls platform.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Prepend&lt;T&gt;">
@@ -252,7 +245,6 @@
         <param name="item">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <returns>For internal use by the Microsoft.Maui.Controls platform.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Internals/EvalRequested.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Internals/EvalRequested.xml
@@ -19,7 +19,6 @@
   </Attributes>
   <Docs>
     <summary>For internal use by platform renderers.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -39,7 +38,6 @@
       <Docs>
         <param name="script">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by platform renderers.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Script">
@@ -59,7 +57,6 @@
       <Docs>
         <summary>For internal use by platform renderers.</summary>
         <value>For internal use by the Microsoft.Maui.Controls platform.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Internals/ExpressionSearch.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Internals/ExpressionSearch.xml
@@ -19,7 +19,6 @@
   </Attributes>
   <Docs>
     <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -35,7 +34,6 @@
       <Parameters />
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Default">
@@ -55,7 +53,6 @@
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <value>For internal use by the Microsoft.Maui.Controls platform.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Internals/GIFBitmap.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Internals/GIFBitmap.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="BackgroundColor">
@@ -30,9 +28,6 @@
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Bounds">
@@ -49,9 +44,6 @@
         <ReturnType>Microsoft.Maui.Controls.Internals.GIFBitmap+Rect</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ColorTable">
@@ -68,9 +60,6 @@
         <ReturnType>Microsoft.Maui.Controls.Internals.GIFColorTable</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CreateBitmapAsync">
@@ -99,9 +88,6 @@
         <param name="decoder">To be added.</param>
         <param name="previousBitmap">To be added.</param>
         <param name="ignoreImageData">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Data">
@@ -118,9 +104,6 @@
         <ReturnType>System.Int32[]</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="DataPosition">
@@ -137,9 +120,6 @@
         <ReturnType>System.Int64</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Delay">
@@ -156,9 +136,6 @@
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Dispose">
@@ -175,9 +152,6 @@
         <ReturnType>Microsoft.Maui.Controls.Internals.GIFBitmap+DisposeMethod</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsInterlaced">
@@ -194,9 +168,6 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsTransparent">
@@ -213,9 +184,6 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="LoopCount">
@@ -232,9 +200,6 @@
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TransparencyIndex">
@@ -251,9 +216,6 @@
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Internals/GIFBitmapDecoder.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Internals/GIFBitmapDecoder.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -27,8 +25,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Compose">
@@ -53,8 +49,6 @@
         <param name="header">To be added.</param>
         <param name="currentBitmap">To be added.</param>
         <param name="previousBitmap">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="DecodeAsync">
@@ -79,9 +73,6 @@
         <param name="stream">To be added.</param>
         <param name="width">To be added.</param>
         <param name="height">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Internals/GIFColorTable.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Internals/GIFColorTable.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="CreateColorTableAsync">
@@ -36,9 +34,6 @@
       <Docs>
         <param name="stream">To be added.</param>
         <param name="size">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Data">
@@ -55,9 +50,6 @@
         <ReturnType>System.Int32[]</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ResetTransparency">
@@ -75,8 +67,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetTransparency">
@@ -97,8 +87,6 @@
       </Parameters>
       <Docs>
         <param name="transparencyIndex">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Internals/GIFDecoderFormatException.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Internals/GIFDecoderFormatException.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -27,8 +25,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -46,8 +42,6 @@
       </Parameters>
       <Docs>
         <param name="message">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -67,8 +61,6 @@
       <Docs>
         <param name="message">To be added.</param>
         <param name="innerException">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Internals/GIFDecoderStreamReader.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Internals/GIFDecoderStreamReader.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -31,8 +29,6 @@
       </Parameters>
       <Docs>
         <param name="stream">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CurrentBlockBuffer">
@@ -49,9 +45,6 @@
         <ReturnType>System.Byte[]</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CurrentBlockSize">
@@ -68,9 +61,6 @@
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CurrentPosition">
@@ -87,9 +77,6 @@
         <ReturnType>System.Int64</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Read">
@@ -107,9 +94,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ReadAsync">
@@ -132,9 +116,6 @@
       <Docs>
         <param name="buffer">To be added.</param>
         <param name="toRead">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ReadBlockAsync">
@@ -152,9 +133,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ReadShort">
@@ -172,9 +150,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ReadString">
@@ -195,9 +170,6 @@
       </Parameters>
       <Docs>
         <param name="length">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SkipBlockAsync">
@@ -215,9 +187,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Internals/GIFHeader.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Internals/GIFHeader.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="BackgroundColor">
@@ -30,9 +28,6 @@
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="BackgroundColorIndex">
@@ -49,9 +44,6 @@
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CreateHeaderAsync">
@@ -74,9 +66,6 @@
       <Docs>
         <param name="stream">To be added.</param>
         <param name="skipTypeIdentifier">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GlobalColorTable">
@@ -93,9 +82,6 @@
         <ReturnType>Microsoft.Maui.Controls.Internals.GIFColorTable</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Height">
@@ -112,9 +98,6 @@
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsGIFHeader">
@@ -131,9 +114,6 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PixelAspectRatio">
@@ -150,9 +130,6 @@
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TypeIdentifier">
@@ -169,9 +146,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Version">
@@ -188,9 +162,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Width">
@@ -207,9 +178,6 @@
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Internals/GIFImageParser.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Internals/GIFImageParser.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -27,8 +25,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="AddBitmap">
@@ -53,8 +49,6 @@
         <param name="header">To be added.</param>
         <param name="bitmap">To be added.</param>
         <param name="ignoreImageData">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FinishedParsing">
@@ -72,8 +66,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ParseAsync">
@@ -98,9 +90,6 @@
         <param name="stream">To be added.</param>
         <param name="skipTypeIdentifier">To be added.</param>
         <param name="ignoreImageData">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="StartParsing">
@@ -118,8 +107,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Internals/InvalidationTrigger.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Internals/InvalidationTrigger.xml
@@ -21,7 +21,6 @@
   </Attributes>
   <Docs>
     <summary>For internal use by platform renderers.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="HorizontalOptionsChanged">

--- a/src/Controls/docs/Microsoft.Maui.Controls.Internals/NameScope.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Internals/NameScope.xml
@@ -24,7 +24,6 @@
   </Attributes>
   <Docs>
     <summary>For internal use by platform renderers.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -41,7 +40,6 @@
       <Parameters />
       <Docs>
         <summary>For internal use by platform renderers.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetNameScope">
@@ -66,7 +64,6 @@
         <param name="bindable">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by platform renderers.</summary>
         <returns>For internal use by the Microsoft.Maui.Controls platform.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="NameScopeProperty">
@@ -86,7 +83,6 @@
       </ReturnValue>
       <Docs>
         <summary>For internal use by platform renderers.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetNameScope">
@@ -112,7 +108,6 @@
         <param name="bindable">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="value">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by platform renderers.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.Internals.INameScope.FindByName">
@@ -140,7 +135,6 @@
         <param name="name">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by platform renderers.</summary>
         <returns>For internal use by the Microsoft.Maui.Controls platform.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.Internals.INameScope.RegisterName">
@@ -169,7 +163,6 @@
         <param name="name">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="scopedElement">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by platform renderers.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Internals/NavigationModel.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Internals/NavigationModel.xml
@@ -19,7 +19,6 @@
   </Attributes>
   <Docs>
     <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -35,7 +34,6 @@
       <Parameters />
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Clear">
@@ -55,7 +53,6 @@
       <Parameters />
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CurrentPage">
@@ -75,7 +72,6 @@
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <value>For internal use by the Microsoft.Maui.Controls platform.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="InsertPageBefore">
@@ -100,7 +96,6 @@
         <param name="page">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="before">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Modals">
@@ -120,7 +115,6 @@
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <value>For internal use by the Microsoft.Maui.Controls platform.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Pop">
@@ -144,7 +138,6 @@
         <param name="ancestralNav">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <returns>For internal use by the Microsoft.Maui.Controls platform.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PopModal">
@@ -165,7 +158,6 @@
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <returns>For internal use by the Microsoft.Maui.Controls platform.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PopTopPage">
@@ -186,7 +178,6 @@
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <returns>For internal use by the Microsoft.Maui.Controls platform.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PopToRoot">
@@ -209,7 +200,6 @@
       <Docs>
         <param name="ancestralNav">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Push">
@@ -234,7 +224,6 @@
         <param name="page">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="ancestralNav">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PushModal">
@@ -257,7 +246,6 @@
       <Docs>
         <param name="page">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RemovePage">
@@ -281,7 +269,6 @@
         <param name="page">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <returns>For internal use by the Microsoft.Maui.Controls platform.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Roots">
@@ -306,7 +293,6 @@
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <value>For internal use by the Microsoft.Maui.Controls platform.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Tree">
@@ -326,7 +312,6 @@
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <value>For internal use by the Microsoft.Maui.Controls platform.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Internals/NavigationProxy.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Internals/NavigationProxy.xml
@@ -23,7 +23,6 @@
   </Attributes>
   <Docs>
     <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -39,7 +38,6 @@
       <Parameters />
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetModalStack">
@@ -60,7 +58,6 @@
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <returns>For internal use by the Microsoft.Maui.Controls platform.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetNavigationStack">
@@ -81,7 +78,6 @@
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <returns>For internal use by the Microsoft.Maui.Controls platform.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Inner">
@@ -101,7 +97,6 @@
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <value>For internal use by the Microsoft.Maui.Controls platform.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="InsertPageBefore">
@@ -129,7 +124,6 @@
         <param name="page">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="before">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ModalStack">
@@ -152,7 +146,6 @@
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <value>For internal use by the Microsoft.Maui.Controls platform.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="NavigationStack">
@@ -175,7 +168,6 @@
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <value>For internal use by the Microsoft.Maui.Controls platform.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnInsertPageBefore">
@@ -200,7 +192,6 @@
         <param name="page">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="before">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnPopAsync">
@@ -224,7 +215,6 @@
         <param name="animated">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <returns>For internal use by the Microsoft.Maui.Controls platform.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnPopModal">
@@ -248,7 +238,6 @@
         <param name="animated">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <returns>For internal use by the Microsoft.Maui.Controls platform.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnPopToRootAsync">
@@ -272,7 +261,6 @@
         <param name="animated">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <returns>For internal use by the Microsoft.Maui.Controls platform.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnPushAsync">
@@ -298,7 +286,6 @@
         <param name="animated">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <returns>For internal use by the Microsoft.Maui.Controls platform.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnPushModal">
@@ -324,7 +311,6 @@
         <param name="animated">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <returns>For internal use by the Microsoft.Maui.Controls platform.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnRemovePage">
@@ -347,7 +333,6 @@
       <Docs>
         <param name="page">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PopAsync">
@@ -371,7 +356,6 @@
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <returns>For internal use by the Microsoft.Maui.Controls platform.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PopAsync">
@@ -398,7 +382,6 @@
         <param name="animated">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <returns>For internal use by the Microsoft.Maui.Controls platform.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PopModalAsync">
@@ -422,7 +405,6 @@
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <returns>For internal use by the Microsoft.Maui.Controls platform.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PopModalAsync">
@@ -449,7 +431,6 @@
         <param name="animated">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <returns>For internal use by the Microsoft.Maui.Controls platform.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PopToRootAsync">
@@ -473,7 +454,6 @@
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <returns>For internal use by the Microsoft.Maui.Controls platform.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PopToRootAsync">
@@ -500,7 +480,6 @@
         <param name="animated">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <returns>For internal use by the Microsoft.Maui.Controls platform.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PushAsync">
@@ -527,7 +506,6 @@
         <param name="root">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <returns>For internal use by the Microsoft.Maui.Controls platform.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PushAsync">
@@ -556,7 +534,6 @@
         <param name="animated">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <returns>For internal use by the Microsoft.Maui.Controls platform.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PushModalAsync">
@@ -583,7 +560,6 @@
         <param name="modal">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <returns>For internal use by the Microsoft.Maui.Controls platform.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PushModalAsync">
@@ -612,7 +588,6 @@
         <param name="animated">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <returns>For internal use by the Microsoft.Maui.Controls platform.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RemovePage">
@@ -638,7 +613,6 @@
       <Docs>
         <param name="page">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Internals/NavigationRequestType.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Internals/NavigationRequestType.xml
@@ -17,7 +17,6 @@
   </Attributes>
   <Docs>
     <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Insert">

--- a/src/Controls/docs/Microsoft.Maui.Controls.Internals/NavigationRequestedEventArgs.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Internals/NavigationRequestedEventArgs.xml
@@ -19,7 +19,6 @@
   </Attributes>
   <Docs>
     <summary>For internal use by platform renderers.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -40,7 +39,6 @@
         <param name="page">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="animated">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -68,7 +66,6 @@
         <param name="animated">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="realize">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -92,7 +89,6 @@
         <param name="before">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="animated">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by platform renderers.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Animated">
@@ -112,7 +108,6 @@
       <Docs>
         <summary>For internal use by platform renderers.</summary>
         <value>For internal use by the Microsoft.Maui.Controls platform.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="BeforePage">
@@ -132,7 +127,6 @@
       <Docs>
         <summary>For internal use by platform renderers.</summary>
         <value>For internal use by the Microsoft.Maui.Controls platform.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Realize">
@@ -156,7 +150,6 @@
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <value>For internal use by the Microsoft.Maui.Controls platform.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RequestType">
@@ -175,7 +168,6 @@
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <value>For internal use by the Microsoft.Maui.Controls platform.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Task">
@@ -195,7 +187,6 @@
       <Docs>
         <summary>For internal use by platform renderers.</summary>
         <value>For internal use by the Microsoft.Maui.Controls platform.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Internals/NotifyCollectionChangedEventArgsEx.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Internals/NotifyCollectionChangedEventArgsEx.xml
@@ -19,7 +19,6 @@
   </Attributes>
   <Docs>
     <summary>For internal use by platform renderers.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -41,7 +40,6 @@
         <param name="count">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="action">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by platform renderers.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -65,7 +63,6 @@
         <param name="action">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="changedItems">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by platform renderers.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -89,7 +86,6 @@
         <param name="action">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="changedItem">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by platform renderers.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -115,7 +111,6 @@
         <param name="newItems">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="oldItems">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by platform renderers.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -141,7 +136,6 @@
         <param name="changedItems">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="startingIndex">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by platform renderers.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -167,7 +161,6 @@
         <param name="changedItem">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="index">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by platform renderers.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -193,7 +186,6 @@
         <param name="newItem">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="oldItem">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by platform renderers.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -221,7 +213,6 @@
         <param name="oldItems">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="startingIndex">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by platform renderers.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -249,7 +240,6 @@
         <param name="index">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="oldIndex">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by platform renderers.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -277,7 +267,6 @@
         <param name="index">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="oldIndex">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by platform renderers.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -305,7 +294,6 @@
         <param name="oldItem">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="index">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by platform renderers.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Count">
@@ -325,7 +313,6 @@
       <Docs>
         <summary>For internal use by platform renderers.</summary>
         <value>For internal use by the Microsoft.Maui.Controls platform.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Internals/NotifyCollectionChangedEventArgsExtensions.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Internals/NotifyCollectionChangedEventArgsExtensions.xml
@@ -19,7 +19,6 @@
   </Attributes>
   <Docs>
     <summary>For internal use by platform renderers.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Apply">
@@ -49,7 +48,6 @@
         <param name="reset">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by platform renderers.</summary>
         <returns>For internal use by the Microsoft.Maui.Controls platform.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Apply&lt;TFrom&gt;">
@@ -80,7 +78,6 @@
         <param name="from">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="to">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by platform renderers.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="WithCount">
@@ -106,7 +103,6 @@
         <param name="count">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by platform renderers.</summary>
         <returns>For internal use by the Microsoft.Maui.Controls platform.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Internals/PageExtensions.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Internals/PageExtensions.xml
@@ -18,7 +18,6 @@
   </Attributes>
   <Docs>
     <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="AncestorToRoot">
@@ -41,7 +40,6 @@
         <param name="page">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <returns>For internal use by the Microsoft.Maui.Controls platform.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Internals/Performance.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Internals/Performance.xml
@@ -19,7 +19,6 @@
   </Attributes>
   <Docs>
     <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -35,7 +34,6 @@
       <Parameters />
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Provider">
@@ -55,7 +53,6 @@
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <value>For internal use by the Microsoft.Maui.Controls platform.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetProvider">
@@ -78,7 +75,6 @@
       <Docs>
         <param name="instance">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Start">
@@ -119,7 +115,6 @@
         <param name="path">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="member">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Start">
@@ -159,7 +154,6 @@
         <param name="path">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="member">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Stop">
@@ -200,7 +194,6 @@
         <param name="path">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="member">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Internals/PlatformBindingHelpers.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Internals/PlatformBindingHelpers.xml
@@ -19,7 +19,6 @@
   </Attributes>
   <Docs>
     <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="SetBinding&lt;TNativeView&gt;">
@@ -54,7 +53,6 @@
         <param name="targetProperty">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="binding">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetBinding&lt;TNativeView&gt;">
@@ -91,7 +89,6 @@
         <param name="bindingBase">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="propertyChanged">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetBinding&lt;TNativeView&gt;">
@@ -128,7 +125,6 @@
         <param name="bindingBase">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="updateSourceEventName">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetBindingContext&lt;TNativeView&gt;">
@@ -163,7 +159,6 @@
         <param name="bindingContext">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="getChild">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetValue&lt;TNativeView&gt;">
@@ -198,7 +193,6 @@
         <param name="targetProperty">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="value">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TransferBindablePropertiesToWrapper&lt;TNativeView,TNativeWrapper&gt;">
@@ -237,7 +231,6 @@
         <param name="nativeView">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="wrapper">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Internals/PreserveAttribute.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Internals/PreserveAttribute.xml
@@ -22,7 +22,6 @@
   </Attributes>
   <Docs>
     <summary>For internal use by platform renderers.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -38,7 +37,6 @@
       <Parameters />
       <Docs>
         <summary>For internal use by platform renderers.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -60,7 +58,6 @@
         <param name="allMembers">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="conditional">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by platform renderers.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="AllMembers">
@@ -79,7 +76,6 @@
       </ReturnValue>
       <Docs>
         <summary>For internal use by platform renderers.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Conditional">
@@ -98,7 +94,6 @@
       </ReturnValue>
       <Docs>
         <summary>For internal use by platform renderers.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Internals/Profile.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Internals/Profile.xml
@@ -22,7 +22,6 @@
   </Attributes>
   <Docs>
     <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Data">
@@ -40,7 +39,6 @@
       </ReturnValue>
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Dispose">
@@ -62,7 +60,6 @@
       <Parameters />
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Enable">
@@ -85,8 +82,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FrameBegin">
@@ -121,8 +116,6 @@
       <Docs>
         <param name="name">To be added.</param>
         <param name="line">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FrameEnd">
@@ -149,8 +142,6 @@
       </Parameters>
       <Docs>
         <param name="name">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FramePartition">
@@ -180,7 +171,6 @@
         <param name="id">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="line">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsEnabled">
@@ -202,9 +192,6 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Start">
@@ -223,7 +210,6 @@
       <Parameters />
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Stop">
@@ -242,7 +228,6 @@
       <Parameters />
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Internals/ProfileDatum.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Internals/ProfileDatum.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -27,8 +25,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Depth">
@@ -45,8 +41,6 @@
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Id">
@@ -63,8 +57,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Line">
@@ -81,8 +73,6 @@
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Name">
@@ -99,8 +89,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Path">
@@ -117,8 +105,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SubTicks">
@@ -135,8 +121,6 @@
         <ReturnType>System.Int64</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Ticks">
@@ -153,8 +137,6 @@
         <ReturnType>System.Int64</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Internals/PromptArguments.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Internals/PromptArguments.xml
@@ -17,8 +17,6 @@
     </Attribute>
   </Attributes>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -56,8 +54,6 @@
         <param name="placeholder">To be added.</param>
         <param name="maxLength">To be added.</param>
         <param name="keyboard">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -89,8 +85,6 @@
         <param name="maxLength">To be added.</param>
         <param name="keyboard">To be added.</param>
         <param name="initialValue">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Accept">
@@ -107,9 +101,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Cancel">
@@ -126,9 +117,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="InitialValue">
@@ -145,9 +133,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Keyboard">
@@ -164,9 +149,6 @@
         <ReturnType>Microsoft.Maui.Keyboard</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="MaxLength">
@@ -183,9 +165,6 @@
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Message">
@@ -202,9 +181,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Placeholder">
@@ -221,9 +197,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Result">
@@ -240,9 +213,6 @@
         <ReturnType>System.Threading.Tasks.TaskCompletionSource&lt;System.String&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetResult">
@@ -263,8 +233,6 @@
       </Parameters>
       <Docs>
         <param name="text">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Title">
@@ -281,9 +249,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Internals/PropertyPropagationExtensions.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Internals/PropertyPropagationExtensions.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="PropagatePropertyChanged">
@@ -38,8 +36,6 @@
         <param name="propertyName">To be added.</param>
         <param name="target">To be added.</param>
         <param name="source">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Internals/Registrar.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Internals/Registrar.xml
@@ -19,7 +19,6 @@
   </Attributes>
   <Docs>
     <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="ExtraAssemblies">
@@ -39,7 +38,6 @@
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <value>For internal use by the Microsoft.Maui.Controls platform.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RegisterAll">
@@ -62,7 +60,6 @@
       <Docs>
         <param name="attrTypes">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RegisterAll">
@@ -85,8 +82,6 @@
       <Docs>
         <param name="attrTypes">To be added.</param>
         <param name="flags">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Registered">
@@ -106,7 +101,6 @@
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <value>For internal use by the Microsoft.Maui.Controls platform.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RegisterEffects">
@@ -130,7 +124,6 @@
         <param name="resolutionName">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="effectAttributes">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RegisterRenderers">
@@ -152,7 +145,6 @@
       <Docs>
         <param name="attributes">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RegisterStylesheets">
@@ -173,8 +165,6 @@
       </Parameters>
       <Docs>
         <param name="flags">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Internals/ResourceLoader.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Internals/ResourceLoader.xml
@@ -19,7 +19,6 @@
   </Attributes>
   <Docs>
     <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="CanProvideContentFor">
@@ -50,7 +49,6 @@
         <param name="rlq">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <returns>For internal use by the Microsoft.Maui.Controls platform.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsEnabled">
@@ -75,9 +73,6 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ResourceProvider">
@@ -105,7 +100,6 @@
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <value>For internal use by the Microsoft.Maui.Controls platform.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ResourceProvider2">
@@ -124,7 +118,6 @@
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <value>For internal use by the Microsoft.Maui.Controls platform.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Internals/ResourcesChangedEventArgs.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Internals/ResourcesChangedEventArgs.xml
@@ -19,7 +19,6 @@
   </Attributes>
   <Docs>
     <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -39,7 +38,6 @@
       <Docs>
         <param name="values">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="StyleSheets">
@@ -58,7 +56,6 @@
       </ReturnValue>
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Values">
@@ -78,7 +75,6 @@
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <value>For internal use by the Microsoft.Maui.Controls platform.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Internals/TableModel.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Internals/TableModel.xml
@@ -23,7 +23,6 @@
   </Attributes>
   <Docs>
     <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -39,7 +38,6 @@
       <Parameters />
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetCell">
@@ -68,7 +66,6 @@
         <param name="row">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <returns>For internal use by the Microsoft.Maui.Controls platform.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetHeaderCell">
@@ -95,7 +92,6 @@
         <param name="section">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <returns>For internal use by the Microsoft.Maui.Controls platform.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetItem">
@@ -124,7 +120,6 @@
         <param name="row">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <returns>For internal use by the Microsoft.Maui.Controls platform.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetRowCount">
@@ -151,7 +146,6 @@
         <param name="section">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <returns>For internal use by the Microsoft.Maui.Controls platform.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetSectionCount">
@@ -175,7 +169,6 @@
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <returns>For internal use by the Microsoft.Maui.Controls platform.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetSectionIndexTitles">
@@ -199,7 +192,6 @@
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <returns>For internal use by the Microsoft.Maui.Controls platform.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetSectionTextColor">
@@ -225,7 +217,6 @@
         <param name="section">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <returns>For internal use by the Microsoft.Maui.Controls platform.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetSectionTitle">
@@ -252,7 +243,6 @@
         <param name="section">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <returns>For internal use by the Microsoft.Maui.Controls platform.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ItemLongPressed">
@@ -271,7 +261,6 @@
       </ReturnValue>
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ItemSelected">
@@ -290,7 +279,6 @@
       </ReturnValue>
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnRowLongPressed">
@@ -313,7 +301,6 @@
       <Docs>
         <param name="item">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnRowSelected">
@@ -336,7 +323,6 @@
       <Docs>
         <param name="item">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RowLongPressed">
@@ -359,7 +345,6 @@
       <Docs>
         <param name="item">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RowLongPressed">
@@ -387,7 +372,6 @@
         <param name="section">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="row">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RowSelected">
@@ -413,7 +397,6 @@
       <Docs>
         <param name="item">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RowSelected">
@@ -441,7 +424,6 @@
         <param name="section">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="row">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Internals/TextTransformUtilites.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Internals/TextTransformUtilites.xml
@@ -17,8 +17,6 @@
     </Attribute>
   </Attributes>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="GetTransformedText">
@@ -46,9 +44,6 @@
       <Docs>
         <param name="source">To be added.</param>
         <param name="textTransform">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetPlainText">
@@ -76,8 +71,6 @@
       <Docs>
         <param name="inputView">To be added.</param>
         <param name="platformText">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Internals/TypedBindingBase.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Internals/TypedBindingBase.xml
@@ -19,7 +19,6 @@
   </Attributes>
   <Docs>
     <summary>For internal use by platform renderers.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Converter">
@@ -39,7 +38,6 @@
       <Docs>
         <summary>For internal use by platform renderers.</summary>
         <value>For internal use by the Microsoft.Maui.Controls platform.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ConverterParameter">
@@ -59,7 +57,6 @@
       <Docs>
         <summary>For internal use by platform renderers.</summary>
         <value>For internal use by the Microsoft.Maui.Controls platform.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Source">
@@ -79,7 +76,6 @@
       <Docs>
         <summary>For internal use by platform renderers.</summary>
         <value>For internal use by the Microsoft.Maui.Controls platform.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompat/Application.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompat/Application.xml
@@ -14,7 +14,6 @@
   <Interfaces />
   <Docs>
     <summary>AppCompat application instance on Android.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="GetSendAppearingEventOnResume">
@@ -37,8 +36,6 @@
       <Docs>
         <param name="element">The platform specific element on which to perform the operation.</param>
         <summary>Returns a Boolean value that tells whether the appearing event is sent when the application resumes.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetSendAppearingEventOnResume">
@@ -61,8 +58,6 @@
       <Docs>
         <param name="config">The platform specific configuration that contains the element on which to perform the operation.</param>
         <summary>Returns a Boolean value that tells whether the appearing event is sent when the application resumes.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetSendDisappearingEventOnPause">
@@ -85,8 +80,6 @@
       <Docs>
         <param name="element">The platform specific element on which to perform the operation.</param>
         <summary>Returns a Boolean value that tells whether the disappearing event is sent when the application is paused.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetSendDisappearingEventOnPause">
@@ -109,8 +102,6 @@
       <Docs>
         <param name="config">The platform specific configuration that contains the element on which to perform the operation.</param>
         <summary>Returns a Boolean value that tells whether the disappearing event is sent when the application is paused.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetShouldPreserveKeyboardOnResume">
@@ -133,8 +124,6 @@
       <Docs>
         <param name="element">The platform specific element on which to perform the operation.</param>
         <summary>Returns a Boolean value that tells whether the keyboard state should be preserved when the application resumes.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetShouldPreserveKeyboardOnResume">
@@ -157,8 +146,6 @@
       <Docs>
         <param name="config">The platform specific configuration that contains the element on which to perform the operation.</param>
         <summary>Returns a Boolean value that tells whether the keyboard state should be preserved when the application resumes.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SendAppearingEventOnResume">
@@ -183,8 +170,6 @@
         <param name="config">The platform specific configuration that contains the element on which to perform the operation.</param>
         <param name="value">The new property value to assign.</param>
         <summary>Sets a value that controls whether the appearing event is sent when the application resumes.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SendAppearingEventOnResumeProperty">
@@ -203,7 +188,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the attached property that controls whether the appearing event is sent when the application resumes.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SendDisappearingEventOnPause">
@@ -228,8 +212,6 @@
         <param name="config">The platform specific configuration that contains the element on which to perform the operation.</param>
         <param name="value">The new property value to assign.</param>
         <summary>Sets a Boolean value that controls whether the disappearing event is sent when the application is paused.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SendDisappearingEventOnPauseProperty">
@@ -248,7 +230,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the attached property that controls whether the disappearing event is sent when the application is paused.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetSendAppearingEventOnResume">
@@ -273,7 +254,6 @@
         <param name="element">The platform specific element on which to perform the operation.</param>
         <param name="value">The new property value to assign.</param>
         <summary>Sets a Boolean value that controls whether the appearing event is sent when the application resumes.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetSendDisappearingEventOnPause">
@@ -298,7 +278,6 @@
         <param name="element">The platform specific element on which to perform the operation.</param>
         <param name="value">The new property value to assign.</param>
         <summary>Sets a Boolean value that controls whether the disappearing event is sent when the application is paused.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetShouldPreserveKeyboardOnResume">
@@ -323,7 +302,6 @@
         <param name="element">The platform specific element on which to perform the operation.</param>
         <param name="value">The new property value to assign.</param>
         <summary>Sets a Boolean value that controls whether the keyboard state should be preserved when the application resumes.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ShouldPreserveKeyboardOnResume">
@@ -348,8 +326,6 @@
         <param name="config">The platform specific configuration that contains the element on which to perform the operation.</param>
         <param name="value">The new property value to assign.</param>
         <summary>Sets a Boolean value that controls whether the keyboard state should be preserved when the application resumes.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ShouldPreserveKeyboardOnResumeProperty">
@@ -368,7 +344,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the property that controls whether the keyboard state should be preserved when the application resumes.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompat/NavigationPage.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompat/NavigationPage.xml
@@ -14,7 +14,6 @@
   <Interfaces />
   <Docs>
     <summary>Appcompat platform specific navigation page.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="BarHeightProperty">
@@ -33,7 +32,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the attached property that controls the height of the navigation bar.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetBarHeight">
@@ -57,7 +55,6 @@
         <param name="element">The element whose bar height to get.</param>
         <summary>Gets the navigation bar height for the specified <paramref name="element" />.</summary>
         <returns>The new bar height.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetBarHeight">
@@ -81,7 +78,6 @@
         <param name="config">The platform configuration for the element whose bar height to get.</param>
         <summary>Gets the navigation bar height for the specified element.</summary>
         <returns>The new bar height.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetBarHeight">
@@ -106,7 +102,6 @@
         <param name="element">The element whose bar height to set.</param>
         <param name="value">The new bar height value.</param>
         <summary>Sets the new bar height value for the element.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetBarHeight">
@@ -132,7 +127,6 @@
         <param name="value">The new bar height value.</param>
         <summary>Sets the new bar height value for the element and returns a fluid API object.</summary>
         <returns>A fluent object on which the developer may make further method calls.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/Application.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/Application.xml
@@ -14,7 +14,6 @@
   <Interfaces />
   <Docs>
     <summary>The application instance that Microsoft.Maui.Controls created on the Android platform.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="GetWindowSoftInputModeAdjust">
@@ -38,7 +37,6 @@
         <param name="element">The platform specific element on which to perform the operation.</param>
         <summary>Returns a value that tells whether the soft input mode of the provided <paramref name="element" /> pans or resizes its content to allow the display of the on-screen input UI.</summary>
         <returns>A value that tells whether the soft input mode of the provided <paramref name="element" /> pans or resizes its content to allow the display of the on-screen input UI.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetWindowSoftInputModeAdjust">
@@ -62,7 +60,6 @@
         <param name="config">The platform specific configuration that contains the element on which to perform the operation.</param>
         <summary>Returns a value that tells whether the soft input mode of the provided platform configuration pans or resizes its content to allow the display of the on-screen input UI.</summary>
         <returns>A value that tells whether the soft input mode of the provided platform configuration pans or resizes its content to allow the display of the on-screen input UI.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetWindowSoftInputModeAdjust">
@@ -87,7 +84,6 @@
         <param name="element">The platform specific element on which to perform the operation.</param>
         <param name="value">The new property value to assign.</param>
         <summary>Sets a value that controls whether the soft input mode of the provided <paramref name="element" /> pans or resizes its content to allow the display of the on-screen input UI.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="UseWindowSoftInputModeAdjust">
@@ -113,7 +109,6 @@
         <param name="value">The new property value to assign.</param>
         <summary>Sets a value that controls whether the soft input mode of the provided platform configuration pans or resizes its content to allow the display of the on-screen input UI.</summary>
         <returns>A value that controls whether the soft input mode of the provided platform configuration pans or resizes its content to allow the display of the on-screen input UI.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="WindowSoftInputModeAdjustProperty">
@@ -132,7 +127,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the attached property that controls whether the soft input mode pans or resizes content to allow the display of the on-screen input UI.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/Button.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/Button.xml
@@ -14,7 +14,6 @@
   <Interfaces />
   <Docs>
     <summary>Controls padding and shadows for buttons on the Android platform.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="GetUseDefaultPadding">
@@ -38,7 +37,6 @@
         <param name="element">The Android button for which to get the padding behavior.</param>
         <summary>Returns a Boolean value that tells whether the default padding will be used.</summary>
         <returns>A Boolean value that tells whether the default padding will be used.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetUseDefaultShadow">
@@ -62,7 +60,6 @@
         <param name="element">The Android button for which to get the shadow behavior.</param>
         <summary>Returns a Boolean value that tells whether the default shadow will be used.</summary>
         <returns>A Boolean value that tells whether the default shadow will be used.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetUseDefaultPadding">
@@ -88,7 +85,6 @@
         <param name="value">
           <see langword="true" /> to use the default padding. Otherwise, <see langword="false" /></param>
         <summary>Sets a Boolean value that controls whether the button will use the default padding.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetUseDefaultPadding">
@@ -115,7 +111,6 @@
           <see langword="true" /> to use the default padding. Otherwise, <see langword="false" /></param>
         <summary>Sets a Boolean value that controls whether the button will use the default padding.</summary>
         <returns>A fluent object on which the developer may make further method calls.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetUseDefaultShadow">
@@ -141,7 +136,6 @@
         <param name="value">
           <see langword="true" /> to use the default shadow. Otherwise, <see langword="false" /></param>
         <summary>Sets a Boolean value that controls whether the button will use the default shadow.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetUseDefaultShadow">
@@ -168,7 +162,6 @@
           <see langword="true" /> to use the default shadow. Otherwise, <see langword="false" /></param>
         <summary>Sets a Boolean value that controls whether the button will use the default shadow.</summary>
         <returns>A fluent object on which the developer may make further method calls.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="UseDefaultPadding">
@@ -193,7 +186,6 @@
         <summary>Returns <see langword="true" /> if the button will use the default padding. Otherwise, returns <see langword="false" />.</summary>
         <returns>
           <see langword="true" /> if the button will use the default padding. Otherwise, <see langword="false" />.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="UseDefaultPaddingProperty">
@@ -212,7 +204,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the attached property that controls whether the button will use the default padding.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="UseDefaultShadow">
@@ -237,7 +228,6 @@
         <summary>Returns <see langword="true" /> if the button will use the default shadow. Otherwise, returns <see langword="false" />.</summary>
         <returns>
           <see langword="true" /> if the button will use the default shadow. Otherwise, <see langword="false" />.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="UseDefaultShadowProperty">
@@ -256,7 +246,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the attached property that controls whether the button will use the default shadow.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/Entry.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/Entry.xml
@@ -14,7 +14,6 @@
   <Interfaces />
   <Docs>
     <summary>Controls input method editor (IME) options for entry fields on the Android platform.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="GetImeOptions">
@@ -38,7 +37,6 @@
         <param name="element">The Android entry for which to get the input method editor options.</param>
         <summary>Returns flags that specify input method editor options, such as the kind of action that is sent by the editor.</summary>
         <returns>The flags that specify input method editor options, such as the kind of action that is sent by the editor.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ImeOptions">
@@ -62,7 +60,6 @@
         <param name="config">The platform configuration for the Android entry for which to get the input method editor options.</param>
         <summary>Returns flags that specify input method editor options, such as the kind of action that is sent by the editor.</summary>
         <returns>The flags that specify input method editor options, such as the kind of action that is sent by the editor.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ImeOptionsProperty">
@@ -81,7 +78,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the attached property that specifies input method editor options.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetImeOptions">
@@ -106,7 +102,6 @@
         <param name="element">The Android entry for which to set the input method editor options.</param>
         <param name="value">The new options to set.</param>
         <summary>Sets the attached property that specifies input method editor options</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetImeOptions">
@@ -131,8 +126,6 @@
         <param name="config">The platform configuration for the Android entry for which to set the input method editor options.</param>
         <param name="value">The new options to set.</param>
         <summary>Sets the attached property that specifies input method editor options</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="GetIsShadowEnabled">
@@ -34,9 +32,6 @@
       </Parameters>
       <Docs>
         <param name="element">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetIsShadowEnabled">
@@ -57,9 +52,6 @@
       </Parameters>
       <Docs>
         <param name="config">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetShadowColor">
@@ -80,9 +72,6 @@
       </Parameters>
       <Docs>
         <param name="element">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetShadowColor">
@@ -103,9 +92,6 @@
       </Parameters>
       <Docs>
         <param name="config">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetShadowOffset">
@@ -126,9 +112,6 @@
       </Parameters>
       <Docs>
         <param name="element">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetShadowOffset">
@@ -149,9 +132,6 @@
       </Parameters>
       <Docs>
         <param name="config">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetShadowRadius">
@@ -172,9 +152,6 @@
       </Parameters>
       <Docs>
         <param name="element">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetShadowRadius">
@@ -195,9 +172,6 @@
       </Parameters>
       <Docs>
         <param name="config">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsShadowEnabledProperty">
@@ -214,8 +188,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetIsShadowEnabled">
@@ -238,8 +210,6 @@
       <Docs>
         <param name="element">To be added.</param>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetIsShadowEnabled">
@@ -262,9 +232,6 @@
       <Docs>
         <param name="config">To be added.</param>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetShadowColor">
@@ -287,8 +254,6 @@
       <Docs>
         <param name="element">To be added.</param>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetShadowColor">
@@ -311,9 +276,6 @@
       <Docs>
         <param name="config">To be added.</param>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetShadowOffset">
@@ -336,8 +298,6 @@
       <Docs>
         <param name="element">To be added.</param>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetShadowOffset">
@@ -360,9 +320,6 @@
       <Docs>
         <param name="config">To be added.</param>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetShadowRadius">
@@ -385,8 +342,6 @@
       <Docs>
         <param name="element">To be added.</param>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetShadowRadius">
@@ -409,9 +364,6 @@
       <Docs>
         <param name="config">To be added.</param>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ShadowColorProperty">
@@ -428,8 +380,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ShadowOffsetProperty">
@@ -446,8 +396,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ShadowRadiusProperty">
@@ -464,8 +412,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImeFlags.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImeFlags.xml
@@ -13,7 +13,6 @@
   </Base>
   <Docs>
     <summary>Enumerates input method editor (IME) options for entry fields on the Android platform.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Default">

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ListView.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ListView.xml
@@ -14,7 +14,6 @@
   <Interfaces />
   <Docs>
     <summary>The list view instance that Microsoft.Maui.Controls created on the Android platform.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="GetIsFastScrollEnabled">
@@ -38,7 +37,6 @@
         <param name="element">The platform specific element on which to perform the operation.</param>
         <summary>Returns a Boolean value that tells whether fast scrolling is enabled.</summary>
         <returns>A Boolean value that tells whether fast scrolling is enabled.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsFastScrollEnabled">
@@ -62,7 +60,6 @@
         <param name="config">The platform specific configuration that contains the element on which to perform the operation.</param>
         <summary>Returns a Boolean value that tells whether fast scrolling is enabled.</summary>
         <returns>A Boolean value that tells whether fast scrolling is enabled.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsFastScrollEnabledProperty">
@@ -81,7 +78,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the attached property that controls whether fast scrolling is enabled.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetIsFastScrollEnabled">
@@ -106,7 +102,6 @@
         <param name="element">The platform specific element on which to perform the operation.</param>
         <param name="value">The new property value to assign.</param>
         <summary>Sets the attached property that controls whether fast scrolling is enabled.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetIsFastScrollEnabled">
@@ -132,7 +127,6 @@
         <param name="value">The new property value to assign.</param>
         <summary>Sets the attached property that controls whether fast scrolling is enabled.</summary>
         <returns>The updated configuration object, on which more methods may be called.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/MixedContentHandling.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/MixedContentHandling.xml
@@ -13,7 +13,6 @@
   </Base>
   <Docs>
     <summary>Enumerates web view behaviors when handling mixed content.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="AlwaysAllow">

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ShellItem.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ShellItem.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members />
 </Type>

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/SwipeView.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/SwipeView.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="GetSwipeTransitionMode">
@@ -34,9 +32,6 @@
       </Parameters>
       <Docs>
         <param name="element">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetSwipeTransitionMode">
@@ -57,9 +52,6 @@
       </Parameters>
       <Docs>
         <param name="config">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetSwipeTransitionMode">
@@ -82,8 +74,6 @@
       <Docs>
         <param name="element">To be added.</param>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetSwipeTransitionMode">
@@ -106,9 +96,6 @@
       <Docs>
         <param name="config">To be added.</param>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SwipeTransitionModeProperty">
@@ -125,8 +112,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/TabbedPage.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/TabbedPage.xml
@@ -14,7 +14,6 @@
   <Interfaces />
   <Docs>
     <summary>The tabbed page instance that Microsoft.Maui.Controls created on the Android platform.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="BarItemColorProperty">
@@ -41,7 +40,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the attached property that controls the color of a bar item.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="BarSelectedItemColorProperty">
@@ -68,7 +66,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the attached property that controls the color of a selected bar item.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="DisableSmoothScroll">
@@ -90,8 +87,6 @@
       <Docs>
         <param name="config">To be added.</param>
         <summary>Turns off smooth scrolling for <c>this</c><see cref="T:Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.TabbedPage" />.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="DisableSwipePaging">
@@ -115,7 +110,6 @@
         <param name="config">The platform specific configuration that contains the element on which to perform the operation.</param>
         <summary>Disables swiped paging.</summary>
         <returns>The updated element on the Android platform.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="EnableSmoothScroll">
@@ -137,8 +131,6 @@
       <Docs>
         <param name="config">To be added.</param>
         <summary>Turns on smooth scrolling for <c>this</c><see cref="T:Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.TabbedPage" />.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="EnableSwipePaging">
@@ -162,7 +154,6 @@
         <param name="config">The platform specific configuration that contains the element on which to perform the operation.</param>
         <summary>Enables swiped paging.</summary>
         <returns>The updated element on the Android platform.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetBarItemColor">
@@ -194,7 +185,6 @@
         <param name="element">The platform specific element on which to perform the operation.</param>
         <summary>Returns the color for bar items.</summary>
         <returns>The color for bar items.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetBarItemColor">
@@ -226,7 +216,6 @@
         <param name="config">The platform specific configuration for the element on which to perform the operation.</param>
         <summary>Returns the color for bar items.</summary>
         <returns>The color for bar items.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetBarSelectedItemColor">
@@ -258,7 +247,6 @@
         <param name="element">The platform specific element on which to perform the operation.</param>
         <summary>Returns the color for selected bar items.</summary>
         <returns>The color for bar items.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetBarSelectedItemColor">
@@ -290,7 +278,6 @@
         <param name="config">The platform specific configuration for the element on which to perform the operation.</param>
         <summary>Returns the color for selected bar items.</summary>
         <returns>The color for bar items.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetIsSmoothScrollEnabled">
@@ -312,8 +299,6 @@
       <Docs>
         <param name="element">To be added.</param>
         <summary>Gets whether smooth scrolling is enabled for <paramref name="element" />.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetIsSwipePagingEnabled">
@@ -337,7 +322,6 @@
         <param name="element">The platform specific element on which to perform the operation.</param>
         <summary>Returns a Boolean value that tells whether swiped paging is enabled.</summary>
         <returns>A Boolean value that tells whether swipe paging is enabled.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetMaxItemCount">
@@ -361,7 +345,6 @@
         <param name="element">The platform specific element on which to perform the operation.</param>
         <summary>Returns the maximum allowed number of items.</summary>
         <returns>The maximum allowed number of items.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetMaxItemCount">
@@ -385,7 +368,6 @@
         <param name="config">The platform specific configuration for the element on which to perform the operation.</param>
         <summary>Returns the maximum allowed number of items.</summary>
         <returns>The maximum allowed number of items.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetOffscreenPageLimit">
@@ -409,7 +391,6 @@
         <param name="element">The platform specific element on which to perform the operation.</param>
         <summary>Returns the number of offscreen pages are cached in memory.</summary>
         <returns>The number of offscreen pages are cached in memory.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetToolbarPlacement">
@@ -433,7 +414,6 @@
         <param name="element">The platform specific element on which to perform the operation.</param>
         <summary>Returns the toolbar placement.</summary>
         <returns>The toolbar placement.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetToolbarPlacement">
@@ -457,7 +437,6 @@
         <param name="config">The platform specific configuration for the element on which to perform the operation.</param>
         <summary>Returns the toolbar placement.</summary>
         <returns>The toolbar placement.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsSmoothScrollEnabled">
@@ -479,8 +458,6 @@
       <Docs>
         <param name="config">To be added.</param>
         <summary>Gets whether smooth scrolling is enabled for <c>this</c><see cref="T:Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.TabbedPage" />.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsSmoothScrollEnabledProperty">
@@ -498,7 +475,6 @@
       </ReturnValue>
       <Docs>
         <summary>The <see cref="T:Microsoft.Maui.Controls.BindableProperty" /> associated with the <see cref="M:Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.TabbedPage.IsSmoothScrollEnabled(Microsoft.Maui.Controls.IPlatformElementConfiguration{Microsoft.Maui.Controls.PlatformConfiguration.Android,Microsoft.Maui.Controls.TabbedPage})" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsSwipePagingEnabled">
@@ -523,7 +499,6 @@
         <summary>Gets a Boolean value that controls whether swipe paging is enabled.</summary>
         <returns>
           <see langword="true" /> if swiped paging is enabled. Otherwise, <see langword="false" />.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsSwipePagingEnabledProperty">
@@ -542,7 +517,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.TabbedPage.IsSwipePagingEnabled(Microsoft.Maui.Controls.IPlatformElementConfiguration{Microsoft.Maui.Controls.PlatformConfiguration.Android,Microsoft.Maui.Controls.TabbedPage})" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OffscreenPageLimit">
@@ -566,7 +540,6 @@
         <param name="config">The platform specific configuration that contains the element on which to perform the operation.</param>
         <summary>Returns the number of offscreen pages are cached in memory.</summary>
         <returns>The number of offscreen pages are cached in memory.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OffscreenPageLimitProperty">
@@ -585,7 +558,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the attached offscreen page limit property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetBarItemColor">
@@ -618,7 +590,6 @@
         <param name="element">The element whose value to set.</param>
         <param name="value">The new bar item color value.</param>
         <summary>Sets the color for bar items.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetBarItemColor">
@@ -652,7 +623,6 @@
         <param name="value">The new bar item color value.</param>
         <summary>Sets the color for bar items.</summary>
         <returns>A fluent object on which the developer can make further method calls.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetBarSelectedItemColor">
@@ -685,7 +655,6 @@
         <param name="element">The platform specific element whose value to set.</param>
         <param name="value">The new selected item color value.</param>
         <summary>Sets the color for selected bar items.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetBarSelectedItemColor">
@@ -719,7 +688,6 @@
         <param name="value">The new selected item color value.</param>
         <summary>Sets the color for selected bar items.</summary>
         <returns>A fluent object on which the developer can make further method calls.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetIsSmoothScrollEnabled">
@@ -744,7 +712,6 @@
         <param name="value">
           <see langword="true" /> if <paramref name="element" /> should enable smooth scrolling.</param>
         <summary>Enables or disables smooth scrolling on <paramref name="element" />.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetIsSmoothScrollEnabled">
@@ -771,8 +738,6 @@
         <param name="value">
           <see langword="true" /> if smooth scrolling should be enabled.</param>
         <summary>Enables or disables smooth scrolling on <c>this</c><see cref="T:Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.TabbedPage" />.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetIsSwipePagingEnabled">
@@ -797,7 +762,6 @@
         <param name="element">The platform specific element on which to perform the operation.</param>
         <param name="value">The new property value to assign.</param>
         <summary>Sets a value that controls whether page swiping is enabled to the provided <paramref name="value" />.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetIsSwipePagingEnabled">
@@ -823,7 +787,6 @@
         <param name="value">The new property value to assign.</param>
         <summary>Sets a value that controls whether page swiping is enabled to the provided <paramref name="value" />.</summary>
         <returns>The configuration that was updated.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetOffscreenPageLimit">
@@ -848,7 +811,6 @@
         <param name="element">The platform specific element on which to perform the operation.</param>
         <param name="value">The new property value to assign.</param>
         <summary>Sets the number of off-screen pages that are stored in memory to the provided <paramref name="value" />.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetOffscreenPageLimit">
@@ -874,7 +836,6 @@
         <param name="value">The new property value to assign.</param>
         <summary>Sets the number of off-screen pages that are stored in memory to the provided <paramref name="value" />.</summary>
         <returns>The configuration that was updated.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetToolbarPlacement">
@@ -899,7 +860,6 @@
         <param name="element">The platform specific element whose value to set.</param>
         <param name="value">The new toolbar placement value.</param>
         <summary>Sets the toolbar placement.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetToolbarPlacement">
@@ -925,7 +885,6 @@
         <param name="value">The new toolbar placement value.</param>
         <summary>Sets the toolbar placement.</summary>
         <returns>A fluent object on which the developer can make further method calls.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ToolbarPlacementProperty">
@@ -944,7 +903,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the attached property that controls the placement of the toolbar.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ToolbarPlacement.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ToolbarPlacement.xml
@@ -13,7 +13,6 @@
   </Base>
   <Docs>
     <summary>Enumerates toolbar positions.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Bottom">

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ViewCell.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ViewCell.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="GetIsContextActionsLegacyModeEnabled">
@@ -34,9 +32,6 @@
       </Parameters>
       <Docs>
         <param name="element">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetIsContextActionsLegacyModeEnabled">
@@ -57,9 +52,6 @@
       </Parameters>
       <Docs>
         <param name="config">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsContextActionsLegacyModeEnabledProperty">
@@ -76,8 +68,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetIsContextActionsLegacyModeEnabled">
@@ -100,8 +90,6 @@
       <Docs>
         <param name="element">To be added.</param>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetIsContextActionsLegacyModeEnabled">
@@ -124,9 +112,6 @@
       <Docs>
         <param name="config">To be added.</param>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/WebView.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/WebView.xml
@@ -14,7 +14,6 @@
   <Interfaces />
   <Docs>
     <summary>Controls the mixed content mode on web views on the Android platform.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="DisplayZoomControls">
@@ -37,8 +36,6 @@
       <Docs>
         <param name="config">The platform configuration for the element on which to perform the operation.</param>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="DisplayZoomControlsProperty">
@@ -55,8 +52,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="EnableZoomControls">
@@ -79,8 +74,6 @@
       <Docs>
         <param name="config">The platform configuration for the element on which to perform the operation.</param>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="EnableZoomControlsProperty">
@@ -97,8 +90,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetDisplayZoomControls">
@@ -119,9 +110,6 @@
       </Parameters>
       <Docs>
         <param name="element">The element on which to perform the operation.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetEnableZoomControls">
@@ -142,9 +130,6 @@
       </Parameters>
       <Docs>
         <param name="element">The element on which to perform the operation.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetMixedContentMode">
@@ -167,8 +152,6 @@
       <Docs>
         <param name="element">The Android web view for which to get the loading behavior for content that is a mix of secure and insecure content.</param>
         <summary>Returns the mixed content mode for the web view.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="MixedContentMode">
@@ -191,8 +174,6 @@
       <Docs>
         <param name="config">The platform configuration for the Android web view for which to get the loading behavior for content that is a mix of secure and insecure content.</param>
         <summary>Gets the mixed content loading behavior.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="MixedContentModeProperty">
@@ -211,7 +192,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the attached property that controls the loading behavior for content that is a mix of secure and insecure content.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetDisplayZoomControls">
@@ -234,9 +214,6 @@
       <Docs>
         <param name="config">The platform configuration for the element on which to perform the operation.</param>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetDisplayZoomControls">
@@ -259,8 +236,6 @@
       <Docs>
         <param name="element">The element on which to perform the operation.</param>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetEnableZoomControls">
@@ -283,9 +258,6 @@
       <Docs>
         <param name="config">The platform configuration for the element on which to perform the operation.</param>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetEnableZoomControls">
@@ -308,8 +280,6 @@
       <Docs>
         <param name="element">The element on which to perform the operation.</param>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetMixedContentMode">
@@ -334,7 +304,6 @@
         <param name="element">The Android web view for which to set the loading behavior for content that is a mix of secure and insecure content.</param>
         <param name="value">The new mixed content mode.</param>
         <summary>Sets the mixed content mode for the web view.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetMixedContentMode">
@@ -359,8 +328,6 @@
         <param name="config">The platform configuration for the Android web view for which to set the loading behavior for content that is a mix of secure and insecure content.</param>
         <param name="value">The new mixed content mode.</param>
         <summary>Sets the mixed content mode for the web view.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ZoomControlsDisplayed">
@@ -381,9 +348,6 @@
       </Parameters>
       <Docs>
         <param name="config">The platform configuration for the element on which to perform the operation.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ZoomControlsEnabled">
@@ -404,9 +368,6 @@
       </Parameters>
       <Docs>
         <param name="config">The platform configuration for the element on which to perform the operation.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/WindowSoftInputModeAdjust.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/WindowSoftInputModeAdjust.xml
@@ -13,7 +13,6 @@
   </Base>
   <Docs>
     <summary>Enumerates values that control how an on-screen input interface is visually accommodated.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Pan">

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific/BoxView.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific/BoxView.xml
@@ -14,7 +14,6 @@
   <Interfaces />
   <Docs>
     <summary>Controls the presence of the corner radius of box views on the GTK platform.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="GetHasCornerRadius">
@@ -38,7 +37,6 @@
         <param name="element">The box view element on the GTK platform whose corner radius to get.</param>
         <summary>Returns a Boolean value that tells whether the box view has a corner radius set.</summary>
         <returns>A Boolean value that tells whether the box view has a corner radius set.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetHasCornerRadius">
@@ -62,7 +60,6 @@
         <param name="config">The platform configuration for the box view element on the GTK platform whose corner radius to get.</param>
         <summary>Returns a Boolean value that tells whether the box view has a corner radius set.</summary>
         <returns>A Boolean value that tells whether the box view has a corner radius set.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="HasCornerRadiusProperty">
@@ -81,7 +78,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the attached property that controls whether the box view has a corner radius.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetHasCornerRadius">
@@ -106,7 +102,6 @@
         <param name="element">The box view element on the GTK platform whose corner radius presence to set.</param>
         <param name="tabPosition">The new corner radius presence value.</param>
         <summary>Sets the corner radius presence.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetHasCornerRadius">
@@ -132,7 +127,6 @@
         <param name="value">The new corner radius presence value</param>
         <summary>Sets the corner radius presence.</summary>
         <returns>A fluent object on which the developer may make further method calls.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific/NavigationPage.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific/NavigationPage.xml
@@ -14,7 +14,6 @@
   <Interfaces />
   <Docs>
     <summary>Provides access to the back button icon on navigation pages on the GTK platform.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="BackButtonIconProperty">
@@ -33,7 +32,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the attached property that stores the back button icon.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetBackButtonIcon">
@@ -57,7 +55,6 @@
         <param name="element">The navigation page on the GTK platform whose back button icon to get.</param>
         <summary>Gets the icon for the back button.</summary>
         <returns>The path to the back button icon.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetBackButtonIcon">
@@ -81,7 +78,6 @@
         <param name="config">The platform configuration for the navigation page on the GTK platform whose back button icon to get.</param>
         <summary>Gets the path to the back button icon.</summary>
         <returns>The path to the back button icon.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetBackButtonIcon">
@@ -106,7 +102,6 @@
         <param name="element">The navigation page on the GTK platform whose back button icon to get.</param>
         <param name="backButtonIcon">The new back button icon path.</param>
         <summary>Sets the path to the back button icon.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetBackButtonIcon">
@@ -132,7 +127,6 @@
         <param name="value">The new back button icon path.</param>
         <summary>Sets the path to the back button icon.</summary>
         <returns>A fluent object on which the developer may make further method calls.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific/TabPosition.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific/TabPosition.xml
@@ -13,7 +13,6 @@
   </Base>
   <Docs>
     <summary>Enumerates tab positions on a tabbed page on the GTK platform.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Bottom">

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific/TabbedPage.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific/TabbedPage.xml
@@ -14,7 +14,6 @@
   <Interfaces />
   <Docs>
     <summary>Controls the tab position on tabbed pages on the GTK platform.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="GetTabPosition">
@@ -38,7 +37,6 @@
         <param name="element">The tabbed page on the GTK platform whose tab position to get.</param>
         <summary>Gets the tab position.</summary>
         <returns>The tab position.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetTabPosition">
@@ -62,7 +60,6 @@
         <param name="config">The platform configuration for the tabbed page on the GTK platform whose tab position to get.</param>
         <summary>Gets the tab position.</summary>
         <returns>A fluent object on which the developer may make further method calls.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetTabPosition">
@@ -87,7 +84,6 @@
         <param name="element">The tabbed page on the GTK platform whose tab position to set.</param>
         <param name="tabPosition">The new tab position.</param>
         <summary>Sets the tab position.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetTabPosition">
@@ -113,7 +109,6 @@
         <param name="value">The new tab position.</param>
         <summary>Sets the tab position.</summary>
         <returns>A fluent object on which the developer may make further method calls.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TabPositionProperty">
@@ -132,7 +127,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the attached property that controls the tab position.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Application.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Application.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="ActiveBezelInteractionElementPropertyKey">
@@ -30,8 +28,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindablePropertyKey</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetActiveBezelInteractionElement">
@@ -52,9 +48,6 @@
       </Parameters>
       <Docs>
         <param name="application">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetActiveBezelInteractionElement">
@@ -75,9 +68,6 @@
       </Parameters>
       <Docs>
         <param name="config">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetOverlayContent">
@@ -98,9 +88,6 @@
       </Parameters>
       <Docs>
         <param name="application">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetOverlayContent">
@@ -121,9 +108,6 @@
       </Parameters>
       <Docs>
         <param name="config">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetUseBezelInteraction">
@@ -144,9 +128,6 @@
       </Parameters>
       <Docs>
         <param name="element">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetUseBezelInteraction">
@@ -167,9 +148,6 @@
       </Parameters>
       <Docs>
         <param name="config">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OverlayContentProperty">
@@ -186,8 +164,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetActiveBezelInteractionElement">
@@ -215,8 +191,6 @@
       <Docs>
         <param name="application">To be added.</param>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetActiveBezelInteractionElement">
@@ -244,9 +218,6 @@
       <Docs>
         <param name="config">To be added.</param>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetOverlayContent">
@@ -269,8 +240,6 @@
       <Docs>
         <param name="application">To be added.</param>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetOverlayContent">
@@ -293,9 +262,6 @@
       <Docs>
         <param name="config">To be added.</param>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetUseBezelInteraction">
@@ -318,8 +284,6 @@
       <Docs>
         <param name="element">To be added.</param>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetUseBezelInteraction">
@@ -342,9 +306,6 @@
       <Docs>
         <param name="config">To be added.</param>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="UseBezelInteractionProperty">
@@ -361,8 +322,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/ButtonStyle.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/ButtonStyle.xml
@@ -14,7 +14,6 @@
   <Interfaces />
   <Docs>
     <summary>Enumerates button styles</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Bottom">
@@ -33,7 +32,6 @@
       </ReturnValue>
       <Docs>
         <summary>Indicates the bottom button style.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Circle">
@@ -52,7 +50,6 @@
       </ReturnValue>
       <Docs>
         <summary>Indicates the circle button style.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Default">
@@ -71,7 +68,6 @@
       </ReturnValue>
       <Docs>
         <summary>Indicates the default button style.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SelectMode">
@@ -90,7 +86,6 @@
       </ReturnValue>
       <Docs>
         <summary>Indicates a selection button.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Text">
@@ -109,7 +104,6 @@
       </ReturnValue>
       <Docs>
         <summary>Indicates a text button.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Entry.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Entry.xml
@@ -14,7 +14,6 @@
   <Interfaces />
   <Docs>
     <summary>Provides access to the font weight for entry controls on the Tizen platform.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="FontWeightProperty">
@@ -33,7 +32,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the attached property that controls the font weight.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetFontWeight">
@@ -57,7 +55,6 @@
         <param name="element">The entry element on the Tizen platform whose font weight icon to get.</param>
         <summary>Returns the font weight for the entry text.</summary>
         <returns>The font weight for the entry text.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetFontWeight">
@@ -81,7 +78,6 @@
         <param name="config">The platform configuration for the entry element on the Tizen platform whose font weight icon to get.</param>
         <summary>Returns a string representation of the font weight for the entry text.</summary>
         <returns>A string representation of the font weight for the entry text.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetFontWeight">
@@ -106,7 +102,6 @@
         <param name="element">The entry element on the Tizen platform whose font weight icon to set.</param>
         <param name="weight">The new font weight value.</param>
         <summary>Sets the font weight on the entry text.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetFontWeight">
@@ -132,7 +127,6 @@
         <param name="weight">The new font weight value.</param>
         <summary>Sets the font weight on the entry text.</summary>
         <returns>A fluent object on which the developer may make further method calls.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/FocusDirection.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/FocusDirection.xml
@@ -19,7 +19,6 @@
   </Attributes>
   <Docs>
     <summary>Contains constants for describing focus directions.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Back">
@@ -38,7 +37,6 @@
       </ReturnValue>
       <Docs>
         <summary>The constant for specifying the back focus direction.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Down">
@@ -57,7 +55,6 @@
       </ReturnValue>
       <Docs>
         <summary>The constant for specifying the down focus direction.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Forward">
@@ -76,7 +73,6 @@
       </ReturnValue>
       <Docs>
         <summary>The constant for specifying the forward focus direction.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Left">
@@ -95,7 +91,6 @@
       </ReturnValue>
       <Docs>
         <summary>The constant for specifying the left focus direction.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="None">
@@ -114,7 +109,6 @@
       </ReturnValue>
       <Docs>
         <summary>The constant for specifying no focus direction.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Right">
@@ -133,7 +127,6 @@
       </ReturnValue>
       <Docs>
         <summary>The constant for specifying the right focus direction.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Up">
@@ -152,7 +145,6 @@
       </ReturnValue>
       <Docs>
         <summary>The constant for specifying the up focus direction.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/FontWeight.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/FontWeight.xml
@@ -14,7 +14,6 @@
   <Interfaces />
   <Docs>
     <summary>Contains constants for font weights.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Black">
@@ -33,7 +32,6 @@
       </ReturnValue>
       <Docs>
         <summary>The constant for specifying the black font weight.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Bold">
@@ -52,7 +50,6 @@
       </ReturnValue>
       <Docs>
         <summary>The constant for specifying the bold font weight.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Book">
@@ -71,7 +68,6 @@
       </ReturnValue>
       <Docs>
         <summary>The constant for specifying the book font weight.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ExtraBlack">
@@ -90,7 +86,6 @@
       </ReturnValue>
       <Docs>
         <summary>The constant for specifying the extra black font weight.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Light">
@@ -109,7 +104,6 @@
       </ReturnValue>
       <Docs>
         <summary>The constant for specifying the light font weight.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Medium">
@@ -128,7 +122,6 @@
       </ReturnValue>
       <Docs>
         <summary>The constant for specifying the medium font weight.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="None">
@@ -147,7 +140,6 @@
       </ReturnValue>
       <Docs>
         <summary>The constant for specifying no font weight.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Normal">
@@ -166,7 +158,6 @@
       </ReturnValue>
       <Docs>
         <summary>The constant for specifying the normal, or default, font weight.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SemiBold">
@@ -185,7 +176,6 @@
       </ReturnValue>
       <Docs>
         <summary>The constant for specifying the semibold font weight.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Thin">
@@ -204,7 +194,6 @@
       </ReturnValue>
       <Docs>
         <summary>The constant for specifying the thin font weight.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="UltraBold">
@@ -223,7 +212,6 @@
       </ReturnValue>
       <Docs>
         <summary>The constant for specifying the ultrabold font weight.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="UltraLight">
@@ -242,7 +230,6 @@
       </ReturnValue>
       <Docs>
         <summary>The constant for specifying the ultralight font weight.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Image.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Image.xml
@@ -14,7 +14,6 @@
   <Interfaces />
   <Docs>
     <summary>Provides access to the blend color for images on the Tizen platform.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="BlendColorProperty">
@@ -33,7 +32,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the attached property that controls the blend color.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FileProperty">
@@ -50,8 +48,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetBlendColor">
@@ -75,7 +71,6 @@
         <param name="element">The image on the Tizen platform whose back button icon to get.</param>
         <summary>Returns the blend color for the image.</summary>
         <returns>The blend color for the image.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetBlendColor">
@@ -99,7 +94,6 @@
         <param name="config">The platform configuration for the image on the Tizen platform whose blend color to get.</param>
         <summary>Returns the blend color for the image.</summary>
         <returns>The blend color for the image.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetFile">
@@ -120,9 +114,6 @@
       </Parameters>
       <Docs>
         <param name="element">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetFile">
@@ -143,9 +134,6 @@
       </Parameters>
       <Docs>
         <param name="config">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetBlendColor">
@@ -170,7 +158,6 @@
         <param name="element">To be added.</param>
         <param name="color">The new blend color value.</param>
         <summary>Sets the blend color.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetBlendColor">
@@ -196,7 +183,6 @@
         <param name="color">The new blend color value.</param>
         <summary>Sets the blend color.</summary>
         <returns>A fluent object on which the developer may make further method calls.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetFile">
@@ -219,8 +205,6 @@
       <Docs>
         <param name="element">To be added.</param>
         <param name="file">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetFile">
@@ -243,9 +227,6 @@
       <Docs>
         <param name="config">To be added.</param>
         <param name="file">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Label.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Label.xml
@@ -14,7 +14,6 @@
   <Interfaces />
   <Docs>
     <summary>Provides access to the font weight for labels on the Tizen platform.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="FontWeightProperty">
@@ -33,7 +32,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the attached property that controls the font weight.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetFontWeight">
@@ -57,7 +55,6 @@
         <param name="element">The label element on the Tizen platform whose font weight icon to get.</param>
         <summary>Returns the font weight for the label text.</summary>
         <returns>The font weight for the label text.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetFontWeight">
@@ -81,7 +78,6 @@
         <param name="config">The platform configuration for the label element on the Tizen platform whose font weight icon to get.</param>
         <summary>Returns a string representation of the font weight for the label text.</summary>
         <returns>A string representation of the font weight for the label text.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetFontWeight">
@@ -106,7 +102,6 @@
         <param name="element">The label element on the Tizen platform whose font weight icon to set.</param>
         <param name="weight">The new font weight value.</param>
         <summary>Sets the font weight on the label text.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetFontWeight">
@@ -132,7 +127,6 @@
         <param name="weight">The new font weight value.</param>
         <summary>Sets the font weight on the label text.</summary>
         <returns>A fluent object on which the developer may make further method calls.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/NavigationPage.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/NavigationPage.xml
@@ -14,7 +14,6 @@
   <Interfaces />
   <Docs>
     <summary>Provides access to the bread crumb bar for navigation pages on the Tizen platform.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="GetHasBreadCrumbsBar">
@@ -39,7 +38,6 @@
         <summary>Returns a Boolean value that tells whether the navigation page has a bread crumb bar.</summary>
         <returns>
           <see langword="true" /> if the navigation page has a bread crumb bar. Otherwise, <see langword="false" />.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="HasBreadCrumbsBar">
@@ -64,7 +62,6 @@
         <summary>Returns a Boolean value that tells whether the navigation page has a bread crumb bar.</summary>
         <returns>
           <see langword="true" /> if the navigation page has a bread crumb bar. Otherwise, <see langword="false" />.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="HasBreadCrumbsBarProperty">
@@ -83,7 +80,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the attached property that represents whether the navigation page has a bread crumb bar.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetHasBreadCrumbsBar">
@@ -108,7 +104,6 @@
         <param name="element">The navigation page on the Tizen platform whose font weight icon to set.</param>
         <param name="value">The new bread crumb bar presence value.</param>
         <summary>Sets a Boolean value that tells whether the navigation page has a bread crumb bar.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetHasBreadCrumbsBar">
@@ -134,7 +129,6 @@
         <param name="value">The new bread crumb bar presence value.</param>
         <summary>Sets a Boolean value that tells whether the navigation page has a bread crumb bar.</summary>
         <returns>A fluent object on which the developer may make further method calls.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Page.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Page.xml
@@ -14,7 +14,6 @@
   <Interfaces />
   <Docs>
     <summary>Provides access to the bread crumb bar for pages on the Tizen platform.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="BreadCrumbProperty">
@@ -33,7 +32,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the attached property that represents bread crumb bar value.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetBreadCrumb">
@@ -57,7 +55,6 @@
         <param name="page">The page whose bread crumb representation to get.</param>
         <summary>Returns the breadcrumb representation for a page.</summary>
         <returns>The breadcrumb representation for the page.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetBreadCrumb">
@@ -81,7 +78,6 @@
         <param name="config">The platform configuration for the page whose bread crumb representation to get.</param>
         <summary>Returns the breadcrumb representation for a page.</summary>
         <returns>The breadcrumb representation for the page.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetBreadCrumb">
@@ -106,7 +102,6 @@
         <param name="page">The page whose bread crumb value to set.</param>
         <param name="value">The new bread crumb value.</param>
         <summary>Sets the bread crumb value for the page.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetBreadCrumb">
@@ -132,7 +127,6 @@
         <param name="value">The new bread crumb value.</param>
         <summary>Sets the bread crumb value for the page.</summary>
         <returns>A fluent object on which the developer may make further method calls.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/ProgressBar.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/ProgressBar.xml
@@ -14,7 +14,6 @@
   <Interfaces />
   <Docs>
     <summary>Provides access to the pulsing status for progress bars.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="GetPulsingStatus">
@@ -39,7 +38,6 @@
         <summary>Returns <see langword="true" /> if the progress bar is pulsing. Otherwise, returns <see langword="false" />.</summary>
         <returns>
           <see langword="true" /> if the progress bar is pulsing. Otherwise, <see langword="false" />.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetPulsingStatus">
@@ -64,7 +62,6 @@
         <summary>Returns <see langword="true" /> if the progress bar is pulsing. Otherwise, returns <see langword="false" />.</summary>
         <returns>
           <see langword="true" /> if the progress bar is pulsing. Otherwise, <see langword="false" />.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ProgressBarPulsingStatusProperty">
@@ -83,7 +80,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the attached property that controls the pulsing status of the progress bar.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetPulsingStatus">
@@ -109,7 +105,6 @@
         <param name="isPulsing">
           <see langword="true" /> to cause the progress bar is pulsing. Otherwise, <see langword="false" />.</param>
         <summary>Turns pulsing on or off.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetPulsingStatus">
@@ -136,7 +131,6 @@
           <see langword="true" /> to cause the progress bar is pulsing. Otherwise, <see langword="false" />.</param>
         <summary>Turns pulsing on or off.</summary>
         <returns>A fluent object on which the developer can make further method calls.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/ProgressBarStyle.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/ProgressBarStyle.xml
@@ -14,7 +14,6 @@
   <Interfaces />
   <Docs>
     <summary>Enumerates visual styles for progress bars.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Default">
@@ -33,7 +32,6 @@
       </ReturnValue>
       <Docs>
         <summary>Indicates the default progress bar style.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Pending">
@@ -52,7 +50,6 @@
       </ReturnValue>
       <Docs>
         <summary>Indicates the pending style, to communicate that a progress estimate has not yet been made.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Switch.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Switch.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="ColorProperty">
@@ -30,8 +28,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetColor">
@@ -52,9 +48,6 @@
       </Parameters>
       <Docs>
         <param name="element">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetColor">
@@ -75,9 +68,6 @@
       </Parameters>
       <Docs>
         <param name="config">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetColor">
@@ -100,8 +90,6 @@
       <Docs>
         <param name="element">To be added.</param>
         <param name="color">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetColor">
@@ -124,9 +112,6 @@
       <Docs>
         <param name="config">To be added.</param>
         <param name="color">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/SwitchStyle.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/SwitchStyle.xml
@@ -14,7 +14,6 @@
   <Interfaces />
   <Docs>
     <summary>Enumerates visual styles for switches.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="CheckBox">
@@ -33,7 +32,6 @@
       </ReturnValue>
       <Docs>
         <summary>Indicates a checkbox UI.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Favorite">
@@ -52,7 +50,6 @@
       </ReturnValue>
       <Docs>
         <summary>Indicates a favorite, or star, UI.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnOff">
@@ -69,8 +66,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Small">
@@ -87,8 +82,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Toggle">
@@ -107,7 +100,6 @@
       </ReturnValue>
       <Docs>
         <summary>Indicates a toggle UI.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/TabbedPageStyle.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/TabbedPageStyle.xml
@@ -14,7 +14,6 @@
   <Interfaces />
   <Docs>
     <summary>Enumerates tab bar styles for a tabbed page.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Default">
@@ -33,7 +32,6 @@
       </ReturnValue>
       <Docs>
         <summary>Indicates the default tab bar style.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Tabbar">
@@ -52,7 +50,6 @@
       </ReturnValue>
       <Docs>
         <summary>Indicates a tab bar with no title.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TabbarWithTitle">
@@ -71,7 +68,6 @@
       </ReturnValue>
       <Docs>
         <summary>Indicates a tab bar with a title.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Application.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Application.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="GetImageDirectory">
@@ -34,9 +32,6 @@
       </Parameters>
       <Docs>
         <param name="element">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetImageDirectory">
@@ -57,9 +52,6 @@
       </Parameters>
       <Docs>
         <param name="config">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ImageDirectoryProperty">
@@ -76,8 +68,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetImageDirectory">
@@ -100,8 +90,6 @@
       <Docs>
         <param name="element">To be added.</param>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetImageDirectory">
@@ -124,9 +112,6 @@
       <Docs>
         <param name="config">To be added.</param>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/CollapseStyle.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/CollapseStyle.xml
@@ -13,7 +13,6 @@
   </Base>
   <Docs>
     <summary>Enumerates collapse styles for master-detail pages.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Full">

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/FlyoutPage.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/FlyoutPage.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="CollapsedPaneWidth">
@@ -34,9 +32,6 @@
       </Parameters>
       <Docs>
         <param name="config">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CollapsedPaneWidth">
@@ -59,9 +54,6 @@
       <Docs>
         <param name="config">To be added.</param>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CollapsedPaneWidthProperty">
@@ -78,8 +70,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CollapseStyleProperty">
@@ -96,8 +86,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetCollapsedPaneWidth">
@@ -118,9 +106,6 @@
       </Parameters>
       <Docs>
         <param name="element">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetCollapseStyle">
@@ -141,9 +126,6 @@
       </Parameters>
       <Docs>
         <param name="element">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetCollapseStyle">
@@ -164,9 +146,6 @@
       </Parameters>
       <Docs>
         <param name="config">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetCollapsedPaneWidth">
@@ -189,8 +168,6 @@
       <Docs>
         <param name="element">To be added.</param>
         <param name="collapsedPaneWidth">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetCollapseStyle">
@@ -213,8 +190,6 @@
       <Docs>
         <param name="element">To be added.</param>
         <param name="collapseStyle">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetCollapseStyle">
@@ -237,9 +212,6 @@
       <Docs>
         <param name="config">To be added.</param>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="UsePartialCollapse">
@@ -260,9 +232,6 @@
       </Parameters>
       <Docs>
         <param name="config">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/InputView.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/InputView.xml
@@ -14,7 +14,6 @@
   <Interfaces />
   <Docs>
     <summary>Provides access to reading order detection on the Windows platform.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="DetectReadingOrderFromContentProperty">
@@ -33,7 +32,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the attached property that controls whether the reading order is detected from the input view's content.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetDetectReadingOrderFromContent">
@@ -57,7 +55,6 @@
         <param name="element">The input view element whose reading order detection behavior to get.</param>
         <summary>Returns a Boolean value that tells whether the reading order is detected from the input view's content.</summary>
         <returns>A Boolean value that tells whether the reading order is detected from the input view's content.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetDetectReadingOrderFromContent">
@@ -81,7 +78,6 @@
         <param name="config">The platform configuration for the input view element whose reading order detection behavior to get.</param>
         <summary>Returns a Boolean value that tells whether the reading order is detected from the input view's content.</summary>
         <returns>A Boolean value that tells whether the reading order is detected from the input view's content.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetDetectReadingOrderFromContent">
@@ -107,7 +103,6 @@
         <param name="value">
           <see langword="true" /> to detect the reading order from the content. Otherwise, <see langword="false" />.</param>
         <summary>Sets a Boolean value that controls whether the reading order is detected from the input view's content.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetDetectReadingOrderFromContent">
@@ -134,7 +129,6 @@
           <see langword="true" /> to detect the reading order from the content. Otherwise, <see langword="false" />.</param>
         <summary>Sets a Boolean value that controls whether the reading order is detected from the input view's content.</summary>
         <returns>A fluent object on which the developer may make further method calls.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Label.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Label.xml
@@ -14,7 +14,6 @@
   <Interfaces />
   <Docs>
     <summary>Provides access to reading order detection on the Windows platform.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="DetectReadingOrderFromContentProperty">
@@ -33,7 +32,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the attached property that controls whether the reading order is detected from the label's content.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetDetectReadingOrderFromContent">
@@ -57,7 +55,6 @@
         <param name="element">The label element whose reading order detection behavior to get.</param>
         <summary>Returns a Boolean value that tells whether the reading order is detected from the label's content.</summary>
         <returns>A Boolean value that tells whether the reading order is detected from the label's content.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetDetectReadingOrderFromContent">
@@ -81,7 +78,6 @@
         <param name="config">The platform configuration for the label element whose reading order detection behavior to get.</param>
         <summary>Returns a Boolean value that tells whether the reading order is detected from the label's content.</summary>
         <returns>A Boolean value that tells whether the reading order is detected from the label's content.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetDetectReadingOrderFromContent">
@@ -107,7 +103,6 @@
         <param name="value">
           <see langword="true" /> to detect the reading order from the content. Otherwise, <see langword="false" />.</param>
         <summary>Sets a Boolean value that controls whether the reading order is detected from the label's content.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetDetectReadingOrderFromContent">
@@ -134,7 +129,6 @@
           <see langword="true" /> to detect the reading order from the content. Otherwise, <see langword="false" />.</param>
         <summary>Sets a Boolean value that controls whether the reading order is detected from the label's content.</summary>
         <returns>A fluent object on which the developer may make further method calls.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/ListView.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/ListView.xml
@@ -14,7 +14,6 @@
   <Interfaces />
   <Docs>
     <summary>Platform-specific properties for list view controls on UWP.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="GetSelectionMode">
@@ -37,8 +36,6 @@
       <Docs>
         <param name="element">The element whose selection mode to get.</param>
         <summary>Returns the selection mode for the element.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetSelectionMode">
@@ -61,8 +58,6 @@
       <Docs>
         <param name="config">The element whose selection mode to get.</param>
         <summary>Returns the selection mode for the element.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SelectionModeProperty">
@@ -81,7 +76,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the selection mode attached property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetSelectionMode">
@@ -106,7 +100,6 @@
         <param name="element">The element whose selectio mode to set.</param>
         <param name="value">The new selection mode value.</param>
         <summary>Sets the selection mode for the element.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetSelectionMode">
@@ -131,8 +124,6 @@
         <param name="config">The element whose selectio mode to set.</param>
         <param name="value">The new selection mode value.</param>
         <summary>Sets the selection mode for the element.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/ListViewSelectionMode.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/ListViewSelectionMode.xml
@@ -13,7 +13,6 @@
   </Base>
   <Docs>
     <summary>Selection modes for list view controls on UWP.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Accessible">

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/RefreshView.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/RefreshView.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="GetRefreshPullDirection">
@@ -34,9 +32,6 @@
       </Parameters>
       <Docs>
         <param name="element">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetRefreshPullDirection">
@@ -57,9 +52,6 @@
       </Parameters>
       <Docs>
         <param name="config">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RefreshPullDirectionProperty">
@@ -76,8 +68,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetRefreshPullDirection">
@@ -100,8 +90,6 @@
       <Docs>
         <param name="element">To be added.</param>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetRefreshPullDirection">
@@ -124,9 +112,6 @@
       <Docs>
         <param name="config">To be added.</param>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/SearchBar.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/SearchBar.xml
@@ -14,7 +14,6 @@
   <Interfaces />
   <Docs>
     <summary>Provides control over the spellchecker on search bars.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="DisableSpellCheck">
@@ -37,7 +36,6 @@
       <Docs>
         <param name="config">The platform configuration for the search bar element.</param>
         <summary>Disables the spellchecker.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="EnableSpellCheck">
@@ -60,7 +58,6 @@
       <Docs>
         <param name="config">The platform configuration for the search bar element.</param>
         <summary>Enables the spellchecker.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetIsSpellCheckEnabled">
@@ -85,7 +82,6 @@
         <summary>Returns a Boolean value that tells whether the spellchecker is enabled.</summary>
         <returns>
           <see langword="true" /> if the spellchecker is enabled. Otherwise, <see langword="false" />.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetIsSpellCheckEnabled">
@@ -110,7 +106,6 @@
         <summary>Returns a Boolean value that tells whether the spellchecker is enabled.</summary>
         <returns>
           <see langword="true" /> if the spellchecker is enabled. Otherwise, <see langword="false" />.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsSpellCheckEnabled">
@@ -135,7 +130,6 @@
         <summary>Returns a Boolean value that tells whether the spellchecker is enabled.</summary>
         <returns>
           <see langword="true" /> if the spellchecker is enabled. Otherwise, <see langword="false" />.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsSpellCheckEnabledProperty">
@@ -154,7 +148,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the attached property that turns the spellchecker on and off.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetIsSpellCheckEnabled">
@@ -180,7 +173,6 @@
         <param name="value">
           <see langword="true" /> to turn the spellchecker on. <see langword="false" /> to turn it off.</param>
         <summary>Turns the spellchecker on and off.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetIsSpellCheckEnabled">
@@ -207,7 +199,6 @@
           <see langword="true" /> to turn the spellchecker on. <see langword="false" /> to turn it off.</param>
         <summary>Turns the spellchecker on and off.</summary>
         <returns>A fluent object on which the developer may make further method calls.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/TabbedPage.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/TabbedPage.xml
@@ -14,7 +14,6 @@
   <Interfaces />
   <Docs>
     <summary>Provides control over header icons on the Windows platform.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="DisableHeaderIcons">
@@ -37,7 +36,6 @@
       <Docs>
         <param name="config">The platform configuration for the element on which to perform the operation.</param>
         <summary>Disables header icons.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="EnableHeaderIcons">
@@ -60,7 +58,6 @@
       <Docs>
         <param name="config">The platform configuration for the element on which to perform the operation.</param>
         <summary>Enables header icons.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetHeaderIconsEnabled">
@@ -85,7 +82,6 @@
         <summary>Returns a Boolean value that tells whether header icons are enabled.</summary>
         <returns>
           <see langword="true" /> if header icons are enabled. Otherwise, <see langword="false" />.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetHeaderIconsEnabled">
@@ -110,7 +106,6 @@
         <summary>Returns a Boolean value that tells whether header icons are enabled.</summary>
         <returns>
           <see langword="true" /> if header icons are enabled. Otherwise, <see langword="false" />.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetHeaderIconsSize">
@@ -134,7 +129,6 @@
         <param name="element">The element on which to perform the operation.</param>
         <summary>Returns the size of header icons.</summary>
         <returns>The size of header icons.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetHeaderIconsSize">
@@ -158,7 +152,6 @@
         <param name="config">The platform configuration for the element on which to perform the operation.</param>
         <summary>Returns the size of header icons.</summary>
         <returns>The size of header icons.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="HeaderIconsEnabledProperty">
@@ -177,7 +170,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the attached property that enables and disables header icons.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="HeaderIconsSizeProperty">
@@ -196,7 +188,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the attached property that controls the size of header icons.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsHeaderIconsEnabled">
@@ -221,7 +212,6 @@
         <summary>Returns a Boolean value that tells whether header icons are enabled.</summary>
         <returns>
           <see langword="true" /> if header icons are enabled. Otherwise, <see langword="false" />.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetHeaderIconsEnabled">
@@ -247,7 +237,6 @@
         <param name="value">
           <see langword="true" /> to enable header icons. <see langword="false" /> to disable them.</param>
         <summary>Turns header icons on and off.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetHeaderIconsEnabled">
@@ -274,7 +263,6 @@
           <see langword="true" /> to enable header icons. <see langword="false" /> to disable them.</param>
         <summary>Turns header icons on and off.</summary>
         <returns>A fluent object on which the developer may make further method calls.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetHeaderIconsSize">
@@ -299,7 +287,6 @@
         <param name="element">The element on which to perform the operation.</param>
         <param name="value">The new header icon size.</param>
         <summary>Specifies the size of header icons.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetHeaderIconsSize">
@@ -325,7 +312,6 @@
         <param name="value">The new header icon size.</param>
         <summary>Specifies the size of header icons.</summary>
         <returns>A fluent object on which the developer may make further method calls.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/ToolbarPlacement.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/ToolbarPlacement.xml
@@ -13,7 +13,6 @@
   </Base>
   <Docs>
     <summary>Enumerates toolbar positions for pages on the Windows platform.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Bottom">

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml
@@ -14,7 +14,6 @@
   <Interfaces />
   <Docs>
     <summary>Provides access to platform-specific features of visual elements on the Windows platform.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="AccessKeyHorizontalOffsetProperty">
@@ -33,7 +32,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the attached property that gets and sets the horizontal offset from the nominal position to use for displaying the access key tip.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="AccessKeyPlacementProperty">
@@ -52,7 +50,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the attached property that gets and sets the nominal position to use for displaying the access key tip.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="AccessKeyProperty">
@@ -71,7 +68,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the attached property that gets and sets the access key.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="AccessKeyVerticalOffsetProperty">
@@ -90,7 +86,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the attached property that gets and sets the vertical offset from the nominal position to use for displaying the access key tip.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetAccessKey">
@@ -114,7 +109,6 @@
         <param name="element">The element for which to get the access key.</param>
         <summary>Returns the access key value.</summary>
         <returns>The access key value.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetAccessKey">
@@ -138,7 +132,6 @@
         <param name="config">The platform configuration for the element for which to get the access key.</param>
         <summary>Returns the access key value.</summary>
         <returns>The access key value.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetAccessKeyHorizontalOffset">
@@ -162,7 +155,6 @@
         <param name="element">The element for which to get the horizontal offset.</param>
         <summary>Gets the horizontal offset from the nominal position to use for displaying the access key tip.</summary>
         <returns>The horizontal offset from the nominal position to use for displaying the access key tip.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetAccessKeyHorizontalOffset">
@@ -186,7 +178,6 @@
         <param name="config">The platform configuration for the element for which to get the horizontal offset.</param>
         <summary>Gets the horizontal offset from the nominal position to use for displaying the access key tip.</summary>
         <returns>The horizontal offset from the nominal position to use for displaying the access key tip.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetAccessKeyPlacement">
@@ -210,7 +201,6 @@
         <param name="element">The element for which to get the access key placement.</param>
         <summary>Gets the nominal position to use for displaying the access key tip.</summary>
         <returns>The nominal position to use for displaying the access key tip.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetAccessKeyPlacement">
@@ -234,7 +224,6 @@
         <param name="config">The platform configuration for the element for which to get the access key placement.</param>
         <summary>Gets the nominal position to use for displaying the access key tip.</summary>
         <returns>The nominal position to use for displaying the access key tip.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetAccessKeyVerticalOffset">
@@ -258,7 +247,6 @@
         <param name="element">The element for which to get the vertical offset.</param>
         <summary>Gets the vertical offset from the nominal position to use for displaying the access key tip.</summary>
         <returns>The vertical offset from the nominal position to use for displaying the access key tip.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetAccessKeyVerticalOffset">
@@ -282,7 +270,6 @@
         <param name="config">The platform configuration for the element for which to get the vertical offset.</param>
         <summary>Gets the vertical offset from the nominal position to use for displaying the access key tip.</summary>
         <returns>The vertical offset from the nominal position to use for displaying the access key tip.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetIsLegacyColorModeEnabled">
@@ -307,7 +294,6 @@
         <summary>Returns a Boolean value that controls whether legacy color mode is enabled.</summary>
         <returns>
           <see langword="true" /> if legacy color mode is enabled. Otherwise, <see langword="false" />.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetIsLegacyColorModeEnabled">
@@ -332,7 +318,6 @@
         <summary>Returns a Boolean value that controls whether legacy color mode is enabled.</summary>
         <returns>
           <see langword="true" /> if legacy color mode is enabled. Otherwise, <see langword="false" />.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsLegacyColorModeEnabledProperty">
@@ -351,7 +336,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the attached property that controls the legacy color mode.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetAccessKey">
@@ -376,7 +360,6 @@
         <param name="element">The element for which to set the access key string.</param>
         <param name="value">The new access key value.</param>
         <summary>Sets the value that the access key displays.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetAccessKey">
@@ -402,7 +385,6 @@
         <param name="value">The new access key value.</param>
         <summary>Sets the value that the access key displays.</summary>
         <returns>A fluent object on which the developer may make furter method calls.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetAccessKeyHorizontalOffset">
@@ -427,7 +409,6 @@
         <param name="element">The element for which to set the horizontal access key offset.</param>
         <param name="value">The new offset value.</param>
         <summary>Sets the horizontal offset from the nominal position to use for displaying the access key.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetAccessKeyHorizontalOffset">
@@ -453,7 +434,6 @@
         <param name="value">The new offset value.</param>
         <summary>Sets the horizontal offset from the nominal position to use for displaying the access key.</summary>
         <returns>A fluent object on which the developer may make furter method calls.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetAccessKeyPlacement">
@@ -478,7 +458,6 @@
         <param name="element">The element for which to set the horizontal access key placement.</param>
         <param name="value">The new placement value.</param>
         <summary>Sets nominal position to use for displaying the access key.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetAccessKeyPlacement">
@@ -504,7 +483,6 @@
         <param name="value">The new placement value.</param>
         <summary>Sets nominal position to use for displaying the access key.</summary>
         <returns>A fluent object on which the developer may make furter method calls.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetAccessKeyVerticalOffset">
@@ -529,7 +507,6 @@
         <param name="element">The element for which to set the vertical access key offset.</param>
         <param name="value">The new offset value.</param>
         <summary>Sets the vertical offset from the nominal position to use for displaying the access key.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetAccessKeyVerticalOffset">
@@ -555,7 +532,6 @@
         <param name="value">The new offset value.</param>
         <summary>Sets the vertical offset from the nominal position to use for displaying the access key.</summary>
         <returns>A fluent object on which the developer may make furter method calls.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetIsLegacyColorModeEnabled">
@@ -581,7 +557,6 @@
         <param name="value">
           <see langword="true" /> to enable legacy color mode. Otherwise, <see langword="false" />.</param>
         <summary>Turns the legacy color mode on and off.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetIsLegacyColorModeEnabled">
@@ -608,7 +583,6 @@
           <see langword="true" /> to enable legacy color mode. Otherwise, <see langword="false" />.</param>
         <summary>Turns the legacy color mode on and off.</summary>
         <returns>A fluent object on which the developer may make further method calls.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/WebView.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/WebView.xml
@@ -78,7 +78,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the attached property that controls whether the web view allows JavaScript alerts.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetIsJavaScriptAlertEnabled">

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Application.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Application.xml
@@ -14,7 +14,6 @@
   <Interfaces />
   <Docs>
     <summary>Provides control over simultaneous recognition for pan gesture recognizers.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="EnableAccessibilityScalingForNamedFontSizesProperty">
@@ -32,7 +31,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the attached property that controls whether named font sizes should participate in the device's accessibility scaling.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetEnableAccessibilityScalingForNamedFontSizes">
@@ -56,7 +54,6 @@
         <summary>Returns a Boolean value that tells whether named font sizes should participate in the device's accessibility scaling.</summary>
         <returns>
           <see langword="true" /> for device's accessibility scaling. Otherwise, <see langword="false" />.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetEnableAccessibilityScalingForNamedFontSizes">
@@ -80,7 +77,6 @@
         <summary>Returns a Boolean value that tells whether named font sizes should participate in the device's accessibility scaling.</summary>
         <returns>
           <see langword="true" /> for device's accessibility scaling. Otherwise, <see langword="false" />.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetHandleControlUpdatesOnMainThread">
@@ -101,9 +97,6 @@
       </Parameters>
       <Docs>
         <param name="element">The element on which to perform the operation.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetHandleControlUpdatesOnMainThread">
@@ -124,9 +117,6 @@
       </Parameters>
       <Docs>
         <param name="config">The platform configuration for the element on which to perform the operation.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetPanGestureRecognizerShouldRecognizeSimultaneously">
@@ -151,7 +141,6 @@
         <summary>Returns a Boolean value that tells whether the pan gesture recognizer should participate in simultaneous recognition of gestures.</summary>
         <returns>
           <see langword="true" /> for simultaneous recognition. Otherwise, <see langword="false" />.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetPanGestureRecognizerShouldRecognizeSimultaneously">
@@ -176,7 +165,6 @@
         <summary>Returns a Boolean value that tells whether the pan gesture recognizer should participate in simultaneous recognition of gestures.</summary>
         <returns>
           <see langword="true" /> for simultaneous recognition. Otherwise, <see langword="false" />.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="HandleControlUpdatesOnMainThreadProperty">
@@ -193,8 +181,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PanGestureRecognizerShouldRecognizeSimultaneouslyProperty">
@@ -213,7 +199,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the attached property that controls whether the pan gesture recognizer should participate in simultaneous recognition of gestures.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetEnableAccessibilityScalingForNamedFontSizes">
@@ -238,7 +223,6 @@
         <param name="value">
           <see langword="true" /> for device's accessibility scaling. Otherwise, <see langword="false" />.</param>
         <summary>Sets a Boolean value that controls whether named font sizes should participate in the device's accessibility scaling.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetEnableAccessibilityScalingForNamedFontSizes">
@@ -264,7 +248,6 @@
           <see langword="true" /> for device's accessibility scaling. Otherwise, <see langword="false" />.</param>
         <summary>Sets a Boolean value that controls whether named font sizes should participate in the device's accessibility scaling.</summary>
         <returns>A fluent object on which the developer may make further method calls.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetHandleControlUpdatesOnMainThread">
@@ -287,8 +270,6 @@
       <Docs>
         <param name="element">The element on which to perform the operation.</param>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetHandleControlUpdatesOnMainThread">
@@ -311,9 +292,7 @@
       <Docs>
         <param name="config">The platform configuration for the element on which to perform the operation.</param>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
         <returns>A fluent object on which the developer may make further method calls.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetPanGestureRecognizerShouldRecognizeSimultaneously">
@@ -339,7 +318,6 @@
         <param name="value">
           <see langword="true" /> for simultaneous recognition. Otherwise, <see langword="false" />.</param>
         <summary>Sets a Boolean value that controls whether the pan gesture recognizer should participate in simultaneous recognition of gestures.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetPanGestureRecognizerShouldRecognizeSimultaneously">
@@ -366,7 +344,6 @@
           <see langword="true" /> for simultaneous recognition. Otherwise, <see langword="false" />.</param>
         <summary>Sets a Boolean value that controls whether the pan gesture recognizer should participate in simultaneous recognition of gestures.</summary>
         <returns>A fluent object on which the developer may make further method calls.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/BlurEffectStyle.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/BlurEffectStyle.xml
@@ -13,7 +13,6 @@
   </Base>
   <Docs>
     <summary>Enumerates blur effect styles.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Dark">

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Cell.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Cell.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="DefaultBackgroundColor">
@@ -34,9 +32,6 @@
       </Parameters>
       <Docs>
         <param name="config">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="DefaultBackgroundColorProperty">
@@ -54,7 +49,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="M:Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific.Cell.DefaultBackgroundColor(Microsoft.Maui.Controls.IPlatformElementConfiguration{Microsoft.Maui.Controls.PlatformConfiguration.iOS,Microsoft.Maui.Controls.Cell})" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetDefaultBackgroundColor">
@@ -75,9 +69,6 @@
       </Parameters>
       <Docs>
         <param name="element">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetDefaultBackgroundColor">
@@ -100,8 +91,6 @@
       <Docs>
         <param name="element">To be added.</param>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetDefaultBackgroundColor">
@@ -124,9 +113,6 @@
       <Docs>
         <param name="config">To be added.</param>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/DatePicker.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/DatePicker.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="GetUpdateMode">
@@ -34,9 +32,6 @@
       </Parameters>
       <Docs>
         <param name="element">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetUpdateMode">
@@ -59,8 +54,6 @@
       <Docs>
         <param name="element">To be added.</param>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetUpdateMode">
@@ -83,9 +76,6 @@
       <Docs>
         <param name="config">To be added.</param>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="UpdateMode">
@@ -106,9 +96,6 @@
       </Parameters>
       <Docs>
         <param name="config">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="UpdateModeProperty">
@@ -125,8 +112,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Entry.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Entry.xml
@@ -40,7 +40,6 @@
         <param name="config">The platform specific configuration that contains the element on which to perform the operation.</param>
         <summary>Returns a Boolean value that tells whether the entry control automatically adjusts the font size.</summary>
         <returns>A Boolean value that tells whether the entry control automatically adjusts the font size.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="AdjustsFontSizeToFitWidthProperty">
@@ -59,7 +58,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the attached property that controls whether the entry control automatically adjusts the font size.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CursorColorProperty">
@@ -78,7 +76,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the attached property that controls the color of the cursor.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="DisableAdjustsFontSizeToFitWidth">
@@ -102,7 +99,6 @@
         <param name="config">The platform specific configuration that contains the element on which to perform the operation.</param>
         <summary>Disables automatic font size adjustment on the platform-specific element.</summary>
         <returns>The updated configuration object on which developers can make successive method calls.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="EnableAdjustsFontSizeToFitWidth">
@@ -126,7 +122,6 @@
         <param name="config">The platform specific configuration that contains the element on which to perform the operation.</param>
         <summary>Enables automatic font size adjustment on the platform-specific element.</summary>
         <returns>The updated configuration object on which developers can make successive method calls.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetAdjustsFontSizeToFitWidth">
@@ -150,7 +145,6 @@
         <param name="element">The platform specific element on which to perform the operation.</param>
         <summary>Returns a Boolean value that tells whether the entry control automatically adjusts the font size of text that the user enters.</summary>
         <returns>A Boolean value that tells whether the entry control automatically adjusts the font size of text that the user enters.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetCursorColor">
@@ -174,7 +168,6 @@
         <param name="element">The element whose cursor color to get.</param>
         <summary>Gets the color of the cursor.</summary>
         <returns>The color of the cursor.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetCursorColor">
@@ -198,7 +191,6 @@
         <param name="config">The platform configuration for the element whose cursor color to get.</param>
         <summary>Gets the color of the cursor.</summary>
         <returns>The color of the cursor.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetAdjustsFontSizeToFitWidth">
@@ -223,7 +215,6 @@
         <param name="element">The platform specific element on which to perform the operation.</param>
         <param name="value">The new property value to assign.</param>
         <summary>Sets a Boolean value that tells whether the entry control automatically adjusts the font size of text that the user enters.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetAdjustsFontSizeToFitWidth">
@@ -249,7 +240,6 @@
         <param name="value">The new property value to assign.</param>
         <summary>Sets a Boolean value that tells whether automatic font size adjusmtent is enabled on the element.</summary>
         <returns>The updated configuration object on which developers can make successive method calls.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetCursorColor">
@@ -274,7 +264,6 @@
         <param name="element">The element whose cursor color to Set.</param>
         <param name="value">The new cursor color.</param>
         <summary>Sets the color of the cursor.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetCursorColor">
@@ -300,7 +289,6 @@
         <param name="value">The new cursor color.</param>
         <summary>Sets the color of the cursor and returns a fluent object.</summary>
         <returns>A fluent object on which the developer can make further method calls.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/FlyoutPage.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/FlyoutPage.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="ApplyShadowProperty">
@@ -30,8 +28,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetApplyShadow">
@@ -52,9 +48,6 @@
       </Parameters>
       <Docs>
         <param name="element">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetApplyShadow">
@@ -75,9 +68,6 @@
       </Parameters>
       <Docs>
         <param name="config">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetApplyShadow">
@@ -100,8 +90,6 @@
       <Docs>
         <param name="element">To be added.</param>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetApplyShadow">
@@ -124,9 +112,6 @@
       <Docs>
         <param name="config">To be added.</param>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/GroupHeaderStyle.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/GroupHeaderStyle.xml
@@ -11,8 +11,6 @@
     <BaseTypeName>System.Enum</BaseTypeName>
   </Base>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Grouped">
@@ -30,7 +28,6 @@
       </ReturnValue>
       <MemberValue>1</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
     <Member MemberName="Plain">
@@ -48,7 +45,6 @@
       </ReturnValue>
       <MemberValue>0</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/LargeTitleDisplayMode.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/LargeTitleDisplayMode.xml
@@ -13,7 +13,6 @@
   </Base>
   <Docs>
     <summary>Enumerates preferences for displaying large titles.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Always">

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ListView.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ListView.xml
@@ -14,7 +14,6 @@
   <Interfaces />
   <Docs>
     <summary>Provides access to the separator style for list views on the iOS platform.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="GetGroupHeaderStyle">
@@ -35,9 +34,6 @@
       </Parameters>
       <Docs>
         <param name="element">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetGroupHeaderStyle">
@@ -58,9 +54,6 @@
       </Parameters>
       <Docs>
         <param name="config">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetRowAnimationsEnabled">
@@ -81,9 +74,6 @@
       </Parameters>
       <Docs>
         <param name="element">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetSeparatorStyle">
@@ -107,7 +97,6 @@
         <param name="element">The list view element whose separator style to get.</param>
         <summary>Returns the separator style for a list view.</summary>
         <returns>The separator style for a list view.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetSeparatorStyle">
@@ -131,7 +120,6 @@
         <param name="config">The platform configuration for the list view element whose separator style to get.</param>
         <summary>Returns the separator style for a list view.</summary>
         <returns>The separator style for a list view.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GroupHeaderStyleProperty">
@@ -148,8 +136,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RowAnimationsEnabled">
@@ -170,9 +156,6 @@
       </Parameters>
       <Docs>
         <param name="config">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RowAnimationsEnabledProperty">
@@ -190,7 +173,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="M:Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific.ListView.RowAnimationsEnabled(Microsoft.Maui.Controls.IPlatformElementConfiguration{Microsoft.Maui.Controls.PlatformConfiguration.iOS,Microsoft.Maui.Controls.ListView})" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SeparatorStyleProperty">
@@ -209,7 +191,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the attached property that controls the separator style.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetGroupHeaderStyle">
@@ -232,8 +213,6 @@
       <Docs>
         <param name="element">To be added.</param>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetGroupHeaderStyle">
@@ -256,9 +235,6 @@
       <Docs>
         <param name="config">To be added.</param>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetRowAnimationsEnabled">
@@ -281,8 +257,6 @@
       <Docs>
         <param name="element">To be added.</param>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetRowAnimationsEnabled">
@@ -305,9 +279,6 @@
       <Docs>
         <param name="config">To be added.</param>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetSeparatorStyle">
@@ -332,7 +303,6 @@
         <param name="element">The list view element whose separator style to set</param>
         <param name="value">The new separator style value.</param>
         <summary>Sets the separator style for a list view.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetSeparatorStyle">
@@ -358,7 +328,6 @@
         <param name="value">The new separator style value.</param>
         <summary>Sets the separator style for a list view.</summary>
         <returns>A fluent object on which the developer can make further method calls.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/NavigationPage.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/NavigationPage.xml
@@ -14,7 +14,6 @@
   <Interfaces />
   <Docs>
     <summary>The navigation page instance that Microsoft.Maui.Controls created on the iOS platform.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="DisableTranslucentNavigationBar">
@@ -38,7 +37,6 @@
         <param name="config">The platform specific configuration that contains the element on which to perform the operation.</param>
         <summary>Makes the navigation bar opaque on the platform-specific element.</summary>
         <returns>The updated configuration object on which developers can make successive method calls.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="EnableTranslucentNavigationBar">
@@ -62,7 +60,6 @@
         <param name="config">The platform specific configuration that contains the element on which to perform the operation.</param>
         <summary>Makes the navigation bar translucent on the platform-specific element.</summary>
         <returns>The updated configuration object on which developers can make successive method calls.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetHideNavigationBarSeparator">
@@ -86,7 +83,6 @@
         <param name="element">The element for which to return whether the navigation bar separator is hidden.</param>
         <summary>Returns <see langword="true" /> if the separator is hidden. Otherwise, returns <see langword="false" />.</summary>
         <returns>see langword="true" /&gt; if the separator is hidden. Otherwise, <see langword="false" /></returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetIsNavigationBarTranslucent">
@@ -110,7 +106,6 @@
         <param name="element">The platform specific element on which to perform the operation.</param>
         <summary>Returns a Boolean value that tells whether the navigation bar on the platform-specific navigation page is translucent.</summary>
         <returns>A Boolean value that tells whether the navigation bar on the platform-specific navigation page is translucent.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetPrefersLargeTitles">
@@ -134,7 +129,6 @@
         <param name="element">The element whose large title preference to get.</param>
         <summary>Returns the large title preference of <paramref name="element" />.</summary>
         <returns>The large title preference of <paramref name="element" />.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetStatusBarTextColorMode">
@@ -158,7 +152,6 @@
         <param name="element">The platform specific element on which to perform the operation.</param>
         <summary>Returns a value that controls whether the status bar text color is adjusted to match the luminosity of the navigation bar for the platform-specific navigation page.</summary>
         <returns>A value that controls whether the status bar text color is adjusted to match the luminosity of the navigation bar for the platform-specific navigation page.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetStatusBarTextColorMode">
@@ -182,7 +175,6 @@
         <param name="config">The platform specific configuration that contains the element on which to perform the operation.</param>
         <summary>Returns a value that controls whether the status bar text color is adjusted to match the luminosity of the navigation bar for the platform-specific navigation page.</summary>
         <returns>A value that controls whether the status bar text color is adjusted to match the luminosity of the navigation bar for the platform-specific navigation page.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="HideNavigationBarSeparator">
@@ -207,7 +199,6 @@
         <summary>Returns <see langword="true" /> if the separator is hidden. Otherwise, returns <see langword="false" />.</summary>
         <returns>
           <see langword="true" /> if the separator is hidden. Otherwise, <see langword="false" /></returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="HideNavigationBarSeparatorProperty">
@@ -226,7 +217,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the attached property that controls whether the navigation bar separator is hidden.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsNavigationBarTranslucent">
@@ -250,7 +240,6 @@
         <param name="config">The platform specific configuration that contains the element on which to perform the operation.</param>
         <summary>Returns a Boolean value that tells whether the navigation bar on the platform-specific navigation page is translucent.</summary>
         <returns>A Boolean value that tells whether the navigation bar on the platform-specific navigation page is translucent.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsNavigationBarTranslucentProperty">
@@ -269,7 +258,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="M:Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific.NavigationPage.IsNavigationBarTranslucent(Microsoft.Maui.Controls.IPlatformElementConfiguration{Microsoft.Maui.Controls.PlatformConfiguration.iOS,Microsoft.Maui.Controls.NavigationPage})" /> method.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PrefersLargeTitles">
@@ -293,7 +281,6 @@
         <param name="config">The element whose large title preference to get.</param>
         <summary>Returns a value that indicates the element's preference for large titles.</summary>
         <returns>A value that indicates the element's preference for large titles.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PrefersLargeTitlesProperty">
@@ -312,7 +299,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the attached property that controls the navigation page's preference for large titles.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetHideNavigationBarSeparator">
@@ -338,7 +324,6 @@
         <param name="value">
           <see langword="true" /> to hide the separator. Otherwise, <see langword="false" />.</param>
         <summary>Developers set this to <see langword="true" /> to hide the separator. Otherwise, <see langword="false" />.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetHideNavigationBarSeparator">
@@ -365,7 +350,6 @@
           <see langword="true" /> to hide the separator. Otherwise, <see langword="false" />.</param>
         <summary>Developers set this to <see langword="true" /> to hide the separator. Otherwise, <see langword="false" />.</summary>
         <returns>A fluent object on which the developer can make further method calls.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetIsNavigationBarTranslucent">
@@ -390,7 +374,6 @@
         <param name="element">The platform specific element on which to perform the operation.</param>
         <param name="value">The new property value to assign.</param>
         <summary>Sets a Boolean value that controls whether the navigation bar on the platform-specific navigation page is translucent.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetIsNavigationBarTranslucent">
@@ -416,7 +399,6 @@
         <param name="value">The new property value to assign.</param>
         <summary>Sets a Boolean value that controls whether the navigation bar on the platform-specific navigation page is translucent.</summary>
         <returns>The updated configuration object on which developers can make successive method calls.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetPrefersLargeTitles">
@@ -441,7 +423,6 @@
         <param name="element">The element whose preference to set.</param>
         <param name="value">The new large title preference behavior.</param>
         <summary>Sets the large title preference behavior of <paramref name="element" /> to <paramref name="value" />.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetPrefersLargeTitles">
@@ -466,8 +447,6 @@
         <param name="config">The element whose preference to set.</param>
         <param name="value">The new large title preference behavior.</param>
         <summary>Sets the large title preference behavior of <paramref name="config" /> to <paramref name="value" />.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetStatusBarTextColorMode">
@@ -492,7 +471,6 @@
         <param name="element">The platform specific element on which to perform the operation.</param>
         <param name="value">The new property value to assign.</param>
         <summary>Sets a value that controls whether the status bar text color is adjusted to match the luminosity of the navigation bar for the platform-specific navigation page.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetStatusBarTextColorMode">
@@ -518,7 +496,6 @@
         <param name="value">The new property value to assign.</param>
         <summary>Sets a value that controls whether the status bar text color is adjusted to match the luminosity of the navigation bar for the platform-specific navigation page.</summary>
         <returns>The updated configuration object on which developers can make successive method calls.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="StatusBarTextColorModeProperty">
@@ -537,7 +514,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the attached property that controls whether the status bar text color is adjusted to match the luminosity of the navigation bar for the platform-specific navigation page.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Picker.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Picker.xml
@@ -14,7 +14,6 @@
   <Interfaces />
   <Docs>
     <summary>The picker instance that Microsoft.Maui.Controls created on the iOS platform.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="GetUpdateMode">
@@ -38,7 +37,6 @@
         <param name="element">The platform specific element on which to perform the operation.</param>
         <summary>Returns a value that tells whether elements in the picker are continuously updated while scrolling or updated once after scrolling has completed.</summary>
         <returns>A value that tells whether elements in the picker are continuously updated while scrolling or updated once after scrolling has completed.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetUpdateMode">
@@ -63,7 +61,6 @@
         <param name="element">The platform specific element on which to perform the operation.</param>
         <param name="value">The new property value to assign.</param>
         <summary>Sets a value that controls whether elements in the picker are continuously updated while scrolling or updated once after scrolling has completed.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetUpdateMode">
@@ -89,7 +86,6 @@
         <param name="value">The new property value to assign.</param>
         <summary>Sets a value that controls whether elements in the picker are continuously updated while scrolling or updated once after scrolling has completed.</summary>
         <returns>The updated configuration object on which developers can make successive method calls.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="UpdateMode">
@@ -113,7 +109,6 @@
         <param name="config">The platform specific configuration that contains the element on which to perform the operation.</param>
         <summary>Returns a value that tells whether elements in the picker are continuously updated while scrolling or updated once after scrolling has completed.</summary>
         <returns>A value that tells whether elements in the picker are continuously updated while scrolling or updated once after scrolling has completed.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="UpdateModeProperty">
@@ -132,7 +127,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the attached property that controls whether elements in the picker are continuously updated while scrolling or updated once after scrolling has completed.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ScrollView.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ScrollView.xml
@@ -14,7 +14,6 @@
   <Interfaces />
   <Docs>
     <summary>The scroll view instance that Microsoft.Maui.Controls created on the iOS platform.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="GetShouldDelayContentTouches">
@@ -38,7 +37,6 @@
         <param name="element">The platform specific element on which to perform the operation.</param>
         <summary>Returns a Boolean value that tells whether iOS will wait to determine if a touch is intended as a scroll, or scroll immediately.</summary>
         <returns>A Boolean value that tells whether iOS will wait to determine if a touch is intended as a scroll, or scroll immediately.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetShouldDelayContentTouches">
@@ -63,7 +61,6 @@
         <param name="element">The platform specific element on which to perform the operation.</param>
         <param name="value">The new property value to assign.</param>
         <summary>Sets a Boolean value that tells whether iOS will wait to determine if a touch is intended as a scroll, or scroll immediately.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetShouldDelayContentTouches">
@@ -89,7 +86,6 @@
         <param name="value">The new property value to assign.</param>
         <summary>Sets a Boolean value that tells whether iOS will wait to determine if a touch is intended as a scroll, or scroll immediately.</summary>
         <returns>The updated configuration object, on which more methods may be called.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ShouldDelayContentTouches">
@@ -113,7 +109,6 @@
         <param name="config">The platform specific configuration that contains the element on which to perform the operation.</param>
         <summary>Returns a Boolean value that tells whether iOS will wait to determine if a touch is intended as a scroll, or scroll immediately.</summary>
         <returns>A Boolean value that tells whether iOS will wait to determine if a touch is intended as a scroll, or scroll immediately.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ShouldDelayContentTouchesProperty">
@@ -132,7 +127,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the attached property that controls whether iOS will wait to determine if a touch is intended as a scroll, or scroll immediately.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/SearchBar.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/SearchBar.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="GetSearchBarStyle">
@@ -34,9 +32,6 @@
       </Parameters>
       <Docs>
         <param name="element">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetSearchBarStyle">
@@ -57,9 +52,6 @@
       </Parameters>
       <Docs>
         <param name="config">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SearchBarStyleProperty">
@@ -76,8 +68,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetSearchBarStyle">
@@ -100,8 +90,6 @@
       <Docs>
         <param name="element">To be added.</param>
         <param name="style">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetSearchBarStyle">
@@ -124,9 +112,6 @@
       <Docs>
         <param name="config">To be added.</param>
         <param name="style">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/SeparatorStyle.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/SeparatorStyle.xml
@@ -13,7 +13,6 @@
   </Base>
   <Docs>
     <summary>Enumerates list view separator styles.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Default">

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Slider.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Slider.xml
@@ -14,7 +14,6 @@
   <Interfaces />
   <Docs>
     <summary>Platform-specific functionality for sliders the iOS platform.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="GetUpdateOnTap">
@@ -39,7 +38,6 @@
         <summary>Returns a Boolean value that tells whether tapping on the slider will update its value.</summary>
         <returns>
           <see langword="true" /> if tapping updates the value. Otherwise, <see langword="false" />.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetUpdateOnTap">
@@ -64,7 +62,6 @@
         <summary>Returns a Boolean value that tells whether tapping on the slider will update its value.</summary>
         <returns>
           <see langword="true" /> if tapping updates the value. Otherwise, <see langword="false" />.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetUpdateOnTap">
@@ -90,7 +87,6 @@
         <param name="value">
           <see langword="true" /> if tapping will update the value. Otherwise, <see langword="false" />.</param>
         <summary>Sets a Boolean value that tells whether tapping on the slider will update its value.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetUpdateOnTap">
@@ -117,7 +113,6 @@
           <see langword="true" /> if tapping will update the value. Otherwise, <see langword="false" />.</param>
         <summary>Sets a Boolean value that tells whether tapping on the slider will update its value.</summary>
         <returns>A fluent object on which the developer may make more method calls.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="UpdateOnTapProperty">
@@ -136,7 +131,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the attached property that controls whether tapping on the slider updates its value.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/StatusBarHiddenMode.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/StatusBarHiddenMode.xml
@@ -13,7 +13,6 @@
   </Base>
   <Docs>
     <summary>Enumerates status bar hiding behavior preferences.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Default">

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/StatusBarTextColorMode.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/StatusBarTextColorMode.xml
@@ -13,7 +13,6 @@
   </Base>
   <Docs>
     <summary>Enumerates text color adjustment options for the status bar.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="DoNotAdjust">

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/SwipeView.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/SwipeView.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="GetSwipeTransitionMode">
@@ -34,9 +32,6 @@
       </Parameters>
       <Docs>
         <param name="element">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetSwipeTransitionMode">
@@ -57,9 +52,6 @@
       </Parameters>
       <Docs>
         <param name="config">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetSwipeTransitionMode">
@@ -82,8 +74,6 @@
       <Docs>
         <param name="element">To be added.</param>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetSwipeTransitionMode">
@@ -106,9 +96,6 @@
       <Docs>
         <param name="config">To be added.</param>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SwipeTransitionModeProperty">
@@ -125,8 +112,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/TabbedPage.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/TabbedPage.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="GetTranslucencyMode">
@@ -34,9 +32,6 @@
       </Parameters>
       <Docs>
         <param name="element">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetTranslucencyMode">
@@ -57,9 +52,6 @@
       </Parameters>
       <Docs>
         <param name="config">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetTranslucencyMode">
@@ -82,8 +74,6 @@
       <Docs>
         <param name="element">To be added.</param>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetTranslucencyMode">
@@ -106,9 +96,6 @@
       <Docs>
         <param name="config">To be added.</param>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TranslucencyModeProperty">
@@ -125,8 +112,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/TimePicker.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/TimePicker.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="GetUpdateMode">
@@ -34,9 +32,6 @@
       </Parameters>
       <Docs>
         <param name="element">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetUpdateMode">
@@ -59,8 +54,6 @@
       <Docs>
         <param name="element">To be added.</param>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetUpdateMode">
@@ -83,9 +76,6 @@
       <Docs>
         <param name="config">To be added.</param>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="UpdateMode">
@@ -106,9 +96,6 @@
       </Parameters>
       <Docs>
         <param name="config">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="UpdateModeProperty">
@@ -125,8 +112,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/TranslucencyMode.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/TranslucencyMode.xml
@@ -11,8 +11,6 @@
     <BaseTypeName>System.Enum</BaseTypeName>
   </Base>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Default">
@@ -30,7 +28,6 @@
       </ReturnValue>
       <MemberValue>0</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
     <Member MemberName="Opaque">
@@ -48,7 +45,6 @@
       </ReturnValue>
       <MemberValue>2</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
     <Member MemberName="Translucent">
@@ -66,7 +62,6 @@
       </ReturnValue>
       <MemberValue>1</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/UIModalPresentationStyle.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/UIModalPresentationStyle.xml
@@ -12,7 +12,6 @@
   </Base>
   <Docs>
     <summary>Enumerates valid modal presentation styles.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Automatic">
@@ -30,7 +29,6 @@
       </ReturnValue>
       <MemberValue>2</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
     <Member MemberName="FormSheet">
@@ -84,7 +82,6 @@
       </ReturnValue>
       <MemberValue>3</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
     <Member MemberName="PageSheet">
@@ -102,7 +99,6 @@
       </ReturnValue>
       <MemberValue>4</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/UISearchBarStyle.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/UISearchBarStyle.xml
@@ -11,8 +11,6 @@
     <BaseTypeName>System.Enum</BaseTypeName>
   </Base>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Default">
@@ -30,7 +28,6 @@
       </ReturnValue>
       <MemberValue>0</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
     <Member MemberName="Minimal">
@@ -48,7 +45,6 @@
       </ReturnValue>
       <MemberValue>2</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
     <Member MemberName="Prominent">
@@ -66,7 +62,6 @@
       </ReturnValue>
       <MemberValue>1</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/UIStatusBarAnimation.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/UIStatusBarAnimation.xml
@@ -13,7 +13,6 @@
   </Base>
   <Docs>
     <summary>Enumerates animation styles for status bar updates.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Fade">

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/UpdateMode.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/UpdateMode.xml
@@ -13,7 +13,6 @@
   </Base>
   <Docs>
     <summary>Enumerates values that control whether elements in a picker are continuously updated while scrolling or updated once after scrolling has completed.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Immediately">

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific/NavigationPage.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific/NavigationPage.xml
@@ -14,7 +14,6 @@
   <Interfaces />
   <Docs>
     <summary>The navigation page instance that Microsoft.Maui.Controls created on the macOS platform.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="GetNavigationTransitionPopStyle">
@@ -38,7 +37,6 @@
         <param name="element">The platform specific element on which to perform the operation.</param>
         <summary>Returns the NavigationTransitionStyle value that tells what transition is used when a page is popped from the navigation stack.</summary>
         <returns>The NavigationTransitionStyle value that tells the current transition when a page is popped from the navigation stack.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetNavigationTransitionPopStyle">
@@ -62,7 +60,6 @@
         <param name="config">The platform specific configuration that contains the element on which to perform the operation.</param>
         <summary>Returns the NavigationTransitionStyle value that tells what transition is used when a page is popped from the navigation stack.</summary>
         <returns>The NavigationTransitionStyle value that tells the current transition when a page is popped from the navigation stack.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetNavigationTransitionPushStyle">
@@ -86,7 +83,6 @@
         <param name="element">The platform specific element on which to perform the operation.</param>
         <summary>Returns the NavigationTransitionStyle value that tells what transition is used when a page is push on the navigation stack.</summary>
         <returns>The NavigationTransitionStyle value that tells the current transition when a page is pushed on the navigation stack.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetNavigationTransitionPushStyle">
@@ -110,7 +106,6 @@
         <param name="config">The platform specific configuration that contains the element on which to perform the operation.</param>
         <summary>Returns the NavigationTransitionStyle value that tells what transition is used when a page is pushed on the navigation stack.</summary>
         <returns>The NavigationTransitionStyle value that tells the current transition when a page is pushed on the navigation stack.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="NavigationTransitionPopStyleProperty">
@@ -129,7 +124,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the attached property that controls the transition style of the platform-specific navigation page when a page is popped from the navigation stack.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="NavigationTransitionPushStyleProperty">
@@ -148,7 +142,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the attached property that controls the transition style of the platform-specific navigation page when a page is pushed on the navigation stack.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetNavigationTransitionPopStyle">
@@ -173,7 +166,6 @@
         <param name="element">The platform specific element on which to perform the operation.</param>
         <param name="value">The new transition style.</param>
         <summary>Sets the transition style which is used, when popping from the navigation stack.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetNavigationTransitionPushStyle">
@@ -198,7 +190,6 @@
         <param name="element">The platform specific element on which to perform the operation.</param>
         <param name="value">The new transition style.</param>
         <summary>Sets the transition style which is used, when pushing pages on the navigation stack.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetNavigationTransitionStyle">
@@ -225,7 +216,6 @@
         <param name="pushStyle">The new transition style when a page is pushed on the navigation stack.</param>
         <param name="popStyle">The new transition style when a page is popped from the navigation stack.</param>
         <summary>Sets the transition style which is used, when popping and pushing pages on the navigation stack.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetNavigationTransitionStyle">
@@ -253,7 +243,6 @@
         <param name="popStyle">The new transition style when a page is popped from the navigation stack.</param>
         <summary>Sets the transition style which is used, when popping and pushing pages on the navigation stack.</summary>
         <returns>The updated configuration object on which developers can make successive method calls.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific/NavigationTransitionStyle.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific/NavigationTransitionStyle.xml
@@ -13,7 +13,6 @@
   </Base>
   <Docs>
     <summary>Enumerates navigation transition styles.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Crossfade">

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific/Page.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific/Page.xml
@@ -14,7 +14,6 @@
   <Interfaces />
   <Docs>
     <summary>The page instance that Microsoft.Maui.Controls created on the macOS platform.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="GetTabOrder">
@@ -38,7 +37,6 @@
         <param name="element">The platform specific element on which to perform the operation.</param>
         <summary>Returns the tab order of the visual elements on a page as array.</summary>
         <returns>An array of VisualElement.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetTabOrder">
@@ -62,7 +60,6 @@
         <param name="config">The platform specific configuration that contains the element on which to perform the operation.</param>
         <summary>Returns the tab order of the visual elements on a page as array.</summary>
         <returns>An array of VisualElement.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetTabOrder">
@@ -93,7 +90,6 @@
         <param name="element">The platform specific element on which to perform the operation.</param>
         <param name="value">An array of VisualElement.</param>
         <summary>Sets the tab order of visual elements on a page. Users can cycle through these elements with the tab key.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetTabOrder">
@@ -125,7 +121,6 @@
         <param name="value">An array of VisualElement.</param>
         <summary>Sets the tab order of visual elements on a page. Users can cycle through these elements with the tab key.</summary>
         <returns>The platform specific configuration that contains the element on which to perform the operation.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TabOrderProperty">
@@ -144,7 +139,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the attached property that holds the tab order of the visual elements.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific/TabbedPage.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific/TabbedPage.xml
@@ -14,7 +14,6 @@
   <Interfaces />
   <Docs>
     <summary>The tabbed page instance that Microsoft.Maui.Controls created on the macOS platform.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="GetTabsStyle">
@@ -37,8 +36,6 @@
       <Docs>
         <param name="element">The platform specific element on which to perform the operation.</param>
         <summary>Returns a value that describes the way that tabs are displayed.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetTabsStyle">
@@ -61,8 +58,6 @@
       <Docs>
         <param name="config">The platform specific configuration that contains the element on which to perform the operation.</param>
         <summary>Returns a value that describes the way that tabs are displayed.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="HideTabs">
@@ -85,8 +80,6 @@
       <Docs>
         <param name="config">The platform specific configuration that contains the element on which to perform the operation.</param>
         <summary>Hides the tabs on the tabbed page.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetShowTabs">
@@ -111,8 +104,6 @@
         <param name="config">The platform specific configuration that contains the element on which to perform the operation.</param>
         <param name="value">The new property value to assign.</param>
         <summary>Sets a value that controls the way that tabs are displayed.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetTabsStyle">
@@ -137,7 +128,6 @@
         <param name="element">The platform specific element on which to perform the operation.</param>
         <param name="value">The new property value to assign.</param>
         <summary>Sets a value that controls the way that tabs are displayed.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ShowTabs">
@@ -160,8 +150,6 @@
       <Docs>
         <param name="config">The platform specific configuration that contains the element on which to perform the operation.</param>
         <summary>Sets tab display to the default style.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ShowTabsOnNavigation">
@@ -184,8 +172,6 @@
       <Docs>
         <param name="config">The platform specific configuration that contains the element on which to perform the operation.</param>
         <summary>Sets tab display to the respond to user swipes.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TabsStyleProperty">
@@ -204,7 +190,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the attached property that controls how tabs are displayed.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration/Android.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration/Android.xml
@@ -36,7 +36,6 @@
       <Parameters />
       <Docs>
         <summary>Creates a new Android marker class.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration/GTK.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration/GTK.xml
@@ -18,7 +18,6 @@
   </Interfaces>
   <Docs>
     <summary>Marker class that identifies the Linux platform.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -34,7 +33,6 @@
       <Parameters />
       <Docs>
         <summary>Creates a new GTK marker class.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration/Tizen.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration/Tizen.xml
@@ -36,7 +36,6 @@
       <Parameters />
       <Docs>
         <summary>Creates a new Tizen marker class.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration/Windows.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration/Windows.xml
@@ -36,7 +36,6 @@
       <Parameters />
       <Docs>
         <summary>Creates a new Windows marker class.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration/iOS.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration/iOS.xml
@@ -36,7 +36,6 @@
       <Parameters />
       <Docs>
         <summary>Creates a new iOS marker class.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration/macOS.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration/macOS.xml
@@ -34,7 +34,6 @@
       <Parameters />
       <Docs>
         <summary>Creates a new macOS marker class.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Shapes/ArcSegment.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Shapes/ArcSegment.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -27,8 +25,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -54,8 +50,6 @@
         <param name="rotationAngle">To be added.</param>
         <param name="sweepDirection">To be added.</param>
         <param name="isLargeArc">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsLargeArc">
@@ -72,9 +66,6 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsLargeArcProperty">
@@ -91,8 +82,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Point">
@@ -109,9 +98,6 @@
         <ReturnType>Microsoft.Maui.Controls.Point</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PointProperty">
@@ -128,8 +114,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RotationAngle">
@@ -146,9 +130,6 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RotationAngleProperty">
@@ -165,8 +146,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Size">
@@ -188,9 +167,6 @@
         <ReturnType>Microsoft.Maui.Graphics.Size</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SizeProperty">
@@ -207,8 +183,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SweepDirection">
@@ -225,9 +199,6 @@
         <ReturnType>Microsoft.Maui.Controls.SweepDirection</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SweepDirectionProperty">
@@ -244,8 +215,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Shapes/BezierSegment.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Shapes/BezierSegment.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -27,8 +25,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -50,8 +46,6 @@
         <param name="point1">To be added.</param>
         <param name="point2">To be added.</param>
         <param name="point3">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Point1">
@@ -68,9 +62,6 @@
         <ReturnType>Microsoft.Maui.Controls.Point</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Point1Property">
@@ -87,8 +78,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Point2">
@@ -105,9 +94,6 @@
         <ReturnType>Microsoft.Maui.Controls.Point</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Point2Property">
@@ -124,8 +110,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Point3">
@@ -142,9 +126,6 @@
         <ReturnType>Microsoft.Maui.Controls.Point</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Point3Property">
@@ -161,8 +142,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Shapes/CompositeTransform.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Shapes/CompositeTransform.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -27,8 +25,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CenterX">
@@ -45,9 +41,6 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CenterXProperty">
@@ -64,8 +57,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CenterY">
@@ -82,9 +73,6 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CenterYProperty">
@@ -101,8 +89,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Rotation">
@@ -119,9 +105,6 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RotationProperty">
@@ -138,8 +121,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ScaleX">
@@ -156,9 +137,6 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ScaleXProperty">
@@ -175,8 +153,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ScaleY">
@@ -193,9 +169,6 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ScaleYProperty">
@@ -212,8 +185,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SkewX">
@@ -230,9 +201,6 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SkewXProperty">
@@ -249,8 +217,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SkewY">
@@ -267,9 +233,6 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SkewYProperty">
@@ -286,8 +249,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TranslateX">
@@ -304,9 +265,6 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TranslateXProperty">
@@ -323,8 +281,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TranslateY">
@@ -341,9 +297,6 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TranslateYProperty">
@@ -360,8 +313,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Shapes/Ellipse.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Shapes/Ellipse.xml
@@ -17,8 +17,6 @@
     </Attribute>
   </Attributes>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -32,8 +30,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Shapes/EllipseGeometry.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Shapes/EllipseGeometry.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -27,8 +25,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -50,8 +46,6 @@
         <param name="center">To be added.</param>
         <param name="radiusX">To be added.</param>
         <param name="radiusY">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Center">
@@ -68,9 +62,6 @@
         <ReturnType>Microsoft.Maui.Controls.Point</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CenterProperty">
@@ -87,8 +78,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RadiusX">
@@ -105,9 +94,6 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RadiusXProperty">
@@ -124,8 +110,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RadiusY">
@@ -142,9 +126,6 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RadiusYProperty">
@@ -161,8 +142,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Shapes/FillRule.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Shapes/FillRule.xml
@@ -11,8 +11,6 @@
     <BaseTypeName>System.Enum</BaseTypeName>
   </Base>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="EvenOdd">
@@ -30,7 +28,6 @@
       </ReturnValue>
       <MemberValue>0</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
     <Member MemberName="Nonzero">
@@ -48,7 +45,6 @@
       </ReturnValue>
       <MemberValue>1</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Shapes/Geometry.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Shapes/Geometry.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -27,8 +25,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Shapes/GeometryCollection.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Shapes/GeometryCollection.xml
@@ -15,8 +15,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -30,8 +28,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Shapes/GeometryGroup.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Shapes/GeometryGroup.xml
@@ -17,8 +17,6 @@
     </Attribute>
   </Attributes>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -32,8 +30,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Children">
@@ -50,9 +46,6 @@
         <ReturnType>Microsoft.Maui.Controls.Shapes.GeometryCollection</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ChildrenProperty">
@@ -69,8 +62,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FillRule">
@@ -87,9 +78,6 @@
         <ReturnType>Microsoft.Maui.Controls.Shapes.FillRule</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FillRuleProperty">
@@ -106,8 +94,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="InvalidateGeometryRequested">
@@ -124,8 +110,6 @@
         <ReturnType>System.EventHandler</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Shapes/GeometryHelper.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Shapes/GeometryHelper.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="FlattenArc">
@@ -50,8 +48,6 @@
         <param name="isLargeArc">To be added.</param>
         <param name="isCounterclockwise">To be added.</param>
         <param name="tolerance">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FlattenCubicBezier">
@@ -82,8 +78,6 @@
         <param name="ptCtrl2">To be added.</param>
         <param name="ptEnd">To be added.</param>
         <param name="tolerance">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FlattenGeometry">
@@ -106,9 +100,6 @@
       <Docs>
         <param name="geoSrc">To be added.</param>
         <param name="tolerance">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FlattenGeometry">
@@ -135,8 +126,6 @@
         <param name="geoSrc">To be added.</param>
         <param name="tolerance">To be added.</param>
         <param name="matxPrevious">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FlattenQuadraticBezier">
@@ -165,8 +154,6 @@
         <param name="ptCtrl">To be added.</param>
         <param name="ptEnd">To be added.</param>
         <param name="tolerance">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Shapes/Line.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Shapes/Line.xml
@@ -17,8 +17,6 @@
     </Attribute>
   </Attributes>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -32,8 +30,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="X1">
@@ -50,9 +46,6 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="X1Property">
@@ -69,8 +62,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="X2">
@@ -87,9 +78,6 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="X2Property">
@@ -106,8 +94,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Y1">
@@ -124,9 +110,6 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Y1Property">
@@ -143,8 +126,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Y2">
@@ -161,9 +142,6 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Y2Property">
@@ -180,8 +158,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Shapes/LineGeometry.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Shapes/LineGeometry.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -27,8 +25,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -48,8 +44,6 @@
       <Docs>
         <param name="startPoint">To be added.</param>
         <param name="endPoint">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="EndPoint">
@@ -66,9 +60,6 @@
         <ReturnType>Microsoft.Maui.Controls.Point</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="EndPointProperty">
@@ -85,8 +76,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="StartPoint">
@@ -103,9 +92,6 @@
         <ReturnType>Microsoft.Maui.Controls.Point</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="StartPointProperty">
@@ -122,8 +108,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Shapes/LineSegment.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Shapes/LineSegment.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -27,8 +25,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -46,8 +42,6 @@
       </Parameters>
       <Docs>
         <param name="point">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Point">
@@ -64,9 +58,6 @@
         <ReturnType>Microsoft.Maui.Controls.Point</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PointProperty">
@@ -83,8 +74,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Shapes/Matrix.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Shapes/Matrix.xml
@@ -17,8 +17,6 @@
     </Attribute>
   </Attributes>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -46,8 +44,6 @@
         <param name="m22">To be added.</param>
         <param name="offsetX">To be added.</param>
         <param name="offsetY">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Append">
@@ -68,8 +64,6 @@
       </Parameters>
       <Docs>
         <param name="matrix">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Determinant">
@@ -86,9 +80,6 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="HasInverse">
@@ -105,9 +96,6 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Identity">
@@ -124,9 +112,6 @@
         <ReturnType>Microsoft.Maui.Controls.Shapes.Matrix</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Invert">
@@ -144,8 +129,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsIdentity">
@@ -162,9 +145,6 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="M11">
@@ -181,9 +161,6 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="M12">
@@ -200,9 +177,6 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="M21">
@@ -219,9 +193,6 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="M22">
@@ -238,9 +209,6 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Multiply">
@@ -263,9 +231,6 @@
       <Docs>
         <param name="trans1">To be added.</param>
         <param name="trans2">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OffsetX">
@@ -282,9 +247,6 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OffsetY">
@@ -301,9 +263,6 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="op_Multiply">
@@ -326,9 +285,6 @@
       <Docs>
         <param name="trans1">To be added.</param>
         <param name="trans2">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Prepend">
@@ -349,8 +305,6 @@
       </Parameters>
       <Docs>
         <param name="matrix">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Rotate">
@@ -371,8 +325,6 @@
       </Parameters>
       <Docs>
         <param name="angle">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RotateAt">
@@ -397,8 +349,6 @@
         <param name="angle">To be added.</param>
         <param name="centerX">To be added.</param>
         <param name="centerY">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RotateAtPrepend">
@@ -423,8 +373,6 @@
         <param name="angle">To be added.</param>
         <param name="centerX">To be added.</param>
         <param name="centerY">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RotatePrepend">
@@ -445,8 +393,6 @@
       </Parameters>
       <Docs>
         <param name="angle">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Scale">
@@ -469,8 +415,6 @@
       <Docs>
         <param name="scaleX">To be added.</param>
         <param name="scaleY">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ScaleAt">
@@ -497,8 +441,6 @@
         <param name="scaleY">To be added.</param>
         <param name="centerX">To be added.</param>
         <param name="centerY">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ScaleAtPrepend">
@@ -525,8 +467,6 @@
         <param name="scaleY">To be added.</param>
         <param name="centerX">To be added.</param>
         <param name="centerY">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ScalePrepend">
@@ -549,8 +489,6 @@
       <Docs>
         <param name="scaleX">To be added.</param>
         <param name="scaleY">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetIdentity">
@@ -568,8 +506,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Skew">
@@ -592,8 +528,6 @@
       <Docs>
         <param name="skewX">To be added.</param>
         <param name="skewY">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SkewPrepend">
@@ -616,8 +550,6 @@
       <Docs>
         <param name="skewX">To be added.</param>
         <param name="skewY">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Transform">
@@ -638,9 +570,6 @@
       </Parameters>
       <Docs>
         <param name="point">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Transform">
@@ -661,8 +590,6 @@
       </Parameters>
       <Docs>
         <param name="points">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Translate">
@@ -685,8 +612,6 @@
       <Docs>
         <param name="offsetX">To be added.</param>
         <param name="offsetY">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TranslatePrepend">
@@ -709,8 +634,6 @@
       <Docs>
         <param name="offsetX">To be added.</param>
         <param name="offsetY">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Shapes/MatrixTransform.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Shapes/MatrixTransform.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -27,8 +25,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Matrix">
@@ -45,9 +41,6 @@
         <ReturnType>Microsoft.Maui.Controls.Shapes.Matrix</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="MatrixProperty">
@@ -64,8 +57,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Shapes/MatrixTypeConverter.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Shapes/MatrixTypeConverter.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -27,8 +25,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ConvertFromInvariantString">
@@ -49,9 +45,6 @@
       </Parameters>
       <Docs>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Shapes/Path.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Shapes/Path.xml
@@ -17,8 +17,6 @@
     </Attribute>
   </Attributes>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -32,8 +30,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Data">
@@ -55,9 +51,6 @@
         <ReturnType>Microsoft.Maui.Controls.Shapes.Geometry</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="DataProperty">
@@ -74,8 +67,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RenderTransform">
@@ -92,9 +83,6 @@
         <ReturnType>Microsoft.Maui.Controls.Shapes.Transform</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RenderTransformProperty">
@@ -111,8 +99,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Shapes/PathFigure.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Shapes/PathFigure.xml
@@ -21,8 +21,6 @@
     </Attribute>
   </Attributes>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -36,8 +34,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="BatchBegin">
@@ -58,8 +54,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="BatchCommit">
@@ -80,8 +74,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsClosed">
@@ -98,9 +90,6 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsClosedProperty">
@@ -117,8 +106,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsFilled">
@@ -135,9 +122,6 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsFilledProperty">
@@ -154,8 +138,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Segments">
@@ -172,9 +154,6 @@
         <ReturnType>Microsoft.Maui.Controls.Shapes.PathSegmentCollection</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SegmentsProperty">
@@ -191,8 +170,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="StartPoint">
@@ -209,9 +186,6 @@
         <ReturnType>Microsoft.Maui.Controls.Point</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="StartPointProperty">
@@ -228,8 +202,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Shapes/PathFigureCollection.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Shapes/PathFigureCollection.xml
@@ -15,8 +15,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -30,8 +28,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Shapes/PathFigureCollectionConverter.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Shapes/PathFigureCollectionConverter.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -27,8 +25,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ConvertFromInvariantString">
@@ -49,9 +45,6 @@
       </Parameters>
       <Docs>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ParseStringToPathFigureCollection">
@@ -74,8 +67,6 @@
       <Docs>
         <param name="pathFigureCollection">To be added.</param>
         <param name="pathString">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Shapes/PathGeometry.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Shapes/PathGeometry.xml
@@ -17,8 +17,6 @@
     </Attribute>
   </Attributes>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -32,8 +30,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -51,8 +47,6 @@
       </Parameters>
       <Docs>
         <param name="figures">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -72,8 +66,6 @@
       <Docs>
         <param name="figures">To be added.</param>
         <param name="fillRule">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Figures">
@@ -95,9 +87,6 @@
         <ReturnType>Microsoft.Maui.Controls.Shapes.PathFigureCollection</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FiguresProperty">
@@ -114,8 +103,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FillRule">
@@ -132,9 +119,6 @@
         <ReturnType>Microsoft.Maui.Controls.Shapes.FillRule</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FillRuleProperty">
@@ -151,8 +135,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Shapes/PathGeometryConverter.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Shapes/PathGeometryConverter.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -27,8 +25,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ConvertFromInvariantString">
@@ -49,9 +45,6 @@
       </Parameters>
       <Docs>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Shapes/PathSegment.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Shapes/PathSegment.xml
@@ -16,8 +16,6 @@
     </Interface>
   </Interfaces>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -31,8 +29,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="BatchBegin">
@@ -53,8 +49,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="BatchCommit">
@@ -75,8 +69,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Shapes/PathSegmentCollection.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Shapes/PathSegmentCollection.xml
@@ -15,8 +15,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -30,8 +28,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Shapes/PenLineCap.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Shapes/PenLineCap.xml
@@ -11,8 +11,6 @@
     <BaseTypeName>System.Enum</BaseTypeName>
   </Base>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Flat">
@@ -30,7 +28,6 @@
       </ReturnValue>
       <MemberValue>0</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
     <Member MemberName="Round">
@@ -48,7 +45,6 @@
       </ReturnValue>
       <MemberValue>2</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
     <Member MemberName="Square">
@@ -66,7 +62,6 @@
       </ReturnValue>
       <MemberValue>1</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Shapes/PenLineJoin.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Shapes/PenLineJoin.xml
@@ -11,8 +11,6 @@
     <BaseTypeName>System.Enum</BaseTypeName>
   </Base>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Bevel">
@@ -30,7 +28,6 @@
       </ReturnValue>
       <MemberValue>1</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
     <Member MemberName="Miter">
@@ -48,7 +45,6 @@
       </ReturnValue>
       <MemberValue>0</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
     <Member MemberName="Round">
@@ -66,7 +62,6 @@
       </ReturnValue>
       <MemberValue>2</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Shapes/PointCollectionConverter.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Shapes/PointCollectionConverter.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -27,8 +25,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ConvertFromInvariantString">
@@ -49,9 +45,6 @@
       </Parameters>
       <Docs>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Shapes/PolyBezierSegment.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Shapes/PolyBezierSegment.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -27,8 +25,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -46,8 +42,6 @@
       </Parameters>
       <Docs>
         <param name="points">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Points">
@@ -64,9 +58,6 @@
         <ReturnType>Microsoft.Maui.Controls.Shapes.PointCollection</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PointsProperty">
@@ -83,8 +74,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Shapes/PolyLineSegment.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Shapes/PolyLineSegment.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -27,8 +25,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -46,8 +42,6 @@
       </Parameters>
       <Docs>
         <param name="points">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Points">
@@ -64,9 +58,6 @@
         <ReturnType>Microsoft.Maui.Controls.Shapes.PointCollection</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PointsProperty">
@@ -83,8 +74,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Shapes/PolyQuadraticBezierSegment.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Shapes/PolyQuadraticBezierSegment.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -27,8 +25,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -46,8 +42,6 @@
       </Parameters>
       <Docs>
         <param name="points">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Points">
@@ -64,9 +58,6 @@
         <ReturnType>Microsoft.Maui.Controls.Shapes.PointCollection</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PointsProperty">
@@ -83,8 +74,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Shapes/Polygon.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Shapes/Polygon.xml
@@ -17,8 +17,6 @@
     </Attribute>
   </Attributes>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -32,8 +30,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FillRule">
@@ -50,9 +46,6 @@
         <ReturnType>Microsoft.Maui.Controls.Shapes.FillRule</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FillRuleProperty">
@@ -69,8 +62,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Points">
@@ -87,9 +78,6 @@
         <ReturnType>Microsoft.Maui.Controls.Shapes.PointCollection</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PointsProperty">
@@ -106,8 +94,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Shapes/Polyline.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Shapes/Polyline.xml
@@ -17,8 +17,6 @@
     </Attribute>
   </Attributes>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -32,8 +30,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FillRule">
@@ -50,9 +46,6 @@
         <ReturnType>Microsoft.Maui.Controls.Shapes.FillRule</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FillRuleProperty">
@@ -69,8 +62,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Points">
@@ -87,9 +78,6 @@
         <ReturnType>Microsoft.Maui.Controls.Shapes.PointCollection</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PointsProperty">
@@ -106,8 +94,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Shapes/QuadraticBezierSegment.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Shapes/QuadraticBezierSegment.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -27,8 +25,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -48,8 +44,6 @@
       <Docs>
         <param name="point1">To be added.</param>
         <param name="point2">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Point1">
@@ -66,9 +60,6 @@
         <ReturnType>Microsoft.Maui.Controls.Point</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Point1Property">
@@ -85,8 +76,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Point2">
@@ -103,9 +92,6 @@
         <ReturnType>Microsoft.Maui.Controls.Point</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Point2Property">
@@ -122,8 +108,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Shapes/Rectangle.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Shapes/Rectangle.xml
@@ -17,8 +17,6 @@
     </Attribute>
   </Attributes>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -32,8 +30,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RadiusX">
@@ -50,9 +46,6 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RadiusXProperty">
@@ -69,8 +62,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RadiusY">
@@ -87,9 +78,6 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RadiusYProperty">
@@ -106,8 +94,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Shapes/RectangleGeometry.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Shapes/RectangleGeometry.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -27,8 +25,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -46,8 +42,6 @@
       </Parameters>
       <Docs>
         <param name="rect">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Rect">
@@ -64,9 +58,6 @@
         <ReturnType>Microsoft.Maui.Controls.Rect</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RectProperty">
@@ -83,8 +74,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Shapes/RotateTransform.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Shapes/RotateTransform.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -27,8 +25,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -46,8 +42,6 @@
       </Parameters>
       <Docs>
         <param name="angle">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -69,8 +63,6 @@
         <param name="angle">To be added.</param>
         <param name="centerX">To be added.</param>
         <param name="centerY">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Angle">
@@ -87,9 +79,6 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="AngleProperty">
@@ -106,8 +95,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CenterX">
@@ -124,9 +111,6 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CenterXProperty">
@@ -143,8 +127,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CenterY">
@@ -161,9 +143,6 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CenterYProperty">
@@ -180,8 +159,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Shapes/RoundRectangleGeometry.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Shapes/RoundRectangleGeometry.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -27,8 +25,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -48,8 +44,6 @@
       <Docs>
         <param name="cornerRadius">To be added.</param>
         <param name="rect">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CornerRadius">
@@ -66,9 +60,6 @@
         <ReturnType>Microsoft.Maui.Controls.CornerRadius</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CornerRadiusProperty">
@@ -85,8 +76,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Rect">
@@ -103,9 +92,6 @@
         <ReturnType>Microsoft.Maui.Controls.Rect</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RectProperty">
@@ -122,8 +108,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Shapes/ScaleTransform.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Shapes/ScaleTransform.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -27,8 +25,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -48,8 +44,6 @@
       <Docs>
         <param name="scaleX">To be added.</param>
         <param name="scaleY">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -73,8 +67,6 @@
         <param name="scaleY">To be added.</param>
         <param name="centerX">To be added.</param>
         <param name="centerY">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CenterX">
@@ -91,9 +83,6 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CenterXProperty">
@@ -110,8 +99,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CenterY">
@@ -128,9 +115,6 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CenterYProperty">
@@ -147,8 +131,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ScaleX">
@@ -165,9 +147,6 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ScaleXProperty">
@@ -184,8 +163,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ScaleY">
@@ -202,9 +179,6 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ScaleYProperty">
@@ -221,8 +195,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Shapes/Shape.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Shapes/Shape.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -27,8 +25,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Aspect">
@@ -45,9 +41,6 @@
         <ReturnType>Microsoft.Maui.Controls.Stretch</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="AspectProperty">
@@ -64,8 +57,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Fill">
@@ -82,9 +73,6 @@
         <ReturnType>Microsoft.Maui.Controls.Brush</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FillProperty">
@@ -101,8 +89,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Stroke">
@@ -119,9 +105,6 @@
         <ReturnType>Microsoft.Maui.Controls.Brush</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="StrokeDashArray">
@@ -138,9 +121,6 @@
         <ReturnType>Microsoft.Maui.Controls.DoubleCollection</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="StrokeDashArrayProperty">
@@ -157,8 +137,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="StrokeDashOffset">
@@ -175,9 +153,6 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="StrokeDashOffsetProperty">
@@ -194,8 +169,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="StrokeLineCap">
@@ -212,9 +185,6 @@
         <ReturnType>Microsoft.Maui.Controls.Shapes.PenLineCap</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="StrokeLineCapProperty">
@@ -231,8 +201,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="StrokeLineJoin">
@@ -249,9 +217,6 @@
         <ReturnType>Microsoft.Maui.Controls.Shapes.PenLineJoin</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="StrokeLineJoinProperty">
@@ -268,8 +233,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="StrokeMiterLimit">
@@ -286,9 +249,6 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="StrokeMiterLimitProperty">
@@ -305,8 +265,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="StrokeProperty">
@@ -323,8 +281,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="StrokeThickness">
@@ -341,9 +297,6 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="StrokeThicknessProperty">
@@ -360,8 +313,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Shapes/SkewTransform.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Shapes/SkewTransform.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -27,8 +25,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -48,8 +44,6 @@
       <Docs>
         <param name="angleX">To be added.</param>
         <param name="angleY">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -73,8 +67,6 @@
         <param name="angleY">To be added.</param>
         <param name="centerX">To be added.</param>
         <param name="centerY">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="AngleX">
@@ -91,9 +83,6 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="AngleXProperty">
@@ -110,8 +99,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="AngleY">
@@ -128,9 +115,6 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="AngleYProperty">
@@ -147,8 +131,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CenterX">
@@ -165,9 +147,6 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CenterXProperty">
@@ -184,8 +163,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CenterY">
@@ -202,9 +179,6 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CenterYProperty">
@@ -221,8 +195,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Shapes/Transform.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Shapes/Transform.xml
@@ -17,8 +17,6 @@
     </Attribute>
   </Attributes>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -32,8 +30,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Value">
@@ -50,9 +46,6 @@
         <ReturnType>Microsoft.Maui.Controls.Shapes.Matrix</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ValueProperty">
@@ -69,8 +62,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Shapes/TransformCollection.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Shapes/TransformCollection.xml
@@ -15,8 +15,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -30,8 +28,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Shapes/TransformGroup.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Shapes/TransformGroup.xml
@@ -17,8 +17,6 @@
     </Attribute>
   </Attributes>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -32,8 +30,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Children">
@@ -50,9 +46,6 @@
         <ReturnType>Microsoft.Maui.Controls.Shapes.TransformCollection</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ChildrenProperty">
@@ -69,8 +62,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Shapes/TransformTypeConverter.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Shapes/TransformTypeConverter.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -27,8 +25,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ConvertFromInvariantString">
@@ -49,9 +45,6 @@
       </Parameters>
       <Docs>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Shapes/TranslateTransform.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Shapes/TranslateTransform.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -27,8 +25,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -48,8 +44,6 @@
       <Docs>
         <param name="x">To be added.</param>
         <param name="y">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="X">
@@ -66,9 +60,6 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="XProperty">
@@ -85,8 +76,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Y">
@@ -103,9 +92,6 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="YProperty">
@@ -122,8 +108,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.StyleSheets/StyleSheet.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.StyleSheets/StyleSheet.xml
@@ -14,7 +14,6 @@
   <Interfaces />
   <Docs>
     <summary>Class for loading style sheets from strings, assembly resources, and text readers.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="FromAssemblyResource">
@@ -50,7 +49,6 @@
         <param name="lineInfo">The line information for retrieving the style sheet.</param>
         <summary>Returns the specified style sheet.</summary>
         <returns>The specified style sheet.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FromReader">
@@ -74,7 +72,6 @@
         <param name="reader">The text reader from which to read the style sheet data.</param>
         <summary>Returns a style sheet by reading style data from the <paramref name="reader" />.</summary>
         <returns>A style sheet created from the data in the reader.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FromResource">
@@ -106,7 +103,6 @@
         <param name="lineInfo">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <returns>For internal use by the Microsoft.Maui.Controls platform.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FromString">
@@ -135,7 +131,6 @@
         <param name="stylesheet">The style sheet, as a string.</param>
         <summary>Creates and returns a style sheet from a string that contains a text representation of a style sheet.</summary>
         <returns>The style sheet for the data.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Xaml.Diagnostics/BindingBaseErrorEventArgs.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Xaml.Diagnostics/BindingBaseErrorEventArgs.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Binding">
@@ -30,9 +28,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindingBase</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ErrorCode">
@@ -49,9 +44,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Message">
@@ -68,9 +60,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="MessageArgs">
@@ -87,9 +76,6 @@
         <ReturnType>System.Object[]</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="XamlSourceInfo">
@@ -106,9 +92,6 @@
         <ReturnType>Microsoft.Maui.Controls.Xaml.Diagnostics.XamlSourceInfo</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Xaml.Diagnostics/BindingDiagnostics.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Xaml.Diagnostics/BindingDiagnostics.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -27,8 +25,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="BindingFailed">
@@ -45,8 +41,6 @@
         <ReturnType>System.EventHandler&lt;Microsoft.Maui.Controls.Xaml.Diagnostics.BindingBaseErrorEventArgs&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Xaml.Diagnostics/BindingErrorEventArgs.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Xaml.Diagnostics/BindingErrorEventArgs.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Source">
@@ -30,9 +28,6 @@
         <ReturnType>System.Object</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Target">
@@ -49,9 +44,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableObject</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TargetProperty">
@@ -68,9 +60,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Xaml/AcceptEmptyServiceProviderAttribute.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Xaml/AcceptEmptyServiceProviderAttribute.xml
@@ -37,7 +37,6 @@
       <Parameters />
       <Docs>
         <summary>Creates a new <see cref="T:Microsoft.Maui.Controls.Xaml.AcceptEmptyServiceProviderAttribute" /> with default values.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Xaml/XamlParseException.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Xaml/XamlParseException.xml
@@ -22,7 +22,6 @@
   </Attributes>
   <Docs>
     <summary>Exception that is raised when the XAML parser encounters a XAML error.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -37,7 +36,6 @@
       <Parameters />
       <Docs>
         <summary>For internal use by the XAML engine.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -56,7 +54,6 @@
       <Docs>
         <param name="message">For internal use by the XAML engine.</param>
         <summary>For internal use by the XAML engine.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -77,7 +74,6 @@
         <param name="info">For internal use by the XAML engine.</param>
         <param name="context">For internal use by the XAML engine.</param>
         <summary>For internal use by the XAML engine.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -98,7 +94,6 @@
         <param name="message">For internal use by the XAML engine.</param>
         <param name="innerException">For internal use by the XAML engine..</param>
         <summary>For internal use by the XAML engine.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -122,7 +117,6 @@
         <param name="xmlInfo">For internal use by the XAML engine.</param>
         <param name="innerException">For internal use by the XAML engine.</param>
         <summary>For internal use by the XAML engine.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="XmlInfo">
@@ -145,7 +139,6 @@
       <Docs>
         <summary>Information about the condition that caused the exception to be thrown.</summary>
         <value>For internal use by the XAML engine.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls.Xaml/XmlLineInfo.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Xaml/XmlLineInfo.xml
@@ -19,7 +19,6 @@
   </Interfaces>
   <Docs>
     <summary>For internal use by the XAML infrastructure.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -36,7 +35,6 @@
       <Parameters />
       <Docs>
         <summary>For internal use by the XAML engine.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -59,7 +57,6 @@
         <param name="linenumber">For internal use by the XAML engine.</param>
         <param name="lineposition">For internal use by the XAML engine.</param>
         <summary>For internal use by the XAML engine.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="HasLineInfo">
@@ -83,8 +80,6 @@
       <Parameters />
       <Docs>
         <summary>For internal use by the XAML infrastructure.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="LineNumber">
@@ -107,8 +102,6 @@
       </ReturnValue>
       <Docs>
         <summary>For internal use by the XAML infrastructure.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="LinePosition">
@@ -131,8 +124,6 @@
       </ReturnValue>
       <Docs>
         <summary>For internal use by the XAML infrastructure.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/AbsoluteLayout.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/AbsoluteLayout.xml
@@ -191,7 +191,6 @@
       <Parameters />
       <Docs>
         <summary>Initializes a new instance of the AbsoluteLayout class.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="AutoSize">
@@ -480,8 +479,6 @@
       <Docs>
         <typeparam name="T">The platform configuration that selects the platform specific to use.</typeparam>
         <summary>Returns the configuration object that the developer can use to call platform-specific methods for the layout.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnChildAdded">
@@ -571,8 +568,6 @@
       <Docs>
         <param name="child">To be added.</param>
         <param name="oldLogicalIndex">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnSizeRequest">

--- a/src/Controls/docs/Microsoft.Maui.Controls/Accelerator.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/Accelerator.xml
@@ -19,7 +19,6 @@
   </Attributes>
   <Docs>
     <summary>Represents a shortcut key for a <see cref="T:Microsoft.Maui.Controls.MenuItem" />.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Equals">
@@ -44,7 +43,6 @@
         <summary>Compares <see langword="this" /> accelerator to <paramref name="obj" /> and returns <see langword="true" /> if <paramref name="obj" /> is a of type <see cref="T:Microsoft.Maui.Controls.Accelerator" /> and is equal to this one. Otherwise, returns <see langword="false" />.</summary>
         <returns>
           <see langword="true" /> if <paramref name="obj" /> is a of type <see cref="T:Microsoft.Maui.Controls.Accelerator" /> and is equal to this one. Otherwise, returns <see langword="false" />.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FromString">
@@ -91,8 +89,6 @@
       <Parameters />
       <Docs>
         <summary>Returns the hashcode for the lower case string that represents the shortcut key.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Keys">
@@ -116,8 +112,6 @@
       </ReturnValue>
       <Docs>
         <summary>For internal use only.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="op_Implicit">
@@ -165,7 +159,6 @@
       <Docs>
         <summary>Returns a text representation of the accelerator.</summary>
         <returns>The text representation of the accelerator.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/AccessKeyPlacement.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/AccessKeyPlacement.xml
@@ -13,7 +13,6 @@
   </Base>
   <Docs>
     <summary>Enumerates access key placement relative to the control that the access key describes.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Auto">

--- a/src/Controls/docs/Microsoft.Maui.Controls/ActivityIndicator.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/ActivityIndicator.xml
@@ -207,8 +207,6 @@ var indicator = new ActivityIndicator {
       <Docs>
         <typeparam name="T">To be added.</typeparam>
         <summary>Returns the platform-specific instance of this <see cref="T:Microsoft.Maui.Controls.ActivityIndicator" />, on which a platform-specific method may be called.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/AdaptiveTrigger.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/AdaptiveTrigger.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -27,8 +25,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="MinWindowHeight">
@@ -45,9 +41,6 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="MinWindowHeightProperty">
@@ -64,8 +57,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="MinWindowWidth">
@@ -82,9 +73,6 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="MinWindowWidthProperty">
@@ -101,8 +89,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnAttached">
@@ -120,8 +106,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnDetached">
@@ -139,8 +123,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/Animation.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/Animation.xml
@@ -24,7 +24,6 @@
   </Interfaces>
   <Docs>
     <summary>Encapsulates an animation, a collection of functions that modify properties over a user-perceptible time period.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -46,7 +45,6 @@
       <Parameters />
       <Docs>
         <summary>Creates a new <see cref="T:Microsoft.Maui.Controls.Animation" /> object with default values.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -80,7 +78,6 @@
         <param name="easing">The easing function to use to transision in, out, or in and out of the animation.</param>
         <param name="finished">An action to call when the animation is finished.</param>
         <summary>Creates a new <see cref="T:Microsoft.Maui.Controls.Animation" /> object with the specified parameters.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Add">
@@ -113,7 +110,6 @@
         <param name="finishAt">The fraction into this animation at which the added child animation will stop animating.</param>
         <param name="animation">The animation to add.</param>
         <summary>Adds an <see cref="T:Microsoft.Maui.Controls.Animation" /> object to this <see cref="T:Microsoft.Maui.Controls.Animation" /> that begins at <paramref name="beginAt" /> and finishes at <paramref name="finishAt" />.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Commit">
@@ -154,7 +150,6 @@
         <param name="finished">An action to call when the animation is finished.</param>
         <param name="repeat">A function that returns true if the animation should continue.</param>
         <summary>Runs the <paramref name="owner" /> animation with the supplied parameters.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetCallback">
@@ -181,7 +176,6 @@
       <Docs>
         <summary>Returns a callback that recursively runs the eased animation step on this <see cref="T:Microsoft.Maui.Controls.Animation" /> object and those of its children that have begun and not finished.</summary>
         <returns>A callback that recursively runs the eased animation step on this <see cref="T:Microsoft.Maui.Controls.Animation" /> object and those of its children that have begun and not finished.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetEnumerator">
@@ -210,8 +204,6 @@
       <Parameters />
       <Docs>
         <summary>Returns an enumerator that can be used to iterate over the child <see cref="T:Microsoft.Maui.Controls.Animation" /> objects of this <see cref="T:Microsoft.Maui.Controls.Animation" /> object.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Insert">
@@ -244,8 +236,6 @@
         <param name="finishAt">The fraction into this animation at which the added child animation will stop animating.</param>
         <param name="animation">The animation to add.</param>
         <summary>Adds an <see cref="T:Microsoft.Maui.Controls.Animation" /> object to this <see cref="T:Microsoft.Maui.Controls.Animation" /> that begins at <paramref name="beginAt" /> and finishes at <paramref name="finishAt" />.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsEnabled">
@@ -262,9 +252,6 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="WithConcurrent">
@@ -297,8 +284,6 @@
         <param name="beginAt">The fraction into this animation at which the added child animation will begin animating.</param>
         <param name="finishAt">The fraction into this animation at which the added child animation will stop animating.</param>
         <summary>Adds <paramref name="animation" /> to the children of this <see cref="T:Microsoft.Maui.Controls.Animation" /> object and sets the start and end times of <paramref name="animation" /> to <paramref name="beginAt" /> and <paramref name="finishAt" />, respectively.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="WithConcurrent">
@@ -337,8 +322,6 @@
         <param name="beginAt">The fraction into this animation at which the added child animation will begin animating.</param>
         <param name="finishAt">The fraction into this animation at which the added child animation will stop animating.</param>
         <summary>Creates a new <see cref="T:Microsoft.Maui.Controls.Animation" /> object with the specified <paramref name="callback" />, and adds it to the children of this <see cref="T:Microsoft.Maui.Controls.Animation" /> object.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/AnimationExtensions.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/AnimationExtensions.xml
@@ -20,7 +20,6 @@
   <Interfaces />
   <Docs>
     <summary>Extension methods for <see cref="T:Microsoft.Maui.Controls.IAnimatable" /> objects.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="AbortAnimation">
@@ -51,7 +50,6 @@
         <param name="self">The object on which this method will be run.</param>
         <param name="handle">An animation key that must be unique among its sibling and parent animations for the duration of the animation.</param>
         <summary>Stops the animation.</summary>
-        <returns>To be added.</returns>
         <remarks>If <paramref name="handle" /> refers to an animation that belongs to this <see cref="T:Microsoft.Maui.Controls.IAnimatable" /> instance, then its tweener handlers are removed, the tweener is stopped, the animation is removed from this <see cref="T:Microsoft.Maui.Controls.IAnimatable" /> instance, and it is marked as finished. If <paramref name="handle" /> refers to one of the kinetics that belong to this <see cref="T:Microsoft.Maui.Controls.IAnimatable" /> instance, then it and its ticker are removed.</remarks>
       </Docs>
     </Member>
@@ -95,7 +93,6 @@
         <param name="finished">An action to call when the animation is finished.</param>
         <param name="repeat">A function that returns true if the animation should continue.</param>
         <summary>Sets the specified parameters and starts the animation.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Animate">
@@ -138,7 +135,6 @@
         <param name="finished">An action to call when the animation is finished.</param>
         <param name="repeat">A function that returns true if the animation should continue.</param>
         <summary>Sets the specified parameters and starts the animation.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Animate">
@@ -185,7 +181,6 @@
         <param name="finished">An action to call when the animation is finished.</param>
         <param name="repeat">A function that returns true if the animation should continue.</param>
         <summary>Sets the specified parameters and starts the animation.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Animate&lt;T&gt;">
@@ -234,7 +229,6 @@
         <param name="finished">An action to call when the animation is finished.</param>
         <param name="repeat">A function that returns true if the animation should continue.</param>
         <summary>Sets the specified parameters and starts the animation.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="AnimateKinetic">
@@ -273,7 +267,6 @@
         <param name="drag">The amount that the progression speed is reduced per frame. Can be negative.</param>
         <param name="finished">An action to call when the animation is finished.</param>
         <summary>Sets the specified parameters and starts the kinetic animation.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="AnimationIsRunning">
@@ -304,8 +297,6 @@
         <param name="self">The object on which this method will be run.</param>
         <param name="handle">An animation key that must be unique among its sibling and parent animations for the duration of the animation.</param>
         <summary>Returns a Boolean value that indicates whether or not the animation that is specified by <paramref name="handle" /> is running.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Batch">
@@ -326,9 +317,6 @@
       </Parameters>
       <Docs>
         <param name="self">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Interpolate">

--- a/src/Controls/docs/Microsoft.Maui.Controls/AppLinkEntry.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/AppLinkEntry.xml
@@ -33,7 +33,6 @@
       <Parameters />
       <Docs>
         <summary>Creates a new <see cref="T:Microsoft.Maui.Controls.AppLinkEntry" /> with default values.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="AppLinkUri">
@@ -56,7 +55,6 @@
       <Docs>
         <summary>Gets or sets an application-specific URI that uniquely describes content within an app.</summary>
         <value>An application-specific URI that uniquely describes content within an app.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="AppLinkUriProperty">
@@ -75,7 +73,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.AppLinkEntry.AppLinkUri" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Description">
@@ -98,7 +95,6 @@
       <Docs>
         <summary>Gets or sets a description that appears with the item in search results.</summary>
         <value>The description that appears with the item in search results.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="DescriptionProperty">
@@ -117,7 +113,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.AppLinkEntry.Description" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FromUri">
@@ -140,8 +135,6 @@
       <Docs>
         <param name="uri">A URI that can be parsed by the target appliction to recreate a specific state.</param>
         <summary>Creates and returns a new <see cref="T:Microsoft.Maui.Controls.AppLinkEntry" /> for the specified <paramref name="uri" />.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsLinkActive">
@@ -183,7 +176,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.AppLinkEntry.IsLinkActive" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="KeyValues">
@@ -229,7 +221,6 @@
       <Docs>
         <summary>Gets or sets a small image that appears with the item in search results.</summary>
         <value>A small image that appears with the item in search results</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ThumbnailProperty">
@@ -248,7 +239,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.AppLinkEntry.Thumbnail" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Title">
@@ -271,7 +261,6 @@
       <Docs>
         <summary>Gets or sets the title of the item.</summary>
         <value>The title of the item.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TitleProperty">
@@ -290,7 +279,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.AppLinkEntry.Title" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ToString">
@@ -311,7 +299,6 @@
       <Docs>
         <summary>Returns a string representation of this <see cref="T:Microsoft.Maui.Controls.AppLinkEntry" />.</summary>
         <returns>A  string representation of this <see cref="T:Microsoft.Maui.Controls.AppLinkEntry" />.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/AppThemeChangedEventArgs.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/AppThemeChangedEventArgs.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -31,8 +29,6 @@
       </Parameters>
       <Docs>
         <param name="appTheme">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RequestedTheme">
@@ -49,9 +45,6 @@
         <ReturnType>Microsoft.Maui.Controls.OSAppTheme</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/Application.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/Application.xml
@@ -47,7 +47,6 @@
       <Parameters />
       <Docs>
         <summary>Initializes a new <see cref="T:Microsoft.Maui.Controls.Application" /> instance.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="AppLinks">
@@ -85,8 +84,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ClearCurrent">
@@ -111,7 +108,6 @@
       <Parameters />
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Current">
@@ -134,8 +130,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets the current application.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Dispatcher">
@@ -152,9 +146,6 @@
         <ReturnType>Microsoft.Maui.Controls.IDispatcher</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsApplicationOrNull">
@@ -182,8 +173,6 @@
       <Docs>
         <param name="element">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="LogWarningsToApplicationOutput">
@@ -206,8 +195,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets whether runtime warnings are sent to the application's output.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="MainPage">
@@ -253,7 +240,6 @@
       </ReturnValue>
       <Docs>
         <summary>Event that is raised after a view has been popped modally.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ModalPopping">
@@ -275,7 +261,6 @@
       </ReturnValue>
       <Docs>
         <summary>Event that is raised when a view is modally popped.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ModalPushed">
@@ -297,7 +282,6 @@
       </ReturnValue>
       <Docs>
         <summary>Event that is raised after a view has been pushed modally.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ModalPushing">
@@ -319,7 +303,6 @@
       </ReturnValue>
       <Docs>
         <summary>Event that is raised when a view is modally pushed.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="NavigationProxy">
@@ -343,8 +326,6 @@
       </ReturnValue>
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="On&lt;T&gt;">
@@ -375,8 +356,6 @@
       <Docs>
         <typeparam name="T">The platform configuration for which to retrieve the application instance.</typeparam>
         <summary>Returns the platform-specific instance of this <see cref="T:Microsoft.Maui.Controls.Application" />, on which a platform-specific method may be called.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnAppLinkRequestReceived">
@@ -399,7 +378,6 @@
       <Docs>
         <param name="uri">The URI for the request.</param>
         <summary>App developers override this method to respond when the user initiates an app link request.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnParentSet">
@@ -423,7 +401,6 @@
       <Parameters />
       <Docs>
         <summary>Throws <see cref="T:System.InvalidOperationException" />.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnResume">
@@ -447,7 +424,6 @@
       <Parameters />
       <Docs>
         <summary>Application developers override this method to perform actions when the application resumes from a sleeping state.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnSleep">
@@ -471,7 +447,6 @@
       <Parameters />
       <Docs>
         <summary>Application developers override this method to perform actions when the application enters the sleeping state.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnStart">
@@ -495,7 +470,6 @@
       <Parameters />
       <Docs>
         <summary>Application developers override this method to perform actions when the application starts.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PageAppearing">
@@ -514,7 +488,6 @@
       </ReturnValue>
       <Docs>
         <summary>Event that is raised when a page is about to appear on the screen.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PageDisappearing">
@@ -533,7 +506,6 @@
       </ReturnValue>
       <Docs>
         <summary>Event that is raised when a page is about to disappear from the screen.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PanGestureId">
@@ -557,8 +529,6 @@
       </ReturnValue>
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Properties">
@@ -604,7 +574,6 @@
       <Parameters />
       <Docs>
         <summary>Quits the application.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RequestedTheme">
@@ -621,9 +590,6 @@
         <ReturnType>Microsoft.Maui.Controls.OSAppTheme</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RequestedThemeChanged">
@@ -640,8 +606,6 @@
         <ReturnType>System.EventHandler&lt;Microsoft.Maui.Controls.AppThemeChangedEventArgs&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Resources">
@@ -664,8 +628,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the resource dictionary for this <see cref="T:Microsoft.Maui.Controls.Application" /> object.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SavePropertiesAsync">
@@ -719,7 +681,6 @@
       <Docs>
         <param name="uri">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SendResume">
@@ -744,7 +705,6 @@
       <Parameters />
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SendSleep">
@@ -769,7 +729,6 @@
       <Parameters />
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SendSleepAsync">
@@ -794,8 +753,6 @@
       <Parameters />
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SendStart">
@@ -820,7 +777,6 @@
       <Parameters />
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetAppIndexingProvider">
@@ -851,7 +807,6 @@
       <Docs>
         <param name="provider">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetCurrentApplication">
@@ -879,7 +834,6 @@
       <Docs>
         <param name="value">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TriggerThemeChanged">
@@ -905,8 +859,6 @@
       </Parameters>
       <Docs>
         <param name="args">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="UserAppTheme">
@@ -923,9 +875,6 @@
         <ReturnType>Microsoft.Maui.Controls.OSAppTheme</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/AutomationProperties.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/AutomationProperties.xml
@@ -14,7 +14,6 @@
   <Interfaces />
   <Docs>
     <summary>Contains both abbreviated and detailed UI information that is supplied to accessibility services.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -30,7 +29,6 @@
       <Parameters />
       <Docs>
         <summary>Creates a new <see cref="T:Microsoft.Maui.Controls.AutomationProperties" /> object with default values.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetHelpText">
@@ -53,8 +51,6 @@
       <Docs>
         <param name="bindable">The bindable object whose help text to get.</param>
         <summary>Returns the help text, if any, for the bindable object.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetIsInAccessibleTree">
@@ -108,7 +104,6 @@
         <param name="bindable">The object whose label to find.</param>
         <summary>Returns the element that labels <paramref name="bindable" />, if <paramref name="bindable" /> does not label itself and if another element describes it in the UI.</summary>
         <returns>The element that labels <paramref name="bindable" />, if present.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetName">
@@ -132,7 +127,6 @@
         <param name="bindable">The object whose name to get.</param>
         <summary>Returns the short, developer-specified, introductory name of the element, such as "Progress Indicator" or "Button".</summary>
         <returns>The short, introdctory name of the element.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="HelpTextProperty">
@@ -151,7 +145,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the attached property that contains the detailed description of the UI element and its behavior.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsInAccessibleTreeProperty">
@@ -170,7 +163,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the attached property that contains a Boolean value that tells whether the element is available to the accessible app.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="LabeledByProperty">
@@ -189,7 +181,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the attached property that holds a reference to the element that labels the element that is being made accessible.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="NameProperty">
@@ -208,7 +199,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the attached property that contains the brief description of the UI element</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetHelpText">
@@ -233,7 +223,6 @@
         <param name="bindable">The object whose help text to set.</param>
         <param name="value">The new help text value.</param>
         <summary>Sets the help text for <paramref name="bindable" />.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetIsInAccessibleTree">
@@ -259,7 +248,6 @@
         <param name="value">
           <see langword="true" /> to make <paramref name="bindable" /> visible to the accessibility system. <see langword="false" /> to remove it from the system.</param>
         <summary>Sets a Boolean value that tells whether the bindable object is available to the accessibility system.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetLabeledBy">
@@ -284,7 +272,6 @@
         <param name="bindable">The object whose label to set.</param>
         <param name="value">The visual element that will name <paramref name="bindable" />, or <see langword="null" /> to make <paramref name="bindable" /> its own label.</param>
         <summary>Sets another element, such as a <see cref="T:Microsoft.Maui.Controls.Label" /> as the label for <paramref name="bindable" />.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetName">
@@ -309,7 +296,6 @@
         <param name="bindable">The object whose name to set.</param>
         <param name="value">The new name.</param>
         <summary>Sets the short, developer-specified, introductory name of the element, such as "Progress Indicator" or "Button".</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/BackButtonBehavior.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/BackButtonBehavior.xml
@@ -13,7 +13,6 @@
   <Interfaces />
   <Docs>
     <summary>A <see cref="T:Microsoft.Maui.Controls.BindableObject" /> specifying the behavior associated with the back button in a Shell application.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -27,8 +26,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Command">
@@ -45,9 +42,6 @@
         <ReturnType>System.Windows.Input.ICommand</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CommandParameter">
@@ -64,9 +58,6 @@
         <ReturnType>System.Object</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CommandParameterProperty">
@@ -84,7 +75,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.BackButtonBehavior.CommandParameter" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CommandProperty">
@@ -102,7 +92,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.BackButtonBehavior.Command" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IconOverride">
@@ -119,9 +108,6 @@
         <ReturnType>Microsoft.Maui.Controls.ImageSource</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IconOverrideProperty">
@@ -139,7 +125,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.BackButtonBehavior.IconOverride" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsEnabled">
@@ -156,9 +141,6 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsEnabledProperty">
@@ -176,7 +158,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.BackButtonBehavior.IsEnabled" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TextOverride">
@@ -193,9 +174,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TextOverrideProperty">
@@ -213,7 +191,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.BackButtonBehavior.TextOverride" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/BackButtonPressedEventArgs.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/BackButtonPressedEventArgs.xml
@@ -17,7 +17,6 @@
   <Interfaces />
   <Docs>
     <summary>Internal use only. Contains arguments for the event that is raised when a back button is pressed.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -36,7 +35,6 @@
       <Parameters />
       <Docs>
         <summary>Internal use only. Initializes a new <see cref="T:Microsoft.Maui.Controls.BackButtonPressedEventArgs" /> instance.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Handled">
@@ -58,8 +56,6 @@
       </ReturnValue>
       <Docs>
         <summary>Internal use only. Gets or sets a value that indicates whether the back button event has already been handled.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/BaseMenuItem.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/BaseMenuItem.xml
@@ -17,7 +17,6 @@
   <Interfaces />
   <Docs>
     <summary>Base class for menu items.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -36,7 +35,6 @@
       <Parameters />
       <Docs>
         <summary>Initializes a new <see cref="T:Microsoft.Maui.Controls.BaseMenuItem" /> instance.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/BaseShellItem.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/BaseShellItem.xml
@@ -22,7 +22,6 @@
   </Attributes>
   <Docs>
     <summary>A <see cref="T:Microsoft.Maui.Controls.NavigableElement" /> that is the base class for <see cref="T:Microsoft.Maui.Controls.ShellGroupItem" /> and <see cref="T:Microsoft.Maui.Controls.ShellContent" />.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -37,7 +36,6 @@
       <Parameters />
       <Docs>
         <summary>Creates a new <see cref="T:Microsoft.Maui.Controls.BaseShellItem" /> with default values.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Appearing">
@@ -54,8 +52,6 @@
         <ReturnType>System.EventHandler</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Disappearing">
@@ -72,8 +68,6 @@
         <ReturnType>System.EventHandler</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FlyoutIcon">
@@ -92,7 +86,6 @@
       <Docs>
         <summary>The icon to use for the item. If this property is unset, it will fallback to using the <see cref="P:Microsoft.Maui.Controls.BaseShellItem.Icon" /> property value.</summary>
         <value>A <see cref="T:Microsoft.Maui.Controls.ImageSource" /> that represents an icon.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FlyoutIconProperty">
@@ -110,7 +103,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.BaseShellItem.FlyoutIcon" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Icon">
@@ -129,7 +121,6 @@
       <Docs>
         <summary>Defines the icon to display in parts of the chrome that are not the flyout.</summary>
         <value>A <see cref="T:Microsoft.Maui.Controls.ImageSource" /> that represents an icon.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IconProperty">
@@ -147,7 +138,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.BaseShellItem.Icon" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsChecked">
@@ -167,7 +157,6 @@
         <summary>Defines if the item is currently highlighted in the flyout.</summary>
         <value>
           <see langword="true" /> if the item is currently highlighted.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsCheckedProperty">
@@ -185,7 +174,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.BaseShellItem.IsChecked" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsEnabled">
@@ -205,7 +193,6 @@
         <summary>Defines if the item is selectable in the chrome.</summary>
         <value>
           <see langword="true" /> if the item is selectable in the chrome.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsEnabledProperty">
@@ -223,7 +210,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.BaseShellItem.IsEnabled" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsTabStop">
@@ -245,7 +231,6 @@
       <Docs>
         <summary>Indicates whether a FlyoutItem is included in tab navigation.</summary>
         <value>Default value is <see langword="true" />; when <see langword="false" />, the FlyoutItem is ignored by the tab-navigation infrastructure, irrespective if a TabIndex is set.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsTabStopProperty">
@@ -263,7 +248,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.BaseShellItem.IsTabStopProperty" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsVisible">
@@ -280,9 +264,6 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsVisibleProperty">
@@ -299,8 +280,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnAppearing">
@@ -318,8 +297,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnDisappearing">
@@ -337,8 +314,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnPropertyChanged">
@@ -366,7 +341,6 @@
       <Docs>
         <param name="propertyName">The name of the changed property.</param>
         <summary>Called whenever a property changes.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnTabIndexPropertyChanged">
@@ -390,7 +364,6 @@
         <param name="oldValue">Old TabIndex.</param>
         <param name="newValue">New TabIndex.</param>
         <summary>Called whenever the TabIndex property changes.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnTabStopPropertyChanged">
@@ -414,7 +387,6 @@
         <param name="oldValue">Old IsTabStop value.</param>
         <param name="newValue">New IsTabStop value.</param>
         <summary>Called whenever the IsTabStop property changes.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Route">
@@ -433,7 +405,6 @@
       <Docs>
         <summary>The string used to address the item.</summary>
         <value>A unique string that identifies the item.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TabIndex">
@@ -455,7 +426,6 @@
       <Docs>
         <summary>Indicates the order in which FlyoutItem objects receive focus when the user navigates through items by pressing the Tab key.</summary>
         <value>Defaults to 0.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TabIndexDefaultValueCreator">
@@ -475,7 +445,6 @@
       <Docs>
         <summary>Called to set the default value of the TabIndex property..</summary>
         <returns>Defaults to 0.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TabIndexProperty">
@@ -493,7 +462,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.BaseShellItem.TabIndexProperty" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TabStopDefaultValueCreator">
@@ -514,7 +482,6 @@
         <summary>Called to set the default value of the TabStop property.</summary>
         <returns>
           <see langword="true" /> if TabStop.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Title">
@@ -533,7 +500,6 @@
       <Docs>
         <summary>Title to display in the UI.</summary>
         <value>Title to display in the UI.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TitleProperty">
@@ -551,7 +517,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.BaseShellItem.Title" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/BaseSwipeEventArgs.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/BaseSwipeEventArgs.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -31,8 +29,6 @@
       </Parameters>
       <Docs>
         <param name="swipeDirection">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SwipeDirection">
@@ -49,9 +45,6 @@
         <ReturnType>Microsoft.Maui.Controls.SwipeDirection</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/Behavior.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/Behavior.xml
@@ -33,7 +33,6 @@
       <Parameters />
       <Docs>
         <summary>Creates a new Behavior with default values.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="AssociatedType">
@@ -55,8 +54,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets the type of the objects with which this <see cref="T:Microsoft.Maui.Controls.Behavior" /> can be associated.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnAttachedTo">
@@ -82,7 +79,6 @@
       <Docs>
         <param name="bindable">The bindable object to which the behavior was attached.</param>
         <summary>Application developers override this method to implement the behaviors that will be associated with <paramref name="bindable" />.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnDetachingFrom">
@@ -108,7 +104,6 @@
       <Docs>
         <param name="bindable">The bindable object from which the behavior was detached.</param>
         <summary>Application developers override this method to remove the behaviors from <paramref name="bindable" /> that were implemented in a previous call to the <see cref="M:Microsoft.Maui.Controls.Behavior.OnAttachedTo(Microsoft.Maui.Controls.BindableObject)" /> method.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/BindableLayout.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/BindableLayout.xml
@@ -13,7 +13,6 @@
   <Interfaces />
   <Docs>
     <summary>Static class specifying the attached properties that allow a <see cref="T:Microsoft.Maui.Controls.ILayout" /> work with a data-bound <see cref="T:System.Collections.IEnumerable" />.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="EmptyViewProperty">
@@ -30,8 +29,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="EmptyViewTemplateProperty">
@@ -48,8 +45,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetEmptyView">
@@ -70,9 +65,6 @@
       </Parameters>
       <Docs>
         <param name="b">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetEmptyViewTemplate">
@@ -93,9 +85,6 @@
       </Parameters>
       <Docs>
         <param name="b">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetItemsSource">
@@ -116,9 +105,6 @@
       </Parameters>
       <Docs>
         <param name="b">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetItemTemplate">
@@ -139,9 +125,6 @@
       </Parameters>
       <Docs>
         <param name="b">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetItemTemplateSelector">
@@ -162,9 +145,6 @@
       </Parameters>
       <Docs>
         <param name="b">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ItemsSourceProperty">
@@ -181,8 +161,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ItemTemplateProperty">
@@ -199,8 +177,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ItemTemplateSelectorProperty">
@@ -217,8 +193,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetEmptyView">
@@ -241,8 +215,6 @@
       <Docs>
         <param name="b">To be added.</param>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetEmptyViewTemplate">
@@ -265,8 +237,6 @@
       <Docs>
         <param name="b">To be added.</param>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetItemsSource">
@@ -289,8 +259,6 @@
       <Docs>
         <param name="b">To be added.</param>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetItemTemplate">
@@ -313,8 +281,6 @@
       <Docs>
         <param name="b">To be added.</param>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetItemTemplateSelector">
@@ -337,8 +303,6 @@
       <Docs>
         <param name="b">To be added.</param>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/BindableObject.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/BindableObject.xml
@@ -157,7 +157,6 @@ public static void OneWayDemo ()
       <Parameters />
       <Docs>
         <summary>Apply the bindings to <see cref="P:Microsoft.Maui.Controls.BindableObject.BindingContext" />.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="BindingContext">
@@ -223,7 +222,6 @@ Debug.WriteLine (label.Text); // prints "John Doe"
       </ReturnValue>
       <Docs>
         <summary>Raised whenever the <see cref="P:Microsoft.Maui.Controls.BindableObject.BindingContext" /> property changes.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="BindingContextProperty">
@@ -361,8 +359,6 @@ stack.BindingContext = new {Jane = new {Name = "Jane Doe"}, John = new {Name = "
       </Parameters>
       <Docs>
         <param name="property">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CoerceValue">
@@ -383,8 +379,6 @@ stack.BindingContext = new {Jane = new {Name = "Jane Doe"}, John = new {Name = "
       </Parameters>
       <Docs>
         <param name="propertyKey">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Dispatcher">
@@ -401,9 +395,6 @@ stack.BindingContext = new {Jane = new {Name = "Jane Doe"}, John = new {Name = "
         <ReturnType>Microsoft.Maui.Controls.IDispatcher</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetValue">
@@ -485,7 +476,6 @@ class MyBindable : BindableObject
         <param name="property1">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <returns>For internal use by the Microsoft.Maui.Controls platform.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetValues">
@@ -521,7 +511,6 @@ class MyBindable : BindableObject
         <param name="property2">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <returns>For internal use by the Microsoft.Maui.Controls platform.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsSet">
@@ -546,7 +535,6 @@ class MyBindable : BindableObject
         <summary>Returns <see langword="true" /> if the target property exists and has been set.</summary>
         <returns>
           <see langword="true" /> if the target property exists and has been set. If the property has not been set, returns <see langword="false" />. If the <paramref name="targetProperty" /> is null, an <c>ArgumentNullException</c> is thrown.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnBindingContextChanged">
@@ -572,7 +560,6 @@ class MyBindable : BindableObject
       <Parameters />
       <Docs>
         <summary>Override this method to execute an action when the BindingContext changes.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnPropertyChanged">
@@ -672,7 +659,6 @@ class MyBindable : BindableObject
       </ReturnValue>
       <Docs>
         <summary>Raised when a property has changed.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PropertyChanging">
@@ -697,7 +683,6 @@ class MyBindable : BindableObject
       </ReturnValue>
       <Docs>
         <summary>Raised when a property is about to change.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RemoveBinding">
@@ -809,7 +794,6 @@ Debug.WriteLine (label.Text); // prints "John Doe"
         <param name="bindable">The object on which to set the inherited binding context.</param>
         <param name="value">The inherited context to set.</param>
         <summary>Sets the inherited context to a nested element.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetValue">
@@ -939,7 +923,6 @@ class MyBindable : BindableObject
         <param name="value">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="attributes">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="UnapplyBindings">
@@ -997,7 +980,6 @@ class MyBindable : BindableObject
         <param name="property">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="key">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/BindableObjectExtensions.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/BindableObjectExtensions.xml
@@ -50,9 +50,6 @@
         <param name="bindableObject">To be added.</param>
         <param name="bindableProperty">To be added.</param>
         <param name="returnIfNotSet">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetAppThemeColor">
@@ -79,8 +76,6 @@
         <param name="targetProperty">To be added.</param>
         <param name="light">To be added.</param>
         <param name="dark">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetBinding">
@@ -248,8 +243,6 @@ Debug.WriteLine (label.Text); // prints "John Doe"
         <param name="targetProperty">To be added.</param>
         <param name="light">To be added.</param>
         <param name="dark">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/BindableProperty.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/BindableProperty.xml
@@ -77,7 +77,6 @@
         <param name="defaultValueCreator">A Func used to initialize default value for reference types.</param>
         <summary>Creates a new instance of the BindableProperty class.</summary>
         <returns>A newly created BindableProperty.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Create&lt;TDeclarer,TPropertyType&gt;">
@@ -137,7 +136,6 @@
         <param name="defaultValueCreator">A Func used to initialize default value for reference types.</param>
         <summary>Deprecated. Do not use.</summary>
         <returns>A newly created BindableProperty.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CreateAttached">
@@ -183,7 +181,6 @@
         <param name="defaultValueCreator">A Func used to initialize default value for reference types.</param>
         <summary>Creates a new instance of the BindableProperty class for an attached property.</summary>
         <returns>A newly created attached BindableProperty.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CreateAttached&lt;TDeclarer,TPropertyType&gt;">
@@ -345,7 +342,6 @@
         <param name="defaultValueCreator">A Func used to initialize default value for reference types.</param>
         <summary>Deprecated. Do not use.</summary>
         <returns>A newly created BindablePropertyKey.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CreateReadOnly">
@@ -392,7 +388,6 @@
         <summary>Creates a new instance of the BindablePropertyKey class.</summary>
         <returns>
         </returns>
-        <remarks>To be added.</remarks>
         <para>Attached properties are bindable properties that are bound to an object other than their parent. Often, they are used for child items in tables and grids, where data about the location of an item is maintained by its parent, but must be accessed from the child item itself.</para>
       </Docs>
     </Member>
@@ -511,7 +506,6 @@
         <summary>Gets the default BindingMode.</summary>
         <value>
         </value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="DefaultValue">
@@ -539,7 +533,6 @@
         <summary>Gets the default value for the BindableProperty.</summary>
         <value>
         </value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsReadOnly">
@@ -567,7 +560,6 @@
         <summary>Gets a value indicating if the BindableProperty is created form a BindablePropertyKey.</summary>
         <value>
         </value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PropertyName">
@@ -595,7 +587,6 @@
         <summary>Gets the property name.</summary>
         <value>
         </value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ReturnType">
@@ -623,7 +614,6 @@
         <summary>Gets the type of the BindableProperty.</summary>
         <value>
         </value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="UnsetValue">
@@ -640,8 +630,6 @@
         <ReturnType>System.Object</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/BindablePropertyConverter.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/BindablePropertyConverter.xml
@@ -24,7 +24,6 @@
   </Attributes>
   <Docs>
     <summary>A <see cref="T:System.ComponentModel.TypeConverter" /> for bindable properties.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -41,7 +40,6 @@
       <Parameters />
       <Docs>
         <summary>Creates a new <see cref="T:Microsoft.Maui.Controls.BindablePropertyConverter" /> with default values.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ConvertFromInvariantString">
@@ -64,8 +62,6 @@
       <Docs>
         <param name="value">The value to convert.</param>
         <summary>Returns a bindable property when supplied a string of the form <c>Type.PropertyName</c>.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IExtendedTypeConverter.ConvertFrom">
@@ -96,8 +92,6 @@
         <param name="value">For internal use only.</param>
         <param name="serviceProvider">For internal use only.</param>
         <summary>For internal use only.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IExtendedTypeConverter.ConvertFromInvariantString">
@@ -125,8 +119,6 @@
         <param name="value">For internal use only.</param>
         <param name="serviceProvider">For internal use only.</param>
         <summary>For internal use only.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/BindablePropertyKey.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/BindablePropertyKey.xml
@@ -64,7 +64,6 @@ class Bindable : BindableObject
       <Docs>
         <summary>Gets the BindableProperty.</summary>
         <value>A BindableProperty used for read access.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/Binding.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/Binding.xml
@@ -42,7 +42,6 @@
       <Parameters />
       <Docs>
         <summary>Constructs and initializes a new instance of the <see cref="T:Microsoft.Maui.Controls.Binding" /> class.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -140,7 +139,6 @@ Debug.WriteLine (person.Name); //prints "Foo". ReverseConverter.ConvertBack () i
       <Docs>
         <summary>Gets or sets the converter to be used for this binding ?</summary>
         <value>An IValueConverter, or <see langword="null" />.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ConverterParameter">
@@ -166,7 +164,6 @@ Debug.WriteLine (person.Name); //prints "Foo". ReverseConverter.ConvertBack () i
       <Docs>
         <summary>Gets or sets the parameter passed as argument to the converter.</summary>
         <value>An object, or <see langword="null" />.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Create&lt;TSource&gt;">
@@ -250,8 +247,6 @@ Debug.WriteLine (label.Text); //prints "John Doe".
         <ReturnType>System.Object</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Path">
@@ -277,7 +272,6 @@ Debug.WriteLine (label.Text); //prints "John Doe".
       <Docs>
         <summary>Gets or sets the path of the property</summary>
         <value>A string indicating the path to the property.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Source">
@@ -324,8 +318,6 @@ Debug.WriteLine (label.Text); //prints "John Doe".
       </ReturnValue>
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/BindingBase.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/BindingBase.xml
@@ -20,7 +20,6 @@
   <Interfaces />
   <Docs>
     <summary>An abstract class that provides a <see cref="T:Microsoft.Maui.Controls.BindingMode" /> and a formatting option.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="DisableCollectionSynchronization">
@@ -105,7 +104,6 @@
       <Docs>
         <summary>Gets or sets the value to use instead of the default value for the property, if no specified value exists.</summary>
         <value>The value to use instead of the default value for the property, if no specified value exists</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Mode">
@@ -130,8 +128,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the mode for this binding.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="StringFormat">
@@ -200,7 +196,6 @@ label.AddBinding (new Binding (Label.TextProperty, "Price") {
       <Docs>
         <summary>Gets or sets the value to supply for a bound property when the target of the binding is <see langword="null" />.</summary>
         <value>The value to supply for a bound property when the target of the binding is <see langword="null" />.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ThrowIfApplied">

--- a/src/Controls/docs/Microsoft.Maui.Controls/BindingCondition.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/BindingCondition.xml
@@ -56,7 +56,6 @@
       <Parameters />
       <Docs>
         <summary>Initializes a new <see cref="T:Microsoft.Maui.Controls.BindingCondition" /> instance.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Binding">
@@ -78,8 +77,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the binding against which the <see cref="P:Microsoft.Maui.Controls.BindingCondition.Value" /> property will be compared.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Value">
@@ -101,8 +98,6 @@
       </ReturnValue>
       <Docs>
         <summary>The binding value that satisfies the condition.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.Xaml.IValueProvider.ProvideValue">
@@ -131,8 +126,6 @@
       <Docs>
         <param name="serviceProvider">Used by the XAML infrastructure.</param>
         <summary>Used by the XAML infrastructure.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/BoundsConstraint.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/BoundsConstraint.xml
@@ -20,7 +20,6 @@
   <Interfaces />
   <Docs>
     <summary>A bounds layout constraint used by <see cref="T:Microsoft.Maui.Controls.Compatibility.RelativeLayout" />s.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="FromExpression">
@@ -51,8 +50,6 @@
         <param name="expression">The expression from which to compile the constraint.</param>
         <param name="parents">The parents to consider when compiling the constraint.</param>
         <summary>Returns a <see cref="T:Microsoft.Maui.Controls.BoundsConstraint" /> object that contains the compiled version of <paramref name="expression" /> and is relative to either <paramref name="parents" /> or the views referred to in <paramref name="expression" />.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/BoundsTypeConverter.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/BoundsTypeConverter.xml
@@ -25,7 +25,6 @@
   </Attributes>
   <Docs>
     <summary>A <see cref="T:System.ComponentModel.TypeConverter" /> that converts strings into <see cref="T:Microsoft.Maui.Controls.Shapes.Rectangle" />s for use with <see cref="T:Microsoft.Maui.Controls.AbsoluteLayout" />s.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -47,7 +46,6 @@
       <Parameters />
       <Docs>
         <summary>Creates a new <see cref="T:Microsoft.Maui.Controls.BoundsTypeConverter" /> with default values.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ConvertFromInvariantString">
@@ -70,8 +68,6 @@
       <Docs>
         <param name="value">The value to convert.</param>
         <summary>Converts <paramref name="value" /> into a <see cref="T:Microsoft.Maui.Controls.Shapes.Rectangle" />.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/BoxView.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/BoxView.xml
@@ -124,7 +124,6 @@
       <Docs>
         <summary>Gets or sets the corner radius for the box view.</summary>
         <value>The corner radius for the box view.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CornerRadiusProperty">
@@ -143,7 +142,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.BoxView.CornerRadius" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="On&lt;T&gt;">
@@ -174,8 +172,6 @@
       <Docs>
         <typeparam name="T">To be added.</typeparam>
         <summary>Returns the platform-specific instance of this <see cref="T:Microsoft.Maui.Controls.BoxView" />, on which a platform-specific method may be called.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnSizeRequest">
@@ -211,8 +207,6 @@
         <param name="widthConstraint">The requested width.</param>
         <param name="heightConstraint">The requested height.</param>
         <summary>Method that is called when a size request is made to the box view.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/BrushTypeConverter.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/BrushTypeConverter.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -27,8 +25,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ConvertFromInvariantString">
@@ -49,9 +45,6 @@
       </Parameters>
       <Docs>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Hsl">
@@ -68,8 +61,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Hsla">
@@ -86,8 +77,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="LinearGradient">
@@ -104,8 +93,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RadialGradient">
@@ -122,8 +109,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Rgb">
@@ -140,8 +125,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Rgba">
@@ -158,8 +141,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/Button.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/Button.xml
@@ -146,7 +146,6 @@ void IncrementLabel()
       <Parameters />
       <Docs>
         <summary>Initializes a new instance of the Button class.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="BorderColor">
@@ -197,7 +196,6 @@ void IncrementLabel()
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.Button.BorderColor" /> bindable property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="BorderWidth">
@@ -248,7 +246,6 @@ void IncrementLabel()
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.Button.BorderWidth" /> bindable property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ChangeVisualState">
@@ -267,7 +264,6 @@ void IncrementLabel()
       <Parameters />
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CharacterSpacing">
@@ -284,9 +280,6 @@ void IncrementLabel()
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CharacterSpacingProperty">
@@ -304,7 +297,6 @@ void IncrementLabel()
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.Button.CharacterSpacing" /> bindable property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Clicked">
@@ -381,7 +373,6 @@ void IncrementLabel()
       <Docs>
         <summary>Gets or sets the parameter to pass to the Command property. This is a bindable property.</summary>
         <value>A object to pass to the command property. The default value is <see langword="null" />.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CommandParameterProperty">
@@ -406,7 +397,6 @@ void IncrementLabel()
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.Button.CommandParameter" /> bindable property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CommandProperty">
@@ -431,7 +421,6 @@ void IncrementLabel()
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.Button.Command" /> bindable property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ContentLayout">
@@ -450,8 +439,6 @@ void IncrementLabel()
       </ReturnValue>
       <Docs>
         <summary>Gets or sets an object that controls the position of the button image and the spacing between the button's image and the button's text.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ContentLayoutProperty">
@@ -470,7 +457,6 @@ void IncrementLabel()
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.Button.ContentLayout" /> bindable property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CornerRadius">
@@ -490,7 +476,6 @@ void IncrementLabel()
       <Docs>
         <summary>Gets or sets the corner radius for the button, in device-independent units.</summary>
         <value>The corner radius for the button, in device-independent units.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CornerRadiusProperty">
@@ -509,7 +494,6 @@ void IncrementLabel()
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.Button.CornerRadius" /> bindable property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Font">
@@ -535,7 +519,6 @@ void IncrementLabel()
       <Docs>
         <summary>Gets or sets the Font for the Label text. This is a bindable property.</summary>
         <value>The <see cref="T:Microsoft.Maui.Controls.Font" /> value for the button. The default is <see langword="null" />, which represents the default font on the platform.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FontAttributes">
@@ -557,8 +540,6 @@ void IncrementLabel()
       </ReturnValue>
       <Docs>
         <summary>Gets a value that indicates whether the font for the button text is bold, italic, or neither.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FontAttributesProperty">
@@ -580,7 +561,6 @@ void IncrementLabel()
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.Button.FontAttributes" /> bindable property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FontFamily">
@@ -602,8 +582,6 @@ void IncrementLabel()
       </ReturnValue>
       <Docs>
         <summary>Gets the font family to which the font for the button text belongs.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FontFamilyProperty">
@@ -625,7 +603,6 @@ void IncrementLabel()
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.Button.FontFamily" /> bindable property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FontProperty">
@@ -650,7 +627,6 @@ void IncrementLabel()
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.Button.Font" /> bindable property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FontSize">
@@ -677,8 +653,6 @@ void IncrementLabel()
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the size of the font of the button text.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FontSizeProperty">
@@ -700,7 +674,6 @@ void IncrementLabel()
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.Button.FontSize" /> bindable property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ImageSource">
@@ -718,8 +691,6 @@ void IncrementLabel()
       </ReturnValue>
       <Docs>
         <summary>Allows you to display a bitmap image on the Button.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ImageSourceProperty">
@@ -737,7 +708,6 @@ void IncrementLabel()
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.Button.ImageSource" /> bindable property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsPressed">
@@ -755,8 +725,6 @@ void IncrementLabel()
       </ReturnValue>
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsPressedProperty">
@@ -774,7 +742,6 @@ void IncrementLabel()
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.Button.IsPressed" /> bindable property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="On&lt;T&gt;">
@@ -805,8 +772,6 @@ void IncrementLabel()
       <Docs>
         <typeparam name="T">To be added.</typeparam>
         <summary>Returns the platform-specific instance of this <see cref="T:Microsoft.Maui.Controls.Button" />, on which a platform-specific method may be called.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnBindingContextChanged">
@@ -852,7 +817,6 @@ void IncrementLabel()
       <Docs>
         <summary>Gets or sets the padding for the button.</summary>
         <value>The padding for the button.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PaddingProperty">
@@ -871,7 +835,6 @@ void IncrementLabel()
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.Button.Padding" /> bindable property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Pressed">
@@ -890,7 +853,6 @@ void IncrementLabel()
       </ReturnValue>
       <Docs>
         <summary>Occurs when the Button is pressed.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Released">
@@ -937,7 +899,6 @@ void IncrementLabel()
       <Parameters />
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SendPressed">
@@ -965,7 +926,6 @@ void IncrementLabel()
       <Parameters />
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SendReleased">
@@ -993,7 +953,6 @@ void IncrementLabel()
       <Parameters />
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Text">
@@ -1045,7 +1004,6 @@ void IncrementLabel()
       <Docs>
         <summary>Gets or sets the <see cref="T:Microsoft.Maui.Graphics.Color" /> for the text of the button. This is a bindable property.</summary>
         <value>The <see cref="T:Microsoft.Maui.Graphics.Color" /> value.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TextColorProperty">
@@ -1070,7 +1028,6 @@ void IncrementLabel()
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.Button.TextColor" /> bindable property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TextProperty">
@@ -1095,7 +1052,6 @@ void IncrementLabel()
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.Button.Text" /> bindable property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TextTransform">
@@ -1112,9 +1068,6 @@ void IncrementLabel()
         <ReturnType>Microsoft.Maui.Controls.TextTransform</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TextTransformProperty">
@@ -1132,7 +1085,6 @@ void IncrementLabel()
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.Button.TextTransform" /> bindable property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="UpdateFormsText">
@@ -1155,9 +1107,6 @@ void IncrementLabel()
       <Docs>
         <param name="source">To be added.</param>
         <param name="textTransform">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IBorderElement.BorderColorDefaultValue">
@@ -1178,8 +1127,6 @@ void IncrementLabel()
       </ReturnValue>
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IBorderElement.BorderWidthDefaultValue">
@@ -1200,8 +1147,6 @@ void IncrementLabel()
       </ReturnValue>
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IBorderElement.CornerRadiusDefaultValue">
@@ -1222,8 +1167,6 @@ void IncrementLabel()
       </ReturnValue>
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IBorderElement.IsBackgroundColorSet">
@@ -1245,8 +1188,6 @@ void IncrementLabel()
       <Parameters />
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IBorderElement.IsBackgroundSet">
@@ -1267,9 +1208,6 @@ void IncrementLabel()
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IBorderElement.IsBorderColorSet">
@@ -1291,8 +1229,6 @@ void IncrementLabel()
       <Parameters />
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IBorderElement.IsBorderWidthSet">
@@ -1314,8 +1250,6 @@ void IncrementLabel()
       <Parameters />
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform..</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IBorderElement.IsCornerRadiusSet">
@@ -1337,8 +1271,6 @@ void IncrementLabel()
       <Parameters />
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IBorderElement.OnBorderColorPropertyChanged">
@@ -1365,7 +1297,6 @@ void IncrementLabel()
         <param name="oldValue">To be added.</param>
         <param name="newValue">To be added.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IImageController.GetLoadAsAnimation">
@@ -1386,9 +1317,6 @@ void IncrementLabel()
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IImageController.SetIsLoading">
@@ -1413,7 +1341,6 @@ void IncrementLabel()
       <Docs>
         <param name="isLoading">To be added.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IImageElement.Aspect">
@@ -1434,8 +1361,6 @@ void IncrementLabel()
       </ReturnValue>
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IImageElement.IsAnimationPlaying">
@@ -1455,9 +1380,6 @@ void IncrementLabel()
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IImageElement.IsLoading">
@@ -1477,9 +1399,6 @@ void IncrementLabel()
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IImageElement.IsOpaque">
@@ -1500,8 +1419,6 @@ void IncrementLabel()
       </ReturnValue>
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IImageElement.OnImageSourceSourceChanged">
@@ -1527,8 +1444,6 @@ void IncrementLabel()
       <Docs>
         <param name="sender">To be added.</param>
         <param name="e">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IImageElement.RaiseImageSourcePropertyChanged">
@@ -1550,7 +1465,6 @@ void IncrementLabel()
       <Parameters />
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IImageElement.Source">
@@ -1571,8 +1485,6 @@ void IncrementLabel()
       </ReturnValue>
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.Internals.IFontElement.FontSizeDefaultValueCreator">
@@ -1595,8 +1507,6 @@ void IncrementLabel()
       <Parameters />
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.Internals.IFontElement.OnFontAttributesChanged">
@@ -1624,7 +1534,6 @@ void IncrementLabel()
         <param name="oldValue">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="newValue">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.Internals.IFontElement.OnFontChanged">
@@ -1652,7 +1561,6 @@ void IncrementLabel()
         <param name="oldValue">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="newValue">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.Internals.IFontElement.OnFontFamilyChanged">
@@ -1680,7 +1588,6 @@ void IncrementLabel()
         <param name="oldValue">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="newValue">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.Internals.IFontElement.OnFontSizeChanged">
@@ -1708,7 +1615,6 @@ void IncrementLabel()
         <param name="oldValue">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="newValue">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/ButtonsMask.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/ButtonsMask.xml
@@ -18,7 +18,6 @@
   </Attributes>
   <Docs>
     <summary>Flag values that represent mouse buttons.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Primary">

--- a/src/Controls/docs/Microsoft.Maui.Controls/CarouselLayoutTypeConverter.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/CarouselLayoutTypeConverter.xml
@@ -17,8 +17,6 @@
     </Attribute>
   </Attributes>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -32,8 +30,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ConvertFromInvariantString">
@@ -54,9 +50,6 @@
       </Parameters>
       <Docs>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/CarouselPage.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/CarouselPage.xml
@@ -172,8 +172,6 @@ MainPage = new CarouselPage {
       <Docs>
         <typeparam name="T">To be added.</typeparam>
         <summary>Returns the platform-specific instance of this <see cref="T:Microsoft.Maui.Controls.CarouselPage" />, on which a platform-specific method may be called.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/CarouselView.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/CarouselView.xml
@@ -18,7 +18,6 @@
   </Attributes>
   <Docs>
     <summary>A <see cref="T:Microsoft.Maui.Controls.ItemsView" /> whose scrollable child views 'snap' into place.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -32,8 +31,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="AnimateCurrentItemChanges">
@@ -55,9 +52,6 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="AnimatePositionChanges">
@@ -79,9 +73,6 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CurrentItem">
@@ -98,9 +89,6 @@
         <ReturnType>System.Object</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CurrentItemChanged">
@@ -117,8 +105,6 @@
         <ReturnType>System.EventHandler&lt;Microsoft.Maui.Controls.CurrentItemChangedEventArgs&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CurrentItemChangedCommand">
@@ -135,9 +121,6 @@
         <ReturnType>System.Windows.Input.ICommand</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CurrentItemChangedCommandParameter">
@@ -154,9 +137,6 @@
         <ReturnType>System.Object</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CurrentItemChangedCommandParameterProperty">
@@ -173,8 +153,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CurrentItemChangedCommandProperty">
@@ -191,8 +169,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CurrentItemProperty">
@@ -209,8 +185,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CurrentItemVisualState">
@@ -227,8 +201,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="DefaultItemVisualState">
@@ -245,8 +217,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IndicatorView">
@@ -268,9 +238,6 @@
         <ReturnType>Microsoft.Maui.Controls.IndicatorView</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsBounceEnabled">
@@ -287,9 +254,6 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsBounceEnabledProperty">
@@ -306,8 +270,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsDragging">
@@ -324,9 +286,6 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsDraggingProperty">
@@ -343,8 +302,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsScrollAnimated">
@@ -361,9 +318,6 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsScrollAnimatedProperty">
@@ -380,8 +334,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsScrolling">
@@ -403,9 +355,6 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsSwipeEnabled">
@@ -422,9 +371,6 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsSwipeEnabledProperty">
@@ -441,8 +387,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ItemsLayout">
@@ -464,9 +408,6 @@
         <ReturnType>Microsoft.Maui.Controls.LinearItemsLayout</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ItemsLayoutProperty">
@@ -483,8 +424,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Loop">
@@ -501,9 +440,6 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="LoopProperty">
@@ -520,8 +456,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="NextItemVisualState">
@@ -538,8 +472,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnCurrentItemChanged">
@@ -560,8 +492,6 @@
       </Parameters>
       <Docs>
         <param name="args">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnPositionChanged">
@@ -582,8 +512,6 @@
       </Parameters>
       <Docs>
         <param name="args">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PeekAreaInsets">
@@ -600,9 +528,6 @@
         <ReturnType>Microsoft.Maui.Thickness</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PeekAreaInsetsProperty">
@@ -619,8 +544,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Position">
@@ -637,9 +560,6 @@
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PositionChanged">
@@ -656,8 +576,6 @@
         <ReturnType>System.EventHandler&lt;Microsoft.Maui.Controls.PositionChangedEventArgs&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PositionChangedCommand">
@@ -674,9 +592,6 @@
         <ReturnType>System.Windows.Input.ICommand</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PositionChangedCommandParameter">
@@ -693,9 +608,6 @@
         <ReturnType>System.Object</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PositionChangedCommandParameterProperty">
@@ -712,8 +624,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PositionChangedCommandProperty">
@@ -730,8 +640,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PositionProperty">
@@ -748,8 +656,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PreviousItemVisualState">
@@ -766,8 +672,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetIsDragging">
@@ -793,8 +697,6 @@
       </Parameters>
       <Docs>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="VisibleViews">
@@ -811,9 +713,6 @@
         <ReturnType>System.Collections.ObjectModel.ObservableCollection&lt;Microsoft.Maui.Controls.View&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="VisibleViewsProperty">
@@ -830,8 +729,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/Cell.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/Cell.xml
@@ -206,7 +206,6 @@ Content = new TableView
       <MemberValue>40</MemberValue>
       <Docs>
         <summary>The default height of cells.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Disappearing">
@@ -280,7 +279,6 @@ Content = new TableView
       </ReturnValue>
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="HasContextActions">
@@ -302,8 +300,6 @@ Content = new TableView
       </ReturnValue>
       <Docs>
         <summary>Gets a value that indicates whether the cell has at least one menu item in its <see cref="P:Microsoft.Maui.Controls.Cell.ContextActions" /> list property.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Height">
@@ -346,9 +342,6 @@ Content = new TableView
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsEnabled">
@@ -427,9 +420,6 @@ Content = new TableView
       <Parameters />
       <Docs>
         <typeparam name="T">To be added.</typeparam>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnAppearing">
@@ -479,7 +469,6 @@ Content = new TableView
       <Parameters />
       <Docs>
         <summary>Event that is raised when the binding context is changed.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnDisappearing">
@@ -527,7 +516,6 @@ Content = new TableView
       <Parameters />
       <Docs>
         <summary>Application developers can override this method to do actions when the cell's parent is set.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnPropertyChanging">
@@ -551,7 +539,6 @@ Content = new TableView
       <Docs>
         <param name="propertyName">The name of the property on which to monitor value changes.</param>
         <summary>TApplication developers can override this method to do actions when the property named by <paramref name="propertyName" /> is set.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnTapped">
@@ -634,7 +621,6 @@ Content = new TableView
       <Parameters />
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SendDisappearing">
@@ -662,7 +648,6 @@ Content = new TableView
       <Parameters />
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Tapped">

--- a/src/Controls/docs/Microsoft.Maui.Controls/CheckBox.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/CheckBox.xml
@@ -24,8 +24,6 @@
     </Attribute>
   </Attributes>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -39,8 +37,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ChangeVisualState">
@@ -58,8 +54,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CheckedChanged">
@@ -76,8 +70,6 @@
         <ReturnType>System.EventHandler&lt;Microsoft.Maui.Controls.CheckedChangedEventArgs&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Color">
@@ -94,9 +86,6 @@
         <ReturnType>Microsoft.Maui.Graphics.Color</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ColorProperty">
@@ -113,8 +102,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsChecked">
@@ -131,9 +118,6 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsCheckedProperty">
@@ -150,8 +134,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsCheckedVisualState">
@@ -168,8 +150,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="On&lt;T&gt;">
@@ -198,9 +178,6 @@
       <Parameters />
       <Docs>
         <typeparam name="T">To be added.</typeparam>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IBorderElement.BorderColor">
@@ -220,9 +197,6 @@
         <ReturnType>Microsoft.Maui.Graphics.Color</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IBorderElement.BorderColorDefaultValue">
@@ -242,9 +216,6 @@
         <ReturnType>Microsoft.Maui.Graphics.Color</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IBorderElement.BorderWidth">
@@ -264,9 +235,6 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IBorderElement.BorderWidthDefaultValue">
@@ -286,9 +254,6 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IBorderElement.CornerRadius">
@@ -308,9 +273,6 @@
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IBorderElement.CornerRadiusDefaultValue">
@@ -330,9 +292,6 @@
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IBorderElement.IsBackgroundColorSet">
@@ -353,9 +312,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IBorderElement.IsBackgroundSet">
@@ -376,9 +332,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IBorderElement.IsBorderColorSet">
@@ -399,9 +352,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IBorderElement.IsBorderWidthSet">
@@ -422,9 +372,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IBorderElement.IsCornerRadiusSet">
@@ -445,9 +392,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IBorderElement.OnBorderColorPropertyChanged">
@@ -473,8 +417,6 @@
       <Docs>
         <param name="oldValue">To be added.</param>
         <param name="newValue">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/CheckedChangedEventArgs.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/CheckedChangedEventArgs.xml
@@ -13,7 +13,6 @@
   <Interfaces />
   <Docs>
     <summary>Event Args for <see cref="T:Microsoft.Maui.Controls.CheckBox" />'s <see cref="E:Microsoft.Maui.Controls.CheckBox.CheckedChanged" /> event.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -32,7 +31,6 @@
       <Docs>
         <param name="value">Boolean value indicating whether the <see cref="T:Microsoft.Maui.Controls.CheckBox" /> is checked.</param>
         <summary>Creates a new <see cref="T:Microsoft.Maui.Controls.CheckedChangedEventArgs" /> specifying whether the <see cref="T:Microsoft.Maui.Controls.CheckBox" /> is checked.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Value">
@@ -52,7 +50,6 @@
         <summary>Boolean value indicating whether the <see cref="T:Microsoft.Maui.Controls.CheckBox" /> is checked.</summary>
         <value>
           <see langword="true" /> if checked.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/ChildGestureRecognizer.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/ChildGestureRecognizer.xml
@@ -21,7 +21,6 @@
   </Interfaces>
   <Docs>
     <summary>A gesture recognizer for use as a child of another.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -37,7 +36,6 @@
       <Parameters />
       <Docs>
         <summary>Creates a new <see cref="T:Microsoft.Maui.Controls.ChildGestureRecognizer" /> with default values.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GestureRecognizer">
@@ -57,7 +55,6 @@
       <Docs>
         <summary>Gets or sets the recognizer.</summary>
         <value>The recognizer.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnPropertyChanged">
@@ -86,7 +83,6 @@
       <Docs>
         <param name="propertyName">The property that changed.</param>
         <summary>Method that is called when the recognizer is changed.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PropertyChanged">
@@ -108,7 +104,6 @@
       </ReturnValue>
       <Docs>
         <summary>Event handler for changed properties.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/ClickGestureRecognizer.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/ClickGestureRecognizer.xml
@@ -14,7 +14,6 @@
   <Interfaces />
   <Docs>
     <summary>Recognizer for click gestures.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -30,7 +29,6 @@
       <Parameters />
       <Docs>
         <summary>Creates a new <see cref="T:Microsoft.Maui.Controls.ClickGestureRecognizer" /> with default values.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Buttons">
@@ -71,7 +69,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.ClickGestureRecognizer.Buttons" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Clicked">
@@ -90,7 +87,6 @@
       </ReturnValue>
       <Docs>
         <summary>The event handler for the click gesture, if present.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Command">
@@ -153,7 +149,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.ClickGestureRecognizer.CommandParameter" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CommandProperty">
@@ -172,7 +167,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.ClickGestureRecognizer.Command" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="NumberOfClicksRequired">
@@ -191,8 +185,6 @@
       </ReturnValue>
       <Docs>
         <summary>The number of clicks required to activate the recognizer.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="NumberOfClicksRequiredProperty">
@@ -211,7 +203,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.ClickGestureRecognizer.NumberOfClicksRequired" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SendClicked">

--- a/src/Controls/docs/Microsoft.Maui.Controls/ClickedEventArgs.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/ClickedEventArgs.xml
@@ -14,7 +14,6 @@
   <Interfaces />
   <Docs>
     <summary>Event arguments for a click event.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -36,7 +35,6 @@
         <param name="buttons">The button or buttons that were pressed.</param>
         <param name="commandParameter">The command parameter.</param>
         <summary>Creates a new <see cref="T:Microsoft.Maui.Controls.ClickedEventArgs" /> with the specified values.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Buttons">
@@ -56,7 +54,6 @@
       <Docs>
         <summary>Gets the button or buttons that were pressed.</summary>
         <value>The button or buttons that were pressed.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Parameter">
@@ -76,7 +73,6 @@
       <Docs>
         <summary>Gets the command parameter.</summary>
         <value>The command parameter.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/CollectionView.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/CollectionView.xml
@@ -18,7 +18,6 @@
   </Attributes>
   <Docs>
     <summary>A <see cref="T:Microsoft.Maui.Controls.SelectableItemsView" /> that presents a collection of items.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -32,8 +31,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/ColumnDefinition.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/ColumnDefinition.xml
@@ -57,7 +57,6 @@
       <Parameters />
       <Docs>
         <summary>Creates a new <see cref="T:Microsoft.Maui.Controls.ColumnDefinition" /> object with default values.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SizeChanged">
@@ -85,7 +84,6 @@
       </ReturnValue>
       <Docs>
         <summary>Event that is raised when the size of the column is changed.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Width">
@@ -110,8 +108,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the width of the column.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="WidthProperty">
@@ -136,7 +132,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.ColumnDefinition.Width" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/ColumnDefinitionCollection.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/ColumnDefinitionCollection.xml
@@ -56,7 +56,6 @@
       <Parameters />
       <Docs>
         <summary>Creates a new empty <see cref="T:Microsoft.Maui.Controls.ColumnDefinitionCollection" /> collection.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/ColumnDefinitionCollectionTypeConverter.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/ColumnDefinitionCollectionTypeConverter.xml
@@ -17,8 +17,6 @@
     </Attribute>
   </Attributes>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -32,8 +30,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ConvertFromInvariantString">
@@ -54,9 +50,6 @@
       </Parameters>
       <Docs>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/Command.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/Command.xml
@@ -76,7 +76,6 @@ var button = new Button {
       <Docs>
         <param name="execute">An Action to execute when the Command is executed.</param>
         <summary>Initializes a new instance of the Command class.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -223,7 +222,6 @@ var button = new Button {
       </ReturnValue>
       <Docs>
         <summary>Occurs when the target of the Command should reevaluate whether or not the Command can be executed.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ChangeCanExecute">
@@ -249,7 +247,6 @@ var button = new Button {
       <Parameters />
       <Docs>
         <summary>Send a <see cref="E:System.Windows.Input.ICommand.CanExecuteChanged" /></summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Execute">

--- a/src/Controls/docs/Microsoft.Maui.Controls/CompareStateTrigger.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/CompareStateTrigger.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -27,8 +25,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnAttached">
@@ -46,8 +42,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Property">
@@ -64,9 +58,6 @@
         <ReturnType>System.Object</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PropertyProperty">
@@ -83,8 +74,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Value">
@@ -101,9 +90,6 @@
         <ReturnType>System.Object</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ValueProperty">
@@ -120,8 +106,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/CompressedLayout.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/CompressedLayout.xml
@@ -14,7 +14,6 @@
   <Interfaces />
   <Docs>
     <summary>Contains attached properties for omitting redundant renderers.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="GetHeadlessOffset">
@@ -42,8 +41,6 @@
       <Docs>
         <param name="bindable">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetIsHeadless">
@@ -68,7 +65,6 @@
         <summary>Gets a Boolean value that tells whether layout compression is enabled for <paramref name="bindable" />.</summary>
         <returns>
           <see langword="true" /> if layout compression is enabled for <paramref name="bindable" />. Otherwise, returns <see langword="false" />.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="HeadlessOffsetProperty">
@@ -92,7 +88,6 @@
       </ReturnValue>
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsHeadlessProperty">
@@ -111,7 +106,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the attached property that controls whether compressed layout is enabled.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetIsHeadless">

--- a/src/Controls/docs/Microsoft.Maui.Controls/Condition.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/Condition.xml
@@ -17,7 +17,6 @@
   <Interfaces />
   <Docs>
     <summary>Base class for conditions.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/ConstraintType.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/ConstraintType.xml
@@ -19,7 +19,6 @@
   </Base>
   <Docs>
     <summary>Enumeration specifying whether a constraint is constant, relative to a view, or relative to its parent.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Constant">

--- a/src/Controls/docs/Microsoft.Maui.Controls/ContentPage.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/ContentPage.xml
@@ -78,7 +78,6 @@ namespace ContentPageExample
       <Parameters />
       <Docs>
         <summary>Initializes a new ContentPage instance.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Content">
@@ -104,7 +103,6 @@ namespace ContentPageExample
       <Docs>
         <summary>Gets or sets the view that contains the content of the Page.</summary>
         <value>A <see cref="T:Microsoft.Maui.Controls.View" /> subclass, or <see langword="null" />.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ContentProperty">
@@ -123,7 +121,6 @@ namespace ContentPageExample
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.ContentPage.Content" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnBindingContextChanged">
@@ -143,7 +140,6 @@ namespace ContentPageExample
       <Parameters />
       <Docs>
         <summary>Method that is called when the binding context changes.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/ContentPresenter.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/ContentPresenter.xml
@@ -14,7 +14,6 @@
   <Interfaces />
   <Docs>
     <summary>Layout manager for templated views.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -30,7 +29,6 @@
       <Parameters />
       <Docs>
         <summary>Creates a new empty <see cref="T:Microsoft.Maui.Controls.ContentPresenter" /> with default values</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Content">
@@ -49,8 +47,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the view whose layout is managed by this <see cref="T:Microsoft.Maui.Controls.ContentPresenter" />.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ContentProperty">
@@ -69,7 +65,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.ContentPresenter.Content" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="LayoutChildren">
@@ -98,7 +93,6 @@
         <param name="width">The width of the layout rectangle.</param>
         <param name="height">The height of the layout rectangle.</param>
         <summary>Lays out the children of the <see cref="P:Microsoft.Maui.Controls.ContentPresenter.Content" /> property within the rectangle that is defined by <paramref name="x" />, <paramref name="y" />, <paramref name="widht" />, and <paramref name="height" />.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnSizeRequest">
@@ -131,8 +125,6 @@
         <param name="widthConstraint">The width constraint of the size request.</param>
         <param name="heightConstraint">The width constraint of the size request.</param>
         <summary>Method that is raised when a size request is made.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/ContentPropertyAttribute.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/ContentPropertyAttribute.xml
@@ -70,7 +70,6 @@ This is equivalent to the following, more explicit XAML
       <Docs>
         <param name="name">The name of the property.</param>
         <summary>Initializes a new instance of the ContentPropertyAttribute class.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Name">
@@ -96,7 +95,6 @@ This is equivalent to the following, more explicit XAML
       <Docs>
         <summary>Gets the name of the content property</summary>
         <value>A string representing the name of the content property.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/ContentView.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/ContentView.xml
@@ -112,7 +112,6 @@ MainPage = new ContentPage () {
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.ContentView.Content" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnBindingContextChanged">
@@ -132,7 +131,6 @@ MainPage = new ContentPage () {
       <Parameters />
       <Docs>
         <summary>Method that is called when the binding context changes.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/ControlTemplate.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/ControlTemplate.xml
@@ -14,7 +14,6 @@
   <Interfaces />
   <Docs>
     <summary>Template that specifies a group of styles and effects for controls.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -30,7 +29,6 @@
       <Parameters />
       <Docs>
         <summary>For internal use only.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -48,8 +46,6 @@
       </Parameters>
       <Docs>
         <param name="createTemplate">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -69,7 +65,6 @@
       <Docs>
         <param name="type">The type of control for which to create a template.</param>
         <summary>Creates a new control template for the specified control type.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/CurrentItemChangedEventArgs.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/CurrentItemChangedEventArgs.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="CurrentItem">
@@ -30,9 +28,6 @@
         <ReturnType>System.Object</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PreviousItem">
@@ -49,9 +44,6 @@
         <ReturnType>System.Object</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/DataPackage.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/DataPackage.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -27,8 +25,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Image">
@@ -45,9 +41,6 @@
         <ReturnType>Microsoft.Maui.Controls.ImageSource</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Properties">
@@ -64,9 +57,6 @@
         <ReturnType>Microsoft.Maui.Controls.DataPackagePropertySet</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Text">
@@ -83,9 +73,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="View">
@@ -102,9 +89,6 @@
         <ReturnType>Microsoft.Maui.Controls.DataPackageView</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/DataPackageOperation.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/DataPackageOperation.xml
@@ -16,8 +16,6 @@
     </Attribute>
   </Attributes>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Copy">
@@ -35,7 +33,6 @@
       </ReturnValue>
       <MemberValue>1</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
     <Member MemberName="None">
@@ -53,7 +50,6 @@
       </ReturnValue>
       <MemberValue>0</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/DataPackagePropertySet.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/DataPackagePropertySet.xml
@@ -16,8 +16,6 @@
     </Interface>
   </Interfaces>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -31,8 +29,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Add">
@@ -55,8 +51,6 @@
       <Docs>
         <param name="key">To be added.</param>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ContainsKey">
@@ -77,9 +71,6 @@
       </Parameters>
       <Docs>
         <param name="key">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Count">
@@ -96,9 +87,6 @@
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetEnumerator">
@@ -116,9 +104,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Item">
@@ -139,9 +124,6 @@
       </Parameters>
       <Docs>
         <param name="key">To be added.</param>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Keys">
@@ -158,9 +140,6 @@
         <ReturnType>System.Collections.Generic.IEnumerable&lt;System.String&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="System.Collections.IEnumerable.GetEnumerator">
@@ -181,9 +160,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TryGetValue">
@@ -206,9 +182,6 @@
       <Docs>
         <param name="key">To be added.</param>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Values">
@@ -225,9 +198,6 @@
         <ReturnType>System.Collections.Generic.IEnumerable&lt;System.Object&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/DataPackagePropertySetView.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/DataPackagePropertySetView.xml
@@ -34,8 +34,6 @@
     </Interface>
   </Interfaces>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -53,8 +51,6 @@
       </Parameters>
       <Docs>
         <param name="dataPackagePropertySet">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="_dataPackagePropertySet">
@@ -71,8 +67,6 @@
         <ReturnType>Microsoft.Maui.Controls.DataPackagePropertySet</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ContainsKey">
@@ -96,9 +90,6 @@
       </Parameters>
       <Docs>
         <param name="key">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Count">
@@ -118,9 +109,6 @@
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetEnumerator">
@@ -141,9 +129,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Item">
@@ -167,9 +152,6 @@
       </Parameters>
       <Docs>
         <param name="key">To be added.</param>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Keys">
@@ -189,9 +171,6 @@
         <ReturnType>System.Collections.Generic.IEnumerable&lt;System.String&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="System.Collections.IEnumerable.GetEnumerator">
@@ -212,9 +191,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TryGetValue">
@@ -237,9 +213,6 @@
       <Docs>
         <param name="key">To be added.</param>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Values">
@@ -259,9 +232,6 @@
         <ReturnType>System.Collections.Generic.IEnumerable&lt;System.Object&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/DataPackageView.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/DataPackageView.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="GetImageAsync">
@@ -31,9 +29,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetTextAsync">
@@ -51,9 +46,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Properties">
@@ -70,9 +62,6 @@
         <ReturnType>Microsoft.Maui.Controls.DataPackagePropertySetView</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/DataTemplate.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/DataTemplate.xml
@@ -41,7 +41,6 @@
       <Parameters />
       <Docs>
         <summary>For internal use only.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -68,7 +67,6 @@
       <Docs>
         <param name="loadTemplate">A custom content generator to be called </param>
         <summary>Creates and initializes a new instance of the <see cref="T:Microsoft.Maui.Controls.DataTemplate" /> class.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -95,7 +93,6 @@
       <Docs>
         <param name="type">The type of control for which to create a template.</param>
         <summary>Creates a new <see cref="T:Microsoft.Maui.Controls.DataTemplate" /> for type <paramref name="type" />.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Bindings">
@@ -121,8 +118,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets a dictionary of bindings, indexed by the bound properties.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetBinding">
@@ -154,7 +149,6 @@
         <param name="property">The property to which to bind.</param>
         <param name="binding">The binding to use.</param>
         <summary>Sets the binding for <paramref name="property" />.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetValue">
@@ -186,7 +180,6 @@
         <param name="property">The property to set.</param>
         <param name="value">The new value.</param>
         <summary>Sets the value of <paramref name="property" />.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Values">
@@ -212,8 +205,6 @@
       </ReturnValue>
       <Docs>
         <summary>Returns a dictionary of property values for this <see cref="T:Microsoft.Maui.Controls.DataTemplate" />, indexed by property.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.Internals.IDataTemplateController.Id">
@@ -233,9 +224,6 @@
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.Internals.IDataTemplateController.IdString">
@@ -255,9 +243,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/DataTrigger.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/DataTrigger.xml
@@ -92,7 +92,6 @@
       <Docs>
         <param name="targetType">The type of the object on which the data trigger will be added.</param>
         <summary>Initializes a new <see cref="T:Microsoft.Maui.Controls.DataTrigger" /> instance.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Binding">
@@ -114,8 +113,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the binding whose value will be compared to <see cref="P:Microsoft.Maui.Controls.DataTrigger.Value" /> to determine when to invoke the setters.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Setters">
@@ -137,8 +134,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets the list of <see cref="T:Microsoft.Maui.Controls.Setter" /> objects that will be applied when the binding that is named by the  <see cref="P:Microsoft.Maui.Controls.DataTrigger.Binding" /> property becomes equal to <see cref="P:Microsoft.Maui.Controls.DataTrigger.Value" />.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Value">
@@ -160,8 +155,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the value of the binding, named by the <see cref="P:Microsoft.Maui.Controls.DataTrigger.Binding" /> property, that will cause the setters to be applied.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.Xaml.IValueProvider.ProvideValue">
@@ -190,8 +183,6 @@
       <Docs>
         <param name="serviceProvider">For internal use by the XAML infrastructure.</param>
         <summary>For internal use by the XAML infrastructure.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/DateChangedEventArgs.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/DateChangedEventArgs.xml
@@ -20,7 +20,6 @@
   <Interfaces />
   <Docs>
     <summary>Event arguments for <see cref="E:Microsoft.Maui.Controls.DatePicker.DateSelected" /> event.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -48,7 +47,6 @@
         <param name="oldDate">The old date.</param>
         <param name="newDate">The new date.</param>
         <summary>Creates a new <see cref="T:Microsoft.Maui.Controls.DateChangedEventArgs" /> object that represents a change from <paramref name="oldDate" /> to <paramref name="newDate" />.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="NewDate">
@@ -73,8 +71,6 @@
       </ReturnValue>
       <Docs>
         <summary>The date that the user entered.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OldDate">
@@ -99,8 +95,6 @@
       </ReturnValue>
       <Docs>
         <summary>The date that was on the element at the time that the user selected it.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/DatePicker.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/DatePicker.xml
@@ -99,9 +99,6 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CharacterSpacingProperty">
@@ -118,8 +115,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Date">
@@ -217,8 +212,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets a value that indicates whether the font for the date picker text is bold, italic, or neither.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FontAttributesProperty">
@@ -237,7 +230,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.DatePicker.FontAttributes" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FontFamily">
@@ -256,8 +248,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the font family for the picker text.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FontFamilyProperty">
@@ -276,7 +266,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.DatePicker.FontFamily" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FontSize">
@@ -301,7 +290,6 @@
       <Docs>
         <summary>Gets or sets the size of the font for the text in the picker.</summary>
         <value>A <see langword="double" /> that indicates the size of the font.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FontSizeProperty">
@@ -320,7 +308,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.DatePicker.FontSize" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Format">
@@ -509,8 +496,6 @@
       <Docs>
         <typeparam name="T">To be added.</typeparam>
         <summary>Returns the platform-specific instance of this <see cref="T:Microsoft.Maui.Controls.DatePicker" />, on which a platform-specific method may be called.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TextColor">
@@ -529,8 +514,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the text color for the date picker.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TextColorProperty">
@@ -549,7 +532,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.DatePicker.TextColor" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TextTransform">
@@ -566,9 +548,6 @@
         <ReturnType>Microsoft.Maui.Controls.TextTransform</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TextTransformProperty">
@@ -585,8 +564,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="UpdateFormsText">
@@ -609,9 +586,6 @@
       <Docs>
         <param name="source">To be added.</param>
         <param name="textTransform">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.Internals.IFontElement.FontSizeDefaultValueCreator">
@@ -634,8 +608,6 @@
       <Parameters />
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.Internals.IFontElement.OnFontAttributesChanged">
@@ -663,7 +635,6 @@
         <param name="oldValue">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="newValue">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.Internals.IFontElement.OnFontChanged">
@@ -691,7 +662,6 @@
         <param name="oldValue">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="newValue">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.Internals.IFontElement.OnFontFamilyChanged">
@@ -719,7 +689,6 @@
         <param name="oldValue">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="newValue">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.Internals.IFontElement.OnFontSizeChanged">
@@ -747,7 +716,6 @@
         <param name="oldValue">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="newValue">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/DependencyAttribute.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/DependencyAttribute.xml
@@ -25,7 +25,6 @@
   </Attributes>
   <Docs>
     <summary>An attribute that indicates that the specified type provides a concrete implementation of a needed interface.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -51,7 +50,6 @@
       <Docs>
         <param name="implementorType">The type of the implementor of the dependency.</param>
         <summary>Creates a new <see cref="T:Microsoft.Maui.Controls.DependencyAttribute" /> with default values.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/DependencyService.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/DependencyService.xml
@@ -20,7 +20,6 @@
   <Interfaces />
   <Docs>
     <summary>Static class that provides the <see cref="M:Microsoft.Maui.Controls.DependencyService.Get``1(Microsoft.Maui.Controls.DependencyFetchTarget)" /> factory method for retrieving platform-specific implementations of the specified type T.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Get&lt;T&gt;">
@@ -57,8 +56,6 @@
         <typeparam name="T">The type of object to fetch.</typeparam>
         <param name="fetchTarget">The dependency fetch target.</param>
         <summary>Returns the platform-specific implementation of type <paramref name="T" />.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Register&lt;T&gt;">
@@ -89,7 +86,6 @@
       <Docs>
         <typeparam name="T">The type of object to register.</typeparam>
         <summary>Registers the platform-specific implementation of type T.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Register&lt;T,TImpl&gt;">
@@ -127,7 +123,6 @@
         <typeparam name="T">The type of object to register.</typeparam>
         <typeparam name="TImpl">The implementation to register.</typeparam>
         <summary>Registers the platform-specific implementation of type T.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RegisterSingleton&lt;T&gt;">
@@ -156,8 +151,6 @@
       <Docs>
         <typeparam name="T">To be added.</typeparam>
         <param name="instance">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Resolve&lt;T&gt;">
@@ -189,7 +182,6 @@
         <param name="fallbackFetchTarget">The fetch target to use if fetching initially fails.</param>
         <summary>The method to use to resolve dependencies by type.</summary>
         <returns>The resolved dependency instance.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/DesignMode.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/DesignMode.xml
@@ -35,7 +35,6 @@
         <summary>Indicates whether the application is being run in a previewer.</summary>
         <value>
           <see langword="true" /> if the application is being run in a previewer. <see langword="false" /> if the application is being run on a device or emulator.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/Device.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/Device.xml
@@ -40,7 +40,6 @@
       </ReturnValue>
       <Docs>
         <summary>The string "Android", representing the Android operating system.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="BeginInvokeOnMainThread">
@@ -123,7 +122,6 @@ Device.BeginInvokeOnMainThread (() => {
       <Docs>
         <summary>Returns the current <see cref="T:System.Threading.SynchronizationContext" /> from the main thread.</summary>
         <returns>The current <see cref="T:System.Threading.SynchronizationContext" /> from the main thread.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetNamedSize">
@@ -152,7 +150,6 @@ Device.BeginInvokeOnMainThread (() => {
         <param name="targetElementType">The element type for which to calculate the numeric size.</param>
         <summary>Returns a double that represents the named size for the font that is used on the element on the native platform.</summary>
         <returns>The named size for the font that is used on the element on the native platform.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetNamedSize">
@@ -181,7 +178,6 @@ Device.BeginInvokeOnMainThread (() => {
         <param name="targetElement">The element for which to calculate the numeric size.</param>
         <summary>Returns a double that represents a font size that corresponds to <paramref name="size" /> on <paramref name="targetElement" />.</summary>
         <returns>A double that represents a font size that corresponds to <paramref name="size" /> on <paramref name="targetElement" />.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetNamedSize">
@@ -214,7 +210,6 @@ Device.BeginInvokeOnMainThread (() => {
         <param name="useOldSizes">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <returns>For internal use by the Microsoft.Maui.Controls platform.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GTK">
@@ -233,7 +228,6 @@ Device.BeginInvokeOnMainThread (() => {
       </ReturnValue>
       <Docs>
         <summary>The string "GTK", representing the Linux operating system.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Idiom">
@@ -259,7 +253,6 @@ Device.BeginInvokeOnMainThread (() => {
       <Docs>
         <summary>Gets the kind of device that Microsoft.Maui.Controls is currently working on.</summary>
         <value>A <see cref="T:Microsoft.Maui.Controls.TargetIdiom" /> that represents the device type.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="info">
@@ -283,7 +276,6 @@ Device.BeginInvokeOnMainThread (() => {
       </ReturnValue>
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Info">
@@ -307,8 +299,6 @@ Device.BeginInvokeOnMainThread (() => {
       </ReturnValue>
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="InvokeOnMainThreadAsync">
@@ -330,8 +320,6 @@ Device.BeginInvokeOnMainThread (() => {
       <Docs>
         <param name="action">The Action to invoke</param>
         <summary>Invokes an Action on the device main (UI) thread.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="InvokeOnMainThreadAsync">
@@ -353,8 +341,6 @@ Device.BeginInvokeOnMainThread (() => {
       <Docs>
         <param name="funcTask">The Func to invoke.</param>
         <summary>Invokes a Func on the device main (UI) thread.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="InvokeOnMainThreadAsync&lt;T&gt;">
@@ -380,8 +366,6 @@ Device.BeginInvokeOnMainThread (() => {
         <typeparam name="T">The return type of the Func.</typeparam>
         <param name="funcTask">The Func to invoke.</param>
         <summary>Invokes a Func on the device main (UI) thread.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="InvokeOnMainThreadAsync&lt;T&gt;">
@@ -407,8 +391,6 @@ Device.BeginInvokeOnMainThread (() => {
         <typeparam name="T">The return type of the Func.</typeparam>
         <param name="func">The Func to invoke.</param>
         <summary>Invokes a Func on the device main (UI) thread.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="iOS">
@@ -427,7 +409,6 @@ Device.BeginInvokeOnMainThread (() => {
       </ReturnValue>
       <Docs>
         <summary>The string "iOS", representing the iOS operating system.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsInvokeRequired">
@@ -451,8 +432,6 @@ Device.BeginInvokeOnMainThread (() => {
       </ReturnValue>
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="macOS">
@@ -471,7 +450,6 @@ Device.BeginInvokeOnMainThread (() => {
       </ReturnValue>
       <Docs>
         <summary>The string "macOS", representing the macOS operating system.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnPlatform">
@@ -644,7 +622,6 @@ button.HeightRequest = Device.OnPlatform (20,30,30);
       <Docs>
         <summary>Gets the <see cref="T:Microsoft.Maui.Controls.TargetPlatform" /> indicating the OS Microsoft.Maui.Controls is working on.</summary>
         <value>A <see cref="T:Microsoft.Maui.Controls.TargetPlatform" /> that indicates the current OS.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PlatformServices">
@@ -668,8 +645,6 @@ button.HeightRequest = Device.OnPlatform (20,30,30);
       </ReturnValue>
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RuntimePlatform">
@@ -688,8 +663,6 @@ button.HeightRequest = Device.OnPlatform (20,30,30);
       </ReturnValue>
       <Docs>
         <summary>Gets the kind of device that Microsoft.Maui.Controls is currently working on.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="StartTimer">
@@ -755,7 +728,6 @@ Device.StartTimer (new TimeSpan (0, 0, 60), () =>
       </ReturnValue>
       <Docs>
         <summary>The string "Tizen", representing the Tizen operating system.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="UWP">
@@ -774,7 +746,6 @@ Device.StartTimer (new TimeSpan (0, 0, 60), () =>
       </ReturnValue>
       <Docs>
         <summary>The string "UWP", representing the UWP operating system.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="WPF">
@@ -793,7 +764,6 @@ Device.StartTimer (new TimeSpan (0, 0, 60), () =>
       </ReturnValue>
       <Docs>
         <summary>The string "WPF", representing the Windows Presentation Foundation framework.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/DeviceStateTrigger.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/DeviceStateTrigger.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -27,8 +25,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Device">
@@ -45,9 +41,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="DeviceProperty">
@@ -64,8 +57,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/DoubleCollection.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/DoubleCollection.xml
@@ -20,8 +20,6 @@
     </Attribute>
   </Attributes>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -35,8 +33,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/DoubleCollectionConverter.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/DoubleCollectionConverter.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -27,8 +25,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ConvertFromInvariantString">
@@ -49,9 +45,6 @@
       </Parameters>
       <Docs>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/DropCompletedEventArgs.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/DropCompletedEventArgs.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -27,8 +25,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/DropGestureRecognizer.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/DropGestureRecognizer.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -27,8 +25,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="AllowDrop">
@@ -45,9 +41,6 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="AllowDropProperty">
@@ -64,8 +57,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="DragLeave">
@@ -82,8 +73,6 @@
         <ReturnType>System.EventHandler&lt;Microsoft.Maui.Controls.DragEventArgs&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="DragLeaveCommand">
@@ -100,9 +89,6 @@
         <ReturnType>System.Windows.Input.ICommand</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="DragLeaveCommandParameter">
@@ -119,9 +105,6 @@
         <ReturnType>System.Object</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="DragLeaveCommandParameterProperty">
@@ -138,8 +121,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="DragLeaveCommandProperty">
@@ -156,8 +137,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="DragOver">
@@ -174,8 +153,6 @@
         <ReturnType>System.EventHandler&lt;Microsoft.Maui.Controls.DragEventArgs&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="DragOverCommand">
@@ -192,9 +169,6 @@
         <ReturnType>System.Windows.Input.ICommand</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="DragOverCommandParameter">
@@ -211,9 +185,6 @@
         <ReturnType>System.Object</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="DragOverCommandParameterProperty">
@@ -230,8 +201,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="DragOverCommandProperty">
@@ -248,8 +217,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Drop">
@@ -266,8 +233,6 @@
         <ReturnType>System.EventHandler&lt;Microsoft.Maui.Controls.DropEventArgs&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="DropCommand">
@@ -284,9 +249,6 @@
         <ReturnType>System.Windows.Input.ICommand</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="DropCommandParameter">
@@ -303,9 +265,6 @@
         <ReturnType>System.Object</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="DropCommandParameterProperty">
@@ -322,8 +281,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="DropCommandProperty">
@@ -340,8 +297,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SendDragLeave">
@@ -367,8 +322,6 @@
       </Parameters>
       <Docs>
         <param name="args">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SendDragOver">
@@ -394,8 +347,6 @@
       </Parameters>
       <Docs>
         <param name="args">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SendDrop">
@@ -421,9 +372,6 @@
       </Parameters>
       <Docs>
         <param name="args">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/EasingTypeConverter.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/EasingTypeConverter.xml
@@ -17,8 +17,6 @@
     </Attribute>
   </Attributes>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -32,8 +30,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ConvertFromInvariantString">
@@ -54,9 +50,6 @@
       </Parameters>
       <Docs>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/Editor.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/Editor.xml
@@ -122,7 +122,6 @@ var editor = new Editor {
       </ReturnValue>
       <Docs>
         <summary>Backing store for the property that controls whether the editor will change size to accommodate input as the user enters it.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CharacterSpacingProperty">
@@ -139,8 +138,6 @@ var editor = new Editor {
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Completed">
@@ -183,8 +180,6 @@ var editor = new Editor {
       </ReturnValue>
       <Docs>
         <summary>Gets a value that indicates whether the font for the editor is bold, italic, or neither.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FontAttributesProperty">
@@ -204,7 +199,6 @@ var editor = new Editor {
       </ReturnValue>
       <Docs>
         <summary>Backing store for the FontAttributes property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FontFamily">
@@ -224,8 +218,6 @@ var editor = new Editor {
       </ReturnValue>
       <Docs>
         <summary>Gets the font family to which the font for the editor belongs.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FontFamilyProperty">
@@ -245,7 +237,6 @@ var editor = new Editor {
       </ReturnValue>
       <Docs>
         <summary>Backing store for the FontFamily property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FontSize">
@@ -270,8 +261,6 @@ var editor = new Editor {
       </ReturnValue>
       <Docs>
         <summary>Gets the size of the font for the editor.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FontSizeProperty">
@@ -291,7 +280,6 @@ var editor = new Editor {
       </ReturnValue>
       <Docs>
         <summary>Backing store for the FontSize property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsTextPredictionEnabled">
@@ -308,9 +296,6 @@ var editor = new Editor {
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsTextPredictionEnabledProperty">
@@ -328,7 +313,6 @@ var editor = new Editor {
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.Editor.IsTextPredictionEnabled" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="On&lt;T&gt;">
@@ -359,8 +343,6 @@ var editor = new Editor {
       <Docs>
         <typeparam name="T">To be added.</typeparam>
         <summary>Returns the platform-specific instance of this <see cref="T:Microsoft.Maui.Controls.Editor" />, on which a platform-specific method may be called.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnTextChanged">
@@ -383,8 +365,6 @@ var editor = new Editor {
       <Docs>
         <param name="oldValue">To be added.</param>
         <param name="newValue">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PlaceholderColorProperty">
@@ -403,7 +383,6 @@ var editor = new Editor {
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.InputView.PlaceholderColor" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PlaceholderProperty">
@@ -422,7 +401,6 @@ var editor = new Editor {
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.InputView.Placeholder" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SendCompleted">
@@ -450,7 +428,6 @@ var editor = new Editor {
       <Parameters />
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TextColorProperty">
@@ -470,7 +447,6 @@ var editor = new Editor {
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.InputView.TextColor" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TextProperty">
@@ -516,7 +492,6 @@ var editor = new Editor {
       <Parameters />
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.Internals.IFontElement.FontSizeDefaultValueCreator">
@@ -539,8 +514,6 @@ var editor = new Editor {
       <Parameters />
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.Internals.IFontElement.OnFontAttributesChanged">
@@ -568,7 +541,6 @@ var editor = new Editor {
         <param name="oldValue">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="newValue">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.Internals.IFontElement.OnFontChanged">
@@ -596,7 +568,6 @@ var editor = new Editor {
         <param name="oldValue">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="newValue">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.Internals.IFontElement.OnFontFamilyChanged">
@@ -624,7 +595,6 @@ var editor = new Editor {
         <param name="oldValue">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="newValue">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.Internals.IFontElement.OnFontSizeChanged">
@@ -652,7 +622,6 @@ var editor = new Editor {
         <param name="oldValue">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="newValue">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/EditorAutoSizeOption.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/EditorAutoSizeOption.xml
@@ -13,7 +13,6 @@
   </Base>
   <Docs>
     <summary>Enumerates values that control whether an editor will change size to accommodate input as the user enters it.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Disabled">

--- a/src/Controls/docs/Microsoft.Maui.Controls/Effect.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/Effect.xml
@@ -36,7 +36,6 @@
       <Docs>
         <summary>Gets the element to which the style is attached.</summary>
         <value>The <see cref="T:Microsoft.Maui.Controls.Element" /> to which the property is attached, if the property is attached. Otherwise, <see langword="null" />.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsAttached">
@@ -55,8 +54,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets a value that tells whether the effect is attached to an element.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnAttached">
@@ -76,7 +73,6 @@
       <Parameters />
       <Docs>
         <summary>Method that is called after the effect is attached and made valid.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnDetached">
@@ -96,7 +92,6 @@
       <Parameters />
       <Docs>
         <summary>Method that is called after the effect is detached and invalidated.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Resolve">

--- a/src/Controls/docs/Microsoft.Maui.Controls/EffectiveFlowDirectionExtensions.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/EffectiveFlowDirectionExtensions.xml
@@ -19,7 +19,6 @@
   </Attributes>
   <Docs>
     <summary>Extension methods for finding out the flow direction and whether it was explicitly set.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="IsExplicit">
@@ -44,7 +43,6 @@
         <summary>Returns <see langword="true" /> if the developer set the flow direction on the current object. Returns <see langword="false" /> if the flow direction is inherited or was not set by the developer.</summary>
         <returns>
           <see langword="true" /> if the developer set the flow direction on the current object, or <see langword="false" /> if the flow direction is inherited or was not set by the developer.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsImplicit">
@@ -69,7 +67,6 @@
         <summary>Returns <see langword="false" /> if the developer set the flow direction on the current object. Returns <see langword="true" /> if the flow direction is inherited or was not set by the developer.</summary>
         <returns>
           <see langword="false" /> if the developer set the flow direction on the current object, or <see langword="true" /> if the flow direction is inherited or was not set by the developer.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsLeftToRight">
@@ -94,7 +91,6 @@
         <summary>Returns <see langword="true" /> if the flow direction is left-to-right. Otherwise, returns <see langword="false" />.</summary>
         <returns>
           <see langword="true" /> if the flow direction is left-to-right. Otherwise, <see langword="false" />.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsRightToLeft">
@@ -119,7 +115,6 @@
         <summary>Returns <see langword="true" /> if the flow direction is right-to-left. Otherwise, returns <see langword="false" />.</summary>
         <returns>
           <see langword="true" /> if the flow direction is right-to-left. Otherwise, <see langword="false" />.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/EffectiveVisualExtensions.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/EffectiveVisualExtensions.xml
@@ -17,8 +17,6 @@
     </Attribute>
   </Attributes>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="IsDefault">
@@ -39,9 +37,6 @@
       </Parameters>
       <Docs>
         <param name="visual">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsMatchParent">
@@ -62,9 +57,6 @@
       </Parameters>
       <Docs>
         <param name="visual">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsMaterial">
@@ -85,9 +77,6 @@
       </Parameters>
       <Docs>
         <param name="visual">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/ElementEventArgs.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/ElementEventArgs.xml
@@ -51,7 +51,6 @@
       <Docs>
         <param name="element">The element relevant to the event.</param>
         <summary>Constructs and initializes a new instance of the <see cref="T:Microsoft.Maui.Controls.ElementEventArgs" /> class.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Element">
@@ -77,7 +76,6 @@
       <Docs>
         <summary>Gets the element relevant to the event.</summary>
         <value>The element relevant to the event.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/ElementTemplate.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/ElementTemplate.xml
@@ -18,7 +18,6 @@
   </Interfaces>
   <Docs>
     <summary>Base class for <see cref="T:Microsoft.Maui.Controls.DataTemplate" /> and <see cref="T:Microsoft.Maui.Controls.ControlTemplate" /> classes.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="CreateContent">
@@ -38,8 +37,6 @@
       <Parameters />
       <Docs>
         <summary>Used by the XAML infrastructure to load data templates and set up the content of the resulting UI.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.Internals.IDataTemplate.LoadTemplate">
@@ -61,8 +58,6 @@
       </ReturnValue>
       <Docs>
         <summary>For internal use only.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/EntryCell.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/EntryCell.xml
@@ -146,8 +146,6 @@ namespace FormsGallery
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the horizontal alignement of the Text property. This is a bindable property.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="HorizontalTextAlignmentProperty">
@@ -167,7 +165,6 @@ namespace FormsGallery
       </ReturnValue>
       <Docs>
         <summary>Identifies the HorizontalTextAlignment bindable property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Keyboard">
@@ -408,7 +405,6 @@ namespace FormsGallery
       <Parameters />
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Text">
@@ -479,9 +475,6 @@ namespace FormsGallery
         <ReturnType>Microsoft.Maui.TextAlignment</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="VerticalTextAlignmentProperty">
@@ -498,8 +491,6 @@ namespace FormsGallery
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="XAlign">

--- a/src/Controls/docs/Microsoft.Maui.Controls/EventTrigger.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/EventTrigger.xml
@@ -86,7 +86,6 @@
       <Parameters />
       <Docs>
         <summary>Creates a new <see cref="T:Microsoft.Maui.Controls.EventTrigger" /> instance.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Actions">
@@ -110,7 +109,6 @@
         <summary>Gets the list of <see cref="T:Microsoft.Maui.Controls.TriggerAction" /> objects that will be invoked when the event that is identified by the <see cref="P:Microsoft.Maui.Controls.EventTrigger.Event" /> property is raised.</summary>
         <value>
         </value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Event">
@@ -134,7 +132,6 @@
         <summary>Gets or sets the name of the event that will cause the actions that are contained in the <see cref="P:Microsoft.Maui.Controls.EventTrigger.Actions" /> to be invoked.</summary>
         <value>
         </value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/ExportFontAttribute.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/ExportFontAttribute.xml
@@ -20,8 +20,6 @@
     </Attribute>
   </Attributes>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -39,8 +37,6 @@
       </Parameters>
       <Docs>
         <param name="fontFileName">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Alias">
@@ -57,9 +53,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FontFileName">
@@ -76,9 +69,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/FileImageSource.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/FileImageSource.xml
@@ -25,7 +25,6 @@
   </Attributes>
   <Docs>
     <summary>An <see cref="T:Microsoft.Maui.Controls.ImageSource" /> that reads an image from a file.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -47,7 +46,6 @@
       <Parameters />
       <Docs>
         <summary>Creates a new <see cref="T:Microsoft.Maui.Controls.FileImageSource" /> object with default values.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Cancel">
@@ -99,8 +97,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the file from which this <see cref="T:Microsoft.Maui.Controls.FileImageSource" /> will load an image.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FileProperty">
@@ -125,7 +121,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="T:Microsoft.Maui.Controls.FileImageSource.File" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsEmpty">
@@ -145,7 +140,6 @@
         <summary>Indicates whether the <see cref="P:Microsoft.Maui.Controls.FileImageSource.File" /> property is null or empty.</summary>
         <value>
           <see langword="true" /> if null or empty.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnPropertyChanged">
@@ -174,7 +168,6 @@
       <Docs>
         <param name="propertyName">To be added.</param>
         <summary>Method that is called when the property that is specified by <paramref name="propertyName" /> is changed.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="op_Implicit">
@@ -201,8 +194,6 @@
       <Docs>
         <param name="file">To be added.</param>
         <summary>Allows implicit casting from a string.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="op_Implicit">
@@ -229,8 +220,6 @@
       <Docs>
         <param name="file">To be added.</param>
         <summary>Allows implicit casting to a string.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ToString">
@@ -250,8 +239,6 @@
       <Parameters />
       <Docs>
         <summary>Returns the path to the file for the image, prefixed with the string, "File: ".</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/FileImageSourceConverter.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/FileImageSourceConverter.xml
@@ -20,7 +20,6 @@
   </Attributes>
   <Docs>
     <summary>A <see cref="T:System.ComponentModel.TypeConverter" /> that converts to <see cref="T:Microsoft.Maui.Controls.FileImageSource" />.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -37,7 +36,6 @@
       <Parameters />
       <Docs>
         <summary>Creates a new <see cref="T:Microsoft.Maui.Controls.FileImageSource" /> with default values.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ConvertFromInvariantString">
@@ -60,8 +58,6 @@
       <Docs>
         <param name="value">The value to convert.</param>
         <summary>Creates a file image source given a path to an image.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/FlexLayout.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/FlexLayout.xml
@@ -38,7 +38,6 @@
       <Parameters />
       <Docs>
         <summary>Creates a new <see cref="T:Microsoft.Maui.Controls.FlexLayout" /> with default values.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="AlignContent">
@@ -57,7 +56,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets a value that controls how multiple rows or columns of child elements are aligned.</summary>
-        <value>To be added.</value>
         <remarks>
           <para>This property behaves similarly to <see cref="P:Microsoft.Maui.Controls.FlexLayout.AlignItems" />, but applies to how entire rows or columns are aligned, not individual elements. The below image illustrates three different <see cref="P:Microsoft.Maui.Controls.FlexLayout.AlignContent" /> values working on wrapped rows. The iOS screenshot shows <see cref="F:Microsoft.Maui.Layouts.FlexAlignContent.SpaceBetween" />, the Android screenshot shows <see cref="F:Microsoft.Maui.Layouts.FlexAlignContent.SpaceAround" />, and the UWP screenshot shows <see cref="F:Microsoft.Maui.Layouts.FlexAlignContent.SpaceEvenly" />.</para>
           <para>
@@ -82,7 +80,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.FlexLayout.AlignContent" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="AlignItems">
@@ -126,7 +123,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.FlexLayout.AlignItems" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="AlignSelfProperty">
@@ -145,7 +141,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the attached property that optionally overrides the item alignment for this child within its row or column in the parent.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="BasisProperty">
@@ -164,7 +159,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the attached property that contains information about this element's relative or absolute basis.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Direction">
@@ -208,7 +202,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.FlexLayout.Direction" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetAlignSelf">
@@ -232,7 +225,6 @@
         <param name="bindable">The object for which to retrieve the property value.</param>
         <summary>Returns the value that optionally overrides the item alignment for this child within its row or column in the parent.</summary>
         <returns>The value that optionally overrides the item alignment for this child within its row or column in the parent.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetBasis">
@@ -256,7 +248,6 @@
         <param name="bindable">The object for which to retrieve the property value.</param>
         <summary>Returns the value that describes this element's relative or absolute basis length.</summary>
         <returns>The value that describes this element's relative or absolute basis length.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetGrow">
@@ -280,7 +271,6 @@
         <param name="bindable">The object for which to retrieve the property value.</param>
         <summary>Returns the value that determines the proportional growth that this element will accept to acccommodate the layout in the row or column.</summary>
         <returns>The value that determines the proportional growth that this element will accept to acccommodate the layout in the row or column.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetOrder">
@@ -304,7 +294,6 @@
         <param name="bindable">The object for which to retrieve the property value.</param>
         <summary>Returns the visual order of the element among its siblings.</summary>
         <returns>The visual order of the element among its siblings.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetShrink">
@@ -328,7 +317,6 @@
         <param name="bindable">The object for which to retrieve the property value.</param>
         <summary>Returns the value that determines the proportional reduction in size that this element will accept to acccommodate the layout in the row or column.</summary>
         <returns>The proportional reduction in size that this element will accept to acccommodate the layout in the row or column.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GrowProperty">
@@ -347,7 +335,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the attached property that determines the proportional growth that this element will accept to acccommodate the layout in the row or column.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="JustifyContent">
@@ -391,7 +378,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.FlexLayout.JustifyContent" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="LayoutChildren">
@@ -420,7 +406,6 @@
         <param name="width">The width of the rectangle.</param>
         <param name="height">The height of the rectangle.</param>
         <summary>Lays out the <see cref="P:Microsoft.Maui.Controls.Layout.Children" /> in the specified rectangle.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnAdded">
@@ -443,7 +428,6 @@
       <Docs>
         <param name="view">The view to which the layout was added.</param>
         <summary>Method that is called when the flex layout is added to a view.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnMeasure">
@@ -468,8 +452,6 @@
         <param name="widthConstraint">The width constraint.</param>
         <param name="heightConstraint">The height constraint.</param>
         <summary>Method that is called to request that the layout measure its child elements.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnParentSet">
@@ -489,7 +471,6 @@
       <Parameters />
       <Docs>
         <summary>Method that is called when the layout's parent is set.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnRemoved">
@@ -512,7 +493,6 @@
       <Docs>
         <param name="view">The view from which the layout was removed.</param>
         <summary>Method that is called when the layout is removed from a view.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OrderProperty">
@@ -531,7 +511,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the attached property that determines this element's visual order among its siblings.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Position">
@@ -551,7 +530,6 @@
       <Docs>
         <summary>Gets or sets a value that controls whether the coordinates of child elements are specified in absolute or relative terms.</summary>
         <value>A value that controls whether the coordinates of child elements are specified in absolute or relative terms.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PositionProperty">
@@ -570,7 +548,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.FlexLayout.Position" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetAlignSelf">
@@ -625,7 +602,6 @@
         <param name="bindable">The object for which to retrieve the property value.</param>
         <param name="value">The new flex basis value.</param>
         <summary>Sets the value that describes this element's relative or absolute basis length.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetGrow">
@@ -650,7 +626,6 @@
         <param name="bindable">The object for which to retrieve the property value.</param>
         <param name="value">The new flex growth value.</param>
         <summary>Sets the value that determines the proportional growth that this element will accept to acccommodate the layout in the row or column.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetOrder">
@@ -706,7 +681,6 @@
         <param name="bindable">The object for which to retrieve the property value.</param>
         <param name="value">The new flex shrink value.</param>
         <summary>Sets the value that determines the proportional reduction in size that this element will accept to acccommodate the layout in the row or column.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ShrinkProperty">
@@ -725,7 +699,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the attached property that determines the proportional reduction in size that this element will accept to acccommodate the layout in the row or column.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Wrap">
@@ -745,7 +718,6 @@
       <Docs>
         <summary>Gets or sets a value that controls whether and how child elements within this layout wrap.</summary>
         <value>A value that controls whether and how child elements within this layout wrap.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="WrapProperty">
@@ -764,7 +736,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.FlexLayout.Wrap" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/FlyoutDisplayOptions.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/FlyoutDisplayOptions.xml
@@ -12,7 +12,6 @@
   </Base>
   <Docs>
     <summary>Enumerates display modes for the flyout in a Shell appication.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="AsMultipleItems">
@@ -30,7 +29,6 @@
       </ReturnValue>
       <MemberValue>1</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
     <Member MemberName="AsSingleItem">
@@ -48,7 +46,6 @@
       </ReturnValue>
       <MemberValue>0</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/FlyoutHeaderBehavior.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/FlyoutHeaderBehavior.xml
@@ -12,7 +12,6 @@
   </Base>
   <Docs>
     <summary>Enumeration of modes followed by the <see cref="P:Microsoft.Maui.Controls.Shell.FlyoutHeader" />.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="CollapseOnScroll">
@@ -66,7 +65,6 @@
       </ReturnValue>
       <MemberValue>1</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
     <Member MemberName="Scroll">
@@ -84,7 +82,6 @@
       </ReturnValue>
       <MemberValue>2</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/FlyoutItem.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/FlyoutItem.xml
@@ -18,7 +18,6 @@
   </Attributes>
   <Docs>
     <summary>A <see cref="T:Microsoft.Maui.Controls.ShellItem" /> that has a collection of <see cref="T:Microsoft.Maui.Controls.Tab" /> objects.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -32,8 +31,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetIsVisible">
@@ -54,9 +51,6 @@
       </Parameters>
       <Docs>
         <param name="obj">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ImageStyle">
@@ -74,7 +68,6 @@
       </ReturnValue>
       <Docs>
         <summary>StyleClass set on the Image of each Flyout Item. This const is set to "FlyoutItemImageStyle".</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsVisibleProperty">
@@ -91,8 +84,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="LabelStyle">
@@ -110,7 +101,6 @@
       </ReturnValue>
       <Docs>
         <summary>StyleClass set on the Label of each Flyout Item. This const is set to "FlyoutItemLabelStyle".</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="LayoutStyle">
@@ -128,7 +118,6 @@
       </ReturnValue>
       <Docs>
         <summary>StyleClass set on the Label of every Flyout Item. This const is set to "FlyoutItemLayoutStyle".</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetIsVisible">
@@ -151,8 +140,6 @@
       <Docs>
         <param name="obj">To be added.</param>
         <param name="isVisible">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/FlyoutLayoutBehavior.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/FlyoutLayoutBehavior.xml
@@ -11,8 +11,6 @@
     <BaseTypeName>System.Enum</BaseTypeName>
   </Base>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Default">
@@ -30,7 +28,6 @@
       </ReturnValue>
       <MemberValue>0</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
     <Member MemberName="Popover">
@@ -48,7 +45,6 @@
       </ReturnValue>
       <MemberValue>3</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
     <Member MemberName="Split">
@@ -66,7 +62,6 @@
       </ReturnValue>
       <MemberValue>2</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
     <Member MemberName="SplitOnLandscape">
@@ -84,7 +79,6 @@
       </ReturnValue>
       <MemberValue>1</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
     <Member MemberName="SplitOnPortrait">
@@ -102,7 +96,6 @@
       </ReturnValue>
       <MemberValue>4</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/FlyoutPage.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/FlyoutPage.xml
@@ -24,8 +24,6 @@
     </Attribute>
   </Attributes>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -39,8 +37,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="BackButtonPressed">
@@ -65,8 +61,6 @@
         <ReturnType>System.EventHandler&lt;Microsoft.Maui.Controls.BackButtonPressedEventArgs&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CanChangeIsPresented">
@@ -91,9 +85,6 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Detail">
@@ -110,9 +101,6 @@
         <ReturnType>Microsoft.Maui.Controls.Page</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="DetailBounds">
@@ -137,9 +125,6 @@
         <ReturnType>Microsoft.Maui.Controls.Shapes.Rectangle</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Flyout">
@@ -156,9 +141,6 @@
         <ReturnType>Microsoft.Maui.Controls.Page</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FlyoutBounds">
@@ -183,9 +165,6 @@
         <ReturnType>Microsoft.Maui.Controls.Shapes.Rectangle</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FlyoutLayoutBehavior">
@@ -202,9 +181,6 @@
         <ReturnType>Microsoft.Maui.Controls.FlyoutLayoutBehavior</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FlyoutLayoutBehaviorProperty">
@@ -221,8 +197,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsGestureEnabled">
@@ -239,9 +213,6 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsGestureEnabledProperty">
@@ -258,8 +229,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsPresented">
@@ -276,9 +245,6 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsPresentedChanged">
@@ -295,8 +261,6 @@
         <ReturnType>System.EventHandler</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsPresentedProperty">
@@ -313,8 +277,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="LayoutChildren">
@@ -341,8 +303,6 @@
         <param name="y">To be added.</param>
         <param name="width">To be added.</param>
         <param name="height">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="On&lt;T&gt;">
@@ -371,9 +331,6 @@
       <Parameters />
       <Docs>
         <typeparam name="T">To be added.</typeparam>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnAppearing">
@@ -391,8 +348,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnBackButtonPressed">
@@ -410,9 +365,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnParentSet">
@@ -430,8 +382,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ShouldShowSplitMode">
@@ -456,9 +406,6 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ShouldShowToolbarButton">
@@ -476,9 +423,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="UpdateFlyoutLayoutBehavior">
@@ -504,8 +448,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/FocusEventArgs.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/FocusEventArgs.xml
@@ -49,7 +49,6 @@
         <param name="visualElement">The <see cref="T:Microsoft.Maui.Controls.VisualElement" /> whose focused was changed.</param>
         <param name="isFocused">Whether or not the <paramref name="visualElement" /> was focused.</param>
         <summary>Constructs and initializes a new instance of the <see cref="T:Microsoft.Maui.Controls.FocusEventArgs" /> class.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsFocused">
@@ -76,7 +75,6 @@
         <summary>Gets whether or not the <see cref="P:Microsoft.Maui.Controls.FocusEventArgs.VisualElement" /> was focused.</summary>
         <value>
           <see langword="true" /> if the view was focused, <see langword="false" /> otherwise.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="VisualElement">
@@ -102,7 +100,6 @@
       <Docs>
         <summary>Gets the <see cref="T:Microsoft.Maui.Controls.VisualElement" /> who's focused was changed.</summary>
         <value>The <see cref="T:Microsoft.Maui.Controls.VisualElement" /> who's focused was changed.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/FontAttributes.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/FontAttributes.xml
@@ -25,7 +25,6 @@
   </Attributes>
   <Docs>
     <summary>Enumerates values that describe font styles.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Bold">

--- a/src/Controls/docs/Microsoft.Maui.Controls/FontAttributesConverter.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/FontAttributesConverter.xml
@@ -18,7 +18,6 @@
   </Attributes>
   <Docs>
     <summary>Converts a string into a <see cref="T:Microsoft.Maui.Controls.FontAttributes" /> object.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -32,8 +31,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ConvertFromInvariantString">
@@ -54,9 +51,6 @@
       </Parameters>
       <Docs>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/FontImageSource.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/FontImageSource.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -27,8 +25,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Color">
@@ -45,9 +41,6 @@
         <ReturnType>Microsoft.Maui.Graphics.Color</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ColorProperty">
@@ -65,7 +58,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.FontImageSource.Color" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FontFamily">
@@ -82,9 +74,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FontFamilyProperty">
@@ -102,7 +91,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.FontImageSource.FontFamily" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Glyph">
@@ -119,9 +107,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GlyphProperty">
@@ -139,7 +124,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.FontImageSource.Glyph" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsEmpty">
@@ -157,8 +141,6 @@
       </ReturnValue>
       <Docs>
         <summary>Indicates whether the <see cref="P:Microsoft.Maui.Controls.FontImageSource" /> property is null or empty.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Size">
@@ -180,9 +162,6 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SizeProperty">
@@ -200,7 +179,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.FontImageSource.Size" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/FontSizeConverter.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/FontSizeConverter.xml
@@ -26,7 +26,6 @@
   </Attributes>
   <Docs>
     <summary>Converts a string into a font size.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -45,7 +44,6 @@
       <Parameters />
       <Docs>
         <summary>Initializes a new <see cref="T:Microsoft.Maui.Controls.FontSizeConverter" /> object.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ConvertFromInvariantString">
@@ -68,8 +66,6 @@
       <Docs>
         <param name="value">The value to convert.</param>
         <summary>Converts a string representation of a font size into a font size.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IExtendedTypeConverter.ConvertFrom">
@@ -109,8 +105,6 @@
         <param name="value">For internal use only.</param>
         <param name="serviceProvider">For internal use only.</param>
         <summary>For internal use only.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IExtendedTypeConverter.ConvertFromInvariantString">
@@ -138,8 +132,6 @@
         <param name="value">For internal use only.</param>
         <param name="serviceProvider">For internal use only.</param>
         <summary>For internal use only.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/FontTypeConverter.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/FontTypeConverter.xml
@@ -47,7 +47,6 @@
       <Parameters />
       <Docs>
         <summary>Creates a new <see cref="T:Microsoft.Maui.Controls.FontTypeConverter" /> with default values.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ConvertFromInvariantString">
@@ -70,8 +69,6 @@
       <Docs>
         <param name="value">The value to convert.</param>
         <summary>Converts <paramref name="value" /> into a <see cref="T:Microsoft.Maui.Controls.Font" />.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/FormattedString.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/FormattedString.xml
@@ -45,7 +45,6 @@
       <Parameters />
       <Docs>
         <summary>Initializes a new instance of the FormattedString class.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnBindingContextChanged">
@@ -65,7 +64,6 @@
       <Parameters />
       <Docs>
         <summary>Method that is called when the binding context is changed.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="op_Explicit">
@@ -92,8 +90,6 @@
       <Docs>
         <param name="formatted">The formatted string to cast.</param>
         <summary>Cast the FormattedString to a string, stripping all the attributes.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="op_Implicit">
@@ -120,8 +116,6 @@
       <Docs>
         <param name="text">The text to cast.</param>
         <summary>Cast a string to a FormattedString that contains a single span with no attribute set.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Spans">
@@ -144,8 +138,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets the collection of spans.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ToString">
@@ -169,8 +161,6 @@
       <Parameters />
       <Docs>
         <summary>Returns the text of the formatted string as an unformatted string.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/Frame.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/Frame.xml
@@ -97,7 +97,6 @@
       <Docs>
         <summary>Gets or sets the border color for the frame.</summary>
         <value>The border color for the frame.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="BorderColorProperty">
@@ -116,7 +115,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.Frame.BorderColor" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CornerRadius">
@@ -135,8 +133,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the corner radius of the frame.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CornerRadiusProperty">
@@ -155,7 +151,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.Frame.CornerRadius" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="HasShadow">
@@ -239,8 +234,6 @@
       <Docs>
         <typeparam name="T">To be added.</typeparam>
         <summary>Returns the platform-specific instance of this <see cref="T:Microsoft.Maui.Controls.Frame" />, on which a platform-specific method may be called.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OutlineColor">
@@ -329,9 +322,6 @@
         <ReturnType>Microsoft.Maui.Graphics.Color</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IBorderElement.BorderWidth">
@@ -351,9 +341,6 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IBorderElement.BorderWidthDefaultValue">
@@ -373,9 +360,6 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IBorderElement.CornerRadius">
@@ -395,9 +379,6 @@
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IBorderElement.CornerRadiusDefaultValue">
@@ -417,9 +398,6 @@
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IBorderElement.IsBackgroundColorSet">
@@ -440,9 +418,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IBorderElement.IsBackgroundSet">
@@ -463,9 +438,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IBorderElement.IsBorderColorSet">
@@ -486,9 +458,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IBorderElement.IsBorderWidthSet">
@@ -509,9 +478,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IBorderElement.IsCornerRadiusSet">
@@ -532,9 +498,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IBorderElement.OnBorderColorPropertyChanged">
@@ -560,8 +523,6 @@
       <Docs>
         <param name="oldValue">To be added.</param>
         <param name="newValue">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/GestureElement.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/GestureElement.xml
@@ -21,7 +21,6 @@
   </Interfaces>
   <Docs>
     <summary>An element that can respond to gestures.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -37,7 +36,6 @@
       <Parameters />
       <Docs>
         <summary>Creates a new <see cref="T:Microsoft.Maui.Controls.GestureElement" /> object with default values.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GestureRecognizers">
@@ -60,7 +58,6 @@
       <Docs>
         <summary>Gets the list of recognizers that belong to the element.</summary>
         <value>The list of recognizers that belong to the element.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.Internals.ISpatialElement.Region">
@@ -83,7 +80,6 @@
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
         <value>For internal use by the Microsoft.Maui.Controls platform.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/GestureState.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/GestureState.xml
@@ -19,7 +19,6 @@
   </Base>
   <Docs>
     <summary>Enumeration specifying the various states of a gesture.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Began">

--- a/src/Controls/docs/Microsoft.Maui.Controls/GradientBrush.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/GradientBrush.xml
@@ -17,8 +17,6 @@
     </Attribute>
   </Attributes>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -32,8 +30,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GradientStops">
@@ -50,9 +46,6 @@
         <ReturnType>Microsoft.Maui.Controls.GradientStopCollection</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GradientStopsProperty">
@@ -69,8 +62,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="InvalidateGradientBrushRequested">
@@ -87,8 +78,6 @@
         <ReturnType>System.EventHandler</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/GradientStop.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/GradientStop.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -27,8 +25,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -48,8 +44,6 @@
       <Docs>
         <param name="color">To be added.</param>
         <param name="offset">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Color">
@@ -66,9 +60,6 @@
         <ReturnType>Microsoft.Maui.Graphics.Color</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ColorProperty">
@@ -85,8 +76,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Equals">
@@ -107,9 +96,6 @@
       </Parameters>
       <Docs>
         <param name="obj">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetHashCode">
@@ -127,9 +113,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Offset">
@@ -146,9 +129,6 @@
         <ReturnType>System.Single</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OffsetProperty">
@@ -165,8 +145,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/GradientStopCollection.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/GradientStopCollection.xml
@@ -15,8 +15,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -30,8 +28,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/Grid.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/Grid.xml
@@ -454,7 +454,6 @@
       <Docs>
         <param name="trigger">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="LayoutChildren">
@@ -491,7 +490,6 @@
         <summary>
           <para>Lays out the child elements when the layout is invalidated.</para>
         </summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="On&lt;T&gt;">
@@ -522,8 +520,6 @@
       <Docs>
         <typeparam name="T">The platform configuration that selects the platform specific to use.</typeparam>
         <summary>Returns the configuration object that the developer can use to call platform-specific methods for the grid control.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnAdded">
@@ -575,7 +571,6 @@
       <Parameters />
       <Docs>
         <summary>Application developers override this to respond when the binding context changes.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnRemoved">
@@ -604,7 +599,6 @@
       <Docs>
         <param name="view">The element that was removed.</param>
         <summary>Method that is called when a child is removed from this <see cref="T:Microsoft.Maui.Controls.Grid" /> element.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnSizeRequest">
@@ -646,7 +640,6 @@
         <returns>
           <para>The new requested size.</para>
         </returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RowDefinitions">
@@ -704,7 +697,6 @@
       </ReturnValue>
       <Docs>
         <summary>Implements the <see cref="P:Microsoft.Maui.Controls.Grid.RowDefinitions" /> property, and allows the <see cref="T:Microsoft.Maui.Controls.Grid" /> class to bind it to properties on other objects at run time.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RowProperty">

--- a/src/Controls/docs/Microsoft.Maui.Controls/GridItemsLayout.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/GridItemsLayout.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -31,8 +29,6 @@
       </Parameters>
       <Docs>
         <param name="orientation">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -52,8 +48,6 @@
       <Docs>
         <param name="span">To be added.</param>
         <param name="orientation">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="HorizontalItemSpacing">
@@ -70,9 +64,6 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="HorizontalItemSpacingProperty">
@@ -89,8 +80,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Span">
@@ -107,9 +96,6 @@
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SpanProperty">
@@ -127,7 +113,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.GridItemsLayout.Span" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="VerticalItemSpacing">
@@ -144,9 +129,6 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="VerticalItemSpacingProperty">
@@ -163,8 +145,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/GridLengthTypeConverter.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/GridLengthTypeConverter.xml
@@ -61,7 +61,6 @@
       <Parameters />
       <Docs>
         <summary>Creates a new <see cref="T:Microsoft.Maui.GridLength.Star" /> object with default values.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ConvertFromInvariantString">
@@ -84,8 +83,6 @@
       <Docs>
         <param name="value">The value to convert.</param>
         <summary>Converts a valid grid length descriptor in to a <see cref="T:Microsoft.Maui.GridLength.Star" />.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/GroupableItemsView.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/GroupableItemsView.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -27,8 +25,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GroupFooterTemplate">
@@ -45,9 +41,6 @@
         <ReturnType>Microsoft.Maui.Controls.DataTemplate</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GroupFooterTemplateProperty">
@@ -64,8 +57,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GroupHeaderTemplate">
@@ -82,9 +73,6 @@
         <ReturnType>Microsoft.Maui.Controls.DataTemplate</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GroupHeaderTemplateProperty">
@@ -101,8 +89,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsGrouped">
@@ -119,9 +105,6 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsGroupedProperty">
@@ -138,8 +121,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/HandlerAttribute.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/HandlerAttribute.xml
@@ -25,7 +25,6 @@
   </Attributes>
   <Docs>
     <summary>An abstract attribute whose subclasses specify the platform-specific renderers for Microsoft.Maui.Controls abstract controls.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -45,8 +44,6 @@
       <Docs>
         <param name="handler">To be added.</param>
         <param name="target">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -68,8 +65,6 @@
         <param name="handler">To be added.</param>
         <param name="target">To be added.</param>
         <param name="supportedVisuals">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Priority">
@@ -91,9 +86,6 @@
         <ReturnType>System.Int16</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ShouldRegister">
@@ -119,8 +111,6 @@
       <Parameters />
       <Docs>
         <summary>Returns a Boolean value that indicates whether the runtime should automatically register the handler for the target.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/HtmlWebViewSource.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/HtmlWebViewSource.xml
@@ -20,7 +20,6 @@
   <Interfaces />
   <Docs>
     <summary>A WebViewSource bound to an HTML-formatted string.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -42,7 +41,6 @@
       <Parameters />
       <Docs>
         <summary>Creates a new empty <see cref="T:Microsoft.Maui.Controls.HtmlWebViewSource" /> object with default values.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="BaseUrl">
@@ -67,8 +65,6 @@
       </ReturnValue>
       <Docs>
         <summary>The base URL for the source HTML document.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="BaseUrlProperty">
@@ -93,7 +89,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.HtmlWebViewSource.BaseUrl" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Html">
@@ -118,8 +113,6 @@
       </ReturnValue>
       <Docs>
         <summary>The HTML content.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="HtmlProperty">
@@ -144,7 +137,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.HtmlWebViewSource.Html" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Load">
@@ -172,7 +164,6 @@
       <Docs>
         <param name="renderer">The renderer into which to load html content.</param>
         <summary>Loads the specified <paramref name="renderer" /> with the current base URL and HTML.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/Image.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/Image.xml
@@ -109,7 +109,6 @@ var image = new Image { Source = "picture.png" };]]></code>
       <Docs>
         <summary>Gets or sets the scaling mode for the image. This is a bindable property.</summary>
         <value>A <see cref="T:Microsoft.Maui.Aspect" /> representing the scaling mode of the image. Default is <see cref="F:Microsoft.Maui.Aspect.AspectFit" />.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="AspectProperty">
@@ -134,7 +133,6 @@ var image = new Image { Source = "picture.png" };]]></code>
       </ReturnValue>
       <Docs>
         <summary>Identifies the Aspect bindable property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsAnimationPlaying">
@@ -151,9 +149,6 @@ var image = new Image { Source = "picture.png" };]]></code>
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsAnimationPlayingProperty">
@@ -170,8 +165,6 @@ var image = new Image { Source = "picture.png" };]]></code>
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsLoading">
@@ -297,7 +290,6 @@ indicator.BindingContext = image;]]></code>
       </ReturnValue>
       <Docs>
         <summary>Backing store for the IsOpaque bindable property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="On&lt;T&gt;">
@@ -328,8 +320,6 @@ indicator.BindingContext = image;]]></code>
       <Docs>
         <typeparam name="T">To be added.</typeparam>
         <summary>Returns the platform-specific instance of this <see cref="T:Microsoft.Maui.Controls.Image" />, on which a platform-specific method may be called.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnBindingContextChanged">
@@ -427,7 +417,6 @@ indicator.BindingContext = image;]]></code>
       <Docs>
         <param name="isLoading">Whether the image is loading.</param>
         <summary>Sets a value that indicates whether the image is currently loading.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Source">
@@ -458,7 +447,6 @@ indicator.BindingContext = image;]]></code>
       <Docs>
         <summary>Gets or sets the source of the image. This is a bindable property.</summary>
         <value>An <see cref="T:Microsoft.Maui.Controls.ImageSource" /> representing the image source. Default is null.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SourceProperty">
@@ -483,7 +471,6 @@ indicator.BindingContext = image;]]></code>
       </ReturnValue>
       <Docs>
         <summary>Identifies the Source bindable property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IImageController.GetLoadAsAnimation">
@@ -504,9 +491,6 @@ indicator.BindingContext = image;]]></code>
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IImageElement.OnImageSourceSourceChanged">
@@ -532,8 +516,6 @@ indicator.BindingContext = image;]]></code>
       <Docs>
         <param name="sender">To be added.</param>
         <param name="e">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IImageElement.RaiseImageSourcePropertyChanged">
@@ -554,8 +536,6 @@ indicator.BindingContext = image;]]></code>
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/ImageButton.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/ImageButton.xml
@@ -42,8 +42,6 @@
     </Attribute>
   </Attributes>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -57,8 +55,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Aspect">
@@ -75,9 +71,6 @@
         <ReturnType>Microsoft.Maui.Aspect</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="AspectProperty">
@@ -95,7 +88,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.ImageButton.Aspect" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="BorderColor">
@@ -112,9 +104,6 @@
         <ReturnType>Microsoft.Maui.Graphics.Color</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="BorderColorProperty">
@@ -132,7 +121,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.ImageButton.BorderColor" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="BorderWidth">
@@ -149,9 +137,6 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="BorderWidthProperty">
@@ -169,7 +154,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.ImageButton.BorderWidth" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ChangeVisualState">
@@ -187,8 +171,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Clicked">
@@ -205,8 +187,6 @@
         <ReturnType>System.EventHandler</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Command">
@@ -223,9 +203,6 @@
         <ReturnType>System.Windows.Input.ICommand</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CommandParameter">
@@ -242,9 +219,6 @@
         <ReturnType>System.Object</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CommandParameterProperty">
@@ -262,7 +236,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.ImageButton.CommandParameter" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CommandProperty">
@@ -280,7 +253,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.ImageButton.Command" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CornerRadius">
@@ -297,9 +269,6 @@
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CornerRadiusProperty">
@@ -317,7 +286,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.ImageButton.CornerRadius" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsLoading">
@@ -337,9 +305,6 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsLoadingProperty">
@@ -357,7 +322,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.ImageButton.IsLoading" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsOpaque">
@@ -374,9 +338,6 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsOpaqueProperty">
@@ -394,7 +355,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.ImageButton.IsOpaque" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsPressed">
@@ -411,9 +371,6 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsPressedProperty">
@@ -431,7 +388,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.ImageButton.IsPressed" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="On&lt;T&gt;">
@@ -460,9 +416,6 @@
       <Parameters />
       <Docs>
         <typeparam name="T">To be added.</typeparam>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnBindingContextChanged">
@@ -480,8 +433,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnMeasure">
@@ -504,9 +455,6 @@
       <Docs>
         <param name="widthConstraint">To be added.</param>
         <param name="heightConstraint">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Padding">
@@ -523,9 +471,6 @@
         <ReturnType>Microsoft.Maui.Thickness</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PaddingProperty">
@@ -543,7 +488,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.ImageButton.Padding" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Pressed">
@@ -560,8 +504,6 @@
         <ReturnType>System.EventHandler</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PropagateUpClicked">
@@ -579,8 +521,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PropagateUpPressed">
@@ -598,8 +538,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PropagateUpReleased">
@@ -617,8 +555,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RaiseImageSourcePropertyChanged">
@@ -639,8 +575,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Released">
@@ -657,8 +591,6 @@
         <ReturnType>System.EventHandler</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SendClicked">
@@ -684,8 +616,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SendPressed">
@@ -711,8 +641,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SendReleased">
@@ -738,8 +666,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetIsLoading">
@@ -768,8 +694,6 @@
       </Parameters>
       <Docs>
         <param name="isLoading">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetIsPressed">
@@ -795,8 +719,6 @@
       </Parameters>
       <Docs>
         <param name="isPressed">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Source">
@@ -818,9 +740,6 @@
         <ReturnType>Microsoft.Maui.Controls.ImageSource</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SourceProperty">
@@ -838,7 +757,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.ImageButton.Source" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IBorderElement.BorderColorDefaultValue">
@@ -858,9 +776,6 @@
         <ReturnType>Microsoft.Maui.Graphics.Color</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IBorderElement.BorderWidthDefaultValue">
@@ -880,9 +795,6 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IBorderElement.CornerRadiusDefaultValue">
@@ -902,9 +814,6 @@
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IBorderElement.IsBackgroundColorSet">
@@ -925,9 +834,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IBorderElement.IsBackgroundSet">
@@ -948,9 +854,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IBorderElement.IsBorderColorSet">
@@ -971,9 +874,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IBorderElement.IsBorderWidthSet">
@@ -994,9 +894,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IBorderElement.IsCornerRadiusSet">
@@ -1017,9 +914,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IBorderElement.OnBorderColorPropertyChanged">
@@ -1045,8 +939,6 @@
       <Docs>
         <param name="oldValue">To be added.</param>
         <param name="newValue">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IImageController.GetLoadAsAnimation">
@@ -1067,9 +959,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IImageElement.IsAnimationPlaying">
@@ -1089,9 +978,6 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IImageElement.OnImageSourceSourceChanged">
@@ -1117,8 +1003,6 @@
       <Docs>
         <param name="sender">To be added.</param>
         <param name="e">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/ImageSource.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/ImageSource.xml
@@ -26,7 +26,6 @@
   </Attributes>
   <Docs>
     <summary>Abstract class whose implementors load images from files or the Web.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -42,7 +41,6 @@
       <Parameters />
       <Docs>
         <summary>Creates a new <see cref="T:Microsoft.Maui.Controls.ImageSource" /> with default values.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Cancel">
@@ -125,8 +123,6 @@
       <Docs>
         <param name="file">The name of a file that contains a valid image.</param>
         <summary>Returns a new <see cref="T:Microsoft.Maui.Controls.FileImageSource" /> that reads from <paramref name="file" />.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FromResource">
@@ -152,8 +148,6 @@
         <param name="resource">The name of a valid image resource in <paramref name="sourceAssembly" />.</param>
         <param name="sourceAssembly">The source assembly in which to search for the image.</param>
         <summary>Creates a <see cref="T:Microsoft.Maui.Controls.ImageSource" /> from the specified resource in the specified source assembly.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FromResource">
@@ -179,8 +173,6 @@
         <param name="resource">The name of a valid image resource in the assembly to which <paramref name="resolvingType" /> belongs.</param>
         <param name="resolvingType">A type from the assembly in which to look up the image resource with <paramref name="resource" />.</param>
         <summary>Creates a <see cref="T:Microsoft.Maui.Controls.ImageSource" /> from the specified resource in the specified source assembly.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FromStream">
@@ -262,8 +254,6 @@
       <Docs>
         <param name="uri">A URI that identifies a valid image.</param>
         <summary>Returns a new <see cref="T:Microsoft.Maui.Controls.UriImageSource" /> that reads from <paramref name="uri" />.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsEmpty">
@@ -280,9 +270,6 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnLoadingCompleted">
@@ -363,7 +350,6 @@
       <Parameters />
       <Docs>
         <summary>Called by inheritors to indicate that the source changed.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="op_Implicit">
@@ -392,8 +378,6 @@
       <Docs>
         <param name="source">A string that represents an image location.</param>
         <summary>Allows implicit casting from a string that represents an absolute URI.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="op_Implicit">
@@ -422,8 +406,6 @@
       <Docs>
         <param name="uri">A absolute URI that specifies an image location.</param>
         <summary>Allows implicit casting from <see cref="T:System.Uri" /> objects that were created with an absolute URI.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/ImageSourceConverter.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/ImageSourceConverter.xml
@@ -20,7 +20,6 @@
   </Attributes>
   <Docs>
     <summary>Class that takes a string representation of an image file location and returns a <see cref="T:Microsoft.Maui.Controls.ImageSource" /> from the specified resource.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -37,7 +36,6 @@
       <Parameters />
       <Docs>
         <summary>Creates a new <see cref="T:Microsoft.Maui.Controls.ImageSourceConverter" /> with default values.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ConvertFromInvariantString">
@@ -60,8 +58,6 @@
       <Docs>
         <param name="value">The value to convert.</param>
         <summary>Returns an image source created from a URI that is contained in <paramref name="value" />.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/IndicatorShape.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/IndicatorShape.xml
@@ -11,8 +11,6 @@
     <BaseTypeName>System.Enum</BaseTypeName>
   </Base>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Circle">
@@ -30,7 +28,6 @@
       </ReturnValue>
       <MemberValue>0</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
     <Member MemberName="Square">
@@ -48,7 +45,6 @@
       </ReturnValue>
       <MemberValue>1</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/IndicatorView.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/IndicatorView.xml
@@ -20,8 +20,6 @@
     </Attribute>
   </Attributes>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -35,8 +33,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Count">
@@ -53,9 +49,6 @@
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CountProperty">
@@ -72,8 +65,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="HideSingle">
@@ -90,9 +81,6 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="HideSingleProperty">
@@ -109,8 +97,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IndicatorColor">
@@ -127,9 +113,6 @@
         <ReturnType>Microsoft.Maui.Graphics.Color</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IndicatorColorProperty">
@@ -146,8 +129,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IndicatorLayout">
@@ -164,9 +145,6 @@
         <ReturnType>Microsoft.Maui.Controls.Layout&lt;Microsoft.Maui.Controls.View&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IndicatorSize">
@@ -183,9 +161,6 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IndicatorSizeProperty">
@@ -202,8 +177,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IndicatorsShape">
@@ -220,9 +193,6 @@
         <ReturnType>Microsoft.Maui.Controls.IndicatorShape</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IndicatorsShapeProperty">
@@ -239,8 +209,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IndicatorTemplate">
@@ -257,9 +225,6 @@
         <ReturnType>Microsoft.Maui.Controls.DataTemplate</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IndicatorTemplateProperty">
@@ -276,8 +241,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ItemsSource">
@@ -294,9 +257,6 @@
         <ReturnType>System.Collections.IEnumerable</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ItemsSourceProperty">
@@ -313,8 +273,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="MaximumVisible">
@@ -331,9 +289,6 @@
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="MaximumVisibleProperty">
@@ -350,8 +305,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnMeasure">
@@ -374,9 +327,6 @@
       <Docs>
         <param name="widthConstraint">To be added.</param>
         <param name="heightConstraint">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Position">
@@ -393,9 +343,6 @@
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PositionProperty">
@@ -412,8 +359,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SelectedIndicatorColor">
@@ -430,9 +375,6 @@
         <ReturnType>Microsoft.Maui.Graphics.Color</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SelectedIndicatorColorProperty">
@@ -449,8 +391,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/InitializationFlags.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/InitializationFlags.xml
@@ -16,8 +16,6 @@
     </Attribute>
   </Attributes>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="DisableCss">
@@ -35,7 +33,6 @@
       </ReturnValue>
       <MemberValue>1</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/InputView.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/InputView.xml
@@ -39,7 +39,6 @@
       <Docs>
         <summary>Gets or sets a value that indicates the number of device-independent units that should be in between characters in the text displayed by the Entry. Applies to Text and Placeholder.</summary>
         <value>The number of device-independent units that should be in between characters in the text.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CharacterSpacingProperty">
@@ -57,7 +56,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.InputView.CharacterSpacing" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsReadOnly">
@@ -94,7 +92,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.InputView.IsReadOnly" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Keyboard">
@@ -120,7 +117,6 @@
       <Docs>
         <summary>Gets or sets the Keyboard for the InputView. This is a bindable property.</summary>
         <value>The <see cref="T:Microsoft.Maui.Keyboard" /> to use for the InputView.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="KeyboardProperty">
@@ -145,7 +141,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.InputView.Keyboard" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="MaxLength">
@@ -165,7 +160,6 @@
       <Docs>
         <summary>Gets or sets the maximum allowed length of input.</summary>
         <value>An integer in the interval [0,<c>int.MaxValue</c>]. The default value is <c>Int.MaxValue</c>.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="MaxLengthProperty">
@@ -184,7 +178,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.InputView.MaxLength" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnTextChanged">
@@ -207,8 +200,6 @@
       <Docs>
         <param name="oldValue">To be added.</param>
         <param name="newValue">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnTextTransformChanged">
@@ -231,8 +222,6 @@
       <Docs>
         <param name="oldValue">To be added.</param>
         <param name="newValue">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Placeholder">
@@ -251,7 +240,6 @@
       <Docs>
         <summary>Gets or sets the text that is displayed when the control is empty.</summary>
         <value>The text that is displayed when the control is empty.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PlaceholderColor">
@@ -270,7 +258,6 @@
       <Docs>
         <summary>Gets or sets the color of the placeholder text.</summary>
         <value>The color of the placeholder text.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PlaceholderColorProperty">
@@ -288,7 +275,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.InputView.PlaceholderColor" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PlaceholderProperty">
@@ -306,7 +292,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.InputView.Placeholder" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Text">
@@ -343,7 +328,6 @@
       </ReturnValue>
       <Docs>
         <summary>Event that is raised when the text of the Editor changes.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TextColor">
@@ -361,8 +345,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the text color.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TextColorProperty">
@@ -380,7 +362,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.InputView.TextColor" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TextProperty">
@@ -398,7 +379,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.InputView.Text" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TextTransform">
@@ -415,9 +395,6 @@
         <ReturnType>Microsoft.Maui.Controls.TextTransform</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TextTransformProperty">
@@ -434,8 +411,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="UpdateFormsText">
@@ -458,9 +433,6 @@
       <Docs>
         <param name="original">To be added.</param>
         <param name="transform">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/InvalidNavigationException.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/InvalidNavigationException.xml
@@ -17,8 +17,6 @@
     </Attribute>
   </Attributes>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -32,8 +30,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -51,8 +47,6 @@
       </Parameters>
       <Docs>
         <param name="message">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -72,8 +66,6 @@
       <Docs>
         <param name="info">To be added.</param>
         <param name="context">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -93,8 +85,6 @@
       <Docs>
         <param name="message">To be added.</param>
         <param name="innerException">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/ItemSizingStrategy.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/ItemSizingStrategy.xml
@@ -11,8 +11,6 @@
     <BaseTypeName>System.Enum</BaseTypeName>
   </Base>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="MeasureAllItems">
@@ -30,7 +28,6 @@
       </ReturnValue>
       <MemberValue>0</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
     <Member MemberName="MeasureFirstItem">
@@ -48,7 +45,6 @@
       </ReturnValue>
       <MemberValue>1</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/ItemTappedEventArgs.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/ItemTappedEventArgs.xml
@@ -20,7 +20,6 @@
   <Interfaces />
   <Docs>
     <summary>Event arguments for the <see cref="E:Microsoft.Maui.Controls.ListView.ItemTapped" /> event.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -53,7 +52,6 @@
         <param name="group">The item group.</param>
         <param name="item">The item that was tapped.</param>
         <summary>Creates a new <see cref="T:Microsoft.Maui.Controls.ItemTappedEventArgs" /> object for the specified <paramref name="item" /> that was tapped and the <paramref name="group" /> to which it belongs.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -75,8 +73,6 @@
         <param name="group">To be added.</param>
         <param name="item">To be added.</param>
         <param name="itemIndex">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Group">
@@ -101,8 +97,6 @@
       </ReturnValue>
       <Docs>
         <summary>The collection of elements to which the tapped item belongs.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Item">
@@ -127,8 +121,6 @@
       </ReturnValue>
       <Docs>
         <summary>The visual element that the user tapped.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ItemIndex">
@@ -145,9 +137,6 @@
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/ItemVisibilityEventArgs.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/ItemVisibilityEventArgs.xml
@@ -52,7 +52,6 @@
       <Docs>
         <param name="item">The modified item.</param>
         <summary>Initializes a new instance of the ItemVisibilityEventArgs class with the item whose visibility has changed.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -72,8 +71,6 @@
       <Docs>
         <param name="item">To be added.</param>
         <param name="itemIndex">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Item">
@@ -99,7 +96,6 @@
       <Docs>
         <summary>The item from the <see cref="P:Microsoft.Maui.Controls.ItemsView`1.ItemsSource" /> whose visibility has changed.</summary>
         <value>An object.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ItemIndex">
@@ -116,9 +112,6 @@
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/ItemsLayout.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/ItemsLayout.xml
@@ -19,8 +19,6 @@
     </Interface>
   </Interfaces>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -38,8 +36,6 @@
       </Parameters>
       <Docs>
         <param name="orientation">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Orientation">
@@ -56,9 +52,6 @@
         <ReturnType>Microsoft.Maui.Controls.ItemsLayoutOrientation</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SnapPointsAlignment">
@@ -75,9 +68,6 @@
         <ReturnType>Microsoft.Maui.Controls.SnapPointsAlignment</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SnapPointsAlignmentProperty">
@@ -95,7 +85,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.ItemsLayout.SnapPointsAlignment" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SnapPointsType">
@@ -112,9 +101,6 @@
         <ReturnType>Microsoft.Maui.Controls.SnapPointsType</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SnapPointsTypeProperty">
@@ -132,7 +118,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.ItemsLayout.SnapPointsType" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/ItemsLayoutOrientation.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/ItemsLayoutOrientation.xml
@@ -11,8 +11,6 @@
     <BaseTypeName>System.Enum</BaseTypeName>
   </Base>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Horizontal">
@@ -30,7 +28,6 @@
       </ReturnValue>
       <MemberValue>1</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
     <Member MemberName="Vertical">
@@ -48,7 +45,6 @@
       </ReturnValue>
       <MemberValue>0</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/ItemsLayoutTypeConverter.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/ItemsLayoutTypeConverter.xml
@@ -17,8 +17,6 @@
     </Attribute>
   </Attributes>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -32,8 +30,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ConvertFromInvariantString">
@@ -54,9 +50,6 @@
       </Parameters>
       <Docs>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/ItemsUpdatingScrollMode.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/ItemsUpdatingScrollMode.xml
@@ -11,8 +11,6 @@
     <BaseTypeName>System.Enum</BaseTypeName>
   </Base>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="KeepItemsInView">
@@ -30,7 +28,6 @@
       </ReturnValue>
       <MemberValue>0</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
     <Member MemberName="KeepLastItemInView">
@@ -48,7 +45,6 @@
       </ReturnValue>
       <MemberValue>2</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
     <Member MemberName="KeepScrollOffset">
@@ -66,7 +62,6 @@
       </ReturnValue>
       <MemberValue>1</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/ItemsView.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/ItemsView.xml
@@ -13,7 +13,6 @@
   <Interfaces />
   <Docs>
     <summary>A <see cref="T:Microsoft.Maui.Controls.View" /> that serves as a base class for views that contain a templated list of items.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -27,8 +26,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="EmptyView">
@@ -45,9 +42,6 @@
         <ReturnType>System.Object</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="EmptyViewProperty">
@@ -65,7 +59,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.ItemsView.EmptyView" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="EmptyViewTemplate">
@@ -82,9 +75,6 @@
         <ReturnType>Microsoft.Maui.Controls.DataTemplate</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="EmptyViewTemplateProperty">
@@ -102,7 +92,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.ItemsView.EmptyViewTemplate" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="HorizontalScrollBarVisibility">
@@ -119,9 +108,6 @@
         <ReturnType>Microsoft.Maui.Controls.ScrollBarVisibility</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="HorizontalScrollBarVisibilityProperty">
@@ -138,8 +124,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="InternalItemsLayout">
@@ -156,9 +140,6 @@
         <ReturnType>Microsoft.Maui.Controls.IItemsLayout</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ItemsSource">
@@ -175,9 +156,6 @@
         <ReturnType>System.Collections.IEnumerable</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ItemsSourceProperty">
@@ -195,7 +173,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.ItemsView.ItemsSource" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ItemsUpdatingScrollMode">
@@ -212,9 +189,6 @@
         <ReturnType>Microsoft.Maui.Controls.ItemsUpdatingScrollMode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ItemsUpdatingScrollModeProperty">
@@ -231,8 +205,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ItemTemplate">
@@ -249,9 +221,6 @@
         <ReturnType>Microsoft.Maui.Controls.DataTemplate</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ItemTemplateProperty">
@@ -269,7 +238,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.ItemsView.ItemTemplate" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnBindingContextChanged">
@@ -287,8 +255,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnMeasure">
@@ -311,9 +277,6 @@
       <Docs>
         <param name="widthConstraint">To be added.</param>
         <param name="heightConstraint">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnRemainingItemsThresholdReached">
@@ -331,8 +294,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnScrolled">
@@ -353,8 +314,6 @@
       </Parameters>
       <Docs>
         <param name="e">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnScrollToRequested">
@@ -375,8 +334,6 @@
       </Parameters>
       <Docs>
         <param name="e">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RemainingItemsThreshold">
@@ -393,9 +350,6 @@
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RemainingItemsThresholdProperty">
@@ -412,8 +366,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RemainingItemsThresholdReached">
@@ -430,8 +382,6 @@
         <ReturnType>System.EventHandler</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RemainingItemsThresholdReachedCommand">
@@ -448,9 +398,6 @@
         <ReturnType>System.Windows.Input.ICommand</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RemainingItemsThresholdReachedCommandParameter">
@@ -467,9 +414,6 @@
         <ReturnType>System.Object</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RemainingItemsThresholdReachedCommandParameterProperty">
@@ -486,8 +430,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RemainingItemsThresholdReachedCommandProperty">
@@ -504,8 +446,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Scrolled">
@@ -522,8 +462,6 @@
         <ReturnType>System.EventHandler&lt;Microsoft.Maui.Controls.ItemsViewScrolledEventArgs&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ScrollTo">
@@ -550,8 +488,6 @@
         <param name="groupIndex">To be added.</param>
         <param name="position">To be added.</param>
         <param name="animate">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ScrollTo">
@@ -578,8 +514,6 @@
         <param name="group">To be added.</param>
         <param name="position">To be added.</param>
         <param name="animate">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ScrollToRequested">
@@ -596,8 +530,6 @@
         <ReturnType>System.EventHandler&lt;Microsoft.Maui.Controls.ScrollToRequestEventArgs&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SendRemainingItemsThresholdReached">
@@ -615,8 +547,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SendScrolled">
@@ -637,8 +567,6 @@
       </Parameters>
       <Docs>
         <param name="e">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="VerticalScrollBarVisibility">
@@ -655,9 +583,6 @@
         <ReturnType>Microsoft.Maui.Controls.ScrollBarVisibility</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="VerticalScrollBarVisibilityProperty">
@@ -674,8 +599,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/ItemsViewScrolledEventArgs.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/ItemsViewScrolledEventArgs.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -27,8 +25,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CenterItemIndex">
@@ -45,9 +41,6 @@
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FirstVisibleItemIndex">
@@ -64,9 +57,6 @@
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="HorizontalDelta">
@@ -83,9 +73,6 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="HorizontalOffset">
@@ -102,9 +89,6 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="LastVisibleItemIndex">
@@ -121,9 +105,6 @@
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="VerticalDelta">
@@ -140,9 +121,6 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="VerticalOffset">
@@ -159,9 +137,6 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/Label.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/Label.xml
@@ -101,9 +101,6 @@ public class App : Application
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CharacterSpacingProperty">
@@ -120,8 +117,6 @@ public class App : Application
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Font">
@@ -178,8 +173,6 @@ public class App : Application
       </ReturnValue>
       <Docs>
         <summary>Gets a value that indicates whether the font for the label is bold, italic, or neither.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FontAttributesProperty">
@@ -201,7 +194,6 @@ public class App : Application
       </ReturnValue>
       <Docs>
         <summary>Backing store for the FontAttributes property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FontFamily">
@@ -246,7 +238,6 @@ public class App : Application
       </ReturnValue>
       <Docs>
         <summary>Backing store for the FontFamily property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FontProperty">
@@ -299,8 +290,6 @@ public class App : Application
       </ReturnValue>
       <Docs>
         <summary>Gets the size of the font for the label.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FontSizeProperty">
@@ -322,7 +311,6 @@ public class App : Application
       </ReturnValue>
       <Docs>
         <summary>Backing store for the FontSize property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FormattedText">
@@ -370,7 +358,6 @@ public class App : Application
       </ReturnValue>
       <Docs>
         <summary>Backing store for the FormattedText property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetChildElements">
@@ -394,7 +381,6 @@ public class App : Application
         <param name="point">The point under which to look for child elements.</param>
         <summary>Returns the child elements that are under the specified point.</summary>
         <returns>The child elements that are under the specified point.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="HorizontalTextAlignment">
@@ -414,8 +400,6 @@ public class App : Application
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the horizontal alignment of the Text property. This is a bindable property.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="HorizontalTextAlignmentProperty">
@@ -435,7 +419,6 @@ public class App : Application
       </ReturnValue>
       <Docs>
         <summary>Identifies the HorizontalTextAlignment bindable property</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="LineBreakMode">
@@ -508,7 +491,6 @@ public class App : Application
       <Docs>
         <summary>Gets or sets the multiplier to apply to the default line height when displaying text.</summary>
         <value>The multiplier to apply to the default line height when displaying text.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="LineHeightProperty">
@@ -527,7 +509,6 @@ public class App : Application
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.Label.LineHeight" /> bindable property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="MaxLines">
@@ -545,8 +526,6 @@ public class App : Application
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the maximum number of lines allowed in the <see cref="T:Microsoft.Maui.Controls.Label" />.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="MaxLinesProperty">
@@ -564,7 +543,6 @@ public class App : Application
       </ReturnValue>
       <Docs>
         <summary>Static method providing the <see cref="T:Microsoft.Maui.Controls.BindableProperty" /> for <see cref="P:Microsoft.Maui.Controls.Label.MaxLines" />.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="On&lt;T&gt;">
@@ -595,8 +573,6 @@ public class App : Application
       <Docs>
         <typeparam name="T">To be added.</typeparam>
         <summary>Returns the platform-specific instance of this <see cref="T:Microsoft.Maui.Controls.Label" />, on which a platform-specific method may be called.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnBindingContextChanged">
@@ -616,7 +592,6 @@ public class App : Application
       <Parameters />
       <Docs>
         <summary>Method that is called when the binding context is changed.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Padding">
@@ -633,9 +608,6 @@ public class App : Application
         <ReturnType>Microsoft.Maui.Thickness</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PaddingProperty">
@@ -652,8 +624,6 @@ public class App : Application
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Text">
@@ -754,8 +724,6 @@ public class App : Application
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the <see cref="T:Microsoft.Maui.TextDecorations" /> applied to <see cref="P:Microsoft.Maui.Controls.Label.Text" />.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TextDecorationsProperty">
@@ -773,7 +741,6 @@ public class App : Application
       </ReturnValue>
       <Docs>
         <summary>Static method providing the <see cref="T:Microsoft.Maui.Controls.BindableProperty" /> associated with <see cref="P:Microsoft.Maui.Controls.Label.TextDecorations" />.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TextProperty">
@@ -816,9 +783,6 @@ public class App : Application
         <ReturnType>Microsoft.Maui.Controls.TextTransform</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TextTransformProperty">
@@ -835,8 +799,6 @@ public class App : Application
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TextType">
@@ -854,8 +816,6 @@ public class App : Application
       </ReturnValue>
       <Docs>
         <summary>Determines whether the Label should display plain text or HTML text.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TextTypeProperty">
@@ -873,7 +833,6 @@ public class App : Application
       </ReturnValue>
       <Docs>
         <summary>Backing store for the TextType bindable property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="UpdateFormsText">
@@ -896,9 +855,6 @@ public class App : Application
       <Docs>
         <param name="source">To be added.</param>
         <param name="textTransform">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="VerticalTextAlignment">
@@ -918,8 +874,6 @@ public class App : Application
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the vertical alignement of the Text property. This is a bindable property.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="VerticalTextAlignmentProperty">
@@ -939,7 +893,6 @@ public class App : Application
       </ReturnValue>
       <Docs>
         <summary>Identifies the VerticalTextAlignment bindable property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="XAlign">
@@ -1031,8 +984,6 @@ public class App : Application
       <Parameters />
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.Internals.IFontElement.OnFontAttributesChanged">
@@ -1060,7 +1011,6 @@ public class App : Application
         <param name="oldValue">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="newValue">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.Internals.IFontElement.OnFontChanged">
@@ -1088,7 +1038,6 @@ public class App : Application
         <param name="oldValue">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="newValue">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.Internals.IFontElement.OnFontFamilyChanged">
@@ -1116,7 +1065,6 @@ public class App : Application
         <param name="oldValue">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="newValue">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.Internals.IFontElement.OnFontSizeChanged">
@@ -1144,7 +1092,6 @@ public class App : Application
         <param name="oldValue">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="newValue">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="YAlign">

--- a/src/Controls/docs/Microsoft.Maui.Controls/Layout.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/Layout.xml
@@ -55,7 +55,6 @@
       <Parameters />
       <Docs>
         <summary>Intitializes a new <see cref="T:Microsoft.Maui.Controls.Layout" /> instance.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CascadeInputTransparent">
@@ -76,7 +75,6 @@
         <summary>Gets or sets a value that controls whether child elements inherit the input transparency of <see langword="this" /> layout when the tranparency is <see langword="true" />.</summary>
         <value>
           <see langword="true" /> to cause child elements to inherit the input transparency of <see langword="this" /> layout, when <see langword="this" /> layout's <see cref="P:Microsoft.Maui.Controls.VisualElement.InputTransparent" /> is true. <see langword="false" /> to cause child elements to ignore the input tranparency of <see langword="this" /> layout.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CascadeInputTransparentProperty">
@@ -95,7 +93,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.Layout.CascadeInputTransparent" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Children">
@@ -122,8 +119,6 @@
       </ReturnValue>
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ForceLayout">
@@ -246,7 +241,6 @@
         <summary>Gets or sets a value which determines if the Layout should clip its children to its bounds.</summary>
         <value>
           <see langword="true" /> if the Layout is clipped; otherwise, <see langword="false" />. The default value is <see langword="false" />.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsClippedToBoundsProperty">
@@ -271,7 +265,6 @@
       </ReturnValue>
       <Docs>
         <summary>Identifies the <see cref="P:Microsoft.Maui.Controls.Layout.IsClippedToBounds" /> bindable property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="LayoutChanged">
@@ -419,7 +412,6 @@
       <Parameters />
       <Docs>
         <summary>Invoked whenever a child of the layout has emitted <see cref="E:Microsoft.Maui.Controls.VisualElement.MeasureInvalidated" />. Implement this method to add class handling for this event.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnChildMeasureInvalidated">
@@ -550,7 +542,6 @@
       </ReturnValue>
       <Docs>
         <summary>Identifies the Padding bindable property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RaiseChild">
@@ -597,8 +588,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ShouldInvalidateOnChildAdded">
@@ -624,8 +613,6 @@
       <Docs>
         <param name="child">The child for which to specify whether or not to track invalidation.</param>
         <summary>When implemented, should return <see langword="true" /> if <paramref name="child" /> should call <see cref="M:Microsoft.Maui.Controls.VisualElement.InvalidateMeasure" />, and to return <see langword="false" /> if it should not.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ShouldInvalidateOnChildRemoved">
@@ -651,8 +638,6 @@
       <Docs>
         <param name="child">The child for which to specify whether or not to track invalidation.</param>
         <summary>When implemented, should return <see langword="true" /> if <paramref name="child" /> should call <see cref="M:Microsoft.Maui.Controls.VisualElement.InvalidateMeasure" /> when it is removed, and to return <see langword="false" /> if it should not.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="UpdateChildrenLayout">

--- a/src/Controls/docs/Microsoft.Maui.Controls/LayoutAlignment.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/LayoutAlignment.xml
@@ -24,7 +24,6 @@
   </Attributes>
   <Docs>
     <summary>Values that represent LayoutAlignment.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Center">

--- a/src/Controls/docs/Microsoft.Maui.Controls/LayoutOptions.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/LayoutOptions.xml
@@ -25,7 +25,6 @@
   </Attributes>
   <Docs>
     <summary>A struct whose static members define various alignment and expansion options.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -53,7 +52,6 @@
         <param name="alignment">An alignment value.</param>
         <param name="expands">Whether or not an element will expand to fill available space in its parent.</param>
         <summary>Creates a new <see cref="T:Microsoft.Maui.Controls.LayoutOptions" /> object with <paramref name="alignment" /> and <paramref name="expands" />.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Alignment">
@@ -79,7 +77,6 @@
       <Docs>
         <summary>Gets or sets a value that indicates how an element will be aligned.</summary>
         <value>The <see cref="T:Microsoft.Maui.Controls.LayoutAlignment" /> flags that describe the behavior of an element.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Center">
@@ -104,7 +101,6 @@
       </ReturnValue>
       <Docs>
         <summary>A <see cref="T:Microsoft.Maui.Controls.LayoutOptions" /> structure that describes an element that is centered and does not expand.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CenterAndExpand">
@@ -129,7 +125,6 @@
       </ReturnValue>
       <Docs>
         <summary>A <see cref="T:Microsoft.Maui.Controls.LayoutOptions" /> structure that describes an element that is centered and expands.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="End">
@@ -154,7 +149,6 @@
       </ReturnValue>
       <Docs>
         <summary>A <see cref="T:Microsoft.Maui.Controls.LayoutOptions" /> structure that describes an element that appears at the end of its parent and does not expand.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="EndAndExpand">
@@ -179,7 +173,6 @@
       </ReturnValue>
       <Docs>
         <summary>A <see cref="T:Microsoft.Maui.Controls.LayoutOptions" /> object that describes an element that appears at the end of its parent and expands.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Expands">
@@ -205,7 +198,6 @@
       <Docs>
         <summary>Gets or sets a value that indicates whether or not the element that is described by this <see cref="T:Microsoft.Maui.Controls.LayoutOptions" /> structure will occupy the largest space that its parent will give to it.</summary>
         <value>Whether or not the element that is described by this <see cref="T:Microsoft.Maui.Controls.LayoutOptions" /> structure will occupy the largest space that its parent will give it. <see langword="true" /> if the element will occupy the largest space the parent will give to it. <see langword="false" /> if the element will be as compact as it can be.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Fill">
@@ -230,7 +222,6 @@
       </ReturnValue>
       <Docs>
         <summary>A <see cref="T:Microsoft.Maui.Controls.LayoutOptions" /> stucture that describes an element that has no padding around itself and does not expand.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FillAndExpand">
@@ -255,7 +246,6 @@
       </ReturnValue>
       <Docs>
         <summary>A <see cref="T:Microsoft.Maui.Controls.LayoutOptions" /> structure that describes an element that has no padding around itself and expands.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Start">
@@ -280,7 +270,6 @@
       </ReturnValue>
       <Docs>
         <summary>A <see cref="T:Microsoft.Maui.Controls.LayoutOptions" /> structure that describes an element that appears at the start of its parent and does not expand.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="StartAndExpand">
@@ -305,7 +294,6 @@
       </ReturnValue>
       <Docs>
         <summary>A <see cref="T:Microsoft.Maui.Controls.LayoutOptions" /> structure that describes an element that appears at the start of its parent and expands.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/LayoutOptionsConverter.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/LayoutOptionsConverter.xml
@@ -20,7 +20,6 @@
   </Attributes>
   <Docs>
     <summary>Class that takes a string representation of a <see cref="T:Microsoft.Maui.Controls.LayoutOptions" /> and returns a corresponding <see cref="T:Microsoft.Maui.Controls.LayoutOptions" />.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -37,7 +36,6 @@
       <Parameters />
       <Docs>
         <summary>Creates a new <see cref="T:Microsoft.Maui.Controls.LayoutOptions" /> with default values.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ConvertFromInvariantString">
@@ -60,8 +58,6 @@
       <Docs>
         <param name="value">The value to convert.</param>
         <summary>Returns a  <see cref="T:Microsoft.Maui.Controls.LayoutOptions" /> for a valid layout options string.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/LinearGradientBrush.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/LinearGradientBrush.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -27,8 +25,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -46,8 +42,6 @@
       </Parameters>
       <Docs>
         <param name="gradientStops">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -69,8 +63,6 @@
         <param name="gradientStops">To be added.</param>
         <param name="startPoint">To be added.</param>
         <param name="endPoint">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="EndPoint">
@@ -87,9 +79,6 @@
         <ReturnType>Microsoft.Maui.Controls.Point</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="EndPointProperty">
@@ -106,8 +95,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsEmpty">
@@ -124,9 +111,6 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="StartPoint">
@@ -143,9 +127,6 @@
         <ReturnType>Microsoft.Maui.Controls.Point</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="StartPointProperty">
@@ -162,8 +143,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/LinearItemsLayout.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/LinearItemsLayout.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -31,8 +29,6 @@
       </Parameters>
       <Docs>
         <param name="orientation">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CarouselVertical">
@@ -49,8 +45,6 @@
         <ReturnType>Microsoft.Maui.Controls.IItemsLayout</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Horizontal">
@@ -67,8 +61,6 @@
         <ReturnType>Microsoft.Maui.Controls.IItemsLayout</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ItemSpacing">
@@ -85,9 +77,6 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ItemSpacingProperty">
@@ -104,8 +93,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Vertical">
@@ -122,8 +109,6 @@
         <ReturnType>Microsoft.Maui.Controls.IItemsLayout</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/ListProxyChangedEventArgs.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/ListProxyChangedEventArgs.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -33,8 +31,6 @@
       <Docs>
         <param name="oldList">To be added.</param>
         <param name="newList">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="NewList">
@@ -51,9 +47,6 @@
         <ReturnType>System.Collections.Generic.IReadOnlyCollection&lt;System.Object&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OldList">
@@ -70,9 +63,6 @@
         <ReturnType>System.Collections.Generic.IReadOnlyCollection&lt;System.Object&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/ListStringTypeConverter.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/ListStringTypeConverter.xml
@@ -19,7 +19,6 @@
   </Attributes>
   <Docs>
     <summary>Type converter for converting properly formatted string lists to lists.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -35,7 +34,6 @@
       <Parameters />
       <Docs>
         <summary>Creates a new <see cref="T:Microsoft.Maui.Controls.ListStringTypeConverter" /> object.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ConvertFromInvariantString">
@@ -58,8 +56,6 @@
       <Docs>
         <param name="value">The value to convert.</param>
         <summary>Converts <paramref name="value" /> to a list.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/ListView.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/ListView.xml
@@ -67,7 +67,6 @@
       <Parameters />
       <Docs>
         <summary>Creates and initializes a new instance of the <see cref="T:Microsoft.Maui.Controls.ListView" /> class.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -116,7 +115,6 @@
       <Parameters />
       <Docs>
         <summary>Enters the refreshing state by setting the <see cref="P:Microsoft.Maui.Controls.ListView.IsRefreshing" /> property to <see langword="true" />.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CachingStrategy">
@@ -135,8 +133,6 @@
       </ReturnValue>
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CreateDefault">
@@ -208,8 +204,6 @@
       <Docs>
         <param name="item">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="EndRefresh">
@@ -232,7 +226,6 @@
       <Parameters />
       <Docs>
         <summary>Exits the refreshing state by setting the <see cref="P:Microsoft.Maui.Controls.ListView.IsRefreshing" /> property to <see langword="false" />.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Footer">
@@ -254,8 +247,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the string, binding, or view that will be displayed at the bottom of the list view.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FooterElement">
@@ -282,8 +273,6 @@
       </ReturnValue>
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FooterProperty">
@@ -305,7 +294,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.ListView.Footer" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FooterTemplate">
@@ -327,8 +315,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets a data template to use to format a data object for display at the bottom of the list view.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FooterTemplateProperty">
@@ -350,7 +336,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.ListView.FooterTemplate" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetDisplayTextFromGroup">
@@ -381,8 +366,6 @@
       <Docs>
         <param name="cell">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GroupDisplayBinding">
@@ -545,7 +528,6 @@
       </ReturnValue>
       <Docs>
         <summary>Identifies the <see cref="P:Microsoft.Maui.Controls.ListView.GroupHeaderTemplate" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GroupShortNameBinding">
@@ -703,7 +685,6 @@ ListView CreateListView()
       </ReturnValue>
       <Docs>
         <summary>Identifies the <see cref="F:Microsoft.Maui.Controls.ListView.HasUnevenRowsProperty" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Header">
@@ -725,8 +706,6 @@ ListView CreateListView()
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the string, binding, or view that will be displayed at the top of the list view.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="HeaderElement">
@@ -753,8 +732,6 @@ ListView CreateListView()
       </ReturnValue>
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="HeaderProperty">
@@ -776,7 +753,6 @@ ListView CreateListView()
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.ListView.Header" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="HeaderTemplate">
@@ -798,8 +774,6 @@ ListView CreateListView()
       </ReturnValue>
       <Docs>
         <summary>Gets or sets a data template to use to format a data object for display at the top of the list view.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="HeaderTemplateProperty">
@@ -821,7 +795,6 @@ ListView CreateListView()
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.ListView.HeaderTemplate" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="HorizontalScrollBarVisibility">
@@ -838,9 +811,6 @@ ListView CreateListView()
         <ReturnType>Microsoft.Maui.Controls.ScrollBarVisibility</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="HorizontalScrollBarVisibilityProperty">
@@ -858,7 +828,6 @@ ListView CreateListView()
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.ListView.HorizontalScrollBarVisibility" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsGroupingEnabled">
@@ -887,7 +856,6 @@ ListView CreateListView()
         <value>
           <see langword="true" /> if grouping is enabled, <see langword="false" /> otherwise and by default.
         </value>
-        <remarks>To be added.</remarks>
         <altmember cref="P:Microsoft.Maui.Controls.ListView.GroupDisplayBinding" />
         <altmember cref="P:Microsoft.Maui.Controls.ListView.GroupHeaderTemplate" />
       </Docs>
@@ -915,7 +883,6 @@ ListView CreateListView()
       </ReturnValue>
       <Docs>
         <summary>Identifies the <see cref="F:Microsoft.Maui.Controls.ListView.IsGroupingEnabledProperty" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsPullToRefreshEnabled">
@@ -937,8 +904,6 @@ ListView CreateListView()
       </ReturnValue>
       <Docs>
         <summary>Gets or sets a value that tells whether the user can swipe down to cause the application to refresh.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsPullToRefreshEnabledProperty">
@@ -960,7 +925,6 @@ ListView CreateListView()
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.ListView.IsPullToRefreshEnabled" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsRefreshing">
@@ -982,8 +946,6 @@ ListView CreateListView()
       </ReturnValue>
       <Docs>
         <summary>Gets or sets a value that tells whether the list view is currently refreshing.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsRefreshingProperty">
@@ -1005,7 +967,6 @@ ListView CreateListView()
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.ListView.IsRefreshing" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ItemAppearing">
@@ -1083,7 +1044,6 @@ ListView CreateListView()
       </ReturnValue>
       <Docs>
         <summary>Event that is raised when a new item is selected.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ItemTapped">
@@ -1109,7 +1069,6 @@ ListView CreateListView()
       </ReturnValue>
       <Docs>
         <summary>Event that is raised when an item is tapped.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="NotifyRowTapped">
@@ -1142,7 +1101,6 @@ ListView CreateListView()
         <param name="index">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="cell">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="NotifyRowTapped">
@@ -1177,7 +1135,6 @@ ListView CreateListView()
         <param name="inGroupIndex">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="cell">To be added.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="NotifyRowTapped">
@@ -1210,8 +1167,6 @@ ListView CreateListView()
         <param name="index">To be added.</param>
         <param name="cell">To be added.</param>
         <param name="isContextmenuRequested">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="NotifyRowTapped">
@@ -1246,8 +1201,6 @@ ListView CreateListView()
         <param name="inGroupIndex">To be added.</param>
         <param name="cell">To be added.</param>
         <param name="isContextMenuRequested">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="On&lt;T&gt;">
@@ -1278,8 +1231,6 @@ ListView CreateListView()
       <Docs>
         <typeparam name="T">To be added.</typeparam>
         <summary>Returns the platform-specific instance of this <see cref="T:Microsoft.Maui.Controls.ListView" />, on which a platform-specific method may be called.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnBindingContextChanged">
@@ -1299,7 +1250,6 @@ ListView CreateListView()
       <Parameters />
       <Docs>
         <summary>Method that is called when the binding context changes.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnSizeRequest">
@@ -1336,8 +1286,6 @@ ListView CreateListView()
         <param name="widthConstraint">The width constraint.</param>
         <param name="heightConstraint">The height constraint.</param>
         <summary>Method that is called when a size request is made.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RefreshAllowed">
@@ -1361,8 +1309,6 @@ ListView CreateListView()
       </ReturnValue>
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RefreshCommand">
@@ -1384,8 +1330,6 @@ ListView CreateListView()
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the command that is run when the list view enters the refreshing state.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RefreshCommandProperty">
@@ -1407,7 +1351,6 @@ ListView CreateListView()
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.ListView.RefreshCommand" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RefreshControlColor">
@@ -1424,9 +1367,6 @@ ListView CreateListView()
         <ReturnType>Microsoft.Maui.Graphics.Color</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RefreshControlColorProperty">
@@ -1444,7 +1384,6 @@ ListView CreateListView()
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.ListView.RefreshControlColor" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Refreshing">
@@ -1466,7 +1405,6 @@ ListView CreateListView()
       </ReturnValue>
       <Docs>
         <summary>Event that is raised when the list view refreshes.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RowHeight">
@@ -1492,8 +1430,6 @@ ListView CreateListView()
       </ReturnValue>
       <Docs>
         <summary>Gets or sets a value that represents the height of a row.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RowHeightProperty">
@@ -1519,7 +1455,6 @@ ListView CreateListView()
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="F:Microsoft.Maui.Controls.ListView.RowHeightProperty" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Scrolled">
@@ -1536,8 +1471,6 @@ ListView CreateListView()
         <ReturnType>System.EventHandler&lt;Microsoft.Maui.Controls.ScrolledEventArgs&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ScrollTo">
@@ -1639,7 +1572,6 @@ ListView CreateListView()
       </ReturnValue>
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SelectedItem">
@@ -1666,7 +1598,6 @@ ListView CreateListView()
       <Docs>
         <summary>Gets or sets the currently selected item from the <see cref="P:Microsoft.Maui.Controls.ItemsView`1.ItemsSource" />.</summary>
         <value>The selected item or <see langword="null" /> if no item is selected.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SelectedItemProperty">
@@ -1692,7 +1623,6 @@ ListView CreateListView()
       </ReturnValue>
       <Docs>
         <summary>Identifies the <see cref="F:Microsoft.Maui.Controls.ListView.SelectedItemProperty" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SelectionMode">
@@ -1732,7 +1662,6 @@ ListView CreateListView()
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.ListView.SelectionMode" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SendCellAppearing">
@@ -1763,7 +1692,6 @@ ListView CreateListView()
       <Docs>
         <param name="cell">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SendCellDisappearing">
@@ -1794,7 +1722,6 @@ ListView CreateListView()
       <Docs>
         <param name="cell">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SendRefreshing">
@@ -1822,7 +1749,6 @@ ListView CreateListView()
       <Parameters />
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SendScrolled">
@@ -1848,8 +1774,6 @@ ListView CreateListView()
       </Parameters>
       <Docs>
         <param name="args">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SeparatorColor">
@@ -1871,7 +1795,6 @@ ListView CreateListView()
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the color of the bar that separates list items.</summary>
-        <value>To be added.</value>
         <remarks>The default value is <c>Color.Default</c>. This property has no effect if <see cref="P:Microsoft.Maui.Controls.ListView.SeparatorVisibility" /> is <see langword="false" />.</remarks>
       </Docs>
     </Member>
@@ -1894,7 +1817,6 @@ ListView CreateListView()
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.ListView.SeparatorColor" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SeparatorVisibility">
@@ -1916,8 +1838,6 @@ ListView CreateListView()
       </ReturnValue>
       <Docs>
         <summary>Gets or sets a value that tells whether separators are visible between items.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SeparatorVisibilityProperty">
@@ -1939,7 +1859,6 @@ ListView CreateListView()
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.ListView.SeparatorVisibility" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetupContent">
@@ -2027,7 +1946,6 @@ ListView CreateListView()
         <summary>Returns <see langword="false" /> if <paramref name="template" /> is a template selector and elements are being retained. Otherwise, returns <see langword="true" />.</summary>
         <returns>
           <see langword="false" /> if <paramref name="template" /> is a template selector and elements are being retained. Otherwise, <see langword="true" />.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="VerticalScrollBarVisibility">
@@ -2044,9 +1962,6 @@ ListView CreateListView()
         <ReturnType>Microsoft.Maui.Controls.ScrollBarVisibility</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="VerticalScrollBarVisibilityProperty">
@@ -2064,7 +1979,6 @@ ListView CreateListView()
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.ListView.VerticalScrollBarVisibility" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/ListViewSelectionMode.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/ListViewSelectionMode.xml
@@ -13,7 +13,6 @@
   </Base>
   <Docs>
     <summary>Enumerates values that control whether items in a list view can or cannot be selected.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="None">

--- a/src/Controls/docs/Microsoft.Maui.Controls/MarshalingObservableCollection.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/MarshalingObservableCollection.xml
@@ -19,8 +19,6 @@
     </Interface>
   </Interfaces>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -38,8 +36,6 @@
       </Parameters>
       <Docs>
         <param name="list">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CollectionChanged">
@@ -59,8 +55,6 @@
         <ReturnType>System.Collections.Specialized.NotifyCollectionChangedEventHandler</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/MeasureFlags.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/MeasureFlags.xml
@@ -18,7 +18,6 @@
   </Attributes>
   <Docs>
     <summary>Enumerates values that tell whether margins are included when laying out windows.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="IncludeMargins">

--- a/src/Controls/docs/Microsoft.Maui.Controls/Menu.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/Menu.xml
@@ -33,7 +33,6 @@
   </Interfaces>
   <Docs>
     <summary>Represents an application menu on platforms that support them.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -49,7 +48,6 @@
       <Parameters />
       <Docs>
         <summary>Creates a new menu with default values.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Add">
@@ -75,7 +73,6 @@
       <Docs>
         <param name="item">The menu to add to this menu.</param>
         <summary>Add <paramref name="item" /> to the end of the collection of menus in this menu.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Clear">
@@ -98,7 +95,6 @@
       <Parameters />
       <Docs>
         <summary>Clears all the menus from this menu.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Contains">
@@ -126,7 +122,6 @@
         <summary>Returns <see langword="true" /> if <paramref name="item" /> is contained in the top-level collection of menus that belong to this menu. Otherwise, returns <see langword="false" />.</summary>
         <returns>
           <see langword="true" /> if <paramref name="item" /> is contained in the top-level collection of menus that belong to this menu. Otherwise, <see langword="false" />.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CopyTo">
@@ -154,7 +149,6 @@
         <param name="array">The menu items to copy into this menu.</param>
         <param name="arrayIndex">The index at which to begin inserting menus.</param>
         <summary>Copies <paramref name="array" /> into this menu's collection of menus, beginning at <paramref name="arrayIndex" />.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Count">
@@ -176,8 +170,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets the number of menus that are contained in this menu.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetEnumerator">
@@ -200,8 +192,6 @@
       <Parameters />
       <Docs>
         <summary>Returns an enumerator for the menus that are contained in this menu.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IndexOf">
@@ -227,8 +217,6 @@
       <Docs>
         <param name="item">The menu whose index to get.</param>
         <summary>Returns the index of <paramref name="item" />.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Insert">
@@ -256,7 +244,6 @@
         <param name="index">The index at which to insert <paramref name="itme" />.</param>
         <param name="item">The menu to insert.</param>
         <summary>Inserts <paramref name="item" /> into this menu's collection of items at <paramref name="index" />.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Invalidate">
@@ -276,7 +263,6 @@
       <Parameters />
       <Docs>
         <summary>Visually displays the menu as invalid.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsReadOnly">
@@ -300,7 +286,6 @@
         <summary>Returns <see langword="false" />.</summary>
         <value>
           <see langword="false" />.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Item">
@@ -327,7 +312,6 @@
         <param name="index">The index of the item to get or set.</param>
         <summary>Gets or sets the menu at <paramref name="index" />.</summary>
         <value>The menu at <paramref name="index" />.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Items">
@@ -346,8 +330,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets the collection of menus that belong to this menu.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Remove">
@@ -373,8 +355,6 @@
       <Docs>
         <param name="item">The menu to remove.</param>
         <summary>Removes <paramref name="item" />.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RemoveAt">
@@ -400,7 +380,6 @@
       <Docs>
         <param name="index">The index for the menu to remove.</param>
         <summary>Removes the menu at <paramref name="index" />.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="System.Collections.IEnumerable.GetEnumerator">
@@ -423,8 +402,6 @@
       <Parameters />
       <Docs>
         <summary>For internal use only.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Text">
@@ -444,7 +421,6 @@
       <Docs>
         <summary>Gets or sets the text of the menu.</summary>
         <value>The menu text.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/MenuItem.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/MenuItem.xml
@@ -21,7 +21,6 @@
   </Interfaces>
   <Docs>
     <summary>Class that presents a menu item and associates it with a command.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -40,7 +39,6 @@
       <Parameters />
       <Docs>
         <summary>Intitializes a new <see cref="T:Microsoft.Maui.Controls.MenuItem" /> instance.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="AcceleratorProperty">
@@ -59,7 +57,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the accelerator attached property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="class">
@@ -81,9 +78,6 @@
         <ReturnType>System.Collections.Generic.IList&lt;System.String&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Clicked">
@@ -105,7 +99,6 @@
       </ReturnValue>
       <Docs>
         <summary>Event that is raised when the menu item is clicked.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Command">
@@ -127,8 +120,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the command that is run when the menu is clicked.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CommandParameter">
@@ -150,8 +141,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the parameter that is passed to the command.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CommandParameterProperty">
@@ -173,7 +162,6 @@
       </ReturnValue>
       <Docs>
         <summary>Identifies the command parameter bound property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CommandProperty">
@@ -195,7 +183,6 @@
       </ReturnValue>
       <Docs>
         <summary>Identifies the command bound property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetAccelerator">
@@ -218,8 +205,6 @@
       <Docs>
         <param name="bindable">The bindable object for which to retrieve the accelerator keys.</param>
         <summary>Gets the accelerator for the specified bindable object.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Icon">
@@ -249,8 +234,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the icon for the menu item.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IconImageSource">
@@ -267,9 +250,6 @@
         <ReturnType>Microsoft.Maui.Controls.ImageSource</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IconImageSourceProperty">
@@ -286,8 +266,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IconProperty">
@@ -317,7 +295,6 @@
       </ReturnValue>
       <Docs>
         <summary>Identfies the icon bound property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsDestructive">
@@ -371,7 +348,6 @@
       </ReturnValue>
       <Docs>
         <summary>Identifies the IsDestructive bound property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsEnabled">
@@ -398,8 +374,6 @@
       </ReturnValue>
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsEnabledProperty">
@@ -418,7 +392,6 @@
       </ReturnValue>
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsEnabledPropertyName">
@@ -443,9 +416,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnClicked">
@@ -468,7 +438,6 @@
       <Parameters />
       <Docs>
         <summary>When overridden by an app dev, implements behavior when the menu item is clicked.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetAccelerator">
@@ -493,7 +462,6 @@
         <param name="bindable">The bindable object for which to set the accelerator keys.</param>
         <param name="value">The new accelerator for the object.</param>
         <summary>Sets the accelerator for the specified bindable object.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="StyleClass">
@@ -516,8 +484,6 @@
       </ReturnValue>
       <Docs>
         <summary>Sets the StyleClass of the generated <see cref="T:Microsoft.Maui.Controls.FlyoutItem" /> when used with <see cref="T:Microsoft.Maui.Controls.Shell" /></summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Text">
@@ -539,8 +505,6 @@
       </ReturnValue>
       <Docs>
         <summary>The text of the menu item.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TextProperty">
@@ -562,7 +526,6 @@
       </ReturnValue>
       <Docs>
         <summary>Identifies the text bound property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IMenuItemController.Activate">
@@ -588,8 +551,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/MenuItemCollection.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/MenuItemCollection.xml
@@ -35,7 +35,6 @@
   </Interfaces>
   <Docs>
     <summary>A group of related <see cref="T:Microsoft.Maui.Controls.MenuItem" /> objects.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -49,8 +48,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Add">
@@ -74,8 +71,6 @@
       </Parameters>
       <Docs>
         <param name="item">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Clear">
@@ -96,8 +91,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Contains">
@@ -121,9 +114,6 @@
       </Parameters>
       <Docs>
         <param name="item">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CopyTo">
@@ -149,8 +139,6 @@
       <Docs>
         <param name="array">To be added.</param>
         <param name="arrayIndex">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Count">
@@ -170,9 +158,6 @@
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetEnumerator">
@@ -193,9 +178,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IndexOf">
@@ -219,9 +201,6 @@
       </Parameters>
       <Docs>
         <param name="item">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Insert">
@@ -247,8 +226,6 @@
       <Docs>
         <param name="index">To be added.</param>
         <param name="item">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsReadOnly">
@@ -268,9 +245,6 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Item">
@@ -294,9 +268,6 @@
       </Parameters>
       <Docs>
         <param name="index">To be added.</param>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Remove">
@@ -320,9 +291,6 @@
       </Parameters>
       <Docs>
         <param name="item">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RemoveAt">
@@ -346,8 +314,6 @@
       </Parameters>
       <Docs>
         <param name="index">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="System.Collections.IEnumerable.GetEnumerator">
@@ -368,9 +334,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="System.Collections.Specialized.INotifyCollectionChanged.CollectionChanged">
@@ -390,8 +353,6 @@
         <ReturnType>System.Collections.Specialized.NotifyCollectionChangedEventHandler</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/MessagingCenter.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/MessagingCenter.xml
@@ -60,7 +60,6 @@ Assert.AreEqual(2, subscriber.IntProperty);
       <Parameters />
       <Docs>
         <summary>Creates a new <see cref="T:Microsoft.Maui.Controls.MessagingCenter" /> with default values.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Instance">
@@ -80,7 +79,6 @@ Assert.AreEqual(2, subscriber.IntProperty);
       <Docs>
         <summary>Gets the singleton instance of the <see cref="T:Microsoft.Maui.Controls.MessagingCenter" />.</summary>
         <value>The singleton instance of the <see cref="T:Microsoft.Maui.Controls.MessagingCenter" />.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Send&lt;TSender&gt;">
@@ -122,7 +120,6 @@ Assert.AreEqual(2, subscriber.IntProperty);
         <param name="sender">The instance that is sending the message. Typically, this is specified with the <see langword="this" /> keyword used within the sending object.</param>
         <param name="message">The message that will be sent to objects that are listening for the message from instances of type <typeparamref name="TSender" />.</param>
         <summary>Sends a named message that has no arguments.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Send&lt;TSender,TArgs&gt;">
@@ -168,7 +165,6 @@ Assert.AreEqual(2, subscriber.IntProperty);
         <param name="message">The message that will be sent to objects that are listening for the message from instances of type <typeparamref name="TSender" />.</param>
         <param name="args">The arguments that will be passed to the listener's callback.</param>
         <summary>Sends a named message with the specified arguments.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Subscribe&lt;TSender&gt;">
@@ -214,7 +210,6 @@ Assert.AreEqual(2, subscriber.IntProperty);
         <param name="callback">A callback, which takes the sender and arguments as parameters, that is run when the message is received by the subscriber.</param>
         <param name="source">The object that will send the messages.</param>
         <summary>Run the <paramref name="callback" /> on <paramref name="subscriber" /> in response to messages that are named <paramref name="message" /> and that are created by <paramref name="source" />.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Subscribe&lt;TSender,TArgs&gt;">
@@ -262,7 +257,6 @@ Assert.AreEqual(2, subscriber.IntProperty);
         <param name="callback">A callback, which takes the sender and arguments as parameters, that is run when the message is received by the subscriber.</param>
         <param name="source">The object that will send the messages.</param>
         <summary>Run the <paramref name="callback" /> on <paramref name="subscriber" /> in response to parameterized messages that are named <paramref name="message" /> and that are created by <paramref name="source" />.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Unsubscribe&lt;TSender&gt;">
@@ -300,7 +294,6 @@ Assert.AreEqual(2, subscriber.IntProperty);
         <param name="subscriber">The object that is subscribing to the messages. Typically, this is specified with the <see langword="this" /> keyword used within the subscribing object.</param>
         <param name="message">The message that will be sent to objects that are listening for the message from instances of type <typeparamref name="TSender" />.</param>
         <summary>Unsubscribes a subscriber from the specified messages that come from the specified sender.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Unsubscribe&lt;TSender,TArgs&gt;">
@@ -341,7 +334,6 @@ Assert.AreEqual(2, subscriber.IntProperty);
         <param name="subscriber">The object that is subscribing to the messages. Typically, this is specified with the <see langword="this" /> keyword used within the subscribing object.</param>
         <param name="message">The message that will be sent to objects that are listening for the message from instances of type <typeparamref name="TSender" />.</param>
         <summary>Unsubscribes from the specified parameterless subscriber messages.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IMessagingCenter.Send&lt;TSender&gt;">
@@ -377,7 +369,6 @@ Assert.AreEqual(2, subscriber.IntProperty);
         <param name="sender">The instance that is sending the message. Typically, this is specified with the <see langword="this" /> keyword used within the sending object.</param>
         <param name="message">The message that will be sent to objects that are listening for the message from instances of type <typeparamref name="TSender" />.</param>
         <summary>Sends the named parameterless message to objects that are listening for it on the type that is specified by <typeparamref name="TSender" />.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IMessagingCenter.Send&lt;TSender,TArgs&gt;">
@@ -417,7 +408,6 @@ Assert.AreEqual(2, subscriber.IntProperty);
         <param name="message">The message that will be sent to objects that are listening for the message from instances of type <typeparamref name="TSender" />.</param>
         <param name="args">The arguments that will be passed to the listener's callback.</param>
         <summary>Sends a message and arguments to objects that are listening for them on the type that is specified by <typeparamref name="TSender" />.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IMessagingCenter.Subscribe&lt;TSender&gt;">
@@ -457,7 +447,6 @@ Assert.AreEqual(2, subscriber.IntProperty);
         <param name="callback">A callback, which takes the sender and arguments as parameters, that is run when the message is received by the subscriber.</param>
         <param name="source">The object that will send the messages.</param>
         <summary>Subscribes to the specified <paramref name="message" /> from the specified <paramref name="source" />.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IMessagingCenter.Subscribe&lt;TSender,TArgs&gt;">
@@ -499,7 +488,6 @@ Assert.AreEqual(2, subscriber.IntProperty);
         <param name="callback">A callback, which takes the sender and arguments as parameters, that is run when the message is received by the subscriber.</param>
         <param name="source">The object that will send the messages.</param>
         <summary>Subscribes to the specified <paramref name="message" /> from the specified <paramref name="source" />.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IMessagingCenter.Unsubscribe&lt;TSender&gt;">
@@ -535,7 +523,6 @@ Assert.AreEqual(2, subscriber.IntProperty);
         <param name="subscriber">The object that is unsubscribing to the messages. Typically, this is specified with the <see langword="this" /> keyword used within the subscribing object.</param>
         <param name="message">The message that will be sent to objects that are listening for the message from instances of type <typeparamref name="TSender" />.</param>
         <summary>Unsubscribes the specified <paramref name="subscriber" /> from the specified <paramref name="message" />.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IMessagingCenter.Unsubscribe&lt;TSender,TArgs&gt;">
@@ -573,7 +560,6 @@ Assert.AreEqual(2, subscriber.IntProperty);
         <param name="subscriber">The object that is subscribing to the messages. Typically, this is specified with the <see langword="this" /> keyword used within the subscribing object.</param>
         <param name="message">The message that will be sent to objects that are listening for the message from instances of type <typeparamref name="TSender" />.</param>
         <summary>Unsubscribes the specified <paramref name="subscriber" /> from the specified <paramref name="message" />.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/ModalEventArgs.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/ModalEventArgs.xml
@@ -17,7 +17,6 @@
   <Interfaces />
   <Docs>
     <summary>Base class for <see cref="T:Microsoft.Maui.Controls.ModalPushedEventArgs" />, <see cref="T:Microsoft.Maui.Controls.ModalPushingEventArgs" />, <see cref="T:Microsoft.Maui.Controls.ModalPoppedEventArgs" />, and <see cref="T:Microsoft.Maui.Controls.ModalPoppingEventArgs" />.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -40,7 +39,6 @@
       <Docs>
         <param name="modal">The modal page.</param>
         <summary>Creates a new <see cref="T:Microsoft.Maui.Controls.ModalEventArgs" /> object for a navigation event that happened to the <paramref name="modal" /> page.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Modal">
@@ -62,8 +60,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the page whose navigation triggered the event.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/ModalPoppedEventArgs.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/ModalPoppedEventArgs.xml
@@ -17,7 +17,6 @@
   <Interfaces />
   <Docs>
     <summary>Arguments for the event that is raised when a modal window is popped from the navigation stack.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -40,7 +39,6 @@
       <Docs>
         <param name="modal">The modal page.</param>
         <summary>Constructs a new <see cref="T:Microsoft.Maui.Controls.ModalPoppedEventArgs" /> object for the page that was just popped.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/ModalPoppingEventArgs.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/ModalPoppingEventArgs.xml
@@ -17,7 +17,6 @@
   <Interfaces />
   <Docs>
     <summary>Arguments for the event that is raised when a modal window is popping from the navigation stack.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -40,7 +39,6 @@
       <Docs>
         <param name="modal">The modal page.</param>
         <summary>Constructs a new <see cref="T:Microsoft.Maui.Controls.ModalPoppingEventArgs" /> object for the page that is being popped.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Cancel">
@@ -62,8 +60,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets a value that tells whether the modal navigation was canceled.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/ModalPushedEventArgs.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/ModalPushedEventArgs.xml
@@ -17,7 +17,6 @@
   <Interfaces />
   <Docs>
     <summary>Arguments for the event that is raised when a modal window is pushed onto the navigation stack.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -40,7 +39,6 @@
       <Docs>
         <param name="modal">The modal page.</param>
         <summary>Constructs a new <see cref="T:Microsoft.Maui.Controls.ModalPushedEventArgs" /> object for the page that was just popped.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/ModalPushingEventArgs.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/ModalPushingEventArgs.xml
@@ -17,7 +17,6 @@
   <Interfaces />
   <Docs>
     <summary>Arguments for the event that is raised when a modal window is being pushed onto the navigation stack.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -40,7 +39,6 @@
       <Docs>
         <param name="modal">The modal page.</param>
         <summary>Constructs a new <see cref="T:Microsoft.Maui.Controls.ModalPushingEventArgs" /> object for the page that is being pushed.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/MultiBinding.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/MultiBinding.xml
@@ -17,8 +17,6 @@
     </Attribute>
   </Attributes>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -32,8 +30,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Bindings">
@@ -50,9 +46,6 @@
         <ReturnType>System.Collections.Generic.IList&lt;Microsoft.Maui.Controls.BindingBase&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Converter">
@@ -69,9 +62,6 @@
         <ReturnType>Microsoft.Maui.Controls.IMultiValueConverter</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ConverterParameter">
@@ -88,9 +78,6 @@
         <ReturnType>System.Object</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/MultiTrigger.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/MultiTrigger.xml
@@ -91,7 +91,6 @@
       <Docs>
         <param name="targetType">The type of the trigger target.</param>
         <summary>Initializes a new <see cref="T:Microsoft.Maui.Controls.MultiTrigger" /> instance.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Conditions">
@@ -113,8 +112,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets the list of conditions that must be satisfied in ordeer for the setters in the <see cref="P:Microsoft.Maui.Controls.MultiTrigger.Setters" /> list to be invoked.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Setters">
@@ -136,8 +133,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets the list of <see cref="T:Microsoft.Maui.Controls.Setter" /> objects that will be applied when the list of conditions in the <see cref="P:Microsoft.Maui.Controls.MultiTrigger.Conditions" /> property are all met.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/NameScopeExtensions.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/NameScopeExtensions.xml
@@ -20,7 +20,6 @@
   <Interfaces />
   <Docs>
     <summary>Extension methods for <see cref="T:Microsoft.Maui.Controls.Element" />  that adds a strongly-typed FindByName method.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="FindByName&lt;T&gt;">
@@ -55,8 +54,6 @@
         <param name="element">An element in the scope to search.</param>
         <param name="name">The name of the element to find.</param>
         <summary>Returns the instance of type <paramref name="T" /> that has name <paramref name="name" /> in the scope that includes <paramref name="element" />.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/NamedPlatformColor.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/NamedPlatformColor.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="AlternateSelectedControlTextColor">
@@ -30,8 +28,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="BackgroundDark">
@@ -48,8 +44,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="BackgroundLight">
@@ -66,8 +60,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Black">
@@ -84,8 +76,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ControlAccent">
@@ -102,8 +92,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ControlBackgroundColor">
@@ -120,8 +108,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ControlColor">
@@ -138,8 +124,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ControlTextColor">
@@ -156,8 +140,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="DarkerGray">
@@ -174,8 +156,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="DisabledControlTextColor">
@@ -192,8 +172,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FindHighlightColor">
@@ -210,8 +188,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GridColor">
@@ -228,8 +204,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="HeaderTextColor">
@@ -246,8 +220,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="HighlightColor">
@@ -264,8 +236,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="HoloBlueBright">
@@ -282,8 +252,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="HoloBlueDark">
@@ -300,8 +268,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="HoloBlueLight">
@@ -318,8 +284,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="HoloGreenDark">
@@ -336,8 +300,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="HoloGreenLight">
@@ -354,8 +316,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="HoloOrangeDark">
@@ -372,8 +332,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="HoloOrangeLight">
@@ -390,8 +348,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="HoloPurple">
@@ -408,8 +364,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="HoloRedDark">
@@ -426,8 +380,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="HoloRedLight">
@@ -444,8 +396,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="KeyboardFocusIndicatorColor">
@@ -462,8 +412,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Label">
@@ -480,8 +428,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="LabelColor">
@@ -498,8 +444,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Link">
@@ -516,8 +460,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="LinkColor">
@@ -534,8 +476,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OpaqueSeparator">
@@ -552,8 +492,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PlaceholderText">
@@ -570,8 +508,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PlaceholderTextColor">
@@ -588,8 +524,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="QuaternaryLabel">
@@ -606,8 +540,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="QuaternaryLabelColor">
@@ -624,8 +556,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SecondaryLabel">
@@ -642,8 +572,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SecondaryLabelColor">
@@ -660,8 +588,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SelectedContentBackgroundColor">
@@ -678,8 +604,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SelectedControlColor">
@@ -696,8 +620,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SelectedControlTextColor">
@@ -714,8 +636,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SelectedMenuItemTextColor">
@@ -732,8 +652,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SelectedTextBackgroundColor">
@@ -750,8 +668,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SelectedTextColor">
@@ -768,8 +684,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Separator">
@@ -786,8 +700,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SeparatorColor">
@@ -804,8 +716,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ShadowColor">
@@ -822,8 +732,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SystemAltHighColor">
@@ -840,8 +748,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SystemAltLowColor">
@@ -858,8 +764,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SystemAltMediumColor">
@@ -876,8 +780,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SystemAltMediumHighColor">
@@ -894,8 +796,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SystemAltMediumLowColor">
@@ -912,8 +812,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SystemBaseHighColor">
@@ -930,8 +828,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SystemBaseLowColor">
@@ -948,8 +844,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SystemBaseMediumColor">
@@ -966,8 +860,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SystemBaseMediumHighColor">
@@ -984,8 +876,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SystemBaseMediumLowColor">
@@ -1002,8 +892,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SystemBlue">
@@ -1020,8 +908,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SystemChromeAltLowColor">
@@ -1038,8 +924,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SystemChromeBlackHighColor">
@@ -1056,8 +940,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SystemChromeBlackLowColor">
@@ -1074,8 +956,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SystemChromeBlackMediumColor">
@@ -1092,8 +972,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SystemChromeBlackMediumLowColor">
@@ -1110,8 +988,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SystemChromeDisabledHighColor">
@@ -1128,8 +1004,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SystemChromeDisabledLowColor">
@@ -1146,8 +1020,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SystemChromeHighColor">
@@ -1164,8 +1036,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SystemChromeLowColor">
@@ -1182,8 +1052,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SystemChromeMediumColor">
@@ -1200,8 +1068,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SystemChromeMediumLowColor">
@@ -1218,8 +1084,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SystemChromeWhiteColor">
@@ -1236,8 +1100,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SystemGray">
@@ -1254,8 +1116,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SystemGray2">
@@ -1272,8 +1132,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SystemGray3">
@@ -1290,8 +1148,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SystemGray4">
@@ -1308,8 +1164,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SystemGray5">
@@ -1326,8 +1180,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SystemGray6">
@@ -1344,8 +1196,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SystemGreen">
@@ -1362,8 +1212,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SystemIndigo">
@@ -1380,8 +1228,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SystemListLowColor">
@@ -1398,8 +1244,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SystemListMediumColor">
@@ -1416,8 +1260,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SystemOrange">
@@ -1434,8 +1276,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SystemPink">
@@ -1452,8 +1292,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SystemPurple">
@@ -1470,8 +1308,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SystemRed">
@@ -1488,8 +1324,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SystemTeal">
@@ -1506,8 +1340,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SystemYellow">
@@ -1524,8 +1356,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TabIndicatorText">
@@ -1542,8 +1372,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TertiaryLabel">
@@ -1560,8 +1388,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TertiaryLabelColor">
@@ -1578,8 +1404,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TextBackgroundColor">
@@ -1596,8 +1420,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TextColor">
@@ -1614,8 +1436,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Transparent">
@@ -1632,8 +1452,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="UnderPageBackgroundColor">
@@ -1650,8 +1468,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="UnemphasizedSelectedContentBackgroundColor">
@@ -1668,8 +1484,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="UnemphasizedSelectedTextBackgroundColor">
@@ -1686,8 +1500,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="UnemphasizedSelectedTextColor">
@@ -1704,8 +1516,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="White">
@@ -1722,8 +1532,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="WidgetEditTextDark">
@@ -1740,8 +1548,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="WindowBackgroundColor">
@@ -1758,8 +1564,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="WindowFrameTextColor">
@@ -1776,8 +1580,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/NavigationEventArgs.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/NavigationEventArgs.xml
@@ -51,7 +51,6 @@
         <param name="page">The page that was popped or is newly visible.</param>
         <summary>
         </summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Page">

--- a/src/Controls/docs/Microsoft.Maui.Controls/NavigationPage.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/NavigationPage.xml
@@ -60,7 +60,6 @@
       <Parameters />
       <Docs>
         <summary>Initializes a new <see cref="T:Microsoft.Maui.Controls.NavigationPage" /> object.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -86,7 +85,6 @@
       <Docs>
         <param name="root">To be added.</param>
         <summary>Creates a new <see cref="T:Microsoft.Maui.Controls.NavigationPage" /> element with <paramref name="root" /> as its root element.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="BackButtonTitleProperty">
@@ -111,7 +109,6 @@
       </ReturnValue>
       <Docs>
         <summary>Identifies the property associated with the title of the back button.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="BarBackground">
@@ -128,9 +125,6 @@
         <ReturnType>Microsoft.Maui.Controls.Brush</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="BarBackgroundColor">
@@ -179,7 +173,6 @@
       </ReturnValue>
       <Docs>
         <summary>Identifies the property associated with the color of the NavigationPage's bar background color.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="BarBackgroundProperty">
@@ -196,8 +189,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="BarTextColor">
@@ -246,7 +237,6 @@
       </ReturnValue>
       <Docs>
         <summary>Identifies the property associated with the color of the NavigationPage's bar text color.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CurrentPage">
@@ -271,8 +261,6 @@
       </ReturnValue>
       <Docs>
         <summary>The <see cref="T:Microsoft.Maui.Controls.Page" /> that is currently top-most on the navigation stack.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CurrentPageProperty">
@@ -328,7 +316,6 @@
         <param name="page">The <see cref="T:Microsoft.Maui.Controls.Page" /> whose back-button's title is being requested.</param>
         <summary>The title of the back button for the specified <paramref name="page" />.</summary>
         <returns>The title of the back button that would be shown if the specified <paramref name="page" /> were the <see cref="P:Microsoft.Maui.Controls.NavigationPage.CurrentPage" />.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetHasBackButton">
@@ -354,8 +341,6 @@
       <Docs>
         <param name="page">To be added.</param>
         <summary>Returns a value that indicates whether <paramref name="page" /> has a back button.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetHasNavigationBar">
@@ -386,7 +371,6 @@
         <summary>Returns a value that indicates whether the <paramref name="page" /> has a navigation bar.</summary>
         <returns>
           <see langword="true" /> if <paramref name="page" /> would display a navigation bar were it the <see cref="P:Microsoft.Maui.Controls.NavigationPage.CurrentPage" />.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetIconColor">
@@ -407,9 +391,6 @@
       </Parameters>
       <Docs>
         <param name="bindable">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetTitleIcon">
@@ -438,9 +419,6 @@
       </Parameters>
       <Docs>
         <param name="bindable">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetTitleIconImageSource">
@@ -461,9 +439,6 @@
       </Parameters>
       <Docs>
         <param name="bindable">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetTitleView">
@@ -487,7 +462,6 @@
         <param name="bindable">The bindable object whose title view to get.</param>
         <summary>Returns the view to use as a title for the navigation page.</summary>
         <returns>The view to use as a title for the navigation page.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="HasBackButtonProperty">
@@ -509,7 +483,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the HasBackButton property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="HasNavigationBarProperty">
@@ -534,7 +507,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the HasNavigationBar property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IconColorProperty">
@@ -551,8 +523,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="InsertPageBeforeRequested">
@@ -579,7 +549,6 @@
       </ReturnValue>
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="On&lt;T&gt;">
@@ -610,8 +579,6 @@
       <Docs>
         <typeparam name="T">To be added.</typeparam>
         <summary>Returns the platform-specific instance of this <see cref="T:Microsoft.Maui.Controls.NavigationPage" />, on which a platform-specific method may be called.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnBackButtonPressed">
@@ -634,8 +601,6 @@
       <Parameters />
       <Docs>
         <summary>Event that is raised when the hardware back button is pressed. This event is not raised on iOS.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Pages">
@@ -662,8 +627,6 @@
       </ReturnValue>
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Peek">
@@ -694,8 +657,6 @@
       <Docs>
         <param name="depth">To be added.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PopAsync">
@@ -722,7 +683,6 @@
       <Docs>
         <summary>Asynchronously removes the top <see cref="T:Microsoft.Maui.Controls.Page" /> from the navigation stack.</summary>
         <returns>The <see cref="T:Microsoft.Maui.Controls.Page" /> that had been at the top of the navigation stack.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PopAsync">
@@ -748,8 +708,6 @@
       <Docs>
         <param name="animated">To be added.</param>
         <summary>Asynchronously removes the top <see cref="T:Microsoft.Maui.Controls.Page" /> from the navigation stack, with optional animation.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PopAsyncInner">
@@ -782,8 +740,6 @@
         <param name="animated">To be added.</param>
         <param name="fast">To be added.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Popped">
@@ -808,7 +764,6 @@
       </ReturnValue>
       <Docs>
         <summary>Event that is raised after a page is popped from this <see cref="T:Microsoft.Maui.Controls.NavigationPage" /> element.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PoppedToRoot">
@@ -862,7 +817,6 @@
       </ReturnValue>
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PopToRootAsync">
@@ -889,7 +843,6 @@
       <Docs>
         <summary>Pops all but the root <see cref="T:Microsoft.Maui.Controls.Page" /> off the navigation stack.</summary>
         <returns>A task that represents the asynchronous dismiss operation.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PopToRootAsync">
@@ -915,8 +868,6 @@
       <Docs>
         <param name="animated">To be added.</param>
         <summary>A task for asynchronously popping all pages off of the navigation stack.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PopToRootRequested">
@@ -943,7 +894,6 @@
       </ReturnValue>
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PushAsync">
@@ -973,7 +923,6 @@
         <param name="page">The <see cref="T:Microsoft.Maui.Controls.Page" /> to present.</param>
         <summary>Presents a <see cref="T:Microsoft.Maui.Controls.Page" /> by asynchronously pushing it onto the navigation stack.</summary>
         <returns>An awaitable Task, indicating the Push completion.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PushAsync">
@@ -1001,8 +950,6 @@
         <param name="page">To be added.</param>
         <param name="animated">To be added.</param>
         <summary>A task for asynchronously pushing a page onto the navigation stack, with optional animation.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Pushed">
@@ -1027,7 +974,6 @@
       </ReturnValue>
       <Docs>
         <summary>Event that is raised when a page is pushed onto this <see cref="T:Microsoft.Maui.Controls.NavigationPage" /> element.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PushRequested">
@@ -1054,7 +1000,6 @@
       </ReturnValue>
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RemovePageRequested">
@@ -1081,7 +1026,6 @@
       </ReturnValue>
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RootPage">
@@ -1102,8 +1046,6 @@
         <summary>
           The <see cref="T:Microsoft.Maui.Controls.Page" /> that is the root of the navigation stack.
         </summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RootPageProperty">
@@ -1156,7 +1098,6 @@
         <param name="page">To be added.</param>
         <param name="value">To be added.</param>
         <summary>Sets the title that appears on the back button for <paramref name="page" />.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetHasBackButton">
@@ -1184,7 +1125,6 @@
         <param name="page">To be added.</param>
         <param name="value">To be added.</param>
         <summary>Adds or removes a back button to <paramref name="page" />, with optional animation.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetHasNavigationBar">
@@ -1215,7 +1155,6 @@
         <param name="page">To be added.</param>
         <param name="value">To be added.</param>
         <summary>Sets a value that indicates whether or not this <see cref="T:Microsoft.Maui.Controls.NavigationPage" /> element has a navigation bar.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetIconColor">
@@ -1238,8 +1177,6 @@
       <Docs>
         <param name="bindable">To be added.</param>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetTitleIcon">
@@ -1270,8 +1207,6 @@
       <Docs>
         <param name="bindable">To be added.</param>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetTitleIconImageSource">
@@ -1294,8 +1229,6 @@
       <Docs>
         <param name="bindable">To be added.</param>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetTitleView">
@@ -1320,7 +1253,6 @@
         <param name="bindable">The bindable object whose title to set.</param>
         <param name="value">The view to use.</param>
         <summary>Sets the view to use as the title for the navigation page.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="StackDepth">
@@ -1347,8 +1279,6 @@
       </ReturnValue>
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Tint">
@@ -1381,7 +1311,6 @@
       </ReturnValue>
       <Docs>
         <summary>The color to be used as the Tint of the <see cref="T:Microsoft.Maui.Controls.NavigationPage" />.</summary>
-        <value>To be added.</value>
         <remarks>
           <para>Tint is especially important in iOS 7 and later, where the Tint is primary way to specify which controls on screen are active or have an action associated with them.</para>
         </remarks>
@@ -1417,7 +1346,6 @@
       </ReturnValue>
       <Docs>
         <summary>Identifies the <see cref="P:Microsoft.Maui.Controls.NavigationPage.Tint" /> bindable property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TitleIconImageSourceProperty">
@@ -1434,8 +1362,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TitleIconProperty">
@@ -1467,8 +1393,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TitleViewProperty">
@@ -1524,8 +1448,6 @@
         <param name="animated">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="fast">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/OSAppTheme.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/OSAppTheme.xml
@@ -11,8 +11,6 @@
     <BaseTypeName>System.Enum</BaseTypeName>
   </Base>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Dark">
@@ -30,7 +28,6 @@
       </ReturnValue>
       <MemberValue>2</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
     <Member MemberName="Light">
@@ -48,7 +45,6 @@
       </ReturnValue>
       <MemberValue>1</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
     <Member MemberName="Unspecified">
@@ -66,7 +62,6 @@
       </ReturnValue>
       <MemberValue>0</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/On.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/On.xml
@@ -19,7 +19,6 @@
   </Attributes>
   <Docs>
     <summary>Class that is used within <c>OnPlatform</c> tags in XAML when specifying values on platforms.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -35,7 +34,6 @@
       <Parameters />
       <Docs>
         <summary>Creates a new <see cref="T:Microsoft.Maui.Controls.On" /> with default values.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Platform">
@@ -59,8 +57,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the list of specified platforms.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Value">
@@ -79,8 +75,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the value on the current platform.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/OrientationStateTrigger.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/OrientationStateTrigger.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -27,8 +25,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnAttached">
@@ -46,8 +42,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnDetached">
@@ -65,8 +59,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Orientation">
@@ -83,9 +75,6 @@
         <ReturnType>Microsoft.Maui.Controls.Internals.DeviceOrientation</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OrientationProperty">
@@ -102,8 +91,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/Page.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/Page.xml
@@ -66,7 +66,6 @@
       <Parameters />
       <Docs>
         <summary>Creates a new <see cref="T:Microsoft.Maui.Controls.Page" /> element with default values.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ActionSheetSignalName">
@@ -85,7 +84,6 @@
       </ReturnValue>
       <Docs>
         <summary>This method is for internal use.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="AlertSignalName">
@@ -104,7 +102,6 @@
       </ReturnValue>
       <Docs>
         <summary>This method is for internal use.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Appearing">
@@ -129,7 +126,6 @@
       </ReturnValue>
       <Docs>
         <summary>Indicates that the <see cref="T:Microsoft.Maui.Controls.Page" /> is about to appear.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="BackgroundImage">
@@ -162,8 +158,6 @@
       </ReturnValue>
       <Docs>
         <summary>Identifies the image used as a background for the <see cref="T:Microsoft.Maui.Controls.Page" />.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="BackgroundImageProperty">
@@ -196,7 +190,6 @@
       </ReturnValue>
       <Docs>
         <summary>Identifies the <see cref="P:Microsoft.Maui.Controls.Page.BackgroundImage" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="BackgroundImageSource">
@@ -213,9 +206,6 @@
         <ReturnType>Microsoft.Maui.Controls.ImageSource</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="BackgroundImageSourceProperty">
@@ -232,8 +222,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="BusySetSignalName">
@@ -252,7 +240,6 @@
       </ReturnValue>
       <Docs>
         <summary>This method is for internal use.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ContainerArea">
@@ -279,8 +266,6 @@
       </ReturnValue>
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Disappearing">
@@ -380,8 +365,6 @@
         <param name="message">The body text of the alert dialog.</param>
         <param name="cancel">Text to be displayed on the 'Cancel' button.</param>
         <summary>Presents an alert dialog to the application user with a single cancel button.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="DisplayAlert">
@@ -417,7 +400,6 @@
         <param name="cancel">Text to be displayed on the 'Cancel' button.</param>
         <summary>Presents an alert dialog to the application user with an accept and a cancel button.</summary>
         <returns>A task that contains the user's choice as a Boolean value. <see langword="true" /> indicates that the user accepted the alert. <see langword="false" /> indicates that the user cancelled the alert.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="DisplayPromptAsync">
@@ -458,9 +440,6 @@
         <param name="placeholder">To be added.</param>
         <param name="maxLength">To be added.</param>
         <param name="keyboard">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="DisplayPromptAsync">
@@ -495,9 +474,6 @@
         <param name="maxLength">To be added.</param>
         <param name="keyboard">To be added.</param>
         <param name="initialValue">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ForceLayout">
@@ -523,7 +499,6 @@
       <Parameters />
       <Docs>
         <summary>Forces the <see cref="T:Microsoft.Maui.Controls.Page" /> to perform a layout pass.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Icon">
@@ -556,8 +531,6 @@
       </ReturnValue>
       <Docs>
         <summary>Resource identifier for the <see cref="T:Microsoft.Maui.Controls.Page" />'s associated icon.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IconImageSource">
@@ -574,9 +547,6 @@
         <ReturnType>Microsoft.Maui.Controls.ImageSource</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IconImageSourceProperty">
@@ -593,8 +563,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IconProperty">
@@ -627,7 +595,6 @@
       </ReturnValue>
       <Docs>
         <summary>Identifies the <see cref="P:Microsoft.Maui.Controls.Page.Icon" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IgnoresContainerArea">
@@ -654,8 +621,6 @@
       </ReturnValue>
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="InternalChildren">
@@ -682,8 +647,6 @@
       </ReturnValue>
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsBusy">
@@ -734,7 +697,6 @@
       </ReturnValue>
       <Docs>
         <summary>Identifies the <see cref="P:Microsoft.Maui.Controls.Page.IsBusy" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="LayoutChanged">
@@ -762,7 +724,6 @@
       </ReturnValue>
       <Docs>
         <summary>Raised when the layout of the <see cref="T:Microsoft.Maui.Controls.Page" /> has changed.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="LayoutChildren">
@@ -797,7 +758,6 @@
         <param name="width">Width of layout area.</param>
         <param name="height">Height of layout area.</param>
         <summary>Lays out children <see cref="T:Microsoft.Maui.Controls.Element" />s into the specified area.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="On&lt;T&gt;">
@@ -828,8 +788,6 @@
       <Docs>
         <typeparam name="T">To be added.</typeparam>
         <summary>Returns the platform-specific instance of this <see cref="T:Microsoft.Maui.Controls.Page" />, on which a platform-specific method may be called.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnAppearing">
@@ -855,7 +813,6 @@
       <Parameters />
       <Docs>
         <summary>When overridden, allows application developers to customize behavior immediately prior to the <see cref="T:Microsoft.Maui.Controls.Page" /> becoming visible.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnBackButtonPressed">
@@ -943,7 +900,6 @@
         <param name="sender">The object that raised the event.</param>
         <param name="e">The event arguments.</param>
         <summary>Indicates that the preferred size of a child <see cref="T:Microsoft.Maui.Controls.Element" /> has changed.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnDisappearing">
@@ -995,7 +951,6 @@
       <Parameters />
       <Docs>
         <summary>Called when the <see cref="T:Microsoft.Maui.Controls.Page" />'s <see cref="P:Microsoft.Maui.Controls.Element.Parent" /> property has changed.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnSizeAllocated">
@@ -1026,7 +981,6 @@
         <param name="width">The width allocated to the <see cref="T:Microsoft.Maui.Controls.Page" />.</param>
         <param name="height">The height allocated to the <see cref="T:Microsoft.Maui.Controls.Page" />.</param>
         <summary>Indicates that the <see cref="T:Microsoft.Maui.Controls.Page" /> has been assigned a size.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Padding">
@@ -1051,8 +1005,6 @@
       </ReturnValue>
       <Docs>
         <summary>The space between the content of the <see cref="T:Microsoft.Maui.Controls.Page" /> and it's border.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PaddingProperty">
@@ -1077,7 +1029,6 @@
       </ReturnValue>
       <Docs>
         <summary>Identifies the <see cref="P:Microsoft.Maui.Controls.Page.Padding" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PromptSignalName">
@@ -1094,8 +1045,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SendAppearing">
@@ -1123,7 +1072,6 @@
       <Parameters />
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SendBackButtonPressed">
@@ -1146,8 +1094,6 @@
       <Parameters />
       <Docs>
         <summary>Calls <see cref="M:Microsoft.Maui.Controls.Page.OnBackButtonPressed" />.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SendDisappearing">
@@ -1175,7 +1121,6 @@
       <Parameters />
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Title">
@@ -1200,8 +1145,6 @@
       </ReturnValue>
       <Docs>
         <summary>The <see cref="T:Microsoft.Maui.Controls.Page" />'s title.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TitleProperty">
@@ -1226,7 +1169,6 @@
       </ReturnValue>
       <Docs>
         <summary>Identifies the <see cref="P:Microsoft.Maui.Controls.Page.Title" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ToolbarItems">
@@ -1251,8 +1193,6 @@
       </ReturnValue>
       <Docs>
         <summary>A set of <see cref="T:Microsoft.Maui.Controls.ToolbarItem" />s, implemented in a platform-specific manner.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="UpdateChildrenLayout">
@@ -1278,7 +1218,6 @@
       <Parameters />
       <Docs>
         <summary>Requests that the children <see cref="T:Microsoft.Maui.Controls.Element" />s of the <see cref="T:Microsoft.Maui.Controls.Page" /> update their layouts.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/PanGestureRecognizer.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/PanGestureRecognizer.xml
@@ -19,7 +19,6 @@
   </Interfaces>
   <Docs>
     <summary>A gesture recognizer for panning content that is larger than its parent view.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -36,7 +35,6 @@
       <Parameters />
       <Docs>
         <summary>Creates a new <see cref="T:Microsoft.Maui.Controls.PanGestureRecognizer" /> with default values.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PanUpdated">
@@ -56,7 +54,6 @@
       </ReturnValue>
       <Docs>
         <summary>Event that is raised when the pan gesture changes.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SendPan">
@@ -93,7 +90,6 @@
         <param name="totalY">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="gestureId">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SendPanCanceled">
@@ -126,7 +122,6 @@
         <param name="sender">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="gestureId">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SendPanCompleted">
@@ -159,7 +154,6 @@
         <param name="sender">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="gestureId">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SendPanStarted">
@@ -192,7 +186,6 @@
         <param name="sender">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="gestureId">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TouchPoints">
@@ -212,8 +205,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the number of touch points in the gesture.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TouchPointsProperty">
@@ -233,7 +224,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.PanGestureRecognizer.TouchPoints" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/PanUpdatedEventArgs.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/PanUpdatedEventArgs.xml
@@ -15,7 +15,6 @@
   <Interfaces />
   <Docs>
     <summary>Event that is raised when a pan gesture updates.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -38,7 +37,6 @@
         <param name="type">Whether the gesture just began, is continuing, was completed, or is canceled.</param>
         <param name="gestureId">An identifier for the gesture.</param>
         <summary>Creates a new <see cref="T:Microsoft.Maui.Controls.PanUpdatedEventArgs" /> with the specified values.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -65,7 +63,6 @@
         <param name="totalx">The total change in the X direction since the beginning of the gesture.</param>
         <param name="totaly">The total change in the Y direction since the beginning of the gesture.</param>
         <summary>Creates a new <see cref="T:Microsoft.Maui.Controls.PanUpdatedEventArgs" /> with the specified values.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GestureId">
@@ -85,8 +82,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets the identifier for the gesture that raised the event.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="StatusType">
@@ -106,8 +101,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets a value that tells if this event is for a newly started gesture, a running gesture, a completed gesture, or a canceled gesture.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TotalX">
@@ -127,8 +120,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets the total change in the X direction since the beginning of the gesture.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TotalY">
@@ -148,8 +139,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets the total change in the Y direction since the beginning of the gesture.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/Picker.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/Picker.xml
@@ -77,9 +77,6 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CharacterSpacingProperty">
@@ -96,8 +93,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FontAttributes">
@@ -116,8 +111,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets a value that indicates whether the font for the searchbar text is bold, italic, or neither.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FontAttributesProperty">
@@ -136,7 +129,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.Picker.FontAttributes" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FontFamily">
@@ -155,8 +147,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the font family for the picker text.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FontFamilyProperty">
@@ -175,7 +165,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.Picker.FontFamily" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FontSize">
@@ -200,7 +189,6 @@
       <Docs>
         <summary>Gets or sets the size of the font for the text in the picker.</summary>
         <value>A <see langword="double" /> that indicates the size of the font.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FontSizeProperty">
@@ -219,7 +207,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.Picker.FontSize" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="HorizontalTextAlignment">
@@ -236,9 +223,6 @@
         <ReturnType>Microsoft.Maui.TextAlignment</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="HorizontalTextAlignmentProperty">
@@ -255,8 +239,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ItemDisplayBinding">
@@ -275,8 +257,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets a binding that selects the property that will be displayed for each object in the list of items.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Items">
@@ -321,8 +301,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the source list of items to template and display.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ItemsSourceProperty">
@@ -341,7 +319,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.Picker.ItemsSource" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="On&lt;T&gt;">
@@ -372,8 +349,6 @@
       <Docs>
         <typeparam name="T">To be added.</typeparam>
         <summary>Returns the platform-specific instance of this <see cref="T:Microsoft.Maui.Controls.Picker" />, on which a platform-specific method may be called.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SelectedIndex">
@@ -424,7 +399,6 @@
       </ReturnValue>
       <Docs>
         <summary>Raised when the value of the SelectIndex property has changed.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SelectedIndexProperty">
@@ -469,8 +443,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the selected item.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SelectedItemProperty">
@@ -489,7 +461,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.Picker.SelectedItem" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TextColor">
@@ -508,8 +479,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the text color.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TextColorProperty">
@@ -528,7 +497,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.Picker.TextColor" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TextTransform">
@@ -545,9 +513,6 @@
         <ReturnType>Microsoft.Maui.Controls.TextTransform</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TextTransformProperty">
@@ -564,8 +529,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Title">
@@ -608,9 +571,6 @@
         <ReturnType>Microsoft.Maui.Graphics.Color</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TitleColorProperty">
@@ -628,7 +588,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.Picker.TitleColor" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TitleProperty">
@@ -677,9 +636,6 @@
       <Docs>
         <param name="source">To be added.</param>
         <param name="textTransform">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="VerticalTextAlignment">
@@ -696,9 +652,6 @@
         <ReturnType>Microsoft.Maui.TextAlignment</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="VerticalTextAlignmentProperty">
@@ -715,8 +668,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.Internals.IFontElement.FontSizeDefaultValueCreator">
@@ -739,8 +690,6 @@
       <Parameters />
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.Internals.IFontElement.OnFontAttributesChanged">
@@ -768,7 +717,6 @@
         <param name="oldValue">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="newValue">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.Internals.IFontElement.OnFontChanged">
@@ -796,7 +744,6 @@
         <param name="oldValue">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="newValue">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.Internals.IFontElement.OnFontFamilyChanged">
@@ -824,7 +771,6 @@
         <param name="oldValue">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="newValue">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.Internals.IFontElement.OnFontSizeChanged">
@@ -852,7 +798,6 @@
         <param name="oldValue">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="newValue">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/PinchGestureRecognizer.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/PinchGestureRecognizer.xml
@@ -19,7 +19,6 @@
   </Interfaces>
   <Docs>
     <summary>Recognizer for pinch gestures.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -36,7 +35,6 @@
       <Parameters />
       <Docs>
         <summary>Constructs a new pinch gesture recognizer.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsPinching">
@@ -63,8 +61,6 @@
       </ReturnValue>
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PinchUpdated">
@@ -84,7 +80,6 @@
       </ReturnValue>
       <Docs>
         <summary>Event that is raised when a pinch gesture updates.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SendPinch">
@@ -119,7 +114,6 @@
         <param name="delta">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="currentScalePoint">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SendPinchCanceled">
@@ -150,7 +144,6 @@
       <Docs>
         <param name="sender">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SendPinchEnded">
@@ -181,7 +174,6 @@
       <Docs>
         <param name="sender">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SendPinchStarted">
@@ -214,7 +206,6 @@
         <param name="sender">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="initialScalePoint">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/PinchGestureUpdatedEventArgs.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/PinchGestureUpdatedEventArgs.xml
@@ -15,7 +15,6 @@
   <Interfaces />
   <Docs>
     <summary>Event arguments for the <see cref="E:Microsoft.Maui.Controls.PinchGestureRecognizer.PinchUpdated" /> event.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -36,7 +35,6 @@
       <Docs>
         <param name="status">The new gesture status.</param>
         <summary>Constructs a new <see cref="T:Microsoft.Maui.Controls.PinchGestureUpdatedEventArgs" /> object with default values.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">

--- a/src/Controls/docs/Microsoft.Maui.Controls/PoppedToRootEventArgs.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/PoppedToRootEventArgs.xml
@@ -41,7 +41,6 @@
         <param name="page">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="poppedPages">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by platform renderers.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PoppedPages">

--- a/src/Controls/docs/Microsoft.Maui.Controls/PositionChangedEventArgs.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/PositionChangedEventArgs.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="CurrentPosition">
@@ -30,9 +28,6 @@
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PreviousPosition">
@@ -49,9 +44,6 @@
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/PresentationMode.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/PresentationMode.xml
@@ -16,8 +16,6 @@
     </Attribute>
   </Attributes>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Animated">
@@ -35,7 +33,6 @@
       </ReturnValue>
       <MemberValue>2</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
     <Member MemberName="Modal">
@@ -53,7 +50,6 @@
       </ReturnValue>
       <MemberValue>4</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
     <Member MemberName="ModalAnimated">
@@ -71,7 +67,6 @@
       </ReturnValue>
       <MemberValue>6</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
     <Member MemberName="ModalNotAnimated">
@@ -89,7 +84,6 @@
       </ReturnValue>
       <MemberValue>5</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
     <Member MemberName="NotAnimated">
@@ -107,7 +101,6 @@
       </ReturnValue>
       <MemberValue>1</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/ProgressBar.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/ProgressBar.xml
@@ -102,8 +102,6 @@ Debug.WriteLine ("Animation completed");
       <Docs>
         <typeparam name="T">To be added.</typeparam>
         <summary>Returns the platform-specific instance of this <see cref="T:Microsoft.Maui.Controls.ProgressBar" />, on which a platform-specific method may be called.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Progress">
@@ -149,7 +147,6 @@ Debug.WriteLine ("Animation completed");
       <Docs>
         <summary>Get or sets the color of the progress bar.</summary>
         <value>The color of the progress bar.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ProgressColorProperty">
@@ -168,7 +165,6 @@ Debug.WriteLine ("Animation completed");
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.ProgressBar.ProgressColor" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ProgressProperty">
@@ -247,9 +243,6 @@ Debug.WriteLine ("Animation completed");
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/PropertyChangingEventArgs.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/PropertyChangingEventArgs.xml
@@ -20,7 +20,6 @@
   <Interfaces />
   <Docs>
     <summary>Event arguments for the <see cref="T:Microsoft.Maui.Controls.PropertyChangingEventHandler" /> delegate.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -46,7 +45,6 @@
       <Docs>
         <param name="propertyName">To be added.</param>
         <summary>Creates a new <see cref="T:Microsoft.Maui.Controls.PropertyChangingEventArgs" /> object that indicates that <paramref name="propertyName" /> is changing.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PropertyName">
@@ -72,7 +70,6 @@
       <Docs>
         <summary>Gets the name of the property that is changing.</summary>
         <value>The name of the property that is changing.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/PropertyCondition.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/PropertyCondition.xml
@@ -67,7 +67,6 @@
       <Parameters />
       <Docs>
         <summary>Initializes a new <see cref="T:Microsoft.Maui.Controls.PropertyCondition" /> instance.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Property">
@@ -89,8 +88,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the property against which the <see cref="P:Microsoft.Maui.Controls.PropertyCondition.Value" /> property will be compared.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Value">
@@ -112,8 +109,6 @@
       </ReturnValue>
       <Docs>
         <summary>The binding value that satisfies the condition.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.Xaml.IValueProvider.ProvideValue">
@@ -142,8 +137,6 @@
       <Docs>
         <param name="serviceProvider">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/QueryPropertyAttribute.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/QueryPropertyAttribute.xml
@@ -17,8 +17,6 @@
     </Attribute>
   </Attributes>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -38,8 +36,6 @@
       <Docs>
         <param name="name">To be added.</param>
         <param name="queryId">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Name">
@@ -56,9 +52,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="QueryId">
@@ -75,9 +68,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/RadialGradientBrush.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/RadialGradientBrush.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -27,8 +25,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -46,8 +42,6 @@
       </Parameters>
       <Docs>
         <param name="gradientStops">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -67,8 +61,6 @@
       <Docs>
         <param name="gradientStops">To be added.</param>
         <param name="radius">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -90,8 +82,6 @@
         <param name="gradientStops">To be added.</param>
         <param name="center">To be added.</param>
         <param name="radius">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Center">
@@ -108,9 +98,6 @@
         <ReturnType>Microsoft.Maui.Controls.Point</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CenterProperty">
@@ -127,8 +114,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsEmpty">
@@ -145,9 +130,6 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Radius">
@@ -164,9 +146,6 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RadiusProperty">
@@ -183,8 +162,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/RadioButton.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/RadioButton.xml
@@ -22,8 +22,6 @@
     </Interface>
   </Interfaces>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -37,8 +35,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="BorderColor">
@@ -55,9 +51,6 @@
         <ReturnType>Microsoft.Maui.Graphics.Color</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="BorderColorProperty">
@@ -74,8 +67,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="BorderWidth">
@@ -92,9 +83,6 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="BorderWidthProperty">
@@ -111,8 +99,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ChangeVisualState">
@@ -130,8 +116,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CharacterSpacing">
@@ -148,9 +132,6 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CharacterSpacingProperty">
@@ -167,8 +148,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CheckedChanged">
@@ -185,8 +164,6 @@
         <ReturnType>System.EventHandler&lt;Microsoft.Maui.Controls.CheckedChangedEventArgs&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CheckedIndicator">
@@ -203,8 +180,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CheckedVisualState">
@@ -221,8 +196,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Content">
@@ -239,9 +212,6 @@
         <ReturnType>System.Object</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ContentAsString">
@@ -259,9 +229,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ContentProperty">
@@ -278,8 +245,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CornerRadius">
@@ -296,9 +261,6 @@
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CornerRadiusProperty">
@@ -315,8 +277,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="DefaultTemplate">
@@ -333,9 +293,6 @@
         <ReturnType>Microsoft.Maui.Controls.ControlTemplate</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FontAttributes">
@@ -352,9 +309,6 @@
         <ReturnType>Microsoft.Maui.Controls.FontAttributes</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FontAttributesProperty">
@@ -371,8 +325,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FontFamily">
@@ -389,9 +341,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FontFamilyProperty">
@@ -408,8 +357,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FontSize">
@@ -431,9 +378,6 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FontSizeProperty">
@@ -450,8 +394,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GroupName">
@@ -468,9 +410,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GroupNameProperty">
@@ -487,8 +426,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsChecked">
@@ -505,9 +442,6 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsCheckedProperty">
@@ -524,8 +458,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="On&lt;T&gt;">
@@ -554,9 +486,6 @@
       <Parameters />
       <Docs>
         <typeparam name="T">To be added.</typeparam>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnApplyTemplate">
@@ -574,8 +503,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnMeasure">
@@ -598,9 +525,6 @@
       <Docs>
         <param name="widthConstraint">To be added.</param>
         <param name="heightConstraint">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ResolveControlTemplate">
@@ -618,9 +542,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TemplateRootName">
@@ -637,8 +558,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TextColor">
@@ -655,9 +574,6 @@
         <ReturnType>Microsoft.Maui.Graphics.Color</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TextColorProperty">
@@ -674,8 +590,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TextTransform">
@@ -692,9 +606,6 @@
         <ReturnType>Microsoft.Maui.Controls.TextTransform</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TextTransformProperty">
@@ -711,8 +622,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="UncheckedButton">
@@ -729,8 +638,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="UncheckedVisualState">
@@ -747,8 +654,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="UpdateFormsText">
@@ -771,9 +676,6 @@
       <Docs>
         <param name="source">To be added.</param>
         <param name="textTransform">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Value">
@@ -790,9 +692,6 @@
         <ReturnType>System.Object</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ValueProperty">
@@ -809,8 +708,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IBorderElement.BorderColorDefaultValue">
@@ -830,9 +727,6 @@
         <ReturnType>Microsoft.Maui.Graphics.Color</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IBorderElement.BorderWidthDefaultValue">
@@ -852,9 +746,6 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IBorderElement.CornerRadiusDefaultValue">
@@ -874,9 +765,6 @@
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IBorderElement.IsBackgroundColorSet">
@@ -897,9 +785,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IBorderElement.IsBackgroundSet">
@@ -920,9 +805,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IBorderElement.IsBorderColorSet">
@@ -943,9 +825,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IBorderElement.IsBorderWidthSet">
@@ -966,9 +845,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IBorderElement.IsCornerRadiusSet">
@@ -989,9 +865,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IBorderElement.OnBorderColorPropertyChanged">
@@ -1017,8 +890,6 @@
       <Docs>
         <param name="oldValue">To be added.</param>
         <param name="newValue">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.Internals.IFontElement.FontSizeDefaultValueCreator">
@@ -1039,9 +910,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.Internals.IFontElement.OnFontAttributesChanged">
@@ -1067,8 +935,6 @@
       <Docs>
         <param name="oldValue">To be added.</param>
         <param name="newValue">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.Internals.IFontElement.OnFontChanged">
@@ -1094,8 +960,6 @@
       <Docs>
         <param name="oldValue">To be added.</param>
         <param name="newValue">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.Internals.IFontElement.OnFontFamilyChanged">
@@ -1121,8 +985,6 @@
       <Docs>
         <param name="oldValue">To be added.</param>
         <param name="newValue">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.Internals.IFontElement.OnFontSizeChanged">
@@ -1148,8 +1010,6 @@
       <Docs>
         <param name="oldValue">To be added.</param>
         <param name="newValue">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/RadioButtonGroup.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/RadioButtonGroup.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="GetGroupName">
@@ -34,9 +32,6 @@
       </Parameters>
       <Docs>
         <param name="b">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetSelectedValue">
@@ -57,9 +52,6 @@
       </Parameters>
       <Docs>
         <param name="bindableObject">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GroupNameProperty">
@@ -76,8 +68,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SelectedValueProperty">
@@ -94,8 +84,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/ReferenceTypeConverter.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/ReferenceTypeConverter.xml
@@ -18,7 +18,6 @@
   </Interfaces>
   <Docs>
     <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -34,7 +33,6 @@
       <Parameters />
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ConvertFromInvariantString">
@@ -57,8 +55,6 @@
       <Docs>
         <param name="value">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IExtendedTypeConverter.ConvertFrom">
@@ -88,8 +84,6 @@
         <param name="value">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="serviceProvider">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IExtendedTypeConverter.ConvertFromInvariantString">
@@ -117,8 +111,6 @@
         <param name="value">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="serviceProvider">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/RefreshView.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/RefreshView.xml
@@ -24,8 +24,6 @@
     </Attribute>
   </Attributes>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -39,8 +37,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Command">
@@ -57,9 +53,6 @@
         <ReturnType>System.Windows.Input.ICommand</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CommandParameter">
@@ -76,9 +69,6 @@
         <ReturnType>System.Object</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CommandParameterProperty">
@@ -95,8 +85,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CommandProperty">
@@ -113,8 +101,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsRefreshing">
@@ -131,9 +117,6 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsRefreshingProperty">
@@ -150,8 +133,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="On&lt;T&gt;">
@@ -180,9 +161,6 @@
       <Parameters />
       <Docs>
         <typeparam name="T">To be added.</typeparam>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnMeasure">
@@ -205,9 +183,6 @@
       <Docs>
         <param name="widthConstraint">To be added.</param>
         <param name="heightConstraint">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnPropertyChanged">
@@ -234,8 +209,6 @@
       </Parameters>
       <Docs>
         <param name="propertyName">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RefreshColor">
@@ -252,9 +225,6 @@
         <ReturnType>Microsoft.Maui.Graphics.Color</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RefreshColorProperty">
@@ -271,8 +241,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Refreshing">
@@ -289,8 +257,6 @@
         <ReturnType>System.EventHandler</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/Region.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/Region.xml
@@ -41,7 +41,6 @@
         <summary>Returns <see langword="true" /> if the specified point is inside the region. Otherwise, returns <see langword="false" />.</summary>
         <returns>
           <see langword="true" /> if the specified point is inside the region. Otherwise, <see langword="false" />.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Contains">
@@ -68,7 +67,6 @@
         <summary>Returns <see langword="true" /> if the point that is represented by the specified coordinates is inside the region. Otherwise, returns <see langword="false" />.</summary>
         <returns>
           <see langword="true" /> if the specified point that is represented by the specified coordinates is inside the region. Otherwise, <see langword="false" />.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Deflate">
@@ -89,7 +87,6 @@
       <Docs>
         <summary>Returns a region shrunk by the values in the most recent inflation, or does nothing if there has not been a previous inflation.</summary>
         <returns>A region shrunk by the values in the most recent inflation, or does nothing if there has not been a previous inflation.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FromLines">
@@ -121,7 +118,6 @@
         <param name="startY">The top of the region.</param>
         <summary>Creates and returns a region that detects points inside a collection of rectangles created from the lines that are specified by the provided data.</summary>
         <returns>A region that detects points inside a collection of rectangles created from the lines that are specified by the provided data.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Inflate">
@@ -145,7 +141,6 @@
         <param name="size">The amount by which to move each side of the region or its subregions.</param>
         <summary>Returns a region that is expanded by or has all of its subregions expanded by the specified <paramref name="size" />.</summary>
         <returns>A  region that is expanded by or has all of its subregions expanded by the specified <paramref name="size" />.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Inflate">
@@ -175,7 +170,6 @@
         <param name="bottom">The amount to move the bottom down.</param>
         <summary>Returns a region that is expanded by or has all of its subregions expanded by the specified values.</summary>
         <returns>A  region that is expanded by or has all of its subregions expanded by the specified values.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/RelativeBindingSource.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/RelativeBindingSource.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -35,8 +33,6 @@
         <param name="mode">To be added.</param>
         <param name="ancestorType">To be added.</param>
         <param name="ancestorLevel">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="AncestorLevel">
@@ -53,9 +49,6 @@
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="AncestorType">
@@ -72,9 +65,6 @@
         <ReturnType>System.Type</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Mode">
@@ -91,9 +81,6 @@
         <ReturnType>Microsoft.Maui.Controls.RelativeBindingSourceMode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Self">
@@ -110,9 +97,6 @@
         <ReturnType>Microsoft.Maui.Controls.RelativeBindingSource</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TemplatedParent">
@@ -129,9 +113,6 @@
         <ReturnType>Microsoft.Maui.Controls.RelativeBindingSource</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/RelativeBindingSourceMode.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/RelativeBindingSourceMode.xml
@@ -11,8 +11,6 @@
     <BaseTypeName>System.Enum</BaseTypeName>
   </Base>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="FindAncestor">
@@ -30,7 +28,6 @@
       </ReturnValue>
       <MemberValue>3</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
     <Member MemberName="FindAncestorBindingContext">
@@ -48,7 +45,6 @@
       </ReturnValue>
       <MemberValue>4</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
     <Member MemberName="Self">
@@ -66,7 +62,6 @@
       </ReturnValue>
       <MemberValue>2</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
     <Member MemberName="TemplatedParent">
@@ -84,7 +79,6 @@
       </ReturnValue>
       <MemberValue>1</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/RenderWithAttribute.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/RenderWithAttribute.xml
@@ -65,8 +65,6 @@
       <Docs>
         <param name="type">To be added.</param>
         <param name="supportedVisuals">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SupportedVisuals">
@@ -83,9 +81,6 @@
         <ReturnType>System.Type[]</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Type">

--- a/src/Controls/docs/Microsoft.Maui.Controls/ResourceDictionary.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/ResourceDictionary.xml
@@ -45,7 +45,6 @@
   </Interfaces>
   <Docs>
     <summary>An IDictionary that maps identifier strings to arbitrary resource objects.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -67,7 +66,6 @@
       <Parameters />
       <Docs>
         <summary>Creates a new empty <see cref="T:Microsoft.Maui.Controls.ResourceDictionary" /> object.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Add">
@@ -90,7 +88,6 @@
       <Docs>
         <param name="mergedResourceDictionary">The resource dictionary to add.</param>
         <summary>Add <paramref name="mergedResourceDictionary" /> to the merged dictionaries in <see langword="this" /> resource dictionary.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Add">
@@ -142,7 +139,6 @@
       <Docs>
         <param name="styleSheet">The style sheet to add</param>
         <summary>Adds <paramref name="styleSheet" /> to <see langword="this" /> resource dictionary's list of style sheets.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Add">
@@ -176,7 +172,6 @@
         <param name="key">The identifier to be used to retrieve the <paramref name="value" />.</param>
         <param name="value">The <see cref="T:System.Object" /> associated with the <paramref name="key" />.</param>
         <summary>Adds <paramref name="key" /> and <paramref name="value" /> to the <see cref="T:Microsoft.Maui.Controls.ResourceDictionary" /> as a key-value pair.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Clear">
@@ -205,7 +200,6 @@
       <Parameters />
       <Docs>
         <summary>Empties the <see cref="T:Microsoft.Maui.Controls.ResourceDictionary" />.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ContainsKey">
@@ -237,7 +231,6 @@
       <Docs>
         <param name="key">The identifier being searched for.</param>
         <summary>Whether the <see cref="T:Microsoft.Maui.Controls.ResourceDictionary" /> contains a key-value pair identified by <paramref name="key" />.</summary>
-        <returns>To be added.</returns>
         <remarks>This method will only return true if the key is in the immediate ResourceDictionary; it will not search any merged dictionaries.</remarks>
       </Docs>
     </Member>
@@ -266,8 +259,6 @@
       </ReturnValue>
       <Docs>
         <summary>The number of entries in the <see cref="T:Microsoft.Maui.Controls.ResourceDictionary" />.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetEnumerator">
@@ -296,8 +287,6 @@
       <Parameters />
       <Docs>
         <summary>Returns a <see cref="T:System.Collections.Generic.IEnumerator`1" /> of the <see cref="T:Microsoft.Maui.Controls.ResourceDictionary" />'s <see cref="T:System.Collections.Generic.KeyValuePair`2" />s.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Item">
@@ -329,8 +318,6 @@
       <Docs>
         <param name="index">The identifier of the desired object.</param>
         <summary>Retrieves the <see cref="T:System.Object" /> value associated with the key <paramref name="index" />.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Keys">
@@ -358,8 +345,6 @@
       </ReturnValue>
       <Docs>
         <summary>The collection of identifier <see langword="string" />s that are keys in the <see cref="T:Microsoft.Maui.Controls.ResourceDictionary" />.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="MergedDictionaries">
@@ -378,8 +363,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets the collection of dictionaries that were merged into this dictionary.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="MergedWith">
@@ -410,7 +393,6 @@
       <Docs>
         <summary>Gets or sets the type of object with which the resource dictionary is merged.</summary>
         <value>The type of object with which the resource dictionary is merged, or null if the dictionary is not merged with another.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Remove">
@@ -444,7 +426,6 @@
         <summary>Removes the key and value identified by <paramref name="key" /> from the <see cref="T:Microsoft.Maui.Controls.ResourceDictionary" />.</summary>
         <returns>
           <see langword="true" /> if the key existed and the removal was successful.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetAndCreateSource&lt;T&gt;">
@@ -481,7 +462,6 @@
         <typeparam name="T">To be added.</typeparam>
         <param name="value">To be added.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Source">
@@ -506,7 +486,6 @@
       <Docs>
         <summary>Gets or sets the URI of the merged resource dictionary.</summary>
         <value>The URI of the merged resource dictionary.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="System.Collections.Generic.ICollection&lt;System.Collections.Generic.KeyValuePair&lt;System.String,System.Object&gt;&gt;.Add">
@@ -538,7 +517,6 @@
       <Docs>
         <param name="item">The item to add.</param>
         <summary>Adds an item to the collection.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="System.Collections.Generic.ICollection&lt;System.Collections.Generic.KeyValuePair&lt;System.String,System.Object&gt;&gt;.Contains">
@@ -570,8 +548,6 @@
       <Docs>
         <param name="item">The item to add.</param>
         <summary>Returns a value that indicates whether the dictionary contains the value in <paramref name="item" />, indexed by the key in <paramref name="item" />.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="System.Collections.Generic.ICollection&lt;System.Collections.Generic.KeyValuePair&lt;System.String,System.Object&gt;&gt;.CopyTo">
@@ -605,7 +581,6 @@
         <param name="array">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="arrayIndex">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="System.Collections.Generic.ICollection&lt;System.Collections.Generic.KeyValuePair&lt;System.String,System.Object&gt;&gt;.IsReadOnly">
@@ -633,8 +608,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets a value that indicates whether the resource dictionary is read-only.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="System.Collections.Generic.ICollection&lt;System.Collections.Generic.KeyValuePair&lt;System.String,System.Object&gt;&gt;.Remove">
@@ -666,8 +639,6 @@
       <Docs>
         <param name="item">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="System.Collections.IEnumerable.GetEnumerator">
@@ -696,8 +667,6 @@
       <Parameters />
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TryGetValue">
@@ -723,9 +692,6 @@
       <Docs>
         <param name="key">To be added.</param>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Values">
@@ -753,8 +719,6 @@
       </ReturnValue>
       <Docs>
         <summary>Retrieves the values of the <see cref="T:Microsoft.Maui.Controls.ResourceDictionary" />.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.Internals.IResourceDictionary.ValuesChanged">
@@ -774,8 +738,6 @@
         <ReturnType>System.EventHandler&lt;Microsoft.Maui.Controls.Internals.ResourcesChangedEventArgs&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/RouteFactory.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/RouteFactory.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -27,8 +25,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetOrCreate">
@@ -46,9 +42,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/Routing.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/Routing.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="FormatRoute">
@@ -34,9 +32,6 @@
       </Parameters>
       <Docs>
         <param name="segments">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FormatRoute">
@@ -57,9 +52,6 @@
       </Parameters>
       <Docs>
         <param name="route">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetOrCreateContent">
@@ -80,9 +72,6 @@
       </Parameters>
       <Docs>
         <param name="route">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetRoute">
@@ -103,9 +92,6 @@
       </Parameters>
       <Docs>
         <param name="obj">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RegisterRoute">
@@ -128,8 +114,6 @@
       <Docs>
         <param name="route">To be added.</param>
         <param name="type">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RegisterRoute">
@@ -152,8 +136,6 @@
       <Docs>
         <param name="route">To be added.</param>
         <param name="factory">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RouteProperty">
@@ -170,8 +152,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetRoute">
@@ -194,8 +174,6 @@
       <Docs>
         <param name="obj">To be added.</param>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="UnRegisterRoute">
@@ -216,8 +194,6 @@
       </Parameters>
       <Docs>
         <param name="route">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/RoutingEffect.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/RoutingEffect.xml
@@ -14,7 +14,6 @@
   <Interfaces />
   <Docs>
     <summary>Platform-independent effect that wraps an inner effect, which is usually platform-specific.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -34,7 +33,6 @@
       <Docs>
         <param name="effectId">The ID for the effect.</param>
         <summary>Creates a new routing effect with the specified <paramref name="effectId" />.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnAttached">
@@ -54,7 +52,6 @@
       <Parameters />
       <Docs>
         <summary>Method that is called after the effect is attached and made valid.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnDetached">
@@ -74,7 +71,6 @@
       <Parameters />
       <Docs>
         <summary>Method that is called after the effect is detached and invalidated.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/RowDefinition.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/RowDefinition.xml
@@ -57,7 +57,6 @@
       <Parameters />
       <Docs>
         <summary>Creates a new <see cref="T:Microsoft.Maui.Controls.RowDefinition" /> object with default values.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Height">
@@ -82,8 +81,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the height of the row.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="HeightProperty">
@@ -108,7 +105,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.RowDefinition.Height" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SizeChanged">
@@ -136,7 +132,6 @@
       </ReturnValue>
       <Docs>
         <summary>Event that is raised when the size of the row is changed.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/RowDefinitionCollection.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/RowDefinitionCollection.xml
@@ -23,7 +23,6 @@
   <Interfaces />
   <Docs>
     <summary>A <see cref="T:Microsoft.Maui.Controls.DefinitionCollection`1" /> for <see cref="T:Microsoft.Maui.Controls.RowDefinition" />s.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -45,7 +44,6 @@
       <Parameters />
       <Docs>
         <summary>Creates a new empty <see cref="T:Microsoft.Maui.Controls.RowDefinitionCollection" /> object.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/RowDefinitionCollectionTypeConverter.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/RowDefinitionCollectionTypeConverter.xml
@@ -17,8 +17,6 @@
     </Attribute>
   </Attributes>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -32,8 +30,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ConvertFromInvariantString">
@@ -54,9 +50,6 @@
       </Parameters>
       <Docs>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/ScrollMode.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/ScrollMode.xml
@@ -11,8 +11,6 @@
     <BaseTypeName>System.Enum</BaseTypeName>
   </Base>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Auto">
@@ -30,7 +28,6 @@
       </ReturnValue>
       <MemberValue>2</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
     <Member MemberName="Disabled">
@@ -48,7 +45,6 @@
       </ReturnValue>
       <MemberValue>0</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
     <Member MemberName="Enabled">
@@ -66,7 +62,6 @@
       </ReturnValue>
       <MemberValue>1</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/ScrollToMode.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/ScrollToMode.xml
@@ -15,7 +15,6 @@
   </Base>
   <Docs>
     <summary>Enumerates values that describe how a scroll request is made.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Element">

--- a/src/Controls/docs/Microsoft.Maui.Controls/ScrollToPosition.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/ScrollToPosition.xml
@@ -16,7 +16,6 @@
   </Base>
   <Docs>
     <summary>Enumerates values that describe a scroll request.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Center">

--- a/src/Controls/docs/Microsoft.Maui.Controls/ScrollToRequestEventArgs.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/ScrollToRequestEventArgs.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -37,8 +35,6 @@
         <param name="groupIndex">To be added.</param>
         <param name="scrollToPosition">To be added.</param>
         <param name="isAnimated">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -62,8 +58,6 @@
         <param name="group">To be added.</param>
         <param name="scrollToPosition">To be added.</param>
         <param name="isAnimated">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Group">
@@ -80,9 +74,6 @@
         <ReturnType>System.Object</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GroupIndex">
@@ -99,9 +90,6 @@
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Index">
@@ -118,9 +106,6 @@
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsAnimated">
@@ -137,9 +122,6 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Item">
@@ -156,9 +138,6 @@
         <ReturnType>System.Object</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Mode">
@@ -175,9 +154,6 @@
         <ReturnType>Microsoft.Maui.Controls.ScrollToMode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ScrollToPosition">
@@ -194,9 +170,6 @@
         <ReturnType>Microsoft.Maui.Controls.ScrollToPosition</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/ScrollToRequestedEventArgs.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/ScrollToRequestedEventArgs.xml
@@ -20,7 +20,6 @@
   </Interfaces>
   <Docs>
     <summary>Arguments for the event that is raised when a scroll is requested.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Element">
@@ -41,8 +40,6 @@
       </ReturnValue>
       <Docs>
         <summary>An element to scroll to.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Mode">
@@ -63,8 +60,6 @@
       </ReturnValue>
       <Docs>
         <summary>Whether to scroll by element or by position.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Position">
@@ -85,8 +80,6 @@
       </ReturnValue>
       <Docs>
         <summary>An enumeration value that describes which part of an element to scroll to.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ScrollX">
@@ -107,8 +100,6 @@
       </ReturnValue>
       <Docs>
         <summary>The X position to scroll to.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ScrollY">
@@ -129,8 +120,6 @@
       </ReturnValue>
       <Docs>
         <summary>The Y position to scroll to.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ShouldAnimate">
@@ -151,8 +140,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets a value that tells whether the scroll operation should be animated.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.ITemplatedItemsListScrollToRequestedEventArgs.Group">
@@ -174,8 +161,6 @@
       </ReturnValue>
       <Docs>
         <summary>This method is for internal use by platform renderers.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.ITemplatedItemsListScrollToRequestedEventArgs.Item">
@@ -197,8 +182,6 @@
       </ReturnValue>
       <Docs>
         <summary>Internal.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/ScrollView.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/ScrollView.xml
@@ -198,8 +198,6 @@ MainPage = new ContentPage
         <param name="item">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="pos">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="HorizontalScrollBarVisibility">
@@ -219,7 +217,6 @@ MainPage = new ContentPage
       <Docs>
         <summary>Gets or sets a value that controls when the horizontal scroll bar is visible.</summary>
         <value>A value that controls when the horizontal scroll bar is visible.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="HorizontalScrollBarVisibilityProperty">
@@ -238,7 +235,6 @@ MainPage = new ContentPage
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.ScrollView.HorizontalScrollBarVisibility" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="LayoutAreaOverride">
@@ -263,9 +259,6 @@ MainPage = new ContentPage
         <ReturnType>Microsoft.Maui.Controls.Shapes.Rectangle</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="LayoutChildren">
@@ -333,8 +326,6 @@ MainPage = new ContentPage
       <Docs>
         <typeparam name="T">To be added.</typeparam>
         <summary>Returns the platform-specific instance of this <see cref="T:Microsoft.Maui.Controls.ScrollView" />, on which a platform-specific method may be called.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnSizeRequest">
@@ -451,7 +442,6 @@ MainPage = new ContentPage
       </ReturnValue>
       <Docs>
         <summary>Event that is raised after a scroll completes.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ScrollToAsync">
@@ -480,8 +470,6 @@ MainPage = new ContentPage
         <param name="y">The Y position of the finished scroll.</param>
         <param name="animated">Whether or not to animate the scroll.</param>
         <summary>Returns a task that scrolls the scroll view to a position asynchronously.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ScrollToAsync">
@@ -510,8 +498,6 @@ MainPage = new ContentPage
         <param name="position">The scroll position.</param>
         <param name="animated">Whether or not to animate the scroll.</param>
         <summary>Returns a task that scrolls the scroll view to an element asynchronously.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ScrollToRequested">
@@ -538,7 +524,6 @@ MainPage = new ContentPage
       </ReturnValue>
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ScrollX">
@@ -559,8 +544,6 @@ MainPage = new ContentPage
       </ReturnValue>
       <Docs>
         <summary>Gets the current X scroll position.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ScrollXProperty">
@@ -581,7 +564,6 @@ MainPage = new ContentPage
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.ScrollView.ScrollX" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ScrollY">
@@ -602,8 +584,6 @@ MainPage = new ContentPage
       </ReturnValue>
       <Docs>
         <summary>Gets the current Y scroll position.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ScrollYProperty">
@@ -624,7 +604,6 @@ MainPage = new ContentPage
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.ScrollView.ScrollY" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SendScrollFinished">
@@ -652,7 +631,6 @@ MainPage = new ContentPage
       <Parameters />
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetScrolledPosition">
@@ -685,7 +663,6 @@ MainPage = new ContentPage
         <param name="x">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="y">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="VerticalScrollBarVisibility">
@@ -705,7 +682,6 @@ MainPage = new ContentPage
       <Docs>
         <summary>Gets or sets a value that controls when the vertical scroll bar is visible.</summary>
         <value>A value that controls when the vertical scroll bar is visible.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="VerticalScrollBarVisibilityProperty">
@@ -724,7 +700,6 @@ MainPage = new ContentPage
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.ScrollView.VerticalScrollBarVisibility" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/ScrolledEventArgs.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/ScrolledEventArgs.xml
@@ -16,7 +16,6 @@
   <Interfaces />
   <Docs>
     <summary>Arguments for the event that is raised when a window is scrolled.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -40,7 +39,6 @@
         <param name="x">The X position of the finished scroll.</param>
         <param name="y">The Y position of the finished scroll.</param>
         <summary>Constructs a new <see cref="T:Microsoft.Maui.Controls.ScrolledEventArgs" /> object for a scroll to <paramref name="x" /> and <paramref name="y" />.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ScrollX">
@@ -61,8 +59,6 @@
       </ReturnValue>
       <Docs>
         <summary>The X position of the finished scroll.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ScrollY">
@@ -83,8 +79,6 @@
       </ReturnValue>
       <Docs>
         <summary>The Y position of the finished scroll.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/SearchBar.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/SearchBar.xml
@@ -106,7 +106,6 @@ public class App : Application
       <Parameters />
       <Docs>
         <summary>Creates a new <see cref="T:Microsoft.Maui.Controls.SearchBar" />.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CancelButtonColor">
@@ -128,8 +127,6 @@ public class App : Application
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the color of the cancel button.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CancelButtonColorProperty">
@@ -151,7 +148,6 @@ public class App : Application
       </ReturnValue>
       <Docs>
         <summary>Backing store for the CancelButtonColor property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CharacterSpacingProperty">
@@ -168,8 +164,6 @@ public class App : Application
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FontAttributes">
@@ -189,8 +183,6 @@ public class App : Application
       </ReturnValue>
       <Docs>
         <summary>Gets a value that indicates whether the font for the searchbar text is bold, italic, or neither.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FontAttributesProperty">
@@ -210,7 +202,6 @@ public class App : Application
       </ReturnValue>
       <Docs>
         <summary>Backing store for the FontAttributes property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FontFamily">
@@ -230,8 +221,6 @@ public class App : Application
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the font family for the search bar text.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FontFamilyProperty">
@@ -251,7 +240,6 @@ public class App : Application
       </ReturnValue>
       <Docs>
         <summary>Backing store for the FontFamily property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FontSize">
@@ -276,8 +264,6 @@ public class App : Application
       </ReturnValue>
       <Docs>
         <summary>Gets the size of the font for the text in the searchbar.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FontSizeProperty">
@@ -297,7 +283,6 @@ public class App : Application
       </ReturnValue>
       <Docs>
         <summary>Backing store for the FontSize property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="HorizontalTextAlignment">
@@ -317,8 +302,6 @@ public class App : Application
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the horizontal text alignment.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="HorizontalTextAlignmentProperty">
@@ -338,7 +321,6 @@ public class App : Application
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.SearchBar.HorizontalTextAlignment" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="On&lt;T&gt;">
@@ -369,8 +351,6 @@ public class App : Application
       <Docs>
         <typeparam name="T">To be added.</typeparam>
         <summary>Returns the platform-specific instance of this <see cref="T:Microsoft.Maui.Controls.SearchBar" />, on which a platform-specific method may be called.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnSearchButtonPressed">
@@ -398,7 +378,6 @@ public class App : Application
       <Parameters />
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PlaceholderColorProperty">
@@ -418,7 +397,6 @@ public class App : Application
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.InputView.PlaceholderColor" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PlaceholderProperty">
@@ -443,7 +421,6 @@ public class App : Application
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.InputView.Placeholder" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SearchButtonPressed">
@@ -468,7 +445,6 @@ public class App : Application
       </ReturnValue>
       <Docs>
         <summary>Event that is raised when the user presses the Search button.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SearchCommand">
@@ -494,7 +470,6 @@ public class App : Application
       <Docs>
         <summary>Gets or sets the command that is run when the user presses Search button.</summary>
         <value>The command that is run when the user presses Search button.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SearchCommandParameter">
@@ -520,7 +495,6 @@ public class App : Application
       <Docs>
         <summary>Gets or sets the parameter that is sent to the <see cref="P:Microsoft.Maui.Controls.SearchBar.SearchCommand" />.</summary>
         <value>The parameter that is sent to the <see cref="P:Microsoft.Maui.Controls.SearchBar.SearchCommand" />.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SearchCommandParameterProperty">
@@ -545,7 +519,6 @@ public class App : Application
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.SearchBar.SearchCommandParameter" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SearchCommandProperty">
@@ -570,7 +543,6 @@ public class App : Application
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.SearchBar.SearchCommand" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TextColorProperty">
@@ -590,7 +562,6 @@ public class App : Application
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.InputView.TextColor" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TextProperty">
@@ -615,7 +586,6 @@ public class App : Application
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.InputView.Text" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="VerticalTextAlignment">
@@ -632,9 +602,6 @@ public class App : Application
         <ReturnType>Microsoft.Maui.TextAlignment</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="VerticalTextAlignmentProperty">
@@ -651,8 +618,6 @@ public class App : Application
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.Internals.IFontElement.FontSizeDefaultValueCreator">
@@ -675,8 +640,6 @@ public class App : Application
       <Parameters />
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.Internals.IFontElement.OnFontAttributesChanged">
@@ -704,7 +667,6 @@ public class App : Application
         <param name="oldValue">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="newValue">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.Internals.IFontElement.OnFontChanged">
@@ -732,7 +694,6 @@ public class App : Application
         <param name="oldValue">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="newValue">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.Internals.IFontElement.OnFontFamilyChanged">
@@ -760,7 +721,6 @@ public class App : Application
         <param name="oldValue">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="newValue">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.Internals.IFontElement.OnFontSizeChanged">
@@ -788,7 +748,6 @@ public class App : Application
         <param name="oldValue">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="newValue">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/SearchBoxVisibility.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/SearchBoxVisibility.xml
@@ -11,8 +11,6 @@
     <BaseTypeName>System.Enum</BaseTypeName>
   </Base>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Collapsible">
@@ -30,7 +28,6 @@
       </ReturnValue>
       <MemberValue>1</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
     <Member MemberName="Expanded">
@@ -48,7 +45,6 @@
       </ReturnValue>
       <MemberValue>2</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
     <Member MemberName="Hidden">
@@ -66,7 +62,6 @@
       </ReturnValue>
       <MemberValue>0</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/SearchHandler.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/SearchHandler.xml
@@ -20,7 +20,6 @@
   </Interfaces>
   <Docs>
     <summary>Default implementation of <see cref="T:Microsoft.Maui.Controls.ISearchHandlerController" />.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -34,8 +33,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="BackgroundColor">
@@ -52,9 +49,6 @@
         <ReturnType>Microsoft.Maui.Graphics.Color</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="BackgroundColorProperty">
@@ -71,8 +65,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CancelButtonColor">
@@ -89,9 +81,6 @@
         <ReturnType>Microsoft.Maui.Graphics.Color</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CancelButtonColorProperty">
@@ -108,8 +97,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CharacterSpacing">
@@ -126,9 +113,6 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CharacterSpacingProperty">
@@ -145,8 +129,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ClearIcon">
@@ -164,8 +146,6 @@
       </ReturnValue>
       <Docs>
         <summary>The icon displayed to clear the contents of the search box.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ClearIconHelpText">
@@ -183,8 +163,6 @@
       </ReturnValue>
       <Docs>
         <summary>The accessible help text for the clear icon.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ClearIconHelpTextProperty">
@@ -202,7 +180,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.SearchHandler.ClearIconHelpText" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ClearIconName">
@@ -220,8 +197,6 @@
       </ReturnValue>
       <Docs>
         <summary>The name of the clear icon for use with screen readers.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ClearIconNameProperty">
@@ -239,7 +214,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.SearchHandler.ClearIconName" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ClearIconProperty">
@@ -257,7 +231,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.SearchHandler.ClearIcon" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ClearPlaceholderCommand">
@@ -275,8 +248,6 @@
       </ReturnValue>
       <Docs>
         <summary>ICommand executed when the <see cref="P:Microsoft.Maui.Controls.SearchHandler.ClearPlaceholderIcon" /> is tapped.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ClearPlaceholderCommandParameter">
@@ -294,8 +265,6 @@
       </ReturnValue>
       <Docs>
         <summary>The parameter passed to the <see cref="P:Microsoft.Maui.Controls.SearchHandler.ClearPlaceholderCommand" />.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ClearPlaceholderCommandParameterProperty">
@@ -313,7 +282,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.SearchHandler.ClearPlaceholderCommandParameter" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ClearPlaceholderCommandProperty">
@@ -331,7 +299,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.SearchHandler.ClearPlaceholderCommand" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ClearPlaceholderEnabled">
@@ -350,7 +317,6 @@
       <Docs>
         <summary>Whether the <see cref="P:Microsoft.Maui.Controls.SearchHandler.ClearPlaceholderCommand" /> can be executed.</summary>
         <value>The default value is `true`.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ClearPlaceholderEnabledProperty">
@@ -368,7 +334,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.SearchHandler.ClearPlaceholderEnabled" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ClearPlaceholderHelpText">
@@ -386,8 +351,6 @@
       </ReturnValue>
       <Docs>
         <summary>The accessible help text for the <see cref="P:Microsoft.Maui.Controls.SearchHandler.ClearPlaceholderIcon" />.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ClearPlaceholderHelpTextProperty">
@@ -405,7 +368,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.SearchHandler.ClearPlaceholderHelpText" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ClearPlaceholderIcon">
@@ -423,8 +385,6 @@
       </ReturnValue>
       <Docs>
         <summary>The clear placeholder icon displayed when the search box is empty.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ClearPlaceholderIconProperty">
@@ -442,7 +402,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.SearchHandler.ClearPlaceholderIcon" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ClearPlaceholderName">
@@ -460,8 +419,6 @@
       </ReturnValue>
       <Docs>
         <summary>The name of the clear placeholder icon for use with screen readers.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ClearPlaceholderNameProperty">
@@ -479,7 +436,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.SearchHandler.ClearPlaceholderName" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Command">
@@ -497,8 +453,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the ICommand executed when the search query is confirmed.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CommandParameter">
@@ -516,8 +470,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the parameter of the <see cref="P:Microsoft.Maui.Controls.SearchHandler.Command" />, which is executed when the search query is confirmed.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CommandParameterProperty">
@@ -535,7 +487,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.SearchHandler.CommandParameter" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CommandProperty">
@@ -553,7 +504,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.SearchHandler.Command" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="DisplayMemberName">
@@ -571,8 +521,6 @@
       </ReturnValue>
       <Docs>
         <summary>The name or path of the property that is displayed for each item of data in the <see cref="P:Microsoft.Maui.Controls.SearchHandler.ItemsSource" /> collection.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="DisplayMemberNameProperty">
@@ -590,7 +538,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.SearchHandler.DisplayMemberName" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Focus">
@@ -608,9 +555,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FocusChangeRequested">
@@ -632,8 +576,6 @@
         <ReturnType>System.EventHandler&lt;Microsoft.Maui.Controls.VisualElement+FocusRequestArgs&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Focused">
@@ -650,8 +592,6 @@
         <ReturnType>System.EventHandler&lt;System.EventArgs&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FontAttributes">
@@ -668,9 +608,6 @@
         <ReturnType>Microsoft.Maui.Controls.FontAttributes</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FontAttributesProperty">
@@ -687,8 +624,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FontFamily">
@@ -705,9 +640,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FontFamilyProperty">
@@ -724,8 +656,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FontSize">
@@ -747,9 +677,6 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FontSizeProperty">
@@ -766,8 +693,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="HorizontalTextAlignment">
@@ -784,9 +709,6 @@
         <ReturnType>Microsoft.Maui.TextAlignment</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="HorizontalTextAlignmentProperty">
@@ -803,8 +725,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsFocused">
@@ -821,9 +741,6 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsFocusedProperty">
@@ -840,8 +757,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsFocusedPropertyKey">
@@ -863,8 +778,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindablePropertyKey</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsSearchEnabled">
@@ -883,7 +796,6 @@
       <Docs>
         <summary>Gets or sets whether the search box is enabled.</summary>
         <value>The default value is `true`.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsSearchEnabledProperty">
@@ -901,7 +813,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.SearchHandler.IsSearchEnabled" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ItemsSource">
@@ -920,7 +831,6 @@
       <Docs>
         <summary>The collection of items to be displayed in the suggestion area. Default is <see langword="null" />.</summary>
         <value>The default value is `null`.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ItemsSourceProperty">
@@ -938,7 +848,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.SearchHandler.ItemsSource" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ItemTemplate">
@@ -956,7 +865,6 @@
       </ReturnValue>
       <Docs>
         <summary>The <see cref="T:Microsoft.Maui.Controls.DataTemplate" /> to apply to each item in <see cref="P:Microsoft.Maui.Controls.SearchHandler.ItemsSource" />.</summary>
-        <value>To be added.</value>
         <remarks>
           <para>For example, to create the style shown here: <img src="~/xml/Microsoft.Maui.Controls/_images/search-results-template.png" />, developers could use either the following XAML or C#:</para>
           <example>
@@ -1028,7 +936,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.SearchHandler.ItemTemplate" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Keyboard">
@@ -1045,9 +952,6 @@
         <ReturnType>Microsoft.Maui.Keyboard</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="KeyboardProperty">
@@ -1064,8 +968,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnClearPlaceholderClicked">
@@ -1084,7 +986,6 @@
       <Parameters />
       <Docs>
         <summary>Developers may override this method to respond to the <see cref="P:Microsoft.Maui.Controls.SearchHandler.ClearPlaceholderIcon" /> being tapped.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnFocused">
@@ -1102,8 +1003,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnItemSelected">
@@ -1197,7 +1096,6 @@
       <Parameters />
       <Docs>
         <summary>Developers may override this method to respond to the user entering or confirming their query in the search box.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnUnfocus">
@@ -1215,8 +1113,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Placeholder">
@@ -1234,8 +1130,6 @@
       </ReturnValue>
       <Docs>
         <summary>The text to display when the search box is empty.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PlaceholderColor">
@@ -1252,9 +1146,6 @@
         <ReturnType>Microsoft.Maui.Graphics.Color</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PlaceholderColorProperty">
@@ -1271,8 +1162,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PlaceholderProperty">
@@ -1290,7 +1179,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.SearchHandler.Placeholder" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Query">
@@ -1308,8 +1196,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the text of the search box.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="QueryIcon">
@@ -1327,8 +1213,6 @@
       </ReturnValue>
       <Docs>
         <summary>The icon used to indicate that search is available.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="QueryIconHelpText">
@@ -1346,8 +1230,6 @@
       </ReturnValue>
       <Docs>
         <summary>The accessible help text for the <see cref="P:Microsoft.Maui.Controls.SearchHandler.QueryIcon" />.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="QueryIconHelpTextProperty">
@@ -1365,7 +1247,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.SearchHandler.QueryIconHelpText" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="QueryIconName">
@@ -1383,8 +1264,6 @@
       </ReturnValue>
       <Docs>
         <summary>The name of the <see cref="P:Microsoft.Maui.Controls.SearchHandler.QueryIcon" /> for use with screen readers.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="QueryIconNameProperty">
@@ -1402,7 +1281,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.SearchHandler.QueryIconName" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="QueryIconProperty">
@@ -1420,7 +1298,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.SearchHandler.QueryIcon" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="QueryProperty">
@@ -1438,7 +1315,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.SearchHandler.Query" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SearchBoxVisibility">
@@ -1457,7 +1333,6 @@
       <Docs>
         <summary>Gets or sets whether the search box is visible.</summary>
         <value>The default is <see cref="F:Microsoft.Maui.Controls.SearchBoxVisibility.Expanded" /> (visible and expanded).</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SearchBoxVisibilityProperty">
@@ -1475,7 +1350,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.SearchHandler.SearchBoxVisibility" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SelectedItem">
@@ -1492,9 +1366,6 @@
         <ReturnType>System.Object</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SelectedItemProperty">
@@ -1512,7 +1383,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.SearchHandler.SelectedItem" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetIsFocused">
@@ -1538,8 +1408,6 @@
       </Parameters>
       <Docs>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ShowsResults">
@@ -1558,7 +1426,6 @@
       <Docs>
         <summary>Gets or sets whether search results should be expected in the suggestion area on text entry.</summary>
         <value>The default value is `false`.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ShowsResultsProperty">
@@ -1576,7 +1443,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.SearchHandler.ShowsResults" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TextColor">
@@ -1593,9 +1459,6 @@
         <ReturnType>Microsoft.Maui.Graphics.Color</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TextColorProperty">
@@ -1612,8 +1475,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TextTransform">
@@ -1630,9 +1491,6 @@
         <ReturnType>Microsoft.Maui.Controls.TextTransform</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TextTransformProperty">
@@ -1649,8 +1507,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Unfocus">
@@ -1668,8 +1524,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Unfocused">
@@ -1686,8 +1540,6 @@
         <ReturnType>System.EventHandler&lt;System.EventArgs&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="UpdateFormsText">
@@ -1710,9 +1562,6 @@
       <Docs>
         <param name="source">To be added.</param>
         <param name="textTransform">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="VerticalTextAlignment">
@@ -1729,9 +1578,6 @@
         <ReturnType>Microsoft.Maui.TextAlignment</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="VerticalTextAlignmentProperty">
@@ -1748,8 +1594,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.Internals.IFontElement.FontSizeDefaultValueCreator">
@@ -1770,9 +1614,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.Internals.IFontElement.OnFontAttributesChanged">
@@ -1798,8 +1639,6 @@
       <Docs>
         <param name="oldValue">To be added.</param>
         <param name="newValue">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.Internals.IFontElement.OnFontChanged">
@@ -1825,8 +1664,6 @@
       <Docs>
         <param name="oldValue">To be added.</param>
         <param name="newValue">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.Internals.IFontElement.OnFontFamilyChanged">
@@ -1852,8 +1689,6 @@
       <Docs>
         <param name="oldValue">To be added.</param>
         <param name="newValue">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.Internals.IFontElement.OnFontSizeChanged">
@@ -1879,8 +1714,6 @@
       <Docs>
         <param name="oldValue">To be added.</param>
         <param name="newValue">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.ISearchHandlerController.ClearPlaceholderClicked">
@@ -1901,8 +1734,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.ISearchHandlerController.ItemSelected">
@@ -1926,8 +1757,6 @@
       </Parameters>
       <Docs>
         <param name="obj">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.ISearchHandlerController.ListProxy">
@@ -1947,9 +1776,6 @@
         <ReturnType>System.Collections.Generic.IReadOnlyList&lt;System.Object&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.ISearchHandlerController.ListProxyChanged">
@@ -1969,8 +1795,6 @@
         <ReturnType>System.EventHandler&lt;Microsoft.Maui.Controls.ListProxyChangedEventArgs&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.ISearchHandlerController.QueryConfirmed">
@@ -1991,8 +1815,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/SelectableItemsView.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/SelectableItemsView.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -27,8 +25,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnSelectionChanged">
@@ -49,8 +45,6 @@
       </Parameters>
       <Docs>
         <param name="args">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SelectedItem">
@@ -67,9 +61,6 @@
         <ReturnType>System.Object</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SelectedItemProperty">
@@ -87,7 +78,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.SelectableItemsView.SelectedItem" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SelectedItems">
@@ -104,9 +94,6 @@
         <ReturnType>System.Collections.Generic.IList&lt;System.Object&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SelectedItemsProperty">
@@ -124,7 +111,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.SelectableItemsView.SelectedItems" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SelectionChanged">
@@ -141,8 +127,6 @@
         <ReturnType>System.EventHandler&lt;Microsoft.Maui.Controls.SelectionChangedEventArgs&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SelectionChangedCommand">
@@ -159,9 +143,6 @@
         <ReturnType>System.Windows.Input.ICommand</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SelectionChangedCommandParameter">
@@ -178,9 +159,6 @@
         <ReturnType>System.Object</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SelectionChangedCommandParameterProperty">
@@ -198,7 +176,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.SelectableItemsView.SelectionChangedCommandParameter" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SelectionChangedCommandProperty">
@@ -216,7 +193,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.SelectableItemsView.SelectionChangedCommand" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SelectionMode">
@@ -233,9 +209,6 @@
         <ReturnType>Microsoft.Maui.Controls.SelectionMode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SelectionModeProperty">
@@ -253,7 +226,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.SelectableItemsView.SelectionMode" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="UpdateSelectedItems">
@@ -274,8 +246,6 @@
       </Parameters>
       <Docs>
         <param name="newSelection">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/SelectedItemChangedEventArgs.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/SelectedItemChangedEventArgs.xml
@@ -20,7 +20,6 @@
   <Interfaces />
   <Docs>
     <summary>Event arguments for the <see cref="E:Microsoft.Maui.Controls.ListView.ItemSelected" /> event.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -51,7 +50,6 @@
       <Docs>
         <param name="selectedItem">The newly selected item.</param>
         <summary>Creates a new <see cref="T:Microsoft.Maui.Controls.SelectedItemChangedEventArgs" /> event that indicates that the user has selected <paramref name="selectedItem" />.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -71,8 +69,6 @@
       <Docs>
         <param name="selectedItem">To be added.</param>
         <param name="selectedItemIndex">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SelectedItem">
@@ -97,8 +93,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets the new selected item.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SelectedItemIndex">
@@ -115,9 +109,6 @@
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/SelectedPositionChangedEventArgs.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/SelectedPositionChangedEventArgs.xml
@@ -14,7 +14,6 @@
   <Interfaces />
   <Docs>
     <summary>Event arguments for positional scrolling events.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -34,7 +33,6 @@
       <Docs>
         <param name="selectedPosition">The newly selected position.</param>
         <summary>Creates a new <see cref="T:Microsoft.Maui.Controls.SelectedPositionChangedEventArgs" /> with the specified new <paramref name="selectedPosition" />.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SelectedPosition">
@@ -53,8 +51,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets the newly selected position.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/SelectionChangedEventArgs.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/SelectionChangedEventArgs.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="CurrentSelection">
@@ -30,9 +28,6 @@
         <ReturnType>System.Collections.Generic.IReadOnlyList&lt;System.Object&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PreviousSelection">
@@ -49,9 +44,6 @@
         <ReturnType>System.Collections.Generic.IReadOnlyList&lt;System.Object&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/SelectionMode.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/SelectionMode.xml
@@ -11,8 +11,6 @@
     <BaseTypeName>System.Enum</BaseTypeName>
   </Base>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Multiple">
@@ -30,7 +28,6 @@
       </ReturnValue>
       <MemberValue>2</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
     <Member MemberName="None">
@@ -48,7 +45,6 @@
       </ReturnValue>
       <MemberValue>0</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
     <Member MemberName="Single">
@@ -66,7 +62,6 @@
       </ReturnValue>
       <MemberValue>1</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/SeparatorVisibility.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/SeparatorVisibility.xml
@@ -16,7 +16,6 @@
   </Base>
   <Docs>
     <summary>Enumerates values that control the visibility of list item separators.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Default">

--- a/src/Controls/docs/Microsoft.Maui.Controls/Setter.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/Setter.xml
@@ -47,7 +47,6 @@
       <Parameters />
       <Docs>
         <summary>Creates a new <see cref="T:Microsoft.Maui.Controls.Setter" /> object.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Property">
@@ -69,7 +68,6 @@
       </ReturnValue>
       <Docs>
         <summary>The property on which to apply the assignment.</summary>
-        <value>To be added.</value>
         <remarks>
           <para>Only bindable properties can be set with a <see cref="T:Microsoft.Maui.Controls.Setter" />.</para>.</remarks>
       </Docs>
@@ -88,9 +86,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Value">
@@ -112,8 +107,6 @@
       </ReturnValue>
       <Docs>
         <summary>The value to assign to the property.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.Xaml.IValueProvider.ProvideValue">
@@ -142,8 +135,6 @@
       <Docs>
         <param name="serviceProvider">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/SettersExtensions.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/SettersExtensions.xml
@@ -49,7 +49,6 @@
         <param name="property">The property to set.</param>
         <param name="value">The value to which to set the property set.</param>
         <summary>Add a Setter with a value to the IList&lt;Setter&gt;</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="AddBinding">
@@ -79,7 +78,6 @@
         <param name="property">The property to set.</param>
         <param name="binding">The binding to add.</param>
         <summary>Add a Setter with a Binding to the IList&lt;Setter&gt;</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="AddDynamicResource">
@@ -109,7 +107,6 @@
         <param name="property">The resource to add.</param>
         <param name="key">The resource key.</param>
         <summary>Add a Setter with a DynamicResource to the IList&lt;Setter&gt;</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/Shell.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/Shell.xml
@@ -34,7 +34,6 @@
   </Attributes>
   <Docs>
     <summary>A <see cref="T:Microsoft.Maui.Controls.Page" /> that provides fundamental UI features that most applications require, leaving you to focus on the application's core workload.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -49,7 +48,6 @@
       <Parameters />
       <Docs>
         <summary>Creates a new <see cref="T:Microsoft.Maui.Controls.Shell" /> element with default values.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Current">
@@ -67,7 +65,6 @@
       </ReturnValue>
       <Docs>
         <summary>Static property providing access to the current <see cref="T:Microsoft.Maui.Controls.Shell" />.</summary>
-        <value>To be added.</value>
         <remarks>
           <para>This is a typecast alias for <c>Microsoft.Maui.Controls.Application.Current.MainPage</c>.</para>
         </remarks>
@@ -88,8 +85,6 @@
       </ReturnValue>
       <Docs>
         <summary>The current navigation state of the <see cref="T:Microsoft.Maui.Controls.Shell" />.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CurrentStateProperty">
@@ -107,7 +102,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.Shell.CurrentState" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GoToAsync">
@@ -128,9 +122,6 @@
       </Parameters>
       <Docs>
         <param name="state">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GoToAsync">
@@ -154,7 +145,6 @@
         <param name="state">To be added.</param>
         <param name="animate">To be added.</param>
         <summary>Asynchronously navigates to <paramref name="state" />, optionally animating.</summary>
-        <returns>To be added.</returns>
         <remarks>
           <para>Note that <see cref="T:Microsoft.Maui.Controls.ShellNavigationState" /> has implicit conversions from <see langword="string" /> and <see cref="T:System.Uri" />, so developers may write code such as the following, with no explicit instantiation of the <see cref="T:Microsoft.Maui.Controls.ShellNavigationState" />:</para>
           <example>
@@ -180,8 +170,6 @@ await Shell.Current.GoToAsync("app://xamarin.com/xaminals/animals/monkeys");
       </ReturnValue>
       <Docs>
         <summary>The collection of <see cref="T:Microsoft.Maui.Controls.ShellItem" /> objects managed by <c>this</c><see cref="T:Microsoft.Maui.Controls.Shell" />.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ItemsProperty">
@@ -199,7 +187,6 @@ await Shell.Current.GoToAsync("app://xamarin.com/xaminals/animals/monkeys");
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.Shell.Items" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Navigated">
@@ -217,7 +204,6 @@ await Shell.Current.GoToAsync("app://xamarin.com/xaminals/animals/monkeys");
       </ReturnValue>
       <Docs>
         <summary>The library raises this event after performing navigation.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Navigating">
@@ -235,7 +221,6 @@ await Shell.Current.GoToAsync("app://xamarin.com/xaminals/animals/monkeys");
       </ReturnValue>
       <Docs>
         <summary>The library raises this event immediately prior to performing navigation.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnBackButtonPressed">
@@ -361,8 +346,6 @@ await Shell.Current.GoToAsync("app://xamarin.com/xaminals/animals/monkeys");
       <Docs>
         <param name="constructorHint">To be added.</param>
         <param name="memberName">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IShellController.AddAppearanceObserver">
@@ -389,7 +372,6 @@ await Shell.Current.GoToAsync("app://xamarin.com/xaminals/animals/monkeys");
         <param name="observer">To be added.</param>
         <param name="pivot">To be added.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IShellController.AddFlyoutBehaviorObserver">
@@ -414,7 +396,6 @@ await Shell.Current.GoToAsync("app://xamarin.com/xaminals/animals/monkeys");
       <Docs>
         <param name="observer">To be added.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IShellController.AppearanceChanged">
@@ -441,7 +422,6 @@ await Shell.Current.GoToAsync("app://xamarin.com/xaminals/animals/monkeys");
         <param name="source">To be added.</param>
         <param name="appearanceSet">To be added.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IShellController.FlyoutHeader">
@@ -462,8 +442,6 @@ await Shell.Current.GoToAsync("app://xamarin.com/xaminals/animals/monkeys");
       </ReturnValue>
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IShellController.GenerateFlyoutGrouping">
@@ -485,8 +463,6 @@ await Shell.Current.GoToAsync("app://xamarin.com/xaminals/animals/monkeys");
       <Parameters />
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IShellController.GetFlyoutItemDataTemplate">
@@ -510,9 +486,6 @@ await Shell.Current.GoToAsync("app://xamarin.com/xaminals/animals/monkeys");
       </Parameters>
       <Docs>
         <param name="bo">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IShellController.GetItems">
@@ -533,9 +506,6 @@ await Shell.Current.GoToAsync("app://xamarin.com/xaminals/animals/monkeys");
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IShellController.GetNavigationState">
@@ -566,8 +536,6 @@ await Shell.Current.GoToAsync("app://xamarin.com/xaminals/animals/monkeys");
         <param name="shellContent">To be added.</param>
         <param name="includeStack">To be added.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IShellController.ItemsCollectionChanged">
@@ -587,8 +555,6 @@ await Shell.Current.GoToAsync("app://xamarin.com/xaminals/animals/monkeys");
         <ReturnType>System.Collections.Specialized.NotifyCollectionChangedEventHandler</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IShellController.OnFlyoutItemSelected">
@@ -613,7 +579,6 @@ await Shell.Current.GoToAsync("app://xamarin.com/xaminals/animals/monkeys");
       <Docs>
         <param name="element">To be added.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IShellController.OnFlyoutItemSelectedAsync">
@@ -638,8 +603,6 @@ await Shell.Current.GoToAsync("app://xamarin.com/xaminals/animals/monkeys");
       <Docs>
         <param name="element">To be added.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IShellController.ProposeNavigation">
@@ -674,8 +637,6 @@ await Shell.Current.GoToAsync("app://xamarin.com/xaminals/animals/monkeys");
         <param name="stack">To be added.</param>
         <param name="canCancel">To be added.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IShellController.RemoveAppearanceObserver">
@@ -700,8 +661,6 @@ await Shell.Current.GoToAsync("app://xamarin.com/xaminals/animals/monkeys");
       <Docs>
         <param name="observer">To be added.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IShellController.RemoveFlyoutBehaviorObserver">
@@ -726,8 +685,6 @@ await Shell.Current.GoToAsync("app://xamarin.com/xaminals/animals/monkeys");
       <Docs>
         <param name="observer">To be added.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IShellController.StructureChanged">
@@ -748,7 +705,6 @@ await Shell.Current.GoToAsync("app://xamarin.com/xaminals/animals/monkeys");
       </ReturnValue>
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IShellController.UpdateCurrentState">
@@ -773,7 +729,6 @@ await Shell.Current.GoToAsync("app://xamarin.com/xaminals/animals/monkeys");
       <Docs>
         <param name="source">To be added.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/ShellAppearance.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/ShellAppearance.xml
@@ -21,8 +21,6 @@
     </Attribute>
   </Attributes>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="BackgroundColor">
@@ -39,9 +37,6 @@
         <ReturnType>Microsoft.Maui.Graphics.Color</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="DisabledColor">
@@ -58,9 +53,6 @@
         <ReturnType>Microsoft.Maui.Graphics.Color</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Equals">
@@ -81,9 +73,6 @@
       </Parameters>
       <Docs>
         <param name="obj">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FlyoutBackdrop">
@@ -100,9 +89,6 @@
         <ReturnType>Microsoft.Maui.Controls.Brush</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ForegroundColor">
@@ -119,9 +105,6 @@
         <ReturnType>Microsoft.Maui.Graphics.Color</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetHashCode">
@@ -139,9 +122,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Ingest">
@@ -162,9 +142,6 @@
       </Parameters>
       <Docs>
         <param name="pivot">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="MakeComplete">
@@ -182,8 +159,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="op_Equality">
@@ -206,9 +181,6 @@
       <Docs>
         <param name="appearance1">To be added.</param>
         <param name="appearance2">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="op_Inequality">
@@ -231,9 +203,6 @@
       <Docs>
         <param name="appearance1">To be added.</param>
         <param name="appearance2">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TabBarBackgroundColor">
@@ -250,9 +219,6 @@
         <ReturnType>Microsoft.Maui.Graphics.Color</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TabBarDisabledColor">
@@ -269,9 +235,6 @@
         <ReturnType>Microsoft.Maui.Graphics.Color</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TabBarForegroundColor">
@@ -288,9 +251,6 @@
         <ReturnType>Microsoft.Maui.Graphics.Color</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TabBarTitleColor">
@@ -307,9 +267,6 @@
         <ReturnType>Microsoft.Maui.Graphics.Color</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TabBarUnselectedColor">
@@ -326,9 +283,6 @@
         <ReturnType>Microsoft.Maui.Graphics.Color</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TitleColor">
@@ -345,9 +299,6 @@
         <ReturnType>Microsoft.Maui.Graphics.Color</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="UnselectedColor">
@@ -364,9 +315,6 @@
         <ReturnType>Microsoft.Maui.Graphics.Color</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IShellAppearanceElement.EffectiveTabBarBackgroundColor">
@@ -386,9 +334,6 @@
         <ReturnType>Microsoft.Maui.Graphics.Color</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IShellAppearanceElement.EffectiveTabBarDisabledColor">
@@ -408,9 +353,6 @@
         <ReturnType>Microsoft.Maui.Graphics.Color</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IShellAppearanceElement.EffectiveTabBarForegroundColor">
@@ -430,9 +372,6 @@
         <ReturnType>Microsoft.Maui.Graphics.Color</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IShellAppearanceElement.EffectiveTabBarTitleColor">
@@ -452,9 +391,6 @@
         <ReturnType>Microsoft.Maui.Graphics.Color</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IShellAppearanceElement.EffectiveTabBarUnselectedColor">
@@ -474,9 +410,6 @@
         <ReturnType>Microsoft.Maui.Graphics.Color</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/ShellContent.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/ShellContent.xml
@@ -25,7 +25,6 @@
   </Attributes>
   <Docs>
     <summary>Corresponds to a <see cref="T:Microsoft.Maui.Controls.ContentPage" /> contained in a <see cref="T:Microsoft.Maui.Controls.ShellSection" />.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -39,8 +38,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Content">
@@ -58,7 +55,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the <see cref="T:Microsoft.Maui.Controls.Page" />.</summary>
-        <value>To be added.</value>
         <remarks>Using this property will cause performance issues. Please use <see cref="P:Microsoft.Maui.Controls.ShellContent.ContentTemplate" /> instead.</remarks>
       </Docs>
     </Member>
@@ -77,7 +73,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.ShellContent.Content" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ContentTemplate">
@@ -95,8 +90,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets a data template to create when ShellContent becomes active.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ContentTemplateProperty">
@@ -114,7 +107,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.ShellContent.ContentTemplate" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="MenuItems">
@@ -132,8 +124,6 @@
       </ReturnValue>
       <Docs>
         <summary>Add <see cref="T:Microsoft.Maui.Controls.MenuItem" /> instances to flyout.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="MenuItemsProperty">
@@ -151,7 +141,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.ShellContent.MenuItems" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnChildAdded">
@@ -172,8 +161,6 @@
       </Parameters>
       <Docs>
         <param name="child">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnChildRemoved">
@@ -199,8 +186,6 @@
       </Parameters>
       <Docs>
         <param name="child">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnChildRemoved">
@@ -223,8 +208,6 @@
       <Docs>
         <param name="child">To be added.</param>
         <param name="oldLogicalIndex">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="op_Implicit">
@@ -246,8 +229,6 @@
       <Docs>
         <param name="page">To be added.</param>
         <summary>Used primarily by XAML to implicitly wrap a page in with a <see cref="T:Microsoft.Maui.Controls.ShellContent" />.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IShellContentController.GetOrCreateContent">
@@ -269,8 +250,6 @@
       <Parameters />
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IShellContentController.IsPageVisibleChanged">
@@ -290,8 +269,6 @@
         <ReturnType>System.EventHandler</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IShellContentController.Page">
@@ -312,8 +289,6 @@
       </ReturnValue>
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IShellContentController.RecyclePage">
@@ -338,7 +313,6 @@
       <Docs>
         <param name="page">To be added.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/ShellGroupItem.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/ShellGroupItem.xml
@@ -13,7 +13,6 @@
   <Interfaces />
   <Docs>
     <summary>A <see cref="T:Microsoft.Maui.Controls.BaseShellItem" /> that has <see cref="T:Microsoft.Maui.Controls.FlyoutDisplayOptions" />. Base class for <see cref="T:Microsoft.Maui.Controls.ShellItem" /> and <see cref="T:Microsoft.Maui.Controls.ShellSection" />.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -27,8 +26,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FlyoutDisplayOptions">
@@ -46,8 +43,6 @@
       </ReturnValue>
       <Docs>
         <summary>AsSingleItem (default) will only display the title of this item in the flyout. AsMultipleItems will create a separate flyout option for each child and <see cref="T:Microsoft.Maui.Controls.MenuItem" />.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FlyoutDisplayOptionsProperty">
@@ -65,7 +60,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.ShellGroupItem.FlyoutDisplayOptions" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/ShellItem.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/ShellItem.xml
@@ -31,7 +31,6 @@
   </Attributes>
   <Docs>
     <summary>One or more items in the flyout. Contained within a <see cref="T:Microsoft.Maui.Controls.Shell" />.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -45,8 +44,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CurrentItem">
@@ -64,8 +61,6 @@
       </ReturnValue>
       <Docs>
         <summary>The currently selected <see cref="T:Microsoft.Maui.Controls.Tab" /> or <see cref="T:Microsoft.Maui.Controls.ShellSection" />.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CurrentItemProperty">
@@ -83,7 +78,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.ShellItem.CurrentItem" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Items">
@@ -101,8 +95,6 @@
       </ReturnValue>
       <Docs>
         <summary>The collection of <see cref="T:Microsoft.Maui.Controls.ShellSection" /> objects managed by <c>this</c><see cref="T:Microsoft.Maui.Controls.ShellItem" />.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ItemsProperty">
@@ -120,7 +112,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.ShellItem.Items" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="On&lt;T&gt;">
@@ -149,9 +140,6 @@
       <Parameters />
       <Docs>
         <typeparam name="T">To be added.</typeparam>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnChildAdded">
@@ -227,8 +215,6 @@
       <Docs>
         <param name="child">To be added.</param>
         <param name="oldLogicalIndex">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="op_Implicit">
@@ -250,8 +236,6 @@
       <Docs>
         <param name="menuItem">To be added.</param>
         <summary>Used primarily by XAML to implicitly create a <see cref="T:Microsoft.Maui.Controls.MenuItem" /> from a <see cref="T:Microsoft.Maui.Controls.ShellSection" /> .</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="op_Implicit">
@@ -273,8 +257,6 @@
       <Docs>
         <param name="shellContent">To be added.</param>
         <summary>Used primarily by XAML to implicitly create a <see cref="T:Microsoft.Maui.Controls.ShellItem" /> from a <see cref="T:Microsoft.Maui.Controls.ShellContent" /> .</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="op_Implicit">
@@ -296,8 +278,6 @@
       <Docs>
         <param name="shellSection">To be added.</param>
         <summary>Used primarily by XAML to implicitly create a <see cref="T:Microsoft.Maui.Controls.ShellItem" /> from a <see cref="T:Microsoft.Maui.Controls.ShellSection" /> .</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="op_Implicit">
@@ -319,8 +299,6 @@
       <Docs>
         <param name="page">To be added.</param>
         <summary>Used primarily by XAML to implicitly create a <see cref="T:Microsoft.Maui.Controls.ShellItem" /> from a <see cref="T:Microsoft.Maui.Controls.TemplatedPage" /> .</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IShellItemController.GetItems">
@@ -341,9 +319,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IShellItemController.ItemsCollectionChanged">
@@ -363,8 +338,6 @@
         <ReturnType>System.Collections.Specialized.NotifyCollectionChangedEventHandler</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IShellItemController.ProposeSection">
@@ -391,8 +364,6 @@
         <param name="shellSection">To be added.</param>
         <param name="setValue">To be added.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IShellItemController.ShowTabs">
@@ -412,9 +383,6 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/ShellNavigatedEventArgs.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/ShellNavigatedEventArgs.xml
@@ -13,7 +13,6 @@
   <Interfaces />
   <Docs>
     <summary>Arguments for the <see cref="M:Microsoft.Maui.Controls.Shell.OnNavigated(Microsoft.Maui.Controls.ShellNavigatedEventArgs)" /> event.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -35,8 +34,6 @@
         <param name="previous">To be added.</param>
         <param name="current">To be added.</param>
         <param name="source">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Current">
@@ -53,9 +50,6 @@
         <ReturnType>Microsoft.Maui.Controls.ShellNavigationState</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Previous">
@@ -72,9 +66,6 @@
         <ReturnType>Microsoft.Maui.Controls.ShellNavigationState</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Source">
@@ -91,9 +82,6 @@
         <ReturnType>Microsoft.Maui.Controls.ShellNavigationSource</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/ShellNavigatingDeferral.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/ShellNavigatingDeferral.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Complete">
@@ -31,8 +29,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/ShellNavigatingEventArgs.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/ShellNavigatingEventArgs.xml
@@ -13,7 +13,6 @@
   <Interfaces />
   <Docs>
     <summary>Arguments for the <see cref="M:Microsoft.Maui.Controls.Shell.OnNavigating(Microsoft.Maui.Controls.ShellNavigatingEventArgs)" /> event.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -37,8 +36,6 @@
         <param name="target">To be added.</param>
         <param name="source">To be added.</param>
         <param name="canCancel">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CanCancel">
@@ -55,9 +52,6 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Cancel">
@@ -75,9 +69,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Cancelled">
@@ -94,9 +85,6 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Current">
@@ -113,9 +101,6 @@
         <ReturnType>Microsoft.Maui.Controls.ShellNavigationState</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetDeferral">
@@ -133,9 +118,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Source">
@@ -152,9 +134,6 @@
         <ReturnType>Microsoft.Maui.Controls.ShellNavigationSource</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Target">
@@ -171,9 +150,6 @@
         <ReturnType>Microsoft.Maui.Controls.ShellNavigationState</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/ShellNavigationSource.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/ShellNavigationSource.xml
@@ -12,7 +12,6 @@
   </Base>
   <Docs>
     <summary>Enumerates reasons for a navigation event in Shell applications.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Insert">
@@ -30,7 +29,6 @@
       </ReturnValue>
       <MemberValue>4</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
     <Member MemberName="Pop">
@@ -48,7 +46,6 @@
       </ReturnValue>
       <MemberValue>2</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
     <Member MemberName="PopToRoot">
@@ -66,7 +63,6 @@
       </ReturnValue>
       <MemberValue>3</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
     <Member MemberName="Push">
@@ -84,7 +80,6 @@
       </ReturnValue>
       <MemberValue>1</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
     <Member MemberName="Remove">
@@ -102,7 +97,6 @@
       </ReturnValue>
       <MemberValue>5</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
     <Member MemberName="ShellContentChanged">
@@ -120,7 +114,6 @@
       </ReturnValue>
       <MemberValue>8</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
     <Member MemberName="ShellItemChanged">
@@ -138,7 +131,6 @@
       </ReturnValue>
       <MemberValue>6</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
     <Member MemberName="ShellSectionChanged">
@@ -156,7 +148,6 @@
       </ReturnValue>
       <MemberValue>7</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
     <Member MemberName="Unknown">
@@ -174,7 +165,6 @@
       </ReturnValue>
       <MemberValue>0</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/ShellNavigationState.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/ShellNavigationState.xml
@@ -18,7 +18,6 @@
   </Attributes>
   <Docs>
     <summary>A URI representing either the current page or a destination for navigation in a Shell application.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -32,8 +31,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -51,8 +48,6 @@
       </Parameters>
       <Docs>
         <param name="location">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -70,8 +65,6 @@
       </Parameters>
       <Docs>
         <param name="location">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Location">
@@ -88,9 +81,6 @@
         <ReturnType>System.Uri</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="op_Implicit">
@@ -111,9 +101,6 @@
       </Parameters>
       <Docs>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="op_Implicit">
@@ -134,9 +121,6 @@
       </Parameters>
       <Docs>
         <param name="uri">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/ShellSection.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/ShellSection.xml
@@ -28,7 +28,6 @@
   </Attributes>
   <Docs>
     <summary>Grouped content in a Shell application, navigable by bottom tabs. </summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -42,8 +41,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CurrentItem">
@@ -61,8 +58,6 @@
       </ReturnValue>
       <Docs>
         <summary>The currently selected <see cref="T:Microsoft.Maui.Controls.ShellContent" />.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CurrentItemProperty">
@@ -80,7 +75,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.ShellSection.CurrentItem" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetNavigationStack">
@@ -98,9 +92,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Items">
@@ -118,8 +109,6 @@
       </ReturnValue>
       <Docs>
         <summary>The collection of <see cref="T:Microsoft.Maui.Controls.ShellContent" /> objects managed by <c>this</c><see cref="T:Microsoft.Maui.Controls.ShellSection" />.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ItemsProperty">
@@ -137,7 +126,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.ShellSection.Items" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnBindingContextChanged">
@@ -155,8 +143,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnChildAdded">
@@ -232,8 +218,6 @@
       <Docs>
         <param name="child">To be added.</param>
         <param name="oldLogicalIndex">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnInsertPageBefore">
@@ -256,8 +240,6 @@
       <Docs>
         <param name="page">To be added.</param>
         <param name="before">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnPopAsync">
@@ -278,9 +260,6 @@
       </Parameters>
       <Docs>
         <param name="animated">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnPopToRootAsync">
@@ -301,9 +280,6 @@
       </Parameters>
       <Docs>
         <param name="animated">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnPushAsync">
@@ -326,9 +302,6 @@
       <Docs>
         <param name="page">To be added.</param>
         <param name="animated">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnRemovePage">
@@ -349,8 +322,6 @@
       </Parameters>
       <Docs>
         <param name="page">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="op_Implicit">
@@ -371,9 +342,6 @@
       </Parameters>
       <Docs>
         <param name="shellContent">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="op_Implicit">
@@ -394,9 +362,6 @@
       </Parameters>
       <Docs>
         <param name="page">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Stack">
@@ -413,9 +378,6 @@
         <ReturnType>System.Collections.Generic.IReadOnlyList&lt;Microsoft.Maui.Controls.Page&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IShellSectionController.AddContentInsetObserver">
@@ -440,7 +402,6 @@
       <Docs>
         <param name="observer">To be added.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IShellSectionController.AddDisplayedPageObserver">
@@ -467,7 +428,6 @@
         <param name="observer">To be added.</param>
         <param name="callback">To be added.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IShellSectionController.GetItems">
@@ -488,9 +448,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IShellSectionController.ItemsCollectionChanged">
@@ -510,8 +467,6 @@
         <ReturnType>System.Collections.Specialized.NotifyCollectionChangedEventHandler</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IShellSectionController.NavigationRequested">
@@ -531,8 +486,6 @@
         <ReturnType>System.EventHandler&lt;Microsoft.Maui.Controls.Internals.NavigationRequestedEventArgs&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IShellSectionController.PresentedPage">
@@ -553,8 +506,6 @@
       </ReturnValue>
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IShellSectionController.RemoveContentInsetObserver">
@@ -579,8 +530,6 @@
       <Docs>
         <param name="observer">To be added.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IShellSectionController.RemoveDisplayedPageObserver">
@@ -605,8 +554,6 @@
       <Docs>
         <param name="observer">To be added.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IShellSectionController.SendInsetChanged">
@@ -633,7 +580,6 @@
         <param name="inset">To be added.</param>
         <param name="tabThickness">To be added.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IShellSectionController.SendPopped">
@@ -663,7 +609,6 @@
       <Parameters />
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IShellSectionController.SendPopped">
@@ -695,8 +640,6 @@
       </Parameters>
       <Docs>
         <param name="page">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IShellSectionController.SendPopping">
@@ -720,8 +663,6 @@
       </Parameters>
       <Docs>
         <param name="poppingCompleted">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IShellSectionController.SendPopping">
@@ -753,8 +694,6 @@
       </Parameters>
       <Docs>
         <param name="page">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IShellSectionController.SendPoppingToRoot">
@@ -778,8 +717,6 @@
       </Parameters>
       <Docs>
         <param name="finishedPopping">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/Slider.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/Slider.xml
@@ -165,8 +165,6 @@ namespace FormsGallery
         <ReturnType>System.EventHandler</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="DragCompletedCommand">
@@ -183,9 +181,6 @@ namespace FormsGallery
         <ReturnType>System.Windows.Input.ICommand</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="DragCompletedCommandProperty">
@@ -203,7 +198,6 @@ namespace FormsGallery
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.Slider.DragCompletedCommand" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="DragStarted">
@@ -220,8 +214,6 @@ namespace FormsGallery
         <ReturnType>System.EventHandler</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="DragStartedCommand">
@@ -238,9 +230,6 @@ namespace FormsGallery
         <ReturnType>System.Windows.Input.ICommand</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="DragStartedCommandProperty">
@@ -258,7 +247,6 @@ namespace FormsGallery
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.Slider.DragStartedCommand" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Maximum">
@@ -331,7 +319,6 @@ namespace FormsGallery
       <Docs>
         <summary>Gets or sets the color of the portion of the slider track that contains the maximum value of the slider.</summary>
         <value>Thhe color of the portion of the slider track that contains the maximum value of the slider.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="MaximumTrackColorProperty">
@@ -350,7 +337,6 @@ namespace FormsGallery
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.Slider.MaximumTrackColor" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Minimum">
@@ -423,7 +409,6 @@ namespace FormsGallery
       <Docs>
         <summary>Gets or sets the color of the portion of the slider track that contains the minimum value of the slider.</summary>
         <value>Thhe color of the portion of the slider track that contains the minimum value of the slider.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="MinimumTrackColorProperty">
@@ -442,7 +427,6 @@ namespace FormsGallery
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.Slider.MinimumTrackColor" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="On&lt;T&gt;">
@@ -473,8 +457,6 @@ namespace FormsGallery
       <Docs>
         <typeparam name="T">The platform for which to get a platform-specific instance.</typeparam>
         <summary>Returns the platform-specific instance of this <see cref="T:Microsoft.Maui.Controls.Slider" />, on which a platform-specific method may be called.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ThumbColor">
@@ -494,7 +476,6 @@ namespace FormsGallery
       <Docs>
         <summary>Gets or sets the color of the slider thumb button.</summary>
         <value>The color of the slider thumb button.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ThumbColorProperty">
@@ -513,7 +494,6 @@ namespace FormsGallery
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.Slider.ThumbColor" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ThumbImage">
@@ -541,7 +521,6 @@ namespace FormsGallery
       <Docs>
         <summary>Gets or sets the image to use for the slider thumb button.</summary>
         <value>The image to use for the slider thumb button.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ThumbImageProperty">
@@ -568,7 +547,6 @@ namespace FormsGallery
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.Slider.ThumbImage" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ThumbImageSource">
@@ -585,9 +563,6 @@ namespace FormsGallery
         <ReturnType>Microsoft.Maui.Controls.ImageSource</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ThumbImageSourceProperty">
@@ -604,8 +579,6 @@ namespace FormsGallery
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Value">
@@ -705,8 +678,6 @@ namespace FormsGallery
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.ISliderController.SendDragStarted">
@@ -727,8 +698,6 @@ namespace FormsGallery
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/SnapPointsAlignment.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/SnapPointsAlignment.xml
@@ -11,8 +11,6 @@
     <BaseTypeName>System.Enum</BaseTypeName>
   </Base>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Center">
@@ -30,7 +28,6 @@
       </ReturnValue>
       <MemberValue>1</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
     <Member MemberName="End">
@@ -48,7 +45,6 @@
       </ReturnValue>
       <MemberValue>2</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
     <Member MemberName="Start">
@@ -66,7 +62,6 @@
       </ReturnValue>
       <MemberValue>0</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/SnapPointsType.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/SnapPointsType.xml
@@ -11,8 +11,6 @@
     <BaseTypeName>System.Enum</BaseTypeName>
   </Base>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Mandatory">
@@ -30,7 +28,6 @@
       </ReturnValue>
       <MemberValue>1</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
     <Member MemberName="MandatorySingle">
@@ -48,7 +45,6 @@
       </ReturnValue>
       <MemberValue>2</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
     <Member MemberName="None">
@@ -66,7 +62,6 @@
       </ReturnValue>
       <MemberValue>0</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/SolidColorBrush.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/SolidColorBrush.xml
@@ -17,8 +17,6 @@
     </Attribute>
   </Attributes>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -32,8 +30,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -51,8 +47,6 @@
       </Parameters>
       <Docs>
         <param name="color">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Color">
@@ -69,9 +63,6 @@
         <ReturnType>Microsoft.Maui.Graphics.Color</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ColorProperty">
@@ -88,8 +79,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Equals">
@@ -110,9 +99,6 @@
       </Parameters>
       <Docs>
         <param name="obj">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetHashCode">
@@ -130,9 +116,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsEmpty">
@@ -149,9 +132,6 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/Span.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/Span.xml
@@ -52,7 +52,6 @@
       <Parameters />
       <Docs>
         <summary>Initialize a new instance of the Span class.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="BackgroundColor">
@@ -75,7 +74,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the Color of the span background.</summary>
-        <value>To be added.</value>
         <remarks>Not supported on WindowsPhone.</remarks>
       </Docs>
     </Member>
@@ -95,7 +93,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.Span.BackgroundColor" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CharacterSpacing">
@@ -112,9 +109,6 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CharacterSpacingProperty">
@@ -131,8 +125,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Font">
@@ -163,8 +155,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the Font for the text in the span.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FontAttributes">
@@ -186,8 +176,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets a value that indicates whether the font for the span is bold, italic, or neither.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FontAttributesProperty">
@@ -206,7 +194,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.Span.FontAttributes" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FontFamily">
@@ -228,8 +215,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets the font family to which the font for the text in the span belongs.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FontFamilyProperty">
@@ -248,7 +233,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.Span.FontFamily" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FontProperty">
@@ -267,7 +251,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.Span.Font" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FontSize">
@@ -294,8 +277,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets the size of the font for the text in the span.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FontSizeProperty">
@@ -314,7 +295,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.Span.FontSize" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ForegroundColor">
@@ -337,8 +317,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the Color for the text in the span.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ForegroundColorProperty">
@@ -365,7 +343,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.Span.ForegroundColor" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="LineHeight">
@@ -385,7 +362,6 @@
       <Docs>
         <summary>Gets or sets the multiplier to apply to the default line height when displaying text.</summary>
         <value>The multiplier to apply to the default line height when displaying text.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="LineHeightProperty">
@@ -404,7 +380,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.Span.LineHeight" /> bindable property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnBindingContextChanged">
@@ -423,7 +398,6 @@
       <Parameters />
       <Docs>
         <summary>Override this method to execute an action when the BindingContext changes.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Style">
@@ -442,8 +416,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the Style to apply to the span.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="StyleProperty">
@@ -462,7 +434,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.Span.Style" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Text">
@@ -485,8 +456,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the text of the span.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TextColor">
@@ -505,8 +474,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the text color.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TextColorProperty">
@@ -525,7 +492,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.Span.TextColor" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TextDecorations">
@@ -546,8 +512,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the <see cref="T:Microsoft.Maui.TextDecorations" /> applied to this span.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TextDecorationsProperty">
@@ -565,7 +529,6 @@
       </ReturnValue>
       <Docs>
         <summary>The <see cref="T:Microsoft.Maui.Controls.BindableProperty" /> associated with the <see cref="P:Microsoft.Maui.Controls.Span.TextDecorations" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TextProperty">
@@ -584,7 +547,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.Span.Text" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TextTransform">
@@ -601,9 +563,6 @@
         <ReturnType>Microsoft.Maui.Controls.TextTransform</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TextTransformProperty">
@@ -620,8 +579,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="UpdateFormsText">
@@ -644,9 +601,6 @@
       <Docs>
         <param name="source">To be added.</param>
         <param name="textTransform">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.Internals.IFontElement.FontSizeDefaultValueCreator">
@@ -669,8 +623,6 @@
       <Parameters />
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.Internals.IFontElement.OnFontAttributesChanged">
@@ -698,7 +650,6 @@
         <param name="oldValue">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="newValue">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.Internals.IFontElement.OnFontChanged">
@@ -726,7 +677,6 @@
         <param name="oldValue">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="newValue">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.Internals.IFontElement.OnFontFamilyChanged">
@@ -754,7 +704,6 @@
         <param name="oldValue">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="newValue">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.Internals.IFontElement.OnFontSizeChanged">
@@ -782,7 +731,6 @@
         <param name="oldValue">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="newValue">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/StackLayout.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/StackLayout.xml
@@ -119,8 +119,6 @@
       <Docs>
         <typeparam name="T">The platform configuration that selects the platform specific to use.</typeparam>
         <summary>Returns the configuration object that the developer can use to call platform-specific methods for the layout.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnSizeRequest">

--- a/src/Controls/docs/Microsoft.Maui.Controls/StateTrigger.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/StateTrigger.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -27,8 +25,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsActive">
@@ -45,9 +41,6 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsActiveProperty">
@@ -64,8 +57,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnAttached">
@@ -83,8 +74,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/StateTriggerBase.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/StateTriggerBase.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -27,8 +25,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsActive">
@@ -45,9 +41,6 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsActiveChanged">
@@ -64,8 +57,6 @@
         <ReturnType>System.EventHandler</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsAttached">
@@ -82,9 +73,6 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnAttached">
@@ -102,8 +90,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnDetached">
@@ -121,8 +107,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetActive">
@@ -143,8 +127,6 @@
       </Parameters>
       <Docs>
         <param name="active">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/Stepper.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/Stepper.xml
@@ -117,7 +117,6 @@
       <Parameters />
       <Docs>
         <summary>Initializes a new instance of the Stepper class.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -149,7 +148,6 @@
         <param name="val">The current selected value.</param>
         <param name="increment">The increment by which Value is increased or decreased.</param>
         <summary>Initializes a new instance of the Stepper class.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Increment">
@@ -201,7 +199,6 @@
       </ReturnValue>
       <Docs>
         <summary>Identifies the Increment bindable property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Maximum">
@@ -227,7 +224,6 @@
       <Docs>
         <summary>Gets or sets the maximum selectable value. This is a bindable property.</summary>
         <value>A double.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="MaximumProperty">
@@ -252,7 +248,6 @@
       </ReturnValue>
       <Docs>
         <summary>Identifies the Maximum bindable property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Minimum">
@@ -278,7 +273,6 @@
       <Docs>
         <summary>Gets or sets the minimum selectabel value. This is a bindable property.</summary>
         <value>A double.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="MinimumProperty">
@@ -303,7 +297,6 @@
       </ReturnValue>
       <Docs>
         <summary>Identifies the Minimum bindable property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="On&lt;T&gt;">
@@ -334,8 +327,6 @@
       <Docs>
         <typeparam name="T">To be added.</typeparam>
         <summary>Returns the platform-specific instance of this <see cref="T:Microsoft.Maui.Controls.Stepper" />, on which a platform-specific method may be called.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="StepperPosition">
@@ -360,9 +351,6 @@
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="StepperPositionProperty">
@@ -387,8 +375,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Value">
@@ -414,7 +400,6 @@
       <Docs>
         <summary>Gets or sets the current value. This is a bindable property.</summary>
         <value>A double.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ValueChanged">
@@ -439,7 +424,6 @@
       </ReturnValue>
       <Docs>
         <summary>Raised when the <see cref="P:Microsoft.Maui.Controls.Stepper.Value" /> property changes.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ValueProperty">
@@ -464,7 +448,6 @@
       </ReturnValue>
       <Docs>
         <summary>Identifies the Value bindable property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/StreamImageSource.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/StreamImageSource.xml
@@ -25,7 +25,6 @@
   <Docs>
     <summary>
       <see cref="T:Microsoft.Maui.Controls.ImageSource" /> that loads an image from a <see cref="T:System.IO.Stream" />.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -47,7 +46,6 @@
       <Parameters />
       <Docs>
         <summary>Creates a new <see cref="T:Microsoft.Maui.Controls.StreamImageSource" /> object with default values.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsEmpty">
@@ -64,9 +62,6 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnPropertyChanged">
@@ -95,7 +90,6 @@
       <Docs>
         <param name="propertyName">The property that changed.</param>
         <summary>Method that is called when the property that is specified by <paramref name="propertyName" /> is changed.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Stream">
@@ -122,7 +116,6 @@
         <summary>Gets or sets the delegate responsible for returning a <see cref="T:System.IO.Stream" /> for the Image.</summary>
         <value>
         </value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="StreamProperty">
@@ -147,7 +140,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.StreamImageSource.Stream" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IStreamImageSource.GetStreamAsync">
@@ -173,8 +165,6 @@
       <Docs>
         <param name="userToken">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/Stretch.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/Stretch.xml
@@ -11,8 +11,6 @@
     <BaseTypeName>System.Enum</BaseTypeName>
   </Base>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Fill">
@@ -30,7 +28,6 @@
       </ReturnValue>
       <MemberValue>1</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
     <Member MemberName="None">
@@ -48,7 +45,6 @@
       </ReturnValue>
       <MemberValue>0</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
     <Member MemberName="Uniform">
@@ -66,7 +62,6 @@
       </ReturnValue>
       <MemberValue>2</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
     <Member MemberName="UniformToFill">
@@ -84,7 +79,6 @@
       </ReturnValue>
       <MemberValue>3</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/StructuredItemsView.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/StructuredItemsView.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -27,8 +25,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Footer">
@@ -45,9 +41,6 @@
         <ReturnType>System.Object</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FooterProperty">
@@ -64,8 +57,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FooterTemplate">
@@ -82,9 +73,6 @@
         <ReturnType>Microsoft.Maui.Controls.DataTemplate</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FooterTemplateProperty">
@@ -101,8 +89,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Header">
@@ -119,9 +105,6 @@
         <ReturnType>System.Object</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="HeaderProperty">
@@ -138,8 +121,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="HeaderTemplate">
@@ -156,9 +137,6 @@
         <ReturnType>Microsoft.Maui.Controls.DataTemplate</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="HeaderTemplateProperty">
@@ -175,8 +153,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ItemSizingStrategy">
@@ -193,9 +169,6 @@
         <ReturnType>Microsoft.Maui.Controls.ItemSizingStrategy</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ItemSizingStrategyProperty">
@@ -212,8 +185,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ItemsLayout">
@@ -230,9 +201,6 @@
         <ReturnType>Microsoft.Maui.Controls.IItemsLayout</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ItemsLayoutProperty">
@@ -249,8 +217,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/Style.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/Style.xml
@@ -22,7 +22,6 @@
   </Attributes>
   <Docs>
     <summary>Class that contains triggers, setters, and behaviors that completely or partially define the appearance and behavior of a class of visual elements.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -51,7 +50,6 @@
       <Docs>
         <param name="targetType">The type of view to which the style will be applied.</param>
         <summary>Intitializes a new <see cref="T:Microsoft.Maui.Controls.Style" /> instance.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ApplyToDerivedTypes">
@@ -70,8 +68,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets a Boolean value that controls whether the style should be applied to controls that are derived from the base type.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="BasedOn">
@@ -93,7 +89,6 @@
       </ReturnValue>
       <Docs>
         <summary>The <see cref="T:Microsoft.Maui.Controls.Style" /> on which this <see cref="T:Microsoft.Maui.Controls.Style" /> is based.</summary>
-        <value>To be added.</value>
         <remarks>The <see cref="T:Microsoft.Maui.Controls.Style" /> supports a mechanism in XAML that is similar to inheritance in C#.</remarks>
       </Docs>
     </Member>
@@ -116,8 +111,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the key that identifies the <see cref="T:Microsoft.Maui.Controls.Style" /> on which this <see cref="T:Microsoft.Maui.Controls.Style" /> is based.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Behaviors">
@@ -139,8 +132,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets the list of <see cref="T:Microsoft.Maui.Controls.Behavior" /> objects that belong to this <see cref="T:Microsoft.Maui.Controls.Style" />.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CanCascade">
@@ -159,8 +150,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets a Boolean value that controls whether, when applying an explicit style to a control, an implicit style that targets the same control should also be applied.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Class">
@@ -179,8 +168,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the class for the style.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Setters">
@@ -202,8 +189,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets the list of <see cref="T:Microsoft.Maui.Controls.Setter" /> objects that belong to this <see cref="T:Microsoft.Maui.Controls.Style" />.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TargetType">
@@ -225,7 +210,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets the type of object that this style can describe. See Remarks.</summary>
-        <value>To be added.</value>
         <remarks>
           <p>Developers should be aware that implicit styles are only applied to the specific type that is described by <see cref="P:Microsoft.Maui.Controls.Style.TargetType" />, and not to types that inherit from it.</p>
         </remarks>
@@ -250,8 +234,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets the list of <see cref="T:Microsoft.Maui.Controls.Trigger" /> objects that belong to this <see cref="T:Microsoft.Maui.Controls.Style" />.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/SweepDirection.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/SweepDirection.xml
@@ -11,8 +11,6 @@
     <BaseTypeName>System.Enum</BaseTypeName>
   </Base>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Clockwise">
@@ -30,7 +28,6 @@
       </ReturnValue>
       <MemberValue>1</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
     <Member MemberName="CounterClockwise">
@@ -48,7 +45,6 @@
       </ReturnValue>
       <MemberValue>0</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/SwipeChangingEventArgs.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/SwipeChangingEventArgs.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -33,8 +31,6 @@
       <Docs>
         <param name="swipeDirection">To be added.</param>
         <param name="offset">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Offset">
@@ -51,9 +47,6 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/SwipeEndedEventArgs.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/SwipeEndedEventArgs.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -33,8 +31,6 @@
       <Docs>
         <param name="swipeDirection">To be added.</param>
         <param name="isOpen">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsOpen">
@@ -51,9 +47,6 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/SwipeGestureRecognizer.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/SwipeGestureRecognizer.xml
@@ -18,7 +18,6 @@
   </Interfaces>
   <Docs>
     <summary>Recognizer for swipe gestures.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -34,7 +33,6 @@
       <Parameters />
       <Docs>
         <summary>Creates a new <see cref="T:Microsoft.Maui.Controls.SwipeGestureRecognizer" /> with default values.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Command">
@@ -54,7 +52,6 @@
       <Docs>
         <summary>Gets or sets the command to run when a swipe gesture is recognized.</summary>
         <value>The command to run when a swipe gesture is recognized.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CommandParameter">
@@ -74,7 +71,6 @@
       <Docs>
         <summary>Gets or sets the parameter to pass to commands that take one.</summary>
         <value>The parameter to pass to commands that take one.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CommandParameterProperty">
@@ -93,7 +89,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.SwipeGestureRecognizer.CommandParameter" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CommandProperty">
@@ -112,7 +107,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.SwipeGestureRecognizer.Command" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Direction">
@@ -132,7 +126,6 @@
       <Docs>
         <summary>Gets or sets the direction of swipes to recognize.</summary>
         <value>The direction of swipes to recognize.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="DirectionProperty">
@@ -151,7 +144,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.SwipeGestureRecognizer.Direction" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SendSwiped">
@@ -176,7 +168,6 @@
         <param name="sender">The view that was swiped.</param>
         <param name="direction">The swipe direction.</param>
         <summary>Method that is called by the platform renderer when a swipe occurs.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Swiped">
@@ -195,7 +186,6 @@
       </ReturnValue>
       <Docs>
         <summary>Method that is called when a view is swiped.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Threshold">
@@ -215,7 +205,6 @@
       <Docs>
         <summary>Gets or sets the minimum swipe distance that will cause the gesture to be recognized.</summary>
         <value>The minimum swipe distance that will cause the gesture to be recognized.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ThresholdProperty">
@@ -234,7 +223,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.SwipeGestureRecognizer.Threshold" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.ISwipeGestureController.DetectSwipe">
@@ -262,8 +250,6 @@
         <param name="sender">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="direction">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.ISwipeGestureController.SendSwipe">
@@ -293,7 +279,6 @@
         <param name="totalX">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="totalY">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/SwipeItem.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/SwipeItem.xml
@@ -16,8 +16,6 @@
     </Interface>
   </Interfaces>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -31,8 +29,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="BackgroundColor">
@@ -49,9 +45,6 @@
         <ReturnType>Microsoft.Maui.Graphics.Color</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="BackgroundColorProperty">
@@ -68,8 +61,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Invoked">
@@ -89,8 +80,6 @@
         <ReturnType>System.EventHandler&lt;System.EventArgs&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsVisible">
@@ -110,9 +99,6 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsVisibleProperty">
@@ -129,8 +115,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnInvoked">
@@ -156,8 +140,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/SwipeItemView.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/SwipeItemView.xml
@@ -16,8 +16,6 @@
     </Interface>
   </Interfaces>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -31,8 +29,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Command">
@@ -52,9 +48,6 @@
         <ReturnType>System.Windows.Input.ICommand</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CommandParameter">
@@ -74,9 +67,6 @@
         <ReturnType>System.Object</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CommandParameterProperty">
@@ -93,8 +83,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CommandProperty">
@@ -111,8 +99,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Invoked">
@@ -132,8 +118,6 @@
         <ReturnType>System.EventHandler&lt;System.EventArgs&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnInvoked">
@@ -159,8 +143,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/SwipeItems.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/SwipeItems.xml
@@ -34,8 +34,6 @@
     </Interface>
   </Interfaces>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -49,8 +47,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -68,8 +64,6 @@
       </Parameters>
       <Docs>
         <param name="swipeItems">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Add">
@@ -93,8 +87,6 @@
       </Parameters>
       <Docs>
         <param name="item">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Clear">
@@ -115,8 +107,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CollectionChanged">
@@ -136,8 +126,6 @@
         <ReturnType>System.Collections.Specialized.NotifyCollectionChangedEventHandler</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Contains">
@@ -161,9 +149,6 @@
       </Parameters>
       <Docs>
         <param name="item">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CopyTo">
@@ -189,8 +174,6 @@
       <Docs>
         <param name="array">To be added.</param>
         <param name="arrayIndex">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Count">
@@ -210,9 +193,6 @@
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetEnumerator">
@@ -233,9 +213,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IndexOf">
@@ -259,9 +236,6 @@
       </Parameters>
       <Docs>
         <param name="item">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Insert">
@@ -287,8 +261,6 @@
       <Docs>
         <param name="index">To be added.</param>
         <param name="item">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsReadOnly">
@@ -308,9 +280,6 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Item">
@@ -334,9 +303,6 @@
       </Parameters>
       <Docs>
         <param name="index">To be added.</param>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Mode">
@@ -353,9 +319,6 @@
         <ReturnType>Microsoft.Maui.Controls.SwipeMode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ModeProperty">
@@ -372,8 +335,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnBindingContextChanged">
@@ -391,8 +352,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Remove">
@@ -416,9 +375,6 @@
       </Parameters>
       <Docs>
         <param name="item">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RemoveAt">
@@ -442,8 +398,6 @@
       </Parameters>
       <Docs>
         <param name="index">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SwipeBehaviorOnInvoked">
@@ -460,9 +414,6 @@
         <ReturnType>Microsoft.Maui.Controls.SwipeBehaviorOnInvoked</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SwipeBehaviorOnInvokedProperty">
@@ -479,8 +430,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="System.Collections.IEnumerable.GetEnumerator">
@@ -501,9 +450,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/SwipeStartedEventArgs.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/SwipeStartedEventArgs.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -31,8 +29,6 @@
       </Parameters>
       <Docs>
         <param name="swipeDirection">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/SwipeView.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/SwipeView.xml
@@ -27,8 +27,6 @@
     </Attribute>
   </Attributes>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -42,8 +40,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="BottomItems">
@@ -60,9 +56,6 @@
         <ReturnType>Microsoft.Maui.Controls.SwipeItems</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="BottomItemsProperty">
@@ -79,8 +72,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Close">
@@ -98,8 +89,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CloseRequested">
@@ -116,8 +105,6 @@
         <ReturnType>System.EventHandler</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="LeftItems">
@@ -134,9 +121,6 @@
         <ReturnType>Microsoft.Maui.Controls.SwipeItems</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="LeftItemsProperty">
@@ -153,8 +137,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="On&lt;T&gt;">
@@ -183,9 +165,6 @@
       <Parameters />
       <Docs>
         <typeparam name="T">To be added.</typeparam>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnBindingContextChanged">
@@ -203,8 +182,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Open">
@@ -225,8 +202,6 @@
       </Parameters>
       <Docs>
         <param name="openSwipeItem">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OpenRequested">
@@ -248,8 +223,6 @@
         <ReturnType>System.EventHandler&lt;Microsoft.Maui.Controls.OpenSwipeEventArgs&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RightItems">
@@ -266,9 +239,6 @@
         <ReturnType>Microsoft.Maui.Controls.SwipeItems</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RightItemsProperty">
@@ -285,8 +255,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SwipeChanging">
@@ -303,8 +271,6 @@
         <ReturnType>System.EventHandler&lt;Microsoft.Maui.Controls.SwipeChangingEventArgs&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SwipeEnded">
@@ -321,8 +287,6 @@
         <ReturnType>System.EventHandler&lt;Microsoft.Maui.Controls.SwipeEndedEventArgs&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SwipeStarted">
@@ -339,8 +303,6 @@
         <ReturnType>System.EventHandler&lt;Microsoft.Maui.Controls.SwipeStartedEventArgs&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Threshold">
@@ -357,9 +319,6 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ThresholdProperty">
@@ -376,8 +335,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TopItems">
@@ -394,9 +351,6 @@
         <ReturnType>Microsoft.Maui.Controls.SwipeItems</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TopItemsProperty">
@@ -413,8 +367,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.ISwipeViewController.IsOpen">
@@ -434,9 +386,6 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.ISwipeViewController.SendSwipeChanging">
@@ -460,8 +409,6 @@
       </Parameters>
       <Docs>
         <param name="args">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.ISwipeViewController.SendSwipeEnded">
@@ -485,8 +432,6 @@
       </Parameters>
       <Docs>
         <param name="args">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.ISwipeViewController.SendSwipeStarted">
@@ -510,8 +455,6 @@
       </Parameters>
       <Docs>
         <param name="args">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/SwipedEventArgs.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/SwipedEventArgs.xml
@@ -14,7 +14,6 @@
   <Interfaces />
   <Docs>
     <summary>Arguments for swipe events.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -36,7 +35,6 @@
         <param name="parameter">The parameter to pass to the command for the swipe.</param>
         <param name="direction">The swipe direction.</param>
         <summary>Creates a new swipe event argument object with the specified values.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Direction">
@@ -56,7 +54,6 @@
       <Docs>
         <summary>Gets the direction of the swipe.</summary>
         <value>The direction of the swipe.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Parameter">
@@ -76,7 +73,6 @@
       <Docs>
         <summary>Ges the command parameter.</summary>
         <value>The command parameter.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/Switch.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/Switch.xml
@@ -112,7 +112,6 @@ namespace FormsGallery
       <Parameters />
       <Docs>
         <summary>Creates a new <see cref="T:Microsoft.Maui.Controls.Switch" /> element with default values.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ChangeVisualState">
@@ -130,8 +129,6 @@ namespace FormsGallery
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsToggled">
@@ -156,8 +153,6 @@ namespace FormsGallery
       </ReturnValue>
       <Docs>
         <summary>Gets or sets a Boolean value that indicates whether this <see cref="T:Microsoft.Maui.Controls.Switch" /> element is toggled.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsToggledProperty">
@@ -182,7 +177,6 @@ namespace FormsGallery
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.Switch.IsToggled" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="On&lt;T&gt;">
@@ -213,8 +207,6 @@ namespace FormsGallery
       <Docs>
         <typeparam name="T">To be added.</typeparam>
         <summary>Returns the platform-specific instance of this <see cref="T:Microsoft.Maui.Controls.Switch" />, on which a platform-specific method may be called.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnColor">
@@ -234,7 +226,6 @@ namespace FormsGallery
       <Docs>
         <summary>Gets or sets the color of the switch when it is in the "On" position.</summary>
         <value>The color of the switch when it is in the "On" position.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnColorProperty">
@@ -253,7 +244,6 @@ namespace FormsGallery
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.Switch.OnColor" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SwitchOffVisualState">
@@ -270,8 +260,6 @@ namespace FormsGallery
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SwitchOnVisualState">
@@ -288,8 +276,6 @@ namespace FormsGallery
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ThumbColor">
@@ -306,9 +292,6 @@ namespace FormsGallery
         <ReturnType>Microsoft.Maui.Graphics.Color</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ThumbColorProperty">
@@ -325,8 +308,6 @@ namespace FormsGallery
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Toggled">
@@ -351,7 +332,6 @@ namespace FormsGallery
       </ReturnValue>
       <Docs>
         <summary>Event that is raised when this <see cref="T:Microsoft.Maui.Controls.Switch" /> is toggled.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/SwitchCell.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/SwitchCell.xml
@@ -95,7 +95,6 @@ namespace FormsGallery
       <Parameters />
       <Docs>
         <summary>Initializes a new instance of the SwitchCell class.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="On">
@@ -121,7 +120,6 @@ namespace FormsGallery
       <Docs>
         <summary>Gets or sets the state of the switch. This is a bindable property.</summary>
         <value>Default is <see langword="false" />.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnChanged">
@@ -146,7 +144,6 @@ namespace FormsGallery
       </ReturnValue>
       <Docs>
         <summary>Triggered when the switch has changed value.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnColor">
@@ -163,9 +160,6 @@ namespace FormsGallery
         <ReturnType>Microsoft.Maui.Graphics.Color</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnColorProperty">
@@ -183,7 +177,6 @@ namespace FormsGallery
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.SwitchCell.OnColor" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnProperty">
@@ -208,7 +201,6 @@ namespace FormsGallery
       </ReturnValue>
       <Docs>
         <summary>Identifies the <see cref="P:Microsoft.Maui.Controls.SwitchCell.On" /> bindable property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Text">
@@ -235,7 +227,6 @@ namespace FormsGallery
         <summary>Gets or sets the text displayed next to the switch. This is a bindable property.</summary>
         <value>
         </value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TextProperty">
@@ -260,7 +251,6 @@ namespace FormsGallery
       </ReturnValue>
       <Docs>
         <summary>Identifies the Text bindable property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/Tab.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/Tab.xml
@@ -17,8 +17,6 @@
     </Attribute>
   </Attributes>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -32,8 +30,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/TabBar.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/TabBar.xml
@@ -17,8 +17,6 @@
     </Attribute>
   </Attributes>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -32,8 +30,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/TabbedPage.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/TabbedPage.xml
@@ -166,7 +166,6 @@ class TabbedPageDemoPage2 : TabbedPage
       <Parameters />
       <Docs>
         <summary>Creates a new <see cref="T:Microsoft.Maui.Controls.TabbedPage" /> element with default values.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="BarBackground">
@@ -183,9 +182,6 @@ class TabbedPageDemoPage2 : TabbedPage
         <ReturnType>Microsoft.Maui.Controls.Brush</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="BarBackgroundColor">
@@ -205,7 +201,6 @@ class TabbedPageDemoPage2 : TabbedPage
       <Docs>
         <summary>Gets or sets the background color of the bar.</summary>
         <value>The background color of the bar.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="BarBackgroundColorProperty">
@@ -224,7 +219,6 @@ class TabbedPageDemoPage2 : TabbedPage
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.TabbedPage.BarBackgroundColor" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="BarBackgroundProperty">
@@ -241,8 +235,6 @@ class TabbedPageDemoPage2 : TabbedPage
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="BarTextColor">
@@ -262,7 +254,6 @@ class TabbedPageDemoPage2 : TabbedPage
       <Docs>
         <summary>Gets or sets the color of text on the bar.</summary>
         <value>The color of text on the bar.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="BarTextColorProperty">
@@ -281,7 +272,6 @@ class TabbedPageDemoPage2 : TabbedPage
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.TabbedPage.BarTextColor" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CreateDefault">
@@ -342,8 +332,6 @@ class TabbedPageDemoPage2 : TabbedPage
       <Docs>
         <typeparam name="T">To be added.</typeparam>
         <summary>Returns the platform-specific instance of this <see cref="T:Microsoft.Maui.Controls.TabbedPage" />, on which a platform-specific method may be called.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SelectedTabColor">
@@ -360,9 +348,6 @@ class TabbedPageDemoPage2 : TabbedPage
         <ReturnType>Microsoft.Maui.Graphics.Color</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SelectedTabColorProperty">
@@ -380,7 +365,6 @@ class TabbedPageDemoPage2 : TabbedPage
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.TabbedPage.SelectedTabColor" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="UnselectedTabColor">
@@ -397,9 +381,6 @@ class TabbedPageDemoPage2 : TabbedPage
         <ReturnType>Microsoft.Maui.Graphics.Color</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="UnselectedTabColorProperty">
@@ -417,7 +398,6 @@ class TabbedPageDemoPage2 : TabbedPage
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.TabbedPage.UnselectedTabColor" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/TableRoot.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/TableRoot.xml
@@ -23,7 +23,6 @@
   <Interfaces />
   <Docs>
     <summary>A <see cref="T:Microsoft.Maui.Controls.TableSection" /> that contains either a table section or the entire table.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -45,7 +44,6 @@
       <Parameters />
       <Docs>
         <summary>Constructs and initializes a new instance of the <see cref="T:Microsoft.Maui.Controls.TableRoot" /> class.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -71,7 +69,6 @@
       <Docs>
         <param name="title">The title of the table.</param>
         <summary>Constructs and initializes a new instance of the <see cref="T:Microsoft.Maui.Controls.TableRoot" /> class with a title.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/TableSection.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/TableSection.xml
@@ -23,7 +23,6 @@
   <Interfaces />
   <Docs>
     <summary>A logical and visible section of a <see cref="T:Microsoft.Maui.Controls.TableView" />.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -45,7 +44,6 @@
       <Parameters />
       <Docs>
         <summary>Creates a new <see cref="T:Microsoft.Maui.Controls.TableSection" /> with default values.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -71,7 +69,6 @@
       <Docs>
         <param name="title">The title of the table section.</param>
         <summary>Creates a new <see cref="T:Microsoft.Maui.Controls.TableSection" /> with the title <paramref name="title" />.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/TableSectionBase.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/TableSectionBase.xml
@@ -21,7 +21,6 @@
   <Docs>
     <summary>Abstract base class defining a table section.</summary>
     <remarks>
-      <para>To be added.</para>
     </remarks>
   </Docs>
   <Members>
@@ -44,7 +43,6 @@
       <Parameters />
       <Docs>
         <summary>Creates a new <see cref="T:Microsoft.Maui.Controls.TableSectionBase" /> object with default values.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -70,7 +68,6 @@
       <Docs>
         <param name="title">The title of the table section.</param>
         <summary>Creates a new <see cref="T:Microsoft.Maui.Controls.TableSectionBase" /> object with the specified <paramref name="title" />.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TextColor">
@@ -87,9 +84,6 @@
         <ReturnType>Microsoft.Maui.Graphics.Color</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TextColorProperty">
@@ -107,7 +101,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.TableSectionBase.TextColor" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Title">
@@ -132,8 +125,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the title.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TitleProperty">
@@ -158,7 +149,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.TableSectionBase.Title" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/TableView.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/TableView.xml
@@ -102,7 +102,6 @@ public class App : Application
       <Parameters />
       <Docs>
         <summary>Initializes a new <see cref="T:Microsoft.Maui.Controls.TableView" /> instance.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -128,7 +127,6 @@ public class App : Application
       <Docs>
         <param name="root">The root of the table view.</param>
         <summary>Initializes a new <see cref="T:Microsoft.Maui.Controls.TableView" /> instance.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="HasUnevenRows">
@@ -153,7 +151,6 @@ public class App : Application
       </ReturnValue>
       <Docs>
         <summary>Gets or sets a value that indicates whether the rows that are contained in this <see cref="T:Microsoft.Maui.Controls.TableView" /> can have uneven rows.</summary>
-        <value>To be added.</value>
         <remarks>
           <para>When the <see cref="P:Microsoft.Maui.Controls.TableView.HasUnevenRows" /> property is <see langword="true" />, application developers can set the <see cref="P:Microsoft.Maui.Controls.Cell.Height" /> properties to control the height of <see cref="T:Microsoft.Maui.Controls.Cell" /> items in the table. When the <see cref="P:Microsoft.Maui.Controls.TableView.HasUnevenRows" /> property is <see langword="true" />, the <see cref="P:Microsoft.Maui.Controls.TableView.RowHeight" /> property is ignored. When the <see cref="P:Microsoft.Maui.Controls.TableView.HasUnevenRows" /> property is <see langword="false" />, app developers can set the <see cref="P:Microsoft.Maui.Controls.TableView.RowHeight" /> property to set the height of all Cells, and their individual <see cref="P:Microsoft.Maui.Controls.Cell.Height" /> properties are ignored.</para>
           <para>Note: developers must specify row heights on the iOS platform, even when <see cref="P:Microsoft.Maui.Controls.TableView.HasUnevenRows" /> is <see langword="true" />.</para>
@@ -182,7 +179,6 @@ public class App : Application
       </ReturnValue>
       <Docs>
         <summary>Backing store for the HasUnevenRows property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Intent">
@@ -207,8 +203,6 @@ public class App : Application
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the intent of the table.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Model">
@@ -232,8 +226,6 @@ public class App : Application
       </ReturnValue>
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ModelChanged">
@@ -260,7 +252,6 @@ public class App : Application
       </ReturnValue>
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="On&lt;T&gt;">
@@ -291,8 +282,6 @@ public class App : Application
       <Docs>
         <typeparam name="T">To be added.</typeparam>
         <summary>Returns the platform-specific instance of this <see cref="T:Microsoft.Maui.Controls.TableView" />, on which a platform-specific method may be called.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnBindingContextChanged">
@@ -318,7 +307,6 @@ public class App : Application
       <Parameters />
       <Docs>
         <summary>Method that is called when the binding context changes.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnModelChanged">
@@ -344,7 +332,6 @@ public class App : Application
       <Parameters />
       <Docs>
         <summary>Method that is called when the model changes.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnSizeRequest">
@@ -380,8 +367,6 @@ public class App : Application
         <param name="widthConstraint">The width constraint of the size request.</param>
         <param name="heightConstraint">The height constraint of the size request.</param>
         <summary>Method that is called when a size request is made.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Root">
@@ -406,8 +391,6 @@ public class App : Application
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the root of the table.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RowHeight">
@@ -432,8 +415,6 @@ public class App : Application
       </ReturnValue>
       <Docs>
         <summary>An integer that describes the height of the items in the list. This is ignored if HasUnevenRows is true.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RowHeightProperty">
@@ -458,7 +439,6 @@ public class App : Application
       </ReturnValue>
       <Docs>
         <summary>Backing store for the row height property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.ITableViewController.Model">
@@ -480,8 +460,6 @@ public class App : Application
       </ReturnValue>
       <Docs>
         <summary>Internal.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/TabsStyle.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/TabsStyle.xml
@@ -13,7 +13,6 @@
   </Base>
   <Docs>
     <summary>Enumerates tab styles for tabbed pages.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Default">

--- a/src/Controls/docs/Microsoft.Maui.Controls/TapGestureRecognizer.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/TapGestureRecognizer.xml
@@ -42,7 +42,6 @@
       <Parameters />
       <Docs>
         <summary>Initializes a new instance of a TapGestureRecognizer object.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -76,7 +75,6 @@
       <Docs>
         <param name="tappedCallback">An action whose first argument is the View the recognizer is associated with and whose second argument is the callback parameter.</param>
         <summary>Initializes a new instance of a TapGestureRecognizer object with a parameterized callback.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -110,7 +108,6 @@
       <Docs>
         <param name="tappedCallback">An action whose first argument is the View the recognizer is associated with.</param>
         <summary>Initializes a new instance of a TapGestureRecognizer object with a callback.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Command">
@@ -135,7 +132,6 @@
       </ReturnValue>
       <Docs>
         <summary>The Command to invoke when the gesture has been triggered by the user. This is a bindable property.</summary>
-        <value>To be added.</value>
         <remarks>The object passed to the Command will be the contents of <see cref="P:Microsoft.Maui.Controls.TapGestureRecognizer.CommandParameter" /></remarks>
       </Docs>
     </Member>
@@ -161,8 +157,6 @@
       </ReturnValue>
       <Docs>
         <summary>An object to be passed to the TappedCallback. This is a bindable property.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CommandParameterProperty">
@@ -187,7 +181,6 @@
       </ReturnValue>
       <Docs>
         <summary>Identifies the CommandParameter bindable property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CommandProperty">
@@ -212,7 +205,6 @@
       </ReturnValue>
       <Docs>
         <summary>Identifies the Command bindable property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="NumberOfTapsRequired">
@@ -238,7 +230,6 @@
       <Docs>
         <summary>The number of taps required to trigger the callback. This is a bindable property.</summary>
         <value>The number of taps to recognize. The default value is 1.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="NumberOfTapsRequiredProperty">
@@ -263,7 +254,6 @@
       </ReturnValue>
       <Docs>
         <summary>Identifies the NumberOfTapsRequired bindable property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SendTapped">
@@ -291,7 +281,6 @@
       <Docs>
         <param name="sender">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Tapped">
@@ -316,7 +305,6 @@
       </ReturnValue>
       <Docs>
         <summary>Event that is raised when the user taps.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TappedCallback">
@@ -417,7 +405,6 @@
       </ReturnValue>
       <Docs>
         <summary>Identifies the TappedCallbackParameter bindable property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TappedCallbackProperty">
@@ -450,7 +437,6 @@
       </ReturnValue>
       <Docs>
         <summary>Identifies the TappedCallback bindable property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/TappedEventArgs.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/TappedEventArgs.xml
@@ -20,7 +20,6 @@
   <Interfaces />
   <Docs>
     <summary>Arguments for the <see cref="T:Microsoft.Maui.Controls.ListView.ItemTapped" /> event.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -46,7 +45,6 @@
       <Docs>
         <param name="parameter">A parameter object for the tapped event.</param>
         <summary>Creates a new <see cref="T:Microsoft.Maui.Controls.TappedEventArgs" /> object with the supplied parameter.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Parameter">
@@ -71,8 +69,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets the parameter object for this <see cref="T:Microsoft.Maui.Controls.TappedEventArgs" /> object.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/TemplateBinding.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/TemplateBinding.xml
@@ -49,7 +49,6 @@
       <Parameters />
       <Docs>
         <summary>Creates an empty template binding.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -77,7 +76,6 @@
         <param name="converterParameter">A parameter to pass to the converter.</param>
         <param name="stringFormat">A format string to use for displaying property values.</param>
         <summary>Creates a new TemplateBinding with the specified values. Must be non-empty and non-null.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Converter">
@@ -96,8 +94,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the type converter to use to convert strings into instances of the bound property type.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ConverterParameter">
@@ -116,8 +112,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets a format string to use for displaying property values.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Path">
@@ -136,8 +130,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets a string that identifies the property to which to bind.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/TemplateExtensions.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/TemplateExtensions.xml
@@ -20,7 +20,6 @@
   <Interfaces />
   <Docs>
     <summary>Extension class for DataTemplate, providing a string-based shortcut method for defining a Binding.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="SetBinding">
@@ -53,7 +52,6 @@
         <param name="targetProperty">The target property of the binding.</param>
         <param name="path">The path to the binding.</param>
         <summary>Binds the <paramref name="self" /> object's <paramref name="targetProperty" /> to a new <see cref="T:Microsoft.Maui.Controls.Binding" /> instance that was created with <paramref name="path" />.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/TemplatedPage.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/TemplatedPage.xml
@@ -14,7 +14,6 @@
   <Interfaces />
   <Docs>
     <summary>A page that displays full-screen content with a control template, and the base class for <see cref="T:Microsoft.Maui.Controls.ContentPage" /> .</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -30,7 +29,6 @@
       <Parameters />
       <Docs>
         <summary>Creates a new empty templated page.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ControlTemplate">
@@ -49,8 +47,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the control template that is used to display content.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ControlTemplateProperty">
@@ -69,7 +65,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.TemplatedPage.ControlTemplate" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetTemplateChild">
@@ -90,9 +85,6 @@
       </Parameters>
       <Docs>
         <param name="name">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnApplyTemplate">
@@ -110,8 +102,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnChildRemoved">
@@ -137,8 +127,6 @@
       </Parameters>
       <Docs>
         <param name="child">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnChildRemoved">
@@ -161,8 +149,6 @@
       <Docs>
         <param name="child">To be added.</param>
         <param name="oldLogicalIndex">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/TemplatedView.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/TemplatedView.xml
@@ -14,7 +14,6 @@
   <Interfaces />
   <Docs>
     <summary>A view that displays content with a control template, and the base class for <see cref="T:Microsoft.Maui.Controls.ContentView" />.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -30,7 +29,6 @@
       <Parameters />
       <Docs>
         <summary>Creates a new empty templated view.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ControlTemplate">
@@ -49,8 +47,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the control template that is used to display content.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ControlTemplateProperty">
@@ -69,7 +65,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.TemplatedView.ControlTemplate" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetTemplateChild">
@@ -90,9 +85,6 @@
       </Parameters>
       <Docs>
         <param name="name">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="LayoutChildren">
@@ -121,7 +113,6 @@
         <param name="width">The width of the bounding rectangle.</param>
         <param name="height">The height of the bounding rectangle.</param>
         <summary>Positions and sizes the children of the templated view within the rectangle defined by <paramref name="x" />, <paramref name="y" />, <paramref name="width" />, and <paramref name="height" />T.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnApplyTemplate">
@@ -139,8 +130,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnChildRemoved">
@@ -166,8 +155,6 @@
       </Parameters>
       <Docs>
         <param name="child">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnChildRemoved">
@@ -190,8 +177,6 @@
       <Docs>
         <param name="child">To be added.</param>
         <param name="oldLogicalIndex">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnSizeRequest">
@@ -224,8 +209,6 @@
         <param name="widthConstraint">The width constraint that was passed with the request.</param>
         <param name="heightConstraint">The height constraint that was passed with the request.</param>
         <summary>Method that is called when the layout updates.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ResolveControlTemplate">
@@ -243,9 +226,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/TextAlignmentConverter.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/TextAlignmentConverter.xml
@@ -37,7 +37,6 @@
       <Parameters />
       <Docs>
         <summary>Creates a new default converter.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ConvertFromInvariantString">
@@ -61,7 +60,6 @@
         <param name="value">The value to convert.</param>
         <summary>Returns the object for the string representation.</summary>
         <returns>The object for the string representation.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/TextChangedEventArgs.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/TextChangedEventArgs.xml
@@ -20,7 +20,6 @@
   <Interfaces />
   <Docs>
     <summary>Event arguments for <c>TextChanged</c> events. Provides old and new text values.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -48,7 +47,6 @@
         <param name="oldTextValue">The old text value.</param>
         <param name="newTextValue">The new text value.</param>
         <summary>Creates a new <see cref="T:Microsoft.Maui.Controls.TextChangedEventArgs" /> with <paramref name="oldTextValue" /> and <paramref name="newTextValue" />.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="NewTextValue">
@@ -73,8 +71,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets the new text value.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OldTextValue">
@@ -99,8 +95,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets the old text value.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/TextDecorationConverter.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/TextDecorationConverter.xml
@@ -18,7 +18,6 @@
   </Attributes>
   <Docs>
     <summary>A <see cref="T:System.ComponentModel.TypeConverter" /> subclass that can convert between a string and a <see cref="T:Microsoft.Maui.TextDecorations" /> object.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -32,8 +31,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ConvertFromInvariantString">
@@ -55,7 +52,6 @@
       <Docs>
         <param name="value">A comma-separated string whose contents correspond to values of <see cref="T:Microsoft.Maui.TextDecorations" />.</param>
         <summary>Converts a single value or comma-separated string to a <see cref="T:Microsoft.Maui.TextDecorations" /> object.</summary>
-        <returns>To be added.</returns>
         <remarks>
           <para>The elements of <param name="value" /> must each be a value within <see cref="T:Microsoft.Maui.TextDecorations" /> or the string "line-through".</para>
         </remarks>

--- a/src/Controls/docs/Microsoft.Maui.Controls/TimePicker.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/TimePicker.xml
@@ -85,9 +85,6 @@ var beeroclock = new TimePicker () { Time = new TimeSpan (17,0,0) };
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CharacterSpacingProperty">
@@ -104,8 +101,6 @@ var beeroclock = new TimePicker () { Time = new TimeSpan (17,0,0) };
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FontAttributes">
@@ -124,8 +119,6 @@ var beeroclock = new TimePicker () { Time = new TimeSpan (17,0,0) };
       </ReturnValue>
       <Docs>
         <summary>TGets a value that indicates whether the font for the searchbar text is bold, italic, or neither.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FontAttributesProperty">
@@ -144,7 +137,6 @@ var beeroclock = new TimePicker () { Time = new TimeSpan (17,0,0) };
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.TimePicker.FontAttributes" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FontFamily">
@@ -163,8 +155,6 @@ var beeroclock = new TimePicker () { Time = new TimeSpan (17,0,0) };
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the font family for the picker text.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FontFamilyProperty">
@@ -183,7 +173,6 @@ var beeroclock = new TimePicker () { Time = new TimeSpan (17,0,0) };
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.TimePicker.FontFamily" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FontSize">
@@ -208,7 +197,6 @@ var beeroclock = new TimePicker () { Time = new TimeSpan (17,0,0) };
       <Docs>
         <summary>Gets or sets the size of the font for the text in the picker.</summary>
         <value>A <see langword="double" /> that indicates the size of the font.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FontSizeProperty">
@@ -227,7 +215,6 @@ var beeroclock = new TimePicker () { Time = new TimeSpan (17,0,0) };
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.TimePicker.FontSize" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Format">
@@ -310,8 +297,6 @@ var beeroclock = new TimePicker () { Time = new TimeSpan (17,0,0) };
       <Docs>
         <typeparam name="T">To be added.</typeparam>
         <summary>Returns the platform-specific instance of this <see cref="T:Microsoft.Maui.Controls.TimePicker" />, on which a platform-specific method may be called.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TextColor">
@@ -330,8 +315,6 @@ var beeroclock = new TimePicker () { Time = new TimeSpan (17,0,0) };
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the text color.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TextColorProperty">
@@ -350,7 +333,6 @@ var beeroclock = new TimePicker () { Time = new TimeSpan (17,0,0) };
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.TimePicker.TextColor" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TextTransform">
@@ -367,9 +349,6 @@ var beeroclock = new TimePicker () { Time = new TimeSpan (17,0,0) };
         <ReturnType>Microsoft.Maui.Controls.TextTransform</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TextTransformProperty">
@@ -386,8 +365,6 @@ var beeroclock = new TimePicker () { Time = new TimeSpan (17,0,0) };
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Time">
@@ -413,7 +390,6 @@ var beeroclock = new TimePicker () { Time = new TimeSpan (17,0,0) };
       <Docs>
         <summary>Gets or sets the displayed time. This is a bindable property.</summary>
         <value>The <see cref="T:System.TimeSpan" /> displayed in the TimePicker.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TimeProperty">
@@ -462,9 +438,6 @@ var beeroclock = new TimePicker () { Time = new TimeSpan (17,0,0) };
       <Docs>
         <param name="source">To be added.</param>
         <param name="textTransform">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.Internals.IFontElement.FontSizeDefaultValueCreator">
@@ -487,8 +460,6 @@ var beeroclock = new TimePicker () { Time = new TimeSpan (17,0,0) };
       <Parameters />
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.Internals.IFontElement.OnFontAttributesChanged">
@@ -516,7 +487,6 @@ var beeroclock = new TimePicker () { Time = new TimeSpan (17,0,0) };
         <param name="oldValue">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="newValue">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.Internals.IFontElement.OnFontChanged">
@@ -544,7 +514,6 @@ var beeroclock = new TimePicker () { Time = new TimeSpan (17,0,0) };
         <param name="oldValue">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="newValue">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.Internals.IFontElement.OnFontFamilyChanged">
@@ -572,7 +541,6 @@ var beeroclock = new TimePicker () { Time = new TimeSpan (17,0,0) };
         <param name="oldValue">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="newValue">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.Internals.IFontElement.OnFontSizeChanged">
@@ -600,7 +568,6 @@ var beeroclock = new TimePicker () { Time = new TimeSpan (17,0,0) };
         <param name="oldValue">TFor internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="newValue">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/ToggledEventArgs.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/ToggledEventArgs.xml
@@ -20,7 +20,6 @@
   <Interfaces />
   <Docs>
     <summary>Event arguments for <see cref="E:Microsoft.Maui.Controls.Switch.Toggled" /> and <see cref="E:Microsoft.Maui.Controls.SwitchCell.OnChanged" /> events.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -46,7 +45,6 @@
       <Docs>
         <param name="value">Whether the toggle is in the On position.</param>
         <summary>Creates a new <see cref="T:Microsoft.Maui.Controls.ToggledEventArgs" /> that indicates that the toggle control was toggled to <paramref name="value" />.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Value">
@@ -71,8 +69,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets the Boolean value to which the toggle control was toggled.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/ToolbarItem.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/ToolbarItem.xml
@@ -45,7 +45,6 @@
       <Parameters />
       <Docs>
         <summary>Constructs and initializes a new instance of the <see cref="T:Microsoft.Maui.Controls.ToolbarItem" /> class.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -79,7 +78,6 @@
         <param name="order">The order for the toolbar item.</param>
         <param name="priority">The toolbar item priority.</param>
         <summary>Constructs and initializes a new instance of the <see cref="T:Microsoft.Maui.Controls.ToolbarItem" /> class.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Activated">
@@ -112,7 +110,6 @@
       </ReturnValue>
       <Docs>
         <summary>Obsolete. Developers should use the inherited <c>Clicked</c> event, instead.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Name">
@@ -146,7 +143,6 @@
       <Docs>
         <summary>Obsolete. Developers should use the inherited <c>Text</c> property, instead.</summary>
         <value>The name of the toolbar item.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Order">
@@ -171,8 +167,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets a value that indicates on which of the primary, secondary, or default toolbar surfaces to display this <see cref="T:Microsoft.Maui.Controls.ToolbarItem" /> element.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Priority">
@@ -197,8 +191,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the priority of this <see cref="T:Microsoft.Maui.Controls.ToolbarItem" /> element.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/ToolbarItemOrder.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/ToolbarItemOrder.xml
@@ -19,7 +19,6 @@
   </Base>
   <Docs>
     <summary>Enumeration specifying whether the <see cref="T:Microsoft.Maui.Controls.ToolbarItem" /> appears on the primary toolbar surface or secondary.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Default">

--- a/src/Controls/docs/Microsoft.Maui.Controls/Trigger.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/Trigger.xml
@@ -131,7 +131,6 @@
       <Docs>
         <param name="targetType">The view type to which the trigger will be added.</param>
         <summary>Initializes a new <see cref="T:Microsoft.Maui.Controls.Trigger" /> instance.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Property">
@@ -153,8 +152,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the property whose value will be compared to <see cref="P:Microsoft.Maui.Controls.Trigger.Value" /> to determine when to invoke the setters.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Setters">
@@ -176,8 +173,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets the list of <see cref="T:Microsoft.Maui.Controls.Setter" /> objects that will be applied when the property that is named by <see cref="P:Microsoft.Maui.Controls.Trigger.Property" /> becomes equal to <see cref="P:Microsoft.Maui.Controls.Trigger.Value" />.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Value">
@@ -199,8 +194,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the value of the property, named by the <see cref="P:Microsoft.Maui.Controls.Trigger.Property" /> property, that will cause the setters to be applied.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.Xaml.IValueProvider.ProvideValue">
@@ -229,8 +222,6 @@
       <Docs>
         <param name="serviceProvider">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/TriggerAction.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/TriggerAction.xml
@@ -39,8 +39,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets the type of the objects with which this <see cref="T:Microsoft.Maui.Controls.TriggerAction" /> can be associated.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Invoke">
@@ -66,7 +64,6 @@
       <Docs>
         <param name="sender">The object on which to invoke the action.</param>
         <summary>Application developers override this method to provide the behavior that is triggered.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/TriggerBase.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/TriggerBase.xml
@@ -43,7 +43,6 @@
         <summary>Gets the list of <see cref="T:Microsoft.Maui.Controls.TriggerAction" /> objects that will be invoked when the trigger condition is met. Ignored for the <see cref="T:Microsoft.Maui.Controls.EventTrigger" /> class.</summary>
         <value>
         </value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ExitActions">
@@ -67,7 +66,6 @@
         <summary>Gets the list of <see cref="T:Microsoft.Maui.Controls.TriggerAction" /> objects that will be invoked after the trigger condition is no longer met. Ignored for the <see cref="T:Microsoft.Maui.Controls.EventTrigger" /> class.</summary>
         <value>
         </value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsSealed">
@@ -89,7 +87,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets a value that indicates whether or not the trigger is sealed.</summary>
-        <value>To be added.</value>
         <remarks>A trigger becomes sealed when its `IAttachedObject.AttachTo(Microsoft.Maui.Controls.BindableObject)` method is called. Once it is sealed, its <see cref="P:Microsoft.Maui.Controls.TriggerBase.EnterActions" /> and <see cref="P:Microsoft.Maui.Controls.TriggerBase.ExitActions" /> lists become readonly.</remarks>
       </Docs>
     </Member>
@@ -112,8 +109,6 @@
       </ReturnValue>
       <Docs>
         <summary>The type of object to which this <see cref="T:Microsoft.Maui.Controls.TriggerBase" /> object can be attached.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/TypeConverterAttribute.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/TypeConverterAttribute.xml
@@ -25,7 +25,6 @@
   </Attributes>
   <Docs>
     <summary>Attribute that specifies the type of <see cref="T:System.ComponentModel.TypeConverter" /> used by its target.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -47,7 +46,6 @@
       <Parameters />
       <Docs>
         <summary>Creates a new <see cref="T:System.ComponentModel.TypeConverterAttribute" /> with default values.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -73,7 +71,6 @@
       <Docs>
         <param name="typeName">The name of the type that this attribute can decorate.</param>
         <summary>Creates a new <see cref="T:System.ComponentModel.TypeConverterAttribute" /> object that specifies that the class it decorates converts values to the <paramref name="typeName" /> type.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -99,7 +96,6 @@
       <Docs>
         <param name="type">The type that this attribute can decorate.</param>
         <summary>reates a new <see cref="T:System.ComponentModel.TypeConverterAttribute" /> object that specifies that the class it decorates converts values to <paramref name="type" />.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ConverterTypeName">
@@ -124,8 +120,6 @@
       </ReturnValue>
       <Docs>
         <summary>The name of the type to which the class decorated with this attribute can convert values.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Default">
@@ -150,7 +144,6 @@
       </ReturnValue>
       <Docs>
         <summary>A <see cref="T:System.ComponentModel.TypeConverterAttribute" /> that contains no information about the types to which the class that it decorates can convert values.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Equals">
@@ -179,8 +172,6 @@
       <Docs>
         <param name="obj">The object against which to do the comparison.</param>
         <summary>Returns true if <paramref name="obj" /> is a <see cref="T:System.ComponentModel.TypeConverterAttribute" /> and has the same <see cref="P:System.ComponentModel.TypeConverterAttribute.ConverterTypeName" /> value.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetHashCode">
@@ -206,8 +197,6 @@
       <Parameters />
       <Docs>
         <summary>Returns a value that is used for efficient storage and lookup of this <see cref="T:System.ComponentModel.TypeConverterAttribute" /> object.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/TypeTypeConverter.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/TypeTypeConverter.xml
@@ -24,7 +24,6 @@
   </Attributes>
   <Docs>
     <summary>Class that takes a string representation of a <see cref="T:System.Type" /> and returns a corresponding <see cref="T:System.Type" />.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -41,7 +40,6 @@
       <Parameters />
       <Docs>
         <summary>Creates a new <see cref="T:Microsoft.Maui.Controls.TypeTypeConverter" /> with default values.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ConvertFromInvariantString">
@@ -64,8 +62,6 @@
       <Docs>
         <param name="value">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>Returns a type for a valid type name.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IExtendedTypeConverter.ConvertFrom">
@@ -104,8 +100,6 @@
         <param name="value">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="serviceProvider">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use only.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IExtendedTypeConverter.ConvertFromInvariantString">
@@ -133,8 +127,6 @@
         <param name="value">For internal use by the Microsoft.Maui.Controls platform.</param>
         <param name="serviceProvider">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use only.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/UnsolvableConstraintsException.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/UnsolvableConstraintsException.xml
@@ -25,7 +25,6 @@
   </Attributes>
   <Docs>
     <summary>Exception indicating that the <see cref="T:Microsoft.Maui.Controls.Compatibility.Constraint" />s specified cannot be simultaneously satisfied.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -39,8 +38,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -66,7 +63,6 @@
       <Docs>
         <param name="message">A description for this exception.</param>
         <summary>Creates a new <see cref="T:Microsoft.Maui.Controls.UnsolvableConstraintsException" /> object with the <paramref name="message" /> explanatory message.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -86,8 +82,6 @@
       <Docs>
         <param name="info">To be added.</param>
         <param name="context">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -107,8 +101,6 @@
       <Docs>
         <param name="message">To be added.</param>
         <param name="innerException">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/UriImageSource.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/UriImageSource.xml
@@ -20,7 +20,6 @@
   <Interfaces />
   <Docs>
     <summary>An ImageSource that loads an image from a URI, caching the result.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -42,7 +41,6 @@
       <Parameters />
       <Docs>
         <summary>Creates a new <see cref="T:Microsoft.Maui.Controls.UriImageSource" /> object with default values.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CacheValidity">
@@ -67,8 +65,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets a <see cref="T:System.TimeSpan" /> structure that indicates the length of time after which the image cache becomes invalid.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CachingEnabled">
@@ -93,8 +89,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets a Boolean value that indicates whether caching is enabled on this <see cref="T:Microsoft.Maui.Controls.UriImageSource" /> object.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetStreamAsync">
@@ -122,8 +116,6 @@
       <Docs>
         <param name="userToken">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsEmpty">
@@ -140,9 +132,6 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ToString">
@@ -163,7 +152,6 @@
       <Docs>
         <summary>Returns the path to the file for the image, prefixed with the string, "Uri: ".</summary>
         <returns>The path to the file for the image, prefixed with the string, "Uri: ".</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Uri">
@@ -193,8 +181,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the URI for the image to get.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="UriProperty">
@@ -219,7 +205,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.UriImageSource.Uri" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/UriTypeConverter.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/UriTypeConverter.xml
@@ -25,7 +25,6 @@
   </Attributes>
   <Docs>
     <summary>A <see cref="T:System.ComponentModel.TypeConverter" /> that converts from a string or <see cref="T:System.Uri" /> to a <see cref="T:System.Uri" />.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -47,7 +46,6 @@
       <Parameters />
       <Docs>
         <summary>Creates a new <see cref="T:Microsoft.Maui.Controls.UriTypeConverter" /> with default values.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ConvertFromInvariantString">
@@ -70,8 +68,6 @@
       <Docs>
         <param name="value">The value to convert.</param>
         <summary>Returns a <see cref="T:System.Uri" /> object for a string representation of a URI.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/UrlWebViewSource.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/UrlWebViewSource.xml
@@ -20,7 +20,6 @@
   <Interfaces />
   <Docs>
     <summary>A WebViewSource bound to a URL.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -42,7 +41,6 @@
       <Parameters />
       <Docs>
         <summary>Creates a new <see cref="T:Microsoft.Maui.Controls.UrlWebViewSource" /> object with default values.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Load">
@@ -70,7 +68,6 @@
       <Docs>
         <param name="renderer">To be added.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Url">
@@ -95,8 +92,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the URL for this <see cref="T:Microsoft.Maui.Controls.UrlWebViewSource" /> object.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="UrlProperty">
@@ -121,7 +116,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.UrlWebViewSource.Url" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/ValueChangedEventArgs.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/ValueChangedEventArgs.xml
@@ -20,7 +20,6 @@
   <Interfaces />
   <Docs>
     <summary>Event arguments for <c>ValueChanged</c> events. Provides both old and new values.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -48,7 +47,6 @@
         <param name="oldValue">The old value.</param>
         <param name="newValue">The new value.</param>
         <summary>Creates a new <see cref="T:Microsoft.Maui.Controls.ValueChangedEventArgs" /> event with <paramref name="oldValue" /> and <paramref name="newValue" />.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="NewValue">
@@ -73,8 +71,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets the new value.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OldValue">
@@ -99,8 +95,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets the old value.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/ViewCell.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/ViewCell.xml
@@ -48,7 +48,6 @@
       <Parameters />
       <Docs>
         <summary>Initializes a new instance of the ViewCell class.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="View">
@@ -75,7 +74,6 @@
         <summary>Gets or sets the View representing the content of the ViewCell.</summary>
         <value>
         </value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/ViewExtensions.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/ViewExtensions.xml
@@ -20,7 +20,6 @@
   <Interfaces />
   <Docs>
     <summary>Extension methods for <see cref="T:Microsoft.Maui.Controls.View" />s, providing animatable scaling, rotation, and layout functions.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="CancelAnimations">
@@ -49,7 +48,6 @@
       <Docs>
         <param name="view">The view on which this method operates.</param>
         <summary>Aborts the TranslateTo, LayoutTo, RotateTo, ScaleTo, and FadeTo animations on <paramref name="view" /> element.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FadeTo">
@@ -84,8 +82,6 @@
         <param name="length">The time, in milliseconds, over which to animate the transition. The default is 250.</param>
         <param name="easing">The easing function to use for the animation.</param>
         <summary>Returns a task that performs the fade that is described by the <paramref name="opacity" />, <paramref name="length" />, and <paramref name="easing" /> parameters.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="LayoutTo">
@@ -120,8 +116,6 @@
         <param name="length">The time, in milliseconds, over which to animate the transition. The default is 250.</param>
         <param name="easing">The easing function to use for the animation.</param>
         <summary>Returns a task that eases the bounds of the <see cref="T:Microsoft.Maui.Controls.VisualElement" /> that is specified by the <paramref name="view" /> to the rectangle that is specified by the <paramref name="bounds" /> parameter.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RelRotateTo">
@@ -156,8 +150,6 @@
         <param name="length">The time, in milliseconds, over which to animate the transition. The default is 250.</param>
         <param name="easing">The easing function to use for the animation.</param>
         <summary>Rotates the <see cref="T:Microsoft.Maui.Controls.VisualElement" /> that is specified by <paramref name="view" /> from its current rotation by <paramref name="drotation" />.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RelScaleTo">
@@ -192,8 +184,6 @@
         <param name="length">The time, in milliseconds, over which to animate the transition. The default is 250.</param>
         <param name="easing">The easing function to use for the animation.</param>
         <summary>Returns a task that scales the <see cref="T:Microsoft.Maui.Controls.VisualElement" /> that is specified by <paramref name="view" /> from its current scale to <paramref name="dscale" />.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RotateTo">
@@ -228,8 +218,6 @@
         <param name="length">The time, in milliseconds, over which to animate the transition. The default is 250.</param>
         <param name="easing">The easing function to use for the animation.</param>
         <summary>Returns a task that performs the rotation that is described by the <paramref name="rotation" />, <paramref name="length" />, and <paramref name="easing" /> parameters.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RotateXTo">
@@ -264,8 +252,6 @@
         <param name="length">The time, in milliseconds, over which to animate the transition. The default is 250.</param>
         <param name="easing">The easing function to use for the animation.</param>
         <summary>Returns a task that skews the X axis by <paramref name="rotation" />, taking time <paramref name="length" /> and using <paramref name="easing" />.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RotateYTo">
@@ -300,8 +286,6 @@
         <param name="length">The time, in milliseconds, over which to animate the transition. The default is 250.</param>
         <param name="easing">The easing function to use for the animation.</param>
         <summary>Returns a task that skews the Y axis by <paramref name="rotation" />, taking time <paramref name="length" /> and using <paramref name="easing" />.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ScaleTo">
@@ -336,8 +320,6 @@
         <param name="length">The time, in milliseconds, over which to animate the transition. The default is 250.</param>
         <param name="easing">The easing function to use for the animation.</param>
         <summary>Returns a task that scales the <see cref="T:Microsoft.Maui.Controls.VisualElement" /> that is specified by <paramref name="view" /> to the absolute scale factor <paramref name="scale" />.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ScaleXTo">
@@ -364,9 +346,6 @@
         <param name="scale">To be added.</param>
         <param name="length">To be added.</param>
         <param name="easing">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ScaleYTo">
@@ -393,9 +372,6 @@
         <param name="scale">To be added.</param>
         <param name="length">To be added.</param>
         <param name="easing">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TranslateTo">
@@ -431,7 +407,6 @@
         <param name="length">The duration of the animation in milliseconds.</param>
         <param name="easing">The easing of the animation.</param>
         <summary>Animates an elements TranslationX and TranslationY properties from their current values to the new values. This ensures that the input layout is in the same position as the visual layout.</summary>
-        <returns>To be added.</returns>
         <remarks>
           <para>To animate a view that receives user touch input from outside of the screen, the developer must first lay out the view in its final position, then translate the view off screen, and then finally animate the view back to its final position on the screen.</para>
           <para>TranslateTo is useful for animations because it is applied post-layout. Translation animations will not conflict with managed layouts and thus are ideal for doing slide in/out style animations.</para>

--- a/src/Controls/docs/Microsoft.Maui.Controls/ViewState.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/ViewState.xml
@@ -24,7 +24,6 @@
   </Attributes>
   <Docs>
     <summary>Deprecated. Do not use.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Default">

--- a/src/Controls/docs/Microsoft.Maui.Controls/VisualAttribute.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/VisualAttribute.xml
@@ -17,8 +17,6 @@
     </Attribute>
   </Attributes>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -38,8 +36,6 @@
       <Docs>
         <param name="key">To be added.</param>
         <param name="visual">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/VisualElement.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/VisualElement.xml
@@ -49,8 +49,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="AnchorX">
@@ -76,7 +74,6 @@
       <Docs>
         <summary>Gets or sets the X component of the center point for any transform, relative to the bounds of the element. This is a bindable property.</summary>
         <value>The value that declares the X component of the transform. The default value is 0.5.</value>
-        <remarks>To be added.</remarks>
         <altmember cref="P:Microsoft.Maui.Controls.VisualElement.AnchorY" />
       </Docs>
     </Member>
@@ -102,7 +99,6 @@
       </ReturnValue>
       <Docs>
         <summary>Identifies the AnchorX bindable property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="AnchorY">
@@ -128,7 +124,6 @@
       <Docs>
         <summary>Gets or sets the Y component of the center point for any transform, relative to the bounds of the element. This is a bindable property.</summary>
         <value>The value that declares the Y component of the transform. The default value is 0.5.</value>
-        <remarks>To be added.</remarks>
         <altmember cref="P:Microsoft.Maui.Controls.VisualElement.AnchorX" />
       </Docs>
     </Member>
@@ -154,7 +149,6 @@
       </ReturnValue>
       <Docs>
         <summary>Identifies the AnchorY bindable property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Background">
@@ -176,9 +170,6 @@
         <ReturnType>Microsoft.Maui.Controls.Brush</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="BackgroundColor">
@@ -204,7 +195,6 @@
       <Docs>
         <summary>Gets or sets the color which will fill the background of a VisualElement. This is a bindable property.</summary>
         <value>The color that is used to fill the background of a VisualElement.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="BackgroundColorProperty">
@@ -229,7 +219,6 @@
       </ReturnValue>
       <Docs>
         <summary>Identifies the BackgroundColor bindable property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="BackgroundProperty">
@@ -246,8 +235,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="BatchBegin">
@@ -332,7 +319,6 @@
       </ReturnValue>
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Batched">
@@ -359,8 +345,6 @@
       </ReturnValue>
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Behaviors">
@@ -384,7 +368,6 @@
         <summary>Gets the list of Behaviors associated to this element. This is a bindable property.</summary>
         <value>
         </value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="BehaviorsProperty">
@@ -406,7 +389,6 @@
       </ReturnValue>
       <Docs>
         <summary>Identifies the Behaviors bindable property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Bounds">
@@ -454,7 +436,6 @@
       <Parameters />
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ChildrenReordered">
@@ -479,7 +460,6 @@
       </ReturnValue>
       <Docs>
         <summary>Occurs when the Children of a VisualElement have been re-ordered.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Clip">
@@ -501,9 +481,6 @@
         <ReturnType>Microsoft.Maui.Controls.Shapes.Geometry</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ClipProperty">
@@ -520,8 +497,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="DisableLayout">
@@ -548,8 +523,6 @@
       </ReturnValue>
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FlowDirection">
@@ -569,7 +542,6 @@
       <Docs>
         <summary>Gets or sets the layout flow direction.</summary>
         <value>The layout flow direction.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FlowDirectionProperty">
@@ -588,7 +560,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.VisualElement.FlowDirection" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Focus">
@@ -643,7 +614,6 @@
       </ReturnValue>
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Focused">
@@ -720,7 +690,6 @@
       </ReturnValue>
       <Docs>
         <summary>Identifies the Height bindable property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="HeightRequest">
@@ -769,7 +738,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the HeightRequest property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="InputTransparent">
@@ -822,7 +790,6 @@
       </ReturnValue>
       <Docs>
         <summary>Identifies the InputTransparent bindable property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="InvalidateMeasure">
@@ -848,7 +815,6 @@
       <Parameters />
       <Docs>
         <summary>Method that is called to invalidate the layout of this <see cref="T:Microsoft.Maui.Controls.VisualElement" />. Raises the <see cref="E:Microsoft.Maui.Controls.VisualElement.MeasureInvalidated" /> event.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="InvalidateMeasureNonVirtual">
@@ -876,7 +842,6 @@
       <Docs>
         <param name="trigger">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsEnabled">
@@ -947,7 +912,6 @@
       </ReturnValue>
       <Docs>
         <summary>Identifies the IsEnabled bindable property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsFocused">
@@ -1014,7 +978,6 @@
       </ReturnValue>
       <Docs>
         <summary>Identifies the IsFocused bindable property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsFocusedPropertyKey">
@@ -1038,7 +1001,6 @@
       </ReturnValue>
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsInNativeLayout">
@@ -1065,8 +1027,6 @@
       </ReturnValue>
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsNativeStateConsistent">
@@ -1093,8 +1053,6 @@
       </ReturnValue>
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsPlatformEnabled">
@@ -1121,8 +1079,6 @@
       </ReturnValue>
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsTabStop">
@@ -1163,7 +1119,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.VisualElement.IsTabStop" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsVisible">
@@ -1254,7 +1209,6 @@
       </ReturnValue>
       <Docs>
         <summary>Identifies the IsVisible bindable property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Layout">
@@ -1338,7 +1292,6 @@
       </ReturnValue>
       <Docs>
         <summary>Event that is raised when the layout of a visual element is invalidated.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="MinimumHeightRequest">
@@ -1410,7 +1363,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the MinimumHeightRequest property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="MinimumWidthRequest">
@@ -1483,7 +1435,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the MinimumWidthRequest property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="NativeSizeChanged">
@@ -1511,7 +1462,6 @@
       <Parameters />
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="NavigationProperty">
@@ -1528,8 +1478,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnBindingContextChanged">
@@ -1547,8 +1495,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnChildAdded">
@@ -1624,8 +1570,6 @@
       <Docs>
         <param name="child">To be added.</param>
         <param name="oldLogicalIndex">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnChildrenReordered">
@@ -1676,8 +1620,6 @@
         <param name="widthConstraint">The width constraint to request.</param>
         <param name="heightConstraint">The height constraint to request.</param>
         <summary>Method that is called when a layout measurement happens.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnSizeAllocated">
@@ -1771,8 +1713,6 @@
       <Docs>
         <param name="oldValue">To be added.</param>
         <param name="newValue">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnTabStopPropertyChanged">
@@ -1795,8 +1735,6 @@
       <Docs>
         <param name="oldValue">To be added.</param>
         <param name="newValue">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Opacity">
@@ -1870,7 +1808,6 @@
       </ReturnValue>
       <Docs>
         <summary>Identifies the Opacity bindable property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Resources">
@@ -1974,7 +1911,6 @@
       </ReturnValue>
       <Docs>
         <summary>Identifies the Rotation bindable property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RotationX">
@@ -2025,7 +1961,6 @@
       </ReturnValue>
       <Docs>
         <summary>Identifies the RotationX bindable property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RotationY">
@@ -2076,7 +2011,6 @@
       </ReturnValue>
       <Docs>
         <summary>Identifies the RotationY bindable property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Scale">
@@ -2127,7 +2061,6 @@
       </ReturnValue>
       <Docs>
         <summary>Identifies the Scale bindable property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ScaleX">
@@ -2147,7 +2080,6 @@
       <Docs>
         <summary>Gets or sets a scale value to apply to the X direction.</summary>
         <value>The scale value to apply to the X direction.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ScaleXProperty">
@@ -2166,7 +2098,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.VisualElement.ScaleX" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ScaleY">
@@ -2186,7 +2117,6 @@
       <Docs>
         <summary>Gets or sets a scale value to apply to the Y direction.</summary>
         <value>The scale value to apply to the Y direction.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ScaleYProperty">
@@ -2205,7 +2135,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.VisualElement.ScaleY" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SizeAllocated">
@@ -2278,8 +2207,6 @@
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TabIndex">
@@ -2299,9 +2226,6 @@
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TabIndexDefaultValueCreator">
@@ -2319,9 +2243,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TabIndexProperty">
@@ -2339,7 +2260,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.VisualElement.TabIndex" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TabStopDefaultValueCreator">
@@ -2357,9 +2277,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TranslationX">
@@ -2406,7 +2323,6 @@
       </ReturnValue>
       <Docs>
         <summary>Identifies the TranslationX bindable property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TranslationY">
@@ -2453,7 +2369,6 @@
       </ReturnValue>
       <Docs>
         <summary>Identifies the TranslationY bindable property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Triggers">
@@ -2477,7 +2392,6 @@
         <summary>Gets the list of Trigger associated to this element. This is a bindable property.</summary>
         <value>
         </value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TriggersProperty">
@@ -2499,7 +2413,6 @@
       </ReturnValue>
       <Docs>
         <summary>Identifies the Triggers bindable property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Unfocus">
@@ -2567,9 +2480,6 @@
         <ReturnType>Microsoft.Maui.Controls.IVisual</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="VisualProperty">
@@ -2587,7 +2497,6 @@
       </ReturnValue>
       <Docs>
         <summary>The backing store for the <see cref="P:Microsoft.Maui.Controls.VisualElement.Visual" /> field.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Width">
@@ -2638,7 +2547,6 @@
       </ReturnValue>
       <Docs>
         <summary>Identifies the Width bindable property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="WidthRequest">
@@ -2687,7 +2595,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the WidthRequest property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="X">
@@ -2736,7 +2643,6 @@
       <Docs>
         <summary>Gets the effective visual flow direction for the element on the platform, taking into account the locale and logical flow settings.</summary>
         <value>The effective flow direction for the visual element.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IVisualElementController.InvalidateMeasure">
@@ -2762,7 +2668,6 @@
       <Docs>
         <param name="trigger">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>This method is for internal use.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="XProperty">
@@ -2787,7 +2692,6 @@
       </ReturnValue>
       <Docs>
         <summary>Identifies the X bindable property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Y">
@@ -2838,7 +2742,6 @@
       </ReturnValue>
       <Docs>
         <summary>Identifies the Y bindable property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/VisualMarker.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/VisualMarker.xml
@@ -13,7 +13,6 @@
   <Interfaces />
   <Docs>
     <summary>Contains the <see cref="T:Microsoft.Maui.Controls.IVisual" /> types implemented by the Xamarin Forms team and the default <see cref="T:Microsoft.Maui.Controls.IVisual" /> types used by the Visual system.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Default">
@@ -31,8 +30,6 @@
       </ReturnValue>
       <Docs>
         <summary>Indicates for a <see cref="T:Microsoft.Maui.Controls.View" /> render using the default renderer.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="MatchParent">
@@ -55,8 +52,6 @@
       </ReturnValue>
       <Docs>
         <summary>Indicates for a <see cref="T:Microsoft.Maui.Controls.View" /> to use the same <see cref="T:Microsoft.Maui.Controls.IVisual" /> as its direct parent.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Material">
@@ -74,7 +69,6 @@
       </ReturnValue>
       <Docs>
         <summary>Indicates for a <see cref="T:Microsoft.Maui.Controls.View" /> to render using a material renderer.</summary>
-        <value>To be added.</value>
         <remarks>In order to use the Material visuals you must install <format type="text/html"><a href="https://www.nuget.org/packages/Microsoft.Maui.Controls.Visual.Material">Microsoft.Maui.Controls.Visual.Material</a></format>.</remarks>
       </Docs>
     </Member>

--- a/src/Controls/docs/Microsoft.Maui.Controls/VisualState.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/VisualState.xml
@@ -32,7 +32,6 @@
       <Parameters />
       <Docs>
         <summary>Creates a new <see cref="T:Microsoft.Maui.Controls.VisualState" /> object with default values.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Name">
@@ -52,7 +51,6 @@
       <Docs>
         <summary>Gets or sets the developer-specified name of this visual state.</summary>
         <value>The developer-specified name of this visual state.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Setters">
@@ -72,7 +70,6 @@
       <Docs>
         <summary>Gets the list of property setters that establish the visual representation of the element when it is in the state that is named by <see langword="this" /> visual state object.</summary>
         <value>The list of property setters that establish the visual representation of the element when it is in the state that is named by <see langword="this" /> visual state object.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="StateTriggers">
@@ -89,9 +86,6 @@
         <ReturnType>System.Collections.Generic.IList&lt;Microsoft.Maui.Controls.StateTriggerBase&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TargetType">
@@ -111,7 +105,6 @@
       <Docs>
         <summary>Gets or sets the type of element that <see langword="this" /> visual state object can target.</summary>
         <value>The type of element that <see langword="this" /> visual state object can target.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/VisualStateGroup.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/VisualStateGroup.xml
@@ -19,7 +19,6 @@
   </Attributes>
   <Docs>
     <summary>Contains a list of related visual states that can be applied to a visual element.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -35,7 +34,6 @@
       <Parameters />
       <Docs>
         <summary>Creates a new <see cref="T:Microsoft.Maui.Controls.VisualStateGroup" /> object with default values.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CurrentState">
@@ -55,7 +53,6 @@
       <Docs>
         <summary>Gets the current visual state.</summary>
         <value>The current visual state.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Name">
@@ -75,7 +72,6 @@
       <Docs>
         <summary>Gets or sets the name of the visual state.</summary>
         <value>The name of the visual state.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="States">
@@ -95,7 +91,6 @@
       <Docs>
         <summary>Gets the list of states that comprise the group.</summary>
         <value>The list of states that comprise the group.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TargetType">
@@ -115,7 +110,6 @@
       <Docs>
         <summary>Gets or sets the type of element that <see langword="this" /> visual state group can target.</summary>
         <value>The type of element that <see langword="this" /> visual state group can target.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/VisualStateGroupList.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/VisualStateGroupList.xml
@@ -33,7 +33,6 @@
   </Interfaces>
   <Docs>
     <summary>Contains a list of visual state groups for an application.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -49,7 +48,6 @@
       <Parameters />
       <Docs>
         <summary>Creates a new <see cref="T:Microsoft.Maui.Controls.VisualStateGroupList" /> object with default values.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -67,8 +65,6 @@
       </Parameters>
       <Docs>
         <param name="isDefault">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Add">
@@ -94,7 +90,6 @@
       <Docs>
         <param name="item">The visual state group to add to the list.</param>
         <summary>Adds the specified visual state group to the list.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Clear">
@@ -117,7 +112,6 @@
       <Parameters />
       <Docs>
         <summary>Removes all visual state groups from the list.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Contains">
@@ -145,7 +139,6 @@
         <summary>Checks whether <paramref name="item" /> is in the list of visual state groups.</summary>
         <returns>
           <see langword="true" /> if <paramref name="item" /> is in the list of groups. Otherwise, <see langword="false" />.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CopyTo">
@@ -173,7 +166,6 @@
         <param name="array">To be added.</param>
         <param name="arrayIndex">To be added.</param>
         <summary>Copies the list group to the specified <paramref name="array" />, starting at <paramref name="arrayIndex" />.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Count">
@@ -196,7 +188,6 @@
       <Docs>
         <summary>Gets the number of visual state groups in the list.</summary>
         <value>The number of visual state groups in the list.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetEnumerator">
@@ -220,7 +211,6 @@
       <Docs>
         <summary>Returns an enumerator for iterating over the groups in the list.</summary>
         <returns>An enumerator for iterating over the groups in the list.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IndexOf">
@@ -247,7 +237,6 @@
         <param name="item">The group whose index to get.</param>
         <summary>Returns the index of <paramref name="item" /> if found. Otherwise, returns <c>-1</c>.</summary>
         <returns>The index of <paramref name="item" /> if found. Otherwise, <c>-1</c>.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Insert">
@@ -302,7 +291,6 @@
         <summary>Gets a Boolean value that tells whether this list is read-only.</summary>
         <value>
           <see langword="true" /> if the list is read-only. Otherwise, <see langword="false" />.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Item">
@@ -329,7 +317,6 @@
         <param name="index">The index of the item to get or set.</param>
         <summary>Gets or sets the item at the specified <paramref name="index" />.</summary>
         <value>The item at the specified <paramref name="index" />.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Remove">
@@ -356,7 +343,6 @@
         <param name="item">The item to remove.</param>
         <summary>Removes the group from the list of groups.</summary>
         <returns>The removed group.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RemoveAt">
@@ -382,7 +368,6 @@
       <Docs>
         <param name="index">The index of the item to remove.</param>
         <summary>Removes the item at the specified <paramref name="index" />.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="System.Collections.IEnumerable.GetEnumerator">
@@ -406,7 +391,6 @@
       <Docs>
         <summary>Gets an enumerator that iterates over the groups in this list.</summary>
         <returns>An enumerator that iterates over the groups in this list.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/VisualStateManager.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/VisualStateManager.xml
@@ -14,7 +14,6 @@
   <Interfaces />
   <Docs>
     <summary>Manages visual state groups and transitions controls between states.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="GetVisualStateGroups">
@@ -38,7 +37,6 @@
         <param name="visualElement">The visual element whose visual state groups to get.</param>
         <summary>Returns the visual state groups that can be applied to the specified visual element.</summary>
         <returns>The visual state groups that can be applied to the specified visual element.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GoToState">
@@ -65,7 +63,6 @@
         <summary>Transitions the specified <paramref name="visualElement" /> to the state with the specified <paramref name="name" />.</summary>
         <returns>
           <see langword="true" /> if the transition was successful. Otherwise, <see langword="false" /></returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="HasVisualStateGroups">
@@ -90,7 +87,6 @@
         <summary>Returns <see langword="true" /> if <paramref name="element" /> has one or more visual state groups associated with it. Otherwise, returns <see langword="false" />.</summary>
         <returns>
           <see langword="true" /> if <paramref name="element" /> has one or more visual state groups associated with it. Otherwise, <see langword="false" />.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetVisualStateGroups">
@@ -115,7 +111,6 @@
         <param name="visualElement">To be added.</param>
         <param name="value">The list of visual state groups to associate with <paramref name="visualElement" />.</param>
         <summary>Associates a list of visual state groups with a visual element.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="VisualStateGroupsProperty">
@@ -134,7 +129,6 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the attached property that contains the visual state groups in the manager.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/VisualTypeConverter.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/VisualTypeConverter.xml
@@ -18,7 +18,6 @@
   </Attributes>
   <Docs>
     <summary>A <see cref="T:System.ComponentModel.TypeConverter" /> that can convert a string into a <see cref="T:Microsoft.Maui.Controls.IVisual" /> object.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -32,8 +31,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ConvertFromInvariantString">
@@ -54,9 +51,6 @@
       </Parameters>
       <Docs>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/WebNavigatedEventArgs.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/WebNavigatedEventArgs.xml
@@ -17,7 +17,6 @@
   <Interfaces />
   <Docs>
     <summary>Class that contains arguments for the event that is raised after web navigation completes.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -46,7 +45,6 @@
         <param name="url">The URL of the navigation event.</param>
         <param name="result">The result of the navigation that originated the event.</param>
         <summary>Initializes a new <see cref="T:Microsoft.Maui.Controls.WebNavigatedEventArgs" /> instance.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Result">
@@ -68,8 +66,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets a value that describes the result of the navigation.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/WebNavigatingEventArgs.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/WebNavigatingEventArgs.xml
@@ -17,7 +17,6 @@
   <Interfaces />
   <Docs>
     <summary>Class that contains arguments for the event that is raised after web navigation begins.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -44,7 +43,6 @@
         <param name="source">The web view source that originated the event.</param>
         <param name="url">The URL of the navigation event.</param>
         <summary>Initializes a new <see cref="T:Microsoft.Maui.Controls.WebNavigatingEventArgs" /> instance.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Cancel">
@@ -66,8 +64,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets a value that indicates whether or not to cancel the navigation.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/WebNavigationEvent.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/WebNavigationEvent.xml
@@ -16,7 +16,6 @@
   </Base>
   <Docs>
     <summary>Contains values that indicate why a navigation event was raised.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Back">

--- a/src/Controls/docs/Microsoft.Maui.Controls/WebNavigationEventArgs.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/WebNavigationEventArgs.xml
@@ -17,7 +17,6 @@
   <Interfaces />
   <Docs>
     <summary>TClass that contains arguments for the event that is when web navigation begins.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -44,7 +43,6 @@
         <param name="source">The web view source that originated the event.</param>
         <param name="url">The URL of the navigation event.</param>
         <summary>Initializes a new <see cref="T:Microsoft.Maui.Controls.WebNavigationEventArgs" /> instance.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="NavigationEvent">
@@ -66,8 +64,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets the navigation event that was raised.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Source">
@@ -89,8 +85,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets the element that performed the navigation.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Url">
@@ -112,8 +106,6 @@
       </ReturnValue>
       <Docs>
         <summary>The destination of the navigation.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/WebNavigationResult.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/WebNavigationResult.xml
@@ -16,7 +16,6 @@
   </Base>
   <Docs>
     <summary>Enumerates values that indicate the outcome of a web navigation.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Cancel">

--- a/src/Controls/docs/Microsoft.Maui.Controls/WebView.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/WebView.xml
@@ -110,7 +110,6 @@ namespace FormsGallery
       <Parameters />
       <Docs>
         <summary>Creates a new <see cref="T:Microsoft.Maui.Controls.WebView" /> element with default values.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CanGoBack">
@@ -132,8 +131,6 @@ namespace FormsGallery
       </ReturnValue>
       <Docs>
         <summary>Gets a value that indicates whether the user can navigate to previous pages.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CanGoBackProperty">
@@ -155,7 +152,6 @@ namespace FormsGallery
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.WebView.CanGoBack" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CanGoForward">
@@ -177,8 +173,6 @@ namespace FormsGallery
       </ReturnValue>
       <Docs>
         <summary>Gets a value that indicates whether the user can navigate forward.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CanGoForwardProperty">
@@ -200,7 +194,6 @@ namespace FormsGallery
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.WebView.CanGoForward" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Cookies">
@@ -218,8 +211,6 @@ namespace FormsGallery
       </ReturnValue>
       <Docs>
         <summary>When set this will act as a sync for cookies.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CookiesProperty">
@@ -236,8 +227,6 @@ namespace FormsGallery
         <ReturnType>Microsoft.Maui.Controls.BindableProperty</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Eval">
@@ -263,7 +252,6 @@ namespace FormsGallery
       <Docs>
         <param name="script">A script to evaluate.</param>
         <summary>Evaluates the script that is specified by <paramref name="script" />.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="EvalRequested">
@@ -290,7 +278,6 @@ namespace FormsGallery
       </ReturnValue>
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="EvaluateJavaScriptAsync">
@@ -341,7 +328,6 @@ namespace FormsGallery
       </ReturnValue>
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GoBack">
@@ -364,7 +350,6 @@ namespace FormsGallery
       <Parameters />
       <Docs>
         <summary>Navigates to the previous page.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GoBackRequested">
@@ -391,7 +376,6 @@ namespace FormsGallery
       </ReturnValue>
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GoForward">
@@ -414,7 +398,6 @@ namespace FormsGallery
       <Parameters />
       <Docs>
         <summary>Navigates to the next page in the list of visited pages.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GoForwardRequested">
@@ -441,7 +424,6 @@ namespace FormsGallery
       </ReturnValue>
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Navigated">
@@ -463,7 +445,6 @@ namespace FormsGallery
       </ReturnValue>
       <Docs>
         <summary>Event that is raised after navigation completes.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Navigating">
@@ -485,7 +466,6 @@ namespace FormsGallery
       </ReturnValue>
       <Docs>
         <summary>Event that is raised when navigation starts.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="On&lt;T&gt;">
@@ -516,8 +496,6 @@ namespace FormsGallery
       <Docs>
         <typeparam name="T">To be added.</typeparam>
         <summary>Returns the platform-specific instance of this <see cref="T:Microsoft.Maui.Controls.WebView" />, on which a platform-specific method may be called.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnBindingContextChanged">
@@ -537,7 +515,6 @@ namespace FormsGallery
       <Parameters />
       <Docs>
         <summary>Method that is called when the binding context is changed.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnPropertyChanged">
@@ -566,7 +543,6 @@ namespace FormsGallery
       <Docs>
         <param name="propertyName">The name of the property that was changed.</param>
         <summary>Method that is called when <see cref="P:Microsoft.Maui.Controls.WebView.Source" /> is changed.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnSourceChanged">
@@ -597,7 +573,6 @@ namespace FormsGallery
         <param name="sender">The object that raised the event.</param>
         <param name="e">The event arguments.</param>
         <summary>Method that is called when the view source that is specified by the <paramref name="sender" /> parameter is changed.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Reload">
@@ -615,8 +590,6 @@ namespace FormsGallery
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ReloadRequested">
@@ -641,8 +614,6 @@ namespace FormsGallery
         <ReturnType>System.EventHandler</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SendNavigated">
@@ -673,7 +644,6 @@ namespace FormsGallery
       <Docs>
         <param name="args">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SendNavigating">
@@ -704,7 +674,6 @@ namespace FormsGallery
       <Docs>
         <param name="args">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Source">
@@ -734,8 +703,6 @@ namespace FormsGallery
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the <see cref="T:Microsoft.Maui.Controls.WebViewSource" /> object that represents the location that this <see cref="T:Microsoft.Maui.Controls.WebView" /> object displays.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SourceProperty">
@@ -760,7 +727,6 @@ namespace FormsGallery
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.WebView.Source" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="UserAgent">
@@ -778,7 +744,6 @@ namespace FormsGallery
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the user agent string that this <see cref="T:Microsoft.Maui.Controls.WebView" /> object uses.</summary>
-        <value>To be added.</value>
         <remarks>
           The default value is the default User Agent of the underlying platform browser, or <see langword="null" /> if it cannot be determined.
           If the parameter is <see langword="null" /> the User Agent will not be updated and the current User Agent will remain.
@@ -800,7 +765,6 @@ namespace FormsGallery
       </ReturnValue>
       <Docs>
         <summary>Backing store for the <see cref="P:Microsoft.Maui.Controls.WebView.UserAgent" /> property.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IWebViewController.CanGoBack">
@@ -827,8 +791,6 @@ namespace FormsGallery
       </ReturnValue>
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IWebViewController.CanGoForward">
@@ -855,8 +817,6 @@ namespace FormsGallery
       </ReturnValue>
       <Docs>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IWebViewController.EvalRequested">
@@ -876,8 +836,6 @@ namespace FormsGallery
         <ReturnType>System.EventHandler&lt;Microsoft.Maui.Controls.Internals.EvalRequested&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/WebViewSource.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/WebViewSource.xml
@@ -20,7 +20,6 @@
   <Interfaces />
   <Docs>
     <summary>Abstract class whose subclasses provide the data for a <see cref="T:Microsoft.Maui.Controls.WebView" />.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -42,7 +41,6 @@
       <Parameters />
       <Docs>
         <summary>Creates a new <see cref="T:Microsoft.Maui.Controls.WebViewSource" /> object with default values.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Load">
@@ -70,7 +68,6 @@
       <Docs>
         <param name="renderer">For internal use by the Microsoft.Maui.Controls platform.</param>
         <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OnSourceChanged">
@@ -96,7 +93,6 @@
       <Parameters />
       <Docs>
         <summary>Method that is called when the source is changed.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="op_Implicit">
@@ -125,8 +121,6 @@
       <Docs>
         <param name="url">The URL to convert.</param>
         <summary>Casts a string that contains a URL to a <see cref="T:Microsoft.Maui.Controls.WebViewSource" /> instance.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="op_Implicit">
@@ -155,8 +149,6 @@
       <Docs>
         <param name="url">The URL to convert.</param>
         <summary>Casts a <see cref="T:System.Uri" /> object to a <see cref="T:Microsoft.Maui.Controls.WebViewSource" /> instance.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/WebViewSourceTypeConverter.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/WebViewSourceTypeConverter.xml
@@ -25,7 +25,6 @@
   </Attributes>
   <Docs>
     <summary>A <see cref="T:System.ComponentModel.TypeConverter" /> that converts a string to a <see cref="T:Microsoft.Maui.Controls.UrlWebViewSource" />.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -47,7 +46,6 @@
       <Parameters />
       <Docs>
         <summary>Creates a new <see cref="T:Microsoft.Maui.Controls.WebViewSourceTypeConverter" /> with default values.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ConvertFromInvariantString">
@@ -70,8 +68,6 @@
       <Docs>
         <param name="value">The value to convert.</param>
         <summary>Returns a web view source for the URL that is contained in <paramref name="value" />.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/XmlnsDefinitionAttribute.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/XmlnsDefinitionAttribute.xml
@@ -21,7 +21,6 @@
   </Attributes>
   <Docs>
     <summary>Attribute specifying the mapping between an XML namespace and a CLR namespace.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -41,8 +40,6 @@
       <Docs>
         <param name="xmlNamespace">To be added.</param>
         <param name="clrNamespace">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="AssemblyName">
@@ -59,9 +56,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ClrNamespace">
@@ -78,9 +72,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="XmlNamespace">
@@ -97,9 +88,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Controls/docs/Microsoft.Maui.Controls/XmlnsPrefixAttribute.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/XmlnsPrefixAttribute.xml
@@ -17,8 +17,6 @@
     </Attribute>
   </Attributes>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -38,8 +36,6 @@
       <Docs>
         <param name="xmlNamespace">To be added.</param>
         <param name="prefix">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Prefix">
@@ -56,9 +52,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="XmlNamespace">
@@ -75,9 +68,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Core/docs/Microsoft.Maui/Aspect.xml
+++ b/src/Core/docs/Microsoft.Maui/Aspect.xml
@@ -19,7 +19,6 @@
   </Base>
   <Docs>
     <summary>Defines how an image is displayed.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="AspectFill">
@@ -45,7 +44,6 @@
       <MemberValue>1</MemberValue>
       <Docs>
         <summary>Scale the image to fill the view. Some parts may be clipped in order to fill the view.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="AspectFit">
@@ -96,7 +94,6 @@
       <MemberValue>2</MemberValue>
       <Docs>
         <summary>Scale the image so it exactly fills the view. Scaling may not be uniform in X and Y.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Core/docs/Microsoft.Maui/ClearButtonVisibility.xml
+++ b/src/Core/docs/Microsoft.Maui/ClearButtonVisibility.xml
@@ -11,8 +11,6 @@
     <BaseTypeName>System.Enum</BaseTypeName>
   </Base>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Never">
@@ -30,7 +28,6 @@
       </ReturnValue>
       <MemberValue>0</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
     <Member MemberName="WhileEditing">
@@ -48,7 +45,6 @@
       </ReturnValue>
       <MemberValue>1</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
   </Members>

--- a/src/Core/docs/Microsoft.Maui/CornerRadius.xml
+++ b/src/Core/docs/Microsoft.Maui/CornerRadius.xml
@@ -22,7 +22,6 @@
   </Attributes>
   <Docs>
     <summary>Contains methods and properties for specifying corner radiuses.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -42,7 +41,6 @@
       <Docs>
         <param name="uniformRadius">The radius for all four corners.</param>
         <summary>Creates a new <see cref="T:Microsoft.Maui.CornerRadius" /> such that all four of its corners have the same radius.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -68,7 +66,6 @@
         <param name="bottomLeft">The radius of the bottom left corner.</param>
         <param name="bottomRight">The radius of the bottom right corner.</param>
         <summary>Creates a new <see cref="T:Microsoft.Maui.CornerRadius" /> such that each of four of its corners have the specified radiuses.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="BottomLeft">
@@ -88,7 +85,6 @@
       <Docs>
         <summary>Gets the radius of the top left corner.</summary>
         <value>The radius of the top left corner.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="BottomRight">
@@ -108,7 +104,6 @@
       <Docs>
         <summary>Gets the radius of the bottom right corner.</summary>
         <value>The radius of the bottom right corner.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Deconstruct">
@@ -135,8 +130,6 @@
         <param name="topRight">To be added.</param>
         <param name="bottomLeft">To be added.</param>
         <param name="bottomRight">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Equals">
@@ -161,7 +154,6 @@
         <summary>Compares this corner radius to another.</summary>
         <returns>
           <see langword="true" /> if <paramref name="obj" /> has the same effective corner radius values. Otherwise, <see langword="false" />.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetHashCode">
@@ -182,7 +174,6 @@
       <Docs>
         <summary>Gets the hashcode for the corner radius.</summary>
         <returns>The hashcode for the corner radius.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="op_Equality">
@@ -209,7 +200,6 @@
         <summary>Compares the <paramref name="left" /> and <paramref name="right" /> corner radius values.</summary>
         <returns>
           <see langword="true" /> if <paramref name="left" /> has the same effective corner radius values as <paramref name="right" />. Otherwise, <see langword="false" />.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="op_Implicit">
@@ -232,8 +222,6 @@
       <Docs>
         <param name="uniformRadius">The uniform radius to convert to a corner radius object.</param>
         <summary>Creates and returns a new <see cref="T:Microsoft.Maui.CornerRadius" /> such that all four of its corners have the same radius.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="op_Inequality">
@@ -260,7 +248,6 @@
         <summary>Compares the <paramref name="left" /> and <paramref name="right" /> corner radius values.</summary>
         <returns>
           <see langword="true" /> if <paramref name="left" /> has different effective corner radius values as <paramref name="right" />. Otherwise, <see langword="false" />.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TopLeft">
@@ -280,7 +267,6 @@
       <Docs>
         <summary>Gets the radius of the top left corner.</summary>
         <value>The radius of the top left corner.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TopRight">
@@ -300,7 +286,6 @@
       <Docs>
         <summary>Gets the radius of the top right corner.</summary>
         <value>The radius of the top right corner.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Core/docs/Microsoft.Maui/Easing.xml
+++ b/src/Core/docs/Microsoft.Maui/Easing.xml
@@ -171,7 +171,6 @@
       <Docs>
         <param name="easingFunc">A function that maps animation times.</param>
         <summary>Creates a new <see cref="T:Microsoft.Maui.Easing" /> object with the <paramref name="easingFunc" /> function.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="BounceIn">
@@ -346,7 +345,6 @@
         <param name="v">A value in the range [0,1] to which the easing function should be applied.</param>
         <summary>Applies the easing function to the specified value <paramref name="v" />.</summary>
         <returns>The value of the easing function when applied to the value <paramref name="v" />.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Linear">

--- a/src/Core/docs/Microsoft.Maui/EmbeddedFont.xml
+++ b/src/Core/docs/Microsoft.Maui/EmbeddedFont.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -27,8 +25,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FontName">
@@ -45,9 +41,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ResourceStream">
@@ -64,9 +57,6 @@
         <ReturnType>System.IO.Stream</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Core/docs/Microsoft.Maui/FlyoutBehavior.xml
+++ b/src/Core/docs/Microsoft.Maui/FlyoutBehavior.xml
@@ -12,7 +12,6 @@
   </Base>
   <Docs>
     <summary>Enumeration of modes for the root menu of a Shell application.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Disabled">
@@ -30,7 +29,6 @@
       </ReturnValue>
       <MemberValue>0</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
     <Member MemberName="Flyout">
@@ -48,7 +46,6 @@
       </ReturnValue>
       <MemberValue>1</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
     <Member MemberName="Locked">
@@ -66,7 +63,6 @@
       </ReturnValue>
       <MemberValue>2</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
   </Members>

--- a/src/Core/docs/Microsoft.Maui/Font.xml
+++ b/src/Core/docs/Microsoft.Maui/Font.xml
@@ -63,7 +63,6 @@
         <param name="size">The desired font size.</param>
         <summary>Returns a font instance that represents the default bold font, in the requested size, for the device.</summary>
         <returns>The requested bold <see cref="T:Microsoft.Maui.Font" />.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="BoldSystemFontOfSize">
@@ -101,7 +100,6 @@
         <param name="size">The desired font <see cref="T:Microsoft.Maui.Controls.NamedSize" />.</param>
         <summary>Returns an usable font instance representing the default bold font, in the requested NamedSize, for the device.</summary>
         <returns>The requested bold <see cref="T:Microsoft.Maui.Font" />.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Default">
@@ -125,7 +123,6 @@
       <Docs>
         <summary>Gets the default font for the device.</summary>
         <value>The default font for the device.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Equals">
@@ -179,8 +176,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets a value that indicates whether the font is bold, italic, or neither.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Family">
@@ -204,7 +199,6 @@
       <Docs>
         <summary>Gets the font family to which this font belongs.</summary>
         <value>The font family to which this <see cref="T:Microsoft.Maui.Font" /> structure belongs.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Size">
@@ -228,7 +222,6 @@
       <Docs>
         <summary>Gets the size of the font.</summary>
         <value>A <see langword="double" /> that indicates the size of the font.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetHashCode">
@@ -275,8 +268,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets a value that tells whether this font has no attributes, belongs to the default family, and has no attributes set.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OfSize">
@@ -371,8 +362,6 @@
         <param name="left">The first font in the comparison.</param>
         <param name="right">The second font in the comparison.</param>
         <summary>Returns <see langword="true" /> if <paramref name="left" /> represents the same font that <paramref name="right" /> represents. Otherwise, <see langword="false" />.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="op_Inequality">
@@ -403,8 +392,6 @@
         <param name="left">The first font in the comparison.</param>
         <param name="right">The second font in the comparison.</param>
         <summary>Returns <see langword="true" /> if <paramref name="left" /> does not represent the same font that <paramref name="right" /> represents. Otherwise, <see langword="false" />.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SystemFontOfSize">
@@ -434,7 +421,6 @@
         <param name="size">The desired font size.</param>
         <summary>Returns an usable font instance representing the default font, in the requested size, for the device and platform.</summary>
         <returns>The requested <see cref="T:Microsoft.Maui.Font" />.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SystemFontOfSize">
@@ -464,7 +450,6 @@
         <param name="size">The desired font <see cref="T:Microsoft.Maui.Controls.NamedSize" />.</param>
         <summary>Returns an usable font instance representing the default font, in the requested size, for the device and platform.</summary>
         <returns>The requested bold <see cref="T:Microsoft.Maui.Font" />.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SystemFontOfSize">
@@ -494,7 +479,6 @@
         <param name="attributes">Whether the font is bold, italic, or neither.</param>
         <summary>Returns a font structure with the specified size and attributes.</summary>
         <returns>A <see cref="T:Microsoft.Maui.Font" /> structure with the specified <paramref name="attributes" /> and <paramref name="size" />.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SystemFontOfSize">
@@ -524,7 +508,6 @@
         <param name="attributes">Whether the font is bold, italic, or neither.</param>
         <summary>Returns a font structure with the specified size and attributes.</summary>
         <returns>A <see cref="T:Microsoft.Maui.Font" /> structure with the specified <paramref name="attributes" /> and <paramref name="size" />.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ToString">
@@ -577,7 +560,6 @@
         <param name="fontAttributes">Whether the font is italic, bold, or neither.</param>
         <summary>Returns a new font structure with the specified attributes.</summary>
         <returns>A new <see cref="T:Microsoft.Maui.Font" /> structure with the attributes that were specified with <paramref name="fontAttributes" />.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="WithSize">
@@ -604,8 +586,6 @@
       <Docs>
         <param name="size">The requested font size.</param>
         <summary>Returns a new font structure with the size that was specified with <paramref name="size" />.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="WithSize">
@@ -632,8 +612,6 @@
       <Docs>
         <param name="size">The requested named font size.</param>
         <summary>A new <see cref="T:Microsoft.Maui.Font" /> structure with the size that was specified with <paramref name="size" />.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Core/docs/Microsoft.Maui/FontFile.xml
+++ b/src/Core/docs/Microsoft.Maui/FontFile.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -27,8 +25,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Extension">
@@ -45,9 +41,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Extensions">
@@ -64,8 +57,6 @@
         <ReturnType>System.String[]</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FileName">
@@ -82,9 +73,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FileNameWithExtension">
@@ -102,9 +90,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FileNameWithExtension">
@@ -125,9 +110,6 @@
       </Parameters>
       <Docs>
         <param name="extension">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FromString">
@@ -148,9 +130,6 @@
       </Parameters>
       <Docs>
         <param name="input">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetPostScriptNameWithSpaces">
@@ -168,9 +147,6 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PostScriptName">
@@ -187,9 +163,6 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Core/docs/Microsoft.Maui/GestureStatus.xml
+++ b/src/Core/docs/Microsoft.Maui/GestureStatus.xml
@@ -14,7 +14,6 @@
   </Base>
   <Docs>
     <summary>Enumerates possible gesture states.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Canceled">

--- a/src/Core/docs/Microsoft.Maui/GridLength.xml
+++ b/src/Core/docs/Microsoft.Maui/GridLength.xml
@@ -85,7 +85,6 @@
         <param name="value">The size of the GridLength.</param>
         <param name="type">The GridUnitType (Auto, Star, Absolute) of the GridLength.</param>
         <summary>Initializes a new GridLength.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Auto">
@@ -142,7 +141,6 @@
         <param name="obj">A GridLength to compare to.</param>
         <summary>Test the equality of this GridLength and another one.</summary>
         <returns>true is the GridLength are equal. False otherwise.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetHashCode">
@@ -168,7 +166,6 @@
       <Parameters />
       <Docs>
         <summary>Returns a value that is used for efficient storage of this object in collections.</summary>
-        <returns>To be added.</returns>
         <remarks>Overridden.</remarks>
       </Docs>
     </Member>
@@ -195,7 +192,6 @@
       <Docs>
         <summary>Gets or sets the GridUnitType of the GridLength</summary>
         <value>The GridUnitType of the GridLength</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsAbsolute">
@@ -221,7 +217,6 @@
       <Docs>
         <summary>Gets whether or not the GridUnitType of the GridLength is GridUnitType.Absolute.</summary>
         <value>true if the GridUnitType of the GridLength is GridUnitType.Absolute</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsAuto">
@@ -247,7 +242,6 @@
       <Docs>
         <summary>Gets whether or not the GridUnitType of the GridLength is GridUnitType.Auto.</summary>
         <value>true if the GridUnitType of the GridLength is GridUnitType.Auto</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsStar">
@@ -273,7 +267,6 @@
       <Docs>
         <summary>Gets a value that indicates whether the GridUnitType of the GridLength is GridUnitType.Star.</summary>
         <value>true if the GridUnitType of the GridLength is GridUnitType.Star</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="op_Implicit">
@@ -303,7 +296,6 @@
         <param name="absoluteValue">The absolute size</param>
         <summary>Casting operator to convert a double into a GridLength of type GridUnitType.Absolute</summary>
         <returns>A GridLength of type GridUnitType.Absolute and of size absolutesize</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Star">
@@ -346,8 +338,6 @@
       <Parameters />
       <Docs>
         <summary>Returns the value and the grid unit type, separated by a ".".</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Value">
@@ -373,7 +363,6 @@
       <Docs>
         <summary>Gets the Value of the GridLength.</summary>
         <value>The value in GridUnitType of the GridLength.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Core/docs/Microsoft.Maui/GridUnitType.xml
+++ b/src/Core/docs/Microsoft.Maui/GridUnitType.xml
@@ -19,7 +19,6 @@
   </Base>
   <Docs>
     <summary>Enumerates values that control how the <see cref="P:Microsoft.Maui.GridLength.Value" /> property is interpreted for row and column definitions.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Absolute">
@@ -45,7 +44,6 @@
       <MemberValue>0</MemberValue>
       <Docs>
         <summary>Interpret the <see cref="P:Microsoft.Maui.GridLength.Value" /> property value as the number of device-specific units.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Auto">
@@ -71,7 +69,6 @@
       <MemberValue>2</MemberValue>
       <Docs>
         <summary>Ignore the <see cref="P:Microsoft.Maui.GridLength.Value" /> property value and choose a size that fits the children of the row or column.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Star">

--- a/src/Core/docs/Microsoft.Maui/Keyboard.xml
+++ b/src/Core/docs/Microsoft.Maui/Keyboard.xml
@@ -25,7 +25,6 @@
   </Attributes>
   <Docs>
     <summary>Default keyboard and base class for specialized keyboards, such as those for telephone numbers, email, and URLs.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Chat">
@@ -50,8 +49,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets an instance of type "ChatKeyboard".</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Create">
@@ -80,8 +77,6 @@
       <Docs>
         <param name="flags">The flags that control the keyboard's appearance and behavior.</param>
         <summary>Returns a new keyboard with the specified <see cref="T:Microsoft.Maui.KeyboardFlags" />.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Default">
@@ -106,8 +101,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets an instance of type "Keyboard".</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Email">
@@ -132,8 +125,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets an instance of type "EmailKeyboard".</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Numeric">
@@ -158,8 +149,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets an instance of type "NumericKeyboard".</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Plain">
@@ -178,8 +167,6 @@
       </ReturnValue>
       <Docs>
         <summary>Returns a new keyboard with None <see cref="T:Microsoft.Maui.KeyboardFlags" /> ".</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Telephone">
@@ -204,8 +191,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets an instance of type "TelephoneKeyboard".</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Text">
@@ -230,8 +215,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets an instance of type "TextKeyboard".</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Url">
@@ -256,8 +239,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets an instance of type "UrlKeyboard".</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Core/docs/Microsoft.Maui/KeyboardFlags.xml
+++ b/src/Core/docs/Microsoft.Maui/KeyboardFlags.xml
@@ -24,7 +24,6 @@
   </Attributes>
   <Docs>
     <summary>Enumerates keyboard option flags that controls capitalization, spellcheck, and suggestion behavior.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="All">

--- a/src/Core/docs/Microsoft.Maui/LineBreakMode.xml
+++ b/src/Core/docs/Microsoft.Maui/LineBreakMode.xml
@@ -19,7 +19,6 @@
   </Base>
   <Docs>
     <summary>Enumeration specifying various options for line breaking.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="CharacterWrap">

--- a/src/Core/docs/Microsoft.Maui/OpenSwipeItem.xml
+++ b/src/Core/docs/Microsoft.Maui/OpenSwipeItem.xml
@@ -11,8 +11,6 @@
     <BaseTypeName>System.Enum</BaseTypeName>
   </Base>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="BottomItems">
@@ -30,7 +28,6 @@
       </ReturnValue>
       <MemberValue>3</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
     <Member MemberName="LeftItems">
@@ -48,7 +45,6 @@
       </ReturnValue>
       <MemberValue>0</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
     <Member MemberName="RightItems">
@@ -66,7 +62,6 @@
       </ReturnValue>
       <MemberValue>2</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
     <Member MemberName="TopItems">
@@ -84,7 +79,6 @@
       </ReturnValue>
       <MemberValue>1</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
   </Members>

--- a/src/Core/docs/Microsoft.Maui/ReturnType.xml
+++ b/src/Core/docs/Microsoft.Maui/ReturnType.xml
@@ -13,7 +13,6 @@
   </Base>
   <Docs>
     <summary>Enumerates return button styles.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Default">

--- a/src/Core/docs/Microsoft.Maui/ScrollBarVisibility.xml
+++ b/src/Core/docs/Microsoft.Maui/ScrollBarVisibility.xml
@@ -13,7 +13,6 @@
   </Base>
   <Docs>
     <summary>Enumerates conditions under which scroll bars will be visible.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Always">

--- a/src/Core/docs/Microsoft.Maui/ScrollOrientation.xml
+++ b/src/Core/docs/Microsoft.Maui/ScrollOrientation.xml
@@ -19,7 +19,6 @@
   </Base>
   <Docs>
     <summary>Enumeration specifying vertical or horizontal scrolling directions.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Both">
@@ -81,7 +80,6 @@
       </ReturnValue>
       <MemberValue>3</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
     <Member MemberName="Vertical">

--- a/src/Core/docs/Microsoft.Maui/SizeRequest.xml
+++ b/src/Core/docs/Microsoft.Maui/SizeRequest.xml
@@ -26,7 +26,6 @@
   </Attributes>
   <Docs>
     <summary>Struct that defines minimum and maximum <see cref="T:Microsoft.Maui.Graphics.Size" />s.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -53,7 +52,6 @@
       <Docs>
         <param name="request">The size of the request.</param>
         <summary>Creates a new <see cref="T:Microsoft.Maui.SizeRequest" /> with the specified <paramref name="request" /> size.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -82,7 +80,6 @@
         <param name="request">The size of the request.</param>
         <param name="minimum">The minimum size for the request.</param>
         <summary>Creates a new <see cref="T:Microsoft.Maui.SizeRequest" /> object that requests at least the size <paramref name="minimum" />, but preferably the size <paramref name="request" />.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Minimum">
@@ -108,8 +105,6 @@
       </ReturnValue>
       <Docs>
         <summary>The minimum acceptable size.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Request">
@@ -135,8 +130,6 @@
       </ReturnValue>
       <Docs>
         <summary>The requested size.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ToString">
@@ -159,8 +152,6 @@
       <Parameters />
       <Docs>
         <summary>Returns a string representation of the size request.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Core/docs/Microsoft.Maui/SwipeBehaviorOnInvoked.xml
+++ b/src/Core/docs/Microsoft.Maui/SwipeBehaviorOnInvoked.xml
@@ -11,8 +11,6 @@
     <BaseTypeName>System.Enum</BaseTypeName>
   </Base>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Auto">
@@ -30,7 +28,6 @@
       </ReturnValue>
       <MemberValue>0</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
     <Member MemberName="Close">
@@ -48,7 +45,6 @@
       </ReturnValue>
       <MemberValue>1</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
     <Member MemberName="RemainOpen">
@@ -66,7 +62,6 @@
       </ReturnValue>
       <MemberValue>2</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
   </Members>

--- a/src/Core/docs/Microsoft.Maui/SwipeDirection.xml
+++ b/src/Core/docs/Microsoft.Maui/SwipeDirection.xml
@@ -18,7 +18,6 @@
   </Attributes>
   <Docs>
     <summary>Enumerates swipe directions.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Down">

--- a/src/Core/docs/Microsoft.Maui/SwipeMode.xml
+++ b/src/Core/docs/Microsoft.Maui/SwipeMode.xml
@@ -11,8 +11,6 @@
     <BaseTypeName>System.Enum</BaseTypeName>
   </Base>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Execute">
@@ -30,7 +28,6 @@
       </ReturnValue>
       <MemberValue>1</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
     <Member MemberName="Reveal">
@@ -48,7 +45,6 @@
       </ReturnValue>
       <MemberValue>0</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
   </Members>

--- a/src/Core/docs/Microsoft.Maui/TextAlignment.xml
+++ b/src/Core/docs/Microsoft.Maui/TextAlignment.xml
@@ -24,7 +24,6 @@
   </Attributes>
   <Docs>
     <summary>Enumerates values that control text alignment.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Center">

--- a/src/Core/docs/Microsoft.Maui/TextDecorations.xml
+++ b/src/Core/docs/Microsoft.Maui/TextDecorations.xml
@@ -20,7 +20,6 @@
   </Attributes>
   <Docs>
     <summary>Flagging enumeration defining text decorations.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="None">

--- a/src/Core/docs/Microsoft.Maui/TextTransform.xml
+++ b/src/Core/docs/Microsoft.Maui/TextTransform.xml
@@ -11,8 +11,6 @@
     <BaseTypeName>System.Enum</BaseTypeName>
   </Base>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Default">
@@ -30,7 +28,6 @@
       </ReturnValue>
       <MemberValue>1</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
     <Member MemberName="Lowercase">
@@ -48,7 +45,6 @@
       </ReturnValue>
       <MemberValue>2</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
     <Member MemberName="None">
@@ -66,7 +62,6 @@
       </ReturnValue>
       <MemberValue>0</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
     <Member MemberName="Uppercase">
@@ -84,7 +79,6 @@
       </ReturnValue>
       <MemberValue>3</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
   </Members>

--- a/src/Core/docs/Microsoft.Maui/TextType.xml
+++ b/src/Core/docs/Microsoft.Maui/TextType.xml
@@ -11,8 +11,6 @@
     <BaseTypeName>System.Enum</BaseTypeName>
   </Base>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Html">
@@ -30,7 +28,6 @@
       </ReturnValue>
       <MemberValue>1</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
     <Member MemberName="Text">
@@ -48,7 +45,6 @@
       </ReturnValue>
       <MemberValue>0</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
   </Members>

--- a/src/Core/docs/Microsoft.Maui/Thickness.xml
+++ b/src/Core/docs/Microsoft.Maui/Thickness.xml
@@ -28,7 +28,6 @@
   </Attributes>
   <Docs>
     <summary>Struct defining thickness around the edges of a <see cref="T:Microsoft.Maui.Controls.Shapes.Rectangle" /> using doubles.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -54,7 +53,6 @@
       <Docs>
         <param name="uniformSize">The uniform size of all edges in the new thickness.</param>
         <summary>Creates a new <see cref="T:Microsoft.Maui.Thickness" /> object that represents a uniform thickness of size <paramref name="uniformSize" />.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -82,7 +80,6 @@
         <param name="horizontalSize">The width of the left and right thicknesses.</param>
         <param name="verticalSize">The height of the top and bottom thicknesses.</param>
         <summary>Creates a new <see cref="T:Microsoft.Maui.Thickness" /> object that has a horizontal thickness of <paramref name="horizontalSize" /> and a vertical thickness of <paramref name="verticalSize" />.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -114,7 +111,6 @@
         <param name="right">The width of the right thickness.</param>
         <param name="bottom">The height of the bottom thickness.</param>
         <summary>Creates a new <see cref="T:Microsoft.Maui.Thickness" /> object with thicknesses defined by <paramref name="left" />, <paramref name="top" />, <paramref name="right" />, and <paramref name="bottom" />.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Bottom">
@@ -139,8 +135,6 @@
       </ReturnValue>
       <Docs>
         <summary>The thickness of the bottom of a rectangle.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Deconstruct">
@@ -167,8 +161,6 @@
         <param name="top">To be added.</param>
         <param name="right">To be added.</param>
         <param name="bottom">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Equals">
@@ -199,7 +191,6 @@
         <summary>Whether the <paramref name="obj" /> is a <see cref="T:Microsoft.Maui.Thickness" /> with equivalent values.</summary>
         <returns>
           <see langword="true" /> if <paramref name="obj" /> is a <see cref="T:Microsoft.Maui.Thickness" /> and has equivalent values.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetHashCode">
@@ -225,8 +216,6 @@
       <Parameters />
       <Docs>
         <summary>A has value for this <see cref="T:Microsoft.Maui.Thickness" />.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="HorizontalThickness">
@@ -251,8 +240,6 @@
       </ReturnValue>
       <Docs>
         <summary>The sum of <see cref="P:Microsoft.Maui.Thickness.Left" /> and <see cref="P:Microsoft.Maui.Thickness.Right" />.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsEmpty">
@@ -269,9 +256,6 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Left">
@@ -296,8 +280,6 @@
       </ReturnValue>
       <Docs>
         <summary>The thickness of the left side of a rectangle.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="op_Equality">
@@ -330,7 +312,6 @@
         <summary>Whether two <see cref="T:Microsoft.Maui.Thickness" />es have identical values.</summary>
         <returns>
           <see langword="true" /> if <paramref name="left" /> and <paramref name="right" /> have identical values for <see cref="P:Microsoft.Maui.Thickness.Left" />,<see cref="P:Microsoft.Maui.Thickness.Right" />, <see cref="P:Microsoft.Maui.Thickness.Top" />, and <see cref="P:Microsoft.Maui.Thickness.Bottom" />.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="op_Implicit">
@@ -391,7 +372,6 @@
       <Docs>
         <param name="size">A <see cref="T:Microsoft.Maui.Graphics.Size" /> to convert to a <see cref="T:Microsoft.Maui.Thickness" /></param>
         <summary>Converts a <see cref="T:Microsoft.Maui.Graphics.Size" /> into a <see cref="T:Microsoft.Maui.Thickness" />.</summary>
-        <returns>To be added.</returns>
         <remarks>
           <para>The <see cref="T:Microsoft.Maui.Thickness" />'s <see cref="P:Microsoft.Maui.Thickness.Left" /> and <see cref="P:Microsoft.Maui.Thickness.Right" /> are both set equal to the <paramref name="size" />'s <see cref="P:Microsoft.Maui.Graphics.Size.Width" /> and the  <see cref="T:Microsoft.Maui.Thickness" />'s <see cref="P:Microsoft.Maui.Thickness.Top" /> and <see cref="P:Microsoft.Maui.Thickness.Bottom" /> are both set equal to the <paramref name="size" />'s <see cref="P:Microsoft.Maui.Graphics.Size.Height" />.</para>
         </remarks>
@@ -427,7 +407,6 @@
         <summary>Whether the values of two <see cref="T:Microsoft.Maui.Thickness" />'s have at least one difference.</summary>
         <returns>
           <see langword="true" /> if any of the <see cref="P:Microsoft.Maui.Thickness.Left" />,<see cref="P:Microsoft.Maui.Thickness.Right" />, <see cref="P:Microsoft.Maui.Thickness.Top" />, and <see cref="P:Microsoft.Maui.Thickness.Bottom" /> values differ between <paramref name="left" /> and <paramref name="right" />.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Right">
@@ -452,8 +431,6 @@
       </ReturnValue>
       <Docs>
         <summary>The thickness of the right side of a rectangle.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Top">
@@ -478,8 +455,6 @@
       </ReturnValue>
       <Docs>
         <summary>The thickness of the top of a rectangle.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="VerticalThickness">
@@ -504,8 +479,6 @@
       </ReturnValue>
       <Docs>
         <summary>The sum of <see cref="P:Microsoft.Maui.Thickness.Top" /> and <see cref="P:Microsoft.Maui.Thickness.Bottom" />.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Core/docs/Microsoft.Maui/ViewExtensions.xml
+++ b/src/Core/docs/Microsoft.Maui/ViewExtensions.xml
@@ -20,7 +20,6 @@
   <Interfaces />
   <Docs>
     <summary>Extension methods for <see cref="T:Microsoft.Maui.Controls.View" />s, providing animatable scaling, rotation, and layout functions.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="CancelAnimations">
@@ -49,7 +48,6 @@
       <Docs>
         <param name="view">The view on which this method operates.</param>
         <summary>Aborts the TranslateTo, LayoutTo, RotateTo, ScaleTo, and FadeTo animations on <paramref name="view" /> element.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FadeTo">
@@ -84,8 +82,6 @@
         <param name="length">The time, in milliseconds, over which to animate the transition. The default is 250.</param>
         <param name="easing">The easing function to use for the animation.</param>
         <summary>Returns a task that performs the fade that is described by the <paramref name="opacity" />, <paramref name="length" />, and <paramref name="easing" /> parameters.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="LayoutTo">
@@ -120,8 +116,6 @@
         <param name="length">The time, in milliseconds, over which to animate the transition. The default is 250.</param>
         <param name="easing">The easing function to use for the animation.</param>
         <summary>Returns a task that eases the bounds of the <see cref="T:Microsoft.Maui.VisualElement" /> that is specified by the <paramref name="view" /> to the rectangle that is specified by the <paramref name="bounds" /> parameter.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RelRotateTo">
@@ -156,8 +150,6 @@
         <param name="length">The time, in milliseconds, over which to animate the transition. The default is 250.</param>
         <param name="easing">The easing function to use for the animation.</param>
         <summary>Rotates the <see cref="T:Microsoft.Maui.VisualElement" /> that is specified by <paramref name="view" /> from its current rotation by <paramref name="drotation" />.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RelScaleTo">
@@ -192,8 +184,6 @@
         <param name="length">The time, in milliseconds, over which to animate the transition. The default is 250.</param>
         <param name="easing">The easing function to use for the animation.</param>
         <summary>Returns a task that scales the <see cref="T:Microsoft.Maui.VisualElement" /> that is specified by <paramref name="view" /> from its current scale to <paramref name="dscale" />.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RotateTo">
@@ -228,8 +218,6 @@
         <param name="length">The time, in milliseconds, over which to animate the transition. The default is 250.</param>
         <param name="easing">The easing function to use for the animation.</param>
         <summary>Returns a task that performs the rotation that is described by the <paramref name="rotation" />, <paramref name="length" />, and <paramref name="easing" /> parameters.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RotateXTo">
@@ -264,8 +252,6 @@
         <param name="length">The time, in milliseconds, over which to animate the transition. The default is 250.</param>
         <param name="easing">The easing function to use for the animation.</param>
         <summary>Returns a task that skews the Y axis by <paramref name="opacity" />, taking time <paramref name="length" /> and using <paramref name="easing" />.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RotateYTo">
@@ -300,8 +286,6 @@
         <param name="length">The time, in milliseconds, over which to animate the transition. The default is 250.</param>
         <param name="easing">The easing function to use for the animation.</param>
         <summary>Returns a task that skews the X axis by <paramref name="opacity" />, taking time <paramref name="length" /> and using <paramref name="easing" />.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ScaleTo">
@@ -336,8 +320,6 @@
         <param name="length">The time, in milliseconds, over which to animate the transition. The default is 250.</param>
         <param name="easing">The easing function to use for the animation.</param>
         <summary>Returns a task that scales the <see cref="T:Microsoft.Maui.VisualElement" /> that is specified by <paramref name="view" /> to the absolute scale factor <paramref name="scale" />.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ScaleXTo">
@@ -364,9 +346,6 @@
         <param name="scale">To be added.</param>
         <param name="length">To be added.</param>
         <param name="easing">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ScaleYTo">
@@ -393,9 +372,6 @@
         <param name="scale">To be added.</param>
         <param name="length">To be added.</param>
         <param name="easing">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="TranslateTo">
@@ -431,7 +407,6 @@
         <param name="length">The duration of the animation in milliseconds.</param>
         <param name="easing">The easing of the animation.</param>
         <summary>Animates an elements TranslationX and TranslationY properties from their current values to the new values. This ensures that the input layout is in the same position as the visual layout.</summary>
-        <returns>To be added.</returns>
         <remarks>
           <para>To animate a view that receives user touch input from outside of the screen, the developer must first lay out the view in its final position, then translate the view off screen, and then finally animate the view back to its final position on the screen.</para>
           <para>TranslateTo is useful for animations because it is applied post-layout. Translation animations will not conflict with managed layouts and thus are ideal for doing slide in/out style animations.</para>

--- a/src/Core/docs/Microsoft.Maui/VisualDiagnostics.xml
+++ b/src/Core/docs/Microsoft.Maui/VisualDiagnostics.xml
@@ -18,8 +18,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -36,8 +34,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetXamlSourceInfo">
@@ -61,9 +57,6 @@
       </Parameters>
       <Docs>
         <param name="obj">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RegisterSourceInfo">
@@ -98,8 +91,6 @@
         <param name="uri">To be added.</param>
         <param name="lineNumber">To be added.</param>
         <param name="linePosition">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="VisualTreeChanged">
@@ -119,8 +110,6 @@
         <ReturnType>System.EventHandler&lt;Microsoft.Maui.Controls.Xaml.Diagnostics.VisualTreeChangeEventArgs&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Core/docs/Microsoft.Maui/VisualTreeChangeEventArgs.xml
+++ b/src/Core/docs/Microsoft.Maui/VisualTreeChangeEventArgs.xml
@@ -18,8 +18,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -46,8 +44,6 @@
         <param name="child">To be added.</param>
         <param name="childIndex">To be added.</param>
         <param name="changeType">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ChangeType">
@@ -67,9 +63,6 @@
         <ReturnType>Microsoft.Maui.Controls.Xaml.Diagnostics.VisualTreeChangeType</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Child">
@@ -89,9 +82,6 @@
         <ReturnType>System.Object</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ChildIndex">
@@ -111,9 +101,6 @@
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Parent">
@@ -133,9 +120,6 @@
         <ReturnType>System.Object</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/src/Core/docs/Microsoft.Maui/VisualTreeChangeType.xml
+++ b/src/Core/docs/Microsoft.Maui/VisualTreeChangeType.xml
@@ -11,8 +11,6 @@
     <BaseTypeName>System.Enum</BaseTypeName>
   </Base>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Add">
@@ -30,7 +28,6 @@
       </ReturnValue>
       <MemberValue>0</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
     <Member MemberName="Remove">
@@ -48,7 +45,6 @@
       </ReturnValue>
       <MemberValue>1</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
       </Docs>
     </Member>
   </Members>

--- a/src/Core/docs/Microsoft.Maui/WeakEventManager.xml
+++ b/src/Core/docs/Microsoft.Maui/WeakEventManager.xml
@@ -12,8 +12,6 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -27,8 +25,6 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="AddEventHandler">
@@ -57,8 +53,6 @@
       <Docs>
         <param name="handler">To be added.</param>
         <param name="eventName">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="AddEventHandler&lt;TEventArgs&gt;">
@@ -95,8 +89,6 @@
         <typeparam name="TEventArgs">To be added.</typeparam>
         <param name="handler">To be added.</param>
         <param name="eventName">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="HandleEvent">
@@ -121,8 +113,6 @@
         <param name="sender">To be added.</param>
         <param name="args">To be added.</param>
         <param name="eventName">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RemoveEventHandler">
@@ -151,8 +141,6 @@
       <Docs>
         <param name="handler">To be added.</param>
         <param name="eventName">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RemoveEventHandler&lt;TEventArgs&gt;">
@@ -189,8 +177,6 @@
         <typeparam name="TEventArgs">To be added.</typeparam>
         <param name="handler">To be added.</param>
         <param name="eventName">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>


### PR DESCRIPTION
### Description of Change

Removing all the To be added. strings from the XML API docs that we have now to see if that mitigates the out of place "To be added." comments we see in Visual Studio IntelliSense.

For the specific example mentioned in the issue below, see this screenshot where "To be added." is now gone.

![image](https://github.com/user-attachments/assets/582dec78-3ae5-4be6-aec9-b740ad5c7082)

### Issues Fixed

Fixes #25220
<sub>And finally fixes https://github.com/xamarin/Xamarin.Forms/issues/7252</sub>
