### PR TITLE
[Testing] Extension for finding any element & test-7167 fix

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/XFIssue/Issue7167.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/XFIssue/Issue7167.cs
@@ -30,14 +30,13 @@ public class Issue7167 : _IssuesUITest
 		// App.Print.Tree();
 		
 		App.ScrollDown(ListViewId, ScrollStrategy.Auto, 0.65, 200);
-		App.WaitForElement("23");
-	
+		App.WaitForAnyElement(["20", "40", "60", "80"]);
+
 		// when adding additional items via a addrange and a CollectionChangedEventArgs.Action.Reset is sent
 		// then the listview shouldnt reset or it should not scroll to the top
 		App.Tap(AddRangeCommandId);
 
-		// Verify that item "23" is still visible
-		App.WaitForElement("23");
+		App.WaitForAnyElement(["20", "40", "60", "80"]);
 	}
 }
 #endif

--- a/src/TestUtils/src/UITest.Appium/HelperExtensions.cs
+++ b/src/TestUtils/src/UITest.Appium/HelperExtensions.cs
@@ -652,6 +652,24 @@ namespace UITest.Appium
 		}
 
 		/// <summary>
+		/// Wait function that will repeatly query the app until any matching element is found. 
+		/// Throws a TimeoutException if no element is found within the time limit.
+		/// </summary>
+		/// <param name="app">Represents the main gateway to interact with an app.</param>
+		/// <param name="marked">Collection of target Elements.</param>
+		/// <param name="timeoutMessage">The message used in the TimeoutException.</param>
+		/// <param name="timeout">The TimeSpan to wait before failing.</param>
+		/// <param name="retryFrequency">The TimeSpan to wait between each query call to the app.</param>
+		/// <param name="postTimeout">The final TimeSpan to wait after the element has been found.</param>
+		public static IUIElement WaitForAnyElement(this IApp app, string[] marked, string timeoutMessage = "Timed out waiting for element...", TimeSpan? timeout = null, TimeSpan? retryFrequency = null, TimeSpan? postTimeout = null)
+		{
+			IUIElement result() => FindAnyElement(app, marked);
+			var results = WaitForAtLeastOne(result, timeoutMessage, timeout, retryFrequency);
+
+			return results;
+		}
+
+		/// <summary>
 		/// Wait function that will repeatly query the app until a matching element is found. 
 		/// Throws a TimeoutException if no element is found within the time limit.
 		/// </summary>
@@ -2093,6 +2111,17 @@ namespace UITest.Appium
 				result = app.FindElementByText(element);
 
 			return result;
+		}
+
+		static IUIElement FindAnyElement(IApp app, string[] elements)
+		{
+			foreach (var element in elements)
+			{
+				if (FindElement(app, element) is IUIElement result)
+					return result;
+			}
+
+			throw new InvalidOperationException($"Did not find any elements in the list: {string.Join(", ", elements)}");
 		}
 
 		static IReadOnlyCollection<IUIElement> FindElements(IApp app, string element)


### PR DESCRIPTION
Scrolling through a list and waiting for a specific element can fail unpredictably due to varying screen sizes and swipe behavior. Instead, I recommend verifying that the list renders correctly after scrolling by checking for the presence of any new element in the array, rather than relying on a specific one.

This PR fixes the failing 7167 test