### PR TITLE
Toggling Header/Footer in CollectionView Dynamically throws an exception

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
@@ -577,7 +577,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 				uiView?.Dispose();
 				uiView = null;
-
+				formsElement?.Handler?.DisconnectHandler();
 				formsElement = null;
 			}
 			else

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue25724.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue25724.xaml
@@ -1,0 +1,51 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Maui.Controls.Sample.Issues.Issue25724"
+             xmlns:local="clr-namespace:Maui.Controls.Sample.Issues"
+             x:Name="ThisMainPage"
+             Title="Main Page">
+
+  <Grid RowDefinitions="Auto,*">
+
+    <HorizontalStackLayout
+          Grid.Row="0"
+          Padding="20"
+          HorizontalOptions="Center"
+          Spacing="20">
+       <Button AutomationId="ToggleHeaderButton" Text="Toggle Header" Clicked="ToggleHeader"></Button>
+        <Button AutomationId="ToggleFooterButton" Text="Toggle Footer" Clicked="ToggleFooter"></Button>
+    </HorizontalStackLayout>
+
+    <CollectionView x:Name="CollectionView" Grid.Row="1" ItemsSource="{Binding ItemList}">
+
+      <CollectionView.Header>
+          <Label
+              Padding="10"
+              FontAttributes="Bold"
+              FontSize="Large"
+              Text="This Is A Header" />
+      </CollectionView.Header>
+
+      <CollectionView.ItemTemplate>
+        <DataTemplate>
+          <Label Padding="20,5,5,5" Text="{Binding .}" />
+        </DataTemplate>
+      </CollectionView.ItemTemplate>
+
+      <CollectionView.EmptyView>
+          <Label Padding="20,5,5,5" Text="Empty" />
+      </CollectionView.EmptyView>
+
+      <CollectionView.Footer>
+          <Label
+              Padding="10"
+              FontAttributes="Bold"
+              FontSize="Large"
+              Text="This Is A Footer" />
+      </CollectionView.Footer>
+
+    </CollectionView>
+
+  </Grid>
+</ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue25724.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue25724.xaml.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.ObjectModel;
+﻿#nullable enable
+using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Windows.Input;

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue25724.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue25724.xaml.cs
@@ -1,0 +1,53 @@
+﻿using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Windows.Input;
+
+namespace Maui.Controls.Sample.Issues
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	[Issue(IssueTracker.Github, 25724, "ObjectDisposedException When Toggling Header/Footer in CollectionView Dynamically", PlatformAffected.iOS)]
+
+	public partial class Issue25724 : ContentPage
+	{
+		object? header;
+		object? footer;
+		public Issue25724()
+		{
+			InitializeComponent();
+			BindingContext = new Issue25724ViewModel();
+		}
+
+		void ToggleHeader(object sender, System.EventArgs e)
+		{
+			header = CollectionView.Header ?? header;
+
+			if (CollectionView.Header == null)
+				CollectionView.Header = header;
+			else
+				CollectionView.Header = null;
+		}
+
+		void ToggleFooter(object sender, System.EventArgs e)
+		{
+			footer = CollectionView.Footer ?? footer;
+
+			if (CollectionView.Footer == null)
+				CollectionView.Footer = footer;
+			else
+				CollectionView.Footer = null;
+		}
+
+		internal class Issue25724ViewModel
+		{
+			public ObservableCollection<string> ItemList { get; set; }
+			public Issue25724ViewModel()
+			{
+				// Initialize the ItemList
+				ItemList = new ObservableCollection<string>();
+			}
+
+		}
+
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/CollectionView/CollectionViewUITests.HeaderAndFooter.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/CollectionView/CollectionViewUITests.HeaderAndFooter.cs
@@ -74,9 +74,6 @@ namespace Microsoft.Maui.TestCases.Tests
 
         [Test]
         [Category(UITestCategories.CollectionView)]
-#if TEST_FAILS_ON_IOS || TEST_FAILS_ON_CATALYST
-        [Ignore("Currently fails on iOS & MAC platform; UI Behavior is different in iOS with collectionViewHandler than Android and Windows ")]
-#endif
         public void HeaderFooterGridHorizontalWorks()
         {
             // Navigate to the selection galleries

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/CollectionView/CollectionViewUITests.HeaderAndFooter.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/CollectionView/CollectionViewUITests.HeaderAndFooter.cs
@@ -74,6 +74,9 @@ namespace Microsoft.Maui.TestCases.Tests
 
         [Test]
         [Category(UITestCategories.CollectionView)]
+#if TEST_FAILS_ON_IOS || TEST_FAILS_ON_CATALYST
+        [Ignore("Currently fails on iOS & MAC platform; UI Behavior is different in iOS with collectionViewHandler than Android and Windows ")]
+#endif
         public void HeaderFooterGridHorizontalWorks()
         {
             // Navigate to the selection galleries

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25724.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25724.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿#if IOS || MACCATALYST
+using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
 
@@ -21,3 +22,4 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		}
 	}
 }
+#endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25724.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25724.cs
@@ -1,0 +1,23 @@
+﻿using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	internal class Issue25724 : _IssuesUITest
+	{
+		public Issue25724(TestDevice device) : base(device) { }
+
+		public override string Issue => "ObjectDisposedException When Toggling Header/Footer in CollectionView Dynamically";
+
+		[Test]
+		[Category(UITestCategories.CollectionView)]
+		public void CollectionViewDynamicHeaderShouldNotCrashOnDisplay()
+		{
+			App.WaitForElement("This Is A Header");
+            App.Tap("ToggleHeaderButton"); // This is the button that toggles the header to null
+            App.Tap("ToggleHeaderButton");// This is the button that toggles the header back to the original value
+            App.WaitForElement("This Is A Header");
+		}
+	}
+}


### PR DESCRIPTION
### Root Cause

The issue occurred when toggling the header template in a `CollectionView`. Specifically, when the header was set to `null` and then re-assigned, an `ObjectDisposedException` was thrown. This happened because the platform UIView associated with the header was disposed when toggled off, but the handler for the `VisualElement `was not cleared, leading to a stale reference.
 
### Description of Change

To resolve the issue, I utilized the `DisconnectHandler()` method provided by MAUI, which cleanly disconnects the handler from its associated platform view. This ensures that all resources tied to the handler are properly released, preventing any stale references. After calling `DisconnectHandler()`, `formsElement` is set to `null `to fully clear the reference, allowing the framework to initialize a fresh handler as needed. This approach maintains a consistent view lifecycle and prevents exceptions caused by attempting to access disposed views.

### Tested the behaviour in the following platforms
 
- [ ] Android
- [ ] Windows
- [x] iOS
- [x] Mac

### Issues Fixed
 
Fixes https://github.com/dotnet/maui/issues/25724

### Screenshots

| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video width="300" height="600"  src="https://github.com/user-attachments/assets/df3cc728-2664-411d-9b87-cfcb92d1b3f5"> | <video width="300" height="600"  src="https://github.com/user-attachments/assets/434fc1c8-4d0a-475f-b8ab-a4dddaf847b0">) |
