### PR TITLE
NullReference fix in ShellPageRendererTracker.UpdateTabBarVisibility()

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellPageRendererTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellPageRendererTracker.cs
@@ -134,6 +134,11 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 		protected virtual void UpdateTabBarVisible()
 		{
+			if (ViewController is null || Page is null)
+			{
+				return;
+			}
+			
 			var tabBarVisible =
 				(Page.FindParentOfType<ShellItem>() as IShellItemController)?.ShowTabs ?? Shell.GetTabBarIsVisible(Page);
 


### PR DESCRIPTION
### Description of Change

Check if Page and ViewController are not null in ShellPageRendererTracker.UpdateTabBarVisibility()

### Issues Fixed

Fixes #26784 