### PR TITLE
Fix Incorrect First and Last Visible Item index in CollectionView Scrolled Event

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/Android/RecyclerViewScrollListener.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/RecyclerViewScrollListener.cs
@@ -1,4 +1,5 @@
 ﻿#nullable disable
+using System;
 using AndroidX.RecyclerView.Widget;
 
 namespace Microsoft.Maui.Controls.Handlers.Items
@@ -87,6 +88,52 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				lastVisibleItemIndex = linearLayoutManager.FindLastVisibleItemPosition();
 				centerItemIndex = recyclerView.CalculateCenterItemIndex(firstVisibleItemIndex, linearLayoutManager, _getCenteredItemOnXAndY);
 			}
+
+			var hasHeader = ItemsViewAdapter.ItemsSource.HasHeader;
+			var hasFooter = ItemsViewAdapter.ItemsSource.HasFooter;
+			var itemsCount = ItemsViewAdapter.ItemCount;
+
+			if (firstVisibleItemIndex == 0 && lastVisibleItemIndex == itemsCount - 1)
+			{
+				lastVisibleItemIndex -= 2;
+			}
+			else
+			{
+				if (hasHeader && !hasFooter)
+				{
+					lastVisibleItemIndex -= 1;
+					if (firstVisibleItemIndex != 0)
+					{
+						firstVisibleItemIndex -= 1;
+					}
+				}
+				else if (!hasHeader && hasFooter)
+				{
+					if (lastVisibleItemIndex == itemsCount - 1)
+					{
+						lastVisibleItemIndex -= 1;
+						firstVisibleItemIndex -= 1;
+					}
+				}
+				else if (hasHeader && hasFooter)
+				{
+					if (firstVisibleItemIndex == 0)
+					{
+						lastVisibleItemIndex -= 1;
+					}
+					else if (firstVisibleItemIndex != 0 && lastVisibleItemIndex != itemsCount - 1)
+					{
+						firstVisibleItemIndex -= 1;
+						lastVisibleItemIndex -= 1;
+					}
+					else
+					{
+						firstVisibleItemIndex -= 1;
+						lastVisibleItemIndex -= 2;
+					}
+				}
+			}
+
 			return (firstVisibleItemIndex, centerItemIndex, lastVisibleItemIndex);
 		}
 

--- a/src/Controls/src/Core/Handlers/Items/Android/RecyclerViewScrollListener.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/RecyclerViewScrollListener.cs
@@ -100,24 +100,14 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 			if (firstVisibleItemIndex == 0 && lastVisibleItemIndex == itemsCount - 1)
 			{
-				if (hasHeader && hasFooter)
-				{
-					lastVisibleItemIndex -= itemsCount > 2 ? 2 : 1;
-				}
-				else if (hasHeader || hasFooter)
-				{
-					lastVisibleItemIndex -= itemsCount > 1 ? 1 : lastVisibleItemIndex;
-				}
+				lastVisibleItemIndex -= hasHeader && hasFooter ? 2 : 1;
 			}
 			else
 			{
 				if (hasHeader && !hasFooter)
 				{
 					lastVisibleItemIndex -= 1;
-					if (firstVisibleItemIndex != 0)
-					{
-						firstVisibleItemIndex -= 1;
-					}
+					firstVisibleItemIndex -= 1;
 				}
 				else if (!hasHeader && hasFooter)
 				{
@@ -132,7 +122,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 					{
 						lastVisibleItemIndex -= 1;
 					}
-					else if (firstVisibleItemIndex != 0 && lastVisibleItemIndex != itemsCount - 1)
+					else if (lastVisibleItemIndex != itemsCount - 1)
 					{
 						firstVisibleItemIndex -= 1;
 						lastVisibleItemIndex -= 1;
@@ -143,6 +133,16 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 						lastVisibleItemIndex -= 2;
 					}
 				}
+			}
+
+			if (firstVisibleItemIndex < 0)
+			{
+				firstVisibleItemIndex = 0;
+			}
+
+			if (lastVisibleItemIndex < 0)
+			{
+				lastVisibleItemIndex = 0;
 			}
 
 			return (firstVisibleItemIndex, centerItemIndex, lastVisibleItemIndex);

--- a/src/Controls/src/Core/Handlers/Items/Android/RecyclerViewScrollListener.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/RecyclerViewScrollListener.cs
@@ -89,13 +89,25 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				centerItemIndex = recyclerView.CalculateCenterItemIndex(firstVisibleItemIndex, linearLayoutManager, _getCenteredItemOnXAndY);
 			}
 
