### PR TITLE
[Proposal] ScrollView inside a VerticalStackLayout

### DIFF
--- a/src/Core/src/Layouts/VerticalStackLayoutManager.cs
+++ b/src/Core/src/Layouts/VerticalStackLayoutManager.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Maui.Layouts
 			double measuredHeight = 0;
 			double measuredWidth = 0;
 			double childWidthConstraint = widthConstraint - padding.HorizontalThickness;
+			double childHeightConstraint;
 			int spacingCount = 0;
 
 			for (int n = 0; n < Stack.Count; n++)
@@ -28,7 +29,11 @@ namespace Microsoft.Maui.Layouts
 				}
 
 				spacingCount += 1;
-				var measure = child.Measure(childWidthConstraint, double.PositiveInfinity);
+				childHeightConstraint =  double.PositiveInfinity;
+				if (child is IScrollView)
+					childHeightConstraint = heightConstraint - measuredHeight;
+
+				var measure = child.Measure(childWidthConstraint, childHeightConstraint);
 				measuredHeight += measure.Height;
 				measuredWidth = Math.Max(measuredWidth, measure.Width);
 			}


### PR DESCRIPTION
### Description of Change

`ScrollView` inside a `VerticalStackLayout` will not scroll unless its height is explicitly set because it defaults to having an infinite height. This behavior often confuses developers and results in a poor experience when working with .NET MAUI. For example

- https://github.com/dotnet/maui/issues/8990
- https://stackoverflow.com/questions/75465567/workaround-for-scrollview-not-scrolling-inside-a-stacklayout-in-maui
To improve this, the height of a `ScrollView` inside a `VerticalStackLayout` can automatically adjust to occupy the remaining available space in the layout, rather than defaulting to infinity. This would allow the ScrollView to either:

- Adjust to the minimum size required to fit its content, or
- Expand to fill the available space, enabling scrolling when the content exceeds the allocated area.

If developers explicitly set a height for the ScrollView, that value would keep on taking precedence over the calculated height.

### Issues Fixed

Fixes https://stackoverflow.com/questions/75465567/workaround-for-scrollview-not-scrolling-inside-a-stacklayout-in-maui

## Workarounds
For developers who happen to encounter this PR and are looking for a workaround:

- Instead of `VerticalStackLayout` use `StackLayout` and add `FillAndExpand` to` VerticalOptions` of your scroll view
- Use grid and `*` as row definition 
- Explicitly calculate the height of your `ScrollView` and assign it to its `HeightRequest`