### PR TITLE
Remove FlyoutBehavior on Basic Template

### DIFF
--- a/src/Templates/src/templates/maui-mobile/AppShell.xaml
+++ b/src/Templates/src/templates/maui-mobile/AppShell.xaml
@@ -10,7 +10,9 @@
 <!--#if (!IncludeSampleContent) -->
     xmlns:local="clr-namespace:MauiApp._1"
 <!--#endif -->
+<!--#if (IncludeSampleContent) -->
     Shell.FlyoutBehavior="Flyout"
+<!--#endif -->
     Title="MauiApp._1">
 
 <!--#if (!IncludeSampleContent) -->


### PR DESCRIPTION
### Description of Change

There's no reason to set the `FlyoutBehavior` on the basic template

FlyoutBehavior should typically just be inferred from the Shell structure and then the user can modify it for different scenarios.