### PR TITLE
[Windows] Fix for the screen does not display when changing the CurrentPage of a TabbedPage

### DIFF
--- a/src/Controls/src/Core/Page/Page.cs
+++ b/src/Controls/src/Core/Page/Page.cs
@@ -502,8 +502,7 @@ namespace Microsoft.Maui.Controls
 		
 		internal override void OnChildMeasureInvalidatedInternal(VisualElement child, InvalidationTrigger trigger)
 		{
-			// TODO: once we remove old Xamarin public signatures we can invoke `OnChildMeasureInvalidated(VisualElement, InvalidationTrigger)` directly
-			OnChildMeasureInvalidated(child, new InvalidationEventArgs(trigger));
+			InvokeMeasureInvalidated(InvalidationTrigger.MeasureChanged);
 		}
 
 		/// <summary>

--- a/src/Controls/src/Core/VisualElement/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement/VisualElement.cs
@@ -1369,6 +1369,11 @@ namespace Microsoft.Maui.Controls
 			InvalidateMeasureInternal(trigger);
 		}
 
+		internal void InvokeMeasureInvalidated(InvalidationTrigger trigger)
+		{
+			MeasureInvalidated?.Invoke(this, new InvalidationEventArgs(trigger));
+		}
+
 		internal virtual void InvalidateMeasureInternal(InvalidationTrigger trigger)
 		{
 			_measureCache.Clear();

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue25518.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue25518.cs
@@ -58,11 +58,16 @@ namespace Maui.Controls.Sample.Issues
 			CurrentPage = Children[0];
 		}
 
-		public void SwitchTabMultiPageAsync()
+		public void SwitchTabSecondPage()
 		{
 			var page = new SecondPage25518() { Title = "Two" };
 			Children.Add(page);
 			CurrentPage = Children[1];
+		}
+
+		public void SwitchTabFirstPage()
+		{
+			CurrentPage = Children[0];
 		}
 	}
 
@@ -82,7 +87,7 @@ namespace Maui.Controls.Sample.Issues
 				if (page is Issue25518 multiLayerPage)
 				{
 					var tabMultiPage = multiLayerPage.Children.FirstOrDefault() as TabMultiPage25518;
-					tabMultiPage?.SwitchTabMultiPageAsync();
+					tabMultiPage?.SwitchTabSecondPage();
 				}
 			};
 
