### PR TITLE
Fixed An issue with Microsoft.Maui.Animations when testing a custom busy indicator control.

### DIFF
--- a/src/Graphics/src/Graphics/Platforms/MaciOS/PlatformCanvas.cs
+++ b/src/Graphics/src/Graphics/Platforms/MaciOS/PlatformCanvas.cs
@@ -405,6 +405,13 @@ namespace Microsoft.Maui.Graphics.Platform
 				_context.SetShouldAntialias(true);
 		}
 
+		// Normalize the angle to be between 0 and 2PI
+        float NormalizeAngle(float angle)
+        {
+            var twoPi = MathF.PI * 2;
+            return (angle % twoPi + twoPi) % twoPi;
+        }
+
 		protected override void PlatformDrawArc(float x, float y, float width, float height, float startAngle, float endAngle, bool clockwise, bool close)
 		{
 			_rect.X = x;
@@ -414,14 +421,9 @@ namespace Microsoft.Maui.Graphics.Platform
 
 			if (!_antialias)
 				_context.SetShouldAntialias(false);
-			var startAngleInRadians = GeometryUtil.DegreesToRadians(-startAngle);
-			var endAngleInRadians = GeometryUtil.DegreesToRadians(-endAngle);
 
-			while (startAngleInRadians < 0)
-				startAngleInRadians += MathF.PI * 2;
-
-			while (endAngleInRadians < 0)
-				endAngleInRadians += MathF.PI * 2;
+			var startAngleInRadians = NormalizeAngle(GeometryUtil.DegreesToRadians(-startAngle));
+			var endAngleInRadians = NormalizeAngle(GeometryUtil.DegreesToRadians(-endAngle));
 
 			if (width == height)
 			{


### PR DESCRIPTION
### Issue Details
The custom busy indicator control disappears after some time (approx 16 seconds) on iOS and macOS.

### Root Cause
Invalid valid value for start and end angle was passed to the PlatformDrawArc method. As a result, the indicator disappears from view and below message is displayed in the debug console.

**Error Message**

`Maui.Controls.Sample.Sandbox[49285:546706] [Unknown process name] CGPathAddArc: invalid value for start or end angle.`
 
### Description of Change
* Core Graphics requires angles within the range [0,2π] radians. Any angle outside this range, whether negative or exceeding is considered invalid.

**Debugging session**
`
2024-11-18 16:24:18.799770+0530 Maui.Controls.Sample.Sandbox[49285:546706] startAngle: -359685 endAngle: -359725
2024-11-18 16:24:18.800034+0530 Maui.Controls.Sample.Sandbox[49285:546706] Drawing arc from 6282.732 to 6283.4297
2024-11-18 16:24:18.800189+0530 Maui.Controls.Sample.Sandbox[49285:546706] [Unknown process name] CGPathAddArc: invalid value for start or end angle.
`
* The values 6282.732 and 6283.4297 (radians) far exceed the proper radians (approximately 6.2832). These values are derived from a significantly negative start and end angle in degrees (-359685° and -359725°), converted to radians.

* Bringing them into the 0 to 2π range before using them in your drawing logic resolves the issue.

 
Validated the behaviour in the following platforms
 
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac
 
 
### Issues Fixed
  
Fixes #22055

### Output 
|Before|After|
|--|--|
| <video src="https://github.com/user-attachments/assets/d6f5dae0-135a-4f3d-9ce1-7fb89d1cb47f" >| <video src="https://github.com/user-attachments/assets/8a0a5c46-fbee-4893-9553-168b2454adad" >|
| <video src="https://github.com/user-attachments/assets/7410f9a3-1c50-4d39-9db8-12f1f5bded0a" >| <video src="https://github.com/user-attachments/assets/f7587dc1-b533-435b-89d9-004abf402be8" >|














