### PR TITLE
Fall back to loading .NET 8 date strings

### DIFF
--- a/src/Essentials/src/Preferences/Preferences.uwp.cs
+++ b/src/Essentials/src/Preferences/Preferences.uwp.cs
@@ -212,12 +212,16 @@ namespace Microsoft.Maui.Storage
 				{
 					if (defaultValue is DateTime dt)
 					{
-						long tempValue = (long)Convert.ChangeType(value, typeof(long), CultureInfo.InvariantCulture);
-						return (T)(object)DateTime.FromBinary(tempValue);
+						// long for the .NET 9+ format
+						if (long.TryParse(value, CultureInfo.InvariantCulture, out var longValue))
+							return (T)(object)DateTime.FromBinary(longValue);
+						// DateTime string for the .NET 8 format
+						if (DateTime.TryParse(value, CultureInfo.InvariantCulture, out var datetimeValue))
+							return (T)(object)datetimeValue;
 					}
 					else if (defaultValue is DateTimeOffset dto)
 					{
-						if (DateTimeOffset.TryParse((string)value, out var dateTimeOffset))
+						if (DateTimeOffset.TryParse((string)value, CultureInfo.InvariantCulture, out var dateTimeOffset))
 						{
 							return (T)(object)dateTimeOffset;
 						}

--- a/src/Essentials/test/DeviceTests/Tests/Preferences_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/Preferences_Tests.cs
@@ -251,7 +251,7 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 		public void DateTime_Supports_Reading_String_Compat()
 		{
 			// This is a special test where when unpackaged on windows in .NET 8
-			// dates were stored as ToString but in .NET 6 they are stored as ToBinary.
+			// dates were stored as ToString but in .NET 9 they are stored as ToBinary.
 			// This test ensures that the compat layer is working correctly
 			// and that the date is read correctly regardless of the storage format.
 			// This test is only valid on windows unpackaged.

--- a/src/Essentials/test/DeviceTests/Tests/Preferences_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/Preferences_Tests.cs
@@ -246,6 +246,27 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 		public void FailsWithUnsupportedType() =>
 			Assert.Throws<NotSupportedException>(() => Preferences.Default.Set("anything", new int[] { 1 }));
 
+#if WINDOWS
+		[Fact]
+		public void DateTime_Supports_Reading_String_Compat()
+		{
+			// This is a special test where when unpackaged on windows in .NET 8
+			// dates were stored as ToString but in .NET 6 they are stored as ToBinary.
+			// This test ensures that the compat layer is working correctly
+			// and that the date is read correctly regardless of the storage format.
+			// This test is only valid on windows unpackaged.
+
+			if (ApplicationModel.AppInfoUtils.IsPackagedApp)
+				return;
+
+			Preferences.Default.Set("datetime_compat", testDateTime.ToString(), null);
+
+			var get = Preferences.Default.Get("datetime_compat", DateTime.MinValue, null);
+
+			Assert.Equal(testDateTime, get);
+		}
+#endif
+
 		[Theory]
 		[InlineData("datetime1", null)]
 		[InlineData("datetime1", sharedNameTestData)]


### PR DESCRIPTION

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

This has to do with the different implementations of the preferences API on Windows depending on packaged or unpackaged.

* The .NET 8 template was packaged
* The .NET 9 template was unpackaged

The implementation differs:

* packaged uses the ApplicationDataContainer APIs and stores as long and cannot be retrieved as string
* unpackaged uses a string dictionary that is serialized to a file

The real change comes in at #22815 where that PR had this line: https://github.com/dotnet/maui/pull/22815/files#diff-6ed591e38dc7754551705bf5bb96f992115c384d19166e8dcda76267e177fb0cR196-R197

In .NET 8 everything was a "ToString" system for unpackaged. In .NET 9 there is now a ToBinary.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #25930

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
