### PR TITLE
Fixed the double tap editor freeze issue and added test cases

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue25975.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue25975.cs
@@ -16,9 +16,9 @@
 				AutoSize = EditorAutoSizeOption.TextChanges,
 			};
 
-			var rec = new TapGestureRecognizer { NumberOfTapsRequired = 2 };
-			rec.Tapped += (s, e) => { editor.Text = "World"; };
-			editor.GestureRecognizers.Add(rec);
+			var tapGestureRecognizer = new TapGestureRecognizer { NumberOfTapsRequired = 2 };
+			tapGestureRecognizer.Tapped += (s, e) => { editor.Text = "World"; };
+			editor.GestureRecognizers.Add(tapGestureRecognizer);
 
 			Content = editor;
 

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue25975.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue25975.cs
@@ -10,17 +10,32 @@
 				Text = "Hello",
 				AutomationId = "DoubleTapEditor",
 				FontSize = 24,
+				MaxLength = 5,
 				HorizontalTextAlignment = TextAlignment.Center,
 				VerticalOptions = LayoutOptions.Center,
 				HorizontalOptions = LayoutOptions.Fill,
 				AutoSize = EditorAutoSizeOption.TextChanges,
 			};
 
-			var tapGestureRecognizer = new TapGestureRecognizer { NumberOfTapsRequired = 2 };
-			tapGestureRecognizer.Tapped += (s, e) => { editor.Text = "World"; };
-			editor.GestureRecognizers.Add(tapGestureRecognizer);
+			var entry = new Entry()
+			{
+				Text = "Entry",
+				AutomationId = "DoubleTapEntry",
+				FontSize = 24,
+				VerticalOptions = LayoutOptions.Center,
+				HorizontalTextAlignment = TextAlignment.Center,
+				HorizontalOptions = LayoutOptions.Fill,
+			};
 
-			Content = editor;
+			var stackLayout = new StackLayout()
+			{
+				Children =
+				{
+					editor, entry
+				}
+			};
+
+			Content = stackLayout;
 
 		}
 	}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue25975.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue25975.cs
