### PR TITLE
Add fallback to ContentPresenter Content binding using reflection

### DIFF
--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui25947_2.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui25947_2.xaml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests"
+    x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui25947_2">
+    <local:CustomTemplatedView25947 x:Name="CustomView">
+        <Label Text="Hello, Issue 25947." />
+    </local:CustomTemplatedView25947>
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui25947_2.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui25947_2.xaml.cs
@@ -1,0 +1,73 @@
+﻿using System.Linq;
+using Microsoft.Maui.ApplicationModel;
+using Microsoft.Maui.Controls.Core.UnitTests;
+using Microsoft.Maui.Dispatching;
+using Microsoft.Maui.UnitTests;
+using NUnit.Framework;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public partial class Maui25947_2
+{
+	public Maui25947_2()
+	{
+		InitializeComponent();
+	}
+
+	public Maui25947_2(bool useCompiledXaml)
+	{
+		//this stub will be replaced at compile time
+	}
+
+	[TestFixture]
+	class Test
+	{
+		[SetUp]
+		public void Setup()
+		{
+			Application.SetCurrentApplication(new MockApplication());
+			DispatcherProvider.SetCurrent(new DispatcherProviderStub());
+		}
+
+		[TearDown]
+		public void TearDown()
+		{
+			AppInfo.SetCurrent(null);
+		}
+
+		[Test]
+		public void TestCustomTemplatedView([Values(false, true)] bool useCompiledXaml)
+		{
+			var page = new Maui25947_2(useCompiledXaml);
+
+			var stackLayout = page.CustomView.Children[0];
+			Assert.IsInstanceOf<StackLayout>(stackLayout);
+			Assert.AreEqual(1, ((StackLayout)stackLayout).Children.Count);
+
+			var contentPresenter = ((StackLayout)stackLayout).Children[0];
+			Assert.IsInstanceOf<ContentPresenter>(contentPresenter);
+			Assert.AreEqual(1, ((ContentPresenter)contentPresenter).Children.Count);
+
+			var label = ((ContentPresenter)contentPresenter).Children[0];
+			Assert.IsInstanceOf<Label>(label);
+			Assert.AreEqual("Hello, Issue 25947.", ((Label)label).Text);
+		}
+	}
+}
+
+[ContentProperty(nameof(Content))]
+public sealed class CustomTemplatedView25947 : TemplatedView
+{
+	public CustomTemplatedView25947()
+	{
+		ControlTemplate = new ControlTemplate(() => new StackLayout { new ContentPresenter() });
+	}
+
+	public static readonly BindableProperty ContentProperty = BindableProperty.Create(nameof(Content), typeof(View), typeof(CustomTemplatedView25947), null);
+
+	public View Content
+	{
+		get => (View)GetValue(ContentProperty);
+		set => SetValue(ContentProperty, value);
+	}
+}


### PR DESCRIPTION
### Description of Change

It turns out that for customers that are deriving from `TemplatedView` run into issues with the `ContentPresenter` and the binding for the `Content` property.
- For customers that don't trim their apps, the fallback to reflection would match the behavior they were experiencing in .NET 8
- For customers that trim/Native AOT their apps, the fallback likely won't do anything but it also won't produce any warning.

AFAIK we currently don't have any docs that would mention how to implement custom `TemplatedView` that could be updated to mention that the "proper" way to do this is to implement the `object IContentView.Content` property in the derived class. I added runtime warning but I'm not sure how many developers will actually see this or just miss it completely. 

cc @PureWeen @mattleibow @StephaneDelcroix @davidbritch 

### Issues Fixed

Fixes #25947
