### PR TITLE
Differentiate app icon & splash screen colors for sample content template

### DIFF
--- a/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
+++ b/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
@@ -48,10 +48,20 @@
 
 	<ItemGroup>
 		<!-- App Icon -->
+<!--#if (!IncludeSampleContent) -->
 		<MauiIcon Include="Resources\AppIcon\appicon.svg" ForegroundFile="Resources\AppIcon\appiconfg.svg" Color="#512BD4" />
+<!--#endif -->
+<!--#if (IncludeSampleContent) -->
+		<MauiIcon Include="Resources\AppIcon\appicon.svg" ForegroundFile="Resources\AppIcon\appiconfg.svg" Color="#17171a" />
+<!--#endif -->
 
 		<!-- Splash Screen -->
+<!--#if (!IncludeSampleContent) -->
 		<MauiSplashScreen Include="Resources\Splash\splash.svg" Color="#512BD4" BaseSize="128,128" />
+<!--#endif -->
+<!--#if (IncludeSampleContent) -->
+		<MauiSplashScreen Include="Resources\Splash\splash.svg" Color="#17171a" BaseSize="128,128" />
+<!--#endif -->
 
 		<!-- Images -->
 		<MauiImage Include="Resources\Images\*" />


### PR DESCRIPTION
### Description of Change

Adds a slightly different, fitting color for the new .NET MAUI template when you choose include the sample content. This change was lost with the initial implementation of this.
