### PR TITLE
[actions] update to inclusive-heat-sensor v0.1.2

### DIFF
--- a/.github/workflows/inclusive-heat-sensor.yml
+++ b/.github/workflows/inclusive-heat-sensor.yml
@@ -14,5 +14,9 @@ permissions:
 
 jobs:
   detect-heat:
-    uses: jonathanpeppers/inclusive-heat-sensor/.github/workflows/comments.yml@v0.1.1
+    uses: jonathanpeppers/inclusive-heat-sensor/.github/workflows/comments.yml@v0.1.2
     secrets: inherit
+    with:
+      minimizeComment: true
+      offensiveThreshold: 9
+      angerThreshold: 9


### PR DESCRIPTION
Context: https://github.com/jonathanpeppers/inclusive-heat-sensor/releases/tag/v0.1.2
Changes: https://github.com/jonathanpeppers/inclusive-heat-sensor/compare/v0.1.1...v0.1.2

After reviewing comments coming in for the past month, we made a few adjustments to make things more precise. We also stopped recording comment text, and simply a use public link to it instead.

v0.1.2 has these changes.

Let's also configure the bot to auto-hide comments if they score a 9 out of 10 or higher. This seems reasonable as:

* A comment like "This sucks" is a 7/10. So, it would have to be pretty bad (mean comment!) to get auto-hidden.

* If the comment triggers a Microsoft/OpenAI "content filter", we ignore the comment entirely as we can't be sure it's offensive at all.

We will continue monitoring the results.