### PR TITLE
[iOS] Moved GeneralWrapperView from Controls to Core

### DIFF
--- a/src/Core/src/Platform/iOS/GeneralWrapperView.cs
+++ b/src/Core/src/Platform/iOS/GeneralWrapperView.cs
@@ -1,7 +1,7 @@
 using System;
 using Microsoft.Maui.Graphics;
 
-namespace Microsoft.Maui.Controls.Platform;
+namespace Microsoft.Maui.Platform;
 
 class GeneralWrapperView : MauiView, ICrossPlatformLayout
 {


### PR DESCRIPTION
@rmarinho I wanted to use a GeneralWrapperView here https://github.com/dotnet/maui/pull/25098, but realized it is in Controls. Maybe it should be in Core like the MAUI view?