@@ -7,7 +7,7 @@
 		{
 			var editor = new Editor()
 			{
-				Text = "Editor",
+				Text = "MAUI",
 				AutomationId = "DoubleTapEditor",
 				FontSize = 24,
 				MaxLength = 5,
@@ -17,21 +17,11 @@
 				AutoSize = EditorAutoSizeOption.TextChanges,
 			};
 
-			var entry = new Entry()
-			{
-				Text = "Entry",
-				AutomationId = "DoubleTapEntry",
-				FontSize = 24,
-				VerticalOptions = LayoutOptions.Center,
-				HorizontalTextAlignment = TextAlignment.Center,
-				HorizontalOptions = LayoutOptions.Fill,
-			};
-
 			var stackLayout = new StackLayout()
 			{
 				Children =
 				{
-					editor, entry
+					editor
 				}
 			};
 

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue25975.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue25975.cs
@@ -7,7 +7,7 @@
 		{
 			var editor = new Editor()
 			{
-				Text = "Hello",
+				Text = "Editor",
 				AutomationId = "DoubleTapEditor",
 				FontSize = 24,
 				MaxLength = 5,

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue25975.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue25975.cs
@@ -1,0 +1,24 @@
+﻿namespace Maui.Controls.Sample.Issues
+{
+	[Issue(IssueTracker.Github, 25975, "Double tapping Editor control locks app", PlatformAffected.All)]
+	public class Issue25975 : TestContentPage
+	{
+		protected override void Init()
+		{
+			Content =
+				new VerticalStackLayout()
+				{
+					new Editor()
+					{
+						Text = "Hello",
+						AutomationId = "Editor",
+						FontSize = 24,
+						HorizontalTextAlignment = TextAlignment.Center,
+						VerticalOptions= LayoutOptions.Center,
+						HorizontalOptions = LayoutOptions.Fill,
+						AutoSize = EditorAutoSizeOption.TextChanges,
+					},
+				};
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue25975.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue25975.cs
@@ -5,20 +5,23 @@
 	{
 		protected override void Init()
 		{
-			Content =
-				new VerticalStackLayout()
-				{
-					new Editor()
-					{
-						Text = "Hello",
-						AutomationId = "Editor",
-						FontSize = 24,
-						HorizontalTextAlignment = TextAlignment.Center,
-						VerticalOptions= LayoutOptions.Center,
-						HorizontalOptions = LayoutOptions.Fill,
-						AutoSize = EditorAutoSizeOption.TextChanges,
-					},
-				};
+			var editor = new Editor()
+			{
+				Text = "Hello",
+				AutomationId = "DoubleTapEditor",
+				FontSize = 24,
+				HorizontalTextAlignment = TextAlignment.Center,
+				VerticalOptions = LayoutOptions.Center,
+				HorizontalOptions = LayoutOptions.Fill,
+				AutoSize = EditorAutoSizeOption.TextChanges,
+			};
+
+			var rec = new TapGestureRecognizer { NumberOfTapsRequired = 2 };
+			rec.Tapped += (s, e) => { editor.Text = "World"; };
+			editor.GestureRecognizers.Add(rec);
+
+			Content = editor;
+
 		}
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25975.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25975.cs
@@ -16,11 +16,10 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		[Category(UITestCategories.Editor)]
 		public void PerformDoubleTapActionOnEditor()
 		{
-			App.WaitForElement("Editor");
-			App.DoubleTap("Editor");
-			App.EnterText("Editor", "Hello world");
-			var editorText = App.FindElement("Editor").GetText();
-			Assert.That(editorText, Is.EqualTo("Hello world"));
+			App.WaitForElement("DoubleTapEditor");
+			App.DoubleTap("DoubleTapEditor");
+			var editorText = App.FindElement("DoubleTapEditor").GetText();
+			Assert.That(editorText, Is.EqualTo("World"));
 		}
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25975.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25975.cs
@@ -1,4 +1,3 @@
-#if ANDROID
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
@@ -25,4 +24,3 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		}
 	}
 }
-#endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25975.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25975.cs
@@ -1,0 +1,28 @@
+#if ANDROID
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue25975 : _IssuesUITest
+	{
+		public Issue25975(TestDevice device)
+			: base(device)
+		{ }
+
+		public override string Issue => "Double tapping Editor control locks app";
+
+		[Test]
+		[Category(UITestCategories.Editor)]
+		public void PerformDoubleTapActionOnEditor()
+		{
+			App.WaitForElement("Editor");
+			App.DoubleTap("Editor");
+			App.EnterText("Editor", "Hello world");
+			var editorText = App.FindElement("Editor").GetText();
+			Assert.That(editorText, Is.EqualTo("Hello world"));
+		}
+	}
+}
+#endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25975.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25975.cs
@@ -22,10 +22,11 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 			App.EnterText("DoubleTapEditor", "World");
 
 			var editorText = App.FindElement("DoubleTapEditor").GetText();
-			Assert.That(editorText, Is.EqualTo("World"));
 
 			App.DoubleTap("DoubleTapEntry");
 			App.EnterText("DoubleTapEntry", "World");
+
+			Assert.That(editorText, Is.EqualTo("World"));
 		}
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25975.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25975.cs
@@ -19,14 +19,14 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 			App.WaitForElement("DoubleTapEditor");
 			App.DoubleTap("DoubleTapEditor");
 			App.ClearText("DoubleTapEditor");
-			App.EnterText("DoubleTapEditor", "World");
-
-			var editorText = App.FindElement("DoubleTapEditor").GetText();
+			App.EnterText("DoubleTapEditor", "Hello");
 
 			App.DoubleTap("DoubleTapEntry");
+			App.ClearText("DoubleTapEntry");
 			App.EnterText("DoubleTapEntry", "World");
 
-			Assert.That(editorText, Is.EqualTo("World"));
+			var editorText = App.FindElement("DoubleTapEditor").GetText();
+			Assert.That(editorText, Is.EqualTo("Hello"));
 		}
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25975.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25975.cs
@@ -18,15 +18,14 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		{
 			App.WaitForElement("DoubleTapEditor");
 			App.DoubleTap("DoubleTapEditor");
-			App.ClearText("DoubleTapEditor");
 			App.EnterText("DoubleTapEditor", "Hello");
 
-			App.DoubleTap("DoubleTapEntry");
-			App.ClearText("DoubleTapEntry");
-			App.EnterText("DoubleTapEntry", "World");
+			App.DoubleTap("DoubleTapEditor");
+			App.ClearText("DoubleTapEditor");
+			App.EnterText("DoubleTapEditor", "World");
 
 			var editorText = App.FindElement("DoubleTapEditor").GetText();
-			Assert.That(editorText, Is.EqualTo("Hello"));
+			Assert.That(editorText, Is.EqualTo("World"));
 		}
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25975.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25975.cs
@@ -18,8 +18,14 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		{
 			App.WaitForElement("DoubleTapEditor");
 			App.DoubleTap("DoubleTapEditor");
+			App.ClearText("DoubleTapEditor");
+			App.EnterText("DoubleTapEditor", "World");
+
 			var editorText = App.FindElement("DoubleTapEditor").GetText();
 			Assert.That(editorText, Is.EqualTo("World"));
+
+			App.DoubleTap("DoubleTapEntry");
+			App.EnterText("DoubleTapEntry", "World");
 		}
 	}
 }

--- a/src/Core/src/Handlers/Editor/EditorHandler.iOS.cs
+++ b/src/Core/src/Handlers/Editor/EditorHandler.iOS.cs
@@ -61,16 +61,16 @@ namespace Microsoft.Maui.Handlers
 				// get an exception; it doesn't know what do to with it. So instead we'll size
 				// it to fit its current contents and use those values to replace infinite constraints
 
-				PlatformView.SizeToFit();
+				var sizeThatFits = PlatformView.SizeThatFits(new CGSize(widthConstraint, heightConstraint));
 
 				if (double.IsInfinity(widthConstraint))
 				{
-					widthConstraint = PlatformView.Frame.Size.Width;
+					widthConstraint = sizeThatFits.Width;
 				}
 
 				if (double.IsInfinity(heightConstraint))
 				{
-					heightConstraint = PlatformView.Frame.Size.Height;
+					heightConstraint = sizeThatFits.Height;
 				}
 			}
 


### PR DESCRIPTION
### Issue Details
Double-tapping the editor causes the app to freeze or become unresponsive.

### Root Cause
When you double-tap the editor and AutoSize is set to "TextChanges," the editor continuously resizes to fit the content, leading to the app freezing or hanging.
 
### Description of Change
* Avoided calling PlatformView.SizeToFit() directly within the GetDesiredSize() method. Instead, a more controlled approach is used to measure the size.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #25975 
Fixes https://github.com/dotnet/maui/issues/25940
Fixes https://github.com/dotnet/maui/issues/25938
Fixes https://github.com/dotnet/maui/issues/17757

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->

### Tested the behaviour in the following platforms
 
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

### Output Screenshot
| Before  | After  |
|---------|--------|
|  <video src="https://github.com/user-attachments/assets/1d772981-47cd-4ff0-9f27-2fea4960f97e" width="320" height="640" controls></video>   |   <video src="https://github.com/user-attachments/assets/2382d890-6297-4940-918b-911d17f23b86" width="320" height="640" controls></video>   |
