### PR TITLE
[Windows] Optimize `LayoutHandler.Windows.cs` (take 2)

### DIFF
--- a/eng/BannedSymbols.txt
+++ b/eng/BannedSymbols.txt
@@ -3,3 +3,4 @@ M:Android.Content.Res.ColorStateList.#ctor(System.Int32[][],System.Int32[]);Use 
 P:Microsoft.Maui.MauiWinUIApplication.Services;Use the IPlatformApplication.Current.Services instead
 P:Microsoft.Maui.MauiWinUIApplication.Application;Use the IPlatformApplication.Current.Application instead
 P:Microsoft.UI.Xaml.Window.AppWindow;This API doesn't have null safety. Use GetAppWindow() and make sure to account for the possibility that GetAppWindow() might be null.
+P:Microsoft.UI.Xaml.Controls.Panel.Children;Use MauiPanel.CachedChildren instead to avoid performance hit

--- a/src/Compatibility/Core/src/Windows/ButtonRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/ButtonRenderer.cs
@@ -274,27 +274,42 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 				case Button.ButtonContentLayout.ImagePosition.Top:
 					container.Orientation = Orientation.Vertical;
 					image.Margin = WinUIHelpers.CreateThickness(0, 0, 0, spacing);
+#pragma warning disable RS0030 // Do not use banned APIs; Panel.Children is banned for performance reasons.
 					container.Children.Add(image);
 					container.Children.Add(textBlock);
+#pragma warning restore RS0030 // Do not use banned APIs
+
 					break;
 				case Button.ButtonContentLayout.ImagePosition.Bottom:
 					container.Orientation = Orientation.Vertical;
 					image.Margin = WinUIHelpers.CreateThickness(0, spacing, 0, 0);
+
+#pragma warning disable RS0030 // Do not use banned APIs; Panel.Children is banned for performance reasons.
 					container.Children.Add(textBlock);
 					container.Children.Add(image);
+#pragma warning restore RS0030 // Do not use banned APIs
+
 					break;
 				case Button.ButtonContentLayout.ImagePosition.Right:
 					container.Orientation = Orientation.Horizontal;
 					image.Margin = WinUIHelpers.CreateThickness(spacing, 0, 0, 0);
+
+#pragma warning disable RS0030 // Do not use banned APIs; Panel.Children is banned for performance reasons.
 					container.Children.Add(textBlock);
 					container.Children.Add(image);
+#pragma warning restore RS0030 // Do not use banned APIs
+
 					break;
 				default:
 					// Defaults to image on the left
 					container.Orientation = Orientation.Horizontal;
 					image.Margin = WinUIHelpers.CreateThickness(0, 0, spacing, 0);
+
+#pragma warning disable RS0030 // Do not use banned APIs; Panel.Children is banned for performance reasons.
 					container.Children.Add(image);
 					container.Children.Add(textBlock);
+#pragma warning restore RS0030 // Do not use banned APIs
+
 					break;
 			}
 

