### PR TITLE
Fix XAMLC error when building an app with AoT compilation

### DIFF
--- a/samples/CommunityToolkit.Maui.Sample/Pages/Converters/CompareConverterPage.xaml
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Converters/CompareConverterPage.xaml
@@ -1,0 +1,48 @@
+<pages:BasePage
+    x:Class="CommunityToolkit.Maui.Sample.Pages.Converters.CompareConverterPage"
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:converters="clr-namespace:CommunityToolkit.Maui.Sample.Converters"
+    xmlns:mct="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
+    xmlns:pages="clr-namespace:CommunityToolkit.Maui.Sample.Pages"
+    xmlns:vm="clr-namespace:CommunityToolkit.Maui.Sample.ViewModels.Converters"
+    x:DataType="vm:CompareConverterViewModel"
+    x:TypeArguments="vm:CompareConverterViewModel">
+
+    <pages:BasePage.Resources>
+        <ResourceDictionary>
+            <x:Double x:Key="ComparingValue">5.0</x:Double>
+            <Color x:Key="LightGreen">LightGreen</Color>
+            <Color x:Key="PaleVioletRed">PaleVioletRed</Color>
+
+            <converters:CompareDoubleToColorConverter
+                x:Key="isLargerThanOneConverter"
+                ComparingValue="5"
+                ComparisonOperator="Greater"
+                FalseObject="PaleVioletRed"
+                TrueObject="LightGreen" />
+        </ResourceDictionary>
+    </pages:BasePage.Resources>
+
+    <VerticalStackLayout Spacing="20">
+
+        <Label Text="The CompareConverter is a Converter that converts an object of a type implementing IComparable, and returns the comparison result as a bool if no objects were specified through the TrueObject and/or FalseObject properties. If values are assigned to the TrueObject and/or FalseObject properties, the CompareConverter returns the respective object assigned." TextColor="{StaticResource NormalLabelTextColor}" />
+
+        <Slider
+            HorizontalOptions="FillAndExpand"
+            Maximum="10"
+            Minimum="0"
+            Value="{Binding SliderValue, Mode=TwoWay}" />
+
+        <Label
+            Padding="4,0"
+            BackgroundColor="{Binding SliderValue, Mode=OneWay, Converter={StaticResource isLargerThanOneConverter}}"
+            Text="The background of this label will be green if the value of the slider is greater than 1, and red otherwise."
+            TextColor="Black" />
+
+        <Label Text="The following label will show whether the value of the slider is greater than or equal to 50%:" TextColor="{StaticResource NormalLabelTextColor}" />
+
+        <Label Text="{Binding SliderValue, Mode=OneWay, Converter={mct:CompareConverter ComparingValue={StaticResource ComparingValue}, ComparisonOperator=GreaterOrEqual}}" />
+
+    </VerticalStackLayout>
+</pages:BasePage>

--- a/src/CommunityToolkit.Maui/Converters/CompareConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/CompareConverter.shared.cs
@@ -1,0 +1,50 @@
+using System;
+using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+
+namespace CommunityToolkit.Maui.Converters;
+
+/// <summary>
+/// Converts an object that implements IComparable to an object or a boolean based on a comparison.
+/// </summary>
+[AcceptEmptyServiceProvider]
+public sealed partial class CompareConverter : CompareConverter<IComparable, object>
+{
+}
+
+/// <summary>
+/// Converts an object that implements IComparable to an object or a boolean based on a comparison.
+/// </summary>
+public abstract class CompareConverter<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TValue, TReturnObject> : BaseConverterOneWay<TValue, object> where TValue : IComparable
+{
+	/// <inheritdoc/>
+	public override object ConvertFrom(TValue value, CultureInfo culture)
+	{
+		if (value is null)
+		{
+			throw new ArgumentNullException(nameof(value));
+		}
+
+		var result = value.CompareTo(ComparingValue);
+
+		return ComparisonOperator switch
+		{
+			OperatorType.Smaller => EvaluateCondition(result < 0, shouldReturnObjectResult),
+			OperatorType.SmallerOrEqual => EvaluateCondition(result <= 0, shouldReturnObjectResult),
+			OperatorType.Equal => EvaluateCondition(result is 0, shouldReturnObjectResult),
+			OperatorType.NotEqual => EvaluateCondition(result is not 0, shouldReturnObjectResult),
+			OperatorType.GreaterOrEqual => EvaluateCondition(result >= 0, shouldReturnObjectResult),
+			OperatorType.Greater => EvaluateCondition(result > 0, shouldReturnObjectResult),
+			_ => throw new NotSupportedException($"\"{ComparisonOperator}\" is not supported."),
+		};
+	}
+
+	object EvaluateCondition(bool comparisonResult, bool shouldReturnObject) => (comparisonResult, shouldReturnObject) switch
+	{
+		(true, true) => TrueObject ?? throw new InvalidOperationException($"{nameof(TrueObject)} cannot be null"),
+		(false, true) => FalseObject ?? throw new InvalidOperationException($"{nameof(FalseObject)} cannot be null"),
+		(true, _) => true,
+		_ => false
+	};
+}


### PR DESCRIPTION
Fixes #25871

Fix the XAMLC error when building an app with AoT compilation.

* Add `CompareConverter` class in `src/CommunityToolkit.Maui/Converters/CompareConverter.shared.cs` to handle `System.IComparable` type.
* Update `samples/CommunityToolkit.Maui.Sample/Pages/Converters/CompareConverterPage.xaml` to use the corrected `CompareConverter`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dotnet/maui/pull/26135?shareId=e04a88bd-bb14-43d3-bdd8-0baf57bc50d9).