### PR TITLE
[ci] See if we can provision by default on devdiv

### DIFF
--- a/eng/pipelines/common/device-tests-steps.yml
+++ b/eng/pipelines/common/device-tests-steps.yml
@@ -36,10 +36,10 @@ steps:
       installDefaultAndroidApi: ${{ or(eq(parameters.platform, 'ios'), eq(parameters.platform, 'catalyst'))  }}
       provisionatorChannel: ${{ parameters.provisionatorChannel }}
       ${{ if not(parameters.skipProvisioning) }}:
-        skipProvisioning: false
+        skipProvisionator : false
         gitHubToken: $(github--pat--vs-mobiletools-engineering-service2)
       ${{ else }}:  
-        skipProvisioning: true
+        skipProvisionator: true
 
   - pwsh: ./build.ps1 --target=dotnet --configuration="Release" --verbosity=diagnostic
     displayName: 'Install .NET'

--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -68,7 +68,7 @@ steps:
 
 
   # Provision Additional Software
-  - ${{ if ne(parameters.skipProvisioning, 'true') }}:
+  - ${{ if not(parameters.skipProvisioning) }}:
     - ${{ if eq(variables['System.TeamProject'], 'devdiv') }}:
       - task: xamops.azdevex.provisionator-task.provisionator@2
         displayName: 'Provision Additional Software'

--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -66,9 +66,9 @@ steps:
       condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
       timeoutInMinutes: 30
 
-
   # Provision Additional Software
   - ${{ if ne(parameters.skipProvisionator, true) }}:
+    # Prepare macOS
     - task: xamops.azdevex.provisionator-task.provisionator@2
       displayName: 'Provision Additional Software'
       condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
@@ -87,17 +87,7 @@ steps:
         ${{ if eq(parameters.installDefaultAndroidApi, true) }}:
           INSTALL_DEFAULT_ANDROID_API: 'true'
  
-  # Setup JDK Paths (gradle needs it)
-  - bash: |
-      echo "##vso[task.setvariable variable=JI_JAVA_HOME]$(JAVA_HOME_17_X64)"
-      echo "##vso[task.setvariable variable=JAVA_HOME]$(JAVA_HOME_17_X64)"
-    #  brew install --cask microsoft-openjdk@17
-    displayName: 'Setup JDK Paths'
-    condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))  
- 
-  # Prepare Windows
-  # Provision Additional Software
-  - ${{ if ne(parameters.skipProvisioning, true) }}:
+    # Prepare Windows
     - task: xamops.azdevex.provisionator-task.provisionator@2
       displayName: 'Provision Additional Software'
       condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
@@ -113,6 +103,15 @@ steps:
           SKIP_ANDROID_API_IMAGES: 'true'
         ${{ if eq(parameters.installDefaultAndroidApi, true) }}:
           INSTALL_DEFAULT_ANDROID_API: 'true'
+
+  # Prepare Both
+  # Setup JDK Paths (gradle needs it)
+  - bash: |
+      echo "##vso[task.setvariable variable=JI_JAVA_HOME]$(JAVA_HOME_17_X64)"
+      echo "##vso[task.setvariable variable=JAVA_HOME]$(JAVA_HOME_17_X64)"
+    #  brew install --cask microsoft-openjdk@17
+    displayName: 'Setup JDK Paths'
+    condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))  
 
   - pwsh: |
       if ($env:JAVA_HOME_17_X64) {
@@ -132,7 +131,6 @@ steps:
     displayName: 'Setup JDK Paths'
     condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
 
-  # Prepare Both
   - task: UseDotNet@2
     displayName: 'Use .NET SDK $(DOTNET_VERSION)'
     inputs:

--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -68,7 +68,7 @@ steps:
 
 
   # Provision Additional Software
-  - ${{ if not(parameters.skipProvisioning) }}:
+  - ${{ if not(parameters.skipProvisionator) }}:
     - task: xamops.azdevex.provisionator-task.provisionator@2
       displayName: 'Provision Additional Software'
       condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))

--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -68,7 +68,7 @@ steps:
 
 
   # Provision Additional Software
-  - ${{ if ne(parameters.skipProvisioning, 'true') }}:
+  - ${{ if not(parameters.skipProvisioning) }}:
     - task: xamops.azdevex.provisionator-task.provisionator@2
       displayName: 'Provision Additional Software'
       condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
