### PR TITLE
Fix for CollectionView with RefreshView when ObservableCollection<T>.Clear() throws System.ArgumentOutOfRangeException

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
@@ -125,12 +125,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		{
 			CheckForEmptySource();
 
-			// Use the static ItemCount property to match the item count expected by UICollectionView during batch updates.
-			if(ItemsSource is ObservableItemsSource)
-			{
-				return ItemsSource.ItemCount;
-			}
-
 			return ItemsSource.ItemCountInGroup(section);
 		}
 

--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
@@ -125,6 +125,12 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		{
 			CheckForEmptySource();
 
+			// Use the static ItemCount property to match the item count expected by UICollectionView during batch updates.
+			if(ItemsSource is ObservableItemsSource)
+			{
+				return ItemsSource.ItemCount;
+			}
+
 			return ItemsSource.ItemCountInGroup(section);
 		}
 

--- a/src/Controls/src/Core/Handlers/Items/iOS/ObservableItemsSource.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ObservableItemsSource.cs
@@ -61,8 +61,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		public int ItemCountInGroup(nint group)
 		{
-			//Return the updated item count to ensure item indices are validated against the current item source count.
-			return ItemsCount();
+			return Count;
 		}
 
 		public object Group(NSIndexPath indexPath)
@@ -280,7 +279,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		internal object ElementAt(int index)
 		{
 			if (_itemsSource is IList list)
-				return list[index];
+				return (index >= 0 && index < list.Count) ? list[index] : -1;
 
 			int count = 0;
 			foreach (var item in _itemsSource)

--- a/src/Controls/src/Core/Handlers/Items/iOS/ObservableItemsSource.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ObservableItemsSource.cs
@@ -279,7 +279,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		internal object ElementAt(int index)
 		{
 			if (_itemsSource is IList list)
-				return (index >= 0 && index < list.Count) ? list[index] : -1;
+				return (index >= 0 && index < list.Count) ? list[index] : null;
 
 			int count = 0;
 			foreach (var item in _itemsSource)
@@ -289,7 +289,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				count++;
 			}
 
-			return -1;
+			return null;
 		}
 
 		internal int IndexOf(object item)

