### PR TITLE
[HybridWebView] Add support for async .NET methods

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Controls/HybridWebViewPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/HybridWebViewPage.xaml.cs
@@ -123,6 +123,36 @@ namespace Maui.Controls.Sample.Pages
 					Value = i,
 				};
 			}
+
+			public async Task DoAsyncWork()
+			{
+				await Task.Delay(1000);
+				Debug.WriteLine("DoAsyncWork");
+			}
+
+			public async Task DoAsyncWorkParams(int i, string s)
+			{
+				await Task.Delay(1000);
+				Debug.WriteLine($"DoAsyncWorkParams: {i}, {s}");
+			}
+
+			public async Task<string> DoAsyncWorkReturn()
+			{
+				await Task.Delay(1000);
+				Debug.WriteLine("DoAsyncWorkReturn");
+				return "Hello from C#!";
+			}
+
+			public async Task<SyncReturn> DoAsyncWorkParamsReturn(int i, string s)
+			{
+				await Task.Delay(1000);
+				Debug.WriteLine($"DoAsyncWorkParamsReturn: {i}, {s}");
+				return new SyncReturn
+				{
+					Message = "Hello from C#! " + s,
+					Value = i,
+				};
+			}
 		}
 
 		public class SyncReturn

--- a/src/Controls/samples/Controls.Sample/Resources/Raw/HybridSamplePage/index.html
+++ b/src/Controls/samples/Controls.Sample/Resources/Raw/HybridSamplePage/index.html
@@ -69,6 +69,30 @@
             LogMessage("Invoked DoSyncWorkParamsReturn, return value: message=" + retValue.Message + ", value=" + retValue.Value);
         }
 
+        async function InvokeDoAsyncWork() {
+            LogMessage("Invoking DoAsyncWork");
+            await window.HybridWebView.InvokeDotNet('DoAsyncWork');
+            LogMessage("Invoked DoAsyncWork");
+        }
+
+        async function InvokeDoAsyncWorkParams() {
+            LogMessage("Invoking DoAsyncWorkParams");
+            await window.HybridWebView.InvokeDotNet('DoAsyncWorkParams', [123, 'hello']);
+            LogMessage("Invoked DoAsyncWorkParams");
+        }
+
+        async function InvokeDoAsyncWorkReturn() {
+            LogMessage("Invoking DoAsyncWorkReturn");
+            const retValue = await window.HybridWebView.InvokeDotNet('DoAsyncWorkReturn');
+            LogMessage("Invoked DoAsyncWorkReturn, return value: " + retValue);
+        }
+
+        async function InvokeDoAsyncWorkParamsReturn() {
+            LogMessage("Invoking DoAsyncWorkParamsReturn");
+            const retValue = await window.HybridWebView.InvokeDotNet('DoAsyncWorkParamsReturn', [123, 'hello']);
+            LogMessage("Invoked DoAsyncWorkParamsReturn, return value: message=" + retValue.Message + ", value=" + retValue.Value);
+        }
+
     </script>
 </head>
 <body>
@@ -83,6 +107,12 @@
         <button onclick="InvokeDoSyncWorkParams()">Call C# sync method (params)</button>
         <button onclick="InvokeDoSyncWorkReturn()">Call C# method (no params) and get simple return value</button>
         <button onclick="InvokeDoSyncWorkParamsReturn()">Call C# method (params) and get complex return value</button>
+    </div>
+    <div>
+        <button onclick="InvokeDoAsyncWork()">Call C# async method (no params)</button>
+        <button onclick="InvokeDoAsyncWorkParams()">Call C# async method (params)</button>
+        <button onclick="InvokeDoAsyncWorkReturn()">Call C# async method (no params) and get simple return value</button>
+        <button onclick="InvokeDoAsyncWorkParamsReturn()">Call C# async method (params) and get complex return value</button>
     </div>
     <div>
         Log: <textarea readonly id="messageLog" style="width: 80%; height: 10em;"></textarea>

--- a/src/Controls/tests/DeviceTests/Elements/HybridWebView/HybridWebViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/HybridWebView/HybridWebViewTests.cs
@@ -369,6 +369,33 @@ namespace Microsoft.Maui.DeviceTests
 				return null;
 			}
 
