### PR TITLE
Remove CastingList from MenuFlyoutSubItem

### DIFF
--- a/src/Controls/src/Core/Menu/MenuFlyoutSubItem.cs
+++ b/src/Controls/src/Core/Menu/MenuFlyoutSubItem.cs
@@ -1,12 +1,6 @@
 #nullable disable
-using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.ComponentModel;
-using System.Windows.Input;
-using Microsoft.Maui.Controls.StyleSheets;
-using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Controls
 {
@@ -16,10 +10,7 @@ namespace Microsoft.Maui.Controls
 
 		public MenuFlyoutSubItem()
 		{
-			LogicalChildrenInternalBackingStore = new CastingList<Element, IMenuElement>(_menus);
 		}
-
-		private protected override IList<Element> LogicalChildrenInternalBackingStore { get; }
 
 		public IMenuElement this[int index]
 		{
@@ -38,6 +29,7 @@ namespace Microsoft.Maui.Controls
 		public void Add(IMenuElement item)
 		{
 			var index = _menus.Count;
+			_menus.Add(item);
 			AddLogicalChild((Element)item);
 			NotifyHandler(nameof(IMenuBarItemHandler.Add), index, item);
 		}
@@ -70,6 +62,7 @@ namespace Microsoft.Maui.Controls
 
 		public void Insert(int index, IMenuElement item)
 		{
+			_menus.Insert(index, item);
 			InsertLogicalChild(index, (Element)item);
 			NotifyHandler(nameof(IMenuFlyoutSubItemHandler.Insert), index, item);
 		}
@@ -77,7 +70,10 @@ namespace Microsoft.Maui.Controls
 		public bool Remove(IMenuElement item)
 		{
 			var index = _menus.IndexOf(item);
-			var result = RemoveLogicalChild((Element)item, index);
+			_menus.RemoveAt(index);
+
+			// Logical Child Index might not match location in _menus list
+			var result = RemoveLogicalChild((Element)item);
 			NotifyHandler(nameof(IMenuFlyoutHandler.Remove), index, item);
 
 			return result;
@@ -86,7 +82,10 @@ namespace Microsoft.Maui.Controls
 		public void RemoveAt(int index)
 		{
 			var item = _menus[index];
-			RemoveLogicalChild((Element)item, index);
+			_menus.RemoveAt(index);
+
+			// Logical Child Index might not match location in _menus list
+			RemoveLogicalChild((Element)item);
 			NotifyHandler(nameof(IMenuFlyoutHandler.Remove), index, item);
 		}
 

--- a/src/Controls/tests/Core.UnitTests/Menu/MenuBarItemTests.cs
+++ b/src/Controls/tests/Core.UnitTests/Menu/MenuBarItemTests.cs
@@ -10,6 +10,21 @@ namespace Microsoft.Maui.Controls.Core.UnitTests.Menu
 	public class MenuBarItemTests :
 		MenuTestBase<MenuBarItem, IMenuElement, MenuFlyoutItem, MenuBarItemHandlerUpdate>
 	{
+		[Fact]
+		public void StartsEnabled()
+		{
+			MenuBarItem menuBarItem = new MenuBarItem();
+			Assert.True(menuBarItem.IsEnabled);
+		}
+
+		[Fact]
+		public void DisableWorks()
+		{
+			MenuBarItem menuBarItem = new MenuBarItem();
+			menuBarItem.IsEnabled = false;
+			Assert.False(menuBarItem.IsEnabled);
+		}
+
 		protected override int GetIndex(MenuBarItemHandlerUpdate handlerUpdate) =>
 			handlerUpdate.Index;
 

--- a/src/Controls/tests/Core.UnitTests/Menu/MenuFlyoutSubItemTests.cs
+++ b/src/Controls/tests/Core.UnitTests/Menu/MenuFlyoutSubItemTests.cs
@@ -12,21 +12,6 @@ namespace Microsoft.Maui.Controls.Core.UnitTests.Menu
 		MenuTestBase<MenuFlyoutSubItem, IMenuElement, MenuFlyoutItem, MenuFlyoutSubItemHandlerUpdate>
 	{
 		[Fact]
-		public void StartsEnabled()
-		{
-			MenuBarItem menuBarItem = new MenuBarItem();
-			Assert.True(menuBarItem.IsEnabled);
-		}
-
-		[Fact]
-		public void DisableWorks()
-		{
-			MenuBarItem menuBarItem = new MenuBarItem();
-			menuBarItem.IsEnabled = false;
-			Assert.False(menuBarItem.IsEnabled);
-		}
-
-		[Fact]
 		public void CommandPropertyChangesEnabled()
 		{
 			MenuFlyoutItem menuBarItem = new MenuFlyoutItem();

--- a/src/Controls/tests/Core.UnitTests/Menu/MenuTestBase.cs
+++ b/src/Controls/tests/Core.UnitTests/Menu/MenuTestBase.cs
@@ -1,4 +1,5 @@
 ﻿#nullable enable
+using System.Collections;
 using System.Collections.Generic;
 using Microsoft.Maui.Handlers;
 using Xunit;
@@ -16,6 +17,40 @@ namespace Microsoft.Maui.Controls.Core.UnitTests.Menu
 		protected abstract TIChildType GetItem(THandlerUpdate handlerUpdate);
 
 		protected abstract int GetIndex(THandlerUpdate handlerUpdate);
+
+		[Fact]
+		public void IconImageSourceAddsCorrectlyToEachSetOfLogicalChildren()
+		{
+			var menuBar = new TTestType();
+
+			var child0 = new TChildType();
+			var child1 = new TChildType();
+			
+			menuBar.Add(child0);
+			menuBar.Add(child1);
+
+			if (menuBar is MenuItem mi0)
+				mi0.IconImageSource = new FileImageSource { File = "coffee.png" };
+
+			if (child0 is MenuItem mi1)
+				mi1.IconImageSource = new FileImageSource { File = "coffee.png" };
+
+			if (child1 is MenuItem mi2)
+				mi2.IconImageSource = new FileImageSource { File = "coffee.png" };
+
+			foreach(var item in menuBar)
+			{
+				Assert.NotNull(item);
+				if (item is IList list)
+				{
+					foreach(var child in list)
+					{
+						Assert.NotNull(child);
+					}
+				}
+			}
+		}
+
 
 		[Fact]
 		public void UsingIndexUpdatesParent()


### PR DESCRIPTION
### Description of Change

Fix crash setting `MenuFlyoutSubItem` IconImageSource on Windows.

From https://github.com/dotnet/maui/pull/24688 the ImageSource  is added as logical children of the menu item. However, the `LogicalChildrenInternalBackingStore` collection from MenuFlyoutSubItem  does a casting to `IMenuElement` https://github.com/dotnet/maui/blob/5b5aaa5ef83f54688bee408cf14768f443d5aa2e/src/Controls/src/Core/Menu/MenuFlyoutSubItem.cs#L19

Trying to add the IconImageSource to the LogicalChildrenInternalBackingStore insert a null value because this casting https://github.com/dotnet/maui/blob/5b5aaa5ef83f54688bee408cf14768f443d5aa2e/src/Controls/src/Core/ReadOnlyCastingList.cs#L91 fails, cannot convert from Element to `IMenuElement`.

This PR splits the implementation of the internal `_menu` list up from the logical children. This allows Logical Children of any type to get added. 

### Issues Fixed

Fixes #25893
