### PR TITLE
[Windows] Optimize `LayoutHandler.Windows.cs`

### DIFF
--- a/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -54,6 +54,7 @@ Microsoft.Maui.WebProcessTerminatedEventArgs.Sender.get -> Microsoft.Web.WebView
 override Microsoft.Maui.Handlers.HybridWebViewHandler.ConnectHandler(Microsoft.UI.Xaml.Controls.WebView2! platformView) -> void
 override Microsoft.Maui.Handlers.HybridWebViewHandler.CreatePlatformView() -> Microsoft.UI.Xaml.Controls.WebView2!
 override Microsoft.Maui.Handlers.HybridWebViewHandler.DisconnectHandler(Microsoft.UI.Xaml.Controls.WebView2! platformView) -> void
+override Microsoft.Maui.Handlers.LayoutHandler.ConnectHandler(Microsoft.Maui.Platform.LayoutPanel! platformView) -> void
 static Microsoft.Maui.ElementHandlerExtensions.GetRequiredService<T>(this Microsoft.Maui.IElementHandler! handler, System.Type! type) -> T
 static Microsoft.Maui.ElementHandlerExtensions.GetRequiredService<T>(this Microsoft.Maui.IElementHandler! handler) -> T
 static Microsoft.Maui.ElementHandlerExtensions.GetService<T>(this Microsoft.Maui.IElementHandler! handler, System.Type! type) -> T?


### PR DESCRIPTION
### Description of Change

I've been scratching my head how to improve performance of `LayoutHandler` and it seems that storing `Children` of `PlatformView` leads to a significant performance gain in my test scenario (#21787). 

Hopefully, there is not a logical error. Please review carefully.

#### Speedscope


* MAIN: [1732718317..speedscope.MAIN.json](https://github.com/user-attachments/files/17936051/1732718317.speedscope.MAIN.json)
* PR: [1732718128..speedscope.PR.json](https://github.com/user-attachments/files/17936050/1732718128.speedscope.PR.json)

![image](https://github.com/user-attachments/assets/d07e55b7-02d7-4df8-aaab-29c3dbe5cd2f)

-> 98 % improvement for `IPanelMethods.get_Children`, and ~2% improvement for the app itself.

### Issues Fixed

Contributes to #21787