### PR TITLE
[iOS] Set height for EmptyView if is not an IView

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
@@ -538,7 +538,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		protected virtual CGRect DetermineEmptyViewFrame()
 		{
-			nfloat emptyViewHeight = 0;
+			nfloat emptyViewHeight = CollectionView.Frame.Height;
 
 			if (_emptyViewFormsElement is IView emptyView)
 			{

--- a/src/Controls/tests/TestCases.HostApp/Elements/CollectionView/CollectionViewCoreGalleryPage.cs
+++ b/src/Controls/tests/TestCases.HostApp/Elements/CollectionView/CollectionViewCoreGalleryPage.cs
@@ -1,4 +1,5 @@
 using Controls.Sample.UITests;
+using Maui.Controls.Sample.CollectionViewGalleries.EmptyViewGalleries;
 using Maui.Controls.Sample.CollectionViewGalleries.GroupingGalleries;
 using Maui.Controls.Sample.CollectionViewGalleries.HeaderFooterGalleries;
 using Maui.Controls.Sample.CollectionViewGalleries.ItemSizeGalleries;
@@ -44,6 +45,7 @@ namespace Maui.Controls.Sample.CollectionViewGalleries
 						// ItemsFromViewModelShouldBeSelected (src\Compatibility\ControlGallery\src\Issues.Shared\CollectionViewBoundMultiSelection.cs)
 						TestBuilder.NavButton("Selection Galleries", () => new SelectionGallery(), Navigation),
 						TestBuilder.NavButton("Item Size Galleries", () => new ItemsSizeGallery(), Navigation),
+						TestBuilder.NavButton("EmptyView Galleries", () => new EmptyViewGallery(), Navigation)
 					}
 					}
 				};

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/CollectionView/CollectionViewUITests.EmptyView.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/CollectionView/CollectionViewUITests.EmptyView.cs
@@ -1,0 +1,42 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests
+{
+#if IOS
+    public class CollectionViewEmptyViewTests : CollectionViewUITests
+    {
+        protected override bool ResetAfterEachTest => true;
+
+        public CollectionViewEmptyViewTests(TestDevice device)
+            : base(device)
+        {
+        }
+
+        [Test]
+        [Category(UITestCategories.CollectionView)]
+        public void EmptyViewItemsSourceNullStringWorks()
+        {
+            VisitInitialGallery("EmptyView");
+
+            VisitSubGallery("EmptyView (null ItemsSource)");
+
+            // EmptyView string
+            App.WaitForElement("Nothing to display.");
+        }
+
+        [Test]
+        [Category(UITestCategories.CollectionView)]
+        public void EmptyViewItemsSourceNullViewWorks()
+        {
+            VisitInitialGallery("EmptyView");
+
+            VisitSubGallery("EmptyView (null ItemsSource) View");
+
+            // EmptyView string
+            App.WaitForElement("Nothing to display.");
+        }
+    }
+#endif
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25551.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25551.cs
@@ -8,7 +8,7 @@ using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
 
-namespace Microsoft.Maui.TestCases.Tests.Tests.Issues
+namespace Microsoft.Maui.TestCases.Tests.Issues
 {
 	internal class Issue25551 : _IssuesUITest
 	{


### PR DESCRIPTION
### Description of Change

We [introduced some calculations](https://github.com/dotnet/maui/commit/763b6f5af451129e277571feb149293f9d0064ee) for when EmptyView is a IView, but the user can just provide a string as the EmptyView and that will be rendered as UILabel on iOS. 
By setting by default the CollectionView.Height we keep the old behaviour. 

### Issues Fixed

Fixes #26663 
