### PR TITLE
Enable GetDrawableAsync for release

### DIFF
--- a/src/Core/tests/DeviceTests/Services/ImageSource/StreamImageSourceServiceTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Services/ImageSource/StreamImageSourceServiceTests.Android.cs
@@ -22,7 +22,6 @@ namespace Microsoft.Maui.DeviceTests
 			await Assert.ThrowsAsync<InvalidCastException>(() => service.GetDrawableAsync(imageSource, MauiProgram.DefaultContext));
 		}
 
-#if DEBUG
 		[Theory]
 		[InlineData("#FF0000")]
 		[InlineData("#00FF00")]
@@ -45,6 +44,5 @@ namespace Microsoft.Maui.DeviceTests
 
 			bitmap.AssertColorAtCenter(expectedColor);
 		}
-#endif
 	}
 }


### PR DESCRIPTION
### Description of Change

We disabled this test on release mode for device tests. 

Checking to see if this exception is still happening

### Fixes

- #24338