### PR TITLE
[iOS] Add templated cells as children of the CollectionView2

### DIFF
--- a/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs
@@ -410,7 +410,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 
 				uiView?.Dispose();
 				uiView = null;
-
+				formsElement?.Handler?.DisconnectHandler();
 				formsElement = null;
 			}
 			else

--- a/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs
@@ -211,83 +211,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 			CollectionView.ReloadData();
 		}
 
-		// void InvalidateMeasureIfContentSizeChanged()
-		// {
-		// 	var contentSize = CollectionView?.CollectionViewLayout?.CollectionViewContentSize;
-		//
-		// 	if (!contentSize.HasValue)
-		// 	{
-		// 		return;
-		// 	}
-		//
-		// 	bool widthChanged = _previousContentSize.Width != contentSize.Value.Width;
-		// 	bool heightChanged = _previousContentSize.Height != contentSize.Value.Height;
-		//
-		// 	if (_initialized && (widthChanged || heightChanged))
-		// 	{
-		// 		var screenFrame = CollectionView?.Window?.Frame;
-		//
-		// 		if (!screenFrame.HasValue)
-		// 		{
-		// 			return;
-		// 		}
-		//
-		// 		var screenWidth = screenFrame.Value.Width;
-		// 		var screenHeight = screenFrame.Value.Height;
-		// 		bool invalidate = false;
-		//
-		// 		// If both the previous content size and the current content size are larger
-		// 		// than the screen size, then we know that we're already maxed out and the 
-		// 		// CollectionView items are scrollable. There's no reason to force an invalidation
-		// 		// of the CollectionView to expand/contract it.
-		//
-		// 		// If either size is smaller than that, we need to invalidate to ensure that the 
-		// 		// CollectionView is re-measured and set to the correct size.
-		//
-		// 		if (widthChanged && (contentSize.Value.Width < screenWidth || _previousContentSize.Width < screenWidth))
-		// 		{
-		// 			invalidate = true;
-		// 		}
-		//
-		// 		if (heightChanged && (contentSize.Value.Height < screenHeight || _previousContentSize.Height < screenHeight))
-		// 		{
-		// 			invalidate = true;
-		// 		}
-		//
-		// 		if (invalidate)
-		// 		{
-		// 			(ItemsView as IView)?.InvalidateMeasure();
-		// 		}
-		// 	}
-		// 	_previousContentSize = contentSize.Value;
-		// }
-
-		const int HeaderTag = 111;
-
-		// internal Size? GetSize()
-		// {
-		// 	if (_emptyViewDisplayed)
-		// 	{
-		// 		return _emptyUIView.Frame.Size.ToSize();
-		// 	}
-
-		// 	nfloat headerHeight = 0;
-		// 	var headerView = CollectionView.ViewWithTag(HeaderTag);
-
-		// 	if (headerView != null)
-		// 		headerHeight = headerView.Frame.Height;
-
-		// 	var sizeColl = CollectionView.CollectionViewLayout.CollectionViewContentSize;
-		// 	return sizeColl.ToSize();
-		// }
-
-		// void ConstrainItemsToBounds()
-		// {
-		// 	var contentBounds = CollectionView.AdjustedContentInset.InsetRect(CollectionView.Bounds);
-		// 	var constrainedSize = contentBounds.Size;
-		// 	ItemsViewLayout.UpdateConstraints(constrainedSize);
-		// }
-
 		void EnsureLayoutInitialized()
 		{
 			if (_initialized)
@@ -370,7 +293,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 
 				if (!_cellReuseIds.Contains(reuseId))
 				{
-					Console.WriteLine($"REGISTER CELL ID: {reuseId}");
 					CollectionView.RegisterClassForCell(cellType, new NSString(reuseId));
 					_cellReuseIds.Add(reuseId);
 				}
@@ -408,7 +330,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 					//Platform.GetRenderer(formsElement)?.DisposeRendererAndChildren();
 				}
 
-				uiView?.Dispose();
 				uiView = null;
 				formsElement?.Handler?.DisconnectHandler();
 				formsElement = null;

--- a/src/Controls/src/Core/Handlers/Items2/iOS/TemplatedCell2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/TemplatedCell2.cs
@@ -109,29 +109,28 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 		public void Bind(DataTemplate template, object bindingContext, ItemsView itemsView)
 		{
 			var virtualView = template.CreateContent(bindingContext, itemsView) as View;
-			BindVirtualView(virtualView, bindingContext, itemsView, true);
+			BindVirtualView(virtualView, bindingContext, itemsView, false);
 		}
 
 		public void Bind(View virtualView, ItemsView itemsView)
 		{
-			BindVirtualView(virtualView, itemsView.BindingContext, itemsView, false);
+			BindVirtualView(virtualView, itemsView.BindingContext, itemsView, true);
 		}
 
