### PR TITLE
[iOS] ObservableGroupedSource - improvements

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/iOS/ObservableGroupedSource.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ObservableGroupedSource.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				incc.CollectionChanged += CollectionChanged;
 			}
 
+			_groupCount = GroupsCount();
 			ResetGroupTracking();
 		}
 
@@ -198,6 +199,8 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		{
 			ResetGroupTracking();
 
+			_groupCount = GroupsCount();
+			
 			_collectionView.ReloadData();
 			if (collectionWasReset)
 			{
@@ -391,6 +394,17 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			}
 
 			update();
+		}
+
+		int GroupsCount()
+		{
+			if (_groupSource is IList list)
+				return list.Count;
+
+			int count = 0;
+			foreach (var item in _groupSource)
+				count++;
+			return count;
 		}
 	}
 }

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue25514.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue25514.xaml
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Maui.Controls.Sample.Issues.Issue25514">
+
+    <Grid RowDefinitions="*,Auto">
+        <CollectionView
+            ItemsSource="{Binding StringsGroups}"
+            IsGrouped="True">
+            <CollectionView.GroupHeaderTemplate>
+                <DataTemplate>
+                    <Label Text="{Binding Header}"/>
+                </DataTemplate>
+            </CollectionView.GroupHeaderTemplate>
+        </CollectionView>
+
+        <Button Command="{Binding LoadCollectionCommand}"
+                Grid.Row="1"
+                AutomationId="button"
+                Text="Load Data"/>
+
+    </Grid>
+</ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue25514.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue25514.xaml.cs
@@ -1,0 +1,42 @@
+﻿using System.Collections.ObjectModel;
+
+namespace Maui.Controls.Sample.Issues
+{
+	[Issue(IssueTracker.Github, 25514, "Grouped CollectionView with header template and templateselector crashes", PlatformAffected.iOS)]
+	public partial class Issue25514 : ContentPage
+	{
+		public Issue25514()
+		{
+			InitializeComponent();
+			BindingContext = new Issue25514ViewModel();
+		}
+	}
+
+	public class Issue25514ViewModel : ViewModel
+	{
+		public Command LoadCollectionCommand => new(() =>
+		{
+			StringsGroups = [];
+			for (int i = 0; i < 2; i++)
+			{
+				StringsGroups.Add(new StringsGroup("Hello", ["Item 1", "Item 2"]));
+			}
+		});
+
+		private ObservableCollection<StringsGroup> _stringsGroups = [];
+		public ObservableCollection<StringsGroup> StringsGroups
+		{
+			get => _stringsGroups;
+			set
+			{
+				_stringsGroups = value;
+				OnPropertyChanged();
+			}
+		}
+
+		public class StringsGroup(string header, List<string> strings) : List<string>(strings)
+		{
+			public string Header { get; private set; } = header;
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25514.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25514.cs
@@ -1,0 +1,23 @@
+﻿using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue25514 : _IssuesUITest
+	{
+		public Issue25514(TestDevice testDevice) : base(testDevice)
+		{
+		}
+
+		public override string Issue => "Grouped CollectionView with header template and templateselector crashes";
+
+		[Test]
+		[Category(UITestCategories.CollectionView)]
+		public void AppShouldNotCrashAfterLoadingGroupedCollectionView()
+		{
+			App.WaitForElement("button");
+			App.Click("button");
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change

I've made some changes so that the `ObservableGroupedSource` resembles `ObservableItemsSource`. It fixes the crash https://github.com/dotnet/maui/issues/25514 which I've observed on both CV and CV2

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/25514

|Before|After|
|--|--|
<video src="https://github.com/user-attachments/assets/01f89ef9-2851-41cc-9520-b5476acd976c" width="300px"/>|<video src="https://github.com/user-attachments/assets/382a9bd0-719e-4bf1-bc3a-07c12d24eca5" width="300px"/>|

@rmarinho what do you think?