### PR TITLE
[WiP] Fix leak on Command Element

### DIFF
--- a/src/Controls/src/Core/CommandElement.cs
+++ b/src/Controls/src/Core/CommandElement.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Maui.Controls
 			{
 				newCommand.CanExecuteChanged += commandElement.CanExecuteChanged;
 
-				//HandleTearDown(commandElement);
+				HandleTearDown(commandElement);
 
 				commandElement.CanExecuteChanged(bo, EventArgs.Empty);
 			}

--- a/src/Controls/src/Core/CommandElement.cs
+++ b/src/Controls/src/Core/CommandElement.cs
@@ -18,8 +18,13 @@ namespace Microsoft.Maui.Controls
 		{
 			var commandElement = (ICommandElement)bo;
 			if (n is ICommand newCommand)
+			{
 				newCommand.CanExecuteChanged += commandElement.CanExecuteChanged;
-			commandElement.CanExecuteChanged(bo, EventArgs.Empty);
+
+				//HandleTearDown(commandElement);
+
+				commandElement.CanExecuteChanged(bo, EventArgs.Empty);
+			}
 		}
 
 		public static void OnCommandParameterChanged(BindableObject bo, object o, object n)
@@ -34,6 +39,23 @@ namespace Microsoft.Maui.Controls
 				return true;
 
 			return commandElement.Command.CanExecute(commandElement.CommandParameter);
+		}
+
+		static void HandleTearDown(ICommandElement commandElement)
+		{
+			if (commandElement is not VisualElement ve)
+				return;
+
+			ve.Unloaded -= OnUnloaded;
+			ve.Unloaded += OnUnloaded;
+
+			static void OnUnloaded(object? sender, EventArgs e)
+			{
+				if (sender is ICommandElement element && element.Command is not null)
+				{
+					element.Command.CanExecuteChanged -= element.CanExecuteChanged;
+				}
+			}
 		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/RefreshView/RefreshViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/RefreshView/RefreshViewTests.cs
@@ -4,8 +4,10 @@ using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
+using System.Windows.Input;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Handlers.Items;
+using Microsoft.Maui.DeviceTests.Stubs;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Hosting;
 using Microsoft.Maui.Platform;
@@ -25,9 +27,15 @@ namespace Microsoft.Maui.DeviceTests
 					handlers.AddHandler<RefreshView, RefreshViewHandler>();
 					handlers.AddHandler<Label, LabelHandler>();
 					handlers.AddHandler<Entry, EntryHandler>();
+
+					handlers.AddHandler<Grid, LayoutHandler>();
+					handlers.AddHandler<NavigationPage, NavigationViewHandler>();
+					handlers.AddHandler<Button, ButtonHandler>();
+					handlers.AddHandler(typeof(Toolbar), typeof(ToolbarHandler));
 				});
 			});
 		}
+
 		[Fact(DisplayName = "Setting the content of RefreshView removes previous platform view from visual tree")]
 		public async Task ChangingRefreshViewContentRemovesPreviousContentsPlatformViewFromVisualTree()
 		{
@@ -46,6 +54,122 @@ namespace Microsoft.Maui.DeviceTests
 				await Task.Yield();
 				Assert.NotNull(((newContent as IView).Handler as IPlatformViewHandler).PlatformView.GetParent());
 			});
