### PR TITLE
Fixed HorizontalStackLayout Crashes Debugger on Negative Spacing

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue19513.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue19513.cs
@@ -1,0 +1,32 @@
+using Microsoft.Maui.Controls;
+
+namespace Maui.Controls.Sample.Issues;
+[Issue(IssueTracker.Github, 19513, "HorizontalStackLayout Crashes Debugger on Negative Spacing", PlatformAffected.UWP)]
+public class Issue19513:ContentPage
+{
+	public Issue19513()
+	{
+		var stackLayout = new StackLayout
+		{
+			AutomationId = "StackLayout",
+			Spacing = -60
+		};
+ 
+		var Image1 = new Image
+		{
+			Source = "groceries.png",
+			AutomationId = "Image1"
+		};
+ 
+		var Image2 = new Image
+		{
+			Source = "shopping_cart.png",
+			AutomationId = "Image2"
+		};
+ 
+		stackLayout.Children.Add(Image1);
+		stackLayout.Children.Add(Image2);
+ 
+		Content = stackLayout;
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue19513.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue19513.cs
@@ -1,8 +1,9 @@
 using Microsoft.Maui.Controls;
 
 namespace Maui.Controls.Sample.Issues;
+
 [Issue(IssueTracker.Github, 19513, "HorizontalStackLayout Crashes Debugger on Negative Spacing", PlatformAffected.UWP)]
-public class Issue19513:ContentPage
+public class Issue19513 : ContentPage
 {
 	public Issue19513()
 	{
@@ -11,22 +12,22 @@ public class Issue19513:ContentPage
 			AutomationId = "StackLayout",
 			Spacing = -60
 		};
- 
+
 		var Image1 = new Image
 		{
 			Source = "groceries.png",
 			AutomationId = "Image1"
 		};
- 
+
 		var Image2 = new Image
 		{
 			Source = "shopping_cart.png",
 			AutomationId = "Image2"
 		};
- 
+
 		stackLayout.Children.Add(Image1);
 		stackLayout.Children.Add(Image2);
- 
+
 		Content = stackLayout;
 	}
 }

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue19513.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue19513.cs
@@ -2,7 +2,7 @@ using Microsoft.Maui.Controls;
 
 namespace Maui.Controls.Sample.Issues;
 [Issue(IssueTracker.Github, 19513, "HorizontalStackLayout Crashes Debugger on Negative Spacing", PlatformAffected.UWP)]
-public class Issue19513:ContentPage
+public class Issue19513 : ContentPage
 {
 	public Issue19513()
 	{
@@ -11,22 +11,22 @@ public class Issue19513:ContentPage
 			AutomationId = "StackLayout",
 			Spacing = -60
 		};
- 
+
 		var Image1 = new Image
 		{
 			Source = "groceries.png",
 			AutomationId = "Image1"
 		};
- 
+
 		var Image2 = new Image
 		{
 			Source = "shopping_cart.png",
 			AutomationId = "Image2"
 		};
- 
+
 		stackLayout.Children.Add(Image1);
 		stackLayout.Children.Add(Image2);
- 
+
 		Content = stackLayout;
 	}
 }

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue19513.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue19513.cs
@@ -2,7 +2,7 @@ using Microsoft.Maui.Controls;
 
 namespace Maui.Controls.Sample.Issues;
 [Issue(IssueTracker.Github, 19513, "HorizontalStackLayout Crashes Debugger on Negative Spacing", PlatformAffected.UWP)]
