### PR TITLE
Add Syncfusion Toolkit to Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -46,6 +46,9 @@ updates:
       patterns:
         - "xunit"
         - "xunit.runner.*"
+    SyncfusionToolkit:
+      patterns:
+        - "Syncfusion.Maui.Toolkit"
   ignore:
     - dependency-name: "MicrosoftMauiGraphicsVersion"         # maestro
     - dependency-name: "Microsoft.Maui.Graphics*"             # maestro


### PR DESCRIPTION
### Description of Change

By adding the Syncfusion Toolkit to the Dependabot config, we ensure that the toolkit is included in the list of dependencies that Dependabot will monitor for updates.

That way the new .NET MAUI template can stay up-to-date with the latest versions of the Syncfusion Toolkit and ensure that our project remains compatible with the latest features and bug fixes.