### PR TITLE
Fix up relevant CA1416 warnings

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/iOS/ContextActionCell.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/iOS/ContextActionCell.cs
@@ -33,19 +33,17 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		{
 			var rect = new RectangleF(0, 0, 1, 1);
 			var size = rect.Size;
-
-			UIGraphics.BeginImageContext(size);
-			var context = UIGraphics.GetCurrentContext();
-			context.SetFillColor(Microsoft.Maui.Platform.ColorExtensions.Red.CGColor);
-			context.FillRect(rect);
-			DestructiveBackground = UIGraphics.GetImageFromCurrentImageContext();
-
-			context.SetFillColor(Microsoft.Maui.Platform.ColorExtensions.LightGray.CGColor);
-			context.FillRect(rect);
-
-			NormalBackground = UIGraphics.GetImageFromCurrentImageContext();
-
-			context.Dispose();
+			using var renderer = new UIGraphicsImageRenderer(size);
+			DestructiveBackground = renderer.CreateImage((UIGraphicsImageRendererContext ctx) => {
+				var context = ctx.CGContext;
+				context.SetFillColor(Microsoft.Maui.Platform.ColorExtensions.Red.CGColor);
+				context.FillRect(rect);
+			});
+			NormalBackground = renderer.CreateImage((UIGraphicsImageRendererContext ctx) => {
+				var context = ctx.CGContext;
+				context.SetFillColor(Microsoft.Maui.Platform.ColorExtensions.LightGray.CGColor);
+				context.FillRect(rect);
+			});
 		}
 
 		public ContextActionsCell() : base(UITableViewCellStyle.Default, Key)

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellPageRendererTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellPageRendererTracker.cs
@@ -448,29 +448,25 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				return img;
 
 			var rect = new CGRect(0, 0, 23f, 23f);
+			using var renderer = new UIGraphicsImageRenderer(rect.Size);
+			var renderedImage = renderer.CreateImage((UIGraphicsImageRendererContext ctx) => {
+				var context = ctx.CGContext;
+				context.SaveState();
+				context.SetStrokeColor(UIColor.Blue.CGColor);
 
-			UIGraphics.BeginImageContextWithOptions(rect.Size, false, 0);
-			var ctx = UIGraphics.GetCurrentContext();
-			ctx.SaveState();
-			ctx.SetStrokeColor(UIColor.Blue.CGColor);
+				float size = 3f;
+				float start = 4f;
+				context.SetLineWidth(size);
+				for (int i = 0; i < 3; i++)
+				{
+					context.MoveTo(1f, start + i * (size * 2));
+					context.AddLineToPoint(22f, start + i * (size * 2));
+					context.StrokePath();
+				}
 
-			float size = 3f;
-			float start = 4f;
-			ctx.SetLineWidth(size);
-
-			for (int i = 0; i < 3; i++)
-			{
-				ctx.MoveTo(1f, start + i * (size * 2));
-				ctx.AddLineToPoint(22f, start + i * (size * 2));
-				ctx.StrokePath();
-			}
-
-			ctx.RestoreState();
-			img = UIGraphics.GetImageFromCurrentImageContext();
-			UIGraphics.EndImageContext();
-
-			_nSCache.SetObjectforKey(img, (NSString)hamburgerKey);
-			return img;
+				context.RestoreState();
+			});
+			return renderedImage;
 		}
 
 		void OnToolbarItemsChanged(object sender, NotifyCollectionChangedEventArgs e)

--- a/src/Controls/src/Core/Platform/iOS/Extensions/BrushExtensions.cs
+++ b/src/Controls/src/Core/Platform/iOS/Extensions/BrushExtensions.cs
@@ -121,15 +121,11 @@ namespace Microsoft.Maui.Controls.Platform
 			if (backgroundLayer == null)
 				return null;
 
-			UIGraphics.BeginImageContextWithOptions(backgroundLayer.Bounds.Size, false, UIScreen.MainScreen.Scale);
-
-			if (UIGraphics.GetCurrentContext() == null)
-				return null;
-
-			backgroundLayer.RenderInContext(UIGraphics.GetCurrentContext());
-			UIImage gradientImage = UIGraphics.GetImageFromCurrentImageContext();
-			UIGraphics.EndImageContext();
-
+			var size = new CGSize(backgroundLayer.Bounds.Size.Width * UIScreen.MainScreen.Scale, backgroundLayer.Bounds.Size.Height * UIScreen.MainScreen.Scale);
+			var renderer = new UIGraphicsImageRenderer(size);
+			var gradientImage = renderer.CreateImage((UIGraphicsImageRendererContext ctx) => {
+				backgroundLayer.RenderInContext(ctx.CGContext);
+			});
 			return gradientImage;
 		}
 

