### PR TITLE
Revert PR #23052 behavior under new app context switch

### DIFF
--- a/src/Controls/src/Core/LegacyLayouts/Layout.cs
+++ b/src/Controls/src/Core/LegacyLayouts/Layout.cs
@@ -609,6 +609,11 @@ namespace Microsoft.Maui.Controls.Compatibility
 			{
 				InvalidateLayout();
 			}
+
+			if (UseLegacyMeasureInvalidatedBehaviorEnabled)
+			{
+				view.MeasureInvalidated += OnChildMeasureInvalidated;
+			}
 		}
 
 		void OnInternalRemoved(View view, int oldIndex)
@@ -617,6 +622,11 @@ namespace Microsoft.Maui.Controls.Compatibility
 			if (ShouldInvalidateOnChildRemoved(view))
 			{
 				InvalidateLayout();
+			}
+
+			if (UseLegacyMeasureInvalidatedBehaviorEnabled)
+			{
+				view.MeasureInvalidated -= OnChildMeasureInvalidated;
 			}
 		}
 

--- a/src/Controls/src/Core/Page/Page.cs
+++ b/src/Controls/src/Core/Page/Page.cs
@@ -66,6 +66,7 @@ namespace Microsoft.Maui.Controls
 
 		readonly Lazy<PlatformConfigurationRegistry<Page>> _platformConfigurationRegistry;
 
+		bool _allocatedFlag;
 		Rect _containerArea;
 
 		bool _containerAreaSet;
@@ -542,6 +543,7 @@ namespace Microsoft.Maui.Controls
 		/// <param name="height">The height allocated to the page.</param>
 		protected override void OnSizeAllocated(double width, double height)
 		{
+			_allocatedFlag = true;
 			base.OnSizeAllocated(width, height);
 			UpdateChildrenLayout();
 		}
@@ -603,7 +605,12 @@ namespace Microsoft.Maui.Controls
 				}
 			}
 
+			_allocatedFlag = false;
 			InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
+			if (!_allocatedFlag && Width >= 0 && Height >= 0 && UseLegacyMeasureInvalidatedBehaviorEnabled)
+			{
+				SizeAllocated(Width, Height);
+			}
 		}
 
 		internal void OnAppearing(Action action)
@@ -705,6 +712,13 @@ namespace Microsoft.Maui.Controls
 				for (var i = 0; i < e.OldItems.Count; i++)
 				{
 					var item = (Element)e.OldItems[i];
+
+					if (UseLegacyMeasureInvalidatedBehaviorEnabled &&
+						item is VisualElement visual)
+					{
+						visual.MeasureInvalidated -= OnChildMeasureInvalidated;
+					}
+
 					RemoveLogicalChild(item);
 				}
 			}
@@ -719,6 +733,12 @@ namespace Microsoft.Maui.Controls
 					if (insertIndex < 0)
 					{
 						insertIndex = InternalChildren.IndexOf(item);
+					}
+
+					if (UseLegacyMeasureInvalidatedBehaviorEnabled &&
+						item is VisualElement visual)
+					{
+						visual.MeasureInvalidated += OnChildMeasureInvalidated;
 					}
 
 					InsertLogicalChild(insertIndex, item);

--- a/src/Controls/src/Core/VisualElement/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement/VisualElement.cs
@@ -1349,7 +1349,8 @@ namespace Microsoft.Maui.Controls
 		// rely on the previous behavior or that are affected by the event propagation being slow on deep control
 		// hierarchies. This can be removed once a better fix is in place, such as https://github.com/dotnet/maui/pull/24848
 		// or https://github.com/dotnet/maui/pull/25291.
-		internal static bool UseLegacyMeasureInvalidatedBehaviorEnabled { get; } = AppContext.TryGetSwitch("Microsoft.Maui.UseLegacyMeasureInvalidatedBehavior", out var enabled) && enabled;
+		internal static bool UseLegacyMeasureInvalidatedBehaviorEnabled { get; } =
+			AppContext.TryGetSwitch("Microsoft.Maui.RuntimeFeature.UseLegacyMeasureInvalidatedBehavior", out var enabled) && enabled;
 
 		/// <summary>
 		/// Invalidates the measure of an element.


### PR DESCRIPTION
### Description of Change

PR #23052 introduced some new behavior with unforeseen performance implications (reported in #24551 and #25264). It was included in a servicing release and it's currently blocking us from moving to the latest servicing update. While we already have PRs to rectify the situation (#24823, or alternatively #25291) they are quite intrusive and thus not suitable for servicing.

This leaves us with very few options. I suggest conditionally reverting the changes from #23052 under an `Microsoft.Maui.RuntimeFeature.UseLegacyMeasureInvalidatedBehavior` app context switch. This should allow us to optionally restore the .NET 8.0.82 behavior until a proper fix is in place.