-			var hasHeader = ItemsViewAdapter.ItemsSource.HasHeader;
-			var hasFooter = ItemsViewAdapter.ItemsSource.HasFooter;
-			var itemsCount = ItemsViewAdapter.ItemCount;
+			bool hasHeader = ItemsViewAdapter.ItemsSource.HasHeader;
+			bool hasFooter = ItemsViewAdapter.ItemsSource.HasFooter;
+			int itemsCount = ItemsViewAdapter.ItemCount;
+
+			if (!hasHeader && !hasFooter)
+			{
+				return (firstVisibleItemIndex, centerItemIndex, lastVisibleItemIndex);
+			}
 
 			if (firstVisibleItemIndex == 0 && lastVisibleItemIndex == itemsCount - 1)
 			{
-				lastVisibleItemIndex -= 2;
+				if (hasHeader && hasFooter)
+				{
+					lastVisibleItemIndex -= itemsCount > 2 ? 2 : 1;
+				}
+				else if (hasHeader || hasFooter)
+				{
+					lastVisibleItemIndex -= itemsCount > 1 ? 1 : lastVisibleItemIndex;
+				}
 			}
 			else
 			{

--- a/src/Controls/src/Core/Handlers/Items/Android/RecyclerViewScrollListener.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/RecyclerViewScrollListener.cs
@@ -1,5 +1,5 @@
 ﻿#nullable disable
-using System;
+
 using AndroidX.RecyclerView.Widget;
 
 namespace Microsoft.Maui.Controls.Handlers.Items

--- a/src/Controls/src/Core/Handlers/Items/Android/RecyclerViewScrollListener.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/RecyclerViewScrollListener.cs
@@ -112,7 +112,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 					if (lastVisibleItemIndex == itemsCount - 1)
 					{
 						lastVisibleItemIndex -= 1;
-						firstVisibleItemIndex -= 1;
 					}
 				}
 				else if (hasHeader && hasFooter)

--- a/src/Controls/src/Core/Handlers/Items/Android/RecyclerViewScrollListener.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/RecyclerViewScrollListener.cs
@@ -1,5 +1,4 @@
 ﻿#nullable disable
-
 using AndroidX.RecyclerView.Widget;
 
 namespace Microsoft.Maui.Controls.Handlers.Items

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue25649.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue25649.xaml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Maui.Controls.Sample.Issues.Issue25649"
+             xmlns:local="clr-namespace:Maui.Controls.Sample.Issues">
+
+    <ContentPage.BindingContext>
+        <local:_25649MainViewModel/>
+    </ContentPage.BindingContext>
+
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="0.8*"/>
+            <RowDefinition Height="0.2*"/>
+        </Grid.RowDefinitions>
+
+        <CollectionView AutomationId="collectionView"
+                        x:DataType="local:_25649MainViewModel"
+                        ItemsSource="{Binding _25649People}"
+                        Scrolled="OnCollectionViewScrolled"
+                        BackgroundColor="DarkGray">
+            <CollectionView.ItemsLayout>
+                <LinearItemsLayout Orientation="Vertical"
+                                   SnapPointsType="Mandatory"/>
+            </CollectionView.ItemsLayout>
+
+            <CollectionView.Header>
+                <StackLayout BackgroundColor="LightGray">
+                    <Label Margin="10,0,0,0"
+                           Text="People"
+                           FontSize="12"
+                           FontAttributes="Bold"/>
+                </StackLayout>
+            </CollectionView.Header>
+
+            <CollectionView.ItemTemplate>
+                <DataTemplate x:DataType="local:_25649Person">
+                    <VerticalStackLayout>
+                        <Label Text="{Binding Name}"
+                               FontSize="Medium"/>
+                        <Rectangle HeightRequest="2"
+                                   BackgroundColor="Black"/>
+                    </VerticalStackLayout>
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+
+            <CollectionView.Footer>
+                <StackLayout BackgroundColor="LightGray">
+                    <Label Margin="10,0,0,0"
+                           Text="Footer"
+                           FontSize="12"
+                           FontAttributes="Bold"/>
+                </StackLayout>
+            </CollectionView.Footer>
+        </CollectionView>
+
+        <Label Grid.Row="1"
+               x:Name="labelFirstLastVisible"
+               Text="Index of First and Last Visible Items"
+               HorizontalOptions="Start"
+               VerticalOptions="Center"/>
+    </Grid>
+</ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue25649.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue25649.xaml
@@ -54,23 +54,13 @@
             </CollectionView.Footer>
         </CollectionView>
 
