### PR TITLE
Add TJ as Localization chief in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,3 +4,9 @@
 /src/BlazorWebView/                                     @dotnet/dotnet-maui-blazor-eng
 /src/Templates/src/templates/maui-blazor/               @dotnet/dotnet-maui-blazor-eng
 /src/Templates/src/templates/maui-blazor-solution/      @dotnet/dotnet-maui-blazor-eng
+
+# Localization
+/eng/automation/LocProject.json                        @tj-devel709
+**/localize/*.json                                     @tj-devel709
+**/*.resx                                              @tj-devel709
+**.*.resx.lcl                                          @tj-devel709


### PR DESCRIPTION
### Description of Change

Adds @tj-devel709 as code owner for files that have to do with localization

### Issues Fixed

Related https://github.com/dotnet/maui/issues/1747
