### PR TITLE
[Android] Top bar item colors - fix

### DIFF
--- a/src/Controls/src/Core/Platform/Android/TabbedPageManager.cs
+++ b/src/Controls/src/Core/Platform/Android/TabbedPageManager.cs
@@ -890,6 +890,7 @@ namespace Microsoft.Maui.Controls.Handlers
 
 					icon.Mutate();
 					icon.SetState(_stateSet);
+					_tabLayout.TabIconTint = colors;
 					ADrawableCompat.SetTintList(icon, colors);
 				}
 			}

--- a/src/Controls/src/Core/Platform/Android/TabbedPageManager.cs
+++ b/src/Controls/src/Core/Platform/Android/TabbedPageManager.cs
@@ -890,7 +890,12 @@ namespace Microsoft.Maui.Controls.Handlers
 
 					icon.Mutate();
 					icon.SetState(_stateSet);
-					_tabLayout.TabIconTint = colors;
+
+					// The FontImageSource has its own color, so we don't need to apply the tint list.
+					if (page.IconImageSource is not FontImageSource)
+					{
+						_tabLayout.TabIconTint = colors;
+					}
 					ADrawableCompat.SetTintList(icon, colors);
 				}
 			}


### PR DESCRIPTION
### Description
Android docs: https://developer.android.com/reference/com/google/android/material/tabs/TabLayout#setTabIconTint(android.content.res.ColorStateList)

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/26905

|Before|After|
|--|--|
<video src="https://github.com/user-attachments/assets/0651a427-67a8-40c9-95cc-a37c80970f53" width="300px"/>|<video src="https://github.com/user-attachments/assets/a7971630-7f33-4598-a34b-d0b2972a24c8" width="300px"/>|

@jsuarezruiz what do you think?