### PR TITLE
[X] Delay binding context type check until relative binding source is resolved

### DIFF
--- a/src/Controls/src/Core/Binding.cs
+++ b/src/Controls/src/Core/Binding.cs
@@ -124,18 +124,6 @@ namespace Microsoft.Maui.Controls
 			var isApplied = IsApplied;
 
 			var bindingContext = src ?? Context ?? context;
-
-			// Do not check type mismatch if this is a binding with Source and compilation of bindings with Source is disabled
-			bool skipTypeMismatchCheck = Source is not null && !RuntimeFeature.IsXamlCBindingWithSourceCompilationEnabled;
-			if (!skipTypeMismatchCheck)
-			{
-				if (DataType != null && bindingContext != null && !DataType.IsAssignableFrom(bindingContext.GetType()))
-				{
-					BindingDiagnostics.SendBindingFailure(this, "Binding", $"Mismatch between the specified x:DataType ({DataType}) and the current binding context ({bindingContext.GetType()}).");
-					bindingContext = null;
-				}
-			}
-
 			base.Apply(bindingContext, bindObj, targetProperty, fromBindingContextChanged, specificity);
 
 			if (src != null && isApplied && fromBindingContextChanged)

--- a/src/Controls/src/Core/BindingExpression.cs
+++ b/src/Controls/src/Core/BindingExpression.cs
@@ -65,6 +65,20 @@ namespace Microsoft.Maui.Controls
 		/// </summary>
 		internal void Apply(object sourceObject, BindableObject target, BindableProperty property, SetterSpecificity specificity)
 		{
+			if (Binding is Binding { Source: var source, DataType: Type dataType })
+			{
+				// Do not check type mismatch if this is a binding with Source and compilation of bindings with Source is disale
+				bool skipTypeMismatchCheck = source is not null && !RuntimeFeature.IsXamlCBindingWithSourceCompilationEnabled;
+				if (!skipTypeMismatchCheck)
+				{
+					if (sourceObject != null && !dataType.IsAssignableFrom(sourceObject.GetType()))
+					{
+						BindingDiagnostics.SendBindingFailure(Binding, "Binding", $"Mismatch between the specified x:DataType ({dataType}) and the current binding context ({sourceObject.GetType()}).");
+						sourceObject = null;
+					}
+				}
+			}
+			
 			_targetProperty = property;
 			_specificity = specificity;
 

--- a/src/Controls/src/Core/TypedBinding.cs
+++ b/src/Controls/src/Core/TypedBinding.cs
@@ -290,7 +290,7 @@ namespace Microsoft.Maui.Controls.Internals
 			var isTSource = sourceObject is TSource;
 			if (!isTSource && sourceObject is not null)
 			{
-				BindingDiagnostics.SendBindingFailure(this, "Binding", $"Mismatch between the specified x:DataType ({typeof(TSource)}) and the current binding context ({sourceObject.GetType()})");
+				BindingDiagnostics.SendBindingFailure(this, "Binding", $"Mismatch between the specified x:DataType ({typeof(TSource)}) and the current binding context ({sourceObject.GetType()}).");
 			}
 
 			var mode = this.GetRealizedMode(property);

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui25608.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui25608.xaml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui25608">
+    <VerticalStackLayout Spacing="25">
+        <Image
+            x:Name="Image"
+            Source="dotnet_bot.png"
+            HeightRequest="{Binding Spacing, x:DataType=VerticalStackLayout, Source={RelativeSource AncestorType={x:Type VerticalStackLayout}}}" />
+    </VerticalStackLayout>
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui25608.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui25608.xaml.cs
@@ -45,7 +45,7 @@ public partial class Maui25608
         }
 
         [Test]
