### PR TITLE
[Windows] Tap Events Incorrectly passed Through Button - fix

### DIFF
--- a/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
@@ -40,18 +40,26 @@ namespace Microsoft.Maui.Controls.Platform
 			_collectionChangedHandler = ModelGestureRecognizersOnCollectionChanged;
 
 			if (_handler.VirtualView == null)
+			{
 				throw new ArgumentNullException(nameof(handler.VirtualView));
+			}
 
 			if (_handler.PlatformView == null)
+			{
 				throw new ArgumentNullException(nameof(handler.PlatformView));
+			}
 
 			Element = (VisualElement)_handler.VirtualView;
 			Control = _handler.PlatformView;
 
 			if (_handler.ContainerView != null)
+			{
 				Container = _handler.ContainerView;
+			}
 			else
+			{
 				Container = _handler.PlatformView;
+			}
 		}
 
 		public FrameworkElement? Container
@@ -60,7 +68,9 @@ namespace Microsoft.Maui.Controls.Platform
 			set
 			{
 				if (_container == value)
+				{
 					return;
+				}
 
 				ClearContainerEventHandlers();
 
@@ -103,7 +113,9 @@ namespace Microsoft.Maui.Controls.Platform
 			set
 			{
 				if (_control == value)
+				{
 					return;
+				}
 
 				if (_control is not null)
 				{
@@ -129,19 +141,25 @@ namespace Microsoft.Maui.Controls.Platform
 
 		void SendEventArgs<TRecognizer>(Action<TRecognizer> func)
 		{
-			if (_container == null && _control == null)
+			if (_container is null && _control is null)
+			{
 				return;
+			}
 
 			var view = Element as View;
 			var gestures = view?.GestureRecognizers;
 
-			if (gestures == null)
+			if (gestures is null)
+			{
 				return;
+			}
 
 			foreach (var gesture in gestures)
 			{
 				if (gesture is TRecognizer recognizer)
+				{
 					func(recognizer);
+				}
 			}
 		}
 
@@ -216,7 +234,9 @@ namespace Microsoft.Maui.Controls.Platform
 			SendEventArgs<DropGestureRecognizer>(async rec =>
 			{
 				if (!rec.AllowDrop)
+				{
 					return;
+				}
 
 				try
 				{
@@ -261,9 +281,13 @@ namespace Microsoft.Maui.Controls.Platform
 						if (Uri.TryCreate(args.Data.Text, UriKind.Absolute, out uri))
 						{
 							if (args.Data.Text.StartsWith("http", StringComparison.OrdinalIgnoreCase))
+							{
 								e.Data.SetWebLink(uri);
+							}
 							else
+							{
 								e.Data.SetApplicationLink(uri);
+							}
 						}
 						else
 						{
@@ -411,7 +435,9 @@ namespace Microsoft.Maui.Controls.Platform
 		void HandleSwipe(ManipulationDeltaRoutedEventArgs e, View view)
 		{
 			if (_fingers.Count > 1 || view == null)
+			{
 				return;
+			}
 
 			_isSwiping = true;
 
@@ -424,7 +450,9 @@ namespace Microsoft.Maui.Controls.Platform
 		void HandlePan(ManipulationDeltaRoutedEventArgs e, View view)
 		{
 			if (view == null)
+			{
 				return;
+			}
 			
 			_isPanning = true;
 
@@ -442,7 +470,9 @@ namespace Microsoft.Maui.Controls.Platform
 		void HandlePinch(ManipulationDeltaRoutedEventArgs e, View view)
 		{
 			if (_fingers.Count < 2 || view == null)
+			{
 				return;
+			}
 
 			_isPinching = true;
 
@@ -483,7 +513,9 @@ namespace Microsoft.Maui.Controls.Platform
 			var view = Element as View;
 
 			if (view == null)
+			{
 				return;
+			}
 
 			HandleSwipe(e, view);
 			HandlePinch(e, view);
@@ -494,7 +526,10 @@ namespace Microsoft.Maui.Controls.Platform
 		{
 			var view = Element as View;
 			if (view == null)
+			{
 				return;
+			}
+
 			_wasPinchGestureStartedSent = false;
 			_wasPanGestureStartedSent = false;
 		}
@@ -503,7 +538,10 @@ namespace Microsoft.Maui.Controls.Platform
 		{
 			uint id = e.Pointer.PointerId;
 			if (_fingers.Contains(id))
+			{
 				_fingers.Remove(id);
+			}
+
 			SwipeComplete(false);
 			PinchComplete(false);
 			PanComplete(false);
@@ -526,14 +564,19 @@ namespace Microsoft.Maui.Controls.Platform
 		{
 			uint id = e.Pointer.PointerId;
 			if (!_fingers.Contains(id))
+			{
 				_fingers.Add(id);
+			}
 		}
 
 		void OnPointerReleased(object sender, PointerRoutedEventArgs e)
 		{
 			uint id = e.Pointer.PointerId;
 			if (_fingers.Contains(id))
+			{
 				_fingers.Remove(id);
+			}
+
 			SwipeComplete(true);
 			PinchComplete(true);
 			PanComplete(true);
@@ -589,7 +632,9 @@ namespace Microsoft.Maui.Controls.Platform
 		{
 			var view = Element as View;
 			if (view == null)
+			{
 				return;
+			}
 
 			var pointerGestures = ElementGestureRecognizers.GetGesturesFor<PointerGestureRecognizer>();
 			foreach (var recognizer in pointerGestures)
@@ -603,7 +648,9 @@ namespace Microsoft.Maui.Controls.Platform
 			var result = e.GetPositionRelativeToElement(relativeTo);
 
 			if (result is null)
+			{
 				return null;
+			}
 
 			return result.Value.ToPoint();
 		}
@@ -612,7 +659,9 @@ namespace Microsoft.Maui.Controls.Platform
 		{
 			var view = Element as View;
 			if (view == null)
+			{
 				return;
+			}
 
 			if (!view.IsEnabled)
 			{
@@ -622,14 +671,18 @@ namespace Microsoft.Maui.Controls.Platform
 			var tapPosition = e.GetPositionRelativeToPlatformElement(Control);
 
 			if (tapPosition == null)
+			{
 				return;
+			}
 
 			var children =
 				(view as IGestureController)?.GetChildElements(new Point(tapPosition.Value.X, tapPosition.Value.Y))?.
 				GetChildGesturesFor<TapGestureRecognizer>(ValidateGesture);
 
 			if (ProcessGestureRecognizers(children))
+			{
 				return;
+			}
 
 			IEnumerable<TapGestureRecognizer> tapGestures = view.GestureRecognizers.GetGesturesFor<TapGestureRecognizer>(ValidateGesture);
 			ProcessGestureRecognizers(tapGestures);
@@ -638,7 +691,9 @@ namespace Microsoft.Maui.Controls.Platform
 			{
 				bool handled = false;
 				if (tapGestures == null)
+				{
 					return handled;
+				}
 
 				foreach (var recognizer in tapGestures)
 				{
@@ -657,9 +712,13 @@ namespace Microsoft.Maui.Controls.Platform
 				{
 					// Currently we only support single right clicks
 					if ((g.Buttons & ButtonsMask.Secondary) == ButtonsMask.Secondary)
+					{
 						return g.NumberOfTapsRequired == 1;
+					}
 					else
+					{
 						return false;
+					}
 				}
 
 				if ((g.Buttons & ButtonsMask.Primary) != ButtonsMask.Primary)
@@ -677,7 +736,9 @@ namespace Microsoft.Maui.Controls.Platform
 		{
 			var view = Element as View;
 			if (view == null || !_isSwiping)
+			{
 				return;
+			}
 
 			if (success)
 			{
@@ -694,7 +755,9 @@ namespace Microsoft.Maui.Controls.Platform
 		{
 			var view = Element as View;
 			if (view == null || !_isPanning)
+			{
 				return;
+			}
 
 			foreach (IPanGestureController recognizer in view.GestureRecognizers.GetGesturesFor<PanGestureRecognizer>().Where(g => g.TouchPoints == _fingers.Count))
 			{
@@ -715,8 +778,10 @@ namespace Microsoft.Maui.Controls.Platform
 		void PinchComplete(bool success)
 		{
 			var view = Element as View;
-			if (view == null || !_isPinching)
+			if (view is null || !_isPinching)
+			{
 				return;
+			}
 
 			IEnumerable<PinchGestureRecognizer> pinchGestures = view.GestureRecognizers.GetGesturesFor<PinchGestureRecognizer>();
 			foreach (IPinchGestureController recognizer in pinchGestures)
@@ -828,16 +893,25 @@ namespace Microsoft.Maui.Controls.Platform
 				return;
 			}
 
-			//We can't handle ManipulationMode.Scale and System , so we don't support pinch/pan on a scrollview 
+			// We can't handle ManipulationMode.Scale and System, so we don't support pinch/pan on a scroll view
 			if (Element is ScrollView)
 			{
 				var logger = Application.Current?.FindMauiContext()?.CreateLogger<GesturePlatformManager>();
 				if (hasPinchGesture)
+				{
 					logger?.LogWarning("PinchGestureRecognizer is not supported on a ScrollView in Windows Platforms");
+				}
+
 				if (hasPanGesture)
+				{
 					logger?.LogWarning("PanGestureRecognizer is not supported on a ScrollView in Windows Platforms");
+				}
+
 				if (hasSwipeGesture)
+				{
 					logger?.LogWarning("SwipeGestureRecognizer is not supported on a ScrollView in Windows Platforms");
+				}
+
 				return;
 			}
 

--- a/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Graphics;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media.Imaging;
 using Windows.Storage.Streams;
@@ -357,8 +358,16 @@ namespace Microsoft.Maui.Controls.Platform
 				{
 					_subscriptionFlags &= ~SubscriptionFlags.ContainerTapAndRightTabEventSubscribed;
 
-					_container.RemoveHandler(FrameworkElement.TappedEvent, _tappedEventHandler);
-					_tappedEventHandler = null;
+					if (_control is TextBox)
+					{
+						_container.RemoveHandler(FrameworkElement.TappedEvent, _tappedEventHandler);
+						_tappedEventHandler = null;
+					}
+					else
+					{
+						_container.Tapped -= OnTap;
+					}
+
 					_container.RightTapped -= OnTap;
 				}
 
@@ -366,8 +375,15 @@ namespace Microsoft.Maui.Controls.Platform
 				{
 					_subscriptionFlags &= ~SubscriptionFlags.ContainerDoubleTapEventSubscribed;
 
-					_container.RemoveHandler(FrameworkElement.DoubleTappedEvent, _doubleTappedEventHandler);
-					_doubleTappedEventHandler = null;
+					if (_control is TextBox)
+					{
+						_container.RemoveHandler(FrameworkElement.DoubleTappedEvent, _doubleTappedEventHandler);
+						_doubleTappedEventHandler = null;
+					}
+					else
+					{
+						_container.DoubleTapped -= OnTap;
+					}
 				}
 
 				if ((_subscriptionFlags & SubscriptionFlags.ContainerPgrPointerEventsSubscribed) != 0)
@@ -848,8 +864,17 @@ namespace Microsoft.Maui.Controls.Platform
 				|| children?.GetChildGesturesFor<TapGestureRecognizer>(g => g.NumberOfTapsRequired == 1).Any() == true)
 			{
 				_subscriptionFlags |= SubscriptionFlags.ContainerTapAndRightTabEventSubscribed;
-				_tappedEventHandler = new TappedEventHandler(OnTap);
-				_container.AddHandler(FrameworkElement.TappedEvent,_tappedEventHandler, true);
+
+				if (_control is TextBox)
+				{
+					_tappedEventHandler = new TappedEventHandler(OnTap);
+					_container.AddHandler(FrameworkElement.TappedEvent, _tappedEventHandler, true);
+				}
+				else
+				{
+					_container.Tapped += OnTap;
+				}
+
 				_container.RightTapped += OnTap;
 			}
 			else
@@ -865,8 +890,16 @@ namespace Microsoft.Maui.Controls.Platform
 				|| children?.GetChildGesturesFor<TapGestureRecognizer>(g => g.NumberOfTapsRequired == 1 || g.NumberOfTapsRequired == 2).Any() == true)
 			{
 				_subscriptionFlags |= SubscriptionFlags.ContainerDoubleTapEventSubscribed;
-				_doubleTappedEventHandler = new DoubleTappedEventHandler(OnTap);
-				_container.AddHandler(FrameworkElement.DoubleTappedEvent, _doubleTappedEventHandler, true);
+
+				if (_control is TextBox)
+				{
+					_doubleTappedEventHandler = new DoubleTappedEventHandler(OnTap);
+					_container.AddHandler(FrameworkElement.DoubleTappedEvent, _doubleTappedEventHandler, true);
+				}
+				else
+				{
+					_container.DoubleTapped += OnTap;
+				}
 			}
 			else
 			{

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue12213.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue12213.cs
@@ -1,35 +1,60 @@
-﻿using Microsoft.Maui.Controls;
-using Microsoft.Maui.Controls.CustomAttributes;
-using Microsoft.Maui.Graphics;
-
-namespace Maui.Controls.Sample.Issues
+﻿namespace Maui.Controls.Sample.Issues
 {
 	[Issue(IssueTracker.Github, 12213, "[Windows] TapGestureRecognizer not working on Entry", PlatformAffected.UWP)]
 	public class Issue12213 : TestContentPage
 	{
-
 		public Issue12213()
 		{
 		}
 
 		protected override void Init()
 		{
-			var stackLayout = new StackLayout();
+			var stackLayout = new StackLayout() { AutomationId = "StackLayout" };
 
-			var entry = new Entry();
-			entry.Placeholder = "Enter Your Name";
-			entry.AutomationId = "Entry";
-			var tapGestureRecognizer = new TapGestureRecognizer();
-			tapGestureRecognizer.Tapped += TapGestureRecognizer_Tapped;
-			tapGestureRecognizer.NumberOfTapsRequired = 1;
-			entry.GestureRecognizers.Add(tapGestureRecognizer);
-			stackLayout.Children.Add(entry);
+			// Register a tap gesture recognizer for the stack layout.
+			{
+				var tapGestureRecognizer = new TapGestureRecognizer();
+				tapGestureRecognizer.Tapped += StackLayoutTapGestureRecognizer_Tapped;
+				tapGestureRecognizer.NumberOfTapsRequired = 1;
+				stackLayout.GestureRecognizers.Add(tapGestureRecognizer);
+			}
+
+			// Add a button to the stack layout.
+			{
+				var button = new Button();
+				button.Text = "No operation button";
+				button.AutomationId = "Button";
+				stackLayout.Children.Add(button);
+			}
+
+			// Add an entry to the stack layout.
+			{
+				var tapGestureRecognizer = new TapGestureRecognizer();
+				tapGestureRecognizer.Tapped += EntryTapGestureRecognizer_Tapped;
+				tapGestureRecognizer.NumberOfTapsRequired = 1;
+
+				var entry = new Entry();
+				entry.Placeholder = "Enter Your Name";
+				entry.AutomationId = "Entry";
+				entry.GestureRecognizers.Add(tapGestureRecognizer);
+				stackLayout.Children.Add(entry);
+			}
+
 			Content = stackLayout;
 		}
 
-		private void TapGestureRecognizer_Tapped(object sender, TappedEventArgs e)
+		private void StackLayoutTapGestureRecognizer_Tapped(object sender, TappedEventArgs e)
 		{
-			Label label = new Label { Text = "Tapped" }; 
+			Label label = new Label { AutomationId = "StackLayoutTapped", Text = "Non-entry tapped" };
+			if (Content is Layout layout)
+			{
+				layout.Children.Add(label);
+			}
+		}
+
+		private void EntryTapGestureRecognizer_Tapped(object sender, TappedEventArgs e)
+		{
+			Label label = new Label { AutomationId = "EntryTapped", Text = "Entry tapped" };
 			if (Content is Layout layout)
 			{
 				layout.Children.Add(label);

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue12213.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue12213.cs
@@ -1,25 +1,33 @@
-﻿using NUnit.Framework;
+﻿using Microsoft.Maui.Controls;
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using UITest.Appium;
 using UITest.Core;
 
-namespace Microsoft.Maui.TestCases.Tests.Issues
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue12213 : _IssuesUITest
 {
-	public class Issue12213 : _IssuesUITest
+	public Issue12213(TestDevice testDevice) : base(testDevice)
 	{
-		public Issue12213(TestDevice testDevice) : base(testDevice)
-		{
-		}
+	}
 
-		public override string Issue => "[Windows] TapGestureRecognizer not working on Entry";
+	public override string Issue => "[Windows] TapGestureRecognizer not working on Entry";
 
-		[Test]
-		[Category(UITestCategories.Entry)]
-		[Category(UITestCategories.Gestures)]
-		public void TapGestureRecognizerNotWorkingOnEntry()
-		{
-			App.WaitForElement("Entry");
-			App.Tap("Entry");
-			App.WaitForElement("Tapped");
-		}
+	[Test]
+	[Category(UITestCategories.Entry)]
+	[Category(UITestCategories.Gestures)]
+	public void TapGestureRecognizerNotWorkingOnEntry()
+	{
+		// The button is placed on a stack layout. Button is tapped but the stack layout itself must NOT be tapped.
+		App.WaitForElement("Button");
+		App.Tap("Button");
+
+		// The entry should be tapped.
+		App.WaitForElement("Entry");
+		App.Tap("Entry");
+		App.WaitForElement("EntryTapped");
+
+		ClassicAssert.Null(App.FindElement("StackLayoutTapped"));
 	}
 }

--- a/src/TestUtils/src/UITest.Appium/HelperExtensions.cs
+++ b/src/TestUtils/src/UITest.Appium/HelperExtensions.cs
@@ -634,7 +634,7 @@ namespace UITest.Appium
 		}
 
 		/// <summary>
-		/// Wait function that will repeatly query the app until a matching element is found. 
+		/// Wait function that will repeatedly query the app until a matching element is found. 
 		/// Throws a TimeoutException if no element is found within the time limit.
 		/// </summary>
 		/// <param name="app">Represents the main gateway to interact with an app.</param>
@@ -652,7 +652,7 @@ namespace UITest.Appium
 		}
 
 		/// <summary>
-		/// Wait function that will repeatly query the app until any matching element is found. 
+		/// Wait function that will repeatedly query the app until any matching element is found. 
 		/// Throws a TimeoutException if no element is found within the time limit.
 		/// </summary>
 		/// <param name="app">Represents the main gateway to interact with an app.</param>
@@ -670,7 +670,7 @@ namespace UITest.Appium
 		}
 
 		/// <summary>
-		/// Wait function that will repeatly query the app until a matching element is found. 
+		/// Wait function that will repeatedly query the app until a matching element is found. 
 		/// Throws a TimeoutException if no element is found within the time limit.
 		/// </summary>
 		/// <param name="app">Represents the main gateway to interact with an app.</param>
@@ -688,7 +688,7 @@ namespace UITest.Appium
 		}
 
 		/// <summary>
-		/// Wait function that will repeatly query the app until a matching element is found. 
+		/// Wait function that will repeatedly query the app until a matching element is found. 
 		/// Throws a TimeoutException if no element is found within the time limit.
 		/// </summary>
 		/// <param name="app">Represents the main gateway to interact with an app.</param>
@@ -709,7 +709,7 @@ namespace UITest.Appium
 		}
 
 		/// <summary>
-		/// Wait function that will repeatly query the app until a matching element is no longer found. 
+		/// Wait function that will repeatedly query the app until a matching element is no longer found. 
 		/// Throws a TimeoutException if the element is visible at the end of the time limit.
 		/// </summary>
 		/// <param name="app">Represents the main gateway to interact with an app.</param>
@@ -725,7 +725,7 @@ namespace UITest.Appium
 		}
 
 		/// <summary>
-		/// Wait function that will repeatly query the app until a matching element is no longer found. 
+		/// Wait function that will repeatedly query the app until a matching element is no longer found. 
 		/// Throws a TimeoutException if the element is visible at the end of the time limit.
 		/// </summary>
 		/// <param name="app">Represents the main gateway to interact with an app.</param>
@@ -741,7 +741,7 @@ namespace UITest.Appium
 		}
 
 		/// <summary>
-		/// Wait function that will repeatly query the app until a matching element is no longer found. 
+		/// Wait function that will repeatedly query the app until a matching element is no longer found. 
 		/// Throws a TimeoutException if the element is visible at the end of the time limit.
 		/// </summary>
 		/// <param name="app">Represents the main gateway to interact with an app.</param>


### PR DESCRIPTION
### Description of Change

#25311 makes it possible to register when an entry is tapped. However, it seems it breaks other controls. 

This is, in a way, naive way to fix it by "special-casing" (see the third commit) #25311's behavior just for entries and not other controls.

Notes:

* The first commit modifies test so one can check behavior "before" and "after"
* The second commit is strictly to fix preexisting code style issues.
* The third commit is the workaround.

### Issues Fixed

Fixes #26640