### PR TITLE
Use sub-directories in the file provider

### DIFF
--- a/src/Essentials/src/Resources/xml/microsoft_maui_essentials_fileprovider_file_paths.xml
+++ b/src/Essentials/src/Resources/xml/microsoft_maui_essentials_fileprovider_file_paths.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="UTF-8" ?>
 <paths>
-  <external-path name="external_files" path="." />
-  <cache-path name="internal_cache" path="." />
-  <external-cache-path name="external_cache" path="." />
+  <external-path name="external_files" path="2203693cc04e0be7f4f024d5f9499e13" />
+  <cache-path name="internal_cache" path="2203693cc04e0be7f4f024d5f9499e13" />
+  <external-cache-path name="external_cache" path="2203693cc04e0be7f4f024d5f9499e13" />
 </paths>


### PR DESCRIPTION
On Android, it's a better practice to scope the paths used in a FileContentProvider as much as possible.  Currently we just use the root `.` path for each area, even though we always seem to save temp files to `2203693cc04e0be7f4f024d5f9499e13` as a subfolder.

This updates our provider file paths to scope to that folder.

Related to https://github.com/dotnet/maui/issues/27685