### PR TITLE
Add three templates to locproject.json

### DIFF
--- a/eng/automation/LocProject.json
+++ b/eng/automation/LocProject.json
@@ -64,10 +64,28 @@
               "OutputPath":  ".\\src\\Templates\\src\\templates\\maui-mobile\\.template.config\\localize\\"
             },
             {
+              "SourceFile":  ".\\src\\Templates\\src\\templates\\maui-multiproject\\.template.config\\localize\\templatestrings.json",
+              "LclFile":  "loc\\{Lang}\\src\\Templates\\src\\templates\\maui-multiproject\\.template.config\\localize\\templatestrings.json.lcl",
+              "CopyOption":  "LangIDOnName",
+              "OutputPath":  ".\\src\\Templates\\src\\templates\\maui-multiproject\\.template.config\\localize\\"
+            },
+            {
               "SourceFile":  ".\\src\\Templates\\src\\templates\\maui-resourcedictionary-xaml\\.template.config\\localize\\templatestrings.json",
               "LclFile":  "loc\\{Lang}\\src\\Templates\\src\\templates\\maui-resourcedictionary-xaml\\.template.config\\localize\\templatestrings.json.lcl",
               "CopyOption":  "LangIDOnName",
               "OutputPath":  ".\\src\\Templates\\src\\templates\\maui-resourcedictionary-xaml\\.template.config\\localize\\"
+            },
+            {
+              "SourceFile":  ".\\src\\Templates\\src\\templates\\maui-window-csharp\\.template.config\\localize\\templatestrings.json",
+              "LclFile":  "loc\\{Lang}\\src\\Templates\\src\\templates\\maui-window-csharp\\.template.config\\localize\\templatestrings.json.lcl",
+              "CopyOption":  "LangIDOnName",
+              "OutputPath":  ".\\src\\Templates\\src\\templates\\maui-window-csharp\\.template.config\\localize\\"
+            },
+            {
+              "SourceFile":  ".\\src\\Templates\\src\\templates\\maui-window-xaml\\.template.config\\localize\\templatestrings.json",
+              "LclFile":  "loc\\{Lang}\\src\\Templates\\src\\templates\\maui-window-xaml\\.template.config\\localize\\templatestrings.json.lcl",
+              "CopyOption":  "LangIDOnName",
+              "OutputPath":  ".\\src\\Templates\\src\\templates\\maui-window-xaml\\.template.config\\localize\\"
             }
         ],
         "LssFiles": [],


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

The following templates are not currently used in our localization process for some reason and should be added:

- maui-window-xaml
- maui-window-csharp
- maui-multiproject


<!-- Enter description of the fix in this section -->

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #26175

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
