### PR TITLE
Remove Tizen people from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,10 +1,5 @@
 *       @dotnet/dotnet-maui-reviewers
 
-# Tizen (this probably doesn't work since these do not have write access
-**/Tizen @rookiejava @myroot @shyunmin @sung-su @JoonghyunCho
-*.tizen.cs @rookiejava @myroot @shyunmin @sung-su @JoonghyunCho
-*.Tizen.cs @rookiejava @myroot @shyunmin @sung-su @JoonghyunCho
-
 # Blazor Desktop
 /src/BlazorWebView/                                     @dotnet/dotnet-maui-blazor-eng
 /src/Templates/src/templates/maui-blazor/               @dotnet/dotnet-maui-blazor-eng


### PR DESCRIPTION
### Description of Change

Since they don't have write access it wasn't working anyway.

### Issues Fixed

Related #1747
