### PR TITLE
Skip invalidation on propagation

### DIFF
--- a/src/Compatibility/Core/tests/Compatibility.UnitTests/GridTests.cs
+++ b/src/Compatibility/Core/tests/Compatibility.UnitTests/GridTests.cs
@@ -445,7 +445,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		static void AssertEqualWithTolerance(double a, double b, double tolerance)
 		{
 			var diff = Math.Abs(a - b);
-			Assert.True(diff <= tolerance);
+			Assert.True(diff <= tolerance, $"a: {a} b: {b} tolerance: {tolerance}");
 		}
 
 		[Theory]

--- a/src/Controls/src/Core/ContentPresenter.cs
+++ b/src/Controls/src/Core/ContentPresenter.cs
@@ -130,5 +130,10 @@ namespace Microsoft.Maui.Controls
 			this.ArrangeContent(bounds);
 			return bounds.Size;
 		}
+
+		private protected override void InvalidateMeasureLegacy(InvalidationTrigger trigger, int depth, int depthLeveltoInvalidate)
+		{
+			base.InvalidateMeasureLegacy(trigger, depth, 1);
+		}
 	}
 }

--- a/src/Controls/src/Core/InvalidationEventArgs.cs
+++ b/src/Controls/src/Core/InvalidationEventArgs.cs
@@ -10,7 +10,15 @@ namespace Microsoft.Maui.Controls
 		{
 			Trigger = trigger;
 		}
+		public InvalidationEventArgs(InvalidationTrigger trigger, int depth) : this(trigger)
+		{
+			CurrentInvalidationDepth = depth;
+		}
+
 
 		public InvalidationTrigger Trigger { get; private set; }
+
+
+		public int CurrentInvalidationDepth { set; get; }
 	}
 }

--- a/src/Controls/src/Core/LegacyLayouts/Layout.cs
+++ b/src/Controls/src/Core/LegacyLayouts/Layout.cs
@@ -561,9 +561,14 @@ namespace Microsoft.Maui.Controls.Compatibility
 				}
 			}
 
-			if (depth <= 1)
-			{
+			InvalidateMeasureLegacy(trigger, depth, int.MaxValue);
+		}
 
+		// This lets us override the rules for invalidation on MAUI controls that unfortunately still inheirt from the legacy layout
+		private protected virtual void InvalidateMeasureLegacy(InvalidationTrigger trigger, int depth, int depthLeveltoInvalidate)
+		{
+			if (depth <= depthLeveltoInvalidate)
+			{
 				CurrentInvalidationDepth = depth;
 				if (trigger == InvalidationTrigger.RendererReady)
 				{

--- a/src/Controls/src/Core/LegacyLayouts/StackLayout.cs
+++ b/src/Controls/src/Core/LegacyLayouts/StackLayout.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Maui.Controls.Compatibility
 			ComputeConstraintForView(view, false);
 		}
 
-		internal override void InvalidateMeasureInternal(InvalidationTrigger trigger)
+		internal override void InvalidateMeasureInternal(InvalidationEventArgs trigger)
 		{
 			_layoutInformation = new LayoutInformation();
 			base.InvalidateMeasureInternal(trigger);

--- a/src/Controls/src/Core/Page/Page.cs
+++ b/src/Controls/src/Core/Page/Page.cs
@@ -500,10 +500,13 @@ namespace Microsoft.Maui.Controls
 				SetInheritedBindingContext(TitleView, BindingContext);
 		}
 		
-		internal override void OnChildMeasureInvalidatedInternal(VisualElement child, InvalidationTrigger trigger)
+
+		internal override void OnChildMeasureInvalidatedInternal(VisualElement child, InvalidationTrigger trigger, int depth)
 		{
+			CurrentInvalidationDepth = depth;
 			// TODO: once we remove old Xamarin public signatures we can invoke `OnChildMeasureInvalidated(VisualElement, InvalidationTrigger)` directly
 			OnChildMeasureInvalidated(child, new InvalidationEventArgs(trigger));
+			CurrentInvalidationDepth = 0;
 		}
 
 		/// <summary>
@@ -514,7 +517,9 @@ namespace Microsoft.Maui.Controls
 		protected virtual void OnChildMeasureInvalidated(object sender, EventArgs e)
 		{
 			InvalidationTrigger trigger = (e as InvalidationEventArgs)?.Trigger ?? InvalidationTrigger.Undefined;
-			OnChildMeasureInvalidated((VisualElement)sender, trigger);
+			var depth = CurrentInvalidationDepth;
+			CurrentInvalidationDepth = 0;
+			OnChildMeasureInvalidated((VisualElement)sender, trigger, depth);
 		}
 
 		/// <summary>
@@ -593,7 +598,7 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		internal virtual void OnChildMeasureInvalidated(VisualElement child, InvalidationTrigger trigger)
+		internal virtual void OnChildMeasureInvalidated(VisualElement child, InvalidationTrigger trigger, int depth)
 		{
 			var container = this as IPageContainer<Page>;
 			if (container != null)
@@ -613,7 +618,16 @@ namespace Microsoft.Maui.Controls
 				}
 			}
 
-			InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
+			if (depth <= 1)
+			{
+				CurrentInvalidationDepth = depth;
+				InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
+				CurrentInvalidationDepth = 0;
+			}
+			else
+			{
+				FireMeasureChanged(trigger, depth);
+			}
 		}
 
 		internal void OnAppearing(Action action)

