### PR TITLE
Always propagate the BC to the ControlTemplate

### DIFF
--- a/src/Controls/src/Core/ContentView/ContentView.cs
+++ b/src/Controls/src/Core/ContentView/ContentView.cs
@@ -33,18 +33,6 @@ namespace Microsoft.Maui.Controls
 			SetInheritedBindingContext(child, context);
 		}
 
-		internal override void OnControlTemplateChanged(ControlTemplate oldValue, ControlTemplate newValue)
-		{
-			if (oldValue == null)
-				return;
-
-			base.OnControlTemplateChanged(oldValue, newValue);
-			if (Content is View content)
-			{
-				SetInheritedBindingContext(content, BindingContext);
-			}
-		}
-
 		object IContentView.Content => Content;
 
 		IView IContentView.PresentedContent => ((this as IControlTemplated).TemplateRoot as IView) ?? Content;

--- a/src/Controls/src/Core/ContentView/ContentView.cs
+++ b/src/Controls/src/Core/ContentView/ContentView.cs
@@ -22,15 +22,15 @@ namespace Microsoft.Maui.Controls
 		{
 			base.OnBindingContextChanged();
 
-			IView content = Content;
+			if (Content is View content)
+			{
+				SetInheritedBindingContext(content, BindingContext);
+			}
+		}
 
-			if (content == null && (this as IContentView)?.PresentedContent is IView presentedContent)
-				content = presentedContent;
-
-			ControlTemplate controlTemplate = ControlTemplate;
-
-			if (content is BindableObject bindableContent && controlTemplate != null)
-				SetInheritedBindingContext(bindableContent, BindingContext);
+		internal override void SetChildInheritedBindingContext(Element child, object context)
+		{
+			SetInheritedBindingContext(child, context);
 		}
 
 		internal override void OnControlTemplateChanged(ControlTemplate oldValue, ControlTemplate newValue)
@@ -39,9 +39,7 @@ namespace Microsoft.Maui.Controls
 				return;
 
 			base.OnControlTemplateChanged(oldValue, newValue);
-			View content = Content;
-			ControlTemplate controlTemplate = ControlTemplate;
-			if (content != null && controlTemplate != null)
+			if (Content is View content)
 			{
 				SetInheritedBindingContext(content, BindingContext);
 			}

--- a/src/Controls/src/Core/ContentView/ContentView.cs
+++ b/src/Controls/src/Core/ContentView/ContentView.cs
@@ -28,6 +28,16 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
+		internal override void OnControlTemplateChanged(ControlTemplate oldValue, ControlTemplate newValue)
+		{
+			base.OnControlTemplateChanged(oldValue, newValue);
+
+			if (Content is View content)
+			{
+				SetInheritedBindingContext(content, BindingContext);
+			}
+		}
+
 		internal override void SetChildInheritedBindingContext(Element child, object context)
 		{
 			SetInheritedBindingContext(child, context);

--- a/src/Controls/tests/Core.UnitTests/ContentViewUnitTest.cs
+++ b/src/Controls/tests/Core.UnitTests/ContentViewUnitTest.cs
@@ -330,7 +330,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact]
-		public void DoesntInheritBindingContextToContentFromControlTemplate()
+		public void DoesNotInheritBindingContextToContentFromControlTemplate()
 		{
 			var contentView = new ContentView();
 			var child1 = new View();
@@ -339,23 +339,25 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			contentView.ControlTemplate = new ControlTemplate(typeof(SimpleTemplate));
 			contentView.Content = child1;
 
-			var bc = "Test";
+			var bcContentView = "Test";
 			var bcSimpleTemplate = "other context";
-			contentView.BindingContext = bc;
+			contentView.BindingContext = bcContentView;
 
 			var simpleTemplate = contentView.GetVisualTreeDescendants().OfType<SimpleTemplate>().Single();
+			var cp = contentView.GetVisualTreeDescendants().OfType<ContentPresenter>().Single();
 			simpleTemplate.BindingContext = bcSimpleTemplate;
 
-			Assert.Equal(bc, child1.BindingContext);
+			Assert.Equal(bcContentView, child1.BindingContext);
 			Assert.Equal(contentView.BindingContext, child1.BindingContext);
 			Assert.Equal(bcSimpleTemplate, simpleTemplate.BindingContext);
 
 			// Change out content and make sure simple templates BC doesn't propagate
 			contentView.Content = child2;
 
-			Assert.Equal(bc, child2.BindingContext);
+			Assert.Equal(bcContentView, child2.BindingContext);
 			Assert.Equal(contentView.BindingContext, child2.BindingContext);
 			Assert.Equal(bcSimpleTemplate, simpleTemplate.BindingContext);
+			Assert.Equal(bcSimpleTemplate, cp.BindingContext);
 		}
 
 		[Fact]


### PR DESCRIPTION
### Description of Change

With the initial design of Xamarin.Forms the BC would never propagate to the ControlTemplate as we can see from the test `DoesNotInheritBindingContextToTemplate` that you can reference inside this PR.

I'm not really clear on the initial reasoning here. I've compared the behavior to a `ContentControl` in WinUI and the DataContext in `WinUI` always propagates to the Template and the `DataContext` on the `ContentView` always propagates to the `ContentPresenter` even if the template changes the `DataContext`

![image](https://github.com/user-attachments/assets/14ae67fd-1111-408f-9100-ab751dcb41d9)

We changed this behavior in a slightly awkward way in net8.0 https://github.com/dotnet/maui/pull/12536 where we are only setting the `ControlTemplate` BC when the `Content` isn't set and it only works for the initial `ControlTemplate` since we didn't copy this logic into `ControlTemplateChanged`

It's also a bit weird now because the ordering will change how the BC gets assigned. For example, 

```C#
contentView.ControlTemplate = new ControlTemplate(typeof(SimpleTemplate));
var bc = "Test";
contentView.BindingContext = bc;
contentView.Content = child;
```

This will cause the BC to propagate to the `ControlTemplate` but now it won't propagate when you change the `ControlTemplate`. Which is basically what the issue this is fixing is seeing happen.

This PR fully commits in the direction of just setting the `ControlTemplates` binding context always from the `ContentView`'s `BindingContext`


### Issues Fixed
Fixes #25934
Fixes #22607
Fixes #14919

