### PR TITLE
[iOS] Use a GeneralWrapperView for the EmptyView on CollectionView

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
@@ -584,7 +584,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 					//Platform.GetRenderer(formsElement)?.DisposeRendererAndChildren();
 				}
 
-
 				uiView?.Dispose();
 				uiView = null;
 				formsElement?.Handler?.DisconnectHandler();

--- a/src/Controls/src/Core/Handlers/Items/iOS/TemplateHelpers.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/TemplateHelpers.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				// No template, and the EmptyView is a Maui view; use that
 				// But we need to wrap it in a GeneralWrapperView so it can be measured and arranged
 				var wrapperView = new GeneralWrapperView(mauiView, itemsView.FindMauiContext());
-
+				wrapperView.Frame = mauiView.Bounds.ToCGRect();
 				return (wrapperView, mauiView);
 			}
 

--- a/src/Controls/src/Core/Handlers/Items/iOS/TemplateHelpers.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/TemplateHelpers.cs
@@ -1,8 +1,7 @@
 #nullable disable
 using System;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui.Controls.Internals;
-using ObjCRuntime;
+using Microsoft.Maui.Controls.Platform;
 using UIKit;
 
 namespace Microsoft.Maui.Controls.Handlers.Items
@@ -55,10 +54,10 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				PropertyPropagationExtensions.PropagatePropertyChanged(null, formsView, itemsView);
 
 				// No template, and the EmptyView is a Forms view; use that
-				var renderer = GetHandler(formsView, itemsView.FindMauiContext());
-				var element = renderer.VirtualView as VisualElement;
+				// But we need to wrap it in a GeneralWrapperView so it can be measured and arranged
+				var wrapperView = new GeneralWrapperView(formsView, itemsView.FindMauiContext());
 
-				return ((UIView)renderer.PlatformView, element);
+				return (wrapperView, formsView);
 			}
 
 			return (new UILabel { TextAlignment = UITextAlignment.Center, Text = $"{view}" }, null);

--- a/src/Controls/src/Core/Handlers/Items/iOS/TemplateHelpers.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/TemplateHelpers.cs
@@ -48,16 +48,16 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				return ((UIView)renderer.PlatformView, element);
 			}
 
-			if (view is View formsView)
+			if (view is View mauiView)
 			{
 				// Make sure the Visual property is available when the renderer is created
-				PropertyPropagationExtensions.PropagatePropertyChanged(null, formsView, itemsView);
+				PropertyPropagationExtensions.PropagatePropertyChanged(null, mauiView, itemsView);
 
-				// No template, and the EmptyView is a Forms view; use that
+				// No template, and the EmptyView is a Maui view; use that
 				// But we need to wrap it in a GeneralWrapperView so it can be measured and arranged
-				var wrapperView = new GeneralWrapperView(formsView, itemsView.FindMauiContext());
+				var wrapperView = new GeneralWrapperView(mauiView, itemsView.FindMauiContext());
 
-				return (wrapperView, formsView);
+				return (wrapperView, mauiView);
 			}
 
 			return (new UILabel { TextAlignment = UITextAlignment.Center, Text = $"{view}" }, null);

--- a/src/Controls/src/Core/Handlers/Items2/iOS/TemplatedCell2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/TemplatedCell2.cs
@@ -4,6 +4,7 @@ using System.ComponentModel;
 using CoreGraphics;
 using Foundation;
 using Microsoft.Maui.Controls.Internals;
+using Microsoft.Maui.Controls.Platform;
 using Microsoft.Maui.Graphics;
 using UIKit;
 