-public class Issue19513 : ContentPage
+public class Issue19513:ContentPage
 {
 	public Issue19513()
 	{
@@ -11,22 +11,22 @@ public class Issue19513 : ContentPage
 			AutomationId = "StackLayout",
 			Spacing = -60
 		};
-
+ 
 		var Image1 = new Image
 		{
 			Source = "groceries.png",
 			AutomationId = "Image1"
 		};
-
+ 
 		var Image2 = new Image
 		{
 			Source = "shopping_cart.png",
 			AutomationId = "Image2"
 		};
-
+ 
 		stackLayout.Children.Add(Image1);
 		stackLayout.Children.Add(Image2);
-
+ 
 		Content = stackLayout;
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue19513.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue19513.cs
@@ -1,15 +1,15 @@
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
- 
+
 namespace Microsoft.Maui.TestCases.Tests.Issues;
 
-public class Issue19513: _IssuesUITest
+public class Issue19513 : _IssuesUITest
 {
 	public Issue19513(TestDevice testDevice) : base(testDevice)
 	{
 	}
- 
+
 	public override string Issue => "HorizontalStackLayout Crashes Debugger on Negative Spacing";
 	[Test]
 	[Category(UITestCategories.Layout)]

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue19513.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue19513.cs
@@ -1,15 +1,15 @@
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
-
+ 
 namespace Microsoft.Maui.TestCases.Tests.Issues;
 
-public class Issue19513 : _IssuesUITest
+public class Issue19513: _IssuesUITest
 {
 	public Issue19513(TestDevice testDevice) : base(testDevice)
 	{
 	}
-
+ 
 	public override string Issue => "HorizontalStackLayout Crashes Debugger on Negative Spacing";
 	[Test]
 	[Category(UITestCategories.Layout)]

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue19513.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue19513.cs
@@ -1,0 +1,20 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+ 
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue19513: _IssuesUITest
+{
+	public Issue19513(TestDevice testDevice) : base(testDevice)
+	{
+	}
+ 
+	public override string Issue => "HorizontalStackLayout Crashes Debugger on Negative Spacing";
+	[Test]
+	[Category(UITestCategories.Layout)]
+	public void NegativeSpacingCrashes()
+	{
+		App.WaitForElement("Image1");
+	}
+}

--- a/src/Core/src/Platform/Windows/MauiPanel.cs
+++ b/src/Core/src/Platform/Windows/MauiPanel.cs
@@ -63,8 +63,7 @@ namespace Microsoft.Maui.Platform
 			var height = finalSize.Height;
 
 			var actual = CrossPlatformArrange(new Rect(0, 0, width, height));
-			actual.Width = Math.Max(actual.Width, 0);
-			actual.Height = Math.Max(actual.Height, 0);
+
 			return actual.ToPlatform();
 		}
 

--- a/src/Core/src/Platform/Windows/MauiPanel.cs
+++ b/src/Core/src/Platform/Windows/MauiPanel.cs
@@ -47,7 +47,8 @@ namespace Microsoft.Maui.Platform
 			}
 
 			var measure = CrossPlatformMeasure(availableSize.Width, availableSize.Height);
-
+			measure.Width = Math.Max(measure.Width, 0);
+			measure.Height = Math.Max(measure.Height, 0);
 			return measure.ToPlatform();
 		}
 
@@ -62,7 +63,8 @@ namespace Microsoft.Maui.Platform
 			var height = finalSize.Height;
 
 			var actual = CrossPlatformArrange(new Rect(0, 0, width, height));
-
+			actual.Width = Math.Max(actual.Width, 0);
+			actual.Height = Math.Max(actual.Height, 0);
 			return actual.ToPlatform();
 		}
 

--- a/src/Core/src/Platform/Windows/MauiPanel.cs
+++ b/src/Core/src/Platform/Windows/MauiPanel.cs
@@ -63,7 +63,8 @@ namespace Microsoft.Maui.Platform
 			var height = finalSize.Height;
 
 			var actual = CrossPlatformArrange(new Rect(0, 0, width, height));
-
+			actual.Width = Math.Max(actual.Width, 0);
+			actual.Height = Math.Max(actual.Height, 0);
 			return actual.ToPlatform();
 		}
 

--- a/src/Core/src/Platform/Windows/MauiPanel.cs
+++ b/src/Core/src/Platform/Windows/MauiPanel.cs
@@ -47,8 +47,10 @@ namespace Microsoft.Maui.Platform
 			}
 
 			var measure = CrossPlatformMeasure(availableSize.Width, availableSize.Height);
+
 			measure.Width = Math.Max(measure.Width, 0);
 			measure.Height = Math.Max(measure.Height, 0);
+
 			return measure.ToPlatform();
 		}
 
@@ -63,8 +65,7 @@ namespace Microsoft.Maui.Platform
 			var height = finalSize.Height;
 
 			var actual = CrossPlatformArrange(new Rect(0, 0, width, height));
-			actual.Width = Math.Max(actual.Width, 0);
-			actual.Height = Math.Max(actual.Height, 0);
+
 			return actual.ToPlatform();
 		}
 


### PR DESCRIPTION
### Issue Details:
When negative spacing value is given for StackLayout, System.ArgumentOutOfRangeException is thrown in WinUI.

The issue occurs when an Image control is placed inside a StackLayout without explicitly setting the HeightRequest and WidthRequest properties.
 
### Root Cause:
The measured value (Width/Height)of the elements like image has calculated as 0 during first measure call in WinUI platform when negative spacing is passed for Layouts.  When deducting the negative spacing from measured value(Width / height) in Measure() of LayoutManager.cs it will return negative value in Measure override of MauiPanel.cs. So when converting this negative value to ToPlatform(), System.ArgumentOutOfRangeException is thrown.
 
### Description of Change:
As Measured value of Image is negative during first call from native, the negative value has been constrained and the measured value is set to 0 using Math.Max() and converting 0 to ToPlatform() will not throw exception.
On the subsequent call, the Image is measured correctly, and the negative spacing is appropriately deducted from the measured value. This adjustment ensures that the spacing is applied accurately and aligns with the intended layout behavior.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #19513 

**Tested the behavior in the following platforms.**
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

#Output Screenshot
| Before  | After  |
|---------|--------|
|  <img src="https://github.com/user-attachments/assets/26f6bced-cda1-4177-852e-4490dc6753e7" width="320" height="240" controls></img>   |   <img src="https://github.com/user-attachments/assets/8feaeb57-7369-4496-acea-d9a507888aaf" width="320" height="240" controls></img>   |