### PR TITLE
Fixed Header and Footer template is not visible in CollectionView

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/StructuredItemsViewHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Items/StructuredItemsViewHandler.Windows.cs
@@ -108,7 +108,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				_currentHeader = null;
 			}
 
-			var header = ItemsView.Header;
+			var header = ItemsView.Header ?? ItemsView.HeaderTemplate;
 
 			switch (header)
 			{
@@ -133,7 +133,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 					if (headerTemplate != null)
 					{
 						ListViewBase.HeaderTemplate = ItemsViewTemplate;
-						ListViewBase.Header = new ItemTemplateContext(headerTemplate, header, Element);
+						ListViewBase.Header = new ItemTemplateContext(headerTemplate, header, Element, mauiContext: MauiContext);
 					}
 					else
 					{
@@ -157,7 +157,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				_currentFooter = null;
 			}
 
-			var footer = ItemsView.Footer;
+			var footer = ItemsView.Footer ?? ItemsView.FooterTemplate;
 
 			switch (footer)
 			{
@@ -182,7 +182,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 					if (footerTemplate != null)
 					{
 						ListViewBase.FooterTemplate = ItemsViewTemplate;
-						ListViewBase.Footer = new ItemTemplateContext(footerTemplate, footer, Element);
+						ListViewBase.Footer = new ItemTemplateContext(footerTemplate, footer, Element, mauiContext: MauiContext);
 					}
 					else
 					{

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue8761.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue8761.xaml
@@ -3,8 +3,6 @@
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     x:Class="Maui.Controls.Sample.Issues.Issue8761">
-
-<Grid>
     <CollectionView ItemsSource="{Binding Items}">
         <CollectionView.HeaderTemplate>
             <DataTemplate>
@@ -33,5 +31,4 @@
             </DataTemplate>
         </CollectionView.FooterTemplate>
     </CollectionView>
-</Grid>
 </ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue8761.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue8761.xaml
@@ -2,9 +2,9 @@
 <ContentPage
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-    xmlns:local="clr-namespace:MauiCollectionViewFooterBug"
     x:Class="Maui.Controls.Sample.Issues.Issue8761">
 
+<Grid>
     <CollectionView ItemsSource="{Binding Items}">
         <CollectionView.HeaderTemplate>
             <DataTemplate>
@@ -33,5 +33,5 @@
             </DataTemplate>
         </CollectionView.FooterTemplate>
     </CollectionView>
-
+</Grid>
 </ContentPage>

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue8761.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue8761.cs
@@ -1,6 +1,4 @@
-﻿#if ANDROID
-// https://github.com/dotnet/maui/issues/22892
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
 
@@ -26,4 +24,3 @@ public class Issue8761 : _IssuesUITest
 		}
 	}
 }
-#endif


### PR DESCRIPTION
### Issue Details:
 
When both the HeaderTemplate and FooterTemplate are declared for a CollectionView, neither template is visible in the view.
 
### Root Cause:
In the StructuredItemsView handler, the UpdateHeader() and UpdateFooter() methods return null for the Header property, resulting in the switch case returning null as well. Additionally, both the Header and MauiContext are found to be null when mapped to the native ListViewBase.Header, causing the header to fail to render properly
 
### Description of Change:
Fixed by recalculating the Header value to account for both the Header and HeaderTemplate. Furthermore, the MauiContext was explicitly passed as a parameter to the ItemTemplateContext during the mapping process. This ensures that the MauiContext is properly associated with ListViewBase.Header, enabling the header to render as expected. Processed same for footer template in UpdateFooter()
 
**Tested the behavior in the following platforms.**
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac
 
Issue not reproduced in iOS and macOS platforms as it is fixed by this PR #25418
 
### Issues Fixed:
 
Fixes #22892
 
### Screenshots
| Before Issue Fix | After Issue Fix |
|--|--|
| <Image src="https://github.com/user-attachments/assets/9690922c-86a2-442a-8007-e71366d26f5a">|<Image src="https://github.com/user-attachments/assets/b3bb96af-9d0c-4179-8fc6-d1196d2a49d2">|


