### PR TITLE
[ci] Remove use of  System.Formats.Asn1 by removing Microsoft.Build.Tasks.Core

### DIFF
--- a/eng/NuGetVersions.targets
+++ b/eng/NuGetVersions.targets
@@ -305,6 +305,11 @@
         Version="$(SystemDrawingCommonPackageVersion)"
     />
 
+    <PackageReference
+        Update="System.Formats.Asn1"
+        Version="$(SystemFormatsAsn1PackageVersion)"
+    />
+
 
     <PackageReference Update="Microsoft.DotNet.Build.Tasks.Workloads" Version="$(MicrosoftDotNetBuildTasksWorkloadsPackageVersion)" />
     <PackageReference Update="Microsoft.Signed.WiX" Version="$(MicrosoftSignedWixVersion)" />

--- a/eng/NuGetVersions.targets
+++ b/eng/NuGetVersions.targets
@@ -305,12 +305,6 @@
         Version="$(SystemDrawingCommonPackageVersion)"
     />
 
-    <PackageReference
-        Update="System.Formats.Asn1"
-        Version="$(SystemFormatsAsn1PackageVersion)"
-    />
-
-
     <PackageReference Update="Microsoft.DotNet.Build.Tasks.Workloads" Version="$(MicrosoftDotNetBuildTasksWorkloadsPackageVersion)" />
     <PackageReference Update="Microsoft.Signed.WiX" Version="$(MicrosoftSignedWixVersion)" />
     <PackageReference Update="MicroBuild.Plugins.SwixBuild.Dotnet" Version="$(MicroBuildPluginsSwixBuildDotnetPackageVersion)" />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -131,8 +131,7 @@
     <FizzlerPackageVersion>1.3.0</FizzlerPackageVersion>
     <TizenUIExtensionsVersion>0.9.0</TizenUIExtensionsVersion>
     <ExCSSPackageVersion>4.2.3</ExCSSPackageVersion>
-    <SystemDrawingCommonPackageVersion>8.0.3</SystemDrawingCommonPackageVersion>
-    <SystemFormatsAsn1PackageVersion>9.0.0</SystemFormatsAsn1PackageVersion>
+    <SystemDrawingCommonPackageVersion>9.0.0</SystemDrawingCommonPackageVersion>
     <MicrosoftDotNetBuildTasksFeedVersion>9.0.0-beta.24572.2</MicrosoftDotNetBuildTasksFeedVersion>
     <MicrosoftDotNetBuildTasksInstallersPackageVersion>9.0.0-beta.24572.2</MicrosoftDotNetBuildTasksInstallersPackageVersion>
     <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>9.0.0-beta.24572.2</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -132,6 +132,7 @@
     <TizenUIExtensionsVersion>0.9.0</TizenUIExtensionsVersion>
     <ExCSSPackageVersion>4.2.3</ExCSSPackageVersion>
     <SystemDrawingCommonPackageVersion>8.0.3</SystemDrawingCommonPackageVersion>
+    <SystemFormatsAsn1PackageVersion>9.0.0</SystemFormatsAsn1PackageVersion>
     <MicrosoftDotNetBuildTasksFeedVersion>9.0.0-beta.24572.2</MicrosoftDotNetBuildTasksFeedVersion>
     <MicrosoftDotNetBuildTasksInstallersPackageVersion>9.0.0-beta.24572.2</MicrosoftDotNetBuildTasksInstallersPackageVersion>
     <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>9.0.0-beta.24572.2</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>

--- a/src/Controls/src/Build.Tasks/Controls.Build.Tasks.csproj
+++ b/src/Controls/src/Build.Tasks/Controls.Build.Tasks.csproj
@@ -25,10 +25,8 @@
 	<ItemGroup>
 		<PackageReference Include="Mono.Cecil" Version="0.11.5" PrivateAssets="all" GeneratePathProperty="true" />
 		<PackageReference Include="System.CodeDom" Version="7.0.0" PrivateAssets="all" GeneratePathProperty="true" />
-		<PackageReference Include="Microsoft.Build" Version="17.8.3" PrivateAssets="all" Condition=" '$(_IncludeMicrosoftBuildPackage)' == 'true' "/>
 		<PackageReference Include="Microsoft.Build.Framework" Version="17.8.3" PrivateAssets="all" />
 		<PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.8.3" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.8.3" PrivateAssets="all" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Controls/tests/Xaml.UnitTests/Controls.Xaml.UnitTests.csproj
