### PR TITLE
[Windows] Disable HitTest when showing EmptyView on CollectionView

### DIFF
--- a/src/Controls/src/Core/Platform/Windows/CollectionView/FormsGridView.cs
+++ b/src/Controls/src/Core/Platform/Windows/CollectionView/FormsGridView.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Maui.Controls.Platform
 		int _span;
 		ItemsWrapGrid _wrapGrid;
 		ContentControl _emptyViewContentControl;
+		ScrollViewer _scrollViewer;
 		FrameworkElement _emptyView;
 		View _formsEmptyView;
 		Orientation _orientation;
@@ -145,6 +146,8 @@ namespace Microsoft.Maui.Controls.Platform
 
 			_emptyViewContentControl = GetTemplateChild("EmptyViewContentControl") as ContentControl;
 
+			_scrollViewer = GetTemplateChild("ScrollViewer") as ScrollViewer;
+
 			if (_emptyView != null && _emptyViewContentControl != null)
 			{
 				_emptyViewContentControl.Content = _emptyView;
@@ -171,6 +174,13 @@ namespace Microsoft.Maui.Controls.Platform
 			{
 				return;
 			}
+
+			if (_scrollViewer == null)
+			{
+				// If the empty view is visible, we don't want to hit test the ScrollViewer 
+				// because on the template, the empty view is on bottom of the ScrollViewer
+				_scrollViewer.IsHitTestVisible = !(visibility == WVisibility.Visible);
+			}	
 
 			_emptyViewContentControl.Visibility = visibility;
 		}

--- a/src/Controls/src/Core/Platform/Windows/CollectionView/FormsGridView.cs
+++ b/src/Controls/src/Core/Platform/Windows/CollectionView/FormsGridView.cs
@@ -170,12 +170,12 @@ namespace Microsoft.Maui.Controls.Platform
 
 		void UpdateEmptyViewVisibility(WVisibility visibility)
 		{
-			if (_emptyViewContentControl == null)
+			if (_emptyViewContentControl is null)
 			{
 				return;
 			}
 
-			if (_scrollViewer == null)
+			if (_scrollViewer is not null)
 			{
 				// If the empty view is visible, we don't want to hit test the ScrollViewer 
 				// because on the template, the empty view is on bottom of the ScrollViewer

--- a/src/Controls/src/Core/Platform/Windows/CollectionView/FormsGridView.cs
+++ b/src/Controls/src/Core/Platform/Windows/CollectionView/FormsGridView.cs
@@ -175,12 +175,14 @@ namespace Microsoft.Maui.Controls.Platform
 				return;
 			}
 
+			// Adjust the ScrollViewer's hit test visibility if it exists
 			if (_scrollViewer is not null)
 			{
-				// If the empty view is visible, we don't want to hit test the ScrollViewer 
-				// because on the template, the empty view is on bottom of the ScrollViewer
-				_scrollViewer.IsHitTestVisible = !(visibility == WVisibility.Visible);
-			}	
+				// When the empty view is visible, disable hit testing for the ScrollViewer.
+				// This ensures that interactions are directed to the empty view instead of the ScrollViewer.
+				// In the template, the empty view is placed below the ScrollViewer in the visual tree.
+				_scrollViewer.IsHitTestVisible = visibility != WVisibility.Visible;
+			}
 
 			_emptyViewContentControl.Visibility = visibility;
 		}

--- a/src/Controls/src/Core/Platform/Windows/FormsListView.cs
+++ b/src/Controls/src/Core/Platform/Windows/FormsListView.cs
@@ -101,11 +101,13 @@ namespace Microsoft.Maui.Controls.Platform
 				return;
 			}
 
+			// Adjust the ScrollViewer's hit test visibility if it exists
 			if (_scrollViewer is not null)
 			{
-				// If the empty view is visible, we don't want to hit test the ScrollViewer 
-				// because on the template, the empty view is on bottom of the ScrollViewer
-				_scrollViewer.IsHitTestVisible = !(visibility == WVisibility.Visible);
+				// When the empty view is visible, disable hit testing for the ScrollViewer.
+				// This ensures that interactions are directed to the empty view instead of the ScrollViewer.
+				// In the template, the empty view is placed below the ScrollViewer in the visual tree.
+				_scrollViewer.IsHitTestVisible = visibility != WVisibility.Visible;
 			}
 
 			_emptyViewContentControl.Visibility = visibility;