+		}
+
+		[Fact("Batata")]
+		public async Task DoesNotLeak()
+		{
+			SetupBuilder();
+
+			// Long-lived ICommand, like a Singleton ViewModel
+			var command = new MyCommand();
+			var c2 = new MyCommand();
+			WeakReference reference = null;
+			var navPage = new NavigationPage(new ContentPage());
+
+			await CreateHandlerAndAddToWindow<WindowHandlerStub>(new Window(navPage), async window =>
+			{
+				var layout = new Grid();
+				//var refreshView = new RefreshView
+				//{
+				//	Command = command,
+				//};
+
+				var btn = new Button
+				{
+					Command = command
+				};
+
+				var label = new Label();
+				//refreshView.Content = label;
+				layout.Add(btn);
+				//var handler = CreateHandler<LayoutHandler>(layout);
+				//((window.VirtualView as Window).Page as ContentPage).Content = layout;
+
+				var page2 = new ContentPage
+				{
+					Content = layout
+				};
+
+				reference = new(btn);
+				await navPage.PushAsync(page2);
+				await OnLoadedAsync(btn);
+				btn.Command = c2;
+				await navPage.PopAsync();
+				await OnUnloadedAsync(page2);
+				_ = 1; 
+			});
+
+
+
+			//await InvokeOnMainThreadAsync(async () =>
+			//{
+			//	var layout = new Grid();
+			//	var refreshView = new RefreshView
+			//	{
+			//		Command = command,
+			//	};
+			//	var label = new Label();
+			//	refreshView.Content = label;
+			//	layout.Add(refreshView);
+			//	var handler = CreateHandler<LayoutHandler>(layout);
+			//	await OnLoadedAsync(refreshView);
+			//	reference = new(refreshView);
+			//});
+
+			Assert.NotNull(reference);
+
+			// Several GCs required on iOS
+			await AssertionExtensions.WaitForGC(reference);
+		}
+
+		[Fact("Batata 2")]
+		public async Task MultiCommandsShouldNotLeak()
+		{
+			SetupBuilder();
+
+			// Long-lived ICommand, like a Singleton ViewModel
+			var command = new MyCommand();
+			var command2 = new MyCommand();
+			WeakReference reference = null;
+			var navPage = new NavigationPage(new ContentPage());
+
+			await CreateHandlerAndAddToWindow<WindowHandlerStub>(new Window(navPage), async window =>
+			{
+				var layout = new Grid();
+				var refreshView = new RefreshView
+				{
+					Command = command,
+				};
+				var label = new Label();
+				refreshView.Content = label;
+				layout.Add(refreshView);
+
+				var page2 = new ContentPage
+				{
+					Content = refreshView
+				};
+
+				reference = new(refreshView);
+				await navPage.PushAsync(page2);
+				await OnLoadedAsync(refreshView);
+				refreshView.Command = command2;
+				await navPage.PopAsync();
+				await OnUnloadedAsync(page2);
+				_ = 1; 
+			});
+
+		}
+
+		class MyCommand : ICommand
+		{
+			public event EventHandler CanExecuteChanged;
+
+			public bool CanExecute(object parameter) => true;
+
+			public void Execute(object parameter) { }
+
+			public void FireCanExecuteChanged() => CanExecuteChanged?.Invoke(this, EventArgs.Empty);
 		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/RefreshView/RefreshViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/RefreshView/RefreshViewTests.cs
@@ -4,10 +4,8 @@ using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
-using System.Windows.Input;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Handlers.Items;
-using Microsoft.Maui.DeviceTests.Stubs;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Hosting;
 using Microsoft.Maui.Platform;
@@ -27,15 +25,9 @@ namespace Microsoft.Maui.DeviceTests
 					handlers.AddHandler<RefreshView, RefreshViewHandler>();
 					handlers.AddHandler<Label, LabelHandler>();
 					handlers.AddHandler<Entry, EntryHandler>();
-
-					handlers.AddHandler<Grid, LayoutHandler>();
-					handlers.AddHandler<NavigationPage, NavigationViewHandler>();
-					handlers.AddHandler<Button, ButtonHandler>();
-					handlers.AddHandler(typeof(Toolbar), typeof(ToolbarHandler));
 				});
 			});
 		}
-
 		[Fact(DisplayName = "Setting the content of RefreshView removes previous platform view from visual tree")]
 		public async Task ChangingRefreshViewContentRemovesPreviousContentsPlatformViewFromVisualTree()
 		{
@@ -54,122 +46,6 @@ namespace Microsoft.Maui.DeviceTests
 				await Task.Yield();
 				Assert.NotNull(((newContent as IView).Handler as IPlatformViewHandler).PlatformView.GetParent());
 			});
