### PR TITLE
Update developer doc to direct installing VS 17.12 or newer, not 17.10

### DIFF
--- a/.github/DEVELOPMENT.md
+++ b/.github/DEVELOPMENT.md
@@ -4,7 +4,7 @@ This page contains steps to build and run the .NET MAUI repository from source. 
 
 ## Initial setup
    ### Windows
-   - Install VS 17.10 or newer
+   - Install VS 17.12 or newer
       - Follow [these steps](https://learn.microsoft.com/dotnet/maui/get-started/installation?tabs=vswin) to include MAUI
    - If building iOS with pair to Mac: Install current stable Xcode on your Mac. Install from the [App Store](https://apps.apple.com/us/app/xcode/id497799835?mt=12) or [Apple Developer portal](https://developer.apple.com/download/more/?name=Xcode)
    - If you're missing any of the Android SDKs, Visual Studio should prompt you to install them. If it doesn't prompt you then use the [Android SDK Manager](https://learn.microsoft.com/xamarin/android/get-started/installation/android-sdk) to install the necessary SDKs.


### PR DESCRIPTION
### Description of Change

You are really supposed to use 17.12 for .NET9 support. Also, when I used 17.11, though it mostly worked, I saw the error "The 'interceptors' feature is not enabled in this namespace. Add '<InterceptorsNamespaces>...". That error went away when moving to 17.12 P5. See MAUI Teams thread for more details.

### Issues Fixed

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
