### PR TITLE
Fix issue with FilePicker for iOS apps running on Mac

### DIFF
--- a/src/Essentials/src/FilePicker/FilePicker.ios.cs
+++ b/src/Essentials/src/FilePicker/FilePicker.ios.cs
@@ -39,7 +39,9 @@ namespace Microsoft.Maui.Storage
 			};
 
 #if !MACCATALYST
-			if (documentPicker.PresentationController != null)
+			// Only assign the PresentationController.Delegate on iOS when it is not running on Mac.
+			if (documentPicker.PresentationController != null && 
+				!(OperatingSystem.IsIOSVersionAtLeast(14, 0) && NSProcessInfo.ProcessInfo.IsiOSApplicationOnMac))
 			{
 				documentPicker.PresentationController.Delegate =
 					new UIPresentationControllerDelegate(() => GetFileResults(null, tcs));


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

Fix #25661 by not assigning the `documentPicker.PresentationController.Delegate` if the iOS app is running on Mac. 

There is already an `#if !MACCATALYST` check to ensure this code is not compiled for Mac Catalyst apps, but we also need to guard against the same problem for iOS apps running on Mac.

### Issues Fixed

Fixes #25661

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
