### PR TITLE
Update Appium version to 2.12.2

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -153,7 +153,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Appium -->
-    <AppiumVersion>2.11.5</AppiumVersion>
+    <AppiumVersion>2.12.2</AppiumVersion>
     <AppiumWindowsDriverVersion>2.12.32</AppiumWindowsDriverVersion>
     <AppiumXCUITestDriverVersion>7.27.0</AppiumXCUITestDriverVersion>
     <AppiumMac2DriverVersion>1.19.1</AppiumMac2DriverVersion>

--- a/eng/scripts/appium-install.ps1
+++ b/eng/scripts/appium-install.ps1
@@ -144,7 +144,6 @@ if ($missingAppium -or ($appiumCurrentVersion -ne $appiumVersion)) {
 
 # Clean npm cache, just in case
 Write-Output  "Cleaning npm cache"
-
 npm cache clean --force
 
 $existingDrivers = appium driver list --installed --json  | ConvertFrom-Json

--- a/eng/scripts/appium-install.ps1
+++ b/eng/scripts/appium-install.ps1
@@ -118,7 +118,7 @@ if ($AppiumHome) {
 
 # Check for an existing appium install version
 $appiumCurrentVersion = ""
-try { $appiumCurrentVersion = appium -v | Out-String } catch { Write-Debug "Problem" }
+try { $appiumCurrentVersion = (appium -v | Out-String).Trim() -replace "`r", "" -replace "`n", "" } catch { Write-Debug "Problem retrieving current Appium version" }
 
 if ($appiumCurrentVersion) {
     Write-Output  "Existing Appium version $appiumCurrentVersion"

--- a/eng/scripts/appium-install.ps1
+++ b/eng/scripts/appium-install.ps1
@@ -142,6 +142,11 @@ if ($missingAppium -or ($appiumCurrentVersion -ne $appiumVersion)) {
     write-Output  "Installed appium $appiumVersion"
 }
 
+# Clean npm cache, just in case
+Write-Output  "Cleaning npm cache"
+
+npm cache clean --force
+
 $existingDrivers = appium driver list --installed --json  | ConvertFrom-Json
 Write-Output "List of installed drivers $existingDrivers"
 
@@ -152,7 +157,7 @@ if ($IsWindows) {
         Write-Output  "Updated appium driver windows"
     } else {
         Write-Output  "Installing appium driver windows"
-        appium driver install --source=npm appium-windows-driver@$windowsDriverVersion
+        appium driver install --source=npm appium-windows-driver@$windowsDriverVersion --verbose
         Write-Output  "Installed appium driver windows"
     }
 }
@@ -165,7 +170,7 @@ if ($IsMacOS) {
         Write-Output  "Updated appium driver xcuitest"
     } else {
         Write-Output  "Installing appium driver xcuitest"
-        appium driver install xcuitest@$iOSDriverVersion
+        appium driver install xcuitest@$iOSDriverVersion --verbose
         Write-Output  "Installed appium driver xcuitest"
     }
     if ($existingDrivers.mac2) {
@@ -174,7 +179,7 @@ if ($IsMacOS) {
         Write-Output  "Updated appium driver mac2"
     } else {
         Write-Output  "Installing appium driver mac2"
-        appium driver install mac2@$macDriverVersion
+        appium driver install mac2@$macDriverVersion --verbose
         Write-Output  "Installed appium driver mac2"
     }
 }
@@ -185,7 +190,7 @@ if ($existingDrivers.uiautomator2) {
     Write-Output  "Updated appium driver uiautomator2"
 } else {
     Write-Output  "Installing appium driver uiautomator2"
-    appium driver install uiautomator2@$androidDriverVersion
+    appium driver install uiautomator2@$androidDriverVersion --verbose
     Write-Output  "Installed appium driver uiautomator2"
 }
 

--- a/eng/scripts/appium-install.ps1
+++ b/eng/scripts/appium-install.ps1
@@ -157,7 +157,7 @@ if ($IsWindows) {
         Write-Output  "Updated appium driver windows"
     } else {
         Write-Output  "Installing appium driver windows"
-        appium driver install --source=npm appium-windows-driver@$windowsDriverVersion --verbose
+        appium driver install --source=npm appium-windows-driver@$windowsDriverVersion
         Write-Output  "Installed appium driver windows"
     }
 }
@@ -170,7 +170,7 @@ if ($IsMacOS) {
         Write-Output  "Updated appium driver xcuitest"
     } else {
         Write-Output  "Installing appium driver xcuitest"
-        appium driver install xcuitest@$iOSDriverVersion --verbose
+        appium driver install xcuitest@$iOSDriverVersion
         Write-Output  "Installed appium driver xcuitest"
     }
     if ($existingDrivers.mac2) {
@@ -179,7 +179,7 @@ if ($IsMacOS) {
         Write-Output  "Updated appium driver mac2"
     } else {
         Write-Output  "Installing appium driver mac2"
-        appium driver install mac2@$macDriverVersion --verbose
+        appium driver install mac2@$macDriverVersion
         Write-Output  "Installed appium driver mac2"
     }
 }
@@ -190,7 +190,7 @@ if ($existingDrivers.uiautomator2) {
     Write-Output  "Updated appium driver uiautomator2"
 } else {
     Write-Output  "Installing appium driver uiautomator2"
-    appium driver install uiautomator2@$androidDriverVersion --verbose
+    appium driver install uiautomator2@$androidDriverVersion
     Write-Output  "Installed appium driver uiautomator2"
 }
 


### PR DESCRIPTION
Updating the used Appium version to 2.12.2 to fix failing appium driver installs and reenabling UI tests in our pipelines