### PR TITLE
[localization] Fix template names in Japanese localization for .NET MAUI ContentPage and Window

### DIFF
--- a/src/Templates/src/templates/maui-contentpage-csharp/.template.config/localize/templatestrings.ja.json
+++ b/src/Templates/src/templates/maui-contentpage-csharp/.template.config/localize/templatestrings.ja.json
@@ -1,6 +1,6 @@
 {
   "author": "Microsoft",
-  "name": "..NET MAUI ContentPage (C#)",
+  "name": ".NET MAUI ContentPage (C#)",
   "description": "A page for displaying content using C#.",
   "postActions/openInEditor/description": "エディターで NewPage1.cs を開きます。",
   "symbols/namespace/description": "生成されたコードの名前空間。"

--- a/src/Templates/src/templates/maui-window-csharp/.template.config/localize/templatestrings.ja.json
+++ b/src/Templates/src/templates/maui-window-csharp/.template.config/localize/templatestrings.ja.json
@@ -1,6 +1,6 @@
 {
   "author": "Microsoft",
-  "name": "..NET MAUI Window (C#)",
+  "name": ".NET MAUI Window (C#)",
   "description": "A window for displaying a page using C#.",
   "postActions/openInEditor/description": "エディターで NewWindow1.cs を開きます。",
   "symbols/namespace/description": "生成されたコードの名前空間。"


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

<!-- Enter description of the fix in this section -->

Due to a localization error, the template name is unintended.
This PR will correct that.

Current behaviors

```sh
$ dotnet new list
これらのテンプレートは、入力:  と一致しました

テンプレート名                                   短い名前                    言語        タグ                                                                         
-----------------------------------------------  --------------------------  ----------  -----------------------------------------------------------------------------
..NET MAUI ContentPage (C#)                      maui-page-csharp            [C#]        MAUI/Android/iOS/macOS/Mac Catalyst/WinUI/Tizen/Xaml/Code                    
..NET MAUI Window (C#)                           maui-window-csharp          [C#]        MAUI/Android/iOS/macOS/Mac Catalyst/WinUI/Tizen/Xaml/Code                    
.NET MAUI Blazor Hybrid and Web App              maui-blazor-web             [C#]        MAUI/Android/iOS/macOS/Mac Catalyst/Windows/Tizen/Blazor/Blazor Hybrid/Mobile
.NET MAUI Blazor アプリ                          maui-blazor                 [C#]        MAUI/Android/iOS/macOS/Mac Catalyst/Windows/Tizen/Blazor/Blazor Hybrid/Mobile
```


### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes # ... None

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
