### PR TITLE
Fix problem with null VirtualView in HybridVewHandler on iOS

### DIFF
--- a/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.iOS.cs
@@ -165,7 +165,7 @@ namespace Microsoft.Maui.Handlers
 
 			private (byte[] ResponseBytes, string ContentType, int StatusCode) GetResponseBytes(string? url)
 			{
-				if (Handler is null || !Handler.HasContainer)
+				if (Handler is null || Handler is IViewHandler ivh && ivh.VirtualView is not null)
 				{
 					return (Array.Empty<byte>(), ContentType: string.Empty, StatusCode: 404);
 				}

--- a/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.iOS.cs
@@ -165,7 +165,7 @@ namespace Microsoft.Maui.Handlers
 
 			private (byte[] ResponseBytes, string ContentType, int StatusCode) GetResponseBytes(string? url)
 			{
-				if (Handler is null)
+				if (Handler is null || !Handler.HasContainer)
 				{
 					return (Array.Empty<byte>(), ContentType: string.Empty, StatusCode: 404);
 				}

--- a/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.iOS.cs
@@ -165,7 +165,7 @@ namespace Microsoft.Maui.Handlers
 
 			private (byte[] ResponseBytes, string ContentType, int StatusCode) GetResponseBytes(string? url)
 			{
-				if (Handler is null || Handler is IViewHandler ivh && ivh.VirtualView is not null)
+				if (Handler is null || Handler is IViewHandler ivh && ivh.VirtualView is null)
 				{
 					return (Array.Empty<byte>(), ContentType: string.Empty, StatusCode: 404);
 				}


### PR DESCRIPTION

### Description of Change

Checking if Handler has container before using VirtualView which can crash app if is null

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #26883

