### PR TITLE
Better exception for using viewCell with collection View

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/Android/TemplatedItemViewHolder.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/TemplatedItemViewHolder.cs
@@ -57,7 +57,13 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				_itemContentView.Recycle();
 
 				// Create the new content
-				View = (View)template.CreateContent();
+				var content = template.CreateContent();
+				View = content as View;
+
+				if(View is null)
+				{
+					throw new InvalidOperationException($"{template} could not be created from {content}");
+				}
 
 				// Set the binding context _before_ we create the renderer; that way, the bound data will be 
 				// available during OnElementChanged

--- a/src/Controls/src/Core/Handlers/Items/iOS/TemplatedCell.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/TemplatedCell.cs
@@ -168,7 +168,12 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				}
 
 				// Create the content and renderer for the view 
-				var view = itemTemplate.CreateContent() as View;
+				var content = itemTemplate.CreateContent();
+
+				if(content is not View view)
+				{
+					throw new InvalidOperationException($"{itemTemplate} could not be created from {content}");
+				}
 
 				// Set the binding context _before_ we create the renderer; that way, it's available during OnElementChanged
 				view.BindingContext = bindingContext;

--- a/src/Controls/src/Core/Platform/Windows/CollectionView/ItemContentControl.cs
+++ b/src/Controls/src/Core/Platform/Windows/CollectionView/ItemContentControl.cs
@@ -172,7 +172,14 @@ namespace Microsoft.Maui.Controls.Platform
 				// If the content has never been realized (i.e., this is a new instance), 
 				// or if we need to switch DataTemplates (because this instance is being recycled)
 				// then we'll need to create the content from the template 
-				_visualElement = dataTemplate.CreateContent() as VisualElement;
+				var content = dataTemplate.CreateContent();
+				_visualElement = content as VisualElement;
+
+				if(_visualElement is null)
+				{
+					throw new InvalidOperationException($"{dataTemplate} could not be created from {content}");
+				}
+
 				_visualElement.BindingContext = dataContext;
 				_handler = _visualElement.ToHandler(mauiContext);
 


### PR DESCRIPTION
### Description of Change

The exception thrown when using ViewCell within a DataTemplate in CollectionView is currently uninformative and inconsistent across platforms. This inconsistency can confuse developers who may not realize that ViewCell is incompatible with CollectionView and may frequently encounter this issue.

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/24379

|Before|After|
|--|--|
|Android||
|<img src="https://github.com/user-attachments/assets/cc6516b9-3f82-49cc-ad92-00973a3b82a5" width="300px"/>|<img src="https://github.com/user-attachments/assets/a447f366-9161-4ac8-a0b2-871eec8b55a3" width="300px"/>|
|iOS||
|<img src="https://github.com/user-attachments/assets/bbe64f3f-f38f-477b-907d-26288855a7f6" width="300px"/>|<img src="https://github.com/user-attachments/assets/9f411e6e-23fd-4756-b5e7-a81dfc196920" width="300px"/>|
