### PR TITLE
Move DataTemplateSelector to own file in template

### DIFF
--- a/src/Templates/src/templates/maui-mobile/Pages/Controls/ChipDataTemplateSelector.cs
+++ b/src/Templates/src/templates/maui-mobile/Pages/Controls/ChipDataTemplateSelector.cs
@@ -1,3 +1,5 @@
+using MauiApp._1.Models;
+
 namespace MauiApp._1.Pages.Controls;
 
 public class ChipDataTemplateSelector : DataTemplateSelector

--- a/src/Templates/src/templates/maui-mobile/Pages/Controls/ChipDataTemplateSelector.cs
+++ b/src/Templates/src/templates/maui-mobile/Pages/Controls/ChipDataTemplateSelector.cs
@@ -1,0 +1,12 @@
+namespace MauiApp._1.Pages.Controls;
+
+public class ChipDataTemplateSelector : DataTemplateSelector
+{
+	public required DataTemplate SelectedTagTemplate { get; set; }
+	public required DataTemplate NormalTagTemplate { get; set; }
+
+	protected override DataTemplate OnSelectTemplate(object item, BindableObject container)
+	{
+		return (item as Tag)?.IsSelected ?? false ? SelectedTagTemplate : NormalTagTemplate;
+	}
+}

--- a/src/Templates/src/templates/maui-mobile/Pages/ProjectDetailPage.xaml
+++ b/src/Templates/src/templates/maui-mobile/Pages/ProjectDetailPage.xaml
@@ -46,7 +46,7 @@
             </Border>
         </DataTemplate>
 
-        <pages:ChipDataTemplateSelector 
+        <controls:ChipDataTemplateSelector 
             x:Key="ChipDataTemplateSelector"
             NormalTagTemplate="{StaticResource NormalTagTemplate}"
             SelectedTagTemplate="{StaticResource SelectedTagTemplate}"/>

--- a/src/Templates/src/templates/maui-mobile/Pages/ProjectDetailPage.xaml.cs
+++ b/src/Templates/src/templates/maui-mobile/Pages/ProjectDetailPage.xaml.cs
@@ -11,14 +11,3 @@ public partial class ProjectDetailPage : ContentPage
 		BindingContext = model;
 	}
 }
-
-public class ChipDataTemplateSelector : DataTemplateSelector
-{
-	public required DataTemplate SelectedTagTemplate { get; set; }
-	public required DataTemplate NormalTagTemplate { get; set; }
-
-	protected override DataTemplate OnSelectTemplate(object item, BindableObject container)
-	{
-		return (item as Tag)?.IsSelected ?? false ? SelectedTagTemplate : NormalTagTemplate;
-	}
-}


### PR DESCRIPTION
### Description of Change

As per https://github.com/dotnet/maui/issues/25515, moving the `ChipDataTemplateSelector` into its own file

Also applied this to the sample app here: https://github.com/dotnet/maui-samples/pull/550

### Issues Fixed

Related to #25515