### PR TITLE
[XC] Add support for DoesNotInheritDataTypeAttribute to XamlC

### DIFF
--- a/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
+++ b/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
@@ -459,6 +459,10 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 				{
 					break;
 				}
+				if (DoesNotInheritDataType(n))
+				{
+					break;
+				}
 
 				if (n.XmlType.Name == nameof(Microsoft.Maui.Controls.DataTemplate)
 					&& n.XmlType.NamespaceUri == XamlParser.MauiUri)
@@ -584,6 +588,16 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 					&& node.TryGetPropertyName(parentNode, out var propertyName)
 					&& propertyName.NamespaceURI == ""
 					&& propertyName.LocalName == nameof(BindableObject.BindingContext);
+			}
+
+			bool DoesNotInheritDataType(IElementNode node)
+			{
+				return GetParent(node) is IElementNode parentNode
+					&& node.TryGetPropertyName(parentNode, out XmlName propertyName)
+					&& parentNode.XmlType.TryGetTypeReference(context.Cache, module, (IXmlLineInfo)node, out TypeReference parentTypeRef)
+					&& parentTypeRef.ResolveCached(context.Cache) is TypeDefinition parentType
+					&& parentType.GetProperty(context.Cache, pd => pd.Name == propertyName.LocalName, out var propertyDeclaringTypeRef) is PropertyDefinition propertyDef
+					&& propertyDef.CustomAttributes.Any(ca => ca.AttributeType.FullName == "Microsoft.Maui.Controls.Xaml.DoesNotInheritDataTypeAttribute");
 			}
 		}
 

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui23989.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui23989.xaml.cs
@@ -37,7 +37,7 @@ public partial class Maui23989
 		public void ItemDisplayBindingWithoutDataTypeFails([Values(false, true)] bool useCompiledXaml)
 		{
 			if (useCompiledXaml)
-				Assert.Throws(new BuildExceptionConstraint(12, 13, s => s.Contains("0045", StringComparison.Ordinal)), () => MockCompiler.Compile(typeof(Maui23989), null, true));
+				Assert.Throws(new BuildExceptionConstraint(12, 13, s => s.Contains("0022", StringComparison.Ordinal)), () => MockCompiler.Compile(typeof(Maui23989), treatWarningsAsErrors: true));
 
 			var layout = new Maui23989(useCompiledXaml);
 			//without x:DataType, bindings aren't compiled

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui25935.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui25935.xaml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                    xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests"
+                    x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui25935"
+                    x:DataType="local:Maui25935">
+    <Picker x:Name="Picker"
+            ItemDisplayBinding="{Binding .}">
+        <Picker.ItemsSource>
+            <x:Array Type="{x:Type x:Int32}">
+                <x:Int32>1</x:Int32>
+                <x:Int32>2</x:Int32>
+                <x:Int32>3</x:Int32>
+            </x:Array>
+        </Picker.ItemsSource>
+    </Picker>
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui25935.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui25935.xaml.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Maui.ApplicationModel;
+using Microsoft.Maui.Controls.Core.UnitTests;
+using Microsoft.Maui.Dispatching;
+using Microsoft.Maui.Graphics;
+using Microsoft.Maui.UnitTests;
+using NUnit.Framework;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public partial class Maui25935
+{
+	public Maui25935()
+	{
+		InitializeComponent();
+	}
+
+	public Maui25935(bool useCompiledXaml)
+	{
+		//this stub will be replaced at compile time
+	}
+
+	[TestFixture]
+	class Test
+	{
+		[SetUp]
+		public void Setup()
+		{
+			Application.SetCurrentApplication(new MockApplication());
+			DispatcherProvider.SetCurrent(new DispatcherProviderStub());
+		}
+
+		[TearDown] public void TearDown() => AppInfo.SetCurrent(null);
+
+		[Test]
+		public void ToolBarItemAppThemeBinding([Values(false, true)] bool useCompiledXaml)
+		{
+			var page = new Maui25935(useCompiledXaml);
+			var items = page.Picker.Items.ToArray();
+			Assert.Contains("1", items);
+			Assert.Contains("2", items);
+			Assert.Contains("3", items);
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change

In #25173 we implemented a way to stop propagation of `x:DataType` to properties where it doesn't make sense (for example `Picker.ItemDisplayBinding`) in runtime XAML parsing, but we haven't implemented it in XamlC.

### Issues Fixed

Fixes #25935

/cc @StephaneDelcroix 