### PR TITLE
Fix Tweener leak on Animation

### DIFF
--- a/src/Controls/src/Core/AnimationExtensions.cs
+++ b/src/Controls/src/Core/AnimationExtensions.cs
@@ -47,6 +47,12 @@ namespace Microsoft.Maui.Controls
 
 		static readonly Dictionary<AnimatableKey, Info> s_animations;
 		static readonly Dictionary<AnimatableKey, int> s_kinetics;
+
+		/// <summary>
+		/// This property is used for UnitTest 
+		/// </summary>
+		static internal int TweenersCounter => s_tweeners.Count;
+
 		static int s_currentTweener = 1;
 
 		static AnimationExtensions()

--- a/src/Controls/src/Core/AnimationExtensions.cs
+++ b/src/Controls/src/Core/AnimationExtensions.cs
@@ -67,6 +67,12 @@ namespace Microsoft.Maui.Controls
 			};
 			s_tweeners[id] = animation;
 			animation.Commit(animationManager);
+
+			animation.Finished += () =>
+			{
+				s_tweeners.TryRemove(id, out _);
+				animation.Finished = null;
+			};
 			return id;
 		}
 
@@ -81,6 +87,13 @@ namespace Microsoft.Maui.Controls
 			};
 			s_tweeners[id] = animation;
 			animation.Commit(animationManager);
+
+			animation.Finished += () =>
+			{
+				s_tweeners.TryRemove(id, out _);
+				animation.Finished = null;
+			};
+
 			return id;
 		}
 

--- a/src/Controls/src/Core/Tweener.cs
+++ b/src/Controls/src/Core/Tweener.cs
@@ -34,6 +34,8 @@ namespace Microsoft.Maui.Controls
 	{
 		readonly Func<long, bool> _step;
 
+
+
 		public TweenerAnimation(Func<long, bool> step)
 		{
 			_step = step;
@@ -43,6 +45,9 @@ namespace Microsoft.Maui.Controls
 		{
 			var running = _step.Invoke((long)millisecondsSinceLastUpdate);
 			HasFinished = !running;
+
+			if (HasFinished)
+				Finished?.Invoke();
 		}
 
 		internal override void ForceFinish()

--- a/src/Controls/src/Core/Tweener.cs
+++ b/src/Controls/src/Core/Tweener.cs
@@ -34,8 +34,6 @@ namespace Microsoft.Maui.Controls
 	{
 		readonly Func<long, bool> _step;
 
-
-
 		public TweenerAnimation(Func<long, bool> step)
 		{
 			_step = step;


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

This PR is a piece of #25232, that is a WiP to fix memories leaks on Animation.

This PR prevents the Tweener to live forever and the `s_tweeners` collection to grow forever.

<!-- Enter description of the fix in this section -->

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #25001

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