--- a/src/Compatibility/Core/src/Windows/EditorRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/EditorRenderer.cs
@@ -205,8 +205,10 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 		{
 			FormsTextBox child = Control;
 
+#pragma warning disable RS0030 // Do not use banned APIs; Panel.Children is banned for performance reasons.
 			if (Children.Count == 0 || child == null)
 				return new SizeRequest();
+#pragma warning restore RS0030 // Do not use banned APIs
 
 			var constraint = new global::Windows.Foundation.Size(widthConstraint, heightConstraint);
 			child.Measure(constraint);

--- a/src/Compatibility/Core/src/Windows/EntryRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/EntryRenderer.cs
@@ -502,8 +502,10 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 		{
 			FormsTextBox child = Control;
 
+#pragma warning disable RS0030 // Do not use banned APIs; Panel.Children is banned for performance reasons.
 			if (Children.Count == 0 || child == null)
 				return new SizeRequest();
+#pragma warning restore RS0030 // Do not use banned APIs
 
 			var constraint = new global::Windows.Foundation.Size(widthConstraint, heightConstraint);
 			child.Measure(constraint);

--- a/src/Compatibility/Core/src/Windows/FormsButton.cs
+++ b/src/Compatibility/Core/src/Windows/FormsButton.cs
@@ -109,7 +109,9 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 
 			if (content is StackPanel sp)
 			{
+#pragma warning disable RS0030 // Do not use banned APIs; Panel.Children is banned for performance reasons.
 				foreach (var item in sp.Children)
+#pragma warning restore RS0030 // Do not use banned APIs
 				{
 					if (item is TextBlock textBlock)
 					{

--- a/src/Compatibility/Core/src/Windows/LayoutRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/LayoutRenderer.cs
@@ -40,7 +40,9 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 		{
 			base.UpdateBackgroundColor();
 
+#pragma warning disable RS0030 // Do not use banned APIs; Panel.Children is banned for performance reasons.
 			if (GetValue(BackgroundProperty) == null && Children.Count == 0)
+#pragma warning restore RS0030 // Do not use banned APIs
 			{
 				// Forces the layout to take up actual space if it's otherwise empty
 				Background = new WSolidColorBrush(Colors.Transparent);

--- a/src/Compatibility/Core/src/Windows/Platform.cs
+++ b/src/Compatibility/Core/src/Windows/Platform.cs
@@ -331,7 +331,10 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 				};
 
 				Canvas.SetZIndex(_busyIndicator, 1);
+
+#pragma warning disable RS0030 // Do not use banned APIs; Panel.Children is banned for performance reasons.
 				_container.Children.Add(_busyIndicator);
+#pragma warning restore RS0030 // Do not use banned APIs
 			}
 
 			return _busyIndicator;
@@ -435,8 +438,10 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 
 			IVisualElementRenderer pageRenderer = GetRenderer(page);
 
+#pragma warning disable RS0030 // Do not use banned APIs; Panel.Children is banned for performance reasons.
 			if (_container.Children.Contains(pageRenderer.ContainerElement))
 				_container.Children.Remove(pageRenderer.ContainerElement);
+#pragma warning restore RS0030 // Do not use banned APIs
 		}
 
 		void AddPage(Page page)
@@ -451,8 +456,10 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 
 			IVisualElementRenderer pageRenderer = page.GetOrCreateRenderer();
 
+#pragma warning disable RS0030 // Do not use banned APIs; Panel.Children is banned for performance reasons.
 			if (!_container.Children.Contains(pageRenderer.ContainerElement))
 				_container.Children.Add(pageRenderer.ContainerElement);
+#pragma warning restore RS0030 // Do not use banned APIs
 
 			pageRenderer.ContainerElement.Width = _container.ActualWidth;
 			pageRenderer.ContainerElement.Height = _container.ActualHeight;

--- a/src/Compatibility/Core/src/Windows/TabbedPageRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/TabbedPageRenderer.cs
@@ -488,10 +488,16 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 			var stackPanels = Control.GetDescendantsByName<WStackPanel>(TabBarHeaderStackPanelName);
 			foreach (var stackPanel in stackPanels)
 			{
+#pragma warning disable RS0030 // Do not use banned APIs; Panel.Children is banned for performance reasons.
 				int stackPanelChildCount = stackPanel.Children.Count;
+#pragma warning restore RS0030 // Do not use banned APIs
+
 				for (int i = 0; i < stackPanelChildCount; i++)
 				{
+#pragma warning disable RS0030 // Do not use banned APIs; Panel.Children is banned for performance reasons.
 					var stackPanelItem = stackPanel.Children[i];
+#pragma warning restore RS0030 // Do not use banned APIs
+					
 					if (stackPanelItem is WImage tabBarImage)
 					{
 						// Update icon image.

--- a/src/Compatibility/Core/src/Windows/VisualElementPackager.cs
+++ b/src/Compatibility/Core/src/Windows/VisualElementPackager.cs
@@ -129,7 +129,9 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 			if (_columnSpan > 0)
 				Microsoft.UI.Xaml.Controls.Grid.SetColumnSpan(childRenderer.ContainerElement, _columnSpan);
 
+#pragma warning disable RS0030 // Do not use banned APIs; Panel.Children is banned for performance reasons.
 			_panel.Children.Add(childRenderer.ContainerElement);
+#pragma warning restore RS0030 // Do not use banned APIs
 		}
 
 		void OnChildAdded(object sender, ElementEventArgs e)
@@ -164,7 +166,9 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 				if (_columnSpan > 0)
 					childRenderer.ContainerElement.ClearValue(Microsoft.UI.Xaml.Controls.Grid.ColumnSpanProperty);
 
+#pragma warning disable RS0030 // Do not use banned APIs; Panel.Children is banned for performance reasons.
 				_panel.Children.Remove(childRenderer.ContainerElement);
+#pragma warning restore RS0030 // Do not use banned APIs
 
 				view.Cleanup();
 			}

--- a/src/Compatibility/Core/src/Windows/VisualElementRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/VisualElementRenderer.cs
@@ -106,8 +106,10 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 
 		public virtual SizeRequest GetDesiredSize(double widthConstraint, double heightConstraint)
 		{
+#pragma warning disable RS0030 // Do not use banned APIs; Panel.Children is banned for performance reasons.
 			if (Children.Count == 0 || Control == null)
 				return new SizeRequest();
+#pragma warning restore RS0030 // Do not use banned APIs
 
 			var constraint = new global::Windows.Foundation.Size(widthConstraint, heightConstraint);
 			TNativeElement child = Control;
@@ -229,7 +231,10 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 			{
 				// in the event that a custom renderer has added native controls,
 				// we need to be sure to arrange them so that they are arranged.
+#pragma warning disable RS0030 // Do not use banned APIs; Panel.Children is banned for performance reasons.
 				var nativeChildren = Children;
+#pragma warning restore RS0030 // Do not use banned APIs
+
 				for (int i = 0; i < nativeChildren.Count; i++)
 				{
 					var nativeChild = nativeChildren[i];
@@ -404,7 +409,9 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 
 			if (oldControl != null)
 			{
+#pragma warning disable RS0030 // Do not use banned APIs; Panel.Children is banned for performance reasons.
 				Children.Remove(oldControl);
+#pragma warning restore RS0030 // Do not use banned APIs
 
 				oldControl.Loaded -= OnControlLoaded;
 				oldControl.GotFocus -= OnControlGotFocus;
@@ -432,7 +439,10 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 
 			control.GotFocus += OnControlGotFocus;
 			control.LostFocus += OnControlLostFocus;
+
+#pragma warning disable RS0030 // Do not use banned APIs; Panel.Children is banned for performance reasons.
 			Children.Add(control);
+#pragma warning restore RS0030 // Do not use banned APIs
 
 			UpdateBackgroundColor();
 			UpdateBackground();
@@ -669,7 +679,10 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 			// Panel will be our Background color
 
 			_backgroundLayer = new Canvas { IsHitTestVisible = false };
+
+#pragma warning disable RS0030 // Do not use banned APIs; Panel.Children is banned for performance reasons.
 			Children.Insert(0, _backgroundLayer);
+#pragma warning restore RS0030 // Do not use banned APIs
 
 			UpdateBackgroundColor();
 			UpdateBackground();
@@ -682,7 +695,10 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 				return;
 			}
 
+#pragma warning disable RS0030 // Do not use banned APIs; Panel.Children is banned for performance reasons.
 			Children.Remove(_backgroundLayer);
+#pragma warning restore RS0030 // Do not use banned APIs
+
 			_backgroundLayer = null;
 
 			UpdateBackgroundColor();

--- a/src/Controls/src/Core/Compatibility/Handlers/Android/VisualElementRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Android/VisualElementRenderer.cs
@@ -48,10 +48,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			if (ChildCount > 0)
 			{
 				var platformView = GetChildAt(0);
-				if (platformView != null)
-				{
-					platformView.Layout(0, 0, r - l, b - t);
-				}
+				platformView?.Layout(0, 0, r - l, b - t);
 			}
 		}
 

--- a/src/Controls/src/Core/Compatibility/Handlers/Windows/VisualElementRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Windows/VisualElementRenderer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -35,6 +36,18 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		public UIElement? GeTPlatformElement() => Control;
 
+		UIElementCollection? _cachedChildren;
+
+		[SuppressMessage("ApiDesign", "RS0030:Do not use banned APIs", Justification = "Panel.Children property is banned to enforce use of this CachedChildren property.")]
+		internal UIElementCollection CachedChildren
+		{
+			get
+			{
+				_cachedChildren ??= Children;
+				return _cachedChildren;
+			}
+		}
+
 		protected virtual void UpdateNativeControl() { }
 
 		protected void SetNativeControl(TPlatformElement control)
@@ -44,7 +57,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 			if (oldControl != null)
 			{
-				Children.Remove(oldControl);
+				CachedChildren.Remove(oldControl);
 			}
 
 			if (Control == null)
@@ -55,7 +68,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			Control.HorizontalAlignment = Microsoft.UI.Xaml.HorizontalAlignment.Stretch;
 			Control.VerticalAlignment = Microsoft.UI.Xaml.VerticalAlignment.Stretch;
 
-			Children.Add(control);
+			CachedChildren.Add(control);
 			UpdateNativeControl();
 		}
 
@@ -68,10 +81,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			if (Element == null || availableSize.Width * availableSize.Height == 0)
 				return new WSize(0, 0);
 
-			if (Control != null)
-			{
-				Control.Measure(availableSize);
-			}
+			Control?.Measure(availableSize);
 
 			var mauiContext = Element?.Handler?.MauiContext;
 			var minimumSize = MinimumSize();
@@ -99,10 +109,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		protected override WSize ArrangeOverride(global::Windows.Foundation.Size finalSize)
 		{
 			var myRect = new WRect(0, 0, finalSize.Width, finalSize.Height);
-			if (Control != null)
-			{
-				Control.Arrange(myRect);
-			}
+			Control?.Arrange(myRect);
 
 			var mauiContext = Element?.Handler?.MauiContext;
 			if (Element is not IVisualTreeElement vte || mauiContext == null)
@@ -151,7 +158,10 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				return;
 			}
 
-			panel.Children.Clear();
+#pragma warning disable RS0030 // Do not use banned APIs; Panel.Children is banned for performance reasons. Here we can just cache it.
+			var panelChildren = panel.Children;
+#pragma warning restore RS0030 // Do not use banned APIs
+			panelChildren.Clear();
 
 			if (element is not IVisualTreeElement vte)
 				return;
@@ -163,7 +173,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			foreach (var child in vte.GetVisualChildren())
 			{
 				if (child is Maui.IElement childElement)
-					panel.Children.Add(childElement.ToPlatform(mauiContext));
+					panelChildren.Add(childElement.ToPlatform(mauiContext));
 			}
 		}
 

--- a/src/Controls/src/Core/Handlers/Shell/Windows/ShellSplitView.cs
+++ b/src/Controls/src/Core/Handlers/Shell/Windows/ShellSplitView.cs
@@ -70,7 +70,11 @@ namespace Microsoft.Maui.Controls.Platform
 				var contentRoot = _splitView.GetDescendantByName<WGrid>("ContentRoot");
 				if (contentRoot != null)
 				{
-					foreach (var child in contentRoot.Children)
+#pragma warning disable RS0030 // Do not use banned APIs; Panel.Children is banned for performance reasons. Here we cannot avoid accessing it.
+					var children = contentRoot.Children;
+#pragma warning restore RS0030 // Do not use banned APIs
+
+					foreach (var child in children)
 					{
 						if (child is WRectangle maybe &&
 							$"{child.GetValue(FrameworkElement.NameProperty)}" == "LightDismissLayer")

--- a/src/Controls/src/Core/Handlers/Shell/Windows/ViewToHandlerConverter.cs
+++ b/src/Controls/src/Core/Handlers/Shell/Windows/ViewToHandlerConverter.cs
@@ -54,7 +54,10 @@ namespace Microsoft.Maui.Controls.Platform
 				_view.MeasureInvalidated += OnMeasureInvalidated;
 
 				FrameworkElement = view.ToPlatform(view.FindMauiContext()!);
+
+#pragma warning disable RS0030 // Do not use banned APIs; Panel.Children is banned for performance reasons. Here we allow it as a part of initialization.
 				Children.Add(FrameworkElement);
+#pragma warning restore RS0030 // Do not use banned APIs
 
 				// make sure we re-measure once the template is applied
 

--- a/src/Controls/src/Core/Platform/AlertManager/ActionSheetDialog.Windows.cs
+++ b/src/Controls/src/Core/Platform/AlertManager/ActionSheetDialog.Windows.cs
@@ -82,6 +82,10 @@ namespace Microsoft.Maui.Controls.Platform
 				}
 			};
 
+#pragma warning disable RS0030 // Do not use banned APIs; Panel.Children is banned for performance reasons. Here we can just cache it.
+			var mainLayoutChildren = mainLayout.Children;
+#pragma warning restore RS0030 // Do not use banned APIs
+
 			var firstLayout = new UI.Xaml.Controls.Grid
 			{
 				RowDefinitions =
@@ -91,13 +95,17 @@ namespace Microsoft.Maui.Controls.Platform
 				}
 			};
 
+#pragma warning disable RS0030 // Do not use banned APIs; Panel.Children is banned for performance reasons. Here we can just cache it.
+			var firstLayoutChildren = firstLayout.Children;
+#pragma warning restore RS0030 // Do not use banned APIs
+
 			TitleBlock = new TextBlock { FontSize = 18, MaxLines = 2 };
-			firstLayout.Children.Add(TitleBlock);
+			firstLayoutChildren.Add(TitleBlock);
 			UI.Xaml.Controls.Grid.SetRow(TitleBlock, 0);
 
 			OptionsList = new UI.Xaml.Controls.ListView { IsItemClickEnabled = true, Margin = new UI.Xaml.Thickness(0, 10, 0, 10), SelectionMode = UI.Xaml.Controls.ListViewSelectionMode.None };
 			OptionsList.ItemClick += ListItemSelected;
-			firstLayout.Children.Add(OptionsList);
+			firstLayoutChildren.Add(OptionsList);
 			UI.Xaml.Controls.Grid.SetRow(OptionsList, 1);
 
 			var secondLayout = new UI.Xaml.Controls.Grid
@@ -110,20 +118,24 @@ namespace Microsoft.Maui.Controls.Platform
 				VerticalAlignment = VerticalAlignment.Bottom
 			};
 
+#pragma warning disable RS0030 // Do not use banned APIs; Panel.Children is banned for performance reasons. Here we can just cache it.
+			var secondLayoutChildren = secondLayout.Children;
+#pragma warning restore RS0030 // Do not use banned APIs
+
 			LeftBtn = new UI.Xaml.Controls.Button { Height = 32, HorizontalAlignment = HorizontalAlignment.Stretch, Margin = new UI.Xaml.Thickness(0, 0, 5, 0) };
 			LeftBtn.Click += ActionButtonClicked;
-			secondLayout.Children.Add(LeftBtn);
+			secondLayoutChildren.Add(LeftBtn);
 			UI.Xaml.Controls.Grid.SetColumn(LeftBtn, 0);
 
 			RightBtn = new UI.Xaml.Controls.Button { Height = 32, HorizontalAlignment = HorizontalAlignment.Stretch, Margin = new UI.Xaml.Thickness(5, 0, 0, 0) };
 			RightBtn.Click += ActionButtonClicked;
-			secondLayout.Children.Add(RightBtn);
+			secondLayoutChildren.Add(RightBtn);
 			UI.Xaml.Controls.Grid.SetColumn(RightBtn, 1);
 
-			mainLayout.Children.Add(firstLayout);
+			mainLayoutChildren.Add(firstLayout);
 			UI.Xaml.Controls.Grid.SetRow(firstLayout, 0);
 
-			mainLayout.Children.Add(secondLayout);
+			mainLayoutChildren.Add(secondLayout);
 			UI.Xaml.Controls.Grid.SetRow(secondLayout, 1);
 
 			Content = mainLayout;

--- a/src/Controls/src/Core/Platform/AlertManager/PromptDialog.Windows.cs
+++ b/src/Controls/src/Core/Platform/AlertManager/PromptDialog.Windows.cs
@@ -56,8 +56,10 @@ public sealed partial class PromptDialog : ContentDialog
 		TextBlockMessage = new TextBlock { Text = "Message", TextWrapping = UI.Xaml.TextWrapping.Wrap };
 		TextBoxInput = new MauiPasswordTextBox();
 
+#pragma warning disable RS0030 // Do not use banned APIs; Panel.Children is banned for performance reasons. Here we allow it as a part of initialization.
 		layout.Children.Add(TextBlockMessage);
 		layout.Children.Add(TextBoxInput);
+#pragma warning restore RS0030 // Do not use banned APIs
 
 		Content = layout;
 	}

--- a/src/Controls/src/Core/Platform/Windows/CollectionView/ItemContentControl.cs
+++ b/src/Controls/src/Core/Platform/Windows/CollectionView/ItemContentControl.cs
@@ -348,11 +348,13 @@ namespace Microsoft.Maui.Controls.Platform
 
 				var platformView = view.ToPlatform();
 
+#pragma warning disable RS0030 // Do not use banned APIs; Panel.Children is banned for performance reasons. Here we cannot avoid accessing it.
 				// Just in case this view is already parented to a wrapper that's been cycled out
 				if (platformView.Parent is ContentLayoutPanel clp)
 					clp.Children.Remove(platformView);
 
 				Children.Add(platformView);
+#pragma warning restore RS0030 // Do not use banned APIs
 			}
 
 			protected override WSize ArrangeOverride(WSize finalSize) => _view.Arrange(new Rect(0, 0, finalSize.Width, finalSize.Height)).ToPlatform();

--- a/src/Controls/tests/DeviceTests/Elements/ContentView/ContentViewTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/ContentView/ContentViewTests.Windows.cs
@@ -7,13 +7,13 @@ namespace Microsoft.Maui.DeviceTests
 	{
 		static int GetChildCount(ContentViewHandler contentViewHandler)
 		{
-			return contentViewHandler.PlatformView.Children.Count;
+			return contentViewHandler.PlatformView.CachedChildren.Count;
 		}
 
 		static int GetContentChildCount(ContentViewHandler contentViewHandler)
 		{
-			if (contentViewHandler.PlatformView.Children[0] is LayoutPanel childLayoutPanel)
-				return childLayoutPanel.Children.Count;
+			if (contentViewHandler.PlatformView.CachedChildren[0] is LayoutPanel childLayoutPanel)
+				return childLayoutPanel.CachedChildren.Count;
 			else
 				return 0;
 		}

--- a/src/Controls/tests/DeviceTests/Elements/Frame/FrameTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Frame/FrameTests.cs
@@ -448,21 +448,27 @@ namespace Microsoft.Maui.DeviceTests
 			public ContentLayoutPanel(IView view, double widthConstraint, double heightConstraint)
 			{
 				if (!double.IsPositiveInfinity(widthConstraint))
+				{
 					this.Width = widthConstraint;
+				}
 
 				if (!double.IsPositiveInfinity(heightConstraint))
+				{
 					this.Height = heightConstraint;
+				}
 
 				_view = view;
 				_widthConstraint = widthConstraint;
 				_heightConstraint = heightConstraint;
 				var platformView = view.ToPlatform();
 
+#pragma warning disable RS0030 // Do not use banned APIs; Panel.Children is banned for performance reasons. In tests, we don't mind.
 				// Just in case this view is already parented to a wrapper that's been cycled out
 				if (platformView.Parent is ContentLayoutPanel clp)
 					clp.Children.Remove(platformView);
 
 				Children.Add(platformView);
+#pragma warning restore RS0030 // Do not use banned APIs
 			}
 
 			protected override WSize ArrangeOverride(WSize finalSize) => _view.Arrange(new Rect(0, 0, finalSize.Width, finalSize.Height)).ToPlatform();

--- a/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.Windows.cs
@@ -27,13 +27,22 @@ namespace Microsoft.Maui.DeviceTests
 				async (handler) =>
 				{
 					var windowRootViewContainer = (WPanel)handler.PlatformView.Content;
+
+#pragma warning disable RS0030 // Do not use banned APIs; Panel.Children is banned for performance reasons. In tests, we don't mind.
+					var windowRootViewContainerChildren = windowRootViewContainer.Children;
+#pragma warning restore RS0030 // Do not use banned APIs
+
 					ContentPage backgroundColorContentPage = new ContentPage() { Content = new Label() { Text = "Modal Page" } };
 
 
 					if (useColor)
+					{
 						backgroundColorContentPage.BackgroundColor = Colors.Purple.WithAlpha(0.5f);
+					}
 					else
+					{
 						backgroundColorContentPage.Background = new SolidColorBrush(Colors.Purple.WithAlpha(0.5f));
+					}
 
 					await navPage.CurrentPage.Navigation.PushModalAsync(backgroundColorContentPage);
 					await OnLoadedAsync(backgroundColorContentPage);
@@ -43,14 +52,14 @@ namespace Microsoft.Maui.DeviceTests
 					var rootPageRootView =
 						navPage.FindMauiContext().GetNavigationRootManager().RootView;
 
-					Assert.Equal(1, windowRootViewContainer.Children.IndexOf(modalRootView));
-					Assert.Equal(0, windowRootViewContainer.Children.IndexOf(rootPageRootView));
+					Assert.Equal(1, windowRootViewContainerChildren.IndexOf(modalRootView));
+					Assert.Equal(0, windowRootViewContainerChildren.IndexOf(rootPageRootView));
 
 					await navPage.CurrentPage.Navigation.PopModalAsync();
 					await OnUnloadedAsync(backgroundColorContentPage);
 
-					Assert.Equal(0, windowRootViewContainer.Children.IndexOf(rootPageRootView));
-					Assert.DoesNotContain(modalRootView, windowRootViewContainer.Children);
+					Assert.Equal(0, windowRootViewContainerChildren.IndexOf(rootPageRootView));
+					Assert.DoesNotContain(modalRootView, windowRootViewContainerChildren);
 				});
 		}
 

