### PR TITLE
[iOS] CV2 - Disable clipping bounds for WrapperView

### DIFF
--- a/src/Controls/src/Core/Handlers/Items2/iOS/TemplatedCell2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/TemplatedCell2.cs
@@ -276,7 +276,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 			_view = view;
 			_mauiContext = mauiContext;
 			UpdatePlatformView();
-			ClipsToBounds = true;
 		}
 
 		internal void UpdatePlatformView()
@@ -287,6 +286,16 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 			if (nativeView.Superview == this)
 			{
 				nativeView.RemoveFromSuperview();
+			}
+
+			if (nativeView is WrapperView)
+			{
+				// Disable clipping for WrapperView to allow the shadow to be displayed
+				ClipsToBounds = false;
+			}
+			else
+			{
+				ClipsToBounds = true;
 			}
 
 			AddSubview(nativeView);


### PR DESCRIPTION
### Description of Change

`CollectionView 2` clips to bounds for every cell, which causes shadows of a header or footer to be clipped and rendered incorrectly, which is not the case with a `CollectionView1`

### Issues Fixed


|Before|After|
|--|--|
|<img src="https://github.com/user-attachments/assets/9a8eb32a-296c-484a-b462-890049b976cc" width="300px"/>|<img src="https://github.com/user-attachments/assets/b9efdadc-3fa4-4626-8956-766a7efe5c4b" width="300px"/>|

@rmarinho what do you think?
The other solution would be to enable clipping for footer and header for CollectionView1 