### PR TITLE
[Android] ListView ContextActions in modal page

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/CellAdapter.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/CellAdapter.cs
@@ -8,6 +8,7 @@ using Android.Views;
 using Android.Widget;
 using AndroidX.AppCompat.App;
 using Microsoft.Maui.Controls.Platform;
+using static Microsoft.Maui.Controls.Platform.ModalNavigationManager;
 using AActionMode = global::AndroidX.AppCompat.View.ActionMode;
 using AListView = Android.Widget.ListView;
 using AMenu = Android.Views.IMenu;
@@ -225,6 +226,10 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 			if (cell == null)
 				return false;
+
+			var fragmentManager = view?.Context?.GetActivity()?.GetFragmentManager();
+			if (fragmentManager.Fragments.Count > 1 && fragmentManager.Fragments[^1] is ModalFragment modalFragment)
+				return modalFragment.HandleContextMode(cell);
 
 			if (_actionMode != null || _supportActionMode != null)
 			{

--- a/src/Controls/src/Core/Menu/MenuItem.cs
+++ b/src/Controls/src/Core/Menu/MenuItem.cs
@@ -106,6 +106,8 @@ namespace Microsoft.Maui.Controls
 
 		protected virtual void OnClicked() => Clicked?.Invoke(this, EventArgs.Empty);
 
+		internal void RaiseClickedEvent() => OnClicked();
+
 		void IMenuItemController.Activate()
 		{
 			if (IsEnabled)


### PR DESCRIPTION
### Description of Change

Android does not natively support applying an Action Mode to a DialogFragment. When startActionMode or startSupportActionMode is invoked, the Action Mode is associated with the Activity hosting the Fragment. This creates a usability issue because the DialogFragment often covers the navigation bar, which is where context actions are typically displayed. As a result, users may perceive that no action has been initiated. Furthermore, if the DialogFragment is closed while the context action is still active, the navigation bar remains in the context menu state, causing confusion.

To address this limitation, I propose intercepting the creation of the ActionMode when the FragmentManager detects a modal fragment. Instead of relying on the default implementation, we can introduce a custom solution that uses an action sheet within the modal navigation class. This ensures that context actions are visually and functionally tied to the DialogFragment, improving the overall user experience.

### Issues Fixed


Fixes https://github.com/dotnet/maui/issues/21261

|Before|After|
|--|--|
|<video src="https://github.com/user-attachments/assets/27f8ab88-f85d-4b82-a2bf-a2f2f1924491" width="300px"/>|<video src="https://github.com/user-attachments/assets/251813ab-5703-4c81-81b2-cda67c8691fc" width="300px"/>|
