### PR TITLE
[Android] Use a GeneralWrapperView for a Flyout View

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue26392.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue26392.cs
@@ -1,0 +1,46 @@
+﻿namespace Maui.Controls.Sample.Issues
+{
+	[Issue(IssueTracker.Github, 26392, "Click on flyout clicks on page behind", PlatformAffected.Android)]
+	public class Issue26392 : FlyoutPage
+	{
+		public Issue26392()
+		{
+			var label = new Label()
+			{
+				Text = "Button behind flyout was not clicked",
+				AutomationId = "ActionLabel"
+			};
+
+			Flyout = new ContentPage()
+			{
+				Title = "Flyout",
+				Content = new StackLayout()
+				{
+					Children =
+					{
+						label,
+						new Button()
+						{
+							Margin = new Thickness(0, 50, 0, 0),
+							InputTransparent = true,
+							Text = "Transparent button",
+							AutomationId="ButtonInFlyout"
+						}
+					}
+				}
+			};
+
+			Detail = new NavigationPage(new ContentPage()
+			{
+				Title = "Main Page",
+				Content = new Button()
+				{
+					Text = "Click me",
+					Command = new Command(() => label.Text = "Button in detail was clicked"),
+				}
+			});
+
+			IsPresented = true;
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue26392.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue26392.cs
@@ -1,0 +1,26 @@
+﻿using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue26392 : _IssuesUITest
+	{
+		public Issue26392(TestDevice testDevice) : base(testDevice)
+		{
+		}
+
+		public override string Issue => "Click on flyout clicks on page behind";
+
+		[Test]
+		[Category(UITestCategories.FlyoutPage)]
+		public void ClickThroughFlyoutShouldBeImpossible()
+		{
+			App.WaitForElement("ButtonInFlyout");
+			App.Click("ButtonInFlyout");
+
+			var actionLabelText = App.WaitForElement("ActionLabel").GetText();
+			Assert.That(actionLabelText, Is.EqualTo("Button behind flyout was not clicked"));
+		}
+	}
+}

--- a/src/Core/src/Handlers/FlyoutView/FlyoutViewHandler.Android.cs
+++ b/src/Core/src/Handlers/FlyoutView/FlyoutViewHandler.Android.cs
@@ -1,18 +1,15 @@
 ﻿using System;
-using System.Threading.Tasks;
-using Android.App.Roles;
+using Android.Content;
 using Android.Runtime;
 using Android.Views;
 using AndroidX.AppCompat.Widget;
 using AndroidX.DrawerLayout.Widget;
-using AndroidX.Fragment.App;
-using AndroidX.Lifecycle;
 
 namespace Microsoft.Maui.Handlers
 {
 	public partial class FlyoutViewHandler : ViewHandler<IFlyoutView, View>
 	{
-		View? _flyoutView;
+		FlyoutContainer? _flyoutView;
 		const uint DefaultScrimColor = 0x99000000;
 		View? _navigationRoot;
 		LinearLayoutCompat? _sideBySideView;
@@ -118,18 +115,15 @@ namespace Microsoft.Maui.Handlers
 		void UpdateFlyout()
 		{
 			_ = MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
-			_ = VirtualView.Flyout.ToPlatform(MauiContext);
 
-			var newFlyoutView = VirtualView.Flyout.ToPlatform();
-			if (_flyoutView == newFlyoutView)
-				return;
-
-			if (_flyoutView != null)
-				_flyoutView.RemoveFromParent();
-
-			_flyoutView = newFlyoutView;
-			if (_flyoutView == null)
-				return;
+			if (_flyoutView is null)
+			{
+				_flyoutView = new FlyoutContainer(Context, VirtualView.Flyout, MauiContext);
+			}
+			else
+			{
+				_flyoutView.UpdatePlatformView(VirtualView.Flyout, MauiContext);
+			}
 
 			if (VirtualView.Flyout.Background == null && Context?.Theme != null)
 			{
@@ -371,6 +365,17 @@ namespace Microsoft.Maui.Handlers
 		{
 			if (handler is FlyoutViewHandler platformHandler)
 				platformHandler.UpdateFlyoutBehavior();
+		}
+
+		internal class FlyoutContainer : GeneralWrapperView
+		{
+			public FlyoutContainer(Context context, IView childView, IMauiContext mauiContext) : base(context, childView, mauiContext) { }
+
+			public override bool OnTouchEvent(MotionEvent? e)
+			{
+				// Disable click-through on items behind the drawer
+				return true;
+			}
 		}
 	}
 }

--- a/src/Core/src/Platform/Android/GeneralWrapperView.cs
+++ b/src/Core/src/Platform/Android/GeneralWrapperView.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using Android.Content;
+
+namespace Microsoft.Maui.Platform;
+
+class GeneralWrapperView : ContentViewGroup, ICrossPlatformLayout
+{
+	public WeakReference<IView>? ChildView { get; private set; }
+
+	public GeneralWrapperView(Context context, IView childView, IMauiContext mauiContext) : base(context)
+	{
+		CrossPlatformLayout = this;
+		UpdatePlatformView(childView, mauiContext);
+	}
+
+	public void Disconnect()
+	{
+		if (ChildView == null || !ChildView.TryGetTarget(out var childView))
+		{
+			return;
+		}
+
+		if (ChildCount > 0)
+		{
+			GetChildAt(0)?.RemoveFromParent();
+		}
+
+		childView.DisconnectHandlers();
+	}
+
+	public void UpdatePlatformView(IView? newChildView, IMauiContext mauiContext)
+	{
+		if (ChildCount > 0)
+		{
+			GetChildAt(0)?.RemoveFromParent();
+		}
+
+		if (newChildView is null)
+		{
+			ChildView = null;
+			return;
+		}
+
+		ChildView = new(newChildView);
+		var nativeView = newChildView.ToPlatform(mauiContext);
+		AddView(nativeView);
+	}
+
+	Graphics.Size ICrossPlatformLayout.CrossPlatformMeasure(double widthConstraint, double heightConstraint)
+	{
+		if (ChildView == null || !ChildView.TryGetTarget(out var childView))
+			return Graphics.Size.Zero;
+
+		return childView.Measure(widthConstraint, heightConstraint);
+	}
+
+	public Graphics.Size CrossPlatformArrange(Graphics.Rect bounds)
+	{
+		if (ChildView == null || !ChildView.TryGetTarget(out var childView))
+			return Graphics.Size.Zero;
+		return childView.Arrange(new Graphics.Rect(0, 0, bounds.Width, bounds.Height));
+
+	}
+}


### PR DESCRIPTION
### Description of Change

### Introduction of `GeneralWrapperView`:

Added a new GeneralWrapperView class in src/Controls/src/Core/Platform/Android/GeneralWrapperView.cs to handle the wrapping of views, enabling better measurement and arrangement. Like in this PR: https://github.com/dotnet/maui/pull/26513

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/26392

|Before|After|
|--|--|
|<video src="https://github.com/user-attachments/assets/8beda2ab-6df4-4e2d-8ac8-ac5dcdfedecc" width="300px"/>|<video src="https://github.com/user-attachments/assets/57025fbc-f795-413d-a7fe-df71b3a119e5" width="300px"/>|