### PR TITLE
[ci] Fix provision on templates stage

### DIFF
--- a/eng/pipelines/common/maui-templates-steps.yml
+++ b/eng/pipelines/common/maui-templates-steps.yml
@@ -2,12 +2,6 @@ parameters:
   - name: condition
     default: true
 
-  - name: skipXcode
-    default: false
-
-  - name: skipProvisioning
-    default: true
-
   - name: artifactName
     type: string
     default: nuget
@@ -36,12 +30,6 @@ steps:
 - ${{ each step in parameters.prepareSteps }}:
   - ${{ each pair in step }}:
       ${{ pair.key }}: ${{ pair.value }}
-
-- template: provision.yml
-  parameters:
-    checkoutDirectory: ${{ parameters.checkoutDirectory }}
-    skipXcode: ${{ parameters.skipXcode }}
-    skipProvisioning: ${{ parameters.skipProvisioning }}
 
 - task: DownloadBuildArtifacts@0
   displayName: 'Download Packages'

--- a/eng/pipelines/common/maui-templates.yml
+++ b/eng/pipelines/common/maui-templates.yml
@@ -69,11 +69,6 @@ jobs:
           checkoutDirectory: ${{ parameters.checkoutDirectory }}
           prepareSteps: ${{ parameters.prepareSteps }}
           category: ${{ category }}
-          skipXcode: false
-          ${{ if eq(parameters.skipProvisioning, 'true') }}:
-            skipProvisioning: true
-          ${{ else }}:  
-            skipProvisioning: false
 
 
 - ${{ each category in parameters.BuildCategories }}:
@@ -129,13 +124,6 @@ jobs:
     #     displayName: 'Clean bot'
     #     continueOnError: true
     #     timeoutInMinutes: 60
-
-    - template: provision.yml
-      parameters:
-        skipXcode: ${{ eq(RunPlatform.testName, 'RunOnAndroid') }}
-        skipProvisioning: true
-        skipAndroidImages: ${{ ne(RunPlatform.testName, 'RunOnAndroid') }}
-        checkoutDirectory: ${{ parameters.checkoutDirectory }}
 
     - task: DownloadBuildArtifacts@0
       displayName: 'Download Packages'

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -83,7 +83,7 @@ parameters:
         vmImage: $(macOSXVmImage)
         demands:
           - macOS.Name -equals Sonoma
-          - macOS.Architecture -equals x64
+          - macOS.Architecture -equals arm64
         artifact: build-macos
  
   - name: PackPlatforms
@@ -100,7 +100,7 @@ parameters:
         vmImage: $(macOSXVmImage)
         demands:
           - macOS.Name -equals Sonoma
-          - macOS.Architecture -equals x64
+          - macOS.Architecture -equals arm64
         artifact: nuget-macos
 
   - name: BuildTemplatePlatforms

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -83,7 +83,7 @@ parameters:
         vmImage: $(macOSXVmImage)
         demands:
           - macOS.Name -equals Sonoma
-          - macOS.Architecture -equals arm64
+          - macOS.Architecture -equals x64
         artifact: build-macos
  
   - name: PackPlatforms

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -348,8 +348,20 @@ stages:
               ${{ parameters.BuildEverything }},
               ne(variables['Build.Reason'], 'PullRequest'),
               eq(variables['System.TeamProject'], 'devdiv'))
-        ${{ if or(eq(parameters.UseProvisionator, true), eq(variables['internalProvisioning'],'True') ) }}:
-          skipProvisioning: false
+        prepareSteps:
+          - template: common/provision.yml
+            parameters:
+              checkoutDirectory: '$(System.DefaultWorkingDirectory)'
+              provisionatorChannel: ${{ parameters.provisionatorChannel }}
+              skipAndroidSdks: true
+              skipAndroidImages: true
+              installDefaultAndroidApi: true
+              skipXcode: false
+              ${{ if or(eq(parameters.UseProvisionator, 'True'), eq(variables['internalProvisioning'],'True') )}}:
+                skipProvisionator: false
+                gitHubToken: $(github--pat--vs-mobiletools-engineering-service2)
+              ${{ else }}:  
+                skipProvisionator: true
           
         
   - ${{ if eq(variables['System.TeamProject'], 'devdiv') }}:


### PR DESCRIPTION
### Description of Change

The skipProvisioning step wasn't t working, so we might as well do what we do on the other stages and use the preSteps to call provisionator. This fixes the failing runs for macOS templates when it wasn't t find the certs, the link shows the certs being installed now on devdiv.

https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=10693145&view=logs&j=f4504d3f-6c6f-5196-4181-43965e1caaf6&t=6e906d46-d3e3-5c94-db0d-03ff0993d5f6&l=420

<img width="536" alt="Screenshot 2024-12-11 at 16 10 54" src="https://github.com/user-attachments/assets/701e192d-8d81-4350-8d51-1523972f7cb3" />

Also run the pack on a arm machine to be faster, I tried to run the build osx also on arm but I found [this issue ](https://github.com/dotnet/maui/issues/26516).



This pull request includes changes to the `eng/pipelines` directory to simplify the pipeline templates and update platform architecture requirements. The most important changes include removing unnecessary parameters and templates, and updating the architecture for macOS builds.

Pipeline simplification:

* [`eng/pipelines/common/maui-templates-steps.yml`](diffhunk://#diff-683c300126c5e1a74448bc4908e7fca6e2a5a77a16faa79cb21dbc7a3bbcbf82L5-L10): Removed `skipXcode` and `skipProvisioning` parameters and the `provision.yml` template from the `steps` section. [[1]](diffhunk://#diff-683c300126c5e1a74448bc4908e7fca6e2a5a77a16faa79cb21dbc7a3bbcbf82L5-L10) [[2]](diffhunk://#diff-683c300126c5e1a74448bc4908e7fca6e2a5a77a16faa79cb21dbc7a3bbcbf82L40-L45)
* [`eng/pipelines/common/maui-templates.yml`](diffhunk://#diff-beb9b1c0fe7c80ce160eac3a028a267cd8bf6bef41239e0a4bf5829ae3ac25a7L72-L76): Removed `skipXcode` and `skipProvisioning` parameters from the `jobs` section and the `provision.yml` template. [[1]](diffhunk://#diff-beb9b1c0fe7c80ce160eac3a028a267cd8bf6bef41239e0a4bf5829ae3ac25a7L72-L76) [[2]](diffhunk://#diff-beb9b1c0fe7c80ce160eac3a028a267cd8bf6bef41239e0a4bf5829ae3ac25a7L133-L139)

Platform architecture update:

* [`eng/pipelines/handlers.yml`](diffhunk://#diff-5c9b6f86c989bb9415ea86f38f9e127f8dadf3a8516e9d027c7ee6289f10c394L103-R103): Changed the macOS architecture requirement from `x64` to `arm64`.
* [`eng/pipelines/handlers.yml`](diffhunk://#diff-5c9b6f86c989bb9415ea86f38f9e127f8dadf3a8516e9d027c7ee6289f10c394L351-R364): Updated the `prepareSteps` section to include new parameters and conditions for provisioning.

### Issues Fixed

Work related with #25732
