### PR TITLE
[ci] Try to call trim

### DIFF
--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/BlazorTemplateTest.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/BlazorTemplateTest.cs
@@ -4,40 +4,43 @@
 public class BlazorTemplateTest : BaseTemplateTests
 {
 	[Test]
-	// Parameters:  target framework, build config, dotnet new additional parameters
+	// Parameters:  target framework, build config, dotnet new additional parameters, use tricky project name, additional dotnet build parameters
 
 	// First, default scenarios
-	[TestCase(DotNetCurrent, "Debug", "", false)]
-	[TestCase(DotNetCurrent, "Release", "", false)]
+	[TestCase(DotNetCurrent, "Debug", "", false, "")]
+	[TestCase(DotNetCurrent, "Release", "", false, "TrimMode=partial")]
+	[TestCase(DotNetCurrent, "Release", "", false, "TrimMode=full")]
 
 	// Then, scenarios with additional template parameters:
 	// - Interactivity Location: None/WASM/Server/Auto
 	// - Empty vs. With Sample Content
 	// - ProgramMain vs. TopLevel statements
 	// And alternately testing other options for a healthy mix.
-	[TestCase(DotNetCurrent, "Debug", "-I None --Empty", false)]
-	[TestCase(DotNetCurrent, "Release", "-I WebAssembly --Empty", false)]
-	[TestCase(DotNetCurrent, "Debug", "-I Server --Empty", false)]
-	[TestCase(DotNetCurrent, "Release", "-I Auto --Empty", false)]
+	// additionalDotNetBuildParams is a space-separated list of additional properties to pass to .NET MAUI build
+	// Like "TrimMode=partial" for faster builds with AOT
+	[TestCase(DotNetCurrent, "Debug", "-I None --Empty", false, "")]
+	[TestCase(DotNetCurrent, "Release", "-I WebAssembly --Empty", false, "TrimMode=partial")]
+	[TestCase(DotNetCurrent, "Debug", "-I Server --Empty", false, "")]
+	[TestCase(DotNetCurrent, "Release", "-I Auto --Empty", false, "TrimMode=partial")]
 	[TestCase(DotNetCurrent, "Debug", "-I None", false)]
-	[TestCase(DotNetCurrent, "Release", "-I WebAssembly", false)]
-	[TestCase(DotNetCurrent, "Debug", "-I Server", false)]
-	[TestCase(DotNetCurrent, "Release", "-I Auto", false)]
-	[TestCase(DotNetCurrent, "Debug", "-I None --Empty --UseProgramMain", false)]
-	[TestCase(DotNetCurrent, "Release", "-I WebAssembly --Empty --UseProgramMain", false)]
-	[TestCase(DotNetCurrent, "Debug", "-I Server --Empty --UseProgramMain", false)]
-	[TestCase(DotNetCurrent, "Release", "-I Auto --Empty --UseProgramMain", false)]
-	[TestCase(DotNetCurrent, "Debug", "-I None --UseProgramMain", false)]
-	[TestCase(DotNetCurrent, "Release", "-I WebAssembly --UseProgramMain", false)]
-	[TestCase(DotNetCurrent, "Debug", "-I Server --UseProgramMain", false)]
-	[TestCase(DotNetCurrent, "Release", "-I Auto --UseProgramMain", false)]
+	[TestCase(DotNetCurrent, "Release", "-I WebAssembly", false, "TrimMode=partial")]
+	[TestCase(DotNetCurrent, "Debug", "-I Server", false, "")]
+	[TestCase(DotNetCurrent, "Release", "-I Auto", false, "TrimMode=partial")]
+	[TestCase(DotNetCurrent, "Debug", "-I None --Empty --UseProgramMain", false, "")]
+	[TestCase(DotNetCurrent, "Release", "-I WebAssembly --Empty --UseProgramMain", false, "TrimMode=partial")]
+	[TestCase(DotNetCurrent, "Debug", "-I Server --Empty --UseProgramMain", false, "")]
+	[TestCase(DotNetCurrent, "Release", "-I Auto --Empty --UseProgramMain", false, "TrimMode=partial")]
+	[TestCase(DotNetCurrent, "Debug", "-I None --UseProgramMain", false, "")]
+	[TestCase(DotNetCurrent, "Release", "-I WebAssembly --UseProgramMain", false, "TrimMode=partial")]
+	[TestCase(DotNetCurrent, "Debug", "-I Server --UseProgramMain", false, "")]
+	[TestCase(DotNetCurrent, "Release", "-I Auto --UseProgramMain", false, "TrimMode=partial")]
 
 	// Then, some scenarios with tricky names in Debug builds only
 	// This doesn't work on Android in Release, so we skip that for now
 	// See https://github.com/dotnet/android/issues/9107
 	// [TestCase(DotNetCurrent, "Debug", "", true)]
 	// [TestCase(DotNetCurrent, "Debug", "-I Server --UseProgramMain", true)]
-	public void BuildMauiBlazorWebSolution(string framework, string config, string additionalDotNetNewParams, bool useTrickyProjectName)
+	public void BuildMauiBlazorWebSolution(string framework, string config, string additionalDotNetNewParams, bool useTrickyProjectName, string additionalDotNetBuildParams)
 	{
 		const string templateShortName = "maui-blazor-web";
 
@@ -45,6 +48,13 @@ public class BlazorTemplateTest : BaseTemplateTests
 		if (useTrickyProjectName)
 		{
 			solutionProjectDir += "&More";
+		}
+
+		var buildProps = BuildProps;
+
+		if (additionalDotNetBuildParams is not "" and not null)
+		{
+			additionalDotNetBuildParams.Split(" ").ToList().ForEach(p => buildProps.Add(p));
 		}
 
 		var webAppProjectDir = Path.Combine(solutionProjectDir, Path.GetFileName(solutionProjectDir) + ".Web");
@@ -70,8 +80,8 @@ public class BlazorTemplateTest : BaseTemplateTests
 		Assert.IsTrue(DotnetInternal.Build(webAppProjectFile, config, target: "", properties: BuildProps, msbuildWarningsAsErrors: true),
 			$"Project {Path.GetFileName(webAppProjectFile)} failed to build. Check test output/attachments for errors.");
 
-		TestContext.WriteLine($"Building .NET MAUI app: {mauiAppProjectFile}");
-		Assert.IsTrue(DotnetInternal.Build(mauiAppProjectFile, config, target: "", properties: BuildProps, msbuildWarningsAsErrors: true),
+		TestContext.WriteLine($"Building .NET MAUI app: {mauiAppProjectFile} props: {buildProps}");
+		Assert.IsTrue(DotnetInternal.Build(mauiAppProjectFile, config, target: "", properties: buildProps, msbuildWarningsAsErrors: true),
 			$"Project {Path.GetFileName(mauiAppProjectFile)} failed to build. Check test output/attachments for errors.");
 	}
 }

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/BlazorTemplateTest.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/BlazorTemplateTest.cs
@@ -9,7 +9,7 @@ public class BlazorTemplateTest : BaseTemplateTests
 	// First, default scenarios
 	[TestCase(DotNetCurrent, "Debug", "", false, "")]
 	[TestCase(DotNetCurrent, "Release", "", false, "TrimMode=partial")]
-	[TestCase(DotNetCurrent, "Release", "", false, "TrimMode=full")]
+	//[TestCase(DotNetCurrent, "Release", "", false, "TrimMode=full")]
 
 	// Then, scenarios with additional template parameters:
 	// - Interactivity Location: None/WASM/Server/Auto
@@ -22,7 +22,7 @@ public class BlazorTemplateTest : BaseTemplateTests
 	[TestCase(DotNetCurrent, "Release", "-I WebAssembly --Empty", false, "TrimMode=partial")]
 	[TestCase(DotNetCurrent, "Debug", "-I Server --Empty", false, "")]
 	[TestCase(DotNetCurrent, "Release", "-I Auto --Empty", false, "TrimMode=partial")]
-	[TestCase(DotNetCurrent, "Debug", "-I None", false)]
+	[TestCase(DotNetCurrent, "Debug", "-I None", false, "")]
 	[TestCase(DotNetCurrent, "Release", "-I WebAssembly", false, "TrimMode=partial")]
 	[TestCase(DotNetCurrent, "Debug", "-I Server", false, "")]
 	[TestCase(DotNetCurrent, "Release", "-I Auto", false, "TrimMode=partial")]

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/SimpleTemplateTest.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/SimpleTemplateTest.cs
@@ -54,7 +54,7 @@ public class SimpleTemplateTest : BaseTemplateTests
 
 		if (additionalDotNetBuildParams is not "" and not null)
 		{
-			additionalDotNetBuildParams.Split("").ToList().ForEach(p => buildProps.Add(p));
+			additionalDotNetBuildParams.Split(" ").ToList().ForEach(p => buildProps.Add(p));
 		}
 
 		string target = shouldPack ? "Pack" : "";
@@ -150,7 +150,7 @@ public class SimpleTemplateTest : BaseTemplateTests
 
 		if (additionalDotNetBuildParams is not "" and not null)
 		{
-			additionalDotNetBuildParams.Split("").ToList().ForEach(p => buildProps.Add(p));
+			additionalDotNetBuildParams.Split(" ").ToList().ForEach(p => buildProps.Add(p));
 		}
 
 		string target = shouldPack ? "Pack" : "";
@@ -305,7 +305,7 @@ public class SimpleTemplateTest : BaseTemplateTests
 
 		if (additionalDotNetBuildParams is not "" and not null)
 		{
-			additionalDotNetBuildParams.Split("").ToList().ForEach(p => buildProps.Add(p));
+			additionalDotNetBuildParams.Split(" ").ToList().ForEach(p => buildProps.Add(p));
 		}
 		
 		Assert.IsTrue(DotnetInternal.Build(projectFile, config, properties: buildProps, msbuildWarningsAsErrors: true),

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/SimpleTemplateTest.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/SimpleTemplateTest.cs
@@ -10,19 +10,19 @@ public class SimpleTemplateTest : BaseTemplateTests
 	[TestCase("maui", DotNetPrevious, "Debug", false, "","")]
 	[TestCase("maui", DotNetPrevious, "Release", false, "", "")]
 	[TestCase("maui", DotNetCurrent, "Debug", false, "", "")]
-	[TestCase("maui", DotNetCurrent, "Release", false, "", "TrimMode=Partial")]
+	[TestCase("maui", DotNetCurrent, "Release", false, "", "TrimMode=partial")]
 	[TestCase("maui", DotNetCurrent, "Debug", false, "--sample-content", "")]
-	[TestCase("maui", DotNetCurrent, "Release", false, "--sample-content", "TrimMode=Partial")]
+	[TestCase("maui", DotNetCurrent, "Release", false, "--sample-content", "TrimMode=partial")]
 	[TestCase("maui-blazor", DotNetPrevious, "Debug", false, "", "")]
 	[TestCase("maui-blazor", DotNetPrevious, "Release", false, "", "")]
 	[TestCase("maui-blazor", DotNetCurrent, "Debug", false, "", "")]
-	[TestCase("maui-blazor", DotNetCurrent, "Release", false, "", "TrimMode=Partial")]
+	[TestCase("maui-blazor", DotNetCurrent, "Release", false, "", "TrimMode=partial")]
 	[TestCase("maui-blazor", DotNetCurrent, "Debug", false, "--Empty","")]
-	[TestCase("maui-blazor", DotNetCurrent, "Release", false, "--Empty","TrimMode=Partial")]
+	[TestCase("maui-blazor", DotNetCurrent, "Release", false, "--Empty","TrimMode=partial")]
 	[TestCase("mauilib", DotNetPrevious, "Debug", true, "", "")]
 	[TestCase("mauilib", DotNetPrevious, "Release", true, "","")]
 	[TestCase("mauilib", DotNetCurrent, "Debug", true, "", "")]
-	[TestCase("mauilib", DotNetCurrent, "Release", true, "", "TrimMode=Partial")]
+	[TestCase("mauilib", DotNetCurrent, "Release", true, "", "TrimMode=partial")]
 	public void Build(string id, string framework, string config, bool shouldPack, string additionalDotNetNewParams, string additionalDotNetBuildParams)	
 	{
 		var projectDir = TestDirectory;
@@ -112,15 +112,15 @@ public class SimpleTemplateTest : BaseTemplateTests
 	[TestCase("maui", DotNetPrevious, "Debug", false, "")]
 	[TestCase("maui", DotNetPrevious, "Release", false, "")]
 	[TestCase("maui", DotNetCurrent, "Debug", false, "")]
-	[TestCase("maui", DotNetCurrent, "Release", false, "TrimMode=Partial")]
+	[TestCase("maui", DotNetCurrent, "Release", false, "TrimMode=partial")]
 	[TestCase("maui-blazor", DotNetPrevious, "Debug", false,	"")]
 	[TestCase("maui-blazor", DotNetPrevious, "Release", false,	"")]
 	[TestCase("maui-blazor", DotNetCurrent, "Debug", false,	"")]
-	[TestCase("maui-blazor", DotNetCurrent, "Release", false, "TrimMode=Partial")]
+	[TestCase("maui-blazor", DotNetCurrent, "Release", false, "TrimMode=partial")]
 	[TestCase("mauilib", DotNetPrevious, "Debug", true, "")]
 	[TestCase("mauilib", DotNetPrevious, "Release", true, "")]
 	[TestCase("mauilib", DotNetCurrent, "Debug", true, "")]
-	[TestCase("mauilib", DotNetCurrent, "Release", true, "TrimMode=Partial")]
+	[TestCase("mauilib", DotNetCurrent, "Release", true, "TrimMode=partial")]
 	public void BuildWithMauiVersion(string id, string framework, string config, bool shouldPack, string additionalDotNetBuildParams)
 	{
 		var projectDir = TestDirectory;
@@ -280,11 +280,11 @@ public class SimpleTemplateTest : BaseTemplateTests
 
 	[Test]
 	[TestCase("maui", "Debug", "2.0", "2", "")]
-	[TestCase("maui", "Release", "2.0", "2", "TrimMode=Partial")]
-	[TestCase("maui", "Release", "0.3", "3", "TrimMode=Partial")]
+	[TestCase("maui", "Release", "2.0", "2", "TrimMode=partial")]
+	[TestCase("maui", "Release", "0.3", "3", "TrimMode=partial")]
 	[TestCase("maui-blazor", "Debug", "2.0", "2", "")]
-	[TestCase("maui-blazor", "Release", "2.0", "2",	"TrimMode=Partial")]
-	[TestCase("maui-blazor", "Release", "0.3", "3", "TrimMode=Partial")]
+	[TestCase("maui-blazor", "Release", "2.0", "2",	"TrimMode=partial")]
+	[TestCase("maui-blazor", "Release", "0.3", "3", "TrimMode=partial")]
 	public void BuildWithDifferentVersionNumber(string id, string config, string display, string version, string additionalDotNetBuildParams)
 	{
 		var projectDir = TestDirectory;

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/SimpleTemplateTest.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/SimpleTemplateTest.cs
@@ -49,14 +49,16 @@ public class SimpleTemplateTest : BaseTemplateTests
 				"XC0103", // https://github.com/CommunityToolkit/Maui/issues/2205
 			};
 		}
+		
+		var buildProps = BuildProps;
 
 		if (additionalDotNetBuildParams is not "" and not null)
 		{
-			additionalDotNetBuildParams.Split("").ToList().ForEach(p => BuildProps.Add(p));
+			additionalDotNetBuildParams.Split("").ToList().ForEach(p => buildProps.Add(p));
 		}
 
 		string target = shouldPack ? "Pack" : "";
-		Assert.IsTrue(DotnetInternal.Build(projectFile, config, target: target, properties: BuildProps, msbuildWarningsAsErrors: true, warningsToIgnore: warningsToIgnore),
+		Assert.IsTrue(DotnetInternal.Build(projectFile, config, target: target, properties: buildProps, msbuildWarningsAsErrors: true, warningsToIgnore: warningsToIgnore),
 			$"Project {Path.GetFileName(projectFile)} failed to build. Check test output/attachments for errors.");
 	}
 
@@ -144,13 +146,15 @@ public class SimpleTemplateTest : BaseTemplateTests
 
 		string binlogDir = Path.Combine(TestEnvironment.GetMauiDirectory(), $"artifacts\\log\\{Path.GetFileName(projectDir)}.binlog");
 
+		var buildProps = BuildProps;
+
 		if (additionalDotNetBuildParams is not "" and not null)
 		{
-			additionalDotNetBuildParams.Split("").ToList().ForEach(p => BuildProps.Add(p));
+			additionalDotNetBuildParams.Split("").ToList().ForEach(p => buildProps.Add(p));
 		}
 
 		string target = shouldPack ? "Pack" : "";
-		Assert.IsTrue(DotnetInternal.Build(projectFile, config, target: target, binlogPath: binlogDir, properties: BuildProps),
+		Assert.IsTrue(DotnetInternal.Build(projectFile, config, target: target, binlogPath: binlogDir, properties: buildProps),
 			$"Project {Path.GetFileName(projectFile)} failed to build. Check test output/attachments for errors.");
 	}
 
@@ -297,12 +301,14 @@ public class SimpleTemplateTest : BaseTemplateTests
 			$"<ApplicationVersion>1</ApplicationVersion>",
 			$"<ApplicationVersion>{version}</ApplicationVersion>");
 
+		var buildProps = BuildProps;
+
 		if (additionalDotNetBuildParams is not "" and not null)
 		{
-			additionalDotNetBuildParams.Split("").ToList().ForEach(p => BuildProps.Add(p));
+			additionalDotNetBuildParams.Split("").ToList().ForEach(p => buildProps.Add(p));
 		}
 		
-		Assert.IsTrue(DotnetInternal.Build(projectFile, config, properties: BuildProps, msbuildWarningsAsErrors: true),
+		Assert.IsTrue(DotnetInternal.Build(projectFile, config, properties: buildProps, msbuildWarningsAsErrors: true),
 			$"Project {Path.GetFileName(projectFile)} failed to build. Check test output/attachments for errors.");
 	}
 }

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/SimpleTemplateTest.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/SimpleTemplateTest.cs
@@ -6,24 +6,24 @@ namespace Microsoft.Maui.IntegrationTests;
 public class SimpleTemplateTest : BaseTemplateTests
 {
 	[Test]
-	// Parameters: short name, target framework, build config, use pack target, additionalDotNetNewParams
-	[TestCase("maui", DotNetPrevious, "Debug", false, "")]
-	[TestCase("maui", DotNetPrevious, "Release", false, "")]
-	[TestCase("maui", DotNetCurrent, "Debug", false, "")]
-	[TestCase("maui", DotNetCurrent, "Release", false, "")]
-	[TestCase("maui", DotNetCurrent, "Debug", false, "--sample-content")]
-	[TestCase("maui", DotNetCurrent, "Release", false, "--sample-content")]
-	[TestCase("maui-blazor", DotNetPrevious, "Debug", false, "")]
-	[TestCase("maui-blazor", DotNetPrevious, "Release", false, "")]
-	[TestCase("maui-blazor", DotNetCurrent, "Debug", false, "")]
-	[TestCase("maui-blazor", DotNetCurrent, "Release", false, "")]
-	[TestCase("maui-blazor", DotNetCurrent, "Debug", false, "--Empty")]
-	[TestCase("maui-blazor", DotNetCurrent, "Release", false, "--Empty")]
-	[TestCase("mauilib", DotNetPrevious, "Debug", true, "")]
-	[TestCase("mauilib", DotNetPrevious, "Release", true, "")]
-	[TestCase("mauilib", DotNetCurrent, "Debug", true, "")]
-	[TestCase("mauilib", DotNetCurrent, "Release", true, "")]
-	public void Build(string id, string framework, string config, bool shouldPack, string additionalDotNetNewParams)
+	// Parameters: short name, target framework, build config, use pack target, additionalDotNetNewParams, additionalDotNetBuildParams
+	[TestCase("maui", DotNetPrevious, "Debug", false, "","")]
+	[TestCase("maui", DotNetPrevious, "Release", false, "", "")]
+	[TestCase("maui", DotNetCurrent, "Debug", false, "", "")]
+	[TestCase("maui", DotNetCurrent, "Release", false, "", "TrimMode=Partial")]
+	[TestCase("maui", DotNetCurrent, "Debug", false, "--sample-content", "")]
+	[TestCase("maui", DotNetCurrent, "Release", false, "--sample-content", "TrimMode=Partial")]
+	[TestCase("maui-blazor", DotNetPrevious, "Debug", false, "", "")]
+	[TestCase("maui-blazor", DotNetPrevious, "Release", false, "", "")]
+	[TestCase("maui-blazor", DotNetCurrent, "Debug", false, "", "")]
+	[TestCase("maui-blazor", DotNetCurrent, "Release", false, "", "TrimMode=Partial")]
+	[TestCase("maui-blazor", DotNetCurrent, "Debug", false, "--Empty","")]
+	[TestCase("maui-blazor", DotNetCurrent, "Release", false, "--Empty","TrimMode=Partial")]
+	[TestCase("mauilib", DotNetPrevious, "Debug", true, "", "")]
+	[TestCase("mauilib", DotNetPrevious, "Release", true, "","")]
+	[TestCase("mauilib", DotNetCurrent, "Debug", true, "", "")]
+	[TestCase("mauilib", DotNetCurrent, "Release", true, "", "TrimMode=Partial")]
+	public void Build(string id, string framework, string config, bool shouldPack, string additionalDotNetNewParams, string additionalDotNetBuildParams)	
 	{
 		var projectDir = TestDirectory;
 		var projectFile = Path.Combine(projectDir, $"{Path.GetFileName(projectDir)}.csproj");
@@ -50,6 +50,10 @@ public class SimpleTemplateTest : BaseTemplateTests
 			};
 		}
 
+		if (additionalDotNetBuildParams is not "" and not null)
+		{
+			additionalDotNetBuildParams.Split("").ToList().ForEach(p => BuildProps.Add(p));
+		}
 
 		string target = shouldPack ? "Pack" : "";
 		Assert.IsTrue(DotnetInternal.Build(projectFile, config, target: target, properties: BuildProps, msbuildWarningsAsErrors: true, warningsToIgnore: warningsToIgnore),
@@ -102,20 +106,20 @@ public class SimpleTemplateTest : BaseTemplateTests
 	}
 
 	[Test]
-	// Parameters: short name, target framework, build config, use pack target
-	[TestCase("maui", DotNetPrevious, "Debug", false)]
-	[TestCase("maui", DotNetPrevious, "Release", false)]
-	[TestCase("maui", DotNetCurrent, "Debug", false)]
-	[TestCase("maui", DotNetCurrent, "Release", false)]
-	[TestCase("maui-blazor", DotNetPrevious, "Debug", false)]
-	[TestCase("maui-blazor", DotNetPrevious, "Release", false)]
-	[TestCase("maui-blazor", DotNetCurrent, "Debug", false)]
-	[TestCase("maui-blazor", DotNetCurrent, "Release", false)]
-	[TestCase("mauilib", DotNetPrevious, "Debug", true)]
-	[TestCase("mauilib", DotNetPrevious, "Release", true)]
-	[TestCase("mauilib", DotNetCurrent, "Debug", true)]
-	[TestCase("mauilib", DotNetCurrent, "Release", true)]
-	public void BuildWithMauiVersion(string id, string framework, string config, bool shouldPack)
+	// Parameters: short name, target framework, build config, use pack target, additionalDotNetBuildParams
+	[TestCase("maui", DotNetPrevious, "Debug", false, "")]
+	[TestCase("maui", DotNetPrevious, "Release", false, "")]
+	[TestCase("maui", DotNetCurrent, "Debug", false, "")]
+	[TestCase("maui", DotNetCurrent, "Release", false, "TrimMode=Partial")]
+	[TestCase("maui-blazor", DotNetPrevious, "Debug", false,	"")]
+	[TestCase("maui-blazor", DotNetPrevious, "Release", false,	"")]
+	[TestCase("maui-blazor", DotNetCurrent, "Debug", false,	"")]
+	[TestCase("maui-blazor", DotNetCurrent, "Release", false, "TrimMode=Partial")]
+	[TestCase("mauilib", DotNetPrevious, "Debug", true, "")]
+	[TestCase("mauilib", DotNetPrevious, "Release", true, "")]
+	[TestCase("mauilib", DotNetCurrent, "Debug", true, "")]
+	[TestCase("mauilib", DotNetCurrent, "Release", true, "TrimMode=Partial")]
+	public void BuildWithMauiVersion(string id, string framework, string config, bool shouldPack, string additionalDotNetBuildParams)
 	{
 		var projectDir = TestDirectory;
 		var projectFile = Path.Combine(projectDir, $"{Path.GetFileName(projectDir)}.csproj");
@@ -139,6 +143,11 @@ public class SimpleTemplateTest : BaseTemplateTests
 			$"<PropertyGroup><MauiVersion>{mv}</MauiVersion></PropertyGroup></Project>");
 
 		string binlogDir = Path.Combine(TestEnvironment.GetMauiDirectory(), $"artifacts\\log\\{Path.GetFileName(projectDir)}.binlog");
+
+		if (additionalDotNetBuildParams is not "" and not null)
+		{
+			additionalDotNetBuildParams.Split("").ToList().ForEach(p => BuildProps.Add(p));
+		}
 
 		string target = shouldPack ? "Pack" : "";
 		Assert.IsTrue(DotnetInternal.Build(projectFile, config, target: target, binlogPath: binlogDir, properties: BuildProps),
@@ -266,13 +275,13 @@ public class SimpleTemplateTest : BaseTemplateTests
 	}
 
 	[Test]
-	[TestCase("maui", "Debug", "2.0", "2")]
-	[TestCase("maui", "Release", "2.0", "2")]
-	[TestCase("maui", "Release", "0.3", "3")]
-	[TestCase("maui-blazor", "Debug", "2.0", "2")]
-	[TestCase("maui-blazor", "Release", "2.0", "2")]
-	[TestCase("maui-blazor", "Release", "0.3", "3")]
-	public void BuildWithDifferentVersionNumber(string id, string config, string display, string version)
+	[TestCase("maui", "Debug", "2.0", "2", "")]
+	[TestCase("maui", "Release", "2.0", "2", "TrimMode=Partial")]
+	[TestCase("maui", "Release", "0.3", "3", "TrimMode=Partial")]
+	[TestCase("maui-blazor", "Debug", "2.0", "2", "")]
+	[TestCase("maui-blazor", "Release", "2.0", "2",	"TrimMode=Partial")]
+	[TestCase("maui-blazor", "Release", "0.3", "3", "TrimMode=Partial")]
+	public void BuildWithDifferentVersionNumber(string id, string config, string display, string version, string additionalDotNetBuildParams)
 	{
 		var projectDir = TestDirectory;
 		var projectFile = Path.Combine(projectDir, $"{Path.GetFileName(projectDir)}.csproj");
@@ -288,6 +297,11 @@ public class SimpleTemplateTest : BaseTemplateTests
 			$"<ApplicationVersion>1</ApplicationVersion>",
 			$"<ApplicationVersion>{version}</ApplicationVersion>");
 
+		if (additionalDotNetBuildParams is not "" and not null)
+		{
+			additionalDotNetBuildParams.Split("").ToList().ForEach(p => BuildProps.Add(p));
+		}
+		
 		Assert.IsTrue(DotnetInternal.Build(projectFile, config, properties: BuildProps, msbuildWarningsAsErrors: true),
 			$"Project {Path.GetFileName(projectFile)} failed to build. Check test output/attachments for errors.");
 	}


### PR DESCRIPTION
### Description of Change

We need to speed up the template tests because on arm and Release we now do AOT.  So we set the linker to `partial` on release

Before
<img width="373" alt="Screenshot 2024-11-18 at 17 49 52" src="https://github.com/user-attachments/assets/87405fba-9818-408f-b25a-927513861026">

After
<img width="402" alt="Screenshot 2024-11-19 at 09 15 04" src="https://github.com/user-attachments/assets/20b27767-f624-4296-a7bd-e07b0676db62">

Fixes https://github.com/dotnet/maui/issues/25944