### PR TITLE
Improve accessibility sample content new project template

### DIFF
--- a/src/Templates/src/templates/maui-mobile/Pages/ManageMetaPage.xaml
+++ b/src/Templates/src/templates/maui-mobile/Pages/ManageMetaPage.xaml
@@ -54,8 +54,10 @@
                 <BindableLayout.ItemTemplate>
                     <DataTemplate x:DataType="models:Category">
                         <Grid ColumnSpacing="{StaticResource LayoutSpacing}" ColumnDefinitions="4*,3*,30,Auto">
-                            <Entry Text="{Binding Title}" Grid.Column="0"/>
-                            <Entry Text="{Binding Color}" Grid.Column="1" x:Name="ColorEntry">
+                            <Entry Text="{Binding Title}" Grid.Column="0" SemanticProperties.Description="Title" />
+                            <Entry Text="{Binding Color}" Grid.Column="1" x:Name="ColorEntry"
+                                SemanticProperties.Description="Color"
+                                SemanticProperties.Hint="Category color in HEX format">
                                 <Entry.Behaviors>
                                     <toolkit:TextValidationBehavior 
                                         InvalidStyle="{StaticResource InvalidEntryStyle}"
@@ -63,31 +65,41 @@
                                         RegexPattern="^#(?:[0-9a-fA-F]{3}){1,2}$" />
                                 </Entry.Behaviors>
                             </Entry>
+
                             <BoxView HeightRequest="30" WidthRequest="30" VerticalOptions="Center" 
-                                Color="{Binding Text, Source={x:Reference ColorEntry}, x:DataType=Entry}" Grid.Column="2"/>
+                                Color="{Binding Text, Source={x:Reference ColorEntry}, x:DataType=Entry}" Grid.Column="2"
+                                SemanticProperties.HeadingLevel="None" />
+
                             <Button 
                                 ImageSource="{StaticResource IconDelete}"
                                 Background="Transparent"
                                 Command="{Binding DeleteCategoryCommand, Source={RelativeSource AncestorType={x:Type pageModels:ManageMetaPageModel}}, x:DataType=pageModels:ManageMetaPageModel}" CommandParameter="{Binding .}"
-                                Grid.Column="3"/>
+                                Grid.Column="3"
+                                SemanticProperties.Description="Delete" />
                         </Grid>
                     </DataTemplate>
                 </BindableLayout.ItemTemplate>
             </VerticalStackLayout>
 
             <Grid ColumnSpacing="{StaticResource LayoutSpacing}" ColumnDefinitions="*,Auto" Margin="0,10">
-                <Button Text="Save" Command="{Binding SaveCategoriesCommand}" HeightRequest="{OnIdiom 44,Desktop=60}" Grid.Column="0"/>
-                <Button ImageSource="{StaticResource IconAdd}" Command="{Binding AddCategoryCommand}" Grid.Column="1"/>
+                <Button Text="Save" Command="{Binding SaveCategoriesCommand}"
+                    HeightRequest="{OnIdiom 44,Desktop=60}" Grid.Column="0" />
+
+                <Button ImageSource="{StaticResource IconAdd}"
+                    Command="{Binding AddCategoryCommand}" Grid.Column="1"
+                    SemanticProperties.Description="Add" />
             </Grid>
 
-            <Label Text="Tags" Style="{StaticResource Title2}"/>
+            <Label Text="Tags" Style="{StaticResource Title2}" />
             <VerticalStackLayout Spacing="{StaticResource LayoutSpacing}"
                 BindableLayout.ItemsSource="{Binding Tags}">
                 <BindableLayout.ItemTemplate>
                     <DataTemplate x:DataType="models:Tag">
                         <Grid ColumnSpacing="{StaticResource LayoutSpacing}" ColumnDefinitions="4*,3*,30,Auto">
-                            <Entry Text="{Binding Title}" Grid.Column="0"/>
-                            <Entry Text="{Binding Color}" Grid.Column="1" x:Name="ColorEntry">
+                            <Entry Text="{Binding Title}" Grid.Column="0" SemanticProperties.Description="Title" />
+                            <Entry Text="{Binding Color}" Grid.Column="1" x:Name="ColorEntry"
+                                SemanticProperties.Description="Color"
+                                SemanticProperties.Hint="Tag color in HEX format">
                                 <Entry.Behaviors>
                                     <toolkit:TextValidationBehavior 
                                         InvalidStyle="{StaticResource InvalidEntryStyle}"