--- a/src/Core/src/Handlers/Application/ApplicationHandler.iOS.cs
+++ b/src/Core/src/Handlers/Application/ApplicationHandler.iOS.cs
@@ -46,9 +46,14 @@ namespace Microsoft.Maui.Handlers
 			}
 		}
 
-		[SupportedOSPlatform("maccatalyst13.0")]
 		public static partial void MapActivateWindow(ApplicationHandler handler, IApplication application, object? args)
 		{
+			// ActivateSceneSession requires 17+
+			if (!OperatingSystem.IsIOSVersionAtLeast(17) && !OperatingSystem.IsMacCatalystVersionAtLeast(17))
+			{
+				return;
+			}
+
 			if (args is IWindow window)
 			{
 				var sceneSession = (window.Handler?.PlatformView as UIWindow)?.WindowScene?.Session;

--- a/src/Core/src/Handlers/SwipeItemMenuItem/SwipeItemMenuItemHandler.iOS.cs
+++ b/src/Core/src/Handlers/SwipeItemMenuItem/SwipeItemMenuItemHandler.iOS.cs
@@ -142,12 +142,33 @@ namespace Microsoft.Maui.Handlers
 
 				var width = maxResizeFactor * sourceSize.Width;
 				var height = maxResizeFactor * sourceSize.Height;
-				UIGraphics.BeginImageContextWithOptions(new CGSize((nfloat)width, (nfloat)height), false, 0);
-				sourceImage.Draw(new CGRect(0, 0, (nfloat)width, (nfloat)height));
-				var resultImage = UIGraphics.GetImageFromCurrentImageContext();
-				UIGraphics.EndImageContext();
 
-				return resultImage;
+				if (!OperatingSystem.IsIOSVersionAtLeast(17))
+				{
+					UIGraphics.BeginImageContextWithOptions(new CGSize((nfloat)width, (nfloat)height), false, 0);
+					sourceImage.Draw(new CGRect(0, 0, (nfloat)width, (nfloat)height));
+					var resultImage = UIGraphics.GetImageFromCurrentImageContext();
+					UIGraphics.EndImageContext();
+
+					return resultImage;
+				}
+
+				var format = new UIGraphicsImageRendererFormat
+				{
+					Opaque = false,
+					Scale = 0
+				};
+
+				using (var renderer = new UIGraphicsImageRenderer(new CGSize(width, height), format))
+				{
+					var resultImage = renderer.CreateImage((UIGraphicsImageRendererContext imageContext) =>
+					{
+						var cgcontext = imageContext.CGContext;
+						cgcontext.DrawImage(new CGRect(0, 0, (nfloat)width, (nfloat)height), sourceImage.CGImage);
+					});
+
+					return resultImage;
+				}
 			}
 		}
 

--- a/src/Core/src/Hosting/LifecycleEvents/AppHostBuilderExtensions.iOS.cs
+++ b/src/Core/src/Hosting/LifecycleEvents/AppHostBuilderExtensions.iOS.cs
@@ -49,18 +49,9 @@ namespace Microsoft.Maui.LifecycleEvents
 							app.GetWindow()?.Stopped();
 					});
 