+			public async Task Invoke_NoParam_ReturnTask()
+			{
+				await Task.Delay(1);
+				UpdateLastMethodCalled();
+			}
+
+			public async Task<object> Invoke_NoParam_ReturnTaskNull()
+			{
+				await Task.Delay(1);
+				UpdateLastMethodCalled();
+				return null;
+			}
+
+			public async Task<int> Invoke_NoParam_ReturnTaskValueType()
+			{
+				await Task.Delay(1);
+				UpdateLastMethodCalled();
+				return 2;
+			}
+
+			public async Task<ComputationResult> Invoke_NoParam_ReturnTaskComplex()
+			{
+				await Task.Delay(1);
+				UpdateLastMethodCalled();
+				return NewComplexResult;
+			}
+
 			public int Invoke_OneParam_ReturnValueType(Dictionary<string, int> dict)
 			{
 				Assert.NotNull(dict);
@@ -440,6 +467,10 @@ namespace Microsoft.Maui.DeviceTests
 				// 3. Methods with different return values (none, simple, complex, etc.)
 				yield return new object[] { "Invoke_NoParam_NoReturn", null };
 				yield return new object[] { "Invoke_NoParam_ReturnNull", null };
+				yield return new object[] { "Invoke_NoParam_ReturnTask", null };
+				yield return new object[] { "Invoke_NoParam_ReturnTaskNull", null };
+				yield return new object[] { "Invoke_NoParam_ReturnTaskValueType", ValueTypeResult };
+				yield return new object[] { "Invoke_NoParam_ReturnTaskComplex", ComplexResult };
 				yield return new object[] { "Invoke_OneParam_ReturnValueType", ValueTypeResult };
 				yield return new object[] { "Invoke_OneParam_ReturnDictionary", DictionaryResult };
 				yield return new object[] { "Invoke_NullParam_ReturnComplex", ComplexResult };

--- a/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.Windows.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Specialized;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.InteropServices.WindowsRuntime;
@@ -45,7 +44,6 @@ namespace Microsoft.Maui.Handlers
 					PlatformView.Source = new Uri(new Uri(AppOriginUri, "/").ToString());
 				}
 			});
-
 		}
 
 		void OnWebViewLoaded(object sender, RoutedEventArgs e)
@@ -105,77 +103,84 @@ namespace Microsoft.Maui.Handlers
 			// Get a deferral object so that WebView2 knows there's some async stuff going on. We call Complete() at the end of this method.
 			using var deferral = eventArgs.GetDeferral();
 
