### PR TITLE
Add RequireService to StaticExtension

### DIFF
--- a/src/Controls/src/Xaml/MarkupExtensions/StaticExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/StaticExtension.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Maui.Controls.Xaml
 	[ContentProperty(nameof(Member))]
 	[ProvideCompiled("Microsoft.Maui.Controls.Build.Tasks.StaticExtension")]
 	[RequiresUnreferencedCode(TrimmerConstants.XamlRuntimeParsingNotSupportedWarning)]
+	[RequireService([typeof(IXamlTypeResolver)])]
 	public class StaticExtension : IMarkupExtension
 	{
 		public string Member { get; set; }


### PR DESCRIPTION
### Description of Change

Add `[RequireService([typeof(IXamlTypeResolver)])]` to `StaticExtension` to prevent build warnings.

### Issues Fixed

Fixes #26372