-
-			// Pre iOS 13 doesn't support scenes
-			if (!OperatingSystem.IsIOSVersionAtLeast(13))
-				return;
-
-
 			iOS
 				.SceneWillEnterForeground(scene =>
 				{
-					if (!OperatingSystem.IsIOSVersionAtLeast(13))
-						return;
-
 					if (scene.Delegate is IUIWindowSceneDelegate windowScene &&
 						scene.ActivationState != UISceneActivationState.Unattached)
 					{
@@ -69,33 +60,21 @@ namespace Microsoft.Maui.LifecycleEvents
 				})
 				.SceneOnActivated(scene =>
 				{
-					if (!OperatingSystem.IsIOSVersionAtLeast(13))
-						return;
-
 					if (scene.Delegate is IUIWindowSceneDelegate sd)
 						sd.GetWindow().GetWindow()?.Activated();
 				})
 				.SceneOnResignActivation(scene =>
 				{
-					if (!OperatingSystem.IsIOSVersionAtLeast(13))
-						return;
-
 					if (scene.Delegate is IUIWindowSceneDelegate sd)
 						sd.GetWindow().GetWindow()?.Deactivated();
 				})
 				.SceneDidEnterBackground(scene =>
 				{
-					if (!OperatingSystem.IsIOSVersionAtLeast(13))
-						return;
-
 					if (scene.Delegate is IUIWindowSceneDelegate sd)
 						sd.GetWindow().GetWindow()?.Stopped();
 				})
 				.SceneDidDisconnect(scene =>
 				{
-					if (!OperatingSystem.IsIOSVersionAtLeast(13))
-						return;
-
 					if (scene.Delegate is IUIWindowSceneDelegate sd)
 						sd.GetWindow().GetWindow()?.Destroying();
 				});
@@ -103,16 +82,9 @@ namespace Microsoft.Maui.LifecycleEvents
 
 		static void OnConfigureWindow(IiOSLifecycleBuilder iOS)
 		{
-			// Pre iOS 13 doesn't support scenes
-			if (!OperatingSystem.IsIOSVersionAtLeast(13))
-				return;
-
 			iOS = iOS
 				.WindowSceneDidUpdateCoordinateSpace((windowScene, _, _, _) =>
 				{
-					if (!OperatingSystem.IsIOSVersionAtLeast(13))
-						return;
-
 					if (windowScene.Delegate is not IUIWindowSceneDelegate wsd ||
 						wsd.GetWindow() is not UIWindow platformWindow)
 						return;

--- a/src/Core/src/ImageSources/iOS/ImageSourceExtensions.cs
+++ b/src/Core/src/ImageSources/iOS/ImageSourceExtensions.cs
@@ -35,20 +35,17 @@ namespace Microsoft.Maui
 				return null;
 			}
 
-			UIGraphics.BeginImageContextWithOptions(imagesize, false, scale);
-			var ctx = new NSStringDrawingContext();
-
-			var boundingRect = attString.GetBoundingRect(imagesize, 0, ctx);
-			attString.DrawString(new CGRect(
-				imagesize.Width / 2 - boundingRect.Size.Width / 2,
-				imagesize.Height / 2 - boundingRect.Size.Height / 2,
-				imagesize.Width,
-				imagesize.Height));
-
-			var image = UIGraphics.GetImageFromCurrentImageContext();
-			UIGraphics.EndImageContext();
-
-			return image.ImageWithRenderingMode(UIImageRenderingMode.Automatic);
+			var renderer = new UIGraphicsImageRenderer(imagesize);
+			var rendererImage = renderer.CreateImage((UIGraphicsImageRendererContext renderContext) => {
+				var ctx = new NSStringDrawingContext();
+				var boundingRect = attString.GetBoundingRect(imagesize, 0, ctx);
+				attString.DrawString(new CGRect(
+					imagesize.Width / 2 - boundingRect.Size.Width / 2,
+					imagesize.Height / 2 - boundingRect.Size.Height / 2,
+					imagesize.Width,
+					imagesize.Height));
+			});
+			return rendererImage;
 		}
 
 		internal static UIImage? GetPlatformImage(this IFileImageSource imageSource)

--- a/src/Core/src/Platform/iOS/ColorExtensions.cs
+++ b/src/Core/src/Platform/iOS/ColorExtensions.cs
@@ -14,126 +14,57 @@ namespace Microsoft.Maui.Platform
 
 		internal static UIColor LabelColor
 		{
-			get
-			{
-				if (OperatingSystem.IsIOSVersionAtLeast(13) || OperatingSystem.IsTvOSVersionAtLeast(13))
-					return UIColor.Label;
-
-				return UIColor.Black;
-			}
+			get => UIColor.Label;
 		}
 
 		internal static UIColor PlaceholderColor
 		{
-			get
-			{
-
-				if (OperatingSystem.IsIOSVersionAtLeast(13) || OperatingSystem.IsTvOSVersionAtLeast(13))
-					return UIColor.PlaceholderText;
-
-				return SeventyPercentGrey;
-			}
+			get => UIColor.PlaceholderText;
 		}
 
 		internal static UIColor SecondaryLabelColor
 		{
-			get
-			{
-
-				if (OperatingSystem.IsIOSVersionAtLeast(13) || OperatingSystem.IsTvOSVersionAtLeast(13))
-					return UIColor.SecondaryLabel;
-
-				return new Color(.32f, .4f, .57f).ToPlatform();
-			}
+			get => UIColor.SecondaryLabel;
 		}
 
 		internal static UIColor BackgroundColor
 		{
-			get
-			{
-
-				if (OperatingSystem.IsIOSVersionAtLeast(13))
-					return UIColor.SystemBackground;
-
-				return UIColor.White;
-			}
+			get => UIColor.SystemBackground;
 		}
 
 		internal static UIColor SeparatorColor
 		{
-			get
-			{
-				if (OperatingSystem.IsIOSVersionAtLeast(13) || OperatingSystem.IsTvOSVersionAtLeast(13))
-					return UIColor.Separator;
-
-				return UIColor.Gray;
-			}
+			get => UIColor.Separator;
 		}
 
 		internal static UIColor OpaqueSeparatorColor
 		{
-			get
-			{
-				if (OperatingSystem.IsIOSVersionAtLeast(13) || OperatingSystem.IsTvOSVersionAtLeast(13))
-					return UIColor.OpaqueSeparator;
-
-				return UIColor.Black;
-			}
+			get => UIColor.OpaqueSeparator;
 		}
 
 		internal static UIColor GroupedBackground
 		{
-			get
-			{
-				if (OperatingSystem.IsIOSVersionAtLeast(13))
-					return UIColor.SystemGroupedBackground;
-
-				return new UIColor(247f / 255f, 247f / 255f, 247f / 255f, 1);
-			}
+			get => UIColor.SystemGroupedBackground;
 		}
 
 		internal static UIColor AccentColor
 		{
-			get
-			{
-				if (OperatingSystem.IsIOSVersionAtLeast(13) || OperatingSystem.IsTvOSVersionAtLeast(13))
-					return UIColor.SystemBlue;
-
-				return Color.FromRgba(50, 79, 133, 255).ToPlatform();
-			}
+			get => UIColor.SystemBlue;
 		}
 
 		internal static UIColor Red
 		{
-			get
-			{
-				if (OperatingSystem.IsIOSVersionAtLeast(13) || OperatingSystem.IsTvOSVersionAtLeast(13))
-					return UIColor.SystemRed;
-
-				return UIColor.FromRGBA(255, 0, 0, 255);
-			}
+			get => UIColor.SystemRed;
 		}
 
 		internal static UIColor Gray
 		{
-			get
-			{
-				if (OperatingSystem.IsIOSVersionAtLeast(13) || OperatingSystem.IsTvOSVersionAtLeast(13))
-					return UIColor.SystemGray;
-
-				return UIColor.Gray;
-			}
+			get => UIColor.SystemGray;
 		}
 
 		internal static UIColor LightGray
 		{
-			get
-			{
-				if (OperatingSystem.IsIOSVersionAtLeast(13))
-					return UIColor.SystemGray2;
-
-				return UIColor.LightGray;
-			}
+			get => UIColor.SystemGray2;
 		}
 
 		public static CGColor ToCGColor(this Color color)

--- a/src/Core/src/Platform/iOS/KeyboardAutoManagerScroll.cs
+++ b/src/Core/src/Platform/iOS/KeyboardAutoManagerScroll.cs
@@ -368,11 +368,7 @@ public static class KeyboardAutoManagerScroll
 		}
 		else
 		{
-			if (OperatingSystem.IsIOSVersionAtLeast(13, 0))
-				statusBarHeight = window.WindowScene?.StatusBarManager?.StatusBarFrame.Height ?? 0;
-			else
-				statusBarHeight = UIApplication.SharedApplication.StatusBarFrame.Height;
-
+			statusBarHeight = window.WindowScene?.StatusBarManager?.StatusBarFrame.Height ?? 0;
 			navigationBarAreaHeight = statusBarHeight;
 		}
 

--- a/src/Core/src/Platform/iOS/MauiCheckBox.cs
+++ b/src/Core/src/Platform/iOS/MauiCheckBox.cs
@@ -177,10 +177,16 @@ namespace Microsoft.Maui.Platform
 
 		UIImage CreateCheckBox(UIImage? check)
 		{
-			UIGraphics.BeginImageContextWithOptions(new CGSize(DefaultSize, DefaultSize), false, 0);
-			var context = UIGraphics.GetCurrentContext();
-			context.SaveState();
+			var renderer = new UIGraphicsImageRenderer(new CGSize(DefaultSize, DefaultSize));
+			var image = renderer.CreateImage((UIGraphicsImageRendererContext ctx) => {
+				var context = ctx.CGContext;
+				RenderCheckMark(context, check);
+			});
+			return image;
+		}
 
+		void RenderCheckMark(CGContext context, UIImage? check)
+		{
 			var checkedColor = CheckBoxTintUIColor;
 
 			if (checkedColor != null)
@@ -203,18 +209,20 @@ namespace Microsoft.Maui.Platform
 				boxPath.Fill();
 				check.Draw(new CGPoint(0, 0), CGBlendMode.DestinationOut, 1);
 			}
-
-			context.RestoreState();
-			var img = UIGraphics.GetImageFromCurrentImageContext();
-			UIGraphics.EndImageContext();
-
-			return img;
 		}
 
 		static UIImage CreateCheckMark()
 		{
-			UIGraphics.BeginImageContextWithOptions(new CGSize(DefaultSize, DefaultSize), false, 0);
-			var context = UIGraphics.GetCurrentContext();
+			using var renderer = new UIGraphicsImageRenderer (new CGSize(DefaultSize, DefaultSize));
+			var image = renderer.CreateImage((UIGraphicsImageRendererContext ctx) => {
+				var context = ctx.CGContext;
+				RenderCheckMark(context);
+			});
+			return image;
+		}
+
+		static void RenderCheckMark(CGContext context)
+		{
 			context.SaveState();
 
 			var vPadding = LineWidth / 2;
@@ -230,10 +238,6 @@ namespace Microsoft.Maui.Platform
 			checkPath.Stroke();
 
 			context.RestoreState();
-			var img = UIGraphics.GetImageFromCurrentImageContext();
-			UIGraphics.EndImageContext();
-
-			return img;
 		}
 
 		public override CGSize SizeThatFits(CGSize size)