@@ -94,12 +99,32 @@ namespace Maui.Controls.Sample.Issues
 	{
 		public SecondPage25518()
 		{
-			Content = new Label 
+			var button = new Button
+			{
+				Text = "Move to main page",
+				AutomationId = "MoveToMainPage"
+			};
+
+			button.Clicked += (sender, e) =>
+			{
+				var page = Application.Current.MainPage;
+				if (page is Issue25518 multiLayerPage)
+				{
+					var tabMultiPage = multiLayerPage.Children.FirstOrDefault() as TabMultiPage25518;
+					tabMultiPage?.SwitchTabFirstPage();
+				}
+			};
+			var label = new Label 
 			{ 
 				Text = "Welcome to Second Page",
 				VerticalOptions = LayoutOptions.Center, 
 				HorizontalOptions = LayoutOptions.Center 
 			};
+
+			var stackLayout = new StackLayout();
+			stackLayout.Children.Add(label);
+			stackLayout.Children.Add(button);
+			Content = stackLayout;
 		}
 	}
 

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue25518.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue25518.cs
@@ -1,0 +1,183 @@
+﻿using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Platform;
+
+namespace Maui.Controls.Sample.Issues
+{
+	[Issue(IssueTracker.Github, 25518, "[Windows] Fix for the screen does not display when changing the CurrentPage of a TabbedPage", PlatformAffected.UWP)]
+	public partial class Issue25518 : ContentPage
+	{
+		public Issue25518()
+		{
+			Children = new ObservableCollection<Page>();
+			Children.CollectionChanged += Children_CollectionChanged;
+
+			var page = new TabMultiPage25518();
+			Children.Add(page);
+
+		}
+
+		private void Children_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+		{
+			if (e.Action == NotifyCollectionChangedAction.Add)
+			{
+				foreach (var item in e.NewItems)
+				{
+					var page = item as Page;
+					page.Parent = this;
+				}
+			}
+			else if (e.Action == NotifyCollectionChangedAction.Remove)
+			{
+				foreach (var item in e.OldItems)
+				{
+					var page = item as Page;
+					page.Parent = null;
+				}
+			}
+			else if (e.Action == NotifyCollectionChangedAction.Reset)
+			{
+				foreach (var item in e.OldItems)
+				{
+					var page = item as Page;
+					page.Parent = null;
+				}
+			}
+		}
+
+		public ObservableCollection<Page> Children { get; }
+	}
+
+	public class TabMultiPage25518 : TabbedPage
+	{
+		public TabMultiPage25518()
+		{
+			var page = new FirstPage25518() { Title = "One" };
+			Children.Add(page);
+			CurrentPage = Children[0];
+		}
+
+		public void SwitchTabMultiPageAsync()
+		{
+			var page = new SecondPage25518() { Title = "Two" };
+			Children.Add(page);
+			CurrentPage = Children[1];
+		}
+	}
+
+	public class FirstPage25518 : ContentPage
+	{
+		public FirstPage25518()
+		{
+			var button = new Button 
+			{ 
+				Text = "Move to second page", 
+				AutomationId="MoveToSecondPage" 
+			};
+
+			button.Clicked += (sender, e) =>
+			{
+				var page = Application.Current.MainPage;
+				if (page is Issue25518 multiLayerPage)
+				{
+					var tabMultiPage = multiLayerPage.Children.FirstOrDefault() as TabMultiPage25518;
+					tabMultiPage?.SwitchTabMultiPageAsync();
+				}
+			};
+
+			Content = button;
+		}
+	}
+
+	public class SecondPage25518 : ContentPage
+	{
+		public SecondPage25518()
+		{
+			Content = new Label 
+			{ 
+				Text = "Welcome to Second Page",
+				VerticalOptions = LayoutOptions.Center, 
+				HorizontalOptions = LayoutOptions.Center 
+			};
+		}
+	}
+
+#if WINDOWS
+
+	public partial class MultiLayerPageHandler25518 : ViewHandler<Issue25518, ContentPanel>
+	{
+
+		internal class ContentPanel25518 : ContentPanel
+		{
+
+		}
+
+		public static PropertyMapper<Issue25518, MultiLayerPageHandler25518> PropertyMapper = new PropertyMapper<Issue25518, MultiLayerPageHandler25518>(ViewHandler.ViewMapper)
+		{
+		};
+
+		public MultiLayerPageHandler25518() : base(PropertyMapper)
+		{
+		}
+
+		protected override ContentPanel CreatePlatformView()
+		{
+			var view = new ContentPanel25518()
+			{
+				CrossPlatformLayout = VirtualView,
+			};
+
+			return view;
+		}
+
+		protected override void ConnectHandler(ContentPanel platformView)
+		{
+			base.ConnectHandler(platformView);
+			platformView.Loaded += OnLoaded;
+
+			foreach (var child in VirtualView.Children)
+			{
+				var element = child.ToPlatform(MauiContext);
+				platformView.Children.Add(element);
+			}
+		}
+
+		protected override void DisconnectHandler(ContentPanel platformView)
+		{
+			platformView.Loaded -= OnLoaded;
+			base.DisconnectHandler(platformView);
+		}
+
+		private void OnLoaded(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
+		{
+			if (this is IPlatformViewHandler handler)
+			{
+				if (handler.VirtualView is Issue25518 multiLayerPage)
+				{
+					foreach (var child in multiLayerPage.Children)
+					{
+						child.SendAppearing();
+					}
+				}
+			}
+		}
+	}
+
+#endif
+
+	public static class Issue25518Extensions
+	{
+		public static MauiAppBuilder Issue25518ConfigureHandlers(this MauiAppBuilder builder)
+		{
+			builder.ConfigureMauiHandlers(handlers =>
+			{
+#if WINDOWS
+				handlers.AddHandler(typeof(Issue25518), typeof(MultiLayerPageHandler25518));
+#endif
+			});
+
+			return builder;
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/MauiProgram.cs
+++ b/src/Controls/tests/TestCases.HostApp/MauiProgram.cs
@@ -25,7 +25,8 @@ namespace Maui.Controls.Sample
 				.Issue18720AddMappers()
 				.Issue18720EditorAddMappers()
 				.Issue18720DatePickerAddMappers()
-				.Issue18720TimePickerAddMappers();
+				.Issue18720TimePickerAddMappers()
+			    .Issue25518ConfigureHandlers();
 
 #if IOS || MACCATALYST
 

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25518.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25518.cs
@@ -1,0 +1,27 @@
+﻿#if WINDOWS
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue25518 : _IssuesUITest
+	{
+		public Issue25518(TestDevice device) : base(device)
+		{
+		}
+
+		public override string Issue => "[Windows] Fix for the screen does not display when changing the CurrentPage of a TabbedPage";
+
+		[Test]
+		[Category(UITestCategories.TabbedPage)]
+		public void VerifyTabbedPageContent()
+		{
+			App.WaitForElement("MoveToSecondPage");
+			App.Tap("MoveToSecondPage");
+
+			VerifyScreenshot();
+		}
+	}
+}
+#endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25518.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25518.cs
@@ -20,6 +20,11 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 			App.WaitForElement("MoveToSecondPage");
 			App.Tap("MoveToSecondPage");
 
+			App.WaitForElement("MoveToMainPage");
+			App.Tap("MoveToMainPage");
+
+			App.WaitForElement("MoveToSecondPage");
+			App.Tap("MoveToSecondPage");
 			VerifyScreenshot();
 		}
 	}


### PR DESCRIPTION
### Root cause
While navigating to the next page, the MeasureOverride method is repeatedly called on the parent, which prevents the Arrange method from being called.
 
### Description of change
 
The OnChildMeasureInvalidatedInternal method has been modified to ensure that measure invalidation is only propagated to the parent when necessary, preventing unnecessary repeated calls to OnChildMeasureInvalidatedInternal.

### References

- Breaking PR: https://github.com/dotnet/maui/pull/23052
- Fix Reference: https://github.com/dotnet/maui/pull/24823

### Issues Fixed

Fixes #25518

### Tested the behaviour in the following platforms

- [x] Android
- [x] Windows
- [ ] iOS
- [ ] Mac

### Screenshot


https://github.com/user-attachments/assets/f722f3d0-fc58-40b1-a81e-518ee8c81faa


