### PR TITLE
Invert SourceRect width/height on orientation change for ActionSheet

### DIFF
--- a/src/Controls/src/Core/Platform/AlertManager/AlertManager.iOS.cs
+++ b/src/Controls/src/Core/Platform/AlertManager/AlertManager.iOS.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using CoreGraphics;
 using Foundation;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Graphics;
@@ -195,7 +196,7 @@ namespace Microsoft.Maui.Controls.Platform
 					var topViewController = GetTopUIViewController(presentingWindow);
 					UIDevice.CurrentDevice.BeginGeneratingDeviceOrientationNotifications();
 					var observer = NSNotificationCenter.DefaultCenter.AddObserver(UIDevice.OrientationDidChangeNotification,
-						n => alert.PopoverPresentationController.SourceRect = topViewController.View.Bounds);
+						n => alert.PopoverPresentationController.SourceRect = new CGRect(0, 0, topViewController.View.Bounds.Height, topViewController.View.Bounds.Width));
 
 					arguments.Result.Task.ContinueWith(t =>
 					{


### PR DESCRIPTION
### Description of Change

Invert SourceRect width/height on orientation change for ActionSheet to ensure it says centred.

### Issues Fixed

Fixes #26560

| Before | After |
| -------- | ------- |
|![Simulator Screen Recording - iPad Pro 11-inch (M4) - 2024-12-12 at 18 14 02](https://github.com/user-attachments/assets/622e6845-9b7a-47fd-9561-99e657dfd7ce)|![Simulator Screen Recording - iPad Pro 11-inch (M4) - 2024-12-12 at 18 05 41](https://github.com/user-attachments/assets/d62be158-7088-4751-8af7-3d01a97fb5b1)|