### PR TITLE
Change the yaml to build PR if lcl files were changed

### DIFF
--- a/eng/pipelines/common/localization-handback.yml
+++ b/eng/pipelines/common/localization-handback.yml
@@ -1,24 +1,36 @@
 parameters:
-      CeapexPat: $(dn-bot-ceapex-package-r) # PAT for the loc AzDO instance https://dev.azure.com/ceapex
-      GithubPat: $(BotAccount-dotnet-bot-repo-PAT)
+  CeapexPat: $(dn-bot-ceapex-package-r) # PAT for the loc AzDO instance https://dev.azure.com/ceapex
+  GithubPat: $(BotAccount-dotnet-bot-repo-PAT)
 
 stages:
   - stage: localization_handback
     displayName: Localization Handback
     dependsOn: []
-    condition: eq(variables.isLocBranch, true)
+    condition: eq(variables.isLocHandoffBranch, true)
 
     jobs:
-      - job : generate_resx
+      - job: generate_resx
         displayName: 'Process incoming translations'
-        pool:  $(HostedWinVS2019)
+        pool: $(HostedWinVS2019)
 
         variables:
           - group: OneLocBuildVariables # Contains the CeapexPat and GithubPat
 
         steps:
+          - powershell: |
+              $hasLclFiles = git diff --name-only HEAD~1 HEAD | Select-String '\.lcl$'
+              if ($hasLclFiles) {
+                Write-Host "##vso[task.setvariable variable=hasLclFiles]true"
+                Write-Host "Result: Found .lcl files (true)"
+              } else {
+                Write-Host "##vso[task.setvariable variable=hasLclFiles]false"
+                Write-Host "Result: No .lcl files found (false)"
+              }
+            displayName: 'Check for .lcl files'
+
           - task: OneLocBuild@2
             displayName: 'Localization Build'
+            condition: eq(variables['hasLclFiles'], 'true')
             env:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
             inputs:


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

<!-- Enter description of the fix in this section -->
The old way relied on the SourceBranch starting with 'lego' but in the Maui pipeline, it is being triggered by the PR landing in main which makes the SourceBranch equal to main. This new way will just be able to check if the latest commit touches any lcl files, we will run the tool to see if there are any new translations ready to be brought over in a new PR.

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->


<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
