### PR TITLE
[iOS] Fixed the RemainingItemsThresholdReachedCommand not firing issue in CollectionView

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewDelegator.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewDelegator.cs
@@ -138,11 +138,28 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			int firstVisibleItemIndex = -1, centerItemIndex = -1, lastVisibleItemIndex = -1;
 			if (VisibleItems)
 			{
-				firstVisibleItemIndex = (int)First.Item;
-				centerItemIndex = (int)Center.Item;
-				lastVisibleItemIndex = (int)Last.Item;
+				IItemsViewSource source = ViewController.ItemsSource;
+
+				firstVisibleItemIndex = GetItemIndex(First, source);
+				centerItemIndex = GetItemIndex(Center, source);
+				lastVisibleItemIndex = GetItemIndex(Last, source);
 			}
 			return (VisibleItems, firstVisibleItemIndex, centerItemIndex, lastVisibleItemIndex);
+		}
+
+		static int GetItemIndex(NSIndexPath indexPath, IItemsViewSource itemSource)
+		{
+			int index = (int)indexPath.Item;
+
+			if (indexPath.Section > 0)
+			{
+				for (int i = 0; i < indexPath.Section; i++)
+				{
+					index += itemSource.ItemCountInGroup(i);
+				}
+			}
+
+			return index;
 		}
 
 		static NSIndexPath GetCenteredIndexPath(UICollectionView collectionView)

--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewDelegator.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewDelegator.cs
@@ -140,8 +140,8 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			{
 				IItemsViewSource source = ViewController.ItemsSource;
 
-				firstVisibleItemIndex = GetItemIndex(First, source);
-				centerItemIndex = GetItemIndex(Center, source);
+				firstVisibleItemIndex = (int)First.Item;
+				centerItemIndex = (int)Center.Item;
 				lastVisibleItemIndex = GetItemIndex(Last, source);
 			}
 			return (VisibleItems, firstVisibleItemIndex, centerItemIndex, lastVisibleItemIndex);

--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewDelegator.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewDelegator.cs
@@ -138,11 +138,9 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			int firstVisibleItemIndex = -1, centerItemIndex = -1, lastVisibleItemIndex = -1;
 			if (VisibleItems)
 			{
-				IItemsViewSource source = ViewController.ItemsSource;
-
 				firstVisibleItemIndex = (int)First.Item;
 				centerItemIndex = (int)Center.Item;
-				lastVisibleItemIndex = GetItemIndex(Last, source);
+				lastVisibleItemIndex = GetItemIndex(Last, ViewController.ItemsSource);
 			}
 			return (VisibleItems, firstVisibleItemIndex, centerItemIndex, lastVisibleItemIndex);
 		}

--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewDelegator.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewDelegator.cs
@@ -138,9 +138,11 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			int firstVisibleItemIndex = -1, centerItemIndex = -1, lastVisibleItemIndex = -1;
 			if (VisibleItems)
 			{
-				firstVisibleItemIndex = (int)First.Item;
-				centerItemIndex = (int)Center.Item;
-				lastVisibleItemIndex = GetItemIndex(Last, ViewController.ItemsSource);
+				IItemsViewSource source = ViewController.ItemsSource;
+
+				firstVisibleItemIndex = GetItemIndex(First, source);
+				centerItemIndex = GetItemIndex(Center, source);
+				lastVisibleItemIndex = GetItemIndex(Last, source);
 			}
 			return (VisibleItems, firstVisibleItemIndex, centerItemIndex, lastVisibleItemIndex);
 		}

--- a/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewDelegator2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewDelegator2.cs
@@ -5,6 +5,7 @@ using CoreGraphics;
 using Foundation;
 using ObjCRuntime;
 using UIKit;