-			var requestUri = HybridWebViewQueryStringHelper.RemovePossibleQueryString(eventArgs.Request.Uri);
+			var (stream, contentType, statusCode, reason) = await GetResponseStreamAsync(eventArgs.Request.Uri);
+			var contentLength = stream?.Size ?? 0;
+			var headers =
+				$"""
+				Content-Type: {contentType}
+				Content-Length: {contentLength}
+				""";
+
+			eventArgs.Response = sender.Environment!.CreateWebResourceResponse(
+				Content: stream,
+				StatusCode: statusCode,
+				ReasonPhrase: reason,
+				Headers: headers);
+
+			// Notify WebView2 that the deferred (async) operation is complete and we set a response.
+			deferral.Complete();
+		}
+
+		private async Task<(IRandomAccessStream Stream, string ContentType, int StatusCode, string Reason)> GetResponseStreamAsync(string url)
+		{
+			var requestUri = HybridWebViewQueryStringHelper.RemovePossibleQueryString(url);
 
 			if (new Uri(requestUri) is Uri uri && AppOriginUri.IsBaseOf(uri))
 			{
 				var relativePath = AppOriginUri.MakeRelativeUri(uri).ToString().Replace('/', '\\');
 
-				string? contentType = null;
-				Stream? contentStream = null;
-
 				// 1. Try special InvokeDotNet path
 				if (relativePath == InvokeDotNetPath)
 				{
-					var fullUri = new Uri(eventArgs.Request.Uri);
+					var fullUri = new Uri(url);
 					var invokeQueryString = HttpUtility.ParseQueryString(fullUri.Query);
-					(var contentBytes, contentType) = InvokeDotNet(invokeQueryString);
+					var contentBytes = await InvokeDotNetAsync(invokeQueryString);
 					if (contentBytes is not null)
 					{
-						contentStream = new MemoryStream(contentBytes);
+						var bytesStream = new MemoryStream(contentBytes);
+						var ras = await CopyContentToRandomAccessStreamAsync(bytesStream);
+						return (Stream: ras, ContentType: "application/json", StatusCode: 200, Reason: "OK");
 					}
 				}
+
+				string contentType;
 
 				// 2. If nothing found yet, try to get static content from the asset path
-				if (contentStream is null)
+				if (string.IsNullOrEmpty(relativePath))
 				{
-					if (string.IsNullOrEmpty(relativePath))
-					{
-						relativePath = VirtualView.DefaultFile;
-						contentType = "text/html";
-					}
-					else
-					{
-						if (!ContentTypeProvider.TryGetContentType(relativePath, out contentType!))
-						{
-							// TODO: Log this
-							contentType = "text/plain";
-						}
-					}
-
-					var assetPath = Path.Combine(VirtualView.HybridRoot!, relativePath!);
-					contentStream = await GetAssetStreamAsync(assetPath);
-				}
-
-				if (contentStream is null)
-				{
-					// 3.a. If still nothing is found, return a 404
-					var notFoundContent = "Resource not found (404)";
-					eventArgs.Response = sender.Environment!.CreateWebResourceResponse(
-						Content: null,
-						StatusCode: 404,
-						ReasonPhrase: "Not Found",
-						Headers: GetHeaderString("text/plain", notFoundContent.Length)
-					);
+					relativePath = VirtualView.DefaultFile;
+					contentType = "text/html";
 				}
 				else
 				{
-					// 3.b. Otherwise, return the content
-					eventArgs.Response = sender.Environment!.CreateWebResourceResponse(
-						Content: await CopyContentToRandomAccessStreamAsync(contentStream),
-						StatusCode: 200,
-						ReasonPhrase: "OK",
-						Headers: GetHeaderString(contentType ?? "text/plain", (int)contentStream.Length)
-					);
+					if (!ContentTypeProvider.TryGetContentType(relativePath, out contentType!))
+					{
+						// TODO: Log this
+						contentType = "text/plain";
+					}
 				}
 
-				contentStream?.Dispose();
+				var assetPath = Path.Combine(VirtualView.HybridRoot!, relativePath!);
+				using var contentStream = await GetAssetStreamAsync(assetPath);
+
+				if (contentStream is not null)
+				{
+					// 3.a. If something was found, return the content
+					var ras = await CopyContentToRandomAccessStreamAsync(contentStream);
+					return (Stream: ras, ContentType: contentType, StatusCode: 200, Reason: "OK");
+				}
 			}
 
-			// Notify WebView2 that the deferred (async) operation is complete and we set a response.
-			deferral.Complete();
+			// 3.b. Otherwise, return a 404
+			var ras404 = new InMemoryRandomAccessStream();
+			using (var writer = new StreamWriter(ras404.AsStreamForWrite()))
+			{
+				writer.WriteLine("Resource not found (404)");
+			}
 
-			async Task<IRandomAccessStream> CopyContentToRandomAccessStreamAsync(Stream content)
+			return (Stream: ras404, ContentType: "text/plain", StatusCode: 404, Reason: "Not Found");
+
+			static async Task<IRandomAccessStream> CopyContentToRandomAccessStreamAsync(Stream content)
 			{
 				using var memStream = new MemoryStream();
 				await content.CopyToAsync(memStream);
@@ -184,10 +189,6 @@ namespace Microsoft.Maui.Handlers
 				return randomAccessStream;
 			}
 		}
-
-		private protected static string GetHeaderString(string contentType, int contentLength) =>
-$@"Content-Type: {contentType}
-Content-Length: {contentLength}";
 
 		[RequiresUnreferencedCode(DynamicFeatures)]
 #if !NETSTANDARD

--- a/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.Windows.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Specialized;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.InteropServices.WindowsRuntime;
@@ -44,6 +45,7 @@ namespace Microsoft.Maui.Handlers
 					PlatformView.Source = new Uri(new Uri(AppOriginUri, "/").ToString());
 				}
 			});
+
 		}
 
 		void OnWebViewLoaded(object sender, RoutedEventArgs e)
@@ -189,6 +191,7 @@ namespace Microsoft.Maui.Handlers
 				return randomAccessStream;
 			}
 		}
+
 
 		[RequiresUnreferencedCode(DynamicFeatures)]
 #if !NETSTANDARD

--- a/src/Core/src/Platform/Android/MauiHybridWebViewClient.cs
+++ b/src/Core/src/Platform/Android/MauiHybridWebViewClient.cs
@@ -9,12 +9,8 @@ using System.IO.Pipelines;
 using System.Text;
 using System.Threading.Tasks;
 using System.Web;
-using Android.Media.TV;
 using Android.Webkit;
-using Java.Nio;
 using Microsoft.Extensions.Logging;
-using Microsoft.Maui.Storage;
-using Xamarin.Google.Crypto.Tink.Prf;
 using AWebView = Android.Webkit.WebView;
 
 namespace Microsoft.Maui.Platform


### PR DESCRIPTION
### Description of Change

This PR makes the call from JS into .NET be able to support async methods (return `Task` or `Task<T>`)

This PR has a fair bit of things moving around because of the async and the fact that I wanted to make the code flow the same on all the platforms. The code was getting a bit nested, so I broke things out into methods.



### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes https://github.com/dotnet/maui/issues/25968