--- a/src/Controls/tests/DeviceTests/Elements/TemplatedView/TemplatedViewTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/TemplatedView/TemplatedViewTests.Windows.cs
@@ -7,9 +7,9 @@ namespace Microsoft.Maui.DeviceTests
 	public partial class TemplatedViewTests
 	{
 		static int GetChildCount(ContentViewHandler contentViewHandler) =>
-			contentViewHandler.PlatformView.Children.Count;
+			contentViewHandler.PlatformView.CachedChildren.Count;
 
 		static UIElement GetChild(ContentViewHandler contentViewHandler, int index = 0) =>
-			contentViewHandler.PlatformView.Children[index];
+			contentViewHandler.PlatformView.CachedChildren[index];
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.Windows.cs
@@ -86,14 +86,19 @@ namespace Microsoft.Maui.DeviceTests
 			await CreateHandlerAndAddToWindow<IWindowHandler>(mainPage, (handler) =>
 			{
 				var windowRootViewContainer = (WPanel)handler.PlatformView.Content;
+
+#pragma warning disable RS0030 // Do not use banned APIs; Panel.Children is banned for performance reasons. In tests, we don't mind.
+				var windowRootViewContainerChildren = windowRootViewContainer.Children;
+#pragma warning restore RS0030 // Do not use banned APIs
+
 				var overlayView =
-					windowRootViewContainer
-						.Children
+					windowRootViewContainerChildren
 						.OfType<W2DGraphicsView>()
 						.SingleOrDefault();
 
 				Assert.NotNull(overlayView);
-				Assert.Equal(overlayView, windowRootViewContainer.Children.Last());
+				Assert.Equal(overlayView, windowRootViewContainerChildren.Last());
+
 				return Task.CompletedTask;
 			});
 		}
