### PR TITLE
[ci] Always install .net

### DIFF
--- a/eng/configure-toolset.ps1
+++ b/eng/configure-toolset.ps1
@@ -1,0 +1,8 @@
+# We can't use already installed dotnet cli since we need to install additional workloads.
+# We could potentially try to find an existing installation that has all the required workloads,
+# but it's unlikely one will be available.
+
+useInstalledDotNetCli="false"
+
+# Working around issue https://github.com/dotnet/arcade/issues/7327
+# DisableNativeToolsetInstalls=true

--- a/eng/configure-toolset.sh
+++ b/eng/configure-toolset.sh
@@ -1,0 +1,5 @@
+# We can't use already installed dotnet cli since we need to install additional workloads.
+# We could potentially try to find an existing installation that has all the required workloads,
+# but it's unlikely one will be available.
+
+$script:useInstalledDotNetCli = $false


### PR DESCRIPTION
### Description of Change

Configure the toolset arcade install to always install a dotnet version instead of using the global one if exists. 