@@ -97,7 +97,7 @@ steps:
  
   # Prepare Windows
   # Provision Additional Software
-  - ${{ if ne(parameters.skipProvisioning, 'true') }}:
+  - ${{ if not(parameters.skipProvisioning) }}:
     - task: xamops.azdevex.provisionator-task.provisionator@2
       displayName: 'Provision Additional Software'
       condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))

--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -68,25 +68,24 @@ steps:
 
 
   # Provision Additional Software
-  - ${{ if not(parameters.skipProvisioning) }}:
-    - ${{ if eq(variables['System.TeamProject'], 'devdiv') }}:
-      - task: xamops.azdevex.provisionator-task.provisionator@2
-        displayName: 'Provision Additional Software'
-        condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
-        continueOnError: true
-        inputs:
-          provisioning_script: ${{ parameters.checkoutDirectory }}/${{ parameters.provisionatorPath }}
-          provisioning_extra_args: ${{ parameters.provisionatorExtraArguments }}
-          github_token: ${{ parameters.gitHubToken }}
-        env:
-          PROVISIONATOR_CHANNEL: ${{ parameters.provisionatorChannel }}
-          AUTH_TOKEN_COMPONENTS_MAC_IOS_CERTIFICATE_P12: ${{ parameters.certPass }}
-          ${{ if eq(parameters.skipAndroidSdks, true) }}:
-            SKIP_ANDROID_API_SDKS: 'true'
-          ${{ if eq(parameters.skipAndroidImages, true) }}:
-            SKIP_ANDROID_API_IMAGES: 'true'
-          ${{ if eq(parameters.installDefaultAndroidApi, true) }}:
-            INSTALL_DEFAULT_ANDROID_API: 'true'
+  - ${{ if ne(parameters.skipProvisioning, 'true') }}:
+    - task: xamops.azdevex.provisionator-task.provisionator@2
+      displayName: 'Provision Additional Software'
+      condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
+      continueOnError: true
+      inputs:
+        provisioning_script: ${{ parameters.checkoutDirectory }}/${{ parameters.provisionatorPath }}
+        provisioning_extra_args: ${{ parameters.provisionatorExtraArguments }}
+        github_token: ${{ parameters.gitHubToken }}
+      env:
+        PROVISIONATOR_CHANNEL: ${{ parameters.provisionatorChannel }}
+        AUTH_TOKEN_COMPONENTS_MAC_IOS_CERTIFICATE_P12: ${{ parameters.certPass }}
+        ${{ if eq(parameters.skipAndroidSdks, true) }}:
+          SKIP_ANDROID_API_SDKS: 'true'
+        ${{ if eq(parameters.skipAndroidImages, true) }}:
+          SKIP_ANDROID_API_IMAGES: 'true'
+        ${{ if eq(parameters.installDefaultAndroidApi, true) }}:
+          INSTALL_DEFAULT_ANDROID_API: 'true'
  
   # Setup JDK Paths (gradle needs it)
   - bash: |

--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -68,7 +68,7 @@ steps:
 
 
   # Provision Additional Software
-  - ${{ if not(parameters.skipProvisionator) }}:
+  - ${{ if ne(parameters.skipProvisionator, true) }}:
     - task: xamops.azdevex.provisionator-task.provisionator@2
       displayName: 'Provision Additional Software'
       condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
@@ -97,7 +97,7 @@ steps:
  
   # Prepare Windows
   # Provision Additional Software
-  - ${{ if not(parameters.skipProvisioning) }}:
+  - ${{ if ne(parameters.skipProvisioning, true) }}:
     - task: xamops.azdevex.provisionator-task.provisionator@2
       displayName: 'Provision Additional Software'
       condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))

--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -2,7 +2,7 @@ parameters:
   poolName: ''
   clearCaches: true
   skipXcode: false
-  skipProvisioning: true
+  skipProvisionator: true
   skipAndroidSdks: false
   skipAndroidImages: false
   installDefaultAndroidApi: false

--- a/eng/pipelines/common/ui-tests-build-sample.yml
+++ b/eng/pipelines/common/ui-tests-build-sample.yml
@@ -7,6 +7,7 @@ parameters:
   version: '' #the iOS version'
   provisionatorChannel: 'latest'
   agentPoolAccessToken: ''