@@ -109,7 +114,12 @@ namespace Microsoft.Maui.DeviceTests
 			await CreateHandlerAndAddToWindow<IWindowHandler>(mainPage, async (handler) =>
 			{
 				var windowRootViewContainer = (WPanel)handler.PlatformView.Content;
-				var countBeforePageSwap = windowRootViewContainer.Children.Count;
+				
+#pragma warning disable RS0030 // Do not use banned APIs; Panel.Children is banned for performance reasons. In tests, we don't mind.
+				var windowRootViewContainerChildren = windowRootViewContainer.Children;
+#pragma warning restore RS0030 // Do not use banned APIs
+
+				var countBeforePageSwap = windowRootViewContainerChildren.Count;
 
 				var mainPageRootView =
 					mainPage.FindMauiContext().GetNavigationRootManager().RootView;
@@ -118,7 +128,7 @@ namespace Microsoft.Maui.DeviceTests
 				await OnNavigatedToAsync(swappedInMainPage.CurrentPage);
 				await OnFrameSetToNotEmpty(swappedInMainPage.CurrentPage);
 
-				var countAfterPageSwap = windowRootViewContainer.Children.Count;
+				var countAfterPageSwap = windowRootViewContainerChildren.Count;
 				Assert.Equal(countBeforePageSwap, countAfterPageSwap);
 			});
 		}

