### PR TITLE
Correct Button EventHandler signature in template

### DIFF
--- a/src/Templates/src/templates/maui-mobile/MainPage.xaml.cs
+++ b/src/Templates/src/templates/maui-mobile/MainPage.xaml.cs
@@ -9,7 +9,7 @@ public partial class MainPage : ContentPage
 		InitializeComponent();
 	}
 
-	private void OnCounterClicked(object sender, EventArgs e)
+	private void OnCounterClicked(object? sender, EventArgs e)
 	{
 		count++;
 
@@ -21,4 +21,3 @@ public partial class MainPage : ContentPage
 		SemanticScreenReader.Announce(CounterBtn.Text);
 	}
 }
-


### PR DESCRIPTION
### Description of Change

Add the correct [EventHandler signature](https://learn.microsoft.com/dotnet/api/system.eventhandler?view=net-9.0#definition) for the template taking into account nullability. While working on SourceGen, we came across the warning below. We've never seen that warning before because the event handler was never used from code, but with Source Generation it will be. Correcting this now to be more correct and anticipating on the Source Generation being built.

> error CS8622: Nullability of reference types in type of parameter 'sender' of 'void MainPage.OnCounterClicked(object sender, EventArgs e)' doesn't match the target delegate 'EventHandler' (possibly because of nullability attributes).

You can also trigger the warning by hooking the event from code, for example in the constructor of the `MainPage` like: `CounterBtn.Clicked += OnCounterClicked;`

Additionally removes one new line at the end of the file, there were 2, only 1 is enough.
