### PR TITLE
Revert "Add Gerald & Javier as UI Test CODEOWNERS"

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,6 +10,3 @@
 **/localize/*.json                                     @tj-devel709
 **/*.resx                                              @tj-devel709
 **.*.resx.lcl                                          @tj-devel709
-
-# UI Testing
-/src/Controls/tests/TestCases.*.Tests                  @jfversluis @jsuarezruiz


### PR DESCRIPTION
Reverts dotnet/maui#26497

This change caused that Javier and me were now added to _all_ PRs, probably because this is one of the only code owner paths that are set up. Probably the PRs requests are distributed better when we have more people assigned to more areas?

Anyway, for now lets revert this until we tweak it some more!