--- a/src/Controls/tests/DeviceTests/TestClasses/NestingView.cs
+++ b/src/Controls/tests/DeviceTests/TestClasses/NestingView.cs
@@ -52,6 +52,21 @@ namespace Microsoft.Maui.DeviceTests
 #endif
 	{
 
+#if WINDOWS
+		UI.Xaml.Controls.UIElementCollection _cachedChildren;
+
+		internal UI.Xaml.Controls.UIElementCollection CachedChildren
+		{
+			get
+			{
+#pragma warning disable RS0030 // Do not use banned APIs; Panel.Children is banned for performance reasons.
+				_cachedChildren ??= Children;
+#pragma warning restore RS0030 // Do not use banned APIs
+				return _cachedChildren;
+			}
+		}
+#endif
+
 #if ANDROID
 		public NestingViewPlatformView(Context context) : base(context)
 		{
@@ -90,11 +105,11 @@ namespace Microsoft.Maui.DeviceTests
 		public PlatformView AddChild(PlatformView platformView)
 		{
 #if WINDOWS
-			this.Children.Add(platformView);
+			CachedChildren.Add(platformView);
 #elif ANDROID
-			this.AddView(platformView);
+			AddView(platformView);
 #else
-			this.AddSubview(platformView);
+			AddSubview(platformView);
 #endif
 
 			return platformView;

--- a/src/Core/src/Handlers/Border/BorderHandler.Windows.cs
+++ b/src/Core/src/Handlers/Border/BorderHandler.Windows.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Maui.Handlers
 			_ = handler.VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} should have been set by base class.");
 			_ = handler.MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
 
-			handler.PlatformView.Children.Clear();
+			handler.PlatformView.CachedChildren.Clear();
 			handler.PlatformView.EnsureBorderPath();
 
 			if (handler.VirtualView.PresentedContent is IView view)

--- a/src/Core/src/Handlers/ContentView/ContentViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/ContentView/ContentViewHandler.Windows.cs
@@ -20,10 +20,12 @@ namespace Microsoft.Maui.Handlers
 			_ = handler.VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} should have been set by base class.");
 			_ = handler.MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
 
-			handler.PlatformView.Children.Clear();
+			handler.PlatformView.CachedChildren.Clear();
 
 			if (handler.VirtualView.PresentedContent is IView view)
-				handler.PlatformView.Children.Add(view.ToPlatform(handler.MauiContext));
+			{
+				handler.PlatformView.CachedChildren.Add(view.ToPlatform(handler.MauiContext));
+			}
 		}
 
 		protected override ContentPanel CreatePlatformView()
@@ -49,7 +51,7 @@ namespace Microsoft.Maui.Handlers
 		protected override void DisconnectHandler(ContentPanel platformView)
 		{
 			platformView.CrossPlatformLayout = null;
-			platformView.Children?.Clear();
+			platformView.CachedChildren?.Clear();
 
 			base.DisconnectHandler(platformView);
 		}

--- a/src/Core/src/Handlers/Layout/LayoutHandler.Windows.cs
+++ b/src/Core/src/Handlers/Layout/LayoutHandler.Windows.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Maui.Handlers
 
 			PlatformView.CrossPlatformLayout = VirtualView;
 
-			var children = PlatformView.Children;
+			var children = PlatformView.CachedChildren;
 			children.Clear();
 
 			foreach (var child in VirtualView.OrderByZIndex())

--- a/src/Core/src/Handlers/Layout/LayoutHandler.Windows.cs
+++ b/src/Core/src/Handlers/Layout/LayoutHandler.Windows.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Maui.Handlers
 			_ = MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
 
 			var targetIndex = VirtualView.GetLayoutHandlerIndex(child);
-			PlatformView.Children.Insert(targetIndex, child.ToPlatform(MauiContext));
+			PlatformView.CachedChildren.Insert(targetIndex, child.ToPlatform(MauiContext));
 		}
 
 		public override void SetVirtualView(IView view)
@@ -42,13 +42,13 @@ namespace Microsoft.Maui.Handlers
 
 			if (child?.ToPlatform() is UIElement view)
 			{
-				PlatformView.Children.Remove(view);
+				PlatformView.CachedChildren.Remove(view);
 			}
 		}
 
 		public void Clear()
 		{
-			PlatformView?.Children.Clear();
+			PlatformView?.CachedChildren.Clear();
 		}
 
 		public void Insert(int index, IView child)
@@ -58,7 +58,7 @@ namespace Microsoft.Maui.Handlers
 			_ = MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
 
 			var targetIndex = VirtualView.GetLayoutHandlerIndex(child);
-			PlatformView.Children.Insert(targetIndex, child.ToPlatform(MauiContext));
+			PlatformView.CachedChildren.Insert(targetIndex, child.ToPlatform(MauiContext));
 		}
 
 		public void Update(int index, IView child)
@@ -67,7 +67,7 @@ namespace Microsoft.Maui.Handlers
 			_ = VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} should have been set by base class.");
 			_ = MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
 
-			PlatformView.Children[index] = child.ToPlatform(MauiContext);
+			PlatformView.CachedChildren[index] = child.ToPlatform(MauiContext);
 			EnsureZIndexOrder(child);
 		}
 
@@ -98,18 +98,18 @@ namespace Microsoft.Maui.Handlers
 		protected override void DisconnectHandler(LayoutPanel platformView)
 		{
 			// If we're being disconnected from the xplat element, then we should no longer be managing its children
-			platformView.Children.Clear();
+			platformView.CachedChildren.Clear();
 			base.DisconnectHandler(platformView);
 		}
 
 		void EnsureZIndexOrder(IView child)
 		{
-			if (PlatformView.Children.Count == 0)
+			if (PlatformView.CachedChildren.Count == 0)
 			{
 				return;
 			}
 
-			var children = PlatformView.Children;
+			var children = PlatformView.CachedChildren;
 			var currentIndex = children.IndexOf(child.ToPlatform(MauiContext!));
 
 			if (currentIndex == -1)

--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Windows.cs
@@ -131,10 +131,10 @@ namespace Microsoft.Maui.Handlers
 
 			if (GetContentPanel(scrollViewer) is ContentPanel currentPaddingLayer)
 			{
-				if (currentPaddingLayer.Children.Count == 0 || currentPaddingLayer.Children[0] != nativeContent)
+				if (currentPaddingLayer.CachedChildren.Count == 0 || currentPaddingLayer.CachedChildren[0] != nativeContent)
 				{
-					currentPaddingLayer.Children.Clear();
-					currentPaddingLayer.Children.Add(nativeContent);
+					currentPaddingLayer.CachedChildren.Clear();
+					currentPaddingLayer.CachedChildren.Add(nativeContent);
 
 				}
 			}
@@ -158,7 +158,7 @@ namespace Microsoft.Maui.Handlers
 			};
 
 			scrollViewer.Content = null;