--- a/src/Controls/src/Core/Page/Page.cs
+++ b/src/Controls/src/Core/Page/Page.cs
@@ -503,10 +503,8 @@ namespace Microsoft.Maui.Controls
 
 		internal override void OnChildMeasureInvalidatedInternal(VisualElement child, InvalidationTrigger trigger, int depth)
 		{
-			CurrentInvalidationDepth = depth;
 			// TODO: once we remove old Xamarin public signatures we can invoke `OnChildMeasureInvalidated(VisualElement, InvalidationTrigger)` directly
-			OnChildMeasureInvalidated(child, new InvalidationEventArgs(trigger));
-			CurrentInvalidationDepth = 0;
+			OnChildMeasureInvalidated(child, new InvalidationEventArgs(trigger, depth));
 		}
 
 		/// <summary>
@@ -516,9 +514,18 @@ namespace Microsoft.Maui.Controls
 		/// <param name="e">The event arguments.</param>
 		protected virtual void OnChildMeasureInvalidated(object sender, EventArgs e)
 		{
-			InvalidationTrigger trigger = (e as InvalidationEventArgs)?.Trigger ?? InvalidationTrigger.Undefined;
-			var depth = CurrentInvalidationDepth;
-			CurrentInvalidationDepth = 0;
+			var depth = 0;
+			InvalidationTrigger trigger;
+			if (e is InvalidationEventArgs args)
+			{
+				trigger = args.Trigger;
+				depth = args.CurrentInvalidationDepth;
+			}
+			else
+			{
+				trigger = InvalidationTrigger.Undefined;
+			}
+
 			OnChildMeasureInvalidated((VisualElement)sender, trigger, depth);
 		}
 
@@ -620,9 +627,7 @@ namespace Microsoft.Maui.Controls
 
 			if (depth <= 1)
 			{
-				CurrentInvalidationDepth = depth;
-				InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
-				CurrentInvalidationDepth = 0;
+				InvalidateMeasureInternal(new InvalidationEventArgs(InvalidationTrigger.MeasureChanged, depth));
 			}
 			else
 			{

--- a/src/Controls/src/Core/ScrollView/ScrollView.cs
+++ b/src/Controls/src/Core/ScrollView/ScrollView.cs
@@ -474,5 +474,10 @@ namespace Microsoft.Maui.Controls
 
 			return bounds.Size;
 		}
+
+		private protected override void InvalidateMeasureLegacy(InvalidationTrigger trigger, int depth, int depthLeveltoInvalidate)
+		{
+			base.InvalidateMeasureLegacy(trigger, depth, 1);
+		}
 	}
 }

--- a/src/Controls/src/Core/TemplatedView/TemplatedView.cs
+++ b/src/Controls/src/Core/TemplatedView/TemplatedView.cs
@@ -1,6 +1,7 @@
 #nullable disable
 using System;
 using System.Collections.Generic;
+using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Layouts;
 
@@ -148,6 +149,12 @@ namespace Microsoft.Maui.Controls
 			this.ArrangeContent(bounds);
 			return bounds.Size;
 		}
+
+		private protected override void InvalidateMeasureLegacy(InvalidationTrigger trigger, int depth, int depthLeveltoInvalidate)
+		{
+			base.InvalidateMeasureLegacy(trigger, depth, 1);
+		}
+
 #nullable disable
 
 	}

--- a/src/Controls/tests/Core.UnitTests/PageTests.cs
+++ b/src/Controls/tests/Core.UnitTests/PageTests.cs
@@ -557,7 +557,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 				IsPlatformEnabled = true
 			};
 
-			var scrollView = new ScrollViewCheck()
+			var scrollView = new ScrollViewInvalidationMeasureCheck()
 			{
 				Content = new VerticalStackLayout()
 				{
@@ -567,7 +567,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 				IsPlatformEnabled = true
 			};
 
-			var page = new InvalidatePageCheck()
+			var page = new InvalidatePageInvalidateMeasureCheck()
 			{
 				Content = scrollView
 			};
@@ -581,20 +581,36 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			};
 
 			page.Fired = 0;
