### PR TITLE
Fixed scrolling issue on ProjectListPage

### DIFF
--- a/src/Templates/src/templates/maui-mobile/Pages/ProjectListPage.xaml
+++ b/src/Templates/src/templates/maui-mobile/Pages/ProjectListPage.xaml
@@ -19,7 +19,10 @@
       <CollectionView
             ItemsSource="{Binding Projects}"
             Margin="{StaticResource LayoutPadding}">
-        <CollectionView.ItemTemplate>
+      <CollectionView.ItemsLayout>
+        <LinearItemsLayout Orientation="Vertical" ItemSpacing="{StaticResource LayoutSpacing}" />
+      </CollectionView.ItemsLayout>
+      <CollectionView.ItemTemplate>
           <DataTemplate x:DataType="models:Project">
             <Border>
               <VerticalStackLayout Padding="10">

--- a/src/Templates/src/templates/maui-mobile/Pages/ProjectListPage.xaml
+++ b/src/Templates/src/templates/maui-mobile/Pages/ProjectListPage.xaml
@@ -16,29 +16,28 @@
                 Command="{Binding AppearingCommand}" />
     </ContentPage.Behaviors>
     <Grid>
-      <CollectionView
-            ItemsSource="{Binding Projects}"
-            Margin="{StaticResource LayoutPadding}">
-      <CollectionView.ItemsLayout>
-        <LinearItemsLayout Orientation="Vertical" ItemSpacing="{StaticResource LayoutSpacing}" />
-      </CollectionView.ItemsLayout>
-      <CollectionView.ItemTemplate>
-          <DataTemplate x:DataType="models:Project">
-            <Border>
-              <VerticalStackLayout Padding="10">
-                <Label Text="{Binding Name}" FontSize="24" />
-                <Label Text="{Binding Description}" />
-              </VerticalStackLayout>
-              <Border.GestureRecognizers>
-                <TapGestureRecognizer Command="{Binding NavigateToProjectCommand, Source={RelativeSource AncestorType={x:Type pageModels:ProjectListPageModel}}, x:DataType=pageModels:ProjectListPageModel}" CommandParameter="{Binding .}" />
-              </Border.GestureRecognizers>
-            </Border>
-          </DataTemplate>
-        </CollectionView.ItemTemplate>
-      </CollectionView>
-      
-        <controls:AddButton
-            Command="{Binding AddProjectCommand}"
-            />
+      <ScrollView>
+        <VerticalStackLayout 
+            BindableLayout.ItemsSource="{Binding Projects}" 
+            Margin="{StaticResource LayoutPadding}" 
+            Spacing="{StaticResource LayoutSpacing}">
+            <BindableLayout.ItemTemplate>
+                <DataTemplate x:DataType="models:Project">
+                    <Border>
+                        <VerticalStackLayout Padding="10">
+                            <Label Text="{Binding Name}" FontSize="24" />
+                            <Label Text="{Binding Description}" />
+                        </VerticalStackLayout>
+                        <Border.GestureRecognizers>
+                            <TapGestureRecognizer Command="{Binding NavigateToProjectCommand, Source={RelativeSource AncestorType={x:Type pageModels:ProjectListPageModel}}, x:DataType=pageModels:ProjectListPageModel}" CommandParameter="{Binding .}"/>
+                        </Border.GestureRecognizers>
+                    </Border>
+                </DataTemplate>
+            </BindableLayout.ItemTemplate>
+        </VerticalStackLayout>
+      </ScrollView>
+
+        <controls:AddButton 
+            Command="{Binding AddProjectCommand}" />
     </Grid>
 </ContentPage>

--- a/src/Templates/src/templates/maui-mobile/Pages/ProjectListPage.xaml
+++ b/src/Templates/src/templates/maui-mobile/Pages/ProjectListPage.xaml
@@ -16,6 +16,7 @@
                 Command="{Binding AppearingCommand}" />
     </ContentPage.Behaviors>
     <Grid>
+      <ScrollView>
         <VerticalStackLayout 
             BindableLayout.ItemsSource="{Binding Projects}" 
             Margin="{StaticResource LayoutPadding}" 
@@ -34,8 +35,9 @@
                 </DataTemplate>
             </BindableLayout.ItemTemplate>
         </VerticalStackLayout>
+      </ScrollView>
 