--- a/src/Core/src/Platform/iOS/MauiTimePicker.cs
+++ b/src/Core/src/Platform/iOS/MauiTimePicker.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Maui.Platform
 			_proxy = new(dateSelected);
 #endif
 
-			if (OperatingSystem.IsIOSVersionAtLeast(14))
+			if (OperatingSystem.IsIOSVersionAtLeast(13, 4) || OperatingSystem.IsMacCatalyst())
 			{
 				_picker.PreferredDatePickerStyle = UIDatePickerStyle.Wheels;
 			}

--- a/src/Core/src/Platform/iOS/MauiUIApplicationDelegate.Menu.cs
+++ b/src/Core/src/Platform/iOS/MauiUIApplicationDelegate.Menu.cs
@@ -29,13 +29,15 @@ namespace Microsoft.Maui
 			MenuBuilder = builder;
 
 			UIWindow? window = null;
-			if (OperatingSystem.IsMacCatalystVersionAtLeast(14))
+
+			// WindowingBehaviors is only available on iOS 16+ and Mac Catalyst
+			if (OperatingSystem.IsMacCatalystVersionAtLeast(16) || OperatingSystem.IsIOSVersionAtLeast(16))
 			{
 				// for iOS 14+ where active apperance is supported
 				var activeWindowScenes = new List<UIWindowScene>();
 				foreach (var scene in UIApplication.SharedApplication.ConnectedScenes)
 				{
-					if (scene is UIWindowScene windowScene &&
+					if (scene is UIWindowScene windowScene && 
 						windowScene.TraitCollection.ActiveAppearance == UIUserInterfaceActiveAppearance.Active)
 					{
 						activeWindowScenes.Add(windowScene);
@@ -60,7 +62,9 @@ namespace Microsoft.Maui
 						}
 					}
 					else
+					{
 						window = activeWindowScenes[0].KeyWindow;
+					}
 				}
 			}
 			else