+  skipProvisioning: true
   configuration : "Release"
   testFilter: ''
   runtimeVariant: 'Mono'
@@ -27,6 +28,11 @@ steps:
       skipAndroidSdks: false
       skipXcode: ${{ or(eq(parameters.platform, 'android'), eq(parameters.platform, 'windows')) }}
       provisionatorChannel: ${{ parameters.provisionatorChannel }}
+      ${{ if parameters.skipProvisioning }}:
+        skipProvisioning: true
+      ${{ else }}:  
+        skipProvisioning: false
+        gitHubToken: $(github--pat--vs-mobiletools-engineering-service2)
       
   - task: PowerShell@2
     condition: ne('${{ parameters.platform }}' , 'windows')

--- a/eng/pipelines/common/ui-tests-build-sample.yml
+++ b/eng/pipelines/common/ui-tests-build-sample.yml
@@ -23,15 +23,14 @@ steps:
 
   - template: provision.yml
     parameters:
-      skipProvisioning: true
       # FIXME: 'Build the MSBuild Tasks' step fails for net9.0-android35 without API 35
       skipAndroidSdks: false
       skipXcode: ${{ or(eq(parameters.platform, 'android'), eq(parameters.platform, 'windows')) }}
       provisionatorChannel: ${{ parameters.provisionatorChannel }}
       ${{ if parameters.skipProvisioning }}:
-        skipProvisioning: true
+        skipProvisionator: true
       ${{ else }}:  
-        skipProvisioning: false
+        skipProvisionator: false
         gitHubToken: $(github--pat--vs-mobiletools-engineering-service2)
       
   - task: PowerShell@2

--- a/eng/pipelines/common/ui-tests-compatibility-steps.yml
+++ b/eng/pipelines/common/ui-tests-compatibility-steps.yml
@@ -26,10 +26,10 @@ steps:
     parameters:
       ${{ if eq(parameters.platform, 'windows') }}:
         platform: windows
-        skipProvisioning: true
+        skipProvisionator: true
       ${{ if ne(parameters.platform, 'windows') }}:
         platform: macos
-        skipProvisioning: false
+        skipProvisionator: false
       skipXcode: ${{ or(eq(parameters.platform, 'android'), eq(parameters.platform, 'windows')) }}
       provisionatorChannel: ${{ parameters.provisionatorChannel }}
  

--- a/eng/pipelines/common/ui-tests-steps.yml
+++ b/eng/pipelines/common/ui-tests-steps.yml
@@ -43,9 +43,9 @@ steps:
       skipXcode: ${{ or(eq(parameters.platform, 'android'), eq(parameters.platform, 'windows')) }}
       provisionatorChannel: ${{ parameters.provisionatorChannel }}
       ${{ if parameters.skipProvisioning }}:
-        skipProvisioning: true
+        skipProvisionator: true
       ${{ else }}:  
-        skipProvisioning: false
+        skipProvisionator: false
         gitHubToken: $(github--pat--vs-mobiletools-engineering-service2)
 
   - task: PowerShell@2

--- a/eng/pipelines/common/ui-tests-steps.yml
+++ b/eng/pipelines/common/ui-tests-steps.yml
@@ -42,11 +42,11 @@ steps:
       skipAndroidSdks: ${{ ne(parameters.platform, 'android') }}
       skipXcode: ${{ or(eq(parameters.platform, 'android'), eq(parameters.platform, 'windows')) }}
       provisionatorChannel: ${{ parameters.provisionatorChannel }}
-      ${{ if not(parameters.skipProvisioning) }}:
+      ${{ if parameters.skipProvisioning }}:
+        skipProvisioning: true
+      ${{ else }}:  
         skipProvisioning: false
         gitHubToken: $(github--pat--vs-mobiletools-engineering-service2)
-      ${{ else }}:  
-        skipProvisioning: true
 
   - task: PowerShell@2
     condition: ne('${{ parameters.platform }}' , 'windows')

--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -44,10 +44,7 @@ variables:
 - name: provisionator.path
   value: 'eng/provisioning/provisioning.csx'
 - name: internalProvisioning
-  value: $[or(
-            eq(variables['provisioning'], 'true'),
-            eq(variables['System.TeamProject'], 'devdiv')
-          )]
+  value: false
 - name: provisionator.extraArguments
   value: '-vvvv'
 - name: DotNet.Dir