@@ -95,8 +107,10 @@
                                         RegexPattern="^#(?:[0-9a-fA-F]{3}){1,2}$" />
                                 </Entry.Behaviors>
                             </Entry>
+
                             <BoxView HeightRequest="30" WidthRequest="30" VerticalOptions="Center" 
-                                Color="{Binding Text, Source={x:Reference ColorEntry}, x:DataType=Entry}" Grid.Column="2"/>
+                                Color="{Binding Text, Source={x:Reference ColorEntry}, x:DataType=Entry}" Grid.Column="2"
+                                SemanticProperties.HeadingLevel="None" />
         
                             <Button 
                                 ImageSource="{StaticResource IconDelete}"
@@ -109,8 +123,12 @@
             </VerticalStackLayout>
 
             <Grid ColumnSpacing="{StaticResource LayoutSpacing}" ColumnDefinitions="*,Auto" Margin="0,10">
-                <Button Text="Save" Command="{Binding SaveTagsCommand}" HeightRequest="{OnIdiom 44,Desktop=60}" Grid.Column="0"/>
-                <Button ImageSource="{StaticResource IconAdd}" Command="{Binding AddTagCommand}" Grid.Column="1"/>
+                <Button Text="Save" Command="{Binding SaveTagsCommand}"
+                    HeightRequest="{OnIdiom 44,Desktop=60}" Grid.Column="0" />
+
+                <Button ImageSource="{StaticResource IconAdd}"
+                    Command="{Binding AddTagCommand}" Grid.Column="1"
+                    SemanticProperties.Description="Add" />
             </Grid>
         </VerticalStackLayout>
     </ScrollView>

--- a/src/Templates/src/templates/maui-mobile/Pages/TaskDetailPage.xaml
+++ b/src/Templates/src/templates/maui-mobile/Pages/TaskDetailPage.xaml
@@ -14,23 +14,25 @@
             Command="{Binding DeleteCommand}"
             Order="Primary"
             Priority="0"
-            IconImageSource="{StaticResource IconDelete}" />
+            IconImageSource="{StaticResource IconDelete}"
+            SemanticProperties.Description="Delete" />
     </ContentPage.ToolbarItems>        
 
     <Grid>
         <ScrollView>
             <VerticalStackLayout Spacing="{StaticResource LayoutSpacing}" Padding="{StaticResource LayoutPadding}">
-                <sf:SfTextInputLayout 
-                    Hint="Task">
+                <sf:SfTextInputLayout Hint="Task">
                     <Entry
-                        Text="{Binding Title}" />
+                        Text="{Binding Title}"
+                        SemanticProperties.Description="Title" />
                 </sf:SfTextInputLayout>
 
-                <sf:SfTextInputLayout 
-                    Hint="Completed">
+                <sf:SfTextInputLayout Hint="Completed">
                     <CheckBox
                         HorizontalOptions="End"
-                        IsChecked="{Binding IsCompleted}" />
+                        IsChecked="{Binding IsCompleted}"
+                        SemanticProperties.Description="Status"
+                        SemanticProperties.Hint="Indicates if this task is completed" />
                 </sf:SfTextInputLayout>
 
                 <sf:SfTextInputLayout 
@@ -40,7 +42,9 @@
                         ItemsSource="{Binding Projects}"
                         ItemDisplayBinding="{Binding Name, x:DataType=models:Project}"
                         SelectedItem="{Binding Project}"
-                        SelectedIndex="{Binding SelectedProjectIndex}" />
+                        SelectedIndex="{Binding SelectedProjectIndex}"
+                        SemanticProperties.Description="Project"
+                        SemanticProperties.Hint="Which project this task belongs to" />
                 </sf:SfTextInputLayout>
 
                 <Button 


### PR DESCRIPTION
### Description of Change

Adds the missing accessibility titles and descriptions to the buttons and input fields in the `ManageMetaPage.xaml` and `TaskDetailPage.xaml` files.

### Issues Fixed

Related to #26819
Related to #26918
Related to #26233

(Intentionally not using fixes keyword because the a11y team needs to close the issues after verifying)