-        <controls:AddButton 
+    <controls:AddButton 
             Command="{Binding AddProjectCommand}" />
     </Grid>
 </ContentPage>

--- a/src/Templates/src/templates/maui-mobile/Pages/ProjectListPage.xaml
+++ b/src/Templates/src/templates/maui-mobile/Pages/ProjectListPage.xaml
@@ -16,28 +16,26 @@
                 Command="{Binding AppearingCommand}" />
     </ContentPage.Behaviors>
     <Grid>
-      <ScrollView>
-        <VerticalStackLayout 
-            BindableLayout.ItemsSource="{Binding Projects}" 
-            Margin="{StaticResource LayoutPadding}" 
-            Spacing="{StaticResource LayoutSpacing}">
-            <BindableLayout.ItemTemplate>
-                <DataTemplate x:DataType="models:Project">
-                    <Border>
-                        <VerticalStackLayout Padding="10">
-                            <Label Text="{Binding Name}" FontSize="24" />
-                            <Label Text="{Binding Description}" />
-                        </VerticalStackLayout>
-                        <Border.GestureRecognizers>
-                            <TapGestureRecognizer Command="{Binding NavigateToProjectCommand, Source={RelativeSource AncestorType={x:Type pageModels:ProjectListPageModel}}, x:DataType=pageModels:ProjectListPageModel}" CommandParameter="{Binding .}"/>
-                        </Border.GestureRecognizers>
-                    </Border>
-                </DataTemplate>
-            </BindableLayout.ItemTemplate>
-        </VerticalStackLayout>
-      </ScrollView>
-
-    <controls:AddButton 
-            Command="{Binding AddProjectCommand}" />
+      <CollectionView
+            ItemsSource="{Binding Projects}"
+            Margin="{StaticResource LayoutPadding}">
+        <CollectionView.ItemTemplate>
+          <DataTemplate x:DataType="models:Project">
+            <Border>
+              <VerticalStackLayout Padding="10">
+                <Label Text="{Binding Name}" FontSize="24" />
+                <Label Text="{Binding Description}" />
+              </VerticalStackLayout>
+              <Border.GestureRecognizers>
+                <TapGestureRecognizer Command="{Binding NavigateToProjectCommand, Source={RelativeSource AncestorType={x:Type pageModels:ProjectListPageModel}}, x:DataType=pageModels:ProjectListPageModel}" CommandParameter="{Binding .}" />
+              </Border.GestureRecognizers>
+            </Border>
+          </DataTemplate>
+        </CollectionView.ItemTemplate>
+      </CollectionView>
+      
+        <controls:AddButton
+            Command="{Binding AddProjectCommand}"
+            />
     </Grid>
 </ContentPage>


### PR DESCRIPTION
### Issue Detail
Scrolling is not working in ProjectListPage.

### Root Cause
The ProjectList content was wrapped inside a Grid. Since the Grid layout does not support scrolling, any content exceeding the screen height was not accessible.

### Description of Change
Replaced the VerticalStackLayout with a CollectionView in the ProjectListPage.

### Tested the behaviour in the following platforms
 
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

### Issues Fixed
 
Fixes https://github.com/dotnet/maui/issues/26917

### Screenshots

ios:

| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video width="300" height="600"  src="https://github.com/user-attachments/assets/3be69514-bd32-44eb-8b82-31d3fe7bfdfb"> | <video width="300" height="600"  src="https://github.com/user-attachments/assets/2cc7070b-b978-4c83-a029-5a39580ad12d">) |

Mac:

| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video width="300" height="600"  src="https://github.com/user-attachments/assets/61795c29-8724-413f-a2a2-519ee5fd4769"> | <video width="300" height="600"  src="https://github.com/user-attachments/assets/89d45f50-41f8-459f-ad55-98db497216fe">) |

Android:

| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video width="300" height="600"  src="https://github.com/user-attachments/assets/04e7740a-fa8e-4328-9d4d-22f9ff35fdbf"> | <video width="300" height="600"  src="https://github.com/user-attachments/assets/d5cd2a71-282e-4812-9a5f-0a152c12e9f5">) |

Windows:

| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video width="300" height="600"  src="https://github.com/user-attachments/assets/518ce65a-2116-4528-88f0-4ce9e86aa45f"> | <video width="300" height="600"  src="https://github.com/user-attachments/assets/dcc62c76-447c-4178-b56b-8ad25648943e">) |
