### PR TITLE
Title doesn't visible when set IsVisible to true of ShellContent

### DIFF
--- a/src/Controls/src/Core/Handlers/Shell/Windows/ShellFlyoutItemView.cs
+++ b/src/Controls/src/Core/Handlers/Shell/Windows/ShellFlyoutItemView.cs
@@ -120,7 +120,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 				var request = view.Measure(availableSize.Width, availableSize.Height);
 				Clip = new RectangleGeometry { Rect = new WRect(0, 0, request.Width, request.Height) };
-				return request.ToPlatform();
+				return base.MeasureOverride(availableSize);
 			}
 
 			return base.MeasureOverride(availableSize);

--- a/src/Controls/src/Core/Handlers/Shell/Windows/ShellFlyoutItemView.cs
+++ b/src/Controls/src/Core/Handlers/Shell/Windows/ShellFlyoutItemView.cs
@@ -120,7 +120,6 @@ namespace Microsoft.Maui.Controls.Platform
 
 				var request = view.Measure(availableSize.Width, availableSize.Height);
 				Clip = new RectangleGeometry { Rect = new WRect(0, 0, request.Width, request.Height) };
-				
 			}
 
 			return base.MeasureOverride(availableSize);

--- a/src/Controls/src/Core/Handlers/Shell/Windows/ShellFlyoutItemView.cs
+++ b/src/Controls/src/Core/Handlers/Shell/Windows/ShellFlyoutItemView.cs
@@ -117,9 +117,10 @@ namespace Microsoft.Maui.Controls.Platform
 						fe.Visibility = WVisibility.Visible;
 					}
 				}
-
+				base.MeasureOverride(availableSize);
 				var request = view.Measure(availableSize.Width, availableSize.Height);
 				Clip = new RectangleGeometry { Rect = new WRect(0, 0, request.Width, request.Height) };
+				return request.ToPlatform();
 			}
 
 			return base.MeasureOverride(availableSize);

--- a/src/Controls/src/Core/Handlers/Shell/Windows/ShellFlyoutItemView.cs
+++ b/src/Controls/src/Core/Handlers/Shell/Windows/ShellFlyoutItemView.cs
@@ -120,7 +120,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 				var request = view.Measure(availableSize.Width, availableSize.Height);
 				Clip = new RectangleGeometry { Rect = new WRect(0, 0, request.Width, request.Height) };
-				return base.MeasureOverride(availableSize);
+				
 			}
 
 			return base.MeasureOverride(availableSize);

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue19783.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue19783.cs
@@ -12,11 +12,11 @@ namespace Maui.Controls.Sample.Issues
 		{
 			var shellContent = new ShellContent()
 			{
-				ContentTemplate = new DataTemplate(typeof(WelcomePage))
+				ContentTemplate = new DataTemplate(typeof(Issue19783_WelcomePage))
 			};
 			var shellContent2 = new ShellContent()
 			{
-				ContentTemplate = new DataTemplate(typeof(ProfilePage))
+				ContentTemplate = new DataTemplate(typeof(Issue19783_ProfilePage))
 			};
 			this.Items.Add(new FlyoutItem()
 			{
@@ -46,10 +46,10 @@ namespace Maui.Controls.Sample.Issues
 		}
 	}
 
-	public class WelcomePage : ContentPage
+	public class Issue19783_WelcomePage : ContentPage
 	{
 		StackLayout stackLayout;
-		public WelcomePage()
+		public Issue19783_WelcomePage()
 		{
 			Title = "Welcome";
 			stackLayout = new StackLayout();
@@ -67,9 +67,9 @@ namespace Maui.Controls.Sample.Issues
 		}
 	}
 
-	public class ProfilePage : ContentPage
+	public class Issue19783_ProfilePage : ContentPage
 	{
-		public ProfilePage()
+		public Issue19783_ProfilePage()
 		{
 			Title = "Profile";
 			Content = new Label { Text = "Profile" };

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue19783.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue19783.cs
@@ -1,0 +1,78 @@
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.ComponentModel;
+
+namespace Maui.Controls.Sample.Issues
+{
+
+	[Issue(IssueTracker.Github, 19783, "ShellContent IsVisible=True Does not display Title")]
+	public class Issue19783 : Shell
+	{
+		public Issue19783()
+		{
+			var shellContent = new ShellContent()
+			{
+				ContentTemplate = new DataTemplate(typeof(WelcomePage))
+			};
+			var shellContent2 = new ShellContent()
+			{
+				ContentTemplate = new DataTemplate(typeof(ProfilePage))
+			};
+			this.Items.Add(new FlyoutItem()
+			{
+				Title = "Welcome Page",
+				Items =
+				{
+					shellContent
+				}
+			});
+			this.Items.Add(new FlyoutItem()
+			{
+				Title = "Profile Page",
+				IsVisible = false,
+				Items =
+				{
+					shellContent2
+				}
+			});
+			Button button = new Button();
+			button.Text = "Toggle Profile Page";
+			button.AutomationId = "ToggleProfilePage";
+			button.Clicked += (sender, e) =>
+			{
+				this.Items[1].IsVisible = true;
+			};
+			this.FlyoutFooter = button;
+		}
+	}
+
+	public class WelcomePage : ContentPage
+	{
+		StackLayout stackLayout;
+		public WelcomePage()
+		{
+			Title = "Welcome";
+			stackLayout = new StackLayout();
+			var button = new Button();
+			button.Text = "click to open pane";
+			button.AutomationId = "OpenPane";
+			button.Clicked += (sender, e) =>
+			{
+				Shell.Current.FlyoutIsPresented = true;
+			};
+			var label = new Label { Text = "Welcome to the Shell" };
+			stackLayout.Children.Add(label);
+			stackLayout.Children.Add(button);
+			Content = stackLayout;
+		}
+	}
+
+	public class ProfilePage : ContentPage
+	{
+		public ProfilePage()
+		{
+			Title = "Profile";
+			Content = new Label { Text = "Profile" };
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue19783.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue19783.cs
@@ -1,0 +1,24 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue19783 : _IssuesUITest
+	{
+		public Issue19783(TestDevice device) : base(device) { }
+
+		public override string Issue => "ShellContent IsVisible=True Does not display Title";
+
+		[Test]
+		[Category(UITestCategories.Shell)]
+		public void Issue19783Shell()
+		{
+			App.WaitForElement("click to open pane");
+			App.Tap("OpenPane");
+			App.WaitForElement("Toggle Profile Page");
+			App.Tap("ToggleProfilePage");
+			App.WaitForElement("Profile Page");
+		}
+	}
+}


### PR DESCRIPTION
### Issue Details:
Title doesn't visible when set IsVisible to true of ShellContent on button click.
 
### Root Cause:
Without calling base.MeasureOverride, the ShellFlyoutItemView (or its content) was not measured properly by the layout system. As a result, it was  not sized at all, causing it to be invisible in the view.

### Description of Change:
Added a call to base.MeasureOverride(availableSize) to ensure that the internal measurement logic provided by the base class is executed before measuring the custom view.
 
**Tested the behavior in the following platforms.**
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac
 
### Issues Fixed:
 
Fixes #19783
Fixes #19496
 
### Screenshots
| Before Issue Fix | After Issue Fix |
|--|--|
|<image src="https://github.com/user-attachments/assets/c25718a2-8c35-41e1-b674-9e157be22b37">|<image src="https://github.com/user-attachments/assets/ac2d17c9-c018-4cae-bc7c-1613cf0f4e26">|