@@ -72,9 +69,9 @@ variables:
   - group: Xamarin-Secrets
 
 - ${{ if or(eq(variables['System.TeamProject'], 'DevDiv'), eq(variables['Build.DefinitionName'], 'dotnet-maui')) }}:
-  - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
-    - name: internalProvisioning
-      value: true
+  - name: internalProvisioning
+    value: true
+  - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}: 
     - name: PrivateBuild
       value: false
     - name: _RunAsPublic
@@ -85,8 +82,6 @@ variables:
       value: real
     # - name: PostBuildSign
     #   value: true
-    # For eng/common/SetupNugetSources.ps1
-    # - group: Xamarin-Secrets
 
     - group: DotNetBuilds storage account read tokens
     - group: AzureDevOps-Artifact-Feeds-Pats

--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -43,6 +43,11 @@ variables:
   value: 'eng/provisioning/xcode.csx'
 - name: provisionator.path
   value: 'eng/provisioning/provisioning.csx'
+- name: internalProvisioning
+  value: $[or(
+            eq(variables['provisioning'], 'true'),
+            eq(variables['System.TeamProject'], 'devdiv')
+          )]
 - name: provisionator.extraArguments
   value: '-vvvv'
 - name: DotNet.Dir
@@ -68,6 +73,8 @@ variables:
 
 - ${{ if or(eq(variables['System.TeamProject'], 'DevDiv'), eq(variables['Build.DefinitionName'], 'dotnet-maui')) }}:
   - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
+    - name: internalProvisioning
+      value: true
     - name: PrivateBuild
       value: false
     - name: _RunAsPublic

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -198,10 +198,10 @@ stages:
                   installDefaultAndroidApi: false
                   skipXcode: ${{ ne(BuildPlatform.name , 'macOS') }}
                   ${{ if or(parameters.UseProvisionator, variables['internalProvisioning']) }}:
-                    skipProvisioning: false
+                    skipProvisionator: false
                     gitHubToken: $(github--pat--vs-mobiletools-engineering-service2)
                   ${{ else }}:  
-                    skipProvisioning: true
+                    skipProvisionator: true
               - pwsh: ./build.ps1 --target=dotnet --configuration="${{ BuildConfiguration }}" --verbosity=diagnostic
                 displayName: 'Install .NET'
                 retryCountOnTaskFailure: 3
@@ -270,11 +270,11 @@ stages:
                       skipAndroidImages: true
                       installDefaultAndroidApi: true
                       skipXcode: ${{ ne(PackPlatform.name , 'macOS') }}
-                      ${{ if or(parameters.UseProvisionator, variables['internalProvisioning']) }}:
-                        skipProvisioning: false
+                      ${{ if or(eq(parameters.UseProvisionator, 'True'), eq(variables['internalProvisioning'],'True') )}}:
+                        skipProvisionator: false
                         gitHubToken: $(github--pat--vs-mobiletools-engineering-service2)
                       ${{ else }}:  
-                        skipProvisioning: true
+                        skipProvisionator: true
                       
   - stage: samples_net
     displayName: Test .NET MAUI Samples

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -197,7 +197,7 @@ stages:
                   skipAndroidImages: true
                   installDefaultAndroidApi: false
                   skipXcode: ${{ ne(BuildPlatform.name , 'macOS') }}
-                  ${{ if parameters.UseProvisionator }}:
+                  ${{ if or(parameters.UseProvisionator, variables['internalProvisioning']) }}:
                     skipProvisioning: false
                     gitHubToken: $(github--pat--vs-mobiletools-engineering-service2)
                   ${{ else }}:  
@@ -270,7 +270,7 @@ stages:
                       skipAndroidImages: true
                       installDefaultAndroidApi: true
                       skipXcode: ${{ ne(PackPlatform.name , 'macOS') }}
-                      ${{ if parameters.UseProvisionator }}:
+                      ${{ if or(parameters.UseProvisionator, variables['internalProvisioning']) }}:
                         skipProvisioning: false
                         gitHubToken: $(github--pat--vs-mobiletools-engineering-service2)
                       ${{ else }}:  
@@ -298,7 +298,7 @@ stages:
                 skipAndroidImages: true
                 installDefaultAndroidApi: true
                 skipXcode: ${{ ne(BuildPlatform.name , 'macOS') }}