-			scrollView.Fired = 0;
+			scrollView.InvalidateMeasureCount = 0;
 			label.InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
 			Assert.Equal(1, fired);
 			Assert.Equal(0, page.Fired);
-			Assert.Equal(0, scrollView.Fired);
+			Assert.Equal(0, scrollView.InvalidateMeasureCount);
 			page.Content.InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
 			Assert.Equal(1, page.Fired);
 		}
 
-		class ScrollViewCheck : ScrollView
+		class LabelInvalidateMeasureCheck : Label
 		{
-			public int Fired { get; set; }
+			public int InvalidateMeasureCount { get; set; }
 
-			public ScrollViewCheck()
+			public LabelInvalidateMeasureCheck()
+			{
+
+			}
+
+			internal override void InvalidateMeasureInternal(InvalidationTrigger trigger)
+			{
+				base.InvalidateMeasureInternal(trigger);
+				InvalidateMeasureCount++;
+			}
+		}
+
+		class ScrollViewInvalidationMeasureCheck : ScrollView
+		{
+			public int InvalidateMeasureCount { get; set; }
+
+			public ScrollViewInvalidationMeasureCheck()
 			{
 				
 			}
@@ -602,15 +618,15 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			internal override void InvalidateMeasureInternal(InvalidationTrigger trigger)
 			{
 				base.InvalidateMeasureInternal(trigger);
-				Fired++;
+				InvalidateMeasureCount++;
 			}
 		}
 
-		class InvalidatePageCheck : ContentPage
+		class InvalidatePageInvalidateMeasureCheck : ContentPage
 		{
 			public int Fired { get; set; }
 
-			public InvalidatePageCheck()
+			public InvalidatePageInvalidateMeasureCheck()
 			{
 				
 			}

--- a/src/Controls/tests/Core.UnitTests/PageTests.cs
+++ b/src/Controls/tests/Core.UnitTests/PageTests.cs
@@ -580,14 +580,14 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 				fired++;
 			};
 
-			page.Fired = 0;
+			page.InvalidateMeasureCount = 0;
 			scrollView.InvalidateMeasureCount = 0;
 			label.InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
 			Assert.Equal(1, fired);
-			Assert.Equal(0, page.Fired);
+			Assert.Equal(0, page.InvalidateMeasureCount);
 			Assert.Equal(0, scrollView.InvalidateMeasureCount);
 			page.Content.InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
-			Assert.Equal(1, page.Fired);
+			Assert.Equal(1, page.InvalidateMeasureCount);
 		}
 
 		class LabelInvalidateMeasureCheck : Label
@@ -599,7 +599,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			}
 
-			internal override void InvalidateMeasureInternal(InvalidationTrigger trigger)
+			internal override void InvalidateMeasureInternal(InvalidationEventArgs trigger)
 			{
 				base.InvalidateMeasureInternal(trigger);
 				InvalidateMeasureCount++;
@@ -615,7 +615,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 				
 			}
 
-			internal override void InvalidateMeasureInternal(InvalidationTrigger trigger)
+			internal override void InvalidateMeasureInternal(InvalidationEventArgs trigger)
 			{
 				base.InvalidateMeasureInternal(trigger);
 				InvalidateMeasureCount++;
@@ -624,17 +624,17 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 		class InvalidatePageInvalidateMeasureCheck : ContentPage
 		{
-			public int Fired { get; set; }
+			public int InvalidateMeasureCount { get; set; }
 
 			public InvalidatePageInvalidateMeasureCheck()
 			{
 				
 			}
 
-			internal override void InvalidateMeasureInternal(InvalidationTrigger trigger)
+			internal override void InvalidateMeasureInternal(InvalidationEventArgs trigger)
 			{
 				base.InvalidateMeasureInternal(trigger);
-				Fired++;
+				InvalidateMeasureCount++;
 			}
 		}
 	}

--- a/src/Controls/tests/Core.UnitTests/PageTests.cs
+++ b/src/Controls/tests/Core.UnitTests/PageTests.cs
@@ -617,6 +617,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			internal override void InvalidateMeasureInternal(InvalidationTrigger trigger)
 			{
+				base.InvalidateMeasureInternal(trigger);
 				Fired++;
 			}
 		}


### PR DESCRIPTION
### Description

The main purpose of https://github.com/dotnet/maui/pull/23052 was to propagate the MeasureInvalidated event up the tree. The problem with doing this is that the `Page` and the `Compatibility.Layout` will fire `InvalidateMeasure` when that propagation gets to them.

This PR shift the needle back a little bit and only fires those paths if the invalidation is fired from a direct child. We still want the event to propagate up the tree for listeners to act on but we don't want anything beyond the immediate parent to invalidate