### PR TITLE
[Windows] `FileSystem.Current.AppDataDirectory` returns different path after updating to latest version - fix

### DIFF
--- a/src/Essentials/src/FileSystem/FileSystem.uwp.cs
+++ b/src/Essentials/src/FileSystem/FileSystem.uwp.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Maui.Storage
 			}
 			else
 			{
-				string path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), AppSpecificPath, "Data");
+				string path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), AppSpecificPath, "Data");
 
 				if (!File.Exists(path))
 				{


### PR DESCRIPTION
### Description of Change

Unfortunately #23265 introduced a regression. This PR attempts to fix it.

The regression was introduced because this [line](https://github.com/dotnet/maui/pull/23265/files?diff=split&w=0#diff-68e97c448bfa67ad3c292a6e146185895b0c2c6437fe5f361d6044327b56dc84L26):

```cs
Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), AppSpecificPath, "Data");
```

was translated to this [line](https://github.com/dotnet/maui/pull/23265/files?diff=split&w=0#diff-68e97c448bfa67ad3c292a6e146185895b0c2c6437fe5f361d6044327b56dc84R39):

```cs
Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), AppSpecificPath, "Data");
```

### Issues Fixed

Fixes #25981
