### PR TITLE
[Windows] Fix crash setting MenuFlyoutSubItem IconImageSource

### DIFF
--- a/src/Controls/src/Core/Menu/MenuFlyoutSubItem.cs
+++ b/src/Controls/src/Core/Menu/MenuFlyoutSubItem.cs
@@ -16,7 +16,12 @@ namespace Microsoft.Maui.Controls
 
 		public MenuFlyoutSubItem()
 		{
-			LogicalChildrenInternalBackingStore = new CastingList<Element, IMenuElement>(_menus);
+			LogicalChildrenInternalBackingStore = new List<Element>();
+
+			foreach(var item in _menus)
+			{
+				LogicalChildrenInternalBackingStore.Add((Element)item);
+			}
 		}
 
 		private protected override IList<Element> LogicalChildrenInternalBackingStore { get; }

--- a/src/Controls/src/Core/Menu/MenuFlyoutSubItem.cs
+++ b/src/Controls/src/Core/Menu/MenuFlyoutSubItem.cs
@@ -9,10 +9,10 @@ namespace Microsoft.Maui.Controls
 	{
 		readonly List<IElement> _menus = new List<IElement>();
 
-        public MenuFlyoutSubItem()
-        {
-            LogicalChildrenInternalBackingStore = new CastingList<Element, IElement>(_menus);
-        }
+		public MenuFlyoutSubItem()
+		{
+			LogicalChildrenInternalBackingStore = new CastingList<Element, IElement>(_menus);
+		}
 
 		private protected override IList<Element> LogicalChildrenInternalBackingStore { get; }
 
@@ -53,10 +53,10 @@ namespace Microsoft.Maui.Controls
 			_menus.CopyTo(array, arrayIndex);
 		}
 
