### PR TITLE
[ci] Templates need xcodeselect

### DIFF
--- a/eng/pipelines/common/maui-templates.yml
+++ b/eng/pipelines/common/maui-templates.yml
@@ -69,7 +69,7 @@ jobs:
     - template: provision.yml
       parameters:
         checkoutDirectory: ${{ parameters.checkoutDirectory }}
-        skipXcode: ${{ ne(parameters.PlatformName, 'macos') }}
+        skipXcode: false
         skipProvisioning: true
 
     - task: DownloadBuildArtifacts@0

--- a/eng/pipelines/common/maui-templates.yml
+++ b/eng/pipelines/common/maui-templates.yml
@@ -69,7 +69,7 @@ jobs:
     - template: provision.yml
       parameters:
         checkoutDirectory: ${{ parameters.checkoutDirectory }}
-        skipXcode: false
+        skipXcode: ${{ ne('${{ PLATFORM_NAME }}', 'macos') }}
         skipProvisioning: true
 
     - task: DownloadBuildArtifacts@0

--- a/eng/pipelines/common/maui-templates.yml
+++ b/eng/pipelines/common/maui-templates.yml
@@ -69,7 +69,7 @@ jobs:
     - template: provision.yml
       parameters:
         checkoutDirectory: ${{ parameters.checkoutDirectory }}
-        skipXcode: ${{ ne('${{ PLATFORM_NAME }}', 'macos') }}
+        skipXcode: false
         skipProvisioning: true
 
     - task: DownloadBuildArtifacts@0

--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -43,6 +43,8 @@ steps:
     #     AUTH_TOKEN_COMPONENTS_MAC_IOS_CERTIFICATE_P12: ${{ parameters.certPass }}
 
     - script: |
+        echo Remove old Xamarin Settings
+        rm -f ~/Library/Preferences/Xamarin/Settings.plist
         echo Mac OS version:
         sw_vers -productVersion
         echo

--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -57,6 +57,8 @@ steps:
         xcrun xcode-select --print-path
         xcodebuild -version
       displayName: Select Xcode Version
+      condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
+
 
   # Provision Additional Software
   #- ${{ if ne(parameters.skipProvisioning, 'true') }}:

--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -58,6 +58,8 @@ steps:
         sudo xcode-select -s /Applications/Xcode_$(REQUIRED_XCODE).app
         xcrun xcode-select --print-path
         xcodebuild -version
+        xcodebuild -downloadAllPlatforms
+        xcodebuild -runFirstLaunch
       displayName: Select Xcode Version
       condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
 


### PR DESCRIPTION
### Description of Change

- Some builds are failing on templates because we are not selecting the correct Xcode on macOS. 
- Theres also a issue where the old [VSMac settings file is taking precedence Xcode select](https://github.com/xamarin/xamarin-macios/issues/11172) so we delete that preferences file 
