### PR TITLE
[X] Make OnPlatformExtension and OnIdiomExtension trim-compatible

### DIFF
--- a/src/Controls/src/Xaml/MarkupExtensions/OnIdiomExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/OnIdiomExtension.cs
@@ -14,7 +14,6 @@ namespace Microsoft.Maui.Controls.Xaml
 		 typeof(IValueConverterProvider),
 		 typeof(IXmlLineInfoProvider),
 		 typeof(IConverterOptions)])]
-	[RequiresUnreferencedCode("The OnIdiomExtension is not trim safe. Use OnIdiom<T> instead.")]
 	public class OnIdiomExtension : IMarkupExtension
 	{
 		// See Device.Idiom
@@ -61,7 +60,9 @@ namespace Microsoft.Maui.Controls.Xaml
 
 			var value = GetValue();
 			if (value == null && propertyType.IsValueType)
-				return Activator.CreateInstance(propertyType);
+			{
+				throw new XamlParseException($"Missing value for idiom {DeviceInfo.Idiom} or Default", serviceProvider);
+			}
 
 			if (Converter != null)
 				return Converter.Convert(value, propertyType, ConverterParameter, CultureInfo.CurrentUICulture);

--- a/src/Controls/src/Xaml/MarkupExtensions/OnPlatformExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/OnPlatformExtension.cs
@@ -13,7 +13,6 @@ namespace Microsoft.Maui.Controls.Xaml
 		 typeof(IValueConverterProvider),
 		 typeof(IXmlLineInfoProvider),
 		 typeof(IConverterOptions)])]
-	[RequiresUnreferencedCode("The OnPlatformExtension is not trim safe. Use OnPlatform<T> instead.")]
 	public class OnPlatformExtension : IMarkupExtension
 	{
 		static object s_notset = new object();
@@ -81,7 +80,9 @@ namespace Microsoft.Maui.Controls.Xaml
 						return bp.GetDefaultValue(targetObject as BindableObject);
 				}
 				if (propertyType.IsValueType)
-					return Activator.CreateInstance(propertyType);
+				{
+					throw new XamlParseException($"Missing value for platform {DeviceInfo.Platform} or Default", serviceProvider);
+				}
 				return null;
 			}
 

--- a/src/Controls/tests/Xaml.UnitTests/MarkupExpressionParserTests.cs
+++ b/src/Controls/tests/Xaml.UnitTests/MarkupExpressionParserTests.cs
@@ -386,7 +386,6 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		[TestCase("{OnIdiom Phone=23, Tablet=25, Desktop=26, TV=30, Watch=10}", "Desktop", 26)]
 		[TestCase("{OnIdiom Phone=23, Tablet=25, Desktop=26, TV=30, Watch=10}", "TV", 30)]
 		[TestCase("{OnIdiom Phone=23, Tablet=25, Desktop=26, TV=30, Watch=10}", "Watch", 10)]
-		[TestCase("{OnIdiom Phone=23}", "Desktop", default(int))]
 		public void OnIdiomExtension(string markup, string idiom, int expected)
 		{
 			mockDeviceInfo.Idiom = DeviceIdiom.Create(idiom);
@@ -401,6 +400,40 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 			});
 
 			Assert.AreEqual(expected, actual);
+		}
+
+		[TestCase("{OnIdiom Phone=23}", "Desktop")]
+		public void OnIdiomExtensionMissingValue(string markup, string idiom)
+		{
+			mockDeviceInfo.Idiom = DeviceIdiom.Create(idiom);
+
+			var serviceProvider = new Internals.XamlServiceProvider(null, null)
+			{
+				IXamlTypeResolver = typeResolver,
+				IProvideValueTarget = new MockValueProvider("foo", new object())
+				{
+					TargetProperty = GetType().GetProperty(nameof(FontSize))
+				}
+			};
+
+			Assert.Throws<XamlParseException>(() => (new MarkupExtensionParser()).ParseExpression(ref markup, serviceProvider));
+		}
+
+		[TestCase("{OnPlatform Android=23}", "iOS")]
+		public void OnPlatformExtensionMissingValue(string markup, string platform)
+		{
+			mockDeviceInfo.Platform = DevicePlatform.Create(platform);
+
+			var serviceProvider = new Internals.XamlServiceProvider(null, null)
+			{
+				IXamlTypeResolver = typeResolver,
+				IProvideValueTarget = new MockValueProvider("foo", new object())
+				{
+					TargetProperty = GetType().GetProperty(nameof(FontSize))
+				}
+			};
+
+			Assert.Throws<XamlParseException>(() => (new MarkupExtensionParser()).ParseExpression(ref markup, serviceProvider));
 		}
 
 		[TestCase("{Binding")]


### PR DESCRIPTION
### Description of Change

I revisited the `OnIdiomExtension` and `OnPlatformExtension` based on customer feedback and I've realized the only trim-incompatible part of the code is creating default value for value types. This seems like a weird edge case and I believe we should throw so the developer fixes the XAML.

This would be a breaking change though. If approved, this PR shouldn't be included in servicing releases.

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/26115

/cc @StephaneDelcroix @PureWeen 