### PR TITLE
Fix iOS] Fix CarouselViewLoopNoFreeze so that it's passing on both CV1 and CV2 sets of handlers

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/iOS/CarouselViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/CarouselViewController.cs
@@ -509,7 +509,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			}
 
 			//If _gotoPosition is != -1 we are scrolling to that possition
-			if (_gotoPosition == -1 && carousel.Position != position)
+			if (carousel.Position != position)
 			{
 				carousel.SetValueFromRenderer(CarouselView.PositionProperty, position);
 			}

--- a/src/Controls/src/Core/Handlers/Items/iOS/CarouselViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/CarouselViewController.cs
@@ -322,7 +322,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		[UnconditionalSuppressMessage("Memory", "MEM0003", Justification = "Proven safe in test: MemoryTests.HandlerDoesNotLeak")]
 		void CollectionViewUpdating(object sender, NotifyCollectionChangedEventArgs e)
 		{
-			if (ItemsSource.ItemCount == 0 || ItemsView is not CarouselView carousel)
+			if (ItemsView is not CarouselView carousel)
 			{
 				return;
 			}
@@ -488,7 +488,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				return;
 			}
 
-			if (goToPosition != carouselPosition || forceScroll)
+			if (_gotoPosition == -1 && (goToPosition != carouselPosition || forceScroll))
 			{
 				_gotoPosition = goToPosition;
 				carousel.ScrollTo(goToPosition, position: Microsoft.Maui.Controls.ScrollToPosition.Center, animate: animate);
@@ -509,7 +509,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			}
 
 			//If _gotoPosition is != -1 we are scrolling to that possition
-			if (carousel.Position != position)
+			if (_gotoPosition == -1 && carousel.Position != position)
 			{
 				carousel.SetValueFromRenderer(CarouselView.PositionProperty, position);
 			}

--- a/src/Controls/src/Core/Handlers/Items/iOS/CarouselViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/CarouselViewController.cs
@@ -367,11 +367,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			SetPosition(targetPosition);
 			SetCurrentItem(targetPosition);
 
-			if (e.Action == NotifyCollectionChangedAction.Reset)
-			{
-
-			}
-			else
+			if (e.Action == NotifyCollectionChangedAction.Remove)
 			{
 				//Since we can be removing the item that is already created next to the current item we need to update the visible cells
 				if (ItemsView.Loop)
@@ -492,7 +488,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				return;
 			}
 
-			if (goToPosition != carouselPosition || forceScroll || carouselPosition == 0)
+			if (goToPosition != carouselPosition || forceScroll)
 			{
 				_gotoPosition = goToPosition;
 				carousel.ScrollTo(goToPosition, position: Microsoft.Maui.Controls.ScrollToPosition.Center, animate: animate);

--- a/src/Controls/tests/TestCases.HostApp/Issues/CarouselViewLoopNoFreeze.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/CarouselViewLoopNoFreeze.cs
@@ -14,7 +14,7 @@ namespace Maui.Controls.Sample.Issues
 		readonly string _btnSwipeAutomationId = "btnSwipe";
 
 		readonly ViewModelIssue12574 _viewModel;
-		readonly CarouselView _carouselView;
+		readonly CarouselView1 _carouselView;
 		readonly Button _btn;
 		readonly Button _btn2;
 		readonly Button _btn3;

--- a/src/Controls/tests/TestCases.HostApp/Issues/CarouselViewLoopNoFreeze.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/CarouselViewLoopNoFreeze.cs
@@ -48,7 +48,7 @@ namespace Maui.Controls.Sample.Issues
 				_carouselView.ScrollTo(_viewModel.CurrentPosition);
 			};
 
-			_carouselView = new CarouselView2
+			_carouselView = new CarouselView
 			{
 				AutomationId = _carouselAutomationId,
 				Margin = new Thickness(30),

--- a/src/Controls/tests/TestCases.HostApp/Issues/CarouselViewLoopNoFreeze.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/CarouselViewLoopNoFreeze.cs
@@ -14,7 +14,7 @@ namespace Maui.Controls.Sample.Issues
 		readonly string _btnSwipeAutomationId = "btnSwipe";
 
 		readonly ViewModelIssue12574 _viewModel;
-		readonly CarouselView2 _carouselView;
+		readonly CarouselView1 _carouselView;
 		readonly Button _btn;
 		readonly Button _btn2;
 		readonly Button _btn3;

--- a/src/Controls/tests/TestCases.HostApp/Issues/CarouselViewLoopNoFreeze.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/CarouselViewLoopNoFreeze.cs
@@ -14,7 +14,7 @@ namespace Maui.Controls.Sample.Issues
 		readonly string _btnSwipeAutomationId = "btnSwipe";
 
 		readonly ViewModelIssue12574 _viewModel;
-		readonly CarouselView1 _carouselView;
+		readonly CarouselView _carouselView;
 		readonly Button _btn;
 		readonly Button _btn2;
 		readonly Button _btn3;


### PR DESCRIPTION
### Issue Details

- When removing the last item in the carosuel view, zeroth index item updated instead of previous items of the last index.
- When swiping to the last item and removing the all the item in the carousel view, argument output range exception raised.

### Root cause:
**Issue12574Test**

- Current index of the visible cell in carousel view loop layout does not updated When dynamically removing the items from last index of the carousel view,

**RemoveItemsQuickly**

- Swiping till last element and removing all the items, while cell displaying the end of the item tried to get the index of the path. Here index return the negative value.



### Description Changes:
**Issue12574Test**

- Invoked the CollectionView.ReloadItems method to reload specific items while dynamically removing the item, using the helper method GetScrollToIndexPath(targetPosition) to identify the correct item to update the visible cell in carousel view the loop layout manager.

**RemoveItemsQuickly**

- Return the index path as zero in GetCorrectedIndex method when items count is zero.


Validated the behaviour in the following platforms

- [] Android
- [] Windows
- [x] iOS
- [] Mac

Fixes https://github.com/dotnet/maui/issues/25775

### Output:
**Issue12574Test**

|Before|After|
|--|--|
| <video src="https://github.com/user-attachments/assets/47b4fa8a-646f-4694-9749-f77319a73c60" >| <video src="https://github.com/user-attachments/assets/245fdaa4-81bc-4d7a-a3da-42d7ba616c55">|

**RemoveItemsQuickly**
Before changes

|Before|After|
|--|--|
| <img width="512" alt="image" src="https://github.com/user-attachments/assets/8a01ccd7-aad4-4c24-9735-2150d699bf24">| <video src="https://github.com/user-attachments/assets/717d6d01-fda4-4dae-a03e-0de5f04b404f">|