+using Microsoft.Maui.Controls.Handlers.Items;
 
 namespace Microsoft.Maui.Controls.Handlers.Items2
 {
@@ -138,11 +139,28 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 			int firstVisibleItemIndex = -1, centerItemIndex = -1, lastVisibleItemIndex = -1;
 			if (VisibleItems)
 			{
-				firstVisibleItemIndex = (int)First.Item;
-				centerItemIndex = (int)Center.Item;
-				lastVisibleItemIndex = (int)Last.Item;
+				IItemsViewSource source = ViewController.ItemsSource;
+
+				firstVisibleItemIndex = GetItemIndex(First, source);
+				centerItemIndex = GetItemIndex(Center, source);
+				lastVisibleItemIndex = GetItemIndex(Last, source);
 			}
 			return (VisibleItems, firstVisibleItemIndex, centerItemIndex, lastVisibleItemIndex);
+		}
+
+		static int GetItemIndex(NSIndexPath indexPath, IItemsViewSource itemSource)
+		{
+			int index = (int)indexPath.Item;
+
+			if (indexPath.Section > 0)
+			{
+				for (int i = 0; i < indexPath.Section; i++)
+				{
+					index += itemSource.ItemCountInGroup(i);
+				}
+			}
+
+			return index;
 		}
 
 		static NSIndexPath GetCenteredIndexPath(UICollectionView collectionView)

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue25889.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue25889.xaml
@@ -1,0 +1,38 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Maui.Controls.Sample.Issues.Issue25889"
+             xmlns:local="clr-namespace:Maui.Controls.Sample.Issues">
+
+  <ContentPage.BindingContext>
+        <local:_25889MainViewModel/>
+    </ContentPage.BindingContext>
+
+    <Grid x:Name="mainGrid">
+      <Grid.RowDefinitions>
+        <RowDefinition Height="50"/>
+        <RowDefinition Height="*"/>
+      </Grid.RowDefinitions>
+
+      <Label x:Name="label" AutomationId="mainPageLabel" Grid.Row="0"/>
+
+    <CollectionView Grid.Row="1" x:DataType="local:_25889MainViewModel" AutomationId="collectionView"
+        IsGrouped="True"
+        ItemsSource="{Binding ActivityGroups}"
+        RemainingItemsThreshold="2"
+        RemainingItemsThresholdReachedCommand="{Binding GetDataCommand}">
+        
+        <CollectionView.GroupHeaderTemplate>
+            <DataTemplate x:DataType="local:_25889GroupedActivity">
+                <Label Text="{Binding Key}" FontAttributes="Bold" Padding="5" />
+            </DataTemplate>
+        </CollectionView.GroupHeaderTemplate>
+
+        <CollectionView.ItemTemplate>
+            <DataTemplate x:DataType="local:_25889ActivityItem">
+                <Label Text="{Binding Name}" Padding="10" />
+            </DataTemplate>
+        </CollectionView.ItemTemplate>
+    </CollectionView>
+</Grid>
+</ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue25889.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue25889.xaml.cs
@@ -1,0 +1,84 @@
+﻿using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Windows.Input;
+
+namespace Maui.Controls.Sample.Issues
+{
+	[Issue(IssueTracker.Github, 25889, "CollectionView RemainingItemsThresholdReachedCommand not Firing", PlatformAffected.iOS)]
+	public partial class Issue25889 : ContentPage
+	{
+		public Issue25889()
+		{
+			InitializeComponent();
+			label.SetBinding(Label.TextProperty, "LabelText");
+		}
+
+	}
+
+	public class _25889MainViewModel : BindableObject
+	{
+		public ObservableCollection<_25889GroupedActivity> ActivityGroups { get; set; }
+
+		public ICommand GetDataCommand { get; }
+
+		private string _labelText;
+
+		public string LabelText
+		{
+			get => _labelText;
+			set
+			{
+				if (_labelText != value)
+				{
+					_labelText = value;
+					OnPropertyChanged();
+				}
+			}
+		}
+
+		public _25889MainViewModel()
+		{
+
+			var activityGroups = new ObservableCollection<_25889GroupedActivity>();
+
+			var group1Items = new List<_25889ActivityItem>();
+			for (int i = 1; i <= 10; i++)
+			{
+				group1Items.Add(new _25889ActivityItem { Name = $"Activity {i}" });
+			}
+			activityGroups.Add(new _25889GroupedActivity("Group 1", group1Items));
+
+			var group2Items = new List<_25889ActivityItem>();
+			for (int i = 11; i <= 25; i++)
+			{
+				group2Items.Add(new _25889ActivityItem { Name = $"Activity {i}" });
+			}
+			activityGroups.Add(new _25889GroupedActivity("Group 2", group2Items));
+
+			ActivityGroups = activityGroups;
+			GetDataCommand = new Command(RemainingItemsThresholdReachedCommandFired);
+
+			LabelText = "Not fired";
+		}
+
+		private void RemainingItemsThresholdReachedCommandFired()
+		{
+			LabelText = "Command Fired!";
+		}
+	}
+
+	public class _25889GroupedActivity : List<_25889ActivityItem>
+	{
+		public string Key { get; }
+
+		public _25889GroupedActivity(string key, List<_25889ActivityItem> items) : base(items)
+		{
+			Key = key;
+		}
+	}
+
+	public class _25889ActivityItem
+	{
+		public string Name { get; set; }
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25889.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25889.cs
@@ -1,0 +1,26 @@
+﻿using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue25889 : _IssuesUITest
+	{
+		public Issue25889(TestDevice device) : base(device)
+		{
+		}
+
+		public override string Issue => "CollectionView RemainingItemsThresholdReachedCommand not Firing";
+
+		[Test]
+		[Category(UITestCategories.CollectionView)]
+		public async Task RemainingItemsThresholdReachedCommandFired()
+		{
+			App.WaitForElement("collectionView");
+			App.ScrollDown("collectionView");
+			await Task.Delay(1000);
+			var label = App.WaitForElement("mainPageLabel");
+			Assert.That(label.GetText(), Is.EqualTo("Command Fired!"));
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25889.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25889.cs
@@ -14,11 +14,10 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 
 		[Test]
 		[Category(UITestCategories.CollectionView)]
-		public async Task RemainingItemsThresholdReachedCommandFired()
+		public void RemainingItemsThresholdReachedCommandFired()
 		{
 			App.WaitForElement("collectionView");
 			App.ScrollDown("collectionView");
-			await Task.Delay(1000);
 			var label = App.WaitForElement("mainPageLabel");
 			Assert.That(label.GetText(), Is.EqualTo("Command Fired!"));
 		}


### PR DESCRIPTION
### Issue Detail
The RemainingItemsThresholdReachedCommand is not triggered as expected on macOS and iOS platforms.

### Root Cause
On macOS and iOS, the index of the items was only being updated based on the currently visible items. During scrolling, the index was not recalculated correctly, which caused the command to fail when the remaining items threshold was reached.

### Description of Change
Updated the logic to ensure the index of items is recalculated accurately during scrolling. This change ensures that the RemainingItemsThresholdReachedCommand is triggered correctly when the threshold condition is met on macOS and iOS.


### Tested the behaviour in the following platforms
 
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

### Issues Fixed
 
Fixes https://github.com/dotnet/maui/issues/25889

### Screenshots

| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video width="300" height="600"  src="https://github.com/user-attachments/assets/af8deb4d-42b4-4a20-b366-0f9229109391"> | <video width="300" height="600"  src="https://github.com/user-attachments/assets/35383d28-e5c8-462a-9c89-964642339bfb">) |
