### PR TITLE
[iOS] Avoid infinite loop when calculating a DesiredSize

### DIFF
--- a/src/Core/src/Handlers/Editor/EditorHandler.iOS.cs
+++ b/src/Core/src/Handlers/Editor/EditorHandler.iOS.cs
@@ -61,16 +61,16 @@ namespace Microsoft.Maui.Handlers
 				// get an exception; it doesn't know what do to with it. So instead we'll size
 				// it to fit its current contents and use those values to replace infinite constraints
 
-				PlatformView.SizeToFit();
+				var sizeThatFits = PlatformView.SizeThatFits(new CGSize(widthConstraint, heightConstraint));
 
 				if (double.IsInfinity(widthConstraint))
 				{
-					widthConstraint = PlatformView.Frame.Size.Width;
+					widthConstraint = sizeThatFits.Width;
 				}
 
 				if (double.IsInfinity(heightConstraint))
 				{
-					heightConstraint = PlatformView.Frame.Size.Height;
+					heightConstraint = sizeThatFits.Height;
 				}
 			}
 


### PR DESCRIPTION
### Description of Change

Avoided calling `PlatformView.SizeToFit()`directly within the `GetDesiredSize()` method and instead use a more controlled approach to measure the size.

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/25940
Fixes https://github.com/dotnet/maui/issues/25938
Fixes https://github.com/dotnet/maui/issues/17757

|Before|After|
|--|--|
|<video src="https://github.com/user-attachments/assets/d622c465-1a86-4fd1-86a7-c35ab673edcd" width="300px"/>|<video src="https://github.com/user-attachments/assets/80430318-0654-4e9b-9781-0f0848ce5e29" width="300px"/>|

It also fixes an editor when entering text that exceeds the maximum height and resets the position
|Before|After|
|--|--|
|<video src="https://github.com/user-attachments/assets/c87fd93a-97e4-460b-a977-459bc3da15da" width="300px"/>|<video src="https://github.com/user-attachments/assets/bef2603a-3d54-42d3-850c-5aa43e627b7a" width="300px"/>|