### PR TITLE
Fixed #26769 - crash when iOS app is running on MacOS

### DIFF
--- a/src/Compatibility/Core/src/iOS/ContextActionCell.cs
+++ b/src/Compatibility/Core/src/iOS/ContextActionCell.cs
@@ -345,15 +345,18 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 			if (controller == null)
 				throw new InvalidOperationException("No UIViewController found to present.");
 
-			if (UIDevice.CurrentDevice.UserInterfaceIdiom == UIUserInterfaceIdiom.Phone)
+			if (UIDevice.CurrentDevice.UserInterfaceIdiom == UIUserInterfaceIdiom.Phone || (UIDevice.CurrentDevice.UserInterfaceIdiom == UIUserInterfaceIdiom.Pad && actionSheet.PopoverPresentationController == null))
 			{
 				var cancel = UIAlertAction.Create(StringResources.Cancel, UIAlertActionStyle.Cancel, null);
 				actionSheet.AddAction(cancel);
 			}
 			else
 			{
-				actionSheet.PopoverPresentationController.SourceView = _tableView;
-				actionSheet.PopoverPresentationController.SourceRect = sourceRect;
+				if (actionSheet.PopoverPresentationController != null)
+				{
+					actionSheet.PopoverPresentationController.SourceView = _tableView;
+					actionSheet.PopoverPresentationController.SourceRect = sourceRect;
+				}
 			}
 
 			controller.PresentViewController(actionSheet, true, null);

--- a/src/Compatibility/Core/src/iOS/Platform.cs
+++ b/src/Compatibility/Core/src/iOS/Platform.cs
@@ -518,7 +518,11 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 			{
 				UIDevice.CurrentDevice.BeginGeneratingDeviceOrientationNotifications();
 				var observer = NSNotificationCenter.DefaultCenter.AddObserver(UIDevice.OrientationDidChangeNotification,
-					n => { alert.PopoverPresentationController.SourceRect = window.RootViewController.View.Bounds; });
+					n =>
+					{
+						if (alert.PopoverPresentationController != null)
+							alert.PopoverPresentationController.SourceRect = window.RootViewController.View.Bounds;
+					});
 
 				arguments.Result.Task.ContinueWith(t =>
 				{
@@ -526,9 +530,12 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 					UIDevice.CurrentDevice.EndGeneratingDeviceOrientationNotifications();
 				}, TaskScheduler.FromCurrentSynchronizationContext());
 
-				alert.PopoverPresentationController.SourceView = window.RootViewController.View;
-				alert.PopoverPresentationController.SourceRect = window.RootViewController.View.Bounds;
-				alert.PopoverPresentationController.PermittedArrowDirections = 0; // No arrow
+				if (alert.PopoverPresentationController != null)
+				{
+					alert.PopoverPresentationController.SourceView = window.RootViewController.View;
+					alert.PopoverPresentationController.SourceRect = window.RootViewController.View.Bounds;
+					alert.PopoverPresentationController.PermittedArrowDirections = 0; // No arrow
+				}
 			}
 
 			window.RootViewController.PresentViewController(alert, true, null);

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/iOS/ContextActionCell.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/iOS/ContextActionCell.cs
@@ -340,15 +340,18 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			if (controller == null)
 				throw new InvalidOperationException("No UIViewController found to present.");
 
-			if (UIDevice.CurrentDevice.UserInterfaceIdiom == UIUserInterfaceIdiom.Phone)
+			if (UIDevice.CurrentDevice.UserInterfaceIdiom == UIUserInterfaceIdiom.Phone || (UIDevice.CurrentDevice.UserInterfaceIdiom == UIUserInterfaceIdiom.Pad && actionSheet.PopoverPresentationController == null))
 			{
 				var cancel = UIAlertAction.Create(StringResources.Cancel, UIAlertActionStyle.Cancel, null);
 				actionSheet.AddAction(cancel);
 			}
 			else
 			{
-				actionSheet.PopoverPresentationController.SourceView = _tableView;
-				actionSheet.PopoverPresentationController.SourceRect = sourceRect;
+				if (actionSheet.PopoverPresentationController != null)
+				{
+					actionSheet.PopoverPresentationController.SourceView = _tableView;
+					actionSheet.PopoverPresentationController.SourceRect = sourceRect;
+				}
 			}
 
 			controller.PresentViewController(actionSheet, true, null);


### PR DESCRIPTION
Fixed issue #26769 - crash when iOS app is running on MacOS and "More" item is clicked in ListView context menu. 

### Description of Change

Checking PopoverPresentationController for null, it seems to be null checked already in all other places.

### Issues Fixed

Fixes #26769
