### PR TITLE
Change Yaml to use OneLocTool to create PR after we receive the lcl files

### DIFF
--- a/eng/pipelines/common/localization-handback.yml
+++ b/eng/pipelines/common/localization-handback.yml
@@ -1,0 +1,34 @@
+parameters:
+      CeapexPat: $(dn-bot-ceapex-package-r) # PAT for the loc AzDO instance https://dev.azure.com/ceapex
+      GithubPat: $(BotAccount-dotnet-bot-repo-PAT)
+
+stages:
+  - stage: localization_handback
+    displayName: Localization Handback
+    dependsOn: []
+    condition: eq(variables.isLocBranch, true)
+
+    jobs:
+      - job : generate_resx
+        displayName: 'Process incoming translations'
+        pool:  $(HostedWinVS2019)
+
+        variables:
+          - group: OneLocBuildVariables # Contains the CeapexPat and GithubPat
+
+        steps:
+          - task: OneLocBuild@2
+            displayName: 'Localization Build'
+            env:
+              SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+            inputs:
+              locProj: 'eng/automation/LocProject.json'
+              outDir: '$(Build.ArtifactStagingDirectory)'
+              packageSourceAuth: patAuth
+              patVariable: ${{ parameters.CeapexPat }}
+              isCreatePrSelected: true
+              isAutoCompletePrSelected: false
+              repoType: gitHub
+              prSourceBranchPrefix: $(LocBranchPrefix)
+              gitHubPatVariable: "${{ parameters.GithubPat }}"
+              gitHubPrMergeMethod: merge

--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -18,7 +18,7 @@ variables:
 - name: isMainBranch
   value: $[eq(variables['Build.SourceBranch'], 'refs/heads/main')]
 - name: isLocBranch
-  value: $[or(eq(variables['Build.SourceBranch'], 'refs/heads/loc'), startsWith(variables['Build.SourceBranch'], 'refs/heads/loc-'))]
+  value: $[or(eq(variables['Build.SourceBranch'], 'refs/heads/lego'), startsWith(variables['Build.SourceBranch'], 'refs/heads/lego'))]
 - name: isTargetMainBranch
   value: $[eq(variables['System.PullRequest.TargetBranch'], 'refs/heads/main')]
 - name: isLocPRBranch

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -354,3 +354,5 @@ stages:
 
   - ${{ if eq(variables['System.TeamProject'], 'devdiv') }}:
     - template: common/localization-handoff.yml                     # Process outgoing strings [Localization Handoff]
+    - template: common/localization-handback.yml                    # Process incoming translations and Create PR to main [Localization Handback]
+    - template: common/merge-translations-update.yml                # Validating incoming translations strings and merge PR [Localization Handback]

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -355,4 +355,3 @@ stages:
   - ${{ if eq(variables['System.TeamProject'], 'devdiv') }}:
     - template: common/localization-handoff.yml                     # Process outgoing strings [Localization Handoff]
     - template: common/localization-handback.yml                    # Process incoming translations and Create PR to main [Localization Handback]
-    - template: common/merge-translations-update.yml                # Validating incoming translations strings and merge PR [Localization Handback]


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

After we receive the lcl file updates from the OneLoc tool in PRs such as this: https://github.com/dotnet/maui/pull/25933/files, we need to also run the OneLocTool with the flag `isCreatePrSelected` set to true to ensure the tool uses those translations from the lcl files and puts them in the json and resx files to be used by customers. There was more logic in the eng/pipelines/common/localization-handback.yml and eng/pipelines/common/merge-translations-update.yml but I opted to simplify it for now to make sure we are on track to get these PRs created.

<!-- Enter description of the fix in this section -->

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #26176

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