-		private void BindVirtualView(View virtualView, object bindingContext, ItemsView itemsView, bool needsContainer)
+		void BindVirtualView(View virtualView, object bindingContext, ItemsView itemsView, bool needsContainer)
 		{
 			if (PlatformHandler is null && virtualView is not null)
 			{
 				var mauiContext = itemsView.FindMauiContext()!;
 				var nativeView = virtualView.ToPlatform(mauiContext);
 
-				if (!needsContainer)
+				if (needsContainer)
 				{
-					PlatformView = nativeView;
+					PlatformView = new UIContainerView2(virtualView, mauiContext);
 				}
 				else
 				{
-					var mauiWrapperView = new UIContainerView2(virtualView, mauiContext);
-					PlatformView = mauiWrapperView;
+					PlatformView = nativeView;
 				}
 
 				PlatformHandler = virtualView.Handler as IPlatformViewHandler;

--- a/src/Controls/src/Core/Handlers/Items2/iOS/TemplatedCell2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/TemplatedCell2.cs
@@ -64,6 +64,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 			{
 				//view.MeasureInvalidated -= MeasureInvalidated;
 				view.BindingContext = null;
+				(view.Parent as ItemsView)?.RemoveLogicalChild(view);
 			}
 		}
 
@@ -107,49 +108,42 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 
 		public void Bind(DataTemplate template, object bindingContext, ItemsView itemsView)
 		{
-			if (PlatformHandler is null)
+			var virtualView = template.CreateContent(bindingContext, itemsView) as View;
+			BindVirtualView(virtualView, bindingContext, itemsView, true);
+		}
+
+		public void Bind(View virtualView, ItemsView itemsView)
+		{
+			BindVirtualView(virtualView, itemsView.BindingContext, itemsView, false);
+		}
+
+		private void BindVirtualView(View virtualView, object bindingContext, ItemsView itemsView, bool needsContainer)
+		{
+			if (PlatformHandler is null && virtualView is not null)
 			{
-				var virtualView = template.CreateContent(bindingContext, itemsView) as View;
-
 				var mauiContext = itemsView.FindMauiContext()!;
-				var nativeView = virtualView!.ToPlatform(mauiContext);
+				var nativeView = virtualView.ToPlatform(mauiContext);
 
-				PlatformView = nativeView;
+				if (!needsContainer)
+				{
+					PlatformView = nativeView;
+				}
+				else
+				{
+					var mauiWrapperView = new UIContainerView2(virtualView, mauiContext);
+					PlatformView = mauiWrapperView;
+				}
 
 				PlatformHandler = virtualView.Handler as IPlatformViewHandler;
-
-				InitializeContentConstraints(nativeView);
+				InitializeContentConstraints(PlatformView);
 
 				virtualView.BindingContext = bindingContext;
+				itemsView.AddLogicalChild(virtualView);
 			}
 
 			if (PlatformHandler?.VirtualView is View view)
 			{
 				view.SetValueFromRenderer(BindableObject.BindingContextProperty, bindingContext);
-			}
-		}
-
-		public void Bind(View virtualView, ItemsView itemsView)
-		{
-			if (PlatformHandler is null && virtualView is not null)
-			{
-				var mauiContext = itemsView.FindMauiContext()!;
-				var nativeView = virtualView!.ToPlatform(mauiContext);
-
-				var mauiWrapperView = new UIContainerView2(virtualView, mauiContext);
-
-				PlatformView = mauiWrapperView;
-
-				PlatformHandler = virtualView.Handler as IPlatformViewHandler;
-
-				InitializeContentConstraints(mauiWrapperView);
-
-				virtualView.BindingContext = itemsView.BindingContext;
-			}
-
-			if (PlatformHandler?.VirtualView is View view)
-			{
-				view.SetValueFromRenderer(BindableObject.BindingContextProperty, itemsView.BindingContext);
 			}
 		}
 

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue26066.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue26066.xaml
@@ -3,7 +3,7 @@
   xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
   xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
   x:Class="Maui.Controls.Sample.Issues.Issue26066"
-  xmlns:cv2="clr-namespace:Maui.Controls.Sample"
+  xmlns:sample="clr-namespace:Maui.Controls.Sample"
   xmlns:local="clr-namespace:Maui.Controls.Sample.Issues"
   x:DataType="local:Issue26066ViewModel">
   <ContentPage.BindingContext>
@@ -27,7 +27,7 @@
       AutomationId="TestLoadButtonCV2"
       Text="Load Items CV2"
       Command="{Binding LoadCommandCV2}"/>
-    <cv2:CollectionView2  Grid.Row="1" BackgroundColor="LightBlue"
+    <sample:CollectionView2  Grid.Row="1" BackgroundColor="LightBlue"
         ItemsSource="{Binding Images2}"
         ItemTemplate="{StaticResource template}"/>
     <Button BackgroundColor="LightGreen "
@@ -35,7 +35,7 @@
       AutomationId="TestLoadButtonCV"
       Text="Load Items CV1"
       Command="{Binding LoadCommand}"/>
-    <CollectionView  Grid.Row="3" BackgroundColor="LightGreen"
+    <sample:CollectionView1  Grid.Row="3" BackgroundColor="LightGreen"
         ItemsSource="{Binding Images}"
         ItemTemplate="{StaticResource template}"/>
   </Grid>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue26066.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue26066.xaml
@@ -1,0 +1,42 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage
+  xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+  xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+  x:Class="Maui.Controls.Sample.Issues.Issue26066"
+  xmlns:cv2="clr-namespace:Maui.Controls.Sample"
+  xmlns:local="clr-namespace:Maui.Controls.Sample.Issues"
+  x:DataType="local:Issue26066ViewModel">
+  <ContentPage.BindingContext>
+    <local:Issue26066ViewModel/>
+  </ContentPage.BindingContext>
+  <Grid RowDefinitions="Auto,*,Auto,*">
+    <Grid.Resources>
+      <DataTemplate x:DataType="local:Issue22035Model"
+          x:Key="template">
+        <StackLayout Padding="10" BackgroundColor="Lightgray">
+          <Button
+            AutomationId="{Binding AutomationId}"
+            Command="{Binding ShowDialogCommand, Source={x:RelativeSource AncestorType={x:Type local:Issue26066ViewModel}}, x:DataType=local:Issue26066ViewModel}"
+            CommandParameter="{Binding .}"
+            Text="{Binding Text}"/>
+        </StackLayout>
+      </DataTemplate>
+    </Grid.Resources>
+    <Button BackgroundColor="LightBlue"
+      Grid.Row="0"
+      AutomationId="TestLoadButtonCV2"
+      Text="Load Items CV2"
+      Command="{Binding LoadCommandCV2}"/>
+    <cv2:CollectionView2  Grid.Row="1" BackgroundColor="LightBlue"
+        ItemsSource="{Binding Images2}"
+        ItemTemplate="{StaticResource template}"/>
+    <Button BackgroundColor="LightGreen "
+      Grid.Row="2"
+      AutomationId="TestLoadButtonCV"
+      Text="Load Items CV1"
+      Command="{Binding LoadCommand}"/>
+    <CollectionView  Grid.Row="3" BackgroundColor="LightGreen"
+        ItemsSource="{Binding Images}"
+        ItemTemplate="{StaticResource template}"/>
+  </Grid>
+</ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue26066.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue26066.xaml.cs
@@ -1,0 +1,42 @@
+﻿using System.Collections.ObjectModel;
+using System.Windows.Input;
+
+namespace Maui.Controls.Sample.Issues
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	[Issue(IssueTracker.Github, 26066, "CollectionViewHandler2 RelativeSource binding to AncestorType not working", PlatformAffected.Android | PlatformAffected.iOS)]
+	public partial class Issue26066 : ContentPage
+	{
+		public Issue26066()
+		{
+			InitializeComponent();
+		}
+	}
+
+	class Issue26066ViewModel
+	{
+		public Issue26066ViewModel()
+		{
+			LoadCommand.Execute(null);
+			LoadCommandCV2.Execute(null);
+		}
+
+		public ObservableCollection<Issue22035Model> Images { get; set; } = new();
+		public ObservableCollection<Issue22035Model> Images2 { get; set; } = new();
+
+		public ICommand ShowDialogCommand => new Command(async () => await Application.Current.MainPage.DisplayAlert("New Dialog", "Hello from Espinho", "OK"));
+
+		public ICommand LoadCommand => new Command(() => LoadItems(Images, "CV1"));
+
+		public ICommand LoadCommandCV2 => new Command(() => LoadItems(Images2, "CV2"));
+
+		static void LoadItems(ObservableCollection<Issue22035Model> items, string text)
+		{
+			items.Clear();
+			for (int i = 0; i < 3	; i++)
+			{
+				items.Add(new Issue22035Model { Text = $"{text} - Item {i}", ImagePath = i% 2 == 0 ? "photo21314.jpg" : "oasis.jpg" });
+			}
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue26066.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue26066.cs
@@ -4,13 +4,9 @@ using UITest.Core;
 
 namespace Microsoft.Maui.TestCases.Tests.Issues;
 
-public class Issue26066 : _IssuesUITest
+public class Issue26066(TestDevice testDevice) : _IssuesUITest(testDevice)
 {
-    public Issue26066(TestDevice testDevice) : base(testDevice)
-    {
-    }
-
-    public override string Issue => "CollectionViewHandler2 RelativeSource binding to AncestorType not working";
+	public override string Issue => "CollectionViewHandler2 RelativeSource binding to AncestorType not working";
 
     [Test]
     [Category(UITestCategories.CollectionView)]

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue26066.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue26066.cs
@@ -1,0 +1,27 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue26066 : _IssuesUITest
+{
+    public Issue26066(TestDevice testDevice) : base(testDevice)
+    {
+    }
+
+    public override string Issue => "CollectionViewHandler2 RelativeSource binding to AncestorType not working";
+
+    [Test]
+    [Category(UITestCategories.CollectionView)]
+    public void CollectionView2ShouldFindAncestorType()
+    {
+        var text = "CV2";
+        var i = 1;
+        var automationId = $"{text} - Item {i}".Replace(" ", "", StringComparison.Ordinal);
+        App.WaitForElement(automationId);
+        App.Click(automationId);
+        App.WaitForElement("OK");
+        App.Click("OK");
+    }
+}


### PR DESCRIPTION
### Description of Change

When porting to the new implementation we forgot to move add the inflated templates as a children of the ItemsView.

This pull request includes several changes to improve the functionality and maintainability of the `ItemsViewController2` and `TemplatedCell2` classes, as well as adding a new test case for a specific issue.  Also does some cleanup

Codebase simplification:

* [`src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs`](diffhunk://#diff-dcaa555cd62425342259680af963c19dc908ab24491c229d751caf3c056eeca7L214-L290): Removed unused methods `InvalidateMeasureIfContentSizeChanged`, `GetSize`, and `ConstrainItemsToBounds`. Also removed a debug `Console.WriteLine` statement from `DetermineCellReuseId` and updated `UpdateView` to properly disconnect handlers and dispose of views. [[1]](diffhunk://#diff-dcaa555cd62425342259680af963c19dc908ab24491c229d751caf3c056eeca7L214-L290) [[2]](diffhunk://#diff-dcaa555cd62425342259680af963c19dc908ab24491c229d751caf3c056eeca7L373) [[3]](diffhunk://#diff-dcaa555cd62425342259680af963c19dc908ab24491c229d751caf3c056eeca7L411-R334)

Enhancements to binding logic:

* [`src/Controls/src/Core/Handlers/Items2/iOS/TemplatedCell2.cs`](diffhunk://#diff-617eb1f606ac3f05750380c858c3fbef7b80cba5fc556bc3f53bf6b792380978R67): Updated the `Unbind` method to remove logical children and refactored the `Bind` method to use a helper method `BindVirtualView` for better code organization and clarity. [[1]](diffhunk://#diff-617eb1f606ac3f05750380c858c3fbef7b80cba5fc556bc3f53bf6b792380978R67) [[2]](diffhunk://#diff-617eb1f606ac3f05750380c858c3fbef7b80cba5fc556bc3f53bf6b792380978L109-R145)

New test case:

* `src/Controls/tests/TestCases.HostApp/Issues/Issue26066.xaml` and `src/Controls/tests/TestCases.HostApp/Issues/Issue26066.xaml.cs`: Added a new test case to address Issue 26066, which involves testing the `CollectionViewHandler2` with `RelativeSource` binding to `AncestorType`. [[1]](diffhunk://#diff-efb8508abc878ed9dee7cfc5fc5948ed37c969105aa83a9b1f892af2f825b617R1-R42) [[2]](diffhunk://#diff-84bb7f309b1e9ddf195f354c915e1e80d073d5d06ed60c8313796fc29570fb18R1-R42)
* [`src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue26066.cs`](diffhunk://#diff-35e2cfc839047627602556d9a99b3e6be67b9b74a7a6d893f132eaf98d9d6601R1-R23): Added a corresponding test method to verify that `CollectionView2` can find the ancestor type and handle the binding correctly.

### Issues Fixed

Fixes #26066 

