### PR TITLE
Fix [iOS]VerticalOffset Not Reset to Zero After Clearing ItemSource in CollectionView

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewDelegator.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewDelegator.cs
@@ -30,14 +30,8 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			var (visibleItems, firstVisibleItemIndex, centerItemIndex, lastVisibleItemIndex) = GetVisibleItemsIndex();
 
 			var contentInset = scrollView.ContentInset;
-			var contentOffsetX = scrollView.ContentOffset.X + contentInset.Left;
-			var contentOffsetY = scrollView.ContentOffset.Y + contentInset.Top;
-
-			if (!visibleItems && ViewController.ItemsSource.ItemCount == 0)
-			{
-				contentOffsetX = 0;
-				contentOffsetY = 0;
-			}
+			var contentOffsetX = !visibleItems ? 0 : scrollView.ContentOffset.X + contentInset.Left;
+			var contentOffsetY = !visibleItems ? 0 : scrollView.ContentOffset.Y + contentInset.Top;
 
 			var itemsViewScrolledEventArgs = new ItemsViewScrolledEventArgs
 			{

--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewDelegator.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewDelegator.cs
@@ -29,12 +29,15 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		{
 			var (visibleItems, firstVisibleItemIndex, centerItemIndex, lastVisibleItemIndex) = GetVisibleItemsIndex();
 
-			if (!visibleItems)
-				return;
-
 			var contentInset = scrollView.ContentInset;
 			var contentOffsetX = scrollView.ContentOffset.X + contentInset.Left;
 			var contentOffsetY = scrollView.ContentOffset.Y + contentInset.Top;
+
+			if (!visibleItems && ViewController.ItemsSource.ItemCount == 0)
+			{
+				contentOffsetX = 0;
+				contentOffsetY = 0;
+			}
 
 			var itemsViewScrolledEventArgs = new ItemsViewScrolledEventArgs
 			{

--- a/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewDelegator2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewDelegator2.cs
@@ -30,14 +30,8 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 			var (visibleItems, firstVisibleItemIndex, centerItemIndex, lastVisibleItemIndex) = GetVisibleItemsIndex();
 
 			var contentInset = scrollView.ContentInset;
-			var contentOffsetX = scrollView.ContentOffset.X + contentInset.Left;
-			var contentOffsetY = scrollView.ContentOffset.Y + contentInset.Top;
-
-			if (!visibleItems && ViewController.ItemsSource.ItemCount == 0)
-			{
-				contentOffsetX = 0;
-				contentOffsetY = 0;
-			}
+			var contentOffsetX = !visibleItems ? 0 : scrollView.ContentOffset.X + contentInset.Left;
+			var contentOffsetY = !visibleItems ? 0 : scrollView.ContentOffset.Y + contentInset.Top;
 
 			var itemsViewScrolledEventArgs = new ItemsViewScrolledEventArgs
 			{

--- a/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewDelegator2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewDelegator2.cs
@@ -29,12 +29,15 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 		{
 			var (visibleItems, firstVisibleItemIndex, centerItemIndex, lastVisibleItemIndex) = GetVisibleItemsIndex();
 
-			if (!visibleItems)
-				return;
-
 			var contentInset = scrollView.ContentInset;
 			var contentOffsetX = scrollView.ContentOffset.X + contentInset.Left;
 			var contentOffsetY = scrollView.ContentOffset.Y + contentInset.Top;
+
+			if (!visibleItems && ViewController.ItemsSource.ItemCount == 0)
+			{
+				contentOffsetX = 0;
+				contentOffsetY = 0;
+			}
 
 			var itemsViewScrolledEventArgs = new ItemsViewScrolledEventArgs
 			{

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue21708.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue21708.xaml
@@ -39,6 +39,7 @@
         Text="VerticalOffset: " />
         
     <Label AutomationId="Label"
+        Grid.ColumnSpan="2"
         Grid.Row="1"
         HorizontalTextAlignment="Start"
         Grid.Column="1"

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue21708.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue21708.xaml
@@ -1,0 +1,68 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+			       xmlns:controls="clr-namespace:Maui.Controls.Sample.Issues"
+             x:Class="Maui.Controls.Sample.Issues.Issue21708">
+
+	<Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition />
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition />
+            <ColumnDefinition />
+			<ColumnDefinition />
+        </Grid.ColumnDefinitions>
+
+        <Button
+            Grid.Row="0"
+            Grid.Column="0"
+            Margin="10"
+			AutomationId="Fill"
+            Clicked="FillButton_OnClicked"
+            Text="Fill" />
+
+        <Button
+            Grid.Row="0"
+            Grid.Column="2"
+            Margin="10"
+			AutomationId="Empty"
+            Clicked="EmptyButton_OnClicked"
+            Text="Empty" />
+
+                   <Label
+        Grid.Row="1"
+        Grid.Column="0"
+        AutomationId="VerticalOffsetLabel"
+        Text="VerticalOffset: " />
+        
+    <Label AutomationId="Label"
+        Grid.Row="1"
+        HorizontalTextAlignment="Start"
+        Grid.Column="1"
+        Text="{Binding VerticalOffset}" />
+
+        <CollectionView AutomationId="CollectionView"
+            x:Name="CollectionView"
+            Grid.Row="2"
+            Grid.Column="0"
+            Grid.ColumnSpan="3"
+            ItemsSource="{Binding Items}"
+            Scrolled="CollectionView_OnScrolled">
+            <CollectionView.ItemTemplate>
+                <DataTemplate>
+                    <Label
+                        Margin="10"
+                        FontSize="Default"
+                        HeightRequest="20"
+                        HorizontalTextAlignment="Center"
+                        Text="{Binding .}"
+                        TextColor="RoyalBlue" />
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+        </CollectionView>
+    </Grid>
+		
+</ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue21708.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue21708.xaml.cs
@@ -1,0 +1,52 @@
+﻿using System.Collections.ObjectModel;
+
+namespace Maui.Controls.Sample.Issues
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	[Issue(IssueTracker.Github, 21708, "CollectionView.Scrolled event offset isn't correctly reset when items change on Android", PlatformAffected.All)]
+	public partial class Issue21708 : ContentPage
+	{
+		ObservableCollection<int> _items;
+        double _verticalOffset;
+
+        public Issue21708()
+        {
+            InitializeComponent();
+            _items = new ObservableCollection<int>();
+            AddItemsToCollectionView();
+            CollectionView.ItemsSource = _items;
+			BindingContext = this;
+        }
+
+        public double VerticalOffset
+        {
+            get => _verticalOffset;
+            set
+            {
+                _verticalOffset = value;
+                OnPropertyChanged(nameof(VerticalOffset));
+            }
+        }
+
+        void CollectionView_OnScrolled(object sender, ItemsViewScrolledEventArgs e)
+        {
+            VerticalOffset = e.VerticalOffset;
+        }
+
+        void EmptyButton_OnClicked(object sender, EventArgs e)
+        {
+            _items.Clear();
+        }
+
+        void FillButton_OnClicked(object sender, EventArgs e)
+		{
+			AddItemsToCollectionView();
+		}
+
+		void AddItemsToCollectionView()
+		{
+			foreach (var i in Enumerable.Range(0, 50))
+				_items.Add(i);
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue21708.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue21708.cs
@@ -18,7 +18,9 @@ public class Issue21708 : _IssuesUITest
 		App.ScrollDown("CollectionView");
 		Assert.That(App.FindElement("Label").GetText(), Is.GreaterThan("0"));
 		App.Tap("Empty");
+		#if !ANDROID
 		Assert.That(App.FindElement("Label").GetText(), Is.EqualTo("0"));
+		#endif
 		App.Tap("Fill");
 		App.ScrollDown("CollectionView");
 		Assert.That(App.FindElement("Label").GetText(), Is.GreaterThan("0"));

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue21708.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue21708.cs
@@ -21,9 +21,5 @@ public class Issue21708 : _IssuesUITest
 		#if !ANDROID
 		Assert.That(App.FindElement("Label").GetText(), Is.EqualTo("0"));
 		#endif
-		App.Tap("Fill");
-		App.WaitForElement("Fill");
-		App.ScrollDown("CollectionView");
-		Assert.That(App.FindElement("Label").GetText(), Is.GreaterThan("0"));
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue21708.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue21708.cs
@@ -22,6 +22,7 @@ public class Issue21708 : _IssuesUITest
 		Assert.That(App.FindElement("Label").GetText(), Is.EqualTo("0"));
 		#endif
 		App.Tap("Fill");
+		App.WaitForElement("Fill");
 		App.ScrollDown("CollectionView");
 		Assert.That(App.FindElement("Label").GetText(), Is.GreaterThan("0"));
 	}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue21708.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue21708.cs
@@ -1,0 +1,26 @@
+﻿using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue21708 : _IssuesUITest
+{
+	public Issue21708(TestDevice device) : base(device) { }
+
+	public override string Issue => "CollectionView.Scrolled event offset isn't correctly reset when items change on Android";
+
+	[Test]
+	[Category(UITestCategories.CollectionView)]
+	public void VerifyCollectionViewVerticalOffset()
+	{
+		App.WaitForElement("Fill");
+		App.ScrollDown("CollectionView");
+		Assert.That(App.FindElement("Label").GetText(), Is.GreaterThan("0"));
+		App.Tap("Empty");
+		Assert.That(App.FindElement("Label").GetText(), Is.EqualTo("0"));
+		App.Tap("Fill");
+		App.ScrollDown("CollectionView");
+		Assert.That(App.FindElement("Label").GetText(), Is.GreaterThan("0"));
+	}
+}


### PR DESCRIPTION
### Issue Details:
When clearing the ItemSource of a CollectionView, the VerticalOffset does not reset to zero on iOS and MacCatalyst. Instead, the last offset value is retained. However, after adding items back to the ItemSource, the VerticalOffset updates as expected when scrolling.

### Root Cause:
The UIScrollView.ContentOffset retains its previous value even when the ItemSource is cleared, as there are no visible items in the CollectionView. The VerticalOffset property of the CollectionView depends on the ContentOffset value, which is not reset in such cases.

### Description of Change

Reset HorizontalOffset and VerticalOffset to zero when ItemSource is empty and no items are visible.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #26798 

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->

### Regarding Test case
The test case for this fix is included in this [PR](https://github.com/dotnet/maui/pull/26782)

### Validated the behaviour in the following platforms
 
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

### Output Screenshot
| Before  | After  |
|---------|--------|
|  <video src="https://github.com/user-attachments/assets/122d36c8-3cf6-4d13-be21-f24a3a7f2bf6" width="320" height="240" controls></video>   |   <video src="https://github.com/user-attachments/assets/100c63d6-d407-4fe6-b7be-27f2bd5c9d5b" width="320" height="240" controls></video>   |
