### PR TITLE
Don’t call NSAttributedString with HTML from a background thread

### DIFF
--- a/src/Controls/src/Core/Label/Label.iOS.cs
+++ b/src/Controls/src/Core/Label/Label.iOS.cs
@@ -38,13 +38,6 @@ namespace Microsoft.Maui.Controls
 
 		static void MapFormatting(ILabelHandler handler, Label label)
 		{
-			// we need to re-apply color and font for HTML labels
-			if (!label.HasFormattedTextSpans && label.TextType == TextType.Html)
-			{
-				handler.UpdateValue(nameof(ILabel.TextColor));
-				handler.UpdateValue(nameof(ILabel.Font));
-			}
-
 			if (!IsPlainText(label))
 				return;
 

--- a/src/Controls/src/Core/Label/Label.iOS.cs
+++ b/src/Controls/src/Core/Label/Label.iOS.cs
@@ -36,12 +36,17 @@ namespace Microsoft.Maui.Controls
 			handler.PlatformView?.UpdateMaxLines(label);
 		}
 
-		static void MapFormatting(ILabelHandler handler, Label label)
+		internal static void MapFormatting(ILabelHandler handler, Label label)
 		{
-			if (!IsPlainText(label))
-				return;
-
-			LabelHandler.MapFormatting(handler, label);
+			if (IsPlainText(label))
+			{
+				LabelHandler.MapFormatting(handler, label);
+			}
+			else
+			{
+				handler.UpdateValue(nameof(ILabel.TextColor));
+				handler.UpdateValue(nameof(ILabel.Font));
+			}
 		}
 
 		void RecalculateSpanPositions(Size size)

--- a/src/Controls/src/Core/Platform/iOS/Extensions/LabelExtensions.cs
+++ b/src/Controls/src/Core/Platform/iOS/Extensions/LabelExtensions.cs
@@ -14,7 +14,22 @@ namespace Microsoft.Maui.Controls.Platform
 			switch (label.TextType)
 			{
 				case TextType.Html:
-					platformLabel.UpdateTextHtml(label);
+					// NOTE: Setting HTML text this will crash with some sort of consistency error.
+					// https://github.com/dotnet/maui/issues/25946
+					// Here we have to dispatch back the the main queue to avoid the crash.
+					// This is observed with CarouselView 1 but not with 2, so hopefully this
+					// will be just disappear once we switch.
+					CoreFoundation.DispatchQueue.MainQueue.DispatchAsync(() =>
+					{
+						platformLabel.UpdateTextHtml(label);
+
+						if (label.Handler is LabelHandler labelHandler)
+							Label.MapFormatting(labelHandler, label);
+
+						// NOTE: Because we are updating text outside the normal layout
+						// pass, we need to invalidate the measure for the next pass.
+						label.InvalidateMeasure();
+					});
 					break;
 
 				default:

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue25946.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue25946.xaml
@@ -1,0 +1,34 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Maui.Controls.Sample.Issues.Issue25946">
+    <Grid RowDefinitions="*,Auto">
+        <CarouselView x:Name="collectionView">
+            <CarouselView.ItemsSource>
+                <x:Array Type="{x:Type x:String}">
+                    <x:String>Item1</x:String>
+                    <x:String>Item2</x:String>
+                    <x:String>Item3</x:String>
+                </x:Array>
+            </CarouselView.ItemsSource>
+            <CarouselView.ItemTemplate>
+                <DataTemplate>
+                    <ContentView>
+                        <VerticalStackLayout HorizontalOptions="Center"
+                                             WidthRequest="200"
+                                             HeightRequest="200"
+                                             Background="Green">
+                            <Label Text="{Binding .}"/>
+                            <Label Text="{Binding .}"
+                                   TextType="Html"/>
+                        </VerticalStackLayout>
+                    </ContentView>
+                </DataTemplate>
+            </CarouselView.ItemTemplate>
+        </CarouselView>
+        <Button Grid.Row="1"
+                AutomationId="btnScrollToLastItem"
+                Clicked="ButtonClicked"
+                Text="Scroll to last Item"/>
+    </Grid>
+</ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue25946.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue25946.xaml.cs
@@ -1,0 +1,16 @@
+﻿namespace Maui.Controls.Sample.Issues
+{
+	[Issue(IssueTracker.Github, 25946, "App crashes on iOS 18 when placing html label in carousel view with > 2 elements", PlatformAffected.iOS)]
+	public partial class Issue25946 : ContentPage
+	{
+		public Issue25946()
+		{
+			InitializeComponent();
+		}
+
+		void ButtonClicked(object sender, EventArgs e)
+		{
+			collectionView.ScrollTo(1, animate: true);
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25946.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25946.cs
@@ -1,0 +1,26 @@
+﻿using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue25946 : _IssuesUITest
+	{
+		public Issue25946(TestDevice testDevice) : base(testDevice)
+		{
+		}
+
+		public override string Issue => "App crashes on iOS 18 when placing html label in carousel view with > 2 elements";
+
+		[Test]
+		[Category(UITestCategories.CarouselView)]
+		[Category(UITestCategories.Label)]
+		public void AppShouldNotCrash()
+		{
+			App.WaitForElement("btnScrollToLastItem");
+			App.Click("btnScrollToLastItem");
+
+			App.WaitForElement("Item2");
+		}
+	}
+}

--- a/src/Core/src/Handlers/Label/LabelHandler.iOS.cs
+++ b/src/Core/src/Handlers/Label/LabelHandler.iOS.cs
@@ -81,11 +81,5 @@ namespace Microsoft.Maui.Handlers
 			// so we need to make sure those are applied, too
 			handler.UpdateValue(nameof(ILabel.HorizontalTextAlignment));
 		}
-
-		internal static void ReapplyFormattingForHTMLLabel(ILabelHandler handler, ILabel label)
-		{
-			handler.UpdateValue(nameof(ILabel.TextColor));
-			handler.UpdateValue(nameof(ILabel.Font));
-		}
 	}
 }