--- a/src/Controls/src/Core/Platform/Windows/FormsListView.cs
+++ b/src/Controls/src/Core/Platform/Windows/FormsListView.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Maui.Controls.Platform
 	internal partial class FormsListView : Microsoft.UI.Xaml.Controls.ListView, IEmptyView
 	{
 		ContentControl _emptyViewContentControl;
+		ScrollViewer _scrollViewer;
 		FrameworkElement _emptyView;
 		View _formsEmptyView;
 
@@ -68,6 +69,8 @@ namespace Microsoft.Maui.Controls.Platform
 
 			_emptyViewContentControl = GetTemplateChild("EmptyViewContentControl") as ContentControl;
 
+			_scrollViewer = GetTemplateChild("ScrollViewer") as ScrollViewer;
+
 			if (_emptyView != null)
 			{
 				_emptyViewContentControl.Content = _emptyView;
@@ -96,6 +99,13 @@ namespace Microsoft.Maui.Controls.Platform
 			if (_emptyViewContentControl == null)
 			{
 				return;
+			}
+
+			if (_scrollViewer == null)
+			{
+				// If the empty view is visible, we don't want to hit test the ScrollViewer 
+				// because on the template, the empty view is on bottom of the ScrollViewer
+				_scrollViewer.IsHitTestVisible = !(visibility == WVisibility.Visible);
 			}
 
 			_emptyViewContentControl.Visibility = visibility;

--- a/src/Controls/src/Core/Platform/Windows/FormsListView.cs
+++ b/src/Controls/src/Core/Platform/Windows/FormsListView.cs
@@ -96,12 +96,12 @@ namespace Microsoft.Maui.Controls.Platform
 
 		void UpdateEmptyViewVisibility(WVisibility visibility)
 		{
-			if (_emptyViewContentControl == null)
+			if (_emptyViewContentControl is null)
 			{
 				return;
 			}
 
-			if (_scrollViewer == null)
+			if (_scrollViewer is not null)
 			{
 				// If the empty view is visible, we don't want to hit test the ScrollViewer 
 				// because on the template, the empty view is on bottom of the ScrollViewer

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue19609.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue19609.xaml
@@ -2,7 +2,7 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="Maui.Controls.Sample.Issues.Issue19609">
-  <CollectionView>
+  <CollectionView AutomationId="cv" HorizontalOptions="Center" VerticalOptions="Center">
     <CollectionView.EmptyView>
       <Button Text="Click Me" AutomationId="btnClick" Clicked="Button_Clicked" HorizontalOptions="Center" VerticalOptions="Center"/>
     </CollectionView.EmptyView>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue19609.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue19609.xaml
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Maui.Controls.Sample.Issues.Issue19609">
+  <CollectionView>
+    <CollectionView.EmptyView>
+      <Button Text="Click Me" AutomationId="btnClick" Clicked="Button_Clicked" HorizontalOptions="Center" VerticalOptions="Center"/>
+    </CollectionView.EmptyView>
+  </CollectionView>
+</ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue19609.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue19609.xaml.cs
@@ -1,0 +1,16 @@
+﻿namespace Maui.Controls.Sample.Issues
+{
+	[Issue(IssueTracker.Github, "19609", "Button clicked event and command will not be occurred in EmptyView of CollectionView", PlatformAffected.UWP)]
+	public partial class Issue19609 : ContentPage
+	{
+		public Issue19609()
+		{
+			InitializeComponent();
+		}
+
+		void Button_Clicked(object sender, EventArgs e)
+		{
+			(sender as Button).Text = "Clicked";
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue19609.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue19609.cs
@@ -17,8 +17,18 @@ public class Issue19609 : _IssuesUITest
 	public void CanTapButtonOnEmptyView()
 	{
 		var btnElementId = "btnClick";
+		var btnElementCVId = "cv";
+		App.WaitForElement(btnElementCVId, $"Can t find the CollectionView {btnElementCVId}", timeout: TimeSpan.FromSeconds(10));
+#if WINDOWS
+		// on Windows, the button is not on Appium hirearchy, so we need to tap on the center of the CollectionView where the empty view is
+		var cv = App.FindElement(btnElementCVId);
+		var cvLocation = cv.GetRect();
+		var cvCenter = new Point(cvLocation.X + cvLocation.Width / 2, cvLocation.Y + cvLocation.Height / 2);
+		App.TapCoordinates(cvCenter.X, cvCenter.Y);
+#else
 		App.WaitForElement(btnElementId, $"Can t find the button {btnElementId}", timeout: TimeSpan.FromSeconds(10));
 		App.Tap(btnElementId);
+#endif
 		App.WaitForTextToBePresentInElement(btnElementId, "Clicked", timeout: TimeSpan.FromSeconds(10));
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue19609.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue19609.cs
@@ -16,9 +16,9 @@ public class Issue19609 : _IssuesUITest
 	[Category(UITestCategories.CollectionView)]
 	public void CanTapButtonOnEmptyView()
 	{
-		App.WaitForElement("btnClick");
-		App.Tap("btnClick");
-		var text = App.WaitForElement("btnClick").GetText();
-		Assert.That("Clicked" == text);
+		var btnElementId = "btnClick";
+		App.WaitForElement(btnElementId, $"Can t find the button {btnElementId}", timeout: TimeSpan.FromSeconds(10));
+		App.Tap(btnElementId);
+		App.WaitForTextToBePresentInElement(btnElementId, "Clicked", timeout: TimeSpan.FromSeconds(10));
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue19609.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue19609.cs
@@ -10,7 +10,7 @@ public class Issue19609 : _IssuesUITest
 {
 	public Issue19609(TestDevice device) : base(device) { }
 
-	public override string Issue => "Navigating Back to FlyoutPage Renders Blank Page";
+	public override string Issue => "Button clicked event and command will not be occurred in EmptyView of CollectionView";
 
 	[Test]
 	[Category(UITestCategories.CollectionView)]

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue19609.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue19609.cs
@@ -1,0 +1,24 @@
+﻿using System.Drawing;
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+using OpenQA.Selenium.Interactions;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+public class Issue19609 : _IssuesUITest
+{
+	public Issue19609(TestDevice device) : base(device) { }
+
+	public override string Issue => "Navigating Back to FlyoutPage Renders Blank Page";
+
+	[Test]
+	[Category(UITestCategories.CollectionView)]
+	public void CanTapButtonOnEmptyView()
+	{
+		App.WaitForElement("btnClick");
+		App.Tap("btnClick");
+		var text = App.WaitForElement("btnClick").GetText();
+		Assert.That("Clicked" == text);
+	}
+}


### PR DESCRIPTION
### Description of Change

On the the templates for `FormsListViewTemplate` the  `EmptyViewContentControl` is bellow the ScrollViewer so it does t receive inputs even if no items are showing.

### Issues Fixed

Fixes #19609 
