### PR TITLE
Add GraphicsView UiTestCategory

### DIFF
--- a/eng/pipelines/common/ui-tests.yml
+++ b/eng/pipelines/common/ui-tests.yml
@@ -19,7 +19,7 @@ parameters:
     - 'Border,BoxView,Brush,Button'
     - 'CarouselView,Cells,CheckBox,CollectionView,ContextActions,CustomRenderers'
     - 'DatePicker,Dispatcher,DisplayAlert,DisplayPrompt,DragAndDrop'
-    - 'Editor,Effects,Entry,FlyoutPage,Focus,Frame,Gestures'
+    - 'Editor,Effects,Entry,FlyoutPage,Focus,Frame,Gestures,GraphicsView'
     - 'Image,ImageButton,IndicatorView,InputTransparent,IsEnabled,IsVisible'
     - 'Label,Layout,Lifecycle,ListView'
     - 'ManualReview,Maps,Navigation'

--- a/src/Controls/tests/TestCases.Shared.Tests/UITestCategories.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/UITestCategories.cs
@@ -71,5 +71,6 @@ namespace Microsoft.Maui.TestCases.Tests
 		public const string Accessibility = "Accessibility";
 		public const string Brush = "Brush";
 		public const string Compatibility = "MovedFromCompatibility";
+		public const string GraphicsView = "GraphicsView";
 	}
 }


### PR DESCRIPTION
I'd like to fix a few GraphicsView issues, but I've noticed that there's no UiTestCategory for this Control.

For example https://github.com/dotnet/maui/pull/26304

@jfversluis can this category by added? :)