### PR TITLE
Remove code that enables/disables Entry

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue25829.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue25829.xaml
@@ -1,0 +1,70 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Maui.Controls.Sample.Issues.Issue25829"
+             xmlns:ns="clr-namespace:Maui.Controls.Sample.Issues">
+  <ScrollView>
+        <VerticalStackLayout
+            Padding="30,0"
+            Spacing="25">
+
+            <Button x:Name="testButton"
+                Text="This Button Should be Visible" Clicked="OnButtonClicked" 
+                SemanticProperties.HeadingLevel="Level1" />
+
+            <Image
+                Source="dotnet_bot.png"
+                HeightRequest="185"
+                Aspect="AspectFit"
+                SemanticProperties.Description="dot net bot in a hovercraft number nine" />
+
+
+            <Button                
+                Text="Click me" 
+                SemanticProperties.Hint="Counts the number of times you click"
+                
+                HorizontalOptions="Fill" />
+            <Button                
+                Text="Click me" 
+                SemanticProperties.Hint="Counts the number of times you click"
+                
+                HorizontalOptions="Fill" />
+            <Button                
+                Text="Click me" 
+                SemanticProperties.Hint="Counts the number of times you click"
+                
+                HorizontalOptions="Fill" />
+            <Button                
+                Text="Click me" 
+                SemanticProperties.Hint="Counts the number of times you click"                
+                HorizontalOptions="Fill" />
+            <Button                
+                Text="Click me" 
+                SemanticProperties.Hint="Counts the number of times you click"                
+                HorizontalOptions="Fill" />
+            <Button                
+                Text="Click me" 
+                SemanticProperties.Hint="Counts the number of times you click"                
+                HorizontalOptions="Fill" />
+            <Button                
+                Text="Click me" 
+                SemanticProperties.Hint="Counts the number of times you click"                
+                HorizontalOptions="Fill" />
+            <Button                
+                Text="Click me" 
+                SemanticProperties.Hint="Counts the number of times you click"                
+                HorizontalOptions="Fill" />
+            <Button                
+                Text="Click me" 
+                SemanticProperties.Hint="Counts the number of times you click"                
+                HorizontalOptions="Fill" />
+
+            <Entry Text=""></Entry>
+            <Entry Text="Entry Field"></Entry>
+            <Entry Text="Entry Field"></Entry>
+            <Entry Text="Entry Field"></Entry>
+            <Entry Text="Entry Field"></Entry>
+            <Entry Text="Entry Field"></Entry>
+        </VerticalStackLayout>
+    </ScrollView>
+</ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue25829.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue25829.xaml.cs
@@ -1,0 +1,31 @@
+namespace Maui.Controls.Sample.Issues;
+
+
+[Issue(IssueTracker.Github, 25829, "ScrollView starts at the position of first Entry control on the bottom rather than at 0",
+	PlatformAffected.Android)]
+public partial class Issue25829 : ContentPage
+{
+	public Issue25829()
+	{
+		InitializeComponent();
+	}
+
+	protected override void OnAppearing()
+	{
+		base.OnAppearing();
+
+		if(this.Navigation.ModalStack.Contains(this))
+		{
+			testButton.AutomationId = "Success";
+		}
+		else
+		{
+			testButton.AutomationId = "PushModal";
+		}
+	}
+
+	public async void OnButtonClicked(object sender, EventArgs e)
+	{
+		await Navigation.PushModalAsync(new Issue25829());
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25829.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25829.cs
@@ -1,0 +1,23 @@
+﻿using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+using System.Threading.Tasks;
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue25829 : _IssuesUITest
+	{
+		public Issue25829(TestDevice device) : base(device) { }
+
+		public override string Issue => "ScrollView starts at the position of first Entry control on the bottom rather than at 0";
+
+		[Test]
+		[Category(UITestCategories.Entry)]
+		public void ScrollViewStartsOccasionallyStartsAtTheFirstEntry()
+		{
+			App.WaitForElement("PushModal");
+			App.Tap("PushModal");
+			App.WaitForElement("Success");
+			App.Tap("Success");
+		}
+	}
+}

--- a/src/Core/src/Handlers/Entry/EntryHandler.Android.cs
+++ b/src/Core/src/Handlers/Entry/EntryHandler.Android.cs
@@ -42,7 +42,6 @@ namespace Microsoft.Maui.Handlers
 		// TODO: NET8 issoto - Change the return type to MauiAppCompatEditText
 		protected override void ConnectHandler(AppCompatEditText platformView)
 		{
-			platformView.ViewAttachedToWindow += OnPlatformViewAttachedToWindow;
 			platformView.TextChanged += OnTextChanged;
 			platformView.FocusChange += OnFocusedChange;
 			platformView.Touch += OnTouch;
@@ -53,7 +52,6 @@ namespace Microsoft.Maui.Handlers
 		protected override void DisconnectHandler(AppCompatEditText platformView)
 		{
 			_clearButtonDrawable = null;
-			platformView.ViewAttachedToWindow -= OnPlatformViewAttachedToWindow;
 			platformView.TextChanged -= OnTextChanged;
 			platformView.FocusChange -= OnFocusedChange;
 			platformView.Touch -= OnTouch;
@@ -145,16 +143,6 @@ namespace Microsoft.Maui.Handlers
 		{
 			if (args is FocusRequest request)
 				handler.PlatformView.Focus(request);
-		}
-
-		void OnPlatformViewAttachedToWindow(object? sender, ViewAttachedToWindowEventArgs e)
-		{
-			if (PlatformView.IsAlive() && PlatformView.Enabled)
-			{
-				// https://issuetracker.google.com/issues/37095917
-				PlatformView.Enabled = false;
-				PlatformView.Enabled = true;
-			}
 		}
 
 		void OnTextChanged(object? sender, TextChangedEventArgs e)


### PR DESCRIPTION
### Description of Change

I ran the test added to the original PR https://github.com/dotnet/maui/pull/24064 with the code removed and it still passes from what you can see on this issue. So, I'm just going to revert this change for now because we don't have any reason to keep this change and it's a fairly negative result that it can cause an auto scroll in some scenarios.

I've added a test, so when/if we add this code back in.

### Issues Fixed

Fixes #25829

