### PR TITLE
Make MauiAppCompatEditText public

### DIFF
--- a/src/Core/src/Platform/Android/MauiAppCompatEditText.cs
+++ b/src/Core/src/Platform/Android/MauiAppCompatEditText.cs
@@ -4,7 +4,7 @@ using AndroidX.AppCompat.Widget;
 
 namespace Microsoft.Maui.Platform
 {
-	internal class MauiAppCompatEditText : AppCompatEditText
+	public class MauiAppCompatEditText : AppCompatEditText
 	{
 		public event EventHandler? SelectionChanged;
 

--- a/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -42,6 +42,9 @@ Microsoft.Maui.ITitleBar.Title.get -> string?
 Microsoft.Maui.IWebView.ProcessTerminated(Microsoft.Maui.WebProcessTerminatedEventArgs! args) -> void
 *REMOVED*Microsoft.Maui.IWindow.Content.get -> Microsoft.Maui.IView!
 Microsoft.Maui.IWindow.Content.get -> Microsoft.Maui.IView?
+Microsoft.Maui.Platform.MauiAppCompatEditText
+Microsoft.Maui.Platform.MauiAppCompatEditText.MauiAppCompatEditText(Android.Content.Context! context) -> void
+Microsoft.Maui.Platform.MauiAppCompatEditText.SelectionChanged -> System.EventHandler?
 Microsoft.Maui.Platform.MauiHybridWebView
 Microsoft.Maui.Platform.MauiHybridWebView.MauiHybridWebView(Microsoft.Maui.Handlers.HybridWebViewHandler! handler, Android.Content.Context! context) -> void
 Microsoft.Maui.Platform.MauiHybridWebView.SendRawMessage(string! rawMessage) -> void
@@ -57,6 +60,7 @@ Microsoft.Maui.WebProcessTerminatedEventArgs.Sender.get -> Android.Views.View?
 override Microsoft.Maui.Handlers.HybridWebViewHandler.ConnectHandler(Android.Webkit.WebView! platformView) -> void
 override Microsoft.Maui.Handlers.HybridWebViewHandler.CreatePlatformView() -> Android.Webkit.WebView!
 override Microsoft.Maui.Handlers.HybridWebViewHandler.DisconnectHandler(Android.Webkit.WebView! platformView) -> void
+override Microsoft.Maui.Platform.MauiAppCompatEditText.OnSelectionChanged(int selStart, int selEnd) -> void
 override Microsoft.Maui.Platform.MauiHybridWebViewClient.Dispose(bool disposing) -> void
 override Microsoft.Maui.Platform.MauiHybridWebViewClient.ShouldInterceptRequest(Android.Webkit.WebView? view, Android.Webkit.IWebResourceRequest? request) -> Android.Webkit.WebResourceResponse?
 override Microsoft.Maui.Platform.MauiWebViewClient.OnRenderProcessGone(Android.Webkit.WebView? view, Android.Webkit.RenderProcessGoneDetail? detail) -> bool


### PR DESCRIPTION
### Description of Change

Along the same lines as #26121 but only makes `MauiAppCompatEditText` public and does not touch the handlers as that would be too breaking at this point.

This was triggered by https://github.com/dotnet/maui/issues/25728 because people had no way to implement the workaround probably because `MauiAppCompatEditText` could not be reached. 