-        public void TestNonCompiledResourceDictionary([Values(false, true)] bool useCompiledXaml)
+        public void TestValidBindingWithRelativeSource([Values(false, true)] bool useCompiledXaml)
         {
             bool bindingFailureReported = false;
             _bindingFailureHandler = (sender, args) => bindingFailureReported = true;

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui25608.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui25608.xaml.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using Microsoft.Maui.ApplicationModel;
+using Microsoft.Maui.Dispatching;
+
+using Microsoft.Maui.Controls.Core.UnitTests;
+using Microsoft.Maui.Controls.Xaml.Diagnostics;
+using Microsoft.Maui.UnitTests;
+using NUnit.Framework;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public partial class Maui25608
+{
+    public Maui25608()
+    {
+        InitializeComponent();
+    }
+
+    public Maui25608(bool useCompiledXaml)
+    {
+        //this stub will be replaced at compile time
+    }
+
+    [TestFixture]
+    class Test
+    {
+        EventHandler<BindingBaseErrorEventArgs> _bindingFailureHandler;
+
+        [SetUp]
+        public void Setup()
+        {
+            Application.SetCurrentApplication(new MockApplication());
+            DispatcherProvider.SetCurrent(new DispatcherProviderStub());
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (_bindingFailureHandler is not null)
+            {
+                BindingDiagnostics.BindingFailed -= _bindingFailureHandler;
+            }
+
+            AppInfo.SetCurrent(null);
+        }
+
+        [Test]
+        public void TestNonCompiledResourceDictionary([Values(false, true)] bool useCompiledXaml)
+        {
+            bool bindingFailureReported = false;
+            _bindingFailureHandler = (sender, args) => bindingFailureReported = true;
+            BindingDiagnostics.BindingFailed += _bindingFailureHandler;
+
+            var page = new Maui25608(useCompiledXaml);
+
+            Assert.AreEqual(25, page.Image.HeightRequest);
+            Assert.IsFalse(bindingFailureReported);
+        }
+    }
+}

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui25608_2.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui25608_2.xaml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui25608_2">
+    <VerticalStackLayout Spacing="25">
+        <Image
+            x:Name="Image"
+            Source="dotnet_bot.png"
+            HeightRequest="{Binding Spacing, x:DataType=VerticalStackLayout, Source={RelativeSource AncestorType={x:Type ContentPage}}}" />
+    </VerticalStackLayout>
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui25608_2.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui25608_2.xaml.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using Microsoft.Maui.ApplicationModel;
+using Microsoft.Maui.Dispatching;
+
+using Microsoft.Maui.Controls.Core.UnitTests;
+using Microsoft.Maui.Controls.Xaml.Diagnostics;
+using Microsoft.Maui.UnitTests;
+using NUnit.Framework;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public partial class Maui25608_2
+{
+    public Maui25608_2()
+    {
+        InitializeComponent();
+    }
+
+    public Maui25608_2(bool useCompiledXaml)
+    {
+        //this stub will be replaced at compile time
+    }
+
+    [TestFixture]
+    class Test
+    {
+        EventHandler<BindingBaseErrorEventArgs> _bindingFailureHandler;
+
+        [SetUp]
+        public void Setup()
+        {
+            Application.SetCurrentApplication(new MockApplication());
+            DispatcherProvider.SetCurrent(new DispatcherProviderStub());
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (_bindingFailureHandler is not null)
+            {
+                BindingDiagnostics.BindingFailed -= _bindingFailureHandler;
+            }
+
+            AppInfo.SetCurrent(null);
+        }
+
+        [Test]
+        public void TestInvalidBindingWithRelativeSource([Values(false, true)] bool useCompiledXaml)
+        {
+            bool bindingFailureReported = false;
+            _bindingFailureHandler = (sender, args) =>
+			{
+				bindingFailureReported = true;
+				Assert.AreEqual("Mismatch between the specified x:DataType (Microsoft.Maui.Controls.VerticalStackLayout) and the current binding context (Microsoft.Maui.Controls.Xaml.UnitTests.Maui25608_2).", args.Message);
+			};
+            BindingDiagnostics.BindingFailed += _bindingFailureHandler;
+
+            var page = new Maui25608_2(useCompiledXaml);
+
+            Assert.AreNotEqual(25, page.Image.HeightRequest);
+            Assert.IsTrue(bindingFailureReported);
+        }
+    }
+}


### PR DESCRIPTION
### Description of Change

We are checking if the binding context type matches the declared `x:DataType` too early. We need to wait until we resolve relative source otherwise the binding doesn't work.

Fixes #25608

/cc @PureWeen @StephaneDelcroix 