-                ${{ if parameters.UseProvisionator }}:
+                ${{ if or(parameters.UseProvisionator, variables['internalProvisioning']) }}:
                   skipProvisioning: false
                   gitHubToken: $(github--pat--vs-mobiletools-engineering-service2)
                 ${{ else }}:  
@@ -343,7 +343,7 @@ stages:
         RunPlatforms: ${{ parameters.RunTemplatePlatforms }}
         BuildPlatforms: ${{ parameters.BuildTemplatePlatforms }}
         MacBuildPool: ${{ parameters.MacTemplatePool }}
-        ${{ if parameters.UseProvisionator }}:
+        ${{ if or(parameters.UseProvisionator, variables['internalProvisioning']) }}:
           skipProvisioning: false
         ${{ else }}:
           skipProvisioning: true

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -197,11 +197,10 @@ stages:
                   skipAndroidImages: true
                   installDefaultAndroidApi: false
                   skipXcode: ${{ ne(BuildPlatform.name , 'macOS') }}
-                  ${{ if or(parameters.UseProvisionator, variables['internalProvisioning']) }}:
+                  ${{ if or(parameters.UseProvisionator, eq(variables['internalProvisioning'],'True')) }}:
                     skipProvisionator: false
                     gitHubToken: $(github--pat--vs-mobiletools-engineering-service2)
-                  ${{ else }}:  
-                    skipProvisionator: true
+            
               - pwsh: ./build.ps1 --target=dotnet --configuration="${{ BuildConfiguration }}" --verbosity=diagnostic
                 displayName: 'Install .NET'
                 retryCountOnTaskFailure: 3
@@ -299,10 +298,10 @@ stages:
                 installDefaultAndroidApi: true
                 skipXcode: ${{ ne(BuildPlatform.name , 'macOS') }}
                 ${{ if or(parameters.UseProvisionator, variables['internalProvisioning']) }}:
-                  skipProvisioning: false
+                  skipProvisionator: false
                   gitHubToken: $(github--pat--vs-mobiletools-engineering-service2)
                 ${{ else }}:  
-                  skipProvisioning: true
+                  skipProvisionator: true
             - task: DownloadBuildArtifacts@0
               displayName: 'Download Packages'
               inputs:
@@ -344,9 +343,9 @@ stages:
         BuildPlatforms: ${{ parameters.BuildTemplatePlatforms }}
         MacBuildPool: ${{ parameters.MacTemplatePool }}
         ${{ if or(parameters.UseProvisionator, variables['internalProvisioning']) }}:
-          skipProvisioning: false
+          skipProvisionator: false
         ${{ else }}:
-          skipProvisioning: true
+          skipProvisionator: true
         conditionMacTemplates: or(
               ${{ parameters.BuildEverything }},
               ne(variables['Build.Reason'], 'PullRequest'),

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -299,7 +299,7 @@ stages:
                 skipAndroidImages: true
                 installDefaultAndroidApi: true
                 skipXcode: ${{ ne(BuildPlatform.name , 'macOS') }}
-                ${{ if or(parameters.UseProvisionator, variables['internalProvisioning']) }}:
+                ${{ if or(eq(parameters.UseProvisionator, true), eq(variables['internalProvisioning'],'True') ) }}:
                   skipProvisionator: false
                   gitHubToken: $(github--pat--vs-mobiletools-engineering-service2)
                 ${{ else }}:  
@@ -348,6 +348,9 @@ stages:
               ${{ parameters.BuildEverything }},
               ne(variables['Build.Reason'], 'PullRequest'),
               eq(variables['System.TeamProject'], 'devdiv'))
-
+        ${{ if or(eq(parameters.UseProvisionator, true), eq(variables['internalProvisioning'],'True') ) }}:
+          skipProvisioning: false
+          
+        
   - ${{ if eq(variables['System.TeamProject'], 'devdiv') }}:
     - template: common/localization-handoff.yml                     # Process outgoing strings [Localization Handoff]

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -344,10 +344,6 @@ stages:
         RunPlatforms: ${{ parameters.RunTemplatePlatforms }}
         BuildPlatforms: ${{ parameters.BuildTemplatePlatforms }}
         MacBuildPool: ${{ parameters.MacTemplatePool }}