-        <StackLayout Grid.Row="1">
-            <Label
-                x:Name="firstVisibleItemIndex"
-                AutomationId="FirstVisibleItemIndex"
-                Text="First Visible Item Index"
-                HorizontalOptions="Start"
-                VerticalOptions="Center"/>
-
-            <Label
-                x:Name="lastVisibleItemIndex"
-                AutomationId="LastVisibleItemIndex"
-                Text="Last Visible Item Index"
-                HorizontalOptions="Start"
-                VerticalOptions="Center"/>
-
-        </StackLayout>
-
+        <Label
+            x:Name="lastVisibleItemIndex"
+            Grid.Row="1"
+            AutomationId="LastVisibleItemIndex"
+            Text="Last Visible Item Index"
+            HorizontalOptions="Start"
+            VerticalOptions="Center"/>
 
     </Grid>
 </ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue25649.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue25649.xaml
@@ -54,10 +54,23 @@
             </CollectionView.Footer>
         </CollectionView>
 
-        <Label Grid.Row="1"
-               x:Name="labelFirstLastVisible"
-               Text="Index of First and Last Visible Items"
-               HorizontalOptions="Start"
-               VerticalOptions="Center"/>
+        <StackLayout Grid.Row="1">
+            <Label
+                x:Name="firstVisibleItemIndex"
+                AutomationId="FirstVisibleItemIndex"
+                Text="First Visible Item Index"
+                HorizontalOptions="Start"
+                VerticalOptions="Center"/>
+
+            <Label
+                x:Name="lastVisibleItemIndex"
+                AutomationId="LastVisibleItemIndex"
+                Text="Last Visible Item Index"
+                HorizontalOptions="Start"
+                VerticalOptions="Center"/>
+
+        </StackLayout>
+
+
     </Grid>
 </ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue25649.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue25649.xaml.cs
@@ -1,0 +1,92 @@
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Windows.Input;
+
+namespace Maui.Controls.Sample.Issues
+{
+	[Issue(IssueTracker.Github, 25649, "CollectionView OnCollectionViewScrolled Calls and parameters are inconsistent or incorrect", PlatformAffected.All)]
+	public partial class Issue25649 : ContentPage
+	{
+		public Issue25649()
+		{
+			InitializeComponent();
+		}
+
+		private void OnCollectionViewScrolled(object sender, ItemsViewScrolledEventArgs e)
+		{
+			labelFirstLastVisible.Text = $"Scrolled: {e.FirstVisibleItemIndex} to {e.LastVisibleItemIndex}";
+		}
+	}
+
+	public class _25649MainViewModel : BindableObject
+	{
+		public ObservableCollection<_25649Person> _25649People { get; set; }
+		public _25649MainViewModel()
+		{
+
+			_25649People = new ObservableCollection<_25649Person>()
+			{
+				new _25649Person() { Name = "Person 0" },
+				new _25649Person() { Name = "Person 1" },
+				new _25649Person() { Name = "Person 2" },
+				new _25649Person() { Name = "Person 3" },
+				new _25649Person() { Name = "Person 4" },
+				new _25649Person() { Name = "Person 5" },
+				new _25649Person() { Name = "Person 6" },
+				new _25649Person() { Name = "Person 7" },
+				new _25649Person() { Name = "Person 8" },
+				new _25649Person() { Name = "Person 9" },
+				new _25649Person() { Name = "Person 10" },
+				new _25649Person() { Name = "Person 11" },
+				new _25649Person() { Name = "Person 12" },
+				new _25649Person() { Name = "Person 13" },
+				new _25649Person() { Name = "Person 14" },
+				new _25649Person() { Name = "Person 15" },
+				new _25649Person() { Name = "Person 16" },
+				new _25649Person() { Name = "Person 17" },
+				new _25649Person() { Name = "Person 18" },
+				new _25649Person() { Name = "Person 19" },
+				new _25649Person() { Name = "Person 20" },
+				new _25649Person() { Name = "Person 21" },
+				new _25649Person() { Name = "Person 22" },
+				new _25649Person() { Name = "Person 23" },
+				new _25649Person() { Name = "Person 24" },
+				new _25649Person() { Name = "Person 25" },
+				new _25649Person() { Name = "Person 26" },
+				new _25649Person() { Name = "Person 27" },
+				new _25649Person() { Name = "Person 28" },
+				new _25649Person() { Name = "Person 29" },
+				new _25649Person() { Name = "Person 30" },
+				new _25649Person() { Name = "Person 31" },
+				new _25649Person() { Name = "Person 32" },
+				new _25649Person() { Name = "Person 33" },
+				new _25649Person() { Name = "Person 34" },
+				new _25649Person() { Name = "Person 35" },
+				new _25649Person() { Name = "Person 36" },
+				new _25649Person() { Name = "Person 37" },
+				new _25649Person() { Name = "Person 38" },
+				new _25649Person() { Name = "Person 39" },
+				new _25649Person() { Name = "Person 40" },
+				new _25649Person() { Name = "Person 41" },
+				new _25649Person() { Name = "Person 42" },
+				new _25649Person() { Name = "Person 43" },
+				new _25649Person() { Name = "Person 44" },
+				new _25649Person() { Name = "Person 45" },
+				new _25649Person() { Name = "Person 46" },
+				new _25649Person() { Name = "Person 47" },
+				new _25649Person() { Name = "Person 48" },
+				new _25649Person() { Name = "Person 49" },
+				new _25649Person() { Name = "Person 50" },
+
+			};
+		}
+	}
+
+	public class _25649Person
+	{
+		public string Name { get; set; }
+	}
+}
+
+
+

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue25649.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue25649.xaml.cs
@@ -12,7 +12,7 @@ namespace Maui.Controls.Sample.Issues
 			InitializeComponent();
 		}
 
