### PR TITLE
Revert "[Windows] `FileSystem.Current.AppDataDirectory` returns different path after updating to latest version - fix"

### DIFF
--- a/src/Essentials/src/FileSystem/FileSystem.uwp.cs
+++ b/src/Essentials/src/FileSystem/FileSystem.uwp.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Maui.Storage
 			}
 			else
 			{
-				string path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), AppSpecificPath, "Data");
+				string path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), AppSpecificPath, "Data");
 
 				if (!File.Exists(path))
 				{


### PR DESCRIPTION
Reverts dotnet/maui#26039

I looked into this issue some more and I see we were always putting preferences and app data in the wrong location. They were always supposed to be stored in roaming as they are supposed to travel with the app.

All the way back in 8.0.70 and 9.0.0 preview 7 we "broke" the way we stored it: https://github.com/dotnet/maui/pull/23265/files#diff-68e97c448bfa67ad3c292a6e146185895b0c2c6437fe5f361d6044327b56dc84R39

However, we actually made it all consistent - we stored the values in local storage and not roaming storage.

Then in 9.0.21 we saw it and realised that we were wrong and reverted our bug: https://github.com/dotnet/maui/pull/26039/files

However, now it is more correct, but more inconsistent and breaking to our users.

Even though technically we will be incorrect to move preferences back to local storage, it will be the way we have always done things.

Fixes #26602