### PR TITLE
Fix Android Shell Navigation not properly waiting for end of transaction

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellItemRendererBase.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellItemRendererBase.cs
@@ -138,7 +138,12 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 		protected virtual Task<bool> HandleFragmentUpdate(ShellNavigationSource navSource, ShellSection shellSection, Page page, bool animated)
 		{
-			TaskCompletionSource<bool> result = new TaskCompletionSource<bool>();
+			// We're using RunContinuationsAsynchronously because we don't want a subsequent navigation
+			// to start until the current one has finished.
+			// The AnimationFinished event is used to signal when the animation has completed,
+			// but that doesn't mean the fragment transaction has completed.
+			var result = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
 			bool isForCurrentTab = shellSection == ShellSection;
 			bool initialUpdate = _fragmentMap.Count == 0;
 			if (!_fragmentMap.ContainsKey(ShellSection))

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Bugzilla/Bugzilla42329.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Bugzilla/Bugzilla42329.cs
@@ -20,23 +20,34 @@ public class Bugzilla42329 : _IssuesUITest
 
 	[Test]
 	[Category(UITestCategories.ListView)]
-	public void MemoryLeakB42329()
+	public async Task MemoryLeakB42329()
 	{
 		App.WaitForElement(LabelPage1);
 		App.Tap(LabelPage1);
 
+		await WaitForFlyoutAnimation();
 		App.WaitForElement(Page2Title);
 		App.Tap(Page2Title);
 
+		await WaitForFlyoutAnimation();
 		App.WaitForElement(LabelPage2);
 		App.Tap(LabelPage2);
 
+		await WaitForFlyoutAnimation();
 		App.WaitForElement(Page3Title);
 		App.Tap(Page3Title);
+
 #if ANDROID || WINDOWS //In random scenario, the destructor called upon the fourth navigation. So added one more navigation for Android and Windows to make this test work.
 		App.TapInFlyoutPageFlyout(Page2Title);
 		App.TapInFlyoutPageFlyout(Page3Title);
 #endif
 		App.WaitForElement("Destructor called");
+	}
+
+	static async Task WaitForFlyoutAnimation()
+	{
+		// give it time to complete flyout animation
+		// sometimes the test runner is too fast and taps on wrong coordinates
+		await Task.Delay(100);
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue12211.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue12211.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿using System.Globalization;
+using NUnit.Framework;
 using NUnit.Framework.Legacy;
 using UITest.Appium;
 using UITest.Core;
@@ -39,6 +40,6 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 
 		string? GetCurrentOpacityStatus() => App.FindElement("CurrentOpacity").GetText();
 
-		string GetExpectedCurrentOpacityStatus(double expectedOpacity) => $"Current opacity is {expectedOpacity}";
+		string GetExpectedCurrentOpacityStatus(double expectedOpacity) => $"Current opacity is {expectedOpacity.ToString(CultureInfo.InvariantCulture)}";
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue23158.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue23158.cs
@@ -23,6 +23,7 @@ public class Issue23158 : _IssuesUITest
 		App.Click("AddEntry");
 
 		// Click the new entry to see if there is the clear button or not. No such button should be present.
+		App.WaitForElement("Entry3");
 		App.Tap("Entry3");
 
 		VerifyScreenshot();

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25436.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25436.cs
@@ -19,11 +19,7 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 			App.Tap("BackButton");
 			App.WaitForElement("Login");
 			App.Tap("Login");
-#if ANDROID
-			App.Tap(AppiumQuery.ByXPath("//android.widget.ImageButton[@content-desc='Open navigation drawer']"));
-#else
-			App.Tap(FlyoutIconAutomationId);
-#endif
+			App.TapShellFlyoutIcon();
 			VerifyScreenshot();
 		}
 			


### PR DESCRIPTION
### Description of Change

Android device test "Can reuse page" (Shell version) is failing on API >=33.

As we can see from the screenshot here, the end of the animation doesn't mean that the transaction has completed.

<img width="1130" alt="image" src="https://github.com/user-attachments/assets/6b9d7928-e901-421f-b3cc-c8a48e20d361" />

This simple change allows android to complete the last frame properly before engaging a new navigation.
I think this is positive even for `animtated: false` navigations.

This PR also fixes other randomly failing tests.

### Issues Fixed

Fixes often broken device tests.