-        public IEnumerator<IMenuElement> GetEnumerator()
-        {
-            return _menus.Cast<IMenuElement>().GetEnumerator();
-        }
+		public IEnumerator<IMenuElement> GetEnumerator()
+		{
+			return _menus.Cast<IMenuElement>().GetEnumerator();
+		}
 
 		public int IndexOf(IMenuElement item)
 		{

--- a/src/Controls/src/Core/Menu/MenuFlyoutSubItem.cs
+++ b/src/Controls/src/Core/Menu/MenuFlyoutSubItem.cs
@@ -1,34 +1,24 @@
 #nullable disable
-using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.ComponentModel;
-using System.Windows.Input;
-using Microsoft.Maui.Controls.StyleSheets;
-using Microsoft.Maui.Graphics;
+using System.Linq;
 
 namespace Microsoft.Maui.Controls
 {
 	public partial class MenuFlyoutSubItem : MenuFlyoutItem, IMenuFlyoutSubItem
 	{
-		readonly List<IMenuElement> _menus = new List<IMenuElement>();
+		readonly List<IElement> _menus = new List<IElement>();
 
-		public MenuFlyoutSubItem()
-		{
-			LogicalChildrenInternalBackingStore = new List<Element>();
-
-			foreach(var item in _menus)
-			{
-				LogicalChildrenInternalBackingStore.Add((Element)item);
-			}
-		}
+        public MenuFlyoutSubItem()
+        {
+            LogicalChildrenInternalBackingStore = new CastingList<Element, IElement>(_menus);
+        }
 
 		private protected override IList<Element> LogicalChildrenInternalBackingStore { get; }
 
 		public IMenuElement this[int index]
 		{
-			get { return _menus[index]; }
+			get { return _menus[index] as IMenuElement; }
 			set
 			{
 				RemoveAt(index);
@@ -63,10 +53,10 @@ namespace Microsoft.Maui.Controls
 			_menus.CopyTo(array, arrayIndex);
 		}
 
-		public IEnumerator<IMenuElement> GetEnumerator()
-		{
-			return _menus.GetEnumerator();
-		}
+        public IEnumerator<IMenuElement> GetEnumerator()
+        {
+            return _menus.Cast<IMenuElement>().GetEnumerator();
+        }
 
 		public int IndexOf(IMenuElement item)
 		{
@@ -92,7 +82,7 @@ namespace Microsoft.Maui.Controls
 		{
 			var item = _menus[index];
 			RemoveLogicalChild((Element)item, index);
-			NotifyHandler(nameof(IMenuFlyoutHandler.Remove), index, item);
+			NotifyHandler(nameof(IMenuFlyoutHandler.Remove), index, item as IMenuElement);
 		}
 
 		IEnumerator IEnumerable.GetEnumerator()

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue25893.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue25893.xaml
@@ -4,7 +4,8 @@
                           xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
                           x:Class="Maui.Controls.Sample.Issues.Issue25893">
   <Grid RowDefinitions="Auto,*,Auto">
-    <ContentView Grid.Row="0" Grid.RowSpan="3">
+    <Label AutomationId="WaitForStubControl" Text="Issue25893"/>
+    <ContentView Grid.Row="1" Grid.RowSpan="2" BackgroundColor="LightGray">
       <FlyoutBase.ContextFlyout>
         <MenuFlyout x:Name="ContextMenu">
           <MenuFlyoutItem IconImageSource="dotnet_bot.png" Text="Copy" />

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue25893.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue25893.xaml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<controls:TestContentPage xmlns:controls="clr-namespace:Maui.Controls.Sample.Issues"
+                          xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+                          xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                          x:Class="Maui.Controls.Sample.Issues.Issue25893">
+  <Grid RowDefinitions="Auto,*,Auto">
+    <ContentView Grid.Row="0" Grid.RowSpan="3">
+      <FlyoutBase.ContextFlyout>
+        <MenuFlyout x:Name="ContextMenu">
+          <MenuFlyoutItem IconImageSource="dotnet_bot.png" Text="Copy" />
+          <MenuFlyoutSubItem IconImageSource="dotnet_bot.png" Text="Zoom"  />
+        </MenuFlyout>
+      </FlyoutBase.ContextFlyout>
+    </ContentView>
+  </Grid>
+</controls:TestContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue25893.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue25893.xaml
@@ -4,14 +4,20 @@
                           xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
                           x:Class="Maui.Controls.Sample.Issues.Issue25893">
   <Grid RowDefinitions="Auto,*,Auto">
-    <Label AutomationId="WaitForStubControl" Text="Issue25893"/>
-    <ContentView Grid.Row="1" Grid.RowSpan="2" BackgroundColor="LightGray">
+    <Label AutomationId="WaitForStubControl" x:Name="InfoLabel" />
+    <ContentView x:Name="ViewWithMenu" Grid.Row="1" BackgroundColor="LightGray">
       <FlyoutBase.ContextFlyout>
         <MenuFlyout x:Name="ContextMenu">
-          <MenuFlyoutItem IconImageSource="dotnet_bot.png" Text="Copy" />
-          <MenuFlyoutSubItem IconImageSource="dotnet_bot.png" Text="Zoom" />
+          <MenuFlyoutItem IconImageSource="dotnet_bot.png" Text="Item1" />
+          <MenuFlyoutSubItem IconImageSource="dotnet_bot.png" Text="SubItem1" />
+          <MenuFlyoutSubItem IconImageSource="dotnet_bot.png" Text="SubItem2" />
+          <MenuFlyoutSubItem IconImageSource="dotnet_bot.png" Text="SubItem3" />
         </MenuFlyout>
       </FlyoutBase.ContextFlyout>
     </ContentView>
+    <HorizontalStackLayout Grid.Row="2">
+      <Button AutomationId="AddMenuItem" Text="Add MenuItem" Clicked="AddButtonClicked" />
+      <Button AutomationId="RemoveMenuItem" Text="Remove MenuItem" Clicked="RemoveButtonClicked" />
+    </HorizontalStackLayout>
   </Grid>
 </controls:TestContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue25893.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue25893.xaml
@@ -8,7 +8,7 @@
       <FlyoutBase.ContextFlyout>
         <MenuFlyout x:Name="ContextMenu">
           <MenuFlyoutItem IconImageSource="dotnet_bot.png" Text="Copy" />
-          <MenuFlyoutSubItem IconImageSource="dotnet_bot.png" Text="Zoom"  />
+          <MenuFlyoutSubItem IconImageSource="dotnet_bot.png" Text="Zoom" />
         </MenuFlyout>
       </FlyoutBase.ContextFlyout>
     </ContentView>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue25893.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue25893.xaml
@@ -5,7 +5,7 @@
                           x:Class="Maui.Controls.Sample.Issues.Issue25893">
   <Grid RowDefinitions="Auto,*,Auto">
     <Label AutomationId="WaitForStubControl" x:Name="InfoLabel" />
-    <ContentView x:Name="ViewWithMenu" Grid.Row="1" BackgroundColor="LightGray">
+    <ContentView x:Name="ViewWithMenu" AutomationId="ViewWithMenu" Grid.Row="1" BackgroundColor="LightGray">
       <FlyoutBase.ContextFlyout>
         <MenuFlyout x:Name="ContextMenu">
           <MenuFlyoutItem IconImageSource="dotnet_bot.png" Text="Item1" />

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue25893.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue25893.xaml.cs
@@ -1,0 +1,17 @@
+﻿namespace Maui.Controls.Sample.Issues
+{
+
+	[Issue(IssueTracker.Github, 25893, "Setting MenuFlyoutSubItem IconImageSource throws a NullReferenceException", PlatformAffected.UWP)]
+	public partial class Issue25893 : TestContentPage
+	{
+		public Issue25893()
+		{
+			InitializeComponent();	
+		}
+
+		protected override void Init()
+		{
+		
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue25893.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue25893.xaml.cs
@@ -4,14 +4,50 @@
 	[Issue(IssueTracker.Github, 25893, "Setting MenuFlyoutSubItem IconImageSource throws a NullReferenceException", PlatformAffected.UWP)]
 	public partial class Issue25893 : TestContentPage
 	{
+		MenuFlyout _contextMenu;
+
 		public Issue25893()
 		{
-			InitializeComponent();	
+			InitializeComponent();
+
+			_contextMenu = FlyoutBase.GetContextFlyout(ViewWithMenu) as MenuFlyout;
+
+			if (_contextMenu is null)
+				return;
+
+			var itemsCount = _contextMenu.Count;
+			InfoLabel.Text = $"{itemsCount}";
 		}
 
 		protected override void Init()
 		{
-		
+
 		}
-	}
+
+		void AddButtonClicked(object sender, EventArgs e)
+		{
+			if (_contextMenu is null)
+				return;
+
+			var itemsCount = _contextMenu.Count;
+			InfoLabel.Text = $"{itemsCount}";
+
+			var itemNumber = itemsCount > 0 ? itemsCount : 1;
+			_contextMenu.Add(new MenuFlyoutSubItem { IconImageSource = "dotnet_bot.png", Text = $"Added Item {itemNumber}" });
+		}
+
+		void RemoveButtonClicked(object sender, EventArgs e)
+		{
+			if (_contextMenu is null)
+				return;
+
+			var itemsCount = _contextMenu.Count;
+			InfoLabel.Text = $"{itemsCount}";
+
+			if (itemsCount > 0)
+			{
+				_contextMenu.RemoveAt(itemsCount - 1);
+			}	
+		}
+    }
 }

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue25893.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue25893.xaml.cs
@@ -4,19 +4,18 @@
 	[Issue(IssueTracker.Github, 25893, "Setting MenuFlyoutSubItem IconImageSource throws a NullReferenceException", PlatformAffected.UWP)]
 	public partial class Issue25893 : TestContentPage
 	{
-		MenuFlyout _contextMenu;
+		readonly MenuFlyout _contextMenu;
 
 		public Issue25893()
 		{
 			InitializeComponent();
 
-			_contextMenu = FlyoutBase.GetContextFlyout(ViewWithMenu) as MenuFlyout;
+			_contextMenu = (MenuFlyout)FlyoutBase.GetContextFlyout(ViewWithMenu);
 
 			if (_contextMenu is null)
 				return;
 
-			var itemsCount = _contextMenu.Count;
-			InfoLabel.Text = $"{itemsCount}";
+			InfoLabel.Text = $"{_contextMenu.Count}";
 		}
 
 		protected override void Init()
@@ -26,28 +25,27 @@
 
 		void AddButtonClicked(object sender, EventArgs e)
 		{
-			if (_contextMenu is null)
-				return;
-
 			var itemsCount = _contextMenu.Count;
-			InfoLabel.Text = $"{itemsCount}";
-
 			var itemNumber = itemsCount > 0 ? itemsCount : 1;
 			_contextMenu.Add(new MenuFlyoutSubItem { IconImageSource = "dotnet_bot.png", Text = $"Added Item {itemNumber}" });
+
+			UpdateInfoLabel();
 		}
 
 		void RemoveButtonClicked(object sender, EventArgs e)
 		{
-			if (_contextMenu is null)
-				return;
-
 			var itemsCount = _contextMenu.Count;
-			InfoLabel.Text = $"{itemsCount}";
 
 			if (itemsCount > 0)
-			{
 				_contextMenu.RemoveAt(itemsCount - 1);
-			}	
+			
+			UpdateInfoLabel();
+		}
+
+		void UpdateInfoLabel()
+		{
+			var itemsCount = _contextMenu.Count;
+			InfoLabel.Text = $"{itemsCount}";
 		}
     }
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25893.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25893.cs
@@ -1,0 +1,23 @@
+﻿using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue25893 : _IssuesUITest
+{
+	public override string Issue => "Setting MenuFlyoutSubItem IconImageSource throws a NullReferenceException";
+
+	public Issue25893(TestDevice testDevice) : base(testDevice)
+	{
+	}
+
+	[Test]
+	[Category(UITestCategories.ContextActions)]
+	public void MenuFlyoutSubItemWithIconNoCrash()
+	{
+		App.WaitForElement("WaitForStubControl");
+
+		// Without crashing, the test has passed.
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25893.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25893.cs
@@ -1,4 +1,5 @@
 ﻿using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using UITest.Appium;
 using UITest.Core;
 
@@ -17,6 +18,24 @@ public class Issue25893 : _IssuesUITest
 	public void MenuFlyoutSubItemWithIconNoCrash()
 	{
 		App.WaitForElement("WaitForStubControl");
+
+		var result1 = App.FindElement("WaitForStubControl").GetText();
+		ClassicAssert.AreEqual("3", result1);
+
+		App.Tap("AddMenuItem");
+		
+		var result2 = App.FindElement("WaitForStubControl").GetText();
+		ClassicAssert.AreEqual("4", result2);
+
+		App.Tap("RemoveMenuItem");
+		App.Tap("RemoveMenuItem");
+		
+		var result3 = App.FindElement("WaitForStubControl").GetText();
+		ClassicAssert.AreEqual("2", result3);
+
+		App.RightClick("WaitForStubControl");
+
+		VerifyScreenshot();
 
 		// Without crashing, the test has passed.
 	}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25893.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25893.cs
@@ -1,4 +1,4 @@
-﻿#if WINDOWS
+﻿#if MACCATALYST || WINDOWS
 using NUnit.Framework;
 using NUnit.Framework.Legacy;
 using UITest.Appium;

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25893.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25893.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿#if WINDOWS
+using NUnit.Framework;
 using NUnit.Framework.Legacy;
 using UITest.Appium;
 using UITest.Core;
@@ -20,23 +21,20 @@ public class Issue25893 : _IssuesUITest
 		App.WaitForElement("WaitForStubControl");
 
 		var result1 = App.FindElement("WaitForStubControl").GetText();
-		ClassicAssert.AreEqual("3", result1);
+		ClassicAssert.AreEqual("4", result1);
 
 		App.Tap("AddMenuItem");
 		
 		var result2 = App.FindElement("WaitForStubControl").GetText();
-		ClassicAssert.AreEqual("4", result2);
+		ClassicAssert.AreEqual("5", result2);
 
 		App.Tap("RemoveMenuItem");
 		App.Tap("RemoveMenuItem");
 		
 		var result3 = App.FindElement("WaitForStubControl").GetText();
-		ClassicAssert.AreEqual("2", result3);
-
-		App.RightClick("WaitForStubControl");
-
-		VerifyScreenshot();
+		ClassicAssert.AreEqual("3", result3);
 
 		// Without crashing, the test has passed.
 	}
 }
+#endif

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Issue25893.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Issue25893.xaml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+			 x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Issue25893">
+  <Grid RowDefinitions="Auto,*,Auto">
+    <Label AutomationId="WaitForStubControl" Text="Issue25893"/>
+    <ContentView x:Name="ViewWithMenu" Grid.Row="1" Grid.RowSpan="2" BackgroundColor="LightGray">
+      <FlyoutBase.ContextFlyout>
+        <MenuFlyout x:Name="ContextMenu">
+          <MenuFlyoutItem IconImageSource="dotnet_bot.png" Text="Item1" />
+          <MenuFlyoutSubItem IconImageSource="dotnet_bot.png" Text="SubItem1" />
+        </MenuFlyout>
+      </FlyoutBase.ContextFlyout>
+    </ContentView>
+  </Grid>
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Issue25893.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Issue25893.xaml.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Core.UnitTests;
+using NUnit.Framework;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests
+{
+	public partial class Issue25893 : ContentPage
+	{
+		public Issue25893()
+		{
+			InitializeComponent();
+		}
+
+		public Issue25893(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		public class Tests
+		{
+			[TestCase(false)]
+			[TestCase(true)]
+			public void MenuFlyoutSubItemWithIcon(bool useCompiledXaml)
+			{
+				var page = new Issue25893(useCompiledXaml);
+				var view = page.FindByName<ContentView>("ViewWithMenu");
+				var contextFlyout = FlyoutBase.GetContextFlyout(view);
+	
+				Assert.AreEqual(contextFlyout.LogicalChildrenInternal.Count, 2);
+			}
+		}
+	}
+}

--- a/src/Core/src/Handlers/MenuFlyoutSubItem/MenuFlyoutSubItemHandler.Windows.cs
+++ b/src/Core/src/Handlers/MenuFlyoutSubItem/MenuFlyoutSubItemHandler.Windows.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using Microsoft.Maui.Platform;
 using Microsoft.UI.Xaml.Controls;
@@ -62,16 +63,19 @@ namespace Microsoft.Maui.Handlers
 				view.Source?.ToIconSource(handler.MauiContext!)?.CreateIconElement();
 		}
 
-		public override void SetVirtualView(IElement view)
-		{
-			base.SetVirtualView(view);
-			PlatformView.Items.Clear();
+        public override void SetVirtualView(IElement view)
+        {
+            base.SetVirtualView(view);
+            PlatformView.Items.Clear();
 
-			foreach (var item in ((IMenuFlyoutSubItem)view))
-			{
-				PlatformView.Items.Add((MenuFlyoutItemBase)item.ToPlatform(MauiContext!));
-			}
-		}
+            if (view is IMenuFlyoutSubItem menuFlyoutSubItem)
+            {
+                foreach (var item in menuFlyoutSubItem.OfType<IMenuElement>())
+                {
+                    PlatformView.Items.Add((MenuFlyoutItemBase)item.ToPlatform(MauiContext!));
+                }
+            }
+        }
 
 		// workaround WinUI bug https://github.com/microsoft/microsoft-ui-xaml/issues/7797
 		void Reset()

--- a/src/Core/src/Handlers/MenuFlyoutSubItem/MenuFlyoutSubItemHandler.iOS.cs
+++ b/src/Core/src/Handlers/MenuFlyoutSubItem/MenuFlyoutSubItemHandler.iOS.cs
@@ -1,4 +1,6 @@
-﻿using UIKit;
+﻿using System.Collections.Generic;
+using System.Linq;
+using UIKit;
 
 namespace Microsoft.Maui.Handlers
 {
@@ -15,8 +17,10 @@ namespace Microsoft.Maui.Handlers
 				uIMenuBuilder = builder;
 			}
 
+			var menuItems = ((IMenuFlyoutSubItem)VirtualView).OfType<IMenuElement>().ToList();
+			
 			var menu =
-				VirtualView.ToPlatformMenu(
+				menuItems.ToPlatformMenu(
 					VirtualView.Text,
 					VirtualView.Source,
 					MauiContext!,


### PR DESCRIPTION
### Description of Change

Fix crash setting `MenuFlyoutSubItem` IconImageSource on Windows.

From https://github.com/dotnet/maui/pull/24688 the ImageSource  is added as logical children of the menu item. However, the `LogicalChildrenInternalBackingStore` collection from MenuFlyoutSubItem  does a casting to `IMenuElement` https://github.com/dotnet/maui/blob/5b5aaa5ef83f54688bee408cf14768f443d5aa2e/src/Controls/src/Core/Menu/MenuFlyoutSubItem.cs#L19

Trying to add the IconImageSource to the LogicalChildrenInternalBackingStore insert a null value because this casting https://github.com/dotnet/maui/blob/5b5aaa5ef83f54688bee408cf14768f443d5aa2e/src/Controls/src/Core/ReadOnlyCastingList.cs#L91 fails, cannot convert from Element to `IMenuElement`.

This PR apply changes to allow Element in the `LogicalChildrenInternalBackingStore` collection from MenuFlyoutSubItem.

### Issues Fixed

Fixes #25893