--- a/src/Core/src/Handlers/Label/LabelHandler.iOS.cs
+++ b/src/Core/src/Handlers/Label/LabelHandler.iOS.cs
@@ -81,5 +81,11 @@ namespace Microsoft.Maui.Handlers
 			// so we need to make sure those are applied, too
 			handler.UpdateValue(nameof(ILabel.HorizontalTextAlignment));
 		}
+
+		internal static void ReapplyFormattingForHTMLLabel(ILabelHandler handler, ILabel label)
+		{
+			handler.UpdateValue(nameof(ILabel.TextColor));
+			handler.UpdateValue(nameof(ILabel.Font));
+		}
 	}
 }

--- a/src/Core/src/Platform/iOS/LabelExtensions.cs
+++ b/src/Core/src/Platform/iOS/LabelExtensions.cs
@@ -88,9 +88,16 @@ namespace Microsoft.Maui.Platform
 			};
 
 			NSError nsError = new();
-#pragma warning disable CS8601
-			platformLabel.AttributedText = new NSAttributedString(text, attr, ref nsError);
-#pragma warning restore CS8601
+			CoreFoundation.DispatchQueue.MainQueue.DispatchAsync(() =>
+			{
+				platformLabel.AttributedText = new NSAttributedString(text, attr, ref nsError);
+				if (label.Handler is ILabelHandler labelHandler)
+				{
+					labelHandler.UpdateValue(nameof(ILabel.TextColor));
+					labelHandler.UpdateValue(nameof(ILabel.Font));
+				}
+				label.InvalidateMeasure();
+			});
 		}
 
 		internal static void UpdateTextPlainText(this UILabel platformLabel, IText label)

--- a/src/Core/src/Platform/iOS/LabelExtensions.cs
+++ b/src/Core/src/Platform/iOS/LabelExtensions.cs
@@ -88,14 +88,17 @@ namespace Microsoft.Maui.Platform
 			};
 
 			NSError nsError = new();
-			CoreFoundation.DispatchQueue.MainQueue.DispatchAsync(() =>
-			{
-				platformLabel.AttributedText = new NSAttributedString(text, attr, ref nsError);
-				if (label.Handler is ILabelHandler labelHandler)
-					LabelHandler.ReapplyFormattingForHTMLLabel(labelHandler, label);
-					
-				label.InvalidateMeasure();
-			});
+
+			// NOTE: Sometimes this will crash with some sort of consistency error.
+			// https://github.com/dotnet/maui/issues/25946
+			// The caller should ensure that this extension is dispatched. We cannot
+			// do it here as we need to re-apply the formatting and we cannot call
+			// into Controls from Core.
+			// This is observed with CarouselView 1 but not with 2, so hopefully this
+			// will be just disappear once we switch.
+#pragma warning disable CS8601
+			platformLabel.AttributedText = new NSAttributedString(text, attr, ref nsError);
+#pragma warning restore CS8601
 		}
 
 		internal static void UpdateTextPlainText(this UILabel platformLabel, IText label)

--- a/src/Core/src/Platform/iOS/LabelExtensions.cs
+++ b/src/Core/src/Platform/iOS/LabelExtensions.cs
@@ -92,10 +92,8 @@ namespace Microsoft.Maui.Platform
 			{
 				platformLabel.AttributedText = new NSAttributedString(text, attr, ref nsError);
 				if (label.Handler is ILabelHandler labelHandler)
-				{
-					labelHandler.UpdateValue(nameof(ILabel.TextColor));
-					labelHandler.UpdateValue(nameof(ILabel.Font));
-				}
+					LabelHandler.ReapplyFormattingForHTMLLabel(labelHandler, label);
+					
 				label.InvalidateMeasure();
 			});
 		}


### PR DESCRIPTION
According to Apple's documentation: https://developer.apple.com/documentation/foundation/nsattributedstring/1524613-initwithdata

> Don’t call this method from a background thread if the options dictionary includes the [NSDocumentTypeDocumentAttribute](https://developer.apple.com/documentation/uikit/nsdocumenttypedocumentattribute) attribute with a value of [NSHTMLTextDocumentType](https://developer.apple.com/documentation/uikit/nshtmltextdocumenttype). If you do, the method tries to synchronize with the main thread, fails, and times out. Calling it from the main thread works, but can still time out if the HTML contains references to external resources. The HTML import mechanism is meant for implementing something like markdown (that is, text styles, colors, and so on), not for general HTML import.

Also, it seems to be a common problem among Apple developers:
https://forums.developer.apple.com/forums/thread/115405


### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/25946

|Before|After|
|--|--|
|<video src="https://github.com/user-attachments/assets/21af7336-8df7-44a1-aa8f-4a27d2cf2579" width="300px"/>|<video width="300px" src="https://github.com/user-attachments/assets/449c911a-0ceb-4d26-a086-88be87dee3c3" />|