-			paddingShim.Children.Add(nativeContent);
+			paddingShim.CachedChildren.Add(nativeContent);
 			scrollViewer.Content = paddingShim;
 		}
 

--- a/src/Core/src/Handlers/View/ViewHandlerOfT.Windows.cs
+++ b/src/Core/src/Handlers/View/ViewHandlerOfT.Windows.cs
@@ -16,46 +16,71 @@ namespace Microsoft.Maui.Handlers
 
 		protected override void SetupContainer()
 		{
-			if (PlatformView == null || ContainerView != null)
+			if (PlatformView is null || ContainerView is not null)
+			{
 				return;
+			}
 
-			var oldParent = (Panel?)PlatformView.Parent;
-			var oldIndex = oldParent?.Children.IndexOf(PlatformView);
+#pragma warning disable RS0030 // Do not use banned APIs; Panel.Children is banned for performance reasons. MauiPanel might not be used everywhere though.
+			var oldParentChildren = PlatformView.Parent is MauiPanel mauiPanel
+				? mauiPanel.CachedChildren
+				: (PlatformView.Parent as Panel)?.Children;
+#pragma warning restore RS0030 // Do not use banned APIs
+
+			var oldIndex = oldParentChildren?.IndexOf(PlatformView);
+
 			if (oldIndex is int oldIdx && oldIdx >= 0)
-				oldParent?.Children.RemoveAt(oldIdx);
+			{
+				oldParentChildren?.RemoveAt(oldIdx);
+			}
 
 			ContainerView ??= new WrapperView();
 			((WrapperView)ContainerView).Child = PlatformView;
 
 			if (oldIndex is int idx && idx >= 0)
-				oldParent?.Children.Insert(idx, ContainerView);
+			{
+				oldParentChildren?.Insert(idx, ContainerView);
+			}
 			else
-				oldParent?.Children.Add(ContainerView);
+			{
+				oldParentChildren?.Add(ContainerView);
+			}
 		}
 
 		protected override void RemoveContainer()
 		{
-			if (PlatformView == null || ContainerView == null || PlatformView.Parent != ContainerView)
+			if (PlatformView is null || ContainerView is null || PlatformView.Parent != ContainerView)
 			{
 				CleanupContainerView(ContainerView);
 				ContainerView = null;
 				return;
 			}
 
-			var oldParent = (Panel?)ContainerView.Parent;
-			var oldIndex = oldParent?.Children.IndexOf(ContainerView);
+#pragma warning disable RS0030 // Do not use banned APIs; Panel.Children is banned for performance reasons. MauiPanel might not be used everywhere though.
+			var oldParentChildren = PlatformView.Parent is MauiPanel mauiPanel
+				? mauiPanel.CachedChildren
+				: (PlatformView.Parent as Panel)?.Children;
+#pragma warning restore RS0030 // Do not use banned APIs
+
+			var oldIndex = oldParentChildren?.IndexOf(ContainerView);
 			if (oldIndex is int oldIdx && oldIdx >= 0)
-				oldParent?.Children.RemoveAt(oldIdx);
+			{
+				oldParentChildren?.RemoveAt(oldIdx);
+			}
 
 			CleanupContainerView(ContainerView);
 			ContainerView = null;
 
 			if (oldIndex is int idx && idx >= 0)
-				oldParent?.Children.Insert(idx, PlatformView);
+			{
+				oldParentChildren?.Insert(idx, PlatformView);
+			}
 			else
-				oldParent?.Children.Add(PlatformView);
+			{
+				oldParentChildren?.Add(PlatformView);
+			}
 
-			void CleanupContainerView(FrameworkElement? containerView)
+			static void CleanupContainerView(FrameworkElement? containerView)
 			{
 				if (containerView is WrapperView wrapperView)
 				{

--- a/src/Core/src/Handlers/Window/WindowHandler.Windows.cs
+++ b/src/Core/src/Handlers/Window/WindowHandler.Windows.cs
@@ -57,13 +57,15 @@ namespace Microsoft.Maui.Handlers
 
 			if (platformView.Content is WindowRootViewContainer container)
 			{
-				container.Children.Clear();
+				container.CachedChildren.Clear();
 				platformView.Content = null;
 			}
 
 			var appWindow = platformView.GetAppWindow();
 			if (appWindow is not null)
+			{
 				appWindow.Changed -= OnWindowChanged;
+			}
 
 			base.DisconnectHandler(platformView);
 		}
@@ -89,8 +91,7 @@ namespace Microsoft.Maui.Handlers
 				container.AddPage(windowManager.RootView);
 			}
 
-			if (window.VisualDiagnosticsOverlay != null)
-				window.VisualDiagnosticsOverlay.Initialize();
+			window.VisualDiagnosticsOverlay?.Initialize();
 		}
 
 		public static void MapX(IWindowHandler handler, IWindow view) =>

--- a/src/Core/src/Platform/Windows/ButtonExtensions.cs
+++ b/src/Core/src/Platform/Windows/ButtonExtensions.cs
@@ -198,17 +198,29 @@ namespace Microsoft.Maui.Platform
 			where T : FrameworkElement
 		{
 			if (platformButton.Content is null)
+			{
 				return null;
+			}
 
 			if (platformButton.Content is T t)
+			{
 				return t;
+			}
 
 			if (platformButton.Content is Panel panel)
 			{
-				foreach (var child in panel.Children)
+#pragma warning disable RS0030 // Do not use banned APIs; Panel.Children is banned for performance reasons. MauiPanel might not be used everywhere though.
+				var children = panel is MauiPanel mauiPanel
+					? mauiPanel.CachedChildren
+					: panel.Children;
+#pragma warning restore RS0030 // Do not use banned APIs
+
+				foreach (var child in children)
 				{
 					if (child is T c)
+					{
 						return c;
+					}
 				}
 			}
 

--- a/src/Core/src/Platform/Windows/ContentPanel.cs
+++ b/src/Core/src/Platform/Windows/ContentPanel.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Maui.Platform
 			get => _content;
 			set
 			{
-				var children = Children;
+				var children = CachedChildren;
 
 				// Remove the previous content if it exists
 				if (_content is not null && children.Contains(_content) && value != _content)
@@ -96,7 +96,7 @@ namespace Microsoft.Maui.Platform
 		{
 			if (containsCheck)
 			{
-				var children = Children;
+				var children = CachedChildren;
 
 				if (!children.Contains(_borderPath))
 				{
@@ -105,7 +105,7 @@ namespace Microsoft.Maui.Platform
 			}
 			else
 			{
-				Children.Add(_borderPath);
+				CachedChildren.Add(_borderPath);
 			}
 		}
 

--- a/src/Core/src/Platform/Windows/LayoutPanel.cs
+++ b/src/Core/src/Platform/Windows/LayoutPanel.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Maui.Platform
 			}
 
 			_backgroundLayer = new Canvas { IsHitTestVisible = false };
-			Children.Insert(0, _backgroundLayer);
+			CachedChildren.Insert(0, _backgroundLayer);
 		}
 
 		void RemoveBackgroundLayer()
@@ -99,7 +99,7 @@ namespace Microsoft.Maui.Platform
 				return;
 			}
 
