### PR TITLE
Download using new APIs

### DIFF
--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -345,7 +345,7 @@ Task("dotnet-pack-maui")
 
 Task("dotnet-pack-additional")
     .WithCriteria(RunPackTarget())
-    .Does(() =>
+    .Does(async () =>
     {
         // Download some additional symbols that need to be archived along with the maui symbols:
         //  - _NativeAssets.windows
@@ -353,16 +353,14 @@ Task("dotnet-pack-additional")
         //     - libHarfBuzzSharp.pdb
         var assetsDir = $"./artifacts/additional-assets";
         var nativeAssetsVersion = XmlPeek("./eng/Versions.props", "/Project/PropertyGroup/_SkiaSharpNativeAssetsVersion");
-        NuGetInstall("_NativeAssets.windows", new NuGetInstallSettings
-        {
-            Version = nativeAssetsVersion,
-            ExcludeVersion = true,
-            OutputDirectory = assetsDir,
-            Source = new[] { "https://pkgs.dev.azure.com/xamarin/public/_packaging/SkiaSharp/nuget/v3/index.json" },
-        });
+        await DownloadNuGetPackageAsync(
+            "_NativeAssets.windows",
+            nativeAssetsVersion,
+            assetsDir,
+            "https://pkgs.dev.azure.com/xamarin/public/_packaging/SkiaSharp/nuget/v3/index.json");
+        Zip(assetsDir, $"{assetsDir}.zip");
         foreach (var nupkg in GetFiles($"{assetsDir}/**/*.nupkg"))
             DeleteFile(nupkg);
-        Zip(assetsDir, $"{assetsDir}.zip");
     });
 
 Task("dotnet-pack-library-packs")

--- a/eng/devices/windows.cake
+++ b/eng/devices/windows.cake
@@ -96,7 +96,7 @@ Task("GenerateMsixCert")
 	{
 		Information("Generating cert");
 		var rsa = RSA.Create();
-		var req = new CertificateRequest("CN=" + certCN, rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+		var req = new CertificateRequest("CN=" + certCN, rsa, System.Security.Cryptography.HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
 
 		req.CertificateExtensions.Add(new X509EnhancedKeyUsageExtension(new OidCollection
 		{


### PR DESCRIPTION

### Description of Change

mono is no longer found on machines, so we need to use the NuGet APIs directly.