### PR TITLE
[Windows] Fix for Flyout Content Template not updating dynamically

### DIFF
--- a/src/Controls/src/Core/Handlers/Shell/ShellHandler.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellHandler.cs
@@ -22,7 +22,6 @@ namespace Microsoft.Maui.Controls.Handlers
 					[nameof(Shell.FlyoutBackground)] = MapFlyoutBackground,
 					[nameof(Shell.FlyoutBackgroundColor)] = MapFlyoutBackground,
 					[nameof(Shell.FlyoutContent)] = MapFlyout,
-					[nameof(Shell.FlyoutContentTemplate)] = MapFlyout,
 					[nameof(Shell.CurrentItem)] = MapCurrentItem,
 					[nameof(Shell.FlyoutBackdrop)] = MapFlyoutBackdrop,
 					[nameof(Shell.FlyoutFooter)] = MapFlyoutFooter,
@@ -34,6 +33,7 @@ namespace Microsoft.Maui.Controls.Handlers
 					[nameof(Shell.FlyoutItems)] = MapFlyoutItems,
 #if WINDOWS
 					[nameof(Shell.FlyoutIcon)] = MapFlyoutIcon,
+					[nameof(Shell.FlyoutContentTemplate)] = MapFlyout,
 #endif
 				};
 

--- a/src/Controls/src/Core/Handlers/Shell/ShellHandler.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellHandler.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Maui.Controls.Handlers
 					[nameof(Shell.FlyoutBackground)] = MapFlyoutBackground,
 					[nameof(Shell.FlyoutBackgroundColor)] = MapFlyoutBackground,
 					[nameof(Shell.FlyoutContent)] = MapFlyout,
+					[nameof(Shell.FlyoutContentTemplate)] = MapFlyout,
 					[nameof(Shell.CurrentItem)] = MapCurrentItem,
 					[nameof(Shell.FlyoutBackdrop)] = MapFlyoutBackdrop,
 					[nameof(Shell.FlyoutFooter)] = MapFlyoutFooter,

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/XFIssue/ShellFlyoutContent.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/XFIssue/ShellFlyoutContent.cs
@@ -1,5 +1,4 @@
-﻿#if TEST_FAILS_ON_WINDOWS // On Windows, the Shell Flyout Content Template does not update dynamically. Issue: https://github.com/dotnet/maui/issues/26435. 
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
 
@@ -27,5 +26,3 @@ public class ShellFlyoutContent : _IssuesUITest
 		App.Tap("FlyoutItem");
 	}
 }
-#endif
-

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/XFIssue/ShellFlyoutContent.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/XFIssue/ShellFlyoutContent.cs
@@ -6,6 +6,15 @@ namespace Microsoft.Maui.TestCases.Tests.Issues;
 
 public class ShellFlyoutContent : _IssuesUITest
 {
+
+#if WINDOWS //In Windows AutomationId for FlyoutItems not works in Appium.
+	const string FlyoutItem = "Flyout Item Top";
+	const string ResetButton = "Click to Reset";
+#else
+    const string FlyoutItem = "FlyoutItem";
+ 	const string ResetButton = "Reset";
+#endif
+
 	public ShellFlyoutContent(TestDevice testDevice) : base(testDevice)
 	{
 	}
@@ -17,12 +26,12 @@ public class ShellFlyoutContent : _IssuesUITest
 	public void FlyoutContentTests()
 	{
 		App.WaitForElement("PageLoaded");
-		App.TapInShellFlyout("FlyoutItem");
+		App.TapInShellFlyout(FlyoutItem);
 		App.Tap("ToggleContent");
 		App.TapInShellFlyout("ContentView");
-		App.Tap("FlyoutItem");
+		App.Tap(FlyoutItem);
 		App.Tap("ToggleFlyoutContentTemplate");
-		App.TapInShellFlyout("Reset");
-		App.Tap("FlyoutItem");
+		App.TapInShellFlyout(ResetButton);
+		App.Tap(FlyoutItem);
 	}
 }


### PR DESCRIPTION
### Root Cause of the issue 

- The Flyout content did not update dynamically when the FlyoutContentTemplate was changed at runtime.

### Description of Change

- To address this, I have implemented the necessary mapping for the FlyoutContentTemplate, ensuring that the Flyout content dynamically responds and updates correctly whenever the property is modified.

### Issues Fixed

Fixes #26435

### Tested the behaviour in the following platforms

- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

### Screenshot

| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video width="400" height="500"  src="https://github.com/user-attachments/assets/2a05c38f-4f60-4f22-84a0-6245b63046d5"> | <video width="400" height="500"  src="https://github.com/user-attachments/assets/9d7f5780-41dd-4223-a789-a3bf38e7dad7"> |