-		}
-
-		[Fact("Batata")]
-		public async Task DoesNotLeak()
-		{
-			SetupBuilder();
-
-			// Long-lived ICommand, like a Singleton ViewModel
-			var command = new MyCommand();
-			var c2 = new MyCommand();
-			WeakReference reference = null;
-			var navPage = new NavigationPage(new ContentPage());
-
-			await CreateHandlerAndAddToWindow<WindowHandlerStub>(new Window(navPage), async window =>
-			{
-				var layout = new Grid();
-				//var refreshView = new RefreshView
-				//{
-				//	Command = command,
-				//};
-
-				var btn = new Button
-				{
-					Command = command
-				};
-
-				var label = new Label();
-				//refreshView.Content = label;
-				layout.Add(btn);
-				//var handler = CreateHandler<LayoutHandler>(layout);
-				//((window.VirtualView as Window).Page as ContentPage).Content = layout;
-
-				var page2 = new ContentPage
-				{
-					Content = layout
-				};
-
-				reference = new(btn);
-				await navPage.PushAsync(page2);
-				await OnLoadedAsync(btn);
-				btn.Command = c2;
-				await navPage.PopAsync();
-				await OnUnloadedAsync(page2);
-				_ = 1; 
-			});
-
-
-
-			//await InvokeOnMainThreadAsync(async () =>
-			//{
-			//	var layout = new Grid();
-			//	var refreshView = new RefreshView
-			//	{
-			//		Command = command,
-			//	};
-			//	var label = new Label();
-			//	refreshView.Content = label;
-			//	layout.Add(refreshView);
-			//	var handler = CreateHandler<LayoutHandler>(layout);
-			//	await OnLoadedAsync(refreshView);
-			//	reference = new(refreshView);
-			//});
-
-			Assert.NotNull(reference);
-
-			// Several GCs required on iOS
-			await AssertionExtensions.WaitForGC(reference);
-		}
-
-		[Fact("Batata 2")]
-		public async Task MultiCommandsShouldNotLeak()
-		{
-			SetupBuilder();
-
-			// Long-lived ICommand, like a Singleton ViewModel
-			var command = new MyCommand();
-			var command2 = new MyCommand();
-			WeakReference reference = null;
-			var navPage = new NavigationPage(new ContentPage());
-
-			await CreateHandlerAndAddToWindow<WindowHandlerStub>(new Window(navPage), async window =>
-			{
-				var layout = new Grid();
-				var refreshView = new RefreshView
-				{
-					Command = command,
-				};
-				var label = new Label();
-				refreshView.Content = label;
-				layout.Add(refreshView);
-
-				var page2 = new ContentPage
-				{
-					Content = refreshView
-				};
-
-				reference = new(refreshView);
-				await navPage.PushAsync(page2);
-				await OnLoadedAsync(refreshView);
-				refreshView.Command = command2;
-				await navPage.PopAsync();
-				await OnUnloadedAsync(page2);
-				_ = 1; 
-			});
-
-		}
-
-		class MyCommand : ICommand
-		{
-			public event EventHandler CanExecuteChanged;
-
-			public bool CanExecute(object parameter) => true;
-
-			public void Execute(object parameter) { }
-
-			public void FireCanExecuteChanged() => CanExecuteChanged?.Invoke(this, EventArgs.Empty);
 		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
+++ b/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
@@ -602,7 +602,7 @@ public class MemoryTests : ControlsHandlerTestBase
 
 		await AssertionExtensions.WaitForGC(reference);
 	}
-	
+
 	[Fact]
 	public async Task TweenersWillNotLeakDuringInfiniteAnimation()
 	{
@@ -629,6 +629,14 @@ public class MemoryTests : ControlsHandlerTestBase
 
 		Assert.True(AnimationExtensions.TweenersCounter <= 2);
 	}
+}
+
+class MyCommand : ICommand
+{
+	public event EventHandler CanExecuteChanged;
+	public bool CanExecute(object parameter) => true;
+	public void Execute(object parameter) { }
+	public void FireCanExecuteChanged() => CanExecuteChanged?.Invoke(this, EventArgs.Empty);
 }
 
 sealed class AnimationPage : ContentPage


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

<!-- Enter description of the fix in this section -->
This PRs make sure that controls that implements `ICommandElement` unsubscribe from `Command.CanExecuteChanged` event avoid the control to leak if the `Command` lives longer than it.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #16124

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
