### PR TITLE
Make MauiAppCompatEditText public & adapt EntryHandler

### DIFF
--- a/src/Core/src/Handlers/Editor/EditorHandler.Android.cs
+++ b/src/Core/src/Handlers/Editor/EditorHandler.Android.cs
@@ -1,20 +1,16 @@
 ﻿using System;
 using Android.Views;
 using Android.Views.InputMethods;
-using AndroidX.AppCompat.Widget;
 using Microsoft.Maui.Graphics;
 using static Android.Views.View;
 
 namespace Microsoft.Maui.Handlers
 {
-	// TODO: NET8 issoto - Change the TPlatformView generic type to MauiAppCompatEditText
-	// This type adds support to the SelectionChanged event
-	public partial class EditorHandler : ViewHandler<IEditor, AppCompatEditText>
+	public partial class EditorHandler : ViewHandler<IEditor, MauiAppCompatEditText>
 	{
 		bool _set;
 
-		// TODO: NET8 issoto - Change the return type to MauiAppCompatEditText
-		protected override AppCompatEditText CreatePlatformView()
+		protected override MauiAppCompatEditText CreatePlatformView()
 		{
 			var editText = new MauiAppCompatEditText(Context)
 			{
@@ -33,31 +29,31 @@ namespace Microsoft.Maui.Handlers
 		{
 			base.SetVirtualView(view);
 
-			// TODO: NET8 issoto - Remove the casting once we can set the TPlatformView generic type as MauiAppCompatEditText
-			if (!_set && PlatformView is MauiAppCompatEditText editText)
-				editText.SelectionChanged += OnSelectionChanged;
+			if (!_set)
+			{
+				PlatformView.SelectionChanged += OnSelectionChanged;
+			}
 
 			_set = true;
 		}
 
-		// TODO: NET8 issoto - Change the platformView type to MauiAppCompatEditText
-		protected override void ConnectHandler(AppCompatEditText platformView)
+		protected override void ConnectHandler(MauiAppCompatEditText platformView)
 		{
 			platformView.ViewAttachedToWindow += OnPlatformViewAttachedToWindow;
 			platformView.TextChanged += OnTextChanged;
 			platformView.FocusChange += OnFocusChange;
 		}
 
-		// TODO: NET8 issoto - Change the platformView type to MauiAppCompatEditText
-		protected override void DisconnectHandler(AppCompatEditText platformView)
+		protected override void DisconnectHandler(MauiAppCompatEditText platformView)
 		{
 			platformView.ViewAttachedToWindow -= OnPlatformViewAttachedToWindow;
 			platformView.TextChanged -= OnTextChanged;
 			platformView.FocusChange -= OnFocusChange;
 
-			// TODO: NET8 issoto - Remove the casting once we can set the TPlatformView generic type as MauiAppCompatEditText
-			if (_set && platformView is MauiAppCompatEditText editText)
-				editText.SelectionChanged -= OnSelectionChanged;
+			if (_set)
+			{
+				platformView.SelectionChanged -= OnSelectionChanged;
+			}
 
 			_set = false;
 		}
@@ -77,7 +73,9 @@ namespace Microsoft.Maui.Handlers
 		public static void MapPlaceholderColor(IEditorHandler handler, IEditor editor)
 		{
 			if (handler is EditorHandler platformHandler)
+			{
 				handler.PlatformView?.UpdatePlaceholderColor(editor);
+			}
 		}
 
 		public static void MapCharacterSpacing(IEditorHandler handler, IEditor editor) =>
@@ -120,7 +118,9 @@ namespace Microsoft.Maui.Handlers
 		static void MapFocus(IEditorHandler handler, IEditor editor, object? args)
 		{
 			if (args is FocusRequest request)
+			{
 				handler.PlatformView.Focus(request);
+			}
 		}
 
 		void OnPlatformViewAttachedToWindow(object? sender, ViewAttachedToWindowEventArgs e)
@@ -149,10 +149,14 @@ namespace Microsoft.Maui.Handlers
 			var selectedTextLength = PlatformView.GetSelectedTextLength();
 
 			if (VirtualView.CursorPosition != cursorPosition)
+			{
 				VirtualView.CursorPosition = cursorPosition;
+			}
 
 			if (VirtualView.SelectionLength != selectedTextLength)
+			{
 				VirtualView.SelectionLength = selectedTextLength;
+			}
 		}
 
 		private void OnFocusChange(object? sender, FocusChangeEventArgs e)

--- a/src/Core/src/Handlers/Entry/EntryHandler.Android.cs
+++ b/src/Core/src/Handlers/Entry/EntryHandler.Android.cs
@@ -3,22 +3,19 @@ using Android.Graphics.Drawables;
 using Android.Text;
 using Android.Views;
 using Android.Views.InputMethods;
-using AndroidX.AppCompat.Widget;
 using AndroidX.Core.Content;
 using static Android.Views.View;
 using static Android.Widget.TextView;
 
 namespace Microsoft.Maui.Handlers
 {
-	// TODO: NET8 issoto - Change the TPlatformView generic type to MauiAppCompatEditText
-	// This type adds support to the SelectionChanged event
-	public partial class EntryHandler : ViewHandler<IEntry, AppCompatEditText>
+	public partial class EntryHandler : ViewHandler<IEntry, MauiAppCompatEditText>
 	{
 		Drawable? _clearButtonDrawable;
 		bool _clearButtonVisible;
 		bool _set;
 
-		protected override AppCompatEditText CreatePlatformView()
+		protected override MauiAppCompatEditText CreatePlatformView()
 		{
 			var nativeEntry = new MauiAppCompatEditText(Context);
 			return nativeEntry;
@@ -32,15 +29,15 @@ namespace Microsoft.Maui.Handlers
 		{
 			base.SetVirtualView(view);
 
-			// TODO: NET8 issoto - Remove the casting once we can set the TPlatformView generic type as MauiAppCompatEditText
-			if (!_set && PlatformView is MauiAppCompatEditText editText)
-				editText.SelectionChanged += OnSelectionChanged;
+			if (!_set)
+			{
+				PlatformView.SelectionChanged += OnSelectionChanged;
+			}
 
 			_set = true;
 		}
 
-		// TODO: NET8 issoto - Change the return type to MauiAppCompatEditText
-		protected override void ConnectHandler(AppCompatEditText platformView)
+		protected override void ConnectHandler(MauiAppCompatEditText platformView)
 		{
 			platformView.TextChanged += OnTextChanged;
 			platformView.FocusChange += OnFocusedChange;
@@ -48,8 +45,7 @@ namespace Microsoft.Maui.Handlers
 			platformView.EditorAction += OnEditorAction;
 		}
 
-		// TODO: NET8 issoto - Change the return type to MauiAppCompatEditText
-		protected override void DisconnectHandler(AppCompatEditText platformView)
+		protected override void DisconnectHandler(MauiAppCompatEditText platformView)
 		{
 			_clearButtonDrawable = null;
 			platformView.TextChanged -= OnTextChanged;
@@ -57,9 +53,10 @@ namespace Microsoft.Maui.Handlers
 			platformView.Touch -= OnTouch;
 			platformView.EditorAction -= OnEditorAction;
 
-			// TODO: NET8 issoto - Remove the casting once we can set the TPlatformView generic type as MauiAppCompatEditText
-			if (_set && platformView is MauiAppCompatEditText editText)
-				editText.SelectionChanged -= OnSelectionChanged;
+			if (_set)
+			{
+				platformView.SelectionChanged -= OnSelectionChanged;
+			}
 
 			_set = false;
 		}
@@ -100,8 +97,10 @@ namespace Microsoft.Maui.Handlers
 
 		public static void MapPlaceholderColor(IEntryHandler handler, IEntry entry)
 		{
-			if (handler is EntryHandler platformHandler)
+			if (handler is EntryHandler)
+			{
 				handler.PlatformView?.UpdatePlaceholderColor(entry);
+			}
 		}
 
 		public static void MapFont(IEntryHandler handler, IEntry entry) =>
@@ -136,18 +135,22 @@ namespace Microsoft.Maui.Handlers
 		public static void MapClearButtonVisibility(IEntryHandler handler, IEntry entry)
 		{
 			if (handler is EntryHandler platformHandler)
+			{
 				handler.PlatformView?.UpdateClearButtonVisibility(entry, platformHandler.GetClearButtonDrawable);
+			}
 		}
 
 		static void MapFocus(IEntryHandler handler, IEntry entry, object? args)
 		{
 			if (args is FocusRequest request)
+			{
 				handler.PlatformView.Focus(request);
+			}
 		}
 
 		void OnTextChanged(object? sender, TextChangedEventArgs e)
 		{
-			if (VirtualView == null)
+			if (VirtualView is null)
 			{
 				return;
 			}
@@ -165,7 +168,7 @@ namespace Microsoft.Maui.Handlers
 
 		void OnFocusedChange(object? sender, FocusChangeEventArgs e)
 		{
-			if (VirtualView == null)
+			if (VirtualView is null)
 			{
 				return;
 			}
@@ -176,7 +179,7 @@ namespace Microsoft.Maui.Handlers
 		// Check whether the touched position inbounds with clear button.
 		void OnTouch(object? sender, TouchEventArgs e) =>
 			e.Handled =
-				_clearButtonVisible && VirtualView != null &&
+				_clearButtonVisible && VirtualView is not null &&
 				PlatformView.HandleClearButtonTouched(e, GetClearButtonDrawable);
 
 		void OnEditorAction(object? sender, EditorActionEventArgs e)
@@ -187,7 +190,7 @@ namespace Microsoft.Maui.Handlers
 			// This means, just by subscribing to EditorAction/KeyPressed/etc.. you change the behavior of the control
 			// So, we are setting handled to false here in order to maintain default behavior
 			bool handled = false;
-			if (returnType != null)
+			if (returnType is not null)
 			{
 				var actionId = e.ActionId;
 				var evt = e.Event;
@@ -225,10 +228,14 @@ namespace Microsoft.Maui.Handlers
 			var selectedTextLength = PlatformView.GetSelectedTextLength();
 
 			if (VirtualView.CursorPosition != cursorPosition)
+			{
 				VirtualView.CursorPosition = cursorPosition;
+			}
 
 			if (VirtualView.SelectionLength != selectedTextLength)
+			{
 				VirtualView.SelectionLength = selectedTextLength;
+			}
 		}
 
 		internal void ShowClearButton()
@@ -241,14 +248,22 @@ namespace Microsoft.Maui.Handlers
 			var drawable = GetClearButtonDrawable();
 
 			if (VirtualView?.TextColor is not null)
+			{
 				drawable?.SetColorFilter(VirtualView.TextColor.ToPlatform(), FilterMode.SrcIn);
+			}
 			else
+			{
 				drawable?.ClearColorFilter();
+			}
 
 			if (PlatformView.LayoutDirection == LayoutDirection.Rtl)
+			{
 				PlatformView.SetCompoundDrawablesWithIntrinsicBounds(drawable, null, null, null);
+			}
 			else
+			{
 				PlatformView.SetCompoundDrawablesWithIntrinsicBounds(null, null, drawable, null);
+			}
 
 			_clearButtonVisible = true;
 		}

--- a/src/Core/src/Platform/Android/MauiAppCompatEditText.cs
+++ b/src/Core/src/Platform/Android/MauiAppCompatEditText.cs
@@ -4,7 +4,7 @@ using AndroidX.AppCompat.Widget;
 
 namespace Microsoft.Maui.Platform
 {
-	internal class MauiAppCompatEditText : AppCompatEditText
+	public class MauiAppCompatEditText : AppCompatEditText
 	{
 		public event EventHandler? SelectionChanged;
 

--- a/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -42,6 +42,9 @@ Microsoft.Maui.ITitleBar.Title.get -> string?
 Microsoft.Maui.IWebView.ProcessTerminated(Microsoft.Maui.WebProcessTerminatedEventArgs! args) -> void
 *REMOVED*Microsoft.Maui.IWindow.Content.get -> Microsoft.Maui.IView!
 Microsoft.Maui.IWindow.Content.get -> Microsoft.Maui.IView?
+Microsoft.Maui.Platform.MauiAppCompatEditText
+Microsoft.Maui.Platform.MauiAppCompatEditText.MauiAppCompatEditText(Android.Content.Context! context) -> void
+Microsoft.Maui.Platform.MauiAppCompatEditText.SelectionChanged -> System.EventHandler?
 Microsoft.Maui.Platform.MauiHybridWebView
 Microsoft.Maui.Platform.MauiHybridWebView.MauiHybridWebView(Microsoft.Maui.Handlers.HybridWebViewHandler! handler, Android.Content.Context! context) -> void
 Microsoft.Maui.Platform.MauiHybridWebView.SendRawMessage(string! rawMessage) -> void
@@ -54,9 +57,13 @@ Microsoft.Maui.TextAlignment.Justify = 3 -> Microsoft.Maui.TextAlignment
 Microsoft.Maui.WebProcessTerminatedEventArgs
 Microsoft.Maui.WebProcessTerminatedEventArgs.RenderProcessGoneDetail.get -> Android.Webkit.RenderProcessGoneDetail?
 Microsoft.Maui.WebProcessTerminatedEventArgs.Sender.get -> Android.Views.View?
+override Microsoft.Maui.Handlers.EntryHandler.ConnectHandler(Microsoft.Maui.Platform.MauiAppCompatEditText! platformView) -> void
+override Microsoft.Maui.Handlers.EntryHandler.CreatePlatformView() -> Microsoft.Maui.Platform.MauiAppCompatEditText!
+override Microsoft.Maui.Handlers.EntryHandler.DisconnectHandler(Microsoft.Maui.Platform.MauiAppCompatEditText! platformView) -> void
 override Microsoft.Maui.Handlers.HybridWebViewHandler.ConnectHandler(Android.Webkit.WebView! platformView) -> void
 override Microsoft.Maui.Handlers.HybridWebViewHandler.CreatePlatformView() -> Android.Webkit.WebView!
 override Microsoft.Maui.Handlers.HybridWebViewHandler.DisconnectHandler(Android.Webkit.WebView! platformView) -> void
+override Microsoft.Maui.Platform.MauiAppCompatEditText.OnSelectionChanged(int selStart, int selEnd) -> void
 override Microsoft.Maui.Platform.MauiHybridWebViewClient.Dispose(bool disposing) -> void
 override Microsoft.Maui.Platform.MauiHybridWebViewClient.ShouldInterceptRequest(Android.Webkit.WebView? view, Android.Webkit.IWebResourceRequest? request) -> Android.Webkit.WebResourceResponse?
 override Microsoft.Maui.Platform.MauiWebViewClient.OnRenderProcessGone(Android.Webkit.WebView? view, Android.Webkit.RenderProcessGoneDetail? detail) -> bool
@@ -77,4 +84,5 @@ static Microsoft.Maui.Keyboard.Date.get -> Microsoft.Maui.Keyboard!
 static Microsoft.Maui.Keyboard.Password.get -> Microsoft.Maui.Keyboard!
 static Microsoft.Maui.Keyboard.Time.get -> Microsoft.Maui.Keyboard!
 static Microsoft.Maui.ViewExtensions.DisconnectHandlers(this Microsoft.Maui.IView! view) -> void
+override Microsoft.Maui.Handlers.BorderHandler.PlatformArrange(Microsoft.Maui.Graphics.Rect rect) -> void
 override Microsoft.Maui.Handlers.BorderHandler.PlatformArrange(Microsoft.Maui.Graphics.Rect rect) -> void

--- a/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -85,4 +85,3 @@ static Microsoft.Maui.Keyboard.Password.get -> Microsoft.Maui.Keyboard!
 static Microsoft.Maui.Keyboard.Time.get -> Microsoft.Maui.Keyboard!
 static Microsoft.Maui.ViewExtensions.DisconnectHandlers(this Microsoft.Maui.IView! view) -> void
 override Microsoft.Maui.Handlers.BorderHandler.PlatformArrange(Microsoft.Maui.Graphics.Rect rect) -> void
-override Microsoft.Maui.Handlers.BorderHandler.PlatformArrange(Microsoft.Maui.Graphics.Rect rect) -> void

--- a/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -58,8 +58,10 @@ Microsoft.Maui.WebProcessTerminatedEventArgs
 Microsoft.Maui.WebProcessTerminatedEventArgs.RenderProcessGoneDetail.get -> Android.Webkit.RenderProcessGoneDetail?
 Microsoft.Maui.WebProcessTerminatedEventArgs.Sender.get -> Android.Views.View?
 override Microsoft.Maui.Handlers.EntryHandler.ConnectHandler(Microsoft.Maui.Platform.MauiAppCompatEditText! platformView) -> void
+override Microsoft.Maui.Handlers.EditorHandler.ConnectHandler(Microsoft.Maui.Platform.MauiAppCompatEditText! platformView) -> void
 override Microsoft.Maui.Handlers.EntryHandler.CreatePlatformView() -> Microsoft.Maui.Platform.MauiAppCompatEditText!
 override Microsoft.Maui.Handlers.EntryHandler.DisconnectHandler(Microsoft.Maui.Platform.MauiAppCompatEditText! platformView) -> void
+override Microsoft.Maui.Handlers.EditorHandler.DisconnectHandler(Microsoft.Maui.Platform.MauiAppCompatEditText! platformView) -> void
 override Microsoft.Maui.Handlers.HybridWebViewHandler.ConnectHandler(Android.Webkit.WebView! platformView) -> void
 override Microsoft.Maui.Handlers.HybridWebViewHandler.CreatePlatformView() -> Android.Webkit.WebView!
 override Microsoft.Maui.Handlers.HybridWebViewHandler.DisconnectHandler(Android.Webkit.WebView! platformView) -> void


### PR DESCRIPTION
### Description of Change

This change makes `MauiAppCompatEditText` public and makes the necessary changes to the Android `EntryHandler` accordingly.

This was triggered by https://github.com/dotnet/maui/issues/25728 because people had no way to implement the workaround probably because `MauiAppCompatEditText` could not be reached. Also there were a couple of TODOs in code to make this change.