@@ -126,7 +127,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 
 				if (needsContainer)
 				{
-					PlatformView = new UIContainerView2(virtualView, mauiContext);
+					PlatformView = new GeneralWrapperView(virtualView, mauiContext);
 				}
 				else
 				{
@@ -256,53 +257,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 			{
 				SelectedBackgroundView.BackgroundColor = UIColor.Clear;
 			}
-		}
-	}
-
-	class UIContainerView2 : UIView
-	{
-		readonly IView _view;
-		readonly IMauiContext _mauiContext;
-
-		public UIContainerView2(IView view, IMauiContext mauiContext)
-		{
-			_view = view;
-			_mauiContext = mauiContext;
-			UpdatePlatformView();
-		}
-
-		internal void UpdatePlatformView()
-		{
-			var handler = _view.ToHandler(_mauiContext);
-			var nativeView = _view.ToPlatform();
-
-			if (nativeView.Superview == this)
-			{
-				nativeView.RemoveFromSuperview();
-			}
-
-			if (nativeView is WrapperView)
-			{
-				// Disable clipping for WrapperView to allow the shadow to be displayed
-				ClipsToBounds = false;
-			}
-			else
-			{
-				ClipsToBounds = true;
-			}
-
-			AddSubview(nativeView);
-		}
-
-		public override void LayoutSubviews()
-		{
-			_view?.Arrange(new Rect(0, 0, Frame.Width, Frame.Height));
-			base.LayoutSubviews();
-		}
-
-		public override CGSize SizeThatFits(CGSize size)
-		{
-			return _view.Measure(size.Width, size.Height).ToCGSize();
 		}
 	}
 }

--- a/src/Controls/src/Core/Platform/iOS/GeneralWrapperView.cs
+++ b/src/Controls/src/Core/Platform/iOS/GeneralWrapperView.cs
@@ -1,0 +1,59 @@
+using System;
+using Microsoft.Maui.Graphics;
+
+namespace Microsoft.Maui.Controls.Platform;
+
+class GeneralWrapperView : MauiView, ICrossPlatformLayout
+{
+    //Make this a weakreference
+    public WeakReference<IView> ChildView { get; private set; }
+
+    public GeneralWrapperView(IView childView, IMauiContext context)
+    {
+        CrossPlatformLayout = this;
+        ChildView = new(childView);
+        UpdatePlatformView(childView, context);
+    }
+
+    internal void UpdatePlatformView(IView childView, IMauiContext context)
+    {
+        var nativeView = childView.ToPlatform(context);
+
+        if (nativeView.Superview == this)
+        {
+            nativeView.RemoveFromSuperview();
+        }
+
+        if (nativeView is WrapperView)
+        {
+            // Disable clipping for WrapperView to allow the shadow to be displayed
+            ClipsToBounds = false;
+        }
+        else
+        {
+            ClipsToBounds = true;
+        }
+
+        AddSubview(nativeView);
+    }
+
+    public Size CrossPlatformArrange(Rect bounds)
+    {
+        if (ChildView is null || !ChildView.TryGetTarget(out var childView))
+        {
+            return Size.Zero;
+        }
+
+        return childView.Arrange(bounds);
+    }
+
+    public Size CrossPlatformMeasure(double widthConstraint, double heightConstraint)
+    {
+        if (ChildView is null || !ChildView.TryGetTarget(out var childView))
+        {
+            return Size.Zero;
+        }
+
+        return childView.Measure(widthConstraint, heightConstraint);
+    }
+}


### PR DESCRIPTION
### Description of Change

When the empty view only had 1 button , no layout, it wasn't renderer correctly , the height was always 0. So we can reuse the same approach from CV2 , and reuse the code to fix both approaches for now. 

This pull request includes several changes to the iOS handlers and template helpers in the `src/Controls/src/Core/Handlers/Items` directory. The most significant changes involve the introduction of a new `GeneralWrapperView` class to replace `UIContainerView2` and updates to the handling of views in the `TemplateHelpers` and `TemplatedCell2` classes.

### Introduction of `GeneralWrapperView`:

* Added a new `GeneralWrapperView` class in `src/Controls/src/Core/Platform/iOS/GeneralWrapperView.cs` to handle the wrapping of views, enabling better measurement and arrangement.

### Updates to `TemplateHelpers`:

* Modified the `RealizeView` method in `TemplateHelpers.cs` to replace `UIContainerView2` with `GeneralWrapperView`, improving the handling of views without templates.
* Removed unnecessary `using` directives and added new ones to reflect the changes in dependencies.

### Updates to `TemplatedCell2`:

* Replaced instances of `UIContainerView2` with `GeneralWrapperView` in the `BindVirtualView` method to ensure consistent handling of views.
* Removed the `UIContainerView2` class from `TemplatedCell2.cs`, as it is now replaced by `GeneralWrapperView`.

### Minor Cleanup:

* Removed an unnecessary blank line in `ItemsViewController.cs` to maintain code cleanliness.

To test 
Test for issue https://github.com/dotnet/maui/issues/19609 should pass

### Issues Fixed

Fixes #26508 
