### PR TITLE
[iOS] Simplify iOS ScrollView - improvement

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue26900.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue26900.cs
@@ -1,0 +1,37 @@
+﻿namespace Maui.Controls.Sample.Issues
+{
+
+	[Issue(IssueTracker.Github, 26900, "Scroll view doesn't scroll when its height is explicitly set", PlatformAffected.iOS)]
+	public class Issue26900 : TestContentPage
+	{
+		protected override void Init()
+		{
+			Content = new ScrollView
+			{
+				AutomationId = "scrollview",
+				HeightRequest = 200,
+				BackgroundColor = Colors.Blue,
+				Content = new VerticalStackLayout()
+				{
+					BackgroundColor = Colors.Yellow,
+					Children = {
+					new Label
+					{
+						Text = "Hello, world!",
+						AutomationId="label1",
+						HeightRequest = 205,
+						BackgroundColor = Colors.Red
+					},
+					new Label
+					{
+						Text = "Hello, world2!",
+						AutomationId="label2",
+						HeightRequest = 200,
+						BackgroundColor = Colors.Green
+					}
+				}}
+			};
+		}
+	}
+}
+

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue26900.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue26900.cs
@@ -1,0 +1,24 @@
+﻿using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue26900 : _IssuesUITest
+	{
+		public Issue26900(TestDevice testDevice) : base(testDevice)
+		{
+		}
+
+		public override string Issue => "Scroll view doesn't scroll when its height is explicitly set";
+
+		[Test]
+		[Category(UITestCategories.ScrollView)]
+		public void ScrollViewShouldScroll()
+		{
+			App.WaitForElement("label1");
+			App.ScrollDown("label1", ScrollStrategy.Gesture, 0.90, 1000);
+			App.WaitForElement("label2");
+		}
+	}
+}

--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.iOS.cs
@@ -186,17 +186,17 @@ namespace Microsoft.Maui.Handlers
 
 			var contentSize = Size.Zero;
 
-			if (widthConstraint != double.PositiveInfinity && Dimension.IsExplicitSet(contentView.Width))
+			if (!double.IsInfinity(widthConstraint) && Dimension.IsExplicitSet(contentView.Width))
 			{
 				widthConstraint = contentView.Width;
 			}
 
-			if (heightConstraint != double.PositiveInfinity && Dimension.IsExplicitSet(contentView.Height))
+			if (!double.IsInfinity(heightConstraint) && Dimension.IsExplicitSet(contentView.Height))
 			{
 				heightConstraint = contentView.Height;
 			}
 
-			if (content != null)
+			if (content is not null)
 			{
 				contentSize = content.Measure(widthConstraint - inset.HorizontalThickness,
 					heightConstraint - inset.VerticalThickness);

--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.iOS.cs
@@ -167,7 +167,7 @@ namespace Microsoft.Maui.Handlers
 			var scrollOrientation = scrollView.Orientation;
 			var contentWidthConstraint = scrollOrientation is ScrollOrientation.Horizontal or ScrollOrientation.Both ? double.PositiveInfinity : widthConstraint;
 			var contentHeightConstraint = scrollOrientation is ScrollOrientation.Vertical or ScrollOrientation.Both ? double.PositiveInfinity : heightConstraint;
-			var contentSize = scrollView.MeasureContent(scrollView.Padding, contentWidthConstraint, contentHeightConstraint);
+			var contentSize = MeasureContent(scrollView, scrollView.Padding, contentWidthConstraint, contentHeightConstraint);
 
 			// Our target size is the smaller of it and the constraints
 			var width = contentSize.Width <= widthConstraint ? contentSize.Width : widthConstraint;
@@ -177,6 +177,21 @@ namespace Microsoft.Maui.Handlers
 			height = ViewHandlerExtensions.ResolveConstraints(height, scrollView.Height, scrollView.MinimumHeight, scrollView.MaximumHeight);
 
 			return new Size(width, height);
+		}
+
+		static Size MeasureContent(IContentView contentView, Thickness inset, double widthConstraint, double heightConstraint)
+		{
+			var content = contentView.PresentedContent;
+
+			var contentSize = Size.Zero;
+
+			if (content != null)
+			{
+				contentSize = content.Measure(widthConstraint - inset.HorizontalThickness,
+					heightConstraint - inset.VerticalThickness);
+			}
+
+			return new Size(contentSize.Width + inset.HorizontalThickness, contentSize.Height + inset.VerticalThickness);
 		}
 
 		Size ICrossPlatformLayout.CrossPlatformArrange(Rect bounds)

--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.iOS.cs
@@ -2,6 +2,7 @@
 using CoreGraphics;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Layouts;
+using Microsoft.Maui.Primitives;
 using UIKit;
 
 namespace Microsoft.Maui.Handlers
@@ -184,6 +185,16 @@ namespace Microsoft.Maui.Handlers
 			var content = contentView.PresentedContent;
 
 			var contentSize = Size.Zero;
+
+			if (widthConstraint != double.PositiveInfinity && Dimension.IsExplicitSet(contentView.Width))
+			{
+				widthConstraint = contentView.Width;
+			}
+
+			if (heightConstraint != double.PositiveInfinity && Dimension.IsExplicitSet(contentView.Height))
+			{
+				heightConstraint = contentView.Height;
+			}
 
 			if (content != null)
 			{


### PR DESCRIPTION
### Description of Change

I think, I've identified a potential regression related to the simplified ScrollView on iOS (https://github.com/dotnet/maui/pull/26763). The issue occurs when an explicit HeightRequest is set on the ScrollView. In such cases, the content of the ScrollView is restricted to the specified height, which prevents scrolling as intended. 

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/26900

```
<ScrollView HeightRequest="200" BackgroundColor="Blue">
        <VerticalStackLayout BackgroundColor="Yellow">
                <Label Text="Hello, world!"
                        HeightRequest="250"
                        BackgroundColor="Red"/>
                <Label Text="Hello, world2!"
                        BackgroundColor="Green"
                        HeightRequest="200"/>
        </VerticalStackLayout>
</ScrollView>
```

|Before|After|
|--|--|
|<video src="https://github.com/user-attachments/assets/fbecafc1-98b1-4dbf-86fa-c24739dcaeaa" width="300px"/>|<video src="https://github.com/user-attachments/assets/dbb5007c-a76e-4acd-9151-82897442e203" width="300px"/>|
