### PR TITLE
[iOS] Inherit UIContainerView from MauiView

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellFlyoutContentRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellFlyoutContentRenderer.cs
@@ -193,7 +193,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 		void ReMeasureFooter()
 		{
-			var size = _footerView?.SizeThatFits(new CGSize(View.Frame.Width, double.PositiveInfinity));
+			var size = _footerView?.UpdateSize(new CGSize(View.Frame.Width, double.PositiveInfinity));
 			if (size is not null)
 				UpdateFooterPosition(size.Value.Height);
 		}

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellFlyoutLayoutManager.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellFlyoutLayoutManager.cs
@@ -184,7 +184,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			if (HeaderView is null || ContentView?.Superview is null)
 				return;
 
-			HeaderView.SizeThatFits(new CGSize(ContentView.Superview.Frame.Width, double.PositiveInfinity));
+			HeaderView.UpdateSize(new CGSize(ContentView.Superview.Frame.Width, double.PositiveInfinity));
 			UpdateHeaderSize();
 		}
 
@@ -196,7 +196,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			// If the HeaderView hasn't been measured we need to measure it
 			if (double.IsNaN(MeasuredHeaderViewHeightWithMargin))
 			{
-				HeaderView.SizeThatFits(new CGSize(ContentView.Superview.Frame.Width, double.PositiveInfinity));
+				HeaderView.UpdateSize(new CGSize(ContentView.Superview.Frame.Width, double.PositiveInfinity));
 			}
 
 			SetHeaderContentInset();

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellPageRendererTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellPageRendererTracker.cs
@@ -258,7 +258,10 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			{
 				var view = NavigationItem.TitleView;
 				NavigationItem.TitleView = null;
-				view?.Dispose();
+				if(view is TitleViewContainer titleViewContainer)
+				{
+					titleViewContainer.Disconnect();
+				}
 			}
 			else
 			{
@@ -899,7 +902,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				if (_context.Shell.Toolbar != null)
 					_context.Shell.Toolbar.PropertyChanged -= OnToolbarPropertyChanged;
 
-				if (NavigationItem?.TitleView is TitleViewContainer tvc)
+				if (IsRootPage && NavigationItem?.TitleView is TitleViewContainer tvc)
 					tvc.Disconnect();
 			}
 


### PR DESCRIPTION
To inherit `UIContainerView` from `GeneralWrapperView`, `GeneralWrapperView` needs to be public, so if these changes are okay then I will modify the public API perhaps

This would close this one: https://github.com/dotnet/maui/pull/26456 

I've added an internal method `UpdateSize` to `UiContainerView`, because SizeThatFits should not affect the size of a view which currently happens

@rmarinho @PureWeen 