@@ -69,6 +73,7 @@ namespace Microsoft.Maui
 				window = Window ?? this.GetWindow() ??
 					UIApplication.SharedApplication.GetWindow()?.Handler?.PlatformView as UIWindow;
 			}
+
 			window?.GetWindow()?.Handler?.UpdateValue(nameof(IMenuBarElement.MenuBar));
 
 			MenuBuilder = null;

--- a/src/Graphics/src/Graphics/Platforms/iOS/UIImageExtensions.cs
+++ b/src/Graphics/src/Graphics/Platforms/iOS/UIImageExtensions.cs
@@ -1,4 +1,6 @@
+using System;
 using CoreGraphics;
+using SceneKit;
 using UIKit;
 
 namespace Microsoft.Maui.Graphics.Platform
@@ -27,37 +29,75 @@ namespace Microsoft.Maui.Graphics.Platform
 
 		public static UIImage ScaleImage(this UIImage target, CGSize size, bool disposeOriginal = false)
 		{
-			UIGraphics.BeginImageContext(size);
-			target.Draw(new CGRect(CGPoint.Empty, size));
-			var image = UIGraphics.GetImageFromCurrentImageContext();
-			UIGraphics.EndImageContext();
-
-			if (disposeOriginal)
+			if (!OperatingSystem.IsIOSVersionAtLeast(17))
 			{
-				target.Dispose();
+				UIGraphics.BeginImageContext(size);
+				target.Draw(new CGRect(CGPoint.Empty, size));
+				var image = UIGraphics.GetImageFromCurrentImageContext();
+				UIGraphics.EndImageContext();
+
+				if (disposeOriginal)
+				{
+					target.Dispose();
+				}
+
+				return image;
 			}
 
-			return image;
+			using (var renderer = new UIGraphicsImageRenderer(target.Size))
+			{
+				var resultImage = renderer.CreateImage((UIGraphicsImageRendererContext imageContext) =>
+				{ 
+					var cgcontext = imageContext.CGContext;
+					cgcontext.DrawImage(new CGRect(CGPoint.Empty, size), target.CGImage);
+
+					if (disposeOriginal)
+					{
+						target.Dispose();
+					}			
+				});
+
+				return resultImage;
+			}
 		}
 
 		public static UIImage NormalizeOrientation(this UIImage target, bool disposeOriginal = false)
 		{
+			
 			if (target.Orientation == UIImageOrientation.Up)
 			{
 				return target;
 			}
 
-			UIGraphics.BeginImageContextWithOptions(target.Size, false, target.CurrentScale);
-			target.Draw(CGPoint.Empty);
-			var image = UIGraphics.GetImageFromCurrentImageContext();
-			UIGraphics.EndImageContext();
-
-			if (disposeOriginal)
+			if (!OperatingSystem.IsIOSVersionAtLeast(17))
 			{
-				target.Dispose();
+				UIGraphics.BeginImageContextWithOptions(target.Size, false, target.CurrentScale);
+				target.Draw(CGPoint.Empty);
+				var image = UIGraphics.GetImageFromCurrentImageContext();
+				UIGraphics.EndImageContext();
+
+				if (disposeOriginal)
+				{
+					target.Dispose();
+				}
+
+				return image;
 			}
 
-			return image;
+			using (var renderer = new UIGraphicsImageRenderer(target.Size))
+			{
+				var resultImage = renderer.CreateImage((UIGraphicsImageRendererContext imageContext) =>
+				{ 
+					var cgcontext = imageContext.CGContext;
+					cgcontext.DrawImage(new CGRect(0, 0, target.Size.Width, target.Size.Height), target.CGImage);
+					if (disposeOriginal)
+					{
+						target.Dispose();
+					}
+				});
+
+				return resultImage;
+			}	
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change

Unfortunately CA1416 still isn't reliable on iOS/Catalyst due to 

https://github.com/dotnet/roslyn-analyzers/issues/7239

You can work around the issue but it makes the code somewhat confusing to deal with, so we opted to not go the workaround path. 

That being said, there were a lot of useful other bits that @stephen-hawley contributed into this PR https://github.com/dotnet/maui/pull/20477. 

This PR pulls out all the bits that do fix some areas where we weren't checking for the right OperatingSystem Version and it converts to some newer APIS for iOS 18;