-			Children.Remove(_backgroundLayer);
+			CachedChildren.Remove(_backgroundLayer);
 			_backgroundLayer = null;
 		}
 	}

--- a/src/Core/src/Platform/Windows/MauiButton.cs
+++ b/src/Core/src/Platform/Windows/MauiButton.cs
@@ -57,8 +57,8 @@ namespace Microsoft.Maui.Platform
 				Visibility = UI.Xaml.Visibility.Collapsed,
 			};
 
-			Children.Add(_image);
-			Children.Add(_textBlock);
+			CachedChildren.Add(_image);
+			CachedChildren.Add(_textBlock);
 
 			LayoutImageLeft(0);
 		}

--- a/src/Core/src/Platform/Windows/MauiPanel.cs
+++ b/src/Core/src/Platform/Windows/MauiPanel.cs
@@ -1,5 +1,6 @@
 ﻿#nullable enable
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Maui.Graphics;
 using Microsoft.UI.Xaml.Controls;
 using WSize = global::Windows.Foundation.Size;
@@ -8,6 +9,18 @@ namespace Microsoft.Maui.Platform
 {
 	public abstract class MauiPanel : Panel, ICrossPlatformLayoutBacking, IVisualTreeElementProvidable
 	{
+		UIElementCollection? _cachedChildren;
+
+		[SuppressMessage("ApiDesign", "RS0030:Do not use banned APIs", Justification = "Panel.Children property is banned to enforce use of this CachedChildren property.")]
+		internal UIElementCollection CachedChildren
+		{
+			get
+			{
+				_cachedChildren ??= Children;
+				return _cachedChildren;
+			}
+		}
+
 		public ICrossPlatformLayout? CrossPlatformLayout
 		{
 			get; set;

--- a/src/Core/src/Platform/Windows/RootNavigationView.cs
+++ b/src/Core/src/Platform/Windows/RootNavigationView.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Data;
@@ -344,7 +345,7 @@ namespace Microsoft.Maui.Platform
 
 		void ReplacePaneMenuItemsWithCustomContent(UIElement? customContent)
 		{
-			_flyoutPanel.Children.Clear();
+			_flyoutPanel.CachedChildren.Clear();
 
 			if (customContent == null)
 			{
@@ -352,7 +353,7 @@ namespace Microsoft.Maui.Platform
 			}
 			else
 			{
-				_flyoutPanel.Children.Add(customContent);
+				_flyoutPanel.CachedChildren.Add(customContent);
 				PaneCustomContent = _flyoutPanel;
 			}
 		}
@@ -370,6 +371,18 @@ namespace Microsoft.Maui.Platform
 		{
 			public Maui.IView? FlyoutView { get; set; }
 
+			UIElementCollection? _cachedChildren;
+
+			[SuppressMessage("ApiDesign", "RS0030:Do not use banned APIs", Justification = "Panel.Children property is banned to enforce use of this CachedChildren property.")]
+			internal UIElementCollection CachedChildren
+			{
+				get
+				{
+					_cachedChildren ??= Children;
+					return _cachedChildren;
+				}
+			}
+
 			public FlyoutPanel()
 			{
 			}
@@ -377,7 +390,7 @@ namespace Microsoft.Maui.Platform
 			public double ContentWidth { get; set; }
 
 			FrameworkElement? FlyoutContent =>
-				Children.Count > 0 ? (FrameworkElement?)Children[0] : null;
+				CachedChildren.Count > 0 ? (FrameworkElement?)CachedChildren[0] : null;
 
 			protected override Size MeasureOverride(Size availableSize)
 			{

--- a/src/Core/src/Platform/Windows/RootPanel.cs
+++ b/src/Core/src/Platform/Windows/RootPanel.cs
@@ -1,5 +1,6 @@
 ﻿#nullable enable
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Maui.Graphics;
 using Microsoft.UI.Xaml.Controls;
 
@@ -10,6 +11,18 @@ namespace Microsoft.Maui.Platform
 	{
 		internal Func<double, double, Size>? CrossPlatformMeasure { get; set; }
 		internal Func<Rect, Size>? CrossPlatformArrange { get; set; }
+
+		UIElementCollection? _cachedChildren;
+
+		[SuppressMessage("ApiDesign", "RS0030:Do not use banned APIs", Justification = "Panel.Children property is banned to enforce use of this CachedChildren property.")]
+		internal UIElementCollection CachedChildren
+		{
+			get
+			{
+				_cachedChildren ??= Children;
+				return _cachedChildren;
+			}
+		}
 
 		protected override global::Windows.Foundation.Size MeasureOverride(global::Windows.Foundation.Size availableSize)
 		{
@@ -29,7 +42,7 @@ namespace Microsoft.Maui.Platform
 			var size = new global::Windows.Foundation.Size(width, height);
 
 			// Measure the children (should only be one, the Page)
-			foreach (var child in Children)
+			foreach (var child in CachedChildren)
 			{
 				child.Measure(size);
 			}
@@ -39,7 +52,7 @@ namespace Microsoft.Maui.Platform
 
 		protected override global::Windows.Foundation.Size ArrangeOverride(global::Windows.Foundation.Size finalSize)
 		{
-			foreach (var child in Children)
+			foreach (var child in CachedChildren)
 			{
 				child.Arrange(new global::Windows.Foundation.Rect(new global::Windows.Foundation.Point(0, 0), finalSize));
 			}

--- a/src/Core/src/Platform/Windows/WindowRootViewContainer.cs
+++ b/src/Core/src/Platform/Windows/WindowRootViewContainer.cs
@@ -1,6 +1,4 @@
-using System;
-using Microsoft.Maui.Graphics.Platform;
-using Microsoft.Maui.Graphics.Win2D;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Windows.Foundation;
@@ -10,6 +8,18 @@ namespace Microsoft.Maui.Platform
 	internal class WindowRootViewContainer : Panel
 	{
 		FrameworkElement? _topPage;
+		UIElementCollection? _cachedChildren;
+
+		[SuppressMessage("ApiDesign", "RS0030:Do not use banned APIs", Justification = "Panel.Children property is banned to enforce use of this CachedChildren property.")]
+		internal UIElementCollection CachedChildren
+		{
+			get
+			{
+				_cachedChildren ??= Children;
+				return _cachedChildren;
+			}
+		}
+
 		protected override Size MeasureOverride(Size availableSize)
 		{
 			var width = availableSize.Width;
@@ -24,7 +34,7 @@ namespace Microsoft.Maui.Platform
 			var size = new Size(width, height);
 
 			// measure the children to fit the container exactly
-			foreach (var child in Children)
+			foreach (var child in CachedChildren)
 			{
 				child.Measure(size);
 			}
@@ -34,7 +44,7 @@ namespace Microsoft.Maui.Platform
 
 		protected override Size ArrangeOverride(Size finalSize)
 		{
-			foreach (var child in Children)
+			foreach (var child in CachedChildren)
 			{
 				child.Arrange(new Rect(new Point(0, 0), finalSize));
 			}
@@ -44,13 +54,13 @@ namespace Microsoft.Maui.Platform
 
 		internal void AddPage(FrameworkElement pageView)
 		{
-			if (!Children.Contains(pageView))
+			if (!CachedChildren.Contains(pageView))
 			{
 				int indexOFTopPage = 0;
 				if (_topPage != null)
-					indexOFTopPage = Children.IndexOf(_topPage) + 1;
+					indexOFTopPage = CachedChildren.IndexOf(_topPage) + 1;
 
-				Children.Insert(indexOFTopPage, pageView);
+				CachedChildren.Insert(indexOFTopPage, pageView);
 				_topPage = pageView;
 			}
 		}
@@ -59,25 +69,25 @@ namespace Microsoft.Maui.Platform
 		{
 			int indexOFTopPage = -1;
 			if (_topPage != null)
-				indexOFTopPage = Children.IndexOf(_topPage) - 1;
+				indexOFTopPage = CachedChildren.IndexOf(_topPage) - 1;
 
-			Children.Remove(pageView);
+			CachedChildren.Remove(pageView);
 
 			if (indexOFTopPage >= 0)
-				_topPage = (FrameworkElement)Children[indexOFTopPage];
+				_topPage = (FrameworkElement)CachedChildren[indexOFTopPage];
 			else
 				_topPage = null;
 		}
 
 		internal void AddOverlay(FrameworkElement overlayView)
 		{
-			if (!Children.Contains(overlayView))
-				Children.Add(overlayView);
+			if (!CachedChildren.Contains(overlayView))
+				CachedChildren.Add(overlayView);
 		}
 
 		internal void RemoveOverlay(FrameworkElement overlayView)
 		{
-			Children.Remove(overlayView);
+			CachedChildren.Remove(overlayView);
 		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/Layout/LayoutHandlerTests.Windows.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Layout/LayoutHandlerTests.Windows.cs
@@ -17,21 +17,21 @@ namespace Microsoft.Maui.DeviceTests.Handlers.Layout
 
 		double GetNativeChildCount(LayoutHandler layoutHandler)
 		{
-			return layoutHandler.PlatformView.Children.Count;
+			return layoutHandler.PlatformView.CachedChildren.Count;
 		}
 
 		double GetNativeChildCount(object platformView)
 		{
-			return (platformView as LayoutPanel).Children.Count;
+			return (platformView as LayoutPanel).CachedChildren.Count;
 		}
 
 		IReadOnlyList<UIElement> GetNativeChildren(LayoutHandler layoutHandler)
 		{
 			var views = new List<UIElement>();
 
-			for (int i = 0; i < layoutHandler.PlatformView.Children.Count; i++)
+			for (int i = 0; i < layoutHandler.PlatformView.CachedChildren.Count; i++)
 			{
-				views.Add(layoutHandler.PlatformView.Children[i]);
+				views.Add(layoutHandler.PlatformView.CachedChildren[i]);
 			}
 
 			return views;

--- a/src/Core/tests/DeviceTests/Handlers/Page/PageHandlerTests.Windows.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Page/PageHandlerTests.Windows.cs
@@ -10,9 +10,11 @@ namespace Microsoft.Maui.DeviceTests
 			int childCount = 0;
 			if (handler.PlatformView is ContentPanel view)
 			{
-				childCount = view.Children.Count;
+				childCount = view.CachedChildren.Count;
 				if (childCount == 1)
-					return view.Children[0];
+				{
+					return view.CachedChildren[0];
+				}
 			}
 
 			Assert.Equal(1, childCount);

--- a/src/Core/tests/DeviceTests/Handlers/Window/WindowHandlerTests.Windows.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Window/WindowHandlerTests.Windows.cs
@@ -140,7 +140,7 @@ namespace Microsoft.Maui.DeviceTests
 				var navigation = GetRootNavigationView(handler);
 				var page = Assert.IsType<ContentPanel>(navigation.Content);
 
-				var btn = Assert.IsAssignableFrom<UI.Xaml.Controls.TextBlock>(page.Children[0]);
+				var btn = Assert.IsAssignableFrom<UI.Xaml.Controls.TextBlock>(page.CachedChildren[0]);
 
 				Assert.Equal("Yay!", btn.Text);
 			});
@@ -157,7 +157,7 @@ namespace Microsoft.Maui.DeviceTests
 				var page = Assert.IsType<ContentPanel>(navigation.Content);
 
 				Assert.Null(page.Content);
-				Assert.Empty(page.Children);
+				Assert.Empty(page.CachedChildren);
 			});
 		}
 
@@ -179,9 +179,9 @@ namespace Microsoft.Maui.DeviceTests
 
 			var container = Assert.IsType<WindowRootViewContainer>(rootContainer);
 
-			Assert.NotEmpty(container.Children);
+			Assert.NotEmpty(container.CachedChildren);
 
-			var root = Assert.IsType<WindowRootView>(container.Children[0]);
+			var root = Assert.IsType<WindowRootView>(container.CachedChildren[0]);
 			var navigation = Assert.IsType<RootNavigationView>(root.Content);
 
 			return navigation;


### PR DESCRIPTION
### Description of Change

I've been scratching my head how to improve performance of `LayoutHandler` and it seems that storing `Children` of `PlatformView` leads to a significant performance gain in my test scenario (#21787). This PR is a replacement for #26161 that implements @mattleibow's [suggestion](https://github.com/dotnet/maui/pull/26161#discussion_r1874227689) from the previous PR. Interestingly, the suggestion allows to easily use `CachedChildren` in more places and thus improve performance a bit more.

[Explanation](https://github.com/dotnet/maui/pull/26161#discussion_r1873739247) from @Sergio0694:

> > "Do we have an idea what the property [i.e. Panel.Children] does underneath?"
> 
> Assuming that's some WinUI `Panel` control, accessing that property will invoke the `get_Children` method on the native WinRT object, then marshal the returned `IInspectable*` pointer to a C# object (ie. it'll go find the existing RCW for it, or create a new one if it doesn't exist already).

#### Speedscope

* main: [1733654186..speedscope.MAIN.json](https://github.com/user-attachments/files/18051680/1733654186.speedscope.MAIN.json)
* PR: [1733653984..speedscope.PR.json](https://github.com/user-attachments/files/18051679/1733653984.speedscope.PR.json)

![image](https://github.com/user-attachments/assets/38efbac7-59fe-498e-87f1-670d77b16617)

-> 97% improvement for `IPanelMethods.get_Children`.

### Issues Fixed

Contributes to #21787