+++ b/src/Controls/tests/Xaml.UnitTests/Controls.Xaml.UnitTests.csproj
@@ -25,10 +25,8 @@
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="Mono.Cecil" Version="0.11.5" />
     <PackageReference Include="System.CodeDom" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Build" Version="16.9.0" />
     <PackageReference Include="Microsoft.Build.Framework" Version="16.9.0" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.9.0" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="16.9.0" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.1.0" />
   </ItemGroup>
 

--- a/src/Controls/tests/Xaml.UnitTests/Controls.Xaml.UnitTests.csproj
+++ b/src/Controls/tests/Xaml.UnitTests/Controls.Xaml.UnitTests.csproj
@@ -28,7 +28,6 @@
     <PackageReference Include="Microsoft.Build" Version="16.9.0" />
     <PackageReference Include="Microsoft.Build.Framework" Version="16.9.0" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.9.0" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="16.9.0" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.1.0" />
   </ItemGroup>
 

--- a/src/SingleProject/Resizetizer/src/Resizetizer.csproj
+++ b/src/SingleProject/Resizetizer/src/Resizetizer.csproj
@@ -25,10 +25,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build" Version="17.8.3" PrivateAssets="all" Condition=" '$(_IncludeMicrosoftBuildPackage)' == 'true' " />
     <PackageReference Include="Microsoft.Build.Framework" Version="17.8.3" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.8.3" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.8.3" PrivateAssets="all" />
   </ItemGroup>
 
   <Import Project="ResizetizerPackages.projitems" />

--- a/src/SingleProject/Resizetizer/src/Resizetizer.csproj
+++ b/src/SingleProject/Resizetizer/src/Resizetizer.csproj
@@ -28,8 +28,6 @@
     <PackageReference Include="Microsoft.Build" Version="17.8.3" PrivateAssets="all" Condition=" '$(_IncludeMicrosoftBuildPackage)' == 'true' " />
     <PackageReference Include="Microsoft.Build.Framework" Version="17.8.3" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.8.3" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.8.3" PrivateAssets="all" />
-    <PackageReference Include="System.Formats.Asn1" />
   </ItemGroup>
 
   <Import Project="ResizetizerPackages.projitems" />

--- a/src/SingleProject/Resizetizer/src/Resizetizer.csproj
+++ b/src/SingleProject/Resizetizer/src/Resizetizer.csproj
@@ -29,6 +29,7 @@
     <PackageReference Include="Microsoft.Build.Framework" Version="17.8.3" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.8.3" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.8.3" PrivateAssets="all" />
+    <PackageReference Include="System.Formats.Asn1" />
   </ItemGroup>
 
   <Import Project="ResizetizerPackages.projitems" />


### PR DESCRIPTION
### Description of Change

This pull request includes several changes to update and remove package references across multiple project files. The most important removing various `Microsoft.Build` package references.
Also some changes involve updating the `System.Drawing.Common` to 9.0.0
 
Package version updates:

* [`eng/Versions.props`](diffhunk://#diff-1ea18ff65faa2ae6fed570b83747086d0317f5e4bc325064f6c14319a9c4ff67L134-R134): Updated `SystemDrawingCommonPackageVersion` from `8.0.3` to `9.0.0`.

Package reference removals:

* [`src/Controls/src/Build.Tasks/Controls.Build.Tasks.csproj`](diffhunk://#diff-214e0ba78874d50099e2bd55c060ce4af3ff350f1a1931e6e56d57ebb85bc460L28-L31): Removed `Microsoft.Build` and `Microsoft.Build.Tasks.Core` package references.
* [`src/Controls/tests/Xaml.UnitTests/Controls.Xaml.UnitTests.csproj`](diffhunk://#diff-7f5e28b6c956dd2ebe27b9960568b7a219cc98d9a0856e52dcfa225c24c95310L28-L31): Removed `Microsoft.Build` and `Microsoft.Build.Tasks.Core` package references.
* [`src/SingleProject/Resizetizer/src/Resizetizer.csproj`](diffhunk://#diff-161416fdc3d384a1e3bf1669b6115609ec49fc48bff2142c09604bd7d3aa562cL28-L31): Removed `Microsoft.Build` and `Microsoft.Build.Tasks.Core` package references.

Minor cleanup:

* [`eng/NuGetVersions.targets`](diffhunk://#diff-6f7571edc245072b28d62cfffb1f90547711103aa218e6a81356599e9b97c5bdL308): Removed an unnecessary empty line.

### Issues Fixed

Fixes #26162

