### PR TITLE
[iOS] Fixed Using safe area causes white area at the top upon entry focus

### DIFF
--- a/src/Core/src/Platform/iOS/KeyboardAutoManagerScroll.cs
+++ b/src/Core/src/Platform/iOS/KeyboardAutoManagerScroll.cs
@@ -475,6 +475,12 @@ public static class KeyboardAutoManagerScroll
 		else if (cursorRect.Y <= topBoundary && cursorRect.Bottom <= bottomBoundary)
 		{
 			move = cursorRect.Y - (nfloat)topBoundary;
+
+			// no need to move the screen down if we can already see the view
+			if (move < 0)
+			{
+				move = 0;
+			}
 		}
 
 		else if (cursorRect.Y <= topBoundary && cursorRect.Bottom >= bottomBoundary)


### PR DESCRIPTION
### Root Cause
 When an Entry is focused and the keyboard opens, the view adjusts and scrolls downward, causing a white space to appear at the top of the screen.
 
### Description of Change
In the AdjustPosition method,  the move value is calculated when CursorRect.Y is less than topBoundary and CursorRect.Bottom is also less than bottomBoundar, which lead to unnecessary scrollling. To address this, a condition was added to ensure that if the move value is less than 0, it is reset to 0. 

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #25866 
Fixes #32168 

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->

### Validated the behaviour in the following platforms
- [ ] Android
- [ ] Windows
- [x] iOS
- [ ] Mac
  
UseSafeArea and IgnoreSafeArea are most relevant on iOS alone due to the unique layout constraints of safe areas.

### Output Screenshot
| Before  | After  |
|---------|--------|
|  <img src="https://github.com/user-attachments/assets/d02d7fd3-b7cc-44aa-be07-5fff7a0bf9bb" width="320" height="640" controls></img>   |   <img src="https://github.com/user-attachments/assets/082b8882-5c61-4457-97fc-e35debbfb9a0" width="320" height="640" controls></img>   |
