### PR TITLE
Don't require obsolete ISystemResourcesProvider

### DIFF
--- a/src/Controls/src/Core/Application/Application.cs
+++ b/src/Controls/src/Core/Application/Application.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Maui.Controls
 		readonly Lazy<PlatformConfigurationRegistry<Application>> _platformConfigurationRegistry;
 
 #pragma warning disable CS0612 // Type or member is obsolete
-		readonly Lazy<IResourceDictionary> _systemResources;
+		readonly Lazy<IResourceDictionary?> _systemResources;
 #pragma warning restore CS0612 // Type or member is obsolete
 
 		IAppIndexingProvider? _appIndexProvider;
@@ -40,10 +40,13 @@ namespace Microsoft.Maui.Controls
 				SetCurrentApplication(this);
 
 #pragma warning disable CS0612 // Type or member is obsolete
-			_systemResources = new Lazy<IResourceDictionary>(() =>
+			_systemResources = new Lazy<IResourceDictionary?>(() =>
 			{
 				var systemResources = DependencyService.Get<ISystemResourcesProvider>().GetSystemResources();
-				systemResources.ValuesChanged += OnParentResourcesChanged;
+				if (systemResources is not null)
+				{
+					systemResources.ValuesChanged += OnParentResourcesChanged;
+				}
 				return systemResources;
 			});
 #pragma warning restore CS0612 // Type or member is obsolete
@@ -127,7 +130,7 @@ namespace Microsoft.Maui.Controls
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public NavigationProxy? NavigationProxy { get; private set; }
 
-		internal IResourceDictionary SystemResources => _systemResources.Value;
+		internal IResourceDictionary? SystemResources => _systemResources.Value;
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/Application.xml" path="//Member[@MemberName='SetAppIndexingProvider']/Docs/*" />
 		[EditorBrowsable(EditorBrowsableState.Never)]


### PR DESCRIPTION


<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

The `ISystemResourcesProvider` type and the way to use it is obsolete and not required to be implemented. However we have the init code path requiring it. Everywhere else checks for null, except the init code path.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #24216

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
