### PR TITLE
Improve accessibility MainPage in sample content template

### DIFF
--- a/src/Templates/src/templates/maui-mobile/Pages/MainPage.xaml
+++ b/src/Templates/src/templates/maui-mobile/Pages/MainPage.xaml
@@ -63,7 +63,7 @@
                                 WidthRequest="44"
                                 IsVisible="{Binding HasCompletedTasks}"
                                 Command="{Binding CleanTasksCommand}"
-                                />
+                                SemanticProperties.Description="Clean tasks" />
                         </Grid>
                         <VerticalStackLayout Spacing="15"
                             BindableLayout.ItemsSource="{Binding Tasks}">


### PR DESCRIPTION
### Description of Change

Improves the accessibility of the MainPage in the sample content template by adding a description to the CleanTasks button.

### Issues Fixed

Related to #26896 

(Intentionally not using fixes keyword because the a11y team needs to close the issues after verifying)