### PR TITLE
ScrollView.ScrollToAsync doesn't work when called from Page.OnAppearing - fix

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue26781.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue26781.xaml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Maui.Controls.Sample.Issues.Issue26781">
+
+  <ScrollView
+    HeightRequest="100"
+    x:Name="scrollView">
+    <VerticalStackLayout>
+      <Label Text="This is a scroll view scrolled to y pos"/>
+      <Label AutomationId="SuccessLabel"
+             Margin="0,200,0,0"
+             Text="Success if visible"/>
+    </VerticalStackLayout>
+  </ScrollView>
+</ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue26781.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue26781.xaml.cs
@@ -1,0 +1,16 @@
+﻿namespace Maui.Controls.Sample.Issues
+{
+	[Issue(IssueTracker.Github, 26781, "ScrollView.ScrollToAsync doesn't work when called from Page.OnAppearing", PlatformAffected.iOS | PlatformAffected.Android)]
+	public partial class Issue26781 : ContentPage
+	{
+		public Issue26781()
+		{
+			InitializeComponent();
+		}
+
+		protected override async void OnAppearing()
+		{
+			await scrollView.ScrollToAsync(0, 2000, true);
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue26781.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue26781.cs
@@ -1,0 +1,22 @@
+﻿using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue26781 : _IssuesUITest
+	{
+		public Issue26781(TestDevice testDevice) : base(testDevice)
+		{
+		}
+
+		public override string Issue => "ScrollView.ScrollToAsync doesn't work when called from Page.OnAppearing";
+
+		[Test]
+		[Category(UITestCategories.ScrollView)]
+		public void ScrollToAsyncShouldWork()
+		{
+			App.WaitForElement("SuccessLabel");
+		}
+	}
+}


### PR DESCRIPTION
### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/26781?reload=1

```
<Grid RowDefinitions="*,*">
    <ScrollView x:Name="scrollView">

        <VerticalStackLayout>
            <Label Text="This is a scroll view scrolled to the bottom button"
                    HeightRequest="500"/>
            <Button x:Name="BottomButton"
                    AutomationId="successButton"
                    Text="Success if visible"/>
        </VerticalStackLayout>
    </ScrollView>
    <ScrollView Grid.Row="1"
                x:Name="scrollView2">
        <VerticalStackLayout>
            <Label Text="This is a scroll view scrolled to y pos"
                    HeightRequest="500"/>
            <Label AutomationId="successLabel"
                    Text="Success if visible"/>
        </VerticalStackLayout>
    </ScrollView>
</Grid>
```

```c#
protected override async void OnAppearing()
{
	await scrollView.ScrollToAsync(BottomButton, ScrollToPosition.MakeVisible, true);
	await scrollView2.ScrollToAsync(0, 600, true);
}
```

|Android|iOS|
|--|--|
|<video src="https://github.com/user-attachments/assets/080ace25-2af1-40d0-b098-5029dfc6236c" width="300px"/>|<video src="https://github.com/user-attachments/assets/981c7a64-bde4-4fcf-87fd-0337b127e056" width="300px"/>|
