### PR TITLE
[iOS] Flyout Items Not Displayed in RightToLeft FlowDirection in Landscape - fix

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/FlyoutPage/iOS/PhoneFlyoutPageRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/FlyoutPage/iOS/PhoneFlyoutPageRenderer.cs
@@ -390,7 +390,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 			if (IsRTL && !FlyoutOverlapsDetailsInPopoverMode)
 			{
-				flyoutFrame.X = (int)(flyoutFrame.Width * .25);
+				flyoutFrame.X = (int)(frame.Width - flyoutFrame.Width);
 			}
 
 			var detailsFrame = frame;

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/XFIssue/Issue2818.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/XFIssue/Issue2818.cs
@@ -1,6 +1,5 @@
-﻿#if TEST_FAILS_ON_WINDOWS && TEST_FAILS_ON_CATALYST && TEST_FAILS_ON_IOS
+﻿﻿#if TEST_FAILS_ON_WINDOWS && TEST_FAILS_ON_CATALYST
 // Orientation not supported in Catalyst and Windows
-// On iOS FlyoutPage RTL is not working as expected, Issue: https://github.com/dotnet/maui/issues/26726
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
@@ -35,8 +34,8 @@ public class Issue2818 : _IssuesUITest
 		Assert.That(positionStart, Is.Not.EqualTo(secondPosition));
 	}
 
-	[Test]
-	public void RootViewSizeDoesntChangeAfterBackground()
+	[Test]  
+	public async Task RootViewSizeDoesntChangeAfterBackground()
 	{
 		var idiom = App.WaitForElement("Idiom");
 		App.SetOrientationLandscape();
@@ -52,6 +51,7 @@ public class Issue2818 : _IssuesUITest
 		App.WaitForNoElement("RootLayout");
 		App.ForegroundApp();
 		var newWindowSize = App.WaitForElement("RootLayout");
+		await Task.Delay(2000); // Wait for the app to settle after foregrounding
 		Assert.That(newWindowSize.GetRect().Width, Is.EqualTo(windowSize.GetRect().Width));
 		Assert.That(newWindowSize.GetRect().Height, Is.EqualTo(windowSize.GetRect().Height));
 	}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/XFIssue/Issue2818.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/XFIssue/Issue2818.cs
@@ -1,4 +1,4 @@
-﻿﻿#if TEST_FAILS_ON_WINDOWS && TEST_FAILS_ON_CATALYST
+﻿#if TEST_FAILS_ON_WINDOWS && TEST_FAILS_ON_CATALYST
 // Orientation not supported in Catalyst and Windows
 using NUnit.Framework;
 using UITest.Appium;
@@ -51,7 +51,17 @@ public class Issue2818 : _IssuesUITest
 		App.WaitForNoElement("RootLayout");
 		App.ForegroundApp();
 		var newWindowSize = App.WaitForElement("RootLayout");
-		await Task.Delay(2000); // Wait for the app to settle after foregrounding
+
+		// Poll until the width stabilizes. After foregrounding, some platforms (esp. Android/iOS)
+		// may momentarily report an intermediate layout size while the window / flyout re-applies
+		// RTL + orientation constraints. This loop prevents test flakiness by waiting for the
+		// final (restored) size instead of asserting too early
+		int retries = 50;
+		while (newWindowSize.GetRect().Width != windowSize.GetRect().Width && retries-- > 0)
+		{
+			await Task.Delay(100);
+		}
+
 		Assert.That(newWindowSize.GetRect().Width, Is.EqualTo(windowSize.GetRect().Width));
 		Assert.That(newWindowSize.GetRect().Height, Is.EqualTo(windowSize.GetRect().Height));
 	}


### PR DESCRIPTION

Description needs updates. See details below.
### ✨ Suggested PR Description

<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Root Cause

In `PhoneFlyoutPageRenderer.LayoutChildren()`, when `IsRTL && !FlyoutOverlapsDetailsInPopoverMode`, the flyout panel's X position was calculated as:

```csharp
flyoutFrame.X = (int)(flyoutFrame.Width * .25);
```

This formula positions the flyout at 25% of its own width from the left edge — not at the right side of the screen. In landscape orientation (where `frame.Width` is large), this places the flyout far off to the left, making its content invisible or clipped rather than right-aligned as expected for RTL layout.

### Description of Change

**`PhoneFlyoutPageRenderer.cs`** — 1-line fix:

```csharp
// Before
flyoutFrame.X = (int)(flyoutFrame.Width * .25);

// After
flyoutFrame.X = (int)(frame.Width - flyoutFrame.Width);
```

`frame.Width - flyoutFrame.Width` is the standard right-align formula: it positions the flyout so its right edge aligns with the screen's right edge, which is the correct position for an RTL flyout panel.

**`Issue2818.cs`** (test) — two changes:

1. Removed `TEST_FAILS_ON_IOS` compile guard. The test was previously skipped on iOS because the RTL flyout was broken. The fix makes iOS behavior correct, so the guard is no longer needed.

2. Added `RootViewSizeDoesntChangeAfterBackground` test (async) with a polling loop (up to 5s / 50 × 100ms) to wait for window size to stabilize after backgrounding/foregrounding the app. This prevents flakiness caused by intermediate layout sizes during window restoration on iOS.

### Issues Fixed

Fixes #26726

### Platforms Tested

- [x] iOS (primary — fix targets iOS RTL landscape flyout behavior)
- [ ] Android (not affected — `PhoneFlyoutPageRenderer` is iOS-only)
- [ ] Windows (not affected)
- [ ] Mac Catalyst (test still excluded via `TEST_FAILS_ON_CATALYST` guard)
</details>

<details>