### PR TITLE
Fix minor online API docs warnings

### DIFF
--- a/src/Controls/src/Core/NavigableElement/NavigableElement.cs
+++ b/src/Controls/src/Core/NavigableElement/NavigableElement.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Maui.Controls
 		/// <summary>Bindable property for <see cref="Navigation"/>.</summary>
 		public static readonly BindableProperty NavigationProperty = NavigationPropertyKey.BindableProperty;
 
-		/// <inheritdoc/>
+		/// <inheritdoc cref="StyleableElement.StyleProperty" />
 		public static readonly new BindableProperty StyleProperty = StyleableElement.StyleProperty;
 
 		internal NavigableElement()

--- a/src/Controls/src/Core/VisualElement/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement/VisualElement.cs
@@ -16,14 +16,14 @@ namespace Microsoft.Maui.Controls
 	/// An <see cref="Element" /> that occupies an area on the screen, has a visual appearance, and can obtain touch input.
 	/// </summary>
 	/// <remarks>
-	/// The base class for most Microsoft.Maui.Controls on-screen elements. Provides most properties, events, and methods for presenting an item on screen.
+	/// The base class for most .NET MAUI on-screen elements. Provides most properties, events, and methods for presenting an item on screen.
 	/// </remarks>
 	public partial class VisualElement : NavigableElement, IAnimatable, IVisualElementController, IResourcesProvider, IStyleElement, IFlowDirectionController, IPropertyPropagationController, IVisualController, IWindowController, IView, IControlsVisualElement
 	{
 		/// <summary>Bindable property for <see cref="NavigableElement.Navigation"/>.</summary>
 		public new static readonly BindableProperty NavigationProperty = NavigableElement.NavigationProperty;
 
-		/// <inheritdoc/>
+		/// <inheritdoc cref="StyleableElement.StyleProperty" />
 		public new static readonly BindableProperty StyleProperty = NavigableElement.StyleProperty;
 
 		bool _inputTransparentExplicit = (bool)InputTransparentProperty.DefaultValue;


### PR DESCRIPTION
### Description of Change

While gathering the API docs for .NET 9 GA there were 2 warnings that came out of the build system. Don't need immediate fixing, but good to have them out of the way.

Additionally, 1 Xamarin.Forms -> Microsoft.Maui.Controls replacement error 😅 