### PR TITLE
ScrollX and ScrollY values at the ScrollView.Scrolled event are not consistent in ScrollOrientation.Both mode

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Bugzilla/Bugzilla41415.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Bugzilla/Bugzilla41415.cs
@@ -1,6 +1,6 @@
 ﻿namespace Maui.Controls.Sample.Issues
 {
-	[Issue(IssueTracker.None, 41415, "ScrollX and ScrollY Values Are Not Consistent in 'ScrollOrientation.Both' Mode", PlatformAffected.Android)]
+	[Issue(IssueTracker.None, 41415, "ScrollX and ScrollY Values are not consistent in 'ScrollOrientation.Both' Mode", PlatformAffected.Android)]
 	public class Bugzilla41415 : ContentPage
 	{
 		const string ButtonId = "ClickId";

--- a/src/Controls/tests/TestCases.HostApp/Issues/Bugzilla/Bugzilla41415.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Bugzilla/Bugzilla41415.cs
@@ -1,6 +1,6 @@
 ﻿namespace Maui.Controls.Sample.Issues
 {
-	[Issue(IssueTracker.None, 41415, "ScrollX and ScrollY values are not consistent with iOS", PlatformAffected.Android)]
+	[Issue(IssueTracker.None, 41415, "ScrollX and ScrollY Values Are Not Consistent in 'ScrollOrientation.Both' Mode", PlatformAffected.Android)]
 	public class Bugzilla41415 : ContentPage
 	{
 		const string ButtonId = "ClickId";

--- a/src/Controls/tests/TestCases.HostApp/Issues/Bugzilla/Bugzilla41415.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Bugzilla/Bugzilla41415.cs
@@ -7,8 +7,6 @@
 		const string ButtonText = "Click Me";
 
 		float _x;
-		bool _didXChange, _didYChange;
-
 		public Bugzilla41415()
 		{
 			var grid = new Grid
@@ -32,8 +30,6 @@
 
 			var labelx = new Label();
 			var labely = new Label();
-			var labelz = new Label();
-			var labela = new Label();
 
 			var scrollView = new ScrollView
 			{
@@ -47,25 +43,6 @@
 			{
 				labelx.Text = $"x: {(int)Math.Round(args.ScrollX)}";
 				labely.Text = $"y: {(int)Math.Round(args.ScrollY)}";
-
-				// first and second taps
-				if (_x == 0)
-				{
-					if (Math.Round(args.ScrollX) != 0 && Math.Round(args.ScrollX) != 100)
-						_didXChange = true;
-					if (Math.Round(args.ScrollY) != 0 && Math.Round(args.ScrollY) != 100)
-						_didYChange = true;
-				}
-				else if (_x == 100)
-				{
-					if (Math.Round(args.ScrollX) != _x && Math.Round(args.ScrollX) != _x + 100)
-						_didXChange = true;
-					if (Math.Round(args.ScrollY) != 100)
-						_didYChange = true;
-				}
-
-				labelz.Text = "z: " + _didXChange.ToString();
-				labela.Text = "a: " + _didYChange.ToString();
 			};
 
 			var button = new Button { AutomationId = ButtonId, Text = ButtonText };
@@ -74,10 +51,6 @@
 				// reset
 				labelx.Text = null;
 				labely.Text = null;
-				labelz.Text = null;
-				labela.Text = null;
-				_didXChange = false;
-				_didYChange = false;
 
 				await scrollView.ScrollToAsync(_x + 100, 100, true);
 				_x = 100;
@@ -86,16 +59,12 @@
 			Grid.SetRow(button, 0);
 			Grid.SetRow(labelx, 1);
 			Grid.SetRow(labely, 2);
-			Grid.SetRow(labelz, 3);
-			Grid.SetRow(labela, 4);
-			Grid.SetRow(scrollView, 5);
+			Grid.SetRow(scrollView, 3);
 
 			Content = new Grid
 			{
 				RowDefinitions = new RowDefinitionCollection
 				{
-					new RowDefinition { Height = GridLength.Auto },
-					new RowDefinition { Height = GridLength.Auto },
 					new RowDefinition { Height = GridLength.Auto },
 					new RowDefinition { Height = GridLength.Auto },
 					new RowDefinition { Height = GridLength.Auto },
@@ -106,8 +75,6 @@
 					button,
 					labelx,
 					labely,
-					labelz,
-					labela,
 					scrollView,
 				}
 			};

--- a/src/Controls/tests/TestCases.HostApp/Issues/Bugzilla/Bugzilla41415.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Bugzilla/Bugzilla41415.cs
@@ -1,6 +1,6 @@
 ﻿namespace Maui.Controls.Sample.Issues
 {
-	[Issue(IssueTracker.None, 41415, "ScrollX and ScrollY values at the scrolled event are not consistent in 'ScrollOrientation.Both' mode", PlatformAffected.Android)]
+	[Issue(IssueTracker.None, 41415, "ScrollX and ScrollY values at the ScrollView.Scrolled event are not consistent in ScrollOrientation.Both mode", PlatformAffected.Android)]
 	public class Bugzilla41415 : ContentPage
 	{
 		const string ButtonId = "ClickId";

--- a/src/Controls/tests/TestCases.HostApp/Issues/Bugzilla/Bugzilla41415.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Bugzilla/Bugzilla41415.cs
@@ -1,6 +1,6 @@
 ﻿namespace Maui.Controls.Sample.Issues
 {
-	[Issue(IssueTracker.None, 41415, "ScrollX and ScrollY Values are not consistent in 'ScrollOrientation.Both' Mode", PlatformAffected.Android)]
+	[Issue(IssueTracker.None, 41415, "ScrollX and ScrollY values at the scrolled event are not consistent in 'ScrollOrientation.Both' mode", PlatformAffected.Android)]
 	public class Bugzilla41415 : ContentPage
 	{
 		const string ButtonId = "ClickId";

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Bugzilla/Bugzilla41415.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Bugzilla/Bugzilla41415.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		{
 		}
 
-		public override string Issue => "ScrollX and ScrollY values at the scrolled event are not consistent in 'ScrollOrientation.Both' mode";
+		public override string Issue => "ScrollX and ScrollY values at the ScrollView.Scrolled event are not consistent in ScrollOrientation.Both mode";
 
 		[Test]
 		public void Bugzilla41415Test()

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Bugzilla/Bugzilla41415.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Bugzilla/Bugzilla41415.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		{
 		}
 
-		public override string Issue => "ScrollX and ScrollY Values Are Not Consistent in 'ScrollOrientation.Both' Mode";
+		public override string Issue => "ScrollX and ScrollY Values are not consistent in 'ScrollOrientation.Both' Mode";
 
 		[Test]
 		public void Bugzilla41415Test()

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Bugzilla/Bugzilla41415.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Bugzilla/Bugzilla41415.cs
@@ -1,7 +1,4 @@
-﻿#if TEST_FAILS_ON_ANDROID && TEST_FAILS_ON_WINDOWS
-// On Android ScrollY and ScrollX values are resetted, Issue: https://github.com/dotnet/maui/issues/26747
-// On Windows tests are failing in CI, but not locally. Need to investigate more.
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
 
@@ -18,7 +15,7 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		{
 		}
 
-		public override string Issue => "ScrollX and ScrollY values are not consistent with iOS";
+		public override string Issue => "ScrollX and ScrollY Values Are Not Consistent in 'ScrollOrientation.Both' Mode";
 
 		[Test]
 		public void Bugzilla41415Test()
@@ -39,4 +36,3 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		}
 	}
 }
-#endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Bugzilla/Bugzilla41415.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Bugzilla/Bugzilla41415.cs
@@ -25,13 +25,9 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 			App.WaitForElement(ButtonId);
 			App.WaitForElementTillPageNavigationSettled("x: 100");
 			App.WaitForElementTillPageNavigationSettled("y: 100");
-			App.WaitForElement("z: True");
-			App.WaitForElement("a: True");
 			App.Tap(ButtonId);
 			App.WaitForElement(ButtonId);
 			App.WaitForElementTillPageNavigationSettled("y: 100");
-			App.WaitForElement("z: True");
-			App.WaitForElement("a: False");
 			App.WaitForElementTillPageNavigationSettled("x: 200");
 		}
 	}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Bugzilla/Bugzilla41415.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Bugzilla/Bugzilla41415.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		{
 		}
 
-		public override string Issue => "ScrollX and ScrollY Values are not consistent in 'ScrollOrientation.Both' Mode";
+		public override string Issue => "ScrollX and ScrollY values at the scrolled event are not consistent in 'ScrollOrientation.Both' mode";
 
 		[Test]
 		public void Bugzilla41415Test()

--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Android.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Android.cs
@@ -97,11 +97,27 @@ namespace Microsoft.Maui.Handlers
 				return;
 			}
 
-			// Pass the native ScrollView's ScrollY to the virtual view to maintain the correct vertical offset.
-			VirtualView.VerticalOffset = Context.FromPixels(PlatformView.ScrollY);
-			// Need to pass the native HorizontalScrollView's ScrollX position to the virtual view to resolve
-    		// the zero scroll offset issue since the framework returns an improper ScrollX value.
-			VirtualView.HorizontalOffset = Context.FromPixels(PlatformView._hScrollView?.ScrollX ?? e.ScrollX);
+			int scrollX = e.ScrollX;
+			int scrollY = e.ScrollY;
+
+			if (VirtualView.Orientation == ScrollOrientation.Both)
+			{
+				if (scrollX == 0 && PlatformView._hScrollView is not null)
+				{
+					// Need to pass the native HorizontalScrollView's ScrollX position to the virtual view to resolve
+    				// the zero scroll offset issue since the framework returns an improper ScrollX value.
+					scrollX = PlatformView._hScrollView.ScrollX;
+				}
+
+				if (scrollY == 0)
+				{
+					// Pass the native ScrollView's ScrollY to the virtual view to maintain the correct vertical offset.
+					scrollY = PlatformView.ScrollY;
+				}
+			}
+			
+			VirtualView.HorizontalOffset = context.FromPixels(scrollX);
+    		VirtualView.VerticalOffset = context.FromPixels(scrollY);
 		}
 
 		public static void MapContent(IScrollViewHandler handler, IScrollView scrollView)

--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Android.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Android.cs
@@ -102,11 +102,11 @@ namespace Microsoft.Maui.Handlers
 
 			if (VirtualView.Orientation == ScrollOrientation.Both)
 			{
-				if (scrollX == 0 && PlatformView._hScrollView is not null)
+				if (scrollX == 0)
 				{
 					// Need to pass the native HorizontalScrollView's ScrollX position to the virtual view to resolve
     				// the zero scroll offset issue since the framework returns an improper ScrollX value.
-					scrollX = PlatformView._hScrollView.ScrollX;
+					scrollX = PlatformView.HorizontalScrollOffset;
 				}
 
 				if (scrollY == 0)

--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Android.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Android.cs
@@ -97,8 +97,11 @@ namespace Microsoft.Maui.Handlers
 				return;
 			}
 
-			VirtualView.VerticalOffset = Context.FromPixels(e.ScrollY);
-			VirtualView.HorizontalOffset = Context.FromPixels(e.ScrollX);
+			// Pass the native ScrollView's ScrollY to the virtual view to maintain the correct vertical offset.
+			VirtualView.VerticalOffset = Context.FromPixels(PlatformView.ScrollY);
+			// Need to pass the native HorizontalScrollView's ScrollX position to the virtual view to resolve
+    		// the zero scroll offset issue since the framework returns an improper ScrollX value.
+			VirtualView.HorizontalOffset = Context.FromPixels(PlatformView._hScrollView?.ScrollX ?? e.ScrollX);
 		}
 
 		public static void MapContent(IScrollViewHandler handler, IScrollView scrollView)

--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Android.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Android.cs
@@ -90,9 +90,9 @@ namespace Microsoft.Maui.Handlers
 
 		void ScrollChange(object? sender, AndroidX.Core.Widget.NestedScrollView.ScrollChangeEventArgs e)
 		{
-			var context = (sender as View)?.Context;
+			var platformView = sender as MauiScrollView;
 
-			if (context == null)
+			if (platformView?.Context is null)
 			{
 				return;
 			}
@@ -106,18 +106,18 @@ namespace Microsoft.Maui.Handlers
 				{
 					// Need to pass the native HorizontalScrollView's ScrollX position to the virtual view to resolve
     				// the zero scroll offset issue since the framework returns an improper ScrollX value.
-					scrollX = PlatformView.HorizontalScrollOffset;
+					scrollX = platformView.HorizontalScrollOffset;
 				}
 
 				if (scrollY == 0)
 				{
 					// Pass the native ScrollView's ScrollY to the virtual view to maintain the correct vertical offset.
-					scrollY = PlatformView.ScrollY;
+					scrollY = platformView.ScrollY;
 				}
 			}
 			
-			VirtualView.HorizontalOffset = context.FromPixels(scrollX);
-    		VirtualView.VerticalOffset = context.FromPixels(scrollY);
+			VirtualView.HorizontalOffset = platformView.Context.FromPixels(scrollX);
+    		VirtualView.VerticalOffset = platformView.Context.FromPixels(scrollY);
 		}
 
 		public static void MapContent(IScrollViewHandler handler, IScrollView scrollView)

--- a/src/Core/src/Platform/Android/MauiScrollView.cs
+++ b/src/Core/src/Platform/Android/MauiScrollView.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Maui.Platform
 	{
 		View? _content;
 
-		internal MauiHorizontalScrollView? _hScrollView { get; private set; }
+		MauiHorizontalScrollView? _hScrollView;
 		bool _isBidirectional;
 		ScrollOrientation _scrollOrientation = ScrollOrientation.Vertical;
 		ScrollBarVisibility _defaultHorizontalScrollVisibility;
@@ -26,6 +26,7 @@ namespace Microsoft.Maui.Platform
 		internal float LastY { get; set; }
 
 		internal bool ShouldSkipOnTouch;
+		internal int HorizontalScrollOffset => _hScrollView?.ScrollX ?? 0;
 
 		public MauiScrollView(Context context) : base(context)
 		{

--- a/src/Core/src/Platform/Android/MauiScrollView.cs
+++ b/src/Core/src/Platform/Android/MauiScrollView.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Maui.Platform
 	{
 		View? _content;
 
-		MauiHorizontalScrollView? _hScrollView;
+		internal MauiHorizontalScrollView? _hScrollView { get; private set; }
 		bool _isBidirectional;
 		ScrollOrientation _scrollOrientation = ScrollOrientation.Vertical;
 		ScrollBarVisibility _defaultHorizontalScrollVisibility;


### PR DESCRIPTION
### Root Cause:
The issue occurs in the ScrollView when using "Both" scroll mode, where the ScrollX and ScrollY values were not consistently retained during consecutive scroll actions. This inconsistency arises because the framework's ScrollChanged event does not always propagate the correct values for both horizontal and vertical scroll axes. The ScrollView’s internal behavior was resetting the scroll positions incorrectly when switching between horizontal and vertical scrolling, especially in "Both" orientation mode.
 
### Description of Change:
To resolve the issue, the following changes were made:

- ***Horizontal Scroll Position Fix***: A new property, HorizontalScrollOffset, was added to directly retrieve the horizontal scroll position from the native _hScrollView instance, ensuring the correct value for ScrollX is consistently used.
- ***Vertical Scroll Position Fix***: The vertical scroll position (ScrollY) is now retrieved directly from PlatformView.ScrollY, ensuring the correct scroll position is retained during horizontal scrolling actions.

### Fix Reference: 
https://github.com/xamarin/Xamarin.Forms/blob/2f8f4864a4d289dc89a6228e2ca9d6a49993e365/Xamarin.Forms.Platform.Android/Renderers/ScrollViewRenderer.cs#L315

### Issue fixed: 
Fixes #26747 

### Output Video
Before Issue Fix | After Issue Fix |
|----------|----------|
|<video width="200" height="200" alt="Before Fix video" src="https://github.com/user-attachments/assets/7524506d-0a7f-429d-b2aa-d638cee73e1e">|<video width="200" height="200" alt="After Fix video" src="https://github.com/user-attachments/assets/0718a486-ca55-4a6f-bf8e-61699d400c1b">