-		private void OnCollectionViewScrolled(object sender, ItemsViewScrolledEventArgs e)
+		void OnCollectionViewScrolled(object sender, ItemsViewScrolledEventArgs e)
 		{
 			labelFirstLastVisible.Text = $"Scrolled: {e.FirstVisibleItemIndex} to {e.LastVisibleItemIndex}";
 		}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue25649.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue25649.xaml.cs
@@ -14,7 +14,8 @@ namespace Maui.Controls.Sample.Issues
 
 		void OnCollectionViewScrolled(object sender, ItemsViewScrolledEventArgs e)
 		{
-			labelFirstLastVisible.Text = $"Scrolled: {e.FirstVisibleItemIndex} to {e.LastVisibleItemIndex}";
+			firstVisibleItemIndex.Text = e.FirstVisibleItemIndex.ToString();
+			lastVisibleItemIndex.Text = e.LastVisibleItemIndex.ToString();
 		}
 	}
 
@@ -57,27 +58,6 @@ namespace Maui.Controls.Sample.Issues
 				new _25649Person() { Name = "Person 28" },
 				new _25649Person() { Name = "Person 29" },
 				new _25649Person() { Name = "Person 30" },
-				new _25649Person() { Name = "Person 31" },
-				new _25649Person() { Name = "Person 32" },
-				new _25649Person() { Name = "Person 33" },
-				new _25649Person() { Name = "Person 34" },
-				new _25649Person() { Name = "Person 35" },
-				new _25649Person() { Name = "Person 36" },
-				new _25649Person() { Name = "Person 37" },
-				new _25649Person() { Name = "Person 38" },
-				new _25649Person() { Name = "Person 39" },
-				new _25649Person() { Name = "Person 40" },
-				new _25649Person() { Name = "Person 41" },
-				new _25649Person() { Name = "Person 42" },
-				new _25649Person() { Name = "Person 43" },
-				new _25649Person() { Name = "Person 44" },
-				new _25649Person() { Name = "Person 45" },
-				new _25649Person() { Name = "Person 46" },
-				new _25649Person() { Name = "Person 47" },
-				new _25649Person() { Name = "Person 48" },
-				new _25649Person() { Name = "Person 49" },
-				new _25649Person() { Name = "Person 50" },
-
 			};
 		}
 	}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue25649.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue25649.xaml.cs
@@ -14,7 +14,6 @@ namespace Maui.Controls.Sample.Issues
 
 		void OnCollectionViewScrolled(object sender, ItemsViewScrolledEventArgs e)
 		{
-			firstVisibleItemIndex.Text = e.FirstVisibleItemIndex.ToString();
 			lastVisibleItemIndex.Text = e.LastVisibleItemIndex.ToString();
 		}
 	}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25649.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25649.cs
