### PR TITLE
Updated the Blazor Hybrid Solution template to work better with the dotnet cli or IDEs that rely on it.

### DIFF
--- a/src/Templates/src/templates/maui-blazor-solution/.template.config/template.json
+++ b/src/Templates/src/templates/maui-blazor-solution/.template.config/template.json
@@ -15,9 +15,11 @@
   "sourceName": "MauiApp.1",
   "primaryOutputs": [
     {
+      "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
       "path": "MauiApp.1.Shared/Pages/Home.razor"
     },
     {
+      "condition": "(HostIdentifier == \"dotnetcli\" || HostIdentifier == \"dotnetcli-preview\")",
       "path": "MauiApp.1.sln"
     },
     {

--- a/src/Templates/src/templates/maui-blazor-solution/.template.config/template.json
+++ b/src/Templates/src/templates/maui-blazor-solution/.template.config/template.json
@@ -15,11 +15,9 @@
   "sourceName": "MauiApp.1",
   "primaryOutputs": [
     {
-      "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
       "path": "MauiApp.1.Shared/Pages/Home.razor"
     },
     {
-      "condition": "(HostIdentifier == \"dotnetcli\" || HostIdentifier == \"dotnetcli-preview\")",
       "path": "MauiApp.1.sln"
     },
     {
@@ -102,12 +100,6 @@
               "MauiApp.1.Web/Services/**",
               "MauiApp.1.Web.Client/Services/**",
               "MauiApp.1.Web.Client/wwwroot/**"
-            ]
-          },
-          {
-            "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
-            "exclude": [
-              "*.sln"
             ]
           }
         ]

--- a/src/Templates/src/templates/maui-blazor-solution/.template.config/template.json
+++ b/src/Templates/src/templates/maui-blazor-solution/.template.config/template.json
@@ -103,6 +103,12 @@
               "MauiApp.1.Web.Client/Services/**",
               "MauiApp.1.Web.Client/wwwroot/**"
             ]
+          },
+          {
+            "condition": "(HostIdentifier == \"vs\")",
+            "exclude": [
+              "*.sln"
+            ]
           }
         ]
     }


### PR DESCRIPTION
### Description of Change

Updated the Blazor Hybrid Solution template to better support using the dotnet cli or IDEs that rely on it, like VSCode and Rider.

### Issues Fixed

Excluding the .sln file doesn't make sense, since other IDEs can use the .sln file as well. If it's not needed, it can be deleted, much like other templates do. Not having it in the first place makes life significantly more difficult for users of this template on non Visual Studio environments. 

Fixes #

Updated the template to remove the conditionals that exclude the .sln file for dotnetcli.