-        ${{ if or(parameters.UseProvisionator, variables['internalProvisioning']) }}:
-          skipProvisionator: false
-        ${{ else }}:
-          skipProvisionator: true
         conditionMacTemplates: or(
               ${{ parameters.BuildEverything }},
               ne(variables['Build.Reason'], 'PullRequest'),

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -197,9 +197,11 @@ stages:
                   skipAndroidImages: true
                   installDefaultAndroidApi: false
                   skipXcode: ${{ ne(BuildPlatform.name , 'macOS') }}
-                  ${{ if or(parameters.UseProvisionator, eq(variables['internalProvisioning'],'True')) }}:
+                  ${{ if or(parameters.UseProvisionator, eq(variables['internalProvisioning'],'True') ) }}:
                     skipProvisionator: false
                     gitHubToken: $(github--pat--vs-mobiletools-engineering-service2)
+                  ${{ else }}:
+                    skipProvisionator: true
             
               - pwsh: ./build.ps1 --target=dotnet --configuration="${{ BuildConfiguration }}" --verbosity=diagnostic
                 displayName: 'Install .NET'

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -197,7 +197,7 @@ stages:
                   skipAndroidImages: true
                   installDefaultAndroidApi: false
                   skipXcode: ${{ ne(BuildPlatform.name , 'macOS') }}
-                  ${{ if or(parameters.UseProvisionator, eq(variables['internalProvisioning'],'True') ) }}:
+                  ${{ if or(eq(parameters.UseProvisionator, true), eq(variables['internalProvisioning'],'True') ) }}:
                     skipProvisionator: false
                     gitHubToken: $(github--pat--vs-mobiletools-engineering-service2)
                   ${{ else }}:

--- a/eng/pipelines/ui-tests.yml
+++ b/eng/pipelines/ui-tests.yml
@@ -144,14 +144,17 @@ stages:
         androidApiLevels: [ 30 ]
         iosVersions: [ '18.0' ]
         provisionatorChannel: ${{ parameters.provisionatorChannel }}
-        skipProvisioning: ${{ or(not(parameters.UseProvisionator), false) }}
       ${{ else }}:
         androidApiLevels: [ 30 ]
         iosVersions: [ '18.0' ]
         provisionatorChannel: ${{ parameters.provisionatorChannel }}
-        skipProvisioning: ${{ not(parameters.UseProvisionator) }}
       ${{ if parameters.CompatibilityTests }}:
         runCompatibilityTests: true
+      ${{ if or(parameters.UseProvisionator, variables['internalProvisioning']) }}:
+        skipProvisioning: false
+        gitHubToken: $(github--pat--vs-mobiletools-engineering-service2)
+      ${{ else }}:  
+        skipProvisioning: true
       projects:
         - name: controls
           desc: Controls

--- a/eng/pipelines/ui-tests.yml
+++ b/eng/pipelines/ui-tests.yml
@@ -150,7 +150,7 @@ stages:
         provisionatorChannel: ${{ parameters.provisionatorChannel }}
       ${{ if parameters.CompatibilityTests }}:
         runCompatibilityTests: true
-      ${{ if or(parameters.UseProvisionator, variables['internalProvisioning']) }}:
+      ${{ if or(eq(parameters.UseProvisionator, true), eq(variables['internalProvisioning'],'True') ) }}:
         skipProvisioning: false
         gitHubToken: $(github--pat--vs-mobiletools-engineering-service2)
       ${{ else }}:  


### PR DESCRIPTION
### Description of Change

Set variables to provision the certs by default on DevDiv, and allow to manually started on xamarin instance 

The idea is to have two variables UseProvisionator that can be set at queue time and a internalProvisioning that is set on the pipeline on devdiv.

It also now allows to by demand provision a bot on xamarin public azdo instance

- Manual start the pipeline
- Enable the UseProvisionator flag 
- Allow to select a bot by adding a demand to provision like 
```
  - Agent.Name -equals BOT-0225.Sonoma
```
<img width="641" alt="Screenshot 2024-11-28 at 14 15 07" src="https://github.com/user-attachments/assets/20765a94-9581-472f-bc22-a277715426a4">

Example pipeline 
https://dev.azure.com/xamarin/public/_build/results?buildId=129622&view=logs&j=7b56c296-8a0a-5e10-b668-0a573fbf1ddf&t=29de6a03-df83-5147-affc-5206150077b8


### Issues Fixed

Fixes #25948