@@ -1,0 +1,24 @@
+﻿using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue25649 : _IssuesUITest
+	{
+		public Issue25649(TestDevice testDevice) : base(testDevice)
+		{
+		}
+
+		public override string Issue => "CollectionView OnCollectionViewScrolled Calls and parameters are inconsistent or incorrect";
+
+		[Test]
+		[Category(UITestCategories.CollectionView)]
+		public void Issue25649Test()
+		{
+			App.WaitForElement("collectionView");
+			App.ScrollDown("collectionView");
+			VerifyScreenshot();
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25649.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25649.cs
@@ -14,23 +14,15 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 
 		public override string Issue => "CollectionView OnCollectionViewScrolled Calls and parameters are inconsistent or incorrect";
 
-
-#if IOS
-		private const string firstVisibleIndex = "5";
-#elif ANDROID
-		private const string firstVisibleIndex = "6";
-#elif WINDOWS
-		private const string firstVisibleIndex = "14";
-#endif
-
 		[Test]
 		[Category(UITestCategories.CollectionView)]
 		public void Issue25649Test()
 		{
 			App.WaitForElement("collectionView");
 			App.ScrollDown("collectionView", ScrollStrategy.Gesture, 0.99);
-			var firstVisibleItemIndex = App.FindElement("FirstVisibleItemIndex").GetText();
-			Assert.That(firstVisibleItemIndex, Is.EqualTo(firstVisibleIndex));
+
+			// The ScrollDown method returns a different FirstVisibleItemIndex values on each call, so it cannot be used for consistent test validation.
+
 			var lastVisibleItemIndex = App.FindElement("LastVisibleItemIndex").GetText();
 			Assert.That(lastVisibleItemIndex, Is.EqualTo("30"));
 		}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25649.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25649.cs
@@ -1,4 +1,6 @@
-﻿using NUnit.Framework;
+﻿#if !MACCATALYST
+
+using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
 
@@ -12,13 +14,26 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 
 		public override string Issue => "CollectionView OnCollectionViewScrolled Calls and parameters are inconsistent or incorrect";
 
+
+#if IOS
+		private const string firstVisibleIndex = "5";
+#elif ANDROID
+		private const string firstVisibleIndex = "6";
+#elif WINDOWS
+		private const string firstVisibleIndex = "14";
+#endif
+
 		[Test]
 		[Category(UITestCategories.CollectionView)]
 		public void Issue25649Test()
 		{
 			App.WaitForElement("collectionView");
-			App.ScrollDown("collectionView");
-			VerifyScreenshot();
+			App.ScrollDown("collectionView", ScrollStrategy.Gesture, 0.99);
+			var firstVisibleItemIndex = App.FindElement("FirstVisibleItemIndex").GetText();
+			Assert.That(firstVisibleItemIndex, Is.EqualTo(firstVisibleIndex));
+			var lastVisibleItemIndex = App.FindElement("LastVisibleItemIndex").GetText();
+			Assert.That(lastVisibleItemIndex, Is.EqualTo("30"));
 		}
 	}
 }
+#endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25649.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25649.cs
@@ -1,4 +1,4 @@
-﻿#if !MACCATALYST
+﻿#if TEST_FAILS_ON_CATALYST // Scroll actions do not work on MacCatalyst, so this test is ignored on MacCatalyst.
 
 using NUnit.Framework;
 using UITest.Appium;


### PR DESCRIPTION
### Issue Details
In the CollectionView, the Scrolled event parameters FirstVisibleItemIndex and LastVisibleItemIndex return incorrect values.

### Root Cause
The CollectionView includes the header at the zeroth index and the footer at the last index. As a result, the first and last visible item positions are updated without excluding the header and footer.
 
### Description of Change
Implemented logic to calculate the first and last visible item positions, excluding the header and footer.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #25649 

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->

### Validated the behaviour in the following platforms
 
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

### Output Screenshot
| Before  | After  |
|---------|--------|
|  <video src="https://github.com/user-attachments/assets/2a096581-b285-41af-a639-9026e5a9fdaf" width="320" height="240" controls></video>   |   <video src="https://github.com/user-attachments/assets/7ff7b301-c132-402c-905f-d73b1d6c4049" width="320" height="240" controls></video>   |
