### PR TITLE
[Windows] Fixed the exception when using CarouselView PeekAreaInsets Property in OnSizeAllocated method

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/CarouselViewHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Items/CarouselViewHandler.Windows.cs
@@ -560,7 +560,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		{
 			if (newSize != _currentSize && newSize.Width > 0 && newSize.Height > 0)
 			{
-				ListViewBase.SizeChanged -= OnListViewSizeChanged;
 				_currentSize = newSize;
 
 				if (_isCarouselViewReady)
@@ -589,9 +588,8 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			{
 				item.ItemHeight = itemHeight;
 				item.ItemWidth = itemWidth;
-
-				item.InvalidateMeasure();
 			}
+			ListViewBase.InvalidateMeasure();
 		}
 	}
 }

--- a/src/Controls/src/Core/Handlers/Items/CarouselViewHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Items/CarouselViewHandler.Windows.cs
@@ -560,6 +560,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		{
 			if (newSize != _currentSize && newSize.Width > 0 && newSize.Height > 0)
 			{
+				ListViewBase.SizeChanged -= OnListViewSizeChanged;
 				_currentSize = newSize;
 
 				if (_isCarouselViewReady)

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/CarouselViewUITests.AdjustPeekAreaInsets.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/CarouselViewUITests.AdjustPeekAreaInsets.cs
@@ -1,5 +1,4 @@
-﻿#if TEST_FAILS_ON_WINDOWS // This test fails on Windows due to app crash, Issue: https://github.com/dotnet/maui/issues/26822
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
 
@@ -22,4 +21,3 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		}	
 	}
 }
-#endif


### PR DESCRIPTION
### Issue Detail
A layout cycle exception occurs on Windows when using PeekAreaInsets in the OnSizeAllocated method.

### Root Cause
The InvalidateMeasure method was being called individually on each ItemContentControl within ListViewBase. This led to multiple redundant measure invalidations, causing an infinite loop and triggering a layout cycle exception.

### Description of Change
The individual InvalidateMeasure calls on each ItemContentControl were replaced with a single InvalidateMeasure call on the parent ListViewBase, ensuring efficient layout recalculations and preventing layout cycle issues.

### Tested the behaviour in the following platforms
 
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

### Issues Fixed
 
Fixes https://github.com/dotnet/maui/issues/26822

### Screenshots

Before
![image](https://github.com/user-attachments/assets/ab8dc03b-7283-4883-880b-36719e5f8d58)

After
![image](https://github.com/user-attachments/assets/3cf51193-e205-4bec-93be-7c9069cc3c0a)