--- a/src/Controls/src/Core/Handlers/Items/iOS/ObservableItemsSource.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ObservableItemsSource.cs
@@ -61,7 +61,8 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		public int ItemCountInGroup(nint group)
 		{
-			return Count;
+			//Return the updated item count to ensure item indices are validated against the current item source count.
+			return ItemsCount();
 		}
 
 		public object Group(NSIndexPath indexPath)

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue23868.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue23868.xaml
@@ -1,0 +1,44 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Maui.Controls.Sample.Issues.Issue23868"
+             xmlns:local="clr-namespace:Maui.Controls.Sample.Issues"
+             x:Name="ThisMainPage"
+             Title="Main Page">
+  <StackLayout>
+    <Label Text="Pull to refresh twice to replicate the issue"
+               HorizontalOptions="Center"
+               VerticalOptions="Center"
+               FontSize="16"
+               Margin="10"
+               TextColor="Red" />
+        <RefreshView x:Name="refreshView" Command="{Binding PullToRefreshCommand}" Refreshing="OnRefreshing">
+            <CollectionView AutomationId="CollectionView" x:Name="collectionView" ItemsSource="{Binding Items}">
+                <CollectionView.Header>
+                    <Grid ColumnDefinitions="2*,*"
+                          HorizontalOptions="CenterAndExpand"
+                          IsVisible="{Binding Source={x:Reference collectionView}, Path=ItemsSource.Count, FallbackValue=False}">
+                        <Label Grid.Column="0"
+                               Text="Items Count:"
+                               VerticalTextAlignment="Center"
+                               HorizontalOptions="EndAndExpand"/>
+                        <Label Grid.Column="1"
+                               Text="{Binding Items.Count}"
+                               VerticalTextAlignment="Center"
+                               HorizontalOptions="StartAndExpand"/>
+                    </Grid>
+                </CollectionView.Header>
+                <CollectionView.ItemTemplate>
+                    <DataTemplate>
+                        <Label Text="{Binding}" HorizontalOptions="Center" VerticalOptions="Center"/>
+                    </DataTemplate>
+                </CollectionView.ItemTemplate>
+            </CollectionView>
+        </RefreshView>
+
+        <StackLayout Orientation="Horizontal" HorizontalOptions="Center" Margin="10">
+            <Button Text="UpdateData" AutomationId="UpdateData" Clicked="OnUpdateDataClicked"/>
+            <Button Text="ClearData" Clicked="OnClearDataClicked"/>
+        </StackLayout>
+    </StackLayout>
+</ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue23868.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue23868.xaml.cs
@@ -1,0 +1,75 @@
+﻿#nullable enable
+using System.Collections.ObjectModel;
+using System.Text.Json;
+
+namespace Maui.Controls.Sample.Issues
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	[Issue(IssueTracker.Github, 23868, "CollectionView with RefreshView Throws Exception During Pull-to-Refresh Actions", PlatformAffected.iOS)]
+	public partial class Issue23868: ContentPage
+	{
+            private ObservableCollection<string> _items = new ObservableCollection<string>();
+
+        public ObservableCollection<string> Items
+        {
+            get => _items;
+            set
+            {
+                _items = value;
+                collectionView.ItemsSource = _items;
+            }
+        }
+
+        public Command PullToRefreshCommand { get; }
+
+        public Issue23868()
+        {
+            InitializeComponent();
+            Items = new ObservableCollection<string>();
+            BindingContext = this;
+
+            PullToRefreshCommand = new Command(async () => await SimulateHttpRequest());
+        }
+
+        private async Task SimulateHttpRequest()
+        {
+            refreshView.IsRefreshing = true;
+
+            // Simulate delay for data fetching
+            await Task.Delay(200);
+
+            // Simulated local JSON data
+            string jsonData = "[\"Local Item 1\", \"Local Item 2\", \"Local Item 3\"]";
+
+            // Parse the local data as a response
+            var items = JsonSerializer.Deserialize<string[]>(jsonData);
+
+            // Update ObservableCollection with fetched data
+            if (items != null)
+            {
+                Items.Clear();
+                foreach (var item in items)
+                {
+                    Items.Add(item);
+                }
+            }
+
+            refreshView.IsRefreshing = false;
+        }
+
+        private async void OnUpdateDataClicked(object sender, EventArgs e)
+        {
+            await SimulateHttpRequest();
+        }
+
+        private void OnClearDataClicked(object sender, EventArgs e)
+        {
+            Items.Clear();
+        }
+
+        private void OnRefreshing(object sender, EventArgs e)
+        {
+            PullToRefreshCommand.Execute(null);
+        }
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue23868.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue23868.cs
@@ -1,0 +1,28 @@
+﻿#if TEST_FAILS_ON_CATALYST //Swipe actions cannot be performed on the macOS test server
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	internal class Issue23868 : _IssuesUITest
+	{
+		public Issue23868(TestDevice device) : base(device) { }
+
+		public override string Issue => "CollectionView with RefreshView Throws Exception During Pull-to-Refresh Actions";
+
+		[Test]
+		[Category(UITestCategories.CollectionView)]
+		public void CollectionViewWithHeaderAndRefreshViewShouldNotCrashOnPullToRefresh()
+		{
+			App.WaitForElement("UpdateData");
+			App.Tap("UpdateData");
+			App.WaitForElement("CollectionView");
+			App.ScrollUp("CollectionView", ScrollStrategy.Gesture, swipeSpeed: 7000);
+			App.WaitForElement("CollectionView");
+			App.ScrollUp("CollectionView", ScrollStrategy.Gesture, swipeSpeed: 7000);
+			App.WaitForElement("CollectionView");
+		}
+	}
+}
+#endif


### PR DESCRIPTION
### Root Cause:
The issue arises because the `UICollectionView`'s internal `_itemSource` becomes empty during pull-to-refresh, even though the `ItemsSource` in the controller still holds a valid count. This discrepancy causes an invalid state, where the `GetSizeForItem` method tries to access an index that no longer exists, resulting in a `System.ArgumentOutOfRangeException`. The issue was further compounded by the fact that `GetSizeForItem` was being called before the `CollectionChanged` event was triggered. This occurs because the `ContentOffset` is set during the pull-to-refresh operation, which prematurely triggers layout recalculations, leading to an invalid state.
 
### Description of Change:
The change ensures the `ElementAt` method safely accesses elements by validating the index with `(index >= 0 && index < list.Count)`. Using a ternary operator, it immediately returns the item or `-1` for invalid indices, preventing `System.ArgumentOutOfRangeException` and simplifying the logic for better reliability.

### Issues Fixed
Fixes #23868 

### Tested the behaviour in the following platforms
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac
 
###Output Video
Before Issue Fix | After Issue Fix |
|----------|----------|
|<video width="300" height="600" alt="Before Fix video" src="https://github.com/user-attachments/assets/a331f745-fa76-4318-9079-c384b3b00ec1">|<video width="300" height="600" alt="After Fix video" src="https://github.com/user-attachments/assets/6bf167ee-7c2a-4d20-bd29-e3d25b86199f">|