### PR TITLE
Fixed Dynamically Added FlyoutItems During Navigation Not Displayed on Windows

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/XFIssue/Issue11214.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/XFIssue/Issue11214.cs
@@ -5,6 +5,10 @@ namespace Maui.Controls.Sample.Issues;
 public class Issue11214 : TestShell
 {
 	FlyoutItem _itemexpanderItems;
+#if WINDOWS
+	// Modifying SelectedItem in Navigation view causes the OnNavigated method to be called again. 
+	int count = 0;
+#endif
 	protected override void Init()
 	{
 		_itemexpanderItems = new FlyoutItem()
@@ -47,8 +51,14 @@ public class Issue11214 : TestShell
 
 		args.Cancel();
 
+#if WINDOWS
+		count++;
+		if (count % 2 == 0)
+			return;
+#endif
+
 		if (_itemexpanderItems.Items.Count == 0 ||
-			_itemexpanderItems.Items[0].Items.Count == 0)
+				_itemexpanderItems.Items[0].Items.Count == 0)
 		{
 			for (int i = 0; i < 2; i++)
 			{

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/XFIssue/Issue11214.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/XFIssue/Issue11214.cs
@@ -1,5 +1,4 @@
-﻿#if TEST_FAILS_ON_WINDOWS // FlyoutItems added dynamically during navigation are not displayed on Windows. More information: https://github.com/dotnet/maui/issues/26391.
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
 
@@ -7,6 +6,12 @@ namespace Microsoft.Maui.TestCases.Tests.Issues;
 
 public class Issue11214 : _IssuesUITest
 {
+	const string flyoutString =
+#if WINDOWS
+	 "Click Me and You Should see 2 Items show up";
+#else
+		"ExpandMe";
+#endif
 	public Issue11214(TestDevice testDevice) : base(testDevice)
 	{
 	}
@@ -19,15 +24,14 @@ public class Issue11214 : _IssuesUITest
 	public void FlyoutItemChangesPropagateCorrectlyToPlatformForShellElementsNotCurrentlyActive()
 	{
 		App.WaitForElement("PageLoaded");
-		App.TapInShellFlyout("ExpandMe");
+		App.TapInShellFlyout(flyoutString);
 		App.ShowFlyout();
 		for (int i = 0; i < 2; i++)
 			App.WaitForElement($"Some Item: {i}");
-		App.Tap("ExpandMe");
+		App.Tap(flyoutString);
 		App.ShowFlyout();
 		for (int i = 0; i < 2; i++)
 			App.WaitForNoElement($"Some Item: {i}");
 	}
 
 }
-#endif 


### PR DESCRIPTION
### Issue Details
When adding FlyoutItems dynamically during navigation using the Shell.Navigating event, the newly added items do not appear in the flyout on Windows.

### Root cause
Setting the SelectedItem of the NavigationView triggers the ItemInvoked event again, which in turn causes the OnNavigating method to be called repeatedly. I found a PR that links this behavior to an underlying native issue.

Native issue PR - https://github.com/microsoft/microsoft-ui-xaml/issues/6397 .

The event firing a second time occurs because the current item is being updated in the [MapItems](https://github.com/dotnet/maui/blob/b615b738f902b9c7a7f4123ba6af63d65ccdeafe/src/Controls/src/Core/Handlers/Shell/ShellHandler.Windows.cs#L190) and [MapFlyoutItems](https://github.com/dotnet/maui/blob/b615b738f902b9c7a7f4123ba6af63d65ccdeafe/src/Controls/src/Core/Handlers/Shell/ShellHandler.Windows.cs#L193)  methods. Commenting out these lines resolves the issue, but the flyout selection is no longer in sync with the shell. 

PR - #10295

### Description of Change
Simply returning the second call without performing any operation on windows platform resolves the issue and test case is passed.

### Issues Fixed
Fixes #26391

### Output

![image (1)](https://github.com/user-attachments/assets/1c7bec86-0102-4dea-aa9d-f138c